### PR TITLE
Fix duplicate camera VLAN issues for Wi-Fi Protect cameras

### DIFF
--- a/src/NetworkOptimizer.Audit/ConfigAuditEngine.cs
+++ b/src/NetworkOptimizer.Audit/ConfigAuditEngine.cs
@@ -303,8 +303,8 @@ public class ConfigAuditEngine
         ExecutePhase1_ExtractNetworks(ctx);
         ExecutePhase2_ExtractSwitches(ctx);
         ExecutePhase3_AnalyzePortSecurity(ctx);
-        ExecutePhase3a_ProtectCameraFallback(ctx);
         ExecutePhase3b_AnalyzeWirelessClients(ctx);
+        ExecutePhase3a_ProtectCameraFallback(ctx);
         ExecutePhase3c_AnalyzeOfflineClients(ctx);
         ExecutePhase4_AnalyzeNetworkConfiguration(ctx);
         ExecutePhase5_AnalyzeFirewallRules(ctx);
@@ -548,6 +548,14 @@ public class ConfigAuditEngine
         {
             if (issue.Metadata?.TryGetValue("camera_mac", out var macObj) == true && macObj is string mac)
                 alreadyFlaggedMacs.Add(mac);
+        }
+
+        // Also skip cameras that are wireless clients - Phase 3b will flag them
+        // with richer context (AP name, band, signal strength)
+        foreach (var client in ctx.WirelessClients)
+        {
+            if (!string.IsNullOrEmpty(client.Mac))
+                alreadyFlaggedMacs.Add(client.Mac);
         }
 
         var fallbackIssues = ctx.SecurityEngine.AnalyzeProtectCameraPlacement(ctx.Switches, ctx.Networks, alreadyFlaggedMacs);


### PR DESCRIPTION
## Summary

- **Fix duplicate audit issues for Wi-Fi connected Protect cameras** - Cameras like the G6 Instant that connect via Wi-Fi were flagged twice: once by the Protect API fallback (Phase 3a) and again by the wireless client rule (Phase 3b). Fixed by running wireless client extraction before the fallback and adding all wireless client MACs to the skip set, so the wireless rule handles them with richer context (AP name, band, signal).
- **Two new dedup tests** covering wireless camera skip and mixed wired/wireless scenarios.

## Test plan

- [x] All 12 fallback tests pass (10 existing + 2 new)
- [x] Full suite passes (3,964 tests, 0 failures, 0 warnings)
- [x] Deploy to two test sites, run audit, verify single issue for Wi-Fi camera (not duplicate), and no regression on wired camera rule