### PR TITLE
Fix DNS mismatch false positive for isolated VLANs

### DIFF
--- a/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
@@ -2214,22 +2214,47 @@ public class DnsSecurityAnalyzer
                 .Distinct()
                 .ToList();
 
+            // Check if all mismatched networks are isolation-sensitive (IoT, Guest, Security, DMZ).
+            // Using separate DNS for these VLANs is a common security practice to prevent
+            // internal DNS leakage - e.g., separate AdGuard/Pi-hole instances per trust zone.
+            var isolationPurposes = new HashSet<NetworkPurpose>
+            {
+                NetworkPurpose.IoT, NetworkPurpose.Guest,
+                NetworkPurpose.Security, NetworkPurpose.Dmz
+            };
+            var mismatchedNetworkNames = mismatchedNetworks.Select(n => n.Network).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var mismatchedNetworkInfos = networks
+                .Where(n => !string.IsNullOrEmpty(n.Name) && mismatchedNetworkNames.Contains(n.Name))
+                .ToList();
+            var allIsolationNetworks = mismatchedNetworkInfos.Count > 0
+                && mismatchedNetworkInfos.All(n => isolationPurposes.Contains(n.Purpose));
+
+            var severity = allIsolationNetworks ? AuditSeverity.Informational : AuditSeverity.Recommended;
+            var message = allIsolationNetworks
+                ? $"{providerName} uses different IPs for {string.Join(", ", networkDetails)} vs. most networks ({expectedSetDisplay}). This is common when using separate DNS instances for network isolation."
+                : $"{providerName} IP mismatch: most networks use {expectedSetDisplay} but {string.Join(", ", networkDetails)} use different IPs. This may indicate misconfiguration.";
+            var recommendation = allIsolationNetworks
+                ? "Verify this is intentional. Using separate DNS instances for isolated VLANs is a security best practice."
+                : $"Update the DHCP DNS settings for the affected network(s) to use {expectedSetDisplay}.";
+            var scoreImpact = allIsolationNetworks ? 0 : 5;
+
             result.Issues.Add(new AuditIssue
             {
                 Type = IssueTypes.DnsInconsistentConfig,
-                Severity = AuditSeverity.Recommended,
+                Severity = severity,
                 DeviceName = result.GatewayName,
-                Message = $"{providerName} IP mismatch: most networks use {expectedSetDisplay} but {string.Join(", ", networkDetails)} use different IPs. This may indicate misconfiguration.",
-                RecommendedAction = $"Update the DHCP DNS settings for the affected network(s) to use {expectedSetDisplay}.",
+                Message = message,
+                RecommendedAction = recommendation,
                 RuleId = "DNS-IP-MISMATCH-001",
-                ScoreImpact = 5,
+                ScoreImpact = scoreImpact,
                 Metadata = new Dictionary<string, object>
                 {
                     { "expected_ip", expectedSet.First() },
                     { "expected_ips", expectedSet },
                     { "mismatched_networks", mismatchedNetworks.Select(n => n.Network).ToList() },
                     { "mismatched_ips", allMismatchedIps },
-                    { "provider_name", providerName }
+                    { "provider_name", providerName },
+                    { "intentional_isolation", allIsolationNetworks }
                 }
             });
         }

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
@@ -7059,6 +7059,103 @@ public class DnsSecurityAnalyzerTests : IDisposable
         result.Issues.Should().NotContain(i => i.RuleId == "DNS-IP-MISMATCH-001");
     }
 
+    [Fact]
+    public async Task Analyze_IsolationNetworksDifferentDns_InformationalNotRecommended()
+    {
+        // IoT and Guest VLANs use a separate DNS instance for isolation - this is intentional
+        // and should be Informational, not Recommended
+        var networks = new List<NetworkInfo>
+        {
+            new NetworkInfo { Id = "net1", Name = "Default", VlanId = 1, DhcpEnabled = true, Gateway = "192.168.1.1",
+                DnsServers = new List<string> { "192.168.100.10" }, Purpose = NetworkPurpose.Home },
+            new NetworkInfo { Id = "net2", Name = "Office", VlanId = 10, DhcpEnabled = true, Gateway = "192.168.10.1",
+                DnsServers = new List<string> { "192.168.100.10" }, Purpose = NetworkPurpose.Home },
+            new NetworkInfo { Id = "net3", Name = "IoT", VlanId = 42, DhcpEnabled = true, Gateway = "192.168.42.1",
+                DnsServers = new List<string> { "192.168.100.11" }, Purpose = NetworkPurpose.IoT },
+            new NetworkInfo { Id = "net4", Name = "Guest", VlanId = 50, DhcpEnabled = true, Gateway = "192.168.50.1",
+                DnsServers = new List<string> { "192.168.100.11" }, Purpose = NetworkPurpose.Guest }
+        };
+
+        var result = await _analyzer.AnalyzeAsync(null, null, null, networks);
+
+        var mismatchIssue = result.Issues.FirstOrDefault(i => i.RuleId == "DNS-IP-MISMATCH-001");
+        mismatchIssue.Should().NotBeNull("issue should still be raised for visibility");
+        mismatchIssue!.Severity.Should().Be(AuditSeverity.Informational);
+        mismatchIssue.ScoreImpact.Should().Be(0);
+        mismatchIssue.Message.Should().Contain("network isolation");
+        mismatchIssue.Metadata!["intentional_isolation"].Should().Be(true);
+    }
+
+    [Fact]
+    public async Task Analyze_MixedPurposeDifferentDns_RemainsRecommended()
+    {
+        // A Home network using different DNS is not isolation-motivated - keep Recommended
+        var networks = new List<NetworkInfo>
+        {
+            new NetworkInfo { Id = "net1", Name = "Default", VlanId = 1, DhcpEnabled = true, Gateway = "192.168.1.1",
+                DnsServers = new List<string> { "192.168.100.10" }, Purpose = NetworkPurpose.Home },
+            new NetworkInfo { Id = "net2", Name = "Office", VlanId = 10, DhcpEnabled = true, Gateway = "192.168.10.1",
+                DnsServers = new List<string> { "192.168.100.10" }, Purpose = NetworkPurpose.Home },
+            new NetworkInfo { Id = "net3", Name = "Kids", VlanId = 20, DhcpEnabled = true, Gateway = "192.168.20.1",
+                DnsServers = new List<string> { "192.168.100.99" }, Purpose = NetworkPurpose.Home }
+        };
+
+        var result = await _analyzer.AnalyzeAsync(null, null, null, networks);
+
+        var mismatchIssue = result.Issues.FirstOrDefault(i => i.RuleId == "DNS-IP-MISMATCH-001");
+        mismatchIssue.Should().NotBeNull();
+        mismatchIssue!.Severity.Should().Be(AuditSeverity.Recommended);
+        mismatchIssue.ScoreImpact.Should().Be(5);
+        mismatchIssue.Message.Should().Contain("misconfiguration");
+    }
+
+    [Fact]
+    public async Task Analyze_SecurityAndDmzDifferentDns_InformationalNotRecommended()
+    {
+        // Security cameras and DMZ using different DNS is also isolation-motivated
+        var networks = new List<NetworkInfo>
+        {
+            new NetworkInfo { Id = "net1", Name = "Default", VlanId = 1, DhcpEnabled = true, Gateway = "192.168.1.1",
+                DnsServers = new List<string> { "192.168.100.10" }, Purpose = NetworkPurpose.Home },
+            new NetworkInfo { Id = "net2", Name = "Office", VlanId = 10, DhcpEnabled = true, Gateway = "192.168.10.1",
+                DnsServers = new List<string> { "192.168.100.10" }, Purpose = NetworkPurpose.Home },
+            new NetworkInfo { Id = "net3", Name = "Cameras", VlanId = 30, DhcpEnabled = true, Gateway = "192.168.30.1",
+                DnsServers = new List<string> { "192.168.100.11" }, Purpose = NetworkPurpose.Security },
+            new NetworkInfo { Id = "net4", Name = "DMZ", VlanId = 40, DhcpEnabled = true, Gateway = "192.168.40.1",
+                DnsServers = new List<string> { "192.168.100.11" }, Purpose = NetworkPurpose.Dmz }
+        };
+
+        var result = await _analyzer.AnalyzeAsync(null, null, null, networks);
+
+        var mismatchIssue = result.Issues.FirstOrDefault(i => i.RuleId == "DNS-IP-MISMATCH-001");
+        mismatchIssue.Should().NotBeNull();
+        mismatchIssue!.Severity.Should().Be(AuditSeverity.Informational);
+        mismatchIssue.ScoreImpact.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Analyze_MixOfIsolationAndTrustedDifferentDns_RemainsRecommended()
+    {
+        // If mismatched set includes both IoT and a Home network, keep Recommended
+        var networks = new List<NetworkInfo>
+        {
+            new NetworkInfo { Id = "net1", Name = "Default", VlanId = 1, DhcpEnabled = true, Gateway = "192.168.1.1",
+                DnsServers = new List<string> { "192.168.100.10" }, Purpose = NetworkPurpose.Home },
+            new NetworkInfo { Id = "net2", Name = "Office", VlanId = 10, DhcpEnabled = true, Gateway = "192.168.10.1",
+                DnsServers = new List<string> { "192.168.100.10" }, Purpose = NetworkPurpose.Home },
+            new NetworkInfo { Id = "net3", Name = "IoT", VlanId = 42, DhcpEnabled = true, Gateway = "192.168.42.1",
+                DnsServers = new List<string> { "192.168.100.11" }, Purpose = NetworkPurpose.IoT },
+            new NetworkInfo { Id = "net4", Name = "Misc", VlanId = 60, DhcpEnabled = true, Gateway = "192.168.60.1",
+                DnsServers = new List<string> { "192.168.100.11" }, Purpose = NetworkPurpose.Home }
+        };
+
+        var result = await _analyzer.AnalyzeAsync(null, null, null, networks);
+
+        var mismatchIssue = result.Issues.FirstOrDefault(i => i.RuleId == "DNS-IP-MISMATCH-001");
+        mismatchIssue.Should().NotBeNull();
+        mismatchIssue!.Severity.Should().Be(AuditSeverity.Recommended);
+    }
+
     #endregion
 
     #region Raw Device Data DNS Analysis Tests


### PR DESCRIPTION
## Summary

- DNS IP mismatch audit now recognizes when IoT, Guest, Security, or DMZ VLANs intentionally use different DNS servers (e.g., separate AdGuard Home instances for VLAN isolation)
- These cases are now flagged as **Informational** with zero score impact instead of **Recommended** with a 5-point penalty
- Mismatched DNS on trusted networks (Home, etc.) still flags as **Recommended**

Fixes #478. Does not regress #475 (dual DNS set comparison).

## Test plan

- [x] 4 new tests covering isolation-only, trusted-only, mixed, and Security/DMZ scenarios
- [x] All 290 existing DNS audit tests pass
- [x] All 4 dual Pi-hole tests from #475 pass
- [x] Verified on NAS - no false positive, full DNS protection shown
- [x] Verified on Mac - no regression, partial protection shown correctly