### PR TITLE
Fix Docker healthcheck port

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -93,7 +93,7 @@ EXPOSE 5201
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-    CMD curl -f http://localhost:8080/api/health || exit 1
+    CMD curl -f http://localhost:8042/api/health || exit 1
 
 # Set ownership for app directories
 RUN chown -R app:app /app


### PR DESCRIPTION
While setting up the project I noticed that the container appeared as unhealthy because it was trying to query the `/api/health` endpoint on port 8080, whereas 8042 is the default port at the moment.

```
root@UNRAID:~# docker ps --filter name=network-optimizer --format "table {{.Names}}\t{{.Status}}"
NAMES                         STATUS
network-optimizer             Up 2 minutes (unhealthy)
network-optimizer-speedtest   Up 2 minutes
```

If i exec into the container and sanity-check this:

```
root@2f969c8e32d0:/app# curl -f http://localhost:8080/api/health
curl: (7) Failed to connect to localhost port 8080 after 0 ms: Couldn't connect to server

root@2f969c8e32d0:/app# curl -f http://localhost:8042/api/health
{"status":"healthy","timestamp":"2026-01-10T13:47:48.0377703Z"}
```

This change should fix our issues of the container appearing as unhealthy (and resolve my current problem of Traefik not routing for unhealthy containers)