### PR TITLE
Fix SpeedTest accuracy and display precision

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
@@ -252,7 +252,7 @@
                                     <td>
                                         @if (result.PingMs.HasValue)
                                         {
-                                            <span>@result.PingMs.Value.ToString("F0") ms</span>
+                                            <span>@result.PingMs.Value.ToString("F1") ms</span>
                                         }
                                         else
                                         {

--- a/src/OpenSpeedTest/assets/js/app-2.5.4.js
+++ b/src/OpenSpeedTest/assets/js/app-2.5.4.js
@@ -332,14 +332,14 @@ window.onload = function() {
     var ShowData = data;
     if (Display === "Ping") {
       if (ShowData >= 1 && ShowData < 10000) {
-        this.pingResult.el.textContent = Math.floor(ShowData);
-        this.pingMobres.el.textContent = Math.floor(ShowData);
+        this.pingResult.el.textContent = ShowData.toFixed(1);
+        this.pingMobres.el.textContent = ShowData.toFixed(1);
       } else if (ShowData >= 0 && ShowData < 1) {
         if (ShowData == 0) {
           ShowData = 0;
         }
-        this.pingResult.el.textContent = ShowData;
-        this.pingMobres.el.textContent = ShowData;
+        this.pingResult.el.textContent = ShowData.toFixed(1);
+        this.pingMobres.el.textContent = ShowData.toFixed(1);
       }
     }
     if (Display === "Error") {
@@ -366,9 +366,9 @@ window.onload = function() {
     var ShowData = data;
     if (Display === "Jitter") {
       if (ShowData >= 1 && ShowData < 10000) {
-        this.jitterDesk.el.textContent = Math.floor(ShowData);
+        this.jitterDesk.el.textContent = ShowData.toFixed(1);
         if (ShowData >= 1 && ShowData < 100) {
-          this.JitterResultMon.el.textContent = Math.floor(ShowData);
+          this.JitterResultMon.el.textContent = ShowData.toFixed(1);
         }
         if (ShowData >= 100) {
           var kData = (ShowData / 1000).toFixed(1);
@@ -378,8 +378,8 @@ window.onload = function() {
         if (ShowData == 0) {
           ShowData = 0;
         }
-        this.jitterDesk.el.textContent = ShowData;
-        this.JitterResultMon.el.textContent = ShowData;
+        this.jitterDesk.el.textContent = ShowData.toFixed(1);
+        this.JitterResultMon.el.textContent = ShowData.toFixed(1);
       }
     }
   };
@@ -1085,7 +1085,7 @@ window.onload = function() {
         dtDiff = dTime;
         dtTotal += dtLoad;
         if (dTotal > 0) {
-          LiveSpeedArr = dTotal / dtTotal / 125 * upAdjust;
+          LiveSpeedArr = dTotal / dtTotal / 125 * dlAdjust;
           currentSpeed = LiveSpeedArr;
         }
       }

--- a/src/OpenSpeedTest/index.html
+++ b/src/OpenSpeedTest/index.html
@@ -81,9 +81,9 @@
         var ulDelay = 300;
         var dlDelay = 300;
 
-    // Overhead Compensation factor, This is a browser-dependent test, Many Unknowns. Currently, 4%. That is within the margin of error.
-        var upAdjust = 1.04;
-        var dlAdjust = 1.04;
+    // Overhead Compensation factor - 0.3% adjustment for HTTP overhead (original was 4%, likely a typo)
+        var upAdjust = 1.003;
+        var dlAdjust = 1.003;
 
    // You can pass "Clean" or "C" as a URL Parameter and reset the Overhead Compensation factor to Zero or set any value between 0 and 4. 1 = 1% to 4 = 4% 
    // "clean" will not accept values above 4, so Compensation is limited to a maximum of 4%.


### PR DESCRIPTION
## Summary
- Reduce overhead compensation from 4% to 0.3% (original value was likely a typo)
- Fix bug where download calculation used `upAdjust` instead of `dlAdjust`
- Display ping and jitter with 1 decimal place (was truncated to integer)

## Test plan
- [x] Tested on NAS - speeds now align with iperf3 results
- [x] Tested on Mac native deployment
- [x] Verified ping/jitter display shows decimal values