### PR TITLE
Fix: Prevent data loss and crash loops in "MongoDB on SSD" tweak

### DIFF
--- a/src/NetworkOptimizer.Web/Resources/PerfTweaks/06-mongodb-ssd-offload.sh
+++ b/src/NetworkOptimizer.Web/Resources/PerfTweaks/06-mongodb-ssd-offload.sh
@@ -174,8 +174,8 @@ if [ -f "$SSD_DB_DIR/WiredTiger" ]; then
     # Compare timestamps: if eMMC data is newer than SSD, the SSD copy is stale
     # (e.g., after a removal that copied SSD back to eMMC, then ran on eMMC for a while).
     # Re-migrate to pick up the newer eMMC data.
-    EMMC_TS=$(stat -c %Y "$EMMC_DB_DIR/WiredTiger" 2>/dev/null || echo 0)
-    SSD_TS=$(stat -c %Y "$SSD_DB_DIR/WiredTiger" 2>/dev/null || echo 0)
+    EMMC_TS=$(stat -c %Y "$EMMC_DB_DIR/WiredTiger.turtle" 2>/dev/null || echo 0)
+    SSD_TS=$(stat -c %Y "$SSD_DB_DIR/WiredTiger.turtle" 2>/dev/null || echo 0)
     if [ "$EMMC_TS" -gt "$SSD_TS" ]; then
         log "SSD copy is stale (eMMC is newer). Will re-migrate."
         NEEDS_MIGRATION=true


### PR DESCRIPTION
## Summary

Fix staleness check to prevent data loss when re-enabling the "MongoDB on SSD" tweak, and avoid post-upgrade `unifi-mongodb` crash loops.

## Problem

The "MongoDB on SSD" tweak fails to detect when eMMC data is newer than the SSD copy, causing either data loss or a post-upgrade crash loop.

The failure is caused by a flawed staleness check in `06-mongodb-ssd-offload.sh`:

```bash
EMMC_TS=$(stat -c %Y "$EMMC_DB_DIR/WiredTiger" 2>/dev/null || echo 0)
SSD_TS=$(stat -c %Y "$SSD_DB_DIR/WiredTiger" 2>/dev/null || echo 0)
```

Because `WiredTiger` is a static version header, its timestamp does not change during application upgrades or normal operations. Comparing it to the actively updated `.turtle` file on the gateway demonstrates why the staleness check fails:

```bash
# stat -c '%y %n' /data/unifi/data/db/WiredTiger{,.turtle}
2025-09-13 ... /data/unifi/data/db/WiredTiger         # Static version header
2026-05-26 ... /data/unifi/data/db/WiredTiger.turtle  # Current database state
```

The script incorrectly assumes the SSD is "current" and bypasses the migration:

```text
May 26 18:51:47 ... mongodb-ssd-offload[...]: SSD copy found and current. Setting up bind mount.
```

**Impact:**

- **Data Loss:** During normal operation, any data written to eMMC while the tweak is disabled is shadowed (and effectively lost) by the stale SSD mount upon re-enabling the tweak.
- **Crash Loop:** Post-upgrade, the script mounts the older SSD database over the newly upgraded system. The stale metadata may be incompatible with the new binary (e.g. `Fatal Assertion 34433`).

## Fix

Update staleness check to evaluate `WiredTiger.turtle` instead of the static `WiredTiger` file. The `.turtle` file is updated during checkpoints and shutdowns, which should be a reliable indicator of the last consistent database state.

```bash
# Before
EMMC_TS=$(stat -c %Y "$EMMC_DB_DIR/WiredTiger" 2>/dev/null || echo 0)
SSD_TS=$(stat -c %Y "$SSD_DB_DIR/WiredTiger" 2>/dev/null || echo 0)

# After
EMMC_TS=$(stat -c %Y "$EMMC_DB_DIR/WiredTiger.turtle" 2>/dev/null || echo 0)
SSD_TS=$(stat -c %Y "$SSD_DB_DIR/WiredTiger.turtle" 2>/dev/null || echo 0)
```

## Testing

This commit was built and executed against a UCG-Fiber gateway.

**Test Scenario:** Disabled the tweak to allow MongoDB to write directly to the eMMC, then re-enabled it. The script correctly identified that the eMMC data was newer than the stale SSD copy and triggered a fresh migration:

```text
May 29 00:13:26 ... mongodb-ssd-offload[...]: SSD copy is stale (eMMC is newer). Will re-migrate.
```
