### PR TITLE
ISP Health: dashboard polish, scoring refinements, and chart improvements

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -85,6 +85,7 @@ else
         </button>
     </div>
     <div class="isp-health-hero card">
+        <span class="isp-health-updated">Last updated: @TimeFormatHelper.FormatRelativeTimeShort(r.ComputedAt)</span>
         <div class="card-body isp-health-hero-body">
             <div class="isp-health-hero-gauge">
                 <IspHealthScoreGauge Score="r.OverallScore" Label="ISP Health" />
@@ -98,6 +99,14 @@ else
                     <span class="isp-speed-measured">@FormatSpeed(r.MeasuredDownloadMbps) / @FormatSpeed(r.MeasuredUploadMbps)</span>
                     <span class="isp-speed-unit">Mbps</span>
                 </div>
+                @if (r.SpeedTestTime.HasValue)
+                {
+                    <div class="isp-speed-tested">Best &middot; @TimeFormatHelper.FormatRelativeTimeShort(r.SpeedTestTime.Value)</div>
+                }
+                else
+                {
+                    <div class="isp-speed-tested">No recent WAN speed test</div>
+                }
                 @if (r.TypicalDownloadMbps.HasValue || r.TypicalUploadMbps.HasValue)
                 {
                     <div class="isp-speed-sub">
@@ -105,17 +114,16 @@ else
                         <span>@FormatSpeed(r.TypicalDownloadMbps) / @FormatSpeed(r.TypicalUploadMbps) Mbps</span>
                     </div>
                 }
-                else if (!(r.ExpectedDownloadMbps.HasValue || r.ExpectedUploadMbps.HasValue))
+                @if (r.ExpectedDownloadMbps.HasValue || r.ExpectedUploadMbps.HasValue)
+                {
+                    <div class="isp-speed-sub">
+                        <span class="isp-speed-sub-label">Plan</span>
+                        <span>@FormatSpeed(r.ExpectedDownloadMbps) / @FormatSpeed(r.ExpectedUploadMbps) Mbps</span>
+                    </div>
+                }
+                else if (!(r.TypicalDownloadMbps.HasValue || r.TypicalUploadMbps.HasValue))
                 {
                     <div class="isp-speed-sub">Set your ISP speeds in UniFi Network to grade throughput</div>
-                }
-                @if (r.SpeedTestTime.HasValue)
-                {
-                    <div class="isp-speed-tested" data-tooltip="Best download and best upload from your recent WAN speed tests; each may come from a different test.">Best &middot; @FormatAge(r.SpeedTestTime.Value)</div>
-                }
-                else
-                {
-                    <div class="isp-speed-tested">No recent WAN speed test</div>
                 }
             </div>
             <div class="isp-health-hero-dimensions">
@@ -392,14 +400,6 @@ else
     private static string FormatRtt(double? ms) => ms.HasValue ? $"{ms.Value:0.0} ms" : "--";
 
     private static string FormatLossPct(double? pct) => pct switch { null => "--", 0 => "0%", _ => $"{pct.Value:0.##}%" };
-
-    private string FormatAge(DateTime utc)
-    {
-        var age = DateTime.UtcNow - utc;
-        if (age.TotalHours < 1) return $"{Math.Max(1, (int)age.TotalMinutes)} min ago";
-        if (age.TotalDays < 1) return $"{(int)age.TotalHours} h ago";
-        return $"{(int)age.TotalDays} d ago";
-    }
 
     private static string IssueClass(IspIssueSeverity severity) => severity switch
     {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -263,9 +263,9 @@ public class IspHealthScorer
         var mid = (profile.IdleRttNormalLowMs + profile.IdleRttNormalHighMs) / 2.0;
         var score = ScoreCurve.Interpolate(idleBaseline.Value,
             (profile.IdleRttIdealMs, 100),
-            (profile.IdleRttNormalLowMs, 88),
-            (mid, 75),
-            (profile.IdleRttNormalHighMs, 62),
+            (profile.IdleRttNormalLowMs, 92),
+            (mid, 84),
+            (profile.IdleRttNormalHighMs, 75),
             (profile.IdleRttPoorMs, 25),
             (profile.IdleRttPoorMs * 2, 0));
 
@@ -712,6 +712,18 @@ public class IspHealthScorer
                 Title = "Throughput below plan",
                 Description = $"The best WAN speed test ({speedFactor.ValueText}) falls well short of the {FormatMbps(inputs.ExpectedDownloadMbps ?? 0)} / {FormatMbps(inputs.ExpectedUploadMbps ?? 0)} Mbps plan configured in UniFi Network.",
                 Recommendation = "If the configured plan speeds are right, raise the shortfall with your ISP. If the plan changed, update the ISP speeds in UniFi Network so grading stays accurate."
+            });
+        }
+
+        var idleLatencyFactor = report.AccessDimension.Factors.FirstOrDefault(f => f.Name == "Idle Latency");
+        if (idleLatencyFactor?.Score is < 75)
+        {
+            issues.Add(new IspHealthIssue
+            {
+                Severity = IspIssueSeverity.Info,
+                Title = "Idle latency above normal",
+                Description = $"Baseline first-hop latency of {idleLatencyFactor.ValueText} is above the normal range for {profile.DisplayName}.",
+                Recommendation = "Common causes: access layer congestion or overprovisioning by the ISP, CPE inefficiency (try a reboot or firmware update), or a longer-than-expected physical haul to the first hop."
             });
         }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -83,6 +83,9 @@ public class IspHealthService
             if (!forceRefresh && cached != null && DateTime.UtcNow - cached.ComputedAt < _options.CacheTtl)
                 return cached;
 
+            if (forceRefresh)
+                _connectionService.ClearCaches();
+
             _computing = true;
             var (report, chartClusters) = await ComputeAsync(ct);
             if (report != null) _cached = new Snapshot(report, chartClusters);

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15160,6 +15160,15 @@ a.affected-client:hover {
     margin-bottom: 0.75rem;
 }
 
+.isp-health-updated {
+    position: absolute;
+    top: 0.6rem;
+    right: 0.75rem;
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    z-index: 1;
+}
+
 .isp-health-hero {
     position: relative;
     margin-bottom: 1rem;
@@ -15528,7 +15537,16 @@ a.affected-client:hover {
     }
 }
 
+#isp-health-asn-chart {
+    margin-left: -7px;
+    margin-right: -2px;
+}
+
 @media (max-width: 768px) {
+    #isp-health-asn-chart {
+        margin-left: 0;
+        margin-right: 0;
+    }
     .isp-health-hero-body {
         grid-template-columns: 1fr;
         gap: 1.25rem;
@@ -15540,15 +15558,28 @@ a.affected-client:hover {
     }
     .isp-health-hero-dimensions {
         gap: 0.4rem;
+        flex-wrap: wrap;
+        justify-content: center;
+        margin-left: -1.75rem;
+        margin-right: -1.75rem;
     }
     .isp-gauge-small {
-        width: 104px;
+        width: min(115px, 28vw);
+    }
+    .isp-gauge-small .isp-gauge-label {
+        font-size: 19px;
     }
     .isp-event-timeline {
         padding-left: 0.75rem;
     }
     .isp-event-item::before {
         left: calc(-0.75rem - 7.5px);
+    }
+}
+
+@media (max-width: 338px) {
+    .isp-gauge-small {
+        width: 115px;
     }
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/isp-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/isp-health-charts.js
@@ -21,6 +21,7 @@ function buildOpts() {
             background: 'transparent',
             toolbar: { show: false },
             zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            parentHeightOffset: 0,
             animations: { enabled: false },
             events: {
                 zoomed: (ctx, opts) => setZoomed(opts?.xaxis?.min != null),
@@ -40,13 +41,29 @@ function buildOpts() {
         },
         yaxis: {
             min: 0,
-            title: { text: 'ms', style: { color: '#9ca3af' } },
+            title: { text: 'ms', style: { color: '#9ca3af', fontSize: '9px' } },
             labels: {
-                style: { colors: '#9ca3af' },
+                style: { colors: '#9ca3af', fontSize: '10px' },
                 formatter: v => v != null ? v.toFixed(1) : '',
             },
+            axisBorder: { show: false },
+            axisTicks: { show: false },
         },
-        grid: { borderColor: '#374151', strokeDashArray: 3 },
+        grid: {
+            borderColor: '#374151',
+            strokeDashArray: 3,
+            padding: { right: 6, top: -8, bottom: 0 },
+        },
+        responsive: [{
+            breakpoint: 768,
+            options: {
+                yaxis: {
+                    min: 0,
+                    show: false,
+                },
+                grid: { padding: { left: -5, right: -5, top: -8, bottom: 0 } },
+            },
+        }],
         legend: { show: true, labels: { colors: '#9ca3af' } },
         tooltip: {
             theme: 'dark',

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -86,7 +86,7 @@ public class IspHealthScorerTests
         var report = new IspHealthScorer(Options).Score(BuildInputs(idleRtt: 2.5), Gpon);
 
         var factor = report.AccessDimension.Factors.Single(f => f.Name == "Idle Latency");
-        factor.Score.Should().Be(75);
+        factor.Score.Should().Be(84);
     }
 
     [Fact]
@@ -141,7 +141,7 @@ public class IspHealthScorerTests
             .AccessDimension.Factors.Single(f => f.Name == "Idle Latency").Score;
 
         low.Should().Be(100);
-        high.Should().BeLessThan(62);
+        high.Should().BeLessThan(75);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- **Plan speed row** - Show the ISP plan speed (from UniFi Network WAN config) below Typical in the Speed vs Plan section, giving users a clear best/typical/plan comparison
- **Speed section reorder** - Move "Best · X ago" directly under the headline speed for better visual hierarchy
- **Last updated timestamp** - "Last updated: X ago" in the hero card upper right, using the standard relative time formatter
- **Mobile dimension gauges** - Fix overflow that shifted content right on narrow viewports. Gauges scale with `min(115px, 28vw)`, wrap 2+1 below ~380px, and restore full size at 338px. Negative margins bust card padding for more breathing room.
- **Per-network RTT chart** - Tighter horizontal fill on desktop and mobile. Y axis hidden on mobile with negative grid padding so the chart goes edge-to-edge.
- **Cache bust on refresh** - The Refresh button now clears the UniFi network config cache so freshly configured ISP speeds are picked up immediately instead of waiting through two stacked 5-minute caches
- **Idle latency scoring curve** - Reshaped so the top of the normal operating range (e.g. 3.0 ms on GPON) scores 75 instead of 62. All access technologies benefit.
- **Idle latency finding** - New info-level finding when idle latency exceeds the normal band, pointing at ISP overprovisioning, CPE inefficiency, or longer-than-expected physical haul