### PR TITLE
Recognize RFC1918 CIDR block rules as VLAN isolation

### DIFF
--- a/src/NetworkOptimizer.Audit/Analyzers/VlanAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/VlanAnalyzer.cs
@@ -864,6 +864,19 @@ public class VlanAnalyzer
                 return true;
         }
 
+        // IP destination with CIDRs that cover all other networks' subnets
+        // This handles RFC1918-to-RFC1918 block rules (e.g., 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
+        if (destTarget == "IP" && rule.DestinationIps?.Count > 0)
+        {
+            var otherNetworks = allNetworks.Where(n => n.Id != network.Id).ToList();
+            if (otherNetworks.Count > 0 && otherNetworks.All(n =>
+                !string.IsNullOrEmpty(n.Subnet) &&
+                NetworkUtilities.AnyCidrCoversSubnet(rule.DestinationIps, n.Subnet)))
+            {
+                return true;
+            }
+        }
+
         return false;
     }
 


### PR DESCRIPTION
Fixes #251

## Summary

- Users with a single RFC1918-to-RFC1918 block rule (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) were getting false positive isolation warnings for every VLAN
- `VlanAnalyzer.RuleBlocksToOtherNetworks()` only recognized "ANY" and "NETWORK" destination targets, missing "IP" with CIDR ranges
- Added CIDR-based destination matching so IP block rules that cover all other networks' subnets count as isolation

## Test plan

- [x] Added test: `VlanAnalyzerTests.AnalyzeNetworkIsolation_Rfc1918BlockRule_NoIssue` (was failing, now passes)
- [x] Added test: `FirewallRuleAnalyzerTests.CheckInterVlanIsolation_Rfc1918BlockRule_NoIssue` (confirms the other code path already handled this)
- [x] All 3053 existing tests pass
- [x] Zero build warnings