### PR TITLE
Improve firewall rule analysis for management networks and app-based rules

### DIFF
--- a/src/NetworkOptimizer.Audit/Analyzers/HttpAppIds.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/HttpAppIds.cs
@@ -1,0 +1,52 @@
+namespace NetworkOptimizer.Audit.Analyzers;
+
+/// <summary>
+/// Static lookup for HTTP-related application IDs used in UniFi firewall rules.
+/// These IDs are hardcoded in UniFi firmware and map to DPI application signatures.
+/// </summary>
+public static class HttpAppIds
+{
+    // === Application IDs ===
+
+    /// <summary>
+    /// HTTP (port 80) - plain HTTP web traffic
+    /// </summary>
+    public const int Http = 852190;
+
+    /// <summary>
+    /// HTTPS / HTTP over TLS/SSL (port 443) - encrypted web traffic
+    /// </summary>
+    public const int Https = 1245278;
+
+    /// <summary>
+    /// HTTP/3 (QUIC/UDP port 443) - modern web traffic over QUIC
+    /// </summary>
+    public const int Http3 = 852723;
+
+    /// <summary>
+    /// All HTTP-related app IDs for quick membership testing
+    /// </summary>
+    public static readonly HashSet<int> AllHttpAppIds = new() { Http, Https, Http3 };
+
+    /// <summary>
+    /// Check if an app ID is any HTTP-related application
+    /// </summary>
+    public static bool IsHttpApp(int appId) => AllHttpAppIds.Contains(appId);
+
+    // === Application Category IDs ===
+
+    /// <summary>
+    /// Web Services category (includes HTTP, HTTPS, web apps, etc.)
+    /// </summary>
+    public const int WebServicesCategory = 13;
+
+    /// <summary>
+    /// All web-related category IDs
+    /// </summary>
+    public static readonly HashSet<int> AllWebCategoryIds = new() { WebServicesCategory };
+
+    /// <summary>
+    /// Check if an app category ID represents broad web access
+    /// </summary>
+    public static bool IsWebCategory(int categoryId) => AllWebCategoryIds.Contains(categoryId);
+}

--- a/src/NetworkOptimizer.Audit/Models/FirewallRule.cs
+++ b/src/NetworkOptimizer.Audit/Models/FirewallRule.cs
@@ -107,6 +107,12 @@ public class FirewallRule
     public List<int>? AppIds { get; init; }
 
     /// <summary>
+    /// Application category IDs for category-based matching (e.g., 13 = Web Services, 19 = Network Protocols).
+    /// Used when matching entire categories of applications.
+    /// </summary>
+    public List<int>? AppCategoryIds { get; init; }
+
+    /// <summary>
     /// Whether this is a predefined/system rule (not user-created)
     /// </summary>
     public bool Predefined { get; init; }


### PR DESCRIPTION
## Summary

Enhances firewall rule analysis with better support for management network audits and app-based (DPI) firewall rules.

### Management Network Checks
- Management network Info checks (FW-MGMT-001/002/004) now detect internet blocking via firewall rules, not just the network config toggle
- New **INTERNET_BLOCK_BYPASSED** audit detects allow rules that circumvent internet restrictions on internet-restricted networks
- 5G/LTE modem registration rules can match by IP, MAC, network, or ANY source
- NTP access validation uses UDP port 123 (NTP uses IPs, not DNS names)

### App-Based Firewall Rules
- Overlap detection now handles rules with `AppIds` and `AppCategoryIds`
- Scope scoring correctly identifies APP rules as medium-broad and APP_CATEGORY as broad
- Shadowed rule detection works for app-based allow rules preceded by broad deny rules

### Additional Fixes
- 5G/LTE device detection checks all devices, not just those with port tables

## Test plan

- [x] All 3,995 tests pass
- [x] Audit module coverage: 90.18%
- [x] Deployed and verified on NAS and Mac