### PR TITLE
Fix multi-CIDR coverage, Pi-hole false positive, and Settings cleanup

### DIFF
--- a/src/NetworkOptimizer.Audit/Dns/DnatDnsAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnatDnsAnalyzer.cs
@@ -89,9 +89,9 @@ public class DnatRuleInfo
     public string? NetworkId { get; init; }
 
     /// <summary>
-    /// CIDR notation (for subnet type)
+    /// CIDR notations (for subnet type) - supports multiple CIDRs from firewall address groups
     /// </summary>
-    public string? SubnetCidr { get; init; }
+    public List<string>? SubnetCidrs { get; init; }
 
     /// <summary>
     /// Single IP address (for single_ip type)
@@ -227,13 +227,13 @@ public class DnatDnsAnalyzer
                     break;
 
                 case "subnet":
-                    if (!string.IsNullOrEmpty(rule.SubnetCidr))
+                    if (rule.SubnetCidrs != null)
                     {
-                        // Check which networks are covered by this subnet
+                        // Check which networks are covered by any of the CIDRs
                         foreach (var network in allNetworks)
                         {
                             if (!string.IsNullOrEmpty(network.Subnet) &&
-                                CidrCoversSubnet(rule.SubnetCidr, network.Subnet))
+                                rule.SubnetCidrs.Any(cidr => CidrCoversSubnet(cidr, network.Subnet)))
                             {
                                 coveredNetworkIds.Add(network.Id);
                             }
@@ -393,17 +393,22 @@ public class DnatDnsAnalyzer
             return address;
         }
 
-        // Check firewall address groups
+        // Check firewall address groups - aggregate addresses from all address groups
         if (firewallGroups != null)
         {
+            var allAddresses = new List<string>();
             var groupIds = GetFirewallGroupIds(filter);
             foreach (var groupId in groupIds)
             {
                 var addresses = FirewallGroupHelper.ResolveAddressGroup(groupId, firewallGroups);
                 if (addresses != null && addresses.Count > 0)
                 {
-                    return string.Join(",", addresses);
+                    allAddresses.AddRange(addresses);
                 }
+            }
+            if (allAddresses.Count > 0)
+            {
+                return string.Join(",", allAddresses);
             }
         }
 
@@ -520,17 +525,18 @@ public class DnatDnsAnalyzer
             // Non-inverted firewall group without in_interface - check resolved addresses
             if (resolvedAddresses.Count > 0)
             {
-                // Check if all resolved addresses are CIDRs (network coverage)
-                var allCidrs = resolvedAddresses.All(a => a.Contains('/'));
-                if (allCidrs)
+                // Separate CIDRs from single IPs
+                var cidrs = resolvedAddresses.Where(a => a.Contains('/')).ToList();
+                var singleIps = resolvedAddresses.Where(a => !a.Contains('/')).ToList();
+
+                if (cidrs.Count > 0)
                 {
-                    // Use first CIDR for subnet coverage (simplified - could be multiple)
                     return new DnatRuleInfo
                     {
                         Id = id,
                         Description = description,
                         CoverageType = "subnet",
-                        SubnetCidr = resolvedAddresses[0],
+                        SubnetCidrs = cidrs,
                         RedirectIp = redirectIp,
                         InInterface = inInterface,
                         DestinationAddress = destAddress,
@@ -544,7 +550,7 @@ public class DnatDnsAnalyzer
                     Id = id,
                     Description = description,
                     CoverageType = "single_ip",
-                    SingleIp = resolvedAddresses[0],
+                    SingleIp = string.Join(",", singleIps),
                     RedirectIp = redirectIp,
                     InInterface = inInterface,
                     DestinationAddress = destAddress,
@@ -583,7 +589,7 @@ public class DnatDnsAnalyzer
                     Id = id,
                     Description = description,
                     CoverageType = "subnet",
-                    SubnetCidr = address,
+                    SubnetCidrs = new List<string> { address },
                     RedirectIp = redirectIp,
                     InInterface = inInterface,
                     DestinationAddress = destAddress,

--- a/src/NetworkOptimizer.Audit/Dns/ThirdPartyDnsDetector.cs
+++ b/src/NetworkOptimizer.Audit/Dns/ThirdPartyDnsDetector.cs
@@ -323,7 +323,9 @@ public class ThirdPartyDnsDetector
                 }
                 catch
                 {
-                    return (true, "detected");
+                    // JSON parsing failed - can't confirm this is Pi-hole
+                    _logger.LogDebug("Pi-hole probe to {Url}: content contained 'dns' but JSON parse failed", url);
+                    return (false, null);
                 }
             }
 
@@ -380,8 +382,9 @@ public class ThirdPartyDnsDetector
                 }
                 catch
                 {
-                    // JSON parsing failed, but content indicates Pi-hole
-                    return (true, "detected");
+                    // JSON parsing failed - can't confirm this is Pi-hole
+                    _logger.LogDebug("Pi-hole probe to {Ip}:{Port}: content contained 'dns' but JSON parse failed", ipAddress, port);
+                    return (false, null);
                 }
             }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1858,7 +1858,6 @@
     private bool allowMediaPlayersOnMainNetwork = false;
     private bool allowPrintersOnMainNetwork = true;
     private string dnatExcludedVlans = "";
-    private int? piholeManagementPort = null;
     private string? piholeManagementEndpoint;
     private int unusedPortInactivityDays = 15;
     private int namedPortInactivityDays = 45;
@@ -3252,7 +3251,6 @@
             dnatExcludedVlans = excludedVlans ?? "";
             // Third-party DNS endpoint (Pi-hole, AdGuard Home, etc.) - null means auto-detect
             piholeManagementEndpoint = string.IsNullOrWhiteSpace(piholePort) ? null : piholePort;
-            piholeManagementPort = int.TryParse(piholePort, out var port) && port > 0 ? port : null;
             // Unused port thresholds (defaults: 15 days unnamed, 45 days named)
             unusedPortInactivityDays = int.TryParse(unusedPortDays, out var unusedDays) && unusedDays > 0 ? unusedDays : 15;
             namedPortInactivityDays = int.TryParse(namedPortDays, out var namedDays) && namedDays > 0 ? namedDays : 45;
@@ -3279,7 +3277,18 @@
             await SystemSettings.SetAsync("audit:allowMediaPlayersOnMainNetwork", allowMediaPlayersOnMainNetwork.ToString().ToLower());
             await SystemSettings.SetAsync("audit:allowPrintersOnMainNetwork", allowPrintersOnMainNetwork.ToString().ToLower());
             await SystemSettings.SetAsync("audit:dnatExcludedVlans", dnatExcludedVlans ?? "");
-            await SystemSettings.SetAsync("audit:piholeManagementPort", piholeManagementEndpoint ?? "");
+            // Validate DNS endpoint: must be empty, a port number, or a valid absolute URL
+            var endpoint = piholeManagementEndpoint?.Trim();
+            if (!string.IsNullOrEmpty(endpoint) &&
+                !(int.TryParse(endpoint, out var validPort) && validPort > 0 && validPort <= 65535) &&
+                !Uri.TryCreate(endpoint, UriKind.Absolute, out _))
+            {
+                auditSettingsMessage = "Invalid DNS endpoint. Enter a port number (e.g., 8080) or full URL (e.g., https://pihole.local).";
+                auditSettingsMessageClass = "danger";
+                savingAuditSettings = false;
+                return;
+            }
+            await SystemSettings.SetAsync("audit:piholeManagementPort", endpoint ?? "");
             await SystemSettings.SetAsync("audit:unusedPortInactivityDays", unusedPortInactivityDays.ToString());
             await SystemSettings.SetAsync("audit:namedPortInactivityDays", namedPortInactivityDays.ToString());
 

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/DnatDnsAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/DnatDnsAnalyzerTests.cs
@@ -437,6 +437,164 @@ public class DnatDnsAnalyzerTests
         Assert.False(result.HasDnatDnsRules);
     }
 
+    [Fact]
+    public void Analyze_WithFirewallGroupMultipleCidrs_CoversAllSubnets()
+    {
+        // Firewall address group with multiple CIDRs should cover all matching networks
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true),
+            ("net2", "IoT", "192.168.2.0/24", true),
+            ("net3", "Guest", "192.168.3.0/24", true));
+
+        var firewallGroups = new Dictionary<string, UniFiFirewallGroup>
+        {
+            ["port-group-dns"] = new UniFiFirewallGroup
+            {
+                Id = "port-group-dns",
+                Name = "DNS Ports",
+                GroupType = "port-group",
+                GroupMembers = new List<string> { "53" }
+            },
+            ["addr-group-subnets"] = new UniFiFirewallGroup
+            {
+                Id = "addr-group-subnets",
+                Name = "All Subnets",
+                GroupType = "address-group",
+                GroupMembers = new List<string> { "192.168.1.0/24", "192.168.2.0/24", "192.168.3.0/24" }
+            }
+        };
+
+        var rule = """
+        {
+            "_id": "1",
+            "type": "DNAT",
+            "enabled": true,
+            "protocol": "tcp_udp",
+            "ip_address": "192.168.1.220",
+            "destination_filter": {
+                "port": "53"
+            },
+            "source_filter": {
+                "filter_type": "FIREWALL_GROUPS",
+                "firewall_group_ids": ["addr-group-subnets"]
+            }
+        }
+        """;
+        var natRules = JsonDocument.Parse($"[{rule}]").RootElement;
+
+        var result = _analyzer.Analyze(natRules, networks, firewallGroups: firewallGroups);
+
+        Assert.True(result.HasDnatDnsRules);
+        Assert.Single(result.Rules);
+        Assert.Equal("subnet", result.Rules[0].CoverageType);
+        Assert.NotNull(result.Rules[0].SubnetCidrs);
+        Assert.Equal(3, result.Rules[0].SubnetCidrs!.Count);
+        Assert.True(result.HasFullCoverage);
+        Assert.Equal(3, result.CoveredNetworkIds.Count);
+        Assert.Empty(result.UncoveredNetworkIds);
+    }
+
+    [Fact]
+    public void Analyze_WithFirewallGroupMultipleCidrs_PartialCoverage()
+    {
+        // Firewall address group with 2 CIDRs should cover 2 of 3 networks
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true),
+            ("net2", "IoT", "192.168.2.0/24", true),
+            ("net3", "Guest", "10.0.0.0/24", true));
+
+        var firewallGroups = new Dictionary<string, UniFiFirewallGroup>
+        {
+            ["addr-group-partial"] = new UniFiFirewallGroup
+            {
+                Id = "addr-group-partial",
+                Name = "Some Subnets",
+                GroupType = "address-group",
+                GroupMembers = new List<string> { "192.168.1.0/24", "192.168.2.0/24" }
+            }
+        };
+
+        var rule = """
+        {
+            "_id": "1",
+            "type": "DNAT",
+            "enabled": true,
+            "protocol": "tcp_udp",
+            "ip_address": "192.168.1.220",
+            "destination_filter": {
+                "port": "53"
+            },
+            "source_filter": {
+                "filter_type": "FIREWALL_GROUPS",
+                "firewall_group_ids": ["addr-group-partial"]
+            }
+        }
+        """;
+        var natRules = JsonDocument.Parse($"[{rule}]").RootElement;
+
+        var result = _analyzer.Analyze(natRules, networks, firewallGroups: firewallGroups);
+
+        Assert.True(result.HasDnatDnsRules);
+        Assert.Equal("subnet", result.Rules[0].CoverageType);
+        Assert.Equal(2, result.Rules[0].SubnetCidrs!.Count);
+        Assert.False(result.HasFullCoverage);
+        Assert.Equal(2, result.CoveredNetworkIds.Count);
+        Assert.Single(result.UncoveredNetworkIds);
+        Assert.Contains("net3", result.UncoveredNetworkIds);
+    }
+
+    [Fact]
+    public void Analyze_WithMultipleAddressGroups_AggregatesAddresses()
+    {
+        // Multiple address groups in firewall_group_ids should all be resolved
+        var networks = CreateTestNetworks(
+            ("net1", "LAN", "192.168.1.0/24", true),
+            ("net2", "IoT", "192.168.2.0/24", true));
+
+        var firewallGroups = new Dictionary<string, UniFiFirewallGroup>
+        {
+            ["addr-group-1"] = new UniFiFirewallGroup
+            {
+                Id = "addr-group-1",
+                Name = "LAN Subnet",
+                GroupType = "address-group",
+                GroupMembers = new List<string> { "192.168.1.0/24" }
+            },
+            ["addr-group-2"] = new UniFiFirewallGroup
+            {
+                Id = "addr-group-2",
+                Name = "IoT Subnet",
+                GroupType = "address-group",
+                GroupMembers = new List<string> { "192.168.2.0/24" }
+            }
+        };
+
+        var rule = """
+        {
+            "_id": "1",
+            "type": "DNAT",
+            "enabled": true,
+            "protocol": "tcp_udp",
+            "ip_address": "192.168.1.220",
+            "destination_filter": {
+                "port": "53"
+            },
+            "source_filter": {
+                "filter_type": "FIREWALL_GROUPS",
+                "firewall_group_ids": ["addr-group-1", "addr-group-2"]
+            }
+        }
+        """;
+        var natRules = JsonDocument.Parse($"[{rule}]").RootElement;
+
+        var result = _analyzer.Analyze(natRules, networks, firewallGroups: firewallGroups);
+
+        Assert.True(result.HasDnatDnsRules);
+        Assert.Equal("subnet", result.Rules[0].CoverageType);
+        Assert.Equal(2, result.Rules[0].SubnetCidrs!.Count);
+        Assert.True(result.HasFullCoverage);
+    }
+
     #endregion
 
     #region Protocol Filter Tests

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/ThirdPartyDnsDetectorTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/ThirdPartyDnsDetectorTests.cs
@@ -1606,9 +1606,9 @@ public class ThirdPartyDnsDetectorTests : IDisposable
     }
 
     [Fact]
-    public async Task DetectThirdPartyDnsAsync_PiholeMalformedJsonWithDnsString_StillDetected()
+    public async Task DetectThirdPartyDnsAsync_PiholeMalformedJsonWithDnsString_NotFalsePositive()
     {
-        // Malformed JSON that contains "dns" string - should trigger catch block with true
+        // Malformed JSON that contains "dns" string - should NOT false-positive as Pi-hole
         var malformedResponse = @"{""dns"":true, this is invalid json}";
         var httpClient = CreateMockHttpClient(HttpStatusCode.OK, malformedResponse);
 
@@ -1629,7 +1629,7 @@ public class ThirdPartyDnsDetectorTests : IDisposable
         var result = await detector.DetectThirdPartyDnsAsync(networks);
 
         result.Should().HaveCount(1);
-        result[0].IsPihole.Should().BeTrue(); // Fallback detection from "dns" string
+        result[0].IsPihole.Should().BeFalse(); // Malformed JSON should not be treated as Pi-hole
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- **Multi-CIDR firewall group coverage** - `DnatDnsAnalyzer` now checks all CIDRs from firewall address groups instead of only the first. `ResolveFilterAddress` aggregates addresses from all address groups in a filter. This fixes false "uncovered network" warnings when firewall groups contain multiple subnets.
- **Pi-hole false positive fix** - `ThirdPartyDnsDetector` no longer reports Pi-hole detected when a response contains the string "dns" but has malformed JSON. Previously the catch block returned `(true, "detected")`.
- **Dead code removal** - Removed unused `piholeManagementPort` field from Settings.razor.
- **DNS endpoint validation** - Settings now validates the third-party DNS endpoint input on save, rejecting values that are neither a port number nor a valid absolute URL.

## Test plan

- [x] 3 new multi-CIDR tests: full coverage, partial coverage, multi-group aggregation
- [x] Updated malformed JSON test to assert no false positive
- [x] All 3764 tests pass, 0 warnings