### PR TITLE
Monitoring: SNMP resilience, PPPoE fallback, and discovery ping check

### DIFF
--- a/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
+++ b/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
@@ -174,13 +174,13 @@ public class SnmpPoller : ISnmpPoller
 
         return await Task.Run(() =>
         {
+            var list = new List<Variable>();
             try
             {
                 DebugLog($"SNMP BulkWalk: {ip}:{_config.Port} OID={oid} MaxRep={maxRepetitions}");
 
                 var endpoint = new IPEndPoint(ip, _config.Port);
                 var table = new ObjectIdentifier(oid);
-                var list = new List<Variable>();
 
                 if (_config.Version == SnmpVersion.V3)
                 {
@@ -226,8 +226,8 @@ public class SnmpPoller : ISnmpPoller
             }
             catch (Exception ex)
             {
-                _logger.LogDebug(ex, "SNMP BulkWalk failed for {Ip}:{Oid}", ip, oid);
-                return new List<Variable>();
+                _logger.LogDebug(ex, "SNMP BulkWalk failed for {Ip}:{Oid} (partial: {Count} variables)", ip, oid, list.Count);
+                return list;
             }
         });
     }

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -368,6 +368,7 @@
         TracerStep.DiscoveringL2Neighbor => "Discovering L2 neighbor",
         TracerStep.TracingAccessIsp => "Tracing your ISP",
         TracerStep.TracingTransitAsns => "Tracing intermediate networks",
+        TracerStep.VerifyingReachability => "Verifying reachability",
         TracerStep.ReviewingResults => "Review",
         TracerStep.Done => "Done",
         TracerStep.Failed => "Stopped",

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -135,11 +135,12 @@ public class LanFlowMapService
         GroupMultiClientPorts(snapshot);
         await BuildWanAndClouds(topology, snapshot, ct);
 
-        // WAN interface names for InfluxDB rate queries. Use the physical port
-        // name (not VLAN sub-interface) to match what SNMP records accurately.
+        // WAN interface names for InfluxDB rate queries. Include both physical
+        // and uplink names so PPPoE (ppp*) is covered when the physical port
+        // has no active counters.
         var wans = await _pathView.GetWansAsync(ct);
         snapshot.WanIfNames = wans
-            .Select(w => w.PhysicalIfName ?? w.UplinkIfName)
+            .SelectMany(w => new[] { w.PhysicalIfName, w.UplinkIfName })
             .Where(n => !string.IsNullOrEmpty(n))
             .Select(n => n!)
             .Distinct()
@@ -348,16 +349,21 @@ public class LanFlowMapService
         var gwNode = snapshot.Nodes.FirstOrDefault(n => n.Kind == LanNodeKind.Gateway);
         var gwMac = gwNode?.Mac;
 
-        // Build WAN interface → physical ifname mapping for per-WAN rate queries.
-        var wanIfNameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        // Build WAN interface → ifname candidates for per-WAN rate queries.
+        // Physical port first, uplink (ppp* for PPPoE) as fallback.
+        var wanIfNameMap = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
         try
         {
             var wans = await _pathView.GetWansAsync(ct);
             foreach (var w in wans)
             {
-                var rateIf = w.PhysicalIfName ?? w.UplinkIfName;
-                if (!string.IsNullOrEmpty(rateIf))
-                    wanIfNameMap[w.WanInterface] = rateIf;
+                var candidates = new[] { w.PhysicalIfName, w.UplinkIfName }
+                    .Where(n => !string.IsNullOrEmpty(n))
+                    .Select(n => n!)
+                    .Distinct()
+                    .ToArray();
+                if (candidates.Length > 0)
+                    wanIfNameMap[w.WanInterface] = candidates;
             }
         }
         catch { }
@@ -406,14 +412,19 @@ public class LanFlowMapService
                     var wanIface = link.Id.StartsWith("wan-link-", StringComparison.Ordinal)
                         ? link.Id.Substring("wan-link-".Length) : null;
                     if (wanIface != null
-                        && wanIfNameMap.TryGetValue(wanIface, out var rateIf)
+                        && wanIfNameMap.TryGetValue(wanIface, out var rateIfs)
                         && !string.IsNullOrEmpty(gwMac)
                         && ratesByDevice.TryGetValue(gwMac, out var gwRates))
                     {
-                        var closest = gwRates
-                            .Where(p => string.Equals(p.IfName, rateIf, StringComparison.OrdinalIgnoreCase))
-                            .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
-                            .FirstOrDefault();
+                        MonitoringInfluxClient.InterfaceRatePoint? closest = null;
+                        foreach (var rateIf in rateIfs)
+                        {
+                            closest = gwRates
+                                .Where(p => string.Equals(p.IfName, rateIf, StringComparison.OrdinalIgnoreCase))
+                                .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                                .FirstOrDefault();
+                            if (closest != null) break;
+                        }
                         if (closest != null)
                         {
                             // rate_in_bps = downloads, rate_out_bps = uploads

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -309,22 +309,22 @@ public class MonitoringPathView
         if (string.IsNullOrEmpty(gwMac)) return;
         foreach (var wan in wans)
         {
-            // For VLAN sub-interfaces (eth6.100), use the physical parent (eth6)
-            // for rate stats - VLAN sub-interface SNMP counters double-count on
-            // some kernels. For non-VLAN WANs, PhysicalIfName == UplinkIfName.
-            var rateIfName = wan.PhysicalIfName ?? wan.UplinkIfName;
-            if (!string.IsNullOrEmpty(rateIfName))
+            // Try physical port first (eth6), then logical uplink (ppp2 / eth6.100).
+            // VLAN sub-interfaces double-count on some kernels so physical wins,
+            // but PPPoE makes the physical port inactive so ppp* carries the data.
+            PortLiveRate? portRate = null;
+            if (!string.IsNullOrEmpty(wan.PhysicalIfName))
+                portRate = _liveStats.GetPortRate(gwMac, wan.PhysicalIfName);
+            if (portRate == null && !string.IsNullOrEmpty(wan.UplinkIfName) && wan.UplinkIfName != wan.PhysicalIfName)
+                portRate = _liveStats.GetPortRate(gwMac, wan.UplinkIfName);
+            if (portRate != null)
             {
-                var portRate = _liveStats.GetPortRate(gwMac, rateIfName);
-                if (portRate != null)
-                {
-                    // GetPortRate convention: DownBps = port TX, UpBps = port RX.
-                    // WAN port: TX = to internet = uploads (LiveRateInBps),
-                    //           RX = from internet = downloads (LiveRateOutBps).
-                    wan.LiveRateInBps = portRate.DownBps;
-                    wan.LiveRateOutBps = portRate.UpBps;
-                    continue;
-                }
+                // GetPortRate convention: DownBps = port TX, UpBps = port RX.
+                // WAN port: TX = to internet = uploads (LiveRateInBps),
+                //           RX = from internet = downloads (LiveRateOutBps).
+                wan.LiveRateInBps = portRate.DownBps;
+                wan.LiveRateOutBps = portRate.UpBps;
+                continue;
             }
             var deviceLive = _liveStats.GetForDevice(gwMac);
             wan.LiveRateInBps = deviceLive?.RateInBps;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -226,6 +226,7 @@ public class UpstreamTracerService
             if (!await DiscoverL2NeighborAsync(ct)) return;
             await TraceAccessIspAsync(ct);
             await TraceTransitAsnsAsync(ct);
+            await VerifyReachabilityAsync(ct);
             State.Step = TracerStep.ReviewingResults;
             State.CurrentActivity = "Review the discovered upstream path. Confirm to commit.";
             State.CompletedAt = DateTime.UtcNow;
@@ -789,6 +790,47 @@ public class UpstreamTracerService
         State.CurrentActivity = candidates.Count > 0
             ? $"Discovered {transitCount} transit ASN(s) and {proxyCount} path-end target(s)."
             : "No transit ASNs or path-end targets identified.";
+    }
+
+    private async Task VerifyReachabilityAsync(CancellationToken ct)
+    {
+        State.Step = TracerStep.VerifyingReachability;
+
+        var allTargets = new List<(string Address, ProbeMode Mode, Action Disable)>();
+        foreach (var hop in State.AccessHops)
+            allTargets.Add((hop.Address, hop.RespondedTo, () => hop.Enabled = false));
+        foreach (var transit in State.TransitAsns.Where(t => t.HopAddress != null && t.Method == DiscoveryMethod.DirectRouter))
+            allTargets.Add((transit.HopAddress!, transit.RespondedTo ?? ProbeMode.Icmp, () => transit.Enabled = false));
+
+        if (allTargets.Count == 0) return;
+
+        State.CurrentActivity = $"Pinging {allTargets.Count} candidate(s) to verify reachability...";
+
+        var tasks = allTargets.Select(async t =>
+        {
+            var result = await _localProbe.PingAsync(
+                new ProbeTarget(t.Address, t.Mode),
+                count: 2,
+                perPingTimeout: TimeSpan.FromSeconds(2),
+                ct: ct);
+            return (t, result);
+        });
+
+        var results = await Task.WhenAll(tasks);
+        var unreachable = 0;
+        foreach (var (t, result) in results)
+        {
+            if (!result.Success)
+            {
+                t.Disable();
+                unreachable++;
+                _logger.LogDebug("Ping check failed for {Address} - excluding from proposed targets", t.Address);
+            }
+        }
+
+        State.CurrentActivity = unreachable > 0
+            ? $"Reachability check complete: {unreachable} of {allTargets.Count} target(s) did not respond and were excluded."
+            : $"All {allTargets.Count} target(s) responded to ping.";
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerState.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerState.cs
@@ -41,6 +41,7 @@ public enum TracerStep
     DiscoveringL2Neighbor,
     TracingAccessIsp,
     TracingTransitAsns,
+    VerifyingReachability,
     ReviewingResults,
     Done,
     Failed

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -469,21 +469,21 @@ public class MonitoringCollectionAgent : BackgroundService
         {
             var gwMac = NormalizeMac(gw.Mac);
 
-            // Primary: SNMP rate on the WAN physical port. For VLAN-tagged WANs,
-            // use the parent port (eth6) not the sub-interface (eth6.100) since
-            // VLAN sub-interface counters double-count on some kernels.
-            var rateIfName = _cachedGatewayWanPhysicalIfNames.TryGetValue(gwMac, out var physIf) ? physIf : null;
-            rateIfName ??= _cachedGatewayWanIfNames.TryGetValue(gwMac, out var uplinkIf) ? uplinkIf : null;
-            if (rateIfName != null)
+            // SNMP rate on the WAN interface. Try physical port first (eth6),
+            // then the logical uplink (ppp2 for PPPoE, eth6.100 for VLAN-tagged).
+            // VLAN sub-interfaces double-count on some kernels so physical wins,
+            // but PPPoE makes the physical port inactive so ppp* carries the data.
+            var physIfName = _cachedGatewayWanPhysicalIfNames.TryGetValue(gwMac, out var physIf) ? physIf : null;
+            var uplinkIfName = _cachedGatewayWanIfNames.TryGetValue(gwMac, out var uplinkIf) ? uplinkIf : null;
+            var portRate = physIfName != null ? _liveStats.GetPortRate(gwMac, physIfName) : null;
+            if (portRate == null && uplinkIfName != null && uplinkIfName != physIfName)
+                portRate = _liveStats.GetPortRate(gwMac, uplinkIfName);
+            if (portRate != null)
             {
-                var portRate = _liveStats.GetPortRate(gwMac, rateIfName);
-                if (portRate != null)
-                {
-                    // Gateway WAN perspective: port TX (DownBps) = data toward
-                    // internet = uploads; port RX (UpBps) = from internet = downloads.
-                    _liveStats.RecordInterfaceAggregate(gw.Mac, portRate.DownBps, portRate.UpBps, nowOverride);
-                    continue;
-                }
+                // Gateway WAN perspective: port TX (DownBps) = data toward
+                // internet = uploads; port RX (UpBps) = from internet = downloads.
+                _liveStats.RecordInterfaceAggregate(gw.Mac, portRate.DownBps, portRate.UpBps, nowOverride);
+                continue;
             }
 
             // Fallback: PortTable IsUplink + PortIdx. Covers gateways where

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -51,8 +51,9 @@ public class MonitoringCollectionAgent : BackgroundService
     // the lifetime of this app. Cheap, bounded, and avoids constantly hammering a
     // device that's just not going to answer (USW-Flex-Mini, for example).
     private readonly ConcurrentDictionary<string, int> _snmpFailures = new();
-    private readonly ConcurrentDictionary<string, byte> _snmpExcluded = new();
-    private const int SnmpFailureThreshold = 3;
+    private readonly ConcurrentDictionary<string, DateTime> _snmpExcluded = new();
+    private const int SnmpFailureThreshold = 10;
+    private static readonly TimeSpan SnmpExclusionDuration = TimeSpan.FromHours(1);
     private readonly SemaphoreSlim _snmpGate = new(8);
 
     public MonitoringCollectionAgent(
@@ -231,7 +232,7 @@ public class MonitoringCollectionAgent : BackgroundService
             try
             {
                 var mac = NormalizeMac(device.Mac);
-                if (_snmpExcluded.ContainsKey(mac))
+                if (IsSnmpExcluded(mac))
                 {
                     // Device was previously determined to not support SNMP. Skip silently;
                     // rate data for this device will come from its parent switch port
@@ -649,7 +650,7 @@ public class MonitoringCollectionAgent : BackgroundService
             await _snmpGate.WaitAsync(ct);
             try
             {
-                if (_snmpExcluded.ContainsKey(NormalizeMac(device.Mac))) return;
+                if (IsSnmpExcluded(NormalizeMac(device.Mac))) return;
                 var pollIp = ResolveSnmpAddress(device, gatewayLanIp);
                 if (!IPAddress.TryParse(pollIp, out var ip)) return;
                 var metrics = await poller.GetDeviceMetricsAsync(ip, device.Name);
@@ -737,7 +738,7 @@ public class MonitoringCollectionAgent : BackgroundService
         var gatewayLanIp = await ResolveGatewayLanIpAsync(ct);
         foreach (var device in devices)
         {
-            if (_snmpExcluded.ContainsKey(NormalizeMac(device.Mac))) continue;
+            if (IsSnmpExcluded(NormalizeMac(device.Mac))) continue;
             try
             {
                 var pollIp = ResolveSnmpAddress(device, gatewayLanIp);
@@ -1663,7 +1664,7 @@ public class MonitoringCollectionAgent : BackgroundService
     private void NoteSnmpFailure(string normalizedMac)
     {
         if (string.IsNullOrEmpty(normalizedMac)) return;
-        if (_snmpExcluded.ContainsKey(normalizedMac)) return;
+        if (IsSnmpExcluded(normalizedMac)) return;
 
         var count = _snmpFailures.AddOrUpdate(normalizedMac, 1, (_, prev) => prev + 1);
         if (count < SnmpFailureThreshold) return;
@@ -1676,12 +1677,21 @@ public class MonitoringCollectionAgent : BackgroundService
         if (DateTime.UtcNow - liveStats.LastLatencyUpdate.Value > TimeSpan.FromMinutes(2)) return;
         if (!(liveStats.LatestRttMs.HasValue && liveStats.LatestRttMs.Value >= 0)) return;
 
-        if (_snmpExcluded.TryAdd(normalizedMac, 0))
+        if (_snmpExcluded.TryAdd(normalizedMac, DateTime.UtcNow))
         {
             _logger.LogInformation(
                 "Excluding {Mac} from SNMP polling for this app lifecycle - {Count} consecutive failures despite being reachable on ICMP. Device likely doesn't support SNMP.",
                 normalizedMac, count);
         }
+    }
+
+    private bool IsSnmpExcluded(string normalizedMac)
+    {
+        if (!_snmpExcluded.TryGetValue(normalizedMac, out var excludedAt)) return false;
+        if (DateTime.UtcNow - excludedAt < SnmpExclusionDuration) return true;
+        _snmpExcluded.TryRemove(normalizedMac, out _);
+        _snmpFailures.TryRemove(normalizedMac, out _);
+        return false;
     }
 
     /// <summary>Tells the dashboard which devices were dropped from SNMP polling.</summary>


### PR DESCRIPTION
## Summary

- **Ping-verify upstream discovery candidates** - sends a 2-count ping to each access hop and direct-router transit candidate before proposing them. Targets that don't respond are disabled so they won't appear as proposed monitoring targets.

- **PPPoE WAN rate fallback** - WAN throughput lookups now try the physical port first, then fall back to the logical uplink interface (ppp* for PPPoE). Fixes missing WAN throughput on PPPoE gateways where the physical port has no active SNMP counters.

- **SNMP exclusion recovery** - failure threshold raised from 3 to 10 consecutive failures, and exclusions now expire after 1 hour instead of lasting the entire app lifecycle. A brief SNMP outage no longer permanently kills monitoring until app restart.

- **BulkWalk partial data** - when a BulkWalk encounters an error mid-walk (e.g. GenError on one interface index), returns the data collected before the error instead of discarding everything. One flaky interface no longer zeroes all interface counters.

## Test plan

- [x] Run upstream discovery on a site with unreachable hops - verify they're excluded from proposed targets
- [x] Verify WAN throughput charts populate on DHCP and VLAN-tagged WAN connections (no regression)
- [x] Disable SNMP briefly, re-enable - confirm monitoring recovers within 1 hour without app restart
- [x] Monitor logs for `partial: N variables` messages indicating BulkWalk partial recovery