### PR TITLE
Relayout 2D map on filter changes, grid-wrap mixed infra+client nodes

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -483,6 +483,14 @@ else
                 }
             </div>
         }
+        else if (_influxReachable != true)
+        {
+            <div class="loading-container" style="padding: 3rem;">
+                <div class="spinner"></div>
+            </div>
+        }
+        @if (_influxReachable == true)
+        {
         <div class="card" style="margin-top: 1.5rem;" id="cellular-charts-container">
             <div class="card-header" style="flex-wrap: wrap; gap: 0.75rem;">
                 <h2 class="card-title">Cellular Signal History</h2>
@@ -539,6 +547,7 @@ else
                 </div>
             </div>
         </div>
+        }
     }
 
     @* ──────────────── Tab: Setup ──────────────── *@
@@ -2038,8 +2047,8 @@ else
             await ScrollToSfpChartsAsync();
         }
 
-        // Cellular charts - Cellular tab only
-        if (_activeTab == "cellular" && _monitoringReady && !_cellularChartsMounted)
+        // Cellular charts - Cellular tab only (wait for InfluxDB like SFP waits for module data)
+        if (_activeTab == "cellular" && _monitoringReady && _influxReachable == true && !_cellularChartsMounted)
         {
             _cellularChartsMounted = true;
             try
@@ -2054,7 +2063,7 @@ else
             }
             catch { _cellularChartsMounted = false; }
         }
-        else if (_activeTab != "cellular" && _cellularChartsMounted)
+        else if ((_activeTab != "cellular" || _influxReachable != true) && _cellularChartsMounted)
         {
             _cellularChartsMounted = false;
             try { await JS.InvokeVoidAsync("eval", "window.__cellularCharts?.unmount();"); }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1205,14 +1205,6 @@ class LanFlowMap2D {
                 const mid=(sibEdges.length-1)/2;
                 for(let i=0;i<sibEdges.length;i++)sibEdges[i]._midYOff=(i-mid)*STAGGER;
             }
-            // Multi-row client grids: route each client's horizontal near its own row
-            // so connectors for deeper rows don't cut through shallower row labels
-            const nCl=sibEdges.filter(e=>e._isCl).length;
-            if(nCl>G.clientCols){
-                for(const e of sibEdges){
-                    if(e._isCl)e._midYOff=(e._y2-e._y1)/2-18;
-                }
-            }
         };
         matchTree(gw);
     }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1208,7 +1208,7 @@ class LanFlowMap2D {
                 // drops further before branching horizontally
                 const nCl=sibEdges.filter(e=>e._isCl).length;
                 if(nCl>G.clientCols){
-                    for(const e of sibEdges)if(e._isCl)e._midYOff+=13;
+                    for(const e of sibEdges)if(e._isCl)e._midYOff+=12.5;
                 }
             }
         };

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -42,7 +42,7 @@ const LK = { Uplink:0, WiredClient:1, WifiClient:2, Wan:3, Transit:4, MeshBackha
 // ---- Layout geometry ----
 const G = {
     tierGap:     170,
-    clientTierGap:120,
+    clientTierGap:175,
     cloudGap:    220,
     infraGap:    90,
     clientCellW: 145,
@@ -1200,13 +1200,10 @@ class LanFlowMap2D {
                 if(edge){edge._x1=n.x;edge._y1=pB;edge._x2=c.x;edge._y2=cT;edge._isCl=true;edge._band=edge.lk.band;sibEdges.push(edge);}
             }
 
-            // Stagger horizontal segments of siblings that share the same parent.
-            // Scale stagger down for many-client APs so the fan-out fits in the
-            // vertical space between AP and first client row.
+            // Stagger horizontal segments of siblings that share the same parent
             if(sibEdges.length>1){
                 const mid=(sibEdges.length-1)/2;
-                const stg=Math.min(STAGGER,70/Math.max(sibEdges.length-1,1));
-                for(let i=0;i<sibEdges.length;i++)sibEdges[i]._midYOff=(i-mid)*stg;
+                for(let i=0;i<sibEdges.length;i++)sibEdges[i]._midYOff=(i-mid)*STAGGER;
             }
         };
         matchTree(gw);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1606,7 +1606,7 @@ class LanFlowMap2D {
         }
 
         // Rate labels (stored for dynamic update)
-        n._rateY=y+hh+19;
+        n._rateY=y+hh+28;
     }
 
     _drawClientNode(ctx,n){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -46,7 +46,7 @@ const G = {
     cloudGap:    220,
     infraGap:    90,
     clientCellW: 145,
-    clientCellH: 62,
+    clientCellH: 58,
     clientR:     7,
     clientCols:  6,
     maxClients:  80,

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -45,8 +45,7 @@ const G = {
     cloudGap:    220,
     infraGap:    90,
     clientCellW: 145,
-    clientCellH: 50,
-    clientCellH2:62,
+    clientCellH: 62,
     clientR:     7,
     clientCols:  6,
     maxClients:  80,
@@ -775,7 +774,7 @@ class LanFlowMap2D {
             if(Math.abs(w.x-n.x)<G.boxW/2&&Math.abs(w.y-n.y)<G.boxH/2)hit=n;
             for(const c of n.infra)checkNode(c);
             for(const c of n.clients.slice(0,G.maxClients)){
-                if(this._isNodeVisible(c)&&Math.abs(w.x-c.x)<G.clientCellW/2&&Math.abs(w.y-c.y)<G.clientCellH2/2)hit=c;
+                if(this._isNodeVisible(c)&&Math.abs(w.x-c.x)<G.clientCellW/2&&Math.abs(w.y-c.y)<G.clientCellH/2)hit=c;
             }
         };
         if(this._root)checkNode(this._root);
@@ -1075,7 +1074,7 @@ class LanFlowMap2D {
                 const col=i%cols,row=Math.floor(i/cols);
                 const rowOff=(row%2)*stagger;
                 vc[i].x=gridLeft+col*G.clientCellW+G.clientCellW/2+rowOff;
-                vc[i].y=clientY+(row>0?G.clientCellH+(row-1)*G.clientCellH2:0);
+                vc[i].y=clientY+row*G.clientCellH;
             }
             return;
         }
@@ -1097,7 +1096,7 @@ class LanFlowMap2D {
                     const col=j%cols,row=Math.floor(j/cols);
                     const rowOff=(row%2)*stagger;
                     vc[j].x=gridLeft+col*G.clientCellW+G.clientCellW/2+rowOff;
-                    vc[j].y=clientY+(row>0?G.clientCellH+(row-1)*G.clientCellH2:0);
+                    vc[j].y=clientY+row*G.clientCellH;
                 }
             }else{
                 this._assignAbsoluteXY(kids[i],absX+offsets[i]*sf,depth+1);
@@ -1203,7 +1202,9 @@ class LanFlowMap2D {
             // Stagger horizontal segments of siblings that share the same parent
             if(sibEdges.length>1){
                 const mid=(sibEdges.length-1)/2;
-                for(let i=0;i<sibEdges.length;i++)sibEdges[i]._midYOff=(i-mid)*STAGGER;
+                const nCl=sibEdges.filter(e=>e._isCl).length;
+                const bias=nCl>3?20:0;
+                for(let i=0;i<sibEdges.length;i++)sibEdges[i]._midYOff=(i-mid)*STAGGER+bias;
             }
         };
         matchTree(gw);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1203,9 +1203,7 @@ class LanFlowMap2D {
             // Stagger horizontal segments of siblings that share the same parent
             if(sibEdges.length>1){
                 const mid=(sibEdges.length-1)/2;
-                const nCl=sibEdges.filter(e=>e._isCl).length;
-                const bias=nCl>3?20:0;
-                for(let i=0;i<sibEdges.length;i++)sibEdges[i]._midYOff=(i-mid)*STAGGER+bias;
+                for(let i=0;i<sibEdges.length;i++)sibEdges[i]._midYOff=(i-mid)*STAGGER;
             }
         };
         matchTree(gw);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -915,6 +915,7 @@ class LanFlowMap2D {
         for(const lk of snap.links)this._edges.push({lk,fn:byId.get(lk.fromNodeId),tn:byId.get(lk.toNodeId)});
 
         if(!root)return;
+        this._spreadFactor=this._getSpreadFactor();
         this._contourLayout(root);
         this._assignAbsoluteXY(root,0,0);
         this._placeClouds();
@@ -925,8 +926,17 @@ class LanFlowMap2D {
         this._updateStreamRates();
     }
 
+    _getSpreadFactor(){
+        const wOn=this._overlays.wifiClients;
+        const wdOn=this._overlays.wiredClients;
+        if(wOn&&wdOn)return 1;
+        if(wOn||wdOn)return 1.15;
+        return 1.3;
+    }
+
     _relayout(){
         if(!this._root)return;
+        this._spreadFactor=this._getSpreadFactor();
         this._contourLayout(this._root);
         this._assignAbsoluteXY(this._root,0,0);
         this._placeClouds();
@@ -1062,8 +1072,9 @@ class LanFlowMap2D {
 
         const kids=n._kids||[];
         const offsets=n._kidOffsets||[];
+        const sf=this._spreadFactor||1;
         for(let i=0;i<kids.length;i++){
-            this._assignAbsoluteXY(kids[i],absX+offsets[i],depth+1);
+            this._assignAbsoluteXY(kids[i],absX+offsets[i]*sf,depth+1);
         }
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -298,6 +298,7 @@ class LanFlowMap2D {
                         }else{
                             // Client churn or same topology: update data in place
                             this._updateSnapshotData(s);
+                            this._snapshot=s;
                             this._needsStaticRedraw=true;
                         }
                     }
@@ -389,7 +390,7 @@ class LanFlowMap2D {
         if(isMobile)filterTitle.addEventListener('click',()=>{filterBody.hidden=!filterBody.hidden;});
         filterBody.querySelector('.lan-flow-map-search').addEventListener('input',(e)=>{
             this._filter.text=(e.target.value||'').toLowerCase().trim();
-            this._needsStaticRedraw=true;
+            this._relayout();
             if(this._isFitted)this._fitAll();
         });
         const bandChips=[...filterBody.querySelectorAll('.lan-flow-map-chip')];
@@ -401,7 +402,7 @@ class LanFlowMap2D {
                 else{const onlyThis=this._filter.bands[b]&&bandChips.every(c=>c.dataset.band===b||!this._filter.bands[c.dataset.band]);
                     if(onlyThis){for(const c of bandChips){this._filter.bands[c.dataset.band]=true;c.classList.add('is-on');}}
                     else{this._filter.bands[b]=!this._filter.bands[b];chip.classList.toggle('is-on',this._filter.bands[b]);}}
-                this._needsStaticRedraw=true;
+                this._relayout();
                 if(this._isFitted)this._fitAll();
             });
         });
@@ -428,7 +429,7 @@ class LanFlowMap2D {
                 this._overlays[key]=!this._overlays[key];
                 row.classList.toggle('is-on',this._overlays[key]);
                 try{localStorage.setItem(this._storageKey,JSON.stringify(this._overlays));}catch{}
-                this._needsStaticRedraw=true;
+                this._relayout();
                 if(this._isFitted)this._fitAll();
             });
             ctrlBody.appendChild(row);
@@ -873,6 +874,7 @@ class LanFlowMap2D {
     // siblings apart until no depth overlaps. Guarantees zero cross-tree overlap.
 
     _buildLayout(snap){
+        this._snapshot=snap;
         const byId=new Map();
         for(const n of snap.nodes)byId.set(n.id,new TN(n));
         this._treeMap=byId;
@@ -923,11 +925,26 @@ class LanFlowMap2D {
         this._updateStreamRates();
     }
 
+    _relayout(){
+        if(!this._root)return;
+        this._contourLayout(this._root);
+        this._assignAbsoluteXY(this._root,0,0);
+        this._placeClouds();
+        this._matchEdges();
+        this._initStreams();
+        this._calcBounds();
+        this._updateStreamRates();
+        this._needsStaticRedraw=true;
+    }
+
     // Compute contour (left/right extent at each depth relative to node x=0)
     // and store relative child offsets on the node.
     _contourLayout(n){
         const selfW=isClient(n.d.kind)?G.clientCellW:G.boxW+40;
-        const nc=Math.min(n.clients.length,G.maxClients);
+        n._isGrid=false;
+        const visCl=n.clients.filter(c=>this._isNodeVisible(c));
+        const nc=Math.min(visCl.length,G.maxClients);
+        n._visClients=visCl.slice(0,G.maxClients);
 
         // VirtualHub: treat as a leaf (children won't be rendered)
         if(n.d.kind===NK.VirtualHub){
@@ -957,7 +974,7 @@ class LanFlowMap2D {
         }
 
         // Infra children (+ any direct clients merged in)
-        const kids=n.infra.length>0?[...n.infra,...n.clients.slice(0,nc)]:[];
+        const kids=n.infra.length>0?[...n.infra,...visCl.slice(0,nc)]:[];
 
         if(kids.length===0){
             n._contour=[{l:-selfW/2,r:selfW/2}];
@@ -1027,7 +1044,8 @@ class LanFlowMap2D {
         // Client grid: compact rows with honeycomb stagger so vertical links
         // from the parent fan out to different x positions per row.
         if(n._isGrid){
-            const nc=Math.min(n.clients.length,G.maxClients);
+            const vc=n._visClients||[];
+            const nc=vc.length;
             const cols=n._gridCols;
             const gridW=cols*G.clientCellW;
             const gridLeft=absX-gridW/2;
@@ -1036,8 +1054,8 @@ class LanFlowMap2D {
             for(let i=0;i<nc;i++){
                 const col=i%cols,row=Math.floor(i/cols);
                 const rowOff=(row%2)*stagger;
-                n.clients[i].x=gridLeft+col*G.clientCellW+G.clientCellW/2+rowOff;
-                n.clients[i].y=clientY+row*G.clientCellH;
+                vc[i].x=gridLeft+col*G.clientCellW+G.clientCellW/2+rowOff;
+                vc[i].y=clientY+row*G.clientCellH;
             }
             return;
         }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1208,7 +1208,7 @@ class LanFlowMap2D {
                 // drops further before branching horizontally
                 const nCl=sibEdges.filter(e=>e._isCl).length;
                 if(nCl>G.clientCols){
-                    for(const e of sibEdges)if(e._isCl)e._midYOff+=8;
+                    for(const e of sibEdges)if(e._isCl)e._midYOff+=13;
                 }
             }
         };
@@ -1595,13 +1595,13 @@ class LanFlowMap2D {
         if(name){
             const dn=name.length>24?name.slice(0,23)+'…':name;
             ctx.font=`500 ${G.nameFont}px ${FONT}`;
-            ctx.textAlign='center'; ctx.textBaseline='top';
-            const tw=ctx.measureText(dn).width+10;
-            const ly=y+hh+5;
+            const tw=ctx.measureText(dn).width+12;
+            const ly=y+hh+5+G.nameFont/2;
             ctx.fillStyle=C.labelBg;
-            this._roundRect(ctx,x-tw/2,ly-2,tw,G.nameFont+6,4);
+            this._roundRect(ctx,x-tw/2,ly-8,tw,16,4);
             ctx.fill();
             ctx.fillStyle=C.text;
+            ctx.textAlign='center'; ctx.textBaseline='middle';
             ctx.fillText(dn,x,ly);
         }
 
@@ -1666,12 +1666,12 @@ class LanFlowMap2D {
 
                 if(any&&(downBps>100000||upBps>100000)){
                     ctx.font=`${G.rateFont}px ${FONT}`;
-                    ctx.textBaseline='top';
                     const dTxt='↓'+formatBps(downBps), uTxt='↑'+formatBps(upBps);
                     const tw=ctx.measureText(dTxt+'  '+uTxt).width+12;
                     ctx.fillStyle=C.labelBg;
-                    this._roundRect(ctx,n.x-tw/2,n._rateY-2,tw,G.rateFont+6,4);
+                    this._roundRect(ctx,n.x-tw/2,n._rateY-8,tw,16,4);
                     ctx.fill();
+                    ctx.textBaseline='middle';
                     ctx.textAlign='right'; ctx.fillStyle=C.downstream;
                     ctx.fillText(dTxt,n.x-4,n._rateY);
                     ctx.textAlign='left'; ctx.fillStyle=C.upstream;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -46,7 +46,7 @@ const G = {
     cloudGap:    220,
     infraGap:    90,
     clientCellW: 145,
-    clientCellH: 50,
+    clientCellH: 55,
     clientR:     7,
     clientCols:  6,
     maxClients:  80,
@@ -1208,7 +1208,7 @@ class LanFlowMap2D {
                 // drops further before branching horizontally
                 const nCl=sibEdges.filter(e=>e._isCl).length;
                 if(nCl>G.clientCols){
-                    for(const e of sibEdges)if(e._isCl)e._midYOff+=15;
+                    for(const e of sibEdges)if(e._isCl)e._midYOff+=8;
                 }
             }
         };
@@ -1668,6 +1668,10 @@ class LanFlowMap2D {
                     ctx.font=`${G.rateFont}px ${FONT}`;
                     ctx.textBaseline='top';
                     const dTxt='↓'+formatBps(downBps), uTxt='↑'+formatBps(upBps);
+                    const tw=ctx.measureText(dTxt+'  '+uTxt).width+12;
+                    ctx.fillStyle=C.labelBg;
+                    this._roundRect(ctx,n.x-tw/2,n._rateY-2,tw,G.rateFont+6,4);
+                    ctx.fill();
                     ctx.textAlign='right'; ctx.fillStyle=C.downstream;
                     ctx.fillText(dTxt,n.x-4,n._rateY);
                     ctx.textAlign='left'; ctx.fillStyle=C.upstream;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -971,13 +971,13 @@ class LanFlowMap2D {
             const cols=Math.min(nc,G.clientCols);
             const rows=Math.ceil(nc/cols);
             const gridW=cols*G.clientCellW;
-            const staggerW=rows>1?G.clientCellW/2:0;
-            const halfGrid=(gridW+staggerW)/2;
+            const staggerExtra=rows>1?G.clientCellW/2:0;
             n._isGrid=true;
             n._gridCols=cols;
+            // Contour: node at depth 0, grid rectangle at depth 1 (widened for stagger)
             n._contour=[
                 {l:-selfW/2,r:selfW/2},
-                {l:-halfGrid,r:halfGrid},
+                {l:-gridW/2,r:gridW/2+staggerExtra},
             ];
             n._kidOffsets=[];
             n._kids=[];
@@ -990,11 +990,10 @@ class LanFlowMap2D {
             const cols=Math.min(nc,G.clientCols);
             const rows=Math.ceil(nc/cols);
             const gridW=cols*G.clientCellW;
-            const staggerW=rows>1?G.clientCellW/2:0;
-            const halfGrid=(gridW+staggerW)/2;
+            const staggerExtra=rows>1?G.clientCellW/2:0;
             n._isGrid=true;
             n._gridCols=cols;
-            const gp={_isGridPlaceholder:true,_contour:[{l:-halfGrid,r:halfGrid}]};
+            const gp={_isGridPlaceholder:true,_contour:[{l:-gridW/2,r:gridW/2+staggerExtra}]};
             kids.push(gp);
         }
 
@@ -1007,7 +1006,7 @@ class LanFlowMap2D {
 
         for(const k of kids)if(!k._isGridPlaceholder)this._contourLayout(k);
 
-        const GAP=20;
+        const GAP=12;
         const offsets=[];
         let groupRight=[];
 
@@ -1069,9 +1068,9 @@ class LanFlowMap2D {
             const nc=vc.length;
             const cols=n._gridCols;
             const gridW=cols*G.clientCellW;
-            const stagger=G.clientCellW/2;
-            const gridLeft=absX-(gridW+stagger)/2;
+            const gridLeft=absX-gridW/2;
             const clientY=n.y+G.clientTierGap;
+            const stagger=G.clientCellW/2;
             for(let i=0;i<nc;i++){
                 const col=i%cols,row=Math.floor(i/cols);
                 const rowOff=(row%2)*stagger;
@@ -1090,10 +1089,10 @@ class LanFlowMap2D {
                 const nc=vc.length;
                 const cols=n._gridCols;
                 const gridW=cols*G.clientCellW;
-                const stagger=G.clientCellW/2;
                 const px=absX+offsets[i]*sf;
-                const gridLeft=px-(gridW+stagger)/2;
+                const gridLeft=px-gridW/2;
                 const clientY=n.y+G.clientTierGap;
+                const stagger=G.clientCellW/2;
                 for(let j=0;j<nc;j++){
                     const col=j%cols,row=Math.floor(j/cols);
                     const rowOff=(row%2)*stagger;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -45,7 +45,8 @@ const G = {
     cloudGap:    220,
     infraGap:    90,
     clientCellW: 145,
-    clientCellH: 60,
+    clientCellH: 50,
+    clientCellH2:62,
     clientR:     7,
     clientCols:  6,
     maxClients:  80,
@@ -774,7 +775,7 @@ class LanFlowMap2D {
             if(Math.abs(w.x-n.x)<G.boxW/2&&Math.abs(w.y-n.y)<G.boxH/2)hit=n;
             for(const c of n.infra)checkNode(c);
             for(const c of n.clients.slice(0,G.maxClients)){
-                if(this._isNodeVisible(c)&&Math.abs(w.x-c.x)<G.clientCellW/2&&Math.abs(w.y-c.y)<G.clientCellH/2)hit=c;
+                if(this._isNodeVisible(c)&&Math.abs(w.x-c.x)<G.clientCellW/2&&Math.abs(w.y-c.y)<G.clientCellH2/2)hit=c;
             }
         };
         if(this._root)checkNode(this._root);
@@ -1074,7 +1075,7 @@ class LanFlowMap2D {
                 const col=i%cols,row=Math.floor(i/cols);
                 const rowOff=(row%2)*stagger;
                 vc[i].x=gridLeft+col*G.clientCellW+G.clientCellW/2+rowOff;
-                vc[i].y=clientY+row*G.clientCellH;
+                vc[i].y=clientY+(row>0?G.clientCellH+(row-1)*G.clientCellH2:0);
             }
             return;
         }
@@ -1096,7 +1097,7 @@ class LanFlowMap2D {
                     const col=j%cols,row=Math.floor(j/cols);
                     const rowOff=(row%2)*stagger;
                     vc[j].x=gridLeft+col*G.clientCellW+G.clientCellW/2+rowOff;
-                    vc[j].y=clientY+row*G.clientCellH;
+                    vc[j].y=clientY+(row>0?G.clientCellH+(row-1)*G.clientCellH2:0);
                 }
             }else{
                 this._assignAbsoluteXY(kids[i],absX+offsets[i]*sf,depth+1);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1205,6 +1205,14 @@ class LanFlowMap2D {
                 const mid=(sibEdges.length-1)/2;
                 for(let i=0;i<sibEdges.length;i++)sibEdges[i]._midYOff=(i-mid)*STAGGER;
             }
+            // Multi-row client grids: route each client's horizontal near its own row
+            // so connectors for deeper rows don't cut through shallower row labels
+            const nCl=sibEdges.filter(e=>e._isCl).length;
+            if(nCl>G.clientCols){
+                for(const e of sibEdges){
+                    if(e._isCl)e._midYOff=(e._y2-e._y1)/2-18;
+                }
+            }
         };
         matchTree(gw);
     }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -45,7 +45,7 @@ const G = {
     cloudGap:    220,
     infraGap:    90,
     clientCellW: 145,
-    clientCellH: 53,
+    clientCellH: 60,
     clientR:     7,
     clientCols:  6,
     maxClients:  80,

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -971,13 +971,13 @@ class LanFlowMap2D {
             const cols=Math.min(nc,G.clientCols);
             const rows=Math.ceil(nc/cols);
             const gridW=cols*G.clientCellW;
-            const staggerExtra=rows>1?G.clientCellW/2:0;
+            const staggerW=rows>1?G.clientCellW/2:0;
+            const halfGrid=(gridW+staggerW)/2;
             n._isGrid=true;
             n._gridCols=cols;
-            // Contour: node at depth 0, grid rectangle at depth 1 (widened for stagger)
             n._contour=[
                 {l:-selfW/2,r:selfW/2},
-                {l:-gridW/2,r:gridW/2+staggerExtra},
+                {l:-halfGrid,r:halfGrid},
             ];
             n._kidOffsets=[];
             n._kids=[];
@@ -990,10 +990,11 @@ class LanFlowMap2D {
             const cols=Math.min(nc,G.clientCols);
             const rows=Math.ceil(nc/cols);
             const gridW=cols*G.clientCellW;
-            const staggerExtra=rows>1?G.clientCellW/2:0;
+            const staggerW=rows>1?G.clientCellW/2:0;
+            const halfGrid=(gridW+staggerW)/2;
             n._isGrid=true;
             n._gridCols=cols;
-            const gp={_isGridPlaceholder:true,_contour:[{l:-gridW/2,r:gridW/2+staggerExtra}]};
+            const gp={_isGridPlaceholder:true,_contour:[{l:-halfGrid,r:halfGrid}]};
             kids.push(gp);
         }
 
@@ -1006,7 +1007,7 @@ class LanFlowMap2D {
 
         for(const k of kids)if(!k._isGridPlaceholder)this._contourLayout(k);
 
-        const GAP=12;
+        const GAP=20;
         const offsets=[];
         let groupRight=[];
 
@@ -1068,9 +1069,9 @@ class LanFlowMap2D {
             const nc=vc.length;
             const cols=n._gridCols;
             const gridW=cols*G.clientCellW;
-            const gridLeft=absX-gridW/2;
-            const clientY=n.y+G.clientTierGap;
             const stagger=G.clientCellW/2;
+            const gridLeft=absX-(gridW+stagger)/2;
+            const clientY=n.y+G.clientTierGap;
             for(let i=0;i<nc;i++){
                 const col=i%cols,row=Math.floor(i/cols);
                 const rowOff=(row%2)*stagger;
@@ -1089,10 +1090,10 @@ class LanFlowMap2D {
                 const nc=vc.length;
                 const cols=n._gridCols;
                 const gridW=cols*G.clientCellW;
-                const px=absX+offsets[i]*sf;
-                const gridLeft=px-gridW/2;
-                const clientY=n.y+G.clientTierGap;
                 const stagger=G.clientCellW/2;
+                const px=absX+offsets[i]*sf;
+                const gridLeft=px-(gridW+stagger)/2;
+                const clientY=n.y+G.clientTierGap;
                 for(let j=0;j<nc;j++){
                     const col=j%cols,row=Math.floor(j/cols);
                     const rowOff=(row%2)*stagger;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1006,7 +1006,7 @@ class LanFlowMap2D {
 
         for(const k of kids)if(!k._isGridPlaceholder)this._contourLayout(k);
 
-        const GAP=12;
+        const GAP=20;
         const offsets=[];
         let groupRight=[];
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -46,7 +46,7 @@ const G = {
     cloudGap:    220,
     infraGap:    90,
     clientCellW: 145,
-    clientCellH: 58,
+    clientCellH: 55,
     clientR:     7,
     clientCols:  6,
     maxClients:  80,
@@ -1594,10 +1594,15 @@ class LanFlowMap2D {
         const name=demoMask(n.d.name||n.d.model||'');
         if(name){
             const dn=name.length>24?name.slice(0,23)+'…':name;
-            ctx.fillStyle=C.text;
             ctx.font=`500 ${G.nameFont}px ${FONT}`;
             ctx.textAlign='center'; ctx.textBaseline='top';
-            ctx.fillText(dn,x,y+hh+5);
+            const tw=ctx.measureText(dn).width+10;
+            const ly=y+hh+5;
+            ctx.fillStyle=C.labelBg;
+            this._roundRect(ctx,x-tw/2,ly-2,tw,G.nameFont+6,4);
+            ctx.fill();
+            ctx.fillStyle=C.text;
+            ctx.fillText(dn,x,ly);
         }
 
         // Rate labels (stored for dynamic update)

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -42,7 +42,7 @@ const LK = { Uplink:0, WiredClient:1, WifiClient:2, Wan:3, Transit:4, MeshBackha
 // ---- Layout geometry ----
 const G = {
     tierGap:     170,
-    clientTierGap:175,
+    clientTierGap:165,
     cloudGap:    220,
     infraGap:    90,
     clientCellW: 145,
@@ -1204,6 +1204,12 @@ class LanFlowMap2D {
             if(sibEdges.length>1){
                 const mid=(sibEdges.length-1)/2;
                 for(let i=0;i<sibEdges.length;i++)sibEdges[i]._midYOff=(i-mid)*STAGGER;
+                // Multi-row grids: push client offshoots down so the trunk
+                // drops further before branching horizontally
+                const nCl=sibEdges.filter(e=>e._isCl).length;
+                if(nCl>G.clientCols){
+                    for(const e of sibEdges)if(e._isCl)e._midYOff+=15;
+                }
             }
         };
         matchTree(gw);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -42,6 +42,7 @@ const LK = { Uplink:0, WiredClient:1, WifiClient:2, Wan:3, Transit:4, MeshBackha
 // ---- Layout geometry ----
 const G = {
     tierGap:     170,
+    clientTierGap:120,
     cloudGap:    220,
     infraGap:    90,
     clientCellW: 145,
@@ -1068,7 +1069,7 @@ class LanFlowMap2D {
             const cols=n._gridCols;
             const gridW=cols*G.clientCellW;
             const gridLeft=absX-gridW/2;
-            const clientY=yOff+(depth+1)*G.tierGap;
+            const clientY=n.y+G.clientTierGap;
             const stagger=G.clientCellW/2;
             for(let i=0;i<nc;i++){
                 const col=i%cols,row=Math.floor(i/cols);
@@ -1090,7 +1091,7 @@ class LanFlowMap2D {
                 const gridW=cols*G.clientCellW;
                 const px=absX+offsets[i]*sf;
                 const gridLeft=px-gridW/2;
-                const clientY=yOff+(depth+1)*G.tierGap;
+                const clientY=n.y+G.clientTierGap;
                 const stagger=G.clientCellW/2;
                 for(let j=0;j<nc;j++){
                     const col=j%cols,row=Math.floor(j/cols);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -46,7 +46,7 @@ const G = {
     cloudGap:    220,
     infraGap:    90,
     clientCellW: 145,
-    clientCellH: 55,
+    clientCellH: 50,
     clientR:     7,
     clientCols:  6,
     maxClients:  80,

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -45,7 +45,7 @@ const G = {
     cloudGap:    220,
     infraGap:    90,
     clientCellW: 145,
-    clientCellH: 50,
+    clientCellH: 53,
     clientR:     7,
     clientCols:  6,
     maxClients:  80,

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1208,7 +1208,7 @@ class LanFlowMap2D {
                 // drops further before branching horizontally
                 const nCl=sibEdges.filter(e=>e._isCl).length;
                 if(nCl>G.clientCols){
-                    for(const e of sibEdges)if(e._isCl)e._midYOff+=12.5;
+                    for(const e of sibEdges)if(e._isCl)e._midYOff+=12;
                 }
             }
         };

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1200,10 +1200,13 @@ class LanFlowMap2D {
                 if(edge){edge._x1=n.x;edge._y1=pB;edge._x2=c.x;edge._y2=cT;edge._isCl=true;edge._band=edge.lk.band;sibEdges.push(edge);}
             }
 
-            // Stagger horizontal segments of siblings that share the same parent
+            // Stagger horizontal segments of siblings that share the same parent.
+            // Scale stagger down for many-client APs so the fan-out fits in the
+            // vertical space between AP and first client row.
             if(sibEdges.length>1){
                 const mid=(sibEdges.length-1)/2;
-                for(let i=0;i<sibEdges.length;i++)sibEdges[i]._midYOff=(i-mid)*STAGGER;
+                const stg=Math.min(STAGGER,70/Math.max(sibEdges.length-1,1));
+                for(let i=0;i<sibEdges.length;i++)sibEdges[i]._midYOff=(i-mid)*stg;
             }
         };
         matchTree(gw);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -983,8 +983,18 @@ class LanFlowMap2D {
             return;
         }
 
-        // Infra children (+ any direct clients merged in)
-        const kids=n.infra.length>0?[...n.infra,...visCl.slice(0,nc)]:[];
+        // Infra children; clients always use a grid (placeholder in the kids array)
+        const kids=[...n.infra];
+        if(nc>0){
+            const cols=Math.min(nc,G.clientCols);
+            const rows=Math.ceil(nc/cols);
+            const gridW=cols*G.clientCellW;
+            const staggerExtra=rows>1?G.clientCellW/2:0;
+            n._isGrid=true;
+            n._gridCols=cols;
+            const gp={_isGridPlaceholder:true,_contour:[{l:-gridW/2,r:gridW/2+staggerExtra}]};
+            kids.push(gp);
+        }
 
         if(kids.length===0){
             n._contour=[{l:-selfW/2,r:selfW/2}];
@@ -993,7 +1003,7 @@ class LanFlowMap2D {
             return;
         }
 
-        for(const k of kids)this._contourLayout(k);
+        for(const k of kids)if(!k._isGridPlaceholder)this._contourLayout(k);
 
         const GAP=20;
         const offsets=[];
@@ -1051,9 +1061,8 @@ class LanFlowMap2D {
         n.x=absX;
         n.y=yOff+depth*G.tierGap;
 
-        // Client grid: compact rows with honeycomb stagger so vertical links
-        // from the parent fan out to different x positions per row.
-        if(n._isGrid){
+        // Client grid: compact rows with honeycomb stagger
+        if(n._isGrid&&(!n._kids||n._kids.length===0)){
             const vc=n._visClients||[];
             const nc=vc.length;
             const cols=n._gridCols;
@@ -1074,7 +1083,24 @@ class LanFlowMap2D {
         const offsets=n._kidOffsets||[];
         const sf=this._spreadFactor||1;
         for(let i=0;i<kids.length;i++){
-            this._assignAbsoluteXY(kids[i],absX+offsets[i]*sf,depth+1);
+            if(kids[i]._isGridPlaceholder){
+                const vc=n._visClients||[];
+                const nc=vc.length;
+                const cols=n._gridCols;
+                const gridW=cols*G.clientCellW;
+                const px=absX+offsets[i]*sf;
+                const gridLeft=px-gridW/2;
+                const clientY=yOff+(depth+1)*G.tierGap;
+                const stagger=G.clientCellW/2;
+                for(let j=0;j<nc;j++){
+                    const col=j%cols,row=Math.floor(j/cols);
+                    const rowOff=(row%2)*stagger;
+                    vc[j].x=gridLeft+col*G.clientCellW+G.clientCellW/2+rowOff;
+                    vc[j].y=clientY+row*G.clientCellH;
+                }
+            }else{
+                this._assignAbsoluteXY(kids[i],absX+offsets[i]*sf,depth+1);
+            }
         }
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1006,7 +1006,7 @@ class LanFlowMap2D {
 
         for(const k of kids)if(!k._isGridPlaceholder)this._contourLayout(k);
 
-        const GAP=20;
+        const GAP=12;
         const offsets=[];
         let groupRight=[];
 


### PR DESCRIPTION
## Summary

- **2D map relayouts when filters change** - Toggling Wi-Fi/Wired overlays, band filters, or text search now rebuilds the tree layout so clients compact to fill the canvas instead of leaving gaps
- **Grid-wrap clients with infra siblings** - APs with both infra children (e.g. UDB bridge) and clients now grid-wrap the clients at 6 columns instead of laying them all out in one horizontal line
- **Spread factor** - Infra node spacing widens 15% with one client overlay off, 30% with both off; WAN globes unaffected
- **Dark BG pills on device labels** - Device name and throughput rate labels below network devices now get the same dark background pill as link speed labels
- **Client grid tuning** - Dedicated client tier gap (165 px), row height bumped to 55 px, multi-row grids get a 12 px downward bias on connector offshoots for clearance
- **Cellular Stats tab** - Charts now wait for InfluxDB to be reachable before mounting, matching SFP tab behavior; shows a loading spinner while waiting

## Test plan

- [x] Toggle Wi-Fi/Wired overlays on the 2D map and verify the tree compacts and re-expands
- [x] Toggle band filters (2.4/5/6 GHz) and verify layout adjusts
- [x] Check AP with UDB bridge (Mac site) - clients should grid-wrap, not line up horizontally
- [x] Verify device name and throughput labels have dark background pills
- [x] Navigate to Monitoring > Cellular Stats during app reload - should show spinner then charts, not empty chart areas
- [x] Verify NAS and Mac sites render correctly