### PR TITLE
Parse missing fields from legacy firewall rules (#251)

### DIFF
--- a/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleParser.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleParser.cs
@@ -396,6 +396,34 @@ public class FirewallRuleParser
             ? protocolProp.GetString()
             : null;
 
+        // Legacy rules use protocol_match_excepted (equivalent to zone-based match_opposite_protocol)
+        var matchOppositeProtocol = rule.GetBoolOrDefault("protocol_match_excepted", false);
+
+        // Legacy rules use individual state booleans instead of zone-based connection_state_type/connection_states.
+        // When ALL four are false, the rule is stateless (matches everything) - leave ConnectionStateType null.
+        // When specific ones are true, the rule only matches those connection states.
+        var stateNew = rule.GetBoolOrDefault("state_new", false);
+        var stateEstablished = rule.GetBoolOrDefault("state_established", false);
+        var stateRelated = rule.GetBoolOrDefault("state_related", false);
+        var stateInvalid = rule.GetBoolOrDefault("state_invalid", false);
+
+        string? connectionStateType = null;
+        List<string>? connectionStates = null;
+        var anyStateTrue = stateNew || stateEstablished || stateRelated || stateInvalid;
+        if (anyStateTrue)
+        {
+            connectionStates = new List<string>();
+            if (stateNew) connectionStates.Add("NEW");
+            if (stateEstablished) connectionStates.Add("ESTABLISHED");
+            if (stateRelated) connectionStates.Add("RELATED");
+            if (stateInvalid) connectionStates.Add("INVALID");
+
+            if (stateNew && stateEstablished && stateRelated && stateInvalid)
+                connectionStateType = "ALL";
+            else
+                connectionStateType = "CUSTOM";
+        }
+
         // Source information
         var sourceType = rule.TryGetProperty("src_type", out var srcTypeProp)
             ? srcTypeProp.GetString()
@@ -435,7 +463,9 @@ public class FirewallRuleParser
             : null;
 
         // Legacy rules may use dst_firewallgroup_ids for port groups and/or address groups
+        // Track whether address group IDs were specified (even if resolution fails)
         List<string>? destIps = null;
+        bool hadDstAddressGroupIds = false;
         if (rule.TryGetProperty("dst_firewallgroup_ids", out var dstGroupIds) &&
             dstGroupIds.ValueKind == JsonValueKind.Array)
         {
@@ -456,6 +486,13 @@ public class FirewallRuleParser
                     if (resolvedAddresses is { Count: > 0 })
                     {
                         resolvedIps.AddRange(resolvedAddresses);
+                        hadDstAddressGroupIds = true;
+                    }
+                    else if (resolvedPort == null)
+                    {
+                        // Group ID was neither a port group nor a resolvable address group -
+                        // it was intended as an address group but failed to resolve
+                        hadDstAddressGroupIds = true;
                     }
                 }
             }
@@ -473,7 +510,9 @@ public class FirewallRuleParser
         }
 
         // Legacy rules may use src_firewallgroup_ids for address groups
+        // Track whether address group IDs were specified (even if resolution fails)
         List<string>? sourceIps = null;
+        bool hadSrcAddressGroupIds = false;
         if (rule.TryGetProperty("src_firewallgroup_ids", out var srcGroupIds) &&
             srcGroupIds.ValueKind == JsonValueKind.Array)
         {
@@ -483,6 +522,7 @@ public class FirewallRuleParser
                 var groupId = groupIdElement.GetString();
                 if (!string.IsNullOrEmpty(groupId))
                 {
+                    hadSrcAddressGroupIds = true;
                     var resolvedAddresses = ResolveAddressGroup(groupId);
                     if (resolvedAddresses is { Count: > 0 })
                     {
@@ -579,6 +619,28 @@ public class FirewallRuleParser
         else if (destinationNetworkIds is { Count: > 0 })
             destMatchingTarget = "NETWORK";
 
+        // For legacy rules: if no source/destination is specified at all (all fields empty),
+        // the ruleset defines the scope. Empty source on LAN_IN means "any internal source",
+        // empty destination means "any destination". This mirrors zone-based rules where
+        // SourceMatchingTarget/DestinationMatchingTarget = "ANY".
+        // Don't set ANY if address group IDs were specified but failed to resolve -
+        // that means the rule tried to reference a specific group, not "any".
+        if (sourceMatchingTarget == null
+            && !hadSrcAddressGroupIds
+            && string.IsNullOrEmpty(srcNetworkConfId)
+            && (string.IsNullOrEmpty(source) || !source.Contains('.')))
+        {
+            sourceMatchingTarget = "ANY";
+        }
+
+        if (destMatchingTarget == null
+            && !hadDstAddressGroupIds
+            && string.IsNullOrEmpty(dstNetworkConfId)
+            && (string.IsNullOrEmpty(destination) || !destination.Contains('.')))
+        {
+            destMatchingTarget = "ANY";
+        }
+
         return new FirewallRule
         {
             Id = id,
@@ -603,9 +665,13 @@ public class FirewallRuleParser
             DestinationMatchingTarget = destMatchingTarget,
             DestinationIps = destIps,
             WebDomains = webDomains,
+            MatchOppositeProtocol = matchOppositeProtocol,
             // Zone IDs derived from ruleset for compatibility with zone-based analysis
             SourceZoneId = sourceZoneId,
-            DestinationZoneId = destZoneId
+            DestinationZoneId = destZoneId,
+            // Connection state matching (from legacy boolean fields)
+            ConnectionStateType = connectionStateType,
+            ConnectionStates = connectionStates
         };
     }
 

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
@@ -4752,6 +4752,66 @@ public class FirewallRuleAnalyzerTests
     }
 
     [Fact]
+    public void CheckInterVlanIsolation_LegacyEstablishedRelatedAboveRfc1918Block_NoIssue()
+    {
+        // Simulates a typical legacy firewall setup (issue #251):
+        // 1. Allow Established/Related (index 2000) - matches ALL source/dest but only ESTABLISHED/RELATED states
+        // 2. RFC1918-to-RFC1918 block (index 4000) - blocks all new inter-VLAN traffic
+        // The Allow Established/Related rule should NOT eclipse the block rule because
+        // it doesn't allow NEW connections (ConnectionStateType = CUSTOM without NEW).
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("IoT", NetworkPurpose.IoT, id: "iot-net", vlanId: 20, networkIsolationEnabled: false),
+            CreateNetwork("Corporate", NetworkPurpose.Corporate, id: "corp-net", vlanId: 10),
+            CreateNetwork("Security", NetworkPurpose.Security, id: "sec-net", vlanId: 30),
+            CreateNetwork("Management", NetworkPurpose.Management, id: "mgmt-net", vlanId: 50),
+            CreateNetwork("Home", NetworkPurpose.Home, id: "home-net", vlanId: 40),
+        };
+        var rules = new List<FirewallRule>
+        {
+            // Allow Established/Related - higher priority (lower index)
+            // This is how the legacy parser now maps it: ANY/ANY but CUSTOM with ESTABLISHED+RELATED only
+            new FirewallRule
+            {
+                Id = "allow-established",
+                Name = "Allow Established/Related",
+                Action = "accept",
+                Enabled = true,
+                Index = 2000,
+                Protocol = "all",
+                SourceMatchingTarget = "ANY",
+                DestinationMatchingTarget = "ANY",
+                SourceZoneId = FirewallRuleParser.LegacyInternalZoneId,
+                DestinationZoneId = FirewallRuleParser.LegacyInternalZoneId,
+                ConnectionStateType = "CUSTOM",
+                ConnectionStates = new List<string> { "ESTABLISHED", "RELATED" }
+            },
+            // RFC1918-to-RFC1918 block rule - lower priority (higher index)
+            new FirewallRule
+            {
+                Id = "rfc1918-block",
+                Name = "Block RFC1918 to RFC1918",
+                Action = "DROP",
+                Enabled = true,
+                Index = 4000,
+                Protocol = "all",
+                SourceMatchingTarget = "IP",
+                SourceIps = new List<string> { "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16" },
+                DestinationMatchingTarget = "IP",
+                DestinationIps = new List<string> { "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16" },
+                SourceZoneId = FirewallRuleParser.LegacyInternalZoneId,
+                DestinationZoneId = FirewallRuleParser.LegacyInternalZoneId
+            }
+        };
+
+        var issues = _analyzer.CheckInterVlanIsolation(rules, networks);
+
+        issues.Where(i => i.Type == "MISSING_ISOLATION").Should().BeEmpty(
+            "RFC1918 block rule should be found as effective isolation rule because " +
+            "Allow Established/Related doesn't allow NEW connections");
+    }
+
+    [Fact]
     public void CheckInterVlanIsolation_NonIsolatedGuest_MissingRule_ReturnsIssue()
     {
         var rules = new List<FirewallRule>();

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleParserTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleParserTests.cs
@@ -2192,4 +2192,358 @@ public class FirewallRuleParserTests
     }
 
     #endregion
+
+    #region Legacy Connection State Parsing Tests
+
+    [Fact]
+    public void ParseFirewallRule_AllStatesFalse_ConnectionStateTypeNull()
+    {
+        var json = JsonDocument.Parse(@"{
+            ""_id"": ""rule1"",
+            ""name"": ""Stateless Rule"",
+            ""action"": ""drop"",
+            ""enabled"": true,
+            ""protocol"": ""all"",
+            ""ruleset"": ""LAN_IN"",
+            ""state_new"": false,
+            ""state_established"": false,
+            ""state_related"": false,
+            ""state_invalid"": false
+        }").RootElement;
+
+        var rule = _parser.ParseFirewallRule(json);
+
+        rule.Should().NotBeNull();
+        rule!.ConnectionStateType.Should().BeNull();
+        rule.ConnectionStates.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseFirewallRule_AllStatesTrue_ConnectionStateTypeAll()
+    {
+        var json = JsonDocument.Parse(@"{
+            ""_id"": ""rule1"",
+            ""name"": ""All States"",
+            ""action"": ""accept"",
+            ""enabled"": true,
+            ""protocol"": ""all"",
+            ""ruleset"": ""LAN_IN"",
+            ""state_new"": true,
+            ""state_established"": true,
+            ""state_related"": true,
+            ""state_invalid"": true
+        }").RootElement;
+
+        var rule = _parser.ParseFirewallRule(json);
+
+        rule.Should().NotBeNull();
+        rule!.ConnectionStateType.Should().Be("ALL");
+        rule.ConnectionStates.Should().BeEquivalentTo(new[] { "NEW", "ESTABLISHED", "RELATED", "INVALID" });
+    }
+
+    [Fact]
+    public void ParseFirewallRule_EstablishedRelatedOnly_ConnectionStateTypeCustom()
+    {
+        // Classic "Allow Established/Related" rule - should NOT allow new connections
+        var json = JsonDocument.Parse(@"{
+            ""_id"": ""rule1"",
+            ""name"": ""Allow Established"",
+            ""action"": ""accept"",
+            ""enabled"": true,
+            ""protocol"": ""all"",
+            ""ruleset"": ""LAN_IN"",
+            ""state_new"": false,
+            ""state_established"": true,
+            ""state_related"": true,
+            ""state_invalid"": false
+        }").RootElement;
+
+        var rule = _parser.ParseFirewallRule(json);
+
+        rule.Should().NotBeNull();
+        rule!.ConnectionStateType.Should().Be("CUSTOM");
+        rule.ConnectionStates.Should().BeEquivalentTo(new[] { "ESTABLISHED", "RELATED" });
+        // Critically: this should NOT allow new connections
+        rule.AllowsNewConnections().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ParseFirewallRule_NewAndEstablished_AllowsNewConnections()
+    {
+        var json = JsonDocument.Parse(@"{
+            ""_id"": ""rule1"",
+            ""name"": ""Accept New+Established"",
+            ""action"": ""accept"",
+            ""enabled"": true,
+            ""protocol"": ""all"",
+            ""ruleset"": ""LAN_IN"",
+            ""state_new"": true,
+            ""state_established"": true,
+            ""state_related"": false,
+            ""state_invalid"": false
+        }").RootElement;
+
+        var rule = _parser.ParseFirewallRule(json);
+
+        rule.Should().NotBeNull();
+        rule!.ConnectionStateType.Should().Be("CUSTOM");
+        rule.ConnectionStates.Should().BeEquivalentTo(new[] { "NEW", "ESTABLISHED" });
+        rule.AllowsNewConnections().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ParseFirewallRule_NoStateFields_ConnectionStateTypeNull()
+    {
+        // When state fields are missing entirely (not present in JSON)
+        var json = JsonDocument.Parse(@"{
+            ""_id"": ""rule1"",
+            ""name"": ""No State Info"",
+            ""action"": ""drop"",
+            ""enabled"": true,
+            ""protocol"": ""all"",
+            ""ruleset"": ""LAN_IN""
+        }").RootElement;
+
+        var rule = _parser.ParseFirewallRule(json);
+
+        rule.Should().NotBeNull();
+        rule!.ConnectionStateType.Should().BeNull();
+        rule.ConnectionStates.Should().BeNull();
+    }
+
+    #endregion
+
+    #region Legacy Empty Source/Destination ANY Mapping Tests
+
+    [Fact]
+    public void ParseFirewallRule_EmptySourceFields_SetsSourceMatchingTargetAny()
+    {
+        // A LAN_IN rule with no source specified means "any internal source"
+        var json = JsonDocument.Parse(@"{
+            ""_id"": ""rule1"",
+            ""name"": ""Allow Established"",
+            ""action"": ""accept"",
+            ""enabled"": true,
+            ""protocol"": ""all"",
+            ""ruleset"": ""LAN_IN"",
+            ""src_address"": """",
+            ""src_networkconf_id"": """",
+            ""src_firewallgroup_ids"": [],
+            ""dst_address"": """",
+            ""dst_networkconf_id"": """",
+            ""dst_firewallgroup_ids"": []
+        }").RootElement;
+
+        var rule = _parser.ParseFirewallRule(json);
+
+        rule.Should().NotBeNull();
+        rule!.SourceMatchingTarget.Should().Be("ANY");
+        rule.DestinationMatchingTarget.Should().Be("ANY");
+    }
+
+    [Fact]
+    public void ParseFirewallRule_WithSrcNetworkConfId_DoesNotSetAny()
+    {
+        // If src_networkconf_id is set, it should be NETWORK, not ANY
+        var json = JsonDocument.Parse(@"{
+            ""_id"": ""rule1"",
+            ""name"": ""From Specific Network"",
+            ""action"": ""drop"",
+            ""enabled"": true,
+            ""protocol"": ""all"",
+            ""ruleset"": ""LAN_IN"",
+            ""src_address"": """",
+            ""src_networkconf_id"": ""507f1f77bcf86cd799439011"",
+            ""src_firewallgroup_ids"": [],
+            ""dst_address"": """",
+            ""dst_networkconf_id"": """",
+            ""dst_firewallgroup_ids"": []
+        }").RootElement;
+
+        var rule = _parser.ParseFirewallRule(json);
+
+        rule.Should().NotBeNull();
+        rule!.SourceMatchingTarget.Should().Be("NETWORK");
+        rule.DestinationMatchingTarget.Should().Be("ANY");
+    }
+
+    [Fact]
+    public void ParseFirewallRule_WithAddressGroupIds_DoesNotSetAny()
+    {
+        // If firewall group IDs are specified (even if unresolvable), don't default to ANY
+        var json = JsonDocument.Parse(@"{
+            ""_id"": ""rule1"",
+            ""name"": ""From Address Group"",
+            ""action"": ""drop"",
+            ""enabled"": true,
+            ""protocol"": ""all"",
+            ""ruleset"": ""LAN_IN"",
+            ""src_address"": """",
+            ""src_networkconf_id"": """",
+            ""src_firewallgroup_ids"": [""nonexistent-group""],
+            ""dst_address"": """",
+            ""dst_networkconf_id"": """",
+            ""dst_firewallgroup_ids"": [""another-nonexistent-group""]
+        }").RootElement;
+
+        var rule = _parser.ParseFirewallRule(json);
+
+        rule.Should().NotBeNull();
+        // Source/Dest had group IDs that failed to resolve - should NOT default to ANY
+        rule!.SourceMatchingTarget.Should().NotBe("ANY");
+        rule.DestinationMatchingTarget.Should().NotBe("ANY");
+    }
+
+    [Fact]
+    public void ParseFirewallRule_WithSrcAddress_SetsIpMatchingTarget()
+    {
+        var json = JsonDocument.Parse(@"{
+            ""_id"": ""rule1"",
+            ""name"": ""From Specific IP"",
+            ""action"": ""accept"",
+            ""enabled"": true,
+            ""protocol"": ""all"",
+            ""ruleset"": ""LAN_IN"",
+            ""src_address"": ""192.0.2.100"",
+            ""src_networkconf_id"": """",
+            ""src_firewallgroup_ids"": [],
+            ""dst_address"": """",
+            ""dst_networkconf_id"": """",
+            ""dst_firewallgroup_ids"": []
+        }").RootElement;
+
+        var rule = _parser.ParseFirewallRule(json);
+
+        rule.Should().NotBeNull();
+        rule!.SourceMatchingTarget.Should().Be("IP");
+        rule.SourceIps.Should().BeEquivalentTo(new[] { "192.0.2.100" });
+        // Destination is empty and should be ANY
+        rule.DestinationMatchingTarget.Should().Be("ANY");
+    }
+
+    [Fact]
+    public void ParseFirewallRule_ResolvedAddressGroup_SetsIpNotAny()
+    {
+        var groups = new Dictionary<string, UniFiFirewallGroup>
+        {
+            ["rfc1918-group"] = new UniFiFirewallGroup
+            {
+                Id = "rfc1918-group",
+                Name = "RFC1918",
+                GroupType = "address-group",
+                GroupMembers = new List<string> { "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16" }
+            }
+        };
+        _parser.SetFirewallGroups(groups.Values);
+
+        var json = JsonDocument.Parse(@"{
+            ""_id"": ""rule1"",
+            ""name"": ""RFC1918 Block"",
+            ""action"": ""drop"",
+            ""enabled"": true,
+            ""protocol"": ""all"",
+            ""ruleset"": ""LAN_IN"",
+            ""src_address"": """",
+            ""src_networkconf_id"": """",
+            ""src_firewallgroup_ids"": [""rfc1918-group""],
+            ""dst_address"": """",
+            ""dst_networkconf_id"": """",
+            ""dst_firewallgroup_ids"": [""rfc1918-group""]
+        }").RootElement;
+
+        var rule = _parser.ParseFirewallRule(json);
+
+        rule.Should().NotBeNull();
+        rule!.SourceMatchingTarget.Should().Be("IP");
+        rule.SourceIps.Should().BeEquivalentTo(new[] { "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16" });
+        rule.DestinationMatchingTarget.Should().Be("IP");
+        rule.DestinationIps.Should().BeEquivalentTo(new[] { "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16" });
+    }
+
+    #endregion
+
+    #region Legacy protocol_match_excepted Tests
+
+    [Fact]
+    public void ParseFirewallRule_ProtocolMatchExceptedTrue_SetsMatchOppositeProtocol()
+    {
+        var json = JsonDocument.Parse(@"{
+            ""_id"": ""rule1"",
+            ""name"": ""Block Non-TCP"",
+            ""action"": ""drop"",
+            ""enabled"": true,
+            ""protocol"": ""tcp"",
+            ""ruleset"": ""LAN_IN"",
+            ""protocol_match_excepted"": true
+        }").RootElement;
+
+        var rule = _parser.ParseFirewallRule(json);
+
+        rule.Should().NotBeNull();
+        rule!.MatchOppositeProtocol.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ParseFirewallRule_ProtocolMatchExceptedFalse_DoesNotSetMatchOppositeProtocol()
+    {
+        var json = JsonDocument.Parse(@"{
+            ""_id"": ""rule1"",
+            ""name"": ""Block TCP"",
+            ""action"": ""drop"",
+            ""enabled"": true,
+            ""protocol"": ""tcp"",
+            ""ruleset"": ""LAN_IN"",
+            ""protocol_match_excepted"": false
+        }").RootElement;
+
+        var rule = _parser.ParseFirewallRule(json);
+
+        rule.Should().NotBeNull();
+        rule!.MatchOppositeProtocol.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region Legacy Integration: Established/Related + ANY + RFC1918 Block
+
+    [Fact]
+    public void ParseFirewallRule_EstablishedRelatedAllowWithEmptyFields_CorrectlyMapped()
+    {
+        // This is the critical integration test: a legacy "Allow Established/Related" rule
+        // with empty source/dest should be mapped as ANY source/dest but NOT allowing new connections.
+        // This ensures it doesn't eclipse block rules below it.
+        var json = JsonDocument.Parse(@"{
+            ""_id"": ""rule1"",
+            ""name"": ""Allow Established/Related"",
+            ""action"": ""accept"",
+            ""enabled"": true,
+            ""protocol"": ""all"",
+            ""ruleset"": ""LAN_IN"",
+            ""rule_index"": 2000,
+            ""src_address"": """",
+            ""src_networkconf_id"": """",
+            ""src_firewallgroup_ids"": [],
+            ""dst_address"": """",
+            ""dst_networkconf_id"": """",
+            ""dst_firewallgroup_ids"": [],
+            ""state_new"": false,
+            ""state_established"": true,
+            ""state_related"": true,
+            ""state_invalid"": false
+        }").RootElement;
+
+        var rule = _parser.ParseFirewallRule(json);
+
+        rule.Should().NotBeNull();
+        // Source and dest should be ANY (empty fields on LAN_IN)
+        rule!.SourceMatchingTarget.Should().Be("ANY");
+        rule.DestinationMatchingTarget.Should().Be("ANY");
+        // But it should NOT allow new connections
+        rule.AllowsNewConnections().Should().BeFalse();
+        // And it should have connection state info
+        rule.ConnectionStateType.Should().Be("CUSTOM");
+        rule.ConnectionStates.Should().BeEquivalentTo(new[] { "ESTABLISHED", "RELATED" });
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

- **Connection state booleans** - Legacy rules use `state_new`, `state_established`, `state_related`, `state_invalid` instead of zone-based `connection_state_type`. Without parsing these, an "Allow Established/Related" rule was treated as allowing all connection states including NEW, potentially eclipsing block rules below it.
- **Empty source/destination → ANY** - A LAN_IN rule with no source or destination specified means "any" within that zone scope (this is how iptables works). Previously these rules matched nothing, making them invisible to the audit engine.
- **`protocol_match_excepted`** - Legacy equivalent of `match_opposite_protocol` was not being parsed.

Fixes #251

## Test plan

- [x] 14 new tests covering all edge cases
- [x] Integration test: Allow Established/Related above RFC1918 block (the exact issue #251 scenario)
- [x] All 3249 existing + new tests pass
- [x] Zero build warnings
- [x] Deploy to test environments and ensure no breakage