### PR TITLE
WAN interface selection for Network Tools probes

### DIFF
--- a/src/NetworkOptimizer.Monitoring/Probes/ProbeTypes.cs
+++ b/src/NetworkOptimizer.Monitoring/Probes/ProbeTypes.cs
@@ -25,7 +25,7 @@ public enum VantageKind
 /// What we're probing. Captures address + mode + optional port together so a target that
 /// only responds to TCP:443 stays probed that way (spec 5.4).
 /// </summary>
-public record ProbeTarget(string Address, ProbeMode Mode, int? Port = null)
+public record ProbeTarget(string Address, ProbeMode Mode, int? Port = null, string? SourceInterface = null)
 {
     public override string ToString() => Port.HasValue
         ? $"{Mode.ToString().ToLowerInvariant()}://{Address}:{Port}"

--- a/src/NetworkOptimizer.Monitoring/Probes/TracerouteOutputParser.cs
+++ b/src/NetworkOptimizer.Monitoring/Probes/TracerouteOutputParser.cs
@@ -143,6 +143,6 @@ public static class TracerouteOutputParser
         int count = 0;
         foreach (var ch in rest)
             if (ch == '*') count++;
-        return count == 0 ? 3 : count;
+        return count;
     }
 }

--- a/src/NetworkOptimizer.Web/Components/Pages/MonitoringTools.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/MonitoringTools.razor
@@ -9,6 +9,7 @@
 @inject NetworkOptimizer.Monitoring.Probes.LocalProbeExecutor LocalProbe
 @inject ProbeExecutorFactory ExecutorFactory
 @inject UniFiConnectionService ConnectionService
+@inject SqmService SqmService
 
 <PageTitle>Network Tools - Network Optimizer</PageTitle>
 
@@ -29,7 +30,7 @@
     <div class="card-body">
         <div class="form-group">
             <label class="form-label">From (vantage)</label>
-            <select class="form-control" @bind="_fromKey">
+            <select class="form-control" value="@_fromKey" @onchange="OnVantageChanged">
                 <option value="server">Network Optimizer server</option>
                 @foreach (var d in _devices)
                 {
@@ -51,6 +52,24 @@
                 </div>
             }
         </div>
+
+        @if (_isGatewaySelected && _wanInterfaces.Count > 0)
+        {
+            <div class="form-group">
+                <label class="form-label">WAN interface</label>
+                <select class="form-control" style="max-width: 360px;" @bind="_selectedWanInterface">
+                    <option value="">Auto (OS routing table)</option>
+                    @foreach (var wan in _wanInterfaces)
+                    {
+                        var wanLabel = !string.IsNullOrEmpty(wan.NetworkGroup)
+                            ? $"{wan.Name} ({wan.NetworkGroup}) - {wan.Interface}"
+                            : $"{wan.Name} - {wan.Interface}";
+                        <option value="@wan.Interface">@wanLabel</option>
+                    }
+                </select>
+                <p class="form-help">Bind the probe to a specific WAN link. Useful on multi-WAN gateways.</p>
+            </div>
+        }
 
         <div class="form-group">
             <label class="form-label">To (target)</label>
@@ -220,6 +239,9 @@
     private bool _sshCredentialsMissing;
 
     private List<DiscoveredDevice> _devices = new();
+    private List<WanInterfaceInfo> _wanInterfaces = new();
+    private string _selectedWanInterface = "";
+    private bool _isGatewaySelected;
 
     private PingProbeResult? _pingResult;
     private TracerouteResult? _traceResult;
@@ -228,9 +250,11 @@
 
     protected override async Task OnInitializedAsync()
     {
-        var cap = await LocalProbe.GetCapabilityAsync();
-        _localCapabilities = cap.Describe();
-        await LoadDevicesAsync();
+        var capTask = LocalProbe.GetCapabilityAsync();
+        var devicesTask = LoadDevicesAsync();
+        var wanTask = LoadWanInterfacesAsync();
+        await Task.WhenAll(capTask, devicesTask, wanTask);
+        _localCapabilities = capTask.Result.Describe();
     }
 
     private async Task LoadDevicesAsync()
@@ -246,6 +270,34 @@
                 .ToList() ?? new();
         }
         catch { _devices = new(); }
+    }
+
+    private async Task LoadWanInterfacesAsync()
+    {
+        try
+        {
+            if (!ConnectionService.IsConnected) return;
+            _wanInterfaces = await SqmService.GetWanInterfacesFromControllerAsync();
+        }
+        catch { _wanInterfaces = new(); }
+    }
+
+    private void OnVantageChanged(ChangeEventArgs e)
+    {
+        _fromKey = e.Value?.ToString() ?? "server";
+        _selectedWanInterface = "";
+        _sshCredentialsMissing = false;
+
+        if (_fromKey.StartsWith("device:"))
+        {
+            var mac = _fromKey.Substring("device:".Length);
+            var device = _devices.FirstOrDefault(d => d.Mac == mac);
+            _isGatewaySelected = device?.Type == DeviceType.Gateway;
+        }
+        else
+        {
+            _isGatewaySelected = false;
+        }
     }
 
     private void OnTargetPresetChange(ChangeEventArgs e)
@@ -303,7 +355,8 @@
                 _runError = "Couldn't resolve the chosen vantage; check SSH credentials.";
                 return;
             }
-            var target = new ProbeTarget(_targetAddress.Trim(), _probeMode, _probeMode == ProbeMode.Tcp ? _port : null);
+            var iface = _isGatewaySelected && !string.IsNullOrEmpty(_selectedWanInterface) ? _selectedWanInterface : null;
+            var target = new ProbeTarget(_targetAddress.Trim(), _probeMode, _probeMode == ProbeMode.Tcp ? _port : null, iface);
             _pingResult = await executor.PingAsync(target, count: 5);
         }
         catch (Exception ex)
@@ -334,7 +387,8 @@
                 _runError = "Couldn't resolve the chosen vantage; check SSH credentials.";
                 return;
             }
-            var target = new ProbeTarget(_targetAddress.Trim(), _probeMode, _probeMode == ProbeMode.Tcp ? _port : null);
+            var iface = _isGatewaySelected && !string.IsNullOrEmpty(_selectedWanInterface) ? _selectedWanInterface : null;
+            var target = new ProbeTarget(_targetAddress.Trim(), _probeMode, _probeMode == ProbeMode.Tcp ? _port : null, iface);
             _traceResult = await executor.TracerouteAsync(
                 target,
                 maxHops: 30,

--- a/src/NetworkOptimizer.Web/Components/Pages/MonitoringTools.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/MonitoringTools.razor
@@ -53,7 +53,7 @@
             }
         </div>
 
-        @if (_isGatewaySelected && _wanInterfaces.Count > 0)
+        @if (_isGatewaySelected && _wanInterfaces.Count > 1)
         {
             <div class="form-group">
                 <label class="form-label">WAN interface</label>

--- a/src/NetworkOptimizer.Web/Components/Pages/MonitoringTools.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/MonitoringTools.razor
@@ -9,7 +9,7 @@
 @inject NetworkOptimizer.Monitoring.Probes.LocalProbeExecutor LocalProbe
 @inject ProbeExecutorFactory ExecutorFactory
 @inject UniFiConnectionService ConnectionService
-@inject SqmService SqmService
+@inject ISqmService SqmService
 
 <PageTitle>Network Tools - Network Optimizer</PageTitle>
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/ProbeExecutorFactory.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/ProbeExecutorFactory.cs
@@ -1,7 +1,6 @@
-using Microsoft.Extensions.Logging;
+using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Monitoring.Probes;
 using NetworkOptimizer.Storage.Services;
-using NetworkOptimizer.UniFi.Models;
 using NetworkOptimizer.Web.Services.Ssh;
 
 namespace NetworkOptimizer.Web.Services.Monitoring;
@@ -20,6 +19,7 @@ public class ProbeExecutorFactory
 {
     private readonly LocalProbeExecutor _local;
     private readonly UniFiSshService _uniFiSsh;
+    private readonly IGatewaySshService _gatewaySsh;
     private readonly SshClientService _sshClient;
     private readonly ICredentialProtectionService _credentialProtection;
     private readonly UniFiConnectionService _connection;
@@ -29,6 +29,7 @@ public class ProbeExecutorFactory
     public ProbeExecutorFactory(
         LocalProbeExecutor local,
         UniFiSshService uniFiSsh,
+        IGatewaySshService gatewaySsh,
         SshClientService sshClient,
         ICredentialProtectionService credentialProtection,
         UniFiConnectionService connection,
@@ -37,6 +38,7 @@ public class ProbeExecutorFactory
     {
         _local = local;
         _uniFiSsh = uniFiSsh;
+        _gatewaySsh = gatewaySsh;
         _sshClient = sshClient;
         _credentialProtection = credentialProtection;
         _connection = connection;
@@ -57,7 +59,6 @@ public class ProbeExecutorFactory
 
         try
         {
-            // Look up the device's current management IP from topology.
             if (!_connection.IsConnected) return null;
             var devices = await _connection.GetDiscoveredDevicesAsync(ct);
             var device = devices?.FirstOrDefault(d =>
@@ -66,24 +67,42 @@ public class ProbeExecutorFactory
                               deviceMac.Replace('-', ':').ToLowerInvariant()));
             if (device == null || string.IsNullOrEmpty(device.DisplayIpAddress)) return null;
 
-            // Pull the user's UniFi SSH creds; require both username and a credential
-            // (password OR key path) before we attempt to construct anything.
-            var sshSettings = await _uniFiSsh.GetSettingsAsync();
-            if (sshSettings == null
-                || string.IsNullOrEmpty(sshSettings.Username)
-                || (string.IsNullOrEmpty(sshSettings.Password) && string.IsNullOrEmpty(sshSettings.PrivateKeyPath)))
+            SshConnectionInfo connection;
+
+            if (device.Type == DeviceType.Gateway)
             {
-                _logger.LogDebug("UniFi SSH credentials not configured; cannot build device vantage for {Mac}", deviceMac);
-                return null;
+                var gwSettings = await _gatewaySsh.GetSettingsAsync();
+                if (string.IsNullOrEmpty(gwSettings.Username)
+                    || (string.IsNullOrEmpty(gwSettings.Password) && string.IsNullOrEmpty(gwSettings.PrivateKeyPath)))
+                {
+                    _logger.LogDebug("Gateway SSH credentials not configured; cannot build gateway vantage for {Mac}", deviceMac);
+                    return null;
+                }
+
+                string? decryptedPassword = null;
+                if (!string.IsNullOrEmpty(gwSettings.Password))
+                    decryptedPassword = _credentialProtection.Decrypt(gwSettings.Password);
+
+                connection = SshConnectionInfo.FromGatewaySettings(gwSettings, decryptedPassword);
+            }
+            else
+            {
+                var sshSettings = await _uniFiSsh.GetSettingsAsync();
+                if (sshSettings == null
+                    || string.IsNullOrEmpty(sshSettings.Username)
+                    || (string.IsNullOrEmpty(sshSettings.Password) && string.IsNullOrEmpty(sshSettings.PrivateKeyPath)))
+                {
+                    _logger.LogDebug("UniFi SSH credentials not configured; cannot build device vantage for {Mac}", deviceMac);
+                    return null;
+                }
+
+                string? decryptedPassword = null;
+                if (!string.IsNullOrEmpty(sshSettings.Password))
+                    decryptedPassword = _credentialProtection.Decrypt(sshSettings.Password);
+
+                connection = SshConnectionInfo.FromUniFiSettings(sshSettings, device.DisplayIpAddress, decryptedPassword);
             }
 
-            string? decryptedPassword = null;
-            if (!string.IsNullOrEmpty(sshSettings.Password))
-            {
-                decryptedPassword = _credentialProtection.Decrypt(sshSettings.Password);
-            }
-
-            var connection = SshConnectionInfo.FromUniFiSettings(sshSettings, device.DisplayIpAddress, decryptedPassword);
             return new SshProbeExecutor(
                 _sshClient,
                 connection,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/SshProbeExecutor.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/SshProbeExecutor.cs
@@ -49,6 +49,15 @@ public class SshProbeExecutor : IProbeExecutor
             var pingHelp = await _ssh.ExecuteCommandAsync(_connection, "ping -h 2>&1 || true", TimeSpan.FromSeconds(5), ct);
             var traceHelp = await _ssh.ExecuteCommandAsync(_connection, "traceroute -h 2>&1 || true", TimeSpan.FromSeconds(5), ct);
 
+            var traceOut0 = (traceHelp.Output + traceHelp.Error).ToLowerInvariant();
+            if (traceHelp.ExitCode == 127 || traceOut0.Contains("not found"))
+            {
+                _logger.LogDebug("traceroute not found on {Vantage}, attempting install", Vantage.Id);
+                await _ssh.ExecuteCommandAsync(_connection,
+                    "apt-get install -y traceroute 2>/dev/null || true", TimeSpan.FromSeconds(30), ct);
+                traceHelp = await _ssh.ExecuteCommandAsync(_connection, "traceroute -h 2>&1 || true", TimeSpan.FromSeconds(5), ct);
+            }
+
             var pingOut = (pingHelp.Output + pingHelp.Error).ToLowerInvariant();
             var traceOut = (traceHelp.Output + traceHelp.Error).ToLowerInvariant();
 
@@ -105,8 +114,9 @@ public class SshProbeExecutor : IProbeExecutor
 
         var timeoutSec = Math.Max(1, (int)(perPingTimeout?.TotalSeconds ?? 2));
         // -c count -W timeout. The deadline flag (-w) is iputils-only; -W is supported in both
-        // iputils and busybox. Quote address to be safe.
-        var cmd = $"ping -c {count} -W {timeoutSec} {ShellEscape(target.Address)}";
+        // iputils and busybox. -I binds to a specific interface for WAN selection.
+        var ifaceFlag = !string.IsNullOrEmpty(target.SourceInterface) ? $"-I {ShellEscape(target.SourceInterface)} " : "";
+        var cmd = $"ping {ifaceFlag}-c {count} -W {timeoutSec} {ShellEscape(target.Address)}";
 
         var result = await _ssh.ExecuteCommandAsync(_connection, cmd, TimeSpan.FromSeconds(timeoutSec * count + 10), ct);
         var combined = string.IsNullOrWhiteSpace(result.Output) ? result.Error : result.Output;
@@ -181,16 +191,18 @@ public class SshProbeExecutor : IProbeExecutor
         }
 
         var waitSec = Math.Max(1, (int)(perHopTimeout?.TotalSeconds ?? 2));
-        string flag = target.Mode switch
+        string modeFlag = target.Mode switch
         {
             ProbeMode.Icmp when cap.CanIcmpTraceroute => "-I",
             ProbeMode.Tcp when cap.CanTcpProbe => $"-T -p {target.Port ?? 80}",
             _ => string.Empty
         };
 
-        // Keep PTR resolution enabled — the wizard uses hostnames as labelling signals
-        // (spec 5.5). The per-hop wait timeout still bounds the slowdown.
-        var cmd = $"traceroute -m {maxHops} -w {waitSec} {flag} {ShellEscape(target.Address)}".Trim();
+        var parts = new List<string> { "traceroute", $"-m {maxHops}", $"-w {waitSec}" };
+        if (!string.IsNullOrEmpty(modeFlag)) parts.Add(modeFlag);
+        if (!string.IsNullOrEmpty(target.SourceInterface)) parts.Add($"-i {ShellEscape(target.SourceInterface)}");
+        parts.Add(ShellEscape(target.Address));
+        var cmd = string.Join(" ", parts);
         var overall = totalDeadline ?? TimeSpan.FromSeconds(10);
         var result = await _ssh.ExecuteCommandAsync(_connection, cmd, overall, ct);
 


### PR DESCRIPTION
## Summary

- **WAN interface selector on Network Tools** - When a gateway is selected as the probe vantage on a multi-WAN setup, a new dropdown lists all WAN links by friendly name and Linux interface (e.g. "Comcast Cable (WAN1) - eth4"). Selecting one binds ping (`-I`) and traceroute (`-i`) to that interface, letting users isolate per-WAN latency and path. Single-WAN gateways hide the selector since there's nothing to choose.
- **Gateway SSH credential fix** - `ProbeExecutorFactory` was using generic UniFi SSH credentials for all devices, including gateways. Gateways with separate credentials (configured in Gateway SSH settings) would fail with "Permission denied". Now uses `IGatewaySshService` for gateways, matching every other gateway-facing service.
- **Traceroute auto-install** - If traceroute isn't found on the gateway during capability detection, attempts `apt-get install -y traceroute` before giving up.
- **Traceroute probe count fix** - `CountStars()` in the output parser returned 3 when no stars were present, doubling the displayed probe count on successful hops (showed "3 / 6" instead of "3 / 3").

## Test plan

- [x] On a multi-WAN gateway, select the gateway as vantage and verify the WAN interface dropdown appears
- [x] Select a specific WAN and run ping/traceroute - verify traffic goes out that link
- [x] Select "Auto" and verify default routing behavior
- [x] On a single-WAN gateway, verify the WAN dropdown does not appear
- [x] On a site where gateway SSH creds differ from UniFi SSH creds, verify gateway probes authenticate correctly
- [x] Verify traceroute results show correct probe counts (3 / 3, not 3 / 6)