### PR TITLE
Skip MAC restriction audit for Server-purpose networks

### DIFF
--- a/src/NetworkOptimizer.Audit/Analyzers/PortSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/PortSecurityAnalyzer.cs
@@ -486,7 +486,7 @@ public class PortSecurityAnalyzer
     /// </summary>
     private SwitchCapabilities ParseSwitchCapabilities(JsonElement device)
     {
-        var caps = new SwitchCapabilities();
+        var dot1xEnabled = device.GetBoolOrDefault("dot1x_portctrl_enabled");
 
         if (device.TryGetProperty("switch_caps", out var switchCaps))
         {
@@ -494,12 +494,13 @@ public class PortSecurityAnalyzer
             {
                 return new SwitchCapabilities
                 {
-                    MaxCustomMacAcls = maxAclsProp.GetInt32()
+                    MaxCustomMacAcls = maxAclsProp.GetInt32(),
+                    Dot1xPortCtrlEnabled = dot1xEnabled
                 };
             }
         }
 
-        return caps;
+        return new SwitchCapabilities { Dot1xPortCtrlEnabled = dot1xEnabled };
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Audit/Models/SwitchInfo.cs
+++ b/src/NetworkOptimizer.Audit/Models/SwitchInfo.cs
@@ -91,6 +91,12 @@ public class SwitchCapabilities
     public int MaxCustomMacAcls { get; init; }
 
     /// <summary>
+    /// Whether 802.1X port control is enabled on this switch.
+    /// From the device-level dot1x_portctrl_enabled field.
+    /// </summary>
+    public bool Dot1xPortCtrlEnabled { get; init; }
+
+    /// <summary>
     /// Whether the switch supports port isolation
     /// </summary>
     public bool SupportsIsolation { get; init; }

--- a/src/NetworkOptimizer.Audit/Rules/MacRestrictionRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/MacRestrictionRule.cs
@@ -44,11 +44,31 @@ public class MacRestrictionRule : AuditRuleBase
         if (port.Switch.Capabilities.MaxCustomMacAcls == 0)
             return null; // Switch doesn't support this feature
 
-        // Skip ports on Server networks - servers/hypervisors inherently have multiple MACs
-        // from VMs and containers, making MAC restriction impractical
         var network = GetNetwork(port.NativeNetworkId, networks);
+
+        // Server networks: servers/hypervisors have multiple MACs from VMs and containers,
+        // so MAC restriction is impractical. Recommend 802.1X multi-host if the switch supports it,
+        // otherwise skip entirely.
         if (network?.Purpose == NetworkPurpose.Server)
-            return null;
+        {
+            if (port.IsDot1xSecured)
+                return null; // Already secured via RADIUS
+
+            if (port.Switch.Capabilities.Dot1xPortCtrlEnabled)
+            {
+                return CreateIssue(
+                    "Server port should use 802.1X authentication for port security",
+                    port,
+                    new Dictionary<string, object>
+                    {
+                        { "network", network.Name }
+                    },
+                    "This port is on a Server network where MAC restriction is impractical due to multiple VM/container MACs. " +
+                    "Use 802.1X Multi-Host mode to authenticate the server, then allow subsequent MACs on the port.");
+            }
+
+            return null; // Switch doesn't support 802.1X, nothing actionable
+        }
 
         // Check if port already has MAC restrictions
         if (port.PortSecurityEnabled || (port.AllowedMacAddresses?.Any() ?? false))

--- a/tests/NetworkOptimizer.Audit.Tests/Rules/MacRestrictionRuleTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Rules/MacRestrictionRuleTests.cs
@@ -105,17 +105,47 @@ public class MacRestrictionRuleTests
     }
 
     [Fact]
-    public void Evaluate_ServerNetworkPurpose_ReturnsNull()
+    public void Evaluate_ServerNetwork_NoDot1x_ReturnsNull()
     {
         var networks = new List<NetworkInfo>
         {
             new() { Id = "net-server", Name = "Service", VlanId = 1000, Purpose = NetworkPurpose.Server }
         };
-        var port = CreatePort(isUp: true, forwardMode: "native", nativeNetworkId: "net-server");
+        var port = CreatePort(isUp: true, forwardMode: "native", nativeNetworkId: "net-server", dot1xPortCtrlEnabled: false);
 
         var result = _rule.Evaluate(port, networks);
 
-        result.Should().BeNull("servers/hypervisors have multiple MACs from VMs, making MAC restriction impractical");
+        result.Should().BeNull("switch doesn't support 802.1X, and MAC restriction is impractical for servers");
+    }
+
+    [Fact]
+    public void Evaluate_ServerNetwork_Dot1xAvailable_ReturnsIssue()
+    {
+        var networks = new List<NetworkInfo>
+        {
+            new() { Id = "net-server", Name = "Service", VlanId = 1000, Purpose = NetworkPurpose.Server }
+        };
+        var port = CreatePort(isUp: true, forwardMode: "native", nativeNetworkId: "net-server", dot1xPortCtrlEnabled: true);
+
+        var result = _rule.Evaluate(port, networks);
+
+        result.Should().NotBeNull("802.1X is available and should be recommended for server ports");
+        result!.RecommendedAction.Should().Contain("802.1X");
+    }
+
+    [Fact]
+    public void Evaluate_ServerNetwork_Dot1xAlreadySecured_ReturnsNull()
+    {
+        var networks = new List<NetworkInfo>
+        {
+            new() { Id = "net-server", Name = "Service", VlanId = 1000, Purpose = NetworkPurpose.Server }
+        };
+        var port = CreatePort(isUp: true, forwardMode: "native", nativeNetworkId: "net-server",
+            dot1xPortCtrlEnabled: true, dot1xCtrl: "multi_host");
+
+        var result = _rule.Evaluate(port, networks);
+
+        result.Should().BeNull("port is already secured via 802.1X");
     }
 
     #endregion
@@ -474,14 +504,16 @@ public class MacRestrictionRuleTests
         string? nativeNetworkId = null,
         string? connectedDeviceType = null,
         UniFiPortProfile? assignedProfile = null,
-        string? dot1xCtrl = null)
+        string? dot1xCtrl = null,
+        bool dot1xPortCtrlEnabled = false)
     {
         var switchInfo = new SwitchInfo
         {
             Name = switchName,
             Capabilities = new SwitchCapabilities
             {
-                MaxCustomMacAcls = maxMacAcls
+                MaxCustomMacAcls = maxMacAcls,
+                Dot1xPortCtrlEnabled = dot1xPortCtrlEnabled
             }
         };
 


### PR DESCRIPTION
## Summary

- Ports whose native network has Server purpose are now exempt from MAC restriction audits
- Servers and hypervisors (Proxmox, ESXi, etc.) inherently have multiple MACs from VMs and containers, making per-port MAC restriction impractical

Fixes #395

## Test plan

- [x] New test: `Evaluate_ServerNetworkPurpose_ReturnsNull` 
- [x] All 54 existing MAC restriction tests still pass
- [x] Verify on a network with Server-purpose VLANs that Proxmox ports no longer flagged