### PR TITLE
Revert fan control standby PWM to stock value

### DIFF
--- a/src/NetworkOptimizer.Web/Resources/PerfTweaks/15-fan-control-tuning.sh
+++ b/src/NetworkOptimizer.Web/Resources/PerfTweaks/15-fan-control-tuning.sh
@@ -38,13 +38,13 @@ log() {
 #   hdd:      68 → 55   (protect NVMe/eMMC)
 #   rtl8372: 109 → 85   (10G switch chip)
 #   rtl8261: 103 → 90   (SFP+ PHY)
-#   standby:  20 → 30   (min PWM to avoid fan cycling on/off)
+#   standby:  20        (stock; do not change — role not fully understood via RE)
 
 CPU_SETPOINT=65
 HDD_SETPOINT=55
 RTL8372_SETPOINT=85
 RTL8261_SETPOINT=90
-STANDBY=30
+STANDBY=20
 
 # ─── Wait for uhwd.service ───
 log "Waiting for uhwd.service..."


### PR DESCRIPTION
## Summary

- Reverts the fan control `standby` PID setpoint from 30 back to the stock value of 20
- The standby value's exact role isn't fully understood from reverse engineering, and raising it could prevent the fan from spinning down properly
- Rollback path in `PerfTweaksDeploymentService` already uses 20, so this brings deploy and remove into alignment

## Test plan

- [x] Deploy fan control tweak on a UCG and verify fan still spins up/down normally
- [x] Remove the tweak and confirm stock values are restored correctly