### PR TITLE
v1.17.8

### DIFF
--- a/src/NetworkOptimizer.Monitoring/Models/InterfaceMetrics.cs
+++ b/src/NetworkOptimizer.Monitoring/Models/InterfaceMetrics.cs
@@ -21,6 +21,12 @@ public class InterfaceMetrics
     public string Name { get; set; } = string.Empty;
 
     /// <summary>
+    /// Raw ifName from SNMP (e.g. "eth8" on gateways, "0/1" on switches).
+    /// Stable physical port identifier independent of user-assigned aliases.
+    /// </summary>
+    public string PortId { get; set; } = string.Empty;
+
+    /// <summary>
     /// Interface type (ifType)
     /// </summary>
     public int Type { get; set; }

--- a/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
+++ b/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
@@ -333,7 +333,8 @@ public class SnmpPoller : ISnmpPoller
                     DeviceHostname = hostname ?? string.Empty,
                     Timestamp = DateTime.UtcNow,
                     Description = descr,
-                    Name = GetString(metadata.AliasByIdx, idx) ?? GetString(metadata.NameByIdx, idx) ?? string.Empty,
+                    Name = ResolveIfName(GetString(metadata.AliasByIdx, idx), GetString(metadata.NameByIdx, idx)),
+                    PortId = GetString(metadata.NameByIdx, idx) ?? string.Empty,
                     Type = ParseInt(metadata.TypeByIdx, idx),
                     Mtu = ParseInt(metadata.MtuByIdx, idx),
                     Speed = speed,
@@ -768,6 +769,17 @@ public class SnmpPoller : ISnmpPoller
         }
 
         return dict;
+    }
+
+    private static readonly System.Text.RegularExpressions.Regex EthNRegex = new(@"^eth\d+", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    internal static string ResolveIfName(string? ifAlias, string? ifName)
+    {
+        if (!string.IsNullOrEmpty(ifName)
+            && EthNRegex.IsMatch(ifName)
+            && (string.IsNullOrEmpty(ifAlias) || !EthNRegex.IsMatch(ifAlias)))
+            return ifName;
+        return ifAlias ?? ifName ?? string.Empty;
     }
 
     private static string? GetString(Dictionary<string, string> dict, string idx)

--- a/src/NetworkOptimizer.Threats/Enrichment/GeoEnrichmentService.cs
+++ b/src/NetworkOptimizer.Threats/Enrichment/GeoEnrichmentService.cs
@@ -243,8 +243,10 @@ public class GeoEnrichmentService : IDisposable
                     continue;
                 }
 
-                // Download to temp file, then extract
+                // Download to temp file, then extract to a staging path so we never
+                // write over an .mmdb that DatabaseReader still has open.
                 var tempPath = Path.Combine(dataPath, $"{edition}.tar.gz");
+                var stagingFile = Path.Combine(dataPath, $"{edition}.mmdb.tmp");
                 try
                 {
                     await using (var fs = File.Create(tempPath))
@@ -260,8 +262,7 @@ public class GeoEnrichmentService : IDisposable
                         continue;
                     }
 
-                    // Extract .mmdb from tar.gz using .NET built-in libraries
-                    var targetFile = Path.Combine(dataPath, $"{edition}.mmdb");
+                    // Extract .mmdb from tar.gz to a staging file
                     var extracted = false;
 
                     await using var fileStream = File.OpenRead(tempPath);
@@ -272,10 +273,10 @@ public class GeoEnrichmentService : IDisposable
                     {
                         if (entry.Name.EndsWith(".mmdb", StringComparison.OrdinalIgnoreCase) && entry.DataStream != null)
                         {
-                            await using var outFile = File.Create(targetFile);
+                            await using var outFile = File.Create(stagingFile);
                             await entry.DataStream.CopyToAsync(outFile, cancellationToken);
                             extracted = true;
-                            _logger.LogInformation("Extracted {Edition}.mmdb ({Size:F1} MB)", edition, new FileInfo(targetFile).Length / 1_048_576.0);
+                            _logger.LogInformation("Extracted {Edition}.mmdb ({Size:F1} MB)", edition, new FileInfo(stagingFile).Length / 1_048_576.0);
                             break;
                         }
                     }
@@ -297,16 +298,42 @@ public class GeoEnrichmentService : IDisposable
             }
         }
 
+        // At least one edition succeeded - dispose readers so we can replace the live files,
+        // then move staged files into place and re-initialize.
+        if (errors.Count < editions.Length)
+        {
+            DisposeReaders();
+
+            foreach (var edition in editions)
+            {
+                var staging = Path.Combine(dataPath, $"{edition}.mmdb.tmp");
+                if (!File.Exists(staging)) continue;
+                var target = Path.Combine(dataPath, $"{edition}.mmdb");
+                try
+                {
+                    File.Move(staging, target, overwrite: true);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to move staged {Edition}.mmdb into place", edition);
+                    errors.Add($"{edition}: {ex.Message}");
+                }
+            }
+
+            Initialize(dataPath);
+        }
+
+        // Clean up any leftover staging files on full failure
+        foreach (var edition in editions)
+        {
+            var staging = Path.Combine(dataPath, $"{edition}.mmdb.tmp");
+            try { if (File.Exists(staging)) File.Delete(staging); } catch { /* ignore */ }
+        }
+
         if (errors.Count == 0)
-        {
-            Reload(dataPath);
             return (true, "Both databases downloaded and loaded successfully.");
-        }
         else if (errors.Count < editions.Length)
-        {
-            Reload(dataPath);
             return (true, $"Partial success. Errors: {string.Join("; ", errors)}");
-        }
 
         return (false, $"Download failed: {string.Join("; ", errors)}");
     }
@@ -316,6 +343,12 @@ public class GeoEnrichmentService : IDisposable
     /// </summary>
     public void Reload(string dataPath)
     {
+        DisposeReaders();
+        Initialize(dataPath);
+    }
+
+    private void DisposeReaders()
+    {
         lock (_initLock)
         {
             _cityReader?.Dispose();
@@ -324,8 +357,6 @@ public class GeoEnrichmentService : IDisposable
             _asnReader = null;
             _initialized = false;
         }
-
-        Initialize(dataPath);
     }
 
     public void Dispose()

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -793,16 +793,13 @@ else
             catch { }
         }, null, TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(15));
 
-        if (_snmpState == SnmpDetectionState.NotChecked && ConnectionService.IsConnected)
+        _ = Task.Run(async () =>
         {
-            await RunDetection();
-        }
-        else if (_snmpState == SnmpDetectionState.NotChecked)
-        {
-            await ConnectionService.WaitForConnectionAsync();
+            if (!ConnectionService.IsConnected)
+                await ConnectionService.WaitForConnectionAsync();
             if (ConnectionService.IsConnected)
-                await RunDetection();
-        }
+                await InvokeAsync(RunDetection);
+        });
     }
 
     private void LoadInfluxStateFromSettings(MonitoringSettings settings)
@@ -905,7 +902,7 @@ else
 
     private async void OnConnectionChanged()
     {
-        if (ConnectionService.IsConnected && _snmpState == SnmpDetectionState.NotChecked)
+        if (ConnectionService.IsConnected)
         {
             await InvokeAsync(async () =>
             {

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -1240,6 +1240,7 @@ public class MonitoringCollectionAgent : BackgroundService
         _ = _influx.WriteInterfaceCountersAsync(
             deviceMac: mac,
             ifName: ifName,
+            portId: iface.PortId,
             direction: InterfaceDirection.Unknown, // topology-driven direction set in a later build
             bytesIn: iface.InOctets,
             bytesOut: iface.OutOctets,
@@ -1462,23 +1463,39 @@ public class MonitoringCollectionAgent : BackgroundService
                     foreach (var dev in devArray.EnumerateArray())
                     {
                         var type = dev.TryGetProperty("type", out var tp) ? tp.GetString() : null;
-                        if (type != "ugw" && type != "udm" && type != "uxg") continue;
+                        var model = dev.TryGetProperty("model", out var mdl) ? mdl.GetString() : null;
+                        var name = dev.TryGetProperty("name", out var nm) ? nm.GetString() : null;
+                        var devType = type != null ? NetworkOptimizer.Core.Enums.DeviceTypeExtensions.FromUniFiApiType(type) : (NetworkOptimizer.Core.Enums.DeviceType?)null;
+                        if (devType != NetworkOptimizer.Core.Enums.DeviceType.Gateway)
+                        {
+                            if (type != null && (type == "ugw" || type == "usg" || type == "udm" || type == "uxg" || type == "ucg"))
+                                _logger.LogTrace("WAN ifname: device {Name} ({Model}) type={Type} classified as {DevType} - unexpected",
+                                    name, model, type, devType);
+                            continue;
+                        }
+                        _logger.LogTrace("WAN ifname: processing gateway {Name} ({Model}) type={Type}", name, model, type);
                         var mac = dev.TryGetProperty("mac", out var mp) ? mp.GetString() : null;
                         if (string.IsNullOrEmpty(mac)) continue;
                         var normalizedMac = mac.ToLowerInvariant().Replace('-', ':');
+                        bool foundWan = false;
                         for (int i = 1; i <= 6; i++)
                         {
                             if (!dev.TryGetProperty($"wan{i}", out var wanObj)) continue;
                             var uplinkIf = wanObj.TryGetProperty("uplink_ifname", out var up) ? up.GetString() : null;
+                            _logger.LogTrace("WAN ifname: {Name} wan{Idx} uplink_ifname={UplinkIf}", name, i, uplinkIf ?? "(null)");
                             if (!string.IsNullOrEmpty(uplinkIf))
                             {
                                 gwIfNames[normalizedMac] = uplinkIf;
                                 var physIf = wanObj.TryGetProperty("ifname", out var pf) ? pf.GetString() : null;
                                 if (!string.IsNullOrEmpty(physIf))
                                     gwPhysIfNames[normalizedMac] = physIf;
+                                _logger.LogTrace("WAN ifname: {Name} resolved uplink_ifname={UplinkIf} physIf={PhysIf}", name, uplinkIf, physIf ?? "(null)");
+                                foundWan = true;
                                 break;
                             }
                         }
+                        if (!foundWan)
+                            _logger.LogTrace("WAN ifname: {Name} ({Model}) - no wan1..wan6 with uplink_ifname found", name, model);
                     }
                 }
             }

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -244,6 +244,7 @@ public class MonitoringInfluxClient : IAsyncDisposable
     public Task WriteInterfaceCountersAsync(
         string deviceMac,
         string ifName,
+        string? portId,
         InterfaceDirection direction,
         long bytesIn,
         long bytesOut,
@@ -262,6 +263,7 @@ public class MonitoringInfluxClient : IAsyncDisposable
         var point = PointData.Measurement("interface_counters")
             .Tag("device_mac", NormalizeMac(deviceMac))
             .Tag("if_name", ifName)
+            .Tag("port_id", portId ?? "")
             .Tag("direction", direction.ToString().ToLowerInvariant())
             .Field("bytes_in", bytesIn)
             .Field("bytes_out", bytesOut)

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -303,7 +303,8 @@ export class LanFlowMap {
                     return;
                 }
             }
-            if (!this._shouldAcceptKeys()) return;
+            const scrubberFocused = document.activeElement === this._panels?.scrubberRange;
+            if (!scrubberFocused && !this._shouldAcceptKeys()) return;
             if (e.key === ' ') {
                 e.preventDefault();
                 this._togglePlayPause();
@@ -318,6 +319,7 @@ export class LanFlowMap {
         this._onKeyUp = (e) => {
             this._keys[e.key.toLowerCase()] = false;
             if (e.key === 'Shift') this._keys.shift = false;
+            if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') this._arrowScrubStart = null;
         };
         document.addEventListener('keydown', this._onKeyDown);
         document.addEventListener('keyup', this._onKeyUp);
@@ -1279,13 +1281,18 @@ export class LanFlowMap {
             }
 
             // Left/right arrow: scrub timeline. Throttled to 5 ticks/sec.
+            // Accelerates after holding: 4 → 12 → 35 units/tick over 2 seconds.
+            // Shift multiplies by 9x on top of acceleration.
             if (this._keys?.['arrowleft'] || this._keys?.['arrowright']) {
                 const now = performance.now();
+                if (!this._arrowScrubStart) this._arrowScrubStart = now;
                 if (!this._lastArrowScrub || now - this._lastArrowScrub >= 200) {
                     this._lastArrowScrub = now;
                     const range = this._panels.scrubberRange;
                     if (range) {
-                        const step = this._keys.shift ? 35 : 4;
+                        const held = now - this._arrowScrubStart;
+                        let step = held > 2000 ? 35 : held > 1000 ? 12 : 4;
+                        if (this._keys.shift) step *= 9;
                         const dir = this._keys['arrowright'] ? step : -step;
                         const val = Math.max(0, Math.min(10000, Number(range.value) + dir));
                         range.value = val;
@@ -1293,6 +1300,8 @@ export class LanFlowMap {
                         range.dispatchEvent(new Event('change'));
                     }
                 }
+            } else {
+                this._arrowScrubStart = null;
             }
 
             // Freeze particle motion while paused (Live or Historic) so the
@@ -1598,12 +1607,42 @@ export class LanFlowMap {
             </div>
         `;
         const range = scrubber.querySelector('.lan-flow-map-scrubber-range');
-        range.addEventListener('input', (e) => this._onScrubberInput(Number(e.target.value)));
+        this._scrubberInputDebounce = null;
+        range.addEventListener('input', (e) => {
+            const val = Number(e.target.value);
+            this._onScrubberInput(val);
+            if (this._mode === 'live' && val < 9998) {
+                this._mode = 'historic';
+                this._paused = true;
+                this._syncPlayPauseIcon();
+                this._stopHistoricPlayback();
+                if (this._panels.modeBadge) {
+                    this._panels.modeBadge.textContent = 'Historic';
+                    this._panels.modeBadge.classList.add('is-historic');
+                    this._panels.modeBadge.style.cursor = 'pointer';
+                    this._panels.modeBadge.setAttribute('data-tooltip', 'Click to return to live');
+                }
+                this._syncSpeedLabel();
+            }
+            const now = Date.now();
+            const sinceLastFire = now - this._scrubberLastFire;
+            clearTimeout(this._scrubberInputDebounce);
+            if (sinceLastFire >= 500) {
+                this._scrubberLastFire = now;
+                this._onScrubberChange(val);
+            } else {
+                this._scrubberInputDebounce = setTimeout(() => {
+                    this._scrubberLastFire = Date.now();
+                    this._onScrubberChange(val);
+                }, 500 - sinceLastFire);
+            }
+        });
         this._scrubberThrottleTimer = null;
         this._scrubberLastFire = 0;
         range.addEventListener('change', (e) => {
             const val = Number(e.target.value);
             this._onScrubberInput(val);
+            clearTimeout(this._scrubberInputDebounce);
             const now = Date.now();
             const elapsed = now - this._scrubberLastFire;
             clearTimeout(this._scrubberThrottleTimer);


### PR DESCRIPTION
## Summary

- **Fix WAN speed correlation on UDM-SE gateways** (#664) - SNMP interface name resolution now prefers ifName over ifAlias when ifName matches `eth\d+`, fixing live stats cards showing no WAN throughput on UDM-SE. Also fixes the gateway type filter to include all gateway types (ucg, usg) and stores raw ifName as a `port_id` tag in InfluxDB.
- **Fix GeoLite2 download failing when DatabaseReader holds .mmdb open** (#663) - Extracts to a staging file and swaps into place after disposing readers, preventing file-in-use errors on updates.
- **3D map: live scrubbing and arrow key improvements** (#665) - Timeline scrubber now polls for historic data while dragging (throttled at 500 ms) and immediately exits live mode. Arrow keys work when the scrubber is focused, with hold-to-accelerate and 9x shift multiplier.
- **Re-detect SNMP settings on every Monitoring page load** (#666) - Runs detection in a background task and re-detects on reconnect regardless of prior state.