### PR TITLE
Monitoring: probe gateway latency on its LAN-side IP instead of the WAN IP

### DIFF
--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -1381,6 +1381,12 @@ public class MonitoringCollectionAgent : BackgroundService
         var devices = await GetMonitorableDevicesAsync(ct);
         if (devices.Count == 0) return;
 
+        // Gateways need the LAN-side address here for the same reason SNMP does:
+        // UniFi's "ip" field is the WAN public IP, which often doesn't answer ping
+        // from inside the LAN (PPPoE, CGNAT, upstream-assigned). The Address refresh
+        // below also migrates existing targets seeded with the WAN IP.
+        var gatewayLanIp = await ResolveGatewayLanIpAsync(ct);
+
         await using var db = await _dbFactory.CreateDbContextAsync(ct);
         var existingByTargetId = await db.MonitoringTargets
             .Where(t => t.TargetType == MonitoringTargetType.Fabric)
@@ -1417,13 +1423,14 @@ public class MonitoringCollectionAgent : BackgroundService
         foreach (var d in devices)
         {
             if (string.IsNullOrEmpty(d.Ip) || string.IsNullOrEmpty(d.Mac)) continue;
+            var address = ResolveSnmpAddress(d, gatewayLanIp);
             var targetId = $"fabric-{NormalizeMac(d.Mac)}";
             if (existingByTargetId.TryGetValue(targetId, out var existing))
             {
                 // Refresh address in case the device's management IP changed.
-                if (existing.Address != d.Ip)
+                if (existing.Address != address)
                 {
-                    existing.Address = d.Ip;
+                    existing.Address = address;
                     changed = true;
                 }
                 continue;
@@ -1434,7 +1441,7 @@ public class MonitoringCollectionAgent : BackgroundService
             {
                 TargetId = targetId,
                 Name = string.IsNullOrEmpty(d.Name) ? d.Mac : d.Name,
-                Address = d.Ip,
+                Address = address,
                 ProbeMode = ProbeMode.Icmp,
                 TargetType = MonitoringTargetType.Fabric,
                 DeviceMac = NormalizeMac(d.Mac),
@@ -1698,9 +1705,9 @@ public class MonitoringCollectionAgent : BackgroundService
     }
 
     /// <summary>
-    /// SNMP poll address for a device. For gateways, swap UniFi's WAN public IP for
-    /// the LAN-side gateway IP so the poll actually reaches the device. All other
-    /// device types use their raw IP from UniFi.
+    /// Poll address for a device (SNMP and fabric latency targets). For gateways,
+    /// swap UniFi's WAN public IP for the LAN-side gateway IP so the poll actually
+    /// reaches the device. All other device types use their raw IP from UniFi.
     /// </summary>
     private static string ResolveSnmpAddress(UniFiDeviceResponse device, string? gatewayLanIp)
     {


### PR DESCRIPTION
## Summary

The auto-created fabric latency target for the gateway used the IP that UniFi reports for the device, which is the primary WAN address. On many setups (PPPoE, CGNAT, upstream-assigned addressing) that address does not answer ping from inside the LAN, so the gateway showed as lossy or down in Monitoring even though it was fine.

The fabric target reconciler now resolves gateways to their LAN-side address using the same resolver the SNMP pollers already use (default-LAN network config lookup), both when seeding new targets and when refreshing existing ones.

## Notes

- No migration needed: the reconciler already refreshes a target's address whenever it differs, so existing installs converge to the LAN address on the first latency tick after upgrade.
- No InfluxDB series impact: latency points are tagged by target id (`fabric-{mac}`), which is unchanged. History stays continuous.
- If the LAN address cannot be resolved (no connection, no default LAN), behavior falls back to the UniFi-reported IP exactly as before.

## Testing

- 0 build warnings, full test suite passes
- Verified on both test sites: gateway target address flipped to the LAN IP automatically and probes succeed