### PR TITLE
Fix SSD usage display blank on UniFi OS v5.1+

### DIFF
--- a/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
@@ -92,7 +92,7 @@ public class PerfTweaksDeploymentService
                 "echo '---MONGO_MOUNTPOINT---'; mountpoint -q /data/unifi/data/db 2>/dev/null && echo 'mounted' || echo 'not-mounted'; " +
                 "echo '---MONGO_FINDMNT---'; findmnt -no SOURCE /data/unifi/data/db 2>/dev/null || echo 'N/A'; " +
                 "echo '---MONGO_SERVICE---'; systemctl is-active unifi-mongodb 2>/dev/null || echo 'inactive'; " +
-                "echo '---MONGO_SSD_SIZE---'; du -sh /volume*/unifi-db 2>/dev/null | head -1 | cut -f1 || echo 'N/A'; " +
+                "echo '---MONGO_SSD_SIZE---'; du -sh /volume1/unifi-db /volume/*/unifi-db 2>/dev/null | head -1 | cut -f1 || echo 'N/A'; " +
                 // MongoDB backup
                 $"echo '---MONGO_BACKUP_SCRIPT---'; test -f {OnBootDir}/07-mongodb-ssd-backup.sh && echo 'exists' || echo 'missing'; " +
                 "echo '---MONGO_BACKUP_CRON---'; test -f /etc/cron.d/mongodb-ssd-backup && echo 'exists' || echo 'missing'; " +


### PR DESCRIPTION
Fixes #593

## Summary

- The `MONGO_SSD_SIZE` status check used `du -sh /volume*/unifi-db` which only matches old-style `/volume1` mount paths. UniFi OS 5.1+ mounts the NVMe SSD at `/volume/<uuid>/` instead, so the glob never matched and SSD Usage displayed blank.
- Changed to `du -sh /volume1/unifi-db /volume/*/unifi-db` - the same dual-path pattern already used by the removal code and SSD volume detection.

**Other code paths verified clean:**
- **SSD volume detection** (line 89): Already checks both `/volume1` and `/volume/*/`
- **Boot script** (`06-mongodb-ssd-offload.sh`): Has a `detect_ssd_mount()` function that handles both path formats
- **Removal** (line 637): Already uses `for d in /volume1/unifi-db /volume/*/unifi-db`

## Test plan

- [x] Deploy to a gateway running UniFi OS 5.1+ with MongoDB on SSD and verify SSD Usage shows a value
- [x] Verify SSD Usage still works on pre-5.1 firmware with /volume1 mount