### PR TITLE
UniFi API fallback for device health, API call optimization, gateway-only console fix (#683)

### DIFF
--- a/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
@@ -150,6 +150,9 @@ public class UniFiDeviceResponse
     [JsonPropertyName("temperatures")]
     public System.Text.Json.JsonElement? Temperatures { get; set; }
 
+    [JsonPropertyName("general_temperature")]
+    public double? GeneralTemperature { get; set; }
+
     // Wi-Fi specific (APs only)
     /// <summary>
     /// Radio configuration table - per-radio settings (channel, tx_power, antenna)

--- a/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
@@ -144,6 +144,12 @@ public class UniFiDeviceResponse
     [JsonPropertyName("sys_stats")]
     public SystemStats? SystemStats { get; set; }
 
+    [JsonPropertyName("system-stats")]
+    public SystemStatsSimple? SystemStatsSimple { get; set; }
+
+    [JsonPropertyName("temperatures")]
+    public System.Text.Json.JsonElement? Temperatures { get; set; }
+
     // Wi-Fi specific (APs only)
     /// <summary>
     /// Radio configuration table - per-radio settings (channel, tx_power, antenna)
@@ -676,6 +682,18 @@ public class SystemStats
 
     [JsonPropertyName("loadavg_15")]
     public double? LoadAvg15 { get; set; }
+}
+
+public class SystemStatsSimple
+{
+    [JsonPropertyName("cpu")]
+    public System.Text.Json.JsonElement? Cpu { get; set; }
+
+    [JsonPropertyName("mem")]
+    public System.Text.Json.JsonElement? Mem { get; set; }
+
+    [JsonPropertyName("uptime")]
+    public System.Text.Json.JsonElement? Uptime { get; set; }
 }
 
 public class ConfigNetwork

--- a/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
+++ b/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
@@ -1152,7 +1152,7 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
             _clientProvider.Client,
             _loggerFactory.CreateLogger<UniFiDiscovery>());
 
-        var topology = await discovery.DiscoverTopologyAsync(cancellationToken);
+        var topology = await discovery.DiscoverTopologyAsync(cancellationToken, useCache: false);
 
         if (topology != null)
         {

--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -39,6 +39,9 @@ public class UniFiApiClient : IDisposable
     private string? _csrfToken;
     private readonly AsyncRetryPolicy _retryPolicy;
     private readonly SemaphoreSlim _authLock = new(1, 1);
+    private List<UniFiDeviceResponse>? _cachedDeviceResponses;
+    private DateTime _deviceResponseCacheTime = DateTime.MinValue;
+    private static readonly TimeSpan DeviceResponseCacheTtl = TimeSpan.FromSeconds(15);
     private bool _isAuthenticated = false;
     private bool _isUniFiOs = false; // True for UDM/UCG, false for standalone controller
     private bool _pathDetected = false;
@@ -622,9 +625,18 @@ public class UniFiApiClient : IDisposable
     /// GET /api/s/{site}/stat/device (standalone) - Get all UniFi devices
     /// Returns the large device payload with all port profiles, switch port details, etc.
     /// </summary>
-    public async Task<List<UniFiDeviceResponse>> GetDevicesAsync(CancellationToken cancellationToken = default)
+    public async Task<List<UniFiDeviceResponse>> GetDevicesAsync(CancellationToken cancellationToken = default, bool useCache = true)
     {
-        _logger.LogTrace("Fetching all devices from site {Site}", _site);
+        if (useCache && _cachedDeviceResponses != null
+            && DateTime.UtcNow - _deviceResponseCacheTime < DeviceResponseCacheTtl)
+        {
+            _logger.LogTrace("Returning cached device response ({Count} devices, age {Age:F1}s)",
+                _cachedDeviceResponses.Count,
+                (DateTime.UtcNow - _deviceResponseCacheTime).TotalSeconds);
+            return _cachedDeviceResponses;
+        }
+
+        _logger.LogTrace("Fetching all devices from site {Site} (useCache={UseCache})", _site, useCache);
 
         var response = await ExecuteApiCallAsync<UniFiApiResponse<UniFiDeviceResponse>>(
             () => _httpClient!.GetAsync(BuildApiPath("stat/device"), cancellationToken),
@@ -633,6 +645,8 @@ public class UniFiApiClient : IDisposable
         if (response?.Meta.Rc == "ok")
         {
             _logger.LogTrace("Retrieved {Count} devices", response.Data.Count);
+            _cachedDeviceResponses = response.Data;
+            _deviceResponseCacheTime = DateTime.UtcNow;
             return response.Data;
         }
 

--- a/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
@@ -24,12 +24,12 @@ public class UniFiDiscovery
     /// Discovers all UniFi devices via controller API
     /// Returns devices with full metadata from controller
     /// </summary>
-    public async Task<List<DiscoveredDevice>> DiscoverDevicesAsync(CancellationToken cancellationToken = default)
+    public async Task<List<DiscoveredDevice>> DiscoverDevicesAsync(CancellationToken cancellationToken = default, bool useCache = true)
     {
         _logger.LogTrace("Starting UniFi device discovery via API");
 
         // Fetch devices and network configs in parallel
-        var devicesTask = _apiClient.GetDevicesAsync(cancellationToken);
+        var devicesTask = _apiClient.GetDevicesAsync(cancellationToken, useCache);
         var networksTask = _apiClient.GetNetworkConfigsAsync(cancellationToken);
 
         await Task.WhenAll(devicesTask, networksTask);
@@ -329,11 +329,11 @@ public class UniFiDiscovery
     /// <summary>
     /// Gets comprehensive network topology including devices and their connections
     /// </summary>
-    public async Task<NetworkTopology> DiscoverTopologyAsync(CancellationToken cancellationToken = default)
+    public async Task<NetworkTopology> DiscoverTopologyAsync(CancellationToken cancellationToken = default, bool useCache = true)
     {
         _logger.LogInformation("Starting network topology discovery");
 
-        var devicesTask = DiscoverDevicesAsync(cancellationToken);
+        var devicesTask = DiscoverDevicesAsync(cancellationToken, useCache);
         var clientsTask = DiscoverClientsAsync(cancellationToken);
         var networksTask = _apiClient.GetNetworkConfigsAsync(cancellationToken);
 

--- a/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
@@ -151,10 +151,15 @@ public class UniFiDiscovery
     /// Allows: UDM (original Dream Machine), UDR, UX, etc. which have real Wi-Fi.
     /// </summary>
     internal static bool IsGatewayOnlyConsole(DiscoveredDevice device)
+        => IsGatewayOnlyConsole(device.FriendlyModelName);
+
+    internal static bool IsGatewayOnlyConsole(UniFiDeviceResponse device)
+        => IsGatewayOnlyConsole(device.FriendlyModelName);
+
+    private static bool IsGatewayOnlyConsole(string friendlyModelName)
     {
-        var name = device.FriendlyModelName;
-        return name.StartsWith("UDM-", StringComparison.OrdinalIgnoreCase) ||
-               name.StartsWith("EFG", StringComparison.OrdinalIgnoreCase);
+        return friendlyModelName.StartsWith("UDM-", StringComparison.OrdinalIgnoreCase) ||
+               friendlyModelName.StartsWith("EFG", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -253,56 +258,56 @@ public class UniFiDiscovery
                 Hostname = c.Hostname,
                 Name = c.Name,
                 IpAddress = ipAddress ?? string.Empty,
-            Network = c.Network,
-            NetworkId = c.NetworkId,
-            VirtualNetworkOverrideEnabled = c.VirtualNetworkOverrideEnabled,
-            VirtualNetworkOverrideId = c.VirtualNetworkOverrideId,
-            Vlan = c.Vlan,
-            IsWired = c.IsWired,
-            IsGuest = c.IsGuest,
-            IsBlocked = c.Blocked,
-            ConnectionType = DetermineConnectionType(c),
-            ConnectedToDeviceMac = c.IsWired ? c.SwMac : c.ApMac,
-            SwitchPort = c.SwPort,
-            Uptime = TimeSpan.FromSeconds(c.Uptime),
-            LastSeen = DateTimeOffset.FromUnixTimeSeconds(c.LastSeen).DateTime,
-            FirstSeen = DateTimeOffset.FromUnixTimeSeconds(c.FirstSeen).DateTime,
-            // Wireless-specific
-            Essid = c.Essid,
-            Channel = c.Channel,
-            Rssi = c.Rssi,
-            SignalStrength = c.Signal,
-            NoiseLevel = c.Noise,
-            RadioProtocol = c.RadioProto,
-            Radio = c.Radio,
-            // Wi-Fi 7 MLO
-            IsMlo = c.IsMlo ?? false,
-            MloLinks = c.MloDetails?.Select(m => new MloLink
-            {
-                Radio = m.Radio ?? "",
-                Channel = m.Channel,
-                ChannelWidth = m.ChannelWidth,
-                SignalDbm = m.Signal,
-                NoiseDbm = m.Noise,
-                TxRateKbps = m.TxRate,
-                RxRateKbps = m.RxRate
-            }).ToList(),
-            // Traffic stats
-            TxBytes = c.TxBytes,
-            RxBytes = c.RxBytes,
-            TxPackets = c.TxPackets,
-            RxPackets = c.RxPackets,
-            TxRate = c.TxRate,
-            RxRate = c.RxRate,
-            TxBytesRate = c.TxBytesRate,
-            RxBytesRate = c.RxBytesRate,
-            // QoS
-            Satisfaction = c.Satisfaction,
-            HasFixedIp = c.UseFixedIp,
-            FixedIp = c.FixedIp,
-            Note = c.Note,
-            Oui = c.Oui
-        };
+                Network = c.Network,
+                NetworkId = c.NetworkId,
+                VirtualNetworkOverrideEnabled = c.VirtualNetworkOverrideEnabled,
+                VirtualNetworkOverrideId = c.VirtualNetworkOverrideId,
+                Vlan = c.Vlan,
+                IsWired = c.IsWired,
+                IsGuest = c.IsGuest,
+                IsBlocked = c.Blocked,
+                ConnectionType = DetermineConnectionType(c),
+                ConnectedToDeviceMac = c.IsWired ? c.SwMac : c.ApMac,
+                SwitchPort = c.SwPort,
+                Uptime = TimeSpan.FromSeconds(c.Uptime),
+                LastSeen = DateTimeOffset.FromUnixTimeSeconds(c.LastSeen).DateTime,
+                FirstSeen = DateTimeOffset.FromUnixTimeSeconds(c.FirstSeen).DateTime,
+                // Wireless-specific
+                Essid = c.Essid,
+                Channel = c.Channel,
+                Rssi = c.Rssi,
+                SignalStrength = c.Signal,
+                NoiseLevel = c.Noise,
+                RadioProtocol = c.RadioProto,
+                Radio = c.Radio,
+                // Wi-Fi 7 MLO
+                IsMlo = c.IsMlo ?? false,
+                MloLinks = c.MloDetails?.Select(m => new MloLink
+                {
+                    Radio = m.Radio ?? "",
+                    Channel = m.Channel,
+                    ChannelWidth = m.ChannelWidth,
+                    SignalDbm = m.Signal,
+                    NoiseDbm = m.Noise,
+                    TxRateKbps = m.TxRate,
+                    RxRateKbps = m.RxRate
+                }).ToList(),
+                // Traffic stats
+                TxBytes = c.TxBytes,
+                RxBytes = c.RxBytes,
+                TxPackets = c.TxPackets,
+                RxPackets = c.RxPackets,
+                TxRate = c.TxRate,
+                RxRate = c.RxRate,
+                TxBytesRate = c.TxBytesRate,
+                RxBytesRate = c.RxBytesRate,
+                // QoS
+                Satisfaction = c.Satisfaction,
+                HasFixedIp = c.UseFixedIp,
+                FixedIp = c.FixedIp,
+                Note = c.Note,
+                Oui = c.Oui
+            };
         }).ToList();
 
         return discoveredClients;
@@ -483,6 +488,13 @@ public class UniFiDiscovery
             hasUplinkToUniFiDevice,
             device.ConfigNetworkLan != null);
 
+        // Gateway-only consoles (UDM-Pro, UDM-SE, UDM-Beast, EFG) never become
+        // APs even if the API reports an uplink to another UniFi device.
+        if (IsGatewayOnlyConsole(device))
+        {
+            return DeviceType.Gateway;
+        }
+
         // If the gateway-class device has an uplink to another UniFi device,
         // it's acting as a mesh AP, not the network gateway (UDR/UX have integrated APs)
         if (hasUplinkToUniFiDevice)
@@ -527,8 +539,9 @@ public class UniFiDiscovery
         var hasUplinkToUniFiDevice = !string.IsNullOrEmpty(uplinkMac) &&
                                       allDeviceMacs.Contains(uplinkMac.ToLowerInvariant());
 
-        // If the UDM-type device has an uplink to another UniFi device,
-        // it's acting as a mesh AP, not the network gateway
+        if (IsGatewayOnlyConsole(device))
+            return DeviceType.Gateway;
+
         return hasUplinkToUniFiDevice ? DeviceType.AccessPoint : DeviceType.Gateway;
     }
 

--- a/src/NetworkOptimizer.Web/Services/DiagnosticsService.cs
+++ b/src/NetworkOptimizer.Web/Services/DiagnosticsService.cs
@@ -89,7 +89,7 @@ public class DiagnosticsService
             }
 
             // Fetch all required data in parallel
-            var devicesTask = _connectionService.Client.GetDevicesAsync();
+            var devicesTask = _connectionService.Client.GetDevicesAsync(useCache: false);
             var clientsTask = _connectionService.Client.GetClientsAsync();
             var networksTask = _connectionService.Client.GetNetworkConfigsAsync();
             var portProfilesTask = _connectionService.Client.GetPortProfilesAsync();

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -705,12 +705,12 @@ public class MonitoringCollectionAgent : BackgroundService
                 long? uptime = ss != null ? (long?)ParseJsonDouble(ss.Uptime) : null;
                 double? temp = ParseDeviceTemperature(device);
 
-                // SNMP devices: only supplement fields SNMP doesn't provide.
-                // SNMP covers CPU/mem/uptime reliably. Temperature is the gap -
-                // most switches don't report temp via SNMP but the UniFi API has it.
-                // Always write API temp for SNMP devices; skip CPU/mem/uptime.
+                // SNMP devices: only supplement temp for switches (SNMP doesn't
+                // report switch temps). Gateway and APs get temp from SNMP already;
+                // writing API temp too creates dual-source Z-shape artifacts.
                 if (snmpActive)
                 {
+                    if (device.DeviceType != NetworkOptimizer.Core.Enums.DeviceType.Switch) continue;
                     cpu = null;
                     mem = null;
                     uptime = null;

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -683,26 +683,36 @@ public class MonitoringCollectionAgent : BackgroundService
         });
         await Task.WhenAll(deviceTasks);
 
-        // Fallback: for non-SNMP devices, read CPU/mem/temp from the cached
-        // UniFi API device response (system-stats + temperatures fields).
-        // Same InfluxDB measurement + live cache as SNMP - seamless on the read side.
+        // UniFi API health pass: supplements or replaces SNMP health data.
+        // Non-SNMP devices: full fallback (CPU, mem, temp, uptime).
+        // SNMP devices: fill in gaps only (e.g., temperature on switches where
+        // SNMP doesn't report temp but UniFi API does).
         var now = DateTime.UtcNow;
         foreach (var device in devices)
         {
             var mac = NormalizeMac(device.Mac);
             var snmpOn = !string.IsNullOrEmpty(device.SnmpContact) || !string.IsNullOrEmpty(device.SnmpLocation);
-            if (snmpOn && !IsSnmpExcluded(mac)) continue;
+            var snmpExcl = IsSnmpExcluded(mac);
+            var snmpActive = snmpOn && !snmpExcl;
 
             try
             {
                 var ss = device.SystemStatsSimple;
-                if (ss == null) continue;
+                if (ss == null && device.Temperatures == null) continue;
 
-                double? cpu = ParseJsonDouble(ss.Cpu);
-                double? mem = ParseJsonDouble(ss.Mem);
-                long? uptime = (long?)ParseJsonDouble(ss.Uptime);
-
+                double? cpu = ss != null ? ParseJsonDouble(ss.Cpu) : null;
+                double? mem = ss != null ? ParseJsonDouble(ss.Mem) : null;
+                long? uptime = ss != null ? (long?)ParseJsonDouble(ss.Uptime) : null;
                 double? temp = ParseDeviceTemperature(device);
+
+                // SNMP devices already have CPU/mem/uptime - only supplement temp
+                if (snmpActive)
+                {
+                    cpu = null;
+                    mem = null;
+                    uptime = null;
+                    if (temp == null) continue;
+                }
 
                 if (cpu == null && mem == null && temp == null) continue;
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -755,6 +755,11 @@ public class MonitoringCollectionAgent : BackgroundService
 
     private static double? ParseDeviceTemperature(UniFiDeviceResponse device)
     {
+        // general_temperature: simple numeric field on switches (e.g., 72)
+        if (device.GeneralTemperature.HasValue && device.GeneralTemperature.Value > 0)
+            return device.GeneralTemperature.Value;
+
+        // temperatures: structured array on gateways, bare integer on some devices
         if (device.Temperatures == null || device.Temperatures.Value.ValueKind == System.Text.Json.JsonValueKind.Undefined)
             return null;
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -682,6 +682,96 @@ public class MonitoringCollectionAgent : BackgroundService
             finally { _snmpGate.Release(); }
         });
         await Task.WhenAll(deviceTasks);
+
+        // Fallback: for non-SNMP devices, read CPU/mem/temp from the cached
+        // UniFi API device response (system-stats + temperatures fields).
+        // Same InfluxDB measurement + live cache as SNMP - seamless on the read side.
+        var now = DateTime.UtcNow;
+        foreach (var device in devices)
+        {
+            var mac = NormalizeMac(device.Mac);
+            var snmpOn = !string.IsNullOrEmpty(device.SnmpContact) || !string.IsNullOrEmpty(device.SnmpLocation);
+            if (snmpOn && !IsSnmpExcluded(mac)) continue;
+
+            try
+            {
+                var ss = device.SystemStatsSimple;
+                if (ss == null) continue;
+
+                double? cpu = ParseJsonDouble(ss.Cpu);
+                double? mem = ParseJsonDouble(ss.Mem);
+                long? uptime = (long?)ParseJsonDouble(ss.Uptime);
+
+                double? temp = ParseDeviceTemperature(device);
+
+                if (cpu == null && mem == null && temp == null) continue;
+
+                await _influx.WriteDeviceHealthAsync(
+                    deviceMac: device.Mac,
+                    deviceType: DescribeDeviceType(device.DeviceType),
+                    cpuPercent: cpu,
+                    memoryTotalKb: null,
+                    memoryUsedKb: null,
+                    memoryUsedPercent: mem,
+                    temperatureC: temp,
+                    uptimeSeconds: uptime,
+                    timestamp: now);
+
+                _liveStats.RecordHealth(device.Mac, cpu, mem, temp, uptime, now);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "UniFi API health fallback failed for {Device}", device.Mac);
+            }
+        }
+    }
+
+    private static double? ParseJsonDouble(System.Text.Json.JsonElement? el)
+    {
+        if (el == null || el.Value.ValueKind == System.Text.Json.JsonValueKind.Undefined) return null;
+        if (el.Value.ValueKind == System.Text.Json.JsonValueKind.Number && el.Value.TryGetDouble(out var num)) return num;
+        if (el.Value.ValueKind == System.Text.Json.JsonValueKind.String)
+        {
+            var s = el.Value.GetString()?.Trim();
+            if (double.TryParse(s, System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var parsed))
+                return parsed;
+        }
+        return null;
+    }
+
+    private static double? ParseDeviceTemperature(UniFiDeviceResponse device)
+    {
+        if (device.Temperatures == null || device.Temperatures.Value.ValueKind == System.Text.Json.JsonValueKind.Undefined)
+            return null;
+
+        var el = device.Temperatures.Value;
+
+        // Gateway: array of { name, type, value } - pick the CPU sensor
+        if (el.ValueKind == System.Text.Json.JsonValueKind.Array)
+        {
+            foreach (var sensor in el.EnumerateArray())
+            {
+                var sType = sensor.TryGetProperty("type", out var t) ? t.GetString() : null;
+                if (string.Equals(sType, "cpu", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (sensor.TryGetProperty("value", out var v) && v.TryGetDouble(out var tempVal))
+                        return tempVal;
+                }
+            }
+            // No CPU sensor found, take the first one
+            foreach (var sensor in el.EnumerateArray())
+            {
+                if (sensor.TryGetProperty("value", out var v) && v.TryGetDouble(out var tempVal))
+                    return tempVal;
+            }
+        }
+
+        // Switch: bare integer
+        if (el.ValueKind == System.Text.Json.JsonValueKind.Number && el.TryGetDouble(out var bare))
+            return bare;
+
+        return null;
     }
 
     private async Task SlowTierCollectAsync(MonitoringSettings settings, CancellationToken ct)

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -705,13 +705,16 @@ public class MonitoringCollectionAgent : BackgroundService
                 long? uptime = ss != null ? (long?)ParseJsonDouble(ss.Uptime) : null;
                 double? temp = ParseDeviceTemperature(device);
 
-                // SNMP devices already have CPU/mem/uptime - only supplement temp
+                // Only supplement fields SNMP didn't already provide this cycle.
                 if (snmpActive)
                 {
-                    cpu = null;
-                    mem = null;
+                    var existing = _liveStats.GetForDevice(mac);
+                    var fresh = existing?.LastHealthUpdate >= now.AddSeconds(-35);
+                    if (fresh && existing?.CpuPercent != null) cpu = null;
+                    if (fresh && existing?.MemoryUsedPercent != null) mem = null;
+                    if (fresh && existing?.TemperatureC != null) temp = null;
                     uptime = null;
-                    if (temp == null) continue;
+                    if (cpu == null && mem == null && temp == null) continue;
                 }
 
                 if (cpu == null && mem == null && temp == null) continue;

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -705,16 +705,16 @@ public class MonitoringCollectionAgent : BackgroundService
                 long? uptime = ss != null ? (long?)ParseJsonDouble(ss.Uptime) : null;
                 double? temp = ParseDeviceTemperature(device);
 
-                // Only supplement fields SNMP didn't already provide this cycle.
+                // SNMP devices: only supplement fields SNMP doesn't provide.
+                // SNMP covers CPU/mem/uptime reliably. Temperature is the gap -
+                // most switches don't report temp via SNMP but the UniFi API has it.
+                // Always write API temp for SNMP devices; skip CPU/mem/uptime.
                 if (snmpActive)
                 {
-                    var existing = _liveStats.GetForDevice(mac);
-                    var fresh = existing?.LastHealthUpdate >= now.AddSeconds(-35);
-                    if (fresh && existing?.CpuPercent != null) cpu = null;
-                    if (fresh && existing?.MemoryUsedPercent != null) mem = null;
-                    if (fresh && existing?.TemperatureC != null) temp = null;
+                    cpu = null;
+                    mem = null;
                     uptime = null;
-                    if (cpu == null && mem == null && temp == null) continue;
+                    if (temp == null) continue;
                 }
 
                 if (cpu == null && mem == null && temp == null) continue;

--- a/src/NetworkOptimizer.Web/Services/TopologySnapshotService.cs
+++ b/src/NetworkOptimizer.Web/Services/TopologySnapshotService.cs
@@ -77,7 +77,7 @@ public class TopologySnapshotService : ITopologySnapshotService
                 _clientProvider.Client,
                 _loggerFactory.CreateLogger<UniFiDiscovery>());
 
-            var topology = await discovery.DiscoverTopologyAsync();
+            var topology = await discovery.DiscoverTopologyAsync(useCache: false);
             if (topology == null)
             {
                 _logger.LogWarning("Cannot capture snapshot - topology discovery failed");

--- a/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
@@ -4,6 +4,7 @@ using NetworkOptimizer.Storage.Interfaces;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
 using NetworkOptimizer.UniFi;
+using NetworkOptimizer.UniFi.Models;
 
 namespace NetworkOptimizer.Web.Services;
 
@@ -828,12 +829,25 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
             return _cachedNetworks;
         }
 
-        var discoveryLogger = _loggerFactory.CreateLogger<UniFiDiscovery>();
-        var discovery = new UniFiDiscovery(_client, discoveryLogger);
-        var topology = await discovery.DiscoverTopologyAsync(cancellationToken);
+        var networks = await _client.GetNetworkConfigsAsync(cancellationToken);
 
-        // Cache the result
-        _cachedNetworks = topology.Networks;
+        _cachedNetworks = networks?.Select(n => new NetworkInfo
+        {
+            Id = n.Id,
+            Name = n.Name,
+            Purpose = n.Purpose,
+            Enabled = n.Enabled,
+            VlanId = n.Vlan,
+            IpSubnet = n.IpSubnet,
+            IsDhcpEnabled = n.DhcpdEnabled,
+            DhcpRange = n.DhcpdEnabled ? $"{n.DhcpdStart} - {n.DhcpdStop}" : null,
+            Gateway = n.DhcpdGateway,
+            IsNat = n.IsNat,
+            WanUploadMbps = n.WanProviderCapabilities?.UploadMbps,
+            WanDownloadMbps = n.WanProviderCapabilities?.DownloadMbps,
+            WanNetworkgroup = n.WanNetworkgroup,
+            WanSmartqEnabled = n.WanSmartqEnabled
+        }).ToList() ?? new List<NetworkInfo>();
         _networkCacheTime = DateTime.UtcNow;
 
         return _cachedNetworks;

--- a/src/NetworkOptimizer.Web/Services/WanDataUsageService.cs
+++ b/src/NetworkOptimizer.Web/Services/WanDataUsageService.cs
@@ -367,7 +367,7 @@ public class WanDataUsageService : BackgroundService
             var client = _connectionService.Client;
             if (client == null) return (null, 0);
 
-            var devices = await client.GetDevicesAsync(ct);
+            var devices = await client.GetDevicesAsync(ct, useCache: false);
             var gateway = devices?.FirstOrDefault(d => d.DeviceType == DeviceType.Gateway);
             if (gateway == null) return (null, 0);
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1198,6 +1198,7 @@ class LanFlowMap2D {
                 const my=isWan?midY-28:midY+20;
                 let txt=null;
                 let txtColor=C.textMuted; // default muted; live rates override
+                let txtItalic=false;
 
                 if(isWan){
                     // Show live throughput when active, ISP expected when idle
@@ -1211,6 +1212,7 @@ class LanFlowMap2D {
                             e.lk.fromNodeId===c.d.id||e.lk.toNodeId===c.d.id);
                         if(cloud?.d.ispDownloadMbps&&cloud?.d.ispUploadMbps){
                             txt=`↓${formatSpeed(cloud.d.ispDownloadMbps)}  ↑${formatSpeed(cloud.d.ispUploadMbps)}`;
+                            txtColor='#6b7280'; txtItalic=true;
                         }else if(e.lk.capacityBps>0){
                             txt=formatSpeed(e.lk.capacityBps/1e6);
                         }
@@ -1228,15 +1230,18 @@ class LanFlowMap2D {
                     txt=formatSpeed(e.lk.capacityBps/1e6);
                 }
 
-                if(txt) this._pendingLinkLabels.push({mx,my,txt,txtColor});
+                if(txt) this._pendingLinkLabels.push({mx,my,txt,txtColor,txtItalic});
             }
         }
         ctx.globalAlpha=1;
     }
 
     _drawLinkSpeedLabels(ctx){
-        ctx.font=`${G.rateFont}px ${FONT}`;
-        for(const{mx,my,txt,txtColor}of(this._pendingLinkLabels||[])){
+        const normalFont=`${G.rateFont}px ${FONT}`;
+        const italicFont=`italic ${G.rateFont}px ${FONT}`;
+        ctx.font=normalFont;
+        for(const{mx,my,txt,txtColor,txtItalic}of(this._pendingLinkLabels||[])){
+            ctx.font=txtItalic?italicFont:normalFont;
             const tw=ctx.measureText(txt).width+12;
             ctx.fillStyle=C.labelBg;
             ctx.globalAlpha=1;


### PR DESCRIPTION
## Summary

- **Device health fallback**: Non-SNMP devices (Flex Mini, devices with SNMP toggled off) now get CPU, memory, temperature, and uptime from the UniFi API's `system-stats` and `general_temperature` fields. Writes to the same `device_health` InfluxDB measurement so charts and tooltips pick it up automatically.
- **Switch temperature supplement**: Switches with SNMP get temperature from the UniFi API since SNMP doesn't report switch temps. Gateway and APs are excluded (SNMP already provides their temp).
- **API call optimization**: 15s TTL cache on `GetDevicesAsync` reduces redundant `stat/device` calls from ~7/min to ~2/min. Callers that need fresh data (topology snapshots, diagnostics, WAN data usage, path tracing) bypass the cache explicitly.
- **Network-only fetch**: `GetDiscoveredNetworksAsync` now calls `GetNetworkConfigsAsync` directly (41 KB) instead of `DiscoverTopologyAsync` (562 KB), saving 521 KB of unnecessary device + client data per call.
- **Gateway-only console fix**: UDM-Beast, UDM-Pro, UDM-SE, UDM-Pro-Max, and EFG could be misclassified as access points in WiFi Optimizer if they had an uplink to another UniFi device (e.g. a WAN Switch). The `IsGatewayOnlyConsole` check now runs before the uplink-based AP reclassification.

## Test plan

- [x] Non-SNMP devices show CPU/mem/uptime on Device Health charts
- [x] Switch temps appear on temperature chart (from UniFi API)
- [x] Gateway temp chart is clean single line (no Z-shape from dual sources)
- [x] SNMP devices still get CPU/mem/uptime from SNMP (no regression)
- [x] API call frequency reduced (verified via trace logging)
- [x] UDR/UDR7/UX/UX7 still reclassify as APs when behind another gateway
- [x] UDM-Beast/UDM-Pro/EFG stay as gateways even with UniFi uplink device
- [x] All 6,232 tests pass, 0 warnings