### PR TITLE
v1.15.3 - UniFi OS Server and UXG-Fiber compatibility and Adaptive SQM improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,11 @@ For commercial licensing inquiries, contact tj@ozarkconnect.net.
 - Issues: [GitHub Issues](https://github.com/Ozark-Connect/NetworkOptimizer/issues)
 - Documentation: See component READMEs in `src/` and `docker/`
 
+## Other Projects
+
+- [UniFi Lightshow](https://github.com/Ozark-Connect/unifi-lightshow) - Custom RGB light show controller for UniFi Etherlighting LEDs. Turn your switch rack into a spatial light canvas with SignalRGB integration, seasonal effects, and multi-switch support.
+- [UNVR NAS Backup](https://github.com/Ozark-Connect/unvr-nas-backup) - Automated Protect camera backup from UniFi NVR to NAS storage.
+
 ---
 
 <sub>Network Optimizer for UniFi is an independent project by Ozark Connect and is not affiliated with, endorsed by, or sponsored by Ubiquiti, Inc. Ubiquiti, UniFi, UDM, and Cloud Key are trademarks or registered trademarks of Ubiquiti, Inc. All other trademarks are the property of their respective owners.</sub>

--- a/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
+++ b/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
@@ -91,11 +91,11 @@ public class PerformanceAnalyzer
             {
                 Title = "Hardware Acceleration Disabled",
                 Description = "Hardware Acceleration is disabled on your gateway. " +
-                    "This means all traffic is processed by the CPU instead of being offloaded to dedicated hardware, " +
-                    "which can reduce throughput and increase latency under load.",
+                    "This means all traffic is processed by the CPU instead of using the kernel's fast forwarding path (SFE), " +
+                    "which can significantly reduce throughput and increase CPU load even under light traffic.",
                 Recommendation = "Enable Hardware Acceleration in UniFi Devices > [your gateway] > Settings > Services. " +
                     "Some features like Smart Queues may auto-disable it, but newer firmware versions allow re-enabling it.",
-                Severity = PerformanceSeverity.Info,
+                Severity = PerformanceSeverity.Recommendation,
                 Category = PerformanceCategory.Performance,
                 DeviceName = gateway.Name
             });

--- a/src/NetworkOptimizer.Sqm/Models/ConnectionProfile.cs
+++ b/src/NetworkOptimizer.Sqm/Models/ConnectionProfile.cs
@@ -381,7 +381,7 @@ public class ConnectionProfile
                 if (congestionSeverity != 1.0)
                     multiplier = 1.0 - (1.0 - multiplier) * congestionSeverity;
 
-                var speed = (int)(multiplier * NominalDownloadMbps);
+                var speed = Math.Max(5, (int)(multiplier * NominalDownloadMbps));
                 baseline[key] = speed.ToString();
             }
         }
@@ -486,16 +486,16 @@ public class ConnectionProfile
             },
 
             // GPON: shared splitter means noticeable congestion at peak hours.
-            // Smooth curve: 1.00 overnight → 0.99 morning → 0.98/0.975 → 0.97 workday → 0.965 streaming → taper back up
-            //  Hour:  0      1     2     3     4     5     6     7     8     9    10    11    12    13    14    15    16    17    18    19    20    21    22    23
+            // Smooth curve: 1.00 overnight - 0.99 morning - 0.97 workday - 0.975/0.985/0.9825 afternoon relief (commute gap) - 0.965 streaming peak - taper back up
+            //  Hour:  0      1     2     3     4     5     6     7     8     9    10    11    12    13    14    15      16     17       18    19    20    21    22    23
             ConnectionType.Gpon => CreateUniformWeekPattern(new double[]
-                { 0.995, 1.00, 1.00, 1.00, 1.00, 1.00, 0.99, 0.99, 0.98, 0.975, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.965, 0.965, 0.965, 0.965, 0.975, 0.985 }),
+                { 0.995, 1.00, 1.00, 1.00, 1.00, 1.00, 0.99, 0.99, 0.98, 0.975, 0.97, 0.97, 0.97, 0.97, 0.97, 0.975, 0.985, 0.9825, 0.965, 0.965, 0.965, 0.965, 0.975, 0.985 }),
 
             // XGS-PON: 10G headroom, minimal congestion even at peak.
-            // Compressed version of GPON curve: 1.00 overnight → 0.995 → 0.99/0.9875 → 0.985 workday → 0.98 streaming
-            //  Hour:  0      1     2     3     4     5     6      7      8     9      10     11     12     13     14     15     16     17     18    19    20    21     22     23
+            // Compressed version of GPON curve: 1.00 overnight - 0.995 - 0.985 workday - 0.9875/0.99 afternoon relief (commute gap) - 0.98 streaming peak
+            //  Hour:  0      1     2     3     4     5     6      7      8     9      10     11     12     13     14     15       16    17    18    19    20    21     22     23
             ConnectionType.XgsPon => CreateUniformWeekPattern(new double[]
-                { 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 0.995, 0.995, 0.99, 0.9875, 0.985, 0.985, 0.985, 0.985, 0.985, 0.985, 0.985, 0.985, 0.98, 0.98, 0.98, 0.98, 0.985, 0.99 }),
+                { 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 0.995, 0.995, 0.99, 0.9875, 0.985, 0.985, 0.985, 0.985, 0.985, 0.9875, 0.99, 0.99, 0.98, 0.98, 0.98, 0.98, 0.985, 0.99 }),
 
             // DSL: stable but may have minor peak-hour drops (same pattern all week)
             ConnectionType.Dsl => CreateUniformWeekPattern(new double[]

--- a/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
+++ b/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
@@ -675,13 +675,32 @@ tune_tc_performance() {
         var withinRatio = $"{(int)(_config.BlendingWeightWithin * 100)}/{(int)((1.0 - _config.BlendingWeightWithin) * 100)}";
         var belowRatio = $"{(int)(_config.BlendingWeightBelow * 100)}/{(int)((1.0 - _config.BlendingWeightBelow) * 100)}";
 
-        return $@"# Baseline blending
+        return $@"# Baseline blending (with quarter-hour interpolation)
 current_day=$(date +%u)
 current_day=$((current_day - 1))
 current_hour=$(date +%H | sed 's/^0//')
+current_min=$(date +%M | sed 's/^0//')
 lookup_key=""${{current_day}}_${{current_hour}}""
 
+# Next hour lookup (wraps at midnight to next day)
+next_hour=$(( (current_hour + 1) % 24 ))
+if [ ""$next_hour"" -eq 0 ]; then
+    next_day=$(( (current_day + 1) % 7 ))
+else
+    next_day=$current_day
+fi
+next_key=""${{next_day}}_${{next_hour}}""
+
 baseline_speed=${{BASELINE[$lookup_key]}}
+next_baseline_speed=${{BASELINE[$next_key]}}
+
+# Interpolate at 15-minute breakpoints: :00=0%, :15=25%, :30=50%, :45=75%
+if [ -n ""$baseline_speed"" ] && [ -n ""$next_baseline_speed"" ]; then
+    quarter=$(( current_min / 15 ))
+    weight=$(( quarter * 25 ))
+    baseline_speed=$(( (baseline_speed * (100 - weight) + next_baseline_speed * weight) / 100 ))
+    if [ ""$baseline_speed"" -lt 5 ]; then baseline_speed=5; fi
+fi
 
 if [ -n ""$baseline_speed"" ]; then
     threshold=$(echo ""scale=0; $baseline_speed * 0.9 / 1"" | bc)
@@ -709,13 +728,32 @@ fi";
         var measuredWeight = Inv(1.0 - _config.BlendingWeightWithin);
         var overheadMultiplier = Inv(_config.OverheadMultiplier);
 
-        return $@"# Baseline blending for ping
+        return $@"# Baseline blending for ping (with quarter-hour interpolation)
 current_day=$(date +%u)
 current_day=$((current_day - 1))
 current_hour=$(date +%H | sed 's/^0//')
+current_min=$(date +%M | sed 's/^0//')
 lookup_key=""${{current_day}}_${{current_hour}}""
 
+# Next hour lookup (wraps at midnight to next day)
+next_hour=$(( (current_hour + 1) % 24 ))
+if [ ""$next_hour"" -eq 0 ]; then
+    next_day=$(( (current_day + 1) % 7 ))
+else
+    next_day=$current_day
+fi
+next_key=""${{next_day}}_${{next_hour}}""
+
 baseline_speed=${{BASELINE[$lookup_key]}}
+next_baseline_speed=${{BASELINE[$next_key]}}
+
+# Interpolate at 15-minute breakpoints: :00=0%, :15=25%, :30=50%, :45=75%
+if [ -n ""$baseline_speed"" ] && [ -n ""$next_baseline_speed"" ]; then
+    quarter=$(( current_min / 15 ))
+    weight=$(( quarter * 25 ))
+    baseline_speed=$(( (baseline_speed * (100 - weight) + next_baseline_speed * weight) / 100 ))
+    if [ ""$baseline_speed"" -lt 5 ]; then baseline_speed=5; fi
+fi
 
 if [ -n ""$baseline_speed"" ]; then
     baseline_with_overhead=$(echo ""scale=0; $baseline_speed * {overheadMultiplier} / 1"" | bc)

--- a/src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs
@@ -22,6 +22,30 @@ public class WanProviderCapabilities
 }
 
 /// <summary>
+/// JSON converter that handles bool values that may come as strings ("true"/"false") instead of native booleans.
+/// UniFi OS Server returns some boolean fields as strings.
+/// </summary>
+public class FlexibleBoolConverter : JsonConverter<bool>
+{
+    public override bool Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.TokenType switch
+        {
+            JsonTokenType.True => true,
+            JsonTokenType.False => false,
+            JsonTokenType.String => bool.TryParse(reader.GetString(), out var value) && value,
+            JsonTokenType.Number => reader.GetInt32() != 0,
+            _ => false
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, bool value, JsonSerializerOptions options)
+    {
+        writer.WriteBooleanValue(value);
+    }
+}
+
+/// <summary>
 /// JSON converter that handles int values that may come as strings, empty strings, or null.
 /// UniFi API sometimes returns VLAN IDs as strings or empty strings instead of numbers.
 /// </summary>
@@ -67,12 +91,15 @@ public class UniFiNetworkConfig
     public string Purpose { get; set; } = string.Empty; // "corporate", "guest", "wan", "vlan-only", "remote-user-vpn"
 
     [JsonPropertyName("enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool Enabled { get; set; } = true;
 
     [JsonPropertyName("is_nat")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool IsNat { get; set; }
 
     [JsonPropertyName("vlan_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool VlanEnabled { get; set; }
 
     [JsonPropertyName("vlan")]
@@ -81,6 +108,7 @@ public class UniFiNetworkConfig
 
     // IP configuration
     [JsonPropertyName("dhcpd_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool DhcpdEnabled { get; set; }
 
     [JsonPropertyName("dhcpd_start")]
@@ -93,6 +121,7 @@ public class UniFiNetworkConfig
     public int DhcpdLeasetime { get; set; }
 
     [JsonPropertyName("dhcpd_dns_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool DhcpdDnsEnabled { get; set; }
 
     [JsonPropertyName("dhcpd_dns_1")]
@@ -108,12 +137,14 @@ public class UniFiNetworkConfig
     public string? DhcpdDns4 { get; set; }
 
     [JsonPropertyName("dhcpd_gateway_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool DhcpdGatewayEnabled { get; set; }
 
     [JsonPropertyName("dhcpd_gateway")]
     public string? DhcpdGateway { get; set; }
 
     [JsonPropertyName("dhcpd_time_offset_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool DhcpdTimeOffsetEnabled { get; set; }
 
     [JsonPropertyName("dhcpd_time_offset")]
@@ -138,6 +169,7 @@ public class UniFiNetworkConfig
     public string? Ipv6PdStop { get; set; }
 
     [JsonPropertyName("ipv6_ra_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool Ipv6RaEnabled { get; set; }
 
     [JsonPropertyName("ipv6_ra_priority")]
@@ -207,6 +239,7 @@ public class UniFiNetworkConfig
     public int? WanEgressQos { get; set; }
 
     [JsonPropertyName("wan_smartq_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool WanSmartqEnabled { get; set; }
 
     [JsonPropertyName("wan_smartq_up_rate")]
@@ -264,13 +297,16 @@ public class UniFiNetworkConfig
 
     // Multicast DNS
     [JsonPropertyName("mdns_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool MdnsEnabled { get; set; }
 
     [JsonPropertyName("upnp_lan_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool UpnpLanEnabled { get; set; }
 
     // IGMP
     [JsonPropertyName("igmp_snooping")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool IgmpSnooping { get; set; }
 
     // Network group
@@ -279,6 +315,7 @@ public class UniFiNetworkConfig
 
     // Internet access
     [JsonPropertyName("internet_access_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool InternetAccessEnabled { get; set; }
 
     // Auto scaling
@@ -290,10 +327,12 @@ public class UniFiNetworkConfig
     public List<string>? Schedule { get; set; }
 
     [JsonPropertyName("schedule_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool ScheduleEnabled { get; set; }
 
     // Content filtering
     [JsonPropertyName("contentfilter_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool ContentfilterEnabled { get; set; }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -587,7 +587,7 @@
                     <div class="param">
                         <span class="param-label">Severity <span class="tooltip-icon tooltip-icon-sm" data-tooltip="Scales how deep the congestion dips go. 1.0 = default profile. Higher = more aggressive shaping at peak. Lower = flatter curve.">?</span></span>
                         <div class="wan-time-slider" style="padding: 0; gap: 0.5rem; justify-content: center;">
-                            <input type="range" min="0.75" max="1.25" step="0.01" style="width: 100px;" @bind="wan1Config.CongestionSeverity" @bind:event="oninput" />
+                            <input type="range" min="0" max="2" step="0.01" style="width: 100px;" @bind="wan1Config.CongestionSeverity" @bind:event="oninput" />
                             <span class="param-value">@wan1Config.CongestionSeverity.ToString("F2")</span>
                         </div>
                     </div>
@@ -753,7 +753,7 @@
                     <div class="param">
                         <span class="param-label">Severity <span class="tooltip-icon tooltip-icon-sm" data-tooltip="Scales how deep the congestion dips go. 1.0 = default profile. Higher = more aggressive shaping at peak. Lower = flatter curve.">?</span></span>
                         <div class="wan-time-slider" style="padding: 0; gap: 0.5rem; justify-content: center;">
-                            <input type="range" min="0.75" max="1.25" step="0.01" style="width: 100px;" @bind="wan2Config.CongestionSeverity" @bind:event="oninput" />
+                            <input type="range" min="0" max="2" step="0.01" style="width: 100px;" @bind="wan2Config.CongestionSeverity" @bind:event="oninput" />
                             <span class="param-value">@wan2Config.CongestionSeverity.ToString("F2")</span>
                         </div>
                     </div>
@@ -3198,6 +3198,8 @@
                         var cap = absoluteMax * safetyCap;
                         rate = Math.Min(withOverhead, cap);
                     }
+
+                    rate = Math.Max(5, rate);
 
                     if (rate < minRate) minRate = rate;
                     if (rate > maxRate) maxRate = rate;

--- a/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
@@ -1297,7 +1297,7 @@ WantedBy=multi-user.target
         sb.AppendLine("        echo \"Access-Control-Allow-Origin: *\"");
         sb.AppendLine("        echo \"\"");
         sb.AppendLine("        \"$SCRIPT_DIR/sqm-monitor.sh\"");
-        sb.AppendLine("    } | nc -l -p \"$PORT\" -q 1 > /dev/null 2>&1");
+        sb.AppendLine("    } | busybox nc -l -p \"$PORT\" -w 1 > /dev/null 2>&1");
         sb.AppendLine("    sleep 0.1");
         sb.AppendLine("done");
         sb.AppendLine("SERVER_EOF");

--- a/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
@@ -1297,7 +1297,7 @@ WantedBy=multi-user.target
         sb.AppendLine("        echo \"Access-Control-Allow-Origin: *\"");
         sb.AppendLine("        echo \"\"");
         sb.AppendLine("        \"$SCRIPT_DIR/sqm-monitor.sh\"");
-        sb.AppendLine("    } | busybox nc -l -p \"$PORT\" -w 1 > /dev/null 2>&1");
+        sb.AppendLine("    } | busybox nc -l -p \"$PORT\" > /dev/null 2>&1");
         sb.AppendLine("    sleep 0.1");
         sb.AppendLine("done");
         sb.AppendLine("SERVER_EOF");

--- a/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
@@ -1069,6 +1069,11 @@ WantedBy=multi-user.target
         sb.AppendLine();
         sb.AppendLine("mkdir -p \"$SQM_MONITOR_DIR\"");
         sb.AppendLine();
+        sb.AppendLine("# Install netcat if not available (busybox nc lacks -q flag)");
+        sb.AppendLine("if ! command -v nc > /dev/null 2>&1 || nc -h 2>&1 | grep -q BusyBox; then");
+        sb.AppendLine("    apt-get update -qq > /dev/null 2>&1 && apt-get install -y -qq netcat-openbsd > /dev/null 2>&1");
+        sb.AppendLine("fi");
+        sb.AppendLine();
         sb.AppendLine("# Create the SQM monitor handler script");
         sb.AppendLine("cat > \"$SQM_MONITOR_DIR/sqm-monitor.sh\" << 'HANDLER_EOF'");
         sb.AppendLine("#!/bin/sh");
@@ -1297,7 +1302,7 @@ WantedBy=multi-user.target
         sb.AppendLine("        echo \"Access-Control-Allow-Origin: *\"");
         sb.AppendLine("        echo \"\"");
         sb.AppendLine("        \"$SCRIPT_DIR/sqm-monitor.sh\"");
-        sb.AppendLine("    } | busybox nc -l -p \"$PORT\" > /dev/null 2>&1");
+        sb.AppendLine("    } | nc -l -p \"$PORT\" -q 1 > /dev/null 2>&1");
         sb.AppendLine("    sleep 0.1");
         sb.AppendLine("done");
         sb.AppendLine("SERVER_EOF");

--- a/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PerformanceAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PerformanceAnalyzerTests.cs
@@ -74,7 +74,7 @@ public class PerformanceAnalyzerTests
 
         result.Should().HaveCount(1);
         result[0].Title.Should().Be("Hardware Acceleration Disabled");
-        result[0].Severity.Should().Be(PerformanceSeverity.Info);
+        result[0].Severity.Should().Be(PerformanceSeverity.Recommendation);
         result[0].Category.Should().Be(PerformanceCategory.Performance);
         result[0].DeviceName.Should().Be("Test Gateway");
     }


### PR DESCRIPTION
## Summary

- **UniFi OS Server compatibility** - Fixed JSON deserialization failure when UniFi OS Server returns boolean fields as strings instead of native booleans. Added FlexibleBoolConverter to all bool properties on UniFiNetworkConfig. This was breaking device discovery, AP fetching, wireless clients, and WAN interface detection.

- **Adaptive SQM gateway compatibility** - UXG-Fiber gateway doesn't ship a standalone netcat binary, only busybox nc which lacks the `-q` flag needed for clean connection teardown. SQM deploy now installs `netcat-openbsd` on gateways that only have busybox nc, then uses the original `nc -q 1` that works correctly across all models.

- **GPON/XGS-PON baseline improvements** - Added afternoon relief window (3-5 PM commute gap) to congestion profiles and quarter-hour interpolation between hourly baselines for smoother rate transitions. Added 5 Mbps floor to prevent baseline from hitting zero.

- **Hardware Acceleration warning upgraded** - Changed from Info to Recommendation severity with improved description explaining the SFE fast forwarding path impact.

## Test plan

- [x] Deployed to NAS with UniFi OS Server - devices, clients, WAN interfaces all discovered
- [x] No API errors in logs after 2+ hours of monitoring
- [x] netcat-openbsd installed on UXG-Fiber gateway, nc -q 1 working correctly
- [x] TC monitor responding on port 8088, no broken pipe errors