### PR TITLE
Add filter-to-device toggle on speed test history tables

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
@@ -196,6 +196,14 @@
                                            OnSearch="OnFilterChanged"
                                            ShowStatus="true"
                                            ResultCount="filteredHistory.Count" />
+                    @if (!string.IsNullOrEmpty(deviceFilter))
+                    {
+                        <div class="device-filter-pill">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                            <span>Filtering to <strong>@deviceFilterName</strong></span>
+                            <button class="device-filter-clear" @onclick="ClearDeviceFilter" type="button">×</button>
+                        </div>
+                    }
                 </div>
             }
         </div>
@@ -256,6 +264,9 @@
                                                     <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
                                                 </a>
                                             }
+                                            <button class="device-filter-btn" @onclick="() => SetDeviceFilter(result.DeviceHost, result.DeviceName ?? result.DeviceHost)" @onclick:stopPropagation data-tooltip="Filter to this device">
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                                            </button>
                                             <br />
                                             <code class="text-muted">@result.DeviceHost</code>
                                         }
@@ -269,6 +280,9 @@
                                                     <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
                                                 </a>
                                             }
+                                            <button class="device-filter-btn" @onclick="() => SetDeviceFilter(result.DeviceHost, result.DeviceHost)" @onclick:stopPropagation data-tooltip="Filter to this device">
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                                            </button>
                                         }
                                     </td>
                                     <td>
@@ -340,7 +354,7 @@
                 {
                     <div class="pagination" id="history-pagination">
                         <button class="btn btn-sm btn-secondary" disabled="@(historyPage <= 1)" @onclick="() => ChangePage(-1)">Prev</button>
-                        <span class="pagination-info">Page @historyPage of @historyTotalPages (@filteredHistory.Count@(string.IsNullOrEmpty(historySearchFilter) ? " total" : $" of {testHistory.Count}"))</span>
+                        <span class="pagination-info">Page @historyPage of @historyTotalPages (@filteredHistory.Count@(string.IsNullOrEmpty(historySearchFilter) && string.IsNullOrEmpty(deviceFilter) ? " total" : $" of {testHistory.Count}"))</span>
                         <button class="btn btn-sm btn-secondary" disabled="@(historyPage >= historyTotalPages)" @onclick="() => ChangePage(1)">Next</button>
                     </div>
                 }
@@ -649,7 +663,8 @@
         background: var(--bg-tertiary);
     }
 
-    .client-dashboard-link {
+    .client-dashboard-link,
+    .device-filter-btn {
         color: var(--text-muted);
         margin-left: 4px;
         vertical-align: middle;
@@ -657,12 +672,59 @@
         transition: opacity 0.15s;
     }
 
-    .history-row-clickable:hover .client-dashboard-link {
+    .device-filter-btn {
+        background: none;
+        border: none;
+        cursor: pointer;
+        padding: 0;
+        line-height: 1;
+    }
+
+    .history-row-clickable:hover .client-dashboard-link,
+    .history-row-clickable:hover .device-filter-btn {
         opacity: 1;
     }
 
-    .client-dashboard-link:hover {
+    .client-dashboard-link:hover,
+    .device-filter-btn:hover {
         color: var(--primary-color);
+    }
+
+    .device-filter-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        padding: 0.25rem 0.5rem;
+        background: rgba(5, 89, 201, 0.15);
+        border: 1px solid rgba(5, 89, 201, 0.3);
+        border-radius: 999px;
+        font-size: 0.8125rem;
+        color: var(--text-secondary);
+        white-space: nowrap;
+    }
+
+    .device-filter-pill svg {
+        flex-shrink: 0;
+        color: var(--primary-color);
+    }
+
+    .device-filter-clear {
+        background: none;
+        border: none;
+        color: var(--text-muted);
+        font-size: 1.125rem;
+        line-height: 1;
+        cursor: pointer;
+        padding: 0 0.125rem;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .device-filter-clear:hover {
+        color: var(--text-primary);
+        background: rgba(255, 255, 255, 0.1);
     }
 
     .history-row-expanded {
@@ -685,6 +747,10 @@
     }
 
     .history-search-row {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        flex-wrap: wrap;
         padding-top: 0.5rem;
         border-top: 1px solid var(--border-color);
     }
@@ -715,10 +781,23 @@
     // Search filter (uses shared SpeedTestFilterHelper for consistency with repository)
     private string historySearchFilter = "";
 
-    // Filtered results based on search filter
-    private List<Iperf3Result> filteredHistory => string.IsNullOrEmpty(historySearchFilter)
-        ? testHistory
-        : testHistory.Where(r => SpeedTestFilterHelper.MatchesFilter(r, historySearchFilter.ToLowerInvariant())).ToList();
+    // Device filter (set by clicking filter icon on a row)
+    private string deviceFilter = "";
+    private string deviceFilterName = "";
+
+    // Filtered results based on search filter and device filter
+    private List<Iperf3Result> filteredHistory
+    {
+        get
+        {
+            IEnumerable<Iperf3Result> results = testHistory;
+            if (!string.IsNullOrEmpty(deviceFilter))
+                results = results.Where(r => string.Equals(r.DeviceHost, deviceFilter, StringComparison.OrdinalIgnoreCase));
+            if (!string.IsNullOrEmpty(historySearchFilter))
+                results = results.Where(r => SpeedTestFilterHelper.MatchesFilter(r, historySearchFilter.ToLowerInvariant()));
+            return results.ToList();
+        }
+    }
 
     // Pagination
     private int historyPage = 1;
@@ -992,6 +1071,24 @@
 
     private void OnFilterChanged(string filter)
     {
+        historyPage = 1;
+        expandedHistoryId = null;
+        StateHasChanged();
+    }
+
+    private void SetDeviceFilter(string host, string displayName)
+    {
+        deviceFilter = host;
+        deviceFilterName = displayName;
+        historyPage = 1;
+        expandedHistoryId = null;
+        StateHasChanged();
+    }
+
+    private void ClearDeviceFilter()
+    {
+        deviceFilter = "";
+        deviceFilterName = "";
         historyPage = 1;
         expandedHistoryId = null;
         StateHasChanged();

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
@@ -673,6 +673,10 @@
         transition: opacity 0.15s, color 0.15s;
     }
 
+    .client-dashboard-link {
+        margin-left: 8px;
+    }
+
     .device-filter-btn {
         background: none;
         border: none;

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
@@ -253,10 +253,14 @@
                                     <td>
                                         @{
                                             var isLan = result.IsLocalLanClient();
+                                            var isDeviceFiltered = string.Equals(deviceFilter, result.DeviceHost, StringComparison.OrdinalIgnoreCase);
                                         }
                                         @if (!string.IsNullOrEmpty(result.DeviceName))
                                         {
                                             <span>@result.DeviceName</span>
+                                            <button class="device-filter-btn @(isDeviceFiltered ? "active" : "")" @onclick="() => ToggleDeviceFilter(result.DeviceHost, result.DeviceName ?? result.DeviceHost)" @onclick:stopPropagation data-tooltip="@(isDeviceFiltered ? "Clear device filter" : "Filter to this device")" data-tooltip-hover-only>
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                                            </button>
                                             @if (isLan)
                                             {
                                                 <a href="/client-dashboard?ip=@result.DeviceHost&tab=speed&range=30d" class="client-dashboard-link"
@@ -264,15 +268,15 @@
                                                     <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
                                                 </a>
                                             }
-                                            <button class="device-filter-btn" @onclick="() => SetDeviceFilter(result.DeviceHost, result.DeviceName ?? result.DeviceHost)" @onclick:stopPropagation data-tooltip="Filter to this device">
-                                                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
-                                            </button>
                                             <br />
                                             <code class="text-muted">@result.DeviceHost</code>
                                         }
                                         else
                                         {
                                             <code>@result.DeviceHost</code>
+                                            <button class="device-filter-btn @(isDeviceFiltered ? "active" : "")" @onclick="() => ToggleDeviceFilter(result.DeviceHost, result.DeviceHost)" @onclick:stopPropagation data-tooltip="@(isDeviceFiltered ? "Clear device filter" : "Filter to this device")" data-tooltip-hover-only>
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                                            </button>
                                             @if (isLan)
                                             {
                                                 <a href="/client-dashboard?ip=@result.DeviceHost&tab=speed&range=30d" class="client-dashboard-link"
@@ -280,9 +284,6 @@
                                                     <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
                                                 </a>
                                             }
-                                            <button class="device-filter-btn" @onclick="() => SetDeviceFilter(result.DeviceHost, result.DeviceHost)" @onclick:stopPropagation data-tooltip="Filter to this device">
-                                                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
-                                            </button>
                                         }
                                     </td>
                                     <td>
@@ -353,9 +354,9 @@
                 @if (historyTotalPages > 1)
                 {
                     <div class="pagination" id="history-pagination">
-                        <button class="btn btn-sm btn-secondary" disabled="@(historyPage <= 1)" @onclick="() => ChangePage(-1)">Prev</button>
+                        <button class="btn btn-sm btn-secondary" disabled="@(historyPage <= 1)" @onclick="() => ChangePage(-1)"><span class="pag-arrow">←</span> Prev</button>
                         <span class="pagination-info">Page @historyPage of @historyTotalPages (@filteredHistory.Count@(string.IsNullOrEmpty(historySearchFilter) && string.IsNullOrEmpty(deviceFilter) ? " total" : $" of {testHistory.Count}"))</span>
-                        <button class="btn btn-sm btn-secondary" disabled="@(historyPage >= historyTotalPages)" @onclick="() => ChangePage(1)">Next</button>
+                        <button class="btn btn-sm btn-secondary" disabled="@(historyPage >= historyTotalPages)" @onclick="() => ChangePage(1)">Next <span class="pag-arrow">→</span></button>
                     </div>
                 }
             }
@@ -669,7 +670,7 @@
         margin-left: 4px;
         vertical-align: middle;
         opacity: 0;
-        transition: opacity 0.15s;
+        transition: opacity 0.15s, color 0.15s;
     }
 
     .device-filter-btn {
@@ -678,6 +679,11 @@
         cursor: pointer;
         padding: 0;
         line-height: 1;
+    }
+
+    .device-filter-btn.active {
+        opacity: 1;
+        color: var(--primary-color);
     }
 
     .history-row-clickable:hover .client-dashboard-link,
@@ -1076,10 +1082,18 @@
         StateHasChanged();
     }
 
-    private void SetDeviceFilter(string host, string displayName)
+    private void ToggleDeviceFilter(string host, string displayName)
     {
-        deviceFilter = host;
-        deviceFilterName = displayName;
+        if (string.Equals(deviceFilter, host, StringComparison.OrdinalIgnoreCase))
+        {
+            deviceFilter = "";
+            deviceFilterName = "";
+        }
+        else
+        {
+            deviceFilter = host;
+            deviceFilterName = displayName;
+        }
         historyPage = 1;
         expandedHistoryId = null;
         StateHasChanged();

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
@@ -214,7 +214,7 @@
                     <table class="data-table">
                         <thead>
                             <tr>
-                                <th>Time</th>
+                                <th class="col-time">Time</th>
                                 <th>Device</th>
                                 <th>Source</th>
                                 <th class="hide-mobile">

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
@@ -98,6 +98,14 @@
                 <div class="header-title-row">
                     <h2 class="card-title">Test History</h2>
                     <div class="header-actions">
+                        @if (!string.IsNullOrEmpty(_deviceFilter))
+                        {
+                            <div class="device-filter-pill">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                                <span>Filtering to <strong>@_deviceFilterName</strong></span>
+                                <button class="device-filter-clear" @onclick="ClearDeviceFilter" type="button">×</button>
+                            </div>
+                        }
                         <button class="btn btn-sm btn-secondary" @onclick="LoadResults" disabled="@_loading">
                             @if (_loading)
                             {
@@ -158,12 +166,18 @@
                                             @if (!string.IsNullOrEmpty(result.DeviceName))
                                             {
                                                 <span>@result.DeviceName</span>
+                                                <button class="device-filter-btn" @onclick="() => SetDeviceFilter(result.DeviceHost, result.DeviceName ?? result.DeviceHost)" @onclick:stopPropagation data-tooltip="Filter to this device">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                                                </button>
                                                 <br />
                                                 <code class="text-muted">@result.DeviceHost</code>
                                             }
                                             else
                                             {
                                                 <code>@result.DeviceHost</code>
+                                                <button class="device-filter-btn" @onclick="() => SetDeviceFilter(result.DeviceHost, result.DeviceHost)" @onclick:stopPropagation data-tooltip="Filter to this device">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                                                </button>
                                             }
                                         </td>
                                         <td class="hide-mobile">
@@ -227,7 +241,7 @@
                     {
                         <div class="pagination">
                             <button class="btn btn-sm btn-secondary" disabled="@(_page <= 1)" @onclick="() => ChangePage(-1)">Prev</button>
-                            <span class="pagination-info">Page @_page of @_totalPages (@_results.Count total)</span>
+                            <span class="pagination-info">Page @_page of @_totalPages (@_filteredResults.Count@(string.IsNullOrEmpty(_deviceFilter) ? " total" : $" of {_results.Count}"))</span>
                             <button class="btn btn-sm btn-secondary" disabled="@(_page >= _totalPages)" @onclick="() => ChangePage(1)">Next</button>
                         </div>
                     }
@@ -412,6 +426,71 @@
         flex-wrap: wrap;
         gap: 0.5rem;
     }
+
+    .header-actions {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+    }
+
+    .device-filter-btn {
+        color: var(--text-muted);
+        margin-left: 4px;
+        vertical-align: middle;
+        opacity: 0;
+        transition: opacity 0.15s;
+        background: none;
+        border: none;
+        cursor: pointer;
+        padding: 0;
+        line-height: 1;
+    }
+
+    .history-row-clickable:hover .device-filter-btn {
+        opacity: 1;
+    }
+
+    .device-filter-btn:hover {
+        color: var(--primary-color);
+    }
+
+    .device-filter-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        padding: 0.25rem 0.5rem;
+        background: rgba(5, 89, 201, 0.15);
+        border: 1px solid rgba(5, 89, 201, 0.3);
+        border-radius: 999px;
+        font-size: 0.8125rem;
+        color: var(--text-secondary);
+        white-space: nowrap;
+    }
+
+    .device-filter-pill svg {
+        flex-shrink: 0;
+        color: var(--primary-color);
+    }
+
+    .device-filter-clear {
+        background: none;
+        border: none;
+        color: var(--text-muted);
+        font-size: 1.125rem;
+        line-height: 1;
+        cursor: pointer;
+        padding: 0 0.125rem;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .device-filter-clear:hover {
+        color: var(--text-primary);
+        background: rgba(255, 255, 255, 0.1);
+    }
 </style>
 
 @code {
@@ -426,8 +505,16 @@
     private const int PageSize = 20;
     private System.Threading.Timer? _pollTimer;
 
-    private int _totalPages => Math.Max(1, (int)Math.Ceiling(_results.Count / (double)PageSize));
-    private IEnumerable<Iperf3Result> _pagedResults => _results.Skip((_page - 1) * PageSize).Take(PageSize);
+    // Device filter (set by clicking filter icon on a row)
+    private string _deviceFilter = "";
+    private string _deviceFilterName = "";
+
+    private List<Iperf3Result> _filteredResults => string.IsNullOrEmpty(_deviceFilter)
+        ? _results
+        : _results.Where(r => string.Equals(r.DeviceHost, _deviceFilter, StringComparison.OrdinalIgnoreCase)).ToList();
+
+    private int _totalPages => Math.Max(1, (int)Math.Ceiling(_filteredResults.Count / (double)PageSize));
+    private IEnumerable<Iperf3Result> _pagedResults => _filteredResults.Skip((_page - 1) * PageSize).Take(PageSize);
 
     protected override async Task OnInitializedAsync()
     {
@@ -498,6 +585,24 @@
     {
         await ClientSpeedTestService.UpdateNotesAsync(args.Id, args.Notes);
         await LoadResults();
+    }
+
+    private void SetDeviceFilter(string host, string displayName)
+    {
+        _deviceFilter = host;
+        _deviceFilterName = displayName;
+        _page = 1;
+        _expandedId = 0;
+        StateHasChanged();
+    }
+
+    private void ClearDeviceFilter()
+    {
+        _deviceFilter = "";
+        _deviceFilterName = "";
+        _page = 1;
+        _expandedId = 0;
+        StateHasChanged();
     }
 
     public void Dispose()

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
@@ -163,10 +163,13 @@
                                         @onclick="@(() => ToggleExpand(result.Id))">
                                         <td>@result.TestTime.ToLocalTime().ToString("MMM dd HH:mm")</td>
                                         <td>
+                                            @{
+                                                var isDeviceFiltered = string.Equals(_deviceFilter, result.DeviceHost, StringComparison.OrdinalIgnoreCase);
+                                            }
                                             @if (!string.IsNullOrEmpty(result.DeviceName))
                                             {
                                                 <span>@result.DeviceName</span>
-                                                <button class="device-filter-btn" @onclick="() => SetDeviceFilter(result.DeviceHost, result.DeviceName ?? result.DeviceHost)" @onclick:stopPropagation data-tooltip="Filter to this device">
+                                                <button class="device-filter-btn @(isDeviceFiltered ? "active" : "")" @onclick="() => ToggleDeviceFilter(result.DeviceHost, result.DeviceName ?? result.DeviceHost)" @onclick:stopPropagation data-tooltip="@(isDeviceFiltered ? "Clear device filter" : "Filter to this device")" data-tooltip-hover-only>
                                                     <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
                                                 </button>
                                                 <br />
@@ -175,7 +178,7 @@
                                             else
                                             {
                                                 <code>@result.DeviceHost</code>
-                                                <button class="device-filter-btn" @onclick="() => SetDeviceFilter(result.DeviceHost, result.DeviceHost)" @onclick:stopPropagation data-tooltip="Filter to this device">
+                                                <button class="device-filter-btn @(isDeviceFiltered ? "active" : "")" @onclick="() => ToggleDeviceFilter(result.DeviceHost, result.DeviceHost)" @onclick:stopPropagation data-tooltip="@(isDeviceFiltered ? "Clear device filter" : "Filter to this device")" data-tooltip-hover-only>
                                                     <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
                                                 </button>
                                             }
@@ -240,9 +243,9 @@
                     @if (_totalPages > 1)
                     {
                         <div class="pagination">
-                            <button class="btn btn-sm btn-secondary" disabled="@(_page <= 1)" @onclick="() => ChangePage(-1)">Prev</button>
+                            <button class="btn btn-sm btn-secondary" disabled="@(_page <= 1)" @onclick="() => ChangePage(-1)"><span class="pag-arrow">←</span> Prev</button>
                             <span class="pagination-info">Page @_page of @_totalPages (@_filteredResults.Count@(string.IsNullOrEmpty(_deviceFilter) ? " total" : $" of {_results.Count}"))</span>
-                            <button class="btn btn-sm btn-secondary" disabled="@(_page >= _totalPages)" @onclick="() => ChangePage(1)">Next</button>
+                            <button class="btn btn-sm btn-secondary" disabled="@(_page >= _totalPages)" @onclick="() => ChangePage(1)">Next <span class="pag-arrow">→</span></button>
                         </div>
                     }
                 }
@@ -439,12 +442,17 @@
         margin-left: 4px;
         vertical-align: middle;
         opacity: 0;
-        transition: opacity 0.15s;
+        transition: opacity 0.15s, color 0.15s;
         background: none;
         border: none;
         cursor: pointer;
         padding: 0;
         line-height: 1;
+    }
+
+    .device-filter-btn.active {
+        opacity: 1;
+        color: var(--primary-color);
     }
 
     .history-row-clickable:hover .device-filter-btn {
@@ -587,10 +595,18 @@
         await LoadResults();
     }
 
-    private void SetDeviceFilter(string host, string displayName)
+    private void ToggleDeviceFilter(string host, string displayName)
     {
-        _deviceFilter = host;
-        _deviceFilterName = displayName;
+        if (string.Equals(_deviceFilter, host, StringComparison.OrdinalIgnoreCase))
+        {
+            _deviceFilter = "";
+            _deviceFilterName = "";
+        }
+        else
+        {
+            _deviceFilter = host;
+            _deviceFilterName = displayName;
+        }
         _page = 1;
         _expandedId = 0;
         StateHasChanged();

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
@@ -127,7 +127,7 @@
                         <table class="data-table">
                             <thead>
                                 <tr>
-                                    <th>Time</th>
+                                    <th class="col-time">Time</th>
                                     <th>Device</th>
                                     <th class="hide-mobile">
                                         <span class="tooltip-wrapper tooltip-bottom">

--- a/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
@@ -722,6 +722,14 @@
                                            OnSearch="OnTableFilterChanged"
                                            ShowStatus="true"
                                            ResultCount="filteredHistory.Count" />
+                    @if (!string.IsNullOrEmpty(deviceFilter))
+                    {
+                        <div class="device-filter-pill">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                            <span>Filtering to <strong>@deviceFilterName</strong></span>
+                            <button class="device-filter-clear" @onclick="ClearDeviceFilter" type="button">×</button>
+                        </div>
+                    }
                 </div>
             }
         </div>
@@ -790,6 +798,9 @@
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
                                             </a>
                                         }
+                                        <button class="device-filter-btn" @onclick="() => SetDeviceFilter(result.DeviceHost, result.DeviceName ?? result.DeviceHost)" @onclick:stopPropagation data-tooltip="Filter to this device">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                                        </button>
                                     }
                                     else
                                     {
@@ -801,6 +812,9 @@
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
                                             </a>
                                         }
+                                        <button class="device-filter-btn" @onclick="() => SetDeviceFilter(result.DeviceHost, result.DeviceHost)" @onclick:stopPropagation data-tooltip="Filter to this device">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                                        </button>
                                     }
                                 </td>
                                 <td class="hide-mobile">@(result.Success && result.DownloadMbps > 0 ? result.DownloadMbps.ToString("F1") : "-")</td>
@@ -872,7 +886,7 @@
                     <div class="pagination" id="history-pagination">
                         <button class="btn btn-sm btn-secondary" disabled="@(historyPage <= 1)" @onclick="() => ChangePage(-1)">← Prev</button>
                         <span class="pagination-info">
-                            Page @historyPage of @historyTotalPages (@filteredHistory.Count@(string.IsNullOrEmpty(historySearchFilter) ? " total" : $" of {testHistory.Count}"))
+                            Page @historyPage of @historyTotalPages (@filteredHistory.Count@(string.IsNullOrEmpty(historySearchFilter) && string.IsNullOrEmpty(deviceFilter) ? " total" : $" of {testHistory.Count}"))
                         </span>
                         <button class="btn btn-sm btn-secondary" disabled="@(historyPage >= historyTotalPages)" @onclick="() => ChangePage(1)">Next →</button>
                     </div>
@@ -1193,6 +1207,10 @@
     }
 
     .history-search-row {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        flex-wrap: wrap;
         padding-top: 0.5rem;
         border-top: 1px solid var(--border-color);
     }
@@ -1203,7 +1221,8 @@
         }
     }
 
-    .client-dashboard-link {
+    .client-dashboard-link,
+    .device-filter-btn {
         color: var(--text-muted);
         margin-left: 4px;
         vertical-align: middle;
@@ -1211,12 +1230,62 @@
         transition: opacity 0.15s;
     }
 
-    .history-row-clickable:hover .client-dashboard-link {
+    .device-filter-btn {
+        background: none;
+        border: none;
+        cursor: pointer;
+        padding: 0;
+        line-height: 1;
+    }
+
+    .history-row-clickable:hover .client-dashboard-link,
+    .history-row-clickable:hover .device-filter-btn {
         opacity: 1;
     }
 
     .client-dashboard-link:hover {
         color: var(--primary-color);
+    }
+
+    .device-filter-btn:hover {
+        color: var(--primary-color);
+    }
+
+    .device-filter-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        padding: 0.25rem 0.5rem;
+        background: rgba(5, 89, 201, 0.15);
+        border: 1px solid rgba(5, 89, 201, 0.3);
+        border-radius: 999px;
+        font-size: 0.8125rem;
+        color: var(--text-secondary);
+        white-space: nowrap;
+    }
+
+    .device-filter-pill svg {
+        flex-shrink: 0;
+        color: var(--primary-color);
+    }
+
+    .device-filter-clear {
+        background: none;
+        border: none;
+        color: var(--text-muted);
+        font-size: 1.125rem;
+        line-height: 1;
+        cursor: pointer;
+        padding: 0 0.125rem;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .device-filter-clear:hover {
+        color: var(--text-primary);
+        background: rgba(255, 255, 255, 0.1);
     }
 </style>
 
@@ -1271,10 +1340,23 @@
     // Search filter for table (uses shared SpeedTestFilterHelper for consistency with repository)
     private string historySearchFilter = "";
 
-    // Filtered history based on search filter
-    private List<Iperf3Result> filteredHistory => string.IsNullOrEmpty(historySearchFilter)
-        ? testHistory
-        : testHistory.Where(r => SpeedTestFilterHelper.MatchesFilter(r, historySearchFilter.ToLowerInvariant())).ToList();
+    // Device filter (set by clicking filter icon on a row)
+    private string deviceFilter = "";
+    private string deviceFilterName = "";
+
+    // Filtered history based on search filter and device filter
+    private List<Iperf3Result> filteredHistory
+    {
+        get
+        {
+            IEnumerable<Iperf3Result> results = testHistory;
+            if (!string.IsNullOrEmpty(deviceFilter))
+                results = results.Where(r => string.Equals(r.DeviceHost, deviceFilter, StringComparison.OrdinalIgnoreCase));
+            if (!string.IsNullOrEmpty(historySearchFilter))
+                results = results.Where(r => SpeedTestFilterHelper.MatchesFilter(r, historySearchFilter.ToLowerInvariant()));
+            return results.ToList();
+        }
+    }
 
     // Path analysis for historical results (calculated on demand)
     private Dictionary<int, PathAnalysisResult?> historyPathAnalysis = new();
@@ -2161,8 +2243,26 @@
     /// </summary>
     private void OnTableFilterChanged(string filter)
     {
-        historyPage = 1; // Reset to first page on filter change
-        expandedHistoryId = null; // Collapse any expanded row
+        historyPage = 1;
+        expandedHistoryId = null;
+        StateHasChanged();
+    }
+
+    private void SetDeviceFilter(string host, string displayName)
+    {
+        deviceFilter = host;
+        deviceFilterName = displayName;
+        historyPage = 1;
+        expandedHistoryId = null;
+        StateHasChanged();
+    }
+
+    private void ClearDeviceFilter()
+    {
+        deviceFilter = "";
+        deviceFilterName = "";
+        historyPage = 1;
+        expandedHistoryId = null;
         StateHasChanged();
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
@@ -787,8 +787,6 @@
                                 <td>
                                     @{
                                         var showDashLink = result.IsLocalLanClient();
-                                    }
-                                    @{
                                         var isDeviceFiltered = string.Equals(deviceFilter, result.DeviceHost, StringComparison.OrdinalIgnoreCase);
                                     }
                                     @if (!string.IsNullOrEmpty(result.DeviceName))

--- a/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
@@ -740,7 +740,7 @@
                 <table class="data-table">
                     <thead>
                         <tr>
-                            <th>Time</th>
+                            <th class="col-time">Time</th>
                             <th>Device</th>
                             <th class="hide-mobile">
                                 <span class="tooltip-wrapper tooltip-bottom">

--- a/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
@@ -912,7 +912,7 @@
     </div>
 
     <!-- Test Locations Map -->
-    <SpeedTestMap Results="testHistory"
+    <SpeedTestMap Results="mapResults"
                   OnRefresh="LoadHistory"
                   OnResultClick="ScrollToResult"
                   ApMarkers="apMapMarkers"
@@ -1309,11 +1309,12 @@
     private List<DeviceSshConfiguration> devices = new();
     private DeviceSshConfiguration editingDevice = new() { DeviceType = DeviceType.Server, Enabled = true };
     private List<Iperf3Result> testHistory = new();
+    private List<Iperf3Result> mapResults = new();
     private List<ApMapMarker> apMapMarkers = new();
     private Iperf3Result? currentResult;
     private bool sshConfigured = false;
 
-    // Pagination (uses filteredHistory which respects the map's search filter)
+    // Pagination
     private int historyPage = 1;
     private int historyPageSize = 10;
     private int historyTotalPages => (int)Math.Ceiling(filteredHistory.Count / (double)historyPageSize);
@@ -1569,15 +1570,27 @@
     private async Task HandleSpeedTestTimeRangeChanged(int hours)
     {
         _speedTestTimeRangeHours = hours;
-        testHistory = await SpeedTestService.GetRecentResultsAsync(count: 0, hours: hours);
+        UpdateMapResults();
         StateHasChanged();
+    }
+
+    private void UpdateMapResults()
+    {
+        if (_speedTestTimeRangeHours <= 0)
+        {
+            mapResults = testHistory;
+            return;
+        }
+        var cutoff = DateTime.UtcNow.AddHours(-_speedTestTimeRangeHours);
+        mapResults = testHistory.Where(r => r.TestTime >= cutoff).ToList();
     }
 
     private async Task LoadHistory()
     {
         try
         {
-            testHistory = await SpeedTestService.GetRecentResultsAsync(count: 0, hours: _speedTestTimeRangeHours);
+            testHistory = await SpeedTestService.GetRecentResultsAsync(count: 0, hours: 0);
+            UpdateMapResults();
             historyPage = 1; // Reset to first page when loading fresh data
 
             // Only set currentResult on initial page load (when it's null)

--- a/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
@@ -788,9 +788,15 @@
                                     @{
                                         var showDashLink = result.IsLocalLanClient();
                                     }
+                                    @{
+                                        var isDeviceFiltered = string.Equals(deviceFilter, result.DeviceHost, StringComparison.OrdinalIgnoreCase);
+                                    }
                                     @if (!string.IsNullOrEmpty(result.DeviceName))
                                     {
                                         <span>@result.DeviceName</span>
+                                        <button class="device-filter-btn @(isDeviceFiltered ? "active" : "")" @onclick="() => ToggleDeviceFilter(result.DeviceHost, result.DeviceName ?? result.DeviceHost)" @onclick:stopPropagation data-tooltip="@(isDeviceFiltered ? "Clear device filter" : "Filter to this device")" data-tooltip-hover-only>
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                                        </button>
                                         @if (showDashLink)
                                         {
                                             <a href="/client-dashboard?ip=@result.DeviceHost&tab=speed&range=30d" class="client-dashboard-link"
@@ -798,13 +804,13 @@
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
                                             </a>
                                         }
-                                        <button class="device-filter-btn" @onclick="() => SetDeviceFilter(result.DeviceHost, result.DeviceName ?? result.DeviceHost)" @onclick:stopPropagation data-tooltip="Filter to this device">
-                                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
-                                        </button>
                                     }
                                     else
                                     {
                                         <code>@result.DeviceHost</code>
+                                        <button class="device-filter-btn @(isDeviceFiltered ? "active" : "")" @onclick="() => ToggleDeviceFilter(result.DeviceHost, result.DeviceHost)" @onclick:stopPropagation data-tooltip="@(isDeviceFiltered ? "Clear device filter" : "Filter to this device")" data-tooltip-hover-only>
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                                        </button>
                                         @if (showDashLink)
                                         {
                                             <a href="/client-dashboard?ip=@result.DeviceHost&tab=speed&range=30d" class="client-dashboard-link"
@@ -812,9 +818,6 @@
                                                 <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
                                             </a>
                                         }
-                                        <button class="device-filter-btn" @onclick="() => SetDeviceFilter(result.DeviceHost, result.DeviceHost)" @onclick:stopPropagation data-tooltip="Filter to this device">
-                                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
-                                        </button>
                                     }
                                 </td>
                                 <td class="hide-mobile">@(result.Success && result.DownloadMbps > 0 ? result.DownloadMbps.ToString("F1") : "-")</td>
@@ -884,11 +887,11 @@
                 @if (historyTotalPages > 1)
                 {
                     <div class="pagination" id="history-pagination">
-                        <button class="btn btn-sm btn-secondary" disabled="@(historyPage <= 1)" @onclick="() => ChangePage(-1)">← Prev</button>
+                        <button class="btn btn-sm btn-secondary" disabled="@(historyPage <= 1)" @onclick="() => ChangePage(-1)"><span class="pag-arrow">←</span> Prev</button>
                         <span class="pagination-info">
                             Page @historyPage of @historyTotalPages (@filteredHistory.Count@(string.IsNullOrEmpty(historySearchFilter) && string.IsNullOrEmpty(deviceFilter) ? " total" : $" of {testHistory.Count}"))
                         </span>
-                        <button class="btn btn-sm btn-secondary" disabled="@(historyPage >= historyTotalPages)" @onclick="() => ChangePage(1)">Next →</button>
+                        <button class="btn btn-sm btn-secondary" disabled="@(historyPage >= historyTotalPages)" @onclick="() => ChangePage(1)">Next <span class="pag-arrow">→</span></button>
                     </div>
                 }
             }
@@ -1227,7 +1230,7 @@
         margin-left: 4px;
         vertical-align: middle;
         opacity: 0;
-        transition: opacity 0.15s;
+        transition: opacity 0.15s, color 0.15s;
     }
 
     .device-filter-btn {
@@ -1238,15 +1241,17 @@
         line-height: 1;
     }
 
+    .device-filter-btn.active {
+        opacity: 1;
+        color: var(--primary-color);
+    }
+
     .history-row-clickable:hover .client-dashboard-link,
     .history-row-clickable:hover .device-filter-btn {
         opacity: 1;
     }
 
-    .client-dashboard-link:hover {
-        color: var(--primary-color);
-    }
-
+    .client-dashboard-link:hover,
     .device-filter-btn:hover {
         color: var(--primary-color);
     }
@@ -2248,10 +2253,18 @@
         StateHasChanged();
     }
 
-    private void SetDeviceFilter(string host, string displayName)
+    private void ToggleDeviceFilter(string host, string displayName)
     {
-        deviceFilter = host;
-        deviceFilterName = displayName;
+        if (string.Equals(deviceFilter, host, StringComparison.OrdinalIgnoreCase))
+        {
+            deviceFilter = "";
+            deviceFilterName = "";
+        }
+        else
+        {
+            deviceFilter = host;
+            deviceFilterName = displayName;
+        }
         historyPage = 1;
         expandedHistoryId = null;
         StateHasChanged();

--- a/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
@@ -1233,6 +1233,10 @@
         transition: opacity 0.15s, color 0.15s;
     }
 
+    .client-dashboard-link {
+        margin-left: 8px;
+    }
+
     .device-filter-btn {
         background: none;
         border: none;

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -372,7 +372,7 @@
                     <table class="data-table">
                         <thead>
                             <tr>
-                                <th>Time</th>
+                                <th class="col-time">Time</th>
                                 @if (_wanSeries.Count > 1)
                                 {
                                     <th>WAN</th>

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -541,11 +541,11 @@
                 @if (_historyTotalPages > 1)
                 {
                     <div class="pagination" id="wan-history-pagination">
-                        <button class="btn btn-sm btn-secondary" disabled="@(_historyPage <= 1)" @onclick="() => ChangePage(-1)">← Prev</button>
+                        <button class="btn btn-sm btn-secondary" disabled="@(_historyPage <= 1)" @onclick="() => ChangePage(-1)"><span class="pag-arrow">←</span> Prev</button>
                         <span class="pagination-info">
                             Page @_historyPage of @_historyTotalPages (@_filteredHistory.Count total)
                         </span>
-                        <button class="btn btn-sm btn-secondary" disabled="@(_historyPage >= _historyTotalPages)" @onclick="() => ChangePage(1)">Next →</button>
+                        <button class="btn btn-sm btn-secondary" disabled="@(_historyPage >= _historyTotalPages)" @onclick="() => ChangePage(1)">Next <span class="pag-arrow">→</span></button>
                     </div>
                 }
             }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -5355,6 +5355,11 @@ a.path-hop.hop-clickable:hover {
     font-size: 0.875rem;
 }
 
+.pag-arrow {
+    position: relative;
+    top: -1px;
+}
+
 /* ============================================
    Result Summary (compact link to full result)
    ============================================ */

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1664,7 +1664,7 @@ a.stat-card-link:active {
 }
 
 .data-table .col-time {
-    width: 110px;
+    width: 125px;
     white-space: nowrap;
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1663,6 +1663,11 @@ a.stat-card-link:active {
     font-size: 0.8125rem;
 }
 
+.data-table .col-time {
+    width: 110px;
+    white-space: nowrap;
+}
+
 .data-table tr:not(.history-details-row):hover {
     background: var(--bg-hover);
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -4524,6 +4524,10 @@ select.form-control {
         padding: 0.75rem 0.4rem;
     }
 
+    .data-table .col-time {
+        width: auto;
+    }
+
     td .btn {
         margin: 0 auto;
     }


### PR DESCRIPTION
## Summary

- **Filter-to-device icon** on all speed test history tables (LAN, Client, Client WAN) - a funnel icon next to the device name that toggles filtering the table to that device. Blue when active, grey when off. Works alongside the existing text search filter on LAN and Client pages.
- **Filter indicator pill** shows "Filtering to [device]" with an X to clear, displayed next to the search filter (or next to the Refresh button on Client WAN).
- **Decouple LAN history table from map time slider** - the map time range now only affects map markers; the history table always shows all results. Map results are derived in-memory from the full dataset.
- **Pagination arrows** added to Client Speed Test and Client WAN Speed Test (← Prev / Next →), matching the existing LAN and WAN pages. Arrows shifted up 1px for vertical alignment across all 4 tables.
- **Fixed-width time column** (125px, auto on mobile) for consistent layout across all speed test history tables.

## Test plan

- [x] LAN Speed Test: toggle filter icon on a device row, verify table filters and pill appears. Toggle again to clear. Verify text search still works alongside device filter.
- [x] Client Speed Test: same toggle/pill/text-search verification
- [x] Client WAN Speed Test: same toggle/pill verification (no text search on this page)
- [x] LAN Speed Test: change map time slider, verify table still shows all results while map updates
- [x] Check pagination arrows display and alignment on all 4 tables
- [x] Verify time column width on desktop and mobile