### PR TITLE
Add tower distance estimate and fix signal bars

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Shared/CellularStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/CellularStatsPanel.razor
@@ -548,8 +548,14 @@
     private int GetSignalBars()
     {
         if (modemStats == null) return 0;
-        // Use PrimarySignal which checks for actual RSRP data, not just object existence
-        return modemStats.PrimarySignal?.Bars ?? 0;
+        // Derive bars directly from SignalQuality percentage (0-100 -> 0-5 bars)
+        var quality = modemStats.SignalQuality;
+        if (quality >= 80) return 5;
+        if (quality >= 60) return 4;
+        if (quality >= 40) return 3;
+        if (quality >= 20) return 2;
+        if (quality > 0) return 1;
+        return 0;
     }
 
     private string GetNetworkModeBadgeClass()


### PR DESCRIPTION
## Summary
- Display estimated tower distance based on LTE Timing Advance (78m per TA unit)
- Fix signal bars to derive from SignalQuality percentage instead of separate RSRP logic

## Changes
- Show "Tower: ~{distance} m" when TimingAdvance data is available
- Signal bars now correlate directly with displayed percentage (80%=5, 60%=4, 40%=3, 20%=2, >0=1)

## Test plan
- [x] Verified tower distance displays correctly on LTE connection
- [x] Verified signal bars match percentage on 5G SA, 5G NSA, and LTE-only modes