### PR TITLE
Fix config import corrupting database on restart

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -2080,7 +2080,7 @@
                                     <span class="text-muted">Export type:</span>
                                     <span>@(importPreview.ExportType == "Full" ? "Full backup" : "Settings only")</span>
                                     <span class="text-muted">Export date:</span>
-                                    <span>@importPreview.ExportDate.ToString("MMM d, yyyy h:mm tt") UTC</span>
+                                    <span>@importPreview.ExportDate.ToLocalTime().ToString("MMM d, yyyy h:mm tt")</span>
                                     <span class="text-muted">App version:</span>
                                     <span>@importPreview.AppVersion</span>
                                     @if (importPreview.TableCounts.Count > 0)

--- a/src/NetworkOptimizer.Web/Services/ConfigTransferService.cs
+++ b/src/NetworkOptimizer.Web/Services/ConfigTransferService.cs
@@ -331,9 +331,24 @@ public class ConfigTransferService
                 _logger.LogDebug("DB after history preservation: {Size} bytes (was {OriginalSize})", afterHistorySize, importedDbSize);
             }
 
-            // Replace files
+            // Replace files - must delete WAL/SHM BEFORE replacing the DB file.
+            // SQLite WAL contains page-level operations from the old database; if
+            // present when the new DB is opened, SQLite replays them against wrong
+            // pages and corrupts the schema.
             var targetDbPath = Path.Combine(_dataDirectory, "network_optimizer.db");
             _logger.LogDebug("Replacing DB: {Target}", targetDbPath);
+            var walPath = targetDbPath + "-wal";
+            var shmPath = targetDbPath + "-shm";
+            if (File.Exists(walPath))
+            {
+                File.Delete(walPath);
+                _logger.LogDebug("Deleted stale WAL file");
+            }
+            if (File.Exists(shmPath))
+            {
+                File.Delete(shmPath);
+                _logger.LogDebug("Deleted stale SHM file");
+            }
             File.Copy(importedDbPath, targetDbPath, overwrite: true);
             _logger.LogDebug("DB replaced successfully");
 


### PR DESCRIPTION
## Summary

- Config import replaced the .db file but left stale WAL/SHM files from the previous database in place. On restart, SQLite replayed the old WAL against the new DB file, corrupting the schema and crash-looping the app.
- Now deletes WAL and SHM files before copying the imported database.

## Test plan

- [x] Reproduced on NAS - config export then import caused `SQLite Error 11: 'malformed database schema'` crash loop
- [x] Applied fix, re-tested export/import cycle - app restarts cleanly
- [x] Verified imported DB schema and row counts match the pre-import backup
- [x] All 4282 tests pass, zero build warnings