### PR TITLE
Add hourly speed test scheduling options

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -114,6 +114,9 @@
                                     <label>Frequency</label>
                                     <select class="form-control" value="@auditTask.FrequencyMinutes"
                                             @onchange="e => UpdateFrequency(auditTask, e)">
+                                        <option value="60">Every 1 hour</option>
+                                        <option value="120">Every 2 hours</option>
+                                        <option value="240">Every 4 hours</option>
                                         <option value="360">Every 6 hours</option>
                                         <option value="720">Every 12 hours</option>
                                         <option value="1440">Every 24 hours</option>
@@ -279,6 +282,9 @@
                             <div class="form-group schedule-field">
                                 <label>Frequency</label>
                                 <select class="form-control" @bind="_newWanFrequency">
+                                    <option value="60">Every 1 hour</option>
+                                    <option value="120">Every 2 hours</option>
+                                    <option value="240">Every 4 hours</option>
                                     <option value="360">Every 6 hours</option>
                                     <option value="720">Every 12 hours</option>
                                     <option value="1440">Every 24 hours</option>
@@ -409,6 +415,9 @@
                                 <div class="form-group schedule-field">
                                     <label>Frequency</label>
                                     <select class="form-control" @bind="_newLanFrequency">
+                                        <option value="60">Every 1 hour</option>
+                                        <option value="120">Every 2 hours</option>
+                                        <option value="240">Every 4 hours</option>
                                         <option value="360">Every 6 hours</option>
                                         <option value="720">Every 12 hours</option>
                                         <option value="1440">Every 24 hours</option>
@@ -2443,6 +2452,9 @@
 
     private static string FormatFrequency(int minutes) => minutes switch
     {
+        60 => "Every 1h",
+        120 => "Every 2h",
+        240 => "Every 4h",
         360 => "Every 6h",
         720 => "Every 12h",
         1440 => "Every 24h",


### PR DESCRIPTION
## Summary

- Add 1, 2, and 4 hour frequency options to all schedule dropdowns (audit, WAN speed test, LAN speed test)
- Update `FormatFrequency()` to display the new intervals
- Previous minimum was 6 hours; now supports hourly scheduling

## Test plan

- [x] Verify all three schedule creation dropdowns show 1h, 2h, 4h, 6h, 12h, 24h, 48h, 7d options
- [x] Verify existing schedule edit dropdown (audit) also shows the new options
- [x] Create a 1-hour schedule and confirm it calculates the correct next run time
- [x] Verify FormatFrequency displays "Every 1h", "Every 2h", "Every 4h" for existing scheduled tasks