### PR TITLE
v1.17.11

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -148,7 +148,7 @@ EXPOSE 8042
 EXPOSE 5201
 
 # Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
     CMD curl -f http://localhost:8042/api/health || exit 1
 
 # Set ownership for app directories

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -48,7 +48,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 40s
+      start_period: 120s
 
   # Network Optimizer Speed Test - customized OpenSpeedTest that sends results to Network Optimizer
   # Requires HOST_IP or HOST_NAME to be set in .env for result reporting

--- a/docker/docker-compose.macos.yml
+++ b/docker/docker-compose.macos.yml
@@ -47,7 +47,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 40s
+      start_period: 120s
 
   # Network Optimizer Speed Test - customized OpenSpeedTest that sends results to Network Optimizer
   # Requires HOST_IP or HOST_NAME to be set in .env for result reporting

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -39,7 +39,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 40s
+      start_period: 120s
 
   # Network Optimizer Speed Test - customized OpenSpeedTest that sends results to Network Optimizer
   # Requires HOST_IP or HOST_NAME to be set in .env for result reporting

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 40s
+      start_period: 120s
 
   # Network Optimizer Speed Test - customized OpenSpeedTest that sends results to Network Optimizer
   # Requires HOST_IP or HOST_NAME to be set in .env for result reporting

--- a/scripts/proxmox/install.sh
+++ b/scripts/proxmox/install.sh
@@ -759,7 +759,7 @@ deploy_application() {
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 40s
+      start_period: 120s
 
   network-optimizer-speedtest:
     image: ghcr.io/ozark-connect/speedtest:latest

--- a/src/NetworkOptimizer.UniFi/Models/UniFiClientResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiClientResponse.cs
@@ -158,6 +158,18 @@ public class UniFiClientResponse
     [JsonPropertyName("rx_bytes-r")]
     public double RxBytesRate { get; set; }
 
+    [JsonPropertyName("wired-tx_bytes")]
+    public long WiredTxBytes { get; set; }
+
+    [JsonPropertyName("wired-rx_bytes")]
+    public long WiredRxBytes { get; set; }
+
+    [JsonPropertyName("wired-tx_bytes-r")]
+    public double WiredTxBytesRate { get; set; }
+
+    [JsonPropertyName("wired-rx_bytes-r")]
+    public double WiredRxBytesRate { get; set; }
+
     // QoS and experience
     [JsonPropertyName("qos_policy_applied")]
     public bool QosPolicyApplied { get; set; }

--- a/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
@@ -144,6 +144,15 @@ public class UniFiDeviceResponse
     [JsonPropertyName("sys_stats")]
     public SystemStats? SystemStats { get; set; }
 
+    [JsonPropertyName("system-stats")]
+    public SystemStatsSimple? SystemStatsSimple { get; set; }
+
+    [JsonPropertyName("temperatures")]
+    public System.Text.Json.JsonElement? Temperatures { get; set; }
+
+    [JsonPropertyName("general_temperature")]
+    public double? GeneralTemperature { get; set; }
+
     // Wi-Fi specific (APs only)
     /// <summary>
     /// Radio configuration table - per-radio settings (channel, tx_power, antenna)
@@ -676,6 +685,18 @@ public class SystemStats
 
     [JsonPropertyName("loadavg_15")]
     public double? LoadAvg15 { get; set; }
+}
+
+public class SystemStatsSimple
+{
+    [JsonPropertyName("cpu")]
+    public System.Text.Json.JsonElement? Cpu { get; set; }
+
+    [JsonPropertyName("mem")]
+    public System.Text.Json.JsonElement? Mem { get; set; }
+
+    [JsonPropertyName("uptime")]
+    public System.Text.Json.JsonElement? Uptime { get; set; }
 }
 
 public class ConfigNetwork

--- a/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
@@ -70,6 +70,12 @@ public class UniFiDeviceResponse
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
+    [JsonPropertyName("snmp_contact")]
+    public string? SnmpContact { get; set; }
+
+    [JsonPropertyName("snmp_location")]
+    public string? SnmpLocation { get; set; }
+
     /// <summary>
     /// Gets the best available friendly product name using the product database lookup
     /// </summary>

--- a/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
+++ b/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
@@ -1152,7 +1152,7 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
             _clientProvider.Client,
             _loggerFactory.CreateLogger<UniFiDiscovery>());
 
-        var topology = await discovery.DiscoverTopologyAsync(cancellationToken);
+        var topology = await discovery.DiscoverTopologyAsync(cancellationToken, useCache: false);
 
         if (topology != null)
         {

--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -39,6 +39,9 @@ public class UniFiApiClient : IDisposable
     private string? _csrfToken;
     private readonly AsyncRetryPolicy _retryPolicy;
     private readonly SemaphoreSlim _authLock = new(1, 1);
+    private List<UniFiDeviceResponse>? _cachedDeviceResponses;
+    private DateTime _deviceResponseCacheTime = DateTime.MinValue;
+    private static readonly TimeSpan DeviceResponseCacheTtl = TimeSpan.FromSeconds(15);
     private bool _isAuthenticated = false;
     private bool _isUniFiOs = false; // True for UDM/UCG, false for standalone controller
     private bool _pathDetected = false;
@@ -622,9 +625,18 @@ public class UniFiApiClient : IDisposable
     /// GET /api/s/{site}/stat/device (standalone) - Get all UniFi devices
     /// Returns the large device payload with all port profiles, switch port details, etc.
     /// </summary>
-    public async Task<List<UniFiDeviceResponse>> GetDevicesAsync(CancellationToken cancellationToken = default)
+    public async Task<List<UniFiDeviceResponse>> GetDevicesAsync(CancellationToken cancellationToken = default, bool useCache = true)
     {
-        _logger.LogTrace("Fetching all devices from site {Site}", _site);
+        if (useCache && _cachedDeviceResponses != null
+            && DateTime.UtcNow - _deviceResponseCacheTime < DeviceResponseCacheTtl)
+        {
+            _logger.LogTrace("Returning cached device response ({Count} devices, age {Age:F1}s)",
+                _cachedDeviceResponses.Count,
+                (DateTime.UtcNow - _deviceResponseCacheTime).TotalSeconds);
+            return _cachedDeviceResponses;
+        }
+
+        _logger.LogTrace("Fetching all devices from site {Site} (useCache={UseCache})", _site, useCache);
 
         var response = await ExecuteApiCallAsync<UniFiApiResponse<UniFiDeviceResponse>>(
             () => _httpClient!.GetAsync(BuildApiPath("stat/device"), cancellationToken),
@@ -633,6 +645,8 @@ public class UniFiApiClient : IDisposable
         if (response?.Meta.Rc == "ok")
         {
             _logger.LogTrace("Retrieved {Count} devices", response.Data.Count);
+            _cachedDeviceResponses = response.Data;
+            _deviceResponseCacheTime = DateTime.UtcNow;
             return response.Data;
         }
 

--- a/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
@@ -24,12 +24,12 @@ public class UniFiDiscovery
     /// Discovers all UniFi devices via controller API
     /// Returns devices with full metadata from controller
     /// </summary>
-    public async Task<List<DiscoveredDevice>> DiscoverDevicesAsync(CancellationToken cancellationToken = default)
+    public async Task<List<DiscoveredDevice>> DiscoverDevicesAsync(CancellationToken cancellationToken = default, bool useCache = true)
     {
         _logger.LogTrace("Starting UniFi device discovery via API");
 
         // Fetch devices and network configs in parallel
-        var devicesTask = _apiClient.GetDevicesAsync(cancellationToken);
+        var devicesTask = _apiClient.GetDevicesAsync(cancellationToken, useCache);
         var networksTask = _apiClient.GetNetworkConfigsAsync(cancellationToken);
 
         await Task.WhenAll(devicesTask, networksTask);
@@ -151,10 +151,15 @@ public class UniFiDiscovery
     /// Allows: UDM (original Dream Machine), UDR, UX, etc. which have real Wi-Fi.
     /// </summary>
     internal static bool IsGatewayOnlyConsole(DiscoveredDevice device)
+        => IsGatewayOnlyConsole(device.FriendlyModelName);
+
+    internal static bool IsGatewayOnlyConsole(UniFiDeviceResponse device)
+        => IsGatewayOnlyConsole(device.FriendlyModelName);
+
+    private static bool IsGatewayOnlyConsole(string friendlyModelName)
     {
-        var name = device.FriendlyModelName;
-        return name.StartsWith("UDM-", StringComparison.OrdinalIgnoreCase) ||
-               name.StartsWith("EFG", StringComparison.OrdinalIgnoreCase);
+        return friendlyModelName.StartsWith("UDM-", StringComparison.OrdinalIgnoreCase) ||
+               friendlyModelName.StartsWith("EFG", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -253,56 +258,56 @@ public class UniFiDiscovery
                 Hostname = c.Hostname,
                 Name = c.Name,
                 IpAddress = ipAddress ?? string.Empty,
-            Network = c.Network,
-            NetworkId = c.NetworkId,
-            VirtualNetworkOverrideEnabled = c.VirtualNetworkOverrideEnabled,
-            VirtualNetworkOverrideId = c.VirtualNetworkOverrideId,
-            Vlan = c.Vlan,
-            IsWired = c.IsWired,
-            IsGuest = c.IsGuest,
-            IsBlocked = c.Blocked,
-            ConnectionType = DetermineConnectionType(c),
-            ConnectedToDeviceMac = c.IsWired ? c.SwMac : c.ApMac,
-            SwitchPort = c.SwPort,
-            Uptime = TimeSpan.FromSeconds(c.Uptime),
-            LastSeen = DateTimeOffset.FromUnixTimeSeconds(c.LastSeen).DateTime,
-            FirstSeen = DateTimeOffset.FromUnixTimeSeconds(c.FirstSeen).DateTime,
-            // Wireless-specific
-            Essid = c.Essid,
-            Channel = c.Channel,
-            Rssi = c.Rssi,
-            SignalStrength = c.Signal,
-            NoiseLevel = c.Noise,
-            RadioProtocol = c.RadioProto,
-            Radio = c.Radio,
-            // Wi-Fi 7 MLO
-            IsMlo = c.IsMlo ?? false,
-            MloLinks = c.MloDetails?.Select(m => new MloLink
-            {
-                Radio = m.Radio ?? "",
-                Channel = m.Channel,
-                ChannelWidth = m.ChannelWidth,
-                SignalDbm = m.Signal,
-                NoiseDbm = m.Noise,
-                TxRateKbps = m.TxRate,
-                RxRateKbps = m.RxRate
-            }).ToList(),
-            // Traffic stats
-            TxBytes = c.TxBytes,
-            RxBytes = c.RxBytes,
-            TxPackets = c.TxPackets,
-            RxPackets = c.RxPackets,
-            TxRate = c.TxRate,
-            RxRate = c.RxRate,
-            TxBytesRate = c.TxBytesRate,
-            RxBytesRate = c.RxBytesRate,
-            // QoS
-            Satisfaction = c.Satisfaction,
-            HasFixedIp = c.UseFixedIp,
-            FixedIp = c.FixedIp,
-            Note = c.Note,
-            Oui = c.Oui
-        };
+                Network = c.Network,
+                NetworkId = c.NetworkId,
+                VirtualNetworkOverrideEnabled = c.VirtualNetworkOverrideEnabled,
+                VirtualNetworkOverrideId = c.VirtualNetworkOverrideId,
+                Vlan = c.Vlan,
+                IsWired = c.IsWired,
+                IsGuest = c.IsGuest,
+                IsBlocked = c.Blocked,
+                ConnectionType = DetermineConnectionType(c),
+                ConnectedToDeviceMac = c.IsWired ? c.SwMac : c.ApMac,
+                SwitchPort = c.SwPort,
+                Uptime = TimeSpan.FromSeconds(c.Uptime),
+                LastSeen = DateTimeOffset.FromUnixTimeSeconds(c.LastSeen).DateTime,
+                FirstSeen = DateTimeOffset.FromUnixTimeSeconds(c.FirstSeen).DateTime,
+                // Wireless-specific
+                Essid = c.Essid,
+                Channel = c.Channel,
+                Rssi = c.Rssi,
+                SignalStrength = c.Signal,
+                NoiseLevel = c.Noise,
+                RadioProtocol = c.RadioProto,
+                Radio = c.Radio,
+                // Wi-Fi 7 MLO
+                IsMlo = c.IsMlo ?? false,
+                MloLinks = c.MloDetails?.Select(m => new MloLink
+                {
+                    Radio = m.Radio ?? "",
+                    Channel = m.Channel,
+                    ChannelWidth = m.ChannelWidth,
+                    SignalDbm = m.Signal,
+                    NoiseDbm = m.Noise,
+                    TxRateKbps = m.TxRate,
+                    RxRateKbps = m.RxRate
+                }).ToList(),
+                // Traffic stats
+                TxBytes = c.TxBytes,
+                RxBytes = c.RxBytes,
+                TxPackets = c.TxPackets,
+                RxPackets = c.RxPackets,
+                TxRate = c.TxRate,
+                RxRate = c.RxRate,
+                TxBytesRate = c.TxBytesRate,
+                RxBytesRate = c.RxBytesRate,
+                // QoS
+                Satisfaction = c.Satisfaction,
+                HasFixedIp = c.UseFixedIp,
+                FixedIp = c.FixedIp,
+                Note = c.Note,
+                Oui = c.Oui
+            };
         }).ToList();
 
         return discoveredClients;
@@ -329,11 +334,11 @@ public class UniFiDiscovery
     /// <summary>
     /// Gets comprehensive network topology including devices and their connections
     /// </summary>
-    public async Task<NetworkTopology> DiscoverTopologyAsync(CancellationToken cancellationToken = default)
+    public async Task<NetworkTopology> DiscoverTopologyAsync(CancellationToken cancellationToken = default, bool useCache = true)
     {
         _logger.LogInformation("Starting network topology discovery");
 
-        var devicesTask = DiscoverDevicesAsync(cancellationToken);
+        var devicesTask = DiscoverDevicesAsync(cancellationToken, useCache);
         var clientsTask = DiscoverClientsAsync(cancellationToken);
         var networksTask = _apiClient.GetNetworkConfigsAsync(cancellationToken);
 
@@ -483,6 +488,13 @@ public class UniFiDiscovery
             hasUplinkToUniFiDevice,
             device.ConfigNetworkLan != null);
 
+        // Gateway-only consoles (UDM-Pro, UDM-SE, UDM-Beast, EFG) never become
+        // APs even if the API reports an uplink to another UniFi device.
+        if (IsGatewayOnlyConsole(device))
+        {
+            return DeviceType.Gateway;
+        }
+
         // If the gateway-class device has an uplink to another UniFi device,
         // it's acting as a mesh AP, not the network gateway (UDR/UX have integrated APs)
         if (hasUplinkToUniFiDevice)
@@ -527,8 +539,9 @@ public class UniFiDiscovery
         var hasUplinkToUniFiDevice = !string.IsNullOrEmpty(uplinkMac) &&
                                       allDeviceMacs.Contains(uplinkMac.ToLowerInvariant());
 
-        // If the UDM-type device has an uplink to another UniFi device,
-        // it's acting as a mesh AP, not the network gateway
+        if (IsGatewayOnlyConsole(device))
+            return DeviceType.Gateway;
+
         return hasUplinkToUniFiDevice ? DeviceType.AccessPoint : DeviceType.Gateway;
     }
 

--- a/src/NetworkOptimizer.Web/Components/Layout/NavMenu.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/NavMenu.razor
@@ -11,7 +11,7 @@
         </li>
         <li class="nav-item" @onclick="HandleNavClick">
             <NavLink class="nav-link" href="/monitoring">
-                <img src="/icons/monitoring.svg" alt="" class="nav-icon-img" />
+                <img src="/icons/port-scan.png" alt="" class="nav-icon-img" />
                 <span class="nav-text">Monitoring</span>
             </NavLink>
         </li>
@@ -51,16 +51,16 @@
                 <span class="nav-text">Security Audit</span>
             </NavLink>
         </li>
+        <li class="nav-item nav-sub-item" @onclick="HandleNavClick">
+            <NavLink class="nav-link" href="/upnp-inspector">
+                <span class="nav-sub-icon">└</span>
+                <span class="nav-text">UPnP Inspector</span>
+            </NavLink>
+        </li>
         <li class="nav-item" @onclick="HandleNavClick">
             <NavLink class="nav-link" href="/threats">
                 <img src="/icons/threats.png" alt="" class="nav-icon-img" />
                 <span class="nav-text">Threat Intelligence</span>
-            </NavLink>
-        </li>
-        <li class="nav-item" @onclick="HandleNavClick">
-            <NavLink class="nav-link" href="/upnp-inspector">
-                <img src="/icons/port-scan.png" alt="" class="nav-icon-img" />
-                <span class="nav-text">UPnP Inspector</span>
             </NavLink>
         </li>
         <li class="nav-item" @onclick="HandleNavClick">

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -213,6 +213,16 @@ else
                 <div class="stat-label">Fabric Egress</div>
             </div>
         </div>
+
+        <!-- 2D LAN hierarchy map -->
+        <div class="card lan-flow-map-2d-card" style="margin-top: 1.5rem;">
+            <div class="card-header">
+                <h2 class="card-title">LAN Topology Flow Map</h2>
+            </div>
+            <div class="card-body lan-flow-map-2d-body">
+                <div id="lan-flow-map-2d-stage" class="lan-flow-map-2d-stage"></div>
+            </div>
+        </div>
     }
 
     @* ──────────────── Tab: Network Performance ──────────────── *@
@@ -726,6 +736,69 @@ else
             font-size: 1rem;
         }
     }
+
+    .lan-flow-map-2d-card {
+        overflow: hidden;
+    }
+    .lan-flow-map-2d-body {
+        padding: 0;
+        background: #202023;
+        position: relative;
+    }
+    .lan-flow-map-2d-stage {
+        width: 100%;
+        height: clamp(520px, 70vh, 820px);
+    }
+    .lfm2d-canvas {
+        display: block;
+        width: 100%;
+        height: 100%;
+    }
+    .lfm2d-tooltip {
+        position: absolute;
+        background: rgba(16, 24, 32, 0.92);
+        border: 1px solid rgba(255, 255, 255, 0.06);
+        border-radius: 8px;
+        padding: 0.5rem 0.65rem;
+        font-size: 0.78rem;
+        line-height: 1.35;
+        color: var(--text-primary);
+        pointer-events: none;
+        display: none;
+        z-index: 10;
+        max-width: 260px;
+    }
+    .lan-flow-map-2d-stage .lan-flow-map-controls {
+        right: 3.1rem;
+        top: 0.75rem;
+    }
+    .lfm2d-toolbar {
+        position: absolute;
+        top: 48px;
+        right: 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        z-index: 2;
+    }
+    .lfm2d-btn {
+        width: 32px;
+        height: 32px;
+        border: 1px solid rgba(255,255,255,0.1);
+        border-radius: 6px;
+        background: rgba(26,29,35,0.9);
+        color: var(--text-secondary);
+        font-size: 16px;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        line-height: 1;
+    }
+    .lfm2d-btn:hover {
+        background: rgba(51,56,68,0.9);
+        color: var(--text-primary);
+    }
 </style>
 
 @code {
@@ -774,6 +847,7 @@ else
 
     // Chart mount tracking
     private bool _mapMounted = false;
+    private bool _map2dMounted = false;
     private bool _latencyChartsMounted;
     private bool _healthChartsMounted;
     private bool _sfpChartsMounted;
@@ -1632,6 +1706,24 @@ else
             catch { }
         }
 
+        // 2D hierarchy map - Live tab only
+        if (_activeTab == "live" && _monitoringReady && !_map2dMounted)
+        {
+            _map2dMounted = true;
+            try
+            {
+                await JS.InvokeVoidAsync("eval",
+                    $"(async () => {{ const m = await import('{VersionedJs("/js/lan-flow-map-2d.js")}'); window.__lanFlowMap2d = m; await m.mount('lan-flow-map-2d-stage'); }})();");
+            }
+            catch { _map2dMounted = false; }
+        }
+        else if (_activeTab != "live" && _map2dMounted)
+        {
+            _map2dMounted = false;
+            try { await JS.InvokeVoidAsync("eval", "window.__lanFlowMap2d?.unmount();"); }
+            catch { }
+        }
+
         // Latency charts - Performance tab only
         if (_activeTab == "performance" && _monitoringReady && !_latencyChartsMounted)
         {
@@ -1723,6 +1815,11 @@ else
         if (_mapMounted)
         {
             try { _ = JS.InvokeVoidAsync("eval", "window.__lanFlowMap?.unmount();").AsTask(); }
+            catch { }
+        }
+        if (_map2dMounted)
+        {
+            try { _ = JS.InvokeVoidAsync("eval", "window.__lanFlowMap2d?.unmount();").AsTask(); }
             catch { }
         }
     }

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -533,10 +533,25 @@ using (var scope = app.Services.CreateScope())
             }
         }
     }
+
+    // Clear stale migration locks left by a previous interrupted startup (#624).
+    // At app startup no other process can be migrating this SQLite DB, so any lock is stale.
+    cmd.Parameters.Clear();
+    cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name='__EFMigrationsLock'";
+    if (cmd.ExecuteScalar() != null)
+    {
+        cmd.CommandText = "DELETE FROM __EFMigrationsLock";
+        var cleared = cmd.ExecuteNonQuery();
+        if (cleared > 0)
+            app.Logger.LogWarning("Cleared stale migration lock (likely from a previous interrupted startup)");
+    }
+
     conn.Close();
 
     // Apply any pending migrations (creates DB for new installs, or applies new migrations for existing)
+    app.Logger.LogInformation("Applying database migrations...");
     db.Database.Migrate();
+    app.Logger.LogInformation("Database migrations complete");
 
     // Ensure WAL mode - config imports replace the DB with a DELETE-mode copy
     db.Database.ExecuteSqlRaw("PRAGMA journal_mode=WAL;");

--- a/src/NetworkOptimizer.Web/Services/DiagnosticsService.cs
+++ b/src/NetworkOptimizer.Web/Services/DiagnosticsService.cs
@@ -89,7 +89,7 @@ public class DiagnosticsService
             }
 
             // Fetch all required data in parallel
-            var devicesTask = _connectionService.Client.GetDevicesAsync();
+            var devicesTask = _connectionService.Client.GetDevicesAsync(useCache: false);
             var clientsTask = _connectionService.Client.GetClientsAsync();
             var networksTask = _connectionService.Client.GetNetworkConfigsAsync();
             var portProfilesTask = _connectionService.Client.GetPortProfilesAsync();

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
@@ -193,6 +193,17 @@ public class LanCloud
     /// <summary>Discovery pending state - the access cloud frame is real but
     /// upstream Hops haven't been resolved yet (tracer wizard not run / in progress).</summary>
     public bool IsDiscoveryPending { get; set; }
+
+    /// <summary>ISP expected download speed in Mbps (from UniFi WAN provider capabilities).</summary>
+    public int? IspDownloadMbps { get; set; }
+
+    /// <summary>ISP expected upload speed in Mbps (from UniFi WAN provider capabilities).</summary>
+    public int? IspUploadMbps { get; set; }
+
+    /// <summary>Monitoring target ID whose live RTT feeds this cloud's stats.
+    /// Server-side only; the live tick re-queries this for fresh RTT/loss.</summary>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public string? RttTargetId { get; set; }
 }
 
 public class LinkLiveRates

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -281,27 +281,43 @@ public class LanFlowMapService
                     }
                 }
             }
-            else if (link.Kind == LanLinkKind.WiredClient && !string.IsNullOrEmpty(link.PortKey))
+            else if (link.Kind == LanLinkKind.WiredClient)
             {
-                // Wired client leaves don't have device-level monitoring stats - their
-                // throughput lives on the parent switch port, which the SNMP fast tier
-                // writes into MonitoringLiveStats.PortRates every ~5s. Look up by the
-                // (parentMac, ifName) key already encoded in link.PortKey.
-                var (parentMac, ifName) = ParsePortKey(link.PortKey);
-                if (!string.IsNullOrEmpty(parentMac) && !string.IsNullOrEmpty(ifName))
+                // Primary: parent switch port via SNMP (PortKey).
+                if (!string.IsNullOrEmpty(link.PortKey))
                 {
-                    var portRate = _liveStats.GetPortRate(parentMac, ifName);
-                    if (portRate != null)
+                    var (parentMac, ifName) = ParsePortKey(link.PortKey);
+                    if (!string.IsNullOrEmpty(parentMac) && !string.IsNullOrEmpty(ifName))
                     {
-                        // Direction mapping mirrors MapPortToLinkRates for an internal
-                        // (non-WAN) link: port TX (DownBps) = data toward leaf,
-                        // port RX (UpBps) = data from leaf.
-                        rates = new LinkLiveRates
+                        var portRate = _liveStats.GetPortRate(parentMac, ifName);
+                        if (portRate != null)
                         {
-                            DownstreamBps = portRate.DownBps,
-                            UpstreamBps = portRate.UpBps,
-                            AsOf = portRate.LastUpdate,
-                        };
+                            rates = new LinkLiveRates
+                            {
+                                DownstreamBps = portRate.DownBps,
+                                UpstreamBps = portRate.UpBps,
+                                AsOf = portRate.LastUpdate,
+                            };
+                        }
+                    }
+                }
+                // Fallback: UniFi client stats (for switches without SNMP).
+                // TX from the client's perspective = upload = upstream on the link.
+                if (rates == null)
+                {
+                    var clientMac = ExtractWiredClientMacFromLinkId(link.Id);
+                    if (!string.IsNullOrEmpty(clientMac))
+                    {
+                        var wc = _liveStats.GetWiredClient(clientMac);
+                        if (wc != null)
+                        {
+                            rates = new LinkLiveRates
+                            {
+                                DownstreamBps = wc.TxThroughputBps ?? 0,
+                                UpstreamBps = wc.RxThroughputBps ?? 0,
+                                AsOf = wc.LastUpdate,
+                            };
+                        }
                     }
                 }
             }
@@ -353,16 +369,30 @@ public class LanFlowMapService
             };
         }
 
-        // Cloud RTT from the in-memory target stats cache.
+        // Cloud RTT from the live monitoring target cache (same source as the
+        // ISP RTT stat card) so the globe label stays in lockstep.
         foreach (var cloud in snapshot.Clouds)
         {
-            // The cloud's RTT came from MonitoringPathView at build time - re-resolve it
-            // by querying the same source so the live tick is fresh.
+            double? rtt = cloud.RttAvgMs;
+            double? loss = cloud.LossPercent;
+            bool success = rtt.HasValue;
+
+            if (!string.IsNullOrEmpty(cloud.RttTargetId))
+            {
+                var live = _liveStats.GetTargetStats(cloud.RttTargetId);
+                if (live != null)
+                {
+                    rtt = live.RttAvgMs;
+                    loss = live.LossPercent;
+                    success = live.RttAvgMs.HasValue;
+                }
+            }
+
             update.CloudStats[cloud.Id] = new CloudLiveStats
             {
-                RttAvgMs = cloud.RttAvgMs,
-                LossPercent = cloud.LossPercent,
-                Success = cloud.RttAvgMs.HasValue,
+                RttAvgMs = rtt,
+                LossPercent = loss,
+                Success = success,
             };
         }
 
@@ -436,6 +466,35 @@ public class LanFlowMapService
                 _logger.LogDebug(ex, "Historic rate fetch failed for device {Mac}", mac);
             }
         }
+
+        // Batch pre-fetch all client throughput from InfluxDB (one query per
+        // measurement instead of N queries per client). Keyed by client MAC.
+        var wifiClientRates = new Dictionary<string, MonitoringInfluxClient.ClientThroughputPoint>(StringComparer.OrdinalIgnoreCase);
+        var wiredClientRates = new Dictionary<string, MonitoringInfluxClient.ClientThroughputPoint>(StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            var allWifi = await _influx.QueryAllClientThroughputAsync("wifi_client", from, to, ct);
+            foreach (var p in allWifi)
+            {
+                if (string.IsNullOrEmpty(p.ClientMac)) continue;
+                if (!wifiClientRates.TryGetValue(p.ClientMac, out var existing)
+                    || Math.Abs((p.Time - at).TotalMilliseconds) < Math.Abs((existing.Time - at).TotalMilliseconds))
+                    wifiClientRates[p.ClientMac] = p;
+            }
+        }
+        catch (Exception ex) { _logger.LogDebug(ex, "Historic WiFi client batch query failed"); }
+        try
+        {
+            var allWired = await _influx.QueryAllClientThroughputAsync("wired_client", from, to, ct);
+            foreach (var p in allWired)
+            {
+                if (string.IsNullOrEmpty(p.ClientMac)) continue;
+                if (!wiredClientRates.TryGetValue(p.ClientMac, out var existing)
+                    || Math.Abs((p.Time - at).TotalMilliseconds) < Math.Abs((existing.Time - at).TotalMilliseconds))
+                    wiredClientRates[p.ClientMac] = p;
+            }
+        }
+        catch (Exception ex) { _logger.LogDebug(ex, "Historic wired client batch query failed"); }
 
         // Resolve each link, mirroring the live endpoint's kind-aware dispatch.
         foreach (var link in snapshot.Links)
@@ -556,22 +615,52 @@ public class LanFlowMapService
                         }
                     }
                 }
-                else if (link.Kind == LanLinkKind.WiredClient && !string.IsNullOrEmpty(link.PortKey))
+                else if (link.Kind == LanLinkKind.WiredClient)
                 {
-                    var (deviceMac, ifName) = ParsePortKey(link.PortKey);
-                    if (ratesByDevice.TryGetValue(deviceMac, out var pts))
+                    // Primary: SNMP port rate via PortKey
+                    LinkLiveRates? rates = null;
+                    if (!string.IsNullOrEmpty(link.PortKey))
                     {
-                        var closest = pts
-                            .Where(p => string.Equals(p.IfName, ifName, StringComparison.OrdinalIgnoreCase))
-                            .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
-                            .FirstOrDefault();
-                        if (closest != null)
-                            update.LinkRates[link.Id] = MapPortToLinkRates(link, closest.RateInBps ?? 0, closest.RateOutBps ?? 0, closest.Time);
+                        var (deviceMac, ifName) = ParsePortKey(link.PortKey);
+                        if (ratesByDevice.TryGetValue(deviceMac, out var pts))
+                        {
+                            var closest = pts
+                                .Where(p => string.Equals(p.IfName, ifName, StringComparison.OrdinalIgnoreCase))
+                                .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                                .FirstOrDefault();
+                            if (closest != null)
+                                rates = MapPortToLinkRates(link, closest.RateInBps ?? 0, closest.RateOutBps ?? 0, closest.Time);
+                        }
+                    }
+                    // Fallback: wired_client from batch pre-fetch
+                    if (rates == null)
+                    {
+                        var clientMac = ExtractWiredClientMacFromLinkId(link.Id);
+                        if (!string.IsNullOrEmpty(clientMac) && wiredClientRates.TryGetValue(clientMac, out var wp))
+                        {
+                            rates = new LinkLiveRates
+                            {
+                                DownstreamBps = wp.TxThroughputBps ?? 0,
+                                UpstreamBps = wp.RxThroughputBps ?? 0,
+                                AsOf = wp.Time,
+                            };
+                        }
+                    }
+                    if (rates != null) update.LinkRates[link.Id] = rates;
+                }
+                else if (link.Kind == LanLinkKind.WifiClient)
+                {
+                    var clientMac = ExtractWifiClientMacFromLinkId(link.Id);
+                    if (!string.IsNullOrEmpty(clientMac) && wifiClientRates.TryGetValue(clientMac, out var wp))
+                    {
+                        update.LinkRates[link.Id] = new LinkLiveRates
+                        {
+                            DownstreamBps = wp.TxThroughputBps ?? 0,
+                            UpstreamBps = wp.RxThroughputBps ?? 0,
+                            AsOf = wp.Time,
+                        };
                     }
                 }
-                // WifiClient links: wifi_client throughput is stored with client_mac as
-                // a field (not a tag), making per-client InfluxDB lookups expensive.
-                // Skipped for now; wifi leaves show snapshot rates during playback.
             }
             catch (Exception ex)
             {
@@ -937,7 +1026,7 @@ public class LanFlowMapService
             var mac = NormalizeMac(d.Mac);
             anchors.TryGetValue(mac, out var anchor);
             var kind = MapDeviceKind(d);
-            snapshot.Nodes.Add(new LanNode
+            var node = new LanNode
             {
                 Id = "dev-" + mac,
                 Kind = kind,
@@ -946,7 +1035,14 @@ public class LanFlowMapService
                 Model = d.FriendlyModelName,
                 Placement = anchor,
                 Online = d.State == 1,
-            });
+            };
+            if (string.Equals(d.UplinkType, "wireless", StringComparison.OrdinalIgnoreCase))
+            {
+                node.PhyTxKbps = d.UplinkTxRateKbps > 0 ? d.UplinkTxRateKbps : null;
+                node.PhyRxKbps = d.UplinkRxRateKbps > 0 ? d.UplinkRxRateKbps : null;
+                node.Band = NormalizeBand(d.UplinkRadioBand);
+            }
+            snapshot.Nodes.Add(node);
         }
 
         // Switches and gateway inherit interpolated placement from the centroid of any
@@ -1225,7 +1321,17 @@ public class LanFlowMapService
             {
                 accessCloud.RttAvgMs = lastLive.Live.RttAvgMs;
                 accessCloud.LossPercent = lastLive.Live.LossPercent;
+                accessCloud.RttTargetId = lastLive.TargetId;
             }
+            // ISP expected speeds from UniFi WAN provider capabilities (cached in topology)
+            var wanNet = topology.Networks.FirstOrDefault(n =>
+                n.IsWan && n.WanNetworkgroup != null
+                && n.WanNetworkgroup.Equals(wan.WanInterface, StringComparison.OrdinalIgnoreCase));
+            if (wanNet?.WanDownloadMbps > 0)
+                accessCloud.IspDownloadMbps = wanNet.WanDownloadMbps;
+            if (wanNet?.WanUploadMbps > 0)
+                accessCloud.IspUploadMbps = wanNet.WanUploadMbps;
+
             snapshot.Clouds.Add(accessCloud);
 
             // WAN link: gateway -> access cloud directly. Capacity from WanSummary,
@@ -1665,6 +1771,31 @@ public class LanFlowMapService
         _ => null,
     };
 
+    private async Task<LinkLiveRates?> QueryClientThroughputAsync(
+        string measurement, string clientMac, DateTime at, DateTime from, DateTime to, CancellationToken ct)
+    {
+        try
+        {
+            var result = await _influx.QueryClientThroughputAsync(measurement, clientMac, from, to, ct);
+            var closest = result
+                .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                .FirstOrDefault();
+            if (closest == null) return null;
+            // Tx = switch/AP→client = downstream, Rx = client→switch/AP = upstream
+            return new LinkLiveRates
+            {
+                DownstreamBps = closest.TxThroughputBps ?? 0,
+                UpstreamBps = closest.RxThroughputBps ?? 0,
+                AsOf = closest.Time,
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Historic client throughput query failed for {Mac}", clientMac);
+            return null;
+        }
+    }
+
     private static string? ExtractWifiClientMacFromLinkId(string linkId)
     {
         const string prefix = "cli-link-";
@@ -1672,6 +1803,9 @@ public class LanFlowMapService
             ? linkId.Substring(prefix.Length)
             : null;
     }
+
+    private static string? ExtractWiredClientMacFromLinkId(string linkId)
+        => ExtractWifiClientMacFromLinkId(linkId);
 
     private static string? ExtractDeviceMacFromUplinkId(string linkId)
     {

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -232,13 +232,14 @@ public class MonitoringCollectionAgent : BackgroundService
             try
             {
                 var mac = NormalizeMac(device.Mac);
-                if (IsSnmpExcluded(mac))
-                {
-                    // Device was previously determined to not support SNMP. Skip silently;
-                    // rate data for this device will come from its parent switch port
-                    // (for APs) or be absent.
+
+                // UniFi requires snmp_location or snmp_contact to be set for
+                // SNMP to be enabled on a device. Both empty/null = SNMP off.
+                if (string.IsNullOrEmpty(device.SnmpLocation) && string.IsNullOrEmpty(device.SnmpContact))
                     return;
-                }
+
+                if (IsSnmpExcluded(mac))
+                    return;
                 try
                 {
                     var pollIp = ResolveSnmpAddress(device, gatewayLanIp);
@@ -832,6 +833,7 @@ public class MonitoringCollectionAgent : BackgroundService
     /// clients with stale -r fields.
     /// </summary>
     private readonly ConcurrentDictionary<string, ClientByteSnapshot> _wifiByteCache = new();
+    private readonly ConcurrentDictionary<string, ClientByteSnapshot> _wiredByteCache = new();
     private readonly record struct ClientByteSnapshot(DateTime Timestamp, long TxBytes, long RxBytes);
 
     private async Task WifiClientTierCollectAsync(MonitoringSettings settings, CancellationToken ct)
@@ -852,6 +854,10 @@ public class MonitoringCollectionAgent : BackgroundService
         }
 
         var now = DateTime.UtcNow;
+        var wifiCount = clients.Count(c => !c.IsWired);
+        var wiredCount = clients.Count(c => c.IsWired);
+        _logger.LogDebug("WiFi tier: {Total} clients ({Wifi} wifi, {Wired} wired)", clients.Length, wifiCount, wiredCount);
+        long tickOffset = 0; // nanosecond offset per client to avoid InfluxDB dedup
         foreach (var c in clients)
         {
             if (c.IsWired) continue;
@@ -868,25 +874,29 @@ public class MonitoringCollectionAgent : BackgroundService
             double? rxThroughputBps = null;
             if (c.TxBytesRate > 0 || c.RxBytesRate > 0)
             {
-                // tx_bytes-r / rx_bytes-r are bytes per second
                 txThroughputBps = c.TxBytesRate * 8.0;
                 rxThroughputBps = c.RxBytesRate * 8.0;
+                _wifiByteCache[clientMac] = new ClientByteSnapshot(now, c.TxBytes, c.RxBytes);
             }
             else if (_wifiByteCache.TryGetValue(clientMac, out var prev))
             {
-                var elapsed = (now - prev.Timestamp).TotalSeconds;
-                if (elapsed > 0.5)
+                long deltaTx = c.TxBytes - prev.TxBytes;
+                long deltaRx = c.RxBytes - prev.RxBytes;
+                if (deltaTx > 0 || deltaRx > 0)
                 {
-                    long deltaTx = c.TxBytes - prev.TxBytes;
-                    long deltaRx = c.RxBytes - prev.RxBytes;
-                    if (deltaTx >= 0 && deltaRx >= 0)
+                    var elapsed = (now - prev.Timestamp).TotalSeconds;
+                    if (elapsed > 0.5)
                     {
                         txThroughputBps = deltaTx * 8.0 / elapsed;
                         rxThroughputBps = deltaRx * 8.0 / elapsed;
                     }
+                    _wifiByteCache[clientMac] = new ClientByteSnapshot(now, c.TxBytes, c.RxBytes);
                 }
             }
-            _wifiByteCache[clientMac] = new ClientByteSnapshot(now, c.TxBytes, c.RxBytes);
+            else
+            {
+                _wifiByteCache[clientMac] = new ClientByteSnapshot(now, c.TxBytes, c.RxBytes);
+            }
 
             var snapshot = new WifiClientLiveSnapshot
             {
@@ -909,38 +919,102 @@ public class MonitoringCollectionAgent : BackgroundService
             };
             _liveStats.RecordWifiClient(snapshot);
 
-            // InfluxDB write. Per Gate 1: AP MAC + band are tags, client MAC is a
-            // field to bound cardinality (per-client MAC as a tag would be the classic
-            // InfluxDB cardinality bomb on networks with hundreds of clients).
-            _ = _influx.WriteWifiClientAsync(
-                apMac: apMac,
-                band: band,
-                clientMac: clientMac,
-                signalDbm: c.Signal,
-                noiseDbm: c.Noise,
-                txRateKbps: c.TxRate > 0 ? c.TxRate : null,
-                rxRateKbps: c.RxRate > 0 ? c.RxRate : null,
-                channel: c.Channel,
-                channelWidth: c.ChannelWidth,
-                satisfaction: c.Satisfaction,
-                rssi: c.Rssi,
-                txBytes: c.TxBytes,
-                rxBytes: c.RxBytes,
-                txThroughputBps: txThroughputBps,
-                rxThroughputBps: rxThroughputBps,
-                isMlo: c.IsMlo,
-                timestamp: now);
+            if ((txThroughputBps ?? 0) > 0 || (rxThroughputBps ?? 0) > 0)
+            {
+                _ = _influx.WriteWifiClientAsync(
+                    apMac: apMac,
+                    band: band,
+                    clientMac: clientMac,
+                    signalDbm: c.Signal,
+                    noiseDbm: c.Noise,
+                    txRateKbps: c.TxRate > 0 ? c.TxRate : null,
+                    rxRateKbps: c.RxRate > 0 ? c.RxRate : null,
+                    channel: c.Channel,
+                    channelWidth: c.ChannelWidth,
+                    satisfaction: c.Satisfaction,
+                    rssi: c.Rssi,
+                    txBytes: c.TxBytes,
+                    rxBytes: c.RxBytes,
+                    txThroughputBps: txThroughputBps,
+                    rxThroughputBps: rxThroughputBps,
+                    isMlo: c.IsMlo,
+                    timestamp: now.AddTicks(tickOffset++));
+            }
+        }
+
+        // Wired clients: collect throughput as fallback for non-SNMP switches.
+        // Uses the same tx_bytes/rx_bytes delta approach as WiFi clients.
+        foreach (var c in clients)
+        {
+            if (!c.IsWired) continue;
+            if (string.IsNullOrEmpty(c.Mac)) continue;
+            var clientMac = NormalizeMac(c.Mac);
+
+            double? txBps = null, rxBps = null;
+            // Wired clients use wired-tx_bytes-r / wired-rx_bytes-r (not tx_bytes-r)
+            if (c.WiredTxBytesRate > 0 || c.WiredRxBytesRate > 0)
+            {
+                txBps = c.WiredTxBytesRate * 8.0;
+                rxBps = c.WiredRxBytesRate * 8.0;
+                _wiredByteCache[clientMac] = new ClientByteSnapshot(now, c.WiredTxBytes, c.WiredRxBytes);
+            }
+            else if (_wiredByteCache.TryGetValue(clientMac, out var prev))
+            {
+                long deltaTx = c.WiredTxBytes - prev.TxBytes;
+                long deltaRx = c.WiredRxBytes - prev.RxBytes;
+                if (deltaTx > 0 || deltaRx > 0)
+                {
+                    // Only compute rate when counters actually changed. Elapsed is
+                    // time since last CHANGE, not last poll - avoids 2x rate when
+                    // our poll misaligns with UniFi's counter update cadence.
+                    var elapsed = (now - prev.Timestamp).TotalSeconds;
+                    if (elapsed > 0.5)
+                    {
+                        txBps = deltaTx * 8.0 / elapsed;
+                        rxBps = deltaRx * 8.0 / elapsed;
+                    }
+                    _wiredByteCache[clientMac] = new ClientByteSnapshot(now, c.WiredTxBytes, c.WiredRxBytes);
+                }
+                // When counters unchanged, DON'T update cache timestamp - preserves
+                // the real elapsed time for the next actual change.
+            }
+            else
+            {
+                // First poll: seed cache, no rate yet
+                _wiredByteCache[clientMac] = new ClientByteSnapshot(now, c.WiredTxBytes, c.WiredRxBytes);
+            }
+
+            _liveStats.RecordWiredClient(new WiredClientLiveSnapshot
+            {
+                ClientMac = clientMac,
+                TxThroughputBps = txBps,
+                RxThroughputBps = rxBps,
+                LastUpdate = now,
+            });
+
+            // Write to InfluxDB for historic playback (skip zero throughput)
+            var swMac = NormalizeMac(c.SwMac ?? string.Empty);
+            if (!string.IsNullOrEmpty(swMac) && ((txBps ?? 0) > 0 || (rxBps ?? 0) > 0))
+            {
+                _ = _influx.WriteWiredClientAsync(
+                    switchMac: swMac,
+                    clientMac: clientMac,
+                    txThroughputBps: txBps,
+                    rxThroughputBps: rxBps,
+                    timestamp: now.AddTicks(tickOffset++));
+            }
         }
 
         // Drop stale byte-cache entries for clients we haven't seen this cycle. Otherwise
         // a roamed/disconnected client's stale counter sits forever and gives a bogus
         // delta on reconnect.
-        var seenSet = new HashSet<string>(clients.Where(c => !c.IsWired).Select(c => NormalizeMac(c.Mac)));
+        var seenWifi = new HashSet<string>(clients.Where(c => !c.IsWired).Select(c => NormalizeMac(c.Mac)));
         foreach (var key in _wifiByteCache.Keys)
-        {
-            if (!seenSet.Contains(key))
-                _wifiByteCache.TryRemove(key, out _);
-        }
+            if (!seenWifi.Contains(key)) _wifiByteCache.TryRemove(key, out _);
+
+        var seenWired = new HashSet<string>(clients.Where(c => c.IsWired).Select(c => NormalizeMac(c.Mac)));
+        foreach (var key in _wiredByteCache.Keys)
+            if (!seenWired.Contains(key)) _wiredByteCache.TryRemove(key, out _);
     }
 
     /// <summary>
@@ -1374,7 +1448,7 @@ public class MonitoringCollectionAgent : BackgroundService
     // the default fast tier interval (5s) - the data is always at most one fast tick
     // stale, and slower tiers piggyback on whatever the fast tier just fetched.
     // Concurrent callers serialize on _deviceFetchLock so a miss doesn't fan out.
-    private static readonly TimeSpan DeviceCacheTtl = TimeSpan.FromSeconds(4);
+    private static readonly TimeSpan DeviceCacheTtl = TimeSpan.FromSeconds(30);
     private List<UniFiDeviceResponse> _cachedDevices = new();
     private DateTime _cachedDevicesAt = DateTime.MinValue;
     private readonly SemaphoreSlim _deviceFetchLock = new(1, 1);
@@ -1697,14 +1771,10 @@ public class MonitoringCollectionAgent : BackgroundService
         var count = _snmpFailures.AddOrUpdate(normalizedMac, 1, (_, prev) => prev + 1);
         if (count < SnmpFailureThreshold) return;
 
-        // Only exclude when the device is actually reachable. If our fabric ping has
-        // returned at least once in the last 2 minutes, we know it's online; otherwise
-        // it might just be down, and we'll re-try SNMP when it comes back.
-        var liveStats = _liveStats.GetForDevice(normalizedMac);
-        if (liveStats == null || !liveStats.LastLatencyUpdate.HasValue) return;
-        if (DateTime.UtcNow - liveStats.LastLatencyUpdate.Value > TimeSpan.FromMinutes(2)) return;
-        if (!(liveStats.LatestRttMs.HasValue && liveStats.LatestRttMs.Value >= 0)) return;
-
+        // Exclude after threshold regardless of ping reachability. The 1-hour TTL
+        // handles retry when the device comes back or gets SNMP enabled. Not all
+        // devices are ping targets, so requiring ICMP would leave many non-SNMP
+        // devices burning the timeout forever.
         if (_snmpExcluded.TryAdd(normalizedMac, DateTime.UtcNow))
         {
             _logger.LogInformation(

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -682,6 +682,114 @@ public class MonitoringCollectionAgent : BackgroundService
             finally { _snmpGate.Release(); }
         });
         await Task.WhenAll(deviceTasks);
+
+        // UniFi API health pass: supplements or replaces SNMP health data.
+        // Non-SNMP devices: full fallback (CPU, mem, temp, uptime).
+        // SNMP devices: fill in gaps only (e.g., temperature on switches where
+        // SNMP doesn't report temp but UniFi API does).
+        var now = DateTime.UtcNow;
+        foreach (var device in devices)
+        {
+            var mac = NormalizeMac(device.Mac);
+            var snmpOn = !string.IsNullOrEmpty(device.SnmpContact) || !string.IsNullOrEmpty(device.SnmpLocation);
+            var snmpExcl = IsSnmpExcluded(mac);
+            var snmpActive = snmpOn && !snmpExcl;
+
+            try
+            {
+                var ss = device.SystemStatsSimple;
+                if (ss == null && device.Temperatures == null) continue;
+
+                double? cpu = ss != null ? ParseJsonDouble(ss.Cpu) : null;
+                double? mem = ss != null ? ParseJsonDouble(ss.Mem) : null;
+                long? uptime = ss != null ? (long?)ParseJsonDouble(ss.Uptime) : null;
+                double? temp = ParseDeviceTemperature(device);
+
+                // SNMP devices: only supplement temp for switches (SNMP doesn't
+                // report switch temps). Gateway and APs get temp from SNMP already;
+                // writing API temp too creates dual-source Z-shape artifacts.
+                if (snmpActive)
+                {
+                    if (device.DeviceType != NetworkOptimizer.Core.Enums.DeviceType.Switch) continue;
+                    cpu = null;
+                    mem = null;
+                    uptime = null;
+                    if (temp == null) continue;
+                }
+
+                if (cpu == null && mem == null && temp == null) continue;
+
+                await _influx.WriteDeviceHealthAsync(
+                    deviceMac: device.Mac,
+                    deviceType: DescribeDeviceType(device.DeviceType),
+                    cpuPercent: cpu,
+                    memoryTotalKb: null,
+                    memoryUsedKb: null,
+                    memoryUsedPercent: mem,
+                    temperatureC: temp,
+                    uptimeSeconds: uptime,
+                    timestamp: now);
+
+                _liveStats.RecordHealth(device.Mac, cpu, mem, temp, uptime, now);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "UniFi API health fallback failed for {Device}", device.Mac);
+            }
+        }
+    }
+
+    private static double? ParseJsonDouble(System.Text.Json.JsonElement? el)
+    {
+        if (el == null || el.Value.ValueKind == System.Text.Json.JsonValueKind.Undefined) return null;
+        if (el.Value.ValueKind == System.Text.Json.JsonValueKind.Number && el.Value.TryGetDouble(out var num)) return num;
+        if (el.Value.ValueKind == System.Text.Json.JsonValueKind.String)
+        {
+            var s = el.Value.GetString()?.Trim();
+            if (double.TryParse(s, System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var parsed))
+                return parsed;
+        }
+        return null;
+    }
+
+    private static double? ParseDeviceTemperature(UniFiDeviceResponse device)
+    {
+        // general_temperature: simple numeric field on switches (e.g., 72)
+        if (device.GeneralTemperature.HasValue && device.GeneralTemperature.Value > 0)
+            return device.GeneralTemperature.Value;
+
+        // temperatures: structured array on gateways, bare integer on some devices
+        if (device.Temperatures == null || device.Temperatures.Value.ValueKind == System.Text.Json.JsonValueKind.Undefined)
+            return null;
+
+        var el = device.Temperatures.Value;
+
+        // Gateway: array of { name, type, value } - pick the CPU sensor
+        if (el.ValueKind == System.Text.Json.JsonValueKind.Array)
+        {
+            foreach (var sensor in el.EnumerateArray())
+            {
+                var sType = sensor.TryGetProperty("type", out var t) ? t.GetString() : null;
+                if (string.Equals(sType, "cpu", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (sensor.TryGetProperty("value", out var v) && v.TryGetDouble(out var tempVal))
+                        return tempVal;
+                }
+            }
+            // No CPU sensor found, take the first one
+            foreach (var sensor in el.EnumerateArray())
+            {
+                if (sensor.TryGetProperty("value", out var v) && v.TryGetDouble(out var tempVal))
+                    return tempVal;
+            }
+        }
+
+        // Switch: bare integer
+        if (el.ValueKind == System.Text.Json.JsonValueKind.Number && el.TryGetDouble(out var bare))
+            return bare;
+
+        return null;
     }
 
     private async Task SlowTierCollectAsync(MonitoringSettings settings, CancellationToken ct)

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -394,6 +394,26 @@ public class MonitoringInfluxClient : IAsyncDisposable
         return Task.CompletedTask;
     }
 
+    public Task WriteWiredClientAsync(
+        string switchMac,
+        string clientMac,
+        double? txThroughputBps,
+        double? rxThroughputBps,
+        DateTime timestamp)
+    {
+        if (!IsConfigured) return Task.CompletedTask;
+        var point = PointData.Measurement("wired_client")
+            .Tag("device_mac", NormalizeMac(switchMac))
+            .Field("client_mac", NormalizeMac(clientMac))
+            .Timestamp(timestamp.ToUniversalTime(), WritePrecision.Ns);
+
+        if (txThroughputBps.HasValue) point = point.Field("tx_throughput_bps", txThroughputBps.Value);
+        if (rxThroughputBps.HasValue) point = point.Field("rx_throughput_bps", rxThroughputBps.Value);
+
+        Enqueue(point, longterm: false);
+        return Task.CompletedTask;
+    }
+
     public Task WriteSfpAsync(
         string deviceMac,
         string portName,
@@ -701,6 +721,71 @@ from(bucket: ""{_longtermBucket}"")
     /// AP MAC (tag), optionally by band (tag) and by client MAC (field). Returns
     /// rows ordered by time.
     /// </summary>
+    public record ClientThroughputPoint
+    {
+        public DateTime Time { get; init; }
+        public string? ClientMac { get; init; }
+        public double? TxThroughputBps { get; init; }
+        public double? RxThroughputBps { get; init; }
+    }
+
+    public async Task<IReadOnlyList<ClientThroughputPoint>> QueryAllClientThroughputAsync(
+        string measurement,
+        DateTime from,
+        DateTime to,
+        CancellationToken ct = default)
+    {
+        if (!IsConfigured) return Array.Empty<ClientThroughputPoint>();
+        var flux = $@"from(bucket: ""{_bucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""{measurement}"")
+  |> filter(fn: (r) => r._field == ""tx_throughput_bps"" or r._field == ""rx_throughput_bps"" or r._field == ""client_mac"")
+  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
+  |> filter(fn: (r) => (exists r.tx_throughput_bps and r.tx_throughput_bps > 0.0) or (exists r.rx_throughput_bps and r.rx_throughput_bps > 0.0))";
+
+        var results = new List<ClientThroughputPoint>();
+        await foreach (var record in QueryFluxAsync(flux, ct))
+        {
+            results.Add(new ClientThroughputPoint
+            {
+                Time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow),
+                ClientMac = record.GetValueByKey("client_mac") as string,
+                TxThroughputBps = AsDoubleOrNull(record.GetValueByKey("tx_throughput_bps")),
+                RxThroughputBps = AsDoubleOrNull(record.GetValueByKey("rx_throughput_bps")),
+            });
+        }
+        return results;
+    }
+
+    public async Task<IReadOnlyList<ClientThroughputPoint>> QueryClientThroughputAsync(
+        string measurement,
+        string clientMac,
+        DateTime from,
+        DateTime to,
+        CancellationToken ct = default)
+    {
+        if (!IsConfigured) return Array.Empty<ClientThroughputPoint>();
+        var mac = NormalizeMac(clientMac);
+        var flux = $@"from(bucket: ""{_bucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""{measurement}"")
+  |> filter(fn: (r) => r._field == ""tx_throughput_bps"" or r._field == ""rx_throughput_bps"" or r._field == ""client_mac"")
+  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
+  |> filter(fn: (r) => r.client_mac == ""{mac}"")";
+
+        var results = new List<ClientThroughputPoint>();
+        await foreach (var record in QueryFluxAsync(flux, ct))
+        {
+            results.Add(new ClientThroughputPoint
+            {
+                Time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow),
+                TxThroughputBps = AsDoubleOrNull(record.GetValueByKey("tx_throughput_bps")),
+                RxThroughputBps = AsDoubleOrNull(record.GetValueByKey("rx_throughput_bps")),
+            });
+        }
+        return results;
+    }
+
     public async Task<IReadOnlyList<WifiClientHistoryPoint>> QueryWifiClientHistoryAsync(
         string apMac,
         string? band,

--- a/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
@@ -116,6 +116,7 @@ public class MonitoringLiveStats
     private readonly ConcurrentDictionary<(string DeviceMac, string PortName), SfpLiveStats> _sfpStats = new();
     private readonly ConcurrentDictionary<string, TargetLiveStats> _targetStats = new();
     private readonly ConcurrentDictionary<string, WifiClientLiveSnapshot> _wifiClients = new();
+    private readonly ConcurrentDictionary<string, WiredClientLiveSnapshot> _wiredClients = new();
     // Per-port rate cache. Keyed by (deviceMac, ifName) so the SNMP fast tier
     // (clean 5s cadence) is the writer - the UniFi PortTable byte counters lag
     // ~30s server-side, so polling them every 5s yields a burst-then-zeros
@@ -285,6 +286,29 @@ public class MonitoringLiveStats
     /// <summary>Every currently-tracked WiFi client (across all APs).</summary>
     public IReadOnlyList<WifiClientLiveSnapshot> AllWifiClients() => _wifiClients.Values.ToList();
 
+    // ---- Wired clients (fallback for non-SNMP switches) ----
+
+    public void RecordWiredClient(WiredClientLiveSnapshot snapshot)
+    {
+        if (string.IsNullOrEmpty(snapshot.ClientMac)) return;
+        var key = Normalize(snapshot.ClientMac);
+        var fresh = snapshot with { ClientMac = key, ConsecutiveZeroPolls = 0 };
+        _wiredClients.AddOrUpdate(key, fresh, (_, prior) =>
+        {
+            var newTx = fresh.TxThroughputBps ?? 0;
+            var newRx = fresh.RxThroughputBps ?? 0;
+            if (newTx == 0 && newRx == 0 && ((prior.TxThroughputBps ?? 0) > 0 || (prior.RxThroughputBps ?? 0) > 0) && prior.ConsecutiveZeroPolls < 1)
+                return prior with { TxThroughputBps = prior.TxThroughputBps, RxThroughputBps = prior.RxThroughputBps, LastUpdate = fresh.LastUpdate, ConsecutiveZeroPolls = prior.ConsecutiveZeroPolls + 1 };
+            return fresh;
+        });
+    }
+
+    public WiredClientLiveSnapshot? GetWiredClient(string clientMac)
+    {
+        if (string.IsNullOrEmpty(clientMac)) return null;
+        return _wiredClients.TryGetValue(Normalize(clientMac), out var v) ? v : null;
+    }
+
     /// <summary>Drop stale entries — called periodically by the agent.</summary>
     public void Prune(TimeSpan maxAge)
     {
@@ -422,4 +446,17 @@ public record DeviceLiveStats
         return (LastRateUpdate.HasValue && (now - LastRateUpdate.Value) <= maxAge)
             || (LastLatencyUpdate.HasValue && (now - LastLatencyUpdate.Value) <= maxAge);
     }
+}
+
+/// <summary>
+/// Throughput snapshot for a wired client, derived from UniFi client stats.
+/// Used as a fallback when the parent switch lacks SNMP.
+/// </summary>
+public record WiredClientLiveSnapshot
+{
+    public required string ClientMac { get; init; }
+    public double? TxThroughputBps { get; init; }
+    public double? RxThroughputBps { get; init; }
+    public DateTime LastUpdate { get; init; }
+    public int ConsecutiveZeroPolls { get; init; }
 }

--- a/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
@@ -18,7 +18,7 @@ public class PerfTweaksDeploymentService
     private const string OnBootDir = "/data/on_boot.d";
     private const string PerfTweaksDir = "/data/perf-tweaks";
     private const string SfpModuleDir = "/data/sfp-sgmiiplus";
-    private static readonly Version MaxSupportedFirmware = new(5, 1, 12);
+    private static readonly Version MaxSupportedFirmware = new(5, 1, 13);
 
     private static readonly Dictionary<string, string> BootScriptFiles = new()
     {

--- a/src/NetworkOptimizer.Web/Services/TopologySnapshotService.cs
+++ b/src/NetworkOptimizer.Web/Services/TopologySnapshotService.cs
@@ -77,7 +77,7 @@ public class TopologySnapshotService : ITopologySnapshotService
                 _clientProvider.Client,
                 _loggerFactory.CreateLogger<UniFiDiscovery>());
 
-            var topology = await discovery.DiscoverTopologyAsync();
+            var topology = await discovery.DiscoverTopologyAsync(useCache: false);
             if (topology == null)
             {
                 _logger.LogWarning("Cannot capture snapshot - topology discovery failed");

--- a/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
@@ -4,6 +4,7 @@ using NetworkOptimizer.Storage.Interfaces;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
 using NetworkOptimizer.UniFi;
+using NetworkOptimizer.UniFi.Models;
 
 namespace NetworkOptimizer.Web.Services;
 
@@ -828,12 +829,25 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
             return _cachedNetworks;
         }
 
-        var discoveryLogger = _loggerFactory.CreateLogger<UniFiDiscovery>();
-        var discovery = new UniFiDiscovery(_client, discoveryLogger);
-        var topology = await discovery.DiscoverTopologyAsync(cancellationToken);
+        var networks = await _client.GetNetworkConfigsAsync(cancellationToken);
 
-        // Cache the result
-        _cachedNetworks = topology.Networks;
+        _cachedNetworks = networks?.Select(n => new NetworkInfo
+        {
+            Id = n.Id,
+            Name = n.Name,
+            Purpose = n.Purpose,
+            Enabled = n.Enabled,
+            VlanId = n.Vlan,
+            IpSubnet = n.IpSubnet,
+            IsDhcpEnabled = n.DhcpdEnabled,
+            DhcpRange = n.DhcpdEnabled ? $"{n.DhcpdStart} - {n.DhcpdStop}" : null,
+            Gateway = n.DhcpdGateway,
+            IsNat = n.IsNat,
+            WanUploadMbps = n.WanProviderCapabilities?.UploadMbps,
+            WanDownloadMbps = n.WanProviderCapabilities?.DownloadMbps,
+            WanNetworkgroup = n.WanNetworkgroup,
+            WanSmartqEnabled = n.WanSmartqEnabled
+        }).ToList() ?? new List<NetworkInfo>();
         _networkCacheTime = DateTime.UtcNow;
 
         return _cachedNetworks;

--- a/src/NetworkOptimizer.Web/Services/WanDataUsageService.cs
+++ b/src/NetworkOptimizer.Web/Services/WanDataUsageService.cs
@@ -367,7 +367,7 @@ public class WanDataUsageService : BackgroundService
             var client = _connectionService.Client;
             if (client == null) return (null, 0);
 
-            var devices = await client.GetDevicesAsync(ct);
+            var devices = await client.GetDevicesAsync(ct, useCache: false);
             var gateway = devices?.FirstOrDefault(d => d.DeviceType == DeviceType.Gateway);
             if (gateway == null) return (null, 0);
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14062,7 +14062,7 @@ a.affected-client:hover {
     margin-bottom: 0.45rem;
 }
 .lan-flow-map-controls {
-    top: 2.75rem;
+    top: 3rem;
     right: 0.75rem;
     min-width: 178px;
     display: flex;
@@ -14498,6 +14498,22 @@ a.affected-client:hover {
     display: none;
 }
 .lan-flow-map-wan-pill.is-visible {
+    display: block;
+}
+.lan-flow-map-cloud-rtt {
+    position: absolute;
+    transform: translate(-50%, 0%);
+    background: rgba(148, 163, 184, 0.1);
+    color: var(--text-secondary);
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.7rem;
+    font-variant-numeric: tabular-nums;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    white-space: nowrap;
+    display: none;
+}
+.lan-flow-map-cloud-rtt.is-visible {
     display: block;
 }
 .lan-flow-map-tooltip {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-data.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-data.js
@@ -1,0 +1,62 @@
+// Shared data store for the LAN flow map topology.
+// The 3D map publishes data here after each fetch; the 2D map subscribes
+// so only one set of API calls runs. Pure pub/sub - no fetching.
+
+let _snapshot = null;
+let _liveRates = {};
+let _cloudStats = {};
+let _nodeBadges = {};
+let _paused = false;
+let _mode = 'live';
+let _scrubberValue = 10000;
+let _scrubberRight = 'Live';
+let _playbackSpeed = 1;
+let _listeners = new Set();
+
+export function getSnapshot()  { return _snapshot; }
+export function getLiveRates()  { return _liveRates; }
+export function getCloudStats() { return _cloudStats; }
+export function getNodeBadges() { return _nodeBadges; }
+export function isPaused()       { return _paused; }
+export function getMode()        { return _mode; }
+export function getScrubber()    { return { value: _scrubberValue, right: _scrubberRight, speed: _playbackSpeed }; }
+
+export function subscribe(fn) {
+    _listeners.add(fn);
+    return () => _listeners.delete(fn);
+}
+
+function _notify(event) {
+    for (const fn of _listeners) {
+        try { fn(event); } catch { /* swallow */ }
+    }
+}
+
+export function publishSnapshot(snap) {
+    const firstLoad = !_snapshot;
+    _snapshot = snap;
+    // Only seed rates on first load. Subsequent refreshes must not clobber
+    // the fresh 1s-polled rates with stale snapshot-time values.
+    if (firstLoad) _liveRates = snap.liveRates || {};
+    _notify('snapshot');
+}
+
+export function publishLive(update) {
+    if (update.linkRates)   Object.assign(_liveRates, update.linkRates);
+    if (update.cloudStats)  _cloudStats = update.cloudStats;
+    if (update.nodeBadges)  _nodeBadges = update.nodeBadges;
+    _notify('live');
+}
+
+export function publishPlayState(paused, mode) {
+    _paused = paused;
+    _mode = mode;
+    _notify('playstate');
+}
+
+export function publishScrubber(value, rightLabel, speed) {
+    _scrubberValue = value;
+    _scrubberRight = rightLabel;
+    _playbackSpeed = speed;
+    _notify('scrubber');
+}

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1198,6 +1198,7 @@ class LanFlowMap2D {
                 const my=isWan?midY-28:midY+20;
                 let txt=null;
                 let txtColor=C.textMuted; // default muted; live rates override
+                let txtItalic=false;
 
                 if(isWan){
                     // Show live throughput when active, ISP expected when idle
@@ -1211,6 +1212,7 @@ class LanFlowMap2D {
                             e.lk.fromNodeId===c.d.id||e.lk.toNodeId===c.d.id);
                         if(cloud?.d.ispDownloadMbps&&cloud?.d.ispUploadMbps){
                             txt=`↓${formatSpeed(cloud.d.ispDownloadMbps)}  ↑${formatSpeed(cloud.d.ispUploadMbps)}`;
+                            txtColor='#6b7280'; txtItalic=true;
                         }else if(e.lk.capacityBps>0){
                             txt=formatSpeed(e.lk.capacityBps/1e6);
                         }
@@ -1228,15 +1230,18 @@ class LanFlowMap2D {
                     txt=formatSpeed(e.lk.capacityBps/1e6);
                 }
 
-                if(txt) this._pendingLinkLabels.push({mx,my,txt,txtColor});
+                if(txt) this._pendingLinkLabels.push({mx,my,txt,txtColor,txtItalic});
             }
         }
         ctx.globalAlpha=1;
     }
 
     _drawLinkSpeedLabels(ctx){
-        ctx.font=`${G.rateFont}px ${FONT}`;
-        for(const{mx,my,txt,txtColor}of(this._pendingLinkLabels||[])){
+        const normalFont=`${G.rateFont}px ${FONT}`;
+        const italicFont=`italic ${G.rateFont}px ${FONT}`;
+        ctx.font=normalFont;
+        for(const{mx,my,txt,txtColor,txtItalic}of(this._pendingLinkLabels||[])){
+            ctx.font=txtItalic?italicFont:normalFont;
             const tw=ctx.measureText(txt).width+12;
             ctx.fillStyle=C.labelBg;
             ctx.globalAlpha=1;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1,0 +1,1548 @@
+// 2D hierarchical LAN topology diagram - Canvas 2D renderer.
+// Subscribes to lan-flow-data.js (published by the 3D map) so there are
+// zero duplicate API calls. GPU-composited canvas for smooth particle animation.
+
+import * as flowData from './lan-flow-data.js';
+
+// ---- Color palette (matches 3D map) ----
+const C = {
+    bg:           '#202023',
+    gateway:      '#facc15',
+    switchNode:   '#9aa6b2',
+    ap:           '#3385d6',
+    wiredClient:  '#c9d2e0',
+    wifiClient:   '#e2e8f0',
+    cloud:        '#4d556b',
+    virtualHub:   '#6b7785',
+    downstream:   '#3385d6',
+    upstream:     '#24bc70',
+    pipeCool:     '#1f4068',
+    pipeWarm:     '#e79613',
+    pipeHot:      '#ee6368',
+    band24:       '#fbbf24',
+    band5:        '#3b82f6',
+    band6:        '#a855f7',
+    text:         '#f1f5f9',
+    textSec:      '#cbd5e1',
+    textMuted:    '#9ca3af',
+    labelBg:      'rgba(16,24,32,0.82)',
+    cardBg:       '#1a1d23',
+    globeStroke:  '#3b82f6',
+};
+
+const NK = { Gateway:0, Switch:1, AP:2, WiredClient:3, WifiClient:4, Cloud:5, VirtualHub:6 };
+const LK = { Uplink:0, WiredClient:1, WifiClient:2, Wan:3, Transit:4, MeshBackhaul:5 };
+
+// ---- Layout geometry ----
+const G = {
+    tierGap:     170,
+    cloudGap:    220,
+    infraGap:    90,
+    clientCellW: 145,
+    clientCellH: 50,
+    clientR:     7,
+    clientCols:  6,
+    maxClients:  80,
+    iconSize:    52,
+    boxW:        68,
+    boxH:        60,
+    cloudR:      30,
+    cornerR:     12,
+    pad:         80,
+    pipeBase:    2,
+    pipeMax:     6,
+    nameFont:    11,
+    rateFont:    10,
+    clientFont:  9,
+};
+
+const RATE_THRESH = 1_000_000;
+const EMIT_MAX = 12;
+const MAX_DOTS = 80;
+const FONT = 'system-ui, -apple-system, sans-serif';
+
+// ---- Helpers ----
+
+function hexRgb(h) { return [parseInt(h.slice(1,3),16), parseInt(h.slice(3,5),16), parseInt(h.slice(5,7),16)]; }
+function rgbHex(r,g,b) { return '#'+[r,g,b].map(c=>Math.round(Math.max(0,Math.min(255,c))).toString(16).padStart(2,'0')).join(''); }
+function lerp(a,b,t) { return a+(b-a)*t; }
+function lerpColor(a,b,t) { const [r1,g1,b1]=hexRgb(a),[r2,g2,b2]=hexRgb(b); return rgbHex(lerp(r1,r2,t),lerp(g1,g2,t),lerp(b1,b2,t)); }
+function bandClr(b) { return b==='2.4'?C.band24:b==='5'?C.band5:b==='6'?C.band6:null; }
+function nodeClr(k,b) {
+    if(k===NK.Gateway)return C.gateway; if(k===NK.Switch)return C.switchNode;
+    if(k===NK.AP)return C.ap; if(k===NK.WiredClient)return C.wiredClient;
+    if(k===NK.WifiClient)return bandClr(b)||C.wifiClient;
+    if(k===NK.Cloud)return C.cloud; if(k===NK.VirtualHub)return C.virtualHub;
+    return C.textMuted;
+}
+function isInfra(k) { return k<=NK.AP||k===NK.VirtualHub; }
+function isClient(k) { return k===NK.WiredClient||k===NK.WifiClient; }
+
+function pipeClr(u,band) {
+    const cool=bandClr(band)||C.pipeCool;
+    if(u<0.7)return cool;
+    if(u<0.9)return lerpColor(cool,C.pipeWarm,(u-0.7)/0.2);
+    return lerpColor(C.pipeWarm,C.pipeHot,Math.min((u-0.9)/0.1,1));
+}
+function pipeW(cap) {
+    if(!cap||cap<=0)return G.pipeBase;
+    const t=Math.log10(Math.max(cap/1e9,0.01))+2;
+    return G.pipeBase+Math.min(t,3.5)*0.9;
+}
+
+function formatBps(bps) {
+    if(!Number.isFinite(bps)||bps<=0)return '0 bps';
+    const u=['bps','Kbps','Mbps','Gbps','Tbps'];
+    let i=0,v=bps;
+    while(v>=1000&&i<u.length-1){v/=1000;i++;}
+    return `${v>=100?v.toFixed(0):v.toFixed(1)} ${u[i]}`;
+}
+function formatSpeed(mbps) {
+    if(!mbps)return '';
+    if(mbps>=1000){const g=mbps/1000;return `${g%1===0?g.toFixed(0):g.toFixed(1)} Gbps`;}
+    return `${mbps} Mbps`;
+}
+
+function withAlpha(hex, a) {
+    const [r,g,b] = hexRgb(hex);
+    return `rgba(${r},${g},${b},${a})`;
+}
+
+// ---- Orthogonal path helpers ----
+// All accept an optional midYOff to vertically stagger sibling links.
+
+function orthoLen(x1,y1,x2,y2,midYOff) {
+    if(Math.abs(x1-x2)<0.5)return Math.abs(y2-y1);
+    const my=(y1+y2)/2+(midYOff||0);
+    const top=my-y1, bot=y2-my;
+    const ax=Math.abs(x2-x1),cr=Math.min(G.cornerR,ax/2,Math.min(top,bot));
+    if(cr<1)return top+ax+bot;
+    return (top-cr)+(bot-cr)+Math.PI*cr+(ax-2*cr);
+}
+
+function orthoAt(x1,y1,x2,y2,t,midYOff) {
+    if(Math.abs(x2-x1)<0.5)return{x:x1,y:y1+(y2-y1)*t};
+    const midY=(y1+y2)/2+(midYOff||0);
+    const dx=x2-x1,s=dx>0?1:-1,ax=Math.abs(dx);
+    const top=midY-y1,bot=y2-midY;
+    const cr=Math.min(G.cornerR,ax/2,Math.min(top,bot));
+    if(cr<1){const tot=top+ax+bot;let d=t*tot;if(d<=top)return{x:x1,y:y1+d};d-=top;if(d<=ax)return{x:x1+s*d,y:midY};d-=ax;return{x:x2,y:midY+d};}
+    const s1=top-cr,s2=Math.PI/2*cr,s3=ax-2*cr,s4=s2,s5=bot-cr;
+    const tot=s1+s2+s3+s4+s5;let d=t*tot;
+    if(d<=s1)return{x:x1,y:y1+d};d-=s1;
+    if(d<=s2){
+        // Quadratic bezier matching strokeOrtho: P0=(x1,midY-cr) P1=(x1,midY) P2=(x1+s*cr,midY)
+        const bt=d/s2,u=1-bt;
+        return{x:u*u*x1+2*u*bt*x1+bt*bt*(x1+s*cr), y:u*u*(midY-cr)+2*u*bt*midY+bt*bt*midY};
+    }d-=s2;
+    if(d<=s3)return{x:x1+s*(cr+d),y:midY};d-=s3;
+    if(d<=s4){
+        // Quadratic bezier: P0=(x2-s*cr,midY) P1=(x2,midY) P2=(x2,midY+cr)
+        const bt=d/s4,u=1-bt;
+        return{x:u*u*(x2-s*cr)+2*u*bt*x2+bt*bt*x2, y:u*u*midY+2*u*bt*midY+bt*bt*(midY+cr)};
+    }d-=s4;
+    return{x:x2,y:midY+cr+d};
+}
+
+function strokeOrtho(ctx,x1,y1,x2,y2,midYOff) {
+    const r=G.cornerR;
+    ctx.beginPath();
+    if(Math.abs(x1-x2)<0.5){ctx.moveTo(x1,y1);ctx.lineTo(x2,y2);ctx.stroke();return;}
+    const midY=(y1+y2)/2+(midYOff||0);
+    const dx=x2-x1,s=dx>0?1:-1,ax=Math.abs(dx);
+    const top=midY-y1,bot=y2-midY;
+    const cr=Math.min(r,ax/2,Math.min(top,bot));
+    ctx.moveTo(x1,y1);
+    if(cr<1){ctx.lineTo(x1,midY);ctx.lineTo(x2,midY);ctx.lineTo(x2,y2);ctx.stroke();return;}
+    ctx.lineTo(x1,midY-cr);
+    ctx.quadraticCurveTo(x1,midY,x1+s*cr,midY);
+    ctx.lineTo(x2-s*cr,midY);
+    ctx.quadraticCurveTo(x2,midY,x2,midY+cr);
+    ctx.lineTo(x2,y2);
+    ctx.stroke();
+}
+
+// ---- Layout tree ----
+class TN {
+    constructor(d){this.d=d;this.infra=[];this.clients=[];this.x=0;this.y=0;this.w=0;}
+}
+
+// ---- Particle stream (no DOM, just state) ----
+class Stream {
+    constructor(edge,dir,color){
+        this.edge=edge; this.dir=dir; this.color=color;
+        this.density=0; this.velNorm=0; this.dotSize=0.4;
+        this.spawnAcc=0;
+        this.midYOff=edge._midYOff||0;
+        this.pathLen=orthoLen(edge._x1,edge._y1,edge._x2,edge._y2,this.midYOff);
+        this.slots=[];
+        for(let i=0;i<MAX_DOTS;i++)this.slots.push({t:-1,size:0});
+        this._seeded=false;
+    }
+    setRate(bps){
+        const intensity=Math.max(0,Math.min(1,Math.log10(Math.max(bps,1))/11));
+        this.density=intensity;
+        this.dotSize=0.4+(intensity*intensity)*1.2;
+        // Constant visual speed: match 3D map (2.5 + intensity*4 scene-units/sec)
+        // scaled to SVG pixels. Divide by path length for normalized t/sec.
+        const absPxSec=30+intensity*50;
+        this.velNorm=absPxSec/Math.max(this.pathLen,1);
+
+        // Pre-seed on first non-zero rate so the pipe is already populated
+        // instead of building up from empty over the first few seconds.
+        if(!this._seeded&&intensity>0){
+            this._seeded=true;
+            const emitPerSec=intensity*intensity*EMIT_MAX;
+            const traverseTime=1/Math.max(this.velNorm,0.001);
+            const steadyState=Math.min(Math.round(emitPerSec*traverseTime),MAX_DOTS);
+            for(let i=0;i<steadyState;i++){
+                this.slots[i].t=(i+0.5)/steadyState;
+                if(this.dir<0)this.slots[i].t=1-this.slots[i].t;
+                this.slots[i].size=this.dotSize;
+            }
+        }
+    }
+    advance(dt){
+        // Emission: density²*12 dots/sec, jittered ±20% (3D uses ±40% but
+        // shorter 2D links need tighter spacing to avoid visible gaps)
+        this.spawnAcc+=this.density*this.density*EMIT_MAX*dt;
+        while(this.spawnAcc>=1){
+            this.spawnAcc-=(0.8+Math.random()*0.4);
+            for(const sl of this.slots){if(sl.t<0){sl.t=this.dir>0?0:1;sl.size=this.dotSize;break;}}
+        }
+        for(const sl of this.slots){
+            if(sl.t<0)continue;
+            sl.t+=this.velNorm*dt*this.dir;
+            if(sl.t>1||sl.t<0){sl.t=-1;continue;}
+        }
+    }
+}
+
+// ---- Main class ----
+class LanFlowMap2D {
+    constructor(container){
+        this._el=container;
+        this._canvas=null;
+        this._ctx=null;
+        this._dpr=1;
+        this._cw=0; this._ch=0;
+
+        this._root=null;
+        this._treeMap=new Map();
+        this._clouds=[];
+        this._edges=[];
+        this._liveRates={};
+        this._streams=[];
+        this._images=new Map();
+
+        this._animId=0;
+        this._lastFrame=0;
+        this._unsub=null;
+        this._needsStaticRedraw=true;
+        this._staticCanvas=null;
+
+        // Pan/zoom: offset in world coords + scale
+        this._ox=0; this._oy=0; this._scale=1;
+        this._dragging=false; this._dragStart=null;
+        // World bounds
+        this._bx=0; this._by=0; this._bw=800; this._bh=600;
+
+        this._tooltip=null;
+        this._hoverNode=null;
+    }
+
+    async start(){
+        this._createCanvas();
+        const snap=flowData.getSnapshot();
+        if(snap){
+            this._liveRates={...flowData.getLiveRates()};
+            this._buildLayout(snap);
+            await this._loadImages(snap);
+            this._fitAll();
+            this._needsStaticRedraw=true;
+        }
+        this._unsub=flowData.subscribe((ev)=>{
+            if(ev==='snapshot'){
+                const s=flowData.getSnapshot();
+                if(s){
+                    this._liveRates={...flowData.getLiveRates()};
+                    if(!this._root){
+                        // First load: full build + fit
+                        this._buildLayout(s);
+                        this._loadImages(s).then(()=>{this._fitAll();this._needsStaticRedraw=true;});
+                    }else{
+                        // Detect infrastructure change (devices, not just client churn)
+                        const infraCount=(nodes)=>(nodes||[]).filter(n=>n.kind<=3||n.kind===6).length;
+                        const prevInfra=infraCount(this._snapshot?.nodes);
+                        const newInfra=infraCount(s.nodes);
+                        if(newInfra!==prevInfra){
+                            this._buildLayout(s);
+                            this._loadImages(s).then(()=>{this._needsStaticRedraw=true;});
+                        }else{
+                            // Client churn or same topology: update data in place
+                            this._updateSnapshotData(s);
+                            this._needsStaticRedraw=true;
+                        }
+                    }
+                }
+            }else if(ev==='live'){
+                Object.assign(this._liveRates,flowData.getLiveRates());
+                this._updateStreamRates();
+                this._updateCloudStats();
+                this._needsStaticRedraw=true;
+            }else if(ev==='scrubber'||ev==='playstate'){
+                this._syncScrubber();
+            }
+        });
+        this._lastFrame=performance.now();
+        this._animate();
+    }
+
+    dispose(){
+        cancelAnimationFrame(this._animId);
+        if(this._unsub)this._unsub();
+        if(this._resizeObs)this._resizeObs.disconnect();
+        if(this._onKeyDown)document.removeEventListener('keydown',this._onKeyDown);
+        if(this._isFullscreen)this._el.classList.remove('lan-flow-map-fullscreen');
+        this._streams=[];
+        this._el.innerHTML='';
+    }
+
+    // ---- Canvas setup ----
+
+    _createCanvas(){
+        this._el.innerHTML='';
+        const canvas=document.createElement('canvas');
+        canvas.className='lfm2d-canvas';
+        canvas.style.width='100%';
+        canvas.style.height='100%';
+        canvas.style.display='block';
+        canvas.style.cursor='grab';
+        this._el.appendChild(canvas);
+        this._canvas=canvas;
+        this._ctx=canvas.getContext('2d');
+
+        this._staticCanvas=document.createElement('canvas');
+
+        // Tooltip div
+        this._tooltip=document.createElement('div');
+        this._tooltip.className='lfm2d-tooltip';
+        this._el.appendChild(this._tooltip);
+
+        // Fullscreen button (top-right, matching 3D map style)
+        const fsBtn=document.createElement('button');
+        fsBtn.className='lan-flow-map-fullscreen-btn';
+        fsBtn.setAttribute('data-tooltip','Fullscreen');
+        fsBtn.innerHTML=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="3 8 3 3 8 3"></polyline><polyline points="16 3 21 3 21 8"></polyline>
+            <polyline points="21 16 21 21 16 21"></polyline><polyline points="8 21 3 21 3 16"></polyline></svg>`;
+        fsBtn.addEventListener('click',()=>this._toggleFullscreen());
+        this._el.appendChild(fsBtn);
+        this._fsBtn=fsBtn;
+
+        // Esc key exits fullscreen
+        this._onKeyDown=(e)=>{if(e.key==='Escape'&&this._isFullscreen)this._toggleFullscreen();};
+        document.addEventListener('keydown',this._onKeyDown);
+
+        // Filter + overlay state
+        this._filter={text:'',bands:{'2.4':true,'5':true,'6':true}};
+        const defaultOverlays={wifiClients:true,wiredClients:true,clouds:true};
+        try{const s=JSON.parse(localStorage.getItem('lanFlowMap2dOverlays'));this._overlays=s?{...defaultOverlays,...s}:{...defaultOverlays};}
+        catch{this._overlays={...defaultOverlays};}
+
+        // Filter panel (top-left, matching 3D style, collapsible on mobile)
+        const isMobile=window.matchMedia('(max-width: 768px)').matches;
+        const filter=document.createElement('div');
+        filter.className='lan-flow-map-panel lan-flow-map-filter';
+        const filterTitle=document.createElement('div');
+        filterTitle.className='lan-flow-map-panel-title';
+        filterTitle.textContent=isMobile?'Filter':'Filter clients';
+        if(isMobile)filterTitle.classList.add('lan-flow-map-panel-title-toggle');
+        filter.appendChild(filterTitle);
+        const filterBody=document.createElement('div');
+        filterBody.className='lan-flow-map-panel-body';
+        filterBody.innerHTML=`<input class="lan-flow-map-search" type="search" placeholder="Search by name or MAC" />
+                <div class="lan-flow-map-chips" data-chip-group="band">
+                    <span class="lan-flow-map-chip is-on" data-band="2.4">2.4 GHz</span>
+                    <span class="lan-flow-map-chip is-on" data-band="5">5 GHz</span>
+                    <span class="lan-flow-map-chip is-on" data-band="6">6 GHz</span>
+                </div>`;
+        if(isMobile)filterBody.hidden=true;
+        filter.appendChild(filterBody);
+        if(isMobile)filterTitle.addEventListener('click',()=>{filterBody.hidden=!filterBody.hidden;});
+        filterBody.querySelector('.lan-flow-map-search').addEventListener('input',(e)=>{
+            this._filter.text=(e.target.value||'').toLowerCase().trim();
+            this._needsStaticRedraw=true;
+        });
+        const bandChips=[...filterBody.querySelectorAll('.lan-flow-map-chip')];
+        bandChips.forEach(chip=>{
+            chip.addEventListener('click',()=>{
+                const b=chip.dataset.band;
+                const allOn=bandChips.every(c=>this._filter.bands[c.dataset.band]);
+                if(allOn){for(const c of bandChips){this._filter.bands[c.dataset.band]=(c.dataset.band===b);c.classList.toggle('is-on',this._filter.bands[c.dataset.band]);}}
+                else{const onlyThis=this._filter.bands[b]&&bandChips.every(c=>c.dataset.band===b||!this._filter.bands[c.dataset.band]);
+                    if(onlyThis){for(const c of bandChips){this._filter.bands[c.dataset.band]=true;c.classList.add('is-on');}}
+                    else{this._filter.bands[b]=!this._filter.bands[b];chip.classList.toggle('is-on',this._filter.bands[b]);}}
+                this._needsStaticRedraw=true;
+            });
+        });
+        this._el.appendChild(filter);
+
+        // Overlays panel (top-right, matching 3D style, collapsible on mobile)
+        const controls=document.createElement('div');
+        controls.className='lan-flow-map-panel lan-flow-map-controls';
+        const ctrlTitle=document.createElement('div');
+        ctrlTitle.className='lan-flow-map-panel-title';
+        ctrlTitle.textContent='Overlays';
+        if(isMobile)ctrlTitle.classList.add('lan-flow-map-panel-title-toggle');
+        controls.appendChild(ctrlTitle);
+        const ctrlBody=document.createElement('div');
+        ctrlBody.className='lan-flow-map-panel-body';
+        if(isMobile)ctrlBody.hidden=true;
+        controls.appendChild(ctrlBody);
+        if(isMobile)ctrlTitle.addEventListener('click',()=>{ctrlBody.hidden=!ctrlBody.hidden;});
+        for(const[key,label]of[['wifiClients','Wi-Fi clients'],['wiredClients','Wired clients'],['clouds','WAN globes']]){
+            const row=document.createElement('div');
+            row.className=`lan-flow-map-toggle ${this._overlays[key]?'is-on':''}`;
+            row.innerHTML=`<span>${label}</span><span class="lan-flow-map-toggle-pill"></span>`;
+            row.addEventListener('click',()=>{
+                this._overlays[key]=!this._overlays[key];
+                row.classList.toggle('is-on',this._overlays[key]);
+                try{localStorage.setItem('lanFlowMap2dOverlays',JSON.stringify(this._overlays));}catch{}
+                this._needsStaticRedraw=true;
+            });
+            ctrlBody.appendChild(row);
+        }
+        this._el.appendChild(controls);
+
+        // Toolbar
+        const tb=document.createElement('div');
+        tb.className='lfm2d-toolbar';
+        tb.innerHTML=`<button class="lfm2d-btn" data-action="zin" title="Zoom in">+</button>`
+            +`<button class="lfm2d-btn" data-action="zout" title="Zoom out">&minus;</button>`
+            +`<button class="lfm2d-btn" data-action="fit" title="Fit all">&#x2922;</button>`;
+        tb.addEventListener('click',(e)=>{
+            const a=e.target.closest('[data-action]')?.dataset.action;
+            if(a==='zin')this._zoomBy(1.3);
+            else if(a==='zout')this._zoomBy(1/1.3);
+            else if(a==='fit')this._fitAll();
+        });
+        this._el.appendChild(tb);
+
+        // Mode badge (bottom-left, matching 3D style)
+        const status=document.createElement('div');
+        status.className='lan-flow-map-panel lan-flow-map-status';
+        const modeBadge=document.createElement('span');
+        modeBadge.className='lan-flow-map-mode';
+        modeBadge.textContent='Live';
+        modeBadge.addEventListener('click',()=>{
+            const inst=window.__lanFlowMap?.getInstance?.();
+            if(inst&&inst._mode==='historic'){
+                const r=inst._panels?.scrubberRange;
+                if(r){r.value=10000;r.dispatchEvent(new Event('change'));}
+            }
+        });
+        status.appendChild(modeBadge);
+        this._el.appendChild(status);
+        this._modeBadge=modeBadge;
+
+        // Mirror scrubber (synced from 3D map via shared data store).
+        // Interactions forward to the 3D map's instance.
+        const scrubber=document.createElement('div');
+        scrubber.className='lan-flow-map-scrubber';
+        scrubber.innerHTML=`
+            <div class="lan-flow-map-scrubber-row">
+                <button class="lan-flow-map-scrubber-playpause" data-role="playpause" type="button" aria-label="Pause">⏸</button>
+                <div class="lan-flow-map-speed-control" data-role="speed">
+                    <button class="lan-flow-map-speed-step" data-dir="-1" type="button" aria-label="Slower">-</button>
+                    <span class="lan-flow-map-speed-label" data-role="speed-label">1x</span>
+                    <button class="lan-flow-map-speed-step" data-dir="1" type="button" aria-label="Faster">+</button>
+                </div>
+                <span data-role="left">-24h</span>
+                <input class="lan-flow-map-scrubber-range" type="range" min="0" max="10000" value="10000" />
+                <span data-role="right">Live</span>
+            </div>`;
+        // Forward all interactions to the 3D map
+        const fwd=()=>window.__lanFlowMap?.getInstance?.();
+        const sRange=scrubber.querySelector('.lan-flow-map-scrubber-range');
+        sRange.addEventListener('input',(e)=>{
+            const inst=fwd();if(inst){
+                const r=inst._panels?.scrubberRange;
+                if(r){r.value=e.target.value;r.dispatchEvent(new Event('input'));}
+            }
+        });
+        sRange.addEventListener('change',(e)=>{
+            const inst=fwd();if(inst){
+                const r=inst._panels?.scrubberRange;
+                if(r){r.value=e.target.value;r.dispatchEvent(new Event('change'));}
+            }
+        });
+        scrubber.querySelector('[data-role="playpause"]').addEventListener('click',()=>{
+            const inst=fwd();if(inst)inst._togglePlayPause();
+        });
+        for(const btn of scrubber.querySelectorAll('.lan-flow-map-speed-step')){
+            btn.addEventListener('click',()=>{
+                const inst=fwd();if(inst){
+                    const ob=inst._panels?.scrubber?.querySelector(`.lan-flow-map-speed-step[data-dir="${btn.dataset.dir}"]`);
+                    if(ob)ob.click();
+                }
+            });
+        }
+        this._el.appendChild(scrubber);
+        this._scrubberEls={
+            range:sRange,
+            right:scrubber.querySelector('[data-role="right"]'),
+            playPause:scrubber.querySelector('[data-role="playpause"]'),
+            speedLabel:scrubber.querySelector('[data-role="speed-label"]'),
+        };
+
+        // Events
+        canvas.addEventListener('wheel',(e)=>this._onWheel(e),{passive:false});
+        canvas.addEventListener('pointerdown',(e)=>this._onDown(e));
+        canvas.addEventListener('pointermove',(e)=>this._onMove(e));
+        canvas.addEventListener('pointerup',(e)=>this._onUp(e));
+        canvas.addEventListener('pointerleave',(e)=>{this._onUp(e);this._hideTooltip();});
+
+        // Resize
+        this._resizeObs=new ResizeObserver(()=>this._resize());
+        this._resizeObs.observe(this._el);
+        this._resize();
+    }
+
+    _resize(){
+        const rect=this._el.getBoundingClientRect();
+        this._dpr=window.devicePixelRatio||1;
+        this._cw=rect.width; this._ch=rect.height;
+        this._canvas.width=rect.width*this._dpr;
+        this._canvas.height=rect.height*this._dpr;
+        this._staticCanvas.width=this._canvas.width;
+        this._staticCanvas.height=this._canvas.height;
+        this._needsStaticRedraw=true;
+    }
+
+    // ---- Pan / Zoom ----
+
+    _screenToWorld(sx,sy){
+        return{x:(sx-this._cw/2)/this._scale+this._ox, y:(sy-this._ch/2)/this._scale+this._oy};
+    }
+
+    _onWheel(e){
+        e.preventDefault();
+        const rect=this._canvas.getBoundingClientRect();
+        const sx=e.clientX-rect.left, sy=e.clientY-rect.top;
+        const wBefore=this._screenToWorld(sx,sy);
+        const step=1+Math.min(Math.abs(e.deltaY),100)*0.002;
+        const factor=e.deltaY<0?step:1/step;
+        this._scale=Math.max(0.05,Math.min(10,this._scale*factor));
+        const wAfter=this._screenToWorld(sx,sy);
+        this._ox+=wBefore.x-wAfter.x;
+        this._oy+=wBefore.y-wAfter.y;
+        this._needsStaticRedraw=true;
+    }
+
+    _onDown(e){
+        if(e.button!==0)return;
+        this._dragging=true;
+        this._dragStart={x:e.clientX,y:e.clientY,ox:this._ox,oy:this._oy};
+        this._canvas.style.cursor='grabbing';
+        this._canvas.setPointerCapture(e.pointerId);
+    }
+
+    _onMove(e){
+        const rect=this._canvas.getBoundingClientRect();
+        const sx=e.clientX-rect.left, sy=e.clientY-rect.top;
+        if(this._dragging&&this._dragStart){
+            const dx=(e.clientX-this._dragStart.x)/this._scale;
+            const dy=(e.clientY-this._dragStart.y)/this._scale;
+            this._ox=this._dragStart.ox-dx;
+            this._oy=this._dragStart.oy-dy;
+            this._needsStaticRedraw=true;
+        } else {
+            this._hitTest(sx,sy);
+        }
+    }
+
+    _onUp(){
+        if(!this._dragging)return;
+        this._dragging=false;
+        this._dragStart=null;
+        this._canvas.style.cursor='grab';
+    }
+
+    _fitAll(){
+        if(!this._root)return;
+        const margin=10;
+        const sx=(this._cw-margin*2)/this._bw;
+        const sy=(this._ch-margin*2)/this._bh;
+        this._scale=Math.min(sx,sy,2);
+        this._ox=this._bx+this._bw/2;
+        this._oy=this._by+this._bh/2;
+        this._needsStaticRedraw=true;
+    }
+
+    _syncScrubber(){
+        if(!this._scrubberEls)return;
+        const s=flowData.getScrubber();
+        this._scrubberEls.range.value=s.value;
+        this._scrubberEls.right.textContent=s.right;
+        this._scrubberEls.speedLabel.textContent=`${s.speed}x`;
+        this._scrubberEls.playPause.textContent=flowData.isPaused()?'▶':'⏸';
+        // Mode badge
+        if(this._modeBadge){
+            const mode=flowData.getMode();
+            this._modeBadge.textContent=mode==='historic'?'Historic':'Live';
+            this._modeBadge.classList.toggle('is-historic',mode==='historic');
+            this._modeBadge.style.cursor=mode==='historic'?'pointer':'';
+            this._modeBadge.setAttribute('data-tooltip',mode==='historic'?'Click to return to live':'');
+        }
+    }
+
+    _isNodeVisible(n){
+        const k=n.d.kind;
+        if(k===NK.WifiClient){
+            if(!this._overlays.wifiClients)return false;
+            if(n.d.band&&!this._filter.bands[n.d.band])return false;
+        }
+        if(k===NK.WiredClient&&!this._overlays.wiredClients)return false;
+        if(this._filter.text){
+            const t=this._filter.text;
+            const name=(n.d.name||'').toLowerCase();
+            const mac=(n.d.mac||'').toLowerCase();
+            const ip=(n.d.ip||'').toLowerCase();
+            if(!name.includes(t)&&!mac.includes(t)&&!ip.includes(t))return false;
+        }
+        return true;
+    }
+
+    _isCloudVisible(){return this._overlays.clouds;}
+
+    _zoomBy(factor){
+        this._scale=Math.max(0.05,Math.min(10,this._scale*factor));
+        this._needsStaticRedraw=true;
+    }
+
+    _toggleFullscreen(){
+        this._isFullscreen=!this._isFullscreen;
+        const el=this._el;
+        if(this._isFullscreen){
+            el.classList.add('lan-flow-map-fullscreen');
+            this._fsBtn.innerHTML=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="4 10 10 10 10 4"></polyline><polyline points="14 4 14 10 20 10"></polyline>
+                <polyline points="20 14 14 14 14 20"></polyline><polyline points="10 20 10 14 4 14"></polyline></svg>`;
+            this._fsBtn.setAttribute('data-tooltip','Exit fullscreen (Esc)');
+        }else{
+            el.classList.remove('lan-flow-map-fullscreen');
+            this._fsBtn.innerHTML=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="3 8 3 3 8 3"></polyline><polyline points="16 3 21 3 21 8"></polyline>
+                <polyline points="21 16 21 21 16 21"></polyline><polyline points="8 21 3 21 3 16"></polyline></svg>`;
+            this._fsBtn.setAttribute('data-tooltip','Fullscreen');
+        }
+        setTimeout(()=>{this._resize();this._fitAll();},50);
+    }
+
+    // ---- Tooltip hit-test ----
+
+    _hitTest(sx,sy){
+        const w=this._screenToWorld(sx,sy);
+        let hit=null;
+
+        const checkNode=(n)=>{
+            if(n.d.kind===NK.VirtualHub){
+                if(Math.abs(w.x-n.x)<20&&Math.abs(w.y-n.y)<20)hit=n;
+                return;
+            }
+            if(Math.abs(w.x-n.x)<G.boxW/2&&Math.abs(w.y-n.y)<G.boxH/2)hit=n;
+            for(const c of n.infra)checkNode(c);
+            for(const c of n.clients.slice(0,G.maxClients)){
+                if(Math.abs(w.x-c.x)<G.clientCellW/2&&Math.abs(w.y-c.y)<G.clientCellH/2)hit=c;
+            }
+        };
+        if(this._root)checkNode(this._root);
+
+        if(hit&&hit!==this._hoverNode){
+            this._hoverNode=hit;
+            this._showTooltip(hit,sx,sy);
+        } else if(hit&&hit===this._hoverNode){
+            const tr=this._tooltip.getBoundingClientRect();
+            const cr=this._el.getBoundingClientRect();
+            let tx=sx+14,ty=sy+14;
+            if(tx+tr.width>cr.width-4)tx=sx-tr.width-8;
+            if(ty+tr.height>cr.height-4)ty=sy-tr.height-8;
+            if(tx<4)tx=4; if(ty<4)ty=4;
+            this._tooltip.style.left=tx+'px';
+            this._tooltip.style.top=ty+'px';
+        } else if(!hit){
+            this._hideTooltip();
+        }
+    }
+
+    _showTooltip(node,sx,sy){
+        const d=node.d;
+        const esc=(s)=>(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;');
+        const rows=[];
+        if(d.ip)rows.push(['IP',d.ip]);
+        if(d.mac)rows.push(['MAC',d.mac]);
+        if(d.model)rows.push(['Model',d.model]);
+        if(d.band)rows.push(['Band',`${d.band} GHz`]);
+        if(d.ssid)rows.push(['SSID',d.ssid]);
+        if(d.signalDbm)rows.push(['Signal',`${d.signalDbm} dBm`]);
+        if(d.switchPortName)rows.push(['Switch port',d.switchPortName]);
+        if(d.wiredLinkSpeedMbps)rows.push(['Link speed',formatSpeed(d.wiredLinkSpeedMbps)]);
+        if(d.network)rows.push(['Network',d.network]);
+
+        const badges=flowData.getNodeBadges();
+        const b=badges?.[d.id];
+        if(b?.cpuPercent!=null)rows.push(['CPU',`${b.cpuPercent.toFixed(0)}%`]);
+        if(b?.memoryUsedPercent!=null)rows.push(['Memory',`${b.memoryUsedPercent.toFixed(0)}%`]);
+        if(b?.temperatureC!=null)rows.push(['Temp',`${b.temperatureC.toFixed(0)} °C`]);
+        if(b?.uptimeSeconds!=null){
+            const days=Math.floor(b.uptimeSeconds/86400);
+            const hrs=Math.floor((b.uptimeSeconds%86400)/3600);
+            rows.push(['Uptime',days>0?`${days}d ${hrs}h`:`${hrs}h`]);
+        }
+
+        // Rates: fabric devices use badge, clients use link rates
+        const isFab=d.kind===NK.Gateway||d.kind===NK.Switch||d.kind===NK.AP;
+        let inBps=0,outBps=0,any=false;
+        if(isFab&&b){
+            if(b.fabricIngressBps!=null||b.fabricEgressBps!=null){
+                inBps=b.fabricIngressBps||0;outBps=b.fabricEgressBps||0;any=true;
+            }else if(b.aggregateInBps!=null||b.aggregateOutBps!=null){
+                inBps=b.aggregateInBps||0;outBps=b.aggregateOutBps||0;any=true;
+            }
+        }else{
+            for(const e of this._edges){
+                if(e.lk.fromNodeId!==d.id&&e.lk.toNodeId!==d.id)continue;
+                const r=this._liveRates[e.lk.portKey]||this._liveRates[e.lk.id];
+                if(!r)continue;
+                any=true;
+                const dl=r.downstreamBps||0,ul=r.upstreamBps||0;
+                if(e.lk.toNodeId===d.id){inBps+=dl;outBps+=ul;}
+                else{inBps+=ul;outBps+=dl;}
+            }
+        }
+        if(any){
+            if(isFab){rows.push(['Ingress',formatBps(inBps)]);rows.push(['Egress',formatBps(outBps)]);}
+            else{rows.push(['Download',formatBps(inBps)]);rows.push(['Upload',formatBps(outBps)]);}
+        }
+
+        this._tooltip.innerHTML=
+            `<div style="font-weight:600;margin-bottom:3px">${esc(d.name||d.mac||'')}</div>`
+            +rows.map(([k,v])=>`<div style="display:flex;justify-content:space-between;gap:12px"><span style="color:${C.textMuted}">${k}</span><span>${esc(String(v))}</span></div>`).join('');
+        this._tooltip.style.display='block';
+        // Position dynamically to stay within the container
+        const tr=this._tooltip.getBoundingClientRect();
+        const cr=this._el.getBoundingClientRect();
+        let tx=sx+14, ty=sy+14;
+        if(tx+tr.width>cr.width-4)tx=sx-tr.width-8;
+        if(ty+tr.height>cr.height-4)ty=sy-tr.height-8;
+        if(tx<4)tx=4;
+        if(ty<4)ty=4;
+        this._tooltip.style.left=tx+'px';
+        this._tooltip.style.top=ty+'px';
+    }
+
+    _hideTooltip(){
+        this._hoverNode=null;
+        if(this._tooltip)this._tooltip.style.display='none';
+    }
+
+    // ---- Contour-based layout (Reingold-Tilford style) ----
+    // Computes left/right extent at every depth for each subtree, then pushes
+    // siblings apart until no depth overlaps. Guarantees zero cross-tree overlap.
+
+    _buildLayout(snap){
+        const byId=new Map();
+        for(const n of snap.nodes)byId.set(n.id,new TN(n));
+        this._treeMap=byId;
+
+        const adj=new Map();
+        for(const lk of snap.links){
+            if(lk.kind===LK.Wan||lk.kind===LK.Transit)continue;
+            const a=lk.fromNodeId,b=lk.toNodeId;
+            if(!byId.has(a)||!byId.has(b))continue;
+            if(!adj.has(a))adj.set(a,[]);
+            if(!adj.has(b))adj.set(b,[]);
+            adj.get(a).push({to:b,lk});
+            adj.get(b).push({to:a,lk});
+        }
+
+        let root=null;
+        for(const[,tn]of byId){if(tn.d.kind===NK.Gateway){root=tn;break;}}
+        this._root=root;
+
+        if(root){
+            const visited=new Set([root.d.id]);
+            const queue=[root];
+            while(queue.length>0){
+                const par=queue.shift();
+                for(const{to}of(adj.get(par.d.id)||[])){
+                    if(visited.has(to))continue;
+                    visited.add(to);
+                    const child=byId.get(to);
+                    if(!child)continue;
+                    if(isClient(child.d.kind))par.clients.push(child);
+                    else{par.infra.push(child);queue.push(child);}
+                }
+            }
+        }
+
+        this._clouds=(snap.clouds||[]).map(c=>({d:c,x:0,y:0}));
+        this._edges=[];
+        for(const lk of snap.links)this._edges.push({lk,fn:byId.get(lk.fromNodeId),tn:byId.get(lk.toNodeId)});
+
+        if(!root)return;
+        this._contourLayout(root);
+        this._assignAbsoluteXY(root,0,0);
+        this._placeClouds();
+        this._matchEdges();
+        // Always reinit streams - edges get new endpoint coords on rebuild
+        this._initStreams();
+        this._calcBounds();
+        this._updateStreamRates();
+    }
+
+    // Compute contour (left/right extent at each depth relative to node x=0)
+    // and store relative child offsets on the node.
+    _contourLayout(n){
+        const selfW=isClient(n.d.kind)?G.clientCellW:G.boxW+40;
+        const nc=Math.min(n.clients.length,G.maxClients);
+
+        // VirtualHub: treat as a leaf (children won't be rendered)
+        if(n.d.kind===NK.VirtualHub){
+            const hubW=G.clientCellW;
+            n._contour=[{l:-hubW/2,r:hubW/2}];
+            n._kidOffsets=[];
+            n._kids=[];
+            return;
+        }
+
+        // Pure-client nodes (APs with only WiFi clients): compact grid
+        if(n.infra.length===0&&nc>0){
+            const cols=Math.min(nc,G.clientCols);
+            const rows=Math.ceil(nc/cols);
+            const gridW=cols*G.clientCellW;
+            const staggerExtra=rows>1?G.clientCellW/2:0;
+            n._isGrid=true;
+            n._gridCols=cols;
+            // Contour: node at depth 0, grid rectangle at depth 1 (widened for stagger)
+            n._contour=[
+                {l:-selfW/2,r:selfW/2},
+                {l:-gridW/2,r:gridW/2+staggerExtra},
+            ];
+            n._kidOffsets=[];
+            n._kids=[];
+            return;
+        }
+
+        // Infra children (+ any direct clients merged in)
+        const kids=n.infra.length>0?[...n.infra,...n.clients.slice(0,nc)]:[];
+
+        if(kids.length===0){
+            n._contour=[{l:-selfW/2,r:selfW/2}];
+            n._kidOffsets=[];
+            n._kids=[];
+            return;
+        }
+
+        for(const k of kids)this._contourLayout(k);
+
+        const GAP=40;
+        const offsets=[];
+        let groupRight=[];
+
+        for(let i=0;i<kids.length;i++){
+            const cc=kids[i]._contour;
+            if(i===0){
+                offsets[0]=0;
+                groupRight=cc.map(c=>c.r);
+            }else{
+                let minOff=0;
+                for(let d=0;d<Math.min(groupRight.length,cc.length);d++){
+                    const needed=groupRight[d]-cc[d].l+GAP;
+                    if(needed>minOff)minOff=needed;
+                }
+                offsets[i]=minOff;
+                for(let d=0;d<cc.length;d++){
+                    const sr=cc[d].r+minOff;
+                    if(d<groupRight.length){if(sr>groupRight[d])groupRight[d]=sr;}
+                    else groupRight.push(sr);
+                }
+            }
+        }
+
+        const firstL=offsets[0]+kids[0]._contour[0].l;
+        const lastR=offsets[offsets.length-1]+kids[kids.length-1]._contour[0].r;
+        const center=(firstL+lastR)/2;
+        const centered=offsets.map(o=>o-center);
+
+        n._kidOffsets=centered;
+        n._kids=kids;
+
+        const contour=[{l:-selfW/2,r:selfW/2}];
+        let maxD=0;
+        for(const k of kids)if(k._contour.length>maxD)maxD=k._contour.length;
+        for(let d=0;d<maxD;d++){
+            let l=Infinity,r=-Infinity;
+            for(let i=0;i<kids.length;i++){
+                const cc=kids[i]._contour;
+                if(d<cc.length){
+                    const sl=cc[d].l+centered[i];
+                    const sr=cc[d].r+centered[i];
+                    if(sl<l)l=sl;
+                    if(sr>r)r=sr;
+                }
+            }
+            if(l!==Infinity)contour.push({l,r});
+        }
+        n._contour=contour;
+    }
+
+    _assignAbsoluteXY(n,absX,depth){
+        const yOff=G.pad+80;
+        n.x=absX;
+        n.y=yOff+depth*G.tierGap;
+
+        // Client grid: compact rows with honeycomb stagger so vertical links
+        // from the parent fan out to different x positions per row.
+        if(n._isGrid){
+            const nc=Math.min(n.clients.length,G.maxClients);
+            const cols=n._gridCols;
+            const gridW=cols*G.clientCellW;
+            const gridLeft=absX-gridW/2;
+            const clientY=yOff+(depth+1)*G.tierGap;
+            const stagger=G.clientCellW/2;
+            for(let i=0;i<nc;i++){
+                const col=i%cols,row=Math.floor(i/cols);
+                const rowOff=(row%2)*stagger;
+                n.clients[i].x=gridLeft+col*G.clientCellW+G.clientCellW/2+rowOff;
+                n.clients[i].y=clientY+row*G.clientCellH;
+            }
+            return;
+        }
+
+        const kids=n._kids||[];
+        const offsets=n._kidOffsets||[];
+        for(let i=0;i<kids.length;i++){
+            this._assignAbsoluteXY(kids[i],absX+offsets[i],depth+1);
+        }
+    }
+
+    _updateSnapshotData(snap){
+        // Update cloud data (ISP speeds, RTT) without rebuilding layout
+        for(const c of this._clouds){
+            const fresh=snap.clouds?.find(sc=>sc.id===c.d.id);
+            if(fresh){
+                c.d.ispDownloadMbps=fresh.ispDownloadMbps;
+                c.d.ispUploadMbps=fresh.ispUploadMbps;
+                c.d.rttAvgMs=fresh.rttAvgMs;
+                c.d.lossPercent=fresh.lossPercent;
+            }
+        }
+        // Update node data and detect client changes per parent
+        const newNodeMap=new Map();
+        for(const n of snap.nodes)newNodeMap.set(n.id,n);
+
+        let clientsChanged=false;
+        for(const n of snap.nodes){
+            const tn=this._treeMap.get(n.id);
+            if(tn){
+                tn.d.online=n.online;
+                tn.d.phyTxKbps=n.phyTxKbps;
+                tn.d.phyRxKbps=n.phyRxKbps;
+                tn.d.band=n.band;
+                tn.d.signalDbm=n.signalDbm;
+            }else if(isClient(n.kind)){
+                clientsChanged=true;
+            }
+        }
+        // Check for removed clients
+        for(const[id,tn]of this._treeMap){
+            if(isClient(tn.d.kind)&&!newNodeMap.has(id))clientsChanged=true;
+        }
+        // If clients changed, do a targeted layout rebuild
+        if(clientsChanged){
+            this._liveRates={...flowData.getLiveRates()};
+            this._buildLayout(snap);
+        }
+    }
+
+    _placeClouds(){
+        if(!this._root||this._clouds.length===0)return;
+        const gx=this._root.x,gy=this._root.y;
+        const total=this._clouds.length,sp=G.cloudGap;
+        const sx=gx-((total-1)*sp)/2;
+        const baseY=gy-G.tierGap*1.6;
+        const stagger=45;
+        for(let i=0;i<total;i++){
+            this._clouds[i].x=sx+i*sp;
+            this._clouds[i].y=baseY+(1-i%2)*stagger;
+        }
+    }
+
+    _matchEdges(){
+        const gw=this._root;
+        if(!gw)return;
+        const gwT=gw.y-G.boxH/2;
+        const STAGGER=6;
+
+        // WAN cloud links - stagger by index
+        const wanEdges=[];
+        for(const cloud of this._clouds){
+            const cy=cloud.y+G.cloudR+1;
+            const edge=this._edges.find(e=>
+                (e.lk.kind===LK.Wan||e.lk.kind===LK.Transit)
+                &&(e.lk.fromNodeId===cloud.d.id||e.lk.toNodeId===cloud.d.id));
+            if(edge){edge._x1=cloud.x;edge._y1=cy;edge._x2=gw.x;edge._y2=gwT;edge._isWan=true;wanEdges.push(edge);}
+        }
+        const wanMid=(wanEdges.length-1)/2;
+        for(let i=0;i<wanEdges.length;i++)wanEdges[i]._midYOff=(i-wanMid)*STAGGER;
+
+        // Tree links - stagger siblings from same parent
+        const matchTree=(n)=>{
+            // VirtualHub: only match the hub's own uplink, skip its children
+            if(n.d.kind===NK.VirtualHub)return;
+
+            const pB=n.y+G.boxH/2;
+            const sibEdges=[];
+
+            for(const c of n.infra){
+                // VirtualHub renders as a small ring (r=10), not a full box
+                const cT=c.d.kind===NK.VirtualHub?c.y-12:c.y-G.boxH/2;
+                const edge=this._edges.find(e=>
+                    (e.lk.fromNodeId===n.d.id&&e.lk.toNodeId===c.d.id)
+                    ||(e.lk.fromNodeId===c.d.id&&e.lk.toNodeId===n.d.id));
+                if(edge){edge._x1=n.x;edge._y1=pB;edge._x2=c.x;edge._y2=cT;edge._isCl=false;sibEdges.push(edge);}
+                matchTree(c);
+            }
+            for(const c of n.clients.slice(0,G.maxClients)){
+                const cT=c.y-G.clientR;
+                const edge=this._edges.find(e=>
+                    (e.lk.fromNodeId===n.d.id&&e.lk.toNodeId===c.d.id)
+                    ||(e.lk.fromNodeId===c.d.id&&e.lk.toNodeId===n.d.id));
+                if(edge){edge._x1=n.x;edge._y1=pB;edge._x2=c.x;edge._y2=cT;edge._isCl=true;edge._band=edge.lk.band;sibEdges.push(edge);}
+            }
+
+            // Stagger horizontal segments of siblings that share the same parent
+            if(sibEdges.length>1){
+                const mid=(sibEdges.length-1)/2;
+                for(let i=0;i<sibEdges.length;i++)sibEdges[i]._midYOff=(i-mid)*STAGGER;
+            }
+        };
+        matchTree(gw);
+    }
+
+    _initStreams(){
+        this._streams=[];
+        for(const e of this._edges){
+            if(e._x1==null)continue;
+            const len=orthoLen(e._x1,e._y1,e._x2,e._y2,e._midYOff);
+            if(len<5)continue;
+            e._sDown=new Stream(e,1,C.downstream);
+            e._sUp=new Stream(e,-1,C.upstream);
+            this._streams.push(e._sDown,e._sUp);
+        }
+    }
+
+    _calcBounds(){
+        let x0=Infinity,y0=Infinity,x1=-Infinity,y1=-Infinity;
+        const exp=(x,y,r)=>{x0=Math.min(x0,x-r);y0=Math.min(y0,y-r);x1=Math.max(x1,x+r);y1=Math.max(y1,y+r);};
+        const vis=(n)=>{exp(n.x,n.y,G.boxW);for(const c of n.infra)vis(c);for(const c of n.clients.slice(0,G.maxClients))exp(c.x,c.y,G.clientCellW/2);};
+        vis(this._root);
+        for(const c of this._clouds)exp(c.x,c.y,G.cloudR+30);
+        const p=20;
+        this._bx=x0-p; this._by=y0-p;
+        this._bw=(x1-x0)+p*2; this._bh=(y1-y0)+p*2;
+    }
+
+    // ---- Image preloading ----
+
+    async _loadImages(snap){
+        const models=new Set();
+        for(const n of snap.nodes){
+            if(n.model&&isInfra(n.kind))models.add(n.model.toLowerCase().replace(/ /g,'-'));
+        }
+        const promises=[];
+        for(const m of models){
+            if(this._images.has(m))continue;
+            promises.push(new Promise(resolve=>{
+                const img=new Image();
+                img.onload=()=>{this._images.set(m,img);resolve();};
+                img.onerror=()=>resolve();
+                img.src=`/images/devices/${m}.png`;
+            }));
+        }
+        if(promises.length>0)await Promise.all(promises);
+    }
+
+    // ---- Rate updates ----
+
+    _updateStreamRates(){
+        for(const e of this._edges){
+            if(!e._sDown)continue;
+            const r=this._liveRates[e.lk.portKey]||this._liveRates[e.lk.id];
+            e._sDown.setRate(r?.downstreamBps??0);
+            e._sUp.setRate(r?.upstreamBps??0);
+        }
+    }
+
+    _updateCloudStats(){
+        const cs=flowData.getCloudStats();
+        for(const cloud of this._clouds){
+            const live=cs?.[cloud.d.id];
+            if(live){
+                if(live.rttAvgMs!=null)cloud.d.rttAvgMs=live.rttAvgMs;
+                if(live.lossPercent!=null)cloud.d.lossPercent=live.lossPercent;
+            }
+        }
+    }
+
+    // ---- Draw (called every frame) ----
+
+    _draw(){
+        const canvas=this._canvas, ctx=this._ctx;
+        const dpr=this._dpr, cw=this._cw, ch=this._ch;
+        if(!canvas||cw===0)return;
+
+        // Redraw static layers to offscreen canvas when transform changed
+        if(this._needsStaticRedraw){
+            this._needsStaticRedraw=false;
+            this._drawStatic();
+        }
+
+        // Composite: static + particles
+        ctx.setTransform(1,0,0,1,0,0);
+        ctx.drawImage(this._staticCanvas,0,0);
+
+        // Draw particles on top
+        ctx.setTransform(this._scale*dpr,0,0,this._scale*dpr,
+            (cw/2-this._ox*this._scale)*dpr,
+            (ch/2-this._oy*this._scale)*dpr);
+
+        ctx.globalCompositeOperation='lighter';
+        for(const s of this._streams){
+            if(s.edge._isWan&&!this._isCloudVisible())continue;
+            if(s.edge._isCl){const child=s.edge.tn||s.edge.fn;if(child&&!this._isNodeVisible(child))continue;}
+            ctx.fillStyle=s.color;
+            for(const sl of s.slots){
+                if(sl.t<0)continue;
+                const pt=orthoAt(s.edge._x1,s.edge._y1,s.edge._x2,s.edge._y2,sl.t,s.midYOff);
+                ctx.globalAlpha=0.85;
+                ctx.beginPath();
+                ctx.arc(pt.x,pt.y,sl.size,0,Math.PI*2);
+                ctx.fill();
+            }
+        }
+        ctx.globalCompositeOperation='source-over';
+        ctx.globalAlpha=1;
+
+        // Labels on top of everything (including particles)
+        this._drawLinkSpeedLabels(ctx);
+        this._drawRateLabels(ctx);
+    }
+
+    _drawStatic(){
+        const c=this._staticCanvas;
+        const ctx=c.getContext('2d');
+        const dpr=this._dpr, cw=this._cw, ch=this._ch;
+
+        ctx.setTransform(1,0,0,1,0,0);
+        ctx.fillStyle=C.bg;
+        ctx.fillRect(0,0,c.width,c.height);
+
+        // Apply pan/zoom transform
+        ctx.setTransform(this._scale*dpr,0,0,this._scale*dpr,
+            (cw/2-this._ox*this._scale)*dpr,
+            (ch/2-this._oy*this._scale)*dpr);
+
+        if(!this._root)return;
+
+        // Links (pipes only)
+        this._pendingLinkLabels=[];
+        this._drawAllLinks(ctx);
+        // Clouds (if overlay enabled)
+        if(this._isCloudVisible())this._drawAllClouds(ctx);
+        // Infra + client nodes
+        this._drawAllNodes(ctx,this._root);
+    }
+
+    // ---- Link drawing ----
+
+    _drawAllLinks(ctx){
+        for(const e of this._edges){
+            if(e._x1==null)continue;
+            // Hide links to filtered-out nodes
+            if(e._isWan&&!this._isCloudVisible())continue;
+            if(e._isCl){
+                const child=e.tn||e.fn;
+                if(child&&!this._isNodeVisible(child))continue;
+            }
+            const r=this._liveRates[e.lk.portKey]||this._liveRates[e.lk.id];
+            const dn=r?.downstreamBps??0,up=r?.upstreamBps??0;
+            const cap=e.lk.capacityBps||1e9;
+            const u=Math.max(dn,up)/cap;
+            const band=e.lk.band;
+            ctx.strokeStyle=pipeClr(Math.min(u,1),band);
+            ctx.lineWidth=pipeW(e.lk.capacityBps);
+            ctx.lineCap='round';
+            ctx.globalAlpha=e._isCl?0.3+u*0.45:0.5+u*0.5;
+            strokeOrtho(ctx,e._x1,e._y1,e._x2,e._y2,e._midYOff);
+
+            // Capacity / speed label on infra and WAN links
+            if(!e._isCl){
+                ctx.globalAlpha=1;
+                const isWan=e._isWan;
+                const midY=(e._y1+e._y2)/2+(e._midYOff||0);
+                // WAN: on cloud's vertical above horizontal. Infra: on child's vertical below horizontal.
+                const mx=isWan?e._x1:e._x2;
+                const my=isWan?midY-28:midY+20;
+                let txt=null;
+                let txtColor=C.textMuted; // default muted; live rates override
+
+                if(isWan){
+                    // Show live throughput when active, ISP expected when idle
+                    const lr=this._liveRates[e.lk.portKey]||this._liveRates[e.lk.id];
+                    const ldn=lr?.downstreamBps??0, lup=lr?.upstreamBps??0;
+                    if(ldn>RATE_THRESH||lup>RATE_THRESH){
+                        txt='↓'+(ldn>0?formatBps(ldn):'0 bps')+'  ↑'+(lup>0?formatBps(lup):'0 bps');
+                        txtColor=null; // use down/up colors
+                    }else{
+                        const cloud=this._clouds.find(c=>
+                            e.lk.fromNodeId===c.d.id||e.lk.toNodeId===c.d.id);
+                        if(cloud?.d.ispDownloadMbps&&cloud?.d.ispUploadMbps){
+                            txt=`↓${formatSpeed(cloud.d.ispDownloadMbps)}  ↑${formatSpeed(cloud.d.ispUploadMbps)}`;
+                        }else if(e.lk.capacityBps>0){
+                            txt=formatSpeed(e.lk.capacityBps/1e6);
+                        }
+                    }
+                }else if(e.lk.kind===LK.MeshBackhaul||e.lk.band){
+                    // Mesh/wireless: show asymmetric PHY rates
+                    const n1=e.fn?.d, n2=e.tn?.d;
+                    const phy=n2?.phyTxKbps?n2:n1?.phyTxKbps?n1:null;
+                    if(phy?.phyTxKbps&&phy?.phyRxKbps){
+                        txt=`↓${formatSpeed(phy.phyRxKbps/1000)}  ↑${formatSpeed(phy.phyTxKbps/1000)}`;
+                    }else if(e.lk.capacityBps>0){
+                        txt=formatSpeed(e.lk.capacityBps/1e6);
+                    }
+                }else if(e.lk.capacityBps>0){
+                    txt=formatSpeed(e.lk.capacityBps/1e6);
+                }
+
+                if(txt) this._pendingLinkLabels.push({mx,my,txt,txtColor});
+            }
+        }
+        ctx.globalAlpha=1;
+    }
+
+    _drawLinkSpeedLabels(ctx){
+        ctx.font=`${G.rateFont}px ${FONT}`;
+        for(const{mx,my,txt,txtColor}of(this._pendingLinkLabels||[])){
+            const tw=ctx.measureText(txt).width+12;
+            ctx.fillStyle=C.labelBg;
+            ctx.globalAlpha=1;
+            this._roundRect(ctx,mx-tw/2,my-8,tw,16,4);
+            ctx.fill();
+            if(txtColor){
+                ctx.fillStyle=txtColor;
+                ctx.textAlign='center'; ctx.textBaseline='middle';
+                ctx.fillText(txt,mx,my);
+            }else{
+                const parts=txt.split(' ↑');
+                ctx.textBaseline='middle';
+                ctx.textAlign='right'; ctx.fillStyle=C.downstream;
+                ctx.fillText(parts[0],mx-4,my);
+                ctx.textAlign='left'; ctx.fillStyle=C.upstream;
+                ctx.fillText('↑'+parts[1],mx+4,my);
+            }
+        }
+    }
+
+    // ---- Cloud drawing ----
+
+    _drawAllClouds(ctx){
+        for(const cloud of this._clouds){
+            const cx=cloud.x, cy=cloud.y, r=G.cloudR;
+
+            // Subtle radial fill
+            const grad=ctx.createRadialGradient(cx-r*0.3,cy-r*0.3,0,cx,cy,r);
+            grad.addColorStop(0,'rgba(59,130,246,0.08)');
+            grad.addColorStop(1,'rgba(59,130,246,0.02)');
+            ctx.fillStyle=grad;
+            ctx.beginPath(); ctx.arc(cx,cy,r,0,Math.PI*2); ctx.fill();
+
+            // Outer circle
+            ctx.strokeStyle=C.globeStroke;
+            ctx.lineWidth=1.5; ctx.globalAlpha=0.8;
+            ctx.beginPath(); ctx.arc(cx,cy,r,0,Math.PI*2); ctx.stroke();
+
+            // Longitude lines (3 meridians at different tilts)
+            ctx.lineWidth=0.8; ctx.globalAlpha=0.3;
+            for(const rx of [0.15, 0.5, 0.85]){
+                ctx.beginPath(); ctx.ellipse(cx,cy,r*rx,r,0,0,Math.PI*2); ctx.stroke();
+            }
+
+            // Latitude lines (equator + two parallels)
+            for(const ry of [0.35, 0.65]){
+                ctx.beginPath(); ctx.ellipse(cx,cy,r,r*ry,0,0,Math.PI*2); ctx.stroke();
+            }
+            // Equator slightly brighter
+            ctx.globalAlpha=0.45; ctx.lineWidth=0.9;
+            ctx.beginPath(); ctx.ellipse(cx,cy,r,r*0.08,0,0,Math.PI*2); ctx.stroke();
+
+            ctx.globalAlpha=1;
+
+            // Name
+            const name=cloud.d.asnName||cloud.d.name||'WAN';
+            ctx.fillStyle=C.textSec;
+            ctx.font=`500 ${G.nameFont}px ${FONT}`;
+            ctx.textAlign='center'; ctx.textBaseline='top';
+            ctx.fillText(name,cx,cy+r+8);
+
+            // RTT badge
+            let rttTxt='';
+            if(cloud.d.rttAvgMs!=null)rttTxt+=`${cloud.d.rttAvgMs.toFixed(1)} ms`;
+            if(cloud.d.lossPercent&&cloud.d.lossPercent>0)rttTxt+=(rttTxt?' / ':'')+`${cloud.d.lossPercent.toFixed(1)}% loss`;
+            if(rttTxt){
+                ctx.fillStyle=C.textMuted;
+                ctx.font=`${G.rateFont-1}px ${FONT}`;
+                ctx.fillText(rttTxt,cx,cy+r+22);
+            }
+        }
+    }
+
+    // ---- Node drawing ----
+
+    _drawAllNodes(ctx,n){
+        // VirtualHub: show as compact label with member count, skip children
+        if(n.d.kind===NK.VirtualHub){
+            this._drawHubNode(ctx,n);
+            return;
+        }
+        this._drawInfraNode(ctx,n);
+        for(const c of n.infra)this._drawAllNodes(ctx,c);
+        for(const c of n.clients.slice(0,G.maxClients)){if(this._isNodeVisible(c))this._drawClientNode(ctx,c);}
+        if(n.clients.length>G.maxClients){
+            const last=n.clients[G.maxClients-1];
+            ctx.fillStyle=C.textMuted;
+            ctx.font=`${G.rateFont}px ${FONT}`;
+            ctx.textAlign='left'; ctx.textBaseline='middle';
+            ctx.fillText(`+${n.clients.length-G.maxClients}`,last.x+G.clientR+10,last.y);
+        }
+    }
+
+    _drawHubNode(ctx,n){
+        const x=n.x,y=n.y,color=C.virtualHub;
+        const memberCount=n.infra.length+n.clients.length;
+        const r=10;
+
+        // Small ring
+        ctx.strokeStyle=color; ctx.lineWidth=2; ctx.globalAlpha=0.6;
+        ctx.beginPath(); ctx.arc(x,y,r,0,Math.PI*2); ctx.stroke();
+        ctx.fillStyle=withAlpha(color,0.1);
+        ctx.beginPath(); ctx.arc(x,y,r-1,0,Math.PI*2); ctx.fill();
+        ctx.globalAlpha=1;
+
+        // Label - name may already include count from the server
+        const name=n.d.name||'Hub';
+        const hasCount=/\(\d+\)/.test(name);
+        const label=hasCount?name:memberCount>0?`${name} (${memberCount})`:name;
+        const dn=label.length>28?label.slice(0,27)+'…':label;
+        ctx.fillStyle=C.textSec;
+        ctx.font=`${G.nameFont}px ${FONT}`;
+        ctx.textAlign='center'; ctx.textBaseline='top';
+        ctx.fillText(dn,x,y+r+4);
+    }
+
+    _drawInfraNode(ctx,n){
+        const x=n.x, y=n.y, color=nodeClr(n.d.kind);
+        const hw=G.boxW/2, hh=G.boxH/2;
+        const op=n.d.online?1:0.35;
+
+        // Glow
+        ctx.fillStyle=withAlpha(color,0.07);
+        this._roundRect(ctx,x-hw-5,y-hh-5,G.boxW+10,G.boxH+10,14);
+        ctx.fill();
+
+        // Card
+        ctx.globalAlpha=op;
+        ctx.fillStyle=C.cardBg;
+        this._roundRect(ctx,x-hw,y-hh,G.boxW,G.boxH,10);
+        ctx.fill();
+        ctx.strokeStyle=color; ctx.lineWidth=1.5;
+        this._roundRect(ctx,x-hw,y-hh,G.boxW,G.boxH,10);
+        ctx.stroke();
+
+        // Icon
+        const iSz=G.iconSize;
+        const modelKey=n.d.model?.toLowerCase().replace(/ /g,'-');
+        const img=modelKey?this._images.get(modelKey):null;
+        if(img){
+            ctx.drawImage(img,x-iSz/2,y-iSz/2,iSz,iSz);
+        } else {
+            ctx.fillStyle=withAlpha(color,0.2);
+            const s=iSz/2-6;
+            this._roundRect(ctx,x-s,y-s,s*2,s*2,6);
+            ctx.fill();
+            ctx.fillStyle=color;
+            ctx.font=`600 18px ${FONT}`;
+            ctx.textAlign='center'; ctx.textBaseline='middle';
+            ctx.fillText((n.d.name||'D').charAt(0).toUpperCase(),x,y);
+        }
+        ctx.globalAlpha=1;
+
+        // Name label
+        const name=n.d.name||n.d.model||'';
+        if(name){
+            const dn=name.length>16?name.slice(0,15)+'…':name;
+            ctx.fillStyle=C.text;
+            ctx.font=`500 ${G.nameFont}px ${FONT}`;
+            ctx.textAlign='center'; ctx.textBaseline='top';
+            ctx.fillText(dn,x,y+hh+5);
+        }
+
+        // Rate labels (stored for dynamic update)
+        n._rateY=y+hh+19;
+    }
+
+    _drawClientNode(ctx,n){
+        const x=n.x, y=n.y, color=nodeClr(n.d.kind,n.d.band);
+        const r=G.clientR, op=n.d.online?0.7:0.2;
+
+        ctx.globalAlpha=op;
+        if(n.d.kind===NK.WifiClient){
+            ctx.fillStyle=color;
+            ctx.beginPath(); ctx.arc(x,y,r,0,Math.PI*2); ctx.fill();
+            ctx.strokeStyle='rgba(255,255,255,0.5)'; ctx.lineWidth=0.8;
+            ctx.beginPath();
+            ctx.moveTo(x-2.5,y-0.5);
+            ctx.quadraticCurveTo(x,y-4,x+2.5,y-0.5);
+            ctx.stroke();
+        } else {
+            const s=r*0.9;
+            ctx.fillStyle=color;
+            this._roundRect(ctx,x-s,y-s+0.5,s*2,s*1.5,1.5);
+            ctx.fill();
+            ctx.beginPath(); ctx.moveTo(x,y+s*0.5+0.5); ctx.lineTo(x,y+s+1);
+            ctx.strokeStyle=color; ctx.lineWidth=1.2; ctx.stroke();
+        }
+        ctx.globalAlpha=1;
+
+        // Name label
+        const name=n.d.name||n.d.ip||'';
+        if(name){
+            const dn=name.length>25?name.slice(0,24)+'…':name;
+            ctx.fillStyle=C.textMuted;
+            ctx.font=`${G.clientFont}px ${FONT}`;
+            ctx.textAlign='center'; ctx.textBaseline='top';
+            ctx.fillText(dn,x,y+r+3);
+        }
+    }
+
+    // ---- Rate labels on links + nodes ----
+
+    _drawRateLabels(ctx){
+        const badges=flowData.getNodeBadges();
+        const THRESH=RATE_THRESH;
+
+        // Node rate labels
+        const drawNodeRate=(n)=>{
+            if(n._rateY){
+                let downBps=0,upBps=0,any=false;
+                const b=badges?.[n.d.id];
+                const hasFab=b&&(b.fabricIngressBps!=null||b.fabricEgressBps!=null);
+                const hasAgg=b&&(b.aggregateInBps!=null||b.aggregateOutBps!=null);
+
+                if(hasFab){downBps=b.fabricIngressBps||0;upBps=b.fabricEgressBps||0;any=downBps>0||upBps>0;}
+                else if(hasAgg){
+                    if(n.d.kind===NK.AP){downBps=b.aggregateOutBps||0;upBps=b.aggregateInBps||0;}
+                    else{downBps=b.aggregateInBps||0;upBps=b.aggregateOutBps||0;}
+                    any=downBps>0||upBps>0;
+                }
+
+                if(any&&(downBps>100000||upBps>100000)){
+                    ctx.font=`${G.rateFont}px ${FONT}`;
+                    ctx.textBaseline='top';
+                    const dTxt='↓'+formatBps(downBps), uTxt='↑'+formatBps(upBps);
+                    ctx.textAlign='right'; ctx.fillStyle=C.downstream;
+                    ctx.fillText(dTxt,n.x-4,n._rateY);
+                    ctx.textAlign='left'; ctx.fillStyle=C.upstream;
+                    ctx.fillText(uTxt,n.x+4,n._rateY);
+                }
+            }
+            for(const c of n.infra)drawNodeRate(c);
+        };
+        if(this._root)drawNodeRate(this._root);
+
+        // Link rate labels
+        ctx.font=`${G.rateFont}px ${FONT}`;
+        for(const e of this._edges){
+            if(e._x1==null||e._isCl||e._isWan)continue;
+            const r=this._liveRates[e.lk.portKey]||this._liveRates[e.lk.id];
+            if(!r)continue;
+            const dn=r.downstreamBps??0,up=r.upstreamBps??0;
+            if(dn>THRESH||up>THRESH){
+                // Place on child's vertical segment below the capacity label
+                const midY=(e._y1+e._y2)/2+(e._midYOff||0);
+                const mx=e._x2;
+                const my=midY+38;
+                const dTxt='↓'+(dn>0?formatBps(dn):'0 bps');
+                const uTxt='↑'+(up>0?formatBps(up):'0 bps');
+                const tw=ctx.measureText(dTxt+' '+uTxt).width+14;
+                ctx.fillStyle=C.labelBg;
+                this._roundRect(ctx,mx-tw/2,my-8,tw,16,4);
+                ctx.fill();
+                ctx.textBaseline='middle';
+                ctx.textAlign='right'; ctx.fillStyle=C.downstream;
+                ctx.fillText(dTxt,mx-4,my);
+                ctx.textAlign='left'; ctx.fillStyle=C.upstream;
+                ctx.fillText(uTxt,mx+4,my);
+            }
+        }
+    }
+
+    // ---- Utility ----
+
+    _roundRect(ctx,x,y,w,h,r){
+        ctx.beginPath();
+        ctx.moveTo(x+r,y);
+        ctx.lineTo(x+w-r,y);
+        ctx.quadraticCurveTo(x+w,y,x+w,y+r);
+        ctx.lineTo(x+w,y+h-r);
+        ctx.quadraticCurveTo(x+w,y+h,x+w-r,y+h);
+        ctx.lineTo(x+r,y+h);
+        ctx.quadraticCurveTo(x,y+h,x,y+h-r);
+        ctx.lineTo(x,y+r);
+        ctx.quadraticCurveTo(x,y,x+r,y);
+        ctx.closePath();
+    }
+
+    // ---- Animation loop ----
+
+    _animate(){
+        const now=performance.now();
+        const dt=Math.min((now-this._lastFrame)/1000,0.1);
+        this._lastFrame=now;
+
+        if(!flowData.isPaused()){
+            for(const s of this._streams)s.advance(dt);
+        }
+        this._draw();
+
+        this._animId=requestAnimationFrame(()=>this._animate());
+    }
+}
+
+// ---- Module exports ----
+let _inst=null;
+
+export async function mount(containerId){
+    if(_inst){_inst.dispose();_inst=null;}
+    const container=document.getElementById(containerId);
+    if(!container)return;
+    _inst=new LanFlowMap2D(container);
+    await _inst.start();
+}
+
+export function unmount(){
+    if(_inst){_inst.dispose();_inst=null;}
+}

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -14,6 +14,7 @@ import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
 import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 import { buildBuildings } from './lan-flow-buildings.js';
+import * as flowData from './lan-flow-data.js';
 
 const COLORS = {
     background: 0x202023,
@@ -388,6 +389,7 @@ export class LanFlowMap {
         if (this._raf) cancelAnimationFrame(this._raf);
         if (this._pollTimer) clearInterval(this._pollTimer);
         if (this._historicPlaybackTimer) clearInterval(this._historicPlaybackTimer);
+        if (this._snapshotTimer) clearInterval(this._snapshotTimer);
         if (this._resizeObserver) this._resizeObserver.disconnect();
         if (this._onKeyDown) document.removeEventListener('keydown', this._onKeyDown);
         if (this._onKeyUp) document.removeEventListener('keyup', this._onKeyUp);
@@ -457,6 +459,13 @@ export class LanFlowMap {
             if (!res.ok) throw new Error(`snapshot HTTP ${res.status}`);
             const snap = await res.json();
             this._snapshot = snap;
+            flowData.publishSnapshot(snap);
+            // Seed cloudStats from snapshot clouds so RTT labels show immediately
+            const seedCloudStats = {};
+            for (const c of (snap.clouds || [])) {
+                seedCloudStats[c.id] = { rttAvgMs: c.rttAvgMs, lossPercent: c.lossPercent, success: c.rttAvgMs != null };
+            }
+            flowData.publishLive({ cloudStats: seedCloudStats });
 
             this._layoutNodes(snap);
             this._rebuildBuildings(snap);
@@ -468,6 +477,7 @@ export class LanFlowMap {
             this._buildFloatingLabels(snap);
             this._applyOverlayVisibility();
             this._applyLiveRates(snap.liveRates || {});
+            this._refreshCloudRttLabels();
         } catch (err) {
             this.onError(err);
         }
@@ -500,6 +510,7 @@ export class LanFlowMap {
             const res = await fetch(`${this.apiBase}/live`, { credentials: 'same-origin' });
             if (!res.ok) return;
             const update = await res.json();
+            flowData.publishLive(update);
             this._currentBadges = update.nodeBadges || {};
             this._applyLiveRates(update.linkRates || {});
         } catch (err) {
@@ -1145,6 +1156,7 @@ export class LanFlowMap {
         // Refresh the device-rate text on the floating DOM labels.
         this._refreshDeviceLabelRates();
         this._refreshLinkLabels();
+        this._refreshCloudRttLabels();
     }
 
     _refreshLinkLabels() {
@@ -1194,12 +1206,22 @@ export class LanFlowMap {
         // position, fly to that instead of the default overview.
         this._flyInUntil = performance.now() + 1300;
         const sc = this._savedCamera;
-        this._flyInTargetCam = sc
-            ? new THREE.Vector3(sc.cx, sc.cy, sc.cz)
-            : new THREE.Vector3(60, 40, 60);
-        this._flyInTargetLookAt = sc
-            ? new THREE.Vector3(sc.tx, sc.ty, sc.tz)
-            : null;
+        if (sc) {
+            this._flyInTargetCam = new THREE.Vector3(sc.cx, sc.cy, sc.cz);
+            this._flyInTargetLookAt = new THREE.Vector3(sc.tx, sc.ty, sc.tz);
+        } else {
+            // Compute centroid of all positioned nodes so we aim at the actual
+            // topology, not hardcoded origin (which can be empty space when
+            // anchored APs shift the layout away from 0,0,0).
+            let cx = 0, cy = 0, cz = 0, n = 0;
+            for (const pos of this._positions.values()) {
+                cx += pos.x; cy += pos.y; cz += pos.z; n++;
+            }
+            if (n > 0) { cx /= n; cy /= n; cz /= n; }
+            this._flyInTargetCam = new THREE.Vector3(cx + 60, cy + 40, cz + 60);
+            this._flyInTargetLookAt = new THREE.Vector3(cx, cy, cz);
+            this.controls.target.set(cx, cy, cz);
+        }
         this._flyInStartCam = this.camera.position.clone();
 
         // Cap render rate at 120 fps. setAnimationLoop is the modern Three.js
@@ -1359,6 +1381,148 @@ export class LanFlowMap {
         this._pollTimer = setInterval(() => {
             if (this._mode === 'live' && !this._paused) this._pollLive();
         }, this.pollIntervalMs);
+        // Periodic light snapshot refresh (30s) to pick up data changes
+        // (mesh PHY rates, online status, ISP speeds) without re-running
+        // force layout or resetting the camera.
+        if (this._snapshotTimer) clearInterval(this._snapshotTimer);
+        this._snapshotTimer = setInterval(async () => {
+            if (this._mode === 'live' && !this._paused && !this._destroyed) {
+                try {
+                    const res = await fetch(`${this.apiBase}/snapshot`, { credentials: 'same-origin' });
+                    if (!res.ok) return;
+                    const snap = await res.json();
+                    const prev = this._snapshot;
+                    this._snapshot = snap;
+                    flowData.publishSnapshot(snap);
+
+                    // Diff: infrastructure change = full rebuild; client churn = incremental
+                    const infraKinds = new Set([NODE_KIND.Gateway, NODE_KIND.Switch, NODE_KIND.AccessPoint, NODE_KIND.VirtualHub]);
+                    const prevInfraIds = new Set((prev?.nodes ?? []).filter(n => infraKinds.has(n.kind)).map(n => n.id));
+                    const newInfraIds = new Set((snap.nodes ?? []).filter(n => infraKinds.has(n.kind)).map(n => n.id));
+                    const infraChanged = prevInfraIds.size !== newInfraIds.size
+                        || [...prevInfraIds].some(id => !newInfraIds.has(id));
+
+                    if (infraChanged) {
+                        await this._reloadSnapshot();
+                    } else {
+                        // Incremental client add/remove
+                        const prevNodeIds = new Set((prev?.nodes ?? []).map(n => n.id));
+                        const newNodeIds = new Set((snap.nodes ?? []).map(n => n.id));
+                        const added = (snap.nodes ?? []).filter(n => !prevNodeIds.has(n.id));
+                        const removed = [...prevNodeIds].filter(id => !newNodeIds.has(id));
+                        for (const id of removed) this._removeNodeIncremental(id);
+                        for (const node of added) this._addNodeIncremental(node, snap);
+                        // Don't apply snapshot liveRates - they're stale vs the 1s
+                        // live poll and would clobber fresh rates momentarily.
+                        this._refreshCloudRttLabels();
+                    }
+                } catch { /* transient */ }
+            }
+        }, 30000);
+    }
+
+    // Incremental client add: create mesh near parent, create link pipe + particles.
+    _addNodeIncremental(node, snap) {
+        if (node.kind === NODE_KIND.Cloud) return;
+        // Position near parent: find the link to this node
+        const link = (snap.links ?? []).find(l => l.toNodeId === node.id || l.fromNodeId === node.id);
+        if (!link) return;
+        const parentId = link.fromNodeId === node.id ? link.toNodeId : link.fromNodeId;
+        const parentPos = this._positions.get(parentId);
+        if (!parentPos) return;
+        // Scatter near parent
+        const angle = Math.random() * Math.PI * 2;
+        const dist = 6 + Math.random() * 6;
+        const pos = {
+            x: parentPos.x + Math.cos(angle) * dist,
+            y: parentPos.y - 1.5 + Math.random(),
+            z: parentPos.z + Math.sin(angle) * dist,
+            pinned: false,
+        };
+        this._positions.set(node.id, pos);
+
+        // Build node mesh (same as _buildNodes for a single node)
+        const radius = this._nodeRadius(node.kind);
+        const color = this._nodeColor(node.kind);
+        const group = new THREE.Group();
+        const halo = new THREE.Mesh(
+            new THREE.SphereGeometry(radius * 1.7, 24, 16),
+            new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.12, depthWrite: false }),
+        );
+        group.add(halo);
+        const baseEmissive = 0.45;
+        const core = this._makeDeviceCore(node.kind, radius, color, baseEmissive);
+        group.add(core);
+        group.position.set(pos.x, pos.y, pos.z);
+        if (!node.online) {
+            core.material.opacity = 0.55;
+            core.material.transparent = true;
+            halo.material.opacity = 0.05;
+        }
+        group.userData = { node, core, baseEmissive };
+        this.nodeGroup.add(group);
+        this._nodeMeshes.set(node.id, group);
+        if (node.name) {
+            const sprite = this._makeLabelSprite(node.name);
+            sprite.position.set(0, radius + 0.8, 0);
+            group.add(sprite);
+            this._labelSprites.set(node.id, sprite);
+        }
+
+        // Build link pipe + particles
+        const a = this._positions.get(link.fromNodeId);
+        const b = this._positions.get(link.toNodeId);
+        if (a && b) {
+            const pipe = this._makePipeMesh(a, b, link);
+            this.linkGroup.add(pipe);
+            const down = new ParticleStream({ from: a, to: b, color: COLORS.downstream, particleCount: 0 });
+            const up = new ParticleStream({ from: b, to: a, color: COLORS.upstream, particleCount: 0 });
+            this.particleGroup.add(down.mesh, up.mesh);
+            this._linkMeshes.set(link.id, { pipe, down, up, link });
+            this._nodesByLink.set(link.id, [link.fromNodeId, link.toNodeId]);
+        }
+    }
+
+    // Incremental client remove: dispose mesh, link, particles.
+    _removeNodeIncremental(nodeId) {
+        // Remove node mesh
+        const group = this._nodeMeshes.get(nodeId);
+        if (group) {
+            this.nodeGroup.remove(group);
+            group.traverse(obj => {
+                if (obj.geometry) obj.geometry.dispose();
+                if (obj.material) {
+                    if (Array.isArray(obj.material)) obj.material.forEach(m => m.dispose());
+                    else obj.material.dispose();
+                }
+            });
+            this._nodeMeshes.delete(nodeId);
+        }
+        this._labelSprites.delete(nodeId);
+        this._positions.delete(nodeId);
+
+        // Remove any links connected to this node
+        for (const [linkId, endpoints] of this._nodesByLink) {
+            if (endpoints[0] === nodeId || endpoints[1] === nodeId) {
+                const linkObj = this._linkMeshes.get(linkId);
+                if (linkObj) {
+                    this.linkGroup.remove(linkObj.pipe);
+                    linkObj.pipe.traverse(obj => {
+                        if (obj.geometry) obj.geometry.dispose();
+                        if (obj.material) obj.material.dispose();
+                    });
+                    this.particleGroup.remove(linkObj.down.mesh, linkObj.up.mesh);
+                    linkObj.down.mesh.geometry?.dispose();
+                    linkObj.up.mesh.geometry?.dispose();
+                    this._linkMeshes.delete(linkId);
+                }
+                this._nodesByLink.delete(linkId);
+            }
+        }
+
+        // Remove floating label if present
+        const label = this._floatingLabels.get(nodeId);
+        if (label) { label.el.remove(); this._floatingLabels.delete(nodeId); }
     }
 
     // Play/Pause: in Live mode, pause freezes rates by skipping the poll. In
@@ -1367,6 +1531,7 @@ export class LanFlowMap {
     _togglePlayPause() {
         this._paused = !this._paused;
         this._syncPlayPauseIcon();
+        flowData.publishPlayState(this._paused, this._mode);
         if (this._paused) {
             this._stopHistoricPlayback();
             return;
@@ -1400,10 +1565,11 @@ export class LanFlowMap {
             range.value = clamped;
             // Update the time label from the continuous timestamp, not the
             // integer slider position (which only moves every ~86s at 1x).
+            const rightLabel = (clamped >= 9998) ? 'Live' : _fmtDateTime(this._playbackTime);
             if (this._panels.scrubberRight) {
-                this._panels.scrubberRight.textContent =
-                    (clamped >= 9998) ? 'Live' : _fmtDateTime(this._playbackTime);
+                this._panels.scrubberRight.textContent = rightLabel;
             }
+            flowData.publishScrubber(clamped, rightLabel, this._playbackSpeed);
             tickCount++;
             // Refresh map and stat cards periodically
             if (tickCount % DATA_REFRESH_TICKS === 0 || clamped >= 9998) {
@@ -1881,10 +2047,11 @@ export class LanFlowMap {
     _onScrubberInput(value) {
         // Visual-only update while dragging - cheap label refresh.
         const at = this._scrubberValueToTime(value);
+        const rightLabel = (value >= 9998) ? 'Live' : _fmtDateTime(at);
         if (this._panels.scrubberRight) {
-            this._panels.scrubberRight.textContent =
-                (value >= 9998) ? 'Live' : _fmtDateTime(at);
+            this._panels.scrubberRight.textContent = rightLabel;
         }
+        flowData.publishScrubber(value, rightLabel, this._playbackSpeed);
     }
 
     async _onScrubberChange(value) {
@@ -1907,6 +2074,7 @@ export class LanFlowMap {
             this._paused = false;
             this._syncPlayPauseIcon();
             this._syncSpeedLabel();
+            flowData.publishPlayState(false, 'live');
             this._notifyStatCards(null);
             await this._pollLive();
             return;
@@ -1931,6 +2099,7 @@ export class LanFlowMap {
             this._syncPlayPauseIcon();
             this._stopHistoricPlayback();
         }
+        flowData.publishPlayState(this._paused, this._mode);
         this._notifyStatCards(at);
         await this._loadHistoric(at);
     }
@@ -1971,6 +2140,7 @@ export class LanFlowMap {
             const res = await fetch(url, { credentials: 'same-origin' });
             if (!res.ok) return;
             const update = await res.json();
+            flowData.publishLive(update);
             this._applyLiveRates(update.linkRates || {});
             if (update.nodeBadges) this._currentBadges = update.nodeBadges;
         } catch (err) {
@@ -2060,6 +2230,20 @@ export class LanFlowMap {
             this._wanPills.set(cloud.wanInterface, pill);
         }
 
+        // Cloud RTT labels: live-updating DOM element below each access cloud.
+        this._cloudRttLabels = this._cloudRttLabels || new Map();
+        for (const el of this._cloudRttLabels.values()) el.remove();
+        this._cloudRttLabels.clear();
+        for (const cloud of (snap.clouds || [])) {
+            if (cloud.kind !== 0 /* AccessIsp */) continue;
+            const lbl = document.createElement('div');
+            lbl.className = 'lan-flow-map-cloud-rtt';
+            lbl.style.left = '-9999px';
+            lbl.style.top = '-9999px';
+            this._labelsLayer.appendChild(lbl);
+            this._cloudRttLabels.set(cloud.id, lbl);
+        }
+
         // Hide the existing 3D sprite labels for devices we now show via DOM (keeps
         // the scene from double-labeling them).
         for (const [id, sprite] of this._labelSprites) {
@@ -2119,6 +2303,32 @@ export class LanFlowMap {
             pill.style.transformOrigin = 'center top';
             pill.style.left = `${x}px`;
             pill.style.top = `${y}px`;
+        }
+
+        // Cloud RTT labels - positioned right below the WAN speed test pill.
+        // Only show if the label has content (set by _refreshCloudRttLabels).
+        if (this._cloudRttLabels) {
+            for (const [cloudId, lbl] of this._cloudRttLabels) {
+                if (!lbl.textContent) { lbl.classList.remove('is-visible'); continue; }
+                const group = this._cloudMeshes.get(cloudId);
+                if (!group) { lbl.classList.remove('is-visible'); continue; }
+                tmp.setFromMatrixPosition(group.matrixWorld);
+                tmp.y -= NODE_RADIUS.cloud + 0.5;
+                const dist = tmp.distanceTo(camPos);
+                tmp.project(this.camera);
+                if (tmp.z > 1) { lbl.classList.remove('is-visible'); continue; }
+                const x = (tmp.x * halfW) + halfW;
+                const y = -(tmp.y * halfH) + halfH;
+                const scale = Math.max(MIN_SCALE, Math.min(1.0, REF_DIST / Math.max(dist, 1)));
+                const wanIface = cloudId.replace('cloud-access-', '');
+                const pill = this._wanPills.get(wanIface);
+                const pillOffset = pill?.classList.contains('is-visible') ? (pill.offsetHeight * scale + 6) : 0;
+                lbl.style.transform = `translate(-50%, 0%) scale(${scale.toFixed(3)})`;
+                lbl.style.transformOrigin = 'center top';
+                lbl.style.left = `${x}px`;
+                lbl.style.top = `${y + pillOffset}px`;
+                lbl.classList.add('is-visible');
+            }
         }
 
         // Link rate pills: positioned at the link midpoint. Visibility + text is
@@ -2260,6 +2470,23 @@ export class LanFlowMap {
             const ageLabel = formatAge(ageMs);
             pill.textContent = `Last test: ${dl.toFixed(0)} / ${ul.toFixed(0)} Mbps  ·  ${ageLabel}`;
             pill.classList.add('is-visible');
+        }
+    }
+
+    _refreshCloudRttLabels() {
+        if (!this._cloudRttLabels || this._cloudRttLabels.size === 0) return;
+        const cs = flowData.getCloudStats();
+        for (const [cloudId, lbl] of this._cloudRttLabels) {
+            const stats = cs?.[cloudId];
+            if (!stats || stats.rttAvgMs == null) {
+                lbl.classList.remove('is-visible');
+                continue;
+            }
+            const parts = [`${stats.rttAvgMs.toFixed(2)} ms`];
+            if (stats.lossPercent != null && stats.lossPercent > 0) {
+                parts.push(`${stats.lossPercent.toFixed(1)}% loss`);
+            }
+            lbl.textContent = parts.join('  ·  ');
         }
     }
 
@@ -3108,3 +3335,5 @@ export async function reload() {
     if (!_instance) return;
     await _instance._reloadSnapshot();
 }
+
+export function getInstance() { return _instance; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -518,7 +518,8 @@ export class LanFlowMap {
         // devices have room to settle between the pinned APs without crowding.
         const sceneRadius = 30.0;
         const ANCHOR_SPREAD_FACTOR = 1.875;
-        const scale = (sceneRadius / Math.max(bounds.radius, 1.0)) * ANCHOR_SPREAD_FACTOR;
+        const boundsR = Number.isFinite(bounds.radius) ? bounds.radius : 1.0;
+        const scale = (sceneRadius / Math.max(boundsR, 1.0)) * ANCHOR_SPREAD_FACTOR;
 
         const positions = new Map();
         const anchors = new Map();
@@ -530,29 +531,32 @@ export class LanFlowMap {
 
         for (const node of snap.nodes) {
             const p = node.placement;
-            if (p && p.source === PLACEMENT_SOURCE.Anchor) {
-                // Vertical offset within the floor by device type:
-                // APs use their mount type, clients mid-floor, infra at desk level.
-                const isClient = node.kind === NODE_KIND.WiredClient || node.kind === NODE_KIND.WifiClient;
-                const isInfra = node.kind === NODE_KIND.Switch || node.kind === NODE_KIND.Gateway;
-                const mountM = node.mountType ? (mountOffsetM[node.mountType] || 0)
-                    : isClient ? WALL_H_M * 0.5
-                    : isInfra ? WALL_H_M * 0.15
-                    : 0;
-                positions.set(node.id, {
-                    x: -p.x * scale,
-                    y: p.z * scale * 0.8 + mountM * scale * 0.8,
-                    z: p.y * scale,
-                    pinned: true,
-                });
-                anchors.set(node.id, true);
-            } else if (p && p.source === PLACEMENT_SOURCE.Interpolated) {
-                positions.set(node.id, {
-                    x: -p.x * scale,
-                    y: p.z * scale * 0.8 - 4,
-                    z: p.y * scale,
-                    pinned: false,
-                });
+            if (p && (p.source === PLACEMENT_SOURCE.Anchor || p.source === PLACEMENT_SOURCE.Interpolated)) {
+                if (!Number.isFinite(p.x) || !Number.isFinite(p.y) || !Number.isFinite(p.z)) {
+                    console.warn('[LanFlowMap] Non-finite placement for node', node.id, node.name,
+                        '| placement:', { x: p.x, y: p.y, z: p.z, source: p.source });
+                } else if (p.source === PLACEMENT_SOURCE.Anchor) {
+                    const isClient = node.kind === NODE_KIND.WiredClient || node.kind === NODE_KIND.WifiClient;
+                    const isInfra = node.kind === NODE_KIND.Switch || node.kind === NODE_KIND.Gateway;
+                    const mountM = node.mountType ? (mountOffsetM[node.mountType] || 0)
+                        : isClient ? WALL_H_M * 0.5
+                        : isInfra ? WALL_H_M * 0.15
+                        : 0;
+                    positions.set(node.id, {
+                        x: -p.x * scale,
+                        y: p.z * scale * 0.8 + mountM * scale * 0.8,
+                        z: p.y * scale,
+                        pinned: true,
+                    });
+                    anchors.set(node.id, true);
+                } else {
+                    positions.set(node.id, {
+                        x: -p.x * scale,
+                        y: p.z * scale * 0.8 - 4,
+                        z: p.y * scale,
+                        pinned: false,
+                    });
+                }
             }
         }
 
@@ -977,9 +981,22 @@ export class LanFlowMap {
         const to = new THREE.Vector3(b.x, b.y, b.z);
         const dir = to.clone().sub(from);
         const length = dir.length();
-        if (length < 0.01) return new THREE.Group();
+        if (!Number.isFinite(length) || length < 0.01) {
+            if (!Number.isFinite(length)) {
+                console.warn('[LanFlowMap] NaN pipe length for link', link.id,
+                    '| from:', { x: a.x, y: a.y, z: a.z },
+                    '| to:', { x: b.x, y: b.y, z: b.z },
+                    '| capacityBps:', link.capacityBps);
+            }
+            return new THREE.Group();
+        }
 
         const baseRadius = this._pipeRadiusForCapacity(link.capacityBps);
+        if (!Number.isFinite(baseRadius)) {
+            console.warn('[LanFlowMap] NaN pipe radius for link', link.id,
+                '| capacityBps:', link.capacityBps, '(type:', typeof link.capacityBps, ')');
+            return new THREE.Group();
+        }
         const geo = new THREE.CylinderGeometry(baseRadius, baseRadius, length, 14, 1, true);
         const mat = new THREE.MeshStandardMaterial({
             color: COLORS.pipeCool,
@@ -1002,7 +1019,7 @@ export class LanFlowMap {
     }
 
     _pipeRadiusForCapacity(capacityBps) {
-        if (!capacityBps || capacityBps <= 0) return 0.10;
+        if (typeof capacityBps !== 'number' || !Number.isFinite(capacityBps) || capacityBps <= 0) return 0.10;
         // Log scale: 100 Mbps -> 0.13, 1 Gbps -> 0.18, 10 Gbps -> 0.24, 25 Gbps -> 0.28.
         const gbps = capacityBps / 1_000_000_000;
         const t = Math.log10(Math.max(gbps, 0.01)) + 2;  // 1 Mbps -> 0, 10 Gbps -> 3
@@ -2640,7 +2657,7 @@ export class LanFlowMap {
         const to = new THREE.Vector3(b.x, b.y, b.z);
         const dir = to.clone().sub(from);
         const length = dir.length();
-        if (length < 0.01) return;
+        if (!Number.isFinite(length) || length < 0.01) return;
 
         const mid = from.clone().add(to).multiplyScalar(0.5);
         pipe.position.copy(mid);
@@ -2670,7 +2687,8 @@ export class LanFlowMap {
         }
         const sceneRadius = 30.0;
         const ANCHOR_SPREAD_FACTOR = 1.875;
-        const scale = (sceneRadius / Math.max(bounds.radius, 1.0)) * ANCHOR_SPREAD_FACTOR;
+        const boundsR = Number.isFinite(bounds.radius) ? bounds.radius : 1.0;
+        const scale = (sceneRadius / Math.max(boundsR, 1.0)) * ANCHOR_SPREAD_FACTOR;
         const EARTH_RADIUS = 6_371_000.0;
 
         // Undo JS transform: posX = -(local.x * scale), posZ = local.y * scale
@@ -2776,7 +2794,12 @@ class ParticleStream {
         this._to = toV;
         this._direction = toV.clone().sub(fromV);
         this._length = this._direction.length();
-        this._direction.normalize();
+        if (Number.isFinite(this._length) && this._length > 0.001) {
+            this._direction.normalize();
+        } else {
+            this._length = 0;
+            this._direction.set(0, 1, 0);
+        }
 
         const MAX = 200;
         this._max = MAX;


### PR DESCRIPTION
## What's New

- **2D LAN Topology Flow Map** - A new hierarchical flow map on the Monitoring Live View tab, showing your full network topology with live throughput rates, device health, and client connections in an interactive 2D canvas.
- **Device health for non-SNMP devices** - Devices without SNMP (Flex Mini, devices with SNMP toggled off) now show CPU, memory, and temperature on Device Health charts, sourced from the UniFi API.

## Monitoring

- **Switch temperature monitoring** - Switch temps now appear on the Device Health temperature chart via UniFi API supplement (SNMP doesn't report switch temps).
- **Wired client throughput** - Wired clients behind non-SNMP switches now show live throughput on the 2D map, with InfluxDB storage for historic playback.
- **API call optimization** - Reduced redundant UniFi API device calls from ~7/min to ~2/min with a 15s response cache. Network-only fetches save 521 KB per call by skipping unnecessary device and client data.

## WiFi Optimizer

- **Gateway-only console fix** - UDM-Beast, UDM-Pro, UDM-SE, and EFG no longer misclassified as access points when connected through a WAN switch or other UniFi device.

## Fixes

- **Container startup hang** - Stale migration locks from interrupted startups are now cleared automatically, preventing the container from hanging on restart.
- **3D map NaN geometry guard** - Prevents render errors when device placement data contains invalid coordinates.
- **Docker healthcheck** - Start period increased from 40s to 120s to accommodate larger databases during migration.