### PR TITLE
Add warnings when SQM boot scripts fail to execute

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -1161,6 +1161,7 @@
     // Deployment status
     private SqmDeploymentStatus? deploymentStatus;
     private List<string> deploymentSteps = new();
+    private List<string> deploymentWarnings = new();
     private List<TcInterfaceStats>? tcInterfaces;
 
     // WAN interfaces from controller
@@ -1879,6 +1880,7 @@
 
         isDeploying = true;
         deploymentSteps.Clear();
+        deploymentWarnings.Clear();
         statusMessage = null;
         StateHasChanged();
 
@@ -1927,6 +1929,10 @@
                 if (result.Success)
                 {
                     deploymentSteps.AddRange(result.Steps);
+                    if (result.HasWarnings)
+                    {
+                        deploymentWarnings.AddRange(result.Warnings);
+                    }
                     deploymentSteps.Add($"{wan1Config.Name} deployed successfully (speedtest in 5s)");
                 }
                 else
@@ -1947,6 +1953,10 @@
                 if (result.Success)
                 {
                     deploymentSteps.AddRange(result.Steps);
+                    if (result.HasWarnings)
+                    {
+                        deploymentWarnings.AddRange(result.Warnings);
+                    }
                     deploymentSteps.Add($"{wan2Config.Name} deployed successfully (speedtest in 50s)");
                 }
                 else
@@ -1970,12 +1980,25 @@
                 var w2Interface = (wan1Config.Enabled && wan2Config.Enabled) ? $"ifb{wan2Config.Interface}" : "";
                 var w2Name = (wan1Config.Enabled && wan2Config.Enabled) ? wan2Config.Name : "";
 
-                await DeploymentService.DeploySqmMonitorAsync(w1Interface, w1Name, w2Interface, w2Name);
+                var (monitorSuccess, monitorWarning) = await DeploymentService.DeploySqmMonitorAsync(w1Interface, w1Name, w2Interface, w2Name);
 
+                if (monitorWarning != null)
+                {
+                    deploymentWarnings.Add(monitorWarning);
+                    deploymentSteps.Add($"⚠️ Warning: {monitorWarning}");
+                }
                 deploymentSteps.Add("SQM Monitor deployed");
             }
 
-            statusMessage = "SQM deployment completed successfully!";
+            // Set final status - include warning note if any
+            if (deploymentWarnings.Count > 0)
+            {
+                statusMessage = $"SQM deployment completed with {deploymentWarnings.Count} warning(s). Check the deployment log for details.";
+            }
+            else
+            {
+                statusMessage = "SQM deployment completed successfully!";
+            }
             statusSuccess = true;
 
             // Invalidate cache and refresh status
@@ -1998,6 +2021,7 @@
     {
         isDeploying = true;
         deploymentSteps.Clear();
+        deploymentWarnings.Clear();
         statusMessage = null;
         StateHasChanged();
 
@@ -2006,14 +2030,23 @@
             deploymentSteps.Add("Deploying SQM Monitor...");
             await ScrollDeploymentLog();
 
-            var success = await DeploymentService.DeploySqmMonitorAsync(
+            var (success, warning) = await DeploymentService.DeploySqmMonitorAsync(
                 $"ifb{wan1Config.Interface}", wan1Config.Name,
                 $"ifb{wan2Config.Interface}", wan2Config.Name);
 
             if (success)
             {
-                deploymentSteps.Add("SQM Monitor deployed successfully");
-                statusMessage = "SQM Monitor deployed!";
+                if (warning != null)
+                {
+                    deploymentWarnings.Add(warning);
+                    deploymentSteps.Add($"⚠️ Warning: {warning}");
+                    statusMessage = "SQM Monitor deployed with warnings. Check the deployment log for details.";
+                }
+                else
+                {
+                    deploymentSteps.Add("SQM Monitor deployed successfully");
+                    statusMessage = "SQM Monitor deployed!";
+                }
                 statusSuccess = true;
                 InvalidateCache();
                 await RefreshStatus();
@@ -2041,6 +2074,7 @@
         isDeploying = true;
         statusMessage = null;
         deploymentSteps.Clear();
+        deploymentWarnings.Clear();
         deploymentSteps.Add("Removing SQM and SQM Monitor...");
         await ScrollDeploymentLog();
 

--- a/src/NetworkOptimizer.Web/Services/ISqmDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/ISqmDeploymentService.cs
@@ -45,8 +45,8 @@ public interface ISqmDeploymentService
     /// <param name="wan1Name">Friendly name for WAN1 (e.g., "Yelcot").</param>
     /// <param name="wan2Interface">Physical interface name for WAN2 (e.g., "ifbeth0").</param>
     /// <param name="wan2Name">Friendly name for WAN2 (e.g., "Starlink").</param>
-    /// <returns>True if deployment succeeded, false otherwise.</returns>
-    Task<bool> DeploySqmMonitorAsync(string wan1Interface, string wan1Name, string wan2Interface, string wan2Name);
+    /// <returns>A tuple with success status and optional warning message if the service didn't start correctly.</returns>
+    Task<(bool success, string? warning)> DeploySqmMonitorAsync(string wan1Interface, string wan1Name, string wan2Interface, string wan2Name);
 
     /// <summary>
     /// Remove SQM scripts from the gateway.


### PR DESCRIPTION
## Summary
- Show user-visible warnings when SQM boot scripts fail to execute during deployment
- Previously, deployment reported success even when scripts failed to run, leaving users unaware that a reboot was needed
- Scripts are still deployed (will activate on reboot), but user now sees clear guidance

## Changes
- Add `Warnings` list to `SqmDeploymentResult` for non-fatal issues
- Log detailed script output for debugging (truncated to 500 chars)
- Update `DeploySqmMonitorAsync` to return warning on failure
- UI shows ⚠️ warnings in deployment log and adjusts final status message

## Test plan
- [x] Deploy SQM normally - should show success without warnings
- [x] If boot script fails (e.g., network issues), warning should appear with guidance to check gateway logs
- [x] Run `dotnet test` - all tests pass