### PR TITLE
DNS audit: NextDNS detection, IP-based DoH rules, stricter provider matching

### DIFF
--- a/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
@@ -803,14 +803,14 @@ public class DnsSecurityAnalyzer
                 var dnsServerIps = result.ThirdPartyDnsServers.Select(t => t.DnsServerIp).Distinct().ToList();
                 var networkNames = result.ThirdPartyDnsServers.Select(t => t.NetworkName).Distinct().ToList();
 
-                // Known providers (Pi-hole, AdGuard Home) are trusted - neutral score impact
+                // Known providers (Pi-hole, AdGuard Home, NextDNS CLI) are trusted - neutral score impact
                 // Unknown third-party DNS servers get a minor penalty since we can't verify their filtering
-                var isKnownProvider = result.IsPiholeDetected || result.IsAdGuardHomeDetected;
+                var isKnownProvider = result.IsPiholeDetected || result.IsAdGuardHomeDetected || result.IsNextDnsDetected;
                 var scoreImpact = isKnownProvider ? 0 : 3; // Minor penalty for unknown providers
                 var severity = isKnownProvider ? AuditSeverity.Informational : AuditSeverity.Recommended;
                 var recommendedAction = isKnownProvider
                     ? "Verify third-party DNS provides adequate security and filtering. Consider enabling DNS firewall rules to prevent bypass."
-                    : "Configure the third-party DNS management port in Settings to enable detection. Otherwise, consider a known DNS filtering solution (Pi-hole, AdGuard Home) or CyberSecure Encrypted DNS (DoH).";
+                    : "Configure the third-party DNS management port in Settings to enable detection. Otherwise, consider a known DNS filtering solution (Pi-hole, AdGuard Home, NextDNS) or CyberSecure Encrypted DNS (DoH).";
 
                 result.Issues.Add(new AuditIssue
                 {
@@ -826,6 +826,7 @@ public class DnsSecurityAnalyzer
                         { "third_party_dns_ips", dnsServerIps },
                         { "is_pihole", result.IsPiholeDetected },
                         { "is_adguard_home", result.IsAdGuardHomeDetected },
+                        { "is_nextdns", result.IsNextDnsDetected },
                         { "is_known_provider", isKnownProvider },
                         { "affected_networks", networkNames },
                         { "provider_name", result.ThirdPartyDnsProviderName ?? "Third-Party LAN DNS" },
@@ -1992,7 +1993,7 @@ public class DnsSecurityAnalyzer
             result.HasThirdPartyDns = true;
             result.ThirdPartyDnsServers.AddRange(thirdPartyResults);
 
-            // Determine provider name (Pi-hole takes precedence, then AdGuard Home)
+            // Determine provider name (Pi-hole takes precedence, then AdGuard Home, then NextDNS CLI)
             if (thirdPartyResults.Any(t => t.IsPihole))
             {
                 result.ThirdPartyDnsProviderName = "Pi-hole";
@@ -2004,6 +2005,12 @@ public class DnsSecurityAnalyzer
                 result.ThirdPartyDnsProviderName = "AdGuard Home";
                 _logger.LogInformation("AdGuard Home detected as third-party DNS on {Count} network(s)",
                     thirdPartyResults.Count(t => t.IsAdGuardHome));
+            }
+            else if (thirdPartyResults.Any(t => t.IsNextDns))
+            {
+                result.ThirdPartyDnsProviderName = "NextDNS CLI";
+                _logger.LogInformation("NextDNS CLI detected as third-party DNS on {Count} network(s)",
+                    thirdPartyResults.Count(t => t.IsNextDns));
             }
             else
             {
@@ -2776,6 +2783,7 @@ public class DnsSecurityResult
     public List<ThirdPartyDnsDetector.ThirdPartyDnsInfo> ThirdPartyDnsServers { get; } = new();
     public bool IsPiholeDetected => ThirdPartyDnsServers.Any(t => t.IsPihole);
     public bool IsAdGuardHomeDetected => ThirdPartyDnsServers.Any(t => t.IsAdGuardHome);
+    public bool IsNextDnsDetected => ThirdPartyDnsServers.Any(t => t.IsNextDns);
     public string? ThirdPartyDnsProviderName { get; set; }
 
     /// <summary>

--- a/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
@@ -33,6 +33,13 @@ public class DnsSecurityAnalyzer
         "one.one.one"  // Cloudflare 1.1.1.1 alternate domain
     ];
 
+    // Thresholds for IP-based DoH detection. A rule's destination IP list must
+    // match this many known DoH provider IPs spanning this many distinct providers
+    // before the rule is credited as DoH-bypass blocking. Avoids false positives
+    // from rules that incidentally block one or two DoH IPs for unrelated reasons.
+    private const int MinDohIpMatches = 3;
+    private const int MinDohProvidersMatched = 2;
+
     private readonly ThirdPartyDnsDetector _thirdPartyDetector;
 
     public DnsSecurityAnalyzer(ILogger<DnsSecurityAnalyzer> logger, ThirdPartyDnsDetector thirdPartyDetector)
@@ -612,6 +619,41 @@ public class DnsSecurityAnalyzer
                         result.Doh3RuleName = name;
                         _logger.LogDebug("Found DoH3 block rule: {Name} (zone={Zone}) with {Count} DNS domains",
                             name, destZoneId ?? "any", dnsProviderDomains.Count);
+                    }
+                }
+            }
+
+            // Check for IP-based DoH/DoH3 blocking (destination is a list of known DoH provider IPs).
+            // Catches rules using an IP group or inline IP list of DoH endpoints, which UniFi users
+            // frequently deploy as the primary or supplemental DoH-bypass mechanism. The MinDoh*
+            // thresholds avoid false positives from rules that happen to block one or two DoH IPs
+            // for unrelated reasons.
+            if ((targetsExternalZone || isLegacyLanIn) && matchingTarget == "IP" && rule.DestinationIps?.Count > 0)
+            {
+                var blocksDoh = FirewallGroupHelper.RuleBlocksPortAndProtocol(rule, "443", "tcp");
+                var blocksDoh3 = FirewallGroupHelper.RuleBlocksPortAndProtocol(rule, "443", "udp");
+
+                if (blocksDoh || blocksDoh3)
+                {
+                    var (matchedCount, matchedProviders) = DohProviderRegistry.MatchKnownDohIps(rule.DestinationIps);
+
+                    if (matchedCount >= MinDohIpMatches && matchedProviders.Count >= MinDohProvidersMatched)
+                    {
+                        if (blocksDoh)
+                        {
+                            result.HasDohBlockRule = true;
+                            result.DohRuleName ??= name;
+                            _logger.LogDebug("Found IP-based DoH block rule: {Name} (zone={Zone}) matched {Count} IPs across {ProviderCount} providers: {Providers}",
+                                name, destZoneId ?? "any", matchedCount, matchedProviders.Count, string.Join(", ", matchedProviders));
+                        }
+
+                        if (blocksDoh3)
+                        {
+                            result.HasDoh3BlockRule = true;
+                            result.Doh3RuleName ??= name;
+                            _logger.LogDebug("Found IP-based DoH3 block rule: {Name} (zone={Zone}) matched {Count} IPs across {ProviderCount} providers: {Providers}",
+                                name, destZoneId ?? "any", matchedCount, matchedProviders.Count, string.Join(", ", matchedProviders));
+                        }
                     }
                 }
             }

--- a/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
@@ -20,25 +20,15 @@ public class DnsSecurityAnalyzer
     private const string SettingsKeyDns = "dns";
     private const string SettingsKeyWanDns = "wan_dns";
 
-    // DNS provider domain patterns for detecting DoH/DoQ block rules
-    private static readonly string[] DnsProviderPatterns =
-    [
-        "dns",
-        "doh",
-        "cloudflare-dns",
-        "quad9",
-        "nextdns",
-        "adguard",
-        "opendns",
-        "one.one.one"  // Cloudflare 1.1.1.1 alternate domain
-    ];
+    // WEB and IP-based DoH detection requires coverage of all 4 major providers
+    private static readonly HashSet<string> RequiredDohProviders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Cloudflare", "Google", "Quad9", "OpenDNS"
+    };
 
-    // Thresholds for IP-based DoH detection. A rule's destination IP list must
-    // match this many known DoH provider IPs spanning this many distinct providers
-    // before the rule is credited as DoH-bypass blocking. Avoids false positives
+    // IP-based DoH detection still requires a minimum IP count to avoid false positives
     // from rules that incidentally block one or two DoH IPs for unrelated reasons.
     private const int MinDohIpMatches = 3;
-    private const int MinDohProvidersMatched = 2;
 
     private readonly ThirdPartyDnsDetector _thirdPartyDetector;
 
@@ -586,39 +576,38 @@ public class DnsSecurityAnalyzer
                 }
             }
 
-            // Check for DoH/DoH3 blocking (port 443 with web domains containing DNS providers)
-            // DoH = TCP 443 (HTTP/2), DoH3 = UDP 443 (HTTP/3 over QUIC)
-            // For legacy systems, LAN_IN is also acceptable (gateway's DoH goes to configured providers, not blocked IPs)
+            // Check for DoH/DoH3 blocking (port 443 with web domains covering major DoH providers).
+            // Requires all 4 major providers (Cloudflare, Google, Quad9, OpenDNS) to be covered
+            // to prevent partial blocks from getting credit. Uses DohProviderRegistry hostname
+            // matching rather than loose substring patterns.
             if ((targetsExternalZone || isLegacyLanIn) && matchingTarget == "WEB" && webDomains?.Count > 0)
             {
-                // Check if web domains include DNS providers
-                var dnsProviderDomains = webDomains.Where(d =>
-                    DnsProviderPatterns.Any(pattern => d.Contains(pattern, StringComparison.OrdinalIgnoreCase))
-                ).ToList();
+                var (matchedCount, matchedProviders) = DohProviderRegistry.MatchKnownDohDomains(webDomains);
 
-                if (dnsProviderDomains.Count > 0)
+                if (RequiredDohProviders.IsSubsetOf(matchedProviders))
                 {
-                    // DoH blocking (TCP 443)
-                    if (FirewallGroupHelper.RuleBlocksPortAndProtocol(rule, "443", "tcp"))
+                    var blocksDoh = FirewallGroupHelper.RuleBlocksPortAndProtocol(rule, "443", "tcp");
+                    var blocksDoh3 = FirewallGroupHelper.RuleBlocksPortAndProtocol(rule, "443", "udp");
+
+                    if (blocksDoh)
                     {
                         result.HasDohBlockRule = true;
-                        foreach (var domain in dnsProviderDomains)
+                        result.DohRuleName ??= name;
+                        foreach (var domain in webDomains)
                         {
-                            if (!result.DohBlockedDomains.Contains(domain))
+                            if (DohProviderRegistry.IdentifyProvider(domain) != null && !result.DohBlockedDomains.Contains(domain))
                                 result.DohBlockedDomains.Add(domain);
                         }
-                        result.DohRuleName = name;
-                        _logger.LogDebug("Found DoH block rule: {Name} (zone={Zone}) with {Count} DNS domains",
-                            name, destZoneId ?? "any", dnsProviderDomains.Count);
+                        _logger.LogDebug("Found DoH block rule: {Name} (zone={Zone}) matched {Count} domains across {ProviderCount} providers: {Providers}",
+                            name, destZoneId ?? "any", matchedCount, matchedProviders.Count, string.Join(", ", matchedProviders));
                     }
 
-                    // DoH3 blocking (UDP 443 / HTTP/3 over QUIC)
-                    if (FirewallGroupHelper.RuleBlocksPortAndProtocol(rule, "443", "udp"))
+                    if (blocksDoh3)
                     {
                         result.HasDoh3BlockRule = true;
-                        result.Doh3RuleName = name;
-                        _logger.LogDebug("Found DoH3 block rule: {Name} (zone={Zone}) with {Count} DNS domains",
-                            name, destZoneId ?? "any", dnsProviderDomains.Count);
+                        result.Doh3RuleName ??= name;
+                        _logger.LogDebug("Found DoH3 block rule: {Name} (zone={Zone}) matched {Count} domains across {ProviderCount} providers: {Providers}",
+                            name, destZoneId ?? "any", matchedCount, matchedProviders.Count, string.Join(", ", matchedProviders));
                     }
                 }
             }
@@ -637,7 +626,7 @@ public class DnsSecurityAnalyzer
                 {
                     var (matchedCount, matchedProviders) = DohProviderRegistry.MatchKnownDohIps(rule.DestinationIps);
 
-                    if (matchedCount >= MinDohIpMatches && matchedProviders.Count >= MinDohProvidersMatched)
+                    if (matchedCount >= MinDohIpMatches && RequiredDohProviders.IsSubsetOf(matchedProviders))
                     {
                         if (blocksDoh)
                         {

--- a/src/NetworkOptimizer.Audit/Dns/DohProviderRegistry.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DohProviderRegistry.cs
@@ -185,6 +185,34 @@ public static class DohProviderRegistry
     }
 
     /// <summary>
+    /// Match a list of IP addresses against known DoH providers. Returns the total number
+    /// of IPs that match a known provider and the set of distinct provider names matched.
+    /// Used to detect IP-based DoH-blocking firewall rules where the destination is a list
+    /// of provider IPs (typically referenced via an IP group) rather than a hostname or
+    /// DPI app reference.
+    /// </summary>
+    public static (int MatchedCount, HashSet<string> MatchedProviders) MatchKnownDohIps(IEnumerable<string> ips)
+    {
+        var matchedProviders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        int matchedCount = 0;
+
+        foreach (var ip in ips)
+        {
+            if (string.IsNullOrEmpty(ip))
+                continue;
+
+            var provider = IdentifyProviderFromIp(ip);
+            if (provider != null)
+            {
+                matchedCount++;
+                matchedProviders.Add(provider.Name);
+            }
+        }
+
+        return (matchedCount, matchedProviders);
+    }
+
+    /// <summary>
     /// Identify a provider from a DNS IP address using PTR lookup (authoritative) with static IP fallback.
     /// PTR lookup is tried first and takes priority when successful.
     /// Static IP matching (e.g., "45.90." prefix for NextDNS) is only used as fallback when PTR fails.

--- a/src/NetworkOptimizer.Audit/Dns/DohProviderRegistry.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DohProviderRegistry.cs
@@ -185,6 +185,30 @@ public static class DohProviderRegistry
     }
 
     /// <summary>
+    /// Match a list of domain names against known DoH providers.
+    /// </summary>
+    public static (int MatchedCount, HashSet<string> MatchedProviders) MatchKnownDohDomains(IEnumerable<string> domains)
+    {
+        var matchedProviders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        int matchedCount = 0;
+
+        foreach (var domain in domains)
+        {
+            if (string.IsNullOrEmpty(domain))
+                continue;
+
+            var provider = IdentifyProvider(domain);
+            if (provider != null)
+            {
+                matchedCount++;
+                matchedProviders.Add(provider.Name);
+            }
+        }
+
+        return (matchedCount, matchedProviders);
+    }
+
+    /// <summary>
     /// Match a list of IP addresses against known DoH providers. Returns the total number
     /// of IPs that match a known provider and the set of distinct provider names matched.
     /// Used to detect IP-based DoH-blocking firewall rules where the destination is a list

--- a/src/NetworkOptimizer.Audit/Dns/ThirdPartyDnsDetector.cs
+++ b/src/NetworkOptimizer.Audit/Dns/ThirdPartyDnsDetector.cs
@@ -1,5 +1,8 @@
 using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
 using System.Text.Json;
+using DnsClient;
 using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Audit.Models;
 using NetworkOptimizer.Core.Helpers;
@@ -33,6 +36,8 @@ public class ThirdPartyDnsDetector
         public string? PiholeVersion { get; init; }
         public bool IsAdGuardHome { get; init; }
         public string? AdGuardHomeVersion { get; init; }
+        public bool IsNextDns { get; init; }
+        public string? NextDnsProfile { get; init; }
         public string DnsProviderName { get; init; } = "Third-Party LAN DNS";
     }
 
@@ -117,6 +122,8 @@ public class ThirdPartyDnsDetector
                 string? piholeVersion = null;
                 bool isAdGuardHome = false;
                 string? adGuardHomeVersion = null;
+                bool isNextDns = false;
+                string? nextDnsProfile = null;
                 string providerName = "Third-Party LAN DNS";
 
                 if (!probedIps.Contains(dnsServer))
@@ -139,6 +146,18 @@ public class ThirdPartyDnsDetector
                             providerName = "AdGuard Home";
                             _logger.LogInformation("Detected AdGuard Home at {Ip} (version: {Version})", dnsServer, adGuardHomeVersion ?? "unknown");
                         }
+                        else
+                        {
+                            // If not AdGuard Home, try NextDNS CLI detection. This is slower than
+                            // the local-HTTP probes (requires DNS query through the resolver plus
+                            // an HTTPS round-trip to NextDNS's test endpoint), so it goes last.
+                            (isNextDns, nextDnsProfile) = await ProbeNextDnsAsync(dnsServer);
+                            if (isNextDns)
+                            {
+                                providerName = "NextDNS CLI";
+                                _logger.LogInformation("Detected NextDNS CLI at {Ip} (profile: {Profile})", dnsServer, nextDnsProfile ?? "unknown");
+                            }
+                        }
                     }
                 }
                 else
@@ -151,6 +170,8 @@ public class ThirdPartyDnsDetector
                         piholeVersion = existingResult.PiholeVersion;
                         isAdGuardHome = existingResult.IsAdGuardHome;
                         adGuardHomeVersion = existingResult.AdGuardHomeVersion;
+                        isNextDns = existingResult.IsNextDns;
+                        nextDnsProfile = existingResult.NextDnsProfile;
                         providerName = existingResult.DnsProviderName;
                     }
                 }
@@ -165,6 +186,8 @@ public class ThirdPartyDnsDetector
                     PiholeVersion = piholeVersion,
                     IsAdGuardHome = isAdGuardHome,
                     AdGuardHomeVersion = adGuardHomeVersion,
+                    IsNextDns = isNextDns,
+                    NextDnsProfile = nextDnsProfile,
                     DnsProviderName = providerName
                 });
             }
@@ -243,10 +266,192 @@ public class ThirdPartyDnsDetector
             "9.9.9.9" or "149.112.112.112" => "Quad9",
             "208.67.222.222" or "208.67.220.220" => "OpenDNS",
             "94.140.14.14" or "94.140.15.15" => "AdGuard DNS",
+            "45.90.28.0" or "45.90.30.0" => "NextDNS",
             "76.76.2.0" or "76.76.10.0" => "Control D",
             "185.228.168.9" or "185.228.169.9" => "CleanBrowsing",
             _ => null
         };
+    }
+
+    /// <summary>
+    /// Test hook: override the NextDNS probe outcome for a given DNS server IP.
+    /// When set, ProbeNextDnsAsync delegates to this delegate instead of doing
+    /// the actual DNS + HTTPS dance. The test assembly's [ModuleInitializer]
+    /// sets a safe (false, null) default at assembly load, so production code
+    /// is never exercised by unit tests by default. Tests that exercise the
+    /// probe path explicitly override this with their own outcome and then
+    /// restore the assembly-wide default in their Dispose.
+    /// </summary>
+    internal static Func<string, CancellationToken, Task<(bool IsNextDns, string? Profile)>>? NextDnsProbeOverride { get; set; }
+
+    /// <summary>
+    /// Reset the NextDNS probe override to null. Used for cleanup paths that
+    /// want production semantics (the real DNS+HTTPS probe). Test code should
+    /// generally restore TestAssemblyInit.SetSafeDefault() instead, to avoid
+    /// breaking sibling tests that inherit the assembly-wide default.
+    /// </summary>
+    internal static void ResetNextDnsProbeOverride() => NextDnsProbeOverride = null;
+
+    /// <summary>
+    /// Probe an IP address to detect if it's running NextDNS CLI.
+    /// </summary>
+    /// <remarks>
+    /// NextDNS CLI doesn't expose an HTTP admin interface, so it can't be detected
+    /// via the local-IP probes used for Pi-hole and AdGuard Home. The detection
+    /// signal lives in NextDNS's hosted test endpoint (https://test.nextdns.io),
+    /// which correlates DNS lookups to its auth servers with subsequent HTTPS
+    /// requests bearing the same random subdomain.
+    /// 
+    /// Probe steps:
+    /// 1. Generate a random subdomain {hex}.test.nextdns.io
+    /// 2. Query the audited DNS server for the subdomain's A record. If the
+    ///    audited server is NextDNS CLI, it forwards this lookup upstream to
+    ///    NextDNS via DoH, and NextDNS records the resolver IP that originated
+    ///    the query.
+    /// 3. HTTPS GET to https://{random}.test.nextdns.io with the TCP connection
+    ///    forced to the resolved IP. NextDNS's web server looks up the random
+    ///    subdomain it just saw queried, correlates it with the resolver IP,
+    ///    and returns JSON with status=ok plus clientName indicating the kind
+    ///    of NextDNS client (nextdns-cli, browser DoH, etc.).
+    /// 4. Detection succeeds if status=ok and clientName contains "nextdns".
+    /// </remarks>
+    private async Task<(bool IsNextDns, string? Profile)> ProbeNextDnsAsync(string ipAddress, CancellationToken ct = default)
+    {
+        // Test override short-circuits the real probe
+        if (NextDnsProbeOverride != null)
+        {
+            return await NextDnsProbeOverride(ipAddress, ct);
+        }
+
+        if (!IPAddress.TryParse(ipAddress, out var resolverIp))
+        {
+            return (false, null);
+        }
+
+        // Step 1: generate a random subdomain. 12 hex chars gives 48 bits of
+        // entropy - enough to avoid collisions in NextDNS's recent-query window
+        // without being unnecessarily long.
+        var randomId = Convert.ToHexString(RandomNumberGenerator.GetBytes(6)).ToLowerInvariant();
+        var hostname = $"{randomId}.test.nextdns.io";
+
+        // Step 2: DNS A-record query via the audited resolver
+        IPAddress[] resolvedIps;
+        try
+        {
+            var lookup = new LookupClient(new LookupClientOptions(resolverIp)
+            {
+                Timeout = TimeSpan.FromSeconds(2),
+                UseCache = false,
+                Retries = 0,
+                ContinueOnDnsError = false
+            });
+
+            var dnsResult = await lookup.QueryAsync(hostname, QueryType.A, cancellationToken: ct);
+            if (dnsResult.HasError)
+            {
+                _logger.LogDebug("NextDNS DNS probe: lookup error for {Hostname} via {Resolver}: {Error}",
+                    hostname, ipAddress, dnsResult.ErrorMessage);
+                return (false, null);
+            }
+
+            resolvedIps = dnsResult.Answers
+                .OfType<DnsClient.Protocol.ARecord>()
+                .Select(r => r.Address)
+                .ToArray();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "NextDNS DNS probe: lookup exception for {Hostname} via {Resolver}",
+                hostname, ipAddress);
+            return (false, null);
+        }
+
+        if (resolvedIps.Length == 0)
+        {
+            return (false, null);
+        }
+
+        // Step 3: HTTPS GET with connection pinned to the resolved IP. SNI carries
+        // the random hostname for TLS cert validation; the actual TCP connection
+        // lands on the NextDNS web server IP that the audited resolver returned.
+        var probeIp = resolvedIps[0];
+        var url = $"https://{hostname}/";
+
+        SocketsHttpHandler? probeHandler = null;
+        HttpClient? probeClient = null;
+        try
+        {
+            probeHandler = new SocketsHttpHandler
+            {
+                ConnectCallback = async (ctx, cb) =>
+                {
+                    var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+                    try
+                    {
+                        await socket.ConnectAsync(probeIp, ctx.DnsEndPoint.Port, cb);
+                        return new NetworkStream(socket, ownsSocket: true);
+                    }
+                    catch
+                    {
+                        socket.Dispose();
+                        throw;
+                    }
+                }
+            };
+
+            probeClient = new HttpClient(probeHandler, disposeHandler: false)
+            {
+                Timeout = TimeSpan.FromSeconds(3)
+            };
+
+            using var response = await probeClient.GetAsync(url, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug("NextDNS HTTPS probe: {Status} from {Hostname} via {Resolver}",
+                    (int)response.StatusCode, hostname, ipAddress);
+                return (false, null);
+            }
+
+            var json = await response.Content.ReadAsStringAsync(ct);
+            using var doc = JsonDocument.Parse(json);
+
+            if (!doc.RootElement.TryGetProperty("status", out var statusElement) ||
+                !string.Equals(statusElement.GetString(), "ok", StringComparison.OrdinalIgnoreCase))
+            {
+                return (false, null);
+            }
+
+            if (!doc.RootElement.TryGetProperty("clientName", out var clientElement))
+            {
+                return (false, null);
+            }
+
+            var clientName = clientElement.GetString();
+            if (string.IsNullOrEmpty(clientName) ||
+                clientName.IndexOf("nextdns", StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                return (false, null);
+            }
+
+            string? profile = null;
+            if (doc.RootElement.TryGetProperty("profile", out var profileElement))
+            {
+                profile = profileElement.GetString();
+            }
+
+            return (true, profile);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "NextDNS HTTPS probe: exception for {Hostname} via {Resolver}",
+                hostname, ipAddress);
+            return (false, null);
+        }
+        finally
+        {
+            probeClient?.Dispose();
+            probeHandler?.Dispose();
+        }
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Audit/NetworkOptimizer.Audit.csproj
+++ b/src/NetworkOptimizer.Audit/NetworkOptimizer.Audit.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="DnsClient" Version="1.8.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -7,8 +7,6 @@ using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Audit;
 using NetworkOptimizer.Audit.Analyzers;
 using NetworkOptimizer.Audit.Services;
-using NetworkOptimizer.Core.Enums;
-using NetworkOptimizer.WiFi.Models;
 using NetworkOptimizer.Core.Helpers;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.UniFi;
@@ -16,6 +14,7 @@ using NetworkOptimizer.Web;
 using NetworkOptimizer.Web.Endpoints;
 using NetworkOptimizer.Web.Services;
 using NetworkOptimizer.Web.Services.Ssh;
+using NetworkOptimizer.WiFi.Models;
 using Serilog;
 using Serilog.Events;
 
@@ -539,6 +538,9 @@ using (var scope = app.Services.CreateScope())
     // Apply any pending migrations (creates DB for new installs, or applies new migrations for existing)
     db.Database.Migrate();
 
+    // Ensure WAL mode - config imports replace the DB with a DELETE-mode copy
+    db.Database.ExecuteSqlRaw("PRAGMA journal_mode=WAL;");
+
     // Seed default alert rules - insert any missing rules by EventTypePattern
     {
         var defaults = NetworkOptimizer.Alerts.DefaultAlertRules.GetDefaults();
@@ -989,12 +991,27 @@ app.MapGet("/api/floor-plan/buildings", async (FloorPlanService svc) =>
     var buildings = await svc.GetBuildingsAsync();
     return Results.Ok(buildings.Select(b => new
     {
-        b.Id, b.Name, b.CenterLatitude, b.CenterLongitude, b.CreatedAt,
+        b.Id,
+        b.Name,
+        b.CenterLatitude,
+        b.CenterLongitude,
+        b.CreatedAt,
         Floors = b.Floors.Select(f => new
         {
-            f.Id, f.BuildingId, f.FloorNumber, f.Label, f.SwLatitude, f.SwLongitude,
-            f.NeLatitude, f.NeLongitude, f.Opacity, f.WallsJson, f.FloorMaterial,
-            HasImage = !string.IsNullOrEmpty(f.ImagePath), f.CreatedAt, f.UpdatedAt
+            f.Id,
+            f.BuildingId,
+            f.FloorNumber,
+            f.Label,
+            f.SwLatitude,
+            f.SwLongitude,
+            f.NeLatitude,
+            f.NeLongitude,
+            f.Opacity,
+            f.WallsJson,
+            f.FloorMaterial,
+            HasImage = !string.IsNullOrEmpty(f.ImagePath),
+            f.CreatedAt,
+            f.UpdatedAt
         })
     }));
 });
@@ -1029,9 +1046,20 @@ app.MapGet("/api/floor-plan/buildings/{id:int}/floors", async (int id, FloorPlan
     var floors = await svc.GetFloorsAsync(id);
     return Results.Ok(floors.Select(f => new
     {
-        f.Id, f.BuildingId, f.FloorNumber, f.Label, f.SwLatitude, f.SwLongitude,
-        f.NeLatitude, f.NeLongitude, f.Opacity, f.WallsJson, f.FloorMaterial,
-        HasImage = !string.IsNullOrEmpty(f.ImagePath), f.CreatedAt, f.UpdatedAt
+        f.Id,
+        f.BuildingId,
+        f.FloorNumber,
+        f.Label,
+        f.SwLatitude,
+        f.SwLongitude,
+        f.NeLatitude,
+        f.NeLongitude,
+        f.Opacity,
+        f.WallsJson,
+        f.FloorMaterial,
+        HasImage = !string.IsNullOrEmpty(f.ImagePath),
+        f.CreatedAt,
+        f.UpdatedAt
     }));
 });
 
@@ -1092,9 +1120,18 @@ app.MapGet("/api/floor-plan/floors/{floorId:int}/images", async (int floorId, Fl
     var images = await svc.GetFloorImagesAsync(floorId);
     return Results.Ok(images.Select(i => new
     {
-        i.Id, i.FloorPlanId, i.Label, i.SwLatitude, i.SwLongitude,
-        i.NeLatitude, i.NeLongitude, i.Opacity, i.RotationDeg, i.CropJson,
-        i.SortOrder, HasFile = !string.IsNullOrEmpty(i.ImagePath)
+        i.Id,
+        i.FloorPlanId,
+        i.Label,
+        i.SwLatitude,
+        i.SwLongitude,
+        i.NeLatitude,
+        i.NeLongitude,
+        i.Opacity,
+        i.RotationDeg,
+        i.CropJson,
+        i.SortOrder,
+        HasFile = !string.IsNullOrEmpty(i.ImagePath)
     }));
 });
 
@@ -1118,9 +1155,18 @@ app.MapPost("/api/floor-plan/floors/{floorId:int}/images", async (int floorId, H
     var image = await svc.CreateFloorImageAsync(floorId, stream, swLat, swLng, neLat, neLng, label);
     return Results.Ok(new
     {
-        image.Id, image.FloorPlanId, image.Label, image.SwLatitude, image.SwLongitude,
-        image.NeLatitude, image.NeLongitude, image.Opacity, image.RotationDeg, image.CropJson,
-        image.SortOrder, HasFile = true
+        image.Id,
+        image.FloorPlanId,
+        image.Label,
+        image.SwLatitude,
+        image.SwLongitude,
+        image.NeLatitude,
+        image.NeLongitude,
+        image.Opacity,
+        image.RotationDeg,
+        image.CropJson,
+        image.SortOrder,
+        HasFile = true
     });
 });
 
@@ -1141,8 +1187,17 @@ app.MapPut("/api/floor-plan/images/{imageId:int}", async (int imageId, FloorImag
     if (image == null) return Results.NotFound();
     return Results.Ok(new
     {
-        image.Id, image.FloorPlanId, image.Label, image.SwLatitude, image.SwLongitude,
-        image.NeLatitude, image.NeLongitude, image.Opacity, image.RotationDeg, image.CropJson, image.SortOrder
+        image.Id,
+        image.FloorPlanId,
+        image.Label,
+        image.SwLatitude,
+        image.SwLongitude,
+        image.NeLatitude,
+        image.NeLongitude,
+        image.Opacity,
+        image.RotationDeg,
+        image.CropJson,
+        image.SortOrder
     });
 });
 

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
@@ -420,6 +420,7 @@ public class DnsSecurityAnalyzerTests : IDisposable
     [Fact]
     public async Task Analyze_WithDohBlockRule_DetectsRule()
     {
+        // Must cover all 4 required providers: Cloudflare, Google, Quad9, OpenDNS
         var firewall = JsonDocument.Parse(@"[
             {
                 ""name"": ""Block DoH Bypass"",
@@ -428,7 +429,7 @@ public class DnsSecurityAnalyzerTests : IDisposable
                 ""destination"": {
                     ""port"": ""443"",
                     ""matching_target"": ""WEB"",
-                    ""web_domains"": [""dns.google"", ""cloudflare-dns.com""]
+                    ""web_domains"": [""dns.google"", ""cloudflare-dns.com"", ""dns.quad9.net"", ""doh.opendns.com""]
                 }
             }
         ]").RootElement;
@@ -438,6 +439,78 @@ public class DnsSecurityAnalyzerTests : IDisposable
         result.HasDohBlockRule.Should().BeTrue();
         result.DohBlockedDomains.Should().Contain("dns.google");
         result.DohBlockedDomains.Should().Contain("cloudflare-dns.com");
+        result.DohBlockedDomains.Should().Contain("dns.quad9.net");
+        result.DohBlockedDomains.Should().Contain("doh.opendns.com");
+    }
+
+    [Fact]
+    public async Task Analyze_WithDohBlockRule_MissingRequiredProvider_DoesNotDetect()
+    {
+        // Only 3 of 4 required providers (missing OpenDNS) - should not get credit
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Partial DoH Block"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""destination"": {
+                    ""port"": ""443"",
+                    ""matching_target"": ""WEB"",
+                    ""web_domains"": [""dns.google"", ""cloudflare-dns.com"", ""dns.quad9.net""]
+                }
+            }
+        ]").RootElement;
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall));
+
+        result.HasDohBlockRule.Should().BeFalse("missing OpenDNS means incomplete provider coverage");
+    }
+
+    [Fact]
+    public async Task Analyze_WithDohBlockRule_SingleProvider_DoesNotDetect()
+    {
+        // A single provider domain should not get credit, even with many variants
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block Cloudflare DNS"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""destination"": {
+                    ""port"": ""443"",
+                    ""matching_target"": ""WEB"",
+                    ""web_domains"": [""cloudflare-dns.com"", ""one.one.one.one"", ""dns.cloudflare.com"", ""family.cloudflare-dns.com""]
+                }
+            }
+        ]").RootElement;
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall));
+
+        result.HasDohBlockRule.Should().BeFalse("blocking only Cloudflare variants does not cover other major providers");
+    }
+
+    [Fact]
+    public async Task Analyze_WithDohBlockRule_AllRequiredPlusExtras_DetectsRule()
+    {
+        // All 4 required providers plus extras - comprehensive blocklist like a real deployment
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block DoH Bypass (Full)"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""destination"": {
+                    ""port"": ""443"",
+                    ""matching_target"": ""WEB"",
+                    ""web_domains"": [
+                        ""dns.google"", ""cloudflare-dns.com"", ""dns.quad9.net"", ""doh.opendns.com"",
+                        ""dns.adguard.com"", ""dns.nextdns.io"", ""doh.cleanbrowsing.org""
+                    ]
+                }
+            }
+        ]").RootElement;
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall));
+
+        result.HasDohBlockRule.Should().BeTrue();
+        result.DohBlockedDomains.Should().HaveCountGreaterThanOrEqualTo(7);
     }
 
     [Fact]
@@ -455,7 +528,7 @@ public class DnsSecurityAnalyzerTests : IDisposable
                 ""destination"": {
                     ""port"": ""443"",
                     ""matching_target"": ""IP"",
-                    ""ips"": [""1.1.1.1"", ""8.8.8.8"", ""9.9.9.9"", ""94.140.14.14""]
+                    ""ips"": [""1.1.1.1"", ""8.8.8.8"", ""9.9.9.9"", ""94.140.14.14"", ""208.67.222.222""]
                 }
             }
         ]").RootElement;
@@ -529,7 +602,7 @@ public class DnsSecurityAnalyzerTests : IDisposable
                 ""destination"": {
                     ""port"": ""443"",
                     ""matching_target"": ""IP"",
-                    ""ips"": [""1.1.1.1"", ""8.8.8.8"", ""9.9.9.9""]
+                    ""ips"": [""1.1.1.1"", ""8.8.8.8"", ""9.9.9.9"", ""208.67.222.222""]
                 }
             }
         ]").RootElement;
@@ -554,7 +627,7 @@ public class DnsSecurityAnalyzerTests : IDisposable
                 ""destination"": {
                     ""port"": ""443"",
                     ""matching_target"": ""IP"",
-                    ""ips"": [""1.1.1.1"", ""8.8.8.8"", ""9.9.9.9""]
+                    ""ips"": [""1.1.1.1"", ""8.8.8.8"", ""9.9.9.9"", ""208.67.222.222""]
                 }
             }
         ]").RootElement;
@@ -599,7 +672,8 @@ public class DnsSecurityAnalyzerTests : IDisposable
                     "1.1.1.1", "1.0.0.1",
                     "8.8.8.8", "8.8.4.4",
                     "9.9.9.9", "149.112.112.112",
-                    "94.140.14.14", "94.140.15.15"
+                    "94.140.14.14", "94.140.15.15",
+                    "208.67.222.222", "208.67.220.220"
                 }
             }
         };
@@ -724,7 +798,7 @@ public class DnsSecurityAnalyzerTests : IDisposable
                 ""destination"": {
                     ""port"": ""443"",
                     ""matching_target"": ""WEB"",
-                    ""web_domains"": [""dns.google""]
+                    ""web_domains"": [""dns.google"", ""cloudflare-dns.com"", ""dns.quad9.net"", ""doh.opendns.com""]
                 }
             }
         ]").RootElement;
@@ -748,7 +822,7 @@ public class DnsSecurityAnalyzerTests : IDisposable
                 ""destination"": {
                     ""port"": ""443"",
                     ""matching_target"": ""WEB"",
-                    ""web_domains"": [""dns.google""]
+                    ""web_domains"": [""dns.google"", ""cloudflare-dns.com"", ""dns.quad9.net"", ""doh.opendns.com""]
                 }
             }
         ]").RootElement;
@@ -2540,7 +2614,7 @@ public class DnsSecurityAnalyzerTests : IDisposable
         var firewall = JsonDocument.Parse(@"[
             { ""name"": ""Block DNS"", ""enabled"": true, ""action"": ""drop"", ""destination"": { ""port"": ""53"" } },
             { ""name"": ""Block DoT"", ""enabled"": true, ""action"": ""drop"", ""destination"": { ""port"": ""853"" } },
-            { ""name"": ""Block DoH"", ""enabled"": true, ""action"": ""drop"", ""destination"": { ""port"": ""443"", ""matching_target"": ""WEB"", ""web_domains"": [""dns.google""] } }
+            { ""name"": ""Block DoH"", ""enabled"": true, ""action"": ""drop"", ""destination"": { ""port"": ""443"", ""matching_target"": ""WEB"", ""web_domains"": [""dns.google"", ""cloudflare-dns.com"", ""dns.quad9.net"", ""doh.opendns.com""] } }
         ]").RootElement;
 
         var result = await _analyzer.AnalyzeAsync(settings, ParseFirewallRules(firewall));
@@ -2588,7 +2662,7 @@ public class DnsSecurityAnalyzerTests : IDisposable
                 ""enabled"": true,
                 ""action"": ""drop"",
                 ""source"": { ""matching_target"": ""ANY"" },
-                ""destination"": { ""port"": ""443"", ""matching_target"": ""WEB"", ""web_domains"": [""dns.google""] }
+                ""destination"": { ""port"": ""443"", ""matching_target"": ""WEB"", ""web_domains"": [""dns.google"", ""cloudflare-dns.com"", ""dns.quad9.net"", ""doh.opendns.com""] }
             }
         ]").RootElement;
 
@@ -4176,7 +4250,7 @@ public class DnsSecurityAnalyzerTests : IDisposable
         var firewall = JsonDocument.Parse(@"[
             { ""name"": ""Block DNS"", ""enabled"": true, ""action"": ""drop"", ""protocol"": ""udp"", ""destination"": { ""port"": ""53"" } },
             { ""name"": ""Block DoT/DoQ"", ""enabled"": true, ""action"": ""drop"", ""protocol"": ""tcp_udp"", ""destination"": { ""port"": ""853"" } },
-            { ""name"": ""Block DoH"", ""enabled"": true, ""action"": ""drop"", ""protocol"": ""tcp"", ""destination"": { ""port"": ""443"", ""matching_target"": ""WEB"", ""web_domains"": [""dns.google""] } }
+            { ""name"": ""Block DoH"", ""enabled"": true, ""action"": ""drop"", ""protocol"": ""tcp"", ""destination"": { ""port"": ""443"", ""matching_target"": ""WEB"", ""web_domains"": [""dns.google"", ""cloudflare-dns.com"", ""dns.quad9.net"", ""doh.opendns.com""] } }
         ]").RootElement;
 
         var deviceData = JsonDocument.Parse(@"[

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
@@ -441,6 +441,199 @@ public class DnsSecurityAnalyzerTests : IDisposable
     }
 
     [Fact]
+    public async Task Analyze_WithIpBasedDohBlockRule_DetectsRule()
+    {
+        // An IP-based rule whose destination contains a list of known DoH provider IPs
+        // should be credited as a DoH block, mirroring how UniFi users commonly deploy
+        // this control (alternative or supplement to domain-based or DPI-app-based rules).
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block Public DoH (IPs)"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""protocol"": ""tcp"",
+                ""destination"": {
+                    ""port"": ""443"",
+                    ""matching_target"": ""IP"",
+                    ""ips"": [""1.1.1.1"", ""8.8.8.8"", ""9.9.9.9"", ""94.140.14.14""]
+                }
+            }
+        ]").RootElement;
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall));
+
+        result.HasDohBlockRule.Should().BeTrue();
+        result.DohRuleName.Should().Be("Block Public DoH (IPs)");
+    }
+
+    [Fact]
+    public async Task Analyze_WithIpBasedDohRule_BelowIpThreshold_DoesNotDetect()
+    {
+        // Only 2 known DoH IPs (below MinDohIpMatches = 3) should not trigger detection.
+        // Guards against rules that incidentally block one or two DoH IPs.
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block Two DNS IPs"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""protocol"": ""tcp"",
+                ""destination"": {
+                    ""port"": ""443"",
+                    ""matching_target"": ""IP"",
+                    ""ips"": [""1.1.1.1"", ""8.8.8.8""]
+                }
+            }
+        ]").RootElement;
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall));
+
+        result.HasDohBlockRule.Should().BeFalse("two known DoH IPs is below the minimum match threshold");
+    }
+
+    [Fact]
+    public async Task Analyze_WithIpBasedDohRule_BelowProviderThreshold_DoesNotDetect()
+    {
+        // 3+ IPs matched, but all from the same provider (Cloudflare). Below
+        // MinDohProvidersMatched = 2. Real DoH bypass prevention spans multiple
+        // providers; a single-provider IP block is more likely targeted at one
+        // service for a different reason.
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block Cloudflare Resolvers"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""protocol"": ""tcp"",
+                ""destination"": {
+                    ""port"": ""443"",
+                    ""matching_target"": ""IP"",
+                    ""ips"": [""1.1.1.1"", ""1.0.0.1"", ""1.1.1.2"", ""1.0.0.2""]
+                }
+            }
+        ]").RootElement;
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall));
+
+        result.HasDohBlockRule.Should().BeFalse("a single provider is below the minimum provider threshold");
+    }
+
+    [Fact]
+    public async Task Analyze_WithIpBasedDohRule_UdpOnly_DetectsDoh3NotDoH()
+    {
+        // UDP 443 to DoH provider IPs is DoH3 (HTTP/3 over QUIC), not DoH (TCP).
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block DoH3 by IP"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""protocol"": ""udp"",
+                ""destination"": {
+                    ""port"": ""443"",
+                    ""matching_target"": ""IP"",
+                    ""ips"": [""1.1.1.1"", ""8.8.8.8"", ""9.9.9.9""]
+                }
+            }
+        ]").RootElement;
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall));
+
+        result.HasDohBlockRule.Should().BeFalse("UDP 443 is DoH3, not DoH");
+        result.HasDoh3BlockRule.Should().BeTrue();
+        result.Doh3RuleName.Should().Be("Block DoH3 by IP");
+    }
+
+    [Fact]
+    public async Task Analyze_WithIpBasedDohRule_BothProtocols_DetectsBoth()
+    {
+        // tcp_udp on port 443 to DoH provider IPs catches both DoH (TCP) and DoH3 (UDP).
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block DoH + DoH3 by IP"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""protocol"": ""tcp_udp"",
+                ""destination"": {
+                    ""port"": ""443"",
+                    ""matching_target"": ""IP"",
+                    ""ips"": [""1.1.1.1"", ""8.8.8.8"", ""9.9.9.9""]
+                }
+            }
+        ]").RootElement;
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall));
+
+        result.HasDohBlockRule.Should().BeTrue();
+        result.HasDoh3BlockRule.Should().BeTrue();
+        result.DohRuleName.Should().Be("Block DoH + DoH3 by IP");
+        result.Doh3RuleName.Should().Be("Block DoH + DoH3 by IP");
+    }
+
+    [Fact]
+    public async Task Analyze_WithIpGroupResolvedToDohIps_DetectsRule()
+    {
+        // End-to-end: rule references an IP group via OBJECT/ip_group_id, group is
+        // resolved by the parser, analyzer recognizes the resolved list as DoH IPs.
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block Public DoH (Group)"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""protocol"": ""tcp"",
+                ""destination"": {
+                    ""port"": ""443"",
+                    ""matching_target"": ""IP"",
+                    ""matching_target_type"": ""OBJECT"",
+                    ""ip_group_id"": ""doh-providers-group""
+                }
+            }
+        ]").RootElement;
+
+        var firewallGroups = new List<UniFiFirewallGroup>
+        {
+            new UniFiFirewallGroup
+            {
+                Id = "doh-providers-group",
+                Name = "DoH-Providers",
+                GroupType = "address-group",
+                GroupMembers = new List<string>
+                {
+                    "1.1.1.1", "1.0.0.1",
+                    "8.8.8.8", "8.8.4.4",
+                    "9.9.9.9", "149.112.112.112",
+                    "94.140.14.14", "94.140.15.15"
+                }
+            }
+        };
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall, firewallGroups), null, null, null, null, null);
+
+        result.HasDohBlockRule.Should().BeTrue();
+        result.DohRuleName.Should().Be("Block Public DoH (Group)");
+    }
+
+    [Fact]
+    public async Task Analyze_WithIpBasedDohRule_OnlyOneIpFromKnownProvider_DoesNotDetect()
+    {
+        // 3+ IPs but only 1 is a known DoH provider IP. Below MinDohIpMatches.
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block Mixed IPs"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""protocol"": ""tcp"",
+                ""destination"": {
+                    ""port"": ""443"",
+                    ""matching_target"": ""IP"",
+                    ""ips"": [""1.1.1.1"", ""203.0.113.5"", ""198.51.100.20"", ""192.0.2.10""]
+                }
+            }
+        ]").RootElement;
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall));
+
+        result.HasDohBlockRule.Should().BeFalse("only one known DoH IP among non-DNS addresses");
+    }
+
+    [Fact]
     public async Task Analyze_WithDoqBlockRule_DetectsRule()
     {
         // DoQ (DNS over QUIC) uses UDP 853 per RFC 9250

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/ThirdPartyDnsDetectorTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/ThirdPartyDnsDetectorTests.cs
@@ -23,6 +23,119 @@ public class ThirdPartyDnsDetectorTests : IDisposable
     public void Dispose()
     {
         DohProviderRegistry.ResetDnsResolver();
+        // Restore the assembly-wide safe default rather than nulling out the override.
+        // The module initializer in TestAssemblyInit sets this once at assembly load;
+        // nulling it here would expose subsequent tests to the real DNS+HTTPS probe.
+        TestAssemblyInit.SetSafeDefault();
+    }
+
+    [Fact]
+    public async Task DetectThirdPartyDnsAsync_NextDnsDetected_FlagsProviderAsNextDns()
+    {
+        // Pi-hole and AdGuard Home probes return 404 (not detected). NextDNS probe
+        // override returns a successful detection. Result should record IsNextDns=true
+        // and the provider name should propagate up to the orchestration layer.
+        ThirdPartyDnsDetector.NextDnsProbeOverride = (ip, ct) =>
+            Task.FromResult<(bool, string?)>((true, "fp1234567890abcdef"));
+
+        var httpClient = CreateMockHttpClient(HttpStatusCode.NotFound);
+        var detector = CreateDetector(httpClient);
+
+        var networks = new List<NetworkInfo>
+        {
+            new()
+            {
+                Id = "net1",
+                DhcpEnabled = true,
+                Name = "Trusted",
+                VlanId = 1,
+                Subnet = "10.0.0.0/24",
+                Gateway = "10.0.0.1",
+                DnsServers = new List<string> { "10.0.100.251" }
+            }
+        };
+
+        var result = await detector.DetectThirdPartyDnsAsync(networks);
+
+        result.Should().HaveCount(1);
+        result[0].DnsServerIp.Should().Be("10.0.100.251");
+        result[0].IsNextDns.Should().BeTrue();
+        result[0].NextDnsProfile.Should().Be("fp1234567890abcdef");
+        result[0].IsPihole.Should().BeFalse();
+        result[0].IsAdGuardHome.Should().BeFalse();
+        result[0].DnsProviderName.Should().Be("NextDNS CLI");
+    }
+
+    [Fact]
+    public async Task DetectThirdPartyDnsAsync_NextDnsProbeReturnsFalse_NoNextDnsFlag()
+    {
+        // All three probes fail to identify the resolver. Result should still be
+        // recorded as a third-party DNS, but with no specific provider attribution.
+        ThirdPartyDnsDetector.NextDnsProbeOverride = (ip, ct) =>
+            Task.FromResult<(bool, string?)>((false, null));
+
+        var httpClient = CreateMockHttpClient(HttpStatusCode.NotFound);
+        var detector = CreateDetector(httpClient);
+
+        var networks = new List<NetworkInfo>
+        {
+            new()
+            {
+                Id = "net1",
+                DhcpEnabled = true,
+                Name = "Trusted",
+                VlanId = 1,
+                Subnet = "10.0.0.0/24",
+                Gateway = "10.0.0.1",
+                DnsServers = new List<string> { "10.0.100.251" }
+            }
+        };
+
+        var result = await detector.DetectThirdPartyDnsAsync(networks);
+
+        result.Should().HaveCount(1);
+        result[0].IsNextDns.Should().BeFalse();
+        result[0].NextDnsProfile.Should().BeNull();
+        result[0].DnsProviderName.Should().Be("Third-Party LAN DNS");
+    }
+
+    [Fact]
+    public async Task DetectThirdPartyDnsAsync_PiholeDetected_DoesNotRunNextDnsProbe()
+    {
+        // If Pi-hole is detected first, the NextDNS probe override should never
+        // be invoked. Use a probe that would fail the test if called to enforce this.
+        var nextDnsProbeCalled = false;
+        ThirdPartyDnsDetector.NextDnsProbeOverride = (ip, ct) =>
+        {
+            nextDnsProbeCalled = true;
+            return Task.FromResult<(bool, string?)>((false, null));
+        };
+
+        // Mock HTTP client returns a valid Pi-hole API response on the probe URL
+        var piholeResponse = @"{""dns"":true,""https_port"":443,""took"":0.001}";
+        var httpClient = CreateMockHttpClient(HttpStatusCode.OK, piholeResponse);
+        var detector = CreateDetector(httpClient);
+
+        var networks = new List<NetworkInfo>
+        {
+            new()
+            {
+                Id = "net1",
+                DhcpEnabled = true,
+                Name = "Trusted",
+                VlanId = 1,
+                Subnet = "10.0.0.0/24",
+                Gateway = "10.0.0.1",
+                DnsServers = new List<string> { "10.0.100.10" }
+            }
+        };
+
+        var result = await detector.DetectThirdPartyDnsAsync(networks);
+
+        result.Should().HaveCount(1);
+        result[0].IsPihole.Should().BeTrue();
+        result[0].IsNextDns.Should().BeFalse();
+        nextDnsProbeCalled.Should().BeFalse("NextDNS probe should be skipped when Pi-hole is detected first");
     }
 
     private ThirdPartyDnsDetector CreateDetector(HttpClient? httpClient = null)
@@ -1524,6 +1637,8 @@ public class ThirdPartyDnsDetectorTests : IDisposable
     [InlineData("9.9.9.9", "Quad9")]
     [InlineData("208.67.222.222", "OpenDNS")]
     [InlineData("94.140.14.14", "AdGuard DNS")]
+    [InlineData("45.90.28.0", "NextDNS")]
+    [InlineData("45.90.30.0", "NextDNS")]
     public void DetectExternalDns_KnownProviders_ReturnsCorrectProviderName(string dnsIp, string expectedProvider)
     {
         var detector = CreateDetector();

--- a/tests/NetworkOptimizer.Audit.Tests/TestAssemblyInit.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/TestAssemblyInit.cs
@@ -1,0 +1,38 @@
+using System.Runtime.CompilerServices;
+using NetworkOptimizer.Audit.Dns;
+
+namespace NetworkOptimizer.Audit.Tests;
+
+/// <summary>
+/// Sets assembly-wide test defaults for static mockability hooks.
+/// The [ModuleInitializer] runs once at test-assembly load before any test
+/// executes, so every test in the assembly inherits these defaults without
+/// per-class constructor boilerplate.
+/// </summary>
+/// <remarks>
+/// Currently this only owns ThirdPartyDnsDetector.NextDnsProbeOverride.
+/// DohProviderRegistry.DnsResolver continues to use the existing per-file
+/// constructor/Dispose pattern - it's set in only two test classes and that
+/// scale is fine. If future work adds more test injection points, or if the
+/// DohProviderRegistry pattern picks up additional consumers, those would
+/// be good candidates to migrate into this module initializer.
+/// </remarks>
+internal static class TestAssemblyInit
+{
+    [ModuleInitializer]
+    internal static void Init() => SetSafeDefault();
+
+    /// <summary>
+    /// Sets ThirdPartyDnsDetector.NextDnsProbeOverride to a no-op that returns
+    /// (false, null) for any input. Tests that exercise the NextDNS probe path
+    /// explicitly override this with their own outcome, then call this method
+    /// in Dispose to restore the assembly-wide default rather than nulling out
+    /// the override (which would expose subsequent tests to the real DNS+HTTPS
+    /// probe and burn their 2s DnsClient timeout).
+    /// </summary>
+    internal static void SetSafeDefault()
+    {
+        ThirdPartyDnsDetector.NextDnsProbeOverride = (_, _) =>
+            Task.FromResult<(bool IsNextDns, string? Profile)>((false, null));
+    }
+}


### PR DESCRIPTION
## Summary

- **NextDNS CLI detection** - Detects NextDNS CLI running as a LAN DNS resolver via DNS + HTTPS probe to NextDNS's test.nextdns.io correlation endpoint. NextDNS joins Pi-hole and AdGuard Home as a recognized provider (no score penalty for third-party DNS).
- **IP-based DoH/DoH3 blocking detection** - Recognizes firewall rules that block DoH by destination IP (via IP group or inline list), not just web domain or DPI app. Common deployment pattern on UniFi gateways.
- **Stricter DoH provider matching** - Replaced loose substring matching with structured registry lookups. Now requires all 4 major providers (Cloudflare, Google, Quad9, OpenDNS) to be covered before crediting a DoH block rule, eliminating false positives from partial blocks.
- **WAL mode enforcement** - Ensures WAL journal mode on startup after config imports that replace the DB with a DELETE-mode copy.

## Test plan

- [x] Build: 0 warnings
- [x] All 5,697 tests pass
- [x] Privacy scan: no PII in diff
- [x] New tests for: missing provider coverage, single-provider blocks, IP threshold, IP group resolution, UDP-only (DoH3), both protocols, NextDNS probe success/failure/skip-when-pihole-detected