### PR TITLE
v1.18.0 final changes

### DIFF
--- a/src/NetworkOptimizer.Web/Services/CellularModemService.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemService.cs
@@ -218,8 +218,7 @@ public class CellularModemService : ICellularModemService
 
             if (stats != null)
             {
-                // Update LastPolled in database
-                await UpdateModemConfigAsync(modem.Id, null);
+                await UpdateModemConfigAsync(modem.Id, null, success: true);
 
                 lock (_lock)
                 {
@@ -234,14 +233,14 @@ public class CellularModemService : ICellularModemService
             }
             else
             {
-                await UpdateModemConfigAsync(modem.Id, "Poll returned no data");
+                await UpdateModemConfigAsync(modem.Id, "Poll returned no data", success: false);
                 return (false, "Failed to poll modem - no data returned");
             }
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error refreshing modem {Name}", modem.Name);
-            await UpdateModemConfigAsync(modem.Id, ex.Message);
+            await UpdateModemConfigAsync(modem.Id, ex.Message, success: false);
             return (false, $"Error: {ex.Message}");
         }
     }
@@ -336,7 +335,7 @@ public class CellularModemService : ICellularModemService
         }
     }
 
-    private async Task UpdateModemConfigAsync(int modemId, string? error)
+    private async Task UpdateModemConfigAsync(int modemId, string? error, bool success)
     {
         try
         {
@@ -346,7 +345,8 @@ public class CellularModemService : ICellularModemService
             var config = await repository.GetModemConfigurationAsync(modemId);
             if (config != null)
             {
-                config.LastPolled = DateTime.UtcNow;
+                if (success)
+                    config.LastPolled = DateTime.UtcNow;
                 config.LastError = error;
                 config.UpdatedAt = DateTime.UtcNow;
                 await repository.SaveModemConfigurationAsync(config);

--- a/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
@@ -282,6 +282,15 @@ function shiftWindow(container, direction) {
 }
 
 export async function mount(elId) {
+    // Reset all state in case unmount didn't complete (Blazor Dispose race)
+    stopPoll();
+    currentRangeHours = 24;
+    windowOffset = 0;
+    isCustomRange = false;
+    customFrom = null;
+    customTo = null;
+    modemMeta = [];
+    visibility = {};
     containerId = elId;
     const container = document.getElementById(elId);
     if (!container) return;
@@ -393,10 +402,18 @@ export function soloModem(modemId) {
 export function unmount() {
     stopPoll();
     if (visibilityObserver) { visibilityObserver.disconnect(); visibilityObserver = null; }
+    if (fetchController) { fetchController.abort(); fetchController = null; }
     if (rsrpChart) { rsrpChart.destroy(); rsrpChart = null; }
     if (rsrqChart) { rsrqChart.destroy(); rsrqChart = null; }
     if (snrChart) { snrChart.destroy(); snrChart = null; }
     if (qualityChart) { qualityChart.destroy(); qualityChart = null; }
+    containerId = null;
     modemMeta = [];
     visibility = {};
+    currentRangeHours = 24;
+    windowOffset = 0;
+    isCustomRange = false;
+    customFrom = null;
+    customTo = null;
+    isInViewport = true;
 }


### PR DESCRIPTION
More fixes for cellular monitoring. See [v1.18.0 release notes](https://github.com/Ozark-Connect/NetworkOptimizer/releases/tag/v1.18.0) for what's new in v1.18.0+

## Fixes

- **Faster modem recovery after connection loss** - Failed polls no longer update LastPolled, so the timer retries on the next tick instead of waiting the full polling interval. Previously, SSH failures during modem reboots could create extended data gaps.
- **Cellular chart time range reset** - Navigating to the Cellular Stats tab from the dashboard now correctly shows the 24h view instead of persisting the previous session's time range selection. Matches the existing SFP chart behavior.