### PR TITLE
Add Xfinity XB8/XB10 cable modem provider

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1003,6 +1003,7 @@
                                 <option value="arris-surfboard">ARRIS Surfboard (HTTP)</option>
                                 <option value="arris-surfboard-hnap">ARRIS Surfboard S33/S34 (HNAP)</option>
                                 <option value="motorola-hnap">Motorola MB8611, MB8600 (HNAP)</option>
+                                <option value="xfinity-gateway">Xfinity XB8, XB10 (HTTP)</option>
                             </select>
                         </div>
                     </div>
@@ -4184,6 +4185,7 @@
         "arris-surfboard" => "ARRIS Surfboard (HTTP)",
         "arris-surfboard-hnap" => "ARRIS Surfboard S33/S34 (HNAP)",
         "motorola-hnap" => "Motorola (HNAP)",
+        "xfinity-gateway" => "Xfinity Gateway (HTTP)",
         _ => provider,
     };
 
@@ -4192,6 +4194,7 @@
         "arris-surfboard" => "/cgi-bin/status",
         "arris-surfboard-hnap" => "N/A (uses /HNAP1/)",
         "motorola-hnap" => "N/A (uses /HNAP1/)",
+        "xfinity-gateway" => "/network_setup.jst",
         _ => "/DocsisStatus.htm",
     };
 

--- a/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
@@ -69,7 +69,7 @@
                 <span class="status-label">No Data</span>
             </div>
             <p class="status-message">
-                Monitor your cable modem's downstream power, SNR, upstream power, and FEC error rates. Supports Netgear, ARRIS Surfboard, and Motorola modems.
+                Monitor your cable modem's downstream power, SNR, upstream power, and FEC error rates. Supports Netgear, ARRIS Surfboard, Motorola, and Xfinity modems.
             </p>
             <div class="sqm-actions">
                 <a href="/settings#cable-modem" class="btn btn-primary" @onclick:stopPropagation>Configure CM</a>

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -195,6 +195,7 @@ builder.Services.AddSingleton<ICableModemProvider, NetgearCmProvider>();
 builder.Services.AddSingleton<ICableModemProvider, ArrisSurfboardHttpProvider>();
 builder.Services.AddSingleton<ICableModemProvider, ArrisSurfboardHnapProvider>();
 builder.Services.AddSingleton<ICableModemProvider, MotorolaHnapProvider>();
+builder.Services.AddSingleton<ICableModemProvider, XfinityGatewayProvider>();
 builder.Services.AddSingleton<CableModemMonitorService>();
 
 // Register External ONT providers and service

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
@@ -6,7 +6,7 @@ using NetworkOptimizer.Monitoring.Providers;
 namespace NetworkOptimizer.Web.Services.CableModemProviders;
 
 /// <summary>
-/// Cable modem provider for Xfinity gateways (XB6, XB7, XB8, XB10, etc.).
+/// Cable modem provider for Xfinity gateways (XB8, XB10).
 /// Authenticates via form POST to /check.jst, then scrapes DOCSIS channel
 /// tables from /network_setup.jst. The tables use a transposed layout where
 /// each row is a metric and each column is a channel.
@@ -337,7 +337,9 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
         metricRows.TryGetValue("correctablecodewords", out var correctables);
         metricRows.TryGetValue("uncorrectablecodewords", out var uncorrectables);
 
-        var dsLookup = stats.DownstreamChannels.ToDictionary(c => c.ChannelId);
+        var dsLookup = new Dictionary<int, DsChannel>();
+        foreach (var ch in stats.DownstreamChannels)
+            dsLookup.TryAdd(ch.ChannelId, ch);
 
         for (int i = 0; i < channelIds.Count; i++)
         {

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
@@ -1,0 +1,521 @@
+using System.Net;
+using HtmlAgilityPack;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Monitoring.Providers;
+
+namespace NetworkOptimizer.Web.Services.CableModemProviders;
+
+/// <summary>
+/// Cable modem provider for Xfinity gateways (XB6, XB7, XB8, XB10, etc.).
+/// Authenticates via form POST to /check.jst, then scrapes DOCSIS channel
+/// tables from /network_setup.jst. The tables use a transposed layout where
+/// each row is a metric and each column is a channel.
+/// </summary>
+public sealed class XfinityGatewayProvider : ICableModemProvider
+{
+    /// <inheritdoc/>
+    public string ProviderKey => "xfinity-gateway";
+
+    /// <inheritdoc/>
+    public string DisplayName => "Xfinity Gateway (HTTP)";
+
+    private const string DefaultStatusPath = "/network_setup.jst";
+    private const string LoginPath = "/check.jst";
+    private const int TimeoutSeconds = 15;
+    private const int MaxRetries = 3;
+    private static readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(1);
+
+    private readonly ILogger<XfinityGatewayProvider> _logger;
+
+    public XfinityGatewayProvider(ILogger<XfinityGatewayProvider> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<CableModemStats?> PollAsync(
+        CmPollContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+        {
+            _logger.LogWarning("Xfinity Gateway poll requested but Host is empty (config {Id})", context.Id);
+            return null;
+        }
+
+        for (int attempt = 1; attempt <= MaxRetries; attempt++)
+        {
+            try
+            {
+                var html = await FetchStatusPageAsync(context, cancellationToken);
+                if (html == null)
+                {
+                    _logger.LogWarning(
+                        "Xfinity Gateway at {Host} returned empty response (attempt {Attempt}/{Max})",
+                        context.Host, attempt, MaxRetries);
+                    if (attempt < MaxRetries)
+                    {
+                        await Task.Delay(RetryDelay, cancellationToken);
+                        continue;
+                    }
+                    return null;
+                }
+
+                var stats = ParseNetworkSetup(html, context);
+                _logger.LogDebug(
+                    "Xfinity Gateway {Name} polled: {DsCount} DS channels, {UsCount} US channels",
+                    context.Name, stats.DownstreamChannels.Count, stats.UpstreamChannels.Count);
+                return stats;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (HttpRequestException ex) when (attempt < MaxRetries)
+            {
+                _logger.LogDebug(
+                    ex, "Transient error polling Xfinity Gateway {Name} (attempt {Attempt}/{Max})",
+                    context.Name, attempt, MaxRetries);
+                await Task.Delay(RetryDelay, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error polling Xfinity Gateway {Name} at {Host}", context.Name, context.Host);
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    /// <inheritdoc/>
+    public async Task<(bool Success, string Message)> TestConnectionAsync(
+        CmPollContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+            return (false, "Host is empty");
+
+        try
+        {
+            var html = await FetchStatusPageAsync(context, cancellationToken);
+            if (html == null)
+                return (false, "No response from gateway - check host and credentials");
+
+            var doc = new HtmlDocument();
+            doc.LoadHtml(html);
+
+            var tables = FindChannelTables(doc);
+            if (tables.Downstream == null && tables.Upstream == null)
+                return (false, "Connected but DOCSIS channel tables not found. Is this an Xfinity gateway?");
+
+            var dsCount = CountChannelsInTransposedTable(tables.Downstream);
+            var usCount = CountChannelsInTransposedTable(tables.Upstream);
+
+            var model = ExtractProductType(doc);
+            var modelSuffix = string.IsNullOrEmpty(model) ? "" : $" ({model})";
+
+            return (true, $"Connected{modelSuffix} - {dsCount} downstream, {usCount} upstream channels detected");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Connection failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Authenticate via form POST and fetch the status page in one session.
+    /// Uses CookieContainer to carry the session cookie from login to page fetch.
+    /// </summary>
+    private async Task<string?> FetchStatusPageAsync(CmPollContext context, CancellationToken cancellationToken)
+    {
+        var port = context.Port > 0 ? context.Port : 80;
+        var portSuffix = port == 80 ? "" : $":{port}";
+        var baseUrl = $"http://{context.Host}{portSuffix}";
+
+        var statusPath = string.IsNullOrWhiteSpace(context.StatusPagePath)
+            ? DefaultStatusPath
+            : context.StatusPagePath;
+
+        using var handler = new HttpClientHandler
+        {
+            CookieContainer = new CookieContainer(),
+            AllowAutoRedirect = true,
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+        };
+        using var client = new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromSeconds(TimeoutSeconds),
+        };
+
+        var username = context.Username ?? "admin";
+        var password = context.Password ?? "";
+        var loginContent = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("username", username),
+            new KeyValuePair<string, string>("password", password),
+        });
+
+        var loginResponse = await client.PostAsync($"{baseUrl}{LoginPath}", loginContent, cancellationToken);
+
+        if (!loginResponse.IsSuccessStatusCode)
+        {
+            _logger.LogDebug("Xfinity Gateway login returned {Status} for {Host}",
+                loginResponse.StatusCode, context.Host);
+            return null;
+        }
+
+        var response = await client.GetAsync($"{baseUrl}{statusPath}", cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogDebug("Xfinity Gateway status page returned {Status} for {Host}",
+                response.StatusCode, context.Host);
+            return null;
+        }
+
+        var html = await response.Content.ReadAsStringAsync(cancellationToken);
+        if (string.IsNullOrWhiteSpace(html))
+            return null;
+
+        if (IsLoginPage(html))
+        {
+            _logger.LogDebug("Xfinity Gateway at {Host}: login failed, got redirected back to login page",
+                context.Host);
+            return null;
+        }
+
+        return html;
+    }
+
+    /// <summary>
+    /// Detect if the response is the login page rather than the status page.
+    /// The login page POSTs to check.jst.
+    /// </summary>
+    private static bool IsLoginPage(string html)
+    {
+        return html.Contains("action=\"check.jst\"", StringComparison.OrdinalIgnoreCase)
+            || html.Contains("action='/check.jst'", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private CableModemStats ParseNetworkSetup(string html, CmPollContext context)
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+
+        var stats = new CableModemStats
+        {
+            Timestamp = DateTime.UtcNow,
+            DeviceHost = context.Host,
+            DeviceName = context.Name,
+            DeviceModel = ExtractProductType(doc) ?? "Xfinity Gateway",
+        };
+
+        var tables = FindChannelTables(doc);
+
+        if (tables.Downstream != null)
+            ParseTransposedDownstreamTable(tables.Downstream, stats);
+
+        if (tables.Upstream != null)
+            ParseTransposedUpstreamTable(tables.Upstream, stats);
+
+        if (tables.ErrorCodewords != null)
+            MergeErrorCodewords(tables.ErrorCodewords, stats);
+
+        return stats;
+    }
+
+    /// <summary>
+    /// Locate the three DOCSIS tables by their header text.
+    /// Tables are inside div.netFlow containers with thead text identifying them.
+    /// </summary>
+    private static (HtmlNode? Downstream, HtmlNode? Upstream, HtmlNode? ErrorCodewords) FindChannelTables(
+        HtmlDocument doc)
+    {
+        HtmlNode? dsTable = null, usTable = null, errTable = null;
+
+        var tables = doc.DocumentNode.SelectNodes("//table[contains(@class,'data')]");
+        if (tables == null) return (null, null, null);
+
+        foreach (var table in tables)
+        {
+            var headerText = table.SelectSingleNode(".//thead")?.InnerText ?? "";
+
+            if (headerText.Contains("Downstream", StringComparison.OrdinalIgnoreCase)
+                && headerText.Contains("Channel Bonding", StringComparison.OrdinalIgnoreCase))
+            {
+                dsTable = table;
+            }
+            else if (headerText.Contains("Upstream", StringComparison.OrdinalIgnoreCase)
+                     && headerText.Contains("Channel Bonding", StringComparison.OrdinalIgnoreCase))
+            {
+                usTable = table;
+            }
+            else if (headerText.Contains("Error Codewords", StringComparison.OrdinalIgnoreCase))
+            {
+                errTable = table;
+            }
+        }
+
+        return (dsTable, usTable, errTable);
+    }
+
+    /// <summary>
+    /// Parse a transposed downstream table where each row is a metric
+    /// and each column is a channel.
+    /// Rows: Channel ID, Lock Status, Frequency, SNR, Power Level, Modulation.
+    /// </summary>
+    private void ParseTransposedDownstreamTable(HtmlNode table, CableModemStats stats)
+    {
+        var metricRows = ExtractMetricRows(table);
+        if (!metricRows.TryGetValue("channelid", out var channelIds) || channelIds.Count == 0)
+            return;
+
+        metricRows.TryGetValue("lockstatus", out var lockStatuses);
+        metricRows.TryGetValue("frequency", out var frequencies);
+        metricRows.TryGetValue("snr", out var snrs);
+        metricRows.TryGetValue("powerlevel", out var powers);
+        metricRows.TryGetValue("modulation", out var modulations);
+
+        for (int i = 0; i < channelIds.Count; i++)
+        {
+            var channel = new DsChannel
+            {
+                ChannelId = ParseInt(GetAt(channelIds, i)),
+                LockStatus = GetAt(lockStatuses, i) ?? "",
+                Frequency = ParseFrequencyWithUnits(GetAt(frequencies, i)),
+                Snr = ParseDouble(GetAt(snrs, i)),
+                Power = ParseDouble(GetAt(powers, i)),
+                Modulation = GetAt(modulations, i) ?? "",
+            };
+
+            stats.DownstreamChannels.Add(channel);
+        }
+    }
+
+    /// <summary>
+    /// Parse a transposed upstream table.
+    /// Rows: Channel ID, Lock Status, Frequency, Symbol Rate, Power Level, Modulation, Channel Type.
+    /// </summary>
+    private void ParseTransposedUpstreamTable(HtmlNode table, CableModemStats stats)
+    {
+        var metricRows = ExtractMetricRows(table);
+        if (!metricRows.TryGetValue("channelid", out var channelIds) || channelIds.Count == 0)
+            return;
+
+        metricRows.TryGetValue("lockstatus", out var lockStatuses);
+        metricRows.TryGetValue("frequency", out var frequencies);
+        metricRows.TryGetValue("symbolrate", out var symbolRates);
+        metricRows.TryGetValue("powerlevel", out var powers);
+        metricRows.TryGetValue("modulation", out var modulations);
+        metricRows.TryGetValue("channeltype", out var channelTypes);
+
+        for (int i = 0; i < channelIds.Count; i++)
+        {
+            var channel = new UsChannel
+            {
+                ChannelId = ParseInt(GetAt(channelIds, i)),
+                LockStatus = GetAt(lockStatuses, i) ?? "",
+                Frequency = ParseFrequencyWithUnits(GetAt(frequencies, i)),
+                SymbolRate = ParseLong(GetAt(symbolRates, i)),
+                Power = ParseDouble(GetAt(powers, i)),
+                ChannelType = GetAt(channelTypes, i) ?? GetAt(modulations, i) ?? "",
+            };
+
+            stats.UpstreamChannels.Add(channel);
+        }
+    }
+
+    /// <summary>
+    /// Merge error codewords from the separate table into existing DS channels by channel ID.
+    /// </summary>
+    private void MergeErrorCodewords(HtmlNode table, CableModemStats stats)
+    {
+        var metricRows = ExtractMetricRows(table);
+        if (!metricRows.TryGetValue("channelid", out var channelIds) || channelIds.Count == 0)
+            return;
+
+        metricRows.TryGetValue("correctablecodewords", out var correctables);
+        metricRows.TryGetValue("uncorrectablecodewords", out var uncorrectables);
+
+        var dsLookup = stats.DownstreamChannels.ToDictionary(c => c.ChannelId);
+
+        for (int i = 0; i < channelIds.Count; i++)
+        {
+            var chId = ParseInt(GetAt(channelIds, i));
+            if (chId > 0 && dsLookup.TryGetValue(chId, out var channel))
+            {
+                channel.Correctables = ParseLong(GetAt(correctables, i));
+                channel.Uncorrectables = ParseLong(GetAt(uncorrectables, i));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Extract metric rows from a transposed table.
+    /// Each tbody tr has a th.row-label with the metric name, followed by td values.
+    /// Returns a dictionary keyed by normalized metric name.
+    /// </summary>
+    private static Dictionary<string, List<string>> ExtractMetricRows(HtmlNode table)
+    {
+        var result = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+        var rows = table.SelectNodes(".//tbody/tr");
+        if (rows == null) return result;
+
+        foreach (var row in rows)
+        {
+            var header = row.SelectSingleNode("th");
+            if (header == null) continue;
+
+            var metricName = NormalizeHeader(header.InnerText);
+            if (string.IsNullOrEmpty(metricName)) continue;
+
+            var cells = row.SelectNodes("td");
+            if (cells == null) continue;
+
+            var values = cells
+                .Select(c =>
+                {
+                    var div = c.SelectSingleNode(".//div[contains(@class,'netWidth')]");
+                    return (div ?? c).InnerText.Trim();
+                })
+                .ToList();
+
+            result[metricName] = values;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Extract the Product Type from the Device Information section (e.g. "XB10").
+    /// </summary>
+    private static string? ExtractProductType(HtmlDocument doc)
+    {
+        var labels = doc.DocumentNode.SelectNodes("//span[contains(@class,'readonlyLabel')]");
+        if (labels == null) return null;
+
+        foreach (var label in labels)
+        {
+            if (!label.InnerText.Contains("Product Type", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var value = label.ParentNode?.SelectSingleNode(".//span[contains(@class,'value')]");
+            if (value != null)
+            {
+                var text = value.InnerText.Trim();
+                if (!string.IsNullOrEmpty(text))
+                    return text;
+            }
+        }
+
+        return null;
+    }
+
+    private static int CountChannelsInTransposedTable(HtmlNode? table)
+    {
+        if (table == null) return 0;
+        var metricRows = ExtractMetricRows(table);
+        return metricRows.TryGetValue("channelid", out var ids) ? ids.Count : 0;
+    }
+
+    private static string? GetAt(List<string>? list, int index)
+    {
+        return list != null && index < list.Count ? list[index] : null;
+    }
+
+    /// <summary>
+    /// Normalize header text for matching: lowercase, strip whitespace.
+    /// E.g. "Channel ID" -> "channelid", "Power Level" -> "powerlevel"
+    /// </summary>
+    private static string NormalizeHeader(string text)
+    {
+        return text.Trim().Replace(" ", "").Replace("\n", "").Replace("\r", "").ToLowerInvariant();
+    }
+
+    private static int ParseInt(string? text)
+    {
+        var cleaned = StripUnits(text);
+        return int.TryParse(cleaned, out var val) ? val : 0;
+    }
+
+    private static long ParseLong(string? text)
+    {
+        var cleaned = StripUnits(text);
+        return long.TryParse(cleaned, out var val) ? val : 0;
+    }
+
+    private static double? ParseDouble(string? text)
+    {
+        var cleaned = StripUnits(text);
+        return double.TryParse(cleaned, System.Globalization.NumberStyles.Float,
+            System.Globalization.CultureInfo.InvariantCulture, out var val) ? val : null;
+    }
+
+    /// <summary>
+    /// Parse frequency that may be in "957 MHz" format or raw Hz ("774000000").
+    /// SC-QAM channels use "957 MHz", OFDM/OFDMA channels may use raw Hz.
+    /// </summary>
+    private static long ParseFrequencyWithUnits(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return 0;
+
+        var trimmed = text.Trim();
+
+        if (trimmed.EndsWith("MHz", StringComparison.OrdinalIgnoreCase))
+        {
+            var numPart = trimmed[..^3].Trim();
+            if (double.TryParse(numPart, System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture, out var mhz))
+                return (long)(mhz * 1_000_000);
+            return 0;
+        }
+
+        if (trimmed.EndsWith("GHz", StringComparison.OrdinalIgnoreCase))
+        {
+            var numPart = trimmed[..^3].Trim();
+            if (double.TryParse(numPart, System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture, out var ghz))
+                return (long)(ghz * 1_000_000_000);
+            return 0;
+        }
+
+        if (trimmed.EndsWith("Hz", StringComparison.OrdinalIgnoreCase))
+        {
+            var numPart = trimmed[..^2].Trim();
+            if (long.TryParse(numPart, out var hz))
+                return hz;
+            return 0;
+        }
+
+        if (long.TryParse(trimmed, out var raw))
+            return raw;
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Remove common unit suffixes from cable modem values.
+    /// </summary>
+    private static string StripUnits(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return "";
+
+        var cleaned = text.Trim();
+
+        string[] units = { "Ksym/sec", "Msym/sec", "dBmV", "dB", "MHz", "GHz", "Hz" };
+        foreach (var unit in units)
+        {
+            var idx = cleaned.IndexOf(unit, StringComparison.OrdinalIgnoreCase);
+            if (idx >= 0)
+            {
+                cleaned = cleaned[..idx];
+                break;
+            }
+        }
+
+        return cleaned.Trim();
+    }
+}


### PR DESCRIPTION
## Summary

- New `XfinityGatewayProvider` for Xfinity XB8 and XB10 gateways (provider key: `xfinity-gateway`)
- Authenticates via form POST to `/check.jst`, scrapes DOCSIS channel tables from `/network_setup.jst`
- Handles the transposed table layout these gateways use (rows = metrics, columns = channels) and merges error codewords from a separate table into DS channels
- Parses both "957 MHz" (SC-QAM) and raw Hz (OFDM) frequency formats
- Extracts Product Type (e.g. "XB10") for the device model field

## Test plan

- [ ] Configure an Xfinity XB8 or XB10 with the new provider in Settings
- [ ] Verify Test Connection returns channel counts and product type
- [ ] Verify polling populates DS/US channels and error codewords in the CM panel
- [ ] Verify incorrect credentials show a clear error, not a crash