### PR TITLE
Stop recommending 'Auto' TX power in Wi-Fi Optimizer

### DIFF
--- a/src/NetworkOptimizer.WiFi/Rules/HighPowerRule.cs
+++ b/src/NetworkOptimizer.WiFi/Rules/HighPowerRule.cs
@@ -41,7 +41,9 @@ public class HighPowerRule : IWiFiOptimizerRule
                 : $"{highPowerAps.Count} access points have all radios set to high TX power. This can cause excessive coverage overlap and co-channel interference.",
             AffectedEntity = string.Join(", ", highPowerAps.Select(ap => ap.Name)),
             Recommendation = "In UniFi Network: Settings > WiFi > (SSID) > Advanced > TX Power - " +
-                "consider 'Medium' or 'Auto' for balanced coverage.",
+                (WiFiAnalysisHelpers.SupportsAutoPowerLeveling
+                    ? "consider 'Medium' or 'Auto' for balanced coverage."
+                    : "consider 'Medium' for balanced coverage."),
             ScoreImpact = -5 * highPowerAps.Count
         };
     }

--- a/src/NetworkOptimizer.WiFi/Rules/TxPowerVariationRule.cs
+++ b/src/NetworkOptimizer.WiFi/Rules/TxPowerVariationRule.cs
@@ -31,10 +31,12 @@ public class TxPowerVariationRule : IWiFiOptimizerRule
             Severity = HealthIssueSeverity.Info,
             Dimensions = { HealthDimension.ChannelHealth, HealthDimension.RoamingPerformance },
             Title = "Consider Varied TX Power Levels",
-            Description = "All APs are set to high power. In multi-AP deployments, using 'Auto' or varied " +
-                "power levels often improves roaming behavior and reduces co-channel interference.",
-            Recommendation = "In UniFi Network: Settings > WiFi > (SSID) > Advanced > TX Power - " +
-                "try 'Auto' to let the controller optimize power levels.",
+            Description = WiFiAnalysisHelpers.SupportsAutoPowerLeveling
+                ? "All APs are set to high power. In multi-AP deployments, using 'Auto' or varied power levels often improves roaming behavior and reduces co-channel interference."
+                : "All APs are set to high power. In multi-AP deployments, varying power levels (e.g. 'Medium' on some APs) often improves roaming behavior and reduces co-channel interference.",
+            Recommendation = WiFiAnalysisHelpers.SupportsAutoPowerLeveling
+                ? "In UniFi Network: Settings > WiFi > (SSID) > Advanced > TX Power - try 'Auto' to let the controller optimize power levels."
+                : "In UniFi Network: Settings > WiFi > (SSID) > Advanced > TX Power - try 'Medium' on some APs for better coverage balance.",
             ScoreImpact = -3,
             ShowOnOverview = false  // Informational, only relevant to Channel/Roaming tabs
         };

--- a/src/NetworkOptimizer.WiFi/WiFiAnalysisHelpers.cs
+++ b/src/NetworkOptimizer.WiFi/WiFiAnalysisHelpers.cs
@@ -9,6 +9,13 @@ namespace NetworkOptimizer.WiFi;
 public static class WiFiAnalysisHelpers
 {
     /// <summary>
+    /// Whether UniFi's "Auto" TX power mode does real auto-power-leveling.
+    /// Currently false because Auto is effectively just "High" in UniFi Network.
+    /// Set to true once UniFi implements actual automatic power adjustment.
+    /// </summary>
+    public static bool SupportsAutoPowerLeveling => false;
+
+    /// <summary>
     /// Sort access points by IP address (ascending, proper numeric sorting).
     /// APs without valid IPs are placed at the end.
     /// </summary>


### PR DESCRIPTION
## Summary

- UniFi's "Auto" TX power mode is effectively just "High", so recommending it when we're telling users to turn power down is contradictory
- Wi-Fi Optimizer now recommends "Medium" instead of "Auto" in both the high-power and power-variation rules
- Added a `SupportsAutoPowerLeveling` boolean so we can easily flip the verbiage back when UniFi adds real auto-power-leveling

## Test plan

- [x] Verify build passes with zero warnings
- [x] Verify all tests pass
- [x] Deploy and run Wi-Fi Optimizer on a network with all APs on high power - confirm recommendations say "Medium" not "Auto"