### PR TITLE
Show next run time before first execution

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -125,17 +125,20 @@
                                     </select>
                                 </div>
                             </div>
-                            @if (auditTask.LastRunAt.HasValue)
+                            @if (auditTask.LastRunAt.HasValue || (auditTask.NextRunAt.HasValue && auditTask.Enabled))
                             {
                                 <div class="schedule-status">
-                                    <span class="schedule-status-item">
-                                        <span class="detail-label">Last run:</span>
-                                        <span class="detail-value">@FormatTime(auditTask.LastRunAt.Value)</span>
-                                        @if (!string.IsNullOrEmpty(auditTask.LastStatus))
-                                        {
-                                            <span class="status-badge @GetScheduleStatusClass(auditTask.LastStatus)">@auditTask.LastStatus</span>
-                                        }
-                                    </span>
+                                    @if (auditTask.LastRunAt.HasValue)
+                                    {
+                                        <span class="schedule-status-item">
+                                            <span class="detail-label">Last run:</span>
+                                            <span class="detail-value">@FormatTime(auditTask.LastRunAt.Value)</span>
+                                            @if (!string.IsNullOrEmpty(auditTask.LastStatus))
+                                            {
+                                                <span class="status-badge @GetScheduleStatusClass(auditTask.LastStatus)">@auditTask.LastStatus</span>
+                                            }
+                                        </span>
+                                    }
                                     @if (!string.IsNullOrEmpty(auditTask.LastResultSummary))
                                     {
                                         <span class="schedule-status-item">
@@ -214,17 +217,20 @@
                                         <span class="schedule-detail-tag tag-muted">@FormatStartTime(task.CustomMorningHour.Value, task.CustomMorningMinute ?? 0)</span>
                                     }
                                 </div>
-                                @if (task.LastRunAt.HasValue)
+                                @if (task.LastRunAt.HasValue || (task.NextRunAt.HasValue && task.Enabled))
                                 {
                                     <div class="schedule-status">
-                                        <span class="schedule-status-item">
-                                            <span class="detail-label">Last run:</span>
-                                            <span class="detail-value">@FormatTime(task.LastRunAt.Value)</span>
-                                            @if (!string.IsNullOrEmpty(task.LastStatus))
-                                            {
-                                                <span class="status-badge @GetScheduleStatusClass(task.LastStatus)">@task.LastStatus</span>
-                                            }
-                                        </span>
+                                        @if (task.LastRunAt.HasValue)
+                                        {
+                                            <span class="schedule-status-item">
+                                                <span class="detail-label">Last run:</span>
+                                                <span class="detail-value">@FormatTime(task.LastRunAt.Value)</span>
+                                                @if (!string.IsNullOrEmpty(task.LastStatus))
+                                                {
+                                                    <span class="status-badge @GetScheduleStatusClass(task.LastStatus)">@task.LastStatus</span>
+                                                }
+                                            </span>
+                                        }
                                         @if (!string.IsNullOrEmpty(task.LastResultSummary))
                                         {
                                             <span class="schedule-status-item">
@@ -364,17 +370,20 @@
                                     <span class="schedule-detail-tag">@task.TargetId</span>
                                 }
                             </div>
-                            @if (task.LastRunAt.HasValue)
+                            @if (task.LastRunAt.HasValue || (task.NextRunAt.HasValue && task.Enabled))
                             {
                                 <div class="schedule-status">
-                                    <span class="schedule-status-item">
-                                        <span class="detail-label">Last run:</span>
-                                        <span class="detail-value">@FormatTime(task.LastRunAt.Value)</span>
-                                        @if (!string.IsNullOrEmpty(task.LastStatus))
-                                        {
-                                            <span class="status-badge @GetScheduleStatusClass(task.LastStatus)">@task.LastStatus</span>
-                                        }
-                                    </span>
+                                    @if (task.LastRunAt.HasValue)
+                                    {
+                                        <span class="schedule-status-item">
+                                            <span class="detail-label">Last run:</span>
+                                            <span class="detail-value">@FormatTime(task.LastRunAt.Value)</span>
+                                            @if (!string.IsNullOrEmpty(task.LastStatus))
+                                            {
+                                                <span class="status-badge @GetScheduleStatusClass(task.LastStatus)">@task.LastStatus</span>
+                                            }
+                                        </span>
+                                    }
                                     @if (!string.IsNullOrEmpty(task.LastResultSummary))
                                     {
                                         <span class="schedule-status-item">


### PR DESCRIPTION
## Summary

- Schedule cards now display "Next run: in Xh Ym" immediately after creating a schedule, before the job has run for the first time
- Previously the entire status row (including next run) was gated behind `LastRunAt.HasValue`, so nothing showed until after the first execution
- Applied to all three schedule types: security audit, WAN speed tests, and LAN speed tests

## Test plan

- [x] Create a new WAN or LAN speed test schedule and verify "Next run: in Xh Ym" appears immediately
- [x] Verify existing schedules that have already run still show both "Last run" and "Next run"
- [x] Verify disabled schedules don't show "Next run"