### PR TITLE
Strengthen IFB device check tests

### DIFF
--- a/tests/NetworkOptimizer.Sqm.Tests/ScriptGeneratorTests.cs
+++ b/tests/NetworkOptimizer.Sqm.Tests/ScriptGeneratorTests.cs
@@ -112,12 +112,108 @@ public class ScriptGeneratorTests
         var scripts = generator.GenerateAllScripts(baseline);
         var bootScript = scripts.Values.First();
 
-        // Assert - IFB check appears in both embedded scripts
-        // The boot script contains both the speedtest and ping scripts via heredoc
-        Assert.Contains("ip link show \"$IFB_DEVICE\"", bootScript);
-        Assert.Contains("IFB device $IFB_DEVICE does not exist", bootScript);
+        // Extract the speedtest and ping script sections from the heredocs
+        var speedtestSection = ExtractHeredocSection(bootScript, "SPEEDTEST_EOF");
+        var pingSection = ExtractHeredocSection(bootScript, "PING_EOF");
 
-        // Should reference the correct IFB device name
-        Assert.Contains("IFB_DEVICE=\"ifbeth3\"", bootScript);
+        // Assert - IFB check appears in BOTH embedded scripts independently
+        Assert.Contains("ip link show \"$IFB_DEVICE\"", speedtestSection);
+        Assert.Contains("ip link show \"$IFB_DEVICE\"", pingSection);
+
+        // Both scripts define the correct IFB device name
+        Assert.Contains("IFB_DEVICE=\"ifbeth3\"", speedtestSection);
+        Assert.Contains("IFB_DEVICE=\"ifbeth3\"", pingSection);
+
+        // Both scripts exit with error code 1 on missing IFB
+        Assert.Contains("exit 1", speedtestSection);
+        Assert.Contains("exit 1", pingSection);
+    }
+
+    [Fact]
+    public void GenerateAllScripts_IfbCheck_AppearsBeforeTcCommands()
+    {
+        // Arrange
+        var config = new SqmConfiguration
+        {
+            ConnectionName = "Test WAN",
+            Interface = "eth2",
+            MaxDownloadSpeed = 100,
+            MinDownloadSpeed = 50,
+            AbsoluteMaxDownloadSpeed = 110,
+            PingHost = "8.8.8.8"
+        };
+
+        var generator = new ScriptGenerator(config);
+        var baseline = new Dictionary<string, string> { ["0_12"] = "95" };
+
+        // Act
+        var scripts = generator.GenerateAllScripts(baseline);
+        var bootScript = scripts.Values.First();
+
+        var speedtestSection = ExtractHeredocSection(bootScript, "SPEEDTEST_EOF");
+        var pingSection = ExtractHeredocSection(bootScript, "PING_EOF");
+
+        // Assert - IFB check must come BEFORE any tc usage in both scripts
+        var ifbCheckInSpeedtest = speedtestSection.IndexOf("ip link show \"$IFB_DEVICE\"");
+        var firstTcInSpeedtest = speedtestSection.IndexOf("update_all_tc_classes");
+        Assert.True(ifbCheckInSpeedtest >= 0, "IFB check missing from speedtest script");
+        Assert.True(firstTcInSpeedtest >= 0, "tc command missing from speedtest script");
+        Assert.True(ifbCheckInSpeedtest < firstTcInSpeedtest,
+            "IFB check must appear before the first tc command in speedtest script");
+
+        var ifbCheckInPing = pingSection.IndexOf("ip link show \"$IFB_DEVICE\"");
+        var firstTcInPing = pingSection.IndexOf("update_all_tc_classes");
+        Assert.True(ifbCheckInPing >= 0, "IFB check missing from ping script");
+        Assert.True(firstTcInPing >= 0, "tc command missing from ping script");
+        Assert.True(ifbCheckInPing < firstTcInPing,
+            "IFB check must appear before the first tc command in ping script");
+    }
+
+    [Theory]
+    [InlineData("eth0", "ifbeth0")]
+    [InlineData("eth2", "ifbeth2")]
+    [InlineData("eth3", "ifbeth3")]
+    [InlineData("eth4", "ifbeth4")]
+    public void GenerateAllScripts_IfbDeviceName_DerivedFromInterface(string iface, string expectedIfb)
+    {
+        // Arrange
+        var config = new SqmConfiguration
+        {
+            ConnectionName = "Test WAN",
+            Interface = iface,
+            MaxDownloadSpeed = 100,
+            MinDownloadSpeed = 50,
+            AbsoluteMaxDownloadSpeed = 110,
+            PingHost = "8.8.8.8"
+        };
+
+        var generator = new ScriptGenerator(config);
+        var baseline = new Dictionary<string, string> { ["0_12"] = "95" };
+
+        // Act
+        var scripts = generator.GenerateAllScripts(baseline);
+        var bootScript = scripts.Values.First();
+
+        // Assert - IFB device name is correctly derived for each interface
+        Assert.Contains($"IFB_DEVICE=\"{expectedIfb}\"", bootScript);
+    }
+
+    /// <summary>
+    /// Extracts the content between heredoc delimiters (e.g., between 'SPEEDTEST_EOF' markers).
+    /// </summary>
+    private static string ExtractHeredocSection(string script, string delimiter)
+    {
+        var startMarker = $"<< '{delimiter}'";
+        var startIdx = script.IndexOf(startMarker);
+        Assert.True(startIdx >= 0, $"Heredoc start marker '{startMarker}' not found");
+
+        var contentStart = script.IndexOf('\n', startIdx) + 1;
+        var endIdx = script.IndexOf($"\n{delimiter}\n", contentStart);
+        if (endIdx < 0)
+            endIdx = script.IndexOf($"\n{delimiter}", contentStart);
+
+        Assert.True(endIdx >= 0, $"Heredoc end marker '{delimiter}' not found");
+
+        return script[contentStart..endIdx];
     }
 }


### PR DESCRIPTION
## Summary

- **Independent section validation** - Tests now extract speedtest and ping heredoc sections separately and verify the IFB check exists in each one independently, rather than just checking the combined output where one could mask the other's absence
- **Ordering verification** - New test confirms the IFB device check appears before any `update_all_tc_classes` call in both scripts, which is the whole point of the guard
- **Interface name derivation** - Parameterized test covers eth0/eth2/eth3/eth4 to verify the `ifb{interface}` naming convention

## Test plan

- [x] All 248 tests pass, 0 warnings