### PR TITLE
2D LAN Topology Flow Map, shared data pipeline, client hydration

### DIFF
--- a/src/NetworkOptimizer.Storage/Models/MonitoringSettings.cs
+++ b/src/NetworkOptimizer.Storage/Models/MonitoringSettings.cs
@@ -101,6 +101,10 @@ public class MonitoringSettings
 
     public bool Flex25GLatencyMigrated { get; set; }
 
+    /// <summary>JSON map of MAC → exclusion timestamp for devices that don't support SNMP.
+    /// Persisted so exclusions survive container restarts without re-learning.</summary>
+    public string? SnmpExcludedDevicesJson { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 

--- a/src/NetworkOptimizer.Storage/Models/MonitoringSettings.cs
+++ b/src/NetworkOptimizer.Storage/Models/MonitoringSettings.cs
@@ -101,10 +101,6 @@ public class MonitoringSettings
 
     public bool Flex25GLatencyMigrated { get; set; }
 
-    /// <summary>JSON map of MAC → exclusion timestamp for devices that don't support SNMP.
-    /// Persisted so exclusions survive container restarts without re-learning.</summary>
-    public string? SnmpExcludedDevicesJson { get; set; }
-
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 

--- a/src/NetworkOptimizer.UniFi/Models/UniFiClientResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiClientResponse.cs
@@ -158,6 +158,18 @@ public class UniFiClientResponse
     [JsonPropertyName("rx_bytes-r")]
     public double RxBytesRate { get; set; }
 
+    [JsonPropertyName("wired-tx_bytes")]
+    public long WiredTxBytes { get; set; }
+
+    [JsonPropertyName("wired-rx_bytes")]
+    public long WiredRxBytes { get; set; }
+
+    [JsonPropertyName("wired-tx_bytes-r")]
+    public double WiredTxBytesRate { get; set; }
+
+    [JsonPropertyName("wired-rx_bytes-r")]
+    public double WiredRxBytesRate { get; set; }
+
     // QoS and experience
     [JsonPropertyName("qos_policy_applied")]
     public bool QosPolicyApplied { get; set; }

--- a/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
@@ -70,6 +70,12 @@ public class UniFiDeviceResponse
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
+    [JsonPropertyName("snmp_contact")]
+    public string? SnmpContact { get; set; }
+
+    [JsonPropertyName("snmp_location")]
+    public string? SnmpLocation { get; set; }
+
     /// <summary>
     /// Gets the best available friendly product name using the product database lookup
     /// </summary>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -769,7 +769,7 @@ else
         max-width: 260px;
     }
     .lan-flow-map-2d-stage .lan-flow-map-controls {
-        right: 3.5rem;
+        right: 3.1rem;
         top: 0.75rem;
     }
     .lfm2d-toolbar {

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -758,15 +758,16 @@ else
     .lfm2d-tooltip {
         position: absolute;
         background: rgba(16, 24, 32, 0.92);
-        border: 1px solid rgba(255, 255, 255, 0.08);
-        border-radius: 6px;
-        padding: 4px 8px;
-        font-size: 0.75rem;
+        border: 1px solid rgba(255, 255, 255, 0.06);
+        border-radius: 8px;
+        padding: 0.5rem 0.65rem;
+        font-size: 0.78rem;
+        line-height: 1.35;
         color: var(--text-primary);
         pointer-events: none;
-        white-space: nowrap;
         display: none;
-        z-index: 3;
+        z-index: 10;
+        max-width: 260px;
     }
     .lfm2d-toolbar {
         position: absolute;

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -748,8 +748,11 @@ else
     .lan-flow-map-2d-stage {
         width: 100%;
         height: 620px;
-        overflow: hidden;
         position: relative;
+        overflow: clip;
+    }
+    .lan-flow-map-2d-stage.lan-flow-map-fullscreen {
+        overflow: visible;
     }
     .lfm2d-canvas {
         display: block;

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -768,6 +768,10 @@ else
         z-index: 10;
         max-width: 260px;
     }
+    .lan-flow-map-2d-stage .lan-flow-map-controls {
+        right: 3.5rem;
+        top: 0.75rem;
+    }
     .lfm2d-toolbar {
         position: absolute;
         top: 48px;

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -743,6 +743,7 @@ else
     .lan-flow-map-2d-body {
         padding: 0;
         background: #202023;
+        position: relative;
     }
     .lan-flow-map-2d-stage {
         width: 100%;
@@ -755,11 +756,38 @@ else
         height: auto;
         min-height: 420px;
     }
-    .lan-flow-map-2d-stage .infra-node {
+    .lan-flow-map-2d-stage .cl {
         cursor: default;
     }
-    .lan-flow-map-2d-stage .client-node {
-        cursor: default;
+    .lan-flow-map-2d-stage svg {
+        cursor: grab;
+    }
+    .lfm2d-toolbar {
+        position: absolute;
+        top: 12px;
+        right: 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        z-index: 2;
+    }
+    .lfm2d-btn {
+        width: 32px;
+        height: 32px;
+        border: 1px solid rgba(255,255,255,0.1);
+        border-radius: 6px;
+        background: rgba(26,29,35,0.9);
+        color: var(--text-secondary);
+        font-size: 16px;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        line-height: 1;
+    }
+    .lfm2d-btn:hover {
+        background: rgba(51,56,68,0.9);
+        color: var(--text-primary);
     }
 </style>
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -747,7 +747,7 @@ else
     }
     .lan-flow-map-2d-stage {
         width: 100%;
-        height: 520px;
+        height: 620px;
         overflow: hidden;
     }
     .lfm2d-canvas {

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -747,20 +747,26 @@ else
     }
     .lan-flow-map-2d-stage {
         width: 100%;
-        min-height: 420px;
+        height: 520px;
         overflow: hidden;
     }
-    .lan-flow-map-2d-stage svg {
+    .lfm2d-canvas {
         display: block;
         width: 100%;
-        height: auto;
-        min-height: 420px;
+        height: 100%;
     }
-    .lan-flow-map-2d-stage .cl {
-        cursor: default;
-    }
-    .lan-flow-map-2d-stage svg {
-        cursor: grab;
+    .lfm2d-tooltip {
+        position: absolute;
+        background: rgba(16, 24, 32, 0.92);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: 6px;
+        padding: 4px 8px;
+        font-size: 0.75rem;
+        color: var(--text-primary);
+        pointer-events: none;
+        white-space: nowrap;
+        display: none;
+        z-index: 3;
     }
     .lfm2d-toolbar {
         position: absolute;

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -749,6 +749,7 @@ else
         width: 100%;
         height: 620px;
         overflow: hidden;
+        position: relative;
     }
     .lfm2d-canvas {
         display: block;

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -217,7 +217,7 @@ else
         <!-- 2D LAN hierarchy map -->
         <div class="card lan-flow-map-2d-card" style="margin-top: 1.5rem;">
             <div class="card-header">
-                <h2 class="card-title">LAN Topology</h2>
+                <h2 class="card-title">LAN Topology Flow Map</h2>
             </div>
             <div class="card-body lan-flow-map-2d-body">
                 <div id="lan-flow-map-2d-stage" class="lan-flow-map-2d-stage"></div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -213,6 +213,16 @@ else
                 <div class="stat-label">Fabric Egress</div>
             </div>
         </div>
+
+        <!-- 2D LAN hierarchy map -->
+        <div class="card lan-flow-map-2d-card" style="margin-top: 1.5rem;">
+            <div class="card-header">
+                <h2 class="card-title">LAN Topology</h2>
+            </div>
+            <div class="card-body lan-flow-map-2d-body">
+                <div id="lan-flow-map-2d-stage" class="lan-flow-map-2d-stage"></div>
+            </div>
+        </div>
     }
 
     @* ──────────────── Tab: Network Performance ──────────────── *@
@@ -726,6 +736,31 @@ else
             font-size: 1rem;
         }
     }
+
+    .lan-flow-map-2d-card {
+        overflow: hidden;
+    }
+    .lan-flow-map-2d-body {
+        padding: 0;
+        background: #202023;
+    }
+    .lan-flow-map-2d-stage {
+        width: 100%;
+        min-height: 420px;
+        overflow: hidden;
+    }
+    .lan-flow-map-2d-stage svg {
+        display: block;
+        width: 100%;
+        height: auto;
+        min-height: 420px;
+    }
+    .lan-flow-map-2d-stage .infra-node {
+        cursor: default;
+    }
+    .lan-flow-map-2d-stage .client-node {
+        cursor: default;
+    }
 </style>
 
 @code {
@@ -774,6 +809,7 @@ else
 
     // Chart mount tracking
     private bool _mapMounted = false;
+    private bool _map2dMounted = false;
     private bool _latencyChartsMounted;
     private bool _healthChartsMounted;
     private bool _sfpChartsMounted;
@@ -1632,6 +1668,24 @@ else
             catch { }
         }
 
+        // 2D hierarchy map - Live tab only
+        if (_activeTab == "live" && _monitoringReady && !_map2dMounted)
+        {
+            _map2dMounted = true;
+            try
+            {
+                await JS.InvokeVoidAsync("eval",
+                    $"(async () => {{ const m = await import('{VersionedJs("/js/lan-flow-map-2d.js")}'); window.__lanFlowMap2d = m; await m.mount('lan-flow-map-2d-stage'); }})();");
+            }
+            catch { _map2dMounted = false; }
+        }
+        else if (_activeTab != "live" && _map2dMounted)
+        {
+            _map2dMounted = false;
+            try { await JS.InvokeVoidAsync("eval", "window.__lanFlowMap2d?.unmount();"); }
+            catch { }
+        }
+
         // Latency charts - Performance tab only
         if (_activeTab == "performance" && _monitoringReady && !_latencyChartsMounted)
         {
@@ -1723,6 +1777,11 @@ else
         if (_mapMounted)
         {
             try { _ = JS.InvokeVoidAsync("eval", "window.__lanFlowMap?.unmount();").AsTask(); }
+            catch { }
+        }
+        if (_map2dMounted)
+        {
+            try { _ = JS.InvokeVoidAsync("eval", "window.__lanFlowMap2d?.unmount();").AsTask(); }
             catch { }
         }
     }

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -747,12 +747,7 @@ else
     }
     .lan-flow-map-2d-stage {
         width: 100%;
-        height: 620px;
-        position: relative;
-        overflow: clip;
-    }
-    .lan-flow-map-2d-stage.lan-flow-map-fullscreen {
-        overflow: visible;
+        height: clamp(520px, 70vh, 820px);
     }
     .lfm2d-canvas {
         display: block;

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -770,7 +770,7 @@ else
     }
     .lfm2d-toolbar {
         position: absolute;
-        top: 12px;
+        top: 48px;
         right: 12px;
         display: flex;
         flex-direction: column;

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
@@ -194,6 +194,12 @@ public class LanCloud
     /// upstream Hops haven't been resolved yet (tracer wizard not run / in progress).</summary>
     public bool IsDiscoveryPending { get; set; }
 
+    /// <summary>ISP expected download speed in Mbps (from UniFi WAN provider capabilities).</summary>
+    public int? IspDownloadMbps { get; set; }
+
+    /// <summary>ISP expected upload speed in Mbps (from UniFi WAN provider capabilities).</summary>
+    public int? IspUploadMbps { get; set; }
+
     /// <summary>Monitoring target ID whose live RTT feeds this cloud's stats.
     /// Server-side only; the live tick re-queries this for fresh RTT/loss.</summary>
     [System.Text.Json.Serialization.JsonIgnore]

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
@@ -193,6 +193,11 @@ public class LanCloud
     /// <summary>Discovery pending state - the access cloud frame is real but
     /// upstream Hops haven't been resolved yet (tracer wizard not run / in progress).</summary>
     public bool IsDiscoveryPending { get; set; }
+
+    /// <summary>Monitoring target ID whose live RTT feeds this cloud's stats.
+    /// Server-side only; the live tick re-queries this for fresh RTT/loss.</summary>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public string? RttTargetId { get; set; }
 }
 
 public class LinkLiveRates

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -1241,6 +1241,15 @@ public class LanFlowMapService
                 accessCloud.LossPercent = lastLive.Live.LossPercent;
                 accessCloud.RttTargetId = lastLive.TargetId;
             }
+            // ISP expected speeds from UniFi WAN provider capabilities (cached in topology)
+            var wanNet = topology.Networks.FirstOrDefault(n =>
+                n.IsWan && n.WanNetworkgroup != null
+                && n.WanNetworkgroup.Equals(wan.WanInterface, StringComparison.OrdinalIgnoreCase));
+            if (wanNet?.WanDownloadMbps > 0)
+                accessCloud.IspDownloadMbps = wanNet.WanDownloadMbps;
+            if (wanNet?.WanUploadMbps > 0)
+                accessCloud.IspUploadMbps = wanNet.WanUploadMbps;
+
             snapshot.Clouds.Add(accessCloud);
 
             // WAN link: gateway -> access cloud directly. Capacity from WanSummary,

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -467,6 +467,35 @@ public class LanFlowMapService
             }
         }
 
+        // Batch pre-fetch all client throughput from InfluxDB (one query per
+        // measurement instead of N queries per client). Keyed by client MAC.
+        var wifiClientRates = new Dictionary<string, MonitoringInfluxClient.ClientThroughputPoint>(StringComparer.OrdinalIgnoreCase);
+        var wiredClientRates = new Dictionary<string, MonitoringInfluxClient.ClientThroughputPoint>(StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            var allWifi = await _influx.QueryAllClientThroughputAsync("wifi_client", from, to, ct);
+            foreach (var p in allWifi)
+            {
+                if (string.IsNullOrEmpty(p.ClientMac)) continue;
+                if (!wifiClientRates.TryGetValue(p.ClientMac, out var existing)
+                    || Math.Abs((p.Time - at).TotalMilliseconds) < Math.Abs((existing.Time - at).TotalMilliseconds))
+                    wifiClientRates[p.ClientMac] = p;
+            }
+        }
+        catch (Exception ex) { _logger.LogDebug(ex, "Historic WiFi client batch query failed"); }
+        try
+        {
+            var allWired = await _influx.QueryAllClientThroughputAsync("wired_client", from, to, ct);
+            foreach (var p in allWired)
+            {
+                if (string.IsNullOrEmpty(p.ClientMac)) continue;
+                if (!wiredClientRates.TryGetValue(p.ClientMac, out var existing)
+                    || Math.Abs((p.Time - at).TotalMilliseconds) < Math.Abs((existing.Time - at).TotalMilliseconds))
+                    wiredClientRates[p.ClientMac] = p;
+            }
+        }
+        catch (Exception ex) { _logger.LogDebug(ex, "Historic wired client batch query failed"); }
+
         // Resolve each link, mirroring the live endpoint's kind-aware dispatch.
         foreach (var link in snapshot.Links)
         {
@@ -603,26 +632,33 @@ public class LanFlowMapService
                                 rates = MapPortToLinkRates(link, closest.RateInBps ?? 0, closest.RateOutBps ?? 0, closest.Time);
                         }
                     }
-                    // Fallback: wired_client measurement in InfluxDB
+                    // Fallback: wired_client from batch pre-fetch
                     if (rates == null)
                     {
                         var clientMac = ExtractWiredClientMacFromLinkId(link.Id);
-                        if (!string.IsNullOrEmpty(clientMac))
+                        if (!string.IsNullOrEmpty(clientMac) && wiredClientRates.TryGetValue(clientMac, out var wp))
                         {
-                            var r = await QueryClientThroughputAsync("wired_client", clientMac, at, from, to, ct);
-                            if (r != null) rates = r;
+                            rates = new LinkLiveRates
+                            {
+                                DownstreamBps = wp.TxThroughputBps ?? 0,
+                                UpstreamBps = wp.RxThroughputBps ?? 0,
+                                AsOf = wp.Time,
+                            };
                         }
                     }
                     if (rates != null) update.LinkRates[link.Id] = rates;
                 }
                 else if (link.Kind == LanLinkKind.WifiClient)
                 {
-                    // WiFi client throughput from wifi_client measurement
                     var clientMac = ExtractWifiClientMacFromLinkId(link.Id);
-                    if (!string.IsNullOrEmpty(clientMac))
+                    if (!string.IsNullOrEmpty(clientMac) && wifiClientRates.TryGetValue(clientMac, out var wp))
                     {
-                        var r = await QueryClientThroughputAsync("wifi_client", clientMac, at, from, to, ct);
-                        if (r != null) update.LinkRates[link.Id] = r;
+                        update.LinkRates[link.Id] = new LinkLiveRates
+                        {
+                            DownstreamBps = wp.TxThroughputBps ?? 0,
+                            UpstreamBps = wp.RxThroughputBps ?? 0,
+                            AsOf = wp.Time,
+                        };
                     }
                 }
             }

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -281,27 +281,43 @@ public class LanFlowMapService
                     }
                 }
             }
-            else if (link.Kind == LanLinkKind.WiredClient && !string.IsNullOrEmpty(link.PortKey))
+            else if (link.Kind == LanLinkKind.WiredClient)
             {
-                // Wired client leaves don't have device-level monitoring stats - their
-                // throughput lives on the parent switch port, which the SNMP fast tier
-                // writes into MonitoringLiveStats.PortRates every ~5s. Look up by the
-                // (parentMac, ifName) key already encoded in link.PortKey.
-                var (parentMac, ifName) = ParsePortKey(link.PortKey);
-                if (!string.IsNullOrEmpty(parentMac) && !string.IsNullOrEmpty(ifName))
+                // Primary: parent switch port via SNMP (PortKey).
+                if (!string.IsNullOrEmpty(link.PortKey))
                 {
-                    var portRate = _liveStats.GetPortRate(parentMac, ifName);
-                    if (portRate != null)
+                    var (parentMac, ifName) = ParsePortKey(link.PortKey);
+                    if (!string.IsNullOrEmpty(parentMac) && !string.IsNullOrEmpty(ifName))
                     {
-                        // Direction mapping mirrors MapPortToLinkRates for an internal
-                        // (non-WAN) link: port TX (DownBps) = data toward leaf,
-                        // port RX (UpBps) = data from leaf.
-                        rates = new LinkLiveRates
+                        var portRate = _liveStats.GetPortRate(parentMac, ifName);
+                        if (portRate != null)
                         {
-                            DownstreamBps = portRate.DownBps,
-                            UpstreamBps = portRate.UpBps,
-                            AsOf = portRate.LastUpdate,
-                        };
+                            rates = new LinkLiveRates
+                            {
+                                DownstreamBps = portRate.DownBps,
+                                UpstreamBps = portRate.UpBps,
+                                AsOf = portRate.LastUpdate,
+                            };
+                        }
+                    }
+                }
+                // Fallback: UniFi client stats (for switches without SNMP).
+                // TX from the client's perspective = upload = upstream on the link.
+                if (rates == null)
+                {
+                    var clientMac = ExtractWiredClientMacFromLinkId(link.Id);
+                    if (!string.IsNullOrEmpty(clientMac))
+                    {
+                        var wc = _liveStats.GetWiredClient(clientMac);
+                        if (wc != null)
+                        {
+                            rates = new LinkLiveRates
+                            {
+                                DownstreamBps = wc.RxThroughputBps ?? 0,
+                                UpstreamBps = wc.TxThroughputBps ?? 0,
+                                AsOf = wc.LastUpdate,
+                            };
+                        }
                     }
                 }
             }
@@ -1703,6 +1719,9 @@ public class LanFlowMapService
             ? linkId.Substring(prefix.Length)
             : null;
     }
+
+    private static string? ExtractWiredClientMacFromLinkId(string linkId)
+        => ExtractWifiClientMacFromLinkId(linkId);
 
     private static string? ExtractDeviceMacFromUplinkId(string linkId)
     {

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -313,8 +313,8 @@ public class LanFlowMapService
                         {
                             rates = new LinkLiveRates
                             {
-                                DownstreamBps = wc.RxThroughputBps ?? 0,
-                                UpstreamBps = wc.TxThroughputBps ?? 0,
+                                DownstreamBps = wc.TxThroughputBps ?? 0,
+                                UpstreamBps = wc.RxThroughputBps ?? 0,
                                 AsOf = wc.LastUpdate,
                             };
                         }

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -951,7 +951,7 @@ public class LanFlowMapService
             var mac = NormalizeMac(d.Mac);
             anchors.TryGetValue(mac, out var anchor);
             var kind = MapDeviceKind(d);
-            snapshot.Nodes.Add(new LanNode
+            var node = new LanNode
             {
                 Id = "dev-" + mac,
                 Kind = kind,
@@ -960,7 +960,14 @@ public class LanFlowMapService
                 Model = d.FriendlyModelName,
                 Placement = anchor,
                 Online = d.State == 1,
-            });
+            };
+            if (string.Equals(d.UplinkType, "wireless", StringComparison.OrdinalIgnoreCase))
+            {
+                node.PhyTxKbps = d.UplinkTxRateKbps > 0 ? d.UplinkTxRateKbps : null;
+                node.PhyRxKbps = d.UplinkRxRateKbps > 0 ? d.UplinkRxRateKbps : null;
+                node.Band = NormalizeBand(d.UplinkRadioBand);
+            }
+            snapshot.Nodes.Add(node);
         }
 
         // Switches and gateway inherit interpolated placement from the centroid of any

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -586,22 +586,45 @@ public class LanFlowMapService
                         }
                     }
                 }
-                else if (link.Kind == LanLinkKind.WiredClient && !string.IsNullOrEmpty(link.PortKey))
+                else if (link.Kind == LanLinkKind.WiredClient)
                 {
-                    var (deviceMac, ifName) = ParsePortKey(link.PortKey);
-                    if (ratesByDevice.TryGetValue(deviceMac, out var pts))
+                    // Primary: SNMP port rate via PortKey
+                    LinkLiveRates? rates = null;
+                    if (!string.IsNullOrEmpty(link.PortKey))
                     {
-                        var closest = pts
-                            .Where(p => string.Equals(p.IfName, ifName, StringComparison.OrdinalIgnoreCase))
-                            .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
-                            .FirstOrDefault();
-                        if (closest != null)
-                            update.LinkRates[link.Id] = MapPortToLinkRates(link, closest.RateInBps ?? 0, closest.RateOutBps ?? 0, closest.Time);
+                        var (deviceMac, ifName) = ParsePortKey(link.PortKey);
+                        if (ratesByDevice.TryGetValue(deviceMac, out var pts))
+                        {
+                            var closest = pts
+                                .Where(p => string.Equals(p.IfName, ifName, StringComparison.OrdinalIgnoreCase))
+                                .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                                .FirstOrDefault();
+                            if (closest != null)
+                                rates = MapPortToLinkRates(link, closest.RateInBps ?? 0, closest.RateOutBps ?? 0, closest.Time);
+                        }
+                    }
+                    // Fallback: wired_client measurement in InfluxDB
+                    if (rates == null)
+                    {
+                        var clientMac = ExtractWiredClientMacFromLinkId(link.Id);
+                        if (!string.IsNullOrEmpty(clientMac))
+                        {
+                            var r = await QueryClientThroughputAsync("wired_client", clientMac, at, from, to, ct);
+                            if (r != null) rates = r;
+                        }
+                    }
+                    if (rates != null) update.LinkRates[link.Id] = rates;
+                }
+                else if (link.Kind == LanLinkKind.WifiClient)
+                {
+                    // WiFi client throughput from wifi_client measurement
+                    var clientMac = ExtractWifiClientMacFromLinkId(link.Id);
+                    if (!string.IsNullOrEmpty(clientMac))
+                    {
+                        var r = await QueryClientThroughputAsync("wifi_client", clientMac, at, from, to, ct);
+                        if (r != null) update.LinkRates[link.Id] = r;
                     }
                 }
-                // WifiClient links: wifi_client throughput is stored with client_mac as
-                // a field (not a tag), making per-client InfluxDB lookups expensive.
-                // Skipped for now; wifi leaves show snapshot rates during playback.
             }
             catch (Exception ex)
             {
@@ -1711,6 +1734,31 @@ public class LanFlowMapService
         "6e" or "6ghz" or "6 GHz" or "6" => "6",
         _ => null,
     };
+
+    private async Task<LinkLiveRates?> QueryClientThroughputAsync(
+        string measurement, string clientMac, DateTime at, DateTime from, DateTime to, CancellationToken ct)
+    {
+        try
+        {
+            var result = await _influx.QueryClientThroughputAsync(measurement, clientMac, from, to, ct);
+            var closest = result
+                .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                .FirstOrDefault();
+            if (closest == null) return null;
+            // Tx = switch/AP→client = downstream, Rx = client→switch/AP = upstream
+            return new LinkLiveRates
+            {
+                DownstreamBps = closest.TxThroughputBps ?? 0,
+                UpstreamBps = closest.RxThroughputBps ?? 0,
+                AsOf = closest.Time,
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Historic client throughput query failed for {Mac}", clientMac);
+            return null;
+        }
+    }
 
     private static string? ExtractWifiClientMacFromLinkId(string linkId)
     {

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -353,16 +353,30 @@ public class LanFlowMapService
             };
         }
 
-        // Cloud RTT from the in-memory target stats cache.
+        // Cloud RTT from the live monitoring target cache (same source as the
+        // ISP RTT stat card) so the globe label stays in lockstep.
         foreach (var cloud in snapshot.Clouds)
         {
-            // The cloud's RTT came from MonitoringPathView at build time - re-resolve it
-            // by querying the same source so the live tick is fresh.
+            double? rtt = cloud.RttAvgMs;
+            double? loss = cloud.LossPercent;
+            bool success = rtt.HasValue;
+
+            if (!string.IsNullOrEmpty(cloud.RttTargetId))
+            {
+                var live = _liveStats.GetTargetStats(cloud.RttTargetId);
+                if (live != null)
+                {
+                    rtt = live.RttAvgMs;
+                    loss = live.LossPercent;
+                    success = live.RttAvgMs.HasValue;
+                }
+            }
+
             update.CloudStats[cloud.Id] = new CloudLiveStats
             {
-                RttAvgMs = cloud.RttAvgMs,
-                LossPercent = cloud.LossPercent,
-                Success = cloud.RttAvgMs.HasValue,
+                RttAvgMs = rtt,
+                LossPercent = loss,
+                Success = success,
             };
         }
 
@@ -1225,6 +1239,7 @@ public class LanFlowMapService
             {
                 accessCloud.RttAvgMs = lastLive.Live.RttAvgMs;
                 accessCloud.LossPercent = lastLive.Live.LossPercent;
+                accessCloud.RttTargetId = lastLive.TargetId;
             }
             snapshot.Clouds.Add(accessCloud);
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -971,6 +971,18 @@ public class MonitoringCollectionAgent : BackgroundService
                 RxThroughputBps = rxBps,
                 LastUpdate = now,
             });
+
+            // Write to InfluxDB for historic playback
+            var swMac = NormalizeMac(c.SwMac ?? string.Empty);
+            if (!string.IsNullOrEmpty(swMac))
+            {
+                _ = _influx.WriteWiredClientAsync(
+                    switchMac: swMac,
+                    clientMac: clientMac,
+                    txThroughputBps: txBps,
+                    rxThroughputBps: rxBps,
+                    timestamp: now);
+            }
         }
 
         // Drop stale byte-cache entries for clients we haven't seen this cycle. Otherwise

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -832,6 +832,7 @@ public class MonitoringCollectionAgent : BackgroundService
     /// clients with stale -r fields.
     /// </summary>
     private readonly ConcurrentDictionary<string, ClientByteSnapshot> _wifiByteCache = new();
+    private readonly ConcurrentDictionary<string, ClientByteSnapshot> _wiredByteCache = new();
     private readonly record struct ClientByteSnapshot(DateTime Timestamp, long TxBytes, long RxBytes);
 
     private async Task WifiClientTierCollectAsync(MonitoringSettings settings, CancellationToken ct)
@@ -932,15 +933,55 @@ public class MonitoringCollectionAgent : BackgroundService
                 timestamp: now);
         }
 
+        // Wired clients: collect throughput as fallback for non-SNMP switches.
+        // Uses the same tx_bytes/rx_bytes delta approach as WiFi clients.
+        foreach (var c in clients)
+        {
+            if (!c.IsWired) continue;
+            if (string.IsNullOrEmpty(c.Mac)) continue;
+            var clientMac = NormalizeMac(c.Mac);
+
+            double? txBps = null, rxBps = null;
+            if (c.TxBytesRate > 0 || c.RxBytesRate > 0)
+            {
+                txBps = c.TxBytesRate * 8.0;
+                rxBps = c.RxBytesRate * 8.0;
+            }
+            else if (_wiredByteCache.TryGetValue(clientMac, out var prev))
+            {
+                var elapsed = (now - prev.Timestamp).TotalSeconds;
+                if (elapsed > 0.5)
+                {
+                    long deltaTx = c.TxBytes - prev.TxBytes;
+                    long deltaRx = c.RxBytes - prev.RxBytes;
+                    if (deltaTx >= 0 && deltaRx >= 0)
+                    {
+                        txBps = deltaTx * 8.0 / elapsed;
+                        rxBps = deltaRx * 8.0 / elapsed;
+                    }
+                }
+            }
+            _wiredByteCache[clientMac] = new ClientByteSnapshot(now, c.TxBytes, c.RxBytes);
+
+            _liveStats.RecordWiredClient(new WiredClientLiveSnapshot
+            {
+                ClientMac = clientMac,
+                TxThroughputBps = txBps,
+                RxThroughputBps = rxBps,
+                LastUpdate = now,
+            });
+        }
+
         // Drop stale byte-cache entries for clients we haven't seen this cycle. Otherwise
         // a roamed/disconnected client's stale counter sits forever and gives a bogus
         // delta on reconnect.
-        var seenSet = new HashSet<string>(clients.Where(c => !c.IsWired).Select(c => NormalizeMac(c.Mac)));
+        var seenWifi = new HashSet<string>(clients.Where(c => !c.IsWired).Select(c => NormalizeMac(c.Mac)));
         foreach (var key in _wifiByteCache.Keys)
-        {
-            if (!seenSet.Contains(key))
-                _wifiByteCache.TryRemove(key, out _);
-        }
+            if (!seenWifi.Contains(key)) _wifiByteCache.TryRemove(key, out _);
+
+        var seenWired = new HashSet<string>(clients.Where(c => c.IsWired).Select(c => NormalizeMac(c.Mac)));
+        foreach (var key in _wiredByteCache.Keys)
+            if (!seenWired.Contains(key)) _wiredByteCache.TryRemove(key, out _);
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -942,18 +942,19 @@ public class MonitoringCollectionAgent : BackgroundService
             var clientMac = NormalizeMac(c.Mac);
 
             double? txBps = null, rxBps = null;
-            if (c.TxBytesRate > 0 || c.RxBytesRate > 0)
+            // Wired clients use wired-tx_bytes-r / wired-rx_bytes-r (not tx_bytes-r)
+            if (c.WiredTxBytesRate > 0 || c.WiredRxBytesRate > 0)
             {
-                txBps = c.TxBytesRate * 8.0;
-                rxBps = c.RxBytesRate * 8.0;
+                txBps = c.WiredTxBytesRate * 8.0;
+                rxBps = c.WiredRxBytesRate * 8.0;
             }
             else if (_wiredByteCache.TryGetValue(clientMac, out var prev))
             {
                 var elapsed = (now - prev.Timestamp).TotalSeconds;
                 if (elapsed > 0.5)
                 {
-                    long deltaTx = c.TxBytes - prev.TxBytes;
-                    long deltaRx = c.RxBytes - prev.RxBytes;
+                    long deltaTx = c.WiredTxBytes - prev.TxBytes;
+                    long deltaRx = c.WiredRxBytes - prev.RxBytes;
                     if (deltaTx >= 0 && deltaRx >= 0)
                     {
                         txBps = deltaTx * 8.0 / elapsed;
@@ -961,7 +962,7 @@ public class MonitoringCollectionAgent : BackgroundService
                     }
                 }
             }
-            _wiredByteCache[clientMac] = new ClientByteSnapshot(now, c.TxBytes, c.RxBytes);
+            _wiredByteCache[clientMac] = new ClientByteSnapshot(now, c.WiredTxBytes, c.WiredRxBytes);
 
             _liveStats.RecordWiredClient(new WiredClientLiveSnapshot
             {

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -853,6 +853,9 @@ public class MonitoringCollectionAgent : BackgroundService
         }
 
         var now = DateTime.UtcNow;
+        var wifiCount = clients.Count(c => !c.IsWired);
+        var wiredCount = clients.Count(c => c.IsWired);
+        _logger.LogDebug("WiFi tier: {Total} clients ({Wifi} wifi, {Wired} wired)", clients.Length, wifiCount, wiredCount);
         foreach (var c in clients)
         {
             if (c.IsWired) continue;

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -874,25 +874,29 @@ public class MonitoringCollectionAgent : BackgroundService
             double? rxThroughputBps = null;
             if (c.TxBytesRate > 0 || c.RxBytesRate > 0)
             {
-                // tx_bytes-r / rx_bytes-r are bytes per second
                 txThroughputBps = c.TxBytesRate * 8.0;
                 rxThroughputBps = c.RxBytesRate * 8.0;
+                _wifiByteCache[clientMac] = new ClientByteSnapshot(now, c.TxBytes, c.RxBytes);
             }
             else if (_wifiByteCache.TryGetValue(clientMac, out var prev))
             {
-                var elapsed = (now - prev.Timestamp).TotalSeconds;
-                if (elapsed > 0.5)
+                long deltaTx = c.TxBytes - prev.TxBytes;
+                long deltaRx = c.RxBytes - prev.RxBytes;
+                if (deltaTx > 0 || deltaRx > 0)
                 {
-                    long deltaTx = c.TxBytes - prev.TxBytes;
-                    long deltaRx = c.RxBytes - prev.RxBytes;
-                    if (deltaTx >= 0 && deltaRx >= 0)
+                    var elapsed = (now - prev.Timestamp).TotalSeconds;
+                    if (elapsed > 0.5)
                     {
                         txThroughputBps = deltaTx * 8.0 / elapsed;
                         rxThroughputBps = deltaRx * 8.0 / elapsed;
                     }
+                    _wifiByteCache[clientMac] = new ClientByteSnapshot(now, c.TxBytes, c.RxBytes);
                 }
             }
-            _wifiByteCache[clientMac] = new ClientByteSnapshot(now, c.TxBytes, c.RxBytes);
+            else
+            {
+                _wifiByteCache[clientMac] = new ClientByteSnapshot(now, c.TxBytes, c.RxBytes);
+            }
 
             var snapshot = new WifiClientLiveSnapshot
             {
@@ -956,22 +960,33 @@ public class MonitoringCollectionAgent : BackgroundService
             {
                 txBps = c.WiredTxBytesRate * 8.0;
                 rxBps = c.WiredRxBytesRate * 8.0;
+                _wiredByteCache[clientMac] = new ClientByteSnapshot(now, c.WiredTxBytes, c.WiredRxBytes);
             }
             else if (_wiredByteCache.TryGetValue(clientMac, out var prev))
             {
-                var elapsed = (now - prev.Timestamp).TotalSeconds;
-                if (elapsed > 0.5)
+                long deltaTx = c.WiredTxBytes - prev.TxBytes;
+                long deltaRx = c.WiredRxBytes - prev.RxBytes;
+                if (deltaTx > 0 || deltaRx > 0)
                 {
-                    long deltaTx = c.WiredTxBytes - prev.TxBytes;
-                    long deltaRx = c.WiredRxBytes - prev.RxBytes;
-                    if (deltaTx >= 0 && deltaRx >= 0)
+                    // Only compute rate when counters actually changed. Elapsed is
+                    // time since last CHANGE, not last poll - avoids 2x rate when
+                    // our poll misaligns with UniFi's counter update cadence.
+                    var elapsed = (now - prev.Timestamp).TotalSeconds;
+                    if (elapsed > 0.5)
                     {
                         txBps = deltaTx * 8.0 / elapsed;
                         rxBps = deltaRx * 8.0 / elapsed;
                     }
+                    _wiredByteCache[clientMac] = new ClientByteSnapshot(now, c.WiredTxBytes, c.WiredRxBytes);
                 }
+                // When counters unchanged, DON'T update cache timestamp - preserves
+                // the real elapsed time for the next actual change.
             }
-            _wiredByteCache[clientMac] = new ClientByteSnapshot(now, c.WiredTxBytes, c.WiredRxBytes);
+            else
+            {
+                // First poll: seed cache, no rate yet
+                _wiredByteCache[clientMac] = new ClientByteSnapshot(now, c.WiredTxBytes, c.WiredRxBytes);
+            }
 
             _liveStats.RecordWiredClient(new WiredClientLiveSnapshot
             {

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -915,9 +915,12 @@ public class MonitoringCollectionAgent : BackgroundService
             };
             _liveStats.RecordWifiClient(snapshot);
 
-            // InfluxDB write. Per Gate 1: AP MAC + band are tags, client MAC is a
-            // field to bound cardinality (per-client MAC as a tag would be the classic
-            // InfluxDB cardinality bomb on networks with hundreds of clients).
+            // Skip InfluxDB write when throughput is zero - avoids polluting
+            // historic data with stale-counter cycles where UniFi hadn't updated
+            // tx_bytes between our polls.
+            if ((txThroughputBps ?? 0) <= 0 && (rxThroughputBps ?? 0) <= 0)
+                goto skipWifiInflux;
+
             _ = _influx.WriteWifiClientAsync(
                 apMac: apMac,
                 band: band,
@@ -936,6 +939,7 @@ public class MonitoringCollectionAgent : BackgroundService
                 rxThroughputBps: rxThroughputBps,
                 isMlo: c.IsMlo,
                 timestamp: now.AddTicks(tickOffset++));
+        skipWifiInflux:;
         }
 
         // Wired clients: collect throughput as fallback for non-SNMP switches.
@@ -977,9 +981,9 @@ public class MonitoringCollectionAgent : BackgroundService
                 LastUpdate = now,
             });
 
-            // Write to InfluxDB for historic playback
+            // Write to InfluxDB for historic playback (skip zero throughput)
             var swMac = NormalizeMac(c.SwMac ?? string.Empty);
-            if (!string.IsNullOrEmpty(swMac))
+            if (!string.IsNullOrEmpty(swMac) && ((txBps ?? 0) > 0 || (rxBps ?? 0) > 0))
             {
                 _ = _influx.WriteWiredClientAsync(
                     switchMac: swMac,

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -856,6 +856,7 @@ public class MonitoringCollectionAgent : BackgroundService
         var wifiCount = clients.Count(c => !c.IsWired);
         var wiredCount = clients.Count(c => c.IsWired);
         _logger.LogDebug("WiFi tier: {Total} clients ({Wifi} wifi, {Wired} wired)", clients.Length, wifiCount, wiredCount);
+        long tickOffset = 0; // nanosecond offset per client to avoid InfluxDB dedup
         foreach (var c in clients)
         {
             if (c.IsWired) continue;
@@ -933,7 +934,7 @@ public class MonitoringCollectionAgent : BackgroundService
                 txThroughputBps: txThroughputBps,
                 rxThroughputBps: rxThroughputBps,
                 isMlo: c.IsMlo,
-                timestamp: now);
+                timestamp: now.AddTicks(tickOffset++));
         }
 
         // Wired clients: collect throughput as fallback for non-SNMP switches.
@@ -984,7 +985,7 @@ public class MonitoringCollectionAgent : BackgroundService
                     clientMac: clientMac,
                     txThroughputBps: txBps,
                     rxThroughputBps: rxBps,
-                    timestamp: now);
+                    timestamp: now.AddTicks(tickOffset++));
             }
         }
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -919,31 +919,27 @@ public class MonitoringCollectionAgent : BackgroundService
             };
             _liveStats.RecordWifiClient(snapshot);
 
-            // Skip InfluxDB write when throughput is zero - avoids polluting
-            // historic data with stale-counter cycles where UniFi hadn't updated
-            // tx_bytes between our polls.
-            if ((txThroughputBps ?? 0) <= 0 && (rxThroughputBps ?? 0) <= 0)
-                goto skipWifiInflux;
-
-            _ = _influx.WriteWifiClientAsync(
-                apMac: apMac,
-                band: band,
-                clientMac: clientMac,
-                signalDbm: c.Signal,
-                noiseDbm: c.Noise,
-                txRateKbps: c.TxRate > 0 ? c.TxRate : null,
-                rxRateKbps: c.RxRate > 0 ? c.RxRate : null,
-                channel: c.Channel,
-                channelWidth: c.ChannelWidth,
-                satisfaction: c.Satisfaction,
-                rssi: c.Rssi,
-                txBytes: c.TxBytes,
-                rxBytes: c.RxBytes,
-                txThroughputBps: txThroughputBps,
-                rxThroughputBps: rxThroughputBps,
-                isMlo: c.IsMlo,
-                timestamp: now.AddTicks(tickOffset++));
-        skipWifiInflux:;
+            if ((txThroughputBps ?? 0) > 0 || (rxThroughputBps ?? 0) > 0)
+            {
+                _ = _influx.WriteWifiClientAsync(
+                    apMac: apMac,
+                    band: band,
+                    clientMac: clientMac,
+                    signalDbm: c.Signal,
+                    noiseDbm: c.Noise,
+                    txRateKbps: c.TxRate > 0 ? c.TxRate : null,
+                    rxRateKbps: c.RxRate > 0 ? c.RxRate : null,
+                    channel: c.Channel,
+                    channelWidth: c.ChannelWidth,
+                    satisfaction: c.Satisfaction,
+                    rssi: c.Rssi,
+                    txBytes: c.TxBytes,
+                    rxBytes: c.RxBytes,
+                    txThroughputBps: txThroughputBps,
+                    rxThroughputBps: rxThroughputBps,
+                    isMlo: c.IsMlo,
+                    timestamp: now.AddTicks(tickOffset++));
+            }
         }
 
         // Wired clients: collect throughput as fallback for non-SNMP switches.

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -232,13 +232,14 @@ public class MonitoringCollectionAgent : BackgroundService
             try
             {
                 var mac = NormalizeMac(device.Mac);
-                if (IsSnmpExcluded(mac))
-                {
-                    // Device was previously determined to not support SNMP. Skip silently;
-                    // rate data for this device will come from its parent switch port
-                    // (for APs) or be absent.
+
+                // UniFi requires snmp_location or snmp_contact to be set for
+                // SNMP to be enabled on a device. Both empty/null = SNMP off.
+                if (string.IsNullOrEmpty(device.SnmpLocation) && string.IsNullOrEmpty(device.SnmpContact))
                     return;
-                }
+
+                if (IsSnmpExcluded(mac))
+                    return;
                 try
                 {
                     var pollIp = ResolveSnmpAddress(device, gatewayLanIp);
@@ -1432,7 +1433,7 @@ public class MonitoringCollectionAgent : BackgroundService
     // the default fast tier interval (5s) - the data is always at most one fast tick
     // stale, and slower tiers piggyback on whatever the fast tier just fetched.
     // Concurrent callers serialize on _deviceFetchLock so a miss doesn't fan out.
-    private static readonly TimeSpan DeviceCacheTtl = TimeSpan.FromSeconds(4);
+    private static readonly TimeSpan DeviceCacheTtl = TimeSpan.FromSeconds(30);
     private List<UniFiDeviceResponse> _cachedDevices = new();
     private DateTime _cachedDevicesAt = DateTime.MinValue;
     private readonly SemaphoreSlim _deviceFetchLock = new(1, 1);
@@ -1755,14 +1756,10 @@ public class MonitoringCollectionAgent : BackgroundService
         var count = _snmpFailures.AddOrUpdate(normalizedMac, 1, (_, prev) => prev + 1);
         if (count < SnmpFailureThreshold) return;
 
-        // Only exclude when the device is actually reachable. If our fabric ping has
-        // returned at least once in the last 2 minutes, we know it's online; otherwise
-        // it might just be down, and we'll re-try SNMP when it comes back.
-        var liveStats = _liveStats.GetForDevice(normalizedMac);
-        if (liveStats == null || !liveStats.LastLatencyUpdate.HasValue) return;
-        if (DateTime.UtcNow - liveStats.LastLatencyUpdate.Value > TimeSpan.FromMinutes(2)) return;
-        if (!(liveStats.LatestRttMs.HasValue && liveStats.LatestRttMs.Value >= 0)) return;
-
+        // Exclude after threshold regardless of ping reachability. The 1-hour TTL
+        // handles retry when the device comes back or gets SNMP enabled. Not all
+        // devices are ping targets, so requiring ICMP would leave many non-SNMP
+        // devices burning the timeout forever.
         if (_snmpExcluded.TryAdd(normalizedMac, DateTime.UtcNow))
         {
             _logger.LogInformation(

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -724,8 +724,36 @@ from(bucket: ""{_longtermBucket}"")
     public record ClientThroughputPoint
     {
         public DateTime Time { get; init; }
+        public string? ClientMac { get; init; }
         public double? TxThroughputBps { get; init; }
         public double? RxThroughputBps { get; init; }
+    }
+
+    public async Task<IReadOnlyList<ClientThroughputPoint>> QueryAllClientThroughputAsync(
+        string measurement,
+        DateTime from,
+        DateTime to,
+        CancellationToken ct = default)
+    {
+        if (!IsConfigured) return Array.Empty<ClientThroughputPoint>();
+        var flux = $@"from(bucket: ""{_bucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""{measurement}"")
+  |> filter(fn: (r) => r._field == ""tx_throughput_bps"" or r._field == ""rx_throughput_bps"" or r._field == ""client_mac"")
+  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")";
+
+        var results = new List<ClientThroughputPoint>();
+        await foreach (var record in QueryFluxAsync(flux, ct))
+        {
+            results.Add(new ClientThroughputPoint
+            {
+                Time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow),
+                ClientMac = record.GetValueByKey("client_mac") as string,
+                TxThroughputBps = AsDoubleOrNull(record.GetValueByKey("tx_throughput_bps")),
+                RxThroughputBps = AsDoubleOrNull(record.GetValueByKey("rx_throughput_bps")),
+            });
+        }
+        return results;
     }
 
     public async Task<IReadOnlyList<ClientThroughputPoint>> QueryClientThroughputAsync(

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -394,6 +394,26 @@ public class MonitoringInfluxClient : IAsyncDisposable
         return Task.CompletedTask;
     }
 
+    public Task WriteWiredClientAsync(
+        string switchMac,
+        string clientMac,
+        double? txThroughputBps,
+        double? rxThroughputBps,
+        DateTime timestamp)
+    {
+        if (!IsConfigured) return Task.CompletedTask;
+        var point = PointData.Measurement("wired_client")
+            .Tag("device_mac", NormalizeMac(switchMac))
+            .Field("client_mac", NormalizeMac(clientMac))
+            .Timestamp(timestamp.ToUniversalTime(), WritePrecision.Ns);
+
+        if (txThroughputBps.HasValue) point = point.Field("tx_throughput_bps", txThroughputBps.Value);
+        if (rxThroughputBps.HasValue) point = point.Field("rx_throughput_bps", rxThroughputBps.Value);
+
+        Enqueue(point, longterm: false);
+        return Task.CompletedTask;
+    }
+
     public Task WriteSfpAsync(
         string deviceMac,
         string portName,
@@ -701,6 +721,42 @@ from(bucket: ""{_longtermBucket}"")
     /// AP MAC (tag), optionally by band (tag) and by client MAC (field). Returns
     /// rows ordered by time.
     /// </summary>
+    public record ClientThroughputPoint
+    {
+        public DateTime Time { get; init; }
+        public double? TxThroughputBps { get; init; }
+        public double? RxThroughputBps { get; init; }
+    }
+
+    public async Task<IReadOnlyList<ClientThroughputPoint>> QueryClientThroughputAsync(
+        string measurement,
+        string clientMac,
+        DateTime from,
+        DateTime to,
+        CancellationToken ct = default)
+    {
+        if (!IsConfigured) return Array.Empty<ClientThroughputPoint>();
+        var mac = NormalizeMac(clientMac);
+        var flux = $@"from(bucket: ""{_bucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""{measurement}"")
+  |> filter(fn: (r) => r._field == ""tx_throughput_bps"" or r._field == ""rx_throughput_bps"" or r._field == ""client_mac"")
+  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
+  |> filter(fn: (r) => r.client_mac == ""{mac}"")";
+
+        var results = new List<ClientThroughputPoint>();
+        await foreach (var record in QueryFluxAsync(flux, ct))
+        {
+            results.Add(new ClientThroughputPoint
+            {
+                Time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow),
+                TxThroughputBps = AsDoubleOrNull(record.GetValueByKey("tx_throughput_bps")),
+                RxThroughputBps = AsDoubleOrNull(record.GetValueByKey("rx_throughput_bps")),
+            });
+        }
+        return results;
+    }
+
     public async Task<IReadOnlyList<WifiClientHistoryPoint>> QueryWifiClientHistoryAsync(
         string apMac,
         string? band,

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -740,7 +740,8 @@ from(bucket: ""{_longtermBucket}"")
   |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
   |> filter(fn: (r) => r._measurement == ""{measurement}"")
   |> filter(fn: (r) => r._field == ""tx_throughput_bps"" or r._field == ""rx_throughput_bps"" or r._field == ""client_mac"")
-  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")";
+  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
+  |> filter(fn: (r) => exists r.tx_throughput_bps or exists r.rx_throughput_bps)";
 
         var results = new List<ClientThroughputPoint>();
         await foreach (var record in QueryFluxAsync(flux, ct))

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -741,7 +741,7 @@ from(bucket: ""{_longtermBucket}"")
   |> filter(fn: (r) => r._measurement == ""{measurement}"")
   |> filter(fn: (r) => r._field == ""tx_throughput_bps"" or r._field == ""rx_throughput_bps"" or r._field == ""client_mac"")
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
-  |> filter(fn: (r) => exists r.tx_throughput_bps or exists r.rx_throughput_bps)";
+  |> filter(fn: (r) => (exists r.tx_throughput_bps and r.tx_throughput_bps > 0.0) or (exists r.rx_throughput_bps and r.rx_throughput_bps > 0.0))";
 
         var results = new List<ClientThroughputPoint>();
         await foreach (var record in QueryFluxAsync(flux, ct))

--- a/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
@@ -116,6 +116,7 @@ public class MonitoringLiveStats
     private readonly ConcurrentDictionary<(string DeviceMac, string PortName), SfpLiveStats> _sfpStats = new();
     private readonly ConcurrentDictionary<string, TargetLiveStats> _targetStats = new();
     private readonly ConcurrentDictionary<string, WifiClientLiveSnapshot> _wifiClients = new();
+    private readonly ConcurrentDictionary<string, WiredClientLiveSnapshot> _wiredClients = new();
     // Per-port rate cache. Keyed by (deviceMac, ifName) so the SNMP fast tier
     // (clean 5s cadence) is the writer - the UniFi PortTable byte counters lag
     // ~30s server-side, so polling them every 5s yields a burst-then-zeros
@@ -285,6 +286,29 @@ public class MonitoringLiveStats
     /// <summary>Every currently-tracked WiFi client (across all APs).</summary>
     public IReadOnlyList<WifiClientLiveSnapshot> AllWifiClients() => _wifiClients.Values.ToList();
 
+    // ---- Wired clients (fallback for non-SNMP switches) ----
+
+    public void RecordWiredClient(WiredClientLiveSnapshot snapshot)
+    {
+        if (string.IsNullOrEmpty(snapshot.ClientMac)) return;
+        var key = Normalize(snapshot.ClientMac);
+        var fresh = snapshot with { ClientMac = key, ConsecutiveZeroPolls = 0 };
+        _wiredClients.AddOrUpdate(key, fresh, (_, prior) =>
+        {
+            var newTx = fresh.TxThroughputBps ?? 0;
+            var newRx = fresh.RxThroughputBps ?? 0;
+            if (newTx == 0 && newRx == 0 && ((prior.TxThroughputBps ?? 0) > 0 || (prior.RxThroughputBps ?? 0) > 0) && prior.ConsecutiveZeroPolls < 1)
+                return prior with { TxThroughputBps = prior.TxThroughputBps, RxThroughputBps = prior.RxThroughputBps, LastUpdate = fresh.LastUpdate, ConsecutiveZeroPolls = prior.ConsecutiveZeroPolls + 1 };
+            return fresh;
+        });
+    }
+
+    public WiredClientLiveSnapshot? GetWiredClient(string clientMac)
+    {
+        if (string.IsNullOrEmpty(clientMac)) return null;
+        return _wiredClients.TryGetValue(Normalize(clientMac), out var v) ? v : null;
+    }
+
     /// <summary>Drop stale entries — called periodically by the agent.</summary>
     public void Prune(TimeSpan maxAge)
     {
@@ -422,4 +446,17 @@ public record DeviceLiveStats
         return (LastRateUpdate.HasValue && (now - LastRateUpdate.Value) <= maxAge)
             || (LastLatencyUpdate.HasValue && (now - LastLatencyUpdate.Value) <= maxAge);
     }
+}
+
+/// <summary>
+/// Throughput snapshot for a wired client, derived from UniFi client stats.
+/// Used as a fallback when the parent switch lacks SNMP.
+/// </summary>
+public record WiredClientLiveSnapshot
+{
+    public required string ClientMac { get; init; }
+    public double? TxThroughputBps { get; init; }
+    public double? RxThroughputBps { get; init; }
+    public DateTime LastUpdate { get; init; }
+    public int ConsecutiveZeroPolls { get; init; }
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14500,6 +14500,22 @@ a.affected-client:hover {
 .lan-flow-map-wan-pill.is-visible {
     display: block;
 }
+.lan-flow-map-cloud-rtt {
+    position: absolute;
+    transform: translate(-50%, 0%);
+    background: rgba(148, 163, 184, 0.1);
+    color: var(--text-secondary);
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.7rem;
+    font-variant-numeric: tabular-nums;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    white-space: nowrap;
+    display: none;
+}
+.lan-flow-map-cloud-rtt.is-visible {
+    display: block;
+}
 .lan-flow-map-tooltip {
     position: absolute;
     background: rgba(16, 24, 32, 0.92);

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14062,7 +14062,7 @@ a.affected-client:hover {
     margin-bottom: 0.45rem;
 }
 .lan-flow-map-controls {
-    top: 2.75rem;
+    top: 3rem;
     right: 0.75rem;
     min-width: 178px;
     display: flex;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-data.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-data.js
@@ -6,12 +6,16 @@ let _snapshot = null;
 let _liveRates = {};
 let _cloudStats = {};
 let _nodeBadges = {};
+let _paused = false;
+let _mode = 'live';
 let _listeners = new Set();
 
 export function getSnapshot()  { return _snapshot; }
 export function getLiveRates()  { return _liveRates; }
 export function getCloudStats() { return _cloudStats; }
 export function getNodeBadges() { return _nodeBadges; }
+export function isPaused()     { return _paused; }
+export function getMode()      { return _mode; }
 
 export function subscribe(fn) {
     _listeners.add(fn);
@@ -35,4 +39,10 @@ export function publishLive(update) {
     if (update.cloudStats)  _cloudStats = update.cloudStats;
     if (update.nodeBadges)  _nodeBadges = update.nodeBadges;
     _notify('live');
+}
+
+export function publishPlayState(paused, mode) {
+    _paused = paused;
+    _mode = mode;
+    _notify('playstate');
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-data.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-data.js
@@ -1,0 +1,38 @@
+// Shared data store for the LAN flow map topology.
+// The 3D map publishes data here after each fetch; the 2D map subscribes
+// so only one set of API calls runs. Pure pub/sub - no fetching.
+
+let _snapshot = null;
+let _liveRates = {};
+let _cloudStats = {};
+let _nodeBadges = {};
+let _listeners = new Set();
+
+export function getSnapshot()  { return _snapshot; }
+export function getLiveRates()  { return _liveRates; }
+export function getCloudStats() { return _cloudStats; }
+export function getNodeBadges() { return _nodeBadges; }
+
+export function subscribe(fn) {
+    _listeners.add(fn);
+    return () => _listeners.delete(fn);
+}
+
+function _notify(event) {
+    for (const fn of _listeners) {
+        try { fn(event); } catch { /* swallow */ }
+    }
+}
+
+export function publishSnapshot(snap) {
+    _snapshot = snap;
+    _liveRates = snap.liveRates || {};
+    _notify('snapshot');
+}
+
+export function publishLive(update) {
+    if (update.linkRates)   Object.assign(_liveRates, update.linkRates);
+    if (update.cloudStats)  _cloudStats = update.cloudStats;
+    if (update.nodeBadges)  _nodeBadges = update.nodeBadges;
+    _notify('live');
+}

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-data.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-data.js
@@ -8,14 +8,18 @@ let _cloudStats = {};
 let _nodeBadges = {};
 let _paused = false;
 let _mode = 'live';
+let _scrubberValue = 10000;
+let _scrubberRight = 'Live';
+let _playbackSpeed = 1;
 let _listeners = new Set();
 
 export function getSnapshot()  { return _snapshot; }
 export function getLiveRates()  { return _liveRates; }
 export function getCloudStats() { return _cloudStats; }
 export function getNodeBadges() { return _nodeBadges; }
-export function isPaused()     { return _paused; }
-export function getMode()      { return _mode; }
+export function isPaused()       { return _paused; }
+export function getMode()        { return _mode; }
+export function getScrubber()    { return { value: _scrubberValue, right: _scrubberRight, speed: _playbackSpeed }; }
 
 export function subscribe(fn) {
     _listeners.add(fn);
@@ -45,4 +49,11 @@ export function publishPlayState(paused, mode) {
     _paused = paused;
     _mode = mode;
     _notify('playstate');
+}
+
+export function publishScrubber(value, rightLabel, speed) {
+    _scrubberValue = value;
+    _scrubberRight = rightLabel;
+    _playbackSpeed = speed;
+    _notify('scrubber');
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-data.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-data.js
@@ -33,8 +33,11 @@ function _notify(event) {
 }
 
 export function publishSnapshot(snap) {
+    const firstLoad = !_snapshot;
     _snapshot = snap;
-    _liveRates = snap.liveRates || {};
+    // Only seed rates on first load. Subsequent refreshes must not clobber
+    // the fresh 1s-polled rates with stale snapshot-time values.
+    if (firstLoad) _liveRates = snap.liveRates || {};
     _notify('snapshot');
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -36,7 +36,7 @@ const LK = { Uplink:0, WiredClient:1, WifiClient:2, Wan:3, Transit:4, MeshBackha
 // ---- Layout geometry ----
 const G = {
     tierGap:     170,
-    cloudGap:    100,
+    cloudGap:    160,
     infraGap:    90,
     clientCellW: 145,
     clientCellH: 50,

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -350,23 +350,31 @@ class LanFlowMap2D {
         try{const s=JSON.parse(localStorage.getItem('lanFlowMap2dOverlays'));this._overlays=s?{...defaultOverlays,...s}:{...defaultOverlays};}
         catch{this._overlays={...defaultOverlays};}
 
-        // Filter panel (top-left, matching 3D style)
+        // Filter panel (top-left, matching 3D style, collapsible on mobile)
+        const isMobile=window.matchMedia('(max-width: 768px)').matches;
         const filter=document.createElement('div');
         filter.className='lan-flow-map-panel lan-flow-map-filter';
-        filter.innerHTML=`<div class="lan-flow-map-panel-title">Filter clients</div>
-            <div class="lan-flow-map-panel-body">
-                <input class="lan-flow-map-search" type="search" placeholder="Search by name or MAC" />
+        const filterTitle=document.createElement('div');
+        filterTitle.className='lan-flow-map-panel-title';
+        filterTitle.textContent=isMobile?'Filter':'Filter clients';
+        if(isMobile)filterTitle.classList.add('lan-flow-map-panel-title-toggle');
+        filter.appendChild(filterTitle);
+        const filterBody=document.createElement('div');
+        filterBody.className='lan-flow-map-panel-body';
+        filterBody.innerHTML=`<input class="lan-flow-map-search" type="search" placeholder="Search by name or MAC" />
                 <div class="lan-flow-map-chips" data-chip-group="band">
                     <span class="lan-flow-map-chip is-on" data-band="2.4">2.4 GHz</span>
                     <span class="lan-flow-map-chip is-on" data-band="5">5 GHz</span>
                     <span class="lan-flow-map-chip is-on" data-band="6">6 GHz</span>
-                </div>
-            </div>`;
-        filter.querySelector('.lan-flow-map-search').addEventListener('input',(e)=>{
+                </div>`;
+        if(isMobile)filterBody.hidden=true;
+        filter.appendChild(filterBody);
+        if(isMobile)filterTitle.addEventListener('click',()=>{filterBody.hidden=!filterBody.hidden;});
+        filterBody.querySelector('.lan-flow-map-search').addEventListener('input',(e)=>{
             this._filter.text=(e.target.value||'').toLowerCase().trim();
             this._needsStaticRedraw=true;
         });
-        const bandChips=[...filter.querySelectorAll('.lan-flow-map-chip')];
+        const bandChips=[...filterBody.querySelectorAll('.lan-flow-map-chip')];
         bandChips.forEach(chip=>{
             chip.addEventListener('click',()=>{
                 const b=chip.dataset.band;
@@ -380,11 +388,19 @@ class LanFlowMap2D {
         });
         this._el.appendChild(filter);
 
-        // Overlays panel (top-right, matching 3D style)
+        // Overlays panel (top-right, matching 3D style, collapsible on mobile)
         const controls=document.createElement('div');
         controls.className='lan-flow-map-panel lan-flow-map-controls';
-        controls.innerHTML=`<div class="lan-flow-map-panel-title">Overlays</div><div class="lan-flow-map-panel-body"></div>`;
-        const ctrlBody=controls.querySelector('.lan-flow-map-panel-body');
+        const ctrlTitle=document.createElement('div');
+        ctrlTitle.className='lan-flow-map-panel-title';
+        ctrlTitle.textContent='Overlays';
+        if(isMobile)ctrlTitle.classList.add('lan-flow-map-panel-title-toggle');
+        controls.appendChild(ctrlTitle);
+        const ctrlBody=document.createElement('div');
+        ctrlBody.className='lan-flow-map-panel-body';
+        if(isMobile)ctrlBody.hidden=true;
+        controls.appendChild(ctrlBody);
+        if(isMobile)ctrlTitle.addEventListener('click',()=>{ctrlBody.hidden=!ctrlBody.hidden;});
         for(const[key,label]of[['wifiClients','Wi-Fi clients'],['wiredClients','Wired clients'],['clouds','WAN globes']]){
             const row=document.createElement('div');
             row.className=`lan-flow-map-toggle ${this._overlays[key]?'is-on':''}`;
@@ -1185,13 +1201,13 @@ class LanFlowMap2D {
                     const lr=this._liveRates[e.lk.portKey]||this._liveRates[e.lk.id];
                     const ldn=lr?.downstreamBps??0, lup=lr?.upstreamBps??0;
                     if(ldn>RATE_THRESH||lup>RATE_THRESH){
-                        txt='↓'+(ldn>0?formatBps(ldn):'0 bps')+' ↑'+(lup>0?formatBps(lup):'0 bps');
+                        txt='↓'+(ldn>0?formatBps(ldn):'0 bps')+'  ↑'+(lup>0?formatBps(lup):'0 bps');
                         txtColor=null; // use down/up colors
                     }else{
                         const cloud=this._clouds.find(c=>
                             e.lk.fromNodeId===c.d.id||e.lk.toNodeId===c.d.id);
                         if(cloud?.d.ispDownloadMbps&&cloud?.d.ispUploadMbps){
-                            txt=`↓${formatSpeed(cloud.d.ispDownloadMbps)} ↑${formatSpeed(cloud.d.ispUploadMbps)}`;
+                            txt=`↓${formatSpeed(cloud.d.ispDownloadMbps)}  ↑${formatSpeed(cloud.d.ispUploadMbps)}`;
                         }else if(e.lk.capacityBps>0){
                             txt=formatSpeed(e.lk.capacityBps/1e6);
                         }
@@ -1201,7 +1217,7 @@ class LanFlowMap2D {
                     const n1=e.fn?.d, n2=e.tn?.d;
                     const phy=n2?.phyTxKbps?n2:n1?.phyTxKbps?n1:null;
                     if(phy?.phyTxKbps&&phy?.phyRxKbps){
-                        txt=`↓${formatSpeed(phy.phyRxKbps/1000)} ↑${formatSpeed(phy.phyTxKbps/1000)}`;
+                        txt=`↓${formatSpeed(phy.phyRxKbps/1000)}  ↑${formatSpeed(phy.phyTxKbps/1000)}`;
                     }else if(e.lk.capacityBps>0){
                         txt=formatSpeed(e.lk.capacityBps/1e6);
                     }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -57,8 +57,8 @@ const G = {
 };
 
 const RATE_THRESH = 1_000_000;
-const EMIT_MAX = 10;
-const MAX_DOTS = 10;
+const EMIT_MAX = 12;
+const MAX_DOTS = 14;
 const FONT = 'system-ui, -apple-system, sans-serif';
 
 // ---- Helpers ----
@@ -162,18 +162,37 @@ class Stream {
         this.pathLen=orthoLen(edge._x1,edge._y1,edge._x2,edge._y2);
         this.slots=[];
         for(let i=0;i<MAX_DOTS;i++)this.slots.push({t:-1,size:0});
+        this._seeded=false;
     }
     setRate(bps){
         const intensity=Math.max(0,Math.min(1,Math.log10(Math.max(bps,1))/11));
         this.density=intensity;
         this.dotSize=0.4+(intensity*intensity)*1.2;
+        // Constant visual speed: match 3D map (2.5 + intensity*4 scene-units/sec)
+        // scaled to SVG pixels. Divide by path length for normalized t/sec.
         const absPxSec=50+intensity*80;
         this.velNorm=absPxSec/Math.max(this.pathLen,1);
+
+        // Pre-seed on first non-zero rate so the pipe is already populated
+        // instead of building up from empty over the first few seconds.
+        if(!this._seeded&&intensity>0){
+            this._seeded=true;
+            const emitPerSec=intensity*intensity*EMIT_MAX;
+            const traverseTime=1/Math.max(this.velNorm,0.001);
+            const steadyState=Math.min(Math.round(emitPerSec*traverseTime),MAX_DOTS);
+            for(let i=0;i<steadyState;i++){
+                this.slots[i].t=(i+0.5)/steadyState;
+                if(this.dir<0)this.slots[i].t=1-this.slots[i].t;
+                this.slots[i].size=this.dotSize;
+            }
+        }
     }
     advance(dt){
+        // Emission: density²*12 dots/sec, jittered ±20% (3D uses ±40% but
+        // shorter 2D links need tighter spacing to avoid visible gaps)
         this.spawnAcc+=this.density*this.density*EMIT_MAX*dt;
         while(this.spawnAcc>=1){
-            this.spawnAcc-=(0.6+Math.random()*0.8);
+            this.spawnAcc-=(0.8+Math.random()*0.4);
             for(const sl of this.slots){if(sl.t<0){sl.t=this.dir>0?0:1;sl.size=this.dotSize;break;}}
         }
         for(const sl of this.slots){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -857,7 +857,7 @@ class LanFlowMap2D {
         const gx=this._root.x,gy=this._root.y;
         const total=this._clouds.length,sp=G.cloudGap;
         const sx=gx-((total-1)*sp)/2;
-        const baseY=gy-G.tierGap*1.4;
+        const baseY=gy-G.tierGap*1.6;
         const stagger=45;
         for(let i=0;i<total;i++){
             this._clouds[i].x=sx+i*sp;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1224,9 +1224,9 @@ class LanFlowMap2D {
                         const parts=txt.split(' ↑');
                         ctx.textBaseline='middle';
                         ctx.textAlign='right'; ctx.fillStyle=C.downstream;
-                        ctx.fillText(parts[0],mx-1,my);
+                        ctx.fillText(parts[0],mx-4,my);
                         ctx.textAlign='left'; ctx.fillStyle=C.upstream;
-                        ctx.fillText('↑'+parts[1],mx+1,my);
+                        ctx.fillText('↑'+parts[1],mx+4,my);
                     }
                 }
             }
@@ -1441,9 +1441,9 @@ class LanFlowMap2D {
                     ctx.textBaseline='top';
                     const dTxt='↓'+formatBps(downBps), uTxt='↑'+formatBps(upBps);
                     ctx.textAlign='right'; ctx.fillStyle=C.downstream;
-                    ctx.fillText(dTxt,n.x-2,n._rateY);
+                    ctx.fillText(dTxt,n.x-4,n._rateY);
                     ctx.textAlign='left'; ctx.fillStyle=C.upstream;
-                    ctx.fillText(uTxt,n.x+2,n._rateY);
+                    ctx.fillText(uTxt,n.x+4,n._rateY);
                 }
             }
             for(const c of n.infra)drawNodeRate(c);
@@ -1470,9 +1470,9 @@ class LanFlowMap2D {
                 ctx.fill();
                 ctx.textBaseline='middle';
                 ctx.textAlign='right'; ctx.fillStyle=C.downstream;
-                ctx.fillText(dTxt,mx-2,my);
+                ctx.fillText(dTxt,mx-4,my);
                 ctx.textAlign='left'; ctx.fillStyle=C.upstream;
-                ctx.fillText(uTxt,mx+2,my);
+                ctx.fillText(uTxt,mx+4,my);
             }
         }
     }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1135,6 +1135,10 @@ class LanFlowMap2D {
         }
         ctx.globalCompositeOperation='source-over';
         ctx.globalAlpha=1;
+
+        // Labels on top of everything (including particles)
+        this._drawLinkSpeedLabels(ctx);
+        this._drawRateLabels(ctx);
     }
 
     _drawStatic(){
@@ -1160,9 +1164,6 @@ class LanFlowMap2D {
         if(this._isCloudVisible())this._drawAllClouds(ctx);
         // Infra + client nodes
         this._drawAllNodes(ctx,this._root);
-        // All labels on top (capacity + live rates + node rates)
-        this._drawLinkSpeedLabels(ctx);
-        this._drawRateLabels(ctx);
     }
 
     // ---- Link drawing ----

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1351,11 +1351,10 @@ class LanFlowMap2D {
             if(!r)continue;
             const dn=r.downstreamBps??0,up=r.upstreamBps??0;
             if(dn>THRESH||up>THRESH){
-                // WAN: place on lower vertical segment (gateway column)
-                // Infra: place below the capacity label
+                // Place on child's vertical segment below the capacity label
                 const midY=(e._y1+e._y2)/2+(e._midYOff||0);
-                const mx=e._isWan?e._x2:(e._x1+e._x2)/2;
-                const my=e._isWan?(midY+e._y2)/2:(e._y1+e._y2)/2+14;
+                const mx=e._x2;
+                const my=midY+38;
                 const dTxt='↓'+(dn>0?formatBps(dn):'0 bps');
                 const uTxt='↑'+(up>0?formatBps(up):'0 bps');
                 const tw=ctx.measureText(dTxt+' '+uTxt).width+14;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -35,7 +35,7 @@ const LK = { Uplink:0, WiredClient:1, WifiClient:2, Wan:3, Transit:4, MeshBackha
 
 // ---- Layout geometry ----
 const G = {
-    tierGap:     140,
+    tierGap:     170,
     cloudGap:    100,
     infraGap:    90,
     clientCellW: 145,
@@ -430,7 +430,9 @@ class LanFlowMap2D {
         if(this._tooltip)this._tooltip.style.display='none';
     }
 
-    // ---- Layout (identical to SVG version) ----
+    // ---- Contour-based layout (Reingold-Tilford style) ----
+    // Computes left/right extent at every depth for each subtree, then pushes
+    // siblings apart until no depth overlaps. Guarantees zero cross-tree overlap.
 
     _buildLayout(snap){
         const byId=new Map();
@@ -473,8 +475,8 @@ class LanFlowMap2D {
         for(const lk of snap.links)this._edges.push({lk,fn:byId.get(lk.fromNodeId),tn:byId.get(lk.toNodeId)});
 
         if(!root)return;
-        this._widths(root);
-        this._positions(root,G.pad,0);
+        this._contourLayout(root);
+        this._assignAbsoluteXY(root,0,0);
         this._placeClouds();
         this._matchEdges();
         this._initStreams();
@@ -482,115 +484,101 @@ class LanFlowMap2D {
         this._updateStreamRates();
     }
 
-    _widths(n){
-        for(const c of n.infra)this._widths(c);
-
-        // If node has both infra and clients, merge clients into the
-        // infra grid so a lone wired device doesn't waste a whole column.
-        // Pure-client nodes (APs with only WiFi clients) use compact grid.
-        const mixed = n.infra.length > 0 && n.clients.length > 0;
-        const INFRA_COLS = 3;
-
-        if (mixed) {
-            // Combined list: infra subtrees + clients (each clientCellW wide)
-            const items = [...n.infra.map(c => c.w), ...n.clients.slice(0, G.maxClients).map(() => G.clientCellW)];
-            let maxRowW = 0;
-            for (let i = 0; i < items.length; i += INFRA_COLS) {
-                const row = items.slice(i, i + INFRA_COLS);
-                let rw = row.reduce((s, w) => s + w, 0);
-                if (row.length > 1) rw += (row.length - 1) * G.infraGap;
-                maxRowW = Math.max(maxRowW, rw);
-            }
-            n.w = Math.max(G.boxW + 30, maxRowW);
-        } else if (n.infra.length > 0) {
-            let maxRowW = 0;
-            for (let i = 0; i < n.infra.length; i += INFRA_COLS) {
-                const row = n.infra.slice(i, i + INFRA_COLS);
-                let rw = row.reduce((s, c) => s + c.w, 0);
-                if (row.length > 1) rw += (row.length - 1) * G.infraGap;
-                maxRowW = Math.max(maxRowW, rw);
-            }
-            n.w = Math.max(G.boxW + 30, maxRowW);
-        } else {
-            const nc = Math.min(n.clients.length, G.maxClients);
-            const cols = Math.min(nc, G.clientCols);
-            const cw = cols > 0 ? cols * G.clientCellW : 0;
-            n.w = Math.max(isClient(n.d.kind) ? G.clientCellW : G.boxW + 30, cw);
+    // Get the ordered list of children for layout purposes.
+    // If a node has both infra and clients, merge clients in (sorted: infra first).
+    // If only clients, group into a compact grid virtual node.
+    _layoutChildren(n){
+        const nc=Math.min(n.clients.length,G.maxClients);
+        if(n.infra.length>0){
+            // Mixed or pure infra: merge clients into the child list
+            return[...n.infra,...n.clients.slice(0,nc)];
         }
+        // Pure clients
+        return n.clients.slice(0,nc);
     }
 
-    _positions(n,lx,depth){
-        const yOff=G.pad+80;
-        n.y=yOff+depth*G.tierGap;
-        if(n.infra.length===0&&n.clients.length===0){n.x=lx+n.w/2;return;}
+    // Compute contour (left/right extent at each depth relative to node x=0)
+    // and store relative child offsets on the node.
+    _contourLayout(n){
+        const kids=this._layoutChildren(n);
+        const selfW=isClient(n.d.kind)?G.clientCellW:G.boxW+40;
+        const GAP=isClient(n.d.kind)?8:40;
 
-        const INFRA_COLS=3;
-        const mixed=n.infra.length>0&&n.clients.length>0;
-        const nc=Math.min(n.clients.length,G.maxClients);
+        if(kids.length===0){
+            n._contour=[{l:-selfW/2,r:selfW/2}];
+            n._kidOffsets=[];
+            n._kids=[];
+            return;
+        }
 
-        if(mixed){
-            // Merge infra + clients into one grid, rows of 3
-            // Each item is {type:'infra',node} or {type:'client',node}
-            const items=[
-                ...n.infra.map(c=>({type:'infra',node:c,w:c.w})),
-                ...n.clients.slice(0,nc).map(c=>({type:'client',node:c,w:G.clientCellW})),
-            ];
-            const rows=[];
-            for(let i=0;i<items.length;i+=INFRA_COLS)rows.push(items.slice(i,i+INFRA_COLS));
+        // Recursively compute each child's contour
+        for(const k of kids)this._contourLayout(k);
 
-            let firstRowItems=[];
-            for(let ri=0;ri<rows.length;ri++){
-                const row=rows[ri];
-                let rw=row.reduce((s,it)=>s+it.w,0);
-                if(row.length>1)rw+=(row.length-1)*G.infraGap;
-                let cur=lx+(n.w-rw)/2;
-                const childDepth=depth+1+ri;
-                for(const it of row){
-                    if(it.type==='infra'){
-                        this._positions(it.node,cur,childDepth);
-                    }else{
-                        it.node.x=cur+it.w/2;
-                        it.node.y=yOff+childDepth*G.tierGap;
-                    }
-                    cur+=it.w+G.infraGap;
-                    if(ri===0)firstRowItems.push(it.node);
+        // Place children left to right, checking contour overlap at every depth
+        const offsets=[];
+        // groupRight[d] = rightmost extent at depth d of all placed children so far
+        let groupRight=[];
+
+        for(let i=0;i<kids.length;i++){
+            const cc=kids[i]._contour;
+            if(i===0){
+                offsets[0]=0;
+                groupRight=cc.map(c=>c.r);
+            }else{
+                let minOff=0;
+                for(let d=0;d<Math.min(groupRight.length,cc.length);d++){
+                    const needed=groupRight[d]-cc[d].l+GAP;
+                    if(needed>minOff)minOff=needed;
+                }
+                offsets[i]=minOff;
+                // Merge into group contour
+                for(let d=0;d<cc.length;d++){
+                    const sr=cc[d].r+minOff;
+                    if(d<groupRight.length){if(sr>groupRight[d])groupRight[d]=sr;}
+                    else groupRight.push(sr);
                 }
             }
-            if(firstRowItems.length>0)n.x=(Math.min(...firstRowItems.map(c=>c.x))+Math.max(...firstRowItems.map(c=>c.x)))/2;
-            else n.x=lx+n.w/2;
+        }
 
-        } else if(n.infra.length>0){
-            // Pure infra, rows of 3
-            const rows=[];
-            for(let i=0;i<n.infra.length;i+=INFRA_COLS)rows.push(n.infra.slice(i,i+INFRA_COLS));
+        // Center children around x=0
+        const firstL=offsets[0]+kids[0]._contour[0].l;
+        const lastR=offsets[offsets.length-1]+kids[kids.length-1]._contour[0].r;
+        const center=(firstL+lastR)/2;
+        const centered=offsets.map(o=>o-center);
 
-            let firstRowKids=[];
-            for(let ri=0;ri<rows.length;ri++){
-                const row=rows[ri];
-                let rw=row.reduce((s,c)=>s+c.w,0);
-                if(row.length>1)rw+=(row.length-1)*G.infraGap;
-                let cur=lx+(n.w-rw)/2;
-                const childDepth=depth+1+ri;
-                for(const c of row){this._positions(c,cur,childDepth);cur+=c.w+G.infraGap;}
-                if(ri===0)firstRowKids=row;
+        n._kidOffsets=centered;
+        n._kids=kids;
+
+        // Build node's own contour: self at depth 0, children shifted at depth 1+
+        const contour=[{l:-selfW/2,r:selfW/2}];
+        let maxD=0;
+        for(const k of kids)if(k._contour.length>maxD)maxD=k._contour.length;
+
+        for(let d=0;d<maxD;d++){
+            let l=Infinity,r=-Infinity;
+            for(let i=0;i<kids.length;i++){
+                const cc=kids[i]._contour;
+                if(d<cc.length){
+                    const sl=cc[d].l+centered[i];
+                    const sr=cc[d].r+centered[i];
+                    if(sl<l)l=sl;
+                    if(sr>r)r=sr;
+                }
             }
-            if(firstRowKids.length>0)n.x=(Math.min(...firstRowKids.map(c=>c.x))+Math.max(...firstRowKids.map(c=>c.x)))/2;
-            else n.x=lx+n.w/2;
+            if(l!==Infinity)contour.push({l,r});
+        }
+        n._contour=contour;
+    }
 
-        } else {
-            // Pure clients - compact grid
-            const cols=Math.min(nc,G.clientCols);
-            const cw=cols*G.clientCellW;
-            const gridLeft=lx+(n.w-cw)/2;
-            const clientY=yOff+(depth+1)*G.tierGap;
-            for(let i=0;i<nc;i++){
-                const col=i%cols,row=Math.floor(i/cols);
-                n.clients[i].x=gridLeft+col*G.clientCellW+G.clientCellW/2;
-                n.clients[i].y=clientY+row*G.clientCellH;
-            }
-            const placed=n.clients.slice(0,nc);
-            if(placed.length>0)n.x=(Math.min(...placed.map(c=>c.x))+Math.max(...placed.map(c=>c.x)))/2;
-            else n.x=lx+n.w/2;
+    // Convert relative offsets to absolute x,y positions
+    _assignAbsoluteXY(n,absX,depth){
+        const yOff=G.pad+80;
+        n.x=absX;
+        n.y=yOff+depth*G.tierGap;
+        const kids=n._kids||[];
+        const offsets=n._kidOffsets||[];
+        for(let i=0;i<kids.length;i++){
+            this._assignAbsoluteXY(kids[i],absX+offsets[i],depth+1);
         }
     }
 
@@ -607,7 +595,6 @@ class LanFlowMap2D {
         if(!gw)return;
         const gwT=gw.y-G.boxH/2;
 
-        // Match edges to their drawn endpoints
         for(const cloud of this._clouds){
             const cy=cloud.y+G.cloudR+8;
             const edge=this._edges.find(e=>

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -463,8 +463,14 @@ class LanFlowMap2D {
             this._hoverNode=hit;
             this._showTooltip(hit,sx,sy);
         } else if(hit&&hit===this._hoverNode){
-            this._tooltip.style.left=(sx+14)+'px';
-            this._tooltip.style.top=(sy+14)+'px';
+            const tr=this._tooltip.getBoundingClientRect();
+            const cr=this._el.getBoundingClientRect();
+            let tx=sx+14,ty=sy+14;
+            if(tx+tr.width>cr.width-4)tx=sx-tr.width-8;
+            if(ty+tr.height>cr.height-4)ty=sy-tr.height-8;
+            if(tx<4)tx=4; if(ty<4)ty=4;
+            this._tooltip.style.left=tx+'px';
+            this._tooltip.style.top=ty+'px';
         } else if(!hit){
             this._hideTooltip();
         }
@@ -524,8 +530,16 @@ class LanFlowMap2D {
             `<div style="font-weight:600;margin-bottom:3px">${esc(d.name||d.mac||'')}</div>`
             +rows.map(([k,v])=>`<div style="display:flex;justify-content:space-between;gap:12px"><span style="color:${C.textMuted}">${k}</span><span>${esc(String(v))}</span></div>`).join('');
         this._tooltip.style.display='block';
-        this._tooltip.style.left=(sx+14)+'px';
-        this._tooltip.style.top=(sy+14)+'px';
+        // Position dynamically to stay within the container
+        const tr=this._tooltip.getBoundingClientRect();
+        const cr=this._el.getBoundingClientRect();
+        let tx=sx+14, ty=sy+14;
+        if(tx+tr.width>cr.width-4)tx=sx-tr.width-8;
+        if(ty+tr.height>cr.height-4)ty=sy-tr.height-8;
+        if(tx<4)tx=4;
+        if(ty<4)ty=4;
+        this._tooltip.style.left=tx+'px';
+        this._tooltip.style.top=ty+'px';
     }
 
     _hideTooltip(){
@@ -1200,7 +1214,9 @@ class LanFlowMap2D {
         const dt=Math.min((now-this._lastFrame)/1000,0.1);
         this._lastFrame=now;
 
-        for(const s of this._streams)s.advance(dt);
+        if(!flowData.isPaused()){
+            for(const s of this._streams)s.advance(dt);
+        }
         this._draw();
 
         this._animId=requestAnimationFrame(()=>this._animate());

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -407,7 +407,7 @@ class LanFlowMap2D {
 
     _fitAll(){
         if(!this._root)return;
-        const margin=40;
+        const margin=10;
         const sx=(this._cw-margin*2)/this._bw;
         const sy=(this._ch-margin*2)/this._bh;
         this._scale=Math.min(sx,sy,2);
@@ -728,11 +728,12 @@ class LanFlowMap2D {
     _calcBounds(){
         let x0=Infinity,y0=Infinity,x1=-Infinity,y1=-Infinity;
         const exp=(x,y,r)=>{x0=Math.min(x0,x-r);y0=Math.min(y0,y-r);x1=Math.max(x1,x+r);y1=Math.max(y1,y+r);};
-        const vis=(n)=>{exp(n.x,n.y,G.boxW+20);for(const c of n.infra)vis(c);for(const c of n.clients.slice(0,G.maxClients))exp(c.x,c.y,G.clientCellW/2);};
+        const vis=(n)=>{exp(n.x,n.y,G.boxW);for(const c of n.infra)vis(c);for(const c of n.clients.slice(0,G.maxClients))exp(c.x,c.y,G.clientCellW/2);};
         vis(this._root);
-        for(const c of this._clouds)exp(c.x,c.y,G.cloudR+40);
-        this._bx=x0-G.pad; this._by=y0-G.pad;
-        this._bw=(x1-x0)+G.pad*2; this._bh=(y1-y0)+G.pad*2+30;
+        for(const c of this._clouds)exp(c.x,c.y,G.cloudR+30);
+        const p=20;
+        this._bx=x0-p; this._by=y0-p;
+        this._bw=(x1-x0)+p*2; this._bh=(y1-y0)+p*2;
     }
 
     // ---- Image preloading ----

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1067,8 +1067,9 @@ class LanFlowMap2D {
                 ctx.globalAlpha=1;
                 const isWan=e._isWan;
                 const midY=(e._y1+e._y2)/2+(e._midYOff||0);
-                const mx=isWan?e._x1:(e._x1+e._x2)/2;
-                const my=isWan?midY-28:(e._y1+e._y2)/2;
+                // WAN: on cloud's vertical above horizontal. Infra: on child's vertical below horizontal.
+                const mx=isWan?e._x1:e._x2;
+                const my=isWan?midY-28:midY+20;
                 let txt=null;
                 let txtColor=C.textMuted; // default muted; live rates override
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -255,7 +255,8 @@ class LanFlowMap2D {
         const mx = (e.clientX - rect.left) / rect.width;
         const my = (e.clientY - rect.top) / rect.height;
 
-        const factor = e.deltaY > 0 ? 1.12 : 1 / 1.12;
+        const step = 1 + Math.min(Math.abs(e.deltaY), 100) * 0.001;
+        const factor = e.deltaY > 0 ? step : 1 / step;
         const nw = this._vw * factor;
         const nh = this._vh * factor;
 
@@ -322,6 +323,24 @@ class LanFlowMap2D {
             }
         }
         this._root = root;
+
+        // Diagnostic: dump tree structure
+        if (root) {
+            const dump = (n, depth) => {
+                const pad = '  '.repeat(depth);
+                console.log(`${pad}${n.d.name||n.d.id} (kind=${n.d.kind}) infra=${n.infra.length} clients=${n.clients.length}`);
+                for (const c of n.infra) dump(c, depth+1);
+            };
+            console.log(`[2D Map] Tree: ${byId.size} nodes, root=${root.d.name||root.d.id}`);
+            dump(root, 0);
+            const orphans = [...byId.values()].filter(tn => tn !== root && !tn.d.parentId && tn.d.kind !== NK.Cloud);
+            if (orphans.length) console.warn(`[2D Map] ${orphans.length} orphan nodes (no parentId):`, orphans.map(o => `${o.d.name||o.d.id} kind=${o.d.kind}`));
+            const unlinked = [...byId.values()].filter(tn => tn.d.parentId && !byId.has(tn.d.parentId));
+            if (unlinked.length) console.warn(`[2D Map] ${unlinked.length} nodes with parentId not in map:`, unlinked.map(o => `${o.d.name||o.d.id} parentId=${o.d.parentId}`));
+        } else {
+            console.warn('[2D Map] No gateway root found! Node kinds:', [...byId.values()].map(n => n.d.kind));
+        }
+
         this._clouds = (snap.clouds||[]).map(c => ({ d:c, x:0, y:0 }));
 
         this._edges = [];
@@ -798,8 +817,8 @@ class LanFlowMap2D {
         // Emission density - how many particles visible at once
         // density² * 12 = emissions/sec. At steady state ~density²*12 / velocity particles in flight.
         const density = intensity;
-        // Particle size: squared curve matching 3D map
-        const size = 1.5 + (intensity * intensity) * 5;
+        // Particle size: squared curve matching 3D map, scaled for 2D SVG
+        const size = 0.75 + (intensity * intensity) * 2.5;
         // Velocity: 0..1 range, normalized per-second fraction of path
         const vel = 0.15 + intensity * 0.45;
         // Count: density²*12 is emission rate; at vel speed, in-flight ≈ emission/vel

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -464,27 +464,40 @@ class LanFlowMap2D {
     }
 
     _widths(n){
-        // Compute each infra child's width first
         for(const c of n.infra)this._widths(c);
 
-        // Infra children: max 3 per row, rows stacked vertically
+        // If node has both infra and clients, merge clients into the
+        // infra grid so a lone wired device doesn't waste a whole column.
+        // Pure-client nodes (APs with only WiFi clients) use compact grid.
+        const mixed = n.infra.length > 0 && n.clients.length > 0;
         const INFRA_COLS = 3;
-        let maxRowW = 0;
-        for(let i=0;i<n.infra.length;i+=INFRA_COLS){
-            const row=n.infra.slice(i,i+INFRA_COLS);
-            let rw=row.reduce((s,c)=>s+c.w,0);
-            if(row.length>1)rw+=(row.length-1)*G.infraGap;
-            maxRowW=Math.max(maxRowW,rw);
-        }
 
-        const nc=Math.min(n.clients.length,G.maxClients);
-        const cols=Math.min(nc,G.clientCols);
-        const cw=cols>0?cols*G.clientCellW:0;
-        const self=isClient(n.d.kind)?G.clientCellW:G.boxW+30;
-        let childW=0;
-        if(maxRowW>0&&cw>0)childW=maxRowW+G.infraGap+cw;
-        else childW=maxRowW+cw;
-        n.w=Math.max(self,childW);
+        if (mixed) {
+            // Combined list: infra subtrees + clients (each clientCellW wide)
+            const items = [...n.infra.map(c => c.w), ...n.clients.slice(0, G.maxClients).map(() => G.clientCellW)];
+            let maxRowW = 0;
+            for (let i = 0; i < items.length; i += INFRA_COLS) {
+                const row = items.slice(i, i + INFRA_COLS);
+                let rw = row.reduce((s, w) => s + w, 0);
+                if (row.length > 1) rw += (row.length - 1) * G.infraGap;
+                maxRowW = Math.max(maxRowW, rw);
+            }
+            n.w = Math.max(G.boxW + 30, maxRowW);
+        } else if (n.infra.length > 0) {
+            let maxRowW = 0;
+            for (let i = 0; i < n.infra.length; i += INFRA_COLS) {
+                const row = n.infra.slice(i, i + INFRA_COLS);
+                let rw = row.reduce((s, c) => s + c.w, 0);
+                if (row.length > 1) rw += (row.length - 1) * G.infraGap;
+                maxRowW = Math.max(maxRowW, rw);
+            }
+            n.w = Math.max(G.boxW + 30, maxRowW);
+        } else {
+            const nc = Math.min(n.clients.length, G.maxClients);
+            const cols = Math.min(nc, G.clientCols);
+            const cw = cols > 0 ? cols * G.clientCellW : 0;
+            n.w = Math.max(isClient(n.d.kind) ? G.clientCellW : G.boxW + 30, cw);
+        }
     }
 
     _positions(n,lx,depth){
@@ -493,49 +506,73 @@ class LanFlowMap2D {
         if(n.infra.length===0&&n.clients.length===0){n.x=lx+n.w/2;return;}
 
         const INFRA_COLS=3;
-        const infraRows=[];
-        for(let i=0;i<n.infra.length;i+=INFRA_COLS)infraRows.push(n.infra.slice(i,i+INFRA_COLS));
-        const infraRowCount=infraRows.length;
-
+        const mixed=n.infra.length>0&&n.clients.length>0;
         const nc=Math.min(n.clients.length,G.maxClients);
-        const cols=Math.min(nc,G.clientCols);
-        const cw=cols>0?cols*G.clientCellW:0;
 
-        // Compute infra max row width for centering
-        let maxRowW=0;
-        for(const row of infraRows){
-            let rw=row.reduce((s,c)=>s+c.w,0);
-            if(row.length>1)rw+=(row.length-1)*G.infraGap;
-            maxRowW=Math.max(maxRowW,rw);
+        if(mixed){
+            // Merge infra + clients into one grid, rows of 3
+            // Each item is {type:'infra',node} or {type:'client',node}
+            const items=[
+                ...n.infra.map(c=>({type:'infra',node:c,w:c.w})),
+                ...n.clients.slice(0,nc).map(c=>({type:'client',node:c,w:G.clientCellW})),
+            ];
+            const rows=[];
+            for(let i=0;i<items.length;i+=INFRA_COLS)rows.push(items.slice(i,i+INFRA_COLS));
+
+            let firstRowItems=[];
+            for(let ri=0;ri<rows.length;ri++){
+                const row=rows[ri];
+                let rw=row.reduce((s,it)=>s+it.w,0);
+                if(row.length>1)rw+=(row.length-1)*G.infraGap;
+                let cur=lx+(n.w-rw)/2;
+                const childDepth=depth+1+ri;
+                for(const it of row){
+                    if(it.type==='infra'){
+                        this._positions(it.node,cur,childDepth);
+                    }else{
+                        it.node.x=cur+it.w/2;
+                        it.node.y=yOff+childDepth*G.tierGap;
+                    }
+                    cur+=it.w+G.infraGap;
+                    if(ri===0)firstRowItems.push(it.node);
+                }
+            }
+            if(firstRowItems.length>0)n.x=(Math.min(...firstRowItems.map(c=>c.x))+Math.max(...firstRowItems.map(c=>c.x)))/2;
+            else n.x=lx+n.w/2;
+
+        } else if(n.infra.length>0){
+            // Pure infra, rows of 3
+            const rows=[];
+            for(let i=0;i<n.infra.length;i+=INFRA_COLS)rows.push(n.infra.slice(i,i+INFRA_COLS));
+
+            let firstRowKids=[];
+            for(let ri=0;ri<rows.length;ri++){
+                const row=rows[ri];
+                let rw=row.reduce((s,c)=>s+c.w,0);
+                if(row.length>1)rw+=(row.length-1)*G.infraGap;
+                let cur=lx+(n.w-rw)/2;
+                const childDepth=depth+1+ri;
+                for(const c of row){this._positions(c,cur,childDepth);cur+=c.w+G.infraGap;}
+                if(ri===0)firstRowKids=row;
+            }
+            if(firstRowKids.length>0)n.x=(Math.min(...firstRowKids.map(c=>c.x))+Math.max(...firstRowKids.map(c=>c.x)))/2;
+            else n.x=lx+n.w/2;
+
+        } else {
+            // Pure clients - compact grid
+            const cols=Math.min(nc,G.clientCols);
+            const cw=cols*G.clientCellW;
+            const gridLeft=lx+(n.w-cw)/2;
+            const clientY=yOff+(depth+1)*G.tierGap;
+            for(let i=0;i<nc;i++){
+                const col=i%cols,row=Math.floor(i/cols);
+                n.clients[i].x=gridLeft+col*G.clientCellW+G.clientCellW/2;
+                n.clients[i].y=clientY+row*G.clientCellH;
+            }
+            const placed=n.clients.slice(0,nc);
+            if(placed.length>0)n.x=(Math.min(...placed.map(c=>c.x))+Math.max(...placed.map(c=>c.x)))/2;
+            else n.x=lx+n.w/2;
         }
-
-        let combW=0;
-        if(maxRowW>0&&cw>0)combW=maxRowW+G.infraGap+cw;
-        else combW=maxRowW+cw;
-
-        // Place infra children in rows of 3
-        for(let ri=0;ri<infraRows.length;ri++){
-            const row=infraRows[ri];
-            let rw=row.reduce((s,c)=>s+c.w,0);
-            if(row.length>1)rw+=(row.length-1)*G.infraGap;
-            let cur=lx+(n.w-combW)/2+(maxRowW-rw)/2;
-            const childDepth=depth+1+ri;
-            for(const c of row){this._positions(c,cur,childDepth);cur+=c.w+G.infraGap;}
-        }
-
-        // Place clients to the right of infra
-        const clientStartX=lx+(n.w-combW)/2+(maxRowW>0?maxRowW+G.infraGap:0);
-        const clientY=yOff+(depth+1)*G.tierGap;
-        for(let i=0;i<nc;i++){
-            const col=i%cols,row=Math.floor(i/cols);
-            n.clients[i].x=clientStartX+col*G.clientCellW+G.clientCellW/2;
-            n.clients[i].y=clientY+row*G.clientCellH;
-        }
-
-        // Center parent over first row of infra + clients
-        const firstRowKids=[...(infraRows[0]||[]),...n.clients.slice(0,nc)];
-        if(firstRowKids.length>0)n.x=(Math.min(...firstRowKids.map(c=>c.x))+Math.max(...firstRowKids.map(c=>c.x)))/2;
-        else n.x=lx+n.w/2;
     }
 
     _placeClouds(){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -258,8 +258,12 @@ class LanFlowMap2D {
                 const s=flowData.getSnapshot();
                 if(s){
                     this._liveRates={...flowData.getLiveRates()};
+                    const firstLoad=!this._root;
                     this._buildLayout(s);
-                    this._loadImages(s).then(()=>{this._fitAll();this._needsStaticRedraw=true;});
+                    this._loadImages(s).then(()=>{
+                        if(firstLoad)this._fitAll();
+                        this._needsStaticRedraw=true;
+                    });
                 }
             }else if(ev==='live'){
                 Object.assign(this._liveRates,flowData.getLiveRates());
@@ -657,7 +661,7 @@ class LanFlowMap2D {
         this._assignAbsoluteXY(root,0,0);
         this._placeClouds();
         this._matchEdges();
-        this._initStreams();
+        if(!this._streams||this._streams.length===0)this._initStreams();
         this._calcBounds();
         this._updateStreamRates();
     }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -276,6 +276,8 @@ class LanFlowMap2D {
         cancelAnimationFrame(this._animId);
         if(this._unsub)this._unsub();
         if(this._resizeObs)this._resizeObs.disconnect();
+        if(this._onKeyDown)document.removeEventListener('keydown',this._onKeyDown);
+        if(this._isFullscreen)this._el.classList.remove('lan-flow-map-fullscreen');
         this._streams=[];
         this._el.innerHTML='';
     }
@@ -300,6 +302,21 @@ class LanFlowMap2D {
         this._tooltip=document.createElement('div');
         this._tooltip.className='lfm2d-tooltip';
         this._el.appendChild(this._tooltip);
+
+        // Fullscreen button (top-right, matching 3D map style)
+        const fsBtn=document.createElement('button');
+        fsBtn.className='lan-flow-map-fullscreen-btn';
+        fsBtn.setAttribute('data-tooltip','Fullscreen');
+        fsBtn.innerHTML=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="3 8 3 3 8 3"></polyline><polyline points="16 3 21 3 21 8"></polyline>
+            <polyline points="21 16 21 21 16 21"></polyline><polyline points="8 21 3 21 3 16"></polyline></svg>`;
+        fsBtn.addEventListener('click',()=>this._toggleFullscreen());
+        this._el.appendChild(fsBtn);
+        this._fsBtn=fsBtn;
+
+        // Esc key exits fullscreen
+        this._onKeyDown=(e)=>{if(e.key==='Escape'&&this._isFullscreen)this._toggleFullscreen();};
+        document.addEventListener('keydown',this._onKeyDown);
 
         // Toolbar
         const tb=document.createElement('div');
@@ -402,6 +419,25 @@ class LanFlowMap2D {
     _zoomBy(factor){
         this._scale=Math.max(0.05,Math.min(10,this._scale*factor));
         this._needsStaticRedraw=true;
+    }
+
+    _toggleFullscreen(){
+        this._isFullscreen=!this._isFullscreen;
+        const el=this._el;
+        if(this._isFullscreen){
+            el.classList.add('lan-flow-map-fullscreen');
+            this._fsBtn.innerHTML=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="4 10 10 10 10 4"></polyline><polyline points="14 4 14 10 20 10"></polyline>
+                <polyline points="20 14 14 14 14 20"></polyline><polyline points="10 20 10 14 4 14"></polyline></svg>`;
+            this._fsBtn.setAttribute('data-tooltip','Exit fullscreen (Esc)');
+        }else{
+            el.classList.remove('lan-flow-map-fullscreen');
+            this._fsBtn.innerHTML=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="3 8 3 3 8 3"></polyline><polyline points="16 3 21 3 21 8"></polyline>
+                <polyline points="21 16 21 21 16 21"></polyline><polyline points="8 21 3 21 3 16"></polyline></svg>`;
+            this._fsBtn.setAttribute('data-tooltip','Fullscreen');
+        }
+        setTimeout(()=>{this._resize();this._fitAll();},50);
     }
 
     // ---- Tooltip hit-test ----

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -413,6 +413,23 @@ class LanFlowMap2D {
         });
         this._el.appendChild(tb);
 
+        // Mode badge (bottom-left, matching 3D style)
+        const status=document.createElement('div');
+        status.className='lan-flow-map-panel lan-flow-map-status';
+        const modeBadge=document.createElement('span');
+        modeBadge.className='lan-flow-map-mode';
+        modeBadge.textContent='Live';
+        modeBadge.addEventListener('click',()=>{
+            const inst=window.__lanFlowMap?.getInstance?.();
+            if(inst&&inst._mode==='historic'){
+                const r=inst._panels?.scrubberRange;
+                if(r){r.value=10000;r.dispatchEvent(new Event('change'));}
+            }
+        });
+        status.appendChild(modeBadge);
+        this._el.appendChild(status);
+        this._modeBadge=modeBadge;
+
         // Mirror scrubber (synced from 3D map via shared data store).
         // Interactions forward to the 3D map's instance.
         const scrubber=document.createElement('div');
@@ -554,6 +571,14 @@ class LanFlowMap2D {
         this._scrubberEls.right.textContent=s.right;
         this._scrubberEls.speedLabel.textContent=`${s.speed}x`;
         this._scrubberEls.playPause.textContent=flowData.isPaused()?'▶':'⏸';
+        // Mode badge
+        if(this._modeBadge){
+            const mode=flowData.getMode();
+            this._modeBadge.textContent=mode==='historic'?'Historic':'Live';
+            this._modeBadge.classList.toggle('is-historic',mode==='historic');
+            this._modeBadge.style.cursor=mode==='historic'?'pointer':'';
+            this._modeBadge.setAttribute('data-tooltip',mode==='historic'?'Click to return to live':'');
+        }
     }
 
     _isNodeVisible(n){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1001,10 +1001,12 @@ class LanFlowMap2D {
             // Capacity / speed label on infra and WAN links
             if(!e._isCl){
                 ctx.globalAlpha=1;
-                // WAN labels go on the vertical segment near the cloud, not the shared midpoint
+                // WAN: place on the upper vertical segment (cloud's own column)
+                // Infra: place at the link midpoint
                 const isWan=e._isWan;
+                const midY=(e._y1+e._y2)/2+(e._midYOff||0);
                 const mx=isWan?e._x1:(e._x1+e._x2)/2;
-                const my=isWan?e._y1+30:(e._y1+e._y2)/2;
+                const my=isWan?(e._y1+midY)/2:(e._y1+e._y2)/2;
                 let txt=null;
 
                 if(isWan){
@@ -1267,7 +1269,11 @@ class LanFlowMap2D {
             if(!r)continue;
             const dn=r.downstreamBps??0,up=r.upstreamBps??0;
             if(dn>THRESH||up>THRESH){
-                const mx=(e._x1+e._x2)/2, my=(e._y1+e._y2)/2+14;
+                // WAN: place on lower vertical segment (gateway column)
+                // Infra: place below the capacity label
+                const midY=(e._y1+e._y2)/2+(e._midYOff||0);
+                const mx=e._isWan?e._x2:(e._x1+e._x2)/2;
+                const my=e._isWan?(midY+e._y2)/2:(e._y1+e._y2)/2+14;
                 const dTxt='↓'+(dn>0?formatBps(dn):'0 bps');
                 const uTxt='↑'+(up>0?formatBps(up):'0 bps');
                 const tw=ctx.measureText(dTxt+' '+uTxt).width+14;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -258,12 +258,24 @@ class LanFlowMap2D {
                 const s=flowData.getSnapshot();
                 if(s){
                     this._liveRates={...flowData.getLiveRates()};
-                    const firstLoad=!this._root;
-                    this._buildLayout(s);
-                    this._loadImages(s).then(()=>{
-                        if(firstLoad)this._fitAll();
-                        this._needsStaticRedraw=true;
-                    });
+                    if(!this._root){
+                        // First load: full build + fit
+                        this._buildLayout(s);
+                        this._loadImages(s).then(()=>{this._fitAll();this._needsStaticRedraw=true;});
+                    }else{
+                        // Refresh: detect topology change by link count
+                        const newLinkCount=s.links?.length||0;
+                        const curLinkCount=this._edges?.length||0;
+                        if(newLinkCount!==curLinkCount){
+                            // Topology changed: full rebuild, keep view
+                            this._buildLayout(s);
+                            this._loadImages(s).then(()=>{this._needsStaticRedraw=true;});
+                        }else{
+                            // Same topology: just update data (clouds, node props)
+                            this._updateSnapshotData(s);
+                            this._needsStaticRedraw=true;
+                        }
+                    }
                 }
             }else if(ev==='live'){
                 Object.assign(this._liveRates,flowData.getLiveRates());
@@ -661,7 +673,8 @@ class LanFlowMap2D {
         this._assignAbsoluteXY(root,0,0);
         this._placeClouds();
         this._matchEdges();
-        if(!this._streams||this._streams.length===0)this._initStreams();
+        // Always reinit streams - edges get new endpoint coords on rebuild
+        this._initStreams();
         this._calcBounds();
         this._updateStreamRates();
     }
@@ -792,6 +805,30 @@ class LanFlowMap2D {
         }
     }
 
+    _updateSnapshotData(snap){
+        // Update cloud data (ISP speeds, RTT) without rebuilding layout
+        for(const c of this._clouds){
+            const fresh=snap.clouds?.find(sc=>sc.id===c.d.id);
+            if(fresh){
+                c.d.ispDownloadMbps=fresh.ispDownloadMbps;
+                c.d.ispUploadMbps=fresh.ispUploadMbps;
+                c.d.rttAvgMs=fresh.rttAvgMs;
+                c.d.lossPercent=fresh.lossPercent;
+            }
+        }
+        // Update node data (PHY rates, online status) on existing tree nodes
+        for(const n of snap.nodes){
+            const tn=this._treeMap.get(n.id);
+            if(tn){
+                tn.d.online=n.online;
+                tn.d.phyTxKbps=n.phyTxKbps;
+                tn.d.phyRxKbps=n.phyRxKbps;
+                tn.d.band=n.band;
+                tn.d.signalDbm=n.signalDbm;
+            }
+        }
+    }
+
     _placeClouds(){
         if(!this._root||this._clouds.length===0)return;
         const gx=this._root.x,gy=this._root.y;
@@ -801,7 +838,7 @@ class LanFlowMap2D {
         const stagger=45;
         for(let i=0;i<total;i++){
             this._clouds[i].x=sx+i*sp;
-            this._clouds[i].y=baseY+(i%2)*stagger;
+            this._clouds[i].y=baseY+(1-i%2)*stagger;
         }
     }
 
@@ -1005,22 +1042,28 @@ class LanFlowMap2D {
             // Capacity / speed label on infra and WAN links
             if(!e._isCl){
                 ctx.globalAlpha=1;
-                // WAN: place on the upper vertical segment (cloud's own column)
-                // Infra: place at the link midpoint
                 const isWan=e._isWan;
                 const midY=(e._y1+e._y2)/2+(e._midYOff||0);
                 const mx=isWan?e._x1:(e._x1+e._x2)/2;
-                // WAN: place just above the horizontal routing segment
                 const my=isWan?midY-16:(e._y1+e._y2)/2;
                 let txt=null;
+                let txtColor=C.textMuted; // default muted; live rates override
 
                 if(isWan){
-                    const cloud=this._clouds.find(c=>
-                        e.lk.fromNodeId===c.d.id||e.lk.toNodeId===c.d.id);
-                    if(cloud?.d.ispDownloadMbps&&cloud?.d.ispUploadMbps){
-                        txt=`↓${formatSpeed(cloud.d.ispDownloadMbps)} ↑${formatSpeed(cloud.d.ispUploadMbps)}`;
-                    }else if(e.lk.capacityBps>0){
-                        txt=formatSpeed(e.lk.capacityBps/1e6);
+                    // Show live throughput when active, ISP expected when idle
+                    const lr=this._liveRates[e.lk.portKey]||this._liveRates[e.lk.id];
+                    const ldn=lr?.downstreamBps??0, lup=lr?.upstreamBps??0;
+                    if(ldn>RATE_THRESH||lup>RATE_THRESH){
+                        txt='↓'+(ldn>0?formatBps(ldn):'0 bps')+' ↑'+(lup>0?formatBps(lup):'0 bps');
+                        txtColor=null; // use down/up colors
+                    }else{
+                        const cloud=this._clouds.find(c=>
+                            e.lk.fromNodeId===c.d.id||e.lk.toNodeId===c.d.id);
+                        if(cloud?.d.ispDownloadMbps&&cloud?.d.ispUploadMbps){
+                            txt=`↓${formatSpeed(cloud.d.ispDownloadMbps)} ↑${formatSpeed(cloud.d.ispUploadMbps)}`;
+                        }else if(e.lk.capacityBps>0){
+                            txt=formatSpeed(e.lk.capacityBps/1e6);
+                        }
                     }
                 }else if(e.lk.kind===LK.MeshBackhaul||e.lk.band){
                     // Mesh/wireless: show asymmetric PHY rates
@@ -1041,9 +1084,19 @@ class LanFlowMap2D {
                     ctx.fillStyle=C.labelBg;
                     this._roundRect(ctx,mx-tw/2,my-8,tw,16,4);
                     ctx.fill();
-                    ctx.fillStyle=C.textMuted;
-                    ctx.textAlign='center'; ctx.textBaseline='middle';
-                    ctx.fillText(txt,mx,my);
+                    if(txtColor){
+                        ctx.fillStyle=txtColor;
+                        ctx.textAlign='center'; ctx.textBaseline='middle';
+                        ctx.fillText(txt,mx,my);
+                    }else{
+                        // Directional colors: split at the space between ↑ and preceding text
+                        const parts=txt.split(' ↑');
+                        ctx.textBaseline='middle';
+                        ctx.textAlign='right'; ctx.fillStyle=C.downstream;
+                        ctx.fillText(parts[0],mx-1,my);
+                        ctx.textAlign='left'; ctx.fillStyle=C.upstream;
+                        ctx.fillText('↑'+parts[1],mx+1,my);
+                    }
                 }
             }
         }
@@ -1269,7 +1322,7 @@ class LanFlowMap2D {
         // Link rate labels
         ctx.font=`${G.rateFont}px ${FONT}`;
         for(const e of this._edges){
-            if(e._x1==null||e._isCl)continue;
+            if(e._x1==null||e._isCl||e._isWan)continue;
             const r=this._liveRates[e.lk.portKey]||this._liveRates[e.lk.id];
             if(!r)continue;
             const dn=r.downstreamBps??0,up=r.upstreamBps??0;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -39,10 +39,10 @@ const G = {
     tierGap:     140,
     cloudGap:    100,
     infraGap:    90,
-    clientCellW: 80,
+    clientCellW: 145,
     clientCellH: 50,
     clientR:     7,
-    clientCols:  8,
+    clientCols:  6,
     maxClients:  80,
     iconSize:    52,
     boxW:        68,
@@ -157,8 +157,8 @@ class TN {
 
 // ---- Persistent particle stream (mirrors 3D map's ParticleStream) ----
 
-const MAX_DOTS = 16;
-const EMIT_MAX = 12;
+const MAX_DOTS = 10;
+const EMIT_MAX = 10;
 
 class Stream {
     constructor(edge, dir, color, layer) {
@@ -173,7 +173,7 @@ class Stream {
         this._pathLen = orthoLen(edge._x1, edge._y1, edge._x2, edge._y2);
         this._slots = [];
         for (let i = 0; i < MAX_DOTS; i++) {
-            const dot = el('circle', { r: 0.4, fill: color, opacity: 0, filter: 'url(#pg)' }, layer);
+            const dot = el('circle', { r: 0.4, fill: color, opacity: 0 }, layer);
             this._slots.push({ el: dot, t: -1, size: 0 });
         }
     }
@@ -787,7 +787,7 @@ class LanFlowMap2D {
         // Visible name label below
         const name = n.d.name || n.d.ip || '';
         if (name) {
-            const dn = name.length > 14 ? name.slice(0, 13) + '…' : name;
+            const dn = name.length > 25 ? name.slice(0, 24) + '…' : name;
             const t = el('text', { x:0, y:r + 11, 'text-anchor':'middle', fill:C.textMuted,
                 'font-size':G.clientNameFont, 'font-family':'system-ui,sans-serif' }, g);
             t.textContent = dn;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -447,6 +447,10 @@ class LanFlowMap2D {
         let hit=null;
 
         const checkNode=(n)=>{
+            if(n.d.kind===NK.VirtualHub){
+                if(Math.abs(w.x-n.x)<20&&Math.abs(w.y-n.y)<20)hit=n;
+                return;
+            }
             if(Math.abs(w.x-n.x)<G.boxW/2&&Math.abs(w.y-n.y)<G.boxH/2)hit=n;
             for(const c of n.infra)checkNode(c);
             for(const c of n.clients.slice(0,G.maxClients)){
@@ -457,16 +461,71 @@ class LanFlowMap2D {
 
         if(hit&&hit!==this._hoverNode){
             this._hoverNode=hit;
-            const name=hit.d.name||hit.d.ip||hit.d.mac||'';
-            if(name){
-                this._tooltip.textContent=name;
-                this._tooltip.style.display='block';
-                this._tooltip.style.left=(sx+12)+'px';
-                this._tooltip.style.top=(sy-8)+'px';
-            }
+            this._showTooltip(hit,sx,sy);
+        } else if(hit&&hit===this._hoverNode){
+            this._tooltip.style.left=(sx+14)+'px';
+            this._tooltip.style.top=(sy+14)+'px';
         } else if(!hit){
             this._hideTooltip();
         }
+    }
+
+    _showTooltip(node,sx,sy){
+        const d=node.d;
+        const esc=(s)=>(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;');
+        const rows=[];
+        if(d.ip)rows.push(['IP',d.ip]);
+        if(d.mac)rows.push(['MAC',d.mac]);
+        if(d.model)rows.push(['Model',d.model]);
+        if(d.band)rows.push(['Band',`${d.band} GHz`]);
+        if(d.ssid)rows.push(['SSID',d.ssid]);
+        if(d.signalDbm)rows.push(['Signal',`${d.signalDbm} dBm`]);
+        if(d.switchPortName)rows.push(['Switch port',d.switchPortName]);
+        if(d.wiredLinkSpeedMbps)rows.push(['Link speed',formatSpeed(d.wiredLinkSpeedMbps)]);
+        if(d.network)rows.push(['Network',d.network]);
+
+        const badges=flowData.getNodeBadges();
+        const b=badges?.[d.id];
+        if(b?.cpuPercent!=null)rows.push(['CPU',`${b.cpuPercent.toFixed(0)}%`]);
+        if(b?.memoryUsedPercent!=null)rows.push(['Memory',`${b.memoryUsedPercent.toFixed(0)}%`]);
+        if(b?.temperatureC!=null)rows.push(['Temp',`${b.temperatureC.toFixed(0)} °C`]);
+        if(b?.uptimeSeconds!=null){
+            const days=Math.floor(b.uptimeSeconds/86400);
+            const hrs=Math.floor((b.uptimeSeconds%86400)/3600);
+            rows.push(['Uptime',days>0?`${days}d ${hrs}h`:`${hrs}h`]);
+        }
+
+        // Rates: fabric devices use badge, clients use link rates
+        const isFab=d.kind===NK.Gateway||d.kind===NK.Switch||d.kind===NK.AP;
+        let inBps=0,outBps=0,any=false;
+        if(isFab&&b){
+            if(b.fabricIngressBps!=null||b.fabricEgressBps!=null){
+                inBps=b.fabricIngressBps||0;outBps=b.fabricEgressBps||0;any=true;
+            }else if(b.aggregateInBps!=null||b.aggregateOutBps!=null){
+                inBps=b.aggregateInBps||0;outBps=b.aggregateOutBps||0;any=true;
+            }
+        }else{
+            for(const e of this._edges){
+                if(e.lk.fromNodeId!==d.id&&e.lk.toNodeId!==d.id)continue;
+                const r=this._liveRates[e.lk.portKey]||this._liveRates[e.lk.id];
+                if(!r)continue;
+                any=true;
+                const dl=r.downstreamBps||0,ul=r.upstreamBps||0;
+                if(e.lk.toNodeId===d.id){inBps+=dl;outBps+=ul;}
+                else{inBps+=ul;outBps+=dl;}
+            }
+        }
+        if(any){
+            if(isFab){rows.push(['Ingress',formatBps(inBps)]);rows.push(['Egress',formatBps(outBps)]);}
+            else{rows.push(['Download',formatBps(inBps)]);rows.push(['Upload',formatBps(outBps)]);}
+        }
+
+        this._tooltip.innerHTML=
+            `<div style="font-weight:600;margin-bottom:3px">${esc(d.name||d.mac||'')}</div>`
+            +rows.map(([k,v])=>`<div style="display:flex;justify-content:space-between;gap:12px"><span style="color:${C.textMuted}">${k}</span><span>${esc(String(v))}</span></div>`).join('');
+        this._tooltip.style.display='block';
+        this._tooltip.style.left=(sx+14)+'px';
+        this._tooltip.style.top=(sy+14)+'px';
     }
 
     _hideTooltip(){
@@ -865,7 +924,17 @@ class LanFlowMap2D {
                 if(cap>0){
                     ctx.globalAlpha=1;
                     const mx=(e._x1+e._x2)/2, my=(e._y1+e._y2)/2;
-                    const txt=formatSpeed(cap);
+                    // Wireless links (mesh/wifi): show asymmetric PHY rates if available
+                    // Check both endpoints - the mesh AP or wifi client has the PHY rates
+                    let txt;
+                    const n1=e.fn?.d, n2=e.tn?.d;
+                    const phy=n2?.phyTxKbps?n2:n1?.phyTxKbps?n1:null;
+                    if((e.lk.kind===LK.MeshBackhaul||e.lk.band)&&phy?.phyTxKbps&&phy?.phyRxKbps){
+                        const tx=phy.phyTxKbps/1000, rx=phy.phyRxKbps/1000;
+                        txt=`↓${formatSpeed(rx)} ↑${formatSpeed(tx)}`;
+                    }else{
+                        txt=formatSpeed(cap);
+                    }
                     ctx.font=`${G.rateFont}px ${FONT}`;
                     const tw=ctx.measureText(txt).width+12;
                     ctx.fillStyle=C.labelBg;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -682,8 +682,10 @@ class LanFlowMap2D {
 
         // Tree links - stagger siblings from same parent
         const matchTree=(n)=>{
+            // VirtualHub: only match the hub's own uplink, skip its children
+            if(n.d.kind===NK.VirtualHub)return;
+
             const pB=n.y+G.boxH/2;
-            const allKids=[...n.infra,...n.clients.slice(0,G.maxClients)];
             const sibEdges=[];
 
             for(const c of n.infra){
@@ -949,9 +951,10 @@ class LanFlowMap2D {
         ctx.beginPath(); ctx.arc(x,y,r-1,0,Math.PI*2); ctx.fill();
         ctx.globalAlpha=1;
 
-        // Label: "NAS Server (7)"
+        // Label - name may already include count from the server
         const name=n.d.name||'Hub';
-        const label=memberCount>0?`${name} (${memberCount})`:name;
+        const hasCount=/\(\d+\)/.test(name);
+        const label=hasCount?name:memberCount>0?`${name} (${memberCount})`:name;
         const dn=label.length>28?label.slice(0,27)+'…':label;
         ctx.fillStyle=C.textSec;
         ctx.font=`${G.nameFont}px ${FONT}`;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -109,21 +109,25 @@ function withAlpha(hex, a) {
 }
 
 // ---- Orthogonal path helpers ----
+// All accept an optional midYOff to vertically stagger sibling links.
 
-function orthoLen(x1,y1,x2,y2) {
+function orthoLen(x1,y1,x2,y2,midYOff) {
     if(Math.abs(x1-x2)<0.5)return Math.abs(y2-y1);
-    const ax=Math.abs(x2-x1),hv=Math.abs(y2-y1)/2,cr=Math.min(G.cornerR,ax/2,hv);
-    if(cr<1)return Math.abs(y2-y1)+ax;
-    return (hv-cr)*2+Math.PI*cr+(ax-2*cr);
+    const my=(y1+y2)/2+(midYOff||0);
+    const top=my-y1, bot=y2-my;
+    const ax=Math.abs(x2-x1),cr=Math.min(G.cornerR,ax/2,Math.min(top,bot));
+    if(cr<1)return top+ax+bot;
+    return (top-cr)+(bot-cr)+Math.PI*cr+(ax-2*cr);
 }
 
-function orthoAt(x1,y1,x2,y2,t) {
-    const dy=y2-y1;
-    if(Math.abs(x2-x1)<0.5)return{x:x1,y:y1+dy*t};
-    const midY=(y1+y2)/2,dx=x2-x1,s=dx>0?1:-1,ax=Math.abs(dx),hv=Math.abs(dy)/2;
-    const cr=Math.min(G.cornerR,ax/2,hv);
-    if(cr<1){const tot=hv+ax+hv;let d=t*tot;if(d<=hv)return{x:x1,y:y1+d};d-=hv;if(d<=ax)return{x:x1+s*d,y:midY};d-=ax;return{x:x2,y:midY+d};}
-    const s1=hv-cr,s2=Math.PI/2*cr,s3=ax-2*cr,s4=s2,s5=hv-cr;
+function orthoAt(x1,y1,x2,y2,t,midYOff) {
+    if(Math.abs(x2-x1)<0.5)return{x:x1,y:y1+(y2-y1)*t};
+    const midY=(y1+y2)/2+(midYOff||0);
+    const dx=x2-x1,s=dx>0?1:-1,ax=Math.abs(dx);
+    const top=midY-y1,bot=y2-midY;
+    const cr=Math.min(G.cornerR,ax/2,Math.min(top,bot));
+    if(cr<1){const tot=top+ax+bot;let d=t*tot;if(d<=top)return{x:x1,y:y1+d};d-=top;if(d<=ax)return{x:x1+s*d,y:midY};d-=ax;return{x:x2,y:midY+d};}
+    const s1=top-cr,s2=Math.PI/2*cr,s3=ax-2*cr,s4=s2,s5=bot-cr;
     const tot=s1+s2+s3+s4+s5;let d=t*tot;
     if(d<=s1)return{x:x1,y:y1+d};d-=s1;
     if(d<=s2){const a=d/s2*Math.PI/2;return{x:x1+s*cr*Math.sin(a),y:midY-cr+cr*(1-Math.cos(a))};}d-=s2;
@@ -132,12 +136,14 @@ function orthoAt(x1,y1,x2,y2,t) {
     return{x:x2,y:midY+cr+d};
 }
 
-function strokeOrtho(ctx,x1,y1,x2,y2) {
+function strokeOrtho(ctx,x1,y1,x2,y2,midYOff) {
     const r=G.cornerR;
     ctx.beginPath();
     if(Math.abs(x1-x2)<0.5){ctx.moveTo(x1,y1);ctx.lineTo(x2,y2);ctx.stroke();return;}
-    const midY=(y1+y2)/2,dx=x2-x1,s=dx>0?1:-1,ax=Math.abs(dx),hv=Math.abs(y2-y1)/2;
-    const cr=Math.min(r,ax/2,hv);
+    const midY=(y1+y2)/2+(midYOff||0);
+    const dx=x2-x1,s=dx>0?1:-1,ax=Math.abs(dx);
+    const top=midY-y1,bot=y2-midY;
+    const cr=Math.min(r,ax/2,Math.min(top,bot));
     ctx.moveTo(x1,y1);
     if(cr<1){ctx.lineTo(x1,midY);ctx.lineTo(x2,midY);ctx.lineTo(x2,y2);ctx.stroke();return;}
     ctx.lineTo(x1,midY-cr);
@@ -159,7 +165,8 @@ class Stream {
         this.edge=edge; this.dir=dir; this.color=color;
         this.density=0; this.velNorm=0; this.dotSize=0.4;
         this.spawnAcc=0;
-        this.pathLen=orthoLen(edge._x1,edge._y1,edge._x2,edge._y2);
+        this.midYOff=edge._midYOff||0;
+        this.pathLen=orthoLen(edge._x1,edge._y1,edge._x2,edge._y2,this.midYOff);
         this.slots=[];
         for(let i=0;i<MAX_DOTS;i++)this.slots.push({t:-1,size:0});
         this._seeded=false;
@@ -258,6 +265,7 @@ class LanFlowMap2D {
                 Object.assign(this._liveRates,flowData.getLiveRates());
                 this._updateStreamRates();
                 this._updateCloudStats();
+                this._needsStaticRedraw=true;
             }
         });
         this._lastFrame=performance.now();
@@ -484,25 +492,32 @@ class LanFlowMap2D {
         this._updateStreamRates();
     }
 
-    // Get the ordered list of children for layout purposes.
-    // If a node has both infra and clients, merge clients in (sorted: infra first).
-    // If only clients, group into a compact grid virtual node.
-    _layoutChildren(n){
-        const nc=Math.min(n.clients.length,G.maxClients);
-        if(n.infra.length>0){
-            // Mixed or pure infra: merge clients into the child list
-            return[...n.infra,...n.clients.slice(0,nc)];
-        }
-        // Pure clients
-        return n.clients.slice(0,nc);
-    }
-
     // Compute contour (left/right extent at each depth relative to node x=0)
     // and store relative child offsets on the node.
     _contourLayout(n){
-        const kids=this._layoutChildren(n);
         const selfW=isClient(n.d.kind)?G.clientCellW:G.boxW+40;
-        const GAP=isClient(n.d.kind)?8:40;
+        const nc=Math.min(n.clients.length,G.maxClients);
+
+        // Pure-client nodes (APs with only WiFi clients): compact grid
+        if(n.infra.length===0&&nc>0){
+            const cols=Math.min(nc,G.clientCols);
+            const rows=Math.ceil(nc/cols);
+            const gridW=cols*G.clientCellW;
+            const gridH=rows*G.clientCellH;
+            n._isGrid=true;
+            n._gridCols=cols;
+            // Contour: node at depth 0, grid rectangle at depth 1
+            n._contour=[
+                {l:-selfW/2,r:selfW/2},
+                {l:-gridW/2,r:gridW/2},
+            ];
+            n._kidOffsets=[];
+            n._kids=[];
+            return;
+        }
+
+        // Infra children (+ any direct clients merged in)
+        const kids=n.infra.length>0?[...n.infra,...n.clients.slice(0,nc)]:[];
 
         if(kids.length===0){
             n._contour=[{l:-selfW/2,r:selfW/2}];
@@ -511,12 +526,10 @@ class LanFlowMap2D {
             return;
         }
 
-        // Recursively compute each child's contour
         for(const k of kids)this._contourLayout(k);
 
-        // Place children left to right, checking contour overlap at every depth
+        const GAP=40;
         const offsets=[];
-        // groupRight[d] = rightmost extent at depth d of all placed children so far
         let groupRight=[];
 
         for(let i=0;i<kids.length;i++){
@@ -531,7 +544,6 @@ class LanFlowMap2D {
                     if(needed>minOff)minOff=needed;
                 }
                 offsets[i]=minOff;
-                // Merge into group contour
                 for(let d=0;d<cc.length;d++){
                     const sr=cc[d].r+minOff;
                     if(d<groupRight.length){if(sr>groupRight[d])groupRight[d]=sr;}
@@ -540,7 +552,6 @@ class LanFlowMap2D {
             }
         }
 
-        // Center children around x=0
         const firstL=offsets[0]+kids[0]._contour[0].l;
         const lastR=offsets[offsets.length-1]+kids[kids.length-1]._contour[0].r;
         const center=(firstL+lastR)/2;
@@ -549,11 +560,9 @@ class LanFlowMap2D {
         n._kidOffsets=centered;
         n._kids=kids;
 
-        // Build node's own contour: self at depth 0, children shifted at depth 1+
         const contour=[{l:-selfW/2,r:selfW/2}];
         let maxD=0;
         for(const k of kids)if(k._contour.length>maxD)maxD=k._contour.length;
-
         for(let d=0;d<maxD;d++){
             let l=Infinity,r=-Infinity;
             for(let i=0;i<kids.length;i++){
@@ -570,11 +579,26 @@ class LanFlowMap2D {
         n._contour=contour;
     }
 
-    // Convert relative offsets to absolute x,y positions
     _assignAbsoluteXY(n,absX,depth){
         const yOff=G.pad+80;
         n.x=absX;
         n.y=yOff+depth*G.tierGap;
+
+        // Client grid: place clients in compact rows
+        if(n._isGrid){
+            const nc=Math.min(n.clients.length,G.maxClients);
+            const cols=n._gridCols;
+            const gridW=cols*G.clientCellW;
+            const gridLeft=absX-gridW/2;
+            const clientY=yOff+(depth+1)*G.tierGap;
+            for(let i=0;i<nc;i++){
+                const col=i%cols,row=Math.floor(i/cols);
+                n.clients[i].x=gridLeft+col*G.clientCellW+G.clientCellW/2;
+                n.clients[i].y=clientY+row*G.clientCellH;
+            }
+            return;
+        }
+
         const kids=n._kids||[];
         const offsets=n._kidOffsets||[];
         for(let i=0;i<kids.length;i++){
@@ -594,23 +618,32 @@ class LanFlowMap2D {
         const gw=this._root;
         if(!gw)return;
         const gwT=gw.y-G.boxH/2;
+        const STAGGER=6;
 
+        // WAN cloud links - stagger by index
+        const wanEdges=[];
         for(const cloud of this._clouds){
             const cy=cloud.y+G.cloudR+8;
             const edge=this._edges.find(e=>
                 (e.lk.kind===LK.Wan||e.lk.kind===LK.Transit)
                 &&(e.lk.fromNodeId===cloud.d.id||e.lk.toNodeId===cloud.d.id));
-            if(edge){edge._x1=cloud.x;edge._y1=cy;edge._x2=gw.x;edge._y2=gwT;edge._isWan=true;}
+            if(edge){edge._x1=cloud.x;edge._y1=cy;edge._x2=gw.x;edge._y2=gwT;edge._isWan=true;wanEdges.push(edge);}
         }
+        const wanMid=(wanEdges.length-1)/2;
+        for(let i=0;i<wanEdges.length;i++)wanEdges[i]._midYOff=(i-wanMid)*STAGGER;
 
+        // Tree links - stagger siblings from same parent
         const matchTree=(n)=>{
             const pB=n.y+G.boxH/2;
+            const allKids=[...n.infra,...n.clients.slice(0,G.maxClients)];
+            const sibEdges=[];
+
             for(const c of n.infra){
                 const cT=c.y-G.boxH/2;
                 const edge=this._edges.find(e=>
                     (e.lk.fromNodeId===n.d.id&&e.lk.toNodeId===c.d.id)
                     ||(e.lk.fromNodeId===c.d.id&&e.lk.toNodeId===n.d.id));
-                if(edge){edge._x1=n.x;edge._y1=pB;edge._x2=c.x;edge._y2=cT;edge._isCl=false;}
+                if(edge){edge._x1=n.x;edge._y1=pB;edge._x2=c.x;edge._y2=cT;edge._isCl=false;sibEdges.push(edge);}
                 matchTree(c);
             }
             for(const c of n.clients.slice(0,G.maxClients)){
@@ -618,7 +651,13 @@ class LanFlowMap2D {
                 const edge=this._edges.find(e=>
                     (e.lk.fromNodeId===n.d.id&&e.lk.toNodeId===c.d.id)
                     ||(e.lk.fromNodeId===c.d.id&&e.lk.toNodeId===n.d.id));
-                if(edge){edge._x1=n.x;edge._y1=pB;edge._x2=c.x;edge._y2=cT;edge._isCl=true;edge._band=edge.lk.band;}
+                if(edge){edge._x1=n.x;edge._y1=pB;edge._x2=c.x;edge._y2=cT;edge._isCl=true;edge._band=edge.lk.band;sibEdges.push(edge);}
+            }
+
+            // Stagger horizontal segments of siblings that share the same parent
+            if(sibEdges.length>1){
+                const mid=(sibEdges.length-1)/2;
+                for(let i=0;i<sibEdges.length;i++)sibEdges[i]._midYOff=(i-mid)*STAGGER;
             }
         };
         matchTree(gw);
@@ -628,7 +667,7 @@ class LanFlowMap2D {
         this._streams=[];
         for(const e of this._edges){
             if(e._x1==null)continue;
-            const len=orthoLen(e._x1,e._y1,e._x2,e._y2);
+            const len=orthoLen(e._x1,e._y1,e._x2,e._y2,e._midYOff);
             if(len<5)continue;
             e._sDown=new Stream(e,1,C.downstream);
             e._sUp=new Stream(e,-1,C.upstream);
@@ -715,7 +754,7 @@ class LanFlowMap2D {
             ctx.fillStyle=s.color;
             for(const sl of s.slots){
                 if(sl.t<0)continue;
-                const pt=orthoAt(s.edge._x1,s.edge._y1,s.edge._x2,s.edge._y2,sl.t);
+                const pt=orthoAt(s.edge._x1,s.edge._y1,s.edge._x2,s.edge._y2,sl.t,s.midYOff);
                 ctx.globalAlpha=0.85;
                 ctx.beginPath();
                 ctx.arc(pt.x,pt.y,sl.size,0,Math.PI*2);
@@ -766,7 +805,7 @@ class LanFlowMap2D {
             ctx.lineWidth=pipeW(e.lk.capacityBps);
             ctx.lineCap='round';
             ctx.globalAlpha=e._isCl?0.3+u*0.45:0.5+u*0.5;
-            strokeOrtho(ctx,e._x1,e._y1,e._x2,e._y2);
+            strokeOrtho(ctx,e._x1,e._y1,e._x2,e._y2,e._midYOff);
 
             // Capacity label on infra links
             if(!e._isCl&&e.lk.capacityBps){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1080,6 +1080,8 @@ class LanFlowMap2D {
 
         ctx.globalCompositeOperation='lighter';
         for(const s of this._streams){
+            if(s.edge._isWan&&!this._isCloudVisible())continue;
+            if(s.edge._isCl){const child=s.edge.tn||s.edge.fn;if(child&&!this._isNodeVisible(child))continue;}
             ctx.fillStyle=s.color;
             for(const sl of s.slots){
                 if(sl.t<0)continue;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -39,9 +39,10 @@ const G = {
     tierGap:     140,
     cloudGap:    100,
     infraGap:    90,
-    clientGap:   6,
+    clientCellW: 68,
+    clientCellH: 38,
     clientR:     7,
-    clientCols:  14,
+    clientCols:  10,
     maxClients:  80,
     iconSize:    52,
     boxW:        68,
@@ -54,6 +55,7 @@ const G = {
     labelFont:   11,
     rateFont:    10,
     nameFont:    11,
+    clientNameFont: 9,
 };
 
 // ---- Helpers ----
@@ -171,7 +173,7 @@ class Stream {
         // Particle pool: t < 0 means inactive
         this._slots = [];
         for (let i = 0; i < MAX_DOTS; i++) {
-            const dot = el('circle', { r: 0.75, fill: color, opacity: 0, filter: 'url(#pg)' }, layer);
+            const dot = el('circle', { r: 0.4, fill: color, opacity: 0, filter: 'url(#pg)' }, layer);
             this._slots.push({ el: dot, t: -1, size: 0 });
         }
     }
@@ -179,7 +181,7 @@ class Stream {
     setRate(bps) {
         const intensity = Math.max(0, Math.min(1, Math.log10(Math.max(bps, 1)) / 11));
         this._density = intensity;
-        this._dotSize = 0.75 + (intensity * intensity) * 2.5;
+        this._dotSize = 0.4 + (intensity * intensity) * 1.2;
         this._velocity = 0.15 + intensity * 0.45;
     }
 
@@ -440,12 +442,11 @@ class LanFlowMap2D {
 
         const nc = Math.min(n.clients.length, G.maxClients);
         const cols = Math.min(nc, G.clientCols);
-        const cw = cols > 0 ? cols * (G.clientR * 2 + G.clientGap) - G.clientGap : 0;
+        const cw = cols > 0 ? cols * G.clientCellW : 0;
 
-        const self = isClient(n.d.kind) ? G.clientR * 2 : G.boxW + 30;
-        let childW = 0;
-        if (iw > 0 && cw > 0) childW = iw + G.infraGap + cw;
-        else childW = iw + cw;
+        const self = isClient(n.d.kind) ? G.clientCellW : G.boxW + 30;
+        // Clients go in a centered row BELOW infra, so width = max(infra, clients)
+        const childW = Math.max(iw, cw);
 
         n.w = Math.max(self, childW);
     }
@@ -459,38 +460,40 @@ class LanFlowMap2D {
             return;
         }
 
+        // Infra children: centered row at depth+1
         let iw = n.infra.reduce((s, c) => s + c.w, 0);
         if (n.infra.length > 1) iw += (n.infra.length - 1) * G.infraGap;
 
-        const nc = Math.min(n.clients.length, G.maxClients);
-        const cols = Math.min(nc, G.clientCols);
-        const cw = cols > 0 ? cols * (G.clientR * 2 + G.clientGap) - G.clientGap : 0;
-
-        let combW = 0;
-        if (iw > 0 && cw > 0) combW = iw + G.infraGap + cw;
-        else combW = iw + cw;
-
-        let cur = lx + (n.w - combW) / 2;
-
+        let cur = lx + (n.w - iw) / 2;
         for (const c of n.infra) {
             this._positions(c, cur, depth + 1);
             cur += c.w + G.infraGap;
         }
 
+        // Client children: centered grid rows BELOW infra (separate tier)
+        const nc = Math.min(n.clients.length, G.maxClients);
         if (nc > 0) {
-            const clientY = yOff + (depth + 1) * G.tierGap;
-            const cellW = G.clientR * 2 + G.clientGap;
+            const cols = Math.min(nc, G.clientCols);
+            const gridW = cols * G.clientCellW;
+            const gridLeft = lx + (n.w - gridW) / 2;
+            // If infra children exist, clients go one tier further down
+            const clientDepth = n.infra.length > 0 ? depth + 2 : depth + 1;
+            const clientY = yOff + clientDepth * G.tierGap;
+
             for (let i = 0; i < nc; i++) {
                 const col = i % cols, row = Math.floor(i / cols);
                 const cn = n.clients[i];
-                cn.x = cur + col * cellW + G.clientR;
-                cn.y = clientY + row * cellW;
+                cn.x = gridLeft + col * G.clientCellW + G.clientCellW / 2;
+                cn.y = clientY + row * G.clientCellH;
             }
         }
 
-        const allK = [...n.infra, ...n.clients.slice(0, nc)];
-        if (allK.length > 0) {
-            n.x = (Math.min(...allK.map(c => c.x)) + Math.max(...allK.map(c => c.x))) / 2;
+        // Center parent over infra children (clients are secondary)
+        if (n.infra.length > 0) {
+            n.x = (Math.min(...n.infra.map(c => c.x)) + Math.max(...n.infra.map(c => c.x))) / 2;
+        } else if (nc > 0) {
+            const placed = n.clients.slice(0, nc);
+            n.x = (Math.min(...placed.map(c => c.x)) + Math.max(...placed.map(c => c.x))) / 2;
         } else {
             n.x = lx + n.w / 2;
         }
@@ -536,7 +539,7 @@ class LanFlowMap2D {
         const vis = (n) => {
             exp(n.x, n.y, G.boxW);
             for (const c of n.infra) vis(c);
-            for (const c of n.clients.slice(0, G.maxClients)) exp(c.x, c.y, G.clientR + 8);
+            for (const c of n.clients.slice(0, G.maxClients)) exp(c.x, c.y, G.clientCellW / 2);
         };
         vis(this._root);
         for (const c of this._clouds) exp(c.x, c.y, G.cloudR + 30);
@@ -770,18 +773,23 @@ class LanFlowMap2D {
 
         if (n.d.kind === NK.WifiClient) {
             el('circle', { cx:0, cy:0, r, fill:color, opacity:op }, g);
-            // Tiny wifi arc
             el('path', { d:`M${-2.5} ${-0.5}Q0 ${-4} 2.5 ${-0.5}`, fill:'none',
                 stroke:'#fff', 'stroke-width':0.8, opacity:0.5 }, g);
         } else {
-            // Small monitor shape
             const s = r * 0.9;
             el('rect', { x:-s, y:-s+0.5, width:s*2, height:s*1.5, rx:1.5, fill:color, opacity:op }, g);
             el('line', { x1:0, y1:s*0.5+0.5, x2:0, y2:s+1, stroke:color, 'stroke-width':1.2, opacity:op }, g);
         }
 
+        // Visible name label below
         const name = n.d.name || n.d.ip || '';
-        if (name) g.setAttribute('data-tooltip', name);
+        if (name) {
+            const dn = name.length > 10 ? name.slice(0, 9) + '…' : name;
+            const t = el('text', { x:0, y:r + 11, 'text-anchor':'middle', fill:C.textMuted,
+                'font-size':G.clientNameFont, 'font-family':'system-ui,sans-serif' }, g);
+            t.textContent = dn;
+            g.setAttribute('data-tooltip', name);
+        }
     }
 
     // ---- Toolbar ----
@@ -882,11 +890,11 @@ class LanFlowMap2D {
             const op = e._isCl ? 0.3 + u * 0.45 : 0.5 + u * 0.5;
             e._pe.setAttribute('opacity', String(Math.min(op, 1)));
 
-            // Live rate label on links
+            // Live rate label - show both directions when either exceeds threshold
             if (e._rlD) {
                 if (dn > THRESH || up > THRESH) {
-                    e._rlD.textContent = dn > THRESH ? '↓' + formatBps(dn) : '';
-                    e._rlU.textContent = up > THRESH ? '↑' + formatBps(up) : '';
+                    e._rlD.textContent = '↓' + (dn > 0 ? formatBps(dn) : '0 bps');
+                    e._rlU.textContent = '↑' + (up > 0 ? formatBps(up) : '0 bps');
                     const tw = Math.max((e._rlD.textContent.length + e._rlU.textContent.length) * 5 + 16, 40);
                     e._rlBg.setAttribute('x', -tw / 2);
                     e._rlBg.setAttribute('width', tw);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -312,33 +312,44 @@ class LanFlowMap2D {
         for (const n of snap.nodes) byId.set(n.id, new TN(n));
         this._treeMap = byId;
 
+        // Build adjacency from LINKS (not parentId - parentId is sparse).
+        // This mirrors how the 3D map determines connectivity.
+        const adj = new Map();
+        for (const lk of snap.links) {
+            if (lk.kind === LK.Wan || lk.kind === LK.Transit) continue;
+            const a = lk.fromNodeId, b = lk.toNodeId;
+            if (!byId.has(a) || !byId.has(b)) continue;
+            if (!adj.has(a)) adj.set(a, []);
+            if (!adj.has(b)) adj.set(b, []);
+            adj.get(a).push({ to: b, lk });
+            adj.get(b).push({ to: a, lk });
+        }
+
+        // BFS from gateway to build tree
         let root = null;
         for (const [, tn] of byId) {
-            if (tn.d.kind === NK.Gateway) root = tn;
-            const pid = tn.d.parentId;
-            if (pid && byId.has(pid)) {
-                const par = byId.get(pid);
-                if (isClient(tn.d.kind)) par.clients.push(tn);
-                else if (tn.d.kind !== NK.Cloud) par.infra.push(tn);
-            }
+            if (tn.d.kind === NK.Gateway) { root = tn; break; }
         }
         this._root = root;
 
-        // Diagnostic: dump tree structure
         if (root) {
-            const dump = (n, depth) => {
-                const pad = '  '.repeat(depth);
-                console.log(`${pad}${n.d.name||n.d.id} (kind=${n.d.kind}) infra=${n.infra.length} clients=${n.clients.length}`);
-                for (const c of n.infra) dump(c, depth+1);
-            };
-            console.log(`[2D Map] Tree: ${byId.size} nodes, root=${root.d.name||root.d.id}`);
-            dump(root, 0);
-            const orphans = [...byId.values()].filter(tn => tn !== root && !tn.d.parentId && tn.d.kind !== NK.Cloud);
-            if (orphans.length) console.warn(`[2D Map] ${orphans.length} orphan nodes (no parentId):`, orphans.map(o => `${o.d.name||o.d.id} kind=${o.d.kind}`));
-            const unlinked = [...byId.values()].filter(tn => tn.d.parentId && !byId.has(tn.d.parentId));
-            if (unlinked.length) console.warn(`[2D Map] ${unlinked.length} nodes with parentId not in map:`, unlinked.map(o => `${o.d.name||o.d.id} parentId=${o.d.parentId}`));
-        } else {
-            console.warn('[2D Map] No gateway root found! Node kinds:', [...byId.values()].map(n => n.d.kind));
+            const visited = new Set([root.d.id]);
+            const queue = [root];
+            while (queue.length > 0) {
+                const par = queue.shift();
+                for (const { to } of (adj.get(par.d.id) || [])) {
+                    if (visited.has(to)) continue;
+                    visited.add(to);
+                    const child = byId.get(to);
+                    if (!child) continue;
+                    if (isClient(child.d.kind)) {
+                        par.clients.push(child);
+                    } else {
+                        par.infra.push(child);
+                        queue.push(child);
+                    }
+                }
+            }
         }
 
         this._clouds = (snap.clouds||[]).map(c => ({ d:c, x:0, y:0 }));
@@ -490,6 +501,17 @@ class LanFlowMap2D {
                 edge._x1 = cloud.x; edge._y1 = cy;
                 edge._x2 = gw.x; edge._y2 = gwT;
                 edge._isWan = true;
+
+                // WAN live rate label
+                const midX = (cloud.x + gw.x) / 2;
+                const midY = (cy + gwT) / 2 + 12;
+                const rg = el('g', { transform:`translate(${midX},${midY})`, class:'rate-lbl' }, this._gLabels);
+                const rbg = el('rect', { x:-50, y:-8, width:100, height:16, rx:4, fill:C.labelBg, opacity:0 }, rg);
+                const rd = el('text', { x:-3, y:4, 'text-anchor':'end', fill:C.downstream,
+                    'font-size':G.rateFont, 'font-family':'system-ui,sans-serif' }, rg);
+                const ru = el('text', { x:3, y:4, 'text-anchor':'start', fill:C.upstream,
+                    'font-size':G.rateFont, 'font-family':'system-ui,sans-serif' }, rg);
+                edge._rlG = rg; edge._rlBg = rbg; edge._rlD = rd; edge._rlU = ru;
             }
         }
 
@@ -548,6 +570,19 @@ class LanFlowMap2D {
         if (!isCl && edge?.lk.capacityBps) {
             const cap = edge.lk.capacityBps / 1e6;
             if (cap > 0) this._capLabel((par.x + child.x) / 2, (y1 + y2) / 2, formatSpeed(cap));
+        }
+
+        // Live rate label (updated dynamically) for non-client links
+        if (!isCl && edge) {
+            const midX = (par.x + child.x) / 2;
+            const midY = (y1 + y2) / 2 + 12;
+            const rg = el('g', { transform:`translate(${midX},${midY})`, class:'rate-lbl' }, this._gLabels);
+            const rbg = el('rect', { x:-50, y:-8, width:100, height:16, rx:4, fill:C.labelBg, opacity:0 }, rg);
+            const rd = el('text', { x:-3, y:4, 'text-anchor':'end', fill:C.downstream,
+                'font-size':G.rateFont, 'font-family':'system-ui,sans-serif' }, rg);
+            const ru = el('text', { x:3, y:4, 'text-anchor':'start', fill:C.upstream,
+                'font-size':G.rateFont, 'font-family':'system-ui,sans-serif' }, rg);
+            edge._rlG = rg; edge._rlBg = rbg; edge._rlD = rd; edge._rlU = ru;
         }
     }
 
@@ -765,6 +800,7 @@ class LanFlowMap2D {
     }
 
     _updatePipes() {
+        const THRESH = 1_000_000;
         for (const e of this._edges) {
             if (!e._pe) continue;
             const r = this._liveRates[e.lk.portKey] || this._liveRates[e.lk.id];
@@ -775,6 +811,22 @@ class LanFlowMap2D {
             e._pe.setAttribute('stroke', pipeClr(Math.min(u, 1), e._band));
             const op = e._isCl ? 0.3 + u * 0.45 : 0.5 + u * 0.5;
             e._pe.setAttribute('opacity', String(Math.min(op, 1)));
+
+            // Live rate label on links
+            if (e._rlD) {
+                if (dn > THRESH || up > THRESH) {
+                    e._rlD.textContent = dn > THRESH ? '↓' + formatBps(dn) : '';
+                    e._rlU.textContent = up > THRESH ? '↑' + formatBps(up) : '';
+                    const tw = Math.max((e._rlD.textContent.length + e._rlU.textContent.length) * 5 + 16, 40);
+                    e._rlBg.setAttribute('x', -tw / 2);
+                    e._rlBg.setAttribute('width', tw);
+                    e._rlBg.setAttribute('opacity', 1);
+                } else {
+                    e._rlD.textContent = '';
+                    e._rlU.textContent = '';
+                    e._rlBg.setAttribute('opacity', 0);
+                }
+            }
         }
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1,11 +1,13 @@
 // 2D hierarchical LAN topology diagram.
-// Renders SVG consuming the same API endpoints as the 3D LAN Flow Map.
-// Animated data-flow particles show real-time traffic direction and rate.
+// Subscribes to lan-flow-data.js (published by the 3D map) so there are
+// zero duplicate API calls. Renders SVG with animated data-flow particles.
+
+import * as flowData from './lan-flow-data.js';
 
 const NS = 'http://www.w3.org/2000/svg';
 
 // ---- Color palette (matches 3D map) ----
-const COLORS = {
+const C = {
     bg:           '#202023',
     gateway:      '#facc15',
     switchNode:   '#9aa6b2',
@@ -26,212 +28,129 @@ const COLORS = {
     textSec:      '#cbd5e1',
     textMuted:    '#9ca3af',
     labelBg:      'rgba(16,24,32,0.82)',
-    cloudStroke:  '#3b82f6',
+    globeStroke:  '#3b82f6',
 };
 
-const NODE_KIND = {
-    Gateway: 0, Switch: 1, AccessPoint: 2,
-    WiredClient: 3, WifiClient: 4, Cloud: 5, VirtualHub: 6,
-};
-const LINK_KIND = {
-    Uplink: 0, WiredClient: 1, WifiClient: 2,
-    Wan: 3, Transit: 4, MeshBackhaul: 5,
-};
+const NK = { Gateway:0, Switch:1, AP:2, WiredClient:3, WifiClient:4, Cloud:5, VirtualHub:6 };
+const LK = { Uplink:0, WiredClient:1, WifiClient:2, Wan:3, Transit:4, MeshBackhaul:5 };
 
 // ---- Layout geometry ----
-const L = {
-    tierGap:       130,
-    cloudGap:      90,
-    infraGap:      80,
-    clientGap:     6,
-    clientSize:    18,
-    clientCols:    12,
-    maxClients:    60,
-    infraW:        60,
-    infraH:        48,
-    cloudR:        28,
-    cornerR:       12,
-    padding:       60,
-    pipeBase:      2,
-    pipeMax:       5.5,
-    particleR:     3,
-    labelFont:     11,
-    rateFont:      10,
-    nameFont:      11,
+const G = {
+    tierGap:     140,
+    cloudGap:    100,
+    infraGap:    90,
+    clientGap:   6,
+    clientR:     7,
+    clientCols:  14,
+    maxClients:  80,
+    iconSize:    52,
+    boxW:        68,
+    boxH:        60,
+    cloudR:      30,
+    cornerR:     12,
+    pad:         80,
+    pipeBase:    2,
+    pipeMax:     6,
+    labelFont:   11,
+    rateFont:    10,
+    nameFont:    11,
 };
 
-const RATE_THRESHOLD = 1_000_000;
+// ---- Helpers ----
 
-// ---- Utility ----
-
-function svg(tag, attrs, parent) {
+function el(tag, a, p) {
     const e = document.createElementNS(NS, tag);
-    if (attrs) for (const [k, v] of Object.entries(attrs)) {
-        if (v != null) e.setAttribute(k, String(v));
-    }
-    if (parent) parent.appendChild(e);
+    if (a) for (const [k, v] of Object.entries(a)) if (v != null) e.setAttribute(k, String(v));
+    if (p) p.appendChild(e);
     return e;
 }
 
-function hexToRgb(h) {
-    return [parseInt(h.slice(1, 3), 16), parseInt(h.slice(3, 5), 16), parseInt(h.slice(5, 7), 16)];
-}
-function rgbHex(r, g, b) {
-    return '#' + [r, g, b].map(c => Math.round(Math.max(0, Math.min(255, c))).toString(16).padStart(2, '0')).join('');
-}
-function lerpColor(a, b, t) {
-    const [r1, g1, b1] = hexToRgb(a), [r2, g2, b2] = hexToRgb(b);
-    return rgbHex(r1 + (r2 - r1) * t, g1 + (g2 - g1) * t, b1 + (b2 - b1) * t);
-}
+function hexRgb(h) { return [parseInt(h.slice(1,3),16), parseInt(h.slice(3,5),16), parseInt(h.slice(5,7),16)]; }
+function rgbHex(r,g,b) { return '#'+[r,g,b].map(c=>Math.round(Math.max(0,Math.min(255,c))).toString(16).padStart(2,'0')).join(''); }
+function lerp(a,b,t) { return a+(b-a)*t; }
+function lerpColor(a,b,t) { const [r1,g1,b1]=hexRgb(a),[r2,g2,b2]=hexRgb(b); return rgbHex(lerp(r1,r2,t),lerp(g1,g2,t),lerp(b1,b2,t)); }
 
-function bandColor(band) {
-    if (band === '2.4') return COLORS.band24;
-    if (band === '5')   return COLORS.band5;
-    if (band === '6')   return COLORS.band6;
-    return null;
+function bandClr(b) { return b==='2.4'?C.band24:b==='5'?C.band5:b==='6'?C.band6:null; }
+function nodeClr(k, b) {
+    if (k===NK.Gateway) return C.gateway;
+    if (k===NK.Switch) return C.switchNode;
+    if (k===NK.AP) return C.ap;
+    if (k===NK.WiredClient) return C.wiredClient;
+    if (k===NK.WifiClient) return bandClr(b)||C.wifiClient;
+    if (k===NK.Cloud) return C.cloud;
+    if (k===NK.VirtualHub) return C.virtualHub;
+    return C.textMuted;
 }
+function isInfra(k) { return k<=NK.AP || k===NK.VirtualHub; }
+function isClient(k) { return k===NK.WiredClient || k===NK.WifiClient; }
 
-function nodeColor(kind, band) {
-    switch (kind) {
-        case NODE_KIND.Gateway:     return COLORS.gateway;
-        case NODE_KIND.Switch:      return COLORS.switchNode;
-        case NODE_KIND.AccessPoint: return COLORS.ap;
-        case NODE_KIND.WiredClient: return COLORS.wiredClient;
-        case NODE_KIND.WifiClient:  return bandColor(band) || COLORS.wifiClient;
-        case NODE_KIND.Cloud:       return COLORS.cloud;
-        case NODE_KIND.VirtualHub:  return COLORS.virtualHub;
-        default: return COLORS.textMuted;
-    }
+function pipeClr(u, band) {
+    const cool = bandClr(band) || C.pipeCool;
+    if (u<0.7) return cool;
+    if (u<0.9) return lerpColor(cool, C.pipeWarm, (u-0.7)/0.2);
+    return lerpColor(C.pipeWarm, C.pipeHot, Math.min((u-0.9)/0.1, 1));
 }
-
-function isInfra(kind) {
-    return kind <= NODE_KIND.AccessPoint || kind === NODE_KIND.VirtualHub;
-}
-function isClient(kind) {
-    return kind === NODE_KIND.WiredClient || kind === NODE_KIND.WifiClient;
-}
-
-function pipeColorForUtil(util, band) {
-    const cool = bandColor(band) || COLORS.pipeCool;
-    if (util < 0.7) return cool;
-    if (util < 0.9) return lerpColor(cool, COLORS.pipeWarm, (util - 0.7) / 0.2);
-    return lerpColor(COLORS.pipeWarm, COLORS.pipeHot, Math.min((util - 0.9) / 0.1, 1));
-}
-
-function pipeWidth(capacityBps) {
-    if (!capacityBps || capacityBps <= 0) return L.pipeBase;
-    const gbps = capacityBps / 1e9;
-    const t = Math.log10(Math.max(gbps, 0.01)) + 2;
-    return L.pipeBase + Math.min(t, 3.5) * 0.8;
+function pipeW(cap) {
+    if (!cap||cap<=0) return G.pipeBase;
+    const t = Math.log10(Math.max(cap/1e9, 0.01))+2;
+    return G.pipeBase + Math.min(t, 3.5)*0.9;
 }
 
 function formatBps(bps) {
-    if (!Number.isFinite(bps) || bps <= 0) return '';
-    const units = ['bps', 'Kbps', 'Mbps', 'Gbps', 'Tbps'];
-    let i = 0, v = bps;
-    while (v >= 1000 && i < units.length - 1) { v /= 1000; i++; }
-    return `${v >= 100 ? v.toFixed(0) : v.toFixed(1)} ${units[i]}`;
+    if (!Number.isFinite(bps)||bps<=0) return '';
+    const u=['bps','Kbps','Mbps','Gbps','Tbps'];
+    let i=0, v=bps;
+    while (v>=1000&&i<u.length-1){v/=1000;i++;}
+    return `${v>=100?v.toFixed(0):v.toFixed(1)} ${u[i]}`;
 }
-
-function formatLinkSpeed(mbps) {
+function formatSpeed(mbps) {
     if (!mbps) return '';
-    if (mbps >= 1000) {
-        const g = mbps / 1000;
-        return `${g % 1 === 0 ? g.toFixed(0) : g.toFixed(1)} Gbps`;
-    }
+    if (mbps>=1000){const g=mbps/1000;return `${g%1===0?g.toFixed(0):g.toFixed(1)} Gbps`;}
     return `${mbps} Mbps`;
 }
 
-// ---- Orthogonal path computation ----
+// ---- Orthogonal path (H→R→V never diagonal) ----
 
 function orthoPath(x1, y1, x2, y2) {
-    const r = L.cornerR;
-    if (Math.abs(x1 - x2) < 0.5) return `M${x1} ${y1}L${x2} ${y2}`;
-
-    const midY = (y1 + y2) / 2;
-    const dx = x2 - x1;
-    const s = dx > 0 ? 1 : -1;
-    const ax = Math.abs(dx);
-    const hv = Math.abs(y2 - y1) / 2;
-    const cr = Math.min(r, ax / 2, hv);
-    if (cr < 1) return `M${x1} ${y1}L${x1} ${midY}L${x2} ${midY}L${x2} ${y2}`;
-
-    return `M${x1} ${y1}`
-        + `L${x1} ${midY - cr}`
-        + `Q${x1} ${midY} ${x1 + s * cr} ${midY}`
-        + `L${x2 - s * cr} ${midY}`
-        + `Q${x2} ${midY} ${x2} ${midY + cr}`
-        + `L${x2} ${y2}`;
+    const r = G.cornerR;
+    if (Math.abs(x1-x2)<0.5) return `M${x1} ${y1}L${x2} ${y2}`;
+    const midY=(y1+y2)/2, dx=x2-x1, s=dx>0?1:-1, ax=Math.abs(dx), hv=Math.abs(y2-y1)/2;
+    const cr=Math.min(r, ax/2, hv);
+    if (cr<1) return `M${x1} ${y1}L${x1} ${midY}L${x2} ${midY}L${x2} ${y2}`;
+    return `M${x1} ${y1}L${x1} ${midY-cr}Q${x1} ${midY} ${x1+s*cr} ${midY}L${x2-s*cr} ${midY}Q${x2} ${midY} ${x2} ${midY+cr}L${x2} ${y2}`;
 }
 
-function orthoLength(x1, y1, x2, y2) {
-    if (Math.abs(x1 - x2) < 0.5) return Math.abs(y2 - y1);
-    const ax = Math.abs(x2 - x1);
-    const hv = Math.abs(y2 - y1) / 2;
-    const cr = Math.min(L.cornerR, ax / 2, hv);
-    if (cr < 1) return Math.abs(y2 - y1) + ax;
-    return (hv - cr) * 2 + Math.PI * cr + (ax - 2 * cr);
+function orthoLen(x1, y1, x2, y2) {
+    if (Math.abs(x1-x2)<0.5) return Math.abs(y2-y1);
+    const ax=Math.abs(x2-x1), hv=Math.abs(y2-y1)/2, cr=Math.min(G.cornerR, ax/2, hv);
+    if (cr<1) return Math.abs(y2-y1)+ax;
+    return (hv-cr)*2+Math.PI*cr+(ax-2*cr);
 }
 
-function orthoPointAt(x1, y1, x2, y2, t) {
-    const dy = y2 - y1;
-    if (Math.abs(x2 - x1) < 0.5) return { x: x1, y: y1 + dy * t };
-
-    const midY = (y1 + y2) / 2;
-    const dx = x2 - x1;
-    const s = dx > 0 ? 1 : -1;
-    const ax = Math.abs(dx);
-    const hv = Math.abs(dy) / 2;
-    const cr = Math.min(L.cornerR, ax / 2, hv);
-    if (cr < 1) {
-        const s1 = hv, s2 = ax, total = s1 + s2 + hv;
-        let d = t * total;
-        if (d <= s1) return { x: x1, y: y1 + d };
-        d -= s1;
-        if (d <= s2) return { x: x1 + s * d, y: midY };
-        d -= s2;
-        return { x: x2, y: midY + d };
+function orthoAt(x1, y1, x2, y2, t) {
+    const dy=y2-y1;
+    if (Math.abs(x2-x1)<0.5) return {x:x1, y:y1+dy*t};
+    const midY=(y1+y2)/2, dx=x2-x1, s=dx>0?1:-1, ax=Math.abs(dx), hv=Math.abs(dy)/2;
+    const cr=Math.min(G.cornerR, ax/2, hv);
+    if (cr<1) {
+        const tot=hv+ax+hv; let d=t*tot;
+        if (d<=hv) return {x:x1,y:y1+d}; d-=hv;
+        if (d<=ax) return {x:x1+s*d,y:midY}; d-=ax;
+        return {x:x2,y:midY+d};
     }
-
-    const s1 = hv - cr;
-    const s2 = (Math.PI / 2) * cr;
-    const s3 = ax - 2 * cr;
-    const s4 = s2;
-    const s5 = hv - cr;
-    const total = s1 + s2 + s3 + s4 + s5;
-    let d = t * total;
-
-    if (d <= s1) return { x: x1, y: y1 + d };
-    d -= s1;
-    if (d <= s2) {
-        const a = (d / s2) * (Math.PI / 2);
-        return { x: x1 + s * cr * Math.sin(a), y: (midY - cr) + cr * (1 - Math.cos(a)) };
-    }
-    d -= s2;
-    if (d <= s3) return { x: x1 + s * (cr + d), y: midY };
-    d -= s3;
-    if (d <= s4) {
-        const a = (d / s4) * (Math.PI / 2);
-        return {
-            x: (x2 - s * cr) + s * cr * Math.sin(a),
-            y: midY + cr * (1 - Math.cos(a)),
-        };
-    }
-    d -= s4;
-    return { x: x2, y: midY + cr + d };
+    const s1=hv-cr, s2=Math.PI/2*cr, s3=ax-2*cr, s4=s2, s5=hv-cr;
+    const tot=s1+s2+s3+s4+s5; let d=t*tot;
+    if (d<=s1) return {x:x1,y:y1+d}; d-=s1;
+    if (d<=s2) {const a=d/s2*Math.PI/2; return {x:x1+s*cr*Math.sin(a),y:midY-cr+cr*(1-Math.cos(a))};} d-=s2;
+    if (d<=s3) return {x:x1+s*(cr+d),y:midY}; d-=s3;
+    if (d<=s4) {const a=d/s4*Math.PI/2; return {x:(x2-s*cr)+s*cr*Math.sin(a),y:midY+cr*(1-Math.cos(a))};} d-=s4;
+    return {x:x2, y:midY+cr+d};
 }
 
-// ---- Layout tree node ----
+// ---- Layout tree ----
 
-class TNode {
-    constructor(data) {
-        this.d = data;
-        this.infraChildren = [];
-        this.clientChildren = [];
-        this.x = 0;
-        this.y = 0;
-        this.w = 0;
-    }
+class TN {
+    constructor(d) { this.d=d; this.infra=[]; this.clients=[]; this.x=0; this.y=0; this.w=0; }
 }
 
 // ---- Main class ----
@@ -239,36 +158,63 @@ class TNode {
 class LanFlowMap2D {
     constructor(container) {
         this._el = container;
-        this._svgRoot = null;
+        this._svg = null;
         this._gLinks = null;
+        this._gParts = null;
         this._gNodes = null;
-        this._gParticles = null;
         this._gLabels = null;
 
-        this._snapshot = null;
-        this._treeNodes = new Map();
         this._root = null;
+        this._treeMap = new Map();
         this._clouds = [];
-        this._linkEdges = [];
+        this._edges = [];
         this._liveRates = {};
 
         this._particles = [];
         this._animId = 0;
         this._lastFrame = 0;
-        this._pollId = 0;
+        this._unsub = null;
+
+        // Viewport / pan-zoom state
+        this._vx = 0; this._vy = 0; this._vw = 800; this._vh = 600;
+        this._zoom = 1;
+        this._panX = 0; this._panY = 0;
+        this._baseVx = 0; this._baseVy = 0; this._baseVw = 800; this._baseVh = 600;
+        this._dragging = false;
+        this._dragStart = null;
     }
 
     async start() {
         this._createSvg();
-        await this._loadSnapshot();
-        this._startPolling();
+
+        const snap = flowData.getSnapshot();
+        if (snap) {
+            this._liveRates = { ...flowData.getLiveRates() };
+            this._buildLayout(snap);
+            this._renderAll();
+        }
+
+        this._unsub = flowData.subscribe((ev) => {
+            if (ev === 'snapshot') {
+                const s = flowData.getSnapshot();
+                if (s) {
+                    this._liveRates = { ...flowData.getLiveRates() };
+                    this._buildLayout(s);
+                    this._renderAll();
+                }
+            } else if (ev === 'live') {
+                Object.assign(this._liveRates, flowData.getLiveRates());
+                this._updateRates();
+            }
+        });
+
         this._lastFrame = performance.now();
         this._animate();
     }
 
     dispose() {
         cancelAnimationFrame(this._animId);
-        clearInterval(this._pollId);
+        if (this._unsub) this._unsub();
         this._el.innerHTML = '';
         this._particles = [];
     }
@@ -277,747 +223,598 @@ class LanFlowMap2D {
 
     _createSvg() {
         this._el.innerHTML = '';
-        const s = svg('svg', {
-            'xmlns': NS,
-            'preserveAspectRatio': 'xMidYMin meet',
-            'class': 'lan-flow-map-2d-svg',
-        }, this._el);
-        this._svgRoot = s;
+        const s = el('svg', { xmlns: NS, 'preserveAspectRatio': 'xMidYMin meet', class: 'lfm2d' }, this._el);
+        this._svg = s;
 
-        const defs = svg('defs', null, s);
+        const defs = el('defs', null, s);
+        // Glow for particles
+        const pg = el('filter', { id: 'pg', x:'-80%', y:'-80%', width:'260%', height:'260%' }, defs);
+        el('feGaussianBlur', { in:'SourceGraphic', stdDeviation:'2.5', result:'b' }, pg);
+        const m = el('feMerge', null, pg);
+        el('feMergeNode', { in:'b' }, m);
+        el('feMergeNode', { in:'SourceGraphic' }, m);
 
-        // Glow filter for infra nodes
-        const glow = svg('filter', { id: 'node-glow', x: '-50%', y: '-50%', width: '200%', height: '200%' }, defs);
-        svg('feGaussianBlur', { in: 'SourceGraphic', stdDeviation: '4', result: 'blur' }, glow);
-        const merge = svg('feMerge', null, glow);
-        svg('feMergeNode', { in: 'blur' }, merge);
-        svg('feMergeNode', { in: 'SourceGraphic' }, merge);
+        this._gLinks = el('g', { class:'links' }, s);
+        this._gParts = el('g', { class:'particles' }, s);
+        this._gNodes = el('g', { class:'nodes' }, s);
+        this._gLabels = el('g', { class:'labels' }, s);
 
-        // Particle glow
-        const pglow = svg('filter', { id: 'particle-glow', x: '-100%', y: '-100%', width: '300%', height: '300%' }, defs);
-        svg('feGaussianBlur', { in: 'SourceGraphic', stdDeviation: '2', result: 'blur' }, pglow);
-        const pm = svg('feMerge', null, pglow);
-        svg('feMergeNode', { in: 'blur' }, pm);
-        svg('feMergeNode', { in: 'SourceGraphic' }, pm);
-
-        this._gLinks = svg('g', { class: 'links' }, s);
-        this._gParticles = svg('g', { class: 'particles' }, s);
-        this._gNodes = svg('g', { class: 'nodes' }, s);
-        this._gLabels = svg('g', { class: 'labels' }, s);
+        // Pan/zoom events
+        s.addEventListener('wheel', (e) => this._onWheel(e), { passive: false });
+        s.addEventListener('pointerdown', (e) => this._onPointerDown(e));
+        s.addEventListener('pointermove', (e) => this._onPointerMove(e));
+        s.addEventListener('pointerup', (e) => this._onPointerUp(e));
+        s.addEventListener('pointerleave', (e) => this._onPointerUp(e));
     }
 
-    // ---- Data loading ----
+    // ---- Pan / Zoom ----
 
-    async _loadSnapshot() {
-        try {
-            const r = await fetch('/api/monitoring/lan-flow-map/snapshot');
-            if (!r.ok) return;
-            this._snapshot = await r.json();
-        } catch { return; }
+    _onWheel(e) {
+        e.preventDefault();
+        const rect = this._svg.getBoundingClientRect();
+        const mx = (e.clientX - rect.left) / rect.width;
+        const my = (e.clientY - rect.top) / rect.height;
 
-        this._liveRates = this._snapshot.liveRates || {};
-        this._buildLayout();
-        this._renderAll();
+        const factor = e.deltaY > 0 ? 1.12 : 1 / 1.12;
+        const nw = this._vw * factor;
+        const nh = this._vh * factor;
+
+        // Zoom toward mouse position
+        this._vx += (this._vw - nw) * mx;
+        this._vy += (this._vh - nh) * my;
+        this._vw = nw;
+        this._vh = nh;
+        this._applyViewBox();
     }
 
-    async _pollLive() {
-        try {
-            const r = await fetch('/api/monitoring/lan-flow-map/live');
-            if (!r.ok) return;
-            const update = await r.json();
-            if (update.linkRates) {
-                Object.assign(this._liveRates, update.linkRates);
-                this._updateRates();
-            }
-        } catch { /* swallow */ }
+    _onPointerDown(e) {
+        if (e.button !== 0) return;
+        this._dragging = true;
+        this._dragStart = { x: e.clientX, y: e.clientY, vx: this._vx, vy: this._vy };
+        this._svg.style.cursor = 'grabbing';
+        this._svg.setPointerCapture(e.pointerId);
     }
 
-    _startPolling() {
-        this._pollId = setInterval(() => this._pollLive(), 3000);
+    _onPointerMove(e) {
+        if (!this._dragging || !this._dragStart) return;
+        const rect = this._svg.getBoundingClientRect();
+        const sx = this._vw / rect.width;
+        const sy = this._vh / rect.height;
+        this._vx = this._dragStart.vx - (e.clientX - this._dragStart.x) * sx;
+        this._vy = this._dragStart.vy - (e.clientY - this._dragStart.y) * sy;
+        this._applyViewBox();
+    }
+
+    _onPointerUp(e) {
+        if (!this._dragging) return;
+        this._dragging = false;
+        this._dragStart = null;
+        this._svg.style.cursor = 'grab';
+    }
+
+    _applyViewBox() {
+        this._svg.setAttribute('viewBox', `${this._vx} ${this._vy} ${this._vw} ${this._vh}`);
+    }
+
+    _fitAll() {
+        this._vx = this._baseVx;
+        this._vy = this._baseVy;
+        this._vw = this._baseVw;
+        this._vh = this._baseVh;
+        this._applyViewBox();
     }
 
     // ---- Layout ----
 
-    _buildLayout() {
-        const snap = this._snapshot;
-        if (!snap) return;
+    _buildLayout(snap) {
+        const byId = new Map();
+        for (const n of snap.nodes) byId.set(n.id, new TN(n));
+        this._treeMap = byId;
 
-        const nodesById = new Map();
-        for (const n of snap.nodes) nodesById.set(n.id, new TNode(n));
-        this._treeNodes = nodesById;
-
-        // Build parent-child tree
         let root = null;
-        for (const [, tn] of nodesById) {
-            if (tn.d.kind === NODE_KIND.Gateway) root = tn;
-            if (tn.d.parentId && nodesById.has(tn.d.parentId)) {
-                const parent = nodesById.get(tn.d.parentId);
-                if (isClient(tn.d.kind)) {
-                    parent.clientChildren.push(tn);
-                } else if (tn.d.kind !== NODE_KIND.Cloud) {
-                    parent.infraChildren.push(tn);
-                }
+        for (const [, tn] of byId) {
+            if (tn.d.kind === NK.Gateway) root = tn;
+            const pid = tn.d.parentId;
+            if (pid && byId.has(pid)) {
+                const par = byId.get(pid);
+                if (isClient(tn.d.kind)) par.clients.push(tn);
+                else if (tn.d.kind !== NK.Cloud) par.infra.push(tn);
             }
         }
         this._root = root;
+        this._clouds = (snap.clouds||[]).map(c => ({ d:c, x:0, y:0 }));
 
-        // Clouds
-        this._clouds = (snap.clouds || []).map(c => ({ data: c, x: 0, y: 0 }));
-
-        // Link edges
-        this._linkEdges = [];
-        for (const link of snap.links) {
-            this._linkEdges.push({
-                link,
-                fromNode: nodesById.get(link.fromNodeId),
-                toNode: nodesById.get(link.toNodeId),
-            });
+        this._edges = [];
+        for (const lk of snap.links) {
+            this._edges.push({ lk, fn: byId.get(lk.fromNodeId), tn: byId.get(lk.toNodeId) });
         }
 
         if (!root) return;
-        this._computeWidths(root);
-        const totalW = root.w;
-        this._assignPositions(root, L.padding, 0);
-        this._positionClouds();
+        this._widths(root);
+        this._positions(root, G.pad, 0);
+        this._placeClouds();
     }
 
-    _computeWidths(node) {
-        // Infra children
-        let infraW = 0;
-        for (const child of node.infraChildren) {
-            this._computeWidths(child);
-            infraW += child.w;
-        }
-        if (node.infraChildren.length > 1)
-            infraW += (node.infraChildren.length - 1) * L.infraGap;
+    _widths(n) {
+        let iw = 0;
+        for (const c of n.infra) { this._widths(c); iw += c.w; }
+        if (n.infra.length > 1) iw += (n.infra.length - 1) * G.infraGap;
 
-        // Client grid
-        const nc = Math.min(node.clientChildren.length, L.maxClients);
-        const cols = Math.min(nc, L.clientCols);
-        const clientGridW = cols > 0 ? cols * (L.clientSize + L.clientGap) - L.clientGap : 0;
+        const nc = Math.min(n.clients.length, G.maxClients);
+        const cols = Math.min(nc, G.clientCols);
+        const cw = cols > 0 ? cols * (G.clientR * 2 + G.clientGap) - G.clientGap : 0;
 
-        // Node's own min width
-        const selfW = isClient(node.d.kind) ? L.clientSize : L.infraW + 40;
+        const self = isClient(n.d.kind) ? G.clientR * 2 : G.boxW + 30;
+        let childW = 0;
+        if (iw > 0 && cw > 0) childW = iw + G.infraGap + cw;
+        else childW = iw + cw;
 
-        // Combined: infra and client grids side by side
-        let childrenW = 0;
-        if (infraW > 0 && clientGridW > 0) {
-            childrenW = infraW + L.infraGap + clientGridW;
-        } else {
-            childrenW = infraW + clientGridW;
-        }
-
-        node.w = Math.max(selfW, childrenW);
+        n.w = Math.max(self, childW);
     }
 
-    _assignPositions(node, leftX, depth) {
-        const yBase = L.padding + 60;
-        node.y = yBase + depth * L.tierGap;
+    _positions(n, lx, depth) {
+        const yOff = G.pad + 80;
+        n.y = yOff + depth * G.tierGap;
 
-        if (node.infraChildren.length === 0 && node.clientChildren.length === 0) {
-            node.x = leftX + node.w / 2;
+        if (n.infra.length === 0 && n.clients.length === 0) {
+            n.x = lx + n.w / 2;
             return;
         }
 
-        let infraW = node.infraChildren.reduce((s, c) => s + c.w, 0);
-        if (node.infraChildren.length > 1)
-            infraW += (node.infraChildren.length - 1) * L.infraGap;
+        let iw = n.infra.reduce((s, c) => s + c.w, 0);
+        if (n.infra.length > 1) iw += (n.infra.length - 1) * G.infraGap;
 
-        const nc = Math.min(node.clientChildren.length, L.maxClients);
-        const cols = Math.min(nc, L.clientCols);
-        const clientGridW = cols > 0 ? cols * (L.clientSize + L.clientGap) - L.clientGap : 0;
+        const nc = Math.min(n.clients.length, G.maxClients);
+        const cols = Math.min(nc, G.clientCols);
+        const cw = cols > 0 ? cols * (G.clientR * 2 + G.clientGap) - G.clientGap : 0;
 
-        let combinedW = 0;
-        if (infraW > 0 && clientGridW > 0) combinedW = infraW + L.infraGap + clientGridW;
-        else combinedW = infraW + clientGridW;
+        let combW = 0;
+        if (iw > 0 && cw > 0) combW = iw + G.infraGap + cw;
+        else combW = iw + cw;
 
-        let cursor = leftX + (node.w - combinedW) / 2;
+        let cur = lx + (n.w - combW) / 2;
 
-        // Place infra children
-        for (const child of node.infraChildren) {
-            this._assignPositions(child, cursor, depth + 1);
-            cursor += child.w + L.infraGap;
+        for (const c of n.infra) {
+            this._positions(c, cur, depth + 1);
+            cur += c.w + G.infraGap;
         }
 
-        // Place clients in grid
         if (nc > 0) {
-            const gridLeft = cursor - (infraW > 0 ? 0 : 0);
-            const clientY = yBase + (depth + 1) * L.tierGap;
+            const clientY = yOff + (depth + 1) * G.tierGap;
+            const cellW = G.clientR * 2 + G.clientGap;
             for (let i = 0; i < nc; i++) {
-                const col = i % cols;
-                const row = Math.floor(i / cols);
-                const cn = node.clientChildren[i];
-                cn.x = gridLeft + col * (L.clientSize + L.clientGap) + L.clientSize / 2;
-                cn.y = clientY + row * (L.clientSize + L.clientGap);
+                const col = i % cols, row = Math.floor(i / cols);
+                const cn = n.clients[i];
+                cn.x = cur + col * cellW + G.clientR;
+                cn.y = clientY + row * cellW;
             }
         }
 
-        // Center parent over all children
-        const allKids = [
-            ...node.infraChildren,
-            ...node.clientChildren.slice(0, nc),
-        ];
-        if (allKids.length > 0) {
-            const minX = Math.min(...allKids.map(c => c.x));
-            const maxX = Math.max(...allKids.map(c => c.x));
-            node.x = (minX + maxX) / 2;
+        const allK = [...n.infra, ...n.clients.slice(0, nc)];
+        if (allK.length > 0) {
+            n.x = (Math.min(...allK.map(c => c.x)) + Math.max(...allK.map(c => c.x))) / 2;
         } else {
-            node.x = leftX + node.w / 2;
+            n.x = lx + n.w / 2;
         }
     }
 
-    _positionClouds() {
+    _placeClouds() {
         if (!this._root || this._clouds.length === 0) return;
-        const gx = this._root.x;
-        const gy = this._root.y;
-        const total = this._clouds.length;
-        const spacing = L.cloudGap;
-        const startX = gx - ((total - 1) * spacing) / 2;
-
+        const gx = this._root.x, gy = this._root.y;
+        const total = this._clouds.length, sp = G.cloudGap;
+        const sx = gx - ((total - 1) * sp) / 2;
         for (let i = 0; i < total; i++) {
-            this._clouds[i].x = startX + i * spacing;
-            this._clouds[i].y = gy - L.tierGap;
+            this._clouds[i].x = sx + i * sp;
+            this._clouds[i].y = gy - G.tierGap;
         }
     }
 
-    // ---- Rendering ----
+    // ---- Render ----
 
     _renderAll() {
         this._gLinks.innerHTML = '';
         this._gNodes.innerHTML = '';
-        this._gParticles.innerHTML = '';
+        this._gParts.innerHTML = '';
         this._gLabels.innerHTML = '';
         this._particles = [];
 
-        if (!this._root) {
-            this._renderEmpty();
-            return;
-        }
-
-        this._setViewBox();
-        this._renderCloudLinks();
-        this._renderTreeLinks(this._root);
-        this._renderClouds();
-        this._renderTreeNodes(this._root);
-        this._updateRates();
-    }
-
-    _renderEmpty() {
-        const t = svg('text', {
-            x: '50%', y: '200',
-            'text-anchor': 'middle',
-            fill: COLORS.textMuted,
-            'font-size': '14',
-            'font-family': 'system-ui, sans-serif',
-        }, this._svgRoot);
-        t.textContent = 'Waiting for topology data...';
-        this._svgRoot.setAttribute('viewBox', '0 0 800 400');
-    }
-
-    _setViewBox() {
-        let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-
-        const expand = (x, y, r) => {
-            minX = Math.min(minX, x - r);
-            minY = Math.min(minY, y - r);
-            maxX = Math.max(maxX, x + r);
-            maxY = Math.max(maxY, y + r);
-        };
-
-        const visit = (node) => {
-            expand(node.x, node.y, L.infraW);
-            for (const c of node.infraChildren) visit(c);
-            for (const c of node.clientChildren.slice(0, L.maxClients))
-                expand(c.x, c.y, L.clientSize);
-        };
-        visit(this._root);
-        for (const c of this._clouds) expand(c.x, c.y, L.cloudR + 20);
-
-        const pad = L.padding;
-        const vx = minX - pad;
-        const vy = minY - pad;
-        const vw = (maxX - minX) + pad * 2;
-        const vh = (maxY - minY) + pad * 2 + 30;
-        this._svgRoot.setAttribute('viewBox', `${vx} ${vy} ${vw} ${vh}`);
-    }
-
-    // ---- Link rendering ----
-
-    _renderCloudLinks() {
         if (!this._root) return;
-        const gw = this._root;
-        const gwTop = gw.y - L.infraH / 2;
+
+        this._calcViewBox();
+        this._drawCloudLinks();
+        this._drawTreeLinks(this._root);
+        this._drawClouds();
+        this._drawTree(this._root);
+        this._drawToolbar();
+        this._updateRates();
+        this._svg.style.cursor = 'grab';
+    }
+
+    _calcViewBox() {
+        let x0=Infinity, y0=Infinity, x1=-Infinity, y1=-Infinity;
+        const exp = (x, y, r) => { x0=Math.min(x0,x-r); y0=Math.min(y0,y-r); x1=Math.max(x1,x+r); y1=Math.max(y1,y+r); };
+        const vis = (n) => {
+            exp(n.x, n.y, G.boxW);
+            for (const c of n.infra) vis(c);
+            for (const c of n.clients.slice(0, G.maxClients)) exp(c.x, c.y, G.clientR + 8);
+        };
+        vis(this._root);
+        for (const c of this._clouds) exp(c.x, c.y, G.cloudR + 30);
+
+        const p = G.pad;
+        this._baseVx = x0 - p;
+        this._baseVy = y0 - p;
+        this._baseVw = (x1 - x0) + p * 2;
+        this._baseVh = (y1 - y0) + p * 2 + 50;
+        this._fitAll();
+    }
+
+    // ---- Cloud links ----
+
+    _drawCloudLinks() {
+        if (!this._root) return;
+        const gw = this._root, gwT = gw.y - G.boxH / 2;
 
         for (const cloud of this._clouds) {
-            const cy = cloud.y + L.cloudR + 6;
-            const linkData = this._linkEdges.find(e =>
-                (e.link.kind === LINK_KIND.Wan || e.link.kind === LINK_KIND.Transit)
-                && ((e.link.fromNodeId === cloud.data.id || e.link.toNodeId === cloud.data.id)
-                    || (e.fromNode?.d.kind === NODE_KIND.Gateway && e.toNode?.d.kind === NODE_KIND.Cloud))
-            );
+            const cy = cloud.y + G.cloudR + 8;
+            const edge = this._edges.find(e =>
+                (e.lk.kind === LK.Wan || e.lk.kind === LK.Transit)
+                && (e.lk.fromNodeId === cloud.d.id || e.lk.toNodeId === cloud.d.id));
 
-            const pathD = orthoPath(cloud.x, cy, gw.x, gwTop);
-            const pathEl = svg('path', {
-                d: pathD,
-                fill: 'none',
-                stroke: COLORS.pipeCool,
-                'stroke-width': linkData ? pipeWidth(linkData.link.capacityBps) : L.pipeBase,
-                'stroke-linecap': 'round',
-                opacity: '0.7',
-            }, this._gLinks);
+            const d = orthoPath(cloud.x, cy, gw.x, gwT);
+            const pe = el('path', { d, fill:'none', stroke:C.pipeCool,
+                'stroke-width': edge ? pipeW(edge.lk.capacityBps) : G.pipeBase,
+                'stroke-linecap':'round', opacity:'0.65' }, this._gLinks);
 
-            if (linkData) {
-                linkData._pathEl = pathEl;
-                linkData._x1 = cloud.x; linkData._y1 = cy;
-                linkData._x2 = gw.x; linkData._y2 = gwTop;
-                linkData._isWan = true;
+            if (edge) {
+                edge._pe = pe;
+                edge._x1 = cloud.x; edge._y1 = cy;
+                edge._x2 = gw.x; edge._y2 = gwT;
+                edge._isWan = true;
             }
         }
 
         // Transit links between clouds
-        const sortedClouds = [...this._clouds].sort((a, b) => a.data.order - b.data.order);
-        for (let i = 0; i < sortedClouds.length - 1; i++) {
-            const a = sortedClouds[i], b = sortedClouds[i + 1];
-            const edge = this._linkEdges.find(e =>
-                e.link.kind === LINK_KIND.Transit
-                && ((e.link.fromNodeId === a.data.id && e.link.toNodeId === b.data.id)
-                    || (e.link.fromNodeId === b.data.id && e.link.toNodeId === a.data.id))
-            );
+        const sc = [...this._clouds].sort((a, b) => a.d.order - b.d.order);
+        for (let i = 0; i < sc.length - 1; i++) {
+            const a = sc[i], b = sc[i + 1];
+            const edge = this._edges.find(e =>
+                e.lk.kind === LK.Transit
+                && ((e.lk.fromNodeId === a.d.id && e.lk.toNodeId === b.d.id)
+                    || (e.lk.fromNodeId === b.d.id && e.lk.toNodeId === a.d.id)));
             if (!edge) continue;
-
-            const pathD = `M${a.x + L.cloudR + 4} ${a.y}L${b.x - L.cloudR - 4} ${b.y}`;
-            const pathEl = svg('path', {
-                d: pathD,
-                fill: 'none',
-                stroke: COLORS.pipeCool,
-                'stroke-width': L.pipeBase,
-                'stroke-linecap': 'round',
-                'stroke-dasharray': '6 4',
-                opacity: '0.5',
+            const pe = el('path', {
+                d: `M${a.x+G.cloudR+4} ${a.y}L${b.x-G.cloudR-4} ${b.y}`,
+                fill:'none', stroke:C.pipeCool, 'stroke-width':G.pipeBase,
+                'stroke-linecap':'round', 'stroke-dasharray':'6 4', opacity:'0.45'
             }, this._gLinks);
-            edge._pathEl = pathEl;
-            edge._x1 = a.x + L.cloudR + 4; edge._y1 = a.y;
-            edge._x2 = b.x - L.cloudR - 4; edge._y2 = b.y;
+            edge._pe = pe;
+            edge._x1 = a.x+G.cloudR+4; edge._y1 = a.y;
+            edge._x2 = b.x-G.cloudR-4; edge._y2 = b.y;
         }
     }
 
-    _renderTreeLinks(node) {
-        const parentBottom = node.y + L.infraH / 2;
+    // ---- Tree links ----
 
-        for (const child of node.infraChildren) {
-            const childTop = child.y - L.infraH / 2;
-            this._drawLink(node, child, parentBottom, childTop, false);
-            this._renderTreeLinks(child);
+    _drawTreeLinks(n) {
+        const pB = n.y + G.boxH / 2;
+        for (const c of n.infra) {
+            this._drawLink(n, c, pB, c.y - G.boxH / 2, false);
+            this._drawTreeLinks(c);
         }
-
-        for (const child of node.clientChildren.slice(0, L.maxClients)) {
-            const childTop = child.y - L.clientSize / 2;
-            this._drawLink(node, child, parentBottom, childTop, true);
+        for (const c of n.clients.slice(0, G.maxClients)) {
+            this._drawLink(n, c, pB, c.y - G.clientR, true);
         }
     }
 
-    _drawLink(parent, child, y1, y2, isClientLink) {
-        const edge = this._linkEdges.find(e =>
-            (e.link.fromNodeId === parent.d.id && e.link.toNodeId === child.d.id)
-            || (e.link.fromNodeId === child.d.id && e.link.toNodeId === parent.d.id)
-        );
+    _drawLink(par, child, y1, y2, isCl) {
+        const edge = this._edges.find(e =>
+            (e.lk.fromNodeId === par.d.id && e.lk.toNodeId === child.d.id)
+            || (e.lk.fromNodeId === child.d.id && e.lk.toNodeId === par.d.id));
 
-        const band = edge?.link.band;
-        const coolColor = bandColor(band) || COLORS.pipeCool;
+        const band = edge?.lk.band;
+        const cool = bandClr(band) || C.pipeCool;
 
-        const pathD = orthoPath(parent.x, y1, child.x, y2);
-        const pathEl = svg('path', {
-            d: pathD,
-            fill: 'none',
-            stroke: coolColor,
-            'stroke-width': edge ? pipeWidth(edge.link.capacityBps) : L.pipeBase,
-            'stroke-linecap': 'round',
-            opacity: isClientLink ? '0.35' : '0.6',
-        }, this._gLinks);
+        const d = orthoPath(par.x, y1, child.x, y2);
+        const pe = el('path', { d, fill:'none', stroke:cool,
+            'stroke-width': edge ? pipeW(edge.lk.capacityBps) : G.pipeBase,
+            'stroke-linecap':'round', opacity: isCl ? '0.3' : '0.55' }, this._gLinks);
 
         if (edge) {
-            edge._pathEl = pathEl;
-            edge._x1 = parent.x; edge._y1 = y1;
+            edge._pe = pe; edge._x1 = par.x; edge._y1 = y1;
             edge._x2 = child.x; edge._y2 = y2;
-            edge._isClientLink = isClientLink;
-            edge._band = band;
+            edge._isCl = isCl; edge._band = band;
         }
 
-        // Capacity label for infra links
-        if (!isClientLink && edge?.link.capacityBps) {
-            const cap = edge.link.capacityBps / 1e6;
-            if (cap > 0) {
-                const label = formatLinkSpeed(cap);
-                const midX = (parent.x + child.x) / 2;
-                const midY = (y1 + y2) / 2;
-                this._renderCapLabel(midX, midY, label);
-            }
+        if (!isCl && edge?.lk.capacityBps) {
+            const cap = edge.lk.capacityBps / 1e6;
+            if (cap > 0) this._capLabel((par.x + child.x) / 2, (y1 + y2) / 2, formatSpeed(cap));
         }
     }
 
-    _renderCapLabel(x, y, text) {
-        const g = svg('g', { transform: `translate(${x},${y})` }, this._gLabels);
-
-        const tw = text.length * 5.5 + 12;
-        svg('rect', {
-            x: -tw / 2, y: -8,
-            width: tw, height: 16,
-            rx: 4,
-            fill: COLORS.labelBg,
-        }, g);
-
-        const t = svg('text', {
-            x: 0, y: 4,
-            'text-anchor': 'middle',
-            fill: COLORS.textMuted,
-            'font-size': L.rateFont,
-            'font-family': 'system-ui, sans-serif',
-        }, g);
-        t.textContent = text;
+    _capLabel(x, y, txt) {
+        const g = el('g', { transform:`translate(${x},${y})` }, this._gLabels);
+        const tw = txt.length * 5.5 + 12;
+        el('rect', { x:-tw/2, y:-8, width:tw, height:16, rx:4, fill:C.labelBg }, g);
+        const t = el('text', { x:0, y:4, 'text-anchor':'middle', fill:C.textMuted,
+            'font-size':G.rateFont, 'font-family':'system-ui,sans-serif' }, g);
+        t.textContent = txt;
     }
 
-    // ---- Cloud rendering ----
+    // ---- Cloud nodes ----
 
-    _renderClouds() {
+    _drawClouds() {
         for (const cloud of this._clouds) {
-            const g = svg('g', { transform: `translate(${cloud.x},${cloud.y})` }, this._gNodes);
-            const r = L.cloudR;
+            const g = el('g', { transform:`translate(${cloud.x},${cloud.y})` }, this._gNodes);
+            const r = G.cloudR;
 
-            // Wireframe globe
-            svg('circle', { cx: 0, cy: 0, r, fill: 'none', stroke: COLORS.cloudStroke, 'stroke-width': 1.5, opacity: 0.8 }, g);
-            svg('ellipse', { cx: 0, cy: 0, rx: r * 0.5, ry: r, fill: 'none', stroke: COLORS.cloudStroke, 'stroke-width': 1, opacity: 0.4 }, g);
-            svg('ellipse', { cx: 0, cy: 0, rx: r, ry: r * 0.35, fill: 'none', stroke: COLORS.cloudStroke, 'stroke-width': 1, opacity: 0.4 }, g);
-            svg('ellipse', { cx: 0, cy: 0, rx: r, ry: r * 0.65, fill: 'none', stroke: COLORS.cloudStroke, 'stroke-width': 0.7, opacity: 0.25 }, g);
+            // Blue wireframe globe
+            el('circle', { cx:0, cy:0, r, fill:'none', stroke:C.globeStroke, 'stroke-width':1.5, opacity:0.8 }, g);
+            el('ellipse', { cx:0, cy:0, rx:r*0.45, ry:r, fill:'none', stroke:C.globeStroke, 'stroke-width':1, opacity:0.35 }, g);
+            el('ellipse', { cx:0, cy:0, rx:r, ry:r*0.35, fill:'none', stroke:C.globeStroke, 'stroke-width':1, opacity:0.35 }, g);
+            el('ellipse', { cx:0, cy:0, rx:r, ry:r*0.65, fill:'none', stroke:C.globeStroke, 'stroke-width':0.7, opacity:0.2 }, g);
+            el('circle', { cx:0, cy:0, r:r-1, fill:C.globeStroke, opacity:0.05 }, g);
 
-            // Subtle fill
-            svg('circle', { cx: 0, cy: 0, r: r - 1, fill: COLORS.cloudStroke, opacity: 0.06 }, g);
+            const name = cloud.d.asnName || cloud.d.name || 'WAN';
+            const lb = el('text', { x:0, y:r+18, 'text-anchor':'middle', fill:C.textSec,
+                'font-size':G.nameFont, 'font-family':'system-ui,sans-serif', 'font-weight':500 }, g);
+            lb.textContent = name;
 
-            // Name label below
-            const name = cloud.data.asnName || cloud.data.name || 'WAN';
-            const label = svg('text', {
-                x: 0, y: r + 16,
-                'text-anchor': 'middle',
-                fill: COLORS.textSec,
-                'font-size': L.nameFont,
-                'font-family': 'system-ui, sans-serif',
-                'font-weight': 500,
-            }, g);
-            label.textContent = name;
-
-            // RTT badge
-            cloud._rttEl = svg('text', {
-                x: 0, y: r + 30,
-                'text-anchor': 'middle',
-                fill: COLORS.textMuted,
-                'font-size': L.rateFont - 1,
-                'font-family': 'system-ui, sans-serif',
-            }, g);
-            this._updateCloudBadge(cloud);
+            cloud._rtt = el('text', { x:0, y:r+31, 'text-anchor':'middle', fill:C.textMuted,
+                'font-size':G.rateFont-1, 'font-family':'system-ui,sans-serif' }, g);
+            this._cloudBadge(cloud);
         }
     }
 
-    _updateCloudBadge(cloud) {
-        if (!cloud._rttEl) return;
-        const d = cloud.data;
-        let txt = '';
-        if (d.rttAvgMs != null) txt += `${d.rttAvgMs.toFixed(1)} ms`;
-        if (d.lossPercent != null && d.lossPercent > 0) {
-            txt += txt ? ' / ' : '';
-            txt += `${d.lossPercent.toFixed(1)}% loss`;
-        }
-        cloud._rttEl.textContent = txt;
+    _cloudBadge(c) {
+        if (!c._rtt) return;
+        const d = c.d; let t = '';
+        if (d.rttAvgMs != null) t += `${d.rttAvgMs.toFixed(1)} ms`;
+        if (d.lossPercent && d.lossPercent > 0) t += (t ? ' / ' : '') + `${d.lossPercent.toFixed(1)}% loss`;
+        c._rtt.textContent = t;
     }
 
-    // ---- Node rendering ----
+    // ---- Infrastructure + client nodes ----
 
-    _renderTreeNodes(node) {
-        this._renderInfraNode(node);
-        for (const child of node.infraChildren) this._renderTreeNodes(child);
-        for (const child of node.clientChildren.slice(0, L.maxClients)) {
-            this._renderClientNode(child);
-        }
-        // "+N more" indicator
-        if (node.clientChildren.length > L.maxClients) {
-            const last = node.clientChildren[L.maxClients - 1];
-            const extra = node.clientChildren.length - L.maxClients;
-            const t = svg('text', {
-                x: last.x + L.clientSize + 8,
-                y: last.y + 4,
-                fill: COLORS.textMuted,
-                'font-size': L.rateFont,
-                'font-family': 'system-ui, sans-serif',
-            }, this._gLabels);
+    _drawTree(n) {
+        this._drawInfra(n);
+        for (const c of n.infra) this._drawTree(c);
+        for (const c of n.clients.slice(0, G.maxClients)) this._drawClient(c);
+        if (n.clients.length > G.maxClients) {
+            const last = n.clients[G.maxClients - 1];
+            const extra = n.clients.length - G.maxClients;
+            const t = el('text', { x:last.x + G.clientR + 10, y:last.y + 4,
+                fill:C.textMuted, 'font-size':G.rateFont, 'font-family':'system-ui,sans-serif' }, this._gLabels);
             t.textContent = `+${extra}`;
         }
     }
 
-    _renderInfraNode(node) {
-        const g = svg('g', {
-            transform: `translate(${node.x},${node.y})`,
-            class: 'infra-node',
-        }, this._gNodes);
+    _drawInfra(n) {
+        const g = el('g', { transform:`translate(${n.x},${n.y})`, class:'inf' }, this._gNodes);
+        const color = nodeClr(n.d.kind);
+        const hw = G.boxW / 2, hh = G.boxH / 2;
 
-        const color = nodeColor(node.d.kind);
-        const hw = L.infraW / 2;
-        const hh = L.infraH / 2;
-        const iconSize = 40;
+        // Glow
+        el('rect', { x:-hw-5, y:-hh-5, width:G.boxW+10, height:G.boxH+10,
+            rx:14, fill:color, opacity:0.07 }, g);
 
-        // Glow ring behind
-        svg('rect', {
-            x: -hw - 4, y: -hh - 4,
-            width: L.infraW + 8, height: L.infraH + 8,
-            rx: 12,
-            fill: color,
-            opacity: 0.08,
-            filter: 'url(#node-glow)',
-        }, g);
+        // Card
+        el('rect', { x:-hw, y:-hh, width:G.boxW, height:G.boxH, rx:10,
+            fill:'#1a1d23', stroke:color, 'stroke-width':1.5,
+            opacity: n.d.online ? 1 : 0.35 }, g);
 
-        // Background card
-        svg('rect', {
-            x: -hw, y: -hh,
-            width: L.infraW, height: L.infraH,
-            rx: 8,
-            fill: '#1a1d23',
-            stroke: color,
-            'stroke-width': 1.5,
-            opacity: node.d.online ? 1 : 0.4,
-        }, g);
-
-        // Device icon or fallback
-        if (node.d.model) {
-            const imgPath = `/images/devices/${node.d.model.toLowerCase().replace(/ /g, '-')}.png`;
-            const img = svg('image', {
-                href: imgPath,
-                x: -iconSize / 2, y: -iconSize / 2,
-                width: iconSize, height: iconSize,
-                opacity: node.d.online ? 1 : 0.4,
-            }, g);
-            img.addEventListener('error', () => {
-                img.remove();
-                this._renderFallbackIcon(g, node, color, iconSize);
-            }, { once: true });
+        // Device icon (large, fills the card)
+        const iSz = G.iconSize;
+        if (n.d.model) {
+            const path = `/images/devices/${n.d.model.toLowerCase().replace(/ /g, '-')}.png`;
+            const img = el('image', { href:path, x:-iSz/2, y:-iSz/2, width:iSz, height:iSz,
+                opacity: n.d.online ? 1 : 0.35 }, g);
+            img.addEventListener('error', () => { img.remove(); this._fallback(g, n, color); }, { once: true });
         } else {
-            this._renderFallbackIcon(g, node, color, iconSize);
+            this._fallback(g, n, color);
         }
 
-        // Name label below
-        const name = node.d.name || node.d.model || '';
+        // Name
+        const name = n.d.name || n.d.model || '';
         if (name) {
-            const displayName = name.length > 14 ? name.slice(0, 13) + '…' : name;
-            const t = svg('text', {
-                x: 0, y: hh + 16,
-                'text-anchor': 'middle',
-                fill: COLORS.text,
-                'font-size': L.nameFont,
-                'font-family': 'system-ui, sans-serif',
-                'font-weight': 500,
-            }, g);
-            t.textContent = displayName;
+            const dn = name.length > 16 ? name.slice(0, 15) + '…' : name;
+            const t = el('text', { x:0, y:hh+17, 'text-anchor':'middle', fill:C.text,
+                'font-size':G.nameFont, 'font-family':'system-ui,sans-serif', 'font-weight':500 }, g);
+            t.textContent = dn;
         }
 
-        // Rate label (updated dynamically)
-        node._rateGroup = svg('g', { transform: `translate(0, ${hh + 30})` }, g);
-        node._rateDown = svg('text', {
-            x: -4, y: 0,
-            'text-anchor': 'end',
-            fill: COLORS.downstream,
-            'font-size': L.rateFont,
-            'font-family': 'system-ui, sans-serif',
-        }, node._rateGroup);
-        node._rateUp = svg('text', {
-            x: 4, y: 0,
-            'text-anchor': 'start',
-            fill: COLORS.upstream,
-            'font-size': L.rateFont,
-            'font-family': 'system-ui, sans-serif',
-        }, node._rateGroup);
+        // Rate label area
+        n._rd = el('text', { x:-3, y:hh+31, 'text-anchor':'end', fill:C.downstream,
+            'font-size':G.rateFont, 'font-family':'system-ui,sans-serif' }, g);
+        n._ru = el('text', { x:3, y:hh+31, 'text-anchor':'start', fill:C.upstream,
+            'font-size':G.rateFont, 'font-family':'system-ui,sans-serif' }, g);
     }
 
-    _renderFallbackIcon(g, node, color, size) {
-        const hs = size / 2;
-        svg('rect', {
-            x: -hs + 4, y: -hs + 4,
-            width: size - 8, height: size - 8,
-            rx: 6,
-            fill: color,
-            opacity: 0.2,
-        }, g);
-        const letter = (node.d.name || 'D').charAt(0).toUpperCase();
-        const t = svg('text', {
-            x: 0, y: 5,
-            'text-anchor': 'middle',
-            fill: color,
-            'font-size': 16,
-            'font-weight': 600,
-            'font-family': 'system-ui, sans-serif',
-        }, g);
-        t.textContent = letter;
+    _fallback(g, n, color) {
+        const s = G.iconSize / 2 - 6;
+        el('rect', { x:-s, y:-s, width:s*2, height:s*2, rx:6, fill:color, opacity:0.2 }, g);
+        const t = el('text', { x:0, y:6, 'text-anchor':'middle', fill:color,
+            'font-size':18, 'font-weight':600, 'font-family':'system-ui,sans-serif' }, g);
+        t.textContent = (n.d.name || 'D').charAt(0).toUpperCase();
     }
 
-    _renderClientNode(node) {
-        const g = svg('g', {
-            transform: `translate(${node.x},${node.y})`,
-            class: 'client-node',
-        }, this._gNodes);
+    _drawClient(n) {
+        const g = el('g', { transform:`translate(${n.x},${n.y})`, class:'cl' }, this._gNodes);
+        const color = nodeClr(n.d.kind, n.d.band);
+        const r = G.clientR;
+        const op = n.d.online ? 0.7 : 0.2;
 
-        const color = nodeColor(node.d.kind, node.d.band);
-        const r = L.clientSize / 2 - 1;
-
-        if (node.d.kind === NODE_KIND.WifiClient) {
-            // Circle for WiFi client
-            svg('circle', {
-                cx: 0, cy: 0, r,
-                fill: color,
-                opacity: node.d.online ? 0.7 : 0.2,
-            }, g);
-            // WiFi arc indicator
-            svg('path', {
-                d: `M${-3} ${-1}Q0 ${-5} 3 ${-1}`,
-                fill: 'none',
-                stroke: '#fff',
-                'stroke-width': 1,
-                opacity: 0.5,
-            }, g);
+        if (n.d.kind === NK.WifiClient) {
+            el('circle', { cx:0, cy:0, r, fill:color, opacity:op }, g);
+            // Tiny wifi arc
+            el('path', { d:`M${-2.5} ${-0.5}Q0 ${-4} 2.5 ${-0.5}`, fill:'none',
+                stroke:'#fff', 'stroke-width':0.8, opacity:0.5 }, g);
         } else {
-            // Rounded rect for wired client (monitor shape)
-            const s = r * 1.4;
-            svg('rect', {
-                x: -s, y: -s + 1,
-                width: s * 2, height: s * 1.6,
-                rx: 2,
-                fill: color,
-                opacity: node.d.online ? 0.6 : 0.2,
-            }, g);
-            // Stand
-            svg('line', {
-                x1: 0, y1: s * 0.6 + 1,
-                x2: 0, y2: s + 1,
-                stroke: color,
-                'stroke-width': 1.5,
-                opacity: node.d.online ? 0.6 : 0.2,
-            }, g);
+            // Small monitor shape
+            const s = r * 0.9;
+            el('rect', { x:-s, y:-s+0.5, width:s*2, height:s*1.5, rx:1.5, fill:color, opacity:op }, g);
+            el('line', { x1:0, y1:s*0.5+0.5, x2:0, y2:s+1, stroke:color, 'stroke-width':1.2, opacity:op }, g);
         }
 
-        // Tooltip via data-tooltip
-        const name = node.d.name || node.d.ip || '';
+        const name = n.d.name || n.d.ip || '';
         if (name) g.setAttribute('data-tooltip', name);
+    }
+
+    // ---- Toolbar ----
+
+    _drawToolbar() {
+        const tb = document.createElement('div');
+        tb.className = 'lfm2d-toolbar';
+        tb.innerHTML = `<button class="lfm2d-btn" data-action="zin" title="Zoom in">+</button>`
+            + `<button class="lfm2d-btn" data-action="zout" title="Zoom out">&minus;</button>`
+            + `<button class="lfm2d-btn" data-action="fit" title="Fit all">&#x2922;</button>`;
+        tb.addEventListener('click', (e) => {
+            const a = e.target.closest('[data-action]')?.dataset.action;
+            if (a === 'zin') { this._zoomBy(0.8); }
+            else if (a === 'zout') { this._zoomBy(1.25); }
+            else if (a === 'fit') { this._fitAll(); }
+        });
+        this._el.appendChild(tb);
+    }
+
+    _zoomBy(factor) {
+        const cx = this._vx + this._vw / 2;
+        const cy = this._vy + this._vh / 2;
+        this._vw *= factor;
+        this._vh *= factor;
+        this._vx = cx - this._vw / 2;
+        this._vy = cy - this._vh / 2;
+        this._applyViewBox();
     }
 
     // ---- Rate updates ----
 
     _updateRates() {
-        this._updateNodeRateLabels();
-        this._updatePipeColors();
+        this._updateLabels();
+        this._updatePipes();
+        this._updateCloudStats();
         this._syncParticles();
     }
 
-    _updateNodeRateLabels() {
+    _updateLabels() {
         if (!this._root) return;
+        // Use node badges from the shared data (same source as 3D map).
+        // fabricIngress/Egress for switches, aggregateIn/Out for APs.
+        // Direction: blue ↓ = download = data flowing toward leaves.
+        const badges = flowData.getNodeBadges();
 
-        const nodeRates = new Map();
-        for (const edge of this._linkEdges) {
-            const rates = this._liveRates[edge.link.portKey] || this._liveRates[edge.link.id];
-            if (!rates) continue;
-            const down = rates.downstreamBps ?? rates.DownstreamBps ?? 0;
-            const up = rates.upstreamBps ?? rates.UpstreamBps ?? 0;
+        const upd = (n) => {
+            if (n._rd) {
+                let downBps = 0, upBps = 0, any = false;
+                const b = badges?.[n.d.id];
+                const hasFab = b && (b.fabricIngressBps != null || b.fabricEgressBps != null);
+                const hasAgg = b && (b.aggregateInBps != null || b.aggregateOutBps != null);
 
-            // Accumulate on parent infrastructure node
-            for (const nodeId of [edge.link.fromNodeId, edge.link.toNodeId]) {
-                const tn = this._treeNodes.get(nodeId);
-                if (tn && isInfra(tn.d.kind)) {
-                    const cur = nodeRates.get(nodeId) || { down: 0, up: 0 };
-                    cur.down += down;
-                    cur.up += up;
-                    nodeRates.set(nodeId, cur);
+                if (hasFab) {
+                    downBps = b.fabricIngressBps || 0;
+                    upBps = b.fabricEgressBps || 0;
+                    any = downBps > 0 || upBps > 0;
+                } else if (hasAgg) {
+                    // APs: aggregateIn = client data arriving at AP, aggregateOut = data leaving AP.
+                    // Label is gateway-relative (↓=from gateway) so APs swap.
+                    if (n.d.kind === NK.AP) {
+                        downBps = b.aggregateOutBps || 0;
+                        upBps = b.aggregateInBps || 0;
+                    } else {
+                        downBps = b.aggregateInBps || 0;
+                        upBps = b.aggregateOutBps || 0;
+                    }
+                    any = downBps > 0 || upBps > 0;
+                } else {
+                    // Fallback: sum adjacent link rates
+                    for (const e of this._edges) {
+                        if (e.lk.fromNodeId !== n.d.id && e.lk.toNodeId !== n.d.id) continue;
+                        const r = this._liveRates[e.lk.portKey] || this._liveRates[e.lk.id];
+                        if (!r) continue;
+                        any = true;
+                        downBps += r.downstreamBps ?? 0;
+                        upBps += r.upstreamBps ?? 0;
+                    }
                 }
-            }
-        }
 
-        const updateNode = (node) => {
-            const r = nodeRates.get(node.d.id);
-            if (node._rateDown) {
-                const d = r?.down || 0;
-                const u = r?.up || 0;
-                node._rateDown.textContent = d > RATE_THRESHOLD ? '↓ ' + formatBps(d) : '';
-                node._rateUp.textContent = u > RATE_THRESHOLD ? '↑ ' + formatBps(u) : '';
+                n._rd.textContent = (any && downBps > 100000) ? '↓' + formatBps(downBps) : '';
+                n._ru.textContent = (any && upBps > 100000) ? '↑' + formatBps(upBps) : '';
             }
-            for (const c of node.infraChildren) updateNode(c);
+            for (const c of n.infra) upd(c);
         };
-        updateNode(this._root);
+        upd(this._root);
     }
 
-    _updatePipeColors() {
-        for (const edge of this._linkEdges) {
-            if (!edge._pathEl) continue;
-            const rates = this._liveRates[edge.link.portKey] || this._liveRates[edge.link.id];
-            if (!rates) continue;
-            const down = rates.downstreamBps ?? rates.DownstreamBps ?? 0;
-            const up = rates.upstreamBps ?? rates.UpstreamBps ?? 0;
-            const cap = edge.link.capacityBps || 1e9;
-            const util = Math.max(down, up) / cap;
-            const color = pipeColorForUtil(Math.min(util, 1), edge._band);
-            edge._pathEl.setAttribute('stroke', color);
-            const op = edge._isClientLink ? 0.35 + util * 0.4 : 0.5 + util * 0.5;
-            edge._pathEl.setAttribute('opacity', String(Math.min(op, 1)));
+    _updatePipes() {
+        for (const e of this._edges) {
+            if (!e._pe) continue;
+            const r = this._liveRates[e.lk.portKey] || this._liveRates[e.lk.id];
+            if (!r) continue;
+            const dn = r.downstreamBps ?? 0, up = r.upstreamBps ?? 0;
+            const cap = e.lk.capacityBps || 1e9;
+            const u = Math.max(dn, up) / cap;
+            e._pe.setAttribute('stroke', pipeClr(Math.min(u, 1), e._band));
+            const op = e._isCl ? 0.3 + u * 0.45 : 0.5 + u * 0.5;
+            e._pe.setAttribute('opacity', String(Math.min(op, 1)));
         }
     }
 
-    // ---- Particle system ----
+    _updateCloudStats() {
+        const cs = flowData.getCloudStats();
+        for (const cloud of this._clouds) {
+            const live = cs?.[cloud.d.id];
+            if (live) {
+                if (live.rttAvgMs != null) cloud.d.rttAvgMs = live.rttAvgMs;
+                if (live.lossPercent != null) cloud.d.lossPercent = live.lossPercent;
+            }
+            this._cloudBadge(cloud);
+        }
+    }
+
+    // ---- Particle system (matches 3D map emission model) ----
 
     _syncParticles() {
-        // Remove all existing particles
-        this._gParticles.innerHTML = '';
+        this._gParts.innerHTML = '';
         this._particles = [];
 
-        for (const edge of this._linkEdges) {
-            if (!edge._pathEl || edge._isClientLink) continue;
-            const rates = this._liveRates[edge.link.portKey] || this._liveRates[edge.link.id];
-            if (!rates) continue;
-            const down = rates.downstreamBps ?? rates.DownstreamBps ?? 0;
-            const up = rates.upstreamBps ?? rates.UpstreamBps ?? 0;
+        for (const e of this._edges) {
+            if (!e._pe || e._isCl) continue;
+            const r = this._liveRates[e.lk.portKey] || this._liveRates[e.lk.id];
+            const dn = r?.downstreamBps ?? 0;
+            const up = r?.upstreamBps ?? 0;
+            const len = orthoLen(e._x1, e._y1, e._x2, e._y2);
+            if (len < 5) continue;
 
-            const len = orthoLength(edge._x1, edge._y1, edge._x2, edge._y2);
-            if (len < 10) continue;
+            // Downstream particles
+            if (dn > 0) this._spawnStream(e, dn, 1, C.downstream);
+            // Upstream particles
+            if (up > 0) this._spawnStream(e, up, -1, C.upstream);
+        }
+    }
 
-            // Downstream particles (flow along path direction: parent → child)
-            if (down > RATE_THRESHOLD) {
-                const count = Math.min(Math.ceil(Math.log10(Math.max(down, 1)) / 2.5), 5);
-                const speed = 0.3 + Math.min(Math.log10(Math.max(down, 1)) / 11, 1) * 0.7;
-                for (let i = 0; i < count; i++) {
-                    const el = svg('circle', {
-                        r: L.particleR,
-                        fill: COLORS.downstream,
-                        opacity: 0.85,
-                        filter: 'url(#particle-glow)',
-                    }, this._gParticles);
-                    this._particles.push({
-                        el, edge,
-                        t: i / count,
-                        speed,
-                        dir: 1,
-                    });
-                }
-            }
+    _spawnStream(edge, bps, dir, color) {
+        // 3D map formula: intensity = log10(max(bps,1)) / 11, clamped 0..1
+        const intensity = Math.max(0, Math.min(1, Math.log10(Math.max(bps, 1)) / 11));
+        // Emission density - how many particles visible at once
+        // density² * 12 = emissions/sec. At steady state ~density²*12 / velocity particles in flight.
+        const density = intensity;
+        // Particle size: squared curve matching 3D map
+        const size = 1.5 + (intensity * intensity) * 5;
+        // Velocity: 0..1 range, normalized per-second fraction of path
+        const vel = 0.15 + intensity * 0.45;
+        // Count: density²*12 is emission rate; at vel speed, in-flight ≈ emission/vel
+        const count = Math.max(1, Math.min(Math.ceil(density * density * 12 / Math.max(vel, 0.1)), 10));
 
-            // Upstream particles (flow against path: child → parent)
-            if (up > RATE_THRESHOLD) {
-                const count = Math.min(Math.ceil(Math.log10(Math.max(up, 1)) / 2.5), 5);
-                const speed = 0.3 + Math.min(Math.log10(Math.max(up, 1)) / 11, 1) * 0.7;
-                for (let i = 0; i < count; i++) {
-                    const el = svg('circle', {
-                        r: L.particleR,
-                        fill: COLORS.upstream,
-                        opacity: 0.85,
-                        filter: 'url(#particle-glow)',
-                    }, this._gParticles);
-                    this._particles.push({
-                        el, edge,
-                        t: i / count,
-                        speed,
-                        dir: -1,
-                    });
-                }
-            }
+        for (let i = 0; i < count; i++) {
+            const dot = el('circle', {
+                r: size, fill: color, opacity: 0.85, filter: 'url(#pg)',
+            }, this._gParts);
+            this._particles.push({
+                el: dot, edge,
+                t: i / count + (Math.random() * 0.05),
+                speed: vel * (0.85 + Math.random() * 0.3),
+                dir, size,
+            });
         }
     }
 
@@ -1031,11 +828,7 @@ class LanFlowMap2D {
             if (p.t > 1) p.t -= 1;
             if (p.t < 0) p.t += 1;
 
-            const pt = orthoPointAt(
-                p.edge._x1, p.edge._y1,
-                p.edge._x2, p.edge._y2,
-                p.t
-            );
+            const pt = orthoAt(p.edge._x1, p.edge._y1, p.edge._x2, p.edge._y2, p.t);
             p.el.setAttribute('cx', pt.x);
             p.el.setAttribute('cy', pt.y);
         }
@@ -1045,17 +838,16 @@ class LanFlowMap2D {
 }
 
 // ---- Module exports ----
-
-let _instance = null;
+let _inst = null;
 
 export async function mount(containerId) {
-    if (_instance) { _instance.dispose(); _instance = null; }
-    const el = document.getElementById(containerId);
-    if (!el) return;
-    _instance = new LanFlowMap2D(el);
-    await _instance.start();
+    if (_inst) { _inst.dispose(); _inst = null; }
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    _inst = new LanFlowMap2D(container);
+    await _inst.start();
 }
 
 export function unmount() {
-    if (_instance) { _instance.dispose(); _instance = null; }
+    if (_inst) { _inst.dispose(); _inst = null; }
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1,10 +1,8 @@
-// 2D hierarchical LAN topology diagram.
+// 2D hierarchical LAN topology diagram - Canvas 2D renderer.
 // Subscribes to lan-flow-data.js (published by the 3D map) so there are
-// zero duplicate API calls. Renders SVG with animated data-flow particles.
+// zero duplicate API calls. GPU-composited canvas for smooth particle animation.
 
 import * as flowData from './lan-flow-data.js';
-
-const NS = 'http://www.w3.org/2000/svg';
 
 // ---- Color palette (matches 3D map) ----
 const C = {
@@ -28,6 +26,7 @@ const C = {
     textSec:      '#cbd5e1',
     textMuted:    '#9ca3af',
     labelBg:      'rgba(16,24,32,0.82)',
+    cardBg:       '#1a1d23',
     globeStroke:  '#3b82f6',
 };
 
@@ -52,926 +51,942 @@ const G = {
     pad:         80,
     pipeBase:    2,
     pipeMax:     6,
-    labelFont:   11,
-    rateFont:    10,
     nameFont:    11,
-    clientNameFont: 9,
+    rateFont:    10,
+    clientFont:  9,
 };
 
-// ---- Helpers ----
+const RATE_THRESH = 1_000_000;
+const EMIT_MAX = 10;
+const MAX_DOTS = 10;
+const FONT = 'system-ui, -apple-system, sans-serif';
 
-function el(tag, a, p) {
-    const e = document.createElementNS(NS, tag);
-    if (a) for (const [k, v] of Object.entries(a)) if (v != null) e.setAttribute(k, String(v));
-    if (p) p.appendChild(e);
-    return e;
-}
+// ---- Helpers ----
 
 function hexRgb(h) { return [parseInt(h.slice(1,3),16), parseInt(h.slice(3,5),16), parseInt(h.slice(5,7),16)]; }
 function rgbHex(r,g,b) { return '#'+[r,g,b].map(c=>Math.round(Math.max(0,Math.min(255,c))).toString(16).padStart(2,'0')).join(''); }
 function lerp(a,b,t) { return a+(b-a)*t; }
 function lerpColor(a,b,t) { const [r1,g1,b1]=hexRgb(a),[r2,g2,b2]=hexRgb(b); return rgbHex(lerp(r1,r2,t),lerp(g1,g2,t),lerp(b1,b2,t)); }
-
 function bandClr(b) { return b==='2.4'?C.band24:b==='5'?C.band5:b==='6'?C.band6:null; }
-function nodeClr(k, b) {
-    if (k===NK.Gateway) return C.gateway;
-    if (k===NK.Switch) return C.switchNode;
-    if (k===NK.AP) return C.ap;
-    if (k===NK.WiredClient) return C.wiredClient;
-    if (k===NK.WifiClient) return bandClr(b)||C.wifiClient;
-    if (k===NK.Cloud) return C.cloud;
-    if (k===NK.VirtualHub) return C.virtualHub;
+function nodeClr(k,b) {
+    if(k===NK.Gateway)return C.gateway; if(k===NK.Switch)return C.switchNode;
+    if(k===NK.AP)return C.ap; if(k===NK.WiredClient)return C.wiredClient;
+    if(k===NK.WifiClient)return bandClr(b)||C.wifiClient;
+    if(k===NK.Cloud)return C.cloud; if(k===NK.VirtualHub)return C.virtualHub;
     return C.textMuted;
 }
-function isInfra(k) { return k<=NK.AP || k===NK.VirtualHub; }
-function isClient(k) { return k===NK.WiredClient || k===NK.WifiClient; }
+function isInfra(k) { return k<=NK.AP||k===NK.VirtualHub; }
+function isClient(k) { return k===NK.WiredClient||k===NK.WifiClient; }
 
-function pipeClr(u, band) {
-    const cool = bandClr(band) || C.pipeCool;
-    if (u<0.7) return cool;
-    if (u<0.9) return lerpColor(cool, C.pipeWarm, (u-0.7)/0.2);
-    return lerpColor(C.pipeWarm, C.pipeHot, Math.min((u-0.9)/0.1, 1));
+function pipeClr(u,band) {
+    const cool=bandClr(band)||C.pipeCool;
+    if(u<0.7)return cool;
+    if(u<0.9)return lerpColor(cool,C.pipeWarm,(u-0.7)/0.2);
+    return lerpColor(C.pipeWarm,C.pipeHot,Math.min((u-0.9)/0.1,1));
 }
 function pipeW(cap) {
-    if (!cap||cap<=0) return G.pipeBase;
-    const t = Math.log10(Math.max(cap/1e9, 0.01))+2;
-    return G.pipeBase + Math.min(t, 3.5)*0.9;
+    if(!cap||cap<=0)return G.pipeBase;
+    const t=Math.log10(Math.max(cap/1e9,0.01))+2;
+    return G.pipeBase+Math.min(t,3.5)*0.9;
 }
 
 function formatBps(bps) {
-    if (!Number.isFinite(bps)||bps<=0) return '';
+    if(!Number.isFinite(bps)||bps<=0)return '0 bps';
     const u=['bps','Kbps','Mbps','Gbps','Tbps'];
-    let i=0, v=bps;
-    while (v>=1000&&i<u.length-1){v/=1000;i++;}
+    let i=0,v=bps;
+    while(v>=1000&&i<u.length-1){v/=1000;i++;}
     return `${v>=100?v.toFixed(0):v.toFixed(1)} ${u[i]}`;
 }
 function formatSpeed(mbps) {
-    if (!mbps) return '';
-    if (mbps>=1000){const g=mbps/1000;return `${g%1===0?g.toFixed(0):g.toFixed(1)} Gbps`;}
+    if(!mbps)return '';
+    if(mbps>=1000){const g=mbps/1000;return `${g%1===0?g.toFixed(0):g.toFixed(1)} Gbps`;}
     return `${mbps} Mbps`;
 }
 
-// ---- Orthogonal path (H→R→V never diagonal) ----
-
-function orthoPath(x1, y1, x2, y2) {
-    const r = G.cornerR;
-    if (Math.abs(x1-x2)<0.5) return `M${x1} ${y1}L${x2} ${y2}`;
-    const midY=(y1+y2)/2, dx=x2-x1, s=dx>0?1:-1, ax=Math.abs(dx), hv=Math.abs(y2-y1)/2;
-    const cr=Math.min(r, ax/2, hv);
-    if (cr<1) return `M${x1} ${y1}L${x1} ${midY}L${x2} ${midY}L${x2} ${y2}`;
-    return `M${x1} ${y1}L${x1} ${midY-cr}Q${x1} ${midY} ${x1+s*cr} ${midY}L${x2-s*cr} ${midY}Q${x2} ${midY} ${x2} ${midY+cr}L${x2} ${y2}`;
+function withAlpha(hex, a) {
+    const [r,g,b] = hexRgb(hex);
+    return `rgba(${r},${g},${b},${a})`;
 }
 
-function orthoLen(x1, y1, x2, y2) {
-    if (Math.abs(x1-x2)<0.5) return Math.abs(y2-y1);
-    const ax=Math.abs(x2-x1), hv=Math.abs(y2-y1)/2, cr=Math.min(G.cornerR, ax/2, hv);
-    if (cr<1) return Math.abs(y2-y1)+ax;
+// ---- Orthogonal path helpers ----
+
+function orthoLen(x1,y1,x2,y2) {
+    if(Math.abs(x1-x2)<0.5)return Math.abs(y2-y1);
+    const ax=Math.abs(x2-x1),hv=Math.abs(y2-y1)/2,cr=Math.min(G.cornerR,ax/2,hv);
+    if(cr<1)return Math.abs(y2-y1)+ax;
     return (hv-cr)*2+Math.PI*cr+(ax-2*cr);
 }
 
-function orthoAt(x1, y1, x2, y2, t) {
+function orthoAt(x1,y1,x2,y2,t) {
     const dy=y2-y1;
-    if (Math.abs(x2-x1)<0.5) return {x:x1, y:y1+dy*t};
-    const midY=(y1+y2)/2, dx=x2-x1, s=dx>0?1:-1, ax=Math.abs(dx), hv=Math.abs(dy)/2;
-    const cr=Math.min(G.cornerR, ax/2, hv);
-    if (cr<1) {
-        const tot=hv+ax+hv; let d=t*tot;
-        if (d<=hv) return {x:x1,y:y1+d}; d-=hv;
-        if (d<=ax) return {x:x1+s*d,y:midY}; d-=ax;
-        return {x:x2,y:midY+d};
-    }
-    const s1=hv-cr, s2=Math.PI/2*cr, s3=ax-2*cr, s4=s2, s5=hv-cr;
-    const tot=s1+s2+s3+s4+s5; let d=t*tot;
-    if (d<=s1) return {x:x1,y:y1+d}; d-=s1;
-    if (d<=s2) {const a=d/s2*Math.PI/2; return {x:x1+s*cr*Math.sin(a),y:midY-cr+cr*(1-Math.cos(a))};} d-=s2;
-    if (d<=s3) return {x:x1+s*(cr+d),y:midY}; d-=s3;
-    if (d<=s4) {const a=d/s4*Math.PI/2; return {x:(x2-s*cr)+s*cr*Math.sin(a),y:midY+cr*(1-Math.cos(a))};} d-=s4;
-    return {x:x2, y:midY+cr+d};
+    if(Math.abs(x2-x1)<0.5)return{x:x1,y:y1+dy*t};
+    const midY=(y1+y2)/2,dx=x2-x1,s=dx>0?1:-1,ax=Math.abs(dx),hv=Math.abs(dy)/2;
+    const cr=Math.min(G.cornerR,ax/2,hv);
+    if(cr<1){const tot=hv+ax+hv;let d=t*tot;if(d<=hv)return{x:x1,y:y1+d};d-=hv;if(d<=ax)return{x:x1+s*d,y:midY};d-=ax;return{x:x2,y:midY+d};}
+    const s1=hv-cr,s2=Math.PI/2*cr,s3=ax-2*cr,s4=s2,s5=hv-cr;
+    const tot=s1+s2+s3+s4+s5;let d=t*tot;
+    if(d<=s1)return{x:x1,y:y1+d};d-=s1;
+    if(d<=s2){const a=d/s2*Math.PI/2;return{x:x1+s*cr*Math.sin(a),y:midY-cr+cr*(1-Math.cos(a))};}d-=s2;
+    if(d<=s3)return{x:x1+s*(cr+d),y:midY};d-=s3;
+    if(d<=s4){const a=d/s4*Math.PI/2;return{x:(x2-s*cr)+s*cr*Math.sin(a),y:midY+cr*(1-Math.cos(a))};}d-=s4;
+    return{x:x2,y:midY+cr+d};
+}
+
+function strokeOrtho(ctx,x1,y1,x2,y2) {
+    const r=G.cornerR;
+    ctx.beginPath();
+    if(Math.abs(x1-x2)<0.5){ctx.moveTo(x1,y1);ctx.lineTo(x2,y2);ctx.stroke();return;}
+    const midY=(y1+y2)/2,dx=x2-x1,s=dx>0?1:-1,ax=Math.abs(dx),hv=Math.abs(y2-y1)/2;
+    const cr=Math.min(r,ax/2,hv);
+    ctx.moveTo(x1,y1);
+    if(cr<1){ctx.lineTo(x1,midY);ctx.lineTo(x2,midY);ctx.lineTo(x2,y2);ctx.stroke();return;}
+    ctx.lineTo(x1,midY-cr);
+    ctx.quadraticCurveTo(x1,midY,x1+s*cr,midY);
+    ctx.lineTo(x2-s*cr,midY);
+    ctx.quadraticCurveTo(x2,midY,x2,midY+cr);
+    ctx.lineTo(x2,y2);
+    ctx.stroke();
 }
 
 // ---- Layout tree ----
-
 class TN {
-    constructor(d) { this.d=d; this.infra=[]; this.clients=[]; this.x=0; this.y=0; this.w=0; }
+    constructor(d){this.d=d;this.infra=[];this.clients=[];this.x=0;this.y=0;this.w=0;}
 }
 
-// ---- Persistent particle stream (mirrors 3D map's ParticleStream) ----
-
-const MAX_DOTS = 10;
-const EMIT_MAX = 10;
-
+// ---- Particle stream (no DOM, just state) ----
 class Stream {
-    constructor(edge, dir, color, layer) {
-        this._edge = edge;
-        this._dir = dir;
-        this._color = color;
-        this._layer = layer;
-        this._density = 0;
-        this._velNorm = 0;
-        this._dotSize = 0.4;
-        this._spawnAcc = 0;
-        this._pathLen = orthoLen(edge._x1, edge._y1, edge._x2, edge._y2);
-        this._slots = [];
-        for (let i = 0; i < MAX_DOTS; i++) {
-            const dot = el('circle', { r: 0.4, fill: color, opacity: 0 }, layer);
-            this._slots.push({ el: dot, t: -1, size: 0 });
-        }
+    constructor(edge,dir,color){
+        this.edge=edge; this.dir=dir; this.color=color;
+        this.density=0; this.velNorm=0; this.dotSize=0.4;
+        this.spawnAcc=0;
+        this.pathLen=orthoLen(edge._x1,edge._y1,edge._x2,edge._y2);
+        this.slots=[];
+        for(let i=0;i<MAX_DOTS;i++)this.slots.push({t:-1,size:0});
     }
-
-    setRate(bps) {
-        const intensity = Math.max(0, Math.min(1, Math.log10(Math.max(bps, 1)) / 11));
-        this._density = intensity;
-        this._dotSize = 0.4 + (intensity * intensity) * 1.2;
-        // Constant visual speed: absolute SVG px/sec divided by path length
-        // (mirrors 3D: velocity = 2.5+intensity*4 scene-units/sec / link-length)
-        const absPxSec = 50 + intensity * 80;
-        this._velNorm = absPxSec / Math.max(this._pathLen, 1);
+    setRate(bps){
+        const intensity=Math.max(0,Math.min(1,Math.log10(Math.max(bps,1))/11));
+        this.density=intensity;
+        this.dotSize=0.4+(intensity*intensity)*1.2;
+        const absPxSec=50+intensity*80;
+        this.velNorm=absPxSec/Math.max(this.pathLen,1);
     }
-
-    advance(dt) {
-        const e = this._edge;
-        // Emit new particles based on density
-        this._spawnAcc += this._density * this._density * EMIT_MAX * dt;
-        while (this._spawnAcc >= 1) {
-            this._spawnAcc -= (0.6 + Math.random() * 0.8);
-            for (const slot of this._slots) {
-                if (slot.t < 0) {
-                    slot.t = this._dir > 0 ? 0 : 1;
-                    slot.size = this._dotSize;
-                    slot.el.setAttribute('r', this._dotSize);
-                    slot.el.setAttribute('opacity', 0.85);
-                    break;
-                }
-            }
+    advance(dt){
+        this.spawnAcc+=this.density*this.density*EMIT_MAX*dt;
+        while(this.spawnAcc>=1){
+            this.spawnAcc-=(0.6+Math.random()*0.8);
+            for(const sl of this.slots){if(sl.t<0){sl.t=this.dir>0?0:1;sl.size=this.dotSize;break;}}
         }
-
-        // Advance existing particles
-        for (const slot of this._slots) {
-            if (slot.t < 0) continue;
-            slot.t += this._velNorm * dt * this._dir;
-            if (slot.t > 1 || slot.t < 0) {
-                slot.t = -1;
-                slot.el.setAttribute('opacity', 0);
-                continue;
-            }
-            const pt = orthoAt(e._x1, e._y1, e._x2, e._y2, slot.t);
-            slot.el.setAttribute('cx', pt.x);
-            slot.el.setAttribute('cy', pt.y);
+        for(const sl of this.slots){
+            if(sl.t<0)continue;
+            sl.t+=this.velNorm*dt*this.dir;
+            if(sl.t>1||sl.t<0){sl.t=-1;continue;}
         }
-    }
-
-    dispose() {
-        for (const slot of this._slots) slot.el.remove();
     }
 }
 
 // ---- Main class ----
-
 class LanFlowMap2D {
-    constructor(container) {
-        this._el = container;
-        this._svg = null;
-        this._gLinks = null;
-        this._gParts = null;
-        this._gNodes = null;
-        this._gLabels = null;
+    constructor(container){
+        this._el=container;
+        this._canvas=null;
+        this._ctx=null;
+        this._dpr=1;
+        this._cw=0; this._ch=0;
 
-        this._root = null;
-        this._treeMap = new Map();
-        this._clouds = [];
-        this._edges = [];
-        this._liveRates = {};
+        this._root=null;
+        this._treeMap=new Map();
+        this._clouds=[];
+        this._edges=[];
+        this._liveRates={};
+        this._streams=[];
+        this._images=new Map();
 
-        this._particles = [];
-        this._animId = 0;
-        this._lastFrame = 0;
-        this._unsub = null;
+        this._animId=0;
+        this._lastFrame=0;
+        this._unsub=null;
+        this._needsStaticRedraw=true;
+        this._staticCanvas=null;
 
-        // Viewport / pan-zoom state
-        this._vx = 0; this._vy = 0; this._vw = 800; this._vh = 600;
-        this._zoom = 1;
-        this._panX = 0; this._panY = 0;
-        this._baseVx = 0; this._baseVy = 0; this._baseVw = 800; this._baseVh = 600;
-        this._dragging = false;
-        this._dragStart = null;
+        // Pan/zoom: offset in world coords + scale
+        this._ox=0; this._oy=0; this._scale=1;
+        this._dragging=false; this._dragStart=null;
+        // World bounds
+        this._bx=0; this._by=0; this._bw=800; this._bh=600;
+
+        this._tooltip=null;
+        this._hoverNode=null;
     }
 
-    async start() {
-        this._createSvg();
-
-        const snap = flowData.getSnapshot();
-        if (snap) {
-            this._liveRates = { ...flowData.getLiveRates() };
+    async start(){
+        this._createCanvas();
+        const snap=flowData.getSnapshot();
+        if(snap){
+            this._liveRates={...flowData.getLiveRates()};
             this._buildLayout(snap);
-            this._renderAll();
+            await this._loadImages(snap);
+            this._fitAll();
+            this._needsStaticRedraw=true;
         }
-
-        this._unsub = flowData.subscribe((ev) => {
-            if (ev === 'snapshot') {
-                const s = flowData.getSnapshot();
-                if (s) {
-                    this._liveRates = { ...flowData.getLiveRates() };
+        this._unsub=flowData.subscribe((ev)=>{
+            if(ev==='snapshot'){
+                const s=flowData.getSnapshot();
+                if(s){
+                    this._liveRates={...flowData.getLiveRates()};
                     this._buildLayout(s);
-                    this._renderAll();
+                    this._loadImages(s).then(()=>{this._fitAll();this._needsStaticRedraw=true;});
                 }
-            } else if (ev === 'live') {
-                Object.assign(this._liveRates, flowData.getLiveRates());
-                this._updateRates();
+            }else if(ev==='live'){
+                Object.assign(this._liveRates,flowData.getLiveRates());
+                this._updateStreamRates();
+                this._updateCloudStats();
             }
         });
-
-        this._lastFrame = performance.now();
+        this._lastFrame=performance.now();
         this._animate();
     }
 
-    dispose() {
+    dispose(){
         cancelAnimationFrame(this._animId);
-        if (this._unsub) this._unsub();
-        if (this._streams) for (const s of this._streams) s.dispose();
-        this._streams = [];
-        this._el.innerHTML = '';
+        if(this._unsub)this._unsub();
+        if(this._resizeObs)this._resizeObs.disconnect();
+        this._streams=[];
+        this._el.innerHTML='';
     }
 
-    // ---- SVG skeleton ----
+    // ---- Canvas setup ----
 
-    _createSvg() {
-        this._el.innerHTML = '';
-        const s = el('svg', { xmlns: NS, 'preserveAspectRatio': 'xMidYMin meet', class: 'lfm2d' }, this._el);
-        this._svg = s;
+    _createCanvas(){
+        this._el.innerHTML='';
+        const canvas=document.createElement('canvas');
+        canvas.className='lfm2d-canvas';
+        canvas.style.width='100%';
+        canvas.style.height='100%';
+        canvas.style.display='block';
+        canvas.style.cursor='grab';
+        this._el.appendChild(canvas);
+        this._canvas=canvas;
+        this._ctx=canvas.getContext('2d');
 
-        const defs = el('defs', null, s);
-        // Glow for particles
-        const pg = el('filter', { id: 'pg', x:'-80%', y:'-80%', width:'260%', height:'260%' }, defs);
-        el('feGaussianBlur', { in:'SourceGraphic', stdDeviation:'2.5', result:'b' }, pg);
-        const m = el('feMerge', null, pg);
-        el('feMergeNode', { in:'b' }, m);
-        el('feMergeNode', { in:'SourceGraphic' }, m);
+        this._staticCanvas=document.createElement('canvas');
 
-        this._gLinks = el('g', { class:'links' }, s);
-        this._gParts = el('g', { class:'particles' }, s);
-        this._gNodes = el('g', { class:'nodes' }, s);
-        this._gLabels = el('g', { class:'labels' }, s);
+        // Tooltip div
+        this._tooltip=document.createElement('div');
+        this._tooltip.className='lfm2d-tooltip';
+        this._el.appendChild(this._tooltip);
 
-        // Pan/zoom events
-        s.addEventListener('wheel', (e) => this._onWheel(e), { passive: false });
-        s.addEventListener('pointerdown', (e) => this._onPointerDown(e));
-        s.addEventListener('pointermove', (e) => this._onPointerMove(e));
-        s.addEventListener('pointerup', (e) => this._onPointerUp(e));
-        s.addEventListener('pointerleave', (e) => this._onPointerUp(e));
+        // Toolbar
+        const tb=document.createElement('div');
+        tb.className='lfm2d-toolbar';
+        tb.innerHTML=`<button class="lfm2d-btn" data-action="zin" title="Zoom in">+</button>`
+            +`<button class="lfm2d-btn" data-action="zout" title="Zoom out">&minus;</button>`
+            +`<button class="lfm2d-btn" data-action="fit" title="Fit all">&#x2922;</button>`;
+        tb.addEventListener('click',(e)=>{
+            const a=e.target.closest('[data-action]')?.dataset.action;
+            if(a==='zin')this._zoomBy(1.3);
+            else if(a==='zout')this._zoomBy(1/1.3);
+            else if(a==='fit')this._fitAll();
+        });
+        this._el.appendChild(tb);
+
+        // Events
+        canvas.addEventListener('wheel',(e)=>this._onWheel(e),{passive:false});
+        canvas.addEventListener('pointerdown',(e)=>this._onDown(e));
+        canvas.addEventListener('pointermove',(e)=>this._onMove(e));
+        canvas.addEventListener('pointerup',(e)=>this._onUp(e));
+        canvas.addEventListener('pointerleave',(e)=>{this._onUp(e);this._hideTooltip();});
+
+        // Resize
+        this._resizeObs=new ResizeObserver(()=>this._resize());
+        this._resizeObs.observe(this._el);
+        this._resize();
+    }
+
+    _resize(){
+        const rect=this._el.getBoundingClientRect();
+        this._dpr=window.devicePixelRatio||1;
+        this._cw=rect.width; this._ch=rect.height;
+        this._canvas.width=rect.width*this._dpr;
+        this._canvas.height=rect.height*this._dpr;
+        this._staticCanvas.width=this._canvas.width;
+        this._staticCanvas.height=this._canvas.height;
+        this._needsStaticRedraw=true;
     }
 
     // ---- Pan / Zoom ----
 
-    _onWheel(e) {
+    _screenToWorld(sx,sy){
+        return{x:(sx-this._cw/2)/this._scale+this._ox, y:(sy-this._ch/2)/this._scale+this._oy};
+    }
+
+    _onWheel(e){
         e.preventDefault();
-        const rect = this._svg.getBoundingClientRect();
-        const mx = (e.clientX - rect.left) / rect.width;
-        const my = (e.clientY - rect.top) / rect.height;
-
-        const step = 1 + Math.min(Math.abs(e.deltaY), 100) * 0.001;
-        const factor = e.deltaY > 0 ? step : 1 / step;
-        const nw = this._vw * factor;
-        const nh = this._vh * factor;
-
-        // Zoom toward mouse position
-        this._vx += (this._vw - nw) * mx;
-        this._vy += (this._vh - nh) * my;
-        this._vw = nw;
-        this._vh = nh;
-        this._applyViewBox();
+        const rect=this._canvas.getBoundingClientRect();
+        const sx=e.clientX-rect.left, sy=e.clientY-rect.top;
+        const wBefore=this._screenToWorld(sx,sy);
+        const step=1+Math.min(Math.abs(e.deltaY),100)*0.002;
+        const factor=e.deltaY<0?step:1/step;
+        this._scale=Math.max(0.05,Math.min(10,this._scale*factor));
+        const wAfter=this._screenToWorld(sx,sy);
+        this._ox+=wBefore.x-wAfter.x;
+        this._oy+=wBefore.y-wAfter.y;
+        this._needsStaticRedraw=true;
     }
 
-    _onPointerDown(e) {
-        if (e.button !== 0) return;
-        this._dragging = true;
-        this._dragStart = { x: e.clientX, y: e.clientY, vx: this._vx, vy: this._vy };
-        this._svg.style.cursor = 'grabbing';
-        this._svg.setPointerCapture(e.pointerId);
+    _onDown(e){
+        if(e.button!==0)return;
+        this._dragging=true;
+        this._dragStart={x:e.clientX,y:e.clientY,ox:this._ox,oy:this._oy};
+        this._canvas.style.cursor='grabbing';
+        this._canvas.setPointerCapture(e.pointerId);
     }
 
-    _onPointerMove(e) {
-        if (!this._dragging || !this._dragStart) return;
-        const rect = this._svg.getBoundingClientRect();
-        const sx = this._vw / rect.width;
-        const sy = this._vh / rect.height;
-        this._vx = this._dragStart.vx - (e.clientX - this._dragStart.x) * sx;
-        this._vy = this._dragStart.vy - (e.clientY - this._dragStart.y) * sy;
-        this._applyViewBox();
+    _onMove(e){
+        const rect=this._canvas.getBoundingClientRect();
+        const sx=e.clientX-rect.left, sy=e.clientY-rect.top;
+        if(this._dragging&&this._dragStart){
+            const dx=(e.clientX-this._dragStart.x)/this._scale;
+            const dy=(e.clientY-this._dragStart.y)/this._scale;
+            this._ox=this._dragStart.ox-dx;
+            this._oy=this._dragStart.oy-dy;
+            this._needsStaticRedraw=true;
+        } else {
+            this._hitTest(sx,sy);
+        }
     }
 
-    _onPointerUp(e) {
-        if (!this._dragging) return;
-        this._dragging = false;
-        this._dragStart = null;
-        this._svg.style.cursor = 'grab';
+    _onUp(){
+        if(!this._dragging)return;
+        this._dragging=false;
+        this._dragStart=null;
+        this._canvas.style.cursor='grab';
     }
 
-    _applyViewBox() {
-        this._svg.setAttribute('viewBox', `${this._vx} ${this._vy} ${this._vw} ${this._vh}`);
+    _fitAll(){
+        if(!this._root)return;
+        const margin=40;
+        const sx=(this._cw-margin*2)/this._bw;
+        const sy=(this._ch-margin*2)/this._bh;
+        this._scale=Math.min(sx,sy,2);
+        this._ox=this._bx+this._bw/2;
+        this._oy=this._by+this._bh/2;
+        this._needsStaticRedraw=true;
     }
 
-    _fitAll() {
-        this._vx = this._baseVx;
-        this._vy = this._baseVy;
-        this._vw = this._baseVw;
-        this._vh = this._baseVh;
-        this._applyViewBox();
+    _zoomBy(factor){
+        this._scale=Math.max(0.05,Math.min(10,this._scale*factor));
+        this._needsStaticRedraw=true;
     }
 
-    // ---- Layout ----
+    // ---- Tooltip hit-test ----
 
-    _buildLayout(snap) {
-        const byId = new Map();
-        for (const n of snap.nodes) byId.set(n.id, new TN(n));
-        this._treeMap = byId;
+    _hitTest(sx,sy){
+        const w=this._screenToWorld(sx,sy);
+        let hit=null;
 
-        // Build adjacency from LINKS (not parentId - parentId is sparse).
-        // This mirrors how the 3D map determines connectivity.
-        const adj = new Map();
-        for (const lk of snap.links) {
-            if (lk.kind === LK.Wan || lk.kind === LK.Transit) continue;
-            const a = lk.fromNodeId, b = lk.toNodeId;
-            if (!byId.has(a) || !byId.has(b)) continue;
-            if (!adj.has(a)) adj.set(a, []);
-            if (!adj.has(b)) adj.set(b, []);
-            adj.get(a).push({ to: b, lk });
-            adj.get(b).push({ to: a, lk });
+        const checkNode=(n)=>{
+            if(Math.abs(w.x-n.x)<G.boxW/2&&Math.abs(w.y-n.y)<G.boxH/2)hit=n;
+            for(const c of n.infra)checkNode(c);
+            for(const c of n.clients.slice(0,G.maxClients)){
+                if(Math.abs(w.x-c.x)<G.clientCellW/2&&Math.abs(w.y-c.y)<G.clientCellH/2)hit=c;
+            }
+        };
+        if(this._root)checkNode(this._root);
+
+        if(hit&&hit!==this._hoverNode){
+            this._hoverNode=hit;
+            const name=hit.d.name||hit.d.ip||hit.d.mac||'';
+            if(name){
+                this._tooltip.textContent=name;
+                this._tooltip.style.display='block';
+                this._tooltip.style.left=(sx+12)+'px';
+                this._tooltip.style.top=(sy-8)+'px';
+            }
+        } else if(!hit){
+            this._hideTooltip();
+        }
+    }
+
+    _hideTooltip(){
+        this._hoverNode=null;
+        if(this._tooltip)this._tooltip.style.display='none';
+    }
+
+    // ---- Layout (identical to SVG version) ----
+
+    _buildLayout(snap){
+        const byId=new Map();
+        for(const n of snap.nodes)byId.set(n.id,new TN(n));
+        this._treeMap=byId;
+
+        const adj=new Map();
+        for(const lk of snap.links){
+            if(lk.kind===LK.Wan||lk.kind===LK.Transit)continue;
+            const a=lk.fromNodeId,b=lk.toNodeId;
+            if(!byId.has(a)||!byId.has(b))continue;
+            if(!adj.has(a))adj.set(a,[]);
+            if(!adj.has(b))adj.set(b,[]);
+            adj.get(a).push({to:b,lk});
+            adj.get(b).push({to:a,lk});
         }
 
-        // BFS from gateway to build tree
-        let root = null;
-        for (const [, tn] of byId) {
-            if (tn.d.kind === NK.Gateway) { root = tn; break; }
-        }
-        this._root = root;
+        let root=null;
+        for(const[,tn]of byId){if(tn.d.kind===NK.Gateway){root=tn;break;}}
+        this._root=root;
 
-        if (root) {
-            const visited = new Set([root.d.id]);
-            const queue = [root];
-            while (queue.length > 0) {
-                const par = queue.shift();
-                for (const { to } of (adj.get(par.d.id) || [])) {
-                    if (visited.has(to)) continue;
+        if(root){
+            const visited=new Set([root.d.id]);
+            const queue=[root];
+            while(queue.length>0){
+                const par=queue.shift();
+                for(const{to}of(adj.get(par.d.id)||[])){
+                    if(visited.has(to))continue;
                     visited.add(to);
-                    const child = byId.get(to);
-                    if (!child) continue;
-                    if (isClient(child.d.kind)) {
-                        par.clients.push(child);
-                    } else {
-                        par.infra.push(child);
-                        queue.push(child);
-                    }
+                    const child=byId.get(to);
+                    if(!child)continue;
+                    if(isClient(child.d.kind))par.clients.push(child);
+                    else{par.infra.push(child);queue.push(child);}
                 }
             }
         }
 
-        this._clouds = (snap.clouds||[]).map(c => ({ d:c, x:0, y:0 }));
+        this._clouds=(snap.clouds||[]).map(c=>({d:c,x:0,y:0}));
+        this._edges=[];
+        for(const lk of snap.links)this._edges.push({lk,fn:byId.get(lk.fromNodeId),tn:byId.get(lk.toNodeId)});
 
-        this._edges = [];
-        for (const lk of snap.links) {
-            this._edges.push({ lk, fn: byId.get(lk.fromNodeId), tn: byId.get(lk.toNodeId) });
-        }
-
-        if (!root) return;
+        if(!root)return;
         this._widths(root);
-        this._positions(root, G.pad, 0);
+        this._positions(root,G.pad,0);
         this._placeClouds();
-    }
-
-    _widths(n) {
-        let iw = 0;
-        for (const c of n.infra) { this._widths(c); iw += c.w; }
-        if (n.infra.length > 1) iw += (n.infra.length - 1) * G.infraGap;
-
-        const nc = Math.min(n.clients.length, G.maxClients);
-        const cols = Math.min(nc, G.clientCols);
-        const rows = Math.ceil(nc / Math.max(cols, 1));
-        const cw = cols > 0 ? cols * G.clientCellW : 0;
-
-        const self = isClient(n.d.kind) ? G.clientCellW : G.boxW + 30;
-        // Sum infra + client widths so each subtree gets its own space
-        let childW = 0;
-        if (iw > 0 && cw > 0) childW = iw + G.infraGap + cw;
-        else childW = iw + cw;
-
-        n.w = Math.max(self, childW);
-    }
-
-    _positions(n, lx, depth) {
-        const yOff = G.pad + 80;
-        n.y = yOff + depth * G.tierGap;
-
-        if (n.infra.length === 0 && n.clients.length === 0) {
-            n.x = lx + n.w / 2;
-            return;
-        }
-
-        // Compute sub-widths
-        let iw = n.infra.reduce((s, c) => s + c.w, 0);
-        if (n.infra.length > 1) iw += (n.infra.length - 1) * G.infraGap;
-        const nc = Math.min(n.clients.length, G.maxClients);
-        const cols = Math.min(nc, G.clientCols);
-        const cw = cols > 0 ? cols * G.clientCellW : 0;
-
-        let combW = 0;
-        if (iw > 0 && cw > 0) combW = iw + G.infraGap + cw;
-        else combW = iw + cw;
-
-        // All children at depth+1 - infra first, then clients right
-        let cur = lx + (n.w - combW) / 2;
-
-        for (const c of n.infra) {
-            this._positions(c, cur, depth + 1);
-            cur += c.w + G.infraGap;
-        }
-
-        const clientY = yOff + (depth + 1) * G.tierGap;
-        for (let i = 0; i < nc; i++) {
-            const col = i % cols, row = Math.floor(i / cols);
-            const cn = n.clients[i];
-            cn.x = cur + col * G.clientCellW + G.clientCellW / 2;
-            cn.y = clientY + row * G.clientCellH;
-        }
-
-        // Center parent over ALL children
-        const allK = [...n.infra, ...n.clients.slice(0, nc)];
-        if (allK.length > 0) {
-            n.x = (Math.min(...allK.map(c => c.x)) + Math.max(...allK.map(c => c.x))) / 2;
-        } else {
-            n.x = lx + n.w / 2;
-        }
-    }
-
-    _placeClouds() {
-        if (!this._root || this._clouds.length === 0) return;
-        const gx = this._root.x, gy = this._root.y;
-        const total = this._clouds.length, sp = G.cloudGap;
-        const sx = gx - ((total - 1) * sp) / 2;
-        for (let i = 0; i < total; i++) {
-            this._clouds[i].x = sx + i * sp;
-            this._clouds[i].y = gy - G.tierGap;
-        }
-    }
-
-    // ---- Render ----
-
-    _renderAll() {
-        if (this._streams) for (const s of this._streams) s.dispose();
-        this._streams = [];
-        this._gLinks.innerHTML = '';
-        this._gNodes.innerHTML = '';
-        this._gParts.innerHTML = '';
-        this._gLabels.innerHTML = '';
-
-        if (!this._root) return;
-
-        this._calcViewBox();
-        this._drawCloudLinks();
-        this._drawTreeLinks(this._root);
-        this._drawClouds();
-        this._drawTree(this._root);
+        this._matchEdges();
         this._initStreams();
-        this._drawToolbar();
-        this._updateRates();
-        this._svg.style.cursor = 'grab';
+        this._calcBounds();
+        this._updateStreamRates();
     }
 
-    _calcViewBox() {
-        let x0=Infinity, y0=Infinity, x1=-Infinity, y1=-Infinity;
-        const exp = (x, y, r) => { x0=Math.min(x0,x-r); y0=Math.min(y0,y-r); x1=Math.max(x1,x+r); y1=Math.max(y1,y+r); };
-        const vis = (n) => {
-            exp(n.x, n.y, G.boxW);
-            for (const c of n.infra) vis(c);
-            for (const c of n.clients.slice(0, G.maxClients)) exp(c.x, c.y, G.clientCellW / 2);
-        };
-        vis(this._root);
-        for (const c of this._clouds) exp(c.x, c.y, G.cloudR + 30);
+    _widths(n){
+        // Compute each infra child's width first
+        for(const c of n.infra)this._widths(c);
 
-        const p = G.pad;
-        this._baseVx = x0 - p;
-        this._baseVy = y0 - p;
-        this._baseVw = (x1 - x0) + p * 2;
-        this._baseVh = (y1 - y0) + p * 2 + 50;
-        this._fitAll();
+        // Infra children: max 3 per row, rows stacked vertically
+        const INFRA_COLS = 3;
+        let maxRowW = 0;
+        for(let i=0;i<n.infra.length;i+=INFRA_COLS){
+            const row=n.infra.slice(i,i+INFRA_COLS);
+            let rw=row.reduce((s,c)=>s+c.w,0);
+            if(row.length>1)rw+=(row.length-1)*G.infraGap;
+            maxRowW=Math.max(maxRowW,rw);
+        }
+
+        const nc=Math.min(n.clients.length,G.maxClients);
+        const cols=Math.min(nc,G.clientCols);
+        const cw=cols>0?cols*G.clientCellW:0;
+        const self=isClient(n.d.kind)?G.clientCellW:G.boxW+30;
+        let childW=0;
+        if(maxRowW>0&&cw>0)childW=maxRowW+G.infraGap+cw;
+        else childW=maxRowW+cw;
+        n.w=Math.max(self,childW);
     }
 
-    // ---- Cloud links ----
+    _positions(n,lx,depth){
+        const yOff=G.pad+80;
+        n.y=yOff+depth*G.tierGap;
+        if(n.infra.length===0&&n.clients.length===0){n.x=lx+n.w/2;return;}
 
-    _drawCloudLinks() {
-        if (!this._root) return;
-        const gw = this._root, gwT = gw.y - G.boxH / 2;
+        const INFRA_COLS=3;
+        const infraRows=[];
+        for(let i=0;i<n.infra.length;i+=INFRA_COLS)infraRows.push(n.infra.slice(i,i+INFRA_COLS));
+        const infraRowCount=infraRows.length;
 
-        for (const cloud of this._clouds) {
-            const cy = cloud.y + G.cloudR + 8;
-            const edge = this._edges.find(e =>
-                (e.lk.kind === LK.Wan || e.lk.kind === LK.Transit)
-                && (e.lk.fromNodeId === cloud.d.id || e.lk.toNodeId === cloud.d.id));
+        const nc=Math.min(n.clients.length,G.maxClients);
+        const cols=Math.min(nc,G.clientCols);
+        const cw=cols>0?cols*G.clientCellW:0;
 
-            const d = orthoPath(cloud.x, cy, gw.x, gwT);
-            const pe = el('path', { d, fill:'none', stroke:C.pipeCool,
-                'stroke-width': edge ? pipeW(edge.lk.capacityBps) : G.pipeBase,
-                'stroke-linecap':'round', opacity:'0.65' }, this._gLinks);
+        // Compute infra max row width for centering
+        let maxRowW=0;
+        for(const row of infraRows){
+            let rw=row.reduce((s,c)=>s+c.w,0);
+            if(row.length>1)rw+=(row.length-1)*G.infraGap;
+            maxRowW=Math.max(maxRowW,rw);
+        }
 
-            if (edge) {
-                edge._pe = pe;
-                edge._x1 = cloud.x; edge._y1 = cy;
-                edge._x2 = gw.x; edge._y2 = gwT;
-                edge._isWan = true;
+        let combW=0;
+        if(maxRowW>0&&cw>0)combW=maxRowW+G.infraGap+cw;
+        else combW=maxRowW+cw;
 
-                // WAN live rate label
-                const midX = (cloud.x + gw.x) / 2;
-                const midY = (cy + gwT) / 2 + 12;
-                const rg = el('g', { transform:`translate(${midX},${midY})`, class:'rate-lbl' }, this._gLabels);
-                const rbg = el('rect', { x:-50, y:-8, width:100, height:16, rx:4, fill:C.labelBg, opacity:0 }, rg);
-                const rd = el('text', { x:-3, y:4, 'text-anchor':'end', fill:C.downstream,
-                    'font-size':G.rateFont, 'font-family':'system-ui,sans-serif' }, rg);
-                const ru = el('text', { x:3, y:4, 'text-anchor':'start', fill:C.upstream,
-                    'font-size':G.rateFont, 'font-family':'system-ui,sans-serif' }, rg);
-                edge._rlG = rg; edge._rlBg = rbg; edge._rlD = rd; edge._rlU = ru;
+        // Place infra children in rows of 3
+        for(let ri=0;ri<infraRows.length;ri++){
+            const row=infraRows[ri];
+            let rw=row.reduce((s,c)=>s+c.w,0);
+            if(row.length>1)rw+=(row.length-1)*G.infraGap;
+            let cur=lx+(n.w-combW)/2+(maxRowW-rw)/2;
+            const childDepth=depth+1+ri;
+            for(const c of row){this._positions(c,cur,childDepth);cur+=c.w+G.infraGap;}
+        }
+
+        // Place clients to the right of infra
+        const clientStartX=lx+(n.w-combW)/2+(maxRowW>0?maxRowW+G.infraGap:0);
+        const clientY=yOff+(depth+1)*G.tierGap;
+        for(let i=0;i<nc;i++){
+            const col=i%cols,row=Math.floor(i/cols);
+            n.clients[i].x=clientStartX+col*G.clientCellW+G.clientCellW/2;
+            n.clients[i].y=clientY+row*G.clientCellH;
+        }
+
+        // Center parent over first row of infra + clients
+        const firstRowKids=[...(infraRows[0]||[]),...n.clients.slice(0,nc)];
+        if(firstRowKids.length>0)n.x=(Math.min(...firstRowKids.map(c=>c.x))+Math.max(...firstRowKids.map(c=>c.x)))/2;
+        else n.x=lx+n.w/2;
+    }
+
+    _placeClouds(){
+        if(!this._root||this._clouds.length===0)return;
+        const gx=this._root.x,gy=this._root.y;
+        const total=this._clouds.length,sp=G.cloudGap;
+        const sx=gx-((total-1)*sp)/2;
+        for(let i=0;i<total;i++){this._clouds[i].x=sx+i*sp;this._clouds[i].y=gy-G.tierGap;}
+    }
+
+    _matchEdges(){
+        const gw=this._root;
+        if(!gw)return;
+        const gwT=gw.y-G.boxH/2;
+
+        // Match edges to their drawn endpoints
+        for(const cloud of this._clouds){
+            const cy=cloud.y+G.cloudR+8;
+            const edge=this._edges.find(e=>
+                (e.lk.kind===LK.Wan||e.lk.kind===LK.Transit)
+                &&(e.lk.fromNodeId===cloud.d.id||e.lk.toNodeId===cloud.d.id));
+            if(edge){edge._x1=cloud.x;edge._y1=cy;edge._x2=gw.x;edge._y2=gwT;edge._isWan=true;}
+        }
+
+        const matchTree=(n)=>{
+            const pB=n.y+G.boxH/2;
+            for(const c of n.infra){
+                const cT=c.y-G.boxH/2;
+                const edge=this._edges.find(e=>
+                    (e.lk.fromNodeId===n.d.id&&e.lk.toNodeId===c.d.id)
+                    ||(e.lk.fromNodeId===c.d.id&&e.lk.toNodeId===n.d.id));
+                if(edge){edge._x1=n.x;edge._y1=pB;edge._x2=c.x;edge._y2=cT;edge._isCl=false;}
+                matchTree(c);
             }
-        }
+            for(const c of n.clients.slice(0,G.maxClients)){
+                const cT=c.y-G.clientR;
+                const edge=this._edges.find(e=>
+                    (e.lk.fromNodeId===n.d.id&&e.lk.toNodeId===c.d.id)
+                    ||(e.lk.fromNodeId===c.d.id&&e.lk.toNodeId===n.d.id));
+                if(edge){edge._x1=n.x;edge._y1=pB;edge._x2=c.x;edge._y2=cT;edge._isCl=true;edge._band=edge.lk.band;}
+            }
+        };
+        matchTree(gw);
+    }
 
-        // Transit links between clouds
-        const sc = [...this._clouds].sort((a, b) => a.d.order - b.d.order);
-        for (let i = 0; i < sc.length - 1; i++) {
-            const a = sc[i], b = sc[i + 1];
-            const edge = this._edges.find(e =>
-                e.lk.kind === LK.Transit
-                && ((e.lk.fromNodeId === a.d.id && e.lk.toNodeId === b.d.id)
-                    || (e.lk.fromNodeId === b.d.id && e.lk.toNodeId === a.d.id)));
-            if (!edge) continue;
-            const pe = el('path', {
-                d: `M${a.x+G.cloudR+4} ${a.y}L${b.x-G.cloudR-4} ${b.y}`,
-                fill:'none', stroke:C.pipeCool, 'stroke-width':G.pipeBase,
-                'stroke-linecap':'round', 'stroke-dasharray':'6 4', opacity:'0.45'
-            }, this._gLinks);
-            edge._pe = pe;
-            edge._x1 = a.x+G.cloudR+4; edge._y1 = a.y;
-            edge._x2 = b.x-G.cloudR-4; edge._y2 = b.y;
+    _initStreams(){
+        this._streams=[];
+        for(const e of this._edges){
+            if(e._x1==null)continue;
+            const len=orthoLen(e._x1,e._y1,e._x2,e._y2);
+            if(len<5)continue;
+            e._sDown=new Stream(e,1,C.downstream);
+            e._sUp=new Stream(e,-1,C.upstream);
+            this._streams.push(e._sDown,e._sUp);
         }
     }
 
-    // ---- Tree links ----
-
-    _drawTreeLinks(n) {
-        const pB = n.y + G.boxH / 2;
-        for (const c of n.infra) {
-            this._drawLink(n, c, pB, c.y - G.boxH / 2, false);
-            this._drawTreeLinks(c);
-        }
-        for (const c of n.clients.slice(0, G.maxClients)) {
-            this._drawLink(n, c, pB, c.y - G.clientR, true);
-        }
+    _calcBounds(){
+        let x0=Infinity,y0=Infinity,x1=-Infinity,y1=-Infinity;
+        const exp=(x,y,r)=>{x0=Math.min(x0,x-r);y0=Math.min(y0,y-r);x1=Math.max(x1,x+r);y1=Math.max(y1,y+r);};
+        const vis=(n)=>{exp(n.x,n.y,G.boxW+20);for(const c of n.infra)vis(c);for(const c of n.clients.slice(0,G.maxClients))exp(c.x,c.y,G.clientCellW/2);};
+        vis(this._root);
+        for(const c of this._clouds)exp(c.x,c.y,G.cloudR+40);
+        this._bx=x0-G.pad; this._by=y0-G.pad;
+        this._bw=(x1-x0)+G.pad*2; this._bh=(y1-y0)+G.pad*2+30;
     }
 
-    _drawLink(par, child, y1, y2, isCl) {
-        const edge = this._edges.find(e =>
-            (e.lk.fromNodeId === par.d.id && e.lk.toNodeId === child.d.id)
-            || (e.lk.fromNodeId === child.d.id && e.lk.toNodeId === par.d.id));
+    // ---- Image preloading ----
 
-        const band = edge?.lk.band;
-        const cool = bandClr(band) || C.pipeCool;
-
-        const d = orthoPath(par.x, y1, child.x, y2);
-        const pe = el('path', { d, fill:'none', stroke:cool,
-            'stroke-width': edge ? pipeW(edge.lk.capacityBps) : G.pipeBase,
-            'stroke-linecap':'round', opacity: isCl ? '0.3' : '0.55' }, this._gLinks);
-
-        if (edge) {
-            edge._pe = pe; edge._x1 = par.x; edge._y1 = y1;
-            edge._x2 = child.x; edge._y2 = y2;
-            edge._isCl = isCl; edge._band = band;
+    async _loadImages(snap){
+        const models=new Set();
+        for(const n of snap.nodes){
+            if(n.model&&isInfra(n.kind))models.add(n.model.toLowerCase().replace(/ /g,'-'));
         }
-
-        if (!isCl && edge?.lk.capacityBps) {
-            const cap = edge.lk.capacityBps / 1e6;
-            if (cap > 0) this._capLabel((par.x + child.x) / 2, (y1 + y2) / 2, formatSpeed(cap));
+        const promises=[];
+        for(const m of models){
+            if(this._images.has(m))continue;
+            promises.push(new Promise(resolve=>{
+                const img=new Image();
+                img.onload=()=>{this._images.set(m,img);resolve();};
+                img.onerror=()=>resolve();
+                img.src=`/images/devices/${m}.png`;
+            }));
         }
-
-        // Live rate label (updated dynamically) for non-client links
-        if (!isCl && edge) {
-            const midX = (par.x + child.x) / 2;
-            const midY = (y1 + y2) / 2 + 12;
-            const rg = el('g', { transform:`translate(${midX},${midY})`, class:'rate-lbl' }, this._gLabels);
-            const rbg = el('rect', { x:-50, y:-8, width:100, height:16, rx:4, fill:C.labelBg, opacity:0 }, rg);
-            const rd = el('text', { x:-3, y:4, 'text-anchor':'end', fill:C.downstream,
-                'font-size':G.rateFont, 'font-family':'system-ui,sans-serif' }, rg);
-            const ru = el('text', { x:3, y:4, 'text-anchor':'start', fill:C.upstream,
-                'font-size':G.rateFont, 'font-family':'system-ui,sans-serif' }, rg);
-            edge._rlG = rg; edge._rlBg = rbg; edge._rlD = rd; edge._rlU = ru;
-        }
-    }
-
-    _capLabel(x, y, txt) {
-        const g = el('g', { transform:`translate(${x},${y})` }, this._gLabels);
-        const tw = txt.length * 5.5 + 12;
-        el('rect', { x:-tw/2, y:-8, width:tw, height:16, rx:4, fill:C.labelBg }, g);
-        const t = el('text', { x:0, y:4, 'text-anchor':'middle', fill:C.textMuted,
-            'font-size':G.rateFont, 'font-family':'system-ui,sans-serif' }, g);
-        t.textContent = txt;
-    }
-
-    // ---- Cloud nodes ----
-
-    _drawClouds() {
-        for (const cloud of this._clouds) {
-            const g = el('g', { transform:`translate(${cloud.x},${cloud.y})` }, this._gNodes);
-            const r = G.cloudR;
-
-            // Blue wireframe globe
-            el('circle', { cx:0, cy:0, r, fill:'none', stroke:C.globeStroke, 'stroke-width':1.5, opacity:0.8 }, g);
-            el('ellipse', { cx:0, cy:0, rx:r*0.45, ry:r, fill:'none', stroke:C.globeStroke, 'stroke-width':1, opacity:0.35 }, g);
-            el('ellipse', { cx:0, cy:0, rx:r, ry:r*0.35, fill:'none', stroke:C.globeStroke, 'stroke-width':1, opacity:0.35 }, g);
-            el('ellipse', { cx:0, cy:0, rx:r, ry:r*0.65, fill:'none', stroke:C.globeStroke, 'stroke-width':0.7, opacity:0.2 }, g);
-            el('circle', { cx:0, cy:0, r:r-1, fill:C.globeStroke, opacity:0.05 }, g);
-
-            const name = cloud.d.asnName || cloud.d.name || 'WAN';
-            const lb = el('text', { x:0, y:r+18, 'text-anchor':'middle', fill:C.textSec,
-                'font-size':G.nameFont, 'font-family':'system-ui,sans-serif', 'font-weight':500 }, g);
-            lb.textContent = name;
-
-            cloud._rtt = el('text', { x:0, y:r+31, 'text-anchor':'middle', fill:C.textMuted,
-                'font-size':G.rateFont-1, 'font-family':'system-ui,sans-serif' }, g);
-            this._cloudBadge(cloud);
-        }
-    }
-
-    _cloudBadge(c) {
-        if (!c._rtt) return;
-        const d = c.d; let t = '';
-        if (d.rttAvgMs != null) t += `${d.rttAvgMs.toFixed(1)} ms`;
-        if (d.lossPercent && d.lossPercent > 0) t += (t ? ' / ' : '') + `${d.lossPercent.toFixed(1)}% loss`;
-        c._rtt.textContent = t;
-    }
-
-    // ---- Infrastructure + client nodes ----
-
-    _drawTree(n) {
-        this._drawInfra(n);
-        for (const c of n.infra) this._drawTree(c);
-        for (const c of n.clients.slice(0, G.maxClients)) this._drawClient(c);
-        if (n.clients.length > G.maxClients) {
-            const last = n.clients[G.maxClients - 1];
-            const extra = n.clients.length - G.maxClients;
-            const t = el('text', { x:last.x + G.clientR + 10, y:last.y + 4,
-                fill:C.textMuted, 'font-size':G.rateFont, 'font-family':'system-ui,sans-serif' }, this._gLabels);
-            t.textContent = `+${extra}`;
-        }
-    }
-
-    _drawInfra(n) {
-        const g = el('g', { transform:`translate(${n.x},${n.y})`, class:'inf' }, this._gNodes);
-        const color = nodeClr(n.d.kind);
-        const hw = G.boxW / 2, hh = G.boxH / 2;
-
-        // Glow
-        el('rect', { x:-hw-5, y:-hh-5, width:G.boxW+10, height:G.boxH+10,
-            rx:14, fill:color, opacity:0.07 }, g);
-
-        // Card
-        el('rect', { x:-hw, y:-hh, width:G.boxW, height:G.boxH, rx:10,
-            fill:'#1a1d23', stroke:color, 'stroke-width':1.5,
-            opacity: n.d.online ? 1 : 0.35 }, g);
-
-        // Device icon (large, fills the card)
-        const iSz = G.iconSize;
-        if (n.d.model) {
-            const path = `/images/devices/${n.d.model.toLowerCase().replace(/ /g, '-')}.png`;
-            const img = el('image', { href:path, x:-iSz/2, y:-iSz/2, width:iSz, height:iSz,
-                opacity: n.d.online ? 1 : 0.35 }, g);
-            img.addEventListener('error', () => { img.remove(); this._fallback(g, n, color); }, { once: true });
-        } else {
-            this._fallback(g, n, color);
-        }
-
-        // Name
-        const name = n.d.name || n.d.model || '';
-        if (name) {
-            const dn = name.length > 16 ? name.slice(0, 15) + '…' : name;
-            const t = el('text', { x:0, y:hh+17, 'text-anchor':'middle', fill:C.text,
-                'font-size':G.nameFont, 'font-family':'system-ui,sans-serif', 'font-weight':500 }, g);
-            t.textContent = dn;
-        }
-
-        // Rate label area
-        n._rd = el('text', { x:-3, y:hh+31, 'text-anchor':'end', fill:C.downstream,
-            'font-size':G.rateFont, 'font-family':'system-ui,sans-serif' }, g);
-        n._ru = el('text', { x:3, y:hh+31, 'text-anchor':'start', fill:C.upstream,
-            'font-size':G.rateFont, 'font-family':'system-ui,sans-serif' }, g);
-    }
-
-    _fallback(g, n, color) {
-        const s = G.iconSize / 2 - 6;
-        el('rect', { x:-s, y:-s, width:s*2, height:s*2, rx:6, fill:color, opacity:0.2 }, g);
-        const t = el('text', { x:0, y:6, 'text-anchor':'middle', fill:color,
-            'font-size':18, 'font-weight':600, 'font-family':'system-ui,sans-serif' }, g);
-        t.textContent = (n.d.name || 'D').charAt(0).toUpperCase();
-    }
-
-    _drawClient(n) {
-        const g = el('g', { transform:`translate(${n.x},${n.y})`, class:'cl' }, this._gNodes);
-        const color = nodeClr(n.d.kind, n.d.band);
-        const r = G.clientR;
-        const op = n.d.online ? 0.7 : 0.2;
-
-        if (n.d.kind === NK.WifiClient) {
-            el('circle', { cx:0, cy:0, r, fill:color, opacity:op }, g);
-            el('path', { d:`M${-2.5} ${-0.5}Q0 ${-4} 2.5 ${-0.5}`, fill:'none',
-                stroke:'#fff', 'stroke-width':0.8, opacity:0.5 }, g);
-        } else {
-            const s = r * 0.9;
-            el('rect', { x:-s, y:-s+0.5, width:s*2, height:s*1.5, rx:1.5, fill:color, opacity:op }, g);
-            el('line', { x1:0, y1:s*0.5+0.5, x2:0, y2:s+1, stroke:color, 'stroke-width':1.2, opacity:op }, g);
-        }
-
-        // Visible name label below
-        const name = n.d.name || n.d.ip || '';
-        if (name) {
-            const dn = name.length > 25 ? name.slice(0, 24) + '…' : name;
-            const t = el('text', { x:0, y:r + 11, 'text-anchor':'middle', fill:C.textMuted,
-                'font-size':G.clientNameFont, 'font-family':'system-ui,sans-serif' }, g);
-            t.textContent = dn;
-            g.setAttribute('data-tooltip', name);
-        }
-    }
-
-    // ---- Toolbar ----
-
-    _drawToolbar() {
-        const tb = document.createElement('div');
-        tb.className = 'lfm2d-toolbar';
-        tb.innerHTML = `<button class="lfm2d-btn" data-action="zin" title="Zoom in">+</button>`
-            + `<button class="lfm2d-btn" data-action="zout" title="Zoom out">&minus;</button>`
-            + `<button class="lfm2d-btn" data-action="fit" title="Fit all">&#x2922;</button>`;
-        tb.addEventListener('click', (e) => {
-            const a = e.target.closest('[data-action]')?.dataset.action;
-            if (a === 'zin') { this._zoomBy(0.8); }
-            else if (a === 'zout') { this._zoomBy(1.25); }
-            else if (a === 'fit') { this._fitAll(); }
-        });
-        this._el.appendChild(tb);
-    }
-
-    _zoomBy(factor) {
-        const cx = this._vx + this._vw / 2;
-        const cy = this._vy + this._vh / 2;
-        this._vw *= factor;
-        this._vh *= factor;
-        this._vx = cx - this._vw / 2;
-        this._vy = cy - this._vh / 2;
-        this._applyViewBox();
+        if(promises.length>0)await Promise.all(promises);
     }
 
     // ---- Rate updates ----
 
-    _updateRates() {
-        this._updateLabels();
-        this._updatePipes();
-        this._updateCloudStats();
-        this._updateStreamRates();
+    _updateStreamRates(){
+        for(const e of this._edges){
+            if(!e._sDown)continue;
+            const r=this._liveRates[e.lk.portKey]||this._liveRates[e.lk.id];
+            e._sDown.setRate(r?.downstreamBps??0);
+            e._sUp.setRate(r?.upstreamBps??0);
+        }
     }
 
-    _updateLabels() {
-        if (!this._root) return;
-        // Use node badges from the shared data (same source as 3D map).
-        // fabricIngress/Egress for switches, aggregateIn/Out for APs.
-        // Direction: blue ↓ = download = data flowing toward leaves.
-        const badges = flowData.getNodeBadges();
+    _updateCloudStats(){
+        const cs=flowData.getCloudStats();
+        for(const cloud of this._clouds){
+            const live=cs?.[cloud.d.id];
+            if(live){
+                if(live.rttAvgMs!=null)cloud.d.rttAvgMs=live.rttAvgMs;
+                if(live.lossPercent!=null)cloud.d.lossPercent=live.lossPercent;
+            }
+        }
+    }
 
-        const upd = (n) => {
-            if (n._rd) {
-                let downBps = 0, upBps = 0, any = false;
-                const b = badges?.[n.d.id];
-                const hasFab = b && (b.fabricIngressBps != null || b.fabricEgressBps != null);
-                const hasAgg = b && (b.aggregateInBps != null || b.aggregateOutBps != null);
+    // ---- Draw (called every frame) ----
 
-                if (hasFab) {
-                    downBps = b.fabricIngressBps || 0;
-                    upBps = b.fabricEgressBps || 0;
-                    any = downBps > 0 || upBps > 0;
-                } else if (hasAgg) {
-                    // APs: aggregateIn = client data arriving at AP, aggregateOut = data leaving AP.
-                    // Label is gateway-relative (↓=from gateway) so APs swap.
-                    if (n.d.kind === NK.AP) {
-                        downBps = b.aggregateOutBps || 0;
-                        upBps = b.aggregateInBps || 0;
-                    } else {
-                        downBps = b.aggregateInBps || 0;
-                        upBps = b.aggregateOutBps || 0;
-                    }
-                    any = downBps > 0 || upBps > 0;
-                } else {
-                    // Fallback: sum adjacent link rates
-                    for (const e of this._edges) {
-                        if (e.lk.fromNodeId !== n.d.id && e.lk.toNodeId !== n.d.id) continue;
-                        const r = this._liveRates[e.lk.portKey] || this._liveRates[e.lk.id];
-                        if (!r) continue;
-                        any = true;
-                        downBps += r.downstreamBps ?? 0;
-                        upBps += r.upstreamBps ?? 0;
-                    }
+    _draw(){
+        const canvas=this._canvas, ctx=this._ctx;
+        const dpr=this._dpr, cw=this._cw, ch=this._ch;
+        if(!canvas||cw===0)return;
+
+        // Redraw static layers to offscreen canvas when transform changed
+        if(this._needsStaticRedraw){
+            this._needsStaticRedraw=false;
+            this._drawStatic();
+        }
+
+        // Composite: static + particles
+        ctx.setTransform(1,0,0,1,0,0);
+        ctx.drawImage(this._staticCanvas,0,0);
+
+        // Draw particles on top
+        ctx.setTransform(this._scale*dpr,0,0,this._scale*dpr,
+            (cw/2-this._ox*this._scale)*dpr,
+            (ch/2-this._oy*this._scale)*dpr);
+
+        ctx.globalCompositeOperation='lighter';
+        for(const s of this._streams){
+            ctx.fillStyle=s.color;
+            for(const sl of s.slots){
+                if(sl.t<0)continue;
+                const pt=orthoAt(s.edge._x1,s.edge._y1,s.edge._x2,s.edge._y2,sl.t);
+                ctx.globalAlpha=0.85;
+                ctx.beginPath();
+                ctx.arc(pt.x,pt.y,sl.size,0,Math.PI*2);
+                ctx.fill();
+            }
+        }
+        ctx.globalCompositeOperation='source-over';
+        ctx.globalAlpha=1;
+    }
+
+    _drawStatic(){
+        const c=this._staticCanvas;
+        const ctx=c.getContext('2d');
+        const dpr=this._dpr, cw=this._cw, ch=this._ch;
+
+        ctx.setTransform(1,0,0,1,0,0);
+        ctx.fillStyle=C.bg;
+        ctx.fillRect(0,0,c.width,c.height);
+
+        // Apply pan/zoom transform
+        ctx.setTransform(this._scale*dpr,0,0,this._scale*dpr,
+            (cw/2-this._ox*this._scale)*dpr,
+            (ch/2-this._oy*this._scale)*dpr);
+
+        if(!this._root)return;
+
+        // Links
+        this._drawAllLinks(ctx);
+        // Clouds
+        this._drawAllClouds(ctx);
+        // Infra + client nodes
+        this._drawAllNodes(ctx,this._root);
+        // Rate labels
+        this._drawRateLabels(ctx);
+    }
+
+    // ---- Link drawing ----
+
+    _drawAllLinks(ctx){
+        for(const e of this._edges){
+            if(e._x1==null)continue;
+            const r=this._liveRates[e.lk.portKey]||this._liveRates[e.lk.id];
+            const dn=r?.downstreamBps??0,up=r?.upstreamBps??0;
+            const cap=e.lk.capacityBps||1e9;
+            const u=Math.max(dn,up)/cap;
+            const band=e.lk.band;
+            ctx.strokeStyle=pipeClr(Math.min(u,1),band);
+            ctx.lineWidth=pipeW(e.lk.capacityBps);
+            ctx.lineCap='round';
+            ctx.globalAlpha=e._isCl?0.3+u*0.45:0.5+u*0.5;
+            strokeOrtho(ctx,e._x1,e._y1,e._x2,e._y2);
+
+            // Capacity label on infra links
+            if(!e._isCl&&e.lk.capacityBps){
+                const cap=e.lk.capacityBps/1e6;
+                if(cap>0){
+                    ctx.globalAlpha=1;
+                    const mx=(e._x1+e._x2)/2, my=(e._y1+e._y2)/2;
+                    const txt=formatSpeed(cap);
+                    ctx.font=`${G.rateFont}px ${FONT}`;
+                    const tw=ctx.measureText(txt).width+12;
+                    ctx.fillStyle=C.labelBg;
+                    this._roundRect(ctx,mx-tw/2,my-8,tw,16,4);
+                    ctx.fill();
+                    ctx.fillStyle=C.textMuted;
+                    ctx.textAlign='center'; ctx.textBaseline='middle';
+                    ctx.fillText(txt,mx,my);
+                }
+            }
+        }
+        ctx.globalAlpha=1;
+    }
+
+    // ---- Cloud drawing ----
+
+    _drawAllClouds(ctx){
+        for(const cloud of this._clouds){
+            const cx=cloud.x, cy=cloud.y, r=G.cloudR;
+
+            // Globe wireframe
+            ctx.strokeStyle=C.globeStroke;
+            ctx.lineWidth=1.5; ctx.globalAlpha=0.8;
+            ctx.beginPath(); ctx.arc(cx,cy,r,0,Math.PI*2); ctx.stroke();
+
+            ctx.lineWidth=1; ctx.globalAlpha=0.35;
+            ctx.beginPath(); ctx.ellipse(cx,cy,r*0.45,r,0,0,Math.PI*2); ctx.stroke();
+            ctx.beginPath(); ctx.ellipse(cx,cy,r,r*0.35,0,0,Math.PI*2); ctx.stroke();
+
+            ctx.lineWidth=0.7; ctx.globalAlpha=0.2;
+            ctx.beginPath(); ctx.ellipse(cx,cy,r,r*0.65,0,0,Math.PI*2); ctx.stroke();
+
+            ctx.fillStyle=C.globeStroke; ctx.globalAlpha=0.05;
+            ctx.beginPath(); ctx.arc(cx,cy,r-1,0,Math.PI*2); ctx.fill();
+            ctx.globalAlpha=1;
+
+            // Name
+            const name=cloud.d.asnName||cloud.d.name||'WAN';
+            ctx.fillStyle=C.textSec;
+            ctx.font=`500 ${G.nameFont}px ${FONT}`;
+            ctx.textAlign='center'; ctx.textBaseline='top';
+            ctx.fillText(name,cx,cy+r+8);
+
+            // RTT badge
+            let rttTxt='';
+            if(cloud.d.rttAvgMs!=null)rttTxt+=`${cloud.d.rttAvgMs.toFixed(1)} ms`;
+            if(cloud.d.lossPercent&&cloud.d.lossPercent>0)rttTxt+=(rttTxt?' / ':'')+`${cloud.d.lossPercent.toFixed(1)}% loss`;
+            if(rttTxt){
+                ctx.fillStyle=C.textMuted;
+                ctx.font=`${G.rateFont-1}px ${FONT}`;
+                ctx.fillText(rttTxt,cx,cy+r+22);
+            }
+        }
+    }
+
+    // ---- Node drawing ----
+
+    _drawAllNodes(ctx,n){
+        this._drawInfraNode(ctx,n);
+        for(const c of n.infra)this._drawAllNodes(ctx,c);
+        for(const c of n.clients.slice(0,G.maxClients))this._drawClientNode(ctx,c);
+        if(n.clients.length>G.maxClients){
+            const last=n.clients[G.maxClients-1];
+            ctx.fillStyle=C.textMuted;
+            ctx.font=`${G.rateFont}px ${FONT}`;
+            ctx.textAlign='left'; ctx.textBaseline='middle';
+            ctx.fillText(`+${n.clients.length-G.maxClients}`,last.x+G.clientR+10,last.y);
+        }
+    }
+
+    _drawInfraNode(ctx,n){
+        const x=n.x, y=n.y, color=nodeClr(n.d.kind);
+        const hw=G.boxW/2, hh=G.boxH/2;
+        const op=n.d.online?1:0.35;
+
+        // Glow
+        ctx.fillStyle=withAlpha(color,0.07);
+        this._roundRect(ctx,x-hw-5,y-hh-5,G.boxW+10,G.boxH+10,14);
+        ctx.fill();
+
+        // Card
+        ctx.globalAlpha=op;
+        ctx.fillStyle=C.cardBg;
+        this._roundRect(ctx,x-hw,y-hh,G.boxW,G.boxH,10);
+        ctx.fill();
+        ctx.strokeStyle=color; ctx.lineWidth=1.5;
+        this._roundRect(ctx,x-hw,y-hh,G.boxW,G.boxH,10);
+        ctx.stroke();
+
+        // Icon
+        const iSz=G.iconSize;
+        const modelKey=n.d.model?.toLowerCase().replace(/ /g,'-');
+        const img=modelKey?this._images.get(modelKey):null;
+        if(img){
+            ctx.drawImage(img,x-iSz/2,y-iSz/2,iSz,iSz);
+        } else {
+            ctx.fillStyle=withAlpha(color,0.2);
+            const s=iSz/2-6;
+            this._roundRect(ctx,x-s,y-s,s*2,s*2,6);
+            ctx.fill();
+            ctx.fillStyle=color;
+            ctx.font=`600 18px ${FONT}`;
+            ctx.textAlign='center'; ctx.textBaseline='middle';
+            ctx.fillText((n.d.name||'D').charAt(0).toUpperCase(),x,y);
+        }
+        ctx.globalAlpha=1;
+
+        // Name label
+        const name=n.d.name||n.d.model||'';
+        if(name){
+            const dn=name.length>16?name.slice(0,15)+'…':name;
+            ctx.fillStyle=C.text;
+            ctx.font=`500 ${G.nameFont}px ${FONT}`;
+            ctx.textAlign='center'; ctx.textBaseline='top';
+            ctx.fillText(dn,x,y+hh+5);
+        }
+
+        // Rate labels (stored for dynamic update)
+        n._rateY=y+hh+19;
+    }
+
+    _drawClientNode(ctx,n){
+        const x=n.x, y=n.y, color=nodeClr(n.d.kind,n.d.band);
+        const r=G.clientR, op=n.d.online?0.7:0.2;
+
+        ctx.globalAlpha=op;
+        if(n.d.kind===NK.WifiClient){
+            ctx.fillStyle=color;
+            ctx.beginPath(); ctx.arc(x,y,r,0,Math.PI*2); ctx.fill();
+            ctx.strokeStyle='rgba(255,255,255,0.5)'; ctx.lineWidth=0.8;
+            ctx.beginPath();
+            ctx.moveTo(x-2.5,y-0.5);
+            ctx.quadraticCurveTo(x,y-4,x+2.5,y-0.5);
+            ctx.stroke();
+        } else {
+            const s=r*0.9;
+            ctx.fillStyle=color;
+            this._roundRect(ctx,x-s,y-s+0.5,s*2,s*1.5,1.5);
+            ctx.fill();
+            ctx.beginPath(); ctx.moveTo(x,y+s*0.5+0.5); ctx.lineTo(x,y+s+1);
+            ctx.strokeStyle=color; ctx.lineWidth=1.2; ctx.stroke();
+        }
+        ctx.globalAlpha=1;
+
+        // Name label
+        const name=n.d.name||n.d.ip||'';
+        if(name){
+            const dn=name.length>25?name.slice(0,24)+'…':name;
+            ctx.fillStyle=C.textMuted;
+            ctx.font=`${G.clientFont}px ${FONT}`;
+            ctx.textAlign='center'; ctx.textBaseline='top';
+            ctx.fillText(dn,x,y+r+3);
+        }
+    }
+
+    // ---- Rate labels on links + nodes ----
+
+    _drawRateLabels(ctx){
+        const badges=flowData.getNodeBadges();
+        const THRESH=RATE_THRESH;
+
+        // Node rate labels
+        const drawNodeRate=(n)=>{
+            if(n._rateY){
+                let downBps=0,upBps=0,any=false;
+                const b=badges?.[n.d.id];
+                const hasFab=b&&(b.fabricIngressBps!=null||b.fabricEgressBps!=null);
+                const hasAgg=b&&(b.aggregateInBps!=null||b.aggregateOutBps!=null);
+
+                if(hasFab){downBps=b.fabricIngressBps||0;upBps=b.fabricEgressBps||0;any=downBps>0||upBps>0;}
+                else if(hasAgg){
+                    if(n.d.kind===NK.AP){downBps=b.aggregateOutBps||0;upBps=b.aggregateInBps||0;}
+                    else{downBps=b.aggregateInBps||0;upBps=b.aggregateOutBps||0;}
+                    any=downBps>0||upBps>0;
                 }
 
-                n._rd.textContent = (any && downBps > 100000) ? '↓' + formatBps(downBps) : '';
-                n._ru.textContent = (any && upBps > 100000) ? '↑' + formatBps(upBps) : '';
+                if(any&&(downBps>100000||upBps>100000)){
+                    ctx.font=`${G.rateFont}px ${FONT}`;
+                    ctx.textBaseline='top';
+                    const dTxt='↓'+formatBps(downBps), uTxt='↑'+formatBps(upBps);
+                    ctx.textAlign='right'; ctx.fillStyle=C.downstream;
+                    ctx.fillText(dTxt,n.x-2,n._rateY);
+                    ctx.textAlign='left'; ctx.fillStyle=C.upstream;
+                    ctx.fillText(uTxt,n.x+2,n._rateY);
+                }
             }
-            for (const c of n.infra) upd(c);
+            for(const c of n.infra)drawNodeRate(c);
         };
-        upd(this._root);
-    }
+        if(this._root)drawNodeRate(this._root);
 
-    _updatePipes() {
-        const THRESH = 1_000_000;
-        for (const e of this._edges) {
-            if (!e._pe) continue;
-            const r = this._liveRates[e.lk.portKey] || this._liveRates[e.lk.id];
-            if (!r) continue;
-            const dn = r.downstreamBps ?? 0, up = r.upstreamBps ?? 0;
-            const cap = e.lk.capacityBps || 1e9;
-            const u = Math.max(dn, up) / cap;
-            e._pe.setAttribute('stroke', pipeClr(Math.min(u, 1), e._band));
-            const op = e._isCl ? 0.3 + u * 0.45 : 0.5 + u * 0.5;
-            e._pe.setAttribute('opacity', String(Math.min(op, 1)));
-
-            // Live rate label - show both directions when either exceeds threshold
-            if (e._rlD) {
-                if (dn > THRESH || up > THRESH) {
-                    e._rlD.textContent = '↓' + (dn > 0 ? formatBps(dn) : '0 bps');
-                    e._rlU.textContent = '↑' + (up > 0 ? formatBps(up) : '0 bps');
-                    const tw = Math.max((e._rlD.textContent.length + e._rlU.textContent.length) * 5 + 16, 40);
-                    e._rlBg.setAttribute('x', -tw / 2);
-                    e._rlBg.setAttribute('width', tw);
-                    e._rlBg.setAttribute('opacity', 1);
-                } else {
-                    e._rlD.textContent = '';
-                    e._rlU.textContent = '';
-                    e._rlBg.setAttribute('opacity', 0);
-                }
+        // Link rate labels
+        ctx.font=`${G.rateFont}px ${FONT}`;
+        for(const e of this._edges){
+            if(e._x1==null||e._isCl)continue;
+            const r=this._liveRates[e.lk.portKey]||this._liveRates[e.lk.id];
+            if(!r)continue;
+            const dn=r.downstreamBps??0,up=r.upstreamBps??0;
+            if(dn>THRESH||up>THRESH){
+                const mx=(e._x1+e._x2)/2, my=(e._y1+e._y2)/2+14;
+                const dTxt='↓'+(dn>0?formatBps(dn):'0 bps');
+                const uTxt='↑'+(up>0?formatBps(up):'0 bps');
+                const tw=ctx.measureText(dTxt+' '+uTxt).width+14;
+                ctx.fillStyle=C.labelBg;
+                this._roundRect(ctx,mx-tw/2,my-8,tw,16,4);
+                ctx.fill();
+                ctx.textBaseline='middle';
+                ctx.textAlign='right'; ctx.fillStyle=C.downstream;
+                ctx.fillText(dTxt,mx-2,my);
+                ctx.textAlign='left'; ctx.fillStyle=C.upstream;
+                ctx.fillText(uTxt,mx+2,my);
             }
         }
     }
 
-    _updateCloudStats() {
-        const cs = flowData.getCloudStats();
-        for (const cloud of this._clouds) {
-            const live = cs?.[cloud.d.id];
-            if (live) {
-                if (live.rttAvgMs != null) cloud.d.rttAvgMs = live.rttAvgMs;
-                if (live.lossPercent != null) cloud.d.lossPercent = live.lossPercent;
-            }
-            this._cloudBadge(cloud);
-        }
+    // ---- Utility ----
+
+    _roundRect(ctx,x,y,w,h,r){
+        ctx.beginPath();
+        ctx.moveTo(x+r,y);
+        ctx.lineTo(x+w-r,y);
+        ctx.quadraticCurveTo(x+w,y,x+w,y+r);
+        ctx.lineTo(x+w,y+h-r);
+        ctx.quadraticCurveTo(x+w,y+h,x+w-r,y+h);
+        ctx.lineTo(x+r,y+h);
+        ctx.quadraticCurveTo(x,y+h,x,y+h-r);
+        ctx.lineTo(x,y+r);
+        ctx.quadraticCurveTo(x,y,x+r,y);
+        ctx.closePath();
     }
 
-    // ---- Particle system (persistent emission, matching 3D map) ----
-    // Each link gets two Stream objects (downstream + upstream). setRate()
-    // adjusts emission parameters. advance(dt) spawns new dots and moves
-    // existing ones. Particles are never bulk-recreated on rate updates.
+    // ---- Animation loop ----
 
-    _initStreams() {
-        this._streams = [];
-        for (const e of this._edges) {
-            if (!e._pe) continue;
-            if (e._x1 == null) continue;
-            const len = orthoLen(e._x1, e._y1, e._x2, e._y2);
-            if (len < 5) continue;
-            e._sDown = new Stream(e, 1, C.downstream, this._gParts);
-            e._sUp   = new Stream(e, -1, C.upstream, this._gParts);
-            this._streams.push(e._sDown, e._sUp);
-        }
-    }
+    _animate(){
+        const now=performance.now();
+        const dt=Math.min((now-this._lastFrame)/1000,0.1);
+        this._lastFrame=now;
 
-    _updateStreamRates() {
-        for (const e of this._edges) {
-            if (!e._sDown) continue;
-            const r = this._liveRates[e.lk.portKey] || this._liveRates[e.lk.id];
-            e._sDown.setRate(r?.downstreamBps ?? 0);
-            e._sUp.setRate(r?.upstreamBps ?? 0);
-        }
-    }
+        for(const s of this._streams)s.advance(dt);
+        this._draw();
 
-    _animate() {
-        const now = performance.now();
-        const dt = Math.min((now - this._lastFrame) / 1000, 0.1);
-        this._lastFrame = now;
-
-        for (const s of this._streams) s.advance(dt);
-
-        this._animId = requestAnimationFrame(() => this._animate());
+        this._animId=requestAnimationFrame(()=>this._animate());
     }
 }
 
 // ---- Module exports ----
-let _inst = null;
+let _inst=null;
 
-export async function mount(containerId) {
-    if (_inst) { _inst.dispose(); _inst = null; }
-    const container = document.getElementById(containerId);
-    if (!container) return;
-    _inst = new LanFlowMap2D(container);
+export async function mount(containerId){
+    if(_inst){_inst.dispose();_inst=null;}
+    const container=document.getElementById(containerId);
+    if(!container)return;
+    _inst=new LanFlowMap2D(container);
     await _inst.start();
 }
 
-export function unmount() {
-    if (_inst) { _inst.dispose(); _inst = null; }
+export function unmount(){
+    if(_inst){_inst.dispose();_inst=null;}
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1,0 +1,1061 @@
+// 2D hierarchical LAN topology diagram.
+// Renders SVG consuming the same API endpoints as the 3D LAN Flow Map.
+// Animated data-flow particles show real-time traffic direction and rate.
+
+const NS = 'http://www.w3.org/2000/svg';
+
+// ---- Color palette (matches 3D map) ----
+const COLORS = {
+    bg:           '#202023',
+    gateway:      '#facc15',
+    switchNode:   '#9aa6b2',
+    ap:           '#3385d6',
+    wiredClient:  '#c9d2e0',
+    wifiClient:   '#e2e8f0',
+    cloud:        '#4d556b',
+    virtualHub:   '#6b7785',
+    downstream:   '#3385d6',
+    upstream:     '#24bc70',
+    pipeCool:     '#1f4068',
+    pipeWarm:     '#e79613',
+    pipeHot:      '#ee6368',
+    band24:       '#fbbf24',
+    band5:        '#3b82f6',
+    band6:        '#a855f7',
+    text:         '#f1f5f9',
+    textSec:      '#cbd5e1',
+    textMuted:    '#9ca3af',
+    labelBg:      'rgba(16,24,32,0.82)',
+    cloudStroke:  '#3b82f6',
+};
+
+const NODE_KIND = {
+    Gateway: 0, Switch: 1, AccessPoint: 2,
+    WiredClient: 3, WifiClient: 4, Cloud: 5, VirtualHub: 6,
+};
+const LINK_KIND = {
+    Uplink: 0, WiredClient: 1, WifiClient: 2,
+    Wan: 3, Transit: 4, MeshBackhaul: 5,
+};
+
+// ---- Layout geometry ----
+const L = {
+    tierGap:       130,
+    cloudGap:      90,
+    infraGap:      80,
+    clientGap:     6,
+    clientSize:    18,
+    clientCols:    12,
+    maxClients:    60,
+    infraW:        60,
+    infraH:        48,
+    cloudR:        28,
+    cornerR:       12,
+    padding:       60,
+    pipeBase:      2,
+    pipeMax:       5.5,
+    particleR:     3,
+    labelFont:     11,
+    rateFont:      10,
+    nameFont:      11,
+};
+
+const RATE_THRESHOLD = 1_000_000;
+
+// ---- Utility ----
+
+function svg(tag, attrs, parent) {
+    const e = document.createElementNS(NS, tag);
+    if (attrs) for (const [k, v] of Object.entries(attrs)) {
+        if (v != null) e.setAttribute(k, String(v));
+    }
+    if (parent) parent.appendChild(e);
+    return e;
+}
+
+function hexToRgb(h) {
+    return [parseInt(h.slice(1, 3), 16), parseInt(h.slice(3, 5), 16), parseInt(h.slice(5, 7), 16)];
+}
+function rgbHex(r, g, b) {
+    return '#' + [r, g, b].map(c => Math.round(Math.max(0, Math.min(255, c))).toString(16).padStart(2, '0')).join('');
+}
+function lerpColor(a, b, t) {
+    const [r1, g1, b1] = hexToRgb(a), [r2, g2, b2] = hexToRgb(b);
+    return rgbHex(r1 + (r2 - r1) * t, g1 + (g2 - g1) * t, b1 + (b2 - b1) * t);
+}
+
+function bandColor(band) {
+    if (band === '2.4') return COLORS.band24;
+    if (band === '5')   return COLORS.band5;
+    if (band === '6')   return COLORS.band6;
+    return null;
+}
+
+function nodeColor(kind, band) {
+    switch (kind) {
+        case NODE_KIND.Gateway:     return COLORS.gateway;
+        case NODE_KIND.Switch:      return COLORS.switchNode;
+        case NODE_KIND.AccessPoint: return COLORS.ap;
+        case NODE_KIND.WiredClient: return COLORS.wiredClient;
+        case NODE_KIND.WifiClient:  return bandColor(band) || COLORS.wifiClient;
+        case NODE_KIND.Cloud:       return COLORS.cloud;
+        case NODE_KIND.VirtualHub:  return COLORS.virtualHub;
+        default: return COLORS.textMuted;
+    }
+}
+
+function isInfra(kind) {
+    return kind <= NODE_KIND.AccessPoint || kind === NODE_KIND.VirtualHub;
+}
+function isClient(kind) {
+    return kind === NODE_KIND.WiredClient || kind === NODE_KIND.WifiClient;
+}
+
+function pipeColorForUtil(util, band) {
+    const cool = bandColor(band) || COLORS.pipeCool;
+    if (util < 0.7) return cool;
+    if (util < 0.9) return lerpColor(cool, COLORS.pipeWarm, (util - 0.7) / 0.2);
+    return lerpColor(COLORS.pipeWarm, COLORS.pipeHot, Math.min((util - 0.9) / 0.1, 1));
+}
+
+function pipeWidth(capacityBps) {
+    if (!capacityBps || capacityBps <= 0) return L.pipeBase;
+    const gbps = capacityBps / 1e9;
+    const t = Math.log10(Math.max(gbps, 0.01)) + 2;
+    return L.pipeBase + Math.min(t, 3.5) * 0.8;
+}
+
+function formatBps(bps) {
+    if (!Number.isFinite(bps) || bps <= 0) return '';
+    const units = ['bps', 'Kbps', 'Mbps', 'Gbps', 'Tbps'];
+    let i = 0, v = bps;
+    while (v >= 1000 && i < units.length - 1) { v /= 1000; i++; }
+    return `${v >= 100 ? v.toFixed(0) : v.toFixed(1)} ${units[i]}`;
+}
+
+function formatLinkSpeed(mbps) {
+    if (!mbps) return '';
+    if (mbps >= 1000) {
+        const g = mbps / 1000;
+        return `${g % 1 === 0 ? g.toFixed(0) : g.toFixed(1)} Gbps`;
+    }
+    return `${mbps} Mbps`;
+}
+
+// ---- Orthogonal path computation ----
+
+function orthoPath(x1, y1, x2, y2) {
+    const r = L.cornerR;
+    if (Math.abs(x1 - x2) < 0.5) return `M${x1} ${y1}L${x2} ${y2}`;
+
+    const midY = (y1 + y2) / 2;
+    const dx = x2 - x1;
+    const s = dx > 0 ? 1 : -1;
+    const ax = Math.abs(dx);
+    const hv = Math.abs(y2 - y1) / 2;
+    const cr = Math.min(r, ax / 2, hv);
+    if (cr < 1) return `M${x1} ${y1}L${x1} ${midY}L${x2} ${midY}L${x2} ${y2}`;
+
+    return `M${x1} ${y1}`
+        + `L${x1} ${midY - cr}`
+        + `Q${x1} ${midY} ${x1 + s * cr} ${midY}`
+        + `L${x2 - s * cr} ${midY}`
+        + `Q${x2} ${midY} ${x2} ${midY + cr}`
+        + `L${x2} ${y2}`;
+}
+
+function orthoLength(x1, y1, x2, y2) {
+    if (Math.abs(x1 - x2) < 0.5) return Math.abs(y2 - y1);
+    const ax = Math.abs(x2 - x1);
+    const hv = Math.abs(y2 - y1) / 2;
+    const cr = Math.min(L.cornerR, ax / 2, hv);
+    if (cr < 1) return Math.abs(y2 - y1) + ax;
+    return (hv - cr) * 2 + Math.PI * cr + (ax - 2 * cr);
+}
+
+function orthoPointAt(x1, y1, x2, y2, t) {
+    const dy = y2 - y1;
+    if (Math.abs(x2 - x1) < 0.5) return { x: x1, y: y1 + dy * t };
+
+    const midY = (y1 + y2) / 2;
+    const dx = x2 - x1;
+    const s = dx > 0 ? 1 : -1;
+    const ax = Math.abs(dx);
+    const hv = Math.abs(dy) / 2;
+    const cr = Math.min(L.cornerR, ax / 2, hv);
+    if (cr < 1) {
+        const s1 = hv, s2 = ax, total = s1 + s2 + hv;
+        let d = t * total;
+        if (d <= s1) return { x: x1, y: y1 + d };
+        d -= s1;
+        if (d <= s2) return { x: x1 + s * d, y: midY };
+        d -= s2;
+        return { x: x2, y: midY + d };
+    }
+
+    const s1 = hv - cr;
+    const s2 = (Math.PI / 2) * cr;
+    const s3 = ax - 2 * cr;
+    const s4 = s2;
+    const s5 = hv - cr;
+    const total = s1 + s2 + s3 + s4 + s5;
+    let d = t * total;
+
+    if (d <= s1) return { x: x1, y: y1 + d };
+    d -= s1;
+    if (d <= s2) {
+        const a = (d / s2) * (Math.PI / 2);
+        return { x: x1 + s * cr * Math.sin(a), y: (midY - cr) + cr * (1 - Math.cos(a)) };
+    }
+    d -= s2;
+    if (d <= s3) return { x: x1 + s * (cr + d), y: midY };
+    d -= s3;
+    if (d <= s4) {
+        const a = (d / s4) * (Math.PI / 2);
+        return {
+            x: (x2 - s * cr) + s * cr * Math.sin(a),
+            y: midY + cr * (1 - Math.cos(a)),
+        };
+    }
+    d -= s4;
+    return { x: x2, y: midY + cr + d };
+}
+
+// ---- Layout tree node ----
+
+class TNode {
+    constructor(data) {
+        this.d = data;
+        this.infraChildren = [];
+        this.clientChildren = [];
+        this.x = 0;
+        this.y = 0;
+        this.w = 0;
+    }
+}
+
+// ---- Main class ----
+
+class LanFlowMap2D {
+    constructor(container) {
+        this._el = container;
+        this._svgRoot = null;
+        this._gLinks = null;
+        this._gNodes = null;
+        this._gParticles = null;
+        this._gLabels = null;
+
+        this._snapshot = null;
+        this._treeNodes = new Map();
+        this._root = null;
+        this._clouds = [];
+        this._linkEdges = [];
+        this._liveRates = {};
+
+        this._particles = [];
+        this._animId = 0;
+        this._lastFrame = 0;
+        this._pollId = 0;
+    }
+
+    async start() {
+        this._createSvg();
+        await this._loadSnapshot();
+        this._startPolling();
+        this._lastFrame = performance.now();
+        this._animate();
+    }
+
+    dispose() {
+        cancelAnimationFrame(this._animId);
+        clearInterval(this._pollId);
+        this._el.innerHTML = '';
+        this._particles = [];
+    }
+
+    // ---- SVG skeleton ----
+
+    _createSvg() {
+        this._el.innerHTML = '';
+        const s = svg('svg', {
+            'xmlns': NS,
+            'preserveAspectRatio': 'xMidYMin meet',
+            'class': 'lan-flow-map-2d-svg',
+        }, this._el);
+        this._svgRoot = s;
+
+        const defs = svg('defs', null, s);
+
+        // Glow filter for infra nodes
+        const glow = svg('filter', { id: 'node-glow', x: '-50%', y: '-50%', width: '200%', height: '200%' }, defs);
+        svg('feGaussianBlur', { in: 'SourceGraphic', stdDeviation: '4', result: 'blur' }, glow);
+        const merge = svg('feMerge', null, glow);
+        svg('feMergeNode', { in: 'blur' }, merge);
+        svg('feMergeNode', { in: 'SourceGraphic' }, merge);
+
+        // Particle glow
+        const pglow = svg('filter', { id: 'particle-glow', x: '-100%', y: '-100%', width: '300%', height: '300%' }, defs);
+        svg('feGaussianBlur', { in: 'SourceGraphic', stdDeviation: '2', result: 'blur' }, pglow);
+        const pm = svg('feMerge', null, pglow);
+        svg('feMergeNode', { in: 'blur' }, pm);
+        svg('feMergeNode', { in: 'SourceGraphic' }, pm);
+
+        this._gLinks = svg('g', { class: 'links' }, s);
+        this._gParticles = svg('g', { class: 'particles' }, s);
+        this._gNodes = svg('g', { class: 'nodes' }, s);
+        this._gLabels = svg('g', { class: 'labels' }, s);
+    }
+
+    // ---- Data loading ----
+
+    async _loadSnapshot() {
+        try {
+            const r = await fetch('/api/monitoring/lan-flow-map/snapshot');
+            if (!r.ok) return;
+            this._snapshot = await r.json();
+        } catch { return; }
+
+        this._liveRates = this._snapshot.liveRates || {};
+        this._buildLayout();
+        this._renderAll();
+    }
+
+    async _pollLive() {
+        try {
+            const r = await fetch('/api/monitoring/lan-flow-map/live');
+            if (!r.ok) return;
+            const update = await r.json();
+            if (update.linkRates) {
+                Object.assign(this._liveRates, update.linkRates);
+                this._updateRates();
+            }
+        } catch { /* swallow */ }
+    }
+
+    _startPolling() {
+        this._pollId = setInterval(() => this._pollLive(), 3000);
+    }
+
+    // ---- Layout ----
+
+    _buildLayout() {
+        const snap = this._snapshot;
+        if (!snap) return;
+
+        const nodesById = new Map();
+        for (const n of snap.nodes) nodesById.set(n.id, new TNode(n));
+        this._treeNodes = nodesById;
+
+        // Build parent-child tree
+        let root = null;
+        for (const [, tn] of nodesById) {
+            if (tn.d.kind === NODE_KIND.Gateway) root = tn;
+            if (tn.d.parentId && nodesById.has(tn.d.parentId)) {
+                const parent = nodesById.get(tn.d.parentId);
+                if (isClient(tn.d.kind)) {
+                    parent.clientChildren.push(tn);
+                } else if (tn.d.kind !== NODE_KIND.Cloud) {
+                    parent.infraChildren.push(tn);
+                }
+            }
+        }
+        this._root = root;
+
+        // Clouds
+        this._clouds = (snap.clouds || []).map(c => ({ data: c, x: 0, y: 0 }));
+
+        // Link edges
+        this._linkEdges = [];
+        for (const link of snap.links) {
+            this._linkEdges.push({
+                link,
+                fromNode: nodesById.get(link.fromNodeId),
+                toNode: nodesById.get(link.toNodeId),
+            });
+        }
+
+        if (!root) return;
+        this._computeWidths(root);
+        const totalW = root.w;
+        this._assignPositions(root, L.padding, 0);
+        this._positionClouds();
+    }
+
+    _computeWidths(node) {
+        // Infra children
+        let infraW = 0;
+        for (const child of node.infraChildren) {
+            this._computeWidths(child);
+            infraW += child.w;
+        }
+        if (node.infraChildren.length > 1)
+            infraW += (node.infraChildren.length - 1) * L.infraGap;
+
+        // Client grid
+        const nc = Math.min(node.clientChildren.length, L.maxClients);
+        const cols = Math.min(nc, L.clientCols);
+        const clientGridW = cols > 0 ? cols * (L.clientSize + L.clientGap) - L.clientGap : 0;
+
+        // Node's own min width
+        const selfW = isClient(node.d.kind) ? L.clientSize : L.infraW + 40;
+
+        // Combined: infra and client grids side by side
+        let childrenW = 0;
+        if (infraW > 0 && clientGridW > 0) {
+            childrenW = infraW + L.infraGap + clientGridW;
+        } else {
+            childrenW = infraW + clientGridW;
+        }
+
+        node.w = Math.max(selfW, childrenW);
+    }
+
+    _assignPositions(node, leftX, depth) {
+        const yBase = L.padding + 60;
+        node.y = yBase + depth * L.tierGap;
+
+        if (node.infraChildren.length === 0 && node.clientChildren.length === 0) {
+            node.x = leftX + node.w / 2;
+            return;
+        }
+
+        let infraW = node.infraChildren.reduce((s, c) => s + c.w, 0);
+        if (node.infraChildren.length > 1)
+            infraW += (node.infraChildren.length - 1) * L.infraGap;
+
+        const nc = Math.min(node.clientChildren.length, L.maxClients);
+        const cols = Math.min(nc, L.clientCols);
+        const clientGridW = cols > 0 ? cols * (L.clientSize + L.clientGap) - L.clientGap : 0;
+
+        let combinedW = 0;
+        if (infraW > 0 && clientGridW > 0) combinedW = infraW + L.infraGap + clientGridW;
+        else combinedW = infraW + clientGridW;
+
+        let cursor = leftX + (node.w - combinedW) / 2;
+
+        // Place infra children
+        for (const child of node.infraChildren) {
+            this._assignPositions(child, cursor, depth + 1);
+            cursor += child.w + L.infraGap;
+        }
+
+        // Place clients in grid
+        if (nc > 0) {
+            const gridLeft = cursor - (infraW > 0 ? 0 : 0);
+            const clientY = yBase + (depth + 1) * L.tierGap;
+            for (let i = 0; i < nc; i++) {
+                const col = i % cols;
+                const row = Math.floor(i / cols);
+                const cn = node.clientChildren[i];
+                cn.x = gridLeft + col * (L.clientSize + L.clientGap) + L.clientSize / 2;
+                cn.y = clientY + row * (L.clientSize + L.clientGap);
+            }
+        }
+
+        // Center parent over all children
+        const allKids = [
+            ...node.infraChildren,
+            ...node.clientChildren.slice(0, nc),
+        ];
+        if (allKids.length > 0) {
+            const minX = Math.min(...allKids.map(c => c.x));
+            const maxX = Math.max(...allKids.map(c => c.x));
+            node.x = (minX + maxX) / 2;
+        } else {
+            node.x = leftX + node.w / 2;
+        }
+    }
+
+    _positionClouds() {
+        if (!this._root || this._clouds.length === 0) return;
+        const gx = this._root.x;
+        const gy = this._root.y;
+        const total = this._clouds.length;
+        const spacing = L.cloudGap;
+        const startX = gx - ((total - 1) * spacing) / 2;
+
+        for (let i = 0; i < total; i++) {
+            this._clouds[i].x = startX + i * spacing;
+            this._clouds[i].y = gy - L.tierGap;
+        }
+    }
+
+    // ---- Rendering ----
+
+    _renderAll() {
+        this._gLinks.innerHTML = '';
+        this._gNodes.innerHTML = '';
+        this._gParticles.innerHTML = '';
+        this._gLabels.innerHTML = '';
+        this._particles = [];
+
+        if (!this._root) {
+            this._renderEmpty();
+            return;
+        }
+
+        this._setViewBox();
+        this._renderCloudLinks();
+        this._renderTreeLinks(this._root);
+        this._renderClouds();
+        this._renderTreeNodes(this._root);
+        this._updateRates();
+    }
+
+    _renderEmpty() {
+        const t = svg('text', {
+            x: '50%', y: '200',
+            'text-anchor': 'middle',
+            fill: COLORS.textMuted,
+            'font-size': '14',
+            'font-family': 'system-ui, sans-serif',
+        }, this._svgRoot);
+        t.textContent = 'Waiting for topology data...';
+        this._svgRoot.setAttribute('viewBox', '0 0 800 400');
+    }
+
+    _setViewBox() {
+        let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+
+        const expand = (x, y, r) => {
+            minX = Math.min(minX, x - r);
+            minY = Math.min(minY, y - r);
+            maxX = Math.max(maxX, x + r);
+            maxY = Math.max(maxY, y + r);
+        };
+
+        const visit = (node) => {
+            expand(node.x, node.y, L.infraW);
+            for (const c of node.infraChildren) visit(c);
+            for (const c of node.clientChildren.slice(0, L.maxClients))
+                expand(c.x, c.y, L.clientSize);
+        };
+        visit(this._root);
+        for (const c of this._clouds) expand(c.x, c.y, L.cloudR + 20);
+
+        const pad = L.padding;
+        const vx = minX - pad;
+        const vy = minY - pad;
+        const vw = (maxX - minX) + pad * 2;
+        const vh = (maxY - minY) + pad * 2 + 30;
+        this._svgRoot.setAttribute('viewBox', `${vx} ${vy} ${vw} ${vh}`);
+    }
+
+    // ---- Link rendering ----
+
+    _renderCloudLinks() {
+        if (!this._root) return;
+        const gw = this._root;
+        const gwTop = gw.y - L.infraH / 2;
+
+        for (const cloud of this._clouds) {
+            const cy = cloud.y + L.cloudR + 6;
+            const linkData = this._linkEdges.find(e =>
+                (e.link.kind === LINK_KIND.Wan || e.link.kind === LINK_KIND.Transit)
+                && ((e.link.fromNodeId === cloud.data.id || e.link.toNodeId === cloud.data.id)
+                    || (e.fromNode?.d.kind === NODE_KIND.Gateway && e.toNode?.d.kind === NODE_KIND.Cloud))
+            );
+
+            const pathD = orthoPath(cloud.x, cy, gw.x, gwTop);
+            const pathEl = svg('path', {
+                d: pathD,
+                fill: 'none',
+                stroke: COLORS.pipeCool,
+                'stroke-width': linkData ? pipeWidth(linkData.link.capacityBps) : L.pipeBase,
+                'stroke-linecap': 'round',
+                opacity: '0.7',
+            }, this._gLinks);
+
+            if (linkData) {
+                linkData._pathEl = pathEl;
+                linkData._x1 = cloud.x; linkData._y1 = cy;
+                linkData._x2 = gw.x; linkData._y2 = gwTop;
+                linkData._isWan = true;
+            }
+        }
+
+        // Transit links between clouds
+        const sortedClouds = [...this._clouds].sort((a, b) => a.data.order - b.data.order);
+        for (let i = 0; i < sortedClouds.length - 1; i++) {
+            const a = sortedClouds[i], b = sortedClouds[i + 1];
+            const edge = this._linkEdges.find(e =>
+                e.link.kind === LINK_KIND.Transit
+                && ((e.link.fromNodeId === a.data.id && e.link.toNodeId === b.data.id)
+                    || (e.link.fromNodeId === b.data.id && e.link.toNodeId === a.data.id))
+            );
+            if (!edge) continue;
+
+            const pathD = `M${a.x + L.cloudR + 4} ${a.y}L${b.x - L.cloudR - 4} ${b.y}`;
+            const pathEl = svg('path', {
+                d: pathD,
+                fill: 'none',
+                stroke: COLORS.pipeCool,
+                'stroke-width': L.pipeBase,
+                'stroke-linecap': 'round',
+                'stroke-dasharray': '6 4',
+                opacity: '0.5',
+            }, this._gLinks);
+            edge._pathEl = pathEl;
+            edge._x1 = a.x + L.cloudR + 4; edge._y1 = a.y;
+            edge._x2 = b.x - L.cloudR - 4; edge._y2 = b.y;
+        }
+    }
+
+    _renderTreeLinks(node) {
+        const parentBottom = node.y + L.infraH / 2;
+
+        for (const child of node.infraChildren) {
+            const childTop = child.y - L.infraH / 2;
+            this._drawLink(node, child, parentBottom, childTop, false);
+            this._renderTreeLinks(child);
+        }
+
+        for (const child of node.clientChildren.slice(0, L.maxClients)) {
+            const childTop = child.y - L.clientSize / 2;
+            this._drawLink(node, child, parentBottom, childTop, true);
+        }
+    }
+
+    _drawLink(parent, child, y1, y2, isClientLink) {
+        const edge = this._linkEdges.find(e =>
+            (e.link.fromNodeId === parent.d.id && e.link.toNodeId === child.d.id)
+            || (e.link.fromNodeId === child.d.id && e.link.toNodeId === parent.d.id)
+        );
+
+        const band = edge?.link.band;
+        const coolColor = bandColor(band) || COLORS.pipeCool;
+
+        const pathD = orthoPath(parent.x, y1, child.x, y2);
+        const pathEl = svg('path', {
+            d: pathD,
+            fill: 'none',
+            stroke: coolColor,
+            'stroke-width': edge ? pipeWidth(edge.link.capacityBps) : L.pipeBase,
+            'stroke-linecap': 'round',
+            opacity: isClientLink ? '0.35' : '0.6',
+        }, this._gLinks);
+
+        if (edge) {
+            edge._pathEl = pathEl;
+            edge._x1 = parent.x; edge._y1 = y1;
+            edge._x2 = child.x; edge._y2 = y2;
+            edge._isClientLink = isClientLink;
+            edge._band = band;
+        }
+
+        // Capacity label for infra links
+        if (!isClientLink && edge?.link.capacityBps) {
+            const cap = edge.link.capacityBps / 1e6;
+            if (cap > 0) {
+                const label = formatLinkSpeed(cap);
+                const midX = (parent.x + child.x) / 2;
+                const midY = (y1 + y2) / 2;
+                this._renderCapLabel(midX, midY, label);
+            }
+        }
+    }
+
+    _renderCapLabel(x, y, text) {
+        const g = svg('g', { transform: `translate(${x},${y})` }, this._gLabels);
+
+        const tw = text.length * 5.5 + 12;
+        svg('rect', {
+            x: -tw / 2, y: -8,
+            width: tw, height: 16,
+            rx: 4,
+            fill: COLORS.labelBg,
+        }, g);
+
+        const t = svg('text', {
+            x: 0, y: 4,
+            'text-anchor': 'middle',
+            fill: COLORS.textMuted,
+            'font-size': L.rateFont,
+            'font-family': 'system-ui, sans-serif',
+        }, g);
+        t.textContent = text;
+    }
+
+    // ---- Cloud rendering ----
+
+    _renderClouds() {
+        for (const cloud of this._clouds) {
+            const g = svg('g', { transform: `translate(${cloud.x},${cloud.y})` }, this._gNodes);
+            const r = L.cloudR;
+
+            // Wireframe globe
+            svg('circle', { cx: 0, cy: 0, r, fill: 'none', stroke: COLORS.cloudStroke, 'stroke-width': 1.5, opacity: 0.8 }, g);
+            svg('ellipse', { cx: 0, cy: 0, rx: r * 0.5, ry: r, fill: 'none', stroke: COLORS.cloudStroke, 'stroke-width': 1, opacity: 0.4 }, g);
+            svg('ellipse', { cx: 0, cy: 0, rx: r, ry: r * 0.35, fill: 'none', stroke: COLORS.cloudStroke, 'stroke-width': 1, opacity: 0.4 }, g);
+            svg('ellipse', { cx: 0, cy: 0, rx: r, ry: r * 0.65, fill: 'none', stroke: COLORS.cloudStroke, 'stroke-width': 0.7, opacity: 0.25 }, g);
+
+            // Subtle fill
+            svg('circle', { cx: 0, cy: 0, r: r - 1, fill: COLORS.cloudStroke, opacity: 0.06 }, g);
+
+            // Name label below
+            const name = cloud.data.asnName || cloud.data.name || 'WAN';
+            const label = svg('text', {
+                x: 0, y: r + 16,
+                'text-anchor': 'middle',
+                fill: COLORS.textSec,
+                'font-size': L.nameFont,
+                'font-family': 'system-ui, sans-serif',
+                'font-weight': 500,
+            }, g);
+            label.textContent = name;
+
+            // RTT badge
+            cloud._rttEl = svg('text', {
+                x: 0, y: r + 30,
+                'text-anchor': 'middle',
+                fill: COLORS.textMuted,
+                'font-size': L.rateFont - 1,
+                'font-family': 'system-ui, sans-serif',
+            }, g);
+            this._updateCloudBadge(cloud);
+        }
+    }
+
+    _updateCloudBadge(cloud) {
+        if (!cloud._rttEl) return;
+        const d = cloud.data;
+        let txt = '';
+        if (d.rttAvgMs != null) txt += `${d.rttAvgMs.toFixed(1)} ms`;
+        if (d.lossPercent != null && d.lossPercent > 0) {
+            txt += txt ? ' / ' : '';
+            txt += `${d.lossPercent.toFixed(1)}% loss`;
+        }
+        cloud._rttEl.textContent = txt;
+    }
+
+    // ---- Node rendering ----
+
+    _renderTreeNodes(node) {
+        this._renderInfraNode(node);
+        for (const child of node.infraChildren) this._renderTreeNodes(child);
+        for (const child of node.clientChildren.slice(0, L.maxClients)) {
+            this._renderClientNode(child);
+        }
+        // "+N more" indicator
+        if (node.clientChildren.length > L.maxClients) {
+            const last = node.clientChildren[L.maxClients - 1];
+            const extra = node.clientChildren.length - L.maxClients;
+            const t = svg('text', {
+                x: last.x + L.clientSize + 8,
+                y: last.y + 4,
+                fill: COLORS.textMuted,
+                'font-size': L.rateFont,
+                'font-family': 'system-ui, sans-serif',
+            }, this._gLabels);
+            t.textContent = `+${extra}`;
+        }
+    }
+
+    _renderInfraNode(node) {
+        const g = svg('g', {
+            transform: `translate(${node.x},${node.y})`,
+            class: 'infra-node',
+        }, this._gNodes);
+
+        const color = nodeColor(node.d.kind);
+        const hw = L.infraW / 2;
+        const hh = L.infraH / 2;
+        const iconSize = 40;
+
+        // Glow ring behind
+        svg('rect', {
+            x: -hw - 4, y: -hh - 4,
+            width: L.infraW + 8, height: L.infraH + 8,
+            rx: 12,
+            fill: color,
+            opacity: 0.08,
+            filter: 'url(#node-glow)',
+        }, g);
+
+        // Background card
+        svg('rect', {
+            x: -hw, y: -hh,
+            width: L.infraW, height: L.infraH,
+            rx: 8,
+            fill: '#1a1d23',
+            stroke: color,
+            'stroke-width': 1.5,
+            opacity: node.d.online ? 1 : 0.4,
+        }, g);
+
+        // Device icon or fallback
+        if (node.d.model) {
+            const imgPath = `/images/devices/${node.d.model.toLowerCase().replace(/ /g, '-')}.png`;
+            const img = svg('image', {
+                href: imgPath,
+                x: -iconSize / 2, y: -iconSize / 2,
+                width: iconSize, height: iconSize,
+                opacity: node.d.online ? 1 : 0.4,
+            }, g);
+            img.addEventListener('error', () => {
+                img.remove();
+                this._renderFallbackIcon(g, node, color, iconSize);
+            }, { once: true });
+        } else {
+            this._renderFallbackIcon(g, node, color, iconSize);
+        }
+
+        // Name label below
+        const name = node.d.name || node.d.model || '';
+        if (name) {
+            const displayName = name.length > 14 ? name.slice(0, 13) + '…' : name;
+            const t = svg('text', {
+                x: 0, y: hh + 16,
+                'text-anchor': 'middle',
+                fill: COLORS.text,
+                'font-size': L.nameFont,
+                'font-family': 'system-ui, sans-serif',
+                'font-weight': 500,
+            }, g);
+            t.textContent = displayName;
+        }
+
+        // Rate label (updated dynamically)
+        node._rateGroup = svg('g', { transform: `translate(0, ${hh + 30})` }, g);
+        node._rateDown = svg('text', {
+            x: -4, y: 0,
+            'text-anchor': 'end',
+            fill: COLORS.downstream,
+            'font-size': L.rateFont,
+            'font-family': 'system-ui, sans-serif',
+        }, node._rateGroup);
+        node._rateUp = svg('text', {
+            x: 4, y: 0,
+            'text-anchor': 'start',
+            fill: COLORS.upstream,
+            'font-size': L.rateFont,
+            'font-family': 'system-ui, sans-serif',
+        }, node._rateGroup);
+    }
+
+    _renderFallbackIcon(g, node, color, size) {
+        const hs = size / 2;
+        svg('rect', {
+            x: -hs + 4, y: -hs + 4,
+            width: size - 8, height: size - 8,
+            rx: 6,
+            fill: color,
+            opacity: 0.2,
+        }, g);
+        const letter = (node.d.name || 'D').charAt(0).toUpperCase();
+        const t = svg('text', {
+            x: 0, y: 5,
+            'text-anchor': 'middle',
+            fill: color,
+            'font-size': 16,
+            'font-weight': 600,
+            'font-family': 'system-ui, sans-serif',
+        }, g);
+        t.textContent = letter;
+    }
+
+    _renderClientNode(node) {
+        const g = svg('g', {
+            transform: `translate(${node.x},${node.y})`,
+            class: 'client-node',
+        }, this._gNodes);
+
+        const color = nodeColor(node.d.kind, node.d.band);
+        const r = L.clientSize / 2 - 1;
+
+        if (node.d.kind === NODE_KIND.WifiClient) {
+            // Circle for WiFi client
+            svg('circle', {
+                cx: 0, cy: 0, r,
+                fill: color,
+                opacity: node.d.online ? 0.7 : 0.2,
+            }, g);
+            // WiFi arc indicator
+            svg('path', {
+                d: `M${-3} ${-1}Q0 ${-5} 3 ${-1}`,
+                fill: 'none',
+                stroke: '#fff',
+                'stroke-width': 1,
+                opacity: 0.5,
+            }, g);
+        } else {
+            // Rounded rect for wired client (monitor shape)
+            const s = r * 1.4;
+            svg('rect', {
+                x: -s, y: -s + 1,
+                width: s * 2, height: s * 1.6,
+                rx: 2,
+                fill: color,
+                opacity: node.d.online ? 0.6 : 0.2,
+            }, g);
+            // Stand
+            svg('line', {
+                x1: 0, y1: s * 0.6 + 1,
+                x2: 0, y2: s + 1,
+                stroke: color,
+                'stroke-width': 1.5,
+                opacity: node.d.online ? 0.6 : 0.2,
+            }, g);
+        }
+
+        // Tooltip via data-tooltip
+        const name = node.d.name || node.d.ip || '';
+        if (name) g.setAttribute('data-tooltip', name);
+    }
+
+    // ---- Rate updates ----
+
+    _updateRates() {
+        this._updateNodeRateLabels();
+        this._updatePipeColors();
+        this._syncParticles();
+    }
+
+    _updateNodeRateLabels() {
+        if (!this._root) return;
+
+        const nodeRates = new Map();
+        for (const edge of this._linkEdges) {
+            const rates = this._liveRates[edge.link.portKey] || this._liveRates[edge.link.id];
+            if (!rates) continue;
+            const down = rates.downstreamBps ?? rates.DownstreamBps ?? 0;
+            const up = rates.upstreamBps ?? rates.UpstreamBps ?? 0;
+
+            // Accumulate on parent infrastructure node
+            for (const nodeId of [edge.link.fromNodeId, edge.link.toNodeId]) {
+                const tn = this._treeNodes.get(nodeId);
+                if (tn && isInfra(tn.d.kind)) {
+                    const cur = nodeRates.get(nodeId) || { down: 0, up: 0 };
+                    cur.down += down;
+                    cur.up += up;
+                    nodeRates.set(nodeId, cur);
+                }
+            }
+        }
+
+        const updateNode = (node) => {
+            const r = nodeRates.get(node.d.id);
+            if (node._rateDown) {
+                const d = r?.down || 0;
+                const u = r?.up || 0;
+                node._rateDown.textContent = d > RATE_THRESHOLD ? '↓ ' + formatBps(d) : '';
+                node._rateUp.textContent = u > RATE_THRESHOLD ? '↑ ' + formatBps(u) : '';
+            }
+            for (const c of node.infraChildren) updateNode(c);
+        };
+        updateNode(this._root);
+    }
+
+    _updatePipeColors() {
+        for (const edge of this._linkEdges) {
+            if (!edge._pathEl) continue;
+            const rates = this._liveRates[edge.link.portKey] || this._liveRates[edge.link.id];
+            if (!rates) continue;
+            const down = rates.downstreamBps ?? rates.DownstreamBps ?? 0;
+            const up = rates.upstreamBps ?? rates.UpstreamBps ?? 0;
+            const cap = edge.link.capacityBps || 1e9;
+            const util = Math.max(down, up) / cap;
+            const color = pipeColorForUtil(Math.min(util, 1), edge._band);
+            edge._pathEl.setAttribute('stroke', color);
+            const op = edge._isClientLink ? 0.35 + util * 0.4 : 0.5 + util * 0.5;
+            edge._pathEl.setAttribute('opacity', String(Math.min(op, 1)));
+        }
+    }
+
+    // ---- Particle system ----
+
+    _syncParticles() {
+        // Remove all existing particles
+        this._gParticles.innerHTML = '';
+        this._particles = [];
+
+        for (const edge of this._linkEdges) {
+            if (!edge._pathEl || edge._isClientLink) continue;
+            const rates = this._liveRates[edge.link.portKey] || this._liveRates[edge.link.id];
+            if (!rates) continue;
+            const down = rates.downstreamBps ?? rates.DownstreamBps ?? 0;
+            const up = rates.upstreamBps ?? rates.UpstreamBps ?? 0;
+
+            const len = orthoLength(edge._x1, edge._y1, edge._x2, edge._y2);
+            if (len < 10) continue;
+
+            // Downstream particles (flow along path direction: parent → child)
+            if (down > RATE_THRESHOLD) {
+                const count = Math.min(Math.ceil(Math.log10(Math.max(down, 1)) / 2.5), 5);
+                const speed = 0.3 + Math.min(Math.log10(Math.max(down, 1)) / 11, 1) * 0.7;
+                for (let i = 0; i < count; i++) {
+                    const el = svg('circle', {
+                        r: L.particleR,
+                        fill: COLORS.downstream,
+                        opacity: 0.85,
+                        filter: 'url(#particle-glow)',
+                    }, this._gParticles);
+                    this._particles.push({
+                        el, edge,
+                        t: i / count,
+                        speed,
+                        dir: 1,
+                    });
+                }
+            }
+
+            // Upstream particles (flow against path: child → parent)
+            if (up > RATE_THRESHOLD) {
+                const count = Math.min(Math.ceil(Math.log10(Math.max(up, 1)) / 2.5), 5);
+                const speed = 0.3 + Math.min(Math.log10(Math.max(up, 1)) / 11, 1) * 0.7;
+                for (let i = 0; i < count; i++) {
+                    const el = svg('circle', {
+                        r: L.particleR,
+                        fill: COLORS.upstream,
+                        opacity: 0.85,
+                        filter: 'url(#particle-glow)',
+                    }, this._gParticles);
+                    this._particles.push({
+                        el, edge,
+                        t: i / count,
+                        speed,
+                        dir: -1,
+                    });
+                }
+            }
+        }
+    }
+
+    _animate() {
+        const now = performance.now();
+        const dt = Math.min((now - this._lastFrame) / 1000, 0.1);
+        this._lastFrame = now;
+
+        for (const p of this._particles) {
+            p.t += p.speed * dt * p.dir;
+            if (p.t > 1) p.t -= 1;
+            if (p.t < 0) p.t += 1;
+
+            const pt = orthoPointAt(
+                p.edge._x1, p.edge._y1,
+                p.edge._x2, p.edge._y2,
+                p.t
+            );
+            p.el.setAttribute('cx', pt.x);
+            p.el.setAttribute('cy', pt.y);
+        }
+
+        this._animId = requestAnimationFrame(() => this._animate());
+    }
+}
+
+// ---- Module exports ----
+
+let _instance = null;
+
+export async function mount(containerId) {
+    if (_instance) { _instance.dispose(); _instance = null; }
+    const el = document.getElementById(containerId);
+    if (!el) return;
+    _instance = new LanFlowMap2D(el);
+    await _instance.start();
+}
+
+export function unmount() {
+    if (_instance) { _instance.dispose(); _instance = null; }
+}

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -534,18 +534,27 @@ class LanFlowMap2D {
         const selfW=isClient(n.d.kind)?G.clientCellW:G.boxW+40;
         const nc=Math.min(n.clients.length,G.maxClients);
 
+        // VirtualHub: treat as a leaf (children won't be rendered)
+        if(n.d.kind===NK.VirtualHub){
+            const hubW=G.clientCellW;
+            n._contour=[{l:-hubW/2,r:hubW/2}];
+            n._kidOffsets=[];
+            n._kids=[];
+            return;
+        }
+
         // Pure-client nodes (APs with only WiFi clients): compact grid
         if(n.infra.length===0&&nc>0){
             const cols=Math.min(nc,G.clientCols);
             const rows=Math.ceil(nc/cols);
             const gridW=cols*G.clientCellW;
-            const gridH=rows*G.clientCellH;
+            const staggerExtra=rows>1?G.clientCellW/2:0;
             n._isGrid=true;
             n._gridCols=cols;
-            // Contour: node at depth 0, grid rectangle at depth 1
+            // Contour: node at depth 0, grid rectangle at depth 1 (widened for stagger)
             n._contour=[
                 {l:-selfW/2,r:selfW/2},
-                {l:-gridW/2,r:gridW/2},
+                {l:-gridW/2,r:gridW/2+staggerExtra},
             ];
             n._kidOffsets=[];
             n._kids=[];
@@ -620,16 +629,19 @@ class LanFlowMap2D {
         n.x=absX;
         n.y=yOff+depth*G.tierGap;
 
-        // Client grid: place clients in compact rows
+        // Client grid: compact rows with honeycomb stagger so vertical links
+        // from the parent fan out to different x positions per row.
         if(n._isGrid){
             const nc=Math.min(n.clients.length,G.maxClients);
             const cols=n._gridCols;
             const gridW=cols*G.clientCellW;
             const gridLeft=absX-gridW/2;
             const clientY=yOff+(depth+1)*G.tierGap;
+            const stagger=G.clientCellW/2;
             for(let i=0;i<nc;i++){
                 const col=i%cols,row=Math.floor(i/cols);
-                n.clients[i].x=gridLeft+col*G.clientCellW+G.clientCellW/2;
+                const rowOff=(row%2)*stagger;
+                n.clients[i].x=gridLeft+col*G.clientCellW+G.clientCellW/2+rowOff;
                 n.clients[i].y=clientY+row*G.clientCellH;
             }
             return;
@@ -908,6 +920,11 @@ class LanFlowMap2D {
     // ---- Node drawing ----
 
     _drawAllNodes(ctx,n){
+        // VirtualHub: show as compact label with member count, skip children
+        if(n.d.kind===NK.VirtualHub){
+            this._drawHubNode(ctx,n);
+            return;
+        }
         this._drawInfraNode(ctx,n);
         for(const c of n.infra)this._drawAllNodes(ctx,c);
         for(const c of n.clients.slice(0,G.maxClients))this._drawClientNode(ctx,c);
@@ -918,6 +935,28 @@ class LanFlowMap2D {
             ctx.textAlign='left'; ctx.textBaseline='middle';
             ctx.fillText(`+${n.clients.length-G.maxClients}`,last.x+G.clientR+10,last.y);
         }
+    }
+
+    _drawHubNode(ctx,n){
+        const x=n.x,y=n.y,color=C.virtualHub;
+        const memberCount=n.infra.length+n.clients.length;
+        const r=10;
+
+        // Small ring
+        ctx.strokeStyle=color; ctx.lineWidth=2; ctx.globalAlpha=0.6;
+        ctx.beginPath(); ctx.arc(x,y,r,0,Math.PI*2); ctx.stroke();
+        ctx.fillStyle=withAlpha(color,0.1);
+        ctx.beginPath(); ctx.arc(x,y,r-1,0,Math.PI*2); ctx.fill();
+        ctx.globalAlpha=1;
+
+        // Label: "NAS Server (7)"
+        const name=n.d.name||'Hub';
+        const label=memberCount>0?`${name} (${memberCount})`:name;
+        const dn=label.length>28?label.slice(0,27)+'…':label;
+        ctx.fillStyle=C.textSec;
+        ctx.font=`${G.nameFont}px ${FONT}`;
+        ctx.textAlign='center'; ctx.textBaseline='top';
+        ctx.fillText(dn,x,y+r+4);
     }
 
     _drawInfraNode(ctx,n){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -263,15 +263,15 @@ class LanFlowMap2D {
                         this._buildLayout(s);
                         this._loadImages(s).then(()=>{this._fitAll();this._needsStaticRedraw=true;});
                     }else{
-                        // Refresh: detect topology change by link count
-                        const newLinkCount=s.links?.length||0;
-                        const curLinkCount=this._edges?.length||0;
-                        if(newLinkCount!==curLinkCount){
-                            // Topology changed: full rebuild, keep view
+                        // Detect infrastructure change (devices, not just client churn)
+                        const infraCount=(nodes)=>(nodes||[]).filter(n=>n.kind<=3||n.kind===6).length;
+                        const prevInfra=infraCount(this._snapshot?.nodes);
+                        const newInfra=infraCount(s.nodes);
+                        if(newInfra!==prevInfra){
                             this._buildLayout(s);
                             this._loadImages(s).then(()=>{this._needsStaticRedraw=true;});
                         }else{
-                            // Same topology: just update data (clouds, node props)
+                            // Client churn or same topology: update data in place
                             this._updateSnapshotData(s);
                             this._needsStaticRedraw=true;
                         }
@@ -816,7 +816,11 @@ class LanFlowMap2D {
                 c.d.lossPercent=fresh.lossPercent;
             }
         }
-        // Update node data (PHY rates, online status) on existing tree nodes
+        // Update node data and detect client changes per parent
+        const newNodeMap=new Map();
+        for(const n of snap.nodes)newNodeMap.set(n.id,n);
+
+        let clientsChanged=false;
         for(const n of snap.nodes){
             const tn=this._treeMap.get(n.id);
             if(tn){
@@ -825,7 +829,18 @@ class LanFlowMap2D {
                 tn.d.phyRxKbps=n.phyRxKbps;
                 tn.d.band=n.band;
                 tn.d.signalDbm=n.signalDbm;
+            }else if(isClient(n.kind)){
+                clientsChanged=true;
             }
+        }
+        // Check for removed clients
+        for(const[id,tn]of this._treeMap){
+            if(isClient(tn.d.kind)&&!newNodeMap.has(id))clientsChanged=true;
+        }
+        // If clients changed, do a targeted layout rebuild
+        if(clientsChanged){
+            this._liveRates={...flowData.getLiveRates()};
+            this._buildLayout(snap);
         }
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -671,7 +671,7 @@ class LanFlowMap2D {
         // WAN cloud links - stagger by index
         const wanEdges=[];
         for(const cloud of this._clouds){
-            const cy=cloud.y+G.cloudR+8;
+            const cy=cloud.y+G.cloudR+1;
             const edge=this._edges.find(e=>
                 (e.lk.kind===LK.Wan||e.lk.kind===LK.Transit)
                 &&(e.lk.fromNodeId===cloud.d.id||e.lk.toNodeId===cloud.d.id));
@@ -689,7 +689,8 @@ class LanFlowMap2D {
             const sibEdges=[];
 
             for(const c of n.infra){
-                const cT=c.y-G.boxH/2;
+                // VirtualHub renders as a small ring (r=10), not a full box
+                const cT=c.d.kind===NK.VirtualHub?c.y-12:c.y-G.boxH/2;
                 const edge=this._edges.find(e=>
                     (e.lk.fromNodeId===n.d.id&&e.lk.toNodeId===c.d.id)
                     ||(e.lk.fromNodeId===c.d.id&&e.lk.toNodeId===n.d.id));

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -36,7 +36,7 @@ const LK = { Uplink:0, WiredClient:1, WifiClient:2, Wan:3, Transit:4, MeshBackha
 // ---- Layout geometry ----
 const G = {
     tierGap:     170,
-    cloudGap:    160,
+    cloudGap:    220,
     infraGap:    90,
     clientCellW: 145,
     clientCellH: 50,
@@ -996,11 +996,13 @@ class LanFlowMap2D {
             // Capacity / speed label on infra and WAN links
             if(!e._isCl){
                 ctx.globalAlpha=1;
-                const mx=(e._x1+e._x2)/2, my=(e._y1+e._y2)/2;
+                // WAN labels go on the vertical segment near the cloud, not the shared midpoint
+                const isWan=e._isWan;
+                const mx=isWan?e._x1:(e._x1+e._x2)/2;
+                const my=isWan?e._y1+30:(e._y1+e._y2)/2;
                 let txt=null;
 
-                if(e._isWan){
-                    // WAN links: show ISP expected speeds from cloud data
+                if(isWan){
                     const cloud=this._clouds.find(c=>
                         e.lk.fromNodeId===c.d.id||e.lk.toNodeId===c.d.id);
                     if(cloud?.d.ispDownloadMbps&&cloud?.d.ispUploadMbps){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -130,9 +130,17 @@ function orthoAt(x1,y1,x2,y2,t,midYOff) {
     const s1=top-cr,s2=Math.PI/2*cr,s3=ax-2*cr,s4=s2,s5=bot-cr;
     const tot=s1+s2+s3+s4+s5;let d=t*tot;
     if(d<=s1)return{x:x1,y:y1+d};d-=s1;
-    if(d<=s2){const a=d/s2*Math.PI/2;return{x:x1+s*cr*Math.sin(a),y:midY-cr+cr*(1-Math.cos(a))};}d-=s2;
+    if(d<=s2){
+        // Quadratic bezier matching strokeOrtho: P0=(x1,midY-cr) P1=(x1,midY) P2=(x1+s*cr,midY)
+        const bt=d/s2,u=1-bt;
+        return{x:u*u*x1+2*u*bt*x1+bt*bt*(x1+s*cr), y:u*u*(midY-cr)+2*u*bt*midY+bt*bt*midY};
+    }d-=s2;
     if(d<=s3)return{x:x1+s*(cr+d),y:midY};d-=s3;
-    if(d<=s4){const a=d/s4*Math.PI/2;return{x:(x2-s*cr)+s*cr*Math.sin(a),y:midY+cr*(1-Math.cos(a))};}d-=s4;
+    if(d<=s4){
+        // Quadratic bezier: P0=(x2-s*cr,midY) P1=(x2,midY) P2=(x2,midY+cr)
+        const bt=d/s4,u=1-bt;
+        return{x:u*u*(x2-s*cr)+2*u*bt*x2+bt*bt*x2, y:u*u*midY+2*u*bt*midY+bt*bt*(midY+cr)};
+    }d-=s4;
     return{x:x2,y:midY+cr+d};
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -266,6 +266,8 @@ class LanFlowMap2D {
                 this._updateStreamRates();
                 this._updateCloudStats();
                 this._needsStaticRedraw=true;
+            }else if(ev==='scrubber'||ev==='playstate'){
+                this._syncScrubber();
             }
         });
         this._lastFrame=performance.now();
@@ -331,6 +333,56 @@ class LanFlowMap2D {
             else if(a==='fit')this._fitAll();
         });
         this._el.appendChild(tb);
+
+        // Mirror scrubber (synced from 3D map via shared data store).
+        // Interactions forward to the 3D map's instance.
+        const scrubber=document.createElement('div');
+        scrubber.className='lan-flow-map-scrubber';
+        scrubber.innerHTML=`
+            <div class="lan-flow-map-scrubber-row">
+                <button class="lan-flow-map-scrubber-playpause" data-role="playpause" type="button" aria-label="Pause">⏸</button>
+                <div class="lan-flow-map-speed-control" data-role="speed">
+                    <button class="lan-flow-map-speed-step" data-dir="-1" type="button" aria-label="Slower">-</button>
+                    <span class="lan-flow-map-speed-label" data-role="speed-label">1x</span>
+                    <button class="lan-flow-map-speed-step" data-dir="1" type="button" aria-label="Faster">+</button>
+                </div>
+                <span data-role="left">-24h</span>
+                <input class="lan-flow-map-scrubber-range" type="range" min="0" max="10000" value="10000" />
+                <span data-role="right" style="min-width:10ch">Live</span>
+            </div>`;
+        // Forward all interactions to the 3D map
+        const fwd=()=>window.__lanFlowMap;
+        const sRange=scrubber.querySelector('.lan-flow-map-scrubber-range');
+        sRange.addEventListener('input',(e)=>{
+            const m=fwd();if(m?._instance){
+                const r=m._instance._panels?.scrubberRange;
+                if(r){r.value=e.target.value;r.dispatchEvent(new Event('input'));}
+            }
+        });
+        sRange.addEventListener('change',(e)=>{
+            const m=fwd();if(m?._instance){
+                const r=m._instance._panels?.scrubberRange;
+                if(r){r.value=e.target.value;r.dispatchEvent(new Event('change'));}
+            }
+        });
+        scrubber.querySelector('[data-role="playpause"]').addEventListener('click',()=>{
+            const m=fwd();if(m?._instance)m._instance._togglePlayPause();
+        });
+        for(const btn of scrubber.querySelectorAll('.lan-flow-map-speed-step')){
+            btn.addEventListener('click',()=>{
+                const m=fwd();if(m?._instance){
+                    const ob=m._instance._panels?.scrubber?.querySelector(`.lan-flow-map-speed-step[data-dir="${btn.dataset.dir}"]`);
+                    if(ob)ob.click();
+                }
+            });
+        }
+        this._el.appendChild(scrubber);
+        this._scrubberEls={
+            range:sRange,
+            right:scrubber.querySelector('[data-role="right"]'),
+            playPause:scrubber.querySelector('[data-role="playpause"]'),
+            speedLabel:scrubber.querySelector('[data-role="speed-label"]'),
+        };
 
         // Events
         canvas.addEventListener('wheel',(e)=>this._onWheel(e),{passive:false});
@@ -414,6 +466,15 @@ class LanFlowMap2D {
         this._ox=this._bx+this._bw/2;
         this._oy=this._by+this._bh/2;
         this._needsStaticRedraw=true;
+    }
+
+    _syncScrubber(){
+        if(!this._scrubberEls)return;
+        const s=flowData.getScrubber();
+        this._scrubberEls.range.value=s.value;
+        this._scrubberEls.right.textContent=s.right;
+        this._scrubberEls.speedLabel.textContent=`${s.speed}x`;
+        this._scrubberEls.playPause.textContent=flowData.isPaused()?'▶':'⏸';
     }
 
     _zoomBy(factor){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -793,7 +793,12 @@ class LanFlowMap2D {
         const gx=this._root.x,gy=this._root.y;
         const total=this._clouds.length,sp=G.cloudGap;
         const sx=gx-((total-1)*sp)/2;
-        for(let i=0;i<total;i++){this._clouds[i].x=sx+i*sp;this._clouds[i].y=gy-G.tierGap;}
+        const baseY=gy-G.tierGap*1.4;
+        const stagger=45;
+        for(let i=0;i<total;i++){
+            this._clouds[i].x=sx+i*sp;
+            this._clouds[i].y=baseY+(i%2)*stagger;
+        }
     }
 
     _matchEdges(){
@@ -1044,20 +1049,32 @@ class LanFlowMap2D {
         for(const cloud of this._clouds){
             const cx=cloud.x, cy=cloud.y, r=G.cloudR;
 
-            // Globe wireframe
+            // Subtle radial fill
+            const grad=ctx.createRadialGradient(cx-r*0.3,cy-r*0.3,0,cx,cy,r);
+            grad.addColorStop(0,'rgba(59,130,246,0.08)');
+            grad.addColorStop(1,'rgba(59,130,246,0.02)');
+            ctx.fillStyle=grad;
+            ctx.beginPath(); ctx.arc(cx,cy,r,0,Math.PI*2); ctx.fill();
+
+            // Outer circle
             ctx.strokeStyle=C.globeStroke;
             ctx.lineWidth=1.5; ctx.globalAlpha=0.8;
             ctx.beginPath(); ctx.arc(cx,cy,r,0,Math.PI*2); ctx.stroke();
 
-            ctx.lineWidth=1; ctx.globalAlpha=0.35;
-            ctx.beginPath(); ctx.ellipse(cx,cy,r*0.45,r,0,0,Math.PI*2); ctx.stroke();
-            ctx.beginPath(); ctx.ellipse(cx,cy,r,r*0.35,0,0,Math.PI*2); ctx.stroke();
+            // Longitude lines (3 meridians at different tilts)
+            ctx.lineWidth=0.8; ctx.globalAlpha=0.3;
+            for(const rx of [0.15, 0.5, 0.85]){
+                ctx.beginPath(); ctx.ellipse(cx,cy,r*rx,r,0,0,Math.PI*2); ctx.stroke();
+            }
 
-            ctx.lineWidth=0.7; ctx.globalAlpha=0.2;
-            ctx.beginPath(); ctx.ellipse(cx,cy,r,r*0.65,0,0,Math.PI*2); ctx.stroke();
+            // Latitude lines (equator + two parallels)
+            for(const ry of [0.35, 0.65]){
+                ctx.beginPath(); ctx.ellipse(cx,cy,r,r*ry,0,0,Math.PI*2); ctx.stroke();
+            }
+            // Equator slightly brighter
+            ctx.globalAlpha=0.45; ctx.lineWidth=0.9;
+            ctx.beginPath(); ctx.ellipse(cx,cy,r,r*0.08,0,0,Math.PI*2); ctx.stroke();
 
-            ctx.fillStyle=C.globeStroke; ctx.globalAlpha=0.05;
-            ctx.beginPath(); ctx.arc(cx,cy,r-1,0,Math.PI*2); ctx.fill();
             ctx.globalAlpha=1;
 
             // Name

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1153,13 +1153,15 @@ class LanFlowMap2D {
 
         if(!this._root)return;
 
-        // Links
+        // Links (pipes only)
+        this._pendingLinkLabels=[];
         this._drawAllLinks(ctx);
         // Clouds (if overlay enabled)
         if(this._isCloudVisible())this._drawAllClouds(ctx);
         // Infra + client nodes
         this._drawAllNodes(ctx,this._root);
-        // Rate labels
+        // All labels on top (capacity + live rates + node rates)
+        this._drawLinkSpeedLabels(ctx);
         this._drawRateLabels(ctx);
     }
 
@@ -1225,29 +1227,33 @@ class LanFlowMap2D {
                     txt=formatSpeed(e.lk.capacityBps/1e6);
                 }
 
-                if(txt){
-                    ctx.font=`${G.rateFont}px ${FONT}`;
-                    const tw=ctx.measureText(txt).width+12;
-                    ctx.fillStyle=C.labelBg;
-                    this._roundRect(ctx,mx-tw/2,my-8,tw,16,4);
-                    ctx.fill();
-                    if(txtColor){
-                        ctx.fillStyle=txtColor;
-                        ctx.textAlign='center'; ctx.textBaseline='middle';
-                        ctx.fillText(txt,mx,my);
-                    }else{
-                        // Directional colors: split at the space between ↑ and preceding text
-                        const parts=txt.split(' ↑');
-                        ctx.textBaseline='middle';
-                        ctx.textAlign='right'; ctx.fillStyle=C.downstream;
-                        ctx.fillText(parts[0],mx-4,my);
-                        ctx.textAlign='left'; ctx.fillStyle=C.upstream;
-                        ctx.fillText('↑'+parts[1],mx+4,my);
-                    }
-                }
+                if(txt) this._pendingLinkLabels.push({mx,my,txt,txtColor});
             }
         }
         ctx.globalAlpha=1;
+    }
+
+    _drawLinkSpeedLabels(ctx){
+        ctx.font=`${G.rateFont}px ${FONT}`;
+        for(const{mx,my,txt,txtColor}of(this._pendingLinkLabels||[])){
+            const tw=ctx.measureText(txt).width+12;
+            ctx.fillStyle=C.labelBg;
+            ctx.globalAlpha=1;
+            this._roundRect(ctx,mx-tw/2,my-8,tw,16,4);
+            ctx.fill();
+            if(txtColor){
+                ctx.fillStyle=txtColor;
+                ctx.textAlign='center'; ctx.textBaseline='middle';
+                ctx.fillText(txt,mx,my);
+            }else{
+                const parts=txt.split(' ↑');
+                ctx.textBaseline='middle';
+                ctx.textAlign='right'; ctx.fillStyle=C.downstream;
+                ctx.fillText(parts[0],mx-4,my);
+                ctx.textAlign='left'; ctx.fillStyle=C.upstream;
+                ctx.fillText('↑'+parts[1],mx+4,my);
+            }
+        }
     }
 
     // ---- Cloud drawing ----

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -351,27 +351,27 @@ class LanFlowMap2D {
                 <span data-role="right" style="min-width:10ch">Live</span>
             </div>`;
         // Forward all interactions to the 3D map
-        const fwd=()=>window.__lanFlowMap;
+        const fwd=()=>window.__lanFlowMap?.getInstance?.();
         const sRange=scrubber.querySelector('.lan-flow-map-scrubber-range');
         sRange.addEventListener('input',(e)=>{
-            const m=fwd();if(m?._instance){
-                const r=m._instance._panels?.scrubberRange;
+            const inst=fwd();if(inst){
+                const r=inst._panels?.scrubberRange;
                 if(r){r.value=e.target.value;r.dispatchEvent(new Event('input'));}
             }
         });
         sRange.addEventListener('change',(e)=>{
-            const m=fwd();if(m?._instance){
-                const r=m._instance._panels?.scrubberRange;
+            const inst=fwd();if(inst){
+                const r=inst._panels?.scrubberRange;
                 if(r){r.value=e.target.value;r.dispatchEvent(new Event('change'));}
             }
         });
         scrubber.querySelector('[data-role="playpause"]').addEventListener('click',()=>{
-            const m=fwd();if(m?._instance)m._instance._togglePlayPause();
+            const inst=fwd();if(inst)inst._togglePlayPause();
         });
         for(const btn of scrubber.querySelectorAll('.lan-flow-map-speed-step')){
             btn.addEventListener('click',()=>{
-                const m=fwd();if(m?._instance){
-                    const ob=m._instance._panels?.scrubber?.querySelector(`.lan-flow-map-speed-step[data-dir="${btn.dataset.dir}"]`);
+                const inst=fwd();if(inst){
+                    const ob=inst._panels?.scrubber?.querySelector(`.lan-flow-map-speed-step[data-dir="${btn.dataset.dir}"]`);
                     if(ob)ob.click();
                 }
             });

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -58,7 +58,7 @@ const G = {
 
 const RATE_THRESH = 1_000_000;
 const EMIT_MAX = 12;
-const MAX_DOTS = 14;
+const MAX_DOTS = 20;
 const FONT = 'system-ui, -apple-system, sans-serif';
 
 // ---- Helpers ----
@@ -177,7 +177,7 @@ class Stream {
         this.dotSize=0.4+(intensity*intensity)*1.2;
         // Constant visual speed: match 3D map (2.5 + intensity*4 scene-units/sec)
         // scaled to SVG pixels. Divide by path length for normalized t/sec.
-        const absPxSec=50+intensity*80;
+        const absPxSec=30+intensity*50;
         this.velNorm=absPxSec/Math.max(this.pathLen,1);
 
         // Pre-seed on first non-zero rate so the pipe is already populated

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1006,7 +1006,8 @@ class LanFlowMap2D {
                 const isWan=e._isWan;
                 const midY=(e._y1+e._y2)/2+(e._midYOff||0);
                 const mx=isWan?e._x1:(e._x1+e._x2)/2;
-                const my=isWan?(e._y1+midY)/2:(e._y1+e._y2)/2;
+                // WAN: place just above the horizontal routing segment
+                const my=isWan?midY-16:(e._y1+e._y2)/2;
                 let txt=null;
 
                 if(isWan){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -993,23 +993,35 @@ class LanFlowMap2D {
             ctx.globalAlpha=e._isCl?0.3+u*0.45:0.5+u*0.5;
             strokeOrtho(ctx,e._x1,e._y1,e._x2,e._y2,e._midYOff);
 
-            // Capacity label on infra links
-            if(!e._isCl&&e.lk.capacityBps){
-                const cap=e.lk.capacityBps/1e6;
-                if(cap>0){
-                    ctx.globalAlpha=1;
-                    const mx=(e._x1+e._x2)/2, my=(e._y1+e._y2)/2;
-                    // Wireless links (mesh/wifi): show asymmetric PHY rates if available
-                    // Check both endpoints - the mesh AP or wifi client has the PHY rates
-                    let txt;
+            // Capacity / speed label on infra and WAN links
+            if(!e._isCl){
+                ctx.globalAlpha=1;
+                const mx=(e._x1+e._x2)/2, my=(e._y1+e._y2)/2;
+                let txt=null;
+
+                if(e._isWan){
+                    // WAN links: show ISP expected speeds from cloud data
+                    const cloud=this._clouds.find(c=>
+                        e.lk.fromNodeId===c.d.id||e.lk.toNodeId===c.d.id);
+                    if(cloud?.d.ispDownloadMbps&&cloud?.d.ispUploadMbps){
+                        txt=`↓${formatSpeed(cloud.d.ispDownloadMbps)} ↑${formatSpeed(cloud.d.ispUploadMbps)}`;
+                    }else if(e.lk.capacityBps>0){
+                        txt=formatSpeed(e.lk.capacityBps/1e6);
+                    }
+                }else if(e.lk.kind===LK.MeshBackhaul||e.lk.band){
+                    // Mesh/wireless: show asymmetric PHY rates
                     const n1=e.fn?.d, n2=e.tn?.d;
                     const phy=n2?.phyTxKbps?n2:n1?.phyTxKbps?n1:null;
-                    if((e.lk.kind===LK.MeshBackhaul||e.lk.band)&&phy?.phyTxKbps&&phy?.phyRxKbps){
-                        const tx=phy.phyTxKbps/1000, rx=phy.phyRxKbps/1000;
-                        txt=`↓${formatSpeed(rx)} ↑${formatSpeed(tx)}`;
-                    }else{
-                        txt=formatSpeed(cap);
+                    if(phy?.phyTxKbps&&phy?.phyRxKbps){
+                        txt=`↓${formatSpeed(phy.phyRxKbps/1000)} ↑${formatSpeed(phy.phyTxKbps/1000)}`;
+                    }else if(e.lk.capacityBps>0){
+                        txt=formatSpeed(e.lk.capacityBps/1e6);
                     }
+                }else if(e.lk.capacityBps>0){
+                    txt=formatSpeed(e.lk.capacityBps/1e6);
+                }
+
+                if(txt){
                     ctx.font=`${G.rateFont}px ${FONT}`;
                     const tw=ctx.measureText(txt).width+12;
                     ctx.fillStyle=C.labelBg;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1045,7 +1045,7 @@ class LanFlowMap2D {
                 const isWan=e._isWan;
                 const midY=(e._y1+e._y2)/2+(e._midYOff||0);
                 const mx=isWan?e._x1:(e._x1+e._x2)/2;
-                const my=isWan?midY-16:(e._y1+e._y2)/2;
+                const my=isWan?midY-28:(e._y1+e._y2)/2;
                 let txt=null;
                 let txtColor=C.textMuted; // default muted; live rates override
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -58,7 +58,7 @@ const G = {
 
 const RATE_THRESH = 1_000_000;
 const EMIT_MAX = 12;
-const MAX_DOTS = 20;
+const MAX_DOTS = 80;
 const FONT = 'system-ui, -apple-system, sans-serif';
 
 // ---- Helpers ----

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -39,10 +39,10 @@ const G = {
     tierGap:     140,
     cloudGap:    100,
     infraGap:    90,
-    clientCellW: 68,
-    clientCellH: 38,
+    clientCellW: 80,
+    clientCellH: 50,
     clientR:     7,
-    clientCols:  10,
+    clientCols:  8,
     maxClients:  80,
     iconSize:    52,
     boxW:        68,
@@ -167,10 +167,10 @@ class Stream {
         this._color = color;
         this._layer = layer;
         this._density = 0;
-        this._velocity = 0.15;
-        this._dotSize = 0.75;
+        this._velNorm = 0;
+        this._dotSize = 0.4;
         this._spawnAcc = 0;
-        // Particle pool: t < 0 means inactive
+        this._pathLen = orthoLen(edge._x1, edge._y1, edge._x2, edge._y2);
         this._slots = [];
         for (let i = 0; i < MAX_DOTS; i++) {
             const dot = el('circle', { r: 0.4, fill: color, opacity: 0, filter: 'url(#pg)' }, layer);
@@ -182,7 +182,10 @@ class Stream {
         const intensity = Math.max(0, Math.min(1, Math.log10(Math.max(bps, 1)) / 11));
         this._density = intensity;
         this._dotSize = 0.4 + (intensity * intensity) * 1.2;
-        this._velocity = 0.15 + intensity * 0.45;
+        // Constant visual speed: absolute SVG px/sec divided by path length
+        // (mirrors 3D: velocity = 2.5+intensity*4 scene-units/sec / link-length)
+        const absPxSec = 50 + intensity * 80;
+        this._velNorm = absPxSec / Math.max(this._pathLen, 1);
     }
 
     advance(dt) {
@@ -205,7 +208,7 @@ class Stream {
         // Advance existing particles
         for (const slot of this._slots) {
             if (slot.t < 0) continue;
-            slot.t += this._velocity * dt * this._dir;
+            slot.t += this._velNorm * dt * this._dir;
             if (slot.t > 1 || slot.t < 0) {
                 slot.t = -1;
                 slot.el.setAttribute('opacity', 0);
@@ -442,11 +445,14 @@ class LanFlowMap2D {
 
         const nc = Math.min(n.clients.length, G.maxClients);
         const cols = Math.min(nc, G.clientCols);
+        const rows = Math.ceil(nc / Math.max(cols, 1));
         const cw = cols > 0 ? cols * G.clientCellW : 0;
 
         const self = isClient(n.d.kind) ? G.clientCellW : G.boxW + 30;
-        // Clients go in a centered row BELOW infra, so width = max(infra, clients)
-        const childW = Math.max(iw, cw);
+        // Sum infra + client widths so each subtree gets its own space
+        let childW = 0;
+        if (iw > 0 && cw > 0) childW = iw + G.infraGap + cw;
+        else childW = iw + cw;
 
         n.w = Math.max(self, childW);
     }
@@ -460,40 +466,37 @@ class LanFlowMap2D {
             return;
         }
 
-        // Infra children: centered row at depth+1
+        // Compute sub-widths
         let iw = n.infra.reduce((s, c) => s + c.w, 0);
         if (n.infra.length > 1) iw += (n.infra.length - 1) * G.infraGap;
+        const nc = Math.min(n.clients.length, G.maxClients);
+        const cols = Math.min(nc, G.clientCols);
+        const cw = cols > 0 ? cols * G.clientCellW : 0;
 
-        let cur = lx + (n.w - iw) / 2;
+        let combW = 0;
+        if (iw > 0 && cw > 0) combW = iw + G.infraGap + cw;
+        else combW = iw + cw;
+
+        // All children at depth+1 - infra first, then clients right
+        let cur = lx + (n.w - combW) / 2;
+
         for (const c of n.infra) {
             this._positions(c, cur, depth + 1);
             cur += c.w + G.infraGap;
         }
 
-        // Client children: centered grid rows BELOW infra (separate tier)
-        const nc = Math.min(n.clients.length, G.maxClients);
-        if (nc > 0) {
-            const cols = Math.min(nc, G.clientCols);
-            const gridW = cols * G.clientCellW;
-            const gridLeft = lx + (n.w - gridW) / 2;
-            // If infra children exist, clients go one tier further down
-            const clientDepth = n.infra.length > 0 ? depth + 2 : depth + 1;
-            const clientY = yOff + clientDepth * G.tierGap;
-
-            for (let i = 0; i < nc; i++) {
-                const col = i % cols, row = Math.floor(i / cols);
-                const cn = n.clients[i];
-                cn.x = gridLeft + col * G.clientCellW + G.clientCellW / 2;
-                cn.y = clientY + row * G.clientCellH;
-            }
+        const clientY = yOff + (depth + 1) * G.tierGap;
+        for (let i = 0; i < nc; i++) {
+            const col = i % cols, row = Math.floor(i / cols);
+            const cn = n.clients[i];
+            cn.x = cur + col * G.clientCellW + G.clientCellW / 2;
+            cn.y = clientY + row * G.clientCellH;
         }
 
-        // Center parent over infra children (clients are secondary)
-        if (n.infra.length > 0) {
-            n.x = (Math.min(...n.infra.map(c => c.x)) + Math.max(...n.infra.map(c => c.x))) / 2;
-        } else if (nc > 0) {
-            const placed = n.clients.slice(0, nc);
-            n.x = (Math.min(...placed.map(c => c.x)) + Math.max(...placed.map(c => c.x))) / 2;
+        // Center parent over ALL children
+        const allK = [...n.infra, ...n.clients.slice(0, nc)];
+        if (allK.length > 0) {
+            n.x = (Math.min(...allK.map(c => c.x)) + Math.max(...allK.map(c => c.x))) / 2;
         } else {
             n.x = lx + n.w / 2;
         }
@@ -784,7 +787,7 @@ class LanFlowMap2D {
         // Visible name label below
         const name = n.d.name || n.d.ip || '';
         if (name) {
-            const dn = name.length > 10 ? name.slice(0, 9) + '…' : name;
+            const dn = name.length > 14 ? name.slice(0, 13) + '…' : name;
             const t = el('text', { x:0, y:r + 11, 'text-anchor':'middle', fill:C.textMuted,
                 'font-size':G.clientNameFont, 'font-family':'system-ui,sans-serif' }, g);
             t.textContent = dn;
@@ -928,7 +931,7 @@ class LanFlowMap2D {
     _initStreams() {
         this._streams = [];
         for (const e of this._edges) {
-            if (!e._pe || e._isCl) continue;
+            if (!e._pe) continue;
             if (e._x1 == null) continue;
             const len = orthoLen(e._x1, e._y1, e._x2, e._y2);
             if (len < 5) continue;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -153,6 +153,73 @@ class TN {
     constructor(d) { this.d=d; this.infra=[]; this.clients=[]; this.x=0; this.y=0; this.w=0; }
 }
 
+// ---- Persistent particle stream (mirrors 3D map's ParticleStream) ----
+
+const MAX_DOTS = 16;
+const EMIT_MAX = 12;
+
+class Stream {
+    constructor(edge, dir, color, layer) {
+        this._edge = edge;
+        this._dir = dir;
+        this._color = color;
+        this._layer = layer;
+        this._density = 0;
+        this._velocity = 0.15;
+        this._dotSize = 0.75;
+        this._spawnAcc = 0;
+        // Particle pool: t < 0 means inactive
+        this._slots = [];
+        for (let i = 0; i < MAX_DOTS; i++) {
+            const dot = el('circle', { r: 0.75, fill: color, opacity: 0, filter: 'url(#pg)' }, layer);
+            this._slots.push({ el: dot, t: -1, size: 0 });
+        }
+    }
+
+    setRate(bps) {
+        const intensity = Math.max(0, Math.min(1, Math.log10(Math.max(bps, 1)) / 11));
+        this._density = intensity;
+        this._dotSize = 0.75 + (intensity * intensity) * 2.5;
+        this._velocity = 0.15 + intensity * 0.45;
+    }
+
+    advance(dt) {
+        const e = this._edge;
+        // Emit new particles based on density
+        this._spawnAcc += this._density * this._density * EMIT_MAX * dt;
+        while (this._spawnAcc >= 1) {
+            this._spawnAcc -= (0.6 + Math.random() * 0.8);
+            for (const slot of this._slots) {
+                if (slot.t < 0) {
+                    slot.t = this._dir > 0 ? 0 : 1;
+                    slot.size = this._dotSize;
+                    slot.el.setAttribute('r', this._dotSize);
+                    slot.el.setAttribute('opacity', 0.85);
+                    break;
+                }
+            }
+        }
+
+        // Advance existing particles
+        for (const slot of this._slots) {
+            if (slot.t < 0) continue;
+            slot.t += this._velocity * dt * this._dir;
+            if (slot.t > 1 || slot.t < 0) {
+                slot.t = -1;
+                slot.el.setAttribute('opacity', 0);
+                continue;
+            }
+            const pt = orthoAt(e._x1, e._y1, e._x2, e._y2, slot.t);
+            slot.el.setAttribute('cx', pt.x);
+            slot.el.setAttribute('cy', pt.y);
+        }
+    }
+
+    dispose() {
+        for (const slot of this._slots) slot.el.remove();
+    }
+}
+
 // ---- Main class ----
 
 class LanFlowMap2D {
@@ -215,8 +282,9 @@ class LanFlowMap2D {
     dispose() {
         cancelAnimationFrame(this._animId);
         if (this._unsub) this._unsub();
+        if (this._streams) for (const s of this._streams) s.dispose();
+        this._streams = [];
         this._el.innerHTML = '';
-        this._particles = [];
     }
 
     // ---- SVG skeleton ----
@@ -442,11 +510,12 @@ class LanFlowMap2D {
     // ---- Render ----
 
     _renderAll() {
+        if (this._streams) for (const s of this._streams) s.dispose();
+        this._streams = [];
         this._gLinks.innerHTML = '';
         this._gNodes.innerHTML = '';
         this._gParts.innerHTML = '';
         this._gLabels.innerHTML = '';
-        this._particles = [];
 
         if (!this._root) return;
 
@@ -455,6 +524,7 @@ class LanFlowMap2D {
         this._drawTreeLinks(this._root);
         this._drawClouds();
         this._drawTree(this._root);
+        this._initStreams();
         this._drawToolbar();
         this._updateRates();
         this._svg.style.cursor = 'grab';
@@ -747,7 +817,7 @@ class LanFlowMap2D {
         this._updateLabels();
         this._updatePipes();
         this._updateCloudStats();
-        this._syncParticles();
+        this._updateStreamRates();
     }
 
     _updateLabels() {
@@ -842,50 +912,30 @@ class LanFlowMap2D {
         }
     }
 
-    // ---- Particle system (matches 3D map emission model) ----
+    // ---- Particle system (persistent emission, matching 3D map) ----
+    // Each link gets two Stream objects (downstream + upstream). setRate()
+    // adjusts emission parameters. advance(dt) spawns new dots and moves
+    // existing ones. Particles are never bulk-recreated on rate updates.
 
-    _syncParticles() {
-        this._gParts.innerHTML = '';
-        this._particles = [];
-
+    _initStreams() {
+        this._streams = [];
         for (const e of this._edges) {
             if (!e._pe || e._isCl) continue;
-            const r = this._liveRates[e.lk.portKey] || this._liveRates[e.lk.id];
-            const dn = r?.downstreamBps ?? 0;
-            const up = r?.upstreamBps ?? 0;
+            if (e._x1 == null) continue;
             const len = orthoLen(e._x1, e._y1, e._x2, e._y2);
             if (len < 5) continue;
-
-            // Downstream particles
-            if (dn > 0) this._spawnStream(e, dn, 1, C.downstream);
-            // Upstream particles
-            if (up > 0) this._spawnStream(e, up, -1, C.upstream);
+            e._sDown = new Stream(e, 1, C.downstream, this._gParts);
+            e._sUp   = new Stream(e, -1, C.upstream, this._gParts);
+            this._streams.push(e._sDown, e._sUp);
         }
     }
 
-    _spawnStream(edge, bps, dir, color) {
-        // 3D map formula: intensity = log10(max(bps,1)) / 11, clamped 0..1
-        const intensity = Math.max(0, Math.min(1, Math.log10(Math.max(bps, 1)) / 11));
-        // Emission density - how many particles visible at once
-        // density² * 12 = emissions/sec. At steady state ~density²*12 / velocity particles in flight.
-        const density = intensity;
-        // Particle size: squared curve matching 3D map, scaled for 2D SVG
-        const size = 0.75 + (intensity * intensity) * 2.5;
-        // Velocity: 0..1 range, normalized per-second fraction of path
-        const vel = 0.15 + intensity * 0.45;
-        // Count: density²*12 is emission rate; at vel speed, in-flight ≈ emission/vel
-        const count = Math.max(1, Math.min(Math.ceil(density * density * 12 / Math.max(vel, 0.1)), 10));
-
-        for (let i = 0; i < count; i++) {
-            const dot = el('circle', {
-                r: size, fill: color, opacity: 0.85, filter: 'url(#pg)',
-            }, this._gParts);
-            this._particles.push({
-                el: dot, edge,
-                t: i / count + (Math.random() * 0.05),
-                speed: vel * (0.85 + Math.random() * 0.3),
-                dir, size,
-            });
+    _updateStreamRates() {
+        for (const e of this._edges) {
+            if (!e._sDown) continue;
+            const r = this._liveRates[e.lk.portKey] || this._liveRates[e.lk.id];
+            e._sDown.setRate(r?.downstreamBps ?? 0);
+            e._sUp.setRate(r?.upstreamBps ?? 0);
         }
     }
 
@@ -894,15 +944,7 @@ class LanFlowMap2D {
         const dt = Math.min((now - this._lastFrame) / 1000, 0.1);
         this._lastFrame = now;
 
-        for (const p of this._particles) {
-            p.t += p.speed * dt * p.dir;
-            if (p.t > 1) p.t -= 1;
-            if (p.t < 0) p.t += 1;
-
-            const pt = orthoAt(p.edge._x1, p.edge._y1, p.edge._x2, p.edge._y2, p.t);
-            p.el.setAttribute('cx', pt.x);
-            p.el.setAttribute('cy', pt.y);
-        }
+        for (const s of this._streams) s.advance(dt);
 
         this._animId = requestAnimationFrame(() => this._animate());
     }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -344,6 +344,61 @@ class LanFlowMap2D {
         this._onKeyDown=(e)=>{if(e.key==='Escape'&&this._isFullscreen)this._toggleFullscreen();};
         document.addEventListener('keydown',this._onKeyDown);
 
+        // Filter + overlay state
+        this._filter={text:'',bands:{'2.4':true,'5':true,'6':true}};
+        const defaultOverlays={wifiClients:true,wiredClients:true,clouds:true};
+        try{const s=JSON.parse(localStorage.getItem('lanFlowMap2dOverlays'));this._overlays=s?{...defaultOverlays,...s}:{...defaultOverlays};}
+        catch{this._overlays={...defaultOverlays};}
+
+        // Filter panel (top-left, matching 3D style)
+        const filter=document.createElement('div');
+        filter.className='lan-flow-map-panel lan-flow-map-filter';
+        filter.innerHTML=`<div class="lan-flow-map-panel-title">Filter clients</div>
+            <div class="lan-flow-map-panel-body">
+                <input class="lan-flow-map-search" type="search" placeholder="Search by name or MAC" />
+                <div class="lan-flow-map-chips" data-chip-group="band">
+                    <span class="lan-flow-map-chip is-on" data-band="2.4">2.4 GHz</span>
+                    <span class="lan-flow-map-chip is-on" data-band="5">5 GHz</span>
+                    <span class="lan-flow-map-chip is-on" data-band="6">6 GHz</span>
+                </div>
+            </div>`;
+        filter.querySelector('.lan-flow-map-search').addEventListener('input',(e)=>{
+            this._filter.text=(e.target.value||'').toLowerCase().trim();
+            this._needsStaticRedraw=true;
+        });
+        const bandChips=[...filter.querySelectorAll('.lan-flow-map-chip')];
+        bandChips.forEach(chip=>{
+            chip.addEventListener('click',()=>{
+                const b=chip.dataset.band;
+                const allOn=bandChips.every(c=>this._filter.bands[c.dataset.band]);
+                if(allOn){for(const c of bandChips){this._filter.bands[c.dataset.band]=(c.dataset.band===b);c.classList.toggle('is-on',this._filter.bands[c.dataset.band]);}}
+                else{const onlyThis=this._filter.bands[b]&&bandChips.every(c=>c.dataset.band===b||!this._filter.bands[c.dataset.band]);
+                    if(onlyThis){for(const c of bandChips){this._filter.bands[c.dataset.band]=true;c.classList.add('is-on');}}
+                    else{this._filter.bands[b]=!this._filter.bands[b];chip.classList.toggle('is-on',this._filter.bands[b]);}}
+                this._needsStaticRedraw=true;
+            });
+        });
+        this._el.appendChild(filter);
+
+        // Overlays panel (top-right, matching 3D style)
+        const controls=document.createElement('div');
+        controls.className='lan-flow-map-panel lan-flow-map-controls';
+        controls.innerHTML=`<div class="lan-flow-map-panel-title">Overlays</div><div class="lan-flow-map-panel-body"></div>`;
+        const ctrlBody=controls.querySelector('.lan-flow-map-panel-body');
+        for(const[key,label]of[['wifiClients','Wi-Fi clients'],['wiredClients','Wired clients'],['clouds','WAN globes']]){
+            const row=document.createElement('div');
+            row.className=`lan-flow-map-toggle ${this._overlays[key]?'is-on':''}`;
+            row.innerHTML=`<span>${label}</span><span class="lan-flow-map-toggle-pill"></span>`;
+            row.addEventListener('click',()=>{
+                this._overlays[key]=!this._overlays[key];
+                row.classList.toggle('is-on',this._overlays[key]);
+                try{localStorage.setItem('lanFlowMap2dOverlays',JSON.stringify(this._overlays));}catch{}
+                this._needsStaticRedraw=true;
+            });
+            ctrlBody.appendChild(row);
+        }
+        this._el.appendChild(controls);
+
         // Toolbar
         const tb=document.createElement('div');
         tb.className='lfm2d-toolbar';
@@ -372,7 +427,7 @@ class LanFlowMap2D {
                 </div>
                 <span data-role="left">-24h</span>
                 <input class="lan-flow-map-scrubber-range" type="range" min="0" max="10000" value="10000" />
-                <span data-role="right" style="min-width:10ch">Live</span>
+                <span data-role="right">Live</span>
             </div>`;
         // Forward all interactions to the 3D map
         const fwd=()=>window.__lanFlowMap?.getInstance?.();
@@ -500,6 +555,25 @@ class LanFlowMap2D {
         this._scrubberEls.speedLabel.textContent=`${s.speed}x`;
         this._scrubberEls.playPause.textContent=flowData.isPaused()?'▶':'⏸';
     }
+
+    _isNodeVisible(n){
+        const k=n.d.kind;
+        if(k===NK.WifiClient){
+            if(!this._overlays.wifiClients)return false;
+            if(n.d.band&&!this._filter.bands[n.d.band])return false;
+        }
+        if(k===NK.WiredClient&&!this._overlays.wiredClients)return false;
+        if(this._filter.text){
+            const t=this._filter.text;
+            const name=(n.d.name||'').toLowerCase();
+            const mac=(n.d.mac||'').toLowerCase();
+            const ip=(n.d.ip||'').toLowerCase();
+            if(!name.includes(t)&&!mac.includes(t)&&!ip.includes(t))return false;
+        }
+        return true;
+    }
+
+    _isCloudVisible(){return this._overlays.clouds;}
 
     _zoomBy(factor){
         this._scale=Math.max(0.05,Math.min(10,this._scale*factor));
@@ -1038,8 +1112,8 @@ class LanFlowMap2D {
 
         // Links
         this._drawAllLinks(ctx);
-        // Clouds
-        this._drawAllClouds(ctx);
+        // Clouds (if overlay enabled)
+        if(this._isCloudVisible())this._drawAllClouds(ctx);
         // Infra + client nodes
         this._drawAllNodes(ctx,this._root);
         // Rate labels
@@ -1051,6 +1125,12 @@ class LanFlowMap2D {
     _drawAllLinks(ctx){
         for(const e of this._edges){
             if(e._x1==null)continue;
+            // Hide links to filtered-out nodes
+            if(e._isWan&&!this._isCloudVisible())continue;
+            if(e._isCl){
+                const child=e.tn||e.fn;
+                if(child&&!this._isNodeVisible(child))continue;
+            }
             const r=this._liveRates[e.lk.portKey]||this._liveRates[e.lk.id];
             const dn=r?.downstreamBps??0,up=r?.upstreamBps??0;
             const cap=e.lk.capacityBps||1e9;
@@ -1190,7 +1270,7 @@ class LanFlowMap2D {
         }
         this._drawInfraNode(ctx,n);
         for(const c of n.infra)this._drawAllNodes(ctx,c);
-        for(const c of n.clients.slice(0,G.maxClients))this._drawClientNode(ctx,c);
+        for(const c of n.clients.slice(0,G.maxClients)){if(this._isNodeVisible(c))this._drawClientNode(ctx,c);}
         if(n.clients.length>G.maxClients){
             const last=n.clients[G.maxClients-1];
             ctx.fillStyle=C.textMuted;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1412,10 +1412,11 @@ export class LanFlowMap {
             range.value = clamped;
             // Update the time label from the continuous timestamp, not the
             // integer slider position (which only moves every ~86s at 1x).
+            const rightLabel = (clamped >= 9998) ? 'Live' : _fmtDateTime(this._playbackTime);
             if (this._panels.scrubberRight) {
-                this._panels.scrubberRight.textContent =
-                    (clamped >= 9998) ? 'Live' : _fmtDateTime(this._playbackTime);
+                this._panels.scrubberRight.textContent = rightLabel;
             }
+            flowData.publishScrubber(clamped, rightLabel, this._playbackSpeed);
             tickCount++;
             // Refresh map and stat cards periodically
             if (tickCount % DATA_REFRESH_TICKS === 0 || clamped >= 9998) {
@@ -1893,10 +1894,11 @@ export class LanFlowMap {
     _onScrubberInput(value) {
         // Visual-only update while dragging - cheap label refresh.
         const at = this._scrubberValueToTime(value);
+        const rightLabel = (value >= 9998) ? 'Live' : _fmtDateTime(at);
         if (this._panels.scrubberRight) {
-            this._panels.scrubberRight.textContent =
-                (value >= 9998) ? 'Live' : _fmtDateTime(at);
+            this._panels.scrubberRight.textContent = rightLabel;
         }
+        flowData.publishScrubber(value, rightLabel, this._playbackSpeed);
     }
 
     async _onScrubberChange(value) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1391,14 +1391,17 @@ export class LanFlowMap {
                     const res = await fetch(`${this.apiBase}/snapshot`, { credentials: 'same-origin' });
                     if (!res.ok) return;
                     const snap = await res.json();
-                    // Detect topology change: if node/link count differs, full rebuild
-                    const prevNodes = this._snapshot?.nodes?.length ?? 0;
-                    const prevLinks = this._snapshot?.links?.length ?? 0;
-                    const newNodes = snap.nodes?.length ?? 0;
-                    const newLinks = snap.links?.length ?? 0;
+                    // Detect infrastructure topology change (devices added/removed).
+                    // Client churn is frequent on large networks - don't rebuild for it.
+                    const prevInfra = (this._snapshot?.nodes ?? [])
+                        .filter(n => n.kind <= NODE_KIND.AccessPoint || n.kind === NODE_KIND.VirtualHub).length;
+                    const newInfra = (snap.nodes ?? [])
+                        .filter(n => n.kind <= NODE_KIND.AccessPoint || n.kind === NODE_KIND.VirtualHub).length;
+                    const prevWanLinks = (this._snapshot?.links ?? []).filter(n => n.kind === LINK_KIND.Wan).length;
+                    const newWanLinks = (snap.links ?? []).filter(n => n.kind === LINK_KIND.Wan).length;
                     this._snapshot = snap;
                     flowData.publishSnapshot(snap);
-                    if (newNodes !== prevNodes || newLinks !== prevLinks) {
+                    if (newInfra !== prevInfra || newWanLinks !== prevWanLinks) {
                         await this._reloadSnapshot();
                     } else {
                         this._applyLiveRates(snap.liveRates || {});

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1391,22 +1391,137 @@ export class LanFlowMap {
                     const res = await fetch(`${this.apiBase}/snapshot`, { credentials: 'same-origin' });
                     if (!res.ok) return;
                     const snap = await res.json();
-                    // Detect topology change (any node/link count difference).
-                    const prevNodes = this._snapshot?.nodes?.length ?? 0;
-                    const prevLinks = this._snapshot?.links?.length ?? 0;
-                    const newNodes = snap.nodes?.length ?? 0;
-                    const newLinks = snap.links?.length ?? 0;
+                    const prev = this._snapshot;
                     this._snapshot = snap;
                     flowData.publishSnapshot(snap);
-                    if (newNodes !== prevNodes || newLinks !== prevLinks) {
+
+                    // Diff: infrastructure change = full rebuild; client churn = incremental
+                    const infraKinds = new Set([NODE_KIND.Gateway, NODE_KIND.Switch, NODE_KIND.AccessPoint, NODE_KIND.VirtualHub]);
+                    const prevInfraIds = new Set((prev?.nodes ?? []).filter(n => infraKinds.has(n.kind)).map(n => n.id));
+                    const newInfraIds = new Set((snap.nodes ?? []).filter(n => infraKinds.has(n.kind)).map(n => n.id));
+                    const infraChanged = prevInfraIds.size !== newInfraIds.size
+                        || [...prevInfraIds].some(id => !newInfraIds.has(id));
+
+                    if (infraChanged) {
                         await this._reloadSnapshot();
                     } else {
+                        // Incremental client add/remove
+                        const prevNodeIds = new Set((prev?.nodes ?? []).map(n => n.id));
+                        const newNodeIds = new Set((snap.nodes ?? []).map(n => n.id));
+                        const added = (snap.nodes ?? []).filter(n => !prevNodeIds.has(n.id));
+                        const removed = [...prevNodeIds].filter(id => !newNodeIds.has(id));
+                        for (const id of removed) this._removeNodeIncremental(id);
+                        for (const node of added) this._addNodeIncremental(node, snap);
                         this._applyLiveRates(snap.liveRates || {});
                         this._refreshCloudRttLabels();
                     }
                 } catch { /* transient */ }
             }
         }, 30000);
+    }
+
+    // Incremental client add: create mesh near parent, create link pipe + particles.
+    _addNodeIncremental(node, snap) {
+        if (node.kind === NODE_KIND.Cloud) return;
+        // Position near parent: find the link to this node
+        const link = (snap.links ?? []).find(l => l.toNodeId === node.id || l.fromNodeId === node.id);
+        if (!link) return;
+        const parentId = link.fromNodeId === node.id ? link.toNodeId : link.fromNodeId;
+        const parentPos = this._positions.get(parentId);
+        if (!parentPos) return;
+        // Scatter near parent
+        const angle = Math.random() * Math.PI * 2;
+        const dist = 3 + Math.random() * 4;
+        const pos = {
+            x: parentPos.x + Math.cos(angle) * dist,
+            y: parentPos.y - 1.5 + Math.random(),
+            z: parentPos.z + Math.sin(angle) * dist,
+            pinned: false,
+        };
+        this._positions.set(node.id, pos);
+
+        // Build node mesh (same as _buildNodes for a single node)
+        const radius = this._nodeRadius(node.kind);
+        const color = this._nodeColor(node.kind);
+        const group = new THREE.Group();
+        const halo = new THREE.Mesh(
+            new THREE.SphereGeometry(radius * 1.7, 24, 16),
+            new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.12, depthWrite: false }),
+        );
+        group.add(halo);
+        const baseEmissive = 0.45;
+        const core = this._makeDeviceCore(node.kind, radius, color, baseEmissive);
+        group.add(core);
+        group.position.set(pos.x, pos.y, pos.z);
+        if (!node.online) {
+            core.material.opacity = 0.55;
+            core.material.transparent = true;
+            halo.material.opacity = 0.05;
+        }
+        group.userData = { node, core, baseEmissive };
+        this.nodeGroup.add(group);
+        this._nodeMeshes.set(node.id, group);
+        if (node.name) {
+            const sprite = this._makeLabelSprite(node.name);
+            sprite.position.set(0, radius + 0.8, 0);
+            group.add(sprite);
+            this._labelSprites.set(node.id, sprite);
+        }
+
+        // Build link pipe + particles
+        const a = this._positions.get(link.fromNodeId);
+        const b = this._positions.get(link.toNodeId);
+        if (a && b) {
+            const pipe = this._makePipeMesh(a, b, link);
+            this.linkGroup.add(pipe);
+            const down = new ParticleStream({ from: a, to: b, color: COLORS.downstream, particleCount: 0 });
+            const up = new ParticleStream({ from: b, to: a, color: COLORS.upstream, particleCount: 0 });
+            this.particleGroup.add(down.mesh, up.mesh);
+            this._linkMeshes.set(link.id, { pipe, down, up, link });
+            this._nodesByLink.set(link.id, [link.fromNodeId, link.toNodeId]);
+        }
+    }
+
+    // Incremental client remove: dispose mesh, link, particles.
+    _removeNodeIncremental(nodeId) {
+        // Remove node mesh
+        const group = this._nodeMeshes.get(nodeId);
+        if (group) {
+            this.nodeGroup.remove(group);
+            group.traverse(obj => {
+                if (obj.geometry) obj.geometry.dispose();
+                if (obj.material) {
+                    if (Array.isArray(obj.material)) obj.material.forEach(m => m.dispose());
+                    else obj.material.dispose();
+                }
+            });
+            this._nodeMeshes.delete(nodeId);
+        }
+        this._labelSprites.delete(nodeId);
+        this._positions.delete(nodeId);
+
+        // Remove any links connected to this node
+        for (const [linkId, endpoints] of this._nodesByLink) {
+            if (endpoints[0] === nodeId || endpoints[1] === nodeId) {
+                const linkObj = this._linkMeshes.get(linkId);
+                if (linkObj) {
+                    this.linkGroup.remove(linkObj.pipe);
+                    linkObj.pipe.traverse(obj => {
+                        if (obj.geometry) obj.geometry.dispose();
+                        if (obj.material) obj.material.dispose();
+                    });
+                    this.particleGroup.remove(linkObj.down.mesh, linkObj.up.mesh);
+                    linkObj.down.mesh.geometry?.dispose();
+                    linkObj.up.mesh.geometry?.dispose();
+                    this._linkMeshes.delete(linkId);
+                }
+                this._nodesByLink.delete(linkId);
+            }
+        }
+
+        // Remove floating label if present
+        const label = this._floatingLabels.get(nodeId);
+        if (label) { label.el.remove(); this._floatingLabels.delete(nodeId); }
     }
 
     // Play/Pause: in Live mode, pause freezes rates by skipping the poll. In

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -3182,3 +3182,5 @@ export async function reload() {
     if (!_instance) return;
     await _instance._reloadSnapshot();
 }
+
+export function getInstance() { return _instance; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1148,6 +1148,7 @@ export class LanFlowMap {
         // Refresh the device-rate text on the floating DOM labels.
         this._refreshDeviceLabelRates();
         this._refreshLinkLabels();
+        this._refreshCloudRttLabels();
     }
 
     _refreshLinkLabels() {
@@ -2063,6 +2064,20 @@ export class LanFlowMap {
             this._wanPills.set(cloud.wanInterface, pill);
         }
 
+        // Cloud RTT labels: live-updating DOM element below each access cloud.
+        this._cloudRttLabels = this._cloudRttLabels || new Map();
+        for (const el of this._cloudRttLabels.values()) el.remove();
+        this._cloudRttLabels.clear();
+        for (const cloud of (snap.clouds || [])) {
+            if (cloud.kind !== 0 /* AccessIsp */) continue;
+            const lbl = document.createElement('div');
+            lbl.className = 'lan-flow-map-cloud-rtt';
+            lbl.style.left = '-9999px';
+            lbl.style.top = '-9999px';
+            this._labelsLayer.appendChild(lbl);
+            this._cloudRttLabels.set(cloud.id, lbl);
+        }
+
         // Hide the existing 3D sprite labels for devices we now show via DOM (keeps
         // the scene from double-labeling them).
         for (const [id, sprite] of this._labelSprites) {
@@ -2122,6 +2137,31 @@ export class LanFlowMap {
             pill.style.transformOrigin = 'center top';
             pill.style.left = `${x}px`;
             pill.style.top = `${y}px`;
+        }
+
+        // Cloud RTT labels - positioned right below the WAN speed test pill
+        if (this._cloudRttLabels) {
+            for (const [cloudId, lbl] of this._cloudRttLabels) {
+                const group = this._cloudMeshes.get(cloudId);
+                if (!group) { lbl.classList.remove('is-visible'); continue; }
+                tmp.setFromMatrixPosition(group.matrixWorld);
+                tmp.y -= NODE_RADIUS.cloud + 0.5;
+                const dist = tmp.distanceTo(camPos);
+                tmp.project(this.camera);
+                if (tmp.z > 1) { lbl.classList.remove('is-visible'); continue; }
+                const x = (tmp.x * halfW) + halfW;
+                const y = -(tmp.y * halfH) + halfH;
+                const scale = Math.max(MIN_SCALE, Math.min(1.0, REF_DIST / Math.max(dist, 1)));
+                // Offset below the WAN pill by reading the pill's rendered height + margin
+                const wanIface = cloudId.replace('cloud-access-', '');
+                const pill = this._wanPills.get(wanIface);
+                const pillOffset = pill?.classList.contains('is-visible') ? (pill.offsetHeight * scale + 6) : 0;
+                lbl.style.transform = `translate(-50%, 0%) scale(${scale.toFixed(3)})`;
+                lbl.style.transformOrigin = 'center top';
+                lbl.style.left = `${x}px`;
+                lbl.style.top = `${y + pillOffset}px`;
+                lbl.classList.add('is-visible');
+            }
         }
 
         // Link rate pills: positioned at the link midpoint. Visibility + text is
@@ -2263,6 +2303,23 @@ export class LanFlowMap {
             const ageLabel = formatAge(ageMs);
             pill.textContent = `Last test: ${dl.toFixed(0)} / ${ul.toFixed(0)} Mbps  ·  ${ageLabel}`;
             pill.classList.add('is-visible');
+        }
+    }
+
+    _refreshCloudRttLabels() {
+        if (!this._cloudRttLabels || this._cloudRttLabels.size === 0) return;
+        const cs = flowData.getCloudStats();
+        for (const [cloudId, lbl] of this._cloudRttLabels) {
+            const stats = cs?.[cloudId];
+            if (!stats || stats.rttAvgMs == null) {
+                lbl.classList.remove('is-visible');
+                continue;
+            }
+            const parts = [`${stats.rttAvgMs.toFixed(2)} ms`];
+            if (stats.lossPercent != null && stats.lossPercent > 0) {
+                parts.push(`${stats.lossPercent.toFixed(1)}% loss`);
+            }
+            lbl.textContent = parts.join('  ·  ');
         }
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2139,9 +2139,11 @@ export class LanFlowMap {
             pill.style.top = `${y}px`;
         }
 
-        // Cloud RTT labels - positioned right below the WAN speed test pill
+        // Cloud RTT labels - positioned right below the WAN speed test pill.
+        // Only show if the label has content (set by _refreshCloudRttLabels).
         if (this._cloudRttLabels) {
             for (const [cloudId, lbl] of this._cloudRttLabels) {
+                if (!lbl.textContent) { lbl.classList.remove('is-visible'); continue; }
                 const group = this._cloudMeshes.get(cloudId);
                 if (!group) { lbl.classList.remove('is-visible'); continue; }
                 tmp.setFromMatrixPosition(group.matrixWorld);
@@ -2152,7 +2154,6 @@ export class LanFlowMap {
                 const x = (tmp.x * halfW) + halfW;
                 const y = -(tmp.y * halfH) + halfH;
                 const scale = Math.max(MIN_SCALE, Math.min(1.0, REF_DIST / Math.max(dist, 1)));
-                // Offset below the WAN pill by reading the pill's rendered height + margin
                 const wanIface = cloudId.replace('cloud-access-', '');
                 const pill = this._wanPills.get(wanIface);
                 const pillOffset = pill?.classList.contains('is-visible') ? (pill.offsetHeight * scale + 6) : 0;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -459,6 +459,12 @@ export class LanFlowMap {
             const snap = await res.json();
             this._snapshot = snap;
             flowData.publishSnapshot(snap);
+            // Seed cloudStats from snapshot clouds so RTT labels show immediately
+            const seedCloudStats = {};
+            for (const c of (snap.clouds || [])) {
+                seedCloudStats[c.id] = { rttAvgMs: c.rttAvgMs, lossPercent: c.lossPercent, success: c.rttAvgMs != null };
+            }
+            flowData.publishLive({ cloudStats: seedCloudStats });
 
             this._layoutNodes(snap);
             this._rebuildBuildings(snap);
@@ -470,6 +476,7 @@ export class LanFlowMap {
             this._buildFloatingLabels(snap);
             this._applyOverlayVisibility();
             this._applyLiveRates(snap.liveRates || {});
+            this._refreshCloudRttLabels();
         } catch (err) {
             this.onError(err);
         }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1381,12 +1381,21 @@ export class LanFlowMap {
         this._pollTimer = setInterval(() => {
             if (this._mode === 'live' && !this._paused) this._pollLive();
         }, this.pollIntervalMs);
-        // Periodic snapshot refresh (30s) to pick up topology changes
-        // (mesh PHY rates, new/removed devices, placement updates).
+        // Periodic light snapshot refresh (30s) to pick up data changes
+        // (mesh PHY rates, online status, ISP speeds) without re-running
+        // force layout or resetting the camera.
         if (this._snapshotTimer) clearInterval(this._snapshotTimer);
-        this._snapshotTimer = setInterval(() => {
+        this._snapshotTimer = setInterval(async () => {
             if (this._mode === 'live' && !this._paused && !this._destroyed) {
-                this._reloadSnapshot();
+                try {
+                    const res = await fetch(`${this.apiBase}/snapshot`, { credentials: 'same-origin' });
+                    if (!res.ok) return;
+                    const snap = await res.json();
+                    this._snapshot = snap;
+                    flowData.publishSnapshot(snap);
+                    this._applyLiveRates(snap.liveRates || {});
+                    this._refreshCloudRttLabels();
+                } catch { /* transient */ }
             }
         }, 30000);
     }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1391,10 +1391,19 @@ export class LanFlowMap {
                     const res = await fetch(`${this.apiBase}/snapshot`, { credentials: 'same-origin' });
                     if (!res.ok) return;
                     const snap = await res.json();
+                    // Detect topology change: if node/link count differs, full rebuild
+                    const prevNodes = this._snapshot?.nodes?.length ?? 0;
+                    const prevLinks = this._snapshot?.links?.length ?? 0;
+                    const newNodes = snap.nodes?.length ?? 0;
+                    const newLinks = snap.links?.length ?? 0;
                     this._snapshot = snap;
                     flowData.publishSnapshot(snap);
-                    this._applyLiveRates(snap.liveRates || {});
-                    this._refreshCloudRttLabels();
+                    if (newNodes !== prevNodes || newLinks !== prevLinks) {
+                        await this._reloadSnapshot();
+                    } else {
+                        this._applyLiveRates(snap.liveRates || {});
+                        this._refreshCloudRttLabels();
+                    }
                 } catch { /* transient */ }
             }
         }, 30000);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -14,6 +14,7 @@ import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
 import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 import { buildBuildings } from './lan-flow-buildings.js';
+import * as flowData from './lan-flow-data.js';
 
 const COLORS = {
     background: 0x202023,
@@ -457,6 +458,7 @@ export class LanFlowMap {
             if (!res.ok) throw new Error(`snapshot HTTP ${res.status}`);
             const snap = await res.json();
             this._snapshot = snap;
+            flowData.publishSnapshot(snap);
 
             this._layoutNodes(snap);
             this._rebuildBuildings(snap);
@@ -500,6 +502,7 @@ export class LanFlowMap {
             const res = await fetch(`${this.apiBase}/live`, { credentials: 'same-origin' });
             if (!res.ok) return;
             const update = await res.json();
+            flowData.publishLive(update);
             this._currentBadges = update.nodeBadges || {};
             this._applyLiveRates(update.linkRates || {});
         } catch (err) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1391,17 +1391,14 @@ export class LanFlowMap {
                     const res = await fetch(`${this.apiBase}/snapshot`, { credentials: 'same-origin' });
                     if (!res.ok) return;
                     const snap = await res.json();
-                    // Detect infrastructure topology change (devices added/removed).
-                    // Client churn is frequent on large networks - don't rebuild for it.
-                    const prevInfra = (this._snapshot?.nodes ?? [])
-                        .filter(n => n.kind <= NODE_KIND.AccessPoint || n.kind === NODE_KIND.VirtualHub).length;
-                    const newInfra = (snap.nodes ?? [])
-                        .filter(n => n.kind <= NODE_KIND.AccessPoint || n.kind === NODE_KIND.VirtualHub).length;
-                    const prevWanLinks = (this._snapshot?.links ?? []).filter(n => n.kind === LINK_KIND.Wan).length;
-                    const newWanLinks = (snap.links ?? []).filter(n => n.kind === LINK_KIND.Wan).length;
+                    // Detect topology change (any node/link count difference).
+                    const prevNodes = this._snapshot?.nodes?.length ?? 0;
+                    const prevLinks = this._snapshot?.links?.length ?? 0;
+                    const newNodes = snap.nodes?.length ?? 0;
+                    const newLinks = snap.links?.length ?? 0;
                     this._snapshot = snap;
                     flowData.publishSnapshot(snap);
-                    if (newInfra !== prevInfra || newWanLinks !== prevWanLinks) {
+                    if (newNodes !== prevNodes || newLinks !== prevLinks) {
                         await this._reloadSnapshot();
                     } else {
                         this._applyLiveRates(snap.liveRates || {});

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1982,6 +1982,7 @@ export class LanFlowMap {
             const res = await fetch(url, { credentials: 'same-origin' });
             if (!res.ok) return;
             const update = await res.json();
+            flowData.publishLive(update);
             this._applyLiveRates(update.linkRates || {});
             if (update.nodeBadges) this._currentBadges = update.nodeBadges;
         } catch (err) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1206,12 +1206,22 @@ export class LanFlowMap {
         // position, fly to that instead of the default overview.
         this._flyInUntil = performance.now() + 1300;
         const sc = this._savedCamera;
-        this._flyInTargetCam = sc
-            ? new THREE.Vector3(sc.cx, sc.cy, sc.cz)
-            : new THREE.Vector3(60, 40, 60);
-        this._flyInTargetLookAt = sc
-            ? new THREE.Vector3(sc.tx, sc.ty, sc.tz)
-            : null;
+        if (sc) {
+            this._flyInTargetCam = new THREE.Vector3(sc.cx, sc.cy, sc.cz);
+            this._flyInTargetLookAt = new THREE.Vector3(sc.tx, sc.ty, sc.tz);
+        } else {
+            // Compute centroid of all positioned nodes so we aim at the actual
+            // topology, not hardcoded origin (which can be empty space when
+            // anchored APs shift the layout away from 0,0,0).
+            let cx = 0, cy = 0, cz = 0, n = 0;
+            for (const pos of this._positions.values()) {
+                cx += pos.x; cy += pos.y; cz += pos.z; n++;
+            }
+            if (n > 0) { cx /= n; cy /= n; cz /= n; }
+            this._flyInTargetCam = new THREE.Vector3(cx + 60, cy + 40, cz + 60);
+            this._flyInTargetLookAt = new THREE.Vector3(cx, cy, cz);
+            this.controls.target.set(cx, cy, cz);
+        }
         this._flyInStartCam = this.camera.position.clone();
 
         // Cap render rate at 120 fps. setAnimationLoop is the modern Three.js

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1378,6 +1378,7 @@ export class LanFlowMap {
     _togglePlayPause() {
         this._paused = !this._paused;
         this._syncPlayPauseIcon();
+        flowData.publishPlayState(this._paused, this._mode);
         if (this._paused) {
             this._stopHistoricPlayback();
             return;
@@ -1918,6 +1919,7 @@ export class LanFlowMap {
             this._paused = false;
             this._syncPlayPauseIcon();
             this._syncSpeedLabel();
+            flowData.publishPlayState(false, 'live');
             this._notifyStatCards(null);
             await this._pollLive();
             return;
@@ -1942,6 +1944,7 @@ export class LanFlowMap {
             this._syncPlayPauseIcon();
             this._stopHistoricPlayback();
         }
+        flowData.publishPlayState(this._paused, this._mode);
         this._notifyStatCards(at);
         await this._loadHistoric(at);
     }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -389,6 +389,7 @@ export class LanFlowMap {
         if (this._raf) cancelAnimationFrame(this._raf);
         if (this._pollTimer) clearInterval(this._pollTimer);
         if (this._historicPlaybackTimer) clearInterval(this._historicPlaybackTimer);
+        if (this._snapshotTimer) clearInterval(this._snapshotTimer);
         if (this._resizeObserver) this._resizeObserver.disconnect();
         if (this._onKeyDown) document.removeEventListener('keydown', this._onKeyDown);
         if (this._onKeyUp) document.removeEventListener('keyup', this._onKeyUp);
@@ -1370,6 +1371,14 @@ export class LanFlowMap {
         this._pollTimer = setInterval(() => {
             if (this._mode === 'live' && !this._paused) this._pollLive();
         }, this.pollIntervalMs);
+        // Periodic snapshot refresh (30s) to pick up topology changes
+        // (mesh PHY rates, new/removed devices, placement updates).
+        if (this._snapshotTimer) clearInterval(this._snapshotTimer);
+        this._snapshotTimer = setInterval(() => {
+            if (this._mode === 'live' && !this._paused && !this._destroyed) {
+                this._reloadSnapshot();
+            }
+        }, 30000);
     }
 
     // Play/Pause: in Live mode, pause freezes rates by skipping the poll. In

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1412,7 +1412,8 @@ export class LanFlowMap {
                         const removed = [...prevNodeIds].filter(id => !newNodeIds.has(id));
                         for (const id of removed) this._removeNodeIncremental(id);
                         for (const node of added) this._addNodeIncremental(node, snap);
-                        this._applyLiveRates(snap.liveRates || {});
+                        // Don't apply snapshot liveRates - they're stale vs the 1s
+                        // live poll and would clobber fresh rates momentarily.
                         this._refreshCloudRttLabels();
                     }
                 } catch { /* transient */ }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1431,7 +1431,7 @@ export class LanFlowMap {
         if (!parentPos) return;
         // Scatter near parent
         const angle = Math.random() * Math.PI * 2;
-        const dist = 3 + Math.random() * 4;
+        const dist = 6 + Math.random() * 6;
         const pos = {
             x: parentPos.x + Math.cos(angle) * dist,
             y: parentPos.y - 1.5 + Math.random(),


### PR DESCRIPTION
## Summary

- **2D LAN Topology Flow Map** - Canvas 2D hierarchical network diagram below the 3D view on the Live tab. Contour-based layout (Reingold-Tilford) prevents overlap. Orthogonal link routing with rounded corners, animated data-flow particles, device product icons, client labels, WAN wireframe globes. Pan/drag, scroll-wheel zoom, fullscreen, filter/overlay panels, mirrored timeline scrubber in lockstep with the 3D map.

- **Shared data pipeline** (`lan-flow-data.js`) - The 3D map publishes snapshot and live data; the 2D map subscribes. Zero duplicate API calls. Play/pause state, scrubber position, and mode (live/historic) all flow through the shared store so both views stay in sync.

- **Wired client throughput hydration** - Wired clients on non-SNMP switches now get throughput from UniFi client stats (`wired-tx_bytes-r` / cumulative delta fallback). Written to InfluxDB (`wired_client` measurement) for historic playback. WiFi client historic playback also enabled via batch queries.

- **SNMP skip for non-SNMP devices** - Check `snmp_contact` / `snmp_location` fields from the UniFi device response to determine SNMP availability. Devices without SNMP are skipped instantly, no timeout waste.

- **3D map improvements** - Live cloud RTT DOM labels, incremental client add/remove (no full scene rebuild on client churn), fly-in to topology centroid, non-disruptive 30s snapshot refresh, periodic topology refresh for mesh PHY rate updates.

- **Rate accuracy fixes** - Snapshot refresh no longer clobbers live-polled rates. Delta-computed client throughput uses elapsed time since last counter change (not last poll) to avoid 2x rate when UniFi's update cadence misaligns with our poll. Zero-throughput client points excluded from InfluxDB writes and historic queries.

## Test plan

- [x] 2D map renders full topology with correct layout, no overlap
- [x] Particles flow smoothly on all links including client leaves
- [x] Pan, zoom, fullscreen, filter, overlays all work
- [x] Timeline scrubber syncs between 3D and 2D views
- [x] Historic playback shows client throughput (WiFi + wired)
- [x] SNMP cadence is clean (no timeout gaps from non-SNMP devices)
- [x] Toggling SNMP on/off per device is picked up within 30s
- [x] Client join/leave updates both maps within 30s
- [x] WAN ISP expected speeds display correctly from provider capabilities
- [x] Device cache TTL at 30s doesn't cause stale data issues