### PR TITLE
Fix clipboard copy button on HTTP/mobile

### DIFF
--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -96,6 +96,34 @@
             downloadLink.click();
         }
 
+        // Copy text to clipboard with fallback for non-HTTPS contexts
+        async function copyToClipboard(text) {
+            // Try modern API first (requires HTTPS)
+            if (navigator.clipboard && window.isSecureContext) {
+                try {
+                    await navigator.clipboard.writeText(text);
+                    return true;
+                } catch (err) {
+                    // Fall through to legacy method
+                }
+            }
+            // Fallback: create temporary textarea
+            const textarea = document.createElement('textarea');
+            textarea.value = text;
+            textarea.style.position = 'fixed';
+            textarea.style.left = '-9999px';
+            document.body.appendChild(textarea);
+            textarea.select();
+            try {
+                document.execCommand('copy');
+                return true;
+            } catch (err) {
+                return false;
+            } finally {
+                document.body.removeChild(textarea);
+            }
+        }
+
         // Initialize Tippy.js tooltips
         function initTooltips() {
             // Find all tooltip icons with content siblings

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
@@ -997,14 +997,17 @@
     {
         if (!string.IsNullOrEmpty(openSpeedTestUrl))
         {
-            await JS.InvokeVoidAsync("navigator.clipboard.writeText", openSpeedTestUrl);
-            urlCopied = true;
-            StateHasChanged();
+            var success = await JS.InvokeAsync<bool>("copyToClipboard", openSpeedTestUrl);
+            if (success)
+            {
+                urlCopied = true;
+                StateHasChanged();
 
-            // Reset after 2 seconds
-            await Task.Delay(2000);
-            urlCopied = false;
-            StateHasChanged();
+                // Reset after 2 seconds
+                await Task.Delay(2000);
+                urlCopied = false;
+                StateHasChanged();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `copyToClipboard` helper with fallback for non-HTTPS contexts
- Uses modern `navigator.clipboard` API when available, falls back to legacy `execCommand` with temporary textarea
- Fixes copy button silently failing on HTTP connections and mobile browsers

## Test plan
- [x] Tested on NAS (HTTP)
- [x] Tested on Mac