### PR TITLE
Fix intermittent live map link rate gaps and ISP RTT selection

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -151,7 +151,7 @@ else
                 }
                 <div class="stat-label">ISP Loss</div>
             </div>
-            @{ var transitTarget = GetBestTargetStats(MonitoringTargetType.Transit); }
+            @{ var transitTarget = GetMeanTargetStats(MonitoringTargetType.Transit); }
             <div class="monitoring-stat-card">
                 @if (hasTransitTargets)
                 {
@@ -1501,7 +1501,6 @@ else
             return type switch
             {
                 MonitoringTargetType.AccessIsp => (_historicSnapshot.IspRttMs, _historicSnapshot.IspLossPercent),
-                MonitoringTargetType.Transit => (_historicSnapshot.TransitRttMs, _historicSnapshot.TransitLossPercent),
                 _ => (null, 0)
             };
         }
@@ -1521,6 +1520,30 @@ else
             }
         }
         return (bestRtt, bestLoss);
+    }
+
+    private (double? rtt, double loss) GetMeanTargetStats(MonitoringTargetType type)
+    {
+        if (_historicSnapshot != null)
+        {
+            return type switch
+            {
+                MonitoringTargetType.Transit => (_historicSnapshot.TransitRttMs, _historicSnapshot.TransitLossPercent),
+                _ => (null, 0)
+            };
+        }
+        var targets = _targets.Where(t => t.TargetType == type && t.Enabled).ToList();
+        if (targets.Count == 0) return (null, 0);
+
+        var rtts = new List<double>();
+        var losses = new List<double>();
+        foreach (var t in targets)
+        {
+            var s = LiveStats.GetTargetStats(t.TargetId);
+            if (s?.RttAvgMs != null) rtts.Add(s.RttAvgMs.Value);
+            if (s != null) losses.Add(s.LossPercent);
+        }
+        return (rtts.Count > 0 ? rtts.Average() : null, losses.Count > 0 ? losses.Average() : 0);
     }
 
     private (double ingress, double egress) GetTotalFabricLoad()

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -128,7 +128,7 @@ else
                 <div class="stat-value @(gwLatency.loss > 0 ? "stat-danger" : "")">@FormatLoss(gwLatency.loss)</div>
                 <div class="stat-label">Gateway Loss</div>
             </div>
-            @{ var ispTarget = GetMeanTargetStats(MonitoringTargetType.AccessIsp); }
+            @{ var ispTarget = GetBestTargetStats(MonitoringTargetType.AccessIsp); }
             <div class="monitoring-stat-card">
                 @if (hasIspTargets)
                 {
@@ -151,7 +151,7 @@ else
                 }
                 <div class="stat-label">ISP Loss</div>
             </div>
-            @{ var transitTarget = GetMeanTargetStats(MonitoringTargetType.Transit); }
+            @{ var transitTarget = GetBestTargetStats(MonitoringTargetType.Transit); }
             <div class="monitoring-stat-card">
                 @if (hasTransitTargets)
                 {
@@ -1494,7 +1494,7 @@ else
         return (s?.RttAvgMs, s?.LossPercent ?? 0);
     }
 
-    private (double? rtt, double loss) GetMeanTargetStats(MonitoringTargetType type)
+    private (double? rtt, double loss) GetBestTargetStats(MonitoringTargetType type)
     {
         if (_historicSnapshot != null)
         {
@@ -1508,15 +1508,19 @@ else
         var targets = _targets.Where(t => t.TargetType == type && t.Enabled).ToList();
         if (targets.Count == 0) return (null, 0);
 
-        var rtts = new List<double>();
-        var losses = new List<double>();
+        // Pick the target with the lowest RTT (nearest ISP infrastructure).
+        double? bestRtt = null;
+        double bestLoss = 0;
         foreach (var t in targets)
         {
             var s = LiveStats.GetTargetStats(t.TargetId);
-            if (s?.RttAvgMs != null) rtts.Add(s.RttAvgMs.Value);
-            if (s != null) losses.Add(s.LossPercent);
+            if (s?.RttAvgMs != null && (bestRtt == null || s.RttAvgMs.Value < bestRtt.Value))
+            {
+                bestRtt = s.RttAvgMs;
+                bestLoss = s.LossPercent;
+            }
         }
-        return (rtts.Count > 0 ? rtts.Average() : null, losses.Count > 0 ? losses.Average() : 0);
+        return (bestRtt, bestLoss);
     }
 
     private (double ingress, double egress) GetTotalFabricLoad()

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
@@ -200,10 +200,10 @@ public class LanCloud
     /// <summary>ISP expected upload speed in Mbps (from UniFi WAN provider capabilities).</summary>
     public int? IspUploadMbps { get; set; }
 
-    /// <summary>Monitoring target ID whose live RTT feeds this cloud's stats.
-    /// Server-side only; the live tick re-queries this for fresh RTT/loss.</summary>
+    /// <summary>Monitoring target IDs for all access hops on this WAN.
+    /// Server-side only; the live tick picks the lowest RTT across all of them.</summary>
     [System.Text.Json.Serialization.JsonIgnore]
-    public string? RttTargetId { get; set; }
+    public List<string> RttTargetIds { get; set; } = new();
 }
 
 public class LinkLiveRates

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -369,22 +369,33 @@ public class LanFlowMapService
             };
         }
 
-        // Cloud RTT from the live monitoring target cache (same source as the
-        // ISP RTT stat card) so the globe label stays in lockstep.
+        // Cloud RTT: pick the lowest RTT across all access hop targets for this
+        // WAN so the globe shows the nearest ISP infrastructure latency, not a
+        // deeper transit hop that happens to be last in the wizard ordering.
         foreach (var cloud in snapshot.Clouds)
         {
             double? rtt = cloud.RttAvgMs;
             double? loss = cloud.LossPercent;
             bool success = rtt.HasValue;
 
-            if (!string.IsNullOrEmpty(cloud.RttTargetId))
+            if (cloud.RttTargetIds.Count > 0)
             {
-                var live = _liveStats.GetTargetStats(cloud.RttTargetId);
-                if (live != null)
+                double? bestRtt = null;
+                double? bestLoss = null;
+                foreach (var targetId in cloud.RttTargetIds)
                 {
-                    rtt = live.RttAvgMs;
-                    loss = live.LossPercent;
-                    success = live.RttAvgMs.HasValue;
+                    var live = _liveStats.GetTargetStats(targetId);
+                    if (live?.RttAvgMs != null && (bestRtt == null || live.RttAvgMs.Value < bestRtt.Value))
+                    {
+                        bestRtt = live.RttAvgMs;
+                        bestLoss = live.LossPercent;
+                    }
+                }
+                if (bestRtt.HasValue)
+                {
+                    rtt = bestRtt;
+                    loss = bestLoss;
+                    success = true;
                 }
             }
 
@@ -1275,16 +1286,21 @@ public class LanFlowMapService
                 IsDiscoveryPending = wan.IsPrimary && upstream.Access.Hops.Count == 0,
                 Tier = wan.IsPrimary && upstream.Access.Hops.Count == 0 ? LanCloudTier.Unresolved : LanCloudTier.Solid,
             };
-            // RTT for the access cloud: pick the deepest hop with live data (closest to the
-            // ISP boundary). Wizard-output ordering puts BNG/CMTS/OLT toward the tail.
-            var lastLive = upstream.Access.Hops
-                .Reverse()
-                .FirstOrDefault(h => h.Live != null && h.Live.Success);
-            if (lastLive?.Live != null)
+            // Collect all access hop target IDs so the live tick can pick the
+            // lowest RTT across all of them (closest ISP infrastructure).
+            accessCloud.RttTargetIds = upstream.Access.Hops
+                .Where(h => !string.IsNullOrEmpty(h.TargetId))
+                .Select(h => h.TargetId)
+                .ToList();
+            // Seed the initial RTT from the lowest-latency hop with live data.
+            var bestLive = upstream.Access.Hops
+                .Where(h => h.Live != null && h.Live.Success && h.Live.RttAvgMs.HasValue)
+                .OrderBy(h => h.Live!.RttAvgMs!.Value)
+                .FirstOrDefault();
+            if (bestLive?.Live != null)
             {
-                accessCloud.RttAvgMs = lastLive.Live.RttAvgMs;
-                accessCloud.LossPercent = lastLive.Live.LossPercent;
-                accessCloud.RttTargetId = lastLive.TargetId;
+                accessCloud.RttAvgMs = bestLive.Live.RttAvgMs;
+                accessCloud.LossPercent = bestLive.Live.LossPercent;
             }
             // ISP expected speeds from UniFi WAN provider capabilities (cached in topology)
             var wanNet = topology.Networks.FirstOrDefault(n =>

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -1446,19 +1446,26 @@ public class MonitoringCollectionAgent : BackgroundService
                 if (deltaOut < 0 && !useHc) deltaOut += (long)uint.MaxValue + 1;
                 if (deltaIn >= 0 && deltaOut >= 0)
                 {
-                    rateInBps = deltaIn * 8.0 / elapsed;
-                    rateOutBps = deltaOut * 8.0 / elapsed;
-                    // Mirror into the read-side per-port cache so the 3D map's
-                    // live tick refreshes wired client leaf rates on the clean
-                    // 5s SNMP cadence (UniFi PortTable lags ~30s).
-                    // Direction: rateOutBps = port TX = data toward the leaf
-                    // (DownBps in cache convention); rateInBps = port RX = data
-                    // from the leaf (UpBps).
-                    _liveStats.RecordPortRate(mac, ifName, rateOutBps.Value, rateInBps.Value, now);
+                    if (deltaIn == 0 && deltaOut == 0)
+                    {
+                        // Counters unchanged - device hasn't refreshed them yet.
+                        // Keep the previous cache entry so the next poll that sees
+                        // a real change computes delta/elapsed over the true window.
+                        // Prevents alternating 0 / 2x sawtooth in both the live
+                        // cache and InfluxDB.
+                    }
+                    else
+                    {
+                        rateInBps = deltaIn * 8.0 / elapsed;
+                        rateOutBps = deltaOut * 8.0 / elapsed;
+                        _liveStats.RecordPortRate(mac, ifName, rateOutBps.Value, rateInBps.Value, now);
+                        _counterCache[key] = new CounterSnapshot(now, iface.InOctets, iface.OutOctets);
+                    }
                 }
             }
         }
-        _counterCache[key] = new CounterSnapshot(now, iface.InOctets, iface.OutOctets);
+        if (!_counterCache.ContainsKey(key))
+            _counterCache[key] = new CounterSnapshot(now, iface.InOctets, iface.OutOctets);
 
         bool hcCounters = iface.HighSpeed >= 1000 || iface.Speed >= 1_000_000_000;
         long speedBps = iface.HighSpeed > 0 ? iface.HighSpeed * 1_000_000L : iface.Speed;

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -597,6 +597,9 @@ public class MonitoringCollectionAgent : BackgroundService
                             }
                             else
                             {
+                                // Device perspective: TX = device sends out (upstream away
+                                // from the device); RX = device receives (downstream toward
+                                // the device). Opposite convention vs the port path above.
                                 _deviceByteRateLatest[devKey] = (deltaRx * 8.0 / elapsed, deltaTx * 8.0 / elapsed);
                                 _deviceBytePrev[devKey] = devCurrent;
                             }
@@ -1470,6 +1473,12 @@ public class MonitoringCollectionAgent : BackgroundService
                     {
                         rateInBps = deltaIn * 8.0 / elapsed;
                         rateOutBps = deltaOut * 8.0 / elapsed;
+                        // Mirror into the read-side per-port cache so the 3D map's
+                        // live tick refreshes wired client leaf rates on the clean
+                        // 5s SNMP cadence (UniFi PortTable lags ~30s).
+                        // Direction: rateOutBps = port TX = data toward the leaf
+                        // (DownBps in cache convention); rateInBps = port RX = data
+                        // from the leaf (UpBps).
                         _liveStats.RecordPortRate(mac, ifName, rateOutBps.Value, rateInBps.Value, now);
                         _counterCache[key] = new CounterSnapshot(now, iface.InOctets, iface.OutOctets);
                     }

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -554,6 +554,16 @@ public class MonitoringCollectionAgent : BackgroundService
                             }
                             else
                             {
+                                // Tuple convention is aligned with the SNMP writer
+                                // at WriteInterfaceCounters so downstream consumers
+                                // see stable directions whether SNMP or this UniFi
+                                // PortTable writer was the one that ran last on a
+                                // given cycle: tuple = (rateIn=RX, rateOut=TX).
+                                // NOTE: do NOT mirror into _liveStats per-port cache
+                                // here. UniFi PortTable byte counters update server-
+                                // side ~30s; at our 5s poll cadence that yields a
+                                // burst-then-zeros pattern that would clobber the
+                                // SNMP-fed _liveStats.RecordPortRate writes.
                                 _portRateLatest[key] = (deltaRx * 8.0 / elapsed, deltaTx * 8.0 / elapsed);
                                 _portBytePrev[key] = current;
                             }

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -545,27 +545,23 @@ public class MonitoringCollectionAgent : BackgroundService
                         long deltaRx = current.RxBytes - prev.RxBytes;
                         if (deltaTx >= 0 && deltaRx >= 0)
                         {
-                            // Tuple convention is aligned with the SNMP writer
-                            // at WriteInterfaceCounters so downstream consumers
-                            // see stable directions whether SNMP or this UniFi
-                            // PortTable writer was the one that ran last on a
-                            // given cycle: tuple = (rateIn=RX, rateOut=TX).
-                            //   - DownBps slot holds ifInOctets-style rate (RX,
-                            //     i.e. bytes received on this port; for a
-                            //     parent's port toward a child that's uploads
-                            //     coming up from the child).
-                            //   - UpBps slot holds ifOutOctets-style rate (TX,
-                            //     bytes transmitted; downloads toward the child).
-                            // NOTE: do NOT mirror into _liveStats per-port cache
-                            // here. UniFi PortTable byte counters update server-
-                            // side ~30s; at our 5s poll cadence that yields a
-                            // burst-then-zeros pattern that would clobber the
-                            // SNMP-fed _liveStats.RecordPortRate writes.
-                            _portRateLatest[key] = (deltaRx * 8.0 / elapsed, deltaTx * 8.0 / elapsed);
+                            if (deltaTx == 0 && deltaRx == 0)
+                            {
+                                // Counters unchanged - UniFi hasn't refreshed
+                                // server-side yet. Keep the previous snapshot so
+                                // the next real change computes over the true
+                                // elapsed window.
+                            }
+                            else
+                            {
+                                _portRateLatest[key] = (deltaRx * 8.0 / elapsed, deltaTx * 8.0 / elapsed);
+                                _portBytePrev[key] = current;
+                            }
                         }
                     }
                 }
-                _portBytePrev[key] = current;
+                if (!_portBytePrev.ContainsKey(key))
+                    _portBytePrev[key] = current;
             }
 
             // Device-level aggregate: UniFi's stat.tx_bytes / rx_bytes is the
@@ -585,14 +581,20 @@ public class MonitoringCollectionAgent : BackgroundService
                         long deltaRx = devCurrent.RxBytes - devPrev.RxBytes;
                         if (deltaTx >= 0 && deltaRx >= 0)
                         {
-                            // Device perspective: TX = device sends out (upstream away
-                            // from the device); RX = device receives (downstream toward
-                            // the device). Opposite convention vs the port path above.
-                            _deviceByteRateLatest[devKey] = (deltaRx * 8.0 / elapsed, deltaTx * 8.0 / elapsed);
+                            if (deltaTx == 0 && deltaRx == 0)
+                            {
+                                // Counters unchanged - keep previous snapshot.
+                            }
+                            else
+                            {
+                                _deviceByteRateLatest[devKey] = (deltaRx * 8.0 / elapsed, deltaTx * 8.0 / elapsed);
+                                _deviceBytePrev[devKey] = devCurrent;
+                            }
                         }
                     }
                 }
-                _deviceBytePrev[devKey] = devCurrent;
+                if (!_deviceBytePrev.ContainsKey(devKey))
+                    _deviceBytePrev[devKey] = devCurrent;
             }
         }
     }

--- a/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
@@ -13,6 +13,13 @@ namespace NetworkOptimizer.Web.Services;
 /// </summary>
 public class MonitoringLiveStats
 {
+    private readonly ILogger<MonitoringLiveStats> _logger;
+
+    public MonitoringLiveStats(ILogger<MonitoringLiveStats> logger)
+    {
+        _logger = logger;
+    }
+
     private readonly ConcurrentDictionary<string, DeviceLiveStats> _stats = new();
 
     /// <summary>Total bytes/sec across all monitored interfaces on this device, plus latency.</summary>
@@ -128,11 +135,28 @@ public class MonitoringLiveStats
     public void RecordPortRate(string deviceMac, string ifName, double downBps, double upBps, DateTime timestamp)
     {
         if (string.IsNullOrEmpty(deviceMac) || string.IsNullOrEmpty(ifName)) return;
-        _portRates[(Normalize(deviceMac), ifName)] = new PortLiveRate
+        var key = (Normalize(deviceMac), ifName);
+        _portRates.TryGetValue(key, out var prior);
+        if (downBps == 0 && upBps == 0
+            && prior != null
+            && (prior.DownBps > 0 || prior.UpBps > 0)
+            && prior.ConsecutiveZeroPolls < 1)
+        {
+            _logger.LogDebug(
+                "Port rate hold: {Mac}/{If} was {Down:F0}/{Up:F0} bps, holding through single zero poll",
+                deviceMac, ifName, prior.DownBps, prior.UpBps);
+            _portRates[key] = prior with
+            {
+                LastUpdate = timestamp,
+                ConsecutiveZeroPolls = prior.ConsecutiveZeroPolls + 1,
+            };
+            return;
+        }
+        _portRates[key] = new PortLiveRate
         {
             DownBps = downBps,
             UpBps = upBps,
-            LastUpdate = timestamp
+            LastUpdate = timestamp,
         };
     }
 
@@ -414,6 +438,7 @@ public record PortLiveRate
     /// <summary>Upstream-from-leaf direction rate (parent port RX delta) in bps.</summary>
     public double UpBps { get; init; }
     public DateTime LastUpdate { get; init; }
+    public int ConsecutiveZeroPolls { get; init; }
 }
 
 public record DeviceLiveStats

--- a/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
@@ -142,7 +142,7 @@ public class MonitoringLiveStats
             && (prior.DownBps > 0 || prior.UpBps > 0)
             && prior.ConsecutiveZeroPolls < 1)
         {
-            _logger.LogDebug(
+            _logger.LogTrace(
                 "Port rate hold: {Mac}/{If} was {Down:F0}/{Up:F0} bps, holding through single zero poll",
                 deviceMac, ifName, prior.DownBps, prior.UpBps);
             _portRates[key] = prior with

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -56,7 +56,7 @@ const G = {
     clientFont:  9,
 };
 
-const RATE_THRESH = 1_000_000;
+const RATE_THRESH = 500_000;
 const EMIT_MAX = 12;
 const MAX_DOTS = 80;
 const FONT = 'system-ui, -apple-system, sans-serif';

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -92,6 +92,7 @@ const NODE_KIND = {
 // is the cutoff - low enough to surface most user-noticeable flows, high enough
 // that monitoring's own ping/loss probes don't render labels everywhere.
 const LINK_LABEL_THRESHOLD_BPS = 1_000_000;
+const WAN_LABEL_THRESHOLD_BPS = 500_000;
 
 // Camera-distance cutoff (scene units) above which leaf link labels
 // (WiredClient / WifiClient) stop rendering. Keeps the wide-angle view
@@ -1161,11 +1162,13 @@ export class LanFlowMap {
 
     _refreshLinkLabels() {
         if (!this._linkLabels || this._linkLabels.size === 0) return;
-        for (const [linkId, { el }] of this._linkLabels) {
+        for (const [linkId, { el, kind }] of this._linkLabels) {
             const r = this._currentRates?.[linkId];
             const down = r?.downstreamBps || 0;
             const up = r?.upstreamBps || 0;
-            if (down < LINK_LABEL_THRESHOLD_BPS && up < LINK_LABEL_THRESHOLD_BPS) {
+            const isWan = kind === LINK_KIND.Wan || kind === LINK_KIND.Transit;
+            const thresh = isWan ? WAN_LABEL_THRESHOLD_BPS : LINK_LABEL_THRESHOLD_BPS;
+            if (down < thresh && up < thresh) {
                 el.classList.remove('is-visible');
                 el._hasData = false;
                 continue;


### PR DESCRIPTION
## Summary

- **Port rate hold**: When SNMP counter deltas are zero (device hasn't refreshed its counters yet), hold the previous non-zero rate for one poll cycle instead of writing 0 bps. Mirrors the existing WiFi client hold-previous pattern. Two consecutive zero polls accept the zero as genuinely idle.
- **Counter cache skip**: Don't update the counter cache timestamp when SNMP/UniFi PortTable byte counters haven't changed. The next poll that sees a real change computes the rate over the true elapsed window instead of producing alternating 0 / 2x sawtooth readings. Fixes both live view and InfluxDB historic playback.
- **ISP RTT min-pick**: Globe label and ISP RTT stat card now show the lowest RTT across all access hop targets for a WAN, not the deepest hop. Transit RTT remains averaged so a congested transit ASN raises the reading.
- **WAN link label threshold**: Lowered from 1 Mbps to 0.5 Mbps for WAN/transit links in 3D view. LAN links keep 1 Mbps. 2D view WAN threshold also lowered to 0.5 Mbps.

## Test plan

- [x] Verified on NAS and Mac test sites - no gaps observed after fix
- [x] HAR capture confirmed zero-rate entries appearing every 5s pre-fix
- [x] Debug logging confirmed hold fires on AP/gateway virtual interfaces
- [x] Counter cache fix eliminated hold from firing (root cause addressed)
- [x] Rates add up correctly across path (switch ports + AP backhaul in lockstep)
- [x] No throughput burst after hold releases
- [x] Observe for any regression in rate accuracy over 24h