### PR TITLE
Flag per-port Flow Control overrides in Config Optimizer

### DIFF
--- a/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
+++ b/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
@@ -558,7 +558,7 @@ public class PerformanceAnalyzer
         var fcOffProfileIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (portProfiles != null)
         {
-            var fcOffProfiles = portProfiles.Where(p => p.FlowControlEnabled == false).ToList();
+            var fcOffProfiles = portProfiles.Where(p => !p.FlowControlEnabled).ToList();
             if (fcOffProfiles.Count > 0)
             {
                 _logger?.LogDebug("Found {Count} port profiles with Flow Control disabled", fcOffProfiles.Count);
@@ -596,7 +596,7 @@ public class PerformanceAnalyzer
             var affectedPorts = new List<string>();
             foreach (var port in device.PortTable)
             {
-                if (!port.Up || port.IsUplink)
+                if (!port.Up)
                     continue;
 
                 bool portFcOff;
@@ -606,7 +606,7 @@ public class PerformanceAnalyzer
                     profilesById.TryGetValue(port.PortConfId, out var profile))
                 {
                     // Port has a profile - check the profile's FC setting
-                    portFcOff = profile.FlowControlEnabled == false;
+                    portFcOff = !profile.FlowControlEnabled;
                     profileName = profile.Name;
                 }
                 else

--- a/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
+++ b/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
@@ -43,7 +43,8 @@ public class PerformanceAnalyzer
         JsonDocument? qosRulesData,
         JsonDocument? wanEnrichedData = null,
         bool runPerformanceChecks = true,
-        bool runCellularChecks = true)
+        bool runCellularChecks = true,
+        List<UniFiPortProfile>? portProfiles = null)
     {
         var issues = new List<PerformanceIssue>();
 
@@ -51,7 +52,7 @@ public class PerformanceAnalyzer
         {
             issues.AddRange(CheckHardwareAcceleration(devices, settingsData));
             issues.AddRange(CheckJumboFrames(devices, settingsData));
-            issues.AddRange(CheckFlowControl(devices, networks, clients, settingsData));
+            issues.AddRange(CheckFlowControl(devices, networks, clients, settingsData, portProfiles));
         }
 
         if (runCellularChecks)
@@ -260,7 +261,8 @@ public class PerformanceAnalyzer
         List<UniFiDeviceResponse> devices,
         List<UniFiNetworkConfig> networks,
         List<UniFiClientResponse> clients,
-        JsonDocument? settingsData)
+        JsonDocument? settingsData,
+        List<UniFiPortProfile>? portProfiles = null)
     {
         var issues = new List<PerformanceIssue>();
         var settings = GlobalSwitchSettings.FromSettingsJson(settingsData);
@@ -312,6 +314,9 @@ public class PerformanceAnalyzer
                     });
                 }
             }
+
+            // Check port profiles and per-port overrides
+            issues.AddRange(CheckFlowControlPortProfiles(devices, portProfiles, settings));
         }
         else
         {
@@ -528,6 +533,98 @@ public class PerformanceAnalyzer
                 Category = PerformanceCategory.CellularDataSavings,
                 DeviceName = gateway.Name
             });
+        }
+
+        return issues;
+    }
+
+    /// <summary>
+    /// When global Flow Control is ON, check for port profiles and individual switch ports
+    /// that have Flow Control explicitly disabled - creating inconsistency with the global setting.
+    /// </summary>
+    [VendorSpecific("UniFi", "Reads FlowControlEnabled from port profiles and portconf_id from switch port_table")]
+    internal List<PerformanceIssue> CheckFlowControlPortProfiles(
+        List<UniFiDeviceResponse> devices,
+        List<UniFiPortProfile>? portProfiles,
+        GlobalSwitchSettings? settings)
+    {
+        var issues = new List<PerformanceIssue>();
+        if (portProfiles == null || portProfiles.Count == 0)
+            return issues;
+
+        var profilesById = portProfiles.ToDictionary(p => p.Id, StringComparer.OrdinalIgnoreCase);
+
+        // Find profiles with FC explicitly disabled
+        var fcOffProfiles = portProfiles
+            .Where(p => p.FlowControlEnabled == false)
+            .ToList();
+
+        if (fcOffProfiles.Count == 0)
+            return issues;
+
+        _logger?.LogDebug("Found {Count} port profiles with Flow Control disabled", fcOffProfiles.Count);
+        var fcOffProfileIds = fcOffProfiles.Select(p => p.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        // Flag each profile with FC off
+        foreach (var profile in fcOffProfiles)
+        {
+            var profileName = HtmlEncode(profile.Name);
+            issues.Add(new PerformanceIssue
+            {
+                Title = $"Flow Control Disabled in Profile \"{profile.Name}\"",
+                Description = $"Flow Control is enabled globally, but the Ethernet Port Profile " +
+                    $"\"{profile.Name}\" has Flow Control disabled. Any port assigned to this profile " +
+                    "will not use Flow Control, overriding the global setting.",
+                Recommendation = $"Enable Flow Control in the \"{profileName}\" port profile, or remove the " +
+                    "Flow Control override so it inherits the global setting.",
+                Severity = PerformanceSeverity.Info,
+                Category = PerformanceCategory.Performance
+            });
+        }
+
+        // Find ports on each switch assigned to FC-off profiles
+        foreach (var device in devices)
+        {
+            if (device.PortTable == null || device.DeviceType == DeviceType.Gateway)
+                continue;
+
+            // Only check devices where FC would otherwise be on
+            bool deviceFcOn = settings?.GetEffectiveFlowControl(device) ?? false;
+            if (!deviceFcOn)
+                continue;
+
+            var affectedPorts = new List<string>();
+            foreach (var port in device.PortTable)
+            {
+                if (!port.Up || port.IsUplink || string.IsNullOrEmpty(port.PortConfId))
+                    continue;
+
+                if (fcOffProfileIds.Contains(port.PortConfId) &&
+                    profilesById.TryGetValue(port.PortConfId, out var profile))
+                {
+                    affectedPorts.Add($"{port.Name} (\"{profile.Name}\")");
+                }
+            }
+
+            if (affectedPorts.Count > 0)
+            {
+                var deviceName = HtmlEncode(device.Name);
+                var portList = string.Join(", ", affectedPorts);
+                issues.Add(new PerformanceIssue
+                {
+                    Title = $"Flow Control Overridden on {device.Name}",
+                    Description = $"Flow Control is enabled globally, but {affectedPorts.Count} active " +
+                        $"port(s) on {device.Name} have it disabled via their port profile: {portList}.",
+                    Recommendation = $"Update the port profile(s) to enable Flow Control, or assign " +
+                        $"a different profile to these ports on {deviceName}.",
+                    Severity = PerformanceSeverity.Info,
+                    Category = PerformanceCategory.Performance,
+                    DeviceName = device.Name
+                });
+
+                _logger?.LogDebug("Device {Name}: {Count} ports with FC overridden by profile: {Ports}",
+                    device.Name, affectedPorts.Count, portList);
+            }
         }
 
         return issues;

--- a/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
+++ b/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
@@ -542,47 +542,47 @@ public class PerformanceAnalyzer
     /// When global Flow Control is ON, check for port profiles and individual switch ports
     /// that have Flow Control explicitly disabled - creating inconsistency with the global setting.
     /// </summary>
-    [VendorSpecific("UniFi", "Reads FlowControlEnabled from port profiles and portconf_id from switch port_table")]
+    [VendorSpecific("UniFi", "Reads FlowControlEnabled from port profiles and flow_control_enabled from switch port_table")]
     internal List<PerformanceIssue> CheckFlowControlPortProfiles(
         List<UniFiDeviceResponse> devices,
         List<UniFiPortProfile>? portProfiles,
         GlobalSwitchSettings? settings)
     {
         var issues = new List<PerformanceIssue>();
-        if (portProfiles == null || portProfiles.Count == 0)
-            return issues;
 
-        var profilesById = portProfiles.ToDictionary(p => p.Id, StringComparer.OrdinalIgnoreCase);
+        // Build profile lookup if available
+        var profilesById = portProfiles?.ToDictionary(p => p.Id, StringComparer.OrdinalIgnoreCase)
+            ?? new Dictionary<string, UniFiPortProfile>(StringComparer.OrdinalIgnoreCase);
 
         // Find profiles with FC explicitly disabled
-        var fcOffProfiles = portProfiles
-            .Where(p => p.FlowControlEnabled == false)
-            .ToList();
-
-        if (fcOffProfiles.Count == 0)
-            return issues;
-
-        _logger?.LogDebug("Found {Count} port profiles with Flow Control disabled", fcOffProfiles.Count);
-        var fcOffProfileIds = fcOffProfiles.Select(p => p.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-        // Flag each profile with FC off
-        foreach (var profile in fcOffProfiles)
+        var fcOffProfileIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (portProfiles != null)
         {
-            var profileName = HtmlEncode(profile.Name);
-            issues.Add(new PerformanceIssue
+            var fcOffProfiles = portProfiles.Where(p => p.FlowControlEnabled == false).ToList();
+            if (fcOffProfiles.Count > 0)
             {
-                Title = $"Flow Control Disabled in Profile \"{profile.Name}\"",
-                Description = $"Flow Control is enabled globally, but the Ethernet Port Profile " +
-                    $"\"{profile.Name}\" has Flow Control disabled. Any port assigned to this profile " +
-                    "will not use Flow Control, overriding the global setting.",
-                Recommendation = $"Enable Flow Control in the \"{profileName}\" port profile, or remove the " +
-                    "Flow Control override so it inherits the global setting.",
-                Severity = PerformanceSeverity.Info,
-                Category = PerformanceCategory.Performance
-            });
+                _logger?.LogDebug("Found {Count} port profiles with Flow Control disabled", fcOffProfiles.Count);
+
+                foreach (var profile in fcOffProfiles)
+                {
+                    fcOffProfileIds.Add(profile.Id);
+                    var profileName = HtmlEncode(profile.Name);
+                    issues.Add(new PerformanceIssue
+                    {
+                        Title = $"Flow Control Disabled in Profile \"{profile.Name}\"",
+                        Description = $"Flow Control is enabled globally, but the Ethernet Port Profile " +
+                            $"\"{profile.Name}\" has Flow Control disabled. Any port assigned to this profile " +
+                            "will not use Flow Control, overriding the global setting.",
+                        Recommendation = $"Enable Flow Control in the \"{profileName}\" port profile, or remove the " +
+                            "Flow Control override so it inherits the global setting.",
+                        Severity = PerformanceSeverity.Info,
+                        Category = PerformanceCategory.Performance
+                    });
+                }
+            }
         }
 
-        // Find ports on each switch assigned to FC-off profiles
+        // Find ports on each switch with FC off (via port_table field or profile override)
         foreach (var device in devices)
         {
             if (device.PortTable == null || device.DeviceType == DeviceType.Gateway)
@@ -596,13 +596,30 @@ public class PerformanceAnalyzer
             var affectedPorts = new List<string>();
             foreach (var port in device.PortTable)
             {
-                if (!port.Up || port.IsUplink || string.IsNullOrEmpty(port.PortConfId))
+                if (!port.Up || port.IsUplink)
                     continue;
 
-                if (fcOffProfileIds.Contains(port.PortConfId) &&
+                bool portFcOff;
+                string? profileName = null;
+
+                if (!string.IsNullOrEmpty(port.PortConfId) &&
                     profilesById.TryGetValue(port.PortConfId, out var profile))
                 {
-                    affectedPorts.Add($"{port.Name} (\"{profile.Name}\")");
+                    // Port has a profile - check the profile's FC setting
+                    portFcOff = profile.FlowControlEnabled == false;
+                    profileName = profile.Name;
+                }
+                else
+                {
+                    // No profile - check the port's direct flow_control_enabled field
+                    portFcOff = port.FlowControlEnabled == false;
+                }
+
+                if (portFcOff)
+                {
+                    affectedPorts.Add(profileName != null
+                        ? $"{port.Name} (\"{profileName}\")"
+                        : port.Name);
                 }
             }
 
@@ -614,7 +631,7 @@ public class PerformanceAnalyzer
                 {
                     Title = $"Flow Control Overridden on {device.Name}",
                     Description = $"Flow Control is enabled globally, but {affectedPorts.Count} active " +
-                        $"port(s) on {device.Name} have it disabled via their port profile: {portList}.",
+                        $"port(s) on {device.Name} have it disabled: {portList}.",
                     Recommendation = $"Update the port profile(s) to enable Flow Control, or assign " +
                         $"a different profile to these ports on {deviceName}.",
                     Severity = PerformanceSeverity.Info,

--- a/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
+++ b/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
@@ -559,7 +559,7 @@ public class PerformanceAnalyzer
         if (portProfiles != null)
         {
             var fcOffProfiles = portProfiles
-                .Where(p => !p.FlowControlEnabled && p.Forward != "disabled")
+                .Where(p => p.FlowControlEnabled == false && p.Forward != "disabled")
                 .ToList();
             if (fcOffProfiles.Count > 0)
             {
@@ -609,12 +609,16 @@ public class PerformanceAnalyzer
                 {
                     if (profile.Forward == "disabled")
                         continue;
-                    portFcOff = !profile.FlowControlEnabled;
+
+                    // Profile takes precedence when it explicitly sets FC;
+                    // fall back to port's own field when profile doesn't set it
+                    portFcOff = profile.FlowControlEnabled.HasValue
+                        ? profile.FlowControlEnabled == false
+                        : port.FlowControlEnabled == false;
                     profileName = profile.Name;
                 }
                 else
                 {
-                    // No profile - check the port's direct flow_control_enabled field
                     portFcOff = port.FlowControlEnabled == false;
                 }
 

--- a/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
+++ b/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
@@ -555,7 +555,6 @@ public class PerformanceAnalyzer
             ?? new Dictionary<string, UniFiPortProfile>(StringComparer.OrdinalIgnoreCase);
 
         // Find profiles with FC explicitly disabled
-        var fcOffProfileIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (portProfiles != null)
         {
             var fcOffProfiles = portProfiles
@@ -567,7 +566,6 @@ public class PerformanceAnalyzer
 
                 foreach (var profile in fcOffProfiles)
                 {
-                    fcOffProfileIds.Add(profile.Id);
                     var profileName = HtmlEncode(profile.Name);
                     issues.Add(new PerformanceIssue
                     {
@@ -646,7 +644,7 @@ public class PerformanceAnalyzer
                     DeviceName = device.Name
                 });
 
-                _logger?.LogDebug("Device {Name}: {Count} ports with FC overridden by profile: {Ports}",
+                _logger?.LogDebug("Device {Name}: {Count} ports with FC disabled: {Ports}",
                     device.Name, affectedPorts.Count, portList);
             }
         }

--- a/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
+++ b/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
@@ -558,7 +558,9 @@ public class PerformanceAnalyzer
         var fcOffProfileIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (portProfiles != null)
         {
-            var fcOffProfiles = portProfiles.Where(p => !p.FlowControlEnabled).ToList();
+            var fcOffProfiles = portProfiles
+                .Where(p => !p.FlowControlEnabled && p.Forward != "disabled")
+                .ToList();
             if (fcOffProfiles.Count > 0)
             {
                 _logger?.LogDebug("Found {Count} port profiles with Flow Control disabled", fcOffProfiles.Count);
@@ -596,7 +598,7 @@ public class PerformanceAnalyzer
             var affectedPorts = new List<string>();
             foreach (var port in device.PortTable)
             {
-                if (!port.Up)
+                if (port.Forward == "disabled")
                     continue;
 
                 bool portFcOff;
@@ -605,7 +607,8 @@ public class PerformanceAnalyzer
                 if (!string.IsNullOrEmpty(port.PortConfId) &&
                     profilesById.TryGetValue(port.PortConfId, out var profile))
                 {
-                    // Port has a profile - check the profile's FC setting
+                    if (profile.Forward == "disabled")
+                        continue;
                     portFcOff = !profile.FlowControlEnabled;
                     profileName = profile.Name;
                 }
@@ -630,7 +633,7 @@ public class PerformanceAnalyzer
                 issues.Add(new PerformanceIssue
                 {
                     Title = $"Flow Control Overridden on {device.Name}",
-                    Description = $"Flow Control is enabled globally, but {affectedPorts.Count} active " +
+                    Description = $"Flow Control is enabled globally, but {affectedPorts.Count} " +
                         $"port(s) on {device.Name} have it disabled: {portList}.",
                     Recommendation = $"Update the port profile(s) to enable Flow Control, or assign " +
                         $"a different profile to these ports on {deviceName}.",

--- a/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
+++ b/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
@@ -575,8 +575,8 @@ public class PerformanceAnalyzer
                         Description = $"Flow Control is enabled globally, but the Ethernet Port Profile " +
                             $"\"{profile.Name}\" has Flow Control disabled. Any port assigned to this profile " +
                             "will not use Flow Control, overriding the global setting.",
-                        Recommendation = $"Enable Flow Control in the \"{profileName}\" port profile, or remove the " +
-                            "Flow Control override so it inherits the global setting.",
+                        Recommendation = $"If this isn't intentional, enable Flow Control in the " +
+                            $"\"{profileName}\" port profile or remove the override so it inherits the global setting.",
                         Severity = PerformanceSeverity.Info,
                         Category = PerformanceCategory.Performance
                     });
@@ -639,8 +639,8 @@ public class PerformanceAnalyzer
                     Title = $"Flow Control Overridden on {device.Name}",
                     Description = $"Flow Control is enabled globally, but {affectedPorts.Count} " +
                         $"port(s) on {device.Name} have it disabled: {portList}.",
-                    Recommendation = $"Update the port profile(s) to enable Flow Control, or assign " +
-                        $"a different profile to these ports on {deviceName}.",
+                    Recommendation = $"If this isn't intentional, enable Flow Control on these ports " +
+                        $"in UniFi Devices > {deviceName} > Port Manager.",
                     Severity = PerformanceSeverity.Info,
                     Category = PerformanceCategory.Performance,
                     DeviceName = device.Name

--- a/src/NetworkOptimizer.Diagnostics/DiagnosticsEngine.cs
+++ b/src/NetworkOptimizer.Diagnostics/DiagnosticsEngine.cs
@@ -189,7 +189,8 @@ public class DiagnosticsEngine
                 result.PerformanceIssues = _performanceAnalyzer.Analyze(
                     deviceList, networkList, clientList, settingsData, qosRulesData, wanEnrichedData,
                     runPerformanceChecks: options.RunPerformanceAnalyzer,
-                    runCellularChecks: options.RunCellularDataSavings);
+                    runCellularChecks: options.RunCellularDataSavings,
+                    portProfiles: profileList);
                 result.CellularWanDetected = _performanceAnalyzer.CellularWanDetected;
                 _logger?.LogDebug("Performance Analyzer found {Count} issues", result.PerformanceIssues.Count);
             }

--- a/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
@@ -475,6 +475,9 @@ public class SwitchPort
     [JsonPropertyName("native_networkconf_id")]
     public string? NativeNetworkConfId { get; set; }
 
+    [JsonPropertyName("flow_control_enabled")]
+    public bool? FlowControlEnabled { get; set; }
+
     /// <summary>
     /// Port profile ID if a port profile is assigned to this port.
     /// When set, the port profile settings override the port's direct settings.

--- a/src/NetworkOptimizer.UniFi/Models/UniFiPortProfile.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiPortProfile.cs
@@ -72,7 +72,8 @@ public class UniFiPortProfile
     public List<string>? ExcludedNetworkConfIds { get; set; }
 
     [JsonPropertyName("flowctrl_enabled")]
-    public bool? FlowControlEnabled { get; set; }
+    [JsonConverter(typeof(FlexibleBoolConverter))]
+    public bool FlowControlEnabled { get; set; }
 
     [JsonPropertyName("stormctrl_bcast_enabled")]
     public bool StormCtrlBcastEnabled { get; set; }

--- a/src/NetworkOptimizer.UniFi/Models/UniFiPortProfile.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiPortProfile.cs
@@ -71,7 +71,7 @@ public class UniFiPortProfile
     [JsonPropertyName("excluded_networkconf_ids")]
     public List<string>? ExcludedNetworkConfIds { get; set; }
 
-    [JsonPropertyName("flowctrl_enabled")]
+    [JsonPropertyName("flow_control_enabled")]
     [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool FlowControlEnabled { get; set; }
 

--- a/src/NetworkOptimizer.UniFi/Models/UniFiPortProfile.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiPortProfile.cs
@@ -71,6 +71,9 @@ public class UniFiPortProfile
     [JsonPropertyName("excluded_networkconf_ids")]
     public List<string>? ExcludedNetworkConfIds { get; set; }
 
+    [JsonPropertyName("flowctrl_enabled")]
+    public bool? FlowControlEnabled { get; set; }
+
     [JsonPropertyName("stormctrl_bcast_enabled")]
     public bool StormCtrlBcastEnabled { get; set; }
 

--- a/src/NetworkOptimizer.UniFi/Models/UniFiPortProfile.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiPortProfile.cs
@@ -72,8 +72,7 @@ public class UniFiPortProfile
     public List<string>? ExcludedNetworkConfIds { get; set; }
 
     [JsonPropertyName("flow_control_enabled")]
-    [JsonConverter(typeof(FlexibleBoolConverter))]
-    public bool FlowControlEnabled { get; set; }
+    public bool? FlowControlEnabled { get; set; }
 
     [JsonPropertyName("stormctrl_bcast_enabled")]
     public bool StormCtrlBcastEnabled { get; set; }

--- a/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PerformanceAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PerformanceAnalyzerTests.cs
@@ -1047,19 +1047,19 @@ public class PerformanceAnalyzerTests
     }
 
     [Fact]
-    public void CheckFlowControl_GlobalOn_ProfileWithFcNull_NoIssue()
+    public void CheckFlowControl_GlobalOn_ProfileWithFcDefault_FlagsProfile()
     {
         var devices = new List<UniFiDeviceResponse> { CreateSwitch("switch1", "Switch 1") };
         var settings = CreateSettings(flowCtrlEnabled: true);
         var profiles = new List<UniFiPortProfile>
         {
-            new() { Id = "profile1", Name = "Default Profile", FlowControlEnabled = null }
+            new() { Id = "profile1", Name = "Default Profile" }
         };
 
         var result = _analyzer.CheckFlowControl(
             devices, CreateWanNetwork(500), new List<UniFiClientResponse>(), settings, profiles);
 
-        result.Should().NotContain(i => i.Title.Contains("Profile"));
+        result.Should().Contain(i => i.Title.Contains("Profile") && i.Title.Contains("Default Profile"));
     }
 
     [Fact]
@@ -1151,7 +1151,7 @@ public class PerformanceAnalyzerTests
     }
 
     [Fact]
-    public void CheckFlowControl_GlobalOn_UplinkPortWithFcOff_SkipsUplink()
+    public void CheckFlowControl_GlobalOn_UplinkPortWithFcOff_FlagsUplink()
     {
         var device = CreateSwitch("switch1", "Switch 1");
         device.PortTable = new List<SwitchPort>
@@ -1164,7 +1164,7 @@ public class PerformanceAnalyzerTests
             new List<UniFiDeviceResponse> { device }, CreateWanNetwork(500),
             new List<UniFiClientResponse>(), settings, null);
 
-        result.Should().NotContain(i => i.Title.Contains("Overridden"));
+        result.Should().Contain(i => i.Title.Contains("Overridden"));
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PerformanceAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PerformanceAnalyzerTests.cs
@@ -1102,7 +1102,7 @@ public class PerformanceAnalyzerTests
         deviceIssue.Should().NotBeNull();
         deviceIssue!.Description.Should().Contain("Port 1");
         deviceIssue.Description.Should().NotContain("Port 2");
-        deviceIssue.Description.Should().Contain("1 active port");
+        deviceIssue.Description.Should().Contain("1 port");
         deviceIssue.DeviceName.Should().Be("Switch 1");
     }
 
@@ -1168,7 +1168,7 @@ public class PerformanceAnalyzerTests
     }
 
     [Fact]
-    public void CheckFlowControl_GlobalOn_DownPortWithFcOff_SkipsDownPort()
+    public void CheckFlowControl_GlobalOn_DownPortWithFcOff_StillFlags()
     {
         var device = CreateSwitch("switch1", "Switch 1");
         device.PortTable = new List<SwitchPort>
@@ -1181,7 +1181,7 @@ public class PerformanceAnalyzerTests
             new List<UniFiDeviceResponse> { device }, CreateWanNetwork(500),
             new List<UniFiClientResponse>(), settings, null);
 
-        result.Should().NotContain(i => i.Title.Contains("Overridden"));
+        result.Should().Contain(i => i.Title.Contains("Overridden"));
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PerformanceAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PerformanceAnalyzerTests.cs
@@ -1107,17 +1107,40 @@ public class PerformanceAnalyzerTests
     }
 
     [Fact]
-    public void CheckFlowControl_GlobalOn_UplinkPortWithFcOffProfile_SkipsUplink()
+    public void CheckFlowControl_GlobalOn_PortFcOffDirect_NoProfile_FlagsDevice()
     {
         var device = CreateSwitch("switch1", "Switch 1");
         device.PortTable = new List<SwitchPort>
         {
-            new() { PortIdx = 1, Name = "Uplink", Up = true, IsUplink = true, PortConfId = "profile1" }
+            new() { PortIdx = 1, Name = "Port 1", Up = true, IsUplink = false, FlowControlEnabled = false },
+            new() { PortIdx = 2, Name = "Port 2", Up = true, IsUplink = false, FlowControlEnabled = true }
+        };
+        var settings = CreateSettings(flowCtrlEnabled: true);
+
+        var result = _analyzer.CheckFlowControl(
+            new List<UniFiDeviceResponse> { device }, CreateWanNetwork(500),
+            new List<UniFiClientResponse>(), settings, null);
+
+        var deviceIssue = result.FirstOrDefault(i => i.Title.Contains("Overridden"));
+        deviceIssue.Should().NotBeNull();
+        deviceIssue!.Description.Should().Contain("Port 1");
+        deviceIssue.Description.Should().NotContain("Port 2");
+    }
+
+    [Fact]
+    public void CheckFlowControl_GlobalOn_PortHasProfile_UsesProfileFcNotPortFc()
+    {
+        var device = CreateSwitch("switch1", "Switch 1");
+        device.PortTable = new List<SwitchPort>
+        {
+            // Port's direct FC is false, but profile says true - profile wins
+            new() { PortIdx = 1, Name = "Port 1", Up = true, IsUplink = false,
+                     FlowControlEnabled = false, PortConfId = "profile1" }
         };
         var settings = CreateSettings(flowCtrlEnabled: true);
         var profiles = new List<UniFiPortProfile>
         {
-            new() { Id = "profile1", Name = "No FC Profile", FlowControlEnabled = false }
+            new() { Id = "profile1", Name = "FC On Profile", FlowControlEnabled = true }
         };
 
         var result = _analyzer.CheckFlowControl(
@@ -1128,47 +1151,56 @@ public class PerformanceAnalyzerTests
     }
 
     [Fact]
-    public void CheckFlowControl_GlobalOn_DownPortWithFcOffProfile_SkipsDownPort()
+    public void CheckFlowControl_GlobalOn_UplinkPortWithFcOff_SkipsUplink()
     {
         var device = CreateSwitch("switch1", "Switch 1");
         device.PortTable = new List<SwitchPort>
         {
-            new() { PortIdx = 1, Name = "Port 1", Up = false, IsUplink = false, PortConfId = "profile1" }
+            new() { PortIdx = 1, Name = "Uplink", Up = true, IsUplink = true, FlowControlEnabled = false }
         };
         var settings = CreateSettings(flowCtrlEnabled: true);
-        var profiles = new List<UniFiPortProfile>
-        {
-            new() { Id = "profile1", Name = "No FC Profile", FlowControlEnabled = false }
-        };
 
         var result = _analyzer.CheckFlowControl(
             new List<UniFiDeviceResponse> { device }, CreateWanNetwork(500),
-            new List<UniFiClientResponse>(), settings, profiles);
+            new List<UniFiClientResponse>(), settings, null);
 
         result.Should().NotContain(i => i.Title.Contains("Overridden"));
     }
 
     [Fact]
-    public void CheckFlowControl_GlobalOn_ExcludedDeviceFcOff_SkipsPortProfileCheck()
+    public void CheckFlowControl_GlobalOn_DownPortWithFcOff_SkipsDownPort()
+    {
+        var device = CreateSwitch("switch1", "Switch 1");
+        device.PortTable = new List<SwitchPort>
+        {
+            new() { PortIdx = 1, Name = "Port 1", Up = false, IsUplink = false, FlowControlEnabled = false }
+        };
+        var settings = CreateSettings(flowCtrlEnabled: true);
+
+        var result = _analyzer.CheckFlowControl(
+            new List<UniFiDeviceResponse> { device }, CreateWanNetwork(500),
+            new List<UniFiClientResponse>(), settings, null);
+
+        result.Should().NotContain(i => i.Title.Contains("Overridden"));
+    }
+
+    [Fact]
+    public void CheckFlowControl_GlobalOn_ExcludedDeviceFcOff_SkipsPortCheck()
     {
         var device = CreateSwitch("switch1", "Switch 1");
         device.Mac = "aa:bb:cc:00:00:01";
         device.FlowControlEnabled = false;
         device.PortTable = new List<SwitchPort>
         {
-            new() { PortIdx = 1, Name = "Port 1", Up = true, IsUplink = false, PortConfId = "profile1" }
+            new() { PortIdx = 1, Name = "Port 1", Up = true, IsUplink = false, FlowControlEnabled = false }
         };
         var settings = CreateSettings(flowCtrlEnabled: true, exclusions: new[] { "aa:bb:cc:00:00:01" });
-        var profiles = new List<UniFiPortProfile>
-        {
-            new() { Id = "profile1", Name = "No FC Profile", FlowControlEnabled = false }
-        };
 
         var result = _analyzer.CheckFlowControl(
             new List<UniFiDeviceResponse> { device }, CreateWanNetwork(500),
-            new List<UniFiClientResponse>(), settings, profiles);
+            new List<UniFiClientResponse>(), settings, null);
 
-        // Device-level mismatch IS flagged, but port-level override is not
+        // Device-level mismatch IS flagged, but port-level is not
         // because the device itself already has FC off
         result.Should().NotContain(i => i.Title.Contains("Overridden"));
     }

--- a/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PerformanceAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PerformanceAnalyzerTests.cs
@@ -1047,19 +1047,19 @@ public class PerformanceAnalyzerTests
     }
 
     [Fact]
-    public void CheckFlowControl_GlobalOn_ProfileWithFcDefault_FlagsProfile()
+    public void CheckFlowControl_GlobalOn_ProfileWithFcNull_NoIssue()
     {
         var devices = new List<UniFiDeviceResponse> { CreateSwitch("switch1", "Switch 1") };
         var settings = CreateSettings(flowCtrlEnabled: true);
         var profiles = new List<UniFiPortProfile>
         {
-            new() { Id = "profile1", Name = "Default Profile" }
+            new() { Id = "profile1", Name = "Default Profile", FlowControlEnabled = null }
         };
 
         var result = _analyzer.CheckFlowControl(
             devices, CreateWanNetwork(500), new List<UniFiClientResponse>(), settings, profiles);
 
-        result.Should().Contain(i => i.Title.Contains("Profile") && i.Title.Contains("Default Profile"));
+        result.Should().NotContain(i => i.Title.Contains("Profile"));
     }
 
     [Fact]
@@ -1128,26 +1128,26 @@ public class PerformanceAnalyzerTests
     }
 
     [Fact]
-    public void CheckFlowControl_GlobalOn_PortHasProfile_UsesProfileFcNotPortFc()
+    public void CheckFlowControl_GlobalOn_PortFcOff_ProfileFcNull_StillFlags()
     {
         var device = CreateSwitch("switch1", "Switch 1");
         device.PortTable = new List<SwitchPort>
         {
-            // Port's direct FC is false, but profile says true - profile wins
+            // Port FC is off, profile doesn't set FC (null) - port's value flags it
             new() { PortIdx = 1, Name = "Port 1", Up = true, IsUplink = false,
                      FlowControlEnabled = false, PortConfId = "profile1" }
         };
         var settings = CreateSettings(flowCtrlEnabled: true);
         var profiles = new List<UniFiPortProfile>
         {
-            new() { Id = "profile1", Name = "FC On Profile", FlowControlEnabled = true }
+            new() { Id = "profile1", Name = "Some Profile", FlowControlEnabled = null }
         };
 
         var result = _analyzer.CheckFlowControl(
             new List<UniFiDeviceResponse> { device }, CreateWanNetwork(500),
             new List<UniFiClientResponse>(), settings, profiles);
 
-        result.Should().NotContain(i => i.Title.Contains("Overridden"));
+        result.Should().Contain(i => i.Title.Contains("Overridden"));
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PerformanceAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PerformanceAnalyzerTests.cs
@@ -1012,6 +1012,200 @@ public class PerformanceAnalyzerTests
         result.Should().BeEmpty();
     }
 
+    [Fact]
+    public void CheckFlowControl_GlobalOn_ProfileWithFcOff_FlagsProfile()
+    {
+        var devices = new List<UniFiDeviceResponse> { CreateSwitch("switch1", "Switch 1") };
+        var settings = CreateSettings(flowCtrlEnabled: true);
+        var profiles = new List<UniFiPortProfile>
+        {
+            new() { Id = "profile1", Name = "Custom Profile", FlowControlEnabled = false }
+        };
+
+        var result = _analyzer.CheckFlowControl(
+            devices, CreateWanNetwork(500), new List<UniFiClientResponse>(), settings, profiles);
+
+        result.Should().Contain(i => i.Title.Contains("Profile") && i.Title.Contains("Custom Profile"));
+        var profileIssue = result.First(i => i.Title.Contains("Profile"));
+        profileIssue.Severity.Should().Be(PerformanceSeverity.Info);
+    }
+
+    [Fact]
+    public void CheckFlowControl_GlobalOn_ProfileWithFcOn_NoIssue()
+    {
+        var devices = new List<UniFiDeviceResponse> { CreateSwitch("switch1", "Switch 1") };
+        var settings = CreateSettings(flowCtrlEnabled: true);
+        var profiles = new List<UniFiPortProfile>
+        {
+            new() { Id = "profile1", Name = "Good Profile", FlowControlEnabled = true }
+        };
+
+        var result = _analyzer.CheckFlowControl(
+            devices, CreateWanNetwork(500), new List<UniFiClientResponse>(), settings, profiles);
+
+        result.Should().NotContain(i => i.Title.Contains("Profile"));
+    }
+
+    [Fact]
+    public void CheckFlowControl_GlobalOn_ProfileWithFcNull_NoIssue()
+    {
+        var devices = new List<UniFiDeviceResponse> { CreateSwitch("switch1", "Switch 1") };
+        var settings = CreateSettings(flowCtrlEnabled: true);
+        var profiles = new List<UniFiPortProfile>
+        {
+            new() { Id = "profile1", Name = "Default Profile", FlowControlEnabled = null }
+        };
+
+        var result = _analyzer.CheckFlowControl(
+            devices, CreateWanNetwork(500), new List<UniFiClientResponse>(), settings, profiles);
+
+        result.Should().NotContain(i => i.Title.Contains("Profile"));
+    }
+
+    [Fact]
+    public void CheckFlowControl_GlobalOff_ProfileWithFcOff_NoProfileIssue()
+    {
+        var devices = new List<UniFiDeviceResponse> { CreateSwitch("switch1", "Switch 1") };
+        var settings = CreateSettings(flowCtrlEnabled: false);
+        var profiles = new List<UniFiPortProfile>
+        {
+            new() { Id = "profile1", Name = "Custom Profile", FlowControlEnabled = false }
+        };
+
+        var result = _analyzer.CheckFlowControl(
+            devices, CreateWanNetwork(500), new List<UniFiClientResponse>(), settings, profiles);
+
+        result.Should().NotContain(i => i.Title.Contains("Profile"));
+    }
+
+    [Fact]
+    public void CheckFlowControl_GlobalOn_PortWithFcOffProfile_FlagsDevice()
+    {
+        var device = CreateSwitch("switch1", "Switch 1");
+        device.PortTable = new List<SwitchPort>
+        {
+            new() { PortIdx = 1, Name = "Port 1", Up = true, IsUplink = false, PortConfId = "profile1" },
+            new() { PortIdx = 2, Name = "Port 2", Up = true, IsUplink = false, PortConfId = "profile2" }
+        };
+        var settings = CreateSettings(flowCtrlEnabled: true);
+        var profiles = new List<UniFiPortProfile>
+        {
+            new() { Id = "profile1", Name = "No FC Profile", FlowControlEnabled = false },
+            new() { Id = "profile2", Name = "Good Profile", FlowControlEnabled = true }
+        };
+
+        var result = _analyzer.CheckFlowControl(
+            new List<UniFiDeviceResponse> { device }, CreateWanNetwork(500),
+            new List<UniFiClientResponse>(), settings, profiles);
+
+        var deviceIssue = result.FirstOrDefault(i => i.Title.Contains("Overridden"));
+        deviceIssue.Should().NotBeNull();
+        deviceIssue!.Description.Should().Contain("Port 1");
+        deviceIssue.Description.Should().NotContain("Port 2");
+        deviceIssue.Description.Should().Contain("1 active port");
+        deviceIssue.DeviceName.Should().Be("Switch 1");
+    }
+
+    [Fact]
+    public void CheckFlowControl_GlobalOn_UplinkPortWithFcOffProfile_SkipsUplink()
+    {
+        var device = CreateSwitch("switch1", "Switch 1");
+        device.PortTable = new List<SwitchPort>
+        {
+            new() { PortIdx = 1, Name = "Uplink", Up = true, IsUplink = true, PortConfId = "profile1" }
+        };
+        var settings = CreateSettings(flowCtrlEnabled: true);
+        var profiles = new List<UniFiPortProfile>
+        {
+            new() { Id = "profile1", Name = "No FC Profile", FlowControlEnabled = false }
+        };
+
+        var result = _analyzer.CheckFlowControl(
+            new List<UniFiDeviceResponse> { device }, CreateWanNetwork(500),
+            new List<UniFiClientResponse>(), settings, profiles);
+
+        result.Should().NotContain(i => i.Title.Contains("Overridden"));
+    }
+
+    [Fact]
+    public void CheckFlowControl_GlobalOn_DownPortWithFcOffProfile_SkipsDownPort()
+    {
+        var device = CreateSwitch("switch1", "Switch 1");
+        device.PortTable = new List<SwitchPort>
+        {
+            new() { PortIdx = 1, Name = "Port 1", Up = false, IsUplink = false, PortConfId = "profile1" }
+        };
+        var settings = CreateSettings(flowCtrlEnabled: true);
+        var profiles = new List<UniFiPortProfile>
+        {
+            new() { Id = "profile1", Name = "No FC Profile", FlowControlEnabled = false }
+        };
+
+        var result = _analyzer.CheckFlowControl(
+            new List<UniFiDeviceResponse> { device }, CreateWanNetwork(500),
+            new List<UniFiClientResponse>(), settings, profiles);
+
+        result.Should().NotContain(i => i.Title.Contains("Overridden"));
+    }
+
+    [Fact]
+    public void CheckFlowControl_GlobalOn_ExcludedDeviceFcOff_SkipsPortProfileCheck()
+    {
+        var device = CreateSwitch("switch1", "Switch 1");
+        device.Mac = "aa:bb:cc:00:00:01";
+        device.FlowControlEnabled = false;
+        device.PortTable = new List<SwitchPort>
+        {
+            new() { PortIdx = 1, Name = "Port 1", Up = true, IsUplink = false, PortConfId = "profile1" }
+        };
+        var settings = CreateSettings(flowCtrlEnabled: true, exclusions: new[] { "aa:bb:cc:00:00:01" });
+        var profiles = new List<UniFiPortProfile>
+        {
+            new() { Id = "profile1", Name = "No FC Profile", FlowControlEnabled = false }
+        };
+
+        var result = _analyzer.CheckFlowControl(
+            new List<UniFiDeviceResponse> { device }, CreateWanNetwork(500),
+            new List<UniFiClientResponse>(), settings, profiles);
+
+        // Device-level mismatch IS flagged, but port-level override is not
+        // because the device itself already has FC off
+        result.Should().NotContain(i => i.Title.Contains("Overridden"));
+    }
+
+    [Fact]
+    public void CheckFlowControl_GlobalOn_NoProfiles_NoProfileIssues()
+    {
+        var devices = new List<UniFiDeviceResponse> { CreateSwitch("switch1", "Switch 1") };
+        var settings = CreateSettings(flowCtrlEnabled: true);
+
+        var result = _analyzer.CheckFlowControl(
+            devices, CreateWanNetwork(500), new List<UniFiClientResponse>(), settings, null);
+
+        result.Should().NotContain(i => i.Title.Contains("Profile") || i.Title.Contains("Overridden"));
+    }
+
+    [Fact]
+    public void CheckFlowControl_GlobalOn_MultipleProfilesFcOff_FlagsEach()
+    {
+        var devices = new List<UniFiDeviceResponse> { CreateSwitch("switch1", "Switch 1") };
+        var settings = CreateSettings(flowCtrlEnabled: true);
+        var profiles = new List<UniFiPortProfile>
+        {
+            new() { Id = "profile1", Name = "Profile A", FlowControlEnabled = false },
+            new() { Id = "profile2", Name = "Profile B", FlowControlEnabled = false },
+            new() { Id = "profile3", Name = "Profile C", FlowControlEnabled = true }
+        };
+
+        var result = _analyzer.CheckFlowControl(
+            devices, CreateWanNetwork(500), new List<UniFiClientResponse>(), settings, profiles);
+
+        var profileIssues = result.Where(i => i.Title.Contains("Profile")).ToList();
+        profileIssues.Should().HaveCount(2);
+        profileIssues.Should().Contain(i => i.Title.Contains("Profile A"));
+        profileIssues.Should().Contain(i => i.Title.Contains("Profile B"));
+    }
+
     #endregion
 
     #region CountHighSpeedAccessPorts


### PR DESCRIPTION
## Summary

- When global Flow Control is enabled, the Config Optimizer now flags individual switch ports and port profiles that have FC explicitly disabled
- Checks the per-port `flow_control_enabled` field from the port table, with port profile taking precedence when it explicitly sets FC (falls back to port's own field when profile doesn't set it - works around a UniFi bug where profiles don't currently save FC)
- Skips disabled ports/profiles, gateways, and devices where FC is already off at the device level
- All issues are Info severity with "if this isn't intentional" framing

## Test plan

- [x] 93 unit tests passing (13 new)
- [x] Run Config Optimizer on a site with global FC enabled and a port with `flow_control_enabled: false` - verify the port is flagged
- [x] Run on a site with global FC disabled - verify no FC port/profile issues appear
- [x] Verify disabled ports are not flagged
- [x] Verify down-but-enabled ports ARE flagged