### PR TITLE
Fix WAN speed test incorrectly attributing disabled WANs

### DIFF
--- a/src/NetworkOptimizer.Agents/NetworkOptimizer.Agents.csproj
+++ b/src/NetworkOptimizer.Agents/NetworkOptimizer.Agents.csproj
@@ -13,10 +13,10 @@
   <ItemGroup>
     <PackageReference Include="SSH.NET" Version="2025.1.0" />
     <PackageReference Include="Scriban" Version="7.0.6" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NetworkOptimizer.Alerts/NetworkOptimizer.Alerts.csproj
+++ b/src/NetworkOptimizer.Alerts/NetworkOptimizer.Alerts.csproj
@@ -11,11 +11,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MailKit" Version="4.15.1" />
+    <PackageReference Include="MailKit" Version="4.16.0" />
     <PackageReference Include="Scriban" Version="7.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NetworkOptimizer.Audit/NetworkOptimizer.Audit.csproj
+++ b/src/NetworkOptimizer.Audit/NetworkOptimizer.Audit.csproj
@@ -16,10 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
   </ItemGroup>
 
 </Project>

--- a/src/NetworkOptimizer.Diagnostics/NetworkOptimizer.Diagnostics.csproj
+++ b/src/NetworkOptimizer.Diagnostics/NetworkOptimizer.Diagnostics.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
   </ItemGroup>
 
 </Project>

--- a/src/NetworkOptimizer.Monitoring/NetworkOptimizer.Monitoring.csproj
+++ b/src/NetworkOptimizer.Monitoring/NetworkOptimizer.Monitoring.csproj
@@ -12,8 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="Lextm.SharpSnmpLib" Version="12.5.7" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
   </ItemGroup>
 
 </Project>

--- a/src/NetworkOptimizer.Storage/NetworkOptimizer.Storage.csproj
+++ b/src/NetworkOptimizer.Storage/NetworkOptimizer.Storage.csproj
@@ -15,12 +15,12 @@
 
   <ItemGroup>
     <PackageReference Include="InfluxDB.Client" Version="4.18.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
   </ItemGroup>
 
 </Project>

--- a/src/NetworkOptimizer.Threats/NetworkOptimizer.Threats.csproj
+++ b/src/NetworkOptimizer.Threats/NetworkOptimizer.Threats.csproj
@@ -14,10 +14,10 @@
 
   <ItemGroup>
     <PackageReference Include="MaxMind.GeoIP2" Version="5.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NetworkOptimizer.UniFi/NetworkOptimizer.UniFi.csproj
+++ b/src/NetworkOptimizer.UniFi/NetworkOptimizer.UniFi.csproj
@@ -15,10 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
     <PackageReference Include="Polly" Version="8.6.5" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
   </ItemGroup>

--- a/src/NetworkOptimizer.Web/NetworkOptimizer.Web.csproj
+++ b/src/NetworkOptimizer.Web/NetworkOptimizer.Web.csproj
@@ -29,8 +29,8 @@
 
   <ItemGroup>
     <PackageReference Include="Blazor-ApexCharts" Version="6.1.1-ozarkconnect.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.7" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="SSH.NET" Version="2025.1.0" />

--- a/src/NetworkOptimizer.Web/Services/UwnSpeedTestService.cs
+++ b/src/NetworkOptimizer.Web/Services/UwnSpeedTestService.cs
@@ -238,7 +238,7 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase
                 HashSet<string>? activeWanGroups = null;
                 using (var scope = _scopeFactory.CreateScope())
                 {
-                    var sqmService = scope.ServiceProvider.GetRequiredService<SqmService>();
+                    var sqmService = scope.ServiceProvider.GetRequiredService<ISqmService>();
                     var activeWans = await sqmService.GetWanInterfacesFromControllerAsync();
                     if (activeWans.Count > 0)
                     {
@@ -357,7 +357,7 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase
             List<string> wanIfaceNames;
             using (var scope = _scopeFactory.CreateScope())
             {
-                var sqmService = scope.ServiceProvider.GetRequiredService<SqmService>();
+                var sqmService = scope.ServiceProvider.GetRequiredService<ISqmService>();
                 var wanInterfaces = await sqmService.GetWanInterfacesFromControllerAsync();
                 if (wanInterfaces.Count == 0)
                     return null;

--- a/src/NetworkOptimizer.Web/Services/UwnSpeedTestService.cs
+++ b/src/NetworkOptimizer.Web/Services/UwnSpeedTestService.cs
@@ -231,7 +231,31 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase
             if (_connectionService.IsConnected)
             {
                 var networks = await _connectionService.GetNetworksAsync();
-                wanNetworks = networks.Where(n => n.IsWan && n.Enabled).ToList();
+
+                // Use device-level WAN interface detection to determine which WANs
+                // are actually active on the gateway. The network config's "enabled"
+                // field is unreliable - UniFi reports disabled WANs as enabled=true.
+                HashSet<string>? activeWanGroups = null;
+                using (var scope = _scopeFactory.CreateScope())
+                {
+                    var sqmService = scope.ServiceProvider.GetRequiredService<SqmService>();
+                    var activeWans = await sqmService.GetWanInterfacesFromControllerAsync();
+                    if (activeWans.Count > 0)
+                    {
+                        activeWanGroups = new HashSet<string>(
+                            activeWans.Where(w => !string.IsNullOrEmpty(w.NetworkGroup))
+                                .Select(w => w.NetworkGroup!),
+                            StringComparer.OrdinalIgnoreCase);
+                    }
+                    else
+                    {
+                        Logger.LogWarning("No active WAN interfaces detected on gateway - falling back to network config filter");
+                    }
+                }
+
+                wanNetworks = networks.Where(n => n.IsWan && n.Enabled
+                    && (activeWanGroups == null || activeWanGroups.Contains(n.WanNetworkgroup ?? "WAN")))
+                    .ToList();
                 isMultiWan = wanNetworks.Count > 1;
             }
 
@@ -248,61 +272,30 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase
                 }
                 else
                 {
-                    // Fallback without conntrack
-                    if (wanNetworks!.Count == 2)
-                    {
-                        // If measured speed exceeds any single WAN's configured speed,
-                        // it must be using both connections
-                        var maxSingleDown = wanNetworks.Max(n => n.WanDownloadMbps ?? 0);
-                        var maxSingleUp = wanNetworks.Max(n => n.WanUploadMbps ?? 0);
+                    // Fallback: if measured speed exceeds 125% of any single WAN's
+                    // configured speed, assume multiple WANs are bonded. The 25% margin
+                    // accounts for ISP overprovisioning and burst headroom.
+                    var maxSingleDown = wanNetworks!.Max(n => n.WanDownloadMbps ?? 0);
+                    var maxSingleUp = wanNetworks.Max(n => n.WanUploadMbps ?? 0);
+                    const double fudgeFactor = 1.25;
 
-                        if (downloadMbps > maxSingleDown || uploadMbps > maxSingleUp)
-                        {
-                            // Speed exceeds any single WAN - must be both
-                            var groups = wanNetworks
-                                .Select(n => n.WanNetworkgroup ?? "WAN")
-                                .Distinct().OrderBy(g => g);
-                            result.WanNetworkGroup = string.Join("+", groups);
-                            var names = wanNetworks
-                                .Select(n => !string.IsNullOrEmpty(n.Name) ? n.Name : n.WanNetworkgroup ?? "WAN")
-                                .Distinct().OrderBy(n => n);
-                            result.WanName = string.Join(" + ", names);
-                        }
-                        else
-                        {
-                            // Speed fits within a single WAN - use best-match by WAN IP
-                            var (wanGroup, wanName) = await PathAnalyzer.IdentifyWanConnectionAsync(
-                                finalWanIp ?? "", downloadMbps, uploadMbps, cancellationToken);
-                            result.WanNetworkGroup = wanGroup;
-                            result.WanName = wanName;
-                        }
+                    if (downloadMbps > maxSingleDown * fudgeFactor || uploadMbps > maxSingleUp * fudgeFactor)
+                    {
+                        var groups = wanNetworks
+                            .Select(n => n.WanNetworkgroup ?? "WAN")
+                            .Distinct().OrderBy(g => g);
+                        result.WanNetworkGroup = string.Join("+", groups);
+                        var names = wanNetworks
+                            .Select(n => !string.IsNullOrEmpty(n.Name) ? n.Name : n.WanNetworkgroup ?? "WAN")
+                            .Distinct().OrderBy(n => n);
+                        result.WanName = string.Join(" + ", names);
                     }
                     else
                     {
-                        // 3+ WANs: same heuristic - check if speed exceeds any single WAN
-                        var maxSingleDown = wanNetworks.Max(n => n.WanDownloadMbps ?? 0);
-                        var maxSingleUp = wanNetworks.Max(n => n.WanUploadMbps ?? 0);
-
-                        if (downloadMbps > maxSingleDown || uploadMbps > maxSingleUp)
-                        {
-                            // Speed exceeds any single WAN - assume all
-                            var groups = wanNetworks
-                                .Select(n => n.WanNetworkgroup ?? "WAN")
-                                .Distinct().OrderBy(g => g);
-                            result.WanNetworkGroup = string.Join("+", groups);
-                            var names = wanNetworks
-                                .Select(n => !string.IsNullOrEmpty(n.Name) ? n.Name : n.WanNetworkgroup ?? "WAN")
-                                .Distinct().OrderBy(n => n);
-                            result.WanName = string.Join(" + ", names);
-                        }
-                        else
-                        {
-                            // Speed fits within a single WAN - try IP matching
-                            var (wanGroup, wanName) = await PathAnalyzer.IdentifyWanConnectionAsync(
-                                finalWanIp ?? "", downloadMbps, uploadMbps, cancellationToken);
-                            result.WanNetworkGroup = wanGroup;
-                            result.WanName = wanName;
-                        }
+                        var (wanGroup, wanName) = await PathAnalyzer.IdentifyWanConnectionAsync(
+                            finalWanIp ?? "", downloadMbps, uploadMbps, cancellationToken);
+                        result.WanNetworkGroup = wanGroup;
+                        result.WanName = wanName;
                     }
                 }
             }

--- a/src/NetworkOptimizer.WiFi/NetworkOptimizer.WiFi.csproj
+++ b/src/NetworkOptimizer.WiFi/NetworkOptimizer.WiFi.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
   </ItemGroup>
 
 </Project>

--- a/tests/NetworkOptimizer.Storage.Tests/NetworkOptimizer.Storage.Tests.csproj
+++ b/tests/NetworkOptimizer.Storage.Tests/NetworkOptimizer.Storage.Tests.csproj
@@ -20,8 +20,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/NetworkOptimizer.UniFi.Tests/NetworkOptimizer.UniFi.Tests.csproj
+++ b/tests/NetworkOptimizer.UniFi.Tests/NetworkOptimizer.UniFi.Tests.csproj
@@ -20,7 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- **Disabled WANs included in multi-WAN detection** - UniFi API reports `enabled=true` for disabled WAN networks. Now cross-references actual gateway device interfaces (via `GetWanInterfacesFromControllerAsync`) to determine which WANs are truly active, filtering out disabled/disconnected WANs.
- **Speed-based multi-WAN heuristic too sensitive** - Added 25% fudge factor so ISP overprovisioning and burst headroom don't falsely trigger multi-WAN attribution. Also collapsed the duplicate 2-WAN / 3+-WAN fallback branches which had identical logic.
- **SqmService DI resolution failure** - `SqmService` is registered as `ISqmService` but was resolved by concrete type, causing `InvalidOperationException` that silently broke WAN identification for all UWN speed tests (WanName showed as "WAN1" in the UI).
- **NuGet package updates** - MailKit 4.15.1 -> 4.16.0 (moderate CVE), all Microsoft.* 10.0.0/10.0.1 -> 10.0.7 (resolves transitive System.Security.Cryptography.Xml high-severity CVEs).

## Test plan

- [x] Build with 0 warnings, 0 errors
- [x] All 4,212 tests pass
- [x] Deployed to NAS and Mac test sites
- [x] Fixed 15 historical Mac DB records incorrectly tagged as dual-WAN
- [x] Verify next scheduled WAN speed test on Mac shows "Fiber Supplement" (not "WAN1" or "Fiber Supplement + Internet 2")