### PR TITLE
Add DNAT DNS detection and redirect validation

### DIFF
--- a/src/NetworkOptimizer.Audit/ConfigAuditEngine.cs
+++ b/src/NetworkOptimizer.Audit/ConfigAuditEngine.cs
@@ -41,6 +41,7 @@ public class ConfigAuditEngine
         public required JsonElement? SettingsData { get; init; }
         public required JsonElement? FirewallPoliciesData { get; init; }
         public required List<UniFiFirewallGroup>? FirewallGroups { get; init; }
+        public required JsonElement? NatRulesData { get; init; }
         public required string? ClientName { get; init; }
         public required PortSecurityAnalyzer SecurityEngine { get; init; }
         public required DeviceAllowanceSettings AllowanceSettings { get; init; }
@@ -295,6 +296,7 @@ public class ConfigAuditEngine
             SettingsData = request.SettingsData,
             FirewallPoliciesData = request.FirewallPoliciesData,
             FirewallGroups = request.FirewallGroups,
+            NatRulesData = request.NatRulesData,
             ClientName = request.ClientName,
             SecurityEngine = securityEngine,
             AllowanceSettings = effectiveSettings,
@@ -702,10 +704,10 @@ public class ConfigAuditEngine
     {
         _logger.LogInformation("Phase 5b: Analyzing DNS security");
 
-        if (ctx.SettingsData.HasValue || ctx.FirewallPoliciesData.HasValue)
+        if (ctx.SettingsData.HasValue || ctx.FirewallPoliciesData.HasValue || ctx.NatRulesData.HasValue)
         {
             ctx.DnsSecurityResult = await _dnsAnalyzer.AnalyzeAsync(
-                ctx.SettingsData, ctx.FirewallPoliciesData, ctx.Switches, ctx.Networks, ctx.DeviceData, ctx.PiholeManagementPort, ctx.FirewallGroups);
+                ctx.SettingsData, ctx.FirewallPoliciesData, ctx.Switches, ctx.Networks, ctx.DeviceData, ctx.PiholeManagementPort, ctx.FirewallGroups, ctx.NatRulesData);
             ctx.AllIssues.AddRange(ctx.DnsSecurityResult.Issues);
             ctx.HardeningMeasures.AddRange(ctx.DnsSecurityResult.HardeningNotes);
             _logger.LogInformation("Found {IssueCount} DNS security issues", ctx.DnsSecurityResult.Issues.Count);
@@ -855,7 +857,13 @@ public class ConfigAuditEngine
             HasThirdPartyDns = dnsSecurityResult.HasThirdPartyDns,
             IsPiholeDetected = dnsSecurityResult.IsPiholeDetected,
             ThirdPartyDnsProviderName = dnsSecurityResult.ThirdPartyDnsProviderName,
-            ThirdPartyNetworks = thirdPartyNetworks
+            ThirdPartyNetworks = thirdPartyNetworks,
+            // DNAT DNS Coverage
+            HasDnatDnsRules = dnsSecurityResult.HasDnatDnsRules,
+            DnatProvidesFullCoverage = dnsSecurityResult.DnatProvidesFullCoverage,
+            DnatRedirectTarget = dnsSecurityResult.DnatRedirectTarget,
+            DnatCoveredNetworks = dnsSecurityResult.DnatCoveredNetworks.ToList(),
+            DnatUncoveredNetworks = dnsSecurityResult.DnatUncoveredNetworks.ToList()
         };
     }
 

--- a/src/NetworkOptimizer.Audit/Dns/DnatDnsAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnatDnsAnalyzer.cs
@@ -1,0 +1,527 @@
+using System.Net;
+using System.Text.Json;
+using NetworkOptimizer.Audit.Models;
+
+namespace NetworkOptimizer.Audit.Dns;
+
+/// <summary>
+/// Result of DNAT DNS coverage analysis
+/// </summary>
+public class DnatCoverageResult
+{
+    /// <summary>
+    /// Whether any DNAT DNS rules exist (enabled, UDP port 53)
+    /// </summary>
+    public bool HasDnatDnsRules { get; set; }
+
+    /// <summary>
+    /// Whether DNAT rules provide full coverage across all DHCP-enabled networks
+    /// </summary>
+    public bool HasFullCoverage { get; set; }
+
+    /// <summary>
+    /// Network IDs that have DNAT DNS coverage
+    /// </summary>
+    public List<string> CoveredNetworkIds { get; } = new();
+
+    /// <summary>
+    /// Network IDs that lack DNAT DNS coverage
+    /// </summary>
+    public List<string> UncoveredNetworkIds { get; } = new();
+
+    /// <summary>
+    /// Network names that have DNAT DNS coverage
+    /// </summary>
+    public List<string> CoveredNetworkNames { get; } = new();
+
+    /// <summary>
+    /// Network names that lack DNAT DNS coverage
+    /// </summary>
+    public List<string> UncoveredNetworkNames { get; } = new();
+
+    /// <summary>
+    /// Single IP addresses used in DNAT rules (abnormal configuration)
+    /// </summary>
+    public List<string> SingleIpRules { get; } = new();
+
+    /// <summary>
+    /// The IP address DNS traffic is redirected to (from first matching rule)
+    /// </summary>
+    public string? RedirectTargetIp { get; set; }
+
+    /// <summary>
+    /// Parsed DNAT rules targeting DNS
+    /// </summary>
+    public List<DnatRuleInfo> Rules { get; } = new();
+}
+
+/// <summary>
+/// Information about a parsed DNAT rule
+/// </summary>
+public class DnatRuleInfo
+{
+    /// <summary>
+    /// Rule ID from UniFi
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Rule description
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Coverage type: "network", "subnet", or "single_ip"
+    /// </summary>
+    public required string CoverageType { get; init; }
+
+    /// <summary>
+    /// Network conf ID (for network type)
+    /// </summary>
+    public string? NetworkId { get; init; }
+
+    /// <summary>
+    /// CIDR notation (for subnet type)
+    /// </summary>
+    public string? SubnetCidr { get; init; }
+
+    /// <summary>
+    /// Single IP address (for single_ip type)
+    /// </summary>
+    public string? SingleIp { get; init; }
+
+    /// <summary>
+    /// Target IP for DNS redirect
+    /// </summary>
+    public string? RedirectIp { get; init; }
+
+    /// <summary>
+    /// Interface/VLAN ID this rule applies to (from in_interface field).
+    /// When set, this scopes the rule to traffic from that VLAN even if source is "any".
+    /// </summary>
+    public string? InInterface { get; init; }
+}
+
+/// <summary>
+/// Analyzes DNAT rules for DNS port 53 coverage across networks
+/// </summary>
+public class DnatDnsAnalyzer
+{
+    /// <summary>
+    /// Analyze NAT rules for DNS DNAT coverage
+    /// </summary>
+    /// <param name="natRulesData">Raw NAT rules from UniFi API</param>
+    /// <param name="networks">List of networks to check coverage against</param>
+    /// <returns>Coverage analysis result</returns>
+    public DnatCoverageResult Analyze(JsonElement? natRulesData, List<NetworkInfo>? networks)
+    {
+        var result = new DnatCoverageResult();
+
+        if (!natRulesData.HasValue || networks == null || networks.Count == 0)
+        {
+            return result;
+        }
+
+        // Check ALL networks for DNAT coverage (not just DHCP-enabled)
+        // Any network can have devices making DNS queries, regardless of DHCP status
+        var allNetworks = networks.ToList();
+
+        // Parse DNAT rules targeting UDP port 53
+        var dnatDnsRules = ParseDnatDnsRules(natRulesData.Value);
+        result.Rules.AddRange(dnatDnsRules);
+        result.HasDnatDnsRules = dnatDnsRules.Count > 0;
+
+        if (dnatDnsRules.Count == 0)
+        {
+            // No DNAT DNS rules - all networks uncovered
+            foreach (var network in allNetworks)
+            {
+                result.UncoveredNetworkIds.Add(network.Id);
+                result.UncoveredNetworkNames.Add(network.Name);
+            }
+            return result;
+        }
+
+        // Set redirect target from first rule
+        result.RedirectTargetIp = dnatDnsRules.FirstOrDefault()?.RedirectIp;
+
+        // Track covered networks
+        var coveredNetworkIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var rule in dnatDnsRules)
+        {
+            switch (rule.CoverageType)
+            {
+                case "network":
+                case "interface":
+                    // Network reference or in_interface scoping - full coverage for that network
+                    if (!string.IsNullOrEmpty(rule.NetworkId))
+                    {
+                        coveredNetworkIds.Add(rule.NetworkId);
+                    }
+                    break;
+
+                case "subnet":
+                    if (!string.IsNullOrEmpty(rule.SubnetCidr))
+                    {
+                        // Check which networks are covered by this subnet
+                        foreach (var network in allNetworks)
+                        {
+                            if (!string.IsNullOrEmpty(network.Subnet) &&
+                                CidrCoversSubnet(rule.SubnetCidr, network.Subnet))
+                            {
+                                coveredNetworkIds.Add(network.Id);
+                            }
+                        }
+                    }
+                    break;
+
+                case "single_ip":
+                    if (!string.IsNullOrEmpty(rule.SingleIp))
+                    {
+                        result.SingleIpRules.Add(rule.SingleIp);
+                    }
+                    break;
+            }
+        }
+
+        // Categorize networks by coverage
+        foreach (var network in allNetworks)
+        {
+            if (coveredNetworkIds.Contains(network.Id))
+            {
+                result.CoveredNetworkIds.Add(network.Id);
+                result.CoveredNetworkNames.Add(network.Name);
+            }
+            else
+            {
+                result.UncoveredNetworkIds.Add(network.Id);
+                result.UncoveredNetworkNames.Add(network.Name);
+            }
+        }
+
+        result.HasFullCoverage = result.UncoveredNetworkIds.Count == 0;
+
+        return result;
+    }
+
+    /// <summary>
+    /// Parse NAT rules JSON and extract enabled DNAT rules targeting UDP port 53
+    /// </summary>
+    private List<DnatRuleInfo> ParseDnatDnsRules(JsonElement natRulesData)
+    {
+        var rules = new List<DnatRuleInfo>();
+
+        if (natRulesData.ValueKind != JsonValueKind.Array)
+        {
+            return rules;
+        }
+
+        foreach (var rule in natRulesData.EnumerateArray())
+        {
+            // Check rule type is DNAT
+            var type = rule.GetStringOrNull("type");
+            if (!string.Equals(type, "DNAT", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            // Check enabled
+            if (!rule.GetBoolOrDefault("enabled"))
+            {
+                continue;
+            }
+
+            // Check protocol includes UDP (DNS is primarily UDP)
+            var protocol = rule.GetStringOrNull("protocol")?.ToLowerInvariant();
+            if (!IncludesUdp(protocol))
+            {
+                continue;
+            }
+
+            // Check destination port is 53
+            var destFilter = rule.GetPropertyOrNull("destination_filter");
+            if (destFilter == null)
+            {
+                continue;
+            }
+
+            var destPort = destFilter.Value.GetStringOrNull("port");
+            if (!IncludesPort53(destPort))
+            {
+                continue;
+            }
+
+            // This is a valid DNAT DNS rule - parse it
+            var id = rule.GetStringOrNull("_id") ?? Guid.NewGuid().ToString();
+            var description = rule.GetStringOrNull("description");
+            var redirectIp = rule.GetStringOrNull("ip_address");
+            var inInterface = rule.GetStringOrNull("in_interface");
+
+            // Parse source filter to determine coverage type
+            var sourceFilter = rule.GetPropertyOrNull("source_filter");
+            var filterType = sourceFilter?.GetStringOrNull("filter_type");
+            var networkConfId = sourceFilter?.GetStringOrNull("network_conf_id");
+            var address = sourceFilter?.GetStringOrNull("address");
+
+            DnatRuleInfo ruleInfo;
+
+            if (string.Equals(filterType, "NETWORK_CONF", StringComparison.OrdinalIgnoreCase) &&
+                !string.IsNullOrEmpty(networkConfId))
+            {
+                // Network reference - full coverage for that network
+                ruleInfo = new DnatRuleInfo
+                {
+                    Id = id,
+                    Description = description,
+                    CoverageType = "network",
+                    NetworkId = networkConfId,
+                    RedirectIp = redirectIp,
+                    InInterface = inInterface
+                };
+            }
+            else if (!string.IsNullOrEmpty(address))
+            {
+                if (address.Contains('/'))
+                {
+                    // CIDR subnet
+                    ruleInfo = new DnatRuleInfo
+                    {
+                        Id = id,
+                        Description = description,
+                        CoverageType = "subnet",
+                        SubnetCidr = address,
+                        RedirectIp = redirectIp,
+                        InInterface = inInterface
+                    };
+                }
+                else
+                {
+                    // Single IP (abnormal)
+                    ruleInfo = new DnatRuleInfo
+                    {
+                        Id = id,
+                        Description = description,
+                        CoverageType = "single_ip",
+                        SingleIp = address,
+                        RedirectIp = redirectIp,
+                        InInterface = inInterface
+                    };
+                }
+            }
+            else if (!string.IsNullOrEmpty(inInterface))
+            {
+                // Source is "any" but in_interface scopes to a specific VLAN
+                ruleInfo = new DnatRuleInfo
+                {
+                    Id = id,
+                    Description = description,
+                    CoverageType = "interface",
+                    NetworkId = inInterface, // Use in_interface as the network ID for coverage
+                    RedirectIp = redirectIp,
+                    InInterface = inInterface
+                };
+            }
+            else
+            {
+                continue; // Unknown filter type and no in_interface
+            }
+
+            rules.Add(ruleInfo);
+        }
+
+        return rules;
+    }
+
+    /// <summary>
+    /// Check if protocol includes UDP
+    /// </summary>
+    private static bool IncludesUdp(string? protocol)
+    {
+        if (string.IsNullOrEmpty(protocol))
+        {
+            return false;
+        }
+
+        return protocol switch
+        {
+            "udp" => true,
+            "tcp_udp" => true,
+            "all" => true,
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// Check if port specification includes port 53
+    /// </summary>
+    private static bool IncludesPort53(string? port)
+    {
+        if (string.IsNullOrEmpty(port))
+        {
+            return false;
+        }
+
+        // Could be "53", "53,443", "1:100" (range), etc.
+        if (port == "53")
+        {
+            return true;
+        }
+
+        // Check comma-separated list
+        var ports = port.Split(',');
+        foreach (var p in ports)
+        {
+            var trimmed = p.Trim();
+            if (trimmed == "53")
+            {
+                return true;
+            }
+
+            // Check for range (e.g., "1:100")
+            if (trimmed.Contains(':'))
+            {
+                var range = trimmed.Split(':');
+                if (range.Length == 2 &&
+                    int.TryParse(range[0], out var start) &&
+                    int.TryParse(range[1], out var end))
+                {
+                    if (start <= 53 && 53 <= end)
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Check if a CIDR block covers another subnet
+    /// </summary>
+    /// <param name="ruleCidr">The DNAT rule's CIDR (e.g., "192.168.0.0/16")</param>
+    /// <param name="networkSubnet">The network's subnet (e.g., "192.168.1.0/24")</param>
+    /// <returns>True if ruleCidr completely covers networkSubnet</returns>
+    public static bool CidrCoversSubnet(string ruleCidr, string networkSubnet)
+    {
+        try
+        {
+            var (ruleNetwork, rulePrefixLength) = ParseCidr(ruleCidr);
+            var (subnetNetwork, subnetPrefixLength) = ParseCidr(networkSubnet);
+
+            if (ruleNetwork == null || subnetNetwork == null)
+            {
+                return false;
+            }
+
+            // Rule must have same or shorter prefix (larger network) to cover subnet
+            if (rulePrefixLength > subnetPrefixLength)
+            {
+                return false;
+            }
+
+            // Compare network addresses masked by rule's prefix length
+            var ruleBytes = ruleNetwork.GetAddressBytes();
+            var subnetBytes = subnetNetwork.GetAddressBytes();
+
+            if (ruleBytes.Length != subnetBytes.Length)
+            {
+                return false; // IPv4 vs IPv6 mismatch
+            }
+
+            // Calculate how many full bytes and remaining bits to compare
+            var fullBytes = rulePrefixLength / 8;
+            var remainingBits = rulePrefixLength % 8;
+
+            // Compare full bytes
+            for (int i = 0; i < fullBytes; i++)
+            {
+                if (ruleBytes[i] != subnetBytes[i])
+                {
+                    return false;
+                }
+            }
+
+            // Compare remaining bits if any
+            if (remainingBits > 0 && fullBytes < ruleBytes.Length)
+            {
+                var mask = (byte)(0xFF << (8 - remainingBits));
+                if ((ruleBytes[fullBytes] & mask) != (subnetBytes[fullBytes] & mask))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Parse CIDR notation into network address and prefix length
+    /// </summary>
+    private static (IPAddress? network, int prefixLength) ParseCidr(string cidr)
+    {
+        var parts = cidr.Split('/');
+        if (parts.Length != 2)
+        {
+            return (null, 0);
+        }
+
+        if (!IPAddress.TryParse(parts[0], out var address))
+        {
+            return (null, 0);
+        }
+
+        if (!int.TryParse(parts[1], out var prefixLength))
+        {
+            return (null, 0);
+        }
+
+        return (address, prefixLength);
+    }
+}
+
+/// <summary>
+/// JSON helper extension methods for safe property access
+/// </summary>
+internal static class JsonElementExtensions
+{
+    public static string? GetStringOrNull(this JsonElement element, string propertyName)
+    {
+        if (element.TryGetProperty(propertyName, out var prop) && prop.ValueKind == JsonValueKind.String)
+        {
+            return prop.GetString();
+        }
+        return null;
+    }
+
+    public static bool GetBoolOrDefault(this JsonElement element, string propertyName, bool defaultValue = false)
+    {
+        if (element.TryGetProperty(propertyName, out var prop))
+        {
+            if (prop.ValueKind == JsonValueKind.True)
+            {
+                return true;
+            }
+            if (prop.ValueKind == JsonValueKind.False)
+            {
+                return false;
+            }
+        }
+        return defaultValue;
+    }
+
+    public static JsonElement? GetPropertyOrNull(this JsonElement element, string propertyName)
+    {
+        if (element.TryGetProperty(propertyName, out var prop))
+        {
+            return prop;
+        }
+        return null;
+    }
+}

--- a/src/NetworkOptimizer.Audit/IssueTypes.cs
+++ b/src/NetworkOptimizer.Audit/IssueTypes.cs
@@ -56,4 +56,9 @@ public static class IssueTypes
     public const string DnsThirdPartyDetected = "DNS_THIRD_PARTY_DETECTED";
     public const string DnsUnknownConfig = "DNS_UNKNOWN_CONFIG";
     public const string DnsInconsistentConfig = "DNS_INCONSISTENT_CONFIG";
+
+    // DNS DNAT Issues
+    public const string DnsDnatPartialCoverage = "DNS_DNAT_PARTIAL_COVERAGE";
+    public const string DnsDnatSingleIp = "DNS_DNAT_SINGLE_IP";
+    public const string DnsDnatWrongDestination = "DNS_DNAT_WRONG_DESTINATION";
 }

--- a/src/NetworkOptimizer.Audit/Models/AuditRequest.cs
+++ b/src/NetworkOptimizer.Audit/Models/AuditRequest.cs
@@ -47,6 +47,11 @@ public class AuditRequest
     public List<UniFiFirewallGroup>? FirewallGroups { get; init; }
 
     /// <summary>
+    /// Optional: NAT rules data from UniFi API for DNAT DNS detection
+    /// </summary>
+    public JsonElement? NatRulesData { get; init; }
+
+    /// <summary>
     /// Optional: User-defined device allowance settings
     /// </summary>
     public DeviceAllowanceSettings? AllowanceSettings { get; init; }

--- a/src/NetworkOptimizer.Audit/Models/AuditResult.cs
+++ b/src/NetworkOptimizer.Audit/Models/AuditResult.cs
@@ -227,6 +227,31 @@ public class DnsSecurityInfo
     public List<ThirdPartyDnsNetwork> ThirdPartyNetworks { get; set; } = new();
 
     /// <summary>
+    /// Whether DNAT DNS rules exist (redirecting UDP port 53)
+    /// </summary>
+    public bool HasDnatDnsRules { get; set; }
+
+    /// <summary>
+    /// Whether DNAT rules provide full coverage across all DHCP-enabled networks
+    /// </summary>
+    public bool DnatProvidesFullCoverage { get; set; }
+
+    /// <summary>
+    /// The IP address DNS traffic is redirected to
+    /// </summary>
+    public string? DnatRedirectTarget { get; set; }
+
+    /// <summary>
+    /// Network names that have DNAT DNS coverage
+    /// </summary>
+    public List<string> DnatCoveredNetworks { get; set; } = new();
+
+    /// <summary>
+    /// Network names that lack DNAT DNS coverage
+    /// </summary>
+    public List<string> DnatUncoveredNetworks { get; set; } = new();
+
+    /// <summary>
     /// Whether full DNS protection is in place
     /// </summary>
     public bool FullyProtected => DohEnabled && DnsLeakProtection && DotBlocked && DohBypassBlocked && WanDnsMatchesDoH && DeviceDnsPointsToGateway;

--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -1278,6 +1278,36 @@ public class UniFiApiClient : IDisposable
         });
     }
 
+    /// <summary>
+    /// GET v2/api/site/{site}/nat - Get NAT rules (DNAT/SNAT)
+    /// This endpoint provides NAT rule configuration for DNS redirection detection
+    /// </summary>
+    public async Task<JsonDocument?> GetNatRulesRawAsync(CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Fetching NAT rules from site {Site}", _site);
+
+        if (!await EnsureAuthenticatedAsync(cancellationToken))
+        {
+            return null;
+        }
+
+        return await _retryPolicy.ExecuteAsync(async () =>
+        {
+            var url = BuildV2ApiPath($"site/{_site}/nat");
+            var response = await _httpClient!.GetAsync(url, cancellationToken);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var json = await response.Content.ReadAsStringAsync(cancellationToken);
+                _logger.LogDebug("Retrieved NAT rules ({Length} bytes)", json.Length);
+                return JsonDocument.Parse(json);
+            }
+
+            _logger.LogWarning("Failed to retrieve NAT rules: {StatusCode}", response.StatusCode);
+            return null;
+        });
+    }
+
     #endregion
 
     #region Fingerprint Database APIs

--- a/src/NetworkOptimizer.Web/Services/AuditService.cs
+++ b/src/NetworkOptimizer.Web/Services/AuditService.cs
@@ -589,6 +589,22 @@ public class AuditService
                 _logger.LogWarning(ex, "Failed to fetch firewall groups");
             }
 
+            // Fetch NAT rules for DNAT DNS detection
+            System.Text.Json.JsonElement? natRulesData = null;
+            try
+            {
+                var natDoc = await _connectionService.Client.GetNatRulesRawAsync();
+                if (natDoc != null)
+                {
+                    natRulesData = natDoc.RootElement;
+                    _logger.LogInformation("Fetched NAT rules for DNAT DNS analysis");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to fetch NAT rules for DNAT DNS analysis");
+            }
+
             _logger.LogInformation("Running audit engine on device data ({Length} bytes)", deviceDataJson.Length);
 
             // Fetch UniFi Protect cameras for 100% confidence detection
@@ -644,6 +660,7 @@ public class AuditService
                 SettingsData = settingsData,
                 FirewallPoliciesData = firewallPoliciesData,
                 FirewallGroups = firewallGroups,
+                NatRulesData = natRulesData,
                 AllowanceSettings = allowanceSettings,
                 ProtectCameras = protectCameras,
                 PortProfiles = portProfiles,
@@ -870,7 +887,13 @@ public class AuditService
                         DnsServerIp = n.DnsServerIp,
                         DnsProviderName = n.DnsProviderName
                     })
-                    .ToList()
+                    .ToList(),
+                // DNAT DNS Coverage
+                HasDnatDnsRules = dns.HasDnatDnsRules,
+                DnatProvidesFullCoverage = dns.DnatProvidesFullCoverage,
+                DnatRedirectTarget = dns.DnatRedirectTarget,
+                DnatCoveredNetworks = dns.DnatCoveredNetworks.ToList(),
+                DnatUncoveredNetworks = dns.DnatUncoveredNetworks.ToList()
             };
         }
 
@@ -1044,6 +1067,9 @@ public class AuditService
             Audit.IssueTypes.DnsThirdPartyDetected => "DNS: Third-Party Detected",
             Audit.IssueTypes.DnsInconsistentConfig => "DNS: Inconsistent Configuration",
             Audit.IssueTypes.DnsUnknownConfig => "DNS: Unknown Configuration",
+            Audit.IssueTypes.DnsDnatPartialCoverage => "DNS: Partial DNAT Coverage",
+            Audit.IssueTypes.DnsDnatSingleIp => "DNS: Single IP DNAT",
+            Audit.IssueTypes.DnsDnatWrongDestination => "DNS: Invalid DNAT Target",
 
             _ => message.Split('.').FirstOrDefault() ?? type
         };
@@ -1122,6 +1148,8 @@ public class AuditService
         Audit.IssueTypes.DnsWanMismatch => "Set WAN DNS servers to match your DoH provider",
         Audit.IssueTypes.DnsWanNoStatic => "Configure static DNS on the WAN interface to use your DoH provider's servers",
         Audit.IssueTypes.DnsDeviceMisconfigured => "Configure device DNS to point to the gateway",
+        Audit.IssueTypes.DnsDnatPartialCoverage => "Add DNAT rules for remaining networks or block DNS port 53 at firewall",
+        Audit.IssueTypes.DnsDnatSingleIp => "Configure DNAT rules to use network references or CIDR ranges for complete coverage",
         _ => "Review the configuration and apply security best practices"
     };
 }
@@ -1193,6 +1221,13 @@ public class DnsSecurityReference
     public bool IsPiholeDetected { get; set; }
     public string? ThirdPartyDnsProviderName { get; set; }
     public List<ThirdPartyDnsNetworkReference> ThirdPartyNetworks { get; set; } = new();
+
+    // DNAT DNS Coverage
+    public bool HasDnatDnsRules { get; set; }
+    public bool DnatProvidesFullCoverage { get; set; }
+    public string? DnatRedirectTarget { get; set; }
+    public List<string> DnatCoveredNetworks { get; set; } = new();
+    public List<string> DnatUncoveredNetworks { get; set; } = new();
 }
 
 public class ThirdPartyDnsNetworkReference

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/DnatDnsAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/DnatDnsAnalyzerTests.cs
@@ -1,0 +1,616 @@
+using System.Text.Json;
+using NetworkOptimizer.Audit.Dns;
+using NetworkOptimizer.Audit.Models;
+using Xunit;
+
+namespace NetworkOptimizer.Audit.Tests.Dns;
+
+/// <summary>
+/// Unit tests for DnatDnsAnalyzer
+/// </summary>
+public class DnatDnsAnalyzerTests
+{
+    private readonly DnatDnsAnalyzer _analyzer = new();
+
+    #region Helper Methods
+
+    private static List<NetworkInfo> CreateTestNetworks(params (string id, string name, string subnet, bool dhcpEnabled)[] networks)
+    {
+        return networks.Select(n => new NetworkInfo
+        {
+            Id = n.id,
+            Name = n.name,
+            VlanId = 1,
+            Subnet = n.subnet,
+            DhcpEnabled = n.dhcpEnabled
+        }).ToList();
+    }
+
+    private static string CreateDnatRule(
+        string id,
+        string sourceFilterType,
+        string? sourceAddress = null,
+        string? networkConfId = null,
+        string destPort = "53",
+        string protocol = "udp",
+        bool enabled = true,
+        string redirectIp = "192.168.1.1",
+        string? inInterface = null,
+        string? description = null)
+    {
+        var sourceFilter = sourceFilterType == "NETWORK_CONF"
+            ? $"\"filter_type\": \"NETWORK_CONF\", \"network_conf_id\": \"{networkConfId}\""
+            : sourceFilterType == "ANY"
+                ? "\"filter_type\": \"ANY\""
+                : $"\"filter_type\": \"ADDRESS_AND_PORT\", \"address\": \"{sourceAddress}\"";
+
+        var inInterfaceField = inInterface != null ? $"\"in_interface\": \"{inInterface}\"," : "";
+        var desc = description ?? "Test DNAT";
+
+        return $$"""
+        {
+            "_id": "{{id}}",
+            "description": "{{desc}}",
+            "type": "DNAT",
+            "enabled": {{enabled.ToString().ToLower()}},
+            "protocol": "{{protocol}}",
+            "ip_version": "IPV4",
+            "ip_address": "{{redirectIp}}",
+            {{inInterfaceField}}
+            "destination_filter": {
+                "filter_type": "ADDRESS_AND_PORT",
+                "port": "{{destPort}}"
+            },
+            "source_filter": {
+                {{sourceFilter}}
+            }
+        }
+        """;
+    }
+
+    private static JsonElement ParseNatRules(params string[] rules)
+    {
+        var json = $"[{string.Join(",", rules)}]";
+        return JsonDocument.Parse(json).RootElement;
+    }
+
+    #endregion
+
+    #region No NAT Rules Tests
+
+    [Fact]
+    public void Analyze_WithNullNatRules_ReturnsEmptyResult()
+    {
+        var networks = CreateTestNetworks(("net1", "LAN", "192.168.1.0/24", true));
+
+        var result = _analyzer.Analyze(null, networks);
+
+        Assert.False(result.HasDnatDnsRules);
+        Assert.False(result.HasFullCoverage);
+        Assert.Empty(result.Rules);
+    }
+
+    [Fact]
+    public void Analyze_WithEmptyNetworks_ReturnsEmptyResult()
+    {
+        var natRules = ParseNatRules(CreateDnatRule("1", "ADDRESS_AND_PORT", sourceAddress: "192.168.1.0/24"));
+
+        var result = _analyzer.Analyze(natRules, null);
+
+        Assert.False(result.HasDnatDnsRules);
+    }
+
+    [Fact]
+    public void Analyze_WithNonDhcpNetwork_StillChecksCoverage()
+    {
+        // Non-DHCP networks still need DNAT coverage (static IP devices can make DNS queries)
+        var networks = CreateTestNetworks(("net1", "LAN", "192.168.1.0/24", false));
+        var natRules = ParseNatRules();
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.False(result.HasFullCoverage); // Non-DHCP network still needs coverage
+        Assert.Single(result.UncoveredNetworkIds);
+        Assert.Contains("net1", result.UncoveredNetworkIds);
+    }
+
+    [Fact]
+    public void Analyze_WithEmptyNatRulesArray_ReturnsNoCoverage()
+    {
+        var networks = CreateTestNetworks(("net1", "LAN", "192.168.1.0/24", true));
+        var natRules = ParseNatRules();
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.False(result.HasDnatDnsRules);
+        Assert.False(result.HasFullCoverage);
+        Assert.Single(result.UncoveredNetworkIds);
+    }
+
+    #endregion
+
+    #region Network Reference Coverage Tests
+
+    [Fact]
+    public void Analyze_WithNetworkRefDnat_CoversSpecificNetwork()
+    {
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true),
+            ("net2", "IoT", "192.168.2.0/24", true));
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "NETWORK_CONF", networkConfId: "net1"));
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.True(result.HasDnatDnsRules);
+        Assert.False(result.HasFullCoverage); // Only net1 covered
+        Assert.Single(result.CoveredNetworkIds);
+        Assert.Contains("net1", result.CoveredNetworkIds);
+        Assert.Single(result.UncoveredNetworkIds);
+        Assert.Contains("net2", result.UncoveredNetworkIds);
+    }
+
+    [Fact]
+    public void Analyze_WithMultipleNetworkRefDnat_CoversAllNetworks()
+    {
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true),
+            ("net2", "IoT", "192.168.2.0/24", true));
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "NETWORK_CONF", networkConfId: "net1"),
+            CreateDnatRule("2", "NETWORK_CONF", networkConfId: "net2"));
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.True(result.HasDnatDnsRules);
+        Assert.True(result.HasFullCoverage);
+        Assert.Equal(2, result.CoveredNetworkIds.Count);
+        Assert.Empty(result.UncoveredNetworkIds);
+    }
+
+    #endregion
+
+    #region Subnet Coverage Tests
+
+    [Fact]
+    public void Analyze_WithSubnetDnat_CoversMatchingNetwork()
+    {
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true));
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "ADDRESS_AND_PORT", sourceAddress: "192.168.1.0/24"));
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.True(result.HasDnatDnsRules);
+        Assert.True(result.HasFullCoverage);
+        Assert.Single(result.CoveredNetworkIds);
+        Assert.Contains("net1", result.CoveredNetworkIds);
+    }
+
+    [Fact]
+    public void Analyze_WithLargerSubnetDnat_CoversMultipleNetworks()
+    {
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true),
+            ("net2", "IoT", "192.168.2.0/24", true));
+        // /16 covers both /24 networks
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "ADDRESS_AND_PORT", sourceAddress: "192.168.0.0/16"));
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.True(result.HasDnatDnsRules);
+        Assert.True(result.HasFullCoverage);
+        Assert.Equal(2, result.CoveredNetworkIds.Count);
+    }
+
+    [Fact]
+    public void Analyze_WithSmallerSubnetDnat_DoesNotCoverLargerNetwork()
+    {
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.0.0/16", true)); // Larger network
+        // /24 is smaller than /16, doesn't cover the whole network
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "ADDRESS_AND_PORT", sourceAddress: "192.168.1.0/24"));
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.True(result.HasDnatDnsRules);
+        Assert.False(result.HasFullCoverage);
+        Assert.Empty(result.CoveredNetworkIds);
+    }
+
+    [Fact]
+    public void Analyze_WithNonMatchingSubnet_DoesNotCover()
+    {
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true));
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "ADDRESS_AND_PORT", sourceAddress: "10.0.0.0/24")); // Different subnet
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.True(result.HasDnatDnsRules);
+        Assert.False(result.HasFullCoverage);
+        Assert.Single(result.UncoveredNetworkIds);
+    }
+
+    #endregion
+
+    #region Single IP Tests (Abnormal Configuration)
+
+    [Fact]
+    public void Analyze_WithSingleIpDnat_FlagsAsAbnormal()
+    {
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true));
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "ADDRESS_AND_PORT", sourceAddress: "192.168.1.100")); // Single IP
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.True(result.HasDnatDnsRules);
+        Assert.False(result.HasFullCoverage); // Single IP doesn't provide full coverage
+        Assert.Single(result.SingleIpRules);
+        Assert.Contains("192.168.1.100", result.SingleIpRules);
+    }
+
+    [Fact]
+    public void Analyze_WithMultipleSingleIpDnat_FlagsAllAsAbnormal()
+    {
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true));
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "ADDRESS_AND_PORT", sourceAddress: "192.168.1.100"),
+            CreateDnatRule("2", "ADDRESS_AND_PORT", sourceAddress: "192.168.1.101"));
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.Equal(2, result.SingleIpRules.Count);
+    }
+
+    #endregion
+
+    #region Protocol Filter Tests
+
+    [Fact]
+    public void Analyze_WithTcpOnlyDnat_IgnoresRule()
+    {
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true));
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "ADDRESS_AND_PORT", sourceAddress: "192.168.1.0/24", protocol: "tcp"));
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.False(result.HasDnatDnsRules);
+        Assert.False(result.HasFullCoverage);
+    }
+
+    [Fact]
+    public void Analyze_WithTcpUdpDnat_IncludesRule()
+    {
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true));
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "ADDRESS_AND_PORT", sourceAddress: "192.168.1.0/24", protocol: "tcp_udp"));
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.True(result.HasDnatDnsRules);
+        Assert.True(result.HasFullCoverage);
+    }
+
+    [Fact]
+    public void Analyze_WithAllProtocolDnat_IncludesRule()
+    {
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true));
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "ADDRESS_AND_PORT", sourceAddress: "192.168.1.0/24", protocol: "all"));
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.True(result.HasDnatDnsRules);
+        Assert.True(result.HasFullCoverage);
+    }
+
+    #endregion
+
+    #region Disabled Rule Tests
+
+    [Fact]
+    public void Analyze_WithDisabledDnat_IgnoresRule()
+    {
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true));
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "ADDRESS_AND_PORT", sourceAddress: "192.168.1.0/24", enabled: false));
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.False(result.HasDnatDnsRules);
+        Assert.False(result.HasFullCoverage);
+    }
+
+    #endregion
+
+    #region Non-Port-53 Tests
+
+    [Fact]
+    public void Analyze_WithNonPort53Dnat_IgnoresRule()
+    {
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true));
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "ADDRESS_AND_PORT", sourceAddress: "192.168.1.0/24", destPort: "80"));
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.False(result.HasDnatDnsRules);
+    }
+
+    [Fact]
+    public void Analyze_WithPort53InRange_IncludesRule()
+    {
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true));
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "ADDRESS_AND_PORT", sourceAddress: "192.168.1.0/24", destPort: "1:100")); // Range includes 53
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.True(result.HasDnatDnsRules);
+    }
+
+    [Fact]
+    public void Analyze_WithPort53InList_IncludesRule()
+    {
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true));
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "ADDRESS_AND_PORT", sourceAddress: "192.168.1.0/24", destPort: "22,53,80"));
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.True(result.HasDnatDnsRules);
+    }
+
+    #endregion
+
+    #region Non-DNAT Rule Tests
+
+    [Fact]
+    public void Analyze_WithSnatRule_IgnoresRule()
+    {
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true));
+        // SNAT rule instead of DNAT
+        var snatRule = """
+        {
+            "_id": "1",
+            "type": "SNAT",
+            "enabled": true,
+            "protocol": "udp",
+            "ip_address": "192.168.1.1",
+            "destination_filter": { "filter_type": "ADDRESS_AND_PORT", "port": "53" },
+            "source_filter": { "filter_type": "ADDRESS_AND_PORT", "address": "192.168.1.0/24" }
+        }
+        """;
+        var natRules = JsonDocument.Parse($"[{snatRule}]").RootElement;
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.False(result.HasDnatDnsRules);
+    }
+
+    #endregion
+
+    #region Redirect Target Tests
+
+    [Fact]
+    public void Analyze_SetsRedirectTargetFromFirstRule()
+    {
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true));
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "ADDRESS_AND_PORT", sourceAddress: "192.168.1.0/24", redirectIp: "10.0.0.1"));
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.Equal("10.0.0.1", result.RedirectTargetIp);
+    }
+
+    #endregion
+
+    #region Mixed Coverage Tests
+
+    [Fact]
+    public void Analyze_WithMixedCoverageTypes_CumulativesCoverage()
+    {
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true),
+            ("net2", "IoT", "192.168.2.0/24", true),
+            ("net3", "Guest", "192.168.3.0/24", true));
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "NETWORK_CONF", networkConfId: "net1"), // Network ref
+            CreateDnatRule("2", "ADDRESS_AND_PORT", sourceAddress: "192.168.2.0/24"), // Subnet
+            CreateDnatRule("3", "ADDRESS_AND_PORT", sourceAddress: "192.168.3.100")); // Single IP
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.True(result.HasDnatDnsRules);
+        Assert.False(result.HasFullCoverage); // Single IP doesn't cover net3
+        Assert.Equal(2, result.CoveredNetworkIds.Count); // net1 and net2
+        Assert.Single(result.UncoveredNetworkIds); // net3
+        Assert.Single(result.SingleIpRules); // One single IP rule
+    }
+
+    #endregion
+
+    #region CidrCoversSubnet Tests
+
+    [Fact]
+    public void CidrCoversSubnet_ExactMatch_ReturnsTrue()
+    {
+        Assert.True(DnatDnsAnalyzer.CidrCoversSubnet("192.168.1.0/24", "192.168.1.0/24"));
+    }
+
+    [Fact]
+    public void CidrCoversSubnet_LargerCidrCoversSmaller_ReturnsTrue()
+    {
+        Assert.True(DnatDnsAnalyzer.CidrCoversSubnet("192.168.0.0/16", "192.168.1.0/24"));
+    }
+
+    [Fact]
+    public void CidrCoversSubnet_SmallerCidrDoesNotCoverLarger_ReturnsFalse()
+    {
+        Assert.False(DnatDnsAnalyzer.CidrCoversSubnet("192.168.1.0/24", "192.168.0.0/16"));
+    }
+
+    [Fact]
+    public void CidrCoversSubnet_DifferentNetwork_ReturnsFalse()
+    {
+        Assert.False(DnatDnsAnalyzer.CidrCoversSubnet("192.168.1.0/24", "192.168.2.0/24"));
+    }
+
+    [Fact]
+    public void CidrCoversSubnet_ClassA_ReturnsTrue()
+    {
+        Assert.True(DnatDnsAnalyzer.CidrCoversSubnet("10.0.0.0/8", "10.1.2.0/24"));
+    }
+
+    [Fact]
+    public void CidrCoversSubnet_InvalidCidr_ReturnsFalse()
+    {
+        Assert.False(DnatDnsAnalyzer.CidrCoversSubnet("invalid", "192.168.1.0/24"));
+        Assert.False(DnatDnsAnalyzer.CidrCoversSubnet("192.168.1.0/24", "invalid"));
+    }
+
+    #endregion
+
+    #region Interface Coverage Tests (in_interface with source ANY)
+
+    [Fact]
+    public void Analyze_WithInInterface_SourceAny_CoversInterfaceNetwork()
+    {
+        // When in_interface is set and source is ANY, the rule covers that network
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true),
+            ("net2", "IoT", "192.168.2.0/24", true));
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "ANY", inInterface: "net1", redirectIp: "192.168.1.1"));
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.True(result.HasDnatDnsRules);
+        Assert.Single(result.CoveredNetworkIds);
+        Assert.Contains("net1", result.CoveredNetworkIds);
+        Assert.Single(result.UncoveredNetworkIds);
+        Assert.Contains("net2", result.UncoveredNetworkIds);
+    }
+
+    [Fact]
+    public void Analyze_WithInInterface_AndNetworkRef_BothWork()
+    {
+        // in_interface can be combined with explicit network reference
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true));
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "NETWORK_CONF", networkConfId: "net1", inInterface: "net1", redirectIp: "192.168.1.1"));
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.True(result.HasDnatDnsRules);
+        Assert.True(result.HasFullCoverage);
+        Assert.Single(result.Rules);
+        Assert.Equal("net1", result.Rules[0].InInterface);
+    }
+
+    [Fact]
+    public void Analyze_ExtractsInInterfaceFromRule()
+    {
+        var networks = CreateTestNetworks(("net1", "LAN", "192.168.1.0/24", true));
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "NETWORK_CONF", networkConfId: "net1", inInterface: "interface-123"));
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.Single(result.Rules);
+        Assert.Equal("interface-123", result.Rules[0].InInterface);
+    }
+
+    [Fact]
+    public void Analyze_WithMultipleInterfaceRules_CoversMultipleNetworks()
+    {
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true),
+            ("net2", "IoT", "192.168.2.0/24", true),
+            ("net3", "Guest", "192.168.3.0/24", true));
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "ANY", inInterface: "net1", redirectIp: "192.168.1.1"),
+            CreateDnatRule("2", "ANY", inInterface: "net2", redirectIp: "192.168.2.1"),
+            CreateDnatRule("3", "ANY", inInterface: "net3", redirectIp: "192.168.3.1"));
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.True(result.HasDnatDnsRules);
+        Assert.True(result.HasFullCoverage);
+        Assert.Equal(3, result.CoveredNetworkIds.Count);
+        Assert.Empty(result.UncoveredNetworkIds);
+    }
+
+    [Fact]
+    public void Analyze_InterfaceCoverageType_SetCorrectly()
+    {
+        var networks = CreateTestNetworks(("net1", "LAN", "192.168.1.0/24", true));
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "ANY", inInterface: "net1", redirectIp: "192.168.1.1"));
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.Single(result.Rules);
+        Assert.Equal("interface", result.Rules[0].CoverageType);
+        Assert.Equal("net1", result.Rules[0].NetworkId);
+    }
+
+    #endregion
+
+    #region Multiple Redirect Target Tests
+
+    [Fact]
+    public void Analyze_TracksRedirectIpPerRule()
+    {
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true),
+            ("net2", "IoT", "192.168.2.0/24", true));
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "NETWORK_CONF", networkConfId: "net1", redirectIp: "192.168.1.1"),
+            CreateDnatRule("2", "NETWORK_CONF", networkConfId: "net2", redirectIp: "192.168.2.1"));
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.Equal(2, result.Rules.Count);
+        Assert.Equal("192.168.1.1", result.Rules[0].RedirectIp);
+        Assert.Equal("192.168.2.1", result.Rules[1].RedirectIp);
+    }
+
+    [Fact]
+    public void Analyze_RedirectTargetIp_UsesFirstRule()
+    {
+        // RedirectTargetIp should be from the first rule for backward compatibility
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true),
+            ("net2", "IoT", "192.168.2.0/24", true));
+        var natRules = ParseNatRules(
+            CreateDnatRule("1", "NETWORK_CONF", networkConfId: "net1", redirectIp: "10.0.0.1"),
+            CreateDnatRule("2", "NETWORK_CONF", networkConfId: "net2", redirectIp: "10.0.0.2"));
+
+        var result = _analyzer.Analyze(natRules, networks);
+
+        Assert.Equal("10.0.0.1", result.RedirectTargetIp);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Detect DNAT rules that redirect DNS (port 53) traffic as an alternative to firewall blocking
- Validate DNAT redirect destinations match the expected DNS server (gateway for DoH, Pi-hole IP for third-party DNS)
- Report partial DNAT coverage when some networks lack DNS redirect rules
- Integrate with existing firewall group flattening for port/IP list resolution

## New Audit Issues
- **DNS_DNAT_PARTIAL_COVERAGE** (Critical) - DNAT rules don't cover all networks
- **DNS_DNAT_SINGLE_IP** (Info) - DNAT rules target single IPs instead of network ranges
- **DNS_DNAT_WRONG_DESTINATION** (Critical) - DNAT redirects to incorrect destination

## Test Plan
- [x] All 3,160 tests pass
- [x] Deployed to NAS and Mac for manual verification