### PR TITLE
Chart palette overhaul and filter badge improvements

### DIFF
--- a/src/NetworkOptimizer.Core/Helpers/ChartPalette.cs
+++ b/src/NetworkOptimizer.Core/Helpers/ChartPalette.cs
@@ -1,8 +1,8 @@
 namespace NetworkOptimizer.Core.Helpers;
 
 /// <summary>
-/// 33-color chart palette: Observable 10 + Tableau + D3 Paired + D3 Set3,
-/// with perceptually close pairs (deltaE &lt; 11) culled.
+/// 33-color chart palette: Observable 10 base, extended with curated picks from
+/// Tableau, D3 Paired, and hand-selected colors. All pairs have deltaE &gt; 16.
 /// Single source of truth for C# components;
 /// JS charts use the matching window.Apex.colors set by chart-defaults.js.
 /// </summary>
@@ -13,14 +13,15 @@ public static class ChartPalette
         // Observable 10
         "#4269d0", "#efb118", "#ff725c", "#6cc5b0", "#3ca951",
         "#ff8ab7", "#a463f2", "#97bbf5", "#9c6b4e", "#9498a0",
-        // Tableau (8)
-        "#4e79a7", "#f28e2c", "#b22222", "#76b7b2",
+        // Tableau picks
+        "#4e79a7", "#f28e2c", "#b22222",
         "#edc949", "#af7aa1", "#ff9da7", "#d1b894",
-        // D3 Paired (8)
-        "#a6cee3", "#b2df8a", "#33a02c", "#e31a1c",
-        "#fdbf6f", "#ff7f00", "#cab2d6", "#6a3d9a",
-        // D3 Set3 (7)
-        "#d94f70", "#80b1d3", "#b3de69", "#fccde5",
-        "#bc80bd", "#ccebc5", "#b5508c"
+        // D3 Paired picks
+        "#a6cee3", "#b2df8a", "#e31a1c",
+        "#fdbf6f", "#cab2d6", "#6a3d9a",
+        // Extended
+        "#d94f70", "#ccebc5", "#b5508c",
+        "#2d6a4f", "#c26d3a", "#3d8a8a", "#8b9a46",
+        "#d4956b", "#8a6bbf", "#45b8d4"
     ];
 }

--- a/src/NetworkOptimizer.Core/Helpers/ChartPalette.cs
+++ b/src/NetworkOptimizer.Core/Helpers/ChartPalette.cs
@@ -1,0 +1,16 @@
+namespace NetworkOptimizer.Core.Helpers;
+
+/// <summary>
+/// Grafana "Classic" palette. Single source of truth for C# components;
+/// JS charts use the matching window.Apex.colors set by chart-defaults.js.
+/// </summary>
+public static class ChartPalette
+{
+    public static readonly string[] Colors =
+    [
+        "#7EB26D", "#EAB839", "#6ED0E0", "#EF843C", "#E24D42", "#1F78C1",
+        "#BA43A9", "#705DA0", "#508642", "#CCA300", "#447EBC", "#C15C17",
+        "#890F02", "#0A437C", "#6D1F62", "#584477", "#B7DBAB", "#F4D598",
+        "#70DBED", "#F9BA8F", "#F29191", "#82B5D8", "#E5A8E2", "#AEA2E0"
+    ];
+}

--- a/src/NetworkOptimizer.Core/Helpers/ChartPalette.cs
+++ b/src/NetworkOptimizer.Core/Helpers/ChartPalette.cs
@@ -1,7 +1,8 @@
 namespace NetworkOptimizer.Core.Helpers;
 
 /// <summary>
-/// 40-color chart palette: Observable 10 + Tableau 10 + D3 Paired + D3 Set3.
+/// 33-color chart palette: Observable 10 + Tableau + D3 Paired + D3 Set3,
+/// with perceptually close pairs (deltaE &lt; 11) culled.
 /// Single source of truth for C# components;
 /// JS charts use the matching window.Apex.colors set by chart-defaults.js.
 /// </summary>
@@ -12,14 +13,14 @@ public static class ChartPalette
         // Observable 10
         "#4269d0", "#efb118", "#ff725c", "#6cc5b0", "#3ca951",
         "#ff8ab7", "#a463f2", "#97bbf5", "#9c6b4e", "#9498a0",
-        // Tableau 10
-        "#4e79a7", "#f28e2c", "#e15759", "#76b7b2", "#59a14f",
-        "#edc949", "#af7aa1", "#ff9da7", "#9c755f", "#bab0ab",
-        // D3 Paired
-        "#a6cee3", "#1f78b4", "#b2df8a", "#33a02c", "#fb9a99",
-        "#e31a1c", "#fdbf6f", "#ff7f00", "#cab2d6", "#6a3d9a",
-        // D3 Set3
-        "#8dd3c7", "#bebada", "#fb8072", "#80b1d3", "#fdb462",
-        "#b3de69", "#fccde5", "#bc80bd", "#ccebc5", "#ffed6f"
+        // Tableau (8)
+        "#4e79a7", "#f28e2c", "#e15759", "#76b7b2",
+        "#edc949", "#af7aa1", "#ff9da7", "#bab0ab",
+        // D3 Paired (8)
+        "#a6cee3", "#b2df8a", "#33a02c", "#e31a1c",
+        "#fdbf6f", "#ff7f00", "#cab2d6", "#6a3d9a",
+        // D3 Set3 (7)
+        "#fb8072", "#80b1d3", "#b3de69", "#fccde5",
+        "#bc80bd", "#ccebc5", "#ffed6f"
     ];
 }

--- a/src/NetworkOptimizer.Core/Helpers/ChartPalette.cs
+++ b/src/NetworkOptimizer.Core/Helpers/ChartPalette.cs
@@ -1,16 +1,25 @@
 namespace NetworkOptimizer.Core.Helpers;
 
 /// <summary>
-/// Grafana "Classic" palette. Single source of truth for C# components;
+/// 40-color chart palette: Observable 10 + Tableau 10 + D3 Paired + D3 Set3.
+/// Single source of truth for C# components;
 /// JS charts use the matching window.Apex.colors set by chart-defaults.js.
 /// </summary>
 public static class ChartPalette
 {
     public static readonly string[] Colors =
     [
-        "#7EB26D", "#EAB839", "#6ED0E0", "#EF843C", "#E24D42", "#1F78C1",
-        "#BA43A9", "#705DA0", "#508642", "#CCA300", "#447EBC", "#C15C17",
-        "#890F02", "#0A437C", "#6D1F62", "#584477", "#B7DBAB", "#F4D598",
-        "#70DBED", "#F9BA8F", "#F29191", "#82B5D8", "#E5A8E2", "#AEA2E0"
+        // Observable 10
+        "#4269d0", "#efb118", "#ff725c", "#6cc5b0", "#3ca951",
+        "#ff8ab7", "#a463f2", "#97bbf5", "#9c6b4e", "#9498a0",
+        // Tableau 10
+        "#4e79a7", "#f28e2c", "#e15759", "#76b7b2", "#59a14f",
+        "#edc949", "#af7aa1", "#ff9da7", "#9c755f", "#bab0ab",
+        // D3 Paired
+        "#a6cee3", "#1f78b4", "#b2df8a", "#33a02c", "#fb9a99",
+        "#e31a1c", "#fdbf6f", "#ff7f00", "#cab2d6", "#6a3d9a",
+        // D3 Set3
+        "#8dd3c7", "#bebada", "#fb8072", "#80b1d3", "#fdb462",
+        "#b3de69", "#fccde5", "#bc80bd", "#ccebc5", "#ffed6f"
     ];
 }

--- a/src/NetworkOptimizer.Core/Helpers/ChartPalette.cs
+++ b/src/NetworkOptimizer.Core/Helpers/ChartPalette.cs
@@ -14,13 +14,13 @@ public static class ChartPalette
         "#4269d0", "#efb118", "#ff725c", "#6cc5b0", "#3ca951",
         "#ff8ab7", "#a463f2", "#97bbf5", "#9c6b4e", "#9498a0",
         // Tableau (8)
-        "#4e79a7", "#f28e2c", "#e15759", "#76b7b2",
+        "#4e79a7", "#f28e2c", "#b22222", "#76b7b2",
         "#edc949", "#af7aa1", "#ff9da7", "#d1b894",
         // D3 Paired (8)
         "#a6cee3", "#b2df8a", "#33a02c", "#e31a1c",
         "#fdbf6f", "#ff7f00", "#cab2d6", "#6a3d9a",
         // D3 Set3 (7)
-        "#fb8072", "#80b1d3", "#b3de69", "#fccde5",
+        "#d94f70", "#80b1d3", "#b3de69", "#fccde5",
         "#bc80bd", "#ccebc5", "#b5508c"
     ];
 }

--- a/src/NetworkOptimizer.Core/Helpers/ChartPalette.cs
+++ b/src/NetworkOptimizer.Core/Helpers/ChartPalette.cs
@@ -15,7 +15,7 @@ public static class ChartPalette
         "#ff8ab7", "#a463f2", "#97bbf5", "#9c6b4e", "#9498a0",
         // Tableau (8)
         "#4e79a7", "#f28e2c", "#e15759", "#76b7b2",
-        "#edc949", "#af7aa1", "#ff9da7", "#bab0ab",
+        "#edc949", "#af7aa1", "#ff9da7", "#d1b894",
         // D3 Paired (8)
         "#a6cee3", "#b2df8a", "#33a02c", "#e31a1c",
         "#fdbf6f", "#ff7f00", "#cab2d6", "#6a3d9a",

--- a/src/NetworkOptimizer.Core/Helpers/ChartPalette.cs
+++ b/src/NetworkOptimizer.Core/Helpers/ChartPalette.cs
@@ -21,6 +21,6 @@ public static class ChartPalette
         "#fdbf6f", "#ff7f00", "#cab2d6", "#6a3d9a",
         // D3 Set3 (7)
         "#fb8072", "#80b1d3", "#b3de69", "#fccde5",
-        "#bc80bd", "#ccebc5", "#ffed6f"
+        "#bc80bd", "#ccebc5", "#b5508c"
     ];
 }

--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -89,6 +89,7 @@
         </div>
     </div>
 
+    <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/chart-defaults.js")"></script>
     <script src="_framework/blazor.web.js"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/scrollRestoration.js")"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/updateCheck.js")"></script>

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
@@ -675,10 +675,7 @@
     };
     private const int MaxChartPoints = 20;
 
-    private static readonly string[] SeriesColors = new[]
-    {
-        "#2ba89a", "#a78bfa", "#3b82f6", "#ef5858", "#f59e0b", "#10b981"
-    };
+    private static readonly string[] SeriesColors = ChartPalette.Colors;
 
     private class ChartPoint
     {

--- a/src/NetworkOptimizer.Web/Components/Pages/ThreatDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ThreatDashboard.razor
@@ -2781,27 +2781,13 @@ else
 
     private async Task ToggleSeverity(int level, MouseEventArgs e)
     {
-        if (e.CtrlKey || e.MetaKey)
+        switch (level)
         {
-            switch (level)
-            {
-                case 5: _showSev5 = false; break;
-                case 4: _showSev4 = false; break;
-                case 3: _showSev3 = false; break;
-                case 2: _showSev2 = false; break;
-                case 1: _showSev1 = false; break;
-            }
-        }
-        else
-        {
-            switch (level)
-            {
-                case 5: _showSev5 = !_showSev5; break;
-                case 4: _showSev4 = !_showSev4; break;
-                case 3: _showSev3 = !_showSev3; break;
-                case 2: _showSev2 = !_showSev2; break;
-                case 1: _showSev1 = !_showSev1; break;
-            }
+            case 5: _showSev5 = !_showSev5; break;
+            case 4: _showSev4 = !_showSev4; break;
+            case 3: _showSev3 = !_showSev3; break;
+            case 2: _showSev2 = !_showSev2; break;
+            case 1: _showSev1 = !_showSev1; break;
         }
 
         await LoadDataAsync();

--- a/src/NetworkOptimizer.Web/Components/Pages/ThreatDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ThreatDashboard.razor
@@ -352,27 +352,27 @@ else
                 @* Severity Filter Badges (below chart, same pattern as WAN Speed Test) *@
                 <div class="wan-filter-badges">
                     <button class="wan-filter-badge @(ShowSev5 ? "active" : "inactive")"
-                            @onclick="() => ToggleSeverity(5)">
+                            @onclick="(e) => ToggleSeverity(5, e)">
                         <span class="wan-badge-dot" style="background-color: #ef4444"></span>
                         Critical
                     </button>
                     <button class="wan-filter-badge @(ShowSev4 ? "active" : "inactive")"
-                            @onclick="() => ToggleSeverity(4)">
+                            @onclick="(e) => ToggleSeverity(4, e)">
                         <span class="wan-badge-dot" style="background-color: #f97316"></span>
                         High
                     </button>
                     <button class="wan-filter-badge @(ShowSev3 ? "active" : "inactive")"
-                            @onclick="() => ToggleSeverity(3)">
+                            @onclick="(e) => ToggleSeverity(3, e)">
                         <span class="wan-badge-dot" style="background-color: #eab308"></span>
                         Medium
                     </button>
                     <button class="wan-filter-badge @(ShowSev2 ? "active" : "inactive")"
-                            @onclick="() => ToggleSeverity(2)">
+                            @onclick="(e) => ToggleSeverity(2, e)">
                         <span class="wan-badge-dot" style="background-color: #3b82f6"></span>
                         Low
                     </button>
                     <button class="wan-filter-badge @(ShowSev1 ? "active" : "inactive")"
-                            @onclick="() => ToggleSeverity(1)">
+                            @onclick="(e) => ToggleSeverity(1, e)">
                         <span class="wan-badge-dot" style="background-color: #10b981"></span>
                         Info
                     </button>
@@ -2779,15 +2779,29 @@ else
         await LoadDataAsync();
     }
 
-    private async Task ToggleSeverity(int level)
+    private async Task ToggleSeverity(int level, MouseEventArgs e)
     {
-        switch (level)
+        if (e.CtrlKey || e.MetaKey)
         {
-            case 5: _showSev5 = !_showSev5; break;
-            case 4: _showSev4 = !_showSev4; break;
-            case 3: _showSev3 = !_showSev3; break;
-            case 2: _showSev2 = !_showSev2; break;
-            case 1: _showSev1 = !_showSev1; break;
+            switch (level)
+            {
+                case 5: _showSev5 = false; break;
+                case 4: _showSev4 = false; break;
+                case 3: _showSev3 = false; break;
+                case 2: _showSev2 = false; break;
+                case 1: _showSev1 = false; break;
+            }
+        }
+        else
+        {
+            switch (level)
+            {
+                case 5: _showSev5 = !_showSev5; break;
+                case 4: _showSev4 = !_showSev4; break;
+                case 3: _showSev3 = !_showSev3; break;
+                case 2: _showSev2 = !_showSev2; break;
+                case 1: _showSev1 = !_showSev1; break;
+            }
         }
 
         await LoadDataAsync();

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -359,7 +359,7 @@
                         @foreach (var wan in _wanSeries)
                         {
                             <button class="wan-filter-badge @(wan.IsSelected ? "active" : "inactive")"
-                                    @onclick="@(() => ToggleWanFilter(wan.Key))">
+                                    @onclick="@((e) => ToggleWanFilter(wan.Key, e))">
                                 <span class="wan-badge-dot" style="background-color: @wan.Color"></span>
                                 @wan.DisplayName
                             </button>
@@ -651,16 +651,7 @@
     // Chart downsampling: max points per series when time range > 4 hrs
     private const int MaxChartPoints = 20;
 
-    // WAN color palette
-    private static readonly string[] WanColors = new[]
-    {
-        "#2ba89a", // teal
-        "#a78bfa", // purple
-        "#3b82f6", // blue
-        "#ef5858", // red
-        "#f59e0b", // amber
-        "#10b981"  // emerald
-    };
+    private static readonly string[] WanColors = ChartPalette.Colors;
 
     private class WanChartDataPoint
     {
@@ -1432,12 +1423,15 @@
         await ReleaseCardHeight();
     }
 
-    private async Task ToggleWanFilter(string wanKey)
+    private async Task ToggleWanFilter(string wanKey, MouseEventArgs e)
     {
         var wan = _wanSeries.FirstOrDefault(w => w.Key == wanKey);
         if (wan == null) return;
 
-        wan.IsSelected = !wan.IsSelected;
+        if (e.CtrlKey || e.MetaKey)
+            wan.IsSelected = false;
+        else
+            wan.IsSelected = !wan.IsSelected;
 
         await LockCardHeight();
         _historyPage = 1;

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -691,11 +691,7 @@
         public int[] Indices { get; set; } = [];
     }
 
-    // Show all when none selected (or all selected) - same pattern as WiFi Optimizer Metrics
-    private bool _wanNoneSelected => !_wanSeries.Any(w => w.IsSelected);
-    private bool _wanAllSelected => _wanSeries.All(w => w.IsSelected);
-    private bool _wanShowAll => _wanNoneSelected || _wanAllSelected;
-    private bool IsWanVisible(WanSeriesInfo wan) => _wanShowAll || wan.IsSelected;
+    private bool IsWanVisible(WanSeriesInfo wan) => wan.IsSelected;
 
     protected override async Task OnInitializedAsync()
     {
@@ -1429,9 +1425,21 @@
         if (wan == null) return;
 
         if (e.CtrlKey || e.MetaKey)
-            wan.IsSelected = false;
-        else
+        {
             wan.IsSelected = !wan.IsSelected;
+        }
+        else
+        {
+            var allVis = _wanSeries.All(w => w.IsSelected);
+            var onlyThis = wan.IsSelected && _wanSeries.Where(w => w.Key != wanKey).All(w => !w.IsSelected);
+
+            if (onlyThis)
+                foreach (var w in _wanSeries) w.IsSelected = true;
+            else if (allVis)
+                foreach (var w in _wanSeries) w.IsSelected = w.Key == wanKey;
+            else
+                wan.IsSelected = !wan.IsSelected;
+        }
 
         await LockCardHeight();
         _historyPage = 1;

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -1097,7 +1097,7 @@
             Key = key,
             DisplayName = GetWanDisplayNameForKey(key),
             Color = WanColors[i % WanColors.Length],
-            IsSelected = previousSelection.TryGetValue(key, out var selected) && selected,
+            IsSelected = !previousSelection.TryGetValue(key, out var selected) || selected,
             DownloadData = new(),
             UploadData = new()
         }).ToList();

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -661,6 +661,7 @@ public class MonitoringCollectionAgent : BackgroundService
         if (!_influx.IsConfigured) await _influx.ReconfigureAsync(ct);
 
         var gatewayLanIp = await ResolveGatewayLanIpAsync(ct);
+        var snmpHealthHits = new ConcurrentDictionary<string, bool>();
         var deviceTasks = devices.Select(async device =>
         {
             await _snmpGate.WaitAsync(ct);
@@ -682,6 +683,9 @@ public class MonitoringCollectionAgent : BackgroundService
                 var memPct = metrics.MemoryUsage > 0 ? metrics.MemoryUsage : (double?)null;
                 var temp = metrics.Temperature > 0 ? metrics.Temperature : (double?)null;
                 var uptime = metrics.Uptime > 0 ? metrics.Uptime / 100 : (long?)null;
+
+                if (cpu != null || memPct != null)
+                    snmpHealthHits[NormalizeMac(device.Mac)] = true;
 
                 await _influx.WriteDeviceHealthAsync(
                     deviceMac: device.Mac,
@@ -727,10 +731,10 @@ public class MonitoringCollectionAgent : BackgroundService
                 long? uptime = ss != null ? (long?)ParseJsonDouble(ss.Uptime) : null;
                 double? temp = ParseDeviceTemperature(device);
 
-                // SNMP devices: only supplement temp for switches (SNMP doesn't
-                // report switch temps). Gateway and APs get temp from SNMP already;
-                // writing API temp too creates dual-source Z-shape artifacts.
-                if (snmpActive)
+                // SNMP devices that actually returned health data: only supplement
+                // temp for switches. Devices where SNMP is configured but returned
+                // no health OIDs (e.g., USW-Flex-XG) fall through to full API data.
+                if (snmpActive && snmpHealthHits.ContainsKey(mac))
                 {
                     if (device.DeviceType != NetworkOptimizer.Core.Enums.DeviceType.Switch) continue;
                     cpu = null;

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-defaults.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-defaults.js
@@ -1,0 +1,14 @@
+// Grafana "Classic" palette — 24 visually distinct colors for multi-series charts.
+// Source of truth for both Blazor-rendered ApexCharts (via window.Apex.colors)
+// and JS module charts (via window.Apex.colors or direct import).
+// Charts that set explicit Colors/colors override this default.
+(function () {
+    var palette = [
+        '#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1',
+        '#BA43A9', '#705DA0', '#508642', '#CCA300', '#447EBC', '#C15C17',
+        '#890F02', '#0A437C', '#6D1F62', '#584477', '#B7DBAB', '#F4D598',
+        '#70DBED', '#F9BA8F', '#F29191', '#82B5D8', '#E5A8E2', '#AEA2E0'
+    ];
+    window.Apex = window.Apex || {};
+    window.Apex.colors = palette;
+})();

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-defaults.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-defaults.js
@@ -9,13 +9,13 @@
         '#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951',
         '#ff8ab7', '#a463f2', '#97bbf5', '#9c6b4e', '#9498a0',
         // Tableau (8 — dropped #59a14f, #9c755f as too close to Observable)
-        '#4e79a7', '#f28e2c', '#e15759', '#76b7b2',
+        '#4e79a7', '#f28e2c', '#b22222', '#76b7b2',
         '#edc949', '#af7aa1', '#ff9da7', '#d1b894',
         // D3 Paired (8 — dropped #1f78b4, #fb9a99)
         '#a6cee3', '#b2df8a', '#33a02c', '#e31a1c',
         '#fdbf6f', '#ff7f00', '#cab2d6', '#6a3d9a',
         // D3 Set3 (7 — dropped #8dd3c7, #bebada, #fdb462)
-        '#fb8072', '#80b1d3', '#b3de69', '#fccde5',
+        '#d94f70', '#80b1d3', '#b3de69', '#fccde5',
         '#bc80bd', '#ccebc5', '#b5508c'
     ];
     window.Apex = window.Apex || {};

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-defaults.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-defaults.js
@@ -10,7 +10,7 @@
         '#ff8ab7', '#a463f2', '#97bbf5', '#9c6b4e', '#9498a0',
         // Tableau (8 — dropped #59a14f, #9c755f as too close to Observable)
         '#4e79a7', '#f28e2c', '#e15759', '#76b7b2',
-        '#edc949', '#af7aa1', '#ff9da7', '#bab0ab',
+        '#edc949', '#af7aa1', '#ff9da7', '#d1b894',
         // D3 Paired (8 — dropped #1f78b4, #fb9a99)
         '#a6cee3', '#b2df8a', '#33a02c', '#e31a1c',
         '#fdbf6f', '#ff7f00', '#cab2d6', '#6a3d9a',

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-defaults.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-defaults.js
@@ -16,7 +16,7 @@
         '#fdbf6f', '#ff7f00', '#cab2d6', '#6a3d9a',
         // D3 Set3 (7 — dropped #8dd3c7, #bebada, #fdb462)
         '#fb8072', '#80b1d3', '#b3de69', '#fccde5',
-        '#bc80bd', '#ccebc5', '#ffed6f'
+        '#bc80bd', '#ccebc5', '#b5508c'
     ];
     window.Apex = window.Apex || {};
     window.Apex.colors = palette;

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-defaults.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-defaults.js
@@ -1,13 +1,21 @@
-// Grafana "Classic" palette — 24 visually distinct colors for multi-series charts.
+// 40-color chart palette — Observable 10 + Tableau 10 + D3 Paired + D3 Set3.
 // Source of truth for both Blazor-rendered ApexCharts (via window.Apex.colors)
 // and JS module charts (via window.Apex.colors or direct import).
 // Charts that set explicit Colors/colors override this default.
 (function () {
     var palette = [
-        '#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1',
-        '#BA43A9', '#705DA0', '#508642', '#CCA300', '#447EBC', '#C15C17',
-        '#890F02', '#0A437C', '#6D1F62', '#584477', '#B7DBAB', '#F4D598',
-        '#70DBED', '#F9BA8F', '#F29191', '#82B5D8', '#E5A8E2', '#AEA2E0'
+        // Observable 10 — modern, designed for data viz (2024)
+        '#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951',
+        '#ff8ab7', '#a463f2', '#97bbf5', '#9c6b4e', '#9498a0',
+        // Tableau 10 — proven, slightly more muted
+        '#4e79a7', '#f28e2c', '#e15759', '#76b7b2', '#59a14f',
+        '#edc949', '#af7aa1', '#ff9da7', '#9c755f', '#bab0ab',
+        // D3 Paired — light/dark pairs, good range
+        '#a6cee3', '#1f78b4', '#b2df8a', '#33a02c', '#fb9a99',
+        '#e31a1c', '#fdbf6f', '#ff7f00', '#cab2d6', '#6a3d9a',
+        // D3 Set3 — pleasant pastels
+        '#8dd3c7', '#bebada', '#fb8072', '#80b1d3', '#fdb462',
+        '#b3de69', '#fccde5', '#bc80bd', '#ccebc5', '#ffed6f'
     ];
     window.Apex = window.Apex || {};
     window.Apex.colors = palette;

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-defaults.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-defaults.js
@@ -1,21 +1,22 @@
-// 40-color chart palette — Observable 10 + Tableau 10 + D3 Paired + D3 Set3.
+// 33-color chart palette — Observable 10 + Tableau + D3 Paired + D3 Set3,
+// with perceptually close pairs (deltaE < 11) culled.
 // Source of truth for both Blazor-rendered ApexCharts (via window.Apex.colors)
 // and JS module charts (via window.Apex.colors or direct import).
 // Charts that set explicit Colors/colors override this default.
 (function () {
     var palette = [
-        // Observable 10 — modern, designed for data viz (2024)
+        // Observable 10
         '#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951',
         '#ff8ab7', '#a463f2', '#97bbf5', '#9c6b4e', '#9498a0',
-        // Tableau 10 — proven, slightly more muted
-        '#4e79a7', '#f28e2c', '#e15759', '#76b7b2', '#59a14f',
-        '#edc949', '#af7aa1', '#ff9da7', '#9c755f', '#bab0ab',
-        // D3 Paired — light/dark pairs, good range
-        '#a6cee3', '#1f78b4', '#b2df8a', '#33a02c', '#fb9a99',
-        '#e31a1c', '#fdbf6f', '#ff7f00', '#cab2d6', '#6a3d9a',
-        // D3 Set3 — pleasant pastels
-        '#8dd3c7', '#bebada', '#fb8072', '#80b1d3', '#fdb462',
-        '#b3de69', '#fccde5', '#bc80bd', '#ccebc5', '#ffed6f'
+        // Tableau (8 — dropped #59a14f, #9c755f as too close to Observable)
+        '#4e79a7', '#f28e2c', '#e15759', '#76b7b2',
+        '#edc949', '#af7aa1', '#ff9da7', '#bab0ab',
+        // D3 Paired (8 — dropped #1f78b4, #fb9a99)
+        '#a6cee3', '#b2df8a', '#33a02c', '#e31a1c',
+        '#fdbf6f', '#ff7f00', '#cab2d6', '#6a3d9a',
+        // D3 Set3 (7 — dropped #8dd3c7, #bebada, #fdb462)
+        '#fb8072', '#80b1d3', '#b3de69', '#fccde5',
+        '#bc80bd', '#ccebc5', '#ffed6f'
     ];
     window.Apex = window.Apex || {};
     window.Apex.colors = palette;

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-defaults.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-defaults.js
@@ -1,5 +1,5 @@
-// 33-color chart palette — Observable 10 + Tableau + D3 Paired + D3 Set3,
-// with perceptually close pairs (deltaE < 11) culled.
+// 33-color chart palette — Observable 10 base, extended with curated picks from
+// Tableau, D3 Paired, and hand-selected colors. All pairs have deltaE > 16.
 // Source of truth for both Blazor-rendered ApexCharts (via window.Apex.colors)
 // and JS module charts (via window.Apex.colors or direct import).
 // Charts that set explicit Colors/colors override this default.
@@ -8,15 +8,16 @@
         // Observable 10
         '#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951',
         '#ff8ab7', '#a463f2', '#97bbf5', '#9c6b4e', '#9498a0',
-        // Tableau (8 — dropped #59a14f, #9c755f as too close to Observable)
-        '#4e79a7', '#f28e2c', '#b22222', '#76b7b2',
+        // Tableau picks
+        '#4e79a7', '#f28e2c', '#b22222',
         '#edc949', '#af7aa1', '#ff9da7', '#d1b894',
-        // D3 Paired (8 — dropped #1f78b4, #fb9a99)
-        '#a6cee3', '#b2df8a', '#33a02c', '#e31a1c',
-        '#fdbf6f', '#ff7f00', '#cab2d6', '#6a3d9a',
-        // D3 Set3 (7 — dropped #8dd3c7, #bebada, #fdb462)
-        '#d94f70', '#80b1d3', '#b3de69', '#fccde5',
-        '#bc80bd', '#ccebc5', '#b5508c'
+        // D3 Paired picks
+        '#a6cee3', '#b2df8a', '#e31a1c',
+        '#fdbf6f', '#cab2d6', '#6a3d9a',
+        // Extended
+        '#d94f70', '#ccebc5', '#b5508c',
+        '#2d6a4f', '#c26d3a', '#3d8a8a', '#8b9a46',
+        '#d4956b', '#8a6bbf', '#45b8d4'
     ];
     window.Apex = window.Apex || {};
     window.Apex.colors = palette;

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -104,7 +104,7 @@ function renderBadges(container) {
             const mac = btn.dataset.mac;
 
             if (e.ctrlKey || e.metaKey) {
-                visibility[mac] = false;
+                visibility[mac] = visibility[mac] === false ? undefined : false;
             } else {
                 const allVis = deviceMeta.every(d => visibility[d.mac] !== false);
                 const onlyThis = visibility[mac] !== false

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -3,7 +3,7 @@
 // device-health-charts, and future chart sets share one implementation.
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 
-const PALETTE = ['#2ba89a', '#3b82f6', '#a78bfa', '#ef5858', '#f59e0b', '#10b981'];
+const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
 const POLL_INTERVALS = { 0: 5000, 1: 5000, 6: 10000, 24: 15000, 168: 30000, 720: 30000 };

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -99,8 +99,11 @@ function renderBadges(container) {
             <span>${escapeHtml(d.name)}</span>
         </button>`;
     }).join('');
-    el.querySelectorAll('button').forEach(btn => {
-        btn.addEventListener('click', (e) => {
+    if (!el._delegated) {
+        el._delegated = true;
+        el.addEventListener('click', (e) => {
+            const btn = e.target.closest('button[data-mac]');
+            if (!btn) return;
             const mac = btn.dataset.mac;
 
             if (e.ctrlKey || e.metaKey) {
@@ -116,7 +119,7 @@ function renderBadges(container) {
             updateVisibility();
             renderBadges(container);
         });
-    });
+    }
 }
 
 function updateVisibility() {

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -4,6 +4,21 @@
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 
 const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
+const _colorCache = {};
+function hashColor(id) {
+    if (_colorCache[id]) return _colorCache[id];
+    let h = 0;
+    for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0;
+    const used = new Set(Object.values(_colorCache));
+    let idx = h % PALETTE.length;
+    const start = idx;
+    while (used.has(PALETTE[idx])) {
+        idx = (idx + 1) % PALETTE.length;
+        if (idx === start) break;
+    }
+    _colorCache[id] = PALETTE[idx];
+    return PALETTE[idx];
+}
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
 const POLL_INTERVALS = { 0: 5000, 1: 5000, 6: 10000, 24: 15000, 168: 30000, 720: 30000 };
@@ -136,12 +151,12 @@ function updateVisibility() {
 async function loadAndUpdate() {
     const data = await fetchData();
     if (!data?.devices) return;
-    deviceMeta = data.devices.map((d, i) => ({
-        name: d.name, mac: d.mac, color: PALETTE[i % PALETTE.length],
+    deviceMeta = data.devices.map(d => ({
+        name: d.name, mac: d.mac, color: hashColor(d.mac),
     }));
-    const makeSeries = (field) => data.devices.map((d, i) => ({
+    const makeSeries = (field) => data.devices.map(d => ({
         name: d.name,
-        color: PALETTE[i % PALETTE.length],
+        color: hashColor(d.mac),
         data: (d.data || []).filter(p => p[field] != null).map(p => ({
             x: new Date(p.time).getTime(), y: p[field]
         })),

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -289,7 +289,7 @@ export async function mount(elId) {
     tempChart = new ApexCharts(tempEl, { ...baseOpts(200, '°C', v => v != null ? v.toFixed(0) + ' °C' : ''), series: [], colors: PALETTE });
     cpuChart = new ApexCharts(cpuEl, {
         ...baseOpts(200, 'CPU %', v => v != null ? v.toFixed(0) + '%' : ''),
-        yaxis: { min: 0, max: v => Math.max(v * 1.1, 50), title: { text: 'CPU %', style: { color: '#9ca3af' } }, labels: { style: { colors: '#9ca3af' }, formatter: v => v != null ? v.toFixed(0) + '%' : '' } },
+        yaxis: { min: 0, max: v => Math.max(v * 1.1, 30), title: { text: 'CPU %', style: { color: '#9ca3af' } }, labels: { style: { colors: '#9ca3af' }, formatter: v => v != null ? v.toFixed(0) + '%' : '' } },
         series: [], colors: PALETTE,
     });
     memChart = new ApexCharts(memEl, {

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -100,14 +100,19 @@ function renderBadges(container) {
         </button>`;
     }).join('');
     el.querySelectorAll('button').forEach(btn => {
-        btn.addEventListener('click', () => {
+        btn.addEventListener('click', (e) => {
             const mac = btn.dataset.mac;
-            const allVis = deviceMeta.every(d => visibility[d.mac] !== false);
-            const onlyThis = visibility[mac] !== false
-                && deviceMeta.filter(d => d.mac !== mac).every(d => visibility[d.mac] === false);
-            if (onlyThis) { visibility = {}; }
-            else if (allVis) { deviceMeta.forEach(d => visibility[d.mac] = d.mac === mac); }
-            else { visibility[mac] = visibility[mac] === false; }
+
+            if (e.ctrlKey || e.metaKey) {
+                visibility[mac] = false;
+            } else {
+                const allVis = deviceMeta.every(d => visibility[d.mac] !== false);
+                const onlyThis = visibility[mac] !== false
+                    && deviceMeta.filter(d => d.mac !== mac).every(d => visibility[d.mac] === false);
+                if (onlyThis) { visibility = {}; }
+                else if (allVis) { deviceMeta.forEach(d => visibility[d.mac] = d.mac === mac); }
+                else { visibility[mac] = visibility[mac] === false; }
+            }
             updateVisibility();
             renderBadges(container);
         });

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -152,11 +152,11 @@ async function loadAndUpdate() {
     const data = await fetchData();
     if (!data?.devices) return;
     deviceMeta = data.devices.map(d => ({
-        name: d.name, mac: d.mac, color: hashColor(d.mac),
+        name: d.name, mac: d.mac, color: hashColor(d.name),
     }));
     const makeSeries = (field) => data.devices.map(d => ({
         name: d.name,
-        color: hashColor(d.mac),
+        color: hashColor(d.name),
         data: (d.data || []).filter(p => p[field] != null).map(p => ({
             x: new Date(p.time).getTime(), y: p[field]
         })),

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -247,7 +247,7 @@ async function loadAndUpdate() {
     if (rttChart) rttChart.updateSeries(rttSeries, false);
     if (lossChart) lossChart.updateSeries(lossSeries, false);
 
-    updateChartVisibility('poll');
+    updateChartVisibility();
 
     const container = document.getElementById(containerId);
     if (container) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -164,13 +164,19 @@ function renderBadges(container) {
     el.querySelectorAll('button').forEach(btn => {
         btn.addEventListener('click', (e) => {
             const tid = btn.dataset.target;
+            const name = targetMeta.find(t => t.id === tid)?.name || tid;
+            const before = Object.fromEntries(targetMeta.map(t => [t.name, visibility[t.id] !== false]));
 
             if (e.ctrlKey || e.metaKey) {
+                console.log(`[filter] Ctrl+Click "${name}"`, { before });
                 visibility[tid] = visibility[tid] === false ? undefined : false;
             } else {
                 const allVis = targetMeta.every(t => visibility[t.id] !== false);
                 const onlyThis = visibility[tid] !== false
                     && targetMeta.filter(t => t.id !== tid).every(t => visibility[t.id] === false);
+
+                const branch = onlyThis ? 'onlyThis→showAll' : allVis ? 'allVis→solo' : 'toggle';
+                console.log(`[filter] Click "${name}" → ${branch}`, { before });
 
                 if (onlyThis) {
                     visibility = {};
@@ -180,17 +186,23 @@ function renderBadges(container) {
                     visibility[tid] = visibility[tid] === false;
                 }
             }
-            updateChartVisibility();
+
+            const after = Object.fromEntries(targetMeta.map(t => [t.name, visibility[t.id] !== false]));
+            console.log(`[filter] Result:`, { after });
+
+            updateChartVisibility('click');
             renderBadges(container);
             if (lastFetchData) renderStatsTable(container, lastFetchData);
         });
     });
 }
 
-function updateChartVisibility() {
+function updateChartVisibility(source) {
     if (!rttChart || !lossChart) return;
+    const applied = {};
     targetMeta.forEach((t, i) => {
         const vis = visibility[t.id] !== false;
+        applied[t.name] = vis;
         if (vis) {
             rttChart.showSeries(t.name);
             lossChart.showSeries(t.name);
@@ -199,6 +211,7 @@ function updateChartVisibility() {
             lossChart.hideSeries(t.name);
         }
     });
+    if (source) console.log(`[filter] updateChartVisibility(${source}):`, applied);
 }
 
 async function loadAndUpdate() {
@@ -228,7 +241,7 @@ async function loadAndUpdate() {
     if (rttChart) rttChart.updateSeries(rttSeries, false);
     if (lossChart) lossChart.updateSeries(lossSeries, false);
 
-    updateChartVisibility();
+    updateChartVisibility('poll');
 
     const container = document.getElementById(containerId);
     if (container) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -167,19 +167,13 @@ function renderBadges(container) {
             const btn = e.target.closest('button[data-target]');
             if (!btn) return;
             const tid = btn.dataset.target;
-            const name = targetMeta.find(t => t.id === tid)?.name || tid;
-            const before = Object.fromEntries(targetMeta.map(t => [t.name, visibility[t.id] !== false]));
 
             if (e.ctrlKey || e.metaKey) {
-                console.log(`[filter] Ctrl+Click "${name}"`, { before });
                 visibility[tid] = visibility[tid] === false ? undefined : false;
             } else {
                 const allVis = targetMeta.every(t => visibility[t.id] !== false);
                 const onlyThis = visibility[tid] !== false
                     && targetMeta.filter(t => t.id !== tid).every(t => visibility[t.id] === false);
-
-                const branch = onlyThis ? 'onlyThis→showAll' : allVis ? 'allVis→solo' : 'toggle';
-                console.log(`[filter] Click "${name}" → ${branch}`, { before });
 
                 if (onlyThis) {
                     visibility = {};
@@ -190,22 +184,17 @@ function renderBadges(container) {
                 }
             }
 
-            const after = Object.fromEntries(targetMeta.map(t => [t.name, visibility[t.id] !== false]));
-            console.log(`[filter] Result:`, { after });
-
-            updateChartVisibility('click');
+            updateChartVisibility();
             renderBadges(container);
             if (lastFetchData) renderStatsTable(container, lastFetchData);
         });
     }
 }
 
-function updateChartVisibility(source) {
+function updateChartVisibility() {
     if (!rttChart || !lossChart) return;
-    const applied = {};
     targetMeta.forEach((t, i) => {
         const vis = visibility[t.id] !== false;
-        applied[t.name] = vis;
         if (vis) {
             rttChart.showSeries(t.name);
             lossChart.showSeries(t.name);
@@ -214,7 +203,6 @@ function updateChartVisibility(source) {
             lossChart.hideSeries(t.name);
         }
     });
-    if (source) console.log(`[filter] updateChartVisibility(${source}):`, applied);
 }
 
 async function loadAndUpdate() {

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -227,18 +227,18 @@ async function loadAndUpdate() {
     targetMeta = data.targets.map(t => ({
         id: t.targetId,
         name: t.name,
-        color: hashColor(t.targetId),
+        color: hashColor(t.name),
     }));
 
     const rttSeries = data.targets.map(t => ({
         name: t.name,
-        color: hashColor(t.targetId),
+        color: hashColor(t.name),
         data: (t.rtt || []).map(p => ({ x: new Date(p.time).getTime(), y: p.value })),
     }));
 
     const lossSeries = data.targets.map(t => ({
         name: t.name,
-        color: hashColor(t.targetId),
+        color: hashColor(t.name),
         data: (t.loss || []).map(p => ({ x: new Date(p.time).getTime(), y: p.value })),
     }));
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -162,18 +162,23 @@ function renderBadges(container) {
     }).join('');
 
     el.querySelectorAll('button').forEach(btn => {
-        btn.addEventListener('click', () => {
+        btn.addEventListener('click', (e) => {
             const tid = btn.dataset.target;
-            const allVis = targetMeta.every(t => visibility[t.id] !== false);
-            const onlyThis = visibility[tid] !== false
-                && targetMeta.filter(t => t.id !== tid).every(t => visibility[t.id] === false);
 
-            if (onlyThis) {
-                visibility = {};
-            } else if (allVis) {
-                targetMeta.forEach(t => visibility[t.id] = t.id === tid);
+            if (e.ctrlKey || e.metaKey) {
+                visibility[tid] = false;
             } else {
-                visibility[tid] = visibility[tid] === false;
+                const allVis = targetMeta.every(t => visibility[t.id] !== false);
+                const onlyThis = visibility[tid] !== false
+                    && targetMeta.filter(t => t.id !== tid).every(t => visibility[t.id] === false);
+
+                if (onlyThis) {
+                    visibility = {};
+                } else if (allVis) {
+                    targetMeta.forEach(t => visibility[t.id] = t.id === tid);
+                } else {
+                    visibility[tid] = visibility[tid] === false;
+                }
             }
             updateChartVisibility();
             renderBadges(container);

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -6,7 +6,7 @@
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 
-const PALETTE = ['#2ba89a', '#3b82f6', '#a78bfa', '#ef5858', '#f59e0b', '#10b981'];
+const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
 const POLL_INTERVALS = { 0: 5000, 1: 5000, 6: 10000, 24: 15000, 168: 30000, 720: 30000 };

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -7,6 +7,21 @@
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 
 const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
+const _colorCache = {};
+function hashColor(id) {
+    if (_colorCache[id]) return _colorCache[id];
+    let h = 0;
+    for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0;
+    const used = new Set(Object.values(_colorCache));
+    let idx = h % PALETTE.length;
+    const start = idx;
+    while (used.has(PALETTE[idx])) {
+        idx = (idx + 1) % PALETTE.length;
+        if (idx === start) break;
+    }
+    _colorCache[id] = PALETTE[idx];
+    return PALETTE[idx];
+}
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
 const POLL_INTERVALS = { 0: 5000, 1: 5000, 6: 10000, 24: 15000, 168: 30000, 720: 30000 };
@@ -209,21 +224,21 @@ async function loadAndUpdate() {
     const data = await fetchData();
     if (!data || !data.targets) return;
 
-    targetMeta = data.targets.map((t, i) => ({
+    targetMeta = data.targets.map(t => ({
         id: t.targetId,
         name: t.name,
-        color: PALETTE[i % PALETTE.length],
+        color: hashColor(t.targetId),
     }));
 
-    const rttSeries = data.targets.map((t, i) => ({
+    const rttSeries = data.targets.map(t => ({
         name: t.name,
-        color: PALETTE[i % PALETTE.length],
+        color: hashColor(t.targetId),
         data: (t.rtt || []).map(p => ({ x: new Date(p.time).getTime(), y: p.value })),
     }));
 
-    const lossSeries = data.targets.map((t, i) => ({
+    const lossSeries = data.targets.map(t => ({
         name: t.name,
-        color: PALETTE[i % PALETTE.length],
+        color: hashColor(t.targetId),
         data: (t.loss || []).map(p => ({ x: new Date(p.time).getTime(), y: p.value })),
     }));
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -166,7 +166,7 @@ function renderBadges(container) {
             const tid = btn.dataset.target;
 
             if (e.ctrlKey || e.metaKey) {
-                visibility[tid] = false;
+                visibility[tid] = visibility[tid] === false ? undefined : false;
             } else {
                 const allVis = targetMeta.every(t => visibility[t.id] !== false);
                 const onlyThis = visibility[tid] !== false

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -161,8 +161,11 @@ function renderBadges(container) {
         </button>`;
     }).join('');
 
-    el.querySelectorAll('button').forEach(btn => {
-        btn.addEventListener('click', (e) => {
+    if (!el._delegated) {
+        el._delegated = true;
+        el.addEventListener('click', (e) => {
+            const btn = e.target.closest('button[data-target]');
+            if (!btn) return;
             const tid = btn.dataset.target;
             const name = targetMeta.find(t => t.id === tid)?.name || tid;
             const before = Object.fromEntries(targetMeta.map(t => [t.name, visibility[t.id] !== false]));
@@ -194,7 +197,7 @@ function renderBadges(container) {
             renderBadges(container);
             if (lastFetchData) renderStatsTable(container, lastFetchData);
         });
-    });
+    }
 }
 
 function updateChartVisibility(source) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -102,7 +102,7 @@ function renderBadges(container) {
             const id = btn.dataset.sfp;
 
             if (e.ctrlKey || e.metaKey) {
-                visibility[id] = false;
+                visibility[id] = visibility[id] === false ? undefined : false;
             } else {
                 const allVis = moduleMeta.every(m => visibility[m.id] !== false);
                 const onlyThis = visibility[id] !== false

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -3,7 +3,7 @@
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 
-const PALETTE = ['#2ba89a', '#3b82f6', '#a78bfa', '#ef5858', '#f59e0b', '#10b981'];
+const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
 const POLL_INTERVALS = { 0: 10000, 1: 10000, 6: 15000, 24: 30000, 168: 60000, 720: 60000 };

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -98,14 +98,19 @@ function renderBadges(container) {
         </button>`;
     }).join('');
     el.querySelectorAll('button').forEach(btn => {
-        btn.addEventListener('click', () => {
+        btn.addEventListener('click', (e) => {
             const id = btn.dataset.sfp;
-            const allVis = moduleMeta.every(m => visibility[m.id] !== false);
-            const onlyThis = visibility[id] !== false
-                && moduleMeta.filter(m => m.id !== id).every(m => visibility[m.id] === false);
-            if (onlyThis) { visibility = {}; }
-            else if (allVis) { moduleMeta.forEach(m => visibility[m.id] = m.id === id); }
-            else { visibility[id] = visibility[id] === false; }
+
+            if (e.ctrlKey || e.metaKey) {
+                visibility[id] = false;
+            } else {
+                const allVis = moduleMeta.every(m => visibility[m.id] !== false);
+                const onlyThis = visibility[id] !== false
+                    && moduleMeta.filter(m => m.id !== id).every(m => visibility[m.id] === false);
+                if (onlyThis) { visibility = {}; }
+                else if (allVis) { moduleMeta.forEach(m => visibility[m.id] = m.id === id); }
+                else { visibility[id] = visibility[id] === false; }
+            }
             updateVisibility();
             renderBadges(container);
         });

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -97,8 +97,11 @@ function renderBadges(container) {
             <span>${escapeHtml(m.label)}</span>
         </button>`;
     }).join('');
-    el.querySelectorAll('button').forEach(btn => {
-        btn.addEventListener('click', (e) => {
+    if (!el._delegated) {
+        el._delegated = true;
+        el.addEventListener('click', (e) => {
+            const btn = e.target.closest('button[data-sfp]');
+            if (!btn) return;
             const id = btn.dataset.sfp;
 
             if (e.ctrlKey || e.metaKey) {
@@ -114,7 +117,7 @@ function renderBadges(container) {
             updateVisibility();
             renderBadges(container);
         });
-    });
+    }
 }
 
 function updateVisibility() {


### PR DESCRIPTION
## Summary

- **33-color chart palette** built from Observable 10, Tableau, D3 Paired, and hand-selected colors. All pairs verified to have deltaE > 16 (perceptually distinct). Defined once in `chart-defaults.js` (JS) and `ChartPalette.cs` (C#) - single source of truth for both Blazor and JS charts.
- **Hash-based color assignment** for Latency and Device Stats charts so device colors are stable across categories, tabs, and app restarts. Same display name = same color.
- **Ctrl+Click (Cmd+Click) on filter badges** toggles individual series without the solo/toggle logic. Applied to all chart filter badges (Latency, Device Stats, SFP, WAN Speed Test, Threat Dashboard).
- **Event delegation on filter badges** fixes a race condition where poll-driven DOM rebuilds could swallow clicks.
- **WAN Speed Test badge behavior** now matches Monitoring charts (solo/toggle pattern, badges default to selected).
- **SNMP health fallback fix** - devices where SNMP is configured but doesn't support health OIDs (e.g., USW-Flex-XG) now get CPU/memory from the UniFi API instead of silently dropping health data.

## Test plan

- [ ] Verify chart colors are visually distinct across all Monitoring categories (LAN, ISP, Transit, Internet)
- [ ] Same device shows same color on Latency and Device Stats tabs
- [ ] Click badge: solo when all visible, show-all when solo'd, toggle otherwise
- [ ] Ctrl+Click badge: always toggles that one series
- [ ] Rapid clicking during poll cycles doesn't drop clicks
- [ ] WAN Speed Test badges start bright/selected
- [ ] USW-Flex-XG (or similar) shows CPU/memory data on Device Stats
- [ ] Wi-Fi Optimizer, ClientDashboard, ThreatDashboard custom colors unchanged