### PR TITLE
Redirect syslog-ng persist file to tmpfs in volatile log tweak

### DIFF
--- a/src/NetworkOptimizer.Web/Resources/PerfTweaks/10-journald-volatile.sh
+++ b/src/NetworkOptimizer.Web/Resources/PerfTweaks/10-journald-volatile.sh
@@ -46,6 +46,25 @@ else
     log "journald already configured."
 fi
 
+# ─── Part 1b: syslog-ng persist file → tmpfs ───
+#
+# syslog-ng writes its state to a persist file on every config/state change.
+# Default location is /var/log/.syslog-ng.persist (eMMC). Redirect to /run/
+# (tmpfs) to eliminate these continuous eMMC writes. The persist file only
+# tracks source read positions — losing it on reboot just means syslog-ng
+# re-reads from the current journal position, which is fine for volatile logs.
+
+PERSIST_CONF="/etc/default/syslog-ng-persist"
+PERSIST_TMPFS="/run/syslog-ng.persist"
+
+CURRENT_PERSIST=$(grep "^SYSLOGNG_OPTS" "$PERSIST_CONF" 2>/dev/null | grep -o 'persist-file=[^ "]*' | cut -d= -f2)
+
+if [ "$CURRENT_PERSIST" != "$PERSIST_TMPFS" ]; then
+    echo "SYSLOGNG_OPTS=\"--persist-file=$PERSIST_TMPFS\"" > "$PERSIST_CONF"
+    log "Redirected syslog-ng persist file to tmpfs ($PERSIST_TMPFS)"
+    SYSLOG_CHANGED=true
+fi
+
 # ─── Part 2: syslog-ng local file destinations ───
 #
 # Comment out log{} lines that route to local file destinations on eMMC.


### PR DESCRIPTION
## Summary

- **syslog-ng persist file → tmpfs** - syslog-ng writes its state to a persist file on every config/state change. The default location (`/var/log/.syslog-ng.persist`) is on eMMC. Part 1b of the volatile logging tweak now redirects this to `/run/syslog-ng.persist` (tmpfs), eliminating another source of continuous eMMC writes.

Synced from unifi-perf-tweaks source repo.

## Test plan

- [x] Deploy to gateway with volatile log tweak enabled
- [x] Verify `/etc/default/syslog-ng-persist` contains the `--persist-file=/run/syslog-ng.persist` option
- [x] Confirm syslog-ng uses tmpfs persist path after restart
- [x] Verify script is idempotent (second run reports "already configured")