### PR TITLE
Fix Wi-Fi Optimizer channel density bar proportionality

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/SpectrumAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/SpectrumAnalysis.razor
@@ -1223,7 +1223,14 @@
 
     private int GetBarWidth(double interferenceScore)
     {
-        // Calculate max interference score across all channels
+        if (interferenceScore <= 0) return 0;
+
+        // Use absolute scale so bars reflect real congestion level.
+        // Reference max of 6 = "very congested" (e.g. 6 strong neighbors).
+        // A single network scores ~0.1-1.0, so the bar stays proportionate.
+        // If actual congestion exceeds the reference, scale up to stay readable.
+        var referenceMax = 6.0;
+
         var channelScores = filteredNeighbors
             .GroupBy(n => n.Network.Channel)
             .Select(g =>
@@ -1235,10 +1242,11 @@
             })
             .ToList();
 
-        if (!channelScores.Any()) return 0;
-        var maxScore = channelScores.Max();
-        if (maxScore == 0) return 0;
-        return Math.Min(100, (int)(interferenceScore * 100.0 / maxScore));
+        var actualMax = channelScores.Any() ? channelScores.Max() : 0;
+        var effectiveMax = Math.Max(referenceMax, actualMax);
+
+        // Minimum 8% so even a single weak neighbor is visible
+        return Math.Max(8, Math.Min(100, (int)(interferenceScore * 100.0 / effectiveMax)));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- **Channel density bars now use an absolute scale** - Previously, the RF Environment heatmap bars were sized relative to the most congested channel, so a single neighbor network on a band always showed a full-width bar regardless of signal strength. Now bars reflect actual congestion level: a single weak neighbor shows a small bar, and the bar grows proportionally as more (or stronger) networks appear.
- **Minimum bar width for visibility** - Even a single weak neighbor at -90 dBm still renders a small visible bar (8%) so the channel isn't mistaken for empty.

## Test plan

- [x] Open Wi-Fi Optimizer on a band with few neighbor networks and verify bars are proportionate (not full-width for a single network)
- [x] Check a congested band (many neighbors) and verify bars still fill appropriately
- [x] Verify bar colors (green/yellow/red) still correspond to density thresholds