### PR TITLE
Allow NVRs on Management VLAN in security audit

### DIFF
--- a/src/NetworkOptimizer.Audit/Rules/CameraVlanRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/CameraVlanRule.cs
@@ -71,8 +71,11 @@ public class CameraVlanRule : AuditRuleBase
         if (network == null)
             return null;
 
+        // Check if this is an NVR (allowed on Management VLAN)
+        var isNvr = detection.Metadata?.ContainsKey("is_nvr") == true;
+
         // Check placement using shared logic
-        var placement = VlanPlacementChecker.CheckCameraPlacement(network, networks, ScoreImpact);
+        var placement = VlanPlacementChecker.CheckCameraPlacement(network, networks, ScoreImpact, isNvr: isNvr);
 
         if (placement.IsCorrectlyPlaced)
             return null;
@@ -159,7 +162,9 @@ public class CameraVlanRule : AuditRuleBase
             }
         }
 
-        var message = $"{detection.CategoryName} on {network.Name} VLAN - should be on security VLAN";
+        var message = isNvr
+            ? $"NVR on {network.Name} VLAN - should be on management or security VLAN"
+            : $"{detection.CategoryName} on {network.Name} VLAN - should be on security VLAN";
 
         return new AuditIssue
         {

--- a/src/NetworkOptimizer.Core/Models/ProtectCamera.cs
+++ b/src/NetworkOptimizer.Core/Models/ProtectCamera.cs
@@ -23,10 +23,16 @@ public sealed record ProtectCamera
     public string? ConnectionNetworkId { get; init; }
 
     /// <summary>
+    /// Whether this device is an NVR (UNVR, UNVR-Pro, Cloud Key).
+    /// NVRs are infrastructure devices that can legitimately be on Management or Security VLANs.
+    /// </summary>
+    public bool IsNvr { get; init; }
+
+    /// <summary>
     /// Create a ProtectCamera from MAC and name
     /// </summary>
-    public static ProtectCamera Create(string mac, string name, string? connectionNetworkId = null)
-        => new() { Mac = mac.ToLowerInvariant(), Name = name, ConnectionNetworkId = connectionNetworkId };
+    public static ProtectCamera Create(string mac, string name, string? connectionNetworkId = null, bool isNvr = false)
+        => new() { Mac = mac.ToLowerInvariant(), Name = name, ConnectionNetworkId = connectionNetworkId, IsNvr = isNvr };
 }
 
 /// <summary>
@@ -60,9 +66,9 @@ public sealed class ProtectCameraCollection
     /// <summary>
     /// Add a camera by MAC, name, and connection network ID
     /// </summary>
-    public void Add(string mac, string name, string? connectionNetworkId)
+    public void Add(string mac, string name, string? connectionNetworkId, bool isNvr = false)
     {
-        Add(ProtectCamera.Create(mac, name, connectionNetworkId));
+        Add(ProtectCamera.Create(mac, name, connectionNetworkId, isNvr));
     }
 
     /// <summary>
@@ -117,6 +123,16 @@ public sealed class ProtectCameraCollection
             return !string.IsNullOrEmpty(networkId);
         }
         return false;
+    }
+
+    /// <summary>
+    /// Check if a MAC address belongs to an NVR device
+    /// </summary>
+    public bool IsNvr(string? mac)
+    {
+        if (string.IsNullOrEmpty(mac))
+            return false;
+        return _cameras.TryGetValue(mac, out var camera) && camera.IsNvr;
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -678,7 +678,7 @@ public class UniFiApiClient : IDisposable
             if (device.RequiresSecurityVlan)
             {
                 var name = !string.IsNullOrEmpty(device.Name) ? device.Name : device.Model ?? "Protect Device";
-                result.Add(device.Mac, name, device.ConnectionNetworkId);
+                result.Add(device.Mac, name, device.ConnectionNetworkId, device.IsNvr);
 
                 var deviceType = device.IsCamera ? "camera" :
                                  device.IsDoorbell ? "doorbell" :

--- a/src/NetworkOptimizer.Web/Services/AuditService.cs
+++ b/src/NetworkOptimizer.Web/Services/AuditService.cs
@@ -1591,9 +1591,11 @@ public class AuditService
                                 ? "IoT Device Allowed on VLAN"
                                 : (isInformational ? "IoT Device Possibly on Wrong VLAN" : "IoT Device on Wrong VLAN"),
             Audit.IssueTypes.CameraVlan or Audit.IssueTypes.WifiCameraVlan or "OFFLINE-CAMERA-VLAN" or "OFFLINE-CLOUD-CAMERA-VLAN" =>
-                message.StartsWith("Security System")
-                    ? (isInformational ? "Security System Possibly on Wrong VLAN" : "Security System on Wrong VLAN")
-                    : (isInformational ? "Camera Possibly on Wrong VLAN" : "Camera on Wrong VLAN"),
+                message.StartsWith("NVR")
+                    ? (isInformational ? "NVR Possibly on Wrong VLAN" : "NVR on Wrong VLAN")
+                    : message.StartsWith("Security System")
+                        ? (isInformational ? "Security System Possibly on Wrong VLAN" : "Security System on Wrong VLAN")
+                        : (isInformational ? "Camera Possibly on Wrong VLAN" : "Camera on Wrong VLAN"),
             Audit.IssueTypes.InfraNotOnMgmt => "Infrastructure Device on Wrong VLAN",
 
             // Port security


### PR DESCRIPTION
## Summary

- **NVRs (UNVR, UNVR-Pro, Cloud Key) are now accepted on Management or Security VLANs** - previously all Protect devices were classified as cameras and flagged Critical if not on the Security VLAN, causing false positives for dual-homed NVRs
- **NVR-specific issue title and recommendation** - when an NVR is on the wrong VLAN, the audit shows "NVR on Wrong VLAN" and recommends both Management and Security VLANs as valid targets
- **Regular cameras unchanged** - cameras (including Protect cameras) are still required to be on the Security VLAN only

Closes #268

## Test plan

- [x] 14 new unit tests covering NVR placement, detection metadata, message format, and regression guards
- [x] All 4,977 tests pass with 0 warnings
- [x] Run security audit on NAS - verify existing camera issues unchanged
- [x] Run security audit on Mac - verify existing camera issues unchanged
- [ ] User with UNVR on Management VLAN confirms false positive is resolved