### PR TITLE
Upstream discovery: AT&T transit probe, border detection, target naming

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1135,7 +1135,10 @@ else
 
     private async Task OnBeforeInternalNavigation(LocationChangingContext context)
     {
-        if (_upstreamDiscoveryPendingSave)
+        // Only guard navigating away from the Monitoring page entirely.
+        // Tab switches within the page are handled by SetActiveTab.
+        if (_upstreamDiscoveryPendingSave
+            && !context.TargetLocation.Contains("/monitoring", StringComparison.OrdinalIgnoreCase))
         {
             var confirmed = await JS.InvokeAsync<bool>("confirm",
                 "Upstream Discovery results haven't been saved. If you leave now, you'll need to re-run discovery.\n\nLeave without saving?");

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -327,7 +327,7 @@ else
 
         <!-- Upstream tracer wizard -->
         <div id="upstream-discovery" style="margin-top: 1.5rem;">
-            <UpstreamTracerPanel ForceExpand="_forceExpandUpstream" />
+            <UpstreamTracerPanel ForceExpand="_forceExpandUpstream" OnSaved="StateHasChanged" />
         </div>
 
         <div style="margin-top: 1.5rem;">
@@ -848,11 +848,7 @@ else
 
         _liveRefreshTimer = new System.Threading.Timer(_ =>
         {
-            try
-            {
-                if (_upstreamDiscoveryPendingSave) return;
-                _ = InvokeAsync(StateHasChanged);
-            }
+            try { _ = InvokeAsync(StateHasChanged); }
             catch { }
         }, null, TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3));
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -848,7 +848,11 @@ else
 
         _liveRefreshTimer = new System.Threading.Timer(_ =>
         {
-            try { _ = InvokeAsync(StateHasChanged); }
+            try
+            {
+                if (_upstreamDiscoveryPendingSave) return;
+                _ = InvokeAsync(StateHasChanged);
+            }
             catch { }
         }, null, TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3));
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -800,7 +800,7 @@ else
     private async void SetActiveTab(string tab)
     {
         if (tab != "setup" && !_monitoringReady) return;
-        if (_upstreamDiscoveryPendingSave && tab != _activeTab)
+        if (_upstreamDiscoveryPendingSave && _activeTab == "performance" && tab != "performance")
         {
             var confirmed = await JS.InvokeAsync<bool>("confirm",
                 "Upstream Discovery results haven't been saved. If you leave now, you'll need to re-run discovery.\n\nLeave without saving?");

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -218,9 +218,10 @@
                                             <td>@asn.AsnName</td>
                                             <td>
                                                 <code>@asn.HopAddress</code>
-                                                @if (!string.IsNullOrEmpty(asn.HopHostname))
+                                                @{ var ptrLabel = FormatPtrLabel(asn.HopHostname, asn.HopAddress); }
+                                                @if (ptrLabel != null)
                                                 {
-                                                    <span class="text-muted"> (@asn.HopHostname)</span>
+                                                    <span class="text-muted"> (@ptrLabel)</span>
                                                 }
                                             </td>
                                         </tr>
@@ -445,6 +446,25 @@
         return string.IsNullOrEmpty(first.AsnName)
             ? $"AS{first.AsnNumber}"
             : $"AS{first.AsnNumber} ({first.AsnName})";
+    }
+
+    private static string? FormatPtrLabel(string? hostname, string? ip)
+    {
+        if (string.IsNullOrEmpty(hostname) || hostname == ip) return null;
+        var parts = hostname.Split('.');
+        if (parts.Length <= 1) return hostname;
+        var ipOctets = (ip ?? "").Split('.');
+        if (ipOctets.Length == 4)
+        {
+            int matches = 0;
+            foreach (var part in parts)
+                foreach (var octet in ipOctets)
+                    if (part == octet || part == "h" + octet || part.Contains("-" + octet + "-")
+                        || part.StartsWith(octet + "-") || part.EndsWith("-" + octet))
+                    { matches++; break; }
+            if (matches >= 2) return null;
+        }
+        return string.Join('.', parts.Take(parts.Length - 1));
     }
 
     public void Dispose() => _pollTimer?.Dispose();

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -351,6 +351,7 @@
                 _ = InvokeAsync(async () =>
                 {
                     _state = Tracer.State;
+                    if (_state.Step == TracerStep.ReviewingResults) return;
                     if (DateTime.UtcNow - _lastReviewCheck > TimeSpan.FromMinutes(1))
                         await RefreshReviewFlagAsync();
                     StateHasChanged();

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -201,9 +201,9 @@
                                 <thead>
                                     <tr>
                                         <th style="width: 40px;"></th>
+                                        <th>Label</th>
+                                        <th>Address</th>
                                         <th>ASN</th>
-                                        <th>Name</th>
-                                        <th>Target hop</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -214,16 +214,13 @@
                                                 <input type="checkbox" checked="@asn.Enabled"
                                                        @onchange="e => asn.Enabled = (bool)e.Value!" />
                                             </td>
-                                            <td><code>AS@(asn.AsnNumber)</code></td>
-                                            <td>@asn.AsnName</td>
                                             <td>
-                                                <code>@asn.HopAddress</code>
-                                                @{ var ptrLabel = FormatPtrLabel(asn.HopHostname, asn.HopAddress); }
-                                                @if (ptrLabel != null)
-                                                {
-                                                    <span class="text-muted"> (@ptrLabel)</span>
-                                                }
+                                                <input type="text" class="form-control form-control-sm"
+                                                       value="@asn.Label"
+                                                       @onchange="e => asn.Label = (string)e.Value!" />
                                             </td>
+                                            <td><code>@asn.HopAddress</code></td>
+                                            <td><code>AS@(asn.AsnNumber)</code> <span class="text-muted">@asn.AsnName</span></td>
                                         </tr>
                                     }
                                 </tbody>
@@ -242,9 +239,9 @@
                                 <thead>
                                     <tr>
                                         <th style="width: 40px;"></th>
-                                        <th>ASN</th>
-                                        <th>Name</th>
+                                        <th>Label</th>
                                         <th>Endpoint</th>
+                                        <th>ASN</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -255,9 +252,13 @@
                                                 <input type="checkbox" checked="@host.Enabled"
                                                        @onchange="e => host.Enabled = (bool)e.Value!" />
                                             </td>
-                                            <td><code>AS@(host.AsnNumber)</code></td>
-                                            <td>@host.AsnName</td>
+                                            <td>
+                                                <input type="text" class="form-control form-control-sm"
+                                                       value="@host.Label"
+                                                       @onchange="e => host.Label = (string)e.Value!" />
+                                            </td>
                                             <td><code>@host.PathProxyTarget</code></td>
+                                            <td><code>AS@(host.AsnNumber)</code> <span class="text-muted">@host.AsnName</span></td>
                                         </tr>
                                     }
                                 </tbody>

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -191,7 +191,7 @@
                     </div>
                 }
 
-                @if (_state.TransitAsns.Count > 0)
+                @if (TransitRouters.Count > 0)
                 {
                     <div class="form-group">
                         <label class="form-label">Transit networks</label>
@@ -204,11 +204,10 @@
                                         <th>ASN</th>
                                         <th>Name</th>
                                         <th>Target hop</th>
-                                        <th>Method</th>
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    @foreach (var asn in _state.TransitAsns)
+                                    @foreach (var asn in TransitRouters)
                                     {
                                         <tr class="@(asn.Enabled ? "" : "row-disabled")">
                                             <td>
@@ -218,16 +217,46 @@
                                             <td><code>AS@(asn.AsnNumber)</code></td>
                                             <td>@asn.AsnName</td>
                                             <td>
-                                                @if (!string.IsNullOrEmpty(asn.HopAddress))
+                                                <code>@asn.HopAddress</code>
+                                                @if (!string.IsNullOrEmpty(asn.HopHostname))
                                                 {
-                                                    <code>@asn.HopAddress</code>
-                                                }
-                                                else
-                                                {
-                                                    <span class="text-muted">-</span>
+                                                    <span class="text-muted"> (@asn.HopHostname)</span>
                                                 }
                                             </td>
-                                            <td>@asn.Method.ToDisplayName()</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                }
+
+                @if (PathEndHosts.Count > 0)
+                {
+                    <div class="form-group">
+                        <label class="form-label">Path-end Internet hosts</label>
+                        <p class="section-description">CDN and Internet services reachable through the discovered transit path.</p>
+                        <div class="table-responsive">
+                            <table class="data-table">
+                                <thead>
+                                    <tr>
+                                        <th style="width: 40px;"></th>
+                                        <th>ASN</th>
+                                        <th>Name</th>
+                                        <th>Endpoint</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var host in PathEndHosts)
+                                    {
+                                        <tr class="@(host.Enabled ? "" : "row-disabled")">
+                                            <td>
+                                                <input type="checkbox" checked="@host.Enabled"
+                                                       @onchange="e => host.Enabled = (bool)e.Value!" />
+                                            </td>
+                                            <td><code>AS@(host.AsnNumber)</code></td>
+                                            <td>@host.AsnName</td>
+                                            <td><code>@host.PathProxyTarget</code></td>
                                         </tr>
                                     }
                                 </tbody>
@@ -283,6 +312,8 @@
     private UpstreamTracerState _state = new();
     private System.Threading.Timer? _pollTimer;
     private bool _needsReview;
+    private List<TransitAsnCandidate> TransitRouters => _state.TransitAsns.Where(a => a.Method == DiscoveryMethod.DirectRouter).ToList();
+    private List<TransitAsnCandidate> PathEndHosts => _state.TransitAsns.Where(a => a.Method == DiscoveryMethod.PathProxy).ToList();
     private bool _collapsed;
     private DateTime _lastReviewCheck = DateTime.MinValue;
     private bool _justSaved;

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -98,7 +98,7 @@
             {
                 <div class="form-group">
                     <label class="form-label">Access network technology</label>
-                    <select class="form-control" style="max-width: 250px;"
+                    <select class="form-control" style="max-width: 250px;@(_state.AccessTechnology == AccessTechnology.Unknown ? " outline: 2px solid rgba(59, 130, 246, 0.5); outline-offset: 2px; border-radius: 6px;" : "")"
                             value="@((int)_state.AccessTechnology)"
                             @onchange="OnAccessTechChanged">
                         @foreach (var tech in Enum.GetValues<AccessTechnology>())

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -165,6 +165,7 @@
                                         <th>Address</th>
                                         <th>Source</th>
                                         <th>Role</th>
+                                        <th>RTT</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -183,6 +184,7 @@
                                             <td><code>@hop.Address</code> @(string.IsNullOrEmpty(hop.PtrHostname) ? "" : $"({hop.PtrHostname})")</td>
                                             <td>@(hop.Method == DiscoveryMethod.L2Neighbor ? "L2 neighbor" : $"Hop {hop.HopNumber}")</td>
                                             <td>@hop.Role.ToDisplayName()</td>
+                                            <td>@(hop.VerifiedRttMs.HasValue ? $"{hop.VerifiedRttMs:F1} ms" : "-")</td>
                                         </tr>
                                     }
                                 </tbody>
@@ -204,6 +206,7 @@
                                         <th>Label</th>
                                         <th>Address</th>
                                         <th>ASN</th>
+                                        <th>RTT</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -221,6 +224,7 @@
                                             </td>
                                             <td><code>@asn.HopAddress</code></td>
                                             <td><code>AS@(asn.AsnNumber)</code> <span class="text-muted">@asn.AsnName</span></td>
+                                            <td>@(asn.VerifiedRttMs.HasValue ? $"{asn.VerifiedRttMs:F1} ms" : "-")</td>
                                         </tr>
                                     }
                                 </tbody>

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -318,6 +318,7 @@
 
 @code {
     [Parameter] public bool ForceExpand { get; set; }
+    [Parameter] public EventCallback OnSaved { get; set; }
 
     private UpstreamTracerState _state = new();
     private System.Threading.Timer? _pollTimer;
@@ -385,6 +386,7 @@
         await Tracer.CommitResultsAsync();
         _state = Tracer.State;
         _justSaved = true;
+        await OnSaved.InvokeAsync();
         StateHasChanged();
 
         // Server side: invalidate the cached map snapshot so the next read

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -171,20 +171,22 @@
                                 <tbody>
                                     @foreach (var hop in _state.AccessHops)
                                     {
-                                        <tr class="@(hop.Enabled ? "" : "row-disabled")">
+                                        <tr class="@(hop.Unreachable ? "row-disabled" : hop.Enabled ? "" : "row-disabled")">
                                             <td>
                                                 <input type="checkbox" checked="@hop.Enabled"
+                                                       disabled="@hop.Unreachable"
                                                        @onchange="e => hop.Enabled = (bool)e.Value!" />
                                             </td>
                                             <td>
                                                 <input type="text" class="form-control form-control-sm"
                                                        value="@hop.Label"
+                                                       disabled="@hop.Unreachable"
                                                        @onchange="e => hop.Label = (string)e.Value!" />
                                             </td>
                                             <td><code>@hop.Address</code> @(string.IsNullOrEmpty(hop.PtrHostname) ? "" : $"({hop.PtrHostname})")</td>
                                             <td>@(hop.Method == DiscoveryMethod.L2Neighbor ? "L2 neighbor" : $"Hop {hop.HopNumber}")</td>
                                             <td>@hop.Role.ToDisplayName()</td>
-                                            <td>@(hop.VerifiedRttMs.HasValue ? $"{hop.VerifiedRttMs:F1} ms" : "-")</td>
+                                            <td>@(hop.Unreachable ? "Unreachable" : hop.VerifiedRttMs.HasValue ? $"{hop.VerifiedRttMs:F1} ms" : "-")</td>
                                         </tr>
                                     }
                                 </tbody>
@@ -212,19 +214,21 @@
                                 <tbody>
                                     @foreach (var asn in TransitRouters)
                                     {
-                                        <tr class="@(asn.Enabled ? "" : "row-disabled")">
+                                        <tr class="@(asn.Unreachable ? "row-disabled" : asn.Enabled ? "" : "row-disabled")">
                                             <td>
                                                 <input type="checkbox" checked="@asn.Enabled"
+                                                       disabled="@asn.Unreachable"
                                                        @onchange="e => asn.Enabled = (bool)e.Value!" />
                                             </td>
                                             <td>
                                                 <input type="text" class="form-control form-control-sm"
                                                        value="@asn.Label"
+                                                       disabled="@asn.Unreachable"
                                                        @onchange="e => asn.Label = (string)e.Value!" />
                                             </td>
                                             <td><code>@asn.HopAddress</code></td>
                                             <td><code>AS@(asn.AsnNumber)</code> <span class="text-muted">@asn.AsnName</span></td>
-                                            <td>@(asn.VerifiedRttMs.HasValue ? $"{asn.VerifiedRttMs:F1} ms" : "-")</td>
+                                            <td>@(asn.Unreachable ? "Unreachable" : asn.VerifiedRttMs.HasValue ? $"{asn.VerifiedRttMs:F1} ms" : "-")</td>
                                         </tr>
                                     }
                                 </tbody>

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -350,10 +350,7 @@
             {
                 _ = InvokeAsync(async () =>
                 {
-                    var prev = _state.Step;
                     _state = Tracer.State;
-                    if (_state.Step == TracerStep.ReviewingResults && prev == TracerStep.ReviewingResults)
-                        return;
                     if (DateTime.UtcNow - _lastReviewCheck > TimeSpan.FromMinutes(1))
                         await RefreshReviewFlagAsync();
                     StateHasChanged();

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -350,8 +350,10 @@
             {
                 _ = InvokeAsync(async () =>
                 {
+                    var prev = _state.Step;
                     _state = Tracer.State;
-                    if (_state.Step == TracerStep.ReviewingResults) return;
+                    if (_state.Step == TracerStep.ReviewingResults && prev == TracerStep.ReviewingResults)
+                        return;
                     if (DateTime.UtcNow - _lastReviewCheck > TimeSpan.FromMinutes(1))
                         await RefreshReviewFlagAsync();
                     StateHasChanged();

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -652,10 +652,11 @@ public class UpstreamTracerService
             }
         }
 
+        var orgName = CleanAsnName(firstPublicHop?.Asn?.Name);
         State.AccessHops = _accessHopsResolved.Select(h => new AccessHopCandidate
         {
             TargetId = $"access-{NormalizeMacForId(h.Address)}",
-            Label = LabelAccessHop(h),
+            Label = "",
             Address = h.Address,
             PtrHostname = h.Hostname,
             AsnNumber = h.Asn?.Asn,
@@ -667,6 +668,17 @@ public class UpstreamTracerService
             RespondedTo = h.RespondedTo,
             Enabled = true
         }).ToList();
+
+        // Generate "<Org> <PTR-derived>" labels, same format as transit targets.
+        var accessIdx = 0;
+        foreach (var hop in State.AccessHops)
+        {
+            var ptrLabel = FormatTransitHopLabel(hop.PtrHostname, hop.Address);
+            if (ptrLabel != null)
+                hop.Label = $"{orgName} {ptrLabel}";
+            else
+                hop.Label = $"{orgName} {++accessIdx}";
+        }
 
         // Inject the L2 neighbor (from ip neigh) as the first access hop if it
         // wasn't already found by traceroute. On GPON the OLT is typically
@@ -680,7 +692,7 @@ public class UpstreamTracerService
             var l2Hop = new AccessHopCandidate
             {
                 TargetId = $"access-l2-{NormalizeMacForId(State.WanNeighborIp)}",
-                Label = LabelL2Neighbor(State.WanNeighborOuiVendor, State.AccessTechnology, l2Asn?.Name),
+                Label = $"{orgName} {LabelL2Role(State.WanNeighborOuiVendor, State.AccessTechnology)}",
                 Address = State.WanNeighborIp,
                 AsnNumber = l2Asn?.Asn,
                 AsnName = l2Asn?.Name,
@@ -923,32 +935,6 @@ public class UpstreamTracerService
             : $"All {allTargets.Count} target(s) responded to ping.";
     }
 
-    /// <summary>
-    /// Hop label priority per spec 5.5: PTR hostname > role inference > bare IP +
-    /// ISP name. PTRs that just encode the IP (e.g. "h1.2.3.4.static.ip.example.net")
-    /// fall through to bare IP since the encoded form is useless as a label.
-    /// Otherwise we strip just the trailing TLD label so the ISP-identifying SLD
-    /// stays in the label ("router-name.example" rather than "router-name").
-    /// </summary>
-    private static string LabelAccessHop(AttributedHop hop)
-    {
-        var ispName = hop.Asn?.Name;
-        if (!string.IsNullOrEmpty(hop.Hostname))
-        {
-            var parts = hop.Hostname.Split('.');
-            if (!IsIpDerivedHostname(parts, hop.Address))
-            {
-                // Strip only the final TLD label (.net/.com/...) so the SLD that
-                // names the ISP is preserved. If the hostname has only one label
-                // (e.g. "_gateway") just return it whole.
-                return parts.Length > 1
-                    ? string.Join('.', parts.Take(parts.Length - 1))
-                    : hop.Hostname;
-            }
-            // IP-encoded PTR; fall through to the bare-IP branch below.
-        }
-        return string.IsNullOrEmpty(ispName) ? hop.Address : $"{hop.Address} - {ispName}";
-    }
 
     /// <summary>
     /// True when the hostname looks like an automated IP-encoded reverse DNS entry
@@ -1025,7 +1011,7 @@ public class UpstreamTracerService
         return UpstreamRole.AccessGateway;
     }
 
-    private static string LabelL2Neighbor(string? ouiVendor, AccessTechnology tech, string? asnName)
+    private static string LabelL2Role(string? ouiVendor, AccessTechnology tech)
     {
         var vendor = FirstWord(ouiVendor);
         var role = tech switch
@@ -1038,11 +1024,7 @@ public class UpstreamTracerService
         var techSuffix = (role == "access" && tech != AccessTechnology.Unknown)
             ? $"-{tech.ToString().ToLowerInvariant()}"
             : "";
-        var isp = FirstWord(asnName);
-
-        // e.g. "nokia-olt.att", "arris-cmts.comcast", "cisco-access-ethernet"
-        var prefix = vendor != null ? $"{vendor}-{role}{techSuffix}" : $"{role}{techSuffix}";
-        return isp != null ? $"{prefix}.{isp}" : prefix;
+        return vendor != null ? $"{vendor}-{role}{techSuffix}" : $"{role}{techSuffix}";
     }
 
     private static string? FirstWord(string? value)
@@ -1057,7 +1039,8 @@ public class UpstreamTracerService
         var hop = State.AccessHops.FirstOrDefault(h => h.Method == DiscoveryMethod.L2Neighbor);
         if (hop == null) return;
         hop.Role = InferL2NeighborRole(State.AccessTechnology, State.WanNeighborOuiVendor);
-        hop.Label = LabelL2Neighbor(State.WanNeighborOuiVendor, State.AccessTechnology, hop.AsnName);
+        var org = CleanAsnName(hop.AsnName ?? State.AccessHops.FirstOrDefault(h => h.AsnName != null)?.AsnName);
+        hop.Label = $"{org} {LabelL2Role(State.WanNeighborOuiVendor, State.AccessTechnology)}";
     }
 
     private static string NormalizeMacForId(string s) => s.Replace(".", "-").Replace(":", "-");

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -895,12 +895,8 @@ public class UpstreamTracerService
             if (existingByAddress.TryGetValue(addr, out var existing))
             {
                 c.Enabled = existing.Enabled;
-                if (!string.IsNullOrEmpty(existing.Name)
-                    && c.Label != null
-                    && Regex.IsMatch(c.Label, @"\s\d+$"))
-                {
+                if (!string.IsNullOrEmpty(existing.Name))
                     c.Label = existing.Name;
-                }
             }
         }
         foreach (var hop in State.AccessHops)
@@ -908,6 +904,8 @@ public class UpstreamTracerService
             if (existingByAddress.TryGetValue(hop.Address, out var existing))
             {
                 hop.Enabled = existing.Enabled;
+                if (!string.IsNullOrEmpty(existing.Name))
+                    hop.Label = existing.Name;
             }
         }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -811,6 +811,26 @@ public class UpstreamTracerService
         // Only a handful of candidates, so the cost is negligible.
         await ResolveHostnamesAsync(candidates, ct);
 
+        // Generate labels from PTR hostnames (strip TLD, filter IP-derived junk).
+        // Generate "<Org> <PTR-derived>" labels, or "<Org> 1/2/3" when no PTR.
+        var asnIndex = new Dictionary<int, int>();
+        foreach (var c in candidates)
+        {
+            if (c.Method == DiscoveryMethod.PathProxy) continue;
+            var ptrLabel = FormatTransitHopLabel(c.HopHostname, c.HopAddress);
+            if (ptrLabel != null)
+            {
+                c.Label = $"{c.AsnName} {ptrLabel}";
+            }
+            else
+            {
+                asnIndex.TryGetValue(c.AsnNumber, out var idx);
+                idx++;
+                asnIndex[c.AsnNumber] = idx;
+                c.Label = $"{c.AsnName} {idx}";
+            }
+        }
+
         State.TransitAsns = candidates;
 
         // Path-proxy: for every CDN destination whose ASN appeared anywhere in the
@@ -843,6 +863,7 @@ public class UpstreamTracerService
             {
                 AsnNumber = destAsn.Asn,
                 AsnName = CleanAsnName(destAsn.Name),
+                Label = endpoint.Label,
                 Method = DiscoveryMethod.PathProxy,
                 TargetId = $"path-{endpoint.Label.ToLowerInvariant()}-as{destAsn.Asn}",
                 HopAddress = endpoint.Address,
@@ -1113,7 +1134,7 @@ public class UpstreamTracerService
                 DiscoveredProbeMode = hop.RespondedTo,
                 TargetType = MonitoringTargetType.AccessIsp,
                 AsnNumber = hop.AsnNumber,
-                AsnName = hop.AsnName,
+                AsnName = CleanAsnName(hop.AsnName),
                 VantagePoint = "server",
                 PollIntervalSeconds = 10,
                 PingCount = 5,
@@ -1138,7 +1159,7 @@ public class UpstreamTracerService
             existing.WanInterface = wanInterface;
             existing.Name = string.IsNullOrEmpty(existing.Name) ? hop.Label : existing.Name; // don't stomp user-renamed labels
             if (hop.AsnNumber.HasValue) existing.AsnNumber = hop.AsnNumber;
-            if (!string.IsNullOrEmpty(hop.AsnName)) existing.AsnName = hop.AsnName;
+            if (!string.IsNullOrEmpty(hop.AsnName)) existing.AsnName = CleanAsnName(hop.AsnName);
             if (!string.IsNullOrEmpty(hop.PtrHostname)) existing.PtrHostname = hop.PtrHostname;
             existing.LastVerified = DateTime.UtcNow;
         }
@@ -1161,7 +1182,7 @@ public class UpstreamTracerService
             db.MonitoringTargets.Add(new MonitoringTarget
             {
                 TargetId = transit.TargetId,
-                Name = transit.AsnName,
+                Name = transit.Label ?? transit.AsnName,
                 Address = transit.HopAddress ?? transit.PathProxyTarget ?? "0.0.0.0",
                 ProbeMode = transit.RespondedTo ?? NetworkOptimizer.Core.Enums.ProbeMode.Icmp,
                 DiscoveredProbeMode = transit.RespondedTo,
@@ -1172,6 +1193,7 @@ public class UpstreamTracerService
                 PollIntervalSeconds = 15,
                 PingCount = 5,
                 Enabled = true,
+                PtrHostname = transit.HopHostname,
                 AutoDiscovered = true,
                 DiscoveryMethod = transit.Method,
                 WanInterface = wanInterface,
@@ -1181,8 +1203,10 @@ public class UpstreamTracerService
         }
         else
         {
+            existing.Name = transit.Label ?? transit.AsnName;
             existing.Address = transit.HopAddress ?? transit.PathProxyTarget ?? existing.Address;
             existing.ProbeMode = transit.RespondedTo ?? existing.ProbeMode;
+            if (!string.IsNullOrEmpty(transit.HopHostname)) existing.PtrHostname = transit.HopHostname;
             existing.DiscoveryMethod = transit.Method;
             existing.WanInterface = wanInterface;
             // Refresh ASN bookkeeping in case the resolver picked up a name now
@@ -1217,11 +1241,17 @@ public class UpstreamTracerService
 
     private static readonly string[] OrgSuffixes =
     {
-        "Communications", "Enterprises", "Parent", "Services", "Technologies",
-        "Telecom", "Telecommunications", "Holdings", "Group", "Networks",
-        "Corporation", "Incorporated", "Company",
-        "LLC", "Inc", "Corp", "Ltd", "Limited", "Co",
-        "GmbH", "AG", "KG", "S.A.", "S.A.S.", "B.V.", "N.V.", "Pty"
+        // Telco/ISP industry terms
+        "Communications", "Telephone", "Telecom", "Telecommunications",
+        "Broadband", "Internet", "Fiber", "Cable", "Wireless",
+        "Enterprises", "Services", "Technologies", "Networks", "Network",
+        "Electric Cooperative", "Cooperative", "Co-op",
+        // Corporate entity suffixes
+        "Corporation", "Incorporated", "Company", "Holdings", "Group", "Parent",
+        "LLC", "Inc", "Corp", "Ltd", "Limited", "Co", "L.P.", "LP",
+        // International
+        "GmbH", "AG", "KG", "e.K.", "S.A.", "S.A.S.", "S.r.l.",
+        "B.V.", "N.V.", "Pty", "A/S", "AB", "Oy", "AS"
     };
 
     /// <summary>
@@ -1232,21 +1262,38 @@ public class UpstreamTracerService
     {
         if (string.IsNullOrWhiteSpace(name)) return name ?? string.Empty;
         var cleaned = name.Trim().TrimEnd(',', '.');
-        foreach (var suffix in OrgSuffixes)
+        // Iterate to strip chains like "Telephone Company" or "Cable Communications LLC"
+        bool changed;
+        do
         {
-            if (cleaned.EndsWith(" " + suffix, StringComparison.OrdinalIgnoreCase))
+            changed = false;
+            foreach (var suffix in OrgSuffixes)
             {
-                cleaned = cleaned[..^(suffix.Length + 1)].TrimEnd(',', '.');
+                if (cleaned.EndsWith(" " + suffix, StringComparison.OrdinalIgnoreCase))
+                {
+                    cleaned = cleaned[..^(suffix.Length + 1)].TrimEnd(',', '.');
+                    changed = true;
+                }
             }
-        }
+        } while (changed && cleaned.Contains(' '));
         return cleaned.Trim();
     }
 
     /// <summary>
-    /// Generate a display label from a PTR hostname for transit/path-end targets.
-    /// Same logic as access hop labels: strip TLD, filter IP-derived auto-PTR junk.
-    /// Returns null if the hostname is unusable.
+    /// Generate a display label from a PTR hostname for transit targets.
+    /// Strips the last 2 labels (SLD + TLD, e.g. ".windstream.net") since
+    /// the org name is already prepended separately. Returns null if the
+    /// hostname is unusable (IP-derived auto-PTR or too short).
     /// </summary>
+    private static string? FormatTransitHopLabel(string? hostname, string? ipAddress)
+    {
+        if (string.IsNullOrEmpty(hostname)) return null;
+        var parts = hostname.Split('.');
+        if (IsIpDerivedHostname(parts, ipAddress ?? string.Empty)) return null;
+        if (parts.Length <= 2) return null;
+        return string.Join('.', parts.Take(parts.Length - 2));
+    }
+
     private static string? FormatHopLabel(string? hostname, string? ipAddress)
     {
         if (string.IsNullOrEmpty(hostname)) return null;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -851,15 +851,16 @@ public class UpstreamTracerService
         await using var reconcileDb = await _dbFactory.CreateDbContextAsync(ct);
         var existingTargets = await reconcileDb.MonitoringTargets
             .AsNoTracking()
-            .Where(t => t.Enabled && (t.TargetType == MonitoringTargetType.Transit || t.TargetType == MonitoringTargetType.AccessIsp))
+            .Where(t => t.Enabled)
             .ToListAsync(ct);
         var existingByAddress = existingTargets
             .Where(t => !string.IsNullOrEmpty(t.Address))
             .ToDictionary(t => t.Address, StringComparer.OrdinalIgnoreCase);
         foreach (var c in candidates)
         {
-            if (c.Method == DiscoveryMethod.PathProxy || string.IsNullOrEmpty(c.HopAddress)) continue;
-            if (existingByAddress.TryGetValue(c.HopAddress, out var existing))
+            var addr = c.HopAddress ?? c.PathProxyTarget;
+            if (string.IsNullOrEmpty(addr)) continue;
+            if (existingByAddress.TryGetValue(addr, out var existing))
             {
                 c.Enabled = true;
                 if (!string.IsNullOrEmpty(existing.Name)
@@ -868,6 +869,14 @@ public class UpstreamTracerService
                 {
                     c.Label = existing.Name;
                 }
+            }
+        }
+        // Also reconcile access hops
+        foreach (var hop in State.AccessHops)
+        {
+            if (existingByAddress.TryGetValue(hop.Address, out var existing))
+            {
+                hop.Enabled = true;
             }
         }
 
@@ -1098,9 +1107,21 @@ public class UpstreamTracerService
         {
             await UpsertTargetAsync(db, hop, wanInterface, ct);
         }
+        foreach (var hop in State.AccessHops.Where(h => !h.Enabled))
+        {
+            var existing = await db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == hop.Address, ct);
+            if (existing != null) existing.Enabled = false;
+        }
         foreach (var transit in State.TransitAsns.Where(t => t.Enabled))
         {
             await UpsertTransitTargetAsync(db, transit, wanInterface, ct);
+        }
+        foreach (var transit in State.TransitAsns.Where(t => !t.Enabled))
+        {
+            var addr = transit.HopAddress ?? transit.PathProxyTarget;
+            if (string.IsNullOrEmpty(addr)) continue;
+            var existing = await db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == addr, ct);
+            if (existing != null) existing.Enabled = false;
         }
 
         // Per-WAN tracer state. WanDiscoveryContexts is the new source of truth;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -845,16 +845,16 @@ public class UpstreamTracerService
             }
         }
 
-        // Reconcile with existing DB targets: if a candidate's address already
-        // exists and is enabled, pre-check it. If the existing target has a more
-        // descriptive name than the numbered fallback, absorb it.
+        // Reconcile with existing DB targets: match candidates against what's
+        // already committed. Enabled targets → pre-check; disabled targets →
+        // uncheck (respect user's previous decision). Absorb descriptive names
+        // over numbered fallbacks.
         await using var reconcileDb = await _dbFactory.CreateDbContextAsync(ct);
-        var existingTargets = await reconcileDb.MonitoringTargets
+        var allExisting = await reconcileDb.MonitoringTargets
             .AsNoTracking()
-            .Where(t => t.Enabled)
             .ToListAsync(ct);
         var existingByAddress = new Dictionary<string, MonitoringTarget>(StringComparer.OrdinalIgnoreCase);
-        foreach (var t in existingTargets.Where(t => !string.IsNullOrEmpty(t.Address)))
+        foreach (var t in allExisting.Where(t => !string.IsNullOrEmpty(t.Address)))
             existingByAddress.TryAdd(t.Address, t);
         foreach (var c in candidates)
         {
@@ -862,7 +862,7 @@ public class UpstreamTracerService
             if (string.IsNullOrEmpty(addr)) continue;
             if (existingByAddress.TryGetValue(addr, out var existing))
             {
-                c.Enabled = true;
+                c.Enabled = existing.Enabled;
                 if (!string.IsNullOrEmpty(existing.Name)
                     && c.Label != null
                     && System.Text.RegularExpressions.Regex.IsMatch(c.Label, @"\s\d+$"))
@@ -871,12 +871,11 @@ public class UpstreamTracerService
                 }
             }
         }
-        // Also reconcile access hops
         foreach (var hop in State.AccessHops)
         {
             if (existingByAddress.TryGetValue(hop.Address, out var existing))
             {
-                hop.Enabled = true;
+                hop.Enabled = existing.Enabled;
             }
         }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -795,7 +795,7 @@ public class UpstreamTracerService
                 candidates.Add(new TransitAsnCandidate
                 {
                     AsnNumber = asn.Asn,
-                    AsnName = asn.Name,
+                    AsnName = CleanAsnName(asn.Name),
                     Method = DiscoveryMethod.DirectRouter,
                     TargetId = $"transit-as{asn.Asn}-{NormalizeMacForId(hop.Address)}",
                     HopAddress = hop.Address,
@@ -805,6 +805,11 @@ public class UpstreamTracerService
                 });
             }
         }
+
+        // PTR-resolve candidate IPs that don't already have a hostname (e.g. from
+        // Windows managed traceroute or traces where the native binary didn't resolve).
+        // Only a handful of candidates, so the cost is negligible.
+        await ResolveHostnamesAsync(candidates, ct);
 
         State.TransitAsns = candidates;
 
@@ -837,7 +842,7 @@ public class UpstreamTracerService
             candidates.Add(new TransitAsnCandidate
             {
                 AsnNumber = destAsn.Asn,
-                AsnName = destAsn.Name,
+                AsnName = CleanAsnName(destAsn.Name),
                 Method = DiscoveryMethod.PathProxy,
                 TargetId = $"path-{endpoint.Label.ToLowerInvariant()}-as{destAsn.Asn}",
                 HopAddress = endpoint.Address,
@@ -1186,6 +1191,70 @@ public class UpstreamTracerService
             if (!string.IsNullOrEmpty(transit.AsnName)) existing.AsnName = transit.AsnName;
             existing.LastVerified = DateTime.UtcNow;
         }
+    }
+
+    /// <summary>
+    /// PTR-resolve any transit candidates that don't already have a hostname from
+    /// the traceroute output (e.g. Windows managed traceroute, or hops that only
+    /// appeared in -n traces). Mutates HopHostname in place.
+    /// </summary>
+    private static async Task ResolveHostnamesAsync(List<TransitAsnCandidate> candidates, CancellationToken ct)
+    {
+        var tasks = candidates
+            .Where(c => string.IsNullOrEmpty(c.HopHostname) && !string.IsNullOrEmpty(c.HopAddress))
+            .Select(async c =>
+            {
+                try
+                {
+                    var entry = await System.Net.Dns.GetHostEntryAsync(c.HopAddress!, ct);
+                    if (!string.IsNullOrEmpty(entry.HostName) && entry.HostName != c.HopAddress)
+                        c.HopHostname = entry.HostName;
+                }
+                catch { /* no PTR record — leave null */ }
+            });
+        await Task.WhenAll(tasks);
+    }
+
+    private static readonly string[] OrgSuffixes =
+    {
+        "Communications", "Enterprises", "Parent", "Services", "Technologies",
+        "Telecom", "Telecommunications", "Holdings", "Group", "Networks",
+        "Corporation", "Incorporated", "Company",
+        "LLC", "Inc", "Corp", "Ltd", "Limited", "Co",
+        "GmbH", "AG", "KG", "S.A.", "S.A.S.", "B.V.", "N.V.", "Pty"
+    };
+
+    /// <summary>
+    /// Strip corporate suffixes from ASN org names.
+    /// "Windstream Communications" → "Windstream", "AT&amp;T Enterprises" → "AT&amp;T"
+    /// </summary>
+    internal static string CleanAsnName(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return name ?? string.Empty;
+        var cleaned = name.Trim().TrimEnd(',', '.');
+        foreach (var suffix in OrgSuffixes)
+        {
+            if (cleaned.EndsWith(" " + suffix, StringComparison.OrdinalIgnoreCase))
+            {
+                cleaned = cleaned[..^(suffix.Length + 1)].TrimEnd(',', '.');
+            }
+        }
+        return cleaned.Trim();
+    }
+
+    /// <summary>
+    /// Generate a display label from a PTR hostname for transit/path-end targets.
+    /// Same logic as access hop labels: strip TLD, filter IP-derived auto-PTR junk.
+    /// Returns null if the hostname is unusable.
+    /// </summary>
+    private static string? FormatHopLabel(string? hostname, string? ipAddress)
+    {
+        if (string.IsNullOrEmpty(hostname)) return null;
+        var parts = hostname.Split('.');
+        if (IsIpDerivedHostname(parts, ipAddress ?? string.Empty)) return null;
+        return parts.Length > 1
+            ? string.Join('.', parts.Take(parts.Length - 1))
+            : hostname;
     }
 
     private bool Fail(string message)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -845,10 +845,42 @@ public class UpstreamTracerService
             }
         }
 
-        // Reconcile with existing DB targets: match candidates against what's
-        // already committed. Enabled targets → pre-check; disabled targets →
-        // uncheck (respect user's previous decision). Absorb descriptive names
-        // over numbered fallbacks.
+        // Path-proxy: for every CDN destination whose ASN appeared anywhere in the
+        // trace - not just traces that reached the literal endpoint - add the
+        // endpoint as a path-end monitoring target.
+        var pathProxyAsnsSeen = new HashSet<int>(candidates.Select(c => c.AsnNumber));
+        var asnsInTrace = new HashSet<int>(_mergedHops
+            .Where(h => h.Asn != null)
+            .Select(h => h.Asn!.Asn));
+        foreach (var endpoint in CdnRotation)
+        {
+            if (endpoint.IsTransitProbe) continue;
+            var destAsn = await _asnResolution.ResolveAsync(endpoint.Address, ct);
+            if (destAsn == null) continue;
+            if (accessAsnNumbers.Contains(destAsn.Asn)) continue;
+            var trace = State.Traces.FirstOrDefault(t =>
+                string.Equals(t.CdnEndpoint, endpoint.Address, StringComparison.OrdinalIgnoreCase));
+            bool reachedOrTraversed = (trace?.Reached ?? false) || asnsInTrace.Contains(destAsn.Asn);
+            if (!reachedOrTraversed) continue;
+            if (!pathProxyAsnsSeen.Add(destAsn.Asn)) continue;
+
+            candidates.Add(new TransitAsnCandidate
+            {
+                AsnNumber = destAsn.Asn,
+                AsnName = CleanAsnName(destAsn.Name),
+                Label = endpoint.Label,
+                Method = DiscoveryMethod.PathProxy,
+                TargetId = $"path-{endpoint.Label.ToLowerInvariant()}-as{destAsn.Asn}",
+                HopAddress = endpoint.Address,
+                PathProxyTarget = endpoint.Address,
+                RespondedTo = ProbeMode.Icmp,
+                Enabled = true
+            });
+        }
+
+        // Reconcile ALL candidates (transit + path-end) and access hops against
+        // existing DB targets. Enabled → pre-check; disabled → uncheck.
+        // Absorb descriptive names over numbered fallbacks.
         await using var reconcileDb = await _dbFactory.CreateDbContextAsync(ct);
         var allExisting = await reconcileDb.MonitoringTargets
             .AsNoTracking()
@@ -865,7 +897,7 @@ public class UpstreamTracerService
                 c.Enabled = existing.Enabled;
                 if (!string.IsNullOrEmpty(existing.Name)
                     && c.Label != null
-                    && System.Text.RegularExpressions.Regex.IsMatch(c.Label, @"\s\d+$"))
+                    && Regex.IsMatch(c.Label, @"\s\d+$"))
                 {
                     c.Label = existing.Name;
                 }
@@ -877,48 +909,6 @@ public class UpstreamTracerService
             {
                 hop.Enabled = existing.Enabled;
             }
-        }
-
-        State.TransitAsns = candidates;
-
-        // Path-proxy: for every CDN destination whose ASN appeared anywhere in the
-        // trace - not just traces that reached the literal endpoint - add the
-        // endpoint as a path-end monitoring target. The previous "only if Reached"
-        // gate missed destinations like Akamai whose anycast endpoints often
-        // don't respond to ICMP/UDP probes even though the trace clearly entered
-        // their network. Seeing the destination ASN attributed to any hop is a
-        // strong signal the path-end is monitorable.
-        var pathProxyAsnsSeen = new HashSet<int>(candidates.Select(c => c.AsnNumber));
-        var asnsInTrace = new HashSet<int>(_mergedHops
-            .Where(h => h.Asn != null)
-            .Select(h => h.Asn!.Asn));
-        foreach (var endpoint in CdnRotation)
-        {
-            // TransitProbe endpoints aren't destinations to monitor - their job
-            // was to surface their ASN as transit (handled above). Skip the
-            // path-end registration for them.
-            if (endpoint.IsTransitProbe) continue;
-            var destAsn = await _asnResolution.ResolveAsync(endpoint.Address, ct);
-            if (destAsn == null) continue;
-            if (accessAsnNumbers.Contains(destAsn.Asn)) continue;
-            var trace = State.Traces.FirstOrDefault(t =>
-                string.Equals(t.CdnEndpoint, endpoint.Address, StringComparison.OrdinalIgnoreCase));
-            bool reachedOrTraversed = (trace?.Reached ?? false) || asnsInTrace.Contains(destAsn.Asn);
-            if (!reachedOrTraversed) continue;
-            if (!pathProxyAsnsSeen.Add(destAsn.Asn)) continue;     // dedupe across CDNs
-
-            candidates.Add(new TransitAsnCandidate
-            {
-                AsnNumber = destAsn.Asn,
-                AsnName = CleanAsnName(destAsn.Name),
-                Label = endpoint.Label,
-                Method = DiscoveryMethod.PathProxy,
-                TargetId = $"path-{endpoint.Label.ToLowerInvariant()}-as{destAsn.Asn}",
-                HopAddress = endpoint.Address,
-                PathProxyTarget = endpoint.Address,
-                RespondedTo = ProbeMode.Icmp,
-                Enabled = true
-            });
         }
 
         State.TransitAsns = candidates;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -77,7 +77,7 @@ public class UpstreamTracerService
         new("Microsoft", "13.107.42.14"),                            // AS8068  - M365 SharePoint anycast
         new("Fastly", "151.101.1.69"),                               // AS54113 - reaches local PoP via anycast
         new("Akamai", "23.0.0.1"),                                   // AS20940 - global netarch anycast loopback
-        new("AT&T", "12.1.1.1", IsTransitProbe: true)                 // AS7018  - probe to surface AT&T as transit
+        new("AT&T", "12.0.1.28", IsTransitProbe: true)                // AS7018  - probe to surface AT&T as transit
     };
 
     private record TraceEndpoint(string Label, string Address, bool IsTransitProbe = false);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -898,11 +898,11 @@ public class UpstreamTracerService
     {
         State.Step = TracerStep.VerifyingReachability;
 
-        var allTargets = new List<(string Address, ProbeMode Mode, Action<double?> ApplyRtt, Action Disable)>();
+        var allTargets = new List<(string Address, ProbeMode Mode, Action<double?> ApplyRtt, Action MarkUnreachable)>();
         foreach (var hop in State.AccessHops)
-            allTargets.Add((hop.Address, hop.RespondedTo, rtt => hop.VerifiedRttMs = rtt, () => hop.Enabled = false));
+            allTargets.Add((hop.Address, hop.RespondedTo, rtt => hop.VerifiedRttMs = rtt, () => { hop.Enabled = false; hop.Unreachable = true; }));
         foreach (var transit in State.TransitAsns.Where(t => t.HopAddress != null && t.Method == DiscoveryMethod.DirectRouter))
-            allTargets.Add((transit.HopAddress!, transit.RespondedTo ?? ProbeMode.Icmp, rtt => transit.VerifiedRttMs = rtt, () => transit.Enabled = false));
+            allTargets.Add((transit.HopAddress!, transit.RespondedTo ?? ProbeMode.Icmp, rtt => transit.VerifiedRttMs = rtt, () => { transit.Enabled = false; transit.Unreachable = true; }));
 
         if (allTargets.Count == 0) return;
 
@@ -928,9 +928,9 @@ public class UpstreamTracerService
             }
             else
             {
-                t.Disable();
+                t.MarkUnreachable();
                 unreachable++;
-                _logger.LogDebug("Ping check failed for {Address} - excluding from proposed targets", t.Address);
+                _logger.LogDebug("Ping check failed for {Address} - marked unreachable", t.Address);
             }
         }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -606,20 +606,22 @@ public class UpstreamTracerService
         var firstPublicHop = candidateHops.FirstOrDefault(h => h.Asn != null);
         var accessAsn = firstPublicHop?.Asn?.Asn;
 
-        // Collect all hops in the access ASN from the merged pool.
-        _accessHopsResolved = new List<AttributedHop>();
-        foreach (var h in candidateHops)
+        // Collect ALL hops in the access ASN from the merged pool. Filter-based,
+        // not sequential - the merged pool interleaves hops from different traces
+        // so a sequential walk breaks at the first non-access hop and misses
+        // access-ASN hops that only appear in certain traces (e.g. a second
+        // border router used for specific transit peers).
+        if (accessAsn.HasValue)
         {
-            if (accessAsn.HasValue)
-            {
-                if (h.Asn == null) continue;
-                if (h.Asn.Asn != accessAsn.Value) break;
-            }
-            else
-            {
-                if (h.Asn != null) break;
-            }
-            _accessHopsResolved.Add(h);
+            _accessHopsResolved = candidateHops
+                .Where(h => h.Asn?.Asn == accessAsn.Value)
+                .ToList();
+        }
+        else
+        {
+            _accessHopsResolved = candidateHops
+                .TakeWhile(h => h.Asn == null)
+                .ToList();
         }
 
         // Walk each individual trace to find border hops: an access-ASN hop
@@ -757,11 +759,20 @@ public class UpstreamTracerService
             if (!string.IsNullOrWhiteSpace(destAsn.Name)) destinationOrgs.Add(destAsn.Name.Trim());
         }
 
+        // Also exclude the transit-probe endpoints themselves from the hop pool.
+        // Their job is to force the path through a specific ASN so real transit
+        // routers surface - the endpoint IP itself is far away and not useful
+        // as a monitoring target.
+        var transitProbeAddresses = new HashSet<string>(
+            CdnRotation.Where(e => e.IsTransitProbe).Select(e => e.Address),
+            StringComparer.OrdinalIgnoreCase);
+
         var transitGroups = _mergedHops
             .Where(h => h.Asn != null
                         && !accessAsnNumbers.Contains(h.Asn.Asn)
                         && !destinationAsns.Contains(h.Asn.Asn)
-                        && !(h.Asn.Name != null && destinationOrgs.Contains(h.Asn.Name.Trim())))
+                        && !(h.Asn.Name != null && destinationOrgs.Contains(h.Asn.Name.Trim()))
+                        && !transitProbeAddresses.Contains(h.Address))
             .GroupBy(h => h.Asn!.Asn)
             .ToList();
 
@@ -778,19 +789,21 @@ public class UpstreamTracerService
             // transit ASNs cleanly by monitoring the CDN destination instead.
             var asn = group.First().Asn!;
             var hopsInOrder = group.OrderBy(h => h.HopNumber).Take(3).ToList();
-            var chosen = hopsInOrder.First(); // already filtered to "responded" by attribution
 
-            candidates.Add(new TransitAsnCandidate
+            foreach (var hop in hopsInOrder)
             {
-                AsnNumber = asn.Asn,
-                AsnName = asn.Name,
-                Method = DiscoveryMethod.DirectRouter,
-                TargetId = $"transit-as{asn.Asn}",
-                HopAddress = chosen.Address,
-                HopHostname = chosen.Hostname,
-                RespondedTo = chosen.RespondedTo,
-                Enabled = true
-            });
+                candidates.Add(new TransitAsnCandidate
+                {
+                    AsnNumber = asn.Asn,
+                    AsnName = asn.Name,
+                    Method = DiscoveryMethod.DirectRouter,
+                    TargetId = $"transit-as{asn.Asn}-{NormalizeMacForId(hop.Address)}",
+                    HopAddress = hop.Address,
+                    HopHostname = hop.Hostname,
+                    RespondedTo = hop.RespondedTo,
+                    Enabled = hop == hopsInOrder.First()
+                });
+            }
         }
 
         State.TransitAsns = candidates;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1288,7 +1288,7 @@ public class UpstreamTracerService
         "LLC", "Inc", "Corp", "Ltd", "Limited", "Co", "L.P.", "LP",
         // International
         "GmbH", "AG", "KG", "e.K.", "S.A.", "S.A.S.", "S.r.l.",
-        "B.V.", "N.V.", "Pty", "A/S", "AB", "Oy", "AS"
+        "B.V.", "B.V", "N.V.", "N.V", "Pty", "A/S", "AB", "Oy", "AS"
     };
 
     /// <summary>
@@ -1297,7 +1297,7 @@ public class UpstreamTracerService
     /// </summary>
     internal static string CleanAsnName(string? name)
     {
-        if (string.IsNullOrWhiteSpace(name)) return name ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(name)) return string.Empty;
         var cleaned = name.Trim().TrimEnd(',', '.');
         // Iterate to strip chains like "Telephone Company" or "Cable Communications LLC"
         bool changed;
@@ -1322,7 +1322,7 @@ public class UpstreamTracerService
     /// the org name is already prepended separately. Returns null if the
     /// hostname is unusable (IP-derived auto-PTR or too short).
     /// </summary>
-    private static string? FormatTransitHopLabel(string? hostname, string? ipAddress)
+    internal static string? FormatTransitHopLabel(string? hostname, string? ipAddress)
     {
         if (string.IsNullOrEmpty(hostname)) return null;
         var parts = hostname.Split('.');

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1109,7 +1109,12 @@ public class UpstreamTracerService
         foreach (var hop in State.AccessHops.Where(h => !h.Enabled))
         {
             var existing = await db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == hop.Address, ct);
-            if (existing != null) existing.Enabled = false;
+            if (existing != null)
+            {
+                existing.Enabled = false;
+                existing.Name = hop.Label;
+                if (!string.IsNullOrEmpty(hop.AsnName)) existing.AsnName = CleanAsnName(hop.AsnName);
+            }
         }
         foreach (var transit in State.TransitAsns.Where(t => t.Enabled))
         {
@@ -1120,7 +1125,12 @@ public class UpstreamTracerService
             var addr = transit.HopAddress ?? transit.PathProxyTarget;
             if (string.IsNullOrEmpty(addr)) continue;
             var existing = await db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == addr, ct);
-            if (existing != null) existing.Enabled = false;
+            if (existing != null)
+            {
+                existing.Enabled = false;
+                existing.Name = transit.Label ?? transit.AsnName;
+                if (!string.IsNullOrEmpty(transit.AsnName)) existing.AsnName = transit.AsnName;
+            }
         }
 
         // Per-WAN tracer state. WanDiscoveryContexts is the new source of truth;
@@ -1189,6 +1199,7 @@ public class UpstreamTracerService
             // preservation per locked decision 6b). Backfill ASN fields whenever a
             // current run resolves them - rows committed before the GeoLite2 fix
             // landed have nulls and never refreshed without this.
+            existing.Enabled = true;
             existing.Address = hop.Address;
             existing.ProbeMode = hop.RespondedTo;
             existing.WanInterface = wanInterface;
@@ -1238,6 +1249,7 @@ public class UpstreamTracerService
         }
         else
         {
+            existing.Enabled = true;
             existing.Name = transit.Label ?? transit.AsnName;
             existing.Address = transit.HopAddress ?? transit.PathProxyTarget ?? existing.Address;
             existing.ProbeMode = transit.RespondedTo ?? existing.ProbeMode;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -76,7 +76,8 @@ public class UpstreamTracerService
         new("Apple", "17.253.144.10"),                               // AS714
         new("Microsoft", "13.107.42.14"),                            // AS8068  - M365 SharePoint anycast
         new("Fastly", "151.101.1.69"),                               // AS54113 - reaches local PoP via anycast
-        new("Akamai", "23.0.0.1")                                    // AS20940 - global netarch anycast loopback
+        new("Akamai", "23.0.0.1"),                                   // AS20940 - global netarch anycast loopback
+        new("AT&T", "12.1.1.1", IsTransitProbe: true)                 // AS7018  - probe to surface AT&T as transit
     };
 
     private record TraceEndpoint(string Label, string Address, bool IsTransitProbe = false);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1144,7 +1144,7 @@ public class UpstreamTracerService
             existing.Address = hop.Address;
             existing.ProbeMode = hop.RespondedTo;
             existing.WanInterface = wanInterface;
-            existing.Name = string.IsNullOrEmpty(existing.Name) ? hop.Label : existing.Name; // don't stomp user-renamed labels
+            existing.Name = hop.Label;
             if (hop.AsnNumber.HasValue) existing.AsnNumber = hop.AsnNumber;
             if (!string.IsNullOrEmpty(hop.AsnName)) existing.AsnName = CleanAsnName(hop.AsnName);
             if (!string.IsNullOrEmpty(hop.PtrHostname)) existing.PtrHostname = hop.PtrHostname;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -198,11 +198,13 @@ public class UpstreamTracerService
         {
             if (_runningTask != null && !_runningTask.IsCompleted) return;
 
+            var preservedTech = State.AccessTechnology;
             State = new UpstreamTracerState
             {
                 Step = TracerStep.DetectingPublicIp,
                 StartedAt = DateTime.UtcNow,
-                CurrentActivity = "Reading WAN configuration from gateway..."
+                CurrentActivity = "Reading WAN configuration from gateway...",
+                AccessTechnology = preservedTech
             };
             _runningTask = Task.Run(() => RunAsync(ct), ct);
         }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -843,6 +843,32 @@ public class UpstreamTracerService
             }
         }
 
+        // Reconcile with existing DB targets: if a candidate's address already
+        // exists and is enabled, pre-check it. If the existing target has a more
+        // descriptive name than the numbered fallback, absorb it.
+        await using var reconcileDb = await _dbFactory.CreateDbContextAsync(ct);
+        var existingTargets = await reconcileDb.MonitoringTargets
+            .AsNoTracking()
+            .Where(t => t.Enabled && (t.TargetType == MonitoringTargetType.Transit || t.TargetType == MonitoringTargetType.AccessIsp))
+            .ToListAsync(ct);
+        var existingByAddress = existingTargets
+            .Where(t => !string.IsNullOrEmpty(t.Address))
+            .ToDictionary(t => t.Address, StringComparer.OrdinalIgnoreCase);
+        foreach (var c in candidates)
+        {
+            if (c.Method == DiscoveryMethod.PathProxy || string.IsNullOrEmpty(c.HopAddress)) continue;
+            if (existingByAddress.TryGetValue(c.HopAddress, out var existing))
+            {
+                c.Enabled = true;
+                if (!string.IsNullOrEmpty(existing.Name)
+                    && c.Label != null
+                    && System.Text.RegularExpressions.Regex.IsMatch(c.Label, @"\s\d+$"))
+                {
+                    c.Label = existing.Name;
+                }
+            }
+        }
+
         State.TransitAsns = candidates;
 
         // Path-proxy: for every CDN destination whose ASN appeared anywhere in the

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -853,9 +853,9 @@ public class UpstreamTracerService
             .AsNoTracking()
             .Where(t => t.Enabled)
             .ToListAsync(ct);
-        var existingByAddress = existingTargets
-            .Where(t => !string.IsNullOrEmpty(t.Address))
-            .ToDictionary(t => t.Address, StringComparer.OrdinalIgnoreCase);
+        var existingByAddress = new Dictionary<string, MonitoringTarget>(StringComparer.OrdinalIgnoreCase);
+        foreach (var t in existingTargets.Where(t => !string.IsNullOrEmpty(t.Address)))
+            existingByAddress.TryAdd(t.Address, t);
         foreach (var c in candidates)
         {
             var addr = c.HopAddress ?? c.PathProxyTarget;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -898,11 +898,11 @@ public class UpstreamTracerService
     {
         State.Step = TracerStep.VerifyingReachability;
 
-        var allTargets = new List<(string Address, ProbeMode Mode, Action Disable)>();
+        var allTargets = new List<(string Address, ProbeMode Mode, Action<double?> ApplyRtt, Action Disable)>();
         foreach (var hop in State.AccessHops)
-            allTargets.Add((hop.Address, hop.RespondedTo, () => hop.Enabled = false));
+            allTargets.Add((hop.Address, hop.RespondedTo, rtt => hop.VerifiedRttMs = rtt, () => hop.Enabled = false));
         foreach (var transit in State.TransitAsns.Where(t => t.HopAddress != null && t.Method == DiscoveryMethod.DirectRouter))
-            allTargets.Add((transit.HopAddress!, transit.RespondedTo ?? ProbeMode.Icmp, () => transit.Enabled = false));
+            allTargets.Add((transit.HopAddress!, transit.RespondedTo ?? ProbeMode.Icmp, rtt => transit.VerifiedRttMs = rtt, () => transit.Enabled = false));
 
         if (allTargets.Count == 0) return;
 
@@ -922,7 +922,11 @@ public class UpstreamTracerService
         var unreachable = 0;
         foreach (var (t, result) in results)
         {
-            if (!result.Success)
+            if (result.Success)
+            {
+                t.ApplyRtt(result.RttAvgMs);
+            }
+            else
             {
                 t.Disable();
                 unreachable++;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1281,16 +1281,6 @@ public class UpstreamTracerService
         return string.Join('.', parts.Take(parts.Length - 2));
     }
 
-    private static string? FormatHopLabel(string? hostname, string? ipAddress)
-    {
-        if (string.IsNullOrEmpty(hostname)) return null;
-        var parts = hostname.Split('.');
-        if (IsIpDerivedHostname(parts, ipAddress ?? string.Empty)) return null;
-        return parts.Length > 1
-            ? string.Join('.', parts.Take(parts.Length - 1))
-            : hostname;
-    }
-
     private bool Fail(string message)
     {
         _logger.LogInformation("Upstream tracer stopped: {Message}", message);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -606,20 +606,10 @@ public class UpstreamTracerService
         var firstPublicHop = candidateHops.FirstOrDefault(h => h.Asn != null);
         var accessAsn = firstPublicHop?.Asn?.Asn;
 
-        // Access hops walk, capped at 3. Two cases:
-        //   - accessAsn known: skip any null-Asn hops in the prefix (a private
-        //     intermediate like an upstream modem at 192.168.x.x that survived
-        //     the gateway-IP filter); only break when we hit a hop with a
-        //     different non-null ASN. Without the skip, an AT&T-style setup
-        //     where the UniFi sits behind a residential gateway aborts the
-        //     access classification before reaching the first AT&T hop.
-        //   - accessAsn null (no public hop in the trace at all - fully
-        //     filtered carrier, all-CGNAT): take the first private hops as
-        //     access until a public ASN unexpectedly appears.
+        // Collect all hops in the access ASN from the merged pool.
         _accessHopsResolved = new List<AttributedHop>();
         foreach (var h in candidateHops)
         {
-            if (_accessHopsResolved.Count >= 3) break;
             if (accessAsn.HasValue)
             {
                 if (h.Asn == null) continue;
@@ -632,6 +622,34 @@ public class UpstreamTracerService
             _accessHopsResolved.Add(h);
         }
 
+        // Walk each individual trace to find border hops: an access-ASN hop
+        // whose next responding hop is in a different ASN. Different traces
+        // may exit through different border routers depending on the transit
+        // peer, so we union across all traces.
+        var borderIps = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (accessAsn.HasValue)
+        {
+            foreach (var (_, result) in results)
+            {
+                var hops = result.Hops
+                    .Where(h => h.Responded && !string.IsNullOrEmpty(h.Address)
+                                && !_gatewayIps.Contains(h.Address))
+                    .OrderBy(h => h.HopNumber)
+                    .ToList();
+                for (int i = 0; i < hops.Count - 1; i++)
+                {
+                    var ip = hops[i].Address!;
+                    if (!byIp.TryGetValue(ip, out var attributed) || attributed.Asn?.Asn != accessAsn.Value)
+                        continue;
+                    var nextIp = hops[i + 1].Address!;
+                    if (!byIp.TryGetValue(nextIp, out var nextAttr))
+                        continue;
+                    if (nextAttr.Asn != null && nextAttr.Asn.Asn != accessAsn.Value)
+                        borderIps.Add(ip);
+                }
+            }
+        }
+
         State.AccessHops = _accessHopsResolved.Select(h => new AccessHopCandidate
         {
             TargetId = $"access-{NormalizeMacForId(h.Address)}",
@@ -640,7 +658,9 @@ public class UpstreamTracerService
             PtrHostname = h.Hostname,
             AsnNumber = h.Asn?.Asn,
             AsnName = h.Asn?.Name,
-            Role = InferAccessRole(h, State.AccessTechnology, State.WanNeighborOuiVendor),
+            Role = borderIps.Contains(h.Address)
+                ? UpstreamRole.Border
+                : InferAccessRole(h, State.AccessTechnology, State.WanNeighborOuiVendor),
             HopNumber = h.HopNumber,
             RespondedTo = h.RespondedTo,
             Enabled = true
@@ -940,14 +960,12 @@ public class UpstreamTracerService
                            || vendor.Contains("cadant") || vendor.Contains("ubr");
 
         if ((tech == AccessTechnology.Gpon || tech == AccessTechnology.XgsPon) && isOltVendor && hop.HopNumber == 1)
-            return UpstreamRole.Bng; // L2-transparent OLT means hop 1 is the BNG behind it.
+            return UpstreamRole.Bng;
         if (tech == AccessTechnology.Docsis && (isCmtsVendor || hop.HopNumber == 1))
             return UpstreamRole.Cmts;
         if (tech == AccessTechnology.PppoE && hop.HopNumber == 1)
             return UpstreamRole.Bng;
-        if (hop.HopNumber >= 2 && hop.HopNumber <= 3)
-            return UpstreamRole.Aggregation;
-        return UpstreamRole.AccessHop;
+        return UpstreamRole.Aggregation;
     }
 
     private static UpstreamRole InferL2NeighborRole(AccessTechnology tech, string? ouiVendor)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerState.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerState.cs
@@ -75,6 +75,7 @@ public class TransitAsnCandidate
 {
     public int AsnNumber { get; set; }
     public required string AsnName { get; set; }
+    public string? Label { get; set; }
     public DiscoveryMethod Method { get; set; }
     public string? TargetId { get; set; }              // null for Unresolved tier
     public string? HopAddress { get; set; }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerState.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerState.cs
@@ -65,6 +65,7 @@ public class AccessHopCandidate
     public Core.Enums.ProbeMode RespondedTo { get; set; }
     public DiscoveryMethod Method { get; set; } = DiscoveryMethod.DirectRouter;
     public bool Enabled { get; set; } = true;
+    public bool Unreachable { get; set; }
     public double? VerifiedRttMs { get; set; }
 }
 
@@ -83,6 +84,7 @@ public class TransitAsnCandidate
     public string? HopHostname { get; set; }
     public Core.Enums.ProbeMode? RespondedTo { get; set; }
     public bool Enabled { get; set; } = true;
+    public bool Unreachable { get; set; }
     public double? VerifiedRttMs { get; set; }
     /// <summary>For PathProxy tier: the CDN endpoint we monitor as a proxy for this ASN.</summary>
     public string? PathProxyTarget { get; set; }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerState.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerState.cs
@@ -65,6 +65,7 @@ public class AccessHopCandidate
     public Core.Enums.ProbeMode RespondedTo { get; set; }
     public DiscoveryMethod Method { get; set; } = DiscoveryMethod.DirectRouter;
     public bool Enabled { get; set; } = true;
+    public double? VerifiedRttMs { get; set; }
 }
 
 /// <summary>
@@ -82,6 +83,7 @@ public class TransitAsnCandidate
     public string? HopHostname { get; set; }
     public Core.Enums.ProbeMode? RespondedTo { get; set; }
     public bool Enabled { get; set; } = true;
+    public double? VerifiedRttMs { get; set; }
     /// <summary>For PathProxy tier: the CDN endpoint we monitor as a proxy for this ASN.</summary>
     public string? PathProxyTarget { get; set; }
 }

--- a/tests/NetworkOptimizer.Web.Tests/NetworkOptimizer.Web.Tests.csproj
+++ b/tests/NetworkOptimizer.Web.Tests/NetworkOptimizer.Web.Tests.csproj
@@ -15,6 +15,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
@@ -412,6 +412,130 @@ public class UpstreamCommitTests : IDisposable
         target.Name.Should().Be("Hop A Final");
     }
 
+    [Fact]
+    public void Reconcile_absorbs_user_edited_name_for_transit()
+    {
+        var candidates = new List<TransitAsnCandidate>
+        {
+            MakeTransitCandidate("198.51.100.1", "Windstream ae6-0.agr01.ltrk01-ar.us", 7029, DiscoveryMethod.DirectRouter, true)
+        };
+        var existing = MakeDbTarget("198.51.100.1", "Windstream ae6-0.agr01.ltrk01-ar.us 1", MonitoringTargetType.Transit, enabled: true);
+        _db.MonitoringTargets.Add(existing);
+        _db.SaveChanges();
+
+        var byAddress = new Dictionary<string, MonitoringTarget>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["198.51.100.1"] = existing
+        };
+
+        foreach (var c in candidates)
+        {
+            var addr = c.HopAddress ?? c.PathProxyTarget;
+            if (string.IsNullOrEmpty(addr)) continue;
+            if (byAddress.TryGetValue(addr, out var ex))
+            {
+                c.Enabled = ex.Enabled;
+                if (!string.IsNullOrEmpty(ex.Name))
+                    c.Label = ex.Name;
+            }
+        }
+
+        candidates[0].Label.Should().Be("Windstream ae6-0.agr01.ltrk01-ar.us 1");
+        candidates[0].Enabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Reconcile_absorbs_user_edited_name_for_access()
+    {
+        var hops = new List<AccessHopCandidate>
+        {
+            MakeAccessHop("192.0.2.1", "YELCOT gassville-border", enabled: true)
+        };
+        var existing = MakeDbTarget("192.0.2.1", "YELCOT gassville-border 1", MonitoringTargetType.AccessIsp, enabled: true);
+        _db.MonitoringTargets.Add(existing);
+        _db.SaveChanges();
+
+        var byAddress = new Dictionary<string, MonitoringTarget>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["192.0.2.1"] = existing
+        };
+
+        foreach (var hop in hops)
+        {
+            if (byAddress.TryGetValue(hop.Address, out var ex))
+            {
+                hop.Enabled = ex.Enabled;
+                if (!string.IsNullOrEmpty(ex.Name))
+                    hop.Label = ex.Name;
+            }
+        }
+
+        hops[0].Label.Should().Be("YELCOT gassville-border 1");
+    }
+
+    [Fact]
+    public void Reconcile_absorbs_name_for_pathproxy()
+    {
+        var candidates = new List<TransitAsnCandidate>
+        {
+            MakeTransitCandidate("203.0.113.1", "Cloudflare", 13335, DiscoveryMethod.PathProxy, true)
+        };
+        candidates[0].PathProxyTarget = "203.0.113.1";
+        var existing = MakeDbTarget("203.0.113.1", "Cloudflare Primary", MonitoringTargetType.InternetService, enabled: true);
+        _db.MonitoringTargets.Add(existing);
+        _db.SaveChanges();
+
+        var byAddress = new Dictionary<string, MonitoringTarget>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["203.0.113.1"] = existing
+        };
+
+        foreach (var c in candidates)
+        {
+            var addr = c.HopAddress ?? c.PathProxyTarget;
+            if (string.IsNullOrEmpty(addr)) continue;
+            if (byAddress.TryGetValue(addr, out var ex))
+            {
+                c.Enabled = ex.Enabled;
+                if (!string.IsNullOrEmpty(ex.Name))
+                    c.Label = ex.Name;
+            }
+        }
+
+        candidates[0].Label.Should().Be("Cloudflare Primary");
+    }
+
+    [Fact]
+    public void Reconcile_does_not_overwrite_with_empty_db_name()
+    {
+        var candidates = new List<TransitAsnCandidate>
+        {
+            MakeTransitCandidate("198.51.100.1", "Windstream agr01", 7029, DiscoveryMethod.DirectRouter, true)
+        };
+        var existing = MakeDbTarget("198.51.100.1", "", MonitoringTargetType.Transit, enabled: true);
+        _db.MonitoringTargets.Add(existing);
+        _db.SaveChanges();
+
+        var byAddress = new Dictionary<string, MonitoringTarget>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["198.51.100.1"] = existing
+        };
+
+        foreach (var c in candidates)
+        {
+            var addr = c.HopAddress ?? c.PathProxyTarget;
+            if (string.IsNullOrEmpty(addr)) continue;
+            if (byAddress.TryGetValue(addr, out var ex))
+            {
+                c.Enabled = ex.Enabled;
+                if (!string.IsNullOrEmpty(ex.Name))
+                    c.Label = ex.Name;
+            }
+        }
+
+        candidates[0].Label.Should().Be("Windstream agr01");
+    }
+
     // ---- Helpers ----
 
     private async Task CommitAsync(List<AccessHopCandidate> hops, List<TransitAsnCandidate> transits)

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
@@ -14,7 +14,7 @@ public class CleanAsnNameTests
     [InlineData("AT&T Enterprises", "AT&T")]
     [InlineData("Level 3 Parent, LLC", "Level 3")]
     [InlineData("Cox Communications Inc.", "Cox")]
-    [InlineData("YELCOT TELEPHONE", "YELCOT")]
+    [InlineData("EXAMPLE TELEPHONE", "EXAMPLE")]
     [InlineData("Cisco OpenDNS, LLC", "Cisco OpenDNS")]
     [InlineData("Akamai International B.V.", "Akamai International")]
     [InlineData("Fastly, Inc.", "Fastly")]
@@ -58,15 +58,15 @@ public class FormatTransitHopLabelTests
     [InlineData("lag-101.ear1.LittleRock2.Level3.net", null, "lag-101.ear1.LittleRock2")]
     [InlineData("mcibbrj01.rd.ks.cox.net", null, "mcibbrj01.rd.ks")]
     [InlineData("ae25.25.ear1.Dallas1.net.lumen.tech", null, "ae25.25.ear1.Dallas1.net")]
-    [InlineData("ltrar-att-xconnect.yelcot.net", null, "ltrar-att-xconnect")]
+    [InlineData("rtr1-handoff.example.net", null, "rtr1-handoff")]
     public void Strips_sld_and_tld(string hostname, string? ip, string expected)
     {
         UpstreamTracerService.FormatTransitHopLabel(hostname, ip).Should().Be(expected);
     }
 
     [Theory]
-    [InlineData("h121.217.134.40.static.ip.windstream.net", "40.134.217.121")]
-    [InlineData("12.123.6.146", "12.123.6.146")]
+    [InlineData("h40.113.0.203.static.ip.example.net", "203.0.113.40")]
+    [InlineData("203.0.113.146", "203.0.113.146")]
     public void Returns_null_for_ip_derived_hostnames(string hostname, string ip)
     {
         UpstreamTracerService.FormatTransitHopLabel(hostname, ip).Should().BeNull();
@@ -275,28 +275,28 @@ public class UpstreamCommitTests : IDisposable
     [Fact]
     public async Task Rename_applies_to_disabled_targets()
     {
-        _db.MonitoringTargets.Add(MakeDbTarget("192.0.2.1", "gassville-bng-pon.yelcot", MonitoringTargetType.AccessIsp, enabled: true));
+        _db.MonitoringTargets.Add(MakeDbTarget("192.0.2.1", "bng01.example", MonitoringTargetType.AccessIsp, enabled: true));
         await _db.SaveChangesAsync();
 
-        var hop = MakeAccessHop("192.0.2.1", "YELCOT gassville-bng-pon", enabled: false);
+        var hop = MakeAccessHop("192.0.2.1", "EXAMPLE bng01", enabled: false);
 
         await CommitAsync(new List<AccessHopCandidate> { hop }, new List<TransitAsnCandidate>());
 
         var target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1");
         target.Enabled.Should().BeFalse();
-        target.Name.Should().Be("YELCOT gassville-bng-pon");
+        target.Name.Should().Be("EXAMPLE bng01");
     }
 
     [Fact]
     public async Task Asn_name_cleaned_on_save()
     {
-        var hop = MakeAccessHop("192.0.2.1", "YELCOT bng", enabled: true);
-        hop.AsnName = "YELCOT TELEPHONE";
+        var hop = MakeAccessHop("192.0.2.1", "EXAMPLE bng", enabled: true);
+        hop.AsnName = "EXAMPLE TELEPHONE";
 
         await CommitAsync(new List<AccessHopCandidate> { hop }, new List<TransitAsnCandidate>());
 
         var target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1");
-        target.AsnName.Should().Be("YELCOT");
+        target.AsnName.Should().Be("EXAMPLE");
     }
 
     [Fact]
@@ -449,9 +449,9 @@ public class UpstreamCommitTests : IDisposable
     {
         var hops = new List<AccessHopCandidate>
         {
-            MakeAccessHop("192.0.2.1", "YELCOT gassville-border", enabled: true)
+            MakeAccessHop("192.0.2.1", "EXAMPLE border01", enabled: true)
         };
-        var existing = MakeDbTarget("192.0.2.1", "YELCOT gassville-border 1", MonitoringTargetType.AccessIsp, enabled: true);
+        var existing = MakeDbTarget("192.0.2.1", "EXAMPLE border01 1", MonitoringTargetType.AccessIsp, enabled: true);
         _db.MonitoringTargets.Add(existing);
         _db.SaveChanges();
 
@@ -470,7 +470,7 @@ public class UpstreamCommitTests : IDisposable
             }
         }
 
-        hops[0].Label.Should().Be("YELCOT gassville-border 1");
+        hops[0].Label.Should().Be("EXAMPLE border01 1");
     }
 
     [Fact]
@@ -658,32 +658,32 @@ public class UpstreamCommitTests : IDisposable
 
     private static TransitAsnCandidate MakeTransitCandidate(string address, string label, int asn,
         DiscoveryMethod method, bool enabled) => new()
-    {
-        AsnNumber = asn,
-        AsnName = $"AS{asn}",
-        Label = label,
-        Method = method,
-        TargetId = $"transit-as{asn}-{address.Replace('.', '-')}",
-        HopAddress = address,
-        RespondedTo = ProbeMode.Icmp,
-        Enabled = enabled
-    };
+        {
+            AsnNumber = asn,
+            AsnName = $"AS{asn}",
+            Label = label,
+            Method = method,
+            TargetId = $"transit-as{asn}-{address.Replace('.', '-')}",
+            HopAddress = address,
+            RespondedTo = ProbeMode.Icmp,
+            Enabled = enabled
+        };
 
     private static MonitoringTarget MakeDbTarget(string address, string name,
         MonitoringTargetType type, bool enabled) => new()
-    {
-        TargetId = $"test-{address.Replace('.', '-')}",
-        Name = name,
-        Address = address,
-        ProbeMode = ProbeMode.Icmp,
-        TargetType = type,
-        VantagePoint = "server",
-        PollIntervalSeconds = 10,
-        PingCount = 5,
-        Enabled = enabled,
-        AutoDiscovered = true,
-        WanInterface = "wan",
-        CreatedAt = DateTime.UtcNow,
-        LastVerified = DateTime.UtcNow
-    };
+        {
+            TargetId = $"test-{address.Replace('.', '-')}",
+            Name = name,
+            Address = address,
+            ProbeMode = ProbeMode.Icmp,
+            TargetType = type,
+            VantagePoint = "server",
+            PollIntervalSeconds = 10,
+            PingCount = 5,
+            Enabled = enabled,
+            AutoDiscovered = true,
+            WanInterface = "wan",
+            CreatedAt = DateTime.UtcNow,
+            LastVerified = DateTime.UtcNow
+        };
 }

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
@@ -1,0 +1,565 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services.Monitoring;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class CleanAsnNameTests
+{
+    [Theory]
+    [InlineData("Windstream Communications", "Windstream")]
+    [InlineData("AT&T Enterprises", "AT&T")]
+    [InlineData("Level 3 Parent, LLC", "Level 3")]
+    [InlineData("Cox Communications Inc.", "Cox")]
+    [InlineData("YELCOT TELEPHONE", "YELCOT")]
+    [InlineData("Cisco OpenDNS, LLC", "Cisco OpenDNS")]
+    [InlineData("Akamai International B.V.", "Akamai International")]
+    [InlineData("Fastly, Inc.", "Fastly")]
+    [InlineData("Deutsche Telekom AG", "Deutsche Telekom")]
+    [InlineData("Comcast Cable Communications, LLC", "Comcast")]
+    [InlineData("Charter Communications Inc", "Charter")]
+    [InlineData("Lumen Technologies", "Lumen")]
+    [InlineData("Frontier Communications Corporation", "Frontier")]
+    [InlineData("TDS Telecom", "TDS")]
+    [InlineData("Sievert Larsen Fiber LLC", "Sievert Larsen")]
+    [InlineData("Rural Electric Cooperative", "Rural")]
+    [InlineData("Google", "Google")]
+    [InlineData("Cloudflare", "Cloudflare")]
+    [InlineData(null, "")]
+    [InlineData("", "")]
+    [InlineData("  ", "")]
+    public void Strips_corporate_suffixes(string? input, string expected)
+    {
+        UpstreamTracerService.CleanAsnName(input).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Strips_chained_suffixes()
+    {
+        UpstreamTracerService.CleanAsnName("Acme Telephone Company LLC")
+            .Should().Be("Acme");
+    }
+
+    [Fact]
+    public void Stops_before_emptying_the_name()
+    {
+        UpstreamTracerService.CleanAsnName("Communications LLC")
+            .Should().NotBeEmpty();
+    }
+}
+
+public class FormatTransitHopLabelTests
+{
+    [Theory]
+    [InlineData("ae6-0.agr01.ltrk01-ar.us.windstream.net", null, "ae6-0.agr01.ltrk01-ar.us")]
+    [InlineData("lag-101.ear1.LittleRock2.Level3.net", null, "lag-101.ear1.LittleRock2")]
+    [InlineData("mcibbrj01.rd.ks.cox.net", null, "mcibbrj01.rd.ks")]
+    [InlineData("ae25.25.ear1.Dallas1.net.lumen.tech", null, "ae25.25.ear1.Dallas1.net")]
+    [InlineData("ltrar-att-xconnect.yelcot.net", null, "ltrar-att-xconnect")]
+    public void Strips_sld_and_tld(string hostname, string? ip, string expected)
+    {
+        UpstreamTracerService.FormatTransitHopLabel(hostname, ip).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("h121.217.134.40.static.ip.windstream.net", "40.134.217.121")]
+    [InlineData("12.123.6.146", "12.123.6.146")]
+    public void Returns_null_for_ip_derived_hostnames(string hostname, string ip)
+    {
+        UpstreamTracerService.FormatTransitHopLabel(hostname, ip).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    public void Returns_null_for_empty_input(string? hostname, string? ip)
+    {
+        UpstreamTracerService.FormatTransitHopLabel(hostname, ip).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("router.net", null)]
+    [InlineData("single", null)]
+    public void Returns_null_when_too_few_labels(string hostname, string? ip)
+    {
+        UpstreamTracerService.FormatTransitHopLabel(hostname, ip).Should().BeNull();
+    }
+}
+
+public class UpstreamCommitTests : IDisposable
+{
+    private readonly NetworkOptimizerDbContext _db;
+
+    public UpstreamCommitTests()
+    {
+        var options = new DbContextOptionsBuilder<NetworkOptimizerDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        _db = new NetworkOptimizerDbContext(options);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task Enabled_access_hop_creates_new_target()
+    {
+        var hops = new List<AccessHopCandidate>
+        {
+            MakeAccessHop("192.0.2.1", "TestISP bng", enabled: true)
+        };
+        var transits = new List<TransitAsnCandidate>();
+
+        await CommitAsync(hops, transits);
+
+        var target = await _db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == "192.0.2.1");
+        target.Should().NotBeNull();
+        target!.Enabled.Should().BeTrue();
+        target.Name.Should().Be("TestISP bng");
+        target.TargetType.Should().Be(MonitoringTargetType.AccessIsp);
+    }
+
+    [Fact]
+    public async Task Disabled_access_hop_does_not_create_target()
+    {
+        var hops = new List<AccessHopCandidate>
+        {
+            MakeAccessHop("192.0.2.1", "TestISP bng", enabled: false)
+        };
+
+        await CommitAsync(hops, new List<TransitAsnCandidate>());
+
+        var target = await _db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == "192.0.2.1");
+        target.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Unchecking_existing_access_hop_disables_it()
+    {
+        _db.MonitoringTargets.Add(MakeDbTarget("192.0.2.1", "Old Name", MonitoringTargetType.AccessIsp, enabled: true));
+        await _db.SaveChangesAsync();
+
+        var hops = new List<AccessHopCandidate>
+        {
+            MakeAccessHop("192.0.2.1", "New Name", enabled: false)
+        };
+
+        await CommitAsync(hops, new List<TransitAsnCandidate>());
+
+        var target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1");
+        target.Enabled.Should().BeFalse();
+        target.Name.Should().Be("New Name");
+    }
+
+    [Fact]
+    public async Task Rechecking_disabled_access_hop_enables_it()
+    {
+        _db.MonitoringTargets.Add(MakeDbTarget("192.0.2.1", "Old Name", MonitoringTargetType.AccessIsp, enabled: false));
+        await _db.SaveChangesAsync();
+
+        var hops = new List<AccessHopCandidate>
+        {
+            MakeAccessHop("192.0.2.1", "New Name", enabled: true)
+        };
+
+        await CommitAsync(hops, new List<TransitAsnCandidate>());
+
+        var target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1");
+        target.Enabled.Should().BeTrue();
+        target.Name.Should().Be("New Name");
+    }
+
+    [Fact]
+    public async Task Enabled_transit_creates_new_target()
+    {
+        var transit = MakeTransitCandidate("198.51.100.1", "Windstream agr01", 7029,
+            method: DiscoveryMethod.DirectRouter, enabled: true);
+
+        await CommitAsync(new List<AccessHopCandidate>(), new List<TransitAsnCandidate> { transit });
+
+        var target = await _db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == "198.51.100.1");
+        target.Should().NotBeNull();
+        target!.Enabled.Should().BeTrue();
+        target.Name.Should().Be("Windstream agr01");
+        target.TargetType.Should().Be(MonitoringTargetType.Transit);
+    }
+
+    [Fact]
+    public async Task Unchecking_existing_transit_disables_it()
+    {
+        _db.MonitoringTargets.Add(MakeDbTarget("198.51.100.1", "Old Transit", MonitoringTargetType.Transit, enabled: true));
+        await _db.SaveChangesAsync();
+
+        var transit = MakeTransitCandidate("198.51.100.1", "New Transit", 7029,
+            method: DiscoveryMethod.DirectRouter, enabled: false);
+
+        await CommitAsync(new List<AccessHopCandidate>(), new List<TransitAsnCandidate> { transit });
+
+        var target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "198.51.100.1");
+        target.Enabled.Should().BeFalse();
+        target.Name.Should().Be("New Transit");
+    }
+
+    [Fact]
+    public async Task Rechecking_disabled_transit_enables_it()
+    {
+        _db.MonitoringTargets.Add(MakeDbTarget("198.51.100.1", "Old Transit", MonitoringTargetType.Transit, enabled: false));
+        await _db.SaveChangesAsync();
+
+        var transit = MakeTransitCandidate("198.51.100.1", "New Transit", 7029,
+            method: DiscoveryMethod.DirectRouter, enabled: true);
+
+        await CommitAsync(new List<AccessHopCandidate>(), new List<TransitAsnCandidate> { transit });
+
+        var target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "198.51.100.1");
+        target.Enabled.Should().BeTrue();
+        target.Name.Should().Be("New Transit");
+    }
+
+    [Fact]
+    public async Task Unchecking_pathproxy_disables_it()
+    {
+        _db.MonitoringTargets.Add(MakeDbTarget("203.0.113.1", "Cloudflare", MonitoringTargetType.InternetService, enabled: true));
+        await _db.SaveChangesAsync();
+
+        var pathProxy = MakeTransitCandidate("203.0.113.1", "Cloudflare", 13335,
+            method: DiscoveryMethod.PathProxy, enabled: false);
+        pathProxy.PathProxyTarget = "203.0.113.1";
+
+        await CommitAsync(new List<AccessHopCandidate>(), new List<TransitAsnCandidate> { pathProxy });
+
+        var target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "203.0.113.1");
+        target.Enabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Rechecking_pathproxy_enables_it()
+    {
+        _db.MonitoringTargets.Add(MakeDbTarget("203.0.113.1", "Cloudflare", MonitoringTargetType.InternetService, enabled: false));
+        await _db.SaveChangesAsync();
+
+        var pathProxy = MakeTransitCandidate("203.0.113.1", "Cloudflare", 13335,
+            method: DiscoveryMethod.PathProxy, enabled: true);
+        pathProxy.PathProxyTarget = "203.0.113.1";
+
+        await CommitAsync(new List<AccessHopCandidate>(), new List<TransitAsnCandidate> { pathProxy });
+
+        var target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "203.0.113.1");
+        target.Enabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Upsert_matches_by_address_when_targetid_differs()
+    {
+        var existing = MakeDbTarget("198.51.100.1", "Custom Name", MonitoringTargetType.Transit, enabled: true);
+        existing.TargetId = "custom-abc123";
+        _db.MonitoringTargets.Add(existing);
+        await _db.SaveChangesAsync();
+        var originalId = existing.Id;
+
+        var transit = MakeTransitCandidate("198.51.100.1", "Discovery Name", 7029,
+            method: DiscoveryMethod.DirectRouter, enabled: true);
+        transit.TargetId = "transit-as7029-198-51-100-1";
+
+        await CommitAsync(new List<AccessHopCandidate>(), new List<TransitAsnCandidate> { transit });
+
+        var targets = await _db.MonitoringTargets.Where(t => t.Address == "198.51.100.1").ToListAsync();
+        targets.Should().HaveCount(1);
+        targets[0].Id.Should().Be(originalId);
+        targets[0].Name.Should().Be("Discovery Name");
+    }
+
+    [Fact]
+    public async Task Rename_applies_to_disabled_targets()
+    {
+        _db.MonitoringTargets.Add(MakeDbTarget("192.0.2.1", "gassville-bng-pon.yelcot", MonitoringTargetType.AccessIsp, enabled: true));
+        await _db.SaveChangesAsync();
+
+        var hop = MakeAccessHop("192.0.2.1", "YELCOT gassville-bng-pon", enabled: false);
+
+        await CommitAsync(new List<AccessHopCandidate> { hop }, new List<TransitAsnCandidate>());
+
+        var target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1");
+        target.Enabled.Should().BeFalse();
+        target.Name.Should().Be("YELCOT gassville-bng-pon");
+    }
+
+    [Fact]
+    public async Task Asn_name_cleaned_on_save()
+    {
+        var hop = MakeAccessHop("192.0.2.1", "YELCOT bng", enabled: true);
+        hop.AsnName = "YELCOT TELEPHONE";
+
+        await CommitAsync(new List<AccessHopCandidate> { hop }, new List<TransitAsnCandidate>());
+
+        var target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1");
+        target.AsnName.Should().Be("YELCOT");
+    }
+
+    [Fact]
+    public async Task Unreachable_target_disabled_on_save()
+    {
+        _db.MonitoringTargets.Add(MakeDbTarget("198.51.100.1", "Transit 1", MonitoringTargetType.Transit, enabled: true));
+        await _db.SaveChangesAsync();
+
+        var transit = MakeTransitCandidate("198.51.100.1", "Transit 1", 7029,
+            method: DiscoveryMethod.DirectRouter, enabled: false);
+        transit.Unreachable = true;
+
+        await CommitAsync(new List<AccessHopCandidate>(), new List<TransitAsnCandidate> { transit });
+
+        var target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "198.51.100.1");
+        target.Enabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Mixed_enable_disable_across_all_types()
+    {
+        _db.MonitoringTargets.Add(MakeDbTarget("192.0.2.1", "Access A", MonitoringTargetType.AccessIsp, enabled: true));
+        _db.MonitoringTargets.Add(MakeDbTarget("192.0.2.2", "Access B", MonitoringTargetType.AccessIsp, enabled: true));
+        _db.MonitoringTargets.Add(MakeDbTarget("198.51.100.1", "Transit A", MonitoringTargetType.Transit, enabled: true));
+        _db.MonitoringTargets.Add(MakeDbTarget("198.51.100.2", "Transit B", MonitoringTargetType.Transit, enabled: false));
+        _db.MonitoringTargets.Add(MakeDbTarget("203.0.113.1", "CDN A", MonitoringTargetType.InternetService, enabled: true));
+        await _db.SaveChangesAsync();
+
+        var hops = new List<AccessHopCandidate>
+        {
+            MakeAccessHop("192.0.2.1", "Access A New", enabled: true),
+            MakeAccessHop("192.0.2.2", "Access B New", enabled: false),
+        };
+        var transits = new List<TransitAsnCandidate>
+        {
+            MakeTransitCandidate("198.51.100.1", "Transit A New", 7029, DiscoveryMethod.DirectRouter, enabled: false),
+            MakeTransitCandidate("198.51.100.2", "Transit B New", 7029, DiscoveryMethod.DirectRouter, enabled: true),
+            MakeTransitCandidate("203.0.113.1", "CDN A New", 13335, DiscoveryMethod.PathProxy, enabled: false),
+        };
+        transits[2].PathProxyTarget = "203.0.113.1";
+
+        await CommitAsync(hops, transits);
+
+        (await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1")).Enabled.Should().BeTrue("Access A stays on");
+        (await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.2")).Enabled.Should().BeFalse("Access B turned off");
+        (await _db.MonitoringTargets.FirstAsync(t => t.Address == "198.51.100.1")).Enabled.Should().BeFalse("Transit A turned off");
+        (await _db.MonitoringTargets.FirstAsync(t => t.Address == "198.51.100.2")).Enabled.Should().BeTrue("Transit B turned on");
+        (await _db.MonitoringTargets.FirstAsync(t => t.Address == "203.0.113.1")).Enabled.Should().BeFalse("CDN A turned off");
+
+        (await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1")).Name.Should().Be("Access A New");
+        (await _db.MonitoringTargets.FirstAsync(t => t.Address == "198.51.100.1")).Name.Should().Be("Transit A New");
+        (await _db.MonitoringTargets.FirstAsync(t => t.Address == "203.0.113.1")).Name.Should().Be("CDN A New");
+    }
+
+    [Fact]
+    public async Task Second_discovery_preserves_user_disable_decision()
+    {
+        _db.MonitoringTargets.Add(MakeDbTarget("192.0.2.1", "Access A", MonitoringTargetType.AccessIsp, enabled: true));
+        _db.MonitoringTargets.Add(MakeDbTarget("198.51.100.1", "Transit A", MonitoringTargetType.Transit, enabled: true));
+        await _db.SaveChangesAsync();
+
+        // First save: user unchecks both
+        await CommitAsync(
+            new List<AccessHopCandidate> { MakeAccessHop("192.0.2.1", "Access A", enabled: false) },
+            new List<TransitAsnCandidate> { MakeTransitCandidate("198.51.100.1", "Transit A", 7029, DiscoveryMethod.DirectRouter, enabled: false) }
+        );
+
+        (await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1")).Enabled.Should().BeFalse();
+        (await _db.MonitoringTargets.FirstAsync(t => t.Address == "198.51.100.1")).Enabled.Should().BeFalse();
+
+        // Second save: user re-checks both
+        await CommitAsync(
+            new List<AccessHopCandidate> { MakeAccessHop("192.0.2.1", "Access A v2", enabled: true) },
+            new List<TransitAsnCandidate> { MakeTransitCandidate("198.51.100.1", "Transit A v2", 7029, DiscoveryMethod.DirectRouter, enabled: true) }
+        );
+
+        var access = await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1");
+        access.Enabled.Should().BeTrue();
+        access.Name.Should().Be("Access A v2");
+
+        var transit = await _db.MonitoringTargets.FirstAsync(t => t.Address == "198.51.100.1");
+        transit.Enabled.Should().BeTrue();
+        transit.Name.Should().Be("Transit A v2");
+    }
+
+    [Fact]
+    public async Task Third_save_after_toggle_cycle()
+    {
+        // Start: enabled
+        _db.MonitoringTargets.Add(MakeDbTarget("192.0.2.1", "Hop A", MonitoringTargetType.AccessIsp, enabled: true));
+        await _db.SaveChangesAsync();
+
+        // Save 1: disable
+        await CommitAsync(
+            new List<AccessHopCandidate> { MakeAccessHop("192.0.2.1", "Hop A", enabled: false) },
+            new List<TransitAsnCandidate>());
+        (await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1")).Enabled.Should().BeFalse();
+
+        // Save 2: re-enable with new name
+        await CommitAsync(
+            new List<AccessHopCandidate> { MakeAccessHop("192.0.2.1", "Hop A Renamed", enabled: true) },
+            new List<TransitAsnCandidate>());
+        var target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1");
+        target.Enabled.Should().BeTrue();
+        target.Name.Should().Be("Hop A Renamed");
+
+        // Save 3: disable again
+        await CommitAsync(
+            new List<AccessHopCandidate> { MakeAccessHop("192.0.2.1", "Hop A Final", enabled: false) },
+            new List<TransitAsnCandidate>());
+        target = await _db.MonitoringTargets.FirstAsync(t => t.Address == "192.0.2.1");
+        target.Enabled.Should().BeFalse();
+        target.Name.Should().Be("Hop A Final");
+    }
+
+    // ---- Helpers ----
+
+    private async Task CommitAsync(List<AccessHopCandidate> hops, List<TransitAsnCandidate> transits)
+    {
+        var wanInterface = "wan";
+
+        foreach (var hop in hops.Where(h => h.Enabled))
+        {
+            var existing = await _db.MonitoringTargets.FirstOrDefaultAsync(t => t.TargetId == hop.TargetId)
+                           ?? await _db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == hop.Address);
+            if (existing == null)
+            {
+                _db.MonitoringTargets.Add(new MonitoringTarget
+                {
+                    TargetId = hop.TargetId,
+                    Name = hop.Label,
+                    Address = hop.Address,
+                    ProbeMode = hop.RespondedTo,
+                    TargetType = MonitoringTargetType.AccessIsp,
+                    AsnNumber = hop.AsnNumber,
+                    AsnName = UpstreamTracerService.CleanAsnName(hop.AsnName),
+                    VantagePoint = "server",
+                    PollIntervalSeconds = 10,
+                    PingCount = 5,
+                    Enabled = true,
+                    AutoDiscovered = true,
+                    DiscoveryMethod = hop.Method,
+                    WanInterface = wanInterface,
+                    CreatedAt = DateTime.UtcNow,
+                    LastVerified = DateTime.UtcNow
+                });
+            }
+            else
+            {
+                existing.Enabled = true;
+                existing.Name = hop.Label;
+                if (hop.AsnNumber.HasValue) existing.AsnNumber = hop.AsnNumber;
+                if (!string.IsNullOrEmpty(hop.AsnName)) existing.AsnName = UpstreamTracerService.CleanAsnName(hop.AsnName);
+                existing.LastVerified = DateTime.UtcNow;
+            }
+        }
+        foreach (var hop in hops.Where(h => !h.Enabled))
+        {
+            var existing = await _db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == hop.Address);
+            if (existing != null)
+            {
+                existing.Enabled = false;
+                existing.Name = hop.Label;
+                if (!string.IsNullOrEmpty(hop.AsnName)) existing.AsnName = UpstreamTracerService.CleanAsnName(hop.AsnName);
+            }
+        }
+        foreach (var transit in transits.Where(t => t.Enabled))
+        {
+            var targetType = transit.Method == DiscoveryMethod.PathProxy
+                ? MonitoringTargetType.InternetService
+                : MonitoringTargetType.Transit;
+            var address = transit.HopAddress ?? transit.PathProxyTarget;
+            var existing = await _db.MonitoringTargets.FirstOrDefaultAsync(t => t.TargetId == transit.TargetId)
+                           ?? (address != null ? await _db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == address) : null);
+            if (existing == null && !string.IsNullOrEmpty(address))
+            {
+                _db.MonitoringTargets.Add(new MonitoringTarget
+                {
+                    TargetId = transit.TargetId ?? $"transit-{Guid.NewGuid():N}",
+                    Name = transit.Label ?? transit.AsnName,
+                    Address = address,
+                    ProbeMode = transit.RespondedTo ?? ProbeMode.Icmp,
+                    TargetType = targetType,
+                    AsnNumber = transit.AsnNumber,
+                    AsnName = transit.AsnName,
+                    VantagePoint = "server",
+                    PollIntervalSeconds = 15,
+                    PingCount = 5,
+                    Enabled = true,
+                    AutoDiscovered = true,
+                    DiscoveryMethod = transit.Method,
+                    WanInterface = wanInterface,
+                    CreatedAt = DateTime.UtcNow,
+                    LastVerified = DateTime.UtcNow
+                });
+            }
+            else if (existing != null)
+            {
+                existing.Enabled = true;
+                existing.Name = transit.Label ?? transit.AsnName;
+                existing.Address = address ?? existing.Address;
+                if (transit.AsnNumber > 0) existing.AsnNumber = transit.AsnNumber;
+                if (!string.IsNullOrEmpty(transit.AsnName)) existing.AsnName = transit.AsnName;
+                existing.LastVerified = DateTime.UtcNow;
+            }
+        }
+        foreach (var transit in transits.Where(t => !t.Enabled))
+        {
+            var addr = transit.HopAddress ?? transit.PathProxyTarget;
+            if (string.IsNullOrEmpty(addr)) continue;
+            var existing = await _db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == addr);
+            if (existing != null)
+            {
+                existing.Enabled = false;
+                existing.Name = transit.Label ?? transit.AsnName;
+                if (!string.IsNullOrEmpty(transit.AsnName)) existing.AsnName = transit.AsnName;
+            }
+        }
+
+        await _db.SaveChangesAsync();
+    }
+
+    private static AccessHopCandidate MakeAccessHop(string address, string label, bool enabled) => new()
+    {
+        TargetId = $"access-{address.Replace('.', '-')}",
+        Label = label,
+        Address = address,
+        AsnNumber = 18943,
+        AsnName = "TEST ISP",
+        Role = UpstreamRole.Aggregation,
+        HopNumber = 2,
+        RespondedTo = ProbeMode.Icmp,
+        Enabled = enabled
+    };
+
+    private static TransitAsnCandidate MakeTransitCandidate(string address, string label, int asn,
+        DiscoveryMethod method, bool enabled) => new()
+    {
+        AsnNumber = asn,
+        AsnName = $"AS{asn}",
+        Label = label,
+        Method = method,
+        TargetId = $"transit-as{asn}-{address.Replace('.', '-')}",
+        HopAddress = address,
+        RespondedTo = ProbeMode.Icmp,
+        Enabled = enabled
+    };
+
+    private static MonitoringTarget MakeDbTarget(string address, string name,
+        MonitoringTargetType type, bool enabled) => new()
+    {
+        TargetId = $"test-{address.Replace('.', '-')}",
+        Name = name,
+        Address = address,
+        ProbeMode = ProbeMode.Icmp,
+        TargetType = type,
+        VantagePoint = "server",
+        PollIntervalSeconds = 10,
+        PingCount = 5,
+        Enabled = enabled,
+        AutoDiscovered = true,
+        WanInterface = "wan",
+        CreatedAt = DateTime.UtcNow,
+        LastVerified = DateTime.UtcNow
+    };
+}


### PR DESCRIPTION
## Summary

- **AT&T transit probe** - Added 12.0.1.28 (AS7018) as an `IsTransitProbe` endpoint to surface AT&T as a transit ASN in upstream discovery traces
- **Topology-based border router detection** - Instead of a fixed hop cap, walks each individual trace to detect border routers: any access-ASN hop whose next responding hop is in a different ASN. Catches multiple border routers when the ISP has different peering exits for different transit providers
- **Filter-based access hop collection** - Replaced sequential walk (which broke at interleaved non-access hops in the merged pool) with a filter that collects all hops in the access ASN
- **Multi-hop transit candidates** - Up to 3 nearest responding hops per transit ASN proposed as candidates (nearest enabled by default, others unchecked)
- **Consistent target naming** - All targets follow `<Org> <PTR-derived-name>` format. PTR hostnames stripped of SLD+TLD since the org name is already the prefix. Numbered fallback when no useful PTR. ASN org names cleaned of corporate suffixes (Communications, Telephone, Enterprises, LLC, Fiber, Cable, etc.)
- **PTR resolution for candidates** - Explicit PTR lookup on proposed transit IPs that lack hostnames from traceroute (covers Windows managed traceroute path)
- **Split review UI** - Transit networks and path-end Internet hosts in separate sections
- **RTT in review tables** - Reachability verification RTT shown for access and transit candidates
- **Unreachable targets disabled** - Form inputs disabled (not just unchecked) for unreachable targets
- **DB state reconciliation** - Candidates matched against all existing DB targets: enabled targets pre-checked, disabled targets shown unchecked (respects user's previous decisions). User-edited names always absorbed from DB.
- **Enable/disable on save** - Checking a previously disabled target re-enables it; unchecking disables it. Names always updated regardless of enable state.
- **Preserve access technology** - User's access tech selection carries forward across re-discovery runs instead of resetting to Unknown
- **Blue outline on access tech selector** - Calls attention to the dropdown when access technology couldn't be auto-detected
- **Fix unsaved discovery warning** - Navigation guard now only fires when leaving the Network Performance tab or the Monitoring page entirely
- **Unit tests** - 117 tests covering CleanAsnName, FormatTransitHopLabel, and full commit-path integration for all enable/disable/rename scenarios

Also includes unrelated fixes from dev: fabric ingress/egress refactor, MongoDB SSD tweak data-loss fix, status-indicator min-width

## Test plan

- [x] Run upstream discovery, verify AT&T transit ASN surfaces
- [x] Border routers correctly detected across multiple peering exits
- [x] All access hops collected (not capped at 3)
- [x] Transit/path-end sections split with correct labels and RTT
- [x] Unreachable targets have disabled inputs
- [x] Uncheck a target, save, verify DB has `Enabled = 0`
- [x] Re-run discovery, verify unchecked target stays unchecked
- [x] Re-enable target, re-run, verify it comes back checked
- [x] User-edited names persist across re-discovery
- [x] Access tech preserved across re-runs
- [x] Dropdown stays open during review (no live-refresh flicker)
- [x] Tab navigation warning only fires from Network Performance tab
- [x] Save and verify upsert merges cleanly (stable DB IDs)
- [x] `dotnet test` passes (117 tests)