### PR TITLE
Number and reorder deployment guide sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,13 +131,13 @@ Without SSH access, Security Audit works fully, but you cannot run gateway/devic
 
 | Platform | Method | Guide |
 |----------|--------|-------|
-| Windows | Installer (recommended) | [Download from Releases](https://github.com/Ozark-Connect/NetworkOptimizer/releases) |
 | Linux Server | Docker (recommended) | [Deployment Guide](docker/DEPLOYMENT.md) |
 | Proxmox VE | LXC one-liner | [Proxmox Guide](scripts/proxmox/README.md) |
-| Synology/QNAP/Unraid | Docker | [NAS Deployment](docker/DEPLOYMENT.md#2-nas-deployment-docker) |
+| Synology/QNAP/Unraid | Docker | [NAS Deployment](docker/DEPLOYMENT.md#3-nas-deployment-docker) |
+| Home Assistant | Add-ons | [Home Assistant](docker/DEPLOYMENT.md#5-home-assistant) |
+| Windows | Installer (recommended) | [Download from Releases](https://github.com/Ozark-Connect/NetworkOptimizer/releases) |
 | macOS | Native (best performance) | [macOS Installation](docs/MACOS-INSTALLATION.md) |
 | Linux | Native (no Docker) | [Linux Native](docker/NATIVE-DEPLOYMENT.md#linux-deployment) |
-| Home Assistant | Add-ons | [Home Assistant](docker/DEPLOYMENT.md#home-assistant) |
 
 Docker Desktop on macOS and Windows limits network throughput for speed testing. For accurate multi-gigabit measurements, use native deployment.
 
@@ -191,14 +191,18 @@ bash -c "$(wget -qLO - https://raw.githubusercontent.com/Ozark-Connect/NetworkOp
 
 ```
 src/
-├── NetworkOptimizer.Web        # Blazor web UI
-├── NetworkOptimizer.Audit      # Security audit engine
-├── NetworkOptimizer.UniFi      # UniFi API client
-├── NetworkOptimizer.Storage    # SQLite database
-├── NetworkOptimizer.Monitoring # SNMP/SSH polling
-├── NetworkOptimizer.Sqm        # Adaptive bandwidth management
-├── NetworkOptimizer.Agents     # Agent deployment
-└── NetworkOptimizer.Reports    # PDF/Markdown generation
+├── NetworkOptimizer.Web         # Blazor web UI
+├── NetworkOptimizer.Audit       # Security Audit
+├── NetworkOptimizer.Core        # Shared helpers and utilities
+├── NetworkOptimizer.Diagnostics # Config Optimizer
+├── NetworkOptimizer.Monitoring  # SNMP/SSH polling
+├── NetworkOptimizer.Reports     # PDF/Markdown report generation
+├── NetworkOptimizer.Sqm         # Adaptive SQM
+├── NetworkOptimizer.Storage     # SQLite database
+├── NetworkOptimizer.UniFi       # UniFi API client
+├── NetworkOptimizer.WiFi        # Wi-Fi Optimizer
+├── cfspeedtest/                 # WAN Speed Test (binary for gateway)
+└── OpenSpeedTest/               # Client Speed Test
 ```
 
 ## Tech Stack

--- a/docker/DEPLOYMENT.md
+++ b/docker/DEPLOYMENT.md
@@ -6,53 +6,13 @@ Production deployment guide for Network Optimizer.
 
 | Option | Best For | Guide |
 |--------|----------|-------|
-| Windows Installer | Windows desktops/servers | [Download from Releases](https://github.com/Ozark-Connect/NetworkOptimizer/releases) |
 | Linux + Docker | Self-built servers, VMs, cloud (recommended) | [Below](#1-linux--docker-recommended) |
-| Proxmox LXC | Homelab virtualization, one-liner install | [Proxmox Guide](#proxmox-lxc) |
-| NAS + Docker | Synology, QNAP, Unraid | [NAS Deployment](#2-nas-deployment-docker) |
+| Proxmox LXC | Homelab virtualization, one-liner install | [Proxmox Guide](#2-proxmox-lxc) |
+| NAS + Docker | Synology, QNAP, Unraid | [NAS Deployment](#3-nas-deployment-docker) |
+| Home Assistant | Add-ons | [Home Assistant](#5-home-assistant) |
+| Windows Installer | Windows desktops/servers | [Download from Releases](https://github.com/Ozark-Connect/NetworkOptimizer/releases) |
 | macOS Native | Mac servers, multi-gigabit speed testing | [macOS Installation](../docs/MACOS-INSTALLATION.md) |
 | Linux Native | Maximum performance, no Docker | [Native Guide](NATIVE-DEPLOYMENT.md#linux-deployment) |
-| Home Assistant | Add-ons | [Home Assistant](#home-assistant) |
-
----
-
-### Proxmox LXC
-
-The easiest way to deploy on Proxmox. Run this one-liner on your **Proxmox VE host**:
-
-```bash
-bash -c "$(wget -qLO - https://raw.githubusercontent.com/Ozark-Connect/NetworkOptimizer/main/scripts/proxmox/install.sh)"
-```
-
-The interactive script will:
-1. Create a privileged Debian 12 LXC container
-2. Install Docker and Docker Compose
-3. Deploy Network Optimizer with Docker Compose
-4. Configure auto-start on boot
-
-**Requirements:**
-- Proxmox VE 7.0 or later
-- 10GB disk space, 2GB RAM minimum
-- Internet access for downloading images
-
-**After Installation:**
-```bash
-# Get the auto-generated admin password
-pct exec <CT_ID> -- docker logs network-optimizer 2>&1 | grep -A5 "AUTO-GENERATED"
-
-# Access the web UI
-http://<container-ip>:8042
-```
-
-For advanced configuration, troubleshooting, and manual installation see the [full Proxmox guide](../scripts/proxmox/README.md).
-
----
-
-### Home Assistant
-
-Network Optimizer can be installed as two Home Assistant add-ons. See [issue #201](https://github.com/Ozark-Connect/NetworkOptimizer/issues/201) for setup instructions and discussion.
-
-For the initial admin password, check the add-on's **Log** tab instead of using the `docker logs` command.
 
 ---
 
@@ -188,7 +148,39 @@ sudo systemctl enable network-optimizer
 
 ---
 
-### 2. NAS Deployment (Docker)
+### 2. Proxmox LXC
+
+The easiest way to deploy on Proxmox. Run this one-liner on your **Proxmox VE host**:
+
+```bash
+bash -c "$(wget -qLO - https://raw.githubusercontent.com/Ozark-Connect/NetworkOptimizer/main/scripts/proxmox/install.sh)"
+```
+
+The interactive script will:
+1. Create a privileged Debian 12 LXC container
+2. Install Docker and Docker Compose
+3. Deploy Network Optimizer with Docker Compose
+4. Configure auto-start on boot
+
+**Requirements:**
+- Proxmox VE 7.0 or later
+- 10GB disk space, 2GB RAM minimum
+- Internet access for downloading images
+
+**After Installation:**
+```bash
+# Get the auto-generated admin password
+pct exec <CT_ID> -- docker logs network-optimizer 2>&1 | grep -A5 "AUTO-GENERATED"
+
+# Access the web UI
+http://<container-ip>:8042
+```
+
+For advanced configuration, troubleshooting, and manual installation see the [full Proxmox guide](../scripts/proxmox/README.md).
+
+---
+
+### 3. NAS Deployment (Docker)
 
 For commercial NAS devices with container support.
 
@@ -236,6 +228,14 @@ For maximum network performance or systems without Docker, run natively on the h
 - Windows: Use the [Windows Installer](https://github.com/Ozark-Connect/NetworkOptimizer/releases) instead
 
 See [Native Deployment Guide](NATIVE-DEPLOYMENT.md) for macOS and Linux instructions.
+
+---
+
+### 5. Home Assistant
+
+Network Optimizer can be installed as two Home Assistant add-ons. See [issue #201](https://github.com/Ozark-Connect/NetworkOptimizer/issues/201) for setup instructions and discussion.
+
+For the initial admin password, check the add-on's **Log** tab instead of using the `docker logs` command.
 
 ## Pre-Deployment Checklist
 


### PR DESCRIPTION
## Summary

- Number all deployment guide sections (1-5) and reorder to group Docker-based options first, then native/installer options
- Update anchor links across DEPLOYMENT.md and README.md to match new numbering
- Update README project structure: remove unused Agents project, add missing projects (Core, Diagnostics, WiFi, cfspeedtest, OpenSpeedTest) with nav menu titles

## Test plan

- [x] Verify all anchor links work on the rendered GitHub markdown
- [x] Confirm section numbering is sequential (1-5) in DEPLOYMENT.md
- [x] Confirm README Installation table order matches DEPLOYMENT.md