### PR TITLE
Fix false positive DNS IP mismatch for dual Pi-hole setups

### DIFF
--- a/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
@@ -2159,50 +2159,76 @@ public class DnsSecurityAnalyzer
         if (nonGatewayResults.Count < 2)
             return;
 
-        // Group by DNS IP to find the most common one
-        var ipGroups = nonGatewayResults
-            .GroupBy(r => r.DnsServerIp)
+        // Group by network to get each network's set of third-party DNS IPs.
+        // A network with dual DNS (primary + secondary, e.g. two Pi-holes) will have
+        // multiple IPs - we compare the full set, not individual IPs.
+        var networkDnsSets = nonGatewayResults
+            .GroupBy(r => r.NetworkName, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(r => r.DnsServerIp).OrderBy(ip => ip).ToList(),
+                StringComparer.OrdinalIgnoreCase);
+
+        if (networkDnsSets.Count < 2)
+            return;
+
+        // Create a canonical string key for each network's DNS IP set for comparison
+        var networkSetKeys = networkDnsSets
+            .Select(kvp => new { Network = kvp.Key, SetKey = string.Join(",", kvp.Value), Ips = kvp.Value })
+            .ToList();
+
+        // Group networks by their DNS IP set to find the most common configuration
+        var setGroups = networkSetKeys
+            .GroupBy(n => n.SetKey)
             .OrderByDescending(g => g.Count())
             .ToList();
 
-        // If all networks use the same IP, no inconsistency
-        if (ipGroups.Count <= 1)
+        // If all networks use the same set of IPs, no inconsistency
+        if (setGroups.Count <= 1)
             return;
 
-        // The most common IP is considered the "expected" one
-        var expectedIp = ipGroups[0].Key;
+        // The most common set is considered the "expected" one
+        var expectedSet = setGroups[0].First().Ips;
+        var expectedSetDisplay = string.Join(", ", expectedSet);
         var providerName = result.ThirdPartyDnsProviderName ?? "Third-Party DNS";
 
-        // Flag networks using a different IP
-        var mismatchedNetworks = ipGroups
+        // Flag networks using a different set of IPs
+        var mismatchedNetworks = setGroups
             .Skip(1)
-            .SelectMany(g => g.Select(r => new { r.NetworkName, r.DnsServerIp }))
+            .SelectMany(g => g.Select(n => new { n.Network, DnsIps = string.Join(", ", n.Ips) }))
             .ToList();
 
         if (mismatchedNetworks.Any())
         {
             var networkDetails = mismatchedNetworks
-                .Select(n => $"{n.NetworkName} ({n.DnsServerIp})")
+                .Select(n => $"{n.Network} ({n.DnsIps})")
                 .ToList();
 
             _logger.LogWarning(
-                "DNS IP inconsistency: Most networks use {ExpectedIp} but {Count} network(s) use a different IP: {Details}",
-                expectedIp, mismatchedNetworks.Count, string.Join(", ", networkDetails));
+                "DNS IP inconsistency: Most networks use [{ExpectedIps}] but {Count} network(s) use different IPs: {Details}",
+                expectedSetDisplay, mismatchedNetworks.Count, string.Join(", ", networkDetails));
+
+            var allMismatchedIps = setGroups
+                .Skip(1)
+                .SelectMany(g => g.SelectMany(n => n.Ips))
+                .Distinct()
+                .ToList();
 
             result.Issues.Add(new AuditIssue
             {
                 Type = IssueTypes.DnsInconsistentConfig,
                 Severity = AuditSeverity.Recommended,
                 DeviceName = result.GatewayName,
-                Message = $"{providerName} IP mismatch: most networks use {expectedIp} but {string.Join(", ", networkDetails)} use a different IP. This may indicate misconfiguration.",
-                RecommendedAction = $"Update the DHCP DNS settings for the affected network(s) to use {expectedIp}.",
+                Message = $"{providerName} IP mismatch: most networks use {expectedSetDisplay} but {string.Join(", ", networkDetails)} use different IPs. This may indicate misconfiguration.",
+                RecommendedAction = $"Update the DHCP DNS settings for the affected network(s) to use {expectedSetDisplay}.",
                 RuleId = "DNS-IP-MISMATCH-001",
                 ScoreImpact = 5,
                 Metadata = new Dictionary<string, object>
                 {
-                    { "expected_ip", expectedIp },
-                    { "mismatched_networks", mismatchedNetworks.Select(n => n.NetworkName).ToList() },
-                    { "mismatched_ips", mismatchedNetworks.Select(n => n.DnsServerIp).Distinct().ToList() },
+                    { "expected_ip", expectedSet.First() },
+                    { "expected_ips", expectedSet },
+                    { "mismatched_networks", mismatchedNetworks.Select(n => n.Network).ToList() },
+                    { "mismatched_ips", allMismatchedIps },
                     { "provider_name", providerName }
                 }
             });

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
@@ -6945,6 +6945,120 @@ public class DnsSecurityAnalyzerTests : IDisposable
         result.Issues.Should().NotContain(i => i.RuleId == "DNS-IP-MISMATCH-001");
     }
 
+    [Fact]
+    public async Task Analyze_DualPiholeInstances_NoIpMismatch()
+    {
+        // All networks use the same pair of Pi-hole IPs (primary + secondary)
+        // This is a common HA setup - should NOT trigger IP mismatch
+        var networks = new List<NetworkInfo>
+        {
+            new NetworkInfo { Id = "net1", Name = "Default", VlanId = 1, DhcpEnabled = true, Gateway = "10.0.0.1",
+                DnsServers = new List<string> { "10.0.0.5", "10.0.0.6" }, Purpose = NetworkPurpose.Home },
+            new NetworkInfo { Id = "net2", Name = "IoT", VlanId = 42, DhcpEnabled = true, Gateway = "10.0.42.1",
+                DnsServers = new List<string> { "10.0.0.5", "10.0.0.6" }, Purpose = NetworkPurpose.IoT },
+            new NetworkInfo { Id = "net3", Name = "Guest", VlanId = 50, DhcpEnabled = true, Gateway = "10.0.50.1",
+                DnsServers = new List<string> { "10.0.0.5", "10.0.0.6" }, Purpose = NetworkPurpose.Home },
+            new NetworkInfo { Id = "net4", Name = "Media", VlanId = 60, DhcpEnabled = true, Gateway = "10.0.60.1",
+                DnsServers = new List<string> { "10.0.0.5", "10.0.0.6" }, Purpose = NetworkPurpose.Home }
+        };
+
+        var result = await _analyzer.AnalyzeAsync(null, null, null, networks);
+
+        result.HasThirdPartyDns.Should().BeTrue();
+        result.SiteWideDnsServerIps.Should().Contain("10.0.0.5");
+        result.SiteWideDnsServerIps.Should().Contain("10.0.0.6");
+        result.Issues.Should().NotContain(i => i.RuleId == "DNS-IP-MISMATCH-001");
+        result.Issues.Should().NotContain(i =>
+            i.Type == IssueTypes.DnsInconsistentConfig &&
+            i.RuleId == "DNS-CONSISTENCY-001");
+    }
+
+    [Fact]
+    public async Task Analyze_DualPiholeWithOneNetworkMissing_FlagsMismatch()
+    {
+        // Most networks use both Pi-holes, but one only has the primary - flag the outlier
+        var networks = new List<NetworkInfo>
+        {
+            new NetworkInfo { Id = "net1", Name = "Default", VlanId = 1, DhcpEnabled = true, Gateway = "10.0.0.1",
+                DnsServers = new List<string> { "10.0.0.5", "10.0.0.6" }, Purpose = NetworkPurpose.Home },
+            new NetworkInfo { Id = "net2", Name = "IoT", VlanId = 42, DhcpEnabled = true, Gateway = "10.0.42.1",
+                DnsServers = new List<string> { "10.0.0.5", "10.0.0.6" }, Purpose = NetworkPurpose.IoT },
+            new NetworkInfo { Id = "net3", Name = "Partial", VlanId = 30, DhcpEnabled = true, Gateway = "10.0.30.1",
+                DnsServers = new List<string> { "10.0.0.5" }, Purpose = NetworkPurpose.Home }
+        };
+
+        var result = await _analyzer.AnalyzeAsync(null, null, null, networks);
+
+        result.HasThirdPartyDns.Should().BeTrue();
+        var mismatchIssue = result.Issues.FirstOrDefault(i => i.RuleId == "DNS-IP-MISMATCH-001");
+        mismatchIssue.Should().NotBeNull();
+        mismatchIssue!.Message.Should().Contain("Partial");
+    }
+
+    [Fact]
+    public async Task Analyze_DualPiholeWithOneNetworkDifferentSecondary_FlagsMismatch()
+    {
+        // Most networks use Pi-hole pair (10.0.0.5, 10.0.0.6), but one uses a different secondary
+        var networks = new List<NetworkInfo>
+        {
+            new NetworkInfo { Id = "net1", Name = "Default", VlanId = 1, DhcpEnabled = true, Gateway = "10.0.0.1",
+                DnsServers = new List<string> { "10.0.0.5", "10.0.0.6" }, Purpose = NetworkPurpose.Home },
+            new NetworkInfo { Id = "net2", Name = "IoT", VlanId = 42, DhcpEnabled = true, Gateway = "10.0.42.1",
+                DnsServers = new List<string> { "10.0.0.5", "10.0.0.6" }, Purpose = NetworkPurpose.IoT },
+            new NetworkInfo { Id = "net3", Name = "Stale", VlanId = 30, DhcpEnabled = true, Gateway = "10.0.30.1",
+                DnsServers = new List<string> { "10.0.0.5", "10.0.0.99" }, Purpose = NetworkPurpose.Home }
+        };
+
+        var result = await _analyzer.AnalyzeAsync(null, null, null, networks);
+
+        result.HasThirdPartyDns.Should().BeTrue();
+        var mismatchIssue = result.Issues.FirstOrDefault(i => i.RuleId == "DNS-IP-MISMATCH-001");
+        mismatchIssue.Should().NotBeNull();
+        mismatchIssue!.Message.Should().Contain("Stale");
+    }
+
+    [Fact]
+    public async Task Analyze_DualPiholeWithManagementExcluded_NoIpMismatch()
+    {
+        // All non-management networks use the same pair of Pi-holes
+        // Management network uses gateway DNS only - should not cause mismatch
+        var networks = new List<NetworkInfo>
+        {
+            new NetworkInfo { Id = "net1", Name = "Default", VlanId = 1, DhcpEnabled = true, Gateway = "10.0.0.1",
+                DnsServers = new List<string> { "10.0.0.5", "10.0.0.6" }, Purpose = NetworkPurpose.Home },
+            new NetworkInfo { Id = "net2", Name = "IoT", VlanId = 42, DhcpEnabled = true, Gateway = "10.0.42.1",
+                DnsServers = new List<string> { "10.0.0.5", "10.0.0.6" }, Purpose = NetworkPurpose.IoT },
+            new NetworkInfo { Id = "net3", Name = "Management", VlanId = 99, DhcpEnabled = true, Gateway = "10.0.99.1",
+                DnsServers = new List<string> { "10.0.99.1" }, Purpose = NetworkPurpose.Management }
+        };
+
+        var result = await _analyzer.AnalyzeAsync(null, null, null, networks);
+
+        result.HasThirdPartyDns.Should().BeTrue();
+        result.Issues.Should().NotContain(i => i.RuleId == "DNS-IP-MISMATCH-001");
+    }
+
+    [Fact]
+    public async Task Analyze_PiholeWithGatewayFallback_NoIpMismatch()
+    {
+        // Networks with Pi-hole primary + gateway fallback (common setup)
+        // Gateway IPs are excluded, so all networks should have same non-gateway set
+        var networks = new List<NetworkInfo>
+        {
+            new NetworkInfo { Id = "net1", Name = "Default", VlanId = 1, DhcpEnabled = true, Gateway = "10.0.0.1",
+                DnsServers = new List<string> { "10.0.0.5", "10.0.0.1" }, Purpose = NetworkPurpose.Home },
+            new NetworkInfo { Id = "net2", Name = "IoT", VlanId = 42, DhcpEnabled = true, Gateway = "10.0.42.1",
+                DnsServers = new List<string> { "10.0.0.5", "10.0.42.1" }, Purpose = NetworkPurpose.IoT },
+            new NetworkInfo { Id = "net3", Name = "Media", VlanId = 30, DhcpEnabled = true, Gateway = "10.0.30.1",
+                DnsServers = new List<string> { "10.0.0.5", "10.0.30.1" }, Purpose = NetworkPurpose.Home }
+        };
+
+        var result = await _analyzer.AnalyzeAsync(null, null, null, networks);
+
+        result.HasThirdPartyDns.Should().BeTrue();
+        result.Issues.Should().NotContain(i => i.RuleId == "DNS-IP-MISMATCH-001");
+    }
+
     #endregion
 
     #region Raw Device Data DNS Analysis Tests


### PR DESCRIPTION
## Summary

- Fixed `CheckDnsIpConsistency` comparing individual DNS IPs instead of per-network IP sets, causing false positives when all networks use the same primary + secondary Pi-hole pair
- Now groups by network first and compares the full set of third-party DNS IPs - only flags networks whose set differs from the majority
- Added 5 tests covering dual Pi-hole, partial secondary, different secondary, management exclusion, and gateway fallback scenarios

Fixes #475

## Test plan

- [x] All 4,075 existing tests pass
- [x] 5 new tests for dual Pi-hole IP consistency
- [ ] Manual test with Pi-hole + gateway (secondary/fallback) DNS
- [ ] Manual test with CyberSecure DoH site