### PR TITLE
Fix fingerprint category mappings for smoke detectors and alarms

### DIFF
--- a/src/NetworkOptimizer.Audit/Services/Detectors/FingerprintDetector.cs
+++ b/src/NetworkOptimizer.Audit/Services/Detectors/FingerprintDetector.cs
@@ -64,7 +64,7 @@ public class FingerprintDetector
         { 116, ClientDeviceCategory.SecuritySystem }, // Surveillance System
         { 80, ClientDeviceCategory.SecuritySystem },  // Smart Home Security System
         { 173, ClientDeviceCategory.SecuritySystem }, // Home Security System
-        { 199, ClientDeviceCategory.SecuritySystem }, // Smart Smoke Detector
+        { 199, ClientDeviceCategory.SmartSensor },    // Smart Smoke Detector
         { 248, ClientDeviceCategory.SecuritySystem }, // Smart Access Control
         { 278, ClientDeviceCategory.SecuritySystem }, // Biometric Reader
 
@@ -351,7 +351,7 @@ public class FingerprintDetector
         { 49, ClientDeviceCategory.IoTGeneric },      // Network & Peripheral
         { 51, ClientDeviceCategory.IoTGeneric },      // Smart Device
         { 58, ClientDeviceCategory.IoTGeneric },      // Cloud Device
-        { 60, ClientDeviceCategory.IoTGeneric },      // Alarm System
+        { 60, ClientDeviceCategory.SecuritySystem },   // Alarm System
         { 64, ClientDeviceCategory.IoTGeneric },      // Smart Garden Device
         { 66, ClientDeviceCategory.IoTGeneric },      // IoT Device
         { 67, ClientDeviceCategory.IoTGeneric },      // Smart Cars

--- a/tests/NetworkOptimizer.Audit.Tests/Services/FingerprintDetectorTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Services/FingerprintDetectorTests.cs
@@ -417,7 +417,6 @@ public class FingerprintDetectorTests
     [InlineData(51)]  // Smart Device
     [InlineData(66)]  // IoT Device
     [InlineData(64)]  // Smart Garden Device
-    [InlineData(60)]  // Alarm System
     [InlineData(120)] // Garage Opener
     [InlineData(83)]  // Garage Door
     [InlineData(77)]  // Sprinkler Controller
@@ -1408,7 +1407,7 @@ public class FingerprintDetectorTests
     [InlineData("51", ClientDeviceCategory.IoTGeneric)]       // Smart Device
     [InlineData("66", ClientDeviceCategory.IoTGeneric)]       // IoT Device
     [InlineData("64", ClientDeviceCategory.IoTGeneric)]       // Smart Garden Device
-    [InlineData("60", ClientDeviceCategory.IoTGeneric)]       // Alarm System
+    [InlineData("60", ClientDeviceCategory.SecuritySystem)]    // Alarm System
     [InlineData("80", ClientDeviceCategory.SecuritySystem)]   // Smart Home Security System
     public void Detect_DevTypeId_GenericIoTTypes_MapsCorrectly(string devTypeId, ClientDeviceCategory expected)
     {


### PR DESCRIPTION
## Summary

- **Smart Smoke Detector** (dev_cat 199): Changed from SecuritySystem to SmartSensor - smoke detectors are sensors, not security panels/NVRs
- **Alarm System** (dev_cat 60): Changed from IoTGeneric to SecuritySystem - alarms should be treated consistently with other security systems

## Why

Smart smoke detectors (Nest Protect, etc.) are more like air quality monitors or motion sensors than security panels. They should be categorized as SmartSensor so they get IoT VLAN recommendations.

Alarm systems were inconsistently mapped to IoTGeneric while similar devices (Smart Home Security System, Home Security System) were SecuritySystem. This fixes that inconsistency.

## Test plan

- [x] All 4,834 existing tests pass
- [x] Test expectations updated to match new mappings