### PR TITLE
v1.17.4

### DIFF
--- a/src/NetworkOptimizer.Monitoring/Probes/LocalProbeExecutor.cs
+++ b/src/NetworkOptimizer.Monitoring/Probes/LocalProbeExecutor.cs
@@ -132,12 +132,10 @@ public class LocalProbeExecutor : IProbeExecutor
 
     private async Task<PingProbeResult> NativePingAsync(ProbeTarget target, int count, TimeSpan timeout, CancellationToken ct)
     {
-        // Fast burst: 0.1s interval on macOS (BSD ping allows it for non-root),
-        // 0.2s floor on Linux (iputils enforces minimum for non-root).
+        // Fixed interval per platform: 0.1s on macOS (BSD ping allows it),
+        // 0.15s on Linux. 10 pings completes in 0.9s / 1.35s respectively.
         var safeCount = Math.Max(1, count);
-        var minInterval = OperatingSystem.IsMacOS() ? 0.1 : 0.15;
-        var rawInterval = safeCount > 1 ? 1.5 / (safeCount - 1) : minInterval;
-        var interval = Math.Max(minInterval, Math.Round(rawInterval, 2));
+        var interval = OperatingSystem.IsMacOS() ? 0.1 : 0.15;
         var timeoutSeconds = Math.Max(1, (int)Math.Ceiling(timeout.TotalSeconds));
 
         // Two BSD-vs-iputils gotchas: ping has no -4 on macOS (it aborts with

--- a/src/NetworkOptimizer.Monitoring/Probes/LocalProbeExecutor.cs
+++ b/src/NetworkOptimizer.Monitoring/Probes/LocalProbeExecutor.cs
@@ -27,12 +27,13 @@ public class LocalProbeExecutor : IProbeExecutor
     private readonly SemaphoreSlim _capabilityLock = new(1, 1);
     private bool _tracerouteBinaryAvailable;
 
-    // Throttle native Process.Start traceroutes. Spawning 18 concurrent
-    // processes (9 CDN endpoints * 2 modes from the upstream tracer) tripped
-    // a .NET 10 AccessViolation in SafePipeHandle.CreatePipeSocket on macOS,
-    // crashing the whole host with Abort trap: 6. 4-wide stays under the
-    // race and a full sweep still finishes inside the 10s deadline.
-    private readonly SemaphoreSlim _processLaunchLimiter = new(4, 4);
+    // Throttle native Process.Start. macOS ARM64 has a .NET 10 runtime bug
+    // (dotnet/runtime#112167) where concurrent Process.Start with redirected
+    // stdout/stderr causes heap corruption and Abort trap: 6. Limit to 2 on
+    // macOS (faster 0.1s ping interval compensates). Linux is unaffected.
+    private readonly SemaphoreSlim _processLaunchLimiter = new(
+        OperatingSystem.IsMacOS() ? 2 : 4,
+        OperatingSystem.IsMacOS() ? 2 : 4);
 
     public LocalProbeExecutor(ILogger<LocalProbeExecutor> logger)
     {
@@ -131,13 +132,12 @@ public class LocalProbeExecutor : IProbeExecutor
 
     private async Task<PingProbeResult> NativePingAsync(ProbeTarget target, int count, TimeSpan timeout, CancellationToken ct)
     {
-        // STM-style burst tuning: keep total burst duration ~1.5s by scaling interval
-        // inversely with count. 3 pings = 0.75 s interval, 6 = 0.3 s, 10 = ~0.17 s.
-        // Floor at 0.2 s to satisfy iputils' "minimum interval for non-root" check
-        // (also matches our SSH executor behavior).
+        // Fast burst: 0.1s interval on macOS (BSD ping allows it for non-root),
+        // 0.2s floor on Linux (iputils enforces minimum for non-root).
         var safeCount = Math.Max(1, count);
-        var rawInterval = safeCount > 1 ? 1.5 / (safeCount - 1) : 0.2;
-        var interval = Math.Max(0.2, Math.Round(rawInterval, 2));
+        var minInterval = OperatingSystem.IsMacOS() ? 0.1 : 0.15;
+        var rawInterval = safeCount > 1 ? 1.5 / (safeCount - 1) : minInterval;
+        var interval = Math.Max(minInterval, Math.Round(rawInterval, 2));
         var timeoutSeconds = Math.Max(1, (int)Math.Ceiling(timeout.TotalSeconds));
 
         // Two BSD-vs-iputils gotchas: ping has no -4 on macOS (it aborts with

--- a/src/NetworkOptimizer.Monitoring/Probes/LocalProbeExecutor.cs
+++ b/src/NetworkOptimizer.Monitoring/Probes/LocalProbeExecutor.cs
@@ -133,9 +133,9 @@ public class LocalProbeExecutor : IProbeExecutor
     private async Task<PingProbeResult> NativePingAsync(ProbeTarget target, int count, TimeSpan timeout, CancellationToken ct)
     {
         // Fixed interval per platform: 0.1s on macOS (BSD ping allows it),
-        // 0.15s on Linux. 10 pings completes in 0.9s / 1.35s respectively.
+        // 0.2s on Linux (iputils enforces 200ms minimum for non-root).
         var safeCount = Math.Max(1, count);
-        var interval = OperatingSystem.IsMacOS() ? 0.1 : 0.15;
+        var interval = OperatingSystem.IsMacOS() ? 0.1 : 0.2;
         var timeoutSeconds = Math.Max(1, (int)Math.Ceiling(timeout.TotalSeconds));
 
         // Two BSD-vs-iputils gotchas: ping has no -4 on macOS (it aborts with

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1336,7 +1336,7 @@ else
     private static string FormatRtt(double? ms)
     {
         if (!ms.HasValue) return "-";
-        return $"{ms.Value:0.#} ms";
+        return $"{ms.Value:0.##} ms";
     }
 
     private static string FormatLoss(double percent)

--- a/src/NetworkOptimizer.Web/Endpoints/LanFlowMapEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/LanFlowMapEndpoints.cs
@@ -1,9 +1,12 @@
+using NetworkOptimizer.Web.Services;
 using NetworkOptimizer.Web.Services.LanFlowMap;
 
 namespace NetworkOptimizer.Web.Endpoints;
 
 public static class LanFlowMapEndpoints
 {
+    private record DevicePlacementRequest(string Mac, double Latitude, double Longitude, int? Floor);
+
     public static void Map(WebApplication app)
     {
         app.MapGet("/api/monitoring/lan-flow-map/snapshot",
@@ -34,6 +37,16 @@ public static class LanFlowMapEndpoints
                 var toT = until ?? DateTime.UtcNow;
                 var items = await svc.BuildSpeedTestOverlayAsync(fromT, toT, limitPerKind: 10, ct: ct);
                 return Results.Ok(items);
+            });
+
+        app.MapPost("/api/monitoring/lan-flow-map/device-placement",
+            async (DevicePlacementRequest req, ApMapService apMap, LanFlowMapService svc) =>
+            {
+                if (string.IsNullOrWhiteSpace(req.Mac))
+                    return Results.BadRequest("mac is required");
+                await apMap.SaveApLocationAsync(req.Mac, req.Latitude, req.Longitude, req.Floor);
+                svc.InvalidateCache();
+                return Results.Ok();
             });
     }
 }

--- a/src/NetworkOptimizer.Web/Services/ApMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/ApMapService.cs
@@ -88,7 +88,7 @@ public class ApMapService
     /// <summary>
     /// Save an AP's map location (upsert by MAC address).
     /// </summary>
-    public async Task SaveApLocationAsync(string mac, double lat, double lng)
+    public async Task SaveApLocationAsync(string mac, double lat, double lng, int? floor = null)
     {
         var normalizedMac = mac.ToLowerInvariant();
 
@@ -98,6 +98,7 @@ public class ApMapService
         {
             existing.Latitude = lat;
             existing.Longitude = lng;
+            if (floor.HasValue) existing.Floor = floor.Value;
             existing.UpdatedAt = DateTime.UtcNow;
         }
         else
@@ -107,7 +108,7 @@ public class ApMapService
                 ApMac = normalizedMac,
                 Latitude = lat,
                 Longitude = lng,
-                Floor = 1,
+                Floor = floor ?? 1,
                 UpdatedAt = DateTime.UtcNow
             });
         }

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
@@ -258,6 +258,16 @@ public class LanFlowMapBounds
     /// <summary>Maximum extent of anchor coordinates so the JS layout can normalise.</summary>
     public double Radius { get; set; } = 1.0;
     public int AnchorCount { get; set; }
+
+    /// <summary>Projection centroid latitude (degrees). JS uses this to reverse-project
+    /// 3D scene coordinates back to geo for persistent device placement.</summary>
+    public double? CenterLat { get; set; }
+
+    /// <summary>Projection centroid longitude (degrees).</summary>
+    public double? CenterLng { get; set; }
+
+    /// <summary>Longitude cosine scale factor at centroid latitude.</summary>
+    public double? LngScale { get; set; }
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
@@ -14,6 +14,8 @@ public class LanFlowMapSnapshot
     public Dictionary<string, LinkLiveRates> LiveRates { get; set; } = new();
     public List<SpeedTestOverlayItem> SpeedTests { get; set; } = new();
     public LanFlowMapBounds Bounds { get; set; } = new();
+    public List<LanBuilding> Buildings { get; set; } = new();
+    public Dictionary<string, string> MaterialColors { get; set; } = new();
 
     /// <summary>Interface name of the primary WAN (e.g. "wan"). The JS layer
     /// uses this to route speed test results that don't carry a WanNetworkGroup.</summary>
@@ -63,6 +65,9 @@ public class LanNode
     public string? ParentId { get; set; }
 
     public LanPlacement? Placement { get; set; }
+
+    /// <summary>AP mount type ("ceiling", "wall", "desktop") for vertical positioning within a floor.</summary>
+    public string? MountType { get; set; }
 
     /// <summary>Whether the device responded to our last poll (for dimming offline nodes).</summary>
     public bool Online { get; set; } = true;
@@ -318,4 +323,36 @@ public class LanFlowMapHistoricUpdate
 
     /// <summary>Speed tests whose TestTime falls within the scrub window (or just before it).</summary>
     public List<SpeedTestOverlayItem> SpeedTests { get; set; } = new();
+}
+
+public class LanBuilding
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+    public List<LanBuildingFloor> Floors { get; set; } = new();
+}
+
+public class LanBuildingFloor
+{
+    public int FloorNumber { get; set; }
+    public string FloorMaterial { get; set; } = "floor_wood";
+    public double SwX { get; set; }
+    public double SwY { get; set; }
+    public double NeX { get; set; }
+    public double NeY { get; set; }
+    public double Z { get; set; }
+    public List<LanWall> Walls { get; set; } = new();
+}
+
+public class LanWall
+{
+    public List<LanWallPoint> Points { get; set; } = new();
+    public string Material { get; set; } = "drywall";
+    public List<string?>? Materials { get; set; }
+}
+
+public class LanWallPoint
+{
+    public double X { get; set; }
+    public double Y { get; set; }
 }

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -1,9 +1,11 @@
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.UniFi;
 using NetworkOptimizer.UniFi.Models;
 using NetworkOptimizer.Web.Services.Monitoring;
+using NetworkOptimizer.WiFi.Models;
 
 namespace NetworkOptimizer.Web.Services.LanFlowMap;
 
@@ -88,6 +90,10 @@ public class LanFlowMapService
         var anchors = ProjectAnchors(markers, deviceLocations,
             out var centerLat, out var centerLng, out var lngScale);
         snapshot.Bounds = ComputeBounds(anchors, centerLat, centerLng, lngScale);
+        snapshot.Buildings = await BuildBuildingsAsync(centerLat, centerLng, lngScale, ct);
+        snapshot.MaterialColors = new Dictionary<string, string>(
+            WiFi.Data.MaterialAttenuation.MaterialColors, StringComparer.OrdinalIgnoreCase);
+        CompactBuildingFloors(snapshot.Buildings, anchors);
 
         var nameMaps = await LoadInterfaceNameMaps(ct);
 
@@ -109,7 +115,22 @@ public class LanFlowMapService
             .Where(d => !string.IsNullOrEmpty(d.Mac))
             .ToDictionary(d => NormalizeMac(d.Mac), d => d, StringComparer.OrdinalIgnoreCase);
 
+        // Mount type lookup so AP nodes carry their mount position for 3D vertical offset
+        var mountTypes = markers
+            .Where(m => !string.IsNullOrEmpty(m.MountType))
+            .ToDictionary(m => NormalizeMac(m.Mac), m => m.MountType, StringComparer.OrdinalIgnoreCase);
+
         BuildInfrastructureGraph(topology, anchors, snapshot, nameMaps);
+
+        foreach (var node in snapshot.Nodes)
+        {
+            if (node.Kind == LanNodeKind.AccessPoint && node.Mac != null
+                && mountTypes.TryGetValue(node.Mac, out var mt))
+            {
+                node.MountType = mt;
+            }
+        }
+
         BuildClientLeaves(topology, anchors, snapshot, nameMaps, rawByMac);
         GroupMultiClientPorts(snapshot);
         await BuildWanAndClouds(topology, snapshot, ct);
@@ -616,6 +637,17 @@ public class LanFlowMapService
     // Internal: AP placement -> local Cartesian
     // ---------------------------------------------------------------------------------
 
+    private const double EarthRadiusMetres = 6_371_000.0;
+    private const double FloorHeightMetres = 2.9;
+
+    private static (double x, double y) ProjectLatLng(
+        double lat, double lng, double centerLat, double centerLng, double lngScale)
+    {
+        double x = (lng - centerLng) * Math.PI / 180.0 * lngScale * EarthRadiusMetres;
+        double y = (lat - centerLat) * Math.PI / 180.0 * EarthRadiusMetres;
+        return (x, y);
+    }
+
     private static Dictionary<string, LanPlacement> ProjectAnchors(
         IReadOnlyList<Web.Models.ApMapMarker> markers,
         IReadOnlyList<Storage.Models.ApLocation> deviceLocations,
@@ -644,21 +676,16 @@ public class LanFlowMapService
             centerLng = deviceLocations.Average(d => d.Longitude);
         }
 
-        const double earthRadiusMetres = 6_371_000.0;
         lngScale = Math.Cos(centerLat * Math.PI / 180.0);
 
         foreach (var m in withCoords)
         {
-            double dLat = (m.Latitude!.Value - centerLat) * Math.PI / 180.0;
-            double dLng = (m.Longitude!.Value - centerLng) * Math.PI / 180.0;
-            double x = dLng * lngScale * earthRadiusMetres;
-            double y = dLat * earthRadiusMetres;
-            double z = (m.Floor ?? 1) * 3.0;
+            var (x, y) = ProjectLatLng(m.Latitude!.Value, m.Longitude!.Value, centerLat, centerLng, lngScale);
             anchors[NormalizeMac(m.Mac)] = new LanPlacement
             {
                 X = x,
                 Y = y,
-                Z = z,
+                Z = (m.Floor ?? 1) * FloorHeightMetres,
                 Source = LanPlacementSource.Anchor,
             };
         }
@@ -667,16 +694,12 @@ public class LanFlowMapService
         {
             var mac = NormalizeMac(d.ApMac);
             if (anchors.ContainsKey(mac)) continue;
-            double dLat = (d.Latitude - centerLat) * Math.PI / 180.0;
-            double dLng = (d.Longitude - centerLng) * Math.PI / 180.0;
-            double x = dLng * lngScale * earthRadiusMetres;
-            double y = dLat * earthRadiusMetres;
-            double z = (d.Floor ?? 1) * 3.0;
+            var (x, y) = ProjectLatLng(d.Latitude, d.Longitude, centerLat, centerLng, lngScale);
             anchors[mac] = new LanPlacement
             {
                 X = x,
                 Y = y,
-                Z = z,
+                Z = (d.Floor ?? 1) * FloorHeightMetres,
                 Source = LanPlacementSource.Anchor,
             };
         }
@@ -708,6 +731,133 @@ public class LanFlowMapService
         bounds.CenterLng = centerLng;
         bounds.LngScale = lngScale;
         return bounds;
+    }
+
+    private async Task<List<LanBuilding>> BuildBuildingsAsync(
+        double centerLat, double centerLng, double lngScale, CancellationToken ct)
+    {
+        var result = new List<LanBuilding>();
+        try
+        {
+            using var db = await _dbFactory.CreateDbContextAsync(ct);
+            var buildings = await db.Buildings.Include(b => b.Floors).ToListAsync(ct);
+
+            var jsonOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+
+            foreach (var building in buildings)
+            {
+                var lanBuilding = new LanBuilding
+                {
+                    Id = building.Id,
+                    Name = building.Name,
+                };
+
+                foreach (var floor in building.Floors)
+                {
+                    if (string.IsNullOrWhiteSpace(floor.WallsJson) || floor.WallsJson == "[]")
+                        continue;
+
+                    List<PropagationWall>? walls;
+                    try
+                    {
+                        walls = JsonSerializer.Deserialize<List<PropagationWall>>(floor.WallsJson, jsonOptions);
+                    }
+                    catch
+                    {
+                        continue;
+                    }
+                    if (walls == null || walls.Count == 0) continue;
+
+                    var (swX, swY) = ProjectLatLng(floor.SwLatitude, floor.SwLongitude, centerLat, centerLng, lngScale);
+                    var (neX, neY) = ProjectLatLng(floor.NeLatitude, floor.NeLongitude, centerLat, centerLng, lngScale);
+
+                    var lanFloor = new LanBuildingFloor
+                    {
+                        FloorNumber = floor.FloorNumber,
+                        FloorMaterial = floor.FloorMaterial ?? "floor_wood",
+                        SwX = swX,
+                        SwY = swY,
+                        NeX = neX,
+                        NeY = neY,
+                        Z = floor.FloorNumber * FloorHeightMetres,
+                    };
+
+                    foreach (var wall in walls)
+                    {
+                        if (wall.Points.Count < 2) continue;
+                        var lanWall = new LanWall
+                        {
+                            Material = wall.Material,
+                            Materials = wall.Materials?.Select(m => (string?)m).ToList(),
+                        };
+                        foreach (var pt in wall.Points)
+                        {
+                            var (px, py) = ProjectLatLng(pt.Lat, pt.Lng, centerLat, centerLng, lngScale);
+                            lanWall.Points.Add(new LanWallPoint { X = px, Y = py });
+                        }
+                        lanFloor.Walls.Add(lanWall);
+                    }
+
+                    lanBuilding.Floors.Add(lanFloor);
+                }
+
+                if (lanBuilding.Floors.Count > 0)
+                    result.Add(lanBuilding);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to load buildings for 3D map");
+        }
+        return result;
+    }
+
+    private static void CompactBuildingFloors(
+        List<LanBuilding> buildings, Dictionary<string, LanPlacement> anchors)
+    {
+        foreach (var building in buildings)
+        {
+            var floorNums = building.Floors.Select(f => f.FloorNumber).OrderBy(n => n).ToList();
+            if (floorNums.Count < 2) continue;
+
+            bool hasGap = false;
+            for (int i = 1; i < floorNums.Count; i++)
+            {
+                if (floorNums[i] - floorNums[i - 1] > 1) { hasGap = true; break; }
+            }
+            if (!hasGap) continue;
+
+            // Anchor from the top floor and compact downward so upper floors stay
+            // level with the same floor in other buildings.
+            var zMap = new Dictionary<int, double>();
+            int topFloor = floorNums[^1];
+            for (int i = 0; i < floorNums.Count; i++)
+            {
+                int distFromTop = floorNums.Count - 1 - i;
+                zMap[floorNums[i]] = (topFloor - distFromTop) * FloorHeightMetres;
+            }
+
+            foreach (var floor in building.Floors)
+            {
+                if (zMap.TryGetValue(floor.FloorNumber, out var newZ))
+                    floor.Z = newZ;
+            }
+
+            // Adjust devices whose position falls inside this building's footprint
+            double minX = building.Floors.Min(f => Math.Min(f.SwX, f.NeX));
+            double maxX = building.Floors.Max(f => Math.Max(f.SwX, f.NeX));
+            double minY = building.Floors.Min(f => Math.Min(f.SwY, f.NeY));
+            double maxY = building.Floors.Max(f => Math.Max(f.SwY, f.NeY));
+
+            foreach (var anchor in anchors.Values)
+            {
+                if (anchor.X < minX || anchor.X > maxX || anchor.Y < minY || anchor.Y > maxY)
+                    continue;
+                int deviceFloor = (int)Math.Round(anchor.Z / FloorHeightMetres);
+                if (zMap.TryGetValue(deviceFloor, out var newDevZ))
+                    anchor.Z = newDevZ;
+            }
+        }
     }
 
     // ---------------------------------------------------------------------------------
@@ -1146,7 +1296,7 @@ public class LanFlowMapService
             {
                 X = anchored.Average(p => p.X),
                 Y = anchored.Average(p => p.Y),
-                Z = anchored.Average(p => p.Z) - 3.0,  // sit slightly "below" the APs in 3D
+                Z = anchored.Average(p => p.Z) - FloorHeightMetres,  // sit slightly "below" the APs in 3D
                 Source = LanPlacementSource.Interpolated,
             };
         }

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -74,8 +74,20 @@ public class LanFlowMapService
         var topology = await discovery.DiscoverTopologyAsync(ct);
 
         var markers = await _apMap.GetApMapMarkersAsync();
-        var anchors = ProjectAnchors(markers);
-        snapshot.Bounds = ComputeBounds(anchors);
+
+        // Load non-AP device placements (switches, gateways) from the same table.
+        using var db = await _dbFactory.CreateDbContextAsync();
+        var allLocations = await db.ApLocations.ToListAsync(ct);
+        var apMacs = new HashSet<string>(
+            markers.Select(m => m.Mac.ToLowerInvariant()),
+            StringComparer.OrdinalIgnoreCase);
+        var deviceLocations = allLocations
+            .Where(l => !apMacs.Contains(l.ApMac.ToLowerInvariant()))
+            .ToList();
+
+        var anchors = ProjectAnchors(markers, deviceLocations,
+            out var centerLat, out var centerLng, out var lngScale);
+        snapshot.Bounds = ComputeBounds(anchors, centerLat, centerLng, lngScale);
 
         var nameMaps = await LoadInterfaceNameMaps(ct);
 
@@ -98,7 +110,7 @@ public class LanFlowMapService
             .ToDictionary(d => NormalizeMac(d.Mac), d => d, StringComparer.OrdinalIgnoreCase);
 
         BuildInfrastructureGraph(topology, anchors, snapshot, nameMaps);
-        BuildClientLeaves(topology, snapshot, nameMaps, rawByMac);
+        BuildClientLeaves(topology, anchors, snapshot, nameMaps, rawByMac);
         GroupMultiClientPorts(snapshot);
         await BuildWanAndClouds(topology, snapshot, ct);
 
@@ -604,22 +616,36 @@ public class LanFlowMapService
     // Internal: AP placement -> local Cartesian
     // ---------------------------------------------------------------------------------
 
-    private static Dictionary<string, LanPlacement> ProjectAnchors(IReadOnlyList<Web.Models.ApMapMarker> markers)
+    private static Dictionary<string, LanPlacement> ProjectAnchors(
+        IReadOnlyList<Web.Models.ApMapMarker> markers,
+        IReadOnlyList<Storage.Models.ApLocation> deviceLocations,
+        out double centerLat, out double centerLng, out double lngScale)
     {
+        centerLat = 0;
+        centerLng = 0;
+        lngScale = 1;
+
         var anchors = new Dictionary<string, LanPlacement>();
         var withCoords = markers
             .Where(m => m.Latitude.HasValue && m.Longitude.HasValue)
             .ToList();
-        if (withCoords.Count == 0) return anchors;
+        if (withCoords.Count == 0 && deviceLocations.Count == 0) return anchors;
 
-        // Project lat/lng to a local equirectangular frame centered on the centroid.
-        // Scale so 1 unit ~= 1 metre at the centroid latitude. Z = floor number * 3 metres
-        // (typical floor-to-floor distance). The JS layer normalises to its own scene
-        // units; we just need consistent local coordinates.
-        double centerLat = withCoords.Average(m => m.Latitude!.Value);
-        double centerLng = withCoords.Average(m => m.Longitude!.Value);
+        // Centroid is computed from AP markers only so that repositioning a
+        // switch/gateway doesn't shift the AP reference frame.
+        if (withCoords.Count > 0)
+        {
+            centerLat = withCoords.Average(m => m.Latitude!.Value);
+            centerLng = withCoords.Average(m => m.Longitude!.Value);
+        }
+        else
+        {
+            centerLat = deviceLocations.Average(d => d.Latitude);
+            centerLng = deviceLocations.Average(d => d.Longitude);
+        }
+
         const double earthRadiusMetres = 6_371_000.0;
-        double lngScale = Math.Cos(centerLat * Math.PI / 180.0);
+        lngScale = Math.Cos(centerLat * Math.PI / 180.0);
 
         foreach (var m in withCoords)
         {
@@ -636,23 +662,52 @@ public class LanFlowMapService
                 Source = LanPlacementSource.Anchor,
             };
         }
+
+        foreach (var d in deviceLocations)
+        {
+            var mac = NormalizeMac(d.ApMac);
+            if (anchors.ContainsKey(mac)) continue;
+            double dLat = (d.Latitude - centerLat) * Math.PI / 180.0;
+            double dLng = (d.Longitude - centerLng) * Math.PI / 180.0;
+            double x = dLng * lngScale * earthRadiusMetres;
+            double y = dLat * earthRadiusMetres;
+            double z = (d.Floor ?? 1) * 3.0;
+            anchors[mac] = new LanPlacement
+            {
+                X = x,
+                Y = y,
+                Z = z,
+                Source = LanPlacementSource.Anchor,
+            };
+        }
+
         return anchors;
     }
 
-    private static LanFlowMapBounds ComputeBounds(Dictionary<string, LanPlacement> anchors)
+    private static LanFlowMapBounds ComputeBounds(
+        Dictionary<string, LanPlacement> anchors,
+        double centerLat, double centerLng, double lngScale)
     {
-        if (anchors.Count == 0) return new LanFlowMapBounds { Radius = 1.0, AnchorCount = 0 };
+        var bounds = new LanFlowMapBounds
+        {
+            AnchorCount = anchors.Count,
+        };
+        if (anchors.Count == 0)
+        {
+            bounds.Radius = 1.0;
+            return bounds;
+        }
         double maxR = 0;
         foreach (var p in anchors.Values)
         {
             var r = Math.Sqrt(p.X * p.X + p.Y * p.Y + p.Z * p.Z);
             if (r > maxR) maxR = r;
         }
-        return new LanFlowMapBounds
-        {
-            Radius = Math.Max(maxR, 1.0),
-            AnchorCount = anchors.Count,
-        };
+        bounds.Radius = Math.Max(maxR, 1.0);
+        bounds.CenterLat = centerLat;
+        bounds.CenterLng = centerLng;
+        bounds.LngScale = lngScale;
+        return bounds;
     }
 
     // ---------------------------------------------------------------------------------
@@ -736,6 +791,7 @@ public class LanFlowMapService
 
     private void BuildClientLeaves(
         NetworkTopology topology,
+        Dictionary<string, LanPlacement> anchors,
         LanFlowMapSnapshot snapshot,
         Dictionary<(string mac, int port), InterfaceNameMap> nameMaps,
         Dictionary<string, NetworkOptimizer.UniFi.Models.UniFiDeviceResponse> rawByMac)
@@ -747,6 +803,7 @@ public class LanFlowMapService
             if (string.IsNullOrEmpty(c.ConnectedToDeviceMac)) continue;
             var parentMac = NormalizeMac(c.ConnectedToDeviceMac);
 
+            anchors.TryGetValue(clientMac, out var anchor);
             var nodeId = "cli-" + clientMac;
             var node = new LanNode
             {
@@ -756,6 +813,7 @@ public class LanFlowMapService
                 Ip = string.IsNullOrEmpty(c.IpAddress) ? null : c.IpAddress,
                 Name = ResolveClientLabel(c),
                 ParentId = "dev-" + parentMac,
+                Placement = anchor,
                 Network = c.Network,
                 IsGuest = c.IsGuest,
                 Ssid = c.Essid,

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14588,3 +14588,57 @@ a.affected-client:hover {
         display: none;
     }
 }
+.lan-flow-map-context-menu {
+    position: absolute;
+    z-index: 20;
+    background: rgba(16, 24, 32, 0.95);
+    border: 1px solid rgba(255, 255, 255, 0.10);
+    border-radius: 6px;
+    padding: 4px 0;
+    min-width: 160px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+.lan-flow-map-context-menu-item {
+    padding: 7px 14px;
+    font-size: 0.82rem;
+    color: var(--text-primary);
+    cursor: pointer;
+    user-select: none;
+}
+.lan-flow-map-context-menu-item:hover {
+    background: var(--bg-hover);
+}
+.lan-flow-map-reposition-hud {
+    position: absolute;
+    top: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 15;
+    background: rgba(16, 24, 32, 0.92);
+    border: 1px solid var(--primary-color);
+    border-radius: 8px;
+    padding: 8px 16px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 0.82rem;
+    color: var(--text-primary);
+    white-space: nowrap;
+}
+.lan-flow-map-reposition-title {
+    font-weight: 500;
+    color: var(--primary-hover);
+}
+.lan-flow-map-reposition-keys {
+    color: var(--text-secondary);
+}
+.lan-flow-map-reposition-keys .kbd {
+    display: inline-block;
+    padding: 1px 5px;
+    font-size: 0.72rem;
+    background: var(--bg-tertiary);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 3px;
+    font-family: inherit;
+    line-height: 1.4;
+}

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-buildings.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-buildings.js
@@ -1,0 +1,1239 @@
+// 3D building renderer for the LAN Flow Map.
+// Reads pre-projected building/floor/wall geometry from the snapshot and builds
+// Three.js meshes: walls colored by material, floor planes, and pitched roofs.
+// Procedural textures for brick, siding, wood, and concrete.
+
+import * as THREE from 'three';
+
+const WALL_HEIGHT_M = 2.9;
+const WALL_THICKNESS_M = 0.15;
+const FLOOR_OPACITY = 0.25;
+const WALL_OPACITY = 0.5;
+const ROOF_OPACITY = 0.45;
+const ROOF_COLOR = 0x5a6577;
+const FLOOR_COLOR = 0x2a3545;
+const ROOF_PITCH = 0.28;
+const MAX_RIDGE_M = 3.0;
+
+// Realistic colors for 3D rendering - muted real-world tones instead of
+// the bright signal-map palette from MaterialAttenuation.MaterialColors.
+const REALISTIC_COLORS = {
+    drywall:              '#E8E0D8',
+    drywall_heavy:        '#D5CEC6',
+    wood:                 '#7A5C3A',
+    wood_paneling:        '#A08060',
+    glass:                '#A8C8E0',
+    glass_thin:           '#BDD8EC',
+    brick:                '#8B4225',
+    concrete:             '#8A8A8A',
+    metal:                '#9A9A9A',
+    door_wood:            '#5C3A1E',
+    door_metal:           '#707070',
+    door_glass:           '#9AB8D0',
+    window_1_pane:        '#9AB8D8',
+    window_2_pane:        '#88A8C8',
+    window_3_pane:        '#7898B8',
+    exterior:             '#C0B49C',
+    exterior_residential: '#C0B49C',
+    exterior_commercial:  '#707068',
+    floor_wood:           '#6B5540',
+    floor_concrete:       '#8A8A8A',
+};
+
+// Materials that get procedural textures
+const TEXTURED = new Set([
+    'brick', 'concrete', 'exterior_commercial',
+    'exterior_residential', 'exterior',
+    'wood', 'wood_paneling',
+    'glass', 'glass_thin',
+]);
+
+// Materials drawn per-segment (no tiling). Each segment gets a fresh canvas
+// sized to its real-world proportions.
+const PER_SEGMENT = new Set([
+    'window_1_pane', 'window_2_pane', 'window_3_pane',
+    'door_wood', 'door_metal', 'door_glass',
+]);
+
+// Materials that look different on the interior face. Value is the
+// interior texture key used by _getTexCanvas / _getInteriorTexCanvas.
+const INTERIOR_LOOK = {
+    wood_paneling: 'interior_wood',
+    exterior_residential: 'interior_drywall',
+    exterior: 'interior_drywall',
+    exterior_commercial: 'interior_drywall',
+};
+
+const _interiorTexCache = new Map();
+
+// Flat surround colors for the wall area around doors/windows. Approximates
+// what the adjacent wall material looks like as a solid fill.
+const SURROUND_COLORS = {
+    exterior_residential: '#707072',
+    exterior:             '#707072',
+    exterior_commercial:  '#686868',
+    wood_paneling:        '#757880',
+    wood:                 '#6B4226',
+    brick:                '#8B4225',
+    concrete:             '#808080',
+    drywall:              '#D8D2C8',
+    drywall_heavy:        '#CCC6BC',
+    metal:                '#888888',
+};
+
+const _texCache = new Map();
+
+export function buildBuildings(snap) {
+    const group = new THREE.Group();
+    group.name = 'buildings';
+
+    const buildings = snap.buildings;
+    if (!buildings || buildings.length === 0) return group;
+
+    const bounds = snap.bounds || { radius: 1.0, anchorCount: 0 };
+    if (bounds.anchorCount === 0) return group;
+
+    const sceneRadius = 30.0;
+    const spreadFactor = 1.875;
+    const scale = (sceneRadius / Math.max(bounds.radius, 1.0)) * spreadFactor;
+
+    const wallHScene = WALL_HEIGHT_M * scale * 0.8;
+    const wallDScene = WALL_THICKNESS_M * scale;
+
+    for (const building of buildings) {
+        const bGroup = new THREE.Group();
+        bGroup.name = `building-${building.id}`;
+        let maxFloorNum = -Infinity;
+
+        // Determine winding direction from the longest wall loop to decide
+        // which BoxGeometry face (+Z or -Z) is the exterior.
+        const winding = _detectWinding(building, scale);
+
+        for (const floor of building.floors) {
+            if (floor.floorNumber > maxFloorNum) maxFloorNum = floor.floorNumber;
+            const floorY = floor.z * scale * 0.8;
+
+            _buildFloorPlane(floor, scale, floorY, bGroup);
+            _buildWalls(floor, scale, floorY, wallHScene, wallDScene, winding, bGroup);
+        }
+
+        const topFloor = building.floors.find(f => f.floorNumber === maxFloorNum);
+        if (topFloor) {
+            _buildRoof(topFloor, building, scale, wallHScene, bGroup);
+        }
+
+        group.add(bGroup);
+    }
+
+    return group;
+}
+
+// -- coordinate helpers -------------------------------------------------------
+
+function toScene(pt, scale) {
+    return { x: -pt.x * scale, z: pt.y * scale };
+}
+
+// Compute signed area of the longest wall loop to determine winding direction.
+// Returns 1 if the exterior face is +Z (group 4), -1 if it's -Z (group 5).
+function _detectWinding(building, scale) {
+    // Find the longest closed wall (most points) as the representative outline
+    let bestWall = null;
+    let bestLen = 0;
+    for (const floor of building.floors) {
+        for (const wall of floor.walls) {
+            if (wall.points.length > bestLen) {
+                bestLen = wall.points.length;
+                bestWall = wall;
+            }
+        }
+    }
+    if (!bestWall || bestWall.points.length < 3) return 1;
+
+    // Shoelace formula for signed area in scene space
+    const pts = bestWall.points.map(p => toScene(p, scale));
+    let area = 0;
+    for (let i = 0; i < pts.length; i++) {
+        const j = (i + 1) % pts.length;
+        area += pts[i].x * pts[j].z - pts[j].x * pts[i].z;
+    }
+    // Negative signed area = clockwise in XZ plane = +Z face points outward
+    return area < 0 ? 1 : -1;
+}
+
+// -- procedural textures ------------------------------------------------------
+// Each canvas represents a fixed real-world tile (tileSizeM). The Three.js
+// texture is cached; per-segment materials clone it with repeat set from
+// the wall's actual meter dimensions.
+
+function _getTexCanvas(matKey) {
+    if (_texCache.has(matKey)) return _texCache.get(matKey);
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    let tileSizeM = 1.0;
+
+    switch (matKey) {
+        case 'brick':
+            _drawBrick(canvas, ctx);
+            tileSizeM = 1.0;
+            break;
+        case 'concrete':
+        case 'exterior_commercial':
+            _drawConcrete(canvas, ctx, matKey);
+            tileSizeM = 1.5;
+            break;
+        case 'exterior_residential':
+        case 'exterior':
+            _drawSiding(canvas, ctx);
+            tileSizeM = 1.0;
+            break;
+        case 'wood':
+            _drawLogCabin(canvas, ctx);
+            tileSizeM = 1.0;
+            break;
+        case 'wood_paneling':
+            _drawWoodVertical(canvas, ctx);
+            tileSizeM = 0.6;
+            break;
+        case 'glass':
+        case 'glass_thin':
+            _drawGlassWall(canvas, ctx, matKey === 'glass_thin');
+            tileSizeM = 1.0;
+            break;
+        default:
+            _texCache.set(matKey, null);
+            return null;
+    }
+
+    // Cache the raw canvas and tile size - NOT the Three.js texture.
+    // CanvasTexture.clone() doesn't reliably transfer image data to the GPU,
+    // so each wall segment creates a fresh texture from the cached canvas.
+    _texCache.set(matKey, { canvas, tileSizeM });
+    return _texCache.get(matKey);
+}
+
+// Standard US modular brick: 7-5/8" x 2-1/4" (194mm x 57mm) with
+// 3/8" (10mm) mortar joints. 512px canvas = 1m tile.
+// At 0.512 px/mm: brick = 99px x 29px, mortar = 5px, course = 34px.
+// ~5 bricks wide, ~15 courses tall per 1m tile.
+function _drawBrick(canvas, ctx) {
+    canvas.width = 512;
+    canvas.height = 512;
+    const brickW = 99;
+    const brickH = 29;
+    const mortarGap = 5;
+    const courseH = brickH + mortarGap;
+    const halfBrick = Math.floor((brickW + mortarGap) / 2);
+    const brickColors = [
+        '#8B4225', '#7E3B20', '#96482A', '#6E3320',
+        '#A0502E', '#844028', '#924530', '#7A3822',
+    ];
+
+    // Mortar fill
+    ctx.fillStyle = '#C0B8A8';
+    ctx.fillRect(0, 0, 512, 512);
+
+    let row = 0;
+    for (let y = 0; y < 512; y += courseH) {
+        const offset = (row % 2) ? halfBrick : 0;
+        for (let x = -offset; x < 512; x += brickW + mortarGap) {
+            const ci = (row * 7 + Math.floor((x + offset) / 50)) % brickColors.length;
+            ctx.fillStyle = brickColors[ci];
+            const bx = Math.max(x, 0);
+            const bw = Math.min(x + brickW, 512) - bx;
+            if (bw <= 0) continue;
+            ctx.fillRect(bx, y, bw, brickH);
+
+            // Subtle per-brick shade variation
+            ctx.fillStyle = `rgba(0,0,0,${0.02 + ((row * 3 + x) % 5) * 0.012})`;
+            ctx.fillRect(bx, y, bw, brickH);
+
+            // Fine surface texture
+            for (let t = 0; t < 3; t++) {
+                const tx = bx + Math.random() * bw;
+                const ty = y + Math.random() * brickH;
+                ctx.fillStyle = `rgba(0,0,0,${0.03 + Math.random() * 0.04})`;
+                ctx.fillRect(tx, ty, 1 + Math.random() * 3, 1);
+            }
+        }
+        row++;
+    }
+}
+
+function _drawConcrete(canvas, ctx, matKey) {
+    canvas.width = 256;
+    canvas.height = 256;
+    const base = matKey === 'exterior_commercial' ? '#707068' : '#8A8A8A';
+    ctx.fillStyle = base;
+    ctx.fillRect(0, 0, 256, 256);
+    // Subtle noise
+    for (let i = 0; i < 800; i++) {
+        const x = Math.random() * 256;
+        const y = Math.random() * 256;
+        const s = 1 + Math.random() * 3;
+        ctx.fillStyle = `rgba(${Math.random() > 0.5 ? '255,255,255' : '0,0,0'},${0.03 + Math.random() * 0.04})`;
+        ctx.fillRect(x, y, s, s);
+    }
+    // Form lines (horizontal joints in poured/block concrete)
+    ctx.strokeStyle = 'rgba(0,0,0,0.08)';
+    ctx.lineWidth = 1;
+    for (let y = 64; y < 256; y += 64) {
+        ctx.beginPath();
+        ctx.moveTo(0, y);
+        ctx.lineTo(256, y);
+        ctx.stroke();
+    }
+}
+
+// Horizontal stacked logs with chinking between courses.
+function _drawLogCabin(canvas, ctx) {
+    canvas.width = 256;
+    canvas.height = 256;
+    const logH = 32;
+    const chinkH = 4;
+    const courseH = logH + chinkH;
+    const logColors = ['#6B4226', '#5C3A1E', '#7A4E30', '#634020', '#715038'];
+
+    ctx.fillStyle = '#C8BCA0';
+    ctx.fillRect(0, 0, 256, 256);
+
+    let row = 0;
+    for (let y = 0; y < 256; y += courseH) {
+        const ci = row % logColors.length;
+        ctx.fillStyle = logColors[ci];
+        ctx.fillRect(0, y, 256, logH);
+
+        // Rounded log shading - highlight on top, shadow on bottom
+        const grad = ctx.createLinearGradient(0, y, 0, y + logH);
+        grad.addColorStop(0, 'rgba(255,255,255,0.12)');
+        grad.addColorStop(0.3, 'rgba(255,255,255,0.05)');
+        grad.addColorStop(0.7, 'rgba(0,0,0,0.03)');
+        grad.addColorStop(1, 'rgba(0,0,0,0.15)');
+        ctx.fillStyle = grad;
+        ctx.fillRect(0, y, 256, logH);
+
+        // Horizontal grain lines
+        for (let g = 0; g < 3; g++) {
+            const gy = y + 6 + Math.random() * (logH - 12);
+            ctx.strokeStyle = `rgba(0,0,0,${0.04 + Math.random() * 0.05})`;
+            ctx.lineWidth = 1;
+            ctx.beginPath();
+            ctx.moveTo(0, gy);
+            ctx.lineTo(256, gy + (Math.random() - 0.5) * 2);
+            ctx.stroke();
+        }
+
+        // Occasional knot
+        if (row % 3 === 1) {
+            const kx = 60 + (row * 73) % 140;
+            const ky = y + logH / 2;
+            ctx.fillStyle = 'rgba(60,30,10,0.25)';
+            ctx.beginPath();
+            ctx.ellipse(kx, ky, 5, 3.5, 0, 0, Math.PI * 2);
+            ctx.fill();
+        }
+
+        row++;
+    }
+}
+
+// Horizontal lap siding for residential exteriors - warm greige (gray-beige)
+// engineered wood siding with visible grain texture, pronounced overlap shadows,
+// and staggered vertical butt joints. Modeled after fiber cement/LP SmartSide.
+function _drawSiding(canvas, ctx) {
+    canvas.width = 512;
+    canvas.height = 512;
+    const boardH = 40;
+
+    // Cool-shifted greige to survive ACES tone mapping without going warm/wood
+    const baseR = 112, baseG = 112, baseB = 115;
+
+    let row = 0;
+    for (let y = 0; y < 512; y += boardH) {
+        // Very subtle per-board variation
+        const shift = ((row * 11) % 5) - 2;
+        ctx.fillStyle = `rgb(${baseR + shift},${baseG + shift},${baseB + shift})`;
+        ctx.fillRect(0, y, 512, boardH);
+
+        // Horizontal wood grain showing through - the defining texture of
+        // engineered wood siding vs vinyl
+        for (let gi = 0; gi < 14; gi++) {
+            const gy = y + 2 + (gi / 14) * (boardH - 6) + (Math.random() - 0.5) * 1.5;
+            const darkness = 0.03 + Math.random() * 0.06;
+            ctx.strokeStyle = `rgba(30,30,35,${darkness})`;
+            ctx.lineWidth = 0.5 + Math.random() * 0.8;
+            ctx.beginPath();
+            let gx = 0;
+            ctx.moveTo(gx, gy);
+            for (let sx = 30; sx <= 512; sx += 30) {
+                gx = sx;
+                ctx.lineTo(gx, gy + (Math.random() - 0.5) * 0.8);
+            }
+            ctx.stroke();
+        }
+
+        // Wider grain bands - slightly darker sweeps across the board
+        for (let si = 0; si < 3; si++) {
+            const sy = y + 4 + Math.random() * (boardH - 10);
+            ctx.fillStyle = `rgba(25,25,30,${0.025 + Math.random() * 0.035})`;
+            ctx.fillRect(0, sy, 512, 1 + Math.random() * 2.5);
+        }
+
+        // Pronounced overlap shadow at bottom - crisp dark line
+        const shadowGrad = ctx.createLinearGradient(0, y + boardH - 6, 0, y + boardH);
+        shadowGrad.addColorStop(0, 'rgba(0,0,0,0)');
+        shadowGrad.addColorStop(0.3, 'rgba(0,0,0,0.08)');
+        shadowGrad.addColorStop(0.7, 'rgba(0,0,0,0.18)');
+        shadowGrad.addColorStop(1, 'rgba(0,0,0,0.28)');
+        ctx.fillStyle = shadowGrad;
+        ctx.fillRect(0, y + boardH - 6, 512, 6);
+
+        // Light catch along top edge
+        ctx.fillStyle = 'rgba(255,255,255,0.07)';
+        ctx.fillRect(0, y, 512, 1);
+        ctx.fillStyle = 'rgba(255,255,255,0.03)';
+        ctx.fillRect(0, y + 1, 512, 1);
+
+        // Staggered vertical butt joints where board ends meet
+        if (row % 3 !== 2) {
+            const sx = 120 + ((row * 97) % 280);
+            ctx.fillStyle = 'rgba(0,0,0,0.09)';
+            ctx.fillRect(sx, y + 1, 1, boardH - 4);
+            ctx.fillStyle = 'rgba(255,255,255,0.03)';
+            ctx.fillRect(sx + 1, y + 1, 1, boardH - 4);
+        }
+
+        row++;
+    }
+}
+
+// Painted gray vertical board siding - uniform paint color with subtle wood
+// grain texture showing through. Clean flat boards, no exposed knots.
+// Colors pushed cool/blue-gray to compensate for scene's warm tone mapping.
+function _drawWoodVertical(canvas, ctx) {
+    canvas.width = 512;
+    canvas.height = 512;
+    const boardW = 62;
+    const gapW = 4;
+
+    // Dark gap between boards
+    ctx.fillStyle = '#181c20';
+    ctx.fillRect(0, 0, 512, 512);
+
+    // Uniform painted gray - slight per-board variation like real paint
+    const baseR = 118, baseG = 123, baseB = 132;
+
+    let boardIdx = 0;
+    for (let x = 0; x < 512; x += boardW + gapW) {
+        // Very subtle per-board shift (paint absorption varies slightly)
+        const shift = ((boardIdx * 7) % 5) - 2;
+        ctx.fillStyle = `rgb(${baseR + shift},${baseG + shift},${baseB + shift})`;
+        ctx.fillRect(x, 0, boardW, 512);
+
+        // Subtle grain showing through paint - very faint vertical lines
+        for (let gi = 0; gi < 6; gi++) {
+            const gx = x + 4 + (gi / 6) * (boardW - 8) + (Math.random() - 0.5) * 3;
+            ctx.strokeStyle = `rgba(20,25,35,${0.02 + Math.random() * 0.03})`;
+            ctx.lineWidth = 0.5 + Math.random() * 0.5;
+            ctx.beginPath();
+            let cx = gx;
+            ctx.moveTo(cx, 0);
+            for (let y = 40; y <= 512; y += 40) {
+                cx += (Math.random() - 0.5) * 1;
+                ctx.lineTo(cx, y);
+            }
+            ctx.stroke();
+        }
+
+        // Board channel shadow on right edge
+        ctx.fillStyle = 'rgba(0,0,0,0.12)';
+        ctx.fillRect(x + boardW - 2, 0, 2, 512);
+
+        // Slight highlight on left edge where board catches light
+        ctx.fillStyle = 'rgba(180,190,200,0.04)';
+        ctx.fillRect(x + 1, 0, 1, 512);
+
+        boardIdx++;
+    }
+}
+
+// -- glass walls --------------------------------------------------------------
+// Full glass curtain wall or storefront glazing. Thin dark frame grid with
+// large glass panels.
+function _drawGlassWall(canvas, ctx, thin) {
+    canvas.width = 256;
+    canvas.height = 256;
+    const frameColor = thin ? '#505058' : '#3A3A3E';
+    const frameW = thin ? 3 : 5;
+
+    // Glass base with sky reflection
+    const glassGrad = ctx.createLinearGradient(0, 0, 256, 256);
+    glassGrad.addColorStop(0, thin ? '#A0C0D8' : '#88AACC');
+    glassGrad.addColorStop(0.5, thin ? '#90B0C8' : '#7898B8');
+    glassGrad.addColorStop(1, thin ? '#80A8C0' : '#6888A8');
+    ctx.fillStyle = glassGrad;
+    ctx.fillRect(0, 0, 256, 256);
+
+    // Reflection
+    ctx.fillStyle = 'rgba(255,255,255,0.08)';
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    ctx.lineTo(120, 0);
+    ctx.lineTo(0, 160);
+    ctx.closePath();
+    ctx.fill();
+
+    // Grid frame
+    ctx.fillStyle = frameColor;
+    for (let x = 0; x < 256; x += 128) {
+        ctx.fillRect(x - frameW / 2, 0, frameW, 256);
+    }
+    for (let y = 0; y < 256; y += 128) {
+        ctx.fillRect(0, y - frameW / 2, 256, frameW);
+    }
+}
+
+// -- doors and windows (per-segment, not tiled) -------------------------------
+// These draw a single unit sized to the actual wall segment dimensions.
+// The adjacent wall's texture is tiled as the background so the material
+// pattern (siding, brick, etc.) flows continuously through the segment.
+
+// Tiles the adjacent wall texture across the canvas as background, or
+// falls back to a solid color if no texture is available.
+function _fillWallBackground(ctx, w, h, widthM, heightM, bgTex, fallback) {
+    if (bgTex && bgTex.canvas) {
+        const tileW = w * (bgTex.tileSizeM / widthM);
+        const tileH = h * (bgTex.tileSizeM / heightM);
+        for (let ty = 0; ty < h; ty += tileH) {
+            for (let tx = 0; tx < w; tx += tileW) {
+                ctx.drawImage(bgTex.canvas, tx, ty, tileW, tileH);
+            }
+        }
+    } else {
+        ctx.fillStyle = fallback || '#6E6E72';
+        ctx.fillRect(0, 0, w, h);
+    }
+}
+
+// Residential window proportioned to segment width. Wider segments get taller
+// windows, narrow segments get squarer windows.
+function _drawWindow(canvas, ctx, panes, widthM, heightM, bgTex, fallback) {
+    const w = 256, h = Math.min(2048, Math.round(256 * (heightM / widthM)));
+    canvas.width = w;
+    canvas.height = h;
+
+    // Tile adjacent wall texture as continuous background
+    _fillWallBackground(ctx, w, h, widthM, heightM, bgTex, fallback);
+
+    // Window proportions: width fills ~80% of segment. Height scales with
+    // width but stays proportionate - not floor to ceiling.
+    const winW = w * 0.8;
+    const winH = h * 0.38 + Math.min(winW * 0.4, h * 0.2);
+    const winL = (w - winW) / 2;
+    // Vertically center the window in the upper portion of the wall
+    const winT = (h - winH) * 0.35;
+
+    const trimW = Math.max(3, w * 0.025);
+    const frameW = Math.max(4, w * 0.04);
+
+    // White trim casing
+    ctx.fillStyle = '#D8D8D8';
+    ctx.fillRect(winL - trimW, winT - trimW, winW + trimW * 2, winH + trimW * 2);
+
+    // Dark frame
+    ctx.fillStyle = '#3A3A3E';
+    ctx.fillRect(winL, winT, winW, winH);
+
+    // Glass area
+    const gL = winL + frameW, gT = winT + frameW;
+    const gW = winW - frameW * 2, gH = winH - frameW * 2;
+
+    const glassGrad = ctx.createLinearGradient(gL, gT, gL + gW, gT + gH);
+    glassGrad.addColorStop(0, '#8AAEC8');
+    glassGrad.addColorStop(0.3, '#7BA0BC');
+    glassGrad.addColorStop(0.7, '#6890AE');
+    glassGrad.addColorStop(1, '#5A82A0');
+    ctx.fillStyle = glassGrad;
+    ctx.fillRect(gL, gT, gW, gH);
+
+    // Reflection highlight
+    ctx.fillStyle = 'rgba(255,255,255,0.12)';
+    ctx.beginPath();
+    ctx.moveTo(gL, gT);
+    ctx.lineTo(gL + gW * 0.35, gT);
+    ctx.lineTo(gL, gT + gH * 0.45);
+    ctx.closePath();
+    ctx.fill();
+
+    // Mullions
+    ctx.fillStyle = '#3A3A3E';
+    const mullW = Math.max(2, frameW * 0.6);
+    if (panes >= 2) {
+        ctx.fillRect(gL, gT + gH / 2 - mullW / 2, gW, mullW);
+    }
+    if (panes >= 3) {
+        ctx.fillRect(gL + gW / 2 - mullW / 2, gT, mullW, gH);
+    }
+
+    // Sill
+    ctx.fillStyle = '#C0C0C0';
+    ctx.fillRect(winL - 3, winT + winH + trimW, winW + 6, Math.max(3, h * 0.012));
+}
+
+// Raised-panel residential wood door - sits in the lower portion of the wall.
+function _drawDoorWood(canvas, ctx, widthM, heightM, bgTex, fallback) {
+    const w = 256, h = Math.min(2048, Math.round(256 * (heightM / widthM)));
+    canvas.width = w;
+    canvas.height = h;
+
+    _fillWallBackground(ctx, w, h, widthM, heightM, bgTex, fallback);
+
+    // Standard US door: 6'8" (2.032 m) height, fixed regardless of width.
+    const doorW = w * 0.85;
+    const doorH = h * (2.032 / heightM);
+    const doorL = (w - doorW) / 2;
+    const doorB = h * 0.97;
+    const doorT = doorB - doorH;
+
+    const trim = Math.max(3, w * 0.03);
+
+    // Trim casing
+    ctx.fillStyle = '#D8D8D8';
+    ctx.fillRect(doorL - trim, doorT - trim, doorW + trim * 2, doorH + trim);
+
+    // Door face
+    ctx.fillStyle = '#5C4030';
+    ctx.fillRect(doorL, doorT, doorW, doorH);
+
+    // 6-panel layout (2 cols x 3 rows)
+    const pad = doorW * 0.07;
+    const gapX = doorW * 0.04, gapY = doorH * 0.02;
+    const pw = (doorW - pad * 2 - gapX) / 2;
+    const ph = (doorH - pad * 2 - gapY * 2) / 3;
+
+    for (let row = 0; row < 3; row++) {
+        for (let col = 0; col < 2; col++) {
+            const px = doorL + pad + col * (pw + gapX);
+            const py = doorT + pad + row * (ph + gapY);
+            ctx.fillStyle = 'rgba(0,0,0,0.15)';
+            ctx.fillRect(px, py, pw, ph);
+            ctx.fillStyle = '#6B4E3A';
+            ctx.fillRect(px + 3, py + 3, pw - 6, ph - 6);
+            ctx.fillStyle = 'rgba(255,255,255,0.06)';
+            ctx.fillRect(px + 3, py + 3, pw - 6, 2);
+        }
+    }
+
+    // Handle
+    ctx.fillStyle = '#B0A898';
+    const handleY = doorT + doorH * 0.52;
+    ctx.fillRect(doorL + doorW - doorW * 0.14, handleY, doorW * 0.04, doorH * 0.04);
+}
+
+// Steel entry door with half-lite window.
+function _drawDoorMetal(canvas, ctx, widthM, heightM, bgTex, fallback) {
+    const w = 256, h = Math.min(2048, Math.round(256 * (heightM / widthM)));
+    canvas.width = w;
+    canvas.height = h;
+
+    _fillWallBackground(ctx, w, h, widthM, heightM, bgTex, fallback);
+
+    const doorW = w * 0.85;
+    const doorH = h * (2.032 / heightM);
+    const doorL = (w - doorW) / 2;
+    const doorB = h * 0.97;
+    const doorT = doorB - doorH;
+    const trim = Math.max(3, w * 0.03);
+
+    ctx.fillStyle = '#D8D8D8';
+    ctx.fillRect(doorL - trim, doorT - trim, doorW + trim * 2, doorH + trim);
+
+    ctx.fillStyle = '#6A6A6E';
+    ctx.fillRect(doorL, doorT, doorW, doorH);
+
+    // Embossed panel lines
+    ctx.strokeStyle = 'rgba(0,0,0,0.1)';
+    ctx.lineWidth = 1;
+    ctx.strokeRect(doorL + doorW * 0.08, doorT + doorH * 0.05, doorW * 0.84, doorH * 0.25);
+    ctx.strokeRect(doorL + doorW * 0.08, doorT + doorH * 0.35, doorW * 0.84, doorH * 0.58);
+
+    // Half-lite window
+    const liteL = doorL + doorW * 0.2, liteT = doorT + doorH * 0.07;
+    const liteW = doorW * 0.6, liteH = doorH * 0.18;
+    ctx.fillStyle = '#3A3A3E';
+    ctx.fillRect(liteL, liteT, liteW, liteH);
+    const lGrad = ctx.createLinearGradient(liteL, liteT, liteL + liteW, liteT + liteH);
+    lGrad.addColorStop(0, '#7898B0');
+    lGrad.addColorStop(1, '#5A7A92');
+    ctx.fillStyle = lGrad;
+    ctx.fillRect(liteL + 3, liteT + 3, liteW - 6, liteH - 6);
+
+    // Handle
+    ctx.fillStyle = '#B0A898';
+    ctx.fillRect(doorL + doorW * 0.82, doorT + doorH * 0.52, doorW * 0.04, doorH * 0.04);
+}
+
+// Glass/French door - mostly glass with grid.
+function _drawDoorGlass(canvas, ctx, widthM, heightM, bgTex, fallback) {
+    const w = 256, h = Math.min(2048, Math.round(256 * (heightM / widthM)));
+    canvas.width = w;
+    canvas.height = h;
+
+    _fillWallBackground(ctx, w, h, widthM, heightM, bgTex, fallback);
+
+    const doorW = w * 0.85;
+    const doorH = h * (2.032 / heightM);
+    const doorL = (w - doorW) / 2;
+    const doorB = h * 0.97;
+    const doorT = doorB - doorH;
+    const trim = Math.max(3, w * 0.03);
+
+    ctx.fillStyle = '#D8D8D8';
+    ctx.fillRect(doorL - trim, doorT - trim, doorW + trim * 2, doorH + trim);
+
+    ctx.fillStyle = '#3A3A3E';
+    ctx.fillRect(doorL, doorT, doorW, doorH);
+
+    // Glass area (leave bottom rail ~15%)
+    const railH = doorH * 0.12;
+    const gL = doorL + doorW * 0.04, gT = doorT + doorW * 0.04;
+    const gW = doorW * 0.92, gH = doorH - railH - doorW * 0.08;
+
+    const gGrad = ctx.createLinearGradient(gL, gT, gL + gW, gT + gH);
+    gGrad.addColorStop(0, '#8AAEC8');
+    gGrad.addColorStop(0.4, '#7898B0');
+    gGrad.addColorStop(1, '#6088A0');
+    ctx.fillStyle = gGrad;
+    ctx.fillRect(gL, gT, gW, gH);
+
+    // Reflection
+    ctx.fillStyle = 'rgba(255,255,255,0.1)';
+    ctx.beginPath();
+    ctx.moveTo(gL, gT);
+    ctx.lineTo(gL + gW * 0.3, gT);
+    ctx.lineTo(gL, gT + gH * 0.4);
+    ctx.closePath();
+    ctx.fill();
+
+    // French door grid
+    const mullW = Math.max(2, doorW * 0.02);
+    ctx.fillStyle = '#3A3A3E';
+    ctx.fillRect(gL + gW / 2 - mullW / 2, gT, mullW, gH);
+    for (let r = 1; r < 3; r++) {
+        ctx.fillRect(gL, gT + (gH / 3) * r - mullW / 2, gW, mullW);
+    }
+
+    // Bottom rail
+    ctx.fillStyle = '#4A4A4E';
+    ctx.fillRect(doorL, doorT + doorH - railH, doorW, railH);
+
+    // Handle
+    ctx.fillStyle = '#B0A898';
+    ctx.fillRect(doorL + doorW * 0.82, doorT + doorH * 0.48, doorW * 0.03, doorH * 0.05);
+}
+
+// -- interior textures --------------------------------------------------------
+// Cached separately from exterior textures. Used for the back face of walls
+// that look different inside vs outside.
+
+function _getInteriorTexCanvas(interiorKey) {
+    if (_interiorTexCache.has(interiorKey)) return _interiorTexCache.get(interiorKey);
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    let tileSizeM = 1.0;
+
+    switch (interiorKey) {
+        case 'interior_wood':
+            _drawWoodPanelingInterior(canvas, ctx);
+            tileSizeM = 0.6;
+            break;
+        case 'interior_drywall':
+            _drawDrywallInterior(canvas, ctx);
+            tileSizeM = 1.0;
+            break;
+        default:
+            _interiorTexCache.set(interiorKey, null);
+            return null;
+    }
+
+    _interiorTexCache.set(interiorKey, { canvas, tileSizeM });
+    return _interiorTexCache.get(interiorKey);
+}
+
+// Warm wood paneling with grain and knots - interior face of wood_paneling walls.
+function _drawWoodPanelingInterior(canvas, ctx) {
+    canvas.width = 512;
+    canvas.height = 512;
+    const boardW = 62;
+    const gapW = 3;
+
+    ctx.fillStyle = '#1a1510';
+    ctx.fillRect(0, 0, 512, 512);
+
+    const baseColors = [
+        [155, 120, 85], [140, 108, 78], [160, 125, 88],
+        [135, 105, 75], [148, 115, 82], [145, 112, 80],
+    ];
+
+    let boardIdx = 0;
+    for (let x = 0; x < 512; x += boardW + gapW) {
+        const [br, bg, bb] = baseColors[boardIdx % baseColors.length];
+        const shift = ((boardIdx * 13) % 7) - 3;
+        ctx.fillStyle = `rgb(${br + shift},${bg + shift},${bb + shift})`;
+        ctx.fillRect(x, 0, boardW, 512);
+
+        // Vertical grain lines
+        for (let gi = 0; gi < 6; gi++) {
+            const gx = x + 3 + (gi / 6) * (boardW - 6) + (Math.random() - 0.5) * 4;
+            ctx.strokeStyle = `rgba(40,25,10,${0.04 + Math.random() * 0.06})`;
+            ctx.lineWidth = 0.5 + Math.random() * 0.8;
+            ctx.beginPath();
+            let cx = gx;
+            ctx.moveTo(cx, 0);
+            for (let y = 32; y <= 512; y += 32) {
+                cx += (Math.random() - 0.5) * 1.5;
+                ctx.lineTo(cx, y);
+            }
+            ctx.stroke();
+        }
+
+        // Wider grain bands
+        for (let si = 0; si < 2; si++) {
+            const sx = x + 8 + Math.random() * (boardW - 16);
+            ctx.fillStyle = `rgba(30,18,8,${0.04 + Math.random() * 0.05})`;
+            ctx.fillRect(sx, 0, 2 + Math.random() * 3, 512);
+        }
+
+        // Knot on every third board
+        if (boardIdx % 3 === 0) {
+            const ky = 80 + ((boardIdx * 137) % 300);
+            const kx = x + boardW / 2 + (Math.random() - 0.5) * 10;
+            const kr = 4 + Math.random() * 3;
+            ctx.strokeStyle = 'rgba(60,35,15,0.35)';
+            ctx.lineWidth = 2;
+            ctx.beginPath();
+            ctx.ellipse(kx, ky, kr, kr * 0.7, 0, 0, Math.PI * 2);
+            ctx.stroke();
+            ctx.fillStyle = 'rgba(80,50,25,0.25)';
+            ctx.beginPath();
+            ctx.ellipse(kx, ky, kr - 1, kr * 0.6, 0, 0, Math.PI * 2);
+            ctx.fill();
+        }
+
+        ctx.fillStyle = 'rgba(0,0,0,0.06)';
+        ctx.fillRect(x + boardW - 1, 0, 1, 512);
+
+        boardIdx++;
+    }
+}
+
+// Painted drywall - interior face of exterior walls. Off-white with subtle
+// roller texture.
+function _drawDrywallInterior(canvas, ctx) {
+    canvas.width = 256;
+    canvas.height = 256;
+    ctx.fillStyle = '#E2DBD2';
+    ctx.fillRect(0, 0, 256, 256);
+
+    // Subtle roller texture - tiny stipple noise
+    for (let i = 0; i < 600; i++) {
+        const x = Math.random() * 256;
+        const y = Math.random() * 256;
+        const s = 0.5 + Math.random() * 1.5;
+        ctx.fillStyle = `rgba(${Math.random() > 0.5 ? '255,255,255' : '0,0,0'},${0.01 + Math.random() * 0.02})`;
+        ctx.fillRect(x, y, s, s);
+    }
+}
+
+// -- wall material factory ----------------------------------------------------
+// Textured materials get a fresh texture from cached canvas with repeat scaled
+// to the wall's real-world dimensions. Solid materials use realistic muted colors.
+// Materials in INTERIOR_LOOK return [exteriorMat, interiorMat] for two-sided rendering.
+
+function _createWallMaterial(matKey, segLenM, winding, adjacentMat) {
+    const hex = REALISTIC_COLORS[matKey] || '#94a3b8';
+
+    // Per-segment materials (doors, windows) - drawn fresh with real dimensions,
+    // no tiling. The adjacent wall texture is tiled as the background so the
+    // siding/brick pattern flows continuously through the opening.
+    if (PER_SEGMENT.has(matKey)) {
+        const canvas = document.createElement('canvas');
+        const ctx = canvas.getContext('2d');
+        // Get the adjacent wall's texture canvas to tile as background
+        const bgTex = TEXTURED.has(adjacentMat) ? _getTexCanvas(adjacentMat) : null;
+        const fallback = SURROUND_COLORS[adjacentMat] || '#6E6E72';
+        const drawFn = {
+            window_1_pane: (c, x) => _drawWindow(c, x, 1, segLenM, WALL_HEIGHT_M, bgTex, fallback),
+            window_2_pane: (c, x) => _drawWindow(c, x, 2, segLenM, WALL_HEIGHT_M, bgTex, fallback),
+            window_3_pane: (c, x) => _drawWindow(c, x, 3, segLenM, WALL_HEIGHT_M, bgTex, fallback),
+            door_wood: (c, x) => _drawDoorWood(c, x, segLenM, WALL_HEIGHT_M, bgTex, fallback),
+            door_metal: (c, x) => _drawDoorMetal(c, x, segLenM, WALL_HEIGHT_M, bgTex, fallback),
+            door_glass: (c, x) => _drawDoorGlass(c, x, segLenM, WALL_HEIGHT_M, bgTex, fallback),
+        }[matKey];
+        if (drawFn) drawFn(canvas, ctx);
+        const tex = new THREE.CanvasTexture(canvas);
+        tex.colorSpace = THREE.SRGBColorSpace;
+        const exteriorMat = new THREE.MeshStandardMaterial({
+            map: tex,
+            transparent: WALL_OPACITY < 1.0,
+            opacity: WALL_OPACITY,
+            depthWrite: WALL_OPACITY >= 1.0,
+            roughness: 0.85,
+        });
+
+        // If the adjacent wall has an interior look, build a second canvas
+        // with the interior background for the back face.
+        const intKey = INTERIOR_LOOK[adjacentMat];
+        if (intKey) {
+            const intCanvas = document.createElement('canvas');
+            const intCtx = intCanvas.getContext('2d');
+            const intBg = _getInteriorTexCanvas(intKey);
+            const intFallback = SURROUND_COLORS.drywall || '#D8D2C8';
+            if (drawFn === null) return exteriorMat;
+            // Re-draw the same door/window but with interior background
+            const intDrawFn = {
+                window_1_pane: (c, x) => _drawWindow(c, x, 1, segLenM, WALL_HEIGHT_M, intBg, intFallback),
+                window_2_pane: (c, x) => _drawWindow(c, x, 2, segLenM, WALL_HEIGHT_M, intBg, intFallback),
+                window_3_pane: (c, x) => _drawWindow(c, x, 3, segLenM, WALL_HEIGHT_M, intBg, intFallback),
+                door_wood: (c, x) => _drawDoorWood(c, x, segLenM, WALL_HEIGHT_M, intBg, intFallback),
+                door_metal: (c, x) => _drawDoorMetal(c, x, segLenM, WALL_HEIGHT_M, intBg, intFallback),
+                door_glass: (c, x) => _drawDoorGlass(c, x, segLenM, WALL_HEIGHT_M, intBg, intFallback),
+            }[matKey];
+            if (intDrawFn) intDrawFn(intCanvas, intCtx);
+            const intTex = new THREE.CanvasTexture(intCanvas);
+            intTex.colorSpace = THREE.SRGBColorSpace;
+            const interiorMat = new THREE.MeshStandardMaterial({
+                map: intTex,
+                transparent: WALL_OPACITY < 1.0,
+                opacity: WALL_OPACITY,
+                depthWrite: WALL_OPACITY >= 1.0,
+                roughness: 0.85,
+            });
+            const face4 = winding > 0 ? exteriorMat : interiorMat;
+            const face5 = winding > 0 ? interiorMat : exteriorMat;
+            return [exteriorMat, exteriorMat, exteriorMat, exteriorMat, face4, face5];
+        }
+
+        exteriorMat.side = THREE.DoubleSide;
+        return exteriorMat;
+    }
+
+    const cached = TEXTURED.has(matKey) ? _getTexCanvas(matKey) : null;
+
+    // Build the exterior (primary) material
+    let exteriorMat;
+    if (cached) {
+        const tex = new THREE.CanvasTexture(cached.canvas);
+        tex.wrapS = THREE.RepeatWrapping;
+        tex.wrapT = THREE.RepeatWrapping;
+        tex.colorSpace = THREE.SRGBColorSpace;
+        tex.repeat.set(segLenM / cached.tileSizeM, WALL_HEIGHT_M / cached.tileSizeM);
+        exteriorMat = new THREE.MeshStandardMaterial({
+            map: tex,
+            transparent: WALL_OPACITY < 1.0,
+            opacity: WALL_OPACITY,
+            depthWrite: WALL_OPACITY >= 1.0,
+            side: THREE.FrontSide,
+            roughness: 0.85,
+        });
+    } else {
+        exteriorMat = new THREE.MeshStandardMaterial({
+            color: new THREE.Color(hex),
+            transparent: WALL_OPACITY < 1.0,
+            opacity: WALL_OPACITY,
+            depthWrite: WALL_OPACITY >= 1.0,
+            side: THREE.FrontSide,
+            emissive: new THREE.Color(hex),
+            emissiveIntensity: 0.05,
+            roughness: 0.7,
+        });
+    }
+
+    // If this material has a different interior look, return a 6-material array
+    // for BoxGeometry face groups: [+X, -X, +Y, -Y, +Z front, -Z back].
+    // Front face (+Z, group 4) gets the exterior, back face (-Z, group 5) gets interior.
+    const interiorKey = INTERIOR_LOOK[matKey];
+    if (interiorKey) {
+        const intCached = _getInteriorTexCanvas(interiorKey);
+        let interiorMat;
+        if (intCached) {
+            const tex = new THREE.CanvasTexture(intCached.canvas);
+            tex.wrapS = THREE.RepeatWrapping;
+            tex.wrapT = THREE.RepeatWrapping;
+            tex.colorSpace = THREE.SRGBColorSpace;
+            tex.repeat.set(segLenM / intCached.tileSizeM, WALL_HEIGHT_M / intCached.tileSizeM);
+            interiorMat = new THREE.MeshStandardMaterial({
+                map: tex,
+                transparent: WALL_OPACITY < 1.0,
+                opacity: WALL_OPACITY,
+                depthWrite: WALL_OPACITY >= 1.0,
+                roughness: 0.85,
+            });
+        } else {
+            interiorMat = exteriorMat;
+        }
+        // BoxGeometry groups: [+X, -X, +Y, -Y, +Z(front), -Z(back)]
+        // Winding determines which face is exterior: 1 = +Z is exterior, -1 = -Z is exterior
+        const face4 = winding > 0 ? exteriorMat : interiorMat;
+        const face5 = winding > 0 ? interiorMat : exteriorMat;
+        return [exteriorMat, exteriorMat, exteriorMat, exteriorMat, face4, face5];
+    }
+
+    return exteriorMat;
+}
+
+// -- floor plane (convex hull of wall points, not axis-aligned bbox) ----------
+
+function _buildFloorPlane(floor, scale, floorY, parent) {
+    const pts = [];
+    for (const wall of floor.walls) {
+        for (const pt of wall.points) {
+            pts.push(toScene(pt, scale));
+        }
+    }
+    if (pts.length < 3) return;
+
+    const hull = _convexHull(pts);
+    if (hull.length < 3) return;
+
+    const triCount = hull.length - 2;
+    const verts = new Float32Array(triCount * 9);
+    for (let i = 0; i < triCount; i++) {
+        const a = hull[0], b = hull[i + 1], c = hull[i + 2];
+        const off = i * 9;
+        verts[off]     = a.x; verts[off + 1] = floorY; verts[off + 2] = a.z;
+        verts[off + 3] = b.x; verts[off + 4] = floorY; verts[off + 5] = b.z;
+        verts[off + 6] = c.x; verts[off + 7] = floorY; verts[off + 8] = c.z;
+    }
+
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.BufferAttribute(verts, 3));
+    geo.computeVertexNormals();
+
+    const mat = new THREE.MeshStandardMaterial({
+        color: FLOOR_COLOR,
+        transparent: true,
+        opacity: FLOOR_OPACITY,
+        depthWrite: false,
+        side: THREE.DoubleSide,
+    });
+    parent.add(new THREE.Mesh(geo, mat));
+}
+
+// -- walls --------------------------------------------------------------------
+
+function _buildWalls(floor, scale, floorY, wallH, wallD, winding, parent) {
+    for (const wall of floor.walls) {
+        const pts = wall.points;
+        if (!pts || pts.length < 2) continue;
+
+        for (let i = 0; i < pts.length - 1; i++) {
+            const a = toScene(pts[i], scale);
+            const b = toScene(pts[i + 1], scale);
+
+            const dx = b.x - a.x;
+            const dz = b.z - a.z;
+            const segLen = Math.sqrt(dx * dx + dz * dz);
+            if (segLen < 0.001) continue;
+
+            // Real-world segment length from meter-space points
+            const mDx = pts[i + 1].x - pts[i].x;
+            const mDy = pts[i + 1].y - pts[i].y;
+            const segLenM = Math.sqrt(mDx * mDx + mDy * mDy);
+
+            const angle = Math.atan2(dz, dx);
+            const mx = (a.x + b.x) / 2;
+            const mz = (a.z + b.z) / 2;
+
+            const segMat = (wall.materials && wall.materials[i]) || wall.material;
+            // For doors/windows, find the adjacent wall material for the surround
+            let adjacentMat = wall.material;
+            if (PER_SEGMENT.has(segMat) && wall.materials) {
+                // Look at previous then next segment for a non-door/window material
+                for (const adj of [i - 1, i + 1]) {
+                    if (adj >= 0 && adj < wall.materials.length) {
+                        const m = wall.materials[adj] || wall.material;
+                        if (!PER_SEGMENT.has(m)) { adjacentMat = m; break; }
+                    }
+                }
+            }
+            // Returns a single material or a 6-element array for per-face rendering
+            const material = _createWallMaterial(segMat, segLenM, winding, adjacentMat);
+            const geo = new THREE.BoxGeometry(segLen, wallH, wallD);
+            const mesh = new THREE.Mesh(geo, material);
+            mesh.position.set(mx, floorY + wallH / 2, mz);
+            mesh.rotation.y = -angle;
+            parent.add(mesh);
+        }
+    }
+}
+
+// -- pitched roof -------------------------------------------------------------
+
+function _buildRoof(topFloor, building, scale, wallH, parent) {
+    const allPts = [];
+    for (const floor of building.floors) {
+        for (const wall of floor.walls) {
+            for (const pt of wall.points) {
+                allPts.push(toScene(pt, scale));
+            }
+        }
+    }
+    if (allPts.length < 3) return;
+
+    const hull = _convexHull(allPts);
+    if (hull.length < 3) return;
+
+    const obb = _orientedBoundingBox(hull);
+    const floorY = topFloor.z * scale * 0.8;
+    const eaveY = floorY + wallH;
+    const maxRidgeScene = MAX_RIDGE_M * scale * 0.8;
+    const ridgeHeight = Math.min(obb.shortLen * ROOF_PITCH, maxRidgeScene);
+    const ridgeY = eaveY + ridgeHeight;
+
+    const { longAxis, shortAxis, center } = obb;
+    const halfLong = obb.longLen / 2;
+    const halfShort = obb.shortLen / 2;
+
+    const rA = { x: center.x + longAxis.x * halfLong, z: center.z + longAxis.z * halfLong };
+    const rB = { x: center.x - longAxis.x * halfLong, z: center.z - longAxis.z * halfLong };
+
+    const c0 = { x: rA.x + shortAxis.x * halfShort, z: rA.z + shortAxis.z * halfShort };
+    const c1 = { x: rA.x - shortAxis.x * halfShort, z: rA.z - shortAxis.z * halfShort };
+    const c2 = { x: rB.x - shortAxis.x * halfShort, z: rB.z - shortAxis.z * halfShort };
+    const c3 = { x: rB.x + shortAxis.x * halfShort, z: rB.z + shortAxis.z * halfShort };
+
+    const overhang = obb.shortLen * 0.06;
+    const oc0 = _extend(c0, center, overhang);
+    const oc1 = _extend(c1, center, overhang);
+    const oc2 = _extend(c2, center, overhang);
+    const oc3 = _extend(c3, center, overhang);
+    const orA = _extend(rA, center, overhang);
+    const orB = _extend(rB, center, overhang);
+
+    const verts = new Float32Array([
+        oc0.x, eaveY, oc0.z,   orA.x, ridgeY, orA.z,   oc3.x, eaveY, oc3.z,
+        oc3.x, eaveY, oc3.z,   orA.x, ridgeY, orA.z,   orB.x, ridgeY, orB.z,
+        oc1.x, eaveY, oc1.z,   oc2.x, eaveY, oc2.z,    orA.x, ridgeY, orA.z,
+        oc2.x, eaveY, oc2.z,   orB.x, ridgeY, orB.z,    orA.x, ridgeY, orA.z,
+        oc0.x, eaveY, oc0.z,   oc1.x, eaveY, oc1.z,    orA.x, ridgeY, orA.z,
+        oc3.x, eaveY, oc3.z,   orB.x, ridgeY, orB.z,    oc2.x, eaveY, oc2.z,
+    ]);
+
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.BufferAttribute(verts, 3));
+    geo.computeVertexNormals();
+
+    const mat = new THREE.MeshStandardMaterial({
+        color: ROOF_COLOR,
+        transparent: true,
+        opacity: ROOF_OPACITY,
+        depthWrite: false,
+        side: THREE.DoubleSide,
+        emissive: new THREE.Color(ROOF_COLOR),
+        emissiveIntensity: 0.03,
+    });
+
+    parent.add(new THREE.Mesh(geo, mat));
+}
+
+function _extend(point, center, amount) {
+    const dx = point.x - center.x;
+    const dz = point.z - center.z;
+    const d = Math.sqrt(dx * dx + dz * dz) || 1;
+    return {
+        x: point.x + (dx / d) * amount,
+        z: point.z + (dz / d) * amount,
+    };
+}
+
+// -- convex hull (Andrew's monotone chain) ------------------------------------
+
+function _convexHull(points) {
+    const pts = points.slice().sort((a, b) => a.x - b.x || a.z - b.z);
+    if (pts.length <= 2) return pts.slice();
+
+    const cross = (o, a, b) =>
+        (a.x - o.x) * (b.z - o.z) - (a.z - o.z) * (b.x - o.x);
+
+    const lower = [];
+    for (const p of pts) {
+        while (lower.length >= 2 && cross(lower[lower.length - 2], lower[lower.length - 1], p) <= 0)
+            lower.pop();
+        lower.push(p);
+    }
+
+    const upper = [];
+    for (let i = pts.length - 1; i >= 0; i--) {
+        while (upper.length >= 2 && cross(upper[upper.length - 2], upper[upper.length - 1], pts[i]) <= 0)
+            upper.pop();
+        upper.push(pts[i]);
+    }
+
+    lower.pop();
+    upper.pop();
+    return lower.concat(upper);
+}
+
+// -- oriented bounding box (minimum-area rectangle) ---------------------------
+
+function _orientedBoundingBox(hull) {
+    let bestArea = Infinity;
+    let bestResult = null;
+
+    for (let i = 0; i < hull.length; i++) {
+        const j = (i + 1) % hull.length;
+        const edgeDx = hull[j].x - hull[i].x;
+        const edgeDz = hull[j].z - hull[i].z;
+        const edgeLen = Math.sqrt(edgeDx * edgeDx + edgeDz * edgeDz);
+        if (edgeLen < 1e-9) continue;
+
+        const ax = edgeDx / edgeLen;
+        const az = edgeDz / edgeLen;
+        const bx = -az;
+        const bz = ax;
+
+        let minA = Infinity, maxA = -Infinity;
+        let minB = Infinity, maxB = -Infinity;
+        for (const p of hull) {
+            const projA = p.x * ax + p.z * az;
+            const projB = p.x * bx + p.z * bz;
+            if (projA < minA) minA = projA;
+            if (projA > maxA) maxA = projA;
+            if (projB < minB) minB = projB;
+            if (projB > maxB) maxB = projB;
+        }
+
+        const area = (maxA - minA) * (maxB - minB);
+        if (area < bestArea) {
+            bestArea = area;
+            const lenA = maxA - minA;
+            const lenB = maxB - minB;
+            const isALong = lenA >= lenB;
+            const longLen = isALong ? lenA : lenB;
+            const shortLen = isALong ? lenB : lenA;
+            const longAxis = isALong ? { x: ax, z: az } : { x: bx, z: bz };
+            const shortAxis = isALong ? { x: bx, z: bz } : { x: ax, z: az };
+            const midA = (minA + maxA) / 2;
+            const midB = (minB + maxB) / 2;
+            const cx = midA * ax + midB * bx;
+            const cz = midA * az + midB * bz;
+
+            bestResult = {
+                longLen,
+                shortLen,
+                longAxis,
+                shortAxis,
+                center: { x: cx, z: cz },
+                corners: [
+                    { x: minA * ax + minB * bx, z: minA * az + minB * bz },
+                    { x: maxA * ax + minB * bx, z: maxA * az + minB * bz },
+                    { x: maxA * ax + maxB * bx, z: maxA * az + maxB * bz },
+                    { x: minA * ax + maxB * bx, z: minA * az + maxB * bz },
+                ],
+            };
+        }
+    }
+
+    return bestResult;
+}

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -235,6 +235,30 @@ export class LanFlowMap {
         this.controls.maxDistance = 220;
         this.controls.target.set(0, 0, 0);
 
+        // Restore persisted camera target for fly-in destination.
+        try {
+            const saved = JSON.parse(localStorage.getItem('lanFlowMapCamera'));
+            if (saved) {
+                this._savedCamera = saved;
+            }
+        } catch {}
+
+        // Persist camera on orbit change with 500ms debounce.
+        let camSaveTimer = null;
+        this.controls.addEventListener('change', () => {
+            clearTimeout(camSaveTimer);
+            camSaveTimer = setTimeout(() => {
+                try {
+                    const p = this.camera.position;
+                    const t = this.controls.target;
+                    localStorage.setItem('lanFlowMapCamera', JSON.stringify({
+                        cx: p.x, cy: p.y, cz: p.z,
+                        tx: t.x, ty: t.y, tz: t.z,
+                    }));
+                } catch {}
+            }, 500);
+        });
+
         // Subtle hemispheric lighting so nodes have a sense of depth without flat shading.
         const hemi = new THREE.HemisphereLight(0xb1d4ff, 0x1a2029, 0.55);
         const ambient = new THREE.AmbientLight(0xffffff, 0.35);
@@ -1119,9 +1143,16 @@ export class LanFlowMap {
     // ------------------------------------------------------------------------
 
     _startAnimation() {
-        // Schedule a one-shot camera fly-in on first frame.
+        // Schedule a one-shot camera fly-in. If the user has a saved camera
+        // position, fly to that instead of the default overview.
         this._flyInUntil = performance.now() + 1300;
-        this._flyInTargetCam = new THREE.Vector3(60, 40, 60);
+        const sc = this._savedCamera;
+        this._flyInTargetCam = sc
+            ? new THREE.Vector3(sc.cx, sc.cy, sc.cz)
+            : new THREE.Vector3(60, 40, 60);
+        this._flyInTargetLookAt = sc
+            ? new THREE.Vector3(sc.tx, sc.ty, sc.tz)
+            : null;
         this._flyInStartCam = this.camera.position.clone();
 
         // Cap render rate at 120 fps. setAnimationLoop is the modern Three.js
@@ -1162,7 +1193,10 @@ export class LanFlowMap {
                 const t = 1 - (this._flyInUntil - now) / 1300;
                 const eased = 1 - Math.pow(1 - t, 3);
                 this.camera.position.lerpVectors(this._flyInStartCam, this._flyInTargetCam, eased);
-                this.camera.lookAt(0, 0, 0);
+                if (this._flyInTargetLookAt) {
+                    this.controls.target.lerpVectors(new THREE.Vector3(0, 0, 0), this._flyInTargetLookAt, eased);
+                }
+                this.camera.lookAt(this.controls.target);
             } else if (this._repositionMode && this._repositionGroup) {
                 // In reposition mode WASD nudges the device on the XZ plane
                 if (this._keys) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -16,8 +16,8 @@ import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 import { buildBuildings } from './lan-flow-buildings.js';
 
 const COLORS = {
-    background: 0x161618,
-    fog: 0x161618,
+    background: 0x2a2a2e,
+    fog: 0x2a2a2e,
     gateway: 0xfacc15,
     switchNode: 0x9aa6b2,
     ap: 0x3385d6,

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -464,12 +464,13 @@ export class LanFlowMap {
     }
 
     _rebuildBuildings(snap) {
+        const disposeMat = (m) => { if (m.map) m.map.dispose(); m.dispose(); };
         const disposeGroup = (g) => {
             g.traverse((obj) => {
                 if (obj.geometry) obj.geometry.dispose();
                 if (obj.material) {
-                    if (Array.isArray(obj.material)) obj.material.forEach((m) => m.dispose());
-                    else obj.material.dispose();
+                    if (Array.isArray(obj.material)) obj.material.forEach(disposeMat);
+                    else disposeMat(obj.material);
                 }
             });
             while (g.children.length) g.remove(g.children[0]);
@@ -2507,7 +2508,7 @@ export class LanFlowMap {
 
         // Reverse-project 3D scene coords back to geo
         const bounds = this._snapshot?.bounds;
-        if (!bounds?.centerLat || !bounds?.lngScale) {
+        if (bounds?.centerLat == null || bounds?.lngScale == null) {
             console.warn('[LanFlowMap] No projection params - cannot save placement');
             return;
         }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -206,7 +206,7 @@ export class LanFlowMap {
 
         this.camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 1000);
         // Will animate IN from here on first mount via _flyIn().
-        this.camera.position.set(95, 60, 95);
+        this.camera.position.set(120, 80, 120);
         this.camera.lookAt(0, 0, 0);
 
         // Post-processing: bloom for the luminous-particles look. Selective bloom would
@@ -1121,7 +1121,7 @@ export class LanFlowMap {
     _startAnimation() {
         // Schedule a one-shot camera fly-in on first frame.
         this._flyInUntil = performance.now() + 1300;
-        this._flyInTargetCam = new THREE.Vector3(40, 25, 40);
+        this._flyInTargetCam = new THREE.Vector3(60, 40, 60);
         this._flyInStartCam = this.camera.position.clone();
 
         // Cap render rate at 120 fps. setAnimationLoop is the modern Three.js

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -156,6 +156,12 @@ export class LanFlowMap {
         this._pointerScreen = { x: 0, y: 0 };
         this._hoverTarget = null;
 
+        // Reposition mode state
+        this._repositionMode = false;
+        this._repositionNode = null;   // node being moved
+        this._repositionGroup = null;  // THREE.Group for the node
+        this._repositionOrigPos = null; // original position for cancel
+
         this._raf = null;
         this._pollTimer = null;
         this._lastFrame = performance.now();
@@ -246,18 +252,27 @@ export class LanFlowMap {
         this.canvas.addEventListener('pointermove', (e) => this._onPointerMove(e));
         this.canvas.addEventListener('pointerleave', () => this._clearHover());
         this.canvas.addEventListener('dblclick', (e) => this._onDoubleClick(e));
+        this.canvas.addEventListener('contextmenu', (e) => this._onContextMenu(e));
+        this.canvas.addEventListener('pointerdown', (e) => {
+            if (this._repositionMode) return;
+            this._dismissContextMenu();
+        });
 
         // WASD keyboard navigation: W/S = zoom in/out, A/D = orbit left/right
         this._keys = {};
         this._onKeyDown = (e) => {
             if (e.key === 'Escape') {
+                if (this._repositionMode) {
+                    this._cancelReposition();
+                    return;
+                }
                 if (this.stage?.classList.contains('lan-flow-map-fullscreen')) {
                     this._toggleFullscreen();
                     return;
                 }
             }
             if (!this._shouldAcceptKeys()) return;
-            if (['w','a','s','d'].includes(e.key.toLowerCase())) {
+            if (['w','a','s','d','q','e'].includes(e.key.toLowerCase())) {
                 this._keys[e.key.toLowerCase()] = true;
             }
         };
@@ -323,6 +338,8 @@ export class LanFlowMap {
 
     dispose() {
         this._destroyed = true;
+        if (this._repositionMode) this._exitRepositionMode();
+        this._dismissContextMenu();
         // The render loop registered via setAnimationLoop checks _destroyed
         // and tears itself down. Belt-and-suspenders null it here too.
         this.renderer?.setAnimationLoop(null);
@@ -430,7 +447,7 @@ export class LanFlowMap {
         // and then spread by ANCHOR_SPREAD_FACTOR so interpolated / unanchored
         // devices have room to settle between the pinned APs without crowding.
         const sceneRadius = 30.0;
-        const ANCHOR_SPREAD_FACTOR = 1.5;
+        const ANCHOR_SPREAD_FACTOR = 1.875;
         const scale = (sceneRadius / Math.max(bounds.radius, 1.0)) * ANCHOR_SPREAD_FACTOR;
 
         const positions = new Map();
@@ -440,16 +457,16 @@ export class LanFlowMap {
             const p = node.placement;
             if (p && p.source === PLACEMENT_SOURCE.Anchor) {
                 positions.set(node.id, {
-                    x: p.x * scale,
-                    y: p.z * scale * 0.4,    // floors get vertical separation but compressed
+                    x: -p.x * scale,
+                    y: p.z * scale * 0.8,    // floors get vertical separation but compressed
                     z: p.y * scale,
                     pinned: true,
                 });
                 anchors.set(node.id, true);
             } else if (p && p.source === PLACEMENT_SOURCE.Interpolated) {
                 positions.set(node.id, {
-                    x: p.x * scale,
-                    y: p.z * scale * 0.4 - 4,
+                    x: -p.x * scale,
+                    y: p.z * scale * 0.8 - 4,
                     z: p.y * scale,
                     pinned: false,
                 });
@@ -538,6 +555,27 @@ export class LanFlowMap {
                 p.y += v.vy;
                 p.z += v.vz;
             }
+        }
+
+        // Post-layout: push WiFi clients outward from their parent AP so they
+        // fan out rather than clustering tightly around the infrastructure.
+        const WIFI_SPREAD = 1.4;
+        for (const node of snap.nodes) {
+            if (node.kind !== NODE_KIND.WifiClient) continue;
+            const p = positions.get(node.id);
+            if (!p || p.pinned) continue;
+            const parentId = node.parentId;
+            if (!parentId) continue;
+            const pp = positions.get(parentId);
+            if (!pp) continue;
+            const dx = p.x - pp.x;
+            const dy = p.y - pp.y;
+            const dz = p.z - pp.z;
+            const d = Math.sqrt(dx * dx + dy * dy + dz * dz);
+            if (d < 0.1) continue;
+            p.x = pp.x + dx * WIFI_SPREAD;
+            p.y = pp.y + dy * WIFI_SPREAD;
+            p.z = pp.z + dz * WIFI_SPREAD;
         }
 
         this._positions = positions;
@@ -1031,6 +1069,29 @@ export class LanFlowMap {
                 const eased = 1 - Math.pow(1 - t, 3);
                 this.camera.position.lerpVectors(this._flyInStartCam, this._flyInTargetCam, eased);
                 this.camera.lookAt(0, 0, 0);
+            } else if (this._repositionMode && this._repositionGroup) {
+                // In reposition mode WASD nudges the device on the XZ plane
+                if (this._keys) {
+                    const step = 0.35;
+                    const cam = this.camera;
+                    const forward = new THREE.Vector3();
+                    cam.getWorldDirection(forward);
+                    forward.y = 0;
+                    forward.normalize();
+                    const right = new THREE.Vector3();
+                    right.crossVectors(forward, cam.up).normalize();
+
+                    const g = this._repositionGroup;
+                    if (this._keys['w']) { g.position.x += forward.x * step; g.position.z += forward.z * step; }
+                    if (this._keys['s']) { g.position.x -= forward.x * step; g.position.z -= forward.z * step; }
+                    if (this._keys['d']) { g.position.x += right.x * step; g.position.z += right.z * step; }
+                    if (this._keys['a']) { g.position.x -= right.x * step; g.position.z -= right.z * step; }
+                    if (this._keys['e']) { g.position.y += step; this._repositionPlane.constant = -g.position.y; }
+                    if (this._keys['q']) { g.position.y -= step; this._repositionPlane.constant = -g.position.y; }
+                    if (this._keys['w'] || this._keys['a'] || this._keys['s'] || this._keys['d'] || this._keys['q'] || this._keys['e']) {
+                        this._updateAdjacentLinks();
+                    }
+                }
             } else {
                 // WASD: W/S zoom, A/D orbit around target
                 if (this._keys) {
@@ -1313,6 +1374,7 @@ export class LanFlowMap {
                 <div class="lan-flow-map-help-row"><span>Zoom</span><span class="kbd">Scroll</span> or <span class="kbd">W</span> <span class="kbd">S</span></div>
                 <div class="lan-flow-map-help-row"><span>Hover detail</span><span class="kbd">Mouse over</span></div>
                 <div class="lan-flow-map-help-row"><span>Open client</span><span class="kbd">Double-click</span></div>
+                <div class="lan-flow-map-help-row"><span>Move device</span><span class="kbd">Right-click</span></div>
                 <div class="lan-flow-map-help-row"><span>Fullscreen</span><span class="kbd">Esc</span> to exit</div>
             </div>
         `;
@@ -1939,6 +2001,7 @@ export class LanFlowMap {
         this._pointerScreen.y = e.clientY - rect.top;
         this._pointerNdc.x = (this._pointerScreen.x / rect.width) * 2 - 1;
         this._pointerNdc.y = -(this._pointerScreen.y / rect.height) * 2 + 1;
+        if (this._repositionMode) return;
         this._raycaster.setFromCamera(this._pointerNdc, this.camera);
         // Raycast against device node spheres - cheap, ~tens of meshes.
         const candidates = [];
@@ -1959,6 +2022,7 @@ export class LanFlowMap {
     }
 
     _onDoubleClick(e) {
+        if (this._repositionMode) return;
         const rect = this.canvas.getBoundingClientRect();
         const ndc = new THREE.Vector2(
             ((e.clientX - rect.left) / rect.width) * 2 - 1,
@@ -2081,6 +2145,308 @@ export class LanFlowMap {
     _clearHover() {
         if (this._tooltipEl) this._tooltipEl.classList.remove('is-visible');
         this._hoverTarget = null;
+    }
+
+    // ------------------------------------------------------------------------
+    // Right-click context menu + device reposition
+    // ------------------------------------------------------------------------
+
+    _onContextMenu(e) {
+        e.preventDefault();
+        if (this._repositionMode) return;
+
+        const rect = this.canvas.getBoundingClientRect();
+        const ndc = new THREE.Vector2(
+            ((e.clientX - rect.left) / rect.width) * 2 - 1,
+            -((e.clientY - rect.top) / rect.height) * 2 + 1
+        );
+        this._raycaster.setFromCamera(ndc, this.camera);
+        const candidates = [];
+        for (const group of this._nodeMeshes.values()) {
+            if (!group.visible) continue;
+            for (const child of group.children) {
+                if (child.isMesh) candidates.push(child);
+            }
+        }
+        const hits = this._raycaster.intersectObjects(candidates, false);
+        if (hits.length === 0) return;
+        let g = hits[0].object;
+        while (g && !(g.userData?.node)) g = g.parent;
+        if (!g) return;
+        const node = g.userData.node;
+        if (node.kind !== NODE_KIND.Gateway && node.kind !== NODE_KIND.Switch && node.kind !== NODE_KIND.WiredClient) return;
+
+        this._showContextMenu(e.clientX, e.clientY, node, g);
+    }
+
+    _showContextMenu(clientX, clientY, node, group) {
+        this._dismissContextMenu();
+        const menu = document.createElement('div');
+        menu.className = 'lan-flow-map-context-menu';
+        const item = document.createElement('div');
+        item.className = 'lan-flow-map-context-menu-item';
+        item.textContent = 'Reposition Device';
+        item.addEventListener('click', (e) => {
+            e.stopPropagation();
+            this._dismissContextMenu();
+            this._enterReposition(node, group);
+        });
+        menu.appendChild(item);
+
+        const stageRect = this.stage.getBoundingClientRect();
+        menu.style.left = `${clientX - stageRect.left}px`;
+        menu.style.top = `${clientY - stageRect.top}px`;
+        this.stage.appendChild(menu);
+        this._contextMenuEl = menu;
+    }
+
+    _dismissContextMenu() {
+        if (this._contextMenuEl) {
+            this._contextMenuEl.remove();
+            this._contextMenuEl = null;
+        }
+    }
+
+    _enterReposition(node, group) {
+        this._repositionMode = true;
+        this._repositionNode = node;
+        this._repositionGroup = group;
+        this._repositionOrigPos = group.position.clone();
+        this._clearHover();
+
+        this.controls.enabled = false;
+        this.canvas.style.cursor = 'move';
+
+        // Show the reposition HUD banner
+        const hud = document.createElement('div');
+        hud.className = 'lan-flow-map-reposition-hud';
+        hud.innerHTML = `
+            <span class="lan-flow-map-reposition-title">Moving: ${escapeHtml(node.name || node.mac || 'Device')}</span>
+            <span class="lan-flow-map-reposition-keys">
+                <span class="kbd">W</span><span class="kbd">A</span><span class="kbd">S</span><span class="kbd">D</span> move
+                &nbsp;&middot;&nbsp; <span class="kbd">Q</span><span class="kbd">E</span> / <span class="kbd">Scroll</span> height
+                &nbsp;&middot;&nbsp; Drag to move
+                &nbsp;&middot;&nbsp; <span class="kbd">Click</span> place
+                &nbsp;&middot;&nbsp; <span class="kbd">Esc</span> cancel
+            </span>
+        `;
+        this.stage.appendChild(hud);
+        this._repositionHud = hud;
+
+        // Set up mouse-drag on the XZ plane at the device's Y height.
+        // Confirm on pointerup only if the pointer barely moved (click, not drag).
+        this._repositionDragging = false;
+        this._repositionDragMoved = false;
+        this._repositionDownPt = null;
+        this._repositionPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), -group.position.y);
+        this._repositionMoveHandler = (e) => this._onRepositionPointerMove(e);
+        this._repositionDownHandler = (e) => {
+            if (e.button === 0) {
+                this._repositionDragging = true;
+                this._repositionDragMoved = false;
+                this._repositionDownPt = { x: e.clientX, y: e.clientY };
+                e.preventDefault();
+            }
+        };
+        this._repositionUpHandler = (e) => {
+            if (e.button === 0 && this._repositionMode) {
+                this._repositionDragging = false;
+                if (!this._repositionDragMoved) {
+                    this._confirmReposition();
+                }
+            }
+        };
+        this._repositionWheelHandler = (e) => {
+            if (!this._repositionMode) return;
+            e.preventDefault();
+            const step = e.deltaY > 0 ? -0.5 : 0.5;
+            this._repositionGroup.position.y += step;
+            this._repositionPlane.constant = -this._repositionGroup.position.y;
+            this._updateAdjacentLinks();
+        };
+        this.canvas.addEventListener('pointermove', this._repositionMoveHandler);
+        this.canvas.addEventListener('pointerdown', this._repositionDownHandler, true);
+        this.canvas.addEventListener('pointerup', this._repositionUpHandler);
+        this.canvas.addEventListener('wheel', this._repositionWheelHandler, { passive: false });
+    }
+
+    _onRepositionPointerMove(e) {
+        if (!this._repositionMode || !this._repositionDragging) return;
+
+        // Track whether the pointer actually moved (drag vs click)
+        if (this._repositionDownPt) {
+            const dx = e.clientX - this._repositionDownPt.x;
+            const dy = e.clientY - this._repositionDownPt.y;
+            if (dx * dx + dy * dy > 9) this._repositionDragMoved = true;
+        }
+        if (!this._repositionDragMoved) return;
+
+        const rect = this.canvas.getBoundingClientRect();
+        const ndc = new THREE.Vector2(
+            ((e.clientX - rect.left) / rect.width) * 2 - 1,
+            -((e.clientY - rect.top) / rect.height) * 2 + 1
+        );
+        this._raycaster.setFromCamera(ndc, this.camera);
+        const intersection = new THREE.Vector3();
+        if (this._raycaster.ray.intersectPlane(this._repositionPlane, intersection)) {
+            this._repositionGroup.position.x = intersection.x;
+            this._repositionGroup.position.z = intersection.z;
+            this._updateAdjacentLinks();
+        }
+    }
+
+    _updateAdjacentLinks() {
+        if (!this._repositionNode) return;
+        const nodeId = this._repositionNode.id;
+        const pos = this._repositionGroup.position;
+
+        // If moving a gateway, drag all connected clouds along (they're positioned
+        // relative to the gateway and have no independent geo coords).
+        if (this._repositionNode.kind === NODE_KIND.Gateway) {
+            if (!this._repositionCloudOffsets) {
+                this._repositionCloudOffsets = new Map();
+                for (const [cloudId, group] of this._cloudMeshes) {
+                    this._repositionCloudOffsets.set(cloudId, {
+                        dx: group.position.x - this._repositionOrigPos.x,
+                        dy: group.position.y - this._repositionOrigPos.y,
+                        dz: group.position.z - this._repositionOrigPos.z,
+                    });
+                }
+            }
+            for (const [cloudId, offset] of this._repositionCloudOffsets) {
+                const group = this._cloudMeshes.get(cloudId);
+                if (!group) continue;
+                group.position.set(pos.x + offset.dx, pos.y + offset.dy, pos.z + offset.dz);
+                this._positions.set(cloudId, {
+                    x: group.position.x, y: group.position.y, z: group.position.z, pinned: true,
+                });
+            }
+        }
+
+        for (const [linkId, linkObj] of this._linkMeshes) {
+            if (linkObj.link.fromNodeId !== nodeId && linkObj.link.toNodeId !== nodeId) continue;
+            const otherNodeId = linkObj.link.fromNodeId === nodeId ? linkObj.link.toNodeId : linkObj.link.fromNodeId;
+            const otherGroup = this._nodeMeshes.get(otherNodeId) || this._cloudMeshes.get(otherNodeId);
+            if (!otherGroup) continue;
+
+            const a = linkObj.link.fromNodeId === nodeId ? pos : otherGroup.position;
+            const b = linkObj.link.toNodeId === nodeId ? pos : otherGroup.position;
+
+            // Update pipe mesh
+            this._updatePipePosition(linkObj.pipe, a, b);
+            // Update particle stream endpoints
+            if (linkObj.link.fromNodeId === nodeId) {
+                linkObj.down.updateEndpoints(pos, otherGroup.position);
+                linkObj.up.updateEndpoints(otherGroup.position, pos);
+            } else {
+                linkObj.down.updateEndpoints(otherGroup.position, pos);
+                linkObj.up.updateEndpoints(pos, otherGroup.position);
+            }
+        }
+    }
+
+    _updatePipePosition(pipe, a, b) {
+        if (!pipe.isMesh) return;
+        const from = new THREE.Vector3(a.x, a.y, a.z);
+        const to = new THREE.Vector3(b.x, b.y, b.z);
+        const dir = to.clone().sub(from);
+        const length = dir.length();
+        if (length < 0.01) return;
+
+        const mid = from.clone().add(to).multiplyScalar(0.5);
+        pipe.position.copy(mid);
+        pipe.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), dir.clone().normalize());
+        const origHeight = pipe.geometry.parameters?.height || 1;
+        pipe.scale.y = length / origHeight;
+    }
+
+    async _confirmReposition() {
+        if (!this._repositionMode) return;
+        const group = this._repositionGroup;
+        const node = this._repositionNode;
+        const pos = { x: group.position.x, y: group.position.y, z: group.position.z };
+
+        this._exitRepositionMode();
+
+        // Update the internal positions map
+        this._positions.set(node.id, {
+            x: pos.x, y: pos.y, z: pos.z, pinned: true,
+        });
+
+        // Reverse-project 3D scene coords back to geo
+        const bounds = this._snapshot?.bounds;
+        if (!bounds?.centerLat || !bounds?.lngScale) {
+            console.warn('[LanFlowMap] No projection params - cannot save placement');
+            return;
+        }
+        const sceneRadius = 30.0;
+        const ANCHOR_SPREAD_FACTOR = 1.875;
+        const scale = (sceneRadius / Math.max(bounds.radius, 1.0)) * ANCHOR_SPREAD_FACTOR;
+        const EARTH_RADIUS = 6_371_000.0;
+
+        // Undo JS transform: posX = -(local.x * scale), posZ = local.y * scale
+        // (posY = local.z * scale * 0.8 but we don't save floor from 3D)
+        const localX = -(pos.x / scale);
+        const localY = pos.z / scale; // JS z maps to projection y
+
+        // Undo equirectangular projection
+        const dLng = localX / (bounds.lngScale * EARTH_RADIUS);
+        const dLat = localY / EARTH_RADIUS;
+        const lat = bounds.centerLat + dLat * 180 / Math.PI;
+        const lng = bounds.centerLng + dLng * 180 / Math.PI;
+
+        // Reverse Y → floor: posY = floor * 3.0 * scale * 0.8
+        const floor = Math.round(pos.y / (scale * 0.8) / 3.0);
+
+        try {
+            await fetch(`${this.apiBase}/device-placement`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                credentials: 'same-origin',
+                body: JSON.stringify({ mac: node.mac, latitude: lat, longitude: lng, floor }),
+            });
+        } catch (err) {
+            console.error('[LanFlowMap] Failed to save placement:', err);
+        }
+    }
+
+    _cancelReposition() {
+        if (!this._repositionMode) return;
+        this._repositionGroup.position.copy(this._repositionOrigPos);
+        // Restore cloud positions if we moved a gateway
+        if (this._repositionCloudOffsets) {
+            for (const [cloudId, offset] of this._repositionCloudOffsets) {
+                const group = this._cloudMeshes.get(cloudId);
+                if (!group) continue;
+                group.position.set(
+                    this._repositionOrigPos.x + offset.dx,
+                    this._repositionOrigPos.y + offset.dy,
+                    this._repositionOrigPos.z + offset.dz,
+                );
+            }
+        }
+        this._updateAdjacentLinks();
+        this._exitRepositionMode();
+    }
+
+    _exitRepositionMode() {
+        this._repositionMode = false;
+        this._repositionNode = null;
+        this._repositionGroup = null;
+        this._repositionOrigPos = null;
+        this._repositionDragging = false;
+        this._repositionDragMoved = false;
+        this._repositionDownPt = null;
+        this._repositionCloudOffsets = null;
+
+        this.controls.enabled = true;
+        this.canvas.style.cursor = '';
+
+        if (this._repositionHud) { this._repositionHud.remove(); this._repositionHud = null; }
+        this.canvas.removeEventListener('pointermove', this._repositionMoveHandler);
+        this.canvas.removeEventListener('pointerdown', this._repositionDownHandler, true);
+        this.canvas.removeEventListener('pointerup', this._repositionUpHandler);
+        this.canvas.removeEventListener('wheel', this._repositionWheelHandler);
     }
 }
 
@@ -2229,6 +2595,14 @@ class ParticleStream {
         // Velocity: 2.5 idle -> 6.5 saturated. Still communicates throughput
         // without slamming between crawl and jet on per-poll rate fluctuations.
         this._velocity = 2.5 + intensity * 4.0;
+    }
+
+    updateEndpoints(from, to) {
+        this._from.set(from.x, from.y, from.z);
+        this._to.set(to.x, to.y, to.z);
+        this._direction.copy(this._to).sub(this._from);
+        this._length = this._direction.length();
+        this._direction.normalize();
     }
 
     advance(dt) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -16,8 +16,8 @@ import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 import { buildBuildings } from './lan-flow-buildings.js';
 
 const COLORS = {
-    background: 0x101820,
-    fog: 0x101820,
+    background: 0x161618,
+    fog: 0x161618,
     gateway: 0xfacc15,
     switchNode: 0x9aa6b2,
     ap: 0x3385d6,

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -16,8 +16,8 @@ import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 import { buildBuildings } from './lan-flow-buildings.js';
 
 const COLORS = {
-    background: 0x2a2a2e,
-    fog: 0x2a2a2e,
+    background: 0x202023,
+    fog: 0x202023,
     gateway: 0xfacc15,
     switchNode: 0x9aa6b2,
     ap: 0x3385d6,

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -194,9 +194,7 @@ export class LanFlowMap {
         this.renderer.toneMappingExposure = 1.15;
 
         this.scene = new THREE.Scene();
-        // Radial gradient background - slightly lighter at the center, deep blue-black
-        // at the edges. Gives the scene depth without dominating.
-        this.scene.background = makeRadialBackgroundTexture(width, height);
+        this.scene.background = new THREE.Color(COLORS.background);
         this.scene.fog = new THREE.Fog(COLORS.fog, 70, 260);
 
         this.camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 1000);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1412,7 +1412,7 @@ export class LanFlowMap {
         const overlayDefs = [
             ['wifiClients', 'Wi-Fi clients'],
             ['wiredClients', 'Wired clients'],
-            ['clouds', 'WAN clouds'],
+            ['clouds', 'WAN globes'],
             ['buildings', 'Buildings'],
             // TODO: Speed test path overlay needs rework - see research/monitoring/3d-map-overlays-TODO.md
         ];

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -456,6 +456,7 @@ export class LanFlowMap {
             this._buildClouds(snap);
             this._buildLinks(snap);
             this._buildFloatingLabels(snap);
+            this._applyOverlayVisibility();
             this._applyLiveRates(snap.liveRates || {});
         } catch (err) {
             this.onError(err);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -130,13 +130,20 @@ export class LanFlowMap {
 
         // Overlay + filter state. Defaults match spec 5.7.1 ("default 'all on' so a
         // first-time user sees the full picture, but power users can declutter").
-        this._overlays = {
+        // Restore persisted overlay toggles, falling back to defaults.
+        const defaultOverlays = {
             wifiClients: true,
             wiredClients: true,
             clouds: true,
-            speedTests: false,    // off by default - heavy visual, opt-in
+            speedTests: false,
             buildings: true,
         };
+        try {
+            const saved = JSON.parse(localStorage.getItem('lanFlowMapOverlays'));
+            this._overlays = saved ? { ...defaultOverlays, ...saved } : { ...defaultOverlays };
+        } catch {
+            this._overlays = { ...defaultOverlays };
+        }
         this._filter = {
             text: '',
             bands: { '2.4': true, '5': true, '6': true },
@@ -1418,6 +1425,7 @@ export class LanFlowMap {
                 row.classList.toggle('is-on', this._overlays[key]);
                 this._applyOverlayVisibility();
                 if (key === 'speedTests') this._renderSpeedTestOverlay();
+                try { localStorage.setItem('lanFlowMapOverlays', JSON.stringify(this._overlays)); } catch {}
             });
             controlsBody.appendChild(row);
         }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -13,6 +13,7 @@ import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
 import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
 import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+import { buildBuildings } from './lan-flow-buildings.js';
 
 const COLORS = {
     background: 0x101820,
@@ -134,6 +135,7 @@ export class LanFlowMap {
             wiredClients: true,
             clouds: true,
             speedTests: false,    // off by default - heavy visual, opt-in
+            buildings: true,
         };
         this._filter = {
             text: '',
@@ -237,12 +239,13 @@ export class LanFlowMap {
 
 
         // Container groups so toggling layers is cheap.
+        this.buildingGroup = new THREE.Group();
         this.nodeGroup = new THREE.Group();
         this.linkGroup = new THREE.Group();
         this.cloudGroup = new THREE.Group();
         this.particleGroup = new THREE.Group();
         this.labelGroup = new THREE.Group();
-        this.scene.add(this.nodeGroup, this.linkGroup, this.cloudGroup, this.particleGroup, this.labelGroup);
+        this.scene.add(this.buildingGroup, this.nodeGroup, this.linkGroup, this.cloudGroup, this.particleGroup, this.labelGroup);
     }
 
     _initInteractions() {
@@ -361,16 +364,21 @@ export class LanFlowMap {
     }
 
     _disposeScene() {
+        const disposeMat = (m) => {
+            if (m.map) m.map.dispose();
+            m.dispose();
+        };
         const disposeGroup = (g) => {
             g.traverse((obj) => {
                 if (obj.geometry) obj.geometry.dispose();
                 if (obj.material) {
-                    if (Array.isArray(obj.material)) obj.material.forEach((m) => m.dispose());
-                    else obj.material.dispose();
+                    if (Array.isArray(obj.material)) obj.material.forEach(disposeMat);
+                    else disposeMat(obj.material);
                 }
             });
             while (g.children.length) g.remove(g.children[0]);
         };
+        if (this.buildingGroup) disposeGroup(this.buildingGroup);
         if (this.nodeGroup) disposeGroup(this.nodeGroup);
         if (this.linkGroup) disposeGroup(this.linkGroup);
         if (this.cloudGroup) disposeGroup(this.cloudGroup);
@@ -412,6 +420,7 @@ export class LanFlowMap {
             this._snapshot = snap;
 
             this._layoutNodes(snap);
+            this._rebuildBuildings(snap);
             this._buildNodes(snap);
             // Clouds must build before links - links reference cloud node IDs in their
             // FromNodeId/ToNodeId and _buildLinks looks positions up via _positions.
@@ -422,6 +431,26 @@ export class LanFlowMap {
         } catch (err) {
             this.onError(err);
         }
+    }
+
+    _rebuildBuildings(snap) {
+        const disposeGroup = (g) => {
+            g.traverse((obj) => {
+                if (obj.geometry) obj.geometry.dispose();
+                if (obj.material) {
+                    if (Array.isArray(obj.material)) obj.material.forEach((m) => m.dispose());
+                    else obj.material.dispose();
+                }
+            });
+            while (g.children.length) g.remove(g.children[0]);
+        };
+        if (this.buildingGroup) {
+            disposeGroup(this.buildingGroup);
+            this.scene.remove(this.buildingGroup);
+        }
+        this.buildingGroup = buildBuildings(snap);
+        this.buildingGroup.visible = this._overlays.buildings;
+        this.scene.add(this.buildingGroup);
     }
 
     async _pollLive() {
@@ -453,12 +482,25 @@ export class LanFlowMap {
         const positions = new Map();
         const anchors = new Map();
 
+        // Mount height offsets within a floor (in meters, pre-scale).
+        // ceiling = near ceiling, wall = mid-height, desktop = near floor.
+        const WALL_H_M = 2.9;
+        const mountOffsetM = { ceiling: WALL_H_M * 0.85, wall: WALL_H_M * 0.5, desktop: WALL_H_M * 0.15 };
+
         for (const node of snap.nodes) {
             const p = node.placement;
             if (p && p.source === PLACEMENT_SOURCE.Anchor) {
+                // Vertical offset within the floor by device type:
+                // APs use their mount type, clients mid-floor, infra at desk level.
+                const isClient = node.kind === NODE_KIND.WiredClient || node.kind === NODE_KIND.WifiClient;
+                const isInfra = node.kind === NODE_KIND.Switch || node.kind === NODE_KIND.Gateway;
+                const mountM = node.mountType ? (mountOffsetM[node.mountType] || 0)
+                    : isClient ? WALL_H_M * 0.5
+                    : isInfra ? WALL_H_M * 0.15
+                    : 0;
                 positions.set(node.id, {
                     x: -p.x * scale,
-                    y: p.z * scale * 0.8,    // floors get vertical separation but compressed
+                    y: p.z * scale * 0.8 + mountM * scale * 0.8,
                     z: p.y * scale,
                     pinned: true,
                 });
@@ -619,7 +661,8 @@ export class LanFlowMap {
             this.nodeGroup.add(group);
             this._nodeMeshes.set(node.id, group);
 
-            // Text label, kept simple as a sprite billboard.
+            // Sprite labels for all devices. Infrastructure devices also get DOM
+            // labels (with rate badges) but sprites provide 3D depth sorting.
             if (node.name) {
                 const sprite = this._makeLabelSprite(node.name);
                 sprite.position.set(0, radius + 0.8, 0);
@@ -674,15 +717,32 @@ export class LanFlowMap {
             const b = this._positions.get(link.toNodeId);
             if (!a || !b) continue;
 
-            const pipe = this._makePipeMesh(a, b, link);
+            // For WAN/Transit links, shorten the cloud end to the globe surface
+            // so the pipe terminates at the wireframe, not the center.
+            let effA = a, effB = b;
+            const isWan = link.kind === LINK_KIND.Wan || link.kind === LINK_KIND.Transit;
+            if (isWan) {
+                const r = NODE_RADIUS.cloud;
+                const cloudEnd = this._cloudMeshes.has(link.toNodeId) ? 'b'
+                    : this._cloudMeshes.has(link.fromNodeId) ? 'a' : null;
+                if (cloudEnd) {
+                    const from = cloudEnd === 'b' ? a : b;
+                    const to = cloudEnd === 'b' ? b : a;
+                    const dx = to.x - from.x, dy = to.y - from.y, dz = to.z - from.z;
+                    const d = Math.sqrt(dx * dx + dy * dy + dz * dz) || 1;
+                    const surfPt = { x: to.x - (dx / d) * r, y: to.y - (dy / d) * r, z: to.z - (dz / d) * r };
+                    if (cloudEnd === 'b') effB = surfPt; else effA = surfPt;
+                }
+            }
+
+            const pipe = this._makePipeMesh(effA, effB, link);
             this.linkGroup.add(pipe);
 
-            // Particle streams - two ParticleStream instances (one per direction).
             const down = new ParticleStream({
-                from: a, to: b, color: COLORS.downstream, particleCount: 0,
+                from: effA, to: effB, color: COLORS.downstream, particleCount: 0,
             });
             const up = new ParticleStream({
-                from: b, to: a, color: COLORS.upstream, particleCount: 0,
+                from: effB, to: effA, color: COLORS.upstream, particleCount: 0,
             });
             this.particleGroup.add(down.mesh, up.mesh);
 
@@ -795,25 +855,54 @@ export class LanFlowMap {
                               : 0.35;
             const baseColor = tier === CLOUD_TIER.Unresolved ? 0x2a3340 : COLORS.cloud;
 
-            const geo = new THREE.SphereGeometry(NODE_RADIUS.cloud, 32, 24);
-            const mat = new THREE.MeshStandardMaterial({
-                color: baseColor,
-                emissive: 0x1d2330,
-                emissiveIntensity: 0.3,
-                roughness: 0.95,
-                metalness: 0.02,
+            // Wireframe globe - no solid sphere, just the lat/lng grid lines.
+            // LineBasicMaterial.linewidth doesn't work on WebGL, so we use
+            // thin tube geometry for each line to get visible thickness.
+            const r = NODE_RADIUS.cloud;
+            const gridColor = tier === CLOUD_TIER.Unresolved ? 0x3a4455 : 0x3385d6;
+            const tubeMat = new THREE.MeshBasicMaterial({
+                color: gridColor,
                 transparent: true,
-                opacity: baseOpacity,
+                opacity: baseOpacity * 0.6,
             });
-            const blob = new THREE.Mesh(geo, mat);
-            group.add(blob);
+            const tubeRadius = r * 0.02;
+            // Latitude lines
+            for (let lat = -75; lat <= 75; lat += 25) {
+                const phi = (90 - lat) * Math.PI / 180;
+                const pts = [];
+                for (let lng = 0; lng <= 360; lng += 10) {
+                    const theta = lng * Math.PI / 180;
+                    pts.push(new THREE.Vector3(
+                        r * Math.sin(phi) * Math.cos(theta),
+                        r * Math.cos(phi),
+                        r * Math.sin(phi) * Math.sin(theta),
+                    ));
+                }
+                const curve = new THREE.CatmullRomCurve3(pts);
+                group.add(new THREE.Mesh(new THREE.TubeGeometry(curve, pts.length, tubeRadius, 4, false), tubeMat));
+            }
+            // Longitude lines
+            for (let lng = 0; lng < 360; lng += 30) {
+                const theta = lng * Math.PI / 180;
+                const pts = [];
+                for (let lat = -90; lat <= 90; lat += 10) {
+                    const phi = (90 - lat) * Math.PI / 180;
+                    pts.push(new THREE.Vector3(
+                        r * Math.sin(phi) * Math.cos(theta),
+                        r * Math.cos(phi),
+                        r * Math.sin(phi) * Math.sin(theta),
+                    ));
+                }
+                const curve = new THREE.CatmullRomCurve3(pts);
+                group.add(new THREE.Mesh(new THREE.TubeGeometry(curve, pts.length, tubeRadius, 4, false), tubeMat));
+            }
 
-            // Outer wisp shell to read as a cloud, not a sphere.
-            const wisp = new THREE.Mesh(
-                new THREE.SphereGeometry(NODE_RADIUS.cloud * 1.7, 24, 16),
-                new THREE.MeshBasicMaterial({ color: baseColor, transparent: true, opacity: 0.12, depthWrite: false }),
+            // Subtle outer glow
+            const glow = new THREE.Mesh(
+                new THREE.SphereGeometry(r * 1.5, 24, 16),
+                new THREE.MeshBasicMaterial({ color: 0x1a3050, transparent: true, opacity: 0.08, depthWrite: false }),
             );
-            group.add(wisp);
+            group.add(glow);
 
             // Label: ASN name (primary), with sub-tags for access-tech / OUI / tier hint.
             const labelText = cloud.name || (cloud.asn ? `AS${cloud.asn}` : 'Cloud');
@@ -912,7 +1001,7 @@ export class LanFlowMap {
         const h = subText ? fontSize + subFontSize + pad * 2 + 6 : fontSize + pad * 2;
         canvas.width = w;
         canvas.height = h;
-        ctx.fillStyle = 'rgba(16, 24, 32, 0.85)';
+        ctx.fillStyle = 'rgba(6, 8, 12, 0.92)';
         roundRect(ctx, 0, 0, w, h, 12);
         ctx.fillStyle = '#f1f5f9';
         ctx.textBaseline = 'top';
@@ -1319,6 +1408,7 @@ export class LanFlowMap {
             ['wifiClients', 'Wi-Fi clients'],
             ['wiredClients', 'Wired clients'],
             ['clouds', 'WAN clouds'],
+            ['buildings', 'Buildings'],
             // TODO: Speed test path overlay needs rework - see research/monitoring/3d-map-overlays-TODO.md
         ];
         for (const [key, label] of overlayDefs) {
@@ -1519,6 +1609,7 @@ export class LanFlowMap {
 
     _applyOverlayVisibility() {
         if (this.cloudGroup) this.cloudGroup.visible = this._overlays.clouds;
+        if (this.buildingGroup) this.buildingGroup.visible = this._overlays.buildings;
         this._applyFilter();
     }
 
@@ -1756,8 +1847,8 @@ export class LanFlowMap {
             this._linkLabels.set(link.id, { el, kind: link.kind });
         }
 
-        // Device labels: gateway, switch, AP - clients get name only via the existing
-        // sprite labels to keep DOM count reasonable (clients can number in the hundreds).
+        // Device labels: infrastructure devices (gateway, switch, AP) get DOM labels.
+        // Clients stay as sprites for proper 3D depth sorting.
         for (const node of snap.nodes) {
             if (node.kind === NODE_KIND.WiredClient || node.kind === NODE_KIND.WifiClient) continue;
             if (node.kind === NODE_KIND.Cloud) continue;
@@ -2174,7 +2265,7 @@ export class LanFlowMap {
         while (g && !(g.userData?.node)) g = g.parent;
         if (!g) return;
         const node = g.userData.node;
-        if (node.kind !== NODE_KIND.Gateway && node.kind !== NODE_KIND.Switch && node.kind !== NODE_KIND.WiredClient) return;
+        if (node.kind === NODE_KIND.Cloud || node.kind === NODE_KIND.VirtualHub) return;
 
         this._showContextMenu(e.clientX, e.clientY, node, g);
     }
@@ -2396,7 +2487,7 @@ export class LanFlowMap {
         const lng = bounds.centerLng + dLng * 180 / Math.PI;
 
         // Reverse Y → floor: posY = floor * 3.0 * scale * 0.8
-        const floor = Math.round(pos.y / (scale * 0.8) / 3.0);
+        const floor = Math.round(pos.y / (scale * 0.8) / 2.9);
 
         try {
             await fetch(`${this.apiBase}/device-placement`, {
@@ -2744,18 +2835,22 @@ function lerpColor(a, b, t) {
 }
 
 function makeRadialBackgroundTexture(width, height) {
-    const w = 512;
-    const h = Math.max(256, Math.round(512 * (height / Math.max(width, 1))));
+    // Render at actual screen resolution to avoid upscale banding, and add
+    // subtle noise dithering to break up the 8-bit color quantization in
+    // very dark gradients.
+    const w = Math.max(width, 512);
+    const h = Math.max(height, 256);
     const canvas = document.createElement('canvas');
     canvas.width = w;
     canvas.height = h;
     const ctx = canvas.getContext('2d');
     const grd = ctx.createRadialGradient(w / 2, h / 2, w * 0.05, w / 2, h / 2, w * 0.65);
-    grd.addColorStop(0, '#1c2a3a');
-    grd.addColorStop(0.55, '#121b27');
-    grd.addColorStop(1, '#0a1018');
+    grd.addColorStop(0, '#0a0b0e');
+    grd.addColorStop(0.55, '#060708');
+    grd.addColorStop(1, '#030304');
     ctx.fillStyle = grd;
     ctx.fillRect(0, 0, w, h);
+
     const tex = new THREE.CanvasTexture(canvas);
     tex.minFilter = THREE.LinearFilter;
     tex.magFilter = THREE.LinearFilter;

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -274,7 +274,7 @@ function computeStats(values) {
     };
 }
 
-function fmtRtt(v) { return v != null ? v.toFixed(1) : '-'; }
+function fmtRtt(v) { return v != null ? v.toFixed(3) : '-'; }
 function fmtLoss(v) {
     if (v == null) return '-';
     const s = v.toFixed(2) + '%';


### PR DESCRIPTION
## Summary

**3D Live Map - Floorplan Buildings**
- Renders user's floorplan buildings on the 3D map with procedural material textures (brick with mortar, horizontal lap siding, painted vertical siding, log cabin, concrete, glass)
- Interior/exterior faces render different materials using per-face BoxGeometry groups with winding detection
- Doors and windows proportioned to their wall segment with adjacent wall texture flowing through
- Pitched roofs auto-orient along the building's long axis
- Multi-floor buildings stack at 9.5 ft floor-to-floor spacing with gap compaction for non-consecutive floors

**3D Live Map - WAN Globe**
- Wireframe lat/lng globe replaces cloud blobs for WAN/internet nodes
- WAN pipes terminate at the globe surface

**3D Live Map - Device Positioning**
- All device types can be repositioned via right-click (including Wi-Fi and wired clients)
- AP mount height offsets within floors (ceiling/wall/desktop)
- Anchored clients at mid-floor, switches/gateways at desk level

**3D Live Map - UX**
- Overlay toggles and camera position persist in localStorage
- Wider initial camera framing
- Flat background color (fixes Firefox gradient banding)

**Self-Hosted Network Monitoring**
- 3-decimal RTT precision in statistics table, 2-decimal on stat cards
- Faster ping bursts (0.1s macOS, 0.2s Linux) with reduced macOS process concurrency to mitigate .NET 10 ARM64 heap corruption (dotnet/runtime#112167)

## Test plan

- [x] Verify 3D buildings render with correct material textures
- [x] Check doors/windows proportioned correctly with adjacent wall texture
- [x] Verify WAN globe with visible wireframe grid
- [x] Right-click reposition a Wi-Fi client
- [x] Toggle overlays off/on, refresh, verify state persists
- [x] Orbit camera, refresh, verify fly-in to saved position
- [x] Check RTT precision in statistics table (3 decimal) and stat cards (2 decimal)
- [x] Monitor Mac site for stability (heap corruption fix)