### PR TITLE
Fix console unreachable banner and connection validation

### DIFF
--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -111,7 +111,7 @@ public class UniFiApiClient : IDisposable
 
         _httpClient = new HttpClient(handler)
         {
-            Timeout = TimeSpan.FromSeconds(30)
+            Timeout = TimeSpan.FromSeconds(15)
         };
 
         _httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
@@ -159,6 +159,18 @@ public class UniFiApiClient : IDisposable
                 }
             }
         }
+        catch (TaskCanceledException ex)
+        {
+            // Timeout or cancellation - host is unreachable, don't bother trying login
+            _logger.LogDebug("Login type detection timed out: {Message}", ex.Message);
+            throw;
+        }
+        catch (HttpRequestException ex)
+        {
+            // Connection refused, DNS failure, etc. - host is unreachable
+            _logger.LogDebug("Login type detection failed: {Message}", ex.Message);
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogDebug("Login type detection failed: {Message}", ex.Message);
@@ -188,8 +200,10 @@ public class UniFiApiClient : IDisposable
             // Reset client to clear old cookies
             InitializeHttpClient();
 
-            // Detect which login endpoint to use
-            await DetectLoginTypeAsync(cancellationToken);
+            // Detect which login endpoint to use (5s timeout per call, not shared)
+            using var detectCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            detectCts.CancelAfter(TimeSpan.FromSeconds(5));
+            await DetectLoginTypeAsync(detectCts.Token);
 
             var loginRequest = new UniFiLoginRequest
             {
@@ -211,7 +225,9 @@ public class UniFiApiClient : IDisposable
                 Encoding.UTF8,
                 "application/json");
 
-            var response = await _httpClient!.PostAsync(loginUrl, content, cancellationToken);
+            using var loginCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            loginCts.CancelAfter(TimeSpan.FromSeconds(5));
+            var response = await _httpClient!.PostAsync(loginUrl, content, loginCts.Token);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -367,6 +383,13 @@ public class UniFiApiClient : IDisposable
             {
                 return "Connection timed out. Check network connectivity and firewall settings.";
             }
+        }
+
+        // Timeout from HttpClient.Timeout (TaskCanceledException, not HttpRequestException)
+        if (ex is TaskCanceledException ||
+            ex.Message.Contains("HttpClient.Timeout", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Connection timed out. Check the console URL and firewall/VPN settings.";
         }
 
         // Generic fallback

--- a/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
@@ -107,7 +107,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
                 // Auto-connect if we have credentials and RememberCredentials is true
                 if (settings.RememberCredentials && settings.HasCredentials)
                 {
-                    await Task.Delay(2000); // Wait for app startup
+                    await Task.Delay(1000); // Brief wait for app startup
                     await ConnectWithSettingsAsync(settings);
                 }
             }
@@ -119,6 +119,10 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
         finally
         {
             IsInitialized = true;
+
+            // Notify subscribers so the dashboard can show the connection banner
+            // (especially when auto-connect fails and WaitForConnectionAsync has already timed out)
+            OnConnectionChanged?.Invoke();
         }
     }
 
@@ -227,6 +231,13 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     /// </summary>
     public async Task<bool> ConnectAsync(UniFiConnectionConfig config)
     {
+        // Validate URL before attempting connection
+        if (string.IsNullOrWhiteSpace(config.ControllerUrl))
+        {
+            _lastError = "Console URL is required. Enter the URL or hostname of your UniFi Console.";
+            return false;
+        }
+
         _logger.LogInformation("Connecting to UniFi controller at {Url}", config.ControllerUrl);
 
         try
@@ -307,6 +318,10 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     {
         if (!settings.HasCredentials) return false;
 
+        // Use a shorter timeout for startup auto-connect so the dashboard
+        // shows the "unreachable" banner quickly instead of waiting 60s+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+
         try
         {
             // Decrypt password
@@ -339,12 +354,12 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
                 config.IgnoreControllerSSLErrors
             );
 
-            var success = await _client.LoginAsync();
+            var success = await _client.LoginAsync(cts.Token);
 
             if (success)
             {
                 // Validate the site ID by making a site-specific call
-                var (siteValid, siteError) = await _client.ValidateSiteAsync();
+                var (siteValid, siteError) = await _client.ValidateSiteAsync(cts.Token);
                 if (!siteValid)
                 {
                     _lastError = siteError;
@@ -380,6 +395,14 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
                 _client = null;
                 return false;
             }
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            _lastError = "UniFi Console is unreachable. Check that it's powered on and the URL is correct.";
+            _logger.LogWarning("Startup auto-connect timed out - console unreachable");
+            _client?.Dispose();
+            _client = null;
+            return false;
         }
         catch (Exception ex)
         {
@@ -480,6 +503,9 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     /// </summary>
     public async Task<(bool Success, string? Error, string? ControllerInfo)> TestConnectionAsync(UniFiConnectionConfig config)
     {
+        if (string.IsNullOrWhiteSpace(config.ControllerUrl))
+            return (false, "Console URL is required. Enter the URL or hostname of your UniFi Console.", null);
+
         _logger.LogInformation("Testing connection to UniFi controller at {Url}", config.ControllerUrl);
 
         UniFiApiClient? testClient = null;
@@ -539,6 +565,9 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     /// </summary>
     public async Task<(bool Success, string? Error, List<UniFiSite> Sites)> GetSitesAsync(UniFiConnectionConfig config)
     {
+        if (string.IsNullOrWhiteSpace(config.ControllerUrl))
+            return (false, "Console URL is required. Enter the URL or hostname of your UniFi Console.", new List<UniFiSite>());
+
         _logger.LogInformation("Fetching sites from UniFi controller at {Url}", config.ControllerUrl);
 
         UniFiApiClient? testClient = null;
@@ -854,10 +883,12 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
             return "Host not found. Check the controller URL.";
         }
 
-        // Timeout
-        if (message.Contains("timed out", StringComparison.OrdinalIgnoreCase))
+        // Timeout (includes HttpClient.Timeout and TaskCanceledException)
+        if (message.Contains("timed out", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("HttpClient.Timeout", StringComparison.OrdinalIgnoreCase) ||
+            ex is TaskCanceledException)
         {
-            return "Connection timed out. Check network connectivity and firewall settings.";
+            return "Connection timed out. Check the console URL and firewall/VPN settings.";
         }
 
         return message;


### PR DESCRIPTION
## Summary

- **Console unreachable banner shows promptly** - Previously could take 60s+ to appear on the dashboard when the console was down. Now shows within seconds.
- **Blank URL validation** - Submitting an empty console URL shows a clear validation message instead of an opaque parsing error.
- **Faster connection timeouts** - Login/detect calls use a 5s per-call timeout; general API calls use 15s (down from 30s).
- **Friendly timeout messages** - Raw .NET exception text no longer leaks to users; shows actionable guidance (check URL, firewall/VPN).

## Test plan

- [x] Enter unreachable IP in settings - fails within ~5s with friendly message
- [x] Submit blank console URL - shows validation error immediately
- [x] Start app with saved credentials pointing to unreachable console - banner appears within seconds
- [x] Connect to real console - works normally