### PR TITLE
Fix notes auto-save on paste and add save-on-blur

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/UpnpInspector.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/UpnpInspector.razor
@@ -174,9 +174,8 @@
                                                            placeholder="Add notes..."
                                                            value="@GetNote(GetNoteKey(rule))"
                                                            @oninput="@(e => OnNoteInput(rule, e.Value?.ToString()))"
-                                                           @onkeyup="@(e => OnNoteKeyUp(rule))"
                                                            @onfocus="@(() => currentEditingNote = GetNoteKey(rule))"
-                                                           @onblur="@(() => { var k = GetNoteKey(rule); if (currentEditingNote == k) currentEditingNote = null; })" />
+                                                           @onfocusout="@(() => OnNoteBlur(rule))" />
                                                     @if (IsNoteSaving(GetNoteKey(rule)))
                                                     {
                                                         <span class="note-status saving">Saving...</span>
@@ -361,13 +360,14 @@
             notes.Remove(noteKey);
         else
             notes[noteKey] = newNote ?? "";
+
+        DebounceSaveNote(rule);
     }
 
-    private void OnNoteKeyUp(UniFiPortForwardRule rule)
+    private void DebounceSaveNote(UniFiPortForwardRule rule)
     {
         var noteKey = GetNoteKey(rule);
 
-        // Reset debounce timer on each keystroke
         if (_noteDebounceTimers.TryGetValue(noteKey, out var existingTimer))
         {
             existingTimer.Stop();
@@ -375,11 +375,26 @@
         }
         savedNotes.Remove(noteKey);
 
-        var timer = new System.Timers.Timer(800); // Match SpeedTestDetails debounce
+        var timer = new System.Timers.Timer(800);
         timer.AutoReset = false;
         timer.Elapsed += async (s, e) => await InvokeAsync(() => SaveNoteAsync(rule));
         _noteDebounceTimers[noteKey] = timer;
         timer.Start();
+    }
+
+    private async Task OnNoteBlur(UniFiPortForwardRule rule)
+    {
+        var noteKey = GetNoteKey(rule);
+        if (currentEditingNote == noteKey) currentEditingNote = null;
+
+        // Cancel pending debounce and save immediately
+        if (_noteDebounceTimers.TryGetValue(noteKey, out var existingTimer))
+        {
+            existingTimer.Stop();
+            existingTimer.Dispose();
+            _noteDebounceTimers.Remove(noteKey);
+        }
+        await SaveNoteAsync(rule);
     }
 
     private async Task SaveNoteAsync(UniFiPortForwardRule rule)

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -184,9 +184,9 @@
                     <div class="result-notes" @onclick:stopPropagation="true">
                         <textarea class="notes-input"
                                   placeholder="Add notes..."
-                                  @bind="_notesInput"
-                                  @bind:event="oninput"
-                                  @onkeyup="OnNotesKeyUp"
+                                  value="@_notesInput"
+                                  @oninput="OnNotesInput"
+                                  @onfocusout="OnNotesBlur"
                                   rows="2"></textarea>
                         @if (_notesSaving)
                         {
@@ -1089,17 +1089,30 @@
         builder.AddContent(0, GetHopIcon(hop.Type));
     };
 
-    private void OnNotesKeyUp(KeyboardEventArgs e)
+    private void DebounceSaveNotes()
     {
-        // Reset debounce timer on each keystroke
         _notesDebounceTimer?.Stop();
         _notesDebounceTimer?.Dispose();
         _notesSaved = false;
 
-        _notesDebounceTimer = new System.Timers.Timer(800); // Longer debounce for notes
+        _notesDebounceTimer = new System.Timers.Timer(800);
         _notesDebounceTimer.AutoReset = false;
         _notesDebounceTimer.Elapsed += async (s, e) => await InvokeAsync(SaveNotes);
         _notesDebounceTimer.Start();
+    }
+
+    private void OnNotesInput(ChangeEventArgs e)
+    {
+        _notesInput = e.Value?.ToString() ?? "";
+        DebounceSaveNotes();
+    }
+
+    private async Task OnNotesBlur()
+    {
+        // Cancel any pending debounce and save immediately
+        _notesDebounceTimer?.Stop();
+        _notesDebounceTimer?.Dispose();
+        await SaveNotes();
     }
 
     private async Task SaveNotes()


### PR DESCRIPTION
## Summary

- **Notes fields now save on paste** - Replaced `@onkeyup` (which doesn't fire on paste) with `@oninput`, which fires on any text change including paste, drag-and-drop, and context menu paste.
- **Save on blur** - Notes now save immediately when the field loses focus, cancelling any pending debounce. No double-save risk thanks to the existing unchanged-value guard.
- **Common debounce path** - Both typing and paste go through the same `DebounceSaveNotes` method.

Applies to both Speed Test detail notes and UPnP Inspector notes.

## Test plan

- [x] Type in a speed test notes field, verify it auto-saves after 800ms
- [x] Paste text (Ctrl+V and right-click paste), verify it auto-saves
- [x] Click away from the field (blur), verify immediate save
- [x] Same tests on UPnP Inspector notes