### PR TITLE
Exclude LAG member ports from excessive tagged VLANs audit

### DIFF
--- a/src/NetworkOptimizer.Audit/Models/PortInfo.cs
+++ b/src/NetworkOptimizer.Audit/Models/PortInfo.cs
@@ -127,4 +127,12 @@ public class PortInfo
     /// Used to detect intentional configurations like unrestricted access ports.
     /// </summary>
     public UniFiPortProfile? AssignedPortProfile { get; init; }
+
+    /// <summary>
+    /// Whether this port is a LAG (Link Aggregation Group) child port.
+    /// Child ports are assimilated into a parent LAG port and their individual
+    /// configuration is irrelevant for most audit rules. Only specific rules
+    /// (like unused port detection) should evaluate LAG child ports.
+    /// </summary>
+    public bool IsLagChild { get; init; }
 }

--- a/src/NetworkOptimizer.Audit/Rules/IAuditRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/IAuditRule.cs
@@ -42,6 +42,13 @@ public interface IAuditRule
     bool Enabled { get; }
 
     /// <summary>
+    /// Whether this rule should evaluate LAG child ports.
+    /// Most rules should skip LAG children since their config is controlled
+    /// by the parent LAG port. Defaults to false.
+    /// </summary>
+    bool AppliesToLagChildPorts { get; }
+
+    /// <summary>
     /// Evaluate this rule against a port configuration
     /// </summary>
     /// <param name="port">Port to evaluate</param>
@@ -61,6 +68,7 @@ public abstract class AuditRuleBase : IAuditRule
     public abstract AuditSeverity Severity { get; }
     public virtual int ScoreImpact { get; } = 5;
     public virtual bool Enabled { get; set; } = true;
+    public virtual bool AppliesToLagChildPorts => false;
 
     /// <summary>
     /// Device type detection service for enhanced detection

--- a/src/NetworkOptimizer.Audit/Rules/UnusedPortRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/UnusedPortRule.cs
@@ -39,6 +39,7 @@ public class UnusedPortRule : AuditRuleBase
     public override string Description => "Unused ports should be disabled (forward: disabled) to prevent unauthorized access";
     public override AuditSeverity Severity => AuditSeverity.Recommended;
     public override int ScoreImpact => 2;
+    public override bool AppliesToLagChildPorts => true;
 
     public override AuditIssue? Evaluate(PortInfo port, List<NetworkInfo> networks, List<NetworkInfo>? allNetworks = null)
     {


### PR DESCRIPTION
## Summary

- **LAG child ports no longer trigger false positive "Excessive Tagged VLANs" issues.** LAG member ports have a raw `forward: "all"` config that is irrelevant since they're assimilated into the parent LAG port. Ports with both `lag_idx` (number) and `aggregated_by` (number) are now marked as `IsLagChild` and skipped by most audit rules.
- **Unused port detection still applies to LAG child ports.** Rules can opt in to evaluate LAG children via `AppliesToLagChildPorts`. Currently only `UnusedPortRule` opts in, so disconnected LAG member ports are still flagged if not disabled.

Closes #206

## Test plan

- [x] 10 new tests covering LAG detection, parent vs child, multiple members, missing fields, and integration with both AccessPortVlanRule (excluded) and UnusedPortRule (included)
- [x] All 5,138 existing tests pass, 0 build warnings
- [x] Run audit on NAS deployment and verify LAG ports no longer generate excessive VLAN issues