### PR TITLE
Release: WAN detection overhaul, multi-WAN 3D map, audit mirror-port awareness

### DIFF
--- a/src/NetworkOptimizer.Audit/Analyzers/PortSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/PortSecurityAnalyzer.cs
@@ -679,6 +679,7 @@ public class PortSecurityAnalyzer
             Speed = port.GetIntOrDefault("speed"),
             ForwardMode = forwardMode,
             TaggedVlanMgmt = taggedVlanMgmt,
+            OpMode = port.GetStringOrNull("op_mode"),
             IsUplink = port.GetBoolOrDefault("is_uplink"),
             IsWan = isWan,
             NativeNetworkId = nativeNetworkId,

--- a/src/NetworkOptimizer.Audit/Models/PortInfo.cs
+++ b/src/NetworkOptimizer.Audit/Models/PortInfo.cs
@@ -45,6 +45,20 @@ public class PortInfo
     public string? TaggedVlanMgmt { get; init; }
 
     /// <summary>
+    /// Port operational mode from the UniFi API's op_mode field.
+    /// Values include "switch" (normal switching), "mirror" (mirror destination),
+    /// "aggregate" (LAG parent), and others. Null if not present in the API response.
+    /// </summary>
+    public string? OpMode { get; init; }
+
+    /// <summary>
+    /// Whether this port is configured as a mirror destination (port mirroring/SPAN).
+    /// Mirror destinations cannot accept port profiles and must receive frames at L2
+    /// regardless of VLAN tags, so access-port audit rules should skip them.
+    /// </summary>
+    public bool IsMirrorDestination => string.Equals(OpMode, "mirror", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Whether this is an uplink port
     /// </summary>
     public bool IsUplink { get; init; }

--- a/src/NetworkOptimizer.Audit/Rules/AccessPortVlanRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/AccessPortVlanRule.cs
@@ -49,6 +49,31 @@ public class AccessPortVlanRule : AuditRuleBase
         if (port.IsUplink || port.IsWan)
             return null;
 
+        // Mirror destination ports cannot accept port profiles and receive frames at L2
+        // regardless of VLAN tags - this is by design. Don't treat as a misconfiguration,
+        // but surface as informational so the operator is aware that any device connected
+        // to this port can passively observe traffic from the mirrored source port(s).
+        if (port.IsMirrorDestination)
+        {
+            var mirrorNetwork = GetNetwork(port.NativeNetworkId, networks);
+            return CreateIssue(
+                "Mirror destination port has visibility into all mirrored VLAN traffic",
+                port,
+                new Dictionary<string, object>
+                {
+                    { "network", mirrorNetwork?.Name ?? "Unknown" },
+                    { "is_mirror_destination", true }
+                },
+                "This port is configured as a SPAN/mirror destination. UniFi enforces op_mode=mirror "
+                + "as a distinct operational mode that does not accept port profiles, and mirror "
+                + "destinations must receive frames regardless of VLAN tags to fulfill their capture "
+                + "role. Any device connected to this port can passively observe traffic from the "
+                + "mirrored source port(s), so ensure physical access to this port is restricted "
+                + "appropriately.",
+                overrideSeverity: AuditSeverity.Informational,
+                overrideScoreImpact: 2);
+        }
+
         // Only check ports configured as trunk/custom (these have tagged VLANs)
         // Access ports (ForwardMode = "native") don't have tagged VLANs - that's normal
         // Ports with tagged_vlan_mgmt = "block_all" block all tagged VLANs regardless of forward mode

--- a/src/NetworkOptimizer.Audit/Rules/CameraVlanRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/CameraVlanRule.cs
@@ -29,6 +29,12 @@ public class CameraVlanRule : AuditRuleBase
         if (protectCamera != null)
             return EvaluateProtectCamera(protectCamera, port, networks);
 
+        // Skip mirror destination ports. Defense-in-depth: the ForwardMode gate below
+        // already filters them since UniFi default-configures mirror destinations with
+        // forward="all", but the explicit guard makes the design intent clear.
+        if (port.IsMirrorDestination)
+            return null;
+
         // Skip uplinks, WAN ports, and non-access ports
         if (port.ForwardMode != "native" || port.IsUplink || port.IsWan)
             return null;

--- a/src/NetworkOptimizer.Audit/Rules/IotVlanRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/IotVlanRule.cs
@@ -23,6 +23,12 @@ public class IotVlanRule : AuditRuleBase
         if (port.ForwardMode != "native" || port.IsUplink || port.IsWan)
             return null;
 
+        // Skip mirror destination ports. Defense-in-depth: the ForwardMode gate above
+        // already filters them since UniFi default-configures mirror destinations with
+        // forward="all", but the explicit guard makes the design intent clear.
+        if (port.IsMirrorDestination)
+            return null;
+
         DeviceDetectionResult detection;
         bool isOfflineDevice = false;
 

--- a/src/NetworkOptimizer.Audit/Rules/MacRestrictionRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/MacRestrictionRule.cs
@@ -34,6 +34,12 @@ public class MacRestrictionRule : AuditRuleBase
         if (port.IsUplink || port.IsWan)
             return null;
 
+        // Skip mirror destination ports. Defense-in-depth: the isAccessPort check below
+        // already filters them since mirror destinations have forward="all" (not an access
+        // port shape), but the explicit guard makes the design intent clear.
+        if (port.IsMirrorDestination)
+            return null;
+
         // Skip ports with network fabric devices (AP, switch, bridge) - these are LAN infrastructure
         // Modems, NVRs, Cloud Keys, etc. are endpoints and SHOULD get MAC restriction recommendations
         if (IsNetworkFabricDevice(port.ConnectedDeviceType))

--- a/src/NetworkOptimizer.Audit/Rules/PortIsolationRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/PortIsolationRule.cs
@@ -20,6 +20,12 @@ public class PortIsolationRule : AuditRuleBase
         if (!port.IsUp || port.ForwardMode != "native" || port.IsUplink || port.IsWan)
             return null;
 
+        // Skip mirror destination ports. Defense-in-depth: the ForwardMode gate above
+        // already filters them since UniFi default-configures mirror destinations with
+        // forward="all", but the explicit guard makes the design intent clear.
+        if (port.IsMirrorDestination)
+            return null;
+
         // Check if switch supports isolation
         if (!port.Switch.Capabilities.SupportsIsolation)
             return null;

--- a/src/NetworkOptimizer.Audit/Rules/UnusedPortRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/UnusedPortRule.cs
@@ -48,6 +48,12 @@ public class UnusedPortRule : AuditRuleBase
         if (port.IsUplink || port.IsWan)
             return null;
 
+        // Skip mirror destination ports. A mirror port can be legitimately down when its
+        // capture device is unplugged - recommending it be disabled would break mirroring
+        // as soon as the capture device reconnects.
+        if (port.IsMirrorDestination)
+            return null;
+
         // Check if port is disabled (either via forward mode or hardware enable flag)
         if (port.ForwardMode == "disabled" || !port.IsEnabled)
             return null; // Correctly configured

--- a/src/NetworkOptimizer.Audit/Rules/WiredSubnetMismatchRule.cs
+++ b/src/NetworkOptimizer.Audit/Rules/WiredSubnetMismatchRule.cs
@@ -26,6 +26,12 @@ public class WiredSubnetMismatchRule : AuditRuleBase
         if (port.ForwardMode != "native" || port.IsUplink || port.IsWan)
             return null;
 
+        // Skip mirror destination ports. Defense-in-depth: the ForwardMode gate above
+        // already filters them since UniFi default-configures mirror destinations with
+        // forward="all", but the explicit guard makes the design intent clear.
+        if (port.IsMirrorDestination)
+            return null;
+
         // Skip ports without a connected client
         var client = port.ConnectedClient;
         if (client == null)

--- a/src/NetworkOptimizer.Monitoring/Probes/LocalProbeExecutor.cs
+++ b/src/NetworkOptimizer.Monitoring/Probes/LocalProbeExecutor.cs
@@ -477,7 +477,7 @@ public class LocalProbeExecutor : IProbeExecutor
         // PTR resolution stays ON — hostnames like "cr1.stl1.example.net" are gold for the
         // wizard's hop-labelling logic (spec 5.5). Linux's resolver times out fast, so the
         // cost is bounded by the per-probe deadline anyway.
-        var args = $"-m {maxHops} -w {wait} {protoFlag} {target.Address}".Trim();
+        var args = $"-m {maxHops} -q 2 -w {wait} {protoFlag} {target.Address}".Trim();
         return ("traceroute", args);
     }
 }

--- a/src/NetworkOptimizer.Monitoring/Probes/TracerouteOutputParser.cs
+++ b/src/NetworkOptimizer.Monitoring/Probes/TracerouteOutputParser.cs
@@ -68,18 +68,6 @@ public static class TracerouteOutputParser
                 continue;
             var rest = m.Groups["rest"].Value;
 
-            // Non-responding hop
-            if (rest.Trim().StartsWith("*"))
-            {
-                hops.Add(new TraceHop
-                {
-                    HopNumber = hopNum,
-                    Probes = CountStars(rest),
-                    Responses = 0
-                });
-                continue;
-            }
-
             string? hostname = null;
             string? address = null;
 
@@ -105,9 +93,22 @@ public static class TracerouteOutputParser
                     rttValues.Add(v);
             }
 
-            // Probes per hop is conventionally 3 in both Linux and busybox; count stars + RTTs
-            int probes = 3;
+            int stars = CountStars(rest);
             int responses = rttValues.Count;
+            int probes = stars + responses;
+            if (probes == 0) probes = 1;
+
+            // Fully non-responding hop (all probes timed out)
+            if (responses == 0)
+            {
+                hops.Add(new TraceHop
+                {
+                    HopNumber = hopNum,
+                    Probes = probes,
+                    Responses = 0
+                });
+                continue;
+            }
 
             hops.Add(new TraceHop
             {

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -264,8 +264,8 @@ else
         </div>
 
         <!-- Upstream tracer wizard -->
-        <div style="margin-top: 1.5rem;">
-            <UpstreamTracerPanel />
+        <div id="upstream-discovery" style="margin-top: 1.5rem;">
+            <UpstreamTracerPanel ForceExpand="_forceExpandUpstream" />
         </div>
 
         <div style="margin-top: 1.5rem;">
@@ -707,6 +707,7 @@ else
     private string _activeTab = "setup";
 
     private bool _monitoringReady => _monitoringEnabled && _influxConfigured;
+    private bool _forceExpandUpstream;
 
 
     // Chart mount tracking
@@ -1032,6 +1033,31 @@ else
         public double? GatewayTempC { get; init; }
         public double FabricIngressBps { get; init; }
         public double FabricEgressBps { get; init; }
+    }
+
+    [JSInvokable]
+    public void NavigateToUpstreamDiscovery()
+    {
+        InvokeAsync(async () =>
+        {
+            _activeTab = "performance";
+            _forceExpandUpstream = true;
+            StateHasChanged();
+            await Task.Delay(150);
+            await JS.InvokeVoidAsync("eval", @"
+                (function() {
+                    var el = document.getElementById('upstream-discovery');
+                    if (el) {
+                        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                        el.style.transition = 'outline-color 0.3s';
+                        el.style.outline = '2px solid rgba(59, 130, 246, 0.5)';
+                        el.style.outlineOffset = '4px';
+                        el.style.borderRadius = '12px';
+                        setTimeout(function() { el.style.outline = ''; el.style.outlineOffset = ''; }, 2000);
+                    }
+                })();");
+            _forceExpandUpstream = false;
+        });
     }
 
     [JSInvokable]

--- a/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
@@ -336,6 +336,7 @@
         MonitoringTargetType.AccessIsp => "status-active",
         MonitoringTargetType.Transit => "status-active",
         MonitoringTargetType.InternetService => "status-active",
+        MonitoringTargetType.Custom => "status-active",
         _ => "status-disconnected"
     };
 

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -96,6 +96,18 @@
 
             @if (_state.Step == TracerStep.ReviewingResults)
             {
+                <div class="form-group">
+                    <label class="form-label">Access network technology</label>
+                    <select class="form-control" style="max-width: 250px;"
+                            value="@((int)_state.AccessTechnology)"
+                            @onchange="e => _state.AccessTechnology = (AccessTechnology)int.Parse((string)e.Value!)">
+                        @foreach (var tech in Enum.GetValues<AccessTechnology>())
+                        {
+                            <option value="@((int)tech)">@FormatTechName(tech)</option>
+                        }
+                    </select>
+                </div>
+
                 @if (_state.Traces.Count > 0)
                 {
                     <div class="form-group">
@@ -164,7 +176,7 @@
                                                        @onchange="e => hop.Enabled = (bool)e.Value!" />
                                             </td>
                                             <td>
-                                                <input type="text" class="form-input form-input-sm"
+                                                <input type="text" class="form-control form-control-sm"
                                                        value="@hop.Label"
                                                        @onchange="e => hop.Label = (string)e.Value!" />
                                             </td>
@@ -266,6 +278,8 @@
 </div>
 
 @code {
+    [Parameter] public bool ForceExpand { get; set; }
+
     private UpstreamTracerState _state = new();
     private System.Threading.Timer? _pollTimer;
     private bool _needsReview;
@@ -277,7 +291,7 @@
     {
         await Tracer.RehydrateFromDbAsync();
         _state = Tracer.State;
-        _collapsed = _state.Step == TracerStep.Done;
+        _collapsed = !ForceExpand && _state.Step == TracerStep.Done;
         await RefreshReviewFlagAsync();
         // Poll the tracer state every 1.5s while a run is active; the state machine
         // runs in the background and the UI just observes. Re-check the rediscovery
@@ -365,6 +379,21 @@
 
     private void ToggleCollapse() => _collapsed = !_collapsed;
 
+    private static string FormatTechName(AccessTechnology tech) => tech switch
+    {
+        AccessTechnology.Unknown => "Not detected",
+        AccessTechnology.Gpon => "GPON",
+        AccessTechnology.XgsPon => "XGS-PON",
+        AccessTechnology.Docsis => "DOCSIS (Cable)",
+        AccessTechnology.PppoE => "PPPoE",
+        AccessTechnology.DirectEthernet => "Active Ethernet",
+        AccessTechnology.FixedWireless => "Fixed Wireless",
+        AccessTechnology.Satellite => "Satellite",
+        AccessTechnology.Cellular => "Cellular",
+        AccessTechnology.Other => "Other",
+        _ => tech.ToString()
+    };
+
     private string AccessAsnDisplay()
     {
         var first = _state.AccessHops.FirstOrDefault(h => h.AsnNumber.HasValue);
@@ -379,5 +408,5 @@
 
 <style>
     .row-disabled { opacity: 0.45; }
-    .form-input-sm { padding: 0.25rem 0.5rem; font-size: 0.875rem; }
+    .form-control-sm { padding: 0.25rem 0.5rem; font-size: 0.875rem; }
 </style>

--- a/src/NetworkOptimizer.Web/Endpoints/LanFlowMapEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/LanFlowMapEndpoints.cs
@@ -33,7 +33,7 @@ public static class LanFlowMapEndpoints
         app.MapGet("/api/monitoring/lan-flow-map/speed-tests",
             async (LanFlowMapService svc, DateTime? since, DateTime? until, CancellationToken ct) =>
             {
-                var fromT = since ?? DateTime.UtcNow.AddHours(-24);
+                var fromT = since ?? DateTime.UtcNow.AddDays(-30);
                 var toT = until ?? DateTime.UtcNow;
                 var items = await svc.BuildSpeedTestOverlayAsync(fromT, toT, limitPerKind: 10, ct: ct);
                 return Results.Ok(items);

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -135,21 +135,21 @@ public class LanFlowMapService
         GroupMultiClientPorts(snapshot);
         await BuildWanAndClouds(topology, snapshot, ct);
 
-        var gwRaw = rawDevices.FirstOrDefault(d =>
-            d.DeviceType == NetworkOptimizer.Core.Enums.DeviceType.Gateway);
-        if (gwRaw?.PortTable != null)
-        {
-            snapshot.WanIfNames = gwRaw.PortTable
-                .Where(p => p.IsUplink && !string.IsNullOrEmpty(p.IfName))
-                .Select(p => p.IfName!)
-                .ToList();
-        }
+        // WAN interface names for InfluxDB rate queries. Use the physical port
+        // name (not VLAN sub-interface) to match what SNMP records accurately.
+        var wans = await _pathView.GetWansAsync(ct);
+        snapshot.WanIfNames = wans
+            .Select(w => w.PhysicalIfName ?? w.UplinkIfName)
+            .Where(n => !string.IsNullOrEmpty(n))
+            .Select(n => n!)
+            .Distinct()
+            .ToList();
 
         var portRates = await SeedPortRatesAsync(snapshot, ct);
         SeedLiveRates(snapshot, portRates);
 
         snapshot.SpeedTests = await BuildSpeedTestOverlayAsync(
-            since: snapshot.GeneratedAt - TimeSpan.FromHours(24),
+            since: snapshot.GeneratedAt - TimeSpan.FromDays(30),
             until: snapshot.GeneratedAt,
             limitPerKind: 3,
             ct: ct);
@@ -348,18 +348,19 @@ public class LanFlowMapService
         var gwNode = snapshot.Nodes.FirstOrDefault(n => n.Kind == LanNodeKind.Gateway);
         var gwMac = gwNode?.Mac;
 
-        // Pre-fetch WAN rates. The link ID uses NetworkName ("wan") but InfluxDB
-        // stores the Linux ifname ("eth6"). WanIfNames on the snapshot resolves
-        // this from the port table's IfName field (same source as stat cards).
-        IReadOnlyList<MonitoringInfluxClient.WanRatePoint>? wanRates = null;
-        if (!string.IsNullOrEmpty(gwMac) && snapshot.WanIfNames.Count > 0)
+        // Build WAN interface → physical ifname mapping for per-WAN rate queries.
+        var wanIfNameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        try
         {
-            try
+            var wans = await _pathView.GetWansAsync(ct);
+            foreach (var w in wans)
             {
-                wanRates = await _influx.QueryGatewayWanRatesAsync(gwMac, snapshot.WanIfNames, from, to, ct: ct);
+                var rateIf = w.PhysicalIfName ?? w.UplinkIfName;
+                if (!string.IsNullOrEmpty(rateIf))
+                    wanIfNameMap[w.WanInterface] = rateIf;
             }
-            catch { }
         }
+        catch { }
 
         // Pre-fetch interface_counters per device MAC so we don't re-query for
         // every link on the same device. Covers WiredClient (PortKey), Uplink,
@@ -400,13 +401,25 @@ public class LanFlowMapService
             {
                 if (link.Kind == LanLinkKind.Wan)
                 {
-                    if (wanRates != null)
+                    // Per-WAN: extract interface name from link ID, look up
+                    // the physical ifname, then find matching rate points.
+                    var wanIface = link.Id.StartsWith("wan-link-", StringComparison.Ordinal)
+                        ? link.Id.Substring("wan-link-".Length) : null;
+                    if (wanIface != null
+                        && wanIfNameMap.TryGetValue(wanIface, out var rateIf)
+                        && !string.IsNullOrEmpty(gwMac)
+                        && ratesByDevice.TryGetValue(gwMac, out var gwRates))
                     {
-                        var closest = wanRates
+                        var closest = gwRates
+                            .Where(p => string.Equals(p.IfName, rateIf, StringComparison.OrdinalIgnoreCase))
                             .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
                             .FirstOrDefault();
                         if (closest != null)
-                            update.LinkRates[link.Id] = MapPortToLinkRates(link, closest.DownloadBps ?? 0, closest.UploadBps ?? 0, closest.Time);
+                        {
+                            // rate_in_bps = downloads, rate_out_bps = uploads
+                            update.LinkRates[link.Id] = MapPortToLinkRates(link,
+                                closest.RateInBps ?? 0, closest.RateOutBps ?? 0, closest.Time);
+                        }
                     }
                 }
                 else if (link.Kind == LanLinkKind.Uplink || link.Kind == LanLinkKind.MeshBackhaul)
@@ -1140,7 +1153,7 @@ public class LanFlowMapService
             {
                 Id = $"cloud-access-{wan.WanInterface}",
                 Kind = LanCloudKind.AccessIsp,
-                Name = upstream.Access.AsnName ?? upstream.Access.L2NeighborOui ?? "Access ISP",
+                Name = upstream.Access.AsnName ?? wan.FriendlyName ?? "Access ISP",
                 Asn = upstream.Access.AsnNumber,
                 AsnName = upstream.Access.AsnName,
                 Order = 0,
@@ -1148,8 +1161,12 @@ public class LanFlowMapService
                 AccessTechnology = upstream.Access.AccessTechnology,
                 L2NeighborOui = upstream.Access.L2NeighborOui,
                 IsCgnat = upstream.Access.IsCgnat,
-                IsDiscoveryPending = upstream.Access.Hops.Count == 0,
-                Tier = upstream.Access.Hops.Count == 0 ? LanCloudTier.Unresolved : LanCloudTier.Solid,
+                // TODO: secondary WAN discovery - currently only the primary WAN
+                // runs upstream tracing, so secondary WANs always have 0 hops.
+                // Suppress the "discovery pending" state for them until multi-WAN
+                // tracing is implemented.
+                IsDiscoveryPending = wan.IsPrimary && upstream.Access.Hops.Count == 0,
+                Tier = wan.IsPrimary && upstream.Access.Hops.Count == 0 ? LanCloudTier.Unresolved : LanCloudTier.Solid,
             };
             // RTT for the access cloud: pick the deepest hop with live data (closest to the
             // ISP boundary). Wizard-output ordering puts BNG/CMTS/OLT toward the tail.
@@ -1452,12 +1469,17 @@ public class LanFlowMapService
     {
         await using var db = await _dbFactory.CreateDbContextAsync(ct);
 
+        // Group by WAN so secondary WANs aren't crowded out by frequent
+        // primary WAN tests. Take limitPerKind per group.
         var raw = await db.Iperf3Results
             .AsNoTracking()
             .Where(r => r.Success && r.TestTime >= since && r.TestTime <= until)
             .OrderByDescending(r => r.TestTime)
-            .Take(limitPerKind * 4)
             .ToListAsync(ct);
+        raw = raw
+            .GroupBy(r => r.WanNetworkGroup ?? "")
+            .SelectMany(g => g.Take(limitPerKind))
+            .ToList();
 
         var result = new List<SpeedTestOverlayItem>();
         foreach (var r in raw)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Core.Helpers;
 using NetworkOptimizer.Storage.Models;
-using NetworkOptimizer.UniFi.Models;
 
 namespace NetworkOptimizer.Web.Services.Monitoring;
 
@@ -59,6 +58,8 @@ public class MonitoringPathView
 
         var resolvedWanInterface = wan?.WanInterface ?? wanInterface ?? "wan";
         var isPrimary = wan?.IsPrimary ?? true;
+        _logger.LogDebug("GetUpstreamPathAsync: wans={WanCount}, wan={WanIf}, friendly={Friendly}, resolved={Resolved}, isPrimary={Primary}",
+            wans.Count, wan?.WanInterface, wan?.FriendlyName, resolvedWanInterface, isPrimary);
 
         // Per-WAN context, with fallback to legacy MonitoringSettings for installs that
         // pre-date the WanDiscoveryContexts table. New installs and any post-migration
@@ -76,9 +77,13 @@ public class MonitoringPathView
             .OrderBy(t => t.Id)
             .ToListAsync(ct);
 
-        var l2NeighborMac = wanCtx?.L2NeighborMac ?? settings?.WanNeighborMac;
-        var l2NeighborOui = wanCtx?.L2NeighborOui ?? settings?.WanNeighborOui;
-        var accessTech = wanCtx?.AccessTechnology ?? settings?.AccessTechnology ?? AccessTechnology.Unknown;
+        // TODO: once multi-WAN upstream tracing is implemented, each WAN will
+        // have its own WanDiscoveryContext with L2 neighbor and access tech.
+        // Until then, only fall back to global MonitoringSettings for the
+        // primary WAN so secondaries don't inherit the primary's values.
+        var l2NeighborMac = wanCtx?.L2NeighborMac ?? (isPrimary ? settings?.WanNeighborMac : null);
+        var l2NeighborOui = wanCtx?.L2NeighborOui ?? (isPrimary ? settings?.WanNeighborOui : null);
+        var accessTech = wanCtx?.AccessTechnology ?? (isPrimary ? settings?.AccessTechnology : null) ?? AccessTechnology.Unknown;
 
         var isCgnat = l2NeighborMac != null
             && !string.IsNullOrEmpty(wan?.IpAddress)
@@ -86,7 +91,7 @@ public class MonitoringPathView
 
         var access = new AccessIspCloud
         {
-            AccessTechnology = accessTech.ToString(),
+            AccessTechnology = FormatAccessTechnology(accessTech),
             L2NeighborOui = l2NeighborOui,
             AsnNumber = accessHops.FirstOrDefault()?.AsnNumber,
             AsnName = accessHops.FirstOrDefault()?.AsnName,
@@ -149,11 +154,15 @@ public class MonitoringPathView
         if (!_connectionService.IsConnected || _connectionService.Client == null)
             return Array.Empty<WanSummary>();
 
-        List<UniFiDeviceResponse> devices;
+        // Read wan1...wan6 from raw device JSON instead of relying on
+        // port_table.is_uplink, which may not be set for PPPoE, VLAN-tagged,
+        // or GRE tunnel connections.
+        string? deviceJson;
         try
         {
-            devices = (await _connectionService.Client.GetDevicesAsync(ct))?.ToList()
-                       ?? new List<UniFiDeviceResponse>();
+            deviceJson = await _connectionService.Client.GetDevicesRawJsonAsync(ct);
+            if (string.IsNullOrEmpty(deviceJson))
+                return Array.Empty<WanSummary>();
         }
         catch (Exception ex)
         {
@@ -161,37 +170,130 @@ public class MonitoringPathView
             return Array.Empty<WanSummary>();
         }
 
-        var gateway = devices.FirstOrDefault(d => d.DeviceType == NetworkOptimizer.Core.Enums.DeviceType.Gateway);
-        if (gateway?.PortTable == null) return Array.Empty<WanSummary>();
-
-        var results = new List<WanSummary>();
-        var wanPorts = gateway.PortTable
-            .Where(p => p.IsUplink && !string.IsNullOrEmpty(p.NetworkName))
-            .OrderBy(p => p.PortIdx)
-            .ToList();
-        if (wanPorts.Count == 0)
+        // Fetch WAN network configs for friendly names (covers GRE tunnels and
+        // other virtual WANs that don't have port_table entries).
+        var networkGroupToName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        try
         {
-            wanPorts = gateway.PortTable
-                .Where(p => p.NetworkName != null && p.NetworkName.StartsWith("wan", StringComparison.OrdinalIgnoreCase))
-                .OrderBy(p => p.PortIdx)
-                .ToList();
+            var wanConfigs = await _connectionService.Client.GetWanConfigsAsync(ct);
+            foreach (var wc in wanConfigs.Where(w => !string.IsNullOrEmpty(w.WanNetworkgroup)))
+                networkGroupToName[wc.WanNetworkgroup!] = wc.Name;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "GetWansAsync: failed to fetch WAN configs for names");
         }
 
-        var gwMac = gateway.Mac.ToLowerInvariant().Replace('-', ':');
-        for (int i = 0; i < wanPorts.Count; i++)
+        var results = new List<WanSummary>();
+
+        using (var doc = System.Text.Json.JsonDocument.Parse(deviceJson))
         {
-            var port = wanPorts[i];
-            results.Add(new WanSummary
+            var root = doc.RootElement;
+            var devices = root.ValueKind == System.Text.Json.JsonValueKind.Array
+                ? root
+                : root.TryGetProperty("data", out var data) ? data : root;
+
+            foreach (var device in devices.EnumerateArray())
             {
-                WanInterface = port.NetworkName ?? $"wan{i + 1}",
-                FriendlyName = string.IsNullOrEmpty(port.Name) ? null : port.Name,
-                IsPrimary = i == 0,
-                GatewayMac = gwMac,
-                GatewayPortName = port.Name,
-                LinkSpeedMbps = port.Speed > 0 ? port.Speed : (int?)null,
-                IpAddress = port.Ip,
-                IpClass = NetworkUtilities.ClassifyPublicAddress(port.Ip)
-            });
+                var deviceType = device.TryGetProperty("type", out var typeProp) ? typeProp.GetString() : null;
+                if (deviceType != "ugw" && deviceType != "udm" && deviceType != "uxg")
+                    continue;
+
+                var gwMac = device.TryGetProperty("mac", out var macProp) ? macProp.GetString() : null;
+                gwMac = gwMac?.ToLowerInvariant().Replace('-', ':') ?? "";
+
+                // Build port_idx lookups from port_table and ethernet_overrides
+                var portInfo = new Dictionary<int, (string? networkName, string? name, int speed)>();
+                if (device.TryGetProperty("port_table", out var portTable) &&
+                    portTable.ValueKind == System.Text.Json.JsonValueKind.Array)
+                {
+                    foreach (var port in portTable.EnumerateArray())
+                    {
+                        if (!port.TryGetProperty("port_idx", out var idxProp) || !idxProp.TryGetInt32(out var idx))
+                            continue;
+                        var networkName = port.TryGetProperty("network_name", out var nnProp) ? nnProp.GetString() : null;
+                        var name = port.TryGetProperty("name", out var nameProp) ? nameProp.GetString() : null;
+                        var speed = port.TryGetProperty("speed", out var speedProp) && speedProp.TryGetInt32(out var spd) ? spd : 0;
+                        portInfo[idx] = (networkName, name, speed);
+                    }
+                }
+
+                var ifnameToNetworkGroup = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                if (device.TryGetProperty("ethernet_overrides", out var ethOverrides) &&
+                    ethOverrides.ValueKind == System.Text.Json.JsonValueKind.Array)
+                {
+                    foreach (var ov in ethOverrides.EnumerateArray())
+                    {
+                        var ifn = ov.TryGetProperty("ifname", out var ifnProp) ? ifnProp.GetString() : null;
+                        var ng = ov.TryGetProperty("networkgroup", out var ngProp) ? ngProp.GetString() : null;
+                        if (!string.IsNullOrEmpty(ifn) && !string.IsNullOrEmpty(ng))
+                            ifnameToNetworkGroup[ifn] = ng;
+                    }
+                }
+
+                for (int i = 1; i <= 6; i++)
+                {
+                    var wanKey = $"wan{i}";
+                    if (!device.TryGetProperty(wanKey, out var wanObj)) continue;
+
+                    var uplinkIfname = wanObj.TryGetProperty("uplink_ifname", out var uplinkProp)
+                        ? uplinkProp.GetString() : null;
+                    if (string.IsNullOrEmpty(uplinkIfname)) continue;
+
+                    var ip = wanObj.TryGetProperty("ip", out var ipProp) ? ipProp.GetString() : null;
+                    var wanSpeed = wanObj.TryGetProperty("speed", out var wanSpeedProp) &&
+                        wanSpeedProp.TryGetInt32(out var ws) && ws > 0 ? ws : 0;
+
+                    string? interfaceKey = null;
+                    string? friendlyName = null;
+                    int linkSpeed = wanSpeed;
+
+                    if (wanObj.TryGetProperty("port_idx", out var portIdxProp) &&
+                        portIdxProp.TryGetInt32(out var portIdx) &&
+                        portInfo.TryGetValue(portIdx, out var pi))
+                    {
+                        interfaceKey = pi.networkName;
+                        friendlyName = pi.name;
+                        if (linkSpeed == 0 && pi.speed > 0) linkSpeed = pi.speed;
+                    }
+
+                    // Physical port name (e.g. "eth6" for VLAN-tagged "eth6.100",
+                    // same as uplinkIfname for non-VLAN connections).
+                    var physicalIfname = wanObj.TryGetProperty("ifname", out var ifnProp) ? ifnProp.GetString() : null;
+
+                    // For virtual WANs (GRE, etc.) without port_table entries,
+                    // resolve the friendly name from WAN network configs via
+                    // ethernet_overrides networkgroup or wan key convention.
+                    if (string.IsNullOrEmpty(friendlyName))
+                    {
+                        var lookupIfname = physicalIfname ?? uplinkIfname;
+                        string? networkGroup = null;
+                        if (!string.IsNullOrEmpty(lookupIfname) && ifnameToNetworkGroup.TryGetValue(lookupIfname, out var ng))
+                            networkGroup = ng;
+                        networkGroup ??= i == 1 ? "WAN" : $"WAN{i}";
+                        if (networkGroupToName.TryGetValue(networkGroup, out var configName))
+                            friendlyName = configName;
+                    }
+
+                    interfaceKey ??= i == 1 ? "wan" : $"wan{i}";
+
+                    results.Add(new WanSummary
+                    {
+                        WanInterface = interfaceKey,
+                        FriendlyName = string.IsNullOrEmpty(friendlyName) ? null : friendlyName,
+                        IsPrimary = results.Count == 0,
+                        GatewayMac = gwMac,
+                        GatewayPortName = friendlyName,
+                        UplinkIfName = uplinkIfname,
+                        PhysicalIfName = physicalIfname,
+                        LinkSpeedMbps = linkSpeed > 0 ? linkSpeed : (int?)null,
+                        IpAddress = ip,
+                        IpClass = NetworkUtilities.ClassifyPublicAddress(ip)
+                    });
+                }
+
+                if (results.Count > 0) break;
+            }
         }
 
         _wanCache = results;
@@ -205,9 +307,26 @@ public class MonitoringPathView
         if (wans.Count == 0) return;
         var gwMac = wans[0].GatewayMac;
         if (string.IsNullOrEmpty(gwMac)) return;
-        var deviceLive = _liveStats.GetForDevice(gwMac);
         foreach (var wan in wans)
         {
+            // For VLAN sub-interfaces (eth6.100), use the physical parent (eth6)
+            // for rate stats - VLAN sub-interface SNMP counters double-count on
+            // some kernels. For non-VLAN WANs, PhysicalIfName == UplinkIfName.
+            var rateIfName = wan.PhysicalIfName ?? wan.UplinkIfName;
+            if (!string.IsNullOrEmpty(rateIfName))
+            {
+                var portRate = _liveStats.GetPortRate(gwMac, rateIfName);
+                if (portRate != null)
+                {
+                    // GetPortRate convention: DownBps = port TX, UpBps = port RX.
+                    // WAN port: TX = to internet = uploads (LiveRateInBps),
+                    //           RX = from internet = downloads (LiveRateOutBps).
+                    wan.LiveRateInBps = portRate.DownBps;
+                    wan.LiveRateOutBps = portRate.UpBps;
+                    continue;
+                }
+            }
+            var deviceLive = _liveStats.GetForDevice(gwMac);
             wan.LiveRateInBps = deviceLive?.RateInBps;
             wan.LiveRateOutBps = deviceLive?.RateOutBps;
         }
@@ -218,6 +337,21 @@ public class MonitoringPathView
     /// alongside the human-facing text. Until the tracer ships, AutoLabel is empty;
     /// fall back to AccessHop as the generic positional role.
     /// </summary>
+    private static string? FormatAccessTechnology(AccessTechnology tech) => tech switch
+    {
+        AccessTechnology.Unknown => null,
+        AccessTechnology.Gpon => "GPON",
+        AccessTechnology.XgsPon => "XGS-PON",
+        AccessTechnology.Docsis => "DOCSIS",
+        AccessTechnology.PppoE => "PPPoE",
+        AccessTechnology.DirectEthernet => "Active Ethernet",
+        AccessTechnology.FixedWireless => "Fixed Wireless",
+        AccessTechnology.Satellite => "Satellite",
+        AccessTechnology.Cellular => "Cellular",
+        AccessTechnology.Other => "Other",
+        _ => tech.ToString()
+    };
+
     private static UpstreamRole MapRoleFromAutoLabel(string? autoLabel)
     {
         if (string.IsNullOrEmpty(autoLabel)) return UpstreamRole.AccessHop;
@@ -289,6 +423,8 @@ public record WanSummary
     public required bool IsPrimary { get; init; }
     public string? GatewayMac { get; init; }
     public string? GatewayPortName { get; init; }
+    public string? UplinkIfName { get; init; }
+    public string? PhysicalIfName { get; init; }
     public int? LinkSpeedMbps { get; init; }
     public double? LiveRateInBps { get; set; }
     public double? LiveRateOutBps { get; set; }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -650,7 +650,7 @@ public class UpstreamTracerService
         try
         {
             var result = await _localProbe.TracerouteAsync(target, maxHops: 30,
-                perHopTimeout: TimeSpan.FromSeconds(2),
+                perHopTimeout: TimeSpan.FromSeconds(1),
                 totalDeadline: TimeSpan.FromSeconds(10),
                 ct: ct);
             return (endpoint.Label, result);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -43,11 +43,10 @@ public class UpstreamTracerService
     // DetectPublicIpAsync from the gateway's port_table.
     private readonly HashSet<string> _gatewayIps = new(StringComparer.OrdinalIgnoreCase);
 
-    // The OS-level interface name backing the WAN port (e.g. "ethN" or
-    // "ethN.M" for VLAN-tagged uplinks), read straight from UniFi's
-    // port_table.uplink_ifname during DetectPublicIpAsync. The L2-neighbor
-    // step uses this to target `ip neigh show dev <iface>` correctly even
-    // when the WAN sits on a sub-interface.
+    // The OS-level interface name backing the WAN port (e.g. "ethN",
+    // "ethN.M" for VLAN-tagged, "pppN" for PPPoE), read from the device's
+    // wan1...wan6 uplink_ifname during DetectPublicIpAsync. The L2-neighbor
+    // step uses this to target `ip neigh show dev <iface>` correctly.
     private string? _wanUplinkIfName;
 
     public UpstreamTracerState State { get; private set; } = new();
@@ -259,53 +258,108 @@ public class UpstreamTracerService
             return Fail("Not connected to UniFi Console.");
         }
 
-        List<UniFiDeviceResponse> devices;
+        // Fetch raw device JSON to read wan1...wan6 objects directly.
+        // These are the authoritative WAN descriptors and correctly report
+        // the Linux interface name for all connection types (DHCP, PPPoE,
+        // VLAN-tagged, GRE tunnels) - unlike port_table.is_uplink which
+        // may not be set for non-standard connections.
+        string? deviceJson;
         try
         {
-            devices = (await _connectionService.Client.GetDevicesAsync(ct))?.ToList()
-                      ?? new List<UniFiDeviceResponse>();
+            deviceJson = await _connectionService.Client.GetDevicesRawJsonAsync(ct);
+            if (string.IsNullOrEmpty(deviceJson))
+                return Fail("Empty device response from UniFi Console.");
         }
         catch (Exception ex)
         {
             return Fail($"Couldn't fetch UniFi devices: {ex.Message}");
         }
 
-        var gateway = devices.FirstOrDefault(d =>
-            d.DeviceType == NetworkOptimizer.Core.Enums.DeviceType.Gateway);
-        if (gateway?.PortTable == null)
+        string? wanInterfaceName = null;
+        string? wanUplinkIfName = null;
+        string? wanIp = null;
+
+        using (var doc = System.Text.Json.JsonDocument.Parse(deviceJson))
         {
-            return Fail("No gateway found in topology.");
+            var root = doc.RootElement;
+            var devices = root.ValueKind == System.Text.Json.JsonValueKind.Array
+                ? root
+                : root.TryGetProperty("data", out var data) ? data : root;
+
+            foreach (var device in devices.EnumerateArray())
+            {
+                var deviceType = device.TryGetProperty("type", out var typeProp) ? typeProp.GetString() : null;
+                if (deviceType != "ugw" && deviceType != "udm" && deviceType != "uxg")
+                    continue;
+
+                // Collect every IP the gateway carries so we can filter our own
+                // gateway out of the access-hop classification later.
+                _gatewayIps.Clear();
+                var portIdxToNetworkName = new Dictionary<int, string>();
+                if (device.TryGetProperty("port_table", out var portTable) &&
+                    portTable.ValueKind == System.Text.Json.JsonValueKind.Array)
+                {
+                    foreach (var port in portTable.EnumerateArray())
+                    {
+                        if (port.TryGetProperty("ip", out var ptIpProp))
+                        {
+                            var ptIp = ptIpProp.GetString();
+                            if (!string.IsNullOrEmpty(ptIp)) _gatewayIps.Add(ptIp);
+                        }
+                        if (port.TryGetProperty("port_idx", out var idxProp) &&
+                            idxProp.TryGetInt32(out var idx) &&
+                            port.TryGetProperty("network_name", out var nnProp))
+                        {
+                            var nn = nnProp.GetString();
+                            if (!string.IsNullOrEmpty(nn))
+                                portIdxToNetworkName[idx] = nn;
+                        }
+                    }
+                }
+
+                for (int i = 1; i <= 6; i++)
+                {
+                    var wanKey = $"wan{i}";
+                    if (!device.TryGetProperty(wanKey, out var wanObj)) continue;
+
+                    var uplinkIfname = wanObj.TryGetProperty("uplink_ifname", out var uplinkProp)
+                        ? uplinkProp.GetString() : null;
+                    if (string.IsNullOrEmpty(uplinkIfname)) continue;
+
+                    var ip = wanObj.TryGetProperty("ip", out var wanIpProp)
+                        ? wanIpProp.GetString() : null;
+
+                    // Derive the WAN key from port_table network_name when available
+                    // (e.g. "wan", "wan2") to match convention used by prior code.
+                    string interfaceKey;
+                    if (wanObj.TryGetProperty("port_idx", out var portIdxProp) &&
+                        portIdxProp.TryGetInt32(out var portIdx) &&
+                        portIdxToNetworkName.TryGetValue(portIdx, out var networkName))
+                    {
+                        interfaceKey = networkName;
+                    }
+                    else
+                    {
+                        interfaceKey = i == 1 ? "wan" : $"wan{i}";
+                    }
+
+                    wanInterfaceName = interfaceKey;
+                    wanUplinkIfName = uplinkIfname;
+                    wanIp = ip;
+                    break;
+                }
+
+                if (wanInterfaceName != null) break;
+            }
         }
 
-        // Primary WAN port: first IsUplink port with a network_name starting with "wan",
-        // else any uplink port.
-        var wanPort = gateway.PortTable.FirstOrDefault(p =>
-            p.IsUplink &&
-            (p.NetworkName?.StartsWith("wan", StringComparison.OrdinalIgnoreCase) ?? false));
-        wanPort ??= gateway.PortTable.FirstOrDefault(p => p.IsUplink);
-        if (wanPort == null)
-        {
+        if (wanInterfaceName == null)
             return Fail("Couldn't identify the WAN port on the gateway.");
-        }
 
-        State.WanInterface = wanPort.NetworkName ?? "wan";
-        _wanUplinkIfName = wanPort.UplinkIfName;
-
-        // Snapshot every IP the gateway carries (LAN, WAN, management VLAN) so
-        // we can filter our own gateway out of the access-hop classification
-        // below. Without this the trace's first hop (the LAN gateway address)
-        // gets misclassified as the access ISP's first-mile device.
-        _gatewayIps.Clear();
-        foreach (var port in gateway.PortTable)
-        {
-            if (!string.IsNullOrEmpty(port.Ip)) _gatewayIps.Add(port.Ip);
-        }
-
-        // The port_table IP is the WAN public IP in our experience (or RFC1918 for
-        // double-NAT, CGNAT for cgnat, etc.). NetworkUtilities.ClassifyPublicAddress
-        // does the bracket detection.
-        State.WanIpAddress = wanPort.Ip;
-        State.WanIpClass = NetworkUtilities.ClassifyPublicAddress(wanPort.Ip);
+        State.WanInterface = wanInterfaceName;
+        _wanUplinkIfName = wanUplinkIfName;
+        State.WanIpAddress = wanIp;
+        State.WanIpClass = NetworkUtilities.ClassifyPublicAddress(wanIp);
 
         switch (State.WanIpClass)
         {
@@ -315,14 +369,14 @@ public class UpstreamTracerService
 
             case PublicAddressClass.Cgnat:
                 State.IsCgnat = true;
-                _logger.LogInformation("Tracer: WAN IP is CGNAT ({Ip}); proceeding with discovery", wanPort.Ip);
+                _logger.LogInformation("Tracer: WAN IP is CGNAT ({Ip}); proceeding with discovery", wanIp);
                 break;
 
             case PublicAddressClass.DoubleNat:
                 // Per locked Gate 2 decision 8: proceed anyway, traceroute will still
                 // reveal the upstream ISP. Surface a small "double-NAT detected" badge.
                 State.IsDoubleNat = true;
-                _logger.LogInformation("Tracer: WAN IP is RFC1918 ({Ip}); proceeding (double-NAT)", wanPort.Ip);
+                _logger.LogInformation("Tracer: WAN IP is RFC1918 ({Ip}); proceeding (double-NAT)", wanIp);
                 break;
 
             case PublicAddressClass.IPv6:

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -4,7 +4,6 @@ using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Core.Helpers;
 using NetworkOptimizer.Monitoring.Probes;
 using NetworkOptimizer.Storage.Models;
-using NetworkOptimizer.UniFi.Models;
 using NetworkOptimizer.Web.Services.Ssh;
 
 namespace NetworkOptimizer.Web.Services.Monitoring;
@@ -939,6 +938,7 @@ public class UpstreamTracerService
     private static async Task UpsertTargetAsync(NetworkOptimizerDbContext db, AccessHopCandidate hop, string wanInterface, CancellationToken ct)
     {
         var existing = await db.MonitoringTargets.FirstOrDefaultAsync(t => t.TargetId == hop.TargetId, ct);
+        existing ??= await db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == hop.Address, ct);
         if (existing == null)
         {
             db.MonitoringTargets.Add(new MonitoringTarget
@@ -989,20 +989,10 @@ public class UpstreamTracerService
             ? MonitoringTargetType.InternetService
             : MonitoringTargetType.Transit;
 
-        // PathProxy targets probe the same endpoints as the default WAN targets
-        // (e.g. Cloudflare 1.1.1.1). Skip if one already exists for this address.
-        if (transit.Method == DiscoveryMethod.PathProxy)
-        {
-            var address = transit.HopAddress ?? transit.PathProxyTarget;
-            if (!string.IsNullOrEmpty(address))
-            {
-                var duplicate = await db.MonitoringTargets.AnyAsync(
-                    t => t.Address == address && t.TargetId != transit.TargetId, ct);
-                if (duplicate) return;
-            }
-        }
-
+        var address = transit.HopAddress ?? transit.PathProxyTarget;
         var existing = await db.MonitoringTargets.FirstOrDefaultAsync(t => t.TargetId == transit.TargetId, ct);
+        if (existing == null && !string.IsNullOrEmpty(address))
+            existing = await db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == address, ct);
         if (existing == null)
         {
             db.MonitoringTargets.Add(new MonitoringTarget

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -461,16 +461,33 @@ public class MonitoringCollectionAgent : BackgroundService
         }
 
         // Gateways are the top of the topology - no parent switch to read their
-        // uplink rate from. Fall back to the SNMP rate on the gateway's own WAN
-        // interface (which is what the topology view's gateway pipe actually
-        // represents anyway). We pick the highest-rate non-LAN interface as a
-        // pragmatic heuristic - the WAN interface tends to dominate.
+        // uplink rate from. Use the SNMP rate on the gateway's actual WAN
+        // interface (wan1...wan6 uplink_ifname, e.g. eth6.100 for VLAN-tagged
+        // or ppp3 for PPPoE) rather than port_table.IsUplink which may not be
+        // set for non-standard connection types.
         foreach (var gw in devices.Where(d => d.DeviceType == NetworkOptimizer.Core.Enums.DeviceType.Gateway))
         {
             var gwMac = NormalizeMac(gw.Mac);
 
-            // Primary: UniFi PortTable WAN port byte delta. Works when the gateway's
-            // uplink is a simple physical port and PortIdx aligns with SNMP ifIndex.
+            // Primary: SNMP rate on the WAN physical port. For VLAN-tagged WANs,
+            // use the parent port (eth6) not the sub-interface (eth6.100) since
+            // VLAN sub-interface counters double-count on some kernels.
+            var rateIfName = _cachedGatewayWanPhysicalIfNames.TryGetValue(gwMac, out var physIf) ? physIf : null;
+            rateIfName ??= _cachedGatewayWanIfNames.TryGetValue(gwMac, out var uplinkIf) ? uplinkIf : null;
+            if (rateIfName != null)
+            {
+                var portRate = _liveStats.GetPortRate(gwMac, rateIfName);
+                if (portRate != null)
+                {
+                    // Gateway WAN perspective: port TX (DownBps) = data toward
+                    // internet = uploads; port RX (UpBps) = from internet = downloads.
+                    _liveStats.RecordInterfaceAggregate(gw.Mac, portRate.DownBps, portRate.UpBps, nowOverride);
+                    continue;
+                }
+            }
+
+            // Fallback: PortTable IsUplink + PortIdx. Covers gateways where
+            // the raw JSON hasn't been fetched yet or the wan object is missing.
             (double DownBps, double UpBps)? rate = null;
             if (gw.PortTable != null)
             {
@@ -480,19 +497,15 @@ public class MonitoringCollectionAgent : BackgroundService
                     rate = ComputePortRate(gwMac, wanPort.PortIdx, nowOverride);
                     if (rate.HasValue)
                     {
-                        // Gateway perspective: TX out the WAN = upstream toward internet;
-                        // RX = downstream. Note direction flip vs the switch-port case.
                         _liveStats.RecordInterfaceAggregate(gw.Mac, rate.Value.UpBps, rate.Value.DownBps, nowOverride);
                         continue;
                     }
                 }
             }
 
-            // Fallback: UniFi device-level tx_bytes / rx_bytes delta. Used when the
-            // gateway's WAN-side is a bond/LAG (Linux bond0 aggregating eth4+eth5
-            // for a named WAN port, etc.) and PortTable.PortIdx doesn't
-            // align with any single physical SNMP ifIndex. ComputeDeviceRate
-            // returns (down, up) in our convention.
+            // Last resort: device-level tx_bytes / rx_bytes delta. Used when the
+            // gateway's WAN-side is a bond/LAG and neither wan1...wan6 nor
+            // PortTable produced a usable rate.
             var devRate = ComputeDeviceRate(gwMac);
             if (devRate.HasValue)
             {
@@ -1335,6 +1348,8 @@ public class MonitoringCollectionAgent : BackgroundService
     private List<UniFiDeviceResponse> _cachedDevices = new();
     private DateTime _cachedDevicesAt = DateTime.MinValue;
     private readonly SemaphoreSlim _deviceFetchLock = new(1, 1);
+    private Dictionary<string, string> _cachedGatewayWanIfNames = new(StringComparer.OrdinalIgnoreCase);
+    private Dictionary<string, string> _cachedGatewayWanPhysicalIfNames = new(StringComparer.OrdinalIgnoreCase);
 
     // Gateway LAN IP cache. UniFi reports the gateway's "ip" as the WAN public IP
     // which never answers SNMP from inside the LAN. The actual SNMP-reachable IP is
@@ -1428,6 +1443,52 @@ public class MonitoringCollectionAgent : BackgroundService
                 .ToList() ?? new List<UniFiDeviceResponse>();
             _cachedDevices = filtered;
             _cachedDevicesAt = DateTime.UtcNow;
+
+            // Extract gateway WAN uplink_ifname from raw device JSON so the
+            // gateway rate override uses the correct interface (e.g. eth6.100
+            // for VLAN-tagged, ppp3 for PPPoE) instead of the physical port.
+            var gwIfNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var gwPhysIfNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                var rawJson = await _connectionService.Client.GetDevicesRawJsonAsync(ct);
+                if (!string.IsNullOrEmpty(rawJson))
+                {
+                    using var doc = System.Text.Json.JsonDocument.Parse(rawJson);
+                    var root = doc.RootElement;
+                    var devArray = root.ValueKind == System.Text.Json.JsonValueKind.Array
+                        ? root
+                        : root.TryGetProperty("data", out var arr) ? arr : root;
+                    foreach (var dev in devArray.EnumerateArray())
+                    {
+                        var type = dev.TryGetProperty("type", out var tp) ? tp.GetString() : null;
+                        if (type != "ugw" && type != "udm" && type != "uxg") continue;
+                        var mac = dev.TryGetProperty("mac", out var mp) ? mp.GetString() : null;
+                        if (string.IsNullOrEmpty(mac)) continue;
+                        var normalizedMac = mac.ToLowerInvariant().Replace('-', ':');
+                        for (int i = 1; i <= 6; i++)
+                        {
+                            if (!dev.TryGetProperty($"wan{i}", out var wanObj)) continue;
+                            var uplinkIf = wanObj.TryGetProperty("uplink_ifname", out var up) ? up.GetString() : null;
+                            if (!string.IsNullOrEmpty(uplinkIf))
+                            {
+                                gwIfNames[normalizedMac] = uplinkIf;
+                                var physIf = wanObj.TryGetProperty("ifname", out var pf) ? pf.GetString() : null;
+                                if (!string.IsNullOrEmpty(physIf))
+                                    gwPhysIfNames[normalizedMac] = physIf;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to extract gateway WAN ifnames from raw JSON");
+            }
+            _cachedGatewayWanIfNames = gwIfNames;
+            _cachedGatewayWanPhysicalIfNames = gwPhysIfNames;
+
             return filtered;
         }
         catch (Exception ex)

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14494,6 +14494,7 @@ a.affected-client:hover {
     font-variant-numeric: tabular-nums;
     border: 1px solid rgba(36, 188, 112, 0.3);
     margin-top: 4px;
+    white-space: nowrap;
     display: none;
 }
 .lan-flow-map-wan-pill.is-visible {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1077,7 +1077,12 @@ export class LanFlowMap {
     _buildCloudSubLabel(cloud, tier) {
         const parts = [];
         if (cloud.accessTechnology) parts.push(cloud.accessTechnology);
-        if (cloud.l2NeighborOui) parts.push(cloud.l2NeighborOui);
+        if (cloud.l2NeighborOui) {
+            const oui = cloud.l2NeighborOui.length > 20
+                ? cloud.l2NeighborOui.substring(0, 20).trimEnd() + '...'
+                : cloud.l2NeighborOui;
+            parts.push(oui);
+        }
         if (cloud.isCgnat) parts.push('CGNAT');
         if (tier === CLOUD_TIER.PathProxy) parts.push('via path');
         if (tier === CLOUD_TIER.Unresolved) parts.push('discovery pending');

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -117,7 +117,7 @@ export class LanFlowMap {
         this.canvas = canvasEl;
         this.stage = canvasEl.parentElement || canvasEl;
         this.apiBase = options.apiBase ?? '/api/monitoring/lan-flow-map';
-        this.pollIntervalMs = options.pollIntervalMs ?? 2000;
+        this.pollIntervalMs = options.pollIntervalMs ?? 1000;
         this.onError = options.onError ?? ((err) => console.error('[LanFlowMap]', err));
 
         this._snapshot = null;
@@ -304,12 +304,20 @@ export class LanFlowMap {
                 }
             }
             if (!this._shouldAcceptKeys()) return;
-            if (['w','a','s','d','q','e'].includes(e.key.toLowerCase())) {
+            if (e.key === ' ') {
+                e.preventDefault();
+                this._togglePlayPause();
+                return;
+            }
+            if (e.key === 'Shift') this._keys.shift = true;
+            if (['arrowleft','arrowright','w','a','s','d','q','e'].includes(e.key.toLowerCase())) {
+                if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') e.preventDefault();
                 this._keys[e.key.toLowerCase()] = true;
             }
         };
         this._onKeyUp = (e) => {
             this._keys[e.key.toLowerCase()] = false;
+            if (e.key === 'Shift') this._keys.shift = false;
         };
         document.addEventListener('keydown', this._onKeyDown);
         document.addEventListener('keyup', this._onKeyUp);
@@ -855,11 +863,24 @@ export class LanFlowMap {
         };
 
         const cloudPositions = new Map();
-        for (const cloud of accessClouds) {
+        if (accessClouds.length === 1) {
+            const cloud = accessClouds[0];
             const x = gwX + dirX * accessRadius;
             const y = gwY + 4;
             const z = gwZ + dirZ * accessRadius;
             cloudPositions.set(cloud.id, placeCloud(cloud, x, y, z));
+        } else {
+            const accessFan = Math.min(Math.PI * 0.4, accessClouds.length * (Math.PI / 10));
+            const accessArcStep = accessClouds.length > 1 ? accessFan / (accessClouds.length - 1) : 0;
+            const accessArcStart = -accessFan / 2;
+            for (let i = 0; i < accessClouds.length; i++) {
+                const cloud = accessClouds[i];
+                const angle = outBearing + accessArcStart + accessArcStep * i;
+                const x = gwX + Math.cos(angle) * accessRadius;
+                const y = gwY + 4;
+                const z = gwZ + Math.sin(angle) * accessRadius;
+                cloudPositions.set(cloud.id, placeCloud(cloud, x, y, z));
+            }
         }
         for (let i = 0; i < siblings.length; i++) {
             const cloud = siblings[i];
@@ -1229,8 +1250,8 @@ export class LanFlowMap {
                     const target = this.controls.target;
                     const offset = cam.position.clone().sub(target);
                     const dist = offset.length();
-                    const zoomStep = dist * 0.0225;
-                    const panDist = dist * 0.012;
+                    const zoomStep = dist * 0.015;
+                    const panDist = dist * 0.008;
 
                     if (this._keys['w'] && dist > this.controls.minDistance + zoomStep) {
                         offset.multiplyScalar(1 - zoomStep / dist);
@@ -1250,6 +1271,23 @@ export class LanFlowMap {
                     }
                 }
                 this.controls?.update();
+            }
+
+            // Left/right arrow: scrub timeline. Throttled to 5 ticks/sec.
+            if (this._keys?.['arrowleft'] || this._keys?.['arrowright']) {
+                const now = performance.now();
+                if (!this._lastArrowScrub || now - this._lastArrowScrub >= 200) {
+                    this._lastArrowScrub = now;
+                    const range = this._panels.scrubberRange;
+                    if (range) {
+                        const step = this._keys.shift ? 35 : 4;
+                        const dir = this._keys['arrowright'] ? step : -step;
+                        const val = Math.max(0, Math.min(10000, Number(range.value) + dir));
+                        range.value = val;
+                        range.dispatchEvent(new Event('input'));
+                        range.dispatchEvent(new Event('change'));
+                    }
+                }
             }
 
             // Freeze particle motion while paused (Live or Historic) so the
@@ -1309,11 +1347,8 @@ export class LanFlowMap {
     _startHistoricPlayback() {
         if (this._historicPlaybackTimer) return;
         // Track playback as a continuous timestamp, not integer slider units.
-        // The slider and time label update every tick; the map and stat cards
-        // refresh on a throttled cadence (~3 s wall-clock) to avoid flooding
-        // the API while still feeling responsive.
         const TICK_MS = 1000;
-        const DATA_REFRESH_TICKS = 3; // load new data every 3 ticks
+        const DATA_REFRESH_TICKS = 1;
         this._playbackTime = this._historicAt
             || this._scrubberValueToTime(Number(this._panels.scrubberRange?.value ?? 500));
         let tickCount = 0;
@@ -1328,24 +1363,24 @@ export class LanFlowMap {
             const now = Date.now();
             const span = now - this._scrubberOrigin;
             const value = span > 0
-                ? Math.round((this._playbackTime.getTime() - this._scrubberOrigin) / span * 1000)
-                : 1000;
-            const clamped = Math.max(0, Math.min(1000, value));
+                ? Math.round((this._playbackTime.getTime() - this._scrubberOrigin) / span * 10000)
+                : 10000;
+            const clamped = Math.max(0, Math.min(10000, value));
             range.value = clamped;
             // Update the time label from the continuous timestamp, not the
             // integer slider position (which only moves every ~86s at 1x).
             if (this._panels.scrubberRight) {
                 this._panels.scrubberRight.textContent =
-                    (clamped >= 998) ? 'Live' : _fmtDateTime(this._playbackTime);
+                    (clamped >= 9998) ? 'Live' : _fmtDateTime(this._playbackTime);
             }
             tickCount++;
             // Refresh map and stat cards periodically
-            if (tickCount % DATA_REFRESH_TICKS === 0 || clamped >= 998) {
+            if (tickCount % DATA_REFRESH_TICKS === 0 || clamped >= 9998) {
                 this._playbackAdvancing = true;
                 try {
-                    if (clamped >= 998) {
+                    if (clamped >= 9998) {
                         this._stopHistoricPlayback();
-                        this._onScrubberChange(1000);
+                        this._onScrubberChange(10000);
                     } else {
                         this._historicAt = this._playbackTime;
                         this._notifyStatCards(this._playbackTime);
@@ -1507,6 +1542,9 @@ export class LanFlowMap {
                 <div class="lan-flow-map-help-row"><span>Hover detail</span><span class="kbd">Mouse over</span></div>
                 <div class="lan-flow-map-help-row"><span>Open client</span><span class="kbd">Double-click</span></div>
                 <div class="lan-flow-map-help-row"><span>Move device</span><span class="kbd">Right-click</span></div>
+                <div class="lan-flow-map-help-row"><span>Pause / Play</span><span class="kbd">Space</span></div>
+                <div class="lan-flow-map-help-row"><span>Scrub timeline</span><span class="kbd">←</span> <span class="kbd">→</span></div>
+                <div class="lan-flow-map-help-row"><span>Fast scrub</span><span class="kbd">Shift</span> + <span class="kbd">←</span> <span class="kbd">→</span></div>
                 <div class="lan-flow-map-help-row"><span>Fullscreen</span><span class="kbd">Esc</span> to exit</div>
             </div>
         `;
@@ -1528,8 +1566,8 @@ export class LanFlowMap {
         modeBadge.addEventListener('click', () => {
             if (this._mode === 'live') return;
             const range = this._panels.scrubberRange;
-            if (range) range.value = 1000;
-            this._onScrubberChange(1000);
+            if (range) range.value = 10000;
+            this._onScrubberChange(10000);
         });
         status.appendChild(modeBadge);
         this._panels.status = status;
@@ -1550,28 +1588,59 @@ export class LanFlowMap {
                     <button class="lan-flow-map-speed-step" data-dir="1" type="button" aria-label="Faster">+</button>
                 </div>
                 <span data-role="left">-24h</span>
-                <input class="lan-flow-map-scrubber-range" type="range" min="0" max="1000" value="1000" />
+                <input class="lan-flow-map-scrubber-range" type="range" min="0" max="10000" value="10000" />
                 <span data-role="right">Live</span>
             </div>
         `;
         const range = scrubber.querySelector('.lan-flow-map-scrubber-range');
         range.addEventListener('input', (e) => this._onScrubberInput(Number(e.target.value)));
-        range.addEventListener('change', (e) => this._onScrubberChange(Number(e.target.value)));
+        this._scrubberThrottleTimer = null;
+        this._scrubberLastFire = 0;
+        range.addEventListener('change', (e) => {
+            const val = Number(e.target.value);
+            this._onScrubberInput(val);
+            const now = Date.now();
+            const elapsed = now - this._scrubberLastFire;
+            clearTimeout(this._scrubberThrottleTimer);
+            if (elapsed >= 1000) {
+                this._scrubberLastFire = now;
+                this._onScrubberChange(val);
+            } else {
+                this._scrubberThrottleTimer = setTimeout(() => {
+                    this._scrubberLastFire = Date.now();
+                    this._onScrubberChange(val);
+                }, 1000 - elapsed);
+            }
+        });
+        range.addEventListener('keydown', (e) => e.preventDefault());
         // User grabbing the thumb implicitly cancels any active historic playback.
         range.addEventListener('pointerdown', () => this._stopHistoricPlayback());
         const playPause = scrubber.querySelector('[data-role="playpause"]');
         playPause.addEventListener('click', () => this._togglePlayPause());
-        const SPEED_STEPS = [1, 2, 5, 10, 30, 60, 120, 360, 720, 1440];
+        const SPEED_STEPS = [0.5, 1, 2, 5, 10, 30, 60, 120, 360, 720, 1440];
         this._speedSteps = SPEED_STEPS;
-        this._speedIndex = 0; // starts at 1x
+        this._speedIndex = 1; // starts at 1x
         for (const btn of scrubber.querySelectorAll('.lan-flow-map-speed-step')) {
             btn.addEventListener('click', () => {
                 const dir = Number(btn.dataset.dir);
-                const newIdx = Math.max(0, Math.min(SPEED_STEPS.length - 1, this._speedIndex + dir));
+                let newIdx = Math.max(0, Math.min(SPEED_STEPS.length - 1, this._speedIndex + dir));
+                if (this._mode === 'live' && dir > 0) {
+                    const liveIdx = SPEED_STEPS.indexOf(1);
+                    if (newIdx > liveIdx) newIdx = liveIdx;
+                }
                 if (newIdx === this._speedIndex) return;
                 this._speedIndex = newIdx;
                 this._playbackSpeed = SPEED_STEPS[newIdx];
                 this._syncSpeedLabel();
+                if (this._mode === 'live' && this._playbackSpeed < 1) {
+                    const now = Date.now();
+                    const span = now - this._scrubberOrigin;
+                    const nearNow = span > 0 ? Math.floor((now - 5000 - this._scrubberOrigin) / span * 10000) : 9997;
+                    this._speedTransition = true;
+                    this._onScrubberChange(Math.min(nearNow, 9997));
+                    this._speedTransition = false;
+                    this._startHistoricPlayback();
+                }
                 if (this._mode === 'historic' && this._historicPlaybackTimer) {
                     this._stopHistoricPlayback();
                     this._startHistoricPlayback();
@@ -1753,17 +1822,17 @@ export class LanFlowMap {
         const at = this._scrubberValueToTime(value);
         if (this._panels.scrubberRight) {
             this._panels.scrubberRight.textContent =
-                (value >= 998) ? 'Live' : _fmtDateTime(at);
+                (value >= 9998) ? 'Live' : _fmtDateTime(at);
         }
     }
 
     async _onScrubberChange(value) {
-        if (value >= 998) {
+        if (value >= 9998) {
             // Snap back to live.
             this._stopHistoricPlayback();
             this._mode = 'live';
             this._historicAt = null;
-            this._onScrubberInput(1000);
+            this._onScrubberInput(10000);
             if (this._panels.modeBadge) {
                 this._panels.modeBadge.textContent = 'Live';
                 this._panels.modeBadge.classList.remove('is-historic');
@@ -1771,8 +1840,9 @@ export class LanFlowMap {
                 this._panels.modeBadge.removeAttribute('data-tooltip');
                 if (this._panels.modeBadge._tippy) this._panels.modeBadge._tippy.destroy();
             }
-            // Returning to live resumes polling; clear the paused state so the
-            // play button reflects "playing" again.
+            // Returning to live: reset speed to 1x and resume polling.
+            this._speedIndex = this._speedSteps.indexOf(1);
+            this._playbackSpeed = 1;
             this._paused = false;
             this._syncPlayPauseIcon();
             this._syncSpeedLabel();
@@ -1795,7 +1865,7 @@ export class LanFlowMap {
         // method on every tick (to load the historic snapshot for the new
         // slider position); skip the auto-pause in that case or playback
         // would stop after one tick.
-        if (!this._playbackAdvancing && !this._paused) {
+        if (!this._playbackAdvancing && !this._speedTransition && !this._paused) {
             this._paused = true;
             this._syncPlayPauseIcon();
             this._stopHistoricPlayback();
@@ -1827,10 +1897,10 @@ export class LanFlowMap {
     }
 
     _scrubberValueToTime(value) {
-        // Range 0..1000 maps from the anchored origin (mount - 24h) to now.
+        // Range 0..10000 maps from the anchored origin (mount - 24h) to now.
         // The window grows as the page stays open so recent time is always reachable.
         const now = Date.now();
-        const ms = this._scrubberOrigin + (value / 1000) * (now - this._scrubberOrigin);
+        const ms = this._scrubberOrigin + (value / 10000) * (now - this._scrubberOrigin);
         return new Date(ms);
     }
 
@@ -1978,10 +2048,14 @@ export class LanFlowMap {
             if (!group) { pill.classList.remove('is-visible'); continue; }
             tmp.setFromMatrixPosition(group.matrixWorld);
             tmp.y -= NODE_RADIUS.cloud + 0.5;
+            const dist = tmp.distanceTo(camPos);
             tmp.project(this.camera);
             if (tmp.z > 1) { pill.classList.remove('is-visible'); continue; }
             const x = (tmp.x * halfW) + halfW;
             const y = -(tmp.y * halfH) + halfH;
+            const scale = Math.max(MIN_SCALE, Math.min(1.0, REF_DIST / Math.max(dist, 1)));
+            pill.style.transform = `translate(-50%, 0%) scale(${scale.toFixed(3)})`;
+            pill.style.transformOrigin = 'center top';
             pill.style.left = `${x}px`;
             pill.style.top = `${y}px`;
         }
@@ -2301,14 +2375,29 @@ export class LanFlowMap {
                 if (child.isMesh) candidates.push(child);
             }
         }
+        for (const group of this._cloudMeshes.values()) {
+            if (!group.visible) continue;
+            for (const child of group.children) {
+                if (child.isMesh) candidates.push(child);
+            }
+        }
         const hits = this._raycaster.intersectObjects(candidates, false);
         if (hits.length === 0) return;
         let g = hits[0].object;
-        while (g && !(g.userData?.node)) g = g.parent;
+        while (g && !(g.userData?.node || g.userData?.cloud)) g = g.parent;
         if (!g) return;
+
+        if (g.userData?.cloud) {
+            const cloud = g.userData.cloud;
+            // TODO: enable for all WANs once multi-WAN upstream tracing is implemented
+            if (cloud.kind === 0 && cloud.wanInterface === this._snapshot?.primaryWanInterface) {
+                this._showCloudContextMenu(e.clientX, e.clientY, cloud);
+            }
+            return;
+        }
+
         const node = g.userData.node;
         if (node.kind === NODE_KIND.Cloud || node.kind === NODE_KIND.VirtualHub) return;
-
         this._showContextMenu(e.clientX, e.clientY, node, g);
     }
 
@@ -2323,6 +2412,29 @@ export class LanFlowMap {
             e.stopPropagation();
             this._dismissContextMenu();
             this._enterReposition(node, group);
+        });
+        menu.appendChild(item);
+
+        const stageRect = this.stage.getBoundingClientRect();
+        menu.style.left = `${clientX - stageRect.left}px`;
+        menu.style.top = `${clientY - stageRect.top}px`;
+        this.stage.appendChild(menu);
+        this._contextMenuEl = menu;
+    }
+
+    _showCloudContextMenu(clientX, clientY, cloud) {
+        this._dismissContextMenu();
+        const menu = document.createElement('div');
+        menu.className = 'lan-flow-map-context-menu';
+        const item = document.createElement('div');
+        item.className = 'lan-flow-map-context-menu-item';
+        item.textContent = 'Run Upstream Discovery';
+        item.addEventListener('click', (e) => {
+            e.stopPropagation();
+            this._dismissContextMenu();
+            if (this._dotnetRef) {
+                this._dotnetRef.invokeMethodAsync('NavigateToUpstreamDiscovery');
+            }
         });
         menu.appendChild(item);
 

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/PortProfileResolutionTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/PortProfileResolutionTests.cs
@@ -22,6 +22,47 @@ public class PortProfileResolutionTests
     }
 
     [Fact]
+    public void ExtractSwitches_PortWithOpModeMirror_PopulatesOpModeAndIsMirrorDestination()
+    {
+        // op_mode is the UniFi controller field that flags a port as a mirror/SPAN
+        // destination. ParsePort must propagate it to PortInfo.OpMode so downstream
+        // rules can use IsMirrorDestination to skip these ports.
+        var deviceData = JsonDocument.Parse(@"[
+            {
+                ""type"": ""usw"",
+                ""name"": ""Switch"",
+                ""port_table"": [
+                    {
+                        ""port_idx"": 5,
+                        ""name"": ""Port 5"",
+                        ""op_mode"": ""mirror"",
+                        ""forward"": ""all"",
+                        ""up"": true
+                    },
+                    {
+                        ""port_idx"": 1,
+                        ""name"": ""Port 1"",
+                        ""op_mode"": ""switch"",
+                        ""forward"": ""all"",
+                        ""up"": true
+                    }
+                ]
+            }
+        ]").RootElement;
+        var networks = new List<NetworkInfo>();
+
+        var result = _engine.ExtractSwitches(deviceData, networks, null, null, null);
+
+        var mirrorPort = result[0].Ports.Single(p => p.PortIndex == 5);
+        mirrorPort.OpMode.Should().Be("mirror");
+        mirrorPort.IsMirrorDestination.Should().BeTrue();
+
+        var switchPort = result[0].Ports.Single(p => p.PortIndex == 1);
+        switchPort.OpMode.Should().Be("switch");
+        switchPort.IsMirrorDestination.Should().BeFalse();
+    }
+
+    [Fact]
     public void ExtractSwitches_PortWithProfile_ResolvesForwardModeFromProfile()
     {
         // Port has forward="all" but profile has forward="disabled"

--- a/tests/NetworkOptimizer.Audit.Tests/Models/PortInfoTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Models/PortInfoTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using NetworkOptimizer.Audit.Models;
+using Xunit;
+
+namespace NetworkOptimizer.Audit.Tests.Models;
+
+public class PortInfoTests
+{
+    private static PortInfo CreatePortWithOpMode(string? opMode)
+    {
+        return new PortInfo
+        {
+            PortIndex = 1,
+            OpMode = opMode,
+            Switch = new SwitchInfo { Name = "Test", Capabilities = new SwitchCapabilities() }
+        };
+    }
+
+    [Fact]
+    public void IsMirrorDestination_OpModeMirror_ReturnsTrue()
+    {
+        var port = CreatePortWithOpMode("mirror");
+        port.IsMirrorDestination.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsMirrorDestination_OpModeSwitch_ReturnsFalse()
+    {
+        var port = CreatePortWithOpMode("switch");
+        port.IsMirrorDestination.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsMirrorDestination_OpModeNull_ReturnsFalse()
+    {
+        var port = CreatePortWithOpMode(null);
+        port.IsMirrorDestination.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsMirrorDestination_OpModeMixedCase_ReturnsTrue()
+    {
+        // String comparison is OrdinalIgnoreCase; UniFi has historically used different
+        // casing across firmware versions for similar enum-like fields.
+        var port = CreatePortWithOpMode("Mirror");
+        port.IsMirrorDestination.Should().BeTrue();
+    }
+}

--- a/tests/NetworkOptimizer.Audit.Tests/Rules/AccessPortVlanRuleTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Rules/AccessPortVlanRuleTests.cs
@@ -877,6 +877,28 @@ public class AccessPortVlanRuleTests
 
     #endregion
 
+    #region Mirror Destination Ports
+
+    [Fact]
+    public void Evaluate_MirrorDestinationPort_ReturnsInformational()
+    {
+        // Mirror destination ports (op_mode=mirror) have visibility into all mirrored
+        // VLAN traffic by design. Surface as Informational so the operator is aware of
+        // the physical-access exposure, not flagged as a misconfiguration.
+        var port = CreateTrunkPortWithClient(opMode: "mirror");
+        var networks = CreateVlanNetworks(5);
+
+        var result = _rule.Evaluate(port, networks);
+
+        result.Should().NotBeNull();
+        result!.Severity.Should().Be(AuditSeverity.Informational);
+        result.ScoreImpact.Should().Be(2);
+        result.Message.Should().Contain("Mirror destination");
+        result.Metadata!["is_mirror_destination"].Should().Be(true);
+    }
+
+    #endregion
+
     #region 802.1X / RADIUS Dynamic VLAN Assignment
 
     [Fact]
@@ -1200,7 +1222,8 @@ public class AccessPortVlanRuleTests
         string? nativeNetworkId = null,
         string? connectedDeviceType = null,
         string forwardMode = "custom",
-        string? dot1xCtrl = null)
+        string? dot1xCtrl = null,
+        string? opMode = null)
     {
         var switchInfo = new SwitchInfo
         {
@@ -1214,6 +1237,7 @@ public class AccessPortVlanRuleTests
             Name = portName,
             IsUp = true,
             ForwardMode = forwardMode,
+            OpMode = opMode,
             IsUplink = isUplink,
             IsWan = isWan,
             NativeNetworkId = nativeNetworkId,

--- a/tests/NetworkOptimizer.Audit.Tests/Rules/UnusedPortRuleTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Rules/UnusedPortRuleTests.cs
@@ -26,6 +26,25 @@ public class UnusedPortRuleTests
     }
 
     [Fact]
+    public void Evaluate_MirrorDestinationPort_DownWithOldLastSeen_ReturnsNull()
+    {
+        // Mirror destination ports legitimately have intermittent device occupancy
+        // (capture device may be unplugged). Without the guard, an unplugged mirror
+        // port with an old last_connection would be flagged as unused - acting on
+        // that recommendation breaks mirroring as soon as the capture device returns.
+        var port = CreatePort(
+            isUp: false,
+            forwardMode: "all",
+            lastConnectionSeen: DateTimeOffset.UtcNow.AddDays(-90).ToUnixTimeSeconds(),
+            opMode: "mirror");
+        var networks = new List<NetworkInfo>();
+
+        var result = _rule.Evaluate(port, networks);
+
+        result.Should().BeNull("Mirror destination ports should not be flagged as unused");
+    }
+
+    [Fact]
     public void RuleName_ReturnsExpectedValue()
     {
         _rule.RuleName.Should().Be("Unused Port Disabled");
@@ -797,7 +816,8 @@ public class UnusedPortRuleTests
         string switchName = "Test Switch",
         long? lastConnectionSeen = null,
         UniFiPortProfile? assignedProfile = null,
-        bool isEnabled = true)
+        bool isEnabled = true,
+        string? opMode = null)
     {
         var switchInfo = new SwitchInfo
         {
@@ -813,6 +833,7 @@ public class UnusedPortRuleTests
             IsEnabled = isEnabled,
             IsUp = isUp,
             ForwardMode = forwardMode,
+            OpMode = opMode,
             IsUplink = isUplink,
             IsWan = isWan,
             NativeNetworkId = networkId,


### PR DESCRIPTION
## Summary

- **WAN detection via wan1...wan6** - Upstream tracer, path view, and collection agent now read the device's wan objects directly instead of relying on port_table.is_uplink, which may not be set for PPPoE, VLAN-tagged, or GRE tunnel connections. Fixes #651.
- **Multi-WAN 3D map** - All active WANs render as separate access clouds with per-WAN live rates, speed test pills, and friendly names from UniFi network configs.
- **Per-WAN live and historic rates** - Each WAN link shows its own SNMP interface rate. Historic playback resolves rates per-WAN from InfluxDB.
- **Timeline UX improvements** - 10x scrubber resolution, arrow key scrubbing (shift for fast), spacebar pause/play, 0.5x speed, throttled data loads, reduced WASD sensitivity.
- **Faster traceroute probes** - Reduced per-hop timeout and probe count (-q 2 -w 1) so traces complete within the deadline even on paths with silent intermediate hops. Parser now derives probe count from actual output instead of hardcoding 3.
- **Access technology selector** - Users can set their access network technology during upstream discovery review.
- **Target deduplication** - Upstream discovery save now checks by address as a secondary key, preventing duplicate monitoring targets.
- **Right-click WAN globe** - Context menu navigates to upstream discovery panel.
- **Audit mirror-port awareness** - Port-evaluating audit rules now skip mirror/span ports, avoiding false positives on monitoring ports that intentionally carry all VLANs. (Thanks @jedis00 - #650)
- **Custom target badge** - Custom target type badge now uses active color instead of grey.