### PR TITLE
Disable single-file compression on macOS (ARM64 crash fix)

### DIFF
--- a/docker/NATIVE-DEPLOYMENT.md
+++ b/docker/NATIVE-DEPLOYMENT.md
@@ -221,6 +221,9 @@ launchctl unload ~/Library/LaunchAgents/com.networkoptimizer.app.plist
 # Backup database (optional)
 cp ~/Library/Application\ Support/NetworkOptimizer/network_optimizer.db ~/network_optimizer.db.backup
 
+# Update .NET SDK (picks up runtime stability and security fixes)
+brew upgrade dotnet
+
 # Pull latest from main and rebuild
 cd ~/NetworkOptimizer
 git fetch origin && git checkout main && git pull

--- a/docs/MACOS-INSTALLATION.md
+++ b/docs/MACOS-INSTALLATION.md
@@ -80,6 +80,16 @@ git pull
 
 The install script preserves your database, encryption keys, and `start.sh` configuration by backing them up before reinstalling.
 
+### Keeping .NET Updated
+
+The macOS native build uses a self-contained .NET runtime bundled with the app. The version you get depends on the .NET SDK installed via Homebrew at build time. Periodically update your SDK to pick up runtime stability and security fixes:
+
+```bash
+brew upgrade dotnet
+```
+
+Then re-run the install script to rebuild with the updated runtime.
+
 ## Logs and Debugging
 
 Application logs are in `~/network-optimizer/logs/`:

--- a/scripts/install-macos-native.sh
+++ b/scripts/install-macos-native.sh
@@ -208,6 +208,12 @@ brew install sshpass iperf3 nginx go 2>/dev/null || true
 if ! command -v dotnet &> /dev/null; then
     echo "Installing .NET SDK..."
     brew install dotnet
+else
+    # Always upgrade to latest - the self-contained build bundles the runtime,
+    # so the SDK version at build time determines which runtime ships with the app.
+    # Newer patches include stability and security fixes for macOS ARM64.
+    echo "Updating .NET SDK to latest..."
+    brew upgrade dotnet 2>/dev/null || true
 fi
 
 # Verify .NET version

--- a/scripts/install-macos-native.sh
+++ b/scripts/install-macos-native.sh
@@ -251,7 +251,7 @@ dotnet publish src/NetworkOptimizer.Web/NetworkOptimizer.Web.csproj \
     --self-contained \
     -p:PublishSingleFile=true \
     -p:IncludeNativeLibrariesForSelfExtract=true \
-    -p:EnableCompressionInSingleFile=true \
+    -p:EnableCompressionInSingleFile=false \
     -p:DebugType=None \
     -o "$INSTALL_DIR"
 


### PR DESCRIPTION
## Summary

- **Disable `EnableCompressionInSingleFile`** in the macOS native install script to work around [dotnet/runtime#123324](https://github.com/dotnet/runtime/issues/123324)
- Single-file compression causes `AccessViolationException` (native memory corruption) on osx-arm64 when the app spawns concurrent child processes - the monitoring system's parallel probes trigger this reliably
- Mac test site was crash-looping (51 crashes in stderr log, all `AccessViolationException` at random call sites in the .NET runtime)
- NAS (Docker/Linux) is unaffected - this is macOS ARM64 specific
- The bug is assigned to .NET 11.0.0 milestone, so disabling compression is the correct workaround for now
- Binary size increases slightly but no functional impact

## Test plan

- [x] Deploy to Mac site with updated deploy script and let it soak
- [x] Verify no more `AccessViolationException` crashes in stderr.log
- [x] Confirm app stays up through multiple monitoring probe cycles