### PR TITLE
Add IFB device existence check to SQM scripts and deployment

### DIFF
--- a/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
+++ b/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
@@ -252,6 +252,14 @@ public class ScriptGenerator
         sb.AppendLine("echo \"[$(date)] Starting speedtest adjustment on $INTERFACE...\" >> $LOG_FILE");
         sb.AppendLine();
 
+        // Verify IFB device exists (created by UniFi Smart Queues)
+        sb.AppendLine("# Verify IFB device exists (created by UniFi Smart Queues)");
+        sb.AppendLine("if ! ip link show \"$IFB_DEVICE\" &>/dev/null; then");
+        sb.AppendLine("    echo \"[$(date)] ERROR: IFB device $IFB_DEVICE does not exist. Smart Queues may not be enabled in UniFi Network settings.\" >> $LOG_FILE");
+        sb.AppendLine("    exit 1");
+        sb.AppendLine("fi");
+        sb.AppendLine();
+
         // TC update function
         sb.AppendLine(GetTcUpdateFunction());
         sb.AppendLine();
@@ -373,6 +381,14 @@ public class ScriptGenerator
         sb.AppendLine("if (( $(echo \"$SPEEDTEST_SPEED <= 0\" | bc -l) )) || (( $(echo \"$SPEEDTEST_SPEED > 100000\" | bc -l) )); then");
         sb.AppendLine("    echo \"[$(date)] ERROR: Speedtest result '$SPEEDTEST_SPEED' Mbps is out of valid range (0-100000), skipping ping adjustment\" >> $LOG_FILE");
         sb.AppendLine("    exit 0");
+        sb.AppendLine("fi");
+        sb.AppendLine();
+
+        // Verify IFB device exists (created by UniFi Smart Queues)
+        sb.AppendLine("# Verify IFB device exists (created by UniFi Smart Queues)");
+        sb.AppendLine("if ! ip link show \"$IFB_DEVICE\" &>/dev/null; then");
+        sb.AppendLine("    echo \"[$(date)] ERROR: IFB device $IFB_DEVICE does not exist. Smart Queues may not be enabled in UniFi Network settings.\" >> $LOG_FILE");
+        sb.AppendLine("    exit 1");
         sb.AppendLine("fi");
         sb.AppendLine();
 

--- a/tests/NetworkOptimizer.Sqm.Tests/ScriptGeneratorTests.cs
+++ b/tests/NetworkOptimizer.Sqm.Tests/ScriptGeneratorTests.cs
@@ -90,4 +90,34 @@ public class ScriptGeneratorTests
         Assert.Contains("* 0.3)", bootScript);
         Assert.DoesNotContain("0.30000000000000004", bootScript);
     }
+
+    [Fact]
+    public void GenerateAllScripts_ContainsIfbDeviceCheck_InBothScripts()
+    {
+        // Arrange
+        var config = new SqmConfiguration
+        {
+            ConnectionName = "Test WAN",
+            Interface = "eth3",
+            MaxDownloadSpeed = 100,
+            MinDownloadSpeed = 50,
+            AbsoluteMaxDownloadSpeed = 110,
+            PingHost = "8.8.8.8"
+        };
+
+        var generator = new ScriptGenerator(config);
+        var baseline = new Dictionary<string, string> { ["0_12"] = "95" };
+
+        // Act
+        var scripts = generator.GenerateAllScripts(baseline);
+        var bootScript = scripts.Values.First();
+
+        // Assert - IFB check appears in both embedded scripts
+        // The boot script contains both the speedtest and ping scripts via heredoc
+        Assert.Contains("ip link show \"$IFB_DEVICE\"", bootScript);
+        Assert.Contains("IFB device $IFB_DEVICE does not exist", bootScript);
+
+        // Should reference the correct IFB device name
+        Assert.Contains("IFB_DEVICE=\"ifbeth3\"", bootScript);
+    }
 }


### PR DESCRIPTION
SQM speedtest and ping scripts now verify the IFB virtual device exists before attempting tc operations. If the device is missing (e.g., UniFi dropped Smart Queues), the scripts log a clear error and exit instead of producing cryptic tc failures.

Also adds the same check as a deployment pre-flight gate — deploy will fail fast with an actionable error message if the IFB device is not present on the gateway.