### PR TITLE
Fix hardcoded localhost URL in password reset scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,15 +211,15 @@ In progress: Time-series metrics, cable modem monitoring, WiFi analysis, multi-s
 
 If you forget the admin password, use the reset script for your platform:
 
+**Docker / macOS / Linux:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/Ozark-Connect/NetworkOptimizer/main/scripts/reset-password.sh | bash
+```
+
 **Windows (PowerShell as Administrator):**
 ```powershell
 irm https://raw.githubusercontent.com/Ozark-Connect/NetworkOptimizer/main/scripts/reset-password.ps1 -OutFile reset-password.ps1
 .\reset-password.ps1
-```
-
-**Docker / macOS / Linux:**
-```bash
-curl -fsSL https://raw.githubusercontent.com/Ozark-Connect/NetworkOptimizer/main/scripts/reset-password.sh | bash
 ```
 
 The script stops the service, clears the password, restarts, and shows you the new temporary password.

--- a/scripts/reset-password.ps1
+++ b/scripts/reset-password.ps1
@@ -237,8 +237,8 @@ if ($password) {
     Write-Host ""
     Write-Host "  Temporary password: $password" -ForegroundColor Cyan
     Write-Host ""
-    Write-Host "  Open http://localhost:8042 and log in with this password."
-    Write-Host "  Go to Settings to set a permanent password."
+    Write-Host "  Log in to Network Optimizer with this password,"
+    Write-Host "  then go to Settings to set a permanent one."
     Write-Host ""
 } else {
     Write-Host "Password reset completed, but could not extract the new password from logs." -ForegroundColor Yellow

--- a/scripts/reset-password.sh
+++ b/scripts/reset-password.sh
@@ -440,8 +440,8 @@ show_result() {
         echo ""
         echo -e "  Temporary password: ${CY}${BLD}${password}${CL}"
         echo ""
-        echo "  Open http://localhost:8042 and log in with this password."
-        echo "  Go to Settings to set a permanent password."
+        echo "  Log in to Network Optimizer with this password,"
+        echo "  then go to Settings to set a permanent one."
         echo ""
     else
         msg_warn "Password reset completed, but could not extract the new password from logs."


### PR DESCRIPTION
## Summary

- Replace hardcoded `http://localhost:8042` with a generic message in both reset scripts, since users may be accessing the app from a different machine or behind a reverse proxy

## Test plan

- [x] Verify `show_result` output in `reset-password.sh` says "Log in to Network Optimizer..."
- [x] Verify success output in `reset-password.ps1` says "Log in to Network Optimizer..."