### PR TITLE
Fix smart speakers not covered by 'Allow all media players' audit setting

### DIFF
--- a/src/NetworkOptimizer.Audit/Models/DeviceAllowanceSettings.cs
+++ b/src/NetworkOptimizer.Audit/Models/DeviceAllowanceSettings.cs
@@ -56,10 +56,14 @@ public class DeviceAllowanceSettings
 
     /// <summary>
     /// Check if a smart speaker should be allowed on main network based on vendor.
-    /// Apple HomePods are categorized as SmartSpeaker, so we check AllowAppleStreamingOnMainNetwork.
+    /// Smart speakers are covered by AllowMediaPlayersOnMainNetwork (they are media devices).
+    /// Apple HomePods are also covered by AllowAppleStreamingOnMainNetwork.
     /// </summary>
     public bool IsSmartSpeakerAllowed(string? vendor)
     {
+        if (AllowMediaPlayersOnMainNetwork)
+            return true;
+
         if (AllowAppleStreamingOnMainNetwork &&
             !string.IsNullOrEmpty(vendor) &&
             vendor.Contains("Apple", StringComparison.OrdinalIgnoreCase))

--- a/src/NetworkOptimizer.Audit/Rules/VlanPlacementChecker.cs
+++ b/src/NetworkOptimizer.Audit/Rules/VlanPlacementChecker.cs
@@ -293,7 +293,7 @@ public static class VlanPlacementChecker
         {
             ClientDeviceCategory.StreamingDevice => "streaming-devices",
             ClientDeviceCategory.SmartTV => "smart-tvs",
-            ClientDeviceCategory.SmartSpeaker => "streaming-devices", // Apple HomePod uses same setting
+            ClientDeviceCategory.SmartSpeaker => "media-players", // Smart speakers are media devices
             ClientDeviceCategory.MediaPlayer => "media-players",
             ClientDeviceCategory.Printer => "printers",
             _ => null

--- a/tests/NetworkOptimizer.Audit.Tests/Models/DeviceAllowanceSettingsTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Models/DeviceAllowanceSettingsTests.cs
@@ -207,6 +207,18 @@ public class DeviceAllowanceSettingsTests
     }
 
     [Fact]
+    public void IsSmartSpeakerAllowed_AllowMediaPlayers_ReturnsTrue_ForAnyVendor()
+    {
+        var settings = new DeviceAllowanceSettings { AllowMediaPlayersOnMainNetwork = true };
+
+        settings.IsSmartSpeakerAllowed("Amazon").Should().BeTrue();
+        settings.IsSmartSpeakerAllowed("Google").Should().BeTrue();
+        settings.IsSmartSpeakerAllowed("Sonos").Should().BeTrue();
+        settings.IsSmartSpeakerAllowed("Apple").Should().BeTrue();
+        settings.IsSmartSpeakerAllowed(null).Should().BeTrue();
+    }
+
+    [Fact]
     public void IsSmartSpeakerAllowed_AllowAppleStreaming_ReturnsFalse_ForNullVendor()
     {
         var settings = new DeviceAllowanceSettings { AllowAppleStreamingOnMainNetwork = true };


### PR DESCRIPTION
Fixes #378

## Summary

- Smart speakers (Google Home, Amazon Echo, Sonos, etc.) are now covered by the "Allow all media players on main network" audit setting
- Previously only Apple HomePods could be suppressed (via the Apple streaming setting) - all other smart speakers always generated a VLAN placement warning regardless of settings
- Updated settings gear metadata to point to media players setting instead of streaming devices

## Test plan

- [x] Existing tests pass (35/35 in DeviceAllowanceSettingsTests)
- [x] New test: `IsSmartSpeakerAllowed_AllowMediaPlayers_ReturnsTrue_ForAnyVendor`
- [x] Zero build warnings
- [x] Deploy and verify: enable "Allow all media players", run audit, confirm smart speakers show as Informational (not Recommended)