### PR TITLE
Fix threat timeline chart stalling when no new threats

### DIFF
--- a/src/NetworkOptimizer.Web/Services/ThreatDashboardService.cs
+++ b/src/NetworkOptimizer.Web/Services/ThreatDashboardService.cs
@@ -253,7 +253,8 @@ public class ThreatDashboardService
 
             // Fill gaps with zero-count buckets so the chart shows continuous time progression
             // instead of stalling at the last data point when there are no new threats.
-            return FillTimelineGaps(buckets, from, to, bucketMinutes);
+            // Lag by 30s so we don't plot a false zero before the current collection cycle finishes.
+            return FillTimelineGaps(buckets, from, to.AddSeconds(-30), bucketMinutes);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary

- **Fill zero-count buckets in timeline gaps** - The threat timeline chart now plots explicit zeros at each bucket interval when there are no new threats, instead of freezing at the last data point and appearing stuck.
- **Start from first real data point** - Only fills zeros forward from the earliest event in the DB, so selecting a 24h range with only 2h of data doesn't show 22h of fake zeros before actual data.
- **30s trailing lag** - Stops filling 30 seconds before "now" to avoid flashing a false zero before the current collection cycle has reported in.

## Test plan

- [x] Open Threat Dashboard and observe timeline chart advancing with zeros during quiet periods
- [x] Switch between time ranges (1h, 4h, 24h) and verify no backfilled zeros before first real data
- [x] Verify the trailing edge doesn't flash zero before real data arrives on next 30s refresh