### PR TITLE
Fix trunk link live rates and SNMP interface filter

### DIFF
--- a/src/NetworkOptimizer.Monitoring/Models/InterfaceMetrics.cs
+++ b/src/NetworkOptimizer.Monitoring/Models/InterfaceMetrics.cs
@@ -194,22 +194,27 @@ public class InterfaceMetrics
         var desc = Description.ToLowerInvariant();
         var name = Name.ToLowerInvariant();
 
-        if (desc == "lo" || name == "lo") return false;
+        var exactExclude = new[]
+        {
+            "lo", "bond0", "dummy0", "sit0", "erspan0",
+            "gretap0",
+            "ip_vti0", "ip6_vti0", "ip6tnl0",
+            "soc0", "soc2", "pd99", "mld0", "scan0",
+            "miireg", "teql0",
+        };
+        foreach (var e in exactExclude)
+        {
+            if (desc == e || name == e) return false;
+        }
 
         var excludePrefixes = new[]
         {
-            "loopback",  // Loopback (some devices use full name)
-            "br-",       // Bridge
-            "docker",    // Docker
-            "veth",      // Virtual Ethernet
-            "ifb",       // Intermediate Functional Block
-            "virbr",     // Virtual Bridge
-            "tun",       // Tunnel
-            "tap",       // TAP device
-            "null",      // Null interface
-            "device ",   // USB/PCI device descriptors (e.g. Qualcomm chipset "Device 17cb:1109")
-            "miireg",    // MII register access (not a network interface)
-            "teql",      // Traffic equalizer
+            "loopback",    // Loopback (some devices use full name)
+            "br0", "br-",  // Bridge (br0, br0.42, br-trunk)
+            "br1", "br2", "br3", "br4", "br5", "br6", "br7", "br8", "br9",  // Numbered bridges (br150, br200, br4040)
+            "switch0",     // Internal switch chip (switch0, switch0.1)
+            "mld-",        // Multicast listener discovery
+            "device ",     // USB/PCI descriptors (e.g. "Device 17cb:1109")
         };
 
         foreach (var pattern in excludePrefixes)

--- a/src/NetworkOptimizer.Monitoring/Models/InterfaceMetrics.cs
+++ b/src/NetworkOptimizer.Monitoring/Models/InterfaceMetrics.cs
@@ -194,10 +194,11 @@ public class InterfaceMetrics
         var desc = Description.ToLowerInvariant();
         var name = Name.ToLowerInvariant();
 
-        // Exclude common virtual/internal interfaces
-        var excludePatterns = new[]
+        if (desc == "lo" || name == "lo") return false;
+
+        var excludePrefixes = new[]
         {
-            "lo",        // Loopback
+            "loopback",  // Loopback (some devices use full name)
             "br-",       // Bridge
             "docker",    // Docker
             "veth",      // Virtual Ethernet
@@ -211,7 +212,7 @@ public class InterfaceMetrics
             "teql",      // Traffic equalizer
         };
 
-        foreach (var pattern in excludePatterns)
+        foreach (var pattern in excludePrefixes)
         {
             if (desc.StartsWith(pattern) || name.StartsWith(pattern))
                 return false;

--- a/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
+++ b/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
@@ -355,9 +355,13 @@ public class SnmpPoller : ISnmpPoller
                 {
                     interfaces.Add(metrics);
                 }
+                else
+                {
+                    _logger.LogDebug("ShouldMonitor rejected ifIndex {Idx} desc={Desc} name={Name} on {Ip}", idx, descr, metrics.Name, ip);
+                }
             }
 
-            DebugLog($"Collected metrics for {interfaces.Count} interfaces");
+            DebugLog($"Collected metrics for {interfaces.Count} interfaces from {metadata.DescrByIdx.Count} in metadata");
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -2317,7 +2317,7 @@
     private string _monitoringMessageClass = "success";
 
     // Editable InfluxDB connection inputs (loaded from MonitoringSettings)
-    private string _influxUrl = "http://localhost:8087";
+    private string _influxUrl = "http://localhost:8086";
     private string _influxToken = string.Empty;
     private bool _influxTokenIsSet = false;
     private string _influxOrg = "network-optimizer";
@@ -4669,7 +4669,7 @@
             _monitoringSettings = await SnmpDetection.GetOrCreateSettingsAsync();
             if (_monitoringSettings != null)
             {
-                _influxUrl = _monitoringSettings.InfluxDbUrl ?? "http://localhost:8087";
+                _influxUrl = _monitoringSettings.InfluxDbUrl ?? "http://localhost:8086";
                 _influxOrg = _monitoringSettings.InfluxDbOrg ?? "network-optimizer";
                 _influxBucket = _monitoringSettings.InfluxDbBucket ?? "network_monitoring";
                 _influxLongtermBucket = _monitoringSettings.InfluxDbLongtermBucket ?? "network_monitoring_longterm";

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -222,25 +222,62 @@ public class LanFlowMapService
             }
             else if (link.Kind == LanLinkKind.Uplink || link.Kind == LanLinkKind.MeshBackhaul)
             {
-                // For infrastructure uplinks the child device's aggregate is the most
-                // live measurement we have on every tick. The empirical convention from
-                // the AP badge work: aggregateInBps holds the upload-direction value
-                // (data flowing toward the gateway), aggregateOutBps holds downloads.
-                // The link's particle layer expects DownstreamBps to be downloads
-                // (parent -> child, blue) and UpstreamBps to be uploads
-                // (child -> parent, green), so map accordingly.
-                var childDev = ExtractDeviceMacFromUplinkId(link.Id);
-                if (!string.IsNullOrEmpty(childDev))
+                // Primary: parent's trunk port via PortKey (same SNMP-fed path
+                // that wired client links use, 5 s cadence).
+                if (!string.IsNullOrEmpty(link.PortKey))
                 {
-                    var stats = _liveStats.GetForDevice(childDev);
-                    if (stats != null && stats.LastRateUpdate.HasValue)
+                    var (parentMac, pIfName) = ParsePortKey(link.PortKey);
+                    var portRate = _liveStats.GetPortRate(parentMac, pIfName);
+                    if (portRate != null)
                     {
                         rates = new LinkLiveRates
                         {
-                            DownstreamBps = stats.RateOutBps ?? 0,
-                            UpstreamBps = stats.RateInBps ?? 0,
-                            AsOf = stats.LastRateUpdate.Value,
+                            DownstreamBps = portRate.DownBps,
+                            UpstreamBps = portRate.UpBps,
+                            AsOf = portRate.LastUpdate,
                         };
+                    }
+                }
+                // Fallback: child's own uplink port.
+                if (rates == null)
+                {
+                    var childDev = ExtractDeviceMacFromUplinkId(link.Id);
+                    if (!string.IsNullOrEmpty(childDev))
+                    {
+                        var childNode = snapshot.Nodes.FirstOrDefault(n =>
+                            string.Equals(n.Mac, childDev, StringComparison.OrdinalIgnoreCase));
+                        if (childNode?.UplinkIfName != null)
+                        {
+                            var portRate = _liveStats.GetPortRate(childDev, childNode.UplinkIfName);
+                            if (portRate != null)
+                            {
+                                rates = new LinkLiveRates
+                                {
+                                    DownstreamBps = portRate.UpBps,
+                                    UpstreamBps = portRate.DownBps,
+                                    AsOf = portRate.LastUpdate,
+                                };
+                            }
+                        }
+                    }
+                }
+                // Last resort: device-level aggregate (covers APs whose radio
+                // interfaces don't map to per-port SNMP counters).
+                if (rates == null)
+                {
+                    var childDev = ExtractDeviceMacFromUplinkId(link.Id);
+                    if (!string.IsNullOrEmpty(childDev))
+                    {
+                        var stats = _liveStats.GetForDevice(childDev);
+                        if (stats != null && stats.LastRateUpdate.HasValue)
+                        {
+                            rates = new LinkLiveRates
+                            {
+                                DownstreamBps = stats.RateOutBps ?? 0,
+                                UpstreamBps = stats.RateInBps ?? 0,
+                                AsOf = stats.LastRateUpdate.Value,
+                            };
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- **Trunk link live rates** - uplink links now use per-port SNMP rates (5 s cadence) instead of the device-level aggregate, which was only written for APs and not switches. Falls back to the child's uplink port, then the device aggregate for APs. Fixes trunk links showing idle in live mode and then bursting at 6x the real rate every 30 seconds.

- **SNMP interface filter** - the loopback filter ("lo" prefix match) was also excluding any port whose alias starts with "Lo" (e.g., "Loft Lower", "Lobby"). Rebuilt the filter from actual device data across both test sites: exact matches for kernel defaults, safe prefixes for bridges and switch-chip internals. Keeps gre, wireguard, honeypot, wwan, and ifb as monitorable.

- **Default InfluxDB port** - changed from 8087 to 8086 (InfluxDB's standard default).

## Test plan

- [x] Verify trunk links animate smoothly in live 3D view during a speed test (no 30 s burst lag)
- [x] Verify ports with aliases starting with "Lo" (Loft, Lobby, etc.) appear in monitoring
- [x] Confirm mesh AP backhaul links still animate correctly in live mode
- [x] Check InfluxDB for no junk interfaces (bond0, br0, switch0, etc.) in last 30 s