### PR TITLE
v1.18.3

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -386,6 +386,16 @@ else
     @* ──────────────── Tab: SFP Stats ──────────────── *@
     @if (_activeTab == "sfp" && _monitoringReady)
     {
+        @if (_influxReachable == false)
+        {
+            <div class="alert alert-warning" style="margin-bottom: 1rem;">
+                <strong>InfluxDB: @ShortInfluxStatus()</strong> — SFP chart data is unavailable. Check the <a href="javascript:void(0)" @onclick='() => SetActiveTab("setup")' @onclick:preventDefault>Setup</a> tab to review connection status.
+                @if (!string.IsNullOrEmpty(_influxError))
+                {
+                    <div style="margin-top: 0.25rem; font-size: 0.85rem; opacity: 0.8;">@_influxError</div>
+                }
+            </div>
+        }
         <SfpModulesCard AllSfps="_allSfps" Targets="_targets" DeviceIpByMac="_deviceIpByMac" OnSfpChanged="OnSfpChanged" />
 
         @if (_monitoredSfps.Count > 0)
@@ -463,6 +473,16 @@ else
     @* ──────────────── Tab: Cellular Stats ──────────────── *@
     @if (_activeTab == "cellular" && _monitoringReady)
     {
+        @if (_influxReachable == false)
+        {
+            <div class="alert alert-warning" style="margin-bottom: 1rem;">
+                <strong>InfluxDB: @ShortInfluxStatus()</strong> — Cellular chart data is unavailable. Check the <a href="javascript:void(0)" @onclick='() => SetActiveTab("setup")' @onclick:preventDefault>Setup</a> tab to review connection status.
+                @if (!string.IsNullOrEmpty(_influxError))
+                {
+                    <div style="margin-top: 0.25rem; font-size: 0.85rem; opacity: 0.8;">@_influxError</div>
+                }
+            </div>
+        }
         <div class="card" style="margin-top: 1.5rem;" id="cellular-charts-container">
             <div class="card-header" style="flex-wrap: wrap; gap: 0.75rem;">
                 <h2 class="card-title">Cellular Signal History</h2>
@@ -1119,6 +1139,10 @@ else
         if (_influxError.Contains("unauthorized", StringComparison.OrdinalIgnoreCase)) return "Auth error";
         if (_influxError.Contains("refused", StringComparison.OrdinalIgnoreCase)) return "Connection refused";
         if (_influxError.Contains("timeout", StringComparison.OrdinalIgnoreCase)) return "Timeout";
+        if (_influxError.Contains("bucket", StringComparison.OrdinalIgnoreCase)
+            && _influxError.Contains("not found", StringComparison.OrdinalIgnoreCase)) return "Bucket not found";
+        if (_influxError.Contains("organization", StringComparison.OrdinalIgnoreCase)
+            && _influxError.Contains("not found", StringComparison.OrdinalIgnoreCase)) return "Org not found";
         return "Unreachable";
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -483,6 +483,14 @@ else
                 }
             </div>
         }
+        else if (_influxReachable != true)
+        {
+            <div class="loading-container" style="padding: 3rem;">
+                <div class="spinner"></div>
+            </div>
+        }
+        @if (_influxReachable == true)
+        {
         <div class="card" style="margin-top: 1.5rem;" id="cellular-charts-container">
             <div class="card-header" style="flex-wrap: wrap; gap: 0.75rem;">
                 <h2 class="card-title">Cellular Signal History</h2>
@@ -539,6 +547,7 @@ else
                 </div>
             </div>
         </div>
+        }
     }
 
     @* ──────────────── Tab: Setup ──────────────── *@
@@ -2038,8 +2047,8 @@ else
             await ScrollToSfpChartsAsync();
         }
 
-        // Cellular charts - Cellular tab only
-        if (_activeTab == "cellular" && _monitoringReady && !_cellularChartsMounted)
+        // Cellular charts - Cellular tab only (wait for InfluxDB like SFP waits for module data)
+        if (_activeTab == "cellular" && _monitoringReady && _influxReachable == true && !_cellularChartsMounted)
         {
             _cellularChartsMounted = true;
             try
@@ -2054,7 +2063,7 @@ else
             }
             catch { _cellularChartsMounted = false; }
         }
-        else if (_activeTab != "cellular" && _cellularChartsMounted)
+        else if ((_activeTab != "cellular" || _influxReachable != true) && _cellularChartsMounted)
         {
             _cellularChartsMounted = false;
             try { await JS.InvokeVoidAsync("eval", "window.__cellularCharts?.unmount();"); }

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -193,11 +193,19 @@ public class MonitoringInfluxClient : IAsyncDisposable
                 return new InfluxHealthResult(false, "InfluxDB ping returned false");
             }
 
-            var flux = $@"from(bucket: ""{_bucket}"") |> range(start: -1m) |> limit(n: 1)";
             var queryApi = _client.GetQueryApi();
-            // QueryAsync throws on auth or missing-bucket errors. We don't care about the
-            // result, only that the call succeeds.
+
+            // Probe the primary bucket
+            var flux = $@"from(bucket: ""{_bucket}"") |> range(start: -1m) |> limit(n: 1)";
             await queryApi.QueryAsync(flux, _org, ct);
+
+            // Probe the longterm bucket too - SFP/modem charts query it and users
+            // get confused by 500s when only this one is missing.
+            if (!string.IsNullOrEmpty(_longtermBucket) && _longtermBucket != _bucket)
+            {
+                var ltFlux = $@"from(bucket: ""{_longtermBucket}"") |> range(start: -1m) |> limit(n: 1)";
+                await queryApi.QueryAsync(ltFlux, _org, ct);
+            }
 
             await PersistHealthAsync(true, null, ct);
             return new InfluxHealthResult(true, null);
@@ -1189,9 +1197,23 @@ from(bucket: ""{_longtermBucket}"")
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
     {
         if (_client == null || string.IsNullOrEmpty(_org)) yield break;
-        var queryApi = _client.GetQueryApi();
-        // Use the streaming overload so large windows don't materialize entirely in memory.
-        var tables = await queryApi.QueryAsync(flux, _org, ct);
+
+        List<InfluxDB.Client.Core.Flux.Domain.FluxTable> tables;
+        try
+        {
+            var queryApi = _client.GetQueryApi();
+            tables = await queryApi.QueryAsync(flux, _org, ct);
+        }
+        catch (Exception ex) when (
+            ex is InfluxDB.Client.Core.Exceptions.NotFoundException
+            or InfluxDB.Client.Core.Exceptions.BadRequestException
+            or InfluxDB.Client.Core.Exceptions.UnauthorizedException)
+        {
+            _logger.LogWarning("InfluxDB query failed ({Error}) — check Settings > Monitoring", ex.Message);
+            _ = PersistHealthAsync(false, ex.Message, CancellationToken.None);
+            yield break;
+        }
+
         foreach (var table in tables)
             foreach (var record in table.Records)
                 yield return record;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -384,8 +384,7 @@ a:hover {
     min-height: 0;
 }
 .dashboard-grid .lv-panel > .wan-live-chart-card {
-    margin-top: -0.5rem;
-    margin-bottom: -0.5rem;
+    margin: -0.5rem;
 }
 
 .card-header {
@@ -543,6 +542,16 @@ a:hover {
     .settings-container > .card,
     .audit-container > .card {
         margin-bottom: 1rem;
+    }
+
+    .dashboard-grid .lv-panel > .wan-live-chart-card {
+        padding: 0;
+        margin-left: 0;
+        margin-right: 0;
+    }
+
+    .wan-live-chart-card > .card-body {
+        margin-right: 0;
     }
 }
 
@@ -13764,6 +13773,7 @@ a.affected-client:hover {
         font-size: 0.8rem;
     }
 }
+
 
 /* Loaded Latency Legend */
 .loaded-latency-chart-wrapper {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -42,10 +42,11 @@ const LK = { Uplink:0, WiredClient:1, WifiClient:2, Wan:3, Transit:4, MeshBackha
 // ---- Layout geometry ----
 const G = {
     tierGap:     170,
+    clientTierGap:165,
     cloudGap:    220,
     infraGap:    90,
     clientCellW: 145,
-    clientCellH: 50,
+    clientCellH: 55,
     clientR:     7,
     clientCols:  6,
     maxClients:  80,
@@ -298,6 +299,7 @@ class LanFlowMap2D {
                         }else{
                             // Client churn or same topology: update data in place
                             this._updateSnapshotData(s);
+                            this._snapshot=s;
                             this._needsStaticRedraw=true;
                         }
                     }
@@ -389,7 +391,7 @@ class LanFlowMap2D {
         if(isMobile)filterTitle.addEventListener('click',()=>{filterBody.hidden=!filterBody.hidden;});
         filterBody.querySelector('.lan-flow-map-search').addEventListener('input',(e)=>{
             this._filter.text=(e.target.value||'').toLowerCase().trim();
-            this._needsStaticRedraw=true;
+            this._relayout();
             if(this._isFitted)this._fitAll();
         });
         const bandChips=[...filterBody.querySelectorAll('.lan-flow-map-chip')];
@@ -401,7 +403,7 @@ class LanFlowMap2D {
                 else{const onlyThis=this._filter.bands[b]&&bandChips.every(c=>c.dataset.band===b||!this._filter.bands[c.dataset.band]);
                     if(onlyThis){for(const c of bandChips){this._filter.bands[c.dataset.band]=true;c.classList.add('is-on');}}
                     else{this._filter.bands[b]=!this._filter.bands[b];chip.classList.toggle('is-on',this._filter.bands[b]);}}
-                this._needsStaticRedraw=true;
+                this._relayout();
                 if(this._isFitted)this._fitAll();
             });
         });
@@ -428,7 +430,7 @@ class LanFlowMap2D {
                 this._overlays[key]=!this._overlays[key];
                 row.classList.toggle('is-on',this._overlays[key]);
                 try{localStorage.setItem(this._storageKey,JSON.stringify(this._overlays));}catch{}
-                this._needsStaticRedraw=true;
+                this._relayout();
                 if(this._isFitted)this._fitAll();
             });
             ctrlBody.appendChild(row);
@@ -873,6 +875,7 @@ class LanFlowMap2D {
     // siblings apart until no depth overlaps. Guarantees zero cross-tree overlap.
 
     _buildLayout(snap){
+        this._snapshot=snap;
         const byId=new Map();
         for(const n of snap.nodes)byId.set(n.id,new TN(n));
         this._treeMap=byId;
@@ -913,6 +916,7 @@ class LanFlowMap2D {
         for(const lk of snap.links)this._edges.push({lk,fn:byId.get(lk.fromNodeId),tn:byId.get(lk.toNodeId)});
 
         if(!root)return;
+        this._spreadFactor=this._getSpreadFactor();
         this._contourLayout(root);
         this._assignAbsoluteXY(root,0,0);
         this._placeClouds();
@@ -923,11 +927,35 @@ class LanFlowMap2D {
         this._updateStreamRates();
     }
 
+    _getSpreadFactor(){
+        const wOn=this._overlays.wifiClients;
+        const wdOn=this._overlays.wiredClients;
+        if(wOn&&wdOn)return 1;
+        if(wOn||wdOn)return 1.15;
+        return 1.3;
+    }
+
+    _relayout(){
+        if(!this._root)return;
+        this._spreadFactor=this._getSpreadFactor();
+        this._contourLayout(this._root);
+        this._assignAbsoluteXY(this._root,0,0);
+        this._placeClouds();
+        this._matchEdges();
+        this._initStreams();
+        this._calcBounds();
+        this._updateStreamRates();
+        this._needsStaticRedraw=true;
+    }
+
     // Compute contour (left/right extent at each depth relative to node x=0)
     // and store relative child offsets on the node.
     _contourLayout(n){
         const selfW=isClient(n.d.kind)?G.clientCellW:G.boxW+40;
-        const nc=Math.min(n.clients.length,G.maxClients);
+        n._isGrid=false;
+        const visCl=n.clients.filter(c=>this._isNodeVisible(c));
+        const nc=Math.min(visCl.length,G.maxClients);
+        n._visClients=visCl.slice(0,G.maxClients);
 
         // VirtualHub: treat as a leaf (children won't be rendered)
         if(n.d.kind===NK.VirtualHub){
@@ -956,8 +984,18 @@ class LanFlowMap2D {
             return;
         }
 
-        // Infra children (+ any direct clients merged in)
-        const kids=n.infra.length>0?[...n.infra,...n.clients.slice(0,nc)]:[];
+        // Infra children; clients always use a grid (placeholder in the kids array)
+        const kids=[...n.infra];
+        if(nc>0){
+            const cols=Math.min(nc,G.clientCols);
+            const rows=Math.ceil(nc/cols);
+            const gridW=cols*G.clientCellW;
+            const staggerExtra=rows>1?G.clientCellW/2:0;
+            n._isGrid=true;
+            n._gridCols=cols;
+            const gp={_isGridPlaceholder:true,_contour:[{l:-gridW/2,r:gridW/2+staggerExtra}]};
+            kids.push(gp);
+        }
 
         if(kids.length===0){
             n._contour=[{l:-selfW/2,r:selfW/2}];
@@ -966,7 +1004,7 @@ class LanFlowMap2D {
             return;
         }
 
-        for(const k of kids)this._contourLayout(k);
+        for(const k of kids)if(!k._isGridPlaceholder)this._contourLayout(k);
 
         const GAP=20;
         const offsets=[];
@@ -1024,28 +1062,46 @@ class LanFlowMap2D {
         n.x=absX;
         n.y=yOff+depth*G.tierGap;
 
-        // Client grid: compact rows with honeycomb stagger so vertical links
-        // from the parent fan out to different x positions per row.
-        if(n._isGrid){
-            const nc=Math.min(n.clients.length,G.maxClients);
+        // Client grid: compact rows with honeycomb stagger
+        if(n._isGrid&&(!n._kids||n._kids.length===0)){
+            const vc=n._visClients||[];
+            const nc=vc.length;
             const cols=n._gridCols;
             const gridW=cols*G.clientCellW;
             const gridLeft=absX-gridW/2;
-            const clientY=yOff+(depth+1)*G.tierGap;
+            const clientY=n.y+G.clientTierGap;
             const stagger=G.clientCellW/2;
             for(let i=0;i<nc;i++){
                 const col=i%cols,row=Math.floor(i/cols);
                 const rowOff=(row%2)*stagger;
-                n.clients[i].x=gridLeft+col*G.clientCellW+G.clientCellW/2+rowOff;
-                n.clients[i].y=clientY+row*G.clientCellH;
+                vc[i].x=gridLeft+col*G.clientCellW+G.clientCellW/2+rowOff;
+                vc[i].y=clientY+row*G.clientCellH;
             }
             return;
         }
 
         const kids=n._kids||[];
         const offsets=n._kidOffsets||[];
+        const sf=this._spreadFactor||1;
         for(let i=0;i<kids.length;i++){
-            this._assignAbsoluteXY(kids[i],absX+offsets[i],depth+1);
+            if(kids[i]._isGridPlaceholder){
+                const vc=n._visClients||[];
+                const nc=vc.length;
+                const cols=n._gridCols;
+                const gridW=cols*G.clientCellW;
+                const px=absX+offsets[i]*sf;
+                const gridLeft=px-gridW/2;
+                const clientY=n.y+G.clientTierGap;
+                const stagger=G.clientCellW/2;
+                for(let j=0;j<nc;j++){
+                    const col=j%cols,row=Math.floor(j/cols);
+                    const rowOff=(row%2)*stagger;
+                    vc[j].x=gridLeft+col*G.clientCellW+G.clientCellW/2+rowOff;
+                    vc[j].y=clientY+row*G.clientCellH;
+                }
+            }else{
+                this._assignAbsoluteXY(kids[i],absX+offsets[i]*sf,depth+1);
+            }
         }
     }
 
@@ -1148,6 +1204,12 @@ class LanFlowMap2D {
             if(sibEdges.length>1){
                 const mid=(sibEdges.length-1)/2;
                 for(let i=0;i<sibEdges.length;i++)sibEdges[i]._midYOff=(i-mid)*STAGGER;
+                // Multi-row grids: push client offshoots down so the trunk
+                // drops further before branching horizontally
+                const nCl=sibEdges.filter(e=>e._isCl).length;
+                if(nCl>G.clientCols){
+                    for(const e of sibEdges)if(e._isCl)e._midYOff+=12;
+                }
             }
         };
         matchTree(gw);
@@ -1532,14 +1594,19 @@ class LanFlowMap2D {
         const name=demoMask(n.d.name||n.d.model||'');
         if(name){
             const dn=name.length>24?name.slice(0,23)+'…':name;
-            ctx.fillStyle=C.text;
             ctx.font=`500 ${G.nameFont}px ${FONT}`;
-            ctx.textAlign='center'; ctx.textBaseline='top';
-            ctx.fillText(dn,x,y+hh+5);
+            const tw=ctx.measureText(dn).width+12;
+            const ly=y+hh+5+G.nameFont/2;
+            ctx.fillStyle=C.labelBg;
+            this._roundRect(ctx,x-tw/2,ly-8,tw,16,4);
+            ctx.fill();
+            ctx.fillStyle=C.text;
+            ctx.textAlign='center'; ctx.textBaseline='middle';
+            ctx.fillText(dn,x,ly);
         }
 
         // Rate labels (stored for dynamic update)
-        n._rateY=y+hh+19;
+        n._rateY=y+hh+28;
     }
 
     _drawClientNode(ctx,n){
@@ -1599,8 +1666,12 @@ class LanFlowMap2D {
 
                 if(any&&(downBps>100000||upBps>100000)){
                     ctx.font=`${G.rateFont}px ${FONT}`;
-                    ctx.textBaseline='top';
                     const dTxt='↓'+formatBps(downBps), uTxt='↑'+formatBps(upBps);
+                    const tw=ctx.measureText(dTxt+'  '+uTxt).width+12;
+                    ctx.fillStyle=C.labelBg;
+                    this._roundRect(ctx,n.x-tw/2,n._rateY-8,tw,16,4);
+                    ctx.fill();
+                    ctx.textBaseline='middle';
                     ctx.textAlign='right'; ctx.fillStyle=C.downstream;
                     ctx.fillText(dTxt,n.x-4,n._rateY);
                     ctx.textAlign='left'; ctx.fillStyle=C.upstream;

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -5,7 +5,8 @@
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 
 const HISTORY_MINUTES = 5;
-const POLL_MS = 3000;
+const POLL_MS = 5000;
+const SCROLL_MS = 500;
 const COLOR_DL   = '#3b82f6';
 const COLOR_UL   = '#10b981';
 const COLOR_LOSS = '#ef4444';
@@ -13,8 +14,10 @@ const COLOR_RTT  = '#d946ef';
 
 let chart = null;
 let pollTimer = null;
+let scrollTimer = null;
 let buffer = [];
 let elId = null;
+let visHandler = null;
 let mountGen = 0;
 
 function formatBps(v) {
@@ -101,6 +104,7 @@ function buildOpts() {
                     style: { colors: '#9ca3af', fontSize: '10px' },
                     formatter: v => v != null ? v.toFixed(0) : '',
                     maxWidth: 30,
+                    offsetX: -3,
                 },
                 title: { text: 'ms', style: { color: '#64748b', fontSize: '9px' }, offsetX: -4 },
                 axisBorder: { show: false },
@@ -113,6 +117,18 @@ function buildOpts() {
             padding: { left: 3, right: 0, top: -8, bottom: 0 },
             xaxis: { lines: { show: false } },
         },
+        responsive: [{
+            breakpoint: 1024,
+            options: {
+                yaxis: [
+                    { seriesName: 'Download', show: false, min: 0 },
+                    { seriesName: 'Download', show: false, min: 0 },
+                    { seriesName: 'Loss', opposite: true, show: false, min: 0 },
+                    { seriesName: 'RTT', opposite: true, show: false, min: 0 },
+                ],
+                grid: { padding: { left: -5, right: -5, top: -8, bottom: 0 } },
+            },
+        }],
         legend: { show: false },
         tooltip: {
             theme: 'dark',
@@ -136,18 +152,31 @@ function rttYMax() {
     return Math.ceil((p95 * 1.5) / 10) * 10;
 }
 
+function buildSeriesData() {
+    const now = Date.now();
+    const last = buffer[buffer.length - 1];
+    const pts = [...buffer];
+    if (last && now - last.time > 1000) {
+        pts.push({ time: now, download: last.download, upload: last.upload, loss: last.loss, rtt: last.rtt });
+    }
+    return pts;
+}
+
 function updateChart() {
     if (!chart || buffer.length === 0) return;
+    const el = document.getElementById(elId);
+    if (el?.classList.contains('apexcharts-tooltip-active')) return;
     const now = Date.now();
+    const pts = buildSeriesData();
     chart.updateOptions({
         xaxis: { min: now - HISTORY_MINUTES * 60000, max: now },
         yaxis: [chart.opts.yaxis[0], chart.opts.yaxis[1], chart.opts.yaxis[2], { ...chart.opts.yaxis[3], max: rttYMax() }],
     }, false, false, false);
     chart.updateSeries([
-        { name: 'Download', data: buffer.map(p => ({ x: p.time, y: p.download })) },
-        { name: 'Upload',   data: buffer.map(p => ({ x: p.time, y: p.upload })) },
-        { name: 'Loss',     data: buffer.map(p => ({ x: p.time, y: p.loss })) },
-        { name: 'RTT',      data: buffer.map(p => ({ x: p.time, y: p.rtt })) },
+        { name: 'Download', data: pts.map(p => ({ x: p.time, y: p.download })) },
+        { name: 'Upload',   data: pts.map(p => ({ x: p.time, y: p.upload })) },
+        { name: 'Loss',     data: pts.map(p => ({ x: p.time, y: p.loss })) },
+        { name: 'RTT',      data: pts.map(p => ({ x: p.time, y: p.rtt })) },
     ], false);
 }
 
@@ -165,7 +194,7 @@ async function loadHistory() {
             download: p.downloadBps,
             upload: p.uploadBps,
             rtt: p.rttMs,
-            loss: p.lossPercent,
+            loss: p.lossPercent ?? 0,
         }));
     } catch { }
 }
@@ -180,7 +209,7 @@ async function pollLive() {
             time: Date.now(),
             download: d.downloadBps,
             upload: d.uploadBps,
-            loss: d.lossPercent,
+            loss: d.lossPercent ?? 0,
             rtt: d.rttMs,
         });
         buffer = buffer.filter(p => p.time >= cutoff);
@@ -190,6 +219,7 @@ async function pollLive() {
 
 export async function mount(containerId, opts) {
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+    if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
     if (chart) { chart.destroy(); chart = null; }
     buffer = [];
     const gen = ++mountGen;
@@ -209,15 +239,27 @@ export async function mount(containerId, opts) {
     const interval = opts?.pollMs || POLL_MS;
 
     pollTimer = setInterval(pollLive, interval);
+    scrollTimer = setInterval(updateChart, SCROLL_MS);
+
+    if (visHandler) document.removeEventListener('visibilitychange', visHandler);
+    visHandler = async () => {
+        if (!document.hidden && chart && pollTimer) {
+            await loadHistory();
+            await pollLive();
+        }
+    };
+    document.addEventListener('visibilitychange', visHandler);
 }
 
 export function pause() {
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+    if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
 }
 
 export function resume() {
     if (!chart || pollTimer) return;
     pollTimer = setInterval(pollLive, POLL_MS);
+    scrollTimer = setInterval(updateChart, SCROLL_MS);
 }
 
 export async function seekTime(isoTimestamp) {
@@ -230,10 +272,12 @@ export async function seekTime(isoTimestamp) {
         await loadHistory();
         updateChart();
         pollTimer = setInterval(pollLive, POLL_MS);
+        scrollTimer = setInterval(updateChart, SCROLL_MS);
         return;
     }
     // Historic mode: stop polling, fetch window centered on timestamp
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+    if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
     const at = new Date(isoTimestamp).getTime();
     const halfWindow = HISTORY_MINUTES * 60000 / 2;
     const from = new Date(at - halfWindow);
@@ -285,6 +329,8 @@ export async function seekTime(isoTimestamp) {
 export function unmount() {
     mountGen++;
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+    if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
+    if (visHandler) { document.removeEventListener('visibilitychange', visHandler); visHandler = null; }
     if (chart) { chart.destroy(); chart = null; }
     buffer = [];
     elId = null;


### PR DESCRIPTION
## Summary

- **Handle missing InfluxDB buckets gracefully** - Missing buckets, wrong org names, or revoked tokens no longer crash the app with 500 errors. Returns empty data and marks InfluxDB as unhealthy. Health check now probes both primary and longterm buckets. Warning banners on SFP and Cellular tabs link to the Setup tab.
- **2D map relayouts on filter changes** - Toggling Wi-Fi/Wired overlays, band filters, or text search now rebuilds the tree layout so clients compact to fill the canvas instead of leaving gaps. Infra spacing widens when client overlays are off.
- **Grid-wrap clients with infra siblings** - APs with both infra children (e.g. UDB bridge) and clients now grid-wrap the clients instead of laying them all out horizontally
- **Dark BG pills on device labels** - Device name and throughput rate labels below network devices get the same dark background pill as link speed labels
- **Client grid tuning** - Dedicated client tier gap, row height and multi-row connector offshoot adjustments
- **Cellular Stats tab waits for InfluxDB** - Charts wait for InfluxDB to be reachable before mounting, matching SFP tab behavior
- **Smooth WAN live chart scrolling** - Poll aligned to 5 s SNMP cadence with 500 ms interpolation for continuous scrolling. Tooltip preserved while hovering data points. Tab refocus reloads history to fill gaps.
- **WAN chart mobile full-width** - Y-axis labels hidden on mobile, dashboard chart padding zeroed, right margin pull removed
- **WAN chart fixes** - Null loss defaults to 0 (prevents line breaks), RTT axis labels nudged for alignment

## Test plan

- [x] Rename longterm bucket, verify graceful degradation
- [x] Restore bucket, verify recovery
- [x] Toggle Wi-Fi/Wired overlays on 2D map, verify tree compacts and re-expands
- [x] Check AP with UDB bridge - clients should grid-wrap
- [x] Verify device labels have dark background pills
- [x] Cellular Stats tab during reload shows spinner then charts
- [x] WAN chart scrolls smoothly on dashboard and monitoring
- [x] Tooltip stays open when hovering a data point
- [x] Mobile: WAN chart uses full width