### PR TITLE
Monitoring: Live View historic playback with stat cards, speed control, and full map data

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1183,7 +1183,7 @@ else
                         && mac.Replace("-", ":").Equals(_gatewayMac, StringComparison.OrdinalIgnoreCase);
                     if (isGateway)
                         points = points
-                            .Where(p => System.Text.RegularExpressions.Regex.IsMatch(p.IfName, @"^eth\d+$"))
+                            .Where(p => System.Text.RegularExpressions.Regex.IsMatch(p.IfName, @"^(eth\d+|gre\d+)$"))
                             .ToList();
                     var closest = points
                         .GroupBy(p => p.Time)

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1164,12 +1164,19 @@ else
             transitLoss = losses.Count > 0 ? losses.Average() : 0;
         }));
 
-        // Fabric load (sum across all fabric devices, matching live-mode filter:
-        // gateways only count eth\d+ interfaces, switches count all)
+        // Fabric load (sum across switches, gateways, and cellular modems only -
+        // APs are excluded because their radio interfaces over-count beacons/retries.
+        // The live path only calls RecordFabricSum for these device types, so APs
+        // have FabricIngressBps == null and contribute 0 to the live total.)
         var fabricMacs = _targets
             .Where(t => t.TargetType == MonitoringTargetType.Fabric && !string.IsNullOrEmpty(t.DeviceMac))
             .Select(t => t.DeviceMac!)
             .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Where(mac =>
+            {
+                var stats = LiveStats.GetForDevice(mac);
+                return stats?.FabricIngressBps != null || stats?.FabricEgressBps != null;
+            })
             .ToList();
         if (fabricMacs.Count > 0)
         {

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1183,7 +1183,7 @@ else
                         && mac.Replace("-", ":").Equals(_gatewayMac, StringComparison.OrdinalIgnoreCase);
                     if (isGateway)
                         points = points
-                            .Where(p => System.Text.RegularExpressions.Regex.IsMatch(p.IfName, @"^(eth\d+|gre\d+)$"))
+                            .Where(p => System.Text.RegularExpressions.Regex.IsMatch(p.IfName, @"^eth\d+$"))
                             .ToList();
                     var closest = points
                         .GroupBy(p => p.Time)

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -700,6 +700,9 @@ else
     private List<string> _gatewayWanIfNames = new();
     private System.Threading.Timer? _liveRefreshTimer;
     private System.Threading.Timer? _dataRefreshTimer;
+    private DotNetObjectReference<Monitoring>? _mapDotNetRef;
+    private DateTime? _mapHistoricAt;
+    private HistoricStatSnapshot? _historicSnapshot;
 
     private string _activeTab = "setup";
 
@@ -1012,10 +1015,212 @@ else
         DebounceSfpChartRemount();
     }
 
+    // ─── Historic stat snapshot (synced with 3D map scrubber) ───
+
+    private record HistoricStatSnapshot
+    {
+        public double WanDownloadBps { get; init; }
+        public double WanUploadBps { get; init; }
+        public double? GatewayRttMs { get; init; }
+        public double GatewayLossPercent { get; init; }
+        public double? IspRttMs { get; init; }
+        public double IspLossPercent { get; init; }
+        public double? TransitRttMs { get; init; }
+        public double TransitLossPercent { get; init; }
+        public double? GatewayCpuPercent { get; init; }
+        public double? GatewayMemoryPercent { get; init; }
+        public double? GatewayTempC { get; init; }
+        public double FabricIngressBps { get; init; }
+        public double FabricEgressBps { get; init; }
+    }
+
+    [JSInvokable]
+    public async Task OnMapTimeChanged(string? isoTimestamp)
+    {
+        if (isoTimestamp == null)
+        {
+            _mapHistoricAt = null;
+            _historicSnapshot = null;
+            await InvokeAsync(StateHasChanged);
+            return;
+        }
+
+        var at = DateTime.Parse(isoTimestamp, null, System.Globalization.DateTimeStyles.RoundtripKind);
+        _mapHistoricAt = at;
+        await FetchHistoricSnapshotAsync(at);
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task FetchHistoricSnapshotAsync(DateTime at)
+    {
+        var from = at.AddSeconds(-15);
+        var to = at.AddSeconds(5);
+
+        double wanDown = 0, wanUp = 0;
+        double? gwRtt = null; double gwLoss = 0;
+        double? ispRtt = null; double ispLoss = 0;
+        double? transitRtt = null; double transitLoss = 0;
+        double? gwCpu = null, gwMem = null, gwTemp = null;
+        double fabricIn = 0, fabricOut = 0;
+
+        var tasks = new List<Task>();
+
+        // WAN rates
+        if (_gatewayMac != null && _gatewayWanIfNames.Count > 0)
+        {
+            tasks.Add(Task.Run(async () =>
+            {
+                var points = await InfluxClient.QueryGatewayWanRatesAsync(
+                    _gatewayMac, _gatewayWanIfNames, from, to);
+                var closest = points
+                    .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                    .FirstOrDefault();
+                if (closest != null)
+                {
+                    wanDown = closest.DownloadBps ?? 0;
+                    wanUp = closest.UploadBps ?? 0;
+                }
+            }));
+        }
+
+        // Gateway health
+        if (_gatewayMac != null)
+        {
+            tasks.Add(Task.Run(async () =>
+            {
+                var points = await InfluxClient.QueryDeviceHealthAsync(_gatewayMac, from, to);
+                var closest = points
+                    .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                    .FirstOrDefault();
+                if (closest != null)
+                {
+                    gwCpu = closest.CpuPercent;
+                    gwMem = closest.MemoryUsedPercent;
+                    gwTemp = closest.TemperatureC;
+                }
+            }));
+        }
+
+        // Gateway latency (Fabric target for the gateway)
+        var gwFabric = _targets.FirstOrDefault(t =>
+            t.TargetType == MonitoringTargetType.Fabric
+            && t.Enabled
+            && !string.IsNullOrEmpty(t.DeviceMac)
+            && _gatewayMac != null
+            && t.DeviceMac.Replace("-", ":").Equals(_gatewayMac, StringComparison.OrdinalIgnoreCase));
+        if (gwFabric != null)
+        {
+            tasks.Add(Task.Run(async () =>
+            {
+                var points = await InfluxClient.QueryLatencyAsync(gwFabric.TargetId, from, to);
+                var closest = points
+                    .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                    .FirstOrDefault();
+                if (closest != null)
+                {
+                    gwRtt = closest.RttAvgMs;
+                    gwLoss = closest.LossPercent ?? 0;
+                }
+            }));
+        }
+
+        // ISP latency (mean across enabled ISP targets)
+        tasks.Add(Task.Run(async () =>
+        {
+            var data = await InfluxClient.QueryLatencyByTargetTypeAsync(
+                MonitoringTargetType.AccessIsp, from, to);
+            var rtts = new List<double>();
+            var losses = new List<double>();
+            foreach (var (_, pts) in data)
+            {
+                var closest = pts
+                    .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                    .FirstOrDefault();
+                if (closest == null) continue;
+                if (closest.RttAvgMs.HasValue) rtts.Add(closest.RttAvgMs.Value);
+                if (closest.LossPercent.HasValue) losses.Add(closest.LossPercent.Value);
+            }
+            ispRtt = rtts.Count > 0 ? rtts.Average() : null;
+            ispLoss = losses.Count > 0 ? losses.Average() : 0;
+        }));
+
+        // Transit latency (mean across enabled Transit targets)
+        tasks.Add(Task.Run(async () =>
+        {
+            var data = await InfluxClient.QueryLatencyByTargetTypeAsync(
+                MonitoringTargetType.Transit, from, to);
+            var rtts = new List<double>();
+            var losses = new List<double>();
+            foreach (var (_, pts) in data)
+            {
+                var closest = pts
+                    .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                    .FirstOrDefault();
+                if (closest == null) continue;
+                if (closest.RttAvgMs.HasValue) rtts.Add(closest.RttAvgMs.Value);
+                if (closest.LossPercent.HasValue) losses.Add(closest.LossPercent.Value);
+            }
+            transitRtt = rtts.Count > 0 ? rtts.Average() : null;
+            transitLoss = losses.Count > 0 ? losses.Average() : 0;
+        }));
+
+        // Fabric load (sum across all fabric devices)
+        var fabricMacs = _targets
+            .Where(t => t.TargetType == MonitoringTargetType.Fabric && !string.IsNullOrEmpty(t.DeviceMac))
+            .Select(t => t.DeviceMac!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (fabricMacs.Count > 0)
+        {
+            tasks.Add(Task.Run(async () =>
+            {
+                double totalIn = 0, totalOut = 0;
+                foreach (var mac in fabricMacs)
+                {
+                    var points = await InfluxClient.QueryInterfaceRatesAsync(mac, from, to);
+                    var closest = points
+                        .GroupBy(p => p.Time)
+                        .OrderBy(g => Math.Abs((g.Key - at).TotalMilliseconds))
+                        .FirstOrDefault();
+                    if (closest == null) continue;
+                    foreach (var p in closest)
+                    {
+                        totalIn += p.RateInBps ?? 0;
+                        totalOut += p.RateOutBps ?? 0;
+                    }
+                }
+                fabricIn = totalIn;
+                fabricOut = totalOut;
+            }));
+        }
+
+        try { await Task.WhenAll(tasks); }
+        catch { }
+
+        _historicSnapshot = new HistoricStatSnapshot
+        {
+            WanDownloadBps = wanDown,
+            WanUploadBps = wanUp,
+            GatewayRttMs = gwRtt,
+            GatewayLossPercent = gwLoss,
+            IspRttMs = ispRtt,
+            IspLossPercent = ispLoss,
+            TransitRttMs = transitRtt,
+            TransitLossPercent = transitLoss,
+            GatewayCpuPercent = gwCpu,
+            GatewayMemoryPercent = gwMem,
+            GatewayTempC = gwTemp,
+            FabricIngressBps = fabricIn,
+            FabricEgressBps = fabricOut,
+        };
+    }
+
     // ─── Stat card helpers ───
 
     private (double download, double upload) GetWanRates()
     {
+        if (_historicSnapshot != null)
+            return (_historicSnapshot.WanDownloadBps, _historicSnapshot.WanUploadBps);
         if (_gatewayMac == null || _gatewayWanIfNames.Count == 0) return (0, 0);
         double totalDown = 0, totalUp = 0;
         foreach (var ifName in _gatewayWanIfNames)
@@ -1032,12 +1237,23 @@ else
 
     private DeviceLiveStats? GetGatewayStats()
     {
+        if (_historicSnapshot != null)
+        {
+            return new DeviceLiveStats
+            {
+                CpuPercent = _historicSnapshot.GatewayCpuPercent,
+                MemoryUsedPercent = _historicSnapshot.GatewayMemoryPercent,
+                TemperatureC = _historicSnapshot.GatewayTempC,
+            };
+        }
         if (_gatewayMac == null) return null;
         return LiveStats.GetForDevice(_gatewayMac);
     }
 
     private (double? rtt, double loss) GetGatewayLatency()
     {
+        if (_historicSnapshot != null)
+            return (_historicSnapshot.GatewayRttMs, _historicSnapshot.GatewayLossPercent);
         if (_gatewayMac == null) return (null, 0);
         var gwFabric = _targets.FirstOrDefault(t =>
             t.TargetType == MonitoringTargetType.Fabric
@@ -1051,6 +1267,15 @@ else
 
     private (double? rtt, double loss) GetMeanTargetStats(MonitoringTargetType type)
     {
+        if (_historicSnapshot != null)
+        {
+            return type switch
+            {
+                MonitoringTargetType.AccessIsp => (_historicSnapshot.IspRttMs, _historicSnapshot.IspLossPercent),
+                MonitoringTargetType.Transit => (_historicSnapshot.TransitRttMs, _historicSnapshot.TransitLossPercent),
+                _ => (null, 0)
+            };
+        }
         var targets = _targets.Where(t => t.TargetType == type && t.Enabled).ToList();
         if (targets.Count == 0) return (null, 0);
 
@@ -1067,6 +1292,8 @@ else
 
     private (double ingress, double egress) GetTotalFabricLoad()
     {
+        if (_historicSnapshot != null)
+            return (_historicSnapshot.FabricIngressBps, _historicSnapshot.FabricEgressBps);
         double totalIn = 0, totalOut = 0;
         var fabricMacs = _targets
             .Where(t => t.TargetType == MonitoringTargetType.Fabric && !string.IsNullOrEmpty(t.DeviceMac))
@@ -1183,7 +1410,8 @@ else
             var ago = delta.TotalMinutes < 60 ? $"{(int)delta.TotalMinutes}m ago"
                 : delta.TotalHours < 24 ? $"{(int)delta.TotalHours}h ago"
                 : $"{(int)delta.TotalDays}d ago";
-            _lossInvestigateResult = $"{result.LossPercent:0.#}% loss {ago}";
+            var localTime = result.Timestamp.ToLocalTime().ToString("M/d h:mm tt");
+            _lossInvestigateResult = $"{result.LossPercent:0.#}% loss {ago} ({localTime})";
             StateHasChanged();
             await JS.InvokeVoidAsync("eval",
                 $"window.__latencyCharts?.navigateToTime('{result.Timestamp:o}', '{category}');");
@@ -1219,7 +1447,8 @@ else
             var ago = delta.TotalMinutes < 60 ? $"{(int)delta.TotalMinutes}m ago"
                 : delta.TotalHours < 24 ? $"{(int)delta.TotalHours}h ago"
                 : $"{(int)delta.TotalDays}d ago";
-            _sfpInvestigateResult = $"SFP {desc} {ago}";
+            var localTime = result.Timestamp.ToLocalTime().ToString("M/d h:mm tt");
+            _sfpInvestigateResult = $"SFP {desc} {ago} ({localTime})";
             StateHasChanged();
             await JS.InvokeVoidAsync("eval",
                 $"window.__sfpCharts?.navigateToTime('{result.Timestamp:o}');");
@@ -1250,15 +1479,23 @@ else
             _mapMounted = true;
             try
             {
-                var mapUrl = VersionedJs("/js/lan-flow-map.js");
+                _mapDotNetRef ??= DotNetObjectReference.Create(this);
                 await JS.InvokeVoidAsync("eval",
-                    $"(async () => {{ const m = await import('{mapUrl}'); window.__lanFlowMap = m; await m.mount('lan-flow-map-canvas'); }})();");
+                    "window.__mountLanFlowMap = async function(canvasId, ref) {" +
+                    "  window.__monitoringRef = ref;" +
+                    $"  const m = await import('{VersionedJs("/js/lan-flow-map.js")}');" +
+                    "  window.__lanFlowMap = m;" +
+                    "  await m.mount(canvasId);" +
+                    "}");
+                await JS.InvokeVoidAsync("__mountLanFlowMap", "lan-flow-map-canvas", _mapDotNetRef);
             }
             catch { _mapMounted = false; }
         }
         else if (_activeTab != "live" && _mapMounted)
         {
             _mapMounted = false;
+            _mapHistoricAt = null;
+            _historicSnapshot = null;
             try { await JS.InvokeVoidAsync("eval", "window.__lanFlowMap?.unmount();"); }
             catch { }
         }
@@ -1328,6 +1565,7 @@ else
         _dataRefreshTimer?.Dispose();
         _testFeedbackTimer?.Dispose();
         _sfpChartDebounce?.Dispose();
+        _mapDotNetRef?.Dispose();
         if (_latencyChartsMounted)
         {
             try { _ = JS.InvokeVoidAsync("eval", "window.__latencyCharts?.unmount();").AsTask(); }

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1053,8 +1053,8 @@ else
 
     private async Task FetchHistoricSnapshotAsync(DateTime at)
     {
-        var from = at.AddSeconds(-15);
-        var to = at.AddSeconds(5);
+        var from = at.AddSeconds(-90);
+        var to = at.AddSeconds(30);
 
         double wanDown = 0, wanUp = 0;
         double? gwRtt = null; double gwLoss = 0;

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1164,7 +1164,8 @@ else
             transitLoss = losses.Count > 0 ? losses.Average() : 0;
         }));
 
-        // Fabric load (sum across all fabric devices)
+        // Fabric load (sum across all fabric devices, matching live-mode filter:
+        // gateways only count eth\d+ interfaces, switches count all)
         var fabricMacs = _targets
             .Where(t => t.TargetType == MonitoringTargetType.Fabric && !string.IsNullOrEmpty(t.DeviceMac))
             .Select(t => t.DeviceMac!)
@@ -1178,6 +1179,12 @@ else
                 foreach (var mac in fabricMacs)
                 {
                     var points = await InfluxClient.QueryInterfaceRatesAsync(mac, from, to);
+                    var isGateway = _gatewayMac != null
+                        && mac.Replace("-", ":").Equals(_gatewayMac, StringComparison.OrdinalIgnoreCase);
+                    if (isGateway)
+                        points = points
+                            .Where(p => System.Text.RegularExpressions.Regex.IsMatch(p.IfName, @"^eth\d+$"))
+                            .ToList();
                     var closest = points
                         .GroupBy(p => p.Time)
                         .OrderBy(g => Math.Abs((g.Key - at).TotalMilliseconds))

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
@@ -292,6 +292,7 @@ public class LanFlowMapHistoricUpdate
 {
     public DateTime At { get; set; }
     public Dictionary<string, LinkLiveRates> LinkRates { get; set; } = new();
+    public Dictionary<string, NodeLiveBadge> NodeBadges { get; set; } = new();
     public Dictionary<string, CloudLiveStats> CloudStats { get; set; } = new();
 
     /// <summary>Speed tests whose TestTime falls within the scrub window (or just before it).</summary>

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
@@ -86,6 +86,12 @@ public class LanNode
     /// <summary>For wired clients: the parent switch port's negotiated link speed
     /// in Mbps. Surfaces as "1000 Mbps" / "2.5 Gbps" in the tooltip.</summary>
     public int? WiredLinkSpeedMbps { get; set; }
+
+    /// <summary>SNMP ifName of this device's own uplink port (e.g., "Port 9").
+    /// Server-side only; used by the historic endpoint as a fallback when the
+    /// parent doesn't expose SNMP data (mesh AP → switch case).</summary>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public string? UplinkIfName { get; set; }
 }
 
 public class LanPlacement

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
@@ -18,6 +18,11 @@ public class LanFlowMapSnapshot
     /// <summary>Interface name of the primary WAN (e.g. "wan"). The JS layer
     /// uses this to route speed test results that don't carry a WanNetworkGroup.</summary>
     public string? PrimaryWanInterface { get; set; }
+
+    /// <summary>Linux interface names of gateway WAN ports (e.g. ["eth6"]).
+    /// Server-side only; used by the historic endpoint to query InfluxDB.</summary>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public List<string> WanIfNames { get; set; } = new();
 }
 
 public enum LanNodeKind

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -353,27 +353,45 @@ public class LanFlowMapService
                 }
                 else if (link.Kind == LanLinkKind.Uplink || link.Kind == LanLinkKind.MeshBackhaul)
                 {
-                    var childMac = ExtractDeviceMacFromUplinkId(link.Id);
-                    if (!string.IsNullOrEmpty(childMac) && ratesByDevice.TryGetValue(childMac, out var pts))
+                    if (!string.IsNullOrEmpty(link.PortKey))
                     {
-                        var closest = pts
-                            .GroupBy(p => p.Time)
-                            .OrderBy(g => Math.Abs((g.Key - at).TotalMilliseconds))
-                            .FirstOrDefault();
-                        if (closest != null)
+                        // Wired uplink: use the specific parent trunk port rate (matches live path).
+                        var (deviceMac, ifName) = ParsePortKey(link.PortKey);
+                        if (ratesByDevice.TryGetValue(deviceMac, out var pts))
                         {
-                            double aggIn = 0, aggOut = 0;
-                            foreach (var p in closest)
+                            var closest = pts
+                                .Where(p => string.Equals(p.IfName, ifName, StringComparison.OrdinalIgnoreCase))
+                                .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                                .FirstOrDefault();
+                            if (closest != null)
+                                update.LinkRates[link.Id] = MapPortToLinkRates(link, closest.RateInBps ?? 0, closest.RateOutBps ?? 0, closest.Time);
+                        }
+                    }
+                    else
+                    {
+                        // Wireless mesh: use child device aggregate (same as live path fallback).
+                        var childMac = ExtractDeviceMacFromUplinkId(link.Id);
+                        if (!string.IsNullOrEmpty(childMac) && ratesByDevice.TryGetValue(childMac, out var pts))
+                        {
+                            var closest = pts
+                                .GroupBy(p => p.Time)
+                                .OrderBy(g => Math.Abs((g.Key - at).TotalMilliseconds))
+                                .FirstOrDefault();
+                            if (closest != null)
                             {
-                                aggIn += p.RateInBps ?? 0;
-                                aggOut += p.RateOutBps ?? 0;
+                                double aggIn = 0, aggOut = 0;
+                                foreach (var p in closest)
+                                {
+                                    aggIn += p.RateInBps ?? 0;
+                                    aggOut += p.RateOutBps ?? 0;
+                                }
+                                update.LinkRates[link.Id] = new LinkLiveRates
+                                {
+                                    DownstreamBps = aggOut,
+                                    UpstreamBps = aggIn,
+                                    AsOf = closest.Key,
+                                };
                             }
-                            update.LinkRates[link.Id] = new LinkLiveRates
-                            {
-                                DownstreamBps = aggOut,
-                                UpstreamBps = aggIn,
-                                AsOf = closest.Key,
-                            };
                         }
                     }
                 }
@@ -400,7 +418,10 @@ public class LanFlowMapService
             }
         }
 
-        // Node badges: device health at the historic instant.
+        // Node badges: device health at the historic instant. Aggregate rates
+        // are omitted - the per-link rates (computed above) drive the visual
+        // particles. Computing per-device trunk port rates here would require
+        // duplicating the uplink-resolution logic from the collection agent.
         var healthMacs = snapshot.Nodes
             .Where(n => !string.IsNullOrEmpty(n.Mac))
             .Select(n => n.Mac!)
@@ -415,35 +436,10 @@ public class LanFlowMapService
                     .FirstOrDefault();
                 if (closest == null) continue;
 
-                double? aggIn = null, aggOut = null;
-                double? fabIn = null, fabOut = null;
-                if (ratesByDevice.TryGetValue(mac, out var rates))
-                {
-                    var closestRates = rates
-                        .GroupBy(p => p.Time)
-                        .OrderBy(g => Math.Abs((g.Key - at).TotalMilliseconds))
-                        .FirstOrDefault();
-                    if (closestRates != null)
-                    {
-                        double totalIn = 0, totalOut = 0;
-                        foreach (var r in closestRates)
-                        {
-                            totalIn += r.RateInBps ?? 0;
-                            totalOut += r.RateOutBps ?? 0;
-                        }
-                        aggIn = totalIn;
-                        aggOut = totalOut;
-                    }
-                }
-
                 var node = snapshot.Nodes.FirstOrDefault(n =>
                     string.Equals(n.Mac, mac, StringComparison.OrdinalIgnoreCase));
                 update.NodeBadges[node?.Id ?? $"dev-{mac}"] = new NodeLiveBadge
                 {
-                    AggregateInBps = aggIn,
-                    AggregateOutBps = aggOut,
-                    FabricIngressBps = fabIn,
-                    FabricEgressBps = fabOut,
                     Online = node?.Online ?? true,
                     CpuPercent = closest.CpuPercent,
                     MemoryUsedPercent = closest.MemoryUsedPercent,

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -297,59 +297,199 @@ public class LanFlowMapService
         var update = new LanFlowMapHistoricUpdate { At = at };
         if (!_connection.IsConnected) return update;
 
-        // Build the topology so we know the link / port IDs to look up.
         var snapshot = await BuildSnapshotAsync(ct);
 
         var from = at - TimeSpan.FromSeconds(90);
         var to = at + TimeSpan.FromSeconds(30);
-        var byMac = snapshot.Nodes
-            .Where(n => !string.IsNullOrEmpty(n.Mac))
-            .GroupBy(n => n.Mac!)
-            .ToDictionary(g => g.Key, g => g.First());
 
-        // Wire up each link's PortKey lookup -> historic rate point.
+        // Pre-fetch interface_counters per device MAC so we don't re-query for
+        // every link on the same device. Covers WiredClient (PortKey), Uplink,
+        // MeshBackhaul, and WAN links.
+        var deviceMacs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var link in snapshot.Links)
         {
-            if (string.IsNullOrEmpty(link.PortKey)) continue;
-            var (deviceMac, ifName) = ParsePortKey(link.PortKey);
-            if (string.IsNullOrEmpty(deviceMac) || string.IsNullOrEmpty(ifName)) continue;
-
+            if (link.Kind == LanLinkKind.Uplink || link.Kind == LanLinkKind.MeshBackhaul)
+            {
+                var mac = ExtractDeviceMacFromUplinkId(link.Id);
+                if (!string.IsNullOrEmpty(mac)) deviceMacs.Add(mac);
+            }
+            else if (!string.IsNullOrEmpty(link.PortKey))
+            {
+                var (mac, _) = ParsePortKey(link.PortKey);
+                if (!string.IsNullOrEmpty(mac)) deviceMacs.Add(mac);
+            }
+        }
+        var ratesByDevice = new Dictionary<string, IReadOnlyList<MonitoringInfluxClient.InterfaceRatePoint>>(
+            StringComparer.OrdinalIgnoreCase);
+        foreach (var mac in deviceMacs)
+        {
             try
             {
-                var points = await _influx.QueryInterfaceRatesAsync(deviceMac, from, to, null, ct);
-                var latest = points
-                    .Where(p => string.Equals(p.IfName, ifName, StringComparison.OrdinalIgnoreCase))
-                    .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
-                    .FirstOrDefault();
-                if (latest == null) continue;
-                update.LinkRates[link.Id] = MapPortToLinkRates(link, latest.RateInBps ?? 0, latest.RateOutBps ?? 0, latest.Time);
+                ratesByDevice[mac] = await _influx.QueryInterfaceRatesAsync(mac, from, to, null, ct);
             }
             catch (Exception ex)
             {
-                _logger.LogDebug(ex, "Historic rate fetch failed for {Port}", link.PortKey);
+                _logger.LogDebug(ex, "Historic rate fetch failed for device {Mac}", mac);
             }
         }
 
-        // Cloud latency at the historic instant.
-        foreach (var cloud in snapshot.Clouds)
+        // Resolve each link, mirroring the live endpoint's kind-aware dispatch.
+        foreach (var link in snapshot.Links)
         {
             try
             {
-                var lat = await _influx.QueryLatencyAsync(cloud.Id, from, to, null, ct);
-                var latest = lat
+                if (link.Kind == LanLinkKind.Wan && !string.IsNullOrEmpty(link.PortKey))
+                {
+                    var (deviceMac, ifName) = ParsePortKey(link.PortKey);
+                    if (ratesByDevice.TryGetValue(deviceMac, out var pts))
+                    {
+                        var closest = pts
+                            .Where(p => string.Equals(p.IfName, ifName, StringComparison.OrdinalIgnoreCase))
+                            .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                            .FirstOrDefault();
+                        if (closest != null)
+                            update.LinkRates[link.Id] = MapPortToLinkRates(link, closest.RateInBps ?? 0, closest.RateOutBps ?? 0, closest.Time);
+                    }
+                }
+                else if (link.Kind == LanLinkKind.Uplink || link.Kind == LanLinkKind.MeshBackhaul)
+                {
+                    var childMac = ExtractDeviceMacFromUplinkId(link.Id);
+                    if (!string.IsNullOrEmpty(childMac) && ratesByDevice.TryGetValue(childMac, out var pts))
+                    {
+                        var closest = pts
+                            .GroupBy(p => p.Time)
+                            .OrderBy(g => Math.Abs((g.Key - at).TotalMilliseconds))
+                            .FirstOrDefault();
+                        if (closest != null)
+                        {
+                            double aggIn = 0, aggOut = 0;
+                            foreach (var p in closest)
+                            {
+                                aggIn += p.RateInBps ?? 0;
+                                aggOut += p.RateOutBps ?? 0;
+                            }
+                            update.LinkRates[link.Id] = new LinkLiveRates
+                            {
+                                DownstreamBps = aggOut,
+                                UpstreamBps = aggIn,
+                                AsOf = closest.Key,
+                            };
+                        }
+                    }
+                }
+                else if (link.Kind == LanLinkKind.WiredClient && !string.IsNullOrEmpty(link.PortKey))
+                {
+                    var (deviceMac, ifName) = ParsePortKey(link.PortKey);
+                    if (ratesByDevice.TryGetValue(deviceMac, out var pts))
+                    {
+                        var closest = pts
+                            .Where(p => string.Equals(p.IfName, ifName, StringComparison.OrdinalIgnoreCase))
+                            .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                            .FirstOrDefault();
+                        if (closest != null)
+                            update.LinkRates[link.Id] = MapPortToLinkRates(link, closest.RateInBps ?? 0, closest.RateOutBps ?? 0, closest.Time);
+                    }
+                }
+                // WifiClient links: wifi_client throughput is stored with client_mac as
+                // a field (not a tag), making per-client InfluxDB lookups expensive.
+                // Skipped for now; wifi leaves show snapshot rates during playback.
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Historic rate failed for link {Id}", link.Id);
+            }
+        }
+
+        // Node badges: device health at the historic instant.
+        var healthMacs = snapshot.Nodes
+            .Where(n => !string.IsNullOrEmpty(n.Mac))
+            .Select(n => n.Mac!)
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+        foreach (var mac in healthMacs)
+        {
+            try
+            {
+                var health = await _influx.QueryDeviceHealthAsync(mac, from, to, null, ct);
+                var closest = health
                     .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
                     .FirstOrDefault();
-                if (latest == null) continue;
-                update.CloudStats[cloud.Id] = new CloudLiveStats
+                if (closest == null) continue;
+
+                double? aggIn = null, aggOut = null;
+                double? fabIn = null, fabOut = null;
+                if (ratesByDevice.TryGetValue(mac, out var rates))
                 {
-                    RttAvgMs = latest.RttAvgMs,
-                    LossPercent = latest.LossPercent,
-                    Success = latest.RttAvgMs.HasValue,
+                    var closestRates = rates
+                        .GroupBy(p => p.Time)
+                        .OrderBy(g => Math.Abs((g.Key - at).TotalMilliseconds))
+                        .FirstOrDefault();
+                    if (closestRates != null)
+                    {
+                        double totalIn = 0, totalOut = 0;
+                        foreach (var r in closestRates)
+                        {
+                            totalIn += r.RateInBps ?? 0;
+                            totalOut += r.RateOutBps ?? 0;
+                        }
+                        aggIn = totalIn;
+                        aggOut = totalOut;
+                    }
+                }
+
+                var node = snapshot.Nodes.FirstOrDefault(n =>
+                    string.Equals(n.Mac, mac, StringComparison.OrdinalIgnoreCase));
+                update.NodeBadges[node?.Id ?? $"dev-{mac}"] = new NodeLiveBadge
+                {
+                    AggregateInBps = aggIn,
+                    AggregateOutBps = aggOut,
+                    FabricIngressBps = fabIn,
+                    FabricEgressBps = fabOut,
+                    Online = node?.Online ?? true,
+                    CpuPercent = closest.CpuPercent,
+                    MemoryUsedPercent = closest.MemoryUsedPercent,
+                    TemperatureC = closest.TemperatureC,
                 };
             }
             catch (Exception ex)
             {
-                _logger.LogDebug(ex, "Historic latency fetch failed for {Cloud}", cloud.Id);
+                _logger.LogDebug(ex, "Historic health failed for {Mac}", mac);
+            }
+        }
+
+        // Cloud latency: map cloud kind to monitoring target type and query.
+        foreach (var cloud in snapshot.Clouds)
+        {
+            try
+            {
+                var targetType = cloud.Kind switch
+                {
+                    LanCloudKind.AccessIsp => MonitoringTargetType.AccessIsp,
+                    LanCloudKind.Transit => MonitoringTargetType.Transit,
+                    _ => (MonitoringTargetType?)null
+                };
+                if (targetType == null) continue;
+                var data = await _influx.QueryLatencyByTargetTypeAsync(targetType.Value, from, to, ct: ct);
+                MonitoringInfluxClient.LatencyPoint? best = null;
+                foreach (var (_, pts) in data)
+                {
+                    var closest = pts
+                        .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                        .FirstOrDefault();
+                    if (closest != null && (best == null
+                        || Math.Abs((closest.Time - at).TotalMilliseconds) < Math.Abs((best.Time - at).TotalMilliseconds)))
+                        best = closest;
+                }
+                if (best == null) continue;
+                update.CloudStats[cloud.Id] = new CloudLiveStats
+                {
+                    RttAvgMs = best.RttAvgMs,
+                    LossPercent = best.LossPercent,
+                    Success = best.RttAvgMs.HasValue,
+                };
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Historic latency failed for cloud {Id}", cloud.Id);
             }
         }
 

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -302,10 +302,14 @@ public class LanFlowMapService
         var from = at - TimeSpan.FromSeconds(90);
         var to = at + TimeSpan.FromSeconds(30);
 
+        var gwNode = snapshot.Nodes.FirstOrDefault(n => n.Kind == LanNodeKind.Gateway);
+        var gwMac = gwNode?.Mac;
+
         // Pre-fetch interface_counters per device MAC so we don't re-query for
         // every link on the same device. Covers WiredClient (PortKey), Uplink,
         // MeshBackhaul, and WAN links.
         var deviceMacs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (!string.IsNullOrEmpty(gwMac)) deviceMacs.Add(gwMac);
         foreach (var link in snapshot.Links)
         {
             if (link.Kind == LanLinkKind.Uplink || link.Kind == LanLinkKind.MeshBackhaul)
@@ -338,13 +342,18 @@ public class LanFlowMapService
         {
             try
             {
-                if (link.Kind == LanLinkKind.Wan && !string.IsNullOrEmpty(link.PortKey))
+                if (link.Kind == LanLinkKind.Wan)
                 {
-                    var (deviceMac, ifName) = ParsePortKey(link.PortKey);
-                    if (ratesByDevice.TryGetValue(deviceMac, out var pts))
+                    // Live path uses WanSummary, keyed by WAN interface name
+                    // embedded in the link ID: "wan-link-{wanInterface}".
+                    var wanIface = link.Id.StartsWith("wan-link-", StringComparison.Ordinal)
+                        ? link.Id.Substring("wan-link-".Length)
+                        : null;
+                    if (wanIface != null && !string.IsNullOrEmpty(gwMac)
+                        && ratesByDevice.TryGetValue(gwMac, out var pts))
                     {
                         var closest = pts
-                            .Where(p => string.Equals(p.IfName, ifName, StringComparison.OrdinalIgnoreCase))
+                            .Where(p => string.Equals(p.IfName, wanIface, StringComparison.OrdinalIgnoreCase))
                             .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
                             .FirstOrDefault();
                         if (closest != null)
@@ -369,27 +378,27 @@ public class LanFlowMapService
                     }
                     else
                     {
-                        // Wireless mesh: use child device aggregate (same as live path fallback).
+                        // Wireless mesh: use the vwiresta interface (mesh backhaul),
+                        // matching the live path which uses apMeshUplinkInBps/OutBps
+                        // from the SNMP interface starting with "vwiresta" (no dot).
                         var childMac = ExtractDeviceMacFromUplinkId(link.Id);
                         if (!string.IsNullOrEmpty(childMac) && ratesByDevice.TryGetValue(childMac, out var pts))
                         {
                             var closest = pts
-                                .GroupBy(p => p.Time)
-                                .OrderBy(g => Math.Abs((g.Key - at).TotalMilliseconds))
+                                .Where(p => p.IfName.StartsWith("vwiresta", StringComparison.OrdinalIgnoreCase)
+                                    && !p.IfName.Contains('.'))
+                                .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
                                 .FirstOrDefault();
                             if (closest != null)
                             {
-                                double aggIn = 0, aggOut = 0;
-                                foreach (var p in closest)
-                                {
-                                    aggIn += p.RateInBps ?? 0;
-                                    aggOut += p.RateOutBps ?? 0;
-                                }
+                                // vwiresta rateIn = bytes received over mesh = downloads,
+                                // rateOut = bytes transmitted = uploads. Live path swaps
+                                // these via RecordInterfaceAggregate convention.
                                 update.LinkRates[link.Id] = new LinkLiveRates
                                 {
-                                    DownstreamBps = aggOut,
-                                    UpstreamBps = aggIn,
-                                    AsOf = closest.Key,
+                                    DownstreamBps = closest.RateInBps ?? 0,
+                                    UpstreamBps = closest.RateOutBps ?? 0,
+                                    AsOf = closest.Time,
                                 };
                             }
                         }

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -506,7 +506,11 @@ public class LanFlowMapService
                 if ((node.Kind == LanNodeKind.Switch || node.Kind == LanNodeKind.Gateway)
                     && ratesByDevice.TryGetValue(mac, out var rates))
                 {
-                    var closestRates = rates
+                    var isGw = node.Kind == LanNodeKind.Gateway;
+                    var filtered = isGw
+                        ? rates.Where(p => System.Text.RegularExpressions.Regex.IsMatch(p.IfName, @"^eth\d+$"))
+                        : rates;
+                    var closestRates = filtered
                         .GroupBy(p => p.Time)
                         .OrderBy(g => Math.Abs((g.Key - at).TotalMilliseconds))
                         .FirstOrDefault();

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -102,6 +102,16 @@ public class LanFlowMapService
         GroupMultiClientPorts(snapshot);
         await BuildWanAndClouds(topology, snapshot, ct);
 
+        var gwRaw = rawDevices.FirstOrDefault(d =>
+            d.DeviceType == NetworkOptimizer.Core.Enums.DeviceType.Gateway);
+        if (gwRaw?.PortTable != null)
+        {
+            snapshot.WanIfNames = gwRaw.PortTable
+                .Where(p => p.IsUplink && !string.IsNullOrEmpty(p.IfName))
+                .Select(p => p.IfName!)
+                .ToList();
+        }
+
         var portRates = await SeedPortRatesAsync(snapshot, ct);
         SeedLiveRates(snapshot, portRates);
 
@@ -305,6 +315,19 @@ public class LanFlowMapService
         var gwNode = snapshot.Nodes.FirstOrDefault(n => n.Kind == LanNodeKind.Gateway);
         var gwMac = gwNode?.Mac;
 
+        // Pre-fetch WAN rates. The link ID uses NetworkName ("wan") but InfluxDB
+        // stores the Linux ifname ("eth6"). WanIfNames on the snapshot resolves
+        // this from the port table's IfName field (same source as stat cards).
+        IReadOnlyList<MonitoringInfluxClient.WanRatePoint>? wanRates = null;
+        if (!string.IsNullOrEmpty(gwMac) && snapshot.WanIfNames.Count > 0)
+        {
+            try
+            {
+                wanRates = await _influx.QueryGatewayWanRatesAsync(gwMac, snapshot.WanIfNames, from, to, ct: ct);
+            }
+            catch { }
+        }
+
         // Pre-fetch interface_counters per device MAC so we don't re-query for
         // every link on the same device. Covers WiredClient (PortKey), Uplink,
         // MeshBackhaul, and WAN links.
@@ -344,20 +367,13 @@ public class LanFlowMapService
             {
                 if (link.Kind == LanLinkKind.Wan)
                 {
-                    // Live path uses WanSummary, keyed by WAN interface name
-                    // embedded in the link ID: "wan-link-{wanInterface}".
-                    var wanIface = link.Id.StartsWith("wan-link-", StringComparison.Ordinal)
-                        ? link.Id.Substring("wan-link-".Length)
-                        : null;
-                    if (wanIface != null && !string.IsNullOrEmpty(gwMac)
-                        && ratesByDevice.TryGetValue(gwMac, out var pts))
+                    if (wanRates != null)
                     {
-                        var closest = pts
-                            .Where(p => string.Equals(p.IfName, wanIface, StringComparison.OrdinalIgnoreCase))
+                        var closest = wanRates
                             .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
                             .FirstOrDefault();
                         if (closest != null)
-                            update.LinkRates[link.Id] = MapPortToLinkRates(link, closest.RateInBps ?? 0, closest.RateOutBps ?? 0, closest.Time);
+                            update.LinkRates[link.Id] = MapPortToLinkRates(link, closest.DownloadBps ?? 0, closest.UploadBps ?? 0, closest.Time);
                     }
                 }
                 else if (link.Kind == LanLinkKind.Uplink || link.Kind == LanLinkKind.MeshBackhaul)

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -378,45 +378,87 @@ public class LanFlowMapService
                 }
                 else if (link.Kind == LanLinkKind.Uplink || link.Kind == LanLinkKind.MeshBackhaul)
                 {
+                    MonitoringInfluxClient.InterfaceRatePoint? resolved = null;
+                    bool fromChildSide = false;
+
+                    // Primary: parent's trunk port via PortKey.
                     if (!string.IsNullOrEmpty(link.PortKey))
                     {
-                        // Wired uplink: use the specific parent trunk port rate (matches live path).
-                        var (deviceMac, ifName) = ParsePortKey(link.PortKey);
-                        if (ratesByDevice.TryGetValue(deviceMac, out var pts))
+                        var (pMac, pIf) = ParsePortKey(link.PortKey);
+                        if (ratesByDevice.TryGetValue(pMac, out var pPts))
                         {
-                            var closest = pts
-                                .Where(p => string.Equals(p.IfName, ifName, StringComparison.OrdinalIgnoreCase))
+                            resolved = pPts
+                                .Where(p => string.Equals(p.IfName, pIf, StringComparison.OrdinalIgnoreCase))
                                 .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
                                 .FirstOrDefault();
-                            if (closest != null)
-                                update.LinkRates[link.Id] = MapPortToLinkRates(link, closest.RateInBps ?? 0, closest.RateOutBps ?? 0, closest.Time);
                         }
                     }
-                    else
+
+                    // Fallback: child device's own interface. Covers mesh APs
+                    // (vwiresta) and switches whose parent (e.g., a mesh AP)
+                    // doesn't expose SNMP port data. The live code does the
+                    // same at ComputePortRate(dev.Mac, dev.Uplink.PortIdx).
+                    if (resolved == null)
                     {
-                        // Wireless mesh: use the vwiresta interface (mesh backhaul),
-                        // matching the live path which uses apMeshUplinkInBps/OutBps
-                        // from the SNMP interface starting with "vwiresta" (no dot).
                         var childMac = ExtractDeviceMacFromUplinkId(link.Id);
-                        if (!string.IsNullOrEmpty(childMac) && ratesByDevice.TryGetValue(childMac, out var pts))
+                        if (!string.IsNullOrEmpty(childMac) && ratesByDevice.TryGetValue(childMac, out var cPts))
                         {
-                            var closest = pts
-                                .Where(p => p.IfName.StartsWith("vwiresta", StringComparison.OrdinalIgnoreCase)
-                                    && !p.IfName.Contains('.'))
-                                .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
-                                .FirstOrDefault();
-                            if (closest != null)
+                            if (link.Kind == LanLinkKind.MeshBackhaul)
                             {
-                                // vwiresta rateIn = bytes received over mesh = downloads,
-                                // rateOut = bytes transmitted = uploads. Live path swaps
-                                // these via RecordInterfaceAggregate convention.
-                                update.LinkRates[link.Id] = new LinkLiveRates
-                                {
-                                    DownstreamBps = closest.RateInBps ?? 0,
-                                    UpstreamBps = closest.RateOutBps ?? 0,
-                                    AsOf = closest.Time,
-                                };
+                                resolved = cPts
+                                    .Where(p => p.IfName.StartsWith("vwiresta", StringComparison.OrdinalIgnoreCase)
+                                        && !p.IfName.Contains('.'))
+                                    .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                                    .FirstOrDefault();
                             }
+                            else
+                            {
+                                // Wired switch fallback: find the child's uplink port.
+                                // On switches SNMP ifDescr is "Port N" and the uplink
+                                // is the highest-rate port. Use the same closest-time
+                                // point from the child's interface set; the direction
+                                // swaps because we're reading from the other end.
+                                var childNode = snapshot.Nodes.FirstOrDefault(n =>
+                                    string.Equals(n.Mac, childMac, StringComparison.OrdinalIgnoreCase));
+                                if (childNode?.UplinkIfName != null)
+                                {
+                                    resolved = cPts
+                                        .Where(p => string.Equals(p.IfName, childNode.UplinkIfName, StringComparison.OrdinalIgnoreCase))
+                                        .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                                        .FirstOrDefault();
+                                    fromChildSide = true;
+                                }
+                            }
+                        }
+                    }
+
+                    if (resolved != null)
+                    {
+                        if (link.Kind == LanLinkKind.MeshBackhaul && !fromChildSide)
+                        {
+                            // vwiresta rateIn = downloads, rateOut = uploads
+                            update.LinkRates[link.Id] = new LinkLiveRates
+                            {
+                                DownstreamBps = resolved.RateInBps ?? 0,
+                                UpstreamBps = resolved.RateOutBps ?? 0,
+                                AsOf = resolved.Time,
+                            };
+                        }
+                        else if (fromChildSide)
+                        {
+                            // Reading from child side: directions swap vs parent side.
+                            // Child port RX = bytes arriving from parent = downstream.
+                            // Child port TX = bytes leaving toward parent = upstream.
+                            update.LinkRates[link.Id] = new LinkLiveRates
+                            {
+                                DownstreamBps = resolved.RateInBps ?? 0,
+                                UpstreamBps = resolved.RateOutBps ?? 0,
+                                AsOf = resolved.Time,
+                            };
+                        }
+                        else
+                        {
+                            update.LinkRates[link.Id] = MapPortToLinkRates(link, resolved.RateInBps ?? 0, resolved.RateOutBps ?? 0, resolved.Time);
                         }
                     }
                 }
@@ -673,6 +715,18 @@ public class LanFlowMapService
             }
 
             snapshot.Links.Add(link);
+
+            // Stash the child's own uplink port ifName on its node. The historic
+            // endpoint uses this as a fallback when the parent doesn't expose
+            // SNMP data (e.g., switch plugged into a mesh AP's Ethernet port).
+            if (d.LocalUplinkPort.HasValue && d.LocalUplinkPort.Value > 0)
+            {
+                var childNode = snapshot.Nodes.FirstOrDefault(n => n.Id == "dev-" + mac);
+                if (childNode != null && nameMaps.TryGetValue((mac, d.LocalUplinkPort.Value), out var localMap))
+                {
+                    childNode.UplinkIfName = localMap.IfName;
+                }
+            }
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -443,37 +443,73 @@ public class LanFlowMapService
             }
         }
 
-        // Node badges: device health at the historic instant. Aggregate rates
-        // are omitted - the per-link rates (computed above) drive the visual
-        // particles. Computing per-device trunk port rates here would require
-        // duplicating the uplink-resolution logic from the collection agent.
-        var healthMacs = snapshot.Nodes
-            .Where(n => !string.IsNullOrEmpty(n.Mac))
-            .Select(n => n.Mac!)
-            .Distinct(StringComparer.OrdinalIgnoreCase);
-        foreach (var mac in healthMacs)
+        // Node badges: device health + fabric/aggregate rates at the historic
+        // instant. Matches the live endpoint's badge population logic:
+        //   - Switches/gateways: fabricIngressBps = sum(port Rx), fabricEgressBps = sum(port Tx)
+        //   - APs: aggregateInBps/OutBps from the uplink link rate (already computed above)
+        // Without fabric rates the JS falls back to summing adjacent links,
+        // which double-counts flows traversing the device.
+        foreach (var node in snapshot.Nodes)
         {
+            if (string.IsNullOrEmpty(node.Mac)) continue;
+            var mac = node.Mac;
             try
             {
                 var health = await _influx.QueryDeviceHealthAsync(mac, from, to, null, ct);
-                var closest = health
+                var healthPt = health
                     .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
                     .FirstOrDefault();
-                if (closest == null) continue;
 
-                var node = snapshot.Nodes.FirstOrDefault(n =>
-                    string.Equals(n.Mac, mac, StringComparison.OrdinalIgnoreCase));
-                update.NodeBadges[node?.Id ?? $"dev-{mac}"] = new NodeLiveBadge
+                double? fabIn = null, fabOut = null;
+                if ((node.Kind == LanNodeKind.Switch || node.Kind == LanNodeKind.Gateway)
+                    && ratesByDevice.TryGetValue(mac, out var rates))
                 {
-                    Online = node?.Online ?? true,
-                    CpuPercent = closest.CpuPercent,
-                    MemoryUsedPercent = closest.MemoryUsedPercent,
-                    TemperatureC = closest.TemperatureC,
+                    var closestRates = rates
+                        .GroupBy(p => p.Time)
+                        .OrderBy(g => Math.Abs((g.Key - at).TotalMilliseconds))
+                        .FirstOrDefault();
+                    if (closestRates != null)
+                    {
+                        double sumRx = 0, sumTx = 0;
+                        foreach (var r in closestRates)
+                        {
+                            sumRx += r.RateInBps ?? 0;
+                            sumTx += r.RateOutBps ?? 0;
+                        }
+                        fabIn = sumRx;
+                        fabOut = sumTx;
+                    }
+                }
+
+                // For APs, pull aggregate from the uplink link rate we already computed.
+                double? aggIn = null, aggOut = null;
+                if (node.Kind == LanNodeKind.AccessPoint)
+                {
+                    var uplinkId = $"uplink-{mac}";
+                    if (update.LinkRates.TryGetValue(uplinkId, out var uplinkRate))
+                    {
+                        aggIn = uplinkRate.UpstreamBps;
+                        aggOut = uplinkRate.DownstreamBps;
+                    }
+                }
+
+                if (healthPt == null && fabIn == null && aggIn == null) continue;
+
+                update.NodeBadges[node.Id] = new NodeLiveBadge
+                {
+                    Online = node.Online,
+                    CpuPercent = healthPt?.CpuPercent,
+                    MemoryUsedPercent = healthPt?.MemoryUsedPercent,
+                    TemperatureC = healthPt?.TemperatureC,
+                    FabricIngressBps = fabIn,
+                    FabricEgressBps = fabOut,
+                    AggregateInBps = aggIn,
+                    AggregateOutBps = aggOut,
                 };
             }
             catch (Exception ex)
             {
-                _logger.LogDebug(ex, "Historic health failed for {Mac}", mac);
+                _logger.LogDebug(ex, "Historic badge failed for {Mac}", mac);
             }
         }
 

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -300,8 +300,8 @@ public class LanFlowMapService
         // Build the topology so we know the link / port IDs to look up.
         var snapshot = await BuildSnapshotAsync(ct);
 
-        var from = at - TimeSpan.FromSeconds(15);
-        var to = at + TimeSpan.FromSeconds(5);
+        var from = at - TimeSpan.FromSeconds(90);
+        var to = at + TimeSpan.FromSeconds(30);
         var byMac = snapshot.Nodes
             .Where(n => !string.IsNullOrEmpty(n.Mac))
             .GroupBy(n => n.Mac!)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -26,6 +26,8 @@ public class MonitoringPathView
     private readonly UniFiConnectionService _connectionService;
     private readonly MonitoringLiveStats _liveStats;
     private readonly ILogger<MonitoringPathView> _logger;
+    private IReadOnlyList<WanSummary>? _wanCache;
+    private DateTime _wanCacheExpiry;
 
     public MonitoringPathView(
         IDbContextFactory<NetworkOptimizerDbContext> dbFactory,
@@ -138,6 +140,12 @@ public class MonitoringPathView
     /// </summary>
     public async Task<IReadOnlyList<WanSummary>> GetWansAsync(CancellationToken ct = default)
     {
+        if (_wanCache != null && DateTime.UtcNow < _wanCacheExpiry)
+        {
+            RefreshWanLiveRates(_wanCache);
+            return _wanCache;
+        }
+
         if (!_connectionService.IsConnected || _connectionService.Client == null)
             return Array.Empty<WanSummary>();
 
@@ -163,37 +171,46 @@ public class MonitoringPathView
             .ToList();
         if (wanPorts.Count == 0)
         {
-            // Fall back to any port whose network_name looks like a WAN.
             wanPorts = gateway.PortTable
                 .Where(p => p.NetworkName != null && p.NetworkName.StartsWith("wan", StringComparison.OrdinalIgnoreCase))
                 .OrderBy(p => p.PortIdx)
                 .ToList();
         }
 
+        var gwMac = gateway.Mac.ToLowerInvariant().Replace('-', ':');
         for (int i = 0; i < wanPorts.Count; i++)
         {
             var port = wanPorts[i];
-            // Live throughput for this WAN port comes from the agent's per-port rate
-            // cache (which we maintain anyway for AP backhaul lookups). The cache key
-            // is (gateway MAC, port_idx).
-            var deviceLive = _liveStats.GetForDevice(gateway.Mac);
-
             results.Add(new WanSummary
             {
                 WanInterface = port.NetworkName ?? $"wan{i + 1}",
                 FriendlyName = string.IsNullOrEmpty(port.Name) ? null : port.Name,
                 IsPrimary = i == 0,
-                GatewayMac = gateway.Mac.ToLowerInvariant().Replace('-', ':'),
+                GatewayMac = gwMac,
                 GatewayPortName = port.Name,
                 LinkSpeedMbps = port.Speed > 0 ? port.Speed : (int?)null,
-                LiveRateInBps = deviceLive?.RateInBps,
-                LiveRateOutBps = deviceLive?.RateOutBps,
                 IpAddress = port.Ip,
                 IpClass = NetworkUtilities.ClassifyPublicAddress(port.Ip)
             });
         }
 
+        _wanCache = results;
+        _wanCacheExpiry = DateTime.UtcNow.AddSeconds(30);
+        RefreshWanLiveRates(results);
         return results;
+    }
+
+    private void RefreshWanLiveRates(IReadOnlyList<WanSummary> wans)
+    {
+        if (wans.Count == 0) return;
+        var gwMac = wans[0].GatewayMac;
+        if (string.IsNullOrEmpty(gwMac)) return;
+        var deviceLive = _liveStats.GetForDevice(gwMac);
+        foreach (var wan in wans)
+        {
+            wan.LiveRateInBps = deviceLive?.RateInBps;
+            wan.LiveRateOutBps = deviceLive?.RateOutBps;
+        }
     }
 
     /// <summary>
@@ -273,8 +290,8 @@ public record WanSummary
     public string? GatewayMac { get; init; }
     public string? GatewayPortName { get; init; }
     public int? LinkSpeedMbps { get; init; }
-    public double? LiveRateInBps { get; init; }
-    public double? LiveRateOutBps { get; init; }
+    public double? LiveRateInBps { get; set; }
+    public double? LiveRateOutBps { get; set; }
     public string? IpAddress { get; init; }
     public PublicAddressClass IpClass { get; init; }
 }

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -608,10 +608,10 @@ public class MonitoringCollectionAgent : BackgroundService
     /// all alias counters carried by a physical eth port. Summing those gives
     /// 3-4x the real total, so we restrict gateway fabric sum to plain ethN.
     /// </summary>
-    private static bool IncludeInFabricSum(NetworkOptimizer.Core.Enums.DeviceType type, string ifDescr)
+    internal static bool IncludeInFabricSum(NetworkOptimizer.Core.Enums.DeviceType type, string ifDescr)
     {
         if (type == NetworkOptimizer.Core.Enums.DeviceType.Gateway)
-            return System.Text.RegularExpressions.Regex.IsMatch(ifDescr, @"^eth\d+$");
+            return System.Text.RegularExpressions.Regex.IsMatch(ifDescr, @"^(eth\d+|gre\d+)$");
         return true;
     }
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -611,7 +611,7 @@ public class MonitoringCollectionAgent : BackgroundService
     internal static bool IncludeInFabricSum(NetworkOptimizer.Core.Enums.DeviceType type, string ifDescr)
     {
         if (type == NetworkOptimizer.Core.Enums.DeviceType.Gateway)
-            return System.Text.RegularExpressions.Regex.IsMatch(ifDescr, @"^(eth\d+|gre\d+)$");
+            return System.Text.RegularExpressions.Regex.IsMatch(ifDescr, @"^eth\d+$");
         return true;
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14312,35 +14312,38 @@ a.affected-client:hover {
     background: var(--bg-hover);
     color: var(--text-primary);
 }
-.lan-flow-map-speed-selector {
+.lan-flow-map-speed-control {
     display: flex;
-    gap: 0.15rem;
+    align-items: center;
+    gap: 0.2rem;
     flex-shrink: 0;
 }
-.lan-flow-map-speed-btn {
+.lan-flow-map-speed-step {
     background: transparent;
     border: 1px solid var(--border-color, #334155);
-    color: var(--text-muted);
-    font-size: 0.65rem;
-    padding: 0.15rem 0.35rem;
+    color: var(--text-secondary);
+    width: 1.4rem;
+    height: 1.4rem;
     border-radius: 0.2rem;
     cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.85rem;
+    font-weight: 600;
+    padding: 0;
     line-height: 1;
-    white-space: nowrap;
 }
-.lan-flow-map-speed-btn:hover {
+.lan-flow-map-speed-step:hover {
     background: var(--bg-hover);
+    color: var(--text-primary);
+}
+.lan-flow-map-speed-label {
+    font-size: 0.7rem;
+    font-variant-numeric: tabular-nums;
+    min-width: 2.2rem;
+    text-align: center;
     color: var(--text-secondary);
-}
-.lan-flow-map-speed-btn.is-active {
-    background: var(--primary-color);
-    border-color: var(--primary-color);
-    color: #fff;
-}
-.lan-flow-map-speed-btn.is-disabled {
-    opacity: 0.35;
-    cursor: default;
-    pointer-events: none;
 }
 /* SFP/Optical table device + port cell. Inline so device name, port label,
    and PON badge sit on one row vertically centered, evenly spaced. */
@@ -14580,7 +14583,7 @@ a.affected-client:hover {
         border-radius: 0 0 8px 8px;
         border-top: 1px solid rgba(255, 255, 255, 0.06);
     }
-    .lan-flow-map-speed-selector {
+    .lan-flow-map-speed-control {
         display: none;
     }
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14337,6 +14337,11 @@ a.affected-client:hover {
     border-color: var(--primary-color);
     color: #fff;
 }
+.lan-flow-map-speed-btn.is-disabled {
+    opacity: 0.35;
+    cursor: default;
+    pointer-events: none;
+}
 /* SFP/Optical table device + port cell. Inline so device name, port label,
    and PON badge sit on one row vertically centered, evenly spaced. */
 .sfp-port-cell {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14312,6 +14312,31 @@ a.affected-client:hover {
     background: var(--bg-hover);
     color: var(--text-primary);
 }
+.lan-flow-map-speed-selector {
+    display: flex;
+    gap: 0.15rem;
+    flex-shrink: 0;
+}
+.lan-flow-map-speed-btn {
+    background: transparent;
+    border: 1px solid var(--border-color, #334155);
+    color: var(--text-muted);
+    font-size: 0.65rem;
+    padding: 0.15rem 0.35rem;
+    border-radius: 0.2rem;
+    cursor: pointer;
+    line-height: 1;
+    white-space: nowrap;
+}
+.lan-flow-map-speed-btn:hover {
+    background: var(--bg-hover);
+    color: var(--text-secondary);
+}
+.lan-flow-map-speed-btn.is-active {
+    background: var(--primary-color);
+    border-color: var(--primary-color);
+    color: #fff;
+}
 /* SFP/Optical table device + port cell. Inline so device name, port label,
    and PON badge sit on one row vertically centered, evenly spaced. */
 .sfp-port-cell {
@@ -14549,5 +14574,8 @@ a.affected-client:hover {
         width: 100%;
         border-radius: 0 0 8px 8px;
         border-top: 1px solid rgba(255, 255, 255, 0.06);
+    }
+    .lan-flow-map-speed-selector {
+        display: none;
     }
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14285,7 +14285,7 @@ a.affected-client:hover {
    jumps right under the cursor as it approaches the live edge. */
 .lan-flow-map-scrubber-row [data-role="right"] {
     display: inline-block;
-    min-width: 9.5rem;
+    min-width: 7.5rem;
     text-align: center;
     font-variant-numeric: tabular-nums;
     white-space: nowrap;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14306,7 +14306,7 @@ a.affected-client:hover {
     justify-content: center;
     font-size: 0.8rem;
     padding: 0;
-    padding-bottom: 1px;
+    padding-bottom: 3px;
     flex-shrink: 0;
 }
 .lan-flow-map-scrubber-playpause:hover {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14306,6 +14306,7 @@ a.affected-client:hover {
     justify-content: center;
     font-size: 0.8rem;
     padding: 0;
+    padding-bottom: 1px;
     flex-shrink: 0;
 }
 .lan-flow-map-scrubber-playpause:hover {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1588,9 +1588,13 @@ export class LanFlowMap {
     }
 
     _notifyStatCards(at) {
-        if (!this._dotnetRef) return;
+        if (!this._dotnetRef) {
+            console.warn('[LanFlowMap] _notifyStatCards: dotnetRef is null');
+            return;
+        }
         const iso = at ? at.toISOString() : null;
-        this._dotnetRef.invokeMethodAsync('OnMapTimeChanged', iso).catch(() => {});
+        this._dotnetRef.invokeMethodAsync('OnMapTimeChanged', iso)
+            .catch(err => console.warn('[LanFlowMap] OnMapTimeChanged failed:', err));
     }
 
     _syncPlayPauseIcon() {
@@ -1616,11 +1620,13 @@ export class LanFlowMap {
         try {
             const url = `${this.apiBase}/history?at=${encodeURIComponent(at.toISOString())}`;
             const res = await fetch(url, { credentials: 'same-origin' });
-            if (!res.ok) return;
+            if (!res.ok) { console.warn('[LanFlowMap] _loadHistoric HTTP', res.status); return; }
             const update = await res.json();
+            const rateKeys = Object.keys(update.linkRates || {});
+            console.log(`[LanFlowMap] _loadHistoric: ${rateKeys.length} linkRates`);
             this._applyLiveRates(update.linkRates || {});
         } catch (err) {
-            // Surface but don't crash the rendering loop.
+            console.warn('[LanFlowMap] _loadHistoric error:', err);
         }
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1332,7 +1332,7 @@ export class LanFlowMap {
         modeBadge.textContent = 'Live';
         modeBadge.setAttribute('data-tooltip-hover-only', '');
         modeBadge.addEventListener('click', () => {
-            if (this._mode !== 'live') {
+            if (this._mode === 'live') return;
                 const range = this._panels.scrubberRange;
                 if (range) range.value = 1000;
                 this._onScrubberChange(1000);
@@ -1571,8 +1571,8 @@ export class LanFlowMap {
             if (this._panels.modeBadge) {
                 this._panels.modeBadge.textContent = 'Live';
                 this._panels.modeBadge.classList.remove('is-historic');
-                this._panels.modeBadge.removeAttribute('data-tooltip');
                 this._panels.modeBadge.style.cursor = '';
+                if (this._panels.modeBadge._tippy) this._panels.modeBadge._tippy.disable();
             }
             // Returning to live resumes polling; clear the paused state so the
             // play button reflects "playing" again.
@@ -1589,8 +1589,8 @@ export class LanFlowMap {
         if (this._panels.modeBadge) {
             this._panels.modeBadge.textContent = 'Historic';
             this._panels.modeBadge.classList.add('is-historic');
-            this._panels.modeBadge.setAttribute('data-tooltip', 'Click to return to live');
             this._panels.modeBadge.style.cursor = 'pointer';
+            if (this._panels.modeBadge._tippy) this._panels.modeBadge._tippy.enable();
         }
         this._syncSpeedLabel();
         // Scrubbing back into historic by the user lands paused so they can

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1137,8 +1137,12 @@ export class LanFlowMap {
             const value = Math.round(1000 - msFromNow / (24 * 3600000) * 1000);
             const clamped = Math.max(0, Math.min(1000, value));
             range.value = clamped;
-            // Update the time label on every tick
-            this._onScrubberInput(clamped);
+            // Update the time label from the continuous timestamp, not the
+            // integer slider position (which only moves every ~86s at 1x).
+            if (this._panels.scrubberRight) {
+                this._panels.scrubberRight.textContent =
+                    (clamped >= 998) ? 'Live' : this._playbackTime.toLocaleString();
+            }
             tickCount++;
             // Refresh map and stat cards periodically
             if (tickCount % DATA_REFRESH_TICKS === 0 || clamped >= 998) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1565,6 +1565,7 @@ export class LanFlowMap {
     async _onScrubberChange(value) {
         if (value >= 998) {
             // Snap back to live.
+            this._stopHistoricPlayback();
             this._mode = 'live';
             this._historicAt = null;
             this._onScrubberInput(1000);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -142,7 +142,8 @@ export class LanFlowMap {
         this._mode = 'live';      // 'live' | 'historic'
         this._historicAt = null;  // Date when in historic mode
         this._dotnetRef = window.__monitoringRef || null;
-        this._playbackSpeed = 1;  // multiplier: 0.5, 1, 2, 4
+        this._playbackSpeed = 1;  // real-time multiplier
+        this._playbackAccum = 0;  // fractional slider unit accumulator
 
         this._panels = {};        // DOM refs for overlay UI
         this._floatingLabels = new Map();  // nodeId -> { el, nameEl, rateEl }
@@ -1115,21 +1116,26 @@ export class LanFlowMap {
 
     _startHistoricPlayback() {
         if (this._historicPlaybackTimer) return;
-        // Advance 1 slider unit per tick; vary the tick interval for speed.
-        // 1 unit = 86.4 real seconds (24h / 1000 units).
-        // At 1x: 250ms/unit → full 24h in ~4.2 min.
-        const baseTickMs = 250;
-        const tickMs = Math.max(16, Math.round(baseTickMs / this._playbackSpeed));
+        // 1 slider unit = 86.4 real seconds (24h / 1000). At 1x (real-time),
+        // each 250ms tick accumulates 0.25 real seconds toward the next unit.
+        // Higher multipliers accumulate faster. The slider only advances on
+        // whole-unit crossings; the fractional part carries over.
+        const REAL_SEC_PER_UNIT = 86400 / 1000;
+        const TICK_MS = 250;
+        this._playbackAccum = 0;
         this._historicPlaybackTimer = setInterval(() => {
             if (this._paused) return;
             const range = this._panels.scrubberRange;
             if (!range) return;
+            const realSecThisTick = (TICK_MS / 1000) * this._playbackSpeed;
+            this._playbackAccum += realSecThisTick;
+            const units = Math.floor(this._playbackAccum / REAL_SEC_PER_UNIT);
+            if (units < 1) return;
+            this._playbackAccum -= units * REAL_SEC_PER_UNIT;
             const cur = Number(range.value);
-            const next = Math.min(1000, cur + 1);
+            const next = Math.min(1000, cur + units);
             range.value = next;
             this._onScrubberInput(next);
-            // Mark playback-driven so _onScrubberChange skips its user-scrub
-            // auto-pause and we don't kill our own playback loop.
             this._playbackAdvancing = true;
             try {
                 if (next >= 1000) {
@@ -1141,7 +1147,7 @@ export class LanFlowMap {
             } finally {
                 this._playbackAdvancing = false;
             }
-        }, tickMs);
+        }, TICK_MS);
     }
 
     _stopHistoricPlayback() {
@@ -1320,11 +1326,10 @@ export class LanFlowMap {
         scrubber.innerHTML = `
             <div class="lan-flow-map-scrubber-row">
                 <button class="lan-flow-map-scrubber-playpause" data-role="playpause" type="button" aria-label="Pause">⏸</button>
-                <div class="lan-flow-map-speed-selector" data-role="speed">
-                    <button class="lan-flow-map-speed-btn" data-speed="0.5">0.5x</button>
-                    <button class="lan-flow-map-speed-btn is-active" data-speed="1">1x</button>
-                    <button class="lan-flow-map-speed-btn" data-speed="2">2x</button>
-                    <button class="lan-flow-map-speed-btn" data-speed="4">4x</button>
+                <div class="lan-flow-map-speed-control" data-role="speed">
+                    <button class="lan-flow-map-speed-step" data-dir="-1" type="button" aria-label="Slower">-</button>
+                    <span class="lan-flow-map-speed-label" data-role="speed-label">1x</span>
+                    <button class="lan-flow-map-speed-step" data-dir="1" type="button" aria-label="Faster">+</button>
                 </div>
                 <span data-role="left">-24h</span>
                 <input class="lan-flow-map-scrubber-range" type="range" min="0" max="1000" value="1000" />
@@ -1338,26 +1343,21 @@ export class LanFlowMap {
         range.addEventListener('pointerdown', () => this._stopHistoricPlayback());
         const playPause = scrubber.querySelector('[data-role="playpause"]');
         playPause.addEventListener('click', () => this._togglePlayPause());
-        for (const btn of scrubber.querySelectorAll('.lan-flow-map-speed-btn')) {
+        const SPEED_STEPS = [1, 2, 5, 10, 30, 60, 120, 360, 720, 1440];
+        this._speedSteps = SPEED_STEPS;
+        this._speedIndex = 0; // starts at 1x
+        for (const btn of scrubber.querySelectorAll('.lan-flow-map-speed-step')) {
             btn.addEventListener('click', () => {
-                const speed = Number(btn.dataset.speed);
-                if (btn.classList.contains('is-disabled')) return;
-                this._playbackSpeed = speed;
-                for (const b of scrubber.querySelectorAll('.lan-flow-map-speed-btn'))
-                    b.classList.toggle('is-active', b === btn);
-                if (this._mode === 'live' && speed < 1) {
-                    // Drop out of live into historic playback at the chosen speed
-                    const startValue = 997; // ~4 min behind live
-                    range.value = startValue;
-                    this._onScrubberChange(startValue);
-                    this._paused = false;
-                    this._syncPlayPauseIcon();
-                    this._startHistoricPlayback();
-                } else if (this._mode === 'historic') {
+                const dir = Number(btn.dataset.dir);
+                const newIdx = Math.max(0, Math.min(SPEED_STEPS.length - 1, this._speedIndex + dir));
+                if (newIdx === this._speedIndex) return;
+                this._speedIndex = newIdx;
+                this._playbackSpeed = SPEED_STEPS[newIdx];
+                this._syncSpeedLabel();
+                if (this._mode === 'historic' && this._historicPlaybackTimer) {
                     this._stopHistoricPlayback();
-                    if (!this._paused) this._startHistoricPlayback();
+                    this._startHistoricPlayback();
                 }
-                this._syncSpeedButtons();
             });
         }
         if (isMobile) {
@@ -1371,7 +1371,7 @@ export class LanFlowMap {
         this._panels.scrubberRight = scrubber.querySelector('[data-role="right"]');
         this._panels.scrubberPlayPause = playPause;
         this._paused = false;
-        this._syncSpeedButtons();
+        this._syncSpeedLabel();
     }
 
     _makePanel(extraClass) {
@@ -1551,7 +1551,7 @@ export class LanFlowMap {
             // play button reflects "playing" again.
             this._paused = false;
             this._syncPlayPauseIcon();
-            this._syncSpeedButtons();
+            this._syncSpeedLabel();
             this._notifyStatCards(null);
             await this._pollLive();
             return;
@@ -1563,7 +1563,7 @@ export class LanFlowMap {
             this._panels.modeBadge.textContent = 'Historic';
             this._panels.modeBadge.classList.add('is-historic');
         }
-        this._syncSpeedButtons();
+        this._syncSpeedLabel();
         // Scrubbing back into historic by the user lands paused so they can
         // inspect the point they picked. The playback timer also calls this
         // method on every tick (to load the historic snapshot for the new
@@ -1591,15 +1591,9 @@ export class LanFlowMap {
         btn.setAttribute('aria-label', this._paused ? 'Play' : 'Pause');
     }
 
-    _syncSpeedButtons() {
-        const scrubber = this._panels.scrubber;
-        if (!scrubber) return;
-        const isLive = this._mode === 'live';
-        for (const btn of scrubber.querySelectorAll('.lan-flow-map-speed-btn')) {
-            const speed = Number(btn.dataset.speed);
-            const disabled = isLive && speed > 1;
-            btn.classList.toggle('is-disabled', disabled);
-        }
+    _syncSpeedLabel() {
+        const label = this._panels.scrubber?.querySelector('[data-role="speed-label"]');
+        if (label) label.textContent = `${this._playbackSpeed}x`;
     }
 
     _scrubberValueToTime(value) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1567,6 +1567,7 @@ export class LanFlowMap {
             // Snap back to live.
             this._mode = 'live';
             this._historicAt = null;
+            this._onScrubberInput(1000);
             if (this._panels.modeBadge) {
                 this._panels.modeBadge.textContent = 'Live';
                 this._panels.modeBadge.classList.remove('is-historic');

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1115,19 +1115,17 @@ export class LanFlowMap {
 
     _startHistoricPlayback() {
         if (this._historicPlaybackTimer) return;
-        // Base rate: 75 real seconds per playback second (1.25 min/sec).
-        // Full 24h pass takes ~9.6 min at 1x. _playbackSpeed multiplies this.
-        const baseRate = 75;
-        const tickMs = 250;
-        const realSecPerTick = baseRate * this._playbackSpeed * (tickMs / 1000);
-        const unitsPerSec = 1000 / (24 * 60 * 60);
-        const unitsPerTick = Math.max(1, Math.round(realSecPerTick * unitsPerSec));
+        // Advance 1 slider unit per tick; vary the tick interval for speed.
+        // 1 unit = 86.4 real seconds (24h / 1000 units).
+        // At 1x: 250ms/unit → full 24h in ~4.2 min.
+        const baseTickMs = 250;
+        const tickMs = Math.max(16, Math.round(baseTickMs / this._playbackSpeed));
         this._historicPlaybackTimer = setInterval(() => {
             if (this._paused) return;
             const range = this._panels.scrubberRange;
             if (!range) return;
             const cur = Number(range.value);
-            const next = Math.min(1000, cur + unitsPerTick);
+            const next = Math.min(1000, cur + 1);
             range.value = next;
             this._onScrubberInput(next);
             // Mark playback-driven so _onScrubberChange skips its user-scrub
@@ -1342,13 +1340,24 @@ export class LanFlowMap {
         playPause.addEventListener('click', () => this._togglePlayPause());
         for (const btn of scrubber.querySelectorAll('.lan-flow-map-speed-btn')) {
             btn.addEventListener('click', () => {
-                this._playbackSpeed = Number(btn.dataset.speed);
+                const speed = Number(btn.dataset.speed);
+                if (btn.classList.contains('is-disabled')) return;
+                this._playbackSpeed = speed;
                 for (const b of scrubber.querySelectorAll('.lan-flow-map-speed-btn'))
                     b.classList.toggle('is-active', b === btn);
-                if (this._historicPlaybackTimer) {
-                    this._stopHistoricPlayback();
+                if (this._mode === 'live' && speed < 1) {
+                    // Drop out of live into historic playback at the chosen speed
+                    const startValue = 997; // ~4 min behind live
+                    range.value = startValue;
+                    this._onScrubberChange(startValue);
+                    this._paused = false;
+                    this._syncPlayPauseIcon();
                     this._startHistoricPlayback();
+                } else if (this._mode === 'historic') {
+                    this._stopHistoricPlayback();
+                    if (!this._paused) this._startHistoricPlayback();
                 }
+                this._syncSpeedButtons();
             });
         }
         if (isMobile) {
@@ -1362,6 +1371,7 @@ export class LanFlowMap {
         this._panels.scrubberRight = scrubber.querySelector('[data-role="right"]');
         this._panels.scrubberPlayPause = playPause;
         this._paused = false;
+        this._syncSpeedButtons();
     }
 
     _makePanel(extraClass) {
@@ -1541,6 +1551,7 @@ export class LanFlowMap {
             // play button reflects "playing" again.
             this._paused = false;
             this._syncPlayPauseIcon();
+            this._syncSpeedButtons();
             this._notifyStatCards(null);
             await this._pollLive();
             return;
@@ -1552,6 +1563,7 @@ export class LanFlowMap {
             this._panels.modeBadge.textContent = 'Historic';
             this._panels.modeBadge.classList.add('is-historic');
         }
+        this._syncSpeedButtons();
         // Scrubbing back into historic by the user lands paused so they can
         // inspect the point they picked. The playback timer also calls this
         // method on every tick (to load the historic snapshot for the new
@@ -1577,6 +1589,17 @@ export class LanFlowMap {
         if (!btn) return;
         btn.textContent = this._paused ? '▶' : '⏸';
         btn.setAttribute('aria-label', this._paused ? 'Play' : 'Pause');
+    }
+
+    _syncSpeedButtons() {
+        const scrubber = this._panels.scrubber;
+        if (!scrubber) return;
+        const isLive = this._mode === 'live';
+        for (const btn of scrubber.querySelectorAll('.lan-flow-map-speed-btn')) {
+            const speed = Number(btn.dataset.speed);
+            const disabled = isLive && speed > 1;
+            btn.classList.toggle('is-disabled', disabled);
+        }
     }
 
     _scrubberValueToTime(value) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1116,36 +1116,45 @@ export class LanFlowMap {
 
     _startHistoricPlayback() {
         if (this._historicPlaybackTimer) return;
-        // 1 slider unit = 86.4 real seconds (24h / 1000). At 1x (real-time),
-        // each 250ms tick accumulates 0.25 real seconds toward the next unit.
-        // Higher multipliers accumulate faster. The slider only advances on
-        // whole-unit crossings; the fractional part carries over.
-        const REAL_SEC_PER_UNIT = 86400 / 1000;
-        const TICK_MS = 250;
-        this._playbackAccum = 0;
+        // Track playback as a continuous timestamp, not integer slider units.
+        // The slider and time label update every tick; the map and stat cards
+        // refresh on a throttled cadence (~3 s wall-clock) to avoid flooding
+        // the API while still feeling responsive.
+        const TICK_MS = 1000;
+        const DATA_REFRESH_TICKS = 3; // load new data every 3 ticks
+        this._playbackTime = this._historicAt
+            || this._scrubberValueToTime(Number(this._panels.scrubberRange?.value ?? 500));
+        let tickCount = 0;
         this._historicPlaybackTimer = setInterval(() => {
             if (this._paused) return;
             const range = this._panels.scrubberRange;
             if (!range) return;
-            const realSecThisTick = (TICK_MS / 1000) * this._playbackSpeed;
-            this._playbackAccum += realSecThisTick;
-            const units = Math.floor(this._playbackAccum / REAL_SEC_PER_UNIT);
-            if (units < 1) return;
-            this._playbackAccum -= units * REAL_SEC_PER_UNIT;
-            const cur = Number(range.value);
-            const next = Math.min(1000, cur + units);
-            range.value = next;
-            this._onScrubberInput(next);
-            this._playbackAdvancing = true;
-            try {
-                if (next >= 1000) {
-                    this._stopHistoricPlayback();
-                    this._onScrubberChange(1000);
-                } else {
-                    this._onScrubberChange(next);
+            // Advance the continuous timestamp
+            this._playbackTime = new Date(
+                this._playbackTime.getTime() + TICK_MS * this._playbackSpeed);
+            // Derive slider position from the timestamp
+            const msFromNow = Date.now() - this._playbackTime.getTime();
+            const value = Math.round(1000 - msFromNow / (24 * 3600000) * 1000);
+            const clamped = Math.max(0, Math.min(1000, value));
+            range.value = clamped;
+            // Update the time label on every tick
+            this._onScrubberInput(clamped);
+            tickCount++;
+            // Refresh map and stat cards periodically
+            if (tickCount % DATA_REFRESH_TICKS === 0 || clamped >= 998) {
+                this._playbackAdvancing = true;
+                try {
+                    if (clamped >= 998) {
+                        this._stopHistoricPlayback();
+                        this._onScrubberChange(1000);
+                    } else {
+                        this._historicAt = this._playbackTime;
+                        this._notifyStatCards(this._playbackTime);
+                        this._loadHistoric(this._playbackTime);
+                    }
+                } finally {
+                    this._playbackAdvancing = false;
                 }
-            } finally {
-                this._playbackAdvancing = false;
             }
         }, TICK_MS);
     }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1333,10 +1333,9 @@ export class LanFlowMap {
         modeBadge.setAttribute('data-tooltip-hover-only', '');
         modeBadge.addEventListener('click', () => {
             if (this._mode === 'live') return;
-                const range = this._panels.scrubberRange;
-                if (range) range.value = 1000;
-                this._onScrubberChange(1000);
-            }
+            const range = this._panels.scrubberRange;
+            if (range) range.value = 1000;
+            this._onScrubberChange(1000);
         });
         status.appendChild(modeBadge);
         this._panels.status = status;
@@ -1572,7 +1571,8 @@ export class LanFlowMap {
                 this._panels.modeBadge.textContent = 'Live';
                 this._panels.modeBadge.classList.remove('is-historic');
                 this._panels.modeBadge.style.cursor = '';
-                if (this._panels.modeBadge._tippy) this._panels.modeBadge._tippy.disable();
+                this._panels.modeBadge.removeAttribute('data-tooltip');
+                if (this._panels.modeBadge._tippy) this._panels.modeBadge._tippy.destroy();
             }
             // Returning to live resumes polling; clear the paused state so the
             // play button reflects "playing" again.
@@ -1590,7 +1590,7 @@ export class LanFlowMap {
             this._panels.modeBadge.textContent = 'Historic';
             this._panels.modeBadge.classList.add('is-historic');
             this._panels.modeBadge.style.cursor = 'pointer';
-            if (this._panels.modeBadge._tippy) this._panels.modeBadge._tippy.enable();
+            this._panels.modeBadge.setAttribute('data-tooltip', 'Click to return to live');
         }
         this._syncSpeedLabel();
         // Scrubbing back into historic by the user lands paused so they can

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1145,7 +1145,7 @@ export class LanFlowMap {
             // integer slider position (which only moves every ~86s at 1x).
             if (this._panels.scrubberRight) {
                 this._panels.scrubberRight.textContent =
-                    (clamped >= 998) ? 'Live' : this._playbackTime.toLocaleString();
+                    (clamped >= 998) ? 'Live' : _fmtDateTime(this._playbackTime);
             }
             tickCount++;
             // Refresh map and stat cards periodically
@@ -1558,7 +1558,7 @@ export class LanFlowMap {
         const at = this._scrubberValueToTime(value);
         if (this._panels.scrubberRight) {
             this._panels.scrubberRight.textContent =
-                (value >= 998) ? 'Live' : at.toLocaleString();
+                (value >= 998) ? 'Live' : _fmtDateTime(at);
         }
     }
 
@@ -2341,6 +2341,11 @@ function formatAge(ms) {
     if (h < 24) return `${h}h ago`;
     const d = Math.floor(h / 24);
     return `${d}d ago`;
+}
+
+const _p = (n) => String(n).padStart(2, '0');
+function _fmtDateTime(d) {
+    return `${_p(d.getMonth()+1)}/${_p(d.getDate())}/${String(d.getFullYear()).slice(2)} ${_p(d.getHours())}:${_p(d.getMinutes())}:${_p(d.getSeconds())}`;
 }
 
 function escapeHtml(s) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -141,6 +141,8 @@ export class LanFlowMap {
         };
         this._mode = 'live';      // 'live' | 'historic'
         this._historicAt = null;  // Date when in historic mode
+        this._dotnetRef = window.__monitoringRef || null;
+        this._playbackSpeed = 1;  // multiplier: 0.5, 1, 2, 4
 
         this._panels = {};        // DOM refs for overlay UI
         this._floatingLabels = new Map();  // nodeId -> { el, nameEl, rateEl }
@@ -1113,15 +1115,11 @@ export class LanFlowMap {
 
     _startHistoricPlayback() {
         if (this._historicPlaybackTimer) return;
-        // 10x real-time: 10 sec of real time per 1 sec of playback. Range is
-        // 0..1000 mapped to 24h = 86400 real sec, so 1 unit = 86.4 real sec.
-        // At 250ms tick, advance 2.5 real sec / 86.4 = ~0.029 units. Way too
-        // slow. Instead use a much higher real-time multiplier appropriate
-        // for a 24h window: 10 *minutes* of real time per 1 sec of playback.
-        // That puts a full 24h pass at ~2.4 min, which actually reads.
-        const realSecPerPlaybackSec = 300; // 5 minutes per second
+        // Base rate: 75 real seconds per playback second (1.25 min/sec).
+        // Full 24h pass takes ~9.6 min at 1x. _playbackSpeed multiplies this.
+        const baseRate = 75;
         const tickMs = 250;
-        const realSecPerTick = realSecPerPlaybackSec * (tickMs / 1000);
+        const realSecPerTick = baseRate * this._playbackSpeed * (tickMs / 1000);
         const unitsPerSec = 1000 / (24 * 60 * 60);
         const unitsPerTick = Math.max(1, Math.round(realSecPerTick * unitsPerSec));
         this._historicPlaybackTimer = setInterval(() => {
@@ -1324,6 +1322,12 @@ export class LanFlowMap {
         scrubber.innerHTML = `
             <div class="lan-flow-map-scrubber-row">
                 <button class="lan-flow-map-scrubber-playpause" data-role="playpause" type="button" aria-label="Pause">⏸</button>
+                <div class="lan-flow-map-speed-selector" data-role="speed">
+                    <button class="lan-flow-map-speed-btn" data-speed="0.5">0.5x</button>
+                    <button class="lan-flow-map-speed-btn is-active" data-speed="1">1x</button>
+                    <button class="lan-flow-map-speed-btn" data-speed="2">2x</button>
+                    <button class="lan-flow-map-speed-btn" data-speed="4">4x</button>
+                </div>
                 <span data-role="left">-24h</span>
                 <input class="lan-flow-map-scrubber-range" type="range" min="0" max="1000" value="1000" />
                 <span data-role="right">Live</span>
@@ -1336,6 +1340,17 @@ export class LanFlowMap {
         range.addEventListener('pointerdown', () => this._stopHistoricPlayback());
         const playPause = scrubber.querySelector('[data-role="playpause"]');
         playPause.addEventListener('click', () => this._togglePlayPause());
+        for (const btn of scrubber.querySelectorAll('.lan-flow-map-speed-btn')) {
+            btn.addEventListener('click', () => {
+                this._playbackSpeed = Number(btn.dataset.speed);
+                for (const b of scrubber.querySelectorAll('.lan-flow-map-speed-btn'))
+                    b.classList.toggle('is-active', b === btn);
+                if (this._historicPlaybackTimer) {
+                    this._stopHistoricPlayback();
+                    this._startHistoricPlayback();
+                }
+            });
+        }
         if (isMobile) {
             this.stage.parentElement.insertBefore(scrubber, this.stage.nextSibling);
         } else {
@@ -1526,6 +1541,7 @@ export class LanFlowMap {
             // play button reflects "playing" again.
             this._paused = false;
             this._syncPlayPauseIcon();
+            this._notifyStatCards(null);
             await this._pollLive();
             return;
         }
@@ -1546,7 +1562,14 @@ export class LanFlowMap {
             this._syncPlayPauseIcon();
             this._stopHistoricPlayback();
         }
+        this._notifyStatCards(at);
         await this._loadHistoric(at);
+    }
+
+    _notifyStatCards(at) {
+        if (!this._dotnetRef) return;
+        const iso = at ? at.toISOString() : null;
+        this._dotnetRef.invokeMethodAsync('OnMapTimeChanged', iso).catch(() => {});
     }
 
     _syncPlayPauseIcon() {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -144,6 +144,7 @@ export class LanFlowMap {
         this._dotnetRef = window.__monitoringRef || null;
         this._playbackSpeed = 1;  // real-time multiplier
         this._playbackAccum = 0;  // fractional slider unit accumulator
+        this._scrubberOrigin = Date.now() - 24 * 3600000; // left edge anchored at mount - 24h
 
         this._panels = {};        // DOM refs for overlay UI
         this._floatingLabels = new Map();  // nodeId -> { el, nameEl, rateEl }
@@ -1132,9 +1133,12 @@ export class LanFlowMap {
             // Advance the continuous timestamp
             this._playbackTime = new Date(
                 this._playbackTime.getTime() + TICK_MS * this._playbackSpeed);
-            // Derive slider position from the timestamp
-            const msFromNow = Date.now() - this._playbackTime.getTime();
-            const value = Math.round(1000 - msFromNow / (24 * 3600000) * 1000);
+            // Derive slider position from the timestamp (inverse of _scrubberValueToTime)
+            const now = Date.now();
+            const span = now - this._scrubberOrigin;
+            const value = span > 0
+                ? Math.round((this._playbackTime.getTime() - this._scrubberOrigin) / span * 1000)
+                : 1000;
             const clamped = Math.max(0, Math.min(1000, value));
             range.value = clamped;
             // Update the time label from the continuous timestamp, not the
@@ -1623,9 +1627,10 @@ export class LanFlowMap {
     }
 
     _scrubberValueToTime(value) {
-        // Range 0..1000 maps to 24 hours ago .. now.
+        // Range 0..1000 maps from the anchored origin (mount - 24h) to now.
+        // The window grows as the page stays open so recent time is always reachable.
         const now = Date.now();
-        const ms = now - (1000 - value) * (24 * 60 * 60 * 1000 / 1000);
+        const ms = this._scrubberOrigin + (value / 1000) * (now - this._scrubberOrigin);
         return new Date(ms);
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1330,8 +1330,7 @@ export class LanFlowMap {
         const modeBadge = document.createElement('span');
         modeBadge.className = 'lan-flow-map-mode';
         modeBadge.textContent = 'Live';
-        modeBadge.style.cursor = 'pointer';
-        modeBadge.setAttribute('data-tooltip', 'Click to return to live');
+        modeBadge.setAttribute('data-tooltip-hover-only', '');
         modeBadge.addEventListener('click', () => {
             if (this._mode !== 'live') {
                 const range = this._panels.scrubberRange;
@@ -1572,6 +1571,8 @@ export class LanFlowMap {
             if (this._panels.modeBadge) {
                 this._panels.modeBadge.textContent = 'Live';
                 this._panels.modeBadge.classList.remove('is-historic');
+                this._panels.modeBadge.removeAttribute('data-tooltip');
+                this._panels.modeBadge.style.cursor = '';
             }
             // Returning to live resumes polling; clear the paused state so the
             // play button reflects "playing" again.
@@ -1588,6 +1589,8 @@ export class LanFlowMap {
         if (this._panels.modeBadge) {
             this._panels.modeBadge.textContent = 'Historic';
             this._panels.modeBadge.classList.add('is-historic');
+            this._panels.modeBadge.setAttribute('data-tooltip', 'Click to return to live');
+            this._panels.modeBadge.style.cursor = 'pointer';
         }
         this._syncSpeedLabel();
         // Scrubbing back into historic by the user lands paused so they can

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1326,6 +1326,15 @@ export class LanFlowMap {
         const modeBadge = document.createElement('span');
         modeBadge.className = 'lan-flow-map-mode';
         modeBadge.textContent = 'Live';
+        modeBadge.style.cursor = 'pointer';
+        modeBadge.setAttribute('data-tooltip', 'Click to return to live');
+        modeBadge.addEventListener('click', () => {
+            if (this._mode !== 'live') {
+                const range = this._panels.scrubberRange;
+                if (range) range.value = 1000;
+                this._onScrubberChange(1000);
+            }
+        });
         status.appendChild(modeBadge);
         this._panels.status = status;
         this._panels.modeBadge = modeBadge;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1620,13 +1620,12 @@ export class LanFlowMap {
         try {
             const url = `${this.apiBase}/history?at=${encodeURIComponent(at.toISOString())}`;
             const res = await fetch(url, { credentials: 'same-origin' });
-            if (!res.ok) { console.warn('[LanFlowMap] _loadHistoric HTTP', res.status); return; }
+            if (!res.ok) return;
             const update = await res.json();
-            const rateKeys = Object.keys(update.linkRates || {});
-            console.log(`[LanFlowMap] _loadHistoric: ${rateKeys.length} linkRates`);
             this._applyLiveRates(update.linkRates || {});
+            if (update.nodeBadges) this._currentBadges = update.nodeBadges;
         } catch (err) {
-            console.warn('[LanFlowMap] _loadHistoric error:', err);
+            // Keep ticking; transient errors are fine.
         }
     }
 


### PR DESCRIPTION
## Summary

- **Stat cards sync with map scrubber** - WAN rates, latency (gateway/ISP/transit), gateway health, and fabric load reflect the 3D map timeline position during historic playback, switching back to live values at the live edge
- **Playback speed control** - +/- buttons with rate label (1x through 1440x), where 1x is real-time; continuous time tracking with throttled data refresh
- **Historic map data parity** - The map history endpoint now handles all link kinds (uplinks, WAN, mesh backhaul, wired clients, hub links) with correct direction mapping, node badges with fabric/aggregate rates, and cloud stats via target type queries
- **Investigation timestamps** - Packet loss and SFP anomaly results now include local date/time in parentheses alongside the relative "Xh ago" format
- **GetWansAsync cache** - Stopped hammering the UniFi controller API on every 2-second live poll; port table structure cached for 30 seconds with live rates refreshed from the in-memory cache
- **Scrubber range** - Left edge anchored at mount time so the window grows as the page stays open, keeping all elapsed time periods accessible
- **Historic badge click** - Clicking the "Historic" mode badge returns to live view

## Test plan

- [x] Scrub the 3D map timeline back and verify stat cards update with historic values
- [x] Return to live edge and verify stat cards show real-time values again
- [x] Use +/- speed control during playback, verify speed changes take effect immediately
- [x] Verify WAN link shows correct historic throughput during playback
- [x] Verify mesh AP backhaul link shows correct direction and magnitude
- [x] Verify switch fabric ingress/egress badges match live values in magnitude
- [x] Verify gateway fabric badge doesn't inflate from VLAN sub-interfaces
- [x] Click the "Historic" badge to return to live
- [x] Leave page open for 30+ minutes, verify scrubber can reach recently elapsed times
- [x] Run packet loss investigation, verify timestamp includes local date/time