### PR TITLE
Recognize IPv6 ULA addresses as local (#568)

### DIFF
--- a/src/NetworkOptimizer.Core/Helpers/NetworkUtilities.cs
+++ b/src/NetworkOptimizer.Core/Helpers/NetworkUtilities.cs
@@ -309,6 +309,15 @@ public static class NetworkUtilities
         if (ip.IsIPv6LinkLocal || IPAddress.IsLoopback(ip))
             return true;
 
+        // IPv6 Unique Local Address (fc00::/7, primarily fd00::/8 in practice)
+        if (ip.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            var v6Bytes = ip.GetAddressBytes();
+            if ((v6Bytes[0] & 0xFE) == 0xFC)
+                return true;
+            return false;
+        }
+
         // Only do byte checks for IPv4
         if (ip.AddressFamily != AddressFamily.InterNetwork)
             return false;

--- a/tests/NetworkOptimizer.Core.Tests/Helpers/NetworkUtilitiesTests.cs
+++ b/tests/NetworkOptimizer.Core.Tests/Helpers/NetworkUtilitiesTests.cs
@@ -240,6 +240,26 @@ public class NetworkUtilitiesTests
     }
 
     [Theory]
+    [InlineData("fd12:3456:789a::1", true)]   // IPv6 ULA (fd00::/8)
+    [InlineData("fd00::1", true)]              // IPv6 ULA minimum
+    [InlineData("fdff:ffff:ffff::1", true)]    // IPv6 ULA maximum
+    [InlineData("fc00::1", true)]              // IPv6 ULA (fc00::/8, reserved but valid)
+    [InlineData("fe80::1", true)]              // IPv6 link-local
+    [InlineData("::1", true)]                  // IPv6 loopback
+    public void IsPrivateIpAddress_PrivateIpv6_ReturnsTrue(string ip, bool expected)
+    {
+        NetworkUtilities.IsPrivateIpAddress(ip).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("2001:db8::1")]    // IPv6 documentation range
+    [InlineData("2607:f8b0::1")]   // IPv6 Google
+    public void IsPrivateIpAddress_PublicIpv6_ReturnsFalse(string ip)
+    {
+        NetworkUtilities.IsPrivateIpAddress(ip).Should().BeFalse();
+    }
+
+    [Theory]
     [InlineData("1.1.1.1")]       // Cloudflare
     [InlineData("8.8.8.8")]       // Google
     [InlineData("9.9.9.9")]       // Quad9


### PR DESCRIPTION
Fixes #568

## Summary

- **IPv6 ULA (fc00::/7) now recognized as private** - `IsPrivateIpAddress` returned false for all non-link-local IPv6, causing ULA addresses (fd00::/8) to be misclassified as public WAN IPs. Users with IPv6 ULA infrastructure saw their local hosts treated as external WAN targets in path analysis, geo enrichment attempted on local IPs, and third-party DNS detection skipping local IPv6 DNS servers.

## Test plan

- [x] Existing IPv4 private/public tests still pass
- [x] New IPv6 tests: ULA (fd00::/8, fc00::/8), link-local, loopback return true; global unicast returns false