### PR TITLE
Deduplicate repeated error lines in SQM adjustment UI

### DIFF
--- a/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
@@ -708,7 +708,15 @@ WantedBy=multi-user.target
             {
                 var errorOutput = string.IsNullOrWhiteSpace(result.output) ? "(unknown error)" : result.output;
                 _logger.LogWarning("SQM adjustment failed for {Wan}: {Output}", wanName, errorOutput);
-                return (false, $"Error: {errorOutput}");
+
+                // Deduplicate repeated lines (e.g., speedtest CLI may repeat the same error for each server attempt)
+                var dedupedOutput = string.Join("\n", errorOutput
+                    .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                    .Select(l => l.Trim())
+                    .Where(l => !string.IsNullOrWhiteSpace(l))
+                    .Distinct());
+
+                return (false, $"Error: {dedupedOutput}");
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary

- **Deduplicate repeated error lines** - When the Ookla speedtest CLI fails, it can emit the same error message for each server attempt (e.g., 9 identical "Cannot open socket" lines). The UI now deduplicates these so users see the error once instead of a wall of repeated JSON.

## Test plan

- [x] Trigger an SQM adjustment when speedtest is expected to fail (e.g., wrong interface) and verify the error shows once, not repeated
- [x] Trigger a successful SQM adjustment and verify "SQM adjustment completed successfully" still displays normally
- [x] Check container logs to verify the full raw error output is still logged for debugging