### PR TITLE
Mobile UX: touch interactions, responsive layout, iOS fixes

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -202,7 +202,11 @@
         };
 
         attachListener(getScrollEl());
-        window.addEventListener('resize', function() { attachListener(getScrollEl()); });
+        window.addEventListener('resize', function() {
+            attachListener(getScrollEl());
+            var mc = document.querySelector('.main-content');
+            if (mc) mc.scrollTop = mc.scrollTop + 0;
+        });
 
         // Restart auto-hide timer when sidebar closes
         var sidebar = document.querySelector('.sidebar');

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -202,10 +202,9 @@
         };
 
         attachListener(getScrollEl());
-        window.addEventListener('resize', function() {
-            attachListener(getScrollEl());
-            var mc = document.querySelector('.main-content');
-            if (mc) mc.scrollTop = mc.scrollTop + 0;
+        window.addEventListener('resize', function() { attachListener(getScrollEl()); });
+        window.addEventListener('orientationchange', function() {
+            setTimeout(function() { window.scrollBy(0, 1); window.scrollBy(0, -1); }, 100);
         });
 
         // Restart auto-hide timer when sidebar closes

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -81,7 +81,7 @@
     // Targets .main-content (scroll container on mobile) and .page-content (desktop)
     (function() {
         function getScrollEl() {
-            if (window.innerWidth <= 768) return document.querySelector('.main-content');
+            if (window.innerWidth <= 1024) return document.querySelector('.main-content');
             return document.querySelector('.page-content');
         }
         var lastScrollTop = 0;
@@ -135,7 +135,7 @@
             }
 
             // Mobile-only: top bar hide/show, below-topbar offset
-            if (window.innerWidth <= 768) {
+            if (window.innerWidth <= 1024) {
                 var topBar = document.querySelector('.top-bar');
 
                 var nearBottom = currentEl.scrollHeight - st - currentEl.clientHeight < 40;
@@ -186,7 +186,7 @@
         // hidden=false: page nav (show bar, add padding)
         window.__setScrollState = function(hidden) {
             lastScrollTop = 0;
-            if (window.innerWidth <= 768) {
+            if (window.innerWidth <= 1024) {
                 var topBar = document.querySelector('.top-bar');
                 if (topBar) {
                     if (hidden) {
@@ -217,7 +217,7 @@
         window.__setPtrRef = function(ref) { window.__ptrDotNetRef = ref; };
         // Custom pull-to-refresh (replaces native, blocked by overscroll-behavior)
         (function() {
-            if (window.innerWidth > 768) return;
+            if (window.innerWidth > 1024) return;
             var container = document.querySelector('.main-content');
             var indicator = document.querySelector('.pull-to-refresh');
             if (!container || !indicator) return;

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -111,11 +111,11 @@ else
         <!-- Top stat cards: WAN rates, gateway RTT/loss, ISP/Transit mean RTT/loss -->
         <div class="monitoring-stat-cards">
             @{ var wanRates = GetWanRates(); }
-            <div class="monitoring-stat-card">
+            <div class="monitoring-stat-card monitoring-stat-rate">
                 <div class="stat-value" style="color: #3b82f6;">@FormatRate(wanRates.download)</div>
                 <div class="stat-label">WAN Download</div>
             </div>
-            <div class="monitoring-stat-card">
+            <div class="monitoring-stat-card monitoring-stat-rate">
                 <div class="stat-value" style="color: #10b981;">@FormatRate(wanRates.upload)</div>
                 <div class="stat-label">WAN Upload</div>
             </div>
@@ -765,7 +765,6 @@ else
         .monitoring-stat-card {
             flex: 1 1 80px;
             min-width: 70px;
-            min-height: 58px;
             padding: 0.5rem 0.5rem;
         }
         .monitoring-stat-card .stat-value {
@@ -774,6 +773,9 @@ else
         .monitoring-stat-pair {
             gap: 0.5rem;
             flex-basis: 170px;
+        }
+        .monitoring-stat-rate {
+            min-height: 68px;
         }
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -204,13 +204,15 @@ else
                 <div class="stat-label">Gateway Temp</div>
             </div>
             @{ var fabricLoad = GetTotalFabricLoad(); }
-            <div class="monitoring-stat-card">
-                <div class="stat-value" style="color: #3b82f6;">@FormatRate(fabricLoad.ingress)</div>
-                <div class="stat-label">Fabric Ingress</div>
-            </div>
-            <div class="monitoring-stat-card">
-                <div class="stat-value" style="color: #10b981;">@FormatRate(fabricLoad.egress)</div>
-                <div class="stat-label">Fabric Egress</div>
+            <div class="monitoring-stat-pair">
+                <div class="monitoring-stat-card">
+                    <div class="stat-value" style="color: #3b82f6;">@FormatRate(fabricLoad.ingress)</div>
+                    <div class="stat-label">Fabric Ingress</div>
+                </div>
+                <div class="monitoring-stat-card">
+                    <div class="stat-value" style="color: #10b981;">@FormatRate(fabricLoad.egress)</div>
+                    <div class="stat-label">Fabric Egress</div>
+                </div>
             </div>
         </div>
 
@@ -727,6 +729,15 @@ else
         min-width: 100px;
         text-align: center;
     }
+    .monitoring-stat-pair {
+        display: flex;
+        gap: 0.75rem;
+        flex: 2 1 250px;
+    }
+    .monitoring-stat-pair .monitoring-stat-card {
+        flex: 1 1 0;
+        min-width: 0;
+    }
     .monitoring-stat-card .stat-value {
         font-size: 1.3rem;
         font-weight: 600;
@@ -754,10 +765,15 @@ else
         .monitoring-stat-card {
             flex: 1 1 80px;
             min-width: 70px;
+            min-height: 58px;
             padding: 0.5rem 0.5rem;
         }
         .monitoring-stat-card .stat-value {
             font-size: 1rem;
+        }
+        .monitoring-stat-pair {
+            gap: 0.5rem;
+            flex-basis: 170px;
         }
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -775,7 +775,7 @@ else
             flex-basis: 170px;
         }
         .monitoring-stat-rate {
-            min-height: 68px;
+            min-height: 98px;
         }
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -842,8 +842,11 @@ else
         color: var(--text-primary);
     }
     @@media (max-width: 768px) {
-        .lan-flow-map-2d-card {
-            overflow: visible;
+        .lan-flow-map-2d-stage {
+            height: auto;
+        }
+        .lan-flow-map-2d-stage .lfm2d-canvas {
+            height: clamp(520px, 70vh, 820px);
         }
     }
 </style>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -845,12 +845,6 @@ else
         .lan-flow-map-2d-card {
             overflow: visible;
         }
-        .lan-flow-map-2d-stage {
-            height: auto;
-        }
-        .lan-flow-map-2d-stage .lfm2d-canvas {
-            height: clamp(400px, 55vh, 600px);
-        }
     }
 </style>
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -839,6 +839,17 @@ else
         background: rgba(51,56,68,0.9);
         color: var(--text-primary);
     }
+    @@media (max-width: 768px) {
+        .lan-flow-map-2d-card {
+            overflow: visible;
+        }
+        .lan-flow-map-2d-stage {
+            height: auto;
+        }
+        .lan-flow-map-2d-stage .lfm2d-canvas {
+            height: clamp(400px, 55vh, 600px);
+        }
+    }
 </style>
 
 @code {

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -848,6 +848,9 @@ else
         .lan-flow-map-2d-stage .lfm2d-canvas {
             height: clamp(520px, 70vh, 820px);
         }
+        .lan-flow-map-2d-stage.lan-flow-map-fullscreen .lfm2d-canvas {
+            height: 100%;
+        }
     }
 </style>
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -806,9 +806,11 @@ else
         line-height: 1.35;
         color: var(--text-primary);
         pointer-events: none;
-        display: none;
         z-index: 10;
         max-width: 260px;
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity 0.15s ease, visibility 0.15s ease;
     }
     .lan-flow-map-2d-stage .lan-flow-map-controls {
         right: 3.1rem;

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -758,6 +758,11 @@ else
         font-size: 13px;
         cursor: pointer;
     }
+    @@media (max-width: 1024px) {
+        .monitoring-stat-rate {
+            min-height: 98px;
+        }
+    }
     @@media (max-width: 768px) {
         .monitoring-stat-cards {
             gap: 0.5rem;
@@ -773,9 +778,6 @@ else
         .monitoring-stat-pair {
             gap: 0.5rem;
             flex-basis: 170px;
-        }
-        .monitoring-stat-rate {
-            min-height: 98px;
         }
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14578,7 +14578,7 @@ a.affected-client:hover {
         top: 0.5rem;
     }
     .lan-flow-map-controls {
-        right: 2.5rem;
+        right: 3.1rem;
         top: 0.5rem;
     }
     .lan-flow-map-legend {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2884,10 +2884,7 @@ select.form-control {
     .timestamp {
         font-size: 0.75rem;
     }
-}
 
-
-@media (max-width: 768px) {
     /* Pull-to-refresh indicator */
     .pull-to-refresh {
         position: absolute;
@@ -2929,7 +2926,9 @@ select.form-control {
         from { transform: rotate(0deg) scale(1.4); }
         to { transform: rotate(360deg) scale(1.4); }
     }
+}
 
+@media (max-width: 768px) {
     /* Client dashboard identity bar: smooth collapse name/meta when scrolled down */
     .identity-bar .identity-name,
     .identity-bar .identity-meta {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -114,6 +114,7 @@ a:hover {
 .app-container {
     display: flex;
     height: 100vh;
+    height: 100dvh;
     overflow: hidden;
 }
 
@@ -2800,6 +2801,7 @@ select.form-control {
         top: 0;
         left: 0;
         height: 100vh;
+        height: 100dvh;
         width: 280px;
         transform: translateX(-100%);
         transition: transform 0.3s ease;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14523,11 +14523,14 @@ a.affected-client:hover {
     color: var(--text-primary);
     pointer-events: none;
     z-index: 10;
-    display: none;
     max-width: 260px;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.15s ease, visibility 0.15s ease;
 }
 .lan-flow-map-tooltip.is-visible {
-    display: block;
+    opacity: 1;
+    visibility: visible;
 }
 .lan-flow-map-tooltip-title {
     font-weight: 500;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2850,12 +2850,14 @@ select.form-control {
         height: auto;
         padding: 0.75rem 1rem;
         gap: 0.5rem;
-        transition: transform 0.2s ease, margin 0.2s ease;
+        transition: transform 0.2s ease;
     }
 
     .top-bar.top-bar-hidden {
+        position: absolute;
+        left: 0;
+        right: 0;
         transform: translateY(-100%);
-        margin-bottom: -3rem;
     }
 
     .app-footer {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2740,6 +2740,115 @@ select.form-control {
     .dashboard-card-wrapper.card-span-2 {
         grid-column: span 1;
     }
+
+    /* Show hamburger button */
+    .hamburger-btn {
+        display: block;
+    }
+
+    /* Show mobile logo next to hamburger */
+    .mobile-logo {
+        display: block;
+        height: 60px;
+        margin: -0.5rem 0;
+        max-height: 20vw;
+    }
+
+    .mobile-logo img {
+        height: 100%;
+        width: auto;
+    }
+
+    /* Off-canvas sidebar */
+    .sidebar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        height: 100vh;
+        width: 280px;
+        transform: translateX(-100%);
+        transition: transform 0.3s ease;
+        z-index: 1000;
+        overflow-y: auto;
+    }
+
+    .sidebar.open {
+        transform: translateX(0);
+    }
+
+    /* Overlay when sidebar is open */
+    .sidebar-overlay {
+        display: none;
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(0, 0, 0, 0.5);
+        z-index: 999;
+    }
+
+    .sidebar-overlay.visible {
+        display: block;
+    }
+
+    /* Main content takes full width */
+    .main-content {
+        width: 100%;
+        overflow-y: auto;
+        overflow-x: hidden;
+        overscroll-behavior-y: contain;
+    }
+
+    .page-content {
+        overflow-y: visible;
+        flex: none;
+    }
+
+    /* Top bar adjustments */
+    .top-bar {
+        position: sticky;
+        top: 0;
+        z-index: 100;
+        height: auto;
+        padding: 0.75rem 1rem;
+        gap: 0.5rem;
+        transition: transform 0.2s ease, margin 0.2s ease;
+    }
+
+    .top-bar.top-bar-hidden {
+        transform: translateY(-100%);
+        margin-bottom: -3rem;
+    }
+
+    .app-footer {
+        padding: 0.5rem 1rem;
+        font-size: 0.6rem;
+        opacity: 0;
+        transition: opacity 0.3s ease;
+    }
+
+    .app-footer.footer-visible {
+        opacity: 1;
+    }
+
+    /* Client dashboard identity bar: shift below top bar when it's visible */
+    .identity-bar.below-topbar {
+        top: 70px;
+    }
+
+    .status-indicators {
+        display: none;
+    }
+
+    .header-actions {
+        flex: 1;
+        justify-content: flex-end;
+    }
+
+    .timestamp {
+        font-size: 0.75rem;
+    }
 }
 
 /* Hamburger Menu Button - hidden on desktop */
@@ -2820,107 +2929,6 @@ select.form-control {
         to { transform: rotate(360deg) scale(1.4); }
     }
 
-    /* Show hamburger button on mobile */
-    .hamburger-btn {
-        display: block;
-    }
-
-    /* Show mobile logo next to hamburger */
-    .mobile-logo {
-        display: block;
-        height: 60px;
-        margin: -0.5rem 0;
-        max-height: 20vw;
-    }
-
-    .mobile-logo img {
-        height: 100%;
-        width: auto;
-    }
-
-    /* Off-canvas sidebar */
-    .sidebar {
-        position: fixed;
-        top: 0;
-        left: 0;
-        height: 100vh;
-        width: 280px;
-        transform: translateX(-100%);
-        transition: transform 0.3s ease;
-        z-index: 1000;
-        overflow-y: auto;
-    }
-
-    .sidebar.open {
-        transform: translateX(0);
-    }
-
-    /* Overlay when sidebar is open */
-    .sidebar-overlay {
-        display: none;
-        position: fixed;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: rgba(0, 0, 0, 0.5);
-        z-index: 999;
-    }
-
-    .sidebar-overlay.visible {
-        display: block;
-    }
-
-    /* Main content takes full width */
-    .main-content {
-        width: 100%;
-    }
-
-    /* Top bar adjustments */
-    /* Mobile: main-content becomes scroll container, top bar is sticky */
-    .main-content {
-        overflow-y: auto;
-        overflow-x: hidden;
-        overscroll-behavior-y: contain;
-        /* scroll-padding-top set dynamically by JS based on top bar visibility */
-    }
-
-    .page-content {
-        overflow-y: visible;
-        flex: none;
-    }
-
-    .top-bar {
-        position: sticky;
-        top: 0;
-        z-index: 100;
-        height: auto;
-        padding: 0.75rem 1rem;
-        gap: 0.5rem;
-        transition: transform 0.2s ease, margin 0.2s ease;
-    }
-
-    .top-bar.top-bar-hidden {
-        transform: translateY(-100%);
-        margin-bottom: -3rem;
-    }
-
-    .app-footer {
-        padding: 0.5rem 1rem;
-        font-size: 0.6rem;
-        opacity: 0;
-        transition: opacity 0.3s ease;
-    }
-
-    .app-footer.footer-visible {
-        opacity: 1;
-    }
-
-    /* Client dashboard identity bar: shift below top bar when it's visible */
-    .identity-bar.below-topbar {
-        top: 70px;
-    }
-
     /* Client dashboard identity bar: smooth collapse name/meta when scrolled down */
     .identity-bar .identity-name,
     .identity-bar .identity-meta {
@@ -2947,19 +2955,6 @@ select.form-control {
         margin-right: -16px;
         padding-left: 16px;
         padding-right: 16px;
-    }
-
-    .status-indicators {
-        display: none;
-    }
-
-    .header-actions {
-        flex: 1;
-        justify-content: flex-end;
-    }
-
-    .timestamp {
-        font-size: 0.75rem;
     }
 
     /* Content adjustments */

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2727,6 +2727,41 @@ select.form-control {
     border-top: 1px solid var(--border-color);
 }
 
+/* Hamburger Menu Button - hidden on desktop */
+.hamburger-btn {
+    display: none;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0.5rem;
+    margin-right: 0.5rem;
+}
+
+.hamburger-btn span {
+    display: block;
+    width: 24px;
+    height: 3px;
+    background: var(--text-primary);
+    border-radius: 2px;
+    margin: 5px 0;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+/* Mobile logo - hidden on desktop */
+.mobile-logo {
+    display: none;
+}
+
+/* Sidebar Overlay - hidden on desktop */
+.sidebar-overlay {
+    display: none;
+}
+
+/* Hidden on desktop, shown only in mobile media query below */
+.pull-to-refresh {
+    display: none;
+}
+
 /* Responsive Design */
 @media (max-width: 1024px) {
     .content-grid {
@@ -2851,40 +2886,6 @@ select.form-control {
     }
 }
 
-/* Hamburger Menu Button - hidden on desktop */
-.hamburger-btn {
-    display: none;
-    background: none;
-    border: none;
-    cursor: pointer;
-    padding: 0.5rem;
-    margin-right: 0.5rem;
-}
-
-.hamburger-btn span {
-    display: block;
-    width: 24px;
-    height: 3px;
-    background: var(--text-primary);
-    border-radius: 2px;
-    margin: 5px 0;
-    transition: transform 0.3s ease, opacity 0.3s ease;
-}
-
-/* Mobile logo - hidden on desktop */
-.mobile-logo {
-    display: none;
-}
-
-/* Sidebar Overlay - hidden on desktop */
-.sidebar-overlay {
-    display: none;
-}
-
-/* Hidden on desktop, shown only in mobile media query below */
-.pull-to-refresh {
-    display: none;
-}
 
 @media (max-width: 768px) {
     /* Pull-to-refresh indicator */

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -326,8 +326,6 @@ class LanFlowMap2D {
         this._el.innerHTML='';
         const canvas=document.createElement('canvas');
         canvas.className='lfm2d-canvas';
-        canvas.style.width='100%';
-        canvas.style.height='100%';
         canvas.style.display='block';
         canvas.style.cursor='grab';
         canvas.style.touchAction='none';

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -316,13 +316,7 @@ class LanFlowMap2D {
         if(this._unsub)this._unsub();
         if(this._resizeObs)this._resizeObs.disconnect();
         if(this._onKeyDown)document.removeEventListener('keydown',this._onKeyDown);
-        if(this._isFullscreen){
-            this._el.classList.remove('lan-flow-map-fullscreen');
-            if(this._fsPlaceholder?.parentNode){
-                this._fsPlaceholder.parentNode.replaceChild(this._el,this._fsPlaceholder);
-                this._fsPlaceholder=null;
-            }
-        }
+        if(this._isFullscreen)this._el.classList.remove('lan-flow-map-fullscreen');
         this._streams=[];
         this._el.innerHTML='';
     }
@@ -739,9 +733,6 @@ class LanFlowMap2D {
         this._isFullscreen=!this._isFullscreen;
         const el=this._el;
         if(this._isFullscreen){
-            this._fsPlaceholder=document.createComment('fs');
-            el.parentNode.replaceChild(this._fsPlaceholder,el);
-            document.body.appendChild(el);
             el.classList.add('lan-flow-map-fullscreen');
             this._fsBtn.innerHTML=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
                 <polyline points="4 10 10 10 10 4"></polyline><polyline points="14 4 14 10 20 10"></polyline>
@@ -749,10 +740,6 @@ class LanFlowMap2D {
             this._fsBtn.setAttribute('data-tooltip','Exit fullscreen (Esc)');
         }else{
             el.classList.remove('lan-flow-map-fullscreen');
-            if(this._fsPlaceholder?.parentNode){
-                this._fsPlaceholder.parentNode.replaceChild(el,this._fsPlaceholder);
-                this._fsPlaceholder=null;
-            }
             this._fsBtn.innerHTML=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
                 <polyline points="3 8 3 3 8 3"></polyline><polyline points="16 3 21 3 21 8"></polyline>
                 <polyline points="21 16 21 21 16 21"></polyline><polyline points="8 21 3 21 3 16"></polyline></svg>`;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -596,8 +596,8 @@ class LanFlowMap2D {
     }
 
     _onMove(e){
-        if(!this._pointers.has(e.pointerId))return;
-        this._pointers.set(e.pointerId,{x:e.clientX,y:e.clientY});
+        if(this._pointers.has(e.pointerId))
+            this._pointers.set(e.pointerId,{x:e.clientX,y:e.clientY});
 
         if(this._pointers.size===2&&this._pinchStartDist>0){
             const pts=[...this._pointers.values()];

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -249,6 +249,13 @@ class LanFlowMap2D {
         // Pan/zoom: offset in world coords + scale
         this._ox=0; this._oy=0; this._scale=1;
         this._dragging=false; this._dragStart=null;
+        // Multi-touch pinch zoom
+        this._pointers=new Map();
+        this._pinchStartDist=0;
+        this._pinchStartScale=1;
+        this._pinchStartCenter=null;
+        this._pinchStartOx=0;
+        this._pinchStartOy=0;
         // World bounds
         this._bx=0; this._by=0; this._bw=800; this._bh=600;
 
@@ -323,6 +330,7 @@ class LanFlowMap2D {
         canvas.style.height='100%';
         canvas.style.display='block';
         canvas.style.cursor='grab';
+        canvas.style.touchAction='none';
         this._el.appendChild(canvas);
         this._canvas=canvas;
         this._ctx=canvas.getContext('2d');
@@ -526,7 +534,7 @@ class LanFlowMap2D {
         canvas.addEventListener('pointerdown',(e)=>this._onDown(e));
         canvas.addEventListener('pointermove',(e)=>this._onMove(e));
         canvas.addEventListener('pointerup',(e)=>this._onUp(e));
-        canvas.addEventListener('pointerleave',(e)=>{this._onUp(e);this._hideTooltip();});
+        canvas.addEventListener('pointerleave',(e)=>{this._onUp(e);if(this._pointers.size===0)this._hideTooltip();});
 
         // Resize
         this._resizeObs=new ResizeObserver(()=>this._resize());
@@ -566,14 +574,54 @@ class LanFlowMap2D {
     }
 
     _onDown(e){
-        if(e.button!==0)return;
+        this._pointers.set(e.pointerId,{x:e.clientX,y:e.clientY});
+        this._canvas.setPointerCapture(e.pointerId);
+
+        if(this._pointers.size===2){
+            this._dragging=false;
+            this._dragStart=null;
+            const pts=[...this._pointers.values()];
+            this._pinchStartDist=Math.hypot(pts[1].x-pts[0].x,pts[1].y-pts[0].y);
+            this._pinchStartScale=this._scale;
+            this._pinchStartCenter={x:(pts[0].x+pts[1].x)/2,y:(pts[0].y+pts[1].y)/2};
+            this._pinchStartOx=this._ox;
+            this._pinchStartOy=this._oy;
+            return;
+        }
+
+        if(e.button!==0&&e.pointerType==='mouse')return;
         this._dragging=true;
         this._dragStart={x:e.clientX,y:e.clientY,ox:this._ox,oy:this._oy};
         this._canvas.style.cursor='grabbing';
-        this._canvas.setPointerCapture(e.pointerId);
     }
 
     _onMove(e){
+        if(!this._pointers.has(e.pointerId))return;
+        this._pointers.set(e.pointerId,{x:e.clientX,y:e.clientY});
+
+        if(this._pointers.size===2&&this._pinchStartDist>0){
+            const pts=[...this._pointers.values()];
+            const dist=Math.hypot(pts[1].x-pts[0].x,pts[1].y-pts[0].y);
+            const center={x:(pts[0].x+pts[1].x)/2,y:(pts[0].y+pts[1].y)/2};
+
+            const newScale=Math.max(0.05,Math.min(10,this._pinchStartScale*(dist/this._pinchStartDist)));
+
+            const rect=this._canvas.getBoundingClientRect();
+            const cx0=this._pinchStartCenter.x-rect.left;
+            const cy0=this._pinchStartCenter.y-rect.top;
+            const wx=(cx0-this._cw/2)/this._pinchStartScale+this._pinchStartOx;
+            const wy=(cy0-this._ch/2)/this._pinchStartScale+this._pinchStartOy;
+
+            const cx1=center.x-rect.left;
+            const cy1=center.y-rect.top;
+
+            this._scale=newScale;
+            this._ox=wx-(cx1-this._cw/2)/newScale;
+            this._oy=wy-(cy1-this._ch/2)/newScale;
+            this._needsStaticRedraw=true;
+            return;
+        }
+
         const rect=this._canvas.getBoundingClientRect();
         const sx=e.clientX-rect.left, sy=e.clientY-rect.top;
         if(this._dragging&&this._dragStart){
@@ -587,11 +635,22 @@ class LanFlowMap2D {
         }
     }
 
-    _onUp(){
-        if(!this._dragging)return;
-        this._dragging=false;
-        this._dragStart=null;
-        this._canvas.style.cursor='grab';
+    _onUp(e){
+        this._pointers.delete(e.pointerId);
+        if(this._pointers.size<2)this._pinchStartDist=0;
+
+        if(this._pointers.size===1){
+            const remaining=[...this._pointers.values()][0];
+            this._dragging=true;
+            this._dragStart={x:remaining.x,y:remaining.y,ox:this._ox,oy:this._oy};
+            return;
+        }
+
+        if(this._pointers.size===0){
+            this._dragging=false;
+            this._dragStart=null;
+            this._canvas.style.cursor='grab';
+        }
     }
 
     _fitAll(){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -668,6 +668,7 @@ class LanFlowMap2D {
 
     _fitAll(){
         if(!this._root)return;
+        this._calcBounds(true);
         const margin=10;
         const sx=(this._cw-margin*2)/this._bw;
         const sy=(this._ch-margin*2)/this._bh;
@@ -1142,12 +1143,24 @@ class LanFlowMap2D {
         }
     }
 
-    _calcBounds(){
+    _calcBounds(visibleOnly){
         let x0=Infinity,y0=Infinity,x1=-Infinity,y1=-Infinity;
         const exp=(x,y,r)=>{x0=Math.min(x0,x-r);y0=Math.min(y0,y-r);x1=Math.max(x1,x+r);y1=Math.max(y1,y+r);};
-        const vis=(n)=>{exp(n.x,n.y,G.boxW);for(const c of n.infra)vis(c);for(const c of n.clients.slice(0,G.maxClients))exp(c.x,c.y,G.clientCellW/2);};
-        vis(this._root);
-        for(const c of this._clouds)exp(c.x,c.y,G.cloudR+30);
+        const walk=(n)=>{
+            exp(n.x,n.y,G.boxW);
+            for(const c of n.infra)walk(c);
+            if(!visibleOnly){
+                for(const c of n.clients.slice(0,G.maxClients))exp(c.x,c.y,G.clientCellW/2);
+            }else{
+                for(const c of n.clients.slice(0,G.maxClients)){
+                    if(this._isNodeVisible(c))exp(c.x,c.y,G.clientCellW/2);
+                }
+            }
+        };
+        walk(this._root);
+        if(!visibleOnly||this._isCloudVisible()){
+            for(const c of this._clouds)exp(c.x,c.y,G.cloudR+30);
+        }
         const p=20;
         this._bx=x0-p; this._by=y0-p;
         this._bw=(x1-x0)+p*2; this._bh=(y1-y0)+p*2;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -828,7 +828,8 @@ class LanFlowMap2D {
         this._tooltip.innerHTML=
             `<div style="font-weight:600;margin-bottom:3px">${esc(m(d.name||d.mac||''))}</div>`
             +rows.map(([k,v])=>`<div style="display:flex;justify-content:space-between;gap:12px"><span style="color:${C.textMuted}">${k}</span><span>${esc(String(v))}</span></div>`).join('');
-        this._tooltip.style.display='block';
+        this._tooltip.style.opacity='1';
+        this._tooltip.style.visibility='visible';
         // Position dynamically to stay within the container
         const tr=this._tooltip.getBoundingClientRect();
         const cr=this._el.getBoundingClientRect();
@@ -843,7 +844,7 @@ class LanFlowMap2D {
 
     _hideTooltip(){
         this._hoverNode=null;
-        if(this._tooltip)this._tooltip.style.display='none';
+        if(this._tooltip){this._tooltip.style.opacity='0';this._tooltip.style.visibility='hidden';}
     }
 
     // ---- Contour-based layout (Reingold-Tilford style) ----

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -248,6 +248,7 @@ class LanFlowMap2D {
 
         // Pan/zoom: offset in world coords + scale
         this._ox=0; this._oy=0; this._scale=1;
+        this._isFitted=false;
         this._dragging=false; this._dragStart=null;
         // Multi-touch pinch zoom
         this._pointers=new Map();
@@ -390,6 +391,7 @@ class LanFlowMap2D {
         filterBody.querySelector('.lan-flow-map-search').addEventListener('input',(e)=>{
             this._filter.text=(e.target.value||'').toLowerCase().trim();
             this._needsStaticRedraw=true;
+            if(this._isFitted)this._fitAll();
         });
         const bandChips=[...filterBody.querySelectorAll('.lan-flow-map-chip')];
         bandChips.forEach(chip=>{
@@ -401,6 +403,7 @@ class LanFlowMap2D {
                     if(onlyThis){for(const c of bandChips){this._filter.bands[c.dataset.band]=true;c.classList.add('is-on');}}
                     else{this._filter.bands[b]=!this._filter.bands[b];chip.classList.toggle('is-on',this._filter.bands[b]);}}
                 this._needsStaticRedraw=true;
+                if(this._isFitted)this._fitAll();
             });
         });
         this._el.appendChild(filter);
@@ -427,6 +430,7 @@ class LanFlowMap2D {
                 row.classList.toggle('is-on',this._overlays[key]);
                 try{localStorage.setItem('lanFlowMap2dOverlays',JSON.stringify(this._overlays));}catch{}
                 this._needsStaticRedraw=true;
+                if(this._isFitted)this._fitAll();
             });
             ctrlBody.appendChild(row);
         }
@@ -555,6 +559,7 @@ class LanFlowMap2D {
         this._staticCanvas.width=this._canvas.width;
         this._staticCanvas.height=this._canvas.height;
         this._needsStaticRedraw=true;
+        if(this._isFitted)this._fitAll();
     }
 
     // ---- Pan / Zoom ----
@@ -574,6 +579,7 @@ class LanFlowMap2D {
         const wAfter=this._screenToWorld(sx,sy);
         this._ox+=wBefore.x-wAfter.x;
         this._oy+=wBefore.y-wAfter.y;
+        this._isFitted=false;
         this._needsStaticRedraw=true;
     }
 
@@ -624,6 +630,7 @@ class LanFlowMap2D {
             this._scale=newScale;
             this._ox=wx-(cx1-this._cw/2)/newScale;
             this._oy=wy-(cy1-this._ch/2)/newScale;
+            this._isFitted=false;
             this._needsStaticRedraw=true;
             return;
         }
@@ -637,6 +644,7 @@ class LanFlowMap2D {
             const dy=(e.clientY-this._dragStart.y)/this._scale;
             this._ox=this._dragStart.ox-dx;
             this._oy=this._dragStart.oy-dy;
+            this._isFitted=false;
             this._needsStaticRedraw=true;
         } else {
             this._hitTest(sx,sy);
@@ -681,6 +689,7 @@ class LanFlowMap2D {
         this._scale=Math.min(sx,sy,2);
         this._ox=this._bx+this._bw/2;
         this._oy=this._by+this._bh/2;
+        this._isFitted=true;
         this._needsStaticRedraw=true;
     }
 
@@ -722,6 +731,7 @@ class LanFlowMap2D {
 
     _zoomBy(factor){
         this._scale=Math.max(0.05,Math.min(10,this._scale*factor));
+        this._isFitted=false;
         this._needsStaticRedraw=true;
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -534,7 +534,7 @@ class LanFlowMap2D {
         canvas.addEventListener('pointerdown',(e)=>this._onDown(e));
         canvas.addEventListener('pointermove',(e)=>this._onMove(e));
         canvas.addEventListener('pointerup',(e)=>this._onUp(e));
-        canvas.addEventListener('pointerleave',(e)=>{this._onUp(e);if(this._pointers.size===0)this._hideTooltip();});
+        canvas.addEventListener('pointerleave',(e)=>{this._onUp(e);if(this._pointers.size===0&&e.pointerType==='mouse')this._hideTooltip();});
 
         // Resize
         this._resizeObs=new ResizeObserver(()=>this._resize());

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -543,7 +543,7 @@ class LanFlowMap2D {
     }
 
     _resize(){
-        const rect=this._el.getBoundingClientRect();
+        const rect=this._canvas.getBoundingClientRect();
         this._dpr=window.devicePixelRatio||1;
         this._cw=rect.width; this._ch=rect.height;
         this._canvas.width=rect.width*this._dpr;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -743,7 +743,6 @@ class LanFlowMap2D {
             el.parentNode.replaceChild(this._fsPlaceholder,el);
             document.body.appendChild(el);
             el.classList.add('lan-flow-map-fullscreen');
-            void el.offsetHeight;
             this._fsBtn.innerHTML=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
                 <polyline points="4 10 10 10 10 4"></polyline><polyline points="14 4 14 10 20 10"></polyline>
                 <polyline points="20 14 14 14 14 20"></polyline><polyline points="10 20 10 14 4 14"></polyline></svg>`;
@@ -759,7 +758,7 @@ class LanFlowMap2D {
                 <polyline points="21 16 21 21 16 21"></polyline><polyline points="8 21 3 21 3 16"></polyline></svg>`;
             this._fsBtn.setAttribute('data-tooltip','Fullscreen');
         }
-        setTimeout(()=>{this._resize();this._fitAll();},50);
+        requestAnimationFrame(()=>requestAnimationFrame(()=>{this._resize();this._fitAll();}));
     }
 
     // ---- Tooltip hit-test ----

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -551,12 +551,6 @@ class LanFlowMap2D {
     }
 
     _resize(){
-        if(this._isFullscreen){
-            const el=this._el;
-            el.style.position='static';
-            void el.offsetHeight;
-            el.style.position='';
-        }
         const rect=this._canvas.getBoundingClientRect();
         this._dpr=window.devicePixelRatio||1;
         this._cw=rect.width; this._ch=rect.height;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -543,7 +543,7 @@ class LanFlowMap2D {
     }
 
     _resize(){
-        const rect=this._canvas.getBoundingClientRect();
+        const rect=this._el.getBoundingClientRect();
         this._dpr=window.devicePixelRatio||1;
         this._cw=rect.width; this._ch=rect.height;
         this._canvas.width=rect.width*this._dpr;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -776,7 +776,7 @@ class LanFlowMap2D {
             if(Math.abs(w.x-n.x)<G.boxW/2&&Math.abs(w.y-n.y)<G.boxH/2)hit=n;
             for(const c of n.infra)checkNode(c);
             for(const c of n.clients.slice(0,G.maxClients)){
-                if(Math.abs(w.x-c.x)<G.clientCellW/2&&Math.abs(w.y-c.y)<G.clientCellH/2)hit=c;
+                if(this._isNodeVisible(c)&&Math.abs(w.x-c.x)<G.clientCellW/2&&Math.abs(w.y-c.y)<G.clientCellH/2)hit=c;
             }
         };
         if(this._root)checkNode(this._root);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -733,6 +733,7 @@ class LanFlowMap2D {
             el.parentNode.replaceChild(this._fsPlaceholder,el);
             document.body.appendChild(el);
             el.classList.add('lan-flow-map-fullscreen');
+            void el.offsetHeight;
             this._fsBtn.innerHTML=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
                 <polyline points="4 10 10 10 10 4"></polyline><polyline points="14 4 14 10 20 10"></polyline>
                 <polyline points="20 14 14 14 14 20"></polyline><polyline points="10 20 10 14 4 14"></polyline></svg>`;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -315,7 +315,13 @@ class LanFlowMap2D {
         if(this._unsub)this._unsub();
         if(this._resizeObs)this._resizeObs.disconnect();
         if(this._onKeyDown)document.removeEventListener('keydown',this._onKeyDown);
-        if(this._isFullscreen)this._el.classList.remove('lan-flow-map-fullscreen');
+        if(this._isFullscreen){
+            this._el.classList.remove('lan-flow-map-fullscreen');
+            if(this._fsPlaceholder?.parentNode){
+                this._fsPlaceholder.parentNode.replaceChild(this._el,this._fsPlaceholder);
+                this._fsPlaceholder=null;
+            }
+        }
         this._streams=[];
         this._el.innerHTML='';
     }
@@ -723,6 +729,9 @@ class LanFlowMap2D {
         this._isFullscreen=!this._isFullscreen;
         const el=this._el;
         if(this._isFullscreen){
+            this._fsPlaceholder=document.createComment('fs');
+            el.parentNode.replaceChild(this._fsPlaceholder,el);
+            document.body.appendChild(el);
             el.classList.add('lan-flow-map-fullscreen');
             this._fsBtn.innerHTML=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
                 <polyline points="4 10 10 10 10 4"></polyline><polyline points="14 4 14 10 20 10"></polyline>
@@ -730,6 +739,10 @@ class LanFlowMap2D {
             this._fsBtn.setAttribute('data-tooltip','Exit fullscreen (Esc)');
         }else{
             el.classList.remove('lan-flow-map-fullscreen');
+            if(this._fsPlaceholder?.parentNode){
+                this._fsPlaceholder.parentNode.replaceChild(el,this._fsPlaceholder);
+                this._fsPlaceholder=null;
+            }
             this._fsBtn.innerHTML=`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
                 <polyline points="3 8 3 3 8 3"></polyline><polyline points="16 3 21 3 21 8"></polyline>
                 <polyline points="21 16 21 21 16 21"></polyline><polyline points="8 21 3 21 3 16"></polyline></svg>`;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -576,10 +576,12 @@ class LanFlowMap2D {
     _onDown(e){
         this._pointers.set(e.pointerId,{x:e.clientX,y:e.clientY});
         this._canvas.setPointerCapture(e.pointerId);
+        this._tapStart={x:e.clientX,y:e.clientY,id:e.pointerId};
 
         if(this._pointers.size===2){
             this._dragging=false;
             this._dragStart=null;
+            this._tapStart=null;
             const pts=[...this._pointers.values()];
             this._pinchStartDist=Math.hypot(pts[1].x-pts[0].x,pts[1].y-pts[0].y);
             this._pinchStartScale=this._scale;
@@ -625,6 +627,8 @@ class LanFlowMap2D {
         const rect=this._canvas.getBoundingClientRect();
         const sx=e.clientX-rect.left, sy=e.clientY-rect.top;
         if(this._dragging&&this._dragStart){
+            if(this._tapStart&&Math.hypot(e.clientX-this._tapStart.x,e.clientY-this._tapStart.y)>=8)
+                this._tapStart=null;
             const dx=(e.clientX-this._dragStart.x)/this._scale;
             const dy=(e.clientY-this._dragStart.y)/this._scale;
             this._ox=this._dragStart.ox-dx;
@@ -636,6 +640,9 @@ class LanFlowMap2D {
     }
 
     _onUp(e){
+        const wasTap=this._tapStart&&this._tapStart.id===e.pointerId
+            &&Math.hypot(e.clientX-this._tapStart.x,e.clientY-this._tapStart.y)<8;
+
         this._pointers.delete(e.pointerId);
         if(this._pointers.size<2)this._pinchStartDist=0;
 
@@ -643,6 +650,7 @@ class LanFlowMap2D {
             const remaining=[...this._pointers.values()][0];
             this._dragging=true;
             this._dragStart={x:remaining.x,y:remaining.y,ox:this._ox,oy:this._oy};
+            this._tapStart=null;
             return;
         }
 
@@ -650,7 +658,14 @@ class LanFlowMap2D {
             this._dragging=false;
             this._dragStart=null;
             this._canvas.style.cursor='grab';
+
+            if(wasTap&&e.pointerType!=='mouse'){
+                const rect=this._canvas.getBoundingClientRect();
+                const sx=e.clientX-rect.left, sy=e.clientY-rect.top;
+                this._hitTest(sx,sy);
+            }
         }
+        this._tapStart=null;
     }
 
     _fitAll(){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -551,6 +551,12 @@ class LanFlowMap2D {
     }
 
     _resize(){
+        if(this._isFullscreen){
+            const el=this._el;
+            el.style.position='static';
+            void el.offsetHeight;
+            el.style.position='';
+        }
         const rect=this._canvas.getBoundingClientRect();
         this._dpr=window.devicePixelRatio||1;
         this._cw=rect.width; this._ch=rect.height;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -340,18 +340,11 @@ export class LanFlowMap {
         const isFs = el.classList.contains('lan-flow-map-fullscreen');
         if (isFs) {
             el.classList.remove('lan-flow-map-fullscreen');
-            if (this._fsPlaceholder?.parentNode) {
-                this._fsPlaceholder.parentNode.replaceChild(el, this._fsPlaceholder);
-                this._fsPlaceholder = null;
-            }
             this._panels.fullscreenBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
                 <polyline points="3 8 3 3 8 3"></polyline><polyline points="16 3 21 3 21 8"></polyline>
                 <polyline points="21 16 21 21 16 21"></polyline><polyline points="8 21 3 21 3 16"></polyline></svg>`;
             this._panels.fullscreenBtn.setAttribute('data-tooltip', 'Fullscreen');
         } else {
-            this._fsPlaceholder = document.createComment('fs');
-            el.parentNode.replaceChild(this._fsPlaceholder, el);
-            document.body.appendChild(el);
             el.classList.add('lan-flow-map-fullscreen');
             this._panels.fullscreenBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
                 <polyline points="4 10 10 10 10 4"></polyline><polyline points="14 4 14 10 20 10"></polyline>
@@ -389,13 +382,8 @@ export class LanFlowMap {
 
     dispose() {
         this._destroyed = true;
-        if (this.stage.classList.contains('lan-flow-map-fullscreen')) {
+        if (this.stage.classList.contains('lan-flow-map-fullscreen'))
             this.stage.classList.remove('lan-flow-map-fullscreen');
-            if (this._fsPlaceholder?.parentNode) {
-                this._fsPlaceholder.parentNode.replaceChild(this.stage, this._fsPlaceholder);
-                this._fsPlaceholder = null;
-            }
-        }
         if (this._repositionMode) this._exitRepositionMode();
         this._dismissContextMenu();
         // The render loop registered via setAnimationLoop checks _destroyed

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -353,6 +353,7 @@ export class LanFlowMap {
             el.parentNode.replaceChild(this._fsPlaceholder, el);
             document.body.appendChild(el);
             el.classList.add('lan-flow-map-fullscreen');
+            void el.offsetHeight;
             this._panels.fullscreenBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
                 <polyline points="4 10 10 10 10 4"></polyline><polyline points="14 4 14 10 20 10"></polyline>
                 <polyline points="20 14 14 14 14 20"></polyline><polyline points="10 20 10 14 4 14"></polyline></svg>`;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -365,6 +365,11 @@ export class LanFlowMap {
     }
 
     _handleResize() {
+        if (this.stage.classList.contains('lan-flow-map-fullscreen')) {
+            this.stage.style.position = 'static';
+            void this.stage.offsetHeight;
+            this.stage.style.position = '';
+        }
         const rect = this.canvas.getBoundingClientRect();
         const width = Math.max(rect.width || this.canvas.clientWidth || 800, 320);
         const height = Math.max(rect.height || this.canvas.clientHeight || 480, 240);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -353,7 +353,6 @@ export class LanFlowMap {
             el.parentNode.replaceChild(this._fsPlaceholder, el);
             document.body.appendChild(el);
             el.classList.add('lan-flow-map-fullscreen');
-            void el.offsetHeight;
             this._panels.fullscreenBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
                 <polyline points="4 10 10 10 10 4"></polyline><polyline points="14 4 14 10 20 10"></polyline>
                 <polyline points="20 14 14 14 14 20"></polyline><polyline points="10 20 10 14 4 14"></polyline></svg>`;
@@ -362,7 +361,7 @@ export class LanFlowMap {
         document.dispatchEvent(new CustomEvent('lanflowmap-fullscreen', {
             detail: { fullscreen: !isFs }
         }));
-        setTimeout(() => this._handleResize(), 50);
+        requestAnimationFrame(() => requestAnimationFrame(() => this._handleResize()));
     }
 
     _handleResize() {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -365,11 +365,6 @@ export class LanFlowMap {
     }
 
     _handleResize() {
-        if (this.stage.classList.contains('lan-flow-map-fullscreen')) {
-            this.stage.style.position = 'static';
-            void this.stage.offsetHeight;
-            this.stage.style.position = '';
-        }
         const rect = this.canvas.getBoundingClientRect();
         const width = Math.max(rect.width || this.canvas.clientWidth || 800, 320);
         const height = Math.max(rect.height || this.canvas.clientHeight || 480, 240);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -340,11 +340,18 @@ export class LanFlowMap {
         const isFs = el.classList.contains('lan-flow-map-fullscreen');
         if (isFs) {
             el.classList.remove('lan-flow-map-fullscreen');
+            if (this._fsPlaceholder?.parentNode) {
+                this._fsPlaceholder.parentNode.replaceChild(el, this._fsPlaceholder);
+                this._fsPlaceholder = null;
+            }
             this._panels.fullscreenBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
                 <polyline points="3 8 3 3 8 3"></polyline><polyline points="16 3 21 3 21 8"></polyline>
                 <polyline points="21 16 21 21 16 21"></polyline><polyline points="8 21 3 21 3 16"></polyline></svg>`;
             this._panels.fullscreenBtn.setAttribute('data-tooltip', 'Fullscreen');
         } else {
+            this._fsPlaceholder = document.createComment('fs');
+            el.parentNode.replaceChild(this._fsPlaceholder, el);
+            document.body.appendChild(el);
             el.classList.add('lan-flow-map-fullscreen');
             this._panels.fullscreenBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
                 <polyline points="4 10 10 10 10 4"></polyline><polyline points="14 4 14 10 20 10"></polyline>
@@ -382,6 +389,13 @@ export class LanFlowMap {
 
     dispose() {
         this._destroyed = true;
+        if (this.stage.classList.contains('lan-flow-map-fullscreen')) {
+            this.stage.classList.remove('lan-flow-map-fullscreen');
+            if (this._fsPlaceholder?.parentNode) {
+                this._fsPlaceholder.parentNode.replaceChild(this.stage, this._fsPlaceholder);
+                this._fsPlaceholder = null;
+            }
+        }
         if (this._repositionMode) this._exitRepositionMode();
         this._dismissContextMenu();
         // The render loop registered via setAnimationLoop checks _destroyed

--- a/src/NetworkOptimizer.Web/wwwroot/js/scrollRestoration.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/scrollRestoration.js
@@ -11,7 +11,7 @@
     });
 
     function getScrollContainer() {
-        if (window.innerWidth <= 768) return document.querySelector('.main-content');
+        if (window.innerWidth <= 1024) return document.querySelector('.main-content');
         return document.querySelector('.page-content');
     }
 


### PR DESCRIPTION
## Summary

- **2D map pinch zoom and panning** - Multi-touch support with center-anchored pinch zoom, single-finger pan, and seamless transition when lifting a finger during pinch
- **Touch tooltips on 2D map** - Tap devices to show tooltips on touch screens; hidden clients excluded from hit-testing
- **Tooltip fade transitions** - Both 3D and 2D map tooltips fade in/out (0.15s) instead of snapping
- **Hamburger menu breakpoint raised to 1024px** - Sidebar collapses to hamburger at tablet widths, freeing horizontal space. JS scroll/top-bar/pull-to-refresh breakpoints updated to match
- **Monitoring stat card layout** - Fabric Ingress/Egress cards wrap as a pair; WAN rate cards get min-height at 1024px to prevent layout shift
- **2D scrubber visible on mobile** - Stage goes auto-height so the static-positioned scrubber flows below the canvas; fullscreen canvas fills the screen
- **2D fit-all respects overlays** - Toggling off wired/wifi clients or clouds recalculates bounds; auto-refits on filter/overlay changes and orientation change when fitted
- **3D overlay controls alignment** - Matches 2D positioning on mobile
- **iOS PWA touch offset fix** - scrollBy nudge on orientationchange forces WebKit to reconcile the touch coordinate space after rotation
- **Top bar hidden offset fix** - Uses position:absolute instead of margin-bottom:-3rem to fully remove from flow, eliminating touch target offset
- **Dynamic viewport height** - 100dvh on app-container and sidebar fixes grey bars in landscape when the address bar collapses

## Test plan

- [x] Pinch zoom and single-finger pan on 2D map (mobile)
- [x] Tap nodes for tooltips on 2D map (mobile); hidden clients don't trigger
- [x] Desktop mouse interactions unchanged (wheel zoom, drag pan, hover tooltips)
- [x] Tooltip fade in/out on both 3D and 2D maps
- [x] Hamburger menu appears at tablet widths (769-1024px)
- [x] Sidebar visible on desktop (>1024px)
- [x] Pull-to-refresh works with spinner visible at tablet widths
- [x] Scrubber visible below 2D canvas on mobile
- [x] 2D fullscreen fills screen on mobile
- [x] Fabric Ingress/Egress cards wrap together on narrow screens
- [x] WAN rate cards don't shift layout when values change
- [x] Fit-all zooms tighter when clients/clouds hidden; auto-refits on filter change
- [x] No touch offset after rotation in iOS PWA fullscreen
- [x] No grey bars in landscape mode