### PR TITLE
Fix fingerprint database cache poisoning

### DIFF
--- a/src/NetworkOptimizer.Web/Services/AuditService.cs
+++ b/src/NetworkOptimizer.Web/Services/AuditService.cs
@@ -1188,6 +1188,20 @@ public class AuditService
             // Convert audit result to web models
             var webResult = ConvertAuditResult(auditResult, options);
 
+            // Add critical issue if fingerprint database failed to load
+            if (_fingerprintService.LastFetchFailed)
+            {
+                webResult.Issues.Insert(0, new AuditIssue
+                {
+                    Severity = AuditModels.AuditSeverity.Critical,
+                    Category = "System",
+                    Title = "Device fingerprint database unavailable",
+                    Description = "Device fingerprints could not be loaded from your Console. This may cause devices to be misclassified.",
+                    Recommendation = "Ensure your Console has HTTPS access to *.ui.com and *.ubnt.com. Check firewall rules and DNS resolution."
+                });
+                webResult.CriticalCount++;
+            }
+
             // Cache the result
             LastAuditResultCached = webResult;
             LastAuditTimeCached = DateTime.UtcNow;

--- a/src/NetworkOptimizer.Web/Services/FingerprintDatabaseService.cs
+++ b/src/NetworkOptimizer.Web/Services/FingerprintDatabaseService.cs
@@ -13,6 +13,7 @@ public class FingerprintDatabaseService : IFingerprintDatabaseService
 
     private UniFiFingerprintDatabase? _database;
     private DateTime? _lastFetchTime;
+    private bool _lastFetchFailed;
     private readonly SemaphoreSlim _fetchLock = new(1, 1);
     private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(24);
 
@@ -81,6 +82,7 @@ public class FingerprintDatabaseService : IFingerprintDatabaseService
         if (!_connectionService.IsConnected || _connectionService.Client == null)
         {
             _logger.LogWarning("Cannot fetch fingerprint database: not connected to UniFi controller");
+            _lastFetchFailed = true;
             return;
         }
 
@@ -89,19 +91,29 @@ public class FingerprintDatabaseService : IFingerprintDatabaseService
             _logger.LogInformation("Fetching fingerprint database from UniFi controller...");
 
             _database = await _connectionService.Client.GetCompleteFingerprintDatabaseAsync(cancellationToken);
-            _lastFetchTime = DateTime.UtcNow;
 
-            if (_database != null)
+            // Only cache if we got actual data - don't poison cache with empty results
+            // (empty results happen when Console can't reach UI.com)
+            if (_database != null && _database.DevTypeIds.Count > 0)
             {
+                _lastFetchTime = DateTime.UtcNow;
+                _lastFetchFailed = false;
                 _logger.LogInformation(
                     "Fingerprint database loaded: {DevTypes} device types, {Vendors} vendors, {Devices} specific devices",
                     _database.DevTypeIds.Count,
                     _database.VendorIds.Count,
                     _database.DevIds.Count);
             }
+            else
+            {
+                _lastFetchFailed = true;
+                _logger.LogWarning(
+                    "Fingerprint database fetch returned empty results - Console may not have HTTPS access to *.ui.com. Will retry on next request.");
+            }
         }
         catch (Exception ex)
         {
+            _lastFetchFailed = true;
             _logger.LogError(ex, "Failed to fetch fingerprint database");
         }
     }
@@ -160,12 +172,18 @@ public class FingerprintDatabaseService : IFingerprintDatabaseService
     }
 
     /// <summary>
-    /// Check if the database is loaded
+    /// Check if the database is loaded with data
     /// </summary>
-    public bool IsLoaded => _database != null;
+    public bool IsLoaded => _database != null && _database.DevTypeIds.Count > 0;
 
     /// <summary>
-    /// Get when the database was last fetched
+    /// Check if the last fetch attempt failed or returned empty results.
+    /// This indicates the Console may not have HTTPS access to *.ui.com.
+    /// </summary>
+    public bool LastFetchFailed => _lastFetchFailed;
+
+    /// <summary>
+    /// Get when the database was last successfully fetched
     /// </summary>
     public DateTime? LastFetchTime => _lastFetchTime;
 }

--- a/src/NetworkOptimizer.Web/Services/IFingerprintDatabaseService.cs
+++ b/src/NetworkOptimizer.Web/Services/IFingerprintDatabaseService.cs
@@ -9,12 +9,18 @@ namespace NetworkOptimizer.Web.Services;
 public interface IFingerprintDatabaseService
 {
     /// <summary>
-    /// Gets whether the database has been loaded.
+    /// Gets whether the database has been loaded with data.
     /// </summary>
     bool IsLoaded { get; }
 
     /// <summary>
-    /// Gets when the database was last fetched.
+    /// Gets whether the last fetch attempt failed or returned empty results.
+    /// This indicates the Console may not have HTTPS access to *.ui.com.
+    /// </summary>
+    bool LastFetchFailed { get; }
+
+    /// <summary>
+    /// Gets when the database was last successfully fetched.
     /// </summary>
     DateTime? LastFetchTime { get; }
 


### PR DESCRIPTION
## Summary

- Fix 24-hour cache poisoning when fingerprint database fetch fails or returns empty
- Add critical audit issue when fingerprint database is unavailable

## Problem

When the UniFi Console can't reach Ubiquiti's servers (e.g., due to firewall rules blocking `*.ui.com`), the fingerprint database API returns empty results. Previously, these empty results were cached for 24 hours, preventing retries even after connectivity was restored.

## Changes

- Only update cache timestamp when database contains actual data
- Add `LastFetchFailed` property to track fetch failures
- Display critical audit issue advising users to allow HTTPS access to `*.ui.com` and `*.ubnt.com`

## Test plan

- [x] Verify fingerprint database loads normally when Console has connectivity
- [x] Verify empty results don't poison cache (next request retries immediately)
- [x] Verify critical issue appears in audit when fingerprint fetch fails