### PR TITLE
v1.16.2

### DIFF
--- a/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
@@ -676,7 +676,7 @@ public class PerfTweaksDeploymentService
         if (stream == null) return null;
 
         using var reader = new StreamReader(stream);
-        return reader.ReadToEnd();
+        return reader.ReadToEnd().Replace("\r\n", "\n");
     }
 
     private static byte[]? ReadEmbeddedResourceBytes(string fileName)


### PR DESCRIPTION
## Summary

- **Fix CRLF in perf tweak scripts on Windows** - Shell scripts embedded in the Windows MSI could be deployed with Windows line endings, breaking execution on the gateway. Scripts are now normalized to Unix line endings before deploying.