### PR TITLE
Add mirror-port awareness to port-evaluating audit rules

### DIFF
--- a/src/NetworkOptimizer.Audit/Analyzers/PortSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/PortSecurityAnalyzer.cs
@@ -679,6 +679,7 @@ public class PortSecurityAnalyzer
             Speed = port.GetIntOrDefault("speed"),
             ForwardMode = forwardMode,
             TaggedVlanMgmt = taggedVlanMgmt,
+            OpMode = port.GetStringOrNull("op_mode"),
             IsUplink = port.GetBoolOrDefault("is_uplink"),
             IsWan = isWan,
             NativeNetworkId = nativeNetworkId,

--- a/src/NetworkOptimizer.Audit/Models/PortInfo.cs
+++ b/src/NetworkOptimizer.Audit/Models/PortInfo.cs
@@ -45,6 +45,20 @@ public class PortInfo
     public string? TaggedVlanMgmt { get; init; }
 
     /// <summary>
+    /// Port operational mode from the UniFi API's op_mode field.
+    /// Values include "switch" (normal switching), "mirror" (mirror destination),
+    /// "aggregate" (LAG parent), and others. Null if not present in the API response.
+    /// </summary>
+    public string? OpMode { get; init; }
+
+    /// <summary>
+    /// Whether this port is configured as a mirror destination (port mirroring/SPAN).
+    /// Mirror destinations cannot accept port profiles and must receive frames at L2
+    /// regardless of VLAN tags, so access-port audit rules should skip them.
+    /// </summary>
+    public bool IsMirrorDestination => string.Equals(OpMode, "mirror", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Whether this is an uplink port
     /// </summary>
     public bool IsUplink { get; init; }

--- a/src/NetworkOptimizer.Audit/Rules/AccessPortVlanRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/AccessPortVlanRule.cs
@@ -49,6 +49,31 @@ public class AccessPortVlanRule : AuditRuleBase
         if (port.IsUplink || port.IsWan)
             return null;
 
+        // Mirror destination ports cannot accept port profiles and receive frames at L2
+        // regardless of VLAN tags - this is by design. Don't treat as a misconfiguration,
+        // but surface as informational so the operator is aware that any device connected
+        // to this port can passively observe traffic from the mirrored source port(s).
+        if (port.IsMirrorDestination)
+        {
+            var mirrorNetwork = GetNetwork(port.NativeNetworkId, networks);
+            return CreateIssue(
+                "Mirror destination port has visibility into all mirrored VLAN traffic",
+                port,
+                new Dictionary<string, object>
+                {
+                    { "network", mirrorNetwork?.Name ?? "Unknown" },
+                    { "is_mirror_destination", true }
+                },
+                "This port is configured as a SPAN/mirror destination. UniFi enforces op_mode=mirror "
+                + "as a distinct operational mode that does not accept port profiles, and mirror "
+                + "destinations must receive frames regardless of VLAN tags to fulfill their capture "
+                + "role. Any device connected to this port can passively observe traffic from the "
+                + "mirrored source port(s), so ensure physical access to this port is restricted "
+                + "appropriately.",
+                overrideSeverity: AuditSeverity.Informational,
+                overrideScoreImpact: 2);
+        }
+
         // Only check ports configured as trunk/custom (these have tagged VLANs)
         // Access ports (ForwardMode = "native") don't have tagged VLANs - that's normal
         // Ports with tagged_vlan_mgmt = "block_all" block all tagged VLANs regardless of forward mode

--- a/src/NetworkOptimizer.Audit/Rules/CameraVlanRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/CameraVlanRule.cs
@@ -29,6 +29,12 @@ public class CameraVlanRule : AuditRuleBase
         if (protectCamera != null)
             return EvaluateProtectCamera(protectCamera, port, networks);
 
+        // Skip mirror destination ports. Defense-in-depth: the ForwardMode gate below
+        // already filters them since UniFi default-configures mirror destinations with
+        // forward="all", but the explicit guard makes the design intent clear.
+        if (port.IsMirrorDestination)
+            return null;
+
         // Skip uplinks, WAN ports, and non-access ports
         if (port.ForwardMode != "native" || port.IsUplink || port.IsWan)
             return null;

--- a/src/NetworkOptimizer.Audit/Rules/IotVlanRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/IotVlanRule.cs
@@ -23,6 +23,12 @@ public class IotVlanRule : AuditRuleBase
         if (port.ForwardMode != "native" || port.IsUplink || port.IsWan)
             return null;
 
+        // Skip mirror destination ports. Defense-in-depth: the ForwardMode gate above
+        // already filters them since UniFi default-configures mirror destinations with
+        // forward="all", but the explicit guard makes the design intent clear.
+        if (port.IsMirrorDestination)
+            return null;
+
         DeviceDetectionResult detection;
         bool isOfflineDevice = false;
 

--- a/src/NetworkOptimizer.Audit/Rules/MacRestrictionRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/MacRestrictionRule.cs
@@ -34,6 +34,12 @@ public class MacRestrictionRule : AuditRuleBase
         if (port.IsUplink || port.IsWan)
             return null;
 
+        // Skip mirror destination ports. Defense-in-depth: the isAccessPort check below
+        // already filters them since mirror destinations have forward="all" (not an access
+        // port shape), but the explicit guard makes the design intent clear.
+        if (port.IsMirrorDestination)
+            return null;
+
         // Skip ports with network fabric devices (AP, switch, bridge) - these are LAN infrastructure
         // Modems, NVRs, Cloud Keys, etc. are endpoints and SHOULD get MAC restriction recommendations
         if (IsNetworkFabricDevice(port.ConnectedDeviceType))

--- a/src/NetworkOptimizer.Audit/Rules/PortIsolationRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/PortIsolationRule.cs
@@ -20,6 +20,12 @@ public class PortIsolationRule : AuditRuleBase
         if (!port.IsUp || port.ForwardMode != "native" || port.IsUplink || port.IsWan)
             return null;
 
+        // Skip mirror destination ports. Defense-in-depth: the ForwardMode gate above
+        // already filters them since UniFi default-configures mirror destinations with
+        // forward="all", but the explicit guard makes the design intent clear.
+        if (port.IsMirrorDestination)
+            return null;
+
         // Check if switch supports isolation
         if (!port.Switch.Capabilities.SupportsIsolation)
             return null;

--- a/src/NetworkOptimizer.Audit/Rules/UnusedPortRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/UnusedPortRule.cs
@@ -48,6 +48,12 @@ public class UnusedPortRule : AuditRuleBase
         if (port.IsUplink || port.IsWan)
             return null;
 
+        // Skip mirror destination ports. A mirror port can be legitimately down when its
+        // capture device is unplugged - recommending it be disabled would break mirroring
+        // as soon as the capture device reconnects.
+        if (port.IsMirrorDestination)
+            return null;
+
         // Check if port is disabled (either via forward mode or hardware enable flag)
         if (port.ForwardMode == "disabled" || !port.IsEnabled)
             return null; // Correctly configured

--- a/src/NetworkOptimizer.Audit/Rules/WiredSubnetMismatchRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/WiredSubnetMismatchRule.cs
@@ -26,6 +26,12 @@ public class WiredSubnetMismatchRule : AuditRuleBase
         if (port.ForwardMode != "native" || port.IsUplink || port.IsWan)
             return null;
 
+        // Skip mirror destination ports. Defense-in-depth: the ForwardMode gate above
+        // already filters them since UniFi default-configures mirror destinations with
+        // forward="all", but the explicit guard makes the design intent clear.
+        if (port.IsMirrorDestination)
+            return null;
+
         // Skip ports without a connected client
         var client = port.ConnectedClient;
         if (client == null)

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/PortProfileResolutionTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/PortProfileResolutionTests.cs
@@ -22,6 +22,47 @@ public class PortProfileResolutionTests
     }
 
     [Fact]
+    public void ExtractSwitches_PortWithOpModeMirror_PopulatesOpModeAndIsMirrorDestination()
+    {
+        // op_mode is the UniFi controller field that flags a port as a mirror/SPAN
+        // destination. ParsePort must propagate it to PortInfo.OpMode so downstream
+        // rules can use IsMirrorDestination to skip these ports.
+        var deviceData = JsonDocument.Parse(@"[
+            {
+                ""type"": ""usw"",
+                ""name"": ""Switch"",
+                ""port_table"": [
+                    {
+                        ""port_idx"": 5,
+                        ""name"": ""Port 5"",
+                        ""op_mode"": ""mirror"",
+                        ""forward"": ""all"",
+                        ""up"": true
+                    },
+                    {
+                        ""port_idx"": 1,
+                        ""name"": ""Port 1"",
+                        ""op_mode"": ""switch"",
+                        ""forward"": ""all"",
+                        ""up"": true
+                    }
+                ]
+            }
+        ]").RootElement;
+        var networks = new List<NetworkInfo>();
+
+        var result = _engine.ExtractSwitches(deviceData, networks, null, null, null);
+
+        var mirrorPort = result[0].Ports.Single(p => p.PortIndex == 5);
+        mirrorPort.OpMode.Should().Be("mirror");
+        mirrorPort.IsMirrorDestination.Should().BeTrue();
+
+        var switchPort = result[0].Ports.Single(p => p.PortIndex == 1);
+        switchPort.OpMode.Should().Be("switch");
+        switchPort.IsMirrorDestination.Should().BeFalse();
+    }
+
+    [Fact]
     public void ExtractSwitches_PortWithProfile_ResolvesForwardModeFromProfile()
     {
         // Port has forward="all" but profile has forward="disabled"

--- a/tests/NetworkOptimizer.Audit.Tests/Models/PortInfoTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Models/PortInfoTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using NetworkOptimizer.Audit.Models;
+using Xunit;
+
+namespace NetworkOptimizer.Audit.Tests.Models;
+
+public class PortInfoTests
+{
+    private static PortInfo CreatePortWithOpMode(string? opMode)
+    {
+        return new PortInfo
+        {
+            PortIndex = 1,
+            OpMode = opMode,
+            Switch = new SwitchInfo { Name = "Test", Capabilities = new SwitchCapabilities() }
+        };
+    }
+
+    [Fact]
+    public void IsMirrorDestination_OpModeMirror_ReturnsTrue()
+    {
+        var port = CreatePortWithOpMode("mirror");
+        port.IsMirrorDestination.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsMirrorDestination_OpModeSwitch_ReturnsFalse()
+    {
+        var port = CreatePortWithOpMode("switch");
+        port.IsMirrorDestination.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsMirrorDestination_OpModeNull_ReturnsFalse()
+    {
+        var port = CreatePortWithOpMode(null);
+        port.IsMirrorDestination.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsMirrorDestination_OpModeMixedCase_ReturnsTrue()
+    {
+        // String comparison is OrdinalIgnoreCase; UniFi has historically used different
+        // casing across firmware versions for similar enum-like fields.
+        var port = CreatePortWithOpMode("Mirror");
+        port.IsMirrorDestination.Should().BeTrue();
+    }
+}

--- a/tests/NetworkOptimizer.Audit.Tests/Rules/AccessPortVlanRuleTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Rules/AccessPortVlanRuleTests.cs
@@ -877,6 +877,28 @@ public class AccessPortVlanRuleTests
 
     #endregion
 
+    #region Mirror Destination Ports
+
+    [Fact]
+    public void Evaluate_MirrorDestinationPort_ReturnsInformational()
+    {
+        // Mirror destination ports (op_mode=mirror) have visibility into all mirrored
+        // VLAN traffic by design. Surface as Informational so the operator is aware of
+        // the physical-access exposure, not flagged as a misconfiguration.
+        var port = CreateTrunkPortWithClient(opMode: "mirror");
+        var networks = CreateVlanNetworks(5);
+
+        var result = _rule.Evaluate(port, networks);
+
+        result.Should().NotBeNull();
+        result!.Severity.Should().Be(AuditSeverity.Informational);
+        result.ScoreImpact.Should().Be(2);
+        result.Message.Should().Contain("Mirror destination");
+        result.Metadata!["is_mirror_destination"].Should().Be(true);
+    }
+
+    #endregion
+
     #region 802.1X / RADIUS Dynamic VLAN Assignment
 
     [Fact]
@@ -1200,7 +1222,8 @@ public class AccessPortVlanRuleTests
         string? nativeNetworkId = null,
         string? connectedDeviceType = null,
         string forwardMode = "custom",
-        string? dot1xCtrl = null)
+        string? dot1xCtrl = null,
+        string? opMode = null)
     {
         var switchInfo = new SwitchInfo
         {
@@ -1214,6 +1237,7 @@ public class AccessPortVlanRuleTests
             Name = portName,
             IsUp = true,
             ForwardMode = forwardMode,
+            OpMode = opMode,
             IsUplink = isUplink,
             IsWan = isWan,
             NativeNetworkId = nativeNetworkId,

--- a/tests/NetworkOptimizer.Audit.Tests/Rules/UnusedPortRuleTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Rules/UnusedPortRuleTests.cs
@@ -26,6 +26,25 @@ public class UnusedPortRuleTests
     }
 
     [Fact]
+    public void Evaluate_MirrorDestinationPort_DownWithOldLastSeen_ReturnsNull()
+    {
+        // Mirror destination ports legitimately have intermittent device occupancy
+        // (capture device may be unplugged). Without the guard, an unplugged mirror
+        // port with an old last_connection would be flagged as unused - acting on
+        // that recommendation breaks mirroring as soon as the capture device returns.
+        var port = CreatePort(
+            isUp: false,
+            forwardMode: "all",
+            lastConnectionSeen: DateTimeOffset.UtcNow.AddDays(-90).ToUnixTimeSeconds(),
+            opMode: "mirror");
+        var networks = new List<NetworkInfo>();
+
+        var result = _rule.Evaluate(port, networks);
+
+        result.Should().BeNull("Mirror destination ports should not be flagged as unused");
+    }
+
+    [Fact]
     public void RuleName_ReturnsExpectedValue()
     {
         _rule.RuleName.Should().Be("Unused Port Disabled");
@@ -797,7 +816,8 @@ public class UnusedPortRuleTests
         string switchName = "Test Switch",
         long? lastConnectionSeen = null,
         UniFiPortProfile? assignedProfile = null,
-        bool isEnabled = true)
+        bool isEnabled = true,
+        string? opMode = null)
     {
         var switchInfo = new SwitchInfo
         {
@@ -813,6 +833,7 @@ public class UnusedPortRuleTests
             IsEnabled = isEnabled,
             IsUp = isUp,
             ForwardMode = forwardMode,
+            OpMode = opMode,
             IsUplink = isUplink,
             IsWan = isWan,
             NativeNetworkId = networkId,


### PR DESCRIPTION
PortInfo gains OpMode (string?) and IsMirrorDestination (computed bool), populated from the UniFi controller's op_mode field via ParsePort.

AccessPortVlanRule now returns an Informational issue for mirror destinations (matching the existing 802.1X "Allow All" downgrade pattern) rather than flagging the all-VLANs-tagged condition as a misconfiguration. The Informational notice tells the operator that any device connected to the mirror port can passively observe traffic from the mirrored source port(s), which is the real operational concern.

UnusedPortRule skips mirror destinations to prevent recommending that a mirror port whose capture device is currently unplugged be disabled, which would break mirroring as soon as the capture device reconnects.

PortIsolationRule, MacRestrictionRule, CameraVlanRule, IotVlanRule, and WiredSubnetMismatchRule get explicit defensive guards. These rules already filter mirror destinations incidentally via their ForwardMode gates (UniFi default-configures mirror ports with forward="all"), but the explicit guard documents intent and protects against future refactors that might add code paths bypassing those gates.

Tests:
- AccessPortVlanRuleTests: Evaluate_MirrorDestinationPort_ReturnsInformational
- UnusedPortRuleTests: Evaluate_MirrorDestinationPort_DownWithOldLastSeen_ReturnsNull
- PortInfoTests (new file): IsMirrorDestination unit cases covering mirror, switch, null, and mixed-case op_mode values
- PortProfileResolutionTests: op_mode JSON-to-PortInfo wiring integration test with both mirror and switch op modes