### PR TITLE
Signal Map UX: hover-only Disable AP tooltip, cross-floor drag warning

### DIFF
--- a/src/NetworkOptimizer.Web/wwwroot/js/floorPlanEditor.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/floorPlanEditor.js
@@ -516,7 +516,7 @@ window.fpEditor = {
                 iconSize: [32, 32], iconAnchor: [16, 16], popupAnchor: [0, -16]
             });
             var marker = L.marker([ap.lat, ap.lng], {
-                icon: icon, draggable: draggable && ap.sameFloor, pane: 'apIconPane'
+                icon: icon, draggable: draggable, pane: 'apIconPane'
             }).addTo(self._apLayer);
             marker._apMac = ap.mac;
 
@@ -655,7 +655,7 @@ window.fpEditor = {
             disableApHtml = disableHeader +
                 '<div class="fp-ap-popup-row" style="margin-top:4px">' +
                 '<button class="fp-disable-ap-btn' + (isDisabled ? ' active' : '') + '" ' +
-                'data-tooltip="Simulate removing this AP to test coverage with a replacement" ' +
+                'data-tooltip="Simulate removing this AP to test coverage with a replacement" data-tooltip-hover-only ' +
                 'onclick="fpEditor._toggleDisableAp(\'' + esc(macLower) + '\')">' +
                 (isDisabled ? 'Enable AP' : 'Disable AP') +
                 '</button></div>';
@@ -768,6 +768,15 @@ window.fpEditor = {
                         }
                     });
                 })(glowMarker, ap);
+            } else if (draggable && !ap.sameFloor) {
+                (function (origLatLng) {
+                    marker.on('dragstart', function () {
+                        self._showDrawWarning('Switch to this AP\'s floor to move it');
+                    });
+                    marker.on('dragend', function (e) {
+                        e.target.setLatLng(origLatLng);
+                    });
+                })(L.latLng(ap.lat, ap.lng));
             }
         });
 


### PR DESCRIPTION
## Summary

- **Disable AP tooltip is hover-only** - The tooltip on the Disable AP / Enable AP button in the Simulate section no longer shows on click, only on hover.
- **Cross-floor AP drag warning** - Trying to drag an AP that's on a different floor now shows a toast ("Switch to this AP's floor to move it") and snaps the marker back, instead of silently panning the map.

## Test plan

- [x] Open Signal Map, enter Edit APs mode
- [x] Click Disable AP button - tooltip should NOT appear on click, only on hover
- [x] View a floor with APs from other floors visible - try dragging a cross-floor AP
- [x] Verify toast appears and AP snaps back to original position
- [x] Verify same-floor APs still drag normally