### PR TITLE
Gracefully fall back when BBR kernel module is unavailable

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -55,13 +55,10 @@ services:
       # which caps single-stream throughput at ~rwnd/RTT (e.g. ~225 Mbps at 100ms RTT).
       net.ipv4.tcp_rmem: "4096 131072 33554432"
       net.ipv4.tcp_wmem: "4096 65536 33554432"
-      # BBR paces on bandwidth estimates instead of halving cwnd on every drop, so it
-      # represents real path capacity on paths with shallow policer bursts (common on
-      # consumer ISPs) — which is exactly what a speedtest should be measuring.
-      # Cubic on such paths reports artificially low numbers that reflect policer drops,
-      # not link capacity. Requires bbr kernel module loaded on the host.
-      net.ipv4.tcp_congestion_control: "bbr"
       net.ipv4.tcp_mtu_probing: "1"
+      # tcp_congestion_control is set in entrypoint.sh with graceful fallback to the
+      # host default if the bbr module is not loaded. Setting it here would fail
+      # container start on kernels without bbr.
     environment:
       - TZ=${TZ:-America/Chicago}
       # For URL construction and host enforcement redirect

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -61,13 +61,10 @@ services:
       # which caps single-stream throughput at ~rwnd/RTT (e.g. ~225 Mbps at 100ms RTT).
       net.ipv4.tcp_rmem: "4096 131072 33554432"
       net.ipv4.tcp_wmem: "4096 65536 33554432"
-      # BBR paces on bandwidth estimates instead of halving cwnd on every drop, so it
-      # represents real path capacity on paths with shallow policer bursts (common on
-      # consumer ISPs) — which is exactly what a speedtest should be measuring.
-      # Cubic on such paths reports artificially low numbers that reflect policer drops,
-      # not link capacity. Requires bbr kernel module loaded on the host.
-      net.ipv4.tcp_congestion_control: "bbr"
       net.ipv4.tcp_mtu_probing: "1"
+      # tcp_congestion_control is set in entrypoint.sh with graceful fallback to the
+      # host default if the bbr module is not loaded. Setting it here would fail
+      # container start on kernels without bbr.
     environment:
       - TZ=${TZ:-America/Chicago}
       # For URL construction and host enforcement redirect

--- a/docker/openspeedtest/entrypoint.sh
+++ b/docker/openspeedtest/entrypoint.sh
@@ -2,6 +2,19 @@
 # Ozark Connect Speed Test - Entrypoint
 # Injects runtime configuration into config.js
 
+# Try to enable BBR congestion control. Falls back silently to the host default
+# (usually cubic) if the bbr kernel module isn't loaded. BBR gives more accurate
+# speedtest numbers on paths with shallow ISP policer bursts, but we can't require
+# it — many appliance kernels (Synology, QNAP, some Proxmox setups) don't ship it.
+CC_FILE="/proc/sys/net/ipv4/tcp_congestion_control"
+if [ -w "$CC_FILE" ]; then
+    if echo bbr > "$CC_FILE" 2>/dev/null; then
+        echo "TCP congestion control: bbr"
+    else
+        echo "TCP congestion control: $(cat "$CC_FILE") (bbr not available on host kernel)"
+    fi
+fi
+
 # API endpoint path (single source of truth)
 API_PATH="/api/public/speedtest/results"
 

--- a/docker/openspeedtest/entrypoint.sh
+++ b/docker/openspeedtest/entrypoint.sh
@@ -2,17 +2,28 @@
 # Ozark Connect Speed Test - Entrypoint
 # Injects runtime configuration into config.js
 
-# Try to enable BBR congestion control. Falls back silently to the host default
-# (usually cubic) if the bbr kernel module isn't loaded. BBR gives more accurate
-# speedtest numbers on paths with shallow ISP policer bursts, but we can't require
-# it — many appliance kernels (Synology, QNAP, some Proxmox setups) don't ship it.
+# Report TCP congestion control state. We can't set it from inside the container
+# (/proc/sys is mounted read-only except for sysctls explicitly declared in the
+# compose sysctls: block, and we can't put tcp_congestion_control there because it
+# hard-fails container start on kernels without bbr — Synology, QNAP, some Proxmox
+# setups). The container inherits whatever the host's default CC is, so we just
+# surface the state and point users at the fix if bbr is available but not active.
 CC_FILE="/proc/sys/net/ipv4/tcp_congestion_control"
-if [ -w "$CC_FILE" ]; then
-    if echo bbr > "$CC_FILE" 2>/dev/null; then
-        echo "TCP congestion control: bbr"
-    else
-        echo "TCP congestion control: $(cat "$CC_FILE") (bbr not available on host kernel)"
-    fi
+AVAIL_FILE="/proc/sys/net/ipv4/tcp_available_congestion_control"
+if [ -r "$CC_FILE" ]; then
+    CURRENT_CC=$(cat "$CC_FILE")
+    AVAIL_CC=$(cat "$AVAIL_FILE" 2>/dev/null || echo "unknown")
+    echo "TCP congestion control: $CURRENT_CC (available: $AVAIL_CC)"
+    case " $AVAIL_CC " in
+        *" bbr "*)
+            if [ "$CURRENT_CC" != "bbr" ]; then
+                echo "NOTE: bbr is loaded on the host but not the default. For best speedtest accuracy on shallow-policer WAN paths, set it as default on the host: sysctl -w net.ipv4.tcp_congestion_control=bbr"
+            fi
+            ;;
+        *)
+            echo "NOTE: bbr kernel module is not loaded on the host. For best speedtest accuracy on shallow-policer WAN paths, load it on the host: modprobe tcp_bbr (and persist via /etc/modules-load.d/bbr.conf)"
+            ;;
+    esac
 fi
 
 # API endpoint path (single source of truth)


### PR DESCRIPTION
## Summary

Setting `net.ipv4.tcp_congestion_control=bbr` via compose `sysctls:` fails the entire container start with ENOENT on hosts whose kernel doesn't have the `tcp_bbr` module loaded (common on appliance OSes: Synology, QNAP, some Proxmox / LXC setups). The compose `sysctls:` block is all-or-nothing, so one missing CC value blocks `docker compose up` for affected users.

## What changed

- Removed `net.ipv4.tcp_congestion_control: "bbr"` from `docker-compose.yml` and `docker-compose.prod.yml`. The `tcp_rmem` / `tcp_wmem` / `tcp_mtu_probing` sysctls stay — those are always present on any Linux kernel and don't need a fallback.
- Speedtest container entrypoint now reports the current + available congestion control values and, if bbr is loaded-but-not-default or not loaded at all, prints the exact host-side command to fix it.
- Note: the entrypoint doesn't try to *set* the CC. `/proc/sys` is read-only inside a container netns except for sysctls explicitly declared in compose's `sysctls:` block — which is exactly the hard-fail case we're avoiding. BBR is in effect wherever the host makes it the default, which is the normal case for anyone who intentionally configured it.

## Result

- Hosts with BBR as default CC: container inherits bbr, no change to observed behavior.
- Hosts with BBR module loaded but cubic as default: container inherits cubic; log prints a NOTE telling the operator to `sysctl -w net.ipv4.tcp_congestion_control=bbr` on the host.
- Hosts without the BBR module: container boots cleanly on the host default (previously failed to start); log prints a NOTE telling the operator to `modprobe tcp_bbr`.

## Test plan

- [x] Deployed to NAS speedtest container, verified clean start.
- [x] Log now reads: `TCP congestion control: bbr (available: reno cubic bbr)` on the NAS (host has bbr as default).
- [x] Optional: reproduce on a kernel without `tcp_bbr` loaded to confirm the `modprobe tcp_bbr` NOTE fires and the container still starts.