### PR TITLE
Fix SQM script name sanitization for WAN names with parentheses

### DIFF
--- a/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
+++ b/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
@@ -17,10 +17,10 @@ public class ScriptGenerator
     {
         _config = config;
         _initialDelaySeconds = initialDelaySeconds;
-        // Normalize connection name for use in filenames (lowercase, no spaces)
+        // Normalize connection name for use in filenames (lowercase, no spaces/parens)
         _name = string.IsNullOrWhiteSpace(config.ConnectionName)
             ? config.Interface.ToLowerInvariant()
-            : config.ConnectionName.ToLowerInvariant().Replace(" ", "-");
+            : config.ConnectionName.ToLowerInvariant().Replace(" ", "-").Replace("(", "").Replace(")", "");
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -359,7 +359,7 @@
             <div class="form-row">
                 <div class="form-group">
                     <label class="form-label">Connection Name</label>
-                    <input type="text" class="form-control" @bind="wan1Config.Name" placeholder="e.g., Yelcot, Comcast" />
+                    <input type="text" class="form-control" @bind="wan1Config.Name" @bind:event="onchange" @bind:after="() => wan1Config.Name = SanitizeWanName(wan1Config.Name)" placeholder="e.g., Yelcot, Comcast" />
                 </div>
                 <div class="form-group">
                     <label class="form-label">WAN Interface</label>
@@ -499,7 +499,7 @@
             <div class="form-row">
                 <div class="form-group">
                     <label class="form-label">Connection Name</label>
-                    <input type="text" class="form-control" @bind="wan2Config.Name" placeholder="e.g., Starlink" />
+                    <input type="text" class="form-control" @bind="wan2Config.Name" @bind:event="onchange" @bind:after="() => wan2Config.Name = SanitizeWanName(wan2Config.Name)" placeholder="e.g., Starlink" />
                 </div>
                 <div class="form-group">
                     <label class="form-label">WAN Interface</label>
@@ -1576,6 +1576,13 @@
 
             ApplyConnectionDefaults(config, wan.Name);
         }
+    }
+
+    private static string SanitizeWanName(string? input)
+    {
+        if (string.IsNullOrEmpty(input))
+            return string.Empty;
+        return new string(input.Where(c => char.IsLetterOrDigit(c) || c == ' ' || c == '(' || c == ')' || c == '-' || c == '_').ToArray());
     }
 
     private void OnInterfaceChanged(WanConfigModel config)

--- a/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
@@ -566,8 +566,8 @@ WantedBy=multi-user.target
 
         try
         {
-            // Normalize wan name for script path (lowercase, replace spaces with dashes)
-            var scriptName = wanName.ToLowerInvariant().Replace(" ", "-");
+            // Normalize wan name for script path (lowercase, no spaces/parens)
+            var scriptName = wanName.ToLowerInvariant().Replace(" ", "-").Replace("(", "").Replace(")", "");
             var scriptPath = $"/data/sqm/{scriptName}-speedtest.sh";
 
             _logger.LogInformation("Triggering SQM adjustment script: {Script}", scriptPath);
@@ -822,9 +822,9 @@ WantedBy=multi-user.target
     /// </summary>
     private string GenerateSqmMonitorScript(string wan1Interface, string wan1Name, string wan2Interface, string wan2Name, int port)
     {
-        // Normalize names for log file lookup (lowercase, dashes for spaces)
-        var wan1LogName = wan1Name.ToLowerInvariant().Replace(" ", "-");
-        var wan2LogName = wan2Name.ToLowerInvariant().Replace(" ", "-");
+        // Normalize names for log file lookup (lowercase, no spaces/parens)
+        var wan1LogName = wan1Name.ToLowerInvariant().Replace(" ", "-").Replace("(", "").Replace(")", "");
+        var wan2LogName = wan2Name.ToLowerInvariant().Replace(" ", "-").Replace("(", "").Replace(")", "");
 
         var sb = new StringBuilder();
         sb.AppendLine("#!/bin/sh");


### PR DESCRIPTION
## Summary

Fixes #52 - SQM scripts fail when WAN connection names contain parentheses (e.g., "5.0Gb (WAN1)").

- Strip parentheses from connection names when generating script filenames
- Add input validation to WAN name fields (sanitizes on blur)
- Allowed characters: letters, numbers, spaces, parentheses, dashes, underscores

## Root Cause

WAN names like `5.0Gb (WAN1)` were being converted to script paths like `/data/sqm/5.0gb-(wan1)-speedtest.sh`. The parentheses in the filename caused shell interpretation issues, resulting in empty `/data/sqm/` directories and "script not found" errors.

## Changes

- `ScriptGenerator.cs`: Strip `(` and `)` from connection names when generating filenames
- `SqmDeploymentService.cs`: Same sanitization for adjustment triggers and monitor script
- `Sqm.razor`: Add `SanitizeWanName()` helper, validate input on blur

## Test Plan

- [x] Deploy SQM with WAN name containing parentheses (e.g., "5.0Gb (WAN1)")
- [x] Verify scripts are created as `5.0gb-wan1-speedtest.sh` (no parens)
- [x] Verify "Adjust" button finds and runs the script
- [x] Verify typing invalid characters in WAN name field strips them on blur