### PR TITLE
Fix duplicate threat pattern and attack chain alerts (#360)

### DIFF
--- a/src/NetworkOptimizer.Storage/Repositories/ThreatRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/ThreatRepository.cs
@@ -790,8 +790,10 @@ public class ThreatRepository : IThreatRepository
     {
         try
         {
-            // Dedup: match on DedupKey (stable across runs) or fall back to SourceIpsJson for old patterns
-            var cutoff = DateTime.UtcNow.AddHours(-1);
+            // Dedup: match on DedupKey (stable across runs) or fall back to SourceIpsJson for old patterns.
+            // 6h window matches the longest detection window (ScanSweep/BruteForce). Ongoing attacks
+            // get merged within the window; resumed activity after 6h gets a fresh alert.
+            var cutoff = DateTime.UtcNow.AddHours(-6);
             var existing = pattern.DedupKey != null
                 ? await _context.ThreatPatterns
                     .FirstOrDefaultAsync(p =>


### PR DESCRIPTION
## Summary

- **Pattern dedup window widened to 6h** - The dedup cutoff for threat patterns (ScanSweep, BruteForce, etc.) was only 1 hour, but detectors use a 6-hour sliding window. Ongoing scans created duplicate DB rows and fresh alerts every hour. Now matches the detection window so the same attack merges into a single pattern.
- **Early-stage chain cooldown** - Early-stage attack chains (Recon -> Attempted Exploitation) re-alerted on every new event because the 50% growth threshold was too sensitive for slow-drip scans (2 events -> 3 = 50%). Added a 6-hour cooldown and raised threshold to 2x growth. Full chains (ending in ActiveExploitation/PostExploitation) keep the original aggressive alerting.

## Test plan

- [x] Verify no duplicate ScanSweep alerts for the same IP within 6 hours
- [x] Verify early-stage chain alerts don't re-fire within 6h for same IP with slow event growth
- [x] Verify full chain alerts still fire aggressively on any stage progression
- [x] Verify a genuinely new scan (different IP) still creates a fresh alert