### PR TITLE
Fix container hang from stale migration lock after interrupted startup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -148,7 +148,7 @@ EXPOSE 8042
 EXPOSE 5201
 
 # Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
     CMD curl -f http://localhost:8042/api/health || exit 1
 
 # Set ownership for app directories

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -48,7 +48,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 40s
+      start_period: 120s
 
   # Network Optimizer Speed Test - customized OpenSpeedTest that sends results to Network Optimizer
   # Requires HOST_IP or HOST_NAME to be set in .env for result reporting

--- a/docker/docker-compose.macos.yml
+++ b/docker/docker-compose.macos.yml
@@ -47,7 +47,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 40s
+      start_period: 120s
 
   # Network Optimizer Speed Test - customized OpenSpeedTest that sends results to Network Optimizer
   # Requires HOST_IP or HOST_NAME to be set in .env for result reporting

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -39,7 +39,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 40s
+      start_period: 120s
 
   # Network Optimizer Speed Test - customized OpenSpeedTest that sends results to Network Optimizer
   # Requires HOST_IP or HOST_NAME to be set in .env for result reporting

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 40s
+      start_period: 120s
 
   # Network Optimizer Speed Test - customized OpenSpeedTest that sends results to Network Optimizer
   # Requires HOST_IP or HOST_NAME to be set in .env for result reporting

--- a/scripts/proxmox/install.sh
+++ b/scripts/proxmox/install.sh
@@ -759,7 +759,7 @@ deploy_application() {
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 40s
+      start_period: 120s
 
   network-optimizer-speedtest:
     image: ghcr.io/ozark-connect/speedtest:latest

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -533,10 +533,25 @@ using (var scope = app.Services.CreateScope())
             }
         }
     }
+
+    // Clear stale migration locks left by a previous interrupted startup (#624).
+    // At app startup no other process can be migrating this SQLite DB, so any lock is stale.
+    cmd.Parameters.Clear();
+    cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name='__EFMigrationsLock'";
+    if (cmd.ExecuteScalar() != null)
+    {
+        cmd.CommandText = "DELETE FROM __EFMigrationsLock";
+        var cleared = cmd.ExecuteNonQuery();
+        if (cleared > 0)
+            app.Logger.LogWarning("Cleared stale migration lock (likely from a previous interrupted startup)");
+    }
+
     conn.Close();
 
     // Apply any pending migrations (creates DB for new installs, or applies new migrations for existing)
+    app.Logger.LogInformation("Applying database migrations...");
     db.Database.Migrate();
+    app.Logger.LogInformation("Database migrations complete");
 
     // Ensure WAL mode - config imports replace the DB with a DELETE-mode copy
     db.Database.ExecuteSqlRaw("PRAGMA journal_mode=WAL;");


### PR DESCRIPTION
Closes #624

## Summary

- **Clear stale EF Core migration locks on startup** - If a container is killed mid-migration (by Docker healthcheck, Kubernetes liveness probe, etc.), the `__EFMigrationsLock` row is left behind. On restart, `Migrate()` spins forever trying to acquire the lock. Since this is a single-process SQLite app, any lock present at startup is definitionally stale - clear it and log a warning.
- **Increase Docker healthcheck `start_period` from 40s to 120s** - Gives large version-jump migrations (e.g. 1.11 to 1.15) more time to complete before health checks start counting failures. Updated across Dockerfile, all compose files, and the Proxmox install script.
- **Log migration start/complete** - So users can see what's happening during startup instead of silence.

## Test plan

- [x] Verified `sqlite_master` query returns correct results on both NAS and Mac databases
- [x] Verified neither test site has a stale lock (expected for healthy instances)
- [x] Build passes with 0 warnings
- [x] Deployed to both NAS and Mac test sites