### PR TITLE
Fix WAN detection for configs missing the enabled field

### DIFF
--- a/src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs
@@ -67,7 +67,7 @@ public class UniFiNetworkConfig
     public string Purpose { get; set; } = string.Empty; // "corporate", "guest", "wan", "vlan-only", "remote-user-vpn"
 
     [JsonPropertyName("enabled")]
-    public bool Enabled { get; set; }
+    public bool Enabled { get; set; } = true;
 
     [JsonPropertyName("is_nat")]
     public bool IsNat { get; set; }

--- a/tests/NetworkOptimizer.UniFi.Tests/UniFiNetworkConfigTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/UniFiNetworkConfigTests.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+using FluentAssertions;
+using NetworkOptimizer.UniFi.Models;
+using Xunit;
+
+namespace NetworkOptimizer.UniFi.Tests;
+
+/// <summary>
+/// Tests for UniFiNetworkConfig deserialization, particularly the "enabled" field behavior.
+/// Some UniFi firmware versions omit the "enabled" field for WAN configs (e.g., PPPoE on UCG-Fiber).
+/// </summary>
+public class UniFiNetworkConfigTests
+{
+    [Fact]
+    public void Deserialize_EnabledTrue_ReturnsTrue()
+    {
+        var json = """{ "name": "Internet 1", "purpose": "wan", "enabled": true }""";
+        var config = JsonSerializer.Deserialize<UniFiNetworkConfig>(json)!;
+        config.Enabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Deserialize_EnabledFalse_ReturnsFalse()
+    {
+        var json = """{ "name": "Disabled Net", "purpose": "corporate", "enabled": false }""";
+        var config = JsonSerializer.Deserialize<UniFiNetworkConfig>(json)!;
+        config.Enabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Deserialize_EnabledMissing_DefaultsToTrue()
+    {
+        // Some firmware versions omit "enabled" for WAN configs (e.g., PPPoE on UCG-Fiber).
+        // Missing should be treated as enabled, not disabled.
+        var json = """{ "name": "Internet 1", "purpose": "wan", "wan_type": "pppoe", "wan_networkgroup": "WAN" }""";
+        var config = JsonSerializer.Deserialize<UniFiNetworkConfig>(json)!;
+        config.Enabled.Should().BeTrue("missing 'enabled' field should default to true");
+    }
+
+    [Fact]
+    public void Deserialize_PppoeWanWithoutEnabled_IsIncludedInEnabledFilter()
+    {
+        // Real-world scenario: PPPoE WAN config from UCG-Fiber that omits the "enabled" field
+        var json = """
+        [
+            { "name": "Internet 1", "purpose": "wan", "wan_type": "pppoe", "wan_networkgroup": "WAN", "wan_smartq_enabled": true },
+            { "name": "Internet 2", "purpose": "wan", "wan_type": "dhcp", "wan_networkgroup": "WAN2" },
+            { "name": "Corporate", "purpose": "corporate", "enabled": true }
+        ]
+        """;
+
+        var configs = JsonSerializer.Deserialize<List<UniFiNetworkConfig>>(json)!;
+        var wanConfigs = configs.Where(c => c.Purpose == "wan" && c.Enabled).ToList();
+
+        wanConfigs.Should().HaveCount(2, "both WAN configs should be treated as enabled when field is missing");
+        wanConfigs.Should().Contain(c => c.Name == "Internet 1");
+        wanConfigs.Should().Contain(c => c.Name == "Internet 2");
+    }
+
+    [Fact]
+    public void Deserialize_ExplicitlyDisabledWan_IsExcludedFromEnabledFilter()
+    {
+        var json = """
+        [
+            { "name": "Internet 1", "purpose": "wan", "enabled": true, "wan_networkgroup": "WAN" },
+            { "name": "Internet 2", "purpose": "wan", "enabled": false, "wan_networkgroup": "WAN2" }
+        ]
+        """;
+
+        var configs = JsonSerializer.Deserialize<List<UniFiNetworkConfig>>(json)!;
+        var wanConfigs = configs.Where(c => c.Purpose == "wan" && c.Enabled).ToList();
+
+        wanConfigs.Should().HaveCount(1);
+        wanConfigs.First().Name.Should().Be("Internet 1");
+    }
+}


### PR DESCRIPTION
## Summary

- **Fix WAN interface detection on firmware that omits the `enabled` field** - Some UniFi firmware versions (observed on UCG-Fiber with PPPoE) don't include the `"enabled"` field in WAN network configs from `rest/networkconf`. The `bool` property defaulted to `false`, causing all WAN interfaces to be treated as disabled. Changed the default to `true` so a missing field means enabled. Explicitly disabled WANs (`"enabled": false`) are still correctly filtered out.

Fixes #330

## Test plan

- [x] New deserialization tests for missing, true, and false `enabled` field
- [x] All 4,803 existing tests pass
- [x] Deploy to NAS and verify WAN detection works as before
- [x] Ask issue reporter to test with updated build