### PR TITLE
feat(audit): add TrustedDnsRedirectTargets setting for DNS VIPs

### DIFF
--- a/src/NetworkOptimizer.Audit/ConfigAuditEngine.cs
+++ b/src/NetworkOptimizer.Audit/ConfigAuditEngine.cs
@@ -51,6 +51,7 @@ public class ConfigAuditEngine
         public List<int>? DnatExcludedVlanIds { get; init; }
         public int? PiholeManagementPort { get; init; }  // Used for all third-party DNS (Pi-hole, AdGuard Home, etc.)
         public string? PiholeManagementUrl { get; init; }
+        public List<string>? TrustedDnsRedirectTargets { get; init; }
         public bool? UpnpEnabled { get; init; }
         public List<UniFiPortForwardRule>? PortForwardRules { get; init; }
         public List<UniFiNetworkConfig>? NetworkConfigs { get; init; }
@@ -429,6 +430,7 @@ public class ConfigAuditEngine
             DnatExcludedVlanIds = request.DnatExcludedVlanIds,
             PiholeManagementPort = request.PiholeManagementPort,
             PiholeManagementUrl = request.PiholeManagementUrl,
+            TrustedDnsRedirectTargets = request.TrustedDnsRedirectTargets,
             UpnpEnabled = request.UpnpEnabled,
             PortForwardRules = request.PortForwardRules,
             NetworkConfigs = request.NetworkConfigs,
@@ -993,7 +995,7 @@ public class ConfigAuditEngine
                 .Where(g => !string.IsNullOrEmpty(g.Id))
                 .ToDictionary(g => g.Id, g => g);
             ctx.DnsSecurityResult = await _dnsAnalyzer.AnalyzeAsync(
-                ctx.SettingsData, ctx.FirewallRules, ctx.Switches, ctx.Networks, ctx.DeviceData, ctx.PiholeManagementPort, ctx.NatRulesData, ctx.DnatExcludedVlanIds, ctx.ExternalZoneId, ctx.ZoneLookup, firewallGroupsDict, ctx.PiholeManagementUrl, ctx.NetworkConfigs);
+                ctx.SettingsData, ctx.FirewallRules, ctx.Switches, ctx.Networks, ctx.DeviceData, ctx.PiholeManagementPort, ctx.NatRulesData, ctx.DnatExcludedVlanIds, ctx.ExternalZoneId, ctx.ZoneLookup, firewallGroupsDict, ctx.PiholeManagementUrl, ctx.NetworkConfigs, ctx.TrustedDnsRedirectTargets);
             ctx.AllIssues.AddRange(ctx.DnsSecurityResult.Issues);
             ctx.HardeningMeasures.AddRange(ctx.DnsSecurityResult.HardeningNotes);
             _logger.LogInformation("Found {IssueCount} DNS security issues", ctx.DnsSecurityResult.Issues.Count);

--- a/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
@@ -74,7 +74,8 @@ public class DnsSecurityAnalyzer
     /// <param name="dnatExcludedVlanIds">Optional VLAN IDs to exclude from DNAT coverage checks</param>
     /// <param name="externalZoneId">Optional External/WAN zone ID for validating firewall rule destinations</param>
     /// <param name="zoneLookup">Optional firewall zone lookup for DMZ/Hotspot network identification</param>
-    public async Task<DnsSecurityResult> AnalyzeAsync(JsonElement? settingsData, List<FirewallRule>? firewallRules, List<SwitchInfo>? switches, List<NetworkInfo>? networks, JsonElement? deviceData, int? customDnsManagementPort, JsonElement? natRulesData, List<int>? dnatExcludedVlanIds = null, string? externalZoneId = null, Services.FirewallZoneLookup? zoneLookup = null, Dictionary<string, UniFiFirewallGroup>? firewallGroups = null, string? customDnsManagementUrl = null, List<UniFiNetworkConfig>? networkConfigs = null)
+    /// <param name="trustedDnsRedirectTargets">Optional additional IPs to accept as valid DNAT redirect targets (e.g., keepalived VIPs)</param>
+    public async Task<DnsSecurityResult> AnalyzeAsync(JsonElement? settingsData, List<FirewallRule>? firewallRules, List<SwitchInfo>? switches, List<NetworkInfo>? networks, JsonElement? deviceData, int? customDnsManagementPort, JsonElement? natRulesData, List<int>? dnatExcludedVlanIds = null, string? externalZoneId = null, Services.FirewallZoneLookup? zoneLookup = null, Dictionary<string, UniFiFirewallGroup>? firewallGroups = null, string? customDnsManagementUrl = null, List<UniFiNetworkConfig>? networkConfigs = null, List<string>? trustedDnsRedirectTargets = null)
     {
         var result = new DnsSecurityResult();
 
@@ -143,7 +144,7 @@ public class DnsSecurityAnalyzer
         // Analyze DNAT DNS rules (alternative to firewall blocking)
         if (natRulesData.HasValue && networks?.Any() == true)
         {
-            AnalyzeDnatDnsRules(natRulesData.Value, networks, result, dnatExcludedVlanIds, firewallGroups);
+            AnalyzeDnatDnsRules(natRulesData.Value, networks, result, dnatExcludedVlanIds, firewallGroups, trustedDnsRedirectTargets);
         }
 
         // Generate issues based on findings (includes async WAN DNS validation)
@@ -2371,7 +2372,7 @@ public class DnsSecurityAnalyzer
     /// DNAT rules that redirect UDP port 53 to a trusted DNS server (gateway, Pi-hole)
     /// can be an alternative to firewall blocking when DoH or third-party DNS is configured.
     /// </summary>
-    private void AnalyzeDnatDnsRules(JsonElement natRulesData, List<NetworkInfo> networks, DnsSecurityResult result, List<int>? excludedVlanIds = null, Dictionary<string, UniFiFirewallGroup>? firewallGroups = null)
+    private void AnalyzeDnatDnsRules(JsonElement natRulesData, List<NetworkInfo> networks, DnsSecurityResult result, List<int>? excludedVlanIds = null, Dictionary<string, UniFiFirewallGroup>? firewallGroups = null, List<string>? trustedDnsRedirectTargets = null)
     {
         var dnatAnalyzer = new DnatDnsAnalyzer();
         var coverageResult = dnatAnalyzer.Analyze(natRulesData, networks, excludedVlanIds, firewallGroups);
@@ -2406,7 +2407,7 @@ public class DnsSecurityAnalyzer
         }
 
         // Validate redirect destinations
-        ValidateDnatRedirectTargets(coverageResult, result, networks);
+        ValidateDnatRedirectTargets(coverageResult, result, networks, trustedDnsRedirectTargets);
 
         // Validate destination filters (should be Any or inverted)
         ValidateDnatDestinationFilters(coverageResult, result);
@@ -2421,7 +2422,8 @@ public class DnsSecurityAnalyzer
     private void ValidateDnatRedirectTargets(
         DnatCoverageResult coverageResult,
         DnsSecurityResult result,
-        List<NetworkInfo> networks)
+        List<NetworkInfo> networks,
+        List<string>? trustedDnsRedirectTargets = null)
     {
         if (!coverageResult.HasDnatDnsRules)
             return;
@@ -2446,6 +2448,13 @@ public class DnsSecurityAnalyzer
                         validDestinations.Add(dnsServer);
                     }
                 }
+            }
+
+            // User-configured trusted DNS redirect targets (VIPs, anycast, etc.)
+            if (trustedDnsRedirectTargets != null)
+            {
+                foreach (var ip in trustedDnsRedirectTargets.Where(s => !string.IsNullOrWhiteSpace(s)))
+                    validDestinations.Add(ip.Trim());
             }
 
             result.ExpectedDnatDestinations.AddRange(validDestinations);
@@ -2521,6 +2530,17 @@ public class DnsSecurityAnalyzer
                         }
                     }
                     // else: No DHCP DNS and no DoH - skip validation for this rule
+                }
+
+                // User-configured trusted DNS redirect targets (VIPs, anycast, etc.).
+                // Added per-rule so a rule with no per-network DHCP DNS still validates against trusted IPs.
+                if (trustedDnsRedirectTargets != null)
+                {
+                    foreach (var ip in trustedDnsRedirectTargets.Where(s => !string.IsNullOrWhiteSpace(s)))
+                    {
+                        ruleValidDestinations.Add(ip.Trim());
+                        allValidDestinations.Add(ip.Trim());
+                    }
                 }
 
                 if (ruleValidDestinations.Count == 0)

--- a/src/NetworkOptimizer.Audit/Models/AuditRequest.cs
+++ b/src/NetworkOptimizer.Audit/Models/AuditRequest.cs
@@ -79,6 +79,14 @@ public class AuditRequest
     public List<int>? DnatExcludedVlanIds { get; init; }
 
     /// <summary>
+    /// Optional: Additional IPs to accept as valid DNAT DNS redirect targets.
+    /// Use for DNS VIPs (keepalived, HAProxy, anycast) or DNS servers not in
+    /// LAN DNS configuration. IPs are added to the valid-target set used by
+    /// the DNAT redirect destination validator.
+    /// </summary>
+    public List<string>? TrustedDnsRedirectTargets { get; init; }
+
+    /// <summary>
     /// Optional: Custom port for third-party DNS management interface (Pi-hole, AdGuard Home, etc.)
     /// If not specified, auto-probes ports 80, 443, 8080, 3000
     /// </summary>

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1295,6 +1295,12 @@
             </div>
 
             <div class="form-group" style="margin-top: 1.5rem;">
+                <label class="form-label">Trusted DNS Redirect Targets (optional)</label>
+                <input type="text" class="form-control" @bind="trustedDnsRedirectTargets" placeholder="e.g., 10.0.100.248" style="width: 320px;" />
+                <small class="form-help">Comma-separated IPs to accept as valid DNAT translated targets. Use for DNS VIPs (keepalived, HAProxy) or anycast addresses that are not in your LAN DNS configuration.</small>
+            </div>
+
+            <div class="form-group" style="margin-top: 1.5rem;">
                 <label class="form-label">Third-Party DNS Management (optional)</label>
                 <input type="text" class="form-control" @bind="piholeManagementEndpoint" placeholder="Port number or URL" style="width: 240px;" />
                 <small class="form-help">Custom port (e.g., 8080) or full URL (e.g., https://pihole.local) for the admin interface. Leave empty to auto-probe ports 80, 443, 3000, 8080.</small>
@@ -2081,6 +2087,7 @@
     private bool allowPrintersOnMainNetwork = true;
     private string dnatExcludedVlans = "";
     private string? piholeManagementEndpoint;
+    private string trustedDnsRedirectTargets = "";
     private int unusedPortInactivityDays = 15;
     private int namedPortInactivityDays = 45;
     private bool savingAuditSettings = false;
@@ -3663,6 +3670,7 @@
             var printers = await SystemSettings.GetAsync("audit:allowPrintersOnMainNetwork");
             var excludedVlans = await SystemSettings.GetAsync("audit:dnatExcludedVlans");
             var piholePort = await SystemSettings.GetAsync("audit:piholeManagementPort");
+            var trustedTargets = await SystemSettings.GetAsync("audit:trustedDnsRedirectTargets");
             var unusedPortDays = await SystemSettings.GetAsync("audit:unusedPortInactivityDays");
             var namedPortDays = await SystemSettings.GetAsync("audit:namedPortInactivityDays");
 
@@ -3677,6 +3685,8 @@
             dnatExcludedVlans = excludedVlans ?? "";
             // Third-party DNS endpoint (Pi-hole, AdGuard Home, etc.) - null means auto-detect
             piholeManagementEndpoint = string.IsNullOrWhiteSpace(piholePort) ? null : piholePort;
+            // Trusted DNS redirect targets (VIPs, anycast)
+            trustedDnsRedirectTargets = trustedTargets ?? "";
             // Unused port thresholds (defaults: 15 days unnamed, 45 days named)
             unusedPortInactivityDays = int.TryParse(unusedPortDays, out var unusedDays) && unusedDays > 0 ? unusedDays : 15;
             namedPortInactivityDays = int.TryParse(namedPortDays, out var namedDays) && namedDays > 0 ? namedDays : 45;
@@ -3715,6 +3725,7 @@
                 return;
             }
             await SystemSettings.SetAsync("audit:piholeManagementPort", endpoint ?? "");
+            await SystemSettings.SetAsync("audit:trustedDnsRedirectTargets", trustedDnsRedirectTargets ?? "");
             await SystemSettings.SetAsync("audit:unusedPortInactivityDays", unusedPortInactivityDays.ToString());
             await SystemSettings.SetAsync("audit:namedPortInactivityDays", namedPortInactivityDays.ToString());
 

--- a/src/NetworkOptimizer.Web/Services/AuditService.cs
+++ b/src/NetworkOptimizer.Web/Services/AuditService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
 using Microsoft.Extensions.Caching.Memory;
+using NetworkOptimizer.Alerts.Events;
 using NetworkOptimizer.Audit;
 using NetworkOptimizer.Audit.Models;
 using NetworkOptimizer.Audit.Rules;
@@ -9,7 +10,6 @@ using NetworkOptimizer.Core.Helpers;
 using NetworkOptimizer.Core.Models;
 using NetworkOptimizer.Storage.Interfaces;
 using NetworkOptimizer.Storage.Models;
-using NetworkOptimizer.Alerts.Events;
 using NetworkOptimizer.Threats.Interfaces;
 using NetworkOptimizer.Threats.Models;
 using AuditModels = NetworkOptimizer.Audit.Models;
@@ -2002,8 +2002,8 @@ public class AuditService
         foreach (var part in raw.Split(new[] { ',', ';', '\n', '\r', ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries))
         {
             var trimmed = part.Trim();
-            if (System.Net.IPAddress.TryParse(trimmed, out _))
-                ips.Add(trimmed);
+            if (System.Net.IPAddress.TryParse(trimmed, out var parsed))
+                ips.Add(parsed.ToString());
         }
         return ips.Count > 0 ? ips : null;
     }

--- a/src/NetworkOptimizer.Web/Services/AuditService.cs
+++ b/src/NetworkOptimizer.Web/Services/AuditService.cs
@@ -180,6 +180,7 @@ public class AuditService
             var printers = await _settingsService.GetAsync("audit:allowPrintersOnMainNetwork");
             var dnatExcludedVlans = await _settingsService.GetAsync("audit:dnatExcludedVlans");
             var piholeEndpoint = await _settingsService.GetAsync("audit:piholeManagementPort");
+            var trustedDnsTargets = await _settingsService.GetAsync("audit:trustedDnsRedirectTargets");
             var unusedPortDays = await _settingsService.GetAsync("audit:unusedPortInactivityDays");
             var namedPortDays = await _settingsService.GetAsync("audit:namedPortInactivityDays");
 
@@ -201,6 +202,8 @@ public class AuditService
             {
                 options.PiholeManagementUrl = piholeEndpoint;
             }
+            // Trusted DNS redirect targets (VIPs, anycast IPs not in LAN DNS config)
+            options.TrustedDnsRedirectTargets = ParseIpList(trustedDnsTargets);
             // Unused port thresholds (defaults: 15 days unnamed, 45 days named)
             options.UnusedPortInactivityDays = int.TryParse(unusedPortDays, out var unusedDays) && unusedDays > 0 ? unusedDays : 15;
             options.NamedPortInactivityDays = int.TryParse(namedPortDays, out var namedDays) && namedDays > 0 ? namedDays : 45;
@@ -1446,6 +1449,7 @@ public class AuditService
                 DnatExcludedVlanIds = options.DnatExcludedVlanIds,
                 PiholeManagementPort = options.PiholeManagementPort,
                 PiholeManagementUrl = options.PiholeManagementUrl,
+                TrustedDnsRedirectTargets = options.TrustedDnsRedirectTargets,
                 UpnpEnabled = upnpEnabled,
                 PortForwardRules = portForwardRules,
                 NetworkConfigs = networkConfigs,
@@ -1987,6 +1991,24 @@ public class AuditService
     }
 
     /// <summary>
+    /// Parse a comma/space/semicolon/newline separated list of IP addresses.
+    /// Invalid entries are silently dropped. Returns null if no valid IPs found.
+    /// </summary>
+    private static List<string>? ParseIpList(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return null;
+        var ips = new List<string>();
+        foreach (var part in raw.Split(new[] { ',', ';', '\n', '\r', ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var trimmed = part.Trim();
+            if (System.Net.IPAddress.TryParse(trimmed, out _))
+                ips.Add(trimmed);
+        }
+        return ips.Count > 0 ? ips : null;
+    }
+
+    /// <summary>
     /// Check if a firewall API response contains actual data.
     /// Returns false for null, empty arrays, or empty objects.
     /// </summary>
@@ -2066,6 +2088,7 @@ public class AuditOptions
     public List<int>? DnatExcludedVlanIds { get; set; }
     public int? PiholeManagementPort { get; set; }
     public string? PiholeManagementUrl { get; set; }
+    public List<string>? TrustedDnsRedirectTargets { get; set; }
 
     // Unused port detection thresholds
     public int UnusedPortInactivityDays { get; set; } = 15;

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
@@ -4754,6 +4754,64 @@ public class DnsSecurityAnalyzerTests : IDisposable
     }
 
     [Fact]
+    public async Task Analyze_DnatWithPiholeAndVip_RedirectsToTrustedVip_NoIssue()
+    {
+        // Arrange - Pi-hole pair with a keepalived VIP. DNAT points at the VIP,
+        // which is not in DhcpDns. TrustedDnsRedirectTargets allowlists the VIP.
+        var networks = new List<NetworkInfo>
+        {
+            new NetworkInfo
+            {
+                Id = "net1", Name = "LAN", VlanId = 1,
+                Purpose = NetworkPurpose.Home,
+                Subnet = "192.168.1.0/24", DhcpEnabled = true,
+                Gateway = "192.168.1.1",
+                DnsServers = new List<string> { "192.168.1.5", "192.168.1.6" }
+            }
+        };
+        var switches = new List<SwitchInfo>();
+        var natRules = CreateDnatNatRules(("net1", "192.168.1.4")); // VIP, not in DhcpDns
+        var trusted = new List<string> { "192.168.1.4" };
+
+        // Act
+        var result = await _analyzer.AnalyzeAsync(
+            null, null, switches, networks, null, null, natRules,
+            dnatExcludedVlanIds: null, externalZoneId: null, zoneLookup: null,
+            firewallGroups: null, customDnsManagementUrl: null, networkConfigs: null,
+            trustedDnsRedirectTargets: trusted);
+
+        // Assert
+        result.IsSiteWideThirdPartyDns.Should().BeTrue();
+        result.DnatRedirectTargetIsValid.Should().BeTrue();
+        result.InvalidDnatRules.Should().BeEmpty();
+        result.Issues.Should().NotContain(i => i.Type == IssueTypes.DnsDnatWrongDestination);
+    }
+
+    [Fact]
+    public async Task Analyze_DnatWithPiholeAndVip_NoTrustedList_RaisesIssue()
+    {
+        // Sanity: same setup without the trusted list still raises the issue (no regression).
+        var networks = new List<NetworkInfo>
+        {
+            new NetworkInfo
+            {
+                Id = "net1", Name = "LAN", VlanId = 1,
+                Purpose = NetworkPurpose.Home,
+                Subnet = "192.168.1.0/24", DhcpEnabled = true,
+                Gateway = "192.168.1.1",
+                DnsServers = new List<string> { "192.168.1.5", "192.168.1.6" }
+            }
+        };
+        var natRules = CreateDnatNatRules(("net1", "192.168.1.4"));
+
+        var result = await _analyzer.AnalyzeAsync(null, null, new List<SwitchInfo>(), networks, null, null, natRules);
+
+        result.DnatRedirectTargetIsValid.Should().BeFalse();
+        result.InvalidDnatRules.Should().NotBeEmpty();
+        result.Issues.Should().Contain(i => i.Type == IssueTypes.DnsDnatWrongDestination);
+    }
+
+    [Fact]
     public async Task Analyze_DnatWithDoH_RedirectsToGateway_NoIssue()
     {
         // Arrange - DoH configured, DNAT correctly points to gateway


### PR DESCRIPTION
The DNAT redirect destination validator rejects translated IPs that are not present in the LAN DNS configuration. Setups using a virtual IP (keepalived, HAProxy, anycast) in front of a redundant DNS pair are flagged as misconfigured even though the VIP is the correct target by design - pointing DNAT at a single backend IP would defeat failover.

Add an audit setting (audit:trustedDnsRedirectTargets) that lets operators allowlist additional IPs as valid DNAT translated targets. The list is consulted in both the site-wide third-party DNS branch and the per-network DHCP DNS branch of ValidateDnatRedirectTargets.

Settings UI: comma-separated IPs, validated via IPAddress.TryParse. Empty value preserves existing behavior. No existing tests change.