### PR TITLE
Fix WAN speed test duration to save per-direction value (10s not 20s)

### DIFF
--- a/src/NetworkOptimizer.Web/Services/CloudflareSpeedTestService.cs
+++ b/src/NetworkOptimizer.Web/Services/CloudflareSpeedTestService.cs
@@ -213,7 +213,7 @@ public partial class CloudflareSpeedTestService
                 TestTime = DateTime.UtcNow,
                 Success = true,
                 ParallelStreams = Concurrency,
-                DurationSeconds = (int)(DownloadDuration + UploadDuration).TotalSeconds,
+                DurationSeconds = (int)DownloadDuration.TotalSeconds,
             };
 
             // Identify which WAN connection was used based on Cloudflare-reported IP.

--- a/src/cfspeedtest/main.go
+++ b/src/cfspeedtest/main.go
@@ -115,9 +115,6 @@ func run(cfg speedtest.Config) speedtest.Result {
 	result.Success = true
 	result.Streams = cfg.Streams
 	result.DurationSeconds = int(cfg.Duration.Seconds())
-	if !cfg.DownloadOnly && !cfg.UploadOnly {
-		result.DurationSeconds *= 2
-	}
 
 	return result
 }


### PR DESCRIPTION
LAN speed tests save the single-direction test duration (e.g. 10s), but both WAN speed test paths were saving the combined total of both directions (20s). This fixes both the C# CloudflareSpeedTestService and the Go cfspeedtest binary to report just the per-direction duration, consistent with LAN tests.