### PR TITLE
Monitoring: drag-select a time window on stats charts to zoom

### DIFF
--- a/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
@@ -32,7 +32,8 @@ function baseOpts(height, yTitle, yFormatter, extra) {
             type: 'area', height,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: false },
+            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },
         stroke: { curve: 'smooth', width: 2 },
@@ -237,6 +238,28 @@ function updateCustomLabel(container) {
         btn.setAttribute('data-tooltip', 'Custom date range');
         if (clearBtn) clearBtn.remove();
     }
+}
+
+// Grafana-style drag-select on a chart becomes a custom time window,
+// synced to the range selector (custom-range button + popover inputs).
+function applyDragZoom(xaxis) {
+    const container = document.getElementById(containerId);
+    if (container && xaxis && Number.isFinite(xaxis.min) && Number.isFinite(xaxis.max) && xaxis.min < xaxis.max) {
+        customFrom = new Date(xaxis.min);
+        customTo = new Date(xaxis.max);
+        isCustomRange = true;
+        windowOffset = 0;
+        container.querySelectorAll('[data-range]').forEach(b => b.classList.remove('active'));
+        const fromInput = container.querySelector('[data-input="from"]');
+        const toInput = container.querySelector('[data-input="to"]');
+        if (fromInput) fromInput.value = toLocalDatetimeString(customFrom);
+        if (toInput) toInput.value = toLocalDatetimeString(customTo);
+        updateCustomLabel(container);
+        loadAndUpdate();
+        startPoll();
+    }
+    // Cancel ApexCharts' client-side zoom; the refetch repaints the selected window
+    return { xaxis: { min: undefined, max: undefined } };
 }
 
 function selectPresetRange(container, hours) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
@@ -32,7 +32,8 @@ function baseOpts(height, yTitle, yFormatter, extra) {
             type: 'area', height,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: false },
+            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },
         stroke: { curve: 'smooth', width: 2 },
@@ -267,6 +268,28 @@ function updateCustomLabel(container) {
         btn.setAttribute('data-tooltip', 'Custom date range');
         if (clearBtn) clearBtn.remove();
     }
+}
+
+// Grafana-style drag-select on a chart becomes a custom time window,
+// synced to the range selector (custom-range button + popover inputs).
+function applyDragZoom(xaxis) {
+    const container = document.getElementById(containerId);
+    if (container && xaxis && Number.isFinite(xaxis.min) && Number.isFinite(xaxis.max) && xaxis.min < xaxis.max) {
+        customFrom = new Date(xaxis.min);
+        customTo = new Date(xaxis.max);
+        isCustomRange = true;
+        windowOffset = 0;
+        container.querySelectorAll('[data-range]').forEach(b => b.classList.remove('active'));
+        const fromInput = container.querySelector('[data-input="from"]');
+        const toInput = container.querySelector('[data-input="to"]');
+        if (fromInput) fromInput.value = toLocalDatetimeString(customFrom);
+        if (toInput) toInput.value = toLocalDatetimeString(customTo);
+        updateCustomLabel(container);
+        loadAndUpdate();
+        startPoll();
+    }
+    // Cancel ApexCharts' client-side zoom; the refetch repaints the selected window
+    return { xaxis: { min: undefined, max: undefined } };
 }
 
 function selectPresetRange(container, hours) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -46,7 +46,8 @@ function baseOpts(height, yTitle, yFormatter, extra) {
             type: 'line', height,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: false },
+            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },
         stroke: { curve: 'smooth', width: 2 },
@@ -224,6 +225,28 @@ function updateCustomLabel(container) {
         btn.setAttribute('data-tooltip', 'Custom date range');
         if (clearBtn) clearBtn.remove();
     }
+}
+
+// Grafana-style drag-select on a chart becomes a custom time window,
+// synced to the range selector (custom-range button + popover inputs).
+function applyDragZoom(xaxis) {
+    const container = document.getElementById(containerId);
+    if (container && xaxis && Number.isFinite(xaxis.min) && Number.isFinite(xaxis.max) && xaxis.min < xaxis.max) {
+        customFrom = new Date(xaxis.min);
+        customTo = new Date(xaxis.max);
+        isCustomRange = true;
+        windowOffset = 0;
+        container.querySelectorAll('[data-range]').forEach(b => b.classList.remove('active'));
+        const fromInput = container.querySelector('[data-input="from"]');
+        const toInput = container.querySelector('[data-input="to"]');
+        if (fromInput) fromInput.value = toLocalDatetimeString(customFrom);
+        if (toInput) toInput.value = toLocalDatetimeString(customTo);
+        updateCustomLabel(container);
+        loadAndUpdate();
+        startPoll();
+    }
+    // Cancel ApexCharts' client-side zoom; the refetch repaints the selected window
+    return { xaxis: { min: undefined, max: undefined } };
 }
 
 function selectPresetRange(container, hours) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -53,7 +53,8 @@ function baseChartOpts(type, yTitle, yFormatter, extraOpts) {
             height: type === 'area' ? 200 : 260,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: false },
+            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },
         stroke: { curve: 'smooth', width: 2 },
@@ -462,6 +463,25 @@ function updateCustomLabel(container) {
         btn.setAttribute('data-tooltip', 'Custom date range');
         if (clearBtn) clearBtn.remove();
     }
+}
+
+// Grafana-style drag-select on a chart becomes a custom time window,
+// synced to the range selector (custom-range button + popover inputs).
+function applyDragZoom(xaxis) {
+    const container = document.getElementById(containerId);
+    if (container && xaxis && Number.isFinite(xaxis.min) && Number.isFinite(xaxis.max) && xaxis.min < xaxis.max) {
+        customFrom = new Date(xaxis.min);
+        customTo = new Date(xaxis.max);
+        isCustomRange = true;
+        windowOffset = 0;
+        container.querySelectorAll('[data-range]').forEach(b => b.classList.remove('active'));
+        syncPopoverInputs(container);
+        updateCustomLabel(container);
+        loadAndUpdate();
+        startPoll();
+    }
+    // Cancel ApexCharts' client-side zoom; the refetch repaints the selected window
+    return { xaxis: { min: undefined, max: undefined } };
 }
 
 function getEffectiveFrom() {

--- a/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
@@ -30,7 +30,8 @@ function baseOpts(height, yTitle, yFormatter, extra) {
             type: 'area', height,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: false },
+            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },
         stroke: { curve: 'smooth', width: 2 },
@@ -249,6 +250,28 @@ function updateCustomLabel(container) {
         btn.setAttribute('data-tooltip', 'Custom date range');
         if (clearBtn) clearBtn.remove();
     }
+}
+
+// Grafana-style drag-select on a chart becomes a custom time window,
+// synced to the range selector (custom-range button + popover inputs).
+function applyDragZoom(xaxis) {
+    const container = document.getElementById(containerId);
+    if (container && xaxis && Number.isFinite(xaxis.min) && Number.isFinite(xaxis.max) && xaxis.min < xaxis.max) {
+        customFrom = new Date(xaxis.min);
+        customTo = new Date(xaxis.max);
+        isCustomRange = true;
+        windowOffset = 0;
+        container.querySelectorAll('[data-range]').forEach(b => b.classList.remove('active'));
+        const fromInput = container.querySelector('[data-input="from"]');
+        const toInput = container.querySelector('[data-input="to"]');
+        if (fromInput) fromInput.value = toLocalDatetimeString(customFrom);
+        if (toInput) toInput.value = toLocalDatetimeString(customTo);
+        updateCustomLabel(container);
+        loadAndUpdate();
+        startPoll();
+    }
+    // Cancel ApexCharts' client-side zoom; the refetch repaints the selected window
+    return { xaxis: { min: undefined, max: undefined } };
 }
 
 function selectPresetRange(container, hours) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -30,7 +30,8 @@ function baseOpts(height, yTitle, yFormatter, extra) {
             type: 'area', height,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: false },
+            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },
         stroke: { curve: 'smooth', width: 2 },
@@ -242,6 +243,28 @@ function updateCustomLabel(container) {
         btn.setAttribute('data-tooltip', 'Custom date range');
         if (clearBtn) clearBtn.remove();
     }
+}
+
+// Grafana-style drag-select on a chart becomes a custom time window,
+// synced to the range selector (custom-range button + popover inputs).
+function applyDragZoom(xaxis) {
+    const container = document.getElementById(containerId);
+    if (container && xaxis && Number.isFinite(xaxis.min) && Number.isFinite(xaxis.max) && xaxis.min < xaxis.max) {
+        customFrom = new Date(xaxis.min);
+        customTo = new Date(xaxis.max);
+        isCustomRange = true;
+        windowOffset = 0;
+        container.querySelectorAll('[data-range]').forEach(b => b.classList.remove('active'));
+        const fromInput = container.querySelector('[data-input="from"]');
+        const toInput = container.querySelector('[data-input="to"]');
+        if (fromInput) fromInput.value = toLocalDatetimeString(customFrom);
+        if (toInput) toInput.value = toLocalDatetimeString(customTo);
+        updateCustomLabel(container);
+        loadAndUpdate();
+        startPoll();
+    }
+    // Cancel ApexCharts' client-side zoom; the refetch repaints the selected window
+    return { xaxis: { min: undefined, max: undefined } };
 }
 
 function selectPresetRange(container, hours) {


### PR DESCRIPTION
## What

Drag horizontally on any chart in the Monitoring stats tabs (Network Performance, Device Stats, SFP Stats, CM Stats, ONT Stats, Cellular Stats) to zoom into that time window, Grafana style. Also documents how device health readings are measured, both in the README and in the UI.

## How it works

- The dragged selection becomes a custom time range, fully synced with the time range selector: preset buttons deactivate, the custom-range button lights up with the from/to tooltip and clear (x) control, and the custom range popover inputs reflect the selected window.
- Data is refetched from the server for the selected window instead of zooming into the already-downsampled series, so zooming in reveals finer detail.
- Live polling pauses while zoomed (same behavior as applying a custom range manually) and resumes when a preset is selected or the custom range is cleared.
- All charts within a tab share the window, so dragging on one moves them all.
- Mouse wheel zoom stays disabled so page scrolling is not hijacked over charts.

Live View is intentionally unchanged.

## Measurement transparency (#761)

- New collapsed "Why do these readings differ from UniFi Network?" info panel under the Device Stats charts explaining what we measure: CPU temperature is the SoC die sensor over SNMP (responds within seconds, vs the damped fan-control probe that reads lower and lags), memory is real used memory excluding Linux page cache (matches htop), and switch temperatures fall back to the UniFi API.
- README gets a matching "How readings are measured" subsection, and the device health blurb now notes these stats are one screen for all devices, vs per-device Insights views in UniFi Network.