### PR TITLE
Handle missing InfluxDB buckets gracefully

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -386,6 +386,16 @@ else
     @* ──────────────── Tab: SFP Stats ──────────────── *@
     @if (_activeTab == "sfp" && _monitoringReady)
     {
+        @if (_influxReachable == false)
+        {
+            <div class="alert alert-warning" style="margin-bottom: 1rem;">
+                <strong>InfluxDB: @ShortInfluxStatus()</strong> — SFP chart data is unavailable. Check the <a href="javascript:void(0)" @onclick='() => SetActiveTab("setup")' @onclick:preventDefault>Setup</a> tab to review connection status.
+                @if (!string.IsNullOrEmpty(_influxError))
+                {
+                    <div style="margin-top: 0.25rem; font-size: 0.85rem; opacity: 0.8;">@_influxError</div>
+                }
+            </div>
+        }
         <SfpModulesCard AllSfps="_allSfps" Targets="_targets" DeviceIpByMac="_deviceIpByMac" OnSfpChanged="OnSfpChanged" />
 
         @if (_monitoredSfps.Count > 0)
@@ -463,6 +473,16 @@ else
     @* ──────────────── Tab: Cellular Stats ──────────────── *@
     @if (_activeTab == "cellular" && _monitoringReady)
     {
+        @if (_influxReachable == false)
+        {
+            <div class="alert alert-warning" style="margin-bottom: 1rem;">
+                <strong>InfluxDB: @ShortInfluxStatus()</strong> — Cellular chart data is unavailable. Check the <a href="javascript:void(0)" @onclick='() => SetActiveTab("setup")' @onclick:preventDefault>Setup</a> tab to review connection status.
+                @if (!string.IsNullOrEmpty(_influxError))
+                {
+                    <div style="margin-top: 0.25rem; font-size: 0.85rem; opacity: 0.8;">@_influxError</div>
+                }
+            </div>
+        }
         <div class="card" style="margin-top: 1.5rem;" id="cellular-charts-container">
             <div class="card-header" style="flex-wrap: wrap; gap: 0.75rem;">
                 <h2 class="card-title">Cellular Signal History</h2>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1119,6 +1119,10 @@ else
         if (_influxError.Contains("unauthorized", StringComparison.OrdinalIgnoreCase)) return "Auth error";
         if (_influxError.Contains("refused", StringComparison.OrdinalIgnoreCase)) return "Connection refused";
         if (_influxError.Contains("timeout", StringComparison.OrdinalIgnoreCase)) return "Timeout";
+        if (_influxError.Contains("bucket", StringComparison.OrdinalIgnoreCase)
+            && _influxError.Contains("not found", StringComparison.OrdinalIgnoreCase)) return "Bucket not found";
+        if (_influxError.Contains("organization", StringComparison.OrdinalIgnoreCase)
+            && _influxError.Contains("not found", StringComparison.OrdinalIgnoreCase)) return "Org not found";
         return "Unreachable";
     }
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -193,11 +193,19 @@ public class MonitoringInfluxClient : IAsyncDisposable
                 return new InfluxHealthResult(false, "InfluxDB ping returned false");
             }
 
-            var flux = $@"from(bucket: ""{_bucket}"") |> range(start: -1m) |> limit(n: 1)";
             var queryApi = _client.GetQueryApi();
-            // QueryAsync throws on auth or missing-bucket errors. We don't care about the
-            // result, only that the call succeeds.
+
+            // Probe the primary bucket
+            var flux = $@"from(bucket: ""{_bucket}"") |> range(start: -1m) |> limit(n: 1)";
             await queryApi.QueryAsync(flux, _org, ct);
+
+            // Probe the longterm bucket too - SFP/modem charts query it and users
+            // get confused by 500s when only this one is missing.
+            if (!string.IsNullOrEmpty(_longtermBucket) && _longtermBucket != _bucket)
+            {
+                var ltFlux = $@"from(bucket: ""{_longtermBucket}"") |> range(start: -1m) |> limit(n: 1)";
+                await queryApi.QueryAsync(ltFlux, _org, ct);
+            }
 
             await PersistHealthAsync(true, null, ct);
             return new InfluxHealthResult(true, null);
@@ -1189,9 +1197,23 @@ from(bucket: ""{_longtermBucket}"")
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
     {
         if (_client == null || string.IsNullOrEmpty(_org)) yield break;
-        var queryApi = _client.GetQueryApi();
-        // Use the streaming overload so large windows don't materialize entirely in memory.
-        var tables = await queryApi.QueryAsync(flux, _org, ct);
+
+        List<InfluxDB.Client.Core.Flux.Domain.FluxTable> tables;
+        try
+        {
+            var queryApi = _client.GetQueryApi();
+            tables = await queryApi.QueryAsync(flux, _org, ct);
+        }
+        catch (Exception ex) when (
+            ex is InfluxDB.Client.Core.Exceptions.NotFoundException
+            or InfluxDB.Client.Core.Exceptions.BadRequestException
+            or InfluxDB.Client.Core.Exceptions.UnauthorizedException)
+        {
+            _logger.LogWarning("InfluxDB query failed ({Error}) — check Settings > Monitoring", ex.Message);
+            _ = PersistHealthAsync(false, ex.Message, CancellationToken.None);
+            yield break;
+        }
+
         foreach (var table in tables)
             foreach (var record in table.Records)
                 yield return record;


### PR DESCRIPTION
## Summary

- **InfluxDB query errors no longer crash the app with 500s** - Missing buckets, wrong org names, or revoked tokens in query paths now return empty data and mark InfluxDB as unhealthy, instead of throwing unhandled exceptions.
- **Health check probes both buckets** - Previously only checked the primary bucket, so a missing longterm bucket showed green health while SFP/modem charts were broken.
- **Warning banners on SFP and Cellular tabs** - When InfluxDB is unhealthy, both tabs show a banner with the specific error and a link to the Setup tab.
- **Better status labels** - "Bucket not found" and "Org not found" now show in the Setup tab instead of generic "Unreachable".

## Test plan

- [x] Rename the longterm bucket in InfluxDB and verify: health goes red, SFP/Cellular tabs show banner, no 500s in logs
- [x] Rename it back and verify: health recovers within 60s, charts load again
- [x] Verify wrong org name shows "Org not found" status