### PR TITLE
fix(threats): treat v2 IPS success as authoritative

### DIFF
--- a/src/NetworkOptimizer.Threats/ThreatCollectionService.cs
+++ b/src/NetworkOptimizer.Threats/ThreatCollectionService.cs
@@ -702,11 +702,8 @@ public class ThreatCollectionService : BackgroundService
                     _logger.LogDebug("v2 IPS API returned totalCount={TotalCount}", totalCount);
 
                 events = _normalizer.NormalizeV2Events(v2Response);
-                if (events.Count > 0)
-                {
-                    _logger.LogDebug("Collected {Count} IPS events via v2 API", events.Count);
-                    return events;
-                }
+                _logger.LogDebug("Collected {Count} IPS events via v2 API", events.Count);
+                return events;
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
When ThreatCollectionService polls for IPS events, it calls the v2 system-log endpoint first, then falls back to the v1 stat/ips/event endpoint. The early-return guard in the v2 branch only triggers when the response contains one or more events, so a successful v2 response with zero new events falls through to v1. On UniFi Network 10.2.x the v1 endpoint has been removed and returns 404, which the generic API wrapper logs at ERR level before the outer try/catch can swallow it. Result: one 'API call failed with status NotFound' entry per poll cycle indefinitely on any healthy controller with no new threats in the window.

Treat a v2 response with a defined ValueKind as authoritative. The v1 fallback now only runs when v2 itself throws or returns Undefined, which is the original intent.