### PR TITLE
Smooth WAN live chart scrolling with mobile optimizations

### DIFF
--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -387,14 +387,6 @@ a:hover {
     margin-top: -0.5rem;
     margin-bottom: -0.5rem;
 }
-@@media (max-width: 1024px) {
-    .wan-live-chart-card > .card-body {
-        margin-right: 0;
-    }
-    .dashboard-grid .lv-panel > .wan-live-chart-card {
-        padding: 0;
-    }
-}
 
 .card-header {
     padding: 12px 16px;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -13765,6 +13765,14 @@ a.affected-client:hover {
     }
 }
 
+@@media (max-width: 1024px) {
+    .wan-live-chart-card {
+        margin-left: -1rem;
+        margin-right: -1rem;
+        border-radius: 0;
+    }
+}
+
 /* Loaded Latency Legend */
 .loaded-latency-chart-wrapper {
     position: relative;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -13765,11 +13765,6 @@ a.affected-client:hover {
     }
 }
 
-@@media (max-width: 1024px) {
-    .wan-live-chart-card > .card-body {
-        margin-left: -0.75rem;
-    }
-}
 
 /* Loaded Latency Legend */
 .loaded-latency-chart-wrapper {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -391,9 +391,8 @@ a:hover {
     .wan-live-chart-card > .card-body {
         margin-right: 0;
     }
-    #live-view > .card-body > .wan-live-chart-card {
-        margin-left: -16px;
-        margin-right: -16px;
+    .dashboard-grid .lv-panel > .wan-live-chart-card {
+        padding: 0;
     }
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -544,6 +544,10 @@ a:hover {
     .audit-container > .card {
         margin-bottom: 1rem;
     }
+
+    .dashboard-grid .lv-panel > .wan-live-chart-card {
+        padding: 0;
+    }
 }
 
 /* Clickable card */

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -548,6 +548,10 @@ a:hover {
     .dashboard-grid .lv-panel > .wan-live-chart-card {
         padding: 0;
     }
+
+    .wan-live-chart-card > .card-body {
+        margin-right: 0;
+    }
 }
 
 /* Clickable card */

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -13767,8 +13767,8 @@ a.affected-client:hover {
 
 @@media (max-width: 1024px) {
     .wan-live-chart-card {
-        margin-left: -1rem;
-        margin-right: -1rem;
+        margin-left: -2rem;
+        margin-right: -2rem;
         border-radius: 0;
     }
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -387,6 +387,15 @@ a:hover {
     margin-top: -0.5rem;
     margin-bottom: -0.5rem;
 }
+@@media (max-width: 1024px) {
+    .wan-live-chart-card > .card-body {
+        margin-right: 0;
+    }
+    #live-view > .card-body > .wan-live-chart-card {
+        margin-left: -16px;
+        margin-right: -16px;
+    }
+}
 
 .card-header {
     padding: 12px 16px;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -13766,10 +13766,8 @@ a.affected-client:hover {
 }
 
 @@media (max-width: 1024px) {
-    .wan-live-chart-card {
-        margin-left: -2rem;
-        margin-right: -2rem;
-        border-radius: 0;
+    .wan-live-chart-card > .card-body {
+        margin-left: -0.75rem;
     }
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -384,8 +384,7 @@ a:hover {
     min-height: 0;
 }
 .dashboard-grid .lv-panel > .wan-live-chart-card {
-    margin-top: -0.5rem;
-    margin-bottom: -0.5rem;
+    margin: -0.5rem;
 }
 
 .card-header {
@@ -547,6 +546,8 @@ a:hover {
 
     .dashboard-grid .lv-panel > .wan-live-chart-card {
         padding: 0;
+        margin-left: 0;
+        margin-right: 0;
     }
 
     .wan-live-chart-card > .card-body {

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -37,6 +37,10 @@ function buildOpts() {
             toolbar: { show: false },
             zoom: { enabled: false },
             animations: { enabled: true, easing: 'smooth', dynamicAnimation: { speed: 800 } },
+            events: {
+                mouseMove: (e, ctx, cfg) => { if (cfg.dataPointIndex >= 0) isHovering = true; },
+                mouseLeave: () => { isHovering = false; updateChart(); },
+            },
         },
         series: [
             { name: 'Download', type: 'area', data: [] },
@@ -224,9 +228,6 @@ export async function mount(containerId, opts) {
     elId = containerId;
     const el = document.getElementById(containerId);
     if (!el) return;
-
-    el.addEventListener('mouseenter', () => { isHovering = true; });
-    el.addEventListener('mouseleave', () => { isHovering = false; updateChart(); });
 
     chart = new ApexCharts(el, buildOpts());
     await chart.render();

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -5,7 +5,8 @@
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 
 const HISTORY_MINUTES = 5;
-const POLL_MS = 3000;
+const POLL_MS = 5000;
+const SCROLL_MS = 500;
 const COLOR_DL   = '#3b82f6';
 const COLOR_UL   = '#10b981';
 const COLOR_LOSS = '#ef4444';
@@ -13,6 +14,7 @@ const COLOR_RTT  = '#d946ef';
 
 let chart = null;
 let pollTimer = null;
+let scrollTimer = null;
 let buffer = [];
 let elId = null;
 let mountGen = 0;
@@ -136,19 +138,30 @@ function rttYMax() {
     return Math.ceil((p95 * 1.5) / 10) * 10;
 }
 
+function buildSeriesData() {
+    const now = Date.now();
+    const last = buffer[buffer.length - 1];
+    const pts = [...buffer];
+    if (last && now - last.time > 1000) {
+        pts.push({ time: now, download: last.download, upload: last.upload, loss: last.loss, rtt: last.rtt });
+    }
+    return pts;
+}
+
 function updateChart() {
     if (!chart || buffer.length === 0) return;
     const now = Date.now();
+    const pts = buildSeriesData();
     chart.updateOptions({
         xaxis: { min: now - HISTORY_MINUTES * 60000, max: now },
         yaxis: [chart.opts.yaxis[0], chart.opts.yaxis[1], chart.opts.yaxis[2], { ...chart.opts.yaxis[3], max: rttYMax() }],
     }, false, false, false);
     chart.updateSeries([
-        { name: 'Download', data: buffer.map(p => ({ x: p.time, y: p.download })) },
-        { name: 'Upload',   data: buffer.map(p => ({ x: p.time, y: p.upload })) },
-        { name: 'Loss',     data: buffer.map(p => ({ x: p.time, y: p.loss })) },
-        { name: 'RTT',      data: buffer.map(p => ({ x: p.time, y: p.rtt })) },
-    ], true);
+        { name: 'Download', data: pts.map(p => ({ x: p.time, y: p.download })) },
+        { name: 'Upload',   data: pts.map(p => ({ x: p.time, y: p.upload })) },
+        { name: 'Loss',     data: pts.map(p => ({ x: p.time, y: p.loss })) },
+        { name: 'RTT',      data: pts.map(p => ({ x: p.time, y: p.rtt })) },
+    ], false);
 }
 
 async function loadHistory() {
@@ -190,6 +203,7 @@ async function pollLive() {
 
 export async function mount(containerId, opts) {
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+    if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
     if (chart) { chart.destroy(); chart = null; }
     buffer = [];
     const gen = ++mountGen;
@@ -209,15 +223,18 @@ export async function mount(containerId, opts) {
     const interval = opts?.pollMs || POLL_MS;
 
     pollTimer = setInterval(pollLive, interval);
+    scrollTimer = setInterval(updateChart, SCROLL_MS);
 }
 
 export function pause() {
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+    if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
 }
 
 export function resume() {
     if (!chart || pollTimer) return;
     pollTimer = setInterval(pollLive, POLL_MS);
+    scrollTimer = setInterval(updateChart, SCROLL_MS);
 }
 
 export async function seekTime(isoTimestamp) {
@@ -230,10 +247,12 @@ export async function seekTime(isoTimestamp) {
         await loadHistory();
         updateChart();
         pollTimer = setInterval(pollLive, POLL_MS);
+        scrollTimer = setInterval(updateChart, SCROLL_MS);
         return;
     }
     // Historic mode: stop polling, fetch window centered on timestamp
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+    if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
     const at = new Date(isoTimestamp).getTime();
     const halfWindow = HISTORY_MINUTES * 60000 / 2;
     const from = new Date(at - halfWindow);
@@ -285,6 +304,7 @@ export async function seekTime(isoTimestamp) {
 export function unmount() {
     mountGen++;
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+    if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
     if (chart) { chart.destroy(); chart = null; }
     buffer = [];
     elId = null;

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -191,7 +191,7 @@ async function loadHistory() {
             download: p.downloadBps,
             upload: p.uploadBps,
             rtt: p.rttMs,
-            loss: p.lossPercent,
+            loss: p.lossPercent ?? 0,
         }));
     } catch { }
 }
@@ -206,7 +206,7 @@ async function pollLive() {
             time: Date.now(),
             download: d.downloadBps,
             upload: d.uploadBps,
-            loss: d.lossPercent,
+            loss: d.lossPercent ?? 0,
             rtt: d.rttMs,
         });
         buffer = buffer.filter(p => p.time >= cutoff);

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -148,7 +148,7 @@ function updateChart() {
         { name: 'Upload',   data: buffer.map(p => ({ x: p.time, y: p.upload })) },
         { name: 'Loss',     data: buffer.map(p => ({ x: p.time, y: p.loss })) },
         { name: 'RTT',      data: buffer.map(p => ({ x: p.time, y: p.rtt })) },
-    ], false);
+    ], true);
 }
 
 async function loadHistory() {

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -17,6 +17,7 @@ let pollTimer = null;
 let scrollTimer = null;
 let buffer = [];
 let elId = null;
+let isHovering = false;
 let mountGen = 0;
 
 function formatBps(v) {
@@ -162,7 +163,7 @@ function buildSeriesData() {
 }
 
 function updateChart() {
-    if (!chart || buffer.length === 0) return;
+    if (!chart || buffer.length === 0 || isHovering) return;
     const now = Date.now();
     const pts = buildSeriesData();
     chart.updateOptions({
@@ -223,6 +224,9 @@ export async function mount(containerId, opts) {
     elId = containerId;
     const el = document.getElementById(containerId);
     if (!el) return;
+
+    el.addEventListener('mouseenter', () => { isHovering = true; });
+    el.addEventListener('mouseleave', () => { isHovering = false; updateChart(); });
 
     chart = new ApexCharts(el, buildOpts());
     await chart.render();

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -103,7 +103,7 @@ function buildOpts() {
                     style: { colors: '#9ca3af', fontSize: '10px' },
                     formatter: v => v != null ? v.toFixed(0) : '',
                     maxWidth: 30,
-                    offsetX: -2,
+                    offsetX: -3,
                 },
                 title: { text: 'ms', style: { color: '#64748b', fontSize: '9px' }, offsetX: -4 },
                 axisBorder: { show: false },

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -164,7 +164,7 @@ function buildSeriesData() {
 function updateChart() {
     if (!chart || buffer.length === 0) return;
     const el = document.getElementById(elId);
-    if (el?.querySelector('.apexcharts-canvas.apexcharts-tooltip-active')) return;
+    if (el?.classList.contains('apexcharts-tooltip-active')) return;
     const now = Date.now();
     const pts = buildSeriesData();
     chart.updateOptions({

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -17,7 +17,6 @@ let pollTimer = null;
 let scrollTimer = null;
 let buffer = [];
 let elId = null;
-let isHovering = false;
 let mountGen = 0;
 
 function formatBps(v) {
@@ -37,10 +36,6 @@ function buildOpts() {
             toolbar: { show: false },
             zoom: { enabled: false },
             animations: { enabled: true, easing: 'smooth', dynamicAnimation: { speed: 800 } },
-            events: {
-                mouseMove: (e, ctx, cfg) => { if (cfg.dataPointIndex >= 0) isHovering = true; },
-                mouseLeave: () => { isHovering = false; updateChart(); },
-            },
         },
         series: [
             { name: 'Download', type: 'area', data: [] },
@@ -167,7 +162,9 @@ function buildSeriesData() {
 }
 
 function updateChart() {
-    if (!chart || buffer.length === 0 || isHovering) return;
+    if (!chart || buffer.length === 0) return;
+    const el = document.getElementById(elId);
+    if (el?.querySelector('.apexcharts-tooltip-active')) return;
     const now = Date.now();
     const pts = buildSeriesData();
     chart.updateOptions({

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -17,6 +17,7 @@ let pollTimer = null;
 let scrollTimer = null;
 let buffer = [];
 let elId = null;
+let visHandler = null;
 let mountGen = 0;
 
 function formatBps(v) {
@@ -239,6 +240,15 @@ export async function mount(containerId, opts) {
 
     pollTimer = setInterval(pollLive, interval);
     scrollTimer = setInterval(updateChart, SCROLL_MS);
+
+    if (visHandler) document.removeEventListener('visibilitychange', visHandler);
+    visHandler = async () => {
+        if (!document.hidden && chart && pollTimer) {
+            await loadHistory();
+            await pollLive();
+        }
+    };
+    document.addEventListener('visibilitychange', visHandler);
 }
 
 export function pause() {
@@ -320,6 +330,7 @@ export function unmount() {
     mountGen++;
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
+    if (visHandler) { document.removeEventListener('visibilitychange', visHandler); visHandler = null; }
     if (chart) { chart.destroy(); chart = null; }
     buffer = [];
     elId = null;

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -103,7 +103,7 @@ function buildOpts() {
                     style: { colors: '#9ca3af', fontSize: '10px' },
                     formatter: v => v != null ? v.toFixed(0) : '',
                     maxWidth: 30,
-                    offsetX: 5,
+                    offsetX: -2,
                 },
                 title: { text: 'ms', style: { color: '#64748b', fontSize: '9px' }, offsetX: -4 },
                 axisBorder: { show: false },

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -164,7 +164,7 @@ function buildSeriesData() {
 function updateChart() {
     if (!chart || buffer.length === 0) return;
     const el = document.getElementById(elId);
-    if (el?.querySelector('.apexcharts-tooltip-active')) return;
+    if (el?.querySelector('.apexcharts-canvas.apexcharts-tooltip-active')) return;
     const now = Date.now();
     const pts = buildSeriesData();
     chart.updateOptions({

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -115,6 +115,18 @@ function buildOpts() {
             padding: { left: 3, right: 0, top: -8, bottom: 0 },
             xaxis: { lines: { show: false } },
         },
+        responsive: [{
+            breakpoint: 1024,
+            options: {
+                yaxis: [
+                    { seriesName: 'Download', show: false, min: 0 },
+                    { seriesName: 'Download', show: false, min: 0 },
+                    { seriesName: 'Loss', opposite: true, show: false, min: 0 },
+                    { seriesName: 'RTT', opposite: true, show: false, min: 0 },
+                ],
+                grid: { padding: { left: -5, right: -5, top: -8, bottom: 0 } },
+            },
+        }],
         legend: { show: false },
         tooltip: {
             theme: 'dark',

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -103,6 +103,7 @@ function buildOpts() {
                     style: { colors: '#9ca3af', fontSize: '10px' },
                     formatter: v => v != null ? v.toFixed(0) : '',
                     maxWidth: 30,
+                    offsetX: 5,
                 },
                 title: { text: 'ms', style: { color: '#64748b', fontSize: '9px' }, offsetX: -4 },
                 axisBorder: { show: false },


### PR DESCRIPTION
## Summary

- **Smooth scrolling** - Poll aligned to 5 s SNMP cadence. A 500 ms scroll timer extends the line to current time between polls so the chart scrolls continuously instead of jumping
- **Tooltip preservation** - Chart updates pause while a data point tooltip is active (checks `apexcharts-tooltip-active` class on the container)
- **Tab refocus catch-up** - Reloads 5-min history from InfluxDB when the tab becomes visible again
- **Mobile full-width** - Y-axis labels hidden on <=1024 px via ApexCharts responsive config; dashboard chart padding zeroed on mobile; right margin pull removed on mobile
- **RTT axis label nudge** - `offsetX: -3` on the right-side RTT labels
- **Null loss fix** - `lossPercent ?? 0` prevents line breaks when the API returns null

## Test plan

- [x] WAN chart scrolls smoothly on both dashboard and monitoring
- [x] Tooltip stays open when hovering a data point
- [x] Alt-tab away for 30+ seconds, come back - chart fills in the gap
- [x] Mobile: chart uses full width on both dashboard and monitoring
- [x] Loss line has no breaks during normal operation
- [x] Desktop RTT labels aligned on right axis