### PR TITLE
Monitoring: consistent WAN live chart RTT + Live View map UX fixes

### DIFF
--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -988,7 +988,13 @@ from(bucket: ""{_bucket}"")
         if (!IsConfigured) return Array.Empty<LatencyPoint>();
         var window = aggregateWindow ?? TimeSpan.FromSeconds(
             Math.Max(10, (int)((to - from).TotalSeconds / 150)));
-        var smoothWindow = TimeSpan.FromSeconds(Math.Max(60, window.TotalSeconds * 3));
+        // Query extra lead-in so every target has probed at least once before the first
+        // visible point, priming fill(usePrevious). Without it, the oldest windows
+        // average a partial subset of targets and the left edge of the chart skews high
+        // or low depending on which targets happen to be missing. Warmup rows are
+        // dropped from the results below.
+        var warmup = TimeSpan.FromSeconds(60) + window;
+        var queryFrom = from - warmup;
         var targetFilter = "";
         if (enabledTargetIds is { Count: > 0 })
         {
@@ -998,7 +1004,7 @@ from(bucket: ""{_bucket}"")
         }
         var flux = $@"
 base = from(bucket: ""{_bucket}"")
-  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> range(start: {ToFluxInstant(queryFrom)}, stop: {ToFluxInstant(to)})
   |> filter(fn: (r) => r._measurement == ""latency"")
   |> filter(fn: (r) => r.target_type == ""accessisp"" or r.target_type == ""transit""){targetFilter}
 
@@ -1014,7 +1020,6 @@ rtt = base
   |> mean()
   |> group()
   |> sort(columns: [""_time""])
-  |> timedMovingAverage(every: {ToFluxDuration(window)}, period: {ToFluxDuration(smoothWindow)})
   |> map(fn: (r) => ({{_time: r._time, _value: r._value, _field: ""rtt_avg_ms""}}))
 
 loss = base
@@ -1036,9 +1041,11 @@ union(tables: [rtt, loss])
         var results = new List<LatencyPoint>();
         await foreach (var record in QueryFluxAsync(flux, ct))
         {
+            var time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow);
+            if (time < from) continue;
             results.Add(new LatencyPoint
             {
-                Time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow),
+                Time = time,
                 RttAvgMs = AsDoubleOrNull(record.GetValueByKey("rtt_avg_ms")),
                 LossPercent = AsDoubleOrNull(record.GetValueByKey("loss_percent"))
             });

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -973,8 +973,10 @@ from(bucket: ""{_bucket}"")
     }
 
     /// <summary>Mean RTT and loss across all ISP+Transit targets, aggregated per time window.
-    /// Averages per target_type first (so ISP and Transit contribute equally), then
-    /// averages the two category means to avoid sawtooth from uneven probe timing.</summary>
+    /// Averages each target into a per-window mean first (normalizing uneven probe
+    /// intervals), then averages within each target_type, then averages the two category
+    /// means - the same weighting as /api/monitoring/live-stats, so the WAN live chart
+    /// doesn't jump when its buffer swaps between history and live samples.</summary>
     public async Task<IReadOnlyList<LatencyPoint>> QueryMeanIspTransitLatencyAsync(
         DateTime from,
         DateTime to,
@@ -1002,15 +1004,30 @@ base = from(bucket: ""{_bucket}"")
 
 rtt = base
   |> filter(fn: (r) => r._field == ""rtt_avg_ms"")
-  |> group(columns: [""_field""])
+  |> group(columns: [""target_id"", ""target_type""])
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: true)
   |> fill(usePrevious: true)
+  |> filter(fn: (r) => exists r._value)
+  |> group(columns: [""target_type"", ""_time""])
+  |> mean()
+  |> group(columns: [""_time""])
+  |> mean()
+  |> group()
+  |> sort(columns: [""_time""])
   |> timedMovingAverage(every: {ToFluxDuration(window)}, period: {ToFluxDuration(smoothWindow)})
+  |> map(fn: (r) => ({{_time: r._time, _value: r._value, _field: ""rtt_avg_ms""}}))
 
 loss = base
   |> filter(fn: (r) => r._field == ""loss_percent"")
-  |> group(columns: [""_field""])
+  |> group(columns: [""target_id"", ""target_type""])
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
+  |> group(columns: [""target_type"", ""_time""])
+  |> mean()
+  |> group(columns: [""_time""])
+  |> mean()
+  |> group()
+  |> sort(columns: [""_time""])
+  |> map(fn: (r) => ({{_time: r._time, _value: r._value, _field: ""loss_percent""}}))
 
 union(tables: [rtt, loss])
   |> group()

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -386,7 +386,7 @@ a:hover {
     margin-bottom: 0;
 }
 .wan-live-chart-card > .card-body {
-    padding: 0;
+    padding: 0 0 0.3rem;
     margin-right: -0.75rem;
 }
 .wan-live-chart-card .apexcharts-canvas {
@@ -567,6 +567,7 @@ a:hover {
 
     .wan-live-chart-card > .card-body {
         margin-right: 0;
+        padding-bottom: 0.2rem;
     }
 
     .card.wan-live-chart-card {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -8579,7 +8579,7 @@ a.path-hop.hop-clickable:hover {
 
 /* ApexCharts dark theme overrides annotation label fill - needs double class
    specificity to beat .apexcharts-text rule below */
-.apexcharts-text.apexcharts-xaxis-annotation-label {
+.apexcharts-text.apexcharts-xaxis-annotation-label:not(.wan-chart-tick-label) {
     fill: var(--text-primary) !important;
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14886,7 +14886,7 @@ a.affected-client:hover {
     opacity: 0.6;
     transition: transform 0.2s ease;
     margin-left: 0.5rem;
-    margin-right: -0.35rem;
+    margin-right: -0.25rem;
 }
 .lan-flow-map-panel-title-toggle:not(:has(+ .is-collapsed))::after {
     transform: rotate(180deg);

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14886,7 +14886,7 @@ a.affected-client:hover {
     opacity: 0.6;
     transition: transform 0.2s ease;
     margin-left: 0.5rem;
-    margin-right: -0.25rem;
+    margin-right: -0.3rem;
 }
 .lan-flow-map-panel-title-toggle:not(:has(+ .is-collapsed))::after {
     transform: rotate(180deg);

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14387,42 +14387,16 @@ a.affected-client:hover {
     top: 0.75rem;
     left: 50%;
     transform: translateX(-50%);
-    padding: 0;
     font-size: 0.78rem;
 }
-.lan-flow-map-help-toggle {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.5rem 0.7rem;
-    background: transparent;
-    border: none;
-    color: var(--text-secondary);
-    cursor: pointer;
-    font: inherit;
-}
-.lan-flow-map-help-toggle:hover { color: var(--text-primary); }
-.lan-flow-map-help-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 1.1rem;
-    height: 1.1rem;
-    border-radius: 50%;
-    background: var(--bg-tertiary);
-    color: var(--text-primary);
-    font-weight: 600;
-    font-size: 0.72rem;
-}
-.lan-flow-map-help-body {
-    padding: 0.55rem 0.75rem;
-    border-top: 1px solid var(--bg-tertiary);
-    display: grid;
-    gap: 0.3rem;
+/* The base panel-body max-height (150px) is sized for the Filter/Overlays
+   panels; the Controls legend has up to 10 rows and needs more room. */
+.lan-flow-map-help .lan-flow-map-panel-body:not(.is-collapsed) {
+    max-height: 320px;
     min-width: 180px;
 }
-.lan-flow-map-help-body[hidden] {
-    display: none;
+.lan-flow-map-help .lan-flow-map-panel-body {
+    gap: 0.3rem;
 }
 .lan-flow-map-help-row {
     display: flex;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14388,6 +14388,11 @@ a.affected-client:hover {
     left: 50%;
     transform: translateX(-50%);
     font-size: 0.78rem;
+    /* Same title/body spacing paradigm as the Overlays panel, including the
+       gap collapse via .lan-flow-map-panel:has(.is-collapsed). */
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
 }
 /* The base panel-body max-height (150px) is sized for the Filter/Overlays
    panels; the Controls legend has up to 10 rows and needs more room. */
@@ -14402,6 +14407,9 @@ a.affected-client:hover {
     display: flex;
     justify-content: space-between;
     gap: 0.6rem;
+    /* Keep rows single-line while the collapse animation shrinks the body
+       width, otherwise wrapping makes the panel grow taller mid-collapse. */
+    white-space: nowrap;
 }
 .lan-flow-map-help-row .kbd {
     background: var(--bg-tertiary);
@@ -14882,6 +14890,9 @@ a.affected-client:hover {
     font-size: 0.65rem;
     opacity: 0.6;
     transition: transform 0.2s ease;
+    /* Pull the chevron toward the pill edge, into the panel padding. */
+    margin-left: 0.5rem;
+    margin-right: -0.35rem;
 }
 .lan-flow-map-panel-title-toggle:not(:has(+ .is-collapsed))::after {
     transform: rotate(180deg);

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15002,6 +15002,9 @@ a.affected-client:hover {
     .lan-flow-map-2d-stage {
         height: auto;
     }
+    .lan-flow-map-2d-stage .lan-flow-map-controls {
+        top: 0.5rem;
+    }
     .lan-flow-map-2d-stage .lfm2d-canvas {
         height: clamp(400px, 50vh, 600px);
     }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14388,14 +14388,10 @@ a.affected-client:hover {
     left: 50%;
     transform: translateX(-50%);
     font-size: 0.78rem;
-    /* Same title/body spacing paradigm as the Overlays panel, including the
-       gap collapse via .lan-flow-map-panel:has(.is-collapsed). */
     display: flex;
     flex-direction: column;
     gap: 0.35rem;
 }
-/* The base panel-body max-height (150px) is sized for the Filter/Overlays
-   panels; the Controls legend has up to 10 rows and needs more room. */
 .lan-flow-map-help .lan-flow-map-panel-body:not(.is-collapsed) {
     max-height: 320px;
     min-width: 180px;
@@ -14407,8 +14403,6 @@ a.affected-client:hover {
     display: flex;
     justify-content: space-between;
     gap: 0.6rem;
-    /* Keep rows single-line while the collapse animation shrinks the body
-       width, otherwise wrapping makes the panel grow taller mid-collapse. */
     white-space: nowrap;
 }
 .lan-flow-map-help-row .kbd {
@@ -14890,7 +14884,6 @@ a.affected-client:hover {
     font-size: 0.65rem;
     opacity: 0.6;
     transition: transform 0.2s ease;
-    /* Pull the chevron toward the pill edge, into the panel padding. */
     margin-left: 0.5rem;
     margin-right: -0.35rem;
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -730,14 +730,17 @@ class LanFlowMap2D {
     _syncScrubber(){
         if(!this._scrubberEls)return;
         const s=flowData.getScrubber();
+        const mode=flowData.getMode();
+        const paused=flowData.isPaused();
         this._scrubberEls.range.value=s.value;
-        this._scrubberEls.right.textContent=s.right;
+        // Live-but-paused shows Paused on the time label and badge so frozen
+        // rates aren't mistaken for live data. Historic keeps its timestamp.
+        this._scrubberEls.right.textContent=(mode!=='historic'&&paused)?'Paused':s.right;
         this._scrubberEls.speedLabel.textContent=`${s.speed}x`;
-        this._scrubberEls.playPause.textContent=flowData.isPaused()?'▶':'⏸';
+        this._scrubberEls.playPause.textContent=paused?'▶':'⏸';
         // Mode badge
         if(this._modeBadge){
-            const mode=flowData.getMode();
-            this._modeBadge.textContent=mode==='historic'?'Historic':'Live';
+            this._modeBadge.textContent=mode==='historic'?'Historic':(paused?'Paused':'Live');
             this._modeBadge.classList.toggle('is-historic',mode==='historic');
             this._modeBadge.style.cursor=mode==='historic'?'pointer':'';
             if(mode==='historic'){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -733,14 +733,14 @@ class LanFlowMap2D {
         const mode=flowData.getMode();
         const paused=flowData.isPaused();
         this._scrubberEls.range.value=s.value;
-        // Live-but-paused shows Paused on the time label and badge so frozen
+        // Live-but-paused shows Live (Paused) on the time label so frozen
         // rates aren't mistaken for live data. Historic keeps its timestamp.
         this._scrubberEls.right.textContent=(mode!=='historic'&&paused)?'Live (Paused)':s.right;
         this._scrubberEls.speedLabel.textContent=`${s.speed}x`;
         this._scrubberEls.playPause.textContent=paused?'▶':'⏸';
         // Mode badge
         if(this._modeBadge){
-            this._modeBadge.textContent=mode==='historic'?'Historic':(paused?'Live (Paused)':'Live');
+            this._modeBadge.textContent=mode==='historic'?'Historic':'Live';
             this._modeBadge.classList.toggle('is-historic',mode==='historic');
             this._modeBadge.style.cursor=mode==='historic'?'pointer':'';
             if(mode==='historic'){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -451,6 +451,37 @@ class LanFlowMap2D {
         });
         this._el.appendChild(tb);
 
+        // Controls help (collapsed pill, expands on click, matching 3D style).
+        // 2D subset of the 3D map's legend: no rotate, WASD, or move-device here.
+        // Scrub/pause rows are omitted in liveOnly mounts (dashboard mini-map)
+        // where the scrubber is hidden.
+        const help=document.createElement('div');
+        help.className='lan-flow-map-panel lan-flow-map-help';
+        const scrubRows=this._liveOnly?'':`
+                <div class="lan-flow-map-help-row"><span>Pause / Play</span><span class="kbd">Space</span></div>
+                <div class="lan-flow-map-help-row"><span>Scrub timeline</span><span class="kbd">←</span> <span class="kbd">→</span></div>
+                <div class="lan-flow-map-help-row"><span>Fast scrub</span><span class="kbd">Shift</span> + <span class="kbd">←</span> <span class="kbd">→</span></div>`;
+        help.innerHTML=`
+            <button class="lan-flow-map-help-toggle" type="button" aria-expanded="false">
+                <span class="lan-flow-map-help-icon">?</span>
+                <span class="lan-flow-map-help-label">Controls</span>
+            </button>
+            <div class="lan-flow-map-help-body" hidden>
+                <div class="lan-flow-map-help-row"><span>Pan</span><span class="kbd">Left-drag</span></div>
+                <div class="lan-flow-map-help-row"><span>Zoom</span><span class="kbd">Scroll</span></div>
+                <div class="lan-flow-map-help-row"><span>Hover detail</span><span class="kbd">Mouse over</span></div>
+                <div class="lan-flow-map-help-row"><span>Open client</span><span class="kbd">Double-click</span></div>${scrubRows}
+                <div class="lan-flow-map-help-row"><span>Fullscreen</span><span class="kbd">Esc</span> to exit</div>
+            </div>`;
+        const helpToggle=help.querySelector('.lan-flow-map-help-toggle');
+        const helpBody=help.querySelector('.lan-flow-map-help-body');
+        helpToggle.addEventListener('click',()=>{
+            const isOpen=helpBody.hasAttribute('hidden')===false;
+            if(isOpen){helpBody.setAttribute('hidden','');helpToggle.setAttribute('aria-expanded','false');}
+            else{helpBody.removeAttribute('hidden');helpToggle.setAttribute('aria-expanded','true');}
+        });
+        this._el.appendChild(help);
+
         // Mode badge (bottom-left, matching 3D style)
         const status=document.createElement('div');
         status.className='lan-flow-map-panel lan-flow-map-status';

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -451,35 +451,31 @@ class LanFlowMap2D {
         });
         this._el.appendChild(tb);
 
-        // Controls help (collapsed pill, expands on click, matching 3D style).
+        // Controls help (starts collapsed, title click toggles - same pattern
+        // as the Filter/Overlays panels on mobile, matching 3D style).
         // 2D subset of the 3D map's legend: no rotate, WASD, or move-device here.
         // Scrub/pause rows are omitted in liveOnly mounts (dashboard mini-map)
         // where the scrubber is hidden.
         const help=document.createElement('div');
         help.className='lan-flow-map-panel lan-flow-map-help';
+        const helpTitle=document.createElement('div');
+        helpTitle.className='lan-flow-map-panel-title lan-flow-map-panel-title-toggle';
+        helpTitle.textContent='Controls';
+        help.appendChild(helpTitle);
         const scrubRows=this._liveOnly?'':`
                 <div class="lan-flow-map-help-row"><span>Pause / Play</span><span class="kbd">Space</span></div>
                 <div class="lan-flow-map-help-row"><span>Scrub timeline</span><span class="kbd">←</span> <span class="kbd">→</span></div>
                 <div class="lan-flow-map-help-row"><span>Fast scrub</span><span class="kbd">Shift</span> + <span class="kbd">←</span> <span class="kbd">→</span></div>`;
-        help.innerHTML=`
-            <button class="lan-flow-map-help-toggle" type="button" aria-expanded="false">
-                <span class="lan-flow-map-help-icon">?</span>
-                <span class="lan-flow-map-help-label">Controls</span>
-            </button>
-            <div class="lan-flow-map-help-body" hidden>
+        const helpBody=document.createElement('div');
+        helpBody.className='lan-flow-map-panel-body is-collapsed';
+        helpBody.innerHTML=`
                 <div class="lan-flow-map-help-row"><span>Pan</span><span class="kbd">Left-drag</span></div>
                 <div class="lan-flow-map-help-row"><span>Zoom</span><span class="kbd">Scroll</span></div>
                 <div class="lan-flow-map-help-row"><span>Hover detail</span><span class="kbd">Mouse over</span></div>
                 <div class="lan-flow-map-help-row"><span>Open client</span><span class="kbd">Double-click</span></div>${scrubRows}
-                <div class="lan-flow-map-help-row"><span>Fullscreen</span><span class="kbd">Esc</span> to exit</div>
-            </div>`;
-        const helpToggle=help.querySelector('.lan-flow-map-help-toggle');
-        const helpBody=help.querySelector('.lan-flow-map-help-body');
-        helpToggle.addEventListener('click',()=>{
-            const isOpen=helpBody.hasAttribute('hidden')===false;
-            if(isOpen){helpBody.setAttribute('hidden','');helpToggle.setAttribute('aria-expanded','false');}
-            else{helpBody.removeAttribute('hidden');helpToggle.setAttribute('aria-expanded','true');}
-        });
+                <div class="lan-flow-map-help-row"><span>Fullscreen</span><span class="kbd">Esc</span> to exit</div>`;
+        help.appendChild(helpBody);
+        helpTitle.addEventListener('click',()=>helpBody.classList.toggle('is-collapsed'));
         this._el.appendChild(help);
 
         // Mode badge (bottom-left, matching 3D style)

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -735,12 +735,12 @@ class LanFlowMap2D {
         this._scrubberEls.range.value=s.value;
         // Live-but-paused shows Paused on the time label and badge so frozen
         // rates aren't mistaken for live data. Historic keeps its timestamp.
-        this._scrubberEls.right.textContent=(mode!=='historic'&&paused)?'Paused':s.right;
+        this._scrubberEls.right.textContent=(mode!=='historic'&&paused)?'Live (Paused)':s.right;
         this._scrubberEls.speedLabel.textContent=`${s.speed}x`;
         this._scrubberEls.playPause.textContent=paused?'▶':'⏸';
         // Mode badge
         if(this._modeBadge){
-            this._modeBadge.textContent=mode==='historic'?'Historic':(paused?'Paused':'Live');
+            this._modeBadge.textContent=mode==='historic'?'Historic':(paused?'Live (Paused)':'Live');
             this._modeBadge.classList.toggle('is-historic',mode==='historic');
             this._modeBadge.style.cursor=mode==='historic'?'pointer':'';
             if(mode==='historic'){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1569,12 +1569,11 @@ export class LanFlowMap {
         this._syncPlayPauseIcon();
         flowData.publishPlayState(this._paused, this._mode);
         this._notifyPlayState();
-        // In live mode flip the badge and time label between Live and Paused
+        // In live mode flip the time label between Live and Live (Paused)
         // so frozen rates aren't mistaken for live data. Historic mode keeps
-        // its badge and timestamp.
+        // its timestamp; the mode badge stays Live/Historic either way.
         if (this._mode === 'live') {
             const label = this._paused ? 'Live (Paused)' : 'Live';
-            if (this._panels.modeBadge) this._panels.modeBadge.textContent = label;
             if (this._panels.scrubberRight) this._panels.scrubberRight.textContent = label;
             flowData.publishScrubber(
                 Number(this._panels.scrubberRange?.value ?? 10000), label, this._playbackSpeed);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1569,6 +1569,16 @@ export class LanFlowMap {
         this._syncPlayPauseIcon();
         flowData.publishPlayState(this._paused, this._mode);
         this._notifyPlayState();
+        // In live mode flip the badge and time label between Live and Paused
+        // so frozen rates aren't mistaken for live data. Historic mode keeps
+        // its badge and timestamp.
+        if (this._mode === 'live') {
+            const label = this._paused ? 'Paused' : 'Live';
+            if (this._panels.modeBadge) this._panels.modeBadge.textContent = label;
+            if (this._panels.scrubberRight) this._panels.scrubberRight.textContent = label;
+            flowData.publishScrubber(
+                Number(this._panels.scrubberRange?.value ?? 10000), label, this._playbackSpeed);
+        }
         if (this._paused) {
             this._stopHistoricPlayback();
             return;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1910,6 +1910,13 @@ export class LanFlowMap {
                 this._speedIndex = newIdx;
                 this._playbackSpeed = SPEED_STEPS[newIdx];
                 this._syncSpeedLabel();
+                // Publish right away so the 2D mirror's speed label updates
+                // immediately - otherwise it waits for the next playback tick
+                // (1s), or indefinitely while paused.
+                flowData.publishScrubber(
+                    Number(this._panels.scrubberRange?.value ?? 10000),
+                    this._panels.scrubberRight?.textContent ?? 'Live',
+                    this._playbackSpeed);
                 if (this._mode === 'live' && this._playbackSpeed < 1) {
                     const now = Date.now();
                     const span = now - this._scrubberOrigin;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1778,35 +1778,31 @@ export class LanFlowMap {
         `;
         this._panels.legend = legend;
 
-        // Controls help (collapsed pill, expands on click). OrbitControls handles
-        // the actual input bindings; this just documents them so users can find
+        // Controls help (starts collapsed, title click toggles - same pattern
+        // as the Filter/Overlays panels on mobile). OrbitControls handles the
+        // actual input bindings; this just documents them so users can find
         // their way around without trial and error.
         const help = this._makePanel('lan-flow-map-help');
-        help.innerHTML = `
-            <button class="lan-flow-map-help-toggle" type="button" aria-expanded="false">
-                <span class="lan-flow-map-help-icon">?</span>
-                <span class="lan-flow-map-help-label">Controls</span>
-            </button>
-            <div class="lan-flow-map-help-body" hidden>
-                <div class="lan-flow-map-help-row"><span>Rotate</span><span class="kbd">Left-drag</span></div>
-                <div class="lan-flow-map-help-row"><span>Pan</span><span class="kbd">Right-drag</span> or <span class="kbd">A</span> <span class="kbd">D</span></div>
-                <div class="lan-flow-map-help-row"><span>Zoom</span><span class="kbd">Scroll</span> or <span class="kbd">W</span> <span class="kbd">S</span></div>
-                <div class="lan-flow-map-help-row"><span>Hover detail</span><span class="kbd">Mouse over</span></div>
-                <div class="lan-flow-map-help-row"><span>Open client</span><span class="kbd">Double-click</span></div>
-                <div class="lan-flow-map-help-row"><span>Move device</span><span class="kbd">Right-click</span></div>
-                <div class="lan-flow-map-help-row"><span>Pause / Play</span><span class="kbd">Space</span></div>
-                <div class="lan-flow-map-help-row"><span>Scrub timeline</span><span class="kbd">←</span> <span class="kbd">→</span></div>
-                <div class="lan-flow-map-help-row"><span>Fast scrub</span><span class="kbd">Shift</span> + <span class="kbd">←</span> <span class="kbd">→</span></div>
-                <div class="lan-flow-map-help-row"><span>Fullscreen</span><span class="kbd">Esc</span> to exit</div>
-            </div>
+        const helpTitle = document.createElement('div');
+        helpTitle.className = 'lan-flow-map-panel-title lan-flow-map-panel-title-toggle';
+        helpTitle.textContent = 'Controls';
+        help.appendChild(helpTitle);
+        const helpBody = document.createElement('div');
+        helpBody.className = 'lan-flow-map-panel-body is-collapsed';
+        helpBody.innerHTML = `
+            <div class="lan-flow-map-help-row"><span>Rotate</span><span class="kbd">Left-drag</span></div>
+            <div class="lan-flow-map-help-row"><span>Pan</span><span class="kbd">Right-drag</span> or <span class="kbd">A</span> <span class="kbd">D</span></div>
+            <div class="lan-flow-map-help-row"><span>Zoom</span><span class="kbd">Scroll</span> or <span class="kbd">W</span> <span class="kbd">S</span></div>
+            <div class="lan-flow-map-help-row"><span>Hover detail</span><span class="kbd">Mouse over</span></div>
+            <div class="lan-flow-map-help-row"><span>Open client</span><span class="kbd">Double-click</span></div>
+            <div class="lan-flow-map-help-row"><span>Move device</span><span class="kbd">Right-click</span></div>
+            <div class="lan-flow-map-help-row"><span>Pause / Play</span><span class="kbd">Space</span></div>
+            <div class="lan-flow-map-help-row"><span>Scrub timeline</span><span class="kbd">←</span> <span class="kbd">→</span></div>
+            <div class="lan-flow-map-help-row"><span>Fast scrub</span><span class="kbd">Shift</span> + <span class="kbd">←</span> <span class="kbd">→</span></div>
+            <div class="lan-flow-map-help-row"><span>Fullscreen</span><span class="kbd">Esc</span> to exit</div>
         `;
-        const helpToggle = help.querySelector('.lan-flow-map-help-toggle');
-        const helpBody = help.querySelector('.lan-flow-map-help-body');
-        helpToggle.addEventListener('click', () => {
-            const isOpen = helpBody.hasAttribute('hidden') === false;
-            if (isOpen) { helpBody.setAttribute('hidden', ''); helpToggle.setAttribute('aria-expanded', 'false'); }
-            else { helpBody.removeAttribute('hidden'); helpToggle.setAttribute('aria-expanded', 'true'); }
-        });
+        help.appendChild(helpBody);
+        helpTitle.addEventListener('click', () => helpBody.classList.toggle('is-collapsed'));
         this._panels.help = help;
 
         // Status / mode indicator (bottom-left)

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1573,7 +1573,7 @@ export class LanFlowMap {
         // so frozen rates aren't mistaken for live data. Historic mode keeps
         // its badge and timestamp.
         if (this._mode === 'live') {
-            const label = this._paused ? 'Paused' : 'Live';
+            const label = this._paused ? 'Live (Paused)' : 'Live';
             if (this._panels.modeBadge) this._panels.modeBadge.textContent = label;
             if (this._panels.scrubberRight) this._panels.scrubberRight.textContent = label;
             flowData.publishScrubber(

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -311,7 +311,7 @@ export class LanFlowMap {
                 }
             }
             const scrubberFocused = document.activeElement === this._panels?.scrubberRange;
-            if (!scrubberFocused && !this._shouldAcceptKeys()) return;
+            if (!scrubberFocused && !this._shouldAcceptKeys(e)) return;
             if (e.key === ' ') {
                 e.preventDefault();
                 this._togglePlayPause();
@@ -332,12 +332,23 @@ export class LanFlowMap {
         document.addEventListener('keyup', this._onKeyUp);
     }
 
-    _shouldAcceptKeys() {
+    _shouldAcceptKeys(e) {
         const tag = document.activeElement?.tagName;
         if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return false;
         if (document.activeElement?.isContentEditable) return false;
-        const rect = this.canvas.getBoundingClientRect();
-        return rect.bottom > 0 && rect.top < window.innerHeight;
+        const onScreen = (el) => {
+            if (!el) return false;
+            const rect = el.getBoundingClientRect();
+            return rect.bottom > 0 && rect.top < window.innerHeight;
+        };
+        if (onScreen(this.canvas)) return true;
+        // Scrub/pause keys also work while the companion 2D map is on screen -
+        // it mirrors this map's scrubber, and without this the keyboard goes
+        // dead the moment the 3D canvas scrolls out of view. Camera keys
+        // (WASD/QE) stay 3D-only so the camera can't be flown around unseen.
+        const isScrubKey = e && (e.key === ' ' || e.key === 'Shift'
+            || e.key === 'ArrowLeft' || e.key === 'ArrowRight');
+        return isScrubKey && onScreen(document.querySelector('.lan-flow-map-2d-stage'));
     }
 
     _fitCamera() {

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -24,6 +24,11 @@ let elId = null;
 let visHandler = null;
 let mountGen = 0;
 let lastSampleTime = 0;
+// Historic playback interpolation state (see seekTime).
+let histTimer = null;
+let histAt = 0;
+let histWall = 0;
+let histRate = 0;
 
 function formatBps(v) {
     if (v == null || v < 1) return '0';
@@ -169,9 +174,10 @@ function buildTimeTicks(minMs, maxMs) {
                 text,
                 position: 'bottom',
                 orientation: 'horizontal',
-                offsetY: 14,
+                offsetY: 19,
                 borderColor: 'transparent',
-                style: { background: 'transparent', color: '#64748b', fontSize: '10px' },
+                // --text-muted; CSS vars don't resolve inside the chart config
+                style: { background: 'transparent', color: '#5c5c66', fontSize: '10px' },
             },
         });
     }
@@ -306,6 +312,7 @@ export async function mount(containerId, opts) {
 }
 
 export function pause() {
+    stopHistInterpolation();
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
 }
@@ -316,41 +323,13 @@ export function resume() {
     scrollTimer = setInterval(updateChart, SCROLL_MS);
 }
 
-export async function seekTime(isoTimestamp) {
-    if (!chart) return;
-    if (!isoTimestamp) {
-        // Return to live mode - updateChart replaces the annotations with the
-        // plain time grid, dropping the playhead.
-        if (pollTimer) return; // already live
-        buffer = [];
-        await loadHistory();
-        updateChart();
-        pollTimer = setInterval(pollLive, POLL_MS);
-        scrollTimer = setInterval(updateChart, SCROLL_MS);
-        return;
-    }
-    // Historic mode: stop polling, fetch window centered on timestamp
-    if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
-    if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
-    const at = new Date(isoTimestamp).getTime();
+// Render the historic view at a given playhead time from the current buffer.
+// No fetching - callers load data; the interpolation timer reuses it.
+function renderHistoric(at) {
+    if (!chart || buffer.length === 0) return;
+    const el = document.getElementById(elId);
+    if (el?.classList.contains('apexcharts-tooltip-active')) return;
     const halfWindow = HISTORY_MINUTES * 60000 / 2;
-    const from = new Date(at - halfWindow);
-    const to = new Date(at + halfWindow);
-    try {
-        const resp = await fetch(
-            `/api/monitoring/wan-live-chart-data?from=${from.toISOString()}&to=${to.toISOString()}`,
-            { credentials: 'same-origin' });
-        if (!resp.ok) return;
-        const data = await resp.json();
-        buffer = (data.points || []).map(p => ({
-            time: new Date(p.time).getTime(),
-            download: p.downloadBps,
-            upload: p.uploadBps,
-            rtt: p.rttMs,
-            loss: p.lossPercent,
-        }));
-    } catch { return; }
-    if (buffer.length === 0) return;
     const maxTime = Math.min(at + halfWindow, Date.now());
     const playhead = {
         x: at,
@@ -379,8 +358,75 @@ export async function seekTime(isoTimestamp) {
     ], false);
 }
 
+// Historic playback only seeks once per second (the map's playback tick), so
+// the chart would step instead of slide. Between real seeks, interpolate the
+// playhead at the inferred playback rate and redraw from the existing buffer
+// at the live-mode cadence. Draw-only: no extra fetches or polling.
+function stopHistInterpolation() {
+    if (histTimer) { clearInterval(histTimer); histTimer = null; }
+    histRate = 0;
+    histWall = 0;
+}
+
+export async function seekTime(isoTimestamp) {
+    if (!chart) return;
+    if (!isoTimestamp) {
+        // Return to live mode - updateChart replaces the annotations with the
+        // plain time grid, dropping the playhead.
+        stopHistInterpolation();
+        if (pollTimer) return; // already live
+        buffer = [];
+        await loadHistory();
+        updateChart();
+        pollTimer = setInterval(pollLive, POLL_MS);
+        scrollTimer = setInterval(updateChart, SCROLL_MS);
+        return;
+    }
+    // Historic mode: stop polling, fetch window centered on timestamp
+    if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+    if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
+    const at = new Date(isoTimestamp).getTime();
+    // Infer the playback rate from consecutive forward seeks. Backward jumps,
+    // the first seek, and gaps over 2.5s (paused playback ticks every 1s)
+    // disable interpolation until the rate is re-established.
+    const wall = Date.now();
+    histRate = (histWall && at > histAt && wall - histWall < 2500)
+        ? (at - histAt) / (wall - histWall)
+        : 0;
+    histAt = at;
+    histWall = wall;
+    const halfWindow = HISTORY_MINUTES * 60000 / 2;
+    const from = new Date(at - halfWindow);
+    const to = new Date(at + halfWindow);
+    try {
+        const resp = await fetch(
+            `/api/monitoring/wan-live-chart-data?from=${from.toISOString()}&to=${to.toISOString()}`,
+            { credentials: 'same-origin' });
+        if (!resp.ok) return;
+        const data = await resp.json();
+        buffer = (data.points || []).map(p => ({
+            time: new Date(p.time).getTime(),
+            download: p.downloadBps,
+            upload: p.uploadBps,
+            rtt: p.rttMs,
+            loss: p.lossPercent,
+        }));
+    } catch { return; }
+    if (buffer.length === 0) return;
+    renderHistoric(at);
+    if (!histTimer) {
+        histTimer = setInterval(() => {
+            if (histRate <= 0) return;
+            const elapsed = Date.now() - histWall;
+            if (elapsed > 2500) return; // playback stalled or paused
+            renderHistoric(histAt + elapsed * histRate);
+        }, SCROLL_MS);
+    }
+}
+
 export function unmount() {
     mountGen++;
+    stopHistInterpolation();
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
     if (visHandler) { document.removeEventListener('visibilitychange', visHandler); visHandler = null; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -8,7 +8,9 @@ const HISTORY_MINUTES = 5;
 // Poll faster than the 5s SNMP fast tier so no sample is missed when the two
 // clocks drift out of phase; pollLive dedupes repeat reads via sampleTime.
 const POLL_MS = 2500;
-const SCROLL_MS = 500;
+// Window-scroll redraw cadence. At 250ms each step moves well under a pixel
+// on typical widths, so the chart slides instead of visibly ticking.
+const SCROLL_MS = 250;
 const COLOR_DL   = '#3b82f6';
 const COLOR_UL   = '#10b981';
 const COLOR_LOSS = '#ef4444';
@@ -69,12 +71,12 @@ function buildOpts() {
             type: 'datetime',
             min: Date.now() - HISTORY_MINUTES * 60000,
             max: Date.now(),
-            labels: {
-                show: true,
-                style: { colors: '#64748b', fontSize: '10px' },
-                datetimeUTC: false,
-                datetimeFormatter: { hour: 'HH:mm', minute: 'HH:mm:ss' },
-            },
+            // Built-in labels are hidden: ApexCharts re-picks "nice" ticks as
+            // the window slides, so the labels kept swapping between
+            // :00 | :20 | :40 and :10 | :30 | :50 alignments. Time labels are
+            // drawn as annotations pinned to a fixed 20s grid instead (see
+            // buildTimeTicks).
+            labels: { show: false },
             axisBorder: { show: false },
             axisTicks: { show: false },
         },
@@ -148,6 +150,34 @@ function buildOpts() {
     };
 }
 
+// Time labels pinned to a fixed 20s grid, rendered as x-axis annotations so
+// they scroll with the data. Minute boundaries show the full time; the :20
+// and :40 ticks show just the seconds.
+function buildTimeTicks(minMs, maxMs) {
+    const GRID_MS = 20000;
+    const ticks = [];
+    for (let t = Math.ceil(minMs / GRID_MS) * GRID_MS; t <= maxMs; t += GRID_MS) {
+        const d = new Date(t);
+        const ss = d.getSeconds();
+        const text = ss === 0
+            ? d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+            : ':' + String(ss).padStart(2, '0');
+        ticks.push({
+            x: t,
+            borderColor: 'transparent',
+            label: {
+                text,
+                position: 'bottom',
+                orientation: 'horizontal',
+                offsetY: -4,
+                borderColor: 'transparent',
+                style: { background: 'transparent', color: '#64748b', fontSize: '10px' },
+            },
+        });
+    }
+    return ticks;
+}
+
 function rttYMax() {
     const rtts = buffer.map(p => p.rtt).filter(v => v != null && v > 0).sort((a, b) => a - b);
     if (rtts.length === 0) return 10;
@@ -174,6 +204,7 @@ function updateChart() {
     chart.updateOptions({
         xaxis: { min: now - HISTORY_MINUTES * 60000, max: now },
         yaxis: [chart.opts.yaxis[0], chart.opts.yaxis[1], chart.opts.yaxis[2], { ...chart.opts.yaxis[3], max: rttYMax() }],
+        annotations: { xaxis: buildTimeTicks(now - HISTORY_MINUTES * 60000, now) },
     }, false, false, false);
     chart.updateSeries([
         { name: 'Download', data: pts.map(p => ({ x: p.time, y: p.download })) },
@@ -288,8 +319,8 @@ export function resume() {
 export async function seekTime(isoTimestamp) {
     if (!chart) return;
     if (!isoTimestamp) {
-        // Return to live mode - clear playhead annotation
-        chart.clearAnnotations();
+        // Return to live mode - updateChart replaces the annotations with the
+        // plain time grid, dropping the playhead.
         if (pollTimer) return; // already live
         buffer = [];
         await loadHistory();
@@ -321,19 +352,7 @@ export async function seekTime(isoTimestamp) {
     } catch { return; }
     if (buffer.length === 0) return;
     const maxTime = Math.min(at + halfWindow, Date.now());
-    chart.updateOptions({
-        xaxis: { min: maxTime - HISTORY_MINUTES * 60000, max: maxTime },
-        yaxis: [chart.opts.yaxis[0], chart.opts.yaxis[1], chart.opts.yaxis[2], { ...chart.opts.yaxis[3], max: rttYMax() }],
-    }, false, false, false);
-    chart.updateSeries([
-        { name: 'Download', data: buffer.map(p => ({ x: p.time, y: p.download })) },
-        { name: 'Upload',   data: buffer.map(p => ({ x: p.time, y: p.upload })) },
-        { name: 'Loss',     data: buffer.map(p => ({ x: p.time, y: p.loss })) },
-        { name: 'RTT',      data: buffer.map(p => ({ x: p.time, y: p.rtt })) },
-    ], false);
-
-    chart.clearAnnotations();
-    chart.addXaxisAnnotation({
+    const playhead = {
         x: at,
         borderColor: '#f1f5f9',
         strokeDashArray: 3,
@@ -346,7 +365,18 @@ export async function seekTime(isoTimestamp) {
             orientation: 'horizontal',
             offsetY: -5,
         }
-    });
+    };
+    chart.updateOptions({
+        xaxis: { min: maxTime - HISTORY_MINUTES * 60000, max: maxTime },
+        yaxis: [chart.opts.yaxis[0], chart.opts.yaxis[1], chart.opts.yaxis[2], { ...chart.opts.yaxis[3], max: rttYMax() }],
+        annotations: { xaxis: [...buildTimeTicks(maxTime - HISTORY_MINUTES * 60000, maxTime), playhead] },
+    }, false, false, false);
+    chart.updateSeries([
+        { name: 'Download', data: buffer.map(p => ({ x: p.time, y: p.download })) },
+        { name: 'Upload',   data: buffer.map(p => ({ x: p.time, y: p.upload })) },
+        { name: 'Loss',     data: buffer.map(p => ({ x: p.time, y: p.loss })) },
+        { name: 'RTT',      data: buffer.map(p => ({ x: p.time, y: p.rtt })) },
+    ], false);
 }
 
 export function unmount() {

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -46,6 +46,9 @@ function buildOpts() {
             background: 'transparent',
             toolbar: { show: false },
             zoom: { enabled: false },
+            // Drop the default 15px dead strip below the svg so the time
+            // labels sit close to the card bottom.
+            parentHeightOffset: 0,
             animations: { enabled: true, easing: 'smooth', dynamicAnimation: { speed: 800 } },
         },
         series: [

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -176,8 +176,10 @@ function buildTimeTicks(minMs, maxMs) {
                 orientation: 'horizontal',
                 offsetY: 19,
                 borderColor: 'transparent',
-                // --text-muted; CSS vars don't resolve inside the chart config
-                style: { background: 'transparent', color: '#5c5c66', fontSize: '10px' },
+                // The wan-chart-tick-label class opts these out of the
+                // app.css rule that forces annotation labels to text-primary,
+                // so they fall through to the muted .apexcharts-text fill.
+                style: { background: 'transparent', fontSize: '10px', cssClass: 'wan-chart-tick-label' },
             },
         });
     }

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -157,11 +157,14 @@ function buildOpts() {
     };
 }
 
-// Time labels pinned to a fixed 20s grid, rendered as x-axis annotations so
+// Time labels pinned to a fixed grid, rendered as x-axis annotations so
 // they scroll with the data. Full 24-hour time on every tick, placed below
-// the axis in the space freed by the hidden built-in labels.
+// the axis in the space freed by the hidden built-in labels. The 20s grid
+// fits ~15 HH:mm:ss labels on desktop widths; narrow (mobile) charts drop
+// to a 60s grid so the labels don't collide.
 function buildTimeTicks(minMs, maxMs) {
-    const GRID_MS = 20000;
+    const width = document.getElementById(elId)?.clientWidth || 800;
+    const GRID_MS = width < 640 ? 60000 : 20000;
     const ticks = [];
     for (let t = Math.ceil(minMs / GRID_MS) * GRID_MS; t <= maxMs; t += GRID_MS) {
         const d = new Date(t);

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -29,7 +29,6 @@ let histTimer = null;
 let histAt = 0;
 let histWall = 0;
 let histRate = 0;
-let histPrevRate = 0;
 
 function formatBps(v) {
     if (v == null || v < 1) return '0';
@@ -369,12 +368,20 @@ function renderHistoric(at) {
 
 // Historic playback only seeks once per second (the map's playback tick), so
 // the chart would step instead of slide. Between real seeks, interpolate the
-// playhead at the inferred playback rate and redraw from the existing buffer
-// at the live-mode cadence. Draw-only: no extra fetches or polling.
+// playhead and redraw from the existing buffer at the live-mode cadence.
+// Draw-only: no extra fetches or polling. The rate comes from the map
+// instance's actual playback state - inferring it from seek timing also
+// matched mouse drags and keyboard scrubbing (steady ~200ms steps), which
+// sent the chart flying after the scrub ended.
+function mapPlaybackRate() {
+    const inst = window.__lanFlowMap?.getInstance?.();
+    if (!inst || inst._paused || inst._mode !== 'historic' || !inst._historicPlaybackTimer) return 0;
+    return inst._playbackSpeed > 0 ? inst._playbackSpeed : 0;
+}
+
 function stopHistInterpolation() {
     if (histTimer) { clearInterval(histTimer); histTimer = null; }
     histRate = 0;
-    histPrevRate = 0;
     histWall = 0;
 }
 
@@ -396,21 +403,8 @@ export async function seekTime(isoTimestamp) {
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
     const at = new Date(isoTimestamp).getTime();
-    // Infer the playback rate from consecutive forward seeks. Playback ticks
-    // arrive at a steady ~1s cadence with a constant rate; manual scrubs are
-    // irregular and can imply huge rates (a minute dragged in 200ms), which
-    // would keep extrapolating after the drag stops. Only interpolate after
-    // two consecutive seeks at playback-like spacing with matching rates.
-    const wall = Date.now();
-    const gap = wall - histWall;
-    const rate = (histWall && at > histAt && gap >= 700 && gap <= 2500)
-        ? (at - histAt) / gap
-        : 0;
-    histRate = (rate > 0 && histPrevRate > 0
-        && Math.abs(rate - histPrevRate) <= histPrevRate * 0.3) ? rate : 0;
-    histPrevRate = rate;
     histAt = at;
-    histWall = wall;
+    histWall = Date.now();
     const halfWindow = HISTORY_MINUTES * 60000 / 2;
     // Fetch the window the axis will actually show. The axis is a trailing
     // 5min window ending at min(at + half, now), so a fetch centered on the
@@ -437,17 +431,17 @@ export async function seekTime(isoTimestamp) {
     renderHistoric(at);
     if (!histTimer) {
         histTimer = setInterval(() => {
-            if (histRate <= 0) return;
-            const elapsed = Date.now() - histWall;
-            if (elapsed > 2500) {
-                // Playback stalled or paused: stop extrapolating and settle
-                // back on the last confirmed seek position.
-                histRate = 0;
-                histPrevRate = 0;
-                renderHistoric(histAt);
+            const rate = mapPlaybackRate();
+            if (rate <= 0) {
+                // Not playing (paused, scrubbing, or no map): settle back on
+                // the last confirmed seek position if we were extrapolating.
+                if (histRate > 0) { histRate = 0; renderHistoric(histAt); }
                 return;
             }
-            renderHistoric(histAt + elapsed * histRate);
+            histRate = rate;
+            const elapsed = Date.now() - histWall;
+            if (elapsed > 2500) return; // seeks stalled (hidden tab etc) - hold
+            renderHistoric(histAt + elapsed * rate);
         }, SCROLL_MS);
     }
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -29,6 +29,7 @@ let histTimer = null;
 let histAt = 0;
 let histWall = 0;
 let histRate = 0;
+let histPrevRate = 0;
 
 function formatBps(v) {
     if (v == null || v < 1) return '0';
@@ -373,6 +374,7 @@ function renderHistoric(at) {
 function stopHistInterpolation() {
     if (histTimer) { clearInterval(histTimer); histTimer = null; }
     histRate = 0;
+    histPrevRate = 0;
     histWall = 0;
 }
 
@@ -394,13 +396,19 @@ export async function seekTime(isoTimestamp) {
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
     const at = new Date(isoTimestamp).getTime();
-    // Infer the playback rate from consecutive forward seeks. Backward jumps,
-    // the first seek, and gaps over 2.5s (paused playback ticks every 1s)
-    // disable interpolation until the rate is re-established.
+    // Infer the playback rate from consecutive forward seeks. Playback ticks
+    // arrive at a steady ~1s cadence with a constant rate; manual scrubs are
+    // irregular and can imply huge rates (a minute dragged in 200ms), which
+    // would keep extrapolating after the drag stops. Only interpolate after
+    // two consecutive seeks at playback-like spacing with matching rates.
     const wall = Date.now();
-    histRate = (histWall && at > histAt && wall - histWall < 2500)
-        ? (at - histAt) / (wall - histWall)
+    const gap = wall - histWall;
+    const rate = (histWall && at > histAt && gap >= 700 && gap <= 2500)
+        ? (at - histAt) / gap
         : 0;
+    histRate = (rate > 0 && histPrevRate > 0
+        && Math.abs(rate - histPrevRate) <= histPrevRate * 0.3) ? rate : 0;
+    histPrevRate = rate;
     histAt = at;
     histWall = wall;
     const halfWindow = HISTORY_MINUTES * 60000 / 2;
@@ -431,7 +439,14 @@ export async function seekTime(isoTimestamp) {
         histTimer = setInterval(() => {
             if (histRate <= 0) return;
             const elapsed = Date.now() - histWall;
-            if (elapsed > 2500) return; // playback stalled or paused
+            if (elapsed > 2500) {
+                // Playback stalled or paused: stop extrapolating and settle
+                // back on the last confirmed seek position.
+                histRate = 0;
+                histPrevRate = 0;
+                renderHistoric(histAt);
+                return;
+            }
             renderHistoric(histAt + elapsed * histRate);
         }, SCROLL_MS);
     }

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -404,8 +404,13 @@ export async function seekTime(isoTimestamp) {
     histAt = at;
     histWall = wall;
     const halfWindow = HISTORY_MINUTES * 60000 / 2;
-    const from = new Date(at - halfWindow);
-    const to = new Date(at + halfWindow);
+    // Fetch the window the axis will actually show. The axis is a trailing
+    // 5min window ending at min(at + half, now), so a fetch centered on the
+    // seek time would leave the left of the chart empty when seeking close
+    // to live.
+    const maxTime = Math.min(at + halfWindow, Date.now());
+    const from = new Date(maxTime - HISTORY_MINUTES * 60000);
+    const to = new Date(maxTime);
     try {
         const resp = await fetch(
             `/api/monitoring/wan-live-chart-data?from=${from.toISOString()}&to=${to.toISOString()}`,

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -119,7 +119,9 @@ function buildOpts() {
         grid: {
             borderColor: '#374151',
             strokeDashArray: 3,
-            padding: { left: 3, right: 0, top: -8, bottom: -3 },
+            // Bottom padding holds the strip below the axis where the
+            // annotation time labels render.
+            padding: { left: 3, right: 0, top: -8, bottom: 12 },
             xaxis: { lines: { show: false } },
         },
         responsive: [{
@@ -131,7 +133,7 @@ function buildOpts() {
                     { seriesName: 'Loss', opposite: true, show: false, min: 0, max: v => Math.max(v * 1.2, 10) },
                     { seriesName: 'RTT', opposite: true, show: false, min: 0 },
                 ],
-                grid: { padding: { left: -5, right: -5, top: -8, bottom: -3 } },
+                grid: { padding: { left: -5, right: -5, top: -8, bottom: 12 } },
             },
         }],
         legend: { show: false },
@@ -151,17 +153,15 @@ function buildOpts() {
 }
 
 // Time labels pinned to a fixed 20s grid, rendered as x-axis annotations so
-// they scroll with the data. Minute boundaries show the full time; the :20
-// and :40 ticks show just the seconds.
+// they scroll with the data. Full 24-hour time on every tick, placed below
+// the axis in the space freed by the hidden built-in labels.
 function buildTimeTicks(minMs, maxMs) {
     const GRID_MS = 20000;
     const ticks = [];
     for (let t = Math.ceil(minMs / GRID_MS) * GRID_MS; t <= maxMs; t += GRID_MS) {
         const d = new Date(t);
-        const ss = d.getSeconds();
-        const text = ss === 0
-            ? d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
-            : ':' + String(ss).padStart(2, '0');
+        const text = [d.getHours(), d.getMinutes(), d.getSeconds()]
+            .map(v => String(v).padStart(2, '0')).join(':');
         ticks.push({
             x: t,
             borderColor: 'transparent',
@@ -169,7 +169,7 @@ function buildTimeTicks(minMs, maxMs) {
                 text,
                 position: 'bottom',
                 orientation: 'horizontal',
-                offsetY: -4,
+                offsetY: 14,
                 borderColor: 'transparent',
                 style: { background: 'transparent', color: '#64748b', fontSize: '10px' },
             },


### PR DESCRIPTION
## WAN live chart

- **History now matches live RTT** - The chart pre-loads history from InfluxDB, then appends live samples. The two paths weighted ISP vs transit targets differently (history pooled all probe points, so whichever group had more targets dominated), so every reload or tab-refocus visibly jumped the RTT line and changed its character. The history query now aggregates per target first, then per target type, then averages the type means - the same weighting the live endpoint uses.
- **No more skewed left edge** - The oldest minute of the primed chart trended high or low because targets that had not yet probed within the queried range were missing from the early windows. The query now pads its range with a lead-in and drops the warmup rows.
- **Short RTT events survive reload** - Dropped the 60s moving average that flattened real events (e.g. a speed test bufferbloat hump) out of the primed history. The per-target aggregation already eliminates the sawtooth it was masking.
- **Smooth horizontal scrolling** - The live window redraws at 250ms instead of 500ms so the chart slides instead of visibly ticking. Historic playback gets the same treatment: between the once-per-second playback seeks, the chart interpolates the playhead at the map''s current playback speed and redraws from the already-fetched buffer. Draw-only - no extra polling or fetches.
- **Stable time labels** - The built-in x-axis labels kept re-snapping between :00 | :20 | :40 and :10 | :30 | :50 alignments as the window slid. They are replaced by annotation labels pinned to a fixed 20s grid (60s on narrow/mobile charts) showing full 24-hour HH:mm:ss, rendered below the axis and scrolling with the data.
- **No data gap when scrubbing near live** - The historic fetch was centered on the seek time while the axis shows a trailing 5min window clamped to now, so seeking slightly behind live left the first minutes of the chart empty. The fetch now covers the window the axis actually displays.

## Live View maps

- **Controls legend on the 2D map** - Collapsible legend matching the 3D map''s, limited to the interactions the 2D view supports (pan, zoom, hover, open client, pause/scrub, fullscreen). Scrub rows are omitted on the dashboard mini-map where the scrubber is hidden.
- **Standard collapsible panels** - The 3D map''s Controls legend now uses the same title-click collapse pattern as the Filter and Overlays panels (chevron title, collapsing body) instead of a custom toggle button, and the collapse chevrons on all map panels sit closer to the pill edge.
- **Keyboard scrubbing works while viewing the 2D map** - Space and arrow-key scrubbing previously went dead once the 3D canvas scrolled out of view. Scrub keys now also register while the 2D map is on screen; camera keys (WASD/QE) still require the 3D canvas in view.
- **Paused state is visible** - Pausing in live mode now shows "Live (Paused)" on the scrubber time label on both maps instead of continuing to read "Live" over frozen rates.
- **2D speed label updates instantly** - The 3D speed buttons only published their state on the next playback tick, so the 2D mirror''s speed label lagged up to a second - or indefinitely while paused. Speed changes now publish immediately.