### PR TITLE
Monitoring: guide users to Upstream Discovery when targets aren't set

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -20,6 +20,10 @@
 @inject Microsoft.JSInterop.IJSRuntime JS
 @inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
 @inject NavigationManager NavigationManager
+@inject NetworkOptimizer.Web.Services.Monitoring.UpstreamTracerService UpstreamTracer
+
+<NavigationLock OnBeforeInternalNavigation="OnBeforeInternalNavigation"
+                ConfirmExternalNavigation="_upstreamDiscoveryPendingSave" />
 
 <PageTitle>Monitoring - Network Optimizer</PageTitle>
 
@@ -86,6 +90,24 @@ else
     @* ──────────────── Tab: Live View ──────────────── *@
     @if (_activeTab == "live" && _monitoringReady)
     {
+        var hasIspTargets = HasUpstreamTargets(MonitoringTargetType.AccessIsp);
+        var hasTransitTargets = HasUpstreamTargets(MonitoringTargetType.Transit);
+
+        if (!hasIspTargets || !hasTransitTargets)
+        {
+            <div class="alert alert-info" style="margin-bottom: 1rem;">
+                <div class="banner-content">
+                    <span class="banner-icon banner-icon-info">i</span>
+                    <div class="banner-text" style="flex: 1;">
+                        Run Upstream Discovery to identify your ISP and transit hops for latency and loss tracking.
+                    </div>
+                    <div class="banner-actions">
+                        <button class="btn btn-sm btn-primary" @onclick="NavigateToUpstreamDiscovery">Run Upstream Discovery</button>
+                    </div>
+                </div>
+            </div>
+        }
+
         <!-- Top stat cards: WAN rates, gateway RTT/loss, ISP/Transit mean RTT/loss -->
         <div class="monitoring-stat-cards">
             @{ var wanRates = GetWanRates(); }
@@ -108,20 +130,48 @@ else
             </div>
             @{ var ispTarget = GetMeanTargetStats(MonitoringTargetType.AccessIsp); }
             <div class="monitoring-stat-card">
-                <div class="stat-value">@FormatRtt(ispTarget.rtt)</div>
+                @if (hasIspTargets)
+                {
+                    <div class="stat-value">@FormatRtt(ispTarget.rtt)</div>
+                }
+                else
+                {
+                    <div class="stat-value"><span class="tooltip-icon stat-hint-icon" data-tooltip="Run Upstream Discovery to set ISP targets" @onclick="NavigateToUpstreamDiscovery">?</span></div>
+                }
                 <div class="stat-label">ISP RTT</div>
             </div>
             <div class="monitoring-stat-card">
-                <div class="stat-value @(ispTarget.loss > 0 ? "stat-danger" : "")">@FormatLoss(ispTarget.loss)</div>
+                @if (hasIspTargets)
+                {
+                    <div class="stat-value @(ispTarget.loss > 0 ? "stat-danger" : "")">@FormatLoss(ispTarget.loss)</div>
+                }
+                else
+                {
+                    <div class="stat-value"><span class="tooltip-icon stat-hint-icon" data-tooltip="Run Upstream Discovery to set ISP targets" @onclick="NavigateToUpstreamDiscovery">?</span></div>
+                }
                 <div class="stat-label">ISP Loss</div>
             </div>
             @{ var transitTarget = GetMeanTargetStats(MonitoringTargetType.Transit); }
             <div class="monitoring-stat-card">
-                <div class="stat-value">@FormatRtt(transitTarget.rtt)</div>
+                @if (hasTransitTargets)
+                {
+                    <div class="stat-value">@FormatRtt(transitTarget.rtt)</div>
+                }
+                else
+                {
+                    <div class="stat-value"><span class="tooltip-icon stat-hint-icon" data-tooltip="Run Upstream Discovery to set transit targets" @onclick="NavigateToUpstreamDiscovery">?</span></div>
+                }
                 <div class="stat-label">Transit RTT</div>
             </div>
             <div class="monitoring-stat-card">
-                <div class="stat-value @(transitTarget.loss > 0 ? "stat-danger" : "")">@FormatLoss(transitTarget.loss)</div>
+                @if (hasTransitTargets)
+                {
+                    <div class="stat-value @(transitTarget.loss > 0 ? "stat-danger" : "")">@FormatLoss(transitTarget.loss)</div>
+                }
+                else
+                {
+                    <div class="stat-value"><span class="tooltip-icon stat-hint-icon" data-tooltip="Run Upstream Discovery to set transit targets" @onclick="NavigateToUpstreamDiscovery">?</span></div>
+                }
                 <div class="stat-label">Transit Loss</div>
             </div>
         </div>
@@ -657,6 +707,12 @@ else
     .stat-danger {
         color: var(--danger-color);
     }
+    .stat-hint-icon {
+        width: 22px;
+        height: 22px;
+        font-size: 13px;
+        cursor: pointer;
+    }
     @@media (max-width: 768px) {
         .monitoring-stat-cards {
             gap: 0.5rem;
@@ -677,6 +733,9 @@ else
     public string? TabParam { get; set; }
 
     private string? _lastTabParam;
+
+    private bool _upstreamDiscoveryPendingSave =>
+        UpstreamTracer.State.Step == NetworkOptimizer.Web.Services.Monitoring.TracerStep.ReviewingResults;
 
     private SnmpDetectionState _snmpState = SnmpDetectionState.NotChecked;
     private bool _detecting;
@@ -1057,6 +1116,17 @@ else
         });
     }
 
+    private async Task OnBeforeInternalNavigation(LocationChangingContext context)
+    {
+        if (_upstreamDiscoveryPendingSave)
+        {
+            var confirmed = await JS.InvokeAsync<bool>("confirm",
+                "Upstream Discovery results haven't been saved. If you leave now, you'll need to re-run discovery.\n\nLeave without saving?");
+            if (!confirmed)
+                context.PreventNavigation();
+        }
+    }
+
     [JSInvokable]
     public async Task OnMapTimeChanged(string? isoTimestamp)
     {
@@ -1253,6 +1323,9 @@ else
     }
 
     // ─── Stat card helpers ───
+
+    private bool HasUpstreamTargets(MonitoringTargetType type) =>
+        _targets.Any(t => t.TargetType == type && t.Enabled);
 
     private (double download, double upload) GetWanRates()
     {

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -136,7 +136,7 @@ else
                 }
                 else
                 {
-                    <div class="stat-value"><span class="tooltip-icon stat-hint-icon" data-tooltip="Run Upstream Discovery to set ISP targets" @onclick="NavigateToUpstreamDiscovery">?</span></div>
+                    <div class="stat-value"><span class="tooltip-icon stat-hint-icon" data-tooltip="No targets set - <a href='/monitoring?tab=performance&amp;discover=1'>Run Upstream Discovery</a>">?</span></div>
                 }
                 <div class="stat-label">ISP RTT</div>
             </div>
@@ -147,7 +147,7 @@ else
                 }
                 else
                 {
-                    <div class="stat-value"><span class="tooltip-icon stat-hint-icon" data-tooltip="Run Upstream Discovery to set ISP targets" @onclick="NavigateToUpstreamDiscovery">?</span></div>
+                    <div class="stat-value"><span class="tooltip-icon stat-hint-icon" data-tooltip="No targets set - <a href='/monitoring?tab=performance&amp;discover=1'>Run Upstream Discovery</a>">?</span></div>
                 }
                 <div class="stat-label">ISP Loss</div>
             </div>
@@ -159,7 +159,7 @@ else
                 }
                 else
                 {
-                    <div class="stat-value"><span class="tooltip-icon stat-hint-icon" data-tooltip="Run Upstream Discovery to set transit targets" @onclick="NavigateToUpstreamDiscovery">?</span></div>
+                    <div class="stat-value"><span class="tooltip-icon stat-hint-icon" data-tooltip="No targets set - <a href='/monitoring?tab=performance&amp;discover=1'>Run Upstream Discovery</a>">?</span></div>
                 }
                 <div class="stat-label">Transit RTT</div>
             </div>
@@ -170,7 +170,7 @@ else
                 }
                 else
                 {
-                    <div class="stat-value"><span class="tooltip-icon stat-hint-icon" data-tooltip="Run Upstream Discovery to set transit targets" @onclick="NavigateToUpstreamDiscovery">?</span></div>
+                    <div class="stat-value"><span class="tooltip-icon stat-hint-icon" data-tooltip="No targets set - <a href='/monitoring?tab=performance&amp;discover=1'>Run Upstream Discovery</a>">?</span></div>
                 }
                 <div class="stat-label">Transit Loss</div>
             </div>
@@ -732,6 +732,9 @@ else
     [SupplyParameterFromQuery(Name = "tab")]
     public string? TabParam { get; set; }
 
+    [SupplyParameterFromQuery(Name = "discover")]
+    public string? DiscoverParam { get; set; }
+
     private string? _lastTabParam;
 
     private bool _upstreamDiscoveryPendingSave =>
@@ -798,14 +801,22 @@ else
         return "live";
     }
 
-    private void SetActiveTab(string tab)
+    private async void SetActiveTab(string tab)
     {
         if (tab != "setup" && !_monitoringReady) return;
+        if (_upstreamDiscoveryPendingSave && tab != _activeTab)
+        {
+            var confirmed = await JS.InvokeAsync<bool>("confirm",
+                "Upstream Discovery results haven't been saved. If you leave now, you'll need to re-run discovery.\n\nLeave without saving?");
+            if (!confirmed) return;
+        }
         _activeTab = tab;
         var uri = "/monitoring?tab=" + tab;
         NavigationManager.NavigateTo(uri, forceLoad: false, replace: false);
         _lastTabParam = tab;
     }
+
+    private bool _scrollToDiscoveryPending;
 
     protected override void OnParametersSet()
     {
@@ -820,6 +831,12 @@ else
             }
         }
         _lastTabParam = TabParam;
+
+        if (DiscoverParam == "1" && _activeTab == "performance")
+        {
+            _forceExpandUpstream = true;
+            _scrollToDiscoveryPending = true;
+        }
     }
 
     protected override async Task OnInitializedAsync()
@@ -1099,7 +1116,7 @@ else
             _activeTab = "performance";
             _forceExpandUpstream = true;
             StateHasChanged();
-            await Task.Delay(150);
+            await Task.Delay(500);
             await JS.InvokeVoidAsync("eval", @"
                 (function() {
                     var el = document.getElementById('upstream-discovery');
@@ -1627,6 +1644,25 @@ else
             _latencyChartsMounted = false;
             try { await JS.InvokeVoidAsync("eval", "window.__latencyCharts?.unmount();"); }
             catch { }
+        }
+
+        if (_scrollToDiscoveryPending && _activeTab == "performance")
+        {
+            _scrollToDiscoveryPending = false;
+            _forceExpandUpstream = false;
+            await Task.Delay(500);
+            await JS.InvokeVoidAsync("eval", @"
+                (function() {
+                    var el = document.getElementById('upstream-discovery');
+                    if (el) {
+                        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                        el.style.transition = 'outline-color 0.3s';
+                        el.style.outline = '2px solid rgba(59, 130, 246, 0.5)';
+                        el.style.outlineOffset = '4px';
+                        el.style.borderRadius = '12px';
+                        setTimeout(function() { el.style.outline = ''; el.style.outlineOffset = ''; }, 2000);
+                    }
+                })();");
         }
 
         // Device health charts - Devices tab only

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1111,26 +1111,30 @@ else
     [JSInvokable]
     public void NavigateToUpstreamDiscovery()
     {
-        InvokeAsync(async () =>
+        InvokeAsync(() =>
         {
             _activeTab = "performance";
             _forceExpandUpstream = true;
+            _scrollToDiscoveryPending = true;
             StateHasChanged();
-            await Task.Delay(500);
-            await JS.InvokeVoidAsync("eval", @"
-                (function() {
-                    var el = document.getElementById('upstream-discovery');
-                    if (el) {
-                        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                        el.style.transition = 'outline-color 0.3s';
-                        el.style.outline = '2px solid rgba(59, 130, 246, 0.5)';
-                        el.style.outlineOffset = '4px';
-                        el.style.borderRadius = '12px';
-                        setTimeout(function() { el.style.outline = ''; el.style.outlineOffset = ''; }, 2000);
-                    }
-                })();");
-            _forceExpandUpstream = false;
         });
+    }
+
+    private async Task ScrollToUpstreamDiscoveryAsync()
+    {
+        await Task.Delay(500);
+        await JS.InvokeVoidAsync("eval", @"
+            (function() {
+                var el = document.getElementById('upstream-discovery');
+                if (el) {
+                    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                    el.style.transition = 'outline-color 0.3s';
+                    el.style.outline = '2px solid rgba(59, 130, 246, 0.5)';
+                    el.style.outlineOffset = '4px';
+                    el.style.borderRadius = '12px';
+                    setTimeout(function() { el.style.outline = ''; el.style.outlineOffset = ''; }, 2000);
+                }
+            })();");
     }
 
     private async Task OnBeforeInternalNavigation(LocationChangingContext context)
@@ -1650,19 +1654,7 @@ else
         {
             _scrollToDiscoveryPending = false;
             _forceExpandUpstream = false;
-            await Task.Delay(500);
-            await JS.InvokeVoidAsync("eval", @"
-                (function() {
-                    var el = document.getElementById('upstream-discovery');
-                    if (el) {
-                        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                        el.style.transition = 'outline-color 0.3s';
-                        el.style.outline = '2px solid rgba(59, 130, 246, 0.5)';
-                        el.style.outlineOffset = '4px';
-                        el.style.borderRadius = '12px';
-                        setTimeout(function() { el.style.outline = ''; el.style.outlineOffset = ''; }, 2000);
-                    }
-                })();");
+            await ScrollToUpstreamDiscoveryAsync();
         }
 
         // Device health charts - Devices tab only

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -287,6 +287,12 @@
     private DateTime _lastReviewCheck = DateTime.MinValue;
     private bool _justSaved;
 
+    protected override void OnParametersSet()
+    {
+        if (ForceExpand && _collapsed)
+            _collapsed = false;
+    }
+
     protected override async Task OnInitializedAsync()
     {
         await Tracer.RehydrateFromDbAsync();


### PR DESCRIPTION
## Summary

- ISP/transit stat cards on the monitoring live view now show a `?` tooltip icon with a link to Upstream Discovery instead of a misleading dash or 0% when no targets are configured
- CTA banner appears above the stat cards directing users to run discovery
- Nav-away warning when upstream discovery results are pending save (tab switch, page navigation, and external navigation)
- All entry points to upstream discovery (3D map right-click, CTA banner, tooltip link) use a single scroll+highlight helper with a 500 ms delay for tab content to load
- UpstreamTracerPanel now reacts to ForceExpand parameter changes so navigating to the section always expands it

## Test plan

- [x] Verify stat cards show `?` tooltip icons when no ISP/transit targets are configured
- [x] Hover tooltip and verify it shows a clickable "Run Upstream Discovery" link
- [x] Click the tooltip link and verify it switches to Performance tab, scrolls to and highlights the upstream discovery section
- [x] Verify the CTA banner button does the same
- [x] Right-click the WAN cloud in the 3D map, click "Run Upstream Discovery", verify same scroll behavior
- [x] Run upstream discovery, get to the review step, try switching tabs - verify the confirm dialog appears and blocks tab change if cancelled
- [x] Try navigating away from the page entirely while results are pending - verify browser confirm dialog
- [x] After saving targets, verify stat cards show live data and the banner disappears