### PR TITLE
Fix ONT/CM panel layout and commonize stats panel CSS

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Shared/CellularStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/CellularStatsPanel.razor
@@ -222,15 +222,6 @@
         gap: 1rem;
     }
 
-    .signal-quality-section {
-        display: flex;
-        align-items: center;
-        gap: 1rem;
-        padding: 0.75rem;
-        background: var(--bg-tertiary);
-        border-radius: 8px;
-    }
-
     .device-icon {
         display: flex;
         align-items: center;
@@ -240,44 +231,6 @@
         width: 48px;
         height: 48px;
         object-fit: contain;
-    }
-
-    .modem-nav {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        margin-left: auto;
-    }
-
-    .nav-btn {
-        background: var(--bg-card);
-        border: 1px solid var(--border-color);
-        color: var(--text-primary);
-        width: 28px;
-        height: 28px;
-        border-radius: 4px;
-        cursor: pointer;
-        font-size: 1.2rem;
-        line-height: 1;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    }
-
-    .nav-btn:hover:not(:disabled) {
-        background: var(--accent-color, #3b82f6);
-    }
-
-    .nav-btn:disabled {
-        opacity: 0.4;
-        cursor: not-allowed;
-    }
-
-    .modem-counter {
-        font-size: 0.8rem;
-        color: var(--text-muted, #888);
-        min-width: 30px;
-        text-align: center;
     }
 
     .signal-bars {
@@ -378,25 +331,7 @@
         font-size: 0.85rem;
     }
 
-    .cellular-metrics {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 0.75rem;
-    }
-
-    .metric-box {
-        background: var(--bg-tertiary);
-        border-radius: 8px;
-        padding: 0.75rem;
-    }
-
     .metric-header {
-        font-size: 0.9rem;
-        font-weight: 600;
-        color: var(--accent-color, #3b82f6);
-        margin-bottom: 0.5rem;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
         min-width: 50px;
         flex-shrink: 0;
     }
@@ -407,17 +342,6 @@
 
     .metric-lte .metric-header {
         color: var(--info-color, #0ea5e9);
-    }
-
-    .metric-row {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        font-size: 0.85rem;
-        padding: 2px 0;
-        gap: 0.5rem;
-        max-width: 250px;
-        margin: 0 auto;
     }
 
     .metric-label {
@@ -435,24 +359,11 @@
     .metric-value.fair { color: var(--warning-color, #f59e0b); }
     .metric-value.poor { color: var(--danger-color, #ef4444); }
 
-    /* Mobile adjustments for cellular metrics */
     @@media (max-width: 768px) {
-        .cellular-metrics {
-            grid-template-columns: 1fr;
-        }
-
         .metric-header {
             font-size: 1rem;
             margin-bottom: 0.75rem;
             min-width: 40%;
-        }
-
-        .metric-row {
-            font-size: 1rem;
-        }
-
-        .metric-value {
-            font-size: 1.2rem;
         }
     }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
@@ -123,34 +123,6 @@
 </div>
 
 <style>
-    .cellular-metrics {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 0.75rem;
-    }
-    .metric-box {
-        background: var(--bg-tertiary);
-        border-radius: 8px;
-        padding: 0.75rem;
-    }
-    .metric-header {
-        font-size: 0.9rem;
-        font-weight: 600;
-        color: var(--accent-color, #3b82f6);
-        margin-bottom: 0.5rem;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-    }
-    .metric-row {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        font-size: 0.85rem;
-        padding: 2px 0;
-        gap: 0.5rem;
-        max-width: 250px;
-        margin: 0 auto;
-    }
     .metric-label {
         color: var(--text-muted, #888);
         flex-shrink: 0;

--- a/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
@@ -259,54 +259,11 @@ else
 }
 
 <style>
-    .ont-rx-gauge {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 0.25rem;
-        flex: 1;
-    }
-    .ont-rx-gauge .rx-power-value {
-        font-size: 1.75rem;
-        font-weight: 600;
-    }
-    .ont-rx-gauge .rx-power-label {
-        font-size: 0.85rem;
-        color: var(--text-muted);
-    }
     .metric-value.ont-model-value {
         font-size: 0.95rem;
     }
     .metric-value.ont-ae-value {
         font-size: 1.1rem;
-    }
-    .cellular-metrics {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 0.75rem;
-    }
-    .metric-box {
-        background: var(--bg-tertiary);
-        border-radius: 8px;
-        padding: 0.75rem;
-    }
-    .metric-header {
-        font-size: 0.9rem;
-        font-weight: 600;
-        color: var(--accent-color, #3b82f6);
-        margin-bottom: 0.5rem;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-    }
-    .metric-row {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        font-size: 0.85rem;
-        padding: 2px 0;
-        gap: 0.5rem;
-        max-width: 250px;
-        margin: 0 auto;
     }
     .metric-label {
         color: var(--text-muted, #888);

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1599,7 +1599,7 @@ a.stat-card-link:active {
 }
 
 .metric-value {
-    font-size: 1.5rem;
+    font-size: 1.3rem;
     font-weight: 600;
     line-height: 1;
     margin-bottom: 0.25rem;
@@ -1632,6 +1632,120 @@ a.stat-card-link:active {
 
 .metric-baseline.latency-poor {
     color: var(--danger-color);
+}
+
+@media (max-width: 768px) {
+    .metric-value {
+        font-size: 1.2rem;
+    }
+}
+
+/* Shared stats panel styles (ONT, Cable Modem, Cellular) */
+
+.signal-quality-section {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.75rem;
+    background: var(--bg-tertiary);
+    border-radius: 8px;
+}
+
+.ont-rx-gauge {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.25rem;
+    flex: 1;
+}
+
+.ont-rx-gauge .rx-power-value {
+    font-size: 1.75rem;
+    font-weight: 600;
+}
+
+.ont-rx-gauge .rx-power-label {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.modem-nav {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-left: auto;
+}
+
+.nav-btn {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    color: var(--text-primary);
+    width: 28px;
+    height: 28px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 1.2rem;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.nav-btn:hover:not(:disabled) {
+    background: var(--accent-color, #3b82f6);
+}
+
+.nav-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.modem-counter {
+    font-size: 0.8rem;
+    color: var(--text-muted, #888);
+    min-width: 30px;
+    text-align: center;
+}
+
+.cellular-metrics {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+}
+
+.metric-box {
+    background: var(--bg-tertiary);
+    border-radius: 8px;
+    padding: 0.75rem;
+}
+
+.metric-header {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--accent-color, #3b82f6);
+    margin-bottom: 0.5rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.metric-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.85rem;
+    padding: 2px 0;
+    gap: 0.5rem;
+    max-width: 250px;
+    margin: 0 auto;
+}
+
+@media (max-width: 768px) {
+    .cellular-metrics {
+        grid-template-columns: 1fr;
+    }
+    .metric-row {
+        font-size: 1rem;
+    }
 }
 
 .learning-progress {


### PR DESCRIPTION
## Summary

- Fix external ONT and Cable Modem dashboard panels missing layout styles when the Cellular panel isn't rendered (sites without 5G modems)
- Move shared stats panel CSS (signal-quality-section, modem-nav, metric grid, nav buttons) from component inline styles to app.css
- Add mobile media query so Optical/Module columns stack vertically on small screens
- Reduce metric-value font size from 1.5 rem to 1.3 rem (mobile 1.2 rem)

## Test plan

- [x] Verify ONT panel renders correctly on a site with no cellular modem configured
- [x] Verify Cable Modem panel renders correctly standalone
- [x] Verify Cellular panel still renders correctly with its unique styles
- [x] Check mobile layout - Optical and Module boxes should stack vertically
- [x] Confirm metric-value text is slightly smaller than before