### PR TITLE
Upstream discovery: INDATEL transit probe, ASN proximity gate, monitoring UI fixes

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
@@ -7,7 +7,7 @@
     <div class="card-header card-header-collapsible" @onclick="ToggleCollapse">
         <h2 class="card-title">Latency targets</h2>
         <div style="display: flex; align-items: center; gap: 0.5rem;">
-            <span class="status-badge status-active" @onclick:stopPropagation="true">@Targets.Count active</span>
+            <span class="status-badge status-active" @onclick:stopPropagation="true">@Targets.Count(t => t.Enabled) active</span>
             <a href="/monitoring/tools" class="tooltip-icon settings-link" data-tooltip="Run an ad-hoc probe" @onclick:stopPropagation="true">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="16" height="16">
                     <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM5.5 8.5a.5.5 0 010-1h2.793L7.146 6.354a.5.5 0 11.708-.708l2 2a.5.5 0 010 .708l-2 2a.5.5 0 11-.708-.708L8.293 8.5H5.5zm6.354-1.146a.5.5 0 010 .708L10.707 9.207H13.5a.5.5 0 010 1h-2.793l1.147 1.147a.5.5 0 11-.708.708l-2-2a.5.5 0 010-.708l2-2a.5.5 0 01.708 0z" clip-rule="evenodd" />

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -778,17 +778,42 @@ public class UpstreamTracerService
         // Their job is to force the path through a specific ASN so real transit
         // routers surface - the endpoint IP itself is far away and not useful
         // as a monitoring target. Exception: EndpointIsTransitHop means the
-        // endpoint itself is the transit router (small networks with one hop).
+        // endpoint itself is the transit router (small networks with one hop),
+        // but only if its ASN is near the access network (within 2 ASN
+        // transitions: access → transit, or access → upstream → transit).
         var transitProbeAddresses = new HashSet<string>(
             CdnRotation.Where(e => e.IsTransitProbe && !e.EndpointIsTransitHop).Select(e => e.Address),
             StringComparer.OrdinalIgnoreCase);
+
+        // For EndpointIsTransitHop probes, build the set of ASNs that are
+        // within 2 ASN transitions of the access network. If the endpoint's
+        // ASN isn't in this set, it's not really our ISP's transit.
+        var endpointTransitHopAddresses = new HashSet<string>(
+            CdnRotation.Where(e => e.EndpointIsTransitHop).Select(e => e.Address),
+            StringComparer.OrdinalIgnoreCase);
+        var nearTransitAsns = new HashSet<int>();
+        if (endpointTransitHopAddresses.Count > 0)
+        {
+            var seen = new HashSet<int>();
+            foreach (var h in _mergedHops)
+            {
+                if (h.Asn == null || accessAsnNumbers.Contains(h.Asn.Asn)) continue;
+                if (seen.Add(h.Asn.Asn))
+                {
+                    nearTransitAsns.Add(h.Asn.Asn);
+                    if (seen.Count >= 2) break;
+                }
+            }
+        }
 
         var transitGroups = _mergedHops
             .Where(h => h.Asn != null
                         && !accessAsnNumbers.Contains(h.Asn.Asn)
                         && !destinationAsns.Contains(h.Asn.Asn)
                         && !(h.Asn.Name != null && destinationOrgs.Contains(h.Asn.Name.Trim()))
-                        && !transitProbeAddresses.Contains(h.Address))
+                        && !transitProbeAddresses.Contains(h.Address)
+                        && (!endpointTransitHopAddresses.Contains(h.Address)
+                            || nearTransitAsns.Contains(h.Asn.Asn)))
             .GroupBy(h => h.Asn!.Asn)
             .ToList();
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -77,10 +77,11 @@ public class UpstreamTracerService
         new("Microsoft", "13.107.42.14"),                            // AS8068  - M365 SharePoint anycast
         new("Fastly", "151.101.1.69"),                               // AS54113 - reaches local PoP via anycast
         new("Akamai", "23.0.0.1"),                                   // AS20940 - global netarch anycast loopback
-        new("AT&T", "12.0.1.28", IsTransitProbe: true)                // AS7018  - probe to surface AT&T as transit
+        new("AT&T", "12.0.1.28", IsTransitProbe: true),               // AS7018  - probe to surface AT&T as transit
+        new("INDATEL", "216.176.4.153", IsTransitProbe: true, EndpointIsTransitHop: true) // AS30517 - INDATEL on GLC (Everstream) infra
     };
 
-    private record TraceEndpoint(string Label, string Address, bool IsTransitProbe = false);
+    private record TraceEndpoint(string Label, string Address, bool IsTransitProbe = false, bool EndpointIsTransitHop = false);
 
     public UpstreamTracerService(
         UniFiConnectionService connectionService,
@@ -776,9 +777,10 @@ public class UpstreamTracerService
         // Also exclude the transit-probe endpoints themselves from the hop pool.
         // Their job is to force the path through a specific ASN so real transit
         // routers surface - the endpoint IP itself is far away and not useful
-        // as a monitoring target.
+        // as a monitoring target. Exception: EndpointIsTransitHop means the
+        // endpoint itself is the transit router (small networks with one hop).
         var transitProbeAddresses = new HashSet<string>(
-            CdnRotation.Where(e => e.IsTransitProbe).Select(e => e.Address),
+            CdnRotation.Where(e => e.IsTransitProbe && !e.EndpointIsTransitHop).Select(e => e.Address),
             StringComparer.OrdinalIgnoreCase);
 
         var transitGroups = _mergedHops

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -97,7 +97,7 @@ function buildLossOpts() {
         v => v != null ? v.toFixed(1) + '%' : '',
         {
             yaxis: {
-                min: 0, max: m => Math.max(5, Math.ceil(m.max)),
+                min: 0, max: v => Math.max(v * 1.1, 5),
                 title: { text: '% loss', style: { color: '#9ca3af' } },
                 labels: {
                     style: { colors: '#9ca3af' },

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -97,7 +97,7 @@ function buildLossOpts() {
         v => v != null ? v.toFixed(1) + '%' : '',
         {
             yaxis: {
-                min: 0, max: 100,
+                min: 0, max: m => Math.max(5, Math.ceil(m.max)),
                 title: { text: '% loss', style: { color: '#9ca3af' } },
                 labels: {
                     style: { colors: '#9ca3af' },

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -299,11 +299,18 @@ function computeStats(values) {
 }
 
 function fmtRtt(v) { return v != null ? v.toFixed(3) : '-'; }
-function fmtLoss(v) {
+function fmtLossColored(v, redAt, orangeAt, yellowAt, lightAt, subtleAt, decimals) {
     if (v == null) return '-';
-    const s = v.toFixed(2) + '%';
-    return v > 0 ? `<span style="color:var(--danger-color)">${s}</span>` : s;
+    const s = v.toFixed(decimals) + '%';
+    if (v >= redAt) return `<span style="color:var(--danger-color)">${s}</span>`;
+    if (v >= orangeAt) return `<span style="color:var(--accent-color)">${s}</span>`;
+    if (v >= yellowAt) return `<span style="color:var(--warning-color)">${s}</span>`;
+    if (v >= lightAt) return `<span style="color:#d4c06a">${s}</span>`;
+    if (v > subtleAt) return `<span style="color:#c8c4a8">${s}</span>`;
+    return s;
 }
+function fmtLossMean(v) { return fmtLossColored(v, 1, 0.2, 0.05, 0.005, 0.0005, 3); }
+function fmtLossMax(v) { return fmtLossColored(v, 5, 2, 0.5, 0.005, 0.005, 2); }
 
 function renderStatsTable(container, data) {
     const el = container.querySelector('.latency-stats-table');
@@ -326,7 +333,7 @@ function renderStatsTable(container, data) {
         return `<tr>
             <td><span class="wan-badge-dot" style="background-color:${color};display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:6px"></span>${escapeHtml(t.name)}</td>
             <td>${fmtRtt(rtt?.mean)}</td><td>${fmtRtt(rtt?.min)}</td><td>${fmtRtt(rtt?.max)}</td><td>${fmtRtt(rtt?.p95)}</td><td>${fmtRtt(rtt?.p99)}</td>
-            <td>${fmtLoss(loss?.mean)}</td><td>${fmtLoss(loss?.max)}</td>
+            <td>${fmtLossMean(loss?.mean)}</td><td>${fmtLossMax(loss?.max)}</td>
         </tr>`;
     });
 


### PR DESCRIPTION
## Summary

- **INDATEL transit probe** - Adds INDATEL (AS30517, GLC/Everstream infra) as a new transit probe target for upstream discovery
- **EndpointIsTransitHop** - New probe flag for small transit networks where the probe endpoint itself is the only hop in the ASN. Gated by ASN proximity: the endpoint only surfaces as a transit candidate if its ASN is within 2 ASN transitions of the access network
- **Tiered loss coloring** - Packet loss stats table now uses a 5-tier color scale (subtle, light, yellow, orange, red) with separate thresholds for mean vs max. Loss mean shown at 3 decimal places for more precision
- **Badge fix** - Latency targets "N active" badge now correctly excludes paused targets from the count
- **Loss chart scale** - Y-axis defaults to 5% instead of 100%, expands dynamically for larger values