### PR TITLE
Monitoring: WAN detection via wan1...wan6, multi-WAN 3D map, timeline UX

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1035,6 +1035,17 @@ else
     }
 
     [JSInvokable]
+    public void NavigateToUpstreamDiscovery()
+    {
+        InvokeAsync(() =>
+        {
+            _activeTab = "setup";
+            NavigationManager.NavigateTo("/monitoring?tab=setup", forceLoad: false, replace: false);
+            StateHasChanged();
+        });
+    }
+
+    [JSInvokable]
     public async Task OnMapTimeChanged(string? isoTimestamp)
     {
         if (isoTimestamp == null)

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -265,7 +265,7 @@ else
 
         <!-- Upstream tracer wizard -->
         <div id="upstream-discovery" style="margin-top: 1.5rem;">
-            <UpstreamTracerPanel />
+            <UpstreamTracerPanel ForceExpand="_forceExpandUpstream" />
         </div>
 
         <div style="margin-top: 1.5rem;">
@@ -707,6 +707,7 @@ else
     private string _activeTab = "setup";
 
     private bool _monitoringReady => _monitoringEnabled && _influxConfigured;
+    private bool _forceExpandUpstream;
 
 
     // Chart mount tracking
@@ -1040,10 +1041,22 @@ else
         InvokeAsync(async () =>
         {
             _activeTab = "performance";
+            _forceExpandUpstream = true;
             StateHasChanged();
-            await Task.Yield();
-            await JS.InvokeVoidAsync("eval",
-                "document.getElementById('upstream-discovery')?.scrollIntoView({behavior:'smooth',block:'start'})");
+            await Task.Delay(150);
+            await JS.InvokeVoidAsync("eval", @"
+                (function() {
+                    var el = document.getElementById('upstream-discovery');
+                    if (el) {
+                        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                        el.style.transition = 'outline-color 0.3s';
+                        el.style.outline = '2px solid rgba(59, 130, 246, 0.5)';
+                        el.style.outlineOffset = '4px';
+                        el.style.borderRadius = '12px';
+                        setTimeout(function() { el.style.outline = ''; el.style.outlineOffset = ''; }, 2000);
+                    }
+                })();");
+            _forceExpandUpstream = false;
         });
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -264,7 +264,7 @@ else
         </div>
 
         <!-- Upstream tracer wizard -->
-        <div style="margin-top: 1.5rem;">
+        <div id="upstream-discovery" style="margin-top: 1.5rem;">
             <UpstreamTracerPanel />
         </div>
 
@@ -1039,8 +1039,8 @@ else
     {
         InvokeAsync(() =>
         {
-            _activeTab = "setup";
-            NavigationManager.NavigateTo("/monitoring?tab=setup", forceLoad: false, replace: false);
+            _activeTab = "performance";
+            NavigationManager.NavigateTo("/monitoring?tab=performance#upstream-discovery", forceLoad: false, replace: false);
             StateHasChanged();
         });
     }

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1037,11 +1037,13 @@ else
     [JSInvokable]
     public void NavigateToUpstreamDiscovery()
     {
-        InvokeAsync(() =>
+        InvokeAsync(async () =>
         {
             _activeTab = "performance";
-            NavigationManager.NavigateTo("/monitoring?tab=performance#upstream-discovery", forceLoad: false, replace: false);
             StateHasChanged();
+            await Task.Yield();
+            await JS.InvokeVoidAsync("eval",
+                "document.getElementById('upstream-discovery')?.scrollIntoView({behavior:'smooth',block:'start'})");
         });
     }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -98,7 +98,7 @@
             {
                 <div class="form-group">
                     <label class="form-label">Access network technology</label>
-                    <select class="form-input" style="max-width: 250px;"
+                    <select class="form-control" style="max-width: 250px;"
                             value="@((int)_state.AccessTechnology)"
                             @onchange="e => _state.AccessTechnology = (AccessTechnology)int.Parse((string)e.Value!)">
                         @foreach (var tech in Enum.GetValues<AccessTechnology>())
@@ -176,7 +176,7 @@
                                                        @onchange="e => hop.Enabled = (bool)e.Value!" />
                                             </td>
                                             <td>
-                                                <input type="text" class="form-input form-input-sm"
+                                                <input type="text" class="form-control form-control-sm"
                                                        value="@hop.Label"
                                                        @onchange="e => hop.Label = (string)e.Value!" />
                                             </td>
@@ -408,5 +408,5 @@
 
 <style>
     .row-disabled { opacity: 0.45; }
-    .form-input-sm { padding: 0.25rem 0.5rem; font-size: 0.875rem; }
+    .form-control-sm { padding: 0.25rem 0.5rem; font-size: 0.875rem; }
 </style>

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -266,6 +266,8 @@
 </div>
 
 @code {
+    [Parameter] public bool ForceExpand { get; set; }
+
     private UpstreamTracerState _state = new();
     private System.Threading.Timer? _pollTimer;
     private bool _needsReview;
@@ -277,7 +279,7 @@
     {
         await Tracer.RehydrateFromDbAsync();
         _state = Tracer.State;
-        _collapsed = _state.Step == TracerStep.Done;
+        _collapsed = !ForceExpand && _state.Step == TracerStep.Done;
         await RefreshReviewFlagAsync();
         // Poll the tracer state every 1.5s while a run is active; the state machine
         // runs in the background and the UI just observes. Re-check the rediscovery

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -98,7 +98,7 @@
             {
                 <div class="form-group">
                     <label class="form-label">Access network technology</label>
-                    <select class="form-select" style="max-width: 250px;"
+                    <select class="form-input" style="max-width: 250px;"
                             value="@((int)_state.AccessTechnology)"
                             @onchange="e => _state.AccessTechnology = (AccessTechnology)int.Parse((string)e.Value!)">
                         @foreach (var tech in Enum.GetValues<AccessTechnology>())
@@ -381,7 +381,7 @@
 
     private static string FormatTechName(AccessTechnology tech) => tech switch
     {
-        AccessTechnology.Unknown => "Auto-detect",
+        AccessTechnology.Unknown => "Not detected",
         AccessTechnology.Gpon => "GPON",
         AccessTechnology.XgsPon => "XGS-PON",
         AccessTechnology.Docsis => "DOCSIS (Cable)",

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -386,7 +386,7 @@
         AccessTechnology.XgsPon => "XGS-PON",
         AccessTechnology.Docsis => "DOCSIS (Cable)",
         AccessTechnology.PppoE => "PPPoE",
-        AccessTechnology.DirectEthernet => "Direct Ethernet",
+        AccessTechnology.DirectEthernet => "Active Ethernet",
         AccessTechnology.FixedWireless => "Fixed Wireless",
         AccessTechnology.Satellite => "Satellite",
         AccessTechnology.Cellular => "Cellular",

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -96,6 +96,18 @@
 
             @if (_state.Step == TracerStep.ReviewingResults)
             {
+                <div class="form-group">
+                    <label class="form-label">Access network technology</label>
+                    <select class="form-select" style="max-width: 250px;"
+                            value="@((int)_state.AccessTechnology)"
+                            @onchange="e => _state.AccessTechnology = (AccessTechnology)int.Parse((string)e.Value!)">
+                        @foreach (var tech in Enum.GetValues<AccessTechnology>())
+                        {
+                            <option value="@((int)tech)">@FormatTechName(tech)</option>
+                        }
+                    </select>
+                </div>
+
                 @if (_state.Traces.Count > 0)
                 {
                     <div class="form-group">
@@ -366,6 +378,21 @@
     };
 
     private void ToggleCollapse() => _collapsed = !_collapsed;
+
+    private static string FormatTechName(AccessTechnology tech) => tech switch
+    {
+        AccessTechnology.Unknown => "Auto-detect",
+        AccessTechnology.Gpon => "GPON",
+        AccessTechnology.XgsPon => "XGS-PON",
+        AccessTechnology.Docsis => "DOCSIS (Cable)",
+        AccessTechnology.PppoE => "PPPoE",
+        AccessTechnology.DirectEthernet => "Direct Ethernet",
+        AccessTechnology.FixedWireless => "Fixed Wireless",
+        AccessTechnology.Satellite => "Satellite",
+        AccessTechnology.Cellular => "Cellular",
+        AccessTechnology.Other => "Other",
+        _ => tech.ToString()
+    };
 
     private string AccessAsnDisplay()
     {

--- a/src/NetworkOptimizer.Web/Endpoints/LanFlowMapEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/LanFlowMapEndpoints.cs
@@ -33,7 +33,7 @@ public static class LanFlowMapEndpoints
         app.MapGet("/api/monitoring/lan-flow-map/speed-tests",
             async (LanFlowMapService svc, DateTime? since, DateTime? until, CancellationToken ct) =>
             {
-                var fromT = since ?? DateTime.UtcNow.AddHours(-24);
+                var fromT = since ?? DateTime.UtcNow.AddDays(-30);
                 var toT = until ?? DateTime.UtcNow;
                 var items = await svc.BuildSpeedTestOverlayAsync(fromT, toT, limitPerKind: 10, ct: ct);
                 return Results.Ok(items);

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -1140,7 +1140,7 @@ public class LanFlowMapService
             {
                 Id = $"cloud-access-{wan.WanInterface}",
                 Kind = LanCloudKind.AccessIsp,
-                Name = upstream.Access.AsnName ?? upstream.Access.L2NeighborOui ?? "Access ISP",
+                Name = upstream.Access.AsnName ?? wan.FriendlyName ?? "Access ISP",
                 Asn = upstream.Access.AsnNumber,
                 AsnName = upstream.Access.AsnName,
                 Order = 0,

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -149,7 +149,7 @@ public class LanFlowMapService
         SeedLiveRates(snapshot, portRates);
 
         snapshot.SpeedTests = await BuildSpeedTestOverlayAsync(
-            since: snapshot.GeneratedAt - TimeSpan.FromHours(24),
+            since: snapshot.GeneratedAt - TimeSpan.FromDays(30),
             until: snapshot.GeneratedAt,
             limitPerKind: 3,
             ct: ct);

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -1452,12 +1452,17 @@ public class LanFlowMapService
     {
         await using var db = await _dbFactory.CreateDbContextAsync(ct);
 
+        // Group by WAN so secondary WANs aren't crowded out by frequent
+        // primary WAN tests. Take limitPerKind per group.
         var raw = await db.Iperf3Results
             .AsNoTracking()
             .Where(r => r.Success && r.TestTime >= since && r.TestTime <= until)
             .OrderByDescending(r => r.TestTime)
-            .Take(limitPerKind * 4)
             .ToListAsync(ct);
+        raw = raw
+            .GroupBy(r => r.WanNetworkGroup ?? "")
+            .SelectMany(g => g.Take(limitPerKind))
+            .ToList();
 
         var result = new List<SpeedTestOverlayItem>();
         foreach (var r in raw)

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -135,15 +135,15 @@ public class LanFlowMapService
         GroupMultiClientPorts(snapshot);
         await BuildWanAndClouds(topology, snapshot, ct);
 
-        var gwRaw = rawDevices.FirstOrDefault(d =>
-            d.DeviceType == NetworkOptimizer.Core.Enums.DeviceType.Gateway);
-        if (gwRaw?.PortTable != null)
-        {
-            snapshot.WanIfNames = gwRaw.PortTable
-                .Where(p => p.IsUplink && !string.IsNullOrEmpty(p.IfName))
-                .Select(p => p.IfName!)
-                .ToList();
-        }
+        // WAN interface names for InfluxDB rate queries. Use the physical port
+        // name (not VLAN sub-interface) to match what SNMP records accurately.
+        var wans = await _pathView.GetWansAsync(ct);
+        snapshot.WanIfNames = wans
+            .Select(w => w.PhysicalIfName ?? w.UplinkIfName)
+            .Where(n => !string.IsNullOrEmpty(n))
+            .Select(n => n!)
+            .Distinct()
+            .ToList();
 
         var portRates = await SeedPortRatesAsync(snapshot, ct);
         SeedLiveRates(snapshot, portRates);
@@ -348,18 +348,19 @@ public class LanFlowMapService
         var gwNode = snapshot.Nodes.FirstOrDefault(n => n.Kind == LanNodeKind.Gateway);
         var gwMac = gwNode?.Mac;
 
-        // Pre-fetch WAN rates. The link ID uses NetworkName ("wan") but InfluxDB
-        // stores the Linux ifname ("eth6"). WanIfNames on the snapshot resolves
-        // this from the port table's IfName field (same source as stat cards).
-        IReadOnlyList<MonitoringInfluxClient.WanRatePoint>? wanRates = null;
-        if (!string.IsNullOrEmpty(gwMac) && snapshot.WanIfNames.Count > 0)
+        // Build WAN interface → physical ifname mapping for per-WAN rate queries.
+        var wanIfNameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        try
         {
-            try
+            var wans = await _pathView.GetWansAsync(ct);
+            foreach (var w in wans)
             {
-                wanRates = await _influx.QueryGatewayWanRatesAsync(gwMac, snapshot.WanIfNames, from, to, ct: ct);
+                var rateIf = w.PhysicalIfName ?? w.UplinkIfName;
+                if (!string.IsNullOrEmpty(rateIf))
+                    wanIfNameMap[w.WanInterface] = rateIf;
             }
-            catch { }
         }
+        catch { }
 
         // Pre-fetch interface_counters per device MAC so we don't re-query for
         // every link on the same device. Covers WiredClient (PortKey), Uplink,
@@ -400,13 +401,25 @@ public class LanFlowMapService
             {
                 if (link.Kind == LanLinkKind.Wan)
                 {
-                    if (wanRates != null)
+                    // Per-WAN: extract interface name from link ID, look up
+                    // the physical ifname, then find matching rate points.
+                    var wanIface = link.Id.StartsWith("wan-link-", StringComparison.Ordinal)
+                        ? link.Id.Substring("wan-link-".Length) : null;
+                    if (wanIface != null
+                        && wanIfNameMap.TryGetValue(wanIface, out var rateIf)
+                        && !string.IsNullOrEmpty(gwMac)
+                        && ratesByDevice.TryGetValue(gwMac, out var gwRates))
                     {
-                        var closest = wanRates
+                        var closest = gwRates
+                            .Where(p => string.Equals(p.IfName, rateIf, StringComparison.OrdinalIgnoreCase))
                             .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
                             .FirstOrDefault();
                         if (closest != null)
-                            update.LinkRates[link.Id] = MapPortToLinkRates(link, closest.DownloadBps ?? 0, closest.UploadBps ?? 0, closest.Time);
+                        {
+                            // rate_in_bps = downloads, rate_out_bps = uploads
+                            update.LinkRates[link.Id] = MapPortToLinkRates(link,
+                                closest.RateInBps ?? 0, closest.RateOutBps ?? 0, closest.Time);
+                        }
                     }
                 }
                 else if (link.Kind == LanLinkKind.Uplink || link.Kind == LanLinkKind.MeshBackhaul)

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -1161,8 +1161,12 @@ public class LanFlowMapService
                 AccessTechnology = upstream.Access.AccessTechnology,
                 L2NeighborOui = upstream.Access.L2NeighborOui,
                 IsCgnat = upstream.Access.IsCgnat,
-                IsDiscoveryPending = upstream.Access.Hops.Count == 0,
-                Tier = upstream.Access.Hops.Count == 0 ? LanCloudTier.Unresolved : LanCloudTier.Solid,
+                // TODO: secondary WAN discovery - currently only the primary WAN
+                // runs upstream tracing, so secondary WANs always have 0 hops.
+                // Suppress the "discovery pending" state for them until multi-WAN
+                // tracing is implemented.
+                IsDiscoveryPending = wan.IsPrimary && upstream.Access.Hops.Count == 0,
+                Tier = wan.IsPrimary && upstream.Access.Hops.Count == 0 ? LanCloudTier.Unresolved : LanCloudTier.Solid,
             };
             // RTT for the access cloud: pick the deepest hop with live data (closest to the
             // ISP boundary). Wizard-output ordering puts BNG/CMTS/OLT toward the tail.

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -149,11 +149,15 @@ public class MonitoringPathView
         if (!_connectionService.IsConnected || _connectionService.Client == null)
             return Array.Empty<WanSummary>();
 
-        List<UniFiDeviceResponse> devices;
+        // Read wan1...wan6 from raw device JSON instead of relying on
+        // port_table.is_uplink, which may not be set for PPPoE, VLAN-tagged,
+        // or GRE tunnel connections.
+        string? deviceJson;
         try
         {
-            devices = (await _connectionService.Client.GetDevicesAsync(ct))?.ToList()
-                       ?? new List<UniFiDeviceResponse>();
+            deviceJson = await _connectionService.Client.GetDevicesRawJsonAsync(ct);
+            if (string.IsNullOrEmpty(deviceJson))
+                return Array.Empty<WanSummary>();
         }
         catch (Exception ex)
         {
@@ -161,37 +165,82 @@ public class MonitoringPathView
             return Array.Empty<WanSummary>();
         }
 
-        var gateway = devices.FirstOrDefault(d => d.DeviceType == NetworkOptimizer.Core.Enums.DeviceType.Gateway);
-        if (gateway?.PortTable == null) return Array.Empty<WanSummary>();
-
         var results = new List<WanSummary>();
-        var wanPorts = gateway.PortTable
-            .Where(p => p.IsUplink && !string.IsNullOrEmpty(p.NetworkName))
-            .OrderBy(p => p.PortIdx)
-            .ToList();
-        if (wanPorts.Count == 0)
-        {
-            wanPorts = gateway.PortTable
-                .Where(p => p.NetworkName != null && p.NetworkName.StartsWith("wan", StringComparison.OrdinalIgnoreCase))
-                .OrderBy(p => p.PortIdx)
-                .ToList();
-        }
 
-        var gwMac = gateway.Mac.ToLowerInvariant().Replace('-', ':');
-        for (int i = 0; i < wanPorts.Count; i++)
+        using (var doc = System.Text.Json.JsonDocument.Parse(deviceJson))
         {
-            var port = wanPorts[i];
-            results.Add(new WanSummary
+            var root = doc.RootElement;
+            var devices = root.ValueKind == System.Text.Json.JsonValueKind.Array
+                ? root
+                : root.TryGetProperty("data", out var data) ? data : root;
+
+            foreach (var device in devices.EnumerateArray())
             {
-                WanInterface = port.NetworkName ?? $"wan{i + 1}",
-                FriendlyName = string.IsNullOrEmpty(port.Name) ? null : port.Name,
-                IsPrimary = i == 0,
-                GatewayMac = gwMac,
-                GatewayPortName = port.Name,
-                LinkSpeedMbps = port.Speed > 0 ? port.Speed : (int?)null,
-                IpAddress = port.Ip,
-                IpClass = NetworkUtilities.ClassifyPublicAddress(port.Ip)
-            });
+                var deviceType = device.TryGetProperty("type", out var typeProp) ? typeProp.GetString() : null;
+                if (deviceType != "ugw" && deviceType != "udm" && deviceType != "uxg")
+                    continue;
+
+                var gwMac = device.TryGetProperty("mac", out var macProp) ? macProp.GetString() : null;
+                gwMac = gwMac?.ToLowerInvariant().Replace('-', ':') ?? "";
+
+                var portInfo = new Dictionary<int, (string? networkName, string? name, int speed)>();
+                if (device.TryGetProperty("port_table", out var portTable) &&
+                    portTable.ValueKind == System.Text.Json.JsonValueKind.Array)
+                {
+                    foreach (var port in portTable.EnumerateArray())
+                    {
+                        if (!port.TryGetProperty("port_idx", out var idxProp) || !idxProp.TryGetInt32(out var idx))
+                            continue;
+                        var networkName = port.TryGetProperty("network_name", out var nnProp) ? nnProp.GetString() : null;
+                        var name = port.TryGetProperty("name", out var nameProp) ? nameProp.GetString() : null;
+                        var speed = port.TryGetProperty("speed", out var speedProp) && speedProp.TryGetInt32(out var spd) ? spd : 0;
+                        portInfo[idx] = (networkName, name, speed);
+                    }
+                }
+
+                for (int i = 1; i <= 6; i++)
+                {
+                    var wanKey = $"wan{i}";
+                    if (!device.TryGetProperty(wanKey, out var wanObj)) continue;
+
+                    var uplinkIfname = wanObj.TryGetProperty("uplink_ifname", out var uplinkProp)
+                        ? uplinkProp.GetString() : null;
+                    if (string.IsNullOrEmpty(uplinkIfname)) continue;
+
+                    var ip = wanObj.TryGetProperty("ip", out var ipProp) ? ipProp.GetString() : null;
+                    var wanSpeed = wanObj.TryGetProperty("speed", out var wanSpeedProp) &&
+                        wanSpeedProp.TryGetInt32(out var ws) && ws > 0 ? ws : 0;
+
+                    string? interfaceKey = null;
+                    string? friendlyName = null;
+                    int linkSpeed = wanSpeed;
+
+                    if (wanObj.TryGetProperty("port_idx", out var portIdxProp) &&
+                        portIdxProp.TryGetInt32(out var portIdx) &&
+                        portInfo.TryGetValue(portIdx, out var pi))
+                    {
+                        interfaceKey = pi.networkName;
+                        friendlyName = pi.name;
+                        if (linkSpeed == 0 && pi.speed > 0) linkSpeed = pi.speed;
+                    }
+
+                    interfaceKey ??= i == 1 ? "wan" : $"wan{i}";
+
+                    results.Add(new WanSummary
+                    {
+                        WanInterface = interfaceKey,
+                        FriendlyName = string.IsNullOrEmpty(friendlyName) ? null : friendlyName,
+                        IsPrimary = results.Count == 0,
+                        GatewayMac = gwMac,
+                        GatewayPortName = friendlyName,
+                        LinkSpeedMbps = linkSpeed > 0 ? linkSpeed : (int?)null,
+                        IpAddress = ip,
+                        IpClass = NetworkUtilities.ClassifyPublicAddress(ip)
+                    });
+                }
+
+                if (results.Count > 0) break;
+            }
         }
 
         _wanCache = results;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -253,12 +253,15 @@ public class MonitoringPathView
                         if (linkSpeed == 0 && pi.speed > 0) linkSpeed = pi.speed;
                     }
 
+                    // Physical port name (e.g. "eth6" for VLAN-tagged "eth6.228",
+                    // same as uplinkIfname for non-VLAN connections).
+                    var physicalIfname = wanObj.TryGetProperty("ifname", out var ifnProp) ? ifnProp.GetString() : null;
+
                     // For virtual WANs (GRE, etc.) without port_table entries,
                     // resolve the friendly name from WAN network configs via
                     // ethernet_overrides networkgroup or wan key convention.
                     if (string.IsNullOrEmpty(friendlyName))
                     {
-                        var physicalIfname = wanObj.TryGetProperty("ifname", out var ifnProp) ? ifnProp.GetString() : null;
                         var lookupIfname = physicalIfname ?? uplinkIfname;
                         string? networkGroup = null;
                         if (!string.IsNullOrEmpty(lookupIfname) && ifnameToNetworkGroup.TryGetValue(lookupIfname, out var ng))
@@ -278,6 +281,7 @@ public class MonitoringPathView
                         GatewayMac = gwMac,
                         GatewayPortName = friendlyName,
                         UplinkIfName = uplinkIfname,
+                        PhysicalIfName = physicalIfname,
                         LinkSpeedMbps = linkSpeed > 0 ? linkSpeed : (int?)null,
                         IpAddress = ip,
                         IpClass = NetworkUtilities.ClassifyPublicAddress(ip)
@@ -301,13 +305,17 @@ public class MonitoringPathView
         if (string.IsNullOrEmpty(gwMac)) return;
         foreach (var wan in wans)
         {
-            if (!string.IsNullOrEmpty(wan.UplinkIfName))
+            // Prefer the physical port rate (eth6) over the VLAN sub-interface
+            // (eth6.228) - the physical port counters match what the old
+            // port_table.IsUplink path returned.
+            var rateIfName = wan.PhysicalIfName ?? wan.UplinkIfName;
+            if (!string.IsNullOrEmpty(rateIfName))
             {
-                var portRate = _liveStats.GetPortRate(gwMac, wan.UplinkIfName);
+                var portRate = _liveStats.GetPortRate(gwMac, rateIfName);
                 if (portRate != null)
                 {
-                    wan.LiveRateInBps = portRate.UpBps;
-                    wan.LiveRateOutBps = portRate.DownBps;
+                    wan.LiveRateInBps = portRate.DownBps;
+                    wan.LiveRateOutBps = portRate.UpBps;
                     continue;
                 }
             }
@@ -394,6 +402,7 @@ public record WanSummary
     public string? GatewayMac { get; init; }
     public string? GatewayPortName { get; init; }
     public string? UplinkIfName { get; init; }
+    public string? PhysicalIfName { get; init; }
     public int? LinkSpeedMbps { get; init; }
     public double? LiveRateInBps { get; set; }
     public double? LiveRateOutBps { get; set; }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -77,9 +77,13 @@ public class MonitoringPathView
             .OrderBy(t => t.Id)
             .ToListAsync(ct);
 
-        var l2NeighborMac = wanCtx?.L2NeighborMac ?? settings?.WanNeighborMac;
-        var l2NeighborOui = wanCtx?.L2NeighborOui ?? settings?.WanNeighborOui;
-        var accessTech = wanCtx?.AccessTechnology ?? settings?.AccessTechnology ?? AccessTechnology.Unknown;
+        // TODO: once multi-WAN upstream tracing is implemented, each WAN will
+        // have its own WanDiscoveryContext with L2 neighbor and access tech.
+        // Until then, only fall back to global MonitoringSettings for the
+        // primary WAN so secondaries don't inherit the primary's values.
+        var l2NeighborMac = wanCtx?.L2NeighborMac ?? (isPrimary ? settings?.WanNeighborMac : null);
+        var l2NeighborOui = wanCtx?.L2NeighborOui ?? (isPrimary ? settings?.WanNeighborOui : null);
+        var accessTech = wanCtx?.AccessTechnology ?? (isPrimary ? settings?.AccessTechnology : null) ?? AccessTechnology.Unknown;
 
         var isCgnat = l2NeighborMac != null
             && !string.IsNullOrEmpty(wan?.IpAddress)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -305,15 +305,14 @@ public class MonitoringPathView
         if (string.IsNullOrEmpty(gwMac)) return;
         foreach (var wan in wans)
         {
-            // Prefer the physical port rate (eth6) over the VLAN sub-interface
-            // (eth6.228) - the physical port counters match what the old
-            // port_table.IsUplink path returned.
-            var rateIfName = wan.PhysicalIfName ?? wan.UplinkIfName;
-            if (!string.IsNullOrEmpty(rateIfName))
+            if (!string.IsNullOrEmpty(wan.UplinkIfName))
             {
-                var portRate = _liveStats.GetPortRate(gwMac, rateIfName);
+                var portRate = _liveStats.GetPortRate(gwMac, wan.UplinkIfName);
                 if (portRate != null)
                 {
+                    // GetPortRate convention: DownBps = port TX, UpBps = port RX.
+                    // WAN port: TX = to internet = uploads (LiveRateInBps),
+                    //           RX = from internet = downloads (LiveRateOutBps).
                     wan.LiveRateInBps = portRate.DownBps;
                     wan.LiveRateOutBps = portRate.UpBps;
                     continue;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -58,12 +58,8 @@ public class MonitoringPathView
 
         var resolvedWanInterface = wan?.WanInterface ?? wanInterface ?? "wan";
         var isPrimary = wan?.IsPrimary ?? true;
-        var accessHopCount = await db.MonitoringTargets.AsNoTracking()
-            .CountAsync(t => t.TargetType == MonitoringTargetType.AccessIsp
-                        && (t.WanInterface == resolvedWanInterface
-                            || (isPrimary && t.WanInterface == null)), ct);
-        _logger.LogInformation("GetUpstreamPathAsync: wans={WanCount}, wan={WanIf}, resolved={Resolved}, isPrimary={Primary}, accessHopCount={HopCount}",
-            wans.Count, wan?.WanInterface, resolvedWanInterface, isPrimary, accessHopCount);
+        _logger.LogDebug("GetUpstreamPathAsync: wans={WanCount}, wan={WanIf}, resolved={Resolved}, isPrimary={Primary}",
+            wans.Count, wan?.WanInterface, resolvedWanInterface, isPrimary);
 
         // Per-WAN context, with fallback to legacy MonitoringSettings for installs that
         // pre-date the WanDiscoveryContexts table. New installs and any post-migration

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Core.Helpers;
 using NetworkOptimizer.Storage.Models;
-using NetworkOptimizer.UniFi.Models;
 
 namespace NetworkOptimizer.Web.Services.Monitoring;
 
@@ -59,6 +58,8 @@ public class MonitoringPathView
 
         var resolvedWanInterface = wan?.WanInterface ?? wanInterface ?? "wan";
         var isPrimary = wan?.IsPrimary ?? true;
+        _logger.LogDebug("GetUpstreamPathAsync: wans={WanCount}, wan={WanIf}, resolved={Resolved}, isPrimary={Primary}",
+            wans.Count, wan?.WanInterface, resolvedWanInterface, isPrimary);
 
         // Per-WAN context, with fallback to legacy MonitoringSettings for installs that
         // pre-date the WanDiscoveryContexts table. New installs and any post-migration

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -87,7 +87,7 @@ public class MonitoringPathView
 
         var access = new AccessIspCloud
         {
-            AccessTechnology = accessTech.ToString(),
+            AccessTechnology = FormatAccessTechnology(accessTech),
             L2NeighborOui = l2NeighborOui,
             AsnNumber = accessHops.FirstOrDefault()?.AsnNumber,
             AsnName = accessHops.FirstOrDefault()?.AsnName,
@@ -333,6 +333,21 @@ public class MonitoringPathView
     /// alongside the human-facing text. Until the tracer ships, AutoLabel is empty;
     /// fall back to AccessHop as the generic positional role.
     /// </summary>
+    private static string? FormatAccessTechnology(AccessTechnology tech) => tech switch
+    {
+        AccessTechnology.Unknown => null,
+        AccessTechnology.Gpon => "GPON",
+        AccessTechnology.XgsPon => "XGS-PON",
+        AccessTechnology.Docsis => "DOCSIS",
+        AccessTechnology.PppoE => "PPPoE",
+        AccessTechnology.DirectEthernet => "Active Ethernet",
+        AccessTechnology.FixedWireless => "Fixed Wireless",
+        AccessTechnology.Satellite => "Satellite",
+        AccessTechnology.Cellular => "Cellular",
+        AccessTechnology.Other => "Other",
+        _ => tech.ToString()
+    };
+
     private static UpstreamRole MapRoleFromAutoLabel(string? autoLabel)
     {
         if (string.IsNullOrEmpty(autoLabel)) return UpstreamRole.AccessHop;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -166,6 +166,20 @@ public class MonitoringPathView
             return Array.Empty<WanSummary>();
         }
 
+        // Fetch WAN network configs for friendly names (covers GRE tunnels and
+        // other virtual WANs that don't have port_table entries).
+        var networkGroupToName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            var wanConfigs = await _connectionService.Client.GetWanConfigsAsync(ct);
+            foreach (var wc in wanConfigs.Where(w => !string.IsNullOrEmpty(w.WanNetworkgroup)))
+                networkGroupToName[wc.WanNetworkgroup!] = wc.Name;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "GetWansAsync: failed to fetch WAN configs for names");
+        }
+
         var results = new List<WanSummary>();
 
         using (var doc = System.Text.Json.JsonDocument.Parse(deviceJson))
@@ -184,6 +198,7 @@ public class MonitoringPathView
                 var gwMac = device.TryGetProperty("mac", out var macProp) ? macProp.GetString() : null;
                 gwMac = gwMac?.ToLowerInvariant().Replace('-', ':') ?? "";
 
+                // Build port_idx lookups from port_table and ethernet_overrides
                 var portInfo = new Dictionary<int, (string? networkName, string? name, int speed)>();
                 if (device.TryGetProperty("port_table", out var portTable) &&
                     portTable.ValueKind == System.Text.Json.JsonValueKind.Array)
@@ -196,6 +211,19 @@ public class MonitoringPathView
                         var name = port.TryGetProperty("name", out var nameProp) ? nameProp.GetString() : null;
                         var speed = port.TryGetProperty("speed", out var speedProp) && speedProp.TryGetInt32(out var spd) ? spd : 0;
                         portInfo[idx] = (networkName, name, speed);
+                    }
+                }
+
+                var ifnameToNetworkGroup = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                if (device.TryGetProperty("ethernet_overrides", out var ethOverrides) &&
+                    ethOverrides.ValueKind == System.Text.Json.JsonValueKind.Array)
+                {
+                    foreach (var ov in ethOverrides.EnumerateArray())
+                    {
+                        var ifn = ov.TryGetProperty("ifname", out var ifnProp) ? ifnProp.GetString() : null;
+                        var ng = ov.TryGetProperty("networkgroup", out var ngProp) ? ngProp.GetString() : null;
+                        if (!string.IsNullOrEmpty(ifn) && !string.IsNullOrEmpty(ng))
+                            ifnameToNetworkGroup[ifn] = ng;
                     }
                 }
 
@@ -223,6 +251,21 @@ public class MonitoringPathView
                         interfaceKey = pi.networkName;
                         friendlyName = pi.name;
                         if (linkSpeed == 0 && pi.speed > 0) linkSpeed = pi.speed;
+                    }
+
+                    // For virtual WANs (GRE, etc.) without port_table entries,
+                    // resolve the friendly name from WAN network configs via
+                    // ethernet_overrides networkgroup or wan key convention.
+                    if (string.IsNullOrEmpty(friendlyName))
+                    {
+                        var physicalIfname = wanObj.TryGetProperty("ifname", out var ifnProp) ? ifnProp.GetString() : null;
+                        var lookupIfname = physicalIfname ?? uplinkIfname;
+                        string? networkGroup = null;
+                        if (!string.IsNullOrEmpty(lookupIfname) && ifnameToNetworkGroup.TryGetValue(lookupIfname, out var ng))
+                            networkGroup = ng;
+                        networkGroup ??= i == 1 ? "WAN" : $"WAN{i}";
+                        if (networkGroupToName.TryGetValue(networkGroup, out var configName))
+                            friendlyName = configName;
                     }
 
                     interfaceKey ??= i == 1 ? "wan" : $"wan{i}";

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -253,7 +253,7 @@ public class MonitoringPathView
                         if (linkSpeed == 0 && pi.speed > 0) linkSpeed = pi.speed;
                     }
 
-                    // Physical port name (e.g. "eth6" for VLAN-tagged "eth6.228",
+                    // Physical port name (e.g. "eth6" for VLAN-tagged "eth6.100",
                     // same as uplinkIfname for non-VLAN connections).
                     var physicalIfname = wanObj.TryGetProperty("ifname", out var ifnProp) ? ifnProp.GetString() : null;
 
@@ -305,9 +305,13 @@ public class MonitoringPathView
         if (string.IsNullOrEmpty(gwMac)) return;
         foreach (var wan in wans)
         {
-            if (!string.IsNullOrEmpty(wan.UplinkIfName))
+            // For VLAN sub-interfaces (eth6.100), use the physical parent (eth6)
+            // for rate stats - VLAN sub-interface SNMP counters double-count on
+            // some kernels. For non-VLAN WANs, PhysicalIfName == UplinkIfName.
+            var rateIfName = wan.PhysicalIfName ?? wan.UplinkIfName;
+            if (!string.IsNullOrEmpty(rateIfName))
             {
-                var portRate = _liveStats.GetPortRate(gwMac, wan.UplinkIfName);
+                var portRate = _liveStats.GetPortRate(gwMac, rateIfName);
                 if (portRate != null)
                 {
                     // GetPortRate convention: DownBps = port TX, UpBps = port RX.

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -58,8 +58,12 @@ public class MonitoringPathView
 
         var resolvedWanInterface = wan?.WanInterface ?? wanInterface ?? "wan";
         var isPrimary = wan?.IsPrimary ?? true;
-        _logger.LogDebug("GetUpstreamPathAsync: wans={WanCount}, wan={WanIf}, resolved={Resolved}, isPrimary={Primary}",
-            wans.Count, wan?.WanInterface, resolvedWanInterface, isPrimary);
+        var accessHopCount = await db.MonitoringTargets.AsNoTracking()
+            .CountAsync(t => t.TargetType == MonitoringTargetType.AccessIsp
+                        && (t.WanInterface == resolvedWanInterface
+                            || (isPrimary && t.WanInterface == null)), ct);
+        _logger.LogInformation("GetUpstreamPathAsync: wans={WanCount}, wan={WanIf}, resolved={Resolved}, isPrimary={Primary}, accessHopCount={HopCount}",
+            wans.Count, wan?.WanInterface, resolvedWanInterface, isPrimary, accessHopCount);
 
         // Per-WAN context, with fallback to legacy MonitoringSettings for installs that
         // pre-date the WanDiscoveryContexts table. New installs and any post-migration

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -58,8 +58,8 @@ public class MonitoringPathView
 
         var resolvedWanInterface = wan?.WanInterface ?? wanInterface ?? "wan";
         var isPrimary = wan?.IsPrimary ?? true;
-        _logger.LogDebug("GetUpstreamPathAsync: wans={WanCount}, wan={WanIf}, resolved={Resolved}, isPrimary={Primary}",
-            wans.Count, wan?.WanInterface, resolvedWanInterface, isPrimary);
+        _logger.LogDebug("GetUpstreamPathAsync: wans={WanCount}, wan={WanIf}, friendly={Friendly}, resolved={Resolved}, isPrimary={Primary}",
+            wans.Count, wan?.WanInterface, wan?.FriendlyName, resolvedWanInterface, isPrimary);
 
         // Per-WAN context, with fallback to legacy MonitoringSettings for installs that
         // pre-date the WanDiscoveryContexts table. New installs and any post-migration

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -277,6 +277,7 @@ public class MonitoringPathView
                         IsPrimary = results.Count == 0,
                         GatewayMac = gwMac,
                         GatewayPortName = friendlyName,
+                        UplinkIfName = uplinkIfname,
                         LinkSpeedMbps = linkSpeed > 0 ? linkSpeed : (int?)null,
                         IpAddress = ip,
                         IpClass = NetworkUtilities.ClassifyPublicAddress(ip)
@@ -298,9 +299,19 @@ public class MonitoringPathView
         if (wans.Count == 0) return;
         var gwMac = wans[0].GatewayMac;
         if (string.IsNullOrEmpty(gwMac)) return;
-        var deviceLive = _liveStats.GetForDevice(gwMac);
         foreach (var wan in wans)
         {
+            if (!string.IsNullOrEmpty(wan.UplinkIfName))
+            {
+                var portRate = _liveStats.GetPortRate(gwMac, wan.UplinkIfName);
+                if (portRate != null)
+                {
+                    wan.LiveRateInBps = portRate.UpBps;
+                    wan.LiveRateOutBps = portRate.DownBps;
+                    continue;
+                }
+            }
+            var deviceLive = _liveStats.GetForDevice(gwMac);
             wan.LiveRateInBps = deviceLive?.RateInBps;
             wan.LiveRateOutBps = deviceLive?.RateOutBps;
         }
@@ -382,6 +393,7 @@ public record WanSummary
     public required bool IsPrimary { get; init; }
     public string? GatewayMac { get; init; }
     public string? GatewayPortName { get; init; }
+    public string? UplinkIfName { get; init; }
     public int? LinkSpeedMbps { get; init; }
     public double? LiveRateInBps { get; set; }
     public double? LiveRateOutBps { get; set; }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -43,11 +43,10 @@ public class UpstreamTracerService
     // DetectPublicIpAsync from the gateway's port_table.
     private readonly HashSet<string> _gatewayIps = new(StringComparer.OrdinalIgnoreCase);
 
-    // The OS-level interface name backing the WAN port (e.g. "ethN" or
-    // "ethN.M" for VLAN-tagged uplinks), read straight from UniFi's
-    // port_table.uplink_ifname during DetectPublicIpAsync. The L2-neighbor
-    // step uses this to target `ip neigh show dev <iface>` correctly even
-    // when the WAN sits on a sub-interface.
+    // The OS-level interface name backing the WAN port (e.g. "ethN",
+    // "ethN.M" for VLAN-tagged, "pppN" for PPPoE), read from the device's
+    // wan1...wan6 uplink_ifname during DetectPublicIpAsync. The L2-neighbor
+    // step uses this to target `ip neigh show dev <iface>` correctly.
     private string? _wanUplinkIfName;
 
     public UpstreamTracerState State { get; private set; } = new();
@@ -259,53 +258,108 @@ public class UpstreamTracerService
             return Fail("Not connected to UniFi Console.");
         }
 
-        List<UniFiDeviceResponse> devices;
+        // Fetch raw device JSON to read wan1...wan6 objects directly.
+        // These are the authoritative WAN descriptors and correctly report
+        // the Linux interface name for all connection types (DHCP, PPPoE,
+        // VLAN-tagged, GRE tunnels) - unlike port_table.is_uplink which
+        // may not be set for non-standard connections.
+        string? deviceJson;
         try
         {
-            devices = (await _connectionService.Client.GetDevicesAsync(ct))?.ToList()
-                      ?? new List<UniFiDeviceResponse>();
+            deviceJson = await _connectionService.Client.GetDevicesRawJsonAsync(ct);
+            if (string.IsNullOrEmpty(deviceJson))
+                return Fail("Empty device response from UniFi Console.");
         }
         catch (Exception ex)
         {
             return Fail($"Couldn't fetch UniFi devices: {ex.Message}");
         }
 
-        var gateway = devices.FirstOrDefault(d =>
-            d.DeviceType == NetworkOptimizer.Core.Enums.DeviceType.Gateway);
-        if (gateway?.PortTable == null)
+        string? wanInterfaceName = null;
+        string? wanUplinkIfName = null;
+        string? wanIp = null;
+
+        using (var doc = System.Text.Json.JsonDocument.Parse(deviceJson))
         {
-            return Fail("No gateway found in topology.");
+            var root = doc.RootElement;
+            var devices = root.ValueKind == System.Text.Json.JsonValueKind.Array
+                ? root
+                : root.TryGetProperty("data", out var data) ? data : root;
+
+            foreach (var device in devices.EnumerateArray())
+            {
+                var deviceType = device.TryGetProperty("type", out var typeProp) ? typeProp.GetString() : null;
+                if (deviceType != "ugw" && deviceType != "udm" && deviceType != "uxg")
+                    continue;
+
+                // Collect every IP the gateway carries so we can filter our own
+                // gateway out of the access-hop classification later.
+                _gatewayIps.Clear();
+                var portIdxToNetworkName = new Dictionary<int, string>();
+                if (device.TryGetProperty("port_table", out var portTable) &&
+                    portTable.ValueKind == System.Text.Json.JsonValueKind.Array)
+                {
+                    foreach (var port in portTable.EnumerateArray())
+                    {
+                        if (port.TryGetProperty("ip", out var ptIpProp))
+                        {
+                            var ptIp = ptIpProp.GetString();
+                            if (!string.IsNullOrEmpty(ptIp)) _gatewayIps.Add(ptIp);
+                        }
+                        if (port.TryGetProperty("port_idx", out var idxProp) &&
+                            idxProp.TryGetInt32(out var idx) &&
+                            port.TryGetProperty("network_name", out var nnProp))
+                        {
+                            var nn = nnProp.GetString();
+                            if (!string.IsNullOrEmpty(nn))
+                                portIdxToNetworkName[idx] = nn;
+                        }
+                    }
+                }
+
+                for (int i = 1; i <= 6; i++)
+                {
+                    var wanKey = $"wan{i}";
+                    if (!device.TryGetProperty(wanKey, out var wanObj)) continue;
+
+                    var uplinkIfname = wanObj.TryGetProperty("uplink_ifname", out var uplinkProp)
+                        ? uplinkProp.GetString() : null;
+                    if (string.IsNullOrEmpty(uplinkIfname)) continue;
+
+                    var ip = wanObj.TryGetProperty("ip", out var wanIpProp)
+                        ? wanIpProp.GetString() : null;
+
+                    // Derive the WAN key from port_table network_name when available
+                    // (e.g. "wan", "wan2") to match convention used by prior code.
+                    string interfaceKey;
+                    if (wanObj.TryGetProperty("port_idx", out var portIdxProp) &&
+                        portIdxProp.TryGetInt32(out var portIdx) &&
+                        portIdxToNetworkName.TryGetValue(portIdx, out var networkName))
+                    {
+                        interfaceKey = networkName;
+                    }
+                    else
+                    {
+                        interfaceKey = i == 1 ? "wan" : $"wan{i}";
+                    }
+
+                    wanInterfaceName = interfaceKey;
+                    wanUplinkIfName = uplinkIfname;
+                    wanIp = ip;
+                    break;
+                }
+
+                if (wanInterfaceName != null) break;
+            }
         }
 
-        // Primary WAN port: first IsUplink port with a network_name starting with "wan",
-        // else any uplink port.
-        var wanPort = gateway.PortTable.FirstOrDefault(p =>
-            p.IsUplink &&
-            (p.NetworkName?.StartsWith("wan", StringComparison.OrdinalIgnoreCase) ?? false));
-        wanPort ??= gateway.PortTable.FirstOrDefault(p => p.IsUplink);
-        if (wanPort == null)
-        {
+        if (wanInterfaceName == null)
             return Fail("Couldn't identify the WAN port on the gateway.");
-        }
 
-        State.WanInterface = wanPort.NetworkName ?? "wan";
-        _wanUplinkIfName = wanPort.UplinkIfName;
-
-        // Snapshot every IP the gateway carries (LAN, WAN, management VLAN) so
-        // we can filter our own gateway out of the access-hop classification
-        // below. Without this the trace's first hop (the LAN gateway address)
-        // gets misclassified as the access ISP's first-mile device.
-        _gatewayIps.Clear();
-        foreach (var port in gateway.PortTable)
-        {
-            if (!string.IsNullOrEmpty(port.Ip)) _gatewayIps.Add(port.Ip);
-        }
-
-        // The port_table IP is the WAN public IP in our experience (or RFC1918 for
-        // double-NAT, CGNAT for cgnat, etc.). NetworkUtilities.ClassifyPublicAddress
-        // does the bracket detection.
-        State.WanIpAddress = wanPort.Ip;
-        State.WanIpClass = NetworkUtilities.ClassifyPublicAddress(wanPort.Ip);
+        State.WanInterface = wanInterfaceName;
+        _wanUplinkIfName = wanUplinkIfName;
+        State.WanIpAddress = wanIp;
+        State.WanIpClass = NetworkUtilities.ClassifyPublicAddress(wanIp);
 
         switch (State.WanIpClass)
         {
@@ -315,14 +369,14 @@ public class UpstreamTracerService
 
             case PublicAddressClass.Cgnat:
                 State.IsCgnat = true;
-                _logger.LogInformation("Tracer: WAN IP is CGNAT ({Ip}); proceeding with discovery", wanPort.Ip);
+                _logger.LogInformation("Tracer: WAN IP is CGNAT ({Ip}); proceeding with discovery", wanIp);
                 break;
 
             case PublicAddressClass.DoubleNat:
                 // Per locked Gate 2 decision 8: proceed anyway, traceroute will still
                 // reveal the upstream ISP. Surface a small "double-NAT detected" badge.
                 State.IsDoubleNat = true;
-                _logger.LogInformation("Tracer: WAN IP is RFC1918 ({Ip}); proceeding (double-NAT)", wanPort.Ip);
+                _logger.LogInformation("Tracer: WAN IP is RFC1918 ({Ip}); proceeding (double-NAT)", wanIp);
                 break;
 
             case PublicAddressClass.IPv6:

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -461,16 +461,29 @@ public class MonitoringCollectionAgent : BackgroundService
         }
 
         // Gateways are the top of the topology - no parent switch to read their
-        // uplink rate from. Fall back to the SNMP rate on the gateway's own WAN
-        // interface (which is what the topology view's gateway pipe actually
-        // represents anyway). We pick the highest-rate non-LAN interface as a
-        // pragmatic heuristic - the WAN interface tends to dominate.
+        // uplink rate from. Use the SNMP rate on the gateway's actual WAN
+        // interface (wan1...wan6 uplink_ifname, e.g. eth6.228 for VLAN-tagged
+        // or ppp3 for PPPoE) rather than port_table.IsUplink which may not be
+        // set for non-standard connection types.
         foreach (var gw in devices.Where(d => d.DeviceType == NetworkOptimizer.Core.Enums.DeviceType.Gateway))
         {
             var gwMac = NormalizeMac(gw.Mac);
 
-            // Primary: UniFi PortTable WAN port byte delta. Works when the gateway's
-            // uplink is a simple physical port and PortIdx aligns with SNMP ifIndex.
+            // Primary: SNMP rate on the WAN uplink interface from wan1...wan6.
+            if (_cachedGatewayWanIfNames.TryGetValue(gwMac, out var wanIfName))
+            {
+                var portRate = _liveStats.GetPortRate(gwMac, wanIfName);
+                if (portRate != null)
+                {
+                    // Gateway WAN perspective: port TX (DownBps) = data toward
+                    // internet = uploads; port RX (UpBps) = from internet = downloads.
+                    _liveStats.RecordInterfaceAggregate(gw.Mac, portRate.DownBps, portRate.UpBps, nowOverride);
+                    continue;
+                }
+            }
+
+            // Fallback: PortTable IsUplink + PortIdx. Covers gateways where
+            // the raw JSON hasn't been fetched yet or the wan object is missing.
             (double DownBps, double UpBps)? rate = null;
             if (gw.PortTable != null)
             {
@@ -480,19 +493,15 @@ public class MonitoringCollectionAgent : BackgroundService
                     rate = ComputePortRate(gwMac, wanPort.PortIdx, nowOverride);
                     if (rate.HasValue)
                     {
-                        // Gateway perspective: TX out the WAN = upstream toward internet;
-                        // RX = downstream. Note direction flip vs the switch-port case.
                         _liveStats.RecordInterfaceAggregate(gw.Mac, rate.Value.UpBps, rate.Value.DownBps, nowOverride);
                         continue;
                     }
                 }
             }
 
-            // Fallback: UniFi device-level tx_bytes / rx_bytes delta. Used when the
-            // gateway's WAN-side is a bond/LAG (Linux bond0 aggregating eth4+eth5
-            // for a named WAN port, etc.) and PortTable.PortIdx doesn't
-            // align with any single physical SNMP ifIndex. ComputeDeviceRate
-            // returns (down, up) in our convention.
+            // Last resort: device-level tx_bytes / rx_bytes delta. Used when the
+            // gateway's WAN-side is a bond/LAG and neither wan1...wan6 nor
+            // PortTable produced a usable rate.
             var devRate = ComputeDeviceRate(gwMac);
             if (devRate.HasValue)
             {
@@ -1335,6 +1344,7 @@ public class MonitoringCollectionAgent : BackgroundService
     private List<UniFiDeviceResponse> _cachedDevices = new();
     private DateTime _cachedDevicesAt = DateTime.MinValue;
     private readonly SemaphoreSlim _deviceFetchLock = new(1, 1);
+    private Dictionary<string, string> _cachedGatewayWanIfNames = new(StringComparer.OrdinalIgnoreCase);
 
     // Gateway LAN IP cache. UniFi reports the gateway's "ip" as the WAN public IP
     // which never answers SNMP from inside the LAN. The actual SNMP-reachable IP is
@@ -1428,6 +1438,46 @@ public class MonitoringCollectionAgent : BackgroundService
                 .ToList() ?? new List<UniFiDeviceResponse>();
             _cachedDevices = filtered;
             _cachedDevicesAt = DateTime.UtcNow;
+
+            // Extract gateway WAN uplink_ifname from raw device JSON so the
+            // gateway rate override uses the correct interface (e.g. eth6.228
+            // for VLAN-tagged, ppp3 for PPPoE) instead of the physical port.
+            var gwIfNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                var rawJson = await _connectionService.Client.GetDevicesRawJsonAsync(ct);
+                if (!string.IsNullOrEmpty(rawJson))
+                {
+                    using var doc = System.Text.Json.JsonDocument.Parse(rawJson);
+                    var root = doc.RootElement;
+                    var devArray = root.ValueKind == System.Text.Json.JsonValueKind.Array
+                        ? root
+                        : root.TryGetProperty("data", out var arr) ? arr : root;
+                    foreach (var dev in devArray.EnumerateArray())
+                    {
+                        var type = dev.TryGetProperty("type", out var tp) ? tp.GetString() : null;
+                        if (type != "ugw" && type != "udm" && type != "uxg") continue;
+                        var mac = dev.TryGetProperty("mac", out var mp) ? mp.GetString() : null;
+                        if (string.IsNullOrEmpty(mac)) continue;
+                        for (int i = 1; i <= 6; i++)
+                        {
+                            if (!dev.TryGetProperty($"wan{i}", out var wanObj)) continue;
+                            var uplinkIf = wanObj.TryGetProperty("uplink_ifname", out var up) ? up.GetString() : null;
+                            if (!string.IsNullOrEmpty(uplinkIf))
+                            {
+                                gwIfNames[mac.ToLowerInvariant().Replace('-', ':')] = uplinkIf;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to extract gateway WAN ifnames from raw JSON");
+            }
+            _cachedGatewayWanIfNames = gwIfNames;
+
             return filtered;
         }
         catch (Exception ex)

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -462,17 +462,21 @@ public class MonitoringCollectionAgent : BackgroundService
 
         // Gateways are the top of the topology - no parent switch to read their
         // uplink rate from. Use the SNMP rate on the gateway's actual WAN
-        // interface (wan1...wan6 uplink_ifname, e.g. eth6.228 for VLAN-tagged
+        // interface (wan1...wan6 uplink_ifname, e.g. eth6.100 for VLAN-tagged
         // or ppp3 for PPPoE) rather than port_table.IsUplink which may not be
         // set for non-standard connection types.
         foreach (var gw in devices.Where(d => d.DeviceType == NetworkOptimizer.Core.Enums.DeviceType.Gateway))
         {
             var gwMac = NormalizeMac(gw.Mac);
 
-            // Primary: SNMP rate on the WAN uplink interface from wan1...wan6.
-            if (_cachedGatewayWanIfNames.TryGetValue(gwMac, out var wanIfName))
+            // Primary: SNMP rate on the WAN physical port. For VLAN-tagged WANs,
+            // use the parent port (eth6) not the sub-interface (eth6.100) since
+            // VLAN sub-interface counters double-count on some kernels.
+            var rateIfName = _cachedGatewayWanPhysicalIfNames.TryGetValue(gwMac, out var physIf) ? physIf : null;
+            rateIfName ??= _cachedGatewayWanIfNames.TryGetValue(gwMac, out var uplinkIf) ? uplinkIf : null;
+            if (rateIfName != null)
             {
-                var portRate = _liveStats.GetPortRate(gwMac, wanIfName);
+                var portRate = _liveStats.GetPortRate(gwMac, rateIfName);
                 if (portRate != null)
                 {
                     // Gateway WAN perspective: port TX (DownBps) = data toward
@@ -1345,6 +1349,7 @@ public class MonitoringCollectionAgent : BackgroundService
     private DateTime _cachedDevicesAt = DateTime.MinValue;
     private readonly SemaphoreSlim _deviceFetchLock = new(1, 1);
     private Dictionary<string, string> _cachedGatewayWanIfNames = new(StringComparer.OrdinalIgnoreCase);
+    private Dictionary<string, string> _cachedGatewayWanPhysicalIfNames = new(StringComparer.OrdinalIgnoreCase);
 
     // Gateway LAN IP cache. UniFi reports the gateway's "ip" as the WAN public IP
     // which never answers SNMP from inside the LAN. The actual SNMP-reachable IP is
@@ -1440,9 +1445,10 @@ public class MonitoringCollectionAgent : BackgroundService
             _cachedDevicesAt = DateTime.UtcNow;
 
             // Extract gateway WAN uplink_ifname from raw device JSON so the
-            // gateway rate override uses the correct interface (e.g. eth6.228
+            // gateway rate override uses the correct interface (e.g. eth6.100
             // for VLAN-tagged, ppp3 for PPPoE) instead of the physical port.
             var gwIfNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var gwPhysIfNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             try
             {
                 var rawJson = await _connectionService.Client.GetDevicesRawJsonAsync(ct);
@@ -1459,13 +1465,17 @@ public class MonitoringCollectionAgent : BackgroundService
                         if (type != "ugw" && type != "udm" && type != "uxg") continue;
                         var mac = dev.TryGetProperty("mac", out var mp) ? mp.GetString() : null;
                         if (string.IsNullOrEmpty(mac)) continue;
+                        var normalizedMac = mac.ToLowerInvariant().Replace('-', ':');
                         for (int i = 1; i <= 6; i++)
                         {
                             if (!dev.TryGetProperty($"wan{i}", out var wanObj)) continue;
                             var uplinkIf = wanObj.TryGetProperty("uplink_ifname", out var up) ? up.GetString() : null;
                             if (!string.IsNullOrEmpty(uplinkIf))
                             {
-                                gwIfNames[mac.ToLowerInvariant().Replace('-', ':')] = uplinkIf;
+                                gwIfNames[normalizedMac] = uplinkIf;
+                                var physIf = wanObj.TryGetProperty("ifname", out var pf) ? pf.GetString() : null;
+                                if (!string.IsNullOrEmpty(physIf))
+                                    gwPhysIfNames[normalizedMac] = physIf;
                                 break;
                             }
                         }
@@ -1477,6 +1487,7 @@ public class MonitoringCollectionAgent : BackgroundService
                 _logger.LogDebug(ex, "Failed to extract gateway WAN ifnames from raw JSON");
             }
             _cachedGatewayWanIfNames = gwIfNames;
+            _cachedGatewayWanPhysicalIfNames = gwPhysIfNames;
 
             return filtered;
         }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14494,6 +14494,7 @@ a.affected-client:hover {
     font-variant-numeric: tabular-nums;
     border: 1px solid rgba(36, 188, 112, 0.3);
     margin-top: 4px;
+    white-space: nowrap;
     display: none;
 }
 .lan-flow-map-wan-pill.is-visible {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1990,7 +1990,7 @@ export class LanFlowMap {
             const group = this._cloudMeshes.get(`cloud-access-${wanIface}`);
             if (!group) { pill.classList.remove('is-visible'); continue; }
             tmp.setFromMatrixPosition(group.matrixWorld);
-            tmp.y -= NODE_RADIUS.cloud + 0.5;
+            tmp.y -= NODE_RADIUS.cloud;
             tmp.project(this.camera);
             if (tmp.z > 1) { pill.classList.remove('is-visible'); continue; }
             const x = (tmp.x * halfW) + halfW;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1276,16 +1276,20 @@ export class LanFlowMap {
                 this.controls?.update();
             }
 
-            // Left/right arrow: scrub timeline. ~30s per tick, shift = 10x.
+            // Left/right arrow: scrub timeline. Throttled to 5 ticks/sec.
             if (this._keys?.['arrowleft'] || this._keys?.['arrowright']) {
-                const range = this._panels.scrubberRange;
-                if (range) {
-                    const step = this._keys.shift ? 35 : 4;
-                    const dir = this._keys['arrowright'] ? step : -step;
-                    const val = Math.max(0, Math.min(10000, Number(range.value) + dir));
-                    range.value = val;
-                    range.dispatchEvent(new Event('input'));
-                    range.dispatchEvent(new Event('change'));
+                const now = performance.now();
+                if (!this._lastArrowScrub || now - this._lastArrowScrub >= 200) {
+                    this._lastArrowScrub = now;
+                    const range = this._panels.scrubberRange;
+                    if (range) {
+                        const step = this._keys.shift ? 35 : 4;
+                        const dir = this._keys['arrowright'] ? step : -step;
+                        const val = Math.max(0, Math.min(10000, Number(range.value) + dir));
+                        range.value = val;
+                        range.dispatchEvent(new Event('input'));
+                        range.dispatchEvent(new Event('change'));
+                    }
                 }
             }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1571,12 +1571,23 @@ export class LanFlowMap {
         `;
         const range = scrubber.querySelector('.lan-flow-map-scrubber-range');
         range.addEventListener('input', (e) => this._onScrubberInput(Number(e.target.value)));
-        this._scrubberDebounce = null;
+        this._scrubberThrottleTimer = null;
+        this._scrubberLastFire = 0;
         range.addEventListener('change', (e) => {
             const val = Number(e.target.value);
             this._onScrubberInput(val);
-            clearTimeout(this._scrubberDebounce);
-            this._scrubberDebounce = setTimeout(() => this._onScrubberChange(val), 250);
+            const now = Date.now();
+            const elapsed = now - this._scrubberLastFire;
+            clearTimeout(this._scrubberThrottleTimer);
+            if (elapsed >= 250) {
+                this._scrubberLastFire = now;
+                this._onScrubberChange(val);
+            } else {
+                this._scrubberThrottleTimer = setTimeout(() => {
+                    this._scrubberLastFire = Date.now();
+                    this._onScrubberChange(val);
+                }, 250 - elapsed);
+            }
         });
         // User grabbing the thumb implicitly cancels any active historic playback.
         range.addEventListener('pointerdown', () => this._stopHistoricPlayback());

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1576,17 +1576,24 @@ export class LanFlowMap {
         range.addEventListener('pointerdown', () => this._stopHistoricPlayback());
         const playPause = scrubber.querySelector('[data-role="playpause"]');
         playPause.addEventListener('click', () => this._togglePlayPause());
-        const SPEED_STEPS = [1, 2, 5, 10, 30, 60, 120, 360, 720, 1440];
+        const SPEED_STEPS = [0.5, 1, 2, 5, 10, 30, 60, 120, 360, 720, 1440];
         this._speedSteps = SPEED_STEPS;
-        this._speedIndex = 0; // starts at 1x
+        this._speedIndex = 1; // starts at 1x
         for (const btn of scrubber.querySelectorAll('.lan-flow-map-speed-step')) {
             btn.addEventListener('click', () => {
                 const dir = Number(btn.dataset.dir);
-                const newIdx = Math.max(0, Math.min(SPEED_STEPS.length - 1, this._speedIndex + dir));
+                let newIdx = Math.max(0, Math.min(SPEED_STEPS.length - 1, this._speedIndex + dir));
+                if (this._mode === 'live' && dir > 0) {
+                    const liveIdx = SPEED_STEPS.indexOf(1);
+                    if (newIdx > liveIdx) newIdx = liveIdx;
+                }
                 if (newIdx === this._speedIndex) return;
                 this._speedIndex = newIdx;
                 this._playbackSpeed = SPEED_STEPS[newIdx];
                 this._syncSpeedLabel();
+                if (this._mode === 'live' && this._playbackSpeed < 1) {
+                    this._onScrubberChange(998);
+                }
                 if (this._mode === 'historic' && this._historicPlaybackTimer) {
                     this._stopHistoricPlayback();
                     this._startHistoricPlayback();
@@ -1786,8 +1793,9 @@ export class LanFlowMap {
                 this._panels.modeBadge.removeAttribute('data-tooltip');
                 if (this._panels.modeBadge._tippy) this._panels.modeBadge._tippy.destroy();
             }
-            // Returning to live resumes polling; clear the paused state so the
-            // play button reflects "playing" again.
+            // Returning to live: reset speed to 1x and resume polling.
+            this._speedIndex = this._speedSteps.indexOf(1);
+            this._playbackSpeed = 1;
             this._paused = false;
             this._syncPlayPauseIcon();
             this._syncSpeedLabel();

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1571,7 +1571,13 @@ export class LanFlowMap {
         `;
         const range = scrubber.querySelector('.lan-flow-map-scrubber-range');
         range.addEventListener('input', (e) => this._onScrubberInput(Number(e.target.value)));
-        range.addEventListener('change', (e) => this._onScrubberChange(Number(e.target.value)));
+        this._scrubberDebounce = null;
+        range.addEventListener('change', (e) => {
+            const val = Number(e.target.value);
+            this._onScrubberInput(val);
+            clearTimeout(this._scrubberDebounce);
+            this._scrubberDebounce = setTimeout(() => this._onScrubberChange(val), 250);
+        });
         // User grabbing the thumb implicitly cancels any active historic playback.
         range.addEventListener('pointerdown', () => this._stopHistoricPlayback());
         const playPause = scrubber.querySelector('[data-role="playpause"]');

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1592,7 +1592,10 @@ export class LanFlowMap {
                 this._playbackSpeed = SPEED_STEPS[newIdx];
                 this._syncSpeedLabel();
                 if (this._mode === 'live' && this._playbackSpeed < 1) {
+                    this._speedTransition = true;
                     this._onScrubberChange(997);
+                    this._speedTransition = false;
+                    this._startHistoricPlayback();
                 }
                 if (this._mode === 'historic' && this._historicPlaybackTimer) {
                     this._stopHistoricPlayback();
@@ -1818,7 +1821,7 @@ export class LanFlowMap {
         // method on every tick (to load the historic snapshot for the new
         // slider position); skip the auto-pause in that case or playback
         // would stop after one tick.
-        if (!this._playbackAdvancing && !this._paused) {
+        if (!this._playbackAdvancing && !this._speedTransition && !this._paused) {
             this._paused = true;
             this._syncPlayPauseIcon();
             this._stopHistoricPlayback();

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -309,25 +309,18 @@ export class LanFlowMap {
                 this._togglePlayPause();
                 return;
             }
-            if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
-                const range = this._panels.scrubberRange;
-                if (range) {
-                    e.preventDefault();
-                    const step = e.shiftKey ? 100 : 10;
-                    const dir = e.key === 'ArrowRight' ? step : -step;
-                    const val = Math.max(0, Math.min(10000, Number(range.value) + dir));
-                    range.value = val;
-                    range.dispatchEvent(new Event('input'));
-                    range.dispatchEvent(new Event('change'));
-                    return;
-                }
+            if (['arrowleft','arrowright','w','a','s','d','q','e'].includes(e.key.toLowerCase())) {
+                if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') e.preventDefault();
+                this._keys[e.key.toLowerCase()] = true;
             }
+            if (e.key === 'Shift') this._keys.shift = true;
             if (['w','a','s','d','q','e'].includes(e.key.toLowerCase())) {
                 this._keys[e.key.toLowerCase()] = true;
             }
         };
         this._onKeyUp = (e) => {
             this._keys[e.key.toLowerCase()] = false;
+            if (e.key === 'Shift') this._keys.shift = false;
         };
         document.addEventListener('keydown', this._onKeyDown);
         document.addEventListener('keyup', this._onKeyUp);
@@ -1281,6 +1274,19 @@ export class LanFlowMap {
                     }
                 }
                 this.controls?.update();
+            }
+
+            // Left/right arrow: scrub timeline. ~30s per tick, shift = 10x.
+            if (this._keys?.['arrowleft'] || this._keys?.['arrowright']) {
+                const range = this._panels.scrubberRange;
+                if (range) {
+                    const step = this._keys.shift ? 35 : 4;
+                    const dir = this._keys['arrowright'] ? step : -step;
+                    const val = Math.max(0, Math.min(10000, Number(range.value) + dir));
+                    range.value = val;
+                    range.dispatchEvent(new Event('input'));
+                    range.dispatchEvent(new Event('change'));
+                }
             }
 
             // Freeze particle motion while paused (Live or Historic) so the

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -309,12 +309,13 @@ export class LanFlowMap {
                 this._togglePlayPause();
                 return;
             }
-            if (e.shiftKey && (e.key === 'ArrowLeft' || e.key === 'ArrowRight')) {
+            if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
                 const range = this._panels.scrubberRange;
-                if (range && document.activeElement === range) {
+                if (range) {
                     e.preventDefault();
-                    const step = e.key === 'ArrowRight' ? 10 : -10;
-                    const val = Math.max(0, Math.min(10000, Number(range.value) + step));
+                    const step = e.shiftKey ? 100 : 10;
+                    const dir = e.key === 'ArrowRight' ? step : -step;
+                    const val = Math.max(0, Math.min(10000, Number(range.value) + dir));
                     range.value = val;
                     range.dispatchEvent(new Event('input'));
                     range.dispatchEvent(new Event('change'));
@@ -1601,6 +1602,7 @@ export class LanFlowMap {
                 }, 1000 - elapsed);
             }
         });
+        range.addEventListener('keydown', (e) => e.preventDefault());
         // User grabbing the thumb implicitly cancels any active historic playback.
         range.addEventListener('pointerdown', () => this._stopHistoricPlayback());
         const playPause = scrubber.querySelector('[data-role="playpause"]');

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1987,7 +1987,7 @@ export class LanFlowMap {
             const group = this._cloudMeshes.get(`cloud-access-${wanIface}`);
             if (!group) { pill.classList.remove('is-visible'); continue; }
             tmp.setFromMatrixPosition(group.matrixWorld);
-            tmp.y -= NODE_RADIUS.cloud;
+            tmp.y -= NODE_RADIUS.cloud + 0.5;
             const dist = tmp.distanceTo(camPos);
             tmp.project(this.camera);
             if (tmp.z > 1) { pill.classList.remove('is-visible'); continue; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1343,24 +1343,24 @@ export class LanFlowMap {
             const now = Date.now();
             const span = now - this._scrubberOrigin;
             const value = span > 0
-                ? Math.round((this._playbackTime.getTime() - this._scrubberOrigin) / span * 1000)
-                : 1000;
-            const clamped = Math.max(0, Math.min(1000, value));
+                ? Math.round((this._playbackTime.getTime() - this._scrubberOrigin) / span * 10000)
+                : 10000;
+            const clamped = Math.max(0, Math.min(10000, value));
             range.value = clamped;
             // Update the time label from the continuous timestamp, not the
             // integer slider position (which only moves every ~86s at 1x).
             if (this._panels.scrubberRight) {
                 this._panels.scrubberRight.textContent =
-                    (clamped >= 998) ? 'Live' : _fmtDateTime(this._playbackTime);
+                    (clamped >= 9998) ? 'Live' : _fmtDateTime(this._playbackTime);
             }
             tickCount++;
             // Refresh map and stat cards periodically
             if (tickCount % DATA_REFRESH_TICKS === 0 || clamped >= 998) {
                 this._playbackAdvancing = true;
                 try {
-                    if (clamped >= 998) {
+                    if (clamped >= 9998) {
                         this._stopHistoricPlayback();
-                        this._onScrubberChange(1000);
+                        this._onScrubberChange(10000);
                     } else {
                         this._historicAt = this._playbackTime;
                         this._notifyStatCards(this._playbackTime);
@@ -1543,8 +1543,8 @@ export class LanFlowMap {
         modeBadge.addEventListener('click', () => {
             if (this._mode === 'live') return;
             const range = this._panels.scrubberRange;
-            if (range) range.value = 1000;
-            this._onScrubberChange(1000);
+            if (range) range.value = 10000;
+            this._onScrubberChange(10000);
         });
         status.appendChild(modeBadge);
         this._panels.status = status;
@@ -1565,7 +1565,7 @@ export class LanFlowMap {
                     <button class="lan-flow-map-speed-step" data-dir="1" type="button" aria-label="Faster">+</button>
                 </div>
                 <span data-role="left">-24h</span>
-                <input class="lan-flow-map-scrubber-range" type="range" min="0" max="1000" value="1000" />
+                <input class="lan-flow-map-scrubber-range" type="range" min="0" max="10000" value="10000" />
                 <span data-role="right">Live</span>
             </div>
         `;
@@ -1594,9 +1594,9 @@ export class LanFlowMap {
                 if (this._mode === 'live' && this._playbackSpeed < 1) {
                     const now = Date.now();
                     const span = now - this._scrubberOrigin;
-                    const nearNow = span > 0 ? Math.floor((now - 5000 - this._scrubberOrigin) / span * 1000) : 997;
+                    const nearNow = span > 0 ? Math.floor((now - 5000 - this._scrubberOrigin) / span * 10000) : 9997;
                     this._speedTransition = true;
-                    this._onScrubberChange(Math.min(nearNow, 997));
+                    this._onScrubberChange(Math.min(nearNow, 9997));
                     this._speedTransition = false;
                     this._startHistoricPlayback();
                 }
@@ -1781,17 +1781,17 @@ export class LanFlowMap {
         const at = this._scrubberValueToTime(value);
         if (this._panels.scrubberRight) {
             this._panels.scrubberRight.textContent =
-                (value >= 998) ? 'Live' : _fmtDateTime(at);
+                (value >= 9998) ? 'Live' : _fmtDateTime(at);
         }
     }
 
     async _onScrubberChange(value) {
-        if (value >= 998) {
+        if (value >= 9998) {
             // Snap back to live.
             this._stopHistoricPlayback();
             this._mode = 'live';
             this._historicAt = null;
-            this._onScrubberInput(1000);
+            this._onScrubberInput(10000);
             if (this._panels.modeBadge) {
                 this._panels.modeBadge.textContent = 'Live';
                 this._panels.modeBadge.classList.remove('is-historic');
@@ -1856,10 +1856,10 @@ export class LanFlowMap {
     }
 
     _scrubberValueToTime(value) {
-        // Range 0..1000 maps from the anchored origin (mount - 24h) to now.
+        // Range 0..10000 maps from the anchored origin (mount - 24h) to now.
         // The window grows as the page stays open so recent time is always reachable.
         const now = Date.now();
-        const ms = this._scrubberOrigin + (value / 1000) * (now - this._scrubberOrigin);
+        const ms = this._scrubberOrigin + (value / 10000) * (now - this._scrubberOrigin);
         return new Date(ms);
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1579,14 +1579,14 @@ export class LanFlowMap {
             const now = Date.now();
             const elapsed = now - this._scrubberLastFire;
             clearTimeout(this._scrubberThrottleTimer);
-            if (elapsed >= 250) {
+            if (elapsed >= 1000) {
                 this._scrubberLastFire = now;
                 this._onScrubberChange(val);
             } else {
                 this._scrubberThrottleTimer = setTimeout(() => {
                     this._scrubberLastFire = Date.now();
                     this._onScrubberChange(val);
-                }, 250 - elapsed);
+                }, 1000 - elapsed);
             }
         });
         // User grabbing the thumb implicitly cancels any active historic playback.

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1987,7 +1987,7 @@ export class LanFlowMap {
             const group = this._cloudMeshes.get(`cloud-access-${wanIface}`);
             if (!group) { pill.classList.remove('is-visible'); continue; }
             tmp.setFromMatrixPosition(group.matrixWorld);
-            tmp.y -= NODE_RADIUS.cloud + 1;
+            tmp.y -= NODE_RADIUS.cloud;
             const dist = tmp.distanceTo(camPos);
             tmp.project(this.camera);
             if (tmp.z > 1) { pill.classList.remove('is-visible'); continue; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1988,10 +1988,14 @@ export class LanFlowMap {
             if (!group) { pill.classList.remove('is-visible'); continue; }
             tmp.setFromMatrixPosition(group.matrixWorld);
             tmp.y -= NODE_RADIUS.cloud - 1;
+            const dist = tmp.distanceTo(camPos);
             tmp.project(this.camera);
             if (tmp.z > 1) { pill.classList.remove('is-visible'); continue; }
             const x = (tmp.x * halfW) + halfW;
             const y = -(tmp.y * halfH) + halfH;
+            const scale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, REF_DIST / Math.max(dist, 1)));
+            pill.style.transform = `translate(-50%, 0%) scale(${scale.toFixed(3)})`;
+            pill.style.transformOrigin = 'center top';
             pill.style.left = `${x}px`;
             pill.style.top = `${y}px`;
         }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -309,6 +309,18 @@ export class LanFlowMap {
                 this._togglePlayPause();
                 return;
             }
+            if (e.shiftKey && (e.key === 'ArrowLeft' || e.key === 'ArrowRight')) {
+                const range = this._panels.scrubberRange;
+                if (range && document.activeElement === range) {
+                    e.preventDefault();
+                    const step = e.key === 'ArrowRight' ? 10 : -10;
+                    const val = Math.max(0, Math.min(10000, Number(range.value) + step));
+                    range.value = val;
+                    range.dispatchEvent(new Event('input'));
+                    range.dispatchEvent(new Event('change'));
+                    return;
+                }
+            }
             if (['w','a','s','d','q','e'].includes(e.key.toLowerCase())) {
                 this._keys[e.key.toLowerCase()] = true;
             }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1987,13 +1987,13 @@ export class LanFlowMap {
             const group = this._cloudMeshes.get(`cloud-access-${wanIface}`);
             if (!group) { pill.classList.remove('is-visible'); continue; }
             tmp.setFromMatrixPosition(group.matrixWorld);
-            tmp.y -= NODE_RADIUS.cloud - 1;
+            tmp.y -= NODE_RADIUS.cloud + 1;
             const dist = tmp.distanceTo(camPos);
             tmp.project(this.camera);
             if (tmp.z > 1) { pill.classList.remove('is-visible'); continue; }
             const x = (tmp.x * halfW) + halfW;
             const y = -(tmp.y * halfH) + halfH;
-            const scale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, REF_DIST / Math.max(dist, 1)));
+            const scale = Math.max(MIN_SCALE, Math.min(1.1, REF_DIST / Math.max(dist, 1)));
             pill.style.transform = `translate(-50%, 0%) scale(${scale.toFixed(3)})`;
             pill.style.transformOrigin = 'center top';
             pill.style.left = `${x}px`;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -855,11 +855,24 @@ export class LanFlowMap {
         };
 
         const cloudPositions = new Map();
-        for (const cloud of accessClouds) {
+        if (accessClouds.length === 1) {
+            const cloud = accessClouds[0];
             const x = gwX + dirX * accessRadius;
             const y = gwY + 4;
             const z = gwZ + dirZ * accessRadius;
             cloudPositions.set(cloud.id, placeCloud(cloud, x, y, z));
+        } else {
+            const accessFan = Math.min(Math.PI * 0.6, accessClouds.length * (Math.PI / 6));
+            const accessArcStep = accessClouds.length > 1 ? accessFan / (accessClouds.length - 1) : 0;
+            const accessArcStart = -accessFan / 2;
+            for (let i = 0; i < accessClouds.length; i++) {
+                const cloud = accessClouds[i];
+                const angle = outBearing + accessArcStart + accessArcStep * i;
+                const x = gwX + Math.cos(angle) * accessRadius;
+                const y = gwY + 4;
+                const z = gwZ + Math.sin(angle) * accessRadius;
+                cloudPositions.set(cloud.id, placeCloud(cloud, x, y, z));
+            }
         }
         for (let i = 0; i < siblings.length; i++) {
             const cloud = siblings[i];

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1253,8 +1253,8 @@ export class LanFlowMap {
                     const target = this.controls.target;
                     const offset = cam.position.clone().sub(target);
                     const dist = offset.length();
-                    const zoomStep = dist * 0.0225;
-                    const panDist = dist * 0.012;
+                    const zoomStep = dist * 0.015;
+                    const panDist = dist * 0.008;
 
                     if (this._keys['w'] && dist > this.controls.minDistance + zoomStep) {
                         offset.multiplyScalar(1 - zoomStep / dist);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1990,7 +1990,7 @@ export class LanFlowMap {
             const group = this._cloudMeshes.get(`cloud-access-${wanIface}`);
             if (!group) { pill.classList.remove('is-visible'); continue; }
             tmp.setFromMatrixPosition(group.matrixWorld);
-            tmp.y -= NODE_RADIUS.cloud;
+            tmp.y -= NODE_RADIUS.cloud - 1;
             tmp.project(this.camera);
             if (tmp.z > 1) { pill.classList.remove('is-visible'); continue; }
             const x = (tmp.x * halfW) + halfW;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -117,7 +117,7 @@ export class LanFlowMap {
         this.canvas = canvasEl;
         this.stage = canvasEl.parentElement || canvasEl;
         this.apiBase = options.apiBase ?? '/api/monitoring/lan-flow-map';
-        this.pollIntervalMs = options.pollIntervalMs ?? 2000;
+        this.pollIntervalMs = options.pollIntervalMs ?? 1000;
         this.onError = options.onError ?? ((err) => console.error('[LanFlowMap]', err));
 
         this._snapshot = null;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1041,20 +1041,22 @@ export class LanFlowMap {
             ctx.font = `${subFontSize}px ui-sans-serif, system-ui, sans-serif`;
             subW = Math.ceil(ctx.measureText(subText).width);
         }
-        const w = Math.max(titleW, subW) + pad * 2;
+        const maxW = 600;
+        const w = Math.min(Math.max(titleW, subW) + pad * 2, maxW);
         const h = subText ? fontSize + subFontSize + pad * 2 + 6 : fontSize + pad * 2;
         canvas.width = w;
         canvas.height = h;
         ctx.fillStyle = 'rgba(6, 8, 12, 0.92)';
         roundRect(ctx, 0, 0, w, h, 12);
+        const drawW = w - pad * 2;
         ctx.fillStyle = '#f1f5f9';
         ctx.textBaseline = 'top';
         ctx.font = `${fontSize}px ui-sans-serif, system-ui, sans-serif`;
-        ctx.fillText(text, pad, pad);
+        ctx.fillText(text, pad, pad, drawW);
         if (subText) {
             ctx.fillStyle = '#94a3b8';
             ctx.font = `${subFontSize}px ui-sans-serif, system-ui, sans-serif`;
-            ctx.fillText(subText, pad, pad + fontSize + 6);
+            ctx.fillText(subText, pad, pad + fontSize + 6, drawW);
         }
         const tex = new THREE.CanvasTexture(canvas);
         tex.needsUpdate = true;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1993,7 +1993,7 @@ export class LanFlowMap {
             if (tmp.z > 1) { pill.classList.remove('is-visible'); continue; }
             const x = (tmp.x * halfW) + halfW;
             const y = -(tmp.y * halfH) + halfH;
-            const scale = Math.max(MIN_SCALE, Math.min(1.1, REF_DIST / Math.max(dist, 1)));
+            const scale = Math.max(MIN_SCALE, Math.min(1.0, REF_DIST / Math.max(dist, 1)));
             pill.style.transform = `translate(-50%, 0%) scale(${scale.toFixed(3)})`;
             pill.style.transformOrigin = 'center top';
             pill.style.left = `${x}px`;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2375,14 +2375,28 @@ export class LanFlowMap {
                 if (child.isMesh) candidates.push(child);
             }
         }
+        for (const group of this._cloudMeshes.values()) {
+            if (!group.visible) continue;
+            for (const child of group.children) {
+                if (child.isMesh) candidates.push(child);
+            }
+        }
         const hits = this._raycaster.intersectObjects(candidates, false);
         if (hits.length === 0) return;
         let g = hits[0].object;
-        while (g && !(g.userData?.node)) g = g.parent;
+        while (g && !(g.userData?.node || g.userData?.cloud)) g = g.parent;
         if (!g) return;
+
+        if (g.userData?.cloud) {
+            const cloud = g.userData.cloud;
+            if (cloud.kind === 0) {
+                this._showCloudContextMenu(e.clientX, e.clientY, cloud);
+            }
+            return;
+        }
+
         const node = g.userData.node;
         if (node.kind === NODE_KIND.Cloud || node.kind === NODE_KIND.VirtualHub) return;
-
         this._showContextMenu(e.clientX, e.clientY, node, g);
     }
 
@@ -2397,6 +2411,29 @@ export class LanFlowMap {
             e.stopPropagation();
             this._dismissContextMenu();
             this._enterReposition(node, group);
+        });
+        menu.appendChild(item);
+
+        const stageRect = this.stage.getBoundingClientRect();
+        menu.style.left = `${clientX - stageRect.left}px`;
+        menu.style.top = `${clientY - stageRect.top}px`;
+        this.stage.appendChild(menu);
+        this._contextMenuEl = menu;
+    }
+
+    _showCloudContextMenu(clientX, clientY, cloud) {
+        this._dismissContextMenu();
+        const menu = document.createElement('div');
+        menu.className = 'lan-flow-map-context-menu';
+        const item = document.createElement('div');
+        item.className = 'lan-flow-map-context-menu-item';
+        item.textContent = 'Run Upstream Discovery';
+        item.addEventListener('click', (e) => {
+            e.stopPropagation();
+            this._dismissContextMenu();
+            if (this._dotnetRef) {
+                this._dotnetRef.invokeMethodAsync('NavigateToUpstreamDiscovery');
+            }
         });
         menu.appendChild(item);
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -309,12 +309,9 @@ export class LanFlowMap {
                 this._togglePlayPause();
                 return;
             }
+            if (e.key === 'Shift') this._keys.shift = true;
             if (['arrowleft','arrowright','w','a','s','d','q','e'].includes(e.key.toLowerCase())) {
                 if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') e.preventDefault();
-                this._keys[e.key.toLowerCase()] = true;
-            }
-            if (e.key === 'Shift') this._keys.shift = true;
-            if (['w','a','s','d','q','e'].includes(e.key.toLowerCase())) {
                 this._keys[e.key.toLowerCase()] = true;
             }
         };
@@ -1378,7 +1375,7 @@ export class LanFlowMap {
             }
             tickCount++;
             // Refresh map and stat cards periodically
-            if (tickCount % DATA_REFRESH_TICKS === 0 || clamped >= 998) {
+            if (tickCount % DATA_REFRESH_TICKS === 0 || clamped >= 9998) {
                 this._playbackAdvancing = true;
                 try {
                     if (clamped >= 9998) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2389,7 +2389,7 @@ export class LanFlowMap {
 
         if (g.userData?.cloud) {
             const cloud = g.userData.cloud;
-            if (cloud.kind === 0) {
+            if (cloud.kind === 0 && cloud.wanInterface === this._snapshot?.primaryWanInterface) {
                 this._showCloudContextMenu(e.clientX, e.clientY, cloud);
             }
             return;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1322,11 +1322,8 @@ export class LanFlowMap {
     _startHistoricPlayback() {
         if (this._historicPlaybackTimer) return;
         // Track playback as a continuous timestamp, not integer slider units.
-        // The slider and time label update every tick; the map and stat cards
-        // refresh on a throttled cadence (~3 s wall-clock) to avoid flooding
-        // the API while still feeling responsive.
         const TICK_MS = 1000;
-        const DATA_REFRESH_TICKS = 3; // load new data every 3 ticks
+        const DATA_REFRESH_TICKS = 1;
         this._playbackTime = this._historicAt
             || this._scrubberValueToTime(Number(this._panels.scrubberRange?.value ?? 500));
         let tickCount = 0;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -862,7 +862,7 @@ export class LanFlowMap {
             const z = gwZ + dirZ * accessRadius;
             cloudPositions.set(cloud.id, placeCloud(cloud, x, y, z));
         } else {
-            const accessFan = Math.min(Math.PI * 0.6, accessClouds.length * (Math.PI / 6));
+            const accessFan = Math.min(Math.PI * 0.4, accessClouds.length * (Math.PI / 10));
             const accessArcStep = accessClouds.length > 1 ? accessFan / (accessClouds.length - 1) : 0;
             const accessArcStart = -accessFan / 2;
             for (let i = 0; i < accessClouds.length; i++) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1041,22 +1041,20 @@ export class LanFlowMap {
             ctx.font = `${subFontSize}px ui-sans-serif, system-ui, sans-serif`;
             subW = Math.ceil(ctx.measureText(subText).width);
         }
-        const maxW = 600;
-        const w = Math.min(Math.max(titleW, subW) + pad * 2, maxW);
+        const w = Math.max(titleW, subW) + pad * 2;
         const h = subText ? fontSize + subFontSize + pad * 2 + 6 : fontSize + pad * 2;
         canvas.width = w;
         canvas.height = h;
         ctx.fillStyle = 'rgba(6, 8, 12, 0.92)';
         roundRect(ctx, 0, 0, w, h, 12);
-        const drawW = w - pad * 2;
         ctx.fillStyle = '#f1f5f9';
         ctx.textBaseline = 'top';
         ctx.font = `${fontSize}px ui-sans-serif, system-ui, sans-serif`;
-        ctx.fillText(text, pad, pad, drawW);
+        ctx.fillText(text, pad, pad);
         if (subText) {
             ctx.fillStyle = '#94a3b8';
             ctx.font = `${subFontSize}px ui-sans-serif, system-ui, sans-serif`;
-            ctx.fillText(subText, pad, pad + fontSize + 6, drawW);
+            ctx.fillText(subText, pad, pad + fontSize + 6);
         }
         const tex = new THREE.CanvasTexture(canvas);
         tex.needsUpdate = true;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1592,8 +1592,11 @@ export class LanFlowMap {
                 this._playbackSpeed = SPEED_STEPS[newIdx];
                 this._syncSpeedLabel();
                 if (this._mode === 'live' && this._playbackSpeed < 1) {
+                    const now = Date.now();
+                    const span = now - this._scrubberOrigin;
+                    const nearNow = span > 0 ? Math.floor((now - 5000 - this._scrubberOrigin) / span * 1000) : 997;
                     this._speedTransition = true;
-                    this._onScrubberChange(997);
+                    this._onScrubberChange(Math.min(nearNow, 997));
                     this._speedTransition = false;
                     this._startHistoricPlayback();
                 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1542,6 +1542,9 @@ export class LanFlowMap {
                 <div class="lan-flow-map-help-row"><span>Hover detail</span><span class="kbd">Mouse over</span></div>
                 <div class="lan-flow-map-help-row"><span>Open client</span><span class="kbd">Double-click</span></div>
                 <div class="lan-flow-map-help-row"><span>Move device</span><span class="kbd">Right-click</span></div>
+                <div class="lan-flow-map-help-row"><span>Pause / Play</span><span class="kbd">Space</span></div>
+                <div class="lan-flow-map-help-row"><span>Scrub timeline</span><span class="kbd">←</span> <span class="kbd">→</span></div>
+                <div class="lan-flow-map-help-row"><span>Fast scrub</span><span class="kbd">Shift</span> + <span class="kbd">←</span> <span class="kbd">→</span></div>
                 <div class="lan-flow-map-help-row"><span>Fullscreen</span><span class="kbd">Esc</span> to exit</div>
             </div>
         `;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2389,6 +2389,7 @@ export class LanFlowMap {
 
         if (g.userData?.cloud) {
             const cloud = g.userData.cloud;
+            // TODO: enable for all WANs once multi-WAN upstream tracing is implemented
             if (cloud.kind === 0 && cloud.wanInterface === this._snapshot?.primaryWanInterface) {
                 this._showCloudContextMenu(e.clientX, e.clientY, cloud);
             }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1592,7 +1592,7 @@ export class LanFlowMap {
                 this._playbackSpeed = SPEED_STEPS[newIdx];
                 this._syncSpeedLabel();
                 if (this._mode === 'live' && this._playbackSpeed < 1) {
-                    this._onScrubberChange(998);
+                    this._onScrubberChange(997);
                 }
                 if (this._mode === 'historic' && this._historicPlaybackTimer) {
                     this._stopHistoricPlayback();

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -304,6 +304,11 @@ export class LanFlowMap {
                 }
             }
             if (!this._shouldAcceptKeys()) return;
+            if (e.key === ' ') {
+                e.preventDefault();
+                this._togglePlayPause();
+                return;
+            }
             if (['w','a','s','d','q','e'].includes(e.key.toLowerCase())) {
                 this._keys[e.key.toLowerCase()] = true;
             }


### PR DESCRIPTION
## Summary

- **WAN detection overhaul** - Upstream tracer, path view, and collection agent now read wan1...wan6 objects from raw device JSON instead of relying on port_table.is_uplink, which may not be set for PPPoE, VLAN-tagged, or GRE tunnel connections. Fixes #651.
- **Multi-WAN 3D map** - All active WANs now render as separate access clouds with their own live rates, speed test pills, and friendly names from UniFi network configs. Secondary WANs show as solid (not "discovery pending") since only the primary runs upstream tracing currently.
- **Per-WAN live rates** - Each WAN link shows its own SNMP interface rate instead of broadcasting the device-level aggregate to all WANs. Uses the physical port for VLAN-tagged WANs to avoid kernel double-counting on sub-interfaces.
- **Historic playback per-WAN** - Historic mode resolves rates per-WAN interface from InfluxDB instead of summing all WANs together.
- **Speed test overlay** - Lookback extended to 30 days, results grouped per WAN so secondary WANs aren't crowded out by frequent primary tests. Pills scale with camera distance and don't wrap.
- **Timeline UX** - 10x scrubber resolution (10000 steps), arrow key scrubbing with shift for 10x speed, spacebar pause/play, 0.5x speed drops from live to historic, throttled data loads during scrubbing, WASD sensitivity reduced 33%.
- **Access technology selector** - Users can set their access network technology (GPON, DOCSIS, PPPoE, etc.) during upstream discovery review. Display names formatted properly in both the dropdown and 3D view.
- **Right-click WAN globe** - Context menu on primary WAN globe navigates to upstream discovery panel (expands it and scrolls into view).

## Test plan

- [x] Verify WAN detection works on standard DHCP, PPPoE, and VLAN-tagged setups
- [x] Check all 4 WAN globes render with correct names and spacing
- [x] Confirm live rates show per-WAN, not duplicated across all
- [x] Test historic playback shows per-WAN rates
- [x] Verify speed test pills appear for all WANs with recent tests
- [x] Test arrow key scrubbing, shift+arrow, spacebar pause
- [x] Right-click primary WAN globe navigates to upstream discovery
- [x] Run upstream discovery and verify access technology selector works