### PR TITLE
Add ntfy.sh as a notification channel

### DIFF
--- a/src/NetworkOptimizer.Alerts/Delivery/NtfyChannelConfig.cs
+++ b/src/NetworkOptimizer.Alerts/Delivery/NtfyChannelConfig.cs
@@ -1,0 +1,10 @@
+namespace NetworkOptimizer.Alerts.Delivery;
+
+public class NtfyChannelConfig
+{
+    public string ServerUrl { get; set; } = "https://ntfy.sh";
+    public string Topic { get; set; } = string.Empty;
+    public string? AccessToken { get; set; } // Stored encrypted, for Bearer auth
+    public string? Username { get; set; }
+    public string? Password { get; set; } // Stored encrypted, for Basic auth
+}

--- a/src/NetworkOptimizer.Alerts/Delivery/NtfyDeliveryChannel.cs
+++ b/src/NetworkOptimizer.Alerts/Delivery/NtfyDeliveryChannel.cs
@@ -1,0 +1,212 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using NetworkOptimizer.Alerts.Events;
+using NetworkOptimizer.Alerts.Models;
+using NetworkOptimizer.Core.Enums;
+
+namespace NetworkOptimizer.Alerts.Delivery;
+
+/// <summary>
+/// Delivery channel for ntfy.sh push notifications using the JSON publishing API.
+/// Supports both public ntfy.sh and self-hosted instances.
+/// </summary>
+public class NtfyDeliveryChannel : IAlertDeliveryChannel
+{
+    private readonly ILogger<NtfyDeliveryChannel> _logger;
+    private readonly HttpClient _httpClient;
+    private readonly ISecretDecryptor _secretDecryptor;
+
+    public DeliveryChannelType ChannelType => DeliveryChannelType.Ntfy;
+
+    public NtfyDeliveryChannel(ILogger<NtfyDeliveryChannel> logger, HttpClient httpClient, ISecretDecryptor secretDecryptor)
+    {
+        _logger = logger;
+        _httpClient = httpClient;
+        _secretDecryptor = secretDecryptor;
+    }
+
+    public async Task<bool> SendAsync(AlertEvent alertEvent, AlertHistoryEntry historyEntry, DeliveryChannel channel, CancellationToken cancellationToken = default)
+    {
+        var config = JsonSerializer.Deserialize<NtfyChannelConfig>(channel.ConfigJson);
+        if (config == null || string.IsNullOrEmpty(config.Topic)) return false;
+
+        var message = FormatMessage(alertEvent);
+
+        var payload = JsonSerializer.Serialize(new
+        {
+            topic = config.Topic,
+            title = alertEvent.Title,
+            message,
+            priority = MapPriority(alertEvent.Severity),
+            tags = new[] { MapTag(alertEvent.Severity) },
+            markdown = true
+        });
+
+        return await PostAsync(config, payload, cancellationToken);
+    }
+
+    public async Task<bool> SendDigestAsync(IReadOnlyList<AlertHistoryEntry> alerts, DeliveryChannel channel, DigestSummary summary, CancellationToken cancellationToken = default)
+    {
+        var config = JsonSerializer.Deserialize<NtfyChannelConfig>(channel.ConfigJson);
+        if (config == null || string.IsNullOrEmpty(config.Topic)) return false;
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"**{summary.TotalCount} alerts** in this period");
+        if (summary.CriticalCount > 0) sb.AppendLine($"- Critical: {summary.CriticalCount}");
+        if (summary.ErrorCount > 0) sb.AppendLine($"- Error: {summary.ErrorCount}");
+        if (summary.WarningCount > 0) sb.AppendLine($"- Warning: {summary.WarningCount}");
+        if (summary.InfoCount > 0) sb.AppendLine($"- Info: {summary.InfoCount}");
+
+        sb.AppendLine();
+
+        foreach (var alert in alerts.OrderByDescending(a => a.Severity).Take(10))
+        {
+            sb.AppendLine($"- **{alert.Title}** - {alert.Source} ({TimestampFormatter.FormatLocalShort(alert.TriggeredAt)})");
+        }
+
+        if (alerts.Count > 10)
+            sb.AppendLine($"\n...and {alerts.Count - 10} more alerts");
+
+        // Use highest severity for priority
+        var maxSeverity = alerts.Max(a => a.Severity);
+
+        var payload = JsonSerializer.Serialize(new
+        {
+            topic = config.Topic,
+            title = "Alert Digest",
+            message = sb.ToString().TrimEnd(),
+            priority = MapPriority(maxSeverity),
+            tags = new[] { "bell" },
+            markdown = true
+        });
+
+        return await PostAsync(config, payload, cancellationToken);
+    }
+
+    public async Task<(bool Success, string? Error)> TestAsync(DeliveryChannel channel, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var config = JsonSerializer.Deserialize<NtfyChannelConfig>(channel.ConfigJson);
+            if (config == null || string.IsNullOrEmpty(config.Topic))
+                return (false, "Invalid channel configuration");
+
+            var payload = JsonSerializer.Serialize(new
+            {
+                topic = config.Topic,
+                title = "Network Optimizer - Test",
+                message = "Alert channel test successful.",
+                priority = 3,
+                tags = new[] { "white_check_mark" },
+                markdown = true
+            });
+
+            var success = await PostAsync(config, payload, cancellationToken);
+            return success ? (true, null) : (false, "ntfy POST failed");
+        }
+        catch (Exception ex)
+        {
+            return (false, ex.Message);
+        }
+    }
+
+    private async Task<bool> PostAsync(NtfyChannelConfig config, string payload, CancellationToken cancellationToken)
+    {
+        var url = $"{config.ServerUrl.TrimEnd('/')}";
+
+        const int maxRetries = 2;
+        for (int attempt = 0; attempt <= maxRetries; attempt++)
+        {
+            try
+            {
+                var request = new HttpRequestMessage(HttpMethod.Post, url);
+                request.Content = new StringContent(payload, Encoding.UTF8, "application/json");
+
+                // Add auth header if configured
+                if (!string.IsNullOrEmpty(config.AccessToken))
+                {
+                    var token = _secretDecryptor.Decrypt(config.AccessToken);
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                }
+                else if (!string.IsNullOrEmpty(config.Username) && !string.IsNullOrEmpty(config.Password))
+                {
+                    var password = _secretDecryptor.Decrypt(config.Password);
+                    var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{config.Username}:{password}"));
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+                }
+
+                var response = await _httpClient.SendAsync(request, cancellationToken);
+                if (response.IsSuccessStatusCode)
+                {
+                    _logger.LogDebug("ntfy message delivered to {Topic}", config.Topic);
+                    return true;
+                }
+
+                _logger.LogWarning("ntfy POST returned {StatusCode}", response.StatusCode);
+                if (attempt < maxRetries)
+                    await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, attempt + 1)), cancellationToken);
+            }
+            catch (Exception ex) when (attempt < maxRetries)
+            {
+                _logger.LogWarning("ntfy attempt {Attempt} failed: {Error}", attempt + 1, ex.Message);
+                await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, attempt + 1)), cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to deliver to ntfy");
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    private static string FormatMessage(AlertEvent alertEvent)
+    {
+        var sb = new StringBuilder();
+        if (!string.IsNullOrEmpty(alertEvent.Message))
+            sb.AppendLine(alertEvent.Message);
+
+        if (alertEvent.MetricValue.HasValue)
+            sb.AppendLine($"**Value:** {alertEvent.MetricValue}{(alertEvent.ThresholdValue.HasValue ? $" (threshold: {alertEvent.ThresholdValue})" : "")}");
+
+        if (!string.IsNullOrEmpty(alertEvent.DeviceName))
+            sb.AppendLine($"**Device:** {alertEvent.DeviceName}");
+
+        if (!string.IsNullOrEmpty(alertEvent.DeviceIp))
+            sb.AppendLine($"**IP:** {alertEvent.DeviceIp}");
+
+        sb.AppendLine($"**Source:** {alertEvent.Source}");
+        sb.AppendLine($"**Severity:** {alertEvent.Severity}");
+
+        foreach (var ctx in alertEvent.Context)
+            sb.AppendLine($"**{ctx.Key}:** {ctx.Value}");
+
+        return sb.Length > 0 ? sb.ToString().TrimEnd() : alertEvent.EventType;
+    }
+
+    /// <summary>
+    /// Map AlertSeverity to ntfy priority (1-5).
+    /// 5=max, 4=high, 3=default, 2=low, 1=min.
+    /// </summary>
+    internal static int MapPriority(AlertSeverity severity) => severity switch
+    {
+        AlertSeverity.Critical => 5,
+        AlertSeverity.Error => 4,
+        AlertSeverity.Warning => 3,
+        _ => 2
+    };
+
+    /// <summary>
+    /// Map AlertSeverity to ntfy emoji shortcode tag.
+    /// </summary>
+    internal static string MapTag(AlertSeverity severity) => severity switch
+    {
+        AlertSeverity.Critical => "rotating_light",
+        AlertSeverity.Error => "red_circle",
+        AlertSeverity.Warning => "warning",
+        _ => "information_source"
+    };
+}

--- a/src/NetworkOptimizer.Alerts/Models/DeliveryChannel.cs
+++ b/src/NetworkOptimizer.Alerts/Models/DeliveryChannel.cs
@@ -11,7 +11,8 @@ public enum DeliveryChannelType
     Webhook,
     Slack,
     Discord,
-    Teams
+    Teams,
+    Ntfy
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1129,7 +1129,7 @@
         </div>
         <div class="card-body">
             <p class="section-description">
-                Configure notification channels for the alert engine. Alerts are delivered via email, webhooks, Slack, Discord, or Microsoft Teams.
+                Configure notification channels for the alert engine. Alerts are delivered via email, webhooks, Slack, Discord, Microsoft Teams, or ntfy.sh.
             </p>
 
             @if (alertChannels?.Count > 0)
@@ -1187,6 +1187,7 @@
                             <option value="Slack">Slack</option>
                             <option value="Discord">Discord</option>
                             <option value="Teams">Microsoft Teams</option>
+                            <option value="Ntfy">ntfy.sh</option>
                         </select>
                     </div>
 
@@ -1231,11 +1232,64 @@
                             <small class="form-help">Comma-separated email addresses</small>
                         </div>
                     }
+                    else if (channelFormType == "Ntfy")
+                    {
+                        <div class="form-group">
+                            <label class="form-label">Server URL</label>
+                            <input type="url" class="form-control" @bind="channelNtfyServerUrl" placeholder="https://ntfy.sh" autocomplete="off" data-1p-ignore data-lpignore="true" data-bwignore />
+                            <small class="form-help">Default is ntfy.sh. Change for self-hosted instances.</small>
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Topic</label>
+                            <input type="text" class="form-control" @bind="channelNtfyTopic" placeholder="my-network-alerts" autocomplete="off" data-1p-ignore data-lpignore="true" data-bwignore />
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Access Token</label>
+                            @if (clearNtfyToken)
+                            {
+                                <div class="alert alert-info" style="padding: 0.5rem 0.75rem; margin-bottom: 0.5rem;">
+                                    Token will be cleared on save.
+                                    <a href="javascript:void(0)" @onclick="() => clearNtfyToken = false" style="margin-left: 0.5rem;">Undo</a>
+                                </div>
+                            }
+                            else
+                            {
+                                <input type="password" class="form-control" @bind="channelNtfyAccessToken" autocomplete="new-password" placeholder="@(hasNtfyToken ? "Saved - enter new to update" : "Optional - for private topics")" data-1p-ignore data-lpignore="true" data-bwignore />
+                                @if (hasNtfyToken && string.IsNullOrEmpty(channelNtfyAccessToken))
+                                {
+                                    <a href="javascript:void(0)" @onclick="() => clearNtfyToken = true" class="form-hint" style="cursor: pointer;">Clear existing token</a>
+                                }
+                            }
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Username</label>
+                            <input type="text" class="form-control" @bind="channelNtfyUsername" placeholder="Optional - for basic auth" autocomplete="off" data-1p-ignore data-lpignore="true" data-bwignore />
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Password</label>
+                            @if (clearNtfyPassword)
+                            {
+                                <div class="alert alert-info" style="padding: 0.5rem 0.75rem; margin-bottom: 0.5rem;">
+                                    Password will be cleared on save.
+                                    <a href="javascript:void(0)" @onclick="() => clearNtfyPassword = false" style="margin-left: 0.5rem;">Undo</a>
+                                </div>
+                            }
+                            else
+                            {
+                                <input type="password" class="form-control" @bind="channelNtfyPassword" autocomplete="new-password" placeholder="@(hasNtfyPassword ? "Saved - enter new to update" : "Optional - for basic auth")" data-1p-ignore data-lpignore="true" data-bwignore />
+                                @if (hasNtfyPassword && string.IsNullOrEmpty(channelNtfyPassword))
+                                {
+                                    <a href="javascript:void(0)" @onclick="() => clearNtfyPassword = true" class="form-hint" style="cursor: pointer;">Clear existing password</a>
+                                }
+                            }
+                        </div>
+                        <small class="form-help">Use access token OR username/password, not both.</small>
+                    }
                     else
                     {
                         <div class="form-group">
                             <label class="form-label">Webhook URL</label>
-                            <input type="url" class="form-control" @bind="channelWebhookUrl" placeholder="https://hooks.slack.com/services/..." autocomplete="off" data-1p-ignore data-lpignore="true" data-bwignore />
+                            <input type="url" class="form-control" @bind="channelWebhookUrl" placeholder="@GetWebhookPlaceholder()" autocomplete="off" data-1p-ignore data-lpignore="true" data-bwignore />
                         </div>
                         @if (channelFormType == "Webhook")
                         {
@@ -1829,6 +1883,15 @@
     private string channelWebhookSecret = "";
     private bool hasWebhookSecret = false;
     private bool clearWebhookSecret = false;
+    private string channelNtfyServerUrl = "https://ntfy.sh";
+    private string channelNtfyTopic = "";
+    private string channelNtfyAccessToken = "";
+    private bool hasNtfyToken = false;
+    private bool clearNtfyToken = false;
+    private string channelNtfyUsername = "";
+    private string channelNtfyPassword = "";
+    private bool hasNtfyPassword = false;
+    private bool clearNtfyPassword = false;
     private string channelMinSeverity = "Warning";
     private bool channelEnabled = true;
     private bool channelDigestEnabled = false;
@@ -3262,6 +3325,14 @@
         channelSmtpPort = channelSmtpStartTls ? 587 : 465;
     }
 
+    private string GetWebhookPlaceholder() => channelFormType switch
+    {
+        "Slack" => "https://hooks.slack.com/services/...",
+        "Discord" => "https://discord.com/api/webhooks/...",
+        "Teams" => "https://outlook.office.com/webhook/...",
+        _ => "https://example.com/webhook"
+    };
+
     private void StartAddChannel()
     {
         editingChannelId = null;
@@ -3279,6 +3350,15 @@
         channelWebhookSecret = "";
         hasWebhookSecret = false;
         clearWebhookSecret = false;
+        channelNtfyServerUrl = "https://ntfy.sh";
+        channelNtfyTopic = "";
+        channelNtfyAccessToken = "";
+        hasNtfyToken = false;
+        clearNtfyToken = false;
+        channelNtfyUsername = "";
+        channelNtfyPassword = "";
+        hasNtfyPassword = false;
+        clearNtfyPassword = false;
         channelMinSeverity = "Warning";
         channelEnabled = true;
         channelDigestEnabled = false;
@@ -3329,6 +3409,22 @@
                 }
                 channelWebhookSecret = ""; // Don't expose stored secret
                 clearWebhookSecret = false;
+            }
+            else if (ch.ChannelType == DeliveryChannelType.Ntfy)
+            {
+                var cfg = System.Text.Json.JsonSerializer.Deserialize<NetworkOptimizer.Alerts.Delivery.NtfyChannelConfig>(ch.ConfigJson);
+                if (cfg != null)
+                {
+                    channelNtfyServerUrl = cfg.ServerUrl;
+                    channelNtfyTopic = cfg.Topic;
+                    channelNtfyUsername = cfg.Username ?? "";
+                    hasNtfyToken = !string.IsNullOrEmpty(cfg.AccessToken);
+                    hasNtfyPassword = !string.IsNullOrEmpty(cfg.Password);
+                }
+                channelNtfyAccessToken = "";
+                clearNtfyToken = false;
+                channelNtfyPassword = "";
+                clearNtfyPassword = false;
             }
             else
             {
@@ -3467,6 +3563,15 @@
                     }
                 }
             }
+            else if (channelType == DeliveryChannelType.Ntfy)
+            {
+                if (string.IsNullOrWhiteSpace(channelNtfyTopic))
+                {
+                    alertChannelMessage = "Topic is required.";
+                    alertChannelMessageClass = "warning";
+                    return;
+                }
+            }
             else
             {
                 // Webhook, Slack, Discord, Teams all require a URL
@@ -3573,6 +3678,33 @@
             {
                 Url = channelWebhookUrl,
                 Secret = secret
+            };
+            return System.Text.Json.JsonSerializer.Serialize(cfg);
+        }
+
+        if (type == DeliveryChannelType.Ntfy)
+        {
+            string? token = clearNtfyToken
+                ? null
+                : !string.IsNullOrEmpty(channelNtfyAccessToken)
+                    ? SecretDecryptor.Encrypt(channelNtfyAccessToken)
+                    : GetExistingSecret<NetworkOptimizer.Alerts.Delivery.NtfyChannelConfig>(existingConfigJson, c => c.AccessToken);
+            if (string.IsNullOrEmpty(token)) token = null;
+
+            string? password = clearNtfyPassword
+                ? null
+                : !string.IsNullOrEmpty(channelNtfyPassword)
+                    ? SecretDecryptor.Encrypt(channelNtfyPassword)
+                    : GetExistingSecret<NetworkOptimizer.Alerts.Delivery.NtfyChannelConfig>(existingConfigJson, c => c.Password);
+            if (string.IsNullOrEmpty(password)) password = null;
+
+            var cfg = new NetworkOptimizer.Alerts.Delivery.NtfyChannelConfig
+            {
+                ServerUrl = channelNtfyServerUrl,
+                Topic = channelNtfyTopic,
+                AccessToken = token,
+                Username = string.IsNullOrWhiteSpace(channelNtfyUsername) ? null : channelNtfyUsername,
+                Password = password
             };
             return System.Text.Json.JsonSerializer.Serialize(cfg);
         }

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -249,6 +249,11 @@ builder.Services.AddSingleton<NetworkOptimizer.Alerts.Delivery.IAlertDeliveryCha
     new NetworkOptimizer.Alerts.Delivery.TeamsDeliveryChannel(
         sp.GetRequiredService<ILogger<NetworkOptimizer.Alerts.Delivery.TeamsDeliveryChannel>>(),
         sp.GetRequiredService<IHttpClientFactory>().CreateClient()));
+builder.Services.AddSingleton<NetworkOptimizer.Alerts.Delivery.IAlertDeliveryChannel>(sp =>
+    new NetworkOptimizer.Alerts.Delivery.NtfyDeliveryChannel(
+        sp.GetRequiredService<ILogger<NetworkOptimizer.Alerts.Delivery.NtfyDeliveryChannel>>(),
+        sp.GetRequiredService<IHttpClientFactory>().CreateClient(),
+        sp.GetRequiredService<NetworkOptimizer.Alerts.Delivery.ISecretDecryptor>()));
 
 // Register Threat Intelligence services
 builder.Services.AddSingleton<NetworkOptimizer.Threats.Enrichment.GeoEnrichmentService>();

--- a/tests/NetworkOptimizer.Alerts.Tests/Delivery/NtfyDeliveryChannelTests.cs
+++ b/tests/NetworkOptimizer.Alerts.Tests/Delivery/NtfyDeliveryChannelTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using NetworkOptimizer.Alerts.Delivery;
+using NetworkOptimizer.Core.Enums;
+using Xunit;
+
+namespace NetworkOptimizer.Alerts.Tests.Delivery;
+
+public class NtfyDeliveryChannelTests
+{
+    [Theory]
+    [InlineData(AlertSeverity.Critical, 5)]
+    [InlineData(AlertSeverity.Error, 4)]
+    [InlineData(AlertSeverity.Warning, 3)]
+    [InlineData(AlertSeverity.Info, 2)]
+    public void MapPriority_ReturnsExpectedNtfyPriority(AlertSeverity severity, int expected)
+    {
+        NtfyDeliveryChannel.MapPriority(severity).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(AlertSeverity.Critical, "rotating_light")]
+    [InlineData(AlertSeverity.Error, "red_circle")]
+    [InlineData(AlertSeverity.Warning, "warning")]
+    [InlineData(AlertSeverity.Info, "information_source")]
+    public void MapTag_ReturnsExpectedEmojiShortcode(AlertSeverity severity, string expected)
+    {
+        NtfyDeliveryChannel.MapTag(severity).Should().Be(expected);
+    }
+
+    [Fact]
+    public void MapPriority_CriticalIsHighest()
+    {
+        var critical = NtfyDeliveryChannel.MapPriority(AlertSeverity.Critical);
+        var error = NtfyDeliveryChannel.MapPriority(AlertSeverity.Error);
+        var warning = NtfyDeliveryChannel.MapPriority(AlertSeverity.Warning);
+        var info = NtfyDeliveryChannel.MapPriority(AlertSeverity.Info);
+
+        critical.Should().BeGreaterThan(error);
+        error.Should().BeGreaterThan(warning);
+        warning.Should().BeGreaterThan(info);
+    }
+
+    [Fact]
+    public void MapPriority_AllValuesInNtfyRange()
+    {
+        foreach (var severity in Enum.GetValues<AlertSeverity>())
+        {
+            var priority = NtfyDeliveryChannel.MapPriority(severity);
+            priority.Should().BeInRange(1, 5, $"ntfy priorities must be 1-5, got {priority} for {severity}");
+        }
+    }
+
+    [Fact]
+    public void MapTag_AllSeveritiesReturnNonEmpty()
+    {
+        foreach (var severity in Enum.GetValues<AlertSeverity>())
+        {
+            NtfyDeliveryChannel.MapTag(severity).Should().NotBeNullOrEmpty(
+                $"severity {severity} should map to a tag");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds ntfy.sh as a first-class notification channel using the JSON publishing API (closes #377)
- Supports public ntfy.sh and self-hosted instances with optional Bearer token or Basic auth
- Sends markdown-formatted messages with severity-mapped priorities (1-5) and emoji tags
- Adds contextual webhook URL placeholders for Slack, Discord, Teams, and generic webhooks

## Test plan

- [x] Build passes with zero warnings
- [x] All 5,710 tests pass (including 11 new ntfy tests)
- [x] Configure ntfy.sh channel in Settings, verify form fields render correctly
- [x] Send test notification, verify it arrives with proper title, priority, and emoji
- [x] Edit existing channel, verify credentials show "Saved - enter new to update"
- [x] Verify existing channels (Email, Webhook, Slack, Discord, Teams) are unaffected