### PR TITLE
Fix Client Performance Retry button not re-detecting IP

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -86,7 +86,6 @@
         }
         var lastScrollTop = 0;
         var scrollUpAccum = 0; // cumulative upward scroll distance
-        var hasScrolledDown = false; // tracks if user has ever scrolled down (reset on nav)
         var currentEl = null;
 
         function attachListener(el) {
@@ -141,15 +140,10 @@
 
                 var nearBottom = currentEl.scrollHeight - st - currentEl.clientHeight < 40;
                 if (st <= 0) {
+                    // Always show nav bar at top of page
                     topBar.classList.remove('top-bar-hidden');
                     currentEl.style.scrollPaddingTop = '70px';
-                    // Auto-hide at top only on initial load; if the user scrolled
-                    // down and back up, they're reaching for the nav - don't hide it
-                    if (hasScrolledDown) {
-                        clearAutoHideTimer();
-                    } else {
-                        startAutoHideTimer(topBar);
-                    }
+                    startAutoHideTimer(topBar);
                     scrollUpAccum = 0;
                     lastScrollTop = st;
                 } else if (topBar) {
@@ -161,7 +155,6 @@
                     }
 
                     if (st > lastScrollTop && st > 60 && isContentScrollable()) {
-                        hasScrolledDown = true;
                         topBar.classList.add('top-bar-hidden');
                         currentEl.style.scrollPaddingTop = '0px';
                         clearAutoHideTimer();
@@ -193,7 +186,6 @@
         // hidden=false: page nav (show bar, add padding)
         window.__setScrollState = function(hidden) {
             lastScrollTop = 0;
-            hasScrolledDown = false;
             if (window.innerWidth <= 768) {
                 var topBar = document.querySelector('.top-bar');
                 if (topBar) {

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -86,6 +86,7 @@
         }
         var lastScrollTop = 0;
         var scrollUpAccum = 0; // cumulative upward scroll distance
+        var hasScrolledDown = false; // tracks if user has ever scrolled down (reset on nav)
         var currentEl = null;
 
         function attachListener(el) {
@@ -140,14 +141,19 @@
 
                 var nearBottom = currentEl.scrollHeight - st - currentEl.clientHeight < 40;
                 if (st <= 0) {
-                    // Always show nav bar at top of page - no auto-hide here,
-                    // otherwise the bar hides and the user can't scroll further up to recover it
                     topBar.classList.remove('top-bar-hidden');
                     currentEl.style.scrollPaddingTop = '70px';
-                    clearAutoHideTimer();
+                    // Auto-hide at top only on initial load; if the user scrolled
+                    // down and back up, they're reaching for the nav - don't hide it
+                    if (hasScrolledDown) {
+                        clearAutoHideTimer();
+                    } else {
+                        startAutoHideTimer(topBar);
+                    }
                     scrollUpAccum = 0;
                     lastScrollTop = st;
                 } else if (topBar) {
+                    hasScrolledDown = true;
                     var delta = lastScrollTop - st; // positive = scrolling up
                     if (delta > 0) {
                         scrollUpAccum += delta;
@@ -187,6 +193,7 @@
         // hidden=false: page nav (show bar, add padding)
         window.__setScrollState = function(hidden) {
             lastScrollTop = 0;
+            hasScrolledDown = false;
             if (window.innerWidth <= 768) {
                 var topBar = document.querySelector('.top-bar');
                 if (topBar) {

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -204,6 +204,19 @@
         attachListener(getScrollEl());
         window.addEventListener('resize', function() { attachListener(getScrollEl()); });
 
+        // Show nav bar when content shrinks below scrollable (e.g. Blazor re-render on disconnect)
+        var resizeObs = new ResizeObserver(function() {
+            if (window.innerWidth > 768) return;
+            var topBar = document.querySelector('.top-bar');
+            if (topBar && topBar.classList.contains('top-bar-hidden') && !isContentScrollable()) {
+                topBar.classList.remove('top-bar-hidden');
+                if (currentEl) currentEl.style.scrollPaddingTop = '70px';
+                clearAutoHideTimer();
+            }
+        });
+        var mainContent = document.querySelector('.main-content');
+        if (mainContent) resizeObs.observe(mainContent);
+
         // Restart auto-hide timer when sidebar closes
         var sidebar = document.querySelector('.sidebar');
         if (sidebar) {

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -140,10 +140,11 @@
 
                 var nearBottom = currentEl.scrollHeight - st - currentEl.clientHeight < 40;
                 if (st <= 0) {
-                    // Always show nav bar at top of page
+                    // Always show nav bar at top of page - no auto-hide here,
+                    // otherwise the bar hides and the user can't scroll further up to recover it
                     topBar.classList.remove('top-bar-hidden');
                     currentEl.style.scrollPaddingTop = '70px';
-                    startAutoHideTimer(topBar);
+                    clearAutoHideTimer();
                     scrollUpAccum = 0;
                     lastScrollTop = st;
                 } else if (topBar) {
@@ -203,19 +204,6 @@
 
         attachListener(getScrollEl());
         window.addEventListener('resize', function() { attachListener(getScrollEl()); });
-
-        // Show nav bar when content shrinks below scrollable (e.g. Blazor re-render on disconnect)
-        var resizeObs = new ResizeObserver(function() {
-            if (window.innerWidth > 768) return;
-            var topBar = document.querySelector('.top-bar');
-            if (topBar && topBar.classList.contains('top-bar-hidden') && !isContentScrollable()) {
-                topBar.classList.remove('top-bar-hidden');
-                if (currentEl) currentEl.style.scrollPaddingTop = '70px';
-                clearAutoHideTimer();
-            }
-        });
-        var mainContent = document.querySelector('.main-content');
-        if (mainContent) resizeObs.observe(mainContent);
 
         // Restart auto-hide timer when sidebar closes
         var sidebar = document.querySelector('.sidebar');

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -153,7 +153,6 @@
                     scrollUpAccum = 0;
                     lastScrollTop = st;
                 } else if (topBar) {
-                    hasScrolledDown = true;
                     var delta = lastScrollTop - st; // positive = scrolling up
                     if (delta > 0) {
                         scrollUpAccum += delta;
@@ -162,6 +161,7 @@
                     }
 
                     if (st > lastScrollTop && st > 60 && isContentScrollable()) {
+                        hasScrolledDown = true;
                         topBar.classList.add('top-bar-hidden');
                         currentEl.style.scrollPaddingTop = '0px';
                         clearAutoHideTimer();

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -122,7 +122,7 @@
         <div class="card empty-state">
             <h3>Device Not Found</h3>
             <p>Could not identify your device on the network. Make sure you're connected and the UniFi Console is reachable.</p>
-            <button class="btn btn-primary" @onclick="RetryIdentify">Retry</button>
+            <button class="btn btn-primary" @onclick="() => NavigationManager.NavigateTo(NavigationManager.Uri, forceLoad: true)">Retry</button>
         </div>
     }
     else
@@ -1636,12 +1636,6 @@
             ? DateTime.MinValue
             : to.AddHours(-_selectedTimeFilter);
         return (from, to);
-    }
-
-    private async Task RetryIdentify()
-    {
-        await IdentifyAndLoadAsync();
-        StateHasChanged();
     }
 
     private void ToggleResultExpand(int resultId)

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -90,6 +90,7 @@
                     <strong>Device Offline</strong>
                     <span>This device is currently offline. Showing historical data. Live data will appear when it reconnects.</span>
                 </div>
+                <button class="btn btn-primary btn-sm" @onclick="() => NavigationManager.NavigateTo(NavigationManager.Uri, forceLoad: true)">Retry</button>
             </div>
         </div>
     }


### PR DESCRIPTION
## Summary

- Retry button on the "Device Not Found" screen now does a full page reload instead of re-calling the identity logic within the existing Blazor circuit
- In Blazor Server, `HttpContext` (used to detect client IP) is only available during the initial HTTP request - it's null after the WebSocket circuit starts, so retrying within the circuit could never pick up a new IP (e.g. after switching from WAN/Tailscale to Wi-Fi)

## Test plan

- [x] Open Client Performance on mobile via WAN/Tailscale (shows "Device Not Found")
- [x] Switch to Wi-Fi, tap Retry - should now find the device
- [x] Verify normal Client Performance flow still works on Wi-Fi