### PR TITLE
3D map: live scrubbing and arrow key improvements

### DIFF
--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1292,7 +1292,7 @@ export class LanFlowMap {
                     if (range) {
                         const held = now - this._arrowScrubStart;
                         let step = held > 2000 ? 35 : held > 1000 ? 12 : 4;
-                        if (this._keys.shift) step *= 3;
+                        if (this._keys.shift) step *= 9;
                         const dir = this._keys['arrowright'] ? step : -step;
                         const val = Math.max(0, Math.min(10000, Number(range.value) + dir));
                         range.value = val;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1282,6 +1282,7 @@ export class LanFlowMap {
 
             // Left/right arrow: scrub timeline. Throttled to 5 ticks/sec.
             // Accelerates after holding: 4 → 12 → 35 units/tick over 2 seconds.
+            // Shift multiplies by 3x on top of acceleration.
             if (this._keys?.['arrowleft'] || this._keys?.['arrowright']) {
                 const now = performance.now();
                 if (!this._arrowScrubStart) this._arrowScrubStart = now;
@@ -1291,7 +1292,7 @@ export class LanFlowMap {
                     if (range) {
                         const held = now - this._arrowScrubStart;
                         let step = held > 2000 ? 35 : held > 1000 ? 12 : 4;
-                        if (this._keys.shift) step = Math.max(step, 35);
+                        if (this._keys.shift) step *= 3;
                         const dir = this._keys['arrowright'] ? step : -step;
                         const val = Math.max(0, Math.min(10000, Number(range.value) + dir));
                         range.value = val;
@@ -1299,6 +1300,8 @@ export class LanFlowMap {
                         range.dispatchEvent(new Event('change'));
                     }
                 }
+            } else {
+                this._arrowScrubStart = null;
             }
 
             // Freeze particle motion while paused (Live or Historic) so the

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1647,7 +1647,6 @@ export class LanFlowMap {
                 }, 1000 - elapsed);
             }
         });
-        range.addEventListener('keydown', (e) => e.preventDefault());
         // User grabbing the thumb implicitly cancels any active historic playback.
         range.addEventListener('pointerdown', () => this._stopHistoricPlayback());
         const playPause = scrubber.querySelector('[data-role="playpause"]');

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1615,11 +1615,18 @@ export class LanFlowMap {
                 }
                 this._syncSpeedLabel();
             }
+            const now = Date.now();
+            const sinceLastFire = now - this._scrubberLastFire;
             clearTimeout(this._scrubberInputDebounce);
-            this._scrubberInputDebounce = setTimeout(() => {
-                this._scrubberLastFire = Date.now();
+            if (sinceLastFire >= 500) {
+                this._scrubberLastFire = now;
                 this._onScrubberChange(val);
-            }, 500);
+            } else {
+                this._scrubberInputDebounce = setTimeout(() => {
+                    this._scrubberLastFire = Date.now();
+                    this._onScrubberChange(val);
+                }, 500 - sinceLastFire);
+            }
         });
         this._scrubberThrottleTimer = null;
         this._scrubberLastFire = 0;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -319,6 +319,7 @@ export class LanFlowMap {
         this._onKeyUp = (e) => {
             this._keys[e.key.toLowerCase()] = false;
             if (e.key === 'Shift') this._keys.shift = false;
+            if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') this._arrowScrubStart = null;
         };
         document.addEventListener('keydown', this._onKeyDown);
         document.addEventListener('keyup', this._onKeyUp);
@@ -1280,13 +1281,17 @@ export class LanFlowMap {
             }
 
             // Left/right arrow: scrub timeline. Throttled to 5 ticks/sec.
+            // Accelerates after holding: 4 → 12 → 35 units/tick over 2 seconds.
             if (this._keys?.['arrowleft'] || this._keys?.['arrowright']) {
                 const now = performance.now();
+                if (!this._arrowScrubStart) this._arrowScrubStart = now;
                 if (!this._lastArrowScrub || now - this._lastArrowScrub >= 200) {
                     this._lastArrowScrub = now;
                     const range = this._panels.scrubberRange;
                     if (range) {
-                        const step = this._keys.shift ? 35 : 4;
+                        const held = now - this._arrowScrubStart;
+                        let step = held > 2000 ? 35 : held > 1000 ? 12 : 4;
+                        if (this._keys.shift) step = Math.max(step, 35);
                         const dir = this._keys['arrowright'] ? step : -step;
                         const val = Math.max(0, Math.min(10000, Number(range.value) + dir));
                         range.value = val;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1282,7 +1282,7 @@ export class LanFlowMap {
 
             // Left/right arrow: scrub timeline. Throttled to 5 ticks/sec.
             // Accelerates after holding: 4 → 12 → 35 units/tick over 2 seconds.
-            // Shift multiplies by 3x on top of acceleration.
+            // Shift multiplies by 9x on top of acceleration.
             if (this._keys?.['arrowleft'] || this._keys?.['arrowright']) {
                 const now = performance.now();
                 if (!this._arrowScrubStart) this._arrowScrubStart = now;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1647,6 +1647,7 @@ export class LanFlowMap {
                 }, 1000 - elapsed);
             }
         });
+        range.addEventListener('keydown', (e) => e.preventDefault());
         // User grabbing the thumb implicitly cancels any active historic playback.
         range.addEventListener('pointerdown', () => this._stopHistoricPlayback());
         const playPause = scrubber.querySelector('[data-role="playpause"]');

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -303,7 +303,8 @@ export class LanFlowMap {
                     return;
                 }
             }
-            if (!this._shouldAcceptKeys()) return;
+            const scrubberFocused = document.activeElement === this._panels?.scrubberRange;
+            if (!scrubberFocused && !this._shouldAcceptKeys()) return;
             if (e.key === ' ') {
                 e.preventDefault();
                 this._togglePlayPause();

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1598,12 +1598,22 @@ export class LanFlowMap {
             </div>
         `;
         const range = scrubber.querySelector('.lan-flow-map-scrubber-range');
-        range.addEventListener('input', (e) => this._onScrubberInput(Number(e.target.value)));
+        this._scrubberInputDebounce = null;
+        range.addEventListener('input', (e) => {
+            const val = Number(e.target.value);
+            this._onScrubberInput(val);
+            clearTimeout(this._scrubberInputDebounce);
+            this._scrubberInputDebounce = setTimeout(() => {
+                this._scrubberLastFire = Date.now();
+                this._onScrubberChange(val);
+            }, 500);
+        });
         this._scrubberThrottleTimer = null;
         this._scrubberLastFire = 0;
         range.addEventListener('change', (e) => {
             const val = Number(e.target.value);
             this._onScrubberInput(val);
+            clearTimeout(this._scrubberInputDebounce);
             const now = Date.now();
             const elapsed = now - this._scrubberLastFire;
             clearTimeout(this._scrubberThrottleTimer);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1602,6 +1602,19 @@ export class LanFlowMap {
         range.addEventListener('input', (e) => {
             const val = Number(e.target.value);
             this._onScrubberInput(val);
+            if (this._mode === 'live' && val < 9998) {
+                this._mode = 'historic';
+                this._paused = true;
+                this._syncPlayPauseIcon();
+                this._stopHistoricPlayback();
+                if (this._panels.modeBadge) {
+                    this._panels.modeBadge.textContent = 'Historic';
+                    this._panels.modeBadge.classList.add('is-historic');
+                    this._panels.modeBadge.style.cursor = 'pointer';
+                    this._panels.modeBadge.setAttribute('data-tooltip', 'Click to return to live');
+                }
+                this._syncSpeedLabel();
+            }
             clearTimeout(this._scrubberInputDebounce);
             this._scrubberInputDebounce = setTimeout(() => {
                 this._scrubberLastFire = Date.now();


### PR DESCRIPTION
## Summary

- **Live scrubbing while dragging** - The 3D map and stat cards now update as you drag the timeline scrubber (throttled at 500 ms), not just on release. Immediately exits live mode when the thumb moves off the live position.
- **Arrow key scrubbing via document handler** - Arrow keys work when the scrubber is focused, routed through the existing document-level key handler instead of native input keyboard (which had flaky Shift+Arrow behavior). The native keyboard on the slider stays blocked.
- **Arrow key acceleration** - Holding an arrow key ramps from fine to coarse stepping over 2 seconds (4 → 12 → 35 units/tick). Shift maintains the original 9x multiplier on top of acceleration. Resets reliably via animation loop state.

## Test plan

- [x] Drag scrubbing: map and stat cards update while dragging, not just on release
- [x] Mode badge flips to "Historic" immediately on first thumb movement
- [x] Release fires final position without duplicate load
- [x] Arrow keys step the scrubber when focused
- [x] Shift+Arrow uses 9x multiplier (matches original ratio)
- [x] Acceleration ramps up over 2 seconds, resets on key release
- [x] 3D camera controls (WASD) unaffected when scrubber is not focused
- [x] Playback (play/pause, speed) still works correctly
- [x] Space bar toggles play/pause when scrubber is focused