### PR TITLE
v1.19.6

### DIFF
--- a/src/NetworkOptimizer.Monitoring/Models/OntStats.cs
+++ b/src/NetworkOptimizer.Monitoring/Models/OntStats.cs
@@ -50,6 +50,15 @@ public class OntStats
     /// <summary>Laser wavelength in nm</summary>
     public string? WaveLength { get; set; }
 
+    /// <summary>PON ONU activation state (ITU-T G.984.3 / G.9807.1)</summary>
+    public PonLinkState PonLinkStatus { get; set; }
+
+    /// <summary>Broadband provisioned speed in Mbps (BWP, not SFP link rate)</summary>
+    public int? BwpSpeedMbps { get; set; }
+
+    /// <summary>SFP physical link speed in Mbps (only populated when reported by the device)</summary>
+    public int? SfpLinkSpeedMbps { get; set; }
+
     // Error counters
     /// <summary>FEC corrected error count</summary>
     public long? FecErrors { get; set; }

--- a/src/NetworkOptimizer.Monitoring/Models/PonLinkState.cs
+++ b/src/NetworkOptimizer.Monitoring/Models/PonLinkState.cs
@@ -1,0 +1,78 @@
+namespace NetworkOptimizer.Monitoring.Models;
+
+/// <summary>
+/// ITU-T G.984.3 / G.9807.1 ONU activation states (O1-O7).
+/// </summary>
+public enum PonLinkState
+{
+    Unknown,
+    Initial,
+    Standby,
+    SerialNumber,
+    Ranging,
+    Operation,
+    Popup,
+    EmergencyStop,
+}
+
+public static class PonLinkStateExtensions
+{
+    /// <summary>
+    /// Parse a raw PON link status string (e.g. "OPERATION (O5)", "O5", "RANGING")
+    /// into a typed enum value.
+    /// </summary>
+    public static PonLinkState ParsePonLinkState(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return PonLinkState.Unknown;
+
+        var s = raw.Trim().ToUpperInvariant();
+
+        if (s.Contains("O1") || s.Contains("INITIAL"))
+            return PonLinkState.Initial;
+        if (s.Contains("O2") || s.Contains("STANDBY"))
+            return PonLinkState.Standby;
+        if (s.Contains("O3") || s.Contains("SERIAL"))
+            return PonLinkState.SerialNumber;
+        if (s.Contains("O4") || s.Contains("RANGING"))
+            return PonLinkState.Ranging;
+        if (s.Contains("O5") || s.Contains("OPERATION"))
+            return PonLinkState.Operation;
+        if (s.Contains("O6") || s.Contains("POPUP"))
+            return PonLinkState.Popup;
+        if (s.Contains("O7") || s.Contains("EMERGENCY"))
+            return PonLinkState.EmergencyStop;
+
+        return PonLinkState.Unknown;
+    }
+
+    /// <summary>
+    /// Human-readable label with ITU state code, e.g. "Connected (O5)".
+    /// </summary>
+    public static string ToDisplayString(this PonLinkState state) => state switch
+    {
+        PonLinkState.Initial => "Initializing (O1)",
+        PonLinkState.Standby => "Standby (O2)",
+        PonLinkState.SerialNumber => "Authenticating (O3)",
+        PonLinkState.Ranging => "Ranging (O4)",
+        PonLinkState.Operation => "Connected (O5)",
+        PonLinkState.Popup => "Signal Lost (O6)",
+        PonLinkState.EmergencyStop => "Disabled (O7)",
+        _ => "Unknown",
+    };
+
+    /// <summary>
+    /// Short stable string for InfluxDB storage.
+    /// </summary>
+    public static string ToInfluxValue(this PonLinkState state) => state switch
+    {
+        PonLinkState.Initial => "initial",
+        PonLinkState.Standby => "standby",
+        PonLinkState.SerialNumber => "serial_number",
+        PonLinkState.Ranging => "ranging",
+        PonLinkState.Operation => "operation",
+        PonLinkState.Popup => "popup",
+        PonLinkState.EmergencyStop => "emergency_stop",
+        _ => "unknown",
+    };
+}

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1001,6 +1001,7 @@
                             <select class="form-control" @bind="_editingCm.Provider">
                                 <option value="netgear">Netgear CM (HTTP)</option>
                                 <option value="arris-surfboard">ARRIS Surfboard (HTTP)</option>
+                                <option value="motorola-hnap">Motorola MB8611, MB8600 (HNAP)</option>
                             </select>
                         </div>
                     </div>
@@ -1032,8 +1033,8 @@
                         <div class="form-group" style="flex: 2;">
                             <label class="form-label">Status Page Path (optional)</label>
                             <input type="text" class="form-control" @bind="_editingCm.StatusPagePath"
-                                   placeholder="@(_editingCm.Provider == "arris-surfboard" ? "/cgi-bin/status" : "/DocsisStatus.htm")" />
-                            <small class="form-help">Leave empty to use the provider default.</small>
+                                   placeholder="@GetCmStatusPathPlaceholder(_editingCm.Provider)" />
+                            <small class="form-help">Leave empty to use the provider default.@(_editingCm.Provider == "motorola-hnap" ? " Uses HNAP protocol on /HNAP1/." : "")</small>
                         </div>
                         <div class="form-group" style="flex: 1;">
                             <label class="form-label">Polling Interval (sec)</label>
@@ -4180,7 +4181,15 @@
     {
         "netgear" => "Netgear CM (HTTP)",
         "arris-surfboard" => "ARRIS Surfboard (HTTP)",
+        "motorola-hnap" => "Motorola (HNAP)",
         _ => provider,
+    };
+
+    private static string GetCmStatusPathPlaceholder(string provider) => provider switch
+    {
+        "arris-surfboard" => "/cgi-bin/status",
+        "motorola-hnap" => "N/A (uses /HNAP1/)",
+        _ => "/DocsisStatus.htm",
     };
 
     // --- External ONT Monitoring ---

--- a/src/NetworkOptimizer.Web/Components/Shared/CellularStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/CellularStatsPanel.razor
@@ -11,46 +11,72 @@
             <span>Loading cellular stats...</span>
         </div>
     }
+    else if (modemStats == null && hasConfiguredModems)
+    {
+        <div class="sqm-header">
+            <div class="sqm-status">
+                <span class="status-indicator status-disconnected"></span>
+                <span class="status-label">@configuredModems[currentModemIndex].Name</span>
+            </div>
+        </div>
+
+        <div class="signal-quality-section">
+            <div class="signal-bars">
+                @for (int i = 1; i <= 5; i++)
+                {
+                    <div class="signal-bar"></div>
+                }
+            </div>
+            <div class="signal-quality-text">
+                <span class="quality-value">-</span>
+                <span class="quality-label">Signal Quality</span>
+            </div>
+            <div class="modem-nav">
+                @if (configuredModems.Count > 1)
+                {
+                    <button class="nav-btn" @onclick="PreviousModem" @onclick:stopPropagation disabled="@(currentModemIndex == 0)">&#x2039;</button>
+                    <span class="modem-counter">@(currentModemIndex + 1)/@configuredModems.Count</span>
+                    <button class="nav-btn" @onclick="NextModem" @onclick:stopPropagation disabled="@(currentModemIndex >= configuredModems.Count - 1)">&#x203A;</button>
+                }
+            </div>
+        </div>
+
+        <div class="cellular-metrics">
+            <div class="metric-box metric-5g">
+                <div class="metric-header">5G NR</div>
+                <div class="metric-content">
+                    <div class="metric-row"><span class="metric-label">RSRP:</span><span class="metric-value">-</span></div>
+                    <div class="metric-row"><span class="metric-label">RSRQ:</span><span class="metric-value">-</span></div>
+                    <div class="metric-row"><span class="metric-label">SNR:</span><span class="metric-value">-</span></div>
+                </div>
+            </div>
+            <div class="metric-box metric-lte">
+                <div class="metric-header">LTE</div>
+                <div class="metric-content">
+                    <div class="metric-row"><span class="metric-label">RSRP:</span><span class="metric-value">-</span></div>
+                    <div class="metric-row"><span class="metric-label">RSRQ:</span><span class="metric-value">-</span></div>
+                    <div class="metric-row"><span class="metric-label">SNR:</span><span class="metric-value">-</span></div>
+                </div>
+            </div>
+        </div>
+
+        <div class="sqm-actions">
+            <button class="btn btn-secondary" @onclick="RefreshStats" @onclick:stopPropagation disabled="@isRefreshing">
+                @if (isRefreshing) { <span class="spinner-sm"></span> } else { <span>Refresh</span> }
+            </button>
+            <a href="/settings#cellular-modem" class="btn btn-primary" @onclick:stopPropagation>Modem Settings</a>
+        </div>
+    }
     else if (modemStats == null)
     {
         <div class="sqm-unavailable">
             <div class="sqm-status">
                 <span class="status-indicator status-disconnected"></span>
-                <span class="status-label">@(hasConfiguredModems && configuredModems.Count > 0 ? configuredModems[currentModemIndex].Name : "No Data")</span>
+                <span class="status-label">No Data</span>
             </div>
-            @if (configuredModems.Count > 1)
-            {
-                <div class="modem-nav" style="margin-bottom: 0.75rem;">
-                    <button class="nav-btn" @onclick="PreviousModem" @onclick:stopPropagation disabled="@(currentModemIndex == 0)">‹</button>
-                    <span class="modem-counter">@(currentModemIndex + 1)/@configuredModems.Count</span>
-                    <button class="nav-btn" @onclick="NextModem" @onclick:stopPropagation disabled="@(currentModemIndex >= configuredModems.Count - 1)">›</button>
-                </div>
-            }
-            <p class="status-message">
-                @if (hasConfiguredModems)
-                {
-                    <span>Modem configured but no data available. Click refresh to poll.</span>
-                }
-                else
-                {
-                    <span>No cellular modem configured.</span>
-                }
-            </p>
+            <p class="status-message">No cellular modem configured.</p>
             <div class="sqm-actions">
-                @if (hasConfiguredModems)
-                {
-                    <button class="btn btn-secondary" @onclick="RefreshStats" @onclick:stopPropagation disabled="@isRefreshing">
-                        @if (isRefreshing)
-                        {
-                            <span class="spinner-sm"></span>
-                        }
-                        else
-                        {
-                            <span>Refresh</span>
-                        }
-                    </button>
-                }
-                <a href="/settings#cellular-modem" class="btn btn-primary" @onclick:stopPropagation>@(hasConfiguredModems ? "Modem Settings" : "Configure Modem")</a>
+                <a href="/settings#cellular-modem" class="btn btn-primary" @onclick:stopPropagation>Configure Modem</a>
             </div>
         </div>
     }

--- a/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
@@ -11,39 +11,68 @@
             <span>Loading cable modem stats...</span>
         </div>
     }
+    else if (_stats == null && _configs.Count > 0)
+    {
+        <div class="sqm-header">
+            <div class="sqm-status">
+                <span class="status-indicator status-disconnected"></span>
+                <span class="status-label">@_configs[_currentIndex].Name</span>
+            </div>
+        </div>
+
+        <div class="signal-quality-section signal-centered">
+            <div class="ont-rx-gauge">
+                <span class="rx-power-value">-</span>
+                <span class="rx-power-label">Downstream SNR avg</span>
+            </div>
+            <div class="modem-nav">
+                @if (_configs.Count > 1)
+                {
+                    <button class="nav-btn" @onclick="Previous" @onclick:stopPropagation disabled="@(_currentIndex == 0)">&#x2039;</button>
+                    <span class="modem-counter">@(_currentIndex + 1)/@_configs.Count</span>
+                    <button class="nav-btn" @onclick="Next" @onclick:stopPropagation disabled="@(_currentIndex >= _configs.Count - 1)">&#x203A;</button>
+                }
+            </div>
+        </div>
+
+        <div class="cellular-metrics" style="margin-top: 0.75rem;">
+            <div class="metric-box">
+                <div class="metric-header">Connection</div>
+                <div class="metric-content">
+                    <div class="metric-row"><span class="metric-label">Channels:</span><span class="metric-value">-</span></div>
+                    <div class="metric-row"><span class="metric-label">DS Power:</span><span class="metric-value">-</span></div>
+                    <div class="metric-row"><span class="metric-label">US Power:</span><span class="metric-value">-</span></div>
+                </div>
+            </div>
+            <div class="metric-box">
+                <div class="metric-header">Stats</div>
+                <div class="metric-content">
+                    <div class="metric-row"><span class="metric-label">DS SNR:</span><span class="metric-value">-</span></div>
+                    <div class="metric-row"><span class="metric-label">Correctables:</span><span class="metric-value">-</span></div>
+                    <div class="metric-row"><span class="metric-label">Uncorrectables:</span><span class="metric-value">-</span></div>
+                </div>
+            </div>
+        </div>
+
+        <div class="sqm-actions">
+            <button class="btn btn-secondary" @onclick="Refresh" @onclick:stopPropagation disabled="@_isRefreshing">
+                @if (_isRefreshing) { <span class="spinner-sm"></span> } else { <span>Refresh</span> }
+            </button>
+            <a href="/settings#cable-modem" class="btn btn-primary" @onclick:stopPropagation>CM Settings</a>
+        </div>
+    }
     else if (_stats == null)
     {
         <div class="sqm-unavailable">
             <div class="sqm-status">
                 <span class="status-indicator status-disconnected"></span>
-                <span class="status-label">@(_configs.Count > 0 ? _configs[_currentIndex].Name : "No Data")</span>
+                <span class="status-label">No Data</span>
             </div>
-            @if (_configs.Count > 1)
-            {
-                <div class="modem-nav" style="margin-bottom: 0.75rem;">
-                    <button class="nav-btn" @onclick="Previous" @onclick:stopPropagation disabled="@(_currentIndex == 0)">&#x2039;</button>
-                    <span class="modem-counter">@(_currentIndex + 1)/@_configs.Count</span>
-                    <button class="nav-btn" @onclick="Next" @onclick:stopPropagation disabled="@(_currentIndex >= _configs.Count - 1)">&#x203A;</button>
-                </div>
-            }
             <p class="status-message">
-                @if (_configs.Count > 0)
-                {
-                    <span>Cable modem configured but no data available. Click refresh to poll.</span>
-                }
-                else
-                {
-                    <span>Monitor your cable modem's downstream power, SNR, upstream power, and FEC error rates. Supports Netgear and ARRIS Surfboard modems.</span>
-                }
+                Monitor your cable modem's downstream power, SNR, upstream power, and FEC error rates. Supports Netgear, ARRIS Surfboard, and Motorola modems.
             </p>
             <div class="sqm-actions">
-                @if (_configs.Count > 0)
-                {
-                    <button class="btn btn-secondary" @onclick="Refresh" @onclick:stopPropagation disabled="@_isRefreshing">
-                        @if (_isRefreshing) { <span class="spinner-sm"></span> } else { <span>Refresh</span> }
-                    </button>
-                }
-                <a href="/settings#cable-modem" class="btn btn-primary" @onclick:stopPropagation>@(_configs.Count > 0 ? "CM Settings" : "Configure CM")</a>
+                <a href="/settings#cable-modem" class="btn btn-primary" @onclick:stopPropagation>Configure CM</a>
             </div>
         </div>
     }
@@ -59,7 +88,7 @@
             </div>
         </div>
 
-        <div class="signal-quality-section">
+        <div class="signal-quality-section signal-centered">
             <div class="ont-rx-gauge">
                 <span class="rx-power-value @GetSnrClass(_stats.DownstreamSnrAvgDb)">
                     @(_stats.DownstreamSnrAvgDb.HasValue ? $"{_stats.DownstreamSnrAvgDb.Value:F1} dB" : "-")
@@ -78,35 +107,35 @@
 
         <div class="cellular-metrics" style="margin-top: 0.75rem;">
             <div class="metric-box">
-                <div class="metric-header">Downstream</div>
+                <div class="metric-header">Connection</div>
                 <div class="metric-content">
                     <div class="metric-row">
-                        <span class="metric-label">Power:</span>
+                        <span class="metric-label">Channels:</span>
+                        <span class="metric-value">@_stats.LockedDsChannels DS / @_stats.LockedUsChannels US</span>
+                    </div>
+                    <div class="metric-row">
+                        <span class="metric-label">DS Power:</span>
                         <span class="metric-value">@(_stats.DownstreamPowerAvgDbmv.HasValue ? $"{_stats.DownstreamPowerAvgDbmv.Value:F1} dBmV" : "-")</span>
                     </div>
                     <div class="metric-row">
-                        <span class="metric-label">SNR:</span>
-                        <span class="metric-value @GetSnrClass(_stats.DownstreamSnrAvgDb)">@(_stats.DownstreamSnrAvgDb.HasValue ? $"{_stats.DownstreamSnrAvgDb.Value:F1} dB" : "-")</span>
-                    </div>
-                    <div class="metric-row">
-                        <span class="metric-label">Channels:</span>
-                        <span class="metric-value">@_stats.LockedDsChannels locked</span>
+                        <span class="metric-label">US Power:</span>
+                        <span class="metric-value">@(_stats.UpstreamPowerAvgDbmv.HasValue ? $"{_stats.UpstreamPowerAvgDbmv.Value:F1} dBmV" : "-")</span>
                     </div>
                 </div>
             </div>
             <div class="metric-box">
-                <div class="metric-header">Upstream</div>
+                <div class="metric-header">Stats</div>
                 <div class="metric-content">
                     <div class="metric-row">
-                        <span class="metric-label">Power:</span>
-                        <span class="metric-value">@(_stats.UpstreamPowerAvgDbmv.HasValue ? $"{_stats.UpstreamPowerAvgDbmv.Value:F1} dBmV" : "-")</span>
+                        <span class="metric-label">DS SNR:</span>
+                        <span class="metric-value @GetSnrClass(_stats.DownstreamSnrAvgDb)">@(_stats.DownstreamSnrAvgDb.HasValue ? $"{_stats.DownstreamSnrAvgDb.Value:F1} dB" : "-")</span>
                     </div>
                     <div class="metric-row">
-                        <span class="metric-label">Channels:</span>
-                        <span class="metric-value">@_stats.LockedUsChannels locked</span>
+                        <span class="metric-label">Correctables:</span>
+                        <span class="metric-value">@_stats.TotalCorrectables</span>
                     </div>
                     <div class="metric-row">
-                        <span class="metric-label">Uncorr:</span>
+                        <span class="metric-label">Uncorrectables:</span>
                         <span class="metric-value @(_stats.TotalUncorrectables > 0 ? "signal-poor" : "")">@_stats.TotalUncorrectables</span>
                     </div>
                 </div>

--- a/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
@@ -30,7 +30,7 @@ else if (IsShowingExternal && _externalOntStats != null)
         }
     </div>
 
-    <div class="signal-quality-section">
+    <div class="signal-quality-section signal-centered">
         <div class="ont-rx-gauge">
             <span class="rx-power-value @ExternalRxClass()">
                 @(_externalOntStats.RxPowerDbm.HasValue ? $"{_externalOntStats.RxPowerDbm.Value:0.0#} dBm" : "-")
@@ -49,7 +49,41 @@ else if (IsShowingExternal && _externalOntStats != null)
 
     <div class="cellular-metrics" style="margin-top: 0.75rem;">
         <div class="metric-box">
-            <div class="metric-header">Optical</div>
+            <div class="metric-header">Connection</div>
+            <div class="metric-content">
+                @{ var extModel = SfpModelLabel(_externalOntStats.VendorName, _externalOntStats.VendorPn); }
+                @if (!string.IsNullOrEmpty(extModel))
+                {
+                    <div class="metric-row">
+                        <span class="metric-label">Model:</span>
+                        <span class="metric-value ont-model-value">@extModel</span>
+                    </div>
+                }
+                @if (!string.IsNullOrEmpty(_externalOntStats.PonType))
+                {
+                    <div class="metric-row">
+                        <span class="metric-label">Link Type:</span>
+                        <span class="metric-value">@ExternalLinkTypeLabel()</span>
+                    </div>
+                }
+                @if (_externalOntStats.PonLinkStatus != PonLinkState.Unknown)
+                {
+                    <div class="metric-row">
+                        <span class="metric-label">PON Status:</span>
+                        <span class="metric-value">@_externalOntStats.PonLinkStatus.ToDisplayString()</span>
+                    </div>
+                }
+                @if (_externalOntStats.BwpSpeedMbps.HasValue)
+                {
+                    <div class="metric-row">
+                        <span class="metric-label">BWP:</span>
+                        <span class="metric-value">@(_externalOntStats.BwpSpeedMbps >= 1000 ? $"{_externalOntStats.BwpSpeedMbps / 1000.0:0.##} Gbps" : $"{_externalOntStats.BwpSpeedMbps} Mbps")</span>
+                    </div>
+                }
+            </div>
+        </div>
+        <div class="metric-box">
+            <div class="metric-header">Stats</div>
             <div class="metric-content">
                 <div class="metric-row">
                     <span class="metric-label">RX:</span>
@@ -60,31 +94,11 @@ else if (IsShowingExternal && _externalOntStats != null)
                     <span class="metric-value">@(_externalOntStats.TxPowerDbm.HasValue ? $"{_externalOntStats.TxPowerDbm.Value:0.0#} dBm" : "-")</span>
                 </div>
                 <div class="metric-row">
-                    <span class="metric-label">Temp:</span>
+                    <span class="metric-label">SFP Temp:</span>
                     <span class="metric-value">@(_externalOntStats.TemperatureC.HasValue ? $"{_externalOntStats.TemperatureC.Value:0.0#} °C" : "-")</span>
                 </div>
-            </div>
-        </div>
-        <div class="metric-box">
-            <div class="metric-header">Module</div>
-            <div class="metric-content">
-                @{ var extModel = SfpModelLabel(_externalOntStats.VendorName, _externalOntStats.VendorPn); }
-                @if (!string.IsNullOrEmpty(extModel))
-                {
-                    <div class="metric-row">
-                        <span class="metric-label">Model:</span>
-                        <span class="metric-value ont-model-value">@extModel</span>
-                    </div>
-                }
-                @if (!string.IsNullOrEmpty(_externalOntStats.WaveLength))
-                {
-                    <div class="metric-row">
-                        <span class="metric-label">Wavelength:</span>
-                        <span class="metric-value">@_externalOntStats.WaveLength</span>
-                    </div>
-                }
                 <div class="metric-row">
-                    <span class="metric-label">Voltage:</span>
+                    <span class="metric-label">SFP Voltage:</span>
                     <span class="metric-value">@(_externalOntStats.VoltageV.HasValue ? $"{_externalOntStats.VoltageV.Value:0.0#} V" : "-")</span>
                 </div>
             </div>
@@ -100,24 +114,49 @@ else if (IsShowingExternal)
 {
     var extIdx = _currentIndex - _monitoredOnts.Count;
     var extName = extIdx < _externalOnts.Count ? _externalOnts[extIdx].Name : "ONT";
-    <div class="sqm-unavailable">
+    <div class="sqm-header">
         <div class="sqm-status">
             <span class="status-indicator status-disconnected"></span>
             <span class="status-label">@extName</span>
         </div>
-        @if (TotalCount > 1)
-        {
-            <div class="modem-nav" style="margin-bottom: 0.75rem;">
+    </div>
+
+    <div class="signal-quality-section signal-centered">
+        <div class="ont-rx-gauge">
+            <span class="rx-power-value">-</span>
+            <span class="rx-power-label">RX optical power</span>
+        </div>
+        <div class="modem-nav">
+            @if (TotalCount > 1)
+            {
                 <button class="nav-btn" @onclick="Previous" @onclick:stopPropagation disabled="@(_currentIndex == 0)">&#x2039;</button>
                 <span class="modem-counter">@(_currentIndex + 1)/@TotalCount</span>
                 <button class="nav-btn" @onclick="Next" @onclick:stopPropagation disabled="@(_currentIndex >= TotalCount - 1)">&#x203A;</button>
-            </div>
-        }
-        <p class="status-message">ONT configured but no data yet. Click refresh to poll.</p>
-        <div class="sqm-actions">
-            <button class="btn btn-secondary" @onclick="RefreshExternal" @onclick:stopPropagation>Refresh</button>
-            <a href="/settings#ont-monitoring" class="btn btn-primary" @onclick:stopPropagation>ONT Settings</a>
+            }
         </div>
+    </div>
+
+    <div class="cellular-metrics" style="margin-top: 0.75rem;">
+        <div class="metric-box">
+            <div class="metric-header">Optical</div>
+            <div class="metric-content">
+                <div class="metric-row"><span class="metric-label">RX:</span><span class="metric-value">-</span></div>
+                <div class="metric-row"><span class="metric-label">TX:</span><span class="metric-value">-</span></div>
+                <div class="metric-row"><span class="metric-label">Temp:</span><span class="metric-value">-</span></div>
+            </div>
+        </div>
+        <div class="metric-box">
+            <div class="metric-header">Module</div>
+            <div class="metric-content">
+                <div class="metric-row"><span class="metric-label">Wavelength:</span><span class="metric-value">-</span></div>
+                <div class="metric-row"><span class="metric-label">Voltage:</span><span class="metric-value">-</span></div>
+            </div>
+        </div>
+    </div>
+
+    <div class="sqm-actions">
+        <button class="btn btn-secondary" @onclick="RefreshExternal" @onclick:stopPropagation>Refresh</button>
+        <a href="/settings#ont-monitoring" class="btn btn-primary" @onclick:stopPropagation>ONT Settings</a>
     </div>
 }
 else if (TotalCount == 0)
@@ -163,7 +202,7 @@ else
         }
     </div>
 
-    <div class="signal-quality-section">
+    <div class="signal-quality-section signal-centered">
         <div class="ont-rx-gauge">
             <span class="rx-power-value @rxClass">
                 @(stats?.RxPowerDbm.HasValue == true ? $"{stats.RxPowerDbm.Value:0.0#} dBm" : "-")
@@ -174,20 +213,57 @@ else
             @if (TotalCount > 1)
             {
                 <button class="nav-btn" @onclick="Previous" @onclick:stopPropagation disabled="@(_currentIndex == 0)">‹</button>
-                <span class="modem-counter">@(_currentIndex + 1)/@_monitoredOnts.Count</span>
-                <button class="nav-btn" @onclick="Next" @onclick:stopPropagation disabled="@(_currentIndex >= _monitoredOnts.Count - 1)">›</button>
+                <span class="modem-counter">@(_currentIndex + 1)/@TotalCount</span>
+                <button class="nav-btn" @onclick="Next" @onclick:stopPropagation disabled="@(_currentIndex >= TotalCount - 1)">›</button>
             }
         </div>
     </div>
 
     <div class="cellular-metrics" style="margin-top: 0.75rem;">
         <div class="metric-box">
-            <div class="metric-header">Optical</div>
+            <div class="metric-header">Connection</div>
             <div class="metric-content">
+                @{ var model = SfpModelLabel(current.SfpVendor, current.SfpPart); }
+                @if (!string.IsNullOrEmpty(model))
+                {
+                    <div class="metric-row">
+                        <span class="metric-label">Model:</span>
+                        <span class="metric-value ont-model-value">@model</span>
+                    </div>
+                }
                 <div class="metric-row">
                     <span class="metric-label">Link Type:</span>
                     <span class="metric-value @(current.IsActiveEthernet ? "ont-ae-value" : "")">@LinkTypeLabel(current)</span>
                 </div>
+                @if (current.LinkSpeedMbps.HasValue)
+                {
+                    <div class="metric-row">
+                        <span class="metric-label">SFP Link:</span>
+                        <span class="metric-value">
+                            @FormatLinkSpeed(current.LinkSpeedMbps.Value)
+                            @if (current.IsPon
+                                && current.LinkSpeedMbps <= 1000
+                                && PonVariantLabel(current.SfpPart, current.SfpVendor) == "GPON"
+                                && IsUpgradableGateway())
+                            {
+                                <a href="/perf-tweaks" class="tooltip-icon tooltip-icon-sm"
+                                   data-tooltip="Most GPON SFP ONTs support 2.5 Gbps on this gateway. Check Performance Tweaks."
+                                   style="margin-left: 0.35rem;">?</a>
+                            }
+                        </span>
+                    </div>
+                }
+                <div class="metric-row">
+                    <span class="metric-label">SFP Voltage:</span>
+                    <span class="metric-value">
+                        @(stats?.VoltageV.HasValue == true ? $"{stats.VoltageV.Value:0.0#} V" : "-")
+                    </span>
+                </div>
+            </div>
+        </div>
+        <div class="metric-box">
+            <div class="metric-header">Stats</div>
+            <div class="metric-content">
                 <div class="metric-row">
                     <span class="metric-label">RX:</span>
                     <span class="metric-value @rxClass">
@@ -206,47 +282,10 @@ else
                         @(stats?.BiasMa.HasValue == true ? $"{stats.BiasMa.Value:0.##} mA" : "-")
                     </span>
                 </div>
-            </div>
-        </div>
-        <div class="metric-box">
-            <div class="metric-header">Module</div>
-            <div class="metric-content">
-                @{ var model = SfpModelLabel(current.SfpVendor, current.SfpPart); }
-                @if (!string.IsNullOrEmpty(model))
-                {
-                    <div class="metric-row">
-                        <span class="metric-label">Model:</span>
-                        <span class="metric-value ont-model-value">@model</span>
-                    </div>
-                }
-                @if (current.LinkSpeedMbps.HasValue)
-                {
-                    <div class="metric-row">
-                        <span class="metric-label">Link:</span>
-                        <span class="metric-value">
-                            @FormatLinkSpeed(current.LinkSpeedMbps.Value)
-                            @if (current.IsPon
-                                && current.LinkSpeedMbps <= 1000
-                                && PonVariantLabel(current.SfpPart, current.SfpVendor) == "GPON"
-                                && IsUpgradableGateway())
-                            {
-                                <a href="/perf-tweaks" class="tooltip-icon tooltip-icon-sm"
-                                   data-tooltip="Most GPON SFP ONTs support 2.5 Gbps on this gateway. Check Performance Tweaks."
-                                   style="margin-left: 0.35rem;">?</a>
-                            }
-                        </span>
-                    </div>
-                }
                 <div class="metric-row">
-                    <span class="metric-label">Temp:</span>
+                    <span class="metric-label">SFP Temp:</span>
                     <span class="metric-value">
                         @(stats?.TemperatureC.HasValue == true ? $"{stats.TemperatureC.Value:0.0#} °C" : "-")
-                    </span>
-                </div>
-                <div class="metric-row">
-                    <span class="metric-label">Voltage:</span>
-                    <span class="metric-value">
-                        @(stats?.VoltageV.HasValue == true ? $"{stats.VoltageV.Value:0.0#} V" : "-")
                     </span>
                 </div>
             </div>
@@ -405,6 +444,15 @@ else
         SfpCategory.ActiveEthernet => "Active Ethernet",
         _ => NetworkOptimizer.Core.Helpers.NetworkFormatHelpers.PonVariantLabel(sfp.SfpPart, sfp.SfpVendor)
     };
+
+    private string ExternalLinkTypeLabel()
+    {
+        var ponType = _externalOntStats?.PonType;
+        var wl = _externalOntStats?.WaveLength;
+        if (string.IsNullOrEmpty(ponType)) return "Unknown";
+        if (!string.IsNullOrEmpty(wl)) return $"{ponType} ({wl})";
+        return ponType;
+    }
 
     private static string OpticalHealthClass(double? rxDbm, SfpCategory category)
     {

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -193,6 +193,7 @@ builder.Services.AddSingleton<CellularModemService>();
 // Register Cable Modem providers and service
 builder.Services.AddSingleton<ICableModemProvider, NetgearCmProvider>();
 builder.Services.AddSingleton<ICableModemProvider, ArrisSurfboardProvider>();
+builder.Services.AddSingleton<ICableModemProvider, MotorolaHnapProvider>();
 builder.Services.AddSingleton<CableModemMonitorService>();
 
 // Register External ONT providers and service

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/MotorolaHnapProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/MotorolaHnapProvider.cs
@@ -1,0 +1,577 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Monitoring.Providers;
+
+namespace NetworkOptimizer.Web.Services.CableModemProviders;
+
+/// <summary>
+/// Cable modem provider for Motorola DOCSIS modems that use the HNAP protocol
+/// (MB8611, MB8600, MB7621, etc.). Communicates via JSON-over-HTTPS to the /HNAP1/
+/// endpoint with HMAC-MD5 authentication.
+/// </summary>
+public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
+{
+    /// <inheritdoc/>
+    public string ProviderKey => "motorola-hnap";
+
+    /// <inheritdoc/>
+    public string DisplayName => "Motorola (HNAP)";
+
+    private const string HnapPath = "/HNAP1/";
+    private const string SoapActionPrefix = "http://purenetworks.com/HNAP1/";
+    private const string RowDelimiter = "|+|";
+    private const char ColumnDelimiter = '^';
+    private const int TimeoutSeconds = 15;
+
+    private readonly ILogger<MotorolaHnapProvider> _logger;
+
+    /// <summary>
+    /// Cached HNAP sessions keyed by CmConfiguration.Id.
+    /// Each session holds the derived private key and cookies for reuse across polls.
+    /// </summary>
+    private readonly ConcurrentDictionary<int, HnapSession> _sessions = new();
+
+    public MotorolaHnapProvider(ILogger<MotorolaHnapProvider> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<CableModemStats?> PollAsync(
+        CmPollContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+        {
+            _logger.LogWarning("Motorola HNAP poll requested but Host is empty (config {Id})", context.Id);
+            return null;
+        }
+
+        try
+        {
+            using var client = CreateHttpClient();
+            var baseUrl = BuildBaseUrl(context);
+
+            var session = await EnsureSessionAsync(client, baseUrl, context, cancellationToken);
+            if (session == null)
+            {
+                _logger.LogWarning("Motorola HNAP {Name} at {Host}: login failed", context.Name, context.Host);
+                return null;
+            }
+
+            using var response = await CallMultipleHnapsAsync(
+                client, baseUrl, session,
+                ["GetMotoStatusDownstreamChannelInfo",
+                 "GetMotoStatusUpstreamChannelInfo",
+                 "GetMotoStatusConnectionInfo",
+                 "GetMotoStatusSoftware"],
+                cancellationToken);
+
+            if (response == null)
+            {
+                _sessions.TryRemove(context.Id, out _);
+                _logger.LogWarning("Motorola HNAP {Name} at {Host}: GetMultipleHNAPs failed", context.Name, context.Host);
+                return null;
+            }
+
+            var stats = ParseResponse(response, context);
+
+            _logger.LogDebug(
+                "Motorola HNAP {Name} polled: {DsCount} DS channels, {UsCount} US channels",
+                context.Name, stats.DownstreamChannels.Count, stats.UpstreamChannels.Count);
+
+            return stats;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _sessions.TryRemove(context.Id, out _);
+            _logger.LogWarning(ex, "Error polling Motorola HNAP {Name} at {Host}", context.Name, context.Host);
+            return null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<(bool Success, string Message)> TestConnectionAsync(
+        CmPollContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+            return (false, "Host is empty");
+
+        try
+        {
+            using var client = CreateHttpClient();
+            var baseUrl = BuildBaseUrl(context);
+
+            var session = await LoginAsync(client, baseUrl, context, cancellationToken);
+            if (session == null)
+                return (false, "Login failed. Check credentials, or wait 5 minutes if locked out from failed attempts.");
+
+            _sessions[context.Id] = session;
+
+            using var response = await CallMultipleHnapsAsync(
+                client, baseUrl, session,
+                ["GetMotoStatusDownstreamChannelInfo",
+                 "GetMotoStatusUpstreamChannelInfo"],
+                cancellationToken);
+
+            if (response == null)
+                return (false, "Connected but could not retrieve channel data.");
+
+            var dsCount = CountChannels(response, "GetMotoStatusDownstreamChannelInfoResponse", "MotoConnDownstreamChannel");
+            var usCount = CountChannels(response, "GetMotoStatusUpstreamChannelInfoResponse", "MotoConnUpstreamChannel");
+
+            await LogoutAsync(client, baseUrl, cancellationToken);
+
+            return (true, $"Connected via HNAP - {dsCount} downstream, {usCount} upstream channels detected");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Connection failed: {ex.Message}");
+        }
+    }
+
+    private async Task<HnapSession?> EnsureSessionAsync(
+        HttpClient client, string baseUrl, CmPollContext context, CancellationToken cancellationToken)
+    {
+        if (_sessions.TryGetValue(context.Id, out var cached))
+        {
+            using var testResponse = await CallMultipleHnapsAsync(
+                client, baseUrl, cached,
+                ["GetMotoStatusConnectionInfo"],
+                cancellationToken);
+
+            if (testResponse != null)
+                return cached;
+
+            _sessions.TryRemove(context.Id, out _);
+            _logger.LogDebug("Motorola HNAP session expired for {Name}, re-authenticating", context.Name);
+        }
+
+        var session = await LoginAsync(client, baseUrl, context, cancellationToken);
+        if (session != null)
+            _sessions[context.Id] = session;
+
+        return session;
+    }
+
+    /// <summary>
+    /// Two-phase HNAP login: request challenge, derive keys, authenticate.
+    /// </summary>
+    private async Task<HnapSession?> LoginAsync(
+        HttpClient client, string baseUrl, CmPollContext context, CancellationToken cancellationToken)
+    {
+        var endpoint = baseUrl + HnapPath;
+        var username = context.Username ?? "admin";
+        var password = context.Password ?? "";
+
+        // Phase 1: request challenge
+        var requestPayload = new
+        {
+            Login = new
+            {
+                Action = "request",
+                Username = username,
+                LoginPassword = "",
+                Captcha = "",
+                PrivateLogin = "LoginPassword"
+            }
+        };
+
+        using var phase1Response = await PostHnapAsync(
+            client, endpoint, "Login", "withoutloginkey", requestPayload, cancellationToken);
+
+        if (phase1Response == null)
+            return null;
+
+        if (!phase1Response.RootElement.TryGetProperty("LoginResponse", out var loginResp))
+            return null;
+
+        var result = loginResp.GetProperty("LoginResult").GetString();
+        if (result == "FAILED")
+        {
+            _logger.LogWarning(
+                "Motorola HNAP {Name}: login locked out. Wait 5 minutes before retrying", context.Name);
+            return null;
+        }
+
+        if (!loginResp.TryGetProperty("PublicKey", out var pubKeyEl) ||
+            !loginResp.TryGetProperty("Challenge", out var challengeEl))
+            return null;
+
+        var publicKey = pubKeyEl.GetString() ?? "";
+        var challenge = challengeEl.GetString() ?? "";
+
+        // Derive private key: HMAC-MD5(publicKey + password, challenge)
+        var privateKey = HmacMd5Hex(publicKey + password, challenge);
+
+        // Extract uid cookie if provided
+        string? uid = null;
+        if (loginResp.TryGetProperty("Cookie", out var cookieEl))
+            uid = cookieEl.GetString();
+
+        // Phase 2: authenticate with derived password
+        var loginPassword = HmacMd5Hex(privateKey, challenge);
+
+        var authPayload = new
+        {
+            Login = new
+            {
+                Action = "request",
+                Username = username,
+                LoginPassword = loginPassword,
+                Captcha = "",
+                PrivateLogin = "LoginPassword"
+            }
+        };
+
+        var session = new HnapSession(privateKey, uid);
+        ApplySessionCookies(client, context.Host, session);
+
+        using var phase2Response = await PostHnapAsync(
+            client, endpoint, "Login", privateKey, authPayload, cancellationToken);
+
+        if (phase2Response == null)
+            return null;
+
+        if (!phase2Response.RootElement.TryGetProperty("LoginResponse", out var authResp))
+            return null;
+
+        var authResult = authResp.GetProperty("LoginResult").GetString();
+        if (authResult != "OK")
+        {
+            _logger.LogWarning("Motorola HNAP {Name}: login authentication failed (result: {Result})",
+                context.Name, authResult);
+            return null;
+        }
+
+        _logger.LogDebug("Motorola HNAP {Name}: logged in successfully", context.Name);
+        return session;
+    }
+
+    /// <summary>
+    /// Call GetMultipleHNAPs with the specified actions.
+    /// All Motorola status actions must be called this way.
+    /// </summary>
+    private async Task<JsonDocument?> CallMultipleHnapsAsync(
+        HttpClient client, string baseUrl, HnapSession session,
+        string[] actions, CancellationToken cancellationToken)
+    {
+        var endpoint = baseUrl + HnapPath;
+
+        var innerDict = new Dictionary<string, string>();
+        foreach (var action in actions)
+            innerDict[action] = "";
+
+        var payload = new Dictionary<string, object>
+        {
+            ["GetMultipleHNAPs"] = innerDict
+        };
+
+        var response = await PostHnapAsync(
+            client, endpoint, "GetMultipleHNAPs", session.PrivateKey, payload, cancellationToken);
+
+        if (response == null)
+            return null;
+
+        if (response.RootElement.TryGetProperty("GetMultipleHNAPsResponse", out var multiResp) &&
+            multiResp.TryGetProperty("GetMultipleHNAPsResult", out var multiResult) &&
+            multiResult.GetString() == "OK")
+        {
+            return response;
+        }
+
+        return null;
+    }
+
+    private async Task<JsonDocument?> PostHnapAsync(
+        HttpClient client, string endpoint, string action, string privateKey,
+        object payload, CancellationToken cancellationToken)
+    {
+        var hnapAuth = MakeHnapAuth(action, privateKey);
+        var soapAction = $"\"{SoapActionPrefix}{action}\"";
+
+        var json = JsonSerializer.Serialize(payload);
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, endpoint);
+        request.Content = content;
+        request.Headers.TryAddWithoutValidation("HNAP_AUTH", hnapAuth);
+        request.Headers.TryAddWithoutValidation("SOAPACTION", soapAction);
+        request.Headers.TryAddWithoutValidation("X-Requested-With", "XMLHttpRequest");
+
+        try
+        {
+            var response = await client.SendAsync(request, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug("HNAP POST {Action} returned {Status}", action, response.StatusCode);
+                return null;
+            }
+
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            return JsonDocument.Parse(body);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug(ex, "HNAP POST {Action} failed", action);
+            return null;
+        }
+    }
+
+    private async Task LogoutAsync(HttpClient client, string baseUrl, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await client.GetAsync($"{baseUrl}/Logout.html", cancellationToken);
+        }
+        catch
+        {
+            // Logout is best-effort
+        }
+    }
+
+    private CableModemStats ParseResponse(JsonDocument response, CmPollContext context)
+    {
+        var stats = new CableModemStats
+        {
+            Timestamp = DateTime.UtcNow,
+            DeviceHost = context.Host,
+            DeviceName = context.Name,
+            DeviceModel = "Motorola",
+        };
+
+        var root = response.RootElement;
+        if (!root.TryGetProperty("GetMultipleHNAPsResponse", out var multiResp))
+            return stats;
+
+        // Parse downstream channels from pipe-delimited table string
+        if (multiResp.TryGetProperty("GetMotoStatusDownstreamChannelInfoResponse", out var dsResp) &&
+            dsResp.TryGetProperty("MotoConnDownstreamChannel", out var dsData))
+        {
+            var tableStr = dsData.GetString();
+            if (!string.IsNullOrWhiteSpace(tableStr))
+                ParseDownstreamTable(tableStr, stats);
+        }
+
+        // Parse upstream channels
+        if (multiResp.TryGetProperty("GetMotoStatusUpstreamChannelInfoResponse", out var usResp) &&
+            usResp.TryGetProperty("MotoConnUpstreamChannel", out var usData))
+        {
+            var tableStr = usData.GetString();
+            if (!string.IsNullOrWhiteSpace(tableStr))
+                ParseUpstreamTable(tableStr, stats);
+        }
+
+        // Extract software version for model identification
+        if (multiResp.TryGetProperty("GetMotoStatusSoftwareResponse", out var swResp) &&
+            swResp.TryGetProperty("StatusSoftwareCustomerVer", out var verEl))
+        {
+            var version = verEl.GetString();
+            if (!string.IsNullOrWhiteSpace(version))
+            {
+                // Version strings like "8611-19.2.18" contain the model number
+                if (version.StartsWith("8611", StringComparison.Ordinal))
+                    stats.DeviceModel = "Motorola MB8611";
+                else if (version.StartsWith("8600", StringComparison.Ordinal))
+                    stats.DeviceModel = "Motorola MB8600";
+                else
+                    stats.DeviceModel = $"Motorola ({version.Split('-')[0]})";
+            }
+        }
+
+        return stats;
+    }
+
+    /// <summary>
+    /// Parse downstream table string. Columns: Channel, Lock Status, Modulation,
+    /// Channel ID, Freq. (MHz), Pwr (dBmV), SNR (dB), Corrected, Uncorrected.
+    /// Rows delimited by |+|, columns by ^.
+    /// </summary>
+    private void ParseDownstreamTable(string tableStr, CableModemStats stats)
+    {
+        foreach (var row in tableStr.Split(RowDelimiter))
+        {
+            var cols = row.Split(ColumnDelimiter);
+            if (cols.Length < 9) continue;
+
+            var channel = new DsChannel
+            {
+                ChannelId = ParseInt(cols[3]),
+                LockStatus = cols[1].Trim(),
+                Modulation = cols[2].Trim(),
+                Frequency = ParseFrequency(cols[4]),
+                Power = ParseDouble(cols[5]),
+                Snr = ParseDouble(cols[6]),
+                Correctables = ParseLong(cols[7]),
+                Uncorrectables = ParseLong(cols[8]),
+            };
+
+            if (channel.ChannelId > 0 || !string.IsNullOrWhiteSpace(channel.LockStatus))
+                stats.DownstreamChannels.Add(channel);
+        }
+    }
+
+    /// <summary>
+    /// Parse upstream table string. Columns: Channel, Lock Status, Channel Type,
+    /// Channel ID, Symb. Rate (Ksym/sec), Freq. (MHz), Pwr (dBmV).
+    /// </summary>
+    private void ParseUpstreamTable(string tableStr, CableModemStats stats)
+    {
+        foreach (var row in tableStr.Split(RowDelimiter))
+        {
+            var cols = row.Split(ColumnDelimiter);
+            if (cols.Length < 7) continue;
+
+            var channel = new UsChannel
+            {
+                ChannelId = ParseInt(cols[3]),
+                LockStatus = cols[1].Trim(),
+                ChannelType = cols[2].Trim(),
+                SymbolRate = ParseLong(cols[4]),
+                Frequency = ParseFrequency(cols[5]),
+                Power = ParseDouble(cols[6]) ?? 0,
+            };
+
+            if (channel.ChannelId > 0 || !string.IsNullOrWhiteSpace(channel.LockStatus))
+                stats.UpstreamChannels.Add(channel);
+        }
+    }
+
+    private int CountChannels(JsonDocument response, string responseKey, string channelKey)
+    {
+        if (response.RootElement.TryGetProperty("GetMultipleHNAPsResponse", out var multiResp) &&
+            multiResp.TryGetProperty(responseKey, out var resp) &&
+            resp.TryGetProperty(channelKey, out var data))
+        {
+            var str = data.GetString();
+            if (!string.IsNullOrWhiteSpace(str))
+                return str.Split(RowDelimiter).Length;
+        }
+        return 0;
+    }
+
+    private static string BuildBaseUrl(CmPollContext context)
+    {
+        var port = context.Port > 0 ? context.Port : 443;
+        var portSuffix = port == 443 ? "" : $":{port}";
+        return $"https://{context.Host}{portSuffix}";
+    }
+
+    /// <summary>
+    /// Compute HNAP_AUTH header: HMAC-MD5(privateKey, timestamp + soapActionUri) in hex, space, timestamp.
+    /// </summary>
+    private static string MakeHnapAuth(string action, string privateKey)
+    {
+        var timestamp = (DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() % 2000000000000).ToString();
+        var soapActionUri = $"\"{SoapActionPrefix}{action}\"";
+        var message = timestamp + soapActionUri;
+
+        var hmac = HmacMd5Hex(privateKey, message);
+        return $"{hmac} {timestamp}";
+    }
+
+    /// <summary>
+    /// HMAC-MD5(key, message) → uppercase hex string.
+    /// </summary>
+    private static string HmacMd5Hex(string key, string message)
+    {
+        using var hmac = new HMACMD5(Encoding.UTF8.GetBytes(key));
+        var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(message));
+        return Convert.ToHexString(hash);
+    }
+
+    private static void ApplySessionCookies(HttpClient client, string host, HnapSession session)
+    {
+        // The modem expects PrivateKey and uid cookies
+        var cookieValues = new List<string>();
+        cookieValues.Add($"PrivateKey={session.PrivateKey}");
+        if (session.Uid != null)
+            cookieValues.Add($"uid={session.Uid}");
+
+        client.DefaultRequestHeaders.Remove("Cookie");
+        client.DefaultRequestHeaders.TryAddWithoutValidation("Cookie", string.Join("; ", cookieValues));
+    }
+
+    private HttpClient CreateHttpClient()
+    {
+        var handler = new HttpClientHandler
+        {
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+            ServerCertificateCustomValidationCallback = (_, _, _, _) => true,
+            UseCookies = false,
+        };
+
+        return new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromSeconds(TimeoutSeconds),
+            DefaultRequestHeaders =
+            {
+                { "Accept", "application/json" },
+                { "Connection", "keep-alive" },
+                { "Cache-Control", "no-cache" },
+            },
+        };
+    }
+
+    private static int ParseInt(string text)
+    {
+        var cleaned = StripUnits(text);
+        return int.TryParse(cleaned, out var val) ? val : 0;
+    }
+
+    private static long ParseLong(string text)
+    {
+        var cleaned = StripUnits(text);
+        return long.TryParse(cleaned, out var val) ? val : 0;
+    }
+
+    private static double? ParseDouble(string text)
+    {
+        var cleaned = StripUnits(text);
+        return double.TryParse(cleaned, NumberStyles.Float, CultureInfo.InvariantCulture, out var val) ? val : null;
+    }
+
+    private static long ParseFrequency(string text)
+    {
+        var cleaned = StripUnits(text);
+        return long.TryParse(cleaned, out var val) ? val : 0;
+    }
+
+    private static string StripUnits(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return "";
+
+        var cleaned = text.Trim();
+        string[] units = ["Ksym/sec", "Msym/sec", "dBmV", "dB", "MHz", "Hz"];
+        foreach (var unit in units)
+        {
+            var idx = cleaned.IndexOf(unit, StringComparison.OrdinalIgnoreCase);
+            if (idx >= 0)
+            {
+                cleaned = cleaned[..idx];
+                break;
+            }
+        }
+
+        return cleaned.Trim();
+    }
+
+    public void Dispose()
+    {
+        _sessions.Clear();
+    }
+
+    private sealed record HnapSession(string PrivateKey, string? Uid);
+}

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -1381,6 +1381,12 @@ public class MonitoringCollectionAgent : BackgroundService
         var devices = await GetMonitorableDevicesAsync(ct);
         if (devices.Count == 0) return;
 
+        // Gateways need the LAN-side address here for the same reason SNMP does:
+        // UniFi's "ip" field is the WAN public IP, which often doesn't answer ping
+        // from inside the LAN (PPPoE, CGNAT, upstream-assigned). The Address refresh
+        // below also migrates existing targets seeded with the WAN IP.
+        var gatewayLanIp = await ResolveGatewayLanIpAsync(ct);
+
         await using var db = await _dbFactory.CreateDbContextAsync(ct);
         var existingByTargetId = await db.MonitoringTargets
             .Where(t => t.TargetType == MonitoringTargetType.Fabric)
@@ -1417,13 +1423,14 @@ public class MonitoringCollectionAgent : BackgroundService
         foreach (var d in devices)
         {
             if (string.IsNullOrEmpty(d.Ip) || string.IsNullOrEmpty(d.Mac)) continue;
+            var address = ResolveSnmpAddress(d, gatewayLanIp);
             var targetId = $"fabric-{NormalizeMac(d.Mac)}";
             if (existingByTargetId.TryGetValue(targetId, out var existing))
             {
                 // Refresh address in case the device's management IP changed.
-                if (existing.Address != d.Ip)
+                if (existing.Address != address)
                 {
-                    existing.Address = d.Ip;
+                    existing.Address = address;
                     changed = true;
                 }
                 continue;
@@ -1434,7 +1441,7 @@ public class MonitoringCollectionAgent : BackgroundService
             {
                 TargetId = targetId,
                 Name = string.IsNullOrEmpty(d.Name) ? d.Mac : d.Name,
-                Address = d.Ip,
+                Address = address,
                 ProbeMode = ProbeMode.Icmp,
                 TargetType = MonitoringTargetType.Fabric,
                 DeviceMac = NormalizeMac(d.Mac),
@@ -1698,9 +1705,9 @@ public class MonitoringCollectionAgent : BackgroundService
     }
 
     /// <summary>
-    /// SNMP poll address for a device. For gateways, swap UniFi's WAN public IP for
-    /// the LAN-side gateway IP so the poll actually reaches the device. All other
-    /// device types use their raw IP from UniFi.
+    /// Poll address for a device (SNMP and fabric latency targets). For gateways,
+    /// swap UniFi's WAN public IP for the LAN-side gateway IP so the poll actually
+    /// reaches the device. All other device types use their raw IP from UniFi.
     /// </summary>
     private static string ResolveSnmpAddress(UniFiDeviceResponse device, string? gatewayLanIp)
     {

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -1866,6 +1866,7 @@ public class MonitoringCollectionAgent : BackgroundService
                 txBiasMa: port.SfpCurrent,
                 temperatureC: port.SfpTemperature,
                 voltageV: port.SfpVoltage,
+                sfpLinkSpeedMbps: port.Speed > 0 ? port.Speed : null,
                 timestamp: timestamp);
 
             // Mirror the values into the live-stats cache so the dashboard SFP card can

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -430,6 +430,7 @@ public class MonitoringInfluxClient : IAsyncDisposable
         double? txBiasMa,
         double? temperatureC,
         double? voltageV,
+        int? sfpLinkSpeedMbps,
         DateTime timestamp)
     {
         if (!IsConfigured) return Task.CompletedTask;
@@ -443,6 +444,7 @@ public class MonitoringInfluxClient : IAsyncDisposable
         if (txBiasMa.HasValue) point = point.Field("tx_bias_ma", txBiasMa.Value);
         if (temperatureC.HasValue) point = point.Field("temperature_c", temperatureC.Value);
         if (voltageV.HasValue) point = point.Field("voltage_v", voltageV.Value);
+        if (sfpLinkSpeedMbps.HasValue) point = point.Field("sfp_link_speed_mbps", sfpLinkSpeedMbps.Value);
 
         Enqueue(point, longterm: true);
         return Task.CompletedTask;
@@ -550,6 +552,11 @@ public class MonitoringInfluxClient : IAsyncDisposable
         double? biasMa,
         long? fecErrors,
         long? bipErrors,
+        string? ponType,
+        string? wavelength,
+        string? ponLinkStatus,
+        int? bwpSpeedMbps,
+        int? sfpLinkSpeedMbps,
         DateTime timestamp)
     {
         if (!IsConfigured) return Task.CompletedTask;
@@ -558,6 +565,9 @@ public class MonitoringInfluxClient : IAsyncDisposable
             .Tag("ont_name", ontName)
             .Timestamp(timestamp.ToUniversalTime(), WritePrecision.Ns);
 
+        if (!string.IsNullOrEmpty(ponType)) point = point.Tag("pon_type", ponType);
+        if (!string.IsNullOrEmpty(wavelength)) point = point.Tag("wavelength", wavelength);
+
         if (rxPowerDbm.HasValue) point = point.Field("rx_power_dbm", rxPowerDbm.Value);
         if (txPowerDbm.HasValue) point = point.Field("tx_power_dbm", txPowerDbm.Value);
         if (temperatureC.HasValue) point = point.Field("temperature_c", temperatureC.Value);
@@ -565,6 +575,9 @@ public class MonitoringInfluxClient : IAsyncDisposable
         if (biasMa.HasValue) point = point.Field("bias_ma", biasMa.Value);
         if (fecErrors.HasValue) point = point.Field("fec_errors", fecErrors.Value);
         if (bipErrors.HasValue) point = point.Field("bip_errors", bipErrors.Value);
+        if (!string.IsNullOrEmpty(ponLinkStatus)) point = point.Field("pon_link_status", ponLinkStatus);
+        if (bwpSpeedMbps.HasValue) point = point.Field("bwp_speed_mbps", bwpSpeedMbps.Value);
+        if (sfpLinkSpeedMbps.HasValue) point = point.Field("sfp_link_speed_mbps", sfpLinkSpeedMbps.Value);
 
         Enqueue(point, longterm: true);
         return Task.CompletedTask;

--- a/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
@@ -243,6 +243,11 @@ public class OntMonitorService : IDisposable
                 biasMa: stats.BiasMa,
                 fecErrors: stats.FecErrors,
                 bipErrors: stats.BipErrors,
+                ponType: stats.PonType,
+                wavelength: stats.WaveLength,
+                ponLinkStatus: stats.PonLinkStatus != PonLinkState.Unknown ? stats.PonLinkStatus.ToInfluxValue() : null,
+                bwpSpeedMbps: stats.BwpSpeedMbps,
+                sfpLinkSpeedMbps: stats.SfpLinkSpeedMbps,
                 timestamp: stats.Timestamp);
         }
         catch (Exception ex)

--- a/src/NetworkOptimizer.Web/Services/OntProviders/AttGatewayOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/AttGatewayOntProvider.cs
@@ -1,5 +1,4 @@
 using System.Text.RegularExpressions;
-using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
 
@@ -20,6 +19,10 @@ public class AttGatewayOntProvider : IOntProvider
 
     private static readonly Regex KeyValueRegex = new(
         @"<th\s+scope=""row""[^>]*>([^<]+)</th>\s*<td\s+class=""col2""[^>]*>([^<]*)</td>",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private static readonly Regex KeyValueLooseRegex = new(
+        @"<th\s+scope=""row""[^>]*>([^<]+)</th>\s*\n?\s*<td[^>]*>([^<]*)</td>",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     public AttGatewayOntProvider(ILogger<AttGatewayOntProvider> logger)
@@ -65,9 +68,11 @@ public class AttGatewayOntProvider : IOntProvider
                 ParseBroadbandStatistics(broadbandHtml, stats);
             }
 
+            DerivePonTypeFromWavelength(stats);
+
             _logger.LogDebug(
-                "AT&T gateway {Host} polled: Rx={RxPower} dBm, Tx={TxPower} dBm, Temp={Temp} C",
-                context.Host, stats.RxPowerDbm, stats.TxPowerDbm, stats.TemperatureC);
+                "AT&T gateway {Host} polled: Rx={RxPower} dBm, Tx={TxPower} dBm, {PonType}, BWP={Bwp} Mbps",
+                context.Host, stats.RxPowerDbm, stats.TxPowerDbm, stats.PonType, stats.BwpSpeedMbps);
 
             return stats;
         }
@@ -173,7 +178,7 @@ public class AttGatewayOntProvider : IOntProvider
 
     private void ParseBroadbandStatistics(string html, OntStats stats)
     {
-        var kvMatches = KeyValueRegex.Matches(html);
+        var kvMatches = KeyValueLooseRegex.Matches(html);
         foreach (Match match in kvMatches)
         {
             var key = match.Groups[1].Value.Trim();
@@ -182,18 +187,39 @@ public class AttGatewayOntProvider : IOntProvider
             if (string.IsNullOrEmpty(value))
                 continue;
 
-            if (key.Contains("Broadband Connection Source", StringComparison.OrdinalIgnoreCase))
+            if (key.Equals("Broadband Connection", StringComparison.OrdinalIgnoreCase))
             {
-                // If fiber, set PonType generically (page doesn't distinguish GPON vs XGS-PON)
-                if (value.Contains("FIBER", StringComparison.OrdinalIgnoreCase))
-                    stats.PonType ??= "GPON";
-            }
-            else if (key.Equals("Broadband Connection", StringComparison.OrdinalIgnoreCase))
-            {
-                // Fallback operational status from broadband page
                 stats.OperationalStatus ??= value;
             }
+            else if (key.Contains("PON Link Status", StringComparison.OrdinalIgnoreCase))
+            {
+                stats.PonLinkStatus = PonLinkStateExtensions.ParsePonLinkState(value);
+            }
+            else if (key.Contains("Current Speed", StringComparison.OrdinalIgnoreCase)
+                     && int.TryParse(value, out var speed))
+            {
+                stats.BwpSpeedMbps = speed;
+            }
         }
+    }
+
+    /// <summary>
+    /// Derive PON type from the SFP wavelength.
+    /// Called after both pages are parsed so wavelength is available.
+    /// </summary>
+    private static void DerivePonTypeFromWavelength(OntStats stats)
+    {
+        if (string.IsNullOrWhiteSpace(stats.WaveLength))
+            return;
+
+        var cleaned = stats.WaveLength.Replace("nm", "", StringComparison.OrdinalIgnoreCase).Trim();
+        if (!int.TryParse(cleaned, out var nm))
+            return;
+
+        if (nm is 1490 or 1550)
+            stats.PonType = "GPON";
+        else if (nm == 1577)
+            stats.PonType = "XGS-PON";
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1681,6 +1681,28 @@ a.stat-card-link:active {
     margin-left: auto;
 }
 
+.signal-centered {
+    position: relative;
+    justify-content: center;
+}
+.signal-centered .ont-rx-gauge {
+    flex: initial;
+}
+.signal-centered .modem-nav {
+    position: absolute;
+    right: 0.75rem;
+    margin-left: 0;
+}
+@media (max-width: 768px) {
+    .signal-centered {
+        flex-wrap: wrap;
+    }
+    .signal-centered .modem-nav {
+        position: static;
+        margin-left: 0;
+    }
+}
+
 .nav-btn {
     background: var(--bg-card);
     border: 1px solid var(--border-color);


### PR DESCRIPTION
## Summary

Release PR for v1.19.6.

## Changes

- **Monitoring: gateway latency probed on its LAN-side IP** (#771) - The auto-created latency target for the gateway used the UniFi-reported device IP, which is the primary WAN address and often does not answer ping from inside the LAN (PPPoE, CGNAT, upstream-assigned). The target reconciler now resolves gateways to their LAN-side address using the same resolver SNMP polling uses.
- **Monitoring: Motorola HNAP cable modem provider** (#777) - New CM provider for Motorola DOCSIS modems (MB8611, MB8600, and others using the HNAP protocol). JSON-over-HTTPS with HMAC-MD5 challenge-response authentication, retrieves downstream/upstream DOCSIS channel stats, auto-detects modem model from firmware version.
- **Monitoring: ONT improvements** - AT&T gateway provider derives PON type (GPON vs XGS-PON) from SFP wavelength instead of hardcoding GPON. New PonLinkState enum parses raw device strings into ITU-T G.984.3 states with human-readable labels (e.g. "Connected (O5)"). Records BWP provisioned speed, PON link status, wavelength, and SFP link speed to InfluxDB.
- **Dashboard: CM, ONT, and Cellular panel redesign** - All three panels reorganized with Connection/Stats metric boxes for consistent grouping. Symmetric no-data layout matches populated state. CM uncorrectables moved to correct (downstream) column, correctables added. ONT nav fixed for paging between monitored SFP and external ONTs. Signal gauge centered with scoped CSS. Mobile-responsive nav arrows. SFP-prefixed labels for clarity.