### PR TITLE
Smooth WAN Speed History chart when zoomed out

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -996,8 +996,19 @@
                 .OrderBy(p => p.Timestamp)
                 .ToList();
 
-            wan.DownloadData = shouldDownsample ? DownsampleLttb(CollapseClusters(downloadRaw), MaxChartPoints) : downloadRaw;
-            wan.UploadData = shouldDownsample ? DownsampleLttb(CollapseClusters(uploadRaw), MaxChartPoints) : uploadRaw;
+            if (shouldDownsample)
+            {
+                // Downsample download, then sync upload to the same timestamps
+                // so shared tooltips can pair both values at each point
+                wan.DownloadData = DownsampleLttb(CollapseClusters(downloadRaw), MaxChartPoints);
+                var keptResultIds = wan.DownloadData.Select(d => d.ResultId).ToHashSet();
+                wan.UploadData = uploadRaw.Where(u => keptResultIds.Contains(u.ResultId)).ToList();
+            }
+            else
+            {
+                wan.DownloadData = downloadRaw;
+                wan.UploadData = uploadRaw;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- **LTTB downsampling** - When the time range is > 4 hours, each chart series is capped at 20 points using the Largest-Triangle-Three-Buckets algorithm, which selects real data points that best preserve the visual shape of the curve
- **Time-aware cluster collapsing** - Before LTTB runs, dense test bursts (multiple tests within 2 hours with similar values) are collapsed to remove noise, while points spread across hours/days are always kept to show connection stability
- **Synced upload/download timestamps** - Upload series uses the same data points as download so shared tooltips continue to show both values on hover

All chart points are real, unmodified test results - the algorithms only remove points, never average or interpolate.

## Test plan

- [ ] Check WAN Speed History at various time ranges (1hr, 24hr, 2 weeks, 30 days, All time)
- [ ] Verify tooltips show both download and upload values on hover
- [ ] Verify short time ranges (1hr, 4hr) show full unsampled data
- [ ] Check with multiple WAN connections visible