### PR TITLE
Fix threat dashboard mobile viewport overflow

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/ThreatDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ThreatDashboard.razor
@@ -1728,6 +1728,7 @@ else
     @@media (max-width: 768px) {
         .threat-header-bar {
             flex-direction: column;
+            flex-wrap: nowrap;
             align-items: stretch;
             gap: 0.5rem;
         }


### PR DESCRIPTION
## Summary

- **Fix horizontal overflow on mobile** - The threat dashboard header bar inherited `flex-wrap: wrap` into its mobile column layout, which allowed flex items to create extra horizontal columns and break the viewport width. Adding `flex-wrap: nowrap` at the 768px breakpoint keeps items stacked vertically as intended.

## Test plan

- [x] Open Threat Intelligence on a mobile device or narrow browser window (<768px)
- [x] Verify no horizontal scrollbar / viewport overflow
- [x] Verify tabs and time controls stack vertically and remain usable
- [x] Verify desktop layout (>768px) still wraps correctly when window is narrow