### PR TITLE
Add udm-boot status check and install to WAN Steering

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/WanSteering.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSteering.razor
@@ -6,7 +6,7 @@
 @inject IGatewaySshService GatewaySshService
 @inject ILogger<WanSteering> Logger
 @inject PullToRefreshState PtrState
-@inject ISqmDeploymentService SqmDeploymentService
+@inject SqmDeploymentService SqmDeploymentService
 @rendermode InteractiveServer
 @using NetworkOptimizer.Storage.Models
 @using NetworkOptimizer.Web.Services.Ssh

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSteering.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSteering.razor
@@ -6,6 +6,7 @@
 @inject IGatewaySshService GatewaySshService
 @inject ILogger<WanSteering> Logger
 @inject PullToRefreshState PtrState
+@inject ISqmDeploymentService SqmDeploymentService
 @rendermode InteractiveServer
 @using NetworkOptimizer.Storage.Models
 @using NetworkOptimizer.Web.Services.Ssh
@@ -84,6 +85,20 @@
                         @(_status.BinaryDeployed ? "Deployed" : "Not Deployed")
                     </div>
                 </div>
+                <div class="metric">
+                    <div class="metric-label">UDM Boot</div>
+                    <div class="metric-value">
+                        <span class="status-indicator @(_status.UdmBootInstalled ? "status-active" : "status-inactive")"></span>
+                        @if (_status.UdmBootInstalled)
+                        {
+                            <span>@(_status.UdmBootEnabled ? "Enabled" : "Installed")</span>
+                        }
+                        else
+                        {
+                            <span>Not Installed</span>
+                        }
+                    </div>
+                </div>
                 @if (_deployedAt.HasValue && (DateTime.UtcNow - _deployedAt.Value).TotalSeconds < 45)
                 {
                     <div class="metric">
@@ -122,6 +137,23 @@
                 <div class="alert alert-warning" style="margin-top: 1rem;">
                     <strong>WAN Steer binary outdated.</strong>
                     Gateway is running @(_parsedStatus.Version) but the app is @_appVersion. Redeploy to update.
+                </div>
+            }
+            @if (_status.UdmBootInstalled != true)
+            {
+                <div class="alert alert-warning" style="margin-top: 1rem;">
+                    <strong>UDM Boot Required:</strong> WAN Steering uses a boot script in <code>/data/on_boot.d/</code> that requires udm-boot to persist across reboots. Without it, iptables rules will silently stop being applied after a reboot or firmware update.
+                    <button class="btn btn-sm btn-primary" style="margin-left: 0.5rem;" @onclick="InstallUdmBoot" disabled="@_isInstallingUdmBoot">
+                        @if (_isInstallingUdmBoot)
+                        {
+                            <span class="spinner spinner-sm"></span>
+                            <span>Installing...</span>
+                        }
+                        else
+                        {
+                            <span>Install UDM Boot</span>
+                        }
+                    </button>
                 </div>
             }
         }
@@ -499,6 +531,7 @@
     private bool _isLoading = true;
     private bool _isDeploying;
     private bool _isDiscovering = true;
+    private bool _isInstallingUdmBoot;
     private bool _gatewayConfigured;
     private string? _deployMessage;
     private bool _deploySuccess;
@@ -619,6 +652,24 @@
         catch (Exception ex)
         {
             Logger.LogDebug(ex, "Failed to poll WAN Steering status");
+        }
+    }
+
+    private async Task InstallUdmBoot()
+    {
+        _isInstallingUdmBoot = true;
+        StateHasChanged();
+
+        try
+        {
+            var result = await SqmDeploymentService.InstallUdmBootAsync();
+            if (result.success)
+                await RefreshStatusAsync();
+        }
+        finally
+        {
+            _isInstallingUdmBoot = false;
+            StateHasChanged();
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/WanSteerDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/WanSteerDeploymentService.cs
@@ -47,6 +47,8 @@ public class WanSteerDeploymentService
         try
         {
             var combinedCommand =
+                "echo '---UDM_BOOT---'; test -f /etc/systemd/system/udm-boot.service && echo 'installed' || echo 'missing'; " +
+                "echo '---UDM_BOOT_ENABLED---'; systemctl is-enabled udm-boot 2>/dev/null || echo 'disabled'; " +
                 "echo '---PROCESS---'; pgrep -x wansteer > /dev/null 2>&1 && echo running || echo stopped; " +
                 "echo '---STATUS---'; cat /tmp/wan-steer-status.json 2>/dev/null || echo '{}'; echo; " +
                 "echo '---VERSION---'; /data/wan-steer/wansteer -version 2>/dev/null || echo 'not installed'; " +
@@ -55,6 +57,8 @@ public class WanSteerDeploymentService
             var result = await _gatewaySsh.RunCommandAsync(combinedCommand, TimeSpan.FromSeconds(15));
             var sections = ParseDelimitedOutput(result.output);
 
+            status.UdmBootInstalled = GetSection(sections, "UDM_BOOT").Trim() == "installed";
+            status.UdmBootEnabled = GetSection(sections, "UDM_BOOT_ENABLED").Trim() == "enabled";
             status.IsRunning = result.success && GetSection(sections, "PROCESS").Trim() == "running";
             status.StatusJson = GetSection(sections, "STATUS").Trim();
             if (status.StatusJson == "{}") status.StatusJson = null;
@@ -558,6 +562,8 @@ public class WanSteerDeploymentService
 
 public class WanSteerStatus
 {
+    public bool UdmBootInstalled { get; set; }
+    public bool UdmBootEnabled { get; set; }
     public bool IsRunning { get; set; }
     public string? Version { get; set; }
     public string? StatusJson { get; set; }


### PR DESCRIPTION
## Summary

- Adds udm-boot status indicator to the WAN Steering daemon status metrics bar
- Shows warning banner with one-click install button when udm-boot is missing
- Without udm-boot, the boot script that restores iptables rules won't run after a reboot or firmware update, silently breaking WAN Steering

Same pattern already used by Performance Tweaks and Adaptive SQM.

Closes #589

## Test plan

- [x] Navigate to WAN Steering on a gateway with udm-boot installed - "UDM Boot" metric shows green "Enabled"
- [x] On a gateway without udm-boot - warning banner appears with "Install UDM Boot" button
- [x] Click install button - udm-boot installs and status refreshes to green