### PR TITLE
Fix GPS tracking for walk-test signal mapping

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -2278,6 +2278,7 @@
         align-items: flex-end;
         gap: 3px;
         height: 24px;
+        margin-bottom: 0.5rem;
     }
     .signal-bars .bar {
         width: 5px;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -9272,7 +9272,7 @@ a.path-hop.hop-clickable:hover {
     height: 150px;
     gap: 4px;
     padding: 0 0.5rem;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0;
 }
 
 .signal-bar-wrapper {


### PR DESCRIPTION
## Summary

- GPS coordinates were never captured during signal polling due to a race condition - `OnAfterRenderAsync` checked `_client` before it was loaded by `OnInitializedAsync`
- Switched from one-shot `getCurrentPosition` to `watchPosition` for continuous GPS tracking, which keeps the GPS hardware active during walk tests and is more efficient than repeated one-shot requests
- Added a "Location Permission Denied" banner so users know to re-enable location access if they accidentally denied it
- Zombie write protection: when the GPS watcher goes silent (browser died but Blazor circuit still alive), stops persisting all data after 15 seconds. GPS signal loss still fires error callbacks, so silence reliably indicates a dead browser.
- First poll now fires immediately instead of waiting 5 seconds, so the "Connecting..." state is near-instant
- Added "Connecting..." indicator before first poll data arrives
- Minor CSS polish for the live status indicator

## Test plan

- [x] Verified GPS coordinates saved on every signal ping (2-5m accuracy)
- [x] Verified wired devices don't trigger location permission prompt
- [x] Verified GPS watcher cleans up on page navigation
- [x] Verified permission denied banner appears when GPS is blocked
- [x] Verified zombie writes stop ~15 seconds after killing the browser
- [x] Verified new session picks up GPS correctly after restart
- [x] Verified first poll fires immediately on page load
- [x] Build passes with 0 warnings