### PR TITLE
Add Furbo to cloud camera vendor list

### DIFF
--- a/src/NetworkOptimizer.Audit/Services/DeviceTypeDetectionService.cs
+++ b/src/NetworkOptimizer.Audit/Services/DeviceTypeDetectionService.cs
@@ -1191,7 +1191,8 @@ public class DeviceTypeDetectionService
                System.Text.RegularExpressions.Regex.IsMatch(vendorLower, @"\barlo\b") ||
                System.Text.RegularExpressions.Regex.IsMatch(vendorLower, @"\bsimplisafe\b") ||
                System.Text.RegularExpressions.Regex.IsMatch(vendorLower, @"\btp-link\b") ||
-               System.Text.RegularExpressions.Regex.IsMatch(vendorLower, @"\bcanary\b");
+               System.Text.RegularExpressions.Regex.IsMatch(vendorLower, @"\bcanary\b") ||
+               System.Text.RegularExpressions.Regex.IsMatch(vendorLower, @"\bfurbo\b");
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- **Furbo cloud camera support** - Furbo dog cameras (cloud-connected pet cameras) are now recognized as cloud security devices, so the security audit correctly recommends an internet-connected VLAN instead of a local-only security VLAN.

Extracted from #269 by @ekobres - the rest of that PR (Apple device detection improvements for HomePods and Apple TVs) is pending review and testing.

## Test plan

- [x] Build passes with 0 warnings
- [x] All 5 new Furbo tests pass (basic detection, vendor variations, history-based, cloud vendor theory)
- [x] All 36 existing cloud vendor tests still pass