### PR TITLE
Show CPU-bound disclaimer and fix bottleneck device attribution

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,7 @@
 - ✅ ~~Direction-aware bottleneck calculation~~ (done - `GetDirectionalEfficiency()` in PathAnalysisResult, separate TX/RX bottleneck in NetworkPathAnalyzer)
 - More gateway models in routing limits table as we gather data
 - Threshold tuning based on real-world data collection
+- **Consistent wireless bottleneck attribution across test types:** LAN client speed tests show the bottleneck relative to the AP (e.g., "[AP] Back Yard (wireless)") while WAN client speed tests show it relative to the client (e.g., "[Phone] TJ iPhone (wireless)"). This is because WAN client paths reverse hops and swap ingress/egress, which flips the perspective. The wireless link is the same physical connection - both descriptions are technically correct but inconsistent. Investigate unifying to always name the AP side, since that's what users can control. Relevant code: `CalculateWanClientPathAsync` hop reversal/swap and `CalculateBottleneck` wireless link attribution.
 
 ### ✅ ~~Scheduled LAN Speed Test~~ (done - Alerts & Scheduling feature)
 

--- a/src/NetworkOptimizer.UniFi/Models/NetworkHop.cs
+++ b/src/NetworkOptimizer.UniFi/Models/NetworkHop.cs
@@ -53,6 +53,9 @@ public class NetworkHop
     /// <summary>Link speed on ingress port (Mbps)</summary>
     public int IngressSpeedMbps { get; set; }
 
+    /// <summary>Device that owns the ingress port (null = this device)</summary>
+    public string? IngressPortDeviceName { get; set; }
+
     /// <summary>Port number where traffic exits this device</summary>
     public int? EgressPort { get; set; }
 
@@ -61,6 +64,9 @@ public class NetworkHop
 
     /// <summary>Link speed on egress port (Mbps)</summary>
     public int EgressSpeedMbps { get; set; }
+
+    /// <summary>Device that owns the egress port (null = this device)</summary>
+    public string? EgressPortDeviceName { get; set; }
 
     /// <summary>Whether this hop contains the path bottleneck</summary>
     public bool IsBottleneck { get; set; }

--- a/src/NetworkOptimizer.UniFi/Models/PathAnalysisResult.cs
+++ b/src/NetworkOptimizer.UniFi/Models/PathAnalysisResult.cs
@@ -87,15 +87,18 @@ public class PathAnalysisResult
             return;
         }
 
-        // AP tests are CPU-limited; anything above ~4.4 Gbps is considered good
-        const double ApGoodSpeedThreshold = 4400;
-        bool apPerformingWell = Path.TargetIsAccessPoint &&
-            (MeasuredFromDeviceMbps >= ApGoodSpeedThreshold || MeasuredToDeviceMbps >= ApGoodSpeedThreshold);
-
-        if (Path.TargetIsAccessPoint && apPerformingWell)
+        // AP/cellular modem tests are CPU-limited; if best direction is 25%+ below line rate,
+        // the device CPU is the bottleneck, not the network
+        bool isDeviceTarget = Path.TargetIsAccessPoint || Path.TargetIsCellularModem;
+        if (isDeviceTarget && Path.TheoreticalMaxMbps > 0)
         {
-            Insights.Add("AP speed test - results limited by AP CPU, not network");
-            return;
+            var bestMeasured = Math.Max(MeasuredFromDeviceMbps, MeasuredToDeviceMbps);
+            if (bestMeasured < Path.TheoreticalMaxMbps * 0.75)
+            {
+                var deviceType = Path.TargetIsAccessPoint ? "AP" : "device";
+                Insights.Add($"{deviceType} speed test - results limited by {deviceType} CPU, not network");
+                return;
+            }
         }
 
         // Wireless connection warning (client->AP or AP->AP, not AP->Switch)

--- a/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
+++ b/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
@@ -2788,12 +2788,13 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
         bool isBottleneckMeshBackhaul = false;
         bool isBottleneckClientWifi = false;
         // When bottleneck is on ingress, the port belongs to the upstream device, not the current hop.
-        // Track the upstream device name so the description says "port 3 of Switch-X" not "port 3 of AP-Y".
-        string? bottleneckDeviceNameOverride = null;
+        // Track which hop index had the ingress bottleneck so we can look up the adjacent device.
+        int bottleneckIngressHopIdx = -1;
 
-        NetworkHop? previousHop = null;
-        foreach (var hop in path.Hops)
+        for (int i = 0; i < path.Hops.Count; i++)
         {
+            var hop = path.Hops[i];
+
             // Check ingress - skip for WAN/VPN hops where Ingress represents download speed,
             // not a physical port. The UI bottleneck check uses EgressSpeedMbps consistently
             // (matching "to device" direction), so we only feed Egress into the min calculation
@@ -2812,7 +2813,7 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                     minSpeed = hop.IngressSpeedMbps;
                     bottleneckHop = hop;
                     bottleneckPort = GetPortDescription(hop.IngressPortName, hop.IngressPort, hop.IsWirelessIngress);
-                    bottleneckDeviceNameOverride = previousHop?.DeviceName;
+                    bottleneckIngressHopIdx = i;
                     // Determine wireless type: mesh backhaul vs client Wi-Fi
                     isBottleneckMeshBackhaul = hop.IsWirelessIngress &&
                         hop.IngressPortName?.Contains("mesh", StringComparison.OrdinalIgnoreCase) == true;
@@ -2829,11 +2830,10 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                 {
                     minSpeed = hop.EgressSpeedMbps;
                     bottleneckHop = hop;
-                    bottleneckDeviceNameOverride = null;
+                    bottleneckIngressHopIdx = -1;
                     // If this hop's egress feeds into a WirelessClient, it's a Wi-Fi link
-                    var hopIdx = path.Hops.IndexOf(hop);
-                    var nextIsWireless = hopIdx >= 0 && hopIdx + 1 < path.Hops.Count
-                        && path.Hops[hopIdx + 1].Type == HopType.WirelessClient;
+                    var nextIsWireless = i + 1 < path.Hops.Count
+                        && path.Hops[i + 1].Type == HopType.WirelessClient;
                     bottleneckPort = GetPortDescription(hop.EgressPortName, hop.EgressPort, hop.IsWirelessEgress || nextIsWireless);
                     // Determine wireless type: mesh backhaul vs client Wi-Fi
                     isBottleneckMeshBackhaul = hop.IsWirelessEgress &&
@@ -2841,8 +2841,6 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                     isBottleneckClientWifi = hop.IsWirelessEgress && !isBottleneckMeshBackhaul;
                 }
             }
-
-            previousHop = hop;
         }
 
         if (minSpeed == int.MaxValue)
@@ -2864,8 +2862,12 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
             // Only set description if there's a real bottleneck
             if (path.HasRealBottleneck)
             {
-                // Use upstream device name when bottleneck is on ingress (the port belongs to the upstream device)
-                var deviceName = bottleneckDeviceNameOverride ?? bottleneckHop.DeviceName;
+                // When bottleneck is on ingress, the port belongs to the upstream device.
+                // Hops are ordered target→source, so the upstream device is the next hop.
+                string? upstreamName = null;
+                if (bottleneckIngressHopIdx >= 0 && bottleneckIngressHopIdx + 1 < path.Hops.Count)
+                    upstreamName = path.Hops[bottleneckIngressHopIdx + 1].DeviceName;
+                var deviceName = upstreamName ?? bottleneckHop.DeviceName;
 
                 // Skip redundant port info when device name matches port (e.g., "WAN (WAN)")
                 var portSuffix = bottleneckPort?.Equals(deviceName, StringComparison.OrdinalIgnoreCase) == true

--- a/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
+++ b/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
@@ -2856,6 +2856,8 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                     var nextIsWireless = i + 1 < path.Hops.Count
                         && path.Hops[i + 1].Type == HopType.WirelessClient;
                     bottleneckPort = GetPortDescription(hop.EgressPortName, hop.EgressPort, hop.IsWirelessEgress || nextIsWireless);
+                    // TODO: Wireless bottleneck names the client on WAN paths but the AP on LAN paths
+                    // due to hop reversal in CalculateWanClientPathAsync. See TODO.md.
                     bottleneckPortDeviceName = hop.EgressPortDeviceName;
                     // Determine wireless type: mesh backhaul vs client Wi-Fi
                     isBottleneckMeshBackhaul = hop.IsWirelessEgress &&

--- a/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
+++ b/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
@@ -2787,7 +2787,11 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
         string? bottleneckPort = null;
         bool isBottleneckMeshBackhaul = false;
         bool isBottleneckClientWifi = false;
+        // When bottleneck is on ingress, the port belongs to the upstream device, not the current hop.
+        // Track the upstream device name so the description says "port 3 of Switch-X" not "port 3 of AP-Y".
+        string? bottleneckDeviceNameOverride = null;
 
+        NetworkHop? previousHop = null;
         foreach (var hop in path.Hops)
         {
             // Check ingress - skip for WAN/VPN hops where Ingress represents download speed,
@@ -2808,6 +2812,7 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                     minSpeed = hop.IngressSpeedMbps;
                     bottleneckHop = hop;
                     bottleneckPort = GetPortDescription(hop.IngressPortName, hop.IngressPort, hop.IsWirelessIngress);
+                    bottleneckDeviceNameOverride = previousHop?.DeviceName;
                     // Determine wireless type: mesh backhaul vs client Wi-Fi
                     isBottleneckMeshBackhaul = hop.IsWirelessIngress &&
                         hop.IngressPortName?.Contains("mesh", StringComparison.OrdinalIgnoreCase) == true;
@@ -2824,6 +2829,7 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                 {
                     minSpeed = hop.EgressSpeedMbps;
                     bottleneckHop = hop;
+                    bottleneckDeviceNameOverride = null;
                     // If this hop's egress feeds into a WirelessClient, it's a Wi-Fi link
                     var hopIdx = path.Hops.IndexOf(hop);
                     var nextIsWireless = hopIdx >= 0 && hopIdx + 1 < path.Hops.Count
@@ -2835,6 +2841,8 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                     isBottleneckClientWifi = hop.IsWirelessEgress && !isBottleneckMeshBackhaul;
                 }
             }
+
+            previousHop = hop;
         }
 
         if (minSpeed == int.MaxValue)
@@ -2856,20 +2864,23 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
             // Only set description if there's a real bottleneck
             if (path.HasRealBottleneck)
             {
+                // Use upstream device name when bottleneck is on ingress (the port belongs to the upstream device)
+                var deviceName = bottleneckDeviceNameOverride ?? bottleneckHop.DeviceName;
+
                 // Skip redundant port info when device name matches port (e.g., "WAN (WAN)")
-                var portSuffix = bottleneckPort?.Equals(bottleneckHop.DeviceName, StringComparison.OrdinalIgnoreCase) == true
+                var portSuffix = bottleneckPort?.Equals(deviceName, StringComparison.OrdinalIgnoreCase) == true
                     ? ""
                     : $" ({bottleneckPort})";
 
                 if (minSpeed < 1000)
                 {
-                    path.BottleneckDescription = $"{minSpeed} Mbps link at {bottleneckHop.DeviceName}{portSuffix}";
+                    path.BottleneckDescription = $"{minSpeed} Mbps link at {deviceName}{portSuffix}";
                 }
                 else
                 {
                     var gbps = minSpeed / 1000.0;
                     var gbpsStr = gbps % 1 == 0 ? $"{(int)gbps}" : $"{gbps:F1}";
-                    path.BottleneckDescription = $"{gbpsStr} Gbps link at {bottleneckHop.DeviceName}{portSuffix}";
+                    path.BottleneckDescription = $"{gbpsStr} Gbps link at {deviceName}{portSuffix}";
                 }
             }
         }

--- a/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
+++ b/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
@@ -809,6 +809,13 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                     deviceHop.EgressSpeedMbps = deviceHop.IngressSpeedMbps;
                 }
 
+                // Ingress/egress ports belong to the upstream device
+                if (!string.IsNullOrEmpty(currentMac) && deviceDict.TryGetValue(currentMac, out var uplinkDev))
+                {
+                    deviceHop.IngressPortDeviceName = uplinkDev.Name;
+                    deviceHop.EgressPortDeviceName = uplinkDev.Name;
+                }
+
                 hops.Add(deviceHop);
             }
 
@@ -882,6 +889,10 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                             hop.EgressSpeedMbps = GetPortSpeedFromRawDevices(rawDevices, device.Mac, device.LocalUplinkPort);
                         }
                         hop.EgressPortName = GetPortName(rawDevices, device.UplinkMac, device.UplinkPort);
+
+                        // Egress port is on the upstream device
+                        if (deviceDict.TryGetValue(device.UplinkMac, out var egressOwner))
+                            hop.EgressPortDeviceName = egressOwner.Name;
                     }
                 }
 
@@ -1044,6 +1055,7 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                     // Just swap the port numbers/names for display order consistency
                     (hop.IngressPort, hop.EgressPort) = (hop.EgressPort, hop.IngressPort);
                     (hop.IngressPortName, hop.EgressPortName) = (hop.EgressPortName, hop.IngressPortName);
+                    (hop.IngressPortDeviceName, hop.EgressPortDeviceName) = (hop.EgressPortDeviceName, hop.IngressPortDeviceName);
                 }
                 else
                 {
@@ -1053,6 +1065,7 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                     (hop.IngressSpeedMbps, hop.EgressSpeedMbps) = (hop.EgressSpeedMbps, hop.IngressSpeedMbps);
                     (hop.IsWirelessIngress, hop.IsWirelessEgress) = (hop.IsWirelessEgress, hop.IsWirelessIngress);
                     (hop.WirelessIngressBand, hop.WirelessEgressBand) = (hop.WirelessEgressBand, hop.WirelessIngressBand);
+                    (hop.IngressPortDeviceName, hop.EgressPortDeviceName) = (hop.EgressPortDeviceName, hop.IngressPortDeviceName);
                 }
             }
 
@@ -1731,6 +1744,13 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                 deviceHop.EgressSpeedMbps = deviceHop.IngressSpeedMbps;
             }
 
+            // Ingress/egress ports belong to the upstream device, not this target device
+            if (!string.IsNullOrEmpty(currentMac) && deviceDict.TryGetValue(currentMac, out var uplinkDevice))
+            {
+                deviceHop.IngressPortDeviceName = uplinkDevice.Name;
+                deviceHop.EgressPortDeviceName = uplinkDevice.Name;
+            }
+
             hops.Add(deviceHop);
         }
         else if (targetClient != null)
@@ -2086,6 +2106,10 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                             hop.EgressSpeedMbps = GetPortSpeedFromRawDevices(rawDevices, device.Mac, device.LocalUplinkPort);
                         }
                         hop.EgressPortName = GetPortName(rawDevices, device.UplinkMac, device.UplinkPort);
+
+                        // Egress port is on the upstream device
+                        if (deviceDict.TryGetValue(device.UplinkMac, out var egressOwner))
+                            hop.EgressPortDeviceName = egressOwner.Name;
                     }
                 }
 
@@ -2785,11 +2809,9 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
         int maxSpeed = 0;
         NetworkHop? bottleneckHop = null;
         string? bottleneckPort = null;
+        string? bottleneckPortDeviceName = null;
         bool isBottleneckMeshBackhaul = false;
         bool isBottleneckClientWifi = false;
-        // When bottleneck is on ingress, the port belongs to the upstream device, not the current hop.
-        // Track which hop index had the ingress bottleneck so we can look up the adjacent device.
-        int bottleneckIngressHopIdx = -1;
 
         for (int i = 0; i < path.Hops.Count; i++)
         {
@@ -2813,7 +2835,7 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                     minSpeed = hop.IngressSpeedMbps;
                     bottleneckHop = hop;
                     bottleneckPort = GetPortDescription(hop.IngressPortName, hop.IngressPort, hop.IsWirelessIngress);
-                    bottleneckIngressHopIdx = i;
+                    bottleneckPortDeviceName = hop.IngressPortDeviceName;
                     // Determine wireless type: mesh backhaul vs client Wi-Fi
                     isBottleneckMeshBackhaul = hop.IsWirelessIngress &&
                         hop.IngressPortName?.Contains("mesh", StringComparison.OrdinalIgnoreCase) == true;
@@ -2830,11 +2852,11 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                 {
                     minSpeed = hop.EgressSpeedMbps;
                     bottleneckHop = hop;
-                    bottleneckIngressHopIdx = -1;
                     // If this hop's egress feeds into a WirelessClient, it's a Wi-Fi link
                     var nextIsWireless = i + 1 < path.Hops.Count
                         && path.Hops[i + 1].Type == HopType.WirelessClient;
                     bottleneckPort = GetPortDescription(hop.EgressPortName, hop.EgressPort, hop.IsWirelessEgress || nextIsWireless);
+                    bottleneckPortDeviceName = hop.EgressPortDeviceName;
                     // Determine wireless type: mesh backhaul vs client Wi-Fi
                     isBottleneckMeshBackhaul = hop.IsWirelessEgress &&
                         hop.EgressPortName?.Contains("mesh", StringComparison.OrdinalIgnoreCase) == true;
@@ -2862,12 +2884,8 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
             // Only set description if there's a real bottleneck
             if (path.HasRealBottleneck)
             {
-                // When bottleneck is on ingress, the port belongs to the upstream device.
-                // Hops are ordered target→source, so the upstream device is the next hop.
-                string? upstreamName = null;
-                if (bottleneckIngressHopIdx >= 0 && bottleneckIngressHopIdx + 1 < path.Hops.Count)
-                    upstreamName = path.Hops[bottleneckIngressHopIdx + 1].DeviceName;
-                var deviceName = upstreamName ?? bottleneckHop.DeviceName;
+                // Use the device that owns the port if known, otherwise the hop's own device
+                var deviceName = bottleneckPortDeviceName ?? bottleneckHop.DeviceName;
 
                 // Skip redundant port info when device name matches port (e.g., "WAN (WAN)")
                 var portSuffix = bottleneckPort?.Equals(deviceName, StringComparison.OrdinalIgnoreCase) == true


### PR DESCRIPTION
## Summary

- **CPU disclaimer for device speed tests** - When iperf3 results to an AP or cellular modem are 25%+ below line rate, show the same "results limited by device CPU, not network" disclaimer already used for gateway tests. Replaces the old hardcoded 4.4 Gbps threshold that only triggered for high-end APs.

- **Fix bottleneck description naming wrong device** - The bottleneck description (e.g., "2.5 Gbps link at Switch Main (port 3)") was attributing the port to the wrong device. The target device hop's ingress port is looked up from the upstream switch's port table, but the description used the target device's name. Added `IngressPortDeviceName` / `EgressPortDeviceName` fields to track which device actually owns each port, set at hop construction time and swapped correctly during WAN client path reversal.

## Test plan

- [x] Run a LAN speed test to an AP where results are well below link speed - should show CPU disclaimer
- [x] Run a LAN speed test to an AP where results are near line rate - should NOT show CPU disclaimer
- [x] Gateway speed test still shows its own disclaimer unconditionally
- [x] Verify bottleneck description names the switch, not the AP (check DB JSON: `IngressPortDeviceName` / `EgressPortDeviceName` on hops)
- [x] Run a WAN client speed test with a LAN bottleneck - verify description names the correct device