### PR TITLE
Fix alert rule edit after toggle (#482)

### DIFF
--- a/src/NetworkOptimizer.Storage/Repositories/AlertRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/AlertRepository.cs
@@ -91,6 +91,14 @@ public class AlertRepository : IAlertRepository
         try
         {
             rule.UpdatedAt = DateTime.UtcNow;
+
+            // Detach any already-tracked instance to avoid "already being tracked" errors
+            // when toggle + edit happen on the same scoped DbContext lifetime
+            var tracked = _context.ChangeTracker.Entries<AlertRule>()
+                .FirstOrDefault(e => e.Entity.Id == rule.Id);
+            if (tracked != null)
+                tracked.State = EntityState.Detached;
+
             _context.AlertRules.Update(rule);
             await _context.SaveChangesAsync(cancellationToken);
             _logger.LogInformation("Updated alert rule {RuleId}: {Name}", rule.Id, rule.Name);


### PR DESCRIPTION
## Summary

- Fix EF Core entity tracking conflict when editing an alert rule after toggling it enabled/disabled
- `ToggleRule` calls `UpdateRuleAsync` which starts tracking the entity, then `SaveRule` calls `GetRuleAsync` (without `AsNoTracking`) which tracks a second instance with the same key, causing `InvalidOperationException`
- Fix: detach any already-tracked instance before calling `Update`

Fixes #482

## Test plan

- [x] Toggle a rule off, then immediately edit and save it - should succeed without error
- [x] Toggle a rule on, then edit and save - should succeed
- [x] Create a new rule - should still work
- [x] Delete a rule - should still work