### PR TITLE
Release v1.19.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,17 @@ Full time-series network monitoring that runs entirely on your hardware. SNMP po
 
 The Live View gives you two real-time topology maps. The 3D map is a Three.js visualization with bi-directional particle-flow traffic for all LAN traffic (not just WAN-bound traffic like in UniFi Network), WASD camera navigation, and double-click on any client to jump to their performance dashboard. The 2D map is a hierarchical flow diagram that's easier to read at a glance, showing the same live throughput rates, device health badges, and client connections on a canvas you can pan and zoom. Both support historic playback: scrub backward through your monitoring data to see what your network looked like at any point, with full playback controls and adjustable speed.
 
-Latency and packet loss charting covers four target categories (LAN fabric, ISP access, transit, and internet services) with per-target filter badges, time range presets from 15 minutes to 30 days, and sub-15ms query performance. Device health charts track temperature, CPU, and memory per device over time. SFP/ONT optical monitoring shows live RX/TX power, temperature, voltage, and bias current for PON modules, with automatic GPON vs XGS-PON detection.
+Latency and packet loss charting covers four target categories (LAN fabric, ISP access, transit, and internet services) with per-target filter badges, time range presets from 15 minutes to 30 days, and sub-15ms query performance. Device health charts track temperature, CPU, and memory for all your devices on one screen; in UniFi Network those stats only exist in each device's individual Insights view, with no single pane of glass for hardware health. SFP/ONT optical monitoring shows live RX/TX power, temperature, voltage, and bias current for PON modules, with automatic GPON vs XGS-PON detection.
 
 Upstream Path Discovery uses automated traceroute (ICMP and UDP probes) to map your ISP's access infrastructure, transit networks, and internet service endpoints. It identifies your OLT/CMTS, ISP edge routers, and transit ASNs with full latency and loss charting per hop category. Both maps include a WAN node for each internet connection showing live RTT, current throughput, latest speed test results, and ISP expected speeds.
+
+### How readings are measured
+
+Where Network Optimizer and UniFi Network show different numbers, it's because we read the raw sensors and count the standard way:
+
+- **CPU temperature** is the SoC die sensor read directly over SNMP (LM-SENSORS `temp-cpu`). It responds within seconds to load. UniFi Network appears to report a damped board probe used for fan control, which reads several degrees lower and lags behind load changes.
+- **Memory** is real used memory excluding Linux page cache, the same number `htop` shows. Linux deliberately fills idle RAM with cache, so counting cache as "used" (as UniFi Network does on some models) makes a healthy gateway look like it's leaking memory.
+- **Switch temperatures** fall back to the UniFi API where the SNMP tree exposes no thermal data.
 
 For the full changelog, see the [v1.17.0 release notes](https://github.com/Ozark-Connect/NetworkOptimizer/releases/tag/v1.17.0) and subsequent patch releases.
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -422,6 +422,18 @@ else
                     <div class="chart-header"><h3 class="chart-title">Memory</h3></div>
                     <div class="health-mem-chart"></div>
                 </div>
+
+                <details class="setup-guide" style="margin-top: 1.25rem;">
+                    <summary>Why do these readings differ from UniFi Network?</summary>
+                    <div class="setup-guide-content">
+                        <p>Network Optimizer reads raw sensors over SNMP and counts the standard way, so some values won't match what UniFi Network shows:</p>
+                        <ul>
+                            <li><strong>CPU temperature</strong> is the SoC die sensor, which responds within seconds to load. UniFi Network appears to report a damped board probe used for fan control, which reads several degrees lower and lags behind load changes.</li>
+                            <li><strong>Memory</strong> is real used memory excluding Linux page cache, the same number <code>htop</code> shows. Linux deliberately fills idle RAM with cache, so counting cache as used makes a healthy gateway look like it's leaking memory.</li>
+                            <li><strong>Switch temperatures</strong> come from the UniFi API, since switch SNMP trees expose no thermal data.</li>
+                        </ul>
+                    </div>
+                </details>
             </div>
         </div>
     }

--- a/src/NetworkOptimizer.Web/Components/Shared/SqmStatusPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SqmStatusPanel.razor
@@ -28,6 +28,10 @@
                 {
                     <a href="/settings" class="btn btn-primary">Configure Gateway</a>
                 }
+                else if (isAwaitingStatus)
+                {
+                    <a href="/sqm" class="btn btn-primary">Manage SQM</a>
+                }
                 else
                 {
                     <a href="/sqm" class="btn btn-primary">Configure Adaptive SQM</a>
@@ -100,6 +104,7 @@
     private string statusClass = "";
     private string? errorMessage;
     private bool needsGatewayConfig = false;
+    private bool isAwaitingStatus = false;
     private DateTime? lastUpdate;
 
     // Track if we've ever seen active status (don't flip to "Not Deployed" on transient failures)
@@ -112,6 +117,8 @@
     private const string NotDeployedLabel = "Not Deployed";
     private const string NotDeployedClass = "offline";
     private const string NotDeployedMessage = "Experiencing bufferbloat? Deploy Adaptive SQM to optimize your WAN performance.";
+    private const string AwaitingStatusLabel = "Awaiting Status";
+    private const string AwaitingStatusMessage = "Adaptive SQM is configured. Waiting for the gateway to report status. If this persists, check the deployment on the SQM page.";
 
     // Auto-refresh timer (60 seconds)
     private System.Threading.Timer? _refreshTimer;
@@ -139,6 +146,7 @@
     {
         errorMessage = null;
         needsGatewayConfig = false;
+        isAwaitingStatus = false;
         var hasSavedEnabledConfig = false;
 
         try
@@ -192,10 +200,11 @@
                 }
                 else
                 {
-                    // TC Monitor responded but no interfaces configured
-                    SetNotDeployedStatus();
-                    // Only poll if we have saved enabled configs (user is setting up)
-                    _shouldPoll = hasSavedEnabledConfig;
+                    // TC Monitor responded but no interfaces yet. An enabled
+                    // config exists (we returned early above otherwise), so this
+                    // is the post-deploy or cold-start window, not "not deployed".
+                    SetAwaitingStatus();
+                    _shouldPoll = true;
                 }
             }
             else
@@ -210,10 +219,10 @@
                 }
                 else
                 {
-                    // Never seen active, show as not deployed
-                    SetNotDeployedStatus();
-                    // Only poll if we have saved enabled configs (user is setting up)
-                    _shouldPoll = hasSavedEnabledConfig;
+                    // Never seen active, but an enabled config exists - the
+                    // monitor just hasn't answered yet (e.g. app cold start).
+                    SetAwaitingStatus();
+                    _shouldPoll = true;
                 }
             }
         }
@@ -245,6 +254,14 @@
         statusLabel = NotDeployedLabel;
         statusClass = NotDeployedClass;
         errorMessage = NotDeployedMessage;
+    }
+
+    private void SetAwaitingStatus()
+    {
+        statusLabel = AwaitingStatusLabel;
+        statusClass = "warning";
+        errorMessage = AwaitingStatusMessage;
+        isAwaitingStatus = true;
     }
 
     private async Task RefreshStats()

--- a/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
@@ -27,6 +27,7 @@ public static class MonitoringChartEndpoints
             catch { }
 
             double wanDown = 0, wanUp = 0;
+            DateTime? sampleTime = null;
             if (gatewayMac != null && wanIfNames != null)
             {
                 foreach (var ifName in wanIfNames)
@@ -35,6 +36,8 @@ public static class MonitoringChartEndpoints
                     if (rate == null) continue;
                     wanDown += rate.UpBps;
                     wanUp += rate.DownBps;
+                    if (sampleTime == null || rate.LastUpdate > sampleTime)
+                        sampleTime = rate.LastUpdate;
                 }
             }
 
@@ -84,6 +87,9 @@ public static class MonitoringChartEndpoints
                 uploadBps = wanUp,
                 rttMs = meanRtt,
                 lossPercent = meanLoss,
+                // SNMP sample timestamp (max LastUpdate across WAN ports) so the
+                // live chart can dedupe polls that land on the same sample.
+                sampleTime = sampleTime?.ToString("o"),
             });
         });
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
@@ -32,7 +32,8 @@ function baseOpts(height, yTitle, yFormatter, extra) {
             type: 'area', height,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: false },
+            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },
         stroke: { curve: 'smooth', width: 2 },
@@ -237,6 +238,28 @@ function updateCustomLabel(container) {
         btn.setAttribute('data-tooltip', 'Custom date range');
         if (clearBtn) clearBtn.remove();
     }
+}
+
+// Grafana-style drag-select on a chart becomes a custom time window,
+// synced to the range selector (custom-range button + popover inputs).
+function applyDragZoom(xaxis) {
+    const container = document.getElementById(containerId);
+    if (container && xaxis && Number.isFinite(xaxis.min) && Number.isFinite(xaxis.max) && xaxis.min < xaxis.max) {
+        customFrom = new Date(xaxis.min);
+        customTo = new Date(xaxis.max);
+        isCustomRange = true;
+        windowOffset = 0;
+        container.querySelectorAll('[data-range]').forEach(b => b.classList.remove('active'));
+        const fromInput = container.querySelector('[data-input="from"]');
+        const toInput = container.querySelector('[data-input="to"]');
+        if (fromInput) fromInput.value = toLocalDatetimeString(customFrom);
+        if (toInput) toInput.value = toLocalDatetimeString(customTo);
+        updateCustomLabel(container);
+        loadAndUpdate();
+        startPoll();
+    }
+    // Cancel ApexCharts' client-side zoom; the refetch repaints the selected window
+    return { xaxis: { min: undefined, max: undefined } };
 }
 
 function selectPresetRange(container, hours) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
@@ -32,7 +32,8 @@ function baseOpts(height, yTitle, yFormatter, extra) {
             type: 'area', height,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: false },
+            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },
         stroke: { curve: 'smooth', width: 2 },
@@ -267,6 +268,28 @@ function updateCustomLabel(container) {
         btn.setAttribute('data-tooltip', 'Custom date range');
         if (clearBtn) clearBtn.remove();
     }
+}
+
+// Grafana-style drag-select on a chart becomes a custom time window,
+// synced to the range selector (custom-range button + popover inputs).
+function applyDragZoom(xaxis) {
+    const container = document.getElementById(containerId);
+    if (container && xaxis && Number.isFinite(xaxis.min) && Number.isFinite(xaxis.max) && xaxis.min < xaxis.max) {
+        customFrom = new Date(xaxis.min);
+        customTo = new Date(xaxis.max);
+        isCustomRange = true;
+        windowOffset = 0;
+        container.querySelectorAll('[data-range]').forEach(b => b.classList.remove('active'));
+        const fromInput = container.querySelector('[data-input="from"]');
+        const toInput = container.querySelector('[data-input="to"]');
+        if (fromInput) fromInput.value = toLocalDatetimeString(customFrom);
+        if (toInput) toInput.value = toLocalDatetimeString(customTo);
+        updateCustomLabel(container);
+        loadAndUpdate();
+        startPoll();
+    }
+    // Cancel ApexCharts' client-side zoom; the refetch repaints the selected window
+    return { xaxis: { min: undefined, max: undefined } };
 }
 
 function selectPresetRange(container, hours) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -46,7 +46,8 @@ function baseOpts(height, yTitle, yFormatter, extra) {
             type: 'line', height,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: false },
+            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },
         stroke: { curve: 'smooth', width: 2 },
@@ -224,6 +225,28 @@ function updateCustomLabel(container) {
         btn.setAttribute('data-tooltip', 'Custom date range');
         if (clearBtn) clearBtn.remove();
     }
+}
+
+// Grafana-style drag-select on a chart becomes a custom time window,
+// synced to the range selector (custom-range button + popover inputs).
+function applyDragZoom(xaxis) {
+    const container = document.getElementById(containerId);
+    if (container && xaxis && Number.isFinite(xaxis.min) && Number.isFinite(xaxis.max) && xaxis.min < xaxis.max) {
+        customFrom = new Date(xaxis.min);
+        customTo = new Date(xaxis.max);
+        isCustomRange = true;
+        windowOffset = 0;
+        container.querySelectorAll('[data-range]').forEach(b => b.classList.remove('active'));
+        const fromInput = container.querySelector('[data-input="from"]');
+        const toInput = container.querySelector('[data-input="to"]');
+        if (fromInput) fromInput.value = toLocalDatetimeString(customFrom);
+        if (toInput) toInput.value = toLocalDatetimeString(customTo);
+        updateCustomLabel(container);
+        loadAndUpdate();
+        startPoll();
+    }
+    // Cancel ApexCharts' client-side zoom; the refetch repaints the selected window
+    return { xaxis: { min: undefined, max: undefined } };
 }
 
 function selectPresetRange(container, hours) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -53,7 +53,8 @@ function baseChartOpts(type, yTitle, yFormatter, extraOpts) {
             height: type === 'area' ? 200 : 260,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: false },
+            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },
         stroke: { curve: 'smooth', width: 2 },
@@ -462,6 +463,25 @@ function updateCustomLabel(container) {
         btn.setAttribute('data-tooltip', 'Custom date range');
         if (clearBtn) clearBtn.remove();
     }
+}
+
+// Grafana-style drag-select on a chart becomes a custom time window,
+// synced to the range selector (custom-range button + popover inputs).
+function applyDragZoom(xaxis) {
+    const container = document.getElementById(containerId);
+    if (container && xaxis && Number.isFinite(xaxis.min) && Number.isFinite(xaxis.max) && xaxis.min < xaxis.max) {
+        customFrom = new Date(xaxis.min);
+        customTo = new Date(xaxis.max);
+        isCustomRange = true;
+        windowOffset = 0;
+        container.querySelectorAll('[data-range]').forEach(b => b.classList.remove('active'));
+        syncPopoverInputs(container);
+        updateCustomLabel(container);
+        loadAndUpdate();
+        startPoll();
+    }
+    // Cancel ApexCharts' client-side zoom; the refetch repaints the selected window
+    return { xaxis: { min: undefined, max: undefined } };
 }
 
 function getEffectiveFrom() {

--- a/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
@@ -30,7 +30,8 @@ function baseOpts(height, yTitle, yFormatter, extra) {
             type: 'area', height,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: false },
+            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },
         stroke: { curve: 'smooth', width: 2 },
@@ -249,6 +250,28 @@ function updateCustomLabel(container) {
         btn.setAttribute('data-tooltip', 'Custom date range');
         if (clearBtn) clearBtn.remove();
     }
+}
+
+// Grafana-style drag-select on a chart becomes a custom time window,
+// synced to the range selector (custom-range button + popover inputs).
+function applyDragZoom(xaxis) {
+    const container = document.getElementById(containerId);
+    if (container && xaxis && Number.isFinite(xaxis.min) && Number.isFinite(xaxis.max) && xaxis.min < xaxis.max) {
+        customFrom = new Date(xaxis.min);
+        customTo = new Date(xaxis.max);
+        isCustomRange = true;
+        windowOffset = 0;
+        container.querySelectorAll('[data-range]').forEach(b => b.classList.remove('active'));
+        const fromInput = container.querySelector('[data-input="from"]');
+        const toInput = container.querySelector('[data-input="to"]');
+        if (fromInput) fromInput.value = toLocalDatetimeString(customFrom);
+        if (toInput) toInput.value = toLocalDatetimeString(customTo);
+        updateCustomLabel(container);
+        loadAndUpdate();
+        startPoll();
+    }
+    // Cancel ApexCharts' client-side zoom; the refetch repaints the selected window
+    return { xaxis: { min: undefined, max: undefined } };
 }
 
 function selectPresetRange(container, hours) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -30,7 +30,8 @@ function baseOpts(height, yTitle, yFormatter, extra) {
             type: 'area', height,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: false },
+            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },
         stroke: { curve: 'smooth', width: 2 },
@@ -242,6 +243,28 @@ function updateCustomLabel(container) {
         btn.setAttribute('data-tooltip', 'Custom date range');
         if (clearBtn) clearBtn.remove();
     }
+}
+
+// Grafana-style drag-select on a chart becomes a custom time window,
+// synced to the range selector (custom-range button + popover inputs).
+function applyDragZoom(xaxis) {
+    const container = document.getElementById(containerId);
+    if (container && xaxis && Number.isFinite(xaxis.min) && Number.isFinite(xaxis.max) && xaxis.min < xaxis.max) {
+        customFrom = new Date(xaxis.min);
+        customTo = new Date(xaxis.max);
+        isCustomRange = true;
+        windowOffset = 0;
+        container.querySelectorAll('[data-range]').forEach(b => b.classList.remove('active'));
+        const fromInput = container.querySelector('[data-input="from"]');
+        const toInput = container.querySelector('[data-input="to"]');
+        if (fromInput) fromInput.value = toLocalDatetimeString(customFrom);
+        if (toInput) toInput.value = toLocalDatetimeString(customTo);
+        updateCustomLabel(container);
+        loadAndUpdate();
+        startPoll();
+    }
+    // Cancel ApexCharts' client-side zoom; the refetch repaints the selected window
+    return { xaxis: { min: undefined, max: undefined } };
 }
 
 function selectPresetRange(container, hours) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -5,7 +5,9 @@
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 
 const HISTORY_MINUTES = 5;
-const POLL_MS = 5000;
+// Poll faster than the 5s SNMP fast tier so no sample is missed when the two
+// clocks drift out of phase; pollLive dedupes repeat reads via sampleTime.
+const POLL_MS = 2500;
 const SCROLL_MS = 500;
 const COLOR_DL   = '#3b82f6';
 const COLOR_UL   = '#10b981';
@@ -19,6 +21,7 @@ let buffer = [];
 let elId = null;
 let visHandler = null;
 let mountGen = 0;
+let lastSampleTime = 0;
 
 function formatBps(v) {
     if (v == null || v < 1) return '0';
@@ -196,6 +199,14 @@ async function loadHistory() {
             rtt: p.rttMs,
             loss: p.lossPercent ?? 0,
         }));
+        // Advance the live-sample watermark past the reloaded history so the
+        // next pollLive can't append a sample older than the last history
+        // point (its response may predate the newest cycle history includes -
+        // on mount lastSampleTime is 0, and after a background-tab refocus
+        // it can be minutes stale).
+        for (const p of buffer) {
+            if (p.time > lastSampleTime) lastSampleTime = p.time;
+        }
     } catch { }
 }
 
@@ -204,9 +215,20 @@ async function pollLive() {
         const resp = await fetch('/api/monitoring/live-stats', { credentials: 'same-origin' });
         if (!resp.ok) return;
         const d = await resp.json();
+        // Stamp the point with the server-side SNMP sample time and skip polls
+        // that return the sample we already plotted. Without this, two
+        // unsynchronized ~5s clocks (SNMP tier vs setInterval) alias: some
+        // samples get plotted twice and others never appear. Falls back to
+        // client time when no SNMP rate data exists (rtt-only sites).
+        // Strictly newer, not just different: overlapping fetches can resolve
+        // out of order, and pushing an older sample after a newer one makes
+        // the line double back on itself.
+        const sampleTime = d.sampleTime ? new Date(d.sampleTime).getTime() : Date.now();
+        if (sampleTime <= lastSampleTime) return;
+        lastSampleTime = sampleTime;
         const cutoff = Date.now() - HISTORY_MINUTES * 60000;
         buffer.push({
-            time: Date.now(),
+            time: sampleTime,
             download: d.downloadBps,
             upload: d.uploadBps,
             loss: d.lossPercent ?? 0,
@@ -222,6 +244,7 @@ export async function mount(containerId, opts) {
     if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
     if (chart) { chart.destroy(); chart = null; }
     buffer = [];
+    lastSampleTime = 0;
     const gen = ++mountGen;
     elId = containerId;
     const el = document.getElementById(containerId);


### PR DESCRIPTION
Patch release: drag-to-zoom on the monitoring stats charts, measurement transparency for device health readings, and live chart and SQM panel fixes.

## Monitoring

- **Drag to zoom on stats charts** (#762) - Drag horizontally on any chart in the Network Performance, Device Stats, SFP Stats, CM Stats, ONT Stats, and Cellular Stats tabs to zoom into that time window, Grafana style. The selection becomes a custom range fully synced with the time range selector, data is refetched for the selected window so zooming reveals finer detail instead of stretching the downsampled series, and live polling pauses until a preset is reselected.
- **Device health measurement transparency** (#763) - New collapsed "Why do these readings differ from UniFi Network?" panel under the Device Stats charts, with a matching README section. CPU temperature is the SoC die sensor read over SNMP (responds within seconds to load), memory is real used memory excluding Linux page cache (the same number htop shows), and switch temperatures fall back to the UniFi API. Addresses the confusion in #761.
- **WAN live chart: plot every SNMP sample exactly once** (#757) - The live chart polled the 5s SNMP cache on its own 5s timer, so phase drift caused duplicated and missed samples, and out-of-order fetches could make the line double back. The chart now polls at 2.5s, stamps points with the server-side sample time, and only plots strictly newer samples, including across history reloads on mount and tab refocus.

## Adaptive SQM

- **Dashboard panel: distinguish awaiting gateway status from not deployed** (#758) - With an enabled SQM config, an app cold start or transient TC Monitor miss briefly showed the "Not Deployed" pitch. Those windows now show an "Awaiting Status" state that keeps polling; "Not Deployed" is reserved for when no enabled config exists.