### PR TITLE
Fix chart switch-back lines from unsorted InfluxDB pivot/merge results

### DIFF
--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -905,7 +905,7 @@ from(bucket: ""{_bucket}"")
             Time = kv.Value,
             RttAvgMs = rtt.TryGetValue(kv.Key, out var r) ? r : null,
             LossPercent = loss.TryGetValue(kv.Key, out var l) ? l : null,
-        }).ToList();
+        }).OrderBy(p => p.Time).ToList();
     }
 
     /// <summary>Time-series of RTT and loss for multiple monitoring targets, keyed by target_id.</summary>
@@ -951,6 +951,10 @@ from(bucket: ""{_bucket}"")
                 LossPercent = AsDoubleOrNull(record.GetValueByKey("loss_percent"))
             });
         }
+        // InternetService queries include legacy target_type=wan data; InfluxDB returns
+        // each tag series separately so merged lists may not be in chronological order.
+        foreach (var list in results.Values)
+            list.Sort((a, b) => a.Time.CompareTo(b.Time));
         return results;
     }
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -819,6 +819,7 @@ from(bucket: ""{_bucket}"")
                 UptimeSeconds = (long?)AsDoubleOrNull(record.GetValueByKey("uptime_seconds"))
             });
         }
+        results.Sort((a, b) => a.Time.CompareTo(b.Time));
         return results;
     }
 
@@ -862,7 +863,7 @@ from(bucket: ""{_bucket}"")
             MemoryUsedPercent = mem.TryGetValue(kv.Key, out var m) ? m : null,
             TemperatureC = temp.TryGetValue(kv.Key, out var t) ? t : null,
             UptimeSeconds = uptime.TryGetValue(kv.Key, out var u) ? (long?)u : null,
-        }).ToList();
+        }).OrderBy(p => p.Time).ToList();
     }
 
     /// <summary>Raw latency query by target type - no aggregation, pairs fields in C#.</summary>


### PR DESCRIPTION
## Summary

- InfluxDB's `pivot` operator can return rows out of chronological order when some fields are missing for early data points (e.g., APs not reporting CPU initially). Rows with incomplete pivot columns get appended after complete rows.
- Similarly, when the `internetservice` target type replaced `wan`, the backward-compat query merges both tag series into one list without guaranteed time ordering.
- Added time-based sorting after all InfluxDB pivot and multi-series merge operations in `MonitoringInfluxClient` (4 methods).

## Test plan

- [x] Verified Cloudflare MCI 30-day latency chart no longer shows switch-back line
- [x] Verified AP memory charts no longer show switch-back line on 30-day view
- [x] Narrower time ranges (which excluded the problematic data) continue to work normally