### PR TITLE
Skip IPv6 listen when host has IPv6 disabled

### DIFF
--- a/docker/openspeedtest/entrypoint.sh
+++ b/docker/openspeedtest/entrypoint.sh
@@ -76,9 +76,19 @@ else
     echo "Warning: config.js not found at $CONFIG_FILE"
 fi
 
+# Strip IPv6 listen directive if IPv6 is not available on the host.
+# Kernels with net.ipv6.conf.all.disable_ipv6=1 don't create /proc/net/if_inet6,
+# and nginx will refuse to start if it can't bind [::].
+NGINX_CONF="/etc/nginx/conf.d/default.conf"
+if [ ! -f /proc/net/if_inet6 ]; then
+    sed -i '/listen \[::\]/d' "$NGINX_CONF"
+    echo "IPv6 not available on host - binding IPv4 only"
+else
+    echo "IPv6 available - binding dual-stack"
+fi
+
 # Enforce canonical URL via 302 redirect (matches UI logic exactly)
 # Prevents browser caching issues on mobile
-NGINX_CONF="/etc/nginx/conf.d/default.conf"
 OST_PORT="${OPENSPEEDTEST_PORT:-3005}"
 OST_HTTPS_PORT="${OPENSPEEDTEST_HTTPS_PORT:-443}"
 


### PR DESCRIPTION
Reported in #724

## Summary

- Speedtest container's nginx binds both IPv4 and IPv6 (`listen [::]:3000`), which causes nginx to fail to start on hosts with IPv6 disabled (`net.ipv6.conf.all.disable_ipv6=1`)
- Detect IPv6 availability via `/proc/net/if_inet6` in the entrypoint and strip the IPv6 listen directive if unavailable
- Affects Docker deployments (NAS, external WAN VPS, user installs) - Windows installer and Mac native already bind IPv4-only

## Test plan

- [x] Deployed to NAS - logs show "IPv6 available - binding dual-stack", container starts normally
- [ ] Verify on a host with IPv6 disabled - should log "IPv6 not available on host - binding IPv4 only" and start successfully