### PR TITLE
Add NextDNS detection to ThirdPartyDnsDetector

### DIFF
--- a/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
@@ -772,14 +772,14 @@ public class DnsSecurityAnalyzer
                 var dnsServerIps = result.ThirdPartyDnsServers.Select(t => t.DnsServerIp).Distinct().ToList();
                 var networkNames = result.ThirdPartyDnsServers.Select(t => t.NetworkName).Distinct().ToList();
 
-                // Known providers (Pi-hole, AdGuard Home) are trusted - neutral score impact
+                // Known providers (Pi-hole, AdGuard Home, NextDNS CLI) are trusted - neutral score impact
                 // Unknown third-party DNS servers get a minor penalty since we can't verify their filtering
-                var isKnownProvider = result.IsPiholeDetected || result.IsAdGuardHomeDetected;
+                var isKnownProvider = result.IsPiholeDetected || result.IsAdGuardHomeDetected || result.IsNextDnsDetected;
                 var scoreImpact = isKnownProvider ? 0 : 3; // Minor penalty for unknown providers
                 var severity = isKnownProvider ? AuditSeverity.Informational : AuditSeverity.Recommended;
                 var recommendedAction = isKnownProvider
                     ? "Verify third-party DNS provides adequate security and filtering. Consider enabling DNS firewall rules to prevent bypass."
-                    : "Configure the third-party DNS management port in Settings to enable detection. Otherwise, consider a known DNS filtering solution (Pi-hole, AdGuard Home) or CyberSecure Encrypted DNS (DoH).";
+                    : "Configure the third-party DNS management port in Settings to enable detection. Otherwise, consider a known DNS filtering solution (Pi-hole, AdGuard Home, NextDNS) or CyberSecure Encrypted DNS (DoH).";
 
                 result.Issues.Add(new AuditIssue
                 {
@@ -795,6 +795,7 @@ public class DnsSecurityAnalyzer
                         { "third_party_dns_ips", dnsServerIps },
                         { "is_pihole", result.IsPiholeDetected },
                         { "is_adguard_home", result.IsAdGuardHomeDetected },
+                        { "is_nextdns", result.IsNextDnsDetected },
                         { "is_known_provider", isKnownProvider },
                         { "affected_networks", networkNames },
                         { "provider_name", result.ThirdPartyDnsProviderName ?? "Third-Party LAN DNS" },
@@ -1961,7 +1962,7 @@ public class DnsSecurityAnalyzer
             result.HasThirdPartyDns = true;
             result.ThirdPartyDnsServers.AddRange(thirdPartyResults);
 
-            // Determine provider name (Pi-hole takes precedence, then AdGuard Home)
+            // Determine provider name (Pi-hole takes precedence, then AdGuard Home, then NextDNS CLI)
             if (thirdPartyResults.Any(t => t.IsPihole))
             {
                 result.ThirdPartyDnsProviderName = "Pi-hole";
@@ -1973,6 +1974,12 @@ public class DnsSecurityAnalyzer
                 result.ThirdPartyDnsProviderName = "AdGuard Home";
                 _logger.LogInformation("AdGuard Home detected as third-party DNS on {Count} network(s)",
                     thirdPartyResults.Count(t => t.IsAdGuardHome));
+            }
+            else if (thirdPartyResults.Any(t => t.IsNextDns))
+            {
+                result.ThirdPartyDnsProviderName = "NextDNS CLI";
+                _logger.LogInformation("NextDNS CLI detected as third-party DNS on {Count} network(s)",
+                    thirdPartyResults.Count(t => t.IsNextDns));
             }
             else
             {
@@ -2745,6 +2752,7 @@ public class DnsSecurityResult
     public List<ThirdPartyDnsDetector.ThirdPartyDnsInfo> ThirdPartyDnsServers { get; } = new();
     public bool IsPiholeDetected => ThirdPartyDnsServers.Any(t => t.IsPihole);
     public bool IsAdGuardHomeDetected => ThirdPartyDnsServers.Any(t => t.IsAdGuardHome);
+    public bool IsNextDnsDetected => ThirdPartyDnsServers.Any(t => t.IsNextDns);
     public string? ThirdPartyDnsProviderName { get; set; }
 
     /// <summary>

--- a/src/NetworkOptimizer.Audit/Dns/ThirdPartyDnsDetector.cs
+++ b/src/NetworkOptimizer.Audit/Dns/ThirdPartyDnsDetector.cs
@@ -1,5 +1,8 @@
 using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
 using System.Text.Json;
+using DnsClient;
 using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Audit.Models;
 using NetworkOptimizer.Core.Helpers;
@@ -33,6 +36,8 @@ public class ThirdPartyDnsDetector
         public string? PiholeVersion { get; init; }
         public bool IsAdGuardHome { get; init; }
         public string? AdGuardHomeVersion { get; init; }
+        public bool IsNextDns { get; init; }
+        public string? NextDnsProfile { get; init; }
         public string DnsProviderName { get; init; } = "Third-Party LAN DNS";
     }
 
@@ -117,6 +122,8 @@ public class ThirdPartyDnsDetector
                 string? piholeVersion = null;
                 bool isAdGuardHome = false;
                 string? adGuardHomeVersion = null;
+                bool isNextDns = false;
+                string? nextDnsProfile = null;
                 string providerName = "Third-Party LAN DNS";
 
                 if (!probedIps.Contains(dnsServer))
@@ -139,6 +146,18 @@ public class ThirdPartyDnsDetector
                             providerName = "AdGuard Home";
                             _logger.LogInformation("Detected AdGuard Home at {Ip} (version: {Version})", dnsServer, adGuardHomeVersion ?? "unknown");
                         }
+                        else
+                        {
+                            // If not AdGuard Home, try NextDNS CLI detection. This is slower than
+                            // the local-HTTP probes (requires DNS query through the resolver plus
+                            // an HTTPS round-trip to NextDNS's test endpoint), so it goes last.
+                            (isNextDns, nextDnsProfile) = await ProbeNextDnsAsync(dnsServer);
+                            if (isNextDns)
+                            {
+                                providerName = "NextDNS CLI";
+                                _logger.LogInformation("Detected NextDNS CLI at {Ip} (profile: {Profile})", dnsServer, nextDnsProfile ?? "unknown");
+                            }
+                        }
                     }
                 }
                 else
@@ -151,6 +170,8 @@ public class ThirdPartyDnsDetector
                         piholeVersion = existingResult.PiholeVersion;
                         isAdGuardHome = existingResult.IsAdGuardHome;
                         adGuardHomeVersion = existingResult.AdGuardHomeVersion;
+                        isNextDns = existingResult.IsNextDns;
+                        nextDnsProfile = existingResult.NextDnsProfile;
                         providerName = existingResult.DnsProviderName;
                     }
                 }
@@ -165,6 +186,8 @@ public class ThirdPartyDnsDetector
                     PiholeVersion = piholeVersion,
                     IsAdGuardHome = isAdGuardHome,
                     AdGuardHomeVersion = adGuardHomeVersion,
+                    IsNextDns = isNextDns,
+                    NextDnsProfile = nextDnsProfile,
                     DnsProviderName = providerName
                 });
             }
@@ -243,10 +266,192 @@ public class ThirdPartyDnsDetector
             "9.9.9.9" or "149.112.112.112" => "Quad9",
             "208.67.222.222" or "208.67.220.220" => "OpenDNS",
             "94.140.14.14" or "94.140.15.15" => "AdGuard DNS",
+            "45.90.28.0" or "45.90.30.0" => "NextDNS",
             "76.76.2.0" or "76.76.10.0" => "Control D",
             "185.228.168.9" or "185.228.169.9" => "CleanBrowsing",
             _ => null
         };
+    }
+
+    /// <summary>
+    /// Test hook: override the NextDNS probe outcome for a given DNS server IP.
+    /// When set, ProbeNextDnsAsync delegates to this delegate instead of doing
+    /// the actual DNS + HTTPS dance. The test assembly's [ModuleInitializer]
+    /// sets a safe (false, null) default at assembly load, so production code
+    /// is never exercised by unit tests by default. Tests that exercise the
+    /// probe path explicitly override this with their own outcome and then
+    /// restore the assembly-wide default in their Dispose.
+    /// </summary>
+    internal static Func<string, CancellationToken, Task<(bool IsNextDns, string? Profile)>>? NextDnsProbeOverride { get; set; }
+
+    /// <summary>
+    /// Reset the NextDNS probe override to null. Used for cleanup paths that
+    /// want production semantics (the real DNS+HTTPS probe). Test code should
+    /// generally restore TestAssemblyInit.SetSafeDefault() instead, to avoid
+    /// breaking sibling tests that inherit the assembly-wide default.
+    /// </summary>
+    internal static void ResetNextDnsProbeOverride() => NextDnsProbeOverride = null;
+
+    /// <summary>
+    /// Probe an IP address to detect if it's running NextDNS CLI.
+    /// </summary>
+    /// <remarks>
+    /// NextDNS CLI doesn't expose an HTTP admin interface, so it can't be detected
+    /// via the local-IP probes used for Pi-hole and AdGuard Home. The detection
+    /// signal lives in NextDNS's hosted test endpoint (https://test.nextdns.io),
+    /// which correlates DNS lookups to its auth servers with subsequent HTTPS
+    /// requests bearing the same random subdomain.
+    /// 
+    /// Probe steps:
+    /// 1. Generate a random subdomain {hex}.test.nextdns.io
+    /// 2. Query the audited DNS server for the subdomain's A record. If the
+    ///    audited server is NextDNS CLI, it forwards this lookup upstream to
+    ///    NextDNS via DoH, and NextDNS records the resolver IP that originated
+    ///    the query.
+    /// 3. HTTPS GET to https://{random}.test.nextdns.io with the TCP connection
+    ///    forced to the resolved IP. NextDNS's web server looks up the random
+    ///    subdomain it just saw queried, correlates it with the resolver IP,
+    ///    and returns JSON with status=ok plus clientName indicating the kind
+    ///    of NextDNS client (nextdns-cli, browser DoH, etc.).
+    /// 4. Detection succeeds if status=ok and clientName contains "nextdns".
+    /// </remarks>
+    private async Task<(bool IsNextDns, string? Profile)> ProbeNextDnsAsync(string ipAddress, CancellationToken ct = default)
+    {
+        // Test override short-circuits the real probe
+        if (NextDnsProbeOverride != null)
+        {
+            return await NextDnsProbeOverride(ipAddress, ct);
+        }
+
+        if (!IPAddress.TryParse(ipAddress, out var resolverIp))
+        {
+            return (false, null);
+        }
+
+        // Step 1: generate a random subdomain. 12 hex chars gives 48 bits of
+        // entropy - enough to avoid collisions in NextDNS's recent-query window
+        // without being unnecessarily long.
+        var randomId = Convert.ToHexString(RandomNumberGenerator.GetBytes(6)).ToLowerInvariant();
+        var hostname = $"{randomId}.test.nextdns.io";
+
+        // Step 2: DNS A-record query via the audited resolver
+        IPAddress[] resolvedIps;
+        try
+        {
+            var lookup = new LookupClient(new LookupClientOptions(resolverIp)
+            {
+                Timeout = TimeSpan.FromSeconds(2),
+                UseCache = false,
+                Retries = 0,
+                ContinueOnDnsError = false
+            });
+
+            var dnsResult = await lookup.QueryAsync(hostname, QueryType.A, cancellationToken: ct);
+            if (dnsResult.HasError)
+            {
+                _logger.LogDebug("NextDNS DNS probe: lookup error for {Hostname} via {Resolver}: {Error}",
+                    hostname, ipAddress, dnsResult.ErrorMessage);
+                return (false, null);
+            }
+
+            resolvedIps = dnsResult.Answers
+                .OfType<DnsClient.Protocol.ARecord>()
+                .Select(r => r.Address)
+                .ToArray();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "NextDNS DNS probe: lookup exception for {Hostname} via {Resolver}",
+                hostname, ipAddress);
+            return (false, null);
+        }
+
+        if (resolvedIps.Length == 0)
+        {
+            return (false, null);
+        }
+
+        // Step 3: HTTPS GET with connection pinned to the resolved IP. SNI carries
+        // the random hostname for TLS cert validation; the actual TCP connection
+        // lands on the NextDNS web server IP that the audited resolver returned.
+        var probeIp = resolvedIps[0];
+        var url = $"https://{hostname}/";
+
+        SocketsHttpHandler? probeHandler = null;
+        HttpClient? probeClient = null;
+        try
+        {
+            probeHandler = new SocketsHttpHandler
+            {
+                ConnectCallback = async (ctx, cb) =>
+                {
+                    var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+                    try
+                    {
+                        await socket.ConnectAsync(probeIp, ctx.DnsEndPoint.Port, cb);
+                        return new NetworkStream(socket, ownsSocket: true);
+                    }
+                    catch
+                    {
+                        socket.Dispose();
+                        throw;
+                    }
+                }
+            };
+
+            probeClient = new HttpClient(probeHandler, disposeHandler: false)
+            {
+                Timeout = TimeSpan.FromSeconds(3)
+            };
+
+            using var response = await probeClient.GetAsync(url, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug("NextDNS HTTPS probe: {Status} from {Hostname} via {Resolver}",
+                    (int)response.StatusCode, hostname, ipAddress);
+                return (false, null);
+            }
+
+            var json = await response.Content.ReadAsStringAsync(ct);
+            using var doc = JsonDocument.Parse(json);
+
+            if (!doc.RootElement.TryGetProperty("status", out var statusElement) ||
+                !string.Equals(statusElement.GetString(), "ok", StringComparison.OrdinalIgnoreCase))
+            {
+                return (false, null);
+            }
+
+            if (!doc.RootElement.TryGetProperty("clientName", out var clientElement))
+            {
+                return (false, null);
+            }
+
+            var clientName = clientElement.GetString();
+            if (string.IsNullOrEmpty(clientName) ||
+                clientName.IndexOf("nextdns", StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                return (false, null);
+            }
+
+            string? profile = null;
+            if (doc.RootElement.TryGetProperty("profile", out var profileElement))
+            {
+                profile = profileElement.GetString();
+            }
+
+            return (true, profile);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "NextDNS HTTPS probe: exception for {Hostname} via {Resolver}",
+                hostname, ipAddress);
+            return (false, null);
+        }
+        finally
+        {
+            probeClient?.Dispose();
+            probeHandler?.Dispose();
+        }
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Audit/NetworkOptimizer.Audit.csproj
+++ b/src/NetworkOptimizer.Audit/NetworkOptimizer.Audit.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="DnsClient" Version="1.8.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/ThirdPartyDnsDetectorTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/ThirdPartyDnsDetectorTests.cs
@@ -23,6 +23,119 @@ public class ThirdPartyDnsDetectorTests : IDisposable
     public void Dispose()
     {
         DohProviderRegistry.ResetDnsResolver();
+        // Restore the assembly-wide safe default rather than nulling out the override.
+        // The module initializer in TestAssemblyInit sets this once at assembly load;
+        // nulling it here would expose subsequent tests to the real DNS+HTTPS probe.
+        TestAssemblyInit.SetSafeDefault();
+    }
+
+    [Fact]
+    public async Task DetectThirdPartyDnsAsync_NextDnsDetected_FlagsProviderAsNextDns()
+    {
+        // Pi-hole and AdGuard Home probes return 404 (not detected). NextDNS probe
+        // override returns a successful detection. Result should record IsNextDns=true
+        // and the provider name should propagate up to the orchestration layer.
+        ThirdPartyDnsDetector.NextDnsProbeOverride = (ip, ct) =>
+            Task.FromResult<(bool, string?)>((true, "fp1234567890abcdef"));
+
+        var httpClient = CreateMockHttpClient(HttpStatusCode.NotFound);
+        var detector = CreateDetector(httpClient);
+
+        var networks = new List<NetworkInfo>
+        {
+            new()
+            {
+                Id = "net1",
+                DhcpEnabled = true,
+                Name = "Trusted",
+                VlanId = 1,
+                Subnet = "10.0.0.0/24",
+                Gateway = "10.0.0.1",
+                DnsServers = new List<string> { "10.0.100.251" }
+            }
+        };
+
+        var result = await detector.DetectThirdPartyDnsAsync(networks);
+
+        result.Should().HaveCount(1);
+        result[0].DnsServerIp.Should().Be("10.0.100.251");
+        result[0].IsNextDns.Should().BeTrue();
+        result[0].NextDnsProfile.Should().Be("fp1234567890abcdef");
+        result[0].IsPihole.Should().BeFalse();
+        result[0].IsAdGuardHome.Should().BeFalse();
+        result[0].DnsProviderName.Should().Be("NextDNS CLI");
+    }
+
+    [Fact]
+    public async Task DetectThirdPartyDnsAsync_NextDnsProbeReturnsFalse_NoNextDnsFlag()
+    {
+        // All three probes fail to identify the resolver. Result should still be
+        // recorded as a third-party DNS, but with no specific provider attribution.
+        ThirdPartyDnsDetector.NextDnsProbeOverride = (ip, ct) =>
+            Task.FromResult<(bool, string?)>((false, null));
+
+        var httpClient = CreateMockHttpClient(HttpStatusCode.NotFound);
+        var detector = CreateDetector(httpClient);
+
+        var networks = new List<NetworkInfo>
+        {
+            new()
+            {
+                Id = "net1",
+                DhcpEnabled = true,
+                Name = "Trusted",
+                VlanId = 1,
+                Subnet = "10.0.0.0/24",
+                Gateway = "10.0.0.1",
+                DnsServers = new List<string> { "10.0.100.251" }
+            }
+        };
+
+        var result = await detector.DetectThirdPartyDnsAsync(networks);
+
+        result.Should().HaveCount(1);
+        result[0].IsNextDns.Should().BeFalse();
+        result[0].NextDnsProfile.Should().BeNull();
+        result[0].DnsProviderName.Should().Be("Third-Party LAN DNS");
+    }
+
+    [Fact]
+    public async Task DetectThirdPartyDnsAsync_PiholeDetected_DoesNotRunNextDnsProbe()
+    {
+        // If Pi-hole is detected first, the NextDNS probe override should never
+        // be invoked. Use a probe that would fail the test if called to enforce this.
+        var nextDnsProbeCalled = false;
+        ThirdPartyDnsDetector.NextDnsProbeOverride = (ip, ct) =>
+        {
+            nextDnsProbeCalled = true;
+            return Task.FromResult<(bool, string?)>((false, null));
+        };
+
+        // Mock HTTP client returns a valid Pi-hole API response on the probe URL
+        var piholeResponse = @"{""dns"":true,""https_port"":443,""took"":0.001}";
+        var httpClient = CreateMockHttpClient(HttpStatusCode.OK, piholeResponse);
+        var detector = CreateDetector(httpClient);
+
+        var networks = new List<NetworkInfo>
+        {
+            new()
+            {
+                Id = "net1",
+                DhcpEnabled = true,
+                Name = "Trusted",
+                VlanId = 1,
+                Subnet = "10.0.0.0/24",
+                Gateway = "10.0.0.1",
+                DnsServers = new List<string> { "10.0.100.10" }
+            }
+        };
+
+        var result = await detector.DetectThirdPartyDnsAsync(networks);
+
+        result.Should().HaveCount(1);
+        result[0].IsPihole.Should().BeTrue();
+        result[0].IsNextDns.Should().BeFalse();
+        nextDnsProbeCalled.Should().BeFalse("NextDNS probe should be skipped when Pi-hole is detected first");
     }
 
     private ThirdPartyDnsDetector CreateDetector(HttpClient? httpClient = null)
@@ -1524,6 +1637,8 @@ public class ThirdPartyDnsDetectorTests : IDisposable
     [InlineData("9.9.9.9", "Quad9")]
     [InlineData("208.67.222.222", "OpenDNS")]
     [InlineData("94.140.14.14", "AdGuard DNS")]
+    [InlineData("45.90.28.0", "NextDNS")]
+    [InlineData("45.90.30.0", "NextDNS")]
     public void DetectExternalDns_KnownProviders_ReturnsCorrectProviderName(string dnsIp, string expectedProvider)
     {
         var detector = CreateDetector();

--- a/tests/NetworkOptimizer.Audit.Tests/TestAssemblyInit.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/TestAssemblyInit.cs
@@ -1,0 +1,38 @@
+using System.Runtime.CompilerServices;
+using NetworkOptimizer.Audit.Dns;
+
+namespace NetworkOptimizer.Audit.Tests;
+
+/// <summary>
+/// Sets assembly-wide test defaults for static mockability hooks.
+/// The [ModuleInitializer] runs once at test-assembly load before any test
+/// executes, so every test in the assembly inherits these defaults without
+/// per-class constructor boilerplate.
+/// </summary>
+/// <remarks>
+/// Currently this only owns ThirdPartyDnsDetector.NextDnsProbeOverride.
+/// DohProviderRegistry.DnsResolver continues to use the existing per-file
+/// constructor/Dispose pattern - it's set in only two test classes and that
+/// scale is fine. If future work adds more test injection points, or if the
+/// DohProviderRegistry pattern picks up additional consumers, those would
+/// be good candidates to migrate into this module initializer.
+/// </remarks>
+internal static class TestAssemblyInit
+{
+    [ModuleInitializer]
+    internal static void Init() => SetSafeDefault();
+
+    /// <summary>
+    /// Sets ThirdPartyDnsDetector.NextDnsProbeOverride to a no-op that returns
+    /// (false, null) for any input. Tests that exercise the NextDNS probe path
+    /// explicitly override this with their own outcome, then call this method
+    /// in Dispose to restore the assembly-wide default rather than nulling out
+    /// the override (which would expose subsequent tests to the real DNS+HTTPS
+    /// probe and burn their 2s DnsClient timeout).
+    /// </summary>
+    internal static void SetSafeDefault()
+    {
+        ThirdPartyDnsDetector.NextDnsProbeOverride = (_, _) =>
+            Task.FromResult<(bool IsNextDns, string? Profile)>((false, null));
+    }
+}


### PR DESCRIPTION
Adds detection for NextDNS in two deployment shapes that the auditor previously flagged as unknown third-party DNS:

1. NextDNS CLI on the LAN (private IP) - detected via ProbeNextDnsAsync, which uses NextDNS's random-subdomain correlation under test.nextdns.io. The probe runs last in the detection chain (after Pi-hole and AdGuard Home) because it's slower than local-HTTP probes. Adds DnsClient 1.8.0 (MIT) as a dependency for the DNS query step.

2. NextDNS public anycast IPs (45.90.28.0, 45.90.30.0) - added to GetPublicDnsProviderName for static IP-to-name lookup.

Detected NextDNS resolvers (either shape) get the same Informational/ score-0 treatment as Pi-hole and AdGuard Home.

Test mockability uses a [ModuleInitializer] in TestAssemblyInit that sets NextDnsProbeOverride to a (false, null) no-op once at assembly load, so every test inherits the default without per-class boilerplate. Three new orchestration test cases cover the detected/not-detected paths and the Pi-hole-takes-precedence ordering; two new InlineData entries on the existing KnownProviders test cover the anycast IPs.