### PR TITLE
Fix MAC restriction audit not recognizing multi_mac 802.1X mode

### DIFF
--- a/src/NetworkOptimizer.Audit/Models/PortInfo.cs
+++ b/src/NetworkOptimizer.Audit/Models/PortInfo.cs
@@ -136,17 +136,19 @@ public class PortInfo
 
     /// <summary>
     /// 802.1X control mode from the assigned port profile.
-    /// Values: "auto" (802.1X), "mac_based" (RADIUS MAC auth),
-    /// "force_authorized" (bypass), "force_unauthorized" (block), or null.
+    /// Values: "auto" (802.1X), "mac_based" (RADIUS MAC auth), "multi_host" (first MAC authenticates,
+    /// rest allowed), "multi_mac" (each MAC authenticates), "force_authorized" (bypass),
+    /// "force_unauthorized" (block), or null.
     /// </summary>
     public string? Dot1xCtrl { get; init; }
 
     /// <summary>
     /// Whether this port is secured via 802.1X/RADIUS authentication.
     /// True when Dot1xCtrl is "auto" (802.1X), "mac_based" (RADIUS MAC auth),
-    /// or "multi_host" (802.1X authenticates first MAC, then allows subsequent MACs).
+    /// "multi_host" (802.1X authenticates first MAC, then allows subsequent MACs),
+    /// or "multi_mac" (each MAC must individually authenticate via RADIUS).
     /// </summary>
-    public bool IsDot1xSecured => Dot1xCtrl is "auto" or "mac_based" or "multi_host";
+    public bool IsDot1xSecured => Dot1xCtrl is "auto" or "mac_based" or "multi_host" or "multi_mac";
 
     /// <summary>
     /// The port profile (portconf) assigned to this port, if any.

--- a/src/NetworkOptimizer.Core/Helpers/DisplayFormatters.cs
+++ b/src/NetworkOptimizer.Core/Helpers/DisplayFormatters.cs
@@ -320,7 +320,7 @@ public static class DisplayFormatters
     {
         if (macCount > 1) return $"{macCount} MAC";
         if (macCount == 1) return "1 MAC";
-        if (dot1xCtrl is "auto" or "mac_based" or "multi_host") return "802.1X";
+        if (dot1xCtrl is "auto" or "mac_based" or "multi_host" or "multi_mac") return "802.1X";
         if (portSecurityEnabled) return "Yes";
         return "-";
     }

--- a/src/NetworkOptimizer.Reports/ReportData.cs
+++ b/src/NetworkOptimizer.Reports/ReportData.cs
@@ -290,10 +290,10 @@ public class SwitchDetail
     public int TotalPorts => Ports.Count;
     public int DisabledPorts => Ports.Count(p => p.Forward == "disabled");
     public int MacRestrictedPorts => Ports.Count(p => p.MacRestrictionCount > 0);
-    public int Dot1xPorts => Ports.Count(p => p.Dot1xCtrl is ("auto" or "mac_based" or "multi_host") && p.Forward == "native" && p.IsUp && !p.IsUplink);
+    public int Dot1xPorts => Ports.Count(p => p.Dot1xCtrl is ("auto" or "mac_based" or "multi_host" or "multi_mac") && p.Forward == "native" && p.IsUp && !p.IsUplink);
     public int UnprotectedActivePorts => Ports.Count(p =>
         p.Forward == "native" && p.IsUp && p.MacRestrictionCount == 0 && !p.IsUplink
-        && p.Dot1xCtrl is not ("auto" or "mac_based" or "multi_host"));
+        && p.Dot1xCtrl is not ("auto" or "mac_based" or "multi_host" or "multi_mac"));
 }
 
 /// <summary>
@@ -371,7 +371,7 @@ public class PortDetail
         {
             // Warning if no MAC restriction, no 802.1X, and device supports it
             if (IsUp && supportsAcls && MacRestrictionCount == 0 && !IsUplink
-                && Dot1xCtrl is not ("auto" or "mac_based" or "multi_host"))
+                && Dot1xCtrl is not ("auto" or "mac_based" or "multi_host" or "multi_mac"))
                 return ("No MAC", PortStatusType.Warning);
             return ("OK", PortStatusType.Ok);
         }

--- a/src/NetworkOptimizer.UniFi/Models/UniFiPortProfile.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiPortProfile.cs
@@ -81,9 +81,10 @@ public class UniFiPortProfile
     public bool StormCtrlUcastEnabled { get; set; }
 
     /// <summary>
-    /// 802.1X control mode: "auto", "force_authorized", "force_unauthorized"
-    /// When set to "auto", ports will require 802.1X authentication if enabled on the network.
-    /// "force_authorized" bypasses 802.1X even if enabled - recommended for trunk/fabric ports.
+    /// 802.1X control mode: "auto", "mac_based", "multi_host", "multi_mac",
+    /// "force_authorized", "force_unauthorized".
+    /// Active modes (auto, mac_based, multi_host, multi_mac) provide RADIUS-based port security.
+    /// "force_authorized" bypasses 802.1X - recommended for trunk/fabric ports.
     /// </summary>
     [JsonPropertyName("dot1x_ctrl")]
     public string? Dot1xCtrl { get; set; }

--- a/src/NetworkOptimizer.Web/Components/Pages/Audit.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Audit.razor
@@ -836,8 +836,8 @@
                                 var totalPorts = sw.Ports.Count;
                                 var disabledPorts = sw.Ports.Count(p => p.Forward == "disabled");
                                 var macRestricted = sw.Ports.Count(p => p.PortSecurityMacs.Any());
-                                var dot1xCount = sw.Ports.Count(p => p.Dot1xCtrl is ("auto" or "mac_based" or "multi_host") && p.Forward == "native" && p.IsUp && !p.IsUplink);
-                                var unprotectedActive = sw.Ports.Count(p => p.Forward == "native" && p.IsUp && !p.PortSecurityMacs.Any() && !p.IsUplink && p.Dot1xCtrl is not ("auto" or "mac_based" or "multi_host"));
+                                var dot1xCount = sw.Ports.Count(p => p.Dot1xCtrl is ("auto" or "mac_based" or "multi_host" or "multi_mac") && p.Forward == "native" && p.IsUp && !p.IsUplink);
+                                var unprotectedActive = sw.Ports.Count(p => p.Forward == "native" && p.IsUp && !p.PortSecurityMacs.Any() && !p.IsUplink && p.Dot1xCtrl is not ("auto" or "mac_based" or "multi_host" or "multi_mac"));
                                 <tr>
                                     <td class="icon-cell"><DeviceIcon Model="@sw.ModelName" Size="md" /></td>
                                     <td>@sw.Name</td>
@@ -1823,7 +1823,7 @@
         if (port.Forward == "native")
         {
             if (port.IsUp && supportsAcls && !port.PortSecurityMacs.Any() && !port.IsUplink
-                && port.Dot1xCtrl is not ("auto" or "mac_based" or "multi_host"))
+                && port.Dot1xCtrl is not ("auto" or "mac_based" or "multi_host" or "multi_mac"))
                 return ("No MAC", "row-warning");
             return ("OK", "");
         }

--- a/tests/NetworkOptimizer.Audit.Tests/Rules/MacRestrictionRuleTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Rules/MacRestrictionRuleTests.cs
@@ -305,8 +305,10 @@ public class MacRestrictionRuleTests
     #region 802.1X / RADIUS Authentication
 
     [Theory]
-    [InlineData("auto")]      // 802.1X authentication
-    [InlineData("mac_based")] // RADIUS MAC authentication
+    [InlineData("auto")]       // 802.1X authentication
+    [InlineData("mac_based")]  // RADIUS MAC authentication
+    [InlineData("multi_host")] // First MAC authenticates, rest allowed
+    [InlineData("multi_mac")]  // Each MAC must individually authenticate
     public void Evaluate_Dot1xSecuredPort_ReturnsNull(string dot1xCtrl)
     {
         var port = CreatePort(isUp: true, forwardMode: "native", dot1xCtrl: dot1xCtrl);

--- a/tests/NetworkOptimizer.Core.Tests/Helpers/DisplayFormattersTests.cs
+++ b/tests/NetworkOptimizer.Core.Tests/Helpers/DisplayFormattersTests.cs
@@ -473,6 +473,8 @@ public class DisplayFormattersTests
     [Theory]
     [InlineData("auto", "802.1X")]
     [InlineData("mac_based", "802.1X")]
+    [InlineData("multi_host", "802.1X")]
+    [InlineData("multi_mac", "802.1X")]
     public void GetPortSecurityStatus_Dot1xSecured_Returns8021X(string dot1xCtrl, string expected)
     {
         var result = DisplayFormatters.GetPortSecurityStatus(0, false, dot1xCtrl);


### PR DESCRIPTION
## Summary

- Adds `"multi_mac"` to all 802.1X security checks across the codebase (audit rule, display formatters, reports, UI)
- UniFi's Multi-MAC 802.1X mode (each MAC individually authenticates via RADIUS) was not recognized as a secured port mode, causing ports with this profile setting to be incorrectly flagged for missing MAC restrictions

Fixes #395

## Test plan

- [x] Existing MAC restriction tests pass with new `multi_mac` and `multi_host` InlineData cases (244 tests pass)
- [ ] Verify with a real 802.1X Multi-MAC profile that the audit no longer flags those ports