### PR TITLE
Fix false positive packet loss events and relative time display

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1523,7 +1523,8 @@ else
         StateHasChanged();
         try
         {
-            var result = await InfluxClient.FindRecentLossEventAsync(before, after);
+            var enabledIds = _targets.Where(t => t.Enabled).Select(t => t.TargetId).ToList();
+            var result = await InfluxClient.FindRecentLossEventAsync(before, after, enabledIds);
             if (result == null)
             {
                 _lossInvestigateResult = after.HasValue ? "No newer events" : "No older events";

--- a/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
@@ -342,7 +342,7 @@
 
     private static string RelativeTime(DateTime when)
     {
-        var delta = DateTime.UtcNow - when.ToUniversalTime();
+        var delta = DateTime.UtcNow - DateTime.SpecifyKind(when, DateTimeKind.Utc);
         if (delta < TimeSpan.Zero) return "just now";
         if (delta < TimeSpan.FromSeconds(15)) return "just now";
         if (delta < TimeSpan.FromMinutes(1)) return $"{(int)delta.TotalSeconds}s ago";

--- a/src/NetworkOptimizer.Web/Endpoints/MonitoringInvestigateEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/MonitoringInvestigateEndpoints.cs
@@ -15,8 +15,13 @@ public static class MonitoringInvestigateEndpoints
             DateTime? after,
             CancellationToken ct) =>
         {
+            await using var dbForIds = await dbFactory.CreateDbContextAsync(ct);
+            var enabledIds = await dbForIds.MonitoringTargets.AsNoTracking()
+                .Where(t => t.Enabled)
+                .Select(t => t.TargetId)
+                .ToListAsync(ct);
             var result = await influx.FindRecentLossEventAsync(
-                before?.ToUniversalTime(), after?.ToUniversalTime(), ct);
+                before?.ToUniversalTime(), after?.ToUniversalTime(), enabledIds, ct);
             if (result == null)
                 return Results.Ok(new { found = false });
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1019,8 +1019,7 @@ public class UpstreamTracerService
             if (hop.AsnNumber.HasValue) existing.AsnNumber = hop.AsnNumber;
             if (!string.IsNullOrEmpty(hop.AsnName)) existing.AsnName = hop.AsnName;
             if (!string.IsNullOrEmpty(hop.PtrHostname)) existing.PtrHostname = hop.PtrHostname;
-            if (existing.Enabled)
-                existing.LastVerified = DateTime.UtcNow;
+            existing.LastVerified = DateTime.UtcNow;
         }
     }
 
@@ -1069,8 +1068,7 @@ public class UpstreamTracerService
             // (legacy rows from before the GeoLite2 path landed had nulls).
             if (transit.AsnNumber > 0) existing.AsnNumber = transit.AsnNumber;
             if (!string.IsNullOrEmpty(transit.AsnName)) existing.AsnName = transit.AsnName;
-            if (existing.Enabled)
-                existing.LastVerified = DateTime.UtcNow;
+            existing.LastVerified = DateTime.UtcNow;
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1019,7 +1019,8 @@ public class UpstreamTracerService
             if (hop.AsnNumber.HasValue) existing.AsnNumber = hop.AsnNumber;
             if (!string.IsNullOrEmpty(hop.AsnName)) existing.AsnName = hop.AsnName;
             if (!string.IsNullOrEmpty(hop.PtrHostname)) existing.PtrHostname = hop.PtrHostname;
-            existing.LastVerified = DateTime.UtcNow;
+            if (existing.Enabled)
+                existing.LastVerified = DateTime.UtcNow;
         }
     }
 
@@ -1068,7 +1069,8 @@ public class UpstreamTracerService
             // (legacy rows from before the GeoLite2 path landed had nulls).
             if (transit.AsnNumber > 0) existing.AsnNumber = transit.AsnNumber;
             if (!string.IsNullOrEmpty(transit.AsnName)) existing.AsnName = transit.AsnName;
-            existing.LastVerified = DateTime.UtcNow;
+            if (existing.Enabled)
+                existing.LastVerified = DateTime.UtcNow;
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -808,7 +808,9 @@ from(bucket: ""{_longtermBucket}"")
     /// first match with loss > 1%.
     /// </summary>
     public async Task<RecentLossEvent?> FindRecentLossEventAsync(
-        DateTime? before = null, DateTime? after = null, CancellationToken ct = default)
+        DateTime? before = null, DateTime? after = null,
+        IReadOnlyCollection<string>? enabledTargetIds = null,
+        CancellationToken ct = default)
     {
         if (!IsConfigured) await ReconfigureAsync(ct);
         if (!IsConfigured) return null;
@@ -817,11 +819,18 @@ from(bucket: ""{_longtermBucket}"")
         var rangeStop = before ?? DateTime.UtcNow;
         var sortDesc = !after.HasValue;
 
+        var targetFilter = "";
+        if (enabledTargetIds != null && enabledTargetIds.Count > 0)
+        {
+            var conditions = string.Join(" or ", enabledTargetIds.Select(id => $"r.target_id == \"{id}\""));
+            targetFilter = $"\n  |> filter(fn: (r) => {conditions})";
+        }
+
         var flux = $@"
 from(bucket: ""{_bucket}"")
   |> range(start: {ToFluxInstant(rangeStart)}, stop: {ToFluxInstant(rangeStop)})
   |> filter(fn: (r) => r._measurement == ""latency"")
-  |> filter(fn: (r) => r.target_type == ""accessisp"" or r.target_type == ""transit"" or r.target_type == ""internetservice"" or r.target_type == ""wan"")
+  |> filter(fn: (r) => r.target_type == ""accessisp"" or r.target_type == ""transit"" or r.target_type == ""internetservice"" or r.target_type == ""wan""){targetFilter}
   |> filter(fn: (r) => r._field == ""loss_percent"")
   |> aggregateWindow(every: 1m, fn: mean, createEmpty: false)
   |> filter(fn: (r) => r._value > 1.0)


### PR DESCRIPTION
## Summary

- **Packet Loss Events filter** - the loss event navigator now only searches latency data for currently enabled targets, preventing false positives from disabled/paused targets' historical data.

- **Relative time display** - fixed "Last verified" always showing "just now" on non-UTC servers. SQLite/EF Core returns DateTime with Kind=Unspecified; the old `.ToUniversalTime()` call assumed local time and shifted it forward by the server's UTC offset, making the delta negative.

## Test plan

- [x] Disable a target, click Packet Loss Events - should not find loss data from the disabled target
- [x] Verify "Last verified" column shows correct relative times (not "just now" for old timestamps) on a non-UTC server