### PR TITLE
Monitoring: SNMP resilience, PPPoE support, and discovery UX

### DIFF
--- a/src/NetworkOptimizer.Monitoring/Models/InterfaceMetrics.cs
+++ b/src/NetworkOptimizer.Monitoring/Models/InterfaceMetrics.cs
@@ -194,24 +194,30 @@ public class InterfaceMetrics
         var desc = Description.ToLowerInvariant();
         var name = Name.ToLowerInvariant();
 
-        // Exclude common virtual/internal interfaces
-        var excludePatterns = new[]
+        var exactExclude = new[]
         {
-            "lo",        // Loopback
-            "br-",       // Bridge
-            "docker",    // Docker
-            "veth",      // Virtual Ethernet
-            "ifb",       // Intermediate Functional Block
-            "virbr",     // Virtual Bridge
-            "tun",       // Tunnel
-            "tap",       // TAP device
-            "null",      // Null interface
-            "device ",   // USB/PCI device descriptors (e.g. Qualcomm chipset "Device 17cb:1109")
-            "miireg",    // MII register access (not a network interface)
-            "teql",      // Traffic equalizer
+            "lo", "bond0", "dummy0", "sit0", "erspan0",
+            "gretap0",
+            "ip_vti0", "ip6_vti0", "ip6tnl0",
+            "soc0", "soc2", "pd99", "mld0", "scan0",
+            "miireg", "teql0",
+        };
+        foreach (var e in exactExclude)
+        {
+            if (desc == e || name == e) return false;
+        }
+
+        var excludePrefixes = new[]
+        {
+            "loopback",    // Loopback (some devices use full name)
+            "br0", "br-",  // Bridge (br0, br0.42, br-trunk)
+            "br1", "br2", "br3", "br4", "br5", "br6", "br7", "br8", "br9",  // Numbered bridges (br150, br200, br4040)
+            "switch0",     // Internal switch chip (switch0, switch0.1)
+            "mld-",        // Multicast listener discovery
+            "device ",     // USB/PCI descriptors (e.g. "Device 17cb:1109")
         };
 
-        foreach (var pattern in excludePatterns)
+        foreach (var pattern in excludePrefixes)
         {
             if (desc.StartsWith(pattern) || name.StartsWith(pattern))
                 return false;

--- a/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
+++ b/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
@@ -174,13 +174,13 @@ public class SnmpPoller : ISnmpPoller
 
         return await Task.Run(() =>
         {
+            var list = new List<Variable>();
             try
             {
                 DebugLog($"SNMP BulkWalk: {ip}:{_config.Port} OID={oid} MaxRep={maxRepetitions}");
 
                 var endpoint = new IPEndPoint(ip, _config.Port);
                 var table = new ObjectIdentifier(oid);
-                var list = new List<Variable>();
 
                 if (_config.Version == SnmpVersion.V3)
                 {
@@ -226,8 +226,8 @@ public class SnmpPoller : ISnmpPoller
             }
             catch (Exception ex)
             {
-                _logger.LogDebug(ex, "SNMP BulkWalk failed for {Ip}:{Oid}", ip, oid);
-                return new List<Variable>();
+                _logger.LogDebug(ex, "SNMP BulkWalk failed for {Ip}:{Oid} (partial: {Count} variables)", ip, oid, list.Count);
+                return list;
             }
         });
     }

--- a/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
+++ b/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
@@ -355,9 +355,13 @@ public class SnmpPoller : ISnmpPoller
                 {
                     interfaces.Add(metrics);
                 }
+                else
+                {
+                    _logger.LogDebug("ShouldMonitor rejected ifIndex {Idx} desc={Desc} name={Name} on {Ip}", idx, descr, metrics.Name, ip);
+                }
             }
 
-            DebugLog($"Collected metrics for {interfaces.Count} interfaces");
+            DebugLog($"Collected metrics for {interfaces.Count} interfaces from {metadata.DescrByIdx.Count} in metadata");
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -20,6 +20,10 @@
 @inject Microsoft.JSInterop.IJSRuntime JS
 @inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
 @inject NavigationManager NavigationManager
+@inject NetworkOptimizer.Web.Services.Monitoring.UpstreamTracerService UpstreamTracer
+
+<NavigationLock OnBeforeInternalNavigation="OnBeforeInternalNavigation"
+                ConfirmExternalNavigation="_upstreamDiscoveryPendingSave" />
 
 <PageTitle>Monitoring - Network Optimizer</PageTitle>
 
@@ -86,6 +90,24 @@ else
     @* ──────────────── Tab: Live View ──────────────── *@
     @if (_activeTab == "live" && _monitoringReady)
     {
+        var hasIspTargets = HasUpstreamTargets(MonitoringTargetType.AccessIsp);
+        var hasTransitTargets = HasUpstreamTargets(MonitoringTargetType.Transit);
+
+        if (!hasIspTargets || !hasTransitTargets)
+        {
+            <div class="alert alert-info" style="margin-bottom: 1rem;">
+                <div class="banner-content">
+                    <span class="banner-icon banner-icon-info">i</span>
+                    <div class="banner-text" style="flex: 1;">
+                        Run Upstream Discovery to identify your ISP and transit hops for latency and loss tracking.
+                    </div>
+                    <div class="banner-actions">
+                        <button class="btn btn-sm btn-primary" @onclick="NavigateToUpstreamDiscovery">Run Upstream Discovery</button>
+                    </div>
+                </div>
+            </div>
+        }
+
         <!-- Top stat cards: WAN rates, gateway RTT/loss, ISP/Transit mean RTT/loss -->
         <div class="monitoring-stat-cards">
             @{ var wanRates = GetWanRates(); }
@@ -108,20 +130,48 @@ else
             </div>
             @{ var ispTarget = GetMeanTargetStats(MonitoringTargetType.AccessIsp); }
             <div class="monitoring-stat-card">
-                <div class="stat-value">@FormatRtt(ispTarget.rtt)</div>
+                @if (hasIspTargets)
+                {
+                    <div class="stat-value">@FormatRtt(ispTarget.rtt)</div>
+                }
+                else
+                {
+                    <div class="stat-value"><span class="tooltip-icon stat-hint-icon" data-tooltip="No targets set - <a href='/monitoring?tab=performance&amp;discover=1'>Run Upstream Discovery</a>">?</span></div>
+                }
                 <div class="stat-label">ISP RTT</div>
             </div>
             <div class="monitoring-stat-card">
-                <div class="stat-value @(ispTarget.loss > 0 ? "stat-danger" : "")">@FormatLoss(ispTarget.loss)</div>
+                @if (hasIspTargets)
+                {
+                    <div class="stat-value @(ispTarget.loss > 0 ? "stat-danger" : "")">@FormatLoss(ispTarget.loss)</div>
+                }
+                else
+                {
+                    <div class="stat-value"><span class="tooltip-icon stat-hint-icon" data-tooltip="No targets set - <a href='/monitoring?tab=performance&amp;discover=1'>Run Upstream Discovery</a>">?</span></div>
+                }
                 <div class="stat-label">ISP Loss</div>
             </div>
             @{ var transitTarget = GetMeanTargetStats(MonitoringTargetType.Transit); }
             <div class="monitoring-stat-card">
-                <div class="stat-value">@FormatRtt(transitTarget.rtt)</div>
+                @if (hasTransitTargets)
+                {
+                    <div class="stat-value">@FormatRtt(transitTarget.rtt)</div>
+                }
+                else
+                {
+                    <div class="stat-value"><span class="tooltip-icon stat-hint-icon" data-tooltip="No targets set - <a href='/monitoring?tab=performance&amp;discover=1'>Run Upstream Discovery</a>">?</span></div>
+                }
                 <div class="stat-label">Transit RTT</div>
             </div>
             <div class="monitoring-stat-card">
-                <div class="stat-value @(transitTarget.loss > 0 ? "stat-danger" : "")">@FormatLoss(transitTarget.loss)</div>
+                @if (hasTransitTargets)
+                {
+                    <div class="stat-value @(transitTarget.loss > 0 ? "stat-danger" : "")">@FormatLoss(transitTarget.loss)</div>
+                }
+                else
+                {
+                    <div class="stat-value"><span class="tooltip-icon stat-hint-icon" data-tooltip="No targets set - <a href='/monitoring?tab=performance&amp;discover=1'>Run Upstream Discovery</a>">?</span></div>
+                }
                 <div class="stat-label">Transit Loss</div>
             </div>
         </div>
@@ -657,6 +707,12 @@ else
     .stat-danger {
         color: var(--danger-color);
     }
+    .stat-hint-icon {
+        width: 22px;
+        height: 22px;
+        font-size: 13px;
+        cursor: pointer;
+    }
     @@media (max-width: 768px) {
         .monitoring-stat-cards {
             gap: 0.5rem;
@@ -676,7 +732,13 @@ else
     [SupplyParameterFromQuery(Name = "tab")]
     public string? TabParam { get; set; }
 
+    [SupplyParameterFromQuery(Name = "discover")]
+    public string? DiscoverParam { get; set; }
+
     private string? _lastTabParam;
+
+    private bool _upstreamDiscoveryPendingSave =>
+        UpstreamTracer.State.Step == NetworkOptimizer.Web.Services.Monitoring.TracerStep.ReviewingResults;
 
     private SnmpDetectionState _snmpState = SnmpDetectionState.NotChecked;
     private bool _detecting;
@@ -739,14 +801,22 @@ else
         return "live";
     }
 
-    private void SetActiveTab(string tab)
+    private async void SetActiveTab(string tab)
     {
         if (tab != "setup" && !_monitoringReady) return;
+        if (_upstreamDiscoveryPendingSave && tab != _activeTab)
+        {
+            var confirmed = await JS.InvokeAsync<bool>("confirm",
+                "Upstream Discovery results haven't been saved. If you leave now, you'll need to re-run discovery.\n\nLeave without saving?");
+            if (!confirmed) return;
+        }
         _activeTab = tab;
         var uri = "/monitoring?tab=" + tab;
         NavigationManager.NavigateTo(uri, forceLoad: false, replace: false);
         _lastTabParam = tab;
     }
+
+    private bool _scrollToDiscoveryPending;
 
     protected override void OnParametersSet()
     {
@@ -761,6 +831,12 @@ else
             }
         }
         _lastTabParam = TabParam;
+
+        if (DiscoverParam == "1" && _activeTab == "performance")
+        {
+            _forceExpandUpstream = true;
+            _scrollToDiscoveryPending = true;
+        }
     }
 
     protected override async Task OnInitializedAsync()
@@ -1035,26 +1111,41 @@ else
     [JSInvokable]
     public void NavigateToUpstreamDiscovery()
     {
-        InvokeAsync(async () =>
+        InvokeAsync(() =>
         {
             _activeTab = "performance";
             _forceExpandUpstream = true;
+            _scrollToDiscoveryPending = true;
             StateHasChanged();
-            await Task.Delay(150);
-            await JS.InvokeVoidAsync("eval", @"
-                (function() {
-                    var el = document.getElementById('upstream-discovery');
-                    if (el) {
-                        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                        el.style.transition = 'outline-color 0.3s';
-                        el.style.outline = '2px solid rgba(59, 130, 246, 0.5)';
-                        el.style.outlineOffset = '4px';
-                        el.style.borderRadius = '12px';
-                        setTimeout(function() { el.style.outline = ''; el.style.outlineOffset = ''; }, 2000);
-                    }
-                })();");
-            _forceExpandUpstream = false;
         });
+    }
+
+    private async Task ScrollToUpstreamDiscoveryAsync()
+    {
+        await Task.Delay(500);
+        await JS.InvokeVoidAsync("eval", @"
+            (function() {
+                var el = document.getElementById('upstream-discovery');
+                if (el) {
+                    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                    el.style.transition = 'outline-color 0.3s';
+                    el.style.outline = '2px solid rgba(59, 130, 246, 0.5)';
+                    el.style.outlineOffset = '4px';
+                    el.style.borderRadius = '12px';
+                    setTimeout(function() { el.style.outline = ''; el.style.outlineOffset = ''; }, 2000);
+                }
+            })();");
+    }
+
+    private async Task OnBeforeInternalNavigation(LocationChangingContext context)
+    {
+        if (_upstreamDiscoveryPendingSave)
+        {
+            var confirmed = await JS.InvokeAsync<bool>("confirm",
+                "Upstream Discovery results haven't been saved. If you leave now, you'll need to re-run discovery.\n\nLeave without saving?");
+            if (!confirmed)
+                context.PreventNavigation();
+        }
     }
 
     [JSInvokable]
@@ -1253,6 +1344,9 @@ else
     }
 
     // ─── Stat card helpers ───
+
+    private bool HasUpstreamTargets(MonitoringTargetType type) =>
+        _targets.Any(t => t.TargetType == type && t.Enabled);
 
     private (double download, double upload) GetWanRates()
     {
@@ -1554,6 +1648,13 @@ else
             _latencyChartsMounted = false;
             try { await JS.InvokeVoidAsync("eval", "window.__latencyCharts?.unmount();"); }
             catch { }
+        }
+
+        if (_scrollToDiscoveryPending && _activeTab == "performance")
+        {
+            _scrollToDiscoveryPending = false;
+            _forceExpandUpstream = false;
+            await ScrollToUpstreamDiscoveryAsync();
         }
 
         // Device health charts - Devices tab only

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1523,7 +1523,8 @@ else
         StateHasChanged();
         try
         {
-            var result = await InfluxClient.FindRecentLossEventAsync(before, after);
+            var enabledIds = _targets.Where(t => t.Enabled).Select(t => t.TargetId).ToList();
+            var result = await InfluxClient.FindRecentLossEventAsync(before, after, enabledIds);
             if (result == null)
             {
                 _lossInvestigateResult = after.HasValue ? "No newer events" : "No older events";

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -2317,7 +2317,7 @@
     private string _monitoringMessageClass = "success";
 
     // Editable InfluxDB connection inputs (loaded from MonitoringSettings)
-    private string _influxUrl = "http://localhost:8087";
+    private string _influxUrl = "http://localhost:8086";
     private string _influxToken = string.Empty;
     private bool _influxTokenIsSet = false;
     private string _influxOrg = "network-optimizer";
@@ -4669,7 +4669,7 @@
             _monitoringSettings = await SnmpDetection.GetOrCreateSettingsAsync();
             if (_monitoringSettings != null)
             {
-                _influxUrl = _monitoringSettings.InfluxDbUrl ?? "http://localhost:8087";
+                _influxUrl = _monitoringSettings.InfluxDbUrl ?? "http://localhost:8086";
                 _influxOrg = _monitoringSettings.InfluxDbOrg ?? "network-optimizer";
                 _influxBucket = _monitoringSettings.InfluxDbBucket ?? "network_monitoring";
                 _influxLongtermBucket = _monitoringSettings.InfluxDbLongtermBucket ?? "network_monitoring_longterm";

--- a/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
@@ -342,7 +342,7 @@
 
     private static string RelativeTime(DateTime when)
     {
-        var delta = DateTime.UtcNow - when.ToUniversalTime();
+        var delta = DateTime.UtcNow - DateTime.SpecifyKind(when, DateTimeKind.Utc);
         if (delta < TimeSpan.Zero) return "just now";
         if (delta < TimeSpan.FromSeconds(15)) return "just now";
         if (delta < TimeSpan.FromMinutes(1)) return $"{(int)delta.TotalSeconds}s ago";

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -368,6 +368,7 @@
         TracerStep.DiscoveringL2Neighbor => "Discovering L2 neighbor",
         TracerStep.TracingAccessIsp => "Tracing your ISP",
         TracerStep.TracingTransitAsns => "Tracing intermediate networks",
+        TracerStep.VerifyingReachability => "Verifying reachability",
         TracerStep.ReviewingResults => "Review",
         TracerStep.Done => "Done",
         TracerStep.Failed => "Stopped",

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -287,6 +287,12 @@
     private DateTime _lastReviewCheck = DateTime.MinValue;
     private bool _justSaved;
 
+    protected override void OnParametersSet()
+    {
+        if (ForceExpand && _collapsed)
+            _collapsed = false;
+    }
+
     protected override async Task OnInitializedAsync()
     {
         await Tracer.RehydrateFromDbAsync();

--- a/src/NetworkOptimizer.Web/Endpoints/MonitoringInvestigateEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/MonitoringInvestigateEndpoints.cs
@@ -15,8 +15,13 @@ public static class MonitoringInvestigateEndpoints
             DateTime? after,
             CancellationToken ct) =>
         {
+            await using var dbForIds = await dbFactory.CreateDbContextAsync(ct);
+            var enabledIds = await dbForIds.MonitoringTargets.AsNoTracking()
+                .Where(t => t.Enabled)
+                .Select(t => t.TargetId)
+                .ToListAsync(ct);
             var result = await influx.FindRecentLossEventAsync(
-                before?.ToUniversalTime(), after?.ToUniversalTime(), ct);
+                before?.ToUniversalTime(), after?.ToUniversalTime(), enabledIds, ct);
             if (result == null)
                 return Results.Ok(new { found = false });
 

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -222,25 +222,62 @@ public class LanFlowMapService
             }
             else if (link.Kind == LanLinkKind.Uplink || link.Kind == LanLinkKind.MeshBackhaul)
             {
-                // For infrastructure uplinks the child device's aggregate is the most
-                // live measurement we have on every tick. The empirical convention from
-                // the AP badge work: aggregateInBps holds the upload-direction value
-                // (data flowing toward the gateway), aggregateOutBps holds downloads.
-                // The link's particle layer expects DownstreamBps to be downloads
-                // (parent -> child, blue) and UpstreamBps to be uploads
-                // (child -> parent, green), so map accordingly.
-                var childDev = ExtractDeviceMacFromUplinkId(link.Id);
-                if (!string.IsNullOrEmpty(childDev))
+                // Primary: parent's trunk port via PortKey (same SNMP-fed path
+                // that wired client links use, 5 s cadence).
+                if (!string.IsNullOrEmpty(link.PortKey))
                 {
-                    var stats = _liveStats.GetForDevice(childDev);
-                    if (stats != null && stats.LastRateUpdate.HasValue)
+                    var (parentMac, pIfName) = ParsePortKey(link.PortKey);
+                    var portRate = _liveStats.GetPortRate(parentMac, pIfName);
+                    if (portRate != null)
                     {
                         rates = new LinkLiveRates
                         {
-                            DownstreamBps = stats.RateOutBps ?? 0,
-                            UpstreamBps = stats.RateInBps ?? 0,
-                            AsOf = stats.LastRateUpdate.Value,
+                            DownstreamBps = portRate.DownBps,
+                            UpstreamBps = portRate.UpBps,
+                            AsOf = portRate.LastUpdate,
                         };
+                    }
+                }
+                // Fallback: child's own uplink port.
+                if (rates == null)
+                {
+                    var childDev = ExtractDeviceMacFromUplinkId(link.Id);
+                    if (!string.IsNullOrEmpty(childDev))
+                    {
+                        var childNode = snapshot.Nodes.FirstOrDefault(n =>
+                            string.Equals(n.Mac, childDev, StringComparison.OrdinalIgnoreCase));
+                        if (childNode?.UplinkIfName != null)
+                        {
+                            var portRate = _liveStats.GetPortRate(childDev, childNode.UplinkIfName);
+                            if (portRate != null)
+                            {
+                                rates = new LinkLiveRates
+                                {
+                                    DownstreamBps = portRate.UpBps,
+                                    UpstreamBps = portRate.DownBps,
+                                    AsOf = portRate.LastUpdate,
+                                };
+                            }
+                        }
+                    }
+                }
+                // Last resort: device-level aggregate (covers APs whose radio
+                // interfaces don't map to per-port SNMP counters).
+                if (rates == null)
+                {
+                    var childDev = ExtractDeviceMacFromUplinkId(link.Id);
+                    if (!string.IsNullOrEmpty(childDev))
+                    {
+                        var stats = _liveStats.GetForDevice(childDev);
+                        if (stats != null && stats.LastRateUpdate.HasValue)
+                        {
+                            rates = new LinkLiveRates
+                            {
+                                DownstreamBps = stats.RateOutBps ?? 0,
+                                UpstreamBps = stats.RateInBps ?? 0,
+                                AsOf = stats.LastRateUpdate.Value,
+                            };
+                        }
                     }
                 }
             }

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -135,11 +135,12 @@ public class LanFlowMapService
         GroupMultiClientPorts(snapshot);
         await BuildWanAndClouds(topology, snapshot, ct);
 
-        // WAN interface names for InfluxDB rate queries. Use the physical port
-        // name (not VLAN sub-interface) to match what SNMP records accurately.
+        // WAN interface names for InfluxDB rate queries. Include both physical
+        // and uplink names so PPPoE (ppp*) is covered when the physical port
+        // has no active counters.
         var wans = await _pathView.GetWansAsync(ct);
         snapshot.WanIfNames = wans
-            .Select(w => w.PhysicalIfName ?? w.UplinkIfName)
+            .SelectMany(w => new[] { w.PhysicalIfName, w.UplinkIfName })
             .Where(n => !string.IsNullOrEmpty(n))
             .Select(n => n!)
             .Distinct()
@@ -348,16 +349,21 @@ public class LanFlowMapService
         var gwNode = snapshot.Nodes.FirstOrDefault(n => n.Kind == LanNodeKind.Gateway);
         var gwMac = gwNode?.Mac;
 
-        // Build WAN interface → physical ifname mapping for per-WAN rate queries.
-        var wanIfNameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        // Build WAN interface → ifname candidates for per-WAN rate queries.
+        // Physical port first, uplink (ppp* for PPPoE) as fallback.
+        var wanIfNameMap = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
         try
         {
             var wans = await _pathView.GetWansAsync(ct);
             foreach (var w in wans)
             {
-                var rateIf = w.PhysicalIfName ?? w.UplinkIfName;
-                if (!string.IsNullOrEmpty(rateIf))
-                    wanIfNameMap[w.WanInterface] = rateIf;
+                var candidates = new[] { w.PhysicalIfName, w.UplinkIfName }
+                    .Where(n => !string.IsNullOrEmpty(n))
+                    .Select(n => n!)
+                    .Distinct()
+                    .ToArray();
+                if (candidates.Length > 0)
+                    wanIfNameMap[w.WanInterface] = candidates;
             }
         }
         catch { }
@@ -406,14 +412,19 @@ public class LanFlowMapService
                     var wanIface = link.Id.StartsWith("wan-link-", StringComparison.Ordinal)
                         ? link.Id.Substring("wan-link-".Length) : null;
                     if (wanIface != null
-                        && wanIfNameMap.TryGetValue(wanIface, out var rateIf)
+                        && wanIfNameMap.TryGetValue(wanIface, out var rateIfs)
                         && !string.IsNullOrEmpty(gwMac)
                         && ratesByDevice.TryGetValue(gwMac, out var gwRates))
                     {
-                        var closest = gwRates
-                            .Where(p => string.Equals(p.IfName, rateIf, StringComparison.OrdinalIgnoreCase))
-                            .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
-                            .FirstOrDefault();
+                        MonitoringInfluxClient.InterfaceRatePoint? closest = null;
+                        foreach (var rateIf in rateIfs)
+                        {
+                            closest = gwRates
+                                .Where(p => string.Equals(p.IfName, rateIf, StringComparison.OrdinalIgnoreCase))
+                                .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                                .FirstOrDefault();
+                            if (closest != null) break;
+                        }
                         if (closest != null)
                         {
                             // rate_in_bps = downloads, rate_out_bps = uploads

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -309,22 +309,22 @@ public class MonitoringPathView
         if (string.IsNullOrEmpty(gwMac)) return;
         foreach (var wan in wans)
         {
-            // For VLAN sub-interfaces (eth6.100), use the physical parent (eth6)
-            // for rate stats - VLAN sub-interface SNMP counters double-count on
-            // some kernels. For non-VLAN WANs, PhysicalIfName == UplinkIfName.
-            var rateIfName = wan.PhysicalIfName ?? wan.UplinkIfName;
-            if (!string.IsNullOrEmpty(rateIfName))
+            // Try physical port first (eth6), then logical uplink (ppp2 / eth6.100).
+            // VLAN sub-interfaces double-count on some kernels so physical wins,
+            // but PPPoE makes the physical port inactive so ppp* carries the data.
+            PortLiveRate? portRate = null;
+            if (!string.IsNullOrEmpty(wan.PhysicalIfName))
+                portRate = _liveStats.GetPortRate(gwMac, wan.PhysicalIfName);
+            if (portRate == null && !string.IsNullOrEmpty(wan.UplinkIfName) && wan.UplinkIfName != wan.PhysicalIfName)
+                portRate = _liveStats.GetPortRate(gwMac, wan.UplinkIfName);
+            if (portRate != null)
             {
-                var portRate = _liveStats.GetPortRate(gwMac, rateIfName);
-                if (portRate != null)
-                {
-                    // GetPortRate convention: DownBps = port TX, UpBps = port RX.
-                    // WAN port: TX = to internet = uploads (LiveRateInBps),
-                    //           RX = from internet = downloads (LiveRateOutBps).
-                    wan.LiveRateInBps = portRate.DownBps;
-                    wan.LiveRateOutBps = portRate.UpBps;
-                    continue;
-                }
+                // GetPortRate convention: DownBps = port TX, UpBps = port RX.
+                // WAN port: TX = to internet = uploads (LiveRateInBps),
+                //           RX = from internet = downloads (LiveRateOutBps).
+                wan.LiveRateInBps = portRate.DownBps;
+                wan.LiveRateOutBps = portRate.UpBps;
+                continue;
             }
             var deviceLive = _liveStats.GetForDevice(gwMac);
             wan.LiveRateInBps = deviceLive?.RateInBps;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -226,6 +226,7 @@ public class UpstreamTracerService
             if (!await DiscoverL2NeighborAsync(ct)) return;
             await TraceAccessIspAsync(ct);
             await TraceTransitAsnsAsync(ct);
+            await VerifyReachabilityAsync(ct);
             State.Step = TracerStep.ReviewingResults;
             State.CurrentActivity = "Review the discovered upstream path. Confirm to commit.";
             State.CompletedAt = DateTime.UtcNow;
@@ -789,6 +790,47 @@ public class UpstreamTracerService
         State.CurrentActivity = candidates.Count > 0
             ? $"Discovered {transitCount} transit ASN(s) and {proxyCount} path-end target(s)."
             : "No transit ASNs or path-end targets identified.";
+    }
+
+    private async Task VerifyReachabilityAsync(CancellationToken ct)
+    {
+        State.Step = TracerStep.VerifyingReachability;
+
+        var allTargets = new List<(string Address, ProbeMode Mode, Action Disable)>();
+        foreach (var hop in State.AccessHops)
+            allTargets.Add((hop.Address, hop.RespondedTo, () => hop.Enabled = false));
+        foreach (var transit in State.TransitAsns.Where(t => t.HopAddress != null && t.Method == DiscoveryMethod.DirectRouter))
+            allTargets.Add((transit.HopAddress!, transit.RespondedTo ?? ProbeMode.Icmp, () => transit.Enabled = false));
+
+        if (allTargets.Count == 0) return;
+
+        State.CurrentActivity = $"Pinging {allTargets.Count} candidate(s) to verify reachability...";
+
+        var tasks = allTargets.Select(async t =>
+        {
+            var result = await _localProbe.PingAsync(
+                new ProbeTarget(t.Address, t.Mode),
+                count: 2,
+                perPingTimeout: TimeSpan.FromSeconds(2),
+                ct: ct);
+            return (t, result);
+        });
+
+        var results = await Task.WhenAll(tasks);
+        var unreachable = 0;
+        foreach (var (t, result) in results)
+        {
+            if (!result.Success)
+            {
+                t.Disable();
+                unreachable++;
+                _logger.LogDebug("Ping check failed for {Address} - excluding from proposed targets", t.Address);
+            }
+        }
+
+        State.CurrentActivity = unreachable > 0
+            ? $"Reachability check complete: {unreachable} of {allTargets.Count} target(s) did not respond and were excluded."
+            : $"All {allTargets.Count} target(s) responded to ping.";
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerState.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerState.cs
@@ -41,6 +41,7 @@ public enum TracerStep
     DiscoveringL2Neighbor,
     TracingAccessIsp,
     TracingTransitAsns,
+    VerifyingReachability,
     ReviewingResults,
     Done,
     Failed

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -51,8 +51,9 @@ public class MonitoringCollectionAgent : BackgroundService
     // the lifetime of this app. Cheap, bounded, and avoids constantly hammering a
     // device that's just not going to answer (USW-Flex-Mini, for example).
     private readonly ConcurrentDictionary<string, int> _snmpFailures = new();
-    private readonly ConcurrentDictionary<string, byte> _snmpExcluded = new();
-    private const int SnmpFailureThreshold = 3;
+    private readonly ConcurrentDictionary<string, DateTime> _snmpExcluded = new();
+    private const int SnmpFailureThreshold = 10;
+    private static readonly TimeSpan SnmpExclusionDuration = TimeSpan.FromHours(1);
     private readonly SemaphoreSlim _snmpGate = new(8);
 
     public MonitoringCollectionAgent(
@@ -231,7 +232,7 @@ public class MonitoringCollectionAgent : BackgroundService
             try
             {
                 var mac = NormalizeMac(device.Mac);
-                if (_snmpExcluded.ContainsKey(mac))
+                if (IsSnmpExcluded(mac))
                 {
                     // Device was previously determined to not support SNMP. Skip silently;
                     // rate data for this device will come from its parent switch port
@@ -469,21 +470,21 @@ public class MonitoringCollectionAgent : BackgroundService
         {
             var gwMac = NormalizeMac(gw.Mac);
 
-            // Primary: SNMP rate on the WAN physical port. For VLAN-tagged WANs,
-            // use the parent port (eth6) not the sub-interface (eth6.100) since
-            // VLAN sub-interface counters double-count on some kernels.
-            var rateIfName = _cachedGatewayWanPhysicalIfNames.TryGetValue(gwMac, out var physIf) ? physIf : null;
-            rateIfName ??= _cachedGatewayWanIfNames.TryGetValue(gwMac, out var uplinkIf) ? uplinkIf : null;
-            if (rateIfName != null)
+            // SNMP rate on the WAN interface. Try physical port first (eth6),
+            // then the logical uplink (ppp2 for PPPoE, eth6.100 for VLAN-tagged).
+            // VLAN sub-interfaces double-count on some kernels so physical wins,
+            // but PPPoE makes the physical port inactive so ppp* carries the data.
+            var physIfName = _cachedGatewayWanPhysicalIfNames.TryGetValue(gwMac, out var physIf) ? physIf : null;
+            var uplinkIfName = _cachedGatewayWanIfNames.TryGetValue(gwMac, out var uplinkIf) ? uplinkIf : null;
+            var portRate = physIfName != null ? _liveStats.GetPortRate(gwMac, physIfName) : null;
+            if (portRate == null && uplinkIfName != null && uplinkIfName != physIfName)
+                portRate = _liveStats.GetPortRate(gwMac, uplinkIfName);
+            if (portRate != null)
             {
-                var portRate = _liveStats.GetPortRate(gwMac, rateIfName);
-                if (portRate != null)
-                {
-                    // Gateway WAN perspective: port TX (DownBps) = data toward
-                    // internet = uploads; port RX (UpBps) = from internet = downloads.
-                    _liveStats.RecordInterfaceAggregate(gw.Mac, portRate.DownBps, portRate.UpBps, nowOverride);
-                    continue;
-                }
+                // Gateway WAN perspective: port TX (DownBps) = data toward
+                // internet = uploads; port RX (UpBps) = from internet = downloads.
+                _liveStats.RecordInterfaceAggregate(gw.Mac, portRate.DownBps, portRate.UpBps, nowOverride);
+                continue;
             }
 
             // Fallback: PortTable IsUplink + PortIdx. Covers gateways where
@@ -649,7 +650,7 @@ public class MonitoringCollectionAgent : BackgroundService
             await _snmpGate.WaitAsync(ct);
             try
             {
-                if (_snmpExcluded.ContainsKey(NormalizeMac(device.Mac))) return;
+                if (IsSnmpExcluded(NormalizeMac(device.Mac))) return;
                 var pollIp = ResolveSnmpAddress(device, gatewayLanIp);
                 if (!IPAddress.TryParse(pollIp, out var ip)) return;
                 var metrics = await poller.GetDeviceMetricsAsync(ip, device.Name);
@@ -737,7 +738,7 @@ public class MonitoringCollectionAgent : BackgroundService
         var gatewayLanIp = await ResolveGatewayLanIpAsync(ct);
         foreach (var device in devices)
         {
-            if (_snmpExcluded.ContainsKey(NormalizeMac(device.Mac))) continue;
+            if (IsSnmpExcluded(NormalizeMac(device.Mac))) continue;
             try
             {
                 var pollIp = ResolveSnmpAddress(device, gatewayLanIp);
@@ -1663,7 +1664,7 @@ public class MonitoringCollectionAgent : BackgroundService
     private void NoteSnmpFailure(string normalizedMac)
     {
         if (string.IsNullOrEmpty(normalizedMac)) return;
-        if (_snmpExcluded.ContainsKey(normalizedMac)) return;
+        if (IsSnmpExcluded(normalizedMac)) return;
 
         var count = _snmpFailures.AddOrUpdate(normalizedMac, 1, (_, prev) => prev + 1);
         if (count < SnmpFailureThreshold) return;
@@ -1676,12 +1677,21 @@ public class MonitoringCollectionAgent : BackgroundService
         if (DateTime.UtcNow - liveStats.LastLatencyUpdate.Value > TimeSpan.FromMinutes(2)) return;
         if (!(liveStats.LatestRttMs.HasValue && liveStats.LatestRttMs.Value >= 0)) return;
 
-        if (_snmpExcluded.TryAdd(normalizedMac, 0))
+        if (_snmpExcluded.TryAdd(normalizedMac, DateTime.UtcNow))
         {
             _logger.LogInformation(
                 "Excluding {Mac} from SNMP polling for this app lifecycle - {Count} consecutive failures despite being reachable on ICMP. Device likely doesn't support SNMP.",
                 normalizedMac, count);
         }
+    }
+
+    private bool IsSnmpExcluded(string normalizedMac)
+    {
+        if (!_snmpExcluded.TryGetValue(normalizedMac, out var excludedAt)) return false;
+        if (DateTime.UtcNow - excludedAt < SnmpExclusionDuration) return true;
+        _snmpExcluded.TryRemove(normalizedMac, out _);
+        _snmpFailures.TryRemove(normalizedMac, out _);
+        return false;
     }
 
     /// <summary>Tells the dashboard which devices were dropped from SNMP polling.</summary>

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -808,7 +808,9 @@ from(bucket: ""{_longtermBucket}"")
     /// first match with loss > 1%.
     /// </summary>
     public async Task<RecentLossEvent?> FindRecentLossEventAsync(
-        DateTime? before = null, DateTime? after = null, CancellationToken ct = default)
+        DateTime? before = null, DateTime? after = null,
+        IReadOnlyCollection<string>? enabledTargetIds = null,
+        CancellationToken ct = default)
     {
         if (!IsConfigured) await ReconfigureAsync(ct);
         if (!IsConfigured) return null;
@@ -817,11 +819,18 @@ from(bucket: ""{_longtermBucket}"")
         var rangeStop = before ?? DateTime.UtcNow;
         var sortDesc = !after.HasValue;
 
+        var targetFilter = "";
+        if (enabledTargetIds != null && enabledTargetIds.Count > 0)
+        {
+            var conditions = string.Join(" or ", enabledTargetIds.Select(id => $"r.target_id == \"{id}\""));
+            targetFilter = $"\n  |> filter(fn: (r) => {conditions})";
+        }
+
         var flux = $@"
 from(bucket: ""{_bucket}"")
   |> range(start: {ToFluxInstant(rangeStart)}, stop: {ToFluxInstant(rangeStop)})
   |> filter(fn: (r) => r._measurement == ""latency"")
-  |> filter(fn: (r) => r.target_type == ""accessisp"" or r.target_type == ""transit"" or r.target_type == ""internetservice"" or r.target_type == ""wan"")
+  |> filter(fn: (r) => r.target_type == ""accessisp"" or r.target_type == ""transit"" or r.target_type == ""internetservice"" or r.target_type == ""wan""){targetFilter}
   |> filter(fn: (r) => r._field == ""loss_percent"")
   |> aggregateWindow(every: 1m, fn: mean, createEmpty: false)
   |> filter(fn: (r) => r._value > 1.0)

--- a/tests/NetworkOptimizer.Monitoring.Tests/InterfaceMetricsTests.cs
+++ b/tests/NetworkOptimizer.Monitoring.Tests/InterfaceMetricsTests.cs
@@ -288,146 +288,78 @@ public class InterfaceMetricsTests
 
     [Theory]
     [InlineData("lo", "Loopback")]
-    [InlineData("lo0", "lo0")]
     public void ShouldMonitor_Loopback_ReturnsFalse(string description, string name)
     {
-        // Arrange
-        var metrics = new InterfaceMetrics
-        {
-            Description = description,
-            Name = name
-        };
-
-        // Act & Assert
+        var metrics = new InterfaceMetrics { Description = description, Name = name };
         metrics.ShouldMonitor().Should().BeFalse();
     }
 
     [Theory]
     [InlineData("br-lan", "Bridge LAN")]
     [InlineData("br-guest", "Bridge Guest")]
+    [InlineData("br0", "br0")]
+    [InlineData("br0.42", "br0.42")]
+    [InlineData("br150", "br150")]
     public void ShouldMonitor_BridgeInterfaces_ReturnsFalse(string description, string name)
     {
-        // Arrange
-        var metrics = new InterfaceMetrics
-        {
-            Description = description,
-            Name = name
-        };
-
-        // Act & Assert
+        var metrics = new InterfaceMetrics { Description = description, Name = name };
         metrics.ShouldMonitor().Should().BeFalse();
     }
 
     [Theory]
-    [InlineData("docker0", "Docker Bridge")]
-    [InlineData("docker_gwbridge", "Docker Gateway")]
-    public void ShouldMonitor_DockerInterfaces_ReturnsFalse(string description, string name)
+    [InlineData("switch0", "switch0")]
+    [InlineData("switch0.1", "switch0.1")]
+    public void ShouldMonitor_SwitchChip_ReturnsFalse(string description, string name)
     {
-        // Arrange
-        var metrics = new InterfaceMetrics
-        {
-            Description = description,
-            Name = name
-        };
-
-        // Act & Assert
+        var metrics = new InterfaceMetrics { Description = description, Name = name };
         metrics.ShouldMonitor().Should().BeFalse();
     }
 
     [Theory]
-    [InlineData("veth1234", "veth")]
-    [InlineData("veth0ab1", "Container Interface")]
-    public void ShouldMonitor_VethInterfaces_ReturnsFalse(string description, string name)
+    [InlineData("bond0", "bond0")]
+    [InlineData("dummy0", "dummy0")]
+    [InlineData("sit0", "sit0")]
+    [InlineData("erspan0", "erspan0")]
+    [InlineData("gretap0", "gretap0")]
+    [InlineData("ip_vti0", "ip_vti0")]
+    [InlineData("ip6_vti0", "ip6_vti0")]
+    [InlineData("ip6tnl0", "ip6tnl0")]
+    [InlineData("soc0", "soc0")]
+    [InlineData("pd99", "pd99")]
+    [InlineData("mld0", "mld0")]
+    [InlineData("scan0", "scan0")]
+    public void ShouldMonitor_KernelDefaults_ReturnsFalse(string description, string name)
     {
-        // Arrange
-        var metrics = new InterfaceMetrics
-        {
-            Description = description,
-            Name = name
-        };
-
-        // Act & Assert
-        metrics.ShouldMonitor().Should().BeFalse();
-    }
-
-    [Theory]
-    [InlineData("ifb0", "ifb0")]
-    [InlineData("ifb1", "IFB Device")]
-    public void ShouldMonitor_IfbInterfaces_ReturnsFalse(string description, string name)
-    {
-        // Arrange
-        var metrics = new InterfaceMetrics
-        {
-            Description = description,
-            Name = name
-        };
-
-        // Act & Assert
-        metrics.ShouldMonitor().Should().BeFalse();
-    }
-
-    [Theory]
-    [InlineData("virbr0", "Virtual Bridge")]
-    [InlineData("virbr1", "virbr1")]
-    public void ShouldMonitor_VirbrInterfaces_ReturnsFalse(string description, string name)
-    {
-        // Arrange
-        var metrics = new InterfaceMetrics
-        {
-            Description = description,
-            Name = name
-        };
-
-        // Act & Assert
+        var metrics = new InterfaceMetrics { Description = description, Name = name };
         metrics.ShouldMonitor().Should().BeFalse();
     }
 
     [Theory]
     [InlineData("tun0", "OpenVPN Tunnel")]
-    [InlineData("tun1", "tun1")]
-    public void ShouldMonitor_TunnelInterfaces_ReturnsFalse(string description, string name)
-    {
-        // Arrange
-        var metrics = new InterfaceMetrics
-        {
-            Description = description,
-            Name = name
-        };
-
-        // Act & Assert
-        metrics.ShouldMonitor().Should().BeFalse();
-    }
-
-    [Theory]
     [InlineData("tap0", "TAP Device")]
-    [InlineData("tap1", "tap1")]
-    public void ShouldMonitor_TapInterfaces_ReturnsFalse(string description, string name)
+    [InlineData("docker0", "Docker Bridge")]
+    [InlineData("veth1234", "veth")]
+    [InlineData("ifb0", "ifb0")]
+    [InlineData("virbr0", "Virtual Bridge")]
+    [InlineData("null0", "Null Interface")]
+    [InlineData("gre0", "GRE Tunnel")]
+    [InlineData("wgclt1", "WireGuard")]
+    [InlineData("honeypot0", "Honeypot")]
+    [InlineData("wwan0", "Cellular Modem")]
+    public void ShouldMonitor_MonitorableInterfaces_ReturnsTrue(string description, string name)
     {
-        // Arrange
-        var metrics = new InterfaceMetrics
-        {
-            Description = description,
-            Name = name
-        };
-
-        // Act & Assert
-        metrics.ShouldMonitor().Should().BeFalse();
+        var metrics = new InterfaceMetrics { Description = description, Name = name };
+        metrics.ShouldMonitor().Should().BeTrue();
     }
 
     [Theory]
-    [InlineData("null0", "Null Interface")]
-    [InlineData("null1", "null1")]
-    public void ShouldMonitor_NullInterfaces_ReturnsFalse(string description, string name)
+    [InlineData("Port 1", "Loft Lower")]
+    [InlineData("Port 2", "Lobby Switch")]
+    [InlineData("Port 3", "Loading Dock")]
+    public void ShouldMonitor_UserAliasesStartingWithLo_ReturnsTrue(string description, string name)
     {
-        // Arrange
-        var metrics = new InterfaceMetrics
-        {
-            Description = description,
-            Name = name
-        };
-
-        // Act & Assert
-        metrics.ShouldMonitor().Should().BeFalse();
+        var metrics = new InterfaceMetrics { Description = description, Name = name };
+        metrics.ShouldMonitor().Should().BeTrue();
     }
 
     [Theory]
@@ -474,11 +406,9 @@ public class InterfaceMetricsTests
     [Fact]
     public void ShouldMonitor_CaseInsensitive()
     {
-        // Arrange
         var metrics1 = new InterfaceMetrics { Description = "LO", Name = "Loopback" };
-        var metrics2 = new InterfaceMetrics { Description = "DOCKER0", Name = "Docker" };
+        var metrics2 = new InterfaceMetrics { Description = "BR0", Name = "Bridge" };
 
-        // Act & Assert
         metrics1.ShouldMonitor().Should().BeFalse();
         metrics2.ShouldMonitor().Should().BeFalse();
     }
@@ -486,14 +416,12 @@ public class InterfaceMetricsTests
     [Fact]
     public void ShouldMonitor_ChecksNameIfDescriptionMatches()
     {
-        // Arrange - description doesn't match but name starts with excluded pattern
         var metrics = new InterfaceMetrics
         {
             Description = "Something Else",
-            Name = "docker0"
+            Name = "switch0.1"
         };
 
-        // Act & Assert
         metrics.ShouldMonitor().Should().BeFalse();
     }
 


### PR DESCRIPTION
## Summary

- **Upstream Discovery UX** - guides users to run Upstream Discovery when ISP/transit targets aren't configured, with inline banner and tooltip hints on empty stat cards. Navigation guards prevent losing unsaved discovery results.

- **Discovery ping verification** - pings each discovered upstream target before proposing it, filtering out unreachable hops.

- **PPPoE WAN throughput** - WAN rate lookups now fall back to the logical uplink interface (ppp*) when the physical port has no active SNMP counters.

- **SNMP exclusion recovery** - failure threshold raised from 3 to 10, exclusions expire after 1 hour instead of lasting the app lifecycle. Brief SNMP outages no longer permanently kill monitoring.

- **BulkWalk resilience** - returns partial data on mid-walk errors instead of discarding everything. A transient error on one interface no longer zeroes all interface counters.