### PR TITLE
Add SFP compatibility note for Zyxel PMG3000-D20B

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
@@ -309,6 +309,13 @@
                         </div>
                     }
 
+                    @if (def.Id == "sfp-sgmiiplus")
+                    {
+                        <div class="alert alert-warning" style="margin-top: 0.75rem;">
+                            <strong>Compatibility note:</strong> Zyxel PMG3000-D20B support is currently being tested. If you have this module (or another GPON stick that may not negotiate 2.5 G cleanly with the UniFi host), feel free to try the patch, but be prepared to remove it if the link doesn't come up and stabilize.
+                        </div>
+                    }
+
                     <!-- Action Buttons -->
                     <div class="pt-actions">
                         @if (effectiveStatus == TweakDisplayStatus.NotDeployed)


### PR DESCRIPTION
## Summary

- Adds a warning alert on the SFP+ 2.5 G SGMII+ Patch card noting that Zyxel PMG3000-D20B support is being tested
- Also mentions that other GPON sticks may not negotiate 2.5 G cleanly with the UniFi host
- Advises users to be prepared to remove the tweak if the link doesn't come up and stabilize

## Test plan

- [x] Verify the warning alert appears on the SFP card on Performance Tweaks page
- [x] Verify it shows regardless of deployment status (not gated by any condition)