### PR TITLE
Fix zombie detection stopping logging after GPS denial

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -979,9 +979,14 @@
         // If the GPS watcher was sending callbacks (success or error) but went completely
         // silent, the browser is gone - stop persisting to avoid zombie writes.
         // GPS signal loss still fires error callbacks, so silence = dead browser.
+        // GPS denied fires a single error callback then goes silent - skip zombie
+        // check in that case so we keep logging signal data without coordinates.
         var watcherSilent = _gpsWatcherId.HasValue
+            && !_gpsDenied
             && _lastGpsCallback != default
             && _lastGpsCallback < DateTime.UtcNow.AddSeconds(-15);
+        if (watcherSilent)
+            _isLogging = false;
         var persist = _isLogging && !watcherSilent;
         var lat = watcherSilent ? null : _gpsLat;
         var lng = watcherSilent ? null : _gpsLng;


### PR DESCRIPTION
## Summary

- Zombie detection was incorrectly stopping all signal logging when GPS permission was denied. The GPS watcher fires a single error callback on denial then goes silent - the same silence pattern as a dead browser. Now skips the zombie check when `_gpsDenied` is true so signal data keeps logging without coordinates.
- UI indicator ("Live · Logging") now correctly switches to "Live" when zombie detection stops persistence, instead of continuing to show "Logging" while silently discarding data.

## Test plan

- [x] GPS allowed + close: zombie kills in ~15s, no stale GPS repeating
- [x] GPS denied + keep running: logs signal data without coords indefinitely
- [x] GPS denied + close: circuit timeout kills in ~3 min (benign null-GPS data)
- [x] GPS revoked mid-session: zombie kills in ~15s
- [x] GPS blocked (pre-set): denied banner shows, keeps logging
- [x] Full matrix tested across iOS Firefox and Safari (18 test cases)