### PR TITLE
3D map: persistent device repositioning via right-click

### DIFF
--- a/src/NetworkOptimizer.Web/Endpoints/LanFlowMapEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/LanFlowMapEndpoints.cs
@@ -1,9 +1,12 @@
+using NetworkOptimizer.Web.Services;
 using NetworkOptimizer.Web.Services.LanFlowMap;
 
 namespace NetworkOptimizer.Web.Endpoints;
 
 public static class LanFlowMapEndpoints
 {
+    private record DevicePlacementRequest(string Mac, double Latitude, double Longitude);
+
     public static void Map(WebApplication app)
     {
         app.MapGet("/api/monitoring/lan-flow-map/snapshot",
@@ -34,6 +37,16 @@ public static class LanFlowMapEndpoints
                 var toT = until ?? DateTime.UtcNow;
                 var items = await svc.BuildSpeedTestOverlayAsync(fromT, toT, limitPerKind: 10, ct: ct);
                 return Results.Ok(items);
+            });
+
+        app.MapPost("/api/monitoring/lan-flow-map/device-placement",
+            async (DevicePlacementRequest req, ApMapService apMap, LanFlowMapService svc) =>
+            {
+                if (string.IsNullOrWhiteSpace(req.Mac))
+                    return Results.BadRequest("mac is required");
+                await apMap.SaveApLocationAsync(req.Mac, req.Latitude, req.Longitude);
+                svc.InvalidateCache();
+                return Results.Ok();
             });
     }
 }

--- a/src/NetworkOptimizer.Web/Endpoints/LanFlowMapEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/LanFlowMapEndpoints.cs
@@ -5,7 +5,7 @@ namespace NetworkOptimizer.Web.Endpoints;
 
 public static class LanFlowMapEndpoints
 {
-    private record DevicePlacementRequest(string Mac, double Latitude, double Longitude);
+    private record DevicePlacementRequest(string Mac, double Latitude, double Longitude, int? Floor);
 
     public static void Map(WebApplication app)
     {
@@ -44,7 +44,7 @@ public static class LanFlowMapEndpoints
             {
                 if (string.IsNullOrWhiteSpace(req.Mac))
                     return Results.BadRequest("mac is required");
-                await apMap.SaveApLocationAsync(req.Mac, req.Latitude, req.Longitude);
+                await apMap.SaveApLocationAsync(req.Mac, req.Latitude, req.Longitude, req.Floor);
                 svc.InvalidateCache();
                 return Results.Ok();
             });

--- a/src/NetworkOptimizer.Web/Services/ApMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/ApMapService.cs
@@ -88,7 +88,7 @@ public class ApMapService
     /// <summary>
     /// Save an AP's map location (upsert by MAC address).
     /// </summary>
-    public async Task SaveApLocationAsync(string mac, double lat, double lng)
+    public async Task SaveApLocationAsync(string mac, double lat, double lng, int? floor = null)
     {
         var normalizedMac = mac.ToLowerInvariant();
 
@@ -98,6 +98,7 @@ public class ApMapService
         {
             existing.Latitude = lat;
             existing.Longitude = lng;
+            if (floor.HasValue) existing.Floor = floor.Value;
             existing.UpdatedAt = DateTime.UtcNow;
         }
         else
@@ -107,7 +108,7 @@ public class ApMapService
                 ApMac = normalizedMac,
                 Latitude = lat,
                 Longitude = lng,
-                Floor = 1,
+                Floor = floor ?? 1,
                 UpdatedAt = DateTime.UtcNow
             });
         }

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
@@ -258,6 +258,16 @@ public class LanFlowMapBounds
     /// <summary>Maximum extent of anchor coordinates so the JS layout can normalise.</summary>
     public double Radius { get; set; } = 1.0;
     public int AnchorCount { get; set; }
+
+    /// <summary>Projection centroid latitude (degrees). JS uses this to reverse-project
+    /// 3D scene coordinates back to geo for persistent device placement.</summary>
+    public double? CenterLat { get; set; }
+
+    /// <summary>Projection centroid longitude (degrees).</summary>
+    public double? CenterLng { get; set; }
+
+    /// <summary>Longitude cosine scale factor at centroid latitude.</summary>
+    public double? LngScale { get; set; }
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -74,8 +74,20 @@ public class LanFlowMapService
         var topology = await discovery.DiscoverTopologyAsync(ct);
 
         var markers = await _apMap.GetApMapMarkersAsync();
-        var anchors = ProjectAnchors(markers);
-        snapshot.Bounds = ComputeBounds(anchors);
+
+        // Load non-AP device placements (switches, gateways) from the same table.
+        using var db = await _dbFactory.CreateDbContextAsync();
+        var allLocations = await db.ApLocations.ToListAsync(ct);
+        var apMacs = new HashSet<string>(
+            markers.Select(m => m.Mac.ToLowerInvariant()),
+            StringComparer.OrdinalIgnoreCase);
+        var deviceLocations = allLocations
+            .Where(l => !apMacs.Contains(l.ApMac.ToLowerInvariant()))
+            .ToList();
+
+        var anchors = ProjectAnchors(markers, deviceLocations,
+            out var centerLat, out var centerLng, out var lngScale);
+        snapshot.Bounds = ComputeBounds(anchors, centerLat, centerLng, lngScale);
 
         var nameMaps = await LoadInterfaceNameMaps(ct);
 
@@ -604,22 +616,36 @@ public class LanFlowMapService
     // Internal: AP placement -> local Cartesian
     // ---------------------------------------------------------------------------------
 
-    private static Dictionary<string, LanPlacement> ProjectAnchors(IReadOnlyList<Web.Models.ApMapMarker> markers)
+    private static Dictionary<string, LanPlacement> ProjectAnchors(
+        IReadOnlyList<Web.Models.ApMapMarker> markers,
+        IReadOnlyList<Storage.Models.ApLocation> deviceLocations,
+        out double centerLat, out double centerLng, out double lngScale)
     {
+        centerLat = 0;
+        centerLng = 0;
+        lngScale = 1;
+
         var anchors = new Dictionary<string, LanPlacement>();
         var withCoords = markers
             .Where(m => m.Latitude.HasValue && m.Longitude.HasValue)
             .ToList();
-        if (withCoords.Count == 0) return anchors;
+        if (withCoords.Count == 0 && deviceLocations.Count == 0) return anchors;
 
-        // Project lat/lng to a local equirectangular frame centered on the centroid.
-        // Scale so 1 unit ~= 1 metre at the centroid latitude. Z = floor number * 3 metres
-        // (typical floor-to-floor distance). The JS layer normalises to its own scene
-        // units; we just need consistent local coordinates.
-        double centerLat = withCoords.Average(m => m.Latitude!.Value);
-        double centerLng = withCoords.Average(m => m.Longitude!.Value);
+        // Centroid is computed from AP markers only so that repositioning a
+        // switch/gateway doesn't shift the AP reference frame.
+        if (withCoords.Count > 0)
+        {
+            centerLat = withCoords.Average(m => m.Latitude!.Value);
+            centerLng = withCoords.Average(m => m.Longitude!.Value);
+        }
+        else
+        {
+            centerLat = deviceLocations.Average(d => d.Latitude);
+            centerLng = deviceLocations.Average(d => d.Longitude);
+        }
+
         const double earthRadiusMetres = 6_371_000.0;
-        double lngScale = Math.Cos(centerLat * Math.PI / 180.0);
+        lngScale = Math.Cos(centerLat * Math.PI / 180.0);
 
         foreach (var m in withCoords)
         {
@@ -636,23 +662,52 @@ public class LanFlowMapService
                 Source = LanPlacementSource.Anchor,
             };
         }
+
+        foreach (var d in deviceLocations)
+        {
+            var mac = NormalizeMac(d.ApMac);
+            if (anchors.ContainsKey(mac)) continue;
+            double dLat = (d.Latitude - centerLat) * Math.PI / 180.0;
+            double dLng = (d.Longitude - centerLng) * Math.PI / 180.0;
+            double x = dLng * lngScale * earthRadiusMetres;
+            double y = dLat * earthRadiusMetres;
+            double z = (d.Floor ?? 1) * 3.0;
+            anchors[mac] = new LanPlacement
+            {
+                X = x,
+                Y = y,
+                Z = z,
+                Source = LanPlacementSource.Anchor,
+            };
+        }
+
         return anchors;
     }
 
-    private static LanFlowMapBounds ComputeBounds(Dictionary<string, LanPlacement> anchors)
+    private static LanFlowMapBounds ComputeBounds(
+        Dictionary<string, LanPlacement> anchors,
+        double centerLat, double centerLng, double lngScale)
     {
-        if (anchors.Count == 0) return new LanFlowMapBounds { Radius = 1.0, AnchorCount = 0 };
+        var bounds = new LanFlowMapBounds
+        {
+            AnchorCount = anchors.Count,
+        };
+        if (anchors.Count == 0)
+        {
+            bounds.Radius = 1.0;
+            return bounds;
+        }
         double maxR = 0;
         foreach (var p in anchors.Values)
         {
             var r = Math.Sqrt(p.X * p.X + p.Y * p.Y + p.Z * p.Z);
             if (r > maxR) maxR = r;
         }
-        return new LanFlowMapBounds
-        {
-            Radius = Math.Max(maxR, 1.0),
-            AnchorCount = anchors.Count,
-        };
+        bounds.Radius = Math.Max(maxR, 1.0);
+        bounds.CenterLat = centerLat;
+        bounds.CenterLng = centerLng;
+        bounds.LngScale = lngScale;
+        return bounds;
     }
 
     // ---------------------------------------------------------------------------------

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -110,7 +110,7 @@ public class LanFlowMapService
             .ToDictionary(d => NormalizeMac(d.Mac), d => d, StringComparer.OrdinalIgnoreCase);
 
         BuildInfrastructureGraph(topology, anchors, snapshot, nameMaps);
-        BuildClientLeaves(topology, snapshot, nameMaps, rawByMac);
+        BuildClientLeaves(topology, anchors, snapshot, nameMaps, rawByMac);
         GroupMultiClientPorts(snapshot);
         await BuildWanAndClouds(topology, snapshot, ct);
 
@@ -791,6 +791,7 @@ public class LanFlowMapService
 
     private void BuildClientLeaves(
         NetworkTopology topology,
+        Dictionary<string, LanPlacement> anchors,
         LanFlowMapSnapshot snapshot,
         Dictionary<(string mac, int port), InterfaceNameMap> nameMaps,
         Dictionary<string, NetworkOptimizer.UniFi.Models.UniFiDeviceResponse> rawByMac)
@@ -802,6 +803,7 @@ public class LanFlowMapService
             if (string.IsNullOrEmpty(c.ConnectedToDeviceMac)) continue;
             var parentMac = NormalizeMac(c.ConnectedToDeviceMac);
 
+            anchors.TryGetValue(clientMac, out var anchor);
             var nodeId = "cli-" + clientMac;
             var node = new LanNode
             {
@@ -811,6 +813,7 @@ public class LanFlowMapService
                 Ip = string.IsNullOrEmpty(c.IpAddress) ? null : c.IpAddress,
                 Name = ResolveClientLabel(c),
                 ParentId = "dev-" + parentMac,
+                Placement = anchor,
                 Network = c.Network,
                 IsGuest = c.IsGuest,
                 Ssid = c.Essid,

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14588,3 +14588,57 @@ a.affected-client:hover {
         display: none;
     }
 }
+.lan-flow-map-context-menu {
+    position: absolute;
+    z-index: 20;
+    background: rgba(16, 24, 32, 0.95);
+    border: 1px solid rgba(255, 255, 255, 0.10);
+    border-radius: 6px;
+    padding: 4px 0;
+    min-width: 160px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+.lan-flow-map-context-menu-item {
+    padding: 7px 14px;
+    font-size: 0.82rem;
+    color: var(--text-primary);
+    cursor: pointer;
+    user-select: none;
+}
+.lan-flow-map-context-menu-item:hover {
+    background: var(--bg-hover);
+}
+.lan-flow-map-reposition-hud {
+    position: absolute;
+    top: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 15;
+    background: rgba(16, 24, 32, 0.92);
+    border: 1px solid var(--primary-color);
+    border-radius: 8px;
+    padding: 8px 16px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 0.82rem;
+    color: var(--text-primary);
+    white-space: nowrap;
+}
+.lan-flow-map-reposition-title {
+    font-weight: 500;
+    color: var(--primary-hover);
+}
+.lan-flow-map-reposition-keys {
+    color: var(--text-secondary);
+}
+.lan-flow-map-reposition-keys .kbd {
+    display: inline-block;
+    padding: 1px 5px;
+    font-size: 0.72rem;
+    background: var(--bg-tertiary);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 3px;
+    font-family: inherit;
+    line-height: 1.4;
+}

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -156,6 +156,12 @@ export class LanFlowMap {
         this._pointerScreen = { x: 0, y: 0 };
         this._hoverTarget = null;
 
+        // Reposition mode state
+        this._repositionMode = false;
+        this._repositionNode = null;   // node being moved
+        this._repositionGroup = null;  // THREE.Group for the node
+        this._repositionOrigPos = null; // original position for cancel
+
         this._raf = null;
         this._pollTimer = null;
         this._lastFrame = performance.now();
@@ -246,11 +252,20 @@ export class LanFlowMap {
         this.canvas.addEventListener('pointermove', (e) => this._onPointerMove(e));
         this.canvas.addEventListener('pointerleave', () => this._clearHover());
         this.canvas.addEventListener('dblclick', (e) => this._onDoubleClick(e));
+        this.canvas.addEventListener('contextmenu', (e) => this._onContextMenu(e));
+        this.canvas.addEventListener('pointerdown', (e) => {
+            if (this._repositionMode) return;
+            this._dismissContextMenu();
+        });
 
         // WASD keyboard navigation: W/S = zoom in/out, A/D = orbit left/right
         this._keys = {};
         this._onKeyDown = (e) => {
             if (e.key === 'Escape') {
+                if (this._repositionMode) {
+                    this._cancelReposition();
+                    return;
+                }
                 if (this.stage?.classList.contains('lan-flow-map-fullscreen')) {
                     this._toggleFullscreen();
                     return;
@@ -323,6 +338,8 @@ export class LanFlowMap {
 
     dispose() {
         this._destroyed = true;
+        if (this._repositionMode) this._exitRepositionMode();
+        this._dismissContextMenu();
         // The render loop registered via setAnimationLoop checks _destroyed
         // and tears itself down. Belt-and-suspenders null it here too.
         this.renderer?.setAnimationLoop(null);
@@ -1031,6 +1048,27 @@ export class LanFlowMap {
                 const eased = 1 - Math.pow(1 - t, 3);
                 this.camera.position.lerpVectors(this._flyInStartCam, this._flyInTargetCam, eased);
                 this.camera.lookAt(0, 0, 0);
+            } else if (this._repositionMode && this._repositionGroup) {
+                // In reposition mode WASD nudges the device on the XZ plane
+                if (this._keys) {
+                    const step = 0.35;
+                    const cam = this.camera;
+                    const forward = new THREE.Vector3();
+                    cam.getWorldDirection(forward);
+                    forward.y = 0;
+                    forward.normalize();
+                    const right = new THREE.Vector3();
+                    right.crossVectors(forward, cam.up).normalize();
+
+                    const g = this._repositionGroup;
+                    if (this._keys['w']) { g.position.x += forward.x * step; g.position.z += forward.z * step; }
+                    if (this._keys['s']) { g.position.x -= forward.x * step; g.position.z -= forward.z * step; }
+                    if (this._keys['d']) { g.position.x += right.x * step; g.position.z += right.z * step; }
+                    if (this._keys['a']) { g.position.x -= right.x * step; g.position.z -= right.z * step; }
+                    if (this._keys['w'] || this._keys['a'] || this._keys['s'] || this._keys['d']) {
+                        this._updateAdjacentLinks();
+                    }
+                }
             } else {
                 // WASD: W/S zoom, A/D orbit around target
                 if (this._keys) {
@@ -1939,6 +1977,7 @@ export class LanFlowMap {
         this._pointerScreen.y = e.clientY - rect.top;
         this._pointerNdc.x = (this._pointerScreen.x / rect.width) * 2 - 1;
         this._pointerNdc.y = -(this._pointerScreen.y / rect.height) * 2 + 1;
+        if (this._repositionMode) return;
         this._raycaster.setFromCamera(this._pointerNdc, this.camera);
         // Raycast against device node spheres - cheap, ~tens of meshes.
         const candidates = [];
@@ -1959,6 +1998,7 @@ export class LanFlowMap {
     }
 
     _onDoubleClick(e) {
+        if (this._repositionMode) return;
         const rect = this.canvas.getBoundingClientRect();
         const ndc = new THREE.Vector2(
             ((e.clientX - rect.left) / rect.width) * 2 - 1,
@@ -2081,6 +2121,258 @@ export class LanFlowMap {
     _clearHover() {
         if (this._tooltipEl) this._tooltipEl.classList.remove('is-visible');
         this._hoverTarget = null;
+    }
+
+    // ------------------------------------------------------------------------
+    // Right-click context menu + device reposition
+    // ------------------------------------------------------------------------
+
+    _onContextMenu(e) {
+        e.preventDefault();
+        if (this._repositionMode) return;
+
+        const rect = this.canvas.getBoundingClientRect();
+        const ndc = new THREE.Vector2(
+            ((e.clientX - rect.left) / rect.width) * 2 - 1,
+            -((e.clientY - rect.top) / rect.height) * 2 + 1
+        );
+        this._raycaster.setFromCamera(ndc, this.camera);
+        const candidates = [];
+        for (const group of this._nodeMeshes.values()) {
+            if (!group.visible) continue;
+            for (const child of group.children) {
+                if (child.isMesh) candidates.push(child);
+            }
+        }
+        const hits = this._raycaster.intersectObjects(candidates, false);
+        if (hits.length === 0) return;
+        let g = hits[0].object;
+        while (g && !(g.userData?.node)) g = g.parent;
+        if (!g) return;
+        const node = g.userData.node;
+        if (node.kind !== NODE_KIND.Gateway && node.kind !== NODE_KIND.Switch && node.kind !== NODE_KIND.AccessPoint) return;
+
+        this._showContextMenu(e.clientX, e.clientY, node, g);
+    }
+
+    _showContextMenu(clientX, clientY, node, group) {
+        this._dismissContextMenu();
+        const menu = document.createElement('div');
+        menu.className = 'lan-flow-map-context-menu';
+        const item = document.createElement('div');
+        item.className = 'lan-flow-map-context-menu-item';
+        item.textContent = 'Reposition Device';
+        item.addEventListener('click', (e) => {
+            e.stopPropagation();
+            this._dismissContextMenu();
+            this._enterReposition(node, group);
+        });
+        menu.appendChild(item);
+
+        const stageRect = this.stage.getBoundingClientRect();
+        menu.style.left = `${clientX - stageRect.left}px`;
+        menu.style.top = `${clientY - stageRect.top}px`;
+        this.stage.appendChild(menu);
+        this._contextMenuEl = menu;
+    }
+
+    _dismissContextMenu() {
+        if (this._contextMenuEl) {
+            this._contextMenuEl.remove();
+            this._contextMenuEl = null;
+        }
+    }
+
+    _enterReposition(node, group) {
+        this._repositionMode = true;
+        this._repositionNode = node;
+        this._repositionGroup = group;
+        this._repositionOrigPos = group.position.clone();
+        this._clearHover();
+
+        this.controls.enabled = false;
+        this.canvas.style.cursor = 'move';
+
+        // Show the reposition HUD banner
+        const hud = document.createElement('div');
+        hud.className = 'lan-flow-map-reposition-hud';
+        hud.innerHTML = `
+            <span class="lan-flow-map-reposition-title">Moving: ${escapeHtml(node.name || node.mac || 'Device')}</span>
+            <span class="lan-flow-map-reposition-keys">
+                <span class="kbd">W</span><span class="kbd">A</span><span class="kbd">S</span><span class="kbd">D</span> to nudge
+                &nbsp;&middot;&nbsp; Drag to move
+                &nbsp;&middot;&nbsp; <span class="kbd">Click</span> to place
+                &nbsp;&middot;&nbsp; <span class="kbd">Esc</span> to cancel
+            </span>
+        `;
+        this.stage.appendChild(hud);
+        this._repositionHud = hud;
+
+        // Set up mouse-drag on the XZ plane at the device's Y height.
+        // Confirm on pointerup only if the pointer barely moved (click, not drag).
+        this._repositionDragging = false;
+        this._repositionDragMoved = false;
+        this._repositionDownPt = null;
+        this._repositionPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), -group.position.y);
+        this._repositionMoveHandler = (e) => this._onRepositionPointerMove(e);
+        this._repositionDownHandler = (e) => {
+            if (e.button === 0) {
+                this._repositionDragging = true;
+                this._repositionDragMoved = false;
+                this._repositionDownPt = { x: e.clientX, y: e.clientY };
+                e.preventDefault();
+            }
+        };
+        this._repositionUpHandler = (e) => {
+            if (e.button === 0 && this._repositionMode) {
+                this._repositionDragging = false;
+                if (!this._repositionDragMoved) {
+                    this._confirmReposition();
+                }
+            }
+        };
+        this.canvas.addEventListener('pointermove', this._repositionMoveHandler);
+        this.canvas.addEventListener('pointerdown', this._repositionDownHandler, true);
+        this.canvas.addEventListener('pointerup', this._repositionUpHandler);
+    }
+
+    _onRepositionPointerMove(e) {
+        if (!this._repositionMode || !this._repositionDragging) return;
+
+        // Track whether the pointer actually moved (drag vs click)
+        if (this._repositionDownPt) {
+            const dx = e.clientX - this._repositionDownPt.x;
+            const dy = e.clientY - this._repositionDownPt.y;
+            if (dx * dx + dy * dy > 9) this._repositionDragMoved = true;
+        }
+        if (!this._repositionDragMoved) return;
+
+        const rect = this.canvas.getBoundingClientRect();
+        const ndc = new THREE.Vector2(
+            ((e.clientX - rect.left) / rect.width) * 2 - 1,
+            -((e.clientY - rect.top) / rect.height) * 2 + 1
+        );
+        this._raycaster.setFromCamera(ndc, this.camera);
+        const intersection = new THREE.Vector3();
+        if (this._raycaster.ray.intersectPlane(this._repositionPlane, intersection)) {
+            this._repositionGroup.position.x = intersection.x;
+            this._repositionGroup.position.z = intersection.z;
+            this._updateAdjacentLinks();
+        }
+    }
+
+    _updateAdjacentLinks() {
+        if (!this._repositionNode) return;
+        const nodeId = this._repositionNode.id;
+        const pos = this._repositionGroup.position;
+
+        for (const [linkId, linkObj] of this._linkMeshes) {
+            if (linkObj.link.fromNodeId !== nodeId && linkObj.link.toNodeId !== nodeId) continue;
+            const otherNodeId = linkObj.link.fromNodeId === nodeId ? linkObj.link.toNodeId : linkObj.link.fromNodeId;
+            const otherGroup = this._nodeMeshes.get(otherNodeId);
+            if (!otherGroup) continue;
+
+            const a = linkObj.link.fromNodeId === nodeId ? pos : otherGroup.position;
+            const b = linkObj.link.toNodeId === nodeId ? pos : otherGroup.position;
+
+            // Update pipe mesh
+            this._updatePipePosition(linkObj.pipe, a, b);
+            // Update particle stream endpoints
+            if (linkObj.link.fromNodeId === nodeId) {
+                linkObj.down.updateEndpoints(pos, otherGroup.position);
+                linkObj.up.updateEndpoints(otherGroup.position, pos);
+            } else {
+                linkObj.down.updateEndpoints(otherGroup.position, pos);
+                linkObj.up.updateEndpoints(pos, otherGroup.position);
+            }
+        }
+    }
+
+    _updatePipePosition(pipe, a, b) {
+        if (!pipe.isMesh) return;
+        const from = new THREE.Vector3(a.x, a.y, a.z);
+        const to = new THREE.Vector3(b.x, b.y, b.z);
+        const dir = to.clone().sub(from);
+        const length = dir.length();
+        if (length < 0.01) return;
+
+        const mid = from.clone().add(to).multiplyScalar(0.5);
+        pipe.position.copy(mid);
+        pipe.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), dir.clone().normalize());
+        const origHeight = pipe.geometry.parameters?.height || 1;
+        pipe.scale.y = length / origHeight;
+    }
+
+    async _confirmReposition() {
+        if (!this._repositionMode) return;
+        const group = this._repositionGroup;
+        const node = this._repositionNode;
+        const pos = { x: group.position.x, y: group.position.y, z: group.position.z };
+
+        this._exitRepositionMode();
+
+        // Update the internal positions map
+        this._positions.set(node.id, {
+            x: pos.x, y: pos.y, z: pos.z, pinned: true,
+        });
+
+        // Reverse-project 3D scene coords back to geo
+        const bounds = this._snapshot?.bounds;
+        if (!bounds?.centerLat || !bounds?.lngScale) {
+            console.warn('[LanFlowMap] No projection params - cannot save placement');
+            return;
+        }
+        const sceneRadius = 30.0;
+        const ANCHOR_SPREAD_FACTOR = 1.5;
+        const scale = (sceneRadius / Math.max(bounds.radius, 1.0)) * ANCHOR_SPREAD_FACTOR;
+        const EARTH_RADIUS = 6_371_000.0;
+
+        // Undo JS transform: posX = local.x * scale, posZ = local.y * scale
+        // (posY = local.z * scale * 0.4 but we don't save floor from 3D)
+        const localX = pos.x / scale;
+        const localY = pos.z / scale; // JS z maps to projection y
+
+        // Undo equirectangular projection
+        const dLng = localX / (bounds.lngScale * EARTH_RADIUS);
+        const dLat = localY / EARTH_RADIUS;
+        const lat = bounds.centerLat + dLat * 180 / Math.PI;
+        const lng = bounds.centerLng + dLng * 180 / Math.PI;
+
+        try {
+            await fetch(`${this.apiBase}/device-placement`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                credentials: 'same-origin',
+                body: JSON.stringify({ mac: node.mac, latitude: lat, longitude: lng }),
+            });
+        } catch (err) {
+            console.error('[LanFlowMap] Failed to save placement:', err);
+        }
+    }
+
+    _cancelReposition() {
+        if (!this._repositionMode) return;
+        this._repositionGroup.position.copy(this._repositionOrigPos);
+        this._updateAdjacentLinks();
+        this._exitRepositionMode();
+    }
+
+    _exitRepositionMode() {
+        this._repositionMode = false;
+        this._repositionNode = null;
+        this._repositionGroup = null;
+        this._repositionOrigPos = null;
+        this._repositionDragging = false;
+        this._repositionDragMoved = false;
+        this._repositionDownPt = null;
+
+        this.controls.enabled = true;
+        this.canvas.style.cursor = '';
+
+        if (this._repositionHud) { this._repositionHud.remove(); this._repositionHud = null; }
+        this.canvas.removeEventListener('pointermove', this._repositionMoveHandler);
+        this.canvas.removeEventListener('pointerdown', this._repositionDownHandler, true);
+        this.canvas.removeEventListener('pointerup', this._repositionUpHandler);
     }
 }
 
@@ -2229,6 +2521,14 @@ class ParticleStream {
         // Velocity: 2.5 idle -> 6.5 saturated. Still communicates throughput
         // without slamming between crawl and jet on per-poll rate fluctuations.
         this._velocity = 2.5 + intensity * 4.0;
+    }
+
+    updateEndpoints(from, to) {
+        this._from.set(from.x, from.y, from.z);
+        this._to.set(to.x, to.y, to.z);
+        this._direction.copy(this._to).sub(this._from);
+        this._length = this._direction.length();
+        this._direction.normalize();
     }
 
     advance(dt) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1351,6 +1351,7 @@ export class LanFlowMap {
                 <div class="lan-flow-map-help-row"><span>Zoom</span><span class="kbd">Scroll</span> or <span class="kbd">W</span> <span class="kbd">S</span></div>
                 <div class="lan-flow-map-help-row"><span>Hover detail</span><span class="kbd">Mouse over</span></div>
                 <div class="lan-flow-map-help-row"><span>Open client</span><span class="kbd">Double-click</span></div>
+                <div class="lan-flow-map-help-row"><span>Move device</span><span class="kbd">Right-click</span></div>
                 <div class="lan-flow-map-help-row"><span>Fullscreen</span><span class="kbd">Esc</span> to exit</div>
             </div>
         `;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -272,7 +272,7 @@ export class LanFlowMap {
                 }
             }
             if (!this._shouldAcceptKeys()) return;
-            if (['w','a','s','d'].includes(e.key.toLowerCase())) {
+            if (['w','a','s','d','q','e'].includes(e.key.toLowerCase())) {
                 this._keys[e.key.toLowerCase()] = true;
             }
         };
@@ -447,7 +447,7 @@ export class LanFlowMap {
         // and then spread by ANCHOR_SPREAD_FACTOR so interpolated / unanchored
         // devices have room to settle between the pinned APs without crowding.
         const sceneRadius = 30.0;
-        const ANCHOR_SPREAD_FACTOR = 1.5;
+        const ANCHOR_SPREAD_FACTOR = 1.875;
         const scale = (sceneRadius / Math.max(bounds.radius, 1.0)) * ANCHOR_SPREAD_FACTOR;
 
         const positions = new Map();
@@ -1065,7 +1065,9 @@ export class LanFlowMap {
                     if (this._keys['s']) { g.position.x -= forward.x * step; g.position.z -= forward.z * step; }
                     if (this._keys['d']) { g.position.x += right.x * step; g.position.z += right.z * step; }
                     if (this._keys['a']) { g.position.x -= right.x * step; g.position.z -= right.z * step; }
-                    if (this._keys['w'] || this._keys['a'] || this._keys['s'] || this._keys['d']) {
+                    if (this._keys['e']) { g.position.y += step; this._repositionPlane.constant = -g.position.y; }
+                    if (this._keys['q']) { g.position.y -= step; this._repositionPlane.constant = -g.position.y; }
+                    if (this._keys['w'] || this._keys['a'] || this._keys['s'] || this._keys['d'] || this._keys['q'] || this._keys['e']) {
                         this._updateAdjacentLinks();
                     }
                 }
@@ -2200,10 +2202,11 @@ export class LanFlowMap {
         hud.innerHTML = `
             <span class="lan-flow-map-reposition-title">Moving: ${escapeHtml(node.name || node.mac || 'Device')}</span>
             <span class="lan-flow-map-reposition-keys">
-                <span class="kbd">W</span><span class="kbd">A</span><span class="kbd">S</span><span class="kbd">D</span> to nudge
+                <span class="kbd">W</span><span class="kbd">A</span><span class="kbd">S</span><span class="kbd">D</span> move
+                &nbsp;&middot;&nbsp; <span class="kbd">Q</span><span class="kbd">E</span> / <span class="kbd">Scroll</span> height
                 &nbsp;&middot;&nbsp; Drag to move
-                &nbsp;&middot;&nbsp; <span class="kbd">Click</span> to place
-                &nbsp;&middot;&nbsp; <span class="kbd">Esc</span> to cancel
+                &nbsp;&middot;&nbsp; <span class="kbd">Click</span> place
+                &nbsp;&middot;&nbsp; <span class="kbd">Esc</span> cancel
             </span>
         `;
         this.stage.appendChild(hud);
@@ -2232,9 +2235,18 @@ export class LanFlowMap {
                 }
             }
         };
+        this._repositionWheelHandler = (e) => {
+            if (!this._repositionMode) return;
+            e.preventDefault();
+            const step = e.deltaY > 0 ? -0.5 : 0.5;
+            this._repositionGroup.position.y += step;
+            this._repositionPlane.constant = -this._repositionGroup.position.y;
+            this._updateAdjacentLinks();
+        };
         this.canvas.addEventListener('pointermove', this._repositionMoveHandler);
         this.canvas.addEventListener('pointerdown', this._repositionDownHandler, true);
         this.canvas.addEventListener('pointerup', this._repositionUpHandler);
+        this.canvas.addEventListener('wheel', this._repositionWheelHandler, { passive: false });
     }
 
     _onRepositionPointerMove(e) {
@@ -2324,7 +2336,7 @@ export class LanFlowMap {
             return;
         }
         const sceneRadius = 30.0;
-        const ANCHOR_SPREAD_FACTOR = 1.5;
+        const ANCHOR_SPREAD_FACTOR = 1.875;
         const scale = (sceneRadius / Math.max(bounds.radius, 1.0)) * ANCHOR_SPREAD_FACTOR;
         const EARTH_RADIUS = 6_371_000.0;
 
@@ -2374,6 +2386,7 @@ export class LanFlowMap {
         this.canvas.removeEventListener('pointermove', this._repositionMoveHandler);
         this.canvas.removeEventListener('pointerdown', this._repositionDownHandler, true);
         this.canvas.removeEventListener('pointerup', this._repositionUpHandler);
+        this.canvas.removeEventListener('wheel', this._repositionWheelHandler);
     }
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2153,7 +2153,7 @@ export class LanFlowMap {
         while (g && !(g.userData?.node)) g = g.parent;
         if (!g) return;
         const node = g.userData.node;
-        if (node.kind !== NODE_KIND.Gateway && node.kind !== NODE_KIND.Switch && node.kind !== NODE_KIND.AccessPoint) return;
+        if (node.kind !== NODE_KIND.Gateway && node.kind !== NODE_KIND.Switch) return;
 
         this._showContextMenu(e.clientX, e.clientY, node, g);
     }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -458,7 +458,7 @@ export class LanFlowMap {
             if (p && p.source === PLACEMENT_SOURCE.Anchor) {
                 positions.set(node.id, {
                     x: -p.x * scale,
-                    y: p.z * scale * 0.4,    // floors get vertical separation but compressed
+                    y: p.z * scale * 0.8,    // floors get vertical separation but compressed
                     z: p.y * scale,
                     pinned: true,
                 });
@@ -466,7 +466,7 @@ export class LanFlowMap {
             } else if (p && p.source === PLACEMENT_SOURCE.Interpolated) {
                 positions.set(node.id, {
                     x: -p.x * scale,
-                    y: p.z * scale * 0.4 - 4,
+                    y: p.z * scale * 0.8 - 4,
                     z: p.y * scale,
                     pinned: false,
                 });
@@ -2341,7 +2341,7 @@ export class LanFlowMap {
         const EARTH_RADIUS = 6_371_000.0;
 
         // Undo JS transform: posX = -(local.x * scale), posZ = local.y * scale
-        // (posY = local.z * scale * 0.4 but we don't save floor from 3D)
+        // (posY = local.z * scale * 0.8 but we don't save floor from 3D)
         const localX = -(pos.x / scale);
         const localY = pos.z / scale; // JS z maps to projection y
 
@@ -2351,8 +2351,8 @@ export class LanFlowMap {
         const lat = bounds.centerLat + dLat * 180 / Math.PI;
         const lng = bounds.centerLng + dLng * 180 / Math.PI;
 
-        // Reverse Y → floor: posY = floor * 3.0 * scale * 0.4
-        const floor = Math.max(1, Math.round(pos.y / (scale * 0.4) / 3.0));
+        // Reverse Y → floor: posY = floor * 3.0 * scale * 0.8
+        const floor = Math.max(1, Math.round(pos.y / (scale * 0.8) / 3.0));
 
         try {
             await fetch(`${this.apiBase}/device-placement`, {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -557,6 +557,27 @@ export class LanFlowMap {
             }
         }
 
+        // Post-layout: push WiFi clients outward from their parent AP so they
+        // fan out rather than clustering tightly around the infrastructure.
+        const WIFI_SPREAD = 1.8;
+        for (const node of snap.nodes) {
+            if (node.kind !== NODE_KIND.WifiClient) continue;
+            const p = positions.get(node.id);
+            if (!p || p.pinned) continue;
+            const parentId = node.parentId;
+            if (!parentId) continue;
+            const pp = positions.get(parentId);
+            if (!pp) continue;
+            const dx = p.x - pp.x;
+            const dy = p.y - pp.y;
+            const dz = p.z - pp.z;
+            const d = Math.sqrt(dx * dx + dy * dy + dz * dz);
+            if (d < 0.1) continue;
+            p.x = pp.x + dx * WIFI_SPREAD;
+            p.y = pp.y + dy * WIFI_SPREAD;
+            p.z = pp.z + dz * WIFI_SPREAD;
+        }
+
         this._positions = positions;
     }
 
@@ -2153,7 +2174,7 @@ export class LanFlowMap {
         while (g && !(g.userData?.node)) g = g.parent;
         if (!g) return;
         const node = g.userData.node;
-        if (node.kind !== NODE_KIND.Gateway && node.kind !== NODE_KIND.Switch) return;
+        if (node.kind !== NODE_KIND.Gateway && node.kind !== NODE_KIND.Switch && node.kind !== NODE_KIND.WiredClient) return;
 
         this._showContextMenu(e.clientX, e.clientY, node, g);
     }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2279,10 +2279,33 @@ export class LanFlowMap {
         const nodeId = this._repositionNode.id;
         const pos = this._repositionGroup.position;
 
+        // If moving a gateway, drag all connected clouds along (they're positioned
+        // relative to the gateway and have no independent geo coords).
+        if (this._repositionNode.kind === NODE_KIND.Gateway) {
+            if (!this._repositionCloudOffsets) {
+                this._repositionCloudOffsets = new Map();
+                for (const [cloudId, group] of this._cloudMeshes) {
+                    this._repositionCloudOffsets.set(cloudId, {
+                        dx: group.position.x - this._repositionOrigPos.x,
+                        dy: group.position.y - this._repositionOrigPos.y,
+                        dz: group.position.z - this._repositionOrigPos.z,
+                    });
+                }
+            }
+            for (const [cloudId, offset] of this._repositionCloudOffsets) {
+                const group = this._cloudMeshes.get(cloudId);
+                if (!group) continue;
+                group.position.set(pos.x + offset.dx, pos.y + offset.dy, pos.z + offset.dz);
+                this._positions.set(cloudId, {
+                    x: group.position.x, y: group.position.y, z: group.position.z, pinned: true,
+                });
+            }
+        }
+
         for (const [linkId, linkObj] of this._linkMeshes) {
             if (linkObj.link.fromNodeId !== nodeId && linkObj.link.toNodeId !== nodeId) continue;
             const otherNodeId = linkObj.link.fromNodeId === nodeId ? linkObj.link.toNodeId : linkObj.link.fromNodeId;
-            const otherGroup = this._nodeMeshes.get(otherNodeId);
+            const otherGroup = this._nodeMeshes.get(otherNodeId) || this._cloudMeshes.get(otherNodeId);
             if (!otherGroup) continue;
 
             const a = linkObj.link.fromNodeId === nodeId ? pos : otherGroup.position;
@@ -2369,6 +2392,18 @@ export class LanFlowMap {
     _cancelReposition() {
         if (!this._repositionMode) return;
         this._repositionGroup.position.copy(this._repositionOrigPos);
+        // Restore cloud positions if we moved a gateway
+        if (this._repositionCloudOffsets) {
+            for (const [cloudId, offset] of this._repositionCloudOffsets) {
+                const group = this._cloudMeshes.get(cloudId);
+                if (!group) continue;
+                group.position.set(
+                    this._repositionOrigPos.x + offset.dx,
+                    this._repositionOrigPos.y + offset.dy,
+                    this._repositionOrigPos.z + offset.dz,
+                );
+            }
+        }
         this._updateAdjacentLinks();
         this._exitRepositionMode();
     }
@@ -2381,6 +2416,7 @@ export class LanFlowMap {
         this._repositionDragging = false;
         this._repositionDragMoved = false;
         this._repositionDownPt = null;
+        this._repositionCloudOffsets = null;
 
         this.controls.enabled = true;
         this.canvas.style.cursor = '';

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -559,7 +559,7 @@ export class LanFlowMap {
 
         // Post-layout: push WiFi clients outward from their parent AP so they
         // fan out rather than clustering tightly around the infrastructure.
-        const WIFI_SPREAD = 1.8;
+        const WIFI_SPREAD = 1.4;
         for (const node of snap.nodes) {
             if (node.kind !== NODE_KIND.WifiClient) continue;
             const p = positions.get(node.id);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -457,7 +457,7 @@ export class LanFlowMap {
             const p = node.placement;
             if (p && p.source === PLACEMENT_SOURCE.Anchor) {
                 positions.set(node.id, {
-                    x: p.x * scale,
+                    x: -p.x * scale,
                     y: p.z * scale * 0.4,    // floors get vertical separation but compressed
                     z: p.y * scale,
                     pinned: true,
@@ -465,7 +465,7 @@ export class LanFlowMap {
                 anchors.set(node.id, true);
             } else if (p && p.source === PLACEMENT_SOURCE.Interpolated) {
                 positions.set(node.id, {
-                    x: p.x * scale,
+                    x: -p.x * scale,
                     y: p.z * scale * 0.4 - 4,
                     z: p.y * scale,
                     pinned: false,
@@ -2328,9 +2328,9 @@ export class LanFlowMap {
         const scale = (sceneRadius / Math.max(bounds.radius, 1.0)) * ANCHOR_SPREAD_FACTOR;
         const EARTH_RADIUS = 6_371_000.0;
 
-        // Undo JS transform: posX = local.x * scale, posZ = local.y * scale
+        // Undo JS transform: posX = -(local.x * scale), posZ = local.y * scale
         // (posY = local.z * scale * 0.4 but we don't save floor from 3D)
-        const localX = pos.x / scale;
+        const localX = -(pos.x / scale);
         const localY = pos.z / scale; // JS z maps to projection y
 
         // Undo equirectangular projection

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2351,12 +2351,15 @@ export class LanFlowMap {
         const lat = bounds.centerLat + dLat * 180 / Math.PI;
         const lng = bounds.centerLng + dLng * 180 / Math.PI;
 
+        // Reverse Y → floor: posY = floor * 3.0 * scale * 0.4
+        const floor = Math.max(1, Math.round(pos.y / (scale * 0.4) / 3.0));
+
         try {
             await fetch(`${this.apiBase}/device-placement`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 credentials: 'same-origin',
-                body: JSON.stringify({ mac: node.mac, latitude: lat, longitude: lng }),
+                body: JSON.stringify({ mac: node.mac, latitude: lat, longitude: lng, floor }),
             });
         } catch (err) {
             console.error('[LanFlowMap] Failed to save placement:', err);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2352,7 +2352,7 @@ export class LanFlowMap {
         const lng = bounds.centerLng + dLng * 180 / Math.PI;
 
         // Reverse Y → floor: posY = floor * 3.0 * scale * 0.8
-        const floor = Math.max(1, Math.round(pos.y / (scale * 0.8) / 3.0));
+        const floor = Math.round(pos.y / (scale * 0.8) / 3.0);
 
         try {
             await fetch(`${this.apiBase}/device-placement`, {


### PR DESCRIPTION
## Summary

- **Right-click context menu** on switches, gateways, and wired clients in the 3D LAN Flow Map to reposition them
- **Reposition mode** with WASD horizontal movement, Q/E and scroll wheel for height, drag to move, click to confirm, Esc to cancel
- **Persistent placement** - 3D positions are reverse-projected to geo coordinates and saved to the ApLocations table alongside AP placements
- **Gateway cloud dragging** - WAN clouds maintain their offset when repositioning the gateway
- **WiFi client spread** - post-layout pass pushes WiFi clients 1.4x outward from their parent AP for better visual separation
- **Layout tuning** - anchor spread factor increased 25% (1.5 to 1.875), per-floor vertical separation doubled (0.4 to 0.8), E-W mirror fix for geo projection

## Backend

- `LanFlowMapBounds` now includes projection centroid (lat, lng, lngScale) so JS can reverse-project
- `ProjectAnchors` loads non-AP device placements from ApLocations and projects them as anchors
- `BuildClientLeaves` checks anchors dict for wired client placements
- New `POST /api/monitoring/lan-flow-map/device-placement` endpoint saves placement and invalidates snapshot cache
- `SaveApLocationAsync` accepts optional floor parameter

## Test plan

- [x] Right-click a switch - context menu appears with "Reposition Device"
- [x] Enter reposition mode - HUD banner shows, OrbitControls disabled
- [x] WASD moves device horizontally, Q/E and scroll adjust height
- [x] Drag to move, click to confirm, Esc to cancel (restores original position)
- [x] Placement persists after page reload
- [x] Moving gateway drags WAN clouds along, cancel restores them
- [x] WiFi clients fan out from their parent APs
- [x] Right-click on WiFi client or AP does NOT show context menu
- [x] Right-click on wired client shows context menu and placement persists