### PR TITLE
v1.20.2 TBD

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -298,6 +298,23 @@ else
         <div class="card-header"><h2 class="card-title">Per-Network RTT (@WindowLabel(r))</h2></div>
         <div class="card-body">
             <div id="isp-health-asn-chart"></div>
+
+            @{ var ispAsn = r.IspAsns.FirstOrDefault(a => a.AsnNumber > 0); }
+            @if (ispAsn != null)
+            {
+                <details class="setup-guide" style="margin-top: 1.25rem;">
+                    <summary>Dig deeper with BGP tools</summary>
+                    <div class="setup-guide-content">
+                        <p>The chart above tracks latency to the networks (autonomous systems) your traffic passes through. Your ISP is <strong>@(string.IsNullOrEmpty(ispAsn.AsnName) ? $"AS{ispAsn.AsnNumber}" : ispAsn.AsnName) (AS@(ispAsn.AsnNumber))</strong>. Transit networks are the backbone providers your ISP peers with to reach the rest of the internet.</p>
+                        <p>BGP (Border Gateway Protocol) is how these networks decide where to send your traffic. A path shift in the chart above means your ISP or a transit provider changed the route. These tools let you explore peering, prefixes, and routing for any AS:</p>
+                        <ul>
+                            <li><a href="https://bgp.he.net/AS@(ispAsn.AsnNumber)" target="_blank" rel="noopener">HE BGP Toolkit</a> - Peering, prefixes, and routing details. The go-to tool for most network engineers.</li>
+                            <li><a href="https://bgp.tools/as/@(ispAsn.AsnNumber)" target="_blank" rel="noopener">bgp.tools</a> - Clean overview of upstreams, downstreams, peers, and historical routing in one page.</li>
+                            <li><a href="https://stat.ripe.net/app/launchpad/AS@(ispAsn.AsnNumber)" target="_blank" rel="noopener">RIPE RIPEstat</a> - Authoritative data from RIPE NCC. Routing status, prefix announcements, and historical BGP data for any ASN worldwide.</li>
+                        </ul>
+                    </div>
+                </details>
+            }
         </div>
     </div>
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -125,14 +125,11 @@ public class IspHealthOptions
     /// <summary>Window size in minutes for step-change median comparison.</summary>
     public int StepWindowMinutes { get; set; } = 30;
 
-    /// <summary>
-    /// Absolute floor in ms for a step-change candidate delta. Tuned against real
-    /// transit shifts of ~2.7-3.1 ms on 8-18 ms paths; 3.0 missed them.
-    /// </summary>
-    public double StepMinDeltaMs { get; set; } = 2.0;
+    /// <summary>Absolute floor in ms for a step-change candidate delta.</summary>
+    public double StepMinDeltaMs { get; set; } = 1.5;
 
     /// <summary>Relative floor (fraction of the before-median) for a step-change candidate delta.</summary>
-    public double StepMinRelativeChange { get; set; } = 0.15;
+    public double StepMinRelativeChange { get; set; } = 0.06;
 
     /// <summary>Number of subsequent windows that must hold the new level to confirm a step.</summary>
     public int StepPersistenceWindows { get; set; } = 3;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -6719,6 +6719,11 @@ a.path-hop.hop-clickable:hover {
     margin: 0.5rem 0;
 }
 
+.setup-guide-content a,
+.setup-guide-content a:visited {
+    color: var(--primary-color);
+}
+
 .add-form {
     margin-top: 1.25rem;
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -6724,6 +6724,10 @@ a.path-hop.hop-clickable:hover {
     color: var(--primary-color);
 }
 
+.setup-guide-content a:hover {
+    color: var(--primary-hover);
+}
+
 .add-form {
     margin-top: 1.25rem;
 }


### PR DESCRIPTION
## Summary

- **Lower step-change detection thresholds** - `StepMinDeltaMs` from 2.0 to 1.5 ms, `StepMinRelativeChange` from 15% to 6%, so ISP Health catches smaller path/transit shifts on higher-latency paths (e.g. a 1.5 ms step on a 24 ms baseline was previously masked by the 15% relative gate requiring 3.6 ms)

## Test plan

- [x] Deployed to NAS and Mac
- [x] Observe ISP Health timeline for step-change events over the next 24-48 h
- [x] Verify no false-positive step detections from normal jitter