### PR TITLE
Add edit functionality for scheduled speed tests

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -1496,7 +1496,7 @@
             {
                 <div class="schedule-card-header">
                     <div class="schedule-card-title">
-                        <span class="detail-label">New Schedule</span>
+                        <span class="detail-label">New Scheduled Test</span>
                     </div>
                 </div>
             }
@@ -1566,7 +1566,7 @@
                         {
                             <button class="btn btn-sm btn-primary" @onclick="CreateWanSchedule"
                                     disabled="@(!CanCreateWanSchedule || _creatingSchedule)">
-                                Add Schedule
+                                Add
                             </button>
                         }
                     </div>
@@ -1586,7 +1586,7 @@
             {
                 <div class="schedule-card-header">
                     <div class="schedule-card-title">
-                        <span class="detail-label">New Schedule</span>
+                        <span class="detail-label">New Scheduled Test</span>
                     </div>
                 </div>
             }
@@ -1632,7 +1632,7 @@
                         {
                             <button class="btn btn-sm btn-primary" @onclick="CreateLanSchedule"
                                     disabled="@(string.IsNullOrEmpty(_newLanDevice) || _creatingSchedule)">
-                                Add Schedule
+                                Add
                             </button>
                         }
                     </div>


### PR DESCRIPTION
## Summary

- Add Edit button to WAN and LAN speed test schedule cards
- Clicking Edit shows the form inline under the card with current settings populated
- Save updates the schedule in place (preserves execution history), Cancel resets
- Edit button shows "Editing..." and disables while editing that card
- Form markup extracted into RenderFragments to avoid duplication between add and edit modes
- Deleting a schedule that's being edited correctly re-enables the add form
- Multi-WAN combo schedules correctly pre-select in the dropdown when editing
- Add form has "New Scheduled Test" header to distinguish it from existing schedule cards

## Test plan

- [x] Edit a WAN schedule - verify fields populate correctly (test type, WAN, frequency, start time, max load)
- [x] Edit a LAN schedule - verify fields populate correctly (device, frequency, start time)
- [x] Save an edit - verify schedule updates and card reflects changes
- [x] Cancel an edit - verify form resets to add mode with defaults
- [x] Delete a schedule while editing it - verify add form reappears
- [x] Add a new schedule while none are being edited - verify add still works
- [x] Edit a multi-WAN combo schedule - verify correct combo pre-selects
- [x] Click Edit on one schedule, then Edit on another - verify form switches cleanly