### PR TITLE
Fix step-down detection after short-lived transit shifts

### DIFF
--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/StepChangeDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/StepChangeDetector.cs
@@ -64,8 +64,16 @@ public static class StepChangeDetector
                 AfterMedianMs = after.MedianMs
             });
 
-            // Skip past the persistence span so one shift is not re-reported per boundary
-            i = afterIdx + options.StepPersistenceWindows - 1;
+            var revert = TryDetectRevert(windows, samples, before, after, afterIdx, windowSize, series, options);
+            if (revert != null)
+            {
+                events.Add(revert.Value.Event);
+                i = revert.Value.SkipTo;
+            }
+            else
+            {
+                i = afterIdx + options.StepPersistenceWindows - 1;
+            }
         }
         return events;
     }
@@ -174,6 +182,65 @@ public static class StepChangeDetector
             if (!onNewSide) return false;
         }
         return true;
+    }
+
+    /// <summary>
+    /// After a step is confirmed, scans forward for a revert back to the original
+    /// level. Handles short-lived transit shifts where the elevated level persists
+    /// long enough to confirm the step-up but not long enough for
+    /// <see cref="EstablishedAtOldLevel"/> to anchor an independent step-down.
+    /// </summary>
+    private static (PathShiftEvent Event, int SkipTo)? TryDetectRevert(
+        List<Window> windows, List<LatencySample> samples,
+        Window stepBefore, Window stepAfter, int stepAfterIdx,
+        TimeSpan windowSize, AsnSeries series, IspHealthOptions options)
+    {
+        var midpoint = (stepBefore.MedianMs + stepAfter.MedianMs) / 2.0;
+        var wentUp = stepAfter.MedianMs > stepBefore.MedianMs;
+
+        var searchStart = stepAfterIdx + options.StepPersistenceWindows;
+
+        for (var r = searchStart; r < windows.Count; r++)
+        {
+            var reverted = wentUp
+                ? windows[r].MedianMs < midpoint
+                : windows[r].MedianMs > midpoint;
+            if (!reverted) continue;
+            if (!IsStableLevel(windows[r], options)) continue;
+
+            var lastRequired = r + options.StepPersistenceWindows - 1;
+            if (lastRequired >= windows.Count) return null;
+            var persists = true;
+            for (var j = r; j <= lastRequired; j++)
+            {
+                var onSide = wentUp ? windows[j].MedianMs < midpoint : windows[j].MedianMs > midpoint;
+                if (!onSide) { persists = false; break; }
+            }
+            if (!persists) continue;
+
+            var revertBoundary = r - 1;
+            if (revertBoundary < stepAfterIdx) return null;
+            var revertBefore = windows[revertBoundary];
+            var revertAfter = windows[r];
+
+            var crossing = FindCrossingTime(samples, revertBefore, revertAfter,
+                searchStart: revertBefore.Start,
+                searchEnd: revertAfter.Start + windowSize);
+
+            var evt = new PathShiftEvent
+            {
+                Time = RoundToQuarterHour(crossing ?? windows[r].Start),
+                AsnNumber = series.AsnNumber,
+                AsnName = series.AsnName,
+                TargetId = series.TargetIds.Count == 1 ? series.TargetIds[0] : null,
+                BeforeMedianMs = revertBefore.MedianMs,
+                AfterMedianMs = revertAfter.MedianMs
+            };
+
+            return (evt, lastRequired);
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/StepChangeDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/StepChangeDetectorTests.cs
@@ -67,6 +67,21 @@ public class StepChangeDetectorTests
     }
 
     [Fact]
+    public void Short_lived_shift_reports_both_up_and_down()
+    {
+        var shiftUp = TestSeries.Start.AddHours(10);
+        var shiftDown = shiftUp.AddMinutes(90);
+        var samples = TestSeries.Flat(TestSeries.Start, Day, rttMs: 24, jitterMs: 0.3)
+            .WithSegment(shiftUp, shiftDown, rttMs: 25.5, jitterMs: 0.3);
+
+        var events = StepChangeDetector.DetectForSeries(TestSeries.Asn(30517, "INDATEL", samples), Options);
+
+        events.Should().HaveCount(2);
+        events[0].Direction.Should().Be(PathShiftDirection.Up);
+        events[1].Direction.Should().Be(PathShiftDirection.Down);
+    }
+
+    [Fact]
     public void Sub_threshold_change_is_ignored()
     {
         var stepAt = TestSeries.Start.AddHours(12);

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/StepChangeDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/StepChangeDetectorTests.cs
@@ -74,7 +74,7 @@ public class StepChangeDetectorTests
         var samples = TestSeries.Flat(TestSeries.Start, Day, rttMs: 24, jitterMs: 0.3)
             .WithSegment(shiftUp, shiftDown, rttMs: 25.5, jitterMs: 0.3);
 
-        var events = StepChangeDetector.DetectForSeries(TestSeries.Asn(30517, "INDATEL", samples), Options);
+        var events = StepChangeDetector.DetectForSeries(TestSeries.Asn(64500, "TransitOne", samples), Options);
 
         events.Should().HaveCount(2);
         events[0].Direction.Should().Be(PathShiftDirection.Up);


### PR DESCRIPTION
## Summary

- **Detect step-down after short-lived shifts** - When a transit shift lasts just long enough to confirm (3 windows / 90 min) but then reverts, the step-up was reported but the step-down was missed. The iterator skip after the step-up jumped past the elevated windows, and the boundary delta from the weakest elevated window often fell below threshold. After detecting a step, the detector now scans forward for a revert using the confirmed step's midpoint as the gate, bypassing both issues.

## Test plan

- [x] All 9 StepChangeDetector tests pass (including new `Short_lived_shift_reports_both_up_and_down`)
- [x] Existing tests unchanged: persistent up, persistent down, dip-and-return, reverting hump, sub-threshold, overlapping IQRs, correlated targets
- [x] Deployed to NAS on this branch
- [x] Verify the INDATEL step-down appears in the next ISP Health report refresh