### PR TITLE
Exempt Security and Management networks from DNS DNAT requirement

### DIFF
--- a/src/NetworkOptimizer.Audit/IssueTypes.cs
+++ b/src/NetworkOptimizer.Audit/IssueTypes.cs
@@ -82,6 +82,7 @@ public static class IssueTypes
     // DNS Zone-Specific Info Issues
     public const string DnsDmzNetworkInfo = "DNS_DMZ_NETWORK_INFO";
     public const string DnsGuestThirdPartyInfo = "DNS_GUEST_THIRD_PARTY_INFO";
+    public const string DnsInfraNetworkInfo = "DNS_INFRA_NETWORK_INFO";
 
     // DNS Bypass Issues
     public const string DnsExternalBypass = "DNS_EXTERNAL_BYPASS";

--- a/src/NetworkOptimizer.Web/Services/AuditService.cs
+++ b/src/NetworkOptimizer.Web/Services/AuditService.cs
@@ -1888,6 +1888,7 @@ public class AuditService
             Audit.IssueTypes.DnsDnatRestrictedDestination => "DNS: Restricted DNAT Destination",
             Audit.IssueTypes.DnsDmzNetworkInfo => "DNS: DMZ Network Info",
             Audit.IssueTypes.DnsGuestThirdPartyInfo => "DNS: Guest Network Info",
+            Audit.IssueTypes.DnsInfraNetworkInfo => "DNS: Infrastructure Network Info",
             Audit.IssueTypes.DnsExternalBypass => "DNS: External DNS Bypass",
 
             // UPnP security


### PR DESCRIPTION
## Summary

- **Security and Management networks** now get an Informational issue (zero score impact) instead of a Recommended issue when not covered by DNS DNAT rules or third-party DNS
- These infrastructure networks (cameras, network admin devices) may work best with gateway DNS - no need to flag them
- Follows the existing DMZ and Guest network exemption pattern

Closes #379

## Test plan

- [x] 4 new tests covering Security, Management, DNAT partial coverage, and mixed network separation
- [x] Full test suite passes (5,641 tests, zero failures)
- [x] Deploy to NAS and run audit on a network with Security/Management VLANs