### PR TITLE
Exclude UNAS from Protect camera classification (#561)

### DIFF
--- a/src/NetworkOptimizer.UniFi/Models/UniFiProtectDeviceResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiProtectDeviceResponse.cs
@@ -114,7 +114,7 @@ public class UniFiProtectDeviceResponse
     private static readonly string[] ExcludePatterns =
     [
         "AI Key", "SuperLink", "Gateway", "NVR", "UNVR", "Cloud Key",
-        "Sensor", "Chime", "Bridge", "Hub"
+        "Sensor", "Chime", "Bridge", "Hub", "UNAS"
     ];
 
     /// <summary>


### PR DESCRIPTION
Fixes #561

## Summary

- **UNAS no longer misidentified as Protect camera** - UNAS model names (UNAS-Pro, UNAS-Pro-4, UNAS-Pro-8, UNAS-2-B, etc.) contain "Pro" which matched the camera pattern list in `UniFiProtectDeviceResponse`. This caused them to be classified as security cameras, added to the Protect camera collection, and flagged for Security VLAN placement. Added "UNAS" to the exclude list - exclusions are checked before camera patterns, so all UNAS variants are now correctly skipped.

## Test plan

- [x] Users with UNAS devices should no longer see them flagged as cameras needing Security VLAN
- [x] Actual Protect cameras (G4 Pro, AI Pro, etc.) still correctly classified