### PR TITLE
Read roaming assistant from SSID-level WLAN config

### DIFF
--- a/src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs
@@ -48,6 +48,33 @@ public class FlexibleBoolConverter : JsonConverter<bool>
 }
 
 /// <summary>
+/// Nullable version of FlexibleBoolConverter for fields that may be absent from the response.
+/// </summary>
+public class FlexibleNullableBoolConverter : JsonConverter<bool?>
+{
+    public override bool? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.TokenType switch
+        {
+            JsonTokenType.True => true,
+            JsonTokenType.False => false,
+            JsonTokenType.String => bool.TryParse(reader.GetString(), out var value) ? value : null,
+            JsonTokenType.Number => reader.GetInt32() != 0,
+            JsonTokenType.Null => null,
+            _ => null
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, bool? value, JsonSerializerOptions options)
+    {
+        if (value.HasValue)
+            writer.WriteBooleanValue(value.Value);
+        else
+            writer.WriteNullValue();
+    }
+}
+
+/// <summary>
 /// JSON converter that handles int values that may come as strings, empty strings, or null.
 /// UniFi API sometimes returns VLAN IDs as strings or empty strings instead of numbers.
 /// </summary>

--- a/src/NetworkOptimizer.UniFi/Models/UniFiWlanConfig.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiWlanConfig.cs
@@ -73,6 +73,22 @@ public class UniFiWlanConfig
     [JsonPropertyName("minrate_na_advertising_rates")]
     public bool MinrateNaAdvertisingRates { get; set; }
 
+    [JsonPropertyName("roaming_assistant_na_enabled")]
+    [JsonConverter(typeof(FlexibleNullableBoolConverter))]
+    public bool? RoamingAssistantNaEnabled { get; set; }
+
+    [JsonPropertyName("roaming_assistant_na_rssi")]
+    [JsonConverter(typeof(FlexibleIntConverter))]
+    public int? RoamingAssistantNaRssi { get; set; }
+
+    [JsonPropertyName("roaming_assistant_6e_enabled")]
+    [JsonConverter(typeof(FlexibleNullableBoolConverter))]
+    public bool? RoamingAssistant6eEnabled { get; set; }
+
+    [JsonPropertyName("roaming_assistant_6e_rssi")]
+    [JsonConverter(typeof(FlexibleIntConverter))]
+    public int? RoamingAssistant6eRssi { get; set; }
+
     /// <summary>
     /// AP group mode: "all" means broadcast on all APs, otherwise check ap_group_ids
     /// </summary>

--- a/src/NetworkOptimizer.WiFi/Models/WlanConfiguration.cs
+++ b/src/NetworkOptimizer.WiFi/Models/WlanConfiguration.cs
@@ -50,6 +50,18 @@ public class WlanConfiguration
     /// </summary>
     public bool MloEnabled { get; set; }
 
+    /// <summary>Whether Roaming Assistant is enabled on 5 GHz (SSID-level setting)</summary>
+    public bool? RoamingAssistant5GHzEnabled { get; set; }
+
+    /// <summary>Roaming Assistant RSSI threshold for 5 GHz (dBm)</summary>
+    public int? RoamingAssistant5GHzRssi { get; set; }
+
+    /// <summary>Whether Roaming Assistant is enabled on 6 GHz (SSID-level setting)</summary>
+    public bool? RoamingAssistant6GHzEnabled { get; set; }
+
+    /// <summary>Roaming Assistant RSSI threshold for 6 GHz (dBm)</summary>
+    public int? RoamingAssistant6GHzRssi { get; set; }
+
     /// <summary>Minimum data rate settings</summary>
     public MinRateSettings? MinRateSettings { get; set; }
 

--- a/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
@@ -436,6 +436,10 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
                     MinRate5GHz = w.MinrateNaEnabled ? w.MinrateNaDataRateKbps : null,
                     AdvertiseLowerRates = w.MinrateNgAdvertisingRates || w.MinrateNaAdvertisingRates
                 },
+                RoamingAssistant5GHzEnabled = w.RoamingAssistantNaEnabled,
+                RoamingAssistant5GHzRssi = w.RoamingAssistantNaRssi,
+                RoamingAssistant6GHzEnabled = w.RoamingAssistant6eEnabled,
+                RoamingAssistant6GHzRssi = w.RoamingAssistant6eRssi,
                 NetworkId = w.NetworkConfId,
                 PrivatePresharedKeysEnabled = w.PrivatePresharedKeysEnabled,
                 PpskNetworkIds = w.PrivatePresharedKeys?

--- a/src/NetworkOptimizer.WiFi/Rules/RoamingAssistantRule.cs
+++ b/src/NetworkOptimizer.WiFi/Rules/RoamingAssistantRule.cs
@@ -11,78 +11,86 @@ public class RoamingAssistantRule : IWiFiOptimizerRule
         if (ctx.AccessPoints.Count <= 1)
             return null;
 
-        var issues = new List<string>();
-
         // Try SSID-level settings first (newer UniFi Network versions)
         var enabledWlans = ctx.Wlans.Where(w => w.Enabled).ToList();
         var hasSsidLevelSettings = enabledWlans.Any(w => w.RoamingAssistant5GHzEnabled.HasValue);
 
         if (hasSsidLevelSettings)
-        {
-            if (ctx.Has5GHzCoverage)
-            {
-                var wlansWithout5g = enabledWlans
-                    .Where(w => w.EnabledBands.Contains(RadioBand.Band5GHz) &&
-                                w.RoamingAssistant5GHzEnabled != true)
-                    .ToList();
-
-                if (wlansWithout5g.Count > 0)
-                    issues.Add($"5 GHz: {string.Join(", ", wlansWithout5g.Select(w => w.Name))}");
-            }
-
-            if (ctx.Has6GHzCoverage)
-            {
-                var wlansWithout6g = enabledWlans
-                    .Where(w => w.EnabledBands.Contains(RadioBand.Band6GHz) &&
-                                w.RoamingAssistant6GHzEnabled != true)
-                    .ToList();
-
-                if (wlansWithout6g.Count > 0)
-                    issues.Add($"6 GHz: {string.Join(", ", wlansWithout6g.Select(w => w.Name))}");
-            }
-
-            if (issues.Count == 0)
-                return null;
-
-            return new HealthIssue
-            {
-                Severity = HealthIssueSeverity.Info,
-                Dimensions = { HealthDimension.RoamingPerformance },
-                Title = "Enable Roaming Assistant (Recommended)",
-                Description = $"SSIDs without Roaming Assistant - {string.Join("; ", issues)}. " +
-                    "Roaming Assistant uses BSS transition frames (soft nudge) instead of hard-disconnecting clients.",
-                AffectedEntity = string.Join("; ", issues),
-                Recommendation = "Per SSID: Settings > WiFi > (SSID) > Advanced > Roaming Assistant. " +
-                    "Recommended threshold: -70 to -75 dBm.",
-                ScoreImpact = -3,
-                ShowOnOverview = false
-            };
-        }
+            return EvaluateSsidLevel(ctx, enabledWlans);
 
         // Fallback: per-AP radio_table settings (older UniFi Network versions)
-        var apsWithout5gRoamingAssistant = ctx.AccessPoints
+        return EvaluatePerAp(ctx);
+    }
+
+    private static HealthIssue? EvaluateSsidLevel(WiFiOptimizerContext ctx, List<WlanConfiguration> enabledWlans)
+    {
+        var issues = new List<string>();
+
+        if (ctx.Has5GHzCoverage)
+        {
+            var wlansWithout5g = enabledWlans
+                .Where(w => w.EnabledBands.Contains(RadioBand.Band5GHz) &&
+                            w.RoamingAssistant5GHzEnabled != true)
+                .ToList();
+
+            if (wlansWithout5g.Count > 0)
+                issues.Add($"5 GHz: {string.Join(", ", wlansWithout5g.Select(w => w.Name))}");
+        }
+
+        if (ctx.Has6GHzCoverage)
+        {
+            var wlansWithout6g = enabledWlans
+                .Where(w => w.EnabledBands.Contains(RadioBand.Band6GHz) &&
+                            w.RoamingAssistant6GHzEnabled != true)
+                .ToList();
+
+            if (wlansWithout6g.Count > 0)
+                issues.Add($"6 GHz: {string.Join(", ", wlansWithout6g.Select(w => w.Name))}");
+        }
+
+        if (issues.Count == 0)
+            return null;
+
+        var affected = string.Join("; ", issues);
+        return BuildIssue(
+            $"SSIDs without Roaming Assistant - {affected}. " +
+                "Roaming Assistant uses BSS transition frames (soft nudge) instead of hard-disconnecting clients.",
+            affected,
+            "Per SSID: Settings > WiFi > (SSID) > Advanced > Roaming Assistant. " +
+                "Recommended threshold: -70 to -75 dBm.");
+    }
+
+    private static HealthIssue? EvaluatePerAp(WiFiOptimizerContext ctx)
+    {
+        var apsWithout = ctx.AccessPoints
             .Where(ap => ap.Radios.Any(r =>
                 r.Band == RadioBand.Band5GHz &&
                 r.Channel.HasValue &&
                 !r.RoamingAssistantEnabled))
             .ToList();
 
-        if (apsWithout5gRoamingAssistant.Count == 0)
+        if (apsWithout.Count == 0)
             return null;
 
-        return new HealthIssue
-        {
-            Severity = HealthIssueSeverity.Info,
-            Dimensions = { HealthDimension.RoamingPerformance },
-            Title = "Enable Roaming Assistant (Recommended)",
-            Description = $"{apsWithout5gRoamingAssistant.Count} AP(s) don't have Roaming Assistant enabled on 5 GHz. " +
+        var names = string.Join(", ", apsWithout.Select(ap => ap.Name));
+        return BuildIssue(
+            $"{apsWithout.Count} AP(s) don't have Roaming Assistant enabled on 5 GHz. " +
                 "Unlike Minimum RSSI, this uses BSS transition frames (soft nudge) instead of hard-disconnecting clients.",
-            AffectedEntity = string.Join(", ", apsWithout5gRoamingAssistant.Select(ap => ap.Name)),
-            Recommendation = "Per AP: Devices > (AP) > Settings > Radios > 5 GHz > Roaming Assistant. " +
+            names,
+            "Per AP: Devices > (AP) > Settings > Radios > 5 GHz > Roaming Assistant. " +
                 "Or globally: Settings > WiFi > 5 GHz Roaming Assistant with 'Override All APs'. " +
-                "Recommended threshold: -70 to -75 dBm.",
-            ScoreImpact = -3,
-            ShowOnOverview = false
-        };
+                "Recommended threshold: -70 to -75 dBm.");
     }
+
+    private static HealthIssue BuildIssue(string description, string affected, string recommendation) => new()
+    {
+        Severity = HealthIssueSeverity.Info,
+        Dimensions = { HealthDimension.RoamingPerformance },
+        Title = "Enable Roaming Assistant (Recommended)",
+        Description = description,
+        AffectedEntity = affected,
+        Recommendation = recommendation,
+        ScoreImpact = -3,
+        ShowOnOverview = false
+    };
 }

--- a/src/NetworkOptimizer.WiFi/Rules/RoamingAssistantRule.cs
+++ b/src/NetworkOptimizer.WiFi/Rules/RoamingAssistantRule.cs
@@ -2,21 +2,64 @@ using NetworkOptimizer.WiFi.Models;
 
 namespace NetworkOptimizer.WiFi.Rules;
 
-/// <summary>
-/// Rule that recommends enabling Roaming Assistant on 5 GHz radios.
-/// Unlike Minimum RSSI, Roaming Assistant uses BSS transition frames (soft nudge)
-/// instead of hard-disconnecting clients.
-/// </summary>
 public class RoamingAssistantRule : IWiFiOptimizerRule
 {
     public string RuleId => "WIFI-ROAMING-ASSISTANT-001";
 
     public HealthIssue? Evaluate(WiFiOptimizerContext ctx)
     {
-        // Only relevant for multi-AP deployments
         if (ctx.AccessPoints.Count <= 1)
             return null;
 
+        var issues = new List<string>();
+
+        // Try SSID-level settings first (newer UniFi Network versions)
+        var enabledWlans = ctx.Wlans.Where(w => w.Enabled).ToList();
+        var hasSsidLevelSettings = enabledWlans.Any(w => w.RoamingAssistant5GHzEnabled.HasValue);
+
+        if (hasSsidLevelSettings)
+        {
+            if (ctx.Has5GHzCoverage)
+            {
+                var wlansWithout5g = enabledWlans
+                    .Where(w => w.EnabledBands.Contains(RadioBand.Band5GHz) &&
+                                w.RoamingAssistant5GHzEnabled != true)
+                    .ToList();
+
+                if (wlansWithout5g.Count > 0)
+                    issues.Add($"5 GHz: {string.Join(", ", wlansWithout5g.Select(w => w.Name))}");
+            }
+
+            if (ctx.Has6GHzCoverage)
+            {
+                var wlansWithout6g = enabledWlans
+                    .Where(w => w.EnabledBands.Contains(RadioBand.Band6GHz) &&
+                                w.RoamingAssistant6GHzEnabled != true)
+                    .ToList();
+
+                if (wlansWithout6g.Count > 0)
+                    issues.Add($"6 GHz: {string.Join(", ", wlansWithout6g.Select(w => w.Name))}");
+            }
+
+            if (issues.Count == 0)
+                return null;
+
+            return new HealthIssue
+            {
+                Severity = HealthIssueSeverity.Info,
+                Dimensions = { HealthDimension.RoamingPerformance },
+                Title = "Enable Roaming Assistant (Recommended)",
+                Description = $"SSIDs without Roaming Assistant - {string.Join("; ", issues)}. " +
+                    "Roaming Assistant uses BSS transition frames (soft nudge) instead of hard-disconnecting clients.",
+                AffectedEntity = string.Join("; ", issues),
+                Recommendation = "Per SSID: Settings > WiFi > (SSID) > Advanced > Roaming Assistant. " +
+                    "Recommended threshold: -70 to -75 dBm.",
+                ScoreImpact = -3,
+                ShowOnOverview = false
+            };
+        }
+
+        // Fallback: per-AP radio_table settings (older UniFi Network versions)
         var apsWithout5gRoamingAssistant = ctx.AccessPoints
             .Where(ap => ap.Radios.Any(r =>
                 r.Band == RadioBand.Band5GHz &&
@@ -39,7 +82,7 @@ public class RoamingAssistantRule : IWiFiOptimizerRule
                 "Or globally: Settings > WiFi > 5 GHz Roaming Assistant with 'Override All APs'. " +
                 "Recommended threshold: -70 to -75 dBm.",
             ScoreImpact = -3,
-            ShowOnOverview = false  // Informational, only relevant to Roaming tab
+            ShowOnOverview = false
         };
     }
 }


### PR DESCRIPTION
## Summary

- UniFi Network 10.4.x moved Roaming Assistant from per-AP radio settings to per-SSID WLAN config, covering both 5 GHz and 6 GHz bands
- Parse the new `roaming_assistant_na_enabled/rssi` and `roaming_assistant_6e_enabled/rssi` fields from the WLAN config response
- WiFi Optimizer rule checks SSID-level settings first, falls back to per-AP `radio_table` for older UniFi Network versions
- Added `FlexibleNullableBoolConverter` for nullable bool fields that may be absent from the API response

## Test plan

- [x] Run WiFi health check on UniFi Network 10.4.x - verify SSID-level roaming assistant detection works
- [x] Verify rule correctly identifies SSIDs missing roaming assistant on 5 GHz and 6 GHz
- [x] Verify fallback to per-AP detection on older UniFi Network versions