### PR TITLE
Exclude UX/UX7 in AP mode from port audit issues

### DIFF
--- a/src/NetworkOptimizer.Audit/Analyzers/PortSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/PortSecurityAnalyzer.cs
@@ -662,6 +662,15 @@ public class PortSecurityAnalyzer
 
         foreach (var switchInfo in switches)
         {
+            // Skip port-level audit issues for devices whose ports aren't manageable
+            // in UniFi Port Manager (e.g., UX/UX7 in AP mode)
+            if (switchInfo.HasUnmanageablePorts)
+            {
+                _logger.LogDebug("Skipping audit for {SwitchName} ({ModelName}) - ports not manageable in AP mode",
+                    switchInfo.Name, switchInfo.ModelName);
+                continue;
+            }
+
             _logger.LogDebug("Analyzing {PortCount} ports on {SwitchName}",
                 switchInfo.Ports.Count, switchInfo.Name);
 

--- a/src/NetworkOptimizer.Audit/Models/SwitchInfo.cs
+++ b/src/NetworkOptimizer.Audit/Models/SwitchInfo.cs
@@ -62,6 +62,14 @@ public class SwitchInfo
     public bool IsAccessPoint { get; init; }
 
     /// <summary>
+    /// Whether this device's ports are unmanageable in UniFi Port Manager.
+    /// UX and UX7 devices in AP mode don't expose their switch ports for configuration,
+    /// so port-level audit issues are not actionable.
+    /// </summary>
+    public bool HasUnmanageablePorts =>
+        IsAccessPoint && ModelName is "UX" or "UX7";
+
+    /// <summary>
     /// Switch capabilities
     /// </summary>
     public SwitchCapabilities Capabilities { get; init; } = new();


### PR DESCRIPTION
Closes #232

## Summary

- UX and UX7 devices acting as mesh APs don't expose their switch ports in UniFi Port Manager, making port-level audit recommendations (MAC restriction, unused port, excessive tagged VLANs, port isolation, VLAN placement, etc.) impossible to act on
- Adds a `HasUnmanageablePorts` property on `SwitchInfo` that checks for UX/UX7 models in AP mode
- Skips all port rule evaluation for these devices in the central `AnalyzePorts` loop - one check covers all 7 port rules (DRY)
- Devices still appear in the ports table and switch list, just without non-actionable issues

## Test plan

- [x] Build passes with 0 warnings
- [x] All 4,634 tests pass
- [x] New test: UX7 in AP mode produces zero audit issues
- [x] New test: UX7 as gateway still gets audited normally
- [x] Deploy and have user with UX7 APs run a security audit to confirm issues no longer appear