### PR TITLE
Tighten stale compose comment about BBR sysctl

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -56,9 +56,11 @@ services:
       net.ipv4.tcp_rmem: "4096 131072 33554432"
       net.ipv4.tcp_wmem: "4096 65536 33554432"
       net.ipv4.tcp_mtu_probing: "1"
-      # tcp_congestion_control is set in entrypoint.sh with graceful fallback to the
-      # host default if the bbr module is not loaded. Setting it here would fail
-      # container start on kernels without bbr.
+      # tcp_congestion_control is intentionally not set here — it hard-fails
+      # container start on kernels without the bbr module loaded (Synology, QNAP,
+      # some Proxmox/LXC setups) and compose sysctls are all-or-nothing. The
+      # entrypoint reports CC state and tells the operator how to enable bbr on
+      # the host if desired.
     environment:
       - TZ=${TZ:-America/Chicago}
       # For URL construction and host enforcement redirect

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -62,9 +62,11 @@ services:
       net.ipv4.tcp_rmem: "4096 131072 33554432"
       net.ipv4.tcp_wmem: "4096 65536 33554432"
       net.ipv4.tcp_mtu_probing: "1"
-      # tcp_congestion_control is set in entrypoint.sh with graceful fallback to the
-      # host default if the bbr module is not loaded. Setting it here would fail
-      # container start on kernels without bbr.
+      # tcp_congestion_control is intentionally not set here — it hard-fails
+      # container start on kernels without the bbr module loaded (Synology, QNAP,
+      # some Proxmox/LXC setups) and compose sysctls are all-or-nothing. The
+      # entrypoint reports CC state and tells the operator how to enable bbr on
+      # the host if desired.
     environment:
       - TZ=${TZ:-America/Chicago}
       # For URL construction and host enforcement redirect


### PR DESCRIPTION
## Summary

Follow-up to #554. The replacement comment in the compose files said `tcp_congestion_control is set in entrypoint.sh`, but the entrypoint can't set it — `/proc/sys` is read-only inside a container netns except for sysctls declared in the compose `sysctls:` block, which is exactly the hard-fail case #554 removed.

The entrypoint only reports CC state and prints host-side guidance. Updated the comment to reflect that.

Comment-only change; no behavior difference.

## Test plan

- [x] Compose still parses (YAML comment-only change).
- [x] No deploy needed — comments don't affect running containers.