### PR TITLE
Fix LAG speed detection in reversed server chain path

### DIFF
--- a/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
+++ b/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
@@ -1593,6 +1593,11 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                     if (chainDevice.Type == DeviceType.Gateway)
                         continue;
 
+                    // Ingress = upstream-facing port (toward gateway), not downstream chainPort
+                    // chainPort is the downstream-facing port (toward server) stored during chain building.
+                    // For LAG setups, the upstream port may have different aggregate speed than downstream.
+                    int? ingressPort = chainDevice.LocalUplinkPort ?? chainPort;
+
                     var hop = new NetworkHop
                     {
                         Order = hopOrder++,
@@ -1602,13 +1607,17 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                         DeviceModel = UniFiProductDatabase.GetBestProductName(chainDevice.Model, chainDevice.Shortname),
                         DeviceFirmware = chainDevice.Firmware,
                         DeviceIp = chainDevice.IpAddress,
-                        IngressSpeedMbps = GetPortSpeedFromRawDevices(rawDevices, chainDevice.Mac, chainPort),
-                        IngressPort = chainPort,
-                        IngressPortName = GetPortName(rawDevices, chainDevice.Mac, chainPort),
+                        IngressSpeedMbps = GetPortSpeedFromRawDevices(rawDevices, chainDevice.Mac, ingressPort),
+                        IngressPort = ingressPort,
+                        IngressPortName = GetPortName(rawDevices, chainDevice.Mac, ingressPort),
+                        // Egress = downstream-facing port (toward server)
+                        EgressPort = chainPort,
+                        EgressSpeedMbps = GetPortSpeedFromRawDevices(rawDevices, chainDevice.Mac, chainPort),
+                        EgressPortName = GetPortName(rawDevices, chainDevice.Mac, chainPort),
                         Notes = "Path from gateway"
                     };
 
-                    // Set egress to server's port if this is server's switch
+                    // Override egress for server's switch (egress to server's specific port)
                     if (chainDevice.Mac.Equals(serverPosition.SwitchMac, StringComparison.OrdinalIgnoreCase))
                     {
                         hop.EgressPort = serverPosition.SwitchPort;
@@ -1819,6 +1828,9 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                     var (chainDevice, chainPort) = serverChain[i];
                     hopOrder++;
 
+                    // Ingress = upstream-facing port (toward common ancestor), not downstream chainPort
+                    int? ingressPort = chainDevice.LocalUplinkPort ?? chainPort;
+
                     var hop = new NetworkHop
                     {
                         Order = hopOrder,
@@ -1828,9 +1840,9 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                         DeviceModel = UniFiProductDatabase.GetBestProductName(chainDevice.Model, chainDevice.Shortname),
                         DeviceFirmware = chainDevice.Firmware,
                         DeviceIp = chainDevice.IpAddress,
-                        IngressPort = chainPort,
-                        IngressPortName = GetPortName(rawDevices, chainDevice.Mac, chainPort),
-                        IngressSpeedMbps = GetPortSpeedFromRawDevices(rawDevices, chainDevice.Mac, chainPort)
+                        IngressPort = ingressPort,
+                        IngressPortName = GetPortName(rawDevices, chainDevice.Mac, ingressPort),
+                        IngressSpeedMbps = GetPortSpeedFromRawDevices(rawDevices, chainDevice.Mac, ingressPort)
                     };
 
                     // Set egress based on position in chain
@@ -1860,7 +1872,6 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                 // Add server chain in reverse (from gateway down to server's switch)
                 // Note: We DON'T skip devices that appear in target path (except gateway)
                 // because traffic actually traverses them twice in inter-VLAN routing
-                bool isFirstAfterGateway = true;
                 for (int i = serverChain.Count - 1; i >= 0; i--)
                 {
                     var (chainDevice, chainPort) = serverChain[i];
@@ -1871,28 +1882,12 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
 
                     hopOrder++;
 
-                    // For the first device after gateway, traffic enters via the device's uplink port
-                    // (the port facing the gateway), not the downstream port from serverChain.
-                    // Use LocalUplinkPort and UplinkSpeedMbps which correctly reflect the negotiated
-                    // link speed (e.g., SFP+ running at 1 GbE instead of 10 GbE).
-                    int? ingressPort;
-                    int ingressSpeed;
-                    string? ingressPortName;
-
-                    if (isFirstAfterGateway && chainDevice.LocalUplinkPort.HasValue)
-                    {
-                        ingressPort = chainDevice.LocalUplinkPort;
-                        ingressSpeed = chainDevice.UplinkSpeedMbps;
-                        ingressPortName = GetPortName(rawDevices, chainDevice.Mac, chainDevice.LocalUplinkPort);
-                        isFirstAfterGateway = false;
-                    }
-                    else
-                    {
-                        ingressPort = chainPort;
-                        ingressSpeed = GetPortSpeedFromRawDevices(rawDevices, chainDevice.Mac, chainPort);
-                        ingressPortName = GetPortName(rawDevices, chainDevice.Mac, chainPort);
-                        isFirstAfterGateway = false;
-                    }
+                    // Ingress = upstream-facing port (toward gateway), not downstream chainPort.
+                    // LocalUplinkPort correctly identifies the port facing upstream, which may be
+                    // part of a LAG (e.g., 2x10G aggregate) vs chainPort which faces downstream.
+                    int? ingressPort = chainDevice.LocalUplinkPort ?? chainPort;
+                    int ingressSpeed = GetPortSpeedFromRawDevices(rawDevices, chainDevice.Mac, ingressPort);
+                    string? ingressPortName = GetPortName(rawDevices, chainDevice.Mac, ingressPort);
 
                     var hop = new NetworkHop
                     {
@@ -1906,10 +1901,14 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                         IngressSpeedMbps = ingressSpeed,
                         IngressPort = ingressPort,
                         IngressPortName = ingressPortName,
+                        // Egress = downstream-facing port (toward server)
+                        EgressPort = chainPort,
+                        EgressSpeedMbps = GetPortSpeedFromRawDevices(rawDevices, chainDevice.Mac, chainPort),
+                        EgressPortName = GetPortName(rawDevices, chainDevice.Mac, chainPort),
                         Notes = "Return path from gateway"
                     };
 
-                    // Set egress to server's port if this is server's switch
+                    // Override egress for server's switch (egress to server's specific port)
                     if (chainDevice.Mac.Equals(serverPosition.SwitchMac, StringComparison.OrdinalIgnoreCase))
                     {
                         hop.EgressPort = serverPosition.SwitchPort;

--- a/tests/NetworkOptimizer.UniFi.Tests/DaisyChainPathTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/DaisyChainPathTests.cs
@@ -300,4 +300,94 @@ public class DaisyChainPathTests
     }
 
     #endregion
+
+    #region LAG Speed Tests
+
+    /// <summary>
+    /// When target is gateway and intermediate switches have LAG uplinks,
+    /// ingress should use LocalUplinkPort (LAG aggregate speed) not downstream chainPort.
+    /// Topology: Gateway -> Switch1 -> [LAG 2x10G] -> Switch2 -> Server
+    /// Switch1 egress toward Switch2 should show LAG aggregate (20 Gbps).
+    /// Switch2 ingress from Switch1 should show LAG aggregate (20 Gbps).
+    /// </summary>
+    [Fact]
+    public void BuildHopList_TargetIsGateway_LagUplink_ShowsAggregateSpeed()
+    {
+        // Arrange
+        var topology = NetworkTestData.CreateLagDaisyChainTopology();
+        var serverPosition = NetworkTestData.CreateDaisyChainServerPosition();
+        var rawDevices = NetworkTestData.CreateLagDaisyChainRawDevices();
+        var gateway = topology.Devices.First(d => d.Type == DeviceType.Gateway);
+        var path = new NetworkPath
+        {
+            SourceHost = serverPosition.IpAddress,
+            DestinationHost = gateway.IpAddress,
+            SourceVlanId = 1,
+            DestinationVlanId = 1,
+            RequiresRouting = false,
+            TargetIsGateway = true
+        };
+
+        // Act
+        _analyzer.BuildHopList(path, serverPosition, gateway, null, topology, rawDevices);
+
+        // Assert
+        path.Hops.Should().NotBeEmpty();
+
+        // Switch1 (Core Agg): egress port 5 is LAG parent (5+7) = 20 Gbps
+        var switch1Hop = path.Hops.FirstOrDefault(h => h.DeviceMac == NetworkTestData.Switch1Mac);
+        switch1Hop.Should().NotBeNull("Switch1 should be in path");
+        switch1Hop!.EgressSpeedMbps.Should().Be(20000,
+            "Switch1 egress port 5 is LAG parent (5+7 = 2x10G = 20 Gbps)");
+
+        // Switch2 (Core Switch): ingress port 17 is LAG parent (17+18) = 20 Gbps
+        var switch2Hop = path.Hops.FirstOrDefault(h => h.DeviceMac == NetworkTestData.Switch2Mac);
+        switch2Hop.Should().NotBeNull("Switch2 should be in path");
+        switch2Hop!.IngressSpeedMbps.Should().Be(20000,
+            "Switch2 ingress port 17 is LAG parent (17+18 = 2x10G = 20 Gbps)");
+
+        // Switch2 egress to server should be 2.5 Gbps (non-LAG port 3)
+        switch2Hop.EgressSpeedMbps.Should().Be(2500,
+            "Switch2 egress port 3 is a regular 2.5G port (server connection)");
+    }
+
+    /// <summary>
+    /// When server is downstream in a daisy-chain with LAG uplinks,
+    /// the reversed server chain should use LocalUplinkPort for ingress speed.
+    /// Topology: Gateway -> Switch1 -> [LAG 2x10G] -> Switch2 -> Server
+    /// NAS client on Switch1, Server on Switch2 (same VLAN = L2 path).
+    /// Switch2 ingress from Switch1 should show LAG aggregate (20 Gbps), not 2.5 Gbps.
+    /// </summary>
+    [Fact]
+    public void BuildHopList_DaisyChain_LagUplink_ShowsAggregateSpeed()
+    {
+        // Arrange
+        var topology = NetworkTestData.CreateLagDaisyChainTopology();
+        var serverPosition = NetworkTestData.CreateDaisyChainServerPosition();
+        var rawDevices = NetworkTestData.CreateLagDaisyChainRawDevices();
+        var client = topology.Clients.First(c => c.Mac == NetworkTestData.NasMac);
+        var path = new NetworkPath
+        {
+            SourceHost = serverPosition.IpAddress,
+            DestinationHost = client.IpAddress,
+            SourceVlanId = 1,
+            DestinationVlanId = 1,
+            RequiresRouting = false
+        };
+
+        // Act
+        _analyzer.BuildHopList(path, serverPosition, null, client, topology, rawDevices);
+
+        // Assert
+        path.Hops.Should().NotBeEmpty();
+
+        // Switch2 is added via the reversed server chain (below common ancestor Switch1).
+        // Its ingress should use LocalUplinkPort=17 (LAG 17+18 = 20 Gbps), not chainPort.
+        var switch2Hop = path.Hops.FirstOrDefault(h => h.DeviceMac == NetworkTestData.Switch2Mac);
+        switch2Hop.Should().NotBeNull("Switch2 should be in path");
+        switch2Hop!.IngressSpeedMbps.Should().Be(20000,
+            "Switch2 ingress should use LAG aggregate (port 17+18 = 20 Gbps) via LocalUplinkPort");
+    }
+
+    #endregion
 }

--- a/tests/NetworkOptimizer.UniFi.Tests/Fixtures/NetworkTestData.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/Fixtures/NetworkTestData.cs
@@ -74,7 +74,8 @@ public static class NetworkTestData
         string model = "USW-24-PoE",
         string? uplinkMac = GatewayMac,
         int? uplinkPort = 1,
-        int uplinkSpeed = 1000)
+        int uplinkSpeed = 1000,
+        int? localUplinkPort = null)
     {
         return new DiscoveredDevice
         {
@@ -88,6 +89,7 @@ public static class NetworkTestData
             UplinkMac = uplinkMac,
             UplinkPort = uplinkPort,
             UplinkSpeedMbps = uplinkSpeed,
+            LocalUplinkPort = localUplinkPort,
             UplinkType = "wire",
             IsUplinkConnected = true,
             PortCount = 24
@@ -924,6 +926,7 @@ public static class NetworkTestData
                     State = 1,
                     UplinkMac = GatewayMac,
                     UplinkPort = 1,
+                    LocalUplinkPort = 1,
                     UplinkSpeedMbps = linkSpeedMbps,
                     UplinkType = "wire",
                     IsUplinkConnected = true,
@@ -942,6 +945,7 @@ public static class NetworkTestData
                     State = 1,
                     UplinkMac = Switch1Mac,
                     UplinkPort = 2,
+                    LocalUplinkPort = 1,
                     UplinkSpeedMbps = linkSpeedMbps,
                     UplinkType = "wire",
                     IsUplinkConnected = true,
@@ -1032,6 +1036,124 @@ public static class NetworkTestData
             NetworkName = "Default",
             VlanId = 1,
             IsWired = true
+        };
+    }
+
+    /// <summary>
+    /// Creates a daisy-chain topology with LAG between Switch1 and Switch2:
+    /// Gateway -> Switch1 (Core Agg) -> [LAG 2x10G] -> Switch2 (Core Switch) -> Server
+    ///                               \-> NAS (client)
+    ///
+    /// Switch1 ports: 1 (gateway uplink), 3 (NAS), 5 (LAG parent to Switch2), 7 (LAG child)
+    /// Switch2 ports: 3 (server), 17 (LAG parent to Switch1), 18 (LAG child)
+    /// </summary>
+    public static NetworkTopology CreateLagDaisyChainTopology()
+    {
+        return new NetworkTopology
+        {
+            Devices = new List<DiscoveredDevice>
+            {
+                CreateGateway(lanSpeed: 10000),
+
+                // Switch1 (Core Aggregation) - uplinks to Gateway, LAG to Switch2
+                new DiscoveredDevice
+                {
+                    Mac = Switch1Mac,
+                    IpAddress = Switch1Ip,
+                    Name = "Switch1-CoreAgg",
+                    Model = "USW-Enterprise-XG-24",
+                    Type = DeviceType.Switch,
+                    Adopted = true,
+                    State = 1,
+                    UplinkMac = GatewayMac,
+                    UplinkPort = 1,
+                    LocalUplinkPort = 1,
+                    UplinkSpeedMbps = 10000,
+                    UplinkType = "wire",
+                    IsUplinkConnected = true,
+                    PortCount = 24
+                },
+
+                // Switch2 (Core Switch) - LAG uplink to Switch1
+                new DiscoveredDevice
+                {
+                    Mac = Switch2Mac,
+                    IpAddress = Switch2Ip,
+                    Name = "Switch2-CoreSwitch",
+                    Model = "USW-Pro-Max-24-PoE",
+                    Type = DeviceType.Switch,
+                    Adopted = true,
+                    State = 1,
+                    UplinkMac = Switch1Mac,
+                    UplinkPort = 5,  // Port 5 on Switch1 (LAG parent)
+                    LocalUplinkPort = 17,  // Port 17 on Switch2 (LAG parent)
+                    UplinkSpeedMbps = 10000,
+                    UplinkType = "wire",
+                    IsUplinkConnected = true,
+                    PortCount = 24
+                }
+            },
+            Clients = new List<DiscoveredClient>
+            {
+                new DiscoveredClient
+                {
+                    Mac = NasMac,
+                    IpAddress = NasIp,
+                    Hostname = "nas-server",
+                    Name = "NAS Server",
+                    IsWired = true,
+                    ConnectedToDeviceMac = Switch1Mac,
+                    SwitchPort = 3,
+                    Network = "Default",
+                    NetworkId = "1"
+                }
+            },
+            Networks = new List<NetworkInfo>
+            {
+                new NetworkInfo
+                {
+                    Id = "1",
+                    Name = "Default",
+                    VlanId = 1,
+                    IpSubnet = "192.0.2.0/24",
+                    Purpose = "corporate"
+                }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Creates raw device responses with port tables for the LAG daisy-chain topology.
+    /// Switch1: port 5 (LAG parent, 10G) + port 7 (LAG child, 10G) = 20G aggregate toward Switch2
+    /// Switch2: port 17 (LAG parent, 10G) + port 18 (LAG child, 10G) = 20G aggregate toward Switch1
+    /// </summary>
+    public static Dictionary<string, UniFiDeviceResponse> CreateLagDaisyChainRawDevices()
+    {
+        return new Dictionary<string, UniFiDeviceResponse>(StringComparer.OrdinalIgnoreCase)
+        {
+            [Switch1Mac] = new UniFiDeviceResponse
+            {
+                Mac = Switch1Mac,
+                Name = "Switch1-CoreAgg",
+                PortTable = new List<SwitchPort>
+                {
+                    new SwitchPort { PortIdx = 1, Speed = 10000, Up = true, Name = "Port 1" },
+                    new SwitchPort { PortIdx = 3, Speed = 2500, Up = true, Name = "Port 3" },
+                    new SwitchPort { PortIdx = 5, Speed = 10000, Up = true, Name = "Port 5", LagIdx = 1 },
+                    new SwitchPort { PortIdx = 7, Speed = 10000, Up = true, Name = "Port 7", LagIdx = 1, AggregatedBy = 5 }
+                }
+            },
+            [Switch2Mac] = new UniFiDeviceResponse
+            {
+                Mac = Switch2Mac,
+                Name = "Switch2-CoreSwitch",
+                PortTable = new List<SwitchPort>
+                {
+                    new SwitchPort { PortIdx = 3, Speed = 2500, Up = true, Name = "Port 3" },
+                    new SwitchPort { PortIdx = 17, Speed = 10000, Up = true, Name = "Port 17", LagIdx = 1 },
+                    new SwitchPort { PortIdx = 18, Speed = 10000, Up = true, Name = "Port 18", LagIdx = 1, AggregatedBy = 17 }
+                }
+            }
         };
     }
 


### PR DESCRIPTION
## Summary

- **Fix incorrect port used for ingress speed in reversed server chain** - When building network paths from gateway to server, the code used the downstream-facing port (`chainPort`) for ingress speed lookups instead of the upstream-facing port (`LocalUplinkPort`). For non-LAG setups this didn't matter (symmetric speeds), but for LAG setups it checked the wrong port - e.g., a 2.5G downlink port instead of a 20G LAG uplink aggregate.
- **Apply fix consistently to all 3 reversed chain loops** - Target-is-gateway, L2 daisy-chain, and inter-VLAN return path all had the same bug. Each now uses `LocalUplinkPort ?? chainPort` for ingress (falls back to old behavior when `LocalUplinkPort` is null).
- **Set egress on intermediate hops** - Previously only the server's switch got egress data. Now all hops in the reversed chain have both ingress and egress port/speed info.

Closes #349

## Test plan

- [x] 2 new LAG-specific tests verify aggregate speeds on both sides of the link
- [x] All 7 existing daisy-chain tests still pass (non-LAG behavior unchanged)
- [x] Full test suite passes (4,762 tests, 0 failures)
- [x] Deployed to NAS on `bugfix/lag-speed` - verify LAG speed shows correctly in LAN Speed Test path analysis