### PR TITLE
Fix port profile VLAN precedence over port's base value

### DIFF
--- a/src/NetworkOptimizer.Audit/Analyzers/PortSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/PortSecurityAnalyzer.cs
@@ -520,11 +520,11 @@ public class PortSecurityAnalyzer
                 forwardMode = profile.Forward;
             }
 
-            // Use profile's native network ID if port doesn't have one
-            if (string.IsNullOrEmpty(nativeNetworkId) && !string.IsNullOrEmpty(profile.NativeNetworkId))
+            // Use profile's native network ID if set (profile takes precedence over port's base value)
+            if (!string.IsNullOrEmpty(profile.NativeNetworkId))
             {
-                _logger.LogDebug("Port {Switch} port {Port}: resolving native_networkconf_id from profile '{ProfileName}': {ProfileNetworkId}",
-                    switchInfo.Name, portIdx, profile.Name, profile.NativeNetworkId);
+                _logger.LogDebug("Port {Switch} port {Port}: resolving native_networkconf_id from profile '{ProfileName}': {PortValue} -> {ProfileNetworkId}",
+                    switchInfo.Name, portIdx, profile.Name, nativeNetworkId ?? "(none)", profile.NativeNetworkId);
                 nativeNetworkId = profile.NativeNetworkId;
             }
 


### PR DESCRIPTION
## Summary

- Fixes false positives in `WiredSubnetMismatchRule` where AP ethernet ports (like U6 Enterprise IW) report Default LAN as `native_networkconf_id` even when a port profile assigns a different VLAN
- Port profile's VLAN now takes precedence over the port's base value, consistent with how forward mode and MAC restrictions already work

## Background

The `WiredSubnetMismatchRule` (added after v0.10.8) was flagging clients on AP ethernet ports with the wrong VLAN because the audit was using the port's base `native_networkconf_id` (Default LAN) instead of the VLAN from the applied port profile.

## Changes

**PortSecurityAnalyzer.cs**: Changed VLAN resolution logic so profile takes precedence when set:
```csharp
// Before: Profile only used if port has no VLAN
if (string.IsNullOrEmpty(nativeNetworkId) && !string.IsNullOrEmpty(profile.NativeNetworkId))

// After: Profile takes precedence when set
if (!string.IsNullOrEmpty(profile.NativeNetworkId))
```

**Tests added** (6 new tests):
- Profile VLAN takes precedence over port's base value
- Profile without VLAN uses port's base value
- Port without VLAN uses profile's VLAN
- Integration test with WiredSubnetMismatchRule
- Fallback when no profiles provided

## Test plan

- [x] All 3,857 tests pass
- [x] Build with 0 warnings
- [x] Deployed to NAS and Mac for testing
- [ ] Awaiting confirmation from user with U6 Enterprise IW