### PR TITLE
Add Settings hint to IoT audit recommendations

### DIFF
--- a/src/NetworkOptimizer.Audit/Rules/IotVlanRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/IotVlanRule.cs
@@ -159,19 +159,8 @@ public class IotVlanRule : AuditRuleBase
             }
         }
 
-        // Different messaging for allowed vs not-allowed devices
-        string message;
-        string recommendedAction;
-        if (placement.IsAllowedBySettings)
-        {
-            message = $"{detection.CategoryName} allowed per Settings on {network.Name} VLAN";
-            recommendedAction = "Change in Settings if you want to isolate this device type.";
-        }
-        else
-        {
-            message = $"{detection.CategoryName} on {network.Name} VLAN - should be isolated";
-            recommendedAction = VlanPlacementChecker.GetMoveRecommendation(placement.RecommendedNetworkLabel);
-        }
+        var (message, recommendedAction) = VlanPlacementChecker.GetIoTMessaging(
+            placement, detection.Category, detection.CategoryName, network.Name);
 
         var metadata = VlanPlacementChecker.BuildMetadata(detection, network);
         if (placement.IsAllowedBySettings)

--- a/src/NetworkOptimizer.Audit/Rules/WirelessIotVlanRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/WirelessIotVlanRule.cs
@@ -39,19 +39,8 @@ public class WirelessIotVlanRule : WirelessAuditRuleBase
         if (placement.IsCorrectlyPlaced)
             return null;
 
-        // Different messaging for allowed vs not-allowed devices
-        string message;
-        string recommendedAction;
-        if (placement.IsAllowedBySettings)
-        {
-            message = $"{client.Detection.CategoryName} allowed per Settings on {network.Name} VLAN";
-            recommendedAction = "Change in Settings if you want to isolate this device type.";
-        }
-        else
-        {
-            message = $"{client.Detection.CategoryName} on {network.Name} VLAN - should be isolated";
-            recommendedAction = VlanPlacementChecker.GetMoveRecommendation(placement.RecommendedNetworkLabel);
-        }
+        var (message, recommendedAction) = VlanPlacementChecker.GetIoTMessaging(
+            placement, client.Detection.Category, client.Detection.CategoryName, network.Name);
 
         var metadata = VlanPlacementChecker.BuildMetadata(client.Detection, network, placement.IsLowRisk);
         if (placement.IsAllowedBySettings)


### PR DESCRIPTION
## Summary

- For device types with configurable allowance settings (streaming devices, smart TVs, smart speakers, media players, printers), the warning-level recommendation now reads "Move to IoT (64) or allow this device type in Settings" - letting users know they can either move the device or change their settings to allow it
- Consolidated messaging logic from IotVlanRule and WirelessIotVlanRule into `VlanPlacementChecker.GetIoTMessaging()` to eliminate duplication

## Test plan

- [x] All 3085 audit tests pass
- [x] Run audit on NAS/Mac and verify recommendation text for streaming device / smart TV warnings
- [x] Verify info-level "allowed per Settings" issues still show "Change in Settings if you want to isolate this device type"
- [x] Verify non-configurable IoT devices (smart plugs, thermostats) still show the standard move recommendation without the Settings hint