### PR TITLE
v1.16.3

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
@@ -174,7 +174,7 @@
             @if (_showFirmwareNotes)
             {
                 <div class="card-body">
-                    <div class="pt-firmware-table">
+                    <div class="pt-firmware-table table-responsive">
                         <table class="data-table">
                             <thead>
                                 <tr>

--- a/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
@@ -196,7 +196,7 @@
                                 </tr>
                                 <tr>
                                     <td>Factory Reset</td>
-                                    <td><strong>Boot scripts and SSD data may be wiped</strong></td>
+                                    <td><strong>Boot scripts and custom modules will be wiped; SSD data may be wiped depending on reset options</strong></td>
                                     <td><strong>Reinstall udm-boot and redeploy all tweaks</strong></td>
                                 </tr>
                             </tbody>

--- a/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
@@ -109,7 +109,7 @@
                         </div>
                         <div class="metric">
                             <div class="metric-label">Active Tweaks</div>
-                            <div class="metric-value">@_activeTweakCount / @_compatibleTweaks.Count</div>
+                            <div class="metric-value">@_activeTweakCount / @_compatibleTweakSlotCount</div>
                         </div>
                     </div>
 
@@ -827,9 +827,38 @@
     private List<TweakDefinition> _compatibleTweaks => _tweakDefs
         .Where(d => d.IsCompatibleWith(_status?.GatewayModel)).ToList();
 
-    private int _activeTweakCount => _status?.Tweaks.Values
-        .Count(t => (t.IsActive || t.IsManuallyDeployed)
-            && _compatibleTweaks.Any(d => d.Id == t.Id)) ?? 0;
+    // TODO: Remove deduplication when simultaneous SFP port support is working -
+    // at that point each SFP tweak should count independently.
+    private int _compatibleTweakSlotCount => _compatibleTweaks
+        .Where(d => d.MutuallyExclusiveWith == null
+            || string.Compare(d.Id, d.MutuallyExclusiveWith, StringComparison.Ordinal) < 0)
+        .Count();
+
+    private int _activeTweakCount
+    {
+        get
+        {
+            if (_status == null) return 0;
+            var activeIds = _status.Tweaks.Values
+                .Where(t => (t.IsActive || t.IsManuallyDeployed)
+                    && _compatibleTweaks.Any(d => d.Id == t.Id))
+                .Select(t => t.Id)
+                .ToHashSet();
+
+            // TODO: Remove deduplication when simultaneous SFP port support is working
+            var counted = new HashSet<string>();
+            var count = 0;
+            foreach (var id in activeIds)
+            {
+                var def = _compatibleTweaks.FirstOrDefault(d => d.Id == id);
+                if (def?.MutuallyExclusiveWith != null && counted.Contains(def.MutuallyExclusiveWith))
+                    continue;
+                counted.Add(id);
+                count++;
+            }
+            return count;
+        }
+    }
 
     private static readonly List<TweakDefinition> _tweakDefs = new()
     {

--- a/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
@@ -192,7 +192,7 @@
                                 <tr>
                                     <td>UniFi OS Upgrade</td>
                                     <td>Boot scripts survive and reapply all tweaks on next boot</td>
-                                    <td>Verify udm-boot is still enabled: <code>systemctl status udm-boot</code></td>
+                                    <td>Check status indicators here to confirm everything survived</td>
                                 </tr>
                                 <tr>
                                     <td>Factory Reset</td>

--- a/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
@@ -92,7 +92,7 @@ public class PerfTweaksDeploymentService
                 "echo '---MONGO_MOUNTPOINT---'; mountpoint -q /data/unifi/data/db 2>/dev/null && echo 'mounted' || echo 'not-mounted'; " +
                 "echo '---MONGO_FINDMNT---'; findmnt -no SOURCE /data/unifi/data/db 2>/dev/null || echo 'N/A'; " +
                 "echo '---MONGO_SERVICE---'; systemctl is-active unifi-mongodb 2>/dev/null || echo 'inactive'; " +
-                "echo '---MONGO_SSD_SIZE---'; du -sh /volume*/unifi-db 2>/dev/null | head -1 | cut -f1 || echo 'N/A'; " +
+                "echo '---MONGO_SSD_SIZE---'; du -sh /volume1/unifi-db /volume/*/unifi-db 2>/dev/null | head -1 | cut -f1 || echo 'N/A'; " +
                 // MongoDB backup
                 $"echo '---MONGO_BACKUP_SCRIPT---'; test -f {OnBootDir}/07-mongodb-ssd-backup.sh && echo 'exists' || echo 'missing'; " +
                 "echo '---MONGO_BACKUP_CRON---'; test -f /etc/cron.d/mongodb-ssd-backup && echo 'exists' || echo 'missing'; " +


### PR DESCRIPTION
## Changes

- **Fix SSD usage display blank on UniFi OS v5.1+** (#594) - The status check for MongoDB SSD size used a glob that only matched old-style `/volume1` paths, not the `/volume/<uuid>/` structure used by UniFi OS 5.1+.
- **Count mutually exclusive SFP tweaks as one slot** - Port 6 and Port 7 SFP+ patches are mutually exclusive for now, so the Active Tweaks counter counts them as a single slot instead of inflating both numerator and denominator.
- **Fix factory reset verbiage** - Boot scripts and custom modules will be wiped; SSD data may be wiped depending on reset options (previously said "may be" for everything).