### PR TITLE
v1.15.10

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,7 @@
 - ✅ ~~Direction-aware bottleneck calculation~~ (done - `GetDirectionalEfficiency()` in PathAnalysisResult, separate TX/RX bottleneck in NetworkPathAnalyzer)
 - More gateway models in routing limits table as we gather data
 - Threshold tuning based on real-world data collection
+- **Consistent wireless bottleneck attribution across test types:** LAN client speed tests show the bottleneck relative to the AP (e.g., "[AP] Back Yard (wireless)") while WAN client speed tests show it relative to the client (e.g., "[Phone] TJ iPhone (wireless)"). This is because WAN client paths reverse hops and swap ingress/egress, which flips the perspective. The wireless link is the same physical connection - both descriptions are technically correct but inconsistent. Investigate unifying to always name the AP side, since that's what users can control. Relevant code: `CalculateWanClientPathAsync` hop reversal/swap and `CalculateBottleneck` wireless link attribution.
 
 ### ✅ ~~Scheduled LAN Speed Test~~ (done - Alerts & Scheduling feature)
 

--- a/src/NetworkOptimizer.Core/Helpers/NetworkUtilities.cs
+++ b/src/NetworkOptimizer.Core/Helpers/NetworkUtilities.cs
@@ -309,6 +309,15 @@ public static class NetworkUtilities
         if (ip.IsIPv6LinkLocal || IPAddress.IsLoopback(ip))
             return true;
 
+        // IPv6 Unique Local Address (fc00::/7, primarily fd00::/8 in practice)
+        if (ip.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            var v6Bytes = ip.GetAddressBytes();
+            if ((v6Bytes[0] & 0xFE) == 0xFC)
+                return true;
+            return false;
+        }
+
         // Only do byte checks for IPv4
         if (ip.AddressFamily != AddressFamily.InterNetwork)
             return false;

--- a/src/NetworkOptimizer.UniFi/Models/NetworkHop.cs
+++ b/src/NetworkOptimizer.UniFi/Models/NetworkHop.cs
@@ -53,6 +53,9 @@ public class NetworkHop
     /// <summary>Link speed on ingress port (Mbps)</summary>
     public int IngressSpeedMbps { get; set; }
 
+    /// <summary>Device that owns the ingress port (null = this device)</summary>
+    public string? IngressPortDeviceName { get; set; }
+
     /// <summary>Port number where traffic exits this device</summary>
     public int? EgressPort { get; set; }
 
@@ -61,6 +64,9 @@ public class NetworkHop
 
     /// <summary>Link speed on egress port (Mbps)</summary>
     public int EgressSpeedMbps { get; set; }
+
+    /// <summary>Device that owns the egress port (null = this device)</summary>
+    public string? EgressPortDeviceName { get; set; }
 
     /// <summary>Whether this hop contains the path bottleneck</summary>
     public bool IsBottleneck { get; set; }

--- a/src/NetworkOptimizer.UniFi/Models/PathAnalysisResult.cs
+++ b/src/NetworkOptimizer.UniFi/Models/PathAnalysisResult.cs
@@ -87,15 +87,18 @@ public class PathAnalysisResult
             return;
         }
 
-        // AP tests are CPU-limited; anything above ~4.4 Gbps is considered good
-        const double ApGoodSpeedThreshold = 4400;
-        bool apPerformingWell = Path.TargetIsAccessPoint &&
-            (MeasuredFromDeviceMbps >= ApGoodSpeedThreshold || MeasuredToDeviceMbps >= ApGoodSpeedThreshold);
-
-        if (Path.TargetIsAccessPoint && apPerformingWell)
+        // AP/cellular modem tests are CPU-limited; if best direction is 25%+ below line rate,
+        // the device CPU is the bottleneck, not the network
+        bool isDeviceTarget = Path.TargetIsAccessPoint || Path.TargetIsCellularModem;
+        if (isDeviceTarget && Path.TheoreticalMaxMbps > 0)
         {
-            Insights.Add("AP speed test - results limited by AP CPU, not network");
-            return;
+            var bestMeasured = Math.Max(MeasuredFromDeviceMbps, MeasuredToDeviceMbps);
+            if (bestMeasured < Path.TheoreticalMaxMbps * 0.75)
+            {
+                var deviceType = Path.TargetIsAccessPoint ? "AP" : "device";
+                Insights.Add($"{deviceType} speed test - results limited by {deviceType} CPU, not network");
+                return;
+            }
         }
 
         // Wireless connection warning (client->AP or AP->AP, not AP->Switch)

--- a/src/NetworkOptimizer.UniFi/Models/UniFiProtectDeviceResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiProtectDeviceResponse.cs
@@ -114,7 +114,7 @@ public class UniFiProtectDeviceResponse
     private static readonly string[] ExcludePatterns =
     [
         "AI Key", "SuperLink", "Gateway", "NVR", "UNVR", "Cloud Key",
-        "Sensor", "Chime", "Bridge", "Hub"
+        "Sensor", "Chime", "Bridge", "Hub", "UNAS"
     ];
 
     /// <summary>

--- a/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
+++ b/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
@@ -809,6 +809,13 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                     deviceHop.EgressSpeedMbps = deviceHop.IngressSpeedMbps;
                 }
 
+                // Ingress/egress ports belong to the upstream device
+                if (!string.IsNullOrEmpty(currentMac) && deviceDict.TryGetValue(currentMac, out var uplinkDev))
+                {
+                    deviceHop.IngressPortDeviceName = uplinkDev.Name;
+                    deviceHop.EgressPortDeviceName = uplinkDev.Name;
+                }
+
                 hops.Add(deviceHop);
             }
 
@@ -882,6 +889,10 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                             hop.EgressSpeedMbps = GetPortSpeedFromRawDevices(rawDevices, device.Mac, device.LocalUplinkPort);
                         }
                         hop.EgressPortName = GetPortName(rawDevices, device.UplinkMac, device.UplinkPort);
+
+                        // Egress port is on the upstream device
+                        if (deviceDict.TryGetValue(device.UplinkMac, out var egressOwner))
+                            hop.EgressPortDeviceName = egressOwner.Name;
                     }
                 }
 
@@ -1044,6 +1055,7 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                     // Just swap the port numbers/names for display order consistency
                     (hop.IngressPort, hop.EgressPort) = (hop.EgressPort, hop.IngressPort);
                     (hop.IngressPortName, hop.EgressPortName) = (hop.EgressPortName, hop.IngressPortName);
+                    (hop.IngressPortDeviceName, hop.EgressPortDeviceName) = (hop.EgressPortDeviceName, hop.IngressPortDeviceName);
                 }
                 else
                 {
@@ -1053,6 +1065,7 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                     (hop.IngressSpeedMbps, hop.EgressSpeedMbps) = (hop.EgressSpeedMbps, hop.IngressSpeedMbps);
                     (hop.IsWirelessIngress, hop.IsWirelessEgress) = (hop.IsWirelessEgress, hop.IsWirelessIngress);
                     (hop.WirelessIngressBand, hop.WirelessEgressBand) = (hop.WirelessEgressBand, hop.WirelessIngressBand);
+                    (hop.IngressPortDeviceName, hop.EgressPortDeviceName) = (hop.EgressPortDeviceName, hop.IngressPortDeviceName);
                 }
             }
 
@@ -1731,6 +1744,13 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                 deviceHop.EgressSpeedMbps = deviceHop.IngressSpeedMbps;
             }
 
+            // Ingress/egress ports belong to the upstream device, not this target device
+            if (!string.IsNullOrEmpty(currentMac) && deviceDict.TryGetValue(currentMac, out var uplinkDevice))
+            {
+                deviceHop.IngressPortDeviceName = uplinkDevice.Name;
+                deviceHop.EgressPortDeviceName = uplinkDevice.Name;
+            }
+
             hops.Add(deviceHop);
         }
         else if (targetClient != null)
@@ -2086,6 +2106,10 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                             hop.EgressSpeedMbps = GetPortSpeedFromRawDevices(rawDevices, device.Mac, device.LocalUplinkPort);
                         }
                         hop.EgressPortName = GetPortName(rawDevices, device.UplinkMac, device.UplinkPort);
+
+                        // Egress port is on the upstream device
+                        if (deviceDict.TryGetValue(device.UplinkMac, out var egressOwner))
+                            hop.EgressPortDeviceName = egressOwner.Name;
                     }
                 }
 
@@ -2785,11 +2809,14 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
         int maxSpeed = 0;
         NetworkHop? bottleneckHop = null;
         string? bottleneckPort = null;
+        string? bottleneckPortDeviceName = null;
         bool isBottleneckMeshBackhaul = false;
         bool isBottleneckClientWifi = false;
 
-        foreach (var hop in path.Hops)
+        for (int i = 0; i < path.Hops.Count; i++)
         {
+            var hop = path.Hops[i];
+
             // Check ingress - skip for WAN/VPN hops where Ingress represents download speed,
             // not a physical port. The UI bottleneck check uses EgressSpeedMbps consistently
             // (matching "to device" direction), so we only feed Egress into the min calculation
@@ -2808,6 +2835,7 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                     minSpeed = hop.IngressSpeedMbps;
                     bottleneckHop = hop;
                     bottleneckPort = GetPortDescription(hop.IngressPortName, hop.IngressPort, hop.IsWirelessIngress);
+                    bottleneckPortDeviceName = hop.IngressPortDeviceName;
                     // Determine wireless type: mesh backhaul vs client Wi-Fi
                     isBottleneckMeshBackhaul = hop.IsWirelessIngress &&
                         hop.IngressPortName?.Contains("mesh", StringComparison.OrdinalIgnoreCase) == true;
@@ -2825,10 +2853,12 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                     minSpeed = hop.EgressSpeedMbps;
                     bottleneckHop = hop;
                     // If this hop's egress feeds into a WirelessClient, it's a Wi-Fi link
-                    var hopIdx = path.Hops.IndexOf(hop);
-                    var nextIsWireless = hopIdx >= 0 && hopIdx + 1 < path.Hops.Count
-                        && path.Hops[hopIdx + 1].Type == HopType.WirelessClient;
+                    var nextIsWireless = i + 1 < path.Hops.Count
+                        && path.Hops[i + 1].Type == HopType.WirelessClient;
                     bottleneckPort = GetPortDescription(hop.EgressPortName, hop.EgressPort, hop.IsWirelessEgress || nextIsWireless);
+                    // TODO: Wireless bottleneck names the client on WAN paths but the AP on LAN paths
+                    // due to hop reversal in CalculateWanClientPathAsync. See TODO.md.
+                    bottleneckPortDeviceName = hop.EgressPortDeviceName;
                     // Determine wireless type: mesh backhaul vs client Wi-Fi
                     isBottleneckMeshBackhaul = hop.IsWirelessEgress &&
                         hop.EgressPortName?.Contains("mesh", StringComparison.OrdinalIgnoreCase) == true;
@@ -2856,20 +2886,23 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
             // Only set description if there's a real bottleneck
             if (path.HasRealBottleneck)
             {
+                // Use the device that owns the port if known, otherwise the hop's own device
+                var deviceName = bottleneckPortDeviceName ?? bottleneckHop.DeviceName;
+
                 // Skip redundant port info when device name matches port (e.g., "WAN (WAN)")
-                var portSuffix = bottleneckPort?.Equals(bottleneckHop.DeviceName, StringComparison.OrdinalIgnoreCase) == true
+                var portSuffix = bottleneckPort?.Equals(deviceName, StringComparison.OrdinalIgnoreCase) == true
                     ? ""
                     : $" ({bottleneckPort})";
 
                 if (minSpeed < 1000)
                 {
-                    path.BottleneckDescription = $"{minSpeed} Mbps link at {bottleneckHop.DeviceName}{portSuffix}";
+                    path.BottleneckDescription = $"{minSpeed} Mbps link at {deviceName}{portSuffix}";
                 }
                 else
                 {
                     var gbps = minSpeed / 1000.0;
                     var gbpsStr = gbps % 1 == 0 ? $"{(int)gbps}" : $"{gbps:F1}";
-                    path.BottleneckDescription = $"{gbpsStr} Gbps link at {bottleneckHop.DeviceName}{portSuffix}";
+                    path.BottleneckDescription = $"{gbpsStr} Gbps link at {deviceName}{portSuffix}";
                 }
             }
         }

--- a/tests/NetworkOptimizer.Core.Tests/Helpers/NetworkUtilitiesTests.cs
+++ b/tests/NetworkOptimizer.Core.Tests/Helpers/NetworkUtilitiesTests.cs
@@ -240,6 +240,26 @@ public class NetworkUtilitiesTests
     }
 
     [Theory]
+    [InlineData("fd12:3456:789a::1", true)]   // IPv6 ULA (fd00::/8)
+    [InlineData("fd00::1", true)]              // IPv6 ULA minimum
+    [InlineData("fdff:ffff:ffff::1", true)]    // IPv6 ULA maximum
+    [InlineData("fc00::1", true)]              // IPv6 ULA (fc00::/8, reserved but valid)
+    [InlineData("fe80::1", true)]              // IPv6 link-local
+    [InlineData("::1", true)]                  // IPv6 loopback
+    public void IsPrivateIpAddress_PrivateIpv6_ReturnsTrue(string ip, bool expected)
+    {
+        NetworkUtilities.IsPrivateIpAddress(ip).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("2001:db8::1")]    // IPv6 documentation range
+    [InlineData("2607:f8b0::1")]   // IPv6 Google
+    public void IsPrivateIpAddress_PublicIpv6_ReturnsFalse(string ip)
+    {
+        NetworkUtilities.IsPrivateIpAddress(ip).Should().BeFalse();
+    }
+
+    [Theory]
     [InlineData("1.1.1.1")]       // Cloudflare
     [InlineData("8.8.8.8")]       // Google
     [InlineData("9.9.9.9")]       // Quad9

--- a/tests/NetworkOptimizer.UniFi.Tests/NetworkPathAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/NetworkPathAnalyzerTests.cs
@@ -375,13 +375,13 @@ public class NetworkPathAnalyzerTests
     [Fact]
     public void GenerateInsights_APTarget_PerformingWell_AddsAPInsight()
     {
-        // Arrange
-        var path = NetworkTestData.CreateWiredClientPath();
+        // Arrange - AP on 10G link, measuring 4500 Mbps (below 75% of 10G = CPU-bound)
+        var path = NetworkTestData.CreateWiredClientPath(linkSpeedMbps: 10000);
         path.TargetIsAccessPoint = true;
         var result = new PathAnalysisResult
         {
             Path = path,
-            MeasuredFromDeviceMbps = 4500, // Above 4400 Mbps threshold
+            MeasuredFromDeviceMbps = 4500,
             MeasuredToDeviceMbps = 4500
         };
         result.CalculateEfficiency();

--- a/tests/NetworkOptimizer.UniFi.Tests/PathAnalysisResultTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/PathAnalysisResultTests.cs
@@ -166,13 +166,14 @@ public class PathAnalysisResultTests
     [Fact]
     public void GenerateInsights_ApTestPerformingWell_NotesLimitedByCpu()
     {
-        // Arrange - AP test above 4400 Mbps threshold
+        // Arrange - AP on 10G link, measuring 4500 Mbps (below 75% of 10G = CPU-bound)
         var result = new PathAnalysisResult
         {
             Path = new NetworkPath
             {
                 TargetIsAccessPoint = true,
-                RealisticMaxMbps = 10000
+                TheoreticalMaxMbps = 10000,
+                RealisticMaxMbps = 9400
             },
             MeasuredFromDeviceMbps = 4500,
             MeasuredToDeviceMbps = 4500


### PR DESCRIPTION
## Summary

- **CPU-bound disclaimer for device speed tests** - When iperf3 results to an AP or cellular modem are 25%+ below line rate, show the "results limited by device CPU, not network" disclaimer. Replaces the old hardcoded 4.4 Gbps threshold that only triggered for high-end APs.
- **Fix bottleneck description naming wrong device** - The bottleneck description (e.g., "2.5 Gbps link at Switch Main (port 3)") was attributing the port to the target device instead of the switch it's connected to. Added port ownership tracking to hops so the correct device is always named.
- **IPv6 ULA addresses recognized as local** - `IsPrivateIpAddress` now correctly identifies IPv6 ULA (fc00::/7) as private, fixing path analysis, geo enrichment, DNS detection, and threat filtering for users with IPv6 ULA infrastructure.
- **UNAS no longer misidentified as Protect camera** - UNAS model names containing "Pro" were matching the camera pattern list, causing incorrect Security VLAN placement recommendations.