### PR TITLE
Show mid-cycle adjustment hint when enabling data usage tracking

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -468,7 +468,7 @@
                     var isAdjustmentUnlocked = _unlockedAdjustmentWans.Contains(wanGroup);
                     var isDirty = _dirtyConfigs.Contains(wanGroup);
 
-                    <div class="schedule-section">
+                    <div class="schedule-section" @key="wanGroup">
                         <h2 class="schedule-section-title" style="display: flex; align-items: center;">
                             @displayName <span style="color: var(--text-muted); font-weight: normal; margin-left: 0.25rem;">(@DisplayFormatters.NormalizeWanDisplay(wanGroup))</span>
                             @if (_wanUpStatus.TryGetValue(wanGroup, out var isUp) && isUp)


### PR DESCRIPTION
## Summary

- When a user first enables WAN data usage tracking mid-billing-cycle, shows an info banner explaining that prior usage won't be captured and suggesting they use the Usage Adjustment field as a one-time correction
- Uses the actual billing cycle dates (via `GetBillingCycleDates`) to determine how far into the cycle we are, rather than a naive day-of-month check
- Suppresses the hint when near the cycle start (<2 days in) or near the cycle end (<3 days remaining) since it wouldn't be useful in either case
- Hint dismisses automatically on save or when the user sets a non-zero adjustment

Closes #376

## Test plan

- [x] Enable data usage tracking on a WAN with billing day set far from today - verify info banner appears
- [x] Set billing day to today or yesterday - verify hint does not appear
- [x] Set billing day so cycle ends in 1-2 days - verify hint does not appear
- [x] Enter a non-zero Usage Adjustment value - verify hint disappears
- [x] Click Save - verify hint disappears and does not reappear on page reload
- [x] Toggle tracking off and back on - verify hint reappears (if mid-cycle)