### PR TITLE
Client Stats: clearer traffic direction labels and client IP in detail header

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ClientTimeline.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ClientTimeline.razor
@@ -225,11 +225,11 @@
                     {
                         <span class="client-name">@_selectedClient.Name</span>
                     }
-                    <span class="client-mac">@_selectedClient.Mac</span>
                     @if (!string.IsNullOrEmpty(_selectedClient.Ip))
                     {
                         <span class="client-ip">@_selectedClient.Ip</span>
                     }
+                    <span class="client-mac">@_selectedClient.Mac</span>
                     @if (!string.IsNullOrEmpty(_selectedClient.Ip))
                     {
                         <a href="/client-dashboard?ip=@_selectedClient.Ip&range=30d&tab=signal" class="client-perf-link"

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ClientTimeline.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ClientTimeline.razor
@@ -689,7 +689,7 @@
         ClientConnectionEventType.Disconnected =>
             (!string.IsNullOrEmpty(evt.Duration) ? $"Duration: {evt.Duration}" : "") +
             (!string.IsNullOrEmpty(evt.DataUp) && !string.IsNullOrEmpty(evt.DataDown)
-                ? $" · AP sent {evt.DataUp} / received {evt.DataDown}"
+                ? $" · Device downloaded {evt.DataDown} / uploaded {evt.DataUp}"
                 : "") +
             (evt.Signal.HasValue ? $" · Last signal: {evt.Signal} dBm" : ""),
 

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ClientTimeline.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ClientTimeline.razor
@@ -228,6 +228,10 @@
                     <span class="client-mac">@_selectedClient.Mac</span>
                     @if (!string.IsNullOrEmpty(_selectedClient.Ip))
                     {
+                        <span class="client-ip">@_selectedClient.Ip</span>
+                    }
+                    @if (!string.IsNullOrEmpty(_selectedClient.Ip))
+                    {
                         <a href="/client-dashboard?ip=@_selectedClient.Ip&range=30d&tab=signal" class="client-perf-link"
                            data-tooltip="View full speed and signal history">
                             <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
@@ -261,7 +265,7 @@
                         </span>
                     </div>
                     <div class="info-item">
-                        <span class="info-label">TX/RX Rate:</span>
+                        <span class="info-label">AP TX/RX Rate:</span>
                         <span class="info-value" data-tooltip="TX = AP transmits to client (download), RX = AP receives from client (upload)">@FormatRate(_selectedClient.TxRate) / @FormatRate(_selectedClient.RxRate)</span>
                     </div>
                     @if (_selectedClient.FixedApEnabled)
@@ -685,7 +689,7 @@
         ClientConnectionEventType.Disconnected =>
             (!string.IsNullOrEmpty(evt.Duration) ? $"Duration: {evt.Duration}" : "") +
             (!string.IsNullOrEmpty(evt.DataUp) && !string.IsNullOrEmpty(evt.DataDown)
-                ? $" · {evt.DataUp} up / {evt.DataDown} down"
+                ? $" · AP sent {evt.DataUp} / received {evt.DataDown}"
                 : "") +
             (evt.Signal.HasValue ? $" · Last signal: {evt.Signal} dBm" : ""),
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -9015,6 +9015,15 @@ a.path-hop.hop-clickable:hover {
 }
 
 @media (max-width: 768px) {
+    .client-info-main {
+        flex-wrap: wrap;
+        row-gap: 0.25rem;
+    }
+
+    .client-info-main .client-name {
+        flex-basis: 100%;
+    }
+
     .client-info-main .client-perf-link {
         display: none;
     }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -9030,7 +9030,8 @@ a.path-hop.hop-clickable:hover {
     color: var(--text-primary);
 }
 
-.client-mac {
+.client-mac,
+.client-ip {
     font-size: 0.875rem;
     color: var(--text-muted);
     font-family: monospace;

--- a/src/NetworkOptimizer.WiFi/Models/ClientConnectionEvent.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ClientConnectionEvent.cs
@@ -77,10 +77,10 @@ public class ClientConnectionEvent
     /// <summary>Time connected (for disconnect events)</summary>
     public string? Duration { get; set; }
 
-    /// <summary>Data uploaded (for disconnect events)</summary>
+    /// <summary>Data sent by the AP to the client (UniFi event DATA_UP; for disconnect events)</summary>
     public string? DataUp { get; set; }
 
-    /// <summary>Data downloaded (for disconnect events)</summary>
+    /// <summary>Data received by the AP from the client (UniFi event DATA_DOWN; for disconnect events)</summary>
     public string? DataDown { get; set; }
 
     /// <summary>

--- a/src/NetworkOptimizer.WiFi/Models/ClientConnectionEvent.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ClientConnectionEvent.cs
@@ -77,10 +77,10 @@ public class ClientConnectionEvent
     /// <summary>Time connected (for disconnect events)</summary>
     public string? Duration { get; set; }
 
-    /// <summary>Data sent by the AP to the client (UniFi event DATA_UP; for disconnect events)</summary>
+    /// <summary>Data uploaded by the client (UniFi event DATA_UP; for disconnect events)</summary>
     public string? DataUp { get; set; }
 
-    /// <summary>Data received by the AP from the client (UniFi event DATA_DOWN; for disconnect events)</summary>
+    /// <summary>Data downloaded by the client (UniFi event DATA_DOWN; for disconnect events)</summary>
     public string? DataDown { get; set; }
 
     /// <summary>


### PR DESCRIPTION
## What changed

- **Disconnect events now state direction from the device perspective.** The old "X up / Y down" wording was ambiguous about whose perspective it was. Disconnect details now read "Device downloaded X / uploaded Y".
- **Rate row labeled "AP TX/RX Rate".** Makes it explicit that the rates are from the AP perspective (TX = AP to client, RX = client to AP), matching the existing tooltip.
- **Client IP shown in the detail header.** The Client Stats detail banner now shows the client IP next to the MAC (IP first), styled the same.
- **Mobile layout.** On narrow screens the device name takes its own line and the IP + MAC wrap underneath it instead of overflowing.

## Notes

- `DataUp`/`DataDown` doc comments on `ClientConnectionEvent` now document the UniFi DATA_UP/DATA_DOWN semantics (client upload / client download).
- Build clean (0 warnings), all 4,012 tests pass.