### PR TITLE
Audit: require all 4 major DoH providers for WEB and IP detection

### DIFF
--- a/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
@@ -20,7 +20,7 @@ public class DnsSecurityAnalyzer
     private const string SettingsKeyDns = "dns";
     private const string SettingsKeyWanDns = "wan_dns";
 
-    // DNS provider domain patterns for detecting DoH/DoQ block rules
+    // WEB and IP-based DoH detection requires coverage of all 4 major providers
     private static readonly HashSet<string> RequiredDohProviders = new(StringComparer.OrdinalIgnoreCase)
     {
         "Cloudflare", "Google", "Quad9", "OpenDNS"

--- a/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
@@ -21,17 +21,10 @@ public class DnsSecurityAnalyzer
     private const string SettingsKeyWanDns = "wan_dns";
 
     // DNS provider domain patterns for detecting DoH/DoQ block rules
-    private static readonly string[] DnsProviderPatterns =
-    [
-        "dns",
-        "doh",
-        "cloudflare-dns",
-        "quad9",
-        "nextdns",
-        "adguard",
-        "opendns",
-        "one.one.one"  // Cloudflare 1.1.1.1 alternate domain
-    ];
+    private static readonly HashSet<string> RequiredDohProviders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Cloudflare", "Google", "Quad9", "OpenDNS"
+    };
 
     // Thresholds for IP-based DoH detection. A rule's destination IP list must
     // match this many known DoH provider IPs spanning this many distinct providers
@@ -586,39 +579,38 @@ public class DnsSecurityAnalyzer
                 }
             }
 
-            // Check for DoH/DoH3 blocking (port 443 with web domains containing DNS providers)
-            // DoH = TCP 443 (HTTP/2), DoH3 = UDP 443 (HTTP/3 over QUIC)
-            // For legacy systems, LAN_IN is also acceptable (gateway's DoH goes to configured providers, not blocked IPs)
+            // Check for DoH/DoH3 blocking (port 443 with web domains covering major DoH providers).
+            // Requires all 4 major providers (Cloudflare, Google, Quad9, OpenDNS) to be covered
+            // to prevent partial blocks from getting credit. Uses DohProviderRegistry hostname
+            // matching rather than loose substring patterns.
             if ((targetsExternalZone || isLegacyLanIn) && matchingTarget == "WEB" && webDomains?.Count > 0)
             {
-                // Check if web domains include DNS providers
-                var dnsProviderDomains = webDomains.Where(d =>
-                    DnsProviderPatterns.Any(pattern => d.Contains(pattern, StringComparison.OrdinalIgnoreCase))
-                ).ToList();
+                var (matchedCount, matchedProviders) = DohProviderRegistry.MatchKnownDohDomains(webDomains);
 
-                if (dnsProviderDomains.Count > 0)
+                if (RequiredDohProviders.IsSubsetOf(matchedProviders))
                 {
-                    // DoH blocking (TCP 443)
-                    if (FirewallGroupHelper.RuleBlocksPortAndProtocol(rule, "443", "tcp"))
+                    var blocksDoh = FirewallGroupHelper.RuleBlocksPortAndProtocol(rule, "443", "tcp");
+                    var blocksDoh3 = FirewallGroupHelper.RuleBlocksPortAndProtocol(rule, "443", "udp");
+
+                    if (blocksDoh)
                     {
                         result.HasDohBlockRule = true;
-                        foreach (var domain in dnsProviderDomains)
+                        result.DohRuleName ??= name;
+                        foreach (var domain in webDomains)
                         {
-                            if (!result.DohBlockedDomains.Contains(domain))
+                            if (DohProviderRegistry.IdentifyProvider(domain) != null && !result.DohBlockedDomains.Contains(domain))
                                 result.DohBlockedDomains.Add(domain);
                         }
-                        result.DohRuleName = name;
-                        _logger.LogDebug("Found DoH block rule: {Name} (zone={Zone}) with {Count} DNS domains",
-                            name, destZoneId ?? "any", dnsProviderDomains.Count);
+                        _logger.LogDebug("Found DoH block rule: {Name} (zone={Zone}) matched {Count} domains across {ProviderCount} providers: {Providers}",
+                            name, destZoneId ?? "any", matchedCount, matchedProviders.Count, string.Join(", ", matchedProviders));
                     }
 
-                    // DoH3 blocking (UDP 443 / HTTP/3 over QUIC)
-                    if (FirewallGroupHelper.RuleBlocksPortAndProtocol(rule, "443", "udp"))
+                    if (blocksDoh3)
                     {
                         result.HasDoh3BlockRule = true;
-                        result.Doh3RuleName = name;
-                        _logger.LogDebug("Found DoH3 block rule: {Name} (zone={Zone}) with {Count} DNS domains",
-                            name, destZoneId ?? "any", dnsProviderDomains.Count);
+                        result.Doh3RuleName ??= name;
+                        _logger.LogDebug("Found DoH3 block rule: {Name} (zone={Zone}) matched {Count} domains across {ProviderCount} providers: {Providers}",
+                            name, destZoneId ?? "any", matchedCount, matchedProviders.Count, string.Join(", ", matchedProviders));
                     }
                 }
             }

--- a/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
@@ -26,12 +26,9 @@ public class DnsSecurityAnalyzer
         "Cloudflare", "Google", "Quad9", "OpenDNS"
     };
 
-    // Thresholds for IP-based DoH detection. A rule's destination IP list must
-    // match this many known DoH provider IPs spanning this many distinct providers
-    // before the rule is credited as DoH-bypass blocking. Avoids false positives
+    // IP-based DoH detection still requires a minimum IP count to avoid false positives
     // from rules that incidentally block one or two DoH IPs for unrelated reasons.
     private const int MinDohIpMatches = 3;
-    private const int MinDohProvidersMatched = 2;
 
     private readonly ThirdPartyDnsDetector _thirdPartyDetector;
 
@@ -629,7 +626,7 @@ public class DnsSecurityAnalyzer
                 {
                     var (matchedCount, matchedProviders) = DohProviderRegistry.MatchKnownDohIps(rule.DestinationIps);
 
-                    if (matchedCount >= MinDohIpMatches && matchedProviders.Count >= MinDohProvidersMatched)
+                    if (matchedCount >= MinDohIpMatches && RequiredDohProviders.IsSubsetOf(matchedProviders))
                     {
                         if (blocksDoh)
                         {

--- a/src/NetworkOptimizer.Audit/Dns/DohProviderRegistry.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DohProviderRegistry.cs
@@ -185,6 +185,30 @@ public static class DohProviderRegistry
     }
 
     /// <summary>
+    /// Match a list of domain names against known DoH providers.
+    /// </summary>
+    public static (int MatchedCount, HashSet<string> MatchedProviders) MatchKnownDohDomains(IEnumerable<string> domains)
+    {
+        var matchedProviders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        int matchedCount = 0;
+
+        foreach (var domain in domains)
+        {
+            if (string.IsNullOrEmpty(domain))
+                continue;
+
+            var provider = IdentifyProvider(domain);
+            if (provider != null)
+            {
+                matchedCount++;
+                matchedProviders.Add(provider.Name);
+            }
+        }
+
+        return (matchedCount, matchedProviders);
+    }
+
+    /// <summary>
     /// Match a list of IP addresses against known DoH providers. Returns the total number
     /// of IPs that match a known provider and the set of distinct provider names matched.
     /// Used to detect IP-based DoH-blocking firewall rules where the destination is a list

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
@@ -528,7 +528,7 @@ public class DnsSecurityAnalyzerTests : IDisposable
                 ""destination"": {
                     ""port"": ""443"",
                     ""matching_target"": ""IP"",
-                    ""ips"": [""1.1.1.1"", ""8.8.8.8"", ""9.9.9.9"", ""94.140.14.14""]
+                    ""ips"": [""1.1.1.1"", ""8.8.8.8"", ""9.9.9.9"", ""94.140.14.14"", ""208.67.222.222""]
                 }
             }
         ]").RootElement;
@@ -602,7 +602,7 @@ public class DnsSecurityAnalyzerTests : IDisposable
                 ""destination"": {
                     ""port"": ""443"",
                     ""matching_target"": ""IP"",
-                    ""ips"": [""1.1.1.1"", ""8.8.8.8"", ""9.9.9.9""]
+                    ""ips"": [""1.1.1.1"", ""8.8.8.8"", ""9.9.9.9"", ""208.67.222.222""]
                 }
             }
         ]").RootElement;
@@ -627,7 +627,7 @@ public class DnsSecurityAnalyzerTests : IDisposable
                 ""destination"": {
                     ""port"": ""443"",
                     ""matching_target"": ""IP"",
-                    ""ips"": [""1.1.1.1"", ""8.8.8.8"", ""9.9.9.9""]
+                    ""ips"": [""1.1.1.1"", ""8.8.8.8"", ""9.9.9.9"", ""208.67.222.222""]
                 }
             }
         ]").RootElement;
@@ -672,7 +672,8 @@ public class DnsSecurityAnalyzerTests : IDisposable
                     "1.1.1.1", "1.0.0.1",
                     "8.8.8.8", "8.8.4.4",
                     "9.9.9.9", "149.112.112.112",
-                    "94.140.14.14", "94.140.15.15"
+                    "94.140.14.14", "94.140.15.15",
+                    "208.67.222.222", "208.67.220.220"
                 }
             }
         };

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
@@ -420,6 +420,7 @@ public class DnsSecurityAnalyzerTests : IDisposable
     [Fact]
     public async Task Analyze_WithDohBlockRule_DetectsRule()
     {
+        // Must cover all 4 required providers: Cloudflare, Google, Quad9, OpenDNS
         var firewall = JsonDocument.Parse(@"[
             {
                 ""name"": ""Block DoH Bypass"",
@@ -428,7 +429,7 @@ public class DnsSecurityAnalyzerTests : IDisposable
                 ""destination"": {
                     ""port"": ""443"",
                     ""matching_target"": ""WEB"",
-                    ""web_domains"": [""dns.google"", ""cloudflare-dns.com""]
+                    ""web_domains"": [""dns.google"", ""cloudflare-dns.com"", ""dns.quad9.net"", ""doh.opendns.com""]
                 }
             }
         ]").RootElement;
@@ -438,6 +439,78 @@ public class DnsSecurityAnalyzerTests : IDisposable
         result.HasDohBlockRule.Should().BeTrue();
         result.DohBlockedDomains.Should().Contain("dns.google");
         result.DohBlockedDomains.Should().Contain("cloudflare-dns.com");
+        result.DohBlockedDomains.Should().Contain("dns.quad9.net");
+        result.DohBlockedDomains.Should().Contain("doh.opendns.com");
+    }
+
+    [Fact]
+    public async Task Analyze_WithDohBlockRule_MissingRequiredProvider_DoesNotDetect()
+    {
+        // Only 3 of 4 required providers (missing OpenDNS) - should not get credit
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Partial DoH Block"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""destination"": {
+                    ""port"": ""443"",
+                    ""matching_target"": ""WEB"",
+                    ""web_domains"": [""dns.google"", ""cloudflare-dns.com"", ""dns.quad9.net""]
+                }
+            }
+        ]").RootElement;
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall));
+
+        result.HasDohBlockRule.Should().BeFalse("missing OpenDNS means incomplete provider coverage");
+    }
+
+    [Fact]
+    public async Task Analyze_WithDohBlockRule_SingleProvider_DoesNotDetect()
+    {
+        // A single provider domain should not get credit, even with many variants
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block Cloudflare DNS"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""destination"": {
+                    ""port"": ""443"",
+                    ""matching_target"": ""WEB"",
+                    ""web_domains"": [""cloudflare-dns.com"", ""one.one.one.one"", ""dns.cloudflare.com"", ""family.cloudflare-dns.com""]
+                }
+            }
+        ]").RootElement;
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall));
+
+        result.HasDohBlockRule.Should().BeFalse("blocking only Cloudflare variants does not cover other major providers");
+    }
+
+    [Fact]
+    public async Task Analyze_WithDohBlockRule_AllRequiredPlusExtras_DetectsRule()
+    {
+        // All 4 required providers plus extras - comprehensive blocklist like a real deployment
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block DoH Bypass (Full)"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""destination"": {
+                    ""port"": ""443"",
+                    ""matching_target"": ""WEB"",
+                    ""web_domains"": [
+                        ""dns.google"", ""cloudflare-dns.com"", ""dns.quad9.net"", ""doh.opendns.com"",
+                        ""dns.adguard.com"", ""dns.nextdns.io"", ""doh.cleanbrowsing.org""
+                    ]
+                }
+            }
+        ]").RootElement;
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall));
+
+        result.HasDohBlockRule.Should().BeTrue();
+        result.DohBlockedDomains.Should().HaveCountGreaterThanOrEqualTo(7);
     }
 
     [Fact]
@@ -724,7 +797,7 @@ public class DnsSecurityAnalyzerTests : IDisposable
                 ""destination"": {
                     ""port"": ""443"",
                     ""matching_target"": ""WEB"",
-                    ""web_domains"": [""dns.google""]
+                    ""web_domains"": [""dns.google"", ""cloudflare-dns.com"", ""dns.quad9.net"", ""doh.opendns.com""]
                 }
             }
         ]").RootElement;
@@ -748,7 +821,7 @@ public class DnsSecurityAnalyzerTests : IDisposable
                 ""destination"": {
                     ""port"": ""443"",
                     ""matching_target"": ""WEB"",
-                    ""web_domains"": [""dns.google""]
+                    ""web_domains"": [""dns.google"", ""cloudflare-dns.com"", ""dns.quad9.net"", ""doh.opendns.com""]
                 }
             }
         ]").RootElement;
@@ -2540,7 +2613,7 @@ public class DnsSecurityAnalyzerTests : IDisposable
         var firewall = JsonDocument.Parse(@"[
             { ""name"": ""Block DNS"", ""enabled"": true, ""action"": ""drop"", ""destination"": { ""port"": ""53"" } },
             { ""name"": ""Block DoT"", ""enabled"": true, ""action"": ""drop"", ""destination"": { ""port"": ""853"" } },
-            { ""name"": ""Block DoH"", ""enabled"": true, ""action"": ""drop"", ""destination"": { ""port"": ""443"", ""matching_target"": ""WEB"", ""web_domains"": [""dns.google""] } }
+            { ""name"": ""Block DoH"", ""enabled"": true, ""action"": ""drop"", ""destination"": { ""port"": ""443"", ""matching_target"": ""WEB"", ""web_domains"": [""dns.google"", ""cloudflare-dns.com"", ""dns.quad9.net"", ""doh.opendns.com""] } }
         ]").RootElement;
 
         var result = await _analyzer.AnalyzeAsync(settings, ParseFirewallRules(firewall));
@@ -2588,7 +2661,7 @@ public class DnsSecurityAnalyzerTests : IDisposable
                 ""enabled"": true,
                 ""action"": ""drop"",
                 ""source"": { ""matching_target"": ""ANY"" },
-                ""destination"": { ""port"": ""443"", ""matching_target"": ""WEB"", ""web_domains"": [""dns.google""] }
+                ""destination"": { ""port"": ""443"", ""matching_target"": ""WEB"", ""web_domains"": [""dns.google"", ""cloudflare-dns.com"", ""dns.quad9.net"", ""doh.opendns.com""] }
             }
         ]").RootElement;
 
@@ -4176,7 +4249,7 @@ public class DnsSecurityAnalyzerTests : IDisposable
         var firewall = JsonDocument.Parse(@"[
             { ""name"": ""Block DNS"", ""enabled"": true, ""action"": ""drop"", ""protocol"": ""udp"", ""destination"": { ""port"": ""53"" } },
             { ""name"": ""Block DoT/DoQ"", ""enabled"": true, ""action"": ""drop"", ""protocol"": ""tcp_udp"", ""destination"": { ""port"": ""853"" } },
-            { ""name"": ""Block DoH"", ""enabled"": true, ""action"": ""drop"", ""protocol"": ""tcp"", ""destination"": { ""port"": ""443"", ""matching_target"": ""WEB"", ""web_domains"": [""dns.google""] } }
+            { ""name"": ""Block DoH"", ""enabled"": true, ""action"": ""drop"", ""protocol"": ""tcp"", ""destination"": { ""port"": ""443"", ""matching_target"": ""WEB"", ""web_domains"": [""dns.google"", ""cloudflare-dns.com"", ""dns.quad9.net"", ""doh.opendns.com""] } }
         ]").RootElement;
 
         var deviceData = JsonDocument.Parse(@"[


### PR DESCRIPTION
## Summary

- **WEB-based DoH detection** now requires domain coverage of all 4 major providers (Cloudflare, Google, Quad9, OpenDNS) instead of accepting any single domain containing "dns". Uses `DohProviderRegistry.IdentifyProvider()` for precise matching.
- **IP-based DoH detection** (added in #656) upgraded from "2+ providers" to requiring the same 4 providers, aligning both detection paths.
- Adds `MatchKnownDohDomains()` to `DohProviderRegistry`, mirroring the `MatchKnownDohIps()` pattern from #656.

Previously, a rule blocking only `dns.google` passed the audit even though clients could still bypass DNS via Cloudflare, Quad9, OpenDNS, etc. Now all three detection paths have meaningful coverage requirements:
- **WEB**: all 4 required providers in the domain list
- **IP**: all 4 required providers in the IP list (+ minimum 3 IP count)
- **APP** (DPI): unchanged (single app ID match - this is a DPI signature, not a user-curated list)

## Test plan

- [x] 306/306 audit tests pass
- [x] 0 build warnings
- [x] Run audit on NAS site with WEB-based DoH block rule covering all 4 providers - should pass
- [x] Run audit with partial provider coverage - should flag DNS-LEAK-003