### PR TITLE
Fix OpenSpeedTest port in Proxmox LXC installs

### DIFF
--- a/scripts/proxmox/install.sh
+++ b/scripts/proxmox/install.sh
@@ -658,7 +658,8 @@ deploy_application() {
     image: ghcr.io/ozark-connect/speedtest:latest
     container_name: network-optimizer-speedtest
     restart: unless-stopped
-    network_mode: host
+    ports:
+      - "${OPENSPEEDTEST_PORT:-3005}:3000"
     environment:
       - TZ=${TZ:-America/Chicago}
       - HOST_IP=${HOST_IP:-}
@@ -669,7 +670,7 @@ deploy_application() {
       - OPENSPEEDTEST_HTTPS_PORT=${OPENSPEEDTEST_HTTPS_PORT:-443}
       - REVERSE_PROXIED_HOST_NAME=${REVERSE_PROXIED_HOST_NAME:-}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:${OPENSPEEDTEST_PORT:-3005}/"]
+      test: ["CMD", "curl", "-f", "http://localhost:3000/"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary

- **OpenSpeedTest was listening on port 3000 instead of 3005** in Proxmox LXC installs. The install script used `network_mode: host` for the speedtest container, but nginx inside is hardcoded to listen on port 3000. With host networking there's no port mapping, so the configured port (3005) was never used. Switched to bridge networking with port mapping to match the production docker-compose.yml.
- Fixed the healthcheck to use the internal port (3000) since it runs inside the container.

Fixes #275

## Test plan

- [x] Run the Proxmox install script on a fresh LXC
- [x] Verify port 3005 is open and serves OpenSpeedTest
- [x] Verify port 3000 is no longer exposed
- [x] Verify the main app on 8042 can reach the speedtest server