### PR TITLE
Release: graceful BBR fallback for speedtest container

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -55,13 +55,10 @@ services:
       # which caps single-stream throughput at ~rwnd/RTT (e.g. ~225 Mbps at 100ms RTT).
       net.ipv4.tcp_rmem: "4096 131072 33554432"
       net.ipv4.tcp_wmem: "4096 65536 33554432"
-      # BBR paces on bandwidth estimates instead of halving cwnd on every drop, so it
-      # represents real path capacity on paths with shallow policer bursts (common on
-      # consumer ISPs) — which is exactly what a speedtest should be measuring.
-      # Cubic on such paths reports artificially low numbers that reflect policer drops,
-      # not link capacity. Requires bbr kernel module loaded on the host.
-      net.ipv4.tcp_congestion_control: "bbr"
       net.ipv4.tcp_mtu_probing: "1"
+      # tcp_congestion_control is set in entrypoint.sh with graceful fallback to the
+      # host default if the bbr module is not loaded. Setting it here would fail
+      # container start on kernels without bbr.
     environment:
       - TZ=${TZ:-America/Chicago}
       # For URL construction and host enforcement redirect

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -56,9 +56,11 @@ services:
       net.ipv4.tcp_rmem: "4096 131072 33554432"
       net.ipv4.tcp_wmem: "4096 65536 33554432"
       net.ipv4.tcp_mtu_probing: "1"
-      # tcp_congestion_control is set in entrypoint.sh with graceful fallback to the
-      # host default if the bbr module is not loaded. Setting it here would fail
-      # container start on kernels without bbr.
+      # tcp_congestion_control is intentionally not set here — it hard-fails
+      # container start on kernels without the bbr module loaded (Synology, QNAP,
+      # some Proxmox/LXC setups) and compose sysctls are all-or-nothing. The
+      # entrypoint reports CC state and tells the operator how to enable bbr on
+      # the host if desired.
     environment:
       - TZ=${TZ:-America/Chicago}
       # For URL construction and host enforcement redirect

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -62,9 +62,11 @@ services:
       net.ipv4.tcp_rmem: "4096 131072 33554432"
       net.ipv4.tcp_wmem: "4096 65536 33554432"
       net.ipv4.tcp_mtu_probing: "1"
-      # tcp_congestion_control is set in entrypoint.sh with graceful fallback to the
-      # host default if the bbr module is not loaded. Setting it here would fail
-      # container start on kernels without bbr.
+      # tcp_congestion_control is intentionally not set here — it hard-fails
+      # container start on kernels without the bbr module loaded (Synology, QNAP,
+      # some Proxmox/LXC setups) and compose sysctls are all-or-nothing. The
+      # entrypoint reports CC state and tells the operator how to enable bbr on
+      # the host if desired.
     environment:
       - TZ=${TZ:-America/Chicago}
       # For URL construction and host enforcement redirect

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -61,13 +61,10 @@ services:
       # which caps single-stream throughput at ~rwnd/RTT (e.g. ~225 Mbps at 100ms RTT).
       net.ipv4.tcp_rmem: "4096 131072 33554432"
       net.ipv4.tcp_wmem: "4096 65536 33554432"
-      # BBR paces on bandwidth estimates instead of halving cwnd on every drop, so it
-      # represents real path capacity on paths with shallow policer bursts (common on
-      # consumer ISPs) — which is exactly what a speedtest should be measuring.
-      # Cubic on such paths reports artificially low numbers that reflect policer drops,
-      # not link capacity. Requires bbr kernel module loaded on the host.
-      net.ipv4.tcp_congestion_control: "bbr"
       net.ipv4.tcp_mtu_probing: "1"
+      # tcp_congestion_control is set in entrypoint.sh with graceful fallback to the
+      # host default if the bbr module is not loaded. Setting it here would fail
+      # container start on kernels without bbr.
     environment:
       - TZ=${TZ:-America/Chicago}
       # For URL construction and host enforcement redirect

--- a/docker/openspeedtest/entrypoint.sh
+++ b/docker/openspeedtest/entrypoint.sh
@@ -2,6 +2,30 @@
 # Ozark Connect Speed Test - Entrypoint
 # Injects runtime configuration into config.js
 
+# Report TCP congestion control state. We can't set it from inside the container
+# (/proc/sys is mounted read-only except for sysctls explicitly declared in the
+# compose sysctls: block, and we can't put tcp_congestion_control there because it
+# hard-fails container start on kernels without bbr — Synology, QNAP, some Proxmox
+# setups). The container inherits whatever the host's default CC is, so we just
+# surface the state and point users at the fix if bbr is available but not active.
+CC_FILE="/proc/sys/net/ipv4/tcp_congestion_control"
+AVAIL_FILE="/proc/sys/net/ipv4/tcp_available_congestion_control"
+if [ -r "$CC_FILE" ]; then
+    CURRENT_CC=$(cat "$CC_FILE")
+    AVAIL_CC=$(cat "$AVAIL_FILE" 2>/dev/null || echo "unknown")
+    echo "TCP congestion control: $CURRENT_CC (available: $AVAIL_CC)"
+    case " $AVAIL_CC " in
+        *" bbr "*)
+            if [ "$CURRENT_CC" != "bbr" ]; then
+                echo "NOTE: bbr is loaded on the host but not the default. For best speedtest accuracy on shallow-policer WAN paths, set it as default on the host: sysctl -w net.ipv4.tcp_congestion_control=bbr"
+            fi
+            ;;
+        *)
+            echo "NOTE: bbr kernel module is not loaded on the host. For best speedtest accuracy on shallow-policer WAN paths, load it on the host: modprobe tcp_bbr (and persist via /etc/modules-load.d/bbr.conf)"
+            ;;
+    esac
+fi
+
 # API endpoint path (single source of truth)
 API_PATH="/api/public/speedtest/results"
 


### PR DESCRIPTION
## Summary

Rolls up one change since the last release:

- **#554** — Gracefully fall back when the BBR kernel module is unavailable. Previously the speedtest container tried to set `net.ipv4.tcp_congestion_control=bbr` via compose `sysctls:`, which hard-fails container start with ENOENT on hosts whose kernel doesn't ship the `tcp_bbr` module (Synology, QNAP, some Proxmox/LXC setups). The sysctl is removed from compose; the container now inherits the host's default CC and the entrypoint surfaces the live CC state plus actionable host-side guidance if bbr is loaded-but-not-default or not loaded at all.

Hosts already running bbr as their default CC (the common case for anyone who intentionally configured it) see no behavior change — bbr is still in effect for their speedtests.

## Test plan

- [x] Dev deployed to NAS, container boots clean on a kernel where the previous release would hard-fail.
- [x] Entrypoint log verified: `TCP congestion control: bbr (available: reno cubic bbr)` on a host with bbr as default.
- [x] Optional: spot-check the `modprobe tcp_bbr` NOTE on a host without the bbr module.