### PR TITLE
Fix live WAN chart Y-axis scaling and padding on mobile

### DIFF
--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -569,7 +569,7 @@ a:hover {
         margin-right: 0;
     }
 
-    .wan-live-chart-card {
+    .card.wan-live-chart-card {
         padding-top: 0;
         padding-bottom: 0;
     }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -568,6 +568,11 @@ a:hover {
     .wan-live-chart-card > .card-body {
         margin-right: 0;
     }
+
+    .wan-live-chart-card {
+        padding-top: 0;
+        padding-bottom: 0;
+    }
 }
 
 /* Clickable card */

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -124,7 +124,7 @@ function buildOpts() {
                     { seriesName: 'Download', show: false, min: 0 },
                     { seriesName: 'Download', show: false, min: 0 },
                     { seriesName: 'Loss', opposite: true, show: false, min: 0, max: v => Math.max(v * 1.2, 10) },
-                    { seriesName: 'RTT', opposite: true, show: false, min: 0, max: 10 },
+                    { seriesName: 'RTT', opposite: true, show: false, min: 0 },
                 ],
                 grid: { padding: { left: -5, right: -5, top: -8, bottom: 0 } },
             },

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -114,7 +114,7 @@ function buildOpts() {
         grid: {
             borderColor: '#374151',
             strokeDashArray: 3,
-            padding: { left: 3, right: 0, top: -8, bottom: 0 },
+            padding: { left: 3, right: 0, top: -8, bottom: -3 },
             xaxis: { lines: { show: false } },
         },
         responsive: [{
@@ -126,7 +126,7 @@ function buildOpts() {
                     { seriesName: 'Loss', opposite: true, show: false, min: 0, max: v => Math.max(v * 1.2, 10) },
                     { seriesName: 'RTT', opposite: true, show: false, min: 0 },
                 ],
-                grid: { padding: { left: -5, right: -5, top: -8, bottom: -6 } },
+                grid: { padding: { left: -5, right: -5, top: -8, bottom: -3 } },
             },
         }],
         legend: { show: false },

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -126,7 +126,7 @@ function buildOpts() {
                     { seriesName: 'Loss', opposite: true, show: false, min: 0, max: v => Math.max(v * 1.2, 10) },
                     { seriesName: 'RTT', opposite: true, show: false, min: 0 },
                 ],
-                grid: { padding: { left: -5, right: -5, top: -8, bottom: 0 } },
+                grid: { padding: { left: -5, right: -5, top: -8, bottom: -8 } },
             },
         }],
         legend: { show: false },

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -93,7 +93,7 @@ function buildOpts() {
                 opposite: true,
                 show: false,
                 min: 0,
-                max: v => Math.max(v * 1.2, 5),
+                max: v => Math.max(v * 1.2, 10),
             },
             {
                 seriesName: 'RTT',

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -126,7 +126,7 @@ function buildOpts() {
                     { seriesName: 'Loss', opposite: true, show: false, min: 0, max: v => Math.max(v * 1.2, 10) },
                     { seriesName: 'RTT', opposite: true, show: false, min: 0 },
                 ],
-                grid: { padding: { left: -5, right: -5, top: -8, bottom: -8 } },
+                grid: { padding: { left: -5, right: -5, top: -8, bottom: -6 } },
             },
         }],
         legend: { show: false },

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -121,8 +121,8 @@ function buildOpts() {
             breakpoint: 1024,
             options: {
                 yaxis: [
-                    { seriesName: 'Download', show: false, min: 0 },
-                    { seriesName: 'Download', show: false, min: 0 },
+                    { seriesName: 'Download', show: false, min: 0, max: v => v * 1.1 },
+                    { seriesName: 'Download', show: false, min: 0, max: v => v * 1.1 },
                     { seriesName: 'Loss', opposite: true, show: false, min: 0, max: v => Math.max(v * 1.2, 10) },
                     { seriesName: 'RTT', opposite: true, show: false, min: 0 },
                 ],

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -123,7 +123,7 @@ function buildOpts() {
                 yaxis: [
                     { seriesName: 'Download', show: false, min: 0 },
                     { seriesName: 'Download', show: false, min: 0 },
-                    { seriesName: 'Loss', opposite: true, show: false, min: 0 },
+                    { seriesName: 'Loss', opposite: true, show: false, min: 0, max: v => Math.max(v * 1.2, 10) },
                     { seriesName: 'RTT', opposite: true, show: false, min: 0 },
                 ],
                 grid: { padding: { left: -5, right: -5, top: -8, bottom: 0 } },

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -124,7 +124,7 @@ function buildOpts() {
                     { seriesName: 'Download', show: false, min: 0 },
                     { seriesName: 'Download', show: false, min: 0 },
                     { seriesName: 'Loss', opposite: true, show: false, min: 0, max: v => Math.max(v * 1.2, 10) },
-                    { seriesName: 'RTT', opposite: true, show: false, min: 0 },
+                    { seriesName: 'RTT', opposite: true, show: false, min: 0, max: 10 },
                 ],
                 grid: { padding: { left: -5, right: -5, top: -8, bottom: 0 } },
             },


### PR DESCRIPTION
## Summary

- Set packet loss Y-axis minimum range to 0-10 so low values aren't squished to full height (responsive override was missing `max` entirely)
- Tighten download/upload Y-axis scaling on mobile with 10% headroom instead of ApexCharts' default nice-scale rounding
- Reduce chart grid bottom padding to -3 on both desktop and mobile
- Zero out card top/bottom padding on mobile for the WAN chart container