### PR TITLE
Fix WAN DNS validation for Pi-hole/AdGuard users without gateway DoH

### DIFF
--- a/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
@@ -1238,7 +1238,9 @@ public class DnsSecurityAnalyzer
 
     private async Task ValidateWanDnsConfigurationAsync(DnsSecurityResult result)
     {
-        if (!result.DohConfigured || result.WanDnsServers.Count == 0)
+        // Skip validation only if BOTH DoH is off AND no third-party DNS is detected.
+        // Pi-hole/AdGuard users without gateway DoH still need WAN DNS validated against their local DNS IPs.
+        if ((!result.DohConfigured && !result.HasThirdPartyDns) || result.WanDnsServers.Count == 0)
             return;
 
         // When third-party DNS (Pi-hole, AdGuard Home) is detected, check if WAN DNS


### PR DESCRIPTION
## Summary

- Fixed WAN DNS showing "Mismatched" for Pi-hole/AdGuard Home users who don't have DoH enabled on the gateway

## What was happening

If you use Pi-hole or AdGuard Home for DNS but don't enable DNS-over-HTTPS on the UniFi gateway itself, the audit was incorrectly reporting your WAN DNS as "Mismatched" even when it correctly pointed to your Pi-hole servers.

The DNS Security section would show:
> WAN DNS Configuration: **Mismatched** - Incorrect: 172.16.0.16, 172.16.0.26 on WAN1, WAN2

...even though those IPs are your Pi-hole servers and the configuration is correct.

## The fix

The WAN DNS validation now properly checks against detected third-party DNS servers (Pi-hole, AdGuard Home) even when gateway DoH is disabled. If your WAN DNS points to your local DNS filtering solution, it's now correctly marked as "Matched."

## Test plan

- [x] Added tests for DoH-off + Pi-hole scenarios (match, no-match, partial-match, skip)
- [x] Verified all 28 existing WAN DNS tests still pass
- [x] Full test suite passes (4,803 tests)
- [x] Zero build warnings

Fixes #187