### PR TITLE
Live WAN chart, clickable stat cards, map swap, Add to Dashboard

### DIFF
--- a/src/NetworkOptimizer.Storage/Models/SystemSetting.cs
+++ b/src/NetworkOptimizer.Storage/Models/SystemSetting.cs
@@ -54,4 +54,6 @@ public static class SystemSettingKeys
     // Dashboard layout preferences
     public const string DashboardLayout = "ui.dashboard_layout";
 
+    // Monitoring Live View map order ("3d-first" or "2d-first")
+    public const string MonitoringLiveMapOrder = "ui.monitoring_live_map_order";
 }

--- a/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
@@ -703,7 +703,12 @@
     {
         var card = _layout?.Cards.FirstOrDefault(c => c.Id == cardId);
         if (card == null) return;
-        card.MapMode = card.MapMode == "3d" ? "2d" : "3d";
+        card.MapMode = (card.MapMode ?? "2d") switch
+        {
+            "2d" => "3d",
+            "3d" => "off",
+            _ => "2d",
+        };
     }
 
     // ──────────────────────────────────────────────────────────
@@ -733,8 +738,9 @@
                 </button>
                 @if (card.Id == DashboardCards.LiveView)
                 {
-                    <button class="card-edit-btn" @onclick="() => ToggleMapMode(card.Id)" data-tooltip="@((card.MapMode ?? "2d") == "2d" ? "Switch to 3D" : "Switch to 2D")">
-                        <span style="font-size: 10px; font-weight: 600; line-height: 14px;">@((card.MapMode ?? "2d") == "2d" ? "2D" : "3D")</span>
+                    <button class="card-edit-btn" @onclick="() => ToggleMapMode(card.Id)"
+                            data-tooltip="@((card.MapMode ?? "2d") switch { "2d" => "Switch to 3D", "3d" => "Turn map off", _ => "Switch to 2D" })">
+                        <span style="font-size: 10px; font-weight: 600; line-height: 14px;">@((card.MapMode ?? "2d") switch { "3d" => "3D", "off" => "Off", _ => "2D" })</span>
                     </button>
                 }
                 <button class="card-edit-btn card-edit-btn-toggle" @onclick="() => ToggleCard(card.Id)" data-tooltip="@(card.Visible ? "Hide" : "Show")">

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -832,7 +832,7 @@ else
                 StateHasChanged();
             }
         }
-        _lastTabParam = TabParam;
+        _lastTabParam = TabParam ?? _activeTab;
 
         if (DiscoverParam == "1" && _activeTab == "performance")
         {
@@ -1781,6 +1781,7 @@ else
                 _mapDotNetRef ??= DotNetObjectReference.Create(this);
                 await JS.InvokeVoidAsync("eval",
                     "window.__mountLanFlowMap = async function(canvasId, ref) {" +
+                    "  await new Promise(r => requestAnimationFrame(r));" +
                     "  window.__monitoringRef = ref;" +
                     $"  const m = await import('{VersionedJs("/js/lan-flow-map.js")}');" +
                     "  window.__lanFlowMap = m;" +

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -109,6 +109,10 @@ else
         }
 
         <!-- Top stat cards: WAN rates, gateway RTT/loss, ISP/Transit mean RTT/loss -->
+        var gwFabricTargetId = GetGatewayFabricTargetId();
+        var gwFabricUrl = gwFabricTargetId != null
+            ? $"/monitoring?tab=performance&category=Fabric&target={Uri.EscapeDataString(gwFabricTargetId)}"
+            : "/monitoring?tab=performance&category=Fabric";
         <div class="monitoring-stat-cards">
             @{ var wanRates = GetWanRates(); }
             <div class="monitoring-stat-card monitoring-stat-rate">
@@ -120,16 +124,16 @@ else
                 <div class="stat-label">WAN Upload</div>
             </div>
             @{ var gwLatency = GetGatewayLatency(); }
-            <div class="monitoring-stat-card">
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwFabricUrl))">
                 <div class="stat-value">@FormatRtt(gwLatency.rtt)</div>
                 <div class="stat-label">Gateway RTT</div>
             </div>
-            <div class="monitoring-stat-card">
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwFabricUrl))">
                 <div class="stat-value @(gwLatency.loss > 0 ? "stat-danger" : "")">@FormatLoss(gwLatency.loss)</div>
                 <div class="stat-label">Gateway Loss</div>
             </div>
             @{ var ispTarget = GetBestTargetStats(MonitoringTargetType.AccessIsp); }
-            <div class="monitoring-stat-card">
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&category=AccessIsp"))">
                 @if (hasIspTargets)
                 {
                     <div class="stat-value">@FormatRtt(ispTarget.rtt)</div>
@@ -140,7 +144,7 @@ else
                 }
                 <div class="stat-label">ISP RTT</div>
             </div>
-            <div class="monitoring-stat-card">
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&category=AccessIsp"))">
                 @if (hasIspTargets)
                 {
                     <div class="stat-value @(ispTarget.loss > 0 ? "stat-danger" : "")">@FormatLoss(ispTarget.loss)</div>
@@ -152,7 +156,7 @@ else
                 <div class="stat-label">ISP Loss</div>
             </div>
             @{ var transitTarget = GetMeanTargetStats(MonitoringTargetType.Transit); }
-            <div class="monitoring-stat-card">
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&category=Transit"))">
                 @if (hasTransitTargets)
                 {
                     <div class="stat-value">@FormatRtt(transitTarget.rtt)</div>
@@ -163,7 +167,7 @@ else
                 }
                 <div class="stat-label">Transit RTT</div>
             </div>
-            <div class="monitoring-stat-card">
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&category=Transit"))">
                 @if (hasTransitTargets)
                 {
                     <div class="stat-value @(transitTarget.loss > 0 ? "stat-danger" : "")">@FormatLoss(transitTarget.loss)</div>
@@ -197,16 +201,21 @@ else
 
         <!-- Bottom stat cards: Gateway health + fabric load -->
         <div class="monitoring-stat-cards" style="margin-top: 1.5rem;">
-            @{ var gwStats = GetGatewayStats(); }
-            <div class="monitoring-stat-card">
+            @{
+                var gwStats = GetGatewayStats();
+                var gwDeviceUrl = _gatewayMac != null
+                    ? $"/monitoring?tab=devices&device={Uri.EscapeDataString(_gatewayMac)}"
+                    : "/monitoring?tab=devices";
+            }
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
                 <div class="stat-value">@FormatPercent(gwStats?.CpuPercent)</div>
                 <div class="stat-label">Gateway CPU</div>
             </div>
-            <div class="monitoring-stat-card">
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
                 <div class="stat-value">@FormatPercent(gwStats?.MemoryUsedPercent)</div>
                 <div class="stat-label">Gateway Memory</div>
             </div>
-            <div class="monitoring-stat-card">
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
                 <div class="stat-value">@FormatTemp(gwStats?.TemperatureC)</div>
                 <div class="stat-label">Gateway Temp</div>
             </div>
@@ -740,6 +749,15 @@ else
     [SupplyParameterFromQuery(Name = "sfp")]
     public string? SfpParam { get; set; }
 
+    [SupplyParameterFromQuery(Name = "device")]
+    public string? DeviceParam { get; set; }
+
+    [SupplyParameterFromQuery(Name = "category")]
+    public string? CategoryParam { get; set; }
+
+    [SupplyParameterFromQuery(Name = "target")]
+    public string? TargetParam { get; set; }
+
     private string? _lastTabParam;
 
     private bool _upstreamDiscoveryPendingSave =>
@@ -826,6 +844,11 @@ else
     private bool _scrollToDiscoveryPending;
     private bool _scrollToSfpChartsPending;
     private string? _soloSfpModuleId;
+    private string? _soloDeviceMac;
+    private string? _preSelectCategory;
+    private string? _soloTargetId;
+    private bool _scrollToDeviceChartsPending;
+    private bool _scrollToLatencyChartsPending;
 
     protected override void OnParametersSet()
     {
@@ -851,6 +874,19 @@ else
         {
             _soloSfpModuleId = SfpParam;
             _scrollToSfpChartsPending = true;
+        }
+
+        if (!string.IsNullOrEmpty(DeviceParam) && _activeTab == "devices")
+        {
+            _soloDeviceMac = DeviceParam;
+            _scrollToDeviceChartsPending = true;
+        }
+
+        if (!string.IsNullOrEmpty(CategoryParam) && _activeTab == "performance")
+        {
+            _preSelectCategory = CategoryParam;
+            _soloTargetId = TargetParam;
+            _scrollToLatencyChartsPending = true;
         }
     }
 
@@ -1411,18 +1447,23 @@ else
         return LiveStats.GetForDevice(_gatewayMac);
     }
 
+    private string? GetGatewayFabricTargetId()
+    {
+        if (_gatewayMac == null) return null;
+        return _targets.FirstOrDefault(t =>
+            t.TargetType == MonitoringTargetType.Fabric
+            && t.Enabled
+            && !string.IsNullOrEmpty(t.DeviceMac)
+            && t.DeviceMac.Replace("-", ":").Equals(_gatewayMac, StringComparison.OrdinalIgnoreCase))?.TargetId;
+    }
+
     private (double? rtt, double loss) GetGatewayLatency()
     {
         if (_historicSnapshot != null)
             return (_historicSnapshot.GatewayRttMs, _historicSnapshot.GatewayLossPercent);
-        if (_gatewayMac == null) return (null, 0);
-        var gwFabric = _targets.FirstOrDefault(t =>
-            t.TargetType == MonitoringTargetType.Fabric
-            && t.Enabled
-            && !string.IsNullOrEmpty(t.DeviceMac)
-            && t.DeviceMac.Replace("-", ":").Equals(_gatewayMac, StringComparison.OrdinalIgnoreCase));
-        if (gwFabric == null) return (null, 0);
-        var s = LiveStats.GetTargetStats(gwFabric.TargetId);
+        var targetId = GetGatewayFabricTargetId();
+        if (targetId == null) return (null, 0);
+        var s = LiveStats.GetTargetStats(targetId);
         return (s?.RttAvgMs, s?.LossPercent ?? 0);
     }
 
@@ -1706,7 +1747,7 @@ else
                     "window.__mountWanLiveChart = async function(elId) {" +
                     $"  const m = await import('{VersionedJs("/js/wan-live-chart.js")}');" +
                     "  window.__wanLiveChart = m;" +
-                    "  await m.mount(elId);" +
+                    "  await m.mount(elId, {pollMs: 1000});" +
                     "}");
                 _ = JS.InvokeVoidAsync("__mountWanLiveChart", "monitoring-wan-live-chart");
             }
@@ -1791,6 +1832,37 @@ else
             _scrollToSfpChartsPending = false;
             _soloSfpModuleId = null;
             await ScrollToSfpChartsAsync();
+        }
+
+        if (_scrollToDeviceChartsPending && _activeTab == "devices" && _healthChartsMounted)
+        {
+            _scrollToDeviceChartsPending = false;
+            if (!string.IsNullOrEmpty(_soloDeviceMac))
+            {
+                var mac = _soloDeviceMac;
+                _soloDeviceMac = null;
+                try { await JS.InvokeVoidAsync("eval", $"window.__healthCharts?.soloDevice('{mac}');"); }
+                catch { }
+            }
+        }
+
+        if (_scrollToLatencyChartsPending && _activeTab == "performance" && _latencyChartsMounted)
+        {
+            _scrollToLatencyChartsPending = false;
+            if (!string.IsNullOrEmpty(_preSelectCategory))
+            {
+                var cat = _preSelectCategory;
+                var target = _soloTargetId;
+                _preSelectCategory = null;
+                _soloTargetId = null;
+                try
+                {
+                    await JS.InvokeVoidAsync("eval", $"window.__latencyCharts?.setCategory('{cat}');");
+                    if (!string.IsNullOrEmpty(target))
+                        await JS.InvokeVoidAsync("eval", $"window.__latencyCharts?.soloTarget('{target}');");
+                }
+                catch { }
+            }
         }
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1499,28 +1499,10 @@ else
 
     private async Task SwapMapOrderAsync()
     {
-        if (_mapMounted)
-        {
-            _mapMounted = false;
-            try { await JS.InvokeVoidAsync("eval", "window.__lanFlowMap?.unmount();"); }
-            catch { }
-        }
-        if (_map2dMounted)
-        {
-            _map2dMounted = false;
-            try { await JS.InvokeVoidAsync("eval", "window.__lanFlowMap2d?.unmount();"); }
-            catch { }
-        }
-        if (_wanLiveChartMounted)
-        {
-            _wanLiveChartMounted = false;
-            try { await JS.InvokeVoidAsync("eval", "window.__wanLiveChart?.unmount();"); }
-            catch { }
-        }
-
         _mapOrder2dFirst = !_mapOrder2dFirst;
         await SystemSettings.SetAsync(SystemSettingKeys.MonitoringLiveMapOrder,
             _mapOrder2dFirst ? "2d-first" : null);
+        NavigationManager.NavigateTo("/monitoring?tab=live", forceLoad: true);
     }
 
     private async Task AddLiveViewToDashboardAsync()
@@ -1781,13 +1763,12 @@ else
                 _mapDotNetRef ??= DotNetObjectReference.Create(this);
                 await JS.InvokeVoidAsync("eval",
                     "window.__mountLanFlowMap = async function(canvasId, ref) {" +
-                    "  await new Promise(r => requestAnimationFrame(r));" +
                     "  window.__monitoringRef = ref;" +
                     $"  const m = await import('{VersionedJs("/js/lan-flow-map.js")}');" +
                     "  window.__lanFlowMap = m;" +
                     "  await m.mount(canvasId);" +
                     "}");
-                _ = JS.InvokeVoidAsync("__mountLanFlowMap", "lan-flow-map-canvas", _mapDotNetRef);
+                await JS.InvokeVoidAsync("__mountLanFlowMap", "lan-flow-map-canvas", _mapDotNetRef);
             }
             catch { _mapMounted = false; }
         }

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1741,7 +1741,7 @@ else
                     "window.__mountWanLiveChart = async function(elId) {" +
                     $"  const m = await import('{VersionedJs("/js/wan-live-chart.js")}');" +
                     "  window.__wanLiveChart = m;" +
-                    "  await m.mount(elId, {pollMs: 1000});" +
+                    "  await m.mount(elId);" +
                     "}");
                 _ = JS.InvokeVoidAsync("__mountWanLiveChart", "monitoring-wan-live-chart");
             }

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1703,8 +1703,12 @@ else
             try
             {
                 await JS.InvokeVoidAsync("eval",
-                    $"(async () => {{ const m = await import('{VersionedJs("/js/wan-live-chart.js")}'); " +
-                    "window.__wanLiveChart = m; await m.mount('monitoring-wan-live-chart'); }})();");
+                    "window.__mountWanLiveChart = async function(elId) {" +
+                    $"  const m = await import('{VersionedJs("/js/wan-live-chart.js")}');" +
+                    "  window.__wanLiveChart = m;" +
+                    "  await m.mount(elId);" +
+                    "}");
+                _ = JS.InvokeVoidAsync("__mountWanLiveChart", "monitoring-wan-live-chart");
             }
             catch { _wanLiveChartMounted = false; }
         }

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1499,6 +1499,25 @@ else
 
     private async Task SwapMapOrderAsync()
     {
+        if (_mapMounted)
+        {
+            _mapMounted = false;
+            try { await JS.InvokeVoidAsync("eval", "window.__lanFlowMap?.unmount();"); }
+            catch { }
+        }
+        if (_map2dMounted)
+        {
+            _map2dMounted = false;
+            try { await JS.InvokeVoidAsync("eval", "window.__lanFlowMap2d?.unmount();"); }
+            catch { }
+        }
+        if (_wanLiveChartMounted)
+        {
+            _wanLiveChartMounted = false;
+            try { await JS.InvokeVoidAsync("eval", "window.__wanLiveChart?.unmount();"); }
+            catch { }
+        }
+
         _mapOrder2dFirst = !_mapOrder2dFirst;
         await SystemSettings.SetAsync(SystemSettingKeys.MonitoringLiveMapOrder,
             _mapOrder2dFirst ? "2d-first" : null);

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -21,6 +21,8 @@
 @inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
 @inject NavigationManager NavigationManager
 @inject NetworkOptimizer.Web.Services.Monitoring.UpstreamTracerService UpstreamTracer
+@inject ISystemSettingsService SystemSettings
+@inject DashboardLayoutService DashboardLayout
 
 <NavigationLock OnBeforeInternalNavigation="OnBeforeInternalNavigation"
                 ConfirmExternalNavigation="_upstreamDiscoveryPendingSave" />
@@ -90,6 +92,16 @@ else
     @* ──────────────── Tab: Live View ──────────────── *@
     @if (_activeTab == "live" && _monitoringReady)
     {
+        if (!_liveViewOnDashboard)
+        {
+            <div style="display: flex; justify-content: flex-end; margin-bottom: 0.5rem;">
+                <button class="btn btn-sm btn-outline-primary" @onclick="AddLiveViewToDashboardAsync"
+                        data-tooltip="Add Live View panel to the top of the Dashboard">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="vertical-align: -2px; margin-right: 4px;"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="12" y1="8" x2="12" y2="16"/><line x1="8" y1="12" x2="16" y2="12"/></svg>Add to Dashboard
+                </button>
+            </div>
+        }
+
         var hasIspTargets = HasUpstreamTargets(MonitoringTargetType.AccessIsp);
         var hasTransitTargets = HasUpstreamTargets(MonitoringTargetType.Transit);
 
@@ -187,60 +199,18 @@ else
             </div>
         </div>
 
-        <!-- 3D LAN flow map -->
-        <div class="card lan-flow-map-card" style="margin-top: 0.5rem;">
-            <div class="card-header">
-                <h2 class="card-title">3D LAN Flow Map</h2>
-            </div>
-            <div class="card-body lan-flow-map-body">
-                <div class="lan-flow-map-stage" id="lan-flow-map-stage">
-                    <canvas id="lan-flow-map-canvas" class="lan-flow-map-canvas"></canvas>
-                </div>
-            </div>
-        </div>
-
-        <!-- Bottom stat cards: Gateway health + fabric load -->
-        <div class="monitoring-stat-cards" style="margin-top: 1.5rem;">
-            @{
-                var gwStats = GetGatewayStats();
-                var gwDeviceUrl = _gatewayMac != null
-                    ? $"/monitoring?tab=devices&device={Uri.EscapeDataString(_gatewayMac)}"
-                    : "/monitoring?tab=devices";
-            }
-            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
-                <div class="stat-value">@FormatPercent(gwStats?.CpuPercent)</div>
-                <div class="stat-label">Gateway CPU</div>
-            </div>
-            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
-                <div class="stat-value">@FormatPercent(gwStats?.MemoryUsedPercent)</div>
-                <div class="stat-label">Gateway Memory</div>
-            </div>
-            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
-                <div class="stat-value">@FormatTemp(gwStats?.TemperatureC)</div>
-                <div class="stat-label">Gateway Temp</div>
-            </div>
-            @{ var fabricLoad = GetTotalFabricLoad(); }
-            <div class="monitoring-stat-pair">
-                <div class="monitoring-stat-card">
-                    <div class="stat-value" style="color: #3b82f6;">@FormatRate(fabricLoad.ingress)</div>
-                    <div class="stat-label">Fabric Ingress</div>
-                </div>
-                <div class="monitoring-stat-card">
-                    <div class="stat-value" style="color: #10b981;">@FormatRate(fabricLoad.egress)</div>
-                    <div class="stat-label">Fabric Egress</div>
-                </div>
-            </div>
-        </div>
-
-        <!-- 2D LAN hierarchy map -->
-        <div class="card lan-flow-map-2d-card" style="margin-top: 1.5rem;">
-            <div class="card-header">
-                <h2 class="card-title">LAN Topology Flow Map</h2>
-            </div>
-            <div class="card-body lan-flow-map-2d-body">
-                <div id="lan-flow-map-2d-stage" class="lan-flow-map-2d-stage"></div>
-            </div>
-        </div>
+        @if (_mapOrder2dFirst)
+        {
+            @Map2dCard
+            @GatewayStatCards
+            @Map3dCard
+        }
+        else
+        {
+            @Map3dCard
+            @GatewayStatCards
+            @Map2dCard
+        }
     }
 
     @* ──────────────── Tab: Network Performance ──────────────── *@
@@ -847,6 +817,8 @@ else
     private string? _soloDeviceMac;
     private string? _preSelectCategory;
     private string? _soloTargetId;
+    private bool _mapOrder2dFirst;
+    private bool _liveViewOnDashboard;
 
     protected override void OnParametersSet()
     {
@@ -893,7 +865,12 @@ else
         LoadInfluxStateFromSettings(settings);
         await LoadTargetsAsync();
 
+        _mapOrder2dFirst = await SystemSettings.GetAsync(SystemSettingKeys.MonitoringLiveMapOrder) == "2d-first";
+        var dashLayout = await DashboardLayout.GetLayoutAsync();
+        _liveViewOnDashboard = dashLayout.Cards.Any(c => c.Id == DashboardCards.LiveView && c.Visible);
+
         _activeTab = ResolveDefaultTab();
+        _lastTabParam = TabParam ?? _activeTab;
 
         _liveRefreshTimer = new System.Threading.Timer(_ =>
         {
@@ -1449,6 +1426,96 @@ else
             && t.Enabled
             && !string.IsNullOrEmpty(t.DeviceMac)
             && t.DeviceMac.Replace("-", ":").Equals(_gatewayMac, StringComparison.OrdinalIgnoreCase))?.TargetId;
+    }
+
+    private RenderFragment Map3dCard => __builder =>
+    {
+        <div class="card lan-flow-map-card" style="margin-top: 0.5rem;">
+            <div class="card-header">
+                <h2 class="card-title">3D LAN Flow Map</h2>
+                <div class="card-header-right">
+                    <button class="card-edit-btn" @onclick="SwapMapOrderAsync" data-tooltip="Swap map order">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="7 3 7 21"/><polyline points="3 7 7 3 11 7"/><polyline points="17 21 17 3"/><polyline points="13 17 17 21 21 17"/></svg>
+                    </button>
+                </div>
+            </div>
+            <div class="card-body lan-flow-map-body">
+                <div class="lan-flow-map-stage" id="lan-flow-map-stage">
+                    <canvas id="lan-flow-map-canvas" class="lan-flow-map-canvas"></canvas>
+                </div>
+            </div>
+        </div>
+    };
+
+    private RenderFragment Map2dCard => __builder =>
+    {
+        <div class="card lan-flow-map-2d-card" style="margin-top: 1.5rem;">
+            <div class="card-header">
+                <h2 class="card-title">LAN Topology Flow Map</h2>
+                <div class="card-header-right">
+                    <button class="card-edit-btn" @onclick="SwapMapOrderAsync" data-tooltip="Swap map order">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="7 3 7 21"/><polyline points="3 7 7 3 11 7"/><polyline points="17 21 17 3"/><polyline points="13 17 17 21 21 17"/></svg>
+                    </button>
+                </div>
+            </div>
+            <div class="card-body lan-flow-map-2d-body">
+                <div id="lan-flow-map-2d-stage" class="lan-flow-map-2d-stage"></div>
+            </div>
+        </div>
+    };
+
+    private RenderFragment GatewayStatCards => __builder =>
+    {
+        var gwStats = GetGatewayStats();
+        var gwDeviceUrl = _gatewayMac != null
+            ? $"/monitoring?tab=devices&device={Uri.EscapeDataString(_gatewayMac)}"
+            : "/monitoring?tab=devices";
+        <div class="monitoring-stat-cards" style="margin-top: 1.5rem;">
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
+                <div class="stat-value">@FormatPercent(gwStats?.CpuPercent)</div>
+                <div class="stat-label">Gateway CPU</div>
+            </div>
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
+                <div class="stat-value">@FormatPercent(gwStats?.MemoryUsedPercent)</div>
+                <div class="stat-label">Gateway Memory</div>
+            </div>
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
+                <div class="stat-value">@FormatTemp(gwStats?.TemperatureC)</div>
+                <div class="stat-label">Gateway Temp</div>
+            </div>
+            @{ var fabricLoad = GetTotalFabricLoad(); }
+            <div class="monitoring-stat-pair">
+                <div class="monitoring-stat-card">
+                    <div class="stat-value" style="color: #3b82f6;">@FormatRate(fabricLoad.ingress)</div>
+                    <div class="stat-label">Fabric Ingress</div>
+                </div>
+                <div class="monitoring-stat-card">
+                    <div class="stat-value" style="color: #10b981;">@FormatRate(fabricLoad.egress)</div>
+                    <div class="stat-label">Fabric Egress</div>
+                </div>
+            </div>
+        </div>
+    };
+
+    private async Task SwapMapOrderAsync()
+    {
+        _mapOrder2dFirst = !_mapOrder2dFirst;
+        await SystemSettings.SetAsync(SystemSettingKeys.MonitoringLiveMapOrder,
+            _mapOrder2dFirst ? "2d-first" : null);
+    }
+
+    private async Task AddLiveViewToDashboardAsync()
+    {
+        var layout = await DashboardLayout.GetLayoutAsync();
+        var card = layout.Cards.FirstOrDefault(c => c.Id == DashboardCards.LiveView);
+        if (card != null)
+        {
+            card.Visible = true;
+            layout.Cards.Remove(card);
+            layout.Cards.Insert(0, card);
+        }
+        await DashboardLayout.SaveLayoutAsync(layout);
+        _liveViewOnDashboard = true;
     }
 
     private (double? rtt, double loss) GetGatewayLatency()

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -176,6 +176,13 @@ else
             </div>
         </div>
 
+        <!-- WAN live chart -->
+        <div class="card wan-live-chart-card" style="margin-top: 1rem;">
+            <div class="card-body wan-live-chart-body">
+                <div id="monitoring-wan-live-chart"></div>
+            </div>
+        </div>
+
         <!-- 3D LAN flow map -->
         <div class="card lan-flow-map-card" style="margin-top: 1.5rem;">
             <div class="card-header">
@@ -773,6 +780,7 @@ else
     // Chart mount tracking
     private bool _mapMounted = false;
     private bool _map2dMounted = false;
+    private bool _wanLiveChartMounted = false;
     private bool _latencyChartsMounted;
     private bool _healthChartsMounted;
     private bool _sfpChartsMounted;
@@ -1688,6 +1696,25 @@ else
             catch { }
         }
 
+        // WAN live chart - Live tab only
+        if (_activeTab == "live" && _monitoringReady && !_wanLiveChartMounted)
+        {
+            _wanLiveChartMounted = true;
+            try
+            {
+                await JS.InvokeVoidAsync("eval",
+                    $"(async () => {{ const m = await import('{VersionedJs("/js/wan-live-chart.js")}'); " +
+                    "window.__wanLiveChart = m; await m.mount('monitoring-wan-live-chart'); }})();");
+            }
+            catch { _wanLiveChartMounted = false; }
+        }
+        else if (_activeTab != "live" && _wanLiveChartMounted)
+        {
+            _wanLiveChartMounted = false;
+            try { await JS.InvokeVoidAsync("eval", "window.__wanLiveChart?.unmount();"); }
+            catch { }
+        }
+
         // Latency charts - Performance tab only
         if (_activeTab == "performance" && _monitoringReady && !_latencyChartsMounted)
         {
@@ -1784,6 +1811,11 @@ else
         if (_sfpChartsMounted)
         {
             try { _ = JS.InvokeVoidAsync("eval", "window.__sfpCharts?.unmount();").AsTask(); }
+            catch { }
+        }
+        if (_wanLiveChartMounted)
+        {
+            try { _ = JS.InvokeVoidAsync("eval", "window.__wanLiveChart?.unmount();").AsTask(); }
             catch { }
         }
         if (_mapMounted)

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -203,13 +203,13 @@ else
         {
             @Map2dCard
             @GatewayStatCards
-            @Map3dCard
+            <div style="margin-top: 1rem;">@Map3dCard</div>
         }
         else
         {
             @Map3dCard
             @GatewayStatCards
-            @Map2dCard
+            <div style="margin-top: 1rem;">@Map2dCard</div>
         }
     }
 
@@ -1449,7 +1449,7 @@ else
 
     private RenderFragment Map2dCard => __builder =>
     {
-        <div class="card lan-flow-map-2d-card" style="margin-top: 1.5rem;">
+        <div class="card lan-flow-map-2d-card" style="margin-top: 0.5rem;">
             <div class="card-header">
                 <h2 class="card-title">LAN Topology Flow Map</h2>
                 <div class="card-header-right">
@@ -1470,7 +1470,7 @@ else
         var gwDeviceUrl = _gatewayMac != null
             ? $"/monitoring?tab=devices&device={Uri.EscapeDataString(_gatewayMac)}"
             : "/monitoring?tab=devices";
-        <div class="monitoring-stat-cards" style="margin-top: 1.5rem;">
+        <div class="monitoring-stat-cards" style="margin-top: 0.5rem;">
             <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
                 <div class="stat-value">@FormatPercent(gwStats?.CpuPercent)</div>
                 <div class="stat-label">Gateway CPU</div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1509,7 +1509,17 @@ else
     {
         var layout = await DashboardLayout.GetLayoutAsync();
         var card = layout.Cards.FirstOrDefault(c => c.Id == DashboardCards.LiveView);
-        if (card != null)
+        if (card == null)
+        {
+            card = new DashboardCardConfig
+            {
+                Id = DashboardCards.LiveView,
+                Visible = true,
+                FullWidth = true,
+            };
+            layout.Cards.Insert(0, card);
+        }
+        else
         {
             card.Visible = true;
             layout.Cards.Remove(card);

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -847,8 +847,6 @@ else
     private string? _soloDeviceMac;
     private string? _preSelectCategory;
     private string? _soloTargetId;
-    private bool _scrollToDeviceChartsPending;
-    private bool _scrollToLatencyChartsPending;
 
     protected override void OnParametersSet()
     {
@@ -877,16 +875,12 @@ else
         }
 
         if (!string.IsNullOrEmpty(DeviceParam) && _activeTab == "devices")
-        {
             _soloDeviceMac = DeviceParam;
-            _scrollToDeviceChartsPending = true;
-        }
 
         if (!string.IsNullOrEmpty(CategoryParam) && _activeTab == "performance")
         {
             _preSelectCategory = CategoryParam;
             _soloTargetId = TargetParam;
-            _scrollToLatencyChartsPending = true;
         }
     }
 
@@ -1767,8 +1761,17 @@ else
             try
             {
                 var chartsUrl = VersionedJs("/js/latency-charts.js");
+                var postMount = "";
+                if (!string.IsNullOrEmpty(_preSelectCategory))
+                {
+                    postMount = $"m.setCategory('{System.Text.Encodings.Web.JavaScriptEncoder.Default.Encode(_preSelectCategory)}');";
+                    if (!string.IsNullOrEmpty(_soloTargetId))
+                        postMount += $"m.soloTarget('{System.Text.Encodings.Web.JavaScriptEncoder.Default.Encode(_soloTargetId)}');";
+                    _preSelectCategory = null;
+                    _soloTargetId = null;
+                }
                 await JS.InvokeVoidAsync("eval",
-                    $"(async () => {{ const m = await import('{chartsUrl}'); window.__latencyCharts = m; await m.mount('latency-charts-container'); }})();");
+                    $"(async () => {{ const m = await import('{chartsUrl}'); window.__latencyCharts = m; await m.mount('latency-charts-container'); {postMount} }})();");
             }
             catch { _latencyChartsMounted = false; }
         }
@@ -1793,8 +1796,14 @@ else
             try
             {
                 var healthUrl = VersionedJs("/js/device-health-charts.js");
+                var postMount = "";
+                if (!string.IsNullOrEmpty(_soloDeviceMac))
+                {
+                    postMount = $"m.soloDevice('{System.Text.Encodings.Web.JavaScriptEncoder.Default.Encode(_soloDeviceMac)}');";
+                    _soloDeviceMac = null;
+                }
                 await JS.InvokeVoidAsync("eval",
-                    $"(async () => {{ const m = await import('{healthUrl}'); window.__healthCharts = m; await m.mount('device-health-charts-container'); }})();");
+                    $"(async () => {{ const m = await import('{healthUrl}'); window.__healthCharts = m; await m.mount('device-health-charts-container'); {postMount} }})();");
             }
             catch { _healthChartsMounted = false; }
         }
@@ -1834,36 +1843,6 @@ else
             await ScrollToSfpChartsAsync();
         }
 
-        if (_scrollToDeviceChartsPending && _activeTab == "devices" && _healthChartsMounted)
-        {
-            _scrollToDeviceChartsPending = false;
-            if (!string.IsNullOrEmpty(_soloDeviceMac))
-            {
-                var mac = _soloDeviceMac;
-                _soloDeviceMac = null;
-                try { await JS.InvokeVoidAsync("eval", $"window.__healthCharts?.soloDevice('{mac}');"); }
-                catch { }
-            }
-        }
-
-        if (_scrollToLatencyChartsPending && _activeTab == "performance" && _latencyChartsMounted)
-        {
-            _scrollToLatencyChartsPending = false;
-            if (!string.IsNullOrEmpty(_preSelectCategory))
-            {
-                var cat = _preSelectCategory;
-                var target = _soloTargetId;
-                _preSelectCategory = null;
-                _soloTargetId = null;
-                try
-                {
-                    await JS.InvokeVoidAsync("eval", $"window.__latencyCharts?.setCategory('{cat}');");
-                    if (!string.IsNullOrEmpty(target))
-                        await JS.InvokeVoidAsync("eval", $"window.__latencyCharts?.soloTarget('{target}');");
-                }
-                catch { }
-            }
-        }
     }
 
     public void Dispose()

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -177,14 +177,14 @@ else
         </div>
 
         <!-- WAN live chart -->
-        <div class="card wan-live-chart-card" style="margin-top: 1rem;">
+        <div class="card wan-live-chart-card" style="margin-top: 0.5rem;">
             <div class="card-body wan-live-chart-body">
                 <div id="monitoring-wan-live-chart"></div>
             </div>
         </div>
 
         <!-- 3D LAN flow map -->
-        <div class="card lan-flow-map-card" style="margin-top: 1.5rem;">
+        <div class="card lan-flow-map-card" style="margin-top: 0.5rem;">
             <div class="card-header">
                 <h2 class="card-title">3D LAN Flow Map</h2>
             </div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1502,7 +1502,7 @@ else
         _mapOrder2dFirst = !_mapOrder2dFirst;
         await SystemSettings.SetAsync(SystemSettingKeys.MonitoringLiveMapOrder,
             _mapOrder2dFirst ? "2d-first" : null);
-        NavigationManager.NavigateTo("/monitoring?tab=live", forceLoad: true);
+        await JS.InvokeVoidAsync("eval", "window.location.replace('/monitoring?tab=live');");
     }
 
     private async Task AddLiveViewToDashboardAsync()

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1787,7 +1787,7 @@ else
                     "  window.__lanFlowMap = m;" +
                     "  await m.mount(canvasId);" +
                     "}");
-                await JS.InvokeVoidAsync("__mountLanFlowMap", "lan-flow-map-canvas", _mapDotNetRef);
+                _ = JS.InvokeVoidAsync("__mountLanFlowMap", "lan-flow-map-canvas", _mapDotNetRef);
             }
             catch { _mapMounted = false; }
         }

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -129,13 +129,6 @@ else
     .lv-panel .monitoring-stat-card {
         background: var(--bg-tertiary);
     }
-    .wan-live-chart-card {
-        overflow: hidden;
-        margin-bottom: 0;
-    }
-    .wan-live-chart-body {
-        padding: 0.5rem 0.25rem 0;
-    }
     .lv-map-card {
         overflow: hidden;
         margin-bottom: 0;

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -7,6 +7,7 @@
 @inject IDbContextFactory<NetworkOptimizerDbContext> DbFactory
 @inject UniFiConnectionService ConnectionService
 @inject IJSRuntime JS
+@inject NavigationManager NavigationManager
 @inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
 
 @if (!_ready)
@@ -26,6 +27,13 @@
 }
 else
 {
+    var gwFabricTargetId = GetGatewayFabricTargetId();
+    var gwFabricUrl = gwFabricTargetId != null
+        ? $"/monitoring?tab=performance&category=Fabric&target={Uri.EscapeDataString(gwFabricTargetId)}"
+        : "/monitoring?tab=performance&category=Fabric";
+    var gwDeviceUrl = _gatewayMac != null
+        ? $"/monitoring?tab=devices&device={Uri.EscapeDataString(_gatewayMac)}"
+        : "/monitoring?tab=devices";
     <div class="lv-panel">
         <div class="monitoring-stat-cards">
             @{ var wanRates = GetWanRates(); }
@@ -38,29 +46,29 @@ else
                 <div class="stat-label">WAN Upload</div>
             </div>
             @{ var gwLatency = GetGatewayLatency(); }
-            <div class="monitoring-stat-card">
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwFabricUrl))">
                 <div class="stat-value">@FormatRtt(gwLatency.rtt)</div>
                 <div class="stat-label">Gateway RTT</div>
             </div>
-            <div class="monitoring-stat-card">
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwFabricUrl))">
                 <div class="stat-value @(gwLatency.loss > 0 ? "stat-danger" : "")">@FormatLoss(gwLatency.loss)</div>
                 <div class="stat-label">Gateway Loss</div>
             </div>
             @{ var ispTarget = GetBestTargetStats(MonitoringTargetType.AccessIsp); }
-            <div class="monitoring-stat-card">
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&category=AccessIsp"))">
                 <div class="stat-value">@FormatRtt(ispTarget.rtt)</div>
                 <div class="stat-label">ISP RTT</div>
             </div>
-            <div class="monitoring-stat-card">
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&category=AccessIsp"))">
                 <div class="stat-value @(ispTarget.loss > 0 ? "stat-danger" : "")">@FormatLoss(ispTarget.loss)</div>
                 <div class="stat-label">ISP Loss</div>
             </div>
             @{ var transitTarget = GetMeanTargetStats(MonitoringTargetType.Transit); }
-            <div class="monitoring-stat-card">
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&category=Transit"))">
                 <div class="stat-value">@FormatRtt(transitTarget.rtt)</div>
                 <div class="stat-label">Transit RTT</div>
             </div>
-            <div class="monitoring-stat-card">
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&category=Transit"))">
                 <div class="stat-value @(transitTarget.loss > 0 ? "stat-danger" : "")">@FormatLoss(transitTarget.loss)</div>
                 <div class="stat-label">Transit Loss</div>
             </div>
@@ -93,15 +101,15 @@ else
 
         <div class="monitoring-stat-cards">
             @{ var gwStats = GetGatewayStats(); }
-            <div class="monitoring-stat-card">
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
                 <div class="stat-value">@FormatPercent(gwStats?.CpuPercent)</div>
                 <div class="stat-label">Gateway CPU</div>
             </div>
-            <div class="monitoring-stat-card">
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
                 <div class="stat-value">@FormatPercent(gwStats?.MemoryUsedPercent)</div>
                 <div class="stat-label">Gateway Memory</div>
             </div>
-            <div class="monitoring-stat-card">
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
                 <div class="stat-value">@FormatTemp(gwStats?.TemperatureC)</div>
                 <div class="stat-label">Gateway Temp</div>
             </div>
@@ -299,16 +307,21 @@ else
         return LiveStats.GetForDevice(_gatewayMac);
     }
 
-    private (double? rtt, double loss) GetGatewayLatency()
+    private string? GetGatewayFabricTargetId()
     {
-        if (_gatewayMac == null) return (null, 0);
-        var gwFabric = _targets.FirstOrDefault(t =>
+        if (_gatewayMac == null) return null;
+        return _targets.FirstOrDefault(t =>
             t.TargetType == MonitoringTargetType.Fabric
             && t.Enabled
             && !string.IsNullOrEmpty(t.DeviceMac)
-            && t.DeviceMac.Replace("-", ":").Equals(_gatewayMac, StringComparison.OrdinalIgnoreCase));
-        if (gwFabric == null) return (null, 0);
-        var s = LiveStats.GetTargetStats(gwFabric.TargetId);
+            && t.DeviceMac.Replace("-", ":").Equals(_gatewayMac, StringComparison.OrdinalIgnoreCase))?.TargetId;
+    }
+
+    private (double? rtt, double loss) GetGatewayLatency()
+    {
+        var targetId = GetGatewayFabricTargetId();
+        if (targetId == null) return (null, 0);
+        var s = LiveStats.GetTargetStats(targetId);
         return (s?.RttAvgMs, s?.LossPercent ?? 0);
     }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -66,6 +66,12 @@ else
             </div>
         </div>
 
+        <div class="card wan-live-chart-card">
+            <div class="card-body wan-live-chart-body">
+                <div id="dashboard-wan-live-chart"></div>
+            </div>
+        </div>
+
         @if (MapMode == "3d")
         {
             <div class="card lv-map-card">
@@ -123,6 +129,13 @@ else
     .lv-panel .monitoring-stat-card {
         background: var(--bg-tertiary);
     }
+    .wan-live-chart-card {
+        overflow: hidden;
+        margin-bottom: 0;
+    }
+    .wan-live-chart-body {
+        padding: 0.5rem 0.25rem 0;
+    }
     .lv-map-card {
         overflow: hidden;
         margin-bottom: 0;
@@ -167,6 +180,7 @@ else
     private System.Threading.Timer? _refreshTimer;
     private bool _mapMounted;
     private string? _mountedMode;
+    private bool _chartMounted;
 
     protected override async Task OnInitializedAsync()
     {
@@ -209,6 +223,18 @@ else
                 }
             }
             catch { _mapMounted = false; _mountedMode = null; }
+        }
+
+        if (!_chartMounted)
+        {
+            _chartMounted = true;
+            try
+            {
+                await JS.InvokeVoidAsync("eval",
+                    $"(async () => {{ const m = await import('{VersionedJs("/js/wan-live-chart.js")}'); " +
+                    "window.__dashWanLiveChart = m; await m.mount('dashboard-wan-live-chart'); })();");
+            }
+            catch { _chartMounted = false; }
         }
     }
 
@@ -371,6 +397,11 @@ else
     public void Dispose()
     {
         _refreshTimer?.Dispose();
+        if (_chartMounted)
+        {
+            try { _ = JS.InvokeVoidAsync("eval", "window.__dashWanLiveChart?.unmount();"); }
+            catch { }
+        }
         if (_mapMounted)
         {
             try

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -90,7 +90,7 @@ else
                 </div>
             </div>
         }
-        else
+        else if (MapMode != "off")
         {
             <div class="card lv-map-card">
                 <div class="card-body lv-map-body">
@@ -197,7 +197,7 @@ else
     {
         if (!_ready) return;
 
-        if (!_mapMounted || _mountedMode != MapMode)
+        if (MapMode != "off" && (!_mapMounted || _mountedMode != MapMode))
         {
             if (_mapMounted) await UnmountMap();
 
@@ -224,6 +224,10 @@ else
                 }
             }
             catch { _mapMounted = false; _mountedMode = null; }
+        }
+        else if (MapMode == "off" && _mapMounted)
+        {
+            await UnmountMap();
         }
 
         if (!_chartMounted)

--- a/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
@@ -40,8 +40,8 @@ public static class MonitoringChartEndpoints
 
             var targets = await liveStats.GetIspTransitTargetsAsync(ct);
 
-            double? bestIspRtt = null;
-            double ispLoss = 0;
+            var ispRtts = new List<double>();
+            var ispLosses = new List<double>();
             var transitRtts = new List<double>();
             var transitLosses = new List<double>();
 
@@ -52,11 +52,8 @@ public static class MonitoringChartEndpoints
 
                 if (t.TargetType == MonitoringTargetType.AccessIsp)
                 {
-                    if (st.RttAvgMs != null && (bestIspRtt == null || st.RttAvgMs.Value < bestIspRtt.Value))
-                    {
-                        bestIspRtt = st.RttAvgMs;
-                        ispLoss = st.LossPercent;
-                    }
+                    if (st.RttAvgMs != null) ispRtts.Add(st.RttAvgMs.Value);
+                    ispLosses.Add(st.LossPercent);
                 }
                 else
                 {
@@ -65,21 +62,21 @@ public static class MonitoringChartEndpoints
                 }
             }
 
-            var transitRtt = transitRtts.Count > 0
-                ? transitRtts.Average() : (double?)null;
-            var transitLoss = transitLosses.Count > 0
-                ? transitLosses.Average() : 0.0;
+            var ispRtt = ispRtts.Count > 0 ? ispRtts.Average() : (double?)null;
+            var ispLoss = ispLosses.Count > 0 ? ispLosses.Average() : 0.0;
+            var transitRtt = transitRtts.Count > 0 ? transitRtts.Average() : (double?)null;
+            var transitLoss = transitLosses.Count > 0 ? transitLosses.Average() : 0.0;
 
             double? meanRtt = null;
-            if (bestIspRtt != null && transitRtt != null)
-                meanRtt = (bestIspRtt.Value + transitRtt.Value) / 2;
-            else meanRtt = bestIspRtt ?? transitRtt;
+            if (ispRtt != null && transitRtt != null)
+                meanRtt = (ispRtt.Value + transitRtt.Value) / 2;
+            else meanRtt = ispRtt ?? transitRtt;
 
             double meanLoss = 0;
-            if (bestIspRtt != null && transitRtts.Count > 0)
+            if (ispRtt != null && transitRtt != null)
                 meanLoss = (ispLoss + transitLoss) / 2;
-            else if (bestIspRtt != null) meanLoss = ispLoss;
-            else if (transitLosses.Count > 0) meanLoss = transitLoss;
+            else if (ispRtt != null) meanLoss = ispLoss;
+            else if (transitRtts.Count > 0) meanLoss = transitLoss;
 
             return Results.Ok(new
             {

--- a/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Web.Services;
 
@@ -8,6 +9,94 @@ public static class MonitoringChartEndpoints
 {
     public static void Map(WebApplication app)
     {
+        app.MapGet("/api/monitoring/live-stats", async (
+            MonitoringLiveStats liveStats,
+            UniFiConnectionService connectionService,
+            IDbContextFactory<NetworkOptimizerDbContext> dbFactory,
+            CancellationToken ct) =>
+        {
+            string? gatewayMac = null;
+            List<string>? wanIfNames = null;
+            try
+            {
+                var devices = await connectionService.GetDiscoveredDevicesAsync(ct);
+                var gw = devices?.FirstOrDefault(d =>
+                    d.Type == DeviceType.Gateway || d.HardwareType == DeviceType.Gateway);
+                gatewayMac = gw?.Mac?.Replace("-", ":").ToLowerInvariant();
+                wanIfNames = gw?.WanInterfaceNames;
+            }
+            catch { }
+
+            double wanDown = 0, wanUp = 0;
+            if (gatewayMac != null && wanIfNames != null)
+            {
+                foreach (var ifName in wanIfNames)
+                {
+                    var rate = liveStats.GetPortRate(gatewayMac, ifName);
+                    if (rate == null) continue;
+                    wanDown += rate.UpBps;
+                    wanUp += rate.DownBps;
+                }
+            }
+
+            await using var db = await dbFactory.CreateDbContextAsync(ct);
+            var targets = await db.MonitoringTargets.AsNoTracking()
+                .Where(t => t.Enabled
+                    && (t.TargetType == MonitoringTargetType.AccessIsp
+                        || t.TargetType == MonitoringTargetType.Transit))
+                .Select(t => new { t.TargetId, t.TargetType })
+                .ToListAsync(ct);
+
+            double? bestIspRtt = null;
+            double ispLoss = 0;
+            var transitRtts = new List<double>();
+            var transitLosses = new List<double>();
+
+            foreach (var t in targets)
+            {
+                var st = liveStats.GetTargetStats(t.TargetId);
+                if (st == null) continue;
+
+                if (t.TargetType == MonitoringTargetType.AccessIsp)
+                {
+                    if (st.RttAvgMs != null && (bestIspRtt == null || st.RttAvgMs.Value < bestIspRtt.Value))
+                    {
+                        bestIspRtt = st.RttAvgMs;
+                        ispLoss = st.LossPercent;
+                    }
+                }
+                else
+                {
+                    if (st.RttAvgMs != null) transitRtts.Add(st.RttAvgMs.Value);
+                    transitLosses.Add(st.LossPercent);
+                }
+            }
+
+            var transitRtt = transitRtts.Count > 0
+                ? transitRtts.Average() : (double?)null;
+            var transitLoss = transitLosses.Count > 0
+                ? transitLosses.Average() : 0.0;
+
+            double? meanRtt = null;
+            if (bestIspRtt != null && transitRtt != null)
+                meanRtt = (bestIspRtt.Value + transitRtt.Value) / 2;
+            else meanRtt = bestIspRtt ?? transitRtt;
+
+            double meanLoss = 0;
+            if (bestIspRtt != null && transitRtts.Count > 0)
+                meanLoss = (ispLoss + transitLoss) / 2;
+            else if (bestIspRtt != null) meanLoss = ispLoss;
+            else if (transitLosses.Count > 0) meanLoss = transitLoss;
+
+            return Results.Ok(new
+            {
+                downloadBps = wanDown,
+                uploadBps = wanUp,
+                rttMs = meanRtt,
+                lossPercent = meanLoss,
+            });
+        });
+
         app.MapGet("/api/monitoring/chart-data", async (
             MonitoringInfluxClient influx,
             IDbContextFactory<NetworkOptimizerDbContext> dbFactory,

--- a/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
@@ -92,6 +92,7 @@ public static class MonitoringChartEndpoints
 
         app.MapGet("/api/monitoring/wan-live-chart-data", async (
             MonitoringInfluxClient influx,
+            MonitoringLiveStats liveStats,
             UniFiConnectionService connectionService,
             DateTime? from,
             DateTime? to,
@@ -124,7 +125,9 @@ public static class MonitoringChartEndpoints
             var wanTask = !string.IsNullOrEmpty(gatewayMac) && wanIfNames?.Count > 0
                 ? influx.QueryGatewayWanRatesAsync(gatewayMac, wanIfNames, queryFrom, queryTo, ct: ct)
                 : Task.FromResult<IReadOnlyList<MonitoringInfluxClient.WanRatePoint>>(Array.Empty<MonitoringInfluxClient.WanRatePoint>());
-            var rttTask = influx.QueryMeanIspTransitLatencyAsync(queryFrom, queryTo, ct: ct);
+            var targets = await liveStats.GetIspTransitTargetsAsync(ct);
+            var targetIds = targets.Select(t => t.TargetId).ToList();
+            var rttTask = influx.QueryMeanIspTransitLatencyAsync(queryFrom, queryTo, targetIds, ct: ct);
 
             await Task.WhenAll(wanTask, rttTask);
 

--- a/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
@@ -97,6 +97,70 @@ public static class MonitoringChartEndpoints
             });
         });
 
+        app.MapGet("/api/monitoring/wan-live-chart-data", async (
+            MonitoringInfluxClient influx,
+            UniFiConnectionService connectionService,
+            DateTime? from,
+            DateTime? to,
+            CancellationToken ct) =>
+        {
+            DateTime queryFrom, queryTo;
+            if (from.HasValue && to.HasValue)
+            {
+                queryFrom = from.Value.ToUniversalTime();
+                queryTo = to.Value.ToUniversalTime();
+            }
+            else
+            {
+                queryTo = DateTime.UtcNow;
+                queryFrom = queryTo.AddMinutes(-5);
+            }
+
+            string? gatewayMac = null;
+            List<string>? wanIfNames = null;
+            try
+            {
+                var devices = await connectionService.GetDiscoveredDevicesAsync(ct);
+                var gw = devices?.FirstOrDefault(d =>
+                    d.Type == DeviceType.Gateway || d.HardwareType == DeviceType.Gateway);
+                gatewayMac = gw?.Mac;
+                wanIfNames = gw?.WanInterfaceNames;
+            }
+            catch { }
+
+            var wanTask = !string.IsNullOrEmpty(gatewayMac) && wanIfNames?.Count > 0
+                ? influx.QueryGatewayWanRatesAsync(gatewayMac, wanIfNames, queryFrom, queryTo, ct: ct)
+                : Task.FromResult<IReadOnlyList<MonitoringInfluxClient.WanRatePoint>>(Array.Empty<MonitoringInfluxClient.WanRatePoint>());
+            var rttTask = influx.QueryMeanIspTransitLatencyAsync(queryFrom, queryTo, ct: ct);
+
+            await Task.WhenAll(wanTask, rttTask);
+
+            var wanData = await wanTask;
+            var rttData = await rttTask;
+
+            var rttByTime = rttData.ToDictionary(
+                p => p.Time.Ticks / (TimeSpan.TicksPerSecond * 5) * (TimeSpan.TicksPerSecond * 5),
+                p => p);
+            MonitoringInfluxClient.LatencyPoint? lastRtt = null;
+
+            var points = wanData.Select(w =>
+            {
+                var bucket = w.Time.Ticks / (TimeSpan.TicksPerSecond * 5) * (TimeSpan.TicksPerSecond * 5);
+                if (rttByTime.TryGetValue(bucket, out var rtt)) lastRtt = rtt;
+
+                return new
+                {
+                    time = w.Time.ToString("o"),
+                    downloadBps = w.DownloadBps,
+                    uploadBps = w.UploadBps,
+                    rttMs = lastRtt?.RttAvgMs,
+                    lossPercent = lastRtt?.LossPercent,
+                };
+            });
+
+            return Results.Ok(new { points });
+        });
+
         app.MapGet("/api/monitoring/chart-data", async (
             MonitoringInfluxClient influx,
             IDbContextFactory<NetworkOptimizerDbContext> dbFactory,

--- a/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
@@ -12,7 +12,6 @@ public static class MonitoringChartEndpoints
         app.MapGet("/api/monitoring/live-stats", async (
             MonitoringLiveStats liveStats,
             UniFiConnectionService connectionService,
-            IDbContextFactory<NetworkOptimizerDbContext> dbFactory,
             CancellationToken ct) =>
         {
             string? gatewayMac = null;
@@ -39,13 +38,7 @@ public static class MonitoringChartEndpoints
                 }
             }
 
-            await using var db = await dbFactory.CreateDbContextAsync(ct);
-            var targets = await db.MonitoringTargets.AsNoTracking()
-                .Where(t => t.Enabled
-                    && (t.TargetType == MonitoringTargetType.AccessIsp
-                        || t.TargetType == MonitoringTargetType.Transit))
-                .Select(t => new { t.TargetId, t.TargetType })
-                .ToListAsync(ct);
+            var targets = await liveStats.GetIspTransitTargetsAsync(ct);
 
             double? bestIspRtt = null;
             double ispLoss = 0;

--- a/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
@@ -138,9 +138,12 @@ public static class MonitoringChartEndpoints
             var wanData = await wanTask;
             var rttData = await rttTask;
 
-            var rttByTime = rttData.ToDictionary(
-                p => p.Time.Ticks / (TimeSpan.TicksPerSecond * 5) * (TimeSpan.TicksPerSecond * 5),
-                p => p);
+            var rttByTime = new Dictionary<long, MonitoringInfluxClient.LatencyPoint>();
+            foreach (var p in rttData)
+            {
+                var bucket = p.Time.Ticks / (TimeSpan.TicksPerSecond * 5) * (TimeSpan.TicksPerSecond * 5);
+                rttByTime[bucket] = p;
+            }
             MonitoringInfluxClient.LatencyPoint? lastRtt = null;
 
             var points = wanData.Select(w =>

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -837,7 +837,7 @@ from(bucket: ""{_bucket}"")
         if (!IsConfigured) return Array.Empty<LatencyPoint>();
         var window = aggregateWindow ?? TimeSpan.FromSeconds(
             Math.Max(10, (int)((to - from).TotalSeconds / 150)));
-        var smoothWindow = TimeSpan.FromSeconds(Math.Max(30, window.TotalSeconds * 3));
+        var smoothWindow = TimeSpan.FromSeconds(Math.Max(120, window.TotalSeconds * 3));
         var flux = $@"
 from(bucket: ""{_bucket}"")
   |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -837,7 +837,7 @@ from(bucket: ""{_bucket}"")
         if (!IsConfigured) return Array.Empty<LatencyPoint>();
         var window = aggregateWindow ?? TimeSpan.FromSeconds(
             Math.Max(10, (int)((to - from).TotalSeconds / 150)));
-        var smoothWindow = TimeSpan.FromSeconds(Math.Max(120, window.TotalSeconds * 3));
+        var smoothWindow = TimeSpan.FromSeconds(Math.Max(60, window.TotalSeconds * 3));
         var flux = $@"
 from(bucket: ""{_bucket}"")
   |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -824,7 +824,9 @@ from(bucket: ""{_bucket}"")
         return results;
     }
 
-    /// <summary>Mean RTT and loss across all ISP+Transit targets, aggregated per time window.</summary>
+    /// <summary>Mean RTT and loss across all ISP+Transit targets, aggregated per time window.
+    /// Averages per target_type first (so ISP and Transit contribute equally), then
+    /// averages the two category means to avoid sawtooth from uneven probe timing.</summary>
     public async Task<IReadOnlyList<LatencyPoint>> QueryMeanIspTransitLatencyAsync(
         DateTime from,
         DateTime to,
@@ -833,15 +835,18 @@ from(bucket: ""{_bucket}"")
     {
         if (!IsConfigured) await ReconfigureAsync(ct);
         if (!IsConfigured) return Array.Empty<LatencyPoint>();
-        var window = aggregateWindow ?? PickAggregateWindow(to - from);
+        var window = aggregateWindow ?? TimeSpan.FromSeconds(
+            Math.Max(15, (int)((to - from).TotalSeconds / 150)));
         var flux = $@"
 from(bucket: ""{_bucket}"")
   |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
   |> filter(fn: (r) => r._measurement == ""latency"")
   |> filter(fn: (r) => r.target_type == ""accessisp"" or r.target_type == ""transit"")
   |> filter(fn: (r) => r._field == ""rtt_avg_ms"" or r._field == ""loss_percent"")
-  |> group(columns: [""_field""])
+  |> group(columns: [""target_type"", ""_field""])
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
+  |> group(columns: [""_time"", ""_field""])
+  |> mean()
   |> group()
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -836,7 +836,8 @@ from(bucket: ""{_bucket}"")
         if (!IsConfigured) await ReconfigureAsync(ct);
         if (!IsConfigured) return Array.Empty<LatencyPoint>();
         var window = aggregateWindow ?? TimeSpan.FromSeconds(
-            Math.Max(30, (int)((to - from).TotalSeconds / 150)));
+            Math.Max(10, (int)((to - from).TotalSeconds / 150)));
+        var smoothWindow = TimeSpan.FromSeconds(Math.Max(30, window.TotalSeconds * 3));
         var flux = $@"
 from(bucket: ""{_bucket}"")
   |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
@@ -844,9 +845,12 @@ from(bucket: ""{_bucket}"")
   |> filter(fn: (r) => r.target_type == ""accessisp"" or r.target_type == ""transit"")
   |> filter(fn: (r) => r._field == ""rtt_avg_ms"" or r._field == ""loss_percent"")
   |> group(columns: [""target_type"", ""_field""])
-  |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
+  |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: true)
+  |> fill(usePrevious: true)
   |> group(columns: [""_time"", ""_field""])
   |> mean()
+  |> group(columns: [""_field""])
+  |> timedMovingAverage(every: {ToFluxDuration(window)}, period: {ToFluxDuration(smoothWindow)})
   |> group()
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -836,7 +836,7 @@ from(bucket: ""{_bucket}"")
         if (!IsConfigured) await ReconfigureAsync(ct);
         if (!IsConfigured) return Array.Empty<LatencyPoint>();
         var window = aggregateWindow ?? TimeSpan.FromSeconds(
-            Math.Max(15, (int)((to - from).TotalSeconds / 150)));
+            Math.Max(20, (int)((to - from).TotalSeconds / 150)));
         var flux = $@"
 from(bucket: ""{_bucket}"")
   |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -836,7 +836,7 @@ from(bucket: ""{_bucket}"")
         if (!IsConfigured) await ReconfigureAsync(ct);
         if (!IsConfigured) return Array.Empty<LatencyPoint>();
         var window = aggregateWindow ?? TimeSpan.FromSeconds(
-            Math.Max(20, (int)((to - from).TotalSeconds / 150)));
+            Math.Max(30, (int)((to - from).TotalSeconds / 150)));
         var flux = $@"
 from(bucket: ""{_bucket}"")
   |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -824,6 +824,40 @@ from(bucket: ""{_bucket}"")
         return results;
     }
 
+    /// <summary>Mean RTT and loss across all ISP+Transit targets, aggregated per time window.</summary>
+    public async Task<IReadOnlyList<LatencyPoint>> QueryMeanIspTransitLatencyAsync(
+        DateTime from,
+        DateTime to,
+        TimeSpan? aggregateWindow = null,
+        CancellationToken ct = default)
+    {
+        if (!IsConfigured) await ReconfigureAsync(ct);
+        if (!IsConfigured) return Array.Empty<LatencyPoint>();
+        var window = aggregateWindow ?? PickAggregateWindow(to - from);
+        var flux = $@"
+from(bucket: ""{_bucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""latency"")
+  |> filter(fn: (r) => r.target_type == ""accessisp"" or r.target_type == ""transit"")
+  |> filter(fn: (r) => r._field == ""rtt_avg_ms"" or r._field == ""loss_percent"")
+  |> group(columns: [""_field""])
+  |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
+  |> group()
+  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
+";
+        var results = new List<LatencyPoint>();
+        await foreach (var record in QueryFluxAsync(flux, ct))
+        {
+            results.Add(new LatencyPoint
+            {
+                Time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow),
+                RttAvgMs = AsDoubleOrNull(record.GetValueByKey("rtt_avg_ms")),
+                LossPercent = AsDoubleOrNull(record.GetValueByKey("loss_percent"))
+            });
+        }
+        return results;
+    }
+
     /// <summary>Time-series of RTT and loss for a single monitoring target.</summary>
     public async Task<IReadOnlyList<LatencyPoint>> QueryLatencyAsync(
         string targetId,

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -830,6 +830,7 @@ from(bucket: ""{_bucket}"")
     public async Task<IReadOnlyList<LatencyPoint>> QueryMeanIspTransitLatencyAsync(
         DateTime from,
         DateTime to,
+        IReadOnlyList<string>? enabledTargetIds = null,
         TimeSpan? aggregateWindow = null,
         CancellationToken ct = default)
     {
@@ -838,11 +839,18 @@ from(bucket: ""{_bucket}"")
         var window = aggregateWindow ?? TimeSpan.FromSeconds(
             Math.Max(10, (int)((to - from).TotalSeconds / 150)));
         var smoothWindow = TimeSpan.FromSeconds(Math.Max(60, window.TotalSeconds * 3));
+        var targetFilter = "";
+        if (enabledTargetIds is { Count: > 0 })
+        {
+            var idFilter = string.Join(" or ", enabledTargetIds.Select(id =>
+                $@"r.target_id == ""{SanitizeFluxString(id)}"""));
+            targetFilter = $"\n  |> filter(fn: (r) => {idFilter})";
+        }
         var flux = $@"
 from(bucket: ""{_bucket}"")
   |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
   |> filter(fn: (r) => r._measurement == ""latency"")
-  |> filter(fn: (r) => r.target_type == ""accessisp"" or r.target_type == ""transit"")
+  |> filter(fn: (r) => r.target_type == ""accessisp"" or r.target_type == ""transit""){targetFilter}
   |> filter(fn: (r) => r._field == ""rtt_avg_ms"" or r._field == ""loss_percent"")
   |> group(columns: [""target_type"", ""_field""])
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: true)

--- a/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Storage.Models;
 
 namespace NetworkOptimizer.Web.Services;
 
@@ -14,10 +16,18 @@ namespace NetworkOptimizer.Web.Services;
 public class MonitoringLiveStats
 {
     private readonly ILogger<MonitoringLiveStats> _logger;
+    private readonly IDbContextFactory<NetworkOptimizerDbContext> _dbFactory;
 
-    public MonitoringLiveStats(ILogger<MonitoringLiveStats> logger)
+    private List<(string TargetId, MonitoringTargetType TargetType)>? _ispTransitTargets;
+    private DateTime _ispTransitTargetsCacheTime;
+    private static readonly TimeSpan TargetCacheTtl = TimeSpan.FromSeconds(30);
+    private readonly Lock _targetCacheLock = new();
+
+    public MonitoringLiveStats(ILogger<MonitoringLiveStats> logger,
+        IDbContextFactory<NetworkOptimizerDbContext> dbFactory)
     {
         _logger = logger;
+        _dbFactory = dbFactory;
     }
 
     private readonly ConcurrentDictionary<string, DeviceLiveStats> _stats = new();
@@ -184,6 +194,33 @@ public class MonitoringLiveStats
             Success = success,
             LastUpdate = timestamp
         };
+    }
+
+    /// <summary>Cached list of enabled ISP+Transit monitoring targets. Refreshed every 30s.</summary>
+    public async Task<List<(string TargetId, MonitoringTargetType TargetType)>> GetIspTransitTargetsAsync(
+        CancellationToken ct = default)
+    {
+        lock (_targetCacheLock)
+        {
+            if (_ispTransitTargets != null && DateTime.UtcNow - _ispTransitTargetsCacheTime < TargetCacheTtl)
+                return _ispTransitTargets;
+        }
+
+        await using var db = await _dbFactory.CreateDbContextAsync(ct);
+        var targets = await db.MonitoringTargets.AsNoTracking()
+            .Where(t => t.Enabled
+                && (t.TargetType == MonitoringTargetType.AccessIsp
+                    || t.TargetType == MonitoringTargetType.Transit))
+            .Select(t => new { t.TargetId, t.TargetType })
+            .ToListAsync(ct);
+
+        var result = targets.Select(t => (t.TargetId, t.TargetType)).ToList();
+        lock (_targetCacheLock)
+        {
+            _ispTransitTargets = result;
+            _ispTransitTargetsCacheTime = DateTime.UtcNow;
+        }
+        return result;
     }
 
     /// <summary>Total fabric ingress/egress across all devices in the cache.

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -378,6 +378,10 @@ a:hover {
 }
 .wan-live-chart-card > .card-body {
     padding: 0;
+    margin-right: -0.75rem;
+}
+.wan-live-chart-card .apexcharts-canvas {
+    min-height: 0;
 }
 .dashboard-grid .lv-panel > .wan-live-chart-card {
     margin-top: -0.5rem;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -555,6 +555,13 @@ a:hover {
 .clickable-card:hover {
     background: var(--bg-tertiary);
 }
+.clickable-stat-card {
+    cursor: pointer;
+    transition: opacity 0.15s ease;
+}
+.clickable-stat-card:hover {
+    opacity: 0.8;
+}
 
 /* Speed Test Stats (Dashboard panel) */
 .speed-test-stats {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -376,8 +376,12 @@ a:hover {
 .wan-live-chart-card {
     margin-bottom: 0;
 }
-.wan-live-chart-body {
+.wan-live-chart-card > .card-body {
     padding: 0;
+}
+.lv-panel > .wan-live-chart-card {
+    margin-top: -0.5rem;
+    margin-bottom: -0.5rem;
 }
 
 .card-header {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -373,6 +373,13 @@ a:hover {
     margin-bottom: 1.5rem;
 }
 
+.wan-live-chart-card {
+    margin-bottom: 0;
+}
+.wan-live-chart-body {
+    padding: 0.5rem 0.25rem 0;
+}
+
 .card-header {
     padding: 12px 16px;
     border-bottom: 1px solid rgba(255, 255, 255, 0.06);

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -377,7 +377,7 @@ a:hover {
     margin-bottom: 0;
 }
 .wan-live-chart-body {
-    padding: 0.5rem 0.25rem 0;
+    padding: 0;
 }
 
 .card-header {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -379,7 +379,7 @@ a:hover {
 .wan-live-chart-card > .card-body {
     padding: 0;
 }
-.lv-panel > .wan-live-chart-card {
+.dashboard-grid .lv-panel > .wan-live-chart-card {
     margin-top: -0.5rem;
     margin-bottom: -0.5rem;
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -363,6 +363,16 @@ export async function mount(elId) {
     startPoll();
 }
 
+export function soloDevice(mac) {
+    if (!deviceMeta.length) return;
+    const match = deviceMeta.find(d => d.mac === mac);
+    if (!match) return;
+    deviceMeta.forEach(d => { visibility[d.mac] = d.mac === mac; });
+    updateVisibility();
+    const container = document.getElementById(containerId);
+    if (container) renderBadges(container);
+}
+
 export function unmount() {
     stopPoll();
     if (visibilityObserver) { visibilityObserver.disconnect(); visibilityObserver = null; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -638,6 +638,32 @@ export function restoreState() {
     startPoll();
 }
 
+export function setCategory(cat) {
+    currentCategory = cat;
+    const container = document.getElementById(containerId);
+    if (container) {
+        container.querySelectorAll('[data-category]').forEach(b => {
+            b.classList.toggle('active', b.dataset.category === cat);
+        });
+    }
+    visibility = {};
+    loadAndUpdate();
+    startPoll();
+}
+
+export function soloTarget(targetId) {
+    if (!targetMeta.length) return;
+    const match = targetMeta.find(t => t.id === targetId);
+    if (!match) return;
+    targetMeta.forEach(t => { visibility[t.id] = t.id === targetId; });
+    updateChartVisibility();
+    const container = document.getElementById(containerId);
+    if (container) {
+        renderBadges(container);
+        if (lastFetchData) renderStatsTable(container, lastFetchData);
+    }
+}
+
 export function unmount() {
     stopPoll();
     if (visibilityObserver) { visibilityObserver.disconnect(); visibilityObserver = null; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -166,41 +166,71 @@ async function loadHistory() {
         }
     }
 
-    // Compute mean RTT/loss across ISP+Transit targets per timestamp
-    const rttMap = new Map();
-    const lossMap = new Map();
-
-    function addTargetData(data) {
-        if (!data?.targets) return;
+    // Compute ISP and Transit RTT/loss separately to avoid sawtooth from
+    // interleaved timestamps. Then merge with LOCF (last observation carried
+    // forward) so each output point has the combined mean.
+    function meanTimeSeries(data) {
+        if (!data?.targets?.length) return new Map();
+        const byTime = new Map();
         for (const target of data.targets) {
             for (const p of (target.rtt || [])) {
                 const t = new Date(p.time).getTime();
                 if (p.value == null) continue;
-                if (!rttMap.has(t)) rttMap.set(t, []);
-                rttMap.get(t).push(p.value);
+                if (!byTime.has(t)) byTime.set(t, { rtts: [], losses: [] });
+                byTime.get(t).rtts.push(p.value);
             }
             for (const p of (target.loss || [])) {
                 const t = new Date(p.time).getTime();
                 if (p.value == null) continue;
-                if (!lossMap.has(t)) lossMap.set(t, []);
-                lossMap.get(t).push(p.value);
+                if (!byTime.has(t)) byTime.set(t, { rtts: [], losses: [] });
+                byTime.get(t).losses.push(p.value);
             }
         }
+        const result = new Map();
+        for (const [t, v] of byTime) {
+            result.set(t, {
+                rtt: v.rtts.length > 0 ? v.rtts.reduce((a, b) => a + b, 0) / v.rtts.length : null,
+                loss: v.losses.length > 0 ? v.losses.reduce((a, b) => a + b, 0) / v.losses.length : null,
+            });
+        }
+        return result;
     }
-    addTargetData(isp);
-    addTargetData(transit);
 
-    // Merge all timestamps and build buffer
-    const allTimes = new Set([...dlMap.keys(), ...rttMap.keys()]);
-    const sorted = [...allTimes].sort((a, b) => a - b);
+    const ispSeries = meanTimeSeries(isp);
+    const transitSeries = meanTimeSeries(transit);
 
-    buffer = sorted.map(t => ({
-        time: t,
-        download: dlMap.get(t) ?? null,
-        upload: ulMap.get(t) ?? null,
-        loss: lossMap.has(t) ? lossMap.get(t).reduce((a, b) => a + b, 0) / lossMap.get(t).length : null,
-        rtt: rttMap.has(t) ? rttMap.get(t).reduce((a, b) => a + b, 0) / rttMap.get(t).length : null,
-    }));
+    // Use only WAN rate timestamps for the buffer (throughput is the primary
+    // series); interpolate RTT/loss at each point using LOCF.
+    const wanTimes = [...dlMap.keys()].sort((a, b) => a - b);
+
+    const ispTimes = [...ispSeries.keys()].sort((a, b) => a - b);
+    const transitTimes = [...transitSeries.keys()].sort((a, b) => a - b);
+
+    function locfAt(sortedTimes, seriesMap, t) {
+        let best = null;
+        for (const st of sortedTimes) {
+            if (st > t) break;
+            best = seriesMap.get(st);
+        }
+        return best;
+    }
+
+    buffer = wanTimes.map(t => {
+        const ispVal = locfAt(ispTimes, ispSeries, t);
+        const transitVal = locfAt(transitTimes, transitSeries, t);
+
+        let rtt = null;
+        if (ispVal?.rtt != null && transitVal?.rtt != null) rtt = (ispVal.rtt + transitVal.rtt) / 2;
+        else if (ispVal?.rtt != null) rtt = ispVal.rtt;
+        else if (transitVal?.rtt != null) rtt = transitVal.rtt;
+
+        let loss = null;
+        if (ispVal?.loss != null && transitVal?.loss != null) loss = (ispVal.loss + transitVal.loss) / 2;
+        else if (ispVal?.loss != null) loss = ispVal.loss;
+        else if (transitVal?.loss != null) loss = transitVal.loss;
+
+        return { time: t, download: dlMap.get(t) ?? null, upload: ulMap.get(t) ?? null, loss, rtt };
+    });
 }
 
 async function pollLive() {

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -30,7 +30,7 @@ function formatBps(v) {
 function buildOpts() {
     return {
         chart: {
-            type: 'area',
+            type: 'line',
             height: 175,
             background: 'transparent',
             toolbar: { show: false },
@@ -117,18 +117,7 @@ function buildOpts() {
             padding: { left: 4, right: 4, top: -8, bottom: 0 },
             xaxis: { lines: { show: false } },
         },
-        legend: {
-            show: true,
-            position: 'top',
-            horizontalAlign: 'center',
-            floating: true,
-            offsetY: -4,
-            fontSize: '11px',
-            labels: { colors: '#9ca3af' },
-            markers: { size: 4, offsetX: -2 },
-            itemMargin: { horizontal: 8 },
-            customLegendItems: ['Download', 'Upload', 'Loss', 'RTT'],
-        },
+        legend: { show: false },
         tooltip: {
             theme: 'dark',
             shared: true,
@@ -164,17 +153,42 @@ function sampleNow() {
         ulBps += r.upstreamBps || 0;
     }
 
-    const rttVals = [];
-    const lossVals = [];
-    for (const id of [...ispCloudIds, ...transitCloudIds]) {
+    // ISP: best (lowest) RTT across ISP clouds, matching stat card logic
+    let ispRtt = null;
+    let ispLoss = null;
+    for (const id of ispCloudIds) {
         const c = clouds[id];
         if (!c) continue;
-        if (c.rttAvgMs != null) rttVals.push(c.rttAvgMs);
-        if (c.lossPercent != null) lossVals.push(c.lossPercent);
+        if (c.rttAvgMs != null && (ispRtt === null || c.rttAvgMs < ispRtt)) {
+            ispRtt = c.rttAvgMs;
+            ispLoss = c.lossPercent;
+        }
     }
 
-    const meanRtt = rttVals.length > 0 ? rttVals.reduce((a, b) => a + b, 0) / rttVals.length : null;
-    const meanLoss = lossVals.length > 0 ? lossVals.reduce((a, b) => a + b, 0) / lossVals.length : null;
+    // Transit: mean RTT across transit clouds, matching stat card logic
+    const transitRtts = [];
+    const transitLosses = [];
+    for (const id of transitCloudIds) {
+        const c = clouds[id];
+        if (!c) continue;
+        if (c.rttAvgMs != null) transitRtts.push(c.rttAvgMs);
+        if (c.lossPercent != null) transitLosses.push(c.lossPercent);
+    }
+    const transitRtt = transitRtts.length > 0
+        ? transitRtts.reduce((a, b) => a + b, 0) / transitRtts.length : null;
+    const transitLoss = transitLosses.length > 0
+        ? transitLosses.reduce((a, b) => a + b, 0) / transitLosses.length : null;
+
+    // Mean of ISP and Transit RTT (new combined metric)
+    let meanRtt = null;
+    if (ispRtt != null && transitRtt != null) meanRtt = (ispRtt + transitRtt) / 2;
+    else if (ispRtt != null) meanRtt = ispRtt;
+    else if (transitRtt != null) meanRtt = transitRtt;
+
+    let meanLoss = null;
+    if (ispLoss != null && transitLoss != null) meanLoss = (ispLoss + transitLoss) / 2;
+    else if (ispLoss != null) meanLoss = ispLoss;
+    else if (transitLoss != null) meanLoss = transitLoss;
 
     return {
         time: Date.now(),

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -108,7 +108,7 @@ function buildOpts() {
         grid: {
             borderColor: '#374151',
             strokeDashArray: 3,
-            padding: { left: 3, right: -12, top: -8, bottom: 0 },
+            padding: { left: 3, right: -14, top: -8, bottom: 0 },
             xaxis: { lines: { show: false } },
         },
         legend: { show: false },

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -15,6 +15,7 @@ let chart = null;
 let pollTimer = null;
 let buffer = [];
 let elId = null;
+let mountGen = 0;
 
 function formatBps(v) {
     if (v == null || v < 1) return '0';
@@ -180,18 +181,20 @@ async function pollLive() {
 }
 
 export async function mount(containerId, opts) {
+    const gen = ++mountGen;
+    unmount();
     elId = containerId;
     const el = document.getElementById(containerId);
     if (!el) return;
 
-    buffer = [];
-    if (chart) { chart.destroy(); chart = null; }
-
     chart = new ApexCharts(el, buildOpts());
     await chart.render();
+    if (gen !== mountGen) return;
 
     await loadHistory();
+    if (gen !== mountGen) return;
     await pollLive();
+    if (gen !== mountGen) return;
     updateChart();
     const interval = opts?.pollMs || POLL_MS;
 
@@ -199,6 +202,7 @@ export async function mount(containerId, opts) {
 }
 
 export function unmount() {
+    mountGen++;
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     if (chart) { chart.destroy(); chart = null; }
     buffer = [];

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -47,7 +47,8 @@ function buildOpts() {
             dashArray: [0, 0, 0, 6],
         },
         fill: {
-            type: ['gradient', 'gradient', 'gradient', 'none'],
+            type: ['gradient', 'gradient', 'gradient', 'solid'],
+            opacity: [1, 1, 1, 0],
             gradient: {
                 shadeIntensity: 0.4,
                 opacityFrom: [0.55, 0.45, 0.5, 0],

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -137,100 +137,20 @@ function updateChart() {
 async function loadHistory() {
     const to = new Date();
     const from = new Date(to.getTime() - HISTORY_MINUTES * 60000);
-    const qFrom = from.toISOString();
-    const qTo = to.toISOString();
-
-    const [wanResp, ispResp, transitResp] = await Promise.all([
-        fetch(`/api/monitoring/wan-rate-chart?from=${qFrom}&to=${qTo}`, { credentials: 'same-origin' }).catch(() => null),
-        fetch(`/api/monitoring/chart-data?category=AccessIsp&from=${qFrom}&to=${qTo}`, { credentials: 'same-origin' }).catch(() => null),
-        fetch(`/api/monitoring/chart-data?category=Transit&from=${qFrom}&to=${qTo}`, { credentials: 'same-origin' }).catch(() => null),
-    ]);
-
-    const wan = wanResp?.ok ? await wanResp.json() : null;
-    const isp = ispResp?.ok ? await ispResp.json() : null;
-    const transit = transitResp?.ok ? await transitResp.json() : null;
-
-    // Build time-indexed maps from WAN rate data
-    const dlMap = new Map();
-    const ulMap = new Map();
-    if (wan) {
-        for (const p of (wan.download || [])) {
-            const t = new Date(p.time).getTime();
-            dlMap.set(t, p.value || 0);
-            if (!ulMap.has(t)) ulMap.set(t, 0);
-        }
-        for (const p of (wan.upload || [])) {
-            const t = new Date(p.time).getTime();
-            ulMap.set(t, p.value || 0);
-            if (!dlMap.has(t)) dlMap.set(t, 0);
-        }
-    }
-
-    // Compute ISP and Transit RTT/loss separately to avoid sawtooth from
-    // interleaved timestamps. Then merge with LOCF (last observation carried
-    // forward) so each output point has the combined mean.
-    function meanTimeSeries(data) {
-        if (!data?.targets?.length) return new Map();
-        const byTime = new Map();
-        for (const target of data.targets) {
-            for (const p of (target.rtt || [])) {
-                const t = new Date(p.time).getTime();
-                if (p.value == null) continue;
-                if (!byTime.has(t)) byTime.set(t, { rtts: [], losses: [] });
-                byTime.get(t).rtts.push(p.value);
-            }
-            for (const p of (target.loss || [])) {
-                const t = new Date(p.time).getTime();
-                if (p.value == null) continue;
-                if (!byTime.has(t)) byTime.set(t, { rtts: [], losses: [] });
-                byTime.get(t).losses.push(p.value);
-            }
-        }
-        const result = new Map();
-        for (const [t, v] of byTime) {
-            result.set(t, {
-                rtt: v.rtts.length > 0 ? v.rtts.reduce((a, b) => a + b, 0) / v.rtts.length : null,
-                loss: v.losses.length > 0 ? v.losses.reduce((a, b) => a + b, 0) / v.losses.length : null,
-            });
-        }
-        return result;
-    }
-
-    const ispSeries = meanTimeSeries(isp);
-    const transitSeries = meanTimeSeries(transit);
-
-    // Use only WAN rate timestamps for the buffer (throughput is the primary
-    // series); interpolate RTT/loss at each point using LOCF.
-    const wanTimes = [...dlMap.keys()].sort((a, b) => a - b);
-
-    const ispTimes = [...ispSeries.keys()].sort((a, b) => a - b);
-    const transitTimes = [...transitSeries.keys()].sort((a, b) => a - b);
-
-    function locfAt(sortedTimes, seriesMap, t) {
-        let best = null;
-        for (const st of sortedTimes) {
-            if (st > t) break;
-            best = seriesMap.get(st);
-        }
-        return best;
-    }
-
-    buffer = wanTimes.map(t => {
-        const ispVal = locfAt(ispTimes, ispSeries, t);
-        const transitVal = locfAt(transitTimes, transitSeries, t);
-
-        let rtt = null;
-        if (ispVal?.rtt != null && transitVal?.rtt != null) rtt = (ispVal.rtt + transitVal.rtt) / 2;
-        else if (ispVal?.rtt != null) rtt = ispVal.rtt;
-        else if (transitVal?.rtt != null) rtt = transitVal.rtt;
-
-        let loss = null;
-        if (ispVal?.loss != null && transitVal?.loss != null) loss = (ispVal.loss + transitVal.loss) / 2;
-        else if (ispVal?.loss != null) loss = ispVal.loss;
-        else if (transitVal?.loss != null) loss = transitVal.loss;
-
-        return { time: t, download: dlMap.get(t) ?? null, upload: ulMap.get(t) ?? null, loss, rtt };
-    });
+    try {
+        const resp = await fetch(
+            `/api/monitoring/wan-live-chart-data?from=${from.toISOString()}&to=${to.toISOString()}`,
+            { credentials: 'same-origin' });
+        if (!resp.ok) return;
+        const data = await resp.json();
+        buffer = (data.points || []).map(p => ({
+            time: new Date(p.time).getTime(),
+            download: p.downloadBps,
+            upload: p.uploadBps,
+            rtt: p.rttMs,
+            loss: p.lossPercent,
+        }));
+    } catch { }
 }
 
 async function pollLive() {

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -3,7 +3,7 @@
 // ~5-minute window. Mounted from Blazor in LiveViewPanel and Monitoring Live tab.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import * as flowData from './lan-flow-data.js?v=1';
+import * as flowData from './lan-flow-data.js?v=2';
 
 const MAX_POINTS = 100;
 const COLOR_DL    = '#3b82f6';

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -78,7 +78,7 @@ function buildOpts() {
                 labels: {
                     style: { colors: '#9ca3af', fontSize: '10px' },
                     formatter: v => formatBps(v),
-                    offsetX: -4,
+                    offsetX: -10,
                 },
                 axisBorder: { show: false },
                 axisTicks: { show: false },
@@ -98,7 +98,7 @@ function buildOpts() {
                 labels: {
                     style: { colors: '#9ca3af', fontSize: '10px' },
                     formatter: v => v != null ? v.toFixed(0) + ' ms' : '',
-                    offsetX: 4,
+                    offsetX: -10,
                 },
                 axisBorder: { show: false },
                 axisTicks: { show: false },
@@ -107,7 +107,7 @@ function buildOpts() {
         grid: {
             borderColor: '#374151',
             strokeDashArray: 3,
-            padding: { left: 4, right: 4, top: -8, bottom: 0 },
+            padding: { left: 4, right: -5, top: -8, bottom: 0 },
             xaxis: { lines: { show: false } },
         },
         legend: { show: false },

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -98,8 +98,10 @@ function buildOpts() {
                 max: v => v * 1.5,
                 labels: {
                     style: { colors: '#9ca3af', fontSize: '10px' },
-                    formatter: v => v != null ? v.toFixed(0) + ' ms' : '',
+                    formatter: v => v != null ? v.toFixed(0) : '',
+                    maxWidth: 30,
                 },
+                title: { text: 'ms', style: { color: '#64748b', fontSize: '9px' }, offsetX: -4 },
                 axisBorder: { show: false },
                 axisTicks: { show: false },
             },
@@ -107,7 +109,7 @@ function buildOpts() {
         grid: {
             borderColor: '#374151',
             strokeDashArray: 3,
-            padding: { left: 3, right: -6, top: -8, bottom: 0 },
+            padding: { left: 3, right: 0, top: -8, bottom: 0 },
             xaxis: { lines: { show: false } },
         },
         legend: { show: false },

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -94,7 +94,8 @@ function buildOpts() {
             {
                 seriesName: 'RTT',
                 opposite: true,
-                min: 0,
+                min: v => Math.max(0, v * 0.5),
+                max: v => v * 1.5,
                 labels: {
                     style: { colors: '#9ca3af', fontSize: '10px' },
                     formatter: v => v != null ? v.toFixed(0) + ' ms' : '',

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -99,7 +99,6 @@ function buildOpts() {
                 labels: {
                     style: { colors: '#9ca3af', fontSize: '10px' },
                     formatter: v => v != null ? v.toFixed(0) + ' ms' : '',
-                    offsetX: -4,
                 },
                 axisBorder: { show: false },
                 axisTicks: { show: false },
@@ -108,7 +107,7 @@ function buildOpts() {
         grid: {
             borderColor: '#374151',
             strokeDashArray: 3,
-            padding: { left: 3, right: -14, top: -8, bottom: 0 },
+            padding: { left: 3, right: -6, top: -8, bottom: 0 },
             xaxis: { lines: { show: false } },
         },
         legend: { show: false },

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -1,21 +1,18 @@
-// WAN live chart — real-time area+line chart fed by lan-flow-data.js pub/sub.
-// Shows download, upload, packet loss, and mean ISP/transit RTT as a rolling
-// ~5-minute window. Mounted from Blazor in LiveViewPanel and Monitoring Live tab.
+// WAN live chart — real-time area+line chart showing download, upload, packet
+// loss, and mean ISP/transit RTT. Pre-loads history from InfluxDB, then polls
+// /api/monitoring/live-stats for real-time updates.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import * as flowData from './lan-flow-data.js?v=2';
 
-const MAX_POINTS = 100;
-const COLOR_DL    = '#3b82f6';
-const COLOR_UL    = '#10b981';
-const COLOR_LOSS  = '#ef4444';
-const COLOR_RTT   = '#d946ef';
+const HISTORY_MINUTES = 5;
+const POLL_MS = 3000;
+const COLOR_DL   = '#3b82f6';
+const COLOR_UL   = '#10b981';
+const COLOR_LOSS = '#ef4444';
+const COLOR_RTT  = '#d946ef';
 
 let chart = null;
-let unsub = null;
-let wanLinkIds = [];
-let ispCloudIds = [];
-let transitCloudIds = [];
+let pollTimer = null;
 let buffer = [];
 let elId = null;
 
@@ -36,26 +33,25 @@ function buildOpts() {
             toolbar: { show: false },
             zoom: { enabled: false },
             animations: { enabled: true, easing: 'smooth', dynamicAnimation: { speed: 800 } },
-            sparkline: { enabled: false },
         },
         series: [
-            { name: 'Download',  type: 'area', data: [] },
-            { name: 'Upload',    type: 'area', data: [] },
-            { name: 'Loss',      type: 'area', data: [] },
-            { name: 'RTT',       type: 'line', data: [] },
+            { name: 'Download', type: 'area', data: [] },
+            { name: 'Upload',   type: 'area', data: [] },
+            { name: 'Loss',     type: 'area', data: [] },
+            { name: 'RTT',      type: 'line', data: [] },
         ],
         colors: [COLOR_DL, COLOR_UL, COLOR_LOSS, COLOR_RTT],
         stroke: {
             curve: 'smooth',
-            width: [2, 2, 1.5, 2],
+            width: [2.5, 2.5, 1.5, 1.5],
             dashArray: [0, 0, 0, 6],
         },
         fill: {
             type: ['gradient', 'gradient', 'gradient', 'none'],
             gradient: {
                 shadeIntensity: 0.4,
-                opacityFrom: [0.45, 0.35, 0.5, 0],
-                opacityTo:   [0.05, 0.05, 0.05, 0],
+                opacityFrom: [0.55, 0.45, 0.5, 0],
+                opacityTo:   [0.1,  0.08, 0.05, 0],
                 stops: [0, 95],
             },
         },
@@ -83,13 +79,8 @@ function buildOpts() {
                 },
                 axisBorder: { show: false },
                 axisTicks: { show: false },
-                title: { text: undefined },
             },
-            {
-                seriesName: 'Upload',
-                show: false,
-                min: 0,
-            },
+            { seriesName: 'Upload', show: false, min: 0 },
             {
                 seriesName: 'Loss',
                 opposite: true,
@@ -108,7 +99,6 @@ function buildOpts() {
                 },
                 axisBorder: { show: false },
                 axisTicks: { show: false },
-                title: { text: undefined },
             },
         ],
         grid: {
@@ -129,85 +119,12 @@ function buildOpts() {
                 { formatter: v => v != null ? v.toFixed(1) + ' ms' : '-' },
             ],
         },
-        noData: { text: 'Waiting for data...', style: { color: '#64748b', fontSize: '13px' } },
+        noData: { text: 'Loading...', style: { color: '#64748b', fontSize: '13px' } },
     };
 }
 
-function indexTopology() {
-    const snap = flowData.getSnapshot();
-    if (!snap) return;
-    wanLinkIds = (snap.links || []).filter(l => l.kind === 3).map(l => l.id);
-    ispCloudIds = (snap.clouds || []).filter(c => c.kind === 0).map(c => c.id);
-    transitCloudIds = (snap.clouds || []).filter(c => c.kind === 1).map(c => c.id);
-}
-
-function sampleNow() {
-    const rates = flowData.getLiveRates();
-    const clouds = flowData.getCloudStats();
-
-    let dlBps = 0, ulBps = 0;
-    for (const id of wanLinkIds) {
-        const r = rates[id];
-        if (!r) continue;
-        dlBps += r.downstreamBps || 0;
-        ulBps += r.upstreamBps || 0;
-    }
-
-    // ISP: best (lowest) RTT across ISP clouds, matching stat card logic
-    let ispRtt = null;
-    let ispLoss = null;
-    for (const id of ispCloudIds) {
-        const c = clouds[id];
-        if (!c) continue;
-        if (c.rttAvgMs != null && (ispRtt === null || c.rttAvgMs < ispRtt)) {
-            ispRtt = c.rttAvgMs;
-            ispLoss = c.lossPercent;
-        }
-    }
-
-    // Transit: mean RTT across transit clouds, matching stat card logic
-    const transitRtts = [];
-    const transitLosses = [];
-    for (const id of transitCloudIds) {
-        const c = clouds[id];
-        if (!c) continue;
-        if (c.rttAvgMs != null) transitRtts.push(c.rttAvgMs);
-        if (c.lossPercent != null) transitLosses.push(c.lossPercent);
-    }
-    const transitRtt = transitRtts.length > 0
-        ? transitRtts.reduce((a, b) => a + b, 0) / transitRtts.length : null;
-    const transitLoss = transitLosses.length > 0
-        ? transitLosses.reduce((a, b) => a + b, 0) / transitLosses.length : null;
-
-    // Mean of ISP and Transit RTT (new combined metric)
-    let meanRtt = null;
-    if (ispRtt != null && transitRtt != null) meanRtt = (ispRtt + transitRtt) / 2;
-    else if (ispRtt != null) meanRtt = ispRtt;
-    else if (transitRtt != null) meanRtt = transitRtt;
-
-    let meanLoss = null;
-    if (ispLoss != null && transitLoss != null) meanLoss = (ispLoss + transitLoss) / 2;
-    else if (ispLoss != null) meanLoss = ispLoss;
-    else if (transitLoss != null) meanLoss = transitLoss;
-
-    return {
-        time: Date.now(),
-        download: dlBps,
-        upload: ulBps,
-        loss: meanLoss,
-        rtt: meanRtt,
-    };
-}
-
-function pushAndUpdate() {
-    if (!wanLinkIds.length && !ispCloudIds.length && !transitCloudIds.length) return;
-
-    const pt = sampleNow();
-    buffer.push(pt);
-    if (buffer.length > MAX_POINTS) buffer = buffer.slice(-MAX_POINTS);
-
-    if (!chart) return;
-
+function updateChart() {
+    if (!chart || buffer.length === 0) return;
     chart.updateSeries([
         { name: 'Download', data: buffer.map(p => ({ x: p.time, y: p.download })) },
         { name: 'Upload',   data: buffer.map(p => ({ x: p.time, y: p.upload })) },
@@ -216,13 +133,91 @@ function pushAndUpdate() {
     ], false);
 }
 
-function onFlowEvent(event) {
-    if (event === 'snapshot') {
-        indexTopology();
-        pushAndUpdate();
-    } else if (event === 'live') {
-        pushAndUpdate();
+async function loadHistory() {
+    const to = new Date();
+    const from = new Date(to.getTime() - HISTORY_MINUTES * 60000);
+    const qFrom = from.toISOString();
+    const qTo = to.toISOString();
+
+    const [wanResp, ispResp, transitResp] = await Promise.all([
+        fetch(`/api/monitoring/wan-rate-chart?from=${qFrom}&to=${qTo}`, { credentials: 'same-origin' }).catch(() => null),
+        fetch(`/api/monitoring/chart-data?category=AccessIsp&from=${qFrom}&to=${qTo}`, { credentials: 'same-origin' }).catch(() => null),
+        fetch(`/api/monitoring/chart-data?category=Transit&from=${qFrom}&to=${qTo}`, { credentials: 'same-origin' }).catch(() => null),
+    ]);
+
+    const wan = wanResp?.ok ? await wanResp.json() : null;
+    const isp = ispResp?.ok ? await ispResp.json() : null;
+    const transit = transitResp?.ok ? await transitResp.json() : null;
+
+    // Build time-indexed maps from WAN rate data
+    const dlMap = new Map();
+    const ulMap = new Map();
+    if (wan) {
+        for (const p of (wan.download || [])) {
+            const t = new Date(p.time).getTime();
+            dlMap.set(t, p.value || 0);
+            if (!ulMap.has(t)) ulMap.set(t, 0);
+        }
+        for (const p of (wan.upload || [])) {
+            const t = new Date(p.time).getTime();
+            ulMap.set(t, p.value || 0);
+            if (!dlMap.has(t)) dlMap.set(t, 0);
+        }
     }
+
+    // Compute mean RTT/loss across ISP+Transit targets per timestamp
+    const rttMap = new Map();
+    const lossMap = new Map();
+
+    function addTargetData(data) {
+        if (!data?.targets) return;
+        for (const target of data.targets) {
+            for (const p of (target.rtt || [])) {
+                const t = new Date(p.time).getTime();
+                if (p.value == null) continue;
+                if (!rttMap.has(t)) rttMap.set(t, []);
+                rttMap.get(t).push(p.value);
+            }
+            for (const p of (target.loss || [])) {
+                const t = new Date(p.time).getTime();
+                if (p.value == null) continue;
+                if (!lossMap.has(t)) lossMap.set(t, []);
+                lossMap.get(t).push(p.value);
+            }
+        }
+    }
+    addTargetData(isp);
+    addTargetData(transit);
+
+    // Merge all timestamps and build buffer
+    const allTimes = new Set([...dlMap.keys(), ...rttMap.keys()]);
+    const sorted = [...allTimes].sort((a, b) => a - b);
+
+    buffer = sorted.map(t => ({
+        time: t,
+        download: dlMap.get(t) ?? null,
+        upload: ulMap.get(t) ?? null,
+        loss: lossMap.has(t) ? lossMap.get(t).reduce((a, b) => a + b, 0) / lossMap.get(t).length : null,
+        rtt: rttMap.has(t) ? rttMap.get(t).reduce((a, b) => a + b, 0) / rttMap.get(t).length : null,
+    }));
+}
+
+async function pollLive() {
+    try {
+        const resp = await fetch('/api/monitoring/live-stats', { credentials: 'same-origin' });
+        if (!resp.ok) return;
+        const d = await resp.json();
+        const cutoff = Date.now() - HISTORY_MINUTES * 60000;
+        buffer.push({
+            time: Date.now(),
+            download: d.downloadBps,
+            upload: d.uploadBps,
+            loss: d.lossPercent,
+            rtt: d.rttMs,
+        });
+        buffer = buffer.filter(p => p.time >= cutoff);
+        updateChart();
+    } catch { }
 }
 
 export async function mount(containerId) {
@@ -231,29 +226,20 @@ export async function mount(containerId) {
     if (!el) return;
 
     buffer = [];
-    wanLinkIds = [];
-    ispCloudIds = [];
-    transitCloudIds = [];
-
     if (chart) { chart.destroy(); chart = null; }
 
     chart = new ApexCharts(el, buildOpts());
     await chart.render();
 
-    indexTopology();
-    if (wanLinkIds.length || ispCloudIds.length || transitCloudIds.length) {
-        pushAndUpdate();
-    }
+    await loadHistory();
+    updateChart();
 
-    unsub = flowData.subscribe(onFlowEvent);
+    pollTimer = setInterval(pollLive, POLL_MS);
 }
 
 export function unmount() {
-    if (unsub) { unsub(); unsub = null; }
+    if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     if (chart) { chart.destroy(); chart = null; }
     buffer = [];
-    wanLinkIds = [];
-    ispCloudIds = [];
-    transitCloudIds = [];
     elId = null;
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -108,7 +108,7 @@ function buildOpts() {
         grid: {
             borderColor: '#374151',
             strokeDashArray: 3,
-            padding: { left: 3, right: -10, top: -8, bottom: 0 },
+            padding: { left: 3, right: -12, top: -8, bottom: 0 },
             xaxis: { lines: { show: false } },
         },
         legend: { show: false },

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -27,7 +27,7 @@ function formatBps(v) {
 function buildOpts() {
     return {
         chart: {
-            type: 'line',
+            type: 'area',
             height: 175,
             background: 'transparent',
             toolbar: { show: false },

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -84,7 +84,7 @@ function buildOpts() {
                 axisBorder: { show: false },
                 axisTicks: { show: false },
             },
-            { seriesName: 'Upload', show: false, min: 0 },
+            { seriesName: 'Download', show: false, min: 0 },
             {
                 seriesName: 'Loss',
                 opposite: true,

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -181,8 +181,10 @@ async function pollLive() {
 }
 
 export async function mount(containerId, opts) {
+    if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+    if (chart) { chart.destroy(); chart = null; }
+    buffer = [];
     const gen = ++mountGen;
-    unmount();
     elId = containerId;
     const el = document.getElementById(containerId);
     if (!el) return;

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -1,0 +1,245 @@
+// WAN live chart — real-time area+line chart fed by lan-flow-data.js pub/sub.
+// Shows download, upload, packet loss, and mean ISP/transit RTT as a rolling
+// ~5-minute window. Mounted from Blazor in LiveViewPanel and Monitoring Live tab.
+
+import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
+import * as flowData from './lan-flow-data.js?v=1';
+
+const MAX_POINTS = 100;
+const COLOR_DL    = '#3b82f6';
+const COLOR_UL    = '#10b981';
+const COLOR_LOSS  = '#ef4444';
+const COLOR_RTT   = '#d946ef';
+
+let chart = null;
+let unsub = null;
+let wanLinkIds = [];
+let ispCloudIds = [];
+let transitCloudIds = [];
+let buffer = [];
+let elId = null;
+
+function formatBps(v) {
+    if (v == null || v < 1) return '0';
+    if (v >= 1e9) return (v / 1e9).toFixed(1) + ' Gbps';
+    if (v >= 1e6) return (v / 1e6).toFixed(1) + ' Mbps';
+    if (v >= 1e3) return (v / 1e3).toFixed(0) + ' Kbps';
+    return v.toFixed(0) + ' bps';
+}
+
+function buildOpts() {
+    return {
+        chart: {
+            type: 'area',
+            height: 175,
+            background: 'transparent',
+            toolbar: { show: false },
+            zoom: { enabled: false },
+            animations: { enabled: true, easing: 'smooth', dynamicAnimation: { speed: 800 } },
+            sparkline: { enabled: false },
+        },
+        series: [
+            { name: 'Download',  type: 'area', data: [] },
+            { name: 'Upload',    type: 'area', data: [] },
+            { name: 'Loss',      type: 'area', data: [] },
+            { name: 'RTT',       type: 'line', data: [] },
+        ],
+        colors: [COLOR_DL, COLOR_UL, COLOR_LOSS, COLOR_RTT],
+        stroke: {
+            curve: 'smooth',
+            width: [2, 2, 1.5, 2],
+            dashArray: [0, 0, 0, 6],
+        },
+        fill: {
+            type: ['gradient', 'gradient', 'gradient', 'none'],
+            gradient: {
+                shadeIntensity: 0.4,
+                opacityFrom: [0.45, 0.35, 0.5, 0],
+                opacityTo:   [0.05, 0.05, 0.05, 0],
+                stops: [0, 95],
+            },
+        },
+        markers: { size: 0 },
+        dataLabels: { enabled: false },
+        xaxis: {
+            type: 'datetime',
+            labels: {
+                show: true,
+                style: { colors: '#64748b', fontSize: '10px' },
+                datetimeUTC: false,
+                datetimeFormatter: { hour: 'HH:mm', minute: 'HH:mm:ss' },
+            },
+            axisBorder: { show: false },
+            axisTicks: { show: false },
+        },
+        yaxis: [
+            {
+                seriesName: 'Download',
+                min: 0,
+                labels: {
+                    style: { colors: '#9ca3af', fontSize: '10px' },
+                    formatter: v => formatBps(v),
+                    offsetX: -4,
+                },
+                axisBorder: { show: false },
+                axisTicks: { show: false },
+                title: { text: undefined },
+            },
+            {
+                seriesName: 'Upload',
+                show: false,
+                min: 0,
+            },
+            {
+                seriesName: 'Loss',
+                opposite: true,
+                show: false,
+                min: 0,
+                max: v => Math.max(v * 1.2, 2),
+            },
+            {
+                seriesName: 'RTT',
+                opposite: true,
+                min: 0,
+                labels: {
+                    style: { colors: '#9ca3af', fontSize: '10px' },
+                    formatter: v => v != null ? v.toFixed(0) + ' ms' : '',
+                    offsetX: 4,
+                },
+                axisBorder: { show: false },
+                axisTicks: { show: false },
+                title: { text: undefined },
+            },
+        ],
+        grid: {
+            borderColor: '#374151',
+            strokeDashArray: 3,
+            padding: { left: 4, right: 4, top: -8, bottom: 0 },
+            xaxis: { lines: { show: false } },
+        },
+        legend: {
+            show: true,
+            position: 'top',
+            horizontalAlign: 'center',
+            floating: true,
+            offsetY: -4,
+            fontSize: '11px',
+            labels: { colors: '#9ca3af' },
+            markers: { size: 4, offsetX: -2 },
+            itemMargin: { horizontal: 8 },
+            customLegendItems: ['Download', 'Upload', 'Loss', 'RTT'],
+        },
+        tooltip: {
+            theme: 'dark',
+            shared: true,
+            x: { format: 'HH:mm:ss' },
+            y: [
+                { formatter: v => formatBps(v) },
+                { formatter: v => formatBps(v) },
+                { formatter: v => v != null ? v.toFixed(2) + '%' : '-' },
+                { formatter: v => v != null ? v.toFixed(1) + ' ms' : '-' },
+            ],
+        },
+        noData: { text: 'Waiting for data...', style: { color: '#64748b', fontSize: '13px' } },
+    };
+}
+
+function indexTopology() {
+    const snap = flowData.getSnapshot();
+    if (!snap) return;
+    wanLinkIds = (snap.links || []).filter(l => l.kind === 3).map(l => l.id);
+    ispCloudIds = (snap.clouds || []).filter(c => c.kind === 0).map(c => c.id);
+    transitCloudIds = (snap.clouds || []).filter(c => c.kind === 1).map(c => c.id);
+}
+
+function sampleNow() {
+    const rates = flowData.getLiveRates();
+    const clouds = flowData.getCloudStats();
+
+    let dlBps = 0, ulBps = 0;
+    for (const id of wanLinkIds) {
+        const r = rates[id];
+        if (!r) continue;
+        dlBps += r.downstreamBps || 0;
+        ulBps += r.upstreamBps || 0;
+    }
+
+    const rttVals = [];
+    const lossVals = [];
+    for (const id of [...ispCloudIds, ...transitCloudIds]) {
+        const c = clouds[id];
+        if (!c) continue;
+        if (c.rttAvgMs != null) rttVals.push(c.rttAvgMs);
+        if (c.lossPercent != null) lossVals.push(c.lossPercent);
+    }
+
+    const meanRtt = rttVals.length > 0 ? rttVals.reduce((a, b) => a + b, 0) / rttVals.length : null;
+    const meanLoss = lossVals.length > 0 ? lossVals.reduce((a, b) => a + b, 0) / lossVals.length : null;
+
+    return {
+        time: Date.now(),
+        download: dlBps,
+        upload: ulBps,
+        loss: meanLoss,
+        rtt: meanRtt,
+    };
+}
+
+function pushAndUpdate() {
+    if (!wanLinkIds.length && !ispCloudIds.length && !transitCloudIds.length) return;
+
+    const pt = sampleNow();
+    buffer.push(pt);
+    if (buffer.length > MAX_POINTS) buffer = buffer.slice(-MAX_POINTS);
+
+    if (!chart) return;
+
+    chart.updateSeries([
+        { name: 'Download', data: buffer.map(p => ({ x: p.time, y: p.download })) },
+        { name: 'Upload',   data: buffer.map(p => ({ x: p.time, y: p.upload })) },
+        { name: 'Loss',     data: buffer.map(p => ({ x: p.time, y: p.loss })) },
+        { name: 'RTT',      data: buffer.map(p => ({ x: p.time, y: p.rtt })) },
+    ], false);
+}
+
+function onFlowEvent(event) {
+    if (event === 'snapshot') {
+        indexTopology();
+        pushAndUpdate();
+    } else if (event === 'live') {
+        pushAndUpdate();
+    }
+}
+
+export async function mount(containerId) {
+    elId = containerId;
+    const el = document.getElementById(containerId);
+    if (!el) return;
+
+    buffer = [];
+    wanLinkIds = [];
+    ispCloudIds = [];
+    transitCloudIds = [];
+
+    if (chart) { chart.destroy(); chart = null; }
+
+    chart = new ApexCharts(el, buildOpts());
+    await chart.render();
+
+    indexTopology();
+    if (wanLinkIds.length || ispCloudIds.length || transitCloudIds.length) {
+        pushAndUpdate();
+    }
+
+    unsub = flowData.subscribe(onFlowEvent);
+}
+
+export function unmount() {
+    if (unsub) { unsub(); unsub = null; }
+    if (chart) { chart.destroy(); chart = null; }
+    buffer = [];
+    wanLinkIds = [];
+    ispCloudIds = [];
+    transitCloudIds = [];
+    elId = null;
+}

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -107,7 +107,7 @@ function buildOpts() {
         grid: {
             borderColor: '#374151',
             strokeDashArray: 3,
-            padding: { left: 3, right: -5, top: -8, bottom: 0 },
+            padding: { left: 3, right: -10, top: -8, bottom: 0 },
             xaxis: { lines: { show: false } },
         },
         legend: { show: false },

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -191,6 +191,7 @@ export async function mount(containerId, opts) {
     await chart.render();
 
     await loadHistory();
+    await pollLive();
     updateChart();
     const interval = opts?.pollMs || POLL_MS;
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -99,7 +99,7 @@ function buildOpts() {
                 labels: {
                     style: { colors: '#9ca3af', fontSize: '10px' },
                     formatter: v => v != null ? v.toFixed(0) + ' ms' : '',
-                    offsetX: -10,
+                    offsetX: -4,
                 },
                 axisBorder: { show: false },
                 axisTicks: { show: false },

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -107,7 +107,7 @@ function buildOpts() {
         grid: {
             borderColor: '#374151',
             strokeDashArray: 3,
-            padding: { left: 4, right: -5, top: -8, bottom: 0 },
+            padding: { left: 3, right: -5, top: -8, bottom: 0 },
             xaxis: { lines: { show: false } },
         },
         legend: { show: false },

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -60,6 +60,8 @@ function buildOpts() {
         dataLabels: { enabled: false },
         xaxis: {
             type: 'datetime',
+            min: Date.now() - HISTORY_MINUTES * 60000,
+            max: Date.now(),
             labels: {
                 show: true,
                 style: { colors: '#64748b', fontSize: '10px' },
@@ -126,6 +128,10 @@ function buildOpts() {
 
 function updateChart() {
     if (!chart || buffer.length === 0) return;
+    const now = Date.now();
+    chart.updateOptions({
+        xaxis: { min: now - HISTORY_MINUTES * 60000, max: now },
+    }, false, false, false);
     chart.updateSeries([
         { name: 'Download', data: buffer.map(p => ({ x: p.time, y: p.download })) },
         { name: 'Upload',   data: buffer.map(p => ({ x: p.time, y: p.upload })) },

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -179,7 +179,7 @@ async function pollLive() {
     } catch { }
 }
 
-export async function mount(containerId) {
+export async function mount(containerId, opts) {
     elId = containerId;
     const el = document.getElementById(containerId);
     if (!el) return;
@@ -192,8 +192,9 @@ export async function mount(containerId) {
 
     await loadHistory();
     updateChart();
+    const interval = opts?.pollMs || POLL_MS;
 
-    pollTimer = setInterval(pollLive, POLL_MS);
+    pollTimer = setInterval(pollLive, interval);
 }
 
 export function unmount() {


### PR DESCRIPTION
## Summary

- **Live WAN chart** on Dashboard Live panel and Monitoring Live tab - real-time ApexCharts area+line chart showing download (blue), upload (green), packet loss (red), and mean ISP/transit RTT (magenta dashed). Pre-loads 5 min history from InfluxDB, then polls live stats every 3s with a fixed sliding time window.

- **Clickable stat cards** - Gateway RTT/Loss links to Performance tab (Fabric category, gateway pre-selected), ISP/Transit RTT/Loss to their respective categories, Gateway CPU/Memory/Temp to Device Stats with gateway pre-selected. Works from both Dashboard and Monitoring pages.

- **Map swap buttons** - Icon button on 3D and 2D map card headers to swap their display order, persisted to SystemSettings. Reloads page on swap for clean remount.

- **Dashboard map mode: Off** - The 2D/3D toggle in dashboard edit mode now cycles 2D -> 3D -> Off. Off hides the map entirely, showing just stat cards and the WAN chart.

- **Add to Dashboard button** - Shows on Monitoring Live tab when Live View isn't on the dashboard. Enables the card and moves it to position 0. Handles missing card edge case.

- **New API endpoints** - `GET /api/monitoring/live-stats` (lightweight current WAN rates + mean ISP/Transit RTT/loss from in-memory cache) and `GET /api/monitoring/wan-live-chart-data` (pre-merged history for chart pre-load).

- **RTT smoothing** - InfluxDB query aggregates per target_type with fill-forward, then applies 60s timedMovingAverage. Both live and historical use mean ISP + mean Transit (consistent logic). Only enabled targets are queried.

- **Target cache** - ISP/Transit target list cached in MonitoringLiveStats singleton with 30s TTL, avoiding DB queries on every 3s chart poll.

- **Mount/unmount race fix** - Generation counter prevents stale unmount (from Dashboard dispose) from destroying a chart that Monitoring just mounted.

- **Tab navigation fix** - Stat card deep-links now work from bare `/monitoring` URL (without `?tab=` param).

- **JS chart APIs** - Added `setCategory()`/`soloTarget()` to latency-charts.js and `soloDevice()` to device-health-charts.js for deep-link pre-selection.

## Test plan

- [x] Dashboard: Live panel shows WAN chart with all four series, chart fills horizontal space
- [x] Monitoring Live: same chart appears, stat cards clickable and navigate to correct tabs with pre-selection
- [x] Stat card links work from both `/monitoring` and `/monitoring?tab=live`
- [x] Map swap button swaps 3D/2D order and persists across page loads
- [x] Add to Dashboard button appears only when Live View is hidden, adds it to top
- [x] Flip between Dashboard and Monitoring - chart mounts/unmounts cleanly without stuck "Loading..."
- [x] RTT historical line is smooth, not sawtoothed
- [x] Download and upload share the same Y-axis scale
- [x] Disabling a target excludes it from both live and historical RTT
- [x] Dashboard map mode cycles 2D -> 3D -> Off, Off hides map but keeps stats and chart