### PR TITLE
Fix mobile nav bar scroll behavior on short pages

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -216,7 +216,8 @@
         });
 
         // Show nav bar when content shrinks below scrollable (e.g. tab switch to short content)
-        if (window.innerWidth <= 1024 && currentEl) {
+        var pageContent = document.querySelector('.page-content');
+        if (window.innerWidth <= 1024 && pageContent) {
             new ResizeObserver(function() {
                 var topBar = document.querySelector('.top-bar');
                 if (topBar && topBar.classList.contains('top-bar-hidden') && !isContentScrollable()) {
@@ -224,7 +225,7 @@
                     if (currentEl) currentEl.style.scrollPaddingTop = '70px';
                     startAutoHideTimer(topBar);
                 }
-            }).observe(currentEl);
+            }).observe(pageContent);
         }
 
         // Restart auto-hide timer when sidebar closes

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -102,19 +102,6 @@
             return currentEl && currentEl.scrollHeight > currentEl.clientHeight + 10;
         }
 
-        function wouldStillScroll() {
-            var bar = document.querySelector('.top-bar');
-            var barH = bar ? bar.offsetHeight : 0;
-            return currentEl && currentEl.scrollHeight - barH > currentEl.clientHeight + 10;
-        }
-
-        function collapseIfSafe(topBar) {
-            if (!topBar || !topBar.classList.contains('top-bar-hidden') || !wouldStillScroll()) return;
-            var barH = topBar.offsetHeight;
-            topBar.classList.add('top-bar-collapsed');
-            if (currentEl) currentEl.scrollTop = Math.max(0, currentEl.scrollTop - barH);
-        }
-
         function startAutoHideTimer(topBar) {
             clearAutoHideTimer();
             var page = document.querySelector('[data-autohide-nav]');
@@ -125,7 +112,7 @@
                 if (sidebarOpen) return;
                 if (topBar && !topBar.classList.contains('top-bar-hidden')) {
                     topBar.classList.add('top-bar-hidden');
-                    setTimeout(function() { collapseIfSafe(topBar); }, 350);
+                    setTimeout(function() { if (topBar.classList.contains('top-bar-hidden')) topBar.classList.add('top-bar-collapsed'); }, 350);
                     if (currentEl) currentEl.style.scrollPaddingTop = '0px';
                     var identityBar = document.querySelector('.identity-bar');
                     if (identityBar) identityBar.classList.remove('below-topbar');
@@ -167,7 +154,6 @@
 
                     if (st > lastScrollTop && st > 60 && isContentScrollable()) {
                         topBar.classList.add('top-bar-hidden');
-                        setTimeout(function() { collapseIfSafe(topBar); }, 350);
                         currentEl.style.scrollPaddingTop = '0px';
                         clearAutoHideTimer();
                     } else if (!nearBottom && scrollUpAccum > 60) {

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -108,6 +108,13 @@
             return currentEl && currentEl.scrollHeight - barH > currentEl.clientHeight + 10;
         }
 
+        function collapseIfSafe(topBar) {
+            if (!topBar || !topBar.classList.contains('top-bar-hidden') || !wouldStillScroll()) return;
+            var barH = topBar.offsetHeight;
+            topBar.classList.add('top-bar-collapsed');
+            if (currentEl) currentEl.scrollTop = Math.max(0, currentEl.scrollTop - barH);
+        }
+
         function startAutoHideTimer(topBar) {
             clearAutoHideTimer();
             var page = document.querySelector('[data-autohide-nav]');
@@ -118,7 +125,7 @@
                 if (sidebarOpen) return;
                 if (topBar && !topBar.classList.contains('top-bar-hidden')) {
                     topBar.classList.add('top-bar-hidden');
-                    setTimeout(function() { if (topBar.classList.contains('top-bar-hidden') && wouldStillScroll()) topBar.classList.add('top-bar-collapsed'); }, 350);
+                    setTimeout(function() { collapseIfSafe(topBar); }, 350);
                     if (currentEl) currentEl.style.scrollPaddingTop = '0px';
                     var identityBar = document.querySelector('.identity-bar');
                     if (identityBar) identityBar.classList.remove('below-topbar');
@@ -160,7 +167,7 @@
 
                     if (st > lastScrollTop && st > 60 && isContentScrollable()) {
                         topBar.classList.add('top-bar-hidden');
-                        setTimeout(function() { if (topBar.classList.contains('top-bar-hidden') && wouldStillScroll()) topBar.classList.add('top-bar-collapsed'); }, 350);
+                        setTimeout(function() { collapseIfSafe(topBar); }, 350);
                         currentEl.style.scrollPaddingTop = '0px';
                         clearAutoHideTimer();
                     } else if (!nearBottom && scrollUpAccum > 60) {

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -102,6 +102,12 @@
             return currentEl && currentEl.scrollHeight > currentEl.clientHeight + 10;
         }
 
+        function wouldStillScroll() {
+            var bar = document.querySelector('.top-bar');
+            var barH = bar ? bar.offsetHeight : 0;
+            return currentEl && currentEl.scrollHeight - barH > currentEl.clientHeight + 10;
+        }
+
         function startAutoHideTimer(topBar) {
             clearAutoHideTimer();
             var page = document.querySelector('[data-autohide-nav]');
@@ -112,7 +118,7 @@
                 if (sidebarOpen) return;
                 if (topBar && !topBar.classList.contains('top-bar-hidden')) {
                     topBar.classList.add('top-bar-hidden');
-                    setTimeout(function() { topBar.classList.add('top-bar-collapsed'); }, 350);
+                    setTimeout(function() { if (topBar.classList.contains('top-bar-hidden') && wouldStillScroll()) topBar.classList.add('top-bar-collapsed'); }, 350);
                     if (currentEl) currentEl.style.scrollPaddingTop = '0px';
                     var identityBar = document.querySelector('.identity-bar');
                     if (identityBar) identityBar.classList.remove('below-topbar');
@@ -154,7 +160,7 @@
 
                     if (st > lastScrollTop && st > 60 && isContentScrollable()) {
                         topBar.classList.add('top-bar-hidden');
-                        setTimeout(function() { if (topBar.classList.contains('top-bar-hidden')) topBar.classList.add('top-bar-collapsed'); }, 350);
+                        setTimeout(function() { if (topBar.classList.contains('top-bar-hidden') && wouldStillScroll()) topBar.classList.add('top-bar-collapsed'); }, 350);
                         currentEl.style.scrollPaddingTop = '0px';
                         clearAutoHideTimer();
                     } else if (!nearBottom && scrollUpAccum > 60) {
@@ -310,47 +316,6 @@
                     indicator.style.opacity = '0';
                 }
             });
-        })();
-        // Reveal nav bar on swipe-down when content is too short to scroll
-        (function() {
-            if (window.innerWidth > 1024) return;
-            var container = document.querySelector('.main-content');
-            if (!container) return;
-            var touchStartY = 0;
-            var revealAccum = 0;
-            var tracking = false;
-
-            container.addEventListener('touchstart', function(e) {
-                var topBar = document.querySelector('.top-bar');
-                if (topBar && topBar.classList.contains('top-bar-hidden') && !isContentScrollable()) {
-                    touchStartY = e.touches[0].pageY;
-                    revealAccum = 0;
-                    tracking = true;
-                } else {
-                    tracking = false;
-                }
-            }, { passive: true });
-
-            container.addEventListener('touchmove', function(e) {
-                if (!tracking) return;
-                var dy = e.touches[0].pageY - touchStartY;
-                if (dy > 0) {
-                    revealAccum = dy;
-                } else {
-                    revealAccum = 0;
-                }
-                if (revealAccum > 60) {
-                    var topBar = document.querySelector('.top-bar');
-                    if (topBar) {
-                        topBar.classList.remove('top-bar-hidden', 'top-bar-collapsed');
-                        if (currentEl) currentEl.style.scrollPaddingTop = '70px';
-                        startAutoHideTimer(topBar);
-                    }
-                    tracking = false;
-                }
-            }, { passive: true });
-
-            container.addEventListener('touchend', function() { tracking = false; }, { passive: true });
         })();
     })();
 </script>

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -215,6 +215,18 @@
             setTimeout(function() { window.scrollBy(0, 1); window.scrollBy(0, -1); }, 100);
         });
 
+        // Show nav bar when content shrinks below scrollable (e.g. tab switch to short content)
+        if (window.innerWidth <= 1024 && currentEl) {
+            new ResizeObserver(function() {
+                var topBar = document.querySelector('.top-bar');
+                if (topBar && topBar.classList.contains('top-bar-hidden') && !isContentScrollable()) {
+                    topBar.classList.remove('top-bar-hidden', 'top-bar-collapsed');
+                    if (currentEl) currentEl.style.scrollPaddingTop = '70px';
+                    startAutoHideTimer(topBar);
+                }
+            }).observe(currentEl);
+        }
+
         // Restart auto-hide timer when sidebar closes
         var sidebar = document.querySelector('.sidebar');
         if (sidebar) {

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -112,7 +112,7 @@
                 if (sidebarOpen) return;
                 if (topBar && !topBar.classList.contains('top-bar-hidden')) {
                     topBar.classList.add('top-bar-hidden');
-                    setTimeout(function() { if (topBar.classList.contains('top-bar-hidden')) topBar.classList.add('top-bar-collapsed'); }, 350);
+                    setTimeout(function() { if (topBar.classList.contains('top-bar-hidden') && currentEl && currentEl.scrollHeight - topBar.offsetHeight > currentEl.clientHeight + 10) topBar.classList.add('top-bar-collapsed'); }, 350);
                     if (currentEl) currentEl.style.scrollPaddingTop = '0px';
                     var identityBar = document.querySelector('.identity-bar');
                     if (identityBar) identityBar.classList.remove('below-topbar');

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -311,6 +311,47 @@
                 }
             });
         })();
+        // Reveal nav bar on swipe-down when content is too short to scroll
+        (function() {
+            if (window.innerWidth > 1024) return;
+            var container = document.querySelector('.main-content');
+            if (!container) return;
+            var touchStartY = 0;
+            var revealAccum = 0;
+            var tracking = false;
+
+            container.addEventListener('touchstart', function(e) {
+                var topBar = document.querySelector('.top-bar');
+                if (topBar && topBar.classList.contains('top-bar-hidden') && !isContentScrollable()) {
+                    touchStartY = e.touches[0].pageY;
+                    revealAccum = 0;
+                    tracking = true;
+                } else {
+                    tracking = false;
+                }
+            }, { passive: true });
+
+            container.addEventListener('touchmove', function(e) {
+                if (!tracking) return;
+                var dy = e.touches[0].pageY - touchStartY;
+                if (dy > 0) {
+                    revealAccum = dy;
+                } else {
+                    revealAccum = 0;
+                }
+                if (revealAccum > 60) {
+                    var topBar = document.querySelector('.top-bar');
+                    if (topBar) {
+                        topBar.classList.remove('top-bar-hidden', 'top-bar-collapsed');
+                        if (currentEl) currentEl.style.scrollPaddingTop = '70px';
+                        startAutoHideTimer(topBar);
+                    }
+                    tracking = false;
+                }
+            }, { passive: true });
+
+            container.addEventListener('touchend', function() { tracking = false; }, { passive: true });
+        })();
     })();
 </script>
 


### PR DESCRIPTION
## Summary

- **Auto-hide timer guards against collapsing on short pages** - Only transitions to position:absolute if the content would still be scrollable without the bar's flow space. Short pages keep sticky positioning so the user can scroll up to reveal the nav bar.
- **Scroll-down hide stays smooth** - Removed the position:absolute transition from the scroll-down path, restoring the smooth slide-up animation from #752.
- **ResizeObserver reveals nav on content shrink** - When tab content changes and becomes too short to scroll while the nav is hidden, the nav bar reappears automatically.