### PR TITLE
Tighten port range grouping in Threat Intelligence tables

### DIFF
--- a/src/NetworkOptimizer.Web/Services/ThreatDashboardService.cs
+++ b/src/NetworkOptimizer.Web/Services/ThreatDashboardService.cs
@@ -727,8 +727,8 @@ public class ThreatDashboardService
     {
         if (sortedPorts.Count == 0) return "-";
 
-        // First pass: collapse only consecutive ports (gap=1)
-        var ranges = CollapsePortsWithGap(sortedPorts, 1);
+        // First pass: collapse ports within 10 of each other
+        var ranges = CollapsePortsWithGap(sortedPorts, 10);
 
         // If still more than 10 entries, group tighter (ports within 100 of each other)
         if (ranges.Count > 10)


### PR DESCRIPTION
## Summary

- Ports in the Destinations Accessed and Sources Targeting columns now group more aggressively to reduce visual clutter
- First pass collapses ports within 10 of each other into ranges
- If still more than 10 entries, a second pass groups ports within 100 of each other
- Only affects the display string in those two table columns; the drilldown Port Ranges detail table is unchanged

## Test plan

- [x] Open Threat Intelligence, drill down on an IP with many destination ports
- [x] Verify Destinations Accessed port ranges column is visually compact
- [x] Verify Sources Targeting port ranges column is similarly compact
- [x] Verify the Port Ranges detail section (with per-port event counts) still shows individual ports/ranges as before
- [x] Check an IP with fewer than 10 ports - should show gap=10 grouping (e.g. ports 80 and 88 merge to 80-88)