### PR TITLE
Handle string-typed ints on WanProviderCapabilities

### DIFF
--- a/src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs
@@ -9,16 +9,18 @@ namespace NetworkOptimizer.UniFi.Models;
 public class WanProviderCapabilities
 {
     [JsonPropertyName("upload_kilobits_per_second")]
-    public int UploadKilobitsPerSecond { get; set; }
+    [JsonConverter(typeof(FlexibleIntConverter))]
+    public int? UploadKilobitsPerSecond { get; set; }
 
     [JsonPropertyName("download_kilobits_per_second")]
-    public int DownloadKilobitsPerSecond { get; set; }
+    [JsonConverter(typeof(FlexibleIntConverter))]
+    public int? DownloadKilobitsPerSecond { get; set; }
 
     /// <summary>Upload speed in Mbps</summary>
-    public int UploadMbps => UploadKilobitsPerSecond / 1000;
+    public int? UploadMbps => UploadKilobitsPerSecond / 1000;
 
     /// <summary>Download speed in Mbps</summary>
-    public int DownloadMbps => DownloadKilobitsPerSecond / 1000;
+    public int? DownloadMbps => DownloadKilobitsPerSecond / 1000;
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

- Applies `FlexibleIntConverter` + `int?` to `WanProviderCapabilities.UploadKilobitsPerSecond` and `DownloadKilobitsPerSecond`, closing the gap left by #548
- The parent `UniFiNetworkConfig` got flexible int handling on every `int` field in #548, but the nested `wan_provider_capabilities` DTO was missed. Same class of bug (controller returning a string where the model expects a number) would still throw during deserialization of the `rest/networkconf` response and cascade into Config Optimizer and Device SSH Test
- Computed `UploadMbps` / `DownloadMbps` cascade to `int?` (`int? / 1000`); both consumers (`UniFiDiscovery` and `PerformanceAnalyzer`) already tolerate `int?`

## Test plan

- [x] `dotnet build` — clean (pre-existing NU1903 NuGet warnings only)
- [x] `dotnet test` — all 6,072 tests pass
- [x] Deployed to NAS and Mac test sites; Adaptive SQM re-deploy exercised `WanProviderCapabilities` deserialization on an env previously affected by the string-int issue
- [x] Verified live on NAS gateway: SQM HTB root rate reads/adjusts correctly (949↔962 Mbit adaptive range) with burst/memory_limit tuning intact