### PR TITLE
SNMP: recover rate computation after device counter reset

### DIFF
--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -1494,6 +1494,17 @@ public class MonitoringCollectionAgent : BackgroundService
                         _counterCache[key] = new CounterSnapshot(now, iface.InOctets, iface.OutOctets);
                     }
                 }
+                else
+                {
+                    // Counter reset (device rebooted, e.g. for a firmware upgrade): the
+                    // cached snapshot predates the reset, so the delta goes negative and
+                    // no rate can ever be computed against it. Reseed with the current
+                    // sample so the next poll computes a valid rate. Without this the
+                    // stale snapshot pins every delta negative, every poll counts as an
+                    // SNMP failure, and the device flaps in and out of SNMP exclusion
+                    // until the app restarts.
+                    _counterCache[key] = new CounterSnapshot(now, iface.InOctets, iface.OutOctets);
+                }
             }
         }
         if (!_counterCache.ContainsKey(key))


### PR DESCRIPTION
Fixes the permanent SNMP exclusion flapping seen after a gateway reboot (e.g. console firmware upgrade).

## Root cause

`WriteInterfaceCounters` computes per-interface rates from the delta between the current sample and a cached previous snapshot. When a device reboots, its SNMP counters reset to zero while the cache still holds the huge pre-reboot values:

- Every delta is negative (the 32-bit wrap correction is correctly skipped for HC interfaces), so no rate is computed.
- The negative-delta path never updated the cache, and the seed-if-missing path doesn't apply because the stale key exists. The cache can never heal.
- A poll with no computable rates counts as an SNMP failure, so the device hits 5 consecutive failures within seconds of each exclusion expiry and is re-excluded, forever, until the app restarts.

Observed live: wire captures showed perfect SNMP request/response exchanges while the device flapped through exclusion every 5 minutes, with raw byte counters written to InfluxDB but no rates.

## Fix

One new branch on the already-failing path: a negative delta is treated as a counter reset and reseeds the cache with the current sample. The next poll then computes a valid rate and the failure counter clears, so a rebooted device recovers within two poll cycles (~10 s). Positive-delta and zero-delta behavior is byte-for-byte unchanged.