### PR TITLE
Fix WAN speed test history not filtering errors by connection

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -756,12 +756,18 @@
         var timeFiltered = GetTimeFilteredResults();
 
         // Apply WAN badge filter (none selected or no series = show all)
-        // Failed results always pass through - they may lack WAN metadata
         var visibleWanKeys = _wanSeries.Where(w => IsWanVisible(w)).Select(w => w.Key).ToHashSet();
         _filteredHistory = visibleWanKeys.Count == 0
             ? timeFiltered.ToList()
             : timeFiltered
-                .Where(r => !r.Success || visibleWanKeys.Contains(GetWanKey(r)))
+                .Where(r =>
+                {
+                    // Failed results without WAN metadata: only show when no filter is active
+                    if (!r.Success && string.IsNullOrEmpty(r.WanNetworkGroup))
+                        return false;
+                    // Everything else (successful or failed with WAN metadata): filter by connection
+                    return visibleWanKeys.Contains(GetWanKey(r));
+                })
                 .ToList();
 
         // Update chart data for the active time window


### PR DESCRIPTION
## Summary

- **WAN connection filter now applies to failed/error results** - Previously, filtering WAN speed test history by a specific connection (e.g., "Starlink") still showed all failed test results regardless of filter selection. Now failed results with WAN metadata are filtered by connection like successful results, and failures without WAN metadata (where the connection couldn't be identified) only appear when showing all connections.

## Test plan

- [x] Run WAN speed tests on multiple connections
- [x] Filter history by a specific connection and verify only errors for that connection appear
- [x] Verify errors without WAN metadata appear when no filter is active (show all)
- [x] Verify all results still appear when no connection badge is selected