### PR TITLE
Fix Motorola HNAP cable modem login (MB8611/MB8600)

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -786,7 +786,7 @@
             <!-- Manual Add Form (collapsed by default, expands when editing) -->
             <details class="add-form" open="@modemFormExpanded">
                 <summary @onclick="() => modemFormExpanded = !modemFormExpanded">@(editingModem?.Id > 0 ? "Edit Modem" : "Add Modem Manually")</summary>
-                <div>
+                <div class="add-form-content">
                     <p class="form-help" style="margin-bottom: 1rem;">
                         Only use manual entry if auto-discovery doesn't find your modem.
                     </p>
@@ -990,7 +990,7 @@
 
             <details class="add-form" open="@_cmFormVisible">
                 <summary @onclick="() => _cmFormVisible = !_cmFormVisible">@(_editingCm.Id > 0 ? "Edit Cable Modem" : "Add Cable Modem")</summary>
-                <div style="padding-top: 0.5rem;">
+                <div class="add-form-content">
                     <div class="form-row">
                         <div class="form-group" style="flex: 2;">
                             <label class="form-label">Name</label>
@@ -1150,7 +1150,7 @@
 
             <details class="add-form" open="@_ontFormVisible">
                 <summary @onclick="() => _ontFormVisible = !_ontFormVisible">@(_editingOnt.Id > 0 ? "Edit ONT" : "Add ONT")</summary>
-                <div style="padding-top: 0.5rem;">
+                <div class="add-form-content">
                     <div class="form-row">
                         <div class="form-group" style="flex: 2;">
                             <label class="form-label">Name</label>

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -786,7 +786,7 @@
             <!-- Manual Add Form (collapsed by default, expands when editing) -->
             <details class="add-form" open="@modemFormExpanded">
                 <summary @onclick="() => modemFormExpanded = !modemFormExpanded">@(editingModem?.Id > 0 ? "Edit Modem" : "Add Modem Manually")</summary>
-                <div style="padding-top: 0.5rem;">
+                <div>
                     <p class="form-help" style="margin-bottom: 1rem;">
                         Only use manual entry if auto-discovery doesn't find your modem.
                     </p>

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -990,7 +990,7 @@
 
             <details class="add-form" open="@_cmFormVisible">
                 <summary @onclick="() => _cmFormVisible = !_cmFormVisible">@(_editingCm.Id > 0 ? "Edit Cable Modem" : "Add Cable Modem")</summary>
-                <div class="add-form-content">
+                <div class="add-form-content add-form-content-spaced">
                     <div class="form-row">
                         <div class="form-group" style="flex: 2;">
                             <label class="form-label">Name</label>
@@ -1150,7 +1150,7 @@
 
             <details class="add-form" open="@_ontFormVisible">
                 <summary @onclick="() => _ontFormVisible = !_ontFormVisible">@(_editingOnt.Id > 0 ? "Edit ONT" : "Add ONT")</summary>
-                <div class="add-form-content">
+                <div class="add-form-content add-form-content-spaced">
                     <div class="form-row">
                         <div class="form-group" style="flex: 2;">
                             <label class="form-label">Name</label>

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -784,8 +784,8 @@
             }
 
             <!-- Manual Add Form (collapsed by default, expands when editing) -->
-            <details style="margin-top: 1.5rem;" open="@modemFormExpanded">
-                <summary style="cursor: pointer; font-weight: 500;" @onclick="() => modemFormExpanded = !modemFormExpanded">@(editingModem?.Id > 0 ? "Edit Modem" : "Add Modem Manually")</summary>
+            <details class="add-form" open="@modemFormExpanded">
+                <summary @onclick="() => modemFormExpanded = !modemFormExpanded">@(editingModem?.Id > 0 ? "Edit Modem" : "Add Modem Manually")</summary>
                 <div style="padding-top: 0.5rem;">
                     <p class="form-help" style="margin-bottom: 1rem;">
                         Only use manual entry if auto-discovery doesn't find your modem.
@@ -988,8 +988,8 @@
                 <p class="empty-state">No cable modems configured. Add one below to start monitoring DOCSIS signal levels.</p>
             }
 
-            <details style="margin-top: 1.5rem;" open="@_cmFormVisible">
-                <summary style="cursor: pointer; font-weight: 500;" @onclick="() => _cmFormVisible = !_cmFormVisible">@(_editingCm.Id > 0 ? "Edit Cable Modem" : "Add Cable Modem")</summary>
+            <details class="add-form" open="@_cmFormVisible">
+                <summary @onclick="() => _cmFormVisible = !_cmFormVisible">@(_editingCm.Id > 0 ? "Edit Cable Modem" : "Add Cable Modem")</summary>
                 <div style="padding-top: 0.5rem;">
                     <div class="form-row">
                         <div class="form-group" style="flex: 2;">
@@ -1148,8 +1148,8 @@
                 <p class="empty-state">No ONTs configured. Add one below to start monitoring fiber optics readings.</p>
             }
 
-            <details style="margin-top: 1.5rem;" open="@_ontFormVisible">
-                <summary style="cursor: pointer; font-weight: 500;" @onclick="() => _ontFormVisible = !_ontFormVisible">@(_editingOnt.Id > 0 ? "Edit ONT" : "Add ONT")</summary>
+            <details class="add-form" open="@_ontFormVisible">
+                <summary @onclick="() => _ontFormVisible = !_ontFormVisible">@(_editingOnt.Id > 0 ? "Edit ONT" : "Add ONT")</summary>
                 <div style="padding-top: 0.5rem;">
                     <div class="form-row">
                         <div class="form-group" style="flex: 2;">

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/MotorolaHnapProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/MotorolaHnapProvider.cs
@@ -114,7 +114,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
 
             return stats;
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/MotorolaHnapProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/MotorolaHnapProvider.cs
@@ -4,7 +4,6 @@ using System.Net;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
-using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
 
@@ -29,6 +28,14 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
     private const char ColumnDelimiter = '^';
     private const int TimeoutSeconds = 15;
 
+    /// <summary>
+    /// How long to suspend automatic login retries after a failed login. Newer Motorola
+    /// firmware (e.g. 8611-19.2.x, 8600-19.3.x) bans the client after 3 failed attempts
+    /// by silently dropping packets for 5 minutes, so retrying on every poll would keep
+    /// the lockout tripped forever and every request would surface as a timeout.
+    /// </summary>
+    private static readonly TimeSpan LoginFailureBackoff = TimeSpan.FromMinutes(5);
+
     private readonly ILogger<MotorolaHnapProvider> _logger;
 
     /// <summary>
@@ -36,6 +43,12 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
     /// Each session holds the derived private key and cookies for reuse across polls.
     /// </summary>
     private readonly ConcurrentDictionary<int, HnapSession> _sessions = new();
+
+    /// <summary>
+    /// Per-config timestamps until which automatic login attempts are suspended
+    /// after a login failure, to avoid tripping the modem's 3-strike lockout.
+    /// </summary>
+    private readonly ConcurrentDictionary<int, DateTime> _loginBackoffUntil = new();
 
     public MotorolaHnapProvider(ILogger<MotorolaHnapProvider> logger)
     {
@@ -51,6 +64,19 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         {
             _logger.LogWarning("Motorola HNAP poll requested but Host is empty (config {Id})", context.Id);
             return null;
+        }
+
+        if (_loginBackoffUntil.TryGetValue(context.Id, out var backoffUntil))
+        {
+            if (DateTime.UtcNow < backoffUntil)
+            {
+                _logger.LogDebug(
+                    "Motorola HNAP {Name}: skipping poll until {Until:HH:mm:ss} UTC after login failure",
+                    context.Name, backoffUntil);
+                return null;
+            }
+
+            _loginBackoffUntil.TryRemove(context.Id, out _);
         }
 
         try
@@ -135,6 +161,11 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
 
             return (true, $"Connected via HNAP - {dsCount} downstream, {usCount} upstream channels detected");
         }
+        catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return (false, "Connection timed out. The modem may be in its 5-minute lockout after " +
+                "failed login attempts (it drops packets while locked out). Wait 5 minutes and try again.");
+        }
         catch (Exception ex)
         {
             return (false, $"Connection failed: {ex.Message}");
@@ -200,6 +231,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         var result = loginResp.GetProperty("LoginResult").GetString();
         if (result == "FAILED")
         {
+            _loginBackoffUntil[context.Id] = DateTime.UtcNow + LoginFailureBackoff;
             _logger.LogWarning(
                 "Motorola HNAP {Name}: login locked out. Wait 5 minutes before retrying", context.Name);
             return null;
@@ -227,7 +259,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         {
             Login = new
             {
-                Action = "request",
+                Action = "login",
                 Username = username,
                 LoginPassword = loginPassword,
                 Captcha = "",
@@ -236,7 +268,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         };
 
         var session = new HnapSession(privateKey, uid);
-        ApplySessionCookies(client, context.Host, session);
+        ApplySessionCookies(client, session);
 
         using var phase2Response = await PostHnapAsync(
             client, endpoint, "Login", privateKey, authPayload, cancellationToken);
@@ -247,14 +279,21 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         if (!phase2Response.RootElement.TryGetProperty("LoginResponse", out var authResp))
             return null;
 
+        // Firmware returns OK on success or OK_CHANGED when a password change is being
+        // forced; both grant a valid session. FAILED/AUTH_FAIL count toward the modem's
+        // 3-strike lockout, so back off before retrying.
         var authResult = authResp.GetProperty("LoginResult").GetString();
-        if (authResult != "OK")
+        if (authResult != "OK" && authResult != "OK_CHANGED")
         {
-            _logger.LogWarning("Motorola HNAP {Name}: login authentication failed (result: {Result})",
-                context.Name, authResult);
+            _loginBackoffUntil[context.Id] = DateTime.UtcNow + LoginFailureBackoff;
+            _logger.LogWarning(
+                "Motorola HNAP {Name}: login authentication failed (result: {Result}). " +
+                "Suspending retries for {Minutes} minutes to avoid the modem's failed-login lockout",
+                context.Name, authResult, LoginFailureBackoff.TotalMinutes);
             return null;
         }
 
+        _loginBackoffUntil.TryRemove(context.Id, out _);
         _logger.LogDebug("Motorola HNAP {Name}: logged in successfully", context.Name);
         return session;
     }
@@ -268,6 +307,10 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         string[] actions, CancellationToken cancellationToken)
     {
         var endpoint = baseUrl + HnapPath;
+
+        // Each poll uses a fresh HttpClient, so re-apply the session cookies here
+        // rather than relying on the client that performed the login.
+        ApplySessionCookies(client, session);
 
         var innerDict = new Dictionary<string, string>();
         foreach (var action in actions)
@@ -307,7 +350,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         using var request = new HttpRequestMessage(HttpMethod.Post, endpoint);
         request.Content = content;
         request.Headers.TryAddWithoutValidation("HNAP_AUTH", hnapAuth);
-        request.Headers.TryAddWithoutValidation("SOAPACTION", soapAction);
+        request.Headers.TryAddWithoutValidation("SOAPAction", soapAction);
         request.Headers.TryAddWithoutValidation("X-Requested-With", "XMLHttpRequest");
 
         try
@@ -491,7 +534,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         return Convert.ToHexString(hash);
     }
 
-    private static void ApplySessionCookies(HttpClient client, string host, HnapSession session)
+    private static void ApplySessionCookies(HttpClient client, HnapSession session)
     {
         // The modem expects PrivateKey and uid cookies
         var cookieValues = new List<string>();
@@ -542,10 +585,18 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         return double.TryParse(cleaned, NumberStyles.Float, CultureInfo.InvariantCulture, out var val) ? val : null;
     }
 
+    /// <summary>
+    /// Parse a channel table frequency into Hz. Motorola tables report frequency in MHz
+    /// with a decimal point (e.g. "711.0"); some firmware reports raw Hz (e.g. "711000000").
+    /// Values below 100,000 are treated as MHz.
+    /// </summary>
     private static long ParseFrequency(string text)
     {
         var cleaned = StripUnits(text);
-        return long.TryParse(cleaned, out var val) ? val : 0;
+        if (!double.TryParse(cleaned, NumberStyles.Float, CultureInfo.InvariantCulture, out var val))
+            return 0;
+
+        return val < 100_000 ? (long)(val * 1_000_000) : (long)val;
     }
 
     private static string StripUnits(string text)
@@ -571,6 +622,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
     public void Dispose()
     {
         _sessions.Clear();
+        _loginBackoffUntil.Clear();
     }
 
     private sealed record HnapSession(string PrivateKey, string? Uid);

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -6731,7 +6731,7 @@ a.path-hop.hop-clickable:hover {
 }
 
 .add-form-content {
-    padding: 0.25rem 0 0.5rem;
+    padding-top: 0.25rem;
 }
 
 .add-form-content-spaced {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -6726,7 +6726,7 @@ a.path-hop.hop-clickable:hover {
 .add-form summary {
     cursor: pointer;
     font-weight: 500;
-    font-size: 0.85rem;
+    font-size: 0.875rem;
 }
 
 .setup-guide-content ol,

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -6663,6 +6663,7 @@ a.path-hop.hop-clickable:hover {
     padding: 0.75rem 1rem;
     cursor: pointer;
     font-weight: 500;
+    font-size: 0.9rem;
     color: var(--text-secondary);
     user-select: none;
     list-style: none;
@@ -6715,6 +6716,16 @@ a.path-hop.hop-clickable:hover {
 
 .setup-guide-content p {
     margin: 0.5rem 0;
+}
+
+.add-form {
+    margin-top: 1.5rem;
+}
+
+.add-form summary {
+    cursor: pointer;
+    font-weight: 500;
+    font-size: 0.85rem;
 }
 
 .setup-guide-content ol,

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -6727,7 +6727,11 @@ a.path-hop.hop-clickable:hover {
     cursor: pointer;
     font-weight: 500;
     font-size: 0.875rem;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.25rem;
+}
+
+.add-form-content {
+    padding: 0.25rem 0 0.5rem;
 }
 
 .setup-guide-content ol,

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -4111,6 +4111,7 @@ select.form-control {
     text-align: center;
     padding: 3rem 2rem;
     color: var(--text-secondary);
+    font-size: 0.92rem;
 }
 
 .empty-state .empty-icon {
@@ -6719,7 +6720,7 @@ a.path-hop.hop-clickable:hover {
 }
 
 .add-form {
-    margin-top: 1.5rem;
+    margin-top: 1.25rem;
 }
 
 .add-form summary {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -6727,6 +6727,7 @@ a.path-hop.hop-clickable:hover {
     cursor: pointer;
     font-weight: 500;
     font-size: 0.875rem;
+    margin-bottom: 0.5rem;
 }
 
 .setup-guide-content ol,

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -6734,6 +6734,10 @@ a.path-hop.hop-clickable:hover {
     padding: 0.25rem 0 0.5rem;
 }
 
+.add-form-content-spaced {
+    padding-top: 0.75rem;
+}
+
 .setup-guide-content ol,
 .setup-guide-content ul {
     margin: 0.5rem 0;


### PR DESCRIPTION
Fixes the Motorola HNAP provider failing against current MB8611/MB8600 firmware (#776). Verified against HAR captures and the modem firmware's own login JavaScript.

## What was wrong

- The second login phase sent `Action: "request"` instead of `Action: "login"`, so authentication never succeeded on this firmware.
- Newer firmware locks out a client after 3 failed logins by silently dropping packets for 5 minutes. Since the poller retried on every cycle, the lockout stayed tripped permanently and every request (including Test) surfaced as a 15-second timeout.
- Each poll creates a fresh HttpClient, but session cookies were only applied to the client that performed the login, so cached sessions never validated and the provider re-authenticated on every poll.

## Changes

- Send `Action: "login"` in the authenticate phase and accept `OK_CHANGED` (forced password change) as a valid result.
- Re-apply session cookies on every HNAP call so cached sessions survive across polls.
- Back off 5 minutes after a failed login so the provider cannot trip the modem's 3-strike lockout; the Test connection timeout message now explains the lockout.
- Treat poll timeouts as poll failures (with session cleanup and logging) instead of rethrowing them as cancellation.
- Send the `SOAPAction` header with the same casing as the modem's web UI and parse decimal-MHz channel frequencies ("711.0") into Hz.

## Settings styling

- The manual add/edit forms (Modem, Cable Modem, ONT) now share common `add-form` styles instead of repeated inline styles, with refined font sizes and spacing for the form toggles, setup guide summaries, and empty states.