### PR TITLE
v1.17.16

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1448,19 +1448,8 @@ else
     {
         if (_historicSnapshot != null)
             return (_historicSnapshot.FabricIngressBps, _historicSnapshot.FabricEgressBps);
-        double totalIn = 0, totalOut = 0;
-        var fabricMacs = _targets
-            .Where(t => t.TargetType == MonitoringTargetType.Fabric && !string.IsNullOrEmpty(t.DeviceMac))
-            .Select(t => t.DeviceMac!)
-            .Distinct(StringComparer.OrdinalIgnoreCase);
-        foreach (var mac in fabricMacs)
-        {
-            var stats = LiveStats.GetForDevice(mac);
-            if (stats == null) continue;
-            totalIn += stats.FabricIngressBps ?? 0;
-            totalOut += stats.FabricEgressBps ?? 0;
-        }
-        return (totalIn, totalOut);
+        var total = LiveStats.GetTotalFabricLoad();
+        return (total.IngressBps, total.EgressBps);
     }
 
     private static string FormatRate(double? bps)

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -327,7 +327,7 @@ else
 
         <!-- Upstream tracer wizard -->
         <div id="upstream-discovery" style="margin-top: 1.5rem;">
-            <UpstreamTracerPanel ForceExpand="_forceExpandUpstream" />
+            <UpstreamTracerPanel ForceExpand="_forceExpandUpstream" OnSaved="StateHasChanged" />
         </div>
 
         <div style="margin-top: 1.5rem;">
@@ -800,7 +800,7 @@ else
     private async void SetActiveTab(string tab)
     {
         if (tab != "setup" && !_monitoringReady) return;
-        if (_upstreamDiscoveryPendingSave && tab != _activeTab)
+        if (_upstreamDiscoveryPendingSave && _activeTab == "performance" && tab != "performance")
         {
             var confirmed = await JS.InvokeAsync<bool>("confirm",
                 "Upstream Discovery results haven't been saved. If you leave now, you'll need to re-run discovery.\n\nLeave without saving?");
@@ -1135,7 +1135,10 @@ else
 
     private async Task OnBeforeInternalNavigation(LocationChangingContext context)
     {
-        if (_upstreamDiscoveryPendingSave)
+        // Only guard navigating away from the Monitoring page entirely.
+        // Tab switches within the page are handled by SetActiveTab.
+        if (_upstreamDiscoveryPendingSave
+            && !context.TargetLocation.Contains("/monitoring", StringComparison.OrdinalIgnoreCase))
         {
             var confirmed = await JS.InvokeAsync<bool>("confirm",
                 "Upstream Discovery results haven't been saved. If you leave now, you'll need to re-run discovery.\n\nLeave without saving?");

--- a/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
@@ -627,6 +627,7 @@ ls -la /var/config/run-syslog.sh</code></pre>
 
     .pt-status-metrics .status-indicator {
         width: 10px;
+        min-width: 10px;
         height: 10px;
         border-radius: 50%;
         display: inline-block;
@@ -721,6 +722,7 @@ ls -la /var/config/run-syslog.sh</code></pre>
 
     .pt-health-item .status-indicator {
         width: 8px;
+        min-width: 8px;
         height: 8px;
         border-radius: 50%;
         display: inline-block;

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -1129,6 +1129,7 @@
 
     .status-indicator {
         width: 10px;
+        min-width: 10px;
         height: 10px;
         border-radius: 50%;
         display: inline-block;

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSteering.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSteering.razor
@@ -379,6 +379,7 @@
 
     .ws-status-metrics .status-indicator {
         width: 10px;
+        min-width: 10px;
         height: 10px;
         border-radius: 50%;
         display: inline-block;

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -328,19 +328,8 @@ else
 
     private (double ingress, double egress) GetTotalFabricLoad()
     {
-        double totalIn = 0, totalOut = 0;
-        var fabricMacs = _targets
-            .Where(t => t.TargetType == MonitoringTargetType.Fabric && !string.IsNullOrEmpty(t.DeviceMac))
-            .Select(t => t.DeviceMac!)
-            .Distinct(StringComparer.OrdinalIgnoreCase);
-        foreach (var mac in fabricMacs)
-        {
-            var stats = LiveStats.GetForDevice(mac);
-            if (stats == null) continue;
-            totalIn += stats.FabricIngressBps ?? 0;
-            totalOut += stats.FabricEgressBps ?? 0;
-        }
-        return (totalIn, totalOut);
+        var total = LiveStats.GetTotalFabricLoad();
+        return (total.IngressBps, total.EgressBps);
     }
 
     private static string FormatRate(double? bps)

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -98,7 +98,7 @@
             {
                 <div class="form-group">
                     <label class="form-label">Access network technology</label>
-                    <select class="form-control" style="max-width: 250px;"
+                    <select class="form-control" style="max-width: 250px;@(_state.AccessTechnology == AccessTechnology.Unknown ? " outline: 2px solid rgba(59, 130, 246, 0.5); outline-offset: 2px; border-radius: 6px;" : "")"
                             value="@((int)_state.AccessTechnology)"
                             @onchange="OnAccessTechChanged">
                         @foreach (var tech in Enum.GetValues<AccessTechnology>())
@@ -165,24 +165,28 @@
                                         <th>Address</th>
                                         <th>Source</th>
                                         <th>Role</th>
+                                        <th>RTT</th>
                                     </tr>
                                 </thead>
                                 <tbody>
                                     @foreach (var hop in _state.AccessHops)
                                     {
-                                        <tr class="@(hop.Enabled ? "" : "row-disabled")">
+                                        <tr class="@(hop.Unreachable ? "row-disabled" : hop.Enabled ? "" : "row-disabled")">
                                             <td>
                                                 <input type="checkbox" checked="@hop.Enabled"
+                                                       disabled="@hop.Unreachable"
                                                        @onchange="e => hop.Enabled = (bool)e.Value!" />
                                             </td>
                                             <td>
                                                 <input type="text" class="form-control form-control-sm"
                                                        value="@hop.Label"
+                                                       disabled="@hop.Unreachable"
                                                        @onchange="e => hop.Label = (string)e.Value!" />
                                             </td>
                                             <td><code>@hop.Address</code> @(string.IsNullOrEmpty(hop.PtrHostname) ? "" : $"({hop.PtrHostname})")</td>
                                             <td>@(hop.Method == DiscoveryMethod.L2Neighbor ? "L2 neighbor" : $"Hop {hop.HopNumber}")</td>
                                             <td>@hop.Role.ToDisplayName()</td>
+                                            <td>@(hop.Unreachable ? "Unreachable" : hop.VerifiedRttMs.HasValue ? $"{hop.VerifiedRttMs:F1} ms" : "-")</td>
                                         </tr>
                                     }
                                 </tbody>
@@ -191,7 +195,7 @@
                     </div>
                 }
 
-                @if (_state.TransitAsns.Count > 0)
+                @if (TransitRouters.Count > 0)
                 {
                     <div class="form-group">
                         <label class="form-label">Transit networks</label>
@@ -201,33 +205,68 @@
                                 <thead>
                                     <tr>
                                         <th style="width: 40px;"></th>
+                                        <th>Label</th>
+                                        <th>Address</th>
                                         <th>ASN</th>
-                                        <th>Name</th>
-                                        <th>Target hop</th>
-                                        <th>Method</th>
+                                        <th>RTT</th>
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    @foreach (var asn in _state.TransitAsns)
+                                    @foreach (var asn in TransitRouters)
                                     {
-                                        <tr class="@(asn.Enabled ? "" : "row-disabled")">
+                                        <tr class="@(asn.Unreachable ? "row-disabled" : asn.Enabled ? "" : "row-disabled")">
                                             <td>
                                                 <input type="checkbox" checked="@asn.Enabled"
+                                                       disabled="@asn.Unreachable"
                                                        @onchange="e => asn.Enabled = (bool)e.Value!" />
                                             </td>
-                                            <td><code>AS@(asn.AsnNumber)</code></td>
-                                            <td>@asn.AsnName</td>
                                             <td>
-                                                @if (!string.IsNullOrEmpty(asn.HopAddress))
-                                                {
-                                                    <code>@asn.HopAddress</code>
-                                                }
-                                                else
-                                                {
-                                                    <span class="text-muted">-</span>
-                                                }
+                                                <input type="text" class="form-control form-control-sm"
+                                                       value="@asn.Label"
+                                                       disabled="@asn.Unreachable"
+                                                       @onchange="e => asn.Label = (string)e.Value!" />
                                             </td>
-                                            <td>@asn.Method.ToDisplayName()</td>
+                                            <td><code>@asn.HopAddress</code></td>
+                                            <td><code>AS@(asn.AsnNumber)</code> <span class="text-muted">@asn.AsnName</span></td>
+                                            <td>@(asn.Unreachable ? "Unreachable" : asn.VerifiedRttMs.HasValue ? $"{asn.VerifiedRttMs:F1} ms" : "-")</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                }
+
+                @if (PathEndHosts.Count > 0)
+                {
+                    <div class="form-group">
+                        <label class="form-label">Path-end Internet hosts</label>
+                        <p class="section-description">CDN and Internet services reachable through the discovered transit path.</p>
+                        <div class="table-responsive">
+                            <table class="data-table">
+                                <thead>
+                                    <tr>
+                                        <th style="width: 40px;"></th>
+                                        <th>Label</th>
+                                        <th>Endpoint</th>
+                                        <th>ASN</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var host in PathEndHosts)
+                                    {
+                                        <tr class="@(host.Enabled ? "" : "row-disabled")">
+                                            <td>
+                                                <input type="checkbox" checked="@host.Enabled"
+                                                       @onchange="e => host.Enabled = (bool)e.Value!" />
+                                            </td>
+                                            <td>
+                                                <input type="text" class="form-control form-control-sm"
+                                                       value="@host.Label"
+                                                       @onchange="e => host.Label = (string)e.Value!" />
+                                            </td>
+                                            <td><code>@host.PathProxyTarget</code></td>
+                                            <td><code>AS@(host.AsnNumber)</code> <span class="text-muted">@host.AsnName</span></td>
                                         </tr>
                                     }
                                 </tbody>
@@ -279,10 +318,13 @@
 
 @code {
     [Parameter] public bool ForceExpand { get; set; }
+    [Parameter] public EventCallback OnSaved { get; set; }
 
     private UpstreamTracerState _state = new();
     private System.Threading.Timer? _pollTimer;
     private bool _needsReview;
+    private List<TransitAsnCandidate> TransitRouters => _state.TransitAsns.Where(a => a.Method == DiscoveryMethod.DirectRouter).ToList();
+    private List<TransitAsnCandidate> PathEndHosts => _state.TransitAsns.Where(a => a.Method == DiscoveryMethod.PathProxy).ToList();
     private bool _collapsed;
     private DateTime _lastReviewCheck = DateTime.MinValue;
     private bool _justSaved;
@@ -344,6 +386,7 @@
         await Tracer.CommitResultsAsync();
         _state = Tracer.State;
         _justSaved = true;
+        await OnSaved.InvokeAsync();
         StateHasChanged();
 
         // Server side: invalidate the cached map snapshot so the next read
@@ -414,6 +457,25 @@
         return string.IsNullOrEmpty(first.AsnName)
             ? $"AS{first.AsnNumber}"
             : $"AS{first.AsnNumber} ({first.AsnName})";
+    }
+
+    private static string? FormatPtrLabel(string? hostname, string? ip)
+    {
+        if (string.IsNullOrEmpty(hostname) || hostname == ip) return null;
+        var parts = hostname.Split('.');
+        if (parts.Length <= 1) return hostname;
+        var ipOctets = (ip ?? "").Split('.');
+        if (ipOctets.Length == 4)
+        {
+            int matches = 0;
+            foreach (var part in parts)
+                foreach (var octet in ipOctets)
+                    if (part == octet || part == "h" + octet || part.Contains("-" + octet + "-")
+                        || part.StartsWith(octet + "-") || part.EndsWith("-" + octet))
+                    { matches++; break; }
+            if (matches >= 2) return null;
+        }
+        return string.Join('.', parts.Take(parts.Length - 1));
     }
 
     public void Dispose() => _pollTimer?.Dispose();

--- a/src/NetworkOptimizer.Web/Resources/PerfTweaks/06-mongodb-ssd-offload.sh
+++ b/src/NetworkOptimizer.Web/Resources/PerfTweaks/06-mongodb-ssd-offload.sh
@@ -174,8 +174,8 @@ if [ -f "$SSD_DB_DIR/WiredTiger" ]; then
     # Compare timestamps: if eMMC data is newer than SSD, the SSD copy is stale
     # (e.g., after a removal that copied SSD back to eMMC, then ran on eMMC for a while).
     # Re-migrate to pick up the newer eMMC data.
-    EMMC_TS=$(stat -c %Y "$EMMC_DB_DIR/WiredTiger" 2>/dev/null || echo 0)
-    SSD_TS=$(stat -c %Y "$SSD_DB_DIR/WiredTiger" 2>/dev/null || echo 0)
+    EMMC_TS=$(stat -c %Y "$EMMC_DB_DIR/WiredTiger.turtle" 2>/dev/null || echo 0)
+    SSD_TS=$(stat -c %Y "$SSD_DB_DIR/WiredTiger.turtle" 2>/dev/null || echo 0)
     if [ "$EMMC_TS" -gt "$SSD_TS" ]; then
         log "SSD copy is stale (eMMC is newer). Will re-migrate."
         NEEDS_MIGRATION=true

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -76,7 +76,8 @@ public class UpstreamTracerService
         new("Apple", "17.253.144.10"),                               // AS714
         new("Microsoft", "13.107.42.14"),                            // AS8068  - M365 SharePoint anycast
         new("Fastly", "151.101.1.69"),                               // AS54113 - reaches local PoP via anycast
-        new("Akamai", "23.0.0.1")                                    // AS20940 - global netarch anycast loopback
+        new("Akamai", "23.0.0.1"),                                   // AS20940 - global netarch anycast loopback
+        new("AT&T", "12.0.1.28", IsTransitProbe: true)                // AS7018  - probe to surface AT&T as transit
     };
 
     private record TraceEndpoint(string Label, string Address, bool IsTransitProbe = false);
@@ -197,11 +198,13 @@ public class UpstreamTracerService
         {
             if (_runningTask != null && !_runningTask.IsCompleted) return;
 
+            var preservedTech = State.AccessTechnology;
             State = new UpstreamTracerState
             {
                 Step = TracerStep.DetectingPublicIp,
                 StartedAt = DateTime.UtcNow,
-                CurrentActivity = "Reading WAN configuration from gateway..."
+                CurrentActivity = "Reading WAN configuration from gateway...",
+                AccessTechnology = preservedTech
             };
             _runningTask = Task.Run(() => RunAsync(ct), ct);
         }
@@ -605,45 +608,79 @@ public class UpstreamTracerService
         var firstPublicHop = candidateHops.FirstOrDefault(h => h.Asn != null);
         var accessAsn = firstPublicHop?.Asn?.Asn;
 
-        // Access hops walk, capped at 3. Two cases:
-        //   - accessAsn known: skip any null-Asn hops in the prefix (a private
-        //     intermediate like an upstream modem at 192.168.x.x that survived
-        //     the gateway-IP filter); only break when we hit a hop with a
-        //     different non-null ASN. Without the skip, an AT&T-style setup
-        //     where the UniFi sits behind a residential gateway aborts the
-        //     access classification before reaching the first AT&T hop.
-        //   - accessAsn null (no public hop in the trace at all - fully
-        //     filtered carrier, all-CGNAT): take the first private hops as
-        //     access until a public ASN unexpectedly appears.
-        _accessHopsResolved = new List<AttributedHop>();
-        foreach (var h in candidateHops)
+        // Collect ALL hops in the access ASN from the merged pool. Filter-based,
+        // not sequential - the merged pool interleaves hops from different traces
+        // so a sequential walk breaks at the first non-access hop and misses
+        // access-ASN hops that only appear in certain traces (e.g. a second
+        // border router used for specific transit peers).
+        if (accessAsn.HasValue)
         {
-            if (_accessHopsResolved.Count >= 3) break;
-            if (accessAsn.HasValue)
-            {
-                if (h.Asn == null) continue;
-                if (h.Asn.Asn != accessAsn.Value) break;
-            }
-            else
-            {
-                if (h.Asn != null) break;
-            }
-            _accessHopsResolved.Add(h);
+            _accessHopsResolved = candidateHops
+                .Where(h => h.Asn?.Asn == accessAsn.Value)
+                .ToList();
+        }
+        else
+        {
+            _accessHopsResolved = candidateHops
+                .TakeWhile(h => h.Asn == null)
+                .ToList();
         }
 
+        // Walk each individual trace to find border hops: an access-ASN hop
+        // whose next responding hop is in a different ASN. Different traces
+        // may exit through different border routers depending on the transit
+        // peer, so we union across all traces.
+        var borderIps = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (accessAsn.HasValue)
+        {
+            foreach (var (_, result) in results)
+            {
+                var hops = result.Hops
+                    .Where(h => h.Responded && !string.IsNullOrEmpty(h.Address)
+                                && !_gatewayIps.Contains(h.Address))
+                    .OrderBy(h => h.HopNumber)
+                    .ToList();
+                for (int i = 0; i < hops.Count - 1; i++)
+                {
+                    var ip = hops[i].Address!;
+                    if (!byIp.TryGetValue(ip, out var attributed) || attributed.Asn?.Asn != accessAsn.Value)
+                        continue;
+                    var nextIp = hops[i + 1].Address!;
+                    if (!byIp.TryGetValue(nextIp, out var nextAttr))
+                        continue;
+                    if (nextAttr.Asn != null && nextAttr.Asn.Asn != accessAsn.Value)
+                        borderIps.Add(ip);
+                }
+            }
+        }
+
+        var orgName = CleanAsnName(firstPublicHop?.Asn?.Name);
         State.AccessHops = _accessHopsResolved.Select(h => new AccessHopCandidate
         {
             TargetId = $"access-{NormalizeMacForId(h.Address)}",
-            Label = LabelAccessHop(h),
+            Label = "",
             Address = h.Address,
             PtrHostname = h.Hostname,
             AsnNumber = h.Asn?.Asn,
             AsnName = h.Asn?.Name,
-            Role = InferAccessRole(h, State.AccessTechnology, State.WanNeighborOuiVendor),
+            Role = borderIps.Contains(h.Address)
+                ? UpstreamRole.Border
+                : InferAccessRole(h, State.AccessTechnology, State.WanNeighborOuiVendor),
             HopNumber = h.HopNumber,
             RespondedTo = h.RespondedTo,
             Enabled = true
         }).ToList();
+
+        // Generate "<Org> <PTR-derived>" labels, same format as transit targets.
+        var accessIdx = 0;
+        foreach (var hop in State.AccessHops)
+        {
+            var ptrLabel = FormatTransitHopLabel(hop.PtrHostname, hop.Address);
+            if (ptrLabel != null)
+                hop.Label = $"{orgName} {ptrLabel}";
+            else
+                hop.Label = $"{orgName} {++accessIdx}";
+        }
 
         // Inject the L2 neighbor (from ip neigh) as the first access hop if it
         // wasn't already found by traceroute. On GPON the OLT is typically
@@ -657,7 +694,7 @@ public class UpstreamTracerService
             var l2Hop = new AccessHopCandidate
             {
                 TargetId = $"access-l2-{NormalizeMacForId(State.WanNeighborIp)}",
-                Label = LabelL2Neighbor(State.WanNeighborOuiVendor, State.AccessTechnology, l2Asn?.Name),
+                Label = $"{orgName} {LabelL2Role(State.WanNeighborOuiVendor, State.AccessTechnology)}",
                 Address = State.WanNeighborIp,
                 AsnNumber = l2Asn?.Asn,
                 AsnName = l2Asn?.Name,
@@ -736,11 +773,20 @@ public class UpstreamTracerService
             if (!string.IsNullOrWhiteSpace(destAsn.Name)) destinationOrgs.Add(destAsn.Name.Trim());
         }
 
+        // Also exclude the transit-probe endpoints themselves from the hop pool.
+        // Their job is to force the path through a specific ASN so real transit
+        // routers surface - the endpoint IP itself is far away and not useful
+        // as a monitoring target.
+        var transitProbeAddresses = new HashSet<string>(
+            CdnRotation.Where(e => e.IsTransitProbe).Select(e => e.Address),
+            StringComparer.OrdinalIgnoreCase);
+
         var transitGroups = _mergedHops
             .Where(h => h.Asn != null
                         && !accessAsnNumbers.Contains(h.Asn.Asn)
                         && !destinationAsns.Contains(h.Asn.Asn)
-                        && !(h.Asn.Name != null && destinationOrgs.Contains(h.Asn.Name.Trim())))
+                        && !(h.Asn.Name != null && destinationOrgs.Contains(h.Asn.Name.Trim()))
+                        && !transitProbeAddresses.Contains(h.Address))
             .GroupBy(h => h.Asn!.Asn)
             .ToList();
 
@@ -757,39 +803,57 @@ public class UpstreamTracerService
             // transit ASNs cleanly by monitoring the CDN destination instead.
             var asn = group.First().Asn!;
             var hopsInOrder = group.OrderBy(h => h.HopNumber).Take(3).ToList();
-            var chosen = hopsInOrder.First(); // already filtered to "responded" by attribution
 
-            candidates.Add(new TransitAsnCandidate
+            foreach (var hop in hopsInOrder)
             {
-                AsnNumber = asn.Asn,
-                AsnName = asn.Name,
-                Method = DiscoveryMethod.DirectRouter,
-                TargetId = $"transit-as{asn.Asn}",
-                HopAddress = chosen.Address,
-                HopHostname = chosen.Hostname,
-                RespondedTo = chosen.RespondedTo,
-                Enabled = true
-            });
+                candidates.Add(new TransitAsnCandidate
+                {
+                    AsnNumber = asn.Asn,
+                    AsnName = CleanAsnName(asn.Name),
+                    Method = DiscoveryMethod.DirectRouter,
+                    TargetId = $"transit-as{asn.Asn}-{NormalizeMacForId(hop.Address)}",
+                    HopAddress = hop.Address,
+                    HopHostname = hop.Hostname,
+                    RespondedTo = hop.RespondedTo,
+                    Enabled = hop == hopsInOrder.First()
+                });
+            }
         }
 
-        State.TransitAsns = candidates;
+        // PTR-resolve candidate IPs that don't already have a hostname (e.g. from
+        // Windows managed traceroute or traces where the native binary didn't resolve).
+        // Only a handful of candidates, so the cost is negligible.
+        await ResolveHostnamesAsync(candidates, ct);
+
+        // Generate labels from PTR hostnames (strip TLD, filter IP-derived junk).
+        // Generate "<Org> <PTR-derived>" labels, or "<Org> 1/2/3" when no PTR.
+        var asnIndex = new Dictionary<int, int>();
+        foreach (var c in candidates)
+        {
+            if (c.Method == DiscoveryMethod.PathProxy) continue;
+            var ptrLabel = FormatTransitHopLabel(c.HopHostname, c.HopAddress);
+            if (ptrLabel != null)
+            {
+                c.Label = $"{c.AsnName} {ptrLabel}";
+            }
+            else
+            {
+                asnIndex.TryGetValue(c.AsnNumber, out var idx);
+                idx++;
+                asnIndex[c.AsnNumber] = idx;
+                c.Label = $"{c.AsnName} {idx}";
+            }
+        }
 
         // Path-proxy: for every CDN destination whose ASN appeared anywhere in the
         // trace - not just traces that reached the literal endpoint - add the
-        // endpoint as a path-end monitoring target. The previous "only if Reached"
-        // gate missed destinations like Akamai whose anycast endpoints often
-        // don't respond to ICMP/UDP probes even though the trace clearly entered
-        // their network. Seeing the destination ASN attributed to any hop is a
-        // strong signal the path-end is monitorable.
+        // endpoint as a path-end monitoring target.
         var pathProxyAsnsSeen = new HashSet<int>(candidates.Select(c => c.AsnNumber));
         var asnsInTrace = new HashSet<int>(_mergedHops
             .Where(h => h.Asn != null)
             .Select(h => h.Asn!.Asn));
         foreach (var endpoint in CdnRotation)
         {
-            // TransitProbe endpoints aren't destinations to monitor - their job
-            // was to surface their ASN as transit (handled above). Skip the
-            // path-end registration for them.
             if (endpoint.IsTransitProbe) continue;
             var destAsn = await _asnResolution.ResolveAsync(endpoint.Address, ct);
             if (destAsn == null) continue;
@@ -798,12 +862,13 @@ public class UpstreamTracerService
                 string.Equals(t.CdnEndpoint, endpoint.Address, StringComparison.OrdinalIgnoreCase));
             bool reachedOrTraversed = (trace?.Reached ?? false) || asnsInTrace.Contains(destAsn.Asn);
             if (!reachedOrTraversed) continue;
-            if (!pathProxyAsnsSeen.Add(destAsn.Asn)) continue;     // dedupe across CDNs
+            if (!pathProxyAsnsSeen.Add(destAsn.Asn)) continue;
 
             candidates.Add(new TransitAsnCandidate
             {
                 AsnNumber = destAsn.Asn,
-                AsnName = destAsn.Name,
+                AsnName = CleanAsnName(destAsn.Name),
+                Label = endpoint.Label,
                 Method = DiscoveryMethod.PathProxy,
                 TargetId = $"path-{endpoint.Label.ToLowerInvariant()}-as{destAsn.Asn}",
                 HopAddress = endpoint.Address,
@@ -811,6 +876,37 @@ public class UpstreamTracerService
                 RespondedTo = ProbeMode.Icmp,
                 Enabled = true
             });
+        }
+
+        // Reconcile ALL candidates (transit + path-end) and access hops against
+        // existing DB targets. Enabled → pre-check; disabled → uncheck.
+        // Absorb descriptive names over numbered fallbacks.
+        await using var reconcileDb = await _dbFactory.CreateDbContextAsync(ct);
+        var allExisting = await reconcileDb.MonitoringTargets
+            .AsNoTracking()
+            .ToListAsync(ct);
+        var existingByAddress = new Dictionary<string, MonitoringTarget>(StringComparer.OrdinalIgnoreCase);
+        foreach (var t in allExisting.Where(t => !string.IsNullOrEmpty(t.Address)))
+            existingByAddress.TryAdd(t.Address, t);
+        foreach (var c in candidates)
+        {
+            var addr = c.HopAddress ?? c.PathProxyTarget;
+            if (string.IsNullOrEmpty(addr)) continue;
+            if (existingByAddress.TryGetValue(addr, out var existing))
+            {
+                c.Enabled = existing.Enabled;
+                if (!string.IsNullOrEmpty(existing.Name))
+                    c.Label = existing.Name;
+            }
+        }
+        foreach (var hop in State.AccessHops)
+        {
+            if (existingByAddress.TryGetValue(hop.Address, out var existing))
+            {
+                hop.Enabled = existing.Enabled;
+                if (!string.IsNullOrEmpty(existing.Name))
+                    hop.Label = existing.Name;
+            }
         }
 
         State.TransitAsns = candidates;
@@ -826,11 +922,11 @@ public class UpstreamTracerService
     {
         State.Step = TracerStep.VerifyingReachability;
 
-        var allTargets = new List<(string Address, ProbeMode Mode, Action Disable)>();
+        var allTargets = new List<(string Address, ProbeMode Mode, Action<double?> ApplyRtt, Action MarkUnreachable)>();
         foreach (var hop in State.AccessHops)
-            allTargets.Add((hop.Address, hop.RespondedTo, () => hop.Enabled = false));
+            allTargets.Add((hop.Address, hop.RespondedTo, rtt => hop.VerifiedRttMs = rtt, () => { hop.Enabled = false; hop.Unreachable = true; }));
         foreach (var transit in State.TransitAsns.Where(t => t.HopAddress != null && t.Method == DiscoveryMethod.DirectRouter))
-            allTargets.Add((transit.HopAddress!, transit.RespondedTo ?? ProbeMode.Icmp, () => transit.Enabled = false));
+            allTargets.Add((transit.HopAddress!, transit.RespondedTo ?? ProbeMode.Icmp, rtt => transit.VerifiedRttMs = rtt, () => { transit.Enabled = false; transit.Unreachable = true; }));
 
         if (allTargets.Count == 0) return;
 
@@ -850,11 +946,15 @@ public class UpstreamTracerService
         var unreachable = 0;
         foreach (var (t, result) in results)
         {
-            if (!result.Success)
+            if (result.Success)
             {
-                t.Disable();
+                t.ApplyRtt(result.RttAvgMs);
+            }
+            else
+            {
+                t.MarkUnreachable();
                 unreachable++;
-                _logger.LogDebug("Ping check failed for {Address} - excluding from proposed targets", t.Address);
+                _logger.LogDebug("Ping check failed for {Address} - marked unreachable", t.Address);
             }
         }
 
@@ -863,32 +963,6 @@ public class UpstreamTracerService
             : $"All {allTargets.Count} target(s) responded to ping.";
     }
 
-    /// <summary>
-    /// Hop label priority per spec 5.5: PTR hostname > role inference > bare IP +
-    /// ISP name. PTRs that just encode the IP (e.g. "h1.2.3.4.static.ip.example.net")
-    /// fall through to bare IP since the encoded form is useless as a label.
-    /// Otherwise we strip just the trailing TLD label so the ISP-identifying SLD
-    /// stays in the label ("router-name.example" rather than "router-name").
-    /// </summary>
-    private static string LabelAccessHop(AttributedHop hop)
-    {
-        var ispName = hop.Asn?.Name;
-        if (!string.IsNullOrEmpty(hop.Hostname))
-        {
-            var parts = hop.Hostname.Split('.');
-            if (!IsIpDerivedHostname(parts, hop.Address))
-            {
-                // Strip only the final TLD label (.net/.com/...) so the SLD that
-                // names the ISP is preserved. If the hostname has only one label
-                // (e.g. "_gateway") just return it whole.
-                return parts.Length > 1
-                    ? string.Join('.', parts.Take(parts.Length - 1))
-                    : hop.Hostname;
-            }
-            // IP-encoded PTR; fall through to the bare-IP branch below.
-        }
-        return string.IsNullOrEmpty(ispName) ? hop.Address : $"{hop.Address} - {ispName}";
-    }
 
     /// <summary>
     /// True when the hostname looks like an automated IP-encoded reverse DNS entry
@@ -939,14 +1013,12 @@ public class UpstreamTracerService
                            || vendor.Contains("cadant") || vendor.Contains("ubr");
 
         if ((tech == AccessTechnology.Gpon || tech == AccessTechnology.XgsPon) && isOltVendor && hop.HopNumber == 1)
-            return UpstreamRole.Bng; // L2-transparent OLT means hop 1 is the BNG behind it.
+            return UpstreamRole.Bng;
         if (tech == AccessTechnology.Docsis && (isCmtsVendor || hop.HopNumber == 1))
             return UpstreamRole.Cmts;
         if (tech == AccessTechnology.PppoE && hop.HopNumber == 1)
             return UpstreamRole.Bng;
-        if (hop.HopNumber >= 2 && hop.HopNumber <= 3)
-            return UpstreamRole.Aggregation;
-        return UpstreamRole.AccessHop;
+        return UpstreamRole.Aggregation;
     }
 
     private static UpstreamRole InferL2NeighborRole(AccessTechnology tech, string? ouiVendor)
@@ -967,7 +1039,7 @@ public class UpstreamTracerService
         return UpstreamRole.AccessGateway;
     }
 
-    private static string LabelL2Neighbor(string? ouiVendor, AccessTechnology tech, string? asnName)
+    private static string LabelL2Role(string? ouiVendor, AccessTechnology tech)
     {
         var vendor = FirstWord(ouiVendor);
         var role = tech switch
@@ -980,11 +1052,7 @@ public class UpstreamTracerService
         var techSuffix = (role == "access" && tech != AccessTechnology.Unknown)
             ? $"-{tech.ToString().ToLowerInvariant()}"
             : "";
-        var isp = FirstWord(asnName);
-
-        // e.g. "nokia-olt.att", "arris-cmts.comcast", "cisco-access-ethernet"
-        var prefix = vendor != null ? $"{vendor}-{role}{techSuffix}" : $"{role}{techSuffix}";
-        return isp != null ? $"{prefix}.{isp}" : prefix;
+        return vendor != null ? $"{vendor}-{role}{techSuffix}" : $"{role}{techSuffix}";
     }
 
     private static string? FirstWord(string? value)
@@ -999,7 +1067,8 @@ public class UpstreamTracerService
         var hop = State.AccessHops.FirstOrDefault(h => h.Method == DiscoveryMethod.L2Neighbor);
         if (hop == null) return;
         hop.Role = InferL2NeighborRole(State.AccessTechnology, State.WanNeighborOuiVendor);
-        hop.Label = LabelL2Neighbor(State.WanNeighborOuiVendor, State.AccessTechnology, hop.AsnName);
+        var org = CleanAsnName(hop.AsnName ?? State.AccessHops.FirstOrDefault(h => h.AsnName != null)?.AsnName);
+        hop.Label = $"{org} {LabelL2Role(State.WanNeighborOuiVendor, State.AccessTechnology)}";
     }
 
     private static string NormalizeMacForId(string s) => s.Replace(".", "-").Replace(":", "-");
@@ -1025,9 +1094,31 @@ public class UpstreamTracerService
         {
             await UpsertTargetAsync(db, hop, wanInterface, ct);
         }
+        foreach (var hop in State.AccessHops.Where(h => !h.Enabled))
+        {
+            var existing = await db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == hop.Address, ct);
+            if (existing != null)
+            {
+                existing.Enabled = false;
+                existing.Name = hop.Label;
+                if (!string.IsNullOrEmpty(hop.AsnName)) existing.AsnName = CleanAsnName(hop.AsnName);
+            }
+        }
         foreach (var transit in State.TransitAsns.Where(t => t.Enabled))
         {
             await UpsertTransitTargetAsync(db, transit, wanInterface, ct);
+        }
+        foreach (var transit in State.TransitAsns.Where(t => !t.Enabled))
+        {
+            var addr = transit.HopAddress ?? transit.PathProxyTarget;
+            if (string.IsNullOrEmpty(addr)) continue;
+            var existing = await db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == addr, ct);
+            if (existing != null)
+            {
+                existing.Enabled = false;
+                existing.Name = transit.Label ?? transit.AsnName;
+                if (!string.IsNullOrEmpty(transit.AsnName)) existing.AsnName = transit.AsnName;
+            }
         }
 
         // Per-WAN tracer state. WanDiscoveryContexts is the new source of truth;
@@ -1076,7 +1167,7 @@ public class UpstreamTracerService
                 DiscoveredProbeMode = hop.RespondedTo,
                 TargetType = MonitoringTargetType.AccessIsp,
                 AsnNumber = hop.AsnNumber,
-                AsnName = hop.AsnName,
+                AsnName = CleanAsnName(hop.AsnName),
                 VantagePoint = "server",
                 PollIntervalSeconds = 10,
                 PingCount = 5,
@@ -1096,12 +1187,13 @@ public class UpstreamTracerService
             // preservation per locked decision 6b). Backfill ASN fields whenever a
             // current run resolves them - rows committed before the GeoLite2 fix
             // landed have nulls and never refreshed without this.
+            existing.Enabled = true;
             existing.Address = hop.Address;
             existing.ProbeMode = hop.RespondedTo;
             existing.WanInterface = wanInterface;
-            existing.Name = string.IsNullOrEmpty(existing.Name) ? hop.Label : existing.Name; // don't stomp user-renamed labels
+            existing.Name = hop.Label;
             if (hop.AsnNumber.HasValue) existing.AsnNumber = hop.AsnNumber;
-            if (!string.IsNullOrEmpty(hop.AsnName)) existing.AsnName = hop.AsnName;
+            if (!string.IsNullOrEmpty(hop.AsnName)) existing.AsnName = CleanAsnName(hop.AsnName);
             if (!string.IsNullOrEmpty(hop.PtrHostname)) existing.PtrHostname = hop.PtrHostname;
             existing.LastVerified = DateTime.UtcNow;
         }
@@ -1124,7 +1216,7 @@ public class UpstreamTracerService
             db.MonitoringTargets.Add(new MonitoringTarget
             {
                 TargetId = transit.TargetId,
-                Name = transit.AsnName,
+                Name = transit.Label ?? transit.AsnName,
                 Address = transit.HopAddress ?? transit.PathProxyTarget ?? "0.0.0.0",
                 ProbeMode = transit.RespondedTo ?? NetworkOptimizer.Core.Enums.ProbeMode.Icmp,
                 DiscoveredProbeMode = transit.RespondedTo,
@@ -1135,6 +1227,7 @@ public class UpstreamTracerService
                 PollIntervalSeconds = 15,
                 PingCount = 5,
                 Enabled = true,
+                PtrHostname = transit.HopHostname,
                 AutoDiscovered = true,
                 DiscoveryMethod = transit.Method,
                 WanInterface = wanInterface,
@@ -1144,8 +1237,11 @@ public class UpstreamTracerService
         }
         else
         {
+            existing.Enabled = true;
+            existing.Name = transit.Label ?? transit.AsnName;
             existing.Address = transit.HopAddress ?? transit.PathProxyTarget ?? existing.Address;
             existing.ProbeMode = transit.RespondedTo ?? existing.ProbeMode;
+            if (!string.IsNullOrEmpty(transit.HopHostname)) existing.PtrHostname = transit.HopHostname;
             existing.DiscoveryMethod = transit.Method;
             existing.WanInterface = wanInterface;
             // Refresh ASN bookkeeping in case the resolver picked up a name now
@@ -1154,6 +1250,83 @@ public class UpstreamTracerService
             if (!string.IsNullOrEmpty(transit.AsnName)) existing.AsnName = transit.AsnName;
             existing.LastVerified = DateTime.UtcNow;
         }
+    }
+
+    /// <summary>
+    /// PTR-resolve any transit candidates that don't already have a hostname from
+    /// the traceroute output (e.g. Windows managed traceroute, or hops that only
+    /// appeared in -n traces). Mutates HopHostname in place.
+    /// </summary>
+    private static async Task ResolveHostnamesAsync(List<TransitAsnCandidate> candidates, CancellationToken ct)
+    {
+        var tasks = candidates
+            .Where(c => string.IsNullOrEmpty(c.HopHostname) && !string.IsNullOrEmpty(c.HopAddress))
+            .Select(async c =>
+            {
+                try
+                {
+                    var entry = await System.Net.Dns.GetHostEntryAsync(c.HopAddress!, ct);
+                    if (!string.IsNullOrEmpty(entry.HostName) && entry.HostName != c.HopAddress)
+                        c.HopHostname = entry.HostName;
+                }
+                catch { /* no PTR record — leave null */ }
+            });
+        await Task.WhenAll(tasks);
+    }
+
+    private static readonly string[] OrgSuffixes =
+    {
+        // Telco/ISP industry terms
+        "Communications", "Telephone", "Telecom", "Telecommunications",
+        "Broadband", "Internet", "Fiber", "Cable", "Wireless",
+        "Enterprises", "Services", "Technologies", "Networks", "Network",
+        "Electric Cooperative", "Cooperative", "Co-op",
+        // Corporate entity suffixes
+        "Corporation", "Incorporated", "Company", "Holdings", "Group", "Parent",
+        "LLC", "Inc", "Corp", "Ltd", "Limited", "Co", "L.P.", "LP",
+        // International
+        "GmbH", "AG", "KG", "e.K.", "S.A.", "S.A.S.", "S.r.l.",
+        "B.V.", "B.V", "N.V.", "N.V", "Pty", "A/S", "AB", "Oy", "AS"
+    };
+
+    /// <summary>
+    /// Strip corporate suffixes from ASN org names.
+    /// "Windstream Communications" → "Windstream", "AT&amp;T Enterprises" → "AT&amp;T"
+    /// </summary>
+    internal static string CleanAsnName(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return string.Empty;
+        var cleaned = name.Trim().TrimEnd(',', '.');
+        // Iterate to strip chains like "Telephone Company" or "Cable Communications LLC"
+        bool changed;
+        do
+        {
+            changed = false;
+            foreach (var suffix in OrgSuffixes)
+            {
+                if (cleaned.EndsWith(" " + suffix, StringComparison.OrdinalIgnoreCase))
+                {
+                    cleaned = cleaned[..^(suffix.Length + 1)].TrimEnd(',', '.');
+                    changed = true;
+                }
+            }
+        } while (changed && cleaned.Contains(' '));
+        return cleaned.Trim();
+    }
+
+    /// <summary>
+    /// Generate a display label from a PTR hostname for transit targets.
+    /// Strips the last 2 labels (SLD + TLD, e.g. ".windstream.net") since
+    /// the org name is already prepended separately. Returns null if the
+    /// hostname is unusable (IP-derived auto-PTR or too short).
+    /// </summary>
+    internal static string? FormatTransitHopLabel(string? hostname, string? ipAddress)
+    {
+        if (string.IsNullOrEmpty(hostname)) return null;
+        var parts = hostname.Split('.');
+        if (IsIpDerivedHostname(parts, ipAddress ?? string.Empty)) return null;
+        if (parts.Length <= 2) return null;
+        return string.Join('.', parts.Take(parts.Length - 2));
     }
 
     private bool Fail(string message)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerState.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerState.cs
@@ -65,6 +65,8 @@ public class AccessHopCandidate
     public Core.Enums.ProbeMode RespondedTo { get; set; }
     public DiscoveryMethod Method { get; set; } = DiscoveryMethod.DirectRouter;
     public bool Enabled { get; set; } = true;
+    public bool Unreachable { get; set; }
+    public double? VerifiedRttMs { get; set; }
 }
 
 /// <summary>
@@ -75,12 +77,15 @@ public class TransitAsnCandidate
 {
     public int AsnNumber { get; set; }
     public required string AsnName { get; set; }
+    public string? Label { get; set; }
     public DiscoveryMethod Method { get; set; }
     public string? TargetId { get; set; }              // null for Unresolved tier
     public string? HopAddress { get; set; }
     public string? HopHostname { get; set; }
     public Core.Enums.ProbeMode? RespondedTo { get; set; }
     public bool Enabled { get; set; } = true;
+    public bool Unreachable { get; set; }
+    public double? VerifiedRttMs { get; set; }
     /// <summary>For PathProxy tier: the CDN endpoint we monitor as a proxy for this ASN.</summary>
     public string? PathProxyTarget { get; set; }
 }

--- a/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
@@ -186,6 +186,21 @@ public class MonitoringLiveStats
         };
     }
 
+    /// <summary>Total fabric ingress/egress across all devices in the cache.
+    /// Only devices with non-null fabric data contribute (APs are excluded
+    /// because the collection agent never calls RecordFabricSum for them).</summary>
+    public (double IngressBps, double EgressBps) GetTotalFabricLoad()
+    {
+        double totalIn = 0, totalOut = 0;
+        foreach (var kvp in _stats)
+        {
+            if (kvp.Value.FabricIngressBps == null && kvp.Value.FabricEgressBps == null) continue;
+            totalIn += kvp.Value.FabricIngressBps ?? 0;
+            totalOut += kvp.Value.FabricEgressBps ?? 0;
+        }
+        return (totalIn, totalOut);
+    }
+
     /// <summary>Latest SFP DDM snapshot for a given device port.</summary>
     public SfpLiveStats? GetSfpStats(string deviceMac, string portName)
     {

--- a/tests/NetworkOptimizer.Web.Tests/NetworkOptimizer.Web.Tests.csproj
+++ b/tests/NetworkOptimizer.Web.Tests/NetworkOptimizer.Web.Tests.csproj
@@ -15,6 +15,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
@@ -1,0 +1,689 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services.Monitoring;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class CleanAsnNameTests
+{
+    [Theory]
+    [InlineData("Windstream Communications", "Windstream")]
+    [InlineData("AT&T Enterprises", "AT&T")]
+    [InlineData("Level 3 Parent, LLC", "Level 3")]
+    [InlineData("Cox Communications Inc.", "Cox")]
+    [InlineData("EXAMPLE TELEPHONE", "EXAMPLE")]
+    [InlineData("Cisco OpenDNS, LLC", "Cisco OpenDNS")]
+    [InlineData("Akamai International B.V.", "Akamai International")]
+    [InlineData("Fastly, Inc.", "Fastly")]
+    [InlineData("Deutsche Telekom AG", "Deutsche Telekom")]
+    [InlineData("Comcast Cable Communications, LLC", "Comcast")]
+    [InlineData("Charter Communications Inc", "Charter")]
+    [InlineData("Lumen Technologies", "Lumen")]
+    [InlineData("Frontier Communications Corporation", "Frontier")]
+    [InlineData("TDS Telecom", "TDS")]
+    [InlineData("Sievert Larsen Fiber LLC", "Sievert Larsen")]
+    [InlineData("Rural Electric Cooperative", "Rural")]
+    [InlineData("Google", "Google")]
+    [InlineData("Cloudflare", "Cloudflare")]
+    [InlineData(null, "")]
+    [InlineData("", "")]
+    [InlineData("  ", "")]
+    public void Strips_corporate_suffixes(string? input, string expected)
+    {
+        UpstreamTracerService.CleanAsnName(input).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Strips_chained_suffixes()
+    {
+        UpstreamTracerService.CleanAsnName("Acme Telephone Company LLC")
+            .Should().Be("Acme");
+    }
+
+    [Fact]
+    public void Stops_before_emptying_the_name()
+    {
+        UpstreamTracerService.CleanAsnName("Communications LLC")
+            .Should().NotBeEmpty();
+    }
+}
+
+public class FormatTransitHopLabelTests
+{
+    [Theory]
+    [InlineData("ae6-0.agr01.ltrk01-ar.us.windstream.net", null, "ae6-0.agr01.ltrk01-ar.us")]
+    [InlineData("lag-101.ear1.LittleRock2.Level3.net", null, "lag-101.ear1.LittleRock2")]
+    [InlineData("mcibbrj01.rd.ks.cox.net", null, "mcibbrj01.rd.ks")]
+    [InlineData("ae25.25.ear1.Dallas1.net.lumen.tech", null, "ae25.25.ear1.Dallas1.net")]
+    [InlineData("rtr1-handoff.example.net", null, "rtr1-handoff")]
+    public void Strips_sld_and_tld(string hostname, string? ip, string expected)
+    {
+        UpstreamTracerService.FormatTransitHopLabel(hostname, ip).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("h40.113.0.203.static.ip.example.net", "203.0.113.40")]
+    [InlineData("203.0.113.146", "203.0.113.146")]
+    public void Returns_null_for_ip_derived_hostnames(string hostname, string ip)
+    {
+        UpstreamTracerService.FormatTransitHopLabel(hostname, ip).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    public void Returns_null_for_empty_input(string? hostname, string? ip)
+    {
+        UpstreamTracerService.FormatTransitHopLabel(hostname, ip).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("router.net", null)]
+    [InlineData("single", null)]
+    public void Returns_null_when_too_few_labels(string hostname, string? ip)
+    {
+        UpstreamTracerService.FormatTransitHopLabel(hostname, ip).Should().BeNull();
+    }
+}
+
+public class UpstreamCommitTests : IDisposable
+{
+    private readonly NetworkOptimizerDbContext _db;
+
+    public UpstreamCommitTests()
+    {
+        var options = new DbContextOptionsBuilder<NetworkOptimizerDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        _db = new NetworkOptimizerDbContext(options);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task Enabled_access_hop_creates_new_target()
+    {
+        var hops = new List<AccessHopCandidate>
+        {
+            MakeAccessHop("192.0.2.1", "TestISP bng", enabled: true)
+        };
+        var transits = new List<TransitAsnCandidate>();
+
+        await CommitAsync(hops, transits);
+
+        var target = await _db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == "192.0.2.1");
+        target.Should().NotBeNull();
+        target!.Enabled.Should().BeTrue();
+        target.Name.Should().Be("TestISP bng");
+        target.TargetType.Should().Be(MonitoringTargetType.AccessIsp);
+    }
+
+    [Fact]
+    public async Task Disabled_access_hop_does_not_create_target()
+    {
+        var hops = new List<AccessHopCandidate>
+        {
+            MakeAccessHop("192.0.2.1", "TestISP bng", enabled: false)
+        };
+
+        await CommitAsync(hops, new List<TransitAsnCandidate>());
+
+        var target = await _db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == "192.0.2.1");
+        target.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Unchecking_existing_access_hop_disables_it()
+    {
+        _db.MonitoringTargets.Add(MakeDbTarget("192.0.2.1", "Old Name", MonitoringTargetType.AccessIsp, enabled: true));
+        await _db.SaveChangesAsync();
+
+        var hops = new List<AccessHopCandidate>
+        {
+            MakeAccessHop("192.0.2.1", "New Name", enabled: false)
+        };
+
+        await CommitAsync(hops, new List<TransitAsnCandidate>());
+
+        var target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1");
+        target.Enabled.Should().BeFalse();
+        target.Name.Should().Be("New Name");
+    }
+
+    [Fact]
+    public async Task Rechecking_disabled_access_hop_enables_it()
+    {
+        _db.MonitoringTargets.Add(MakeDbTarget("192.0.2.1", "Old Name", MonitoringTargetType.AccessIsp, enabled: false));
+        await _db.SaveChangesAsync();
+
+        var hops = new List<AccessHopCandidate>
+        {
+            MakeAccessHop("192.0.2.1", "New Name", enabled: true)
+        };
+
+        await CommitAsync(hops, new List<TransitAsnCandidate>());
+
+        var target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1");
+        target.Enabled.Should().BeTrue();
+        target.Name.Should().Be("New Name");
+    }
+
+    [Fact]
+    public async Task Enabled_transit_creates_new_target()
+    {
+        var transit = MakeTransitCandidate("198.51.100.1", "Windstream agr01", 7029,
+            method: DiscoveryMethod.DirectRouter, enabled: true);
+
+        await CommitAsync(new List<AccessHopCandidate>(), new List<TransitAsnCandidate> { transit });
+
+        var target = await _db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == "198.51.100.1");
+        target.Should().NotBeNull();
+        target!.Enabled.Should().BeTrue();
+        target.Name.Should().Be("Windstream agr01");
+        target.TargetType.Should().Be(MonitoringTargetType.Transit);
+    }
+
+    [Fact]
+    public async Task Unchecking_existing_transit_disables_it()
+    {
+        _db.MonitoringTargets.Add(MakeDbTarget("198.51.100.1", "Old Transit", MonitoringTargetType.Transit, enabled: true));
+        await _db.SaveChangesAsync();
+
+        var transit = MakeTransitCandidate("198.51.100.1", "New Transit", 7029,
+            method: DiscoveryMethod.DirectRouter, enabled: false);
+
+        await CommitAsync(new List<AccessHopCandidate>(), new List<TransitAsnCandidate> { transit });
+
+        var target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "198.51.100.1");
+        target.Enabled.Should().BeFalse();
+        target.Name.Should().Be("New Transit");
+    }
+
+    [Fact]
+    public async Task Rechecking_disabled_transit_enables_it()
+    {
+        _db.MonitoringTargets.Add(MakeDbTarget("198.51.100.1", "Old Transit", MonitoringTargetType.Transit, enabled: false));
+        await _db.SaveChangesAsync();
+
+        var transit = MakeTransitCandidate("198.51.100.1", "New Transit", 7029,
+            method: DiscoveryMethod.DirectRouter, enabled: true);
+
+        await CommitAsync(new List<AccessHopCandidate>(), new List<TransitAsnCandidate> { transit });
+
+        var target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "198.51.100.1");
+        target.Enabled.Should().BeTrue();
+        target.Name.Should().Be("New Transit");
+    }
+
+    [Fact]
+    public async Task Unchecking_pathproxy_disables_it()
+    {
+        _db.MonitoringTargets.Add(MakeDbTarget("203.0.113.1", "Cloudflare", MonitoringTargetType.InternetService, enabled: true));
+        await _db.SaveChangesAsync();
+
+        var pathProxy = MakeTransitCandidate("203.0.113.1", "Cloudflare", 13335,
+            method: DiscoveryMethod.PathProxy, enabled: false);
+        pathProxy.PathProxyTarget = "203.0.113.1";
+
+        await CommitAsync(new List<AccessHopCandidate>(), new List<TransitAsnCandidate> { pathProxy });
+
+        var target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "203.0.113.1");
+        target.Enabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Rechecking_pathproxy_enables_it()
+    {
+        _db.MonitoringTargets.Add(MakeDbTarget("203.0.113.1", "Cloudflare", MonitoringTargetType.InternetService, enabled: false));
+        await _db.SaveChangesAsync();
+
+        var pathProxy = MakeTransitCandidate("203.0.113.1", "Cloudflare", 13335,
+            method: DiscoveryMethod.PathProxy, enabled: true);
+        pathProxy.PathProxyTarget = "203.0.113.1";
+
+        await CommitAsync(new List<AccessHopCandidate>(), new List<TransitAsnCandidate> { pathProxy });
+
+        var target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "203.0.113.1");
+        target.Enabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Upsert_matches_by_address_when_targetid_differs()
+    {
+        var existing = MakeDbTarget("198.51.100.1", "Custom Name", MonitoringTargetType.Transit, enabled: true);
+        existing.TargetId = "custom-abc123";
+        _db.MonitoringTargets.Add(existing);
+        await _db.SaveChangesAsync();
+        var originalId = existing.Id;
+
+        var transit = MakeTransitCandidate("198.51.100.1", "Discovery Name", 7029,
+            method: DiscoveryMethod.DirectRouter, enabled: true);
+        transit.TargetId = "transit-as7029-198-51-100-1";
+
+        await CommitAsync(new List<AccessHopCandidate>(), new List<TransitAsnCandidate> { transit });
+
+        var targets = await _db.MonitoringTargets.Where(t => t.Address == "198.51.100.1").ToListAsync();
+        targets.Should().HaveCount(1);
+        targets[0].Id.Should().Be(originalId);
+        targets[0].Name.Should().Be("Discovery Name");
+    }
+
+    [Fact]
+    public async Task Rename_applies_to_disabled_targets()
+    {
+        _db.MonitoringTargets.Add(MakeDbTarget("192.0.2.1", "bng01.example", MonitoringTargetType.AccessIsp, enabled: true));
+        await _db.SaveChangesAsync();
+
+        var hop = MakeAccessHop("192.0.2.1", "EXAMPLE bng01", enabled: false);
+
+        await CommitAsync(new List<AccessHopCandidate> { hop }, new List<TransitAsnCandidate>());
+
+        var target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1");
+        target.Enabled.Should().BeFalse();
+        target.Name.Should().Be("EXAMPLE bng01");
+    }
+
+    [Fact]
+    public async Task Asn_name_cleaned_on_save()
+    {
+        var hop = MakeAccessHop("192.0.2.1", "EXAMPLE bng", enabled: true);
+        hop.AsnName = "EXAMPLE TELEPHONE";
+
+        await CommitAsync(new List<AccessHopCandidate> { hop }, new List<TransitAsnCandidate>());
+
+        var target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1");
+        target.AsnName.Should().Be("EXAMPLE");
+    }
+
+    [Fact]
+    public async Task Unreachable_target_disabled_on_save()
+    {
+        _db.MonitoringTargets.Add(MakeDbTarget("198.51.100.1", "Transit 1", MonitoringTargetType.Transit, enabled: true));
+        await _db.SaveChangesAsync();
+
+        var transit = MakeTransitCandidate("198.51.100.1", "Transit 1", 7029,
+            method: DiscoveryMethod.DirectRouter, enabled: false);
+        transit.Unreachable = true;
+
+        await CommitAsync(new List<AccessHopCandidate>(), new List<TransitAsnCandidate> { transit });
+
+        var target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "198.51.100.1");
+        target.Enabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Mixed_enable_disable_across_all_types()
+    {
+        _db.MonitoringTargets.Add(MakeDbTarget("192.0.2.1", "Access A", MonitoringTargetType.AccessIsp, enabled: true));
+        _db.MonitoringTargets.Add(MakeDbTarget("192.0.2.2", "Access B", MonitoringTargetType.AccessIsp, enabled: true));
+        _db.MonitoringTargets.Add(MakeDbTarget("198.51.100.1", "Transit A", MonitoringTargetType.Transit, enabled: true));
+        _db.MonitoringTargets.Add(MakeDbTarget("198.51.100.2", "Transit B", MonitoringTargetType.Transit, enabled: false));
+        _db.MonitoringTargets.Add(MakeDbTarget("203.0.113.1", "CDN A", MonitoringTargetType.InternetService, enabled: true));
+        await _db.SaveChangesAsync();
+
+        var hops = new List<AccessHopCandidate>
+        {
+            MakeAccessHop("192.0.2.1", "Access A New", enabled: true),
+            MakeAccessHop("192.0.2.2", "Access B New", enabled: false),
+        };
+        var transits = new List<TransitAsnCandidate>
+        {
+            MakeTransitCandidate("198.51.100.1", "Transit A New", 7029, DiscoveryMethod.DirectRouter, enabled: false),
+            MakeTransitCandidate("198.51.100.2", "Transit B New", 7029, DiscoveryMethod.DirectRouter, enabled: true),
+            MakeTransitCandidate("203.0.113.1", "CDN A New", 13335, DiscoveryMethod.PathProxy, enabled: false),
+        };
+        transits[2].PathProxyTarget = "203.0.113.1";
+
+        await CommitAsync(hops, transits);
+
+        (await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1")).Enabled.Should().BeTrue("Access A stays on");
+        (await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.2")).Enabled.Should().BeFalse("Access B turned off");
+        (await _db.MonitoringTargets.FirstAsync(t => t.Address == "198.51.100.1")).Enabled.Should().BeFalse("Transit A turned off");
+        (await _db.MonitoringTargets.FirstAsync(t => t.Address == "198.51.100.2")).Enabled.Should().BeTrue("Transit B turned on");
+        (await _db.MonitoringTargets.FirstAsync(t => t.Address == "203.0.113.1")).Enabled.Should().BeFalse("CDN A turned off");
+
+        (await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1")).Name.Should().Be("Access A New");
+        (await _db.MonitoringTargets.FirstAsync(t => t.Address == "198.51.100.1")).Name.Should().Be("Transit A New");
+        (await _db.MonitoringTargets.FirstAsync(t => t.Address == "203.0.113.1")).Name.Should().Be("CDN A New");
+    }
+
+    [Fact]
+    public async Task Second_discovery_preserves_user_disable_decision()
+    {
+        _db.MonitoringTargets.Add(MakeDbTarget("192.0.2.1", "Access A", MonitoringTargetType.AccessIsp, enabled: true));
+        _db.MonitoringTargets.Add(MakeDbTarget("198.51.100.1", "Transit A", MonitoringTargetType.Transit, enabled: true));
+        await _db.SaveChangesAsync();
+
+        // First save: user unchecks both
+        await CommitAsync(
+            new List<AccessHopCandidate> { MakeAccessHop("192.0.2.1", "Access A", enabled: false) },
+            new List<TransitAsnCandidate> { MakeTransitCandidate("198.51.100.1", "Transit A", 7029, DiscoveryMethod.DirectRouter, enabled: false) }
+        );
+
+        (await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1")).Enabled.Should().BeFalse();
+        (await _db.MonitoringTargets.FirstAsync(t => t.Address == "198.51.100.1")).Enabled.Should().BeFalse();
+
+        // Second save: user re-checks both
+        await CommitAsync(
+            new List<AccessHopCandidate> { MakeAccessHop("192.0.2.1", "Access A v2", enabled: true) },
+            new List<TransitAsnCandidate> { MakeTransitCandidate("198.51.100.1", "Transit A v2", 7029, DiscoveryMethod.DirectRouter, enabled: true) }
+        );
+
+        var access = await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1");
+        access.Enabled.Should().BeTrue();
+        access.Name.Should().Be("Access A v2");
+
+        var transit = await _db.MonitoringTargets.FirstAsync(t => t.Address == "198.51.100.1");
+        transit.Enabled.Should().BeTrue();
+        transit.Name.Should().Be("Transit A v2");
+    }
+
+    [Fact]
+    public async Task Third_save_after_toggle_cycle()
+    {
+        // Start: enabled
+        _db.MonitoringTargets.Add(MakeDbTarget("192.0.2.1", "Hop A", MonitoringTargetType.AccessIsp, enabled: true));
+        await _db.SaveChangesAsync();
+
+        // Save 1: disable
+        await CommitAsync(
+            new List<AccessHopCandidate> { MakeAccessHop("192.0.2.1", "Hop A", enabled: false) },
+            new List<TransitAsnCandidate>());
+        (await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1")).Enabled.Should().BeFalse();
+
+        // Save 2: re-enable with new name
+        await CommitAsync(
+            new List<AccessHopCandidate> { MakeAccessHop("192.0.2.1", "Hop A Renamed", enabled: true) },
+            new List<TransitAsnCandidate>());
+        var target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1");
+        target.Enabled.Should().BeTrue();
+        target.Name.Should().Be("Hop A Renamed");
+
+        // Save 3: disable again
+        await CommitAsync(
+            new List<AccessHopCandidate> { MakeAccessHop("192.0.2.1", "Hop A Final", enabled: false) },
+            new List<TransitAsnCandidate>());
+        target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1");
+        target.Enabled.Should().BeFalse();
+        target.Name.Should().Be("Hop A Final");
+    }
+
+    [Fact]
+    public void Reconcile_absorbs_user_edited_name_for_transit()
+    {
+        var candidates = new List<TransitAsnCandidate>
+        {
+            MakeTransitCandidate("198.51.100.1", "Windstream ae6-0.agr01.ltrk01-ar.us", 7029, DiscoveryMethod.DirectRouter, true)
+        };
+        var existing = MakeDbTarget("198.51.100.1", "Windstream ae6-0.agr01.ltrk01-ar.us 1", MonitoringTargetType.Transit, enabled: true);
+        _db.MonitoringTargets.Add(existing);
+        _db.SaveChanges();
+
+        var byAddress = new Dictionary<string, MonitoringTarget>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["198.51.100.1"] = existing
+        };
+
+        foreach (var c in candidates)
+        {
+            var addr = c.HopAddress ?? c.PathProxyTarget;
+            if (string.IsNullOrEmpty(addr)) continue;
+            if (byAddress.TryGetValue(addr, out var ex))
+            {
+                c.Enabled = ex.Enabled;
+                if (!string.IsNullOrEmpty(ex.Name))
+                    c.Label = ex.Name;
+            }
+        }
+
+        candidates[0].Label.Should().Be("Windstream ae6-0.agr01.ltrk01-ar.us 1");
+        candidates[0].Enabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Reconcile_absorbs_user_edited_name_for_access()
+    {
+        var hops = new List<AccessHopCandidate>
+        {
+            MakeAccessHop("192.0.2.1", "EXAMPLE border01", enabled: true)
+        };
+        var existing = MakeDbTarget("192.0.2.1", "EXAMPLE border01 1", MonitoringTargetType.AccessIsp, enabled: true);
+        _db.MonitoringTargets.Add(existing);
+        _db.SaveChanges();
+
+        var byAddress = new Dictionary<string, MonitoringTarget>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["192.0.2.1"] = existing
+        };
+
+        foreach (var hop in hops)
+        {
+            if (byAddress.TryGetValue(hop.Address, out var ex))
+            {
+                hop.Enabled = ex.Enabled;
+                if (!string.IsNullOrEmpty(ex.Name))
+                    hop.Label = ex.Name;
+            }
+        }
+
+        hops[0].Label.Should().Be("EXAMPLE border01 1");
+    }
+
+    [Fact]
+    public void Reconcile_absorbs_name_for_pathproxy()
+    {
+        var candidates = new List<TransitAsnCandidate>
+        {
+            MakeTransitCandidate("203.0.113.1", "Cloudflare", 13335, DiscoveryMethod.PathProxy, true)
+        };
+        candidates[0].PathProxyTarget = "203.0.113.1";
+        var existing = MakeDbTarget("203.0.113.1", "Cloudflare Primary", MonitoringTargetType.InternetService, enabled: true);
+        _db.MonitoringTargets.Add(existing);
+        _db.SaveChanges();
+
+        var byAddress = new Dictionary<string, MonitoringTarget>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["203.0.113.1"] = existing
+        };
+
+        foreach (var c in candidates)
+        {
+            var addr = c.HopAddress ?? c.PathProxyTarget;
+            if (string.IsNullOrEmpty(addr)) continue;
+            if (byAddress.TryGetValue(addr, out var ex))
+            {
+                c.Enabled = ex.Enabled;
+                if (!string.IsNullOrEmpty(ex.Name))
+                    c.Label = ex.Name;
+            }
+        }
+
+        candidates[0].Label.Should().Be("Cloudflare Primary");
+    }
+
+    [Fact]
+    public void Reconcile_does_not_overwrite_with_empty_db_name()
+    {
+        var candidates = new List<TransitAsnCandidate>
+        {
+            MakeTransitCandidate("198.51.100.1", "Windstream agr01", 7029, DiscoveryMethod.DirectRouter, true)
+        };
+        var existing = MakeDbTarget("198.51.100.1", "", MonitoringTargetType.Transit, enabled: true);
+        _db.MonitoringTargets.Add(existing);
+        _db.SaveChanges();
+
+        var byAddress = new Dictionary<string, MonitoringTarget>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["198.51.100.1"] = existing
+        };
+
+        foreach (var c in candidates)
+        {
+            var addr = c.HopAddress ?? c.PathProxyTarget;
+            if (string.IsNullOrEmpty(addr)) continue;
+            if (byAddress.TryGetValue(addr, out var ex))
+            {
+                c.Enabled = ex.Enabled;
+                if (!string.IsNullOrEmpty(ex.Name))
+                    c.Label = ex.Name;
+            }
+        }
+
+        candidates[0].Label.Should().Be("Windstream agr01");
+    }
+
+    // ---- Helpers ----
+
+    private async Task CommitAsync(List<AccessHopCandidate> hops, List<TransitAsnCandidate> transits)
+    {
+        var wanInterface = "wan";
+
+        foreach (var hop in hops.Where(h => h.Enabled))
+        {
+            var existing = await _db.MonitoringTargets.FirstOrDefaultAsync(t => t.TargetId == hop.TargetId)
+                           ?? await _db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == hop.Address);
+            if (existing == null)
+            {
+                _db.MonitoringTargets.Add(new MonitoringTarget
+                {
+                    TargetId = hop.TargetId,
+                    Name = hop.Label,
+                    Address = hop.Address,
+                    ProbeMode = hop.RespondedTo,
+                    TargetType = MonitoringTargetType.AccessIsp,
+                    AsnNumber = hop.AsnNumber,
+                    AsnName = UpstreamTracerService.CleanAsnName(hop.AsnName),
+                    VantagePoint = "server",
+                    PollIntervalSeconds = 10,
+                    PingCount = 5,
+                    Enabled = true,
+                    AutoDiscovered = true,
+                    DiscoveryMethod = hop.Method,
+                    WanInterface = wanInterface,
+                    CreatedAt = DateTime.UtcNow,
+                    LastVerified = DateTime.UtcNow
+                });
+            }
+            else
+            {
+                existing.Enabled = true;
+                existing.Name = hop.Label;
+                if (hop.AsnNumber.HasValue) existing.AsnNumber = hop.AsnNumber;
+                if (!string.IsNullOrEmpty(hop.AsnName)) existing.AsnName = UpstreamTracerService.CleanAsnName(hop.AsnName);
+                existing.LastVerified = DateTime.UtcNow;
+            }
+        }
+        foreach (var hop in hops.Where(h => !h.Enabled))
+        {
+            var existing = await _db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == hop.Address);
+            if (existing != null)
+            {
+                existing.Enabled = false;
+                existing.Name = hop.Label;
+                if (!string.IsNullOrEmpty(hop.AsnName)) existing.AsnName = UpstreamTracerService.CleanAsnName(hop.AsnName);
+            }
+        }
+        foreach (var transit in transits.Where(t => t.Enabled))
+        {
+            var targetType = transit.Method == DiscoveryMethod.PathProxy
+                ? MonitoringTargetType.InternetService
+                : MonitoringTargetType.Transit;
+            var address = transit.HopAddress ?? transit.PathProxyTarget;
+            var existing = await _db.MonitoringTargets.FirstOrDefaultAsync(t => t.TargetId == transit.TargetId)
+                           ?? (address != null ? await _db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == address) : null);
+            if (existing == null && !string.IsNullOrEmpty(address))
+            {
+                _db.MonitoringTargets.Add(new MonitoringTarget
+                {
+                    TargetId = transit.TargetId ?? $"transit-{Guid.NewGuid():N}",
+                    Name = transit.Label ?? transit.AsnName,
+                    Address = address,
+                    ProbeMode = transit.RespondedTo ?? ProbeMode.Icmp,
+                    TargetType = targetType,
+                    AsnNumber = transit.AsnNumber,
+                    AsnName = transit.AsnName,
+                    VantagePoint = "server",
+                    PollIntervalSeconds = 15,
+                    PingCount = 5,
+                    Enabled = true,
+                    AutoDiscovered = true,
+                    DiscoveryMethod = transit.Method,
+                    WanInterface = wanInterface,
+                    CreatedAt = DateTime.UtcNow,
+                    LastVerified = DateTime.UtcNow
+                });
+            }
+            else if (existing != null)
+            {
+                existing.Enabled = true;
+                existing.Name = transit.Label ?? transit.AsnName;
+                existing.Address = address ?? existing.Address;
+                if (transit.AsnNumber > 0) existing.AsnNumber = transit.AsnNumber;
+                if (!string.IsNullOrEmpty(transit.AsnName)) existing.AsnName = transit.AsnName;
+                existing.LastVerified = DateTime.UtcNow;
+            }
+        }
+        foreach (var transit in transits.Where(t => !t.Enabled))
+        {
+            var addr = transit.HopAddress ?? transit.PathProxyTarget;
+            if (string.IsNullOrEmpty(addr)) continue;
+            var existing = await _db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == addr);
+            if (existing != null)
+            {
+                existing.Enabled = false;
+                existing.Name = transit.Label ?? transit.AsnName;
+                if (!string.IsNullOrEmpty(transit.AsnName)) existing.AsnName = transit.AsnName;
+            }
+        }
+
+        await _db.SaveChangesAsync();
+    }
+
+    private static AccessHopCandidate MakeAccessHop(string address, string label, bool enabled) => new()
+    {
+        TargetId = $"access-{address.Replace('.', '-')}",
+        Label = label,
+        Address = address,
+        AsnNumber = 18943,
+        AsnName = "TEST ISP",
+        Role = UpstreamRole.Aggregation,
+        HopNumber = 2,
+        RespondedTo = ProbeMode.Icmp,
+        Enabled = enabled
+    };
+
+    private static TransitAsnCandidate MakeTransitCandidate(string address, string label, int asn,
+        DiscoveryMethod method, bool enabled) => new()
+        {
+            AsnNumber = asn,
+            AsnName = $"AS{asn}",
+            Label = label,
+            Method = method,
+            TargetId = $"transit-as{asn}-{address.Replace('.', '-')}",
+            HopAddress = address,
+            RespondedTo = ProbeMode.Icmp,
+            Enabled = enabled
+        };
+
+    private static MonitoringTarget MakeDbTarget(string address, string name,
+        MonitoringTargetType type, bool enabled) => new()
+        {
+            TargetId = $"test-{address.Replace('.', '-')}",
+            Name = name,
+            Address = address,
+            ProbeMode = ProbeMode.Icmp,
+            TargetType = type,
+            VantagePoint = "server",
+            PollIntervalSeconds = 10,
+            PingCount = 5,
+            Enabled = enabled,
+            AutoDiscovered = true,
+            WanInterface = "wan",
+            CreatedAt = DateTime.UtcNow,
+            LastVerified = DateTime.UtcNow
+        };
+}


### PR DESCRIPTION
## Upstream Discovery

- **AT&T transit probe** - New probe endpoint (12.0.1.28, AS7018) surfaces AT&T as a transit ASN
- **Topology-based border router detection** - Walks each trace to find where traffic exits the access ISP, catching multiple border routers for different transit peers
- **Multi-hop transit candidates** - Up to 3 nearest hops per transit ASN proposed, with RTT shown from reachability verification
- **Consistent target naming** - All targets follow `<Org> <PTR-derived-name>` format. Corporate suffixes stripped from ASN org names (Communications, Telephone, LLC, etc.)
- **PTR resolution** - Explicit PTR lookup on proposed transit IPs for Windows users where traceroute runs without DNS
- **Split review UI** - Transit networks and path-end Internet hosts shown in separate sections
- **DB state reconciliation** - Existing enabled targets pre-checked, disabled targets shown unchecked, user-edited names preserved across re-discovery
- **Enable/disable on save** - Checking/unchecking targets properly enables/disables them in the database, with names always updated
- **Unreachable targets** - Form inputs disabled for targets that fail reachability, clearly separated from user-unchecked
- **Access technology preserved** - Selection carries forward across re-discovery runs
- **Navigation guard fixes** - Unsaved-changes warning only fires when leaving Network Performance tab; clears immediately after save

## Fixes

- **MongoDB SSD tweak data loss** - Stale-data detection now uses WiredTiger.turtle (written on every checkpoint) instead of WiredTiger (written once at creation), preventing unnecessary re-migrations that could lose data
- **Fabric throughput** - Fixed ingress/egress calculation that was only computing for the gateway instead of all fabric devices
- **Status indicator min-width** - Prevents dot indicators from collapsing in flex layouts