### PR TITLE
Fix deserialization and DI scope exceptions in WiFi Optimizer and Threat Dashboard

### DIFF
--- a/src/NetworkOptimizer.UniFi/Models/UniFiClientResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiClientResponse.cs
@@ -182,25 +182,33 @@ public class UniFiClientResponse
     public string? Note { get; set; }
 
     // Device fingerprinting (all nullable as API can return null)
+    // UniFi API sometimes returns these as floats (e.g. 4.0) so use FlexibleIntConverter
     [JsonPropertyName("fingerprint_source")]
+    [JsonConverter(typeof(FlexibleIntConverter))]
     public int? FingerprintSource { get; set; }
 
     [JsonPropertyName("dev_id_override")]
+    [JsonConverter(typeof(FlexibleIntConverter))]
     public int? DevIdOverride { get; set; }
 
     [JsonPropertyName("dev_cat")]
+    [JsonConverter(typeof(FlexibleIntConverter))]
     public int? DevCat { get; set; }
 
     [JsonPropertyName("dev_family")]
+    [JsonConverter(typeof(FlexibleIntConverter))]
     public int? DevFamily { get; set; }
 
     [JsonPropertyName("os_class")]
+    [JsonConverter(typeof(FlexibleIntConverter))]
     public int? OsClass { get; set; }
 
     [JsonPropertyName("os_name")]
+    [JsonConverter(typeof(FlexibleIntConverter))]
     public int? OsName { get; set; }
 
     [JsonPropertyName("dev_vendor")]
+    [JsonConverter(typeof(FlexibleIntConverter))]
     public int? DevVendor { get; set; }
 
     // Blocked/allowed status

--- a/src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs
@@ -84,7 +84,8 @@ public class FlexibleIntConverter : JsonConverter<int?>
     {
         return reader.TokenType switch
         {
-            JsonTokenType.Number => reader.GetInt32(),
+            JsonTokenType.Number when reader.TryGetInt32(out var i) => i,
+            JsonTokenType.Number => (int)reader.GetDouble(),
             JsonTokenType.String when int.TryParse(reader.GetString(), out var value) => value,
             JsonTokenType.String => null, // Empty string or non-numeric string
             JsonTokenType.Null => null,

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -30,7 +30,7 @@ public class WiFiOptimizerService
     private readonly VlanAnalyzer _vlanAnalyzer;
     private readonly HeatmapDataCache _heatmapCache;
     private readonly FloorPlanService _floorPlanService;
-    private readonly IServiceProvider _serviceProvider;
+    private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly PlannedApService _plannedApService;
     private readonly ChannelRecommendationService _channelRecommendationService;
 
@@ -51,7 +51,7 @@ public class WiFiOptimizerService
         ISystemSettingsService settingsService,
         HeatmapDataCache heatmapCache,
         FloorPlanService floorPlanService,
-        IServiceProvider serviceProvider,
+        IServiceScopeFactory serviceScopeFactory,
         PlannedApService plannedApService,
         ChannelRecommendationService channelRecommendationService,
         ILogger<WiFiOptimizerService> logger,
@@ -63,7 +63,7 @@ public class WiFiOptimizerService
         _settingsService = settingsService;
         _heatmapCache = heatmapCache;
         _floorPlanService = floorPlanService;
-        _serviceProvider = serviceProvider;
+        _serviceScopeFactory = serviceScopeFactory;
         _plannedApService = plannedApService;
         _channelRecommendationService = channelRecommendationService;
         _logger = logger;
@@ -480,9 +480,11 @@ public class WiFiOptimizerService
         ApPropagationContext? propCtx = null;
         try
         {
-            // Resolve ApMapService lazily to avoid circular dependency
-            // (ApMapService -> WiFiOptimizerService -> ApMapService)
-            var apMapService = _serviceProvider.GetRequiredService<ApMapService>();
+            // Resolve ApMapService lazily via a fresh scope to avoid circular dependency
+            // (ApMapService -> WiFiOptimizerService -> ApMapService) and to survive
+            // Blazor circuit disposal (the original scoped IServiceProvider can be disposed)
+            using var scope = _serviceScopeFactory.CreateScope();
+            var apMapService = scope.ServiceProvider.GetRequiredService<ApMapService>();
             var cached = await _heatmapCache.GetOrLoadAsync(_floorPlanService, apMapService, _plannedApService);
             var placedAps = cached.ApMarkers
                 .Where(a => a.Latitude.HasValue && a.Longitude.HasValue)
@@ -796,7 +798,8 @@ public class WiFiOptimizerService
             bool hasBuildingData = false;
             try
             {
-                var apMapService = _serviceProvider.GetRequiredService<ApMapService>();
+                using var scope = _serviceScopeFactory.CreateScope();
+                var apMapService = scope.ServiceProvider.GetRequiredService<ApMapService>();
                 var cached = await _heatmapCache.GetOrLoadAsync(_floorPlanService, apMapService, _plannedApService);
                 var placedAps = cached.ApMarkers
                     .Where(a => a.Latitude.HasValue && a.Longitude.HasValue)

--- a/tests/NetworkOptimizer.UniFi.Tests/FlexibleConverterTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/FlexibleConverterTests.cs
@@ -1,0 +1,185 @@
+using System.Text.Json;
+using NetworkOptimizer.UniFi.Models;
+using Xunit;
+
+namespace NetworkOptimizer.UniFi.Tests;
+
+public class FlexibleIntConverterTests
+{
+    private record IntHolder([property: System.Text.Json.Serialization.JsonConverter(typeof(FlexibleIntConverter))] int? Value);
+
+    [Theory]
+    [InlineData("4", 4)]
+    [InlineData("0", 0)]
+    [InlineData("-1", -1)]
+    [InlineData("2147483647", int.MaxValue)]
+    public void Reads_integer(string json, int expected)
+    {
+        var result = JsonSerializer.Deserialize<IntHolder>($"{{\"Value\":{json}}}");
+        Assert.Equal(expected, result!.Value);
+    }
+
+    [Theory]
+    [InlineData("4.0", 4)]
+    [InlineData("1.9", 1)]
+    [InlineData("0.0", 0)]
+    public void Reads_float_as_truncated_int(string json, int expected)
+    {
+        var result = JsonSerializer.Deserialize<IntHolder>($"{{\"Value\":{json}}}");
+        Assert.Equal(expected, result!.Value);
+    }
+
+    [Theory]
+    [InlineData("\"4\"", 4)]
+    [InlineData("\"0\"", 0)]
+    [InlineData("\"-7\"", -7)]
+    public void Reads_string_integer(string json, int expected)
+    {
+        var result = JsonSerializer.Deserialize<IntHolder>($"{{\"Value\":{json}}}");
+        Assert.Equal(expected, result!.Value);
+    }
+
+    [Fact]
+    public void Reads_null_as_null()
+    {
+        var result = JsonSerializer.Deserialize<IntHolder>("{\"Value\":null}");
+        Assert.Null(result!.Value);
+    }
+
+    [Theory]
+    [InlineData("\"\"")]
+    [InlineData("\"abc\"")]
+    public void Reads_non_numeric_string_as_null(string json)
+    {
+        var result = JsonSerializer.Deserialize<IntHolder>($"{{\"Value\":{json}}}");
+        Assert.Null(result!.Value);
+    }
+
+    [Fact]
+    public void Missing_property_is_null()
+    {
+        var result = JsonSerializer.Deserialize<IntHolder>("{}");
+        Assert.Null(result!.Value);
+    }
+
+    [Fact]
+    public void Writes_value()
+    {
+        var json = JsonSerializer.Serialize(new IntHolder(42));
+        Assert.Contains("42", json);
+    }
+
+    [Fact]
+    public void Writes_null()
+    {
+        var json = JsonSerializer.Serialize(new IntHolder(null));
+        Assert.Contains("null", json);
+    }
+}
+
+public class FlexibleBoolConverterTests
+{
+    private record BoolHolder([property: System.Text.Json.Serialization.JsonConverter(typeof(FlexibleBoolConverter))] bool Value);
+
+    [Fact]
+    public void Reads_true() =>
+        Assert.True(JsonSerializer.Deserialize<BoolHolder>("{\"Value\":true}")!.Value);
+
+    [Fact]
+    public void Reads_false() =>
+        Assert.False(JsonSerializer.Deserialize<BoolHolder>("{\"Value\":false}")!.Value);
+
+    [Theory]
+    [InlineData("\"true\"", true)]
+    [InlineData("\"false\"", false)]
+    [InlineData("\"True\"", true)]
+    [InlineData("\"False\"", false)]
+    public void Reads_string_bool(string json, bool expected)
+    {
+        var result = JsonSerializer.Deserialize<BoolHolder>($"{{\"Value\":{json}}}");
+        Assert.Equal(expected, result!.Value);
+    }
+
+    [Theory]
+    [InlineData("1", true)]
+    [InlineData("0", false)]
+    [InlineData("42", true)]
+    public void Reads_number_as_bool(string json, bool expected)
+    {
+        var result = JsonSerializer.Deserialize<BoolHolder>($"{{\"Value\":{json}}}");
+        Assert.Equal(expected, result!.Value);
+    }
+
+    [Fact]
+    public void Reads_non_boolean_string_as_false()
+    {
+        var result = JsonSerializer.Deserialize<BoolHolder>("{\"Value\":\"garbage\"}");
+        Assert.False(result!.Value);
+    }
+
+    [Fact]
+    public void Writes_true()
+    {
+        var json = JsonSerializer.Serialize(new BoolHolder(true));
+        Assert.Contains("true", json);
+    }
+
+    [Fact]
+    public void Writes_false()
+    {
+        var json = JsonSerializer.Serialize(new BoolHolder(false));
+        Assert.Contains("false", json);
+    }
+}
+
+public class FlexibleNullableBoolConverterTests
+{
+    private record NullBoolHolder([property: System.Text.Json.Serialization.JsonConverter(typeof(FlexibleNullableBoolConverter))] bool? Value);
+
+    [Fact]
+    public void Reads_true() =>
+        Assert.True(JsonSerializer.Deserialize<NullBoolHolder>("{\"Value\":true}")!.Value);
+
+    [Fact]
+    public void Reads_false() =>
+        Assert.False(JsonSerializer.Deserialize<NullBoolHolder>("{\"Value\":false}")!.Value);
+
+    [Fact]
+    public void Reads_null_as_null()
+    {
+        var result = JsonSerializer.Deserialize<NullBoolHolder>("{\"Value\":null}");
+        Assert.Null(result!.Value);
+    }
+
+    [Theory]
+    [InlineData("\"true\"", true)]
+    [InlineData("\"false\"", false)]
+    public void Reads_string_bool(string json, bool expected)
+    {
+        var result = JsonSerializer.Deserialize<NullBoolHolder>($"{{\"Value\":{json}}}");
+        Assert.Equal(expected, result!.Value);
+    }
+
+    [Fact]
+    public void Reads_non_boolean_string_as_null()
+    {
+        var result = JsonSerializer.Deserialize<NullBoolHolder>("{\"Value\":\"garbage\"}");
+        Assert.Null(result!.Value);
+    }
+
+    [Theory]
+    [InlineData("1", true)]
+    [InlineData("0", false)]
+    public void Reads_number_as_bool(string json, bool expected)
+    {
+        var result = JsonSerializer.Deserialize<NullBoolHolder>($"{{\"Value\":{json}}}");
+        Assert.Equal(expected, result!.Value);
+    }
+
+    [Fact]
+    public void Missing_property_is_null()
+    {
+        var result = JsonSerializer.Deserialize<NullBoolHolder>("{}");
+        Assert.Null(result!.Value);
+    }
+}


### PR DESCRIPTION
@
## Summary

- **Fix client deserialization failure on Threat Dashboard** - The UniFi API returns device fingerprinting fields (e.g. `fingerprint_source`) as floats (`4.0`) instead of integers. `FlexibleIntConverter` now handles float-typed JSON numbers via `TryGetInt32` with a `GetDouble` fallback, and is applied to all 7 fingerprinting `int?` fields in `UniFiClientResponse`.

- **Fix ObjectDisposedException in WiFi Optimizer** - `WiFiOptimizerService` (scoped) stored the scoped `IServiceProvider` to lazily resolve `ApMapService` (breaking a circular dependency). After Blazor circuit disposal the provider was dead, but background evaluation still called `BuildOptimizerContextAsync`. Switched to `IServiceScopeFactory` (singleton) which creates a fresh scope each time.

- **Add 37 unit tests** for `FlexibleIntConverter`, `FlexibleBoolConverter`, and `FlexibleNullableBoolConverter` covering integers, floats, strings, nulls, empty strings, and round-trip serialization.

## Test plan

- [x] 0 build warnings
- [x] All 4,485 tests pass (37 new)
- [x] Deployed to NAS and Mac - zero exceptions in logs
- [x] Verify Threat Dashboard resolves client names
- [x] Verify Wi-Fi Optimizer loads without ObjectDisposedException after navigating away and back
@