### PR TITLE
ONT Stats dashboard card links to SFP chart

### DIFF
--- a/src/NetworkOptimizer.Core/Helpers/NetworkFormatHelpers.cs
+++ b/src/NetworkOptimizer.Core/Helpers/NetworkFormatHelpers.cs
@@ -121,4 +121,40 @@ public static class NetworkFormatHelpers
 
         return "PON";
     }
+
+    private static readonly string[] OrgSuffixes =
+    {
+        "Communications", "Telephone", "Telecom", "Telecommunications",
+        "Broadband", "Internet", "Fiber", "Cable", "Wireless",
+        "Enterprises", "Services", "Technologies", "Networks", "Network",
+        "Electric Cooperative", "Cooperative", "Co-op",
+        "Corporation", "Incorporated", "Company", "Holdings", "Group", "Parent",
+        "LLC", "Inc", "Corp", "Ltd", "Limited", "Co", "L.P.", "LP",
+        "GmbH", "AG", "KG", "e.K.", "S.A.", "S.A.S.", "S.r.l.",
+        "B.V.", "B.V", "N.V.", "N.V", "Pty", "A/S", "AB", "Oy", "AS"
+    };
+
+    /// <summary>
+    /// Strip corporate/industry suffixes from an organization name
+    /// ("Hisense Broadband Technologies Co Ltd" -> "Hisense").
+    /// </summary>
+    public static string CleanOrgName(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return string.Empty;
+        var cleaned = name.Trim().TrimEnd(',', '.');
+        bool changed;
+        do
+        {
+            changed = false;
+            foreach (var suffix in OrgSuffixes)
+            {
+                if (cleaned.EndsWith(" " + suffix, StringComparison.OrdinalIgnoreCase))
+                {
+                    cleaned = cleaned[..^(suffix.Length + 1)].TrimEnd(',', '.');
+                    changed = true;
+                }
+            }
+        } while (changed && cleaned.Contains(' '));
+        return cleaned.Trim();
+    }
 }

--- a/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
@@ -184,6 +184,7 @@
     private bool _wanTestLoading = true;
     private bool _threatLoading = true;
     private bool _editMode;
+    private OntStatsPanel? _ontPanel;
     private DashboardLayout? _layout;
     private int deviceCount = 0;
     private int securityScore = 0;
@@ -528,12 +529,12 @@
         // The panel renders its own empty-state when no monitored ONT exists, so the
         // card stays on the dashboard but tells the user how to enable it. Mirrors the
         // CellularStats card's "configure" affordance.
-        <div class="card clickable-card" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=sfp"))">
+        <div class="card clickable-card" @onclick="NavigateToOntChart">
             <div class="card-header">
                 <h2 class="card-title">ONT Stats (GPON / XGS-PON)</h2>
             </div>
             <div class="card-body">
-                <OntStatsPanel />
+                <OntStatsPanel @ref="_ontPanel" />
             </div>
         </div>
     };
@@ -1115,5 +1116,14 @@
             },
             Yaxis = new List<YAxis> { new YAxis { Min = 0 } }
         };
+    }
+
+    private void NavigateToOntChart()
+    {
+        var key = _ontPanel?.CurrentModuleKey;
+        var url = key != null
+            ? $"/monitoring?tab=sfp&sfp={Uri.EscapeDataString(key)}"
+            : "/monitoring?tab=sfp";
+        NavigationManager.NavigateTo(url);
     }
 }

--- a/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
@@ -528,7 +528,7 @@
         // The panel renders its own empty-state when no monitored ONT exists, so the
         // card stays on the dashboard but tells the user how to enable it. Mirrors the
         // CellularStats card's "configure" affordance.
-        <div class="card">
+        <div class="card clickable-card" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=sfp"))">
             <div class="card-header">
                 <h2 class="card-title">ONT Stats (GPON / XGS-PON)</h2>
             </div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -730,6 +730,9 @@ else
     [SupplyParameterFromQuery(Name = "discover")]
     public string? DiscoverParam { get; set; }
 
+    [SupplyParameterFromQuery(Name = "sfp")]
+    public string? SfpParam { get; set; }
+
     private string? _lastTabParam;
 
     private bool _upstreamDiscoveryPendingSave =>
@@ -813,6 +816,8 @@ else
     }
 
     private bool _scrollToDiscoveryPending;
+    private bool _scrollToSfpChartsPending;
+    private string? _soloSfpModuleId;
 
     protected override void OnParametersSet()
     {
@@ -832,6 +837,12 @@ else
         {
             _forceExpandUpstream = true;
             _scrollToDiscoveryPending = true;
+        }
+
+        if (!string.IsNullOrEmpty(SfpParam) && _activeTab == "sfp")
+        {
+            _soloSfpModuleId = SfpParam;
+            _scrollToSfpChartsPending = true;
         }
     }
 
@@ -1129,6 +1140,18 @@ else
                     el.style.outlineOffset = '4px';
                     el.style.borderRadius = '12px';
                     setTimeout(function() { el.style.outline = ''; el.style.outlineOffset = ''; }, 2000);
+                }
+            })();");
+    }
+
+    private async Task ScrollToSfpChartsAsync()
+    {
+        await Task.Delay(300);
+        await JS.InvokeVoidAsync("eval", @"
+            (function() {
+                var el = document.getElementById('sfp-charts-container');
+                if (el) {
+                    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
                 }
             })();");
     }
@@ -1717,8 +1740,11 @@ else
             try
             {
                 var sfpUrl = VersionedJs("/js/sfp-charts.js");
+                var soloJs = !string.IsNullOrEmpty(_soloSfpModuleId)
+                    ? $"m.soloModule('{_soloSfpModuleId.Replace("'", "\\'")}');"
+                    : "";
                 await JS.InvokeVoidAsync("eval",
-                    $"(async () => {{ const m = await import('{sfpUrl}'); window.__sfpCharts = m; await m.mount('sfp-charts-container'); }})();");
+                    $"(async () => {{ const m = await import('{sfpUrl}'); window.__sfpCharts = m; await m.mount('sfp-charts-container'); {soloJs} }})();");
             }
             catch { _sfpChartsMounted = false; }
         }
@@ -1727,6 +1753,13 @@ else
             _sfpChartsMounted = false;
             try { await JS.InvokeVoidAsync("eval", "window.__sfpCharts?.unmount();"); }
             catch { }
+        }
+
+        if (_scrollToSfpChartsPending && _activeTab == "sfp" && _sfpChartsMounted)
+        {
+            _scrollToSfpChartsPending = false;
+            _soloSfpModuleId = null;
+            await ScrollToSfpChartsAsync();
         }
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1741,7 +1741,7 @@ else
             {
                 var sfpUrl = VersionedJs("/js/sfp-charts.js");
                 var soloJs = !string.IsNullOrEmpty(_soloSfpModuleId)
-                    ? $"m.soloModule('{_soloSfpModuleId.Replace("'", "\\'")}');"
+                    ? $"m.soloModule('{System.Text.Encodings.Web.JavaScriptEncoder.Default.Encode(_soloSfpModuleId)}');"
                     : "";
                 await JS.InvokeVoidAsync("eval",
                     $"(async () => {{ const m = await import('{sfpUrl}'); window.__sfpCharts = m; await m.mount('sfp-charts-container'); {soloJs} }})();");

--- a/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
@@ -264,5 +264,9 @@ else
         ? $"{mbps / 1000.0:0.##} Gbps"
         : $"{mbps} Mbps";
 
+    public string? CurrentModuleKey => _monitoredOnts.Count > 0
+        ? $"{_monitoredOnts[_currentIndex].DeviceMac.Replace("-", ":").ToLowerInvariant()}:{_monitoredOnts[_currentIndex].PortName}"
+        : null;
+
     public void Dispose() => _refreshTimer?.Dispose();
 }

--- a/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
@@ -25,7 +25,7 @@ else if (_monitoredOnts.Count == 0)
             and gateway ports. Promote one to a monitored ONT to see live optical levels here.
         </p>
         <div class="sqm-actions">
-            <a href="/monitoring" class="btn btn-primary">Open Monitoring</a>
+            <a href="/monitoring" class="btn btn-primary" @onclick:stopPropagation>Open Monitoring</a>
         </div>
     </div>
 }
@@ -61,9 +61,9 @@ else
         <div class="modem-nav">
             @if (_monitoredOnts.Count > 1)
             {
-                <button class="nav-btn" @onclick="Previous" disabled="@(_currentIndex == 0)">‹</button>
+                <button class="nav-btn" @onclick="Previous" @onclick:stopPropagation disabled="@(_currentIndex == 0)">‹</button>
                 <span class="modem-counter">@(_currentIndex + 1)/@_monitoredOnts.Count</span>
-                <button class="nav-btn" @onclick="Next" disabled="@(_currentIndex >= _monitoredOnts.Count - 1)">›</button>
+                <button class="nav-btn" @onclick="Next" @onclick:stopPropagation disabled="@(_currentIndex >= _monitoredOnts.Count - 1)">›</button>
             }
         </div>
     </div>
@@ -245,7 +245,7 @@ else
 
     private static string SfpModelLabel(string? vendor, string? part)
     {
-        var v = vendor?.Trim();
+        var v = NetworkOptimizer.Core.Helpers.NetworkFormatHelpers.CleanOrgName(vendor);
         var p = part?.Trim();
         if (string.IsNullOrEmpty(v) && string.IsNullOrEmpty(p)) return "";
         if (string.IsNullOrEmpty(v)) return p!;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1301,45 +1301,8 @@ public class UpstreamTracerService
         await Task.WhenAll(tasks);
     }
 
-    private static readonly string[] OrgSuffixes =
-    {
-        // Telco/ISP industry terms
-        "Communications", "Telephone", "Telecom", "Telecommunications",
-        "Broadband", "Internet", "Fiber", "Cable", "Wireless",
-        "Enterprises", "Services", "Technologies", "Networks", "Network",
-        "Electric Cooperative", "Cooperative", "Co-op",
-        // Corporate entity suffixes
-        "Corporation", "Incorporated", "Company", "Holdings", "Group", "Parent",
-        "LLC", "Inc", "Corp", "Ltd", "Limited", "Co", "L.P.", "LP",
-        // International
-        "GmbH", "AG", "KG", "e.K.", "S.A.", "S.A.S.", "S.r.l.",
-        "B.V.", "B.V", "N.V.", "N.V", "Pty", "A/S", "AB", "Oy", "AS"
-    };
-
-    /// <summary>
-    /// Strip corporate suffixes from ASN org names.
-    /// "Windstream Communications" → "Windstream", "AT&amp;T Enterprises" → "AT&amp;T"
-    /// </summary>
-    internal static string CleanAsnName(string? name)
-    {
-        if (string.IsNullOrWhiteSpace(name)) return string.Empty;
-        var cleaned = name.Trim().TrimEnd(',', '.');
-        // Iterate to strip chains like "Telephone Company" or "Cable Communications LLC"
-        bool changed;
-        do
-        {
-            changed = false;
-            foreach (var suffix in OrgSuffixes)
-            {
-                if (cleaned.EndsWith(" " + suffix, StringComparison.OrdinalIgnoreCase))
-                {
-                    cleaned = cleaned[..^(suffix.Length + 1)].TrimEnd(',', '.');
-                    changed = true;
-                }
-            }
-        } while (changed && cleaned.Contains(' '));
-        return cleaned.Trim();
-    }
+    internal static string CleanAsnName(string? name) =>
+        NetworkOptimizer.Core.Helpers.NetworkFormatHelpers.CleanOrgName(name);
 
     /// <summary>
     /// Generate a display label from a PTR hostname for transit targets.

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -379,6 +379,16 @@ export function navigateToTime(isoTimestamp) {
     startPoll();
 }
 
+export function soloModule(id) {
+    if (!moduleMeta.length) return;
+    const match = moduleMeta.find(m => m.id === id);
+    if (!match) return;
+    moduleMeta.forEach(m => { visibility[m.id] = m.id === id; });
+    updateVisibility();
+    const container = document.getElementById(containerId);
+    if (container) renderBadges(container);
+}
+
 export function unmount() {
     stopPoll();
     if (visibilityObserver) { visibilityObserver.disconnect(); visibilityObserver = null; }


### PR DESCRIPTION
## Summary

- Clicking the ONT Stats card on the dashboard navigates to the Monitoring page's SFP Stats tab, scrolls to the SFP Diagnostics chart, and pre-filters to the specific PON module that was displayed (respects multi-module paging)
- Cleans SFP vendor names the same way upstream discovery cleans ASN org names - strips corporate suffixes like "Inc", "Ltd", "Technologies" etc. ("Hisense Broadband Technologies Co Ltd" becomes "Hisense")
- Extracts the org-name cleaning logic from UpstreamTracerService into a shared `CleanOrgName` helper in NetworkFormatHelpers

## Changes

- **OntStatsPanel**: Exposes `CurrentModuleKey` for the parent card click; paging buttons use `@onclick:stopPropagation` to prevent navigation; `SfpModelLabel` cleans vendor via `CleanOrgName`
- **Dashboard**: Card uses `clickable-card` pattern with `@ref` to read the panel's current module
- **Monitoring**: New `sfp` query param triggers `soloModule()` on the JS chart after mount, then scrolls to the chart container; uses `JavaScriptEncoder` for the query param value
- **sfp-charts.js**: New `soloModule(id)` export that filters visibility to a single module and updates badges
- **NetworkFormatHelpers**: New `CleanOrgName` shared helper (extracted from UpstreamTracerService)
- **UpstreamTracerService**: `CleanAsnName` now delegates to the shared helper

## Test plan

- [x] Click ONT Stats card on dashboard - lands on Monitoring SFP tab, scrolled to chart, filtered to that module
- [x] Page to a different ONT module on dashboard, click again - correct module is filtered
- [x] Paging buttons (< >) work without triggering navigation
- [x] With no ONTs configured, clicking the card navigates to SFP tab (no crash)
- [x] SFP vendor name shows cleaned (no "Inc", "Ltd", etc.)
- [x] Upstream discovery labels still clean correctly (regression check)