### PR TITLE
Device cache TTL fix, historic playback optimization, SNMP uptime, scrubber fixes

### DIFF
--- a/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
+++ b/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
@@ -819,12 +819,15 @@ public class SnmpPoller : ISnmpPoller
         {
             if (targetType == typeof(int))
             {
+                if (data.TypeCode == SnmpType.TimeTicks && data is Lextm.SharpSnmpLib.TimeTicks ttInt)
+                    return (T)(object)(int)ttInt.ToUInt32();
+
                 if (int.TryParse(dataString, out var intValue))
                     return (T)(object)intValue;
 
                 if (data.TypeCode == SnmpType.TimeTicks)
                 {
-                    var match = Regex.Match(dataString, @"(\d+)");
+                    var match = Regex.Match(dataString, @"\((\d+)\)");
                     if (match.Success && int.TryParse(match.Groups[1].Value, out var tickValue))
                         return (T)(object)tickValue;
                 }
@@ -832,12 +835,15 @@ public class SnmpPoller : ISnmpPoller
 
             if (targetType == typeof(uint))
             {
+                if (data.TypeCode == SnmpType.TimeTicks && data is Lextm.SharpSnmpLib.TimeTicks ttUint)
+                    return (T)(object)ttUint.ToUInt32();
+
                 if (uint.TryParse(dataString, out var uintValue))
                     return (T)(object)uintValue;
 
                 if (data.TypeCode == SnmpType.TimeTicks)
                 {
-                    var match = Regex.Match(dataString, @"(\d+)");
+                    var match = Regex.Match(dataString, @"\((\d+)\)");
                     if (match.Success && uint.TryParse(match.Groups[1].Value, out var tickValue))
                         return (T)(object)tickValue;
                 }
@@ -845,12 +851,15 @@ public class SnmpPoller : ISnmpPoller
 
             if (targetType == typeof(long))
             {
+                if (data.TypeCode == SnmpType.TimeTicks && data is Lextm.SharpSnmpLib.TimeTicks tt)
+                    return (T)(object)(long)tt.ToUInt32();
+
                 if (long.TryParse(dataString, out var longValue))
                     return (T)(object)longValue;
 
                 if (data.TypeCode == SnmpType.TimeTicks)
                 {
-                    var match = Regex.Match(dataString, @"(\d+)");
+                    var match = Regex.Match(dataString, @"\((\d+)\)");
                     if (match.Success && long.TryParse(match.Groups[1].Value, out var tickValue))
                         return (T)(object)tickValue;
                 }

--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -71,7 +71,8 @@
     {
         "imports": {
             "three": "/lib/three/three.module.js",
-            "three/addons/": "/lib/three/addons/"
+            "three/addons/": "/lib/three/addons/",
+            "/js/lan-flow-data.js": "@FileVersionProvider.AddFileVersionToPath("/", "js/lan-flow-data.js")"
         }
     }
     </script>

--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -67,12 +67,15 @@
     <script src="https://unpkg.com/@@popperjs/core@2"></script>
     <script src="https://unpkg.com/tippy.js@6"></script>
     <!-- Three.js importmap. Vendored under /lib/three/. Used by the 3D LAN flow map (spec 5.7). -->
+    @{
+        var flowDataVersioned = FileVersionProvider.AddFileVersionToPath("/", "js/lan-flow-data.js");
+    }
     <script type="importmap">
     {
         "imports": {
             "three": "/lib/three/three.module.js",
             "three/addons/": "/lib/three/addons/",
-            "/js/lan-flow-data.js": "@FileVersionProvider.AddFileVersionToPath("/", "js/lan-flow-data.js")"
+            "/js/lan-flow-data.js": "@flowDataVersioned"
         }
     }
     </script>

--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -67,15 +67,11 @@
     <script src="https://unpkg.com/@@popperjs/core@2"></script>
     <script src="https://unpkg.com/tippy.js@6"></script>
     <!-- Three.js importmap. Vendored under /lib/three/. Used by the 3D LAN flow map (spec 5.7). -->
-    @{
-        var flowDataVersioned = FileVersionProvider.AddFileVersionToPath("/", "js/lan-flow-data.js");
-    }
     <script type="importmap">
     {
         "imports": {
             "three": "/lib/three/three.module.js",
-            "three/addons/": "/lib/three/addons/",
-            "/js/lan-flow-data.js": "@flowDataVersioned"
+            "three/addons/": "/lib/three/addons/"
         }
     }
     </script>

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapCache.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapCache.cs
@@ -1,3 +1,6 @@
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services.Monitoring;
+
 namespace NetworkOptimizer.Web.Services.LanFlowMap;
 
 /// <summary>
@@ -73,4 +76,6 @@ public record HistoricDataCache(
     DateTime To,
     Dictionary<string, IReadOnlyList<MonitoringInfluxClient.InterfaceRatePoint>> RatesByDevice,
     IReadOnlyList<MonitoringInfluxClient.ClientThroughputPoint> WifiClients,
-    IReadOnlyList<MonitoringInfluxClient.ClientThroughputPoint> WiredClients);
+    IReadOnlyList<MonitoringInfluxClient.ClientThroughputPoint> WiredClients,
+    Dictionary<string, IReadOnlyList<MonitoringInfluxClient.DeviceHealthPoint>> HealthByDevice,
+    Dictionary<MonitoringTargetType, IReadOnlyList<MonitoringInfluxClient.LatencyPoint>> LatencyByTargetType);

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapCache.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapCache.cs
@@ -61,5 +61,16 @@ public class LanFlowMapCache
     {
         _snapshot = null;
         _snapshotAt = DateTime.MinValue;
+        HistoricData = null;
     }
+
+    /// <summary>Cached InfluxDB results for historic playback, shared across scoped service instances.</summary>
+    public HistoricDataCache? HistoricData { get; set; }
 }
+
+public record HistoricDataCache(
+    DateTime From,
+    DateTime To,
+    Dictionary<string, IReadOnlyList<MonitoringInfluxClient.InterfaceRatePoint>> RatesByDevice,
+    IReadOnlyList<MonitoringInfluxClient.ClientThroughputPoint> WifiClients,
+    IReadOnlyList<MonitoringInfluxClient.ClientThroughputPoint> WiredClients);

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -28,6 +28,15 @@ public class LanFlowMapService
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<LanFlowMapService> _logger;
 
+    private HistoricDataCache? _historicCache;
+
+    private record HistoricDataCache(
+        DateTime From,
+        DateTime To,
+        Dictionary<string, IReadOnlyList<MonitoringInfluxClient.InterfaceRatePoint>> RatesByDevice,
+        IReadOnlyList<MonitoringInfluxClient.ClientThroughputPoint> WifiClients,
+        IReadOnlyList<MonitoringInfluxClient.ClientThroughputPoint> WiredClients);
+
     public LanFlowMapService(
         IUniFiClientProvider connection,
         INetworkPathAnalyzer pathAnalyzer,
@@ -410,14 +419,10 @@ public class LanFlowMapService
 
         var snapshot = await BuildSnapshotAsync(ct);
 
-        var from = at - TimeSpan.FromSeconds(90);
-        var to = at + TimeSpan.FromSeconds(30);
-
         var gwNode = snapshot.Nodes.FirstOrDefault(n => n.Kind == LanNodeKind.Gateway);
         var gwMac = gwNode?.Mac;
 
         // Build WAN interface → ifname candidates for per-WAN rate queries.
-        // Physical port first, uplink (ppp* for PPPoE) as fallback.
         var wanIfNameMap = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
         try
         {
@@ -435,65 +440,37 @@ public class LanFlowMapService
         }
         catch { }
 
-        // Per-device queries use the tag index efficiently. Each is a fast
-        // indexed lookup; batching into one OR filter was slower (no index).
-        var deviceMacs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        if (!string.IsNullOrEmpty(gwMac)) deviceMacs.Add(gwMac);
-        foreach (var link in snapshot.Links)
+        // Reuse cached InfluxDB results when the requested time falls within
+        // the previously fetched window. Fetches 5 min ahead so forward
+        // playback goes ~4 min before needing another round-trip.
+        var cached = _historicCache;
+        if (cached == null || at < cached.From || at > cached.To - TimeSpan.FromSeconds(30))
         {
-            if (link.Kind == LanLinkKind.Uplink || link.Kind == LanLinkKind.MeshBackhaul)
-            {
-                var mac = ExtractDeviceMacFromUplinkId(link.Id);
-                if (!string.IsNullOrEmpty(mac)) deviceMacs.Add(mac);
-            }
-            else if (!string.IsNullOrEmpty(link.PortKey))
-            {
-                var (mac, _) = ParsePortKey(link.PortKey);
-                if (!string.IsNullOrEmpty(mac)) deviceMacs.Add(mac);
-            }
-        }
-        var ratesByDevice = new Dictionary<string, IReadOnlyList<MonitoringInfluxClient.InterfaceRatePoint>>(
-            StringComparer.OrdinalIgnoreCase);
-        foreach (var mac in deviceMacs)
-        {
-            try
-            {
-                ratesByDevice[mac] = await _influx.QueryInterfaceRatesAsync(mac, from, to, null, ct);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Historic rate fetch failed for device {Mac}", mac);
-            }
+            cached = await FetchHistoricDataAsync(at, snapshot, gwMac, ct);
+            _historicCache = cached;
         }
 
-        // Batch pre-fetch all client throughput from InfluxDB (one query per
-        // measurement instead of N queries per client). Keyed by client MAC.
+        var ratesByDevice = cached.RatesByDevice;
+        var from = cached.From;
+        var to = cached.To;
+
+        // Resolve closest client throughput points from cached data.
         var wifiClientRates = new Dictionary<string, MonitoringInfluxClient.ClientThroughputPoint>(StringComparer.OrdinalIgnoreCase);
+        foreach (var p in cached.WifiClients)
+        {
+            if (string.IsNullOrEmpty(p.ClientMac)) continue;
+            if (!wifiClientRates.TryGetValue(p.ClientMac, out var existing)
+                || Math.Abs((p.Time - at).TotalMilliseconds) < Math.Abs((existing.Time - at).TotalMilliseconds))
+                wifiClientRates[p.ClientMac] = p;
+        }
         var wiredClientRates = new Dictionary<string, MonitoringInfluxClient.ClientThroughputPoint>(StringComparer.OrdinalIgnoreCase);
-        try
+        foreach (var p in cached.WiredClients)
         {
-            var allWifi = await _influx.QueryAllClientThroughputAsync("wifi_client", from, to, ct);
-            foreach (var p in allWifi)
-            {
-                if (string.IsNullOrEmpty(p.ClientMac)) continue;
-                if (!wifiClientRates.TryGetValue(p.ClientMac, out var existing)
-                    || Math.Abs((p.Time - at).TotalMilliseconds) < Math.Abs((existing.Time - at).TotalMilliseconds))
-                    wifiClientRates[p.ClientMac] = p;
-            }
+            if (string.IsNullOrEmpty(p.ClientMac)) continue;
+            if (!wiredClientRates.TryGetValue(p.ClientMac, out var existing)
+                || Math.Abs((p.Time - at).TotalMilliseconds) < Math.Abs((existing.Time - at).TotalMilliseconds))
+                wiredClientRates[p.ClientMac] = p;
         }
-        catch (Exception ex) { _logger.LogDebug(ex, "Historic WiFi client batch query failed"); }
-        try
-        {
-            var allWired = await _influx.QueryAllClientThroughputAsync("wired_client", from, to, ct);
-            foreach (var p in allWired)
-            {
-                if (string.IsNullOrEmpty(p.ClientMac)) continue;
-                if (!wiredClientRates.TryGetValue(p.ClientMac, out var existing)
-                    || Math.Abs((p.Time - at).TotalMilliseconds) < Math.Abs((existing.Time - at).TotalMilliseconds))
-                    wiredClientRates[p.ClientMac] = p;
-            }
-        }
-        catch (Exception ex) { _logger.LogDebug(ex, "Historic wired client batch query failed"); }
 
         // Resolve each link, mirroring the live endpoint's kind-aware dispatch.
         foreach (var link in snapshot.Links)
@@ -1769,6 +1746,52 @@ public class LanFlowMapService
         "6e" or "6ghz" or "6 GHz" or "6" => "6",
         _ => null,
     };
+
+    private async Task<HistoricDataCache> FetchHistoricDataAsync(
+        DateTime at, LanFlowMapSnapshot snapshot, string? gwMac, CancellationToken ct)
+    {
+        var from = at - TimeSpan.FromSeconds(90);
+        var to = at + TimeSpan.FromMinutes(5);
+
+        var deviceMacs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (!string.IsNullOrEmpty(gwMac)) deviceMacs.Add(gwMac);
+        foreach (var link in snapshot.Links)
+        {
+            if (link.Kind == LanLinkKind.Uplink || link.Kind == LanLinkKind.MeshBackhaul)
+            {
+                var mac = ExtractDeviceMacFromUplinkId(link.Id);
+                if (!string.IsNullOrEmpty(mac)) deviceMacs.Add(mac);
+            }
+            else if (!string.IsNullOrEmpty(link.PortKey))
+            {
+                var (mac, _) = ParsePortKey(link.PortKey);
+                if (!string.IsNullOrEmpty(mac)) deviceMacs.Add(mac);
+            }
+        }
+
+        var ratesByDevice = new Dictionary<string, IReadOnlyList<MonitoringInfluxClient.InterfaceRatePoint>>(
+            StringComparer.OrdinalIgnoreCase);
+        foreach (var mac in deviceMacs)
+        {
+            try
+            {
+                ratesByDevice[mac] = await _influx.QueryInterfaceRatesAsync(mac, from, to, null, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Historic rate fetch failed for device {Mac}", mac);
+            }
+        }
+
+        IReadOnlyList<MonitoringInfluxClient.ClientThroughputPoint> wifi = Array.Empty<MonitoringInfluxClient.ClientThroughputPoint>();
+        IReadOnlyList<MonitoringInfluxClient.ClientThroughputPoint> wired = Array.Empty<MonitoringInfluxClient.ClientThroughputPoint>();
+        try { wifi = await _influx.QueryAllClientThroughputAsync("wifi_client", from, to, ct); }
+        catch (Exception ex) { _logger.LogDebug(ex, "Historic WiFi client batch query failed"); }
+        try { wired = await _influx.QueryAllClientThroughputAsync("wired_client", from, to, ct); }
+        catch (Exception ex) { _logger.LogDebug(ex, "Historic wired client batch query failed"); }
+
+        return new HistoricDataCache(from, to, ratesByDevice, wifi, wired);
+    }
 
     private async Task<LinkLiveRates?> QueryClientThroughputAsync(
         string measurement, string clientMac, DateTime at, DateTime from, DateTime to, CancellationToken ct)

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -435,36 +435,16 @@ public class LanFlowMapService
         }
         catch { }
 
-        // Pre-fetch interface_counters per device MAC so we don't re-query for
-        // every link on the same device. Covers WiredClient (PortKey), Uplink,
-        // MeshBackhaul, and WAN links.
-        var deviceMacs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        if (!string.IsNullOrEmpty(gwMac)) deviceMacs.Add(gwMac);
-        foreach (var link in snapshot.Links)
+        // Single batch query for all device interface rates instead of N per-device queries.
+        Dictionary<string, List<MonitoringInfluxClient.InterfaceRatePoint>> ratesByDevice;
+        try
         {
-            if (link.Kind == LanLinkKind.Uplink || link.Kind == LanLinkKind.MeshBackhaul)
-            {
-                var mac = ExtractDeviceMacFromUplinkId(link.Id);
-                if (!string.IsNullOrEmpty(mac)) deviceMacs.Add(mac);
-            }
-            else if (!string.IsNullOrEmpty(link.PortKey))
-            {
-                var (mac, _) = ParsePortKey(link.PortKey);
-                if (!string.IsNullOrEmpty(mac)) deviceMacs.Add(mac);
-            }
+            ratesByDevice = await _influx.QueryAllInterfaceRatesAsync(from, to, ct: ct);
         }
-        var ratesByDevice = new Dictionary<string, IReadOnlyList<MonitoringInfluxClient.InterfaceRatePoint>>(
-            StringComparer.OrdinalIgnoreCase);
-        foreach (var mac in deviceMacs)
+        catch (Exception ex)
         {
-            try
-            {
-                ratesByDevice[mac] = await _influx.QueryInterfaceRatesAsync(mac, from, to, null, ct);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Historic rate fetch failed for device {Mac}", mac);
-            }
+            _logger.LogDebug(ex, "Historic batch rate fetch failed");
+            ratesByDevice = new Dictionary<string, List<MonitoringInfluxClient.InterfaceRatePoint>>(StringComparer.OrdinalIgnoreCase);
         }
 
         // Batch pre-fetch all client throughput from InfluxDB (one query per

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -28,15 +28,6 @@ public class LanFlowMapService
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<LanFlowMapService> _logger;
 
-    private HistoricDataCache? _historicCache;
-
-    private record HistoricDataCache(
-        DateTime From,
-        DateTime To,
-        Dictionary<string, IReadOnlyList<MonitoringInfluxClient.InterfaceRatePoint>> RatesByDevice,
-        IReadOnlyList<MonitoringInfluxClient.ClientThroughputPoint> WifiClients,
-        IReadOnlyList<MonitoringInfluxClient.ClientThroughputPoint> WiredClients);
-
     public LanFlowMapService(
         IUniFiClientProvider connection,
         INetworkPathAnalyzer pathAnalyzer,
@@ -443,11 +434,11 @@ public class LanFlowMapService
         // Reuse cached InfluxDB results when the requested time falls within
         // the previously fetched window. Fetches 5 min ahead so forward
         // playback goes ~4 min before needing another round-trip.
-        var cached = _historicCache;
+        var cached = _cache.HistoricData;
         if (cached == null || at < cached.From || at > cached.To - TimeSpan.FromSeconds(30))
         {
             cached = await FetchHistoricDataAsync(at, snapshot, gwMac, ct);
-            _historicCache = cached;
+            _cache.HistoricData = cached;
         }
 
         var ratesByDevice = cached.RatesByDevice;

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -435,11 +435,26 @@ public class LanFlowMapService
         }
         catch { }
 
-        // Single batch query for all device interface rates instead of N per-device queries.
+        // Collect device MACs we need rates for, then batch into one InfluxDB query.
+        var deviceMacs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (!string.IsNullOrEmpty(gwMac)) deviceMacs.Add(gwMac);
+        foreach (var link in snapshot.Links)
+        {
+            if (link.Kind == LanLinkKind.Uplink || link.Kind == LanLinkKind.MeshBackhaul)
+            {
+                var mac = ExtractDeviceMacFromUplinkId(link.Id);
+                if (!string.IsNullOrEmpty(mac)) deviceMacs.Add(mac);
+            }
+            else if (!string.IsNullOrEmpty(link.PortKey))
+            {
+                var (mac, _) = ParsePortKey(link.PortKey);
+                if (!string.IsNullOrEmpty(mac)) deviceMacs.Add(mac);
+            }
+        }
         Dictionary<string, List<MonitoringInfluxClient.InterfaceRatePoint>> ratesByDevice;
         try
         {
-            ratesByDevice = await _influx.QueryAllInterfaceRatesAsync(from, to, ct: ct);
+            ratesByDevice = await _influx.QueryBatchInterfaceRatesAsync(deviceMacs, from, to, ct: ct);
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -696,6 +696,7 @@ public class LanFlowMapService
                     CpuPercent = healthPt?.CpuPercent,
                     MemoryUsedPercent = healthPt?.MemoryUsedPercent,
                     TemperatureC = healthPt?.TemperatureC,
+                    UptimeSeconds = healthPt?.UptimeSeconds,
                     FabricIngressBps = fabIn,
                     FabricEgressBps = fabOut,
                     AggregateInBps = aggIn,

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -1766,7 +1766,7 @@ public class LanFlowMapService
         {
             try
             {
-                ratesByDevice[mac] = await _influx.QueryInterfaceRatesAsync(mac, from, to, null, ct);
+                ratesByDevice[mac] = await _influx.QueryInterfaceRatesRawAsync(mac, from, to, ct);
             }
             catch (Exception ex)
             {

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -647,10 +647,9 @@ public class LanFlowMapService
             var mac = node.Mac;
             try
             {
-                var health = await _influx.QueryDeviceHealthAsync(mac, from, to, null, ct);
-                var healthPt = health
-                    .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
-                    .FirstOrDefault();
+                var healthPt = cached.HealthByDevice.TryGetValue(mac, out var healthPts)
+                    ? healthPts.OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds)).FirstOrDefault()
+                    : null;
 
                 double? fabIn = null, fabOut = null;
                 if ((node.Kind == LanNodeKind.Switch || node.Kind == LanNodeKind.Gateway)
@@ -721,16 +720,12 @@ public class LanFlowMapService
                     _ => (MonitoringTargetType?)null
                 };
                 if (targetType == null) continue;
-                var data = await _influx.QueryLatencyByTargetTypeAsync(targetType.Value, from, to, ct: ct);
                 MonitoringInfluxClient.LatencyPoint? best = null;
-                foreach (var (_, pts) in data)
+                if (cached.LatencyByTargetType.TryGetValue(targetType.Value, out var latPts))
                 {
-                    var closest = pts
+                    best = latPts
                         .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
                         .FirstOrDefault();
-                    if (closest != null && (best == null
-                        || Math.Abs((closest.Time - at).TotalMilliseconds) < Math.Abs((best.Time - at).TotalMilliseconds)))
-                        best = closest;
                 }
                 if (best == null) continue;
                 update.CloudStats[cloud.Id] = new CloudLiveStats
@@ -1781,7 +1776,29 @@ public class LanFlowMapService
         try { wired = await _influx.QueryAllClientThroughputAsync("wired_client", from, to, ct); }
         catch (Exception ex) { _logger.LogDebug(ex, "Historic wired client batch query failed"); }
 
-        return new HistoricDataCache(from, to, ratesByDevice, wifi, wired);
+        var healthByDevice = new Dictionary<string, IReadOnlyList<MonitoringInfluxClient.DeviceHealthPoint>>(
+            StringComparer.OrdinalIgnoreCase);
+        foreach (var node in snapshot.Nodes)
+        {
+            if (string.IsNullOrEmpty(node.Mac)) continue;
+            try
+            {
+                healthByDevice[node.Mac] = await _influx.QueryDeviceHealthRawAsync(node.Mac, from, to, ct);
+            }
+            catch (Exception ex) { _logger.LogDebug(ex, "Historic health fetch failed for {Mac}", node.Mac); }
+        }
+
+        var latencyByType = new Dictionary<MonitoringTargetType, IReadOnlyList<MonitoringInfluxClient.LatencyPoint>>();
+        foreach (var targetType in new[] { MonitoringTargetType.AccessIsp, MonitoringTargetType.Transit })
+        {
+            try
+            {
+                latencyByType[targetType] = await _influx.QueryLatencyByTargetTypeRawAsync(targetType, from, to, ct);
+            }
+            catch (Exception ex) { _logger.LogDebug(ex, "Historic latency fetch failed for {Type}", targetType); }
+        }
+
+        return new HistoricDataCache(from, to, ratesByDevice, wifi, wired, healthByDevice, latencyByType);
     }
 
     private async Task<LinkLiveRates?> QueryClientThroughputAsync(

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -435,7 +435,8 @@ public class LanFlowMapService
         }
         catch { }
 
-        // Collect device MACs we need rates for, then batch into one InfluxDB query.
+        // Per-device queries use the tag index efficiently. Each is a fast
+        // indexed lookup; batching into one OR filter was slower (no index).
         var deviceMacs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (!string.IsNullOrEmpty(gwMac)) deviceMacs.Add(gwMac);
         foreach (var link in snapshot.Links)
@@ -451,15 +452,18 @@ public class LanFlowMapService
                 if (!string.IsNullOrEmpty(mac)) deviceMacs.Add(mac);
             }
         }
-        Dictionary<string, List<MonitoringInfluxClient.InterfaceRatePoint>> ratesByDevice;
-        try
+        var ratesByDevice = new Dictionary<string, IReadOnlyList<MonitoringInfluxClient.InterfaceRatePoint>>(
+            StringComparer.OrdinalIgnoreCase);
+        foreach (var mac in deviceMacs)
         {
-            ratesByDevice = await _influx.QueryBatchInterfaceRatesAsync(deviceMacs, from, to, ct: ct);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Historic batch rate fetch failed");
-            ratesByDevice = new Dictionary<string, List<MonitoringInfluxClient.InterfaceRatePoint>>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                ratesByDevice[mac] = await _influx.QueryInterfaceRatesAsync(mac, from, to, null, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Historic rate fetch failed for device {Mac}", mac);
+            }
         }
 
         // Batch pre-fetch all client throughput from InfluxDB (one query per

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -1556,7 +1556,7 @@ public class MonitoringCollectionAgent : BackgroundService
     // the default fast tier interval (5s) - the data is always at most one fast tick
     // stale, and slower tiers piggyback on whatever the fast tier just fetched.
     // Concurrent callers serialize on _deviceFetchLock so a miss doesn't fan out.
-    private static readonly TimeSpan DeviceCacheTtl = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan DeviceCacheTtl = TimeSpan.FromSeconds(4);
     private List<UniFiDeviceResponse> _cachedDevices = new();
     private DateTime _cachedDevicesAt = DateTime.MinValue;
     private readonly SemaphoreSlim _deviceFetchLock = new(1, 1);

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -673,7 +673,7 @@ from(bucket: ""{_bucket}"")
   |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
   |> filter(fn: (r) => r._measurement == ""device_health"")
   |> filter(fn: (r) => r.device_mac == ""{mac}"")
-  |> filter(fn: (r) => r._field == ""cpu_percent"" or r._field == ""memory_used_percent"" or r._field == ""temperature_c"")
+  |> filter(fn: (r) => r._field == ""cpu_percent"" or r._field == ""memory_used_percent"" or r._field == ""temperature_c"" or r._field == ""uptime_seconds"")
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
@@ -685,7 +685,8 @@ from(bucket: ""{_bucket}"")
                 Time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow),
                 CpuPercent = AsDoubleOrNull(record.GetValueByKey("cpu_percent")),
                 MemoryUsedPercent = AsDoubleOrNull(record.GetValueByKey("memory_used_percent")),
-                TemperatureC = AsDoubleOrNull(record.GetValueByKey("temperature_c"))
+                TemperatureC = AsDoubleOrNull(record.GetValueByKey("temperature_c")),
+                UptimeSeconds = (long?)AsDoubleOrNull(record.GetValueByKey("uptime_seconds"))
             });
         }
         return results;
@@ -702,11 +703,12 @@ from(bucket: ""{_bucket}"")
   |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
   |> filter(fn: (r) => r._measurement == ""device_health"")
   |> filter(fn: (r) => r.device_mac == ""{mac}"")
-  |> filter(fn: (r) => r._field == ""cpu_percent"" or r._field == ""memory_used_percent"" or r._field == ""temperature_c"")
+  |> filter(fn: (r) => r._field == ""cpu_percent"" or r._field == ""memory_used_percent"" or r._field == ""temperature_c"" or r._field == ""uptime_seconds"")
 ";
         var cpu = new Dictionary<long, double>();
         var mem = new Dictionary<long, double>();
         var temp = new Dictionary<long, double>();
+        var uptime = new Dictionary<long, double>();
         var times = new Dictionary<long, DateTime>();
 
         await foreach (var record in QueryFluxAsync(flux, ct))
@@ -720,6 +722,7 @@ from(bucket: ""{_bucket}"")
             if (field == "cpu_percent") cpu[key] = value.Value;
             else if (field == "memory_used_percent") mem[key] = value.Value;
             else if (field == "temperature_c") temp[key] = value.Value;
+            else if (field == "uptime_seconds") uptime[key] = value.Value;
         }
 
         return times.Select(kv => new DeviceHealthPoint
@@ -728,6 +731,7 @@ from(bucket: ""{_bucket}"")
             CpuPercent = cpu.TryGetValue(kv.Key, out var c) ? c : null,
             MemoryUsedPercent = mem.TryGetValue(kv.Key, out var m) ? m : null,
             TemperatureC = temp.TryGetValue(kv.Key, out var t) ? t : null,
+            UptimeSeconds = uptime.TryGetValue(kv.Key, out var u) ? (long?)u : null,
         }).ToList();
     }
 
@@ -1193,6 +1197,7 @@ from(bucket: ""{_longtermBucket}"")
         public double? CpuPercent { get; init; }
         public double? MemoryUsedPercent { get; init; }
         public double? TemperatureC { get; init; }
+        public long? UptimeSeconds { get; init; }
     }
 
     public record LatencyPoint

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -508,6 +508,59 @@ from(bucket: ""{_bucket}"")
     }
 
     /// <summary>
+    /// Raw interface rate query for a single device - no aggregateWindow, no pivot.
+    /// Returns raw rate_in_bps and rate_out_bps points paired in C#. Much cheaper
+    /// than the aggregated variant for short-range playback where data is already
+    /// at native 5s cadence.
+    /// </summary>
+    public async Task<IReadOnlyList<InterfaceRatePoint>> QueryInterfaceRatesRawAsync(
+        string deviceMac,
+        DateTime from,
+        DateTime to,
+        CancellationToken ct = default)
+    {
+        if (!IsConfigured) return Array.Empty<InterfaceRatePoint>();
+        var mac = NormalizeMac(deviceMac);
+        var flux = $@"
+from(bucket: ""{_bucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""interface_counters"")
+  |> filter(fn: (r) => r.device_mac == ""{mac}"")
+  |> filter(fn: (r) => r._field == ""rate_in_bps"" or r._field == ""rate_out_bps"")
+";
+        var rateIn = new Dictionary<(string ifName, long ticks), double>();
+        var rateOut = new Dictionary<(string ifName, long ticks), double>();
+        var times = new Dictionary<(string ifName, long ticks), DateTime>();
+
+        await foreach (var record in QueryFluxAsync(flux, ct))
+        {
+            var ifName = record.GetValueByKey("if_name") as string ?? "?";
+            var time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow);
+            var field = record.GetValueByKey("_field") as string;
+            var value = AsDoubleOrNull(record.GetValueByKey("_value"));
+            if (value == null) continue;
+
+            var key = (ifName, time.Ticks);
+            times[key] = time;
+            if (field == "rate_in_bps") rateIn[key] = value.Value;
+            else if (field == "rate_out_bps") rateOut[key] = value.Value;
+        }
+
+        var results = new List<InterfaceRatePoint>(times.Count);
+        foreach (var (key, time) in times)
+        {
+            results.Add(new InterfaceRatePoint
+            {
+                Time = time,
+                IfName = key.ifName,
+                RateInBps = rateIn.TryGetValue(key, out var ri) ? ri : null,
+                RateOutBps = rateOut.TryGetValue(key, out var ro) ? ro : null,
+            });
+        }
+        return results;
+    }
+
+    /// <summary>
     /// Batch variant: fetches interface rates for a set of devices in one query.
     /// Returns results grouped by device MAC for caller-side partitioning.
     /// </summary>

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -508,21 +508,27 @@ from(bucket: ""{_bucket}"")
     }
 
     /// <summary>
-    /// Batch variant: fetches interface rates for ALL devices in one query.
+    /// Batch variant: fetches interface rates for a set of devices in one query.
     /// Returns results grouped by device MAC for caller-side partitioning.
     /// </summary>
-    public async Task<Dictionary<string, List<InterfaceRatePoint>>> QueryAllInterfaceRatesAsync(
+    public async Task<Dictionary<string, List<InterfaceRatePoint>>> QueryBatchInterfaceRatesAsync(
+        IEnumerable<string> deviceMacs,
         DateTime from,
         DateTime to,
         TimeSpan? aggregateWindow = null,
         CancellationToken ct = default)
     {
         if (!IsConfigured) return new Dictionary<string, List<InterfaceRatePoint>>(StringComparer.OrdinalIgnoreCase);
+        var macs = deviceMacs.Select(NormalizeMac).Distinct().ToList();
+        if (macs.Count == 0) return new Dictionary<string, List<InterfaceRatePoint>>(StringComparer.OrdinalIgnoreCase);
+
         var window = aggregateWindow ?? PickAggregateWindow(to - from);
+        var macFilter = string.Join(" or ", macs.Select(m => $@"r.device_mac == ""{m}"""));
         var flux = $@"
 from(bucket: ""{_bucket}"")
   |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
   |> filter(fn: (r) => r._measurement == ""interface_counters"")
+  |> filter(fn: (r) => {macFilter})
   |> filter(fn: (r) => r._field == ""rate_in_bps"" or r._field == ""rate_out_bps"")
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -691,6 +691,89 @@ from(bucket: ""{_bucket}"")
         return results;
     }
 
+    /// <summary>Raw device health query - no aggregation, pairs fields in C#.</summary>
+    public async Task<IReadOnlyList<DeviceHealthPoint>> QueryDeviceHealthRawAsync(
+        string deviceMac, DateTime from, DateTime to, CancellationToken ct = default)
+    {
+        if (!IsConfigured) return Array.Empty<DeviceHealthPoint>();
+        var mac = NormalizeMac(deviceMac);
+        var flux = $@"
+from(bucket: ""{_bucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""device_health"")
+  |> filter(fn: (r) => r.device_mac == ""{mac}"")
+  |> filter(fn: (r) => r._field == ""cpu_percent"" or r._field == ""memory_used_percent"" or r._field == ""temperature_c"")
+";
+        var cpu = new Dictionary<long, double>();
+        var mem = new Dictionary<long, double>();
+        var temp = new Dictionary<long, double>();
+        var times = new Dictionary<long, DateTime>();
+
+        await foreach (var record in QueryFluxAsync(flux, ct))
+        {
+            var time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow);
+            var field = record.GetValueByKey("_field") as string;
+            var value = AsDoubleOrNull(record.GetValueByKey("_value"));
+            if (value == null) continue;
+            var key = time.Ticks;
+            times[key] = time;
+            if (field == "cpu_percent") cpu[key] = value.Value;
+            else if (field == "memory_used_percent") mem[key] = value.Value;
+            else if (field == "temperature_c") temp[key] = value.Value;
+        }
+
+        return times.Select(kv => new DeviceHealthPoint
+        {
+            Time = kv.Value,
+            CpuPercent = cpu.TryGetValue(kv.Key, out var c) ? c : null,
+            MemoryUsedPercent = mem.TryGetValue(kv.Key, out var m) ? m : null,
+            TemperatureC = temp.TryGetValue(kv.Key, out var t) ? t : null,
+        }).ToList();
+    }
+
+    /// <summary>Raw latency query by target type - no aggregation, pairs fields in C#.</summary>
+    public async Task<IReadOnlyList<LatencyPoint>> QueryLatencyByTargetTypeRawAsync(
+        MonitoringTargetType targetType, DateTime from, DateTime to, CancellationToken ct = default)
+    {
+        if (!IsConfigured) await ReconfigureAsync(ct);
+        if (!IsConfigured) return Array.Empty<LatencyPoint>();
+        var typeTag = targetType.ToString().ToLowerInvariant();
+        var typeFilter = targetType == MonitoringTargetType.InternetService
+            ? @"r.target_type == ""internetservice"" or r.target_type == ""wan"""
+            : $@"r.target_type == ""{typeTag}""";
+        var flux = $@"
+from(bucket: ""{_bucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""latency"")
+  |> filter(fn: (r) => {typeFilter})
+  |> filter(fn: (r) => r._field == ""rtt_avg_ms"" or r._field == ""loss_percent"")
+";
+        var rtt = new Dictionary<(string targetId, long ticks), double>();
+        var loss = new Dictionary<(string targetId, long ticks), double>();
+        var times = new Dictionary<(string targetId, long ticks), DateTime>();
+
+        await foreach (var record in QueryFluxAsync(flux, ct))
+        {
+            var targetId = record.GetValueByKey("target_id") as string;
+            if (string.IsNullOrEmpty(targetId)) continue;
+            var time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow);
+            var field = record.GetValueByKey("_field") as string;
+            var value = AsDoubleOrNull(record.GetValueByKey("_value"));
+            if (value == null) continue;
+            var key = (targetId, time.Ticks);
+            times[key] = time;
+            if (field == "rtt_avg_ms") rtt[key] = value.Value;
+            else if (field == "loss_percent") loss[key] = value.Value;
+        }
+
+        return times.Select(kv => new LatencyPoint
+        {
+            Time = kv.Value,
+            RttAvgMs = rtt.TryGetValue(kv.Key, out var r) ? r : null,
+            LossPercent = loss.TryGetValue(kv.Key, out var l) ? l : null,
+        }).ToList();
+    }
+
     /// <summary>Time-series of RTT and loss for multiple monitoring targets, keyed by target_id.</summary>
     public async Task<Dictionary<string, List<LatencyPoint>>> QueryLatencyByTargetTypeAsync(
         MonitoringTargetType targetType,

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -507,6 +507,47 @@ from(bucket: ""{_bucket}"")
         return results;
     }
 
+    /// <summary>
+    /// Batch variant: fetches interface rates for ALL devices in one query.
+    /// Returns results grouped by device MAC for caller-side partitioning.
+    /// </summary>
+    public async Task<Dictionary<string, List<InterfaceRatePoint>>> QueryAllInterfaceRatesAsync(
+        DateTime from,
+        DateTime to,
+        TimeSpan? aggregateWindow = null,
+        CancellationToken ct = default)
+    {
+        if (!IsConfigured) return new Dictionary<string, List<InterfaceRatePoint>>(StringComparer.OrdinalIgnoreCase);
+        var window = aggregateWindow ?? PickAggregateWindow(to - from);
+        var flux = $@"
+from(bucket: ""{_bucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""interface_counters"")
+  |> filter(fn: (r) => r._field == ""rate_in_bps"" or r._field == ""rate_out_bps"")
+  |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
+  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
+";
+        var results = new Dictionary<string, List<InterfaceRatePoint>>(StringComparer.OrdinalIgnoreCase);
+        await foreach (var record in QueryFluxAsync(flux, ct))
+        {
+            var mac = record.GetValueByKey("device_mac") as string ?? "";
+            var point = new InterfaceRatePoint
+            {
+                Time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow),
+                IfName = record.GetValueByKey("if_name") as string ?? "?",
+                RateInBps = AsDoubleOrNull(record.GetValueByKey("rate_in_bps")),
+                RateOutBps = AsDoubleOrNull(record.GetValueByKey("rate_out_bps"))
+            };
+            if (!results.TryGetValue(mac, out var list))
+            {
+                list = new List<InterfaceRatePoint>();
+                results[mac] = list;
+            }
+            list.Add(point);
+        }
+        return results;
+    }
+
     public async Task<IReadOnlyList<WanRatePoint>> QueryGatewayWanRatesAsync(
         string deviceMac,
         IReadOnlyList<string> wanIfNames,

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -847,7 +847,7 @@ class LanFlowMap2D {
 
         for(const k of kids)this._contourLayout(k);
 
-        const GAP=40;
+        const GAP=30;
         const offsets=[];
         let groupRight=[];
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -474,6 +474,8 @@ class LanFlowMap2D {
             const key=e.key.toLowerCase();
             if(key==='arrowleft'||key==='arrowright'){
                 if(inst._keys)inst._keys[key]=true;
+            }else if(key==='shift'){
+                if(inst._keys)inst._keys.shift=true;
             }else if(key===' '){
                 inst._togglePlayPause();
             }
@@ -481,7 +483,11 @@ class LanFlowMap2D {
         sRange.addEventListener('keyup',(e)=>{
             const inst=fwd();if(!inst)return;
             const key=e.key.toLowerCase();
-            if(inst._keys)inst._keys[key]=false;
+            if(key==='shift'){
+                if(inst._keys)inst._keys.shift=false;
+            }else if(inst._keys){
+                inst._keys[key]=false;
+            }
         });
         sRange.addEventListener('input',(e)=>{
             const inst=fwd();if(inst){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -468,6 +468,21 @@ class LanFlowMap2D {
         sRange.addEventListener('pointerdown',()=>{
             const inst=fwd();if(inst)inst._stopHistoricPlayback?.();
         });
+        sRange.addEventListener('keydown',(e)=>{
+            e.preventDefault();
+            const inst=fwd();if(!inst)return;
+            const key=e.key.toLowerCase();
+            if(key==='arrowleft'||key==='arrowright'){
+                if(inst._keys)inst._keys[key]=true;
+            }else if(key===' '){
+                inst._togglePlayPause();
+            }
+        });
+        sRange.addEventListener('keyup',(e)=>{
+            const inst=fwd();if(!inst)return;
+            const key=e.key.toLowerCase();
+            if(inst._keys)inst._keys[key]=false;
+        });
         sRange.addEventListener('input',(e)=>{
             const inst=fwd();if(inst){
                 const r=inst._panels?.scrubberRange;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -2,7 +2,7 @@
 // Subscribes to lan-flow-data.js (published by the 3D map) so there are
 // zero duplicate API calls. GPU-composited canvas for smooth particle animation.
 
-import * as flowData from './lan-flow-data.js';
+import * as flowData from './lan-flow-data.js?v=1';
 
 // ---- Color palette (matches 3D map) ----
 const C = {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -465,6 +465,9 @@ class LanFlowMap2D {
         // Forward all interactions to the 3D map
         const fwd=()=>window.__lanFlowMap?.getInstance?.();
         const sRange=scrubber.querySelector('.lan-flow-map-scrubber-range');
+        sRange.addEventListener('pointerdown',()=>{
+            const inst=fwd();if(inst)inst._stopHistoricPlayback?.();
+        });
         sRange.addEventListener('input',(e)=>{
             const inst=fwd();if(inst){
                 const r=inst._panels?.scrubberRange;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -471,23 +471,19 @@ class LanFlowMap2D {
         sRange.addEventListener('keydown',(e)=>{
             e.preventDefault();
             const inst=fwd();if(!inst)return;
+            if(e.key===' '){inst._togglePlayPause();return;}
+            if(e.key==='Shift'){if(inst._keys)inst._keys.shift=true;return;}
             const key=e.key.toLowerCase();
             if(key==='arrowleft'||key==='arrowright'){
                 if(inst._keys)inst._keys[key]=true;
-            }else if(key==='shift'){
-                if(inst._keys)inst._keys.shift=true;
-            }else if(key===' '){
-                inst._togglePlayPause();
             }
         });
         sRange.addEventListener('keyup',(e)=>{
             const inst=fwd();if(!inst)return;
+            if(e.key==='Shift'){if(inst._keys)inst._keys.shift=false;return;}
             const key=e.key.toLowerCase();
-            if(key==='shift'){
-                if(inst._keys)inst._keys.shift=false;
-            }else if(inst._keys){
-                inst._keys[key]=false;
-            }
+            if(inst._keys)inst._keys[key]=false;
+            if(e.key==='ArrowLeft'||e.key==='ArrowRight')inst._arrowScrubStart=null;
         });
         sRange.addEventListener('input',(e)=>{
             const inst=fwd();if(inst){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -847,7 +847,7 @@ class LanFlowMap2D {
 
         for(const k of kids)this._contourLayout(k);
 
-        const GAP=30;
+        const GAP=20;
         const offsets=[];
         let groupRight=[];
 
@@ -1398,7 +1398,7 @@ class LanFlowMap2D {
         // Name label
         const name=n.d.name||n.d.model||'';
         if(name){
-            const dn=name.length>16?name.slice(0,15)+'…':name;
+            const dn=name.length>24?name.slice(0,23)+'…':name;
             ctx.fillStyle=C.text;
             ctx.font=`500 ${G.nameFont}px ${FONT}`;
             ctx.textAlign='center'; ctx.textBaseline='top';
@@ -1435,7 +1435,7 @@ class LanFlowMap2D {
         // Name label
         const name=n.d.name||n.d.ip||'';
         if(name){
-            const dn=name.length>25?name.slice(0,24)+'…':name;
+            const dn=name.length>32?name.slice(0,31)+'…':name;
             ctx.fillStyle=C.textMuted;
             ctx.font=`${G.clientFont}px ${FONT}`;
             ctx.textAlign='center'; ctx.textBaseline='top';

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -13,7 +13,7 @@ import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
 import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
 import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
-import { buildBuildings } from './lan-flow-buildings.js';
+import { buildBuildings } from './lan-flow-buildings.js?v=1';
 import * as flowData from './lan-flow-data.js?v=1';
 
 const COLORS = {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1575,7 +1575,10 @@ export class LanFlowMap {
             // Refresh map and stat cards periodically
             if (tickCount % DATA_REFRESH_TICKS === 0 || clamped >= 9998) {
                 if (clamped >= 9998) {
-                    this._stopHistoricPlayback();
+                    if (this._historicPlaybackTimer) {
+                        clearInterval(this._historicPlaybackTimer);
+                        this._historicPlaybackTimer = null;
+                    }
                     this._onScrubberChange(10000);
                 } else {
                     this._historicAt = this._playbackTime;
@@ -2091,6 +2094,7 @@ export class LanFlowMap {
         // method on every tick (to load the historic snapshot for the new
         // slider position); skip the auto-pause in that case or playback
         // would stop after one tick.
+        if (this._mode !== 'historic') return;
         if (!this._playbackAdvancing && !this._speedTransition && !this._paused) {
             this._paused = true;
             this._syncPlayPauseIcon();

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1323,6 +1323,7 @@ export class LanFlowMap {
             // Accelerates after holding: 4 → 12 → 35 units/tick over 2 seconds.
             // Shift multiplies by 9x on top of acceleration.
             if (this._keys?.['arrowleft'] || this._keys?.['arrowright']) {
+                if (this._historicPlaybackTimer) this._stopHistoricPlayback();
                 const now = performance.now();
                 if (!this._arrowScrubStart) this._arrowScrubStart = now;
                 if (!this._lastArrowScrub || now - this._lastArrowScrub >= 200) {
@@ -1542,7 +1543,6 @@ export class LanFlowMap {
 
     _startHistoricPlayback() {
         if (this._historicPlaybackTimer) return;
-        this._playbackAdvancing = true;
         // Track playback as a continuous timestamp, not integer slider units.
         const TICK_MS = 1000;
         const DATA_REFRESH_TICKS = 1;
@@ -1590,7 +1590,6 @@ export class LanFlowMap {
     }
 
     _stopHistoricPlayback() {
-        this._playbackAdvancing = false;
         if (this._historicPlaybackTimer) {
             clearInterval(this._historicPlaybackTimer);
             this._historicPlaybackTimer = null;
@@ -2095,10 +2094,9 @@ export class LanFlowMap {
         // slider position); skip the auto-pause in that case or playback
         // would stop after one tick.
         if (this._mode !== 'historic') return;
-        if (!this._playbackAdvancing && !this._speedTransition && !this._paused) {
+        if (!this._historicPlaybackTimer && !this._speedTransition && !this._paused) {
             this._paused = true;
             this._syncPlayPauseIcon();
-            this._stopHistoricPlayback();
         }
         flowData.publishPlayState(this._paused, this._mode);
         this._notifyStatCards(at);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1862,8 +1862,11 @@ export class LanFlowMap {
                     const now = Date.now();
                     const span = now - this._scrubberOrigin;
                     const nearNow = span > 0 ? Math.floor((now - 5000 - this._scrubberOrigin) / span * 10000) : 9997;
+                    const clamped = Math.min(nearNow, 9997);
+                    if (this._panels.scrubberRange) this._panels.scrubberRange.value = clamped;
+                    this._onScrubberInput(clamped);
                     this._speedTransition = true;
-                    this._onScrubberChange(Math.min(nearNow, 9997));
+                    this._onScrubberChange(clamped);
                     this._speedTransition = false;
                     this._startHistoricPlayback();
                 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -14,7 +14,7 @@ import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
 import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 import { buildBuildings } from './lan-flow-buildings.js';
-import * as flowData from './lan-flow-data.js';
+import * as flowData from './lan-flow-data.js?v=1';
 
 const COLORS = {
     background: 0x202023,

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1542,6 +1542,7 @@ export class LanFlowMap {
 
     _startHistoricPlayback() {
         if (this._historicPlaybackTimer) return;
+        this._playbackAdvancing = true;
         // Track playback as a continuous timestamp, not integer slider units.
         const TICK_MS = 1000;
         const DATA_REFRESH_TICKS = 1;
@@ -1573,24 +1574,20 @@ export class LanFlowMap {
             tickCount++;
             // Refresh map and stat cards periodically
             if (tickCount % DATA_REFRESH_TICKS === 0 || clamped >= 9998) {
-                this._playbackAdvancing = true;
-                try {
-                    if (clamped >= 9998) {
-                        this._stopHistoricPlayback();
-                        this._onScrubberChange(10000);
-                    } else {
-                        this._historicAt = this._playbackTime;
-                        this._notifyStatCards(this._playbackTime);
-                        this._loadHistoric(this._playbackTime);
-                    }
-                } finally {
-                    this._playbackAdvancing = false;
+                if (clamped >= 9998) {
+                    this._stopHistoricPlayback();
+                    this._onScrubberChange(10000);
+                } else {
+                    this._historicAt = this._playbackTime;
+                    this._notifyStatCards(this._playbackTime);
+                    this._loadHistoric(this._playbackTime);
                 }
             }
         }, TICK_MS);
     }
 
     _stopHistoricPlayback() {
+        this._playbackAdvancing = false;
         if (this._historicPlaybackTimer) {
             clearInterval(this._historicPlaybackTimer);
             this._historicPlaybackTimer = null;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1546,8 +1546,8 @@ export class LanFlowMap {
         // Track playback as a continuous timestamp, not integer slider units.
         const TICK_MS = 1000;
         const DATA_REFRESH_TICKS = 1;
-        this._playbackTime = this._historicAt
-            || this._scrubberValueToTime(Number(this._panels.scrubberRange?.value ?? 500));
+        this._playbackTime = this._scrubberValueToTime(
+            Number(this._panels.scrubberRange?.value ?? 500));
         let tickCount = 0;
         this._historicPlaybackTimer = setInterval(() => {
             if (this._paused) return;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2136,11 +2136,13 @@ export class LanFlowMap {
     }
 
     async _loadHistoric(at) {
+        const gen = this._historicGen = (this._historicGen || 0) + 1;
         try {
             const url = `${this.apiBase}/history?at=${encodeURIComponent(at.toISOString())}`;
             const res = await fetch(url, { credentials: 'same-origin' });
-            if (!res.ok) return;
+            if (!res.ok || gen !== this._historicGen) return;
             const update = await res.json();
+            if (gen !== this._historicGen) return;
             flowData.publishLive(update);
             this._applyLiveRates(update.linkRates || {});
             if (update.nodeBadges) this._currentBadges = update.nodeBadges;


### PR DESCRIPTION
## Summary

- **Device cache TTL** - Reverted monitoring agent device cache from 30s to 4s. The 30s TTL caused `UpdatePortRatesFromUnifi` to see stale byte counters, producing zero deltas and killing port rate data. The upstream 15s API cache in `UniFiApiClient` already handles call reduction.
- **Historic playback optimization** - Raw InfluxDB queries (no aggregateWindow/pivot) for interface rates, device health, and latency. Results cached for 5 min of forward playback so consecutive ticks don't re-query. Cuts InfluxDB CPU from ~40% sustained to a brief spike every ~4 minutes.
- **SNMP uptime fix** - `ConvertSnmpValue<long>` failed on TimeTicks data because `ToString()` returns formatted text like "1 day, 9:12:14.40 (11953440)", not raw ticks. Now extracts via `TimeTicks.ToUInt32()`. Also added `uptime_seconds` to device health queries and historic playback badges.
- **Scrubber interaction fixes** - Fixed play button auto-pausing after scrub (async race), historic-to-live transition flicker, scrub-during-playback not stopping the timer, 0.5x speed from live not setting slider position, and playback starting from stale position after fast scrubbing.
- **2D scrubber parity** - Forward `pointerdown`, keyboard events (arrows, Shift, Space), and `arrowScrubStart` reset from the 2D scrubber to the 3D map's handlers.
- **Cache busting** - Version query strings on `lan-flow-data.js` and `lan-flow-buildings.js` ES module imports.
- **2D layout** - Tightened horizontal node spacing (GAP 40 to 20), increased device name limit (16 to 24 chars), client name limit (25 to 32 chars), ISP expected rates styled italic/muted.

## Test plan

- [x] Port rates flow on non-SNMP sites (Mac site verified)
- [x] Historic playback InfluxDB CPU stays low (~1% between cache fills)
- [x] SNMP uptime shows real values in live and historic tooltips
- [x] All scrubber scenarios verified: play/pause, arrow keys, Shift acceleration, pointer drag, speed changes, live transitions - across both 2D and 3D inputs
- [x] 0 build warnings, all tests pass