### PR TITLE
Fix UniFi OS Server and UXG-Fiber compatibility (bool parsing, netcat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,8 +284,8 @@ For commercial licensing inquiries, contact tj@ozarkconnect.net.
 
 ## Other Projects
 
-- [UniFi Lightshow](https://github.com/Ozark-Connect/unifi-lightshow) — Custom RGB light show controller for UniFi Etherlighting LEDs. Turn your switch rack into a spatial light canvas with SignalRGB integration, seasonal effects, and multi-switch support.
-- [UNVR NAS Backup](https://github.com/Ozark-Connect/unvr-nas-backup) — Automated Protect camera backup from UniFi NVR to NAS storage.
+- [UniFi Lightshow](https://github.com/Ozark-Connect/unifi-lightshow) - Custom RGB light show controller for UniFi Etherlighting LEDs. Turn your switch rack into a spatial light canvas with SignalRGB integration, seasonal effects, and multi-switch support.
+- [UNVR NAS Backup](https://github.com/Ozark-Connect/unvr-nas-backup) - Automated Protect camera backup from UniFi NVR to NAS storage.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -282,6 +282,11 @@ For commercial licensing inquiries, contact tj@ozarkconnect.net.
 - Issues: [GitHub Issues](https://github.com/Ozark-Connect/NetworkOptimizer/issues)
 - Documentation: See component READMEs in `src/` and `docker/`
 
+## Other Projects
+
+- [UniFi Lightshow](https://github.com/Ozark-Connect/unifi-lightshow) — Custom RGB light show controller for UniFi Etherlighting LEDs. Turn your switch rack into a spatial light canvas with SignalRGB integration, seasonal effects, and multi-switch support.
+- [UNVR NAS Backup](https://github.com/Ozark-Connect/unvr-nas-backup) — Automated Protect camera backup from UniFi NVR to NAS storage.
+
 ---
 
 <sub>Network Optimizer for UniFi is an independent project by Ozark Connect and is not affiliated with, endorsed by, or sponsored by Ubiquiti, Inc. Ubiquiti, UniFi, UDM, and Cloud Key are trademarks or registered trademarks of Ubiquiti, Inc. All other trademarks are the property of their respective owners.</sub>

--- a/src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs
@@ -22,6 +22,30 @@ public class WanProviderCapabilities
 }
 
 /// <summary>
+/// JSON converter that handles bool values that may come as strings ("true"/"false") instead of native booleans.
+/// UniFi OS Server returns some boolean fields as strings.
+/// </summary>
+public class FlexibleBoolConverter : JsonConverter<bool>
+{
+    public override bool Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.TokenType switch
+        {
+            JsonTokenType.True => true,
+            JsonTokenType.False => false,
+            JsonTokenType.String => bool.TryParse(reader.GetString(), out var value) && value,
+            JsonTokenType.Number => reader.GetInt32() != 0,
+            _ => false
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, bool value, JsonSerializerOptions options)
+    {
+        writer.WriteBooleanValue(value);
+    }
+}
+
+/// <summary>
 /// JSON converter that handles int values that may come as strings, empty strings, or null.
 /// UniFi API sometimes returns VLAN IDs as strings or empty strings instead of numbers.
 /// </summary>
@@ -67,12 +91,15 @@ public class UniFiNetworkConfig
     public string Purpose { get; set; } = string.Empty; // "corporate", "guest", "wan", "vlan-only", "remote-user-vpn"
 
     [JsonPropertyName("enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool Enabled { get; set; } = true;
 
     [JsonPropertyName("is_nat")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool IsNat { get; set; }
 
     [JsonPropertyName("vlan_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool VlanEnabled { get; set; }
 
     [JsonPropertyName("vlan")]
@@ -81,6 +108,7 @@ public class UniFiNetworkConfig
 
     // IP configuration
     [JsonPropertyName("dhcpd_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool DhcpdEnabled { get; set; }
 
     [JsonPropertyName("dhcpd_start")]
@@ -93,6 +121,7 @@ public class UniFiNetworkConfig
     public int DhcpdLeasetime { get; set; }
 
     [JsonPropertyName("dhcpd_dns_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool DhcpdDnsEnabled { get; set; }
 
     [JsonPropertyName("dhcpd_dns_1")]
@@ -108,12 +137,14 @@ public class UniFiNetworkConfig
     public string? DhcpdDns4 { get; set; }
 
     [JsonPropertyName("dhcpd_gateway_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool DhcpdGatewayEnabled { get; set; }
 
     [JsonPropertyName("dhcpd_gateway")]
     public string? DhcpdGateway { get; set; }
 
     [JsonPropertyName("dhcpd_time_offset_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool DhcpdTimeOffsetEnabled { get; set; }
 
     [JsonPropertyName("dhcpd_time_offset")]
@@ -138,6 +169,7 @@ public class UniFiNetworkConfig
     public string? Ipv6PdStop { get; set; }
 
     [JsonPropertyName("ipv6_ra_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool Ipv6RaEnabled { get; set; }
 
     [JsonPropertyName("ipv6_ra_priority")]
@@ -207,6 +239,7 @@ public class UniFiNetworkConfig
     public int? WanEgressQos { get; set; }
 
     [JsonPropertyName("wan_smartq_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool WanSmartqEnabled { get; set; }
 
     [JsonPropertyName("wan_smartq_up_rate")]
@@ -264,13 +297,16 @@ public class UniFiNetworkConfig
 
     // Multicast DNS
     [JsonPropertyName("mdns_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool MdnsEnabled { get; set; }
 
     [JsonPropertyName("upnp_lan_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool UpnpLanEnabled { get; set; }
 
     // IGMP
     [JsonPropertyName("igmp_snooping")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool IgmpSnooping { get; set; }
 
     // Network group
@@ -279,6 +315,7 @@ public class UniFiNetworkConfig
 
     // Internet access
     [JsonPropertyName("internet_access_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool InternetAccessEnabled { get; set; }
 
     // Auto scaling
@@ -290,10 +327,12 @@ public class UniFiNetworkConfig
     public List<string>? Schedule { get; set; }
 
     [JsonPropertyName("schedule_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool ScheduleEnabled { get; set; }
 
     // Content filtering
     [JsonPropertyName("contentfilter_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool ContentfilterEnabled { get; set; }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
@@ -1297,7 +1297,7 @@ WantedBy=multi-user.target
         sb.AppendLine("        echo \"Access-Control-Allow-Origin: *\"");
         sb.AppendLine("        echo \"\"");
         sb.AppendLine("        \"$SCRIPT_DIR/sqm-monitor.sh\"");
-        sb.AppendLine("    } | nc -l -p \"$PORT\" -q 1 > /dev/null 2>&1");
+        sb.AppendLine("    } | busybox nc -l -p \"$PORT\" -w 1 > /dev/null 2>&1");
         sb.AppendLine("    sleep 0.1");
         sb.AppendLine("done");
         sb.AppendLine("SERVER_EOF");


### PR DESCRIPTION
## Summary

- **FlexibleBoolConverter for network config deserialization** - UniFi OS Server returns some boolean fields (e.g., `dhcpd_enabled`) as strings (`"true"`) instead of native JSON booleans. This broke deserialization of network configs, which cascaded to device discovery, AP fetching, wireless clients, and WAN interface detection. Added a `FlexibleBoolConverter` (similar to the existing `FlexibleIntConverter`) and applied it to all 15 bool properties on `UniFiNetworkConfig`.

- **Use busybox nc for Adaptive SQM TC monitor** - UniFi OS Server (UXGA) doesn't ship a standalone `nc` binary, only `busybox nc`. Changed the deployed script from `nc -l -p "$PORT" -q 1` to `busybox nc -l -p "$PORT" -w 1`, which works on all gateway models (UCG-Fiber, UXG, UDM, UDR).

## Test plan

- [x] Deployed to NAS with UniFi OS Server - devices, clients, and WAN interfaces all discovered successfully
- [x] Verified no API errors in logs
- [x] Re-deploy Adaptive SQM from UI to push updated nc script to gateway
- [x] Verify TC monitor responds on port 8088 after SQM redeploy