### PR TITLE
Fix JSON parsing for WAN QoS fields when values are empty or non-numeric

### DIFF
--- a/src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs
@@ -203,16 +203,19 @@ public class UniFiNetworkConfig
     public string? WanPassword { get; set; }
 
     [JsonPropertyName("wan_egress_qos")]
-    public int WanEgressQos { get; set; }
+    [JsonConverter(typeof(FlexibleIntConverter))]
+    public int? WanEgressQos { get; set; }
 
     [JsonPropertyName("wan_smartq_enabled")]
     public bool WanSmartqEnabled { get; set; }
 
     [JsonPropertyName("wan_smartq_up_rate")]
-    public int WanSmartqUpRate { get; set; }
+    [JsonConverter(typeof(FlexibleIntConverter))]
+    public int? WanSmartqUpRate { get; set; }
 
     [JsonPropertyName("wan_smartq_down_rate")]
-    public int WanSmartqDownRate { get; set; }
+    [JsonConverter(typeof(FlexibleIntConverter))]
+    public int? WanSmartqDownRate { get; set; }
 
     /// <summary>
     /// WAN provider capabilities (upload/download speeds).


### PR DESCRIPTION
## Summary

Fixes `System.Text.Json.JsonException: The JSON value could not be converted to System.Int32. Path: $.data[1].wan_egress_qos` when UniFi API returns empty strings or null for WAN QoS fields on networks without QoS configured.

## Problem

When a UniFi network has no QoS configured, the API returns empty/null values for `wan_egress_qos`, `wan_smartq_up_rate`, and `wan_smartq_down_rate`. The current model defines these as non-nullable `int`, causing JSON deserialization to fail. This blocks the SSH device configuration flow entirely.

**Stack trace:**
```
System.Text.Json.JsonException: The JSON value could not be converted to System.Int32.
  Path: $.data[1].wan_egress_qos | LineNumber: 0 | BytePositionInLine: 1273.
  ---> System.FormatException: Either the JSON value is not in a supported format, or is out of bounds for an Int32.
     at System.Text.Json.Utf8JsonReader.GetInt32WithQuotes()
     ...
     at NetworkOptimizer.UniFi.UniFiApiClient.GetNetworkConfigsAsync()
```

## Fix

Applied the existing `FlexibleIntConverter` (already used for the `vlan` field on line 79) to the three WAN QoS fields and made them nullable:

```csharp
// Before
[JsonPropertyName("wan_egress_qos")]
public int WanEgressQos { get; set; }

// After
[JsonPropertyName("wan_egress_qos")]
[JsonConverter(typeof(FlexibleIntConverter))]
public int? WanEgressQos { get; set; }
```

Same change applied to `WanSmartqUpRate` and `WanSmartqDownRate`.

## Testing

- Built from source and deployed to a Proxmox LXC running Network Optimizer
- Confirmed the `wan_egress_qos` JSON parsing error no longer occurs
- SSH device configuration now works on networks without QoS configured
- No references to these properties exist outside the model, so no downstream breakage

## Files Changed

- `src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs` — 3 fields updated (lines 205-218)