### PR TITLE
v1.15.8

### DIFF
--- a/src/NetworkOptimizer.Agents/NetworkOptimizer.Agents.csproj
+++ b/src/NetworkOptimizer.Agents/NetworkOptimizer.Agents.csproj
@@ -13,10 +13,10 @@
   <ItemGroup>
     <PackageReference Include="SSH.NET" Version="2025.1.0" />
     <PackageReference Include="Scriban" Version="7.0.6" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NetworkOptimizer.Alerts/NetworkOptimizer.Alerts.csproj
+++ b/src/NetworkOptimizer.Alerts/NetworkOptimizer.Alerts.csproj
@@ -11,11 +11,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MailKit" Version="4.15.1" />
+    <PackageReference Include="MailKit" Version="4.16.0" />
     <PackageReference Include="Scriban" Version="7.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NetworkOptimizer.Audit/NetworkOptimizer.Audit.csproj
+++ b/src/NetworkOptimizer.Audit/NetworkOptimizer.Audit.csproj
@@ -16,10 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
   </ItemGroup>
 
 </Project>

--- a/src/NetworkOptimizer.Diagnostics/NetworkOptimizer.Diagnostics.csproj
+++ b/src/NetworkOptimizer.Diagnostics/NetworkOptimizer.Diagnostics.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
   </ItemGroup>
 
 </Project>

--- a/src/NetworkOptimizer.Monitoring/NetworkOptimizer.Monitoring.csproj
+++ b/src/NetworkOptimizer.Monitoring/NetworkOptimizer.Monitoring.csproj
@@ -12,8 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="Lextm.SharpSnmpLib" Version="12.5.7" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
   </ItemGroup>
 
 </Project>

--- a/src/NetworkOptimizer.Storage/NetworkOptimizer.Storage.csproj
+++ b/src/NetworkOptimizer.Storage/NetworkOptimizer.Storage.csproj
@@ -15,12 +15,12 @@
 
   <ItemGroup>
     <PackageReference Include="InfluxDB.Client" Version="4.18.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
   </ItemGroup>
 
 </Project>

--- a/src/NetworkOptimizer.Threats/NetworkOptimizer.Threats.csproj
+++ b/src/NetworkOptimizer.Threats/NetworkOptimizer.Threats.csproj
@@ -14,10 +14,10 @@
 
   <ItemGroup>
     <PackageReference Include="MaxMind.GeoIP2" Version="5.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NetworkOptimizer.UniFi/NetworkOptimizer.UniFi.csproj
+++ b/src/NetworkOptimizer.UniFi/NetworkOptimizer.UniFi.csproj
@@ -15,10 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
     <PackageReference Include="Polly" Version="8.6.5" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
   </ItemGroup>

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
@@ -196,6 +196,14 @@
                                            OnSearch="OnFilterChanged"
                                            ShowStatus="true"
                                            ResultCount="filteredHistory.Count" />
+                    @if (!string.IsNullOrEmpty(deviceFilter))
+                    {
+                        <div class="device-filter-pill">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                            <span>Filtering to <strong>@deviceFilterName</strong></span>
+                            <button class="device-filter-clear" @onclick="ClearDeviceFilter" type="button">×</button>
+                        </div>
+                    }
                 </div>
             }
         </div>
@@ -206,7 +214,7 @@
                     <table class="data-table">
                         <thead>
                             <tr>
-                                <th>Time</th>
+                                <th class="col-time">Time</th>
                                 <th>Device</th>
                                 <th>Source</th>
                                 <th class="hide-mobile">
@@ -245,10 +253,14 @@
                                     <td>
                                         @{
                                             var isLan = result.IsLocalLanClient();
+                                            var isDeviceFiltered = string.Equals(deviceFilter, result.DeviceHost, StringComparison.OrdinalIgnoreCase);
                                         }
                                         @if (!string.IsNullOrEmpty(result.DeviceName))
                                         {
                                             <span>@result.DeviceName</span>
+                                            <button class="device-filter-btn @(isDeviceFiltered ? "active" : "")" @onclick="() => ToggleDeviceFilter(result.DeviceHost, result.DeviceName ?? result.DeviceHost)" @onclick:stopPropagation data-tooltip="@(isDeviceFiltered ? "Clear device filter" : "Filter to this device")" data-tooltip-hover-only>
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                                            </button>
                                             @if (isLan)
                                             {
                                                 <a href="/client-dashboard?ip=@result.DeviceHost&tab=speed&range=30d" class="client-dashboard-link"
@@ -262,6 +274,9 @@
                                         else
                                         {
                                             <code>@result.DeviceHost</code>
+                                            <button class="device-filter-btn @(isDeviceFiltered ? "active" : "")" @onclick="() => ToggleDeviceFilter(result.DeviceHost, result.DeviceHost)" @onclick:stopPropagation data-tooltip="@(isDeviceFiltered ? "Clear device filter" : "Filter to this device")" data-tooltip-hover-only>
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                                            </button>
                                             @if (isLan)
                                             {
                                                 <a href="/client-dashboard?ip=@result.DeviceHost&tab=speed&range=30d" class="client-dashboard-link"
@@ -339,9 +354,9 @@
                 @if (historyTotalPages > 1)
                 {
                     <div class="pagination" id="history-pagination">
-                        <button class="btn btn-sm btn-secondary" disabled="@(historyPage <= 1)" @onclick="() => ChangePage(-1)">Prev</button>
-                        <span class="pagination-info">Page @historyPage of @historyTotalPages (@filteredHistory.Count@(string.IsNullOrEmpty(historySearchFilter) ? " total" : $" of {testHistory.Count}"))</span>
-                        <button class="btn btn-sm btn-secondary" disabled="@(historyPage >= historyTotalPages)" @onclick="() => ChangePage(1)">Next</button>
+                        <button class="btn btn-sm btn-secondary" disabled="@(historyPage <= 1)" @onclick="() => ChangePage(-1)"><span class="pag-arrow">←</span> Prev</button>
+                        <span class="pagination-info">Page @historyPage of @historyTotalPages (@filteredHistory.Count@(string.IsNullOrEmpty(historySearchFilter) && string.IsNullOrEmpty(deviceFilter) ? " total" : $" of {testHistory.Count}"))</span>
+                        <button class="btn btn-sm btn-secondary" disabled="@(historyPage >= historyTotalPages)" @onclick="() => ChangePage(1)">Next <span class="pag-arrow">→</span></button>
                     </div>
                 }
             }
@@ -649,20 +664,77 @@
         background: var(--bg-tertiary);
     }
 
-    .client-dashboard-link {
+    .client-dashboard-link,
+    .device-filter-btn {
         color: var(--text-muted);
         margin-left: 4px;
         vertical-align: middle;
         opacity: 0;
-        transition: opacity 0.15s;
+        transition: opacity 0.15s, color 0.15s;
     }
 
-    .history-row-clickable:hover .client-dashboard-link {
+    .client-dashboard-link {
+        margin-left: 8px;
+    }
+
+    .device-filter-btn {
+        background: none;
+        border: none;
+        cursor: pointer;
+        padding: 0;
+        line-height: 1;
+    }
+
+    .device-filter-btn.active {
+        opacity: 1;
+        color: var(--primary-color);
+    }
+
+    .history-row-clickable:hover .client-dashboard-link,
+    .history-row-clickable:hover .device-filter-btn {
         opacity: 1;
     }
 
-    .client-dashboard-link:hover {
+    .client-dashboard-link:hover,
+    .device-filter-btn:hover {
         color: var(--primary-color);
+    }
+
+    .device-filter-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        padding: 0.25rem 0.5rem;
+        background: rgba(5, 89, 201, 0.15);
+        border: 1px solid rgba(5, 89, 201, 0.3);
+        border-radius: 999px;
+        font-size: 0.8125rem;
+        color: var(--text-secondary);
+        white-space: nowrap;
+    }
+
+    .device-filter-pill svg {
+        flex-shrink: 0;
+        color: var(--primary-color);
+    }
+
+    .device-filter-clear {
+        background: none;
+        border: none;
+        color: var(--text-muted);
+        font-size: 1.125rem;
+        line-height: 1;
+        cursor: pointer;
+        padding: 0 0.125rem;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .device-filter-clear:hover {
+        color: var(--text-primary);
+        background: rgba(255, 255, 255, 0.1);
     }
 
     .history-row-expanded {
@@ -685,6 +757,10 @@
     }
 
     .history-search-row {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        flex-wrap: wrap;
         padding-top: 0.5rem;
         border-top: 1px solid var(--border-color);
     }
@@ -715,10 +791,23 @@
     // Search filter (uses shared SpeedTestFilterHelper for consistency with repository)
     private string historySearchFilter = "";
 
-    // Filtered results based on search filter
-    private List<Iperf3Result> filteredHistory => string.IsNullOrEmpty(historySearchFilter)
-        ? testHistory
-        : testHistory.Where(r => SpeedTestFilterHelper.MatchesFilter(r, historySearchFilter.ToLowerInvariant())).ToList();
+    // Device filter (set by clicking filter icon on a row)
+    private string deviceFilter = "";
+    private string deviceFilterName = "";
+
+    // Filtered results based on search filter and device filter
+    private List<Iperf3Result> filteredHistory
+    {
+        get
+        {
+            IEnumerable<Iperf3Result> results = testHistory;
+            if (!string.IsNullOrEmpty(deviceFilter))
+                results = results.Where(r => string.Equals(r.DeviceHost, deviceFilter, StringComparison.OrdinalIgnoreCase));
+            if (!string.IsNullOrEmpty(historySearchFilter))
+                results = results.Where(r => SpeedTestFilterHelper.MatchesFilter(r, historySearchFilter.ToLowerInvariant()));
+            return results.ToList();
+        }
+    }
 
     // Pagination
     private int historyPage = 1;
@@ -992,6 +1081,32 @@
 
     private void OnFilterChanged(string filter)
     {
+        historyPage = 1;
+        expandedHistoryId = null;
+        StateHasChanged();
+    }
+
+    private void ToggleDeviceFilter(string host, string displayName)
+    {
+        if (string.Equals(deviceFilter, host, StringComparison.OrdinalIgnoreCase))
+        {
+            deviceFilter = "";
+            deviceFilterName = "";
+        }
+        else
+        {
+            deviceFilter = host;
+            deviceFilterName = displayName;
+        }
+        historyPage = 1;
+        expandedHistoryId = null;
+        StateHasChanged();
+    }
+
+    private void ClearDeviceFilter()
+    {
+        deviceFilter = "";
+        deviceFilterName = "";
         historyPage = 1;
         expandedHistoryId = null;
         StateHasChanged();

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
@@ -98,6 +98,14 @@
                 <div class="header-title-row">
                     <h2 class="card-title">Test History</h2>
                     <div class="header-actions">
+                        @if (!string.IsNullOrEmpty(_deviceFilter))
+                        {
+                            <div class="device-filter-pill">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                                <span>Filtering to <strong>@_deviceFilterName</strong></span>
+                                <button class="device-filter-clear" @onclick="ClearDeviceFilter" type="button">×</button>
+                            </div>
+                        }
                         <button class="btn btn-sm btn-secondary" @onclick="LoadResults" disabled="@_loading">
                             @if (_loading)
                             {
@@ -119,7 +127,7 @@
                         <table class="data-table">
                             <thead>
                                 <tr>
-                                    <th>Time</th>
+                                    <th class="col-time">Time</th>
                                     <th>Device</th>
                                     <th class="hide-mobile">
                                         <span class="tooltip-wrapper tooltip-bottom">
@@ -155,15 +163,24 @@
                                         @onclick="@(() => ToggleExpand(result.Id))">
                                         <td>@result.TestTime.ToLocalTime().ToString("MMM dd HH:mm")</td>
                                         <td>
+                                            @{
+                                                var isDeviceFiltered = string.Equals(_deviceFilter, result.DeviceHost, StringComparison.OrdinalIgnoreCase);
+                                            }
                                             @if (!string.IsNullOrEmpty(result.DeviceName))
                                             {
                                                 <span>@result.DeviceName</span>
+                                                <button class="device-filter-btn @(isDeviceFiltered ? "active" : "")" @onclick="() => ToggleDeviceFilter(result.DeviceHost, result.DeviceName ?? result.DeviceHost)" @onclick:stopPropagation data-tooltip="@(isDeviceFiltered ? "Clear device filter" : "Filter to this device")" data-tooltip-hover-only>
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                                                </button>
                                                 <br />
                                                 <code class="text-muted">@result.DeviceHost</code>
                                             }
                                             else
                                             {
                                                 <code>@result.DeviceHost</code>
+                                                <button class="device-filter-btn @(isDeviceFiltered ? "active" : "")" @onclick="() => ToggleDeviceFilter(result.DeviceHost, result.DeviceHost)" @onclick:stopPropagation data-tooltip="@(isDeviceFiltered ? "Clear device filter" : "Filter to this device")" data-tooltip-hover-only>
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                                                </button>
                                             }
                                         </td>
                                         <td class="hide-mobile">
@@ -226,9 +243,9 @@
                     @if (_totalPages > 1)
                     {
                         <div class="pagination">
-                            <button class="btn btn-sm btn-secondary" disabled="@(_page <= 1)" @onclick="() => ChangePage(-1)">Prev</button>
-                            <span class="pagination-info">Page @_page of @_totalPages (@_results.Count total)</span>
-                            <button class="btn btn-sm btn-secondary" disabled="@(_page >= _totalPages)" @onclick="() => ChangePage(1)">Next</button>
+                            <button class="btn btn-sm btn-secondary" disabled="@(_page <= 1)" @onclick="() => ChangePage(-1)"><span class="pag-arrow">←</span> Prev</button>
+                            <span class="pagination-info">Page @_page of @_totalPages (@_filteredResults.Count@(string.IsNullOrEmpty(_deviceFilter) ? " total" : $" of {_results.Count}"))</span>
+                            <button class="btn btn-sm btn-secondary" disabled="@(_page >= _totalPages)" @onclick="() => ChangePage(1)">Next <span class="pag-arrow">→</span></button>
                         </div>
                     }
                 }
@@ -412,6 +429,76 @@
         flex-wrap: wrap;
         gap: 0.5rem;
     }
+
+    .header-actions {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+    }
+
+    .device-filter-btn {
+        color: var(--text-muted);
+        margin-left: 4px;
+        vertical-align: middle;
+        opacity: 0;
+        transition: opacity 0.15s, color 0.15s;
+        background: none;
+        border: none;
+        cursor: pointer;
+        padding: 0;
+        line-height: 1;
+    }
+
+    .device-filter-btn.active {
+        opacity: 1;
+        color: var(--primary-color);
+    }
+
+    .history-row-clickable:hover .device-filter-btn {
+        opacity: 1;
+    }
+
+    .device-filter-btn:hover {
+        color: var(--primary-color);
+    }
+
+    .device-filter-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        padding: 0.25rem 0.5rem;
+        background: rgba(5, 89, 201, 0.15);
+        border: 1px solid rgba(5, 89, 201, 0.3);
+        border-radius: 999px;
+        font-size: 0.8125rem;
+        color: var(--text-secondary);
+        white-space: nowrap;
+    }
+
+    .device-filter-pill svg {
+        flex-shrink: 0;
+        color: var(--primary-color);
+    }
+
+    .device-filter-clear {
+        background: none;
+        border: none;
+        color: var(--text-muted);
+        font-size: 1.125rem;
+        line-height: 1;
+        cursor: pointer;
+        padding: 0 0.125rem;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .device-filter-clear:hover {
+        color: var(--text-primary);
+        background: rgba(255, 255, 255, 0.1);
+    }
 </style>
 
 @code {
@@ -426,8 +513,16 @@
     private const int PageSize = 20;
     private System.Threading.Timer? _pollTimer;
 
-    private int _totalPages => Math.Max(1, (int)Math.Ceiling(_results.Count / (double)PageSize));
-    private IEnumerable<Iperf3Result> _pagedResults => _results.Skip((_page - 1) * PageSize).Take(PageSize);
+    // Device filter (set by clicking filter icon on a row)
+    private string _deviceFilter = "";
+    private string _deviceFilterName = "";
+
+    private List<Iperf3Result> _filteredResults => string.IsNullOrEmpty(_deviceFilter)
+        ? _results
+        : _results.Where(r => string.Equals(r.DeviceHost, _deviceFilter, StringComparison.OrdinalIgnoreCase)).ToList();
+
+    private int _totalPages => Math.Max(1, (int)Math.Ceiling(_filteredResults.Count / (double)PageSize));
+    private IEnumerable<Iperf3Result> _pagedResults => _filteredResults.Skip((_page - 1) * PageSize).Take(PageSize);
 
     protected override async Task OnInitializedAsync()
     {
@@ -498,6 +593,32 @@
     {
         await ClientSpeedTestService.UpdateNotesAsync(args.Id, args.Notes);
         await LoadResults();
+    }
+
+    private void ToggleDeviceFilter(string host, string displayName)
+    {
+        if (string.Equals(_deviceFilter, host, StringComparison.OrdinalIgnoreCase))
+        {
+            _deviceFilter = "";
+            _deviceFilterName = "";
+        }
+        else
+        {
+            _deviceFilter = host;
+            _deviceFilterName = displayName;
+        }
+        _page = 1;
+        _expandedId = 0;
+        StateHasChanged();
+    }
+
+    private void ClearDeviceFilter()
+    {
+        _deviceFilter = "";
+        _deviceFilterName = "";
+        _page = 1;
+        _expandedId = 0;
+        StateHasChanged();
     }
 
     public void Dispose()

--- a/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
@@ -722,6 +722,14 @@
                                            OnSearch="OnTableFilterChanged"
                                            ShowStatus="true"
                                            ResultCount="filteredHistory.Count" />
+                    @if (!string.IsNullOrEmpty(deviceFilter))
+                    {
+                        <div class="device-filter-pill">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                            <span>Filtering to <strong>@deviceFilterName</strong></span>
+                            <button class="device-filter-clear" @onclick="ClearDeviceFilter" type="button">×</button>
+                        </div>
+                    }
                 </div>
             }
         </div>
@@ -732,7 +740,7 @@
                 <table class="data-table">
                     <thead>
                         <tr>
-                            <th>Time</th>
+                            <th class="col-time">Time</th>
                             <th>Device</th>
                             <th class="hide-mobile">
                                 <span class="tooltip-wrapper tooltip-bottom">
@@ -779,10 +787,14 @@
                                 <td>
                                     @{
                                         var showDashLink = result.IsLocalLanClient();
+                                        var isDeviceFiltered = string.Equals(deviceFilter, result.DeviceHost, StringComparison.OrdinalIgnoreCase);
                                     }
                                     @if (!string.IsNullOrEmpty(result.DeviceName))
                                     {
                                         <span>@result.DeviceName</span>
+                                        <button class="device-filter-btn @(isDeviceFiltered ? "active" : "")" @onclick="() => ToggleDeviceFilter(result.DeviceHost, result.DeviceName ?? result.DeviceHost)" @onclick:stopPropagation data-tooltip="@(isDeviceFiltered ? "Clear device filter" : "Filter to this device")" data-tooltip-hover-only>
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                                        </button>
                                         @if (showDashLink)
                                         {
                                             <a href="/client-dashboard?ip=@result.DeviceHost&tab=speed&range=30d" class="client-dashboard-link"
@@ -794,6 +806,9 @@
                                     else
                                     {
                                         <code>@result.DeviceHost</code>
+                                        <button class="device-filter-btn @(isDeviceFiltered ? "active" : "")" @onclick="() => ToggleDeviceFilter(result.DeviceHost, result.DeviceHost)" @onclick:stopPropagation data-tooltip="@(isDeviceFiltered ? "Clear device filter" : "Filter to this device")" data-tooltip-hover-only>
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                                        </button>
                                         @if (showDashLink)
                                         {
                                             <a href="/client-dashboard?ip=@result.DeviceHost&tab=speed&range=30d" class="client-dashboard-link"
@@ -870,11 +885,11 @@
                 @if (historyTotalPages > 1)
                 {
                     <div class="pagination" id="history-pagination">
-                        <button class="btn btn-sm btn-secondary" disabled="@(historyPage <= 1)" @onclick="() => ChangePage(-1)">← Prev</button>
+                        <button class="btn btn-sm btn-secondary" disabled="@(historyPage <= 1)" @onclick="() => ChangePage(-1)"><span class="pag-arrow">←</span> Prev</button>
                         <span class="pagination-info">
-                            Page @historyPage of @historyTotalPages (@filteredHistory.Count@(string.IsNullOrEmpty(historySearchFilter) ? " total" : $" of {testHistory.Count}"))
+                            Page @historyPage of @historyTotalPages (@filteredHistory.Count@(string.IsNullOrEmpty(historySearchFilter) && string.IsNullOrEmpty(deviceFilter) ? " total" : $" of {testHistory.Count}"))
                         </span>
-                        <button class="btn btn-sm btn-secondary" disabled="@(historyPage >= historyTotalPages)" @onclick="() => ChangePage(1)">Next →</button>
+                        <button class="btn btn-sm btn-secondary" disabled="@(historyPage >= historyTotalPages)" @onclick="() => ChangePage(1)">Next <span class="pag-arrow">→</span></button>
                     </div>
                 }
             }
@@ -895,7 +910,7 @@
     </div>
 
     <!-- Test Locations Map -->
-    <SpeedTestMap Results="testHistory"
+    <SpeedTestMap Results="mapResults"
                   OnRefresh="LoadHistory"
                   OnResultClick="ScrollToResult"
                   ApMarkers="apMapMarkers"
@@ -1193,6 +1208,10 @@
     }
 
     .history-search-row {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        flex-wrap: wrap;
         padding-top: 0.5rem;
         border-top: 1px solid var(--border-color);
     }
@@ -1203,20 +1222,77 @@
         }
     }
 
-    .client-dashboard-link {
+    .client-dashboard-link,
+    .device-filter-btn {
         color: var(--text-muted);
         margin-left: 4px;
         vertical-align: middle;
         opacity: 0;
-        transition: opacity 0.15s;
+        transition: opacity 0.15s, color 0.15s;
     }
 
-    .history-row-clickable:hover .client-dashboard-link {
+    .client-dashboard-link {
+        margin-left: 8px;
+    }
+
+    .device-filter-btn {
+        background: none;
+        border: none;
+        cursor: pointer;
+        padding: 0;
+        line-height: 1;
+    }
+
+    .device-filter-btn.active {
+        opacity: 1;
+        color: var(--primary-color);
+    }
+
+    .history-row-clickable:hover .client-dashboard-link,
+    .history-row-clickable:hover .device-filter-btn {
         opacity: 1;
     }
 
-    .client-dashboard-link:hover {
+    .client-dashboard-link:hover,
+    .device-filter-btn:hover {
         color: var(--primary-color);
+    }
+
+    .device-filter-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        padding: 0.25rem 0.5rem;
+        background: rgba(5, 89, 201, 0.15);
+        border: 1px solid rgba(5, 89, 201, 0.3);
+        border-radius: 999px;
+        font-size: 0.8125rem;
+        color: var(--text-secondary);
+        white-space: nowrap;
+    }
+
+    .device-filter-pill svg {
+        flex-shrink: 0;
+        color: var(--primary-color);
+    }
+
+    .device-filter-clear {
+        background: none;
+        border: none;
+        color: var(--text-muted);
+        font-size: 1.125rem;
+        line-height: 1;
+        cursor: pointer;
+        padding: 0 0.125rem;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .device-filter-clear:hover {
+        color: var(--text-primary);
+        background: rgba(255, 255, 255, 0.1);
     }
 </style>
 
@@ -1231,11 +1307,12 @@
     private List<DeviceSshConfiguration> devices = new();
     private DeviceSshConfiguration editingDevice = new() { DeviceType = DeviceType.Server, Enabled = true };
     private List<Iperf3Result> testHistory = new();
+    private List<Iperf3Result> mapResults = new();
     private List<ApMapMarker> apMapMarkers = new();
     private Iperf3Result? currentResult;
     private bool sshConfigured = false;
 
-    // Pagination (uses filteredHistory which respects the map's search filter)
+    // Pagination
     private int historyPage = 1;
     private int historyPageSize = 10;
     private int historyTotalPages => (int)Math.Ceiling(filteredHistory.Count / (double)historyPageSize);
@@ -1271,10 +1348,23 @@
     // Search filter for table (uses shared SpeedTestFilterHelper for consistency with repository)
     private string historySearchFilter = "";
 
-    // Filtered history based on search filter
-    private List<Iperf3Result> filteredHistory => string.IsNullOrEmpty(historySearchFilter)
-        ? testHistory
-        : testHistory.Where(r => SpeedTestFilterHelper.MatchesFilter(r, historySearchFilter.ToLowerInvariant())).ToList();
+    // Device filter (set by clicking filter icon on a row)
+    private string deviceFilter = "";
+    private string deviceFilterName = "";
+
+    // Filtered history based on search filter and device filter
+    private List<Iperf3Result> filteredHistory
+    {
+        get
+        {
+            IEnumerable<Iperf3Result> results = testHistory;
+            if (!string.IsNullOrEmpty(deviceFilter))
+                results = results.Where(r => string.Equals(r.DeviceHost, deviceFilter, StringComparison.OrdinalIgnoreCase));
+            if (!string.IsNullOrEmpty(historySearchFilter))
+                results = results.Where(r => SpeedTestFilterHelper.MatchesFilter(r, historySearchFilter.ToLowerInvariant()));
+            return results.ToList();
+        }
+    }
 
     // Path analysis for historical results (calculated on demand)
     private Dictionary<int, PathAnalysisResult?> historyPathAnalysis = new();
@@ -1478,15 +1568,27 @@
     private async Task HandleSpeedTestTimeRangeChanged(int hours)
     {
         _speedTestTimeRangeHours = hours;
-        testHistory = await SpeedTestService.GetRecentResultsAsync(count: 0, hours: hours);
+        UpdateMapResults();
         StateHasChanged();
+    }
+
+    private void UpdateMapResults()
+    {
+        if (_speedTestTimeRangeHours <= 0)
+        {
+            mapResults = testHistory;
+            return;
+        }
+        var cutoff = DateTime.UtcNow.AddHours(-_speedTestTimeRangeHours);
+        mapResults = testHistory.Where(r => r.TestTime >= cutoff).ToList();
     }
 
     private async Task LoadHistory()
     {
         try
         {
-            testHistory = await SpeedTestService.GetRecentResultsAsync(count: 0, hours: _speedTestTimeRangeHours);
+            testHistory = await SpeedTestService.GetRecentResultsAsync(count: 0, hours: 0);
+            UpdateMapResults();
             historyPage = 1; // Reset to first page when loading fresh data
 
             // Only set currentResult on initial page load (when it's null)
@@ -2161,8 +2263,34 @@
     /// </summary>
     private void OnTableFilterChanged(string filter)
     {
-        historyPage = 1; // Reset to first page on filter change
-        expandedHistoryId = null; // Collapse any expanded row
+        historyPage = 1;
+        expandedHistoryId = null;
+        StateHasChanged();
+    }
+
+    private void ToggleDeviceFilter(string host, string displayName)
+    {
+        if (string.Equals(deviceFilter, host, StringComparison.OrdinalIgnoreCase))
+        {
+            deviceFilter = "";
+            deviceFilterName = "";
+        }
+        else
+        {
+            deviceFilter = host;
+            deviceFilterName = displayName;
+        }
+        historyPage = 1;
+        expandedHistoryId = null;
+        StateHasChanged();
+    }
+
+    private void ClearDeviceFilter()
+    {
+        deviceFilter = "";
+        deviceFilterName = "";
+        historyPage = 1;
+        expandedHistoryId = null;
         StateHasChanged();
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -372,7 +372,7 @@
                     <table class="data-table">
                         <thead>
                             <tr>
-                                <th>Time</th>
+                                <th class="col-time">Time</th>
                                 @if (_wanSeries.Count > 1)
                                 {
                                     <th>WAN</th>
@@ -541,11 +541,11 @@
                 @if (_historyTotalPages > 1)
                 {
                     <div class="pagination" id="wan-history-pagination">
-                        <button class="btn btn-sm btn-secondary" disabled="@(_historyPage <= 1)" @onclick="() => ChangePage(-1)">← Prev</button>
+                        <button class="btn btn-sm btn-secondary" disabled="@(_historyPage <= 1)" @onclick="() => ChangePage(-1)"><span class="pag-arrow">←</span> Prev</button>
                         <span class="pagination-info">
                             Page @_historyPage of @_historyTotalPages (@_filteredHistory.Count total)
                         </span>
-                        <button class="btn btn-sm btn-secondary" disabled="@(_historyPage >= _historyTotalPages)" @onclick="() => ChangePage(1)">Next →</button>
+                        <button class="btn btn-sm btn-secondary" disabled="@(_historyPage >= _historyTotalPages)" @onclick="() => ChangePage(1)">Next <span class="pag-arrow">→</span></button>
                     </div>
                 }
             }

--- a/src/NetworkOptimizer.Web/NetworkOptimizer.Web.csproj
+++ b/src/NetworkOptimizer.Web/NetworkOptimizer.Web.csproj
@@ -29,8 +29,8 @@
 
   <ItemGroup>
     <PackageReference Include="Blazor-ApexCharts" Version="6.1.1-ozarkconnect.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.7" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="SSH.NET" Version="2025.1.0" />

--- a/src/NetworkOptimizer.Web/Services/UwnSpeedTestService.cs
+++ b/src/NetworkOptimizer.Web/Services/UwnSpeedTestService.cs
@@ -231,7 +231,31 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase
             if (_connectionService.IsConnected)
             {
                 var networks = await _connectionService.GetNetworksAsync();
-                wanNetworks = networks.Where(n => n.IsWan && n.Enabled).ToList();
+
+                // Use device-level WAN interface detection to determine which WANs
+                // are actually active on the gateway. The network config's "enabled"
+                // field is unreliable - UniFi reports disabled WANs as enabled=true.
+                HashSet<string>? activeWanGroups = null;
+                using (var scope = _scopeFactory.CreateScope())
+                {
+                    var sqmService = scope.ServiceProvider.GetRequiredService<ISqmService>();
+                    var activeWans = await sqmService.GetWanInterfacesFromControllerAsync();
+                    if (activeWans.Count > 0)
+                    {
+                        activeWanGroups = new HashSet<string>(
+                            activeWans.Where(w => !string.IsNullOrEmpty(w.NetworkGroup))
+                                .Select(w => w.NetworkGroup!),
+                            StringComparer.OrdinalIgnoreCase);
+                    }
+                    else
+                    {
+                        Logger.LogWarning("No active WAN interfaces detected on gateway - falling back to network config filter");
+                    }
+                }
+
+                wanNetworks = networks.Where(n => n.IsWan && n.Enabled
+                    && (activeWanGroups == null || activeWanGroups.Contains(n.WanNetworkgroup ?? "WAN")))
+                    .ToList();
                 isMultiWan = wanNetworks.Count > 1;
             }
 
@@ -248,61 +272,30 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase
                 }
                 else
                 {
-                    // Fallback without conntrack
-                    if (wanNetworks!.Count == 2)
-                    {
-                        // If measured speed exceeds any single WAN's configured speed,
-                        // it must be using both connections
-                        var maxSingleDown = wanNetworks.Max(n => n.WanDownloadMbps ?? 0);
-                        var maxSingleUp = wanNetworks.Max(n => n.WanUploadMbps ?? 0);
+                    // Fallback: if measured speed exceeds 125% of any single WAN's
+                    // configured speed, assume multiple WANs are bonded. The 25% margin
+                    // accounts for ISP overprovisioning and burst headroom.
+                    var maxSingleDown = wanNetworks!.Max(n => n.WanDownloadMbps ?? 0);
+                    var maxSingleUp = wanNetworks.Max(n => n.WanUploadMbps ?? 0);
+                    const double fudgeFactor = 1.25;
 
-                        if (downloadMbps > maxSingleDown || uploadMbps > maxSingleUp)
-                        {
-                            // Speed exceeds any single WAN - must be both
-                            var groups = wanNetworks
-                                .Select(n => n.WanNetworkgroup ?? "WAN")
-                                .Distinct().OrderBy(g => g);
-                            result.WanNetworkGroup = string.Join("+", groups);
-                            var names = wanNetworks
-                                .Select(n => !string.IsNullOrEmpty(n.Name) ? n.Name : n.WanNetworkgroup ?? "WAN")
-                                .Distinct().OrderBy(n => n);
-                            result.WanName = string.Join(" + ", names);
-                        }
-                        else
-                        {
-                            // Speed fits within a single WAN - use best-match by WAN IP
-                            var (wanGroup, wanName) = await PathAnalyzer.IdentifyWanConnectionAsync(
-                                finalWanIp ?? "", downloadMbps, uploadMbps, cancellationToken);
-                            result.WanNetworkGroup = wanGroup;
-                            result.WanName = wanName;
-                        }
+                    if (downloadMbps > maxSingleDown * fudgeFactor || uploadMbps > maxSingleUp * fudgeFactor)
+                    {
+                        var groups = wanNetworks
+                            .Select(n => n.WanNetworkgroup ?? "WAN")
+                            .Distinct().OrderBy(g => g);
+                        result.WanNetworkGroup = string.Join("+", groups);
+                        var names = wanNetworks
+                            .Select(n => !string.IsNullOrEmpty(n.Name) ? n.Name : n.WanNetworkgroup ?? "WAN")
+                            .Distinct().OrderBy(n => n);
+                        result.WanName = string.Join(" + ", names);
                     }
                     else
                     {
-                        // 3+ WANs: same heuristic - check if speed exceeds any single WAN
-                        var maxSingleDown = wanNetworks.Max(n => n.WanDownloadMbps ?? 0);
-                        var maxSingleUp = wanNetworks.Max(n => n.WanUploadMbps ?? 0);
-
-                        if (downloadMbps > maxSingleDown || uploadMbps > maxSingleUp)
-                        {
-                            // Speed exceeds any single WAN - assume all
-                            var groups = wanNetworks
-                                .Select(n => n.WanNetworkgroup ?? "WAN")
-                                .Distinct().OrderBy(g => g);
-                            result.WanNetworkGroup = string.Join("+", groups);
-                            var names = wanNetworks
-                                .Select(n => !string.IsNullOrEmpty(n.Name) ? n.Name : n.WanNetworkgroup ?? "WAN")
-                                .Distinct().OrderBy(n => n);
-                            result.WanName = string.Join(" + ", names);
-                        }
-                        else
-                        {
-                            // Speed fits within a single WAN - try IP matching
-                            var (wanGroup, wanName) = await PathAnalyzer.IdentifyWanConnectionAsync(
-                                finalWanIp ?? "", downloadMbps, uploadMbps, cancellationToken);
-                            result.WanNetworkGroup = wanGroup;
-                            result.WanName = wanName;
-                        }
+                        var (wanGroup, wanName) = await PathAnalyzer.IdentifyWanConnectionAsync(
+                            finalWanIp ?? "", downloadMbps, uploadMbps, cancellationToken);
+                        result.WanNetworkGroup = wanGroup;
+                        result.WanName = wanName;
                     }
                 }
             }
@@ -364,7 +357,7 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase
             List<string> wanIfaceNames;
             using (var scope = _scopeFactory.CreateScope())
             {
-                var sqmService = scope.ServiceProvider.GetRequiredService<SqmService>();
+                var sqmService = scope.ServiceProvider.GetRequiredService<ISqmService>();
                 var wanInterfaces = await sqmService.GetWanInterfacesFromControllerAsync();
                 if (wanInterfaces.Count == 0)
                     return null;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1663,6 +1663,11 @@ a.stat-card-link:active {
     font-size: 0.8125rem;
 }
 
+.data-table .col-time {
+    width: 125px;
+    white-space: nowrap;
+}
+
 .data-table tr:not(.history-details-row):hover {
     background: var(--bg-hover);
 }
@@ -4519,6 +4524,10 @@ select.form-control {
         padding: 0.75rem 0.4rem;
     }
 
+    .data-table .col-time {
+        width: auto;
+    }
+
     td .btn {
         margin: 0 auto;
     }
@@ -5353,6 +5362,11 @@ a.path-hop.hop-clickable:hover {
 .pagination-info {
     color: var(--text-secondary);
     font-size: 0.875rem;
+}
+
+.pag-arrow {
+    position: relative;
+    top: -1px;
 }
 
 /* ============================================

--- a/src/NetworkOptimizer.WiFi/NetworkOptimizer.WiFi.csproj
+++ b/src/NetworkOptimizer.WiFi/NetworkOptimizer.WiFi.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
   </ItemGroup>
 
 </Project>

--- a/tests/NetworkOptimizer.Storage.Tests/NetworkOptimizer.Storage.Tests.csproj
+++ b/tests/NetworkOptimizer.Storage.Tests/NetworkOptimizer.Storage.Tests.csproj
@@ -20,8 +20,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/NetworkOptimizer.UniFi.Tests/NetworkOptimizer.UniFi.Tests.csproj
+++ b/tests/NetworkOptimizer.UniFi.Tests/NetworkOptimizer.UniFi.Tests.csproj
@@ -20,7 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
More fixes for WAN speed testing. See [v1.15.0 release notes](https://github.com/Ozark-Connect/NetworkOptimizer/releases/tag/v1.15.0) for what's new in v1.15.0+

## WAN Speed Test

- **Disabled WANs no longer attributed in speed tests** - The UniFi API reports disabled WAN networks as enabled, which caused speed tests to incorrectly tag results with both WANs (e.g., "Fiber Supplement + Internet 2") when only one was active. Now cross-references actual gateway device interfaces to determine which WANs are truly active.
- **Speed-based multi-WAN heuristic less trigger-happy** - Added 25% tolerance so ISP overprovisioning and burst headroom don't falsely trigger multi-WAN attribution.
- **Fixed WAN name showing as "WAN1"** - A DI registration mismatch caused WAN identification to silently fail on UWN speed tests, leaving the WAN name blank (displayed as "WAN1" in the UI).

## Speed Test History

- **Filter-to-device toggle** - Click the funnel icon next to any device name in speed test history tables to filter results to just that device. Works on LAN Speed Test, Client Speed Test, and Client WAN Speed Test pages.

## Fixes

- **Map no longer re-fetches when switching time range** - The speed test map now filters the already-loaded results client-side instead of re-querying the database.

## Security

- **NuGet package updates** - MailKit 4.15.1 -> 4.16.0 (moderate CVE), all Microsoft.* 10.0.0/10.0.1 -> 10.0.7 (resolves transitive System.Security.Cryptography.Xml high-severity CVEs).