### PR TITLE
WAN live chart: plot every SNMP sample exactly once

### DIFF
--- a/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
@@ -27,6 +27,7 @@ public static class MonitoringChartEndpoints
             catch { }
 
             double wanDown = 0, wanUp = 0;
+            DateTime? sampleTime = null;
             if (gatewayMac != null && wanIfNames != null)
             {
                 foreach (var ifName in wanIfNames)
@@ -35,6 +36,8 @@ public static class MonitoringChartEndpoints
                     if (rate == null) continue;
                     wanDown += rate.UpBps;
                     wanUp += rate.DownBps;
+                    if (sampleTime == null || rate.LastUpdate > sampleTime)
+                        sampleTime = rate.LastUpdate;
                 }
             }
 
@@ -84,6 +87,9 @@ public static class MonitoringChartEndpoints
                 uploadBps = wanUp,
                 rttMs = meanRtt,
                 lossPercent = meanLoss,
+                // SNMP sample timestamp (max LastUpdate across WAN ports) so the
+                // live chart can dedupe polls that land on the same sample.
+                sampleTime = sampleTime?.ToString("o"),
             });
         });
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -212,8 +212,11 @@ async function pollLive() {
         // unsynchronized ~5s clocks (SNMP tier vs setInterval) alias: some
         // samples get plotted twice and others never appear. Falls back to
         // client time when no SNMP rate data exists (rtt-only sites).
+        // Strictly newer, not just different: overlapping fetches can resolve
+        // out of order, and pushing an older sample after a newer one makes
+        // the line double back on itself.
         const sampleTime = d.sampleTime ? new Date(d.sampleTime).getTime() : Date.now();
-        if (sampleTime === lastSampleTime) return;
+        if (sampleTime <= lastSampleTime) return;
         lastSampleTime = sampleTime;
         const cutoff = Date.now() - HISTORY_MINUTES * 60000;
         buffer.push({

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -199,6 +199,14 @@ async function loadHistory() {
             rtt: p.rttMs,
             loss: p.lossPercent ?? 0,
         }));
+        // Advance the live-sample watermark past the reloaded history so the
+        // next pollLive can't append a sample older than the last history
+        // point (its response may predate the newest cycle history includes -
+        // on mount lastSampleTime is 0, and after a background-tab refocus
+        // it can be minutes stale).
+        for (const p of buffer) {
+            if (p.time > lastSampleTime) lastSampleTime = p.time;
+        }
     } catch { }
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -5,7 +5,9 @@
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 
 const HISTORY_MINUTES = 5;
-const POLL_MS = 5000;
+// Poll faster than the 5s SNMP fast tier so no sample is missed when the two
+// clocks drift out of phase; pollLive dedupes repeat reads via sampleTime.
+const POLL_MS = 2500;
 const SCROLL_MS = 500;
 const COLOR_DL   = '#3b82f6';
 const COLOR_UL   = '#10b981';
@@ -19,6 +21,7 @@ let buffer = [];
 let elId = null;
 let visHandler = null;
 let mountGen = 0;
+let lastSampleTime = 0;
 
 function formatBps(v) {
     if (v == null || v < 1) return '0';
@@ -204,9 +207,17 @@ async function pollLive() {
         const resp = await fetch('/api/monitoring/live-stats', { credentials: 'same-origin' });
         if (!resp.ok) return;
         const d = await resp.json();
+        // Stamp the point with the server-side SNMP sample time and skip polls
+        // that return the sample we already plotted. Without this, two
+        // unsynchronized ~5s clocks (SNMP tier vs setInterval) alias: some
+        // samples get plotted twice and others never appear. Falls back to
+        // client time when no SNMP rate data exists (rtt-only sites).
+        const sampleTime = d.sampleTime ? new Date(d.sampleTime).getTime() : Date.now();
+        if (sampleTime === lastSampleTime) return;
+        lastSampleTime = sampleTime;
         const cutoff = Date.now() - HISTORY_MINUTES * 60000;
         buffer.push({
-            time: Date.now(),
+            time: sampleTime,
             download: d.downloadBps,
             upload: d.uploadBps,
             loss: d.lossPercent ?? 0,
@@ -222,6 +233,7 @@ export async function mount(containerId, opts) {
     if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
     if (chart) { chart.destroy(); chart = null; }
     buffer = [];
+    lastSampleTime = 0;
     const gen = ++mountGen;
     elId = containerId;
     const el = document.getElementById(containerId);


### PR DESCRIPTION
## Summary

The WAN live chart polled the live-stats endpoint on its own 5s timer while the SNMP fast tier produces a sample every ~5s. Two unsynchronized clocks drift in phase, so the chart would periodically plot the same sample twice and miss others entirely - a missed sample meant a full 5s window of rate data (e.g. a short burst) never appeared on the live trace.

## Changes

- `/api/monitoring/live-stats` now includes `sampleTime`, the timestamp of the underlying SNMP sample (max `LastUpdate` across WAN ports). Read path only - no changes to the collection agent, the InfluxDB write path, or the LAN flow map endpoints.
- The chart polls every 2.5s so every sample is seen at least once, stamps points with the server-side sample time instead of client poll time, and skips polls that return a sample it already plotted.
- The guard requires a strictly newer sample time: overlapping fetches can resolve out of order, and plotting an older sample after a newer one made the line double back on itself.

## Result

One chart point per SNMP sample, on the true sample timestamps - no duplicates, no missed samples.