### PR TITLE
Fix channel recommendation recommending same bonding group for multiple APs

### DIFF
--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -159,7 +159,7 @@ public class ChannelRecommendationService
             var radio = ap.Radios.First(r => r.Band == band && r.Channel.HasValue);
             var isPlaced = propContext?.ApsByMac.ContainsKey(ap.Mac.ToLowerInvariant()) == true;
 
-            var (validChannels, effectiveWidth, hadDfsFallback) = GetValidChannelsWithWidth(band, radio, regulatoryData, opts.DfsPreference);
+            var (validChannels, effectiveWidth, hadDfsFallback) = GetValidChannelsWithWidth(band, radio, regulatoryData, opts.DfsPreference, radio.Channel!.Value);
             if (hadDfsFallback) graph.DfsAvoidanceFallback = true;
             var currentWidth = radio.ChannelWidth ?? 20;
 
@@ -959,7 +959,8 @@ public class ChannelRecommendationService
     private (int[] Channels, int Width, bool DfsFallback) GetValidChannelsWithWidth(
         RadioBand band, RadioSnapshot radio,
         RegulatoryChannelData? regulatoryData,
-        DfsPreference dfsPref)
+        DfsPreference dfsPref,
+        int currentChannel)
     {
         var width = radio.ChannelWidth ?? 20;
         var channels = GetValidChannels(band, radio, regulatoryData, dfsPref, width);
@@ -972,10 +973,37 @@ public class ChannelRecommendationService
             band == RadioBand.Band5GHz)
         {
             channels = GetValidChannels(band, radio, regulatoryData, DfsPreference.IncludeWithPenalty, width);
-            return (channels, width, true);
+            return (DeduplicateByBondingGroup(channels, band, width, currentChannel), width, true);
         }
 
-        return (channels, width, false);
+        return (DeduplicateByBondingGroup(channels, band, width, currentChannel), width, false);
+    }
+
+    /// <summary>
+    /// Deduplicate channels that map to the same bonding group at the given width.
+    /// At 80 MHz, channels 149/153/157/161 all produce the same (149-161) block,
+    /// so the optimizer should only see one of them. Keeps the lowest channel
+    /// (bonding group start) as the representative.
+    /// </summary>
+    private static int[] DeduplicateByBondingGroup(int[] channels, RadioBand band, int width, int? currentChannel = null)
+    {
+        if (width <= 20 || band == RadioBand.Band2_4GHz)
+            return channels;
+
+        var deduped = channels
+            .GroupBy(ch => ChannelSpanHelper.GetChannelSpan(band, ch, width))
+            .Select(g =>
+            {
+                // If the AP's current channel is in this group, keep it as the
+                // representative so the optimizer can correctly identify "no change"
+                if (currentChannel.HasValue && g.Contains(currentChannel.Value))
+                    return currentChannel.Value;
+                return g.Min();
+            })
+            .OrderBy(ch => ch)
+            .ToArray();
+
+        return deduped;
     }
 
     private int[] GetValidChannels(

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using NetworkOptimizer.WiFi.Data;
+using NetworkOptimizer.WiFi.Helpers;
 using NetworkOptimizer.WiFi.Models;
 using NetworkOptimizer.WiFi.Services;
 using Xunit;
@@ -475,5 +476,28 @@ public class ChannelRecommendationServiceTests
             rec.RecommendedChannel.Should().BeOneOf(new[] { 1, 6, 11 },
                 $"2.4 GHz should only recommend 1/6/11 but got {rec.RecommendedChannel}");
         }
+    }
+
+    [Fact]
+    public void Optimize_80MHz_DoesNotRecommendSameBondingGroup()
+    {
+        // Two APs on 80 MHz should not both end up in the 149-161 bonding group
+        // (ch 149 and ch 153 are the same 80 MHz block)
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "AP-1", RadioBand.Band5GHz, 36, width: 80),
+            CreateAp("aa:bb:cc:dd:ee:02", "AP-2", RadioBand.Band5GHz, 36, width: 80)
+        };
+        var graph = _service.BuildInterferenceGraph(aps, RadioBand.Band5GHz, null, null, null);
+        var plan = _service.Optimize(graph, RadioBand.Band5GHz, null);
+
+        var ch1 = plan.Recommendations[0].RecommendedChannel;
+        var ch2 = plan.Recommendations[1].RecommendedChannel;
+
+        // Verify they're in different bonding groups
+        var span1 = ChannelSpanHelper.GetChannelSpan(RadioBand.Band5GHz, ch1, 80);
+        var span2 = ChannelSpanHelper.GetChannelSpan(RadioBand.Band5GHz, ch2, 80);
+        ChannelSpanHelper.SpansOverlap(span1, span2).Should().BeFalse(
+            $"APs should be on different 80 MHz blocks but got ch{ch1} ({span1}) and ch{ch2} ({span2})");
     }
 }


### PR DESCRIPTION
## Summary

- At 80 MHz+, the valid channel list included every 20 MHz primary channel (e.g. 36, 40, 44, 48, 149, 153, 157, 161) when regulatory data fell back to the base channel list. The optimizer treated these as different options, but channels in the same bonding group (e.g. 149 and 153 at 80 MHz) produce identical RF blocks.
- This caused the engine to recommend ch 149 for one AP and ch 153 for another, appearing as different channels but actually co-channel interfering.
- Now deduplicates valid channels by bonding group, keeping one representative per group. The AP's current channel is preserved as the representative for its group so "no change" detection still works.
- Applies to all bands and widths > 20 MHz (5 GHz 40/80/160, 6 GHz 40/80/160/320).

## Test plan

- [x] Run channel recommendations on 5 GHz 80 MHz - verify APs land on different bonding groups
- [x] Check debug logs: `validCh` should show ~6 channels at 80 MHz (one per group) instead of 8
- [x] Verify 6 GHz 160 MHz recommendations also produce distinct groups
- [x] Verify existing behavior unchanged for 2.4 GHz and 20 MHz widths