### PR TITLE
Add HomePod support to Apple streaming device allowance

### DIFF
--- a/src/NetworkOptimizer.Audit/Models/DeviceAllowanceSettings.cs
+++ b/src/NetworkOptimizer.Audit/Models/DeviceAllowanceSettings.cs
@@ -8,7 +8,7 @@ namespace NetworkOptimizer.Audit.Models;
 public class DeviceAllowanceSettings
 {
     /// <summary>
-    /// Allow Apple streaming devices (Apple TV) on main network.
+    /// Allow Apple streaming devices (Apple TV, HomePod) on main network.
     /// </summary>
     public bool AllowAppleStreamingOnMainNetwork { get; set; } = false;
 
@@ -41,6 +41,20 @@ public class DeviceAllowanceSettings
         if (AllowAllStreamingOnMainNetwork)
             return true;
 
+        if (AllowAppleStreamingOnMainNetwork &&
+            !string.IsNullOrEmpty(vendor) &&
+            vendor.Contains("Apple", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Check if a smart speaker should be allowed on main network based on vendor.
+    /// Apple HomePods are categorized as SmartSpeaker, so we check AllowAppleStreamingOnMainNetwork.
+    /// </summary>
+    public bool IsSmartSpeakerAllowed(string? vendor)
+    {
         if (AllowAppleStreamingOnMainNetwork &&
             !string.IsNullOrEmpty(vendor) &&
             vendor.Contains("Apple", StringComparison.OrdinalIgnoreCase))

--- a/src/NetworkOptimizer.Audit/Rules/VlanPlacementChecker.cs
+++ b/src/NetworkOptimizer.Audit/Rules/VlanPlacementChecker.cs
@@ -86,6 +86,7 @@ public static class VlanPlacementChecker
             {
                 ClientDeviceCategory.StreamingDevice => allowanceSettings.IsStreamingDeviceAllowed(vendorName),
                 ClientDeviceCategory.SmartTV => allowanceSettings.IsSmartTVAllowed(vendorName),
+                ClientDeviceCategory.SmartSpeaker => allowanceSettings.IsSmartSpeakerAllowed(vendorName),
                 _ => false
             };
 
@@ -260,6 +261,7 @@ public static class VlanPlacementChecker
         {
             ClientDeviceCategory.StreamingDevice => "streaming-devices",
             ClientDeviceCategory.SmartTV => "smart-tvs",
+            ClientDeviceCategory.SmartSpeaker => "streaming-devices", // Apple HomePod uses same setting
             ClientDeviceCategory.Printer => "printers",
             _ => null
         };

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1030,7 +1030,7 @@
                     <input type="checkbox" @bind="allowAppleStreamingOnMainNetwork" />
                     <span>Allow Apple streaming devices on main network</span>
                 </label>
-                <small class="form-help">Apple TV devices on main/corporate VLANs will show as Info instead of Warning</small>
+                <small class="form-help">Apple TV and HomePod devices on main/corporate VLANs will show as Info instead of Warning</small>
             </div>
 
             <div class="form-group">

--- a/tests/NetworkOptimizer.Audit.Tests/Models/DeviceAllowanceSettingsTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Models/DeviceAllowanceSettingsTests.cs
@@ -182,6 +182,64 @@ public class DeviceAllowanceSettingsTests
 
     #endregion
 
+    #region IsSmartSpeakerAllowed Tests
+
+    [Fact]
+    public void IsSmartSpeakerAllowed_AllowAppleStreaming_ReturnsTrue_ForAppleVendor()
+    {
+        // Apple HomePod is categorized as SmartSpeaker
+        // so the Apple streaming allowance should apply
+        var settings = new DeviceAllowanceSettings { AllowAppleStreamingOnMainNetwork = true };
+
+        settings.IsSmartSpeakerAllowed("Apple").Should().BeTrue();
+        settings.IsSmartSpeakerAllowed("Apple Inc").Should().BeTrue();
+        settings.IsSmartSpeakerAllowed("apple").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsSmartSpeakerAllowed_AllowAppleStreaming_ReturnsFalse_ForNonAppleVendor()
+    {
+        var settings = new DeviceAllowanceSettings { AllowAppleStreamingOnMainNetwork = true };
+
+        settings.IsSmartSpeakerAllowed("Amazon").Should().BeFalse();
+        settings.IsSmartSpeakerAllowed("Google").Should().BeFalse();
+        settings.IsSmartSpeakerAllowed("Sonos").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSmartSpeakerAllowed_AllowAppleStreaming_ReturnsFalse_ForNullVendor()
+    {
+        var settings = new DeviceAllowanceSettings { AllowAppleStreamingOnMainNetwork = true };
+
+        settings.IsSmartSpeakerAllowed(null).Should().BeFalse();
+        settings.IsSmartSpeakerAllowed("").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSmartSpeakerAllowed_NoAllowances_ReturnsFalse()
+    {
+        var settings = new DeviceAllowanceSettings();
+
+        settings.IsSmartSpeakerAllowed("Apple").Should().BeFalse();
+        settings.IsSmartSpeakerAllowed("Amazon").Should().BeFalse();
+        settings.IsSmartSpeakerAllowed("Google").Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("apple")]
+    [InlineData("Apple")]
+    [InlineData("APPLE")]
+    [InlineData("Apple Inc")]
+    [InlineData("Apple, Inc.")]
+    public void IsSmartSpeakerAllowed_AllowAppleStreaming_CaseInsensitive(string vendor)
+    {
+        var settings = new DeviceAllowanceSettings { AllowAppleStreamingOnMainNetwork = true };
+
+        settings.IsSmartSpeakerAllowed(vendor).Should().BeTrue();
+    }
+
+    #endregion
+
     #region Default Settings Tests
 
     [Fact]


### PR DESCRIPTION
## Summary
- Extends the "Allow Apple streaming devices on main network" setting to include Apple HomePods
- HomePods are detected as `SmartSpeaker` category, which was not previously covered by the setting
- Non-Apple smart speakers (Amazon Echo, Google Home) remain unaffected by this setting

## Changes
- Added `IsSmartSpeakerAllowed()` method to `DeviceAllowanceSettings`
- Updated `VlanPlacementChecker` to check SmartSpeaker allowance for Apple vendors
- Updated Settings page help text to mention HomePods

## Test plan
- [x] Build passes with 0 warnings
- [x] All 3,414 tests pass
- [x] New tests cover SmartSpeaker allowance logic
- [x] Deployed to NAS and Mac for verification