### PR TITLE
Upstream discovery: add INDATEL/GLC transit probe; tiered loss coloring

### DIFF
--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -77,7 +77,8 @@ public class UpstreamTracerService
         new("Microsoft", "13.107.42.14"),                            // AS8068  - M365 SharePoint anycast
         new("Fastly", "151.101.1.69"),                               // AS54113 - reaches local PoP via anycast
         new("Akamai", "23.0.0.1"),                                   // AS20940 - global netarch anycast loopback
-        new("AT&T", "12.0.1.28", IsTransitProbe: true)                // AS7018  - probe to surface AT&T as transit
+        new("AT&T", "12.0.1.28", IsTransitProbe: true),               // AS7018  - probe to surface AT&T as transit
+        new("INDATEL", "216.176.4.153", IsTransitProbe: true)            // AS30517 - INDATEL on GLC (Everstream) infra
     };
 
     private record TraceEndpoint(string Label, string Address, bool IsTransitProbe = false);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -78,10 +78,10 @@ public class UpstreamTracerService
         new("Fastly", "151.101.1.69"),                               // AS54113 - reaches local PoP via anycast
         new("Akamai", "23.0.0.1"),                                   // AS20940 - global netarch anycast loopback
         new("AT&T", "12.0.1.28", IsTransitProbe: true),               // AS7018  - probe to surface AT&T as transit
-        new("INDATEL", "216.176.4.153", IsTransitProbe: true)            // AS30517 - INDATEL on GLC (Everstream) infra
+        new("INDATEL", "216.176.4.153", IsTransitProbe: true, EndpointIsTransitHop: true) // AS30517 - INDATEL on GLC (Everstream) infra
     };
 
-    private record TraceEndpoint(string Label, string Address, bool IsTransitProbe = false);
+    private record TraceEndpoint(string Label, string Address, bool IsTransitProbe = false, bool EndpointIsTransitHop = false);
 
     public UpstreamTracerService(
         UniFiConnectionService connectionService,
@@ -777,9 +777,10 @@ public class UpstreamTracerService
         // Also exclude the transit-probe endpoints themselves from the hop pool.
         // Their job is to force the path through a specific ASN so real transit
         // routers surface - the endpoint IP itself is far away and not useful
-        // as a monitoring target.
+        // as a monitoring target. Exception: EndpointIsTransitHop means the
+        // endpoint itself is the transit router (small networks with one hop).
         var transitProbeAddresses = new HashSet<string>(
-            CdnRotation.Where(e => e.IsTransitProbe).Select(e => e.Address),
+            CdnRotation.Where(e => e.IsTransitProbe && !e.EndpointIsTransitHop).Select(e => e.Address),
             StringComparer.OrdinalIgnoreCase);
 
         var transitGroups = _mergedHops

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -299,17 +299,18 @@ function computeStats(values) {
 }
 
 function fmtRtt(v) { return v != null ? v.toFixed(3) : '-'; }
-function fmtLossColored(v, redAt, orangeAt, yellowAt, lightAt, decimals) {
+function fmtLossColored(v, redAt, orangeAt, yellowAt, lightAt, subtleAt, decimals) {
     if (v == null) return '-';
     const s = v.toFixed(decimals) + '%';
     if (v >= redAt) return `<span style="color:var(--danger-color)">${s}</span>`;
     if (v >= orangeAt) return `<span style="color:var(--accent-color)">${s}</span>`;
     if (v >= yellowAt) return `<span style="color:var(--warning-color)">${s}</span>`;
-    if (v > lightAt) return `<span style="color:rgba(231,150,19,0.45)">${s}</span>`;
+    if (v >= lightAt) return `<span style="color:#d4c06a">${s}</span>`;
+    if (v > subtleAt) return `<span style="color:#c8c4a8">${s}</span>`;
     return s;
 }
-function fmtLossMean(v) { return fmtLossColored(v, 1, 0.2, 0.05, 0.005, 3); }
-function fmtLossMax(v) { return fmtLossColored(v, 5, 2, 0.5, 0.005, 2); }
+function fmtLossMean(v) { return fmtLossColored(v, 1, 0.2, 0.05, 0.005, 0.0005, 3); }
+function fmtLossMax(v) { return fmtLossColored(v, 5, 2, 0.5, 0.005, 0.005, 2); }
 
 function renderStatsTable(container, data) {
     const el = container.querySelector('.latency-stats-table');

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -299,13 +299,17 @@ function computeStats(values) {
 }
 
 function fmtRtt(v) { return v != null ? v.toFixed(3) : '-'; }
-function fmtLoss(v) {
+function fmtLossColored(v, redAt, orangeAt, yellowAt, lightAt) {
     if (v == null) return '-';
     const s = v.toFixed(2) + '%';
-    if (v > 0.2) return `<span style="color:var(--danger-color)">${s}</span>`;
-    if (v > 0) return `<span style="color:var(--warning-color)">${s}</span>`;
+    if (v >= redAt) return `<span style="color:var(--danger-color)">${s}</span>`;
+    if (v >= orangeAt) return `<span style="color:var(--accent-color)">${s}</span>`;
+    if (v >= yellowAt) return `<span style="color:var(--warning-color)">${s}</span>`;
+    if (v > lightAt) return `<span style="color:rgba(231,150,19,0.45)">${s}</span>`;
     return s;
 }
+function fmtLossMean(v) { return fmtLossColored(v, 1, 0.2, 0.05, 0); }
+function fmtLossMax(v) { return fmtLossColored(v, 5, 2, 0.5, 0); }
 
 function renderStatsTable(container, data) {
     const el = container.querySelector('.latency-stats-table');
@@ -328,7 +332,7 @@ function renderStatsTable(container, data) {
         return `<tr>
             <td><span class="wan-badge-dot" style="background-color:${color};display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:6px"></span>${escapeHtml(t.name)}</td>
             <td>${fmtRtt(rtt?.mean)}</td><td>${fmtRtt(rtt?.min)}</td><td>${fmtRtt(rtt?.max)}</td><td>${fmtRtt(rtt?.p95)}</td><td>${fmtRtt(rtt?.p99)}</td>
-            <td>${fmtLoss(loss?.mean)}</td><td>${fmtLoss(loss?.max)}</td>
+            <td>${fmtLossMean(loss?.mean)}</td><td>${fmtLossMax(loss?.max)}</td>
         </tr>`;
     });
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -302,7 +302,9 @@ function fmtRtt(v) { return v != null ? v.toFixed(3) : '-'; }
 function fmtLoss(v) {
     if (v == null) return '-';
     const s = v.toFixed(2) + '%';
-    return v > 0 ? `<span style="color:var(--danger-color)">${s}</span>` : s;
+    if (v > 0.2) return `<span style="color:var(--danger-color)">${s}</span>`;
+    if (v > 0) return `<span style="color:var(--warning-color)">${s}</span>`;
+    return s;
 }
 
 function renderStatsTable(container, data) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -308,8 +308,8 @@ function fmtLossColored(v, redAt, orangeAt, yellowAt, lightAt) {
     if (v > lightAt) return `<span style="color:rgba(231,150,19,0.45)">${s}</span>`;
     return s;
 }
-function fmtLossMean(v) { return fmtLossColored(v, 1, 0.2, 0.05, 0); }
-function fmtLossMax(v) { return fmtLossColored(v, 5, 2, 0.5, 0); }
+function fmtLossMean(v) { return fmtLossColored(v, 1, 0.2, 0.05, 0.005); }
+function fmtLossMax(v) { return fmtLossColored(v, 5, 2, 0.5, 0.005); }
 
 function renderStatsTable(container, data) {
     const el = container.querySelector('.latency-stats-table');

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -299,17 +299,17 @@ function computeStats(values) {
 }
 
 function fmtRtt(v) { return v != null ? v.toFixed(3) : '-'; }
-function fmtLossColored(v, redAt, orangeAt, yellowAt, lightAt) {
+function fmtLossColored(v, redAt, orangeAt, yellowAt, lightAt, decimals) {
     if (v == null) return '-';
-    const s = v.toFixed(2) + '%';
+    const s = v.toFixed(decimals) + '%';
     if (v >= redAt) return `<span style="color:var(--danger-color)">${s}</span>`;
     if (v >= orangeAt) return `<span style="color:var(--accent-color)">${s}</span>`;
     if (v >= yellowAt) return `<span style="color:var(--warning-color)">${s}</span>`;
     if (v > lightAt) return `<span style="color:rgba(231,150,19,0.45)">${s}</span>`;
     return s;
 }
-function fmtLossMean(v) { return fmtLossColored(v, 1, 0.2, 0.05, 0.005); }
-function fmtLossMax(v) { return fmtLossColored(v, 5, 2, 0.5, 0.005); }
+function fmtLossMean(v) { return fmtLossColored(v, 1, 0.2, 0.05, 0.005, 3); }
+function fmtLossMax(v) { return fmtLossColored(v, 5, 2, 0.5, 0.005, 2); }
 
 function renderStatsTable(container, data) {
     const el = container.querySelector('.latency-stats-table');


### PR DESCRIPTION
## Summary

- Adds INDATEL (AS30517, GLC/Everstream infra) as a new transit probe target at 216.176.4.153
- Adds `EndpointIsTransitHop` flag for small transit networks where the probe endpoint itself is the only hop in the ASN, so it isn't filtered out of the transit candidate pool
- Tiered color scale for packet loss stats with separate thresholds for mean vs max:
  - Mean (3 decimal places): subtle warm > 0%, pale gold > 0.005%, yellow > 0.05%, orange > 0.2%, red > 1%
  - Max (2 decimal places): pale gold > 0.005%, yellow > 0.5%, orange > 2%, red > 5%

## Test plan

- [x] Builds with zero warnings
- [x] Deployed to NAS and Mac
- [x] Run upstream discovery on NAS and verify INDATEL surfaces as a transit candidate
- [x] Verify loss color tiers render correctly on dark background