### PR TITLE
Fix clipboard copy button on HTTP and mobile

### DIFF
--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -96,6 +96,33 @@
             downloadLink.click();
         }
 
+        // Copy text from sibling input element with visual feedback
+        function copyFromInput(button) {
+            const input = button.previousElementSibling;
+            const text = input.value;
+
+            // Try modern API first (requires HTTPS)
+            if (navigator.clipboard && window.isSecureContext) {
+                navigator.clipboard.writeText(text);
+            } else {
+                // Fallback for HTTP contexts
+                input.select();
+                input.setSelectionRange(0, 99999);
+                document.execCommand('copy');
+            }
+            input.blur();
+
+            // Visual feedback
+            const icon = button.querySelector('.copy-icon');
+            const check = button.querySelector('.copy-check');
+            icon.style.display = 'none';
+            check.style.display = 'inline';
+            setTimeout(() => {
+                icon.style.display = 'inline';
+                check.style.display = 'none';
+            }, 2000);
+        }
+
         // Initialize Tippy.js tooltips
         function initTooltips() {
             // Find all tooltip icons with content siblings

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
@@ -60,7 +60,7 @@
                         </div>
                         <div class="url-copy-row">
                             <input type="text" class="url-display" value="@openSpeedTestUrl" readonly />
-                            <button type="button" class="btn-icon" title="Copy URL" onclick="var input = this.previousElementSibling; input.select(); input.setSelectionRange(0, 99999); document.execCommand('copy'); input.blur(); this.querySelector('.copy-icon').style.display='none'; this.querySelector('.copy-check').style.display='inline'; setTimeout(() => { this.querySelector('.copy-icon').style.display='inline'; this.querySelector('.copy-check').style.display='none'; }, 2000);">
+                            <button type="button" class="btn-icon" title="Copy URL" onclick="copyFromInput(this)">
                                 <span class="copy-icon">📋</span>
                                 <span class="copy-check" style="display:none;">✓</span>
                             </button>


### PR DESCRIPTION
## Summary
- Use readonly input field instead of code element for URL display
- Add `copyFromInput()` helper that uses modern Clipboard API on HTTPS, falls back to select/execCommand on HTTP
- Works reliably on mobile browsers

## Test plan
- [x] Tested on NAS (HTTPS)
- [x] Tested on Mac (HTTP)
- [x] Tested on mobile