### PR TITLE
UniFi API: clean diagnosis when console serves HTML instead of JSON

### DIFF
--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -613,8 +613,26 @@ public class UniFiApiClient : IDisposable
                 return null;
             }
 
-            var result = await response.Content.ReadFromJsonAsync<T>(cancellationToken: cancellationToken);
-            return result;
+            try
+            {
+                var result = await response.Content.ReadFromJsonAsync<T>(cancellationToken: cancellationToken);
+                return result;
+            }
+            catch (System.Text.Json.JsonException ex) when (ex is not UniFiNonJsonResponseException)
+            {
+                // The console serves HTML (login/error page) instead of JSON while it's
+                // rebooting or mid-firmware-upgrade. Re-throw with a one-line diagnosis
+                // instead of the raw parser error. The content is buffered, so it can be
+                // re-read here after the failed deserialization.
+                string? body = null;
+                try { body = await response.Content.ReadAsStringAsync(cancellationToken); }
+                catch { /* keep the original parse error context if the body is unreadable */ }
+                throw UniFiNonJsonResponseException.Create(
+                    (int)response.StatusCode,
+                    response.Content.Headers.ContentType?.MediaType,
+                    body,
+                    ex);
+            }
         });
     }
 

--- a/src/NetworkOptimizer.UniFi/UniFiNonJsonResponseException.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiNonJsonResponseException.cs
@@ -1,0 +1,38 @@
+using System.Text.Json;
+
+namespace NetworkOptimizer.UniFi;
+
+/// <summary>
+/// Thrown when the UniFi Console returns a non-JSON body (typically an HTML error or login
+/// page served while the console is rebooting or mid-firmware-upgrade) for an API call that
+/// expects JSON. Derives from <see cref="JsonException"/> so existing catch blocks and retry
+/// predicates keyed on <see cref="JsonException"/> behave exactly as before; only the message
+/// becomes a concise, single-line diagnosis instead of a raw parser error.
+/// </summary>
+public class UniFiNonJsonResponseException : JsonException
+{
+    private const int PreviewLength = 120;
+
+    public UniFiNonJsonResponseException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Builds the exception with a single-line message describing the response:
+    /// status code, content type, and the start of the body with whitespace flattened.
+    /// </summary>
+    public static UniFiNonJsonResponseException Create(
+        int statusCode, string? contentType, string? body, JsonException inner)
+    {
+        var preview = body ?? string.Empty;
+        if (preview.Length > PreviewLength)
+            preview = preview[..PreviewLength] + "...";
+        preview = preview.Replace('\r', ' ').Replace('\n', ' ').Trim();
+
+        return new UniFiNonJsonResponseException(
+            $"UniFi Console returned non-JSON content (status {statusCode}, content-type {contentType ?? "unknown"}) - " +
+            $"it may be rebooting or mid-firmware-upgrade. Body starts with: {preview}",
+            inner);
+    }
+}

--- a/src/NetworkOptimizer.Web/Endpoints/LanFlowMapEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/LanFlowMapEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using NetworkOptimizer.Web.Services;
 using NetworkOptimizer.Web.Services.LanFlowMap;
 
@@ -10,24 +11,45 @@ public static class LanFlowMapEndpoints
     public static void Map(WebApplication app)
     {
         app.MapGet("/api/monitoring/lan-flow-map/snapshot",
-            async (LanFlowMapService svc, CancellationToken ct) =>
+            async (LanFlowMapService svc, ILogger<LanFlowMapService> logger, CancellationToken ct) =>
             {
-                var snap = await svc.BuildSnapshotAsync(ct);
-                return Results.Ok(snap);
+                try
+                {
+                    var snap = await svc.BuildSnapshotAsync(ct);
+                    return Results.Ok(snap);
+                }
+                catch (Exception ex) when (IsConsoleUnavailable(ex))
+                {
+                    return ConsoleUnavailable(logger, "snapshot", ex);
+                }
             });
 
         app.MapGet("/api/monitoring/lan-flow-map/live",
-            async (LanFlowMapService svc, CancellationToken ct) =>
+            async (LanFlowMapService svc, ILogger<LanFlowMapService> logger, CancellationToken ct) =>
             {
-                var update = await svc.GetLiveUpdateAsync(ct);
-                return Results.Ok(update);
+                try
+                {
+                    var update = await svc.GetLiveUpdateAsync(ct);
+                    return Results.Ok(update);
+                }
+                catch (Exception ex) when (IsConsoleUnavailable(ex))
+                {
+                    return ConsoleUnavailable(logger, "live", ex);
+                }
             });
 
         app.MapGet("/api/monitoring/lan-flow-map/history",
-            async (LanFlowMapService svc, DateTime at, CancellationToken ct) =>
+            async (LanFlowMapService svc, ILogger<LanFlowMapService> logger, DateTime at, CancellationToken ct) =>
             {
-                var update = await svc.GetHistoricUpdateAsync(at, ct);
-                return Results.Ok(update);
+                try
+                {
+                    var update = await svc.GetHistoricUpdateAsync(at, ct);
+                    return Results.Ok(update);
+                }
+                catch (Exception ex) when (IsConsoleUnavailable(ex))
+                {
+                    return ConsoleUnavailable(logger, "history", ex);
+                }
             });
 
         app.MapGet("/api/monitoring/lan-flow-map/speed-tests",
@@ -48,5 +70,20 @@ public static class LanFlowMapEndpoints
                 svc.InvalidateCache();
                 return Results.Ok();
             });
+    }
+
+    /// <summary>
+    /// True for failures that mean the UniFi Console couldn't serve the request right now:
+    /// non-JSON bodies (login/error page during reboot or firmware upgrade) or transport
+    /// errors. These are transient, so the map endpoints answer 503 and the JS poller
+    /// quietly retries on its next tick instead of surfacing an unhandled 500.
+    /// </summary>
+    private static bool IsConsoleUnavailable(Exception ex) =>
+        ex is JsonException or HttpRequestException;
+
+    private static IResult ConsoleUnavailable(ILogger logger, string endpoint, Exception ex)
+    {
+        logger.LogDebug(ex, "LAN flow map {Endpoint} unavailable - UniFi Console not serving data", endpoint);
+        return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
     }
 }

--- a/tests/NetworkOptimizer.UniFi.Tests/UniFiNonJsonResponseExceptionTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/UniFiNonJsonResponseExceptionTests.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace NetworkOptimizer.UniFi.Tests;
+
+/// <summary>
+/// Tests for the non-JSON response wrapper thrown when the UniFi Console serves
+/// HTML (login/error page during reboot or firmware upgrade) instead of JSON.
+/// The wrapper must stay catch-compatible with JsonException so existing
+/// handlers and retry predicates behave exactly as before.
+/// </summary>
+public class UniFiNonJsonResponseExceptionTests
+{
+    private static readonly JsonException Inner = new("'<' is an invalid start of a value.");
+
+    [Fact]
+    public void Create_IsCatchableAsJsonException()
+    {
+        var ex = UniFiNonJsonResponseException.Create(200, "text/html", "<!DOCTYPE html>", Inner);
+
+        ex.Should().BeAssignableTo<JsonException>();
+        ex.InnerException.Should().BeSameAs(Inner);
+    }
+
+    [Fact]
+    public void Create_MessageContainsStatusContentTypeAndPreview()
+    {
+        var ex = UniFiNonJsonResponseException.Create(503, "text/html", "<!DOCTYPE html><html>", Inner);
+
+        ex.Message.Should().Contain("status 503");
+        ex.Message.Should().Contain("content-type text/html");
+        ex.Message.Should().Contain("<!DOCTYPE html><html>");
+    }
+
+    [Fact]
+    public void Create_TruncatesLongBodies()
+    {
+        var body = new string('x', 500);
+
+        var ex = UniFiNonJsonResponseException.Create(200, "text/html", body, Inner);
+
+        ex.Message.Should().Contain(new string('x', 120) + "...");
+        ex.Message.Should().NotContain(new string('x', 121));
+    }
+
+    [Fact]
+    public void Create_FlattensNewlinesInPreview()
+    {
+        var ex = UniFiNonJsonResponseException.Create(200, "text/html", "<html>\r\n<body>\nhi", Inner);
+
+        ex.Message.Should().NotContain("\n");
+        ex.Message.Should().NotContain("\r");
+    }
+
+    [Fact]
+    public void Create_HandlesNullBodyAndContentType()
+    {
+        var ex = UniFiNonJsonResponseException.Create(502, null, null, Inner);
+
+        ex.Message.Should().Contain("status 502");
+        ex.Message.Should().Contain("content-type unknown");
+    }
+}


### PR DESCRIPTION
Hardening from the console firmware upgrade window where the UniFi API served HTML (login/error page) and the app logged ~126 raw 40-line JsonException stack traces plus secondary ExceptionHandler 404 noise.

## Changes

- **UniFiApiClient**: the JSON deserialization call is unchanged; a new catch on the already-failing path re-reads the buffered body and rethrows `UniFiNonJsonResponseException` with a one-line diagnosis (status, content-type, first 120 chars of body). The new type derives from `JsonException`, so every existing `catch (JsonException)` site and retry predicate behaves exactly as before - only the message improves.
- **LanFlowMapEndpoints**: the snapshot/live/history GETs now answer 503 when the console can't serve data (`JsonException` or `HttpRequestException`) instead of letting the exception escape into the pipeline (which also triggered the misleading "exception handler produced 404" error). The only consumer is our own poller in `lan-flow-data.js`, which treats any non-OK response as "skip this tick and retry" - so 503 is observationally identical to the previous 500 for the client, minus the server-side noise.
- **Tests**: new unit tests pin the exception's JsonException compatibility, message contents, body truncation, newline flattening, and null handling.

## Regression safety

The deserialization success path is byte-for-byte unchanged; all new code is unreachable unless the request was already throwing. Verified all `catch (JsonException)` sites in the solution match the new subclass, and the Polly retry policy (which only handles `HttpRequestException`/`TaskCanceledException`) is unaffected.