### PR TITLE
GPON/XGS-PON: afternoon relief window and baseline interpolation

### DIFF
--- a/src/NetworkOptimizer.Sqm/Models/ConnectionProfile.cs
+++ b/src/NetworkOptimizer.Sqm/Models/ConnectionProfile.cs
@@ -486,16 +486,16 @@ public class ConnectionProfile
             },
 
             // GPON: shared splitter means noticeable congestion at peak hours.
-            // Smooth curve: 1.00 overnight → 0.99 morning → 0.98/0.975 → 0.97 workday → 0.965 streaming → taper back up
-            //  Hour:  0      1     2     3     4     5     6     7     8     9    10    11    12    13    14    15    16    17    18    19    20    21    22    23
+            // Smooth curve: 1.00 overnight - 0.99 morning - 0.97 workday - 0.975/0.985 afternoon relief (commute gap) - 0.965 streaming peak - taper back up
+            //  Hour:  0      1     2     3     4     5     6     7     8     9    10    11    12    13    14    15      16     17     18    19    20    21    22    23
             ConnectionType.Gpon => CreateUniformWeekPattern(new double[]
-                { 0.995, 1.00, 1.00, 1.00, 1.00, 1.00, 0.99, 0.99, 0.98, 0.975, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.965, 0.965, 0.965, 0.965, 0.975, 0.985 }),
+                { 0.995, 1.00, 1.00, 1.00, 1.00, 1.00, 0.99, 0.99, 0.98, 0.975, 0.97, 0.97, 0.97, 0.97, 0.97, 0.975, 0.985, 0.985, 0.965, 0.965, 0.965, 0.965, 0.975, 0.985 }),
 
             // XGS-PON: 10G headroom, minimal congestion even at peak.
-            // Compressed version of GPON curve: 1.00 overnight → 0.995 → 0.99/0.9875 → 0.985 workday → 0.98 streaming
-            //  Hour:  0      1     2     3     4     5     6      7      8     9      10     11     12     13     14     15     16     17     18    19    20    21     22     23
+            // Compressed version of GPON curve: 1.00 overnight - 0.995 - 0.985 workday - 0.9875/0.99 afternoon relief (commute gap) - 0.98 streaming peak
+            //  Hour:  0      1     2     3     4     5     6      7      8     9      10     11     12     13     14     15       16    17    18    19    20    21     22     23
             ConnectionType.XgsPon => CreateUniformWeekPattern(new double[]
-                { 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 0.995, 0.995, 0.99, 0.9875, 0.985, 0.985, 0.985, 0.985, 0.985, 0.985, 0.985, 0.985, 0.98, 0.98, 0.98, 0.98, 0.985, 0.99 }),
+                { 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 0.995, 0.995, 0.99, 0.9875, 0.985, 0.985, 0.985, 0.985, 0.985, 0.9875, 0.99, 0.99, 0.98, 0.98, 0.98, 0.98, 0.985, 0.99 }),
 
             // DSL: stable but may have minor peak-hour drops (same pattern all week)
             ConnectionType.Dsl => CreateUniformWeekPattern(new double[]

--- a/src/NetworkOptimizer.Sqm/Models/ConnectionProfile.cs
+++ b/src/NetworkOptimizer.Sqm/Models/ConnectionProfile.cs
@@ -486,10 +486,10 @@ public class ConnectionProfile
             },
 
             // GPON: shared splitter means noticeable congestion at peak hours.
-            // Smooth curve: 1.00 overnight - 0.99 morning - 0.97 workday - 0.975/0.985 afternoon relief (commute gap) - 0.965 streaming peak - taper back up
-            //  Hour:  0      1     2     3     4     5     6     7     8     9    10    11    12    13    14    15      16     17     18    19    20    21    22    23
+            // Smooth curve: 1.00 overnight - 0.99 morning - 0.97 workday - 0.975/0.985/0.9825 afternoon relief (commute gap) - 0.965 streaming peak - taper back up
+            //  Hour:  0      1     2     3     4     5     6     7     8     9    10    11    12    13    14    15      16     17       18    19    20    21    22    23
             ConnectionType.Gpon => CreateUniformWeekPattern(new double[]
-                { 0.995, 1.00, 1.00, 1.00, 1.00, 1.00, 0.99, 0.99, 0.98, 0.975, 0.97, 0.97, 0.97, 0.97, 0.97, 0.975, 0.985, 0.985, 0.965, 0.965, 0.965, 0.965, 0.975, 0.985 }),
+                { 0.995, 1.00, 1.00, 1.00, 1.00, 1.00, 0.99, 0.99, 0.98, 0.975, 0.97, 0.97, 0.97, 0.97, 0.97, 0.975, 0.985, 0.9825, 0.965, 0.965, 0.965, 0.965, 0.975, 0.985 }),
 
             // XGS-PON: 10G headroom, minimal congestion even at peak.
             // Compressed version of GPON curve: 1.00 overnight - 0.995 - 0.985 workday - 0.9875/0.99 afternoon relief (commute gap) - 0.98 streaming peak

--- a/src/NetworkOptimizer.Sqm/Models/ConnectionProfile.cs
+++ b/src/NetworkOptimizer.Sqm/Models/ConnectionProfile.cs
@@ -381,7 +381,7 @@ public class ConnectionProfile
                 if (congestionSeverity != 1.0)
                     multiplier = 1.0 - (1.0 - multiplier) * congestionSeverity;
 
-                var speed = (int)(multiplier * NominalDownloadMbps);
+                var speed = Math.Max(5, (int)(multiplier * NominalDownloadMbps));
                 baseline[key] = speed.ToString();
             }
         }

--- a/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
+++ b/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
@@ -675,7 +675,7 @@ tune_tc_performance() {
         var withinRatio = $"{(int)(_config.BlendingWeightWithin * 100)}/{(int)((1.0 - _config.BlendingWeightWithin) * 100)}";
         var belowRatio = $"{(int)(_config.BlendingWeightBelow * 100)}/{(int)((1.0 - _config.BlendingWeightBelow) * 100)}";
 
-        return $@"# Baseline blending (with half-hour interpolation)
+        return $@"# Baseline blending (with quarter-hour interpolation)
 current_day=$(date +%u)
 current_day=$((current_day - 1))
 current_hour=$(date +%H | sed 's/^0//')
@@ -694,9 +694,11 @@ next_key=""${{next_day}}_${{next_hour}}""
 baseline_speed=${{BASELINE[$lookup_key]}}
 next_baseline_speed=${{BASELINE[$next_key]}}
 
-# Interpolate between current and next hour based on minutes
+# Interpolate at 15-minute breakpoints: :00=0%, :15=25%, :30=50%, :45=75%
 if [ -n ""$baseline_speed"" ] && [ -n ""$next_baseline_speed"" ]; then
-    baseline_speed=$(echo ""scale=0; ($baseline_speed * (60 - $current_min) + $next_baseline_speed * $current_min) / 60"" | bc)
+    quarter=$(( current_min / 15 ))
+    weight=$(( quarter * 25 ))
+    baseline_speed=$(( (baseline_speed * (100 - weight) + next_baseline_speed * weight) / 100 ))
 fi
 
 if [ -n ""$baseline_speed"" ]; then
@@ -725,7 +727,7 @@ fi";
         var measuredWeight = Inv(1.0 - _config.BlendingWeightWithin);
         var overheadMultiplier = Inv(_config.OverheadMultiplier);
 
-        return $@"# Baseline blending for ping (with half-hour interpolation)
+        return $@"# Baseline blending for ping (with quarter-hour interpolation)
 current_day=$(date +%u)
 current_day=$((current_day - 1))
 current_hour=$(date +%H | sed 's/^0//')
@@ -744,9 +746,11 @@ next_key=""${{next_day}}_${{next_hour}}""
 baseline_speed=${{BASELINE[$lookup_key]}}
 next_baseline_speed=${{BASELINE[$next_key]}}
 
-# Interpolate between current and next hour based on minutes
+# Interpolate at 15-minute breakpoints: :00=0%, :15=25%, :30=50%, :45=75%
 if [ -n ""$baseline_speed"" ] && [ -n ""$next_baseline_speed"" ]; then
-    baseline_speed=$(echo ""scale=0; ($baseline_speed * (60 - $current_min) + $next_baseline_speed * $current_min) / 60"" | bc)
+    quarter=$(( current_min / 15 ))
+    weight=$(( quarter * 25 ))
+    baseline_speed=$(( (baseline_speed * (100 - weight) + next_baseline_speed * weight) / 100 ))
 fi
 
 if [ -n ""$baseline_speed"" ]; then

--- a/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
+++ b/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
@@ -699,6 +699,7 @@ if [ -n ""$baseline_speed"" ] && [ -n ""$next_baseline_speed"" ]; then
     quarter=$(( current_min / 15 ))
     weight=$(( quarter * 25 ))
     baseline_speed=$(( (baseline_speed * (100 - weight) + next_baseline_speed * weight) / 100 ))
+    if [ ""$baseline_speed"" -lt 5 ]; then baseline_speed=5; fi
 fi
 
 if [ -n ""$baseline_speed"" ]; then
@@ -751,6 +752,7 @@ if [ -n ""$baseline_speed"" ] && [ -n ""$next_baseline_speed"" ]; then
     quarter=$(( current_min / 15 ))
     weight=$(( quarter * 25 ))
     baseline_speed=$(( (baseline_speed * (100 - weight) + next_baseline_speed * weight) / 100 ))
+    if [ ""$baseline_speed"" -lt 5 ]; then baseline_speed=5; fi
 fi
 
 if [ -n ""$baseline_speed"" ]; then

--- a/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
+++ b/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
@@ -675,13 +675,29 @@ tune_tc_performance() {
         var withinRatio = $"{(int)(_config.BlendingWeightWithin * 100)}/{(int)((1.0 - _config.BlendingWeightWithin) * 100)}";
         var belowRatio = $"{(int)(_config.BlendingWeightBelow * 100)}/{(int)((1.0 - _config.BlendingWeightBelow) * 100)}";
 
-        return $@"# Baseline blending
+        return $@"# Baseline blending (with half-hour interpolation)
 current_day=$(date +%u)
 current_day=$((current_day - 1))
 current_hour=$(date +%H | sed 's/^0//')
+current_min=$(date +%M | sed 's/^0//')
 lookup_key=""${{current_day}}_${{current_hour}}""
 
+# Next hour lookup (wraps at midnight to next day)
+next_hour=$(( (current_hour + 1) % 24 ))
+if [ ""$next_hour"" -eq 0 ]; then
+    next_day=$(( (current_day + 1) % 7 ))
+else
+    next_day=$current_day
+fi
+next_key=""${{next_day}}_${{next_hour}}""
+
 baseline_speed=${{BASELINE[$lookup_key]}}
+next_baseline_speed=${{BASELINE[$next_key]}}
+
+# Interpolate between current and next hour based on minutes
+if [ -n ""$baseline_speed"" ] && [ -n ""$next_baseline_speed"" ]; then
+    baseline_speed=$(echo ""scale=0; ($baseline_speed * (60 - $current_min) + $next_baseline_speed * $current_min) / 60"" | bc)
+fi
 
 if [ -n ""$baseline_speed"" ]; then
     threshold=$(echo ""scale=0; $baseline_speed * 0.9 / 1"" | bc)
@@ -709,13 +725,29 @@ fi";
         var measuredWeight = Inv(1.0 - _config.BlendingWeightWithin);
         var overheadMultiplier = Inv(_config.OverheadMultiplier);
 
-        return $@"# Baseline blending for ping
+        return $@"# Baseline blending for ping (with half-hour interpolation)
 current_day=$(date +%u)
 current_day=$((current_day - 1))
 current_hour=$(date +%H | sed 's/^0//')
+current_min=$(date +%M | sed 's/^0//')
 lookup_key=""${{current_day}}_${{current_hour}}""
 
+# Next hour lookup (wraps at midnight to next day)
+next_hour=$(( (current_hour + 1) % 24 ))
+if [ ""$next_hour"" -eq 0 ]; then
+    next_day=$(( (current_day + 1) % 7 ))
+else
+    next_day=$current_day
+fi
+next_key=""${{next_day}}_${{next_hour}}""
+
 baseline_speed=${{BASELINE[$lookup_key]}}
+next_baseline_speed=${{BASELINE[$next_key]}}
+
+# Interpolate between current and next hour based on minutes
+if [ -n ""$baseline_speed"" ] && [ -n ""$next_baseline_speed"" ]; then
+    baseline_speed=$(echo ""scale=0; ($baseline_speed * (60 - $current_min) + $next_baseline_speed * $current_min) / 60"" | bc)
+fi
 
 if [ -n ""$baseline_speed"" ]; then
     baseline_with_overhead=$(echo ""scale=0; $baseline_speed * {overheadMultiplier} / 1"" | bc)

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -3199,6 +3199,8 @@
                         rate = Math.Min(withOverhead, cap);
                     }
 
+                    rate = Math.Max(5, rate);
+
                     if (rate < minRate) minRate = rate;
                     if (rate > maxRate) maxRate = rate;
                 }

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -587,7 +587,7 @@
                     <div class="param">
                         <span class="param-label">Severity <span class="tooltip-icon tooltip-icon-sm" data-tooltip="Scales how deep the congestion dips go. 1.0 = default profile. Higher = more aggressive shaping at peak. Lower = flatter curve.">?</span></span>
                         <div class="wan-time-slider" style="padding: 0; gap: 0.5rem; justify-content: center;">
-                            <input type="range" min="0.75" max="1.25" step="0.01" style="width: 100px;" @bind="wan1Config.CongestionSeverity" @bind:event="oninput" />
+                            <input type="range" min="0.5" max="1.5" step="0.01" style="width: 100px;" @bind="wan1Config.CongestionSeverity" @bind:event="oninput" />
                             <span class="param-value">@wan1Config.CongestionSeverity.ToString("F2")</span>
                         </div>
                     </div>
@@ -753,7 +753,7 @@
                     <div class="param">
                         <span class="param-label">Severity <span class="tooltip-icon tooltip-icon-sm" data-tooltip="Scales how deep the congestion dips go. 1.0 = default profile. Higher = more aggressive shaping at peak. Lower = flatter curve.">?</span></span>
                         <div class="wan-time-slider" style="padding: 0; gap: 0.5rem; justify-content: center;">
-                            <input type="range" min="0.75" max="1.25" step="0.01" style="width: 100px;" @bind="wan2Config.CongestionSeverity" @bind:event="oninput" />
+                            <input type="range" min="0.5" max="1.5" step="0.01" style="width: 100px;" @bind="wan2Config.CongestionSeverity" @bind:event="oninput" />
                             <span class="param-value">@wan2Config.CongestionSeverity.ToString("F2")</span>
                         </div>
                     </div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -587,7 +587,7 @@
                     <div class="param">
                         <span class="param-label">Severity <span class="tooltip-icon tooltip-icon-sm" data-tooltip="Scales how deep the congestion dips go. 1.0 = default profile. Higher = more aggressive shaping at peak. Lower = flatter curve.">?</span></span>
                         <div class="wan-time-slider" style="padding: 0; gap: 0.5rem; justify-content: center;">
-                            <input type="range" min="0.5" max="1.5" step="0.01" style="width: 100px;" @bind="wan1Config.CongestionSeverity" @bind:event="oninput" />
+                            <input type="range" min="0" max="2" step="0.01" style="width: 100px;" @bind="wan1Config.CongestionSeverity" @bind:event="oninput" />
                             <span class="param-value">@wan1Config.CongestionSeverity.ToString("F2")</span>
                         </div>
                     </div>
@@ -753,7 +753,7 @@
                     <div class="param">
                         <span class="param-label">Severity <span class="tooltip-icon tooltip-icon-sm" data-tooltip="Scales how deep the congestion dips go. 1.0 = default profile. Higher = more aggressive shaping at peak. Lower = flatter curve.">?</span></span>
                         <div class="wan-time-slider" style="padding: 0; gap: 0.5rem; justify-content: center;">
-                            <input type="range" min="0.5" max="1.5" step="0.01" style="width: 100px;" @bind="wan2Config.CongestionSeverity" @bind:event="oninput" />
+                            <input type="range" min="0" max="2" step="0.01" style="width: 100px;" @bind="wan2Config.CongestionSeverity" @bind:event="oninput" />
                             <span class="param-value">@wan2Config.CongestionSeverity.ToString("F2")</span>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary

- **Afternoon congestion relief** - GPON and XGS-PON profiles now model a "commute gap" where bandwidth eases before the evening streaming peak. GPON afternoon ramp: 0.975 (3 PM) - 0.985 (4 PM) - 0.9825 (5 PM) - 0.965 (6 PM). XGS-PON proportionally: 0.9875 (3 PM) - 0.99 (4-5 PM) - 0.98 (6 PM).
- **Quarter-hour baseline interpolation** - Both ping and speedtest scripts interpolate between hourly baseline values at 15-minute breakpoints (:00=0%, :15=25%, :30=50%, :45=75%) using pure shell arithmetic. Compatible with the existing "skip tc if rate unchanged" logic.
- **Congestion severity range expanded** - Slider now goes from 0 to 2 (was 0.75-1.25). At 0 the curve is completely flat (no congestion shaping), at 2 the dips are doubled.
- **5 Mbps floor on congestion-adjusted speeds** - Prevents negative or near-zero rates when severity is high. Applied in baseline generation, UI display, and shell script interpolation.

## Test plan

- [ ] Verify Congestion Range display updates for GPON/XGS-PON connection types
- [ ] Verify severity slider reaches full 0-2 range and congestion range never shows below 5 Mbps
- [ ] Redeploy SQM scripts and verify interpolation in ping monitor logs around hour boundaries
- [ ] Verify math: at severity 2.0 on GPON 965 Mbps nominal, 5:37 PM should yield ~930 Mbps (baseline-proportional safety cap)