### PR TITLE
Add SQM firmware regression warning and fix SetLogger build warnings

### DIFF
--- a/src/NetworkOptimizer.Audit/Rules/AccessPortVlanRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/AccessPortVlanRule.cs
@@ -42,12 +42,6 @@ public class AccessPortVlanRule : AuditRuleBase
         ClientDeviceCategory.NAS
     };
 
-    private static ILogger? _logger;
-
-    /// <summary>
-    /// Set the logger for diagnostic output
-    /// </summary>
-    public static void SetLogger(ILogger logger) => _logger = logger;
 
     public override AuditIssue? Evaluate(PortInfo port, List<NetworkInfo> networks, List<NetworkInfo>? allNetworks = null)
     {
@@ -126,7 +120,7 @@ public class AccessPortVlanRule : AuditRuleBase
         var (taggedVlanCount, allowsAllVlans) = GetTaggedVlanInfo(port, networksForCounting);
 
         var excludedCount = port.ExcludedNetworkIds?.Count ?? 0;
-        _logger?.LogDebug(
+        Logger?.LogDebug(
             "ACCESS-VLAN {Switch} port {Port}: networks={NetworkCount}, excluded={ExcludedCount}, native={NativeId}, tagged={TaggedCount}, allowsAll={AllowsAll}, threshold={Threshold}",
             port.Switch.Name, port.PortIndex, networksForCounting.Count, excludedCount,
             port.NativeNetworkId ?? "(none)", taggedVlanCount, allowsAllVlans, effectiveThreshold);

--- a/src/NetworkOptimizer.Audit/Rules/UnusedPortRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/UnusedPortRule.cs
@@ -10,7 +10,6 @@ namespace NetworkOptimizer.Audit.Rules;
 /// </summary>
 public class UnusedPortRule : AuditRuleBase
 {
-    private static ILogger? _logger;
     private static int _unusedPortInactivityDays = 15;
     private static int _namedPortInactivityDays = 45;
 
@@ -20,8 +19,6 @@ public class UnusedPortRule : AuditRuleBase
     /// power events) and are ignored rather than flagging the port.
     /// </summary>
     private const int MaxReasonableAgeDays = 3650; // 10 years
-
-    public static void SetLogger(ILogger logger) => _logger = logger;
 
     /// <summary>
     /// Configure the inactivity thresholds for unused port detection.
@@ -74,7 +71,7 @@ public class UnusedPortRule : AuditRuleBase
             // Don't flag these ports - we can't trust the data
             if (daysSinceLastConnection > MaxReasonableAgeDays)
             {
-                _logger?.LogWarning(
+                Logger?.LogWarning(
                     "UnusedPortRule ignoring invalid lastSeen for {Switch} port {Port}: timestamp={Timestamp} ({Days:F0} days ago exceeds {Max} day maximum)",
                     port.Switch.Name, port.PortIndex, port.LastConnectionSeen, daysSinceLastConnection, MaxReasonableAgeDays);
                 return null;
@@ -88,7 +85,7 @@ public class UnusedPortRule : AuditRuleBase
         }
 
         // Debug logging for flagged ports
-        _logger?.LogInformation("UnusedPortRule flagging {Switch} port {Port}: forward='{Forward}', isUp={IsUp}, lastSeenDaysAgo={LastSeenDays}, threshold={Threshold}d",
+        Logger?.LogInformation("UnusedPortRule flagging {Switch} port {Port}: forward='{Forward}', isUp={IsUp}, lastSeenDaysAgo={LastSeenDays}, threshold={Threshold}d",
             port.Switch.Name, port.PortIndex, port.ForwardMode, port.IsUp,
             port.LastConnectionSeen.HasValue
                 ? $"{(DateTimeOffset.UtcNow - DateTimeOffset.FromUnixTimeSeconds(port.LastConnectionSeen.Value)).TotalDays:F0}"

--- a/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
+++ b/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
@@ -53,6 +53,7 @@ public class PerformanceAnalyzer
             issues.AddRange(CheckHardwareAcceleration(devices, settingsData));
             issues.AddRange(CheckJumboFrames(devices, settingsData));
             issues.AddRange(CheckFlowControl(devices, networks, clients, settingsData, portProfiles));
+            issues.AddRange(CheckSqmFirmwareRegression(devices, networks));
         }
 
         if (runCellularChecks)
@@ -420,6 +421,64 @@ public class PerformanceAnalyzer
                 });
             }
         }
+
+        return issues;
+    }
+
+    private static readonly HashSet<string> SqmFirmwareAffectedGateways = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "UCG-Fiber", "UXG-Fiber", "UCG-Max", "UXG-Max"
+    };
+
+    private static readonly Version SqmLastGoodFirmware = new(5, 0, 10);
+
+    /// <summary>
+    /// Check if SQM is enabled on a gateway with firmware newer than 5.0.10.
+    /// Firmware versions after 5.0.10 have a known SQM download throughput regression
+    /// on high-bandwidth connections (bottlenecked to ~800 Mbps or less).
+    /// </summary>
+    internal List<PerformanceIssue> CheckSqmFirmwareRegression(
+        List<UniFiDeviceResponse> devices,
+        List<UniFiNetworkConfig> networks)
+    {
+        var issues = new List<PerformanceIssue>();
+
+        var gateway = devices.FirstOrDefault(d => d.DeviceType == DeviceType.Gateway);
+        if (gateway == null)
+            return issues;
+
+        if (!SqmFirmwareAffectedGateways.Contains(gateway.FriendlyModelName))
+            return issues;
+
+        var firmwareStr = gateway.DisplayableVersion ?? gateway.Version;
+        if (string.IsNullOrEmpty(firmwareStr) || !Version.TryParse(firmwareStr, out var firmware))
+            return issues;
+
+        if (firmware <= SqmLastGoodFirmware)
+            return issues;
+
+        var sqmWans = networks.Where(n =>
+            string.Equals(n.Purpose, "wan", StringComparison.OrdinalIgnoreCase) &&
+            n.WanSmartqEnabled &&
+            (n.WanProviderCapabilities?.DownloadMbps > 500 || n.WanProviderCapabilities?.UploadMbps > 500))
+            .ToList();
+
+        if (sqmWans.Count == 0)
+            return issues;
+
+        var wanNames = string.Join(", ", sqmWans.Select(w => w.Name));
+
+        issues.Add(new PerformanceIssue
+        {
+            Title = "SQM Performance Regression on Current Firmware",
+            Description = $"Your {gateway.FriendlyModelName} is running firmware {firmwareStr} with SQM enabled on {wanNames}. " +
+                $"UniFi OS versions after 5.0.10 have a known SQM download throughput regression that can bottleneck speeds to 800 Mbps or less on faster connections.",
+            Recommendation = "UniFi OS 5.0.10 provides significantly better SQM download performance on high-speed connections. " +
+                "Rolling back firmware is non-trivial and may require a backup, factory reset, and restore.",
+            Severity = PerformanceSeverity.Recommendation,
+            Category = PerformanceCategory.Performance,
+            DeviceName = gateway.Name
+        });
 
         return issues;
     }

--- a/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PerformanceAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PerformanceAnalyzerTests.cs
@@ -1560,4 +1560,125 @@ public class PerformanceAnalyzerTests
     }
 
     #endregion
+
+    #region SQM Firmware Regression
+
+    [Fact]
+    public void CheckSqmFirmwareRegression_AffectedGateway_ReturnsIssue()
+    {
+        var devices = new List<UniFiDeviceResponse>
+        {
+            new() { Id = "gw1", Mac = "aa:bb:cc:00:00:01", Name = "Gateway", Type = "ugw",
+                    Model = "UDMA6A8", DisplayableVersion = "5.1.2" }
+        };
+        var networks = new List<UniFiNetworkConfig>
+        {
+            new() { Id = "wan1", Name = "WAN", Purpose = "wan", WanSmartqEnabled = true,
+                    WanProviderCapabilities = new WanProviderCapabilities { DownloadKilobitsPerSecond = 1_000_000 } }
+        };
+
+        var result = _analyzer.CheckSqmFirmwareRegression(devices, networks);
+
+        result.Should().HaveCount(1);
+        result[0].Title.Should().Contain("SQM Performance Regression");
+        result[0].Description.Should().Contain("UCG-Fiber");
+        result[0].Description.Should().Contain("5.1.2");
+    }
+
+    [Fact]
+    public void CheckSqmFirmwareRegression_FirmwareAt5010_ReturnsEmpty()
+    {
+        var devices = new List<UniFiDeviceResponse>
+        {
+            new() { Id = "gw1", Mac = "aa:bb:cc:00:00:01", Name = "Gateway", Type = "ugw",
+                    Model = "UDMA6A8", DisplayableVersion = "5.0.10" }
+        };
+        var networks = new List<UniFiNetworkConfig>
+        {
+            new() { Id = "wan1", Name = "WAN", Purpose = "wan", WanSmartqEnabled = true,
+                    WanProviderCapabilities = new WanProviderCapabilities { DownloadKilobitsPerSecond = 1_000_000 } }
+        };
+
+        var result = _analyzer.CheckSqmFirmwareRegression(devices, networks);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CheckSqmFirmwareRegression_FirmwareAt5012_ReturnsIssue()
+    {
+        var devices = new List<UniFiDeviceResponse>
+        {
+            new() { Id = "gw1", Mac = "aa:bb:cc:00:00:01", Name = "Gateway", Type = "ugw",
+                    Model = "UDMA6A8", DisplayableVersion = "5.0.12" }
+        };
+        var networks = new List<UniFiNetworkConfig>
+        {
+            new() { Id = "wan1", Name = "WAN", Purpose = "wan", WanSmartqEnabled = true,
+                    WanProviderCapabilities = new WanProviderCapabilities { DownloadKilobitsPerSecond = 1_000_000 } }
+        };
+
+        var result = _analyzer.CheckSqmFirmwareRegression(devices, networks);
+
+        result.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void CheckSqmFirmwareRegression_SqmDisabled_ReturnsEmpty()
+    {
+        var devices = new List<UniFiDeviceResponse>
+        {
+            new() { Id = "gw1", Mac = "aa:bb:cc:00:00:01", Name = "Gateway", Type = "ugw",
+                    Model = "UXGA6AA", DisplayableVersion = "5.1.7" }
+        };
+        var networks = new List<UniFiNetworkConfig>
+        {
+            new() { Id = "wan1", Name = "WAN", Purpose = "wan", WanSmartqEnabled = false,
+                    WanProviderCapabilities = new WanProviderCapabilities { DownloadKilobitsPerSecond = 1_000_000 } }
+        };
+
+        var result = _analyzer.CheckSqmFirmwareRegression(devices, networks);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CheckSqmFirmwareRegression_SpeedBelow500Mbps_ReturnsEmpty()
+    {
+        var devices = new List<UniFiDeviceResponse>
+        {
+            new() { Id = "gw1", Mac = "aa:bb:cc:00:00:01", Name = "Gateway", Type = "ugw",
+                    Model = "UCGMAX", DisplayableVersion = "5.1.7" }
+        };
+        var networks = new List<UniFiNetworkConfig>
+        {
+            new() { Id = "wan1", Name = "WAN", Purpose = "wan", WanSmartqEnabled = true,
+                    WanProviderCapabilities = new WanProviderCapabilities { DownloadKilobitsPerSecond = 400_000 } }
+        };
+
+        var result = _analyzer.CheckSqmFirmwareRegression(devices, networks);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CheckSqmFirmwareRegression_UnaffectedGatewayModel_ReturnsEmpty()
+    {
+        var devices = new List<UniFiDeviceResponse>
+        {
+            new() { Id = "gw1", Mac = "aa:bb:cc:00:00:01", Name = "Gateway", Type = "ugw",
+                    Model = "UDR", DisplayableVersion = "5.1.7" }
+        };
+        var networks = new List<UniFiNetworkConfig>
+        {
+            new() { Id = "wan1", Name = "WAN", Purpose = "wan", WanSmartqEnabled = true,
+                    WanProviderCapabilities = new WanProviderCapabilities { DownloadKilobitsPerSecond = 1_000_000 } }
+        };
+
+        var result = _analyzer.CheckSqmFirmwareRegression(devices, networks);
+
+        result.Should().BeEmpty();
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

- Add Config Optimizer performance suggestion when SQM is enabled on UCG-Fiber, UXG-Fiber, UCG-Max, or UXG-Max with firmware > 5.0.10 and WAN speeds > 500 Mbps (known download throughput regression to ~800 Mbps or less)
- Fix build warnings from AccessPortVlanRule and UnusedPortRule hiding inherited SetLogger - now use the base class Logger property

## Test plan

- [x] 6 new tests covering: affected gateway triggers, 5.0.10 boundary, 5.0.12 edge case, SQM disabled, speed below threshold, unaffected model
- [x] Zero build warnings
- [x] Full test suite passes
- [x] Deployed to NAS and Mac for verification