### PR TITLE
Fix AP passthrough port handling in port security audit

### DIFF
--- a/src/NetworkOptimizer.Audit/Analyzers/PortSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/PortSecurityAnalyzer.cs
@@ -424,6 +424,11 @@ public class PortSecurityAnalyzer
     {
         var baseType = FromUniFiApiType(deviceType);
 
+        // Access points (type=uap) are always APs, not switches
+        // This handles in-wall APs with integrated switch ports (4+ ports)
+        if (baseType == DeviceType.AccessPoint)
+            return (false, true);
+
         // Non-gateway types are switches (not gateway, not AP)
         if (!baseType.IsGateway())
             return (false, false);


### PR DESCRIPTION
## Summary

- Skip APs with 1-2 ports from port security audit (passthrough ports that can't be disabled)
- Fix AP devices with >2 ports (in-wall APs) to display as `[AP]` instead of `[Switch]` in the UI
- APs with passthrough ports are excluded from Port Security Coverage Summary statistics

## Details

**Passthrough port skipping:** Standard APs have 1-2 ports that are simple passthrough connections - they can't be disabled or configured for port security. Previously these were being flagged as "unprotected ports" which was misleading.

**AP display fix:** In-wall APs with integrated switches (4+ ports) were incorrectly displaying as `[Switch]` in the Port Audit section. The `DetermineDeviceRole` method now correctly identifies `type=uap` devices as access points.

## Test plan

- [x] Added 8 unit tests covering AP passthrough port skipping and AP display logic
- [x] All 3,303 tests pass
- [x] Build succeeds with 0 warnings
- [x] Verify in-wall APs show as `[AP]` in Port Audit UI
- [x] Verify standard APs don't appear in Port Audit device list