### PR TITLE
Smarter management VLAN DHCP audit: check fixed IPs instead of blanket warning

### DIFF
--- a/src/NetworkOptimizer.Audit/ConfigAuditEngine.cs
+++ b/src/NetworkOptimizer.Audit/ConfigAuditEngine.cs
@@ -814,7 +814,7 @@ public class ConfigAuditEngine
 
         var dnsIssues = _vlanAnalyzer.AnalyzeDnsConfiguration(ctx.Networks);
         var gatewayIssues = _vlanAnalyzer.AnalyzeGatewayConfiguration(ctx.Networks);
-        var mgmtDhcpIssues = _vlanAnalyzer.AnalyzeManagementVlanDhcp(ctx.Networks, gatewayName);
+        var mgmtDhcpIssues = _vlanAnalyzer.AnalyzeManagementVlanDhcp(ctx.Networks, ctx.Clients, gatewayName);
         // Note: Network isolation and internet access analysis moved to Phase 5 where firewall rules are available
         var infraVlanIssues = _vlanAnalyzer.AnalyzeInfrastructureVlanPlacement(ctx.DeviceData, ctx.Networks, gatewayName);
 

--- a/src/NetworkOptimizer.Audit/IssueTypes.cs
+++ b/src/NetworkOptimizer.Audit/IssueTypes.cs
@@ -33,7 +33,7 @@ public static class IssueTypes
     public const string DnsLeakage = "DNS_LEAKAGE";
     public const string DnsSharedServers = "DNS_SHARED_SERVERS";
     public const string RoutingEnabled = "ROUTING_ENABLED";
-    public const string MgmtDhcpEnabled = "MGMT_DHCP_ENABLED";
+    public const string MgmtNoFixedIps = "MGMT_NO_FIXED_IPS";
     public const string SecurityNetworkNotIsolated = "SECURITY_NETWORK_NOT_ISOLATED";
     public const string MgmtNetworkNotIsolated = "MGMT_NETWORK_NOT_ISOLATED";
     public const string IotNetworkNotIsolated = "IOT_NETWORK_NOT_ISOLATED";

--- a/src/NetworkOptimizer.Web/Services/AuditService.cs
+++ b/src/NetworkOptimizer.Web/Services/AuditService.cs
@@ -1565,7 +1565,7 @@ public class AuditService
 
         // VLAN security issues (includes device placement - putting devices on correct VLAN)
         "VLAN_VIOLATION" or "INTER_VLAN" or Audit.IssueTypes.RoutingEnabled => "VLAN Security",
-        Audit.IssueTypes.MgmtDhcpEnabled => "VLAN Security",
+        Audit.IssueTypes.MgmtNoFixedIps => "VLAN Security",
         Audit.IssueTypes.SecurityNetworkNotIsolated or Audit.IssueTypes.MgmtNetworkNotIsolated or Audit.IssueTypes.IotNetworkNotIsolated => "VLAN Security",
         Audit.IssueTypes.SecurityNetworkHasInternet or Audit.IssueTypes.MgmtNetworkHasInternet => "VLAN Security",
         Audit.IssueTypes.MgmtMissingUnifiAccess or Audit.IssueTypes.MgmtMissingAfcAccess or Audit.IssueTypes.MgmtMissingNtpAccess or Audit.IssueTypes.MgmtMissing5gAccess => "Firewall Rules",
@@ -1630,7 +1630,7 @@ public class AuditService
 
             // VLAN security
             Audit.IssueTypes.RoutingEnabled => "Routing on Isolated VLAN",
-            Audit.IssueTypes.MgmtDhcpEnabled => "Management VLAN Has DHCP Enabled",
+            Audit.IssueTypes.MgmtNoFixedIps => "Management VLAN: Devices Without Fixed IPs",
             Audit.IssueTypes.SecurityNetworkNotIsolated => "Security Network Not Isolated",
             Audit.IssueTypes.MgmtNetworkNotIsolated => "Management Network Not Isolated",
             Audit.IssueTypes.IotNetworkNotIsolated => "IoT Network Not Isolated",


### PR DESCRIPTION
## Summary

Closes #327. The old `MGMT-DHCP-001` rule blanket-flagged any management VLAN with DHCP enabled, recommending static IPs. This was too aggressive - DHCP reservations (fixed IPs) provide the same IP predictability while keeping operational flexibility (UniFi adoption, centralized subnet management).

- **New logic**: Only flags management VLANs where clients exist *without* DHCP reservations. If all clients have fixed IPs (or no clients are on the network), no issue is raised.
- **Updated message**: Lists which devices lack fixed IPs (up to 5 names, with "+N more" for larger networks)
- **Updated recommendation**: Points users to configure DHCP reservations in UniFi client settings instead of disabling DHCP entirely
- **Updated management network isolation recommendation**: "Enable Isolate Network or add inbound/outbound inter-VLAN blocking Firewall Rules to protect management infrastructure"
- Issue type renamed from `MGMT_DHCP_ENABLED` to `MGMT_NO_FIXED_IPS`

## Test plan

- [x] `dotnet build` - 0 warnings
- [x] `dotnet test` - 5,297 tests pass
- [x] 7 unit tests covering: clients without fixed IPs, all fixed IPs, no clients, DHCP disabled, native VLAN, null clients, name fallback
- [x] Run audit on network with management VLAN + DHCP enabled - verify new message lists devices without fixed IPs