### PR TITLE
Guard 3D map against NaN geometry, bump PerfTweaks FW, nav cleanup

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Layout/NavMenu.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/NavMenu.razor
@@ -21,12 +21,6 @@
                 <span class="nav-text">Network Tools</span>
             </NavLink>
         </li>
-        <li class="nav-item nav-sub-item" @onclick="HandleNavClick">
-            <NavLink class="nav-link" href="/upnp-inspector">
-                <span class="nav-sub-icon">└</span>
-                <span class="nav-text">UPnP Inspector</span>
-            </NavLink>
-        </li>
         <li class="nav-item" @onclick="HandleNavClick">
             <NavLink class="nav-link" href="/config-optimizer">
                 <img src="/icons/tools.png" alt="" class="nav-icon-img" />
@@ -55,6 +49,12 @@
             <NavLink class="nav-link" href="/audit">
                 <img src="/icons/shield-v2.png" alt="" class="nav-icon-img" />
                 <span class="nav-text">Security Audit</span>
+            </NavLink>
+        </li>
+        <li class="nav-item nav-sub-item" @onclick="HandleNavClick">
+            <NavLink class="nav-link" href="/upnp-inspector">
+                <span class="nav-sub-icon">└</span>
+                <span class="nav-text">UPnP Inspector</span>
             </NavLink>
         </li>
         <li class="nav-item" @onclick="HandleNavClick">

--- a/src/NetworkOptimizer.Web/Components/Layout/NavMenu.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/NavMenu.razor
@@ -11,7 +11,7 @@
         </li>
         <li class="nav-item" @onclick="HandleNavClick">
             <NavLink class="nav-link" href="/monitoring">
-                <img src="/icons/monitoring.svg" alt="" class="nav-icon-img" />
+                <img src="/icons/port-scan.png" alt="" class="nav-icon-img" />
                 <span class="nav-text">Monitoring</span>
             </NavLink>
         </li>
@@ -19,6 +19,12 @@
             <NavLink class="nav-link" href="/monitoring/tools">
                 <span class="nav-sub-icon">└</span>
                 <span class="nav-text">Network Tools</span>
+            </NavLink>
+        </li>
+        <li class="nav-item nav-sub-item" @onclick="HandleNavClick">
+            <NavLink class="nav-link" href="/upnp-inspector">
+                <span class="nav-sub-icon">└</span>
+                <span class="nav-text">UPnP Inspector</span>
             </NavLink>
         </li>
         <li class="nav-item" @onclick="HandleNavClick">
@@ -55,12 +61,6 @@
             <NavLink class="nav-link" href="/threats">
                 <img src="/icons/threats.png" alt="" class="nav-icon-img" />
                 <span class="nav-text">Threat Intelligence</span>
-            </NavLink>
-        </li>
-        <li class="nav-item" @onclick="HandleNavClick">
-            <NavLink class="nav-link" href="/upnp-inspector">
-                <img src="/icons/port-scan.png" alt="" class="nav-icon-img" />
-                <span class="nav-text">UPnP Inspector</span>
             </NavLink>
         </li>
         <li class="nav-item" @onclick="HandleNavClick">

--- a/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
@@ -18,7 +18,7 @@ public class PerfTweaksDeploymentService
     private const string OnBootDir = "/data/on_boot.d";
     private const string PerfTweaksDir = "/data/perf-tweaks";
     private const string SfpModuleDir = "/data/sfp-sgmiiplus";
-    private static readonly Version MaxSupportedFirmware = new(5, 1, 12);
+    private static readonly Version MaxSupportedFirmware = new(5, 1, 13);
 
     private static readonly Dictionary<string, string> BootScriptFiles = new()
     {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -531,31 +531,32 @@ export class LanFlowMap {
 
         for (const node of snap.nodes) {
             const p = node.placement;
-            if (p && p.source === PLACEMENT_SOURCE.Anchor
-                && Number.isFinite(p.x) && Number.isFinite(p.y) && Number.isFinite(p.z)) {
-                // Vertical offset within the floor by device type:
-                // APs use their mount type, clients mid-floor, infra at desk level.
-                const isClient = node.kind === NODE_KIND.WiredClient || node.kind === NODE_KIND.WifiClient;
-                const isInfra = node.kind === NODE_KIND.Switch || node.kind === NODE_KIND.Gateway;
-                const mountM = node.mountType ? (mountOffsetM[node.mountType] || 0)
-                    : isClient ? WALL_H_M * 0.5
-                    : isInfra ? WALL_H_M * 0.15
-                    : 0;
-                positions.set(node.id, {
-                    x: -p.x * scale,
-                    y: p.z * scale * 0.8 + mountM * scale * 0.8,
-                    z: p.y * scale,
-                    pinned: true,
-                });
-                anchors.set(node.id, true);
-            } else if (p && p.source === PLACEMENT_SOURCE.Interpolated
-                && Number.isFinite(p.x) && Number.isFinite(p.y) && Number.isFinite(p.z)) {
-                positions.set(node.id, {
-                    x: -p.x * scale,
-                    y: p.z * scale * 0.8 - 4,
-                    z: p.y * scale,
-                    pinned: false,
-                });
+            if (p && (p.source === PLACEMENT_SOURCE.Anchor || p.source === PLACEMENT_SOURCE.Interpolated)) {
+                if (!Number.isFinite(p.x) || !Number.isFinite(p.y) || !Number.isFinite(p.z)) {
+                    console.warn('[LanFlowMap] Non-finite placement for node', node.id, node.name,
+                        '| placement:', { x: p.x, y: p.y, z: p.z, source: p.source });
+                } else if (p.source === PLACEMENT_SOURCE.Anchor) {
+                    const isClient = node.kind === NODE_KIND.WiredClient || node.kind === NODE_KIND.WifiClient;
+                    const isInfra = node.kind === NODE_KIND.Switch || node.kind === NODE_KIND.Gateway;
+                    const mountM = node.mountType ? (mountOffsetM[node.mountType] || 0)
+                        : isClient ? WALL_H_M * 0.5
+                        : isInfra ? WALL_H_M * 0.15
+                        : 0;
+                    positions.set(node.id, {
+                        x: -p.x * scale,
+                        y: p.z * scale * 0.8 + mountM * scale * 0.8,
+                        z: p.y * scale,
+                        pinned: true,
+                    });
+                    anchors.set(node.id, true);
+                } else {
+                    positions.set(node.id, {
+                        x: -p.x * scale,
+                        y: p.z * scale * 0.8 - 4,
+                        z: p.y * scale,
+                        pinned: false,
+                    });
+                }
             }
         }
 
@@ -980,9 +981,22 @@ export class LanFlowMap {
         const to = new THREE.Vector3(b.x, b.y, b.z);
         const dir = to.clone().sub(from);
         const length = dir.length();
-        if (!Number.isFinite(length) || length < 0.01) return new THREE.Group();
+        if (!Number.isFinite(length) || length < 0.01) {
+            if (!Number.isFinite(length)) {
+                console.warn('[LanFlowMap] NaN pipe length for link', link.id,
+                    '| from:', { x: a.x, y: a.y, z: a.z },
+                    '| to:', { x: b.x, y: b.y, z: b.z },
+                    '| capacityBps:', link.capacityBps);
+            }
+            return new THREE.Group();
+        }
 
         const baseRadius = this._pipeRadiusForCapacity(link.capacityBps);
+        if (!Number.isFinite(baseRadius)) {
+            console.warn('[LanFlowMap] NaN pipe radius for link', link.id,
+                '| capacityBps:', link.capacityBps, '(type:', typeof link.capacityBps, ')');
+            return new THREE.Group();
+        }
         const geo = new THREE.CylinderGeometry(baseRadius, baseRadius, length, 14, 1, true);
         const mat = new THREE.MeshStandardMaterial({
             color: COLORS.pipeCool,
@@ -1005,7 +1019,7 @@ export class LanFlowMap {
     }
 
     _pipeRadiusForCapacity(capacityBps) {
-        if (!capacityBps || capacityBps <= 0) return 0.10;
+        if (typeof capacityBps !== 'number' || !Number.isFinite(capacityBps) || capacityBps <= 0) return 0.10;
         // Log scale: 100 Mbps -> 0.13, 1 Gbps -> 0.18, 10 Gbps -> 0.24, 25 Gbps -> 0.28.
         const gbps = capacityBps / 1_000_000_000;
         const t = Math.log10(Math.max(gbps, 0.01)) + 2;  // 1 Mbps -> 0, 10 Gbps -> 3

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -518,7 +518,8 @@ export class LanFlowMap {
         // devices have room to settle between the pinned APs without crowding.
         const sceneRadius = 30.0;
         const ANCHOR_SPREAD_FACTOR = 1.875;
-        const scale = (sceneRadius / Math.max(bounds.radius, 1.0)) * ANCHOR_SPREAD_FACTOR;
+        const boundsR = Number.isFinite(bounds.radius) ? bounds.radius : 1.0;
+        const scale = (sceneRadius / Math.max(boundsR, 1.0)) * ANCHOR_SPREAD_FACTOR;
 
         const positions = new Map();
         const anchors = new Map();
@@ -530,7 +531,8 @@ export class LanFlowMap {
 
         for (const node of snap.nodes) {
             const p = node.placement;
-            if (p && p.source === PLACEMENT_SOURCE.Anchor) {
+            if (p && p.source === PLACEMENT_SOURCE.Anchor
+                && Number.isFinite(p.x) && Number.isFinite(p.y) && Number.isFinite(p.z)) {
                 // Vertical offset within the floor by device type:
                 // APs use their mount type, clients mid-floor, infra at desk level.
                 const isClient = node.kind === NODE_KIND.WiredClient || node.kind === NODE_KIND.WifiClient;
@@ -546,7 +548,8 @@ export class LanFlowMap {
                     pinned: true,
                 });
                 anchors.set(node.id, true);
-            } else if (p && p.source === PLACEMENT_SOURCE.Interpolated) {
+            } else if (p && p.source === PLACEMENT_SOURCE.Interpolated
+                && Number.isFinite(p.x) && Number.isFinite(p.y) && Number.isFinite(p.z)) {
                 positions.set(node.id, {
                     x: -p.x * scale,
                     y: p.z * scale * 0.8 - 4,
@@ -977,7 +980,7 @@ export class LanFlowMap {
         const to = new THREE.Vector3(b.x, b.y, b.z);
         const dir = to.clone().sub(from);
         const length = dir.length();
-        if (length < 0.01) return new THREE.Group();
+        if (!Number.isFinite(length) || length < 0.01) return new THREE.Group();
 
         const baseRadius = this._pipeRadiusForCapacity(link.capacityBps);
         const geo = new THREE.CylinderGeometry(baseRadius, baseRadius, length, 14, 1, true);
@@ -2640,7 +2643,7 @@ export class LanFlowMap {
         const to = new THREE.Vector3(b.x, b.y, b.z);
         const dir = to.clone().sub(from);
         const length = dir.length();
-        if (length < 0.01) return;
+        if (!Number.isFinite(length) || length < 0.01) return;
 
         const mid = from.clone().add(to).multiplyScalar(0.5);
         pipe.position.copy(mid);
@@ -2670,7 +2673,8 @@ export class LanFlowMap {
         }
         const sceneRadius = 30.0;
         const ANCHOR_SPREAD_FACTOR = 1.875;
-        const scale = (sceneRadius / Math.max(bounds.radius, 1.0)) * ANCHOR_SPREAD_FACTOR;
+        const boundsR = Number.isFinite(bounds.radius) ? bounds.radius : 1.0;
+        const scale = (sceneRadius / Math.max(boundsR, 1.0)) * ANCHOR_SPREAD_FACTOR;
         const EARTH_RADIUS = 6_371_000.0;
 
         // Undo JS transform: posX = -(local.x * scale), posZ = local.y * scale
@@ -2776,7 +2780,12 @@ class ParticleStream {
         this._to = toV;
         this._direction = toV.clone().sub(fromV);
         this._length = this._direction.length();
-        this._direction.normalize();
+        if (Number.isFinite(this._length) && this._length > 0.001) {
+            this._direction.normalize();
+        } else {
+            this._length = 0;
+            this._direction.set(0, 1, 0);
+        }
 
         const MAX = 200;
         this._max = MAX;


### PR DESCRIPTION
## Summary

- **3D LAN Flow Map NaN fix (#680)** - Added `Number.isFinite` guards throughout the 3D map pipe and layout code to prevent `CylinderGeometry` NaN errors that blank the entire map. Nodes with non-finite placement data fall through to random positioning instead of propagating NaN. Diagnostic `console.warn` logging captures the exact values when NaN is detected so the root cause can be identified from future reports. Tightened `_pipeRadiusForCapacity` to reject non-numeric input via `typeof` check.

- **PerfTweaks firmware bump (#679)** - `MaxSupportedFirmware` 5.1.12 -> 5.1.13 per user-confirmed EA testing.

- **Nav menu cleanup** - Moved UPnP Inspector under Security Audit as a sub-item. Swapped Monitoring icon from `monitoring.svg` to the port-scan icon.

## Test plan

- [x] 3D LAN Flow Map renders correctly on both test sites
- [x] No `NaN` or `computeBoundingSphere` errors in browser console
- [x] PerfTweaks shows 5.1.13 as supported
- [x] Nav menu: UPnP Inspector appears indented under Security Audit
- [x] Nav menu: Monitoring uses port-scan icon