### PR TITLE
v1.20.3 release changes

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -154,6 +154,7 @@
 
                     if (st > lastScrollTop && st > 60 && isContentScrollable()) {
                         topBar.classList.add('top-bar-hidden');
+                        setTimeout(function() { if (topBar.classList.contains('top-bar-hidden')) topBar.classList.add('top-bar-collapsed'); }, 350);
                         currentEl.style.scrollPaddingTop = '0px';
                         clearAutoHideTimer();
                     } else if (!nearBottom && scrollUpAccum > 60) {

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -138,7 +138,7 @@
                 var topBar = document.querySelector('.top-bar');
 
                 var nearBottom = currentEl.scrollHeight - st - currentEl.clientHeight < 40;
-                if (st <= 0 && !(topBar.classList.contains('top-bar-hidden') && lastScrollTop > 60)) {
+                if (st <= 0 && !(topBar.classList.contains('top-bar-hidden') && lastScrollTop > 60 && isContentScrollable())) {
                     topBar.classList.remove('top-bar-hidden', 'top-bar-collapsed');
                     currentEl.style.scrollPaddingTop = '70px';
                     startAutoHideTimer(topBar);

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -138,7 +138,7 @@
                 var topBar = document.querySelector('.top-bar');
 
                 var nearBottom = currentEl.scrollHeight - st - currentEl.clientHeight < 40;
-                if (st <= 0 && !(topBar.classList.contains('top-bar-hidden') && lastScrollTop > 60 && isContentScrollable())) {
+                if (st <= 0 && !(topBar.classList.contains('top-bar-hidden') && lastScrollTop > 60)) {
                     topBar.classList.remove('top-bar-hidden', 'top-bar-collapsed');
                     currentEl.style.scrollPaddingTop = '70px';
                     startAutoHideTimer(topBar);

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -112,7 +112,7 @@
                 if (sidebarOpen) return;
                 if (topBar && !topBar.classList.contains('top-bar-hidden')) {
                     topBar.classList.add('top-bar-hidden');
-                    setTimeout(function() { topBar.classList.add('top-bar-collapsed'); }, 350);
+                    setTimeout(function() { if (topBar.classList.contains('top-bar-hidden') && currentEl && currentEl.scrollHeight - topBar.offsetHeight > currentEl.clientHeight + 10) topBar.classList.add('top-bar-collapsed'); }, 350);
                     if (currentEl) currentEl.style.scrollPaddingTop = '0px';
                     var identityBar = document.querySelector('.identity-bar');
                     if (identityBar) identityBar.classList.remove('below-topbar');
@@ -154,7 +154,6 @@
 
                     if (st > lastScrollTop && st > 60 && isContentScrollable()) {
                         topBar.classList.add('top-bar-hidden');
-                        setTimeout(function() { if (topBar.classList.contains('top-bar-hidden')) topBar.classList.add('top-bar-collapsed'); }, 350);
                         currentEl.style.scrollPaddingTop = '0px';
                         clearAutoHideTimer();
                     } else if (!nearBottom && scrollUpAccum > 60) {
@@ -208,6 +207,19 @@
         window.addEventListener('orientationchange', function() {
             setTimeout(function() { window.scrollBy(0, 1); window.scrollBy(0, -1); }, 100);
         });
+
+        // Show nav bar when content shrinks below scrollable (e.g. tab switch to short content)
+        var pageContent = document.querySelector('.page-content');
+        if (window.innerWidth <= 1024 && pageContent) {
+            new ResizeObserver(function() {
+                var topBar = document.querySelector('.top-bar');
+                if (topBar && topBar.classList.contains('top-bar-hidden') && !isContentScrollable()) {
+                    topBar.classList.remove('top-bar-hidden', 'top-bar-collapsed');
+                    if (currentEl) currentEl.style.scrollPaddingTop = '70px';
+                    startAutoHideTimer(topBar);
+                }
+            }).observe(pageContent);
+        }
 
         // Restart auto-hide timer when sidebar closes
         var sidebar = document.querySelector('.sidebar');

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1003,6 +1003,7 @@
                                 <option value="arris-surfboard">ARRIS Surfboard (HTTP)</option>
                                 <option value="arris-surfboard-hnap">ARRIS Surfboard S33/S34 (HNAP)</option>
                                 <option value="motorola-hnap">Motorola MB8611, MB8600 (HNAP)</option>
+                                <option value="xfinity-gateway">Xfinity XB8, XB10 (HTTP)</option>
                             </select>
                         </div>
                     </div>
@@ -4184,6 +4185,7 @@
         "arris-surfboard" => "ARRIS Surfboard (HTTP)",
         "arris-surfboard-hnap" => "ARRIS Surfboard S33/S34 (HNAP)",
         "motorola-hnap" => "Motorola (HNAP)",
+        "xfinity-gateway" => "Xfinity Gateway (HTTP)",
         _ => provider,
     };
 
@@ -4192,6 +4194,7 @@
         "arris-surfboard" => "/cgi-bin/status",
         "arris-surfboard-hnap" => "N/A (uses /HNAP1/)",
         "motorola-hnap" => "N/A (uses /HNAP1/)",
+        "xfinity-gateway" => "/network_setup.jst",
         _ => "/DocsisStatus.htm",
     };
 

--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -268,7 +268,7 @@
         <!-- AP Load Balance -->
         <div class="card card-full-width">
             <div class="card-body">
-                <NetworkOptimizer.Web.Components.Shared.WiFi.ApLoadBalance OnClientClick="HandleMapClientClick" />
+                <NetworkOptimizer.Web.Components.Shared.WiFi.ApLoadBalance OnClientClick="HandleMapClientClick" OnNavigateToClients="HandleApLoadBalanceNavigate" />
             </div>
         </div>
     }
@@ -404,21 +404,21 @@
                 else
                 {
                     <div class="band-distribution">
-                        <div class="band-item">
+                        <div class="band-item clickable" @onclick="@(() => NavigateToTab("client", null, RadioBand.Band2_4GHz))">
                             <div class="band-bar-container">
                                 <div class="band-bar band-2ghz" style="height: @GetBandPercentage(_summary?.ClientsOn2_4GHz ?? 0)%"></div>
                             </div>
                             <div class="band-value">@(_summary?.ClientsOn2_4GHz ?? 0)</div>
                             <div class="band-label">2.4 GHz</div>
                         </div>
-                        <div class="band-item">
+                        <div class="band-item clickable" @onclick="@(() => NavigateToTab("client", null, RadioBand.Band5GHz))">
                             <div class="band-bar-container">
                                 <div class="band-bar band-5ghz" style="height: @GetBandPercentage(_summary?.ClientsOn5GHz ?? 0)%"></div>
                             </div>
                             <div class="band-value">@(_summary?.ClientsOn5GHz ?? 0)</div>
                             <div class="band-label">5 GHz</div>
                         </div>
-                        <div class="band-item">
+                        <div class="band-item clickable" @onclick="@(() => NavigateToTab("client", null, RadioBand.Band6GHz))">
                             <div class="band-bar-container">
                                 <div class="band-bar band-6ghz" style="height: @GetBandPercentage(_summary?.ClientsOn6GHz ?? 0)%"></div>
                             </div>
@@ -970,6 +970,11 @@
         _initialClientMac = mac;
         NavigationManager.NavigateTo("/wifi-optimizer?tab=client&client=" + Uri.EscapeDataString(mac), forceLoad: false, replace: false);
         _lastTabParam = "client";
+    }
+
+    private void HandleApLoadBalanceNavigate((string? ApMac, RadioBand? Band) filter)
+    {
+        NavigateToTab("client", filter.ApMac, filter.Band);
     }
 
     private async Task HandleSignalTimeRangeChanged(int hours)

--- a/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
@@ -69,7 +69,7 @@
                 <span class="status-label">No Data</span>
             </div>
             <p class="status-message">
-                Monitor your cable modem's downstream power, SNR, upstream power, and FEC error rates. Supports Netgear, ARRIS Surfboard, and Motorola modems.
+                Monitor your cable modem's downstream power, SNR, upstream power, and FEC error rates. Supports Netgear, ARRIS Surfboard, Motorola, and Xfinity modems.
             </p>
             <div class="sqm-actions">
                 <a href="/settings#cable-modem" class="btn btn-primary" @onclick:stopPropagation>Configure CM</a>

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ApLoadBalance.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ApLoadBalance.razor
@@ -136,7 +136,7 @@
                                 <span class="ap-name"><DeviceIcon Model="@ap.Model" Size="lg" /> @ap.Name</span>
                                 <span class="ap-model">@ap.Model</span>
                             </div>
-                            <div class="ap-client-count">
+                            <div class="ap-client-count clickable" @onclick="@(() => OnNavigateToClients.InvokeAsync((ap.Mac, (RadioBand?)null)))">
                                 <span class="count-value">@ap.TotalClients</span>
                                 <span class="count-label">clients</span>
                             </div>
@@ -147,7 +147,7 @@
                             {
                                 <div class="radio-summary">
                                     <span class="radio-band @GetBandCssClass(radio.Band)">@radio.Band.ToDisplayString()</span>
-                                    <span class="radio-clients">@(radio.ClientCount ?? 0) clients</span>
+                                    <span class="radio-clients clickable" @onclick="@(() => OnNavigateToClients.InvokeAsync((ap.Mac, (RadioBand?)radio.Band)))">@(radio.ClientCount ?? 0) clients</span>
                                     <span class="radio-util @GetUtilizationClass(radio.ChannelUtilization ?? 0)">
                                         @(radio.ChannelUtilization ?? 0)% util
                                     </span>
@@ -196,6 +196,7 @@
 
 @code {
     [Parameter] public EventCallback<string> OnClientClick { get; set; }
+    [Parameter] public EventCallback<(string? ApMac, RadioBand? Band)> OnNavigateToClients { get; set; }
 
     private bool _loading = true;
     private List<AccessPointSnapshot> _accessPoints = new();

--- a/src/NetworkOptimizer.Web/Endpoints/IspHealthEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/IspHealthEndpoints.cs
@@ -16,19 +16,31 @@ public static class IspHealthEndpoints
         {
             var (series, report) = await ispHealth.GetAsnChartDataAsync(ct);
 
-            var asns = series.Select(s => new
+            var asnBuckets = series.Select(s => new
             {
                 asn = s.AsnNumber,
                 name = string.IsNullOrEmpty(s.AsnName) ? $"AS{s.AsnNumber}" : s.AsnName,
-                points = s.Samples
+                buckets = s.Samples
                     .Where(p => p.RttAvgMs.HasValue)
                     .GroupBy(p => new DateTime(p.Time.Ticks - p.Time.Ticks % TimeSpan.TicksPerMinute, DateTimeKind.Utc))
-                    .OrderBy(g => g.Key)
-                    .Select(g => new
-                    {
-                        time = g.Key.ToString("o"),
-                        value = Math.Round(g.Average(p => p.RttAvgMs!.Value), 2)
-                    })
+                    .ToDictionary(g => g.Key, g => Math.Round(g.Average(p => p.RttAvgMs!.Value), 2))
+            }).ToList();
+
+            var allTimes = asnBuckets
+                .SelectMany(a => a.buckets.Keys)
+                .Distinct()
+                .OrderBy(t => t)
+                .ToList();
+
+            var asns = asnBuckets.Select(a => new
+            {
+                a.asn,
+                a.name,
+                points = allTimes.Select(t => new
+                {
+                    time = t.ToString("o"),
+                    value = a.buckets.TryGetValue(t, out var v) ? (double?)v : null
+                })
             });
 
             var events = new List<object>();

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -195,6 +195,7 @@ builder.Services.AddSingleton<ICableModemProvider, NetgearCmProvider>();
 builder.Services.AddSingleton<ICableModemProvider, ArrisSurfboardHttpProvider>();
 builder.Services.AddSingleton<ICableModemProvider, ArrisSurfboardHnapProvider>();
 builder.Services.AddSingleton<ICableModemProvider, MotorolaHnapProvider>();
+builder.Services.AddSingleton<ICableModemProvider, XfinityGatewayProvider>();
 builder.Services.AddSingleton<CableModemMonitorService>();
 
 // Register External ONT providers and service

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
@@ -1,0 +1,523 @@
+using System.Net;
+using HtmlAgilityPack;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Monitoring.Providers;
+
+namespace NetworkOptimizer.Web.Services.CableModemProviders;
+
+/// <summary>
+/// Cable modem provider for Xfinity gateways (XB8, XB10).
+/// Authenticates via form POST to /check.jst, then scrapes DOCSIS channel
+/// tables from /network_setup.jst. The tables use a transposed layout where
+/// each row is a metric and each column is a channel.
+/// </summary>
+public sealed class XfinityGatewayProvider : ICableModemProvider
+{
+    /// <inheritdoc/>
+    public string ProviderKey => "xfinity-gateway";
+
+    /// <inheritdoc/>
+    public string DisplayName => "Xfinity Gateway (HTTP)";
+
+    private const string DefaultStatusPath = "/network_setup.jst";
+    private const string LoginPath = "/check.jst";
+    private const int TimeoutSeconds = 15;
+    private const int MaxRetries = 3;
+    private static readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(1);
+
+    private readonly ILogger<XfinityGatewayProvider> _logger;
+
+    public XfinityGatewayProvider(ILogger<XfinityGatewayProvider> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<CableModemStats?> PollAsync(
+        CmPollContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+        {
+            _logger.LogWarning("Xfinity Gateway poll requested but Host is empty (config {Id})", context.Id);
+            return null;
+        }
+
+        for (int attempt = 1; attempt <= MaxRetries; attempt++)
+        {
+            try
+            {
+                var html = await FetchStatusPageAsync(context, cancellationToken);
+                if (html == null)
+                {
+                    _logger.LogWarning(
+                        "Xfinity Gateway at {Host} returned empty response (attempt {Attempt}/{Max})",
+                        context.Host, attempt, MaxRetries);
+                    if (attempt < MaxRetries)
+                    {
+                        await Task.Delay(RetryDelay, cancellationToken);
+                        continue;
+                    }
+                    return null;
+                }
+
+                var stats = ParseNetworkSetup(html, context);
+                _logger.LogDebug(
+                    "Xfinity Gateway {Name} polled: {DsCount} DS channels, {UsCount} US channels",
+                    context.Name, stats.DownstreamChannels.Count, stats.UpstreamChannels.Count);
+                return stats;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (HttpRequestException ex) when (attempt < MaxRetries)
+            {
+                _logger.LogDebug(
+                    ex, "Transient error polling Xfinity Gateway {Name} (attempt {Attempt}/{Max})",
+                    context.Name, attempt, MaxRetries);
+                await Task.Delay(RetryDelay, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error polling Xfinity Gateway {Name} at {Host}", context.Name, context.Host);
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    /// <inheritdoc/>
+    public async Task<(bool Success, string Message)> TestConnectionAsync(
+        CmPollContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+            return (false, "Host is empty");
+
+        try
+        {
+            var html = await FetchStatusPageAsync(context, cancellationToken);
+            if (html == null)
+                return (false, "No response from gateway - check host and credentials");
+
+            var doc = new HtmlDocument();
+            doc.LoadHtml(html);
+
+            var tables = FindChannelTables(doc);
+            if (tables.Downstream == null && tables.Upstream == null)
+                return (false, "Connected but DOCSIS channel tables not found. Is this an Xfinity gateway?");
+
+            var dsCount = CountChannelsInTransposedTable(tables.Downstream);
+            var usCount = CountChannelsInTransposedTable(tables.Upstream);
+
+            var model = ExtractProductType(doc);
+            var modelSuffix = string.IsNullOrEmpty(model) ? "" : $" ({model})";
+
+            return (true, $"Connected{modelSuffix} - {dsCount} downstream, {usCount} upstream channels detected");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Connection failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Authenticate via form POST and fetch the status page in one session.
+    /// Uses CookieContainer to carry the session cookie from login to page fetch.
+    /// </summary>
+    private async Task<string?> FetchStatusPageAsync(CmPollContext context, CancellationToken cancellationToken)
+    {
+        var port = context.Port > 0 ? context.Port : 80;
+        var portSuffix = port == 80 ? "" : $":{port}";
+        var baseUrl = $"http://{context.Host}{portSuffix}";
+
+        var statusPath = string.IsNullOrWhiteSpace(context.StatusPagePath)
+            ? DefaultStatusPath
+            : context.StatusPagePath;
+
+        using var handler = new HttpClientHandler
+        {
+            CookieContainer = new CookieContainer(),
+            AllowAutoRedirect = true,
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+        };
+        using var client = new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromSeconds(TimeoutSeconds),
+        };
+
+        var username = context.Username ?? "admin";
+        var password = context.Password ?? "";
+        var loginContent = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("username", username),
+            new KeyValuePair<string, string>("password", password),
+        });
+
+        var loginResponse = await client.PostAsync($"{baseUrl}{LoginPath}", loginContent, cancellationToken);
+
+        if (!loginResponse.IsSuccessStatusCode)
+        {
+            _logger.LogDebug("Xfinity Gateway login returned {Status} for {Host}",
+                loginResponse.StatusCode, context.Host);
+            return null;
+        }
+
+        var response = await client.GetAsync($"{baseUrl}{statusPath}", cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogDebug("Xfinity Gateway status page returned {Status} for {Host}",
+                response.StatusCode, context.Host);
+            return null;
+        }
+
+        var html = await response.Content.ReadAsStringAsync(cancellationToken);
+        if (string.IsNullOrWhiteSpace(html))
+            return null;
+
+        if (IsLoginPage(html))
+        {
+            _logger.LogDebug("Xfinity Gateway at {Host}: login failed, got redirected back to login page",
+                context.Host);
+            return null;
+        }
+
+        return html;
+    }
+
+    /// <summary>
+    /// Detect if the response is the login page rather than the status page.
+    /// The login page POSTs to check.jst.
+    /// </summary>
+    private static bool IsLoginPage(string html)
+    {
+        return html.Contains("action=\"check.jst\"", StringComparison.OrdinalIgnoreCase)
+            || html.Contains("action='/check.jst'", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private CableModemStats ParseNetworkSetup(string html, CmPollContext context)
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+
+        var stats = new CableModemStats
+        {
+            Timestamp = DateTime.UtcNow,
+            DeviceHost = context.Host,
+            DeviceName = context.Name,
+            DeviceModel = ExtractProductType(doc) ?? "Xfinity Gateway",
+        };
+
+        var tables = FindChannelTables(doc);
+
+        if (tables.Downstream != null)
+            ParseTransposedDownstreamTable(tables.Downstream, stats);
+
+        if (tables.Upstream != null)
+            ParseTransposedUpstreamTable(tables.Upstream, stats);
+
+        if (tables.ErrorCodewords != null)
+            MergeErrorCodewords(tables.ErrorCodewords, stats);
+
+        return stats;
+    }
+
+    /// <summary>
+    /// Locate the three DOCSIS tables by their header text.
+    /// Tables are inside div.netFlow containers with thead text identifying them.
+    /// </summary>
+    private static (HtmlNode? Downstream, HtmlNode? Upstream, HtmlNode? ErrorCodewords) FindChannelTables(
+        HtmlDocument doc)
+    {
+        HtmlNode? dsTable = null, usTable = null, errTable = null;
+
+        var tables = doc.DocumentNode.SelectNodes("//table[contains(@class,'data')]");
+        if (tables == null) return (null, null, null);
+
+        foreach (var table in tables)
+        {
+            var headerText = table.SelectSingleNode(".//thead")?.InnerText ?? "";
+
+            if (headerText.Contains("Downstream", StringComparison.OrdinalIgnoreCase)
+                && headerText.Contains("Channel Bonding", StringComparison.OrdinalIgnoreCase))
+            {
+                dsTable = table;
+            }
+            else if (headerText.Contains("Upstream", StringComparison.OrdinalIgnoreCase)
+                     && headerText.Contains("Channel Bonding", StringComparison.OrdinalIgnoreCase))
+            {
+                usTable = table;
+            }
+            else if (headerText.Contains("Error Codewords", StringComparison.OrdinalIgnoreCase))
+            {
+                errTable = table;
+            }
+        }
+
+        return (dsTable, usTable, errTable);
+    }
+
+    /// <summary>
+    /// Parse a transposed downstream table where each row is a metric
+    /// and each column is a channel.
+    /// Rows: Channel ID, Lock Status, Frequency, SNR, Power Level, Modulation.
+    /// </summary>
+    private void ParseTransposedDownstreamTable(HtmlNode table, CableModemStats stats)
+    {
+        var metricRows = ExtractMetricRows(table);
+        if (!metricRows.TryGetValue("channelid", out var channelIds) || channelIds.Count == 0)
+            return;
+
+        metricRows.TryGetValue("lockstatus", out var lockStatuses);
+        metricRows.TryGetValue("frequency", out var frequencies);
+        metricRows.TryGetValue("snr", out var snrs);
+        metricRows.TryGetValue("powerlevel", out var powers);
+        metricRows.TryGetValue("modulation", out var modulations);
+
+        for (int i = 0; i < channelIds.Count; i++)
+        {
+            var channel = new DsChannel
+            {
+                ChannelId = ParseInt(GetAt(channelIds, i)),
+                LockStatus = GetAt(lockStatuses, i) ?? "",
+                Frequency = ParseFrequencyWithUnits(GetAt(frequencies, i)),
+                Snr = ParseDouble(GetAt(snrs, i)),
+                Power = ParseDouble(GetAt(powers, i)),
+                Modulation = GetAt(modulations, i) ?? "",
+            };
+
+            stats.DownstreamChannels.Add(channel);
+        }
+    }
+
+    /// <summary>
+    /// Parse a transposed upstream table.
+    /// Rows: Channel ID, Lock Status, Frequency, Symbol Rate, Power Level, Modulation, Channel Type.
+    /// </summary>
+    private void ParseTransposedUpstreamTable(HtmlNode table, CableModemStats stats)
+    {
+        var metricRows = ExtractMetricRows(table);
+        if (!metricRows.TryGetValue("channelid", out var channelIds) || channelIds.Count == 0)
+            return;
+
+        metricRows.TryGetValue("lockstatus", out var lockStatuses);
+        metricRows.TryGetValue("frequency", out var frequencies);
+        metricRows.TryGetValue("symbolrate", out var symbolRates);
+        metricRows.TryGetValue("powerlevel", out var powers);
+        metricRows.TryGetValue("modulation", out var modulations);
+        metricRows.TryGetValue("channeltype", out var channelTypes);
+
+        for (int i = 0; i < channelIds.Count; i++)
+        {
+            var channel = new UsChannel
+            {
+                ChannelId = ParseInt(GetAt(channelIds, i)),
+                LockStatus = GetAt(lockStatuses, i) ?? "",
+                Frequency = ParseFrequencyWithUnits(GetAt(frequencies, i)),
+                SymbolRate = ParseLong(GetAt(symbolRates, i)),
+                Power = ParseDouble(GetAt(powers, i)),
+                ChannelType = GetAt(channelTypes, i) ?? GetAt(modulations, i) ?? "",
+            };
+
+            stats.UpstreamChannels.Add(channel);
+        }
+    }
+
+    /// <summary>
+    /// Merge error codewords from the separate table into existing DS channels by channel ID.
+    /// </summary>
+    private void MergeErrorCodewords(HtmlNode table, CableModemStats stats)
+    {
+        var metricRows = ExtractMetricRows(table);
+        if (!metricRows.TryGetValue("channelid", out var channelIds) || channelIds.Count == 0)
+            return;
+
+        metricRows.TryGetValue("correctablecodewords", out var correctables);
+        metricRows.TryGetValue("uncorrectablecodewords", out var uncorrectables);
+
+        var dsLookup = new Dictionary<int, DsChannel>();
+        foreach (var ch in stats.DownstreamChannels)
+            dsLookup.TryAdd(ch.ChannelId, ch);
+
+        for (int i = 0; i < channelIds.Count; i++)
+        {
+            var chId = ParseInt(GetAt(channelIds, i));
+            if (chId > 0 && dsLookup.TryGetValue(chId, out var channel))
+            {
+                channel.Correctables = ParseLong(GetAt(correctables, i));
+                channel.Uncorrectables = ParseLong(GetAt(uncorrectables, i));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Extract metric rows from a transposed table.
+    /// Each tbody tr has a th.row-label with the metric name, followed by td values.
+    /// Returns a dictionary keyed by normalized metric name.
+    /// </summary>
+    private static Dictionary<string, List<string>> ExtractMetricRows(HtmlNode table)
+    {
+        var result = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+        var rows = table.SelectNodes(".//tbody/tr");
+        if (rows == null) return result;
+
+        foreach (var row in rows)
+        {
+            var header = row.SelectSingleNode("th");
+            if (header == null) continue;
+
+            var metricName = NormalizeHeader(header.InnerText);
+            if (string.IsNullOrEmpty(metricName)) continue;
+
+            var cells = row.SelectNodes("td");
+            if (cells == null) continue;
+
+            var values = cells
+                .Select(c =>
+                {
+                    var div = c.SelectSingleNode(".//div[contains(@class,'netWidth')]");
+                    return (div ?? c).InnerText.Trim();
+                })
+                .ToList();
+
+            result[metricName] = values;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Extract the Product Type from the Device Information section (e.g. "XB10").
+    /// </summary>
+    private static string? ExtractProductType(HtmlDocument doc)
+    {
+        var labels = doc.DocumentNode.SelectNodes("//span[contains(@class,'readonlyLabel')]");
+        if (labels == null) return null;
+
+        foreach (var label in labels)
+        {
+            if (!label.InnerText.Contains("Product Type", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var value = label.ParentNode?.SelectSingleNode(".//span[contains(@class,'value')]");
+            if (value != null)
+            {
+                var text = value.InnerText.Trim();
+                if (!string.IsNullOrEmpty(text))
+                    return text;
+            }
+        }
+
+        return null;
+    }
+
+    private static int CountChannelsInTransposedTable(HtmlNode? table)
+    {
+        if (table == null) return 0;
+        var metricRows = ExtractMetricRows(table);
+        return metricRows.TryGetValue("channelid", out var ids) ? ids.Count : 0;
+    }
+
+    private static string? GetAt(List<string>? list, int index)
+    {
+        return list != null && index < list.Count ? list[index] : null;
+    }
+
+    /// <summary>
+    /// Normalize header text for matching: lowercase, strip whitespace.
+    /// E.g. "Channel ID" -> "channelid", "Power Level" -> "powerlevel"
+    /// </summary>
+    private static string NormalizeHeader(string text)
+    {
+        return text.Trim().Replace(" ", "").Replace("\n", "").Replace("\r", "").ToLowerInvariant();
+    }
+
+    private static int ParseInt(string? text)
+    {
+        var cleaned = StripUnits(text);
+        return int.TryParse(cleaned, out var val) ? val : 0;
+    }
+
+    private static long ParseLong(string? text)
+    {
+        var cleaned = StripUnits(text);
+        return long.TryParse(cleaned, out var val) ? val : 0;
+    }
+
+    private static double? ParseDouble(string? text)
+    {
+        var cleaned = StripUnits(text);
+        return double.TryParse(cleaned, System.Globalization.NumberStyles.Float,
+            System.Globalization.CultureInfo.InvariantCulture, out var val) ? val : null;
+    }
+
+    /// <summary>
+    /// Parse frequency that may be in "957 MHz" format or raw Hz ("774000000").
+    /// SC-QAM channels use "957 MHz", OFDM/OFDMA channels may use raw Hz.
+    /// </summary>
+    private static long ParseFrequencyWithUnits(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return 0;
+
+        var trimmed = text.Trim();
+
+        if (trimmed.EndsWith("MHz", StringComparison.OrdinalIgnoreCase))
+        {
+            var numPart = trimmed[..^3].Trim();
+            if (double.TryParse(numPart, System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture, out var mhz))
+                return (long)(mhz * 1_000_000);
+            return 0;
+        }
+
+        if (trimmed.EndsWith("GHz", StringComparison.OrdinalIgnoreCase))
+        {
+            var numPart = trimmed[..^3].Trim();
+            if (double.TryParse(numPart, System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture, out var ghz))
+                return (long)(ghz * 1_000_000_000);
+            return 0;
+        }
+
+        if (trimmed.EndsWith("Hz", StringComparison.OrdinalIgnoreCase))
+        {
+            var numPart = trimmed[..^2].Trim();
+            if (long.TryParse(numPart, out var hz))
+                return hz;
+            return 0;
+        }
+
+        if (long.TryParse(trimmed, out var raw))
+            return raw;
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Remove common unit suffixes from cable modem values.
+    /// </summary>
+    private static string StripUnits(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return "";
+
+        var cleaned = text.Trim();
+
+        string[] units = { "Ksym/sec", "Msym/sec", "dBmV", "dB", "MHz", "GHz", "Hz" };
+        foreach (var unit in units)
+        {
+            var idx = cleaned.IndexOf(unit, StringComparison.OrdinalIgnoreCase);
+            if (idx >= 0)
+            {
+                cleaned = cleaned[..idx];
+                break;
+            }
+        }
+
+        return cleaned.Trim();
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -126,7 +126,7 @@ public class IspHealthOptions
     public int StepWindowMinutes { get; set; } = 30;
 
     /// <summary>Absolute floor in ms for a step-change candidate delta.</summary>
-    public double StepMinDeltaMs { get; set; } = 1.5;
+    public double StepMinDeltaMs { get; set; } = 1.2;
 
     /// <summary>Relative floor (fraction of the before-median) for a step-change candidate delta.</summary>
     public double StepMinRelativeChange { get; set; } = 0.06;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/StepChangeDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/StepChangeDetector.cs
@@ -267,7 +267,10 @@ public static class StepChangeDetector
 
         foreach (var group in groups)
         {
-            var representative = group.OrderBy(e => e.BeforeMedianMs).First();
+            var representative = group
+                .OrderByDescending(e => e.TargetId?.StartsWith("transit") == true)
+                .ThenBy(e => e.BeforeMedianMs)
+                .First();
             merged.Add(new PathShiftEvent
             {
                 Time = representative.Time,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/StepChangeDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/StepChangeDetector.cs
@@ -64,8 +64,16 @@ public static class StepChangeDetector
                 AfterMedianMs = after.MedianMs
             });
 
-            // Skip past the persistence span so one shift is not re-reported per boundary
-            i = afterIdx + options.StepPersistenceWindows - 1;
+            var revert = TryDetectRevert(windows, samples, before, after, afterIdx, windowSize, series, options);
+            if (revert != null)
+            {
+                events.Add(revert.Value.Event);
+                i = revert.Value.SkipTo;
+            }
+            else
+            {
+                i = afterIdx + options.StepPersistenceWindows - 1;
+            }
         }
         return events;
     }
@@ -174,6 +182,65 @@ public static class StepChangeDetector
             if (!onNewSide) return false;
         }
         return true;
+    }
+
+    /// <summary>
+    /// After a step is confirmed, scans forward for a revert back to the original
+    /// level. Handles short-lived transit shifts where the elevated level persists
+    /// long enough to confirm the step-up but not long enough for
+    /// <see cref="EstablishedAtOldLevel"/> to anchor an independent step-down.
+    /// </summary>
+    private static (PathShiftEvent Event, int SkipTo)? TryDetectRevert(
+        List<Window> windows, List<LatencySample> samples,
+        Window stepBefore, Window stepAfter, int stepAfterIdx,
+        TimeSpan windowSize, AsnSeries series, IspHealthOptions options)
+    {
+        var midpoint = (stepBefore.MedianMs + stepAfter.MedianMs) / 2.0;
+        var wentUp = stepAfter.MedianMs > stepBefore.MedianMs;
+
+        var searchStart = stepAfterIdx + options.StepPersistenceWindows;
+
+        for (var r = searchStart; r < windows.Count; r++)
+        {
+            var reverted = wentUp
+                ? windows[r].MedianMs < midpoint
+                : windows[r].MedianMs > midpoint;
+            if (!reverted) continue;
+            if (!IsStableLevel(windows[r], options)) continue;
+
+            var lastRequired = r + options.StepPersistenceWindows - 1;
+            if (lastRequired >= windows.Count) return null;
+            var persists = true;
+            for (var j = r; j <= lastRequired; j++)
+            {
+                var onSide = wentUp ? windows[j].MedianMs < midpoint : windows[j].MedianMs > midpoint;
+                if (!onSide) { persists = false; break; }
+            }
+            if (!persists) continue;
+
+            var revertBoundary = r - 1;
+            if (revertBoundary < stepAfterIdx) return null;
+            var revertBefore = windows[revertBoundary];
+            var revertAfter = windows[r];
+
+            var crossing = FindCrossingTime(samples, revertBefore, revertAfter,
+                searchStart: revertBefore.Start,
+                searchEnd: revertAfter.Start + windowSize);
+
+            var evt = new PathShiftEvent
+            {
+                Time = RoundToQuarterHour(crossing ?? windows[r].Start),
+                AsnNumber = series.AsnNumber,
+                AsnName = series.AsnName,
+                TargetId = series.TargetIds.Count == 1 ? series.TargetIds[0] : null,
+                BeforeMedianMs = revertBefore.MedianMs,
+                AfterMedianMs = revertAfter.MedianMs
+            };
+
+            return (evt, lastRequired);
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -3108,12 +3108,12 @@ select.form-control {
         height: auto;
         padding: 0.75rem 1rem;
         gap: 0.5rem;
-        transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+        transition: top 0.35s cubic-bezier(0.4, 0, 0.2, 1);
     }
 
     .top-bar.top-bar-hidden {
         position: sticky;
-        transform: translateY(-100%);
+        top: -100%;
         pointer-events: none;
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15201,7 +15201,7 @@ a.affected-client:hover {
     margin-bottom: 0.375rem;
 }
 
-@@media (max-width: 768px) {
+@media (max-width: 768px) {
     .isp-health-card .issue-severity {
         grid-column: 1;
         grid-row: 1;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -7669,6 +7669,16 @@ a.path-hop.hop-clickable:hover {
     gap: 0.5rem;
 }
 
+.band-item.clickable {
+    cursor: pointer;
+    border-radius: 8px;
+    transition: background-color 0.15s ease;
+}
+
+.band-item.clickable:hover {
+    background-color: var(--bg-hover);
+}
+
 .band-bar-container {
     width: 60px;
     height: 120px;
@@ -11106,6 +11116,16 @@ a.path-hop.hop-clickable:hover {
     text-align: right;
 }
 
+.ap-client-count.clickable {
+    cursor: pointer;
+    border-radius: 6px;
+    transition: background-color 0.15s ease;
+}
+
+.ap-client-count.clickable:hover {
+    background-color: var(--bg-hover);
+}
+
 .ap-client-count .count-value {
     font-size: 1.5rem;
     font-weight: 600;
@@ -11156,6 +11176,16 @@ a.path-hop.hop-clickable:hover {
 
 .radio-summary .radio-clients {
     color: var(--text-secondary);
+}
+
+.radio-summary .radio-clients.clickable {
+    cursor: pointer;
+    border-radius: 4px;
+    transition: background-color 0.15s ease;
+}
+
+.radio-summary .radio-clients.clickable:hover {
+    background-color: var(--bg-hover);
 }
 
 .radio-summary .radio-util {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15201,6 +15201,20 @@ a.affected-client:hover {
     margin-bottom: 0.375rem;
 }
 
+@@media (max-width: 768px) {
+    .isp-health-card .issue-severity {
+        grid-column: 1;
+        grid-row: 1;
+        align-self: center;
+        margin-bottom: 0;
+    }
+
+    .isp-health-card .issue-title {
+        grid-column: 2;
+        grid-row: 1;
+    }
+}
+
 .isp-health-toolbar {
     display: flex;
     justify-content: flex-end;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2599,6 +2599,10 @@ select.form-control {
     border-left: 4px solid var(--border-color);
 }
 
+.issue-item + .issue-item {
+    margin-top: 0.5rem;
+}
+
 .issue-item.issue-critical {
     border-left-color: var(--danger-color);
 }
@@ -2675,6 +2679,7 @@ select.form-control {
     font-size: 0.7rem;
     font-weight: 600;
     text-transform: uppercase;
+    margin-bottom: 0.375rem;
 }
 
 .issue-critical .issue-severity {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2599,10 +2599,6 @@ select.form-control {
     border-left: 4px solid var(--border-color);
 }
 
-.issue-item + .issue-item {
-    margin-top: 0.5rem;
-}
-
 .issue-item.issue-critical {
     border-left-color: var(--danger-color);
 }
@@ -2679,7 +2675,6 @@ select.form-control {
     font-size: 0.7rem;
     font-weight: 600;
     text-transform: uppercase;
-    margin-bottom: 0.375rem;
 }
 
 .issue-critical .issue-severity {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15193,6 +15193,14 @@ a.affected-client:hover {
     margin-bottom: 1rem;
 }
 
+.isp-health-card .issue-item + .issue-item {
+    margin-top: 0.5rem;
+}
+
+.isp-health-card .issue-severity {
+    margin-bottom: 0.375rem;
+}
+
 .isp-health-toolbar {
     display: flex;
     justify-content: flex-end;

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/StepChangeDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/StepChangeDetectorTests.cs
@@ -67,6 +67,21 @@ public class StepChangeDetectorTests
     }
 
     [Fact]
+    public void Short_lived_shift_reports_both_up_and_down()
+    {
+        var shiftUp = TestSeries.Start.AddHours(10);
+        var shiftDown = shiftUp.AddMinutes(90);
+        var samples = TestSeries.Flat(TestSeries.Start, Day, rttMs: 24, jitterMs: 0.3)
+            .WithSegment(shiftUp, shiftDown, rttMs: 25.5, jitterMs: 0.3);
+
+        var events = StepChangeDetector.DetectForSeries(TestSeries.Asn(64500, "TransitOne", samples), Options);
+
+        events.Should().HaveCount(2);
+        events[0].Direction.Should().Be(PathShiftDirection.Up);
+        events[1].Direction.Should().Be(PathShiftDirection.Down);
+    }
+
+    [Fact]
     public void Sub_threshold_change_is_ignored()
     {
         var stepAt = TestSeries.Start.AddHours(12);


### PR DESCRIPTION
## Summary

- **Xfinity XB8/XB10 cable modem provider** - Adds SNMP-based monitoring for Xfinity gateway devices (signal levels, channel stats, uptime)
- **ISP Health: Per-Network RTT tooltip fix** - Align all ASN series to a shared time grid so the shared tooltip reliably shows all networks, not just one
- **ISP Health: finding items spacing and mobile layout** - Add gap between findings, severity badge inline with title on mobile
- **ISP Health: step-change detection tuning** - Lower threshold to 1.2 ms and prefer transit ASN labels over generic internet targets in correlated path shifts
- **Fix step-down detection after short-lived transit shifts** - Step-down detector was missing legitimate drops masked by brief transit spikes
- **Clickable links from band distribution and AP load balance to client stats**
- **Fix mobile nav bar scroll behavior** - Auto-hide timer guards against collapsing on short pages where it would make content non-scrollable. Scroll-down hide preserves the smooth sticky animation. A ResizeObserver reveals the nav bar when tab content shrinks below scrollable (e.g. switching to a short tab after auto-hide on a long one).
- **Use negative top instead of transform for nav bar hide** - Sticky elements natively support top offset without creating a new stacking context, avoiding a potential source of scroll hit-testing issues on mobile.