### PR TITLE
v1.20.4 - Per-hop ISP Health grading and new device alert rules

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -239,6 +239,13 @@ The following were implemented in the WiFi Optimizer feature:
 
 ## Monitoring
 
+### Multi-WAN Support (ISP Health & NMS)
+- ISP Health currently grades a single (primary) WAN. Several inputs are read globally rather than scoped to the WAN being scored:
+  - **Upstream ancestry / `hopOrderKnown`** (`IspHealthService.ComputeAsync`): `UpstreamDiscoveries` are queried across all WANs. Rows carry `WanInterface`, and the tracer persists per-WAN, but the scorer reads them globally - so a second WAN's discovery data can flip the jitter-absolve gate (and the routes-through witnesses) for a WAN that has no ancestry of its own. Scope the discovery query and `hopOrderKnown` by `WanInterface`.
+  - **Targets / series / rates** are likewise resolved for the primary WAN only; per-WAN scoring needs each WAN's own targets, latency series, throughput, and expected speeds.
+- Plan: grade ISP Health per-WAN (one report per active WAN), keyed by `WanInterface` end-to-end, and surface a per-WAN selector in the UI. Until then, secondary WANs are not separately graded.
+- **Relevant code:** `IspHealthService.ComputeAsync` (TODO marker at the discoveries query), `UpstreamTracerService.PersistHopOrderAsync` (already per-WAN), `MonitoringPathView` (already WAN-scoped).
+
 ### Gap-Gated SNMP Counter Reset Detection
 - `InterfaceRateCalculator` currently distinguishes a genuine counter reset (device reboot) from a single corrupt SNMP read by requiring two consecutive below-baseline reads before reseeding the baseline (`ResetPending` → `ResetConfirmed`). A discarded over-ceiling rate then advances the baseline so nothing can wedge an interface.
 - Cleaner discriminator: the **elapsed gap**. A real reset only follows a reboot, which trips ~5 consecutive SNMP failures (~25 s) and a 5-minute exclusion, so the first sample back has a large elapsed gap (~5 min). A corrupt-read glitch arrives at the normal ~5 s cadence with a tiny gap. So: backwards counter with a large gap (e.g. ≥ 60 s, above poll jitter and below the exclusion window) → reset, reseed immediately; backwards counter at normal cadence → glitch, hold the baseline and suppress. This reseeds genuine resets in one poll instead of two and makes the rare two-fast-corrupt-reads false-confirm impossible by construction.

--- a/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
+++ b/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
@@ -217,6 +217,133 @@ public static class DefaultAlertRules
             Source = "monitoring",
             MinSeverity = AlertSeverity.Warning,
             CooldownSeconds = 1800 // 30 minutes
+        },
+
+        // --- Gateway health (enabled - always available when monitoring is active) ---
+        new AlertRule
+        {
+            Name = "Gateway: High CPU",
+            IsEnabled = true,
+            EventTypePattern = "device.gateway_high_cpu",
+            Source = "device",
+            MinSeverity = AlertSeverity.Warning,
+            ThresholdPercent = 70,
+            CooldownSeconds = 1800 // 30 minutes
+        },
+        new AlertRule
+        {
+            Name = "Gateway: High Memory",
+            IsEnabled = true,
+            EventTypePattern = "device.gateway_high_memory",
+            Source = "device",
+            MinSeverity = AlertSeverity.Warning,
+            ThresholdPercent = 95,
+            CooldownSeconds = 1800 // 30 minutes
+        },
+
+        // --- Cable modem (disabled until user configures a cable modem) ---
+        new AlertRule
+        {
+            Name = "Cable Modem: Low SNR",
+            IsEnabled = false,
+            EventTypePattern = "cable_modem.ds_snr_low",
+            Source = "cable_modem",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 1800 // 30 minutes
+        },
+        new AlertRule
+        {
+            Name = "Cable Modem: Uncorrectable Errors",
+            IsEnabled = false,
+            EventTypePattern = "cable_modem.uncorrectable_errors",
+            Source = "cable_modem",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 1800 // 30 minutes
+        },
+        new AlertRule
+        {
+            Name = "Cable Modem: DS Power Out of Range",
+            IsEnabled = false,
+            EventTypePattern = "cable_modem.ds_power_out_of_range",
+            Source = "cable_modem",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 1800 // 30 minutes
+        },
+        new AlertRule
+        {
+            Name = "Cable Modem: US Power High",
+            IsEnabled = false,
+            EventTypePattern = "cable_modem.us_power_high",
+            Source = "cable_modem",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 1800 // 30 minutes
+        },
+        new AlertRule
+        {
+            Name = "Cable Modem: Channel Loss",
+            IsEnabled = false,
+            EventTypePattern = "cable_modem.channel_loss",
+            Source = "cable_modem",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 3600 // 1 hour
+        },
+
+        // --- External ONT (disabled until user configures an ONT) ---
+        new AlertRule
+        {
+            Name = "ONT: RX Power Low",
+            IsEnabled = false,
+            EventTypePattern = "ont.rx_power_low",
+            Source = "ont",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 1800 // 30 minutes
+        },
+        new AlertRule
+        {
+            Name = "ONT: PON Link Down",
+            IsEnabled = false,
+            EventTypePattern = "ont.pon_link_down",
+            Source = "ont",
+            MinSeverity = AlertSeverity.Error,
+            CooldownSeconds = 600 // 10 minutes
+        },
+        new AlertRule
+        {
+            Name = "ONT: FEC Error Spike",
+            IsEnabled = false,
+            EventTypePattern = "ont.fec_errors",
+            Source = "ont",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 1800 // 30 minutes
+        },
+
+        // --- Cellular modem (disabled until user configures a cellular modem) ---
+        new AlertRule
+        {
+            Name = "Cellular: Poor Signal",
+            IsEnabled = false,
+            EventTypePattern = "cellular.signal_poor",
+            Source = "cellular",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 1800 // 30 minutes
+        },
+        new AlertRule
+        {
+            Name = "Cellular: Network Downgrade",
+            IsEnabled = false,
+            EventTypePattern = "cellular.network_downgrade",
+            Source = "cellular",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 3600 // 1 hour
+        },
+        new AlertRule
+        {
+            Name = "Cellular: Roaming",
+            IsEnabled = false,
+            EventTypePattern = "cellular.roaming",
+            Source = "cellular",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 3600 // 1 hour
         }
     ];
 }

--- a/src/NetworkOptimizer.Storage/Migrations/20260615034638_AddUpstreamHopAncestors.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260615034638_AddUpstreamHopAncestors.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260615034638_AddUpstreamHopAncestors")]
+    partial class AddUpstreamHopAncestors
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260615034638_AddUpstreamHopAncestors.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260615034638_AddUpstreamHopAncestors.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <summary>
+    /// Adds AncestorHopIps to UpstreamDiscoveries: the monitored hops proven upstream of
+    /// each hop on the discovery traces, so ISP Health can confirm one hop routes through
+    /// another across divergent paths.
+    ///
+    /// The scaffolder also emitted UniFiSshSettings changes because the model snapshot was
+    /// stale (it described the old shape with a Host column). Those columns already exist
+    /// identically on every site - the original AddUniFiSshSettings migration created them -
+    /// so applying that DDL would crash with duplicate/no-such-column. The snapshot is
+    /// regenerated to the correct shape (design-time only, never runs on sites); this
+    /// migration deliberately carries ONLY the AncestorHopIps column.
+    /// </summary>
+    public partial class AddUpstreamHopAncestors : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AncestorHopIps",
+                table: "UpstreamDiscoveries",
+                type: "TEXT",
+                maxLength: 2000,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AncestorHopIps",
+                table: "UpstreamDiscoveries");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/DesignTimeDbContextFactory.cs
+++ b/src/NetworkOptimizer.Storage/Models/DesignTimeDbContextFactory.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace NetworkOptimizer.Storage.Models;
+
+/// <summary>
+/// Design-time factory so EF Core tooling (dotnet ef migrations) can construct the
+/// context without the app's DI. Not used at runtime.
+/// </summary>
+public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<NetworkOptimizerDbContext>
+{
+    public NetworkOptimizerDbContext CreateDbContext(string[] args)
+    {
+        var options = new DbContextOptionsBuilder<NetworkOptimizerDbContext>()
+            .UseSqlite("Data Source=design-time.db")
+            .Options;
+        return new NetworkOptimizerDbContext(options);
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/UpstreamDiscovery.cs
+++ b/src/NetworkOptimizer.Storage/Models/UpstreamDiscovery.cs
@@ -32,6 +32,15 @@ public class UpstreamDiscovery
 
     public int HopNumber { get; set; }
 
+    /// <summary>
+    /// Space-separated IPs of the monitored hops that appear before this one on any
+    /// discovery trace it was seen on - its proven upstream ancestors. ISP Health uses
+    /// these to confirm one hop genuinely routes through another (a witness only absolves
+    /// a hop in its ancestor set), correct across divergent paths. Empty for a first hop.
+    /// </summary>
+    [MaxLength(2000)]
+    public string? AncestorHopIps { get; set; }
+
     public UpstreamRole Role { get; set; }
 
     [MaxLength(50)]

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -69,11 +69,14 @@
         </main>
 
         <footer class="app-footer">
-            @{ var infoVersion = Assembly.GetExecutingAssembly().GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>()?.InformationalVersion; }
+            @{
+                var infoVersion = Assembly.GetExecutingAssembly().GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+                var baseVersion = infoVersion is not null ? System.Text.RegularExpressions.Regex.Match(infoVersion, @"^\d+\.\d+\.\d+").Value : null;
+            }
             <p>&copy; 2026 Ozark Connect - Network Optimizer
-                @if (infoVersion is { } ver && !ver.StartsWith("0.0.0"))
+                @if (baseVersion is { Length: > 0 } bv && !bv.StartsWith("0.0.0"))
                 {
-                    <a href="https://github.com/Ozark-Connect/NetworkOptimizer/releases/tag/v@(ver)" target="_blank" rel="noopener">v@(ver)</a>
+                    <a href="https://github.com/Ozark-Connect/NetworkOptimizer/releases/tag/v@(bv)" target="_blank" rel="noopener">v@(infoVersion)</a>
                 }
                 else
                 {

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -69,7 +69,17 @@
         </main>
 
         <footer class="app-footer">
-            <p>&copy; 2026 Ozark Connect - Network Optimizer @(Assembly.GetExecutingAssembly().GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>()?.InformationalVersion is string v && !v.StartsWith("0.0.0") ? $"v{v}" : "(source build)")</p>
+            @{ var infoVersion = Assembly.GetExecutingAssembly().GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>()?.InformationalVersion; }
+            <p>&copy; 2026 Ozark Connect - Network Optimizer
+                @if (infoVersion is { } ver && !ver.StartsWith("0.0.0"))
+                {
+                    <a href="https://github.com/Ozark-Connect/NetworkOptimizer/releases/tag/v@(ver)" target="_blank" rel="noopener">v@(ver)</a>
+                }
+                else
+                {
+                    <span>(source build)</span>
+                }
+            </p>
         </footer>
     </div>
 </div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -619,7 +619,13 @@
             {
                 @if (_unresolvedAlerts.Any(a => a.Status == AlertStatus.Active))
                 {
-                    <h2 class="alert-group-title">Active</h2>
+                    <div class="alert-group-header">
+                        <h2 class="alert-group-title">Active</h2>
+                        <div class="alert-group-actions">
+                            <button class="btn btn-sm btn-secondary" @onclick="AcknowledgeAllActive">Acknowledge All</button>
+                            <button class="btn btn-sm btn-primary" @onclick="ResolveAllActive">Resolve All</button>
+                        </div>
+                    </div>
                     <div class="alert-list">
                         @foreach (var alert in _unresolvedAlerts.Where(a => a.Status == AlertStatus.Active))
                         {
@@ -669,7 +675,12 @@
 
                 @if (_unresolvedAlerts.Any(a => a.Status == AlertStatus.Acknowledged))
                 {
-                    <h2 class="alert-group-title">Acknowledged</h2>
+                    <div class="alert-group-header">
+                        <h2 class="alert-group-title">Acknowledged</h2>
+                        <div class="alert-group-actions">
+                            <button class="btn btn-sm btn-primary" @onclick="ResolveAllAcknowledged">Resolve All</button>
+                        </div>
+                    </div>
                     <div class="alert-list">
                         @foreach (var alert in _unresolvedAlerts.Where(a => a.Status == AlertStatus.Acknowledged))
                         {
@@ -1328,12 +1339,23 @@
         gap: 0.75rem;
         padding-bottom: 0.25rem;
     }
+    .alert-group-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 0.5rem;
+        margin-top: 0.5rem;
+    }
+    .alert-group-actions {
+        display: flex;
+        gap: 0.5rem;
+    }
     .alert-group-title {
         font-size: 0.9rem;
         font-weight: 600;
         color: var(--text-secondary);
-        margin-bottom: 0.5rem;
-        margin-top: 0.5rem;
+        margin-bottom: 0;
+        margin-top: 0;
         text-transform: uppercase;
         letter-spacing: 0.05em;
     }
@@ -1494,6 +1516,43 @@
                         <div @onclick='() => SelectEventType("monitoring.sfp_tx_power")'><code>monitoring.sfp_tx_power</code> <span>SFP/PON TX power above threshold</span></div>
                         <div @onclick='() => SelectEventType("monitoring.sfp_temperature")'><code>monitoring.sfp_temperature</code> <span>SFP temperature above threshold</span></div>
                         <div @onclick='() => SelectEventType("monitoring.*")'><code>monitoring.*</code> <span>All monitoring events</span></div>
+                    </div>
+                </div>
+                <div>
+                    <h4 class="event-type-group-header">Gateway Health</h4>
+                    <div class="event-type-key-list">
+                        <div @onclick='() => SelectEventType("device.gateway_high_cpu")'><code>device.gateway_high_cpu</code> <span>Gateway CPU sustained above threshold</span></div>
+                        <div @onclick='() => SelectEventType("device.gateway_high_memory")'><code>device.gateway_high_memory</code> <span>Gateway memory above threshold</span></div>
+                        <div @onclick='() => SelectEventType("device.*")'><code>device.*</code> <span>All device events</span></div>
+                    </div>
+                </div>
+                <div>
+                    <h4 class="event-type-group-header">Cable Modem</h4>
+                    <div class="event-type-key-list">
+                        <div @onclick='() => SelectEventType("cable_modem.ds_snr_low")'><code>cable_modem.ds_snr_low</code> <span>Downstream SNR below threshold</span></div>
+                        <div @onclick='() => SelectEventType("cable_modem.uncorrectable_errors")'><code>cable_modem.uncorrectable_errors</code> <span>Uncorrectable FEC error spike</span></div>
+                        <div @onclick='() => SelectEventType("cable_modem.ds_power_out_of_range")'><code>cable_modem.ds_power_out_of_range</code> <span>DS power outside DOCSIS spec range</span></div>
+                        <div @onclick='() => SelectEventType("cable_modem.us_power_high")'><code>cable_modem.us_power_high</code> <span>US transmit power too high</span></div>
+                        <div @onclick='() => SelectEventType("cable_modem.channel_loss")'><code>cable_modem.channel_loss</code> <span>Locked channel count dropped</span></div>
+                        <div @onclick='() => SelectEventType("cable_modem.*")'><code>cable_modem.*</code> <span>All cable modem events</span></div>
+                    </div>
+                </div>
+                <div>
+                    <h4 class="event-type-group-header">External ONT</h4>
+                    <div class="event-type-key-list">
+                        <div @onclick='() => SelectEventType("ont.rx_power_low")'><code>ont.rx_power_low</code> <span>Optical RX power below threshold</span></div>
+                        <div @onclick='() => SelectEventType("ont.pon_link_down")'><code>ont.pon_link_down</code> <span>PON link lost</span></div>
+                        <div @onclick='() => SelectEventType("ont.fec_errors")'><code>ont.fec_errors</code> <span>FEC error rate spike</span></div>
+                        <div @onclick='() => SelectEventType("ont.*")'><code>ont.*</code> <span>All ONT events</span></div>
+                    </div>
+                </div>
+                <div>
+                    <h4 class="event-type-group-header">Cellular Modem</h4>
+                    <div class="event-type-key-list">
+                        <div @onclick='() => SelectEventType("cellular.signal_poor")'><code>cellular.signal_poor</code> <span>Signal quality dropped to poor</span></div>
+                        <div @onclick='() => SelectEventType("cellular.network_downgrade")'><code>cellular.network_downgrade</code> <span>Network mode downgraded (5G to LTE)</span></div>
+                        <div @onclick='() => SelectEventType("cellular.roaming")'><code>cellular.roaming</code> <span>Modem entered roaming state</span></div>
+                        <div @onclick='() => SelectEventType("cellular.*")'><code>cellular.*</code> <span>All cellular events</span></div>
                     </div>
                 </div>
                 <div>
@@ -2124,6 +2183,69 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error resolving alert {Id}", alert.Id);
+        }
+    }
+
+    private async Task AcknowledgeAllActive()
+    {
+        try
+        {
+            var active = _unresolvedAlerts.Where(a => a.Status == AlertStatus.Active).ToList();
+            var now = DateTime.UtcNow;
+            foreach (var alert in active)
+            {
+                alert.Status = AlertStatus.Acknowledged;
+                alert.AcknowledgedAt = now;
+                await AlertRepository.UpdateAlertAsync(alert);
+                await RecalculateIncidentStatusAsync(alert);
+            }
+            await LoadActiveAlerts();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error acknowledging all active alerts");
+        }
+    }
+
+    private async Task ResolveAllActive()
+    {
+        try
+        {
+            var active = _unresolvedAlerts.Where(a => a.Status == AlertStatus.Active).ToList();
+            var now = DateTime.UtcNow;
+            foreach (var alert in active)
+            {
+                alert.Status = AlertStatus.Resolved;
+                alert.ResolvedAt = now;
+                await AlertRepository.UpdateAlertAsync(alert);
+                await RecalculateIncidentStatusAsync(alert);
+            }
+            await LoadActiveAlerts();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error resolving all active alerts");
+        }
+    }
+
+    private async Task ResolveAllAcknowledged()
+    {
+        try
+        {
+            var acknowledged = _unresolvedAlerts.Where(a => a.Status == AlertStatus.Acknowledged).ToList();
+            var now = DateTime.UtcNow;
+            foreach (var alert in acknowledged)
+            {
+                alert.Status = AlertStatus.Resolved;
+                alert.ResolvedAt = now;
+                await AlertRepository.UpdateAlertAsync(alert);
+                await RecalculateIncidentStatusAsync(alert);
+            }
+            await LoadActiveAlerts();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error resolving all acknowledged alerts");
         }
     }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -71,6 +71,20 @@ else if (_report == null)
 else
 {
     var r = _report;
+    @if (!r.HasUpstreamTraceMap)
+    {
+        <div class="alert alert-info" style="margin-bottom: 0.75rem;">
+            <div class="banner-content">
+                <span class="banner-icon banner-icon-info">i</span>
+                <div class="banner-text" style="flex: 1;">
+                    Re-run Upstream Discovery to map your trace path, so ISP Health can tell a genuinely congested hop from one that just deprioritizes ICMP.
+                </div>
+                <div class="banner-actions">
+                    <button class="btn btn-sm btn-primary" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&discover=1"))">Re-run Upstream Discovery</button>
+                </div>
+            </div>
+        </div>
+    }
     <div class="isp-health-toolbar">
         <button class="btn btn-sm btn-secondary" @onclick="RefreshAsync" disabled="@_refreshing"
                 data-tooltip="Recompute ISP Health now from the latest monitoring data" data-tooltip-hover-only>
@@ -172,60 +186,88 @@ else
                     <span class="isp-dimension-score @ScoreTextClass(dimension.Score)">@(dimension.Score?.ToString() ?? "--")</span>
                 </div>
                 <div class="card-body">
-                    @if (dimension.Factors.Count == 0)
+                    @if (dimension == r.IspAsnDimension)
                     {
-                        <p class="page-description">No data for this dimension in the window.</p>
-                    }
-                    @foreach (var factor in dimension.Factors)
-                    {
-                        <div class="isp-factor-row">
-                            <div class="isp-factor-label">
-                                @{ var investigateUrl = FactorInvestigateUrl(factor.Name); }
-                                @if (investigateUrl != null)
-                                {
-                                    <a class="isp-factor-name isp-factor-link" href="@investigateUrl"
-                                       data-tooltip="Jump to the most recent matching loss event on the Network Performance charts">@factor.Name</a>
-                                }
-                                else
-                                {
-                                    <span class="isp-factor-name">@factor.Name</span>
-                                }
-                                @if (!string.IsNullOrEmpty(factor.ValueText))
-                                {
-                                    <span class="isp-factor-value">@factor.ValueText</span>
-                                }
-                            </div>
-                            <div class="isp-factor-bar-track">
-                                <div class="isp-factor-bar @BarClass(factor.Score)" style="width: @(factor.Score ?? 0)%"></div>
-                            </div>
-                            <span class="isp-factor-score @ScoreTextClass(factor.Score)">@(factor.Score?.ToString() ?? "--")</span>
-                        </div>
-                        @if (!string.IsNullOrEmpty(factor.Description))
+                        @if (r.IspTargets.Count == 0)
                         {
-                            <div class="isp-factor-description">@factor.Description</div>
+                            <p class="page-description">No ISP hop data in the window.</p>
                         }
-                    }
-                    @if (dimension == r.IspAsnDimension && r.IspTargets.Count > 1)
-                    {
-                        <div class="isp-target-list">
+                        <div class="isp-hop-list">
                             @foreach (var target in r.IspTargets)
                             {
-                                <div class="isp-target-row">
-                                    <div class="isp-target-name">
-                                        @target.Name
-                                        @if (target.IsGradedHop)
-                                        {
-                                            <span class="isp-target-graded" data-tooltip="The first clean hop; latency factors and the ISP grade come from this target">graded</span>
-                                        }
+                                <div class="isp-hop">
+                                    <div class="isp-hop-row">
+                                        <div class="isp-hop-main">
+                                            <div class="isp-hop-name">
+                                                @target.Name
+                                                @if (target.IsGradedHop)
+                                                {
+                                                    <span class="isp-target-graded" data-tooltip="The lowest-RTT ISP hop; access-layer idle latency is measured from it">Lowest RTT</span>
+                                                }
+                                            </div>
+                                            <div class="isp-factor-bar-track">
+                                                <div class="isp-factor-bar @BarClass(target.OverallScore)" style="width: @(target.OverallScore ?? 0)%"></div>
+                                            </div>
+                                        </div>
+                                        <span class="isp-factor-score @ScoreTextClass(target.OverallScore)">@(target.OverallScore?.ToString() ?? "--")</span>
                                     </div>
-                                    <div class="isp-target-stats">
-                                        <span class="isp-target-stat"><span class="isp-target-stat-label">RTT</span>@FormatRtt(target.MedianRttMs)</span>
-                                        <span class="isp-target-stat"><span class="isp-target-stat-label">P95 Jitter</span>@FormatMs(target.P95JitterMs)</span>
+                                    <div class="isp-hop-stats">
+                                        <span class="isp-target-stat"><span class="isp-target-stat-label">RTT</span>@FormatRtt(target.RttMs)</span>
+                                        <span class="isp-target-stat">
+                                            <span class="isp-target-stat-label">P95 Jitter</span>
+                                            <span class="isp-target-stat-value">
+                                                @FormatJitter(target.P95JitterMs)
+                                                @if (target.JitterAssimilated)
+                                                {
+                                                    <span class="tooltip-icon tooltip-icon-sm" data-tooltip="@JitterAssimilationTooltip(target)">i</span>
+                                                }
+                                            </span>
+                                        </span>
                                         <span class="isp-target-stat"><span class="isp-target-stat-label">Loss</span>@FormatLossPct(target.LossPct)</span>
+                                        @if (target.ReachDeltaMs is > 0.15)
+                                        {
+                                            <span class="isp-target-stat"><span class="isp-target-stat-label">Beyond nearest</span>+@FormatMs(target.ReachDeltaMs)</span>
+                                        }
                                     </div>
                                 </div>
                             }
                         </div>
+                    }
+                    else
+                    {
+                        @if (dimension.Factors.Count == 0)
+                        {
+                            <p class="page-description">No data for this dimension in the window.</p>
+                        }
+                        @foreach (var factor in dimension.Factors)
+                        {
+                            <div class="isp-factor-row">
+                                <div class="isp-factor-label">
+                                    @{ var investigateUrl = FactorInvestigateUrl(factor.Name); }
+                                    @if (investigateUrl != null)
+                                    {
+                                        <a class="isp-factor-name isp-factor-link" href="@investigateUrl"
+                                           data-tooltip="Jump to the most recent matching loss event on the Network Performance charts">@factor.Name</a>
+                                    }
+                                    else
+                                    {
+                                        <span class="isp-factor-name">@factor.Name</span>
+                                    }
+                                    @if (!string.IsNullOrEmpty(factor.ValueText))
+                                    {
+                                        <span class="isp-factor-value">@factor.ValueText</span>
+                                    }
+                                </div>
+                                <div class="isp-factor-bar-track">
+                                    <div class="isp-factor-bar @BarClass(factor.Score)" style="width: @(factor.Score ?? 0)%"></div>
+                                </div>
+                                <span class="isp-factor-score @ScoreTextClass(factor.Score)">@(factor.Score?.ToString() ?? "--")</span>
+                            </div>
+                            @if (!string.IsNullOrEmpty(factor.Description))
+                            {
+                                <div class="isp-factor-description">@factor.Description</div>
+                            }
+                        }
                     }
                 </div>
             </div>
@@ -240,17 +282,36 @@ else
                 <div class="isp-asn-grid">
                     @foreach (var asn in r.IspAsns.Concat(r.TransitAsns))
                     {
+                        var isIspAsn = r.IspAsns.Contains(asn);
+                        var showRange = isIspAsn && asn.MinRttMs.HasValue && asn.MaxRttMs.HasValue
+                            && asn.MaxRttMs.Value - asn.MinRttMs.Value > 0.05;
                         <div class="isp-asn-card">
                             <div class="isp-asn-card-header">
                                 <div>
                                     <div class="isp-asn-name">@(string.IsNullOrEmpty(asn.AsnName) ? $"AS{asn.AsnNumber}" : asn.AsnName)</div>
-                                    <div class="isp-asn-sub">@(r.IspAsns.Contains(asn) ? "ISP network" : "Transit") @(asn.AsnNumber > 0 ? $"· AS{asn.AsnNumber}" : "")</div>
+                                    <div class="isp-asn-sub">@(isIspAsn ? "ISP network" : "Transit") @(asn.AsnNumber > 0 ? $"· AS{asn.AsnNumber}" : "")</div>
                                 </div>
                                 <span class="isp-asn-grade @ScoreTextClass(asn.OverallScore)">@(asn.OverallScore?.ToString() ?? "--")</span>
                             </div>
                             <div class="isp-asn-stats">
-                                <div class="isp-asn-stat"><span class="detail-label">Mean RTT</span><span class="detail-value">@FormatMs(asn.MeanRttMs)</span></div>
-                                <div class="isp-asn-stat"><span class="detail-label">P95 Jitter</span><span class="detail-value">@FormatMs(asn.P95JitterMs)</span></div>
+                                @if (showRange)
+                                {
+                                    <div class="isp-asn-stat"><span class="detail-label">RTT Range</span><span class="detail-value">@FormatRttRange(asn.MinRttMs, asn.MaxRttMs)</span></div>
+                                }
+                                else
+                                {
+                                    <div class="isp-asn-stat"><span class="detail-label">Mean RTT</span><span class="detail-value">@FormatRtt(asn.MeanRttMs)</span></div>
+                                }
+                                <div class="isp-asn-stat">
+                                    <span class="detail-label">P95 Jitter</span>
+                                    <span class="detail-value">
+                                        @FormatJitter(asn.P95JitterMs)
+                                        @if (asn.JitterAssimilated)
+                                        {
+                                            <span class="tooltip-icon tooltip-icon-sm" data-tooltip="@JitterAssimilationTooltip(asn, isIspAsn)">i</span>
+                                        }
+                                    </span>
+                                </div>
                                 <div class="isp-asn-stat"><span class="detail-label">Loss</span><span class="detail-value">@FormatLossPct(asn.LossPct)</span></div>
                                 @if (asn.ReachDeltaMs.HasValue)
                                 {
@@ -324,6 +385,7 @@ else
     private bool _loading = true;
     private bool _chartMounted;
     private bool _refreshing;
+    private System.Threading.Timer? _ageTimer;
 
     protected override async Task OnInitializedAsync()
     {
@@ -341,6 +403,14 @@ else
         {
             _loading = false;
         }
+
+        // Re-render every 30 s so "Last updated: N min ago" ages on its own, without
+        // waiting for a tab reload or a manual refresh.
+        _ageTimer = new System.Threading.Timer(_ =>
+        {
+            try { _ = InvokeAsync(StateHasChanged); }
+            catch { /* never let a render fault kill the timer */ }
+        }, null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
     }
 
     private async Task RefreshAsync()
@@ -414,7 +484,19 @@ else
 
     private static string FormatMs(double? ms) => ms.HasValue ? $"{ms.Value:0.#} ms" : "--";
 
-    private static string FormatRtt(double? ms) => ms.HasValue ? $"{ms.Value:0.0} ms" : "--";
+    private static string FormatJitter(double? ms) => ms.HasValue ? $"{ms.Value:0.00} ms" : "--";
+
+    private static string JitterAssimilationTooltip(IspAsnHealth asn, bool isIsp) => isIsp
+        ? $"Showing {FormatJitter(asn.P95JitterMs)} from the cleanest network beyond your ISP, not your ISP routers' {FormatJitter(asn.RawJitterMs)}. All traffic crosses the ISP to reach it, so the ISP is no jitterier - its higher reading is likely ICMP deprioritization."
+        : $"Showing {FormatJitter(asn.P95JitterMs)} from a router deeper in this network, not the {FormatJitter(asn.RawJitterMs)} a closer router reported. Traffic passes through the closer router to reach it, so the lower value is the true path jitter - the closer router just deprioritizes ICMP.";
+
+    private static string JitterAssimilationTooltip(IspTargetHealth target) =>
+        $"Showing {FormatJitter(target.P95JitterMs)} measured to a network reached through this router, not its own {FormatJitter(target.RawJitterMs)}. Traffic passes through it cleanly, so the higher reading is this router deprioritizing ICMP, not real jitter.";
+
+    private static string FormatRtt(double? ms) => ms.HasValue ? $"{ms.Value:0.00} ms" : "--";
+
+    private static string FormatRttRange(double? min, double? max) =>
+        min.HasValue && max.HasValue ? $"{min.Value:0.00} - {max.Value:0.00} ms" : "--";
 
     private static string FormatLossPct(double? pct) => pct switch { null => "--", 0 => "0%", _ => $"{pct.Value:0.##}%" };
 
@@ -447,6 +529,7 @@ else
 
     public void Dispose()
     {
+        _ageTimer?.Dispose();
         if (_chartMounted)
         {
             try { _ = JS.InvokeVoidAsync("eval", "window.__ispHealthCharts?.unmount();"); }

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -368,6 +368,10 @@ builder.Services.AddScoped<NetworkOptimizer.Web.Services.Monitoring.MonitoringPa
 builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.AsnResolutionService>();
 builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.MonitoringAlertEvaluator>();
 builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.SfpAlertEvaluator>();
+builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.DeviceHealthAlertEvaluator>();
+builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.CableModemAlertEvaluator>();
+builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.OntAlertEvaluator>();
+builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.CellularAlertEvaluator>();
 builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.UpstreamTracerService>();
 builder.Services.AddScoped<InfluxDbProvisioningService>();
 // Probe-execution layer: the server-side LocalProbeExecutor is the default vantage. SSH
@@ -611,6 +615,35 @@ using (var scope = app.Services.CreateScope())
             db.AlertRules.AddRange(missing);
             db.SaveChanges();
             app.Logger.LogInformation("Seeded {Count} new alert rules", missing.Count);
+        }
+
+        // Auto-enable freshly seeded modem/ONT rules for users who already have
+        // configs. Only touches rules we just inserted - never re-enables rules
+        // the user has manually disabled.
+        if (missing.Count > 0)
+        {
+            var seededPatterns = missing.Select(m => m.EventTypePattern).ToHashSet();
+            EnableFreshlySeeded(db, "cable_modem", seededPatterns, () => db.CmConfigurations.Any());
+            EnableFreshlySeeded(db, "ont", seededPatterns, () => db.OntConfigurations.Any());
+            EnableFreshlySeeded(db, "cellular", seededPatterns, () => db.ModemConfigurations.Any());
+        }
+
+        static void EnableFreshlySeeded(
+            NetworkOptimizer.Storage.Models.NetworkOptimizerDbContext db,
+            string source,
+            HashSet<string> seededPatterns,
+            Func<bool> hasConfigs)
+        {
+            var freshlySeeded = db.AlertRules
+                .Where(r => r.Source == source && !r.IsEnabled)
+                .ToList()
+                .Where(r => seededPatterns.Contains(r.EventTypePattern))
+                .ToList();
+            if (freshlySeeded.Count > 0 && hasConfigs())
+            {
+                foreach (var rule in freshlySeeded) rule.IsEnabled = true;
+                db.SaveChanges();
+            }
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/AlertRuleAutoEnable.cs
+++ b/src/NetworkOptimizer.Web/Services/AlertRuleAutoEnable.cs
@@ -1,0 +1,41 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NetworkOptimizer.Storage.Models;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Enables disabled alert rules by source when a user configures their first
+/// monitoring target of that type. Skips if the user already has enabled rules
+/// for that source (meaning they've already interacted with them).
+/// </summary>
+public static class AlertRuleAutoEnable
+{
+    public static async Task EnableBySourceAsync(IServiceScope scope, string source, ILogger logger)
+    {
+        try
+        {
+            var db = scope.ServiceProvider.GetRequiredService<NetworkOptimizerDbContext>();
+
+            var anyEnabled = await db.AlertRules
+                .AnyAsync(r => r.Source == source && r.IsEnabled);
+            if (anyEnabled) return;
+
+            var disabled = await db.AlertRules
+                .Where(r => r.Source == source && !r.IsEnabled)
+                .ToListAsync();
+
+            if (disabled.Count == 0) return;
+
+            foreach (var rule in disabled) rule.IsEnabled = true;
+            await db.SaveChangesAsync();
+
+            logger.LogInformation("Auto-enabled {Count} {Source} alert rules", disabled.Count, source);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to auto-enable {Source} alert rules", source);
+        }
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/CableModemMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemMonitorService.cs
@@ -18,6 +18,7 @@ public sealed class CableModemMonitorService : IDisposable
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ICredentialProtectionService _credentialProtection;
     private readonly MonitoringInfluxClient _influx;
+    private readonly NetworkOptimizer.Web.Services.Monitoring.CableModemAlertEvaluator _alertEvaluator;
     private readonly ILogger<CableModemMonitorService> _logger;
     private readonly Dictionary<string, ICableModemProvider> _providers;
     private readonly Timer _pollingTimer;
@@ -34,11 +35,13 @@ public sealed class CableModemMonitorService : IDisposable
         IEnumerable<ICableModemProvider> providers,
         ICredentialProtectionService credentialProtection,
         MonitoringInfluxClient influx,
+        NetworkOptimizer.Web.Services.Monitoring.CableModemAlertEvaluator alertEvaluator,
         ILogger<CableModemMonitorService> logger)
     {
         _scopeFactory = scopeFactory;
         _credentialProtection = credentialProtection;
         _influx = influx;
+        _alertEvaluator = alertEvaluator;
         _logger = logger;
         _providers = providers.ToDictionary(p => p.ProviderKey, StringComparer.OrdinalIgnoreCase);
 
@@ -91,9 +94,14 @@ public sealed class CableModemMonitorService : IDisposable
             config.Password = _credentialProtection.Encrypt(config.Password);
         }
 
+        var isNew = config.Id == 0;
+
         using var scope = _scopeFactory.CreateScope();
         var repo = scope.ServiceProvider.GetRequiredService<ICmRepository>();
         await repo.SaveCmConfigurationAsync(config);
+
+        if (isNew)
+            await AlertRuleAutoEnable.EnableBySourceAsync(scope, "cable_modem", _logger);
     }
 
     /// <summary>
@@ -322,6 +330,12 @@ public sealed class CableModemMonitorService : IDisposable
 
             _previousTotalCorrectables[config.Id] = currentCorrectables;
             _previousTotalUncorrectables[config.Id] = currentUncorrectables;
+
+            _ = _alertEvaluator.EvaluateAsync(
+                config.Id, config.Name,
+                stats.DownstreamSnrAvgDb, stats.DownstreamPowerAvgDbmv, stats.UpstreamPowerAvgDbmv,
+                stats.LockedDsChannels, stats.LockedUsChannels,
+                deltaUncorrectables);
 
             // Fire-and-forget write to InfluxDB
             _ = Task.Run(async () =>

--- a/src/NetworkOptimizer.Web/Services/CellularModemService.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemService.cs
@@ -22,6 +22,7 @@ public class CellularModemService : ICellularModemService
     private readonly MonitoringInfluxClient _influx;
     private readonly ICredentialProtectionService _credentialProtection;
     private readonly Dictionary<string, ICellularModemProvider> _providers;
+    private readonly NetworkOptimizer.Web.Services.Monitoring.CellularAlertEvaluator _alertEvaluator;
     private readonly Timer? _pollingTimer;
     private readonly object _lock = new();
     private CellularModemStats? _lastStats;
@@ -37,6 +38,7 @@ public class CellularModemService : ICellularModemService
         UniFiConnectionService connectionService,
         MonitoringInfluxClient influx,
         ICredentialProtectionService credentialProtection,
+        NetworkOptimizer.Web.Services.Monitoring.CellularAlertEvaluator alertEvaluator,
         IEnumerable<ICellularModemProvider> providers)
     {
         _logger = logger;
@@ -45,6 +47,7 @@ public class CellularModemService : ICellularModemService
         _connectionService = connectionService;
         _influx = influx;
         _credentialProtection = credentialProtection;
+        _alertEvaluator = alertEvaluator;
         _providers = providers.ToDictionary(p => p.ProviderKey, StringComparer.OrdinalIgnoreCase);
 
         if (!_providers.ContainsKey(DefaultProviderKey))
@@ -229,6 +232,10 @@ public class CellularModemService : ICellularModemService
                 // Write to InfluxDB for time-series charting
                 WriteCellularToInflux(modem, stats);
 
+                _ = _alertEvaluator.EvaluateAsync(
+                    modem.Id, modem.Name,
+                    stats.SignalQuality, stats.NetworkMode, stats.IsRoaming);
+
                 return (true, $"Modem polled successfully. RSRP: {stats.Lte?.Rsrp ?? stats.Nr5g?.Rsrp}dBm");
             }
             else
@@ -266,9 +273,15 @@ public class CellularModemService : ICellularModemService
             config.Password = _credentialProtection.Encrypt(config.Password);
         }
 
+        var isNew = config.Id == 0;
+
         using var scope = _serviceProvider.CreateScope();
         var repository = scope.ServiceProvider.GetRequiredService<IModemRepository>();
         await repository.SaveModemConfigurationAsync(config);
+
+        if (isNew)
+            await AlertRuleAutoEnable.EnableBySourceAsync(scope, "cellular", _logger);
+
         return config;
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/CableModemAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/CableModemAlertEvaluator.cs
@@ -1,0 +1,237 @@
+using System.Collections.Concurrent;
+using NetworkOptimizer.Alerts.Events;
+using NetworkOptimizer.Core.Enums;
+
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Evaluates cable modem DOCSIS metrics against thresholds and publishes alert
+/// events on state transitions. Covers downstream SNR, downstream/upstream power
+/// levels, uncorrectable FEC errors, and locked channel count drops. Thresholds
+/// are based on DOCSIS 3.0/3.1 operating specifications.
+/// </summary>
+public class CableModemAlertEvaluator
+{
+    private const double DsSnrLowDb = 33.0;
+    private const double DsSnrClearDb = 36.0;
+
+    private const double DsPowerLowDbmv = -7.0;
+    private const double DsPowerHighDbmv = 7.0;
+    private const double DsPowerClearLowDbmv = -5.0;
+    private const double DsPowerClearHighDbmv = 5.0;
+
+    private const double UsPowerHighDbmv = 51.0;
+    private const double UsPowerClearDbmv = 48.0;
+
+    private const long UncorrectablesDeltaThreshold = 500;
+
+    private const int ChannelDropThreshold = 4;
+
+    private readonly IAlertEventBus _eventBus;
+    private readonly ILogger<CableModemAlertEvaluator> _logger;
+    private readonly ConcurrentDictionary<string, CmAlertState> _states = new();
+
+    public CableModemAlertEvaluator(IAlertEventBus eventBus, ILogger<CableModemAlertEvaluator> logger)
+    {
+        _eventBus = eventBus;
+        _logger = logger;
+    }
+
+    public async ValueTask EvaluateAsync(
+        int cmId, string cmName,
+        double? dsSnrAvgDb, double? dsPowerAvgDbmv, double? usPowerAvgDbmv,
+        int lockedDsChannels, int lockedUsChannels,
+        long uncorrectablesDelta,
+        CancellationToken ct = default)
+    {
+        var key = cmId.ToString();
+        var state = _states.GetOrAdd(key, _ => new CmAlertState());
+
+        if (dsSnrAvgDb.HasValue)
+            await EvaluateDsSnr(state, cmId, cmName, dsSnrAvgDb.Value, ct);
+
+        if (dsPowerAvgDbmv.HasValue)
+            await EvaluateDsPower(state, cmId, cmName, dsPowerAvgDbmv.Value, ct);
+
+        if (usPowerAvgDbmv.HasValue)
+            await EvaluateUsPower(state, cmId, cmName, usPowerAvgDbmv.Value, ct);
+
+        if (uncorrectablesDelta > UncorrectablesDeltaThreshold)
+            await PublishUncorrectables(cmId, cmName, uncorrectablesDelta, ct);
+
+        if (lockedDsChannels > 0)
+            await EvaluateChannelLoss(state, cmId, cmName, lockedDsChannels, ct);
+    }
+
+    private async ValueTask EvaluateDsSnr(CmAlertState state, int cmId, string cmName, double snr, CancellationToken ct)
+    {
+        if (!state.DsSnrBreached && snr < DsSnrLowDb)
+        {
+            state.DsSnrBreached = true;
+            _logger.LogDebug("Cable modem DS SNR low: {CmName} snr={Snr:0.#} dB", cmName, snr);
+
+            await _eventBus.PublishAsync(new AlertEvent
+            {
+                EventType = "cable_modem.ds_snr_low",
+                Source = "cable_modem",
+                Severity = AlertSeverity.Warning,
+                Title = $"{cmName} downstream SNR low",
+                Message = $"Cable modem {cmName} downstream SNR averaged {snr:0.#} dB, below the {DsSnrLowDb} dB threshold. Below 30 dB is typically service-affecting.",
+                MetricValue = snr,
+                ThresholdValue = DsSnrLowDb,
+                SourceUrl = "/monitoring?tab=cm",
+                Tags = ["cable_modem", "snr"],
+                Context = new Dictionary<string, string>
+                {
+                    ["cm_id"] = cmId.ToString(),
+                    ["metric"] = "ds_snr_avg_db"
+                }
+            }, ct);
+        }
+        else if (state.DsSnrBreached && snr >= DsSnrClearDb)
+        {
+            state.DsSnrBreached = false;
+        }
+    }
+
+    private async ValueTask EvaluateDsPower(CmAlertState state, int cmId, string cmName, double power, CancellationToken ct)
+    {
+        var outOfRange = power < DsPowerLowDbmv || power > DsPowerHighDbmv;
+        var inClearRange = power >= DsPowerClearLowDbmv && power <= DsPowerClearHighDbmv;
+
+        if (!state.DsPowerBreached && outOfRange)
+        {
+            state.DsPowerBreached = true;
+            var direction = power < DsPowerLowDbmv ? "low" : "high";
+            _logger.LogDebug("Cable modem DS power out of range: {CmName} power={Power:0.#} dBmV ({Direction})", cmName, power, direction);
+
+            await _eventBus.PublishAsync(new AlertEvent
+            {
+                EventType = "cable_modem.ds_power_out_of_range",
+                Source = "cable_modem",
+                Severity = AlertSeverity.Warning,
+                Title = $"{cmName} downstream power {direction}",
+                Message = $"Cable modem {cmName} downstream power averaged {power:0.#} dBmV, outside the {DsPowerLowDbmv} to {DsPowerHighDbmv} dBmV DOCSIS operating range.",
+                MetricValue = power,
+                ThresholdValue = power < DsPowerLowDbmv ? DsPowerLowDbmv : DsPowerHighDbmv,
+                SourceUrl = "/monitoring?tab=cm",
+                Tags = ["cable_modem", "power"],
+                Context = new Dictionary<string, string>
+                {
+                    ["cm_id"] = cmId.ToString(),
+                    ["metric"] = "ds_power_avg_dbmv",
+                    ["direction"] = direction
+                }
+            }, ct);
+        }
+        else if (state.DsPowerBreached && inClearRange)
+        {
+            state.DsPowerBreached = false;
+        }
+    }
+
+    private async ValueTask EvaluateUsPower(CmAlertState state, int cmId, string cmName, double power, CancellationToken ct)
+    {
+        if (!state.UsPowerBreached && power > UsPowerHighDbmv)
+        {
+            state.UsPowerBreached = true;
+            _logger.LogDebug("Cable modem US power high: {CmName} power={Power:0.#} dBmV", cmName, power);
+
+            await _eventBus.PublishAsync(new AlertEvent
+            {
+                EventType = "cable_modem.us_power_high",
+                Source = "cable_modem",
+                Severity = AlertSeverity.Warning,
+                Title = $"{cmName} upstream power high",
+                Message = $"Cable modem {cmName} upstream power averaged {power:0.#} dBmV, above {UsPowerHighDbmv} dBmV. The modem is compensating for poor return path signal.",
+                MetricValue = power,
+                ThresholdValue = UsPowerHighDbmv,
+                SourceUrl = "/monitoring?tab=cm",
+                Tags = ["cable_modem", "power"],
+                Context = new Dictionary<string, string>
+                {
+                    ["cm_id"] = cmId.ToString(),
+                    ["metric"] = "us_power_avg_dbmv"
+                }
+            }, ct);
+        }
+        else if (state.UsPowerBreached && power <= UsPowerClearDbmv)
+        {
+            state.UsPowerBreached = false;
+        }
+    }
+
+    private async ValueTask PublishUncorrectables(int cmId, string cmName, long delta, CancellationToken ct)
+    {
+        _logger.LogDebug("Cable modem uncorrectable errors: {CmName} delta={Delta}", cmName, delta);
+
+        await _eventBus.PublishAsync(new AlertEvent
+        {
+            EventType = "cable_modem.uncorrectable_errors",
+            Source = "cable_modem",
+            Severity = AlertSeverity.Warning,
+            Title = $"{cmName} uncorrectable errors",
+            Message = $"Cable modem {cmName} had {delta:N0} uncorrectable FEC errors since the last poll, exceeding the {UncorrectablesDeltaThreshold} threshold.",
+            MetricValue = delta,
+            ThresholdValue = UncorrectablesDeltaThreshold,
+            SourceUrl = "/monitoring?tab=cm",
+            Tags = ["cable_modem", "uncorrectables"],
+            Context = new Dictionary<string, string>
+            {
+                ["cm_id"] = cmId.ToString(),
+                ["metric"] = "uncorrectables_delta"
+            }
+        }, ct);
+    }
+
+    private async ValueTask EvaluateChannelLoss(CmAlertState state, int cmId, string cmName, int lockedDsChannels, CancellationToken ct)
+    {
+        if (lockedDsChannels > state.MaxLockedDsChannels)
+        {
+            state.MaxLockedDsChannels = lockedDsChannels;
+            state.ChannelLossBreached = false;
+            return;
+        }
+
+        var drop = state.MaxLockedDsChannels - lockedDsChannels;
+
+        if (!state.ChannelLossBreached && drop >= ChannelDropThreshold)
+        {
+            state.ChannelLossBreached = true;
+            _logger.LogDebug("Cable modem channel loss: {CmName} locked={Current} max={Max} drop={Drop}", cmName, lockedDsChannels, state.MaxLockedDsChannels, drop);
+
+            await _eventBus.PublishAsync(new AlertEvent
+            {
+                EventType = "cable_modem.channel_loss",
+                Source = "cable_modem",
+                Severity = AlertSeverity.Warning,
+                Title = $"{cmName} downstream channels lost",
+                Message = $"Cable modem {cmName} dropped from {state.MaxLockedDsChannels} to {lockedDsChannels} locked downstream channels ({drop} lost).",
+                MetricValue = lockedDsChannels,
+                ThresholdValue = state.MaxLockedDsChannels,
+                SourceUrl = "/monitoring?tab=cm",
+                Tags = ["cable_modem", "channels"],
+                Context = new Dictionary<string, string>
+                {
+                    ["cm_id"] = cmId.ToString(),
+                    ["metric"] = "locked_ds_channels",
+                    ["max_channels"] = state.MaxLockedDsChannels.ToString(),
+                    ["channels_lost"] = drop.ToString()
+                }
+            }, ct);
+        }
+        else if (state.ChannelLossBreached && drop < ChannelDropThreshold)
+        {
+            state.ChannelLossBreached = false;
+        }
+    }
+
+    private class CmAlertState
+    {
+        public bool DsSnrBreached;
+        public bool DsPowerBreached;
+        public bool UsPowerBreached;
+        public bool ChannelLossBreached;
+        public int MaxLockedDsChannels;
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/CellularAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/CellularAlertEvaluator.cs
@@ -1,0 +1,189 @@
+using System.Collections.Concurrent;
+using NetworkOptimizer.Alerts.Events;
+using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Monitoring.Models;
+
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Evaluates cellular modem readings and publishes alert events on state
+/// transitions. Tracks three conditions per modem:
+/// - Signal quality dropping below the poor threshold (composite score)
+/// - Network mode downgrade (e.g. 5G SA → 5G NSA → LTE)
+/// - Unexpected roaming state
+/// All checks are state-transition based with hysteresis to avoid flapping.
+/// </summary>
+public class CellularAlertEvaluator
+{
+    private const int SignalPoorThreshold = 25;
+    private const int SignalClearThreshold = 35;
+
+    private readonly IAlertEventBus _eventBus;
+    private readonly ILogger<CellularAlertEvaluator> _logger;
+    private readonly ConcurrentDictionary<int, CellularAlertState> _states = new();
+
+    public CellularAlertEvaluator(IAlertEventBus eventBus, ILogger<CellularAlertEvaluator> logger)
+    {
+        _eventBus = eventBus;
+        _logger = logger;
+    }
+
+    public async ValueTask EvaluateAsync(
+        int modemId, string modemName,
+        int signalQuality, CellularNetworkMode networkMode, bool isRoaming,
+        CancellationToken ct = default)
+    {
+        var state = _states.GetOrAdd(modemId, _ => new CellularAlertState());
+
+        await EvaluateSignalQuality(state, modemId, modemName, signalQuality, ct);
+        await EvaluateNetworkMode(state, modemId, modemName, networkMode, ct);
+        await EvaluateRoaming(state, modemId, modemName, isRoaming, ct);
+    }
+
+    private async ValueTask EvaluateSignalQuality(
+        CellularAlertState state, int modemId, string modemName,
+        int signalQuality, CancellationToken ct)
+    {
+        if (!state.SignalBreached && signalQuality < SignalPoorThreshold && signalQuality > 0)
+        {
+            state.SignalBreached = true;
+            _logger.LogDebug("Cellular signal poor: modem {ModemId} quality={Quality}", modemId, signalQuality);
+
+            await _eventBus.PublishAsync(new AlertEvent
+            {
+                EventType = "cellular.signal_poor",
+                Source = "cellular",
+                Severity = AlertSeverity.Warning,
+                Title = $"{modemName} signal quality poor",
+                Message = $"Cellular modem {modemName} signal quality dropped to {signalQuality}/100, below the {SignalPoorThreshold} threshold.",
+                DeviceName = modemName,
+                MetricValue = signalQuality,
+                ThresholdValue = SignalPoorThreshold,
+                SourceUrl = "/monitoring?tab=cellular",
+                Tags = ["cellular", "signal"],
+                Context = new Dictionary<string, string>
+                {
+                    ["modem_id"] = modemId.ToString(),
+                    ["metric"] = "signal_quality"
+                }
+            }, ct);
+        }
+        else if (state.SignalBreached && signalQuality >= SignalClearThreshold)
+        {
+            state.SignalBreached = false;
+        }
+    }
+
+    private async ValueTask EvaluateNetworkMode(
+        CellularAlertState state, int modemId, string modemName,
+        CellularNetworkMode networkMode, CancellationToken ct)
+    {
+        var currentRank = ModeRank(networkMode);
+        var previousRank = state.LastKnownModeRank;
+
+        state.LastKnownModeRank = currentRank;
+
+        if (!previousRank.HasValue || networkMode == CellularNetworkMode.Unknown)
+            return;
+
+        if (currentRank < previousRank.Value && previousRank.Value > 0)
+        {
+            if (!state.NetworkDowngraded)
+            {
+                state.NetworkDowngraded = true;
+                var previousMode = RankToLabel(previousRank.Value);
+                var currentMode = ModeLabel(networkMode);
+
+                _logger.LogDebug("Cellular network downgrade: modem {ModemId} {From} -> {To}",
+                    modemId, previousMode, currentMode);
+
+                await _eventBus.PublishAsync(new AlertEvent
+                {
+                    EventType = "cellular.network_downgrade",
+                    Source = "cellular",
+                    Severity = AlertSeverity.Warning,
+                    Title = $"{modemName} network downgraded",
+                    Message = $"Cellular modem {modemName} dropped from {previousMode} to {currentMode}.",
+                    DeviceName = modemName,
+                    SourceUrl = "/monitoring?tab=cellular",
+                    Tags = ["cellular", "network_mode"],
+                    Context = new Dictionary<string, string>
+                    {
+                        ["modem_id"] = modemId.ToString(),
+                        ["previous_mode"] = previousMode,
+                        ["current_mode"] = currentMode
+                    }
+                }, ct);
+            }
+        }
+        else if (currentRank >= previousRank.Value)
+        {
+            state.NetworkDowngraded = false;
+        }
+    }
+
+    private async ValueTask EvaluateRoaming(
+        CellularAlertState state, int modemId, string modemName,
+        bool isRoaming, CancellationToken ct)
+    {
+        var wasRoaming = state.IsRoaming;
+        state.IsRoaming = isRoaming;
+
+        if (isRoaming && !wasRoaming && state.HasObservedRoaming)
+        {
+            _logger.LogDebug("Cellular roaming detected: modem {ModemId}", modemId);
+
+            await _eventBus.PublishAsync(new AlertEvent
+            {
+                EventType = "cellular.roaming",
+                Source = "cellular",
+                Severity = AlertSeverity.Warning,
+                Title = $"{modemName} is roaming",
+                Message = $"Cellular modem {modemName} entered roaming state. This may indicate loss of primary carrier coverage or incur additional charges.",
+                DeviceName = modemName,
+                SourceUrl = "/monitoring?tab=cellular",
+                Tags = ["cellular", "roaming"],
+                Context = new Dictionary<string, string>
+                {
+                    ["modem_id"] = modemId.ToString()
+                }
+            }, ct);
+        }
+
+        state.HasObservedRoaming = true;
+    }
+
+    private static int ModeRank(CellularNetworkMode mode) => mode switch
+    {
+        CellularNetworkMode.Unknown => 0,
+        CellularNetworkMode.Lte => 1,
+        CellularNetworkMode.Nr5gNsa => 2,
+        CellularNetworkMode.Nr5gSa => 3,
+        _ => 0
+    };
+
+    private static string ModeLabel(CellularNetworkMode mode) => mode switch
+    {
+        CellularNetworkMode.Lte => "LTE",
+        CellularNetworkMode.Nr5gNsa => "5G NSA",
+        CellularNetworkMode.Nr5gSa => "5G SA",
+        _ => "Unknown"
+    };
+
+    private static string RankToLabel(int rank) => rank switch
+    {
+        1 => "LTE",
+        2 => "5G NSA",
+        3 => "5G SA",
+        _ => "Unknown"
+    };
+
+    private class CellularAlertState
+    {
+        public bool SignalBreached;
+        public int? LastKnownModeRank;
+        public bool NetworkDowngraded;
+        public bool IsRoaming;
+        public bool HasObservedRoaming;
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/DeviceHealthAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/DeviceHealthAlertEvaluator.cs
@@ -1,0 +1,126 @@
+using System.Collections.Concurrent;
+using NetworkOptimizer.Alerts.Events;
+using NetworkOptimizer.Core.Enums;
+
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Evaluates gateway CPU and memory readings against thresholds and publishes
+/// alert events on state transitions. CPU uses a sliding window of 5 samples
+/// (~2.5-5 minutes at typical poll intervals) to avoid alerting on transient
+/// spikes. Memory is evaluated per-sample since sustained high memory is
+/// immediately actionable.
+/// </summary>
+public class DeviceHealthAlertEvaluator
+{
+    private const int CpuWindowSize = 5;
+    private const double CpuHighThresholdPercent = 70.0;
+    private const double CpuClearThresholdPercent = 55.0;
+    private const double MemoryHighThresholdPercent = 95.0;
+    private const double MemoryClearThresholdPercent = 85.0;
+
+    private readonly IAlertEventBus _eventBus;
+    private readonly ILogger<DeviceHealthAlertEvaluator> _logger;
+    private readonly ConcurrentDictionary<string, DeviceHealthState> _states = new();
+
+    public DeviceHealthAlertEvaluator(IAlertEventBus eventBus, ILogger<DeviceHealthAlertEvaluator> logger)
+    {
+        _eventBus = eventBus;
+        _logger = logger;
+    }
+
+    public async ValueTask EvaluateAsync(
+        string deviceMac, string? deviceName, string deviceType,
+        double? cpuPercent, double? memoryUsedPercent,
+        CancellationToken ct = default)
+    {
+        if (!string.Equals(deviceType, "gateway", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        var state = _states.GetOrAdd(deviceMac, _ => new DeviceHealthState());
+        var label = deviceName ?? deviceMac;
+
+        if (cpuPercent.HasValue)
+        {
+            state.CpuWindow.Enqueue(cpuPercent.Value);
+            while (state.CpuWindow.Count > CpuWindowSize) state.CpuWindow.Dequeue();
+
+            if (state.CpuWindow.Count >= CpuWindowSize)
+            {
+                var avg = state.CpuWindow.Average();
+
+                if (!state.CpuBreached && avg >= CpuHighThresholdPercent)
+                {
+                    state.CpuBreached = true;
+                    _logger.LogDebug("Gateway CPU threshold breached: {DeviceMac} avg={Avg:0.#}%", deviceMac, avg);
+
+                    await _eventBus.PublishAsync(new AlertEvent
+                    {
+                        EventType = "device.gateway_high_cpu",
+                        Source = "device",
+                        Severity = AlertSeverity.Warning,
+                        Title = $"{label} CPU usage high",
+                        Message = $"Gateway {label} CPU averaged {avg:0.#}% over the last {CpuWindowSize} samples, exceeding the {CpuHighThresholdPercent}% threshold.",
+                        DeviceId = deviceMac,
+                        DeviceName = deviceName,
+                        MetricValue = avg,
+                        ThresholdValue = CpuHighThresholdPercent,
+                        SourceUrl = "/monitoring?tab=health",
+                        Tags = ["device", "gateway", "cpu"],
+                        Context = new Dictionary<string, string>
+                        {
+                            ["device_mac"] = deviceMac,
+                            ["device_type"] = deviceType,
+                            ["metric"] = "cpu_percent"
+                        }
+                    }, ct);
+                }
+                else if (state.CpuBreached && avg <= CpuClearThresholdPercent)
+                {
+                    state.CpuBreached = false;
+                }
+            }
+        }
+
+        if (memoryUsedPercent.HasValue)
+        {
+            if (!state.MemoryBreached && memoryUsedPercent.Value >= MemoryHighThresholdPercent)
+            {
+                state.MemoryBreached = true;
+                _logger.LogDebug("Gateway memory threshold breached: {DeviceMac} mem={Mem:0.#}%", deviceMac, memoryUsedPercent.Value);
+
+                await _eventBus.PublishAsync(new AlertEvent
+                {
+                    EventType = "device.gateway_high_memory",
+                    Source = "device",
+                    Severity = AlertSeverity.Warning,
+                    Title = $"{label} memory usage high",
+                    Message = $"Gateway {label} memory usage at {memoryUsedPercent.Value:0.#}%, exceeding the {MemoryHighThresholdPercent}% threshold.",
+                    DeviceId = deviceMac,
+                    DeviceName = deviceName,
+                    MetricValue = memoryUsedPercent.Value,
+                    ThresholdValue = MemoryHighThresholdPercent,
+                    SourceUrl = "/monitoring?tab=health",
+                    Tags = ["device", "gateway", "memory"],
+                    Context = new Dictionary<string, string>
+                    {
+                        ["device_mac"] = deviceMac,
+                        ["device_type"] = deviceType,
+                        ["metric"] = "memory_used_percent"
+                    }
+                }, ct);
+            }
+            else if (state.MemoryBreached && memoryUsedPercent.Value <= MemoryClearThresholdPercent)
+            {
+                state.MemoryBreached = false;
+            }
+        }
+    }
+
+    private class DeviceHealthState
+    {
+        public Queue<double> CpuWindow { get; } = new();
+        public bool CpuBreached;
+        public bool MemoryBreached;
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -77,9 +77,21 @@ public class IspAsnHealth
     /// <summary>Mean RTT across all of the ASN's monitored hops (shown on the Networks on Your Path card).</summary>
     public double? MeanRttMs { get; init; }
 
+    /// <summary>Lowest and highest hop RTT in the ASN, for the ISP card's RTT range.</summary>
+    public double? MinRttMs { get; init; }
+    public double? MaxRttMs { get; init; }
+
     public double? P95RttMs { get; init; }
     public double? MedianJitterMs { get; init; }
     public double? P95JitterMs { get; init; }
+
+    /// <summary>True when the displayed jitter was assimilated from elsewhere (a cleaner
+    /// farther cluster for transit, or the cleanest transit ASN for the ISP) rather than
+    /// this network's own nearest reading. Drives the info icon on the card.</summary>
+    public bool JitterAssimilated { get; init; }
+
+    /// <summary>This network's own measured jitter before assimilation, for the tooltip.</summary>
+    public double? RawJitterMs { get; init; }
     public double? RttMadMs { get; init; }
     public double? LossPct { get; init; }
 
@@ -103,11 +115,28 @@ public class IspTargetHealth
 {
     public required string TargetId { get; init; }
     public required string Name { get; init; }
-    public double? MedianRttMs { get; init; }
+
+    /// <summary>Displayed RTT: winsorized mean over the window.</summary>
+    public double? RttMs { get; init; }
+
+    /// <summary>Effective (absolved) P95 jitter this hop is graded on.</summary>
     public double? P95JitterMs { get; init; }
+
+    /// <summary>This hop's own measured P95 jitter, before any absolve.</summary>
+    public double? RawJitterMs { get; init; }
+
+    /// <summary>True when a cleaner witness (transit/sibling/destination) pulled this hop's jitter below its own reading.</summary>
+    public bool JitterAssimilated { get; init; }
+
     public double? LossPct { get; init; }
 
-    /// <summary>True for the first clean hop, the target the ISP grade is computed from.</summary>
+    /// <summary>Per-hop quality grade (stability, jitter, loss, congestion, intra-ASN reach).</summary>
+    public int? OverallScore { get; init; }
+
+    /// <summary>RTT beyond this ASN's nearest hop (0 for the nearest). Drives the soft reach ceiling.</summary>
+    public double? ReachDeltaMs { get; init; }
+
+    /// <summary>True for the first clean hop, the target the access layer idle latency comes from.</summary>
     public bool IsGradedHop { get; init; }
 }
 
@@ -192,6 +221,12 @@ public class IspHealthReport
     /// <summary>False when expected WAN speeds were unavailable and loaded analysis was skipped.</summary>
     public bool HasExpectedSpeeds { get; init; }
 
+    /// <summary>
+    /// False when no upstream hop-ancestry (trace map) is persisted, so the per-hop jitter
+    /// absolve gate runs in its lenient fallback. Prompts the user to re-run Upstream Discovery.
+    /// </summary>
+    public bool HasUpstreamTraceMap { get; init; }
+
     /// <summary>False when no loaded windows occurred in the window (line never under load).</summary>
     public bool HasLoadedSamples { get; init; }
 
@@ -241,11 +276,31 @@ public class AsnSeries
     public double? NearestClusterMeanRttMs { get; init; }
 
     /// <summary>
+    /// A farther cluster's samples used to absolve false near-hop jitter. A near hop often
+    /// shows false jitter from ICMP deprioritization; a cleaner farther cluster, confirmed
+    /// downstream by stored traceroute hop order, disproves it. Jitter and stability are
+    /// graded on the BETTER (lower) of <see cref="Samples"/> and this (absolve-only: a
+    /// jittery farther cluster never downgrades the nearer). RTT and reach always use
+    /// Samples. Empty means no confirmed farther cluster, so Samples alone is used.
+    /// </summary>
+    public List<LatencySample> JitterSourceSamples { get; init; } = new();
+
+    /// <summary>
     /// On a grading series, all of this ASN-role's target IDs (every hop, every
     /// cluster), used to attribute congestion to the correct card when the same ASN
     /// appears as both the access ISP and transit. Empty on chart-cluster series.
     /// </summary>
     public List<string> RoleTargetIds { get; init; } = new();
+
+    /// <summary>The IPs of this series' targets, so a witness can be tested for routing through them.</summary>
+    public List<string> HopIps { get; init; } = new();
+
+    /// <summary>
+    /// The monitored hop IPs proven upstream of this series (union over its targets, from the
+    /// discovery traces). A witness series routes through a hop X - and so may absolve it -
+    /// iff X's IP is in the witness's ancestor set. Empty for a first hop.
+    /// </summary>
+    public List<string> AncestorIps { get; init; } = new();
 }
 
 /// <summary>Load classification of one aggregate window.</summary>
@@ -286,6 +341,14 @@ public class IspHealthInputs
     /// <summary>Per-ASN series for access ISP targets.</summary>
     public List<AsnSeries> IspAsnSeries { get; init; } = new();
 
+    /// <summary>
+    /// Per-target series for monitored internet/destination endpoints (anycast DNS, CDN
+    /// probes). Each carries the hops proven upstream of it (AncestorIps) so a destination's
+    /// clean end-to-end jitter can absolve an ISP hop it provably routes through - an
+    /// ICMP-deprioritized hop whose forwarded traffic reaches the destination smoothly.
+    /// </summary>
+    public List<AsnSeries> DestinationSeries { get; init; } = new();
+
     /// <summary>WAN throughput over the window (primary WAN).</summary>
     public List<ThroughputSample> WanRates { get; init; } = new();
 
@@ -313,6 +376,13 @@ public class IspHealthInputs
 
     /// <summary>Pre-detected path shift events. Informational only.</summary>
     public List<PathShiftEvent> PathShifts { get; init; } = new();
+
+    /// <summary>
+    /// True when Upstream Discovery has persisted hop-ancestor data for this WAN. When false
+    /// (never discovered, or pre-ancestor data), the jitter absolve gate falls open for
+    /// transit (transit is always downstream of the ISP) and stays closed for ISP siblings.
+    /// </summary>
+    public bool HopOrderKnown { get; init; }
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -79,8 +79,21 @@ public class IspHealthOptions
     /// </summary>
     public int LoadWindowSeconds { get; set; } = 15;
 
-    /// <summary>How long a computed report stays fresh before recompute.</summary>
-    public TimeSpan CacheTtl { get; set; } = TimeSpan.FromMinutes(5);
+    /// <summary>
+    /// How long a computed report stays fresh before the ISP Health tab recomputes it.
+    /// The score is a 48 h rolling metric, so a few minutes of staleness is invisible; the
+    /// "Last updated" label discloses the age. Each recompute is a heavy Influx query burst,
+    /// so this is kept generous.
+    /// </summary>
+    public TimeSpan CacheTtl { get; set; } = TimeSpan.FromMinutes(15);
+
+    /// <summary>
+    /// Max report age the glanceable dashboard / Live View score tile tolerates before it
+    /// triggers a background recompute. Longer than <see cref="CacheTtl"/> because the tile is
+    /// a summary, not the detail view - this decouples the tile from the recompute cadence so
+    /// simply watching Live View doesn't drive a full ISP Health query every few minutes.
+    /// </summary>
+    public TimeSpan DashboardScoreTtl { get; set; } = TimeSpan.FromMinutes(30);
 
     /// <summary>Bucket size in minutes for congestion detection.</summary>
     public int CongestionBucketMinutes { get; set; } = 15;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -162,6 +162,42 @@ public class IspHealthOptions
 
     /// <summary>Weight of congestion in the per-ASN quality blend.</summary>
     public double AsnCongestionWeight { get; set; } = 0.3;
+
+    /// <summary>
+    /// Lower clamp for the path jitter floor used in floor-relative jitter scoring.
+    /// Below this, ratio scoring would punish sub-millisecond jitter that is excellent
+    /// in absolute terms, so the floor never reads below this value.
+    /// </summary>
+    public double JitterFloorMinMs { get; set; } = 0.3;
+
+    /// <summary>
+    /// Upper clamp for the path jitter floor. Above this the line is jittery
+    /// everywhere; the absolute high-end anchors take over rather than letting a high
+    /// floor excuse genuinely bad jitter.
+    /// </summary>
+    public double JitterFloorMaxMs { get; set; } = 1.5;
+
+    /// <summary>
+    /// Minimum amount a cleaner witness must sit below a hop's own jitter before it counts as
+    /// assimilated. Within this band the difference is measurement noise, so the hop keeps its
+    /// own jitter (no absolve, no assimilation icon). Applies to ISP hops and transit ASNs.
+    /// </summary>
+    public double JitterAssimilationMinDeltaMs { get; set; } = 0.05;
+
+    /// <summary>
+    /// Average WAN load at which packet loss reaches its worst on shared-medium access
+    /// (DOCSIS, PON, fixed wireless). The load-calibrated loss ceiling reaches the
+    /// connection's loaded-loss band at this utilization and holds there above it, rather
+    /// than only at 100%.
+    /// </summary>
+    public double LossSaturationLoadFraction { get; set; } = 0.75;
+
+    /// <summary>
+    /// Upper percentile at which displayed RTT is winsorized: samples above it are capped
+    /// to it before averaging, so a route flap or single bad probe can't distort the mean
+    /// while sustained elevation still shows. 0.99 caps only the worst 1%.
+    /// </summary>
+    public double RttWinsorPercentile { get; set; } = 0.99;
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -11,10 +11,12 @@ namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
 public class IspHealthScorer
 {
     private readonly IspHealthOptions _options;
+    private readonly ILogger? _logger;
 
-    public IspHealthScorer(IspHealthOptions options)
+    public IspHealthScorer(IspHealthOptions options, ILogger? logger = null)
     {
         _options = options;
+        _logger = logger;
     }
 
     public IspHealthReport Score(IspHealthInputs inputs, AccessProfile profile)
@@ -23,9 +25,10 @@ public class IspHealthScorer
         var hasExpectedSpeeds = inputs.ExpectedDownloadMbps.HasValue || inputs.ExpectedUploadMbps.HasValue;
 
         var idleBaseline = ComputeIdleBaseline(inputs.FirstHopSeries, loadWindows);
+        var avgLoad = ComputeAverageLoad(inputs);
         var (speedVsPlan, bestSpeedTest, typicalDownMbps, typicalUpMbps) = ScoreSpeedVsPlan(inputs);
         var idleLatency = ScoreIdleLatency(idleBaseline, profile);
-        var idleLoss = ScoreIdleLoss(inputs.LossPoolSeries, profile);
+        var idleLoss = ScoreIdleLoss(inputs.LossPoolSeries, profile, avgLoad);
         var loadedDeltas = ResolveLoadedDeltas(inputs, loadWindows);
         var (loadedLatency, hasLoadedLatency) = ScoreLoadedLatency(loadedDeltas, profile);
         var (loadedLoss, hasLoadedLoss) = ScoreLoadedLoss(inputs.LossPoolSeries, loadWindows, profile);
@@ -35,10 +38,25 @@ public class IspHealthScorer
 
         var accessMedianRtt = SeriesStats.Median(
             inputs.FirstHopSeries.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList());
-        var transitAsns = inputs.TransitAsnSeries.Select(s => GradeAsn(s, inputs.CongestionEvents, accessMedianRtt, inputs.InternetMedianDeltaMs)).ToList();
-        var ispAsns = inputs.IspAsnSeries.Select(s => GradeAsn(s, inputs.CongestionEvents, accessBaselineRtt: null, internetMedianDeltaMs: null)).ToList();
+
+        // The path jitter floor: the quietest median jitter measured anywhere along the
+        // path (ISP hops and transit clusters). It represents the access layer's inherent
+        // stability - every probe crosses it - so jitter is graded relative to this floor.
+        var jitterFloor = ComputeJitterFloor(inputs);
+        _logger?.LogDebug("ISP Health: path jitter floor {Floor} ms", FormatMsOrNull(jitterFloor));
+
+        var transitAsns = inputs.TransitAsnSeries.Select(s => GradeAsn(s, inputs.CongestionEvents, jitterFloor, accessMedianRtt, inputs.InternetMedianDeltaMs)).ToList();
+
+        // Every ISP hop is graded; the dimension averages them all. Each hop's jitter is
+        // absolved per-hop and routes-through-gated (a transit ASN or deeper ISP hop only
+        // absolves a hop it is proven downstream of), so a divergent clean transit can't
+        // clear a congested hop it never traverses. Hops further out on the same ISP also
+        // get a soft intra-ASN reach ceiling. Access layer idle latency still uses FirstHopSeries.
+        var ispHopGrades = GradeIspHops(inputs.IspAsnSeries, inputs.TransitAsnSeries, transitAsns, inputs.DestinationSeries, inputs.CongestionEvents, jitterFloor, inputs.HopOrderKnown);
+        // Collapse the per-hop grades to one entry per ASN for the Networks on Your Path card.
+        var ispAsns = AggregateIspAsns(ispHopGrades, inputs.CongestionEvents, _options.JitterAssimilationMinDeltaMs);
         var transitDimension = BuildAsnDimension("Transit Health", _options.TransitWeight, transitAsns);
-        var ispAsnDimension = BuildAsnDimension("ISP Network", _options.IspAsnWeight, ispAsns, gradedOnBestHop: true);
+        var ispAsnDimension = BuildIspDimension(_options.IspAsnWeight, ispHopGrades);
 
         var overall = CombineDimensions(accessDimension, transitDimension, ispAsnDimension);
 
@@ -54,10 +72,11 @@ public class IspHealthScorer
             IspAsnDimension = ispAsnDimension,
             TransitAsns = transitAsns,
             IspAsns = ispAsns,
-            IspTargets = inputs.IspTargetSeries.Select(s => BuildIspTargetHealth(s, inputs.FirstHopTargetId)).ToList(),
+            IspTargets = inputs.IspTargetSeries.Select(s => BuildIspTargetHealth(s, inputs.FirstHopTargetId, ispHopGrades, _options.RttWinsorPercentile)).ToList(),
             CongestionEvents = inputs.CongestionEvents,
             PathShifts = inputs.PathShifts,
             HasExpectedSpeeds = hasExpectedSpeeds,
+            HasUpstreamTraceMap = inputs.HopOrderKnown,
             HasLoadedSamples = hasLoadedLatency || hasLoadedLoss,
             ExpectedDownloadMbps = inputs.ExpectedDownloadMbps,
             ExpectedUploadMbps = inputs.ExpectedUploadMbps,
@@ -275,11 +294,11 @@ public class IspHealthScorer
             Score = (int)Math.Round(score),
             Weight = _options.IdleLatencyWeight,
             ValueText = FormatMs(idleBaseline.Value),
-            Description = $"Idle latency to the first ISP hop vs the {FormatMs(profile.IdleRttNormalLowMs)} to {FormatMs(profile.IdleRttNormalHighMs)} normal band for {profile.DisplayName}."
+            Description = $"Idle latency to the first ISP hop vs the {FormatMsBand(profile.IdleRttNormalLowMs)} to {FormatMsBand(profile.IdleRttNormalHighMs)} normal band for {profile.DisplayName}."
         };
     }
 
-    private IspScoreFactor ScoreIdleLoss(List<List<LatencySample>> lossPool, AccessProfile profile)
+    private IspScoreFactor ScoreIdleLoss(List<List<LatencySample>> lossPool, AccessProfile profile, double avgLoad)
     {
         var losses = lossPool.SelectMany(series => series)
             .Where(s => s.LossPercent.HasValue)
@@ -296,9 +315,21 @@ public class IspHealthScorer
         }
 
         var meanLoss = losses.Average();
-        var score = meanLoss <= profile.IdleLossAcceptablePct
-            ? ScoreCurve.Interpolate(meanLoss, (0, 100), (profile.IdleLossIdealPct, 95), (profile.IdleLossAcceptablePct, 70))
-            : ScoreCurve.ExponentialFalloff(meanLoss, profile.IdleLossAcceptablePct, 70);
+        // Calibrate the acceptable loss ceiling to the average load over the window. An idle
+        // line should drop ~nothing; loss only climbs as utilization approaches saturation,
+        // so the ceiling rises QUADRATICALLY in load - staying near the idle threshold at low
+        // load and reaching the connection's loaded-loss band at LossSaturationLoadFraction
+        // (shared-medium access tops out its loss ~75% load, not 100%), holding there above it.
+        var t = Math.Clamp(Math.Clamp(avgLoad, 0, 1) / _options.LossSaturationLoadFraction, 0, 1);
+        var acceptable = profile.IdleLossAcceptablePct
+            + t * t * (profile.LoadedLossDownLowPct - profile.IdleLossAcceptablePct);
+        var score = meanLoss <= acceptable
+            ? ScoreCurve.Interpolate(meanLoss, (0, 100), (profile.IdleLossIdealPct, 95), (acceptable, 70))
+            : ScoreCurve.ExponentialFalloff(meanLoss, acceptable, 70);
+
+        _logger?.LogDebug("ISP Health: packet loss {Loss}% vs load-calibrated ceiling {Ceiling}% ({Load} avg load)",
+            meanLoss.ToString("0.###", CultureInfo.InvariantCulture), acceptable.ToString("0.###", CultureInfo.InvariantCulture),
+            avgLoad.ToString("0%", CultureInfo.InvariantCulture));
 
         return new IspScoreFactor
         {
@@ -306,8 +337,34 @@ public class IspHealthScorer
             Score = (int)Math.Round(score),
             Weight = _options.IdleLossWeight,
             ValueText = FormatPct(meanLoss),
-            Description = $"Average loss across ISP, transit, and anycast DNS targets vs the {FormatPct(profile.IdleLossAcceptablePct)} acceptable ceiling for {profile.DisplayName}."
+            Description = $"Average loss across ISP, transit, and anycast DNS targets vs the {FormatPct(acceptable)} ceiling for {profile.DisplayName} at {avgLoad.ToString("0%", CultureInfo.InvariantCulture)} average load."
         };
+    }
+
+    /// <summary>
+    /// Average WAN utilization over the window. Uses the same windowing and per-window
+    /// utilization basis as <see cref="LoadClassifier"/> (which drives Loaded Loss): group
+    /// rates into LoadWindowSeconds windows, take the busier direction's peak rate in each
+    /// as a fraction of the configured plan. Averaged into "average load" here rather than
+    /// thresholded into loaded/idle. 0 when there are no expected speeds or no rate data.
+    /// </summary>
+    private double ComputeAverageLoad(IspHealthInputs inputs)
+    {
+        var expectedDownBps = inputs.ExpectedDownloadMbps * 1_000_000;
+        var expectedUpBps = inputs.ExpectedUploadMbps * 1_000_000;
+        if (inputs.WanRates.Count == 0 || (expectedDownBps is null && expectedUpBps is null)) return 0;
+
+        var windowSize = TimeSpan.FromSeconds(_options.LoadWindowSeconds);
+        var utils = new List<double>();
+        foreach (var group in inputs.WanRates.GroupBy(r => CongestionDetector.FloorTime(r.Time, windowSize)))
+        {
+            var down = group.Max(r => r.DownloadBps ?? 0);
+            var up = group.Max(r => r.UploadBps ?? 0);
+            var d = expectedDownBps > 0 ? down / expectedDownBps.Value : 0;
+            var u = expectedUpBps > 0 ? up / expectedUpBps.Value : 0;
+            utils.Add(Math.Clamp(Math.Max(d, u), 0, 1));
+        }
+        return utils.Count > 0 ? utils.Average() : 0;
     }
 
     private (IspScoreFactor Factor, bool HasData) ScoreLoadedLatency(LoadedDeltas deltas, AccessProfile profile)
@@ -338,7 +395,7 @@ public class IspHealthScorer
             Score = (int)Math.Round(scores.Average()),
             Weight = _options.LoadedLatencyWeight,
             ValueText = string.Join(", ", parts),
-            Description = $"Latency increase under load vs +{FormatMs(profile.LoadedDeltaExcellentMs)} excellent and +{FormatMs(profile.LoadedDeltaAcceptableMs)} acceptable for {profile.DisplayName}.{source}"
+            Description = $"Latency increase under load vs +{FormatMsBand(profile.LoadedDeltaExcellentMs)} excellent and +{FormatMsBand(profile.LoadedDeltaAcceptableMs)} acceptable for {profile.DisplayName}.{source}"
         }, true);
     }
 
@@ -467,53 +524,93 @@ public class IspHealthScorer
     }
 
     /// <summary>
-    /// Grades one ASN: a quality blend (stability, jitter, loss, congestion) capped
-    /// by a reach ceiling for transit ASNs. The ceiling normalizes distance against
-    /// the measured internet-target delta so rural networks are judged by rural
-    /// geography (a 22 ms POP when the internet sits 14 ms out is solid) while a
-    /// metro POP far beyond a 2 ms internet context grades poorly. Quality deficits
-    /// subtract below the ceiling, so congestion always counts. ISP ASNs pass null
-    /// baselines: no ceiling, quality only.
+    /// Grades one ASN (transit) or one ISP hop: a quality blend (stability, jitter,
+    /// loss, congestion) capped by a reach ceiling. Jitter and stability come from
+    /// <see cref="AsnSeries.JitterSourceSamples"/> when set (a transit ASN's farther
+    /// cluster, to discount false near-hop jitter), otherwise the series itself.
+    /// Two reach modes: <paramref name="accessBaselineRtt"/> + <paramref name="internetMedianDeltaMs"/>
+    /// is the transit ceiling (distance normalized against the measured internet
+    /// context); <paramref name="intraAsnFloorRttMs"/> is the ISP intra-ASN ceiling (a
+    /// soft penalty for hops sitting further out than this ISP's nearest hop). Quality
+    /// deficits subtract below the ceiling, so congestion and jitter always count.
     /// </summary>
-    private IspAsnHealth GradeAsn(AsnSeries series, List<CongestionEvent> congestionEvents, double? accessBaselineRtt, double? internetMedianDeltaMs)
+    private IspAsnHealth GradeAsn(
+        AsnSeries series,
+        List<CongestionEvent> congestionEvents,
+        double? jitterFloorMs,
+        double? accessBaselineRtt,
+        double? internetMedianDeltaMs,
+        double? intraAsnFloorRttMs = null,
+        double? jitterOverrideMs = null)
     {
         var rtts = series.Samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
-        var jitters = series.Samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
         var losses = series.Samples.Where(s => s.LossPercent.HasValue).Select(s => s.LossPercent!.Value).ToList();
+        var jitters = series.Samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
 
         var medianRtt = SeriesStats.Median(rtts);
         var mad = SeriesStats.Mad(rtts);
-        var medianJitter = jitters.Count > 0 ? SeriesStats.Median(jitters) : null;
 
-        int? stabilityScore = null;
-        if (medianRtt is > 0 && mad.HasValue)
+        // Jitter and stability are absolve-only across clusters. The nearest cluster's
+        // variance can be false (ICMP deprioritization at that hop); a cleaner farther
+        // cluster - reached through it - proves the path is steady, so we take the BETTER
+        // (lower) of near and far. We never take the worse: a jittery farther cluster is
+        // its own problem further along the path and must not downgrade the nearer cluster.
+        // An ISP hop instead takes the ISP-wide jitter bound (jitterOverrideMs), which is
+        // already capped by the cleanest transit ASN.
+        var nearJitter = ScoringJitterOf(series.Samples);
+        var rawEffectiveJitter = jitterOverrideMs ?? EffectiveLower(series.Samples, series.JitterSourceSamples, ScoringJitterOf);
+        // Don't assimilate on a trivial difference: a witness must sit at least the minimum
+        // delta below this series' own reading to pull it down. Within that band it's noise,
+        // so keep our own jitter (no absolve, no assimilation flag). Applies to ISP and transit.
+        var effectiveJitter = rawEffectiveJitter.HasValue && nearJitter.HasValue
+            && rawEffectiveJitter.Value > nearJitter.Value - _options.JitterAssimilationMinDeltaMs
+            ? nearJitter
+            : rawEffectiveJitter;
+        var stabilityRatio = EffectiveLower(series.Samples, series.JitterSourceSamples, StabilityRatioOf);
+
+        // Assimilated when a witness (a farther transit cluster, or - for an ISP hop via
+        // the override - a downstream transit/deeper ISP hop) pulled this jitter below the
+        // series' own nearest reading.
+        var jitterAssimilated = effectiveJitter.HasValue
+            && nearJitter.HasValue && effectiveJitter.Value < nearJitter.Value - 0.001;
+
+        if (jitterOverrideMs == null && series.JitterSourceSamples.Count > 0)
         {
-            var ratio = mad.Value / medianRtt.Value;
-            stabilityScore = (int)Math.Round(ScoreCurve.Interpolate(ratio,
-                (0.02, 100), (0.10, 80), (0.25, 55), (0.5, 25), (1.0, 0)));
+            _logger?.LogDebug(
+                "ISP Health: AS{Asn} ({Name}) jitter absolve - near {Near} ms, farther cluster {Far} ms, effective {Eff} ms",
+                series.AsnNumber, series.AsnName, FormatMsOrNull(ScoringJitterOf(series.Samples)),
+                FormatMsOrNull(ScoringJitterOf(series.JitterSourceSamples)), FormatMsOrNull(effectiveJitter));
         }
 
-        int? jitterScore = null;
-        if (medianJitter.HasValue && medianRtt is > 0)
-        {
-            // Anchors tightened ~20% so meaningful jitter costs a touch more
-            var relative = ScoreCurve.Interpolate(medianJitter.Value / medianRtt.Value,
-                (0.04, 100), (0.12, 75), (0.25, 45), (0.50, 0));
-            var absolute = ScoreCurve.Interpolate(medianJitter.Value,
-                (0.4, 100), (1.5, 75), (4, 45), (12, 0));
-            jitterScore = (int)Math.Round(Math.Max(relative, absolute));
-        }
+        int? stabilityScore = stabilityRatio.HasValue
+            ? (int)Math.Round(ScoreCurve.Interpolate(stabilityRatio.Value,
+                (0.02, 100), (0.10, 80), (0.25, 55), (0.5, 25), (1.0, 0)))
+            : null;
 
-        // Reach ceiling: the best grade this ASN's distance allows. The absolute
-        // curve applies only top-end gravity (100 needs sub +1 ms; +7-9 ms tops out
-        // ~93; far distance alone never grades below the high 80s). The relative
-        // curve judges distance against the measured internet context: ratio of this
-        // POP's delta to the median internet-target delta. Validated against rural
-        // data where a clean 22 ms POP (1.6x internet distance) must stay solid.
+        int? jitterScore = effectiveJitter.HasValue
+            ? (int)Math.Round(ScoreJitterVsFloor(effectiveJitter.Value, jitterFloorMs))
+            : null;
+
+        // Reach ceiling: the best grade this hop's distance allows.
         double? reachDelta = null;
         int? reachCeiling = null;
-        if (accessBaselineRtt.HasValue && medianRtt.HasValue)
+        if (intraAsnFloorRttMs.HasValue && medianRtt.HasValue)
         {
+            // ISP intra-ASN reach: distance from this ISP's nearest hop. A second POP a
+            // couple ms out is two sites a real distance apart - nominal, not a fault -
+            // so it tops out short of perfect rather than getting dinged hard.
+            reachDelta = Math.Max(0, medianRtt.Value - intraAsnFloorRttMs.Value);
+            reachCeiling = (int)Math.Round(ScoreCurve.Interpolate(reachDelta.Value,
+                (0, 100), (1, 93), (2, 85), (4, 70), (8, 50), (16, 35)));
+        }
+        else if (accessBaselineRtt.HasValue && medianRtt.HasValue)
+        {
+            // Transit reach ceiling. The absolute curve applies only top-end gravity
+            // (100 needs sub +1 ms; +7-9 ms tops out ~93; far distance alone never grades
+            // below the high 80s). The relative curve judges distance against the measured
+            // internet context: ratio of this POP's delta to the median internet-target
+            // delta. Validated against rural data where a clean 22 ms POP (1.6x internet
+            // distance) must stay solid.
             reachDelta = Math.Max(0, medianRtt.Value - accessBaselineRtt.Value);
             var ceiling = ScoreCurve.Interpolate(reachDelta.Value,
                 (1, 100), (8, 93), (15, 90), (30, 87), (60, 82));
@@ -570,12 +667,17 @@ public class IspHealthScorer
             AsnName = series.AsnName,
             TargetIds = series.TargetIds,
             MedianRttMs = medianRtt,
-            // Display: mean across the full nearest cluster (set on the grading series);
-            // falls back to the graded samples' mean when not provided
-            MeanRttMs = series.NearestClusterMeanRttMs ?? (rtts.Count > 0 ? rtts.Average() : null),
+            // Displayed RTT: winsorized mean (P99-capped) so sustained elevation shows but a
+            // flap can't distort it. Reach (above) stays on the median - that measures distance.
+            MeanRttMs = SeriesStats.WinsorizedMean(rtts, _options.RttWinsorPercentile),
             P95RttMs = SeriesStats.Percentile(rtts, 0.95),
-            MedianJitterMs = medianJitter,
-            P95JitterMs = jitters.Count > 0 ? SeriesStats.Percentile(jitters, 0.95) : null,
+            // Raw near-cluster median, informational only. The displayed and scored jitter
+            // is the effective (absolve/assimilated) value below.
+            MedianJitterMs = jitters.Count > 0 ? SeriesStats.Median(jitters) : null,
+            // The effective jitter: absolve-only across clusters (transit) or the ISP-wide
+            // bound (ISP). This is what the card shows and what the ISP cap reads, so the
+            // displayed value reflects the assimilation rather than the raw near hop.
+            P95JitterMs = effectiveJitter,
             RttMadMs = mad,
             LossPct = losses.Count > 0 ? losses.Average() : null,
             ReachDeltaMs = reachDelta,
@@ -585,25 +687,267 @@ public class IspHealthScorer
             ReachLatencyScore = reachCeiling,
             CongestionScore = congestionScore,
             OverallScore = overall,
-            CongestionEventCount = asnEvents.Count
+            CongestionEventCount = asnEvents.Count,
+            JitterAssimilated = jitterAssimilated,
+            RawJitterMs = nearJitter
         };
     }
 
-    private static IspTargetHealth BuildIspTargetHealth(AsnSeries series, string? firstHopTargetId)
+    /// <summary>The path jitter floor: the lowest scoring (P95) jitter across all ISP hops
+    /// and transit clusters. Null when no series carries jitter.</summary>
+    private double? ComputeJitterFloor(IspHealthInputs inputs)
+    {
+        var medians = new List<double>();
+        void Add(IReadOnlyList<LatencySample> samples)
+        {
+            var m = ScoringJitterOf(samples);
+            if (m.HasValue) medians.Add(m.Value);
+        }
+        foreach (var s in inputs.IspAsnSeries) Add(s.Samples);
+        foreach (var s in inputs.TransitAsnSeries)
+        {
+            Add(s.Samples);
+            if (s.JitterSourceSamples.Count > 0) Add(s.JitterSourceSamples);
+        }
+        return medians.Count > 0 ? medians.Min() : null;
+    }
+
+    /// <summary>
+    /// The jitter statistic used for scoring, the ISP/transit cap, and the cards: P95 of
+    /// the effective jitter. P95 (not median) because the tail is what the cards show and
+    /// what users reason about, and what hurts real-time traffic. The ISP and transit
+    /// jitter shown and scored are the same value. Null when none reported jitter.
+    /// </summary>
+    private static double? ScoringJitterOf(IReadOnlyList<LatencySample> samples)
+    {
+        var js = samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
+        return js.Count > 0 ? SeriesStats.Percentile(js, 0.95) : null;
+    }
+
+    /// <summary>RTT stability ratio (MAD / median) of a sample set; lower is steadier. Null without RTT.</summary>
+    private static double? StabilityRatioOf(IReadOnlyList<LatencySample> samples)
+    {
+        var rtts = samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
+        var median = SeriesStats.Median(rtts);
+        var mad = SeriesStats.Mad(rtts);
+        return median is > 0 && mad.HasValue ? mad.Value / median.Value : null;
+    }
+
+    /// <summary>
+    /// The better (lower) of a metric over the near samples and over the far samples -
+    /// absolve-only. A cleaner farther cluster pulls the value down (the near hop's jitter
+    /// was false); a worse farther cluster is ignored so it never downgrades the nearer
+    /// hop. Far empty means near only.
+    /// </summary>
+    private static double? EffectiveLower(IReadOnlyList<LatencySample> near, IReadOnlyList<LatencySample> far, Func<IReadOnlyList<LatencySample>, double?> metric)
+    {
+        var n = metric(near);
+        if (far.Count == 0) return n;
+        var f = metric(far);
+        if (!f.HasValue) return n;
+        if (!n.HasValue) return f;
+        return Math.Min(n.Value, f.Value);
+    }
+
+    /// <summary>
+    /// Floor-relative jitter score. A target at the floor is as stable as the line
+    /// allows (100). Above it the target is genuinely jittery even if it is only ICMP
+    /// deprioritization. Dual-slope: a gentle slope through a dead band just above the
+    /// floor (+25-50%), then a steeper drop, so 2x the floor reads as a clear signal.
+    /// The high end is absolute - 5+ ms is real jitter no matter how low the floor sits.
+    /// </summary>
+    private double ScoreJitterVsFloor(double jitterMs, double? floorMs)
+    {
+        var f = Math.Clamp(floorMs ?? 0.4, _options.JitterFloorMinMs, _options.JitterFloorMaxMs);
+        return ScoreCurve.Interpolate(jitterMs,
+            (f, 100), (1.25 * f, 96), (1.5 * f, 91), (2.0 * f, 70), (5.0, 22), (12.0, 0));
+    }
+
+    /// <summary>
+    /// Grades every ISP hop. Each hop's jitter is absolved per-hop, routes-through-gated: a
+    /// witness (a transit ASN, another ISP hop, or a monitored destination) may only pull a
+    /// hop's jitter down when the hop is in the witness's ancestor set - proven upstream of it
+    /// on a shared discovery trace - so a divergent clean transit can never clear a congested
+    /// hop it doesn't traverse. When no ancestor data exists (no re-discovery yet) the gate
+    /// falls open for transit (transit is always downstream of the ISP) and stays closed for
+    /// ISP siblings and destinations. A destination's clean end-to-end jitter is a hard upper
+    /// bound on any on-path hop's true jitter, so a smooth path to it absolves an
+    /// ICMP-deprioritized hop whose forwarded traffic actually reaches the destination cleanly.
+    /// Hops are also scored against the intra-ASN reach floor (distance, not a fault).
+    /// </summary>
+    private List<IspAsnHealth> GradeIspHops(
+        List<AsnSeries> ispHopSeries,
+        List<AsnSeries> transitSeries,
+        List<IspAsnHealth> transitAsns,
+        List<AsnSeries> destinationSeries,
+        List<CongestionEvent> congestionEvents,
+        double? jitterFloorMs,
+        bool hopOrderKnown)
+    {
+        // Transit witnesses: each transit ASN's ancestor IPs + its effective jitter.
+        var transitJitterByAsn = transitAsns
+            .Where(a => a.P95JitterMs.HasValue)
+            .GroupBy(a => a.AsnNumber)
+            .ToDictionary(g => g.Key, g => g.Min(a => a.P95JitterMs!.Value));
+        var transitWitnesses = transitSeries
+            .Where(s => transitJitterByAsn.ContainsKey(s.AsnNumber))
+            .Select(s => (Ancestors: s.AncestorIps, Jitter: transitJitterByAsn[s.AsnNumber]))
+            .ToList();
+
+        // Destination witnesses: each monitored endpoint's ancestor IPs + its end-to-end
+        // jitter. Always strict (routes-through required) - a destination's clean path says
+        // nothing about a hop it doesn't cross, so it never absolves on faith. Only built when
+        // ancestry exists; without it (hopOrderKnown false) destinations can never absolve, so
+        // we skip computing their jitter entirely.
+        var destinationWitnesses = hopOrderKnown
+            ? destinationSeries
+                .Select(s => (s.AncestorIps, Jitter: ScoringJitterOf(s.Samples)))
+                .Where(w => w.Jitter.HasValue)
+                .Select(w => (w.AncestorIps, Jitter: w.Jitter!.Value))
+                .ToList()
+            : new List<(List<string> AncestorIps, double Jitter)>();
+
+        // ISP hop witnesses: each hop series + its own measured jitter.
+        var ispHopJitter = ispHopSeries
+            .Select(s => (Series: s, Jitter: ScoringJitterOf(s.Samples)))
+            .ToList();
+
+        var grades = new List<IspAsnHealth>();
+        foreach (var asnGroup in ispHopSeries.GroupBy(s => s.AsnNumber))
+        {
+            var hops = asnGroup.ToList();
+            var floorRtt = hops
+                .Select(s => SeriesStats.Median(s.Samples.Where(x => x.RttAvgMs.HasValue).Select(x => x.RttAvgMs!.Value).ToList()))
+                .Where(m => m.HasValue)
+                .Select(m => m!.Value)
+                .DefaultIfEmpty()
+                .Min();
+            double? intraFloor = hops.Any(s => s.Samples.Any(x => x.RttAvgMs.HasValue)) ? floorRtt : null;
+            foreach (var hop in hops)
+            {
+                var measured = ScoringJitterOf(hop.Samples);
+                // Transit is always downstream of the ISP: with ancestor data we require a
+                // proven routes-through (this hop is in the transit's ancestor set), without
+                // it the gate is open. ISP siblings are strict either way - a sibling absolves
+                // only a hop in its ancestor set, never on faith.
+                var witnesses = transitWitnesses
+                    .Where(w => !hopOrderKnown || RoutesThrough(w.Ancestors, hop.HopIps))
+                    .Select(w => w.Jitter)
+                    .Concat(ispHopJitter
+                        .Where(h => hopOrderKnown && !ReferenceEquals(h.Series, hop) && h.Jitter.HasValue
+                            && RoutesThrough(h.Series.AncestorIps, hop.HopIps))
+                        .Select(h => h.Jitter!.Value))
+                    .Concat(destinationWitnesses
+                        .Where(w => hopOrderKnown && RoutesThrough(w.AncestorIps, hop.HopIps))
+                        .Select(w => w.Jitter))
+                    .ToList();
+                double? effective = measured;
+                if (witnesses.Count > 0)
+                    effective = measured.HasValue ? Math.Min(measured.Value, witnesses.Min()) : witnesses.Min();
+
+                var grade = GradeAsn(hop, congestionEvents, jitterFloorMs, accessBaselineRtt: null, internetMedianDeltaMs: null,
+                    intraAsnFloorRttMs: intraFloor, jitterOverrideMs: effective);
+                // Log the graded effective (post sub-0.05 ms assimilation snap in GradeAsn),
+                // not the raw witness min, so the log matches what the hop is actually scored on.
+                _logger?.LogDebug(
+                    "ISP Health: ISP hop {Target} (AS{Asn}) graded {Score} - measured jitter {Jitter} ms, effective {Eff} ms ({Witnesses} routes-through witnesses), reach +{Reach} ms",
+                    hop.TargetIds.FirstOrDefault(), hop.AsnNumber, grade.OverallScore,
+                    FormatMsOrNull(measured), FormatMsOrNull(grade.P95JitterMs), witnesses.Count, FormatMsOrNull(grade.ReachDeltaMs));
+                grades.Add(grade);
+            }
+        }
+        return grades;
+    }
+
+    /// <summary>
+    /// Whether a witness routes through a hop (and so may absolve it): the hop's IP must be in
+    /// the witness's ancestor set - proven upstream of the witness on a shared discovery trace.
+    /// </summary>
+    private static bool RoutesThrough(List<string> witnessAncestors, List<string> hopIps) =>
+        hopIps.Any(ip => witnessAncestors.Contains(ip, StringComparer.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Collapses per-hop ISP grades to one entry per ASN for the Networks on Your Path
+    /// card: mean RTT and jitter across the hops, averaged grade, and the union of the
+    /// ASN's congestion events.
+    /// </summary>
+    private static List<IspAsnHealth> AggregateIspAsns(List<IspAsnHealth> hopGrades, List<CongestionEvent> congestionEvents, double assimilationMinDeltaMs)
+    {
+        var result = new List<IspAsnHealth>();
+        foreach (var group in hopGrades.GroupBy(h => h.AsnNumber))
+        {
+            var hops = group.ToList();
+            var targetIds = hops.SelectMany(h => h.TargetIds).Distinct().ToList();
+            var targetSet = new HashSet<string>(targetIds);
+            var asnEvents = congestionEvents
+                .Where(e => e.AsnNumbers.Contains(group.Key)
+                    && (e.TargetIds.Count == 0 || e.TargetIds.Any(t => targetSet.Contains(t))))
+                .ToList();
+            var means = hops.Select(h => h.MeanRttMs).Where(m => m.HasValue).Select(m => m!.Value).ToList();
+            // Each hop's P95JitterMs is its per-hop effective (absolved) jitter; RawJitterMs
+            // is its own measured reading. The card shows the mean effective and flags
+            // assimilation when that fell below the mean measured.
+            var effJitters = hops.Select(h => h.P95JitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
+            var rawJitters = hops.Select(h => h.RawJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
+            double? effMean = effJitters.Count > 0 ? effJitters.Average() : null;
+            double? rawMean = rawJitters.Count > 0 ? rawJitters.Average() : null;
+            var lossVals = hops.Select(h => h.LossPct).Where(l => l.HasValue).Select(l => l!.Value).ToList();
+            var medianRtts = hops.Select(h => h.MedianRttMs).Where(m => m.HasValue).Select(m => m!.Value).ToList();
+            var scored = hops.Where(h => h.OverallScore.HasValue).Select(h => h.OverallScore!.Value).ToList();
+            result.Add(new IspAsnHealth
+            {
+                AsnNumber = group.Key,
+                AsnName = hops.Select(h => h.AsnName).FirstOrDefault(n => !string.IsNullOrEmpty(n)),
+                TargetIds = targetIds,
+                MedianRttMs = medianRtts.Count > 0 ? medianRtts.Min() : null,
+                MeanRttMs = means.Count > 0 ? means.Average() : null,
+                // RTT range across the ISP hops, on the same winsorized mean the hops display.
+                MinRttMs = means.Count > 0 ? means.Min() : null,
+                MaxRttMs = means.Count > 0 ? means.Max() : null,
+                P95JitterMs = effMean,
+                LossPct = lossVals.Count > 0 ? lossVals.Average() : null,
+                OverallScore = scored.Count > 0 ? (int)Math.Round(scored.Average()) : null,
+                CongestionEventCount = asnEvents.Count,
+                JitterAssimilated = effMean.HasValue && rawMean.HasValue && effMean.Value < rawMean.Value - assimilationMinDeltaMs,
+                RawJitterMs = rawMean
+            });
+        }
+        return result;
+    }
+
+    private static IspTargetHealth BuildIspTargetHealth(AsnSeries series, string? firstHopTargetId, List<IspAsnHealth> hopGrades, double winsorPercentile)
     {
         var rtts = series.Samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
         var jitters = series.Samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
         var losses = series.Samples.Where(s => s.LossPercent.HasValue).Select(s => s.LossPercent!.Value).ToList();
         var targetId = series.TargetIds.FirstOrDefault() ?? "";
+        var grade = hopGrades.FirstOrDefault(g => g.TargetIds.Contains(targetId));
+        // Jitter comes from the grade (the effective/absolved value the hop is scored on), so
+        // the row matches the grade beside it. Fall back to the hop's own raw P95 when ungraded.
+        var rawP95 = jitters.Count > 0 ? SeriesStats.Percentile(jitters, 0.95) : null;
         return new IspTargetHealth
         {
             TargetId = targetId,
             Name = series.AsnName ?? targetId,
-            MedianRttMs = SeriesStats.Median(rtts),
-            P95JitterMs = jitters.Count > 0 ? SeriesStats.Percentile(jitters, 0.95) : null,
+            RttMs = SeriesStats.WinsorizedMean(rtts, winsorPercentile),
+            P95JitterMs = grade?.P95JitterMs ?? rawP95,
+            RawJitterMs = grade?.RawJitterMs ?? rawP95,
+            JitterAssimilated = grade?.JitterAssimilated ?? false,
             LossPct = losses.Count > 0 ? losses.Average() : null,
+            OverallScore = grade?.OverallScore,
+            ReachDeltaMs = grade?.ReachDeltaMs,
             IsGradedHop = targetId == firstHopTargetId
         };
+    }
+
+    /// <summary>The ISP Network dimension: averages every ISP hop grade. The per-hop
+    /// detail is rendered from <see cref="IspHealthReport.IspTargets"/>, so the dimension
+    /// itself carries no factors.</summary>
+    private IspScoreDimension BuildIspDimension(double weight, List<IspAsnHealth> hopGrades)
+    {
+        var scored = hopGrades.Where(h => h.OverallScore.HasValue).Select(h => h.OverallScore!.Value).ToList();
+        int? score = scored.Count > 0 ? (int)Math.Round(scored.Average()) : null;
+        return new IspScoreDimension { Name = "ISP Network", Score = score, Weight = weight, Factors = new List<IspScoreFactor>() };
     }
 
     private static IspScoreDimension BuildDimension(string name, double weight, List<IspScoreFactor> factors)
@@ -618,17 +962,14 @@ public class IspHealthScorer
         return new IspScoreDimension { Name = name, Score = score, Weight = weight, Factors = factors };
     }
 
-    private static IspScoreDimension BuildAsnDimension(string name, double weight, List<IspAsnHealth> asns, bool gradedOnBestHop = false)
+    private static IspScoreDimension BuildAsnDimension(string name, double weight, List<IspAsnHealth> asns)
     {
-        // The ISP Network grades on the lowest (best) hop, so label its RTT "Best" to
-        // distinguish it from the mean RTT shown on the Networks on Your Path card
-        var rttPrefix = gradedOnBestHop ? "Best " : "";
         var factors = asns.Select(a => new IspScoreFactor
         {
             Name = string.IsNullOrEmpty(a.AsnName) ? $"AS{a.AsnNumber}" : a.AsnName,
             Score = a.OverallScore,
             Weight = 1.0,
-            ValueText = a.MedianRttMs.HasValue ? $"{rttPrefix}{FormatMs(a.MedianRttMs.Value)}" : null,
+            ValueText = a.MeanRttMs.HasValue ? FormatMsCoarse(a.MeanRttMs.Value) : null,
             Description = a.CongestionEventCount > 0
                 ? $"{a.CongestionEventCount} congestion event{(a.CongestionEventCount == 1 ? "" : "s")} in the window."
                 : null
@@ -777,13 +1118,26 @@ public class IspHealthScorer
         CongestionDetector.FloorTime(time, TimeSpan.FromSeconds(_options.LoadWindowSeconds));
 
     private static string FormatMs(double ms) =>
+        $"{ms.ToString("0.00", CultureInfo.InvariantCulture)} ms";
+
+    /// <summary>Coarse RTT for dimension summaries: no decimals at or above 10 ms, one below.
+    /// Detail lives on the Networks on Your Path cards.</summary>
+    private static string FormatMsCoarse(double ms) =>
         ms >= 10 ? $"{ms.ToString("0", CultureInfo.InvariantCulture)} ms" : $"{ms.ToString("0.0", CultureInfo.InvariantCulture)} ms";
 
+    /// <summary>Band references and loaded deltas: one decimal (2.0 ms), not the value's two.</summary>
+    private static string FormatMsBand(double ms) =>
+        $"{ms.ToString("0.0", CultureInfo.InvariantCulture)} ms";
+
+    /// <summary>Debug-log helper: a millisecond value to two decimals, or "n/a" when null.</summary>
+    private static string FormatMsOrNull(double? ms) =>
+        ms.HasValue ? ms.Value.ToString("0.00", CultureInfo.InvariantCulture) : "n/a";
+
     /// <summary>Loaded-latency delta for display: a non-positive delta shows as "0 ms".</summary>
-    private static string FormatLoadedDelta(double ms) => ms <= 0 ? "0 ms" : FormatMs(ms);
+    private static string FormatLoadedDelta(double ms) => ms <= 0 ? "0 ms" : FormatMsBand(ms);
 
     private static string FormatPct(double pct) =>
-        pct == 0 ? "0%" : $"{pct.ToString(pct < 0.1 ? "0.000" : "0.00", CultureInfo.InvariantCulture)}%";
+        pct == 0 ? "0%" : $"{pct.ToString(pct < 0.1 ? "0.###" : "0.##", CultureInfo.InvariantCulture)}%";
 
     private static string FormatMbps(double mbps) =>
         mbps.ToString(mbps >= 100 ? "0" : "0.#", CultureInfo.InvariantCulture);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -51,8 +51,12 @@ public class IspHealthService
     /// </summary>
     public IspHealthSnapshot GetCachedScore()
     {
+        // The glanceable tile tolerates a longer staleness than the detail tab, so sitting on
+        // Live View doesn't drive a full Influx recompute every CacheTtl. A recompute is still
+        // kicked off once the tile crosses DashboardScoreTtl (or on first populate); the ISP
+        // Health tab uses the shorter CacheTtl (via GetReportAsync) for fresher detail.
         var report = _cached?.Report;
-        if (report != null && DateTime.UtcNow - report.ComputedAt < _options.CacheTtl)
+        if (report != null && DateTime.UtcNow - report.ComputedAt < _options.DashboardScoreTtl)
             return new IspHealthSnapshot(IspHealthStatus.Ready, report.OverallScore, report.ComputedAt);
 
         if (!_computing)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -99,6 +99,13 @@ public class IspHealthService
     }
 
     /// <summary>Pipeline readiness, for the tab's prerequisite funnels.</summary>
+    /// <summary>
+    /// Drop the cached report so the next <see cref="GetReportAsync"/> recomputes from current
+    /// data. Called when Upstream Discovery is committed, so the "re-run discovery" banner
+    /// clears as soon as the user revisits the tab, without a manual refresh.
+    /// </summary>
+    public void Invalidate() => _cached = null;
+
     public IspHealthStatus Status => _cached != null ? IspHealthStatus.Ready : _status;
 
     private async Task<(IspHealthReport? Report, List<AsnSeries> ChartClusters)> ComputeAsync(CancellationToken ct)
@@ -111,6 +118,11 @@ public class IspHealthService
 
         AccessTechnology technology;
         List<MonitoringTarget> targets;
+        // TargetId -> the monitored hop IPs proven upstream of it (its ancestors), from
+        // Upstream Discovery's traces. ISP Health uses these to confirm one hop routes
+        // through another before its jitter absolves the other. No live traceroute here.
+        Dictionary<string, List<string>> ancestorIpsByTargetId;
+        bool hopOrderKnown;
         await using (var db = await _dbFactory.CreateDbContextAsync(ct))
         {
             var settings = await db.MonitoringSettings.AsNoTracking().FirstOrDefaultAsync(ct);
@@ -134,6 +146,27 @@ public class IspHealthService
                     || t.TargetType == MonitoringTargetType.Transit
                     || t.TargetType == MonitoringTargetType.InternetService))
                 .ToListAsync(ct);
+
+            // TODO (multi-WAN): discoveries are read across ALL WANs, not scoped to the WAN
+            // being scored. UpstreamDiscovery rows carry WanInterface, but ISP Health scores
+            // a single (primary) WAN and ancestry/hopOrderKnown here is global, so a second
+            // WAN's discovery data could flip the absolve gate for a WAN that has none of its
+            // own. Scope by WanInterface once ISP Health grades per-WAN. See TODO.md.
+            var discoveries = await db.UpstreamDiscoveries.AsNoTracking()
+                .Where(d => d.IsActive && d.MonitoringTargetId != null)
+                .ToListAsync(ct);
+            // TargetId -> ancestor hop IPs. Join discovery rows to the loaded targets by PK.
+            var targetIdById = targets.ToDictionary(t => t.Id, t => t.TargetId);
+            ancestorIpsByTargetId = discoveries
+                .Where(d => targetIdById.ContainsKey(d.MonitoringTargetId!.Value))
+                .GroupBy(d => targetIdById[d.MonitoringTargetId!.Value])
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.SelectMany(d => (d.AncestorHopIps ?? "").Split(' ', StringSplitOptions.RemoveEmptyEntries))
+                        .Distinct(StringComparer.OrdinalIgnoreCase).ToList());
+            // Ancestor data exists when any row carries the (non-null) column - distinguishes
+            // "no discovery yet / pre-ancestor data" from "on-path but no upstream ancestors".
+            hopOrderKnown = discoveries.Any(d => d.AncestorHopIps != null);
         }
 
         var ispTargets = targets.Where(t => t.TargetType == MonitoringTargetType.AccessIsp).ToList();
@@ -241,7 +274,7 @@ public class IspHealthService
                 && internetSeries.ContainsKey(t.TargetId))
             .Select(t => internetSeries[t.TargetId]));
 
-        var (ispGrading, transitGrading, allClusters, chartClusters) = BuildAsnSeriesSets(ispTargets, transitTargets, ispSeries, transitSeries);
+        var (ispGrading, transitGrading, allClusters, chartClusters) = BuildAsnSeriesSets(ispTargets, transitTargets, ispSeries, transitSeries, ancestorIpsByTargetId);
         var internetTargetSeries = targets
             .Where(t => t.TargetType == MonitoringTargetType.InternetService && internetSeries.ContainsKey(t.TargetId))
             .Select(t => new AsnSeries
@@ -249,7 +282,11 @@ public class IspHealthService
                 AsnNumber = t.AsnNumber ?? 0,
                 AsnName = t.Name,
                 TargetIds = { t.TargetId },
-                Samples = internetSeries[t.TargetId]
+                Samples = internetSeries[t.TargetId],
+                HopIps = { t.Address },
+                // Hops proven upstream of this destination, so its clean end-to-end jitter
+                // can absolve an ICMP-deprioritized ISP hop it provably routes through.
+                AncestorIps = ancestorIpsByTargetId.TryGetValue(t.TargetId, out var destAnc) ? destAnc : new List<string>()
             })
             .ToList();
 
@@ -274,6 +311,7 @@ public class IspHealthService
             LossPoolSeries = lossPool,
             TransitAsnSeries = transitGrading,
             IspAsnSeries = ispGrading,
+            DestinationSeries = internetTargetSeries,
             WanRates = wanRates,
             InternetMedianDeltaMs = internetMedianDelta,
             ExpectedDownloadMbps = expectedDown,
@@ -282,10 +320,11 @@ public class IspHealthService
             WanSpeedTests = wanSpeedTests,
             CongestionEvents = congestionEvents,
             PathShifts = pathShifts,
-            SmartQueuesEnabled = smartQueuesEnabled
+            SmartQueuesEnabled = smartQueuesEnabled,
+            HopOrderKnown = hopOrderKnown
         };
 
-        var report = new IspHealthScorer(_options).Score(inputs, profile);
+        var report = new IspHealthScorer(_options, _logger).Score(inputs, profile);
         _status = IspHealthStatus.Ready;
         _logger.LogDebug("ISP Health computed: {Score} ({Tech}), {Events} congestion events, {Shifts} path shifts",
             report.OverallScore, profile.DisplayName, congestionEvents.Count, pathShifts.Count);
@@ -456,15 +495,47 @@ public class IspHealthService
         List<MonitoringTarget> ispTargets,
         List<MonitoringTarget> transitTargets,
         Dictionary<string, List<LatencySample>> ispSeries,
-        Dictionary<string, List<LatencySample>> transitSeries)
+        Dictionary<string, List<LatencySample>> transitSeries,
+        Dictionary<string, List<string>> ancestorIpsByTargetId)
     {
         var ispOverrides = BuildIspAsnOverrides(ispTargets);
-        // The ISP grade follows the live ISP RTT card: the single lowest-RTT target
-        // is the first clean hop and represents the ISP network
-        var (ispGrading, ispClusters, ispChart) = GroupAndCluster(ispTargets, ispSeries, ispOverrides, gradeLowestTargetOnly: true);
+        // Congestion and path-shift detection still runs on clustered series so
+        // events fire at the right granularity
+        var (_, ispClusters, ispChart) = GroupAndCluster(ispTargets, ispSeries, ispOverrides, gradeLowestTargetOnly: true, ancestorIpsByTargetId);
+
+        // Grade each ISP target individually: every hop's own loss, reach, and
+        // congestion contribute to the ISP Network dimension instead of grading only
+        // the first clean hop (jitter is graded ISP-wide in the scorer). The access
+        // layer idle speed rating still uses FirstHopSeries (unchanged). AsnName carries
+        // the ASN org name (not the per-hop target name) so the aggregate ISP card on
+        // Networks on Your Path is labeled by the ASN; the per-hop table uses a separate
+        // series (ispTargetSeries) that keeps each target's own name.
+        var ispGrading = ispTargets
+            .Where(t => ispSeries.ContainsKey(t.TargetId))
+            .Select(t =>
+            {
+                var resolvedAsn = t.AsnNumber ?? 0;
+                var asnName = t.AsnName;
+                if (ispOverrides != null && ispOverrides.TryGetValue(t.TargetId, out var o))
+                {
+                    resolvedAsn = o.Asn;
+                    asnName ??= o.Name;
+                }
+                return new AsnSeries
+                {
+                    AsnNumber = resolvedAsn,
+                    AsnName = asnName,
+                    TargetIds = { t.TargetId },
+                    Samples = ispSeries[t.TargetId],
+                    RoleTargetIds = { t.TargetId },
+                    HopIps = { t.Address },
+                    AncestorIps = ancestorIpsByTargetId.TryGetValue(t.TargetId, out var anc) ? anc : new List<string>()
+                };
+            })
+            .ToList();
 
         var attributedTransit = transitTargets.Where(t => t.AsnNumber is > 0).ToList();
-        var (transitGrading, transitClusters, transitChart) = GroupAndCluster(attributedTransit, transitSeries, null, gradeLowestTargetOnly: false);
+        var (transitGrading, transitClusters, transitChart) = GroupAndCluster(attributedTransit, transitSeries, null, gradeLowestTargetOnly: false, ancestorIpsByTargetId);
 
         return (ispGrading, transitGrading,
             ispClusters.Concat(transitClusters).ToList(),
@@ -495,7 +566,8 @@ public class IspHealthService
         List<MonitoringTarget> targets,
         Dictionary<string, List<LatencySample>> seriesByTarget,
         Dictionary<string, (int Asn, string? Name)>? asnOverrides,
-        bool gradeLowestTargetOnly)
+        bool gradeLowestTargetOnly,
+        Dictionary<string, List<string>> ancestorIpsByTargetId)
     {
         var grading = new List<AsnSeries>();
         var allClusters = new List<AsnSeries>();
@@ -585,6 +657,30 @@ public class IspHealthService
                         .Where(s => s.RttAvgMs.HasValue)
                         .Select(s => s.RttAvgMs!.Value)
                         .ToList();
+                    // Jitter and stability are scored from the farthest cluster when this
+                    // ASN spans more than one: a near hop's jitter is often false (ICMP
+                    // deprioritization), and the farther cluster - reached through the near
+                    // one - is the honest read of the path's jitter. RTT and reach stay on
+                    // the nearest cluster. Only for transit (full clusters graded); the ISP
+                    // grades each hop on its own, so this carve-out does not apply there.
+                    // The assimilation is gated on traceroute hop order: we only trust the
+                    // farther cluster's lower jitter when Upstream Discovery recorded it
+                    // strictly downstream of the nearest cluster (it actually routes through
+                    // it). Without that proof we keep the nearest cluster's own jitter.
+                    var jitterSource = new List<LatencySample>();
+                    if (!gradeLowestTargetOnly && clusters.Count > 1)
+                    {
+                        var farthest = clusters[^1].Select(c => c.Target).ToList();
+                        if (FarClusterRoutesThroughNear(clusters[0], clusters[^1], ancestorIpsByTargetId))
+                        {
+                            jitterSource = farthest.SelectMany(t => seriesByTarget[t.TargetId]).OrderBy(s => s.Time).ToList();
+                        }
+                    }
+                    // This cluster's hop IPs and the union of their ancestors, so the scorer can
+                    // confirm this transit routes through a given ISP hop (the hop is an ancestor).
+                    var clusterAncestors = clusterTargets
+                        .SelectMany(t => ancestorIpsByTargetId.TryGetValue(t.TargetId, out var anc) ? anc : Enumerable.Empty<string>())
+                        .Distinct(StringComparer.OrdinalIgnoreCase).ToList();
                     grading.Add(new AsnSeries
                     {
                         AsnNumber = group.Key,
@@ -592,6 +688,9 @@ public class IspHealthService
                         TargetIds = clusterTargets.Select(t => t.TargetId).ToList(),
                         Samples = clusterTargets.SelectMany(t => seriesByTarget[t.TargetId]).OrderBy(s => s.Time).ToList(),
                         NearestClusterMeanRttMs = nearestRtts.Count > 0 ? nearestRtts.Average() : null,
+                        JitterSourceSamples = jitterSource,
+                        HopIps = clusterTargets.Select(t => t.Address).ToList(),
+                        AncestorIps = clusterAncestors,
                         // All of this ASN-role's hops, so congestion is attributed to the
                         // right card when the same ASN is both the access ISP and transit
                         RoleTargetIds = group.Select(t => t.TargetId).ToList()
@@ -614,6 +713,26 @@ public class IspHealthService
             }
         }
         return (grading, allClusters, chartClusters);
+    }
+
+    /// <summary>
+    /// Confirms a farther RTT cluster is genuinely downstream of the nearer one using the
+    /// ancestor sets stored at Upstream Discovery: some nearer-cluster hop must be in the
+    /// farther cluster's ancestors, proving the route to the farther cluster passes through
+    /// the nearer on a shared trace. Without that proof we decline to assimilate (never
+    /// absolve on faith). Uses stored ancestors - no live traceroute is run.
+    /// </summary>
+    private static bool FarClusterRoutesThroughNear(
+        List<(MonitoringTarget Target, double? Median)> nearCluster,
+        List<(MonitoringTarget Target, double? Median)> farCluster,
+        Dictionary<string, List<string>> ancestorIpsByTargetId)
+    {
+        var nearIps = nearCluster.Select(c => c.Target.Address)
+            .Where(a => !string.IsNullOrEmpty(a)).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var farAncestors = farCluster
+            .SelectMany(c => ancestorIpsByTargetId.TryGetValue(c.Target.TargetId, out var anc) ? anc : Enumerable.Empty<string>())
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        return nearIps.Overlaps(farAncestors);
     }
 
     private static Dictionary<string, List<LatencySample>> ToSamples(

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/SeriesStats.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/SeriesStats.cs
@@ -19,6 +19,20 @@ internal static class SeriesStats
         return sorted[lo] + (sorted[hi] - sorted[lo]) * (rank - lo);
     }
 
+    /// <summary>
+    /// Mean after winsorizing the upper tail: values above the given percentile are capped
+    /// to it, then averaged. Keeps sustained elevation fully visible (those samples sit
+    /// below the cap) while stopping a few extreme outliers - a route flap or a single bad
+    /// probe - from dragging the average. Null when empty.
+    /// </summary>
+    public static double? WinsorizedMean(IReadOnlyList<double> values, double upperPercentile)
+    {
+        if (values.Count == 0) return null;
+        var cap = Percentile(values, upperPercentile);
+        if (cap == null) return values.Average();
+        return values.Select(v => Math.Min(v, cap.Value)).Average();
+    }
+
     /// <summary>Median absolute deviation; robust spread measure.</summary>
     public static double? Mad(IReadOnlyList<double> values)
     {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/OntAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/OntAlertEvaluator.cs
@@ -1,0 +1,162 @@
+using System.Collections.Concurrent;
+using NetworkOptimizer.Alerts.Events;
+using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Monitoring.Models;
+
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Evaluates external ONT (Optical Network Terminal) readings and publishes alert
+/// events on state transitions. Covers RX power degradation, PON link loss, and
+/// FEC error spikes - the same failure modes as in-gateway SFP DDM but sourced
+/// from the ISP-side device.
+/// </summary>
+public class OntAlertEvaluator
+{
+    private const double RxPowerLowDbm = PonThresholds.PonRxPowerLowDbm;
+    private const double RxPowerHysteresisDbm = PonThresholds.PowerHysteresisDbm;
+    private const long FecErrorDeltaThreshold = 1000;
+
+    private readonly IAlertEventBus _eventBus;
+    private readonly ILogger<OntAlertEvaluator> _logger;
+    private readonly ConcurrentDictionary<int, OntAlertState> _states = new();
+
+    public OntAlertEvaluator(IAlertEventBus eventBus, ILogger<OntAlertEvaluator> logger)
+    {
+        _eventBus = eventBus;
+        _logger = logger;
+    }
+
+    public async ValueTask EvaluateAsync(
+        int ontId, string ontName,
+        double? rxPowerDbm,
+        PonLinkState ponLinkStatus,
+        long? fecErrors,
+        CancellationToken ct = default)
+    {
+        var state = _states.GetOrAdd(ontId, _ => new OntAlertState());
+
+        if (rxPowerDbm.HasValue)
+        {
+            await CheckRxPower(state, ontId, ontName, rxPowerDbm.Value, ct);
+        }
+
+        await CheckPonLink(state, ontId, ontName, ponLinkStatus, ct);
+
+        if (fecErrors.HasValue)
+        {
+            await CheckFecErrors(state, ontId, ontName, fecErrors.Value, ct);
+        }
+    }
+
+    private async ValueTask CheckRxPower(
+        OntAlertState state, int ontId, string ontName, double rxPower, CancellationToken ct)
+    {
+        if (rxPower < RxPowerLowDbm && !state.RxPowerBreached)
+        {
+            state.RxPowerBreached = true;
+            _logger.LogDebug("ONT {Name} RX power {Power} dBm below threshold {Threshold} dBm",
+                ontName, rxPower, RxPowerLowDbm);
+
+            await _eventBus.PublishAsync(new AlertEvent
+            {
+                EventType = "ont.rx_power_low",
+                Source = "ont",
+                Severity = AlertSeverity.Warning,
+                Title = $"{ontName} RX power low",
+                Message = $"ONT {ontName} optical RX power {rxPower:0.##} dBm is below {RxPowerLowDbm} dBm threshold.",
+                DeviceName = ontName,
+                MetricValue = rxPower,
+                ThresholdValue = RxPowerLowDbm,
+                SourceUrl = "/monitoring?tab=ont",
+                Tags = ["ont", "rx_power"],
+                Context = new Dictionary<string, string>
+                {
+                    ["ont_id"] = ontId.ToString(),
+                    ["metric"] = "rx_power"
+                }
+            }, ct);
+        }
+        else if (rxPower >= RxPowerLowDbm + RxPowerHysteresisDbm && state.RxPowerBreached)
+        {
+            state.RxPowerBreached = false;
+        }
+    }
+
+    private async ValueTask CheckPonLink(
+        OntAlertState state, int ontId, string ontName, PonLinkState ponLinkStatus, CancellationToken ct)
+    {
+        var isDown = ponLinkStatus != PonLinkState.Operation && ponLinkStatus != PonLinkState.Unknown;
+
+        if (isDown && !state.PonLinkDown)
+        {
+            state.PonLinkDown = true;
+            _logger.LogDebug("ONT {Name} PON link down (state: {State})", ontName, ponLinkStatus);
+
+            await _eventBus.PublishAsync(new AlertEvent
+            {
+                EventType = "ont.pon_link_down",
+                Source = "ont",
+                Severity = AlertSeverity.Error,
+                Title = $"{ontName} PON link down",
+                Message = $"ONT {ontName} PON link is down (state: {ponLinkStatus}).",
+                DeviceName = ontName,
+                SourceUrl = "/monitoring?tab=ont",
+                Tags = ["ont", "pon_link"],
+                Context = new Dictionary<string, string>
+                {
+                    ["ont_id"] = ontId.ToString(),
+                    ["pon_link_state"] = ponLinkStatus.ToString()
+                }
+            }, ct);
+        }
+        else if (!isDown && state.PonLinkDown)
+        {
+            state.PonLinkDown = false;
+        }
+    }
+
+    private async ValueTask CheckFecErrors(
+        OntAlertState state, int ontId, string ontName, long fecErrors, CancellationToken ct)
+    {
+        if (state.PreviousFecErrors.HasValue)
+        {
+            var delta = fecErrors - state.PreviousFecErrors.Value;
+            if (delta < 0) delta = 0; // counter reset
+
+            if (delta > FecErrorDeltaThreshold)
+            {
+                _logger.LogDebug("ONT {Name} FEC error spike: {Delta} errors since last poll", ontName, delta);
+
+                await _eventBus.PublishAsync(new AlertEvent
+                {
+                    EventType = "ont.fec_errors",
+                    Source = "ont",
+                    Severity = AlertSeverity.Warning,
+                    Title = $"{ontName} FEC error spike",
+                    Message = $"ONT {ontName} had {delta:N0} FEC errors since last poll (threshold: {FecErrorDeltaThreshold:N0}).",
+                    DeviceName = ontName,
+                    MetricValue = delta,
+                    ThresholdValue = FecErrorDeltaThreshold,
+                    SourceUrl = "/monitoring?tab=ont",
+                    Tags = ["ont", "fec"],
+                    Context = new Dictionary<string, string>
+                    {
+                        ["ont_id"] = ontId.ToString(),
+                        ["metric"] = "fec_errors",
+                        ["fec_delta"] = delta.ToString()
+                    }
+                }, ct);
+            }
+        }
+
+        state.PreviousFecErrors = fecErrors;
+    }
+
+    private class OntAlertState
+    {
+        public bool RxPowerBreached;
+        public bool PonLinkDown;
+        public long? PreviousFecErrors;
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/PonThresholds.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/PonThresholds.cs
@@ -1,0 +1,24 @@
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Single source-of-truth for PON and SFP optical thresholds.
+/// </summary>
+public static class PonThresholds
+{
+    // --- PON thresholds (SFP and external ONT share these) ---
+    public const double PonRxPowerLowDbm = -25.0;
+    public const double PonTxPowerHighDbm = 4.0;
+    public const double PonTempHighC = 75.0;
+
+    // --- Hysteresis ---
+    public const double PowerHysteresisDbm = 2.0;
+    public const double TempHysteresisC = 5.0;
+
+    // --- Active Ethernet SFP thresholds ---
+    public const double AeRxPowerLowDbm = -14.0;
+    public const double AeTxPowerHighDbm = 1.0;
+    public const double AeTempHighC = 80.0;
+
+    // --- Generic SFP thresholds ---
+    public const double SfpTempHighGenericC = 87.0;
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/SfpAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/SfpAlertEvaluator.cs
@@ -12,18 +12,18 @@ namespace NetworkOptimizer.Web.Services.Monitoring;
 /// </summary>
 public class SfpAlertEvaluator
 {
-    private const double PonRxPowerLowDbm = -25.0;
-    private const double PonTxPowerHighDbm = 4.0;
-    private const double PonTempHighC = 75.0;
+    private const double PonRxPowerLowDbm = PonThresholds.PonRxPowerLowDbm;
+    private const double PonTxPowerHighDbm = PonThresholds.PonTxPowerHighDbm;
+    private const double PonTempHighC = PonThresholds.PonTempHighC;
 
-    private const double AeRxPowerLowDbm = -14.0;
-    private const double AeTxPowerHighDbm = 1.0;
-    private const double AeTempHighC = 80.0;
+    private const double AeRxPowerLowDbm = PonThresholds.AeRxPowerLowDbm;
+    private const double AeTxPowerHighDbm = PonThresholds.AeTxPowerHighDbm;
+    private const double AeTempHighC = PonThresholds.AeTempHighC;
 
-    private const double SfpTempHighC = 87.0;
+    private const double SfpTempHighC = PonThresholds.SfpTempHighGenericC;
 
-    private const double TempHysteresisC = 5.0;
-    private const double PowerHysteresisDbm = 2.0;
+    private const double TempHysteresisC = PonThresholds.TempHysteresisC;
+    private const double PowerHysteresisDbm = PonThresholds.PowerHysteresisDbm;
 
     private readonly IAlertEventBus _eventBus;
     private readonly ILogger<SfpAlertEvaluator> _logger;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -30,6 +30,7 @@ public class UpstreamTracerService
     private readonly AsnResolutionService _asnResolution;
     private readonly LocalProbeExecutor _localProbe;
     private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IspHealth.IspHealthService _ispHealth;
     private readonly NetworkOptimizer.Audit.Services.IeeeOuiDatabase _ouiDb;
     private readonly ILogger<UpstreamTracerService> _logger;
 
@@ -90,6 +91,7 @@ public class UpstreamTracerService
         AsnResolutionService asnResolution,
         LocalProbeExecutor localProbe,
         IServiceScopeFactory scopeFactory,
+        IspHealth.IspHealthService ispHealth,
         NetworkOptimizer.Audit.Services.IeeeOuiDatabase ouiDb,
         ILogger<UpstreamTracerService> logger)
     {
@@ -99,6 +101,7 @@ public class UpstreamTracerService
         _asnResolution = asnResolution;
         _localProbe = localProbe;
         _scopeFactory = scopeFactory;
+        _ispHealth = ispHealth;
         _ouiDb = ouiDb;
         _logger = logger;
     }
@@ -585,6 +588,12 @@ public class UpstreamTracerService
     private List<AttributedHop> _mergedHops = new();
     private List<AttributedHop> _accessHopsResolved = new();
 
+    // Raw per-trace hop sequences from the last discovery sweep. Kept so commit can
+    // persist SAME-PATH hop ordering to UpstreamDiscoveries: the merged pool (_mergedHops)
+    // dedupes hop IPs across ~22 anycast traces, so its hop numbers are not on a common
+    // path and cannot prove "B routes through A". A single trace's sequence can.
+    private List<TracerouteResult> _lastTraces = new();
+
     private async Task TraceAccessIspAsync(CancellationToken ct)
     {
         State.Step = TracerStep.TracingAccessIsp;
@@ -601,6 +610,8 @@ public class UpstreamTracerService
             tasks.Add(TraceOneAsync(endpoint, ProbeMode.Udp, ct));
         }
         var results = await Task.WhenAll(tasks);
+        // Keep the raw per-trace sequences for same-path hop-order persistence at commit.
+        _lastTraces = results.Select(r => r.Result).ToList();
 
         // Summarize per CDN for the live progress UI.
         foreach (var (label, result) in results)
@@ -1225,8 +1236,116 @@ public class UpstreamTracerService
         }
 
         await db.SaveChangesAsync(ct);
+
+        // Persist same-path hop ordering so ISP Health can confirm a farther transit
+        // cluster routes through a nearer one before assimilating its jitter.
+        await PersistHopOrderAsync(db, wanInterface, ct);
+
+        // Drop the ISP Health cache so the "re-run discovery" banner clears on the next tab
+        // view without a manual refresh - the freshly committed ancestry is now in the DB.
+        _ispHealth.Invalidate();
+
         State.Step = TracerStep.Done;
         State.CurrentActivity = "Targets committed. The agent will start probing on the next latency-tier cycle.";
+    }
+
+    /// <summary>
+    /// Persists traceroute hop order to UpstreamDiscoveries so ISP Health can confirm one
+    /// monitored target routes through another (same-path proof) before its jitter absolves
+    /// the other. Hop numbers must be comparable across ASNs (ISP hop vs transit hop), so we
+    /// record TTLs from a SINGLE global canonical trace per WAN - the one discovery trace that
+    /// covered the most monitored hops, i.e. the main path out to the internet. Hops not on
+    /// that trace (divergent side paths) get no row, so the gate conservatively declines to
+    /// order them - exactly the behavior we want for divergent routers.
+    /// </summary>
+    private async Task PersistHopOrderAsync(NetworkOptimizerDbContext db, string wanInterface, CancellationToken ct)
+    {
+        if (_lastTraces.Count == 0)
+        {
+            _logger.LogDebug("Tracer: no per-trace hop data to persist (rehydrated state); leaving UpstreamDiscoveries as-is");
+            return;
+        }
+
+        // Access + transit hops are the graded path; destinations (anycast DNS, CDN probes)
+        // are persisted too so ISP Health can use a destination's clean end-to-end jitter to
+        // absolve an ICMP-deprioritized hop it provably routes through.
+        var targets = await db.MonitoringTargets
+            .Where(t => t.WanInterface == wanInterface && t.Enabled && t.AsnNumber != null
+                && (t.TargetType == MonitoringTargetType.AccessIsp
+                    || t.TargetType == MonitoringTargetType.Transit
+                    || t.TargetType == MonitoringTargetType.InternetService))
+            .ToListAsync(ct);
+
+        // Refresh: drop prior rows for this WAN, then rebuild from this sweep.
+        var prior = await db.UpstreamDiscoveries.Where(d => d.WanInterface == wanInterface).ToListAsync(ct);
+        if (prior.Count > 0) db.UpstreamDiscoveries.RemoveRange(prior);
+        if (targets.Count == 0)
+        {
+            await db.SaveChangesAsync(ct);
+            return;
+        }
+
+        var monitoredAddrs = targets.Select(t => t.Address).Where(a => !string.IsNullOrEmpty(a))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        // Ancestor sets from ALL traces: for each monitored hop, the monitored hops that
+        // appear before it on any trace it was seen on (its proven upstream). Every trace
+        // contributes (including those toward transit targets), so coverage is complete and
+        // divergence-correct - a hop is only an ancestor of another when they truly share a
+        // path with it upstream. Also track the lowest TTL seen, for a representative HopNumber.
+        var ancestorsByIp = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        var minTtlByIp = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var tr in _lastTraces)
+        {
+            var seenMonitored = new List<string>();
+            foreach (var h in tr.Hops.Where(h => h.Responded && !string.IsNullOrEmpty(h.Address)).OrderBy(h => h.HopNumber))
+            {
+                if (!monitoredAddrs.Contains(h.Address!)) continue;
+                if (!ancestorsByIp.TryGetValue(h.Address!, out var anc))
+                    ancestorsByIp[h.Address!] = anc = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                anc.UnionWith(seenMonitored);
+                seenMonitored.Add(h.Address!);
+                if (!minTtlByIp.TryGetValue(h.Address!, out var ttl) || h.HopNumber < ttl)
+                    minTtlByIp[h.Address!] = h.HopNumber;
+            }
+        }
+
+        var now = DateTime.UtcNow;
+        var written = 0;
+        foreach (var t in targets)
+        {
+            var ancestors = ancestorsByIp.TryGetValue(t.Address, out var anc)
+                ? anc.OrderBy(a => a).ToList()
+                : new List<string>();
+            db.UpstreamDiscoveries.Add(new UpstreamDiscovery
+            {
+                MonitoringTargetId = t.Id,
+                AsnNumber = t.AsnNumber!.Value,
+                AsnName = t.AsnName,
+                HopIp = t.Address,
+                HopNumber = minTtlByIp.TryGetValue(t.Address, out var ttl) ? ttl : 0,
+                // Non-null (even if empty) marks that ancestor data exists, so ISP Health can
+                // tell "no discovery yet" (open gate) from "on-path but no ancestors" (a first hop).
+                AncestorHopIps = string.Join(" ", ancestors),
+                Role = t.TargetType switch
+                {
+                    MonitoringTargetType.AccessIsp => UpstreamRole.AccessHop,
+                    MonitoringTargetType.Transit => UpstreamRole.Transit,
+                    _ => UpstreamRole.PathProxy
+                },
+                WanInterface = wanInterface,
+                LastValidated = now,
+                LastTracerouteAt = now,
+                IsActive = true
+            });
+            written++;
+            _logger.LogDebug("Tracer: AS{Asn} {Ip} ({Name}) ancestors=[{Ancestors}]",
+                t.AsnNumber, t.Address, t.PtrHostname ?? t.Name, string.Join(", ", ancestors));
+        }
+
+        await db.SaveChangesAsync(ct);
+        _logger.LogInformation("Tracer: persisted {Count} upstream hop-ancestor rows for {Wan} from {Traces} traces",
+            written, wanInterface, _lastTraces.Count);
     }
 
     private static async Task UpsertTargetAsync(NetworkOptimizerDbContext db, AccessHopCandidate hop, string wanInterface, CancellationToken ct)

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -39,6 +39,7 @@ public class MonitoringCollectionAgent : BackgroundService
     private readonly LocalProbeExecutor _localProbe;
     private readonly NetworkOptimizer.Web.Services.Monitoring.MonitoringAlertEvaluator _alertEvaluator;
     private readonly NetworkOptimizer.Web.Services.Monitoring.SfpAlertEvaluator _sfpAlertEvaluator;
+    private readonly NetworkOptimizer.Web.Services.Monitoring.DeviceHealthAlertEvaluator _deviceHealthAlertEvaluator;
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<MonitoringCollectionAgent> _logger;
 
@@ -69,6 +70,7 @@ public class MonitoringCollectionAgent : BackgroundService
         LocalProbeExecutor localProbe,
         NetworkOptimizer.Web.Services.Monitoring.MonitoringAlertEvaluator alertEvaluator,
         NetworkOptimizer.Web.Services.Monitoring.SfpAlertEvaluator sfpAlertEvaluator,
+        NetworkOptimizer.Web.Services.Monitoring.DeviceHealthAlertEvaluator deviceHealthAlertEvaluator,
         ILoggerFactory loggerFactory,
         ILogger<MonitoringCollectionAgent> logger)
     {
@@ -80,6 +82,7 @@ public class MonitoringCollectionAgent : BackgroundService
         _localProbe = localProbe;
         _alertEvaluator = alertEvaluator;
         _sfpAlertEvaluator = sfpAlertEvaluator;
+        _deviceHealthAlertEvaluator = deviceHealthAlertEvaluator;
         _loggerFactory = loggerFactory;
         _logger = logger;
     }
@@ -709,6 +712,10 @@ public class MonitoringCollectionAgent : BackgroundService
                     timestamp: DateTime.UtcNow);
 
                 _liveStats.RecordHealth(device.Mac, cpu, memPct, temp, uptime, DateTime.UtcNow);
+
+                await _deviceHealthAlertEvaluator.EvaluateAsync(
+                    device.Mac, device.Name, DescribeDeviceType(device.DeviceType),
+                    cpu, memPct);
             }
             catch (Exception ex)
             {
@@ -767,6 +774,10 @@ public class MonitoringCollectionAgent : BackgroundService
                     timestamp: now);
 
                 _liveStats.RecordHealth(device.Mac, cpu, mem, temp, uptime, now);
+
+                await _deviceHealthAlertEvaluator.EvaluateAsync(
+                    device.Mac, device.Name, DescribeDeviceType(device.DeviceType),
+                    cpu, mem);
             }
             catch (Exception ex)
             {

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -1270,13 +1270,23 @@ from(bucket: ""{_longtermBucket}"")
             ? $@"|> filter(fn: (r) => r.cm_id == ""{SanitizeFluxString(cmId)}"")"
             : "";
 
+        var winDur = ToFluxDuration(window);
         var flux = $@"
-from(bucket: ""{_longtermBucket}"")
+gauges = from(bucket: ""{_longtermBucket}"")
   |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
   |> filter(fn: (r) => r._measurement == ""cable_modem"")
   {cmFilter}
-  |> filter(fn: (r) => r._field == ""ds_power_avg_dbmv"" or r._field == ""ds_snr_avg_db"" or r._field == ""us_power_avg_dbmv"" or r._field == ""correctables_delta"" or r._field == ""uncorrectables_delta"" or r._field == ""locked_ds_channels"" or r._field == ""locked_us_channels"")
-  |> aggregateWindow(every: {ToFluxDuration(window)}, fn: last, createEmpty: false)
+  |> filter(fn: (r) => r._field == ""ds_power_avg_dbmv"" or r._field == ""ds_snr_avg_db"" or r._field == ""us_power_avg_dbmv"" or r._field == ""locked_ds_channels"" or r._field == ""locked_us_channels"")
+  |> aggregateWindow(every: {winDur}, fn: last, createEmpty: false)
+
+deltas = from(bucket: ""{_longtermBucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""cable_modem"")
+  {cmFilter}
+  |> filter(fn: (r) => r._field == ""correctables_delta"" or r._field == ""uncorrectables_delta"")
+  |> aggregateWindow(every: {winDur}, fn: sum, createEmpty: false)
+
+union(tables: [gauges, deltas])
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
         var results = new Dictionary<string, List<CmPoint>>();

--- a/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
@@ -19,6 +19,7 @@ public class OntMonitorService : IDisposable
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ICredentialProtectionService _credentialProtection;
     private readonly MonitoringInfluxClient _influx;
+    private readonly NetworkOptimizer.Web.Services.Monitoring.OntAlertEvaluator _alertEvaluator;
     private readonly ILogger<OntMonitorService> _logger;
     private readonly Dictionary<string, IOntProvider> _providers;
     private readonly ConcurrentDictionary<int, OntStats> _statsCache = new();
@@ -31,11 +32,13 @@ public class OntMonitorService : IDisposable
         IEnumerable<IOntProvider> providers,
         ICredentialProtectionService credentialProtection,
         MonitoringInfluxClient influx,
+        NetworkOptimizer.Web.Services.Monitoring.OntAlertEvaluator alertEvaluator,
         ILogger<OntMonitorService> logger)
     {
         _scopeFactory = scopeFactory;
         _credentialProtection = credentialProtection;
         _influx = influx;
+        _alertEvaluator = alertEvaluator;
         _logger = logger;
         _providers = providers.ToDictionary(p => p.ProviderKey, StringComparer.OrdinalIgnoreCase);
 
@@ -97,9 +100,14 @@ public class OntMonitorService : IDisposable
             config.Password = _credentialProtection.Encrypt(config.Password);
         }
 
+        var isNew = config.Id == 0;
+
         using var scope = _scopeFactory.CreateScope();
         var repository = scope.ServiceProvider.GetRequiredService<IOntRepository>();
         await repository.SaveOntConfigurationAsync(config);
+
+        if (isNew)
+            await AlertRuleAutoEnable.EnableBySourceAsync(scope, "ont", _logger);
     }
 
     /// <summary>
@@ -197,6 +205,10 @@ public class OntMonitorService : IDisposable
 
                 // Fire-and-forget write to InfluxDB
                 WriteToInflux(config, stats);
+
+                _ = _alertEvaluator.EvaluateAsync(
+                    config.Id, config.Name,
+                    stats.RxPowerDbm, stats.PonLinkStatus, stats.FecErrors);
 
                 _logger.LogDebug("ONT {Name} polled successfully: Rx={Rx} dBm", config.Name, stats.RxPowerDbm);
                 return stats;

--- a/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
@@ -403,8 +403,9 @@ WantedBy=multi-user.target
 
                 result.Success = false;
                 result.Error = $"IFB device {ifbDevice} does not exist. " +
-                    "Ensure Smart Queues is enabled in UniFi Network settings and the device has finished initializing. " +
-                    "Try toggling Smart Queues off and on, then wait 45 seconds before deploying.";
+                    "Smart Queues is enabled but UniFi didn't actually create the traffic control classes - this is a known UniFi bug. " +
+                    "To fix it, add any QoS rule in UniFi Network (Settings > Policy Table > QoS Rules). " +
+                    "It doesn't matter what the rule targets. Wait 45 seconds, then deploy again.";
                 result.Steps = steps;
                 _logger.LogWarning("SQM deployment blocked: IFB device {Device} not found on gateway", ifbDevice);
                 return result;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2986,6 +2986,16 @@ select.form-control {
     border-top: 1px solid var(--border-color);
 }
 
+.app-footer a {
+    color: var(--text-muted);
+    text-decoration: none;
+}
+
+.app-footer a:hover {
+    color: var(--text-secondary);
+    text-decoration: underline;
+}
+
 /* Hamburger Menu Button - hidden on desktop */
 .hamburger-btn {
     display: none;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15532,6 +15532,10 @@ a.affected-client:hover {
     font-size: 0.85rem;
 }
 
+.isp-asn-stat .tooltip-icon {
+    background-color: var(--btn-map-hover);
+}
+
 .isp-asn-score-track {
     height: 5px;
     border-radius: 0 3px 3px 0;
@@ -15665,31 +15669,44 @@ a.affected-client:hover {
     z-index: 5;
 }
 
-.isp-target-list {
+.isp-hop-list {
+    display: flex;
+    flex-direction: column;
+    margin-top: 0.25rem;
+}
+
+.isp-hop {
+    padding: 0.6rem 0;
+}
+
+.isp-hop + .isp-hop {
+    border-top: 1px solid var(--border-color);
+}
+
+.isp-hop-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.isp-hop-main {
     display: flex;
     flex-direction: column;
     gap: 0.35rem;
-    margin-top: 0.25rem;
-    padding-top: 0.5rem;
-    border-top: 1px solid var(--border-color);
+    flex: 1;
+    min-width: 0;
 }
 
-.isp-target-row {
-    display: flex;
-    flex-direction: column;
-    gap: 0.3rem;
-    padding: 0.55rem 0;
-}
-
-.isp-target-row + .isp-target-row {
-    border-top: 1px solid var(--border-color);
-}
-
-.isp-target-name {
-    font-size: 0.82rem;
+.isp-hop-name {
+    font-size: 0.85rem;
     font-weight: 500;
     color: var(--text-primary);
-    min-width: 0;
+}
+
+.isp-hop-stats {
+    display: flex;
+    gap: 1.25rem;
+    margin-top: 0.45rem;
 }
 
 .isp-target-graded {
@@ -15702,12 +15719,6 @@ a.affected-client:hover {
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-}
-
-.isp-target-stats {
-    display: flex;
-    justify-content: space-between;
-    gap: 0.5rem;
 }
 
 .isp-target-stat {
@@ -15724,6 +15735,12 @@ a.affected-client:hover {
     color: var(--text-muted);
     text-transform: uppercase;
     letter-spacing: 0.04em;
+}
+
+.isp-target-stat-value {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
 }
 
 .isp-factor-link {

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -29,18 +29,27 @@ public class IspHealthScorerTests
         bool withExpectedSpeeds = true,
         List<AsnSeries>? transit = null,
         List<AsnSeries>? ispAsn = null,
+        List<AsnSeries>? ispTargets = null,
+        List<AsnSeries>? destinations = null,
+        string? firstHopTargetId = null,
         List<CongestionEvent>? congestion = null,
         List<SpeedTestSample>? speedTests = null,
         bool smartQueuesEnabled = false,
-        double? internetDeltaMs = null)
+        double? internetDeltaMs = null,
+        bool lineIdle = false,
+        bool hopOrderKnown = false)
     {
-        var rates = TestSeries.Throughput(TestSeries.Start, Day, 50, 5)
-            .Select(r => r.Time >= LoadedDownStart && r.Time < LoadedDownEnd
-                ? r with { DownloadBps = 800_000_000 }
-                : r.Time >= LoadedUpStart && r.Time < LoadedUpEnd
-                    ? r with { UploadBps = 400_000_000 }
-                    : r)
-            .ToList();
+        // lineIdle: a near-zero, flat WAN with no load bursts (~0% average load), for
+        // exercising the load-calibrated packet-loss ceiling at the idle end.
+        var rates = lineIdle
+            ? TestSeries.Throughput(TestSeries.Start, Day, 1, 1)
+            : TestSeries.Throughput(TestSeries.Start, Day, 50, 5)
+                .Select(r => r.Time >= LoadedDownStart && r.Time < LoadedDownEnd
+                    ? r with { DownloadBps = 800_000_000 }
+                    : r.Time >= LoadedUpStart && r.Time < LoadedUpEnd
+                        ? r with { UploadBps = 400_000_000 }
+                        : r)
+                .ToList();
 
         var firstHop = TestSeries.Flat(TestSeries.Start, Day, idleRtt, 0.3, lossPct)
             .WithSegment(LoadedDownStart, LoadedDownEnd, idleRtt + loadedDownDelta, 0.3)
@@ -51,9 +60,12 @@ public class IspHealthScorerTests
             WindowStart = TestSeries.Start,
             WindowEnd = TestSeries.Start + Day,
             FirstHopSeries = firstHop,
+            FirstHopTargetId = firstHopTargetId,
             LossPoolSeries = new List<List<LatencySample>> { firstHop },
             TransitAsnSeries = transit ?? new List<AsnSeries>(),
             IspAsnSeries = ispAsn ?? new List<AsnSeries>(),
+            IspTargetSeries = ispTargets ?? new List<AsnSeries>(),
+            DestinationSeries = destinations ?? new List<AsnSeries>(),
             WanRates = rates,
             InternetMedianDeltaMs = internetDeltaMs,
             ExpectedDownloadMbps = withExpectedSpeeds ? 1000 : null,
@@ -64,7 +76,8 @@ public class IspHealthScorerTests
                 new(TestSeries.Start.AddHours(6), 980, 490)
             },
             CongestionEvents = congestion ?? new List<CongestionEvent>(),
-            SmartQueuesEnabled = smartQueuesEnabled
+            SmartQueuesEnabled = smartQueuesEnabled,
+            HopOrderKnown = hopOrderKnown
         };
     }
 
@@ -147,10 +160,25 @@ public class IspHealthScorerTests
     [Fact]
     public void Loss_past_acceptable_drops_drastically()
     {
-        var report = new IspHealthScorer(Options).Score(BuildInputs(lossPct: 0.075), Gpon);
+        // On an idle line, 0.075% is well past the strict idle ceiling and collapses.
+        var report = new IspHealthScorer(Options).Score(BuildInputs(lossPct: 0.075, lineIdle: true), Gpon);
 
         var factor = report.AccessDimension.Factors.Single(f => f.Name == "Packet Loss");
         factor.Score.Should().BeLessThan(30);
+    }
+
+    [Fact]
+    public void Packet_loss_ceiling_is_calibrated_to_average_load()
+    {
+        // The same 0.1% loss is fine on a line that ran loaded much of the window but a
+        // real problem on an idle line, where ~no loss is expected.
+        var idle = new IspHealthScorer(Options).Score(BuildInputs(lossPct: 0.1, lineIdle: true), Gpon)
+            .AccessDimension.Factors.Single(f => f.Name == "Packet Loss").Score;
+        var loaded = new IspHealthScorer(Options).Score(BuildInputs(lossPct: 0.1), Gpon)
+            .AccessDimension.Factors.Single(f => f.Name == "Packet Loss").Score;
+
+        loaded.Should().BeGreaterThan(idle!.Value,
+            "the loss ceiling tolerates more when the line was busy over the window");
     }
 
     [Fact]
@@ -473,6 +501,398 @@ public class IspHealthScorerTests
         graded.OverallScore.Should().NotBeNull();
     }
 
+    private static AsnSeries IspHop(string targetId, string name, double rttMs, double jitterMs, double lossPct = 0) => new()
+    {
+        AsnNumber = 64496,
+        AsnName = name,
+        TargetIds = { targetId },
+        Samples = TestSeries.Flat(TestSeries.Start, Day, rttMs, jitterMs, lossPct),
+        RoleTargetIds = { targetId }
+    };
+
+    [Fact]
+    public void All_isp_hops_are_graded_independently()
+    {
+        // Both hops are the same ISP ASN; each is graded on its own, and the dimension
+        // averages every hop grade (not just the first clean hop).
+        var hops = new List<AsnSeries>
+        {
+            IspHop("isp-hop-near", "Near ISP Hop", 2.0, 0.3),
+            IspHop("isp-hop-far", "Far ISP Hop", 6.0, 1.5, lossPct: 0.8)
+        };
+
+        var report = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-hop-near"), Gpon);
+
+        report.IspAsns.Should().ContainSingle("the hops collapse to one ASN card on Networks on Your Path");
+        report.IspTargets.Should().HaveCount(2);
+        var near = report.IspTargets.Single(t => t.TargetId == "isp-hop-near");
+        var far = report.IspTargets.Single(t => t.TargetId == "isp-hop-far");
+        near.OverallScore.Should().BeGreaterThan(far.OverallScore!.Value,
+            "the near hop is clean while the far hop has jitter, loss, and distance");
+        report.IspAsnDimension.Score.Should().Be(
+            (int)Math.Round((near.OverallScore!.Value + far.OverallScore!.Value) / 2.0),
+            "the dimension score averages all ISP hop grades");
+    }
+
+    [Fact]
+    public void Far_isp_hop_is_dinged_for_intra_asn_distance_not_perfect()
+    {
+        // A second POP on the same ISP, 2 ms further out and otherwise clean, should read
+        // "fine but not perfect" (~85), not a flawless 100.
+        var hops = new List<AsnSeries>
+        {
+            IspHop("isp-hop-near", "Near ISP Hop", 2.1, 0.3),
+            IspHop("isp-hop-far", "Far ISP Hop", 4.1, 0.3)
+        };
+
+        var report = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-hop-near"), Gpon);
+
+        var far = report.IspTargets.Single(t => t.TargetId == "isp-hop-far");
+        far.ReachDeltaMs.Should().BeApproximately(2.0, 0.2);
+        far.OverallScore.Should().BeInRange(80, 89);
+        report.IspTargets.Single(t => t.TargetId == "isp-hop-near").OverallScore.Should().Be(100);
+    }
+
+    [Fact]
+    public void Higher_isp_jitter_lowers_the_dimension()
+    {
+        // Without hop order, an ISP sibling can't absolve another (we can't prove which is
+        // downstream), so a jittery hop stays jittery and lowers the dimension vs a clean ISP.
+        var clean = new List<AsnSeries>
+        {
+            IspHop("a", "A", 2.1, 0.4),
+            IspHop("b", "B", 2.1, 0.4)
+        };
+        var jittery = new List<AsnSeries>
+        {
+            IspHop("a", "A", 2.1, 0.4),
+            IspHop("b", "B", 2.1, 3.0)
+        };
+
+        var cleanReport = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: clean, ispTargets: clean, firstHopTargetId: "a"), Gpon);
+        var jitteryReport = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: jittery, ispTargets: jittery, firstHopTargetId: "a"), Gpon);
+
+        jitteryReport.IspAsnDimension.Score.Should().BeLessThan(cleanReport.IspAsnDimension.Score!.Value,
+            "higher mean ISP jitter lowers the ISP grade");
+    }
+
+    [Fact]
+    public void Isp_jitter_is_capped_by_the_cleanest_transit_asn()
+    {
+        // The ISP hops look jittery (3 ms, likely ICMP deprioritization), but a transit ASN
+        // reached through the ISP is clean at 0.4 ms - proving the ISP path is steady. The
+        // ISP grade must not be punished for the false ISP-hop jitter.
+        var ispHops = new List<AsnSeries>
+        {
+            IspHop("isp-a", "ISP A", 2.1, 3.0),
+            IspHop("isp-b", "ISP B", 2.2, 3.0)
+        };
+        var cleanTransit = new List<AsnSeries>
+        {
+            TestSeries.Asn(64500, "TransitOne", TestSeries.Flat(TestSeries.Start, Day, 8, 0.4))
+        };
+
+        var withCleanTransit = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: ispHops, ispTargets: ispHops, firstHopTargetId: "isp-a", transit: cleanTransit), Gpon);
+        var noTransit = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: ispHops, ispTargets: ispHops, firstHopTargetId: "isp-a"), Gpon);
+
+        withCleanTransit.IspAsnDimension.Score.Should().BeGreaterThan(noTransit.IspAsnDimension.Score!.Value,
+            "a clean transit ASN beyond the ISP caps the ISP's jitter");
+        withCleanTransit.IspAsns.Single().JitterAssimilated.Should().BeTrue("the transit floor capped the ISP jitter");
+        noTransit.IspAsns.Single().JitterAssimilated.Should().BeFalse("no transit to assimilate from");
+    }
+
+    [Fact]
+    public void Transit_jitter_above_the_isp_mean_does_not_raise_isp_jitter()
+    {
+        // The cap is min, not max: a jittery transit ASN must never drag the ISP jitter UP.
+        // ISP hops are clean (0.3 ms); transit is jittery (2.0 ms). The ISP keeps its own
+        // mean for both score and display.
+        var ispHops = new List<AsnSeries>
+        {
+            IspHop("isp-a", "ISP A", 2.1, 0.3),
+            IspHop("isp-b", "ISP B", 2.1, 0.3)
+        };
+        var jitteryTransit = new List<AsnSeries>
+        {
+            TestSeries.Asn(64500, "TransitOne", TestSeries.Flat(TestSeries.Start, Day, 8, 2.0))
+        };
+
+        var withJitteryTransit = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: ispHops, ispTargets: ispHops, firstHopTargetId: "isp-a", transit: jitteryTransit), Gpon);
+        var noTransit = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: ispHops, ispTargets: ispHops, firstHopTargetId: "isp-a"), Gpon);
+
+        withJitteryTransit.IspAsnDimension.Score.Should().Be(noTransit.IspAsnDimension.Score,
+            "a jittery transit ASN must not raise the ISP jitter (cap is min, not max)");
+        withJitteryTransit.IspAsns.Single().P95JitterMs.Should().BeApproximately(0.3, 0.05,
+            "the displayed ISP jitter stays at the ISP mean when transit is not cleaner");
+    }
+
+    [Fact]
+    public void Congestion_on_non_first_hop_affects_isp_dimension()
+    {
+        var hops = new List<AsnSeries>
+        {
+            IspHop("isp-hop-near", "Near ISP Hop", 2.0, 0.3),
+            IspHop("isp-hop-far", "Far ISP Hop", 5.0, 0.5)
+        };
+        var congestion = new List<CongestionEvent>
+        {
+            new()
+            {
+                Start = TestSeries.Start.AddHours(18),
+                End = TestSeries.Start.AddHours(22),
+                AsnNumbers = { 64496 },
+                TargetIds = { "isp-hop-far" }
+            }
+        };
+
+        var withCongestion = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-hop-near", congestion: congestion), Gpon);
+        var withoutCongestion = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-hop-near"), Gpon);
+
+        withCongestion.IspAsns.Single().CongestionEventCount.Should().Be(1, "the event fired on a hop of this ASN");
+        withCongestion.IspAsnDimension.Score.Should().BeLessThan(
+            withoutCongestion.IspAsnDimension.Score!.Value,
+            "congestion on any ISP hop lowers the ISP dimension score");
+    }
+
+    [Fact]
+    public void With_hop_order_a_divergent_isp_hop_is_not_absolved_but_an_on_path_one_is()
+    {
+        // With ancestor data, a clean transit absolves only the ISP hop it routes through
+        // (the hop is in its ancestor set). A divergent hop the transit never traverses keeps
+        // its own jitter - closing the divergent-path absolve hole.
+        var onPath = new AsnSeries
+        {
+            AsnNumber = 64496,
+            AsnName = "ISP",
+            TargetIds = { "isp-onpath" },
+            RoleTargetIds = { "isp-onpath" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 2.1, 3.0),
+            HopIps = { "10.0.0.1" }
+        };
+        var divergent = new AsnSeries
+        {
+            AsnNumber = 64496,
+            AsnName = "ISP",
+            TargetIds = { "isp-divergent" },
+            RoleTargetIds = { "isp-divergent" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 2.1, 3.0),
+            HopIps = { "10.0.0.9" }
+        };
+        var transit = new AsnSeries
+        {
+            AsnNumber = 64500,
+            AsnName = "Transit",
+            TargetIds = { "transit" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 8, 0.4),
+            HopIps = { "20.0.0.1" },
+            AncestorIps = { "10.0.0.1" } // routes through the on-path hop only
+        };
+        var hops = new List<AsnSeries> { onPath, divergent };
+
+        var report = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-onpath",
+                transit: new List<AsnSeries> { transit }, hopOrderKnown: true), Gpon);
+
+        var onPathGrade = report.IspTargets.Single(t => t.TargetId == "isp-onpath");
+        var divergentGrade = report.IspTargets.Single(t => t.TargetId == "isp-divergent");
+        onPathGrade.OverallScore.Should().BeGreaterThan(divergentGrade.OverallScore!.Value,
+            "the transit absolves the hop it routes through, not the divergent one");
+    }
+
+    [Fact]
+    public void A_clean_destination_absolves_an_icmp_deprioritized_hop_it_routes_through()
+    {
+        // An ISP hop measures high jitter to itself (ICMP control-plane deprioritization),
+        // but a monitored destination reached THROUGH it (the hop is in the destination's
+        // ancestor set) has clean end-to-end jitter - proof the forwarding plane is smooth.
+        // The destination's jitter is a hard upper bound on the hop's true jitter, so it
+        // absolves the hop. No transit routes through the hop; only the destination does.
+        var hop = new AsnSeries
+        {
+            AsnNumber = 64496,
+            AsnName = "ISP",
+            TargetIds = { "isp-icmp-hop" },
+            RoleTargetIds = { "isp-icmp-hop" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 4.5, 7.0), // high self-jitter
+            HopIps = { "10.0.0.9" }
+        };
+        var cleanDestination = new AsnSeries
+        {
+            AsnNumber = 64512,
+            AsnName = "Destination",
+            TargetIds = { "dest-clean" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 6, 0.4), // smooth end-to-end
+            HopIps = { "30.0.0.1" },
+            AncestorIps = { "10.0.0.9" } // reached through the ICMP-deprioritized hop
+        };
+        var hops = new List<AsnSeries> { hop };
+
+        var absolved = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-icmp-hop",
+                destinations: new List<AsnSeries> { cleanDestination }, hopOrderKnown: true), Gpon)
+            .IspTargets.Single(t => t.TargetId == "isp-icmp-hop");
+
+        // Same hop, but the destination does NOT route through it (different ancestor): no absolve.
+        var divergentDest = new AsnSeries
+        {
+            AsnNumber = 64512,
+            AsnName = "Destination",
+            TargetIds = { "dest-clean" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 6, 0.4),
+            HopIps = { "30.0.0.1" },
+            AncestorIps = { "10.0.0.1" } // a different hop, not ours
+        };
+        var notAbsolved = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-icmp-hop",
+                destinations: new List<AsnSeries> { divergentDest }, hopOrderKnown: true), Gpon)
+            .IspTargets.Single(t => t.TargetId == "isp-icmp-hop");
+
+        absolved.OverallScore.Should().BeGreaterThan(notAbsolved.OverallScore!.Value,
+            "a clean destination routing through the hop proves its jitter is an ICMP artifact");
+    }
+
+    [Fact]
+    public void Isp_target_health_carries_per_target_grade()
+    {
+        var hops = new List<AsnSeries>
+        {
+            IspHop("isp-hop-near", "Near ISP Hop", 2.0, 0.3),
+            IspHop("isp-hop-far", "Far ISP Hop", 6.0, 1.5, lossPct: 0.8)
+        };
+
+        var report = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-hop-near"), Gpon);
+
+        report.IspTargets.Should().HaveCount(2);
+        var nearTarget = report.IspTargets.Single(t => t.TargetId == "isp-hop-near");
+        var farTarget = report.IspTargets.Single(t => t.TargetId == "isp-hop-far");
+        nearTarget.OverallScore.Should().NotBeNull();
+        farTarget.OverallScore.Should().NotBeNull();
+        nearTarget.OverallScore.Should().BeGreaterThan(farTarget.OverallScore!.Value);
+        nearTarget.IsGradedHop.Should().BeTrue();
+        farTarget.IsGradedHop.Should().BeFalse();
+    }
+
+    [Fact]
+    public void A_clean_farther_cluster_absolves_false_near_jitter()
+    {
+        // The near cluster shows 4 ms jitter (false - ICMP deprioritization on that hop),
+        // but the farther cluster, reached through it, is clean at 0.4 ms. The ASN must take
+        // the better of the two, so it is not punished for the false near jitter.
+        var nearCluster = TestSeries.Flat(TestSeries.Start, Day, 10, 4.0);
+        var farCluster = TestSeries.Flat(TestSeries.Start, Day, 13, 0.4);
+        var withFartherSource = new AsnSeries
+        {
+            AsnNumber = 64500,
+            AsnName = "TransitOne",
+            TargetIds = { "transit-near" },
+            Samples = nearCluster,
+            JitterSourceSamples = farCluster
+        };
+        var nearOnly = new AsnSeries
+        {
+            AsnNumber = 64500,
+            AsnName = "TransitOne",
+            TargetIds = { "transit-near" },
+            Samples = nearCluster
+        };
+
+        var graded = new IspHealthScorer(Options).Score(
+            BuildInputs(transit: new List<AsnSeries> { withFartherSource }), Gpon).TransitAsns.Single();
+        var ungraded = new IspHealthScorer(Options).Score(
+            BuildInputs(transit: new List<AsnSeries> { nearOnly }), Gpon).TransitAsns.Single();
+
+        graded.JitterScore.Should().BeGreaterThan(ungraded.JitterScore!.Value,
+            "the clean farther cluster disproves the near hop's false jitter");
+        graded.JitterScore.Should().BeGreaterThan(85);
+        graded.P95JitterMs.Should().BeApproximately(0.4, 0.1,
+            "the displayed jitter is the absolved value, not the near hop's 4 ms");
+        graded.JitterAssimilated.Should().BeTrue("the farther cluster pulled the jitter down");
+        graded.RawJitterMs.Should().BeApproximately(4.0, 0.1, "the raw near reading is kept for the tooltip");
+    }
+
+    [Fact]
+    public void Without_hop_order_a_transit_asn_is_graded_on_its_near_cluster()
+    {
+        // Backward compat: installs that have not re-run discovery have no stored hop
+        // order, so the service never sets JitterSourceSamples. The ASN must still grade
+        // cleanly - on its nearest cluster's own jitter, with no farther-cluster absolve.
+        var nearJittery = TestSeries.Flat(TestSeries.Start, Day, 10, 4.0);
+        var noHopOrder = new AsnSeries
+        {
+            AsnNumber = 64500,
+            AsnName = "TransitOne",
+            TargetIds = { "transit-near" },
+            Samples = nearJittery
+            // JitterSourceSamples intentionally empty (no hop order available)
+        };
+
+        var graded = new IspHealthScorer(Options).Score(
+            BuildInputs(transit: new List<AsnSeries> { noHopOrder }), Gpon).TransitAsns.Single();
+
+        graded.OverallScore.Should().NotBeNull();
+        graded.MedianJitterMs.Should().BeApproximately(4.0, 0.1, "jitter is the near cluster's own, never absolved without proof");
+    }
+
+    [Fact]
+    public void A_jittery_farther_cluster_never_downgrades_the_nearer()
+    {
+        // The near cluster is clean (0.4 ms); the farther cluster is jittery (4 ms). The far
+        // cluster's jitter is its own problem further along the path and must NOT drag the
+        // nearer cluster's grade down. Absolve-only: take the better, never the worse.
+        var nearClean = TestSeries.Flat(TestSeries.Start, Day, 10, 0.4);
+        var farJittery = TestSeries.Flat(TestSeries.Start, Day, 13, 4.0);
+        var withJitteryFar = new AsnSeries
+        {
+            AsnNumber = 64500,
+            AsnName = "TransitOne",
+            TargetIds = { "transit-near" },
+            Samples = nearClean,
+            JitterSourceSamples = farJittery
+        };
+        var nearOnly = new AsnSeries
+        {
+            AsnNumber = 64500,
+            AsnName = "TransitOne",
+            TargetIds = { "transit-near" },
+            Samples = nearClean
+        };
+
+        var withFar = new IspHealthScorer(Options).Score(
+            BuildInputs(transit: new List<AsnSeries> { withJitteryFar }), Gpon).TransitAsns.Single();
+        var without = new IspHealthScorer(Options).Score(
+            BuildInputs(transit: new List<AsnSeries> { nearOnly }), Gpon).TransitAsns.Single();
+
+        withFar.JitterScore.Should().Be(without.JitterScore,
+            "a jittery farther cluster must not downgrade the clean nearer cluster");
+        withFar.JitterAssimilated.Should().BeFalse("nothing was assimilated - the near cluster was already cleaner");
+    }
+
+    [Fact]
+    public void Displayed_rtt_winsorizes_a_flap_so_one_spike_does_not_distort_it()
+    {
+        // 8 ms baseline all window with a 5-minute spike to 2000 ms (a route flap). The raw
+        // mean would jump to ~15 ms; the winsorized mean (P99-capped) stays at the baseline.
+        var spikeStart = TestSeries.Start.AddHours(6);
+        var series = TestSeries.Flat(TestSeries.Start, Day, 8, 0.5)
+            .WithSegment(spikeStart, spikeStart.AddMinutes(5), 2000, 0.5);
+        var transit = new List<AsnSeries> { TestSeries.Asn(64500, "TransitOne", series) };
+
+        var graded = new IspHealthScorer(Options).Score(BuildInputs(transit: transit), Gpon).TransitAsns.Single();
+
+        graded.MeanRttMs.Should().BeApproximately(8, 1.5, "a sub-1% flap is winsorized out of the displayed RTT");
+    }
+
     [Fact]
     public void Congestion_events_lower_the_asn_grade()
     {
@@ -494,23 +914,24 @@ public class IspHealthScorerTests
     [Fact]
     public void Same_asn_as_isp_and_transit_attributes_congestion_by_role()
     {
-        // AT&T is AS7018 for both the access ISP and a transit provider. A congestion
-        // event on the transit hops must credit only the transit card, not the ISP card.
+        // A vertically integrated carrier can be the same ASN for both the access ISP and a
+        // transit provider. A congestion event on the transit hops must credit only the
+        // transit card, not the ISP card.
         var ispSeries = new AsnSeries
         {
-            AsnNumber = 7018,
-            AsnName = "AT&T",
-            TargetIds = { "att-isp-hop" },
+            AsnNumber = 64500,
+            AsnName = "IntegratedCarrier",
+            TargetIds = { "carrier-isp-hop" },
             Samples = TestSeries.Flat(TestSeries.Start, Day, 2.0, 0.3),
-            RoleTargetIds = { "att-isp-hop" }
+            RoleTargetIds = { "carrier-isp-hop" }
         };
         var transitSeries = new AsnSeries
         {
-            AsnNumber = 7018,
-            AsnName = "AT&T",
-            TargetIds = { "att-transit-hop" },
+            AsnNumber = 64500,
+            AsnName = "IntegratedCarrier",
+            TargetIds = { "carrier-transit-hop" },
             Samples = TestSeries.Flat(TestSeries.Start, Day, 2.0, 0.3),
-            RoleTargetIds = { "att-transit-hop" }
+            RoleTargetIds = { "carrier-transit-hop" }
         };
         var congestion = new List<CongestionEvent>
         {
@@ -518,8 +939,8 @@ public class IspHealthScorerTests
             {
                 Start = TestSeries.Start.AddHours(19),
                 End = TestSeries.Start.AddHours(21),
-                AsnNumbers = { 7018 },
-                TargetIds = { "att-transit-hop" }
+                AsnNumbers = { 64500 },
+                TargetIds = { "carrier-transit-hop" }
             }
         };
         var report = new IspHealthScorer(Options).Score(


### PR DESCRIPTION
Release v1.20.4. Net changes since v1.20.3.

## ISP Health (#805)

- **Every ISP-network hop is graded**, not just the nearest - packet loss and congestion are read across all ISP targets. The lowest-RTT hop still anchors access idle latency.
- **Divergence-correct jitter attribution.** A cleaner upstream (transit ASN, deeper ISP hop, or monitored destination) only absolves a hop's jitter when it provably routes through that hop, so a divergent clean path can't mask a congested hop it never traverses. Hop ancestry learned from the discovery traceroutes makes this exact.
- **Destination-based absolve.** A destination's clean end-to-end jitter absolves an ICMP-deprioritized hop whose forwarded traffic reaches it smoothly. Sub-0.05 ms differences are treated as noise and not assimilated.
- Per-ASN cards show effective (absolved) jitter with an info icon explaining when and why; RTT range across hops; transit RTT as a winsorized mean.
- Access-Layer packet-loss ceiling calibrated to average WAN load.
- A banner prompts a re-run of Upstream Discovery when no trace map is persisted; it clears automatically once discovery is committed.
- **Lower InfluxDB load** (#806). The dashboard / Live View score tile no longer drives a full recompute every few minutes just by being on screen; the heavy 48 h query now fires far less often, cutting periodic DB CPU spikes. Scoring is unchanged.
- Adds the `AncestorHopIps` column to `UpstreamDiscoveries`.

## Alerts (#803)

- New alert evaluators for gateway, cable modem, ONT, and cellular.

## Fixes

- IFB device missing error now explains the QoS-rule workaround.
- Footer version links to the GitHub release notes, with the prerelease suffix stripped from the URL.