### PR TITLE
Fix SQM checkbox not wrapping on mobile

### DIFF
--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2336,6 +2336,11 @@ select.form-control {
         transform: none;
     }
 
+    .card-header-collapsible .card-header-right {
+        width: 100%;
+        justify-content: space-between;
+    }
+
     /* Filter tabs mobile - wrap below title, compact sizing */
     .filter-tabs {
         width: 100%;


### PR DESCRIPTION
## Summary

- **SQM config checkbox always wraps below card header on mobile** - The "Enable Adaptive SQM" checkbox in the WAN config card headers would only wrap to a new line when the viewport was narrow enough to overflow. Now it always wraps below the title on mobile (<=768px) for a consistent layout.

## Test plan

- [x] Open Adaptive SQM page on mobile or narrow viewport
- [x] Verify "Enable Adaptive SQM" checkbox wraps below "WAN Configuration" title
- [x] Verify chevron sits at the right end of the wrapped row
- [x] Verify other collapsible card headers (Config Optimizer) are unaffected