### PR TITLE
Fix: Prevent SQLite database corruption on FUSE/network filesystems

### DIFF
--- a/docker/DEPLOYMENT.md
+++ b/docker/DEPLOYMENT.md
@@ -211,6 +211,8 @@ For commercial NAS devices with container support.
 
 Community templates maintained by [@stefan-matic](https://github.com/stefan-matic/unraid-templates).
 
+> **Important: Database storage path.** Unraid's `/mnt/user/` paths use a FUSE filesystem (shfs) that is incompatible with SQLite's WAL journal mode. Network Optimizer detects this automatically and falls back to DELETE journal mode, which prevents database corruption but may cause occasional database busy errors under heavy monitoring load. For best performance, map the `/app/data` volume to a cache drive path (e.g., `/mnt/cache/appdata/network-optimizer/data`) instead of `/mnt/user/appdata/...`. This also applies to OMV setups using mergerfs and any deployment where the data volume is on NFS, SMB, or other network/FUSE mounts.
+
 ---
 Or use manual Docker Compose deployment (note: cannot be managed by Unraid GUI if deployed via compose)
 

--- a/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
+++ b/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
@@ -374,7 +374,7 @@ public class SnmpPoller : ISnmpPoller
                 }
                 else
                 {
-                    _logger.LogDebug("ShouldMonitor rejected ifIndex {Idx} desc={Desc} name={Name} on {Ip}", idx, descr, metrics.Name, ip);
+                    _logger.LogTrace("ShouldMonitor rejected ifIndex {Idx} desc={Desc} name={Name} on {Ip}", idx, descr, metrics.Name, ip);
                 }
             }
 

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -1726,7 +1726,9 @@ static partial class StartupHelpers
                 if (parts.Length < 3) continue;
 
                 var mountPoint = parts[1];
-                if (resolvedPath.StartsWith(mountPoint, StringComparison.Ordinal) && mountPoint.Length > bestMatch.Length)
+                if (mountPoint.Length > bestMatch.Length
+                    && resolvedPath.StartsWith(mountPoint, StringComparison.Ordinal)
+                    && (mountPoint == "/" || resolvedPath.Length == mountPoint.Length || resolvedPath[mountPoint.Length] == '/'))
                 {
                     bestMatch = mountPoint;
                     bestFsType = parts[2];

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -553,8 +553,22 @@ using (var scope = app.Services.CreateScope())
     db.Database.Migrate();
     app.Logger.LogInformation("Database migrations complete");
 
-    // Ensure WAL mode - config imports replace the DB with a DELETE-mode copy
-    db.Database.ExecuteSqlRaw("PRAGMA journal_mode=WAL;");
+    // FUSE/network filesystems (Unraid shfs, mergerfs, NFS, SMB) don't support the shared-memory
+    // mmap that WAL mode requires, causing silent database corruption. Use DELETE mode instead.
+    if (StartupHelpers.IsFuseFilesystem(dbPath))
+    {
+        db.Database.ExecuteSqlRaw("PRAGMA journal_mode=DELETE;");
+        app.Logger.LogWarning(
+            "FUSE/network filesystem detected - using DELETE journal mode to prevent database corruption. " +
+            "To use WAL mode (better performance), store the database on a direct filesystem " +
+            "(e.g., /mnt/cache instead of /mnt/user on Unraid)");
+    }
+    else
+    {
+        // Ensure WAL mode - config imports replace the DB with a DELETE-mode copy
+        db.Database.ExecuteSqlRaw("PRAGMA journal_mode=WAL;");
+        app.Logger.LogInformation("Database journal mode: WAL");
+    }
 
     // Seed default alert rules - insert any missing rules by EventTypePattern
     {
@@ -1690,5 +1704,48 @@ class DigestStateStoreAdapter(NetworkOptimizer.Storage.Interfaces.ISettingsRepos
     public async Task SetLastSentAsync(int channelId, DateTime sentAt, CancellationToken cancellationToken)
     {
         await settings.SaveSystemSettingAsync(Key(channelId), sentAt.ToString("O"), cancellationToken);
+    }
+}
+
+static partial class StartupHelpers
+{
+    internal static bool IsFuseFilesystem(string filePath)
+    {
+        if (!OperatingSystem.IsLinux())
+            return false;
+
+        try
+        {
+            var resolvedPath = Path.GetFullPath(filePath);
+            var bestMatch = string.Empty;
+            var bestFsType = string.Empty;
+
+            foreach (var line in File.ReadLines("/proc/mounts"))
+            {
+                var parts = line.Split(' ');
+                if (parts.Length < 3) continue;
+
+                var mountPoint = parts[1];
+                if (resolvedPath.StartsWith(mountPoint, StringComparison.Ordinal) && mountPoint.Length > bestMatch.Length)
+                {
+                    bestMatch = mountPoint;
+                    bestFsType = parts[2];
+                }
+            }
+
+            if (string.IsNullOrEmpty(bestFsType))
+                return false;
+
+            return bestFsType.StartsWith("fuse", StringComparison.OrdinalIgnoreCase)
+                || bestFsType.Equals("nfs", StringComparison.OrdinalIgnoreCase)
+                || bestFsType.Equals("nfs4", StringComparison.OrdinalIgnoreCase)
+                || bestFsType.Equals("cifs", StringComparison.OrdinalIgnoreCase)
+                || bestFsType.Equals("smb", StringComparison.OrdinalIgnoreCase)
+                || bestFsType.Equals("9p", StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Detect FUSE and network filesystems (Unraid shfs, mergerfs, NFS, SMB) at startup via `/proc/mounts` and automatically switch SQLite to DELETE journal mode, preventing silent database corruption from WAL's shared-memory mmap incompatibility
- Non-FUSE deployments continue using WAL mode as before
- Document the limitation and recommend direct filesystem paths (e.g., `/mnt/cache` on Unraid) for best performance

Fixes #706

## Test plan

- [x] Build: 0 warnings, 0 errors
- [x] All 6,084 tests pass
- [x] Deployed to NAS (ext4) - correctly selects WAL, logs `Database journal mode: WAL`
- [x] Deployed to Mac (APFS) - correctly selects WAL, logs `Database journal mode: WAL`
- [x] Both boxes started with DBs in DELETE mode - confirmed WAL was restored on startup
- [ ] Verify on actual FUSE filesystem (Unraid) that DELETE mode is selected