### PR TITLE
Add 8311 community firmware ONT provider + TLS fallback

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1157,9 +1157,10 @@
                         </div>
                         <div class="form-group" style="flex: 2;">
                             <label class="form-label">Provider</label>
-                            <select class="form-control" @bind="_editingOnt.Provider">
+                            <select class="form-control" value="@_editingOnt.Provider" @onchange="OnOntProviderChanged">
                                 <option value="att-gateway">AT&T Gateway (HTTP)</option>
                                 <option value="realtek-ont">Realtek ONT Stick (HTTP)</option>
+                                <option value="8311">8311 Community Firmware (HTTP)</option>
                                 <option value="generic-http-ont">Generic HTTP ONT</option>
                             </select>
                         </div>
@@ -4314,10 +4315,24 @@
         _ontFormVisible = false;
     }
 
+    private void OnOntProviderChanged(ChangeEventArgs e)
+    {
+        var provider = e.Value?.ToString() ?? "att-gateway";
+        _editingOnt.Provider = provider;
+        _editingOnt.Port = GetOntProviderDefaultPort(provider);
+    }
+
+    private static int GetOntProviderDefaultPort(string provider) => provider switch
+    {
+        "8311" => 443,
+        _ => 80,
+    };
+
     private static string GetOntProviderDisplayName(string provider) => provider switch
     {
         "att-gateway" => "AT&T Gateway (HTTP)",
         "realtek-ont" => "Realtek ONT Stick (HTTP)",
+        "8311" => "8311 Community Firmware (HTTP)",
         "generic-http-ont" => "Generic HTTP ONT",
         _ => provider,
     };

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -198,6 +198,7 @@ builder.Services.AddSingleton<CableModemMonitorService>();
 // Register External ONT providers and service
 builder.Services.AddSingleton<IOntProvider, AttGatewayOntProvider>();
 builder.Services.AddSingleton<IOntProvider, RealtekOntProvider>();
+builder.Services.AddSingleton<IOntProvider, Lantiq8311OntProvider>();
 builder.Services.AddSingleton<IOntProvider, GenericHttpOntProvider>();
 builder.Services.AddSingleton<OntMonitorService>();
 

--- a/src/NetworkOptimizer.Web/Services/OntProviders/AttGatewayOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/AttGatewayOntProvider.cs
@@ -8,10 +8,10 @@ namespace NetworkOptimizer.Web.Services.OntProviders;
 /// <summary>
 /// Scrapes AT&amp;T residential gateways (BGW210, BGW320-500/505) that expose
 /// fiber stats via unauthenticated HTTP pages. No login required.
+/// Tries port-based scheme first, falls back to the opposite with self-signed cert bypass.
 /// </summary>
 public class AttGatewayOntProvider : IOntProvider
 {
-    private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<AttGatewayOntProvider> _logger;
 
     private static readonly Regex DdmRegex = new(
@@ -22,11 +22,8 @@ public class AttGatewayOntProvider : IOntProvider
         @"<th\s+scope=""row""[^>]*>([^<]+)</th>\s*<td\s+class=""col2""[^>]*>([^<]*)</td>",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-    public AttGatewayOntProvider(
-        IHttpClientFactory httpClientFactory,
-        ILogger<AttGatewayOntProvider> logger)
+    public AttGatewayOntProvider(ILogger<AttGatewayOntProvider> logger)
     {
-        _httpClientFactory = httpClientFactory;
         _logger = logger;
     }
 
@@ -37,7 +34,14 @@ public class AttGatewayOntProvider : IOntProvider
     {
         try
         {
-            var client = CreateHttpClient(context);
+            using var client = CreateHttpClient();
+            var baseUrl = await ResolveBaseUrlAsync(client, context, cancellationToken);
+            if (baseUrl == null)
+            {
+                _logger.LogWarning("Failed to reach AT&T gateway at {Host} via HTTP or HTTPS", context.Host);
+                return null;
+            }
+
             var stats = new OntStats
             {
                 Timestamp = DateTime.UtcNow,
@@ -46,9 +50,7 @@ public class AttGatewayOntProvider : IOntProvider
                 DeviceModel = "AT&T Gateway"
             };
 
-            // Primary endpoint: DDM optics data
-            var fiberStatUrl = BuildUrl(context, "/cgi-bin/fiberstat.ha");
-            var fiberHtml = await FetchPageAsync(client, fiberStatUrl, cancellationToken);
+            var fiberHtml = await FetchPageAsync(client, $"{baseUrl}/cgi-bin/fiberstat.ha", cancellationToken);
             if (fiberHtml == null)
             {
                 _logger.LogWarning("Failed to fetch fiberstat.ha from {Host}", context.Host);
@@ -57,9 +59,7 @@ public class AttGatewayOntProvider : IOntProvider
 
             ParseFiberStat(fiberHtml, stats);
 
-            // Secondary endpoint: broadband link status (optional)
-            var broadbandUrl = BuildUrl(context, "/cgi-bin/broadbandstatistics.ha");
-            var broadbandHtml = await FetchPageAsync(client, broadbandUrl, cancellationToken);
+            var broadbandHtml = await FetchPageAsync(client, $"{baseUrl}/cgi-bin/broadbandstatistics.ha", cancellationToken);
             if (broadbandHtml != null)
             {
                 ParseBroadbandStatistics(broadbandHtml, stats);
@@ -83,20 +83,20 @@ public class AttGatewayOntProvider : IOntProvider
     {
         try
         {
-            var client = CreateHttpClient(context);
-            var url = BuildUrl(context, "/cgi-bin/fiberstat.ha");
+            using var client = CreateHttpClient();
+            var baseUrl = await ResolveBaseUrlAsync(client, context, cancellationToken);
+            if (baseUrl == null)
+                return (false, $"Could not reach {context.Host} via HTTP or HTTPS");
 
+            var url = $"{baseUrl}/cgi-bin/fiberstat.ha";
             using var response = await client.GetAsync(url, cancellationToken);
             if (!response.IsSuccessStatusCode)
-            {
                 return (false, $"HTTP {(int)response.StatusCode} from {context.Host}");
-            }
 
             var html = await response.Content.ReadAsStringAsync(cancellationToken);
+            var scheme = baseUrl.StartsWith("https") ? "HTTPS" : "HTTP";
             if (html.Contains("Fiber Status", StringComparison.OrdinalIgnoreCase))
-            {
-                return (true, "Connected to AT&T gateway fiber stats page");
-            }
+                return (true, $"Connected ({scheme}) to AT&T gateway fiber stats page");
 
             return (false, "Page returned but does not appear to be the AT&T fiber stats page");
         }
@@ -196,20 +196,63 @@ public class AttGatewayOntProvider : IOntProvider
         }
     }
 
-    private HttpClient CreateHttpClient(OntPollContext context)
-    {
-        var client = _httpClientFactory.CreateClient("OntProvider");
-        client.Timeout = TimeSpan.FromSeconds(15);
-        return client;
-    }
-
-    private static string BuildUrl(OntPollContext context, string path)
+    /// <summary>
+    /// Tries port-based scheme first, falls back to opposite on connection/SSL failure.
+    /// </summary>
+    private async Task<string?> ResolveBaseUrlAsync(
+        HttpClient client, OntPollContext context, CancellationToken ct)
     {
         var port = context.Port > 0 ? context.Port : 80;
-        var scheme = port == 443 ? "https" : "http";
-        return port == 80 || port == 443
-            ? $"{scheme}://{context.Host}{path}"
-            : $"{scheme}://{context.Host}:{port}{path}";
+        var primaryScheme = port == 443 ? "https" : "http";
+        var fallbackScheme = primaryScheme == "https" ? "http" : "https";
+
+        var primaryUrl = BuildBaseUrl(context.Host, port, primaryScheme);
+        try
+        {
+            using var response = await client.GetAsync($"{primaryUrl}/", ct);
+            return primaryUrl;
+        }
+        catch (HttpRequestException ex) when (
+            ex.InnerException is System.Security.Authentication.AuthenticationException
+            || ex.Message.Contains("SSL", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogDebug("{Scheme} failed with SSL error for {Host}, trying {Fallback}",
+                primaryScheme.ToUpperInvariant(), context.Host, fallbackScheme.ToUpperInvariant());
+        }
+        catch (HttpRequestException)
+        {
+            _logger.LogDebug("{Scheme} connection failed for {Host}, trying {Fallback}",
+                primaryScheme.ToUpperInvariant(), context.Host, fallbackScheme.ToUpperInvariant());
+        }
+
+        var fallbackUrl = BuildBaseUrl(context.Host, port, fallbackScheme);
+        try
+        {
+            using var response = await client.GetAsync($"{fallbackUrl}/", ct);
+            _logger.LogInformation("AT&T gateway {Host} reachable via {Scheme}",
+                context.Host, fallbackScheme.ToUpperInvariant());
+            return fallbackUrl;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static HttpClient CreateHttpClient()
+    {
+        var handler = new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback = (_, _, _, _) => true,
+        };
+        return new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(15) };
+    }
+
+    private static string BuildBaseUrl(string host, int port, string scheme)
+    {
+        var portSuffix = (scheme == "http" && port == 80) || (scheme == "https" && port == 443)
+            ? "" : $":{port}";
+        return $"{scheme}://{host}{portSuffix}";
     }
 
     private async Task<string?> FetchPageAsync(

--- a/src/NetworkOptimizer.Web/Services/OntProviders/GenericHttpOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/GenericHttpOntProvider.cs
@@ -6,18 +6,15 @@ namespace NetworkOptimizer.Web.Services.OntProviders;
 
 /// <summary>
 /// Fallback skeleton provider for ONT brands not yet supported with dedicated parsing.
-/// Returns null from PollAsync (no scraping logic) but provides basic HTTP connectivity testing.
+/// Returns null from PollAsync (no scraping logic) but provides basic HTTP/HTTPS connectivity testing
+/// with self-signed cert bypass.
 /// </summary>
 public class GenericHttpOntProvider : IOntProvider
 {
-    private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<GenericHttpOntProvider> _logger;
 
-    public GenericHttpOntProvider(
-        IHttpClientFactory httpClientFactory,
-        ILogger<GenericHttpOntProvider> logger)
+    public GenericHttpOntProvider(ILogger<GenericHttpOntProvider> logger)
     {
-        _httpClientFactory = httpClientFactory;
         _logger = logger;
     }
 
@@ -38,22 +35,31 @@ public class GenericHttpOntProvider : IOntProvider
     {
         try
         {
-            var client = _httpClientFactory.CreateClient("OntProvider");
-            client.Timeout = TimeSpan.FromSeconds(10);
+            using var client = CreateHttpClient();
 
             var port = context.Port > 0 ? context.Port : 80;
-            var scheme = port == 443 ? "https" : "http";
-            var url = port == 80 || port == 443
-                ? $"{scheme}://{context.Host}/"
-                : $"{scheme}://{context.Host}:{port}/";
+            var primaryScheme = port == 443 ? "https" : "http";
+            var fallbackScheme = primaryScheme == "https" ? "http" : "https";
 
-            using var response = await client.GetAsync(url, cancellationToken);
-            if (response.IsSuccessStatusCode)
+            var primaryUrl = BuildUrl(context.Host, port, primaryScheme);
+            try
             {
-                return (true, $"HTTP {(int)response.StatusCode} - device is reachable");
+                using var response = await client.GetAsync(primaryUrl, cancellationToken);
+                if (response.IsSuccessStatusCode)
+                    return (true, $"{primaryScheme.ToUpperInvariant()} {(int)response.StatusCode} - device is reachable");
+                return (false, $"{primaryScheme.ToUpperInvariant()} {(int)response.StatusCode} from {context.Host}");
+            }
+            catch (HttpRequestException)
+            {
+                _logger.LogDebug("{Scheme} failed for {Host}, trying {Fallback}",
+                    primaryScheme.ToUpperInvariant(), context.Host, fallbackScheme.ToUpperInvariant());
             }
 
-            return (false, $"HTTP {(int)response.StatusCode} from {context.Host}");
+            var fallbackUrl = BuildUrl(context.Host, port, fallbackScheme);
+            using var fb = await client.GetAsync(fallbackUrl, cancellationToken);
+            if (fb.IsSuccessStatusCode)
+                return (true, $"{fallbackScheme.ToUpperInvariant()} {(int)fb.StatusCode} - device is reachable");
+            return (false, $"{fallbackScheme.ToUpperInvariant()} {(int)fb.StatusCode} from {context.Host}");
         }
         catch (HttpRequestException ex)
         {
@@ -67,5 +73,21 @@ public class GenericHttpOntProvider : IOntProvider
         {
             return (false, $"Unexpected error: {ex.Message}");
         }
+    }
+
+    private static HttpClient CreateHttpClient()
+    {
+        var handler = new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback = (_, _, _, _) => true,
+        };
+        return new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(10) };
+    }
+
+    private static string BuildUrl(string host, int port, string scheme)
+    {
+        var portSuffix = (scheme == "http" && port == 80) || (scheme == "https" && port == 443)
+            ? "" : $":{port}";
+        return $"{scheme}://{host}{portSuffix}/";
     }
 }

--- a/src/NetworkOptimizer.Web/Services/OntProviders/Lantiq8311OntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/Lantiq8311OntProvider.cs
@@ -1,0 +1,259 @@
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Monitoring.Providers;
+
+namespace NetworkOptimizer.Web.Services.OntProviders;
+
+/// <summary>
+/// ONT provider for Lantiq/MaxLinear-based GPON/XGS-PON SFP sticks running
+/// 8311 community firmware (LuCI web UI). Covers WAS-110, PRX126, Nokia G-010S-P,
+/// and other sticks flashed with 8311 firmware by djGrrr.
+///
+/// Uses the JSON endpoint at /cgi-bin/luci/admin/8311/gpon_status which returns
+/// pre-formatted DDM data. Auth via LuCI session cookie (sysauth).
+/// Always HTTPS with self-signed certs.
+/// </summary>
+public sealed class Lantiq8311OntProvider : IOntProvider
+{
+    public string ProviderKey => "8311";
+    public string DisplayName => "8311 Community Firmware (HTTP)";
+
+    private const int TimeoutSeconds = 10;
+    private const string GponStatusPath = "/cgi-bin/luci/admin/8311/gpon_status";
+    private const string LoginPath = "/cgi-bin/luci";
+
+    private readonly ILogger<Lantiq8311OntProvider> _logger;
+
+    public Lantiq8311OntProvider(ILogger<Lantiq8311OntProvider> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<OntStats?> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+        {
+            _logger.LogWarning("8311 ONT poll requested but Host is empty (config {Id})", context.Id);
+            return null;
+        }
+
+        try
+        {
+            var baseUrl = BuildBaseUrl(context);
+            using var handler = CreateHandler();
+            using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(TimeoutSeconds) };
+
+            if (!await LoginAsync(client, baseUrl, context, cancellationToken))
+            {
+                _logger.LogWarning("8311 ONT {Name}: login failed", context.Name);
+                return null;
+            }
+
+            var json = await client.GetStringAsync($"{baseUrl}{GponStatusPath}", cancellationToken);
+            var stats = ParseGponStatus(json, context);
+
+            _logger.LogDebug("8311 ONT {Name} polled: Rx={Rx} dBm, Tx={Tx} dBm, Temp={Temp} C, Mode={Mode}",
+                context.Name, stats.RxPowerDbm?.ToString("F2") ?? "-",
+                stats.TxPowerDbm?.ToString("F2") ?? "-",
+                stats.TemperatureC?.ToString("F1") ?? "-",
+                stats.PonType ?? "-");
+
+            return stats;
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error polling 8311 ONT {Name} at {Host}", context.Name, context.Host);
+            return null;
+        }
+    }
+
+    public async Task<(bool Success, string Message)> TestConnectionAsync(
+        OntPollContext context, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+            return (false, "Host is empty");
+
+        try
+        {
+            var baseUrl = BuildBaseUrl(context);
+            using var handler = CreateHandler();
+            using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(TimeoutSeconds) };
+
+            if (!await LoginAsync(client, baseUrl, context, cancellationToken))
+                return (false, "Login failed - check username/password (default: root / no password)");
+
+            using var response = await client.GetAsync($"{baseUrl}{GponStatusPath}", cancellationToken);
+            if (!response.IsSuccessStatusCode)
+                return (false, $"GPON status page returned HTTP {(int)response.StatusCode}");
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken);
+            if (!json.Contains("pon_mode", StringComparison.OrdinalIgnoreCase))
+                return (false, "Connected but response does not contain expected GPON status fields");
+
+            var stats = ParseGponStatus(json, context);
+            return (true, $"Connected (HTTPS) - {stats.PonType ?? "PON"} mode, RX: {stats.RxPowerDbm?.ToString("F2") ?? "?"} dBm");
+        }
+        catch (HttpRequestException ex) when (ex.Message.Contains("SSL", StringComparison.OrdinalIgnoreCase))
+        {
+            return (false, $"SSL connection failed: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Connection failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// LuCI form login: POST username/password to /cgi-bin/luci, get sysauth cookie back.
+    /// Many 8311 sticks ship with no root password set - empty password is valid.
+    /// Uses CookieContainer with AllowAutoRedirect so the sysauth cookie is automatically
+    /// stored and sent on subsequent requests.
+    /// </summary>
+    private async Task<bool> LoginAsync(
+        HttpClient client, string baseUrl, OntPollContext context, CancellationToken ct)
+    {
+        var username = context.Username ?? "root";
+        var password = context.Password ?? "";
+
+        var content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["luci_username"] = username,
+            ["luci_password"] = password,
+        });
+
+        using var response = await client.PostAsync($"{baseUrl}{LoginPath}", content, ct);
+
+        // After login (with auto-redirect following), verify we can access a protected page.
+        // The CookieContainer handles the sysauth cookie automatically.
+        using var probe = await client.GetAsync($"{baseUrl}{GponStatusPath}", ct);
+        if (probe.IsSuccessStatusCode)
+        {
+            var probeContent = await probe.Content.ReadAsStringAsync(ct);
+            return probeContent.Contains("pon_mode", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Parses the JSON response from /cgi-bin/luci/admin/8311/gpon_status.
+    /// Format: {"power":"-21.19 dBm / 5.36 dBm / 14.18 mA", "temperature":"57.77 °C (...) / 55.24 °C (...) / 46.50 °C (...)", ...}
+    /// </summary>
+    private OntStats ParseGponStatus(string json, OntPollContext context)
+    {
+        var stats = new OntStats
+        {
+            Timestamp = DateTime.UtcNow,
+            DeviceHost = context.Host,
+            DeviceName = context.Name,
+            DeviceModel = "8311 ONT",
+        };
+
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            // power: "-21.19 dBm / 5.36 dBm / 14.18 mA"
+            if (root.TryGetProperty("power", out var powerEl))
+            {
+                var power = powerEl.GetString();
+                if (power != null)
+                {
+                    var parts = power.Split('/');
+                    if (parts.Length >= 3)
+                    {
+                        stats.RxPowerDbm = ParseNumericValue(parts[0]);
+                        stats.TxPowerDbm = ParseNumericValue(parts[1]);
+                        stats.BiasMa = ParseNumericValue(parts[2]);
+                    }
+                }
+            }
+
+            // temperature: "57.77 °C (136.0 °F) / 55.24 °C (131.4 °F) / 46.50 °C (115.7 °F)"
+            // Third value is optic temperature
+            if (root.TryGetProperty("temperature", out var tempEl))
+            {
+                var temp = tempEl.GetString();
+                if (temp != null)
+                {
+                    var parts = temp.Split('/');
+                    if (parts.Length >= 3)
+                    {
+                        stats.TemperatureC = ParseNumericValue(parts[2]);
+                    }
+                    else if (parts.Length >= 1)
+                    {
+                        stats.TemperatureC = ParseNumericValue(parts[0]);
+                    }
+                }
+            }
+
+            // voltage: "3.31 V"
+            if (root.TryGetProperty("voltage", out var voltEl))
+            {
+                stats.VoltageV = ParseNumericValue(voltEl.GetString());
+            }
+
+            // pon_mode: "XGS-PON" or "GPON"
+            if (root.TryGetProperty("pon_mode", out var modeEl))
+            {
+                stats.PonType = modeEl.GetString();
+            }
+
+            // status: "O5.1, Associated state"
+            if (root.TryGetProperty("status", out var statusEl))
+            {
+                stats.LinkState = statusEl.GetString();
+            }
+
+            // module_info: "AZORES WAS-110 V1.0 (bfw)"
+            if (root.TryGetProperty("module_info", out var moduleEl))
+            {
+                var moduleInfo = moduleEl.GetString();
+                if (!string.IsNullOrEmpty(moduleInfo))
+                    stats.DeviceModel = moduleInfo;
+            }
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogDebug(ex, "Failed to parse 8311 gpon_status JSON from {Host}", context.Host);
+        }
+
+        return stats;
+    }
+
+    private static double? ParseNumericValue(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return null;
+        var match = Regex.Match(text, @"(-?[\d.]+)");
+        if (match.Success && double.TryParse(match.Groups[1].Value,
+            NumberStyles.Float, CultureInfo.InvariantCulture, out var val))
+            return val;
+        return null;
+    }
+
+    private static string BuildBaseUrl(OntPollContext context)
+    {
+        var port = context.Port > 0 ? context.Port : 443;
+        var scheme = port == 80 ? "http" : "https";
+        var portSuffix = (scheme == "https" && port == 443) || (scheme == "http" && port == 80)
+            ? "" : $":{port}";
+        return $"{scheme}://{context.Host}{portSuffix}";
+    }
+
+    private static HttpClientHandler CreateHandler()
+    {
+        return new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback = (_, _, _, _) => true,
+            CookieContainer = new CookieContainer(),
+            UseCookies = true,
+        };
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/OntProviders/RealtekOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/RealtekOntProvider.cs
@@ -10,6 +10,7 @@ namespace NetworkOptimizer.Web.Services.OntProviders;
 /// <summary>
 /// ONT provider for Realtek-based GPON stick modules (DFP-34X-2C2, etc.)
 /// that expose a web UI with form-based login and status_pon.asp for DDM data.
+/// Tries HTTP first, falls back to HTTPS with self-signed cert bypass.
 /// </summary>
 public sealed class RealtekOntProvider : IOntProvider
 {
@@ -35,13 +36,9 @@ public sealed class RealtekOntProvider : IOntProvider
 
         try
         {
-            var baseUrl = BuildBaseUrl(context);
-            using var handler = new HttpClientHandler
-            {
-                CookieContainer = new CookieContainer(),
-                UseCookies = true,
-            };
-            using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(TimeoutSeconds) };
+            var (baseUrl, client, handler) = await ResolveBaseUrlAsync(context, cancellationToken);
+            using var _ = handler;
+            using var __ = client;
 
             if (!await LoginAsync(client, baseUrl, context, cancellationToken))
             {
@@ -78,13 +75,9 @@ public sealed class RealtekOntProvider : IOntProvider
 
         try
         {
-            var baseUrl = BuildBaseUrl(context);
-            using var handler = new HttpClientHandler
-            {
-                CookieContainer = new CookieContainer(),
-                UseCookies = true,
-            };
-            using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(TimeoutSeconds) };
+            var (baseUrl, client, handler) = await ResolveBaseUrlAsync(context, cancellationToken);
+            using var _ = handler;
+            using var __ = client;
 
             if (!await LoginAsync(client, baseUrl, context, cancellationToken))
                 return (false, "Login failed - check username/password");
@@ -96,7 +89,7 @@ public sealed class RealtekOntProvider : IOntProvider
             try { await client.GetAsync($"{baseUrl}/admin/logout.asp", cancellationToken); }
             catch { }
 
-            return (true, "Connected - PON Status page accessible");
+            return (true, $"Connected ({(baseUrl.StartsWith("https") ? "HTTPS" : "HTTP")}) - PON Status page accessible");
         }
         catch (Exception ex)
         {
@@ -104,11 +97,76 @@ public sealed class RealtekOntProvider : IOntProvider
         }
     }
 
-    private static string BuildBaseUrl(OntPollContext context)
+    /// <summary>
+    /// Tries the port-based scheme first (HTTP for 80, HTTPS for 443), then falls back
+    /// to the opposite scheme. All HTTPS uses self-signed cert bypass since these are
+    /// local network devices.
+    /// </summary>
+    private async Task<(string BaseUrl, HttpClient Client, HttpClientHandler Handler)> ResolveBaseUrlAsync(
+        OntPollContext context, CancellationToken ct)
     {
         var port = context.Port > 0 ? context.Port : 80;
-        var portSuffix = port == 80 ? "" : $":{port}";
-        return $"http://{context.Host}{portSuffix}";
+        var primaryScheme = port == 443 ? "https" : "http";
+        var fallbackScheme = primaryScheme == "https" ? "http" : "https";
+
+        var primaryUrl = BuildBaseUrl(context.Host, port, primaryScheme);
+        var (handler, client) = CreateHttpClient();
+
+        try
+        {
+            using var response = await client.GetAsync(primaryUrl, ct);
+            return (primaryUrl, client, handler);
+        }
+        catch (HttpRequestException ex) when (
+            ex.InnerException is System.Security.Authentication.AuthenticationException
+            || ex.Message.Contains("SSL", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogDebug("{Scheme} failed with SSL error for {Host}, trying {Fallback}",
+                primaryScheme.ToUpperInvariant(), context.Host, fallbackScheme.ToUpperInvariant());
+        }
+        catch (HttpRequestException)
+        {
+            _logger.LogDebug("{Scheme} connection failed for {Host}, trying {Fallback}",
+                primaryScheme.ToUpperInvariant(), context.Host, fallbackScheme.ToUpperInvariant());
+        }
+
+        client.Dispose();
+        handler.Dispose();
+
+        var fallbackUrl = BuildBaseUrl(context.Host, port, fallbackScheme);
+        var (handler2, client2) = CreateHttpClient();
+
+        try
+        {
+            using var probe = await client2.GetAsync(fallbackUrl, ct);
+            _logger.LogInformation("Realtek ONT {Host} reachable via {Scheme}", context.Host, fallbackScheme.ToUpperInvariant());
+            return (fallbackUrl, client2, handler2);
+        }
+        catch
+        {
+            client2.Dispose();
+            handler2.Dispose();
+            throw;
+        }
+    }
+
+    private static (HttpClientHandler Handler, HttpClient Client) CreateHttpClient()
+    {
+        var handler = new HttpClientHandler
+        {
+            CookieContainer = new CookieContainer(),
+            UseCookies = true,
+            ServerCertificateCustomValidationCallback = (_, _, _, _) => true,
+        };
+        var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(TimeoutSeconds) };
+        return (handler, client);
+    }
+
+    private static string BuildBaseUrl(string host, int port, string scheme)
+    {
+        var portSuffix = (scheme == "http" && port == 80) || (scheme == "https" && port == 443)
+            ? "" : $":{port}";
+        return $"{scheme}://{host}{portSuffix}";
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/OntProviders/RealtekOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/RealtekOntProvider.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using System.Text;
 using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 using NetworkOptimizer.Monitoring.Models;
@@ -8,9 +7,9 @@ using NetworkOptimizer.Monitoring.Providers;
 namespace NetworkOptimizer.Web.Services.OntProviders;
 
 /// <summary>
-/// ONT provider for Realtek-based GPON stick modules (DFP-34X-2C2, etc.)
-/// that expose a web UI with form-based login and status_pon.asp for DDM data.
-/// Tries HTTP first, falls back to HTTPS with self-signed cert bypass.
+/// ONT provider for Realtek RTL960x GPON stick modules (ODI DFP-34X-2C2, V-SOL V2801F,
+/// T&amp;W TWCGPON657, etc.) that expose a web UI with form-based login and status_pon.asp
+/// for DDM data. Tries HTTP first, falls back to HTTPS with self-signed cert bypass.
 /// </summary>
 public sealed class RealtekOntProvider : IOntProvider
 {


### PR DESCRIPTION
## Summary

- **New ONT provider: 8311 Community Firmware** - Supports Lantiq/MaxLinear GPON and XGS-PON SFP sticks running 8311 firmware (WAS-110, PRX126, Nokia G-010S-P, etc.). Scrapes the `/cgi-bin/luci/admin/8311/gpon_status` JSON endpoint for DDM data (RX/TX power, temperature, voltage, bias). Auth via LuCI form login with session cookie. Defaults to HTTPS on port 443.
- **Self-signed cert bypass on all ONT providers** - All providers now accept self-signed TLS certificates, matching how cable modem providers already work. These are all local network devices.
- **HTTP/HTTPS fallback** - Providers try the port-based scheme first (HTTP for 80, HTTPS for 443), then automatically fall back to the opposite scheme on connection or SSL failure. Fixes #744 where a PRX126 stick on HTTPS was unreachable.
- **Settings port auto-update** - Selecting the 8311 provider now sets the port field to 443 automatically.

## Test plan

- [ ] Configure 8311 ONT in Settings, verify port defaults to 443
- [ ] Test Connection on 8311 stick (if available) or verify against logged gpon_status JSON
- [ ] Verify existing Realtek ONT on HTTP still works (no regression)
- [ ] Verify AT&T gateway on HTTP still works (no regression)
- [ ] Test a Realtek stick on HTTPS (fallback path)