### PR TITLE
Use negative top instead of transform for mobile nav bar hide

### DIFF
--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -3108,12 +3108,12 @@ select.form-control {
         height: auto;
         padding: 0.75rem 1rem;
         gap: 0.5rem;
-        transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+        transition: top 0.35s cubic-bezier(0.4, 0, 0.2, 1);
     }
 
     .top-bar.top-bar-hidden {
         position: sticky;
-        transform: translateY(-100%);
+        top: -100%;
         pointer-events: none;
     }
 


### PR DESCRIPTION
## Summary

- **Replace transform with top for nav bar slide animation** - The hidden nav bar now uses `top: -100%` instead of `transform: translateY(-100%)` to slide off-screen. Sticky elements natively support `top` offset without creating a new stacking context, which `transform` does. This avoids a potential source of scroll hit-testing confusion that could contribute to the intermittent scroll-lock issue on mobile.