### PR TITLE
Limit SSH test to 4 devices, alternating types

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1728,20 +1728,24 @@
             var devices = await ConnectionService.GetDiscoveredDevicesAsync();
 
             // Find online non-gateway devices (AP, switch, or modem)
-            // Prioritize APs first since they're the primary target for SSH features (speed tests)
+            // Interleave types (AP, modem, switch, AP, ...) so we try variety before giving up
             var testableTypes = new[]
             {
                 NetworkOptimizer.Core.Enums.DeviceType.AccessPoint,
-                NetworkOptimizer.Core.Enums.DeviceType.Switch,
-                NetworkOptimizer.Core.Enums.DeviceType.CellularModem
+                NetworkOptimizer.Core.Enums.DeviceType.CellularModem,
+                NetworkOptimizer.Core.Enums.DeviceType.Switch
             };
 
             var testableDevices = devices
                 .Where(d => testableTypes.Contains(d.Type)
                             && d.State == 1 && !string.IsNullOrEmpty(d.IpAddress))
-                .OrderBy(d => d.Type == NetworkOptimizer.Core.Enums.DeviceType.AccessPoint ? 0 :
-                              d.Type == NetworkOptimizer.Core.Enums.DeviceType.CellularModem ? 1 : 2)
-                .ThenBy(d => d.Name)
+                .GroupBy(d => d.Type)
+                .SelectMany(g => g.OrderBy(d => d.Name).Select((d, i) => new { Device = d, Index = i }))
+                .OrderBy(x => x.Index) // Round-robin: all first-of-type, then all second-of-type, etc.
+                .ThenBy(x => x.Device.Type == NetworkOptimizer.Core.Enums.DeviceType.AccessPoint ? 0 :
+                             x.Device.Type == NetworkOptimizer.Core.Enums.DeviceType.CellularModem ? 1 : 2)
+                .Take(4)
+                .Select(x => x.Device)
                 .ToList();
 
             if (!testableDevices.Any())


### PR DESCRIPTION
## Summary

- Caps SSH connection test at 4 device attempts
- Interleaves device types: AP1 → Modem1 → Switch1 → AP2 (round-robin)
- Keeps test reasonably quick while still trying variety

Follow-up to #207.

## Test plan

- [x] With multiple APs and switches, verify it alternates types rather than trying all APs first