### PR TITLE
Detect IP-based DoH blocking rules

### DIFF
--- a/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
@@ -33,6 +33,13 @@ public class DnsSecurityAnalyzer
         "one.one.one"  // Cloudflare 1.1.1.1 alternate domain
     ];
 
+    // Thresholds for IP-based DoH detection. A rule's destination IP list must
+    // match this many known DoH provider IPs spanning this many distinct providers
+    // before the rule is credited as DoH-bypass blocking. Avoids false positives
+    // from rules that incidentally block one or two DoH IPs for unrelated reasons.
+    private const int MinDohIpMatches = 3;
+    private const int MinDohProvidersMatched = 2;
+
     private readonly ThirdPartyDnsDetector _thirdPartyDetector;
 
     public DnsSecurityAnalyzer(ILogger<DnsSecurityAnalyzer> logger, ThirdPartyDnsDetector thirdPartyDetector)
@@ -612,6 +619,41 @@ public class DnsSecurityAnalyzer
                         result.Doh3RuleName = name;
                         _logger.LogDebug("Found DoH3 block rule: {Name} (zone={Zone}) with {Count} DNS domains",
                             name, destZoneId ?? "any", dnsProviderDomains.Count);
+                    }
+                }
+            }
+
+            // Check for IP-based DoH/DoH3 blocking (destination is a list of known DoH provider IPs).
+            // Catches rules using an IP group or inline IP list of DoH endpoints, which UniFi users
+            // frequently deploy as the primary or supplemental DoH-bypass mechanism. The MinDoh*
+            // thresholds avoid false positives from rules that happen to block one or two DoH IPs
+            // for unrelated reasons.
+            if ((targetsExternalZone || isLegacyLanIn) && matchingTarget == "IP" && rule.DestinationIps?.Count > 0)
+            {
+                var blocksDoh = FirewallGroupHelper.RuleBlocksPortAndProtocol(rule, "443", "tcp");
+                var blocksDoh3 = FirewallGroupHelper.RuleBlocksPortAndProtocol(rule, "443", "udp");
+
+                if (blocksDoh || blocksDoh3)
+                {
+                    var (matchedCount, matchedProviders) = DohProviderRegistry.MatchKnownDohIps(rule.DestinationIps);
+
+                    if (matchedCount >= MinDohIpMatches && matchedProviders.Count >= MinDohProvidersMatched)
+                    {
+                        if (blocksDoh)
+                        {
+                            result.HasDohBlockRule = true;
+                            result.DohRuleName ??= name;
+                            _logger.LogDebug("Found IP-based DoH block rule: {Name} (zone={Zone}) matched {Count} IPs across {ProviderCount} providers: {Providers}",
+                                name, destZoneId ?? "any", matchedCount, matchedProviders.Count, string.Join(", ", matchedProviders));
+                        }
+
+                        if (blocksDoh3)
+                        {
+                            result.HasDoh3BlockRule = true;
+                            result.Doh3RuleName ??= name;
+                            _logger.LogDebug("Found IP-based DoH3 block rule: {Name} (zone={Zone}) matched {Count} IPs across {ProviderCount} providers: {Providers}",
+                                name, destZoneId ?? "any", matchedCount, matchedProviders.Count, string.Join(", ", matchedProviders));
+                        }
                     }
                 }
             }

--- a/src/NetworkOptimizer.Audit/Dns/DohProviderRegistry.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DohProviderRegistry.cs
@@ -185,6 +185,34 @@ public static class DohProviderRegistry
     }
 
     /// <summary>
+    /// Match a list of IP addresses against known DoH providers. Returns the total number
+    /// of IPs that match a known provider and the set of distinct provider names matched.
+    /// Used to detect IP-based DoH-blocking firewall rules where the destination is a list
+    /// of provider IPs (typically referenced via an IP group) rather than a hostname or
+    /// DPI app reference.
+    /// </summary>
+    public static (int MatchedCount, HashSet<string> MatchedProviders) MatchKnownDohIps(IEnumerable<string> ips)
+    {
+        var matchedProviders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        int matchedCount = 0;
+
+        foreach (var ip in ips)
+        {
+            if (string.IsNullOrEmpty(ip))
+                continue;
+
+            var provider = IdentifyProviderFromIp(ip);
+            if (provider != null)
+            {
+                matchedCount++;
+                matchedProviders.Add(provider.Name);
+            }
+        }
+
+        return (matchedCount, matchedProviders);
+    }
+
+    /// <summary>
     /// Identify a provider from a DNS IP address using PTR lookup (authoritative) with static IP fallback.
     /// PTR lookup is tried first and takes priority when successful.
     /// Static IP matching (e.g., "45.90." prefix for NextDNS) is only used as fallback when PTR fails.

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
@@ -441,6 +441,199 @@ public class DnsSecurityAnalyzerTests : IDisposable
     }
 
     [Fact]
+    public async Task Analyze_WithIpBasedDohBlockRule_DetectsRule()
+    {
+        // An IP-based rule whose destination contains a list of known DoH provider IPs
+        // should be credited as a DoH block, mirroring how UniFi users commonly deploy
+        // this control (alternative or supplement to domain-based or DPI-app-based rules).
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block Public DoH (IPs)"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""protocol"": ""tcp"",
+                ""destination"": {
+                    ""port"": ""443"",
+                    ""matching_target"": ""IP"",
+                    ""ips"": [""1.1.1.1"", ""8.8.8.8"", ""9.9.9.9"", ""94.140.14.14""]
+                }
+            }
+        ]").RootElement;
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall));
+
+        result.HasDohBlockRule.Should().BeTrue();
+        result.DohRuleName.Should().Be("Block Public DoH (IPs)");
+    }
+
+    [Fact]
+    public async Task Analyze_WithIpBasedDohRule_BelowIpThreshold_DoesNotDetect()
+    {
+        // Only 2 known DoH IPs (below MinDohIpMatches = 3) should not trigger detection.
+        // Guards against rules that incidentally block one or two DoH IPs.
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block Two DNS IPs"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""protocol"": ""tcp"",
+                ""destination"": {
+                    ""port"": ""443"",
+                    ""matching_target"": ""IP"",
+                    ""ips"": [""1.1.1.1"", ""8.8.8.8""]
+                }
+            }
+        ]").RootElement;
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall));
+
+        result.HasDohBlockRule.Should().BeFalse("two known DoH IPs is below the minimum match threshold");
+    }
+
+    [Fact]
+    public async Task Analyze_WithIpBasedDohRule_BelowProviderThreshold_DoesNotDetect()
+    {
+        // 3+ IPs matched, but all from the same provider (Cloudflare). Below
+        // MinDohProvidersMatched = 2. Real DoH bypass prevention spans multiple
+        // providers; a single-provider IP block is more likely targeted at one
+        // service for a different reason.
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block Cloudflare Resolvers"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""protocol"": ""tcp"",
+                ""destination"": {
+                    ""port"": ""443"",
+                    ""matching_target"": ""IP"",
+                    ""ips"": [""1.1.1.1"", ""1.0.0.1"", ""1.1.1.2"", ""1.0.0.2""]
+                }
+            }
+        ]").RootElement;
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall));
+
+        result.HasDohBlockRule.Should().BeFalse("a single provider is below the minimum provider threshold");
+    }
+
+    [Fact]
+    public async Task Analyze_WithIpBasedDohRule_UdpOnly_DetectsDoh3NotDoH()
+    {
+        // UDP 443 to DoH provider IPs is DoH3 (HTTP/3 over QUIC), not DoH (TCP).
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block DoH3 by IP"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""protocol"": ""udp"",
+                ""destination"": {
+                    ""port"": ""443"",
+                    ""matching_target"": ""IP"",
+                    ""ips"": [""1.1.1.1"", ""8.8.8.8"", ""9.9.9.9""]
+                }
+            }
+        ]").RootElement;
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall));
+
+        result.HasDohBlockRule.Should().BeFalse("UDP 443 is DoH3, not DoH");
+        result.HasDoh3BlockRule.Should().BeTrue();
+        result.Doh3RuleName.Should().Be("Block DoH3 by IP");
+    }
+
+    [Fact]
+    public async Task Analyze_WithIpBasedDohRule_BothProtocols_DetectsBoth()
+    {
+        // tcp_udp on port 443 to DoH provider IPs catches both DoH (TCP) and DoH3 (UDP).
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block DoH + DoH3 by IP"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""protocol"": ""tcp_udp"",
+                ""destination"": {
+                    ""port"": ""443"",
+                    ""matching_target"": ""IP"",
+                    ""ips"": [""1.1.1.1"", ""8.8.8.8"", ""9.9.9.9""]
+                }
+            }
+        ]").RootElement;
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall));
+
+        result.HasDohBlockRule.Should().BeTrue();
+        result.HasDoh3BlockRule.Should().BeTrue();
+        result.DohRuleName.Should().Be("Block DoH + DoH3 by IP");
+        result.Doh3RuleName.Should().Be("Block DoH + DoH3 by IP");
+    }
+
+    [Fact]
+    public async Task Analyze_WithIpGroupResolvedToDohIps_DetectsRule()
+    {
+        // End-to-end: rule references an IP group via OBJECT/ip_group_id, group is
+        // resolved by the parser, analyzer recognizes the resolved list as DoH IPs.
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block Public DoH (Group)"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""protocol"": ""tcp"",
+                ""destination"": {
+                    ""port"": ""443"",
+                    ""matching_target"": ""IP"",
+                    ""matching_target_type"": ""OBJECT"",
+                    ""ip_group_id"": ""doh-providers-group""
+                }
+            }
+        ]").RootElement;
+
+        var firewallGroups = new List<UniFiFirewallGroup>
+        {
+            new UniFiFirewallGroup
+            {
+                Id = "doh-providers-group",
+                Name = "DoH-Providers",
+                GroupType = "address-group",
+                GroupMembers = new List<string>
+                {
+                    "1.1.1.1", "1.0.0.1",
+                    "8.8.8.8", "8.8.4.4",
+                    "9.9.9.9", "149.112.112.112",
+                    "94.140.14.14", "94.140.15.15"
+                }
+            }
+        };
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall, firewallGroups), null, null, null, null, null);
+
+        result.HasDohBlockRule.Should().BeTrue();
+        result.DohRuleName.Should().Be("Block Public DoH (Group)");
+    }
+
+    [Fact]
+    public async Task Analyze_WithIpBasedDohRule_OnlyOneIpFromKnownProvider_DoesNotDetect()
+    {
+        // 3+ IPs but only 1 is a known DoH provider IP. Below MinDohIpMatches.
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block Mixed IPs"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""protocol"": ""tcp"",
+                ""destination"": {
+                    ""port"": ""443"",
+                    ""matching_target"": ""IP"",
+                    ""ips"": [""1.1.1.1"", ""203.0.113.5"", ""198.51.100.20"", ""192.0.2.10""]
+                }
+            }
+        ]").RootElement;
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall));
+
+        result.HasDohBlockRule.Should().BeFalse("only one known DoH IP among non-DNS addresses");
+    }
+
+    [Fact]
     public async Task Analyze_WithDoqBlockRule_DetectsRule()
     {
         // DoQ (DNS over QUIC) uses UDP 853 per RFC 9250


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Summary</h2>
<p>Adds a third detection path for the <code>DNS-LEAK-003</code> audit issue ("No firewall rule blocks public DoH providers") that recognizes IP-based DoH-blocking rules. The auditor previously credited only two patterns:</p>
<ol>
<li><code>WEB</code> target rules whose domain list contains DNS-provider substrings</li>
<li><code>APP</code> target rules referencing the <code>DnsOverHttps</code> UniFi app ID (<code>1310919</code>)</li>
</ol>
<p>A common third pattern - <code>IP</code> target rules pointing at a curated list of provider IPs - was not credited even when comprehensive and operationally effective. This PR closes that gap.</p>
<h2>The gap</h2>
<p>I run a policy that blocks TCP/UDP 443 from Internal to External with destination <code>IP -&gt; List -&gt; DoH-Providers</code>. The group holds 44 well-known DoH endpoints across Cloudflare, Google, Quad9, AdGuard, OpenDNS, CleanBrowsing, Mullvad, ControlD, dns0.eu, and NextDNS anycast. Curl tests confirm the rule works: every IP-literal <code>--doh-url</code> request to those providers times out at the SYN drop, while normal HTTPS and local DNS resolution remain intact. The audit still flagged <code>DNS-LEAK-003</code> as Pending because the rule's matching target is <code>IP</code>, and neither existing detection path inspects IP-target rules.</p>
<p>The existing audit metadata even hints at the assumption baked into the detection:</p>
<pre><code class="language-csharp">Metadata = new Dictionary&lt;string, object&gt;
{
    { "suggested_domains", "dns.google, cloudflare-dns.com, dns.quad9.net, doh.opendns.com" }
}
</code></pre>
<p>It treats the fix as inherently domain-based. In practice IP-based blocking is common, often preferred (catches devices that hardcode IPs and never resolve a hostname), and behaviorally equivalent to the domain-based form for the major public providers whose anycast IPs are stable and well-known.</p>
<h2>Why the App rule alone is not a substitute</h2>
<p>The natural workaround when you see this audit finding is to add a rule using UniFi's "DNS over HTTPS" application (app ID <code>1310919</code>). That satisfies the existing detection logic and is what most users will reach for first. It also has a genuine role to play - I keep mine running as one layer of defense - but it should not be the only layer, and the audit's current logic effectively treats it as sufficient when it is not.</p>
<p>The App category is a DPI signature match. The mechanics:</p>
<ol>
<li>TCP handshake to the DoH endpoint completes normally</li>
<li>As the TLS ClientHello arrives, UniFi's classifier inspects packet features (primarily SNI, secondarily packet sizing and known IP ranges for some providers) and labels the flow as DoH if the signature matches</li>
<li>If labeled, subsequent packets are dropped, killing the handshake before any DNS query completes</li>
</ol>
<p>Two practical consequences fall out of this:</p>
<ul>
<li><strong>Direct-IP DoH (<code>--doh-url https://1.1.1.1/dns-query</code>) usually escapes.</strong> The ClientHello has no SNI value to inspect when the destination is an IP literal. The classifier falls back to weaker heuristics (sizing, hardcoded IP ranges for specific providers) that do not match the major providers consistently.</li>
<li><strong>Coverage is uneven across providers.</strong> UniFi's signature for this category appears to have been built around specific provider observations (Quad9 in particular has a strong signature), and not all major DoH endpoints are equally identified.</li>
</ul>
<p>Empirical test matrix from XPS (Trusted VLAN) with only the App rule active:</p>

Endpoint | Form | Result
-- | -- | --
1.1.1.1 | Cloudflare IP literal | not blocked
8.8.8.8 | Google IP literal | not blocked
9.9.9.9 | Quad9 IP literal | blocked
94.140.14.14 | AdGuard IP literal | not blocked
45.90.28.65 | NextDNS anycast IP | blocked
cloudflare-dns.com | Cloudflare hostname | not blocked
dns.google | Google hostname | not blocked
dns.quad9.net | Quad9 hostname | blocked
dns.nextdns.io | NextDNS hostname | not blocked


<p>3 of 9. The App rule passes the auditor today, but in this configuration is not actually preventing DoH bypass for the bulk of providers an operator would care about. That is the case for recognizing IP-based rules: not because the App rule is wrong, but because it is narrow, and the auditor giving a passing grade to App-only configurations implies a level of coverage the rule does not deliver on its own.</p>
<p>For comparison, with my IP-based rule active (App rule disabled), all 5 of the IP-literal endpoints in that matrix are blocked, because they appear explicitly in the IP group. The two rule types catch different things: the App rule catches SNI-based hostname DoH (especially Quad9) regardless of the destination IP; the IP rule catches anything pointed at the curated provider IPs regardless of SNI presence. Defense in depth, not redundancy.</p>
<h2>The fix</h2>
<p><code>DohProviderRegistry</code> already maintains an authoritative list of provider IPs and prefix matchers (used elsewhere for WAN DNS validation and PTR-based provider identification). Reuse it to identify IP-target rules whose destination list contains a meaningful fraction of known DoH provider IPs.</p>
<p>Two thresholds gate the match to avoid false positives:</p>
<ul>
<li><code>MinDohIpMatches = 3</code> - rules incidentally blocking one or two DoH IPs for unrelated reasons (test fixtures, blocking a single resolver someone uses for an unrelated service) should not be credited as comprehensive DoH-bypass prevention.</li>
<li><code>MinDohProvidersMatched = 2</code> - a rule blocking only Cloudflare resolvers (<code>1.1.1.1</code>, <code>1.0.0.1</code>, <code>1.1.1.2</code>, <code>1.0.0.2</code>) does not prevent DoH bypass; clients still reach Google, Quad9, etc. Real DoH bypass blocklists span multiple providers.</li>
</ul>
<p>Both live at the top of <code>DnsSecurityAnalyzer</code> for easy tuning if the project wants to change them later.</p>
<h2>Changes</h2>
<p><strong><code>src/NetworkOptimizer.Audit/Dns/DohProviderRegistry.cs</code></strong></p>
<p>Adds <code>MatchKnownDohIps(IEnumerable&lt;string&gt; ips)</code> returning <code>(MatchedCount, MatchedProviders)</code>. Pure function, no I/O, reuses the existing <code>IdentifyProviderFromIp</code> lookup.</p>
<p><strong><code>src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs</code></strong></p>
<p>Adds the two threshold constants and a new detection block between the existing WEB and APP detection paths. The block:</p>
<ul>
<li>Activates only when <code>matchingTarget == "IP"</code> and <code>DestinationIps</code> is non-empty</li>
<li>Honors the same external-zone targeting and legacy LAN_IN handling as the WEB and APP paths</li>
<li>Checks TCP 443 (DoH) and UDP 443 (DoH3) independently using the existing <code>FirewallGroupHelper.RuleBlocksPortAndProtocol</code> helper</li>
<li>Uses <code>??=</code> for rule-name assignment so WEB and APP detections take precedence when multiple kinds of rules exist on the same site</li>
<li>Logs matched IP count, distinct provider count, and provider names for diagnostics</li>
</ul>
<p><code>FirewallRuleParser</code> already resolves IP groups (<code>OBJECT/ip_group_id</code>) into <code>DestinationIps</code> before the analyzer runs, so the new path handles both inline IP lists and IP-group references transparently. No parser changes needed.</p>
<p><strong><code>tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs</code></strong></p>
<p>Adds seven tests:</p>
<ul>
<li>Happy path: 4 IPs across 4 providers -&gt; DoH detected</li>
<li>IP threshold guard: 2 IPs, 2 providers -&gt; not detected</li>
<li>Provider threshold guard: 4 IPs, 1 provider only -&gt; not detected</li>
<li>Mixed IPs guard: 1 known DoH IP among 3 unrelated IPs -&gt; not detected</li>
<li>UDP-only: detected as DoH3, not DoH</li>
<li><code>tcp_udp</code>: detected as both DoH and DoH3</li>
<li>IP group resolution: rule references <code>ip_group_id</code>, group contains DoH IPs, end-to-end detection passes</li>
</ul>
<h2>Audit impact</h2>
<p>Sites with existing IP-based DoH-blocking rules will now correctly flip <code>HasDohBlockRule</code> and clear <code>DNS-LEAK-003</code> without any configuration changes on the user side. No regression risk for existing WEB- or APP-based detections; they run first and are unchanged by this PR.</p>
<p>Validated end-to-end against a live UniFi deployment: with the App rule disabled and only the IP-based rule active, the next audit run cleared <code>DNS-LEAK-003</code> and <code>DoH Bypass Prevention</code> continued to show <code>Blocked</code> in the DNS Security panel. Re-enabling the App rule afterward shows both detections crediting in parallel, which is the intended steady state.</p>
<h2>Verification</h2>
<pre><code class="language-bash">dotnet build src/NetworkOptimizer.Audit/NetworkOptimizer.Audit.csproj
dotnet test tests/NetworkOptimizer.Audit.Tests/NetworkOptimizer.Audit.Tests.csproj --filter "FullyQualifiedName~DnsSecurityAnalyzerTests"
</code></pre>
<p>303 of 303 tests pass, including the seven added in this PR.</p></body></html><!--EndFragment-->
</body>
</html>