### PR TITLE
Use Protect API connection_network_id for VLAN override

### DIFF
--- a/src/NetworkOptimizer.Audit/ConfigAuditEngine.cs
+++ b/src/NetworkOptimizer.Audit/ConfigAuditEngine.cs
@@ -280,6 +280,12 @@ public class ConfigAuditEngine
         var effectiveSettings = request.AllowanceSettings ?? DeviceAllowanceSettings.Default;
         securityEngine.SetAllowanceSettings(effectiveSettings);
 
+        // Set Protect cameras for network ID override (uses connection_network_id from Protect API)
+        if (request.ProtectCameras != null && request.ProtectCameras.Count > 0)
+        {
+            securityEngine.SetProtectCameras(request.ProtectCameras);
+        }
+
         return new AuditContext
         {
             DeviceData = deviceData,

--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -666,14 +666,14 @@ public class UniFiApiClient : IDisposable
             if (device.RequiresSecurityVlan)
             {
                 var name = !string.IsNullOrEmpty(device.Name) ? device.Name : device.Model ?? "Protect Device";
-                result.Add(device.Mac, name);
+                result.Add(device.Mac, name, device.ConnectionNetworkId);
 
                 var deviceType = device.IsCamera ? "camera" :
                                  device.IsDoorbell ? "doorbell" :
                                  device.IsNvr ? "NVR" :
                                  device.IsVideoProcessor ? "AI processor" : "device";
-                _logger.LogDebug("Found Protect {DeviceType}: {Name} ({Model}) - MAC: {Mac}",
-                    deviceType, device.Name, device.Model, device.Mac);
+                _logger.LogDebug("Found Protect {DeviceType}: {Name} ({Model}) - MAC: {Mac}, NetworkId: {NetworkId}",
+                    deviceType, device.Name, device.Model, device.Mac, device.ConnectionNetworkId ?? "null");
             }
         }
 


### PR DESCRIPTION
## Summary

- Fixes incorrect VLAN reporting for Wi-Fi Protect devices when Virtual Network Override is configured
- Uses Protect API's `connection_network_id` instead of Network API's `network_id` when they differ
- Observed bug in UniFi Network 10.0.162 where Network API reports SSID-native VLAN while Protect API correctly reports the overridden VLAN

## Changes

- Store `connection_network_id` in `ProtectCameraCollection` when fetching Protect devices
- Override network lookup in `ExtractWirelessClients` when Protect API provides a different network ID
- Add debug logging when network override occurs
- Add 4 tests covering override behavior

## Test plan

- [x] All 1760 tests pass
- [x] Deployed to NAS - Protect devices detected with correct NetworkId
- [x] Deployed to Mac - Health check passes
- [x] Manual testing confirms feature works correctly