### PR TITLE
Fix WAN speed correlation on UDM-SE gateways

### DIFF
--- a/src/NetworkOptimizer.Monitoring/Models/InterfaceMetrics.cs
+++ b/src/NetworkOptimizer.Monitoring/Models/InterfaceMetrics.cs
@@ -21,6 +21,12 @@ public class InterfaceMetrics
     public string Name { get; set; } = string.Empty;
 
     /// <summary>
+    /// Raw ifName from SNMP (e.g. "eth8" on gateways, "0/1" on switches).
+    /// Stable physical port identifier independent of user-assigned aliases.
+    /// </summary>
+    public string PortId { get; set; } = string.Empty;
+
+    /// <summary>
     /// Interface type (ifType)
     /// </summary>
     public int Type { get; set; }

--- a/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
+++ b/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
@@ -333,7 +333,8 @@ public class SnmpPoller : ISnmpPoller
                     DeviceHostname = hostname ?? string.Empty,
                     Timestamp = DateTime.UtcNow,
                     Description = descr,
-                    Name = GetString(metadata.AliasByIdx, idx) ?? GetString(metadata.NameByIdx, idx) ?? string.Empty,
+                    Name = ResolveIfName(GetString(metadata.AliasByIdx, idx), GetString(metadata.NameByIdx, idx)),
+                    PortId = GetString(metadata.NameByIdx, idx) ?? string.Empty,
                     Type = ParseInt(metadata.TypeByIdx, idx),
                     Mtu = ParseInt(metadata.MtuByIdx, idx),
                     Speed = speed,
@@ -768,6 +769,17 @@ public class SnmpPoller : ISnmpPoller
         }
 
         return dict;
+    }
+
+    private static readonly System.Text.RegularExpressions.Regex EthNRegex = new(@"^eth\d+", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    internal static string ResolveIfName(string? ifAlias, string? ifName)
+    {
+        if (!string.IsNullOrEmpty(ifName)
+            && EthNRegex.IsMatch(ifName)
+            && (string.IsNullOrEmpty(ifAlias) || !EthNRegex.IsMatch(ifAlias)))
+            return ifName;
+        return ifAlias ?? ifName ?? string.Empty;
     }
 
     private static string? GetString(Dictionary<string, string> dict, string idx)

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -1462,23 +1462,39 @@ public class MonitoringCollectionAgent : BackgroundService
                     foreach (var dev in devArray.EnumerateArray())
                     {
                         var type = dev.TryGetProperty("type", out var tp) ? tp.GetString() : null;
-                        if (type != "ugw" && type != "udm" && type != "uxg") continue;
+                        var model = dev.TryGetProperty("model", out var mdl) ? mdl.GetString() : null;
+                        var name = dev.TryGetProperty("name", out var nm) ? nm.GetString() : null;
+                        var devType = type != null ? NetworkOptimizer.Core.Enums.DeviceTypeExtensions.FromUniFiApiType(type) : (NetworkOptimizer.Core.Enums.DeviceType?)null;
+                        if (devType != NetworkOptimizer.Core.Enums.DeviceType.Gateway)
+                        {
+                            if (type != null && (type == "ugw" || type == "usg" || type == "udm" || type == "uxg" || type == "ucg"))
+                                _logger.LogDebug("WAN ifname: device {Name} ({Model}) type={Type} classified as {DevType} - unexpected",
+                                    name, model, type, devType);
+                            continue;
+                        }
+                        _logger.LogDebug("WAN ifname: processing gateway {Name} ({Model}) type={Type}", name, model, type);
                         var mac = dev.TryGetProperty("mac", out var mp) ? mp.GetString() : null;
                         if (string.IsNullOrEmpty(mac)) continue;
                         var normalizedMac = mac.ToLowerInvariant().Replace('-', ':');
+                        bool foundWan = false;
                         for (int i = 1; i <= 6; i++)
                         {
                             if (!dev.TryGetProperty($"wan{i}", out var wanObj)) continue;
                             var uplinkIf = wanObj.TryGetProperty("uplink_ifname", out var up) ? up.GetString() : null;
+                            _logger.LogDebug("WAN ifname: {Name} wan{Idx} uplink_ifname={UplinkIf}", name, i, uplinkIf ?? "(null)");
                             if (!string.IsNullOrEmpty(uplinkIf))
                             {
                                 gwIfNames[normalizedMac] = uplinkIf;
                                 var physIf = wanObj.TryGetProperty("ifname", out var pf) ? pf.GetString() : null;
                                 if (!string.IsNullOrEmpty(physIf))
                                     gwPhysIfNames[normalizedMac] = physIf;
+                                _logger.LogDebug("WAN ifname: {Name} resolved uplink_ifname={UplinkIf} physIf={PhysIf}", name, uplinkIf, physIf ?? "(null)");
+                                foundWan = true;
                                 break;
                             }
                         }
+                        if (!foundWan)
+                            _logger.LogDebug("WAN ifname: {Name} ({Model}) - no wan1..wan6 with uplink_ifname found", name, model);
                     }
                 }
             }

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -1240,6 +1240,7 @@ public class MonitoringCollectionAgent : BackgroundService
         _ = _influx.WriteInterfaceCountersAsync(
             deviceMac: mac,
             ifName: ifName,
+            portId: iface.PortId,
             direction: InterfaceDirection.Unknown, // topology-driven direction set in a later build
             bytesIn: iface.InOctets,
             bytesOut: iface.OutOctets,

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -1468,11 +1468,11 @@ public class MonitoringCollectionAgent : BackgroundService
                         if (devType != NetworkOptimizer.Core.Enums.DeviceType.Gateway)
                         {
                             if (type != null && (type == "ugw" || type == "usg" || type == "udm" || type == "uxg" || type == "ucg"))
-                                _logger.LogDebug("WAN ifname: device {Name} ({Model}) type={Type} classified as {DevType} - unexpected",
+                                _logger.LogTrace("WAN ifname: device {Name} ({Model}) type={Type} classified as {DevType} - unexpected",
                                     name, model, type, devType);
                             continue;
                         }
-                        _logger.LogDebug("WAN ifname: processing gateway {Name} ({Model}) type={Type}", name, model, type);
+                        _logger.LogTrace("WAN ifname: processing gateway {Name} ({Model}) type={Type}", name, model, type);
                         var mac = dev.TryGetProperty("mac", out var mp) ? mp.GetString() : null;
                         if (string.IsNullOrEmpty(mac)) continue;
                         var normalizedMac = mac.ToLowerInvariant().Replace('-', ':');
@@ -1481,20 +1481,20 @@ public class MonitoringCollectionAgent : BackgroundService
                         {
                             if (!dev.TryGetProperty($"wan{i}", out var wanObj)) continue;
                             var uplinkIf = wanObj.TryGetProperty("uplink_ifname", out var up) ? up.GetString() : null;
-                            _logger.LogDebug("WAN ifname: {Name} wan{Idx} uplink_ifname={UplinkIf}", name, i, uplinkIf ?? "(null)");
+                            _logger.LogTrace("WAN ifname: {Name} wan{Idx} uplink_ifname={UplinkIf}", name, i, uplinkIf ?? "(null)");
                             if (!string.IsNullOrEmpty(uplinkIf))
                             {
                                 gwIfNames[normalizedMac] = uplinkIf;
                                 var physIf = wanObj.TryGetProperty("ifname", out var pf) ? pf.GetString() : null;
                                 if (!string.IsNullOrEmpty(physIf))
                                     gwPhysIfNames[normalizedMac] = physIf;
-                                _logger.LogDebug("WAN ifname: {Name} resolved uplink_ifname={UplinkIf} physIf={PhysIf}", name, uplinkIf, physIf ?? "(null)");
+                                _logger.LogTrace("WAN ifname: {Name} resolved uplink_ifname={UplinkIf} physIf={PhysIf}", name, uplinkIf, physIf ?? "(null)");
                                 foundWan = true;
                                 break;
                             }
                         }
                         if (!foundWan)
-                            _logger.LogDebug("WAN ifname: {Name} ({Model}) - no wan1..wan6 with uplink_ifname found", name, model);
+                            _logger.LogTrace("WAN ifname: {Name} ({Model}) - no wan1..wan6 with uplink_ifname found", name, model);
                     }
                 }
             }

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -244,6 +244,7 @@ public class MonitoringInfluxClient : IAsyncDisposable
     public Task WriteInterfaceCountersAsync(
         string deviceMac,
         string ifName,
+        string? portId,
         InterfaceDirection direction,
         long bytesIn,
         long bytesOut,
@@ -262,6 +263,7 @@ public class MonitoringInfluxClient : IAsyncDisposable
         var point = PointData.Measurement("interface_counters")
             .Tag("device_mac", NormalizeMac(deviceMac))
             .Tag("if_name", ifName)
+            .Tag("port_id", portId ?? "")
             .Tag("direction", direction.ToString().ToLowerInvariant())
             .Field("bytes_in", bytesIn)
             .Field("bytes_out", bytesOut)


### PR DESCRIPTION
## Summary

- **Fix missing WAN throughput on live stats cards for UDM-SE gateways.** The SNMP poller was preferring ifAlias over ifName when building interface keys. On UDM-SE, ifAlias contains hardware descriptions (e.g. "Realtek Semiconductor Co., Ltd. RTL8125 2.5GbE Controller") instead of Linux interface names, so the WAN lookup against `wan1.uplink_ifname` ("eth8") never matched. Now prefers ifName when it matches `eth\d+` and ifAlias does not.
- **Fix gateway type filter** in WAN interface extraction to use the canonical `FromUniFiApiType()` classification instead of a hardcoded subset (was missing `ucg` and `usg`).
- **Store raw ifName as `port_id` tag** in InfluxDB alongside the existing `if_name` tag, providing a stable physical port identifier for future correlation flexibility.

## Test plan

- [x] Verified on NAS (UCG-Fiber, type=uxg) - `if_name` values unchanged, `port_id` populating correctly
- [x] Verified on Mac (UDM-Pro-Max, type=udm) - WAN resolution working
- [x] Confirmed InfluxDB data continuity - no gaps, no double-counting, no regressions in existing switch port names
- [ ] Awaiting UDM-SE reporter confirmation that WAN Download/Upload appears on live stats card