### PR TITLE
Add GPON stick compatibility dialog to SFP tweaks

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
@@ -323,7 +323,7 @@
                     @if (def.Id == "sfp-sgmiiplus" || def.Id == "sfp-sgmiiplus-port6")
                     {
                         <div class="alert alert-warning" style="margin-top: 0.75rem;">
-                            <strong>Compatibility note:</strong> Zyxel PMG3000-D20B support is currently being tested. If you have this module (or another GPON stick that may not negotiate 2.5 G cleanly with the UniFi host), feel free to try the patch, but be prepared to remove it if the link doesn't come up and stabilize.
+                            <strong>GPON stick compatibility:</strong> Some SFP GPON ONTs (particularly the Zyxel PMG3000-D20B) may not negotiate 2.5 G cleanly with the UniFi host without extra configuration. If your stick won't link up after deploying, <a href="javascript:void(0)" @onclick="() => _showZyxelInstructions = true" @onclick:stopPropagation="true" class="pt-inline-link">check these pre-flight steps</a>.
                         </div>
                     }
 
@@ -519,6 +519,47 @@
                 <button class="btn btn-danger btn-sm" @onclick="ConfirmRemove">
                     Confirm Remove
                 </button>
+            </div>
+        </div>
+    </div>
+}
+
+<!-- Zyxel Pre-Flight Instructions Modal -->
+@if (_showZyxelInstructions)
+{
+    <div class="pt-modal-overlay" @onclick="() => _showZyxelInstructions = false">
+        <div class="pt-modal pt-modal-wide" @onclick:stopPropagation="true">
+            <div class="pt-modal-header">
+                <h3>Zyxel PMG3000-D20B - Pre-Flight Steps</h3>
+            </div>
+            <div class="pt-modal-body pt-instructions">
+                <p>The Zyxel PMG3000-D20B (and some other GPON sticks) may not negotiate 2.5 G cleanly with the UniFi host by default. Run the following commands on the SFP stick <strong>before</strong> deploying the SGMII+ patch.</p>
+
+                <h4>Step 1: Switch to 2.5/1 G auto-negotiation</h4>
+                <p>SSH to your SFP stick and run:</p>
+                <pre><code>linuxshell
+onu lanpcs 0 1 -1 4 15 1 0 5 0 0 1518 1 3 0 0 0</code></pre>
+                <p>This switches the SFP interface to 2.5/1 G auto-negotiation mode. It resets back to the default on SFP reboot, so you always have a way out.</p>
+
+                <h4>Step 2: Deploy the patch</h4>
+                <p>Come back here and deploy the SGMII+ patch. After about a minute, the link should come up and you should have data path again.</p>
+
+                <h4>Step 3: Persist the command</h4>
+                <p>If it works, make the command run automatically on every SFP boot. SSH to the stick again and run:</p>
+                <pre><code># Enter the Linux shell first (if a new SSH session)
+linuxshell
+
+# Check if the boot script file already exists
+ls -la /var/config/run-syslog.sh</code></pre>
+
+                <p>If the file <strong>does not exist</strong> (you see "No such file or directory"):</p>
+                <pre><code>echo 'onu lanpcs 0 1 -1 4 15 1 0 5 0 0 1518 1 3 0 0 0' > /var/config/run-syslog.sh</code></pre>
+
+                <p>If the file <strong>already exists</strong>, safely append the command:</p>
+                <pre><code>grep -q 'lanpcs' /var/config/run-syslog.sh 2>/dev/null || echo 'onu lanpcs 0 1 -1 4 15 1 0 5 0 0 1518 1 3 0 0 0' >> /var/config/run-syslog.sh</code></pre>
+            </div>
+            <div class="pt-modal-footer">
+                <button class="btn btn-primary btn-sm" @onclick="() => _showZyxelInstructions = false">Got It</button>
             </div>
         </div>
     </div>
@@ -800,6 +841,54 @@
             width: 100%;
         }
     }
+
+    /* Inline action link */
+    .pt-inline-link {
+        color: var(--primary-color);
+        text-decoration: underline;
+        cursor: pointer;
+    }
+
+    .pt-inline-link:hover {
+        color: var(--primary-hover);
+    }
+
+    /* Wide modal variant */
+    .pt-modal-wide {
+        max-width: 640px;
+    }
+
+    /* Instructional modal body */
+    .pt-instructions h4 {
+        color: var(--text-primary);
+        font-size: 0.95rem;
+        margin: 1.25rem 0 0.5rem 0;
+    }
+
+    .pt-instructions h4:first-child {
+        margin-top: 0;
+    }
+
+    .pt-instructions p {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        line-height: 1.5;
+        margin: 0 0 0.5rem 0;
+    }
+
+    .pt-instructions pre {
+        background: var(--bg-primary);
+        border-radius: 0.375rem;
+        padding: 0.75rem 1rem;
+        margin: 0.5rem 0 0.75rem 0;
+        overflow-x: auto;
+    }
+
+    .pt-instructions code {
+        font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
+        font-size: 0.8rem;
+        color: var(--text-primary);
+    }
 </style>
 
 @code {
@@ -819,6 +908,7 @@
     private bool _confirmRisk;
     private bool _showRemoveConfirm;
     private string? _pendingRemoveTweakId;
+    private bool _showZyxelInstructions;
     private bool _allConfirmed => _confirmBackup && _confirmBackupDownloaded && _confirmWarranty && _confirmRisk;
     private bool _canDeploy => _status?.UdmBootInstalled == true && _status?.FirmwareSupported == true;
     private List<string> _deploySteps = new();

--- a/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
@@ -524,7 +524,7 @@
     </div>
 }
 
-<!-- Zyxel Pre-Flight Instructions Modal -->
+<!-- GPON Stick Pre-Flight Instructions Modal -->
 @if (_showZyxelInstructions)
 {
     <div class="pt-modal-overlay" @onclick="() => _showZyxelInstructions = false">

--- a/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
@@ -323,7 +323,7 @@
                     @if (def.Id == "sfp-sgmiiplus" || def.Id == "sfp-sgmiiplus-port6")
                     {
                         <div class="alert alert-warning" style="margin-top: 0.75rem;">
-                            <strong>GPON stick compatibility:</strong> Some SFP GPON ONTs (particularly the Zyxel PMG3000-D20B) may not negotiate 2.5 G cleanly with the UniFi host without extra configuration. If your stick won't link up after deploying, <a href="javascript:void(0)" @onclick="() => _showZyxelInstructions = true" @onclick:stopPropagation="true" class="pt-inline-link">check these pre-flight steps</a>.
+                            <strong>GPON stick compatibility:</strong> Some SFP GPON ONTs (particularly the Zyxel PMG3000-D20B) may not negotiate 2.5 G cleanly with the UniFi host without extra configuration. If your stick won't link up after deploying, <a href="javascript:void(0)" @onclick="() => _showZyxelInstructions = true" @onclick:stopPropagation="true" class="pt-inline-link">check these pre-flight steps</a>, and Remove the SFP tweak to restore the link if all else fails.
                         </div>
                     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
@@ -774,10 +774,12 @@ ls -la /var/config/run-syslog.sh</code></pre>
         bottom: 0;
         background: rgba(0, 0, 0, 0.6);
         display: flex;
-        align-items: center;
+        align-items: flex-start;
         justify-content: center;
         z-index: 1000;
-        padding: 1rem;
+        padding: 2rem 1rem;
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
     }
 
     .pt-modal {
@@ -785,6 +787,7 @@ ls -la /var/config/run-syslog.sh</code></pre>
         border-radius: 0.75rem;
         max-width: 540px;
         width: 100%;
+        margin: auto 0;
         box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
@@ -530,22 +530,32 @@
     <div class="pt-modal-overlay" @onclick="() => _showZyxelInstructions = false">
         <div class="pt-modal pt-modal-wide" @onclick:stopPropagation="true">
             <div class="pt-modal-header">
-                <h3>Zyxel PMG3000-D20B - Pre-Flight Steps</h3>
+                <h3>GPON Stick Compatibility - Pre-Flight Steps</h3>
             </div>
             <div class="pt-modal-body pt-instructions">
-                <p>The Zyxel PMG3000-D20B (and some other GPON sticks) may not negotiate 2.5 G cleanly with the UniFi host by default. Run the following commands on the SFP stick <strong>before</strong> deploying the SGMII+ patch.</p>
+                <p>Some GPON ONT SFP modules default to a link mode that won't negotiate 2.5 G with the UniFi host. If your stick doesn't link up after deploying the SGMII+ patch, you likely need to switch it to 2.5/1 G auto-negotiation mode first.</p>
 
-                <h4>Step 1: Switch to 2.5/1 G auto-negotiation</h4>
-                <p>SSH to your SFP stick and run:</p>
+                <p>The general process is:</p>
+                <ol>
+                    <li>SSH into your SFP stick and configure it for 2.5/1 G auto-negotiation</li>
+                    <li>Deploy the SGMII+ patch from this page</li>
+                    <li>If it links up, persist the configuration so it survives SFP reboots</li>
+                </ol>
+                <p>The exact commands vary by stick. If yours isn't listed below, check your stick's documentation or community wiki for the equivalent auto-negotiation command.</p>
+
+                <h4>If it doesn't work</h4>
+                <p>If the link and data path don't come up after deploying, use the Remove button on the tweak card to unload the module - this should restore normal functionality. If the link still doesn't recover after removal, reboot the SFP stick.</p>
+
+                <h4>Zyxel PMG3000-D20B</h4>
+
+                <p><strong>Configure auto-negotiation.</strong> SSH to the stick and run:</p>
                 <pre><code>linuxshell
 onu lanpcs 0 1 -1 4 15 1 0 5 0 0 1518 1 3 0 0 0</code></pre>
-                <p>This switches the SFP interface to 2.5/1 G auto-negotiation mode. It resets back to the default on SFP reboot, so you always have a way out.</p>
+                <p>The <code>linuxshell</code> command breaks out of the Zyxel CLI into a Linux shell. The <code>onu lanpcs</code> command switches the SFP interface to 2.5/1 G auto-negotiation mode. It resets on SFP reboot, so you always have a way out.</p>
 
-                <h4>Step 2: Deploy the patch</h4>
-                <p>Come back here and deploy the SGMII+ patch. After about a minute, the link should come up and you should have data path again.</p>
+                <p><strong>Deploy the patch.</strong> Come back here and deploy the SGMII+ patch. After about a minute, the link should come up and you should have data path again.</p>
 
-                <h4>Step 3: Persist the command</h4>
-                <p>If it works, make the command run automatically on every SFP boot. SSH to the stick again and run:</p>
+                <p><strong>Persist across reboots.</strong> If it works, make the command run automatically on every SFP boot. SSH to the stick again and run:</p>
                 <pre><code># Enter the Linux shell first (if a new SSH session)
 linuxshell
 
@@ -888,6 +898,18 @@ ls -la /var/config/run-syslog.sh</code></pre>
         font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
         font-size: 0.8rem;
         color: var(--text-primary);
+    }
+
+    .pt-instructions ol {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        line-height: 1.5;
+        margin: 0 0 0.75rem 0;
+        padding-left: 1.25rem;
+    }
+
+    .pt-instructions li {
+        margin-bottom: 0.25rem;
     }
 </style>
 


### PR DESCRIPTION
## Summary

- Replaces the static Zyxel compatibility warning on SFP tweak cards with an actionable alert linking to a pre-flight instructions dialog
- Dialog explains the general problem (stick won't negotiate 2.5 G) and the 3-step process, with Zyxel PMG3000-D20B-specific SSH commands for configuring auto-negotiation and persisting via boot script
- Alert also notes that removing the SFP tweak restores the link if all else fails
- CSS classes are generic and reusable (`pt-inline-link`, `pt-instructions`, `pt-modal-wide`) for future instructional modals

## Test plan

- [x] Open Performance Tweaks page
- [x] Verify the GPON compatibility alert appears on both SFP tweak cards
- [x] Click "check these pre-flight steps" link and verify the dialog opens
- [x] Verify dialog content: general intro, recovery guidance, Zyxel-specific commands
- [x] Verify dialog dismisses via "Got It" button and overlay click
- [x] Check mobile responsiveness of the dialog