### PR TITLE
Fix audit PDF trapping users in PWA standalone mode

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Audit.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Audit.razor
@@ -60,9 +60,24 @@
                     }
                 </button>
 
-                <button class="btn btn-secondary" disabled="@(!hasResults)" @onclick="DownloadLatestPdf">
-                    Download PDF
-                </button>
+                @if (_isStandalone)
+                {
+                    <button class="btn btn-secondary" disabled="@(!hasResults)" @onclick="DownloadLatestPdf">
+                        Download PDF
+                    </button>
+                }
+                else if (hasResults)
+                {
+                    <a href="/api/reports/latest/pdf" class="btn btn-secondary" download>
+                        Download PDF
+                    </a>
+                }
+                else
+                {
+                    <button class="btn btn-secondary" disabled>
+                        Download PDF
+                    </button>
+                }
 
                 <button class="btn btn-secondary" @onclick="@(() => NavigationManager.NavigateTo("/settings#security-audit"))">
                     Settings
@@ -869,6 +884,7 @@
     private Dictionary<string, bool> _purposeSaved = new();
     private Dictionary<string, System.Timers.Timer> _purposeSavedTimers = new();
     private bool _purposeOverridesPending;
+    private bool _isStandalone;
 
     private static readonly List<(string Value, string Display)> _purposeOptions =
     [
@@ -920,6 +936,21 @@
 
         // Load network purpose overrides
         _purposeOverrides = await AuditService.GetNetworkPurposeOverridesAsync();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            try
+            {
+                _isStandalone = await JSRuntime.InvokeAsync<bool>("eval",
+                    "window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true");
+                if (_isStandalone)
+                    StateHasChanged();
+            }
+            catch { }
+        }
     }
 
     private async Task RunAudit()


### PR DESCRIPTION
## Summary

- **Audit PDF download fix** - Safari PWA opens PDFs inline with `<a download>`, trapping users with no back button. In PWA standalone mode, uses JS fetch+blob to force a proper file download. In regular browsers, keeps the original direct link behavior.

## Test plan

- [x] In Safari PWA: run audit, tap "Download PDF", verify it downloads as a file instead of opening inline
- [x] In regular browser: tap "Download PDF", verify it still works as a direct download link