### PR TITLE
Release v1.15.5

### DIFF
--- a/src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs
@@ -9,16 +9,18 @@ namespace NetworkOptimizer.UniFi.Models;
 public class WanProviderCapabilities
 {
     [JsonPropertyName("upload_kilobits_per_second")]
-    public int UploadKilobitsPerSecond { get; set; }
+    [JsonConverter(typeof(FlexibleIntConverter))]
+    public int? UploadKilobitsPerSecond { get; set; }
 
     [JsonPropertyName("download_kilobits_per_second")]
-    public int DownloadKilobitsPerSecond { get; set; }
+    [JsonConverter(typeof(FlexibleIntConverter))]
+    public int? DownloadKilobitsPerSecond { get; set; }
 
     /// <summary>Upload speed in Mbps</summary>
-    public int UploadMbps => UploadKilobitsPerSecond / 1000;
+    public int? UploadMbps => UploadKilobitsPerSecond / 1000;
 
     /// <summary>Download speed in Mbps</summary>
-    public int DownloadMbps => DownloadKilobitsPerSecond / 1000;
+    public int? DownloadMbps => DownloadKilobitsPerSecond / 1000;
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

- Speedtest container TCP autotuning ceilings raised to 32 MB and BBR enabled — unblocks single-stream WAN throughput on high-RTT paths
- Client Performance Signal Map now defaults to the connected client's band (unblocks Wi-Fi 6E clients)
- Fix string-typed ints on UniFi network config + nested WAN provider capabilities DTOs — unbreaks Config Optimizer, Device SSH Test, and Adaptive SQM's WAN rate detection on affected controllers

## Test plan

- [x] Deployed to NAS and Mac test sites throughout development
- [x] Adaptive SQM exercised on NAS gateway; WAN provider caps parsed correctly through adaptive rate adjustments
- [x] All 6,072 tests pass on the final commit