### PR TITLE
Don't flag 802.1x ports with curated VLAN lists

### DIFF
--- a/src/NetworkOptimizer.Audit/Rules/IAuditRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/IAuditRule.cs
@@ -279,14 +279,16 @@ public abstract class AuditRuleBase : IAuditRule
         string message,
         PortInfo port,
         Dictionary<string, object>? metadata = null,
-        string? recommendedAction = null)
+        string? recommendedAction = null,
+        AuditSeverity? overrideSeverity = null,
+        int? overrideScoreImpact = null)
     {
         var deviceName = GetBestDeviceName(port);
 
         return new AuditIssue
         {
             Type = RuleId,
-            Severity = Severity,
+            Severity = overrideSeverity ?? Severity,
             Message = message,
             DeviceName = deviceName,
             DeviceMac = port.Switch.MacAddress,
@@ -295,7 +297,7 @@ public abstract class AuditRuleBase : IAuditRule
             Metadata = metadata,
             RecommendedAction = recommendedAction,
             RuleId = RuleId,
-            ScoreImpact = ScoreImpact
+            ScoreImpact = overrideScoreImpact ?? ScoreImpact
         };
     }
 


### PR DESCRIPTION
## Summary

Fixes #367. Ports configured with 802.1X MAC-based authentication legitimately need multiple tagged VLANs for RADIUS dynamic VLAN assignment. The `AccessPortVlanRule` was flagging these as "Excessive Tagged VLANs" even when the admin intentionally curated the VLAN list.

- **802.1X + custom VLAN set**: Skip entirely - trust the admin's intent
- **802.1X + "Allow All"**: Downgrade to Informational (score 2 instead of 6) with 802.1X-aware messaging
- **force_authorized / null**: Normal rule behavior unchanged

Also adds `overrideSeverity` and `overrideScoreImpact` optional parameters to the base `CreateIssue()` method so any rule can downgrade specific cases without changing its default severity.

## Test plan

- [x] 14 new tests covering all 802.1X scenarios (86 total, all passing)
- [x] `mac_based` and `auto` with custom VLAN sets return null
- [x] `mac_based` and `auto` with Allow All return Informational/score 2
- [x] `force_authorized` and null Dot1xCtrl fall through to normal rule
- [x] No connected client, down port, zero networks, empty excluded list
- [x] `allNetworks` parameter used correctly for VLAN counting
- [x] 802.1X takes priority over server detection (Informational, not Recommended)
- [x] Zero build warnings