### PR TITLE
Monitoring: SFP charts, manual targets, probe cadence, UX fixes

### DIFF
--- a/src/NetworkOptimizer.Monitoring/Probes/PingOutputParser.cs
+++ b/src/NetworkOptimizer.Monitoring/Probes/PingOutputParser.cs
@@ -78,7 +78,8 @@ public static class PingOutputParser
             var rtts = ExtractPerReplyRtts(output);
             if (rtts.Count > 0)
             {
-                received = Math.Max(received, rtts.Count);
+                // Clamp to sent so duplicate ICMP replies don't produce negative loss
+                received = Math.Min(sent, Math.Max(received, rtts.Count));
                 min ??= rtts.Min();
                 max ??= rtts.Max();
                 avg ??= rtts.Average();

--- a/src/NetworkOptimizer.Monitoring/Probes/ProbeTypes.cs
+++ b/src/NetworkOptimizer.Monitoring/Probes/ProbeTypes.cs
@@ -76,7 +76,7 @@ public record PingProbeResult
     public string? RawOutput { get; init; }
 
     public bool Success => Received > 0;
-    public double LossPercent => Sent == 0 ? 100.0 : (1.0 - (double)Received / Sent) * 100.0;
+    public double LossPercent => Sent == 0 ? 100.0 : Math.Max(0.0, (1.0 - (double)Received / Sent) * 100.0);
 }
 
 /// <summary>One hop on a traceroute. Address may be null for non-responding hops.</summary>

--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -237,7 +237,7 @@
                 if (el.hasAttribute('data-tooltip-follow')) {
                     opts.followCursor = true;
                 }
-                if (el.hasAttribute('data-tooltip-hover-only')) {
+                if (el.hasAttribute('data-tooltip-hover-only') || el.tagName === 'BUTTON') {
                     opts.trigger = 'mouseenter';
                 }
                 tippy(el, opts);
@@ -290,7 +290,7 @@
                 if (el.hasAttribute('data-tooltip-follow')) {
                     opts.followCursor = true;
                 }
-                if (el.hasAttribute('data-tooltip-hover-only')) {
+                if (el.hasAttribute('data-tooltip-hover-only') || el.tagName === 'BUTTON') {
                     opts.trigger = 'mouseenter';
                 }
                 if (el._tippy) {

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -235,70 +235,6 @@ else if (_snmpState == SnmpDetectionState.EnabledV2c || _snmpState == SnmpDetect
         </div>
     </div>
 
-    @if (_monitoringEnabled && _monitoredSfps.Count > 0)
-    {
-        <div class="card" style="margin-top: 1.5rem;">
-            <div class="card-header">
-                <h2 class="card-title">Optical (SFP / ONT)</h2>
-                <span class="status-badge status-active">@_monitoredSfps.Count modules</span>
-            </div>
-            <div class="card-body">
-                <p class="section-description">
-                    GPON / XGS-PON ONTs and other SFP modules detected on switch / gateway
-                    ports. RX optical power should sit in a healthy range (typically
-                    -3 to -25 dBm for single-mode); values outside that range need
-                    attention.
-                </p>
-                <div class="table-responsive">
-                <table class="data-table">
-                    <thead>
-                        <tr>
-                            <th>Port</th>
-                            <th>Module</th>
-                            <th>RX power</th>
-                            <th>TX power</th>
-                            <th>Temp</th>
-                            <th>Voltage</th>
-                            <th>Bias</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @foreach (var sfp in _monitoredSfps.OrderBy(s => s.DeviceMac).ThenBy(s => s.PortName))
-                        {
-                            var stats = LiveStats.GetSfpStats(sfp.DeviceMac, sfp.PortName);
-                            var deviceName = ResolveDeviceName(sfp.DeviceMac);
-                            var portLabel = !string.IsNullOrEmpty(sfp.FriendlyName) ? sfp.FriendlyName : $"port {sfp.PortName}";
-                            <tr>
-                                <td>
-                                    <div class="sfp-port-cell">
-                                        <strong>@deviceName</strong>
-                                        <span class="text-muted">@portLabel</span>
-                                        @if (sfp.IsPon)
-                                        {
-                                            <span class="status-badge status-active">@PonVariantLabel(sfp.SfpPart, sfp.SfpVendor)</span>
-                                        }
-                                    </div>
-                                </td>
-                                <td>
-                                    @if (!string.IsNullOrEmpty(sfp.SfpPart))
-                                    { <code>@sfp.SfpPart</code> }
-                                    else
-                                    { <span class="text-muted">-</span> }
-                                </td>
-                                <td class="@RxClass(stats?.RxPowerDbm)">@FormatOptical(stats?.RxPowerDbm, "dBm")</td>
-                                <td>@FormatOptical(stats?.TxPowerDbm, "dBm")</td>
-                                <td>@FormatOptical(stats?.TemperatureC, "°C")</td>
-                                <td>@FormatOptical(stats?.VoltageV, "V")</td>
-                                <td>@FormatOptical(stats?.BiasMa, "mA")</td>
-                            </tr>
-                        }
-                    </tbody>
-                </table>
-                </div>
-            </div>
-        </div>
-    }
-
     @if (_monitoringEnabled && _influxReachable == true)
     {
         <!-- 3D LAN flow map (spec 5.7). Centerpiece of the monitoring view. -->
@@ -423,6 +359,181 @@ else if (_snmpState == SnmpDetectionState.EnabledV2c || _snmpState == SnmpDetect
             </div>
         </div>
 
+        @if (_allSfps.Count > 0)
+        {
+        <div class="card" style="margin-top: 1.5rem;">
+            <div class="card-header card-header-collapsible" @onclick="ToggleSfpCollapse">
+                <h2 class="card-title">Optical (SFP / ONT)</h2>
+                <div style="display: flex; align-items: center; gap: 0.5rem;">
+                    <span class="status-badge status-active" @onclick:stopPropagation="true">@_monitoredSfps.Count monitored</span>
+                    <span class="issue-type-chevron">@(_sfpCollapsed ? "▼" : "▲")</span>
+                </div>
+            </div>
+            <div class="expand-wrapper @(!_sfpCollapsed ? "expanded" : "")">
+                <div class="expand-content">
+            <div class="card-body">
+                <p class="section-description">
+                    GPON / XGS-PON ONTs and other SFP modules detected on switch / gateway
+                    ports. For PON modules, RX power typically sits between -15 and -25 dBm;
+                    values weaker than -27 dBm may indicate a failing link.
+                </p>
+                <div class="table-responsive">
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Port</th>
+                            <th>Module</th>
+                            <th>Type</th>
+                            <th>RX power</th>
+                            <th>TX power</th>
+                            <th>Temp</th>
+                            <th>Voltage</th>
+                            <th>Bias</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var sfp in SfpPage())
+                        {
+                            var stats = LiveStats.GetSfpStats(sfp.DeviceMac, sfp.PortName);
+                            var deviceName = ResolveDeviceName(sfp.DeviceMac);
+                            var portLabel = !string.IsNullOrEmpty(sfp.FriendlyName) ? sfp.FriendlyName : $"port {sfp.PortName}";
+                            <tr style="@(sfp.IsMonitoredOnt ? "" : "opacity: 0.6;")">
+                                <td>
+                                    <div class="sfp-port-cell">
+                                        <strong>@deviceName</strong>
+                                        <span class="text-muted">@portLabel</span>
+                                    </div>
+                                </td>
+                                <td>
+                                    @if (!string.IsNullOrEmpty(sfp.SfpPart))
+                                    { <code>@sfp.SfpPart</code> }
+                                    else
+                                    { <span class="text-muted">-</span> }
+                                </td>
+                                <td>
+                                    @if (sfp.IsPon)
+                                    {
+                                        <span class="status-badge status-active">@PonVariantLabel(sfp.SfpPart, sfp.SfpVendor)</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="status-badge status-connected">SFP</span>
+                                    }
+                                </td>
+                                <td class="@RxClass(sfp.IsPon ? stats?.RxPowerDbm : null)">@FormatOptical(stats?.RxPowerDbm, "dBm")</td>
+                                <td>@FormatOptical(stats?.TxPowerDbm, "dBm")</td>
+                                <td>@FormatOptical(stats?.TemperatureC, "°C")</td>
+                                <td>@FormatOptical(stats?.VoltageV, "V")</td>
+                                <td>@FormatOptical(stats?.BiasMa, "mA")</td>
+                                <td style="white-space: nowrap;">
+                                    @if (sfp.IsMonitoredOnt)
+                                    {
+                                        <button class="btn btn-sm btn-secondary"
+                                                @onclick="() => ToggleSfpMonitoringAsync(sfp.Id, false)"
+                                                data-tooltip="Stop monitoring this SFP">
+                                            Unmonitor
+                                        </button>
+                                    }
+                                    else
+                                    {
+                                        <button class="btn btn-sm btn-primary"
+                                                @onclick="() => ToggleSfpMonitoringAsync(sfp.Id, true)"
+                                                data-tooltip="Add this SFP to monitoring">
+                                            Monitor
+                                        </button>
+                                    }
+                                    @if (!sfp.IsPon)
+                                    {
+                                        <button class="btn btn-sm btn-secondary"
+                                                @onclick="() => ToggleSfpPonAsync(sfp.Id, true)"
+                                                data-tooltip="Mark as PON module"
+                                                style="margin-left: 0.25rem;">
+                                            Set PON
+                                        </button>
+                                    }
+                                    else if (!IsPonAutoDetected(sfp))
+                                    {
+                                        <button class="btn btn-sm btn-secondary"
+                                                @onclick="() => ToggleSfpPonAsync(sfp.Id, false)"
+                                                data-tooltip="Mark as regular SFP"
+                                                style="margin-left: 0.25rem;">
+                                            Set SFP
+                                        </button>
+                                    }
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+                </div>
+                @if (SfpTotalPages() > 1)
+                {
+                    <div style="display: flex; align-items: center; gap: 0.75rem; margin-top: 0.75rem;">
+                        <button class="btn btn-sm btn-secondary" disabled="@(_sfpPage == 0)" @onclick="() => { _sfpPage--; StateHasChanged(); }">Prev</button>
+                        <span class="text-muted" style="font-size: 0.85rem;">@(_sfpPage + 1) / @SfpTotalPages()</span>
+                        <button class="btn btn-sm btn-secondary" disabled="@(_sfpPage >= SfpTotalPages() - 1)" @onclick="() => { _sfpPage++; StateHasChanged(); }">Next</button>
+                    </div>
+                }
+            </div>
+                </div>
+            </div>
+        </div>
+        }
+
+        @if (_monitoredSfps.Count > 0)
+        {
+        <!-- SFP DDM time-series: RX/TX power + temperature/voltage -->
+        <div class="card" style="margin-top: 1.5rem;" id="sfp-charts-container">
+            <div class="card-header" style="flex-wrap: wrap; gap: 0.75rem;">
+                <h2 class="card-title">SFP Diagnostics</h2>
+                <div style="display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap;">
+                    <button class="time-btn" data-shift="back" data-tooltip="Shift window back">&#x25C0;</button>
+                    <div class="time-range-selector" style="position: relative;">
+                        <button class="time-btn" data-range="0">15m</button>
+                        <button class="time-btn" data-range="1">1h</button>
+                        <button class="time-btn" data-range="6">6h</button>
+                        <button class="time-btn active" data-range="24">24h</button>
+                        <button class="time-btn" data-range="168">7d</button>
+                        <button class="time-btn" data-range="720">30d</button>
+                        <button class="time-btn custom-range-btn" data-action="custom-range" data-tooltip="Custom date range" data-tooltip-hover-only>
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+                        </button>
+                        <div class="custom-range-popover" data-popover="custom-range">
+                            <div class="custom-range-form">
+                                <div class="custom-range-title">Custom Range</div>
+                                <div class="custom-range-field">
+                                    <label>From</label>
+                                    <input type="datetime-local" data-input="from" class="custom-range-input" />
+                                </div>
+                                <div class="custom-range-field">
+                                    <label>To</label>
+                                    <input type="datetime-local" data-input="to" class="custom-range-input" />
+                                </div>
+                                <div class="custom-range-actions">
+                                    <button class="btn btn-sm btn-secondary" data-action="cancel-custom">Cancel</button>
+                                    <button class="btn btn-sm btn-primary" data-action="apply-custom">Apply</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <button class="time-btn" data-shift="forward" data-tooltip="Shift window forward">&#x25B6;</button>
+                </div>
+            </div>
+            <div class="card-body">
+                <div class="sfp-filter-badges wan-filter-badges"></div>
+                <div class="chart-card">
+                    <div class="chart-header"><h3 class="chart-title">RX / TX Power</h3></div>
+                    <div class="sfp-power-chart"></div>
+                </div>
+                <div class="chart-card" style="margin-top: 1rem;">
+                    <div class="chart-header"><h3 class="chart-title">Temperature</h3></div>
+                    <div class="sfp-temp-chart"></div>
+                </div>
+            </div>
+        </div>
+        }
+
         <!-- Upstream tracer wizard (Build #10). User-initiated discovery of the access
              ISP path + transit ASN clouds; output populates AccessIsp / Transit
              MonitoringTarget rows for the agent's latency tier to probe. -->
@@ -487,7 +598,20 @@ else if (_snmpState == SnmpDetectionState.EnabledV2c || _snmpState == SnmpDetect
                                     </td>
                                     <td>@t.Name</td>
                                     <td><code>@t.Address</code></td>
-                                    <td>@t.PollIntervalSeconds s</td>
+                                    <td>
+                                        @{ var currentInterval = t.PollIntervalSeconds; }
+                                        <select class="cadence-select"
+                                                @onchange="(e) => UpdateTargetIntervalAsync(t.Id, e)">
+                                            <option value="2" selected="@(currentInterval == 2)">2 s</option>
+                                            <option value="5" selected="@(currentInterval == 5)">5 s</option>
+                                            <option value="10" selected="@(currentInterval == 10)">10 s</option>
+                                            <option value="15" selected="@(currentInterval == 15)">15 s</option>
+                                            <option value="30" selected="@(currentInterval == 30)">30 s</option>
+                                            <option value="60" selected="@(currentInterval == 60)">60 s</option>
+                                            <option value="120" selected="@(currentInterval == 120)">2 m</option>
+                                            <option value="300" selected="@(currentInterval == 300)">5 m</option>
+                                        </select>
+                                    </td>
                                     <td>
                                         @if (!t.Enabled)
                                         {
@@ -545,6 +669,71 @@ else if (_snmpState == SnmpDetectionState.EnabledV2c || _snmpState == SnmpDetect
                         probing without losing the row's history.
                     </p>
                 }
+
+                @if (_showAddTarget)
+                {
+                    <div class="add-target-form" style="margin-top: 1rem; padding: 1rem; background: var(--bg-tertiary); border-radius: 8px;">
+                        <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: end;">
+                            <div>
+                                <label class="form-label" style="margin-bottom: 0.25rem; font-size: 0.8rem;">Name</label>
+                                <input type="text" class="custom-range-input" @bind="_newTargetName" placeholder="My ISP gateway" style="width: 160px;" />
+                            </div>
+                            <div>
+                                <label class="form-label" style="margin-bottom: 0.25rem; font-size: 0.8rem;">Address</label>
+                                <input type="text" class="custom-range-input" @bind="_newTargetAddress" placeholder="192.168.1.1 or hostname" style="width: 180px;" />
+                            </div>
+                            <div>
+                                <label class="form-label" style="margin-bottom: 0.25rem; font-size: 0.8rem;">Type</label>
+                                <select class="cadence-select" style="width: 130px;" @bind="_newTargetType">
+                                    <option value="Custom">Custom</option>
+                                    <option value="InternetService">Internet</option>
+                                    <option value="AccessIsp">ISP</option>
+                                    <option value="Transit">Transit</option>
+                                </select>
+                            </div>
+                            <div>
+                                <label class="form-label" style="margin-bottom: 0.25rem; font-size: 0.8rem;">Probe</label>
+                                <select class="cadence-select" style="width: 100px;" @bind="_newTargetProbeMode">
+                                    <option value="Icmp">ICMP</option>
+                                    <option value="Tcp">TCP</option>
+                                </select>
+                            </div>
+                            @if (_newTargetProbeMode == "Tcp")
+                            {
+                                <div>
+                                    <label class="form-label" style="margin-bottom: 0.25rem; font-size: 0.8rem;">Port</label>
+                                    <input type="number" class="custom-range-input" @bind="_newTargetPort" placeholder="443" style="width: 70px;" />
+                                </div>
+                            }
+                            <div>
+                                <label class="form-label" style="margin-bottom: 0.25rem; font-size: 0.8rem;">Interval</label>
+                                <select class="cadence-select" style="width: 80px;" @bind="_newTargetInterval">
+                                    <option value="5">5 s</option>
+                                    <option value="10">10 s</option>
+                                    <option value="15">15 s</option>
+                                    <option value="30">30 s</option>
+                                    <option value="60">60 s</option>
+                                </select>
+                            </div>
+                            <div style="display: flex; gap: 0.5rem;">
+                                <button class="btn btn-sm btn-primary" @onclick="AddTargetAsync" disabled="@_addingTarget">
+                                    @if (_addingTarget) { <span class="spinner-sm"></span> } else { <span>Add</span> }
+                                </button>
+                                <button class="btn btn-sm btn-secondary" @onclick="() => _showAddTarget = false">Cancel</button>
+                            </div>
+                        </div>
+                        @if (!string.IsNullOrEmpty(_addTargetError))
+                        {
+                            <p style="color: var(--danger-color); margin-top: 0.5rem; font-size: 0.85rem;">@_addTargetError</p>
+                        }
+                    </div>
+                }
+                else
+                {
+                    <button class="btn btn-sm btn-secondary" style="margin-top: 0.75rem;" @onclick="() => _showAddTarget = true">
+                        + Add target
+                    </button>
+                }
             </div>
                 </div>
             </div>
@@ -589,6 +778,8 @@ else if (_snmpState == SnmpDetectionState.PollFailing)
     private bool _togglingEnable;
     private List<MonitoringTarget> _targets = new();
     private List<MonitoredSfp> _monitoredSfps = new();
+    private List<MonitoredSfp> _allSfps = new();
+    private Dictionary<string, string> _deviceIpByMac = new();
     private System.Threading.Timer? _refreshTimer;
 
     // Collapse state. Status auto-collapses when fully healthy (computed below);
@@ -596,6 +787,22 @@ else if (_snmpState == SnmpDetectionState.PollFailing)
     private bool _statusCollapsed = false;
     private bool _targetsCollapsed = true;
     private bool _userToggledStatus = false; // once the user clicks, stop auto-collapsing
+
+    // SFP collapse + pagination
+    private bool _sfpCollapsed = false;
+    private int _sfpPage = 0;
+    private const int SfpPageSize = 10;
+
+    // Add-target form state
+    private bool _showAddTarget;
+    private bool _addingTarget;
+    private string _newTargetName = "";
+    private string _newTargetAddress = "";
+    private string _newTargetType = "Custom";
+    private string _newTargetProbeMode = "Icmp";
+    private int _newTargetPort = 443;
+    private int _newTargetInterval = 10;
+    private string? _addTargetError;
 
     // 3D map JS module handle. Mounted after first render (canvas must exist in DOM).
     private bool _mapMounted = false;
@@ -610,19 +817,27 @@ else if (_snmpState == SnmpDetectionState.PollFailing)
         await LoadTargetsAsync();
 
         // Refresh the targets list periodically so LastVerified updates show movement
-        // without requiring a full page reload.
+        // without requiring a full page reload. Uses a longer interval (15 s) and skips
+        // StateHasChanged when the targets card is collapsed, because Blazor re-renders
+        // cause the 3D map's WebGL canvas to stutter.
         _refreshTimer = new System.Threading.Timer(async _ =>
         {
             try
             {
                 await InvokeAsync(async () =>
                 {
+                    var oldTargetCount = _targets.Count;
+                    var oldSfpCount = _allSfps.Count;
                     await LoadTargetsAsync();
-                    StateHasChanged();
+                    var changed = _targets.Count != oldTargetCount
+                        || _allSfps.Count != oldSfpCount
+                        || !_targetsCollapsed;
+                    if (changed)
+                        StateHasChanged();
                 });
             }
             catch { /* prevent timer death */ }
-        }, null, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
+        }, null, TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(15));
 
         if (_snmpState == SnmpDetectionState.NotChecked && ConnectionService.IsConnected)
         {
@@ -782,9 +997,23 @@ else if (_snmpState == SnmpDetectionState.PollFailing)
             await using var db = await DbFactory.CreateDbContextAsync();
             _targets = await db.MonitoringTargets.AsNoTracking()
                 .OrderBy(t => t.TargetType).ThenBy(t => t.Name).ToListAsync();
-            _monitoredSfps = await db.MonitoredSfps.AsNoTracking()
-                .Where(s => s.IsMonitoredOnt)
-                .ToListAsync();
+            _allSfps = await db.MonitoredSfps.AsNoTracking().ToListAsync();
+            _monitoredSfps = _allSfps.Where(s => s.IsMonitoredOnt).ToList();
+
+            try
+            {
+                var devices = await ConnectionService.GetDiscoveredDevicesAsync();
+                if (devices != null)
+                {
+                    _deviceIpByMac = devices
+                        .Where(d => !string.IsNullOrEmpty(d.Mac))
+                        .ToDictionary(
+                            d => d.Mac!.Replace("-", ":").ToLowerInvariant(),
+                            d => d.DisplayIpAddress ?? "",
+                            StringComparer.OrdinalIgnoreCase);
+                }
+            }
+            catch { /* best effort - fall back to fabric target IPs */ }
 
             // Auto-collapse the Monitoring Status card once everything is healthy. The
             // user is here to see live data, not the green checkmarks. Once they've
@@ -801,6 +1030,7 @@ else if (_snmpState == SnmpDetectionState.PollFailing)
         catch
         {
             _targets = new List<MonitoringTarget>();
+            _allSfps = new List<MonitoredSfp>();
             _monitoredSfps = new List<MonitoredSfp>();
         }
     }
@@ -817,6 +1047,54 @@ else if (_snmpState == SnmpDetectionState.PollFailing)
         _targetsCollapsed = !_targetsCollapsed;
         StateHasChanged();
     }
+
+    private void ToggleSfpCollapse()
+    {
+        _sfpCollapsed = !_sfpCollapsed;
+        StateHasChanged();
+    }
+
+    private string ResolveDeviceIp(string deviceMac)
+    {
+        if (string.IsNullOrEmpty(deviceMac)) return "255.255.255.255";
+        var normalized = deviceMac.Replace("-", ":").ToLowerInvariant();
+        if (_deviceIpByMac.TryGetValue(normalized, out var ip) && !string.IsNullOrEmpty(ip))
+            return ip;
+        var target = _targets.FirstOrDefault(t =>
+            t.TargetType == MonitoringTargetType.Fabric
+            && !string.IsNullOrEmpty(t.DeviceMac)
+            && t.DeviceMac.Replace("-", ":").ToLowerInvariant() == normalized);
+        return target?.Address ?? "255.255.255.255";
+    }
+
+    private List<MonitoredSfp> SortedSfps()
+    {
+        return _allSfps
+            .OrderBy(s => ParseIpForSorting(ResolveDeviceIp(s.DeviceMac)))
+            .ThenBy(s => int.TryParse(s.PortName, out var p) ? p : 9999)
+            .ToList();
+    }
+
+    private static long ParseIpForSorting(string? ip)
+    {
+        if (string.IsNullOrEmpty(ip)) return long.MaxValue;
+        var parts = ip.Split('.');
+        if (parts.Length != 4) return long.MaxValue;
+        long result = 0;
+        foreach (var part in parts)
+        {
+            if (!int.TryParse(part, out var octet)) return long.MaxValue;
+            result = (result << 8) | (uint)(octet & 0xFF);
+        }
+        return result;
+    }
+
+    private IEnumerable<MonitoredSfp> SfpPage()
+    {
+        return SortedSfps().Skip(_sfpPage * SfpPageSize).Take(SfpPageSize);
+    }
+
+    private int SfpTotalPages() => Math.Max(1, (int)Math.Ceiling((double)_allSfps.Count / SfpPageSize));
 
     private async Task ToggleTargetAsync(int targetId)
     {
@@ -848,21 +1126,168 @@ else if (_snmpState == SnmpDetectionState.PollFailing)
         catch { /* best effort */ }
     }
 
+    private async Task UpdateTargetIntervalAsync(int targetId, ChangeEventArgs e)
+    {
+        if (!int.TryParse(e.Value?.ToString(), out var interval)) return;
+        try
+        {
+            await using var db = await DbFactory.CreateDbContextAsync();
+            var row = await db.MonitoringTargets.FindAsync(targetId);
+            if (row == null) return;
+            row.PollIntervalSeconds = interval;
+            await db.SaveChangesAsync();
+            await LoadTargetsAsync();
+            StateHasChanged();
+        }
+        catch { /* best effort */ }
+    }
+
+    private async Task AddTargetAsync()
+    {
+        _addTargetError = null;
+        var name = _newTargetName.Trim();
+        var address = _newTargetAddress.Trim();
+        if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(address))
+        {
+            _addTargetError = "Name and address are required.";
+            return;
+        }
+        if (name.Length > 200 || address.Length > 200)
+        {
+            _addTargetError = "Name and address must be under 200 characters.";
+            return;
+        }
+        if (!System.Net.IPAddress.TryParse(address, out _)
+            && !System.Text.RegularExpressions.Regex.IsMatch(address, @"^[a-zA-Z0-9][a-zA-Z0-9.\-]*$"))
+        {
+            _addTargetError = "Address must be a valid IP or hostname.";
+            return;
+        }
+
+        _addingTarget = true;
+        StateHasChanged();
+        try
+        {
+            var targetType = Enum.TryParse<MonitoringTargetType>(_newTargetType, out var tt) ? tt : MonitoringTargetType.Custom;
+            var probeMode = _newTargetProbeMode == "Tcp" ? NetworkOptimizer.Core.Enums.ProbeMode.Tcp : NetworkOptimizer.Core.Enums.ProbeMode.Icmp;
+            var targetId = $"custom-{Guid.NewGuid():N}"[..24];
+
+            await using var db = await DbFactory.CreateDbContextAsync();
+            db.MonitoringTargets.Add(new MonitoringTarget
+            {
+                TargetId = targetId,
+                Name = name,
+                Address = address,
+                TargetType = targetType,
+                ProbeMode = probeMode,
+                Port = probeMode == NetworkOptimizer.Core.Enums.ProbeMode.Tcp ? _newTargetPort : null,
+                PollIntervalSeconds = _newTargetInterval,
+                PingCount = 5,
+                Enabled = true,
+                AutoDiscovered = false,
+                VantagePoint = "server",
+                CreatedAt = DateTime.UtcNow
+            });
+            await db.SaveChangesAsync();
+
+            _showAddTarget = false;
+            _newTargetName = "";
+            _newTargetAddress = "";
+            _newTargetType = "Custom";
+            _newTargetProbeMode = "Icmp";
+            _newTargetPort = 443;
+            _newTargetInterval = 10;
+            await LoadTargetsAsync();
+            StateHasChanged();
+        }
+        catch (Exception ex)
+        {
+            _addTargetError = $"Failed to add target: {ex.Message}";
+        }
+        finally
+        {
+            _addingTarget = false;
+        }
+    }
+
+    private System.Threading.Timer? _sfpChartDebounce;
+
+    private async Task ToggleSfpMonitoringAsync(int sfpId, bool monitored)
+    {
+        try
+        {
+            await using var db = await DbFactory.CreateDbContextAsync();
+            var row = await db.MonitoredSfps.FindAsync(sfpId);
+            if (row == null) return;
+            row.IsMonitoredOnt = monitored;
+            row.UpdatedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync();
+            await LoadTargetsAsync();
+            StateHasChanged();
+            DebounceSfpChartRemount();
+        }
+        catch { /* best effort */ }
+    }
+
+    private async Task ToggleSfpPonAsync(int sfpId, bool isPon)
+    {
+        try
+        {
+            await using var db = await DbFactory.CreateDbContextAsync();
+            var row = await db.MonitoredSfps.FindAsync(sfpId);
+            if (row == null) return;
+            row.IsPon = isPon;
+            row.UpdatedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync();
+            await LoadTargetsAsync();
+            StateHasChanged();
+            DebounceSfpChartRemount();
+        }
+        catch { /* best effort */ }
+    }
+
+    private void DebounceSfpChartRemount()
+    {
+        _sfpChartDebounce?.Dispose();
+        _sfpChartDebounce = new System.Threading.Timer(async _ =>
+        {
+            try
+            {
+                await InvokeAsync(async () =>
+                {
+                    if (_sfpChartsMounted)
+                    {
+                        try { await JS.InvokeVoidAsync("eval", "window.__sfpCharts?.unmount();"); }
+                        catch { }
+                        _sfpChartsMounted = false;
+                    }
+                    StateHasChanged();
+                });
+            }
+            catch { }
+        }, null, TimeSpan.FromSeconds(2), Timeout.InfiniteTimeSpan);
+    }
+
+    private static bool IsPonAutoDetected(MonitoredSfp sfp)
+    {
+        var variant = NetworkOptimizer.Core.Helpers.NetworkFormatHelpers.PonVariantLabel(sfp.SfpPart, sfp.SfpVendor);
+        return variant != "PON";
+    }
+
     private static string FormatOptical(double? value, string unit)
     {
         if (!value.HasValue) return "-";
         return $"{value.Value:0.##} {unit}";
     }
 
-    // Single-mode SFP/PON optical receive should land roughly between -3 and -25 dBm.
-    // Outside that range, the link is either over-driven (too strong, will cause errors)
-    // or under-driven (failing). Color-code the cell so problems jump out.
+    // PON RX power: -8 to -28 dBm is the ITU-T spec receiver range. Typical
+    // operating range is -15 to -25 dBm. Color-code so problems jump out.
     private static string RxClass(double? rxDbm)
     {
         if (!rxDbm.HasValue) return string.Empty;
         var v = rxDbm.Value;
-        if (v >= -27 && v <= -3) return "";              // healthy range
-        if (v >= -30 && v <= -1) return "signal-fair";
+        if (v >= -25 && v <= -8) return "";              // healthy
+        if (v >= -28 && v <= -5) return "signal-fair";   // marginal
         return "signal-poor";
     }
 
@@ -906,6 +1331,7 @@ else if (_snmpState == SnmpDetectionState.PollFailing)
 
     private bool _latencyChartsMounted;
     private bool _healthChartsMounted;
+    private bool _sfpChartsMounted;
 
     private string VersionedJs(string path) => FileVersionProvider.AddFileVersionToPath("", path);
 
@@ -933,6 +1359,24 @@ else if (_snmpState == SnmpDetectionState.PollFailing)
                     $"(async () => {{ const m = await import('{healthUrl}'); window.__healthCharts = m; await m.mount('device-health-charts-container'); }})();");
             }
             catch { _healthChartsMounted = false; }
+        }
+
+        if (_monitoringEnabled && _influxReachable == true && _monitoredSfps.Count > 0 && !_sfpChartsMounted)
+        {
+            _sfpChartsMounted = true;
+            try
+            {
+                var sfpUrl = VersionedJs("/js/sfp-charts.js");
+                await JS.InvokeVoidAsync("eval",
+                    $"(async () => {{ const m = await import('{sfpUrl}'); window.__sfpCharts = m; await m.mount('sfp-charts-container'); }})();");
+            }
+            catch { _sfpChartsMounted = false; }
+        }
+        else if (_sfpChartsMounted && (_monitoredSfps.Count == 0 || !_monitoringEnabled || _influxReachable != true))
+        {
+            _sfpChartsMounted = false;
+            try { await JS.InvokeVoidAsync("eval", "window.__sfpCharts?.unmount();"); }
+            catch { }
         }
 
         if (_monitoringEnabled && _influxReachable == true && !_mapMounted)
@@ -963,6 +1407,7 @@ else if (_snmpState == SnmpDetectionState.PollFailing)
         ConnectionService.OnConnectionChanged -= OnConnectionChanged;
         _refreshTimer?.Dispose();
         _testFeedbackTimer?.Dispose();
+        _sfpChartDebounce?.Dispose();
         if (_latencyChartsMounted)
         {
             try { _ = JS.InvokeVoidAsync("eval", "window.__latencyCharts?.unmount();").AsTask(); }
@@ -971,6 +1416,11 @@ else if (_snmpState == SnmpDetectionState.PollFailing)
         if (_healthChartsMounted)
         {
             try { _ = JS.InvokeVoidAsync("eval", "window.__healthCharts?.unmount();").AsTask(); }
+            catch { }
+        }
+        if (_sfpChartsMounted)
+        {
+            try { _ = JS.InvokeVoidAsync("eval", "window.__sfpCharts?.unmount();").AsTask(); }
             catch { }
         }
         if (_mapMounted)

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -260,6 +260,7 @@ else if (_snmpState == SnmpDetectionState.EnabledV2c || _snmpState == SnmpDetect
                         <button class="time-btn" data-category="Transit">Transit</button>
                         <button class="time-btn" data-category="InternetService">Internet</button>
                     </div>
+                    <div style="display: flex; align-items: center; gap: 0.75rem;">
                     <button class="time-btn" data-shift="back" data-tooltip="Shift window back">&#x25C0;</button>
                     <div class="time-range-selector" style="position: relative;">
                         <button class="time-btn" data-range="0">15m</button>
@@ -290,6 +291,7 @@ else if (_snmpState == SnmpDetectionState.EnabledV2c || _snmpState == SnmpDetect
                         </div>
                     </div>
                     <button class="time-btn" data-shift="forward" data-tooltip="Shift window forward">&#x25B6;</button>
+                    </div>
                 </div>
             </div>
             <div class="card-body">

--- a/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
@@ -186,7 +186,7 @@ else
         {
             await using var db = await DbFactory.CreateDbContextAsync();
             _monitoredOnts = await db.MonitoredSfps.AsNoTracking()
-                .Where(s => s.IsMonitoredOnt)
+                .Where(s => s.IsMonitoredOnt && s.IsPon)
                 .OrderBy(s => s.DeviceMac).ThenBy(s => s.PortName)
                 .ToListAsync();
             _fabricTargets = await db.MonitoringTargets.AsNoTracking()

--- a/src/NetworkOptimizer.Web/Endpoints/SfpChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/SfpChartEndpoints.cs
@@ -1,0 +1,84 @@
+using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services;
+
+namespace NetworkOptimizer.Web.Endpoints;
+
+public static class SfpChartEndpoints
+{
+    public static void Map(WebApplication app)
+    {
+        app.MapGet("/api/monitoring/sfp-chart", async (
+            MonitoringInfluxClient influx,
+            IDbContextFactory<NetworkOptimizerDbContext> dbFactory,
+            int? rangeHours,
+            DateTime? from,
+            DateTime? to,
+            CancellationToken ct) =>
+        {
+            DateTime queryFrom, queryTo;
+            if (from.HasValue && to.HasValue)
+            {
+                queryFrom = from.Value.ToUniversalTime();
+                queryTo = to.Value.ToUniversalTime();
+            }
+            else
+            {
+                var hours = rangeHours ?? 1;
+                queryTo = DateTime.UtcNow;
+                queryFrom = hours == 0 ? queryTo.AddMinutes(-15) : queryTo.AddHours(-hours);
+            }
+
+            await using var db = await dbFactory.CreateDbContextAsync(ct);
+            var sfps = await db.MonitoredSfps.AsNoTracking()
+                .Where(s => s.IsMonitoredOnt)
+                .OrderBy(s => s.DeviceMac).ThenBy(s => s.PortName)
+                .ToListAsync(ct);
+
+            if (sfps.Count == 0)
+                return Results.Ok(new { modules = Array.Empty<object>() });
+
+            var modules = sfps.Select(s => (s.DeviceMac, s.PortName)).ToList();
+            var data = await influx.QuerySfpByModulesAsync(modules, queryFrom, queryTo, ct: ct);
+
+            var targets = await db.MonitoringTargets.AsNoTracking()
+                .Where(t => t.TargetType == MonitoringTargetType.Fabric)
+                .Select(t => new { t.DeviceMac, t.Name })
+                .ToListAsync(ct);
+            var nameMap = targets
+                .Where(t => !string.IsNullOrEmpty(t.DeviceMac))
+                .GroupBy(t => t.DeviceMac!.Replace("-", ":").ToLowerInvariant())
+                .ToDictionary(g => g.Key, g => g.First().Name);
+
+            var result = sfps.Select(s =>
+            {
+                var key = $"{s.DeviceMac.Replace("-", ":").ToLowerInvariant()}:{s.PortName}";
+                data.TryGetValue(key, out var points);
+                var pts = points ?? new List<MonitoringInfluxClient.SfpPoint>();
+                var deviceName = nameMap.TryGetValue(
+                    s.DeviceMac.Replace("-", ":").ToLowerInvariant(), out var n) ? n : s.DeviceMac;
+                var label = !string.IsNullOrEmpty(s.FriendlyName)
+                    ? s.FriendlyName
+                    : $"{deviceName} port {s.PortName}";
+
+                return new
+                {
+                    id = key,
+                    label,
+                    isPon = s.IsPon,
+                    sfpPart = s.SfpPart,
+                    data = pts.Select(p => new
+                    {
+                        time = p.Time.ToString("o"),
+                        rx = p.RxPowerDbm,
+                        tx = p.TxPowerDbm,
+                        temp = p.TemperatureC,
+                        voltage = p.VoltageV
+                    })
+                };
+            });
+
+            return Results.Ok(new { modules = result });
+        });
+    }
+}

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -1487,6 +1487,7 @@ app.MapDelete("/api/config/backups/pending", (ConfigTransferService service) =>
 LanFlowMapEndpoints.Map(app);
 MonitoringChartEndpoints.Map(app);
 DeviceHealthChartEndpoints.Map(app);
+SfpChartEndpoints.Map(app);
 
 app.Run();
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -597,6 +597,53 @@ from(bucket: ""{_bucket}"")
         return results;
     }
 
+    /// <summary>Per-SFP DDM time-series for a set of (device_mac, port_name) pairs.</summary>
+    public async Task<Dictionary<string, List<SfpPoint>>> QuerySfpByModulesAsync(
+        IReadOnlyList<(string DeviceMac, string PortName)> modules,
+        DateTime from,
+        DateTime to,
+        TimeSpan? aggregateWindow = null,
+        CancellationToken ct = default)
+    {
+        if (!IsConfigured) await ReconfigureAsync(ct);
+        if (!IsConfigured || modules.Count == 0) return new Dictionary<string, List<SfpPoint>>();
+        var window = aggregateWindow ?? PickAggregateWindow(to - from);
+
+        var macFilter = string.Join(" or ", modules.Select(m =>
+            $@"(r.device_mac == ""{NormalizeMac(m.DeviceMac)}"" and r.port_name == ""{SanitizeFluxString(m.PortName)}"")"));
+
+        var flux = $@"
+from(bucket: ""{_longtermBucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""sfp"")
+  |> filter(fn: (r) => {macFilter})
+  |> filter(fn: (r) => r._field == ""rx_power_dbm"" or r._field == ""tx_power_dbm"" or r._field == ""temperature_c"" or r._field == ""voltage_v"")
+  |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
+  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
+";
+        var results = new Dictionary<string, List<SfpPoint>>();
+        await foreach (var record in QueryFluxAsync(flux, ct))
+        {
+            var mac = record.GetValueByKey("device_mac") as string ?? "";
+            var port = record.GetValueByKey("port_name") as string ?? "";
+            var key = $"{mac}:{port}";
+            if (!results.TryGetValue(key, out var list))
+            {
+                list = new List<SfpPoint>();
+                results[key] = list;
+            }
+            list.Add(new SfpPoint
+            {
+                Time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow),
+                RxPowerDbm = AsDoubleOrNull(record.GetValueByKey("rx_power_dbm")),
+                TxPowerDbm = AsDoubleOrNull(record.GetValueByKey("tx_power_dbm")),
+                TemperatureC = AsDoubleOrNull(record.GetValueByKey("temperature_c")),
+                VoltageV = AsDoubleOrNull(record.GetValueByKey("voltage_v"))
+            });
+        }
+        return results;
+    }
+
     /// <summary>
     /// Historical WiFi client snapshots for timeline mode on the 3D map. Filter by
     /// AP MAC (tag), optionally by band (tag) and by client MAC (field). Returns
@@ -666,14 +713,11 @@ from(bucket: ""{_bucket}"")
 
     private static TimeSpan PickAggregateWindow(TimeSpan range)
     {
-        // Aim for ~120 points across the range — enough for a smooth chart, light enough
-        // that InfluxDB doesn't return tens of thousands of rows on long windows.
-        if (range <= TimeSpan.FromMinutes(15)) return TimeSpan.FromSeconds(5);
-        if (range <= TimeSpan.FromHours(1)) return TimeSpan.FromSeconds(30);
-        if (range <= TimeSpan.FromHours(6)) return TimeSpan.FromMinutes(3);
-        if (range <= TimeSpan.FromHours(24)) return TimeSpan.FromMinutes(15);
-        if (range <= TimeSpan.FromDays(7)) return TimeSpan.FromHours(1);
-        return TimeSpan.FromHours(6);
+        // Target ~150 data points regardless of range. Floor at 5 s so short ranges
+        // don't produce sub-second windows that InfluxDB can't aggregate meaningfully.
+        const int targetPoints = 150;
+        var windowSeconds = Math.Max(5, (int)(range.TotalSeconds / targetPoints));
+        return TimeSpan.FromSeconds(windowSeconds);
     }
 
     private static string ToFluxInstant(DateTime t) =>
@@ -727,6 +771,15 @@ from(bucket: ""{_bucket}"")
         public required DateTime Time { get; init; }
         public double? RttAvgMs { get; init; }
         public double? LossPercent { get; init; }
+    }
+
+    public record SfpPoint
+    {
+        public required DateTime Time { get; init; }
+        public double? RxPowerDbm { get; init; }
+        public double? TxPowerDbm { get; init; }
+        public double? TemperatureC { get; init; }
+        public double? VoltageV { get; init; }
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14321,6 +14321,19 @@ a.affected-client:hover {
 .sfp-port-cell .text-muted {
     font-size: 0.85rem;
 }
+.cadence-select {
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    border: 1px solid var(--bg-hover);
+    border-radius: 4px;
+    padding: 0.15rem 0.35rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+.cadence-select:focus {
+    outline: 1px solid var(--primary-color);
+    border-color: var(--primary-color);
+}
 .lan-flow-map-mode {
     display: inline-flex;
     align-items: center;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -265,6 +265,9 @@ export class LanFlowMap {
     }
 
     _shouldAcceptKeys() {
+        const tag = document.activeElement?.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return false;
+        if (document.activeElement?.isContentEditable) return false;
         const rect = this.canvas.getBoundingClientRect();
         return rect.bottom > 0 && rect.top < window.innerHeight;
     }
@@ -285,6 +288,9 @@ export class LanFlowMap {
                 <polyline points="20 14 14 14 14 20"></polyline><polyline points="10 20 10 14 4 14"></polyline></svg>`;
             this._panels.fullscreenBtn.setAttribute('data-tooltip', 'Exit fullscreen (Esc)');
         }
+        document.dispatchEvent(new CustomEvent('lanflowmap-fullscreen', {
+            detail: { fullscreen: !isFs }
+        }));
         setTimeout(() => this._handleResize(), 50);
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -25,6 +25,10 @@ let visibility = {};
 let targetMeta = [];
 let containerId = null;
 let fetchController = null;
+let visibilityObserver = null;
+let isInViewport = true;
+let isMapFullscreen = false;
+let fsHandler = null;
 
 function baseChartOpts(type, yTitle, yFormatter, extraOpts) {
     return {
@@ -201,10 +205,12 @@ async function loadAndUpdate() {
     if (container) renderBadges(container);
 }
 
+function isVisible() { return isInViewport && !isMapFullscreen; }
+
 function startPoll() {
     stopPoll();
-    // Don't auto-poll when viewing historical (shifted or custom) windows
     if (windowOffset !== 0 || isCustomRange) return;
+    if (!isVisible()) return;
     const interval = POLL_INTERVALS[currentRangeHours] || 30000;
     pollTimer = setInterval(loadAndUpdate, interval);
 }
@@ -406,12 +412,30 @@ export async function mount(elId) {
         startPoll();
     });
 
+    visibilityObserver = new IntersectionObserver(([entry]) => {
+        const was = isVisible();
+        isInViewport = entry.isIntersecting;
+        if (isVisible() && !was) { loadAndUpdate(); startPoll(); }
+        else if (!isVisible() && was) { stopPoll(); }
+    }, { threshold: 0 });
+    visibilityObserver.observe(container);
+
+    fsHandler = (e) => {
+        const was = isVisible();
+        isMapFullscreen = e.detail.fullscreen;
+        if (isVisible() && !was) { loadAndUpdate(); startPoll(); }
+        else if (!isVisible() && was) { stopPoll(); }
+    };
+    document.addEventListener('lanflowmap-fullscreen', fsHandler);
+
     await loadAndUpdate();
     startPoll();
 }
 
 export function unmount() {
     stopPoll();
+    if (visibilityObserver) { visibilityObserver.disconnect(); visibilityObserver = null; }
+    if (fsHandler) { document.removeEventListener('lanflowmap-fullscreen', fsHandler); fsHandler = null; }
     if (fetchController) { fetchController.abort(); fetchController = null; }
     if (rttChart) { rttChart.destroy(); rttChart = null; }
     if (lossChart) { lossChart.destroy(); lossChart = null; }
@@ -422,4 +446,6 @@ export function unmount() {
     isCustomRange = false;
     customFrom = null;
     customTo = null;
+    isInViewport = true;
+    isMapFullscreen = false;
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -1,26 +1,25 @@
-// TODO: Extract time-range controls (presets, shift arrows, custom range popover,
-// filter badges, poll interval scaling) into a shared module so latency-charts,
-// device-health-charts, and future chart sets share one implementation.
+// SFP DDM time-series charts: RX/TX power, temperature, voltage.
+// Same control pattern as latency-charts.js and device-health-charts.js.
+
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 
 const PALETTE = ['#2ba89a', '#3b82f6', '#a78bfa', '#ef5858', '#f59e0b', '#10b981'];
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
-const POLL_INTERVALS = { 0: 5000, 1: 5000, 6: 10000, 24: 15000, 168: 30000, 720: 30000 };
+const POLL_INTERVALS = { 0: 10000, 1: 10000, 6: 15000, 24: 30000, 168: 60000, 720: 60000 };
 const RANGE_MS = { 0: 15*60000, 1: 3600000, 6: 6*3600000, 24: 86400000, 168: 7*86400000, 720: 30*86400000 };
 
+let powerChart = null;
 let tempChart = null;
-let cpuChart = null;
-let memChart = null;
 let pollTimer = null;
-let currentRangeHours = 1;
+let currentRangeHours = 24;
 let windowOffset = 0;
 let isCustomRange = false;
 let customFrom = null;
 let customTo = null;
 let containerId = null;
 let fetchController = null;
-let deviceMeta = [];
+let moduleMeta = [];
 let visibility = {};
 let visibilityObserver = null;
 let isInViewport = true;
@@ -48,7 +47,6 @@ function baseOpts(height, yTitle, yFormatter, extra) {
             },
         },
         yaxis: {
-            min: 0,
             title: { text: yTitle, style: { color: '#9ca3af' } },
             labels: { style: { colors: '#9ca3af' }, formatter: yFormatter },
         },
@@ -80,7 +78,7 @@ async function fetchData() {
     if (fetchController) fetchController.abort();
     fetchController = new AbortController();
     try {
-        const resp = await fetch(`/api/monitoring/device-health-chart?${buildQueryParams()}`,
+        const resp = await fetch(`/api/monitoring/sfp-chart?${buildQueryParams()}`,
             { signal: fetchController.signal });
         if (!resp.ok) return null;
         return await resp.json();
@@ -91,25 +89,25 @@ async function fetchData() {
 }
 
 function renderBadges(container) {
-    const el = container.querySelector('.health-filter-badges');
+    const el = container.querySelector('.sfp-filter-badges');
     if (!el) return;
-    if (deviceMeta.length <= 1) { el.innerHTML = ''; return; }
-    el.innerHTML = deviceMeta.map(d => {
-        const vis = visibility[d.mac] !== false;
-        return `<button class="wan-filter-badge ${vis ? 'active' : 'inactive'}" data-mac="${d.mac}">
-            <span class="wan-badge-dot" style="background-color: ${d.color}"></span>
-            <span>${escapeHtml(d.name)}</span>
+    if (moduleMeta.length <= 1) { el.innerHTML = ''; return; }
+    el.innerHTML = moduleMeta.map(m => {
+        const vis = visibility[m.id] !== false;
+        return `<button class="wan-filter-badge ${vis ? 'active' : 'inactive'}" data-sfp="${m.id}">
+            <span class="wan-badge-dot" style="background-color: ${m.color}"></span>
+            <span>${escapeHtml(m.label)}</span>
         </button>`;
     }).join('');
     el.querySelectorAll('button').forEach(btn => {
         btn.addEventListener('click', () => {
-            const mac = btn.dataset.mac;
-            const allVis = deviceMeta.every(d => visibility[d.mac] !== false);
-            const onlyThis = visibility[mac] !== false
-                && deviceMeta.filter(d => d.mac !== mac).every(d => visibility[d.mac] === false);
+            const id = btn.dataset.sfp;
+            const allVis = moduleMeta.every(m => visibility[m.id] !== false);
+            const onlyThis = visibility[id] !== false
+                && moduleMeta.filter(m => m.id !== id).every(m => visibility[m.id] === false);
             if (onlyThis) { visibility = {}; }
-            else if (allVis) { deviceMeta.forEach(d => visibility[d.mac] = d.mac === mac); }
-            else { visibility[mac] = visibility[mac] === false; }
+            else if (allVis) { moduleMeta.forEach(m => visibility[m.id] = m.id === id); }
+            else { visibility[id] = visibility[id] === false; }
             updateVisibility();
             renderBadges(container);
         });
@@ -117,32 +115,56 @@ function renderBadges(container) {
 }
 
 function updateVisibility() {
-    deviceMeta.forEach(d => {
-        const vis = visibility[d.mac] !== false;
-        for (const chart of [tempChart, cpuChart, memChart]) {
-            if (!chart) continue;
-            if (vis) chart.showSeries(d.name);
-            else chart.hideSeries(d.name);
+    moduleMeta.forEach(m => {
+        const vis = visibility[m.id] !== false;
+        if (powerChart) {
+            if (vis) { powerChart.showSeries(`${m.label} RX`); powerChart.showSeries(`${m.label} TX`); }
+            else { powerChart.hideSeries(`${m.label} RX`); powerChart.hideSeries(`${m.label} TX`); }
+        }
+        if (tempChart) {
+            if (vis) tempChart.showSeries(m.label);
+            else tempChart.hideSeries(m.label);
         }
     });
 }
 
 async function loadAndUpdate() {
     const data = await fetchData();
-    if (!data?.devices) return;
-    deviceMeta = data.devices.map((d, i) => ({
-        name: d.name, mac: d.mac, color: PALETTE[i % PALETTE.length],
+    if (!data?.modules) return;
+    moduleMeta = data.modules.map((m, i) => ({
+        id: m.id, label: m.label, color: PALETTE[i % PALETTE.length],
     }));
-    const makeSeries = (field) => data.devices.map((d, i) => ({
-        name: d.name,
-        color: PALETTE[i % PALETTE.length],
-        data: (d.data || []).filter(p => p[field] != null).map(p => ({
-            x: new Date(p.time).getTime(), y: p[field]
-        })),
-    }));
-    if (tempChart) tempChart.updateSeries(makeSeries('temp'), false);
-    if (cpuChart) cpuChart.updateSeries(makeSeries('cpu'), false);
-    if (memChart) memChart.updateSeries(makeSeries('mem'), false);
+
+    const powerSeries = [];
+    const tSeries = [];
+    data.modules.forEach((m, i) => {
+        const color = PALETTE[i % PALETTE.length];
+        const pts = m.data || [];
+        powerSeries.push({
+            name: `${m.label} RX`,
+            color: color,
+            data: pts.filter(p => p.rx != null).map(p => ({ x: new Date(p.time).getTime(), y: p.rx })),
+        });
+        powerSeries.push({
+            name: `${m.label} TX`,
+            color: color,
+            data: pts.filter(p => p.tx != null).map(p => ({ x: new Date(p.time).getTime(), y: p.tx })),
+        });
+        tSeries.push({
+            name: m.label,
+            color: color,
+            data: pts.filter(p => p.temp != null).map(p => ({ x: new Date(p.time).getTime(), y: p.temp })),
+        });
+    });
+
+    const powerDash = [];
+    data.modules.forEach(() => { powerDash.push(0); powerDash.push(5); });
+    if (powerChart) {
+        powerChart.updateOptions({ stroke: { curve: 'smooth', width: 2, dashArray: powerDash } }, false, false);
+        powerChart.updateSeries(powerSeries, false);
+    }
+    if (tempChart) tempChart.updateSeries(tSeries, false);
+
     updateVisibility();
     const container = document.getElementById(containerId);
     if (container) renderBadges(container);
@@ -154,7 +176,7 @@ function startPoll() {
     stopPoll();
     if (windowOffset !== 0 || isCustomRange) return;
     if (!isVisible()) return;
-    pollTimer = setInterval(loadAndUpdate, POLL_INTERVALS[currentRangeHours] || 30000);
+    pollTimer = setInterval(loadAndUpdate, POLL_INTERVALS[currentRangeHours] || 60000);
 }
 function stopPoll() { if (pollTimer) { clearInterval(pollTimer); pollTimer = null; } }
 
@@ -252,42 +274,33 @@ export async function mount(elId) {
     const container = document.getElementById(elId);
     if (!container) return;
 
-    const tempEl = container.querySelector('.health-temp-chart');
-    const cpuEl = container.querySelector('.health-cpu-chart');
-    const memEl = container.querySelector('.health-mem-chart');
-    if (!tempEl || !cpuEl || !memEl) return;
+    const powerEl = container.querySelector('.sfp-power-chart');
+    const tempEl = container.querySelector('.sfp-temp-chart');
+    if (!powerEl || !tempEl) return;
 
+    if (powerChart) { powerChart.destroy(); powerChart = null; }
     if (tempChart) { tempChart.destroy(); tempChart = null; }
-    if (cpuChart) { cpuChart.destroy(); cpuChart = null; }
-    if (memChart) { memChart.destroy(); memChart = null; }
 
-    tempChart = new ApexCharts(tempEl, { ...baseOpts(200, '°C', v => v != null ? v.toFixed(0) + ' °C' : ''), series: [], colors: PALETTE });
-    cpuChart = new ApexCharts(cpuEl, {
-        ...baseOpts(200, 'CPU %', v => v != null ? v.toFixed(0) + '%' : ''),
-        yaxis: { min: 0, max: v => Math.max(v * 1.1, 50), title: { text: 'CPU %', style: { color: '#9ca3af' } }, labels: { style: { colors: '#9ca3af' }, formatter: v => v != null ? v.toFixed(0) + '%' : '' } },
+    powerChart = new ApexCharts(powerEl, {
+        ...baseOpts(200, 'dBm', v => v != null ? v.toFixed(1) + ' dBm' : ''),
         series: [], colors: PALETTE,
     });
-    memChart = new ApexCharts(memEl, {
-        ...baseOpts(200, 'Memory %', v => v != null ? v.toFixed(0) + '%' : ''),
-        yaxis: { min: 0, max: v => Math.max(v * 1.1, 50), title: { text: 'Memory %', style: { color: '#9ca3af' } }, labels: { style: { colors: '#9ca3af' }, formatter: v => v != null ? v.toFixed(0) + '%' : '' } },
+    tempChart = new ApexCharts(tempEl, {
+        ...baseOpts(160, '°C', v => v != null ? v.toFixed(0) + ' °C' : ''),
         series: [], colors: PALETTE,
     });
 
+    await powerChart.render();
     await tempChart.render();
-    await cpuChart.render();
-    await memChart.render();
 
-    // Preset range buttons
     container.querySelectorAll('[data-range]').forEach(btn => {
         btn.addEventListener('click', () => selectPresetRange(container, parseInt(btn.dataset.range)));
     });
 
-    // Shift arrows
     container.querySelectorAll('[data-shift]').forEach(btn => {
         btn.addEventListener('click', () => shiftWindow(container, btn.dataset.shift));
     });
 
-    // Custom range popover
     const popover = container.querySelector('[data-popover="custom-range"]');
     const fromInput = container.querySelector('[data-input="from"]');
     const toInput = container.querySelector('[data-input="to"]');
@@ -351,11 +364,10 @@ export function unmount() {
     if (visibilityObserver) { visibilityObserver.disconnect(); visibilityObserver = null; }
     if (fsHandler) { document.removeEventListener('lanflowmap-fullscreen', fsHandler); fsHandler = null; }
     if (fetchController) { fetchController.abort(); fetchController = null; }
+    if (powerChart) { powerChart.destroy(); powerChart = null; }
     if (tempChart) { tempChart.destroy(); tempChart = null; }
-    if (cpuChart) { cpuChart.destroy(); cpuChart = null; }
-    if (memChart) { memChart.destroy(); memChart = null; }
     containerId = null;
-    deviceMeta = [];
+    moduleMeta = [];
     visibility = {};
     windowOffset = 0;
     isCustomRange = false;


### PR DESCRIPTION
## Summary

- **SFP management** - All detected SFP modules visible with Monitor/Unmonitor and PON/SFP type controls. Collapsible, paginated (10/page), sorted by device IP.
- **SFP time-series charts** - RX/TX power and temperature charts with date/time filtering, shift arrows, custom range, and module selector badges. 24h default window.
- **Manual latency targets** - Add custom targets with configurable name, address, type, probe mode, and interval.
- **Probe cadence adjustment** - Inline dropdown per target (2s to 5m).
- **Negative packet loss fix** - Clamped received count to prevent negative loss from duplicate ICMP replies.
- **3D map stutter fix** - Throttled Blazor refresh timer, skip re-renders when targets card is collapsed.
- **Chart polling optimization** - IntersectionObserver pauses polling when charts scroll out of view; custom event pauses during 3D map fullscreen. Immediate catch-up on resume. Viewport and fullscreen tracked independently to prevent state conflicts.
- **GPON Rx power range** - Corrected to -15 to -25 dBm typical.
- **Dashboard ONT Stats** - Filtered to PON modules only.
- **Aggregate window** - Proportional scaling (~150 points) prevents browser OOM on wide ranges.
- **Tooltip fix** - Buttons use hover-only trigger, no click.
- **WASD navigation** - Skips keyboard nav when focus is in an input field.
- **Input validation** - Add-target address validated as IP or hostname.