### PR TITLE
Suppress Hardware Acceleration warning when NetFlow is enabled

### DIFF
--- a/src/NetworkOptimizer.Core/VendorSpecificAttribute.cs
+++ b/src/NetworkOptimizer.Core/VendorSpecificAttribute.cs
@@ -1,0 +1,21 @@
+namespace NetworkOptimizer.Core;
+
+/// <summary>
+/// Marks code that contains vendor-specific assumptions (raw JSON parsing, property names, API behavior).
+/// Phase 1: inventory of spots to replace with strongly-typed models and safe deserialization.
+/// Phase 2: abstract behind vendor-neutral interfaces for multi-vendor support.
+/// </summary>
+[AttributeUsage(
+    AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Parameter,
+    AllowMultiple = false)]
+public sealed class VendorSpecificAttribute : Attribute
+{
+    public string Vendor { get; }
+    public string? Notes { get; }
+
+    public VendorSpecificAttribute(string vendor, string? notes = null)
+    {
+        Vendor = vendor;
+        Notes = notes;
+    }
+}

--- a/src/NetworkOptimizer.UniFi/Helpers/GlobalSwitchSettings.cs
+++ b/src/NetworkOptimizer.UniFi/Helpers/GlobalSwitchSettings.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using NetworkOptimizer.Core;
 using NetworkOptimizer.UniFi.Models;
 
 namespace NetworkOptimizer.UniFi.Helpers;
@@ -8,6 +9,7 @@ namespace NetworkOptimizer.UniFi.Helpers;
 /// Devices listed in switch_exclusions use their own device-level settings;
 /// all other devices inherit from the global values.
 /// </summary>
+[VendorSpecific("UniFi", "Parses UniFi settings JSON 'data' array with 'key' discriminator (global_switch)")]
 public class GlobalSwitchSettings
 {
     public bool JumboFramesEnabled { get; init; }


### PR DESCRIPTION
Closes #325

## Summary

- **Suppress HW accel recommendation when NetFlow is active** - NetFlow requires CPU-based packet inspection, so Hardware Acceleration can't be enabled. The Config Optimizer now checks the controller settings for NetFlow and skips the recommendation instead of showing an unresolvable warning.
- **Add `[VendorSpecific]` attribute** - New `NetworkOptimizer.Core.VendorSpecificAttribute` for marking code that parses raw vendor JSON or reads vendor-specific properties. This builds an inventory for two future refactor phases: strong typing first, then vendor abstraction.
- **Annotate existing vendor-coupled methods** - Applied `[VendorSpecific("UniFi")]` to `PerformanceAnalyzer` checks and `GlobalSwitchSettings` to start the inventory.

## Test plan

- [x] 6 new tests covering NetFlow suppression and `IsNetFlowEnabled` edge cases
- [x] All 81 PerformanceAnalyzer tests pass
- [x] 0 build warnings