### PR TITLE
v1.18.1

### DIFF
--- a/docker/openspeedtest/entrypoint.sh
+++ b/docker/openspeedtest/entrypoint.sh
@@ -76,9 +76,19 @@ else
     echo "Warning: config.js not found at $CONFIG_FILE"
 fi
 
+# Strip IPv6 listen directive if IPv6 is not available on the host.
+# Kernels with net.ipv6.conf.all.disable_ipv6=1 don't create /proc/net/if_inet6,
+# and nginx will refuse to start if it can't bind [::].
+NGINX_CONF="/etc/nginx/conf.d/default.conf"
+if [ ! -f /proc/net/if_inet6 ]; then
+    sed -i '/listen \[::\]/d' "$NGINX_CONF"
+    echo "IPv6 not available on host - binding IPv4 only"
+else
+    echo "IPv6 available - binding dual-stack"
+fi
+
 # Enforce canonical URL via 302 redirect (matches UI logic exactly)
 # Prevents browser caching issues on mobile
-NGINX_CONF="/etc/nginx/conf.d/default.conf"
 OST_PORT="${OPENSPEEDTEST_PORT:-3005}"
 OST_HTTPS_PORT="${OPENSPEEDTEST_HTTPS_PORT:-443}"
 

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
@@ -845,8 +845,10 @@
         if (string.IsNullOrEmpty(openSpeedTestHost))
             openSpeedTestHost = hostName;
 
-        // Build health check URL - use 127.0.0.1 explicitly (localhost can resolve to IPv6 on Windows)
-        openSpeedTestHealthCheckUrl = $"http://127.0.0.1:{openSpeedTestPort}";
+        // Build health check URL - use HOST_IP when set (handles bridge networking where port is bound
+        // to a specific IP), fall back to 127.0.0.1 (not "localhost" which can resolve to IPv6 on Windows)
+        var healthCheckHost = !string.IsNullOrEmpty(hostIp) ? hostIp : "127.0.0.1";
+        openSpeedTestHealthCheckUrl = $"http://{healthCheckHost}:{openSpeedTestPort}";
 
         // Set serverHost for iperf3 instructions (main app host, not speedtest UI host)
         // Priority: HOST_NAME > HOST_IP > auto-detected IP from network interface

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -895,18 +895,24 @@ from(bucket: ""{_bucket}"")
             targetFilter = $"\n  |> filter(fn: (r) => {idFilter})";
         }
         var flux = $@"
-from(bucket: ""{_bucket}"")
+base = from(bucket: ""{_bucket}"")
   |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
   |> filter(fn: (r) => r._measurement == ""latency"")
   |> filter(fn: (r) => r.target_type == ""accessisp"" or r.target_type == ""transit""){targetFilter}
-  |> filter(fn: (r) => r._field == ""rtt_avg_ms"" or r._field == ""loss_percent"")
-  |> group(columns: [""target_type"", ""_field""])
+
+rtt = base
+  |> filter(fn: (r) => r._field == ""rtt_avg_ms"")
+  |> group(columns: [""_field""])
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: true)
   |> fill(usePrevious: true)
-  |> group(columns: [""_time"", ""_field""])
-  |> mean()
-  |> group(columns: [""_field""])
   |> timedMovingAverage(every: {ToFluxDuration(window)}, period: {ToFluxDuration(smoothWindow)})
+
+loss = base
+  |> filter(fn: (r) => r._field == ""loss_percent"")
+  |> group(columns: [""_field""])
+  |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
+
+union(tables: [rtt, loss])
   |> group()
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -90,7 +90,7 @@ function buildOpts() {
                 opposite: true,
                 show: false,
                 min: 0,
-                max: v => Math.max(v * 1.2, 2),
+                max: v => Math.max(v * 1.2, 5),
             },
             {
                 seriesName: 'RTT',

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace NetworkOptimizer.Audit.Tests.Dns;
 
+[Collection("ThirdPartyDns")]
 public class DnsSecurityAnalyzerTests : IDisposable
 {
     private readonly DnsSecurityAnalyzer _analyzer;

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/ThirdPartyDnsDetectorTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/ThirdPartyDnsDetectorTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace NetworkOptimizer.Audit.Tests.Dns;
 
+[Collection("ThirdPartyDns")]
 public class ThirdPartyDnsDetectorTests : IDisposable
 {
     private readonly Mock<ILogger<ThirdPartyDnsDetector>> _loggerMock;


### PR DESCRIPTION
Placeholder for next release. Changes so far:

- Flat-average packet loss across all WAN monitoring targets
- Remove smoothing from loss series on WAN live chart
- Raise loss Y-axis minimum range to 5%
- Fix speedtest container failing to start on hosts with IPv6 disabled (#724)
- Fix OpenSpeedTest health check failing on bridge networking setups (#724)
- Fix flaky DNS test classes with shared static state