### PR TITLE
Fix CRLF line endings in perf tweak scripts on Windows MSI

### DIFF
--- a/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
@@ -676,7 +676,7 @@ public class PerfTweaksDeploymentService
         if (stream == null) return null;
 
         using var reader = new StreamReader(stream);
-        return reader.ReadToEnd();
+        return reader.ReadToEnd().Replace("\r\n", "\n");
     }
 
     private static byte[]? ReadEmbeddedResourceBytes(string fileName)


### PR DESCRIPTION
## Summary

- Normalizes `\r\n` to `\n` in `ReadEmbeddedResource` so shell scripts deployed to the gateway always have Unix line endings, even when built on Windows (MSI)

## Test plan

- [x] Build MSI on Windows, deploy a perf tweak, verify script has LF not CRLF on the gateway