### PR TITLE
Bind to both IPv4 and IPv6 interfaces

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -3,7 +3,7 @@
 
 # ===== Network Binding =====
 # BIND_LOCALHOST_ONLY: Controls which network interfaces the app listens on
-#   - false (default): Binds to 0.0.0.0:8042 (accessible from network)
+#   - false (default): Binds to *:8042 (accessible from network, IPv4 + IPv6)
 #   - true: Binds to 127.0.0.1:8042 (localhost only, use with reverse proxy on same host)
 # BIND_LOCALHOST_ONLY=false
 

--- a/docker/NATIVE-DEPLOYMENT.md
+++ b/docker/NATIVE-DEPLOYMENT.md
@@ -102,7 +102,7 @@ export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
 
 # Environment configuration
 export TZ="America/Chicago"  # Change to your timezone
-export ASPNETCORE_URLS="http://0.0.0.0:8042"
+export ASPNETCORE_URLS="http://*:8042"
 
 # Host IP - required for iperf3 client result tracking
 export HOST_IP="192.168.1.100"  # Change to this Mac's IP address
@@ -310,7 +310,7 @@ cd "$(dirname "$0")"
 
 # Environment configuration
 export TZ="America/Chicago"  # Change to your timezone
-export ASPNETCORE_URLS="http://0.0.0.0:8042"
+export ASPNETCORE_URLS="http://*:8042"
 
 # Host IP - required for iperf3 client result tracking
 export HOST_IP="192.168.1.100"  # Change to this server's IP address
@@ -594,7 +594,7 @@ chmod +x /opt/network-optimizer/start.sh
 
 Change the port in your startup script:
 ```bash
-export ASPNETCORE_URLS="http://0.0.0.0:8080"  # Use different port
+export ASPNETCORE_URLS="http://*:8080"  # Use different port
 ```
 
 ### Check Application Logs

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -18,8 +18,8 @@ if [ "${BIND_LOCALHOST_ONLY,,}" = "true" ]; then
     export ASPNETCORE_URLS="http://127.0.0.1:8042"
     echo "Binding to localhost only (127.0.0.1:8042)"
 else
-    export ASPNETCORE_URLS="http://0.0.0.0:8042"
-    echo "Binding to all interfaces (0.0.0.0:8042)"
+    export ASPNETCORE_URLS="http://*:8042"
+    echo "Binding to all interfaces (*:8042, IPv4 + IPv6)"
 fi
 
 # Drop to app user and run the application

--- a/scripts/install-macos-native.sh
+++ b/scripts/install-macos-native.sh
@@ -340,7 +340,7 @@ export PATH="$BREW_PREFIX/bin:/usr/local/bin:\$PATH"
 
 # Environment configuration
 export TZ="${TZ:-America/Chicago}"
-export ASPNETCORE_URLS="http://0.0.0.0:8042"
+export ASPNETCORE_URLS="http://*:8042"
 
 # Enable iperf3 server for CLI-based client speed testing (port 5201)
 export Iperf3Server__Enabled=true

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -42,7 +42,7 @@ if (OperatingSystem.IsWindows())
                       || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("ASPNETCORE_HTTP_PORTS"));
     if (!urlsConfigured)
     {
-        builder.WebHost.UseUrls("http://0.0.0.0:8042");
+        builder.WebHost.UseUrls("http://*:8042");
     }
 }
 


### PR DESCRIPTION
Closes #612

## Summary

- Changed all `ASPNETCORE_URLS` bindings from `http://0.0.0.0:8042` (IPv4 only) to `http://*:8042`, which tells Kestrel to listen on all interfaces for both IPv4 and IPv6
- Updated Docker entrypoint, Windows service fallback, macOS install script, native deployment docs, and env example

The `*` wildcard is more portable than binding to `[::]` directly - Kestrel creates listeners for whichever protocols are available, so it degrades gracefully if IPv6 is disabled on the host.

## Test plan

- [x] `dotnet build` - 0 warnings
- [x] Deployed to NAS (uses `BIND_LOCALHOST_ONLY=true`, so unaffected by this change)
- [x] Deployed to Mac - updated `start.sh` in place and restarted service