### PR TITLE
Fix fabric ingress/egress only counting gateway

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1448,19 +1448,8 @@ else
     {
         if (_historicSnapshot != null)
             return (_historicSnapshot.FabricIngressBps, _historicSnapshot.FabricEgressBps);
-        double totalIn = 0, totalOut = 0;
-        var fabricMacs = _targets
-            .Where(t => t.TargetType == MonitoringTargetType.Fabric && !string.IsNullOrEmpty(t.DeviceMac))
-            .Select(t => t.DeviceMac!)
-            .Distinct(StringComparer.OrdinalIgnoreCase);
-        foreach (var mac in fabricMacs)
-        {
-            var stats = LiveStats.GetForDevice(mac);
-            if (stats == null) continue;
-            totalIn += stats.FabricIngressBps ?? 0;
-            totalOut += stats.FabricEgressBps ?? 0;
-        }
-        return (totalIn, totalOut);
+        var total = LiveStats.GetTotalFabricLoad();
+        return (total.IngressBps, total.EgressBps);
     }
 
     private static string FormatRate(double? bps)

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -328,19 +328,8 @@ else
 
     private (double ingress, double egress) GetTotalFabricLoad()
     {
-        double totalIn = 0, totalOut = 0;
-        var fabricMacs = _targets
-            .Where(t => t.TargetType == MonitoringTargetType.Fabric && !string.IsNullOrEmpty(t.DeviceMac))
-            .Select(t => t.DeviceMac!)
-            .Distinct(StringComparer.OrdinalIgnoreCase);
-        foreach (var mac in fabricMacs)
-        {
-            var stats = LiveStats.GetForDevice(mac);
-            if (stats == null) continue;
-            totalIn += stats.FabricIngressBps ?? 0;
-            totalOut += stats.FabricEgressBps ?? 0;
-        }
-        return (totalIn, totalOut);
+        var total = LiveStats.GetTotalFabricLoad();
+        return (total.IngressBps, total.EgressBps);
     }
 
     private static string FormatRate(double? bps)

--- a/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
@@ -186,6 +186,21 @@ public class MonitoringLiveStats
         };
     }
 
+    /// <summary>Total fabric ingress/egress across all devices in the cache.
+    /// Only devices with non-null fabric data contribute (APs are excluded
+    /// because the collection agent never calls RecordFabricSum for them).</summary>
+    public (double IngressBps, double EgressBps) GetTotalFabricLoad()
+    {
+        double totalIn = 0, totalOut = 0;
+        foreach (var kvp in _stats)
+        {
+            if (kvp.Value.FabricIngressBps == null && kvp.Value.FabricEgressBps == null) continue;
+            totalIn += kvp.Value.FabricIngressBps ?? 0;
+            totalOut += kvp.Value.FabricEgressBps ?? 0;
+        }
+        return (totalIn, totalOut);
+    }
+
     /// <summary>Latest SFP DDM snapshot for a given device port.</summary>
     public SfpLiveStats? GetSfpStats(string deviceMac, string portName)
     {


### PR DESCRIPTION
## Summary

- **Fabric stats now sum all gateways and switches** - `GetTotalFabricLoad()` was filtering through DB monitoring targets (`MonitoringTargetType.Fabric`) to find device MACs, which only included the gateway. Switches were excluded from the total.
- **Moved aggregation into `MonitoringLiveStats`** - New `GetTotalFabricLoad()` method sums directly from the in-memory cache across all devices with non-null fabric data. The collection agent already records fabric stats for all gateways, switches, and cellular modems via `RecordFabricSum`, so APs are naturally excluded (their fabric fields stay null).
- **Fixed in both Dashboard Live View and Monitoring Live View** - Both pages had identical buggy code; both now call the shared method.

## Test plan

- [x] Open Dashboard Live View and verify Fabric Ingress/Egress reflect traffic across all switches, not just the gateway
- [x] Open Monitoring page and verify the same cards show aggregate fabric load
- [x] Confirm values increase when generating traffic through switches (not just the gateway)