### PR TITLE
Remove single-file publish on macOS (ARM64 crash fix)

### DIFF
--- a/scripts/install-macos-native.sh
+++ b/scripts/install-macos-native.sh
@@ -255,9 +255,6 @@ dotnet publish src/NetworkOptimizer.Web/NetworkOptimizer.Web.csproj \
     -c Release \
     -r "$RUNTIME" \
     --self-contained \
-    -p:PublishSingleFile=true \
-    -p:IncludeNativeLibrariesForSelfExtract=true \
-    -p:EnableCompressionInSingleFile=false \
     -p:DebugType=None \
     -o "$INSTALL_DIR"
 
@@ -324,8 +321,9 @@ fi
 
 # Step 4: Sign binary (single-file executable has native libs embedded)
 echo ""
-echo "[4/9] Signing binary..."
+echo "[4/9] Signing binaries..."
 cd "$INSTALL_DIR"
+find . -name '*.dylib' -exec codesign --force --sign - {} \;
 codesign --force --sign - NetworkOptimizer.Web
 echo "Verifying signature..."
 codesign -v NetworkOptimizer.Web


### PR DESCRIPTION
## Summary

- Removes `PublishSingleFile`, `IncludeNativeLibrariesForSelfExtract`, and `EnableCompressionInSingleFile` from the macOS install script
- Signs dylibs individually since they're no longer bundled into a single executable
- The install script also auto-upgrades the .NET SDK and documents keeping it updated

Single-file bundled executables on Apple Silicon trigger `AccessViolationException` in the .NET 10 runtime under concurrent child process I/O ([dotnet/runtime#123324](https://github.com/dotnet/runtime/issues/123324), [#112167](https://github.com/dotnet/runtime/issues/112167)). Standard self-contained deployment avoids the extraction path entirely.

Fixes #742

## Test plan

- [x] 6 consecutive restart cycles on Mac site with zero crashes (previous build crash-looped within seconds)
- [x] App starts, monitoring probes run, InfluxDB writes succeed
- [x] Let it soak on Mac site