### PR TITLE
v1.17.3

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -700,6 +700,9 @@ else
     private List<string> _gatewayWanIfNames = new();
     private System.Threading.Timer? _liveRefreshTimer;
     private System.Threading.Timer? _dataRefreshTimer;
+    private DotNetObjectReference<Monitoring>? _mapDotNetRef;
+    private DateTime? _mapHistoricAt;
+    private HistoricStatSnapshot? _historicSnapshot;
 
     private string _activeTab = "setup";
 
@@ -1012,10 +1015,226 @@ else
         DebounceSfpChartRemount();
     }
 
+    // ─── Historic stat snapshot (synced with 3D map scrubber) ───
+
+    private record HistoricStatSnapshot
+    {
+        public double WanDownloadBps { get; init; }
+        public double WanUploadBps { get; init; }
+        public double? GatewayRttMs { get; init; }
+        public double GatewayLossPercent { get; init; }
+        public double? IspRttMs { get; init; }
+        public double IspLossPercent { get; init; }
+        public double? TransitRttMs { get; init; }
+        public double TransitLossPercent { get; init; }
+        public double? GatewayCpuPercent { get; init; }
+        public double? GatewayMemoryPercent { get; init; }
+        public double? GatewayTempC { get; init; }
+        public double FabricIngressBps { get; init; }
+        public double FabricEgressBps { get; init; }
+    }
+
+    [JSInvokable]
+    public async Task OnMapTimeChanged(string? isoTimestamp)
+    {
+        if (isoTimestamp == null)
+        {
+            _mapHistoricAt = null;
+            _historicSnapshot = null;
+            await InvokeAsync(StateHasChanged);
+            return;
+        }
+
+        var at = DateTime.Parse(isoTimestamp, null, System.Globalization.DateTimeStyles.RoundtripKind);
+        _mapHistoricAt = at;
+        await FetchHistoricSnapshotAsync(at);
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task FetchHistoricSnapshotAsync(DateTime at)
+    {
+        var from = at.AddSeconds(-90);
+        var to = at.AddSeconds(30);
+
+        double wanDown = 0, wanUp = 0;
+        double? gwRtt = null; double gwLoss = 0;
+        double? ispRtt = null; double ispLoss = 0;
+        double? transitRtt = null; double transitLoss = 0;
+        double? gwCpu = null, gwMem = null, gwTemp = null;
+        double fabricIn = 0, fabricOut = 0;
+
+        var tasks = new List<Task>();
+
+        // WAN rates
+        if (_gatewayMac != null && _gatewayWanIfNames.Count > 0)
+        {
+            tasks.Add(Task.Run(async () =>
+            {
+                var points = await InfluxClient.QueryGatewayWanRatesAsync(
+                    _gatewayMac, _gatewayWanIfNames, from, to);
+                var closest = points
+                    .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                    .FirstOrDefault();
+                if (closest != null)
+                {
+                    wanDown = closest.DownloadBps ?? 0;
+                    wanUp = closest.UploadBps ?? 0;
+                }
+            }));
+        }
+
+        // Gateway health
+        if (_gatewayMac != null)
+        {
+            tasks.Add(Task.Run(async () =>
+            {
+                var points = await InfluxClient.QueryDeviceHealthAsync(_gatewayMac, from, to);
+                var closest = points
+                    .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                    .FirstOrDefault();
+                if (closest != null)
+                {
+                    gwCpu = closest.CpuPercent;
+                    gwMem = closest.MemoryUsedPercent;
+                    gwTemp = closest.TemperatureC;
+                }
+            }));
+        }
+
+        // Gateway latency (Fabric target for the gateway)
+        var gwFabric = _targets.FirstOrDefault(t =>
+            t.TargetType == MonitoringTargetType.Fabric
+            && t.Enabled
+            && !string.IsNullOrEmpty(t.DeviceMac)
+            && _gatewayMac != null
+            && t.DeviceMac.Replace("-", ":").Equals(_gatewayMac, StringComparison.OrdinalIgnoreCase));
+        if (gwFabric != null)
+        {
+            tasks.Add(Task.Run(async () =>
+            {
+                var points = await InfluxClient.QueryLatencyAsync(gwFabric.TargetId, from, to);
+                var closest = points
+                    .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                    .FirstOrDefault();
+                if (closest != null)
+                {
+                    gwRtt = closest.RttAvgMs;
+                    gwLoss = closest.LossPercent ?? 0;
+                }
+            }));
+        }
+
+        // ISP latency (mean across enabled ISP targets)
+        tasks.Add(Task.Run(async () =>
+        {
+            var data = await InfluxClient.QueryLatencyByTargetTypeAsync(
+                MonitoringTargetType.AccessIsp, from, to);
+            var rtts = new List<double>();
+            var losses = new List<double>();
+            foreach (var (_, pts) in data)
+            {
+                var closest = pts
+                    .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                    .FirstOrDefault();
+                if (closest == null) continue;
+                if (closest.RttAvgMs.HasValue) rtts.Add(closest.RttAvgMs.Value);
+                if (closest.LossPercent.HasValue) losses.Add(closest.LossPercent.Value);
+            }
+            ispRtt = rtts.Count > 0 ? rtts.Average() : null;
+            ispLoss = losses.Count > 0 ? losses.Average() : 0;
+        }));
+
+        // Transit latency (mean across enabled Transit targets)
+        tasks.Add(Task.Run(async () =>
+        {
+            var data = await InfluxClient.QueryLatencyByTargetTypeAsync(
+                MonitoringTargetType.Transit, from, to);
+            var rtts = new List<double>();
+            var losses = new List<double>();
+            foreach (var (_, pts) in data)
+            {
+                var closest = pts
+                    .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                    .FirstOrDefault();
+                if (closest == null) continue;
+                if (closest.RttAvgMs.HasValue) rtts.Add(closest.RttAvgMs.Value);
+                if (closest.LossPercent.HasValue) losses.Add(closest.LossPercent.Value);
+            }
+            transitRtt = rtts.Count > 0 ? rtts.Average() : null;
+            transitLoss = losses.Count > 0 ? losses.Average() : 0;
+        }));
+
+        // Fabric load (sum across switches, gateways, and cellular modems only -
+        // APs are excluded because their radio interfaces over-count beacons/retries.
+        // The live path only calls RecordFabricSum for these device types, so APs
+        // have FabricIngressBps == null and contribute 0 to the live total.)
+        var fabricMacs = _targets
+            .Where(t => t.TargetType == MonitoringTargetType.Fabric && !string.IsNullOrEmpty(t.DeviceMac))
+            .Select(t => t.DeviceMac!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Where(mac =>
+            {
+                var stats = LiveStats.GetForDevice(mac);
+                return stats?.FabricIngressBps != null || stats?.FabricEgressBps != null;
+            })
+            .ToList();
+        if (fabricMacs.Count > 0)
+        {
+            tasks.Add(Task.Run(async () =>
+            {
+                double totalIn = 0, totalOut = 0;
+                foreach (var mac in fabricMacs)
+                {
+                    var points = await InfluxClient.QueryInterfaceRatesAsync(mac, from, to);
+                    var isGateway = _gatewayMac != null
+                        && mac.Replace("-", ":").Equals(_gatewayMac, StringComparison.OrdinalIgnoreCase);
+                    if (isGateway)
+                        points = points
+                            .Where(p => System.Text.RegularExpressions.Regex.IsMatch(p.IfName, @"^eth\d+$"))
+                            .ToList();
+                    var closest = points
+                        .GroupBy(p => p.Time)
+                        .OrderBy(g => Math.Abs((g.Key - at).TotalMilliseconds))
+                        .FirstOrDefault();
+                    if (closest == null) continue;
+                    foreach (var p in closest)
+                    {
+                        totalIn += p.RateInBps ?? 0;
+                        totalOut += p.RateOutBps ?? 0;
+                    }
+                }
+                fabricIn = totalIn;
+                fabricOut = totalOut;
+            }));
+        }
+
+        try { await Task.WhenAll(tasks); }
+        catch { }
+
+        _historicSnapshot = new HistoricStatSnapshot
+        {
+            WanDownloadBps = wanDown,
+            WanUploadBps = wanUp,
+            GatewayRttMs = gwRtt,
+            GatewayLossPercent = gwLoss,
+            IspRttMs = ispRtt,
+            IspLossPercent = ispLoss,
+            TransitRttMs = transitRtt,
+            TransitLossPercent = transitLoss,
+            GatewayCpuPercent = gwCpu,
+            GatewayMemoryPercent = gwMem,
+            GatewayTempC = gwTemp,
+            FabricIngressBps = fabricIn,
+            FabricEgressBps = fabricOut,
+        };
+    }
+
     // ─── Stat card helpers ───
 
     private (double download, double upload) GetWanRates()
     {
+        if (_historicSnapshot != null)
+            return (_historicSnapshot.WanDownloadBps, _historicSnapshot.WanUploadBps);
         if (_gatewayMac == null || _gatewayWanIfNames.Count == 0) return (0, 0);
         double totalDown = 0, totalUp = 0;
         foreach (var ifName in _gatewayWanIfNames)
@@ -1032,12 +1251,23 @@ else
 
     private DeviceLiveStats? GetGatewayStats()
     {
+        if (_historicSnapshot != null)
+        {
+            return new DeviceLiveStats
+            {
+                CpuPercent = _historicSnapshot.GatewayCpuPercent,
+                MemoryUsedPercent = _historicSnapshot.GatewayMemoryPercent,
+                TemperatureC = _historicSnapshot.GatewayTempC,
+            };
+        }
         if (_gatewayMac == null) return null;
         return LiveStats.GetForDevice(_gatewayMac);
     }
 
     private (double? rtt, double loss) GetGatewayLatency()
     {
+        if (_historicSnapshot != null)
+            return (_historicSnapshot.GatewayRttMs, _historicSnapshot.GatewayLossPercent);
         if (_gatewayMac == null) return (null, 0);
         var gwFabric = _targets.FirstOrDefault(t =>
             t.TargetType == MonitoringTargetType.Fabric
@@ -1051,6 +1281,15 @@ else
 
     private (double? rtt, double loss) GetMeanTargetStats(MonitoringTargetType type)
     {
+        if (_historicSnapshot != null)
+        {
+            return type switch
+            {
+                MonitoringTargetType.AccessIsp => (_historicSnapshot.IspRttMs, _historicSnapshot.IspLossPercent),
+                MonitoringTargetType.Transit => (_historicSnapshot.TransitRttMs, _historicSnapshot.TransitLossPercent),
+                _ => (null, 0)
+            };
+        }
         var targets = _targets.Where(t => t.TargetType == type && t.Enabled).ToList();
         if (targets.Count == 0) return (null, 0);
 
@@ -1067,6 +1306,8 @@ else
 
     private (double ingress, double egress) GetTotalFabricLoad()
     {
+        if (_historicSnapshot != null)
+            return (_historicSnapshot.FabricIngressBps, _historicSnapshot.FabricEgressBps);
         double totalIn = 0, totalOut = 0;
         var fabricMacs = _targets
             .Where(t => t.TargetType == MonitoringTargetType.Fabric && !string.IsNullOrEmpty(t.DeviceMac))
@@ -1183,7 +1424,8 @@ else
             var ago = delta.TotalMinutes < 60 ? $"{(int)delta.TotalMinutes}m ago"
                 : delta.TotalHours < 24 ? $"{(int)delta.TotalHours}h ago"
                 : $"{(int)delta.TotalDays}d ago";
-            _lossInvestigateResult = $"{result.LossPercent:0.#}% loss {ago}";
+            var localTime = result.Timestamp.ToLocalTime().ToString("M/d h:mm tt");
+            _lossInvestigateResult = $"{result.LossPercent:0.#}% loss {ago} ({localTime})";
             StateHasChanged();
             await JS.InvokeVoidAsync("eval",
                 $"window.__latencyCharts?.navigateToTime('{result.Timestamp:o}', '{category}');");
@@ -1219,7 +1461,8 @@ else
             var ago = delta.TotalMinutes < 60 ? $"{(int)delta.TotalMinutes}m ago"
                 : delta.TotalHours < 24 ? $"{(int)delta.TotalHours}h ago"
                 : $"{(int)delta.TotalDays}d ago";
-            _sfpInvestigateResult = $"SFP {desc} {ago}";
+            var localTime = result.Timestamp.ToLocalTime().ToString("M/d h:mm tt");
+            _sfpInvestigateResult = $"SFP {desc} {ago} ({localTime})";
             StateHasChanged();
             await JS.InvokeVoidAsync("eval",
                 $"window.__sfpCharts?.navigateToTime('{result.Timestamp:o}');");
@@ -1250,15 +1493,23 @@ else
             _mapMounted = true;
             try
             {
-                var mapUrl = VersionedJs("/js/lan-flow-map.js");
+                _mapDotNetRef ??= DotNetObjectReference.Create(this);
                 await JS.InvokeVoidAsync("eval",
-                    $"(async () => {{ const m = await import('{mapUrl}'); window.__lanFlowMap = m; await m.mount('lan-flow-map-canvas'); }})();");
+                    "window.__mountLanFlowMap = async function(canvasId, ref) {" +
+                    "  window.__monitoringRef = ref;" +
+                    $"  const m = await import('{VersionedJs("/js/lan-flow-map.js")}');" +
+                    "  window.__lanFlowMap = m;" +
+                    "  await m.mount(canvasId);" +
+                    "}");
+                await JS.InvokeVoidAsync("__mountLanFlowMap", "lan-flow-map-canvas", _mapDotNetRef);
             }
             catch { _mapMounted = false; }
         }
         else if (_activeTab != "live" && _mapMounted)
         {
             _mapMounted = false;
+            _mapHistoricAt = null;
+            _historicSnapshot = null;
             try { await JS.InvokeVoidAsync("eval", "window.__lanFlowMap?.unmount();"); }
             catch { }
         }
@@ -1328,6 +1579,7 @@ else
         _dataRefreshTimer?.Dispose();
         _testFeedbackTimer?.Dispose();
         _sfpChartDebounce?.Dispose();
+        _mapDotNetRef?.Dispose();
         if (_latencyChartsMounted)
         {
             try { _ = JS.InvokeVoidAsync("eval", "window.__latencyCharts?.unmount();").AsTask(); }

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
@@ -18,6 +18,11 @@ public class LanFlowMapSnapshot
     /// <summary>Interface name of the primary WAN (e.g. "wan"). The JS layer
     /// uses this to route speed test results that don't carry a WanNetworkGroup.</summary>
     public string? PrimaryWanInterface { get; set; }
+
+    /// <summary>Linux interface names of gateway WAN ports (e.g. ["eth6"]).
+    /// Server-side only; used by the historic endpoint to query InfluxDB.</summary>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public List<string> WanIfNames { get; set; } = new();
 }
 
 public enum LanNodeKind
@@ -81,6 +86,12 @@ public class LanNode
     /// <summary>For wired clients: the parent switch port's negotiated link speed
     /// in Mbps. Surfaces as "1000 Mbps" / "2.5 Gbps" in the tooltip.</summary>
     public int? WiredLinkSpeedMbps { get; set; }
+
+    /// <summary>SNMP ifName of this device's own uplink port (e.g., "Port 9").
+    /// Server-side only; used by the historic endpoint as a fallback when the
+    /// parent doesn't expose SNMP data (mesh AP → switch case).</summary>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public string? UplinkIfName { get; set; }
 }
 
 public class LanPlacement
@@ -292,6 +303,7 @@ public class LanFlowMapHistoricUpdate
 {
     public DateTime At { get; set; }
     public Dictionary<string, LinkLiveRates> LinkRates { get; set; } = new();
+    public Dictionary<string, NodeLiveBadge> NodeBadges { get; set; } = new();
     public Dictionary<string, CloudLiveStats> CloudStats { get; set; } = new();
 
     /// <summary>Speed tests whose TestTime falls within the scrub window (or just before it).</summary>

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -102,6 +102,16 @@ public class LanFlowMapService
         GroupMultiClientPorts(snapshot);
         await BuildWanAndClouds(topology, snapshot, ct);
 
+        var gwRaw = rawDevices.FirstOrDefault(d =>
+            d.DeviceType == NetworkOptimizer.Core.Enums.DeviceType.Gateway);
+        if (gwRaw?.PortTable != null)
+        {
+            snapshot.WanIfNames = gwRaw.PortTable
+                .Where(p => p.IsUplink && !string.IsNullOrEmpty(p.IfName))
+                .Select(p => p.IfName!)
+                .ToList();
+        }
+
         var portRates = await SeedPortRatesAsync(snapshot, ct);
         SeedLiveRates(snapshot, portRates);
 
@@ -297,59 +307,292 @@ public class LanFlowMapService
         var update = new LanFlowMapHistoricUpdate { At = at };
         if (!_connection.IsConnected) return update;
 
-        // Build the topology so we know the link / port IDs to look up.
         var snapshot = await BuildSnapshotAsync(ct);
 
-        var from = at - TimeSpan.FromSeconds(15);
-        var to = at + TimeSpan.FromSeconds(5);
-        var byMac = snapshot.Nodes
-            .Where(n => !string.IsNullOrEmpty(n.Mac))
-            .GroupBy(n => n.Mac!)
-            .ToDictionary(g => g.Key, g => g.First());
+        var from = at - TimeSpan.FromSeconds(90);
+        var to = at + TimeSpan.FromSeconds(30);
 
-        // Wire up each link's PortKey lookup -> historic rate point.
-        foreach (var link in snapshot.Links)
+        var gwNode = snapshot.Nodes.FirstOrDefault(n => n.Kind == LanNodeKind.Gateway);
+        var gwMac = gwNode?.Mac;
+
+        // Pre-fetch WAN rates. The link ID uses NetworkName ("wan") but InfluxDB
+        // stores the Linux ifname ("eth6"). WanIfNames on the snapshot resolves
+        // this from the port table's IfName field (same source as stat cards).
+        IReadOnlyList<MonitoringInfluxClient.WanRatePoint>? wanRates = null;
+        if (!string.IsNullOrEmpty(gwMac) && snapshot.WanIfNames.Count > 0)
         {
-            if (string.IsNullOrEmpty(link.PortKey)) continue;
-            var (deviceMac, ifName) = ParsePortKey(link.PortKey);
-            if (string.IsNullOrEmpty(deviceMac) || string.IsNullOrEmpty(ifName)) continue;
-
             try
             {
-                var points = await _influx.QueryInterfaceRatesAsync(deviceMac, from, to, null, ct);
-                var latest = points
-                    .Where(p => string.Equals(p.IfName, ifName, StringComparison.OrdinalIgnoreCase))
-                    .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
-                    .FirstOrDefault();
-                if (latest == null) continue;
-                update.LinkRates[link.Id] = MapPortToLinkRates(link, latest.RateInBps ?? 0, latest.RateOutBps ?? 0, latest.Time);
+                wanRates = await _influx.QueryGatewayWanRatesAsync(gwMac, snapshot.WanIfNames, from, to, ct: ct);
+            }
+            catch { }
+        }
+
+        // Pre-fetch interface_counters per device MAC so we don't re-query for
+        // every link on the same device. Covers WiredClient (PortKey), Uplink,
+        // MeshBackhaul, and WAN links.
+        var deviceMacs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (!string.IsNullOrEmpty(gwMac)) deviceMacs.Add(gwMac);
+        foreach (var link in snapshot.Links)
+        {
+            if (link.Kind == LanLinkKind.Uplink || link.Kind == LanLinkKind.MeshBackhaul)
+            {
+                var mac = ExtractDeviceMacFromUplinkId(link.Id);
+                if (!string.IsNullOrEmpty(mac)) deviceMacs.Add(mac);
+            }
+            else if (!string.IsNullOrEmpty(link.PortKey))
+            {
+                var (mac, _) = ParsePortKey(link.PortKey);
+                if (!string.IsNullOrEmpty(mac)) deviceMacs.Add(mac);
+            }
+        }
+        var ratesByDevice = new Dictionary<string, IReadOnlyList<MonitoringInfluxClient.InterfaceRatePoint>>(
+            StringComparer.OrdinalIgnoreCase);
+        foreach (var mac in deviceMacs)
+        {
+            try
+            {
+                ratesByDevice[mac] = await _influx.QueryInterfaceRatesAsync(mac, from, to, null, ct);
             }
             catch (Exception ex)
             {
-                _logger.LogDebug(ex, "Historic rate fetch failed for {Port}", link.PortKey);
+                _logger.LogDebug(ex, "Historic rate fetch failed for device {Mac}", mac);
             }
         }
 
-        // Cloud latency at the historic instant.
-        foreach (var cloud in snapshot.Clouds)
+        // Resolve each link, mirroring the live endpoint's kind-aware dispatch.
+        foreach (var link in snapshot.Links)
         {
             try
             {
-                var lat = await _influx.QueryLatencyAsync(cloud.Id, from, to, null, ct);
-                var latest = lat
+                if (link.Kind == LanLinkKind.Wan)
+                {
+                    if (wanRates != null)
+                    {
+                        var closest = wanRates
+                            .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                            .FirstOrDefault();
+                        if (closest != null)
+                            update.LinkRates[link.Id] = MapPortToLinkRates(link, closest.DownloadBps ?? 0, closest.UploadBps ?? 0, closest.Time);
+                    }
+                }
+                else if (link.Kind == LanLinkKind.Uplink || link.Kind == LanLinkKind.MeshBackhaul)
+                {
+                    MonitoringInfluxClient.InterfaceRatePoint? resolved = null;
+                    bool fromChildSide = false;
+
+                    // Primary: parent's trunk port via PortKey.
+                    if (!string.IsNullOrEmpty(link.PortKey))
+                    {
+                        var (pMac, pIf) = ParsePortKey(link.PortKey);
+                        if (ratesByDevice.TryGetValue(pMac, out var pPts))
+                        {
+                            resolved = pPts
+                                .Where(p => string.Equals(p.IfName, pIf, StringComparison.OrdinalIgnoreCase))
+                                .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                                .FirstOrDefault();
+                        }
+                    }
+
+                    // Fallback: child device's own interface. Covers mesh APs
+                    // (vwiresta) and switches whose parent (e.g., a mesh AP)
+                    // doesn't expose SNMP port data. The live code does the
+                    // same at ComputePortRate(dev.Mac, dev.Uplink.PortIdx).
+                    if (resolved == null)
+                    {
+                        var childMac = ExtractDeviceMacFromUplinkId(link.Id);
+                        if (!string.IsNullOrEmpty(childMac) && ratesByDevice.TryGetValue(childMac, out var cPts))
+                        {
+                            if (link.Kind == LanLinkKind.MeshBackhaul)
+                            {
+                                resolved = cPts
+                                    .Where(p => p.IfName.StartsWith("vwiresta", StringComparison.OrdinalIgnoreCase)
+                                        && !p.IfName.Contains('.'))
+                                    .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                                    .FirstOrDefault();
+                            }
+                            else
+                            {
+                                // Wired switch fallback: find the child's uplink port.
+                                // On switches SNMP ifDescr is "Port N" and the uplink
+                                // is the highest-rate port. Use the same closest-time
+                                // point from the child's interface set; the direction
+                                // swaps because we're reading from the other end.
+                                var childNode = snapshot.Nodes.FirstOrDefault(n =>
+                                    string.Equals(n.Mac, childMac, StringComparison.OrdinalIgnoreCase));
+                                if (childNode?.UplinkIfName != null)
+                                {
+                                    resolved = cPts
+                                        .Where(p => string.Equals(p.IfName, childNode.UplinkIfName, StringComparison.OrdinalIgnoreCase))
+                                        .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                                        .FirstOrDefault();
+                                    fromChildSide = true;
+                                }
+                            }
+                        }
+                    }
+
+                    if (resolved != null)
+                    {
+                        if (link.Kind == LanLinkKind.MeshBackhaul && !fromChildSide)
+                        {
+                            // vwiresta rateIn = downloads, rateOut = uploads
+                            update.LinkRates[link.Id] = new LinkLiveRates
+                            {
+                                DownstreamBps = resolved.RateInBps ?? 0,
+                                UpstreamBps = resolved.RateOutBps ?? 0,
+                                AsOf = resolved.Time,
+                            };
+                        }
+                        else if (fromChildSide)
+                        {
+                            // Reading from child side: directions swap vs parent side.
+                            // Child port RX = bytes arriving from parent = downstream.
+                            // Child port TX = bytes leaving toward parent = upstream.
+                            update.LinkRates[link.Id] = new LinkLiveRates
+                            {
+                                DownstreamBps = resolved.RateInBps ?? 0,
+                                UpstreamBps = resolved.RateOutBps ?? 0,
+                                AsOf = resolved.Time,
+                            };
+                        }
+                        else
+                        {
+                            update.LinkRates[link.Id] = MapPortToLinkRates(link, resolved.RateInBps ?? 0, resolved.RateOutBps ?? 0, resolved.Time);
+                        }
+                    }
+                }
+                else if (link.Kind == LanLinkKind.WiredClient && !string.IsNullOrEmpty(link.PortKey))
+                {
+                    var (deviceMac, ifName) = ParsePortKey(link.PortKey);
+                    if (ratesByDevice.TryGetValue(deviceMac, out var pts))
+                    {
+                        var closest = pts
+                            .Where(p => string.Equals(p.IfName, ifName, StringComparison.OrdinalIgnoreCase))
+                            .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                            .FirstOrDefault();
+                        if (closest != null)
+                            update.LinkRates[link.Id] = MapPortToLinkRates(link, closest.RateInBps ?? 0, closest.RateOutBps ?? 0, closest.Time);
+                    }
+                }
+                // WifiClient links: wifi_client throughput is stored with client_mac as
+                // a field (not a tag), making per-client InfluxDB lookups expensive.
+                // Skipped for now; wifi leaves show snapshot rates during playback.
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Historic rate failed for link {Id}", link.Id);
+            }
+        }
+
+        // Node badges: device health + fabric/aggregate rates at the historic
+        // instant. Matches the live endpoint's badge population logic:
+        //   - Switches/gateways: fabricIngressBps = sum(port Rx), fabricEgressBps = sum(port Tx)
+        //   - APs: aggregateInBps/OutBps from the uplink link rate (already computed above)
+        // Without fabric rates the JS falls back to summing adjacent links,
+        // which double-counts flows traversing the device.
+        foreach (var node in snapshot.Nodes)
+        {
+            if (string.IsNullOrEmpty(node.Mac)) continue;
+            var mac = node.Mac;
+            try
+            {
+                var health = await _influx.QueryDeviceHealthAsync(mac, from, to, null, ct);
+                var healthPt = health
                     .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
                     .FirstOrDefault();
-                if (latest == null) continue;
-                update.CloudStats[cloud.Id] = new CloudLiveStats
+
+                double? fabIn = null, fabOut = null;
+                if ((node.Kind == LanNodeKind.Switch || node.Kind == LanNodeKind.Gateway)
+                    && ratesByDevice.TryGetValue(mac, out var rates))
                 {
-                    RttAvgMs = latest.RttAvgMs,
-                    LossPercent = latest.LossPercent,
-                    Success = latest.RttAvgMs.HasValue,
+                    var isGw = node.Kind == LanNodeKind.Gateway;
+                    var filtered = isGw
+                        ? rates.Where(p => System.Text.RegularExpressions.Regex.IsMatch(p.IfName, @"^eth\d+$"))
+                        : rates;
+                    var closestRates = filtered
+                        .GroupBy(p => p.Time)
+                        .OrderBy(g => Math.Abs((g.Key - at).TotalMilliseconds))
+                        .FirstOrDefault();
+                    if (closestRates != null)
+                    {
+                        double sumRx = 0, sumTx = 0;
+                        foreach (var r in closestRates)
+                        {
+                            sumRx += r.RateInBps ?? 0;
+                            sumTx += r.RateOutBps ?? 0;
+                        }
+                        fabIn = sumRx;
+                        fabOut = sumTx;
+                    }
+                }
+
+                // For APs, pull aggregate from the uplink link rate we already computed.
+                double? aggIn = null, aggOut = null;
+                if (node.Kind == LanNodeKind.AccessPoint)
+                {
+                    var uplinkId = $"uplink-{mac}";
+                    if (update.LinkRates.TryGetValue(uplinkId, out var uplinkRate))
+                    {
+                        aggIn = uplinkRate.UpstreamBps;
+                        aggOut = uplinkRate.DownstreamBps;
+                    }
+                }
+
+                if (healthPt == null && fabIn == null && aggIn == null) continue;
+
+                update.NodeBadges[node.Id] = new NodeLiveBadge
+                {
+                    Online = node.Online,
+                    CpuPercent = healthPt?.CpuPercent,
+                    MemoryUsedPercent = healthPt?.MemoryUsedPercent,
+                    TemperatureC = healthPt?.TemperatureC,
+                    FabricIngressBps = fabIn,
+                    FabricEgressBps = fabOut,
+                    AggregateInBps = aggIn,
+                    AggregateOutBps = aggOut,
                 };
             }
             catch (Exception ex)
             {
-                _logger.LogDebug(ex, "Historic latency fetch failed for {Cloud}", cloud.Id);
+                _logger.LogDebug(ex, "Historic badge failed for {Mac}", mac);
+            }
+        }
+
+        // Cloud latency: map cloud kind to monitoring target type and query.
+        foreach (var cloud in snapshot.Clouds)
+        {
+            try
+            {
+                var targetType = cloud.Kind switch
+                {
+                    LanCloudKind.AccessIsp => MonitoringTargetType.AccessIsp,
+                    LanCloudKind.Transit => MonitoringTargetType.Transit,
+                    _ => (MonitoringTargetType?)null
+                };
+                if (targetType == null) continue;
+                var data = await _influx.QueryLatencyByTargetTypeAsync(targetType.Value, from, to, ct: ct);
+                MonitoringInfluxClient.LatencyPoint? best = null;
+                foreach (var (_, pts) in data)
+                {
+                    var closest = pts
+                        .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                        .FirstOrDefault();
+                    if (closest != null && (best == null
+                        || Math.Abs((closest.Time - at).TotalMilliseconds) < Math.Abs((best.Time - at).TotalMilliseconds)))
+                        best = closest;
+                }
+                if (best == null) continue;
+                update.CloudStats[cloud.Id] = new CloudLiveStats
+                {
+                    RttAvgMs = best.RttAvgMs,
+                    LossPercent = best.LossPercent,
+                    Success = best.RttAvgMs.HasValue,
+                };
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Historic latency failed for cloud {Id}", cloud.Id);
             }
         }
 
@@ -476,6 +719,18 @@ public class LanFlowMapService
             }
 
             snapshot.Links.Add(link);
+
+            // Stash the child's own uplink port ifName on its node. The historic
+            // endpoint uses this as a fallback when the parent doesn't expose
+            // SNMP data (e.g., switch plugged into a mesh AP's Ethernet port).
+            if (d.LocalUplinkPort.HasValue && d.LocalUplinkPort.Value > 0)
+            {
+                var childNode = snapshot.Nodes.FirstOrDefault(n => n.Id == "dev-" + mac);
+                if (childNode != null && nameMaps.TryGetValue((mac, d.LocalUplinkPort.Value), out var localMap))
+                {
+                    childNode.UplinkIfName = localMap.IfName;
+                }
+            }
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -26,6 +26,8 @@ public class MonitoringPathView
     private readonly UniFiConnectionService _connectionService;
     private readonly MonitoringLiveStats _liveStats;
     private readonly ILogger<MonitoringPathView> _logger;
+    private IReadOnlyList<WanSummary>? _wanCache;
+    private DateTime _wanCacheExpiry;
 
     public MonitoringPathView(
         IDbContextFactory<NetworkOptimizerDbContext> dbFactory,
@@ -138,6 +140,12 @@ public class MonitoringPathView
     /// </summary>
     public async Task<IReadOnlyList<WanSummary>> GetWansAsync(CancellationToken ct = default)
     {
+        if (_wanCache != null && DateTime.UtcNow < _wanCacheExpiry)
+        {
+            RefreshWanLiveRates(_wanCache);
+            return _wanCache;
+        }
+
         if (!_connectionService.IsConnected || _connectionService.Client == null)
             return Array.Empty<WanSummary>();
 
@@ -163,37 +171,46 @@ public class MonitoringPathView
             .ToList();
         if (wanPorts.Count == 0)
         {
-            // Fall back to any port whose network_name looks like a WAN.
             wanPorts = gateway.PortTable
                 .Where(p => p.NetworkName != null && p.NetworkName.StartsWith("wan", StringComparison.OrdinalIgnoreCase))
                 .OrderBy(p => p.PortIdx)
                 .ToList();
         }
 
+        var gwMac = gateway.Mac.ToLowerInvariant().Replace('-', ':');
         for (int i = 0; i < wanPorts.Count; i++)
         {
             var port = wanPorts[i];
-            // Live throughput for this WAN port comes from the agent's per-port rate
-            // cache (which we maintain anyway for AP backhaul lookups). The cache key
-            // is (gateway MAC, port_idx).
-            var deviceLive = _liveStats.GetForDevice(gateway.Mac);
-
             results.Add(new WanSummary
             {
                 WanInterface = port.NetworkName ?? $"wan{i + 1}",
                 FriendlyName = string.IsNullOrEmpty(port.Name) ? null : port.Name,
                 IsPrimary = i == 0,
-                GatewayMac = gateway.Mac.ToLowerInvariant().Replace('-', ':'),
+                GatewayMac = gwMac,
                 GatewayPortName = port.Name,
                 LinkSpeedMbps = port.Speed > 0 ? port.Speed : (int?)null,
-                LiveRateInBps = deviceLive?.RateInBps,
-                LiveRateOutBps = deviceLive?.RateOutBps,
                 IpAddress = port.Ip,
                 IpClass = NetworkUtilities.ClassifyPublicAddress(port.Ip)
             });
         }
 
+        _wanCache = results;
+        _wanCacheExpiry = DateTime.UtcNow.AddSeconds(30);
+        RefreshWanLiveRates(results);
         return results;
+    }
+
+    private void RefreshWanLiveRates(IReadOnlyList<WanSummary> wans)
+    {
+        if (wans.Count == 0) return;
+        var gwMac = wans[0].GatewayMac;
+        if (string.IsNullOrEmpty(gwMac)) return;
+        var deviceLive = _liveStats.GetForDevice(gwMac);
+        foreach (var wan in wans)
+        {
+            wan.LiveRateInBps = deviceLive?.RateInBps;
+            wan.LiveRateOutBps = deviceLive?.RateOutBps;
+        }
     }
 
     /// <summary>
@@ -273,8 +290,8 @@ public record WanSummary
     public string? GatewayMac { get; init; }
     public string? GatewayPortName { get; init; }
     public int? LinkSpeedMbps { get; init; }
-    public double? LiveRateInBps { get; init; }
-    public double? LiveRateOutBps { get; init; }
+    public double? LiveRateInBps { get; set; }
+    public double? LiveRateOutBps { get; set; }
     public string? IpAddress { get; init; }
     public PublicAddressClass IpClass { get; init; }
 }

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -608,7 +608,7 @@ public class MonitoringCollectionAgent : BackgroundService
     /// all alias counters carried by a physical eth port. Summing those gives
     /// 3-4x the real total, so we restrict gateway fabric sum to plain ethN.
     /// </summary>
-    private static bool IncludeInFabricSum(NetworkOptimizer.Core.Enums.DeviceType type, string ifDescr)
+    internal static bool IncludeInFabricSum(NetworkOptimizer.Core.Enums.DeviceType type, string ifDescr)
     {
         if (type == NetworkOptimizer.Core.Enums.DeviceType.Gateway)
             return System.Text.RegularExpressions.Regex.IsMatch(ifDescr, @"^eth\d+$");

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14285,7 +14285,7 @@ a.affected-client:hover {
    jumps right under the cursor as it approaches the live edge. */
 .lan-flow-map-scrubber-row [data-role="right"] {
     display: inline-block;
-    min-width: 9.5rem;
+    min-width: 7.5rem;
     text-align: center;
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
@@ -14306,11 +14306,45 @@ a.affected-client:hover {
     justify-content: center;
     font-size: 0.8rem;
     padding: 0;
+    padding-bottom: 3px;
     flex-shrink: 0;
 }
 .lan-flow-map-scrubber-playpause:hover {
     background: var(--bg-hover);
     color: var(--text-primary);
+}
+.lan-flow-map-speed-control {
+    display: flex;
+    align-items: center;
+    gap: 0.2rem;
+    flex-shrink: 0;
+}
+.lan-flow-map-speed-step {
+    background: transparent;
+    border: 1px solid var(--border-color, #334155);
+    color: var(--text-secondary);
+    width: 1.4rem;
+    height: 1.4rem;
+    border-radius: 0.2rem;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.85rem;
+    font-weight: 600;
+    padding: 0;
+    line-height: 1;
+}
+.lan-flow-map-speed-step:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+}
+.lan-flow-map-speed-label {
+    font-size: 0.7rem;
+    font-variant-numeric: tabular-nums;
+    min-width: 2.2rem;
+    text-align: center;
+    color: var(--text-secondary);
 }
 /* SFP/Optical table device + port cell. Inline so device name, port label,
    and PON badge sit on one row vertically centered, evenly spaced. */
@@ -14549,5 +14583,8 @@ a.affected-client:hover {
         width: 100%;
         border-radius: 0 0 8px 8px;
         border-top: 1px solid rgba(255, 255, 255, 0.06);
+    }
+    .lan-flow-map-speed-control {
+        display: none;
     }
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -141,6 +141,10 @@ export class LanFlowMap {
         };
         this._mode = 'live';      // 'live' | 'historic'
         this._historicAt = null;  // Date when in historic mode
+        this._dotnetRef = window.__monitoringRef || null;
+        this._playbackSpeed = 1;  // real-time multiplier
+        this._playbackAccum = 0;  // fractional slider unit accumulator
+        this._scrubberOrigin = Date.now() - 24 * 3600000; // left edge anchored at mount - 24h
 
         this._panels = {};        // DOM refs for overlay UI
         this._floatingLabels = new Map();  // nodeId -> { el, nameEl, rateEl }
@@ -1113,39 +1117,54 @@ export class LanFlowMap {
 
     _startHistoricPlayback() {
         if (this._historicPlaybackTimer) return;
-        // 10x real-time: 10 sec of real time per 1 sec of playback. Range is
-        // 0..1000 mapped to 24h = 86400 real sec, so 1 unit = 86.4 real sec.
-        // At 250ms tick, advance 2.5 real sec / 86.4 = ~0.029 units. Way too
-        // slow. Instead use a much higher real-time multiplier appropriate
-        // for a 24h window: 10 *minutes* of real time per 1 sec of playback.
-        // That puts a full 24h pass at ~2.4 min, which actually reads.
-        const realSecPerPlaybackSec = 300; // 5 minutes per second
-        const tickMs = 250;
-        const realSecPerTick = realSecPerPlaybackSec * (tickMs / 1000);
-        const unitsPerSec = 1000 / (24 * 60 * 60);
-        const unitsPerTick = Math.max(1, Math.round(realSecPerTick * unitsPerSec));
+        // Track playback as a continuous timestamp, not integer slider units.
+        // The slider and time label update every tick; the map and stat cards
+        // refresh on a throttled cadence (~3 s wall-clock) to avoid flooding
+        // the API while still feeling responsive.
+        const TICK_MS = 1000;
+        const DATA_REFRESH_TICKS = 3; // load new data every 3 ticks
+        this._playbackTime = this._historicAt
+            || this._scrubberValueToTime(Number(this._panels.scrubberRange?.value ?? 500));
+        let tickCount = 0;
         this._historicPlaybackTimer = setInterval(() => {
             if (this._paused) return;
             const range = this._panels.scrubberRange;
             if (!range) return;
-            const cur = Number(range.value);
-            const next = Math.min(1000, cur + unitsPerTick);
-            range.value = next;
-            this._onScrubberInput(next);
-            // Mark playback-driven so _onScrubberChange skips its user-scrub
-            // auto-pause and we don't kill our own playback loop.
-            this._playbackAdvancing = true;
-            try {
-                if (next >= 1000) {
-                    this._stopHistoricPlayback();
-                    this._onScrubberChange(1000);
-                } else {
-                    this._onScrubberChange(next);
-                }
-            } finally {
-                this._playbackAdvancing = false;
+            // Advance the continuous timestamp
+            this._playbackTime = new Date(
+                this._playbackTime.getTime() + TICK_MS * this._playbackSpeed);
+            // Derive slider position from the timestamp (inverse of _scrubberValueToTime)
+            const now = Date.now();
+            const span = now - this._scrubberOrigin;
+            const value = span > 0
+                ? Math.round((this._playbackTime.getTime() - this._scrubberOrigin) / span * 1000)
+                : 1000;
+            const clamped = Math.max(0, Math.min(1000, value));
+            range.value = clamped;
+            // Update the time label from the continuous timestamp, not the
+            // integer slider position (which only moves every ~86s at 1x).
+            if (this._panels.scrubberRight) {
+                this._panels.scrubberRight.textContent =
+                    (clamped >= 998) ? 'Live' : _fmtDateTime(this._playbackTime);
             }
-        }, tickMs);
+            tickCount++;
+            // Refresh map and stat cards periodically
+            if (tickCount % DATA_REFRESH_TICKS === 0 || clamped >= 998) {
+                this._playbackAdvancing = true;
+                try {
+                    if (clamped >= 998) {
+                        this._stopHistoricPlayback();
+                        this._onScrubberChange(1000);
+                    } else {
+                        this._historicAt = this._playbackTime;
+                        this._notifyStatCards(this._playbackTime);
+                        this._loadHistoric(this._playbackTime);
+                    }
+                } finally {
+                    this._playbackAdvancing = false;
+                }
+            }
+        }, TICK_MS);
     }
 
     _stopHistoricPlayback() {
@@ -1311,6 +1330,13 @@ export class LanFlowMap {
         const modeBadge = document.createElement('span');
         modeBadge.className = 'lan-flow-map-mode';
         modeBadge.textContent = 'Live';
+        modeBadge.setAttribute('data-tooltip-hover-only', '');
+        modeBadge.addEventListener('click', () => {
+            if (this._mode === 'live') return;
+            const range = this._panels.scrubberRange;
+            if (range) range.value = 1000;
+            this._onScrubberChange(1000);
+        });
         status.appendChild(modeBadge);
         this._panels.status = status;
         this._panels.modeBadge = modeBadge;
@@ -1324,6 +1350,11 @@ export class LanFlowMap {
         scrubber.innerHTML = `
             <div class="lan-flow-map-scrubber-row">
                 <button class="lan-flow-map-scrubber-playpause" data-role="playpause" type="button" aria-label="Pause">⏸</button>
+                <div class="lan-flow-map-speed-control" data-role="speed">
+                    <button class="lan-flow-map-speed-step" data-dir="-1" type="button" aria-label="Slower">-</button>
+                    <span class="lan-flow-map-speed-label" data-role="speed-label">1x</span>
+                    <button class="lan-flow-map-speed-step" data-dir="1" type="button" aria-label="Faster">+</button>
+                </div>
                 <span data-role="left">-24h</span>
                 <input class="lan-flow-map-scrubber-range" type="range" min="0" max="1000" value="1000" />
                 <span data-role="right">Live</span>
@@ -1336,6 +1367,23 @@ export class LanFlowMap {
         range.addEventListener('pointerdown', () => this._stopHistoricPlayback());
         const playPause = scrubber.querySelector('[data-role="playpause"]');
         playPause.addEventListener('click', () => this._togglePlayPause());
+        const SPEED_STEPS = [1, 2, 5, 10, 30, 60, 120, 360, 720, 1440];
+        this._speedSteps = SPEED_STEPS;
+        this._speedIndex = 0; // starts at 1x
+        for (const btn of scrubber.querySelectorAll('.lan-flow-map-speed-step')) {
+            btn.addEventListener('click', () => {
+                const dir = Number(btn.dataset.dir);
+                const newIdx = Math.max(0, Math.min(SPEED_STEPS.length - 1, this._speedIndex + dir));
+                if (newIdx === this._speedIndex) return;
+                this._speedIndex = newIdx;
+                this._playbackSpeed = SPEED_STEPS[newIdx];
+                this._syncSpeedLabel();
+                if (this._mode === 'historic' && this._historicPlaybackTimer) {
+                    this._stopHistoricPlayback();
+                    this._startHistoricPlayback();
+                }
+            });
+        }
         if (isMobile) {
             this.stage.parentElement.insertBefore(scrubber, this.stage.nextSibling);
         } else {
@@ -1347,6 +1395,7 @@ export class LanFlowMap {
         this._panels.scrubberRight = scrubber.querySelector('[data-role="right"]');
         this._panels.scrubberPlayPause = playPause;
         this._paused = false;
+        this._syncSpeedLabel();
     }
 
     _makePanel(extraClass) {
@@ -1509,23 +1558,30 @@ export class LanFlowMap {
         const at = this._scrubberValueToTime(value);
         if (this._panels.scrubberRight) {
             this._panels.scrubberRight.textContent =
-                (value >= 998) ? 'Live' : at.toLocaleString();
+                (value >= 998) ? 'Live' : _fmtDateTime(at);
         }
     }
 
     async _onScrubberChange(value) {
         if (value >= 998) {
             // Snap back to live.
+            this._stopHistoricPlayback();
             this._mode = 'live';
             this._historicAt = null;
+            this._onScrubberInput(1000);
             if (this._panels.modeBadge) {
                 this._panels.modeBadge.textContent = 'Live';
                 this._panels.modeBadge.classList.remove('is-historic');
+                this._panels.modeBadge.style.cursor = '';
+                this._panels.modeBadge.removeAttribute('data-tooltip');
+                if (this._panels.modeBadge._tippy) this._panels.modeBadge._tippy.destroy();
             }
             // Returning to live resumes polling; clear the paused state so the
             // play button reflects "playing" again.
             this._paused = false;
             this._syncPlayPauseIcon();
+            this._syncSpeedLabel();
+            this._notifyStatCards(null);
             await this._pollLive();
             return;
         }
@@ -1535,7 +1591,10 @@ export class LanFlowMap {
         if (this._panels.modeBadge) {
             this._panels.modeBadge.textContent = 'Historic';
             this._panels.modeBadge.classList.add('is-historic');
+            this._panels.modeBadge.style.cursor = 'pointer';
+            this._panels.modeBadge.setAttribute('data-tooltip', 'Click to return to live');
         }
+        this._syncSpeedLabel();
         // Scrubbing back into historic by the user lands paused so they can
         // inspect the point they picked. The playback timer also calls this
         // method on every tick (to load the historic snapshot for the new
@@ -1546,7 +1605,18 @@ export class LanFlowMap {
             this._syncPlayPauseIcon();
             this._stopHistoricPlayback();
         }
+        this._notifyStatCards(at);
         await this._loadHistoric(at);
+    }
+
+    _notifyStatCards(at) {
+        if (!this._dotnetRef) {
+            console.warn('[LanFlowMap] _notifyStatCards: dotnetRef is null');
+            return;
+        }
+        const iso = at ? at.toISOString() : null;
+        this._dotnetRef.invokeMethodAsync('OnMapTimeChanged', iso)
+            .catch(err => console.warn('[LanFlowMap] OnMapTimeChanged failed:', err));
     }
 
     _syncPlayPauseIcon() {
@@ -1556,10 +1626,16 @@ export class LanFlowMap {
         btn.setAttribute('aria-label', this._paused ? 'Play' : 'Pause');
     }
 
+    _syncSpeedLabel() {
+        const label = this._panels.scrubber?.querySelector('[data-role="speed-label"]');
+        if (label) label.textContent = `${this._playbackSpeed}x`;
+    }
+
     _scrubberValueToTime(value) {
-        // Range 0..1000 maps to 24 hours ago .. now.
+        // Range 0..1000 maps from the anchored origin (mount - 24h) to now.
+        // The window grows as the page stays open so recent time is always reachable.
         const now = Date.now();
-        const ms = now - (1000 - value) * (24 * 60 * 60 * 1000 / 1000);
+        const ms = this._scrubberOrigin + (value / 1000) * (now - this._scrubberOrigin);
         return new Date(ms);
     }
 
@@ -1570,8 +1646,9 @@ export class LanFlowMap {
             if (!res.ok) return;
             const update = await res.json();
             this._applyLiveRates(update.linkRates || {});
+            if (update.nodeBadges) this._currentBadges = update.nodeBadges;
         } catch (err) {
-            // Surface but don't crash the rendering loop.
+            // Keep ticking; transient errors are fine.
         }
     }
 
@@ -2264,6 +2341,11 @@ function formatAge(ms) {
     if (h < 24) return `${h}h ago`;
     const d = Math.floor(h / 24);
     return `${d}d ago`;
+}
+
+const _p = (n) => String(n).padStart(2, '0');
+function _fmtDateTime(d) {
+    return `${_p(d.getMonth()+1)}/${_p(d.getDate())}/${String(d.getFullYear()).slice(2)} ${_p(d.getHours())}:${_p(d.getMinutes())}:${_p(d.getSeconds())}`;
 }
 
 function escapeHtml(s) {


### PR DESCRIPTION
## Summary

- **Live View historic playback** - Stat cards (WAN rates, latency, gateway health, fabric load) sync with the 3D map timeline scrubber, showing InfluxDB point-in-time values during playback and live values at the live edge
- **Playback speed control** - +/- buttons with rate label (1x real-time through 1440x), continuous time tracking with throttled data refresh
- **Full historic map data** - The map history endpoint now handles all link kinds (uplinks, WAN, mesh backhaul, wired clients, hub links) with correct direction mapping, node badges with fabric/aggregate rates, and cloud stats
- **Investigation timestamps** - Packet loss and SFP anomaly results include local date/time in parentheses alongside the relative time
- **GetWansAsync cache** - Port table structure cached for 30 seconds instead of hitting the UniFi controller API on every 2-second live poll
- **Scrubber improvements** - Anchored left edge so the window grows as the page stays open; 24-hour time format; Historic badge click-to-return-to-live with conditional tooltip