### PR TITLE
Fix signal log entry ordering in 7d/30d views

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -742,7 +742,7 @@
                                             var prev = i < _traceHistory.Count - 1 ? _traceHistory[i + 1] : null;
                                             <tr class="result-row @(_expandedTraceTimestamp == trace.Timestamp ? "expanded" : "")"
                                                 @onclick="() => ToggleTraceExpand(trace.Timestamp)">
-                                                <td>@trace.Timestamp.ToLocalTime().ToString("HH:mm:ss")</td>
+                                                <td>@FormatSignalTime(trace.Timestamp)</td>
                                                 <td>@(trace.HopCount?.ToString() ?? "—")</td>
                                                 <td>@(trace.BottleneckLinkSpeedMbps?.ToString("F0") ?? "—") Mbps</td>
                                                 <td class="trace-change-cell">


### PR DESCRIPTION
## Summary

- **Signal log ordering fix** - In 7d and 30d views, downsampling groups entries into time buckets (30-min or 1-hour). When a Local (polled/current) entry and a UniFi historic entry fall in the same bucket, they get identical timestamps and their display order was undefined. Adds a secondary sort by DataSource so the current/live entry always appears in the most recent position.
- **Trace change timestamps** - Trace Changes table was hardcoding `HH:mm:ss` format, hiding the date on older entries. Now uses `FormatSignalTime` which shows "MMM dd HH:mm:ss" for entries from previous days, matching the signal log behavior.

## Test plan

- [x] Open Client Dashboard for any Wi-Fi device
- [x] Switch to 30d signal log view - verify the current (no-dot) entry appears above UniFi (dot) entries at the same timestamp
- [x] Switch to 7d view - same check
- [x] Verify 24h and 1h views still display correctly
- [x] Check Trace Changes section - older entries should show date prefix (e.g., "Feb 19 16:35:59")