### PR TITLE
Adaptive SQM link-speed fix, burst revert, Smart Queues tolerance

### DIFF
--- a/src/NetworkOptimizer.Sqm/Models/SqmConfiguration.cs
+++ b/src/NetworkOptimizer.Sqm/Models/SqmConfiguration.cs
@@ -58,6 +58,21 @@ public class SqmConfiguration
     public int AbsoluteMaxDownloadSpeed { get; set; } = 280;
 
     /// <summary>
+    /// Physical WAN link speed in Mbps (e.g., 1000 for 1GbE, 10000 for 10GbE).
+    /// Used as a final ceiling in the shaping scripts (with HTB headroom) to prevent
+    /// shaping above physical line rate. Null when unknown.
+    /// </summary>
+    public int? WanLinkSpeedMbps { get; set; }
+
+    /// <summary>
+    /// Rate to set on TC during the speedtest probe so the measurement runs unshaped.
+    /// 5% above the larger of AbsoluteMax or physical link speed - safely above anything
+    /// the connection can actually deliver, so TC never constrains the test.
+    /// </summary>
+    public int SpeedtestProbeRateMbps =>
+        Math.Max(100, (int)(Math.Max(AbsoluteMaxDownloadSpeed, WanLinkSpeedMbps ?? 0) * 1.05));
+
+    /// <summary>
     /// Overhead multiplier for speedtest results (1.05 = 5% overhead)
     /// </summary>
     public double OverheadMultiplier { get; set; } = 1.05;
@@ -199,13 +214,11 @@ public class SqmConfiguration
         LatencyDecrease = profile.LatencyDecrease;
         LatencyIncrease = profile.LatencyIncrease;
 
-        // Cap at physical WAN link speed if known (e.g., 1000 for 1GbE)
-        if (wanLinkSpeedMbps is > 0)
-        {
-            MaxDownloadSpeed = Math.Min(MaxDownloadSpeed, wanLinkSpeedMbps.Value);
-            MinDownloadSpeed = Math.Min(MinDownloadSpeed, wanLinkSpeedMbps.Value);
-            AbsoluteMaxDownloadSpeed = Math.Min(AbsoluteMaxDownloadSpeed, wanLinkSpeedMbps.Value);
-        }
+        // Store link speed; the scripts apply it as a final ceiling (with HTB headroom)
+        // rather than pre-clamping AbsoluteMax. Pre-clamping here caused the safety cap to
+        // double-discount against the link speed, producing rates well below what a
+        // connection with nominal just under line rate could actually shape safely.
+        WanLinkSpeedMbps = wanLinkSpeedMbps is > 0 ? wanLinkSpeedMbps : null;
 
         // Apply blending ratios
         var (withinWeight, _) = profile.GetBlendingRatios(withinThreshold: true);

--- a/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
+++ b/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
@@ -232,11 +232,16 @@ public class ScriptGenerator
         sb.AppendLine($"IFB_DEVICE=\"ifb{_config.Interface}\"");
         sb.AppendLine($"MAX_DOWNLOAD_SPEED=\"{_config.MaxDownloadSpeed}\"");
         sb.AppendLine($"ABSOLUTE_MAX_DOWNLOAD_SPEED=\"{_config.AbsoluteMaxDownloadSpeed}\"");
+        sb.AppendLine($"SPEEDTEST_PROBE_RATE=\"{_config.SpeedtestProbeRateMbps}\"");
         sb.AppendLine($"MIN_DOWNLOAD_SPEED=\"{_config.MinDownloadSpeed}\"");
         sb.AppendLine($"UPLOAD_SPEED=\"{_config.NominalUploadSpeed}\"");
         sb.AppendLine($"SHAPE_UPLOAD={(_config.ShapeUpload ? "1" : "0")}");
         sb.AppendLine($"DOWNLOAD_SPEED_MULTIPLIER=\"{Inv(_config.OverheadMultiplier)}\"");
         sb.AppendLine($"SAFETY_CAP=\"{Inv(_config.SafetyCapPercent)}\"");
+        // Physical link speed final clamp (0 = unknown, skip clamp). LINK_SPEED_HEADROOM reserves
+        // headroom below physical line rate so HTB can shape without buffering at the NIC.
+        sb.AppendLine($"WAN_LINK_SPEED_MBPS=\"{_config.WanLinkSpeedMbps ?? 0}\"");
+        sb.AppendLine($"LINK_SPEED_HEADROOM=\"0.98\"");
         sb.AppendLine($"RESULT_FILE=\"/data/sqm/{_name}-result.txt\"");
         sb.AppendLine($"LOG_FILE=\"/var/log/sqm-{_name}.log\"");
         sb.AppendLine();
@@ -273,9 +278,9 @@ public class ScriptGenerator
         sb.AppendLine(GetTcUpdateFunction());
         sb.AppendLine();
 
-        // Set absolute max before speedtest for clean, unlimited test
-        sb.AppendLine("# Set SQM to absolute max before speedtest for accurate measurement");
-        sb.AppendLine("update_all_tc_classes $IFB_DEVICE $ABSOLUTE_MAX_DOWNLOAD_SPEED");
+        // Set probe rate slightly above line rate before speedtest so TC never engages
+        sb.AppendLine("# Set SQM to probe rate (~5% above line rate) before speedtest for truly unshaped measurement");
+        sb.AppendLine("update_all_tc_classes $IFB_DEVICE $SPEEDTEST_PROBE_RATE");
         sb.AppendLine("# Upstream: shape rate if enabled, otherwise just tune performance params");
         sb.AppendLine("if [ \"$SHAPE_UPLOAD\" = \"1\" ]; then");
         sb.AppendLine("    update_all_tc_classes $INTERFACE $UPLOAD_SPEED");
@@ -316,6 +321,16 @@ public class ScriptGenerator
         sb.AppendLine("# Apply safety cap");
         sb.AppendLine("max_adjusted_rate=$(echo \"$MAX_DOWNLOAD_SPEED * $SAFETY_CAP / 1\" | bc)");
         sb.AppendLine("download_speed_mbps=$((download_speed_mbps > max_adjusted_rate ? max_adjusted_rate : download_speed_mbps))");
+        sb.AppendLine();
+
+        // Apply physical link speed ceiling (with HTB headroom) as final clamp
+        sb.AppendLine("# Apply physical link speed ceiling (HTB headroom below line rate)");
+        sb.AppendLine("if [ \"$WAN_LINK_SPEED_MBPS\" -gt 0 ]; then");
+        sb.AppendLine("    link_ceiling=$(echo \"scale=0; $WAN_LINK_SPEED_MBPS * $LINK_SPEED_HEADROOM / 1\" | bc)");
+        sb.AppendLine("    if [ \"$download_speed_mbps\" -gt \"$link_ceiling\" ]; then");
+        sb.AppendLine("        download_speed_mbps=$link_ceiling");
+        sb.AppendLine("    fi");
+        sb.AppendLine("fi");
         sb.AppendLine();
 
         // Save result and apply
@@ -368,6 +383,10 @@ public class ScriptGenerator
         sb.AppendLine($"SHAPE_UPLOAD={(_config.ShapeUpload ? "1" : "0")}");
         sb.AppendLine($"SAFETY_CAP=\"{Inv(_config.SafetyCapPercent)}\"");
         sb.AppendLine($"NOMINAL_SPEED=\"{_config.NominalDownloadSpeed}\"");
+        // Physical link speed final clamp (0 = unknown, skip clamp). LINK_SPEED_HEADROOM reserves
+        // headroom below physical line rate so HTB can shape without buffering at the NIC.
+        sb.AppendLine($"WAN_LINK_SPEED_MBPS=\"{_config.WanLinkSpeedMbps ?? 0}\"");
+        sb.AppendLine($"LINK_SPEED_HEADROOM=\"0.98\"");
         sb.AppendLine($"RESULT_FILE=\"/data/sqm/{_name}-result.txt\"");
         sb.AppendLine($"LOG_FILE=\"/var/log/sqm-{_name}.log\"");
         sb.AppendLine();
@@ -447,6 +466,19 @@ public class ScriptGenerator
         }
         sb.AppendLine("if (( $(echo \"$MAX_DOWNLOAD_SPEED > $max_adjusted_rate\" | bc) )); then");
         sb.AppendLine("    MAX_DOWNLOAD_SPEED=$(echo \"scale=0; $max_adjusted_rate / 1\" | bc)");
+        sb.AppendLine("fi");
+        sb.AppendLine();
+
+        // Physical link speed ceiling (with HTB headroom) as final clamp on the schedule cap
+        sb.AppendLine("# Apply physical link speed ceiling (HTB headroom below line rate)");
+        sb.AppendLine("if [ \"$WAN_LINK_SPEED_MBPS\" -gt 0 ]; then");
+        sb.AppendLine("    link_ceiling=$(echo \"scale=0; $WAN_LINK_SPEED_MBPS * $LINK_SPEED_HEADROOM / 1\" | bc)");
+        sb.AppendLine("    if (( $(echo \"$max_adjusted_rate > $link_ceiling\" | bc) )); then");
+        sb.AppendLine("        max_adjusted_rate=$link_ceiling");
+        sb.AppendLine("    fi");
+        sb.AppendLine("    if (( $(echo \"$MAX_DOWNLOAD_SPEED > $link_ceiling\" | bc) )); then");
+        sb.AppendLine("        MAX_DOWNLOAD_SPEED=$link_ceiling");
+        sb.AppendLine("    fi");
         sb.AppendLine("fi");
         sb.AppendLine();
 
@@ -540,16 +572,16 @@ public class ScriptGenerator
     /// </summary>
     private string GetTcUpdateFunction()
     {
-        return @"# Calculate burst size scaled to rate (prevents frame drops at high speeds)
-# Config E testing showed 5KB is optimal at gig speeds: eliminates downstream drop_overmemory
-# without the bufferbloat regression seen at 8KB+ (which feeds fq_codel faster than it can react)
-# Scale: 5 bytes per Mbps, floor 1500b (stock), cap 5000b
+        return @"# Burst size tuning history:
+# Config E testing showed 5KB burst eliminates downstream drop_overmemory for bulk
+# flows at gig speeds, but 8KB+ creates bursty HTB send patterns (dump at wire rate,
+# pause for token refill) that increase queue depth variance in fq_codel - shows up
+# as latency jitter under load even though fq_codel is working correctly.
+# Whether higher burst helps depends on ISP policing/shaping - some ISPs police with
+# token bucket and penalize bursts above stock, others are fine with 5KB.
+# Reverted to stock 1500b pending per-connection configurability.
 calc_burst() {
-    local rate_mbps=$1
-    local burst=$((rate_mbps * 5))
-    [ ""$burst"" -lt 1500 ] && burst=1500
-    [ ""$burst"" -gt 5000 ] && burst=5000
-    echo ""$burst""
+    echo ""1500""
 }
 
 # Calculate fq_codel memory_limit scaled to rate (prevents drop_overmemory at high speeds)

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -554,8 +554,8 @@
                         <span class="param-unit">Mbps</span>
                     </div>
                     <div class="param">
-                        <span class="param-label">Absolute Max</span>
-                        <span class="param-value">@wan1Config.AbsoluteMax</span>
+                        <span class="param-label">Speedtest Probe Rate <span class="tooltip-icon tooltip-icon-sm" data-tooltip="TC rate set briefly during the speedtest so the measurement runs unshaped. Set well above physical line rate to ensure TC does not engage.">?</span></span>
+                        <span class="param-value">@wan1Config.SpeedtestProbeRate</span>
                         <span class="param-unit">Mbps</span>
                     </div>
                     <div class="param">
@@ -720,8 +720,8 @@
                         <span class="param-unit">Mbps</span>
                     </div>
                     <div class="param">
-                        <span class="param-label">Absolute Max</span>
-                        <span class="param-value">@wan2Config.AbsoluteMax</span>
+                        <span class="param-label">Speedtest Probe Rate <span class="tooltip-icon tooltip-icon-sm" data-tooltip="TC rate set briefly during the speedtest so the measurement runs unshaped. Set well above physical line rate to ensure TC does not engage.">?</span></span>
+                        <span class="param-value">@wan2Config.SpeedtestProbeRate</span>
                         <span class="param-unit">Mbps</span>
                     </div>
                     <div class="param">
@@ -2092,13 +2092,21 @@
         }
         config.DefaultLatencyThreshold = profile.LatencyThreshold;
 
-        // Cap at physical WAN link speed if known (e.g., 1000 for 1GbE)
+        // Clamp the Latency Adjust Range display to the physical link ceiling (with HTB
+        // headroom) so the shown floor/ceiling reflects actual shaping behavior. AbsoluteMax
+        // stays uncapped - it's the profile-derived basis for the speedtest probe rate.
+        // Keep 0.98 in sync with LINK_SPEED_HEADROOM in ScriptGenerator.cs.
         if (config.WanLinkSpeedMbps is > 0)
         {
-            config.MaxSpeed = Math.Min(config.MaxSpeed, config.WanLinkSpeedMbps.Value);
-            config.MinSpeed = Math.Min(config.MinSpeed, config.WanLinkSpeedMbps.Value);
-            config.AbsoluteMax = Math.Min(config.AbsoluteMax, config.WanLinkSpeedMbps.Value);
+            var linkCeiling = (int)(config.WanLinkSpeedMbps.Value * 0.98);
+            config.MaxSpeed = Math.Min(config.MaxSpeed, linkCeiling);
+            config.MinSpeed = Math.Min(config.MinSpeed, linkCeiling);
         }
+
+        // Speedtest probe rate: 5% above the larger of AbsoluteMax or link speed, ensuring
+        // TC never engages during the speedtest probe. Matches SqmConfiguration.SpeedtestProbeRateMbps.
+        var probeBasis = Math.Max(config.AbsoluteMax, config.WanLinkSpeedMbps ?? 0);
+        config.SpeedtestProbeRate = Math.Max(100, (int)(probeBasis * 1.05));
     }
 
     private static string GetLatencyClass(double latencyMs, double baselineMs)
@@ -2580,11 +2588,17 @@
                     w.Interface.Equals(wanConfig.config.Interface, StringComparison.OrdinalIgnoreCase));
                 if (wanInfo?.SmartqDownRateMbps == null) continue;
 
-                // Use the already-capped AbsoluteMax (accounts for WAN link speed)
-                if (wanInfo.SmartqDownRateMbps < wanConfig.config.AbsoluteMax)
+                // Effective max shaping rate = min(AbsoluteMax, physical link speed). Smart Queues
+                // must allow at least this rate; we never shape above physical line rate.
+                // Allow 1 Mbps tolerance: UniFi Network EA/RC has a bug where Smart Queues
+                // breaks unless the rate is set to interface speed minus 1 (e.g. 999 on 1 GbE).
+                var effectiveMax = wanConfig.config.WanLinkSpeedMbps is > 0
+                    ? Math.Min(wanConfig.config.AbsoluteMax, wanConfig.config.WanLinkSpeedMbps.Value)
+                    : wanConfig.config.AbsoluteMax;
+                if (wanInfo.SmartqDownRateMbps < effectiveMax - 1)
                 {
                     statusMessage = $"Smart Queue download rate for {wanConfig.config.Name} is {wanInfo.SmartqDownRateMbps} Mbps, " +
-                        $"but Adaptive SQM needs up to {wanConfig.config.AbsoluteMax} Mbps. " +
+                        $"but Adaptive SQM needs up to {effectiveMax} Mbps. " +
                         $"Increase the rate in UniFi Network > Settings > Internet > {wanInfo.Name} > Advanced > Smart Queues.";
                     statusSuccess = false;
                     isDeploying = false;
@@ -3155,12 +3169,14 @@
         public int MaxSpeed { get; set; }
         public int MinSpeed { get; set; }
         public int AbsoluteMax { get; set; }
+        public int SpeedtestProbeRate { get; set; }
         public double Overhead { get; set; }
         public double BaselineLatency { get; set; }
         public double LatencyThreshold { get; set; }
         public double DefaultLatencyThreshold { get; set; }
 
         // Congestion schedule range (effective shaping rates from baseline-proportional safety cap)
+        // Keep this formula in sync with the bash clamp in ScriptGenerator.cs.
         public (int Min, int Max) GetCongestionRange()
         {
             var profile = new ConnectionProfile
@@ -3172,6 +3188,13 @@
             double absoluteMax = profile.AbsoluteMaxDownloadMbps;
             double safetyCap = profile.SafetyCapPercent;
             bool isFiber = ConnectionType is ConnectionType.Gpon or ConnectionType.XgsPon;
+
+            // Physical link speed ceiling (HTB headroom below line rate). Must match
+            // LINK_SPEED_HEADROOM in ScriptGenerator.cs.
+            const double linkSpeedHeadroom = 0.98;
+            double? linkCeiling = WanLinkSpeedMbps is > 0
+                ? WanLinkSpeedMbps.Value * linkSpeedHeadroom
+                : null;
 
             double minRate = double.MaxValue;
             double maxRate = double.MinValue;
@@ -3198,6 +3221,9 @@
                         var cap = absoluteMax * safetyCap;
                         rate = Math.Min(withOverhead, cap);
                     }
+
+                    if (linkCeiling is { } ceiling && rate > ceiling)
+                        rate = ceiling;
 
                     rate = Math.Max(5, rate);
 

--- a/tests/NetworkOptimizer.Sqm.Tests/ScriptGeneratorTests.cs
+++ b/tests/NetworkOptimizer.Sqm.Tests/ScriptGeneratorTests.cs
@@ -198,6 +198,87 @@ public class ScriptGeneratorTests
         Assert.Contains($"IFB_DEVICE=\"{expectedIfb}\"", bootScript);
     }
 
+    [Fact]
+    public void GenerateAllScripts_WhenLinkSpeedSet_EmbedsLinkCeilingClampInBothScripts()
+    {
+        var config = new SqmConfiguration
+        {
+            ConnectionName = "Test WAN",
+            Interface = "eth6",
+            MaxDownloadSpeed = 1013,
+            MinDownloadSpeed = 868,
+            AbsoluteMaxDownloadSpeed = 1032,
+            SafetyCapPercent = 0.95,
+            PingHost = "8.8.8.8",
+            WanLinkSpeedMbps = 1000
+        };
+
+        var generator = new ScriptGenerator(config);
+        var baseline = new Dictionary<string, string> { ["0_12"] = "940" };
+        var bootScript = generator.GenerateAllScripts(baseline).Values.First();
+
+        var speedtest = ExtractHeredocSection(bootScript, "SPEEDTEST_EOF");
+        var ping = ExtractHeredocSection(bootScript, "PING_EOF");
+
+        Assert.Contains("WAN_LINK_SPEED_MBPS=\"1000\"", speedtest);
+        Assert.Contains("WAN_LINK_SPEED_MBPS=\"1000\"", ping);
+        Assert.Contains("LINK_SPEED_HEADROOM=\"0.98\"", speedtest);
+        Assert.Contains("LINK_SPEED_HEADROOM=\"0.98\"", ping);
+        Assert.Contains("$WAN_LINK_SPEED_MBPS * $LINK_SPEED_HEADROOM", speedtest);
+        Assert.Contains("$WAN_LINK_SPEED_MBPS * $LINK_SPEED_HEADROOM", ping);
+    }
+
+    [Fact]
+    public void GenerateAllScripts_SpeedtestProbeRate_IsAboveLineRate()
+    {
+        var config = new SqmConfiguration
+        {
+            ConnectionName = "Test WAN",
+            Interface = "eth6",
+            MaxDownloadSpeed = 1013,
+            MinDownloadSpeed = 868,
+            AbsoluteMaxDownloadSpeed = 1032,
+            PingHost = "8.8.8.8",
+            WanLinkSpeedMbps = 1000
+        };
+
+        var generator = new ScriptGenerator(config);
+        var bootScript = generator.GenerateAllScripts(new Dictionary<string, string>()).Values.First();
+        var speedtest = ExtractHeredocSection(bootScript, "SPEEDTEST_EOF");
+
+        // Probe rate = 1.05 * max(AbsoluteMax, LinkSpeed) = 1.05 * max(1032, 1000) = 1083
+        Assert.Contains("SPEEDTEST_PROBE_RATE=\"1083\"", speedtest);
+        // Initial TC set uses probe rate, not ABSOLUTE_MAX_DOWNLOAD_SPEED
+        Assert.Contains("update_all_tc_classes $IFB_DEVICE $SPEEDTEST_PROBE_RATE", speedtest);
+    }
+
+    [Fact]
+    public void GenerateAllScripts_WhenLinkSpeedUnknown_EmitsZeroAndSkipsClamp()
+    {
+        var config = new SqmConfiguration
+        {
+            ConnectionName = "Test WAN",
+            Interface = "eth6",
+            MaxDownloadSpeed = 1013,
+            MinDownloadSpeed = 868,
+            AbsoluteMaxDownloadSpeed = 1032,
+            PingHost = "8.8.8.8",
+            WanLinkSpeedMbps = null
+        };
+
+        var generator = new ScriptGenerator(config);
+        var bootScript = generator.GenerateAllScripts(new Dictionary<string, string>()).Values.First();
+
+        var speedtest = ExtractHeredocSection(bootScript, "SPEEDTEST_EOF");
+        var ping = ExtractHeredocSection(bootScript, "PING_EOF");
+
+        Assert.Contains("WAN_LINK_SPEED_MBPS=\"0\"", speedtest);
+        Assert.Contains("WAN_LINK_SPEED_MBPS=\"0\"", ping);
+        // Guard ensures clamp only runs when link speed is known
+        Assert.Contains("if [ \"$WAN_LINK_SPEED_MBPS\" -gt 0 ]", speedtest);
+        Assert.Contains("if [ \"$WAN_LINK_SPEED_MBPS\" -gt 0 ]", ping);
+    }
+
     /// <summary>
     /// Extracts the content between heredoc delimiters (e.g., between 'SPEEDTEST_EOF' markers).
     /// </summary>


### PR DESCRIPTION
## Summary

- **Adaptive SQM link-speed fix** - GPON/XGS-PON connections provisioned just under physical link speed (e.g. 965 Mbps on 1 GbE) were being triple-discounted. The safety cap and baseline ratio were applied to a pre-clamped AbsoluteMax, producing shaping rates ~25 Mbps below what the UI displayed. Shaping range for a 965/1000 GPON link moves from 921-950 up to 950-980 Mbps.
- **Burst tuning reverted to stock 1500b** - Higher burst values (5KB+) create bursty HTB send patterns that increase fq_codel queue depth variance, showing up as latency jitter under load. Pending per-connection configurability.
- **Smart Queues validation tolerance** - UniFi Network EA/RC has a bug where Smart Queues breaks unless rate is set to interface speed minus 1. Validation now allows 1 Mbps tolerance.
- **UI rename** - "Absolute Max" renamed to "Speedtest Probe Rate" with the value bumped to 5% above line rate, labeling the parameter for what it actually does.

## Test plan

- [x] All tests pass (251 SQM tests including 3 new)
- [x] Deployed and verified on NAS and Mac test sites