### PR TITLE
v1.19.2

### DIFF
--- a/src/NetworkOptimizer.Monitoring/Probes/LocalProbeExecutor.cs
+++ b/src/NetworkOptimizer.Monitoring/Probes/LocalProbeExecutor.cs
@@ -116,13 +116,13 @@ public class LocalProbeExecutor : IProbeExecutor
             return await TcpPingAsync(target, count, perPingTimeout ?? TimeSpan.FromSeconds(2), ct);
         }
 
-        // On Linux and macOS, shell out to the native `ping` binary - same approach STM
-        // takes. Kernel-timestamped RTTs are sub-ms accurate; userspace overhead from
-        // .NET's Ping class adds 1-2 ms which makes LAN measurements visibly wrong
-        // ("ping" says 0.2 ms, dashboard says 1.5 ms). Windows ping has different output
-        // and gives less useful data, so the managed Ping + Stopwatch path is the
-        // Windows MSI fallback.
-        if (!OperatingSystem.IsWindows())
+        // On Linux, shell out to the native `ping` binary - kernel-timestamped RTTs
+        // are sub-ms accurate; .NET's managed Ping adds ~0.2-0.3 ms of userspace
+        // overhead which inflates LAN measurements noticeably (20-30% on sub-1 ms
+        // hops). macOS uses managed Ping to avoid .NET 10 ARM64 Process.Start
+        // memory corruption (dotnet/runtime#123324). Windows uses managed Ping
+        // because its ping output format differs.
+        if (OperatingSystem.IsLinux())
         {
             return await NativePingAsync(target, count, perPingTimeout ?? TimeSpan.FromSeconds(2), ct);
         }

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -104,16 +104,15 @@
 
         function startAutoHideTimer(topBar) {
             clearAutoHideTimer();
-            if (!isContentScrollable()) return;
             var page = document.querySelector('[data-autohide-nav]');
             if (!page) return;
             var delay = parseInt(page.getAttribute('data-autohide-nav')) || 3000;
             autoHideTimer = setTimeout(function() {
                 var sidebarOpen = document.querySelector('.sidebar.open');
                 if (sidebarOpen) return;
-                if (!isContentScrollable()) return;
                 if (topBar && !topBar.classList.contains('top-bar-hidden')) {
                     topBar.classList.add('top-bar-hidden');
+                    setTimeout(function() { topBar.classList.add('top-bar-collapsed'); }, 350);
                     if (currentEl) currentEl.style.scrollPaddingTop = '0px';
                     var identityBar = document.querySelector('.identity-bar');
                     if (identityBar) identityBar.classList.remove('below-topbar');
@@ -139,9 +138,8 @@
                 var topBar = document.querySelector('.top-bar');
 
                 var nearBottom = currentEl.scrollHeight - st - currentEl.clientHeight < 40;
-                if (st <= 0) {
-                    // Always show nav bar at top of page
-                    topBar.classList.remove('top-bar-hidden');
+                if (st <= 0 && !(topBar.classList.contains('top-bar-hidden') && lastScrollTop > 60)) {
+                    topBar.classList.remove('top-bar-hidden', 'top-bar-collapsed');
                     currentEl.style.scrollPaddingTop = '70px';
                     startAutoHideTimer(topBar);
                     scrollUpAccum = 0;
@@ -160,7 +158,7 @@
                         clearAutoHideTimer();
                     } else if (!nearBottom && scrollUpAccum > 60) {
                         // Require 60px cumulative upward scroll, not near bottom
-                        topBar.classList.remove('top-bar-hidden');
+                        topBar.classList.remove('top-bar-hidden', 'top-bar-collapsed');
                         currentEl.style.scrollPaddingTop = '70px';
                         startAutoHideTimer(topBar);
                         scrollUpAccum = 0;
@@ -186,13 +184,16 @@
         // hidden=false: page nav (show bar, add padding)
         window.__setScrollState = function(hidden) {
             lastScrollTop = 0;
+            scrollUpAccum = 0;
             if (window.innerWidth <= 1024) {
                 var topBar = document.querySelector('.top-bar');
                 if (topBar) {
                     if (hidden) {
                         topBar.classList.add('top-bar-hidden');
+                        clearAutoHideTimer();
                     } else {
-                        topBar.classList.remove('top-bar-hidden');
+                        topBar.classList.remove('top-bar-hidden', 'top-bar-collapsed');
+                        startAutoHideTimer(topBar);
                     }
                 }
                 if (currentEl) {

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -1561,6 +1561,10 @@
 
         _ = InvokeAsync(async () =>
         {
+            // Save scroll position before content changes
+            var savedScroll = await JS.InvokeAsync<double>("eval",
+                "(function(){ var el = document.querySelector('.main-content') || document.querySelector('.page-content'); return el ? el.scrollTop : 0; })()");
+
             _tabLoading = true;
             StateHasChanged();
             try
@@ -1573,6 +1577,10 @@
                 // No _pendingChartUpdate here - Blazor's render creates the chart with data+annotations.
                 // RenderAsync on a newly created chart destroys and recreates it, causing a delay.
                 StateHasChanged();
+
+                // Restore scroll position after new tab renders
+                await JS.InvokeVoidAsync("eval",
+                    $"requestAnimationFrame(function(){{ var el = document.querySelector('.main-content') || document.querySelector('.page-content'); if(el) el.scrollTop = Math.min({savedScroll}, el.scrollHeight - el.clientHeight); }})");
             }
         });
     }

--- a/src/NetworkOptimizer.Web/Components/ScrollRestoration.razor
+++ b/src/NetworkOptimizer.Web/Components/ScrollRestoration.razor
@@ -26,6 +26,12 @@
     {
         var newPath = GetPath(e.Location);
 
+        if (newPath == _previousPath)
+        {
+            // Query-only change (e.g. tab switch) - preserve scroll and nav state
+            return;
+        }
+
         // Small delay to ensure DOM is ready after Blazor renders
         await Task.Delay(50);
 

--- a/src/NetworkOptimizer.Web/Components/Shared/CellularStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/CellularStatsPanel.razor
@@ -222,15 +222,6 @@
         gap: 1rem;
     }
 
-    .signal-quality-section {
-        display: flex;
-        align-items: center;
-        gap: 1rem;
-        padding: 0.75rem;
-        background: var(--bg-tertiary);
-        border-radius: 8px;
-    }
-
     .device-icon {
         display: flex;
         align-items: center;
@@ -240,44 +231,6 @@
         width: 48px;
         height: 48px;
         object-fit: contain;
-    }
-
-    .modem-nav {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        margin-left: auto;
-    }
-
-    .nav-btn {
-        background: var(--bg-card);
-        border: 1px solid var(--border-color);
-        color: var(--text-primary);
-        width: 28px;
-        height: 28px;
-        border-radius: 4px;
-        cursor: pointer;
-        font-size: 1.2rem;
-        line-height: 1;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    }
-
-    .nav-btn:hover:not(:disabled) {
-        background: var(--accent-color, #3b82f6);
-    }
-
-    .nav-btn:disabled {
-        opacity: 0.4;
-        cursor: not-allowed;
-    }
-
-    .modem-counter {
-        font-size: 0.8rem;
-        color: var(--text-muted, #888);
-        min-width: 30px;
-        text-align: center;
     }
 
     .signal-bars {
@@ -378,25 +331,7 @@
         font-size: 0.85rem;
     }
 
-    .cellular-metrics {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 0.75rem;
-    }
-
-    .metric-box {
-        background: var(--bg-tertiary);
-        border-radius: 8px;
-        padding: 0.75rem;
-    }
-
     .metric-header {
-        font-size: 0.9rem;
-        font-weight: 600;
-        color: var(--accent-color, #3b82f6);
-        margin-bottom: 0.5rem;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
         min-width: 50px;
         flex-shrink: 0;
     }
@@ -407,17 +342,6 @@
 
     .metric-lte .metric-header {
         color: var(--info-color, #0ea5e9);
-    }
-
-    .metric-row {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        font-size: 0.85rem;
-        padding: 2px 0;
-        gap: 0.5rem;
-        max-width: 250px;
-        margin: 0 auto;
     }
 
     .metric-label {
@@ -435,24 +359,11 @@
     .metric-value.fair { color: var(--warning-color, #f59e0b); }
     .metric-value.poor { color: var(--danger-color, #ef4444); }
 
-    /* Mobile adjustments for cellular metrics */
     @@media (max-width: 768px) {
-        .cellular-metrics {
-            grid-template-columns: 1fr;
-        }
-
         .metric-header {
             font-size: 1rem;
             margin-bottom: 0.75rem;
             min-width: 40%;
-        }
-
-        .metric-row {
-            font-size: 1rem;
-        }
-
-        .metric-value {
-            font-size: 1.2rem;
         }
     }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
@@ -123,34 +123,6 @@
 </div>
 
 <style>
-    .cellular-metrics {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 0.75rem;
-    }
-    .metric-box {
-        background: var(--bg-tertiary);
-        border-radius: 8px;
-        padding: 0.75rem;
-    }
-    .metric-header {
-        font-size: 0.9rem;
-        font-weight: 600;
-        color: var(--accent-color, #3b82f6);
-        margin-bottom: 0.5rem;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-    }
-    .metric-row {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        font-size: 0.85rem;
-        padding: 2px 0;
-        gap: 0.5rem;
-        max-width: 250px;
-        margin: 0 auto;
-    }
     .metric-label {
         color: var(--text-muted, #888);
         flex-shrink: 0;

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -107,7 +107,7 @@ else
             </div>
             <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
                 <div class="stat-value">@FormatPercent(gwStats?.MemoryUsedPercent)</div>
-                <div class="stat-label">Gateway Memory</div>
+                <div class="stat-label">Gateway Mem</div>
             </div>
             <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
                 <div class="stat-value">@FormatTemp(gwStats?.TemperatureC)</div>

--- a/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
@@ -259,54 +259,11 @@ else
 }
 
 <style>
-    .ont-rx-gauge {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 0.25rem;
-        flex: 1;
-    }
-    .ont-rx-gauge .rx-power-value {
-        font-size: 1.75rem;
-        font-weight: 600;
-    }
-    .ont-rx-gauge .rx-power-label {
-        font-size: 0.85rem;
-        color: var(--text-muted);
-    }
     .metric-value.ont-model-value {
         font-size: 0.95rem;
     }
     .metric-value.ont-ae-value {
         font-size: 1.1rem;
-    }
-    .cellular-metrics {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 0.75rem;
-    }
-    .metric-box {
-        background: var(--bg-tertiary);
-        border-radius: 8px;
-        padding: 0.75rem;
-    }
-    .metric-header {
-        font-size: 0.9rem;
-        font-weight: 600;
-        color: var(--accent-color, #3b82f6);
-        margin-bottom: 0.5rem;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-    }
-    .metric-row {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        font-size: 0.85rem;
-        padding: 2px 0;
-        gap: 0.5rem;
-        max-width: 250px;
-        margin: 0 auto;
     }
     .metric-label {
         color: var(--text-muted, #888);

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -819,6 +819,7 @@ from(bucket: ""{_bucket}"")
                 UptimeSeconds = (long?)AsDoubleOrNull(record.GetValueByKey("uptime_seconds"))
             });
         }
+        results.Sort((a, b) => a.Time.CompareTo(b.Time));
         return results;
     }
 
@@ -862,7 +863,7 @@ from(bucket: ""{_bucket}"")
             MemoryUsedPercent = mem.TryGetValue(kv.Key, out var m) ? m : null,
             TemperatureC = temp.TryGetValue(kv.Key, out var t) ? t : null,
             UptimeSeconds = uptime.TryGetValue(kv.Key, out var u) ? (long?)u : null,
-        }).ToList();
+        }).OrderBy(p => p.Time).ToList();
     }
 
     /// <summary>Raw latency query by target type - no aggregation, pairs fields in C#.</summary>
@@ -905,7 +906,7 @@ from(bucket: ""{_bucket}"")
             Time = kv.Value,
             RttAvgMs = rtt.TryGetValue(kv.Key, out var r) ? r : null,
             LossPercent = loss.TryGetValue(kv.Key, out var l) ? l : null,
-        }).ToList();
+        }).OrderBy(p => p.Time).ToList();
     }
 
     /// <summary>Time-series of RTT and loss for multiple monitoring targets, keyed by target_id.</summary>
@@ -951,6 +952,10 @@ from(bucket: ""{_bucket}"")
                 LossPercent = AsDoubleOrNull(record.GetValueByKey("loss_percent"))
             });
         }
+        // InternetService queries include legacy target_type=wan data; InfluxDB returns
+        // each tag series separately so merged lists may not be in chronological order.
+        foreach (var list in results.Values)
+            list.Sort((a, b) => a.Time.CompareTo(b.Time));
         return results;
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -568,6 +568,11 @@ a:hover {
     .wan-live-chart-card > .card-body {
         margin-right: 0;
     }
+
+    .card.wan-live-chart-card {
+        padding-top: 0;
+        padding-bottom: 0;
+    }
 }
 
 /* Clickable card */

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -3085,14 +3085,19 @@ select.form-control {
         height: auto;
         padding: 0.75rem 1rem;
         gap: 0.5rem;
-        transition: transform 0.2s ease;
+        transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
     }
 
     .top-bar.top-bar-hidden {
+        position: sticky;
+        transform: translateY(-100%);
+        pointer-events: none;
+    }
+
+    .top-bar.top-bar-hidden.top-bar-collapsed {
         position: absolute;
         left: 0;
         right: 0;
-        transform: translateY(-100%);
     }
 
     .app-footer {
@@ -14635,15 +14640,45 @@ a.affected-client:hover {
     border: 1px solid rgba(255, 255, 255, 0.06);
     border-radius: 6px;
     color: var(--text-secondary);
-    padding: 5px 7px;
     cursor: pointer;
-    line-height: 0;
     pointer-events: auto;
 }
 
 .lan-flow-map-fullscreen-btn:hover {
     color: var(--text-primary);
     background: rgba(16, 24, 32, 0.92);
+}
+.lan-flow-map-fullscreen-btn,
+.lan-flow-map-fit-btn {
+    width: 30px;
+    height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+}
+.lan-flow-map-fit-btn {
+    position: absolute;
+    z-index: 6;
+    top: 0.75rem;
+    right: 3rem;
+    background: rgba(16, 24, 32, 0.78);
+    backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 6px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    pointer-events: auto;
+}
+.lan-flow-map-fit-btn:hover {
+    color: var(--text-primary);
+    background: rgba(16, 24, 32, 0.92);
+}
+@media (max-width: 768px) {
+    .lan-flow-map-fit-btn {
+        right: 0.75rem;
+        top: 3rem;
+    }
 }
 
 .lan-flow-map-fullscreen {
@@ -14789,21 +14824,37 @@ a.affected-client:hover {
 .lan-flow-map-tooltip-row .v {
     color: var(--text-primary);
 }
-.lan-flow-map-panel-body[hidden] {
-    display: none;
+.lan-flow-map-panel-body {
+    overflow: hidden;
+    max-height: 150px;
+    opacity: 1;
+    transition: max-height 0.2s ease-out, opacity 0.2s ease, width 0.2s ease;
+}
+.lan-flow-map-panel-body.is-collapsed {
+    max-height: 0;
+    width: 0;
+    opacity: 0;
+    transition: max-height 0.15s ease-in, opacity 0.15s ease, width 0.15s ease;
 }
 .lan-flow-map-panel-title-toggle {
     cursor: pointer;
     user-select: none;
+}
+.lan-flow-map-panel:has(.is-collapsed) {
+    gap: 0;
+}
+.lan-flow-map-panel-title-toggle:has(+ .is-collapsed) {
+    margin-bottom: 0;
 }
 .lan-flow-map-panel-title-toggle::after {
     content: "▼";
     float: right;
     font-size: 0.65rem;
     opacity: 0.6;
+    transition: transform 0.2s ease;
 }
-.lan-flow-map-panel-title-toggle.is-expanded::after {
-    content: "▲";
+.lan-flow-map-panel-title-toggle:not(:has(+ .is-collapsed))::after {
+    transform: rotate(180deg);
 }
 @media (max-width: 768px) {
     .lan-flow-map-stage {
@@ -14917,7 +14968,7 @@ a.affected-client:hover {
         height: auto;
     }
     .lan-flow-map-2d-stage .lfm2d-canvas {
-        height: clamp(520px, 70vh, 820px);
+        height: clamp(400px, 50vh, 600px);
     }
     .lan-flow-map-2d-stage.lan-flow-map-fullscreen .lfm2d-canvas {
         height: 100%;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1599,7 +1599,7 @@ a.stat-card-link:active {
 }
 
 .metric-value {
-    font-size: 1.5rem;
+    font-size: 1.3rem;
     font-weight: 600;
     line-height: 1;
     margin-bottom: 0.25rem;
@@ -1632,6 +1632,120 @@ a.stat-card-link:active {
 
 .metric-baseline.latency-poor {
     color: var(--danger-color);
+}
+
+@media (max-width: 768px) {
+    .metric-value {
+        font-size: 1.2rem;
+    }
+}
+
+/* Shared stats panel styles (ONT, Cable Modem, Cellular) */
+
+.signal-quality-section {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.75rem;
+    background: var(--bg-tertiary);
+    border-radius: 8px;
+}
+
+.ont-rx-gauge {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.25rem;
+    flex: 1;
+}
+
+.ont-rx-gauge .rx-power-value {
+    font-size: 1.75rem;
+    font-weight: 600;
+}
+
+.ont-rx-gauge .rx-power-label {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.modem-nav {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-left: auto;
+}
+
+.nav-btn {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    color: var(--text-primary);
+    width: 28px;
+    height: 28px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 1.2rem;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.nav-btn:hover:not(:disabled) {
+    background: var(--accent-color, #3b82f6);
+}
+
+.nav-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.modem-counter {
+    font-size: 0.8rem;
+    color: var(--text-muted, #888);
+    min-width: 30px;
+    text-align: center;
+}
+
+.cellular-metrics {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+}
+
+.metric-box {
+    background: var(--bg-tertiary);
+    border-radius: 8px;
+    padding: 0.75rem;
+}
+
+.metric-header {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--accent-color, #3b82f6);
+    margin-bottom: 0.5rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.metric-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.85rem;
+    padding: 2px 0;
+    gap: 0.5rem;
+    max-width: 250px;
+    margin: 0 auto;
+}
+
+@media (max-width: 768px) {
+    .cellular-metrics {
+        grid-template-columns: 1fr;
+    }
+    .metric-row {
+        font-size: 1rem;
+    }
 }
 
 .learning-progress {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -386,9 +386,9 @@ class LanFlowMap2D {
                     <span class="lan-flow-map-chip is-on" data-band="5">5 GHz</span>
                     <span class="lan-flow-map-chip is-on" data-band="6">6 GHz</span>
                 </div>`;
-        if(isMobile)filterBody.hidden=true;
+        if(isMobile)filterBody.classList.add('is-collapsed');
         filter.appendChild(filterBody);
-        if(isMobile)filterTitle.addEventListener('click',()=>{filterBody.hidden=!filterBody.hidden;});
+        if(isMobile)filterTitle.addEventListener('click',()=>{filterBody.classList.toggle('is-collapsed');});
         filterBody.querySelector('.lan-flow-map-search').addEventListener('input',(e)=>{
             this._filter.text=(e.target.value||'').toLowerCase().trim();
             this._relayout();
@@ -419,9 +419,9 @@ class LanFlowMap2D {
         controls.appendChild(ctrlTitle);
         const ctrlBody=document.createElement('div');
         ctrlBody.className='lan-flow-map-panel-body';
-        if(isMobile)ctrlBody.hidden=true;
+        if(isMobile)ctrlBody.classList.add('is-collapsed');
         controls.appendChild(ctrlBody);
-        if(isMobile)ctrlTitle.addEventListener('click',()=>{ctrlBody.hidden=!ctrlBody.hidden;});
+        if(isMobile)ctrlTitle.addEventListener('click',()=>{ctrlBody.classList.toggle('is-collapsed');});
         for(const[key,label]of[['wifiClients','Wi-Fi clients'],['wiredClients','Wired clients'],['clouds','WAN globes']]){
             const row=document.createElement('div');
             row.className=`lan-flow-map-toggle ${this._overlays[key]?'is-on':''}`;
@@ -442,7 +442,7 @@ class LanFlowMap2D {
         tb.className='lfm2d-toolbar';
         tb.innerHTML=`<button class="lfm2d-btn" data-action="zin" title="Zoom in">+</button>`
             +`<button class="lfm2d-btn" data-action="zout" title="Zoom out">&minus;</button>`
-            +`<button class="lfm2d-btn" data-action="fit" title="Fit all">&#x2922;</button>`;
+            +`<button class="lfm2d-btn" data-action="fit" title="Fit all"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 14 4 20 10 20"></polyline><polyline points="20 10 20 4 14 4"></polyline><line x1="14" y1="10" x2="20" y2="4"></line><line x1="4" y1="20" x2="10" y2="14"></line></svg></button>`;
         tb.addEventListener('click',(e)=>{
             const a=e.target.closest('[data-action]')?.dataset.action;
             if(a==='zin')this._zoomBy(1.3);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1707,6 +1707,31 @@ class LanFlowMap2D {
                 ctx.fillText(uTxt,mx+4,my);
             }
         }
+
+        // Client rate labels (same style as node/link labels)
+        ctx.font=`${G.rateFont}px ${FONT}`;
+        for(const e of this._edges){
+            if(e._x1==null||!e._isCl)continue;
+            const child=e.tn||e.fn;
+            if(!child||!this._isNodeVisible(child))continue;
+            const r=this._liveRates[e.lk.portKey]||this._liveRates[e.lk.id];
+            if(!r)continue;
+            const dn=r.downstreamBps??0,up=r.upstreamBps??0;
+            if(dn>THRESH||up>THRESH){
+                const cx=child.x;
+                const cy=child.y+G.clientR+15;
+                const dTxt='↓'+formatBps(dn), uTxt='↑'+formatBps(up);
+                const tw=ctx.measureText(dTxt+'  '+uTxt).width+12;
+                ctx.fillStyle=C.labelBg;
+                this._roundRect(ctx,cx-tw/2,cy-8,tw,16,4);
+                ctx.fill();
+                ctx.textBaseline='middle';
+                ctx.textAlign='right'; ctx.fillStyle=C.downstream;
+                ctx.fillText(dTxt,cx-4,cy);
+                ctx.textAlign='left'; ctx.fillStyle=C.upstream;
+                ctx.fillText(uTxt,cx+4,cy);
+            }
+        }
     }
 
     // ---- Utility ----

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1719,7 +1719,7 @@ class LanFlowMap2D {
             const dn=r.downstreamBps??0,up=r.upstreamBps??0;
             if(dn>THRESH||up>THRESH){
                 const cx=child.x;
-                const cy=child.y+G.clientR+15;
+                const cy=child.y+G.clientR+24;
                 const dTxt='↓'+formatBps(dn), uTxt='↑'+formatBps(up);
                 const tw=ctx.measureText(dTxt+'  '+uTxt).width+12;
                 ctx.fillStyle=C.labelBg;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -340,6 +340,20 @@ export class LanFlowMap {
         return rect.bottom > 0 && rect.top < window.innerHeight;
     }
 
+    _fitCamera() {
+        let cx = 0, cy = 0, cz = 0, n = 0;
+        for (const pos of this._positions.values()) {
+            cx += pos.x; cy += pos.y; cz += pos.z; n++;
+        }
+        if (n > 0) { cx /= n; cy /= n; cz /= n; }
+        const target = new THREE.Vector3(cx, cy, cz);
+        const cam = new THREE.Vector3(cx + 60, cy + 40, cz + 60);
+        this._flyInStartCam = this.camera.position.clone();
+        this._flyInTargetCam = cam;
+        this._flyInTargetLookAt = target;
+        this._flyInUntil = performance.now() + 1300;
+    }
+
     _toggleFullscreen() {
         const el = this.stage;
         const isFs = el.classList.contains('lan-flow-map-fullscreen');
@@ -1633,7 +1647,7 @@ export class LanFlowMap {
                 <span class="lan-flow-map-chip is-on" data-band="6">6 GHz</span>
             </div>
         `;
-        if (isMobile) filterBody.hidden = true;
+        if (isMobile) filterBody.classList.add('is-collapsed');
         filter.appendChild(filterBody);
         if (isMobile) {
             filterTitle.addEventListener('click', () => this._toggleMobilePanel('filter'));
@@ -1682,7 +1696,7 @@ export class LanFlowMap {
         controls.appendChild(controlsTitle);
         const controlsBody = document.createElement('div');
         controlsBody.className = 'lan-flow-map-panel-body';
-        if (isMobile) controlsBody.hidden = true;
+        if (isMobile) controlsBody.classList.add('is-collapsed');
         controls.appendChild(controlsBody);
         if (isMobile) {
             controlsTitle.addEventListener('click', () => this._toggleMobilePanel('controls'));
@@ -1724,6 +1738,17 @@ export class LanFlowMap {
         fsBtn.addEventListener('click', () => this._toggleFullscreen());
         this.stage.appendChild(fsBtn);
         this._panels.fullscreenBtn = fsBtn;
+
+        // Fit / reset camera button
+        const fitBtn = document.createElement('button');
+        fitBtn.className = 'lan-flow-map-fit-btn';
+        fitBtn.setAttribute('data-tooltip', 'Fit all');
+        fitBtn.setAttribute('data-tooltip-hover-only', '');
+        fitBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="4 14 4 20 10 20"></polyline><polyline points="20 10 20 4 14 4"></polyline>
+            <line x1="14" y1="10" x2="20" y2="4"></line><line x1="4" y1="20" x2="10" y2="14"></line></svg>`;
+        fitBtn.addEventListener('click', () => this._fitCamera());
+        this.stage.appendChild(fitBtn);
 
         // Legend (bottom-right)
         const legend = this._makePanel('lan-flow-map-legend');
@@ -1912,15 +1937,13 @@ export class LanFlowMap {
         const panels = { filter: this._panels.filterBody, controls: this._panels.controlsBody };
         const target = panels[panelKey];
         if (!target) return;
-        const wasHidden = target.hidden;
+        const wasCollapsed = target.classList.contains('is-collapsed');
         for (const [key, body] of Object.entries(panels)) {
             if (!body) continue;
-            body.hidden = true;
-            this._panels[key]?.querySelector('.lan-flow-map-panel-title-toggle')?.classList.remove('is-expanded');
+            body.classList.add('is-collapsed');
         }
-        if (wasHidden) {
-            target.hidden = false;
-            this._panels[panelKey]?.querySelector('.lan-flow-map-panel-title-toggle')?.classList.add('is-expanded');
+        if (wasCollapsed) {
+            target.classList.remove('is-collapsed');
         }
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -93,7 +93,7 @@ function buildOpts() {
                 opposite: true,
                 show: false,
                 min: 0,
-                max: v => Math.max(v * 1.2, 5),
+                max: v => Math.max(v * 1.2, 10),
             },
             {
                 seriesName: 'RTT',
@@ -114,19 +114,19 @@ function buildOpts() {
         grid: {
             borderColor: '#374151',
             strokeDashArray: 3,
-            padding: { left: 3, right: 0, top: -8, bottom: 0 },
+            padding: { left: 3, right: 0, top: -8, bottom: -3 },
             xaxis: { lines: { show: false } },
         },
         responsive: [{
             breakpoint: 1024,
             options: {
                 yaxis: [
-                    { seriesName: 'Download', show: false, min: 0 },
-                    { seriesName: 'Download', show: false, min: 0 },
-                    { seriesName: 'Loss', opposite: true, show: false, min: 0 },
+                    { seriesName: 'Download', show: false, min: 0, max: v => v * 1.1 },
+                    { seriesName: 'Download', show: false, min: 0, max: v => v * 1.1 },
+                    { seriesName: 'Loss', opposite: true, show: false, min: 0, max: v => Math.max(v * 1.2, 10) },
                     { seriesName: 'RTT', opposite: true, show: false, min: 0 },
                 ],
-                grid: { padding: { left: -5, right: -5, top: -8, bottom: 0 } },
+                grid: { padding: { left: -5, right: -5, top: -8, bottom: -3 } },
             },
         }],
         legend: { show: false },


### PR DESCRIPTION
## Summary

- **Mobile UX overhaul** - Smooth nav bar hide/show transitions (0.35s Material easing, no layout jump), Client Dashboard auto-hide and tab switch fixes (scroll position preserved, bar stays hidden), 3D map fit button, animated map panel expand/collapse, reduced mobile map height, Gateway Mem label fix
- **Fix live WAN chart Y-axis on mobile** - Packet loss axis was auto-scaling to data max because the responsive override was missing its `max` function. Also tightened download/upload Y-axis headroom and reduced chart padding on mobile.
- **Fix chart switch-back lines** - Latency and device health charts could draw lines backwards on 30-day views when InfluxDB pivot or multi-tag-series merge returned data out of chronological order. Added time-based sorting after all pivot and merge operations.
- **Fix macOS ARM64 crashes** - Removed single-file publish and switched macOS ping probes to managed Ping to avoid .NET 10 runtime memory corruption ([dotnet/runtime#123324](https://github.com/dotnet/runtime/issues/123324)). Linux keeps native ping for sub-ms accuracy.
- **macOS install script auto-upgrades .NET SDK** on each run to pick up runtime patches
- **Commonize stats panel CSS** - Moved duplicated styles from ONT, Cable Modem, and Cellular panels into shared app.css
- **2D flow view: throughput labels on clients** - LAN/Wi-Fi clients now show download/upload rate badges (same style as network devices) when traffic exceeds the floor threshold

Fixes #742

## Test plan

- [x] 30-day latency chart (Cloudflare MCI) no longer shows switch-back line
- [x] 30-day device health chart (AP memory %) no longer shows switch-back line
- [x] 12 consecutive restart cycles on Mac site with zero crashes
- [x] Managed Ping latency verified within ~0.02-0.07 ms of native ping on LAN targets
- [x] Stats panel UI visually unchanged after CSS consolidation
- [x] Client throughput labels appear on 2D flow view when traffic > 500 Kbps, styled identically to infra node labels
- [x] Live WAN chart: packet loss at 2.86% sits at ~29% height (not 75%), download/upload fills ~90% at peak
- [x] Nav bar scroll hide/show smooth on all pages, no content jump
- [x] Client Dashboard auto-hide, tab switch scroll/nav preservation
- [x] 3D map fit button, animated map panel collapse, reduced mobile map height