### PR TITLE
Tune SQM for real-world multi-stream workloads

### DIFF
--- a/src/NetworkOptimizer.Sqm/Models/ConnectionProfile.cs
+++ b/src/NetworkOptimizer.Sqm/Models/ConnectionProfile.cs
@@ -327,8 +327,10 @@ public class ConnectionProfile
     {
         return Type switch
         {
-            // Fiber: minimal cap - WAN link speed already provides most of the headroom
-            ConnectionType.Fiber => 0.98,
+            // Fiber: 95% cap gives htb headroom to shape properly at near-line-rate
+            // At 98% (980 Mbps on 1G), fq_codel memory fills before AQM can react
+            // At 95% (950 Mbps on 1G), htb absorbs bursts and fq_codel manages flows cleanly
+            ConnectionType.Fiber => 0.95,
 
             // All other types: 95% safety margin below the bottleneck
             _ => 0.95

--- a/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
+++ b/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
@@ -514,16 +514,20 @@ calc_burst() {
 }
 
 # Calculate fq_codel memory_limit scaled to rate (prevents drop_overmemory at high speeds)
-# Config E testing showed 6MB is the sweet spot at gig speeds:
-#   - 4MB (stock): ~1400 drop_overmemory per bufferbloat test (both directions)
-#   - 6MB: eliminates downstream drop_overmemory, bufferbloat within 1ms of stock
-#   - 8MB: eliminates all drop_overmemory but adds ~5ms bufferbloat and fails gaming latency
-# Scale: 6144 bytes per Mbps, floor 4MB (stock), cap 6MB
+# Testing showed 8MB is needed for real-world multi-stream workloads (Steam, backups):
+#   - 4MB (stock): ~1400 drop_overmemory per bufferbloat test, ~300/sec during Steam downloads
+#   - 6MB: eliminates most downstream drop_overmemory on synthetic tests, but still hits
+#     memory wall during heavy multi-stream downloads (Steam: 5.6/5.7MB = 99% full)
+#   - 8MB: zero drop_overmemory during Steam downloads, memory stays at ~30-40% utilization
+#     Bufferbloat test shows ~5ms regression vs 6MB, but real-world latency is at idle levels
+#     because the extra headroom lets fq_codel do proper AQM instead of panic-dropping
+# Combined with 95% safety cap on fiber (950 Mbps vs 980), htb has room to shape properly
+# Scale: 8192 bytes per Mbps, floor 4MB (stock), cap 8MB
 calc_fq_mem() {
     local rate_mbps=$1
-    local mem=$((rate_mbps * 6144))
+    local mem=$((rate_mbps * 8192))
     [ ""$mem"" -lt 4194304 ] && mem=4194304
-    [ ""$mem"" -gt 6291456 ] && mem=6291456
+    [ ""$mem"" -gt 8388608 ] && mem=8388608
     echo ""$mem""
 }
 


### PR DESCRIPTION
## Summary

- **Increase fq_codel memory cap from 6MB to 8MB** - 6MB hits memory wall during heavy multi-stream downloads (Steam, backups). At 8MB, memory stays at ~30-40% utilization and fq_codel does proper AQM instead of panic-dropping.
- **Lower fiber safety cap from 98% to 95%** - Gives htb headroom to shape properly at near-line-rate. At 98% (980 Mbps on 1G), fq_codel memory fills before AQM can react.

## Test plan

- [x] Run bufferbloat test and verify latency is acceptable (~5ms regression vs 6MB is expected)
- [x] Monitor `drop_overmemory` during heavy downloads - should be zero
- [x] Verify SQM script generates correct values (8MB cap, 95% fiber rate)