### PR TITLE
Add Server network purpose classification

### DIFF
--- a/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleAnalyzer.cs
@@ -449,9 +449,10 @@ public class FirewallRuleAnalyzer
         // Do NOT filter by isolation - these are DESTINATIONS, and isolation only blocks outbound
         var corporateNetworks = networks.Where(n => n.Purpose == NetworkPurpose.Corporate).ToList();
         var homeNetworks = networks.Where(n => n.Purpose == NetworkPurpose.Home).ToList();
-        var trustedNetworks = corporateNetworks.Concat(homeNetworks).ToList();
+        var serverNetworks = networks.Where(n => n.Purpose == NetworkPurpose.Server).ToList();
+        var trustedNetworks = corporateNetworks.Concat(homeNetworks).Concat(serverNetworks).ToList();
 
-        // IoT should be isolated from: Corporate, Home
+        // IoT should be isolated from: Corporate, Home, Server
         // (IoT → Security and IoT → Management already covered above)
         var iotNetworks = networks.Where(n => n.Purpose == NetworkPurpose.IoT && !n.NetworkIsolationEnabled).ToList();
         foreach (var iot in iotNetworks)
@@ -675,6 +676,7 @@ public class FirewallRuleAnalyzer
                 NetworkPurpose.Guest => " (Guest)",
                 NetworkPurpose.Corporate => " (Corporate)",
                 NetworkPurpose.Home => " (Home)",
+                NetworkPurpose.Server => " (Server)",
                 _ => ""
             };
         }
@@ -917,20 +919,20 @@ public class FirewallRuleAnalyzer
     /// </summary>
     private static bool IsCriticalIsolationMissing(NetworkPurpose purpose1, NetworkPurpose purpose2)
     {
-        // Guest to Corporate, Management, or Security = Critical
+        // Guest to Corporate, Management, Security, or Server = Critical
         if (purpose1 == NetworkPurpose.Guest || purpose2 == NetworkPurpose.Guest)
         {
             var other = purpose1 == NetworkPurpose.Guest ? purpose2 : purpose1;
-            if (other is NetworkPurpose.Corporate or NetworkPurpose.Management or NetworkPurpose.Security)
+            if (other is NetworkPurpose.Corporate or NetworkPurpose.Management or NetworkPurpose.Security or NetworkPurpose.Server)
                 return true;
         }
 
         // Anything to Management = Critical (Management should only be accessed by specific admin devices)
-        // This includes: IoT, Corporate, Home, Security
+        // This includes: IoT, Corporate, Home, Security, Server
         if (purpose1 == NetworkPurpose.Management || purpose2 == NetworkPurpose.Management)
         {
             var other = purpose1 == NetworkPurpose.Management ? purpose2 : purpose1;
-            if (other is NetworkPurpose.IoT or NetworkPurpose.Corporate or NetworkPurpose.Home or NetworkPurpose.Security)
+            if (other is NetworkPurpose.IoT or NetworkPurpose.Corporate or NetworkPurpose.Home or NetworkPurpose.Security or NetworkPurpose.Server)
                 return true;
         }
 
@@ -2060,6 +2062,7 @@ public class FirewallRuleAnalyzer
                 NetworkPurpose.Home => "Home",
                 NetworkPurpose.Corporate => "Corporate",
                 NetworkPurpose.Guest => "Guest",
+                NetworkPurpose.Server => "Server",
                 _ => p.ToString()
             })
             .ToList();
@@ -2128,6 +2131,7 @@ public class FirewallRuleAnalyzer
                 NetworkPurpose.Guest => " (Guest)",
                 NetworkPurpose.Corporate => " (Corporate)",
                 NetworkPurpose.Home => " (Home)",
+                NetworkPurpose.Server => " (Server)",
                 _ => ""
             };
         }

--- a/src/NetworkOptimizer.Audit/Analyzers/VlanAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/VlanAnalyzer.cs
@@ -35,6 +35,9 @@ public class VlanAnalyzer
     private static readonly string[] PrinterPatterns = { "print" };
     // DMZ patterns - fallback name-based detection (zone-based is primary)
     private static readonly string[] DmzPatterns = { "dmz" };
+    private static readonly string[] ServerPatterns = { "server", "datacenter", "data center", "hypervisor", "hosting" };
+    // Server patterns requiring word boundary matching (to avoid "domain controller" matching "domain" in other contexts)
+    private static readonly string[] ServerWordBoundaryPatterns = { "compute", "data", "domain", "vm", "lab", "services", "controllers", "rack", "cluster", "backend", "virtual" };
 
     public VlanAnalyzer(ILogger<VlanAnalyzer> logger)
     {
@@ -310,6 +313,11 @@ public class VlanAnalyzer
             nameBasedPurpose = NetworkPurpose.IoT;
         else if (ManagementPatterns.Any(p => networkName.Contains(p, StringComparison.OrdinalIgnoreCase)))
             nameBasedPurpose = NetworkPurpose.Management;
+        else if (ServerPatterns.Any(p => networkName.Contains(p, StringComparison.OrdinalIgnoreCase)))
+            nameBasedPurpose = NetworkPurpose.Server;
+        // Word-boundary patterns for Server (e.g., "VM VLAN" but not "ViewModel")
+        else if (ServerWordBoundaryPatterns.Any(p => ContainsWord(networkName, p)))
+            nameBasedPurpose = NetworkPurpose.Server;
         else if (GuestPatterns.Any(p => networkName.Contains(p, StringComparison.OrdinalIgnoreCase)))
             nameBasedPurpose = NetworkPurpose.Guest;
         else if (CorporatePatterns.Any(p => networkName.Contains(p, StringComparison.OrdinalIgnoreCase)))

--- a/src/NetworkOptimizer.Audit/Models/NetworkInfo.cs
+++ b/src/NetworkOptimizer.Audit/Models/NetworkInfo.cs
@@ -47,6 +47,11 @@ public enum NetworkPurpose
     Dmz,
 
     /// <summary>
+    /// Server/compute network for hypervisors, containers, and datacenter workloads
+    /// </summary>
+    Server,
+
+    /// <summary>
     /// Unknown or unclassified network
     /// </summary>
     Unknown
@@ -70,6 +75,7 @@ public static class NetworkPurposeExtensions
         NetworkPurpose.Management => "Management",
         NetworkPurpose.Printer => "Printer",
         NetworkPurpose.Dmz => "DMZ",
+        NetworkPurpose.Server => "Server",
         NetworkPurpose.Unknown => "Unclassified",
         _ => purpose.ToString()
     };

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/VlanAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/VlanAnalyzerTests.cs
@@ -521,6 +521,47 @@ public class VlanAnalyzerTests
         result.Should().Be(NetworkPurpose.Unknown);
     }
 
+    [Theory]
+    [InlineData("Server VLAN", NetworkPurpose.Server)]
+    [InlineData("Servers", NetworkPurpose.Server)]
+    [InlineData("Data Center", NetworkPurpose.Server)]
+    [InlineData("Datacenter", NetworkPurpose.Server)]
+    [InlineData("Hypervisor Network", NetworkPurpose.Server)]
+    [InlineData("Hosting", NetworkPurpose.Server)]
+    public void ClassifyNetwork_ServerPatterns_ReturnsServer(string networkName, NetworkPurpose expected)
+    {
+        var result = _analyzer.ClassifyNetwork(networkName);
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Compute VLAN")]
+    [InlineData("Data VLAN")]
+    [InlineData("Domain Controllers")]
+    [InlineData("VM Network")]
+    [InlineData("Lab")]
+    [InlineData("Lab Network")]
+    [InlineData("Services VLAN")]
+    [InlineData("Rack 1")]
+    [InlineData("Cluster")]
+    [InlineData("Backend")]
+    [InlineData("Virtual Machines")]
+    public void ClassifyNetwork_ServerWordBoundaryPatterns_ReturnsServer(string networkName)
+    {
+        var result = _analyzer.ClassifyNetwork(networkName);
+        result.Should().Be(NetworkPurpose.Server);
+    }
+
+    [Theory]
+    [InlineData("ViewModel App")]      // "vm" embedded in "ViewModel"
+    [InlineData("Collaborative")]      // "lab" embedded in "Collaborative"
+    [InlineData("DataService")]        // "data" embedded without boundary
+    public void ClassifyNetwork_ServerWordBoundary_EmbeddedPatterns_DoNotMatch(string networkName)
+    {
+        var result = _analyzer.ClassifyNetwork(networkName);
+        result.Should().NotBe(NetworkPurpose.Server);
+    }
+
     [Fact]
     public void ClassifyNetwork_ExplicitGuestPurpose_ReturnsGuest()
     {


### PR DESCRIPTION
## Summary

- Networks named with server/datacenter/compute keywords now classify as **Server** instead of Unclassified
- Server networks are treated as trusted destinations (like Corporate/Home) in firewall isolation rules - IoT and Guest traffic is flagged when not blocked from reaching them
- Guest to Server isolation is marked Critical; IoT to Server is Recommended

## Details

**Classification keywords:**
- Substring: server, datacenter, data center, hypervisor, hosting
- Word boundary: compute, data, domain, vm, lab, services, controllers, rack, cluster, backend, virtual

**Firewall rules:** Server is added to the trusted networks list, so existing IoT/Guest isolation checks now cover Server as a destination. Server to Management is flagged as Critical.

## Test plan

- [x] 20 new VlanAnalyzer classification tests (substring, word boundary, false positive checks)
- [x] 8 new FirewallRuleAnalyzer isolation tests (IoT/Guest/Corporate/Home to Server, Server to Management/Security, block rule satisfaction, allow-rule bypass)
- [x] `dotnet build` - 0 warnings
- [x] `dotnet test` - all 5,080 tests pass