### PR TITLE
Fix stale SNMPv3 warning persisting after user disables v3

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -793,16 +793,13 @@ else
             catch { }
         }, null, TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(15));
 
-        if (_snmpState == SnmpDetectionState.NotChecked && ConnectionService.IsConnected)
+        _ = Task.Run(async () =>
         {
-            await RunDetection();
-        }
-        else if (_snmpState == SnmpDetectionState.NotChecked)
-        {
-            await ConnectionService.WaitForConnectionAsync();
+            if (!ConnectionService.IsConnected)
+                await ConnectionService.WaitForConnectionAsync();
             if (ConnectionService.IsConnected)
-                await RunDetection();
-        }
+                await InvokeAsync(RunDetection);
+        });
     }
 
     private void LoadInfluxStateFromSettings(MonitoringSettings settings)
@@ -905,7 +902,7 @@ else
 
     private async void OnConnectionChanged()
     {
-        if (ConnectionService.IsConnected && _snmpState == SnmpDetectionState.NotChecked)
+        if (ConnectionService.IsConnected)
         {
             await InvokeAsync(async () =>
             {


### PR DESCRIPTION
## Summary

- SNMP detection was a one-shot that only ran when the DB state was `NotChecked`. Once a detection result was saved, the live UniFi API was never re-queried, so disabling SNMPv3 in the UniFi console had no effect on the warning.
- Detection now runs in the background on every Monitoring page load and on connection changes, updating the DB if the live state differs.
- Page renders instantly from cached DB state, then corrects itself asynchronously.

## Test plan

- [x] Enable SNMPv3 in UniFi console, visit Monitoring page, confirm v3 badge and recommendation banner appear
- [x] Disable SNMPv3, revisit Monitoring page, confirm warning clears after background detection completes
- [x] Disconnect from console, visit Monitoring page, confirm no errors (detection waits for connection)