### PR TITLE
Improve floor plan editor UX: button styling, hint, and double-click fix

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/FloorPlanEditor.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/FloorPlanEditor.razor
@@ -27,11 +27,11 @@
             </select>
             @if (_selectedBuilding != null)
             {
-                <button class="fp-btn fp-btn-sm" @onclick="DeselectBuilding">Done Editing</button>
+                <button class="fp-btn" @onclick="DeselectBuilding">Done Editing</button>
             }
             else
             {
-                <button class="fp-btn fp-btn-sm" @onclick="ShowAddBuildingDialog" data-tooltip="Add new building" data-tooltip-hover-only>+ Building</button>
+                <button class="fp-btn" @onclick="ShowAddBuildingDialog" data-tooltip="Add new building" data-tooltip-hover-only>+ Building</button>
             }
 
             @if (_selectedBuilding != null)
@@ -69,7 +69,7 @@
             {
                 @* ── Walls group ── *@
                 <div class="fp-toolbar-group">
-                    <button class="fp-btn @(_mode == "walls" ? "fp-btn-warning" : "")" @onclick="ToggleWallDrawMode">
+                    <button class="fp-btn @(_mode == "walls" ? "fp-btn-warning" : "fp-btn-primary")" @onclick="ToggleWallDrawMode">
                         @(_mode == "walls" ? "Done Drawing" : "Draw Layout")
                     </button>
                     @if (_mode == "walls")
@@ -195,6 +195,11 @@
                     Drag APs to adjust their locations
                 </div>
             }
+        }
+
+        @if (_selectedBuilding != null && _mode != "walls" && _mode != "aps")
+        {
+            <div class="fp-edit-hint fp-wall-hint"><!--!--><span>Click Draw Layout to draw walls, windows, doors, etc.</span></div>
         }
 
         @if (_mode == "walls")
@@ -463,7 +468,8 @@
     .fp-btn:hover { background: var(--btn-hover-bg, #3d3d5c); }
     .fp-btn.active { background: var(--accent-color, #4f46e5); border-color: var(--accent-color, #4f46e5); }
     .fp-btn-sm { padding: 2px 8px; }
-    .fp-btn-primary { background: var(--accent-color, #4f46e5); border-color: var(--accent-color, #4f46e5); }
+    .fp-btn-primary { background: var(--primary-color, #0559C9); border-color: var(--primary-color, #0559C9); }
+    .fp-btn-primary:hover { background: var(--primary-hover, #3385d6); border-color: var(--primary-hover, #3385d6); }
     .fp-btn-warning { background: rgba(234, 179, 8, 0.85); border-color: rgba(234, 179, 8, 0.85); color: #1e293b; font-weight: 600; }
     .fp-btn-warning:hover { background: rgba(234, 179, 8, 1); }
     .fp-btn-danger { background: #dc2626; border-color: #dc2626; }
@@ -1815,6 +1821,7 @@
     {
         if (_selectedFloor == null) return;
         _isDrawingShape = false;
+        StateHasChanged();
         _selectedFloor.WallsJson = wallsJson;
         await FloorPlanSvc.UpdateFloorAsync(_selectedFloor.Id, wallsJson: wallsJson);
 


### PR DESCRIPTION
## Summary

- **Larger toolbar buttons** - Removed the small style from Done Editing and + Building buttons so they match the rest of the toolbar
- **Draw Layout button** - Now uses primary color (blue) to make it stand out as the main action when a building is selected
- **Building hint** - When a building is selected, shows a hint banner prompting the user to click Draw Layout to draw walls, windows, doors, etc.
- **Primary button color** - Updated `fp-btn-primary` to use the app's primary blue (`--primary-color`) instead of the accent indigo, with proper hover state
- **Double-click to finish shape** - Fixed async timing issue where the dblclick handler tried to pop the duplicate point before it arrived from C# interop. Now waits for the point, removes it, then commits the shape.
- **Hint bar re-render** - Added explicit `StateHasChanged()` after shape commit so the hint bar immediately resets to "Click to place points"

## Test plan

- [x] Select a building - verify Done Editing and + Building buttons are normal size (not small)
- [x] With a building and floor selected, verify Draw Layout button is blue
- [x] Click Draw Layout - verify it switches to yellow "Done Drawing"
- [x] With a building selected but not drawing, verify hint banner appears
- [x] Enter walls mode or AP mode - verify hint banner hides
- [x] Place 2+ points, then double-click - verify shape finishes with correct points (no duplicate)
- [x] After double-click finish, verify hint bar resets to "Click to place points"
- [x] Check Add Building and Add Floor dialogs - Create buttons should be blue