### PR TITLE
Path trace fixes, signal bars, mesh overhead, and mobile UX

### DIFF
--- a/src/NetworkOptimizer.UniFi/Models/PathAnalysisResult.cs
+++ b/src/NetworkOptimizer.UniFi/Models/PathAnalysisResult.cs
@@ -144,7 +144,7 @@ public class PathAnalysisResult
     /// Overhead factors for different link types
     /// </summary>
     public const double ClientWifiOverheadFactor = 0.75;    // 25% overhead
-    public const double MeshBackhaulOverheadFactor = 0.45;  // 55% overhead
+    public const double MeshBackhaulOverheadFactor = 0.55;  // 45% overhead
     public const double WiredOverheadFactor = 0.94;         // 6% overhead
     public const double WanOverheadFactor = 0.94;           // 6% overhead
 
@@ -215,44 +215,43 @@ public class PathAnalysisResult
         {
             // Determine overhead based on path type
             double overheadFactor;
+            // Find mesh hop if present (used for overhead selection and max speed capping)
+            var meshHop = Path.Hops.FirstOrDefault(h =>
+                h.IngressPortName?.Contains("mesh", StringComparison.OrdinalIgnoreCase) == true ||
+                h.EgressPortName?.Contains("mesh", StringComparison.OrdinalIgnoreCase) == true);
+
             if (Path.IsExternalPath)
             {
                 // WAN/VPN paths use wired overhead (6%)
                 overheadFactor = WanOverheadFactor;
             }
-            else
+            else if (meshHop != null)
             {
-                // Find mesh hop if present
-                var meshHop = Path.Hops.FirstOrDefault(h =>
-                    h.IngressPortName?.Contains("mesh", StringComparison.OrdinalIgnoreCase) == true ||
-                    h.EgressPortName?.Contains("mesh", StringComparison.OrdinalIgnoreCase) == true);
-
-                if (meshHop != null)
+                // If target IS the mesh AP, mesh IS the connection - always use mesh overhead
+                if (Path.TargetIsAccessPoint)
                 {
-                    // If target IS the mesh AP, mesh IS the connection - always use mesh overhead
-                    if (Path.TargetIsAccessPoint)
-                    {
-                        overheadFactor = MeshBackhaulOverheadFactor;
-                    }
-                    else
-                    {
-                        // For Wi-Fi clients behind mesh: check if mesh is the bottleneck
-                        var meshSpeedMbps = meshHop.IngressSpeedMbps > 0 && meshHop.EgressSpeedMbps > 0
-                            ? Math.Min(meshHop.IngressSpeedMbps, meshHop.EgressSpeedMbps)
-                            : Math.Max(meshHop.IngressSpeedMbps, meshHop.EgressSpeedMbps);
-
-                        var clientSpeedMbps = Math.Min(wifiRxRateKbps.Value, wifiTxRateKbps.Value) / 1000.0;
-
-                        // Mesh overhead only if mesh is the bottleneck
-                        overheadFactor = meshSpeedMbps < clientSpeedMbps
-                            ? MeshBackhaulOverheadFactor
-                            : ClientWifiOverheadFactor;
-                    }
+                    overheadFactor = MeshBackhaulOverheadFactor;
                 }
                 else
                 {
-                    overheadFactor = ClientWifiOverheadFactor;
+                    // For Wi-Fi clients behind mesh: check if mesh is the bottleneck.
+                    // Use the speed from the mesh-specific port only - the other side of the hop
+                    // may be the client wireless link (not mesh).
+                    var meshSpeedMbps = meshHop.EgressPortName?.Contains("mesh", StringComparison.OrdinalIgnoreCase) == true
+                        ? meshHop.EgressSpeedMbps
+                        : meshHop.IngressSpeedMbps;
+
+                    var clientSpeedMbps = Math.Min(wifiRxRateKbps.Value, wifiTxRateKbps.Value) / 1000.0;
+
+                    // Mesh overhead only if mesh link is slower than client wifi
+                    overheadFactor = meshSpeedMbps > 0 && meshSpeedMbps < clientSpeedMbps
+                        ? MeshBackhaulOverheadFactor
+                        : ClientWifiOverheadFactor;
                 }
+            }
+            else
+            {
+                overheadFactor = ClientWifiOverheadFactor;
             }
             var overheadPercent = (int)Math.Round((1 - overheadFactor) * 100);
 
@@ -260,6 +259,18 @@ public class PathAnalysisResult
             // TX = AP transmits to client = ToDevice direction limit
             var fromDeviceMaxMbps = wifiRxRateKbps.Value / 1000.0;
             var toDeviceMaxMbps = wifiTxRateKbps.Value / 1000.0;
+
+            // When mesh is the bottleneck, cap max to mesh directional rates (client wifi is
+            // faster but data must traverse the slower mesh link). Mesh hop stores child AP's
+            // perspective: TX = child sends toward server (FromDevice), RX = child receives (ToDevice).
+            if (overheadFactor == MeshBackhaulOverheadFactor && meshHop != null)
+            {
+                if (meshHop.WirelessTxRateMbps is > 0)
+                    fromDeviceMaxMbps = Math.Min(fromDeviceMaxMbps, meshHop.WirelessTxRateMbps.Value);
+                if (meshHop.WirelessRxRateMbps is > 0)
+                    toDeviceMaxMbps = Math.Min(toDeviceMaxMbps, meshHop.WirelessRxRateMbps.Value);
+            }
+
             var fromRealistic = fromDeviceMaxMbps * overheadFactor;
             var toRealistic = toDeviceMaxMbps * overheadFactor;
 

--- a/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
+++ b/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
@@ -121,8 +121,8 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
     private static long FilterIdleRate(long rateKbps) =>
         rateKbps == WifiIdleRateKbps ? 0 : rateKbps;
 
-    // Mesh backhaul overhead factor - ~55% overhead due to half-duplex, retransmits, etc.
-    private const double MeshBackhaulOverheadFactor = 0.45;
+    // Mesh backhaul overhead factor - ~45% overhead due to half-duplex, retransmits, etc.
+    private const double MeshBackhaulOverheadFactor = 0.55;
 
     // WAN overhead factor - same as wired (6% overhead)
     private const double WanOverheadFactor = 0.94;
@@ -560,7 +560,7 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
             {
                 Order = 0,
                 Type = HopType.Wan,
-                DeviceName = "WAN",
+                DeviceName = !string.IsNullOrEmpty(wanNetwork?.Name) ? wanNetwork.Name : "WAN",
                 IngressSpeedMbps = wanDownloadMbps > 0 ? wanDownloadMbps : Math.Max(wanDownloadMbps, wanUploadMbps),
                 EgressSpeedMbps = wanUploadMbps > 0 ? wanUploadMbps : Math.Max(wanDownloadMbps, wanUploadMbps),
                 IngressPortName = "WAN",
@@ -702,7 +702,7 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                     Order = 0,
                     Type = targetClient.IsWired ? HopType.Client : HopType.WirelessClient,
                     DeviceMac = targetClient.Mac,
-                    DeviceName = targetClient.Name ?? targetClient.Hostname,
+                    DeviceName = !string.IsNullOrEmpty(targetClient.Name) ? targetClient.Name : targetClient.Hostname,
                     DeviceIp = targetClient.IpAddress,
                     Notes = targetClient.IsWired ? "Client (wired)" : $"Client ({targetClient.ConnectionType})"
                 };
@@ -786,6 +786,10 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                 else if (!string.IsNullOrEmpty(currentMac) && currentPort.HasValue)
                 {
                     deviceHop.IngressSpeedMbps = GetPortSpeedFromRawDevices(rawDevices, currentMac, currentPort);
+                    if (deviceHop.IngressSpeedMbps == 0 && targetDevice.LocalUplinkPort.HasValue)
+                    {
+                        deviceHop.IngressSpeedMbps = GetPortSpeedFromRawDevices(rawDevices, targetDevice.Mac, targetDevice.LocalUplinkPort);
+                    }
                     deviceHop.EgressSpeedMbps = deviceHop.IngressSpeedMbps;
                 }
 
@@ -806,6 +810,12 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                     && device.UplinkSpeedMbps > 0;
 
                 int ingressSpeed = GetPortSpeedFromRawDevices(rawDevices, currentMac, currentPort);
+                // If this device has no port table (e.g., AP with empty port_table),
+                // use the previous hop's egress speed (same physical link, same negotiated speed)
+                if (ingressSpeed == 0 && hops.Count > 0 && hops[^1].EgressSpeedMbps > 0)
+                {
+                    ingressSpeed = hops[^1].EgressSpeedMbps;
+                }
                 string? ingressPortName = GetPortName(rawDevices, currentMac, currentPort);
 
                 var hop = new NetworkHop
@@ -848,6 +858,12 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                     {
                         hop.EgressPort = device.UplinkPort;
                         hop.EgressSpeedMbps = GetPortSpeedFromRawDevices(rawDevices, device.UplinkMac, device.UplinkPort);
+                        // If upstream device has no port table (e.g., AP with empty port_table),
+                        // fall back to local device's uplink port speed (same physical link, same negotiated speed)
+                        if (hop.EgressSpeedMbps == 0 && device.LocalUplinkPort.HasValue)
+                        {
+                            hop.EgressSpeedMbps = GetPortSpeedFromRawDevices(rawDevices, device.Mac, device.LocalUplinkPort);
+                        }
                         hop.EgressPortName = GetPortName(rawDevices, device.UplinkMac, device.UplinkPort);
                     }
                 }
@@ -1466,6 +1482,12 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
             {
                 // Wired uplink - get port speed from upstream switch
                 deviceHop.IngressSpeedMbps = GetPortSpeedFromRawDevices(rawDevices, currentMac, currentPort);
+                // If upstream device has no port table (e.g., AP with empty port_table),
+                // fall back to local device's uplink port speed (same physical link, same negotiated speed)
+                if (deviceHop.IngressSpeedMbps == 0 && targetDevice.LocalUplinkPort.HasValue)
+                {
+                    deviceHop.IngressSpeedMbps = GetPortSpeedFromRawDevices(rawDevices, targetDevice.Mac, targetDevice.LocalUplinkPort);
+                }
                 deviceHop.EgressSpeedMbps = deviceHop.IngressSpeedMbps;
             }
 
@@ -1492,7 +1514,7 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                 Order = 0,
                 Type = targetClient.IsWired ? HopType.Client : HopType.WirelessClient,
                 DeviceMac = targetClient.Mac,
-                DeviceName = targetClient.Name ?? targetClient.Hostname,
+                DeviceName = !string.IsNullOrEmpty(targetClient.Name) ? targetClient.Name : targetClient.Hostname,
                 DeviceIp = targetClient.IpAddress,
                 Notes = targetClient.IsWired ? "Target client (wired)" : $"Target client ({targetClient.ConnectionType})"
             };
@@ -1729,6 +1751,12 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                 // Ingress speed comes from the port/connection from the PREVIOUS hop, not this device's uplink
                 // For APs after a wireless client, ingress is the client's wireless connection (handled by client hop's egress)
                 int ingressSpeed = GetPortSpeedFromRawDevices(rawDevices, currentMac, currentPort);
+                // If this device has no port table (e.g., AP with empty port_table),
+                // use the previous hop's egress speed (same physical link, same negotiated speed)
+                if (ingressSpeed == 0 && hops.Count > 0 && hops[^1].EgressSpeedMbps > 0)
+                {
+                    ingressSpeed = hops[^1].EgressSpeedMbps;
+                }
                 string? ingressPortName = GetPortName(rawDevices, currentMac, currentPort);
 
                 var hop = new NetworkHop
@@ -1795,6 +1823,12 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                     {
                         hop.EgressPort = device.UplinkPort;
                         hop.EgressSpeedMbps = GetPortSpeedFromRawDevices(rawDevices, device.UplinkMac, device.UplinkPort);
+                        // If upstream device has no port table (e.g., AP with empty port_table),
+                        // fall back to local device's uplink port speed (same physical link, same negotiated speed)
+                        if (hop.EgressSpeedMbps == 0 && device.LocalUplinkPort.HasValue)
+                        {
+                            hop.EgressSpeedMbps = GetPortSpeedFromRawDevices(rawDevices, device.Mac, device.LocalUplinkPort);
+                        }
                         hop.EgressPortName = GetPortName(rawDevices, device.UplinkMac, device.UplinkPort);
                     }
                 }
@@ -2085,7 +2119,7 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
             return new NetworkHop
             {
                 Type = HopType.Wan,
-                DeviceName = "WAN",
+                DeviceName = !string.IsNullOrEmpty(wanNetwork?.Name) ? wanNetwork.Name : "WAN",
                 DeviceIp = clientIp,
                 IngressSpeedMbps = wanDownloadMbps > 0 ? wanDownloadMbps : Math.Max(wanDownloadMbps, wanUploadMbps),
                 EgressSpeedMbps = wanUploadMbps > 0 ? wanUploadMbps : Math.Max(wanDownloadMbps, wanUploadMbps),

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -82,26 +82,58 @@
             el.addEventListener('scroll', onScroll, { passive: true });
         }
 
-        function onScroll() {
-            if (window.innerWidth > 768) return;
-            var st = currentEl.scrollTop;
-            var topBar = document.querySelector('.top-bar');
+        var autoHideTimer = null;
 
-            if (topBar && Math.abs(st - lastScrollTop) > 10) {
-                if (st > lastScrollTop && st > 60) {
+        function startAutoHideTimer(topBar) {
+            clearAutoHideTimer();
+            var page = document.querySelector('[data-autohide-nav]');
+            if (!page) return;
+            var delay = parseInt(page.getAttribute('data-autohide-nav')) || 3000;
+            autoHideTimer = setTimeout(function() {
+                var sidebarOpen = document.querySelector('.sidebar.open');
+                if (sidebarOpen) return;
+                if (topBar && !topBar.classList.contains('top-bar-hidden')) {
                     topBar.classList.add('top-bar-hidden');
-                    currentEl.style.scrollPaddingTop = '0px';
-                } else {
-                    topBar.classList.remove('top-bar-hidden');
-                    currentEl.style.scrollPaddingTop = '70px';
+                    if (currentEl) currentEl.style.scrollPaddingTop = '0px';
+                    var identityBar = document.querySelector('.identity-bar');
+                    if (identityBar) identityBar.classList.remove('below-topbar');
                 }
-                lastScrollTop = st;
-            }
+            }, delay);
+        }
 
+        function clearAutoHideTimer() {
+            if (autoHideTimer) { clearTimeout(autoHideTimer); autoHideTimer = null; }
+        }
+
+        function onScroll() {
+            var st = currentEl.scrollTop;
+
+            // Identity bar collapse (all screen sizes)
             var identityBar = document.querySelector('.identity-bar');
             if (identityBar) {
                 identityBar.classList.toggle('identity-collapsed', st > 80);
-                identityBar.classList.toggle('below-topbar', topBar && !topBar.classList.contains('top-bar-hidden'));
+            }
+
+            // Mobile-only: top bar hide/show, below-topbar offset
+            if (window.innerWidth <= 768) {
+                var topBar = document.querySelector('.top-bar');
+
+                if (topBar && Math.abs(st - lastScrollTop) > 10) {
+                    if (st > lastScrollTop && st > 60) {
+                        topBar.classList.add('top-bar-hidden');
+                        currentEl.style.scrollPaddingTop = '0px';
+                        clearAutoHideTimer();
+                    } else {
+                        topBar.classList.remove('top-bar-hidden');
+                        currentEl.style.scrollPaddingTop = '70px';
+                        startAutoHideTimer(topBar);
+                    }
+                    lastScrollTop = st;
+                }
+
+                if (identityBar) {
+                    identityBar.classList.toggle('below-topbar', topBar && !topBar.classList.contains('top-bar-hidden'));
+                }
             }
 
             // Footer: fade in when near bottom (opacity, no layout shift)
@@ -134,6 +166,17 @@
 
         attachListener(getScrollEl());
         window.addEventListener('resize', function() { attachListener(getScrollEl()); });
+
+        // Restart auto-hide timer when sidebar closes
+        var sidebar = document.querySelector('.sidebar');
+        if (sidebar) {
+            new MutationObserver(function() {
+                if (!sidebar.classList.contains('open')) {
+                    var topBar = document.querySelector('.top-bar');
+                    if (topBar) startAutoHideTimer(topBar);
+                }
+            }).observe(sidebar, { attributes: true, attributeFilter: ['class'] });
+        }
     })();
 </script>
 

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -21,7 +21,7 @@
 
 <PageTitle>Client Performance - Network Optimizer</PageTitle>
 
-<div class="client-dashboard-page">
+<div class="client-dashboard-page" data-autohide-nav="2000">
     @* Page Header *@
     <div class="page-header">
         <h1>Client Performance</h1>
@@ -241,24 +241,22 @@
                     </button>
                 }
             </div>
-        </div>
-
-        @* Tabs + Time Filter *@
-        <div class="dashboard-controls">
-            <div class="tab-bar">
-                <button class="tab-btn @(_activeTab == "speed" ? "active" : "")"
-                        @onclick='() => SetActiveTab("speed")'>Speed</button>
-                <button class="tab-btn @(_activeTab == "signal" ? "active" : "")"
-                        @onclick='() => SetActiveTab("signal")'>Signal</button>
-                <button class="tab-btn @(_activeTab == "connection" ? "active" : "")"
-                        @onclick='() => SetActiveTab("connection")'>Connection</button>
-            </div>
-            <div class="time-range-selector">
-                @foreach (var tf in _timeFilters)
-                {
-                    <button class="time-btn @(_selectedTimeFilter == tf.hours ? "active" : "")"
-                            @onclick="() => SetTimeFilter(tf.hours)">@tf.label</button>
-                }
+            <div class="dashboard-controls">
+                <div class="tab-bar">
+                    <button class="tab-btn @(_activeTab == "speed" ? "active" : "")"
+                            @onclick='() => SetActiveTab("speed")'>Speed</button>
+                    <button class="tab-btn @(_activeTab == "signal" ? "active" : "")"
+                            @onclick='() => SetActiveTab("signal")'>Signal</button>
+                    <button class="tab-btn @(_activeTab == "connection" ? "active" : "")"
+                            @onclick='() => SetActiveTab("connection")'>Connection</button>
+                </div>
+                <div class="time-range-selector">
+                    @foreach (var tf in _timeFilters)
+                    {
+                        <button class="time-btn @(_selectedTimeFilter == tf.hours ? "active" : "")"
+                                @onclick="() => SetTimeFilter(tf.hours)">@tf.label</button>
+                    }
+                </div>
             </div>
         </div>
 
@@ -406,15 +404,19 @@
                                     <thead>
                                         <tr>
                                             <th>Time</th>
-                                            <th>From Device</th>
-                                            <th>To Device</th>
+                                            <th class="hide-mobile">From Device</th>
+                                            <th class="hide-mobile">To Device</th>
+                                            <th class="show-mobile">Result</th>
                                             @if (!(_client?.IsWired == true))
                                             {
-                                                <th data-tooltip="AP receive rate (from device)">RX Rate</th>
-                                                <th data-tooltip="AP transmit rate (to device)">TX Rate</th>
+                                                <th class="hide-mobile" data-tooltip="AP receive rate (from device)">RX Rate</th>
+                                                <th class="hide-mobile" data-tooltip="AP transmit rate (to device)">TX Rate</th>
+                                                <th class="show-mobile" data-tooltip="AP link rates (RX / TX)">RX / TX Rate</th>
                                             }
+
                                             <th class="hide-mobile">Ping</th>
                                             <th class="hide-mobile">Type</th>
+                                            <th></th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -422,23 +424,26 @@
                                         {
                                             <tr class="result-row @(_expandedResultId == r.Id ? "expanded" : "")"
                                                 @onclick="() => ToggleResultExpand(r.Id)">
-                                                <td>@FormatSignalTime(r.TestTime)</td>
-                                                <td><span class="speed-down">@r.DownloadMbps.ToString("F1")</span> Mbps</td>
-                                                <td><span class="speed-up">@r.UploadMbps.ToString("F1")</span> Mbps</td>
+                                                <td>@FormatTimeShort(r.TestTime)</td>
+                                                <td class="hide-mobile"><span class="speed-down">@r.DownloadMbps.ToString("F1")</span> Mbps</td>
+                                                <td class="hide-mobile"><span class="speed-up">@r.UploadMbps.ToString("F1")</span> Mbps</td>
+                                                <td class="show-mobile"><span class="speed-down">@r.DownloadMbps.ToString("F0")</span> / <span class="speed-up">@r.UploadMbps.ToString("F0")</span></td>
                                                 @if (!(_client?.IsWired == true))
                                                 {
-                                                    <td>@RenderRate(r.WifiRxRateKbps, "wifi-speed-rx")</td>
-                                                    <td>@RenderRate(r.WifiTxRateKbps, "wifi-speed-tx")</td>
+                                                    <td class="hide-mobile">@RenderRate(r.WifiRxRateKbps, "wifi-speed-rx")</td>
+                                                    <td class="hide-mobile">@RenderRate(r.WifiTxRateKbps, "wifi-speed-tx")</td>
+                                                    <td class="show-mobile">@RenderRateShort(r.WifiRxRateKbps, "wifi-speed-rx") / @RenderRateShort(r.WifiTxRateKbps, "wifi-speed-tx")</td>
                                                 }
                                                 <td class="hide-mobile">@(r.PingMs.HasValue ? $"{r.PingMs.Value:F1} ms" : "-")</td>
                                                 <td class="hide-mobile">@(r.Direction == SpeedTestDirection.BrowserToServer ? "Browser" : "iperf3")</td>
+                                                <td class="expand-chevron"><span>@(_expandedResultId == r.Id ? "▲" : "▼")</span></td>
                                             </tr>
                                             @if (_expandedResultId == r.Id)
                                             {
                                                 <tr class="result-details-row">
-                                                    <td colspan="@(_client?.IsWired == true ? 5 : 7)">
+                                                    <td colspan="@(_client?.IsWired == true ? 6 : 8)">
                                                         <div class="result-details">
-                                                            <SpeedTestDetails Result="r" />
+                                                            <SpeedTestDetails Result="r" HideDeviceName="true" />
                                                         </div>
                                                     </td>
                                                 </tr>
@@ -636,7 +641,8 @@
                     {
                         <div class="card trace-card">
                             <h3>Network Path</h3>
-                            <SpeedTestDetails PathAnalysis="_latestPoll.PathAnalysis" PathOnly="true" />
+                            <SpeedTestDetails PathAnalysis="_latestPoll.PathAnalysis" PathOnly="true"
+                                              ClientSignalDbm="@(_client?.SignalDbm)" ClientRadio="@(_client?.Band)" />
                         </div>
                     }
 
@@ -2001,12 +2007,28 @@
             : local.ToString("MMM dd HH:mm:ss");
     }
 
+    private static string FormatTimeShort(DateTime utcTimestamp)
+    {
+        var local = utcTimestamp.ToLocalTime();
+        return local.Date == DateTime.Now.Date
+            ? local.ToString("HH:mm")
+            : local.ToString("MMM dd HH:mm");
+    }
+
     private static MarkupString RenderRate(long? rateKbps, string colorClass)
     {
         if (!rateKbps.HasValue || rateKbps == 0)
             return new MarkupString("-");
         var value = $"{rateKbps.Value / 1000.0:F0}";
         return new MarkupString($"<span class=\"{colorClass}\">{value}</span> Mbps");
+    }
+
+    private static MarkupString RenderRateShort(long? rateKbps, string colorClass)
+    {
+        if (!rateKbps.HasValue || rateKbps == 0)
+            return new MarkupString("-");
+        var value = $"{rateKbps.Value / 1000.0:F0}";
+        return new MarkupString($"<span class=\"{colorClass}\">{value}</span>");
     }
 
     private static string FormatBand(string? band) => band switch
@@ -2195,10 +2217,16 @@
     .identity-bar {
         padding: 12px 16px;
         position: sticky;
-        top: 0;
+        top: -24px;
         z-index: 10;
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-        transition: top 0.3s ease, padding 0.3s ease;
+        border-radius: var(--border-radius-lg) var(--border-radius-lg) 0 0;
+        box-shadow: none;
+        overflow: visible;
+        margin-bottom: 0;
+        transition: top 0.3s ease, padding 0.3s ease, box-shadow 0.3s ease;
+    }
+    .identity-bar.identity-collapsed {
+        box-shadow: 0 4px 6px -2px rgba(0, 0, 0, 0.3);
     }
     .identity-row-1 {
         display: flex;
@@ -2297,6 +2325,7 @@
         gap: 8px 12px;
         font-size: 0.8125rem;
         color: var(--text-secondary);
+        margin-bottom: 1rem;
     }
     .identity-detail {
         white-space: nowrap;
@@ -2342,8 +2371,31 @@
         align-items: center;
         justify-content: space-between;
         gap: 12px;
-        margin-bottom: 16px;
+        padding: 8px 0;
+        margin: 0 -16px -12px;
+        background: var(--bg-primary);
+        border-radius: 0;
+        position: relative;
         flex-wrap: wrap;
+    }
+    .dashboard-controls::before,
+    .dashboard-controls::after {
+        content: '';
+        position: absolute;
+        top: -6px;
+        width: 6px;
+        height: 6px;
+        background: var(--bg-primary);
+    }
+    .dashboard-controls::before {
+        left: 0;
+        mask: radial-gradient(circle at 100% 0, transparent 6px, black 6px);
+        -webkit-mask: radial-gradient(circle at 100% 0, transparent 6px, black 6px);
+    }
+    .dashboard-controls::after {
+        right: 0;
+        mask: radial-gradient(circle at 0 0, transparent 6px, black 6px);
+        -webkit-mask: radial-gradient(circle at 0 0, transparent 6px, black 6px);
     }
     .tab-bar {
         display: flex;
@@ -2490,10 +2542,21 @@
     .result-details-row td {
         padding: 0;
     }
+    .expand-chevron {
+        width: 2rem;
+        text-align: center;
+        color: var(--text-muted);
+        font-size: 0.75rem;
+    }
     .result-details {
-        padding: 16px;
+        padding: 2px 0 0;
+        margin-bottom: 0.5rem;
         background: rgba(0,0,0,0.2);
         border-bottom: 1px solid var(--border-color);
+    }
+    .result-details .test-details {
+        padding-left: 1rem;
+        padding-right: 1rem;
     }
 
     /* Signal Bars (used in identity bar) */
@@ -2659,7 +2722,12 @@
     /* Mobile responsive */
     @@media (max-width: 768px) {
         .client-dashboard-page {
-            padding: 0 0 24px;
+            padding: 0 0 80px;
+        }
+        .identity-bar {
+            top: 0;
+            border-radius: var(--border-radius-lg);
+            margin-bottom: 1rem;
         }
         .identity-row-1 {
             flex-direction: column;
@@ -2673,6 +2741,7 @@
             display: grid;
             grid-template-columns: 1fr 1fr;
             gap: 6px 12px;
+            margin-bottom: 0;
         }
         .logging-toggle-desktop {
             display: none;
@@ -2686,15 +2755,30 @@
             display: inline-flex;
         }
         .dashboard-controls {
-            flex-direction: column;
-            align-items: stretch;
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            z-index: 10;
+            background: var(--bg-card);
+            padding: 8px 12px;
+            box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.3);
+            flex-direction: row;
+            align-items: center;
+            margin: 0;
+        }
+        .dashboard-controls::before,
+        .dashboard-controls::after {
+            display: none;
         }
         .tab-bar {
             justify-content: stretch;
+            flex: 1;
         }
         .tab-btn {
             flex: 1;
             text-align: center;
+            padding: 0.5rem 0.5rem;
         }
         .speed-hero-results {
             display: grid;

--- a/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
@@ -325,7 +325,6 @@
                             <th class="hide-mobile">Model</th>
                             <th class="show-mobile">Device</th>
                             <th class="hide-mobile">IP Address</th>
-                            <th class="show-mobile">IP</th>
                             <th class="hide-mobile">Type</th>
                             <th>Status</th>
                             <th>Action</th>
@@ -344,7 +343,6 @@
                                     <code class="text-muted">@device.FriendlyModelName</code>
                                 </td>
                                 <td class="hide-mobile"><code>@device.IpAddress</code></td>
-                                <td class="show-mobile"><code>@ShortenIp(device.IpAddress)</code></td>
                                 <td class="hide-mobile">@device.Type.ToDisplayName()</td>
                                 <td>
                                     @if (isOnline)
@@ -457,7 +455,7 @@
                                 <td class="hide-mobile"><code>@device.Host</code></td>
                                 <td class="show-mobile">
                                     @device.Name<br />
-                                    <code class="text-muted">@device.Host</code>
+                                    <code class="text-muted host-truncate">@device.Host</code>
                                 </td>
                                 <td class="hide-mobile">@device.DeviceType.ToDisplayName()</td>
                                 <td>
@@ -2112,15 +2110,6 @@
         historyPage = 1; // Reset to first page on filter change
         expandedHistoryId = null; // Collapse any expanded row
         StateHasChanged();
-    }
-
-    private static string ShortenIp(string? ip)
-    {
-        if (string.IsNullOrEmpty(ip)) return "";
-        var parts = ip.Split('.');
-        if (parts.Length == 4)
-            return $"...{parts[2]}.{parts[3]}";
-        return ip;
     }
 
 }

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -3,6 +3,7 @@
 @using NetworkOptimizer.UniFi.Models
 @using NetworkOptimizer.Web.Services
 @using NetworkOptimizer.Web.Components.Shared
+@using NetworkOptimizer.WiFi.Helpers
 @implements IDisposable
 
 @if (!PathOnly)
@@ -113,6 +114,10 @@
             {
                 <span>Servers <code>@DeviceName</code></span>
             }
+        }
+        else if (HideDeviceName)
+        {
+            <span class="hide-mobile">Host <code>@DeviceHost</code></span>
         }
         else if (IsInTableRow)
         {
@@ -241,13 +246,11 @@
                                     <div class="path-connector path-turn turn-left @(isBottleneckLink ? "bottleneck" : "") @(isWirelessLink ? "wireless" : "")" data-tooltip="@turnTooltip" data-tooltip-interactive="@(isWirelessLink ? "" : null)">
                                         @if (isWirelessLink)
                                         {
-                                            <span class="wireless-icon">📶</span>
+                                            @RenderSignalBars(lastHop, nextHopGlobal)
                                         }
                                         <span class="connector-line"></span>
-                                        @if (linkSpeed > 0)
-                                        {
-                                            <span class="connector-speed">@FormatSpeed(linkSpeed)</span>
-                                        }
+                                        <span class="connector-speed" style="@(linkSpeed == 0 ? "visibility:hidden" : "")">@(linkSpeed > 0 ? FormatSpeed(linkSpeed) : "0")</span>
+                                        <span class="connector-speed-spacer" aria-hidden="true">@(linkSpeed > 0 ? FormatSpeed(linkSpeed) : "0")</span>
                                         <span class="turn-corner"></span>
                                     </div>
                                 }
@@ -274,13 +277,11 @@
                                     <div class="path-connector arrow-left @(isBottleneckLink ? "bottleneck" : "") @(isWirelessLink ? "wireless" : "")" data-tooltip="@connectorTooltip1" data-tooltip-interactive="@(isWirelessLink ? "" : null)">
                                         @if (isWirelessLink)
                                         {
-                                            <span class="wireless-icon">📶</span>
+                                            @RenderSignalBars(hop, nextHopGlobal)
                                         }
                                         <span class="connector-line"></span>
-                                        @if (linkSpeed > 0)
-                                        {
-                                            <span class="connector-speed">@FormatSpeed(linkSpeed)</span>
-                                        }
+                                        <span class="connector-speed" style="@(linkSpeed == 0 ? "visibility:hidden" : "")">@(linkSpeed > 0 ? FormatSpeed(linkSpeed) : "0")</span>
+                                        <span class="connector-speed-spacer" aria-hidden="true">@(linkSpeed > 0 ? FormatSpeed(linkSpeed) : "0")</span>
                                     </div>
                                 }
 
@@ -328,13 +329,11 @@
                                     <div class="path-connector @(needsTurn ? "path-turn" : "") @(isBottleneckLink ? "bottleneck" : "") @(isWirelessLink ? "wireless" : "")" data-tooltip="@connectorTooltip2" data-tooltip-interactive="@(isWirelessLink ? "" : null)">
                                         @if (isWirelessLink)
                                         {
-                                            <span class="wireless-icon">📶</span>
+                                            @RenderSignalBars(hop, nextHopGlobal)
                                         }
                                         <span class="connector-line"></span>
-                                        @if (linkSpeed > 0)
-                                        {
-                                            <span class="connector-speed">@FormatSpeed(linkSpeed)</span>
-                                        }
+                                        <span class="connector-speed" style="@(linkSpeed == 0 ? "visibility:hidden" : "")">@(linkSpeed > 0 ? FormatSpeed(linkSpeed) : "0")</span>
+                                        <span class="connector-speed-spacer" aria-hidden="true">@(linkSpeed > 0 ? FormatSpeed(linkSpeed) : "0")</span>
                                         @if (needsTurn)
                                         {
                                             <span class="turn-corner"></span>
@@ -424,6 +423,21 @@
     /// When true, only renders the path visualization and hides test details (speed, retransmits, metadata).
     /// </summary>
     [Parameter] public bool PathOnly { get; set; }
+
+    /// <summary>
+    /// Hide the device name in test details (useful when already shown in context)
+    /// </summary>
+    [Parameter] public bool HideDeviceName { get; set; }
+
+    /// <summary>
+    /// Client Wi-Fi signal for PathOnly mode (when no Iperf3Result is available)
+    /// </summary>
+    [Parameter] public int? ClientSignalDbm { get; set; }
+
+    /// <summary>
+    /// Client Wi-Fi radio band for PathOnly mode (ng, na, 6e)
+    /// </summary>
+    [Parameter] public string? ClientRadio { get; set; }
 
     /// <summary>
     /// Path analysis result (set automatically when using Result parameter)
@@ -767,6 +781,45 @@
     }
 
     /// <summary>
+    /// Get signal strength info for the wireless link between two hops.
+    /// Returns the signal dBm and band from whichever hop owns the wireless data.
+    /// </summary>
+    private static (int? signalDbm, string? band) GetWirelessSignalInfo(NetworkHop hop, NetworkHop nextHop)
+    {
+        if (hop.IsWirelessEgress && hop.WirelessSignalDbm.HasValue)
+            return (hop.WirelessSignalDbm, hop.WirelessEgressBand);
+        if (nextHop.IsWirelessIngress && nextHop.WirelessSignalDbm.HasValue)
+            return (nextHop.WirelessSignalDbm, nextHop.WirelessIngressBand);
+        return (null, null);
+    }
+
+    private RenderFragment RenderSignalBars(NetworkHop hop, NetworkHop nextHop) => __builder =>
+    {
+        var (signalDbm, band) = GetWirelessSignalInfo(hop, nextHop);
+        // For wireless client hops, signal lives on the Iperf3Result or component params, not the hop
+        if (!signalDbm.HasValue && (hop.Type == HopType.WirelessClient || nextHop.Type == HopType.WirelessClient))
+        {
+            signalDbm = Result?.WifiSignalDbm ?? ClientSignalDbm;
+            band ??= Result?.WifiRadio ?? ClientRadio;
+        }
+        var signalClass = signalDbm.HasValue
+            ? SignalClassification.GetSignalClass(signalDbm.Value, band)
+            : "";
+        var activeBars = signalDbm.HasValue
+            ? SignalClassification.GetBarCount(signalClass)
+            : 0;
+
+        <span class="wireless-icon">
+            <span class="mini-signal-bars @signalClass">
+                @for (int i = 1; i <= 5; i++)
+                {
+                    <span class="bar @(i <= activeBars ? "active" : "")"></span>
+                }
+            </span>
+        </span>
+    };
+
+    /// <summary>
     /// Determine if the link between two hops should be highlighted as a bottleneck.
     /// For asymmetric links (wireless, VPN, WAN), uses IsBottleneck flag to identify direction.
     /// For symmetric (wired) links, highlights ALL links matching the bottleneck speed.
@@ -818,7 +871,7 @@
             var sqmStatus = wanHop.SmartQueueEnabled!.Value ? "Enabled" : "Disabled";
             var sqmLine = $"<div class='device-tooltip-row'><span class='device-tooltip-label'>Smart Queues:</span> {sqmStatus}</div>";
             if (isBottleneckLink)
-                return sqmLine + "<div class='device-tooltip-row' style='color: var(--danger-color);'>Bottleneck: slowest link in path</div>";
+                return sqmLine + "<div class='wifi-tooltip-bottleneck'>Bottleneck: slowest link in path</div>";
             return sqmLine;
         }
 
@@ -906,6 +959,23 @@
             if (!string.IsNullOrEmpty(clientMac))
                 clientTooltip += "<div class='wifi-tooltip-client-link'><a href='./wifi-optimizer?tab=client&client=" + Uri.EscapeDataString(clientMac) + "'>View in Wi-Fi Optimizer</a></div>";
             return clientTooltip;
+        }
+
+        // PathOnly fallback: use component params for client wireless signal
+        if (isClientWireless && ClientSignalDbm.HasValue)
+        {
+            var clientBand = ClientRadio ?? band;
+            var pathOnlyLines = new List<string>();
+            if (!string.IsNullOrEmpty(clientBand))
+                pathOnlyLines.Add($"<div class='wifi-tooltip-link'><span class='wifi-band-badge wifi-band-{clientBand}'>{FormatRadioBand(clientBand)}</span></div>");
+            pathOnlyLines.Add($"<div class='wifi-tooltip-link-signal'>{ClientSignalDbm.Value} dBm</div>");
+            var tooltip = string.Join("", pathOnlyLines);
+            if (isBottleneck)
+                tooltip += "<div class='wifi-tooltip-bottleneck'>Bottleneck: slowest link in path</div>";
+            var mac = hop.Type == HopType.WirelessClient ? hop.DeviceMac : nextHop.DeviceMac;
+            if (!string.IsNullOrEmpty(mac))
+                tooltip += "<div class='wifi-tooltip-client-link'><a href='./wifi-optimizer?tab=client&client=" + Uri.EscapeDataString(mac) + "'>View in Wi-Fi Optimizer</a></div>";
+            return tooltip;
         }
 
         // For mesh/bridge wireless - use same styled format

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2344,11 +2344,12 @@ select.form-control {
         height: auto;
         padding: 0.75rem 1rem;
         gap: 0.5rem;
-        transition: transform 0.3s ease;
+        transition: transform 0.2s ease, margin 0.2s ease;
     }
 
     .top-bar.top-bar-hidden {
         transform: translateY(-100%);
+        margin-bottom: -3rem;
     }
 
     .app-footer {
@@ -2385,6 +2386,14 @@ select.form-control {
         max-height: 0;
         opacity: 0;
         margin: 0;
+    }
+
+    .identity-bar.identity-collapsed {
+        border-radius: 0;
+        margin-left: -16px;
+        margin-right: -16px;
+        padding-left: 16px;
+        padding-right: 16px;
     }
 
     .status-indicators {
@@ -3346,7 +3355,7 @@ select.form-control {
 
 .speed-results > .detail-actions {
     position: absolute;
-    right: 0.5rem;
+    right: 1.25rem;
     top: 0;
     bottom: 0;
     display: flex;
@@ -3640,6 +3649,15 @@ select.form-control {
         display: table-cell !important;
     }
 
+    .host-truncate {
+        display: inline-block;
+        max-width: 125px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        vertical-align: bottom;
+    }
+
     .speedtest-container .data-table,
     .client-speedtest-container .data-table {
         min-width: 350px;
@@ -3653,8 +3671,9 @@ select.form-control {
         margin-bottom: 0.25rem;
     }
 
+    .data-table th,
     .data-table td {
-        padding: 0.75rem 0.5rem;
+        padding: 0.75rem 0.4rem;
     }
 
     td .btn {
@@ -3678,6 +3697,8 @@ select.form-control {
 .history-details .test-details {
     position: relative;
     border-top: 1px solid var(--bg-card);
+    padding-left: 1rem;
+    padding-right: 1rem;
 }
 
 .history-details .path-analysis {
@@ -3782,6 +3803,14 @@ select.form-control {
     cursor: default;
 }
 
+.path-analysis .path-hop[data-tooltip] {
+    cursor: pointer;
+}
+.path-analysis .path-hop[data-tooltip] .hop-icon,
+.path-analysis .path-hop[data-tooltip] .hop-name {
+    cursor: pointer;
+}
+
 .path-analysis .path-hop.bottleneck {
     border: 1px solid var(--warning-color);
 }
@@ -3819,6 +3848,10 @@ select.form-control {
     cursor: default;
 }
 
+.path-analysis .path-connector .connector-speed-spacer {
+    display: none;
+}
+
 .path-analysis .path-connector.bottleneck .connector-line {
     background: var(--warning-color);
 }
@@ -3837,21 +3870,51 @@ select.form-control {
     position: relative;
 }
 
+.path-analysis .path-connector[data-tooltip] {
+    cursor: pointer;
+}
+.path-analysis .path-connector[data-tooltip] .connector-speed {
+    cursor: pointer;
+}
+
 .path-analysis .path-connector .wireless-icon {
     position: absolute;
-    top: -0.9rem;
+    top: -1.05rem;
     left: 50%;
     transform: translateX(-50%);
-    font-size: 0.9rem;
     line-height: 1;
     cursor: pointer;
 }
+
+/* Mini signal strength bars on wireless connectors */
+.mini-signal-bars {
+    display: flex;
+    align-items: flex-end;
+    gap: 0.1rem;
+    height: 14px;
+}
+.mini-signal-bars .bar {
+    width: 3px;
+    border-radius: 1px;
+    background: rgba(255,255,255,0.15);
+}
+.mini-signal-bars .bar:nth-child(1) { height: 20%; }
+.mini-signal-bars .bar:nth-child(2) { height: 40%; }
+.mini-signal-bars .bar:nth-child(3) { height: 60%; }
+.mini-signal-bars .bar:nth-child(4) { height: 80%; }
+.mini-signal-bars .bar:nth-child(5) { height: 100%; }
+.mini-signal-bars.signal-excellent .bar.active { background: #10b981; }
+.mini-signal-bars.signal-good .bar.active { background: #22c55e; }
+.mini-signal-bars.signal-fair .bar.active { background: #eab308; }
+.mini-signal-bars.signal-weak .bar.active { background: #f97316; }
+.mini-signal-bars.signal-poor .bar.active { background: #ef4444; }
 
 /* Path row - base styling (always flex) */
 .path-analysis .path-row {
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    padding: 0.5rem 0;
 }
 
 /* Switchback layout - snake pattern for multi-row traces */
@@ -4070,10 +4133,20 @@ select.form-control {
         display: none;
     }
 
-    /* Rotate speed badges to be readable on mobile */
+    /* Position speed badges beside connector on mobile */
     .path-analysis .path-connector .connector-speed {
         transform: rotate(-90deg);
-        padding-right: 65%;
+        position: absolute;
+        top: 28px;
+        width: 60px;
+        text-align: end;
+    }
+
+    /* Spacer holds vertical space for the absolute-positioned speed label */
+    .path-analysis .path-connector .connector-speed-spacer {
+        display: block;
+        visibility: hidden;
+        font-size: 0.6rem;
     }
 
     /* Reset turn connector margins on mobile */
@@ -4087,6 +4160,8 @@ select.form-control {
 
     /* Counter-rotate wireless icon to stay upright when connector is rotated */
     .path-analysis .path-connector .wireless-icon {
+        top: -1.2rem;
+        left: 43%;
         transform: translateX(-50%) rotate(-90deg);
     }
 
@@ -4237,6 +4312,10 @@ a.path-hop.hop-clickable {
     color: inherit;
     cursor: pointer;
 }
+a.path-hop.hop-clickable .hop-icon,
+a.path-hop.hop-clickable .hop-name {
+    cursor: pointer;
+}
 
 a.path-hop.hop-clickable:hover {
     border-color: var(--primary-light);
@@ -4301,6 +4380,7 @@ a.path-hop.hop-clickable:hover {
     font-size: 0.8rem;
     color: var(--warning-color);
     margin-bottom: 0.5rem;
+    white-space: normal;
 }
 
 .path-analysis .routing-badge {
@@ -4326,6 +4406,7 @@ a.path-hop.hop-clickable:hover {
 /* Notes section */
 .path-analysis .path-notes {
     border-top: 1px solid var(--border-color);
+    white-space: normal;
 }
 
 .path-analysis .note {
@@ -4410,7 +4491,8 @@ a.path-hop.hop-clickable:hover {
 }
 
 .history-details {
-    padding: 1rem 1.5rem 1.5rem;
+    padding: 2px 0 0;
+    margin-bottom: 0.5rem;
 }
 
 /* ============================================

--- a/src/NetworkOptimizer.WiFi/Helpers/SignalClassification.cs
+++ b/src/NetworkOptimizer.WiFi/Helpers/SignalClassification.cs
@@ -93,6 +93,18 @@ public static class SignalClassification
         _ => -78
     };
 
+    /// <summary>
+    /// Get the number of signal bars (1-5) for a given signal class.
+    /// </summary>
+    public static int GetBarCount(string signalClass) => signalClass switch
+    {
+        "signal-excellent" => 5,
+        "signal-good" => 4,
+        "signal-fair" => 3,
+        "signal-weak" => 2,
+        _ => 1
+    };
+
     private static RadioBand ParseBand(string? bandString) => bandString switch
     {
         "ng" => RadioBand.Band2_4GHz,


### PR DESCRIPTION
## Summary

- **Path trace link speed fix** - APs with empty port_table caused missing link speeds when a switch uplinks through an AP. Falls back to local device port speed.
- **Signal bars on wireless connectors** - Replace wifi emoji with mini signal strength bars, colored by band-aware signal quality using SignalClassification.
- **Mesh overhead fixes** - Correctly identify mesh bottleneck using mesh-specific port speed. Cap efficiency to mesh directional rates. Reduce overhead from 55% to 45%.
- **Client Dashboard mobile UX** - Sticky identity bar, fixed bottom tab bar, auto-hide nav, combined table columns, expand/collapse chevrons.
- **WAN hop naming** - Show actual WAN network name (e.g., "AT&T Fiber") instead of generic "WAN".

## Test plan

- [x] Verified link speed fix on switch-to-AP path (Baconphone trace)
- [x] Signal bars render with correct color on all wireless links
- [x] Mesh overhead correctly applied only when mesh is bottleneck
- [x] Desktop sticky bar with shadow on scroll
- [x] Mobile bottom tab bar, auto-hide nav, combined columns
- [x] PathOnly traces show signal data from client params
- [x] 191 relevant tests pass