### PR TITLE
v1.19.5

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -237,6 +237,14 @@ The following were implemented in the WiFi Optimizer feature:
 - These create GRE tunnels that should be treated as valid WAN interfaces for SQM
 - ✅ ~~PPPoE support~~ (done - uses physical interface for lookup, tunnel interface for SQM)
 
+## Monitoring
+
+### Gap-Gated SNMP Counter Reset Detection
+- `InterfaceRateCalculator` currently distinguishes a genuine counter reset (device reboot) from a single corrupt SNMP read by requiring two consecutive below-baseline reads before reseeding the baseline (`ResetPending` → `ResetConfirmed`). A discarded over-ceiling rate then advances the baseline so nothing can wedge an interface.
+- Cleaner discriminator: the **elapsed gap**. A real reset only follows a reboot, which trips ~5 consecutive SNMP failures (~25 s) and a 5-minute exclusion, so the first sample back has a large elapsed gap (~5 min). A corrupt-read glitch arrives at the normal ~5 s cadence with a tiny gap. So: backwards counter with a large gap (e.g. ≥ 60 s, above poll jitter and below the exclusion window) → reset, reseed immediately; backwards counter at normal cadence → glitch, hold the baseline and suppress. This reseeds genuine resets in one poll instead of two and makes the rare two-fast-corrupt-reads false-confirm impossible by construction.
+- **Not required** - the confirmed-by-repeat version is correct and the worst edge (double glitch) self-heals in ~10-15 s with no spike written. Revisit only if logs show clusters of "Discarding implausible SNMP rate" WARNs that aren't explained by a single bad read. Keep a fallback for the (unrealistic) small-gap reset so nothing can wedge.
+- **Relevant code:** `InterfaceRateCalculator.Compute` (reset/candidate branch), `MonitoringCollectionAgent.WriteInterfaceCounters`.
+
 ## Multi-Tenant / Multi-Site Support
 
 ### Multi-Tenant Architecture

--- a/src/NetworkOptimizer.Core/Helpers/NetworkUtilities.cs
+++ b/src/NetworkOptimizer.Core/Helpers/NetworkUtilities.cs
@@ -689,4 +689,29 @@ public static class NetworkUtilities
         // Fallback: just trim trailing slashes
         return url.TrimEnd('/');
     }
+
+    /// <summary>
+    /// Picks the interface whose traffic counters best represent a WAN connection,
+    /// given the physical port (e.g. "eth4") and the logical uplink (e.g. "eth4" for
+    /// plain connections, "eth4.100" for VLAN-tagged, "ppp0" for PPPoE, "gre1" for
+    /// LAN-tunneled cellular WANs).
+    /// VLAN sub-interfaces double-count on some kernels, so when the uplink is a
+    /// sub-interface of the physical port, the physical port wins. Any other logical
+    /// uplink (ppp*, gre*, ...) wins: it carries exactly the WAN payload, while the
+    /// physical port keeps counting too and over-counts (confirmed on a UCG-Fiber
+    /// PPPoE WAN, where the physical port ran ~40% above ppp0 due to tunnel overhead
+    /// and sibling VLANs on the same port).
+    /// </summary>
+    /// <param name="physicalIfName">Physical port interface name, if known</param>
+    /// <param name="uplinkIfName">Logical uplink interface name, if known</param>
+    /// <returns>The preferred interface name, or null when both inputs are null</returns>
+    public static string? PreferredWanCounterInterface(string? physicalIfName, string? uplinkIfName)
+    {
+        if (string.IsNullOrEmpty(uplinkIfName)) return physicalIfName;
+        if (string.IsNullOrEmpty(physicalIfName)) return uplinkIfName;
+        if (uplinkIfName.Equals(physicalIfName, StringComparison.OrdinalIgnoreCase) ||
+            uplinkIfName.StartsWith(physicalIfName + ".", StringComparison.OrdinalIgnoreCase))
+            return physicalIfName;
+        return uplinkIfName;
+    }
 }

--- a/src/NetworkOptimizer.Monitoring/InterfaceRateCalculator.cs
+++ b/src/NetworkOptimizer.Monitoring/InterfaceRateCalculator.cs
@@ -1,0 +1,188 @@
+namespace NetworkOptimizer.Monitoring;
+
+/// <summary>
+/// Pure rate-from-counter computation for SNMP interface octet counters.
+/// Cumulative counters are messy in practice: they wrap (32-bit), stall between
+/// device-side refreshes, reset on reboot/firmware upgrade, and occasionally
+/// return a single corrupt read. This calculator turns a sequence of
+/// (InOctets, OutOctets, timestamp) samples into bits-per-second rates while
+/// refusing to emit physically-impossible spikes or poison its own baseline off
+/// one bad sample.
+/// </summary>
+public static class InterfaceRateCalculator
+{
+    /// <summary>
+    /// Headroom over link speed before a computed rate is treated as a glitch.
+    /// A short polling window plus clock jitter can legitimately push a single
+    /// sample up to ~40% over line rate, so only clearly-impossible values are
+    /// rejected.
+    /// </summary>
+    public const double LinkSpeedToleranceFactor = 1.4;
+
+    /// <summary>
+    /// Absolute rate ceiling used when the interface's link speed is unknown
+    /// (virtual interfaces such as ppp*/gre* report speed 0). These carry WAN /
+    /// tunnel traffic that tops out around 10 Gbps in the wild, so 14 Gbps leaves
+    /// headroom while still rejecting corrupt reads.
+    /// </summary>
+    public const double AbsoluteCeilingBps = 14_000_000_000d; // 14 Gbps
+
+    public enum Outcome
+    {
+        /// <summary>Rate computed and emitted normally.</summary>
+        Normal,
+
+        /// <summary>Counters unchanged since the last poll; baseline held, no rate.</summary>
+        CounterUnchanged,
+
+        /// <summary>First sample for this interface; baseline seeded, no rate.</summary>
+        SeededBaseline,
+
+        /// <summary>
+        /// Counter read below the baseline once. Could be a real reset or a
+        /// single corrupt read - baseline held, candidate remembered, no rate.
+        /// </summary>
+        ResetPending,
+
+        /// <summary>
+        /// A second consecutive below-baseline read confirmed a genuine counter
+        /// reset; baseline reseeded to the current sample, no rate for the
+        /// boundary. Worth an INFO log.
+        /// </summary>
+        ResetConfirmed,
+
+        /// <summary>
+        /// Computed rate exceeded the link-speed ceiling - a corrupt read or a
+        /// snap-back. Rate discarded; baseline advances to this sample so a bad
+        /// baseline can't wedge the interface. Worth a WARN log.
+        /// </summary>
+        ImplausibleRate,
+    }
+
+    /// <summary>
+    /// Per-interface counter state carried between polls: the last trusted
+    /// baseline plus an optional "reset candidate" (a below-baseline reading
+    /// awaiting confirmation before we trust it).
+    /// </summary>
+    public readonly record struct State(
+        long InOctets,
+        long OutOctets,
+        DateTime Timestamp,
+        long? CandidateInOctets = null,
+        long? CandidateOutOctets = null,
+        DateTime? CandidateTimestamp = null);
+
+    public readonly record struct Result(
+        double? RateInBps,
+        double? RateOutBps,
+        State NewState,
+        Outcome Outcome,
+        double? RejectedRateInBps = null,
+        double? RejectedRateOutBps = null);
+
+    /// <summary>
+    /// Compute the rate for a new counter sample against the previous state.
+    /// </summary>
+    /// <param name="previous">Prior state for this interface, or null on first sight.</param>
+    /// <param name="inOctets">Current cumulative inbound octet counter.</param>
+    /// <param name="outOctets">Current cumulative outbound octet counter.</param>
+    /// <param name="now">Timestamp of this sample.</param>
+    /// <param name="useHcCounters">
+    /// True when the device exposes 64-bit high-capacity counters (no 32-bit
+    /// wrap recovery applied).
+    /// </param>
+    /// <param name="linkSpeedBps">
+    /// Interface link speed in bps for the plausibility ceiling, or 0 if unknown.
+    /// </param>
+    public static Result Compute(
+        State? previous,
+        long inOctets,
+        long outOctets,
+        DateTime now,
+        bool useHcCounters,
+        long linkSpeedBps)
+    {
+        var fresh = new State(inOctets, outOctets, now);
+
+        if (previous is not { } prev)
+            return new Result(null, null, fresh, Outcome.SeededBaseline);
+
+        var elapsed = (now - prev.Timestamp).TotalSeconds;
+        if (elapsed <= 0.5)
+            // Too soon, or the clock moved backwards: hold the baseline, no rate.
+            return new Result(null, null, prev, Outcome.CounterUnchanged);
+
+        long deltaIn = inOctets - prev.InOctets;
+        long deltaOut = outOctets - prev.OutOctets;
+
+        // 32-bit wrap recovery for low-speed interfaces that only expose the
+        // 32-bit ifInOctets/ifOutOctets counters.
+        if (!useHcCounters)
+        {
+            if (deltaIn < 0) deltaIn += (long)uint.MaxValue + 1;
+            if (deltaOut < 0) deltaOut += (long)uint.MaxValue + 1;
+        }
+
+        if (deltaIn < 0 || deltaOut < 0)
+        {
+            // Counter went backwards. Either a genuine reset (reboot / firmware
+            // upgrade) or a single corrupt SNMP read - indistinguishable from one
+            // sample. Do NOT reseed the baseline off this reading: a corrupt low
+            // value would make the next clean poll snap back to a terabit/sec
+            // spike. Hold the last good baseline and remember this as a reset
+            // candidate; only a second below-baseline poll confirms a real reset.
+            if (prev.CandidateTimestamp is not null)
+                return new Result(null, null, fresh, Outcome.ResetConfirmed);
+
+            var holding = prev with
+            {
+                CandidateInOctets = inOctets,
+                CandidateOutOctets = outOctets,
+                CandidateTimestamp = now,
+            };
+            return new Result(null, null, holding, Outcome.ResetPending);
+        }
+
+        // Counter advanced (or held flat). Any pending reset candidate is now
+        // disproven - the counter recovered above the baseline, so the earlier
+        // dip was a transient glitch. Drop the candidate and carry on.
+        if (deltaIn == 0 && deltaOut == 0)
+        {
+            // Device hasn't refreshed its counters yet. Hold the baseline so the
+            // next real change computes delta/elapsed over the true window
+            // (prevents an alternating 0 / 2x sawtooth).
+            var held = prev with
+            {
+                CandidateInOctets = null,
+                CandidateOutOctets = null,
+                CandidateTimestamp = null,
+            };
+            return new Result(null, null, held, Outcome.CounterUnchanged);
+        }
+
+        var rateInBps = deltaIn * 8.0 / elapsed;
+        var rateOutBps = deltaOut * 8.0 / elapsed;
+
+        var ceiling = linkSpeedBps > 0 ? linkSpeedBps * LinkSpeedToleranceFactor : AbsoluteCeilingBps;
+        if (rateInBps > ceiling || rateOutBps > ceiling)
+        {
+            // Physically impossible for this link - a corrupt high read or a
+            // snap-back from a momentarily-low counter. The rate is discarded
+            // (surfaced on RejectedRate*Bps for logging only; callers must not
+            // emit it). Advance the baseline to this sample anyway: holding the
+            // old baseline would wedge the interface forever if that baseline is
+            // itself bad (a never-recovering "every read looks impossible" loop).
+            // Advancing means the next clean sample computes a normal delta, and
+            // no rate is ever emitted from a discarded sample regardless.
+            return new Result(
+                null,
+                null,
+                fresh,
+                Outcome.ImplausibleRate,
+                rateInBps,
+                rateOutBps);
+        }
+
+        return new Result(rateInBps, rateOutBps, fresh, Outcome.Normal);
+    }
+}

--- a/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
@@ -344,6 +344,28 @@ public class GatewayWanInterface
     public int? Availability { get; set; }
 
     /// <summary>
+    /// Physical port backing this WAN (e.g., "eth4"). For VLAN-tagged or PPPoE
+    /// connections this is the parent port, not the interface carrying the traffic.
+    /// </summary>
+    [JsonPropertyName("ifname")]
+    public string? IfName { get; set; }
+
+    /// <summary>
+    /// Logical uplink interface carrying the WAN traffic (e.g., "eth4" for plain
+    /// connections, "eth4.100" for VLAN-tagged, "ppp0" for PPPoE).
+    /// </summary>
+    [JsonPropertyName("uplink_ifname")]
+    public string? UplinkIfName { get; set; }
+
+    /// <summary>
+    /// port_table index of the physical port backing this WAN. Absent for
+    /// virtual WANs (GRE-tunneled cellular).
+    /// </summary>
+    [JsonPropertyName("port_idx")]
+    [JsonConverter(typeof(FlexibleIntConverter))]
+    public int? PortIdx { get; set; }
+
+    /// <summary>
     /// Cumulative bytes received on this WAN interface since device boot.
     /// </summary>
     [JsonPropertyName("rx_bytes")]
@@ -583,6 +605,25 @@ public class SwitchPort
 
 public class UplinkInfo
 {
+    /// <summary>
+    /// Interface name of the active uplink. On gateways some firmwares put the
+    /// active WAN's logical interface here (e.g. "eth6.100"); others put a
+    /// bridge here and the WAN interface in uplink_ifname instead.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>OS-level interface name of the active uplink, when reported.</summary>
+    [JsonPropertyName("ifname")]
+    public string? IfName { get; set; }
+
+    /// <summary>
+    /// Logical uplink interface of the active WAN on gateways (e.g. "ppp0" for
+    /// PPPoE). Firmware-dependent; may be absent when name carries it.
+    /// </summary>
+    [JsonPropertyName("uplink_ifname")]
+    public string? UplinkIfName { get; set; }
+
     [JsonPropertyName("uplink_mac")]
     public string UplinkMac { get; set; } = string.Empty;
 

--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -613,8 +613,26 @@ public class UniFiApiClient : IDisposable
                 return null;
             }
 
-            var result = await response.Content.ReadFromJsonAsync<T>(cancellationToken: cancellationToken);
-            return result;
+            try
+            {
+                var result = await response.Content.ReadFromJsonAsync<T>(cancellationToken: cancellationToken);
+                return result;
+            }
+            catch (System.Text.Json.JsonException ex) when (ex is not UniFiNonJsonResponseException)
+            {
+                // The console serves HTML (login/error page) instead of JSON while it's
+                // rebooting or mid-firmware-upgrade. Re-throw with a one-line diagnosis
+                // instead of the raw parser error. The content is buffered, so it can be
+                // re-read here after the failed deserialization.
+                string? body = null;
+                try { body = await response.Content.ReadAsStringAsync(cancellationToken); }
+                catch { /* keep the original parse error context if the body is unreadable */ }
+                throw UniFiNonJsonResponseException.Create(
+                    (int)response.StatusCode,
+                    response.Content.Headers.ContentType?.MediaType,
+                    body,
+                    ex);
+            }
         });
     }
 

--- a/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Core.Helpers;
 using NetworkOptimizer.UniFi.Models;
 
 namespace NetworkOptimizer.UniFi;
@@ -99,10 +100,7 @@ public class UniFiDiscovery
                 TxBytes = d.Stats?.TxBytes ?? 0,
                 RxBytes = d.Stats?.RxBytes ?? 0,
                 PortCount = d.PortTable?.Count ?? 0,
-                WanInterfaceNames = d.PortTable?
-                    .Where(p => p.IsUplink && !string.IsNullOrEmpty(p.IfName))
-                    .Select(p => p.IfName!)
-                    .ToList() ?? new(),
+                WanInterfaceNames = GetWanInterfaceNames(d),
                 // Wi-Fi specific (APs only)
                 RadioTable = d.RadioTable,
                 RadioTableStats = d.RadioTableStats,
@@ -124,6 +122,65 @@ public class UniFiDiscovery
         }
 
         return discoveredDevices;
+    }
+
+    /// <summary>
+    /// Resolves the interface name whose SNMP counters feed the WAN Live View and
+    /// Monitoring overview stats. For now this is the PRIMARY WAN interface only,
+    /// by design: the ISP / transit latency and loss cards shown alongside WAN
+    /// throughput are measured for a single WAN connection, so mixing failover or
+    /// cellular WAN traffic into the throughput numbers would disagree with them.
+    /// The primary WAN can be any connection type, including a GRE-tunneled
+    /// cellular WAN with no physical port.
+    /// Selection order, each translated to the counter-bearing interface via
+    /// <see cref="NetworkUtilities.PreferredWanCounterInterface"/> (ppp*/gre*
+    /// tunnel when the uplink is one, physical port otherwise):
+    /// 1. The gateway's uplink object, which names the active WAN's logical
+    ///    interface (field varies by firmware: uplink_ifname, ifname, or name),
+    ///    matched to its wan1..wan6 object. Tracks failover and covers virtual
+    ///    WANs that have no port_table entry.
+    /// 2. The port_table entry flagged is_uplink (the pre-#669 selector),
+    ///    matched to its wan object. Also covers non-gateway devices.
+    /// 3. The first wan object, preferring ones reported up (seen on PPPoE
+    ///    gateways where neither of the above is populated).
+    /// </summary>
+    internal static List<string> GetWanInterfaceNames(UniFiDeviceResponse d)
+    {
+        var wans = d.GetWanInterfaces();
+
+        var activeUplink = !string.IsNullOrEmpty(d.Uplink?.UplinkIfName) ? d.Uplink.UplinkIfName
+            : !string.IsNullOrEmpty(d.Uplink?.IfName) ? d.Uplink.IfName
+            : d.Uplink?.Name;
+        if (!string.IsNullOrEmpty(activeUplink))
+        {
+            var wan = wans.FirstOrDefault(w => w.UplinkIfName == activeUplink || w.IfName == activeUplink);
+            if (wan != null)
+            {
+                var name = NetworkUtilities.PreferredWanCounterInterface(wan.IfName, wan.UplinkIfName);
+                if (!string.IsNullOrEmpty(name))
+                    return new List<string> { name };
+            }
+        }
+
+        var uplinkPort = d.PortTable?.FirstOrDefault(p => p.IsUplink && !string.IsNullOrEmpty(p.IfName));
+        if (uplinkPort != null)
+        {
+            var wan = wans.FirstOrDefault(w =>
+                (!string.IsNullOrEmpty(w.IfName) && w.IfName == uplinkPort.IfName) ||
+                (w.PortIdx.HasValue && w.PortIdx == uplinkPort.PortIdx));
+            var name = wan != null
+                ? NetworkUtilities.PreferredWanCounterInterface(wan.IfName ?? uplinkPort.IfName, wan.UplinkIfName)
+                : uplinkPort.IfName;
+            return string.IsNullOrEmpty(name) ? new() : new List<string> { name };
+        }
+
+        foreach (var wan in wans.OrderBy(w => w.Up ? 0 : 1).ThenBy(w => w.Key, StringComparer.Ordinal))
+        {
+            var name = NetworkUtilities.PreferredWanCounterInterface(wan.IfName, wan.UplinkIfName);
+            if (!string.IsNullOrEmpty(name))
+                return new List<string> { name };
+        }
+        return new();
     }
 
     /// <summary>
@@ -668,6 +725,14 @@ public class DiscoveredDevice
     public long RxBytes { get; set; }
     public int PortCount { get; set; }
 
+    /// <summary>
+    /// Counter-bearing interface of the PRIMARY WAN only (single entry, by
+    /// design - do not add secondary/cellular WANs). Feeds the WAN Live View
+    /// and Monitoring overview throughput, which sit alongside ISP / transit
+    /// latency cards measured for that one connection; mixing other WANs into
+    /// the throughput would disagree with them. See
+    /// UniFiDiscovery.GetWanInterfaceNames for the selection rules.
+    /// </summary>
     public List<string> WanInterfaceNames { get; set; } = new();
 
     // Wi-Fi specific (APs only)

--- a/src/NetworkOptimizer.UniFi/UniFiNonJsonResponseException.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiNonJsonResponseException.cs
@@ -1,0 +1,38 @@
+using System.Text.Json;
+
+namespace NetworkOptimizer.UniFi;
+
+/// <summary>
+/// Thrown when the UniFi Console returns a non-JSON body (typically an HTML error or login
+/// page served while the console is rebooting or mid-firmware-upgrade) for an API call that
+/// expects JSON. Derives from <see cref="JsonException"/> so existing catch blocks and retry
+/// predicates keyed on <see cref="JsonException"/> behave exactly as before; only the message
+/// becomes a concise, single-line diagnosis instead of a raw parser error.
+/// </summary>
+public class UniFiNonJsonResponseException : JsonException
+{
+    private const int PreviewLength = 120;
+
+    public UniFiNonJsonResponseException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Builds the exception with a single-line message describing the response:
+    /// status code, content type, and the start of the body with whitespace flattened.
+    /// </summary>
+    public static UniFiNonJsonResponseException Create(
+        int statusCode, string? contentType, string? body, JsonException inner)
+    {
+        var preview = body ?? string.Empty;
+        if (preview.Length > PreviewLength)
+            preview = preview[..PreviewLength] + "...";
+        preview = preview.Replace('\r', ' ').Replace('\n', ' ').Trim();
+
+        return new UniFiNonJsonResponseException(
+            $"UniFi Console returned non-JSON content (status {statusCode}, content-type {contentType ?? "unknown"}) - " +
+            $"it may be rebooting or mid-firmware-upgrade. Body starts with: {preview}",
+            inner);
+    }
+}

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1895,6 +1895,9 @@ else
             return (_historicSnapshot.WanDownloadBps, _historicSnapshot.WanUploadBps);
         if (_gatewayMac == null || _gatewayWanIfNames.Count == 0) return (0, 0);
         double totalDown = 0, totalUp = 0;
+        // _gatewayWanIfNames holds the PRIMARY WAN only, by design - these stats
+        // sit beside ISP/transit latency measured for that one connection. Do not
+        // widen it to other WANs (see DiscoveredDevice.WanInterfaceNames).
         foreach (var ifName in _gatewayWanIfNames)
         {
             var rate = LiveStats.GetPortRate(_gatewayMac, ifName);

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -295,6 +295,9 @@ else
     {
         if (_gatewayMac == null || _gatewayWanIfNames.Count == 0) return (0, 0);
         double totalDown = 0, totalUp = 0;
+        // _gatewayWanIfNames holds the PRIMARY WAN only, by design - these stats
+        // sit beside ISP/transit latency measured for that one connection. Do not
+        // widen it to other WANs (see DiscoveredDevice.WanInterfaceNames).
         foreach (var ifName in _gatewayWanIfNames)
         {
             var rate = LiveStats.GetPortRate(_gatewayMac, ifName);

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ClientTimeline.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ClientTimeline.razor
@@ -225,6 +225,10 @@
                     {
                         <span class="client-name">@_selectedClient.Name</span>
                     }
+                    @if (!string.IsNullOrEmpty(_selectedClient.Ip))
+                    {
+                        <span class="client-ip">@_selectedClient.Ip</span>
+                    }
                     <span class="client-mac">@_selectedClient.Mac</span>
                     @if (!string.IsNullOrEmpty(_selectedClient.Ip))
                     {
@@ -261,7 +265,7 @@
                         </span>
                     </div>
                     <div class="info-item">
-                        <span class="info-label">TX/RX Rate:</span>
+                        <span class="info-label">AP TX/RX Rate:</span>
                         <span class="info-value" data-tooltip="TX = AP transmits to client (download), RX = AP receives from client (upload)">@FormatRate(_selectedClient.TxRate) / @FormatRate(_selectedClient.RxRate)</span>
                     </div>
                     @if (_selectedClient.FixedApEnabled)
@@ -685,7 +689,7 @@
         ClientConnectionEventType.Disconnected =>
             (!string.IsNullOrEmpty(evt.Duration) ? $"Duration: {evt.Duration}" : "") +
             (!string.IsNullOrEmpty(evt.DataUp) && !string.IsNullOrEmpty(evt.DataDown)
-                ? $" · {evt.DataUp} up / {evt.DataDown} down"
+                ? $" · Device downloaded {evt.DataDown} / uploaded {evt.DataUp}"
                 : "") +
             (evt.Signal.HasValue ? $" · Last signal: {evt.Signal} dBm" : ""),
 

--- a/src/NetworkOptimizer.Web/Endpoints/LanFlowMapEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/LanFlowMapEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using NetworkOptimizer.Web.Services;
 using NetworkOptimizer.Web.Services.LanFlowMap;
 
@@ -10,24 +11,45 @@ public static class LanFlowMapEndpoints
     public static void Map(WebApplication app)
     {
         app.MapGet("/api/monitoring/lan-flow-map/snapshot",
-            async (LanFlowMapService svc, CancellationToken ct) =>
+            async (LanFlowMapService svc, ILogger<LanFlowMapService> logger, CancellationToken ct) =>
             {
-                var snap = await svc.BuildSnapshotAsync(ct);
-                return Results.Ok(snap);
+                try
+                {
+                    var snap = await svc.BuildSnapshotAsync(ct);
+                    return Results.Ok(snap);
+                }
+                catch (Exception ex) when (IsConsoleUnavailable(ex))
+                {
+                    return ConsoleUnavailable(logger, "snapshot", ex);
+                }
             });
 
         app.MapGet("/api/monitoring/lan-flow-map/live",
-            async (LanFlowMapService svc, CancellationToken ct) =>
+            async (LanFlowMapService svc, ILogger<LanFlowMapService> logger, CancellationToken ct) =>
             {
-                var update = await svc.GetLiveUpdateAsync(ct);
-                return Results.Ok(update);
+                try
+                {
+                    var update = await svc.GetLiveUpdateAsync(ct);
+                    return Results.Ok(update);
+                }
+                catch (Exception ex) when (IsConsoleUnavailable(ex))
+                {
+                    return ConsoleUnavailable(logger, "live", ex);
+                }
             });
 
         app.MapGet("/api/monitoring/lan-flow-map/history",
-            async (LanFlowMapService svc, DateTime at, CancellationToken ct) =>
+            async (LanFlowMapService svc, ILogger<LanFlowMapService> logger, DateTime at, CancellationToken ct) =>
             {
-                var update = await svc.GetHistoricUpdateAsync(at, ct);
-                return Results.Ok(update);
+                try
+                {
+                    var update = await svc.GetHistoricUpdateAsync(at, ct);
+                    return Results.Ok(update);
+                }
+                catch (Exception ex) when (IsConsoleUnavailable(ex))
+                {
+                    return ConsoleUnavailable(logger, "history", ex);
+                }
             });
 
         app.MapGet("/api/monitoring/lan-flow-map/speed-tests",
@@ -48,5 +70,20 @@ public static class LanFlowMapEndpoints
                 svc.InvalidateCache();
                 return Results.Ok();
             });
+    }
+
+    /// <summary>
+    /// True for failures that mean the UniFi Console couldn't serve the request right now:
+    /// non-JSON bodies (login/error page during reboot or firmware upgrade) or transport
+    /// errors. These are transient, so the map endpoints answer 503 and the JS poller
+    /// quietly retries on its next tick instead of surfacing an unhandled 500.
+    /// </summary>
+    private static bool IsConsoleUnavailable(Exception ex) =>
+        ex is JsonException or HttpRequestException;
+
+    private static IResult ConsoleUnavailable(ILogger logger, string endpoint, Exception ex)
+    {
+        logger.LogDebug(ex, "LAN flow map {Endpoint} unavailable - UniFi Console not serving data", endpoint);
+        return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
     }
 }

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Core.Helpers;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.UniFi;
 using NetworkOptimizer.UniFi.Models;
@@ -135,12 +136,12 @@ public class LanFlowMapService
         GroupMultiClientPorts(snapshot);
         await BuildWanAndClouds(topology, snapshot, ct);
 
-        // WAN interface names for InfluxDB rate queries. Include both physical
-        // and uplink names so PPPoE (ppp*) is covered when the physical port
-        // has no active counters.
+        // WAN interface names for InfluxDB rate queries, one per WAN (ppp* tunnel
+        // for PPPoE, physical port otherwise). Including both names would
+        // double-count, since the physical port keeps counting under PPPoE.
         var wans = await _pathView.GetWansAsync(ct);
         snapshot.WanIfNames = wans
-            .SelectMany(w => new[] { w.PhysicalIfName, w.UplinkIfName })
+            .Select(w => NetworkUtilities.PreferredWanCounterInterface(w.PhysicalIfName, w.UplinkIfName))
             .Where(n => !string.IsNullOrEmpty(n))
             .Select(n => n!)
             .Distinct()

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -309,14 +309,18 @@ public class MonitoringPathView
         if (string.IsNullOrEmpty(gwMac)) return;
         foreach (var wan in wans)
         {
-            // Try physical port first (eth6), then logical uplink (ppp2 / eth6.100).
-            // VLAN sub-interfaces double-count on some kernels so physical wins,
-            // but PPPoE makes the physical port inactive so ppp* carries the data.
+            // ppp* tunnel for PPPoE, physical port otherwise (issue #669): the
+            // physical port stays active under PPPoE and over-counts (overhead +
+            // sibling VLANs), while VLAN sub-interfaces double-count on some
+            // kernels. The other name remains a fallback in case the preferred
+            // interface has no SNMP rate yet.
+            var preferred = NetworkUtilities.PreferredWanCounterInterface(wan.PhysicalIfName, wan.UplinkIfName);
+            var fallback = preferred == wan.PhysicalIfName ? wan.UplinkIfName : wan.PhysicalIfName;
             PortLiveRate? portRate = null;
-            if (!string.IsNullOrEmpty(wan.PhysicalIfName))
-                portRate = _liveStats.GetPortRate(gwMac, wan.PhysicalIfName);
-            if (portRate == null && !string.IsNullOrEmpty(wan.UplinkIfName) && wan.UplinkIfName != wan.PhysicalIfName)
-                portRate = _liveStats.GetPortRate(gwMac, wan.UplinkIfName);
+            if (!string.IsNullOrEmpty(preferred))
+                portRate = _liveStats.GetPortRate(gwMac, preferred);
+            if (portRate == null && !string.IsNullOrEmpty(fallback) && fallback != preferred)
+                portRate = _liveStats.GetPortRate(gwMac, fallback);
             if (portRate != null)
             {
                 // GetPortRate convention: DownBps = port TX, UpBps = port RX.

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Net;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Core.Helpers;
 using NetworkOptimizer.Monitoring;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Probes;
@@ -42,7 +43,7 @@ public class MonitoringCollectionAgent : BackgroundService
     private readonly ILogger<MonitoringCollectionAgent> _logger;
 
     // Counter delta cache for server-side rate computation. Key = "deviceMac/ifName".
-    private readonly ConcurrentDictionary<string, CounterSnapshot> _counterCache = new();
+    private readonly ConcurrentDictionary<string, InterfaceRateCalculator.State> _counterCache = new();
     // Per-target last-probed time, for per-target poll intervals on a shared loop.
     private readonly ConcurrentDictionary<int, DateTime> _targetLastProbed = new();
 
@@ -475,15 +476,18 @@ public class MonitoringCollectionAgent : BackgroundService
         {
             var gwMac = NormalizeMac(gw.Mac);
 
-            // SNMP rate on the WAN interface. Try physical port first (eth6),
-            // then the logical uplink (ppp2 for PPPoE, eth6.100 for VLAN-tagged).
-            // VLAN sub-interfaces double-count on some kernels so physical wins,
-            // but PPPoE makes the physical port inactive so ppp* carries the data.
+            // SNMP rate on the WAN interface: ppp* tunnel for PPPoE, physical
+            // port otherwise (issue #669). The physical port stays active under
+            // PPPoE and over-counts (overhead + sibling VLANs), while VLAN
+            // sub-interfaces double-count on some kernels. The other name remains
+            // a fallback in case the preferred interface has no SNMP rate yet.
             var physIfName = _cachedGatewayWanPhysicalIfNames.TryGetValue(gwMac, out var physIf) ? physIf : null;
             var uplinkIfName = _cachedGatewayWanIfNames.TryGetValue(gwMac, out var uplinkIf) ? uplinkIf : null;
-            var portRate = physIfName != null ? _liveStats.GetPortRate(gwMac, physIfName) : null;
-            if (portRate == null && uplinkIfName != null && uplinkIfName != physIfName)
-                portRate = _liveStats.GetPortRate(gwMac, uplinkIfName);
+            var preferred = NetworkUtilities.PreferredWanCounterInterface(physIfName, uplinkIfName);
+            var fallback = preferred == physIfName ? uplinkIfName : physIfName;
+            var portRate = preferred != null ? _liveStats.GetPortRate(gwMac, preferred) : null;
+            if (portRate == null && fallback != null && fallback != preferred)
+                portRate = _liveStats.GetPortRate(gwMac, fallback);
             if (portRate != null)
             {
                 // Gateway WAN perspective: port TX (DownBps) = data toward
@@ -1455,63 +1459,47 @@ public class MonitoringCollectionAgent : BackgroundService
         if (string.IsNullOrEmpty(ifName)) return (null, null);
         var mac = NormalizeMac(device.Mac);
 
-        // Compute rate from previous snapshot
+        // Compute rate from previous snapshot. The calculator handles 32-bit wrap,
+        // unchanged-counter holds, genuine resets, and single-sample SNMP glitches
+        // (which would otherwise inject impossible terabit/sec spikes or poison the
+        // baseline - see InterfaceRateCalculator).
         var key = $"{mac}/{ifName}";
-        double? rateInBps = null;
-        double? rateOutBps = null;
-        if (_counterCache.TryGetValue(key, out var prev))
-        {
-            var elapsed = (now - prev.Timestamp).TotalSeconds;
-            if (elapsed > 0.5)
-            {
-                // 32-bit wrap detection: if delta is negative and we know counter is 32-bit
-                long deltaIn = iface.InOctets - prev.InOctets;
-                long deltaOut = iface.OutOctets - prev.OutOctets;
-                bool useHc = iface.HighSpeed >= 1000 || iface.Speed >= 1_000_000_000;
-                if (deltaIn < 0 && !useHc) deltaIn += (long)uint.MaxValue + 1;
-                if (deltaOut < 0 && !useHc) deltaOut += (long)uint.MaxValue + 1;
-                if (deltaIn >= 0 && deltaOut >= 0)
-                {
-                    if (deltaIn == 0 && deltaOut == 0)
-                    {
-                        // Counters unchanged - device hasn't refreshed them yet.
-                        // Keep the previous cache entry so the next poll that sees
-                        // a real change computes delta/elapsed over the true window.
-                        // Prevents alternating 0 / 2x sawtooth in both the live
-                        // cache and InfluxDB.
-                    }
-                    else
-                    {
-                        rateInBps = deltaIn * 8.0 / elapsed;
-                        rateOutBps = deltaOut * 8.0 / elapsed;
-                        // Mirror into the read-side per-port cache so the 3D map's
-                        // live tick refreshes wired client leaf rates on the clean
-                        // 5s SNMP cadence (UniFi PortTable lags ~30s).
-                        // Direction: rateOutBps = port TX = data toward the leaf
-                        // (DownBps in cache convention); rateInBps = port RX = data
-                        // from the leaf (UpBps).
-                        _liveStats.RecordPortRate(mac, ifName, rateOutBps.Value, rateInBps.Value, now);
-                        _counterCache[key] = new CounterSnapshot(now, iface.InOctets, iface.OutOctets);
-                    }
-                }
-                else
-                {
-                    // Counter reset (device rebooted, e.g. for a firmware upgrade): the
-                    // cached snapshot predates the reset, so the delta goes negative and
-                    // no rate can ever be computed against it. Reseed with the current
-                    // sample so the next poll computes a valid rate. Without this the
-                    // stale snapshot pins every delta negative, every poll counts as an
-                    // SNMP failure, and the device flaps in and out of SNMP exclusion
-                    // until the app restarts.
-                    _counterCache[key] = new CounterSnapshot(now, iface.InOctets, iface.OutOctets);
-                }
-            }
-        }
-        if (!_counterCache.ContainsKey(key))
-            _counterCache[key] = new CounterSnapshot(now, iface.InOctets, iface.OutOctets);
-
         bool hcCounters = iface.HighSpeed >= 1000 || iface.Speed >= 1_000_000_000;
         long speedBps = iface.HighSpeed > 0 ? iface.HighSpeed * 1_000_000L : iface.Speed;
+
+        InterfaceRateCalculator.State? prevState =
+            _counterCache.TryGetValue(key, out var cached) ? cached : null;
+        var calc = InterfaceRateCalculator.Compute(
+            prevState, iface.InOctets, iface.OutOctets, now, hcCounters, speedBps);
+        _counterCache[key] = calc.NewState;
+
+        double? rateInBps = calc.RateInBps;
+        double? rateOutBps = calc.RateOutBps;
+
+        switch (calc.Outcome)
+        {
+            case InterfaceRateCalculator.Outcome.ResetConfirmed:
+                _logger.LogInformation(
+                    "SNMP counter reset confirmed for {Mac}/{IfName}; reseeding baseline.",
+                    mac, ifName);
+                break;
+            case InterfaceRateCalculator.Outcome.ImplausibleRate:
+                _logger.LogWarning(
+                    "Discarding implausible SNMP rate for {Mac}/{IfName}: in={RateIn:F0} out={RateOut:F0} bps exceed link speed {LinkBps} bps (x{Margin}). Likely a corrupt counter read.",
+                    mac, ifName, calc.RejectedRateInBps ?? 0, calc.RejectedRateOutBps ?? 0, speedBps,
+                    InterfaceRateCalculator.LinkSpeedToleranceFactor);
+                break;
+        }
+
+        if (rateInBps.HasValue && rateOutBps.HasValue)
+        {
+            // Mirror into the read-side per-port cache so the 3D map's live tick
+            // refreshes wired client leaf rates on the clean 5s SNMP cadence
+            // (UniFi PortTable lags ~30s).
+            // Direction: rateOutBps = port TX = data toward the leaf (DownBps in
+            // cache convention); rateInBps = port RX = data from the leaf (UpBps).
+            _liveStats.RecordPortRate(mac, ifName, rateOutBps.Value, rateInBps.Value, now);
+        }
 
         _ = _influx.WriteInterfaceCountersAsync(
             deviceMac: mac,
@@ -2045,6 +2033,5 @@ public class MonitoringCollectionAgent : BackgroundService
     private static string NormalizeMac(string mac) =>
         string.IsNullOrEmpty(mac) ? string.Empty : mac.ToLowerInvariant().Replace('-', ':');
 
-    private readonly record struct CounterSnapshot(DateTime Timestamp, long InOctets, long OutOctets);
     private readonly record struct PortByteSnapshot(DateTime Timestamp, long TxBytes, long RxBytes);
 }

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -1494,6 +1494,17 @@ public class MonitoringCollectionAgent : BackgroundService
                         _counterCache[key] = new CounterSnapshot(now, iface.InOctets, iface.OutOctets);
                     }
                 }
+                else
+                {
+                    // Counter reset (device rebooted, e.g. for a firmware upgrade): the
+                    // cached snapshot predates the reset, so the delta goes negative and
+                    // no rate can ever be computed against it. Reseed with the current
+                    // sample so the next poll computes a valid rate. Without this the
+                    // stale snapshot pins every delta negative, every poll counts as an
+                    // SNMP failure, and the device flaps in and out of SNMP exclusion
+                    // until the app restarts.
+                    _counterCache[key] = new CounterSnapshot(now, iface.InOctets, iface.OutOctets);
+                }
             }
         }
         if (!_counterCache.ContainsKey(key))

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -9015,6 +9015,15 @@ a.path-hop.hop-clickable:hover {
 }
 
 @media (max-width: 768px) {
+    .client-info-main {
+        flex-wrap: wrap;
+        row-gap: 0.25rem;
+    }
+
+    .client-info-main .client-name {
+        flex-basis: 100%;
+    }
+
     .client-info-main .client-perf-link {
         display: none;
     }
@@ -9030,7 +9039,8 @@ a.path-hop.hop-clickable:hover {
     color: var(--text-primary);
 }
 
-.client-mac {
+.client-mac,
+.client-ip {
     font-size: 0.875rem;
     color: var(--text-muted);
     font-family: monospace;

--- a/src/NetworkOptimizer.WiFi/Models/ClientConnectionEvent.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ClientConnectionEvent.cs
@@ -77,10 +77,10 @@ public class ClientConnectionEvent
     /// <summary>Time connected (for disconnect events)</summary>
     public string? Duration { get; set; }
 
-    /// <summary>Data uploaded (for disconnect events)</summary>
+    /// <summary>Data uploaded by the client (UniFi event DATA_UP; for disconnect events)</summary>
     public string? DataUp { get; set; }
 
-    /// <summary>Data downloaded (for disconnect events)</summary>
+    /// <summary>Data downloaded by the client (UniFi event DATA_DOWN; for disconnect events)</summary>
     public string? DataDown { get; set; }
 
     /// <summary>

--- a/tests/NetworkOptimizer.Core.Tests/Helpers/NetworkUtilitiesTests.cs
+++ b/tests/NetworkOptimizer.Core.Tests/Helpers/NetworkUtilitiesTests.cs
@@ -527,4 +527,30 @@ public class NetworkUtilitiesTests
     }
 
     #endregion
+
+    #region PreferredWanCounterInterface Tests
+
+    [Theory]
+    // Plain ethernet: physical and uplink are the same port
+    [InlineData("eth4", "eth4", "eth4")]
+    // VLAN-tagged: sub-interface double-counts (verified ~2x on a UCG-Fiber), physical wins
+    [InlineData("eth6", "eth6.100", "eth6")]
+    // PPPoE: tunnel carries the payload, physical over-counts (overhead + sibling VLANs)
+    [InlineData("eth4", "ppp0", "ppp0")]
+    // Cellular WAN via LAN GRE tunnel (UniFi 5G Max): both fields report the tunnel
+    [InlineData("gre1", "gre1", "gre1")]
+    // Hypothetical GRE uplink with a physical LAN port reported: tunnel wins
+    [InlineData("eth3", "gre1", "gre1")]
+    // Missing one side: use whichever is known
+    [InlineData(null, "ppp0", "ppp0")]
+    [InlineData("eth4", null, "eth4")]
+    [InlineData("eth4", "", "eth4")]
+    [InlineData(null, null, null)]
+    public void PreferredWanCounterInterface_PicksCounterBearingInterface(
+        string? physical, string? uplink, string? expected)
+    {
+        NetworkUtilities.PreferredWanCounterInterface(physical, uplink).Should().Be(expected);
+    }
+
+    #endregion
 }

--- a/tests/NetworkOptimizer.Monitoring.Tests/InterfaceRateCalculatorTests.cs
+++ b/tests/NetworkOptimizer.Monitoring.Tests/InterfaceRateCalculatorTests.cs
@@ -1,0 +1,239 @@
+using FluentAssertions;
+using NetworkOptimizer.Monitoring;
+using Xunit;
+
+namespace NetworkOptimizer.Monitoring.Tests;
+
+/// <summary>
+/// Tests for SNMP counter-to-rate computation: normal deltas, 32-bit wrap,
+/// unchanged-counter holds, genuine resets, and single-sample read glitches.
+/// The glitch cases reproduce a corrupt counter read that, untreated, snaps back
+/// to a terabit/sec rate on a 2.5G port.
+/// </summary>
+public class InterfaceRateCalculatorTests
+{
+    private static readonly DateTime T0 = new(2026, 6, 11, 4, 43, 0, DateTimeKind.Utc);
+    private const long TwoPointFiveGbps = 2_500_000_000L;
+
+    private static InterfaceRateCalculator.State Seed(long inO, long outO, DateTime ts) =>
+        new(inO, outO, ts);
+
+    [Fact]
+    public void FirstSample_SeedsBaseline_NoRate()
+    {
+        var r = InterfaceRateCalculator.Compute(
+            previous: null, inOctets: 1000, outOctets: 2000, now: T0,
+            useHcCounters: true, linkSpeedBps: TwoPointFiveGbps);
+
+        r.Outcome.Should().Be(InterfaceRateCalculator.Outcome.SeededBaseline);
+        r.RateInBps.Should().BeNull();
+        r.NewState.InOctets.Should().Be(1000);
+    }
+
+    [Fact]
+    public void NormalDelta_ComputesBitsPerSecond()
+    {
+        var prev = Seed(0, 0, T0);
+        // 1,250,000 bytes in over 10s = 1,000,000 bps.
+        var r = InterfaceRateCalculator.Compute(
+            prev, inOctets: 1_250_000, outOctets: 0, now: T0.AddSeconds(10),
+            useHcCounters: true, linkSpeedBps: TwoPointFiveGbps);
+
+        r.Outcome.Should().Be(InterfaceRateCalculator.Outcome.Normal);
+        r.RateInBps.Should().BeApproximately(1_000_000, 1);
+        r.RateOutBps.Should().Be(0);
+        r.NewState.InOctets.Should().Be(1_250_000);
+    }
+
+    [Fact]
+    public void UnchangedCounters_HoldBaseline_NoRate()
+    {
+        var prev = Seed(5000, 6000, T0);
+        var r = InterfaceRateCalculator.Compute(
+            prev, inOctets: 5000, outOctets: 6000, now: T0.AddSeconds(5),
+            useHcCounters: true, linkSpeedBps: TwoPointFiveGbps);
+
+        r.Outcome.Should().Be(InterfaceRateCalculator.Outcome.CounterUnchanged);
+        r.RateInBps.Should().BeNull();
+        // Baseline timestamp held at T0 so the next real change spans the true window.
+        r.NewState.Timestamp.Should().Be(T0);
+    }
+
+    [Fact]
+    public void SubSecondElapsed_HoldsBaseline_NoRate()
+    {
+        var prev = Seed(5000, 6000, T0);
+        var r = InterfaceRateCalculator.Compute(
+            prev, inOctets: 9000, outOctets: 9000, now: T0.AddSeconds(0.3),
+            useHcCounters: true, linkSpeedBps: TwoPointFiveGbps);
+
+        r.Outcome.Should().Be(InterfaceRateCalculator.Outcome.CounterUnchanged);
+        r.RateInBps.Should().BeNull();
+        r.NewState.Timestamp.Should().Be(T0);
+    }
+
+    [Fact]
+    public void ThirtyTwoBitWrap_RecoversDelta_WhenNotHcCounters()
+    {
+        // prev near the 32-bit ceiling, current wrapped past 0.
+        long prevIn = uint.MaxValue - 100; // 4,294,967,195
+        var prev = Seed(prevIn, 0, T0);
+        // +1000 bytes across the wrap, over 8s = 1000 bytes.
+        var r = InterfaceRateCalculator.Compute(
+            prev, inOctets: 900, outOctets: 0, now: T0.AddSeconds(8),
+            useHcCounters: false, linkSpeedBps: 1_000_000_000L);
+
+        r.Outcome.Should().Be(InterfaceRateCalculator.Outcome.Normal);
+        // delta = (2^32 - (prevIn)) + 900 = 100 + 1 + 900 = 1001 bytes... compute exact:
+        long expectedDelta = (900 - prevIn) + (long)uint.MaxValue + 1;
+        r.RateInBps.Should().BeApproximately(expectedDelta * 8.0 / 8.0, 1);
+    }
+
+    // ─── Genuine reset: two consecutive below-baseline reads ───
+
+    [Fact]
+    public void CounterReset_FirstLowRead_IsPending_HoldsBaseline()
+    {
+        var prev = Seed(6_554_744_931_434, 5_000_000_000, T0);
+        var r = InterfaceRateCalculator.Compute(
+            prev, inOctets: 1_000_000, outOctets: 800_000, now: T0.AddSeconds(5),
+            useHcCounters: true, linkSpeedBps: TwoPointFiveGbps);
+
+        r.Outcome.Should().Be(InterfaceRateCalculator.Outcome.ResetPending);
+        r.RateInBps.Should().BeNull();
+        // Baseline preserved; the low read is remembered as a candidate.
+        r.NewState.InOctets.Should().Be(6_554_744_931_434);
+        r.NewState.CandidateInOctets.Should().Be(1_000_000);
+    }
+
+    [Fact]
+    public void CounterReset_SecondLowRead_ConfirmsReset_ReseedsBaseline()
+    {
+        var prev = Seed(6_554_744_931_434, 5_000_000_000, T0) with
+        {
+            CandidateInOctets = 1_000_000,
+            CandidateOutOctets = 800_000,
+            CandidateTimestamp = T0.AddSeconds(5),
+        };
+        var r = InterfaceRateCalculator.Compute(
+            prev, inOctets: 1_500_000, outOctets: 1_100_000, now: T0.AddSeconds(10),
+            useHcCounters: true, linkSpeedBps: TwoPointFiveGbps);
+
+        r.Outcome.Should().Be(InterfaceRateCalculator.Outcome.ResetConfirmed);
+        r.RateInBps.Should().BeNull();
+        // Baseline reseeded to the current post-reset sample.
+        r.NewState.InOctets.Should().Be(1_500_000);
+        r.NewState.CandidateInOctets.Should().BeNull();
+    }
+
+    // ─── Single-sample glitch (corrupt read, then snap-back) ───
+
+    [Fact]
+    public void GlitchLowThenRecover_AbsorbedWithNoSpike_BaselineNeverPoisoned()
+    {
+        // A corrupt low read between two true ~6.55 TB reads.
+        var baseline = Seed(6_554_744_931_434, 0, T0.AddSeconds(12));
+
+        // Glitch read: counter momentarily reports 0.63 GB.
+        var afterGlitch = InterfaceRateCalculator.Compute(
+            baseline, inOctets: 625_957_356, outOctets: 0, now: T0.AddSeconds(21),
+            useHcCounters: true, linkSpeedBps: TwoPointFiveGbps);
+        afterGlitch.Outcome.Should().Be(InterfaceRateCalculator.Outcome.ResetPending);
+        afterGlitch.RateInBps.Should().BeNull();
+        afterGlitch.NewState.InOctets.Should().Be(6_554_744_931_434, "baseline must not be poisoned");
+
+        // Next true read snaps back to the real counter (+2.1 MB of real traffic).
+        var recovered = InterfaceRateCalculator.Compute(
+            afterGlitch.NewState, inOctets: 6_554_747_046_283, outOctets: 0, now: T0.AddSeconds(26),
+            useHcCounters: true, linkSpeedBps: TwoPointFiveGbps);
+
+        recovered.Outcome.Should().Be(InterfaceRateCalculator.Outcome.Normal);
+        // 2,114,849 bytes over 14s ≈ 1.2 Mbps - NOT 10 Tbps.
+        recovered.RateInBps.Should().BeLessThan(2_000_000);
+        recovered.RateInBps.Should().BeGreaterThan(0);
+        recovered.NewState.InOctets.Should().Be(6_554_747_046_283);
+        recovered.NewState.CandidateInOctets.Should().BeNull();
+    }
+
+    [Fact]
+    public void GlitchHigh_ExceedsLinkSpeed_Discarded_BaselineAdvances()
+    {
+        var prev = Seed(6_554_744_931_434, 0, T0);
+        // Corrupt high read: +6.55 TB in 5s would be ~10 Tbps on a 2.5G port.
+        var r = InterfaceRateCalculator.Compute(
+            prev, inOctets: 16_554_747_046_283, outOctets: 0, now: T0.AddSeconds(5),
+            useHcCounters: true, linkSpeedBps: TwoPointFiveGbps);
+
+        r.Outcome.Should().Be(InterfaceRateCalculator.Outcome.ImplausibleRate);
+        r.RateInBps.Should().BeNull("the bogus rate must not be emitted");
+        r.RejectedRateInBps.Should().BeGreaterThan(TwoPointFiveGbps * InterfaceRateCalculator.LinkSpeedToleranceFactor);
+        // Baseline advances to the rejected sample so a poisoned baseline can never
+        // wedge the interface; the discarded rate is never emitted regardless.
+        r.NewState.InOctets.Should().Be(16_554_747_046_283);
+    }
+
+    [Fact]
+    public void ImplausibleRate_AdvancesBaseline_SoNextSampleRecovers_NeverStuck()
+    {
+        // A poisoned-low baseline (e.g. from two earlier corrupt low reads that
+        // falsely confirmed a reset) makes the next real read look impossible.
+        // The interface must recover, not suppress forever.
+        var poisoned = Seed(630_000_000, 0, T0);
+
+        var rejected = InterfaceRateCalculator.Compute(
+            poisoned, inOctets: 6_554_747_046_283, outOctets: 0, now: T0.AddSeconds(5),
+            useHcCounters: true, linkSpeedBps: TwoPointFiveGbps);
+        rejected.Outcome.Should().Be(InterfaceRateCalculator.Outcome.ImplausibleRate);
+        rejected.RateInBps.Should().BeNull();
+        rejected.NewState.InOctets.Should().Be(6_554_747_046_283, "baseline advanced past the poison");
+
+        // Next clean read computes a normal delta from the corrected baseline.
+        var recovered = InterfaceRateCalculator.Compute(
+            rejected.NewState, inOctets: 6_554_748_840_227, outOctets: 0, now: T0.AddSeconds(10),
+            useHcCounters: true, linkSpeedBps: TwoPointFiveGbps);
+        recovered.Outcome.Should().Be(InterfaceRateCalculator.Outcome.Normal);
+        recovered.RateInBps.Should().BeGreaterThan(0);
+        recovered.RateInBps.Should().BeLessThan(TwoPointFiveGbps);
+    }
+
+    [Fact]
+    public void RateWithin40PercentOverLinkSpeed_IsAllowed()
+    {
+        var prev = Seed(0, 0, T0);
+        // 1.3x link speed: jitter over a short window, still plausible.
+        long bytes = (long)(TwoPointFiveGbps * 1.3 / 8.0 * 5.0); // 5s worth at 1.3x
+        var r = InterfaceRateCalculator.Compute(
+            prev, inOctets: bytes, outOctets: 0, now: T0.AddSeconds(5),
+            useHcCounters: true, linkSpeedBps: TwoPointFiveGbps);
+
+        r.Outcome.Should().Be(InterfaceRateCalculator.Outcome.Normal);
+        r.RateInBps.Should().BeApproximately(TwoPointFiveGbps * 1.3, TwoPointFiveGbps * 0.01);
+    }
+
+    [Fact]
+    public void UnknownLinkSpeed_RateUnderCeiling_IsAllowed()
+    {
+        // ppp*/gre* report speed 0; the 14 Gbps absolute ceiling applies.
+        var prev = Seed(0, 0, T0);
+        long bytes = (long)(10_000_000_000d / 8.0 * 5.0); // 10 Gbps for 5s
+        var r = InterfaceRateCalculator.Compute(
+            prev, inOctets: bytes, outOctets: 0, now: T0.AddSeconds(5),
+            useHcCounters: true, linkSpeedBps: 0);
+
+        r.Outcome.Should().Be(InterfaceRateCalculator.Outcome.Normal);
+        r.RateInBps.Should().BeApproximately(10_000_000_000d, 1_000_000);
+    }
+
+    [Fact]
+    public void UnknownLinkSpeed_RateOverCeiling_IsRejected()
+    {
+        var prev = Seed(0, 0, T0);
+        long bytes = (long)(20_000_000_000d / 8.0 * 5.0); // 20 Gbps, over the 14 Gbps ceiling
+        var r = InterfaceRateCalculator.Compute(
+            prev, inOctets: bytes, outOctets: 0, now: T0.AddSeconds(5),
+            useHcCounters: true, linkSpeedBps: 0);
+
+        r.Outcome.Should().Be(InterfaceRateCalculator.Outcome.ImplausibleRate);
+        r.RateInBps.Should().BeNull();
+    }
+}

--- a/tests/NetworkOptimizer.UniFi.Tests/UniFiNonJsonResponseExceptionTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/UniFiNonJsonResponseExceptionTests.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace NetworkOptimizer.UniFi.Tests;
+
+/// <summary>
+/// Tests for the non-JSON response wrapper thrown when the UniFi Console serves
+/// HTML (login/error page during reboot or firmware upgrade) instead of JSON.
+/// The wrapper must stay catch-compatible with JsonException so existing
+/// handlers and retry predicates behave exactly as before.
+/// </summary>
+public class UniFiNonJsonResponseExceptionTests
+{
+    private static readonly JsonException Inner = new("'<' is an invalid start of a value.");
+
+    [Fact]
+    public void Create_IsCatchableAsJsonException()
+    {
+        var ex = UniFiNonJsonResponseException.Create(200, "text/html", "<!DOCTYPE html>", Inner);
+
+        ex.Should().BeAssignableTo<JsonException>();
+        ex.InnerException.Should().BeSameAs(Inner);
+    }
+
+    [Fact]
+    public void Create_MessageContainsStatusContentTypeAndPreview()
+    {
+        var ex = UniFiNonJsonResponseException.Create(503, "text/html", "<!DOCTYPE html><html>", Inner);
+
+        ex.Message.Should().Contain("status 503");
+        ex.Message.Should().Contain("content-type text/html");
+        ex.Message.Should().Contain("<!DOCTYPE html><html>");
+    }
+
+    [Fact]
+    public void Create_TruncatesLongBodies()
+    {
+        var body = new string('x', 500);
+
+        var ex = UniFiNonJsonResponseException.Create(200, "text/html", body, Inner);
+
+        ex.Message.Should().Contain(new string('x', 120) + "...");
+        ex.Message.Should().NotContain(new string('x', 121));
+    }
+
+    [Fact]
+    public void Create_FlattensNewlinesInPreview()
+    {
+        var ex = UniFiNonJsonResponseException.Create(200, "text/html", "<html>\r\n<body>\nhi", Inner);
+
+        ex.Message.Should().NotContain("\n");
+        ex.Message.Should().NotContain("\r");
+    }
+
+    [Fact]
+    public void Create_HandlesNullBodyAndContentType()
+    {
+        var ex = UniFiNonJsonResponseException.Create(502, null, null, Inner);
+
+        ex.Message.Should().Contain("status 502");
+        ex.Message.Should().Contain("content-type unknown");
+    }
+}

--- a/tests/NetworkOptimizer.UniFi.Tests/WanInterfaceNameTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/WanInterfaceNameTests.cs
@@ -1,0 +1,286 @@
+using System.Text.Json;
+using FluentAssertions;
+using NetworkOptimizer.UniFi.Models;
+using Xunit;
+
+namespace NetworkOptimizer.UniFi.Tests;
+
+/// <summary>
+/// Tests for WAN interface name resolution used by Monitoring WAN throughput
+/// (stat cards, charts, Live View). By design this resolves the PRIMARY WAN
+/// only - the surrounding ISP / transit latency cards are measured for that
+/// one connection. The primary WAN may be plain ethernet, VLAN-tagged, PPPoE
+/// (counters live on the ppp* tunnel, issue #669), or a GRE-tunneled cellular
+/// WAN with no physical port.
+/// </summary>
+public class WanInterfaceNameTests
+{
+    private static UniFiDeviceResponse Parse(string json) =>
+        JsonSerializer.Deserialize<UniFiDeviceResponse>(json)!;
+
+    // ─── Single-WAN gateways, one per connection type ───
+
+    [Fact]
+    public void PlainEthernetWan_UsesPhysicalPort()
+    {
+        var device = Parse("""
+            { "type": "ucg", "wan1": { "ifname": "eth4", "uplink_ifname": "eth4" } }
+            """);
+        UniFiDiscovery.GetWanInterfaceNames(device).Should().Equal("eth4");
+    }
+
+    [Fact]
+    public void PppoeWan_UsesPppTunnel()
+    {
+        var device = Parse("""
+            { "type": "ucg", "wan1": { "ifname": "eth4", "uplink_ifname": "ppp0" } }
+            """);
+        UniFiDiscovery.GetWanInterfaceNames(device).Should().Equal("ppp0");
+    }
+
+    [Fact]
+    public void PppoeWan_MissingPhysicalIfname_UsesPppTunnel()
+    {
+        var device = Parse("""
+            { "type": "ucg", "wan1": { "uplink_ifname": "ppp0" } }
+            """);
+        UniFiDiscovery.GetWanInterfaceNames(device).Should().Equal("ppp0");
+    }
+
+    [Fact]
+    public void VlanTaggedWan_UsesPhysicalPort_NotSubInterface()
+    {
+        // VLAN sub-interfaces double-count on some kernels, so the physical port wins.
+        var device = Parse("""
+            { "type": "ucg", "wan1": { "ifname": "eth6", "uplink_ifname": "eth6.100" } }
+            """);
+        UniFiDiscovery.GetWanInterfaceNames(device).Should().Equal("eth6");
+    }
+
+    [Fact]
+    public void CellularGreWan_UsesGreTunnel()
+    {
+        // UniFi 5G Max reaches the gateway over a LAN GRE tunnel; UniFi reports
+        // the tunnel as both ifname and uplink_ifname.
+        var device = Parse("""
+            { "type": "ucg", "wan1": { "type": "wireless_5g", "ifname": "gre1", "uplink_ifname": "gre1" } }
+            """);
+        UniFiDiscovery.GetWanInterfaceNames(device).Should().Equal("gre1");
+    }
+
+    // ─── Primary selection via the gateway uplink object (firmware shapes vary) ───
+
+    [Fact]
+    public void UplinkObject_NameCarriesVlanInterface_ResolvesPrimaryPhysicalPort()
+    {
+        // Firmware shape A: uplink.name holds the active WAN's logical interface,
+        // ifname/uplink_ifname absent. Multi-WAN site; only the primary resolves.
+        var device = Parse("""
+            {
+              "type": "ucg",
+              "uplink": { "name": "eth6.100", "type": "wire", "up": true },
+              "wan1": { "ifname": "eth6", "uplink_ifname": "eth6.100", "up": true },
+              "wan2": { "ifname": "eth0", "uplink_ifname": "eth0", "up": true },
+              "wan3": { "type": "wireless_5g", "ifname": "gre1", "uplink_ifname": "gre1", "up": true }
+            }
+            """);
+        UniFiDiscovery.GetWanInterfaceNames(device).Should().Equal("eth6");
+    }
+
+    [Fact]
+    public void UplinkObject_UplinkIfnameCarriesPppTunnel_ResolvesPppTunnel()
+    {
+        // Firmware shape B (seen on a PPPoE UCG-Fiber): uplink.name is a bridge,
+        // uplink.uplink_ifname holds the WAN interface.
+        var device = Parse("""
+            {
+              "type": "ucg",
+              "uplink": { "name": "br0", "uplink_ifname": "ppp0", "type": "wire", "up": true },
+              "wan1": { "ifname": "eth4", "uplink_ifname": "ppp0", "up": true }
+            }
+            """);
+        UniFiDiscovery.GetWanInterfaceNames(device).Should().Equal("ppp0");
+    }
+
+    [Fact]
+    public void UplinkObject_GrePrimary_ResolvesGreTunnel_NotWan1()
+    {
+        // Cellular as the PRIMARY WAN: the uplink object points at gre1 even
+        // though an ethernet WAN exists as wan1.
+        var device = Parse("""
+            {
+              "type": "ucg",
+              "uplink": { "name": "gre1", "type": "wire", "up": true },
+              "wan1": { "ifname": "eth4", "uplink_ifname": "eth4", "up": false },
+              "wan2": { "type": "wireless_5g", "ifname": "gre1", "uplink_ifname": "gre1", "up": true }
+            }
+            """);
+        UniFiDiscovery.GetWanInterfaceNames(device).Should().Equal("gre1");
+    }
+
+    [Fact]
+    public void UplinkObject_MatchesByPhysicalIfname()
+    {
+        // uplink references the physical port name; wan matched via ifname.
+        var device = Parse("""
+            {
+              "type": "ucg",
+              "uplink": { "name": "eth4", "type": "wire", "up": true },
+              "wan1": { "ifname": "eth4", "uplink_ifname": "ppp0", "up": true }
+            }
+            """);
+        UniFiDiscovery.GetWanInterfaceNames(device).Should().Equal("ppp0");
+    }
+
+    [Fact]
+    public void UplinkObject_NoMatchingWan_FallsThroughToPortTable()
+    {
+        // uplink names something that isn't a WAN (defensive): fall through.
+        var device = Parse("""
+            {
+              "type": "ucg",
+              "uplink": { "name": "br0", "type": "wire", "up": true },
+              "wan1": { "ifname": "eth4", "uplink_ifname": "ppp0", "port_idx": 4 },
+              "port_table": [
+                { "port_idx": 4, "ifname": "eth4", "is_uplink": true }
+              ]
+            }
+            """);
+        UniFiDiscovery.GetWanInterfaceNames(device).Should().Equal("ppp0");
+    }
+
+    // ─── Primary selection via port_table is_uplink (no usable uplink object) ───
+
+    [Fact]
+    public void PppoeWan_UplinkPortFlagged_RemapsToPppTunnel()
+    {
+        // is_uplink points at the physical port; the counters live on ppp0.
+        var device = Parse("""
+            {
+              "type": "ucg",
+              "wan1": { "ifname": "eth4", "uplink_ifname": "ppp0", "port_idx": 4 },
+              "port_table": [
+                { "port_idx": 4, "ifname": "eth4", "is_uplink": true }
+              ]
+            }
+            """);
+        UniFiDiscovery.GetWanInterfaceNames(device).Should().Equal("ppp0");
+    }
+
+    [Fact]
+    public void FlaggedUplinkPort_MatchesWanByPortIdx_WhenIfnameMissing()
+    {
+        var device = Parse("""
+            {
+              "type": "ucg",
+              "wan1": { "uplink_ifname": "ppp0", "port_idx": 4 },
+              "port_table": [
+                { "port_idx": 4, "ifname": "eth4", "is_uplink": true }
+              ]
+            }
+            """);
+        UniFiDiscovery.GetWanInterfaceNames(device).Should().Equal("ppp0");
+    }
+
+    [Fact]
+    public void MultiWan_FlaggedUplink_ResolvesOnlyThePrimaryWan()
+    {
+        // Primary WAN only, by design: the WAN Live View / overview stats sit
+        // alongside ISP / transit latency measured for one connection.
+        var device = Parse("""
+            {
+              "type": "ucg",
+              "wan1": { "ifname": "eth6", "uplink_ifname": "eth6.100", "port_idx": 7 },
+              "wan2": { "ifname": "eth0", "uplink_ifname": "eth0", "port_idx": 1 },
+              "wan3": { "type": "wireless_5g", "ifname": "gre1", "uplink_ifname": "gre1" },
+              "port_table": [
+                { "port_idx": 1, "ifname": "eth0", "is_uplink": false },
+                { "port_idx": 7, "ifname": "eth6", "is_uplink": true }
+              ]
+            }
+            """);
+        UniFiDiscovery.GetWanInterfaceNames(device).Should().Equal("eth6");
+    }
+
+    [Fact]
+    public void FlaggedUplinkPort_NoMatchingWanObject_UsesPortIfname()
+    {
+        var device = Parse("""
+            {
+              "type": "ucg",
+              "wan1": { "name": "WAN1" },
+              "port_table": [
+                { "port_idx": 4, "ifname": "eth4", "is_uplink": true }
+              ]
+            }
+            """);
+        UniFiDiscovery.GetWanInterfaceNames(device).Should().Equal("eth4");
+    }
+
+    [Fact]
+    public void NonGatewayDevice_UsesPortTableUplink()
+    {
+        // Switches/APs have no wan objects; their uplink port resolves as before.
+        var device = Parse("""
+            {
+              "type": "usw",
+              "uplink": { "name": "Port 24", "port_idx": 24, "type": "wire", "up": true },
+              "port_table": [
+                { "port_idx": 1, "ifname": "eth0", "is_uplink": true },
+                { "port_idx": 2, "ifname": "eth1", "is_uplink": false }
+              ]
+            }
+            """);
+        UniFiDiscovery.GetWanInterfaceNames(device).Should().Equal("eth0");
+    }
+
+    // ─── Last-resort fallback: wan objects only (seen on PPPoE gateways) ───
+
+    [Fact]
+    public void MultiWan_NoUplinkSignals_ResolvesFirstWan()
+    {
+        var device = Parse("""
+            {
+              "type": "ucg",
+              "wan1": { "ifname": "eth4", "uplink_ifname": "ppp0", "up": true },
+              "wan2": { "ifname": "eth5", "uplink_ifname": "eth5", "up": true }
+            }
+            """);
+        UniFiDiscovery.GetWanInterfaceNames(device).Should().Equal("ppp0");
+    }
+
+    [Fact]
+    public void MultiWan_NoUplinkSignals_PrefersWanThatIsUp()
+    {
+        // GRE cellular as the only WAN that is up; wan1 ethernet is down.
+        var device = Parse("""
+            {
+              "type": "ucg",
+              "wan1": { "ifname": "eth4", "uplink_ifname": "eth4", "up": false },
+              "wan2": { "type": "wireless_5g", "ifname": "gre1", "uplink_ifname": "gre1", "up": true }
+            }
+            """);
+        UniFiDiscovery.GetWanInterfaceNames(device).Should().Equal("gre1");
+    }
+
+    [Fact]
+    public void DuplicateWanKeys_ResolveToSingleName()
+    {
+        // Some firmware exposes both "wan" and "wan1" pointing at the same interface.
+        var device = Parse("""
+            {
+              "type": "ucg",
+              "wan":  { "ifname": "eth4", "uplink_ifname": "ppp0" },
+              "wan1": { "ifname": "eth4", "uplink_ifname": "ppp0" }
+            }
+            """);
+        UniFiDiscovery.GetWanInterfaceNames(device).Should().Equal("ppp0");
+    }
+
+    [Fact]
+    public void NoWanData_ReturnsEmpty()
+    {
+        var device = Parse("""{ "type": "ucg" }""");
+        UniFiDiscovery.GetWanInterfaceNames(device).Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
Catch-all release PR; scope to be determined. All changes are deployed to the test sites for soak.

## Monitoring

- **WAN throughput now shows on PPPoE connections** (#769) - On PPPoE gateways (e.g. UCG-Fiber with DSL PPPoE), the WAN Download/Upload cards, charts, and Live View stayed blank even though SNMP was collecting data. They were keyed to the physical port instead of the ppp tunnel that actually carries the traffic. They now read the right interface (and handle VLAN-tagged and GRE-tunneled cellular WANs correctly too). The history backfills, since the data was being recorded all along. Fixes #669.
- **Corrupt SNMP counter reads no longer chart impossible spikes** (#769) - A single garbled SNMP counter read could put a multi-terabit spike on the WAN graph (physically impossible on the link). Rate computation now discards any jump beyond the interface link speed and absorbs one-off glitches without losing its baseline, so a bad read leaves a brief gap instead of a giant spike. A genuine counter reset (device reboot) is still detected and recovers cleanly.
- **SNMP: recover rate computation after device counter reset** (#764) - When a monitored device rebooted (e.g. console firmware upgrade), its SNMP counters reset while the rate cache kept the pre-reboot snapshots, so every delta went negative, no rate could ever be computed, and the device flapped in and out of SNMP exclusion until the app restarted. A negative delta is now treated as a counter reset and reseeds the cache, so a rebooted device recovers within two poll cycles.
- **UniFi API: clean diagnosis when console serves HTML instead of JSON** (#765) - While a console reboots or upgrades firmware, its API serves an HTML login/error page. Instead of a 40-line JsonException stack trace per request, the API client now raises a one-line diagnosis (status, content type, body preview), and the LAN flow map endpoints answer 503 so the map poller quietly retries instead of logging unhandled exceptions.

## WiFi Optimizer

- **Client Stats: clearer traffic direction labels and client IP in detail header** (#768) - Disconnect events now read "Device downloaded X / uploaded Y" instead of the ambiguous "X up / Y down", the rate row is labeled "AP TX/RX Rate" to make the perspective explicit, and the detail banner shows the client IP next to the MAC. On mobile the IP and MAC wrap under the device name.