### PR TITLE
Proxmox: select LXC template matching host architecture

### DIFF
--- a/scripts/proxmox/install.sh
+++ b/scripts/proxmox/install.sh
@@ -187,12 +187,31 @@ find_debian_template() {
         aarch64) host_arch="arm64" ;;
     esac
 
-    # Find the latest debian template for the selected version and architecture
+    local available
+    available=$(pveam available -section system 2>/dev/null | awk '{print $2}')
+
+    # Find the latest debian template for the selected version and architecture.
+    # Standard PVE naming: debian-13-standard_13.1-2_amd64.tar.zst
     local template
-    template=$(pveam available -section system 2>/dev/null | awk '{print $2}' | grep "debian-${version}-standard" | grep "_${host_arch}\.tar" | tail -1 || true)
+    template=$(echo "$available" | grep "debian-${version}-standard" | grep "_${host_arch}\.tar" | tail -1 || true)
+
+    # ARM ports of Proxmox (PXVIRT) publish their own templates named by
+    # codename and build date instead: debian-trixie-20260328_arm64.tar.xz
+    if [[ -z "$template" ]]; then
+        local codename=""
+        case "$version" in
+            11) codename="bullseye" ;;
+            12) codename="bookworm" ;;
+            13) codename="trixie" ;;
+            14) codename="forky" ;;
+        esac
+        if [[ -n "$codename" ]]; then
+            template=$(echo "$available" | grep "^debian-${codename}-" | grep "_${host_arch}\.tar" | tail -1 || true)
+        fi
+    fi
 
     if [[ -z "$template" ]]; then
-        msg_error "Could not find Debian ${version} template for ${host_arch} in repository."
+        msg_error "Could not find a Debian ${version} template for ${host_arch} in the repository."
         msg_info "Available templates:"
         pveam available -section system 2>/dev/null | grep -i debian | head -5
         exit 1

--- a/scripts/proxmox/install.sh
+++ b/scripts/proxmox/install.sh
@@ -177,12 +177,22 @@ find_debian_template() {
     # Update template list
     pveam update &>/dev/null || true
 
-    # Find the latest debian template for the selected version
+    # Match the host architecture. ARM ports of Proxmox (e.g. PXVIRT on a
+    # Raspberry Pi) can list templates for multiple architectures, and an
+    # amd64 rootfs fails to start on an arm64 host.
+    local host_arch
+    host_arch=$(dpkg --print-architecture 2>/dev/null || uname -m)
+    case "$host_arch" in
+        x86_64) host_arch="amd64" ;;
+        aarch64) host_arch="arm64" ;;
+    esac
+
+    # Find the latest debian template for the selected version and architecture
     local template
-    template=$(pveam available -section system 2>/dev/null | grep "debian-${version}-standard" | tail -1 | awk '{print $2}')
+    template=$(pveam available -section system 2>/dev/null | awk '{print $2}' | grep "debian-${version}-standard" | grep "_${host_arch}\.tar" | tail -1 || true)
 
     if [[ -z "$template" ]]; then
-        msg_error "Could not find Debian ${version} template in repository."
+        msg_error "Could not find Debian ${version} template for ${host_arch} in repository."
         msg_info "Available templates:"
         pveam available -section system 2>/dev/null | grep -i debian | head -5
         exit 1

--- a/scripts/proxmox/install.sh
+++ b/scripts/proxmox/install.sh
@@ -211,9 +211,13 @@ find_debian_template() {
     fi
 
     if [[ -z "$template" ]]; then
-        msg_error "Could not find a Debian ${version} template for ${host_arch} in the repository."
-        msg_info "Available templates:"
-        pveam available -section system 2>/dev/null | grep -i debian | head -5
+        # stdout is captured by the caller's command substitution, so the
+        # error must go to stderr to be visible
+        {
+            msg_error "Could not find a Debian ${version} template for ${host_arch} in the repository."
+            msg_info "Available templates:"
+            pveam available -section system 2>/dev/null | grep -i debian | head -5
+        } >&2
         exit 1
     fi
 


### PR DESCRIPTION
## Summary

Fixes #735 - the Proxmox install script fails to start the LXC on ARM hosts (PXVIRT on a Raspberry Pi 5).

`find_debian_template()` picked the latest `debian-X-standard` template with no architecture filter. On ARM ports of Proxmox the template list includes templates for multiple architectures, so the script grabbed `debian-13-standard_13.1-2_amd64.tar.zst`. LXC containers execute the rootfs binaries directly on the host CPU, so an amd64 rootfs on an arm64 host dies at exec of container init - which is exactly the reported `sync_wait: 34 An error occurred in another process` failure.

## Changes

- Detect the host architecture via `dpkg --print-architecture` (falling back to `uname -m`) and filter the template list to match
- Fall back to codename-style template names when no standard-name match exists. PXVIRT does not ship arm64 builds of the standard PVE templates; its own template repo ([jiangcuo/pxvirt-lxc-images](https://github.com/jiangcuo/pxvirt-lxc-images)) publishes names like `debian-trixie-20260328_arm64.tar.xz` (codename + build date), so the script maps Debian 11-14 to bullseye/bookworm/trixie/forky and retries
- Include the architecture in the "could not find template" error message
- Guard the template lookup pipeline with `|| true` so a no-match result reaches the friendly error path instead of being killed by `set -Eeuo pipefail`

## Verification

Simulated the selection logic against three template listings:

| Environment | Requested | Selected |
|---|---|---|
| Stock amd64 PVE | Debian 13 | `debian-13-standard_13.1-2_amd64.tar.zst` (identical to old behavior) |
| PXVIRT on Pi 5 (arm64) | Debian 13 | `debian-trixie-20260328_arm64.tar.xz` |
| PXVIRT on amd64 host | Debian 13 | `debian-13-standard_13.1-2_amd64.tar.zst` (standard name preferred) |

Both `ghcr.io/ozark-connect/network-optimizer:latest` and `ghcr.io/ozark-connect/speedtest:latest` already publish arm64 manifests, so the Docker side should proceed normally once the container boots.

## Caveat

PXVIRT templates are repackaged linuxcontainers.org rootfs images, not PVE-built standard templates. There are community reports that some of these images need network tweaks (e.g. DHCP not coming up without ifupdown2). Needs a real Pi run by the issue reporter to confirm end-to-end.