### PR TITLE
Add Media and Gaming network purpose types

### DIFF
--- a/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleAnalyzer.cs
@@ -456,7 +456,8 @@ public class FirewallRuleAnalyzer
         var corporateNetworks = networks.Where(n => n.Purpose == NetworkPurpose.Corporate).ToList();
         var homeNetworks = networks.Where(n => n.Purpose == NetworkPurpose.Home).ToList();
         var serverNetworks = networks.Where(n => n.Purpose == NetworkPurpose.Server).ToList();
-        var trustedNetworks = corporateNetworks.Concat(homeNetworks).Concat(serverNetworks).ToList();
+        var gamingNetworks = networks.Where(n => n.Purpose == NetworkPurpose.Gaming).ToList();
+        var trustedNetworks = corporateNetworks.Concat(homeNetworks).Concat(gamingNetworks).Concat(serverNetworks).ToList();
 
         // IoT should be isolated from: Corporate, Home, Server
         // (IoT → Security and IoT → Management already covered above)
@@ -466,6 +467,18 @@ public class FirewallRuleAnalyzer
             foreach (var trusted in trustedNetworks)
             {
                 CheckAndAddIsolationIssue(issues, rules, iot, trusted, "FW-ISOLATION-IOT");
+            }
+        }
+
+        // Media should be isolated from: Corporate, Home, Server (same as IoT)
+        // Media is a peer of IoT - no isolation between them
+        // Guest → Media is explicitly allowed (guests can access streaming/entertainment)
+        var mediaNetworks = networks.Where(n => n.Purpose == NetworkPurpose.Media && !n.NetworkIsolationEnabled).ToList();
+        foreach (var media in mediaNetworks)
+        {
+            foreach (var trusted in trustedNetworks)
+            {
+                CheckAndAddIsolationIssue(issues, rules, media, trusted, "FW-ISOLATION-MEDIA");
             }
         }
 
@@ -489,7 +502,25 @@ public class FirewallRuleAnalyzer
             }
         }
 
-        // Guest should be isolated from: Corporate, Home, IoT
+        // Corporate <-> Gaming should be isolated from each other (bidirectional, same as Corp <-> Home)
+        var nonIsolatedGaming = gamingNetworks.Where(n => !n.NetworkIsolationEnabled).ToList();
+
+        foreach (var corp in nonIsolatedCorporate)
+        {
+            foreach (var gaming in gamingNetworks)
+            {
+                CheckAndAddIsolationIssue(issues, rules, corp, gaming, "FW-ISOLATION-CORP-GAMING");
+            }
+        }
+        foreach (var gaming in nonIsolatedGaming)
+        {
+            foreach (var corp in corporateNetworks)
+            {
+                CheckAndAddIsolationIssue(issues, rules, gaming, corp, "FW-ISOLATION-GAMING-CORP");
+            }
+        }
+
+        // Guest should be isolated from: Corporate, Home, Gaming, IoT
         // (Guest → Security and Guest → Management already covered above)
         var guestNetworks = networks.Where(n => n.Purpose == NetworkPurpose.Guest && !n.NetworkIsolationEnabled && !n.IsUniFiGuestNetwork).ToList();
         var allIotNetworks = networks.Where(n => n.Purpose == NetworkPurpose.IoT).ToList();
@@ -541,6 +572,16 @@ public class FirewallRuleAnalyzer
             }
         }
 
+        // Check for allow rules between Media and trusted networks
+        var allMediaNetworks = networks.Where(n => n.Purpose == NetworkPurpose.Media).ToList();
+        foreach (var media in allMediaNetworks)
+        {
+            foreach (var trusted in trustedPlusManagement)
+            {
+                CheckForProblematicAllowRules(issues, rules, media, trusted, externalZoneId);
+            }
+        }
+
         // Check for allow rules between Guest and trusted/IoT networks
         foreach (var guest in allGuestNetworks)
         {
@@ -561,6 +602,16 @@ public class FirewallRuleAnalyzer
             {
                 CheckForProblematicAllowRules(issues, rules, corp, home, externalZoneId);
                 CheckForProblematicAllowRules(issues, rules, home, corp, externalZoneId);
+            }
+        }
+
+        // Check for allow rules between Corporate and Gaming networks (bidirectional)
+        foreach (var corp in corporateNetworks)
+        {
+            foreach (var gaming in gamingNetworks)
+            {
+                CheckForProblematicAllowRules(issues, rules, corp, gaming, externalZoneId);
+                CheckForProblematicAllowRules(issues, rules, gaming, corp, externalZoneId);
             }
         }
 

--- a/src/NetworkOptimizer.Audit/Analyzers/UpnpSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/UpnpSecurityAnalyzer.cs
@@ -96,8 +96,8 @@ public class UpnpSecurityAnalyzer
         // Find networks with UPnP explicitly enabled (per-network binding)
         // Include disabled networks since they can still have UPnP bindings configured
         var networksWithUpnp = networks.Where(n => n.UpnpLanEnabled).ToList();
-        var homeNetworksWithUpnp = networksWithUpnp.Where(n => n.Purpose == NetworkPurpose.Home).ToList();
-        var nonHomeNetworksWithUpnp = networksWithUpnp.Where(n => n.Purpose != NetworkPurpose.Home).ToList();
+        var homeNetworksWithUpnp = networksWithUpnp.Where(n => n.Purpose is NetworkPurpose.Home or NetworkPurpose.Gaming).ToList();
+        var nonHomeNetworksWithUpnp = networksWithUpnp.Where(n => n.Purpose is not NetworkPurpose.Home and not NetworkPurpose.Gaming).ToList();
 
         _logger.LogInformation("Analyzing UPnP security: GlobalEnabled={Enabled}, UPnP rules={RuleCount}, Networks with UPnP={NetworkCount} (Home={HomeCount}, Non-Home={NonHomeCount})",
             isEnabled, upnpRuleCount, networksWithUpnp.Count, homeNetworksWithUpnp.Count, nonHomeNetworksWithUpnp.Count);
@@ -185,7 +185,7 @@ public class UpnpSecurityAnalyzer
 
         // Analyze static port forwards regardless of UPnP status
         // hasHomeNetwork check is used for static port forwards to determine warning severity
-        var hasHomeNetwork = networks.Any(n => n.Purpose == NetworkPurpose.Home);
+        var hasHomeNetwork = networks.Any(n => n.Purpose is NetworkPurpose.Home or NetworkPurpose.Gaming);
         var staticRules = portForwardRules?.Where(r => r.IsUpnp != 1 && r.Enabled == true).ToList() ?? [];
         if (staticRules.Count > 0)
         {

--- a/src/NetworkOptimizer.Audit/Analyzers/VlanAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/VlanAnalyzer.cs
@@ -17,19 +17,24 @@ public class VlanAnalyzer
 
     // Network classification patterns (case-insensitive)
     // Note: "device" removed from IoT - too generic, causes false positives with "Security Devices"
-    // Entertainment patterns (streaming, theater, etc.) classify as IoT - isolated but internet-enabled
-    private static readonly string[] IoTPatterns = { "iot", "smart", "automation", "zero trust", "entertainment", "streaming", "theater", "theatre", "recreation", "living room", "a/v" };
-    // IoT patterns requiring word boundary matching (to avoid "Dave" matching "av", etc.)
-    private static readonly string[] IoTWordBoundaryPatterns = { "media", "av", "tv" };
+    private static readonly string[] IoTPatterns = { "iot", "smart", "automation", "zero trust" };
+    // IoT patterns requiring word boundary matching
+    private static readonly string[] IoTWordBoundaryPatterns = { };
+    // Media/entertainment patterns - semi-trusted, peers with IoT, accessible from Guest
+    private static readonly string[] MediaPatterns = { "entertainment", "streaming", "theater", "theatre", "recreation", "living room", "a/v" };
+    // Media patterns requiring word boundary matching (to avoid "Dave" matching "av", etc.)
+    private static readonly string[] MediaWordBoundaryPatterns = { "media", "av", "tv" };
     private static readonly string[] SecurityPatterns = { "camera", "security", "nvr", "surveillance", "protect", "cctv" };
     // Patterns that require word boundary matching (to avoid false positives like "Hotspot" matching "not")
     private static readonly string[] SecurityWordBoundaryPatterns = { "not" }; // "NoT" = "Network of Things"
     private static readonly string[] ManagementPatterns = { "management", "mgmt", "admin", "infrastructure" };
     private static readonly string[] GuestPatterns = { "guest", "visitor", "hotspot" };
-    // Gaming patterns classify as Home - game consoles need UPnP and full network access
-    private static readonly string[] HomePatterns = { "home", "main", "primary", "personal", "family", "trusted", "private", "gaming", "gamer", "games", "xbox", "playstation", "nintendo", "console", "lan party" };
-    // Home patterns requiring word boundary matching (to avoid "GameChanger" matching "game")
-    private static readonly string[] HomeWordBoundaryPatterns = { "game" };
+    private static readonly string[] HomePatterns = { "home", "main", "primary", "personal", "family", "trusted", "private" };
+    private static readonly string[] HomeWordBoundaryPatterns = { };
+    // Gaming networks - same trust level as Home, game consoles need UPnP and full network access
+    private static readonly string[] GamingPatterns = { "gaming", "gamer", "games", "xbox", "playstation", "nintendo", "console", "lan party" };
+    // Gaming patterns requiring word boundary matching (to avoid "GameChanger" matching "game")
+    private static readonly string[] GamingWordBoundaryPatterns = { "game" };
     private static readonly string[] CorporatePatterns = { "corporate", "office", "business", "enterprise", "warehouse" };
     // Word boundary patterns for Corporate (to avoid "network" matching "work")
     private static readonly string[] CorporateWordBoundaryPatterns = { "work", "biz", "branch", "shop", "staff", "employee", "hq", "store" };
@@ -352,9 +357,15 @@ public class VlanAnalyzer
         // Printer networks before IoT (more specific)
         else if (PrinterPatterns.Any(p => networkName.Contains(p, StringComparison.OrdinalIgnoreCase)))
             nameBasedPurpose = NetworkPurpose.Printer;
+        // Media/entertainment networks (semi-trusted, peers with IoT)
+        else if (MediaPatterns.Any(p => networkName.Contains(p, StringComparison.OrdinalIgnoreCase)))
+            nameBasedPurpose = NetworkPurpose.Media;
+        // Word-boundary patterns for Media (e.g., "Media Room" but not "Dave")
+        else if (MediaWordBoundaryPatterns.Any(p => ContainsWord(networkName, p)))
+            nameBasedPurpose = NetworkPurpose.Media;
         else if (IoTPatterns.Any(p => networkName.Contains(p, StringComparison.OrdinalIgnoreCase)))
             nameBasedPurpose = NetworkPurpose.IoT;
-        // Word-boundary patterns for IoT (e.g., "Media Room" but not "Dave")
+        // Word-boundary patterns for IoT
         else if (IoTWordBoundaryPatterns.Any(p => ContainsWord(networkName, p)))
             nameBasedPurpose = NetworkPurpose.IoT;
         else if (ManagementPatterns.Any(p => networkName.Contains(p, StringComparison.OrdinalIgnoreCase)))
@@ -373,9 +384,15 @@ public class VlanAnalyzer
             nameBasedPurpose = NetworkPurpose.Corporate;
         else if (HomePatterns.Any(p => networkName.Contains(p, StringComparison.OrdinalIgnoreCase)))
             nameBasedPurpose = NetworkPurpose.Home;
-        // Word-boundary patterns for Home (e.g., "Game Room" but not "GameChanger")
+        // Word-boundary patterns for Home
         else if (HomeWordBoundaryPatterns.Any(p => ContainsWord(networkName, p)))
             nameBasedPurpose = NetworkPurpose.Home;
+        // Gaming networks - same trust level as Home
+        else if (GamingPatterns.Any(p => networkName.Contains(p, StringComparison.OrdinalIgnoreCase)))
+            nameBasedPurpose = NetworkPurpose.Gaming;
+        // Word-boundary patterns for Gaming (e.g., "Game Room" but not "GameChanger")
+        else if (GamingWordBoundaryPatterns.Any(p => ContainsWord(networkName, p)))
+            nameBasedPurpose = NetworkPurpose.Gaming;
         // Fallback: if name starts with "default" or "main", or is exactly "lan", treat as Home
         else if (networkName.StartsWith("default", StringComparison.OrdinalIgnoreCase) ||
                  networkName.StartsWith("main", StringComparison.OrdinalIgnoreCase) ||
@@ -390,9 +407,9 @@ public class VlanAnalyzer
         // Step 2: Flag-based adjustments
         // Use UniFi's isolation and internet access flags to refine classification
 
-        // Home/Corporate networks should have internet access
+        // Home/Corporate/Gaming networks should have internet access
         // If they don't, the name-based classification is likely wrong
-        if (nameBasedPurpose is NetworkPurpose.Home or NetworkPurpose.Corporate)
+        if (nameBasedPurpose is NetworkPurpose.Home or NetworkPurpose.Corporate or NetworkPurpose.Gaming)
         {
             if (internetAccessEnabled == false)
             {
@@ -449,7 +466,7 @@ public class VlanAnalyzer
         }
 
         // Log when isolation confirms secure VLAN classification (positive indicator)
-        if (nameBasedPurpose is NetworkPurpose.Security or NetworkPurpose.IoT or NetworkPurpose.Management)
+        if (nameBasedPurpose is NetworkPurpose.Security or NetworkPurpose.IoT or NetworkPurpose.Media or NetworkPurpose.Management)
         {
             if (networkIsolationEnabled == true)
             {
@@ -493,7 +510,7 @@ public class VlanAnalyzer
     }
 
     /// <summary>
-    /// Check if a network name suggests IoT usage (includes entertainment/media networks)
+    /// Check if a network name suggests IoT usage
     /// </summary>
     public bool IsIoTNetwork(string? networkName)
     {
@@ -505,7 +522,19 @@ public class VlanAnalyzer
     }
 
     /// <summary>
-    /// Check if a network name suggests home/gaming usage
+    /// Check if a network name suggests media/entertainment usage
+    /// </summary>
+    public bool IsMediaNetwork(string? networkName)
+    {
+        if (string.IsNullOrEmpty(networkName))
+            return false;
+
+        return MediaPatterns.Any(p => networkName.Contains(p, StringComparison.OrdinalIgnoreCase))
+            || MediaWordBoundaryPatterns.Any(p => ContainsWord(networkName, p));
+    }
+
+    /// <summary>
+    /// Check if a network name suggests home usage
     /// </summary>
     public bool IsHomeNetwork(string? networkName)
     {
@@ -514,6 +543,18 @@ public class VlanAnalyzer
 
         return HomePatterns.Any(p => networkName.Contains(p, StringComparison.OrdinalIgnoreCase))
             || HomeWordBoundaryPatterns.Any(p => ContainsWord(networkName, p));
+    }
+
+    /// <summary>
+    /// Check if a network name suggests gaming usage
+    /// </summary>
+    public bool IsGamingNetwork(string? networkName)
+    {
+        if (string.IsNullOrEmpty(networkName))
+            return false;
+
+        return GamingPatterns.Any(p => networkName.Contains(p, StringComparison.OrdinalIgnoreCase))
+            || GamingWordBoundaryPatterns.Any(p => ContainsWord(networkName, p));
     }
 
     /// <summary>
@@ -815,7 +856,30 @@ public class VlanAnalyzer
                     },
                     RuleId = "NET-ISO-003",
                     ScoreImpact = 10,
-                    RecommendedAction = "Enable network isolation to contain potentially insecure IoT devices. If incorrect, set a different Purpose for the network in Network Reference below."
+                    RecommendedAction = "Enable Isolate Network in Network Settings, or add inter-VLAN blocking Firewall Rules to prevent IoT devices from reaching other VLANs. If incorrect, set a different Purpose for the network in Network Reference below."
+                });
+            }
+
+            // Check Media networks
+            if (network.Purpose == NetworkPurpose.Media && !isEffectivelyIsolated)
+            {
+                issues.Add(new AuditIssue
+                {
+                    Type = IssueTypes.MediaNetworkNotIsolated,
+                    Severity = AuditSeverity.Recommended,
+                    Message = $"Media VLAN '{network.Name}' is not isolated",
+                    DeviceName = gatewayName,
+                    CurrentNetwork = network.Name,
+                    CurrentVlan = network.VlanId,
+                    Metadata = new Dictionary<string, object>
+                    {
+                        { "network", network.Name },
+                        { "vlan", network.VlanId },
+                        { "network_isolation_enabled", network.NetworkIsolationEnabled }
+                    },
+                    RuleId = "NET-ISO-006",
+                    ScoreImpact = 10,
+                    RecommendedAction = "Enable Isolate Network in Network Settings, or add inter-VLAN blocking Firewall Rules to prevent media devices from reaching other VLANs. If incorrect, set a different Purpose for the network in Network Reference below."
                 });
             }
         }

--- a/src/NetworkOptimizer.Audit/IssueTypes.cs
+++ b/src/NetworkOptimizer.Audit/IssueTypes.cs
@@ -37,6 +37,7 @@ public static class IssueTypes
     public const string SecurityNetworkNotIsolated = "SECURITY_NETWORK_NOT_ISOLATED";
     public const string MgmtNetworkNotIsolated = "MGMT_NETWORK_NOT_ISOLATED";
     public const string IotNetworkNotIsolated = "IOT_NETWORK_NOT_ISOLATED";
+    public const string MediaNetworkNotIsolated = "MEDIA_NOT_ISOLATED";
     public const string SecurityNetworkHasInternet = "SECURITY_NETWORK_HAS_INTERNET";
     public const string MgmtNetworkHasInternet = "MGMT_NETWORK_HAS_INTERNET";
 

--- a/src/NetworkOptimizer.Audit/Models/NetworkInfo.cs
+++ b/src/NetworkOptimizer.Audit/Models/NetworkInfo.cs
@@ -52,6 +52,16 @@ public enum NetworkPurpose
     Server,
 
     /// <summary>
+    /// Media/entertainment network (streaming devices, Apple TV, A/V receivers)
+    /// </summary>
+    Media,
+
+    /// <summary>
+    /// Gaming network (consoles, PCs) - same trust level as Home
+    /// </summary>
+    Gaming,
+
+    /// <summary>
     /// Unknown or unclassified network
     /// </summary>
     Unknown
@@ -76,6 +86,8 @@ public static class NetworkPurposeExtensions
         NetworkPurpose.Printer => "Printer",
         NetworkPurpose.Dmz => "DMZ",
         NetworkPurpose.Server => "Server",
+        NetworkPurpose.Media => "Media",
+        NetworkPurpose.Gaming => "Gaming",
         NetworkPurpose.Unknown => "Unclassified",
         _ => purpose.ToString()
     };

--- a/src/NetworkOptimizer.Web/Components/Pages/Audit.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Audit.razor
@@ -889,6 +889,8 @@
         ("Printer", "Printer"),
         ("Dmz", "DMZ"),
         ("Server", "Server"),
+        ("Media", "Media"),
+        ("Gaming", "Gaming"),
         ("Unknown", "Unclassified")
     ];
 

--- a/src/NetworkOptimizer.Web/Services/AuditService.cs
+++ b/src/NetworkOptimizer.Web/Services/AuditService.cs
@@ -1837,6 +1837,7 @@ public class AuditService
             Audit.IssueTypes.SecurityNetworkNotIsolated => "Security Network Not Isolated",
             Audit.IssueTypes.MgmtNetworkNotIsolated => "Management Network Not Isolated",
             Audit.IssueTypes.IotNetworkNotIsolated => "IoT Network Not Isolated",
+            Audit.IssueTypes.MediaNetworkNotIsolated => "Media Network Not Isolated",
             Audit.IssueTypes.SecurityNetworkHasInternet => "Security Network Has Internet",
             Audit.IssueTypes.MgmtNetworkHasInternet => "Management Network Has Internet",
             Audit.IssueTypes.IotVlan or Audit.IssueTypes.WifiIotVlan or "OFFLINE-IOT-VLAN" or "OFFLINE-PRINTER-VLAN" =>

--- a/src/NetworkOptimizer.WiFi/Rules/WiFiOptimizerContext.cs
+++ b/src/NetworkOptimizer.WiFi/Rules/WiFiOptimizerContext.cs
@@ -54,7 +54,7 @@ public class WiFiOptimizerContext
     /// Main networks (Home or Corporate purpose).
     /// </summary>
     public IEnumerable<NetworkInfo> MainNetworks => Networks.Where(n =>
-        n.Enabled && n.Purpose is NetworkPurpose.Home or NetworkPurpose.Corporate);
+        n.Enabled && n.Purpose is NetworkPurpose.Home or NetworkPurpose.Corporate or NetworkPurpose.Gaming);
 
     /// <summary>
     /// Whether any APs have 5 GHz radios active.

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
@@ -4227,6 +4227,149 @@ public class FirewallRuleAnalyzerTests
 
     #endregion
 
+    #region Media Network Isolation Tests
+
+    [Fact]
+    public void CheckInterVlanIsolation_MediaToCorporate_NoBlockRule_FlaggedAsMissing()
+    {
+        // Media to Corporate without a block rule should be flagged
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Media", NetworkPurpose.Media, id: "media-net-id"),
+            CreateNetwork("Corporate", NetworkPurpose.Corporate, id: "corp-net-id")
+        };
+        var rules = new List<FirewallRule>();
+
+        var issues = _analyzer.CheckInterVlanIsolation(rules, networks);
+
+        issues.Should().Contain(i => i.Type == "MISSING_ISOLATION" &&
+            i.Message.Contains("Media") && i.Message.Contains("Corporate"));
+    }
+
+    [Fact]
+    public void CheckInterVlanIsolation_CorporateToMedia_NoBlockRule_NotFlagged()
+    {
+        // Corporate (trusted) → Media: trusted can reach down, no isolation required
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Corporate", NetworkPurpose.Corporate, id: "corp-net-id"),
+            CreateNetwork("Media", NetworkPurpose.Media, id: "media-net-id")
+        };
+        var rules = new List<FirewallRule>();
+
+        var issues = _analyzer.CheckInterVlanIsolation(rules, networks);
+
+        // Should NOT flag Corporate → Media (trusted can reach down)
+        // Note: Media → Corporate IS expected to be flagged, so check direction via message start
+        issues.Should().NotContain(i => i.Type == "MISSING_ISOLATION" &&
+            i.Message.StartsWith("No rule blocking Corporate"));
+    }
+
+    [Fact]
+    public void CheckInterVlanIsolation_GuestToMedia_NoBlockRule_NotFlagged()
+    {
+        // Guest → Media: guests can access media/entertainment, no isolation required
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Guest WiFi", NetworkPurpose.Guest, id: "guest-net-id", networkIsolationEnabled: false),
+            CreateNetwork("Media", NetworkPurpose.Media, id: "media-net-id")
+        };
+        var rules = new List<FirewallRule>();
+
+        var issues = _analyzer.CheckInterVlanIsolation(rules, networks);
+
+        // Should NOT flag Guest → Media
+        issues.Should().NotContain(i => i.Type == "MISSING_ISOLATION" &&
+            i.Message.Contains("Guest") && i.Message.Contains("Media"));
+    }
+
+    [Fact]
+    public void CheckInterVlanIsolation_IoTAndMedia_NoPeerIsolation()
+    {
+        // IoT ↔ Media are peers: no isolation required between them
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("IoT Devices", NetworkPurpose.IoT, id: "iot-net-id"),
+            CreateNetwork("Media", NetworkPurpose.Media, id: "media-net-id")
+        };
+        var rules = new List<FirewallRule>();
+
+        var issues = _analyzer.CheckInterVlanIsolation(rules, networks);
+
+        // Should NOT flag IoT → Media or Media → IoT
+        issues.Should().NotContain(i => i.Type == "MISSING_ISOLATION" &&
+            i.Message.Contains("IoT") && i.Message.Contains("Media"));
+        issues.Should().NotContain(i => i.Type == "MISSING_ISOLATION" &&
+            i.Message.Contains("Media") && i.Message.Contains("IoT"));
+    }
+
+    [Fact]
+    public void CheckInterVlanIsolation_MediaToServer_NoBlockRule_FlaggedAsMissing()
+    {
+        // Media to Server without a block rule should be flagged
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Media", NetworkPurpose.Media, id: "media-net-id"),
+            CreateNetwork("Server VLAN", NetworkPurpose.Server, id: "server-net-id")
+        };
+        var rules = new List<FirewallRule>();
+
+        var issues = _analyzer.CheckInterVlanIsolation(rules, networks);
+
+        issues.Should().Contain(i => i.Type == "MISSING_ISOLATION" &&
+            i.Message.Contains("Media") && i.Message.Contains("Server"));
+    }
+
+    [Fact]
+    public void CheckInterVlanIsolation_MediaWithIsolation_ToCorporate_NoIssue()
+    {
+        // Media with isolation enabled can't reach other VLANs, so no issue
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Media", NetworkPurpose.Media, id: "media-net-id", networkIsolationEnabled: true),
+            CreateNetwork("Corporate", NetworkPurpose.Corporate, id: "corp-net-id")
+        };
+        var rules = new List<FirewallRule>();
+
+        var issues = _analyzer.CheckInterVlanIsolation(rules, networks);
+
+        issues.Should().NotContain(i => i.Type == "MISSING_ISOLATION" &&
+            i.Message.Contains("Media") && i.Message.Contains("Corporate"));
+    }
+
+    [Fact]
+    public void CheckInterVlanIsolation_AllowRuleMediaToCorporate_FlaggedAsIsolationBypassed()
+    {
+        // Allow rule from Media to Corporate should be flagged
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Media", NetworkPurpose.Media, id: "media-net-id"),
+            CreateNetwork("Corporate", NetworkPurpose.Corporate, id: "corp-net-id")
+        };
+        var rules = new List<FirewallRule>
+        {
+            new FirewallRule
+            {
+                Id = "allow-media-corp",
+                Name = "Allow Media to Corp",
+                Action = "ALLOW",
+                Enabled = true,
+                SourceMatchingTarget = "NETWORK",
+                SourceNetworkIds = new List<string> { "media-net-id" },
+                DestinationMatchingTarget = "NETWORK",
+                DestinationNetworkIds = new List<string> { "corp-net-id" }
+            }
+        };
+
+        var issues = _analyzer.CheckInterVlanIsolation(rules, networks);
+
+        issues.Should().Contain(i => i.Type == "ISOLATION_BYPASSED" &&
+            i.RuleId == "FW-ISOLATION-BYPASS" &&
+            i.Message.Contains("Allow Media to Corp"));
+    }
+
+    #endregion
+
     [Fact]
     public void CheckInterVlanIsolation_BlockRuleWithConnectionStateAll_NoIssue()
     {

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/VlanAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/VlanAnalyzerTests.cs
@@ -133,6 +133,42 @@ public class VlanAnalyzerTests
     }
 
     [Fact]
+    public void AnalyzeNetworkIsolation_MediaNetworkNotIsolated_ReturnsRecommendedIssue()
+    {
+        // Arrange
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Media", NetworkPurpose.Media, vlanId: 70, networkIsolationEnabled: false)
+        };
+
+        // Act
+        var issues = _analyzer.AnalyzeNetworkIsolation(networks);
+
+        // Assert
+        issues.Should().HaveCount(1);
+        issues[0].Type.Should().Be("MEDIA_NOT_ISOLATED");
+        issues[0].Severity.Should().Be(AuditSeverity.Recommended);
+        issues[0].ScoreImpact.Should().Be(10);
+        issues[0].RuleId.Should().Be("NET-ISO-006");
+    }
+
+    [Fact]
+    public void AnalyzeNetworkIsolation_MediaNetworkIsolated_ReturnsNoIssues()
+    {
+        // Arrange
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Media", NetworkPurpose.Media, vlanId: 70, networkIsolationEnabled: true)
+        };
+
+        // Act
+        var issues = _analyzer.AnalyzeNetworkIsolation(networks);
+
+        // Assert
+        issues.Should().BeEmpty();
+    }
+
+    [Fact]
     public void AnalyzeNetworkIsolation_NativeVlan_SkipsCheck()
     {
         // Arrange - Native VLAN (ID 1) should be skipped for non-Management purposes
@@ -852,16 +888,16 @@ public class VlanAnalyzerTests
     }
 
     [Theory]
-    [InlineData("Entertainment", NetworkPurpose.IoT)]
-    [InlineData("Entertainment VLAN", NetworkPurpose.IoT)]
-    [InlineData("Streaming Devices", NetworkPurpose.IoT)]
-    [InlineData("Home Theater", NetworkPurpose.IoT)]
-    [InlineData("Theatre Room", NetworkPurpose.IoT)]
-    [InlineData("Recreation Room", NetworkPurpose.IoT)]
-    [InlineData("Living Room", NetworkPurpose.IoT)]
-    public void ClassifyNetwork_EntertainmentPatterns_ReturnsIoT(string networkName, NetworkPurpose expected)
+    [InlineData("Entertainment", NetworkPurpose.Media)]
+    [InlineData("Entertainment VLAN", NetworkPurpose.Media)]
+    [InlineData("Streaming Devices", NetworkPurpose.Media)]
+    [InlineData("Home Theater", NetworkPurpose.Media)]
+    [InlineData("Theatre Room", NetworkPurpose.Media)]
+    [InlineData("Recreation Room", NetworkPurpose.Media)]
+    [InlineData("Living Room", NetworkPurpose.Media)]
+    public void ClassifyNetwork_MediaPatterns_ReturnsMedia(string networkName, NetworkPurpose expected)
     {
-        // Entertainment networks should classify as IoT - isolated but internet-enabled
+        // Entertainment/media networks should classify as Media
         var result = _analyzer.ClassifyNetwork(networkName);
         result.Should().Be(expected);
     }
@@ -873,22 +909,22 @@ public class VlanAnalyzerTests
     [InlineData("A/V Room")]          // Explicit "a/v" pattern match
     [InlineData("TV Network")]        // Word boundary match for "tv"
     [InlineData("Smart TV")]          // Word boundary match for "tv"
-    public void ClassifyNetwork_EntertainmentWordBoundary_ReturnsIoT(string networkName)
+    public void ClassifyNetwork_MediaWordBoundary_ReturnsMedia(string networkName)
     {
-        // Entertainment patterns with word boundary should match IoT
+        // Media patterns with word boundary should match Media
         var result = _analyzer.ClassifyNetwork(networkName);
-        result.Should().Be(NetworkPurpose.IoT);
+        result.Should().Be(NetworkPurpose.Media);
     }
 
     [Theory]
     [InlineData("Dave's Network")]    // "Dave" contains "av" but shouldn't match due to word boundary
     [InlineData("AVLAN")]             // "AVLAN" contains "av" but not as a word
     [InlineData("SocialMedia")]       // "SocialMedia" contains "media" but not as a word
-    public void ClassifyNetwork_FalsePositivePatterns_DoesNotMatchIoT(string networkName)
+    public void ClassifyNetwork_FalsePositivePatterns_DoesNotMatchMedia(string networkName)
     {
-        // These patterns should NOT match IoT due to word boundary requirements
+        // These patterns should NOT match Media due to word boundary requirements
         var result = _analyzer.ClassifyNetwork(networkName);
-        result.Should().NotBe(NetworkPurpose.IoT);
+        result.Should().NotBe(NetworkPurpose.Media);
     }
 
     [Theory]
@@ -1003,17 +1039,17 @@ public class VlanAnalyzerTests
     }
 
     [Theory]
-    [InlineData("Gaming", NetworkPurpose.Home)]
-    [InlineData("Gaming VLAN", NetworkPurpose.Home)]
-    [InlineData("Gamers Network", NetworkPurpose.Home)]
-    [InlineData("Xbox Network", NetworkPurpose.Home)]
-    [InlineData("PlayStation VLAN", NetworkPurpose.Home)]
-    [InlineData("Nintendo Devices", NetworkPurpose.Home)]
-    [InlineData("Console Network", NetworkPurpose.Home)]
-    [InlineData("LAN Party", NetworkPurpose.Home)]
-    public void ClassifyNetwork_GamingPatterns_ReturnsHome(string networkName, NetworkPurpose expected)
+    [InlineData("Gaming", NetworkPurpose.Gaming)]
+    [InlineData("Gaming VLAN", NetworkPurpose.Gaming)]
+    [InlineData("Gamers Network", NetworkPurpose.Gaming)]
+    [InlineData("Xbox Network", NetworkPurpose.Gaming)]
+    [InlineData("PlayStation VLAN", NetworkPurpose.Gaming)]
+    [InlineData("Nintendo Devices", NetworkPurpose.Gaming)]
+    [InlineData("Console Network", NetworkPurpose.Gaming)]
+    [InlineData("LAN Party", NetworkPurpose.Gaming)]
+    public void ClassifyNetwork_GamingPatterns_ReturnsGaming(string networkName, NetworkPurpose expected)
     {
-        // Gaming networks should classify as Home because game consoles need UPnP and full network access
+        // Gaming networks should classify as Gaming - same trust level as Home
         var result = _analyzer.ClassifyNetwork(networkName);
         result.Should().Be(expected);
     }
@@ -1022,11 +1058,11 @@ public class VlanAnalyzerTests
     [InlineData("Game Room")]      // Word boundary match for "game"
     [InlineData("Games")]          // Explicit "games" pattern match
     [InlineData("Game Network")]   // Word boundary match for "game"
-    public void ClassifyNetwork_GameWordBoundary_ReturnsHome(string networkName)
+    public void ClassifyNetwork_GameWordBoundary_ReturnsGaming(string networkName)
     {
-        // "Game" with word boundary should match Home
+        // "Game" with word boundary should match Gaming
         var result = _analyzer.ClassifyNetwork(networkName);
-        result.Should().Be(NetworkPurpose.Home);
+        result.Should().Be(NetworkPurpose.Gaming);
     }
 
     [Fact]
@@ -1180,10 +1216,10 @@ public class VlanAnalyzerTests
     }
 
     [Theory]
-    [InlineData("media-room", NetworkPurpose.IoT)]             // Hyphen delimiter
-    [InlineData("av-equipment", NetworkPurpose.IoT)]           // Hyphen delimiter
-    [InlineData("tv-network", NetworkPurpose.IoT)]             // Hyphen delimiter
-    [InlineData("game-room", NetworkPurpose.Home)]             // Hyphen delimiter
+    [InlineData("media-room", NetworkPurpose.Media)]            // Hyphen delimiter
+    [InlineData("av-equipment", NetworkPurpose.Media)]         // Hyphen delimiter
+    [InlineData("tv-network", NetworkPurpose.Media)]           // Hyphen delimiter
+    [InlineData("game-room", NetworkPurpose.Gaming)]           // Hyphen delimiter
     [InlineData("not-vlan", NetworkPurpose.Security)]          // Hyphen delimiter for "NoT"
     public void ClassifyNetwork_WordBoundary_HyphenDelimiter_OtherPatterns(string networkName, NetworkPurpose expected)
     {
@@ -1485,12 +1521,12 @@ public class VlanAnalyzerTests
     [Theory]
     [InlineData("IoT Devices", true)]
     [InlineData("Smart Home", true)]
-    [InlineData("Entertainment", true)]       // Entertainment patterns classify as IoT
-    [InlineData("Streaming Devices", true)]   // Streaming patterns classify as IoT
-    [InlineData("Media Room", true)]          // Media word boundary match
-    [InlineData("TV Network", true)]          // TV word boundary match
+    [InlineData("Entertainment", false)]      // Entertainment patterns classify as Media, not IoT
+    [InlineData("Streaming Devices", false)]  // Streaming patterns classify as Media, not IoT
+    [InlineData("Media Room", false)]         // Media word boundary → Media, not IoT
+    [InlineData("TV Network", false)]         // TV word boundary → Media, not IoT
     [InlineData("Corporate", false)]
-    [InlineData("Gaming", false)]             // Gaming is Home, not IoT
+    [InlineData("Gaming", false)]             // Gaming is Gaming, not IoT
     [InlineData(null, false)]
     [InlineData("", false)]
     public void IsIoTNetwork_VariousInputs_ReturnsExpected(string? networkName, bool expected)
@@ -1500,21 +1536,60 @@ public class VlanAnalyzerTests
     }
 
     [Theory]
+    [InlineData("Entertainment", true)]
+    [InlineData("Streaming Devices", true)]
+    [InlineData("Media Room", true)]
+    [InlineData("TV Network", true)]
+    [InlineData("AV Equipment", true)]
+    [InlineData("A/V Room", true)]
+    [InlineData("Home Theater", true)]
+    [InlineData("IoT Devices", false)]
+    [InlineData("Corporate", false)]
+    [InlineData("Dave's Network", false)]     // Word boundary prevents match
+    [InlineData("SocialMedia", false)]        // Word boundary prevents match
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    public void IsMediaNetwork_VariousInputs_ReturnsExpected(string? networkName, bool expected)
+    {
+        var result = _analyzer.IsMediaNetwork(networkName);
+        result.Should().Be(expected);
+    }
+
+    [Theory]
     [InlineData("Home", true)]
     [InlineData("Main Network", true)]
-    [InlineData("Gaming", true)]              // Gaming patterns classify as Home
-    [InlineData("Game Room", true)]           // Game word boundary match
-    [InlineData("Xbox Network", true)]        // Xbox is gaming = Home
-    [InlineData("PlayStation", true)]         // PlayStation is gaming = Home
-    [InlineData("Console VLAN", true)]        // Console is gaming = Home
+    [InlineData("Gaming", false)]             // Gaming is now its own type
+    [InlineData("Game Room", false)]          // Game word boundary → Gaming, not Home
+    [InlineData("Xbox Network", false)]       // Xbox is Gaming, not Home
+    [InlineData("PlayStation", false)]        // PlayStation is Gaming, not Home
+    [InlineData("Console VLAN", false)]       // Console is Gaming, not Home
     [InlineData("Corporate", false)]
     [InlineData("IoT", false)]
-    [InlineData("Entertainment", false)]      // Entertainment is IoT, not Home
+    [InlineData("Entertainment", false)]      // Entertainment is Media, not Home
     [InlineData(null, false)]
     [InlineData("", false)]
     public void IsHomeNetwork_VariousInputs_ReturnsExpected(string? networkName, bool expected)
     {
         var result = _analyzer.IsHomeNetwork(networkName);
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Gaming", true)]
+    [InlineData("Game Room", true)]
+    [InlineData("Xbox Network", true)]
+    [InlineData("PlayStation", true)]
+    [InlineData("Console VLAN", true)]
+    [InlineData("LAN Party", true)]
+    [InlineData("Home", false)]
+    [InlineData("Corporate", false)]
+    [InlineData("IoT", false)]
+    [InlineData("GameChanger", false)]        // Word boundary prevents match
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    public void IsGamingNetwork_VariousInputs_ReturnsExpected(string? networkName, bool expected)
+    {
+        var result = _analyzer.IsGamingNetwork(networkName);
         result.Should().Be(expected);
     }
 


### PR DESCRIPTION
## Summary

- **Media** purpose for entertainment networks (streaming, theater, A/V) - previously auto-classified as IoT, causing false-positive `IsolationBypassed` criticals when intentional allow rules exist (e.g., "Allow Guest to Media")
- **Gaming** purpose for game console networks (Xbox, PlayStation, etc.) - previously auto-classified as Home, now a distinct type with the same trust rules

### Trust hierarchy

| Tier | Purpose | Behavior |
|------|---------|----------|
| Protected | Security, Management | Nothing reaches these without explicit rules |
| Trusted | Corporate, Home, Gaming, Server | Can reach down to Media/IoT |
| Semi-trusted | Media, IoT | Peers (no isolation between them), blocked from reaching trusted |
| Untrusted | Guest | Blocked from trusted/IoT, but CAN access Media |

### Changes

- New `Media` and `Gaming` enum values with pattern-based auto-classification
- Media isolation check (Recommended severity, same as IoT)
- Firewall isolation rules: Media/Gaming follow the trust hierarchy above
- UPnP: Gaming treated same as Home (consoles need UPnP)
- UI: Media and Gaming added to purpose override dropdown

## Test plan

- [x] `dotnet build` - 0 warnings
- [x] `dotnet test` - all 4,197 tests pass
- [x] Deployed to NAS and Mac test sites
- [x] Run audit on NAS - verify "Media" network auto-classifies as Media (not IoT)
- [x] Verify "Allow Guest to Media" no longer triggers IsolationBypassed
- [x] Verify Gaming network auto-classifies as Gaming (not Home)