### PR TITLE
Mobile UX: smooth nav bar transitions, map fit button, and layout fixes

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -126,8 +126,6 @@
 
         function onScroll() {
             var st = currentEl.scrollTop;
-            var topBarDbg = document.querySelector('.top-bar');
-            console.log('[scroll] st=' + st + ' lastST=' + lastScrollTop + ' hidden=' + (topBarDbg ? topBarDbg.classList.contains('top-bar-hidden') : '?') + ' collapsed=' + (topBarDbg ? topBarDbg.classList.contains('top-bar-collapsed') : '?') + ' sH=' + currentEl.scrollHeight + ' cH=' + currentEl.clientHeight);
 
             // Identity bar collapse (all screen sizes)
             var identityBar = document.querySelector('.identity-bar');
@@ -185,7 +183,6 @@
         // hidden=true: fragment nav (hide bar, no padding)
         // hidden=false: page nav (show bar, add padding)
         window.__setScrollState = function(hidden) {
-            console.log('[setScrollState] hidden=' + hidden + ' caller=' + new Error().stack.split('\n')[2].trim());
             lastScrollTop = 0;
             scrollUpAccum = 0;
             if (window.innerWidth <= 1024) {

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -138,8 +138,7 @@
                 var topBar = document.querySelector('.top-bar');
 
                 var nearBottom = currentEl.scrollHeight - st - currentEl.clientHeight < 40;
-                if (st <= 0) {
-                    // Always show nav bar at top of page
+                if (st <= 0 && !topBar.classList.contains('top-bar-collapsed')) {
                     topBar.classList.remove('top-bar-hidden', 'top-bar-collapsed');
                     currentEl.style.scrollPaddingTop = '70px';
                     startAutoHideTimer(topBar);

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -186,13 +186,16 @@
         // hidden=false: page nav (show bar, add padding)
         window.__setScrollState = function(hidden) {
             lastScrollTop = 0;
+            scrollUpAccum = 0;
             if (window.innerWidth <= 1024) {
                 var topBar = document.querySelector('.top-bar');
                 if (topBar) {
                     if (hidden) {
                         topBar.classList.add('top-bar-hidden');
+                        clearAutoHideTimer();
                     } else {
                         topBar.classList.remove('top-bar-hidden');
+                        startAutoHideTimer(topBar);
                     }
                 }
                 if (currentEl) {

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -140,8 +140,7 @@
                 var topBar = document.querySelector('.top-bar');
 
                 var nearBottom = currentEl.scrollHeight - st - currentEl.clientHeight < 40;
-                if (st <= 0) {
-                    // Always show nav bar at top of page
+                if (st <= 0 && !(topBar.classList.contains('top-bar-hidden') && lastScrollTop > 60)) {
                     topBar.classList.remove('top-bar-hidden', 'top-bar-collapsed');
                     currentEl.style.scrollPaddingTop = '70px';
                     startAutoHideTimer(topBar);

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -138,7 +138,8 @@
                 var topBar = document.querySelector('.top-bar');
 
                 var nearBottom = currentEl.scrollHeight - st - currentEl.clientHeight < 40;
-                if (st <= 0 && !topBar.classList.contains('top-bar-collapsed')) {
+                if (st <= 0) {
+                    // Always show nav bar at top of page
                     topBar.classList.remove('top-bar-hidden', 'top-bar-collapsed');
                     currentEl.style.scrollPaddingTop = '70px';
                     startAutoHideTimer(topBar);

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -104,16 +104,15 @@
 
         function startAutoHideTimer(topBar) {
             clearAutoHideTimer();
-            if (!isContentScrollable()) return;
             var page = document.querySelector('[data-autohide-nav]');
             if (!page) return;
             var delay = parseInt(page.getAttribute('data-autohide-nav')) || 3000;
             autoHideTimer = setTimeout(function() {
                 var sidebarOpen = document.querySelector('.sidebar.open');
                 if (sidebarOpen) return;
-                if (!isContentScrollable()) return;
                 if (topBar && !topBar.classList.contains('top-bar-hidden')) {
                     topBar.classList.add('top-bar-hidden');
+                    setTimeout(function() { topBar.classList.add('top-bar-collapsed'); }, 350);
                     if (currentEl) currentEl.style.scrollPaddingTop = '0px';
                     var identityBar = document.querySelector('.identity-bar');
                     if (identityBar) identityBar.classList.remove('below-topbar');
@@ -141,7 +140,7 @@
                 var nearBottom = currentEl.scrollHeight - st - currentEl.clientHeight < 40;
                 if (st <= 0) {
                     // Always show nav bar at top of page
-                    topBar.classList.remove('top-bar-hidden');
+                    topBar.classList.remove('top-bar-hidden', 'top-bar-collapsed');
                     currentEl.style.scrollPaddingTop = '70px';
                     startAutoHideTimer(topBar);
                     scrollUpAccum = 0;
@@ -160,7 +159,7 @@
                         clearAutoHideTimer();
                     } else if (!nearBottom && scrollUpAccum > 60) {
                         // Require 60px cumulative upward scroll, not near bottom
-                        topBar.classList.remove('top-bar-hidden');
+                        topBar.classList.remove('top-bar-hidden', 'top-bar-collapsed');
                         currentEl.style.scrollPaddingTop = '70px';
                         startAutoHideTimer(topBar);
                         scrollUpAccum = 0;
@@ -194,7 +193,7 @@
                         topBar.classList.add('top-bar-hidden');
                         clearAutoHideTimer();
                     } else {
-                        topBar.classList.remove('top-bar-hidden');
+                        topBar.classList.remove('top-bar-hidden', 'top-bar-collapsed');
                         startAutoHideTimer(topBar);
                     }
                 }

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -126,6 +126,8 @@
 
         function onScroll() {
             var st = currentEl.scrollTop;
+            var topBarDbg = document.querySelector('.top-bar');
+            console.log('[scroll] st=' + st + ' lastST=' + lastScrollTop + ' hidden=' + (topBarDbg ? topBarDbg.classList.contains('top-bar-hidden') : '?') + ' collapsed=' + (topBarDbg ? topBarDbg.classList.contains('top-bar-collapsed') : '?') + ' sH=' + currentEl.scrollHeight + ' cH=' + currentEl.clientHeight);
 
             // Identity bar collapse (all screen sizes)
             var identityBar = document.querySelector('.identity-bar');
@@ -184,6 +186,7 @@
         // hidden=true: fragment nav (hide bar, no padding)
         // hidden=false: page nav (show bar, add padding)
         window.__setScrollState = function(hidden) {
+            console.log('[setScrollState] hidden=' + hidden + ' caller=' + new Error().stack.split('\n')[2].trim());
             lastScrollTop = 0;
             scrollUpAccum = 0;
             if (window.innerWidth <= 1024) {

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -140,12 +140,15 @@
                 var topBar = document.querySelector('.top-bar');
 
                 var nearBottom = currentEl.scrollHeight - st - currentEl.clientHeight < 40;
-                if (st <= 0 && !(topBar.classList.contains('top-bar-hidden') && lastScrollTop > 60)) {
+                if (st <= 0 && !topBar.classList.contains('top-bar-hidden')) {
                     topBar.classList.remove('top-bar-hidden', 'top-bar-collapsed');
                     currentEl.style.scrollPaddingTop = '70px';
                     startAutoHideTimer(topBar);
                     scrollUpAccum = 0;
                     lastScrollTop = st;
+                } else if (st <= 0) {
+                    lastScrollTop = st;
+                    scrollUpAccum = 0;
                 } else if (topBar) {
                     var delta = lastScrollTop - st; // positive = scrolling up
                     if (delta > 0) {

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -140,15 +140,12 @@
                 var topBar = document.querySelector('.top-bar');
 
                 var nearBottom = currentEl.scrollHeight - st - currentEl.clientHeight < 40;
-                if (st <= 0 && !topBar.classList.contains('top-bar-hidden')) {
+                if (st <= 0 && !(topBar.classList.contains('top-bar-hidden') && lastScrollTop > 60)) {
                     topBar.classList.remove('top-bar-hidden', 'top-bar-collapsed');
                     currentEl.style.scrollPaddingTop = '70px';
                     startAutoHideTimer(topBar);
                     scrollUpAccum = 0;
                     lastScrollTop = st;
-                } else if (st <= 0) {
-                    lastScrollTop = st;
-                    scrollUpAccum = 0;
                 } else if (topBar) {
                     var delta = lastScrollTop - st; // positive = scrolling up
                     if (delta > 0) {

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -1561,6 +1561,10 @@
 
         _ = InvokeAsync(async () =>
         {
+            // Save scroll position before content changes
+            var savedScroll = await JS.InvokeAsync<double>("eval",
+                "(function(){ var el = document.querySelector('.main-content') || document.querySelector('.page-content'); return el ? el.scrollTop : 0; })()");
+
             _tabLoading = true;
             StateHasChanged();
             try
@@ -1573,6 +1577,10 @@
                 // No _pendingChartUpdate here - Blazor's render creates the chart with data+annotations.
                 // RenderAsync on a newly created chart destroys and recreates it, causing a delay.
                 StateHasChanged();
+
+                // Restore scroll position after new tab renders
+                await JS.InvokeVoidAsync("eval",
+                    $"requestAnimationFrame(function(){{ var el = document.querySelector('.main-content') || document.querySelector('.page-content'); if(el) el.scrollTop = Math.min({savedScroll}, el.scrollHeight - el.clientHeight); }})");
             }
         });
     }

--- a/src/NetworkOptimizer.Web/Components/ScrollRestoration.razor
+++ b/src/NetworkOptimizer.Web/Components/ScrollRestoration.razor
@@ -26,6 +26,12 @@
     {
         var newPath = GetPath(e.Location);
 
+        if (newPath == _previousPath)
+        {
+            // Query-only change (e.g. tab switch) - preserve scroll and nav state
+            return;
+        }
+
         // Small delay to ensure DOM is ready after Blazor renders
         await Task.Delay(50);
 

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -107,8 +107,7 @@ else
             </div>
             <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
                 <div class="stat-value">@FormatPercent(gwStats?.MemoryUsedPercent)</div>
-                <div class="stat-label hide-mobile">Gateway Memory</div>
-                <div class="stat-label show-mobile" style="display:none">Gateway Mem</div>
+                <div class="stat-label">Gateway Mem</div>
             </div>
             <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
                 <div class="stat-value">@FormatTemp(gwStats?.TemperatureC)</div>

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -107,7 +107,7 @@ else
             </div>
             <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
                 <div class="stat-value">@FormatPercent(gwStats?.MemoryUsedPercent)</div>
-                <div class="stat-label">Gateway Memory</div>
+                <div class="stat-label">Gateway <span class="hide-mobile">Memory</span><span class="show-mobile">Mem.</span></div>
             </div>
             <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
                 <div class="stat-value">@FormatTemp(gwStats?.TemperatureC)</div>

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -107,7 +107,8 @@ else
             </div>
             <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
                 <div class="stat-value">@FormatPercent(gwStats?.MemoryUsedPercent)</div>
-                <div class="stat-label"><span class="hide-mobile">Gateway Memory</span><span class="show-mobile">Gateway Mem.</span></div>
+                <div class="stat-label hide-mobile">Gateway Memory</div>
+                <div class="stat-label show-mobile" style="display:none">Gateway Mem</div>
             </div>
             <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
                 <div class="stat-value">@FormatTemp(gwStats?.TemperatureC)</div>

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -107,7 +107,7 @@ else
             </div>
             <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
                 <div class="stat-value">@FormatPercent(gwStats?.MemoryUsedPercent)</div>
-                <div class="stat-label">Gateway <span class="hide-mobile">Memory</span><span class="show-mobile">Mem.</span></div>
+                <div class="stat-label"><span class="hide-mobile">Gateway Memory</span><span class="show-mobile">Gateway Mem.</span></div>
             </div>
             <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo(gwDeviceUrl))">
                 <div class="stat-value">@FormatTemp(gwStats?.TemperatureC)</div>

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -3085,15 +3085,19 @@ select.form-control {
         height: auto;
         padding: 0.75rem 1rem;
         gap: 0.5rem;
-        transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1),
-                    margin-bottom 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+        transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
     }
 
     .top-bar.top-bar-hidden {
         position: sticky;
         transform: translateY(-100%);
-        margin-bottom: -56px;
         pointer-events: none;
+    }
+
+    .top-bar.top-bar-hidden.top-bar-collapsed {
+        position: absolute;
+        left: 0;
+        right: 0;
     }
 
     .app-footer {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14922,7 +14922,7 @@ a.affected-client:hover {
         height: auto;
     }
     .lan-flow-map-2d-stage .lfm2d-canvas {
-        height: clamp(520px, 70vh, 820px);
+        height: clamp(400px, 50vh, 600px);
     }
     .lan-flow-map-2d-stage.lan-flow-map-fullscreen .lfm2d-canvas {
         height: 100%;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -425,11 +425,7 @@ a:hover {
 .card-header-collapsible {
     cursor: pointer;
     user-select: none;
-    transition: background 0.15s ease, border-bottom 0.2s ease;
-}
-
-.card-header-collapsible:has(+ .expand-wrapper:not(.expanded)) {
-    border-bottom-color: transparent;
+    transition: background 0.15s ease;
 }
 
 .card-header-collapsible:hover {
@@ -849,9 +845,6 @@ a.stat-card-link:active {
     }
     .monitoring-stat-card .stat-value {
         font-size: 1rem;
-    }
-    .monitoring-stat-card .stat-label {
-        white-space: nowrap;
     }
     .monitoring-stat-pair {
         gap: 0.5rem;
@@ -14807,6 +14800,9 @@ a.affected-client:hover {
 .lan-flow-map-panel-title-toggle {
     cursor: pointer;
     user-select: none;
+}
+.lan-flow-map-panel-title-toggle:not(.is-expanded) {
+    margin-bottom: 0;
 }
 .lan-flow-map-panel-title-toggle::after {
     content: "▼";

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14650,6 +14650,32 @@ a.affected-client:hover {
     color: var(--text-primary);
     background: rgba(16, 24, 32, 0.92);
 }
+.lan-flow-map-fit-btn {
+    position: absolute;
+    z-index: 6;
+    top: 0.75rem;
+    right: 3rem;
+    background: rgba(16, 24, 32, 0.78);
+    backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 6px;
+    color: var(--text-secondary);
+    padding: 5px 7px;
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+    pointer-events: auto;
+}
+.lan-flow-map-fit-btn:hover {
+    color: var(--text-primary);
+    background: rgba(16, 24, 32, 0.92);
+}
+@media (max-width: 768px) {
+    .lan-flow-map-fit-btn {
+        right: 0.75rem;
+        top: 2.75rem;
+    }
+}
 
 .lan-flow-map-fullscreen {
     position: fixed;
@@ -14794,14 +14820,22 @@ a.affected-client:hover {
 .lan-flow-map-tooltip-row .v {
     color: var(--text-primary);
 }
-.lan-flow-map-panel-body[hidden] {
-    display: none;
+.lan-flow-map-panel-body {
+    overflow: hidden;
+    max-height: 500px;
+    opacity: 1;
+    transition: max-height 0.25s ease-out, opacity 0.2s ease;
+}
+.lan-flow-map-panel-body.is-collapsed {
+    max-height: 0;
+    opacity: 0;
+    transition: max-height 0.2s ease-in, opacity 0.15s ease;
 }
 .lan-flow-map-panel-title-toggle {
     cursor: pointer;
     user-select: none;
 }
-.lan-flow-map-panel-title-toggle:not(.is-expanded) {
+.lan-flow-map-panel-title-toggle:has(+ .is-collapsed) {
     margin-bottom: 0;
 }
 .lan-flow-map-panel-title-toggle::after {
@@ -14809,9 +14843,10 @@ a.affected-client:hover {
     float: right;
     font-size: 0.65rem;
     opacity: 0.6;
+    transition: transform 0.2s ease;
 }
-.lan-flow-map-panel-title-toggle.is-expanded::after {
-    content: "▲";
+.lan-flow-map-panel-title-toggle:not(:has(+ .is-collapsed))::after {
+    transform: rotate(180deg);
 }
 @media (max-width: 768px) {
     .lan-flow-map-stage {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -846,6 +846,9 @@ a.stat-card-link:active {
     .monitoring-stat-card .stat-value {
         font-size: 1rem;
     }
+    .monitoring-stat-card .stat-label {
+        white-space: nowrap;
+    }
     .monitoring-stat-pair {
         gap: 0.5rem;
         flex-basis: 170px;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14845,6 +14845,9 @@ a.affected-client:hover {
 .lan-flow-map-panel:has(.is-collapsed) {
     gap: 0;
 }
+.lan-flow-map-panel-title-toggle:has(+ .is-collapsed) {
+    margin-bottom: 0;
+}
 .lan-flow-map-panel-title-toggle::after {
     content: "▼";
     float: right;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14640,15 +14640,22 @@ a.affected-client:hover {
     border: 1px solid rgba(255, 255, 255, 0.06);
     border-radius: 6px;
     color: var(--text-secondary);
-    padding: 5px 7px;
     cursor: pointer;
-    line-height: 0;
     pointer-events: auto;
 }
 
 .lan-flow-map-fullscreen-btn:hover {
     color: var(--text-primary);
     background: rgba(16, 24, 32, 0.92);
+}
+.lan-flow-map-fullscreen-btn,
+.lan-flow-map-fit-btn {
+    width: 30px;
+    height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
 }
 .lan-flow-map-fit-btn {
     position: absolute;
@@ -14660,10 +14667,8 @@ a.affected-client:hover {
     border: 1px solid rgba(255, 255, 255, 0.06);
     border-radius: 6px;
     color: var(--text-secondary);
-    padding: 5px 7px;
     cursor: pointer;
     font-size: 16px;
-    line-height: 0;
     pointer-events: auto;
 }
 .lan-flow-map-fit-btn:hover {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14663,7 +14663,7 @@ a.affected-client:hover {
     padding: 5px 7px;
     cursor: pointer;
     font-size: 16px;
-    line-height: 1;
+    line-height: 0;
     pointer-events: auto;
 }
 .lan-flow-map-fit-btn:hover {
@@ -14824,12 +14824,13 @@ a.affected-client:hover {
     overflow: hidden;
     max-height: 500px;
     opacity: 1;
-    transition: max-height 0.25s ease-out, opacity 0.2s ease;
+    transition: max-height 0.25s ease-out, opacity 0.2s ease, width 0.2s ease;
 }
 .lan-flow-map-panel-body.is-collapsed {
     max-height: 0;
+    width: 0;
     opacity: 0;
-    transition: max-height 0.2s ease-in, opacity 0.15s ease;
+    transition: max-height 0.2s ease-in, opacity 0.15s ease, width 0.2s ease;
 }
 .lan-flow-map-panel-title-toggle {
     cursor: pointer;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14668,7 +14668,8 @@ a.affected-client:hover {
     border-radius: 6px;
     color: var(--text-secondary);
     cursor: pointer;
-    font-size: 16px;
+    font-size: 24px;
+    padding-bottom: 4px;
     pointer-events: auto;
 }
 .lan-flow-map-fit-btn:hover {
@@ -14678,7 +14679,7 @@ a.affected-client:hover {
 @media (max-width: 768px) {
     .lan-flow-map-fit-btn {
         right: 0.75rem;
-        top: 2.75rem;
+        top: 3rem;
     }
 }
 
@@ -14827,22 +14828,22 @@ a.affected-client:hover {
 }
 .lan-flow-map-panel-body {
     overflow: hidden;
-    max-height: 500px;
+    max-height: 150px;
     opacity: 1;
-    transition: max-height 0.25s ease-out, opacity 0.2s ease, width 0.2s ease;
+    transition: max-height 0.2s ease-out, opacity 0.2s ease, width 0.2s ease;
 }
 .lan-flow-map-panel-body.is-collapsed {
     max-height: 0;
     width: 0;
     opacity: 0;
-    transition: max-height 0.2s ease-in, opacity 0.15s ease, width 0.2s ease;
+    transition: max-height 0.15s ease-in, opacity 0.15s ease, width 0.15s ease;
 }
 .lan-flow-map-panel-title-toggle {
     cursor: pointer;
     user-select: none;
 }
-.lan-flow-map-panel-title-toggle:has(+ .is-collapsed) {
-    margin-bottom: 0;
+.lan-flow-map-panel:has(.is-collapsed) {
+    gap: 0;
 }
 .lan-flow-map-panel-title-toggle::after {
     content: "▼";
@@ -14956,6 +14957,10 @@ a.affected-client:hover {
     align-items: center;
     justify-content: center;
     line-height: 1;
+}
+.lfm2d-btn[data-action="fit"] {
+    font-size: 24px;
+    padding-bottom: 4px;
 }
 .lfm2d-btn:hover {
     background: rgba(51,56,68,0.9);

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -3085,12 +3085,14 @@ select.form-control {
         height: auto;
         padding: 0.75rem 1rem;
         gap: 0.5rem;
-        transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+        transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1),
+                    margin-bottom 0.35s cubic-bezier(0.4, 0, 0.2, 1);
     }
 
     .top-bar.top-bar-hidden {
         position: sticky;
         transform: translateY(-100%);
+        margin-bottom: -56px;
         pointer-events: none;
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14668,8 +14668,6 @@ a.affected-client:hover {
     border-radius: 6px;
     color: var(--text-secondary);
     cursor: pointer;
-    font-size: 24px;
-    padding-bottom: 4px;
     pointer-events: auto;
 }
 .lan-flow-map-fit-btn:hover {
@@ -14960,10 +14958,6 @@ a.affected-client:hover {
     align-items: center;
     justify-content: center;
     line-height: 1;
-}
-.lfm2d-btn[data-action="fit"] {
-    font-size: 24px;
-    padding-bottom: 4px;
 }
 .lfm2d-btn:hover {
     background: rgba(51,56,68,0.9);

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -425,7 +425,11 @@ a:hover {
 .card-header-collapsible {
     cursor: pointer;
     user-select: none;
-    transition: background 0.15s ease;
+    transition: background 0.15s ease, border-bottom 0.2s ease;
+}
+
+.card-header-collapsible:has(+ .expand-wrapper:not(.expanded)) {
+    border-bottom-color: transparent;
 }
 
 .card-header-collapsible:hover {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -3085,14 +3085,13 @@ select.form-control {
         height: auto;
         padding: 0.75rem 1rem;
         gap: 0.5rem;
-        transition: transform 0.2s ease;
+        transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
     }
 
     .top-bar.top-bar-hidden {
-        position: absolute;
-        left: 0;
-        right: 0;
+        position: sticky;
         transform: translateY(-100%);
+        pointer-events: none;
     }
 
     .app-footer {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -386,9 +386,9 @@ class LanFlowMap2D {
                     <span class="lan-flow-map-chip is-on" data-band="5">5 GHz</span>
                     <span class="lan-flow-map-chip is-on" data-band="6">6 GHz</span>
                 </div>`;
-        if(isMobile)filterBody.hidden=true;
+        if(isMobile)filterBody.classList.add('is-collapsed');
         filter.appendChild(filterBody);
-        if(isMobile)filterTitle.addEventListener('click',()=>{filterBody.hidden=!filterBody.hidden;});
+        if(isMobile)filterTitle.addEventListener('click',()=>{filterBody.classList.toggle('is-collapsed');});
         filterBody.querySelector('.lan-flow-map-search').addEventListener('input',(e)=>{
             this._filter.text=(e.target.value||'').toLowerCase().trim();
             this._relayout();
@@ -419,9 +419,9 @@ class LanFlowMap2D {
         controls.appendChild(ctrlTitle);
         const ctrlBody=document.createElement('div');
         ctrlBody.className='lan-flow-map-panel-body';
-        if(isMobile)ctrlBody.hidden=true;
+        if(isMobile)ctrlBody.classList.add('is-collapsed');
         controls.appendChild(ctrlBody);
-        if(isMobile)ctrlTitle.addEventListener('click',()=>{ctrlBody.hidden=!ctrlBody.hidden;});
+        if(isMobile)ctrlTitle.addEventListener('click',()=>{ctrlBody.classList.toggle('is-collapsed');});
         for(const[key,label]of[['wifiClients','Wi-Fi clients'],['wiredClients','Wired clients'],['clouds','WAN globes']]){
             const row=document.createElement('div');
             row.className=`lan-flow-map-toggle ${this._overlays[key]?'is-on':''}`;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -442,7 +442,7 @@ class LanFlowMap2D {
         tb.className='lfm2d-toolbar';
         tb.innerHTML=`<button class="lfm2d-btn" data-action="zin" title="Zoom in">+</button>`
             +`<button class="lfm2d-btn" data-action="zout" title="Zoom out">&minus;</button>`
-            +`<button class="lfm2d-btn" data-action="fit" title="Fit all">&#x2922;</button>`;
+            +`<button class="lfm2d-btn" data-action="fit" title="Fit all"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 14 4 20 10 20"></polyline><polyline points="20 10 20 4 14 4"></polyline><line x1="14" y1="10" x2="20" y2="4"></line><line x1="4" y1="20" x2="10" y2="14"></line></svg></button>`;
         tb.addEventListener('click',(e)=>{
             const a=e.target.closest('[data-action]')?.dataset.action;
             if(a==='zin')this._zoomBy(1.3);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1744,7 +1744,9 @@ export class LanFlowMap {
         fitBtn.className = 'lan-flow-map-fit-btn';
         fitBtn.setAttribute('data-tooltip', 'Fit all');
         fitBtn.setAttribute('data-tooltip-hover-only', '');
-        fitBtn.innerHTML = '&#x2922;';
+        fitBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="4 14 4 20 10 20"></polyline><polyline points="20 10 20 4 14 4"></polyline>
+            <line x1="14" y1="10" x2="20" y2="4"></line><line x1="4" y1="20" x2="10" y2="14"></line></svg>`;
         fitBtn.addEventListener('click', () => this._fitCamera());
         this.stage.appendChild(fitBtn);
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -340,6 +340,20 @@ export class LanFlowMap {
         return rect.bottom > 0 && rect.top < window.innerHeight;
     }
 
+    _fitCamera() {
+        let cx = 0, cy = 0, cz = 0, n = 0;
+        for (const pos of this._positions.values()) {
+            cx += pos.x; cy += pos.y; cz += pos.z; n++;
+        }
+        if (n > 0) { cx /= n; cy /= n; cz /= n; }
+        const target = new THREE.Vector3(cx, cy, cz);
+        const cam = new THREE.Vector3(cx + 60, cy + 40, cz + 60);
+        this._flyInStartCam = this.camera.position.clone();
+        this._flyInTargetCam = cam;
+        this._flyInTargetLookAt = target;
+        this._flyInUntil = performance.now() + 1300;
+    }
+
     _toggleFullscreen() {
         const el = this.stage;
         const isFs = el.classList.contains('lan-flow-map-fullscreen');
@@ -1633,7 +1647,7 @@ export class LanFlowMap {
                 <span class="lan-flow-map-chip is-on" data-band="6">6 GHz</span>
             </div>
         `;
-        if (isMobile) filterBody.hidden = true;
+        if (isMobile) filterBody.classList.add('is-collapsed');
         filter.appendChild(filterBody);
         if (isMobile) {
             filterTitle.addEventListener('click', () => this._toggleMobilePanel('filter'));
@@ -1682,7 +1696,7 @@ export class LanFlowMap {
         controls.appendChild(controlsTitle);
         const controlsBody = document.createElement('div');
         controlsBody.className = 'lan-flow-map-panel-body';
-        if (isMobile) controlsBody.hidden = true;
+        if (isMobile) controlsBody.classList.add('is-collapsed');
         controls.appendChild(controlsBody);
         if (isMobile) {
             controlsTitle.addEventListener('click', () => this._toggleMobilePanel('controls'));
@@ -1724,6 +1738,15 @@ export class LanFlowMap {
         fsBtn.addEventListener('click', () => this._toggleFullscreen());
         this.stage.appendChild(fsBtn);
         this._panels.fullscreenBtn = fsBtn;
+
+        // Fit / reset camera button
+        const fitBtn = document.createElement('button');
+        fitBtn.className = 'lan-flow-map-fit-btn';
+        fitBtn.setAttribute('data-tooltip', 'Fit all');
+        fitBtn.setAttribute('data-tooltip-hover-only', '');
+        fitBtn.innerHTML = '&#x2922;';
+        fitBtn.addEventListener('click', () => this._fitCamera());
+        this.stage.appendChild(fitBtn);
 
         // Legend (bottom-right)
         const legend = this._makePanel('lan-flow-map-legend');
@@ -1912,15 +1935,13 @@ export class LanFlowMap {
         const panels = { filter: this._panels.filterBody, controls: this._panels.controlsBody };
         const target = panels[panelKey];
         if (!target) return;
-        const wasHidden = target.hidden;
+        const wasCollapsed = target.classList.contains('is-collapsed');
         for (const [key, body] of Object.entries(panels)) {
             if (!body) continue;
-            body.hidden = true;
-            this._panels[key]?.querySelector('.lan-flow-map-panel-title-toggle')?.classList.remove('is-expanded');
+            body.classList.add('is-collapsed');
         }
-        if (wasHidden) {
-            target.hidden = false;
-            this._panels[panelKey]?.querySelector('.lan-flow-map-panel-title-toggle')?.classList.add('is-expanded');
+        if (wasCollapsed) {
+            target.classList.remove('is-collapsed');
         }
     }
 


### PR DESCRIPTION
## Summary

### Nav Bar Transitions
- **Smoother scroll-triggered hide/show** - Replaced the abrupt 0.2s ease with a 0.35s Material-style cubic-bezier curve. Bar stays `position: sticky` during scroll-triggered hide so there's no layout jump from the sticky-to-absolute switch.
- **Client Dashboard auto-hide fixed** - Auto-hide timer now fires on page navigation and works regardless of content scrollability. After the slide-up transition completes, switches to `position: absolute` via `top-bar-collapsed` so content fills the space.
- **Content-resize scroll clamp guard** - When tab content shrinks and the browser clamps scrollTop to 0, the bar no longer pops back. Detects the jump vs genuine user scroll-to-top.
- **Tab switches preserve scroll and nav state** - ScrollRestoration skips reset on query-only URL changes. Client Dashboard saves/restores scrollTop around tab re-renders.

### Map Improvements
- **3D map fit button** - New camera reset button matching the 2D map's fit button. Flies camera to the computed topology centroid. Positioned left of fullscreen on desktop, below on mobile. Both maps use identical SVG icons.
- **Animated panel expand/collapse** - Filter and Overlays panels now animate open/close with max-height + opacity transitions instead of instant hidden toggle. Collapsed panels shrink to fit side-by-side.
- **Reduced 2D map height on mobile** - Monitoring page map canvas now uses `clamp(400px, 50vh, 600px)` matching the Dashboard sizing.

### Layout Fixes
- **Gateway Mem label** - Shortened from "Gateway Memory" to fit without wrapping.
- **Uniform button sizing** - 3D map fullscreen and fit buttons share 30x30 square sizing with flexbox centering.

## Test plan

- [x] Regular pages (Monitoring, Settings): scroll down hides bar smoothly, scroll up 60px shows it smoothly, no content jump
- [x] Client Dashboard: bar auto-hides ~2s after load, content fills space, scroll up brings it back
- [x] Client Dashboard tab switches (drag scroll): nav bar stays hidden, scroll position preserved, no jump to top
- [x] Client Dashboard tab switches (wheel scroll): same behavior as drag scroll
- [x] Wi-Fi Optimizer tab switches: nav bar and scroll position preserved
- [x] Monitoring tab switches: nav bar and scroll position preserved
- [x] Sidebar open blocks auto-hide timer
- [x] Cross-page navigation resets bar state correctly
- [x] Fragment navigation (hash links) hides bar correctly
- [x] 3D map fit button resets camera to topology centroid with fly-in animation
- [x] 2D map fit button icon matches 3D map (SVG, cross-platform)
- [x] Map panel collapse/expand animates smoothly, panels fit side-by-side when collapsed
- [x] Gateway Mem label centered and doesn't wrap on mobile
- [x] 2D map height reduced on mobile Monitoring page