### PR TITLE
Fix scan data notice on 6 GHz showing wrong message

### DIFF
--- a/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
@@ -73,6 +73,9 @@ public class InterferenceGraph
     public Dictionary<int, (int Utilization, int Interference)>[] ScanChannelData { get; set; } = [];
 
     public List<MeshConstraint> MeshConstraints { get; set; } = new();
+
+    /// <summary>Whether scan results existed for this band (UniFi provided RF scan data)</summary>
+    public bool HasScanData { get; set; }
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -169,6 +169,7 @@ public class ChannelRecommendationService
         // Build external load from RF scan data
         if (scanResults != null)
         {
+            graph.HasScanData = scanResults.Any(s => s.Band == band);
             BuildExternalLoad(graph, bandAps, band, scanResults);
             BuildScanChannelData(graph, bandAps, band, scanResults);
         }
@@ -272,7 +273,7 @@ public class ChannelRecommendationService
             CurrentNetworkScore = currentNetworkScore,
             RecommendedNetworkScore = bestScore,
             UnplacedApCount = graph.Nodes.Count(node => !node.IsPlaced),
-            HasScanData = graph.ScanChannelData.Any(d => d.Count > 0) || graph.ExternalLoad.Any(d => d.Count > 0),
+            HasScanData = graph.HasScanData,
             HasNeighborNetworks = graph.ExternalLoad.Any(d => d.Count > 0),
             HasBuildingData = hasBuildingData
         };


### PR DESCRIPTION
## Summary

- `HasScanData` was checking if the interference graph had populated data, but on 6 GHz with no neighbors and zero utilization, the graph ends up empty even though UniFi provided scan results
- Now checks if scan results exist for the band, so 6 GHz correctly shows "No neighbor networks detected" instead of "No RF scan data available"

## Test plan

- [x] Run channel recommendations on 6 GHz with no neighbor networks - verify "No neighbor networks detected" notice
- [x] All 4,113 tests pass