### PR TITLE
Update SSH configuration docs to match Settings page

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Time-series metrics with historical trending and alerting. Cable modem stats (si
 - **Device SSH:** UniFi Devices > Device Updates and Settings > Device SSH Settings
 - See [Deployment Guide](docker/DEPLOYMENT.md#unifi-ssh-configuration) for detailed instructions (UniFi Network 9.5+)
 
-Without SSH access, Security Audit works fully, but you cannot run gateway/device LAN speed tests, WAN speed tests, or deploy Adaptive SQM configurations.
+Without SSH access, Security Audit works fully, but you cannot run gateway/device LAN speed tests, gateway-based WAN speed tests, or deploy Adaptive SQM configurations.
 
 ## Installation
 

--- a/docker/DEPLOYMENT.md
+++ b/docker/DEPLOYMENT.md
@@ -785,7 +785,8 @@ SSH access is required for some features but not others. Here's what needs what:
 | Feature | Gateway SSH | Device SSH |
 |---------|:-----------:|:----------:|
 | Adaptive SQM | Required | - |
-| WAN Speed Test | Required | - |
+| WAN Speed Test (gateway-based) | Required | - |
+| WAN Speed Test (server-based) | - | - |
 | LAN Speed Test (gateway) | Required | - |
 | LAN Speed Test (devices) | - | Required |
 | Security Audit | - | - |


### PR DESCRIPTION
## Summary

- Replaced the brief SSH intro with a feature/SSH-type matrix table showing exactly which features need Gateway SSH, Device SSH, or neither
- Added new sections covering how to configure SSH in Network Optimizer's Settings page (Gateway SSH and Device SSH separately), per-device SSH overrides, and troubleshooting guidance
- Updated terminology to match the current app UI ("Console" instead of "controller", added "modems" to device list)
- Documented private key authentication support for both Gateway and Device SSH
- Added "gateway-based WAN speed tests" to the README's SSH requirements summary

## Test plan

- [x] Verify rendered markdown looks correct on GitHub (table alignment, headings, bold text)
- [x] Confirm the `#unifi-ssh-configuration` anchor link from README still works