### PR TITLE
v1.16.9

### DIFF
--- a/src/NetworkOptimizer.Audit/Analyzers/PortSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/PortSecurityAnalyzer.cs
@@ -71,9 +71,11 @@ public class PortSecurityAnalyzer
             _logger.LogInformation("Enhanced device detection enabled for audit rules");
         }
 
-        // Inject logger into rules that support it
-        UnusedPortRule.SetLogger(_logger);
-        AccessPortVlanRule.SetLogger(_logger);
+        // Inject logger into rules
+        foreach (var rule in _rules.OfType<AuditRuleBase>())
+            rule.SetLogger(_logger);
+        foreach (var rule in _wirelessRules.OfType<WirelessAuditRuleBase>())
+            rule.SetLogger(_logger);
     }
 
     /// <summary>
@@ -738,6 +740,11 @@ public class PortSecurityAnalyzer
                         _logger.LogDebug("Rule {RuleId} found issue on {Switch} port {Port}: {Message}",
                             rule.RuleId, switchInfo.Name, port.PortIndex, issue.Message);
                     }
+                    else
+                    {
+                        _logger.LogDebug("Rule {RuleId} passed on {Switch} port {Port} ({PortName})",
+                            rule.RuleId, switchInfo.Name, port.PortIndex, port.Name ?? "");
+                    }
                 }
             }
         }
@@ -944,18 +951,28 @@ public class PortSecurityAnalyzer
 
             // Determine effective network ID using this priority:
             // 1. Client's EffectiveNetworkId (handles virtual_network_override_id when override is enabled)
-            // 2. Protect API's connection_network_id (for UniFi Protect cameras)
+            // 2. Protect API's connection_network_id (for Protect cameras with network overrides)
             // 3. Match by VLAN number if available
             var effectiveNetworkId = client.EffectiveNetworkId;
 
-            // For UniFi Protect cameras, also check if Protect API has different network info
-            if (_protectCameras?.TryGetNetworkId(client.Mac, out var protectNetworkId) == true)
+            // For UniFi Protect cameras, prefer Protect API's connection_network_id when it
+            // resolves to a known network. Protect knows the authoritative network for its devices.
+            // However, with L3 switching the connection_network_id can point to the inter-VLAN
+            // routing infrastructure (excluded from networks list), in which case we ignore it.
+            if (_protectCameras?.TryGetNetworkId(client.Mac, out var protectNetworkId) == true &&
+                protectNetworkId != effectiveNetworkId)
             {
-                if (protectNetworkId != effectiveNetworkId)
+                var protectNetwork = networks.FirstOrDefault(n => n.Id == protectNetworkId);
+                if (protectNetwork != null)
                 {
-                    _logger.LogDebug("Network override for {Mac}: Network API reported {NetworkApiId}, using Protect API's {ProtectApiId}",
-                        client.Mac, effectiveNetworkId, protectNetworkId);
+                    _logger.LogDebug("Network override for {Mac}: Network API reported {NetworkApiId}, using Protect API's {ProtectApiId} ({NetworkName})",
+                        client.Mac, effectiveNetworkId, protectNetworkId, protectNetwork.Name);
                     effectiveNetworkId = protectNetworkId;
+                }
+                else
+                {
+                    _logger.LogDebug("Ignoring Protect API network {ProtectApiId} for {Mac} (not in network list, likely L3 routing infrastructure)",
+                        protectNetworkId, client.Mac);
                 }
             }
 

--- a/src/NetworkOptimizer.Audit/Analyzers/VlanAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/VlanAnalyzer.cs
@@ -167,6 +167,57 @@ public class VlanAnalyzer
     }
 
     /// <summary>
+    /// Build a NetworkInfo from a UniFiNetworkConfig (rest/networkconf).
+    /// Used to supplement gateway network_table with switch-routed networks.
+    /// </summary>
+    public NetworkInfo NetworkInfoFromConfig(UniFiNetworkConfig nc, FirewallZoneLookup? zoneLookup = null)
+    {
+        var vlanId = nc.Vlan ?? 1;
+        var isGuest = string.Equals(nc.Purpose, "guest", StringComparison.OrdinalIgnoreCase);
+        var purpose = ClassifyNetwork(nc.Name, nc.Purpose, vlanId,
+            nc.DhcpdEnabled, nc.NetworkIsolationEnabled, nc.InternetAccessEnabled,
+            nc.FirewallZoneId, zoneLookup);
+
+        List<string>? dnsServers = null;
+        if (nc.DhcpdDnsEnabled)
+        {
+            dnsServers = new List<string>();
+            if (!string.IsNullOrEmpty(nc.DhcpdDns1)) dnsServers.Add(nc.DhcpdDns1);
+            if (!string.IsNullOrEmpty(nc.DhcpdDns2)) dnsServers.Add(nc.DhcpdDns2);
+            if (!string.IsNullOrEmpty(nc.DhcpdDns3)) dnsServers.Add(nc.DhcpdDns3);
+            if (!string.IsNullOrEmpty(nc.DhcpdDns4)) dnsServers.Add(nc.DhcpdDns4);
+            if (dnsServers.Count == 0) dnsServers = null;
+        }
+
+        return new NetworkInfo
+        {
+            Id = nc.Id,
+            Name = nc.Name ?? "Unknown",
+            VlanId = vlanId,
+            Purpose = purpose,
+            Subnet = NormalizeSubnet(nc.IpSubnet),
+            Gateway = ExtractGatewayFromSubnet(nc.IpSubnet),
+            DnsServers = dnsServers,
+            DhcpEnabled = nc.DhcpdEnabled,
+            NetworkIsolationEnabled = nc.NetworkIsolationEnabled,
+            InternetAccessEnabled = nc.InternetAccessEnabled,
+            IsUniFiGuestNetwork = isGuest,
+            FirewallZoneId = nc.FirewallZoneId,
+            NetworkGroup = nc.Networkgroup,
+            UpnpLanEnabled = nc.UpnpLanEnabled,
+            Enabled = nc.Enabled
+        };
+    }
+
+    private static string? ExtractGatewayFromSubnet(string? ipSubnet)
+    {
+        if (string.IsNullOrEmpty(ipSubnet))
+            return null;
+        var slashIndex = ipSubnet.IndexOf('/');
+        return slashIndex > 0 ? ipSubnet[..slashIndex] : null;
+    }
+
+    /// <summary>
     /// Parse a single network from JSON
     /// </summary>
     private NetworkInfo? ParseNetwork(JsonElement network, FirewallZoneLookup? zoneLookup = null)
@@ -174,6 +225,15 @@ public class VlanAnalyzer
         var networkId = network.GetStringFromAny("_id", "network_id");
         if (string.IsNullOrEmpty(networkId))
             return null;
+
+        // Skip system/infrastructure networks (e.g., "Inter-VLAN routing" for L3 switching)
+        var attrHiddenId = network.GetStringOrNull("attr_hidden_id");
+        if (string.Equals(attrHiddenId, "ROUTE", StringComparison.OrdinalIgnoreCase))
+        {
+            var sysName = network.GetStringOrDefault("name", "Unknown");
+            _logger.LogDebug("Skipping system network '{Name}' (attr_hidden_id=ROUTE)", sysName);
+            return null;
+        }
 
         var name = network.GetStringOrDefault("name", "Unknown");
         var vlanId = network.GetIntOrDefault("vlan", network.GetIntOrDefault("vlan_id", 1));

--- a/src/NetworkOptimizer.Audit/ConfigAuditEngine.cs
+++ b/src/NetworkOptimizer.Audit/ConfigAuditEngine.cs
@@ -489,7 +489,36 @@ public class ConfigAuditEngine
     {
         _logger.LogInformation("Phase 1: Extracting network topology");
         ctx.Networks = _vlanAnalyzer.ExtractNetworks(ctx.DeviceData, ctx.ZoneLookup);
-        _logger.LogInformation("Found {NetworkCount} networks", ctx.Networks.Count);
+        _logger.LogInformation("Found {NetworkCount} networks from gateway", ctx.Networks.Count);
+
+        // Supplement with switch-routed networks from NetworkConfigs that are missing from
+        // the gateway's network_table (L3 switching moves routing to the switch)
+        if (ctx.NetworkConfigs is { Count: > 0 })
+        {
+            var existingIds = new HashSet<string>(ctx.Networks.Select(n => n.Id));
+            var added = 0;
+            foreach (var nc in ctx.NetworkConfigs)
+            {
+                if (string.IsNullOrEmpty(nc.Id) || existingIds.Contains(nc.Id))
+                    continue;
+                if (nc.IsSystemNetwork || !nc.Enabled)
+                    continue;
+                if (!string.Equals(nc.Purpose, "corporate", StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(nc.Purpose, "guest", StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (!string.Equals(nc.Networkgroup, "LAN", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var networkInfo = _vlanAnalyzer.NetworkInfoFromConfig(nc, ctx.ZoneLookup);
+                ctx.Networks.Add(networkInfo);
+                added++;
+                _logger.LogDebug("Added switch-routed network from config: {Name} (VLAN {VlanId})",
+                    networkInfo.Name, networkInfo.VlanId);
+            }
+
+            if (added > 0)
+                _logger.LogInformation("Added {Count} switch-routed networks from config (total: {Total})", added, ctx.Networks.Count);
+        }
 
         // Apply user purpose overrides
         _vlanAnalyzer.ApplyPurposeOverrides(ctx.Networks, ctx.NetworkPurposeOverrides);
@@ -518,7 +547,7 @@ public class ConfigAuditEngine
         if (ctx.NetworkConfigs != null && ctx.NetworkConfigs.Count > 0)
         {
             allNetworks = ctx.NetworkConfigs
-                .Where(nc => !string.IsNullOrEmpty(nc.Id) &&
+                .Where(nc => !string.IsNullOrEmpty(nc.Id) && !nc.IsSystemNetwork &&
                     (string.Equals(nc.Purpose, "corporate", StringComparison.OrdinalIgnoreCase) ||
                      string.Equals(nc.Purpose, "guest", StringComparison.OrdinalIgnoreCase) ||
                      string.Equals(nc.Purpose, "vlan-only", StringComparison.OrdinalIgnoreCase)))

--- a/src/NetworkOptimizer.Audit/Rules/CameraVlanRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/CameraVlanRule.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Audit.Models;
 using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Core.Models;
@@ -230,14 +231,20 @@ public class CameraVlanRule : AuditRuleBase
     /// </summary>
     private AuditIssue? EvaluateProtectCamera(ProtectCamera camera, PortInfo port, List<NetworkInfo> networks)
     {
-        // Use Protect API's ConnectionNetworkId for authoritative network placement
-        var network = GetNetwork(camera.ConnectionNetworkId, networks);
+        // Use Protect API's ConnectionNetworkId, falling back to port's native network
+        // (ConnectionNetworkId may point to L3 routing infrastructure on switch-routed VLANs)
+        var network = GetNetwork(camera.ConnectionNetworkId, networks)
+            ?? GetNetwork(port.NativeNetworkId, networks);
         if (network == null)
             return null;
 
         var placement = VlanPlacementChecker.CheckCameraPlacement(network, networks, ScoreImpact, isNvr: camera.IsNvr);
         if (placement.IsCorrectlyPlaced)
+        {
+            Logger?.LogDebug("Protect camera '{Name}' on {Switch} port {Port}: correctly placed on {Network} (VLAN {Vlan})",
+                camera.Name, port.Switch.Name, port.PortIndex, network.Name, network.VlanId);
             return null;
+        }
 
         var deviceName = $"{camera.Name} on {port.Switch.Name}";
         var message = camera.IsNvr

--- a/src/NetworkOptimizer.Audit/Rules/IAuditRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/IAuditRule.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Audit.Models;
 using NetworkOptimizer.Audit.Services;
 using NetworkOptimizer.Core.Enums;
@@ -70,6 +71,13 @@ public abstract class AuditRuleBase : IAuditRule
     public virtual int ScoreImpact { get; } = 5;
     public virtual bool Enabled { get; set; } = true;
     public virtual bool AppliesToLagChildPorts => false;
+
+    protected ILogger? Logger { get; private set; }
+
+    public void SetLogger(ILogger logger)
+    {
+        Logger = logger;
+    }
 
     /// <summary>
     /// Device type detection service for enhanced detection

--- a/src/NetworkOptimizer.Audit/Rules/IWirelessAuditRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/IWirelessAuditRule.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Audit.Models;
 
 using AuditSeverity = NetworkOptimizer.Audit.Models.AuditSeverity;
@@ -56,6 +57,13 @@ public abstract class WirelessAuditRuleBase : IWirelessAuditRule
     public abstract AuditSeverity Severity { get; }
     public virtual int ScoreImpact { get; } = 5;
     public virtual bool Enabled { get; set; } = true;
+
+    protected ILogger? Logger { get; private set; }
+
+    public void SetLogger(ILogger logger)
+    {
+        Logger = logger;
+    }
 
     /// <summary>
     /// Device allowance settings for allowing certain devices on main network

--- a/src/NetworkOptimizer.Audit/Rules/VlanSubnetMismatchRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/VlanSubnetMismatchRule.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Sockets;
+using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Audit.Models;
 using NetworkOptimizer.Core.Helpers;
 
@@ -71,7 +72,24 @@ public class VlanSubnetMismatchRule : WirelessAuditRuleBase
         if (NetworkUtilities.IsIpInSubnet(ip, effectiveNetwork.Subnet))
             return null; // IP matches subnet, no issue
 
-        // IP doesn't match subnet - this is a problem
+        // Before flagging, check if the IP matches any other known network's subnet.
+        // UniFi sometimes reports the wrong network_id for PPSK clients while the device
+        // is actually on the correct VLAN (proven by its IP matching that VLAN's subnet).
+        // If the IP matches another known network's subnet, the device is actually on the
+        // correct VLAN - UniFi is just reporting the wrong network_id (common with PPSK SSIDs
+        // where the AP assigns VLANs by password).
+        var matchingNetwork = networks.FirstOrDefault(n =>
+            n.Id != effectiveNetwork.Id &&
+            !string.IsNullOrEmpty(n.Subnet) &&
+            IsValidSubnetFormat(n.Subnet) &&
+            NetworkUtilities.IsIpInSubnet(ip, n.Subnet));
+        if (matchingNetwork != null)
+        {
+            Logger?.LogInformation("Subnet mismatch suppressed for '{Name}' ({Ip}): reported on {Reported} but IP matches {Matching} (VLAN {Vlan})",
+                client.Client.Name ?? client.Client.Mac, clientIp, effectiveNetwork.Name, matchingNetwork.Name, matchingNetwork.VlanId);
+            return null;
+        }
+
         var metadata = new Dictionary<string, object>
         {
             ["clientIp"] = clientIp,

--- a/src/NetworkOptimizer.Audit/Rules/WirelessCameraVlanRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/WirelessCameraVlanRule.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Audit.Models;
 using NetworkOptimizer.Core.Enums;
 
@@ -40,7 +41,11 @@ public class WirelessCameraVlanRule : WirelessAuditRuleBase
         var placement = VlanPlacementChecker.CheckCameraPlacement(network, networks, ScoreImpact, isNvr: isNvr);
 
         if (placement.IsCorrectlyPlaced)
+        {
+            Logger?.LogDebug("Wireless camera '{Name}' correctly placed on {Network} (VLAN {Vlan})",
+                client.Client.Name ?? client.Client.Mac, network.Name, network.VlanId);
             return null;
+        }
 
         var message = isNvr
             ? $"NVR on {network.Name} VLAN - should be on management or security VLAN"

--- a/src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs
@@ -376,4 +376,22 @@ public class UniFiNetworkConfig
     /// </summary>
     [JsonPropertyName("firewall_zone_id")]
     public string? FirewallZoneId { get; set; }
+
+    [JsonPropertyName("attr_hidden_id")]
+    public string? AttrHiddenId { get; set; }
+
+    [JsonPropertyName("attr_no_delete")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
+    public bool AttrNoDelete { get; set; }
+
+    [JsonPropertyName("network_isolation_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
+    public bool NetworkIsolationEnabled { get; set; }
+
+    /// <summary>
+    /// Whether this is a system/infrastructure network (e.g., Inter-VLAN routing for L3 switching).
+    /// These should be excluded from audit analysis and network reference lists.
+    /// </summary>
+    [JsonIgnore]
+    public bool IsSystemNetwork => string.Equals(AttrHiddenId, "ROUTE", StringComparison.OrdinalIgnoreCase);
 }

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/VlanAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/VlanAnalyzerTests.cs
@@ -3484,4 +3484,130 @@ public class VlanAnalyzerTests
     }
 
     #endregion
+
+    #region L3 Switch-Routed Network Tests
+
+    [Fact]
+    public void ExtractNetworks_SkipsRouteSystemNetwork()
+    {
+        var json = """
+        {
+            "data": [{
+                "type": "ugw",
+                "network_table": [
+                    { "_id": "net-home", "name": "Home", "vlan": 1, "purpose": "corporate", "dhcpd_enabled": true, "ip_subnet": "192.168.1.1/24", "network_isolation_enabled": false, "internet_access_enabled": true },
+                    { "_id": "net-route", "name": "Inter-VLAN routing", "vlan": 4040, "purpose": "corporate", "dhcpd_enabled": false, "ip_subnet": "10.255.253.1/24", "network_isolation_enabled": false, "internet_access_enabled": false, "attr_hidden_id": "ROUTE" },
+                    { "_id": "net-iot", "name": "IoT", "vlan": 64, "purpose": "corporate", "dhcpd_enabled": true, "ip_subnet": "192.168.64.1/24", "network_isolation_enabled": true, "internet_access_enabled": true }
+                ]
+            }]
+        }
+        """;
+        var deviceData = System.Text.Json.JsonDocument.Parse(json).RootElement;
+
+        var networks = _analyzer.ExtractNetworks(deviceData);
+
+        networks.Should().HaveCount(2);
+        networks.Should().Contain(n => n.Name == "Home");
+        networks.Should().Contain(n => n.Name == "IoT");
+        networks.Should().NotContain(n => n.Name == "Inter-VLAN routing");
+    }
+
+    [Fact]
+    public void NetworkInfoFromConfig_BuildsCorrectNetworkInfo()
+    {
+        var config = new UniFiNetworkConfig
+        {
+            Id = "sec-net",
+            Name = "Security Devices",
+            Purpose = "corporate",
+            Vlan = 42,
+            IpSubnet = "192.168.42.1/24",
+            DhcpdEnabled = true,
+            DhcpdDnsEnabled = true,
+            DhcpdDns1 = "192.168.53.220",
+            DhcpdDns2 = "192.168.1.1",
+            NetworkIsolationEnabled = true,
+            InternetAccessEnabled = false,
+            Networkgroup = "LAN",
+            Enabled = true
+        };
+
+        var result = _analyzer.NetworkInfoFromConfig(config);
+
+        result.Id.Should().Be("sec-net");
+        result.Name.Should().Be("Security Devices");
+        result.VlanId.Should().Be(42);
+        result.Subnet.Should().Be("192.168.42.0/24");
+        result.Gateway.Should().Be("192.168.42.1");
+        result.DnsServers.Should().BeEquivalentTo(new[] { "192.168.53.220", "192.168.1.1" });
+        result.Purpose.Should().Be(NetworkPurpose.Security);
+        result.NetworkIsolationEnabled.Should().BeTrue();
+        result.InternetAccessEnabled.Should().BeFalse();
+        result.DhcpEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void NetworkInfoFromConfig_NoDnsWhenDisabled()
+    {
+        var config = new UniFiNetworkConfig
+        {
+            Id = "guest-net",
+            Name = "Guest",
+            Purpose = "guest",
+            Vlan = 210,
+            IpSubnet = "192.168.210.1/24",
+            DhcpdEnabled = true,
+            DhcpdDnsEnabled = false,
+            DhcpdDns1 = "8.8.8.8",
+            Networkgroup = "LAN",
+            Enabled = true
+        };
+
+        var result = _analyzer.NetworkInfoFromConfig(config);
+
+        result.DnsServers.Should().BeNull();
+    }
+
+    [Fact]
+    public void IsSystemNetwork_TrueForRouteNetwork()
+    {
+        var config = new UniFiNetworkConfig
+        {
+            Id = "route-net",
+            Name = "Inter-VLAN routing",
+            AttrHiddenId = "ROUTE",
+            AttrNoDelete = true
+        };
+
+        config.IsSystemNetwork.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsSystemNetwork_FalseForRegularNetwork()
+    {
+        var config = new UniFiNetworkConfig
+        {
+            Id = "sec-net",
+            Name = "Security Devices",
+            AttrHiddenId = null
+        };
+
+        config.IsSystemNetwork.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsSystemNetwork_FalseForLanHiddenId()
+    {
+        var config = new UniFiNetworkConfig
+        {
+            Id = "home-net",
+            Name = "Main Home Network",
+            AttrHiddenId = "LAN",
+            AttrNoDelete = true
+        };
+
+        config.IsSystemNetwork.Should().BeFalse();
+    }
+
+    #endregion
 }

--- a/tests/NetworkOptimizer.Audit.Tests/Rules/CameraVlanRuleTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Rules/CameraVlanRuleTests.cs
@@ -1673,9 +1673,9 @@ public class CameraVlanRuleTests
     }
 
     [Fact]
-    public void Evaluate_ProtectCamera_NoConnectionNetworkId_ReturnsNull()
+    public void Evaluate_ProtectCamera_NoConnectionNetworkId_FallsBackToPortNetwork()
     {
-        // Arrange - Protect camera with no ConnectionNetworkId (shouldn't happen, but defensive)
+        // Arrange - Protect camera with no ConnectionNetworkId falls back to port's native network
         var corpNetwork = new NetworkInfo { Id = "corp-net", Name = "Corporate", VlanId = 10, Purpose = NetworkPurpose.Corporate };
         var protectCameras = new ProtectCameraCollection();
         protectCameras.Add("aa:bb:cc:dd:ee:06", "G4 Instant", null, isNvr: false);
@@ -1697,8 +1697,9 @@ public class CameraVlanRuleTests
         // Act
         var result = _rule.Evaluate(port, networks);
 
-        // Assert - No ConnectionNetworkId means we can't determine placement
-        result.Should().BeNull();
+        // Assert - Falls through to port's native network, camera on Corporate should be flagged
+        result.Should().NotBeNull();
+        result!.CurrentNetwork.Should().Be("Corporate");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Audit.Tests/Rules/VlanSubnetMismatchRuleTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Rules/VlanSubnetMismatchRuleTests.cs
@@ -456,6 +456,80 @@ public class VlanSubnetMismatchRuleTests
 
     #endregion
 
+    #region PPSK / Reporting Bug Suppression
+
+    [Fact]
+    public void Evaluate_IpMatchesAnotherNetwork_Suppressed()
+    {
+        // PPSK scenario: UniFi reports device on default VLAN but IP proves it's on VLAN 12
+        var defaultNetwork = CreateNetwork("10.1.0.0/16", vlanId: 1, name: "Default", id: "default-net");
+        var ppskNetwork = CreateNetwork("10.12.0.0/16", vlanId: 12, name: "IoT PPSK", id: "ppsk-net");
+        var client = CreateWirelessClient(
+            ip: "10.12.1.84",
+            networkOverrideEnabled: true,
+            network: defaultNetwork);
+        var networks = new List<NetworkInfo> { defaultNetwork, ppskNetwork };
+
+        var result = _rule.Evaluate(client, networks);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Evaluate_IpMatchesNoNetwork_StillFlags()
+    {
+        // IP doesn't match any known network - genuine issue
+        var iotNetwork = CreateNetwork("192.168.64.0/24", vlanId: 64, name: "IoT", id: "iot-net");
+        var client = CreateWirelessClient(
+            ip: "172.16.99.50",
+            networkOverrideEnabled: true,
+            network: iotNetwork);
+        var networks = new List<NetworkInfo> { iotNetwork };
+
+        var result = _rule.Evaluate(client, networks);
+
+        result.Should().NotBeNull();
+        result!.Message.Should().Contain("172.16.99.50");
+    }
+
+    [Fact]
+    public void Evaluate_IpMatchesAssignedNetwork_NoIssue()
+    {
+        // Device correctly on its assigned network - no mismatch
+        var secNetwork = CreateNetwork("192.168.42.0/24", vlanId: 42, name: "Security", id: "sec-net");
+        var client = CreateWirelessClient(
+            ip: "192.168.42.100",
+            networkOverrideEnabled: true,
+            network: secNetwork);
+        var networks = new List<NetworkInfo> { secNetwork };
+
+        var result = _rule.Evaluate(client, networks);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Evaluate_FixedIpMatchesAnotherNetwork_StillSuppressed()
+    {
+        // Even with a fixed IP, if it matches another network it's a reporting mismatch
+        // (UniFi won't let you set a fixed IP on the wrong subnet)
+        var defaultNetwork = CreateNetwork("10.1.0.0/16", vlanId: 1, name: "Default", id: "default-net");
+        var secNetwork = CreateNetwork("192.168.42.0/24", vlanId: 42, name: "Security", id: "sec-net");
+        var client = CreateWirelessClient(
+            ip: "192.168.42.100",
+            fixedIp: "192.168.42.100",
+            useFixedIp: true,
+            networkOverrideEnabled: true,
+            network: defaultNetwork);
+        var networks = new List<NetworkInfo> { defaultNetwork, secNetwork };
+
+        var result = _rule.Evaluate(client, networks);
+
+        result.Should().BeNull();
+    }
+
+    #endregion
+
     #region Helper Methods
 
     private static NetworkInfo CreateNetwork(


### PR DESCRIPTION
## Summary

- Handle L3 switch-routed VLANs in security audit
- Suppress PPSK subnet mismatch false positives (#530)

## Changes

- Exclude UniFi "Inter-VLAN routing" infrastructure network (`attr_hidden_id=ROUTE`) from audit
- Supplement gateway network_table with switch-routed networks from `rest/networkconf`
- Fix Protect API `connection_network_id` pointing to L3 routing infrastructure
- Suppress VLAN subnet mismatch when client IP matches another known network (PPSK reporting bug)
- Add debug logging for camera placement verification