### PR TITLE
Monitoring: faster traceroute probes, fix parser for variable probe count

### DIFF
--- a/src/NetworkOptimizer.Monitoring/Probes/LocalProbeExecutor.cs
+++ b/src/NetworkOptimizer.Monitoring/Probes/LocalProbeExecutor.cs
@@ -477,7 +477,7 @@ public class LocalProbeExecutor : IProbeExecutor
         // PTR resolution stays ON — hostnames like "cr1.stl1.example.net" are gold for the
         // wizard's hop-labelling logic (spec 5.5). Linux's resolver times out fast, so the
         // cost is bounded by the per-probe deadline anyway.
-        var args = $"-m {maxHops} -w {wait} {protoFlag} {target.Address}".Trim();
+        var args = $"-m {maxHops} -q 2 -w {wait} {protoFlag} {target.Address}".Trim();
         return ("traceroute", args);
     }
 }

--- a/src/NetworkOptimizer.Monitoring/Probes/TracerouteOutputParser.cs
+++ b/src/NetworkOptimizer.Monitoring/Probes/TracerouteOutputParser.cs
@@ -68,18 +68,6 @@ public static class TracerouteOutputParser
                 continue;
             var rest = m.Groups["rest"].Value;
 
-            // Non-responding hop
-            if (rest.Trim().StartsWith("*"))
-            {
-                hops.Add(new TraceHop
-                {
-                    HopNumber = hopNum,
-                    Probes = CountStars(rest),
-                    Responses = 0
-                });
-                continue;
-            }
-
             string? hostname = null;
             string? address = null;
 
@@ -105,9 +93,22 @@ public static class TracerouteOutputParser
                     rttValues.Add(v);
             }
 
-            // Probes per hop is conventionally 3 in both Linux and busybox; count stars + RTTs
-            int probes = 3;
+            int stars = CountStars(rest);
             int responses = rttValues.Count;
+            int probes = stars + responses;
+            if (probes == 0) probes = 1;
+
+            // Fully non-responding hop (all probes timed out)
+            if (responses == 0)
+            {
+                hops.Add(new TraceHop
+                {
+                    HopNumber = hopNum,
+                    Probes = probes,
+                    Responses = 0
+                });
+                continue;
+            }
 
             hops.Add(new TraceHop
             {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -650,7 +650,7 @@ public class UpstreamTracerService
         try
         {
             var result = await _localProbe.TracerouteAsync(target, maxHops: 30,
-                perHopTimeout: TimeSpan.FromSeconds(2),
+                perHopTimeout: TimeSpan.FromSeconds(1),
                 totalDeadline: TimeSpan.FromSeconds(10),
                 ct: ct);
             return (endpoint.Label, result);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1077,7 +1077,12 @@ export class LanFlowMap {
     _buildCloudSubLabel(cloud, tier) {
         const parts = [];
         if (cloud.accessTechnology) parts.push(cloud.accessTechnology);
-        if (cloud.l2NeighborOui) parts.push(cloud.l2NeighborOui);
+        if (cloud.l2NeighborOui) {
+            const oui = cloud.l2NeighborOui.length > 20
+                ? cloud.l2NeighborOui.substring(0, 20).trimEnd() + '...'
+                : cloud.l2NeighborOui;
+            parts.push(oui);
+        }
         if (cloud.isCgnat) parts.push('CGNAT');
         if (tier === CLOUD_TIER.PathProxy) parts.push('via path');
         if (tier === CLOUD_TIER.Unresolved) parts.push('discovery pending');


### PR DESCRIPTION
## Summary

- **Traceroute tuning** - Use `-q 2` (2 probes per hop) and `-w 1` (1s wait) instead of defaults (3 probes, 2s wait). Cuts trace time significantly for paths with silent intermediate hops that were burning through the 10s total deadline before reaching the destination.
- **Parser fix** - Probe count is now derived from actual output (stars + RTT responses) instead of hardcoding 3. Handles mixed-response lines correctly (e.g., one timeout + one response on the same hop).
- **OUI label truncation** - L2 neighbor vendor name capped at 20 characters on the 3D map sub-label to prevent overly wide labels.

## Test plan

- [x] Run upstream discovery on both test sites
- [x] Verify traces that previously showed 0/0 "No reply" now return partial or full results
- [x] Check 3D map OUI labels are truncated properly