### PR TITLE
More SNMP setup guidance

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -696,7 +696,7 @@ else
                     <details class="setup-guide" style="margin-top: 1.25rem;">
                         <summary>Not seeing data for some devices?</summary>
                         <div class="setup-guide-content">
-                            <p>SNMP must be enabled on each device individually in addition to the global console setting:</p>
+                            <p>SNMP must be enabled on each device individually in addition to the global Console setting:</p>
                             <ol>
                                 <li>In UniFi Network, go to <strong>UniFi Devices</strong></li>
                                 <li>Select a device</li>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -692,6 +692,20 @@ else
                             }
                         }
                     </div>
+
+                    <details class="setup-guide" style="margin-top: 1.25rem;">
+                        <summary>Not seeing data for some devices?</summary>
+                        <div class="setup-guide-content">
+                            <p>SNMP must be enabled on each device individually in addition to the global console setting:</p>
+                            <ol>
+                                <li>In UniFi Network, go to <strong>UniFi Devices</strong></li>
+                                <li>Select a device</li>
+                                <li>Open <strong>Settings</strong>, tick <strong>SNMP</strong> on</li>
+                                <li>Set a <strong>Location</strong> or <strong>Contact</strong> value, then <strong>Save</strong></li>
+                            </ol>
+                            <p>Devices without per-device SNMP enabled will not report port-level traffic or health metrics.</p>
+                        </div>
+                    </details>
                 </div>
             </div>
         }


### PR DESCRIPTION
## Self-Hosted Network Monitoring

- **Per-device SNMP setup guidance** - The monitoring wizard and status page now include instructions for enabling SNMP on individual UniFi devices. SNMP must be enabled per-device (with a Location or Contact value set) in addition to the global console setting - devices without it are silently skipped by the poller.