### PR TITLE
Add alert evaluators for gateway, cable modem, ONT, and cellular

### DIFF
--- a/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
+++ b/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
@@ -217,6 +217,133 @@ public static class DefaultAlertRules
             Source = "monitoring",
             MinSeverity = AlertSeverity.Warning,
             CooldownSeconds = 1800 // 30 minutes
+        },
+
+        // --- Gateway health (enabled - always available when monitoring is active) ---
+        new AlertRule
+        {
+            Name = "Gateway: High CPU",
+            IsEnabled = true,
+            EventTypePattern = "device.gateway_high_cpu",
+            Source = "device",
+            MinSeverity = AlertSeverity.Warning,
+            ThresholdPercent = 70,
+            CooldownSeconds = 1800 // 30 minutes
+        },
+        new AlertRule
+        {
+            Name = "Gateway: High Memory",
+            IsEnabled = true,
+            EventTypePattern = "device.gateway_high_memory",
+            Source = "device",
+            MinSeverity = AlertSeverity.Warning,
+            ThresholdPercent = 95,
+            CooldownSeconds = 1800 // 30 minutes
+        },
+
+        // --- Cable modem (enabled - only fires when CM monitoring is configured) ---
+        new AlertRule
+        {
+            Name = "Cable Modem: Low SNR",
+            IsEnabled = true,
+            EventTypePattern = "cable_modem.ds_snr_low",
+            Source = "cable_modem",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 1800 // 30 minutes
+        },
+        new AlertRule
+        {
+            Name = "Cable Modem: Uncorrectable Errors",
+            IsEnabled = true,
+            EventTypePattern = "cable_modem.uncorrectable_errors",
+            Source = "cable_modem",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 1800 // 30 minutes
+        },
+        new AlertRule
+        {
+            Name = "Cable Modem: DS Power Out of Range",
+            IsEnabled = true,
+            EventTypePattern = "cable_modem.ds_power_out_of_range",
+            Source = "cable_modem",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 1800 // 30 minutes
+        },
+        new AlertRule
+        {
+            Name = "Cable Modem: US Power High",
+            IsEnabled = true,
+            EventTypePattern = "cable_modem.us_power_high",
+            Source = "cable_modem",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 1800 // 30 minutes
+        },
+        new AlertRule
+        {
+            Name = "Cable Modem: Channel Loss",
+            IsEnabled = true,
+            EventTypePattern = "cable_modem.channel_loss",
+            Source = "cable_modem",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 3600 // 1 hour
+        },
+
+        // --- External ONT (enabled - only fires when ONT monitoring is configured) ---
+        new AlertRule
+        {
+            Name = "ONT: RX Power Low",
+            IsEnabled = true,
+            EventTypePattern = "ont.rx_power_low",
+            Source = "ont",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 1800 // 30 minutes
+        },
+        new AlertRule
+        {
+            Name = "ONT: PON Link Down",
+            IsEnabled = true,
+            EventTypePattern = "ont.pon_link_down",
+            Source = "ont",
+            MinSeverity = AlertSeverity.Error,
+            CooldownSeconds = 600 // 10 minutes
+        },
+        new AlertRule
+        {
+            Name = "ONT: FEC Error Spike",
+            IsEnabled = true,
+            EventTypePattern = "ont.fec_errors",
+            Source = "ont",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 1800 // 30 minutes
+        },
+
+        // --- Cellular modem (enabled - only fires when cellular monitoring is configured) ---
+        new AlertRule
+        {
+            Name = "Cellular: Poor Signal",
+            IsEnabled = true,
+            EventTypePattern = "cellular.signal_poor",
+            Source = "cellular",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 1800 // 30 minutes
+        },
+        new AlertRule
+        {
+            Name = "Cellular: Network Downgrade",
+            IsEnabled = true,
+            EventTypePattern = "cellular.network_downgrade",
+            Source = "cellular",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 3600 // 1 hour
+        },
+        new AlertRule
+        {
+            Name = "Cellular: Roaming",
+            IsEnabled = true,
+            EventTypePattern = "cellular.roaming",
+            Source = "cellular",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 3600 // 1 hour
         }
     ];
 }

--- a/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
+++ b/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
@@ -241,11 +241,11 @@ public static class DefaultAlertRules
             CooldownSeconds = 1800 // 30 minutes
         },
 
-        // --- Cable modem (enabled - only fires when CM monitoring is configured) ---
+        // --- Cable modem (disabled until user configures a cable modem) ---
         new AlertRule
         {
             Name = "Cable Modem: Low SNR",
-            IsEnabled = true,
+            IsEnabled = false,
             EventTypePattern = "cable_modem.ds_snr_low",
             Source = "cable_modem",
             MinSeverity = AlertSeverity.Warning,
@@ -254,7 +254,7 @@ public static class DefaultAlertRules
         new AlertRule
         {
             Name = "Cable Modem: Uncorrectable Errors",
-            IsEnabled = true,
+            IsEnabled = false,
             EventTypePattern = "cable_modem.uncorrectable_errors",
             Source = "cable_modem",
             MinSeverity = AlertSeverity.Warning,
@@ -263,7 +263,7 @@ public static class DefaultAlertRules
         new AlertRule
         {
             Name = "Cable Modem: DS Power Out of Range",
-            IsEnabled = true,
+            IsEnabled = false,
             EventTypePattern = "cable_modem.ds_power_out_of_range",
             Source = "cable_modem",
             MinSeverity = AlertSeverity.Warning,
@@ -272,7 +272,7 @@ public static class DefaultAlertRules
         new AlertRule
         {
             Name = "Cable Modem: US Power High",
-            IsEnabled = true,
+            IsEnabled = false,
             EventTypePattern = "cable_modem.us_power_high",
             Source = "cable_modem",
             MinSeverity = AlertSeverity.Warning,
@@ -281,18 +281,18 @@ public static class DefaultAlertRules
         new AlertRule
         {
             Name = "Cable Modem: Channel Loss",
-            IsEnabled = true,
+            IsEnabled = false,
             EventTypePattern = "cable_modem.channel_loss",
             Source = "cable_modem",
             MinSeverity = AlertSeverity.Warning,
             CooldownSeconds = 3600 // 1 hour
         },
 
-        // --- External ONT (enabled - only fires when ONT monitoring is configured) ---
+        // --- External ONT (disabled until user configures an ONT) ---
         new AlertRule
         {
             Name = "ONT: RX Power Low",
-            IsEnabled = true,
+            IsEnabled = false,
             EventTypePattern = "ont.rx_power_low",
             Source = "ont",
             MinSeverity = AlertSeverity.Warning,
@@ -301,7 +301,7 @@ public static class DefaultAlertRules
         new AlertRule
         {
             Name = "ONT: PON Link Down",
-            IsEnabled = true,
+            IsEnabled = false,
             EventTypePattern = "ont.pon_link_down",
             Source = "ont",
             MinSeverity = AlertSeverity.Error,
@@ -310,18 +310,18 @@ public static class DefaultAlertRules
         new AlertRule
         {
             Name = "ONT: FEC Error Spike",
-            IsEnabled = true,
+            IsEnabled = false,
             EventTypePattern = "ont.fec_errors",
             Source = "ont",
             MinSeverity = AlertSeverity.Warning,
             CooldownSeconds = 1800 // 30 minutes
         },
 
-        // --- Cellular modem (enabled - only fires when cellular monitoring is configured) ---
+        // --- Cellular modem (disabled until user configures a cellular modem) ---
         new AlertRule
         {
             Name = "Cellular: Poor Signal",
-            IsEnabled = true,
+            IsEnabled = false,
             EventTypePattern = "cellular.signal_poor",
             Source = "cellular",
             MinSeverity = AlertSeverity.Warning,
@@ -330,7 +330,7 @@ public static class DefaultAlertRules
         new AlertRule
         {
             Name = "Cellular: Network Downgrade",
-            IsEnabled = true,
+            IsEnabled = false,
             EventTypePattern = "cellular.network_downgrade",
             Source = "cellular",
             MinSeverity = AlertSeverity.Warning,
@@ -339,7 +339,7 @@ public static class DefaultAlertRules
         new AlertRule
         {
             Name = "Cellular: Roaming",
-            IsEnabled = true,
+            IsEnabled = false,
             EventTypePattern = "cellular.roaming",
             Source = "cellular",
             MinSeverity = AlertSeverity.Warning,

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -619,7 +619,13 @@
             {
                 @if (_unresolvedAlerts.Any(a => a.Status == AlertStatus.Active))
                 {
-                    <h2 class="alert-group-title">Active</h2>
+                    <div class="alert-group-header">
+                        <h2 class="alert-group-title">Active</h2>
+                        <div class="alert-group-actions">
+                            <button class="btn btn-sm btn-secondary" @onclick="AcknowledgeAllActive">Acknowledge All</button>
+                            <button class="btn btn-sm btn-primary" @onclick="ResolveAllActive">Resolve All</button>
+                        </div>
+                    </div>
                     <div class="alert-list">
                         @foreach (var alert in _unresolvedAlerts.Where(a => a.Status == AlertStatus.Active))
                         {
@@ -669,7 +675,12 @@
 
                 @if (_unresolvedAlerts.Any(a => a.Status == AlertStatus.Acknowledged))
                 {
-                    <h2 class="alert-group-title">Acknowledged</h2>
+                    <div class="alert-group-header">
+                        <h2 class="alert-group-title">Acknowledged</h2>
+                        <div class="alert-group-actions">
+                            <button class="btn btn-sm btn-primary" @onclick="ResolveAllAcknowledged">Resolve All</button>
+                        </div>
+                    </div>
                     <div class="alert-list">
                         @foreach (var alert in _unresolvedAlerts.Where(a => a.Status == AlertStatus.Acknowledged))
                         {
@@ -1328,12 +1339,23 @@
         gap: 0.75rem;
         padding-bottom: 0.25rem;
     }
+    .alert-group-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 0.5rem;
+        margin-top: 0.5rem;
+    }
+    .alert-group-actions {
+        display: flex;
+        gap: 0.5rem;
+    }
     .alert-group-title {
         font-size: 0.9rem;
         font-weight: 600;
         color: var(--text-secondary);
-        margin-bottom: 0.5rem;
-        margin-top: 0.5rem;
+        margin-bottom: 0;
+        margin-top: 0;
         text-transform: uppercase;
         letter-spacing: 0.05em;
     }
@@ -2161,6 +2183,69 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error resolving alert {Id}", alert.Id);
+        }
+    }
+
+    private async Task AcknowledgeAllActive()
+    {
+        try
+        {
+            var active = _unresolvedAlerts.Where(a => a.Status == AlertStatus.Active).ToList();
+            var now = DateTime.UtcNow;
+            foreach (var alert in active)
+            {
+                alert.Status = AlertStatus.Acknowledged;
+                alert.AcknowledgedAt = now;
+                await AlertRepository.UpdateAlertAsync(alert);
+                await RecalculateIncidentStatusAsync(alert);
+            }
+            await LoadActiveAlerts();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error acknowledging all active alerts");
+        }
+    }
+
+    private async Task ResolveAllActive()
+    {
+        try
+        {
+            var active = _unresolvedAlerts.Where(a => a.Status == AlertStatus.Active).ToList();
+            var now = DateTime.UtcNow;
+            foreach (var alert in active)
+            {
+                alert.Status = AlertStatus.Resolved;
+                alert.ResolvedAt = now;
+                await AlertRepository.UpdateAlertAsync(alert);
+                await RecalculateIncidentStatusAsync(alert);
+            }
+            await LoadActiveAlerts();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error resolving all active alerts");
+        }
+    }
+
+    private async Task ResolveAllAcknowledged()
+    {
+        try
+        {
+            var acknowledged = _unresolvedAlerts.Where(a => a.Status == AlertStatus.Acknowledged).ToList();
+            var now = DateTime.UtcNow;
+            foreach (var alert in acknowledged)
+            {
+                alert.Status = AlertStatus.Resolved;
+                alert.ResolvedAt = now;
+                await AlertRepository.UpdateAlertAsync(alert);
+                await RecalculateIncidentStatusAsync(alert);
+            }
+            await LoadActiveAlerts();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error resolving all acknowledged alerts");
         }
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -1497,6 +1497,43 @@
                     </div>
                 </div>
                 <div>
+                    <h4 class="event-type-group-header">Gateway Health</h4>
+                    <div class="event-type-key-list">
+                        <div @onclick='() => SelectEventType("device.gateway_high_cpu")'><code>device.gateway_high_cpu</code> <span>Gateway CPU sustained above threshold</span></div>
+                        <div @onclick='() => SelectEventType("device.gateway_high_memory")'><code>device.gateway_high_memory</code> <span>Gateway memory above threshold</span></div>
+                        <div @onclick='() => SelectEventType("device.*")'><code>device.*</code> <span>All device events</span></div>
+                    </div>
+                </div>
+                <div>
+                    <h4 class="event-type-group-header">Cable Modem</h4>
+                    <div class="event-type-key-list">
+                        <div @onclick='() => SelectEventType("cable_modem.ds_snr_low")'><code>cable_modem.ds_snr_low</code> <span>Downstream SNR below threshold</span></div>
+                        <div @onclick='() => SelectEventType("cable_modem.uncorrectable_errors")'><code>cable_modem.uncorrectable_errors</code> <span>Uncorrectable FEC error spike</span></div>
+                        <div @onclick='() => SelectEventType("cable_modem.ds_power_out_of_range")'><code>cable_modem.ds_power_out_of_range</code> <span>DS power outside DOCSIS spec range</span></div>
+                        <div @onclick='() => SelectEventType("cable_modem.us_power_high")'><code>cable_modem.us_power_high</code> <span>US transmit power too high</span></div>
+                        <div @onclick='() => SelectEventType("cable_modem.channel_loss")'><code>cable_modem.channel_loss</code> <span>Locked channel count dropped</span></div>
+                        <div @onclick='() => SelectEventType("cable_modem.*")'><code>cable_modem.*</code> <span>All cable modem events</span></div>
+                    </div>
+                </div>
+                <div>
+                    <h4 class="event-type-group-header">External ONT</h4>
+                    <div class="event-type-key-list">
+                        <div @onclick='() => SelectEventType("ont.rx_power_low")'><code>ont.rx_power_low</code> <span>Optical RX power below threshold</span></div>
+                        <div @onclick='() => SelectEventType("ont.pon_link_down")'><code>ont.pon_link_down</code> <span>PON link lost</span></div>
+                        <div @onclick='() => SelectEventType("ont.fec_errors")'><code>ont.fec_errors</code> <span>FEC error rate spike</span></div>
+                        <div @onclick='() => SelectEventType("ont.*")'><code>ont.*</code> <span>All ONT events</span></div>
+                    </div>
+                </div>
+                <div>
+                    <h4 class="event-type-group-header">Cellular Modem</h4>
+                    <div class="event-type-key-list">
+                        <div @onclick='() => SelectEventType("cellular.signal_poor")'><code>cellular.signal_poor</code> <span>Signal quality dropped to poor</span></div>
+                        <div @onclick='() => SelectEventType("cellular.network_downgrade")'><code>cellular.network_downgrade</code> <span>Network mode downgraded (5G to LTE)</span></div>
+                        <div @onclick='() => SelectEventType("cellular.roaming")'><code>cellular.roaming</code> <span>Modem entered roaming state</span></div>
+                        <div @onclick='() => SelectEventType("cellular.*")'><code>cellular.*</code> <span>All cellular events</span></div>
+                    </div>
+                </div>
+                <div>
                     <h4 class="event-type-group-header">WAN Data Usage</h4>
                     <div class="event-type-key-list">
                         <div @onclick='() => SelectEventType("wan.data_usage_warning")'><code>wan.data_usage_warning</code> <span>Monthly data cap approaching</span></div>

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -368,6 +368,10 @@ builder.Services.AddScoped<NetworkOptimizer.Web.Services.Monitoring.MonitoringPa
 builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.AsnResolutionService>();
 builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.MonitoringAlertEvaluator>();
 builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.SfpAlertEvaluator>();
+builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.DeviceHealthAlertEvaluator>();
+builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.CableModemAlertEvaluator>();
+builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.OntAlertEvaluator>();
+builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.CellularAlertEvaluator>();
 builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.UpstreamTracerService>();
 builder.Services.AddScoped<InfluxDbProvisioningService>();
 // Probe-execution layer: the server-side LocalProbeExecutor is the default vantage. SSH

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -617,24 +617,31 @@ using (var scope = app.Services.CreateScope())
             app.Logger.LogInformation("Seeded {Count} new alert rules", missing.Count);
         }
 
-        // Auto-enable modem/ONT alert rules for users who already have configs.
-        // Rules seed as disabled, but existing users shouldn't have to manually
-        // enable them - they already opted in by configuring the monitoring target.
-        EnableRulesIfConfigsExist(db, "cable_modem", () => db.CmConfigurations.Any());
-        EnableRulesIfConfigsExist(db, "ont", () => db.OntConfigurations.Any());
-        EnableRulesIfConfigsExist(db, "cellular", () => db.ModemConfigurations.Any());
+        // Auto-enable freshly seeded modem/ONT rules for users who already have
+        // configs. Only touches rules we just inserted - never re-enables rules
+        // the user has manually disabled.
+        if (missing.Count > 0)
+        {
+            var seededPatterns = missing.Select(m => m.EventTypePattern).ToHashSet();
+            EnableFreshlySeeded(db, "cable_modem", seededPatterns, () => db.CmConfigurations.Any());
+            EnableFreshlySeeded(db, "ont", seededPatterns, () => db.OntConfigurations.Any());
+            EnableFreshlySeeded(db, "cellular", seededPatterns, () => db.ModemConfigurations.Any());
+        }
 
-        static void EnableRulesIfConfigsExist(
+        static void EnableFreshlySeeded(
             NetworkOptimizer.Storage.Models.NetworkOptimizerDbContext db,
             string source,
+            HashSet<string> seededPatterns,
             Func<bool> hasConfigs)
         {
-            var disabled = db.AlertRules
+            var freshlySeeded = db.AlertRules
                 .Where(r => r.Source == source && !r.IsEnabled)
+                .ToList()
+                .Where(r => seededPatterns.Contains(r.EventTypePattern))
                 .ToList();
-            if (disabled.Count > 0 && hasConfigs())
+            if (freshlySeeded.Count > 0 && hasConfigs())
             {
-                foreach (var rule in disabled) rule.IsEnabled = true;
+                foreach (var rule in freshlySeeded) rule.IsEnabled = true;
                 db.SaveChanges();
             }
         }

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -616,6 +616,28 @@ using (var scope = app.Services.CreateScope())
             db.SaveChanges();
             app.Logger.LogInformation("Seeded {Count} new alert rules", missing.Count);
         }
+
+        // Auto-enable modem/ONT alert rules for users who already have configs.
+        // Rules seed as disabled, but existing users shouldn't have to manually
+        // enable them - they already opted in by configuring the monitoring target.
+        EnableRulesIfConfigsExist(db, "cable_modem", () => db.CmConfigurations.Any());
+        EnableRulesIfConfigsExist(db, "ont", () => db.OntConfigurations.Any());
+        EnableRulesIfConfigsExist(db, "cellular", () => db.ModemConfigurations.Any());
+
+        static void EnableRulesIfConfigsExist(
+            NetworkOptimizer.Storage.Models.NetworkOptimizerDbContext db,
+            string source,
+            Func<bool> hasConfigs)
+        {
+            var disabled = db.AlertRules
+                .Where(r => r.Source == source && !r.IsEnabled)
+                .ToList();
+            if (disabled.Count > 0 && hasConfigs())
+            {
+                foreach (var rule in disabled) rule.IsEnabled = true;
+                db.SaveChanges();
+            }
+        }
     }
 
     // Seed default scheduled tasks if none exist

--- a/src/NetworkOptimizer.Web/Services/AlertRuleAutoEnable.cs
+++ b/src/NetworkOptimizer.Web/Services/AlertRuleAutoEnable.cs
@@ -7,7 +7,8 @@ namespace NetworkOptimizer.Web.Services;
 
 /// <summary>
 /// Enables disabled alert rules by source when a user configures their first
-/// monitoring target of that type. Called from each modem service's save path.
+/// monitoring target of that type. Skips if the user already has enabled rules
+/// for that source (meaning they've already interacted with them).
 /// </summary>
 public static class AlertRuleAutoEnable
 {
@@ -16,6 +17,11 @@ public static class AlertRuleAutoEnable
         try
         {
             var db = scope.ServiceProvider.GetRequiredService<NetworkOptimizerDbContext>();
+
+            var anyEnabled = await db.AlertRules
+                .AnyAsync(r => r.Source == source && r.IsEnabled);
+            if (anyEnabled) return;
+
             var disabled = await db.AlertRules
                 .Where(r => r.Source == source && !r.IsEnabled)
                 .ToListAsync();

--- a/src/NetworkOptimizer.Web/Services/AlertRuleAutoEnable.cs
+++ b/src/NetworkOptimizer.Web/Services/AlertRuleAutoEnable.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NetworkOptimizer.Storage.Models;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Enables disabled alert rules by source when a user configures their first
+/// monitoring target of that type. Called from each modem service's save path.
+/// </summary>
+public static class AlertRuleAutoEnable
+{
+    public static async Task EnableBySourceAsync(IServiceScope scope, string source, ILogger logger)
+    {
+        try
+        {
+            var db = scope.ServiceProvider.GetRequiredService<NetworkOptimizerDbContext>();
+            var disabled = await db.AlertRules
+                .Where(r => r.Source == source && !r.IsEnabled)
+                .ToListAsync();
+
+            if (disabled.Count == 0) return;
+
+            foreach (var rule in disabled) rule.IsEnabled = true;
+            await db.SaveChangesAsync();
+
+            logger.LogInformation("Auto-enabled {Count} {Source} alert rules", disabled.Count, source);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to auto-enable {Source} alert rules", source);
+        }
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/CableModemMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemMonitorService.cs
@@ -18,6 +18,7 @@ public sealed class CableModemMonitorService : IDisposable
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ICredentialProtectionService _credentialProtection;
     private readonly MonitoringInfluxClient _influx;
+    private readonly NetworkOptimizer.Web.Services.Monitoring.CableModemAlertEvaluator _alertEvaluator;
     private readonly ILogger<CableModemMonitorService> _logger;
     private readonly Dictionary<string, ICableModemProvider> _providers;
     private readonly Timer _pollingTimer;
@@ -34,11 +35,13 @@ public sealed class CableModemMonitorService : IDisposable
         IEnumerable<ICableModemProvider> providers,
         ICredentialProtectionService credentialProtection,
         MonitoringInfluxClient influx,
+        NetworkOptimizer.Web.Services.Monitoring.CableModemAlertEvaluator alertEvaluator,
         ILogger<CableModemMonitorService> logger)
     {
         _scopeFactory = scopeFactory;
         _credentialProtection = credentialProtection;
         _influx = influx;
+        _alertEvaluator = alertEvaluator;
         _logger = logger;
         _providers = providers.ToDictionary(p => p.ProviderKey, StringComparer.OrdinalIgnoreCase);
 
@@ -322,6 +325,12 @@ public sealed class CableModemMonitorService : IDisposable
 
             _previousTotalCorrectables[config.Id] = currentCorrectables;
             _previousTotalUncorrectables[config.Id] = currentUncorrectables;
+
+            _ = _alertEvaluator.EvaluateAsync(
+                config.Id, config.Name,
+                stats.DownstreamSnrAvgDb, stats.DownstreamPowerAvgDbmv, stats.UpstreamPowerAvgDbmv,
+                stats.LockedDsChannels, stats.LockedUsChannels,
+                deltaUncorrectables);
 
             // Fire-and-forget write to InfluxDB
             _ = Task.Run(async () =>

--- a/src/NetworkOptimizer.Web/Services/CableModemMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemMonitorService.cs
@@ -94,9 +94,14 @@ public sealed class CableModemMonitorService : IDisposable
             config.Password = _credentialProtection.Encrypt(config.Password);
         }
 
+        var isNew = config.Id == 0;
+
         using var scope = _scopeFactory.CreateScope();
         var repo = scope.ServiceProvider.GetRequiredService<ICmRepository>();
         await repo.SaveCmConfigurationAsync(config);
+
+        if (isNew)
+            await AlertRuleAutoEnable.EnableBySourceAsync(scope, "cable_modem", _logger);
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/CellularModemService.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemService.cs
@@ -22,6 +22,7 @@ public class CellularModemService : ICellularModemService
     private readonly MonitoringInfluxClient _influx;
     private readonly ICredentialProtectionService _credentialProtection;
     private readonly Dictionary<string, ICellularModemProvider> _providers;
+    private readonly NetworkOptimizer.Web.Services.Monitoring.CellularAlertEvaluator _alertEvaluator;
     private readonly Timer? _pollingTimer;
     private readonly object _lock = new();
     private CellularModemStats? _lastStats;
@@ -37,6 +38,7 @@ public class CellularModemService : ICellularModemService
         UniFiConnectionService connectionService,
         MonitoringInfluxClient influx,
         ICredentialProtectionService credentialProtection,
+        NetworkOptimizer.Web.Services.Monitoring.CellularAlertEvaluator alertEvaluator,
         IEnumerable<ICellularModemProvider> providers)
     {
         _logger = logger;
@@ -45,6 +47,7 @@ public class CellularModemService : ICellularModemService
         _connectionService = connectionService;
         _influx = influx;
         _credentialProtection = credentialProtection;
+        _alertEvaluator = alertEvaluator;
         _providers = providers.ToDictionary(p => p.ProviderKey, StringComparer.OrdinalIgnoreCase);
 
         if (!_providers.ContainsKey(DefaultProviderKey))
@@ -228,6 +231,10 @@ public class CellularModemService : ICellularModemService
 
                 // Write to InfluxDB for time-series charting
                 WriteCellularToInflux(modem, stats);
+
+                _ = _alertEvaluator.EvaluateAsync(
+                    modem.Id, modem.Name,
+                    stats.SignalQuality, stats.NetworkMode, stats.IsRoaming);
 
                 return (true, $"Modem polled successfully. RSRP: {stats.Lte?.Rsrp ?? stats.Nr5g?.Rsrp}dBm");
             }

--- a/src/NetworkOptimizer.Web/Services/CellularModemService.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemService.cs
@@ -273,9 +273,15 @@ public class CellularModemService : ICellularModemService
             config.Password = _credentialProtection.Encrypt(config.Password);
         }
 
+        var isNew = config.Id == 0;
+
         using var scope = _serviceProvider.CreateScope();
         var repository = scope.ServiceProvider.GetRequiredService<IModemRepository>();
         await repository.SaveModemConfigurationAsync(config);
+
+        if (isNew)
+            await AlertRuleAutoEnable.EnableBySourceAsync(scope, "cellular", _logger);
+
         return config;
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/CableModemAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/CableModemAlertEvaluator.cs
@@ -1,0 +1,237 @@
+using System.Collections.Concurrent;
+using NetworkOptimizer.Alerts.Events;
+using NetworkOptimizer.Core.Enums;
+
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Evaluates cable modem DOCSIS metrics against thresholds and publishes alert
+/// events on state transitions. Covers downstream SNR, downstream/upstream power
+/// levels, uncorrectable FEC errors, and locked channel count drops. Thresholds
+/// are based on DOCSIS 3.0/3.1 operating specifications.
+/// </summary>
+public class CableModemAlertEvaluator
+{
+    private const double DsSnrLowDb = 33.0;
+    private const double DsSnrClearDb = 36.0;
+
+    private const double DsPowerLowDbmv = -7.0;
+    private const double DsPowerHighDbmv = 7.0;
+    private const double DsPowerClearLowDbmv = -5.0;
+    private const double DsPowerClearHighDbmv = 5.0;
+
+    private const double UsPowerHighDbmv = 51.0;
+    private const double UsPowerClearDbmv = 48.0;
+
+    private const long UncorrectablesDeltaThreshold = 100;
+
+    private const int ChannelDropThreshold = 4;
+
+    private readonly IAlertEventBus _eventBus;
+    private readonly ILogger<CableModemAlertEvaluator> _logger;
+    private readonly ConcurrentDictionary<string, CmAlertState> _states = new();
+
+    public CableModemAlertEvaluator(IAlertEventBus eventBus, ILogger<CableModemAlertEvaluator> logger)
+    {
+        _eventBus = eventBus;
+        _logger = logger;
+    }
+
+    public async ValueTask EvaluateAsync(
+        int cmId, string cmName,
+        double? dsSnrAvgDb, double? dsPowerAvgDbmv, double? usPowerAvgDbmv,
+        int lockedDsChannels, int lockedUsChannels,
+        long uncorrectablesDelta,
+        CancellationToken ct = default)
+    {
+        var key = cmId.ToString();
+        var state = _states.GetOrAdd(key, _ => new CmAlertState());
+
+        if (dsSnrAvgDb.HasValue)
+            await EvaluateDsSnr(state, cmId, cmName, dsSnrAvgDb.Value, ct);
+
+        if (dsPowerAvgDbmv.HasValue)
+            await EvaluateDsPower(state, cmId, cmName, dsPowerAvgDbmv.Value, ct);
+
+        if (usPowerAvgDbmv.HasValue)
+            await EvaluateUsPower(state, cmId, cmName, usPowerAvgDbmv.Value, ct);
+
+        if (uncorrectablesDelta > UncorrectablesDeltaThreshold)
+            await PublishUncorrectables(cmId, cmName, uncorrectablesDelta, ct);
+
+        if (lockedDsChannels > 0)
+            await EvaluateChannelLoss(state, cmId, cmName, lockedDsChannels, ct);
+    }
+
+    private async ValueTask EvaluateDsSnr(CmAlertState state, int cmId, string cmName, double snr, CancellationToken ct)
+    {
+        if (!state.DsSnrBreached && snr < DsSnrLowDb)
+        {
+            state.DsSnrBreached = true;
+            _logger.LogDebug("Cable modem DS SNR low: {CmName} snr={Snr:0.#} dB", cmName, snr);
+
+            await _eventBus.PublishAsync(new AlertEvent
+            {
+                EventType = "cable_modem.ds_snr_low",
+                Source = "cable_modem",
+                Severity = AlertSeverity.Warning,
+                Title = $"{cmName} downstream SNR low",
+                Message = $"Cable modem {cmName} downstream SNR averaged {snr:0.#} dB, below the {DsSnrLowDb} dB threshold. Below 30 dB is typically service-affecting.",
+                MetricValue = snr,
+                ThresholdValue = DsSnrLowDb,
+                SourceUrl = "/monitoring?tab=cm",
+                Tags = ["cable_modem", "snr"],
+                Context = new Dictionary<string, string>
+                {
+                    ["cm_id"] = cmId.ToString(),
+                    ["metric"] = "ds_snr_avg_db"
+                }
+            }, ct);
+        }
+        else if (state.DsSnrBreached && snr >= DsSnrClearDb)
+        {
+            state.DsSnrBreached = false;
+        }
+    }
+
+    private async ValueTask EvaluateDsPower(CmAlertState state, int cmId, string cmName, double power, CancellationToken ct)
+    {
+        var outOfRange = power < DsPowerLowDbmv || power > DsPowerHighDbmv;
+        var inClearRange = power >= DsPowerClearLowDbmv && power <= DsPowerClearHighDbmv;
+
+        if (!state.DsPowerBreached && outOfRange)
+        {
+            state.DsPowerBreached = true;
+            var direction = power < DsPowerLowDbmv ? "low" : "high";
+            _logger.LogDebug("Cable modem DS power out of range: {CmName} power={Power:0.#} dBmV ({Direction})", cmName, power, direction);
+
+            await _eventBus.PublishAsync(new AlertEvent
+            {
+                EventType = "cable_modem.ds_power_out_of_range",
+                Source = "cable_modem",
+                Severity = AlertSeverity.Warning,
+                Title = $"{cmName} downstream power {direction}",
+                Message = $"Cable modem {cmName} downstream power averaged {power:0.#} dBmV, outside the {DsPowerLowDbmv} to {DsPowerHighDbmv} dBmV DOCSIS operating range.",
+                MetricValue = power,
+                ThresholdValue = power < DsPowerLowDbmv ? DsPowerLowDbmv : DsPowerHighDbmv,
+                SourceUrl = "/monitoring?tab=cm",
+                Tags = ["cable_modem", "power"],
+                Context = new Dictionary<string, string>
+                {
+                    ["cm_id"] = cmId.ToString(),
+                    ["metric"] = "ds_power_avg_dbmv",
+                    ["direction"] = direction
+                }
+            }, ct);
+        }
+        else if (state.DsPowerBreached && inClearRange)
+        {
+            state.DsPowerBreached = false;
+        }
+    }
+
+    private async ValueTask EvaluateUsPower(CmAlertState state, int cmId, string cmName, double power, CancellationToken ct)
+    {
+        if (!state.UsPowerBreached && power > UsPowerHighDbmv)
+        {
+            state.UsPowerBreached = true;
+            _logger.LogDebug("Cable modem US power high: {CmName} power={Power:0.#} dBmV", cmName, power);
+
+            await _eventBus.PublishAsync(new AlertEvent
+            {
+                EventType = "cable_modem.us_power_high",
+                Source = "cable_modem",
+                Severity = AlertSeverity.Warning,
+                Title = $"{cmName} upstream power high",
+                Message = $"Cable modem {cmName} upstream power averaged {power:0.#} dBmV, above {UsPowerHighDbmv} dBmV. The modem is compensating for poor return path signal.",
+                MetricValue = power,
+                ThresholdValue = UsPowerHighDbmv,
+                SourceUrl = "/monitoring?tab=cm",
+                Tags = ["cable_modem", "power"],
+                Context = new Dictionary<string, string>
+                {
+                    ["cm_id"] = cmId.ToString(),
+                    ["metric"] = "us_power_avg_dbmv"
+                }
+            }, ct);
+        }
+        else if (state.UsPowerBreached && power <= UsPowerClearDbmv)
+        {
+            state.UsPowerBreached = false;
+        }
+    }
+
+    private async ValueTask PublishUncorrectables(int cmId, string cmName, long delta, CancellationToken ct)
+    {
+        _logger.LogDebug("Cable modem uncorrectable errors: {CmName} delta={Delta}", cmName, delta);
+
+        await _eventBus.PublishAsync(new AlertEvent
+        {
+            EventType = "cable_modem.uncorrectable_errors",
+            Source = "cable_modem",
+            Severity = AlertSeverity.Warning,
+            Title = $"{cmName} uncorrectable errors",
+            Message = $"Cable modem {cmName} had {delta:N0} uncorrectable FEC errors since the last poll, exceeding the {UncorrectablesDeltaThreshold} threshold.",
+            MetricValue = delta,
+            ThresholdValue = UncorrectablesDeltaThreshold,
+            SourceUrl = "/monitoring?tab=cm",
+            Tags = ["cable_modem", "uncorrectables"],
+            Context = new Dictionary<string, string>
+            {
+                ["cm_id"] = cmId.ToString(),
+                ["metric"] = "uncorrectables_delta"
+            }
+        }, ct);
+    }
+
+    private async ValueTask EvaluateChannelLoss(CmAlertState state, int cmId, string cmName, int lockedDsChannels, CancellationToken ct)
+    {
+        if (lockedDsChannels > state.MaxLockedDsChannels)
+        {
+            state.MaxLockedDsChannels = lockedDsChannels;
+            state.ChannelLossBreached = false;
+            return;
+        }
+
+        var drop = state.MaxLockedDsChannels - lockedDsChannels;
+
+        if (!state.ChannelLossBreached && drop >= ChannelDropThreshold)
+        {
+            state.ChannelLossBreached = true;
+            _logger.LogDebug("Cable modem channel loss: {CmName} locked={Current} max={Max} drop={Drop}", cmName, lockedDsChannels, state.MaxLockedDsChannels, drop);
+
+            await _eventBus.PublishAsync(new AlertEvent
+            {
+                EventType = "cable_modem.channel_loss",
+                Source = "cable_modem",
+                Severity = AlertSeverity.Warning,
+                Title = $"{cmName} downstream channels lost",
+                Message = $"Cable modem {cmName} dropped from {state.MaxLockedDsChannels} to {lockedDsChannels} locked downstream channels ({drop} lost).",
+                MetricValue = lockedDsChannels,
+                ThresholdValue = state.MaxLockedDsChannels,
+                SourceUrl = "/monitoring?tab=cm",
+                Tags = ["cable_modem", "channels"],
+                Context = new Dictionary<string, string>
+                {
+                    ["cm_id"] = cmId.ToString(),
+                    ["metric"] = "locked_ds_channels",
+                    ["max_channels"] = state.MaxLockedDsChannels.ToString(),
+                    ["channels_lost"] = drop.ToString()
+                }
+            }, ct);
+        }
+        else if (state.ChannelLossBreached && drop < ChannelDropThreshold)
+        {
+            state.ChannelLossBreached = false;
+        }
+    }
+
+    private class CmAlertState
+    {
+        public bool DsSnrBreached;
+        public bool DsPowerBreached;
+        public bool UsPowerBreached;
+        public bool ChannelLossBreached;
+        public int MaxLockedDsChannels;
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/CableModemAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/CableModemAlertEvaluator.cs
@@ -23,7 +23,7 @@ public class CableModemAlertEvaluator
     private const double UsPowerHighDbmv = 51.0;
     private const double UsPowerClearDbmv = 48.0;
 
-    private const long UncorrectablesDeltaThreshold = 100;
+    private const long UncorrectablesDeltaThreshold = 500;
 
     private const int ChannelDropThreshold = 4;
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/CellularAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/CellularAlertEvaluator.cs
@@ -1,0 +1,189 @@
+using System.Collections.Concurrent;
+using NetworkOptimizer.Alerts.Events;
+using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Monitoring.Models;
+
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Evaluates cellular modem readings and publishes alert events on state
+/// transitions. Tracks three conditions per modem:
+/// - Signal quality dropping below the poor threshold (composite score)
+/// - Network mode downgrade (e.g. 5G SA → 5G NSA → LTE)
+/// - Unexpected roaming state
+/// All checks are state-transition based with hysteresis to avoid flapping.
+/// </summary>
+public class CellularAlertEvaluator
+{
+    private const int SignalPoorThreshold = 25;
+    private const int SignalClearThreshold = 35;
+
+    private readonly IAlertEventBus _eventBus;
+    private readonly ILogger<CellularAlertEvaluator> _logger;
+    private readonly ConcurrentDictionary<int, CellularAlertState> _states = new();
+
+    public CellularAlertEvaluator(IAlertEventBus eventBus, ILogger<CellularAlertEvaluator> logger)
+    {
+        _eventBus = eventBus;
+        _logger = logger;
+    }
+
+    public async ValueTask EvaluateAsync(
+        int modemId, string modemName,
+        int signalQuality, CellularNetworkMode networkMode, bool isRoaming,
+        CancellationToken ct = default)
+    {
+        var state = _states.GetOrAdd(modemId, _ => new CellularAlertState());
+
+        await EvaluateSignalQuality(state, modemId, modemName, signalQuality, ct);
+        await EvaluateNetworkMode(state, modemId, modemName, networkMode, ct);
+        await EvaluateRoaming(state, modemId, modemName, isRoaming, ct);
+    }
+
+    private async ValueTask EvaluateSignalQuality(
+        CellularAlertState state, int modemId, string modemName,
+        int signalQuality, CancellationToken ct)
+    {
+        if (!state.SignalBreached && signalQuality < SignalPoorThreshold && signalQuality > 0)
+        {
+            state.SignalBreached = true;
+            _logger.LogDebug("Cellular signal poor: modem {ModemId} quality={Quality}", modemId, signalQuality);
+
+            await _eventBus.PublishAsync(new AlertEvent
+            {
+                EventType = "cellular.signal_poor",
+                Source = "cellular",
+                Severity = AlertSeverity.Warning,
+                Title = $"{modemName} signal quality poor",
+                Message = $"Cellular modem {modemName} signal quality dropped to {signalQuality}/100, below the {SignalPoorThreshold} threshold.",
+                DeviceName = modemName,
+                MetricValue = signalQuality,
+                ThresholdValue = SignalPoorThreshold,
+                SourceUrl = "/monitoring?tab=cellular",
+                Tags = ["cellular", "signal"],
+                Context = new Dictionary<string, string>
+                {
+                    ["modem_id"] = modemId.ToString(),
+                    ["metric"] = "signal_quality"
+                }
+            }, ct);
+        }
+        else if (state.SignalBreached && signalQuality >= SignalClearThreshold)
+        {
+            state.SignalBreached = false;
+        }
+    }
+
+    private async ValueTask EvaluateNetworkMode(
+        CellularAlertState state, int modemId, string modemName,
+        CellularNetworkMode networkMode, CancellationToken ct)
+    {
+        var currentRank = ModeRank(networkMode);
+        var previousRank = state.LastKnownModeRank;
+
+        state.LastKnownModeRank = currentRank;
+
+        if (!previousRank.HasValue || networkMode == CellularNetworkMode.Unknown)
+            return;
+
+        if (currentRank < previousRank.Value && previousRank.Value > 0)
+        {
+            if (!state.NetworkDowngraded)
+            {
+                state.NetworkDowngraded = true;
+                var previousMode = RankToLabel(previousRank.Value);
+                var currentMode = ModeLabel(networkMode);
+
+                _logger.LogDebug("Cellular network downgrade: modem {ModemId} {From} -> {To}",
+                    modemId, previousMode, currentMode);
+
+                await _eventBus.PublishAsync(new AlertEvent
+                {
+                    EventType = "cellular.network_downgrade",
+                    Source = "cellular",
+                    Severity = AlertSeverity.Warning,
+                    Title = $"{modemName} network downgraded",
+                    Message = $"Cellular modem {modemName} dropped from {previousMode} to {currentMode}.",
+                    DeviceName = modemName,
+                    SourceUrl = "/monitoring?tab=cellular",
+                    Tags = ["cellular", "network_mode"],
+                    Context = new Dictionary<string, string>
+                    {
+                        ["modem_id"] = modemId.ToString(),
+                        ["previous_mode"] = previousMode,
+                        ["current_mode"] = currentMode
+                    }
+                }, ct);
+            }
+        }
+        else if (currentRank >= previousRank.Value)
+        {
+            state.NetworkDowngraded = false;
+        }
+    }
+
+    private async ValueTask EvaluateRoaming(
+        CellularAlertState state, int modemId, string modemName,
+        bool isRoaming, CancellationToken ct)
+    {
+        var wasRoaming = state.IsRoaming;
+        state.IsRoaming = isRoaming;
+
+        if (isRoaming && !wasRoaming && state.HasObservedRoaming)
+        {
+            _logger.LogDebug("Cellular roaming detected: modem {ModemId}", modemId);
+
+            await _eventBus.PublishAsync(new AlertEvent
+            {
+                EventType = "cellular.roaming",
+                Source = "cellular",
+                Severity = AlertSeverity.Warning,
+                Title = $"{modemName} is roaming",
+                Message = $"Cellular modem {modemName} entered roaming state. This may indicate loss of primary carrier coverage or incur additional charges.",
+                DeviceName = modemName,
+                SourceUrl = "/monitoring?tab=cellular",
+                Tags = ["cellular", "roaming"],
+                Context = new Dictionary<string, string>
+                {
+                    ["modem_id"] = modemId.ToString()
+                }
+            }, ct);
+        }
+
+        state.HasObservedRoaming = true;
+    }
+
+    private static int ModeRank(CellularNetworkMode mode) => mode switch
+    {
+        CellularNetworkMode.Unknown => 0,
+        CellularNetworkMode.Lte => 1,
+        CellularNetworkMode.Nr5gNsa => 2,
+        CellularNetworkMode.Nr5gSa => 3,
+        _ => 0
+    };
+
+    private static string ModeLabel(CellularNetworkMode mode) => mode switch
+    {
+        CellularNetworkMode.Lte => "LTE",
+        CellularNetworkMode.Nr5gNsa => "5G NSA",
+        CellularNetworkMode.Nr5gSa => "5G SA",
+        _ => "Unknown"
+    };
+
+    private static string RankToLabel(int rank) => rank switch
+    {
+        1 => "LTE",
+        2 => "5G NSA",
+        3 => "5G SA",
+        _ => "Unknown"
+    };
+
+    private class CellularAlertState
+    {
+        public bool SignalBreached;
+        public int? LastKnownModeRank;
+        public bool NetworkDowngraded;
+        public bool IsRoaming;
+        public bool HasObservedRoaming;
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/DeviceHealthAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/DeviceHealthAlertEvaluator.cs
@@ -1,0 +1,126 @@
+using System.Collections.Concurrent;
+using NetworkOptimizer.Alerts.Events;
+using NetworkOptimizer.Core.Enums;
+
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Evaluates gateway CPU and memory readings against thresholds and publishes
+/// alert events on state transitions. CPU uses a sliding window of 5 samples
+/// (~2.5-5 minutes at typical poll intervals) to avoid alerting on transient
+/// spikes. Memory is evaluated per-sample since sustained high memory is
+/// immediately actionable.
+/// </summary>
+public class DeviceHealthAlertEvaluator
+{
+    private const int CpuWindowSize = 5;
+    private const double CpuHighThresholdPercent = 70.0;
+    private const double CpuClearThresholdPercent = 55.0;
+    private const double MemoryHighThresholdPercent = 95.0;
+    private const double MemoryClearThresholdPercent = 85.0;
+
+    private readonly IAlertEventBus _eventBus;
+    private readonly ILogger<DeviceHealthAlertEvaluator> _logger;
+    private readonly ConcurrentDictionary<string, DeviceHealthState> _states = new();
+
+    public DeviceHealthAlertEvaluator(IAlertEventBus eventBus, ILogger<DeviceHealthAlertEvaluator> logger)
+    {
+        _eventBus = eventBus;
+        _logger = logger;
+    }
+
+    public async ValueTask EvaluateAsync(
+        string deviceMac, string? deviceName, string deviceType,
+        double? cpuPercent, double? memoryUsedPercent,
+        CancellationToken ct = default)
+    {
+        if (!string.Equals(deviceType, "gateway", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        var state = _states.GetOrAdd(deviceMac, _ => new DeviceHealthState());
+        var label = deviceName ?? deviceMac;
+
+        if (cpuPercent.HasValue)
+        {
+            state.CpuWindow.Enqueue(cpuPercent.Value);
+            while (state.CpuWindow.Count > CpuWindowSize) state.CpuWindow.Dequeue();
+
+            if (state.CpuWindow.Count >= CpuWindowSize)
+            {
+                var avg = state.CpuWindow.Average();
+
+                if (!state.CpuBreached && avg >= CpuHighThresholdPercent)
+                {
+                    state.CpuBreached = true;
+                    _logger.LogDebug("Gateway CPU threshold breached: {DeviceMac} avg={Avg:0.#}%", deviceMac, avg);
+
+                    await _eventBus.PublishAsync(new AlertEvent
+                    {
+                        EventType = "device.gateway_high_cpu",
+                        Source = "device",
+                        Severity = AlertSeverity.Warning,
+                        Title = $"{label} CPU usage high",
+                        Message = $"Gateway {label} CPU averaged {avg:0.#}% over the last {CpuWindowSize} samples, exceeding the {CpuHighThresholdPercent}% threshold.",
+                        DeviceId = deviceMac,
+                        DeviceName = deviceName,
+                        MetricValue = avg,
+                        ThresholdValue = CpuHighThresholdPercent,
+                        SourceUrl = "/monitoring?tab=health",
+                        Tags = ["device", "gateway", "cpu"],
+                        Context = new Dictionary<string, string>
+                        {
+                            ["device_mac"] = deviceMac,
+                            ["device_type"] = deviceType,
+                            ["metric"] = "cpu_percent"
+                        }
+                    }, ct);
+                }
+                else if (state.CpuBreached && avg <= CpuClearThresholdPercent)
+                {
+                    state.CpuBreached = false;
+                }
+            }
+        }
+
+        if (memoryUsedPercent.HasValue)
+        {
+            if (!state.MemoryBreached && memoryUsedPercent.Value >= MemoryHighThresholdPercent)
+            {
+                state.MemoryBreached = true;
+                _logger.LogDebug("Gateway memory threshold breached: {DeviceMac} mem={Mem:0.#}%", deviceMac, memoryUsedPercent.Value);
+
+                await _eventBus.PublishAsync(new AlertEvent
+                {
+                    EventType = "device.gateway_high_memory",
+                    Source = "device",
+                    Severity = AlertSeverity.Warning,
+                    Title = $"{label} memory usage high",
+                    Message = $"Gateway {label} memory usage at {memoryUsedPercent.Value:0.#}%, exceeding the {MemoryHighThresholdPercent}% threshold.",
+                    DeviceId = deviceMac,
+                    DeviceName = deviceName,
+                    MetricValue = memoryUsedPercent.Value,
+                    ThresholdValue = MemoryHighThresholdPercent,
+                    SourceUrl = "/monitoring?tab=health",
+                    Tags = ["device", "gateway", "memory"],
+                    Context = new Dictionary<string, string>
+                    {
+                        ["device_mac"] = deviceMac,
+                        ["device_type"] = deviceType,
+                        ["metric"] = "memory_used_percent"
+                    }
+                }, ct);
+            }
+            else if (state.MemoryBreached && memoryUsedPercent.Value <= MemoryClearThresholdPercent)
+            {
+                state.MemoryBreached = false;
+            }
+        }
+    }
+
+    private class DeviceHealthState
+    {
+        public Queue<double> CpuWindow { get; } = new();
+        public bool CpuBreached;
+        public bool MemoryBreached;
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/OntAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/OntAlertEvaluator.cs
@@ -1,0 +1,162 @@
+using System.Collections.Concurrent;
+using NetworkOptimizer.Alerts.Events;
+using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Monitoring.Models;
+
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Evaluates external ONT (Optical Network Terminal) readings and publishes alert
+/// events on state transitions. Covers RX power degradation, PON link loss, and
+/// FEC error spikes - the same failure modes as in-gateway SFP DDM but sourced
+/// from the ISP-side device.
+/// </summary>
+public class OntAlertEvaluator
+{
+    private const double RxPowerLowDbm = PonThresholds.PonRxPowerLowDbm;
+    private const double RxPowerHysteresisDbm = PonThresholds.PowerHysteresisDbm;
+    private const long FecErrorDeltaThreshold = 1000;
+
+    private readonly IAlertEventBus _eventBus;
+    private readonly ILogger<OntAlertEvaluator> _logger;
+    private readonly ConcurrentDictionary<int, OntAlertState> _states = new();
+
+    public OntAlertEvaluator(IAlertEventBus eventBus, ILogger<OntAlertEvaluator> logger)
+    {
+        _eventBus = eventBus;
+        _logger = logger;
+    }
+
+    public async ValueTask EvaluateAsync(
+        int ontId, string ontName,
+        double? rxPowerDbm,
+        PonLinkState ponLinkStatus,
+        long? fecErrors,
+        CancellationToken ct = default)
+    {
+        var state = _states.GetOrAdd(ontId, _ => new OntAlertState());
+
+        if (rxPowerDbm.HasValue)
+        {
+            await CheckRxPower(state, ontId, ontName, rxPowerDbm.Value, ct);
+        }
+
+        await CheckPonLink(state, ontId, ontName, ponLinkStatus, ct);
+
+        if (fecErrors.HasValue)
+        {
+            await CheckFecErrors(state, ontId, ontName, fecErrors.Value, ct);
+        }
+    }
+
+    private async ValueTask CheckRxPower(
+        OntAlertState state, int ontId, string ontName, double rxPower, CancellationToken ct)
+    {
+        if (rxPower < RxPowerLowDbm && !state.RxPowerBreached)
+        {
+            state.RxPowerBreached = true;
+            _logger.LogDebug("ONT {Name} RX power {Power} dBm below threshold {Threshold} dBm",
+                ontName, rxPower, RxPowerLowDbm);
+
+            await _eventBus.PublishAsync(new AlertEvent
+            {
+                EventType = "ont.rx_power_low",
+                Source = "ont",
+                Severity = AlertSeverity.Warning,
+                Title = $"{ontName} RX power low",
+                Message = $"ONT {ontName} optical RX power {rxPower:0.##} dBm is below {RxPowerLowDbm} dBm threshold.",
+                DeviceName = ontName,
+                MetricValue = rxPower,
+                ThresholdValue = RxPowerLowDbm,
+                SourceUrl = "/monitoring?tab=ont",
+                Tags = ["ont", "rx_power"],
+                Context = new Dictionary<string, string>
+                {
+                    ["ont_id"] = ontId.ToString(),
+                    ["metric"] = "rx_power"
+                }
+            }, ct);
+        }
+        else if (rxPower >= RxPowerLowDbm + RxPowerHysteresisDbm && state.RxPowerBreached)
+        {
+            state.RxPowerBreached = false;
+        }
+    }
+
+    private async ValueTask CheckPonLink(
+        OntAlertState state, int ontId, string ontName, PonLinkState ponLinkStatus, CancellationToken ct)
+    {
+        var isDown = ponLinkStatus != PonLinkState.Operation && ponLinkStatus != PonLinkState.Unknown;
+
+        if (isDown && !state.PonLinkDown)
+        {
+            state.PonLinkDown = true;
+            _logger.LogDebug("ONT {Name} PON link down (state: {State})", ontName, ponLinkStatus);
+
+            await _eventBus.PublishAsync(new AlertEvent
+            {
+                EventType = "ont.pon_link_down",
+                Source = "ont",
+                Severity = AlertSeverity.Error,
+                Title = $"{ontName} PON link down",
+                Message = $"ONT {ontName} PON link is down (state: {ponLinkStatus}).",
+                DeviceName = ontName,
+                SourceUrl = "/monitoring?tab=ont",
+                Tags = ["ont", "pon_link"],
+                Context = new Dictionary<string, string>
+                {
+                    ["ont_id"] = ontId.ToString(),
+                    ["pon_link_state"] = ponLinkStatus.ToString()
+                }
+            }, ct);
+        }
+        else if (!isDown && state.PonLinkDown)
+        {
+            state.PonLinkDown = false;
+        }
+    }
+
+    private async ValueTask CheckFecErrors(
+        OntAlertState state, int ontId, string ontName, long fecErrors, CancellationToken ct)
+    {
+        if (state.PreviousFecErrors.HasValue)
+        {
+            var delta = fecErrors - state.PreviousFecErrors.Value;
+            if (delta < 0) delta = 0; // counter reset
+
+            if (delta > FecErrorDeltaThreshold)
+            {
+                _logger.LogDebug("ONT {Name} FEC error spike: {Delta} errors since last poll", ontName, delta);
+
+                await _eventBus.PublishAsync(new AlertEvent
+                {
+                    EventType = "ont.fec_errors",
+                    Source = "ont",
+                    Severity = AlertSeverity.Warning,
+                    Title = $"{ontName} FEC error spike",
+                    Message = $"ONT {ontName} had {delta:N0} FEC errors since last poll (threshold: {FecErrorDeltaThreshold:N0}).",
+                    DeviceName = ontName,
+                    MetricValue = delta,
+                    ThresholdValue = FecErrorDeltaThreshold,
+                    SourceUrl = "/monitoring?tab=ont",
+                    Tags = ["ont", "fec"],
+                    Context = new Dictionary<string, string>
+                    {
+                        ["ont_id"] = ontId.ToString(),
+                        ["metric"] = "fec_errors",
+                        ["fec_delta"] = delta.ToString()
+                    }
+                }, ct);
+            }
+        }
+
+        state.PreviousFecErrors = fecErrors;
+    }
+
+    private class OntAlertState
+    {
+        public bool RxPowerBreached;
+        public bool PonLinkDown;
+        public long? PreviousFecErrors;
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/PonThresholds.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/PonThresholds.cs
@@ -1,0 +1,24 @@
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Single source-of-truth for PON and SFP optical thresholds.
+/// </summary>
+public static class PonThresholds
+{
+    // --- PON thresholds (SFP and external ONT share these) ---
+    public const double PonRxPowerLowDbm = -25.0;
+    public const double PonTxPowerHighDbm = 4.0;
+    public const double PonTempHighC = 75.0;
+
+    // --- Hysteresis ---
+    public const double PowerHysteresisDbm = 2.0;
+    public const double TempHysteresisC = 5.0;
+
+    // --- Active Ethernet SFP thresholds ---
+    public const double AeRxPowerLowDbm = -14.0;
+    public const double AeTxPowerHighDbm = 1.0;
+    public const double AeTempHighC = 80.0;
+
+    // --- Generic SFP thresholds ---
+    public const double SfpTempHighGenericC = 87.0;
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/SfpAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/SfpAlertEvaluator.cs
@@ -12,18 +12,18 @@ namespace NetworkOptimizer.Web.Services.Monitoring;
 /// </summary>
 public class SfpAlertEvaluator
 {
-    private const double PonRxPowerLowDbm = -25.0;
-    private const double PonTxPowerHighDbm = 4.0;
-    private const double PonTempHighC = 75.0;
+    private const double PonRxPowerLowDbm = PonThresholds.PonRxPowerLowDbm;
+    private const double PonTxPowerHighDbm = PonThresholds.PonTxPowerHighDbm;
+    private const double PonTempHighC = PonThresholds.PonTempHighC;
 
-    private const double AeRxPowerLowDbm = -14.0;
-    private const double AeTxPowerHighDbm = 1.0;
-    private const double AeTempHighC = 80.0;
+    private const double AeRxPowerLowDbm = PonThresholds.AeRxPowerLowDbm;
+    private const double AeTxPowerHighDbm = PonThresholds.AeTxPowerHighDbm;
+    private const double AeTempHighC = PonThresholds.AeTempHighC;
 
-    private const double SfpTempHighC = 87.0;
+    private const double SfpTempHighC = PonThresholds.SfpTempHighGenericC;
 
-    private const double TempHysteresisC = 5.0;
-    private const double PowerHysteresisDbm = 2.0;
+    private const double TempHysteresisC = PonThresholds.TempHysteresisC;
+    private const double PowerHysteresisDbm = PonThresholds.PowerHysteresisDbm;
 
     private readonly IAlertEventBus _eventBus;
     private readonly ILogger<SfpAlertEvaluator> _logger;

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -39,6 +39,7 @@ public class MonitoringCollectionAgent : BackgroundService
     private readonly LocalProbeExecutor _localProbe;
     private readonly NetworkOptimizer.Web.Services.Monitoring.MonitoringAlertEvaluator _alertEvaluator;
     private readonly NetworkOptimizer.Web.Services.Monitoring.SfpAlertEvaluator _sfpAlertEvaluator;
+    private readonly NetworkOptimizer.Web.Services.Monitoring.DeviceHealthAlertEvaluator _deviceHealthAlertEvaluator;
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<MonitoringCollectionAgent> _logger;
 
@@ -69,6 +70,7 @@ public class MonitoringCollectionAgent : BackgroundService
         LocalProbeExecutor localProbe,
         NetworkOptimizer.Web.Services.Monitoring.MonitoringAlertEvaluator alertEvaluator,
         NetworkOptimizer.Web.Services.Monitoring.SfpAlertEvaluator sfpAlertEvaluator,
+        NetworkOptimizer.Web.Services.Monitoring.DeviceHealthAlertEvaluator deviceHealthAlertEvaluator,
         ILoggerFactory loggerFactory,
         ILogger<MonitoringCollectionAgent> logger)
     {
@@ -80,6 +82,7 @@ public class MonitoringCollectionAgent : BackgroundService
         _localProbe = localProbe;
         _alertEvaluator = alertEvaluator;
         _sfpAlertEvaluator = sfpAlertEvaluator;
+        _deviceHealthAlertEvaluator = deviceHealthAlertEvaluator;
         _loggerFactory = loggerFactory;
         _logger = logger;
     }
@@ -709,6 +712,10 @@ public class MonitoringCollectionAgent : BackgroundService
                     timestamp: DateTime.UtcNow);
 
                 _liveStats.RecordHealth(device.Mac, cpu, memPct, temp, uptime, DateTime.UtcNow);
+
+                await _deviceHealthAlertEvaluator.EvaluateAsync(
+                    device.Mac, device.Name, DescribeDeviceType(device.DeviceType),
+                    cpu, memPct);
             }
             catch (Exception ex)
             {
@@ -767,6 +774,10 @@ public class MonitoringCollectionAgent : BackgroundService
                     timestamp: now);
 
                 _liveStats.RecordHealth(device.Mac, cpu, mem, temp, uptime, now);
+
+                await _deviceHealthAlertEvaluator.EvaluateAsync(
+                    device.Mac, device.Name, DescribeDeviceType(device.DeviceType),
+                    cpu, mem);
             }
             catch (Exception ex)
             {

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -1270,13 +1270,23 @@ from(bucket: ""{_longtermBucket}"")
             ? $@"|> filter(fn: (r) => r.cm_id == ""{SanitizeFluxString(cmId)}"")"
             : "";
 
+        var winDur = ToFluxDuration(window);
         var flux = $@"
-from(bucket: ""{_longtermBucket}"")
+gauges = from(bucket: ""{_longtermBucket}"")
   |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
   |> filter(fn: (r) => r._measurement == ""cable_modem"")
   {cmFilter}
-  |> filter(fn: (r) => r._field == ""ds_power_avg_dbmv"" or r._field == ""ds_snr_avg_db"" or r._field == ""us_power_avg_dbmv"" or r._field == ""correctables_delta"" or r._field == ""uncorrectables_delta"" or r._field == ""locked_ds_channels"" or r._field == ""locked_us_channels"")
-  |> aggregateWindow(every: {ToFluxDuration(window)}, fn: last, createEmpty: false)
+  |> filter(fn: (r) => r._field == ""ds_power_avg_dbmv"" or r._field == ""ds_snr_avg_db"" or r._field == ""us_power_avg_dbmv"" or r._field == ""locked_ds_channels"" or r._field == ""locked_us_channels"")
+  |> aggregateWindow(every: {winDur}, fn: last, createEmpty: false)
+
+deltas = from(bucket: ""{_longtermBucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""cable_modem"")
+  {cmFilter}
+  |> filter(fn: (r) => r._field == ""correctables_delta"" or r._field == ""uncorrectables_delta"")
+  |> aggregateWindow(every: {winDur}, fn: sum, createEmpty: false)
+
+union(tables: [gauges, deltas])
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
         var results = new Dictionary<string, List<CmPoint>>();

--- a/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
@@ -100,9 +100,14 @@ public class OntMonitorService : IDisposable
             config.Password = _credentialProtection.Encrypt(config.Password);
         }
 
+        var isNew = config.Id == 0;
+
         using var scope = _scopeFactory.CreateScope();
         var repository = scope.ServiceProvider.GetRequiredService<IOntRepository>();
         await repository.SaveOntConfigurationAsync(config);
+
+        if (isNew)
+            await AlertRuleAutoEnable.EnableBySourceAsync(scope, "ont", _logger);
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
@@ -19,6 +19,7 @@ public class OntMonitorService : IDisposable
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ICredentialProtectionService _credentialProtection;
     private readonly MonitoringInfluxClient _influx;
+    private readonly NetworkOptimizer.Web.Services.Monitoring.OntAlertEvaluator _alertEvaluator;
     private readonly ILogger<OntMonitorService> _logger;
     private readonly Dictionary<string, IOntProvider> _providers;
     private readonly ConcurrentDictionary<int, OntStats> _statsCache = new();
@@ -31,11 +32,13 @@ public class OntMonitorService : IDisposable
         IEnumerable<IOntProvider> providers,
         ICredentialProtectionService credentialProtection,
         MonitoringInfluxClient influx,
+        NetworkOptimizer.Web.Services.Monitoring.OntAlertEvaluator alertEvaluator,
         ILogger<OntMonitorService> logger)
     {
         _scopeFactory = scopeFactory;
         _credentialProtection = credentialProtection;
         _influx = influx;
+        _alertEvaluator = alertEvaluator;
         _logger = logger;
         _providers = providers.ToDictionary(p => p.ProviderKey, StringComparer.OrdinalIgnoreCase);
 
@@ -197,6 +200,10 @@ public class OntMonitorService : IDisposable
 
                 // Fire-and-forget write to InfluxDB
                 WriteToInflux(config, stats);
+
+                _ = _alertEvaluator.EvaluateAsync(
+                    config.Id, config.Name,
+                    stats.RxPowerDbm, stats.PonLinkStatus, stats.FecErrors);
 
                 _logger.LogDebug("ONT {Name} polled successfully: Rx={Rx} dBm", config.Name, stats.RxPowerDbm);
                 return stats;


### PR DESCRIPTION
## Summary

- **13 new alert event types** covering gateway health (CPU/memory), DOCSIS cable modems (SNR, power, uncorrectables, channel loss), external ONTs (RX power, PON link, FEC errors), and cellular modems (signal quality, network downgrade, roaming)
- **Shared PON thresholds** - extracted `PonThresholds.cs` as single source-of-truth for optical power/temperature thresholds used by both the SFP and external ONT evaluators
- **Smart auto-enable** - modem/ONT/cellular alert rules seed as disabled, then auto-enable when the user configures their first monitoring target of that type (existing users get them enabled on upgrade). Never re-enables rules the user has manually disabled.
- **FEC error chart fix** - cable modem error deltas were using `fn: last` in the InfluxDB aggregate query, which picks one sample per window instead of summing them. Split into gauge and delta streams with appropriate aggregation.
- **Bulk alert actions** - Acknowledge All and Resolve All buttons on the Active Alerts tab

## Test plan

- [x] Verify new alert rules appear in the Rules tab (gateway enabled, modem/ONT/cellular disabled if no configs)
- [x] Verify the Event Type Patterns modal shows all new categories
- [x] Verify cable modem FEC error chart shows correct summed values over longer time ranges
- [x] Verify Acknowledge All / Resolve All buttons work on Active Alerts
- [x] Verify auto-enable: add a new CM config, check that cable_modem rules become enabled
- [x] Verify user-disabled rules are not re-enabled on app restart