### PR TITLE
Fix NuGet cache permission errors on macOS install

### DIFF
--- a/scripts/install-macos-native.sh
+++ b/scripts/install-macos-native.sh
@@ -120,7 +120,12 @@ cd "$REPO_ROOT"
 # Ensure NuGet cache is writable (stale cache from brew or failed restores can block builds)
 if [ -d "$HOME/.nuget/packages" ] && ! touch "$HOME/.nuget/packages/.write-test" 2>/dev/null; then
     echo "NuGet package cache has permission issues, clearing..."
+    chmod -R u+w "$HOME/.nuget/packages" 2>/dev/null || true
     rm -rf "$HOME/.nuget/packages"
+    if [ -d "$HOME/.nuget/packages" ]; then
+        echo "Error: Could not clear NuGet cache. Try running: sudo rm -rf ~/.nuget/packages"
+        exit 1
+    fi
 fi
 rm -f "$HOME/.nuget/packages/.write-test" 2>/dev/null
 


### PR DESCRIPTION
## Summary

- Before `dotnet publish`, check if `~/.nuget/packages` is writable
- If not, reclaim permissions (`chmod -R u+w`) and clear the cache so NuGet can re-download
- If the cache can't be cleared (root-owned files), exit with a helpful error message

Fixes build failures during `install-macos-native.sh` when the NuGet package cache has stale permissions from a previous Homebrew dotnet install or interrupted restore.

## Test plan

- [x] Simulated bad state (`chmod -R 555 ~/.nuget/packages`) on Mac, ran install - cache cleared and build succeeded
- [x] Ran install again with healthy cache - no intervention, built normally