### PR TITLE
Fix Channel Issues tab missing issue details

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -499,7 +499,7 @@
                     <h4>Channel Issues</h4>
                 </div>
 
-                <IssuesList Issues="_channelIssues" OnClientClick="OnClientClick" />
+                <IssuesList Issues="_channelIssues" ShowDetails="true" OnClientClick="OnClientClick" />
             </div>
         }
         } @* end else (not showing recommendations) *@


### PR DESCRIPTION
## Summary

- **Channel Issues tab now shows full issue details** - The IssuesList component's `ShowDetails` parameter defaulted to `false`, so the Channels > Channel Issues tab only showed issue titles and descriptions. Recommendations, affected radios, and remediation steps were missing. The Overview tab already passed `ShowDetails="true"` and displayed everything correctly.

## Test plan

- [x] Navigate to Channels > Channel Issues tab
- [x] Verify issues show full details: recommendation text, affected radio list, and remediation steps
- [x] Verify Overview tab still displays the same details as before