### PR TITLE
TBD release

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
@@ -116,7 +116,7 @@
                     @if (_gatewayConnected && _status?.FirmwareSupported == false && !string.IsNullOrEmpty(_status?.FirmwareVersion))
                     {
                         <div class="alert alert-danger" style="margin-top: 1rem;">
-                            <strong>Unsupported Firmware:</strong> Performance tweaks are currently tested and supported up to UniFi OS 5.1.10. Your gateway is running @_status.FirmwareVersion. Deploying new tweaks is disabled until we validate compatibility with this version. Existing tweaks will continue to run.
+                            <strong>Unsupported Firmware:</strong> Performance tweaks are currently tested and supported up to UniFi OS 5.1.11. Your gateway is running @_status.FirmwareVersion. Deploying new tweaks is disabled until we validate compatibility with this version. Existing tweaks will continue to run.
                         </div>
                     }
 

--- a/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
@@ -19,7 +19,7 @@ public class PerfTweaksDeploymentService
     private const string OnBootDir = "/data/on_boot.d";
     private const string PerfTweaksDir = "/data/perf-tweaks";
     private const string SfpModuleDir = "/data/sfp-sgmiiplus";
-    private static readonly Version MaxSupportedFirmware = new(5, 1, 10);
+    private static readonly Version MaxSupportedFirmware = new(5, 1, 11);
 
     private static readonly Dictionary<string, string> BootScriptFiles = new()
     {


### PR DESCRIPTION
## Summary

- **Bump perf tweaks firmware gate to 5.1.11** - Raises the max supported UniFi OS version for performance tweaks deployment from 5.1.10 to 5.1.11.