### PR TITLE
Default Client Performance signal map band to the client's band

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -525,6 +525,7 @@
                                              SpeedTestResults="_speedResults"
                                              SignalLogMarkers="_signalMapPoints"
                                              HideDashboardLinks="true"
+                                             InitialBand="@ClientBandToPropagationBand(_client?.Band)"
                                              MapHeight="350px" />
                         </div>
                     }
@@ -2189,6 +2190,16 @@
         "na" or "5g" => "band-5ghz",
         "ng" or "2g" => "band-2ghz",
         _ => ""
+    };
+
+    // Map a UniFi radio code to the FloorPlanEditor propagation band ("2.4" / "5" / "6").
+    // Returns null when unknown so the editor keeps its current band.
+    private static string? ClientBandToPropagationBand(string? band) => band switch
+    {
+        "6e" or "6g" => "6",
+        "na" or "5g" => "5",
+        "ng" or "2g" => "2.4",
+        _ => null
     };
 
     private static string GetSpeedClass(double mbps) => mbps switch

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/FloorPlanEditor.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/FloorPlanEditor.razor
@@ -1625,6 +1625,8 @@
     [Parameter] public EventCallback<int> OnSignalTimeRangeChanged { get; set; }
     /// <summary>External signal time filter in hours (syncs slider position from parent)</summary>
     [Parameter] public int? SignalTimeFilterHours { get; set; }
+    /// <summary>Initial heatmap/signal band ("2.4", "5", or "6"). Applied once when non-null and the user hasn't picked a band manually.</summary>
+    [Parameter] public string? InitialBand { get; set; }
 
     private string _mapId = "fp-map-" + Guid.NewGuid().ToString("N");
     private DotNetObjectReference<FloorPlanEditor>? _dotNetRef;
@@ -1699,6 +1701,7 @@
     // TODO: Replace with per-circuit scoped service when app supports multiple users.
     // Static field works for single-user but is shared across all Blazor circuits.
     private static string _savedHeatmapBand = "5";
+    private bool _userSelectedBand;
 
     protected override void OnInitialized()
     {
@@ -1714,6 +1717,21 @@
             var targetIndex = FindClosestSignalBreakpointIndex(SignalTimeFilterHours.Value);
             if (targetIndex != _signalSliderValue)
                 _signalSliderValue = targetIndex;
+        }
+
+        // Auto-select band from the parent (e.g. the viewed client's connected band) until
+        // the user overrides it via the dropdown. Only applies for recognized values.
+        if (!_userSelectedBand && !string.IsNullOrEmpty(InitialBand)
+            && (InitialBand == "2.4" || InitialBand == "5" || InitialBand == "6")
+            && InitialBand != _heatmapBand)
+        {
+            _heatmapBand = InitialBand;
+            if (_mapInitialized)
+            {
+                await UpdateApMarkers();
+                if (_showSignalData) await UpdateSignalDataMarkers();
+                else if (_showHeatmap) await ComputeHeatmap();
+            }
         }
 
         // Auto-update signal data markers when either data source changes
@@ -3298,6 +3316,7 @@
 
     private async Task OnBandChanged(ChangeEventArgs e)
     {
+        _userSelectedBand = true;
         _heatmapBand = e.Value?.ToString() ?? "5";
         _savedHeatmapBand = _heatmapBand;
         await UpdateApMarkers();


### PR DESCRIPTION
## Summary

- Adds an `InitialBand` parameter to `FloorPlanEditor`. When non-null and the user hasn't manually picked a band from the dropdown, the editor adopts that band and refreshes the heatmap / signal markers.
- Client Performance's Signal Map passes the connected client's radio (`ng`/`na`/`6e` → `"2.4"`/`"5"`/`"6"`) so 6E clients no longer see an empty map because the heatmap defaulted to 5 GHz.
- A `_userSelectedBand` latch stops auto-following once the user picks a band from the dropdown. The static `_savedHeatmapBand` isn't written in the auto-select path, so WiFi Optimizer doesn't inherit a band derived from a specific client.

## Test plan

- [x] Open Client Performance for a 6 GHz / Wi-Fi 6E client → Signal Map shows 6 GHz points immediately (no need to change the dropdown).
- [x] Open Client Performance for a 5 GHz client → map defaults to 5 GHz.
- [x] Open Client Performance for a 2.4 GHz client → map defaults to 2.4 GHz.
- [x] In Client Performance, manually change the band dropdown → subsequent polls (including roams) don't override the user's choice.
- [x] WiFi Optimizer page still defaults to last-used band (`_savedHeatmapBand` unaffected).
- [x] Wired clients: Signal Map not rendered, no regression.