### PR TITLE
Fix UNAS camera misclassification and Cloudflare IP tolerance (#561)

### DIFF
--- a/src/NetworkOptimizer.Audit/Services/DeviceTypeDetectionService.cs
+++ b/src/NetworkOptimizer.Audit/Services/DeviceTypeDetectionService.cs
@@ -169,6 +169,29 @@ public class DeviceTypeDetectionService
             };
         }
 
+        // Priority -0.5: Known UNAS/Drive devices (from V2 API drive_devices array).
+        // These share Ubiquiti OUI prefixes with cameras but are NAS storage devices.
+        if (_protectCameras != null && !string.IsNullOrEmpty(client?.Mac) &&
+            _protectCameras.IsDriveDevice(client.Mac))
+        {
+            _logger?.LogDebug("[Detection] '{DisplayName}': Known UNAS/Drive device (confirmed by controller API)",
+                displayName);
+            return new DeviceDetectionResult
+            {
+                Category = ClientDeviceCategory.NAS,
+                Source = DetectionSource.UniFiFingerprint,
+                ConfidenceScore = 100,
+                VendorName = "Ubiquiti",
+                ProductName = client.Name,
+                RecommendedNetwork = NetworkPurpose.Corporate,
+                Metadata = new Dictionary<string, object>
+                {
+                    ["detection_method"] = "unifi_network_api",
+                    ["mac"] = client.Mac
+                }
+            };
+        }
+
         // Priority 0: Check for obvious name keywords that should OVERRIDE fingerprint
         // This handles cases where vendor fingerprint is wrong (e.g., Cync plugs detected as cameras)
         var obviousNameResult = CheckObviousNameOverride(client?.Name, client?.Hostname, client?.Oui);
@@ -1357,6 +1380,25 @@ public class DeviceTypeDetectionService
     {
         if (string.IsNullOrEmpty(macAddress))
             return DeviceDetectionResult.Unknown;
+
+        // Check for known UNAS/Drive devices before any other detection
+        if (_protectCameras != null && _protectCameras.IsDriveDevice(macAddress))
+        {
+            _logger?.LogDebug("[Detection] MAC {Mac}: Known UNAS/Drive device (confirmed by controller API)", macAddress);
+            return new DeviceDetectionResult
+            {
+                Category = ClientDeviceCategory.NAS,
+                Source = DetectionSource.UniFiFingerprint,
+                ConfidenceScore = 100,
+                VendorName = "Ubiquiti",
+                RecommendedNetwork = NetworkPurpose.Corporate,
+                Metadata = new Dictionary<string, object>
+                {
+                    ["detection_method"] = "unifi_network_api",
+                    ["mac"] = macAddress
+                }
+            };
+        }
 
         // First, check if we have this MAC in client history (for fingerprint data)
         if (_clientHistoryByMac != null &&

--- a/src/NetworkOptimizer.Core/Helpers/CloudflareIpRanges.cs
+++ b/src/NetworkOptimizer.Core/Helpers/CloudflareIpRanges.cs
@@ -49,12 +49,17 @@ public static class CloudflareIpRanges
     /// </summary>
     public static readonly string[] AllRanges = [.. IPv4Ranges, .. IPv6Ranges];
 
+    private const int MaxNonCloudflareHosts = 10;
+
     /// <summary>
-    /// Check if a list of IP addresses/CIDRs represents a Cloudflare-only restriction.
-    /// Returns true if every entry in the list is a known Cloudflare range.
+    /// Check if a list of IP addresses/CIDRs represents a Cloudflare-restricted configuration.
+    /// Returns true if the list is primarily Cloudflare ranges, tolerating a small number of
+    /// individual host IPs (e.g., management/home IPs) that people commonly add alongside CF ranges.
+    /// Non-Cloudflare entries must be single hosts (no CIDR or /32 or /128) - large non-CF subnets
+    /// indicate a different restriction strategy, not a Cloudflare list with extras.
     /// </summary>
     /// <param name="addresses">List of IPs or CIDRs from a firewall group or source restriction</param>
-    /// <returns>True if all addresses match known Cloudflare ranges</returns>
+    /// <returns>True if the list is a Cloudflare IP restriction (possibly with a few management IPs)</returns>
     public static bool IsCloudflareOnly(IEnumerable<string>? addresses)
     {
         if (addresses == null)
@@ -64,13 +69,31 @@ public static class CloudflareIpRanges
         if (list.Count == 0)
             return false;
 
+        int cloudflareCount = 0;
+        int nonCloudflareHostCount = 0;
+
         foreach (var address in list)
         {
-            if (!IsCloudflareAddress(address))
+            if (IsCloudflareAddress(address))
+            {
+                cloudflareCount++;
+                continue;
+            }
+
+            var trimmed = address.Trim();
+            bool isSingleHost = !trimmed.Contains('/')
+                || trimmed.EndsWith("/32")
+                || trimmed.EndsWith("/128");
+
+            if (!isSingleHost)
+                return false;
+
+            nonCloudflareHostCount++;
+            if (nonCloudflareHostCount > MaxNonCloudflareHosts)
                 return false;
         }
 
-        return true;
+        return cloudflareCount > 0;
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Core/Models/ProtectCamera.cs
+++ b/src/NetworkOptimizer.Core/Models/ProtectCamera.cs
@@ -158,6 +158,24 @@ public sealed class ProtectCameraCollection
     public IEnumerable<ProtectCamera> GetAll() => _cameras.Values;
 
     /// <summary>
+    /// MACs of known UNAS/Drive devices (from drive_devices in V2 API).
+    /// These share Ubiquiti OUI prefixes with cameras but are NOT cameras.
+    /// </summary>
+    private readonly HashSet<string> _driveDeviceMacs = new(StringComparer.OrdinalIgnoreCase);
+
+    public void AddDriveDevice(string mac)
+    {
+        _driveDeviceMacs.Add(mac.ToLowerInvariant());
+    }
+
+    public bool IsDriveDevice(string? mac)
+    {
+        return !string.IsNullOrEmpty(mac) && _driveDeviceMacs.Contains(mac);
+    }
+
+    public int DriveDeviceCount => _driveDeviceMacs.Count;
+
+    /// <summary>
     /// Create an empty collection
     /// </summary>
     public static ProtectCameraCollection Empty => new();

--- a/src/NetworkOptimizer.UniFi/Models/UniFiProtectDeviceResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiProtectDeviceResponse.cs
@@ -22,6 +22,9 @@ public class UniFiAllDevicesResponse
 
     [JsonPropertyName("led_devices")]
     public List<UniFiProtectDeviceResponse>? LedDevices { get; set; }
+
+    [JsonPropertyName("drive_devices")]
+    public List<UniFiProtectDeviceResponse>? DriveDevices { get; set; }
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -782,6 +782,25 @@ public class UniFiApiClient : IDisposable
         }
 
         _logger.LogInformation("Found {Count} Protect devices requiring Security VLAN", result.Count);
+
+        if (allDevices.DriveDevices != null)
+        {
+            foreach (var drive in allDevices.DriveDevices)
+            {
+                if (!string.IsNullOrEmpty(drive.Mac))
+                {
+                    result.AddDriveDevice(drive.Mac);
+                    _logger.LogDebug("Found Drive device: {Name} ({Model}) - MAC: {Mac}",
+                        drive.Name, drive.Model, drive.Mac);
+                }
+            }
+
+            if (result.DriveDeviceCount > 0)
+            {
+                _logger.LogInformation("Found {Count} Drive (UNAS) devices excluded from camera detection", result.DriveDeviceCount);
+            }
+        }
+
         return result;
     }
 

--- a/src/NetworkOptimizer.Web/Services/SponsorshipService.cs
+++ b/src/NetworkOptimizer.Web/Services/SponsorshipService.cs
@@ -38,7 +38,7 @@ public class SponsorshipService : ISponsorshipService
         ("Still free. Still no VC funding. Still powered by coffee and spite.", "Fund the spite"),
 
         // Level 6: 31-40 uses - stats flex
-        ("167,000 lines of code. 5,600 tests. One guy on 2 acres in Arkansas. Still cheaper than UI Ground shipping.", "Buy him lunch"),
+        ("217,000 lines of code. 6,100 tests. One guy on 2 acres in Arkansas. Still cheaper than UI Ground shipping.", "Buy him lunch"),
 
         // Level 7: 41-50 uses - former employer dig
         ("You've used this more than some employers used my code. Just saying.", "Money me"),

--- a/tests/NetworkOptimizer.Audit.Tests/Services/DeviceTypeDetectionServiceTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Services/DeviceTypeDetectionServiceTests.cs
@@ -2710,4 +2710,174 @@ public class DeviceTypeDetectionServiceTests
     }
 
     #endregion
+
+    #region UNAS / Drive Device Tests (Issue #561)
+
+    [Fact]
+    public void DetectDeviceType_UnasWithCameraOui_ClassifiedAsNasWhenDriveDeviceKnown()
+    {
+        // Arrange - UNAS Pro 4 shares OUI A8:9C:6C with Protect cameras
+        var service = new DeviceTypeDetectionService();
+        var cameras = new ProtectCameraCollection();
+        cameras.AddDriveDevice("a8:9c:6c:06:0c:cc");
+        service.SetProtectCameras(cameras);
+
+        var client = new UniFiClientResponse
+        {
+            Mac = "a8:9c:6c:06:0c:cc",
+            Name = "storage-core"
+        };
+
+        // Act
+        var result = service.DetectDeviceType(client);
+
+        // Assert - should be NAS, not Camera
+        result.Category.Should().Be(ClientDeviceCategory.NAS);
+        result.ConfidenceScore.Should().Be(100);
+        result.VendorName.Should().Be("Ubiquiti");
+        result.Metadata!["detection_method"].Should().Be("unifi_network_api");
+    }
+
+    [Fact]
+    public void DetectDeviceType_UnasSecondNic_ClassifiedAsNasWhenDriveDeviceKnown()
+    {
+        // Arrange - UNAS with 10G NIC (second MAC, unnamed)
+        var service = new DeviceTypeDetectionService();
+        var cameras = new ProtectCameraCollection();
+        cameras.AddDriveDevice("a8:9c:6c:06:0c:cd");
+        service.SetProtectCameras(cameras);
+
+        var client = new UniFiClientResponse
+        {
+            Mac = "a8:9c:6c:06:0c:cd",
+            Name = "a8:9c:6c:06:0c:cd"
+        };
+
+        // Act
+        var result = service.DetectDeviceType(client);
+
+        // Assert
+        result.Category.Should().Be(ClientDeviceCategory.NAS);
+        result.ConfidenceScore.Should().Be(100);
+    }
+
+    [Fact]
+    public void DetectFromMac_UnasWithCameraOui_ClassifiedAsNasWhenDriveDeviceKnown()
+    {
+        // Arrange - DetectFromMac is a separate code path used for offline detection
+        var service = new DeviceTypeDetectionService();
+        var cameras = new ProtectCameraCollection();
+        cameras.AddDriveDevice("a8:9c:6c:06:0c:cc");
+        service.SetProtectCameras(cameras);
+
+        // Act
+        var result = service.DetectFromMac("a8:9c:6c:06:0c:cc");
+
+        // Assert
+        result.Category.Should().Be(ClientDeviceCategory.NAS);
+        result.ConfidenceScore.Should().Be(100);
+    }
+
+    [Fact]
+    public void DetectDeviceType_ActualProtectCamera_StillDetectedAsCamera()
+    {
+        // Arrange - real camera with same OUI prefix should still be detected
+        var service = new DeviceTypeDetectionService();
+        var cameras = new ProtectCameraCollection();
+        cameras.Add("a8:9c:6c:1e:76:e4", "G4 Bullet", null, isNvr: false);
+        cameras.AddDriveDevice("a8:9c:6c:06:0c:cc");
+        service.SetProtectCameras(cameras);
+
+        var client = new UniFiClientResponse
+        {
+            Mac = "a8:9c:6c:1e:76:e4",
+            Name = "cam-frontdoor"
+        };
+
+        // Act
+        var result = service.DetectDeviceType(client);
+
+        // Assert - camera should still be detected via ProtectCameraCollection
+        result.Category.Should().Be(ClientDeviceCategory.Camera);
+        result.ConfidenceScore.Should().Be(100);
+        result.Metadata!["detection_method"].Should().Be("unifi_protect_api");
+    }
+
+    [Fact]
+    public void DetectDeviceType_UnasWithoutDriveData_FallsBackToMacOui()
+    {
+        // Arrange - if drive_devices isn't available, MAC OUI still fires (backward compat)
+        var service = new DeviceTypeDetectionService();
+        // No SetProtectCameras call - simulates API failure or no V2 data
+
+        var client = new UniFiClientResponse
+        {
+            Mac = "a8:9c:6c:06:0c:cc",
+            Name = "storage-core"
+        };
+
+        // Act
+        var result = service.DetectDeviceType(client);
+
+        // Assert - falls back to MAC OUI (Camera) since we have no drive data
+        // This is expected - without the V2 API data, we can't distinguish
+        result.Category.Should().Be(ClientDeviceCategory.Camera);
+    }
+
+    [Fact]
+    public void ProtectCameraCollection_IsDriveDevice_ReturnsTrueForKnownMac()
+    {
+        var collection = new ProtectCameraCollection();
+        collection.AddDriveDevice("a8:9c:6c:06:0c:cc");
+
+        collection.IsDriveDevice("a8:9c:6c:06:0c:cc").Should().BeTrue();
+        collection.IsDriveDevice("A8:9C:6C:06:0C:CC").Should().BeTrue();
+    }
+
+    [Fact]
+    public void ProtectCameraCollection_IsDriveDevice_ReturnsFalseForUnknownMac()
+    {
+        var collection = new ProtectCameraCollection();
+        collection.AddDriveDevice("a8:9c:6c:06:0c:cc");
+
+        collection.IsDriveDevice("aa:bb:cc:dd:ee:ff").Should().BeFalse();
+        collection.IsDriveDevice(null).Should().BeFalse();
+        collection.IsDriveDevice("").Should().BeFalse();
+    }
+
+    [Fact]
+    public void ProtectCameraCollection_DriveDeviceCount_ReturnsCorrectCount()
+    {
+        var collection = new ProtectCameraCollection();
+        collection.DriveDeviceCount.Should().Be(0);
+
+        collection.AddDriveDevice("a8:9c:6c:06:0c:cc");
+        collection.AddDriveDevice("a8:9c:6c:06:0c:cd");
+        collection.DriveDeviceCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void DetectDeviceType_DriveDeviceTakesPriorityOverNamePattern()
+    {
+        // Arrange - even if name matches a pattern, drive device detection should win
+        var service = new DeviceTypeDetectionService();
+        var cameras = new ProtectCameraCollection();
+        cameras.AddDriveDevice("a8:9c:6c:06:0c:cc");
+        service.SetProtectCameras(cameras);
+
+        var client = new UniFiClientResponse
+        {
+            Mac = "a8:9c:6c:06:0c:cc",
+            Name = "My Security Camera" // misleading name
+        };
+
+        // Act
+        var result = service.DetectDeviceType(client);
+
+        // Assert - drive device classification wins
+        result.Category.Should().Be(ClientDeviceCategory.NAS);
+        result.ConfidenceScore.Should().Be(100);
+    }
+
+    #endregion
 }

--- a/tests/NetworkOptimizer.Core.Tests/Helpers/CloudflareIpRangesTests.cs
+++ b/tests/NetworkOptimizer.Core.Tests/Helpers/CloudflareIpRangesTests.cs
@@ -76,6 +76,7 @@ public class CloudflareIpRangesTests
     [Fact]
     public void IsCloudflareOnly_SingleIpNotInCloudflare_ReturnsFalse()
     {
+        // A single non-CF IP with NO CF ranges is not a Cloudflare list
         CloudflareIpRanges.IsCloudflareOnly(["8.8.8.8"]).Should().BeFalse();
     }
 
@@ -91,6 +92,49 @@ public class CloudflareIpRangesTests
     {
         // 104.0.0.0/8 is larger than 104.16.0.0/13 - not fully covered
         CloudflareIpRanges.IsCloudflareOnly(["104.0.0.0/8"]).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsCloudflareOnly_CloudflarePlusFewManagementIPs_ReturnsTrue()
+    {
+        // Real-world case: CF ranges plus a few static IPs for friends/family access
+        var list = CloudflareIpRanges.IPv4Ranges.ToList();
+        list.Add("204.228.140.228");
+        list.Add("216.134.237.155");
+        list.Add("70.251.208.5");
+        CloudflareIpRanges.IsCloudflareOnly(list).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsCloudflareOnly_CloudflarePlusSlash32_ReturnsTrue()
+    {
+        var list = new List<string>(CloudflareIpRanges.IPv4Ranges) { "198.51.100.1/32" };
+        CloudflareIpRanges.IsCloudflareOnly(list).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsCloudflareOnly_CloudflarePlusNonCfSubnet_ReturnsFalse()
+    {
+        // A /24 is not a single host - this is a different restriction strategy
+        var list = new List<string>(CloudflareIpRanges.IPv4Ranges) { "203.0.113.0/24" };
+        CloudflareIpRanges.IsCloudflareOnly(list).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsCloudflareOnly_CloudflarePlusTooManyManagementIPs_ReturnsFalse()
+    {
+        var list = CloudflareIpRanges.IPv4Ranges.ToList();
+        for (int i = 1; i <= 11; i++)
+            list.Add($"198.51.100.{i}");
+        CloudflareIpRanges.IsCloudflareOnly(list).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsCloudflareOnly_OnlyManagementIPsNoCf_ReturnsFalse()
+    {
+        // Individual IPs without any CF ranges is not a CF list
+        var list = new[] { "204.228.140.228", "216.134.237.155" };
+        CloudflareIpRanges.IsCloudflareOnly(list).Should().BeFalse();
     }
 
     #endregion


### PR DESCRIPTION
## Summary

- **UNAS excluded from camera detection** - UNAS devices share Ubiquiti OUI prefixes with Protect cameras, causing the MAC OUI detector to misclassify them as cameras and flag them for Security VLAN placement. The V2 device API's `drive_devices` array is now deserialized and used to positively classify these as NAS devices at highest detection priority.
- **Cloudflare IP list tolerance** - Users who add a few personal/management IPs (home, office, family) alongside Cloudflare ranges were getting a misleading "consider restricting to Cloudflare IPs" recommendation. Now tolerates up to 10 individual host IPs in a Cloudflare list without losing the "properly restricted" classification.
- Updated sponsorship stats (217k LoC, 6,100 tests)

## Test plan

- [x] 9 new UNAS detection tests covering both detection paths, multi-NIC, coexistence with real cameras, fallback without drive data, priority over misleading names
- [x] 5 new Cloudflare IP tolerance tests covering real-world CF+management lists, /32 notation, non-CF subnet rejection, limit enforcement, no-CF-ranges edge case
- [x] All 6,110 tests pass across 13 test projects
- [x] Deployed to NAS test site - UNAS no longer flagged, Cloudflare port forwards show as properly restricted