### PR TITLE
ISP Health: grade every ISP hop, with divergence-correct jitter attribution

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -239,6 +239,13 @@ The following were implemented in the WiFi Optimizer feature:
 
 ## Monitoring
 
+### Multi-WAN Support (ISP Health & NMS)
+- ISP Health currently grades a single (primary) WAN. Several inputs are read globally rather than scoped to the WAN being scored:
+  - **Upstream ancestry / `hopOrderKnown`** (`IspHealthService.ComputeAsync`): `UpstreamDiscoveries` are queried across all WANs. Rows carry `WanInterface`, and the tracer persists per-WAN, but the scorer reads them globally - so a second WAN's discovery data can flip the jitter-absolve gate (and the routes-through witnesses) for a WAN that has no ancestry of its own. Scope the discovery query and `hopOrderKnown` by `WanInterface`.
+  - **Targets / series / rates** are likewise resolved for the primary WAN only; per-WAN scoring needs each WAN's own targets, latency series, throughput, and expected speeds.
+- Plan: grade ISP Health per-WAN (one report per active WAN), keyed by `WanInterface` end-to-end, and surface a per-WAN selector in the UI. Until then, secondary WANs are not separately graded.
+- **Relevant code:** `IspHealthService.ComputeAsync` (TODO marker at the discoveries query), `UpstreamTracerService.PersistHopOrderAsync` (already per-WAN), `MonitoringPathView` (already WAN-scoped).
+
 ### Gap-Gated SNMP Counter Reset Detection
 - `InterfaceRateCalculator` currently distinguishes a genuine counter reset (device reboot) from a single corrupt SNMP read by requiring two consecutive below-baseline reads before reseeding the baseline (`ResetPending` → `ResetConfirmed`). A discarded over-ceiling rate then advances the baseline so nothing can wedge an interface.
 - Cleaner discriminator: the **elapsed gap**. A real reset only follows a reboot, which trips ~5 consecutive SNMP failures (~25 s) and a 5-minute exclusion, so the first sample back has a large elapsed gap (~5 min). A corrupt-read glitch arrives at the normal ~5 s cadence with a tiny gap. So: backwards counter with a large gap (e.g. ≥ 60 s, above poll jitter and below the exclusion window) → reset, reseed immediately; backwards counter at normal cadence → glitch, hold the baseline and suppress. This reseeds genuine resets in one poll instead of two and makes the rare two-fast-corrupt-reads false-confirm impossible by construction.

--- a/src/NetworkOptimizer.Storage/Migrations/20260615034638_AddUpstreamHopAncestors.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260615034638_AddUpstreamHopAncestors.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260615034638_AddUpstreamHopAncestors")]
+    partial class AddUpstreamHopAncestors
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260615034638_AddUpstreamHopAncestors.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260615034638_AddUpstreamHopAncestors.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <summary>
+    /// Adds AncestorHopIps to UpstreamDiscoveries: the monitored hops proven upstream of
+    /// each hop on the discovery traces, so ISP Health can confirm one hop routes through
+    /// another across divergent paths.
+    ///
+    /// The scaffolder also emitted UniFiSshSettings changes because the model snapshot was
+    /// stale (it described the old shape with a Host column). Those columns already exist
+    /// identically on every site - the original AddUniFiSshSettings migration created them -
+    /// so applying that DDL would crash with duplicate/no-such-column. The snapshot is
+    /// regenerated to the correct shape (design-time only, never runs on sites); this
+    /// migration deliberately carries ONLY the AncestorHopIps column.
+    /// </summary>
+    public partial class AddUpstreamHopAncestors : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AncestorHopIps",
+                table: "UpstreamDiscoveries",
+                type: "TEXT",
+                maxLength: 2000,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AncestorHopIps",
+                table: "UpstreamDiscoveries");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/DesignTimeDbContextFactory.cs
+++ b/src/NetworkOptimizer.Storage/Models/DesignTimeDbContextFactory.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace NetworkOptimizer.Storage.Models;
+
+/// <summary>
+/// Design-time factory so EF Core tooling (dotnet ef migrations) can construct the
+/// context without the app's DI. Not used at runtime.
+/// </summary>
+public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<NetworkOptimizerDbContext>
+{
+    public NetworkOptimizerDbContext CreateDbContext(string[] args)
+    {
+        var options = new DbContextOptionsBuilder<NetworkOptimizerDbContext>()
+            .UseSqlite("Data Source=design-time.db")
+            .Options;
+        return new NetworkOptimizerDbContext(options);
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/UpstreamDiscovery.cs
+++ b/src/NetworkOptimizer.Storage/Models/UpstreamDiscovery.cs
@@ -32,6 +32,15 @@ public class UpstreamDiscovery
 
     public int HopNumber { get; set; }
 
+    /// <summary>
+    /// Space-separated IPs of the monitored hops that appear before this one on any
+    /// discovery trace it was seen on - its proven upstream ancestors. ISP Health uses
+    /// these to confirm one hop genuinely routes through another (a witness only absolves
+    /// a hop in its ancestor set), correct across divergent paths. Empty for a first hop.
+    /// </summary>
+    [MaxLength(2000)]
+    public string? AncestorHopIps { get; set; }
+
     public UpstreamRole Role { get; set; }
 
     [MaxLength(50)]

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -84,6 +84,20 @@ else
             }
         </button>
     </div>
+    @if (!r.HasUpstreamTraceMap)
+    {
+        <div class="alert alert-info" style="margin-bottom: 1rem;">
+            <div class="banner-content">
+                <span class="banner-icon banner-icon-info">i</span>
+                <div class="banner-text" style="flex: 1;">
+                    No upstream trace map yet, so per-hop jitter attribution runs in a lenient fallback. Re-run Upstream Discovery to map your trace path, so ISP Health can tell a genuinely congested hop from one that just deprioritizes ICMP.
+                </div>
+                <div class="banner-actions">
+                    <button class="btn btn-sm btn-primary" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&discover=1"))">Re-run Upstream Discovery</button>
+                </div>
+            </div>
+        </div>
+    }
     <div class="isp-health-hero card">
         <span class="isp-health-updated">Last updated: @TimeFormatHelper.FormatRelativeTimeShort(r.ComputedAt)</span>
         <div class="card-body isp-health-hero-body">

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -259,16 +259,26 @@ else
                 <div class="isp-asn-grid">
                     @foreach (var asn in r.IspAsns.Concat(r.TransitAsns))
                     {
+                        var isIspAsn = r.IspAsns.Contains(asn);
+                        var showRange = isIspAsn && asn.MinRttMs.HasValue && asn.MaxRttMs.HasValue
+                            && asn.MaxRttMs.Value - asn.MinRttMs.Value > 0.05;
                         <div class="isp-asn-card">
                             <div class="isp-asn-card-header">
                                 <div>
                                     <div class="isp-asn-name">@(string.IsNullOrEmpty(asn.AsnName) ? $"AS{asn.AsnNumber}" : asn.AsnName)</div>
-                                    <div class="isp-asn-sub">@(r.IspAsns.Contains(asn) ? "ISP network" : "Transit") @(asn.AsnNumber > 0 ? $"· AS{asn.AsnNumber}" : "")</div>
+                                    <div class="isp-asn-sub">@(isIspAsn ? "ISP network" : "Transit") @(asn.AsnNumber > 0 ? $"· AS{asn.AsnNumber}" : "")</div>
                                 </div>
                                 <span class="isp-asn-grade @ScoreTextClass(asn.OverallScore)">@(asn.OverallScore?.ToString() ?? "--")</span>
                             </div>
                             <div class="isp-asn-stats">
-                                <div class="isp-asn-stat"><span class="detail-label">Mean RTT</span><span class="detail-value">@FormatRtt(asn.MeanRttMs)</span></div>
+                                @if (showRange)
+                                {
+                                    <div class="isp-asn-stat"><span class="detail-label">RTT Range</span><span class="detail-value">@FormatRttRange(asn.MinRttMs, asn.MaxRttMs)</span></div>
+                                }
+                                else
+                                {
+                                    <div class="isp-asn-stat"><span class="detail-label">Mean RTT</span><span class="detail-value">@FormatRtt(asn.MeanRttMs)</span></div>
+                                }
                                 <div class="isp-asn-stat"><span class="detail-label">P95 Jitter</span><span class="detail-value">@FormatJitter(asn.P95JitterMs)</span></div>
                                 <div class="isp-asn-stat"><span class="detail-label">Loss</span><span class="detail-value">@FormatLossPct(asn.LossPct)</span></div>
                                 @if (asn.ReachDeltaMs.HasValue)
@@ -436,6 +446,9 @@ else
     private static string FormatJitter(double? ms) => ms.HasValue ? $"{ms.Value:0.00} ms" : "--";
 
     private static string FormatRtt(double? ms) => ms.HasValue ? $"{ms.Value:0.00} ms" : "--";
+
+    private static string FormatRttRange(double? min, double? max) =>
+        min.HasValue && max.HasValue ? $"{min.Value:0.00} - {max.Value:0.00} ms" : "--";
 
     private static string FormatLossPct(double? pct) => pct switch { null => "--", 0 => "0%", _ => $"{pct.Value:0.##}%" };
 

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -198,7 +198,7 @@ else
                                         <span class="isp-factor-score @ScoreTextClass(target.OverallScore)">@(target.OverallScore?.ToString() ?? "--")</span>
                                     </div>
                                     <div class="isp-hop-stats">
-                                        <span class="isp-target-stat"><span class="isp-target-stat-label">RTT</span>@FormatRtt(target.MedianRttMs)</span>
+                                        <span class="isp-target-stat"><span class="isp-target-stat-label">RTT</span>@FormatRtt(target.RttMs)</span>
                                         <span class="isp-target-stat"><span class="isp-target-stat-label">P95 Jitter</span>@FormatJitter(target.P95JitterMs)</span>
                                         <span class="isp-target-stat"><span class="isp-target-stat-label">Loss</span>@FormatLossPct(target.LossPct)</span>
                                         @if (target.ReachDeltaMs is > 0.15)

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -172,63 +172,79 @@ else
                     <span class="isp-dimension-score @ScoreTextClass(dimension.Score)">@(dimension.Score?.ToString() ?? "--")</span>
                 </div>
                 <div class="card-body">
-                    @if (dimension.Factors.Count == 0)
+                    @if (dimension == r.IspAsnDimension)
                     {
-                        <p class="page-description">No data for this dimension in the window.</p>
-                    }
-                    @foreach (var factor in dimension.Factors)
-                    {
-                        <div class="isp-factor-row">
-                            <div class="isp-factor-label">
-                                @{ var investigateUrl = FactorInvestigateUrl(factor.Name); }
-                                @if (investigateUrl != null)
-                                {
-                                    <a class="isp-factor-name isp-factor-link" href="@investigateUrl"
-                                       data-tooltip="Jump to the most recent matching loss event on the Network Performance charts">@factor.Name</a>
-                                }
-                                else
-                                {
-                                    <span class="isp-factor-name">@factor.Name</span>
-                                }
-                                @if (!string.IsNullOrEmpty(factor.ValueText))
-                                {
-                                    <span class="isp-factor-value">@factor.ValueText</span>
-                                }
-                            </div>
-                            <div class="isp-factor-bar-track">
-                                <div class="isp-factor-bar @BarClass(factor.Score)" style="width: @(factor.Score ?? 0)%"></div>
-                            </div>
-                            <span class="isp-factor-score @ScoreTextClass(factor.Score)">@(factor.Score?.ToString() ?? "--")</span>
-                        </div>
-                        @if (!string.IsNullOrEmpty(factor.Description))
+                        @if (r.IspTargets.Count == 0)
                         {
-                            <div class="isp-factor-description">@factor.Description</div>
+                            <p class="page-description">No ISP hop data in the window.</p>
                         }
-                    }
-                    @if (dimension == r.IspAsnDimension && r.IspTargets.Count > 1)
-                    {
-                        <div class="isp-target-list">
+                        <div class="isp-hop-list">
                             @foreach (var target in r.IspTargets)
                             {
-                                <div class="isp-target-row">
-                                    <div class="isp-target-detail">
-                                        <div class="isp-target-name">
-                                            @target.Name
-                                            @if (target.IsGradedHop)
-                                            {
-                                                <span class="isp-target-graded" data-tooltip="The first clean hop; access layer idle latency comes from this target">idle</span>
-                                            }
+                                <div class="isp-hop">
+                                    <div class="isp-hop-row">
+                                        <div class="isp-hop-main">
+                                            <div class="isp-hop-name">
+                                                @target.Name
+                                                @if (target.IsGradedHop)
+                                                {
+                                                    <span class="isp-target-graded" data-tooltip="The first clean hop; access layer idle latency comes from this target">idle</span>
+                                                }
+                                            </div>
+                                            <div class="isp-factor-bar-track">
+                                                <div class="isp-factor-bar @BarClass(target.OverallScore)" style="width: @(target.OverallScore ?? 0)%"></div>
+                                            </div>
                                         </div>
-                                        <div class="isp-target-stats">
-                                            <span class="isp-target-stat"><span class="isp-target-stat-label">RTT</span>@FormatRtt(target.MedianRttMs)</span>
-                                            <span class="isp-target-stat"><span class="isp-target-stat-label">P95 Jitter</span>@FormatMs(target.P95JitterMs)</span>
-                                            <span class="isp-target-stat"><span class="isp-target-stat-label">Loss</span>@FormatLossPct(target.LossPct)</span>
-                                        </div>
+                                        <span class="isp-factor-score @ScoreTextClass(target.OverallScore)">@(target.OverallScore?.ToString() ?? "--")</span>
                                     </div>
-                                    <span class="isp-target-score @ScoreTextClass(target.OverallScore)">@(target.OverallScore?.ToString() ?? "--")</span>
+                                    <div class="isp-hop-stats">
+                                        <span class="isp-target-stat"><span class="isp-target-stat-label">RTT</span>@FormatRtt(target.MedianRttMs)</span>
+                                        <span class="isp-target-stat"><span class="isp-target-stat-label">P95 Jitter</span>@FormatMs(target.P95JitterMs)</span>
+                                        <span class="isp-target-stat"><span class="isp-target-stat-label">Loss</span>@FormatLossPct(target.LossPct)</span>
+                                        @if (target.ReachDeltaMs is > 0.15)
+                                        {
+                                            <span class="isp-target-stat"><span class="isp-target-stat-label">Beyond nearest</span>+@FormatMs(target.ReachDeltaMs)</span>
+                                        }
+                                    </div>
                                 </div>
                             }
                         </div>
+                    }
+                    else
+                    {
+                        @if (dimension.Factors.Count == 0)
+                        {
+                            <p class="page-description">No data for this dimension in the window.</p>
+                        }
+                        @foreach (var factor in dimension.Factors)
+                        {
+                            <div class="isp-factor-row">
+                                <div class="isp-factor-label">
+                                    @{ var investigateUrl = FactorInvestigateUrl(factor.Name); }
+                                    @if (investigateUrl != null)
+                                    {
+                                        <a class="isp-factor-name isp-factor-link" href="@investigateUrl"
+                                           data-tooltip="Jump to the most recent matching loss event on the Network Performance charts">@factor.Name</a>
+                                    }
+                                    else
+                                    {
+                                        <span class="isp-factor-name">@factor.Name</span>
+                                    }
+                                    @if (!string.IsNullOrEmpty(factor.ValueText))
+                                    {
+                                        <span class="isp-factor-value">@factor.ValueText</span>
+                                    }
+                                </div>
+                                <div class="isp-factor-bar-track">
+                                    <div class="isp-factor-bar @BarClass(factor.Score)" style="width: @(factor.Score ?? 0)%"></div>
+                                </div>
+                                <span class="isp-factor-score @ScoreTextClass(factor.Score)">@(factor.Score?.ToString() ?? "--")</span>
+                            </div>
+                            @if (!string.IsNullOrEmpty(factor.Description))
+                            {
+                                <div class="isp-factor-description">@factor.Description</div>
+                            }
+                        }
                     }
                 </div>
             </div>

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -385,6 +385,7 @@ else
     private bool _loading = true;
     private bool _chartMounted;
     private bool _refreshing;
+    private System.Threading.Timer? _ageTimer;
 
     protected override async Task OnInitializedAsync()
     {
@@ -402,6 +403,14 @@ else
         {
             _loading = false;
         }
+
+        // Re-render every 30 s so "Last updated: N min ago" ages on its own, without
+        // waiting for a tab reload or a manual refresh.
+        _ageTimer = new System.Threading.Timer(_ =>
+        {
+            try { _ = InvokeAsync(StateHasChanged); }
+            catch { /* never let a render fault kill the timer */ }
+        }, null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
     }
 
     private async Task RefreshAsync()
@@ -520,6 +529,7 @@ else
 
     public void Dispose()
     {
+        _ageTimer?.Dispose();
         if (_chartMounted)
         {
             try { _ = JS.InvokeVoidAsync("eval", "window.__ispHealthCharts?.unmount();"); }

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -211,18 +211,21 @@ else
                             @foreach (var target in r.IspTargets)
                             {
                                 <div class="isp-target-row">
-                                    <div class="isp-target-name">
-                                        @target.Name
-                                        @if (target.IsGradedHop)
-                                        {
-                                            <span class="isp-target-graded" data-tooltip="The first clean hop; latency factors and the ISP grade come from this target">graded</span>
-                                        }
+                                    <div class="isp-target-detail">
+                                        <div class="isp-target-name">
+                                            @target.Name
+                                            @if (target.IsGradedHop)
+                                            {
+                                                <span class="isp-target-graded" data-tooltip="The first clean hop; access layer idle latency comes from this target">idle</span>
+                                            }
+                                        </div>
+                                        <div class="isp-target-stats">
+                                            <span class="isp-target-stat"><span class="isp-target-stat-label">RTT</span>@FormatRtt(target.MedianRttMs)</span>
+                                            <span class="isp-target-stat"><span class="isp-target-stat-label">P95 Jitter</span>@FormatMs(target.P95JitterMs)</span>
+                                            <span class="isp-target-stat"><span class="isp-target-stat-label">Loss</span>@FormatLossPct(target.LossPct)</span>
+                                        </div>
                                     </div>
-                                    <div class="isp-target-stats">
-                                        <span class="isp-target-stat"><span class="isp-target-stat-label">RTT</span>@FormatRtt(target.MedianRttMs)</span>
-                                        <span class="isp-target-stat"><span class="isp-target-stat-label">P95 Jitter</span>@FormatMs(target.P95JitterMs)</span>
-                                        <span class="isp-target-stat"><span class="isp-target-stat-label">Loss</span>@FormatLossPct(target.LossPct)</span>
-                                    </div>
+                                    <span class="isp-target-score @ScoreTextClass(target.OverallScore)">@(target.OverallScore?.ToString() ?? "--")</span>
                                 </div>
                             }
                         </div>

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -455,8 +455,8 @@ else
     private static string FormatJitter(double? ms) => ms.HasValue ? $"{ms.Value:0.00} ms" : "--";
 
     private static string JitterAssimilationTooltip(IspAsnHealth asn, bool isIsp) => isIsp
-        ? $"Showing {FormatJitter(asn.P95JitterMs)}, not the ISP hops' {FormatJitter(asn.RawJitterMs)}. A transit network reached through the ISP reads lower, so the ISP can't be jitterier - the higher reading is likely ICMP deprioritization."
-        : $"Showing {FormatJitter(asn.P95JitterMs)}, not the nearest hop's {FormatJitter(asn.RawJitterMs)}. A farther hop reached through it reads lower, proving the path is steady - the higher near reading is likely ICMP deprioritization.";
+        ? $"Showing {FormatJitter(asn.P95JitterMs)} from the cleanest network beyond your ISP, not your ISP routers' {FormatJitter(asn.RawJitterMs)}. All traffic crosses the ISP to reach it, so the ISP is no jitterier - its higher reading is likely ICMP deprioritization."
+        : $"Showing {FormatJitter(asn.P95JitterMs)} from a router deeper in this network, not the {FormatJitter(asn.RawJitterMs)} a closer router reported. Traffic passes through the closer router to reach it, so the lower value is the true path jitter - the closer router just deprioritizes ICMP.";
 
     private static string FormatRtt(double? ms) => ms.HasValue ? $"{ms.Value:0.00} ms" : "--";
 

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -90,7 +90,7 @@ else
             <div class="banner-content">
                 <span class="banner-icon banner-icon-info">i</span>
                 <div class="banner-text" style="flex: 1;">
-                    No upstream trace map yet, so per-hop jitter attribution runs in a lenient fallback. Re-run Upstream Discovery to map your trace path, so ISP Health can tell a genuinely congested hop from one that just deprioritizes ICMP.
+                    Re-run Upstream Discovery to map your trace path, so ISP Health can tell a genuinely congested hop from one that just deprioritizes ICMP.
                 </div>
                 <div class="banner-actions">
                     <button class="btn btn-sm btn-primary" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&discover=1"))">Re-run Upstream Discovery</button>

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -455,8 +455,8 @@ else
     private static string FormatJitter(double? ms) => ms.HasValue ? $"{ms.Value:0.00} ms" : "--";
 
     private static string JitterAssimilationTooltip(IspAsnHealth asn, bool isIsp) => isIsp
-        ? $"Shown jitter is {FormatJitter(asn.P95JitterMs)}, not the ISP hops' own {FormatJitter(asn.RawJitterMs)}. A transit network reached through your ISP measured the lower value, and since that traffic crosses the ISP first, the ISP path can be no jitterier than that. The higher ISP-hop reading is usually ICMP deprioritization, so the cleaner transit value is used."
-        : $"Shown jitter is {FormatJitter(asn.P95JitterMs)}, not this network's nearest-hop {FormatJitter(asn.RawJitterMs)}. A farther hop reached through the nearer one measured the lower value, which proves the path is steady; the nearer hop's higher reading is usually ICMP deprioritization, so the cleaner farther value is used.";
+        ? $"Showing {FormatJitter(asn.P95JitterMs)}, not the ISP hops' {FormatJitter(asn.RawJitterMs)}. A transit network reached through the ISP reads lower, so the ISP can't be jitterier - the higher reading is likely ICMP deprioritization."
+        : $"Showing {FormatJitter(asn.P95JitterMs)}, not the nearest hop's {FormatJitter(asn.RawJitterMs)}. A farther hop reached through it reads lower, proving the path is steady - the higher near reading is likely ICMP deprioritization.";
 
     private static string FormatRtt(double? ms) => ms.HasValue ? $"{ms.Value:0.00} ms" : "--";
 

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -199,7 +199,7 @@ else
                                     </div>
                                     <div class="isp-hop-stats">
                                         <span class="isp-target-stat"><span class="isp-target-stat-label">RTT</span>@FormatRtt(target.MedianRttMs)</span>
-                                        <span class="isp-target-stat"><span class="isp-target-stat-label">P95 Jitter</span>@FormatMs(target.P95JitterMs)</span>
+                                        <span class="isp-target-stat"><span class="isp-target-stat-label">P95 Jitter</span>@FormatJitter(target.P95JitterMs)</span>
                                         <span class="isp-target-stat"><span class="isp-target-stat-label">Loss</span>@FormatLossPct(target.LossPct)</span>
                                         @if (target.ReachDeltaMs is > 0.15)
                                         {
@@ -268,8 +268,8 @@ else
                                 <span class="isp-asn-grade @ScoreTextClass(asn.OverallScore)">@(asn.OverallScore?.ToString() ?? "--")</span>
                             </div>
                             <div class="isp-asn-stats">
-                                <div class="isp-asn-stat"><span class="detail-label">Mean RTT</span><span class="detail-value">@FormatMs(asn.MeanRttMs)</span></div>
-                                <div class="isp-asn-stat"><span class="detail-label">P95 Jitter</span><span class="detail-value">@FormatMs(asn.P95JitterMs)</span></div>
+                                <div class="isp-asn-stat"><span class="detail-label">Mean RTT</span><span class="detail-value">@FormatRtt(asn.MeanRttMs)</span></div>
+                                <div class="isp-asn-stat"><span class="detail-label">P95 Jitter</span><span class="detail-value">@FormatJitter(asn.P95JitterMs)</span></div>
                                 <div class="isp-asn-stat"><span class="detail-label">Loss</span><span class="detail-value">@FormatLossPct(asn.LossPct)</span></div>
                                 @if (asn.ReachDeltaMs.HasValue)
                                 {
@@ -433,7 +433,9 @@ else
 
     private static string FormatMs(double? ms) => ms.HasValue ? $"{ms.Value:0.#} ms" : "--";
 
-    private static string FormatRtt(double? ms) => ms.HasValue ? $"{ms.Value:0.0} ms" : "--";
+    private static string FormatJitter(double? ms) => ms.HasValue ? $"{ms.Value:0.00} ms" : "--";
+
+    private static string FormatRtt(double? ms) => ms.HasValue ? $"{ms.Value:0.00} ms" : "--";
 
     private static string FormatLossPct(double? pct) => pct switch { null => "--", 0 => "0%", _ => $"{pct.Value:0.##}%" };
 

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -71,6 +71,20 @@ else if (_report == null)
 else
 {
     var r = _report;
+    @if (!r.HasUpstreamTraceMap)
+    {
+        <div class="alert alert-info" style="margin-bottom: 0.75rem;">
+            <div class="banner-content">
+                <span class="banner-icon banner-icon-info">i</span>
+                <div class="banner-text" style="flex: 1;">
+                    Re-run Upstream Discovery to map your trace path, so ISP Health can tell a genuinely congested hop from one that just deprioritizes ICMP.
+                </div>
+                <div class="banner-actions">
+                    <button class="btn btn-sm btn-primary" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&discover=1"))">Re-run Upstream Discovery</button>
+                </div>
+            </div>
+        </div>
+    }
     <div class="isp-health-toolbar">
         <button class="btn btn-sm btn-secondary" @onclick="RefreshAsync" disabled="@_refreshing"
                 data-tooltip="Recompute ISP Health now from the latest monitoring data" data-tooltip-hover-only>
@@ -84,20 +98,6 @@ else
             }
         </button>
     </div>
-    @if (!r.HasUpstreamTraceMap)
-    {
-        <div class="alert alert-info" style="margin-bottom: 1rem;">
-            <div class="banner-content">
-                <span class="banner-icon banner-icon-info">i</span>
-                <div class="banner-text" style="flex: 1;">
-                    Re-run Upstream Discovery to map your trace path, so ISP Health can tell a genuinely congested hop from one that just deprioritizes ICMP.
-                </div>
-                <div class="banner-actions">
-                    <button class="btn btn-sm btn-primary" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&discover=1"))">Re-run Upstream Discovery</button>
-                </div>
-            </div>
-        </div>
-    }
     <div class="isp-health-hero card">
         <span class="isp-health-updated">Last updated: @TimeFormatHelper.FormatRelativeTimeShort(r.ComputedAt)</span>
         <div class="card-body isp-health-hero-body">
@@ -214,11 +214,14 @@ else
                                     <div class="isp-hop-stats">
                                         <span class="isp-target-stat"><span class="isp-target-stat-label">RTT</span>@FormatRtt(target.RttMs)</span>
                                         <span class="isp-target-stat">
-                                            <span class="isp-target-stat-label">P95 Jitter</span>@FormatJitter(target.P95JitterMs)
-                                            @if (target.JitterAssimilated)
-                                            {
-                                                <span class="tooltip-icon tooltip-icon-sm" data-tooltip="@JitterAssimilationTooltip(target)">i</span>
-                                            }
+                                            <span class="isp-target-stat-label">P95 Jitter</span>
+                                            <span class="isp-target-stat-value">
+                                                @FormatJitter(target.P95JitterMs)
+                                                @if (target.JitterAssimilated)
+                                                {
+                                                    <span class="tooltip-icon tooltip-icon-sm" data-tooltip="@JitterAssimilationTooltip(target)">i</span>
+                                                }
+                                            </span>
                                         </span>
                                         <span class="isp-target-stat"><span class="isp-target-stat-label">Loss</span>@FormatLossPct(target.LossPct)</span>
                                         @if (target.ReachDeltaMs is > 0.15)

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -279,7 +279,16 @@ else
                                 {
                                     <div class="isp-asn-stat"><span class="detail-label">Mean RTT</span><span class="detail-value">@FormatRtt(asn.MeanRttMs)</span></div>
                                 }
-                                <div class="isp-asn-stat"><span class="detail-label">P95 Jitter</span><span class="detail-value">@FormatJitter(asn.P95JitterMs)</span></div>
+                                <div class="isp-asn-stat">
+                                    <span class="detail-label">P95 Jitter</span>
+                                    <span class="detail-value">
+                                        @FormatJitter(asn.P95JitterMs)
+                                        @if (asn.JitterAssimilated)
+                                        {
+                                            <span class="tooltip-icon tooltip-icon-sm" data-tooltip="@JitterAssimilationTooltip(asn, isIspAsn)">i</span>
+                                        }
+                                    </span>
+                                </div>
                                 <div class="isp-asn-stat"><span class="detail-label">Loss</span><span class="detail-value">@FormatLossPct(asn.LossPct)</span></div>
                                 @if (asn.ReachDeltaMs.HasValue)
                                 {
@@ -444,6 +453,10 @@ else
     private static string FormatMs(double? ms) => ms.HasValue ? $"{ms.Value:0.#} ms" : "--";
 
     private static string FormatJitter(double? ms) => ms.HasValue ? $"{ms.Value:0.00} ms" : "--";
+
+    private static string JitterAssimilationTooltip(IspAsnHealth asn, bool isIsp) => isIsp
+        ? $"Shown jitter is {FormatJitter(asn.P95JitterMs)}, not the ISP hops' own {FormatJitter(asn.RawJitterMs)}. A transit network reached through your ISP measured the lower value, and since that traffic crosses the ISP first, the ISP path can be no jitterier than that. The higher ISP-hop reading is usually ICMP deprioritization, so the cleaner transit value is used."
+        : $"Shown jitter is {FormatJitter(asn.P95JitterMs)}, not this network's nearest-hop {FormatJitter(asn.RawJitterMs)}. A farther hop reached through the nearer one measured the lower value, which proves the path is steady; the nearer hop's higher reading is usually ICMP deprioritization, so the cleaner farther value is used.";
 
     private static string FormatRtt(double? ms) => ms.HasValue ? $"{ms.Value:0.00} ms" : "--";
 

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -188,7 +188,7 @@ else
                                                 @target.Name
                                                 @if (target.IsGradedHop)
                                                 {
-                                                    <span class="isp-target-graded" data-tooltip="The first clean hop; access layer idle latency comes from this target">idle</span>
+                                                    <span class="isp-target-graded" data-tooltip="The lowest-RTT ISP hop; access-layer idle latency is measured from it">Lowest RTT</span>
                                                 }
                                             </div>
                                             <div class="isp-factor-bar-track">

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -199,7 +199,13 @@ else
                                     </div>
                                     <div class="isp-hop-stats">
                                         <span class="isp-target-stat"><span class="isp-target-stat-label">RTT</span>@FormatRtt(target.RttMs)</span>
-                                        <span class="isp-target-stat"><span class="isp-target-stat-label">P95 Jitter</span>@FormatJitter(target.P95JitterMs)</span>
+                                        <span class="isp-target-stat">
+                                            <span class="isp-target-stat-label">P95 Jitter</span>@FormatJitter(target.P95JitterMs)
+                                            @if (target.JitterAssimilated)
+                                            {
+                                                <span class="tooltip-icon tooltip-icon-sm" data-tooltip="@JitterAssimilationTooltip(target)">i</span>
+                                            }
+                                        </span>
                                         <span class="isp-target-stat"><span class="isp-target-stat-label">Loss</span>@FormatLossPct(target.LossPct)</span>
                                         @if (target.ReachDeltaMs is > 0.15)
                                         {
@@ -457,6 +463,9 @@ else
     private static string JitterAssimilationTooltip(IspAsnHealth asn, bool isIsp) => isIsp
         ? $"Showing {FormatJitter(asn.P95JitterMs)} from the cleanest network beyond your ISP, not your ISP routers' {FormatJitter(asn.RawJitterMs)}. All traffic crosses the ISP to reach it, so the ISP is no jitterier - its higher reading is likely ICMP deprioritization."
         : $"Showing {FormatJitter(asn.P95JitterMs)} from a router deeper in this network, not the {FormatJitter(asn.RawJitterMs)} a closer router reported. Traffic passes through the closer router to reach it, so the lower value is the true path jitter - the closer router just deprioritizes ICMP.";
+
+    private static string JitterAssimilationTooltip(IspTargetHealth target) =>
+        $"Showing {FormatJitter(target.P95JitterMs)} measured to a network reached through this router, not its own {FormatJitter(target.RawJitterMs)}. Traffic passes through it cleanly, so the higher reading is this router deprioritizing ICMP, not real jitter.";
 
     private static string FormatRtt(double? ms) => ms.HasValue ? $"{ms.Value:0.00} ms" : "--";
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -326,6 +326,14 @@ public class IspHealthInputs
     /// <summary>Per-ASN series for access ISP targets.</summary>
     public List<AsnSeries> IspAsnSeries { get; init; } = new();
 
+    /// <summary>
+    /// Per-target series for monitored internet/destination endpoints (anycast DNS, CDN
+    /// probes). Each carries the hops proven upstream of it (AncestorIps) so a destination's
+    /// clean end-to-end jitter can absolve an ISP hop it provably routes through - an
+    /// ICMP-deprioritized hop whose forwarded traffic reaches the destination smoothly.
+    /// </summary>
+    public List<AsnSeries> DestinationSeries { get; init; } = new();
+
     /// <summary>WAN throughput over the window (primary WAN).</summary>
     public List<ThroughputSample> WanRates { get; init; } = new();
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -247,11 +247,12 @@ public class AsnSeries
     public double? NearestClusterMeanRttMs { get; init; }
 
     /// <summary>
-    /// Samples jitter and latency stability are scored from, when they should come from
-    /// a different cluster than <see cref="Samples"/>. Used for transit ASNs with a
-    /// farther cluster: a near hop often shows false jitter from ICMP deprioritization
-    /// that the farther cluster (reached through it) disproves, so jitter is graded on
-    /// the farther cluster while RTT and reach stay on the nearest. Empty means use Samples.
+    /// A farther cluster's samples used to absolve false near-hop jitter. A near hop often
+    /// shows false jitter from ICMP deprioritization; a cleaner farther cluster, confirmed
+    /// downstream by stored traceroute hop order, disproves it. Jitter and stability are
+    /// graded on the BETTER (lower) of <see cref="Samples"/> and this (absolve-only: a
+    /// jittery farther cluster never downgrades the nearer). RTT and reach always use
+    /// Samples. Empty means no confirmed farther cluster, so Samples alone is used.
     /// </summary>
     public List<LatencySample> JitterSourceSamples { get; init; } = new();
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -118,7 +118,16 @@ public class IspTargetHealth
 
     /// <summary>Displayed RTT: winsorized mean over the window.</summary>
     public double? RttMs { get; init; }
+
+    /// <summary>Effective (absolved) P95 jitter this hop is graded on.</summary>
     public double? P95JitterMs { get; init; }
+
+    /// <summary>This hop's own measured P95 jitter, before any absolve.</summary>
+    public double? RawJitterMs { get; init; }
+
+    /// <summary>True when a cleaner witness (transit/sibling/destination) pulled this hop's jitter below its own reading.</summary>
+    public bool JitterAssimilated { get; init; }
+
     public double? LossPct { get; init; }
 
     /// <summary>Per-hop quality grade (stability, jitter, loss, congestion, intra-ASN reach).</summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -274,6 +274,14 @@ public class AsnSeries
     /// appears as both the access ISP and transit. Empty on chart-cluster series.
     /// </summary>
     public List<string> RoleTargetIds { get; init; } = new();
+
+    /// <summary>
+    /// Lowest traceroute hop number among this series' targets on the WAN's global
+    /// canonical trace (from UpstreamDiscoveries). Lets the scorer confirm one series
+    /// routes through another - a witness only absolves a hop it sits downstream of.
+    /// Null when no stored hop order covers these targets.
+    /// </summary>
+    public int? MinHopNumber { get; init; }
 }
 
 /// <summary>Load classification of one aggregate window.</summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -221,6 +221,12 @@ public class IspHealthReport
     /// <summary>False when expected WAN speeds were unavailable and loaded analysis was skipped.</summary>
     public bool HasExpectedSpeeds { get; init; }
 
+    /// <summary>
+    /// False when no upstream hop-ancestry (trace map) is persisted, so the per-hop jitter
+    /// absolve gate runs in its lenient fallback. Prompts the user to re-run Upstream Discovery.
+    /// </summary>
+    public bool HasUpstreamTraceMap { get; init; }
+
     /// <summary>False when no loaded windows occurred in the window (line never under load).</summary>
     public bool HasLoadedSamples { get; init; }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -77,6 +77,10 @@ public class IspAsnHealth
     /// <summary>Mean RTT across all of the ASN's monitored hops (shown on the Networks on Your Path card).</summary>
     public double? MeanRttMs { get; init; }
 
+    /// <summary>Lowest and highest hop RTT in the ASN, for the ISP card's RTT range.</summary>
+    public double? MinRttMs { get; init; }
+    public double? MaxRttMs { get; init; }
+
     public double? P95RttMs { get; init; }
     public double? MedianJitterMs { get; init; }
     public double? P95JitterMs { get; init; }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -84,6 +84,14 @@ public class IspAsnHealth
     public double? P95RttMs { get; init; }
     public double? MedianJitterMs { get; init; }
     public double? P95JitterMs { get; init; }
+
+    /// <summary>True when the displayed jitter was assimilated from elsewhere (a cleaner
+    /// farther cluster for transit, or the cleanest transit ASN for the ISP) rather than
+    /// this network's own nearest reading. Drives the info icon on the card.</summary>
+    public bool JitterAssimilated { get; init; }
+
+    /// <summary>This network's own measured jitter before assimilation, for the tooltip.</summary>
+    public double? RawJitterMs { get; init; }
     public double? RttMadMs { get; init; }
     public double? LossPct { get; init; }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -277,13 +277,15 @@ public class AsnSeries
     /// </summary>
     public List<string> RoleTargetIds { get; init; } = new();
 
+    /// <summary>The IPs of this series' targets, so a witness can be tested for routing through them.</summary>
+    public List<string> HopIps { get; init; } = new();
+
     /// <summary>
-    /// Lowest traceroute hop number among this series' targets on the WAN's global
-    /// canonical trace (from UpstreamDiscoveries). Lets the scorer confirm one series
-    /// routes through another - a witness only absolves a hop it sits downstream of.
-    /// Null when no stored hop order covers these targets.
+    /// The monitored hop IPs proven upstream of this series (union over its targets, from the
+    /// discovery traces). A witness series routes through a hop X - and so may absolve it -
+    /// iff X's IP is in the witness's ancestor set. Empty for a first hop.
     /// </summary>
-    public int? MinHopNumber { get; init; }
+    public List<string> AncestorIps { get; init; } = new();
 }
 
 /// <summary>Load classification of one aggregate window.</summary>
@@ -351,6 +353,13 @@ public class IspHealthInputs
 
     /// <summary>Pre-detected path shift events. Informational only.</summary>
     public List<PathShiftEvent> PathShifts { get; init; } = new();
+
+    /// <summary>
+    /// True when Upstream Discovery has persisted hop-ancestor data for this WAN. When false
+    /// (never discovered, or pre-ancestor data), the jitter absolve gate falls open for
+    /// transit (transit is always downstream of the ISP) and stays closed for ISP siblings.
+    /// </summary>
+    public bool HopOrderKnown { get; init; }
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -107,7 +107,10 @@ public class IspTargetHealth
     public double? P95JitterMs { get; init; }
     public double? LossPct { get; init; }
 
-    /// <summary>True for the first clean hop, the target the ISP grade is computed from.</summary>
+    /// <summary>Per-target quality grade (stability, jitter, loss, congestion).</summary>
+    public int? OverallScore { get; init; }
+
+    /// <summary>True for the first clean hop, the target the access layer idle latency comes from.</summary>
     public bool IsGradedHop { get; init; }
 }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -107,8 +107,11 @@ public class IspTargetHealth
     public double? P95JitterMs { get; init; }
     public double? LossPct { get; init; }
 
-    /// <summary>Per-target quality grade (stability, jitter, loss, congestion).</summary>
+    /// <summary>Per-hop quality grade (stability, jitter, loss, congestion, intra-ASN reach).</summary>
     public int? OverallScore { get; init; }
+
+    /// <summary>RTT beyond this ASN's nearest hop (0 for the nearest). Drives the soft reach ceiling.</summary>
+    public double? ReachDeltaMs { get; init; }
 
     /// <summary>True for the first clean hop, the target the access layer idle latency comes from.</summary>
     public bool IsGradedHop { get; init; }
@@ -242,6 +245,15 @@ public class AsnSeries
     /// graded hop); on transit it equals the graded cluster. Display only.
     /// </summary>
     public double? NearestClusterMeanRttMs { get; init; }
+
+    /// <summary>
+    /// Samples jitter and latency stability are scored from, when they should come from
+    /// a different cluster than <see cref="Samples"/>. Used for transit ASNs with a
+    /// farther cluster: a near hop often shows false jitter from ICMP deprioritization
+    /// that the farther cluster (reached through it) disproves, so jitter is graded on
+    /// the farther cluster while RTT and reach stay on the nearest. Empty means use Samples.
+    /// </summary>
+    public List<LatencySample> JitterSourceSamples { get; init; } = new();
 
     /// <summary>
     /// On a grading series, all of this ASN-role's target IDs (every hop, every

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -115,7 +115,9 @@ public class IspTargetHealth
 {
     public required string TargetId { get; init; }
     public required string Name { get; init; }
-    public double? MedianRttMs { get; init; }
+
+    /// <summary>Displayed RTT: winsorized mean over the window.</summary>
+    public double? RttMs { get; init; }
     public double? P95JitterMs { get; init; }
     public double? LossPct { get; init; }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -162,6 +162,20 @@ public class IspHealthOptions
 
     /// <summary>Weight of congestion in the per-ASN quality blend.</summary>
     public double AsnCongestionWeight { get; set; } = 0.3;
+
+    /// <summary>
+    /// Lower clamp for the path jitter floor used in floor-relative jitter scoring.
+    /// Below this, ratio scoring would punish sub-millisecond jitter that is excellent
+    /// in absolute terms, so the floor never reads below this value.
+    /// </summary>
+    public double JitterFloorMinMs { get; set; } = 0.3;
+
+    /// <summary>
+    /// Upper clamp for the path jitter floor. Above this the line is jittery
+    /// everywhere; the absolute high-end anchors take over rather than letting a high
+    /// floor excuse genuinely bad jitter.
+    /// </summary>
+    public double JitterFloorMaxMs { get; set; } = 1.5;
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -178,6 +178,13 @@ public class IspHealthOptions
     public double JitterFloorMaxMs { get; set; } = 1.5;
 
     /// <summary>
+    /// Minimum amount a cleaner witness must sit below a hop's own jitter before it counts as
+    /// assimilated. Within this band the difference is measurement noise, so the hop keeps its
+    /// own jitter (no absolve, no assimilation icon). Applies to ISP hops and transit ASNs.
+    /// </summary>
+    public double JitterAssimilationMinDeltaMs { get; set; } = 0.05;
+
+    /// <summary>
     /// Average WAN load at which packet loss reaches its worst on shared-medium access
     /// (DOCSIS, PON, fixed wireless). The load-calibrated loss ceiling reaches the
     /// connection's loaded-loss band at this utilization and holds there above it, rather

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -184,6 +184,13 @@ public class IspHealthOptions
     /// than only at 100%.
     /// </summary>
     public double LossSaturationLoadFraction { get; set; } = 0.75;
+
+    /// <summary>
+    /// Upper percentile at which displayed RTT is winsorized: samples above it are capped
+    /// to it before averaging, so a route flap or single bad probe can't distort the mean
+    /// while sustained elevation still shows. 0.99 caps only the worst 1%.
+    /// </summary>
+    public double RttWinsorPercentile { get; set; } = 0.99;
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -176,6 +176,14 @@ public class IspHealthOptions
     /// floor excuse genuinely bad jitter.
     /// </summary>
     public double JitterFloorMaxMs { get; set; } = 1.5;
+
+    /// <summary>
+    /// Average WAN load at which packet loss reaches its worst on shared-medium access
+    /// (DOCSIS, PON, fixed wireless). The load-calibrated loss ceiling reaches the
+    /// connection's loaded-loss band at this utilization and holds there above it, rather
+    /// than only at 100%.
+    /// </summary>
+    public double LossSaturationLoadFraction { get; set; } = 0.75;
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using Microsoft.Extensions.Logging;
 
 namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
 
@@ -299,7 +298,7 @@ public class IspHealthScorer
             Score = (int)Math.Round(score),
             Weight = _options.IdleLatencyWeight,
             ValueText = FormatMs(idleBaseline.Value),
-            Description = $"Idle latency to the first ISP hop vs the {FormatMs(profile.IdleRttNormalLowMs)} to {FormatMs(profile.IdleRttNormalHighMs)} normal band for {profile.DisplayName}."
+            Description = $"Idle latency to the first ISP hop vs the {FormatMsBand(profile.IdleRttNormalLowMs)} to {FormatMsBand(profile.IdleRttNormalHighMs)} normal band for {profile.DisplayName}."
         };
     }
 
@@ -400,7 +399,7 @@ public class IspHealthScorer
             Score = (int)Math.Round(scores.Average()),
             Weight = _options.LoadedLatencyWeight,
             ValueText = string.Join(", ", parts),
-            Description = $"Latency increase under load vs +{FormatMs(profile.LoadedDeltaExcellentMs)} excellent and +{FormatMs(profile.LoadedDeltaAcceptableMs)} acceptable for {profile.DisplayName}.{source}"
+            Description = $"Latency increase under load vs +{FormatMsBand(profile.LoadedDeltaExcellentMs)} excellent and +{FormatMsBand(profile.LoadedDeltaAcceptableMs)} acceptable for {profile.DisplayName}.{source}"
         }, true);
     }
 
@@ -1072,6 +1071,10 @@ public class IspHealthScorer
 
     private static string FormatMs(double ms) =>
         $"{ms.ToString("0.00", CultureInfo.InvariantCulture)} ms";
+
+    /// <summary>Threshold/band references in descriptions: drop trailing zeros (2 ms, not 2.00 ms).</summary>
+    private static string FormatMsBand(double ms) =>
+        $"{ms.ToString("0.##", CultureInfo.InvariantCulture)} ms";
 
     /// <summary>Debug-log helper: a millisecond value to two decimals, or "n/a" when null.</summary>
     private static string FormatMsOrNull(double? ms) =>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -1071,7 +1071,7 @@ public class IspHealthScorer
         CongestionDetector.FloorTime(time, TimeSpan.FromSeconds(_options.LoadWindowSeconds));
 
     private static string FormatMs(double ms) =>
-        ms >= 10 ? $"{ms.ToString("0", CultureInfo.InvariantCulture)} ms" : $"{ms.ToString("0.0", CultureInfo.InvariantCulture)} ms";
+        $"{ms.ToString("0.00", CultureInfo.InvariantCulture)} ms";
 
     /// <summary>Debug-log helper: a millisecond value to two decimals, or "n/a" when null.</summary>
     private static string FormatMsOrNull(double? ms) =>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -72,7 +72,7 @@ public class IspHealthScorer
             IspAsnDimension = ispAsnDimension,
             TransitAsns = transitAsns,
             IspAsns = ispAsns,
-            IspTargets = inputs.IspTargetSeries.Select(s => BuildIspTargetHealth(s, inputs.FirstHopTargetId, ispHopGrades)).ToList(),
+            IspTargets = inputs.IspTargetSeries.Select(s => BuildIspTargetHealth(s, inputs.FirstHopTargetId, ispHopGrades, _options.RttWinsorPercentile)).ToList(),
             CongestionEvents = inputs.CongestionEvents,
             PathShifts = inputs.PathShifts,
             HasExpectedSpeeds = hasExpectedSpeeds,
@@ -659,9 +659,9 @@ public class IspHealthScorer
             AsnName = series.AsnName,
             TargetIds = series.TargetIds,
             MedianRttMs = medianRtt,
-            // Display: mean across the full nearest cluster (set on the grading series);
-            // falls back to the graded samples' mean when not provided
-            MeanRttMs = series.NearestClusterMeanRttMs ?? (rtts.Count > 0 ? rtts.Average() : null),
+            // Displayed RTT: winsorized mean (P99-capped) so sustained elevation shows but a
+            // flap can't distort it. Reach (above) stays on the median - that measures distance.
+            MeanRttMs = SeriesStats.WinsorizedMean(rtts, _options.RttWinsorPercentile),
             P95RttMs = SeriesStats.Percentile(rtts, 0.95),
             // Raw near-cluster median, informational only. The displayed and scored jitter
             // is the effective (absolve/assimilated) value below.
@@ -874,8 +874,9 @@ public class IspHealthScorer
                 TargetIds = targetIds,
                 MedianRttMs = medianRtts.Count > 0 ? medianRtts.Min() : null,
                 MeanRttMs = means.Count > 0 ? means.Average() : null,
-                MinRttMs = medianRtts.Count > 0 ? medianRtts.Min() : null,
-                MaxRttMs = medianRtts.Count > 0 ? medianRtts.Max() : null,
+                // RTT range across the ISP hops, on the same winsorized mean the hops display.
+                MinRttMs = means.Count > 0 ? means.Min() : null,
+                MaxRttMs = means.Count > 0 ? means.Max() : null,
                 P95JitterMs = effMean,
                 LossPct = lossVals.Count > 0 ? lossVals.Average() : null,
                 OverallScore = scored.Count > 0 ? (int)Math.Round(scored.Average()) : null,
@@ -887,7 +888,7 @@ public class IspHealthScorer
         return result;
     }
 
-    private static IspTargetHealth BuildIspTargetHealth(AsnSeries series, string? firstHopTargetId, List<IspAsnHealth> hopGrades)
+    private static IspTargetHealth BuildIspTargetHealth(AsnSeries series, string? firstHopTargetId, List<IspAsnHealth> hopGrades, double winsorPercentile)
     {
         var rtts = series.Samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
         var jitters = series.Samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
@@ -898,7 +899,7 @@ public class IspHealthScorer
         {
             TargetId = targetId,
             Name = series.AsnName ?? targetId,
-            MedianRttMs = SeriesStats.Median(rtts),
+            RttMs = SeriesStats.WinsorizedMean(rtts, winsorPercentile),
             P95JitterMs = jitters.Count > 0 ? SeriesStats.Percentile(jitters, 0.95) : null,
             LossPct = losses.Count > 0 ? losses.Average() : null,
             OverallScore = grade?.OverallScore,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -76,6 +76,7 @@ public class IspHealthScorer
             CongestionEvents = inputs.CongestionEvents,
             PathShifts = inputs.PathShifts,
             HasExpectedSpeeds = hasExpectedSpeeds,
+            HasUpstreamTraceMap = inputs.HopOrderKnown,
             HasLoadedSamples = hasLoadedLatency || hasLoadedLoss,
             ExpectedDownloadMbps = inputs.ExpectedDownloadMbps,
             ExpectedUploadMbps = inputs.ExpectedUploadMbps,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -912,12 +912,17 @@ public class IspHealthScorer
         var losses = series.Samples.Where(s => s.LossPercent.HasValue).Select(s => s.LossPercent!.Value).ToList();
         var targetId = series.TargetIds.FirstOrDefault() ?? "";
         var grade = hopGrades.FirstOrDefault(g => g.TargetIds.Contains(targetId));
+        // Jitter comes from the grade (the effective/absolved value the hop is scored on), so
+        // the row matches the grade beside it. Fall back to the hop's own raw P95 when ungraded.
+        var rawP95 = jitters.Count > 0 ? SeriesStats.Percentile(jitters, 0.95) : null;
         return new IspTargetHealth
         {
             TargetId = targetId,
             Name = series.AsnName ?? targetId,
             RttMs = SeriesStats.WinsorizedMean(rtts, winsorPercentile),
-            P95JitterMs = jitters.Count > 0 ? SeriesStats.Percentile(jitters, 0.95) : null,
+            P95JitterMs = grade?.P95JitterMs ?? rawP95,
+            RawJitterMs = grade?.RawJitterMs ?? rawP95,
+            JitterAssimilated = grade?.JitterAssimilated ?? false,
             LossPct = losses.Count > 0 ? losses.Average() : null,
             OverallScore = grade?.OverallScore,
             ReachDeltaMs = grade?.ReachDeltaMs,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -523,15 +523,15 @@ public class IspHealthScorer
         // its own problem further along the path and must not downgrade the nearer cluster.
         // An ISP hop instead takes the ISP-wide jitter bound (jitterOverrideMs), which is
         // already capped by the cleanest transit ASN.
-        var medianJitter = jitterOverrideMs ?? EffectiveLower(series.Samples, series.JitterSourceSamples, MedianJitterOf);
+        var effectiveJitter = jitterOverrideMs ?? EffectiveLower(series.Samples, series.JitterSourceSamples, ScoringJitterOf);
         var stabilityRatio = EffectiveLower(series.Samples, series.JitterSourceSamples, StabilityRatioOf);
 
         if (jitterOverrideMs == null && series.JitterSourceSamples.Count > 0)
         {
             _logger?.LogDebug(
                 "ISP Health: AS{Asn} ({Name}) jitter absolve - near {Near} ms, farther cluster {Far} ms, effective {Eff} ms",
-                series.AsnNumber, series.AsnName, FormatMsOrNull(MedianJitterOf(series.Samples)),
-                FormatMsOrNull(MedianJitterOf(series.JitterSourceSamples)), FormatMsOrNull(medianJitter));
+                series.AsnNumber, series.AsnName, FormatMsOrNull(ScoringJitterOf(series.Samples)),
+                FormatMsOrNull(ScoringJitterOf(series.JitterSourceSamples)), FormatMsOrNull(effectiveJitter));
         }
 
         int? stabilityScore = stabilityRatio.HasValue
@@ -539,8 +539,8 @@ public class IspHealthScorer
                 (0.02, 100), (0.10, 80), (0.25, 55), (0.5, 25), (1.0, 0)))
             : null;
 
-        int? jitterScore = medianJitter.HasValue
-            ? (int)Math.Round(ScoreJitterVsFloor(medianJitter.Value, jitterFloorMs))
+        int? jitterScore = effectiveJitter.HasValue
+            ? (int)Math.Round(ScoreJitterVsFloor(effectiveJitter.Value, jitterFloorMs))
             : null;
 
         // Reach ceiling: the best grade this hop's distance allows.
@@ -623,8 +623,13 @@ public class IspHealthScorer
             // falls back to the graded samples' mean when not provided
             MeanRttMs = series.NearestClusterMeanRttMs ?? (rtts.Count > 0 ? rtts.Average() : null),
             P95RttMs = SeriesStats.Percentile(rtts, 0.95),
-            MedianJitterMs = medianJitter,
-            P95JitterMs = jitters.Count > 0 ? SeriesStats.Percentile(jitters, 0.95) : null,
+            // Raw near-cluster median, informational only. The displayed and scored jitter
+            // is the effective (absolve/assimilated) value below.
+            MedianJitterMs = jitters.Count > 0 ? SeriesStats.Median(jitters) : null,
+            // The effective jitter: absolve-only across clusters (transit) or the ISP-wide
+            // bound (ISP). This is what the card shows and what the ISP cap reads, so the
+            // displayed value reflects the assimilation rather than the raw near hop.
+            P95JitterMs = effectiveJitter,
             RttMadMs = mad,
             LossPct = losses.Count > 0 ? losses.Average() : null,
             ReachDeltaMs = reachDelta,
@@ -638,14 +643,14 @@ public class IspHealthScorer
         };
     }
 
-    /// <summary>The path jitter floor: the lowest median jitter across all ISP hops and
-    /// transit clusters. Null when no series carries jitter.</summary>
+    /// <summary>The path jitter floor: the lowest scoring (P95) jitter across all ISP hops
+    /// and transit clusters. Null when no series carries jitter.</summary>
     private double? ComputeJitterFloor(IspHealthInputs inputs)
     {
         var medians = new List<double>();
         void Add(IReadOnlyList<LatencySample> samples)
         {
-            var m = MedianJitterOf(samples);
+            var m = ScoringJitterOf(samples);
             if (m.HasValue) medians.Add(m.Value);
         }
         foreach (var s in inputs.IspAsnSeries) Add(s.Samples);
@@ -657,11 +662,16 @@ public class IspHealthScorer
         return medians.Count > 0 ? medians.Min() : null;
     }
 
-    /// <summary>Median effective jitter of a sample set, or null when none reported jitter.</summary>
-    private static double? MedianJitterOf(IReadOnlyList<LatencySample> samples)
+    /// <summary>
+    /// The jitter statistic used for scoring, the ISP/transit cap, and the cards: P95 of
+    /// the effective jitter. P95 (not median) because the tail is what the cards show and
+    /// what users reason about, and what hurts real-time traffic. The ISP and transit
+    /// jitter shown and scored are the same value. Null when none reported jitter.
+    /// </summary>
+    private static double? ScoringJitterOf(IReadOnlyList<LatencySample> samples)
     {
         var js = samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
-        return js.Count > 0 ? SeriesStats.Median(js) : null;
+        return js.Count > 0 ? SeriesStats.Percentile(js, 0.95) : null;
     }
 
     /// <summary>RTT stability ratio (MAD / median) of a sample set; lower is steadier. Null without RTT.</summary>
@@ -727,7 +737,7 @@ public class IspHealthScorer
                     intraAsnFloorRttMs: intraFloor, jitterOverrideMs: effectiveIspJitterMs);
                 _logger?.LogDebug(
                     "ISP Health: ISP hop {Target} (AS{Asn}) graded {Score} - measured jitter {Jitter} ms, ISP-wide jitter {Eff} ms, reach +{Reach} ms",
-                    hop.TargetIds.FirstOrDefault(), hop.AsnNumber, grade.OverallScore, FormatMsOrNull(MedianJitterOf(hop.Samples)),
+                    hop.TargetIds.FirstOrDefault(), hop.AsnNumber, grade.OverallScore, FormatMsOrNull(ScoringJitterOf(hop.Samples)),
                     FormatMsOrNull(effectiveIspJitterMs), FormatMsOrNull(grade.ReachDeltaMs));
                 grades.Add(grade);
             }
@@ -739,14 +749,17 @@ public class IspHealthScorer
     /// Effective ISP jitter: the lower of the ISP targets' mean jitter and the cleanest
     /// transit ASN's jitter. Transit is reached through the ISP, so a clean transit ASN
     /// bounds how jittery the ISP path can really be; the ISP targets' own jitter is often
-    /// inflated by ICMP deprioritization. Null when nothing reported jitter.
+    /// inflated by ICMP deprioritization. Unconditional - whenever the transit floor is
+    /// lower than the ISP mean, it wins, for both score and display. Null when nothing
+    /// reported jitter.
     /// </summary>
     private double? ComputeEffectiveIspJitter(List<AsnSeries> ispHopSeries, List<IspAsnHealth> transitAsns)
     {
-        var ispJitters = ispHopSeries.Select(s => MedianJitterOf(s.Samples)).Where(j => j.HasValue).Select(j => j!.Value).ToList();
+        var ispJitters = ispHopSeries.Select(s => ScoringJitterOf(s.Samples)).Where(j => j.HasValue).Select(j => j!.Value).ToList();
         double? meanIsp = ispJitters.Count > 0 ? ispJitters.Average() : null;
 
-        var transitJitters = transitAsns.Select(a => a.MedianJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
+        // Transit P95JitterMs is each ASN's effective (absolve-only) jitter.
+        var transitJitters = transitAsns.Select(a => a.P95JitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
         double? minTransit = transitJitters.Count > 0 ? transitJitters.Min() : null;
 
         double? effective = meanIsp;
@@ -787,8 +800,9 @@ public class IspHealthScorer
                 TargetIds = targetIds,
                 MedianRttMs = medianRtts.Count > 0 ? medianRtts.Min() : null,
                 MeanRttMs = means.Count > 0 ? means.Average() : null,
-                // Mean of the hops' jitter, not the worst: ISP hops are routinely
-                // ICMP-deprioritized, so a single hop's high jitter is not the ASN's jitter.
+                // The effective ISP jitter: every ISP hop grade carries the same ISP-wide
+                // value (mean ISP jitter capped by the cleanest transit ASN), so this is
+                // that assimilated value - not the worst hop's raw jitter.
                 P95JitterMs = jitters.Count > 0 ? jitters.Average() : null,
                 LossPct = lossVals.Count > 0 ? lossVals.Average() : null,
                 OverallScore = scored.Count > 0 ? (int)Math.Round(scored.Average()) : null,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -47,19 +47,14 @@ public class IspHealthScorer
 
         var transitAsns = inputs.TransitAsnSeries.Select(s => GradeAsn(s, inputs.CongestionEvents, jitterFloor, accessMedianRtt, inputs.InternetMedianDeltaMs)).ToList();
 
-        // ISP jitter is bounded by the cleanest transit ASN. Transit sits beyond the ISP
-        // and is reached through it, so a clean transit ASN proves the ISP path is at least
-        // that steady - the ISP's own per-hop jitter is routinely inflated by ICMP
-        // deprioritization and cannot be trusted above that bound. Effective ISP jitter =
-        // min(mean of the ISP targets' jitter, lowest transit ASN jitter).
-        var ispJitter = ComputeEffectiveIspJitter(inputs.IspAsnSeries, transitAsns);
-
-        // Every ISP hop is graded; the dimension averages them all. Hops further out on
-        // the same ISP get a soft intra-ASN reach ceiling (distance is "fine but not
-        // perfect", not a fault). The access layer idle latency still uses FirstHopSeries.
-        var ispHopGrades = GradeIspHops(inputs.IspAsnSeries, inputs.CongestionEvents, jitterFloor, ispJitter.Effective);
+        // Every ISP hop is graded; the dimension averages them all. Each hop's jitter is
+        // absolved per-hop and routes-through-gated (a transit ASN or deeper ISP hop only
+        // absolves a hop it is proven downstream of), so a divergent clean transit can't
+        // clear a congested hop it never traverses. Hops further out on the same ISP also
+        // get a soft intra-ASN reach ceiling. Access layer idle latency still uses FirstHopSeries.
+        var ispHopGrades = GradeIspHops(inputs.IspAsnSeries, inputs.TransitAsnSeries, transitAsns, inputs.CongestionEvents, jitterFloor);
         // Collapse the per-hop grades to one entry per ASN for the Networks on Your Path card.
-        var ispAsns = AggregateIspAsns(ispHopGrades, inputs.CongestionEvents, ispJitter);
+        var ispAsns = AggregateIspAsns(ispHopGrades, inputs.CongestionEvents);
         var transitDimension = BuildAsnDimension("Transit Health", _options.TransitWeight, transitAsns);
         var ispAsnDimension = BuildIspDimension(_options.IspAsnWeight, ispHopGrades);
 
@@ -565,10 +560,10 @@ public class IspHealthScorer
         var effectiveJitter = jitterOverrideMs ?? EffectiveLower(series.Samples, series.JitterSourceSamples, ScoringJitterOf);
         var stabilityRatio = EffectiveLower(series.Samples, series.JitterSourceSamples, StabilityRatioOf);
 
-        // Transit assimilation: a farther cluster pulled this ASN's jitter below its own
-        // nearest reading. (ISP hops carry an override; their assimilation is flagged on
-        // the aggregate, not per hop.)
-        var jitterAssimilated = jitterOverrideMs == null && effectiveJitter.HasValue
+        // Assimilated when a witness (a farther transit cluster, or - for an ISP hop via
+        // the override - a downstream transit/deeper ISP hop) pulled this jitter below the
+        // series' own nearest reading.
+        var jitterAssimilated = effectiveJitter.HasValue
             && nearJitter.HasValue && effectiveJitter.Value < nearJitter.Value - 0.001;
 
         if (jitterOverrideMs == null && series.JitterSourceSamples.Count > 0)
@@ -761,12 +756,36 @@ public class IspHealthScorer
     }
 
     /// <summary>
-    /// Grades every ISP hop. Hops are grouped by ASN so each can be scored against its
-    /// ISP's nearest-hop RTT (the intra-ASN reach floor): a second POP further out is
-    /// nominal distance, not a fault, so it gets a soft ceiling rather than a perfect score.
+    /// Grades every ISP hop. Each hop's jitter is absolved per-hop, routes-through-gated: a
+    /// witness (a transit ASN or a deeper ISP hop) may only pull a hop's jitter down when its
+    /// stored hop number proves it sits downstream of that hop on the WAN's common trace, so
+    /// a divergent clean transit can never clear a congested hop it does not traverse. When a
+    /// hop has no stored hop number (no re-discovery yet) the gate is open - every witness
+    /// applies - which reproduces the prior ISP-wide cap. Hops are also scored against the
+    /// intra-ASN reach floor (a second POP further out is nominal distance, not a fault).
     /// </summary>
-    private List<IspAsnHealth> GradeIspHops(List<AsnSeries> ispHopSeries, List<CongestionEvent> congestionEvents, double? jitterFloorMs, double? effectiveIspJitterMs)
+    private List<IspAsnHealth> GradeIspHops(
+        List<AsnSeries> ispHopSeries,
+        List<AsnSeries> transitSeries,
+        List<IspAsnHealth> transitAsns,
+        List<CongestionEvent> congestionEvents,
+        double? jitterFloorMs)
     {
+        // Transit witnesses: each transit ASN's nearest hop number + its effective jitter.
+        var transitJitterByAsn = transitAsns
+            .Where(a => a.P95JitterMs.HasValue)
+            .GroupBy(a => a.AsnNumber)
+            .ToDictionary(g => g.Key, g => g.Min(a => a.P95JitterMs!.Value));
+        var transitWitnesses = transitSeries
+            .Where(s => transitJitterByAsn.ContainsKey(s.AsnNumber))
+            .Select(s => (Hop: s.MinHopNumber, Jitter: transitJitterByAsn[s.AsnNumber]))
+            .ToList();
+
+        // ISP hop witnesses: each hop's number + its own measured jitter.
+        var ispHopJitter = ispHopSeries
+            .Select(s => (Series: s, Hop: s.MinHopNumber, Jitter: ScoringJitterOf(s.Samples)))
+            .ToList();
+
         var grades = new List<IspAsnHealth>();
         foreach (var asnGroup in ispHopSeries.GroupBy(s => s.AsnNumber))
         {
@@ -780,12 +799,31 @@ public class IspHealthScorer
             double? intraFloor = hops.Any(s => s.Samples.Any(x => x.RttAvgMs.HasValue)) ? floorRtt : null;
             foreach (var hop in hops)
             {
+                var measured = ScoringJitterOf(hop.Samples);
+                // Transit witnesses: transit is always downstream of the ISP, so it may
+                // absolve an ISP hop unless hop order proves it does NOT route through it
+                // (open when there's no stored order - the prior behavior; gated to a true
+                // routes-through once hop numbers exist). ISP-sibling witnesses are strict:
+                // a sibling absolves only a hop it is PROVEN downstream of, since without
+                // hop order we can't tell which sibling is nearer.
+                var witnesses = transitWitnesses
+                    .Where(w => RoutesThrough(w.Hop, hop.MinHopNumber))
+                    .Select(w => w.Jitter)
+                    .Concat(ispHopJitter
+                        .Where(h => !ReferenceEquals(h.Series, hop) && h.Jitter.HasValue
+                            && h.Hop.HasValue && hop.MinHopNumber.HasValue && h.Hop.Value > hop.MinHopNumber.Value)
+                        .Select(h => h.Jitter!.Value))
+                    .ToList();
+                double? effective = measured;
+                if (witnesses.Count > 0)
+                    effective = measured.HasValue ? Math.Min(measured.Value, witnesses.Min()) : witnesses.Min();
+
                 var grade = GradeAsn(hop, congestionEvents, jitterFloorMs, accessBaselineRtt: null, internetMedianDeltaMs: null,
-                    intraAsnFloorRttMs: intraFloor, jitterOverrideMs: effectiveIspJitterMs);
+                    intraAsnFloorRttMs: intraFloor, jitterOverrideMs: effective);
                 _logger?.LogDebug(
-                    "ISP Health: ISP hop {Target} (AS{Asn}) graded {Score} - measured jitter {Jitter} ms, ISP-wide jitter {Eff} ms, reach +{Reach} ms",
-                    hop.TargetIds.FirstOrDefault(), hop.AsnNumber, grade.OverallScore, FormatMsOrNull(ScoringJitterOf(hop.Samples)),
-                    FormatMsOrNull(effectiveIspJitterMs), FormatMsOrNull(grade.ReachDeltaMs));
+                    "ISP Health: ISP hop {Target} (AS{Asn}) hop#{Hop} graded {Score} - measured jitter {Jitter} ms, effective {Eff} ms ({Witnesses} routes-through witnesses), reach +{Reach} ms",
+                    hop.TargetIds.FirstOrDefault(), hop.AsnNumber, hop.MinHopNumber, grade.OverallScore,
+                    FormatMsOrNull(measured), FormatMsOrNull(effective), witnesses.Count, FormatMsOrNull(grade.ReachDeltaMs));
                 grades.Add(grade);
             }
         }
@@ -793,44 +831,20 @@ public class IspHealthScorer
     }
 
     /// <summary>
-    /// Effective ISP jitter: the lower of the ISP targets' mean jitter and the cleanest
-    /// transit ASN's jitter. Transit is reached through the ISP, so a clean transit ASN
-    /// bounds how jittery the ISP path can really be; the ISP targets' own jitter is often
-    /// inflated by ICMP deprioritization. Unconditional - whenever the transit floor is
-    /// lower than the ISP mean, it wins, for both score and display. Null when nothing
-    /// reported jitter.
+    /// Whether a witness routes through a hop (and so may absolve it): the witness's hop
+    /// number must be strictly greater (downstream) than the hop's. When the hop has no
+    /// stored hop number the gate is open (reproduces the ungated prior behavior); when the
+    /// witness has none it cannot be proven downstream, so it is excluded.
     /// </summary>
-    /// <summary>Effective ISP jitter plus the inputs it came from, for the card's assimilation note.</summary>
-    internal record IspJitter(double? Effective, double? MeanIsp, double? MinTransit)
-    {
-        /// <summary>True when the cleanest transit ASN pulled the ISP jitter below the ISP's own mean.</summary>
-        public bool Assimilated => MinTransit.HasValue && MeanIsp.HasValue && MinTransit.Value < MeanIsp.Value - 0.001;
-    }
-
-    private IspJitter ComputeEffectiveIspJitter(List<AsnSeries> ispHopSeries, List<IspAsnHealth> transitAsns)
-    {
-        var ispJitters = ispHopSeries.Select(s => ScoringJitterOf(s.Samples)).Where(j => j.HasValue).Select(j => j!.Value).ToList();
-        double? meanIsp = ispJitters.Count > 0 ? ispJitters.Average() : null;
-
-        // Transit P95JitterMs is each ASN's effective (absolve-only) jitter.
-        var transitJitters = transitAsns.Select(a => a.P95JitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
-        double? minTransit = transitJitters.Count > 0 ? transitJitters.Min() : null;
-
-        double? effective = meanIsp;
-        if (minTransit.HasValue)
-            effective = effective.HasValue ? Math.Min(effective.Value, minTransit.Value) : minTransit;
-
-        _logger?.LogDebug("ISP Health: effective ISP jitter {Eff} ms (mean ISP {Mean} ms, cleanest transit {Transit} ms)",
-            FormatMsOrNull(effective), FormatMsOrNull(meanIsp), FormatMsOrNull(minTransit));
-        return new IspJitter(effective, meanIsp, minTransit);
-    }
+    private static bool RoutesThrough(int? witnessHop, int? throughHop) =>
+        throughHop == null ? true : (witnessHop.HasValue && witnessHop.Value > throughHop.Value);
 
     /// <summary>
     /// Collapses per-hop ISP grades to one entry per ASN for the Networks on Your Path
     /// card: mean RTT and jitter across the hops, averaged grade, and the union of the
     /// ASN's congestion events.
     /// </summary>
-    private static List<IspAsnHealth> AggregateIspAsns(List<IspAsnHealth> hopGrades, List<CongestionEvent> congestionEvents, IspJitter ispJitter)
+    private static List<IspAsnHealth> AggregateIspAsns(List<IspAsnHealth> hopGrades, List<CongestionEvent> congestionEvents)
     {
         var result = new List<IspAsnHealth>();
         foreach (var group in hopGrades.GroupBy(h => h.AsnNumber))
@@ -843,7 +857,13 @@ public class IspHealthScorer
                     && (e.TargetIds.Count == 0 || e.TargetIds.Any(t => targetSet.Contains(t))))
                 .ToList();
             var means = hops.Select(h => h.MeanRttMs).Where(m => m.HasValue).Select(m => m!.Value).ToList();
-            var jitters = hops.Select(h => h.P95JitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
+            // Each hop's P95JitterMs is its per-hop effective (absolved) jitter; RawJitterMs
+            // is its own measured reading. The card shows the mean effective and flags
+            // assimilation when that fell below the mean measured.
+            var effJitters = hops.Select(h => h.P95JitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
+            var rawJitters = hops.Select(h => h.RawJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
+            double? effMean = effJitters.Count > 0 ? effJitters.Average() : null;
+            double? rawMean = rawJitters.Count > 0 ? rawJitters.Average() : null;
             var lossVals = hops.Select(h => h.LossPct).Where(l => l.HasValue).Select(l => l!.Value).ToList();
             var medianRtts = hops.Select(h => h.MedianRttMs).Where(m => m.HasValue).Select(m => m!.Value).ToList();
             var scored = hops.Where(h => h.OverallScore.HasValue).Select(h => h.OverallScore!.Value).ToList();
@@ -856,17 +876,12 @@ public class IspHealthScorer
                 MeanRttMs = means.Count > 0 ? means.Average() : null,
                 MinRttMs = medianRtts.Count > 0 ? medianRtts.Min() : null,
                 MaxRttMs = medianRtts.Count > 0 ? medianRtts.Max() : null,
-                // The effective ISP jitter: every ISP hop grade carries the same ISP-wide
-                // value (mean ISP jitter capped by the cleanest transit ASN), so this is
-                // that assimilated value - not the worst hop's raw jitter.
-                P95JitterMs = jitters.Count > 0 ? jitters.Average() : null,
+                P95JitterMs = effMean,
                 LossPct = lossVals.Count > 0 ? lossVals.Average() : null,
                 OverallScore = scored.Count > 0 ? (int)Math.Round(scored.Average()) : null,
                 CongestionEventCount = asnEvents.Count,
-                // The ISP jitter is assimilated when the cleanest transit ASN capped it
-                // below the ISP's own mean; show that with the raw ISP mean for the tooltip.
-                JitterAssimilated = ispJitter.Assimilated,
-                RawJitterMs = ispJitter.MeanIsp
+                JitterAssimilated = effMean.HasValue && rawMean.HasValue && effMean.Value < rawMean.Value - 0.001,
+                RawJitterMs = rawMean
             });
         }
         return result;
@@ -921,7 +936,7 @@ public class IspHealthScorer
             Name = string.IsNullOrEmpty(a.AsnName) ? $"AS{a.AsnNumber}" : a.AsnName,
             Score = a.OverallScore,
             Weight = 1.0,
-            ValueText = a.MedianRttMs.HasValue ? FormatMsCoarse(a.MedianRttMs.Value) : null,
+            ValueText = a.MeanRttMs.HasValue ? FormatMsCoarse(a.MeanRttMs.Value) : null,
             Description = a.CongestionEventCount > 0
                 ? $"{a.CongestionEventCount} congestion event{(a.CongestionEventCount == 1 ? "" : "s")} in the window."
                 : null

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -52,14 +52,14 @@ public class IspHealthScorer
         // that steady - the ISP's own per-hop jitter is routinely inflated by ICMP
         // deprioritization and cannot be trusted above that bound. Effective ISP jitter =
         // min(mean of the ISP targets' jitter, lowest transit ASN jitter).
-        var effectiveIspJitter = ComputeEffectiveIspJitter(inputs.IspAsnSeries, transitAsns);
+        var ispJitter = ComputeEffectiveIspJitter(inputs.IspAsnSeries, transitAsns);
 
         // Every ISP hop is graded; the dimension averages them all. Hops further out on
         // the same ISP get a soft intra-ASN reach ceiling (distance is "fine but not
         // perfect", not a fault). The access layer idle latency still uses FirstHopSeries.
-        var ispHopGrades = GradeIspHops(inputs.IspAsnSeries, inputs.CongestionEvents, jitterFloor, effectiveIspJitter);
+        var ispHopGrades = GradeIspHops(inputs.IspAsnSeries, inputs.CongestionEvents, jitterFloor, ispJitter.Effective);
         // Collapse the per-hop grades to one entry per ASN for the Networks on Your Path card.
-        var ispAsns = AggregateIspAsns(ispHopGrades, inputs.CongestionEvents);
+        var ispAsns = AggregateIspAsns(ispHopGrades, inputs.CongestionEvents, ispJitter);
         var transitDimension = BuildAsnDimension("Transit Health", _options.TransitWeight, transitAsns);
         var ispAsnDimension = BuildIspDimension(_options.IspAsnWeight, ispHopGrades);
 
@@ -523,8 +523,15 @@ public class IspHealthScorer
         // its own problem further along the path and must not downgrade the nearer cluster.
         // An ISP hop instead takes the ISP-wide jitter bound (jitterOverrideMs), which is
         // already capped by the cleanest transit ASN.
+        var nearJitter = ScoringJitterOf(series.Samples);
         var effectiveJitter = jitterOverrideMs ?? EffectiveLower(series.Samples, series.JitterSourceSamples, ScoringJitterOf);
         var stabilityRatio = EffectiveLower(series.Samples, series.JitterSourceSamples, StabilityRatioOf);
+
+        // Transit assimilation: a farther cluster pulled this ASN's jitter below its own
+        // nearest reading. (ISP hops carry an override; their assimilation is flagged on
+        // the aggregate, not per hop.)
+        var jitterAssimilated = jitterOverrideMs == null && effectiveJitter.HasValue
+            && nearJitter.HasValue && effectiveJitter.Value < nearJitter.Value - 0.001;
 
         if (jitterOverrideMs == null && series.JitterSourceSamples.Count > 0)
         {
@@ -639,7 +646,9 @@ public class IspHealthScorer
             ReachLatencyScore = reachCeiling,
             CongestionScore = congestionScore,
             OverallScore = overall,
-            CongestionEventCount = asnEvents.Count
+            CongestionEventCount = asnEvents.Count,
+            JitterAssimilated = jitterAssimilated,
+            RawJitterMs = nearJitter
         };
     }
 
@@ -753,7 +762,14 @@ public class IspHealthScorer
     /// lower than the ISP mean, it wins, for both score and display. Null when nothing
     /// reported jitter.
     /// </summary>
-    private double? ComputeEffectiveIspJitter(List<AsnSeries> ispHopSeries, List<IspAsnHealth> transitAsns)
+    /// <summary>Effective ISP jitter plus the inputs it came from, for the card's assimilation note.</summary>
+    internal record IspJitter(double? Effective, double? MeanIsp, double? MinTransit)
+    {
+        /// <summary>True when the cleanest transit ASN pulled the ISP jitter below the ISP's own mean.</summary>
+        public bool Assimilated => MinTransit.HasValue && MeanIsp.HasValue && MinTransit.Value < MeanIsp.Value - 0.001;
+    }
+
+    private IspJitter ComputeEffectiveIspJitter(List<AsnSeries> ispHopSeries, List<IspAsnHealth> transitAsns)
     {
         var ispJitters = ispHopSeries.Select(s => ScoringJitterOf(s.Samples)).Where(j => j.HasValue).Select(j => j!.Value).ToList();
         double? meanIsp = ispJitters.Count > 0 ? ispJitters.Average() : null;
@@ -768,7 +784,7 @@ public class IspHealthScorer
 
         _logger?.LogDebug("ISP Health: effective ISP jitter {Eff} ms (mean ISP {Mean} ms, cleanest transit {Transit} ms)",
             FormatMsOrNull(effective), FormatMsOrNull(meanIsp), FormatMsOrNull(minTransit));
-        return effective;
+        return new IspJitter(effective, meanIsp, minTransit);
     }
 
     /// <summary>
@@ -776,7 +792,7 @@ public class IspHealthScorer
     /// card: mean RTT and jitter across the hops, averaged grade, and the union of the
     /// ASN's congestion events.
     /// </summary>
-    private static List<IspAsnHealth> AggregateIspAsns(List<IspAsnHealth> hopGrades, List<CongestionEvent> congestionEvents)
+    private static List<IspAsnHealth> AggregateIspAsns(List<IspAsnHealth> hopGrades, List<CongestionEvent> congestionEvents, IspJitter ispJitter)
     {
         var result = new List<IspAsnHealth>();
         foreach (var group in hopGrades.GroupBy(h => h.AsnNumber))
@@ -808,7 +824,11 @@ public class IspHealthScorer
                 P95JitterMs = jitters.Count > 0 ? jitters.Average() : null,
                 LossPct = lossVals.Count > 0 ? lossVals.Average() : null,
                 OverallScore = scored.Count > 0 ? (int)Math.Round(scored.Average()) : null,
-                CongestionEventCount = asnEvents.Count
+                CongestionEventCount = asnEvents.Count,
+                // The ISP jitter is assimilated when the cleanest transit ASN capped it
+                // below the ISP's own mean; show that with the raw ISP mean for the tooltip.
+                JitterAssimilated = ispJitter.Assimilated,
+                RawJitterMs = ispJitter.MeanIsp
             });
         }
         return result;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -847,10 +847,12 @@ public class IspHealthScorer
 
                 var grade = GradeAsn(hop, congestionEvents, jitterFloorMs, accessBaselineRtt: null, internetMedianDeltaMs: null,
                     intraAsnFloorRttMs: intraFloor, jitterOverrideMs: effective);
+                // Log the graded effective (post sub-0.05 ms assimilation snap in GradeAsn),
+                // not the raw witness min, so the log matches what the hop is actually scored on.
                 _logger?.LogDebug(
                     "ISP Health: ISP hop {Target} (AS{Asn}) graded {Score} - measured jitter {Jitter} ms, effective {Eff} ms ({Witnesses} routes-through witnesses), reach +{Reach} ms",
                     hop.TargetIds.FirstOrDefault(), hop.AsnNumber, grade.OverallScore,
-                    FormatMsOrNull(measured), FormatMsOrNull(effective), witnesses.Count, FormatMsOrNull(grade.ReachDeltaMs));
+                    FormatMsOrNull(measured), FormatMsOrNull(grade.P95JitterMs), witnesses.Count, FormatMsOrNull(grade.ReachDeltaMs));
                 grades.Add(grade);
             }
         }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -52,7 +52,7 @@ public class IspHealthScorer
         // absolves a hop it is proven downstream of), so a divergent clean transit can't
         // clear a congested hop it never traverses. Hops further out on the same ISP also
         // get a soft intra-ASN reach ceiling. Access layer idle latency still uses FirstHopSeries.
-        var ispHopGrades = GradeIspHops(inputs.IspAsnSeries, inputs.TransitAsnSeries, transitAsns, inputs.CongestionEvents, jitterFloor);
+        var ispHopGrades = GradeIspHops(inputs.IspAsnSeries, inputs.TransitAsnSeries, transitAsns, inputs.CongestionEvents, jitterFloor, inputs.HopOrderKnown);
         // Collapse the per-hop grades to one entry per ASN for the Networks on Your Path card.
         var ispAsns = AggregateIspAsns(ispHopGrades, inputs.CongestionEvents);
         var transitDimension = BuildAsnDimension("Transit Health", _options.TransitWeight, transitAsns);
@@ -757,33 +757,34 @@ public class IspHealthScorer
 
     /// <summary>
     /// Grades every ISP hop. Each hop's jitter is absolved per-hop, routes-through-gated: a
-    /// witness (a transit ASN or a deeper ISP hop) may only pull a hop's jitter down when its
-    /// stored hop number proves it sits downstream of that hop on the WAN's common trace, so
-    /// a divergent clean transit can never clear a congested hop it does not traverse. When a
-    /// hop has no stored hop number (no re-discovery yet) the gate is open - every witness
-    /// applies - which reproduces the prior ISP-wide cap. Hops are also scored against the
-    /// intra-ASN reach floor (a second POP further out is nominal distance, not a fault).
+    /// witness (a transit ASN or another ISP hop) may only pull a hop's jitter down when the
+    /// hop is in the witness's ancestor set - proven upstream of it on a shared discovery
+    /// trace - so a divergent clean transit can never clear a congested hop it doesn't
+    /// traverse. When no ancestor data exists (no re-discovery yet) the gate falls open for
+    /// transit (transit is always downstream of the ISP) and stays closed for ISP siblings.
+    /// Hops are also scored against the intra-ASN reach floor (distance, not a fault).
     /// </summary>
     private List<IspAsnHealth> GradeIspHops(
         List<AsnSeries> ispHopSeries,
         List<AsnSeries> transitSeries,
         List<IspAsnHealth> transitAsns,
         List<CongestionEvent> congestionEvents,
-        double? jitterFloorMs)
+        double? jitterFloorMs,
+        bool hopOrderKnown)
     {
-        // Transit witnesses: each transit ASN's nearest hop number + its effective jitter.
+        // Transit witnesses: each transit ASN's ancestor IPs + its effective jitter.
         var transitJitterByAsn = transitAsns
             .Where(a => a.P95JitterMs.HasValue)
             .GroupBy(a => a.AsnNumber)
             .ToDictionary(g => g.Key, g => g.Min(a => a.P95JitterMs!.Value));
         var transitWitnesses = transitSeries
             .Where(s => transitJitterByAsn.ContainsKey(s.AsnNumber))
-            .Select(s => (Hop: s.MinHopNumber, Jitter: transitJitterByAsn[s.AsnNumber]))
+            .Select(s => (Ancestors: s.AncestorIps, Jitter: transitJitterByAsn[s.AsnNumber]))
             .ToList();
 
-        // ISP hop witnesses: each hop's number + its own measured jitter.
+        // ISP hop witnesses: each hop series + its own measured jitter.
         var ispHopJitter = ispHopSeries
-            .Select(s => (Series: s, Hop: s.MinHopNumber, Jitter: ScoringJitterOf(s.Samples)))
+            .Select(s => (Series: s, Jitter: ScoringJitterOf(s.Samples)))
             .ToList();
 
         var grades = new List<IspAsnHealth>();
@@ -800,18 +801,16 @@ public class IspHealthScorer
             foreach (var hop in hops)
             {
                 var measured = ScoringJitterOf(hop.Samples);
-                // Transit witnesses: transit is always downstream of the ISP, so it may
-                // absolve an ISP hop unless hop order proves it does NOT route through it
-                // (open when there's no stored order - the prior behavior; gated to a true
-                // routes-through once hop numbers exist). ISP-sibling witnesses are strict:
-                // a sibling absolves only a hop it is PROVEN downstream of, since without
-                // hop order we can't tell which sibling is nearer.
+                // Transit is always downstream of the ISP: with ancestor data we require a
+                // proven routes-through (this hop is in the transit's ancestor set), without
+                // it the gate is open. ISP siblings are strict either way - a sibling absolves
+                // only a hop in its ancestor set, never on faith.
                 var witnesses = transitWitnesses
-                    .Where(w => RoutesThrough(w.Hop, hop.MinHopNumber))
+                    .Where(w => !hopOrderKnown || RoutesThrough(w.Ancestors, hop.HopIps))
                     .Select(w => w.Jitter)
                     .Concat(ispHopJitter
-                        .Where(h => !ReferenceEquals(h.Series, hop) && h.Jitter.HasValue
-                            && h.Hop.HasValue && hop.MinHopNumber.HasValue && h.Hop.Value > hop.MinHopNumber.Value)
+                        .Where(h => hopOrderKnown && !ReferenceEquals(h.Series, hop) && h.Jitter.HasValue
+                            && RoutesThrough(h.Series.AncestorIps, hop.HopIps))
                         .Select(h => h.Jitter!.Value))
                     .ToList();
                 double? effective = measured;
@@ -821,8 +820,8 @@ public class IspHealthScorer
                 var grade = GradeAsn(hop, congestionEvents, jitterFloorMs, accessBaselineRtt: null, internetMedianDeltaMs: null,
                     intraAsnFloorRttMs: intraFloor, jitterOverrideMs: effective);
                 _logger?.LogDebug(
-                    "ISP Health: ISP hop {Target} (AS{Asn}) hop#{Hop} graded {Score} - measured jitter {Jitter} ms, effective {Eff} ms ({Witnesses} routes-through witnesses), reach +{Reach} ms",
-                    hop.TargetIds.FirstOrDefault(), hop.AsnNumber, hop.MinHopNumber, grade.OverallScore,
+                    "ISP Health: ISP hop {Target} (AS{Asn}) graded {Score} - measured jitter {Jitter} ms, effective {Eff} ms ({Witnesses} routes-through witnesses), reach +{Reach} ms",
+                    hop.TargetIds.FirstOrDefault(), hop.AsnNumber, grade.OverallScore,
                     FormatMsOrNull(measured), FormatMsOrNull(effective), witnesses.Count, FormatMsOrNull(grade.ReachDeltaMs));
                 grades.Add(grade);
             }
@@ -831,13 +830,11 @@ public class IspHealthScorer
     }
 
     /// <summary>
-    /// Whether a witness routes through a hop (and so may absolve it): the witness's hop
-    /// number must be strictly greater (downstream) than the hop's. When the hop has no
-    /// stored hop number the gate is open (reproduces the ungated prior behavior); when the
-    /// witness has none it cannot be proven downstream, so it is excluded.
+    /// Whether a witness routes through a hop (and so may absolve it): the hop's IP must be in
+    /// the witness's ancestor set - proven upstream of the witness on a shared discovery trace.
     /// </summary>
-    private static bool RoutesThrough(int? witnessHop, int? throughHop) =>
-        throughHop == null ? true : (witnessHop.HasValue && witnessHop.Value > throughHop.Value);
+    private static bool RoutesThrough(List<string> witnessAncestors, List<string> hopIps) =>
+        hopIps.Any(ip => witnessAncestors.Contains(ip, StringComparer.OrdinalIgnoreCase));
 
     /// <summary>
     /// Collapses per-hop ISP grades to one entry per ASN for the Networks on Your Path

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -1072,16 +1072,16 @@ public class IspHealthScorer
     private static string FormatMs(double ms) =>
         $"{ms.ToString("0.00", CultureInfo.InvariantCulture)} ms";
 
-    /// <summary>Threshold/band references in descriptions: drop trailing zeros (2 ms, not 2.00 ms).</summary>
+    /// <summary>Band references and loaded deltas: one decimal (2.0 ms), not the value's two.</summary>
     private static string FormatMsBand(double ms) =>
-        $"{ms.ToString("0.##", CultureInfo.InvariantCulture)} ms";
+        $"{ms.ToString("0.0", CultureInfo.InvariantCulture)} ms";
 
     /// <summary>Debug-log helper: a millisecond value to two decimals, or "n/a" when null.</summary>
     private static string FormatMsOrNull(double? ms) =>
         ms.HasValue ? ms.Value.ToString("0.00", CultureInfo.InvariantCulture) : "n/a";
 
     /// <summary>Loaded-latency delta for display: a non-positive delta shows as "0 ms".</summary>
-    private static string FormatLoadedDelta(double ms) => ms <= 0 ? "0 ms" : FormatMs(ms);
+    private static string FormatLoadedDelta(double ms) => ms <= 0 ? "0 ms" : FormatMsBand(ms);
 
     private static string FormatPct(double pct) =>
         pct == 0 ? "0%" : $"{pct.ToString(pct < 0.1 ? "0.###" : "0.##", CultureInfo.InvariantCulture)}%";

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -26,9 +26,10 @@ public class IspHealthScorer
         var hasExpectedSpeeds = inputs.ExpectedDownloadMbps.HasValue || inputs.ExpectedUploadMbps.HasValue;
 
         var idleBaseline = ComputeIdleBaseline(inputs.FirstHopSeries, loadWindows);
+        var avgLoad = ComputeAverageLoad(inputs);
         var (speedVsPlan, bestSpeedTest, typicalDownMbps, typicalUpMbps) = ScoreSpeedVsPlan(inputs);
         var idleLatency = ScoreIdleLatency(idleBaseline, profile);
-        var idleLoss = ScoreIdleLoss(inputs.LossPoolSeries, profile);
+        var idleLoss = ScoreIdleLoss(inputs.LossPoolSeries, profile, avgLoad);
         var loadedDeltas = ResolveLoadedDeltas(inputs, loadWindows);
         var (loadedLatency, hasLoadedLatency) = ScoreLoadedLatency(loadedDeltas, profile);
         var (loadedLoss, hasLoadedLoss) = ScoreLoadedLoss(inputs.LossPoolSeries, loadWindows, profile);
@@ -302,7 +303,7 @@ public class IspHealthScorer
         };
     }
 
-    private IspScoreFactor ScoreIdleLoss(List<List<LatencySample>> lossPool, AccessProfile profile)
+    private IspScoreFactor ScoreIdleLoss(List<List<LatencySample>> lossPool, AccessProfile profile, double avgLoad)
     {
         var losses = lossPool.SelectMany(series => series)
             .Where(s => s.LossPercent.HasValue)
@@ -319,9 +320,18 @@ public class IspHealthScorer
         }
 
         var meanLoss = losses.Average();
-        var score = meanLoss <= profile.IdleLossAcceptablePct
-            ? ScoreCurve.Interpolate(meanLoss, (0, 100), (profile.IdleLossIdealPct, 95), (profile.IdleLossAcceptablePct, 70))
-            : ScoreCurve.ExponentialFalloff(meanLoss, profile.IdleLossAcceptablePct, 70);
+        // Calibrate the acceptable loss ceiling to the average load over the window. An idle
+        // line should drop ~nothing, but a line that ran loaded for much of the window sheds
+        // some packets as expected, so the ceiling blends from the idle threshold toward the
+        // under-load acceptable band by the average utilization.
+        var acceptable = profile.IdleLossAcceptablePct
+            + Math.Clamp(avgLoad, 0, 1) * (profile.LoadedLossDownLowPct - profile.IdleLossAcceptablePct);
+        var score = meanLoss <= acceptable
+            ? ScoreCurve.Interpolate(meanLoss, (0, 100), (profile.IdleLossIdealPct, 95), (acceptable, 70))
+            : ScoreCurve.ExponentialFalloff(meanLoss, acceptable, 70);
+
+        _logger?.LogDebug("ISP Health: packet loss {Loss}% vs load-calibrated ceiling {Ceiling}% ({Load:P0} avg load)",
+            meanLoss.ToString("0.###", CultureInfo.InvariantCulture), acceptable.ToString("0.###", CultureInfo.InvariantCulture), avgLoad);
 
         return new IspScoreFactor
         {
@@ -329,8 +339,29 @@ public class IspHealthScorer
             Score = (int)Math.Round(score),
             Weight = _options.IdleLossWeight,
             ValueText = FormatPct(meanLoss),
-            Description = $"Average loss across ISP, transit, and anycast DNS targets vs the {FormatPct(profile.IdleLossAcceptablePct)} acceptable ceiling for {profile.DisplayName}."
+            Description = $"Average loss across ISP, transit, and anycast DNS targets vs the {FormatPct(acceptable)} ceiling for {profile.DisplayName} at {avgLoad:P0} average load."
         };
+    }
+
+    /// <summary>
+    /// Average WAN utilization over the window: the mean of each rate sample's busier
+    /// direction (download or upload as a fraction of the configured plan), clamped to
+    /// 0-1. 0 when there are no expected speeds or no rate data.
+    /// </summary>
+    private static double ComputeAverageLoad(IspHealthInputs inputs)
+    {
+        var down = inputs.ExpectedDownloadMbps;
+        var up = inputs.ExpectedUploadMbps;
+        if (inputs.WanRates.Count == 0 || (!(down > 0) && !(up > 0))) return 0;
+
+        var utils = new List<double>();
+        foreach (var r in inputs.WanRates)
+        {
+            var d = down > 0 && r.DownloadBps.HasValue ? r.DownloadBps.Value / 1_000_000.0 / down!.Value : 0;
+            var u = up > 0 && r.UploadBps.HasValue ? r.UploadBps.Value / 1_000_000.0 / up!.Value : 0;
+            utils.Add(Math.Clamp(Math.Max(d, u), 0, 1));
+        }
+        return utils.Count > 0 ? utils.Average() : 0;
     }
 
     private (IspScoreFactor Factor, bool HasData) ScoreLoadedLatency(LoadedDeltas deltas, AccessProfile profile)
@@ -1042,7 +1073,7 @@ public class IspHealthScorer
     private static string FormatLoadedDelta(double ms) => ms <= 0 ? "0 ms" : FormatMs(ms);
 
     private static string FormatPct(double pct) =>
-        pct == 0 ? "0%" : $"{pct.ToString(pct < 0.1 ? "0.000" : "0.00", CultureInfo.InvariantCulture)}%";
+        pct == 0 ? "0%" : $"{pct.ToString(pct < 0.1 ? "0.###" : "0.##", CultureInfo.InvariantCulture)}%";
 
     private static string FormatMbps(double mbps) =>
         mbps.ToString(mbps >= 100 ? "0" : "0.#", CultureInfo.InvariantCulture);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Microsoft.Extensions.Logging;
 
 namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
 
@@ -11,10 +12,12 @@ namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
 public class IspHealthScorer
 {
     private readonly IspHealthOptions _options;
+    private readonly ILogger? _logger;
 
-    public IspHealthScorer(IspHealthOptions options)
+    public IspHealthScorer(IspHealthOptions options, ILogger? logger = null)
     {
         _options = options;
+        _logger = logger;
     }
 
     public IspHealthReport Score(IspHealthInputs inputs, AccessProfile profile)
@@ -40,12 +43,21 @@ public class IspHealthScorer
         // path (ISP hops and transit clusters). It represents the access layer's inherent
         // stability - every probe crosses it - so jitter is graded relative to this floor.
         var jitterFloor = ComputeJitterFloor(inputs);
+        _logger?.LogDebug("ISP Health: path jitter floor {Floor} ms", FormatMsOrNull(jitterFloor));
 
         var transitAsns = inputs.TransitAsnSeries.Select(s => GradeAsn(s, inputs.CongestionEvents, jitterFloor, accessMedianRtt, inputs.InternetMedianDeltaMs)).ToList();
+
+        // ISP jitter is bounded by the cleanest transit ASN. Transit sits beyond the ISP
+        // and is reached through it, so a clean transit ASN proves the ISP path is at least
+        // that steady - the ISP's own per-hop jitter is routinely inflated by ICMP
+        // deprioritization and cannot be trusted above that bound. Effective ISP jitter =
+        // min(mean of the ISP targets' jitter, lowest transit ASN jitter).
+        var effectiveIspJitter = ComputeEffectiveIspJitter(inputs.IspAsnSeries, transitAsns);
+
         // Every ISP hop is graded; the dimension averages them all. Hops further out on
         // the same ISP get a soft intra-ASN reach ceiling (distance is "fine but not
         // perfect", not a fault). The access layer idle latency still uses FirstHopSeries.
-        var ispHopGrades = GradeIspHops(inputs.IspAsnSeries, inputs.CongestionEvents, jitterFloor);
+        var ispHopGrades = GradeIspHops(inputs.IspAsnSeries, inputs.CongestionEvents, jitterFloor, effectiveIspJitter);
         // Collapse the per-hop grades to one entry per ASN for the Networks on Your Path card.
         var ispAsns = AggregateIspAsns(ispHopGrades, inputs.CongestionEvents);
         var transitDimension = BuildAsnDimension("Transit Health", _options.TransitWeight, transitAsns);
@@ -494,36 +506,42 @@ public class IspHealthScorer
         double? jitterFloorMs,
         double? accessBaselineRtt,
         double? internetMedianDeltaMs,
-        double? intraAsnFloorRttMs = null)
+        double? intraAsnFloorRttMs = null,
+        double? jitterOverrideMs = null)
     {
         var rtts = series.Samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
         var losses = series.Samples.Where(s => s.LossPercent.HasValue).Select(s => s.LossPercent!.Value).ToList();
-
-        // Jitter and stability are scored from the jitter source (the farther cluster
-        // for a multi-cluster transit ASN), which proves whether the path is truly
-        // jittery or the near hop is just deprioritizing ICMP replies.
-        var jitterSource = JitterSamples(series);
-        var jitterRtts = jitterSource.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
-        var jitters = jitterSource.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
+        var jitters = series.Samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
 
         var medianRtt = SeriesStats.Median(rtts);
-        var stabilityMedian = SeriesStats.Median(jitterRtts);
-        var mad = SeriesStats.Mad(jitterRtts);
-        var medianJitter = jitters.Count > 0 ? SeriesStats.Median(jitters) : null;
+        var mad = SeriesStats.Mad(rtts);
 
-        int? stabilityScore = null;
-        if (stabilityMedian is > 0 && mad.HasValue)
+        // Jitter and stability are absolve-only across clusters. The nearest cluster's
+        // variance can be false (ICMP deprioritization at that hop); a cleaner farther
+        // cluster - reached through it - proves the path is steady, so we take the BETTER
+        // (lower) of near and far. We never take the worse: a jittery farther cluster is
+        // its own problem further along the path and must not downgrade the nearer cluster.
+        // An ISP hop instead takes the ISP-wide jitter bound (jitterOverrideMs), which is
+        // already capped by the cleanest transit ASN.
+        var medianJitter = jitterOverrideMs ?? EffectiveLower(series.Samples, series.JitterSourceSamples, MedianJitterOf);
+        var stabilityRatio = EffectiveLower(series.Samples, series.JitterSourceSamples, StabilityRatioOf);
+
+        if (jitterOverrideMs == null && series.JitterSourceSamples.Count > 0)
         {
-            var ratio = mad.Value / stabilityMedian.Value;
-            stabilityScore = (int)Math.Round(ScoreCurve.Interpolate(ratio,
-                (0.02, 100), (0.10, 80), (0.25, 55), (0.5, 25), (1.0, 0)));
+            _logger?.LogDebug(
+                "ISP Health: AS{Asn} ({Name}) jitter absolve - near {Near} ms, farther cluster {Far} ms, effective {Eff} ms",
+                series.AsnNumber, series.AsnName, FormatMsOrNull(MedianJitterOf(series.Samples)),
+                FormatMsOrNull(MedianJitterOf(series.JitterSourceSamples)), FormatMsOrNull(medianJitter));
         }
 
-        int? jitterScore = null;
-        if (medianJitter.HasValue)
-        {
-            jitterScore = (int)Math.Round(ScoreJitterVsFloor(medianJitter.Value, jitterFloorMs));
-        }
+        int? stabilityScore = stabilityRatio.HasValue
+            ? (int)Math.Round(ScoreCurve.Interpolate(stabilityRatio.Value,
+                (0.02, 100), (0.10, 80), (0.25, 55), (0.5, 25), (1.0, 0)))
+            : null;
+
+        int? jitterScore = medianJitter.HasValue
+            ? (int)Math.Round(ScoreJitterVsFloor(medianJitter.Value, jitterFloorMs))
+            : null;
 
         // Reach ceiling: the best grade this hop's distance allows.
         double? reachDelta = null;
@@ -627,17 +645,49 @@ public class IspHealthScorer
         var medians = new List<double>();
         void Add(IReadOnlyList<LatencySample> samples)
         {
-            var js = samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
-            var m = SeriesStats.Median(js);
+            var m = MedianJitterOf(samples);
             if (m.HasValue) medians.Add(m.Value);
         }
         foreach (var s in inputs.IspAsnSeries) Add(s.Samples);
-        foreach (var s in inputs.TransitAsnSeries) Add(JitterSamples(s));
+        foreach (var s in inputs.TransitAsnSeries)
+        {
+            Add(s.Samples);
+            if (s.JitterSourceSamples.Count > 0) Add(s.JitterSourceSamples);
+        }
         return medians.Count > 0 ? medians.Min() : null;
     }
 
-    private static IReadOnlyList<LatencySample> JitterSamples(AsnSeries series) =>
-        series.JitterSourceSamples.Count > 0 ? series.JitterSourceSamples : series.Samples;
+    /// <summary>Median effective jitter of a sample set, or null when none reported jitter.</summary>
+    private static double? MedianJitterOf(IReadOnlyList<LatencySample> samples)
+    {
+        var js = samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
+        return js.Count > 0 ? SeriesStats.Median(js) : null;
+    }
+
+    /// <summary>RTT stability ratio (MAD / median) of a sample set; lower is steadier. Null without RTT.</summary>
+    private static double? StabilityRatioOf(IReadOnlyList<LatencySample> samples)
+    {
+        var rtts = samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
+        var median = SeriesStats.Median(rtts);
+        var mad = SeriesStats.Mad(rtts);
+        return median is > 0 && mad.HasValue ? mad.Value / median.Value : null;
+    }
+
+    /// <summary>
+    /// The better (lower) of a metric over the near samples and over the far samples -
+    /// absolve-only. A cleaner farther cluster pulls the value down (the near hop's jitter
+    /// was false); a worse farther cluster is ignored so it never downgrades the nearer
+    /// hop. Far empty means near only.
+    /// </summary>
+    private static double? EffectiveLower(IReadOnlyList<LatencySample> near, IReadOnlyList<LatencySample> far, Func<IReadOnlyList<LatencySample>, double?> metric)
+    {
+        var n = metric(near);
+        if (far.Count == 0) return n;
+        var f = metric(far);
+        if (!f.HasValue) return n;
+        if (!n.HasValue) return f;
+        return Math.Min(n.Value, f.Value);
+    }
 
     /// <summary>
     /// Floor-relative jitter score. A target at the floor is as stable as the line
@@ -658,7 +708,7 @@ public class IspHealthScorer
     /// ISP's nearest-hop RTT (the intra-ASN reach floor): a second POP further out is
     /// nominal distance, not a fault, so it gets a soft ceiling rather than a perfect score.
     /// </summary>
-    private List<IspAsnHealth> GradeIspHops(List<AsnSeries> ispHopSeries, List<CongestionEvent> congestionEvents, double? jitterFloorMs)
+    private List<IspAsnHealth> GradeIspHops(List<AsnSeries> ispHopSeries, List<CongestionEvent> congestionEvents, double? jitterFloorMs, double? effectiveIspJitterMs)
     {
         var grades = new List<IspAsnHealth>();
         foreach (var asnGroup in ispHopSeries.GroupBy(s => s.AsnNumber))
@@ -672,9 +722,40 @@ public class IspHealthScorer
                 .Min();
             double? intraFloor = hops.Any(s => s.Samples.Any(x => x.RttAvgMs.HasValue)) ? floorRtt : null;
             foreach (var hop in hops)
-                grades.Add(GradeAsn(hop, congestionEvents, jitterFloorMs, accessBaselineRtt: null, internetMedianDeltaMs: null, intraAsnFloorRttMs: intraFloor));
+            {
+                var grade = GradeAsn(hop, congestionEvents, jitterFloorMs, accessBaselineRtt: null, internetMedianDeltaMs: null,
+                    intraAsnFloorRttMs: intraFloor, jitterOverrideMs: effectiveIspJitterMs);
+                _logger?.LogDebug(
+                    "ISP Health: ISP hop {Target} (AS{Asn}) graded {Score} - measured jitter {Jitter} ms, ISP-wide jitter {Eff} ms, reach +{Reach} ms",
+                    hop.TargetIds.FirstOrDefault(), hop.AsnNumber, grade.OverallScore, FormatMsOrNull(MedianJitterOf(hop.Samples)),
+                    FormatMsOrNull(effectiveIspJitterMs), FormatMsOrNull(grade.ReachDeltaMs));
+                grades.Add(grade);
+            }
         }
         return grades;
+    }
+
+    /// <summary>
+    /// Effective ISP jitter: the lower of the ISP targets' mean jitter and the cleanest
+    /// transit ASN's jitter. Transit is reached through the ISP, so a clean transit ASN
+    /// bounds how jittery the ISP path can really be; the ISP targets' own jitter is often
+    /// inflated by ICMP deprioritization. Null when nothing reported jitter.
+    /// </summary>
+    private double? ComputeEffectiveIspJitter(List<AsnSeries> ispHopSeries, List<IspAsnHealth> transitAsns)
+    {
+        var ispJitters = ispHopSeries.Select(s => MedianJitterOf(s.Samples)).Where(j => j.HasValue).Select(j => j!.Value).ToList();
+        double? meanIsp = ispJitters.Count > 0 ? ispJitters.Average() : null;
+
+        var transitJitters = transitAsns.Select(a => a.MedianJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
+        double? minTransit = transitJitters.Count > 0 ? transitJitters.Min() : null;
+
+        double? effective = meanIsp;
+        if (minTransit.HasValue)
+            effective = effective.HasValue ? Math.Min(effective.Value, minTransit.Value) : minTransit;
+
+        _logger?.LogDebug("ISP Health: effective ISP jitter {Eff} ms (mean ISP {Mean} ms, cleanest transit {Transit} ms)",
+            FormatMsOrNull(effective), FormatMsOrNull(meanIsp), FormatMsOrNull(minTransit));
+        return effective;
     }
 
     /// <summary>
@@ -706,7 +787,9 @@ public class IspHealthScorer
                 TargetIds = targetIds,
                 MedianRttMs = medianRtts.Count > 0 ? medianRtts.Min() : null,
                 MeanRttMs = means.Count > 0 ? means.Average() : null,
-                P95JitterMs = jitters.Count > 0 ? jitters.Max() : null,
+                // Mean of the hops' jitter, not the worst: ISP hops are routinely
+                // ICMP-deprioritized, so a single hop's high jitter is not the ASN's jitter.
+                P95JitterMs = jitters.Count > 0 ? jitters.Average() : null,
                 LossPct = lossVals.Count > 0 ? lossVals.Average() : null,
                 OverallScore = scored.Count > 0 ? (int)Math.Round(scored.Average()) : null,
                 CongestionEventCount = asnEvents.Count
@@ -914,6 +997,10 @@ public class IspHealthScorer
 
     private static string FormatMs(double ms) =>
         ms >= 10 ? $"{ms.ToString("0", CultureInfo.InvariantCulture)} ms" : $"{ms.ToString("0.0", CultureInfo.InvariantCulture)} ms";
+
+    /// <summary>Debug-log helper: a millisecond value to two decimals, or "n/a" when null.</summary>
+    private static string FormatMsOrNull(double? ms) =>
+        ms.HasValue ? ms.Value.ToString("0.00", CultureInfo.InvariantCulture) : "n/a";
 
     /// <summary>Loaded-latency delta for display: a non-positive delta shows as "0 ms".</summary>
     private static string FormatLoadedDelta(double ms) => ms <= 0 ? "0 ms" : FormatMs(ms);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -52,7 +52,7 @@ public class IspHealthScorer
         // absolves a hop it is proven downstream of), so a divergent clean transit can't
         // clear a congested hop it never traverses. Hops further out on the same ISP also
         // get a soft intra-ASN reach ceiling. Access layer idle latency still uses FirstHopSeries.
-        var ispHopGrades = GradeIspHops(inputs.IspAsnSeries, inputs.TransitAsnSeries, transitAsns, inputs.CongestionEvents, jitterFloor, inputs.HopOrderKnown);
+        var ispHopGrades = GradeIspHops(inputs.IspAsnSeries, inputs.TransitAsnSeries, transitAsns, inputs.DestinationSeries, inputs.CongestionEvents, jitterFloor, inputs.HopOrderKnown);
         // Collapse the per-hop grades to one entry per ASN for the Networks on Your Path card.
         var ispAsns = AggregateIspAsns(ispHopGrades, inputs.CongestionEvents);
         var transitDimension = BuildAsnDimension("Transit Health", _options.TransitWeight, transitAsns);
@@ -757,17 +757,21 @@ public class IspHealthScorer
 
     /// <summary>
     /// Grades every ISP hop. Each hop's jitter is absolved per-hop, routes-through-gated: a
-    /// witness (a transit ASN or another ISP hop) may only pull a hop's jitter down when the
-    /// hop is in the witness's ancestor set - proven upstream of it on a shared discovery
-    /// trace - so a divergent clean transit can never clear a congested hop it doesn't
-    /// traverse. When no ancestor data exists (no re-discovery yet) the gate falls open for
-    /// transit (transit is always downstream of the ISP) and stays closed for ISP siblings.
+    /// witness (a transit ASN, another ISP hop, or a monitored destination) may only pull a
+    /// hop's jitter down when the hop is in the witness's ancestor set - proven upstream of it
+    /// on a shared discovery trace - so a divergent clean transit can never clear a congested
+    /// hop it doesn't traverse. When no ancestor data exists (no re-discovery yet) the gate
+    /// falls open for transit (transit is always downstream of the ISP) and stays closed for
+    /// ISP siblings and destinations. A destination's clean end-to-end jitter is a hard upper
+    /// bound on any on-path hop's true jitter, so a smooth path to it absolves an
+    /// ICMP-deprioritized hop whose forwarded traffic actually reaches the destination cleanly.
     /// Hops are also scored against the intra-ASN reach floor (distance, not a fault).
     /// </summary>
     private List<IspAsnHealth> GradeIspHops(
         List<AsnSeries> ispHopSeries,
         List<AsnSeries> transitSeries,
         List<IspAsnHealth> transitAsns,
+        List<AsnSeries> destinationSeries,
         List<CongestionEvent> congestionEvents,
         double? jitterFloorMs,
         bool hopOrderKnown)
@@ -781,6 +785,19 @@ public class IspHealthScorer
             .Where(s => transitJitterByAsn.ContainsKey(s.AsnNumber))
             .Select(s => (Ancestors: s.AncestorIps, Jitter: transitJitterByAsn[s.AsnNumber]))
             .ToList();
+
+        // Destination witnesses: each monitored endpoint's ancestor IPs + its end-to-end
+        // jitter. Always strict (routes-through required) - a destination's clean path says
+        // nothing about a hop it doesn't cross, so it never absolves on faith. Only built when
+        // ancestry exists; without it (hopOrderKnown false) destinations can never absolve, so
+        // we skip computing their jitter entirely.
+        var destinationWitnesses = hopOrderKnown
+            ? destinationSeries
+                .Select(s => (s.AncestorIps, Jitter: ScoringJitterOf(s.Samples)))
+                .Where(w => w.Jitter.HasValue)
+                .Select(w => (w.AncestorIps, Jitter: w.Jitter!.Value))
+                .ToList()
+            : new List<(List<string> AncestorIps, double Jitter)>();
 
         // ISP hop witnesses: each hop series + its own measured jitter.
         var ispHopJitter = ispHopSeries
@@ -812,6 +829,9 @@ public class IspHealthScorer
                         .Where(h => hopOrderKnown && !ReferenceEquals(h.Series, hop) && h.Jitter.HasValue
                             && RoutesThrough(h.Series.AncestorIps, hop.HopIps))
                         .Select(h => h.Jitter!.Value))
+                    .Concat(destinationWitnesses
+                        .Where(w => hopOrderKnown && RoutesThrough(w.AncestorIps, hop.HopIps))
+                        .Select(w => w.Jitter))
                     .ToList();
                 double? effective = measured;
                 if (witnesses.Count > 0)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -38,7 +38,7 @@ public class IspHealthScorer
         var transitAsns = inputs.TransitAsnSeries.Select(s => GradeAsn(s, inputs.CongestionEvents, accessMedianRtt, inputs.InternetMedianDeltaMs)).ToList();
         var ispAsns = inputs.IspAsnSeries.Select(s => GradeAsn(s, inputs.CongestionEvents, accessBaselineRtt: null, internetMedianDeltaMs: null)).ToList();
         var transitDimension = BuildAsnDimension("Transit Health", _options.TransitWeight, transitAsns);
-        var ispAsnDimension = BuildAsnDimension("ISP Network", _options.IspAsnWeight, ispAsns, gradedOnBestHop: true);
+        var ispAsnDimension = BuildAsnDimension("ISP Network", _options.IspAsnWeight, ispAsns);
 
         var overall = CombineDimensions(accessDimension, transitDimension, ispAsnDimension);
 
@@ -54,7 +54,7 @@ public class IspHealthScorer
             IspAsnDimension = ispAsnDimension,
             TransitAsns = transitAsns,
             IspAsns = ispAsns,
-            IspTargets = inputs.IspTargetSeries.Select(s => BuildIspTargetHealth(s, inputs.FirstHopTargetId)).ToList(),
+            IspTargets = inputs.IspTargetSeries.Select(s => BuildIspTargetHealth(s, inputs.FirstHopTargetId, ispAsns)).ToList(),
             CongestionEvents = inputs.CongestionEvents,
             PathShifts = inputs.PathShifts,
             HasExpectedSpeeds = hasExpectedSpeeds,
@@ -589,12 +589,13 @@ public class IspHealthScorer
         };
     }
 
-    private static IspTargetHealth BuildIspTargetHealth(AsnSeries series, string? firstHopTargetId)
+    private static IspTargetHealth BuildIspTargetHealth(AsnSeries series, string? firstHopTargetId, List<IspAsnHealth> ispGrades)
     {
         var rtts = series.Samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
         var jitters = series.Samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
         var losses = series.Samples.Where(s => s.LossPercent.HasValue).Select(s => s.LossPercent!.Value).ToList();
         var targetId = series.TargetIds.FirstOrDefault() ?? "";
+        var grade = ispGrades.FirstOrDefault(g => g.TargetIds.Contains(targetId));
         return new IspTargetHealth
         {
             TargetId = targetId,
@@ -602,6 +603,7 @@ public class IspHealthScorer
             MedianRttMs = SeriesStats.Median(rtts),
             P95JitterMs = jitters.Count > 0 ? SeriesStats.Percentile(jitters, 0.95) : null,
             LossPct = losses.Count > 0 ? losses.Average() : null,
+            OverallScore = grade?.OverallScore,
             IsGradedHop = targetId == firstHopTargetId
         };
     }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -321,17 +321,19 @@ public class IspHealthScorer
 
         var meanLoss = losses.Average();
         // Calibrate the acceptable loss ceiling to the average load over the window. An idle
-        // line should drop ~nothing, but a line that ran loaded for much of the window sheds
-        // some packets as expected, so the ceiling blends from the idle threshold toward the
-        // under-load acceptable band by the average utilization.
+        // line should drop ~nothing; loss only climbs as utilization approaches saturation,
+        // so the ceiling rises QUADRATICALLY in load - staying near the idle threshold at low
+        // load and reaching the connection's normal loaded-loss band only near full load.
+        var load = Math.Clamp(avgLoad, 0, 1);
         var acceptable = profile.IdleLossAcceptablePct
-            + Math.Clamp(avgLoad, 0, 1) * (profile.LoadedLossDownLowPct - profile.IdleLossAcceptablePct);
+            + load * load * (profile.LoadedLossDownLowPct - profile.IdleLossAcceptablePct);
         var score = meanLoss <= acceptable
             ? ScoreCurve.Interpolate(meanLoss, (0, 100), (profile.IdleLossIdealPct, 95), (acceptable, 70))
             : ScoreCurve.ExponentialFalloff(meanLoss, acceptable, 70);
 
-        _logger?.LogDebug("ISP Health: packet loss {Loss}% vs load-calibrated ceiling {Ceiling}% ({Load:P0} avg load)",
-            meanLoss.ToString("0.###", CultureInfo.InvariantCulture), acceptable.ToString("0.###", CultureInfo.InvariantCulture), avgLoad);
+        _logger?.LogDebug("ISP Health: packet loss {Loss}% vs load-calibrated ceiling {Ceiling}% ({Load} avg load)",
+            meanLoss.ToString("0.###", CultureInfo.InvariantCulture), acceptable.ToString("0.###", CultureInfo.InvariantCulture),
+            avgLoad.ToString("0%", CultureInfo.InvariantCulture));
 
         return new IspScoreFactor
         {
@@ -339,7 +341,7 @@ public class IspHealthScorer
             Score = (int)Math.Round(score),
             Weight = _options.IdleLossWeight,
             ValueText = FormatPct(meanLoss),
-            Description = $"Average loss across ISP, transit, and anycast DNS targets vs the {FormatPct(acceptable)} ceiling for {profile.DisplayName} at {avgLoad:P0} average load."
+            Description = $"Average loss across ISP, transit, and anycast DNS targets vs the {FormatPct(acceptable)} ceiling for {profile.DisplayName} at {avgLoad.ToString("0%", CultureInfo.InvariantCulture)} average load."
         };
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -35,10 +35,21 @@ public class IspHealthScorer
 
         var accessMedianRtt = SeriesStats.Median(
             inputs.FirstHopSeries.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList());
-        var transitAsns = inputs.TransitAsnSeries.Select(s => GradeAsn(s, inputs.CongestionEvents, accessMedianRtt, inputs.InternetMedianDeltaMs)).ToList();
-        var ispAsns = inputs.IspAsnSeries.Select(s => GradeAsn(s, inputs.CongestionEvents, accessBaselineRtt: null, internetMedianDeltaMs: null)).ToList();
+
+        // The path jitter floor: the quietest median jitter measured anywhere along the
+        // path (ISP hops and transit clusters). It represents the access layer's inherent
+        // stability - every probe crosses it - so jitter is graded relative to this floor.
+        var jitterFloor = ComputeJitterFloor(inputs);
+
+        var transitAsns = inputs.TransitAsnSeries.Select(s => GradeAsn(s, inputs.CongestionEvents, jitterFloor, accessMedianRtt, inputs.InternetMedianDeltaMs)).ToList();
+        // Every ISP hop is graded; the dimension averages them all. Hops further out on
+        // the same ISP get a soft intra-ASN reach ceiling (distance is "fine but not
+        // perfect", not a fault). The access layer idle latency still uses FirstHopSeries.
+        var ispHopGrades = GradeIspHops(inputs.IspAsnSeries, inputs.CongestionEvents, jitterFloor);
+        // Collapse the per-hop grades to one entry per ASN for the Networks on Your Path card.
+        var ispAsns = AggregateIspAsns(ispHopGrades, inputs.CongestionEvents);
         var transitDimension = BuildAsnDimension("Transit Health", _options.TransitWeight, transitAsns);
-        var ispAsnDimension = BuildAsnDimension("ISP Network", _options.IspAsnWeight, ispAsns);
+        var ispAsnDimension = BuildIspDimension(_options.IspAsnWeight, ispHopGrades);
 
         var overall = CombineDimensions(accessDimension, transitDimension, ispAsnDimension);
 
@@ -54,7 +65,7 @@ public class IspHealthScorer
             IspAsnDimension = ispAsnDimension,
             TransitAsns = transitAsns,
             IspAsns = ispAsns,
-            IspTargets = inputs.IspTargetSeries.Select(s => BuildIspTargetHealth(s, inputs.FirstHopTargetId, ispAsns)).ToList(),
+            IspTargets = inputs.IspTargetSeries.Select(s => BuildIspTargetHealth(s, inputs.FirstHopTargetId, ispHopGrades)).ToList(),
             CongestionEvents = inputs.CongestionEvents,
             PathShifts = inputs.PathShifts,
             HasExpectedSpeeds = hasExpectedSpeeds,
@@ -467,53 +478,73 @@ public class IspHealthScorer
     }
 
     /// <summary>
-    /// Grades one ASN: a quality blend (stability, jitter, loss, congestion) capped
-    /// by a reach ceiling for transit ASNs. The ceiling normalizes distance against
-    /// the measured internet-target delta so rural networks are judged by rural
-    /// geography (a 22 ms POP when the internet sits 14 ms out is solid) while a
-    /// metro POP far beyond a 2 ms internet context grades poorly. Quality deficits
-    /// subtract below the ceiling, so congestion always counts. ISP ASNs pass null
-    /// baselines: no ceiling, quality only.
+    /// Grades one ASN (transit) or one ISP hop: a quality blend (stability, jitter,
+    /// loss, congestion) capped by a reach ceiling. Jitter and stability come from
+    /// <see cref="AsnSeries.JitterSourceSamples"/> when set (a transit ASN's farther
+    /// cluster, to discount false near-hop jitter), otherwise the series itself.
+    /// Two reach modes: <paramref name="accessBaselineRtt"/> + <paramref name="internetMedianDeltaMs"/>
+    /// is the transit ceiling (distance normalized against the measured internet
+    /// context); <paramref name="intraAsnFloorRttMs"/> is the ISP intra-ASN ceiling (a
+    /// soft penalty for hops sitting further out than this ISP's nearest hop). Quality
+    /// deficits subtract below the ceiling, so congestion and jitter always count.
     /// </summary>
-    private IspAsnHealth GradeAsn(AsnSeries series, List<CongestionEvent> congestionEvents, double? accessBaselineRtt, double? internetMedianDeltaMs)
+    private IspAsnHealth GradeAsn(
+        AsnSeries series,
+        List<CongestionEvent> congestionEvents,
+        double? jitterFloorMs,
+        double? accessBaselineRtt,
+        double? internetMedianDeltaMs,
+        double? intraAsnFloorRttMs = null)
     {
         var rtts = series.Samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
-        var jitters = series.Samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
         var losses = series.Samples.Where(s => s.LossPercent.HasValue).Select(s => s.LossPercent!.Value).ToList();
 
+        // Jitter and stability are scored from the jitter source (the farther cluster
+        // for a multi-cluster transit ASN), which proves whether the path is truly
+        // jittery or the near hop is just deprioritizing ICMP replies.
+        var jitterSource = JitterSamples(series);
+        var jitterRtts = jitterSource.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
+        var jitters = jitterSource.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
+
         var medianRtt = SeriesStats.Median(rtts);
-        var mad = SeriesStats.Mad(rtts);
+        var stabilityMedian = SeriesStats.Median(jitterRtts);
+        var mad = SeriesStats.Mad(jitterRtts);
         var medianJitter = jitters.Count > 0 ? SeriesStats.Median(jitters) : null;
 
         int? stabilityScore = null;
-        if (medianRtt is > 0 && mad.HasValue)
+        if (stabilityMedian is > 0 && mad.HasValue)
         {
-            var ratio = mad.Value / medianRtt.Value;
+            var ratio = mad.Value / stabilityMedian.Value;
             stabilityScore = (int)Math.Round(ScoreCurve.Interpolate(ratio,
                 (0.02, 100), (0.10, 80), (0.25, 55), (0.5, 25), (1.0, 0)));
         }
 
         int? jitterScore = null;
-        if (medianJitter.HasValue && medianRtt is > 0)
+        if (medianJitter.HasValue)
         {
-            // Anchors tightened ~20% so meaningful jitter costs a touch more
-            var relative = ScoreCurve.Interpolate(medianJitter.Value / medianRtt.Value,
-                (0.04, 100), (0.12, 75), (0.25, 45), (0.50, 0));
-            var absolute = ScoreCurve.Interpolate(medianJitter.Value,
-                (0.4, 100), (1.5, 75), (4, 45), (12, 0));
-            jitterScore = (int)Math.Round(Math.Max(relative, absolute));
+            jitterScore = (int)Math.Round(ScoreJitterVsFloor(medianJitter.Value, jitterFloorMs));
         }
 
-        // Reach ceiling: the best grade this ASN's distance allows. The absolute
-        // curve applies only top-end gravity (100 needs sub +1 ms; +7-9 ms tops out
-        // ~93; far distance alone never grades below the high 80s). The relative
-        // curve judges distance against the measured internet context: ratio of this
-        // POP's delta to the median internet-target delta. Validated against rural
-        // data where a clean 22 ms POP (1.6x internet distance) must stay solid.
+        // Reach ceiling: the best grade this hop's distance allows.
         double? reachDelta = null;
         int? reachCeiling = null;
-        if (accessBaselineRtt.HasValue && medianRtt.HasValue)
+        if (intraAsnFloorRttMs.HasValue && medianRtt.HasValue)
         {
+            // ISP intra-ASN reach: distance from this ISP's nearest hop. A second POP a
+            // couple ms out is two sites a real distance apart - nominal, not a fault -
+            // so it tops out short of perfect rather than getting dinged hard.
+            reachDelta = Math.Max(0, medianRtt.Value - intraAsnFloorRttMs.Value);
+            reachCeiling = (int)Math.Round(ScoreCurve.Interpolate(reachDelta.Value,
+                (0, 100), (1, 93), (2, 85), (4, 70), (8, 50), (16, 35)));
+        }
+        else if (accessBaselineRtt.HasValue && medianRtt.HasValue)
+        {
+            // Transit reach ceiling. The absolute curve applies only top-end gravity
+            // (100 needs sub +1 ms; +7-9 ms tops out ~93; far distance alone never grades
+            // below the high 80s). The relative curve judges distance against the measured
+            // internet context: ratio of this POP's delta to the median internet-target
+            // delta. Validated against rural data where a clean 22 ms POP (1.6x internet
+            // distance) must stay solid.
             reachDelta = Math.Max(0, medianRtt.Value - accessBaselineRtt.Value);
             var ceiling = ScoreCurve.Interpolate(reachDelta.Value,
                 (1, 100), (8, 93), (15, 90), (30, 87), (60, 82));
@@ -589,13 +620,108 @@ public class IspHealthScorer
         };
     }
 
-    private static IspTargetHealth BuildIspTargetHealth(AsnSeries series, string? firstHopTargetId, List<IspAsnHealth> ispGrades)
+    /// <summary>The path jitter floor: the lowest median jitter across all ISP hops and
+    /// transit clusters. Null when no series carries jitter.</summary>
+    private double? ComputeJitterFloor(IspHealthInputs inputs)
+    {
+        var medians = new List<double>();
+        void Add(IReadOnlyList<LatencySample> samples)
+        {
+            var js = samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
+            var m = SeriesStats.Median(js);
+            if (m.HasValue) medians.Add(m.Value);
+        }
+        foreach (var s in inputs.IspAsnSeries) Add(s.Samples);
+        foreach (var s in inputs.TransitAsnSeries) Add(JitterSamples(s));
+        return medians.Count > 0 ? medians.Min() : null;
+    }
+
+    private static IReadOnlyList<LatencySample> JitterSamples(AsnSeries series) =>
+        series.JitterSourceSamples.Count > 0 ? series.JitterSourceSamples : series.Samples;
+
+    /// <summary>
+    /// Floor-relative jitter score. A target at the floor is as stable as the line
+    /// allows (100). Above it the target is genuinely jittery even if it is only ICMP
+    /// deprioritization. Dual-slope: a gentle slope through a dead band just above the
+    /// floor (+25-50%), then a steeper drop, so 2x the floor reads as a clear signal.
+    /// The high end is absolute - 5+ ms is real jitter no matter how low the floor sits.
+    /// </summary>
+    private double ScoreJitterVsFloor(double jitterMs, double? floorMs)
+    {
+        var f = Math.Clamp(floorMs ?? 0.4, _options.JitterFloorMinMs, _options.JitterFloorMaxMs);
+        return ScoreCurve.Interpolate(jitterMs,
+            (f, 100), (1.25 * f, 96), (1.5 * f, 91), (2.0 * f, 70), (5.0, 22), (12.0, 0));
+    }
+
+    /// <summary>
+    /// Grades every ISP hop. Hops are grouped by ASN so each can be scored against its
+    /// ISP's nearest-hop RTT (the intra-ASN reach floor): a second POP further out is
+    /// nominal distance, not a fault, so it gets a soft ceiling rather than a perfect score.
+    /// </summary>
+    private List<IspAsnHealth> GradeIspHops(List<AsnSeries> ispHopSeries, List<CongestionEvent> congestionEvents, double? jitterFloorMs)
+    {
+        var grades = new List<IspAsnHealth>();
+        foreach (var asnGroup in ispHopSeries.GroupBy(s => s.AsnNumber))
+        {
+            var hops = asnGroup.ToList();
+            var floorRtt = hops
+                .Select(s => SeriesStats.Median(s.Samples.Where(x => x.RttAvgMs.HasValue).Select(x => x.RttAvgMs!.Value).ToList()))
+                .Where(m => m.HasValue)
+                .Select(m => m!.Value)
+                .DefaultIfEmpty()
+                .Min();
+            double? intraFloor = hops.Any(s => s.Samples.Any(x => x.RttAvgMs.HasValue)) ? floorRtt : null;
+            foreach (var hop in hops)
+                grades.Add(GradeAsn(hop, congestionEvents, jitterFloorMs, accessBaselineRtt: null, internetMedianDeltaMs: null, intraAsnFloorRttMs: intraFloor));
+        }
+        return grades;
+    }
+
+    /// <summary>
+    /// Collapses per-hop ISP grades to one entry per ASN for the Networks on Your Path
+    /// card: mean RTT and jitter across the hops, averaged grade, and the union of the
+    /// ASN's congestion events.
+    /// </summary>
+    private static List<IspAsnHealth> AggregateIspAsns(List<IspAsnHealth> hopGrades, List<CongestionEvent> congestionEvents)
+    {
+        var result = new List<IspAsnHealth>();
+        foreach (var group in hopGrades.GroupBy(h => h.AsnNumber))
+        {
+            var hops = group.ToList();
+            var targetIds = hops.SelectMany(h => h.TargetIds).Distinct().ToList();
+            var targetSet = new HashSet<string>(targetIds);
+            var asnEvents = congestionEvents
+                .Where(e => e.AsnNumbers.Contains(group.Key)
+                    && (e.TargetIds.Count == 0 || e.TargetIds.Any(t => targetSet.Contains(t))))
+                .ToList();
+            var means = hops.Select(h => h.MeanRttMs).Where(m => m.HasValue).Select(m => m!.Value).ToList();
+            var jitters = hops.Select(h => h.P95JitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
+            var lossVals = hops.Select(h => h.LossPct).Where(l => l.HasValue).Select(l => l!.Value).ToList();
+            var medianRtts = hops.Select(h => h.MedianRttMs).Where(m => m.HasValue).Select(m => m!.Value).ToList();
+            var scored = hops.Where(h => h.OverallScore.HasValue).Select(h => h.OverallScore!.Value).ToList();
+            result.Add(new IspAsnHealth
+            {
+                AsnNumber = group.Key,
+                AsnName = hops.Select(h => h.AsnName).FirstOrDefault(n => !string.IsNullOrEmpty(n)),
+                TargetIds = targetIds,
+                MedianRttMs = medianRtts.Count > 0 ? medianRtts.Min() : null,
+                MeanRttMs = means.Count > 0 ? means.Average() : null,
+                P95JitterMs = jitters.Count > 0 ? jitters.Max() : null,
+                LossPct = lossVals.Count > 0 ? lossVals.Average() : null,
+                OverallScore = scored.Count > 0 ? (int)Math.Round(scored.Average()) : null,
+                CongestionEventCount = asnEvents.Count
+            });
+        }
+        return result;
+    }
+
+    private static IspTargetHealth BuildIspTargetHealth(AsnSeries series, string? firstHopTargetId, List<IspAsnHealth> hopGrades)
     {
         var rtts = series.Samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
         var jitters = series.Samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
         var losses = series.Samples.Where(s => s.LossPercent.HasValue).Select(s => s.LossPercent!.Value).ToList();
         var targetId = series.TargetIds.FirstOrDefault() ?? "";
-        var grade = ispGrades.FirstOrDefault(g => g.TargetIds.Contains(targetId));
+        var grade = hopGrades.FirstOrDefault(g => g.TargetIds.Contains(targetId));
         return new IspTargetHealth
         {
             TargetId = targetId,
@@ -604,8 +730,19 @@ public class IspHealthScorer
             P95JitterMs = jitters.Count > 0 ? SeriesStats.Percentile(jitters, 0.95) : null,
             LossPct = losses.Count > 0 ? losses.Average() : null,
             OverallScore = grade?.OverallScore,
+            ReachDeltaMs = grade?.ReachDeltaMs,
             IsGradedHop = targetId == firstHopTargetId
         };
+    }
+
+    /// <summary>The ISP Network dimension: averages every ISP hop grade. The per-hop
+    /// detail is rendered from <see cref="IspHealthReport.IspTargets"/>, so the dimension
+    /// itself carries no factors.</summary>
+    private IspScoreDimension BuildIspDimension(double weight, List<IspAsnHealth> hopGrades)
+    {
+        var scored = hopGrades.Where(h => h.OverallScore.HasValue).Select(h => h.OverallScore!.Value).ToList();
+        int? score = scored.Count > 0 ? (int)Math.Round(scored.Average()) : null;
+        return new IspScoreDimension { Name = "ISP Network", Score = score, Weight = weight, Factors = new List<IspScoreFactor>() };
     }
 
     private static IspScoreDimension BuildDimension(string name, double weight, List<IspScoreFactor> factors)
@@ -620,17 +757,14 @@ public class IspHealthScorer
         return new IspScoreDimension { Name = name, Score = score, Weight = weight, Factors = factors };
     }
 
-    private static IspScoreDimension BuildAsnDimension(string name, double weight, List<IspAsnHealth> asns, bool gradedOnBestHop = false)
+    private static IspScoreDimension BuildAsnDimension(string name, double weight, List<IspAsnHealth> asns)
     {
-        // The ISP Network grades on the lowest (best) hop, so label its RTT "Best" to
-        // distinguish it from the mean RTT shown on the Networks on Your Path card
-        var rttPrefix = gradedOnBestHop ? "Best " : "";
         var factors = asns.Select(a => new IspScoreFactor
         {
             Name = string.IsNullOrEmpty(a.AsnName) ? $"AS{a.AsnNumber}" : a.AsnName,
             Score = a.OverallScore,
             Weight = 1.0,
-            ValueText = a.MedianRttMs.HasValue ? $"{rttPrefix}{FormatMs(a.MedianRttMs.Value)}" : null,
+            ValueText = a.MedianRttMs.HasValue ? FormatMs(a.MedianRttMs.Value) : null,
             Description = a.CongestionEventCount > 0
                 ? $"{a.CongestionEventCount} congestion event{(a.CongestionEventCount == 1 ? "" : "s")} in the window."
                 : null

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -54,7 +54,7 @@ public class IspHealthScorer
         // get a soft intra-ASN reach ceiling. Access layer idle latency still uses FirstHopSeries.
         var ispHopGrades = GradeIspHops(inputs.IspAsnSeries, inputs.TransitAsnSeries, transitAsns, inputs.DestinationSeries, inputs.CongestionEvents, jitterFloor, inputs.HopOrderKnown);
         // Collapse the per-hop grades to one entry per ASN for the Networks on Your Path card.
-        var ispAsns = AggregateIspAsns(ispHopGrades, inputs.CongestionEvents);
+        var ispAsns = AggregateIspAsns(ispHopGrades, inputs.CongestionEvents, _options.JitterAssimilationMinDeltaMs);
         var transitDimension = BuildAsnDimension("Transit Health", _options.TransitWeight, transitAsns);
         var ispAsnDimension = BuildIspDimension(_options.IspAsnWeight, ispHopGrades);
 
@@ -558,7 +558,14 @@ public class IspHealthScorer
         // An ISP hop instead takes the ISP-wide jitter bound (jitterOverrideMs), which is
         // already capped by the cleanest transit ASN.
         var nearJitter = ScoringJitterOf(series.Samples);
-        var effectiveJitter = jitterOverrideMs ?? EffectiveLower(series.Samples, series.JitterSourceSamples, ScoringJitterOf);
+        var rawEffectiveJitter = jitterOverrideMs ?? EffectiveLower(series.Samples, series.JitterSourceSamples, ScoringJitterOf);
+        // Don't assimilate on a trivial difference: a witness must sit at least the minimum
+        // delta below this series' own reading to pull it down. Within that band it's noise,
+        // so keep our own jitter (no absolve, no assimilation flag). Applies to ISP and transit.
+        var effectiveJitter = rawEffectiveJitter.HasValue && nearJitter.HasValue
+            && rawEffectiveJitter.Value > nearJitter.Value - _options.JitterAssimilationMinDeltaMs
+            ? nearJitter
+            : rawEffectiveJitter;
         var stabilityRatio = EffectiveLower(series.Samples, series.JitterSourceSamples, StabilityRatioOf);
 
         // Assimilated when a witness (a farther transit cluster, or - for an ISP hop via
@@ -862,7 +869,7 @@ public class IspHealthScorer
     /// card: mean RTT and jitter across the hops, averaged grade, and the union of the
     /// ASN's congestion events.
     /// </summary>
-    private static List<IspAsnHealth> AggregateIspAsns(List<IspAsnHealth> hopGrades, List<CongestionEvent> congestionEvents)
+    private static List<IspAsnHealth> AggregateIspAsns(List<IspAsnHealth> hopGrades, List<CongestionEvent> congestionEvents, double assimilationMinDeltaMs)
     {
         var result = new List<IspAsnHealth>();
         foreach (var group in hopGrades.GroupBy(h => h.AsnNumber))
@@ -899,7 +906,7 @@ public class IspHealthScorer
                 LossPct = lossVals.Count > 0 ? lossVals.Average() : null,
                 OverallScore = scored.Count > 0 ? (int)Math.Round(scored.Average()) : null,
                 CongestionEventCount = asnEvents.Count,
-                JitterAssimilated = effMean.HasValue && rawMean.HasValue && effMean.Value < rawMean.Value - 0.001,
+                JitterAssimilated = effMean.HasValue && rawMean.HasValue && effMean.Value < rawMean.Value - assimilationMinDeltaMs,
                 RawJitterMs = rawMean
             });
         }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -921,7 +921,7 @@ public class IspHealthScorer
             Name = string.IsNullOrEmpty(a.AsnName) ? $"AS{a.AsnNumber}" : a.AsnName,
             Score = a.OverallScore,
             Weight = 1.0,
-            ValueText = a.MedianRttMs.HasValue ? FormatMs(a.MedianRttMs.Value) : null,
+            ValueText = a.MedianRttMs.HasValue ? FormatMsCoarse(a.MedianRttMs.Value) : null,
             Description = a.CongestionEventCount > 0
                 ? $"{a.CongestionEventCount} congestion event{(a.CongestionEventCount == 1 ? "" : "s")} in the window."
                 : null
@@ -1071,6 +1071,11 @@ public class IspHealthScorer
 
     private static string FormatMs(double ms) =>
         $"{ms.ToString("0.00", CultureInfo.InvariantCulture)} ms";
+
+    /// <summary>Coarse RTT for dimension summaries: no decimals at or above 10 ms, one below.
+    /// Detail lives on the Networks on Your Path cards.</summary>
+    private static string FormatMsCoarse(double ms) =>
+        ms >= 10 ? $"{ms.ToString("0", CultureInfo.InvariantCulture)} ms" : $"{ms.ToString("0.0", CultureInfo.InvariantCulture)} ms";
 
     /// <summary>Band references and loaded deltas: one decimal (2.0 ms), not the value's two.</summary>
     private static string FormatMsBand(double ms) =>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -323,10 +323,11 @@ public class IspHealthScorer
         // Calibrate the acceptable loss ceiling to the average load over the window. An idle
         // line should drop ~nothing; loss only climbs as utilization approaches saturation,
         // so the ceiling rises QUADRATICALLY in load - staying near the idle threshold at low
-        // load and reaching the connection's normal loaded-loss band only near full load.
-        var load = Math.Clamp(avgLoad, 0, 1);
+        // load and reaching the connection's loaded-loss band at LossSaturationLoadFraction
+        // (shared-medium access tops out its loss ~75% load, not 100%), holding there above it.
+        var t = Math.Clamp(Math.Clamp(avgLoad, 0, 1) / _options.LossSaturationLoadFraction, 0, 1);
         var acceptable = profile.IdleLossAcceptablePct
-            + load * load * (profile.LoadedLossDownLowPct - profile.IdleLossAcceptablePct);
+            + t * t * (profile.LoadedLossDownLowPct - profile.IdleLossAcceptablePct);
         var score = meanLoss <= acceptable
             ? ScoreCurve.Interpolate(meanLoss, (0, 100), (profile.IdleLossIdealPct, 95), (acceptable, 70))
             : ScoreCurve.ExponentialFalloff(meanLoss, acceptable, 70);
@@ -346,21 +347,26 @@ public class IspHealthScorer
     }
 
     /// <summary>
-    /// Average WAN utilization over the window: the mean of each rate sample's busier
-    /// direction (download or upload as a fraction of the configured plan), clamped to
-    /// 0-1. 0 when there are no expected speeds or no rate data.
+    /// Average WAN utilization over the window. Uses the same windowing and per-window
+    /// utilization basis as <see cref="LoadClassifier"/> (which drives Loaded Loss): group
+    /// rates into LoadWindowSeconds windows, take the busier direction's peak rate in each
+    /// as a fraction of the configured plan. Averaged into "average load" here rather than
+    /// thresholded into loaded/idle. 0 when there are no expected speeds or no rate data.
     /// </summary>
-    private static double ComputeAverageLoad(IspHealthInputs inputs)
+    private double ComputeAverageLoad(IspHealthInputs inputs)
     {
-        var down = inputs.ExpectedDownloadMbps;
-        var up = inputs.ExpectedUploadMbps;
-        if (inputs.WanRates.Count == 0 || (!(down > 0) && !(up > 0))) return 0;
+        var expectedDownBps = inputs.ExpectedDownloadMbps * 1_000_000;
+        var expectedUpBps = inputs.ExpectedUploadMbps * 1_000_000;
+        if (inputs.WanRates.Count == 0 || (expectedDownBps is null && expectedUpBps is null)) return 0;
 
+        var windowSize = TimeSpan.FromSeconds(_options.LoadWindowSeconds);
         var utils = new List<double>();
-        foreach (var r in inputs.WanRates)
+        foreach (var group in inputs.WanRates.GroupBy(r => CongestionDetector.FloorTime(r.Time, windowSize)))
         {
-            var d = down > 0 && r.DownloadBps.HasValue ? r.DownloadBps.Value / 1_000_000.0 / down!.Value : 0;
-            var u = up > 0 && r.UploadBps.HasValue ? r.UploadBps.Value / 1_000_000.0 / up!.Value : 0;
+            var down = group.Max(r => r.DownloadBps ?? 0);
+            var up = group.Max(r => r.UploadBps ?? 0);
+            var d = expectedDownBps > 0 ? down / expectedDownBps.Value : 0;
+            var u = expectedUpBps > 0 ? up / expectedUpBps.Value : 0;
             utils.Add(Math.Clamp(Math.Max(d, u), 0, 1));
         }
         return utils.Count > 0 ? utils.Average() : 0;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -800,6 +800,8 @@ public class IspHealthScorer
                 TargetIds = targetIds,
                 MedianRttMs = medianRtts.Count > 0 ? medianRtts.Min() : null,
                 MeanRttMs = means.Count > 0 ? means.Average() : null,
+                MinRttMs = medianRtts.Count > 0 ? medianRtts.Min() : null,
+                MaxRttMs = medianRtts.Count > 0 ? medianRtts.Max() : null,
                 // The effective ISP jitter: every ISP hop grade carries the same ISP-wide
                 // value (mean ISP jitter capped by the cleanest transit ASN), so this is
                 // that assimilated value - not the worst hop's raw jitter.

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -111,6 +111,10 @@ public class IspHealthService
 
         AccessTechnology technology;
         List<MonitoringTarget> targets;
+        // TargetId -> traceroute hop number from Upstream Discovery, used to confirm a
+        // farther transit cluster actually routes through the nearer one before its lower
+        // jitter is assimilated. Stored at discovery time; no live traceroute is run here.
+        Dictionary<string, int> hopNumberByTargetId;
         await using (var db = await _dbFactory.CreateDbContextAsync(ct))
         {
             var settings = await db.MonitoringSettings.AsNoTracking().FirstOrDefaultAsync(ct);
@@ -134,6 +138,17 @@ public class IspHealthService
                     || t.TargetType == MonitoringTargetType.Transit
                     || t.TargetType == MonitoringTargetType.InternetService))
                 .ToListAsync(ct);
+
+            var discoveries = await db.UpstreamDiscoveries.AsNoTracking()
+                .Where(d => d.IsActive && d.MonitoringTargetId != null)
+                .ToListAsync(ct);
+            // Lowest active hop number per target (a target should map to one hop, but be
+            // defensive). Join discovery rows to the loaded targets by primary key.
+            var targetIdById = targets.ToDictionary(t => t.Id, t => t.TargetId);
+            hopNumberByTargetId = discoveries
+                .Where(d => targetIdById.ContainsKey(d.MonitoringTargetId!.Value))
+                .GroupBy(d => targetIdById[d.MonitoringTargetId!.Value])
+                .ToDictionary(g => g.Key, g => g.Min(d => d.HopNumber));
         }
 
         var ispTargets = targets.Where(t => t.TargetType == MonitoringTargetType.AccessIsp).ToList();
@@ -241,7 +256,7 @@ public class IspHealthService
                 && internetSeries.ContainsKey(t.TargetId))
             .Select(t => internetSeries[t.TargetId]));
 
-        var (ispGrading, transitGrading, allClusters, chartClusters) = BuildAsnSeriesSets(ispTargets, transitTargets, ispSeries, transitSeries);
+        var (ispGrading, transitGrading, allClusters, chartClusters) = BuildAsnSeriesSets(ispTargets, transitTargets, ispSeries, transitSeries, hopNumberByTargetId);
         var internetTargetSeries = targets
             .Where(t => t.TargetType == MonitoringTargetType.InternetService && internetSeries.ContainsKey(t.TargetId))
             .Select(t => new AsnSeries
@@ -285,7 +300,7 @@ public class IspHealthService
             SmartQueuesEnabled = smartQueuesEnabled
         };
 
-        var report = new IspHealthScorer(_options).Score(inputs, profile);
+        var report = new IspHealthScorer(_options, _logger).Score(inputs, profile);
         _status = IspHealthStatus.Ready;
         _logger.LogDebug("ISP Health computed: {Score} ({Tech}), {Events} congestion events, {Shifts} path shifts",
             report.OverallScore, profile.DisplayName, congestionEvents.Count, pathShifts.Count);
@@ -456,26 +471,36 @@ public class IspHealthService
         List<MonitoringTarget> ispTargets,
         List<MonitoringTarget> transitTargets,
         Dictionary<string, List<LatencySample>> ispSeries,
-        Dictionary<string, List<LatencySample>> transitSeries)
+        Dictionary<string, List<LatencySample>> transitSeries,
+        Dictionary<string, int> hopNumberByTargetId)
     {
         var ispOverrides = BuildIspAsnOverrides(ispTargets);
         // Congestion and path-shift detection still runs on clustered series so
         // events fire at the right granularity
-        var (_, ispClusters, ispChart) = GroupAndCluster(ispTargets, ispSeries, ispOverrides, gradeLowestTargetOnly: true);
+        var (_, ispClusters, ispChart) = GroupAndCluster(ispTargets, ispSeries, ispOverrides, gradeLowestTargetOnly: true, hopNumberByTargetId);
 
-        // Grade each ISP target individually: every hop's own loss, jitter,
-        // stability, and congestion contribute to the ISP Network dimension
-        // instead of grading only the first clean hop. The access layer idle
-        // speed rating still uses FirstHopSeries (unchanged).
+        // Grade each ISP target individually: every hop's own loss, reach, and
+        // congestion contribute to the ISP Network dimension instead of grading only
+        // the first clean hop (jitter is graded ISP-wide in the scorer). The access
+        // layer idle speed rating still uses FirstHopSeries (unchanged). AsnName carries
+        // the ASN org name (not the per-hop target name) so the aggregate ISP card on
+        // Networks on Your Path is labeled by the ASN; the per-hop table uses a separate
+        // series (ispTargetSeries) that keeps each target's own name.
         var ispGrading = ispTargets
             .Where(t => ispSeries.ContainsKey(t.TargetId))
             .Select(t =>
             {
-                var resolvedAsn = ispOverrides != null && ispOverrides.TryGetValue(t.TargetId, out var o) ? o.Asn : t.AsnNumber ?? 0;
+                var resolvedAsn = t.AsnNumber ?? 0;
+                var asnName = t.AsnName;
+                if (ispOverrides != null && ispOverrides.TryGetValue(t.TargetId, out var o))
+                {
+                    resolvedAsn = o.Asn;
+                    asnName ??= o.Name;
+                }
                 return new AsnSeries
                 {
                     AsnNumber = resolvedAsn,
-                    AsnName = t.Name,
+                    AsnName = asnName,
                     TargetIds = { t.TargetId },
                     Samples = ispSeries[t.TargetId],
                     RoleTargetIds = { t.TargetId }
@@ -484,7 +509,7 @@ public class IspHealthService
             .ToList();
 
         var attributedTransit = transitTargets.Where(t => t.AsnNumber is > 0).ToList();
-        var (transitGrading, transitClusters, transitChart) = GroupAndCluster(attributedTransit, transitSeries, null, gradeLowestTargetOnly: false);
+        var (transitGrading, transitClusters, transitChart) = GroupAndCluster(attributedTransit, transitSeries, null, gradeLowestTargetOnly: false, hopNumberByTargetId);
 
         return (ispGrading, transitGrading,
             ispClusters.Concat(transitClusters).ToList(),
@@ -515,7 +540,8 @@ public class IspHealthService
         List<MonitoringTarget> targets,
         Dictionary<string, List<LatencySample>> seriesByTarget,
         Dictionary<string, (int Asn, string? Name)>? asnOverrides,
-        bool gradeLowestTargetOnly)
+        bool gradeLowestTargetOnly,
+        Dictionary<string, int> hopNumberByTargetId)
     {
         var grading = new List<AsnSeries>();
         var allClusters = new List<AsnSeries>();
@@ -611,9 +637,19 @@ public class IspHealthService
                     // one - is the honest read of the path's jitter. RTT and reach stay on
                     // the nearest cluster. Only for transit (full clusters graded); the ISP
                     // grades each hop on its own, so this carve-out does not apply there.
-                    var jitterSource = !gradeLowestTargetOnly && clusters.Count > 1
-                        ? clusters[^1].SelectMany(c => seriesByTarget[c.Target.TargetId]).OrderBy(s => s.Time).ToList()
-                        : new List<LatencySample>();
+                    // The assimilation is gated on traceroute hop order: we only trust the
+                    // farther cluster's lower jitter when Upstream Discovery recorded it
+                    // strictly downstream of the nearest cluster (it actually routes through
+                    // it). Without that proof we keep the nearest cluster's own jitter.
+                    var jitterSource = new List<LatencySample>();
+                    if (!gradeLowestTargetOnly && clusters.Count > 1)
+                    {
+                        var farthest = clusters[^1].Select(c => c.Target).ToList();
+                        if (FarClusterRoutesThroughNear(clusters[0], clusters[^1], hopNumberByTargetId, group.Key))
+                        {
+                            jitterSource = farthest.SelectMany(t => seriesByTarget[t.TargetId]).OrderBy(s => s.Time).ToList();
+                        }
+                    }
                     grading.Add(new AsnSeries
                     {
                         AsnNumber = group.Key,
@@ -644,6 +680,42 @@ public class IspHealthService
             }
         }
         return (grading, allClusters, chartClusters);
+    }
+
+    /// <summary>
+    /// Confirms a farther RTT cluster is genuinely downstream of the nearer one using the
+    /// traceroute hop numbers stored at Upstream Discovery: the farther cluster's lowest
+    /// hop number must be strictly greater than the nearer cluster's highest, so the route
+    /// to the farther cluster passes through the nearer. Without hop data for both clusters
+    /// we cannot prove it routes through, so we decline to assimilate (never absolve on
+    /// faith). Uses stored hop order - no live traceroute is run.
+    /// </summary>
+    private bool FarClusterRoutesThroughNear(
+        List<(MonitoringTarget Target, double? Median)> nearCluster,
+        List<(MonitoringTarget Target, double? Median)> farCluster,
+        Dictionary<string, int> hopNumberByTargetId,
+        int asn)
+    {
+        var nearHops = nearCluster
+            .Select(c => hopNumberByTargetId.TryGetValue(c.Target.TargetId, out var h) ? (int?)h : null)
+            .Where(h => h.HasValue).Select(h => h!.Value).ToList();
+        var farHops = farCluster
+            .Select(c => hopNumberByTargetId.TryGetValue(c.Target.TargetId, out var h) ? (int?)h : null)
+            .Where(h => h.HasValue).Select(h => h!.Value).ToList();
+
+        if (nearHops.Count == 0 || farHops.Count == 0)
+        {
+            _logger.LogDebug(
+                "ISP Health: AS{Asn} farther-cluster jitter NOT assimilated - no stored hop order (near {NearN}, far {FarN} hops with numbers)",
+                asn, nearHops.Count, farHops.Count);
+            return false;
+        }
+
+        var routesThrough = farHops.Min() > nearHops.Max();
+        _logger.LogDebug(
+            "ISP Health: AS{Asn} farther-cluster routes-through-nearer={Ok} (nearest hop# max {NearMax}, farthest hop# min {FarMin})",
+            asn, routesThrough, nearHops.Max(), farHops.Min());
+        return routesThrough;
     }
 
     private static Dictionary<string, List<LatencySample>> ToSamples(

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -503,7 +503,8 @@ public class IspHealthService
                     AsnName = asnName,
                     TargetIds = { t.TargetId },
                     Samples = ispSeries[t.TargetId],
-                    RoleTargetIds = { t.TargetId }
+                    RoleTargetIds = { t.TargetId },
+                    MinHopNumber = hopNumberByTargetId.TryGetValue(t.TargetId, out var hn) ? hn : null
                 };
             })
             .ToList();
@@ -650,6 +651,11 @@ public class IspHealthService
                             jitterSource = farthest.SelectMany(t => seriesByTarget[t.TargetId]).OrderBy(s => s.Time).ToList();
                         }
                     }
+                    // Nearest hop number across this graded cluster, so the scorer can tell
+                    // whether this transit routes through a given ISP hop (downstream of it).
+                    var clusterHopNums = clusterTargets
+                        .Select(t => hopNumberByTargetId.TryGetValue(t.TargetId, out var h) ? (int?)h : null)
+                        .Where(h => h.HasValue).Select(h => h!.Value).ToList();
                     grading.Add(new AsnSeries
                     {
                         AsnNumber = group.Key,
@@ -658,6 +664,7 @@ public class IspHealthService
                         Samples = clusterTargets.SelectMany(t => seriesByTarget[t.TargetId]).OrderBy(s => s.Time).ToList(),
                         NearestClusterMeanRttMs = nearestRtts.Count > 0 ? nearestRtts.Average() : null,
                         JitterSourceSamples = jitterSource,
+                        MinHopNumber = clusterHopNums.Count > 0 ? clusterHopNums.Min() : null,
                         // All of this ASN-role's hops, so congestion is attributed to the
                         // right card when the same ASN is both the access ISP and transit
                         RoleTargetIds = group.Select(t => t.TargetId).ToList()

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -99,6 +99,13 @@ public class IspHealthService
     }
 
     /// <summary>Pipeline readiness, for the tab's prerequisite funnels.</summary>
+    /// <summary>
+    /// Drop the cached report so the next <see cref="GetReportAsync"/> recomputes from current
+    /// data. Called when Upstream Discovery is committed, so the "re-run discovery" banner
+    /// clears as soon as the user revisits the tab, without a manual refresh.
+    /// </summary>
+    public void Invalidate() => _cached = null;
+
     public IspHealthStatus Status => _cached != null ? IspHealthStatus.Ready : _status;
 
     private async Task<(IspHealthReport? Report, List<AsnSeries> ChartClusters)> ComputeAsync(CancellationToken ct)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -605,6 +605,15 @@ public class IspHealthService
                         .Where(s => s.RttAvgMs.HasValue)
                         .Select(s => s.RttAvgMs!.Value)
                         .ToList();
+                    // Jitter and stability are scored from the farthest cluster when this
+                    // ASN spans more than one: a near hop's jitter is often false (ICMP
+                    // deprioritization), and the farther cluster - reached through the near
+                    // one - is the honest read of the path's jitter. RTT and reach stay on
+                    // the nearest cluster. Only for transit (full clusters graded); the ISP
+                    // grades each hop on its own, so this carve-out does not apply there.
+                    var jitterSource = !gradeLowestTargetOnly && clusters.Count > 1
+                        ? clusters[^1].SelectMany(c => seriesByTarget[c.Target.TargetId]).OrderBy(s => s.Time).ToList()
+                        : new List<LatencySample>();
                     grading.Add(new AsnSeries
                     {
                         AsnNumber = group.Key,
@@ -612,6 +621,7 @@ public class IspHealthService
                         TargetIds = clusterTargets.Select(t => t.TargetId).ToList(),
                         Samples = clusterTargets.SelectMany(t => seriesByTarget[t.TargetId]).OrderBy(s => s.Time).ToList(),
                         NearestClusterMeanRttMs = nearestRtts.Count > 0 ? nearestRtts.Average() : null,
+                        JitterSourceSamples = jitterSource,
                         // All of this ASN-role's hops, so congestion is attributed to the
                         // right card when the same ASN is both the access ISP and transit
                         RoleTargetIds = group.Select(t => t.TargetId).ToList()

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -459,9 +459,29 @@ public class IspHealthService
         Dictionary<string, List<LatencySample>> transitSeries)
     {
         var ispOverrides = BuildIspAsnOverrides(ispTargets);
-        // The ISP grade follows the live ISP RTT card: the single lowest-RTT target
-        // is the first clean hop and represents the ISP network
-        var (ispGrading, ispClusters, ispChart) = GroupAndCluster(ispTargets, ispSeries, ispOverrides, gradeLowestTargetOnly: true);
+        // Congestion and path-shift detection still runs on clustered series so
+        // events fire at the right granularity
+        var (_, ispClusters, ispChart) = GroupAndCluster(ispTargets, ispSeries, ispOverrides, gradeLowestTargetOnly: true);
+
+        // Grade each ISP target individually: every hop's own loss, jitter,
+        // stability, and congestion contribute to the ISP Network dimension
+        // instead of grading only the first clean hop. The access layer idle
+        // speed rating still uses FirstHopSeries (unchanged).
+        var ispGrading = ispTargets
+            .Where(t => ispSeries.ContainsKey(t.TargetId))
+            .Select(t =>
+            {
+                var resolvedAsn = ispOverrides != null && ispOverrides.TryGetValue(t.TargetId, out var o) ? o.Asn : t.AsnNumber ?? 0;
+                return new AsnSeries
+                {
+                    AsnNumber = resolvedAsn,
+                    AsnName = t.Name,
+                    TargetIds = { t.TargetId },
+                    Samples = ispSeries[t.TargetId],
+                    RoleTargetIds = { t.TargetId }
+                };
+            })
+            .ToList();
 
         var attributedTransit = transitTargets.Where(t => t.AsnNumber is > 0).ToList();
         var (transitGrading, transitClusters, transitChart) = GroupAndCluster(attributedTransit, transitSeries, null, gradeLowestTargetOnly: false);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -111,10 +111,11 @@ public class IspHealthService
 
         AccessTechnology technology;
         List<MonitoringTarget> targets;
-        // TargetId -> traceroute hop number from Upstream Discovery, used to confirm a
-        // farther transit cluster actually routes through the nearer one before its lower
-        // jitter is assimilated. Stored at discovery time; no live traceroute is run here.
-        Dictionary<string, int> hopNumberByTargetId;
+        // TargetId -> the monitored hop IPs proven upstream of it (its ancestors), from
+        // Upstream Discovery's traces. ISP Health uses these to confirm one hop routes
+        // through another before its jitter absolves the other. No live traceroute here.
+        Dictionary<string, List<string>> ancestorIpsByTargetId;
+        bool hopOrderKnown;
         await using (var db = await _dbFactory.CreateDbContextAsync(ct))
         {
             var settings = await db.MonitoringSettings.AsNoTracking().FirstOrDefaultAsync(ct);
@@ -142,13 +143,18 @@ public class IspHealthService
             var discoveries = await db.UpstreamDiscoveries.AsNoTracking()
                 .Where(d => d.IsActive && d.MonitoringTargetId != null)
                 .ToListAsync(ct);
-            // Lowest active hop number per target (a target should map to one hop, but be
-            // defensive). Join discovery rows to the loaded targets by primary key.
+            // TargetId -> ancestor hop IPs. Join discovery rows to the loaded targets by PK.
             var targetIdById = targets.ToDictionary(t => t.Id, t => t.TargetId);
-            hopNumberByTargetId = discoveries
+            ancestorIpsByTargetId = discoveries
                 .Where(d => targetIdById.ContainsKey(d.MonitoringTargetId!.Value))
                 .GroupBy(d => targetIdById[d.MonitoringTargetId!.Value])
-                .ToDictionary(g => g.Key, g => g.Min(d => d.HopNumber));
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.SelectMany(d => (d.AncestorHopIps ?? "").Split(' ', StringSplitOptions.RemoveEmptyEntries))
+                        .Distinct(StringComparer.OrdinalIgnoreCase).ToList());
+            // Ancestor data exists when any row carries the (non-null) column - distinguishes
+            // "no discovery yet / pre-ancestor data" from "on-path but no upstream ancestors".
+            hopOrderKnown = discoveries.Any(d => d.AncestorHopIps != null);
         }
 
         var ispTargets = targets.Where(t => t.TargetType == MonitoringTargetType.AccessIsp).ToList();
@@ -256,7 +262,7 @@ public class IspHealthService
                 && internetSeries.ContainsKey(t.TargetId))
             .Select(t => internetSeries[t.TargetId]));
 
-        var (ispGrading, transitGrading, allClusters, chartClusters) = BuildAsnSeriesSets(ispTargets, transitTargets, ispSeries, transitSeries, hopNumberByTargetId);
+        var (ispGrading, transitGrading, allClusters, chartClusters) = BuildAsnSeriesSets(ispTargets, transitTargets, ispSeries, transitSeries, ancestorIpsByTargetId);
         var internetTargetSeries = targets
             .Where(t => t.TargetType == MonitoringTargetType.InternetService && internetSeries.ContainsKey(t.TargetId))
             .Select(t => new AsnSeries
@@ -297,7 +303,8 @@ public class IspHealthService
             WanSpeedTests = wanSpeedTests,
             CongestionEvents = congestionEvents,
             PathShifts = pathShifts,
-            SmartQueuesEnabled = smartQueuesEnabled
+            SmartQueuesEnabled = smartQueuesEnabled,
+            HopOrderKnown = hopOrderKnown
         };
 
         var report = new IspHealthScorer(_options, _logger).Score(inputs, profile);
@@ -472,12 +479,12 @@ public class IspHealthService
         List<MonitoringTarget> transitTargets,
         Dictionary<string, List<LatencySample>> ispSeries,
         Dictionary<string, List<LatencySample>> transitSeries,
-        Dictionary<string, int> hopNumberByTargetId)
+        Dictionary<string, List<string>> ancestorIpsByTargetId)
     {
         var ispOverrides = BuildIspAsnOverrides(ispTargets);
         // Congestion and path-shift detection still runs on clustered series so
         // events fire at the right granularity
-        var (_, ispClusters, ispChart) = GroupAndCluster(ispTargets, ispSeries, ispOverrides, gradeLowestTargetOnly: true, hopNumberByTargetId);
+        var (_, ispClusters, ispChart) = GroupAndCluster(ispTargets, ispSeries, ispOverrides, gradeLowestTargetOnly: true, ancestorIpsByTargetId);
 
         // Grade each ISP target individually: every hop's own loss, reach, and
         // congestion contribute to the ISP Network dimension instead of grading only
@@ -504,13 +511,14 @@ public class IspHealthService
                     TargetIds = { t.TargetId },
                     Samples = ispSeries[t.TargetId],
                     RoleTargetIds = { t.TargetId },
-                    MinHopNumber = hopNumberByTargetId.TryGetValue(t.TargetId, out var hn) ? hn : null
+                    HopIps = { t.Address },
+                    AncestorIps = ancestorIpsByTargetId.TryGetValue(t.TargetId, out var anc) ? anc : new List<string>()
                 };
             })
             .ToList();
 
         var attributedTransit = transitTargets.Where(t => t.AsnNumber is > 0).ToList();
-        var (transitGrading, transitClusters, transitChart) = GroupAndCluster(attributedTransit, transitSeries, null, gradeLowestTargetOnly: false, hopNumberByTargetId);
+        var (transitGrading, transitClusters, transitChart) = GroupAndCluster(attributedTransit, transitSeries, null, gradeLowestTargetOnly: false, ancestorIpsByTargetId);
 
         return (ispGrading, transitGrading,
             ispClusters.Concat(transitClusters).ToList(),
@@ -542,7 +550,7 @@ public class IspHealthService
         Dictionary<string, List<LatencySample>> seriesByTarget,
         Dictionary<string, (int Asn, string? Name)>? asnOverrides,
         bool gradeLowestTargetOnly,
-        Dictionary<string, int> hopNumberByTargetId)
+        Dictionary<string, List<string>> ancestorIpsByTargetId)
     {
         var grading = new List<AsnSeries>();
         var allClusters = new List<AsnSeries>();
@@ -646,16 +654,16 @@ public class IspHealthService
                     if (!gradeLowestTargetOnly && clusters.Count > 1)
                     {
                         var farthest = clusters[^1].Select(c => c.Target).ToList();
-                        if (FarClusterRoutesThroughNear(clusters[0], clusters[^1], hopNumberByTargetId, group.Key))
+                        if (FarClusterRoutesThroughNear(clusters[0], clusters[^1], ancestorIpsByTargetId))
                         {
                             jitterSource = farthest.SelectMany(t => seriesByTarget[t.TargetId]).OrderBy(s => s.Time).ToList();
                         }
                     }
-                    // Nearest hop number across this graded cluster, so the scorer can tell
-                    // whether this transit routes through a given ISP hop (downstream of it).
-                    var clusterHopNums = clusterTargets
-                        .Select(t => hopNumberByTargetId.TryGetValue(t.TargetId, out var h) ? (int?)h : null)
-                        .Where(h => h.HasValue).Select(h => h!.Value).ToList();
+                    // This cluster's hop IPs and the union of their ancestors, so the scorer can
+                    // confirm this transit routes through a given ISP hop (the hop is an ancestor).
+                    var clusterAncestors = clusterTargets
+                        .SelectMany(t => ancestorIpsByTargetId.TryGetValue(t.TargetId, out var anc) ? anc : Enumerable.Empty<string>())
+                        .Distinct(StringComparer.OrdinalIgnoreCase).ToList();
                     grading.Add(new AsnSeries
                     {
                         AsnNumber = group.Key,
@@ -664,7 +672,8 @@ public class IspHealthService
                         Samples = clusterTargets.SelectMany(t => seriesByTarget[t.TargetId]).OrderBy(s => s.Time).ToList(),
                         NearestClusterMeanRttMs = nearestRtts.Count > 0 ? nearestRtts.Average() : null,
                         JitterSourceSamples = jitterSource,
-                        MinHopNumber = clusterHopNums.Count > 0 ? clusterHopNums.Min() : null,
+                        HopIps = clusterTargets.Select(t => t.Address).ToList(),
+                        AncestorIps = clusterAncestors,
                         // All of this ASN-role's hops, so congestion is attributed to the
                         // right card when the same ASN is both the access ISP and transit
                         RoleTargetIds = group.Select(t => t.TargetId).ToList()
@@ -691,38 +700,22 @@ public class IspHealthService
 
     /// <summary>
     /// Confirms a farther RTT cluster is genuinely downstream of the nearer one using the
-    /// traceroute hop numbers stored at Upstream Discovery: the farther cluster's lowest
-    /// hop number must be strictly greater than the nearer cluster's highest, so the route
-    /// to the farther cluster passes through the nearer. Without hop data for both clusters
-    /// we cannot prove it routes through, so we decline to assimilate (never absolve on
-    /// faith). Uses stored hop order - no live traceroute is run.
+    /// ancestor sets stored at Upstream Discovery: some nearer-cluster hop must be in the
+    /// farther cluster's ancestors, proving the route to the farther cluster passes through
+    /// the nearer on a shared trace. Without that proof we decline to assimilate (never
+    /// absolve on faith). Uses stored ancestors - no live traceroute is run.
     /// </summary>
-    private bool FarClusterRoutesThroughNear(
+    private static bool FarClusterRoutesThroughNear(
         List<(MonitoringTarget Target, double? Median)> nearCluster,
         List<(MonitoringTarget Target, double? Median)> farCluster,
-        Dictionary<string, int> hopNumberByTargetId,
-        int asn)
+        Dictionary<string, List<string>> ancestorIpsByTargetId)
     {
-        var nearHops = nearCluster
-            .Select(c => hopNumberByTargetId.TryGetValue(c.Target.TargetId, out var h) ? (int?)h : null)
-            .Where(h => h.HasValue).Select(h => h!.Value).ToList();
-        var farHops = farCluster
-            .Select(c => hopNumberByTargetId.TryGetValue(c.Target.TargetId, out var h) ? (int?)h : null)
-            .Where(h => h.HasValue).Select(h => h!.Value).ToList();
-
-        if (nearHops.Count == 0 || farHops.Count == 0)
-        {
-            _logger.LogDebug(
-                "ISP Health: AS{Asn} farther-cluster jitter NOT assimilated - no stored hop order (near {NearN}, far {FarN} hops with numbers)",
-                asn, nearHops.Count, farHops.Count);
-            return false;
-        }
-
-        var routesThrough = farHops.Min() > nearHops.Max();
-        _logger.LogDebug(
-            "ISP Health: AS{Asn} farther-cluster routes-through-nearer={Ok} (nearest hop# max {NearMax}, farthest hop# min {FarMin})",
-            asn, routesThrough, nearHops.Max(), farHops.Min());
-        return routesThrough;
+        var nearIps = nearCluster.Select(c => c.Target.Address)
+            .Where(a => !string.IsNullOrEmpty(a)).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var farAncestors = farCluster
+            .SelectMany(c => ancestorIpsByTargetId.TryGetValue(c.Target.TargetId, out var anc) ? anc : Enumerable.Empty<string>())
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        return nearIps.Overlaps(farAncestors);
     }
 
     private static Dictionary<string, List<LatencySample>> ToSamples(

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -140,6 +140,11 @@ public class IspHealthService
                     || t.TargetType == MonitoringTargetType.InternetService))
                 .ToListAsync(ct);
 
+            // TODO (multi-WAN): discoveries are read across ALL WANs, not scoped to the WAN
+            // being scored. UpstreamDiscovery rows carry WanInterface, but ISP Health scores
+            // a single (primary) WAN and ancestry/hopOrderKnown here is global, so a second
+            // WAN's discovery data could flip the absolve gate for a WAN that has none of its
+            // own. Scope by WanInterface once ISP Health grades per-WAN. See TODO.md.
             var discoveries = await db.UpstreamDiscoveries.AsNoTracking()
                 .Where(d => d.IsActive && d.MonitoringTargetId != null)
                 .ToListAsync(ct);
@@ -270,7 +275,11 @@ public class IspHealthService
                 AsnNumber = t.AsnNumber ?? 0,
                 AsnName = t.Name,
                 TargetIds = { t.TargetId },
-                Samples = internetSeries[t.TargetId]
+                Samples = internetSeries[t.TargetId],
+                HopIps = { t.Address },
+                // Hops proven upstream of this destination, so its clean end-to-end jitter
+                // can absolve an ICMP-deprioritized ISP hop it provably routes through.
+                AncestorIps = ancestorIpsByTargetId.TryGetValue(t.TargetId, out var destAnc) ? destAnc : new List<string>()
             })
             .ToList();
 
@@ -295,6 +304,7 @@ public class IspHealthService
             LossPoolSeries = lossPool,
             TransitAsnSeries = transitGrading,
             IspAsnSeries = ispGrading,
+            DestinationSeries = internetTargetSeries,
             WanRates = wanRates,
             InternetMedianDeltaMs = internetMedianDelta,
             ExpectedDownloadMbps = expectedDown,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/SeriesStats.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/SeriesStats.cs
@@ -19,6 +19,20 @@ internal static class SeriesStats
         return sorted[lo] + (sorted[hi] - sorted[lo]) * (rank - lo);
     }
 
+    /// <summary>
+    /// Mean after winsorizing the upper tail: values above the given percentile are capped
+    /// to it, then averaged. Keeps sustained elevation fully visible (those samples sit
+    /// below the cap) while stopping a few extreme outliers - a route flap or a single bad
+    /// probe - from dragging the average. Null when empty.
+    /// </summary>
+    public static double? WinsorizedMean(IReadOnlyList<double> values, double upperPercentile)
+    {
+        if (values.Count == 0) return null;
+        var cap = Percentile(values, upperPercentile);
+        if (cap == null) return values.Average();
+        return values.Select(v => Math.Min(v, cap.Value)).Average();
+    }
+
     /// <summary>Median absolute deviation; robust spread measure.</summary>
     public static double? Mad(IReadOnlyList<double> values)
     {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1273,45 +1273,48 @@ public class UpstreamTracerService
             return;
         }
 
-        // address -> lowest TTL on each individual trace (responding hops only).
-        var traceMaps = _lastTraces
-            .Select(tr => (Target: tr.Target.Address, Map: tr.Hops
-                .Where(h => h.Responded && !string.IsNullOrEmpty(h.Address))
-                .GroupBy(h => h.Address!, StringComparer.OrdinalIgnoreCase)
-                .ToDictionary(g => g.Key, g => g.Min(h => h.HopNumber), StringComparer.OrdinalIgnoreCase)))
-            .ToList();
-
-        // Global canonical trace: the single trace covering the most monitored hops across
-        // ALL ASNs, so ISP and transit hop numbers are comparable on one real path.
         var monitoredAddrs = targets.Select(t => t.Address).Where(a => !string.IsNullOrEmpty(a))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        Dictionary<string, int>? canonicalMap = null;
-        string? canonicalTarget = null;
-        var bestCover = 0;
-        foreach (var (target, map) in traceMaps)
+
+        // Ancestor sets from ALL traces: for each monitored hop, the monitored hops that
+        // appear before it on any trace it was seen on (its proven upstream). Every trace
+        // contributes (including those toward transit targets), so coverage is complete and
+        // divergence-correct - a hop is only an ancestor of another when they truly share a
+        // path with it upstream. Also track the lowest TTL seen, for a representative HopNumber.
+        var ancestorsByIp = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        var minTtlByIp = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var tr in _lastTraces)
         {
-            var cover = monitoredAddrs.Count(a => map.ContainsKey(a));
-            if (cover > bestCover) { bestCover = cover; canonicalMap = map; canonicalTarget = target; }
-        }
-        if (canonicalMap == null || bestCover == 0)
-        {
-            _logger.LogDebug("Tracer: no single trace covered the monitored hops for {Wan}; hop order not persisted", wanInterface);
-            await db.SaveChangesAsync(ct);
-            return;
+            var seenMonitored = new List<string>();
+            foreach (var h in tr.Hops.Where(h => h.Responded && !string.IsNullOrEmpty(h.Address)).OrderBy(h => h.HopNumber))
+            {
+                if (!monitoredAddrs.Contains(h.Address!)) continue;
+                if (!ancestorsByIp.TryGetValue(h.Address!, out var anc))
+                    ancestorsByIp[h.Address!] = anc = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                anc.UnionWith(seenMonitored);
+                seenMonitored.Add(h.Address!);
+                if (!minTtlByIp.TryGetValue(h.Address!, out var ttl) || h.HopNumber < ttl)
+                    minTtlByIp[h.Address!] = h.HopNumber;
+            }
         }
 
         var now = DateTime.UtcNow;
         var written = 0;
         foreach (var t in targets)
         {
-            if (!canonicalMap.TryGetValue(t.Address, out var ttl)) continue;
+            var ancestors = ancestorsByIp.TryGetValue(t.Address, out var anc)
+                ? anc.OrderBy(a => a).ToList()
+                : new List<string>();
             db.UpstreamDiscoveries.Add(new UpstreamDiscovery
             {
                 MonitoringTargetId = t.Id,
                 AsnNumber = t.AsnNumber!.Value,
                 AsnName = t.AsnName,
                 HopIp = t.Address,
-                HopNumber = ttl,
+                HopNumber = minTtlByIp.TryGetValue(t.Address, out var ttl) ? ttl : 0,
+                // Non-null (even if empty) marks that ancestor data exists, so ISP Health can
+                // tell "no discovery yet" (open gate) from "on-path but no ancestors" (a first hop).
+                AncestorHopIps = string.Join(" ", ancestors),
                 Role = t.TargetType == MonitoringTargetType.AccessIsp ? UpstreamRole.AccessHop : UpstreamRole.Transit,
                 WanInterface = wanInterface,
                 LastValidated = now,
@@ -1319,13 +1322,13 @@ public class UpstreamTracerService
                 IsActive = true
             });
             written++;
-            _logger.LogDebug("Tracer: AS{Asn} hop#{Ttl} {Ip} ({Name}) on global canonical trace to {Trace}",
-                t.AsnNumber, ttl, t.Address, t.PtrHostname ?? t.Name, canonicalTarget);
+            _logger.LogDebug("Tracer: AS{Asn} {Ip} ({Name}) ancestors=[{Ancestors}]",
+                t.AsnNumber, t.Address, t.PtrHostname ?? t.Name, string.Join(", ", ancestors));
         }
 
         await db.SaveChangesAsync(ct);
-        _logger.LogInformation("Tracer: persisted {Count} upstream hop-order rows for {Wan} (global canonical trace to {Trace})",
-            written, wanInterface, canonicalTarget);
+        _logger.LogInformation("Tracer: persisted {Count} upstream hop-ancestor rows for {Wan} from {Traces} traces",
+            written, wanInterface, _lastTraces.Count);
     }
 
     private static async Task UpsertTargetAsync(NetworkOptimizerDbContext db, AccessHopCandidate hop, string wanInterface, CancellationToken ct)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -30,6 +30,7 @@ public class UpstreamTracerService
     private readonly AsnResolutionService _asnResolution;
     private readonly LocalProbeExecutor _localProbe;
     private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IspHealth.IspHealthService _ispHealth;
     private readonly NetworkOptimizer.Audit.Services.IeeeOuiDatabase _ouiDb;
     private readonly ILogger<UpstreamTracerService> _logger;
 
@@ -90,6 +91,7 @@ public class UpstreamTracerService
         AsnResolutionService asnResolution,
         LocalProbeExecutor localProbe,
         IServiceScopeFactory scopeFactory,
+        IspHealth.IspHealthService ispHealth,
         NetworkOptimizer.Audit.Services.IeeeOuiDatabase ouiDb,
         ILogger<UpstreamTracerService> logger)
     {
@@ -99,6 +101,7 @@ public class UpstreamTracerService
         _asnResolution = asnResolution;
         _localProbe = localProbe;
         _scopeFactory = scopeFactory;
+        _ispHealth = ispHealth;
         _ouiDb = ouiDb;
         _logger = logger;
     }
@@ -1237,6 +1240,10 @@ public class UpstreamTracerService
         // Persist same-path hop ordering so ISP Health can confirm a farther transit
         // cluster routes through a nearer one before assimilating its jitter.
         await PersistHopOrderAsync(db, wanInterface, ct);
+
+        // Drop the ISP Health cache so the "re-run discovery" banner clears on the next tab
+        // view without a manual refresh - the freshly committed ancestry is now in the DB.
+        _ispHealth.Invalidate();
 
         State.Step = TracerStep.Done;
         State.CurrentActivity = "Targets committed. The agent will start probing on the next latency-tier cycle.";

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1259,9 +1259,14 @@ public class UpstreamTracerService
             return;
         }
 
+        // Access + transit hops are the graded path; destinations (anycast DNS, CDN probes)
+        // are persisted too so ISP Health can use a destination's clean end-to-end jitter to
+        // absolve an ICMP-deprioritized hop it provably routes through.
         var targets = await db.MonitoringTargets
             .Where(t => t.WanInterface == wanInterface && t.Enabled && t.AsnNumber != null
-                && (t.TargetType == MonitoringTargetType.AccessIsp || t.TargetType == MonitoringTargetType.Transit))
+                && (t.TargetType == MonitoringTargetType.AccessIsp
+                    || t.TargetType == MonitoringTargetType.Transit
+                    || t.TargetType == MonitoringTargetType.InternetService))
             .ToListAsync(ct);
 
         // Refresh: drop prior rows for this WAN, then rebuild from this sweep.
@@ -1315,7 +1320,12 @@ public class UpstreamTracerService
                 // Non-null (even if empty) marks that ancestor data exists, so ISP Health can
                 // tell "no discovery yet" (open gate) from "on-path but no ancestors" (a first hop).
                 AncestorHopIps = string.Join(" ", ancestors),
-                Role = t.TargetType == MonitoringTargetType.AccessIsp ? UpstreamRole.AccessHop : UpstreamRole.Transit,
+                Role = t.TargetType switch
+                {
+                    MonitoringTargetType.AccessIsp => UpstreamRole.AccessHop,
+                    MonitoringTargetType.Transit => UpstreamRole.Transit,
+                    _ => UpstreamRole.PathProxy
+                },
                 WanInterface = wanInterface,
                 LastValidated = now,
                 LastTracerouteAt = now,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -585,6 +585,12 @@ public class UpstreamTracerService
     private List<AttributedHop> _mergedHops = new();
     private List<AttributedHop> _accessHopsResolved = new();
 
+    // Raw per-trace hop sequences from the last discovery sweep. Kept so commit can
+    // persist SAME-PATH hop ordering to UpstreamDiscoveries: the merged pool (_mergedHops)
+    // dedupes hop IPs across ~22 anycast traces, so its hop numbers are not on a common
+    // path and cannot prove "B routes through A". A single trace's sequence can.
+    private List<TracerouteResult> _lastTraces = new();
+
     private async Task TraceAccessIspAsync(CancellationToken ct)
     {
         State.Step = TracerStep.TracingAccessIsp;
@@ -601,6 +607,8 @@ public class UpstreamTracerService
             tasks.Add(TraceOneAsync(endpoint, ProbeMode.Udp, ct));
         }
         var results = await Task.WhenAll(tasks);
+        // Keep the raw per-trace sequences for same-path hop-order persistence at commit.
+        _lastTraces = results.Select(r => r.Result).ToList();
 
         // Summarize per CDN for the live progress UI.
         foreach (var (label, result) in results)
@@ -1225,8 +1233,101 @@ public class UpstreamTracerService
         }
 
         await db.SaveChangesAsync(ct);
+
+        // Persist same-path hop ordering so ISP Health can confirm a farther transit
+        // cluster routes through a nearer one before assimilating its jitter.
+        await PersistHopOrderAsync(db, wanInterface, ct);
+
         State.Step = TracerStep.Done;
         State.CurrentActivity = "Targets committed. The agent will start probing on the next latency-tier cycle.";
+    }
+
+    /// <summary>
+    /// Persists traceroute hop order to UpstreamDiscoveries so ISP Health can confirm a
+    /// farther transit cluster genuinely routes through a nearer one (same-path proof)
+    /// before assimilating its jitter. Ordering must come from a SINGLE trace - the merged
+    /// discovery pool dedupes hop IPs across ~22 anycast traces, so its hop numbers are not
+    /// on a common path. For each ASN we pick the one discovery trace that covered the most
+    /// of that ASN's monitored hops and record each hop's TTL on it. Hops absent from that
+    /// trace get no row, so the gate conservatively declines to order them.
+    /// </summary>
+    private async Task PersistHopOrderAsync(NetworkOptimizerDbContext db, string wanInterface, CancellationToken ct)
+    {
+        if (_lastTraces.Count == 0)
+        {
+            _logger.LogDebug("Tracer: no per-trace hop data to persist (rehydrated state); leaving UpstreamDiscoveries as-is");
+            return;
+        }
+
+        var targets = await db.MonitoringTargets
+            .Where(t => t.WanInterface == wanInterface && t.Enabled && t.AsnNumber != null
+                && (t.TargetType == MonitoringTargetType.AccessIsp || t.TargetType == MonitoringTargetType.Transit))
+            .ToListAsync(ct);
+
+        // Refresh: drop prior rows for this WAN, then rebuild from this sweep.
+        var prior = await db.UpstreamDiscoveries.Where(d => d.WanInterface == wanInterface).ToListAsync(ct);
+        if (prior.Count > 0) db.UpstreamDiscoveries.RemoveRange(prior);
+        if (targets.Count == 0)
+        {
+            await db.SaveChangesAsync(ct);
+            return;
+        }
+
+        // address -> lowest TTL on each individual trace (responding hops only).
+        var traceMaps = _lastTraces
+            .Select(tr => (Target: tr.Target.Address, Map: tr.Hops
+                .Where(h => h.Responded && !string.IsNullOrEmpty(h.Address))
+                .GroupBy(h => h.Address!, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key, g => g.Min(h => h.HopNumber), StringComparer.OrdinalIgnoreCase)))
+            .ToList();
+
+        var now = DateTime.UtcNow;
+        var written = 0;
+        foreach (var asnGroup in targets.GroupBy(t => t.AsnNumber!.Value))
+        {
+            var addrs = asnGroup.Select(t => t.Address).Where(a => !string.IsNullOrEmpty(a))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            // Canonical trace for this ASN: the single trace covering the most of its hops,
+            // so every recorded hop number is comparable on one real path.
+            Dictionary<string, int>? canonicalMap = null;
+            string? canonicalTarget = null;
+            var bestCover = 0;
+            foreach (var (target, map) in traceMaps)
+            {
+                var cover = addrs.Count(a => map.ContainsKey(a));
+                if (cover > bestCover) { bestCover = cover; canonicalMap = map; canonicalTarget = target; }
+            }
+            if (canonicalMap == null || bestCover == 0)
+            {
+                _logger.LogDebug("Tracer: AS{Asn} hop order not persisted - no single trace covered its hops", asnGroup.Key);
+                continue;
+            }
+
+            foreach (var t in asnGroup)
+            {
+                if (!canonicalMap.TryGetValue(t.Address, out var ttl)) continue;
+                db.UpstreamDiscoveries.Add(new UpstreamDiscovery
+                {
+                    MonitoringTargetId = t.Id,
+                    AsnNumber = t.AsnNumber!.Value,
+                    AsnName = t.AsnName,
+                    HopIp = t.Address,
+                    HopNumber = ttl,
+                    Role = t.TargetType == MonitoringTargetType.AccessIsp ? UpstreamRole.AccessHop : UpstreamRole.Transit,
+                    WanInterface = wanInterface,
+                    LastValidated = now,
+                    LastTracerouteAt = now,
+                    IsActive = true
+                });
+                written++;
+                _logger.LogDebug("Tracer: AS{Asn} hop#{Ttl} {Ip} ({Name}) on trace to {Trace}",
+                    t.AsnNumber, ttl, t.Address, t.PtrHostname ?? t.Name, canonicalTarget);
+            }
+        }
+
+        await db.SaveChangesAsync(ct);
+        _logger.LogInformation("Tracer: persisted {Count} upstream hop-order rows for {Wan}", written, wanInterface);
     }
 
     private static async Task UpsertTargetAsync(NetworkOptimizerDbContext db, AccessHopCandidate hop, string wanInterface, CancellationToken ct)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1243,13 +1243,13 @@ public class UpstreamTracerService
     }
 
     /// <summary>
-    /// Persists traceroute hop order to UpstreamDiscoveries so ISP Health can confirm a
-    /// farther transit cluster genuinely routes through a nearer one (same-path proof)
-    /// before assimilating its jitter. Ordering must come from a SINGLE trace - the merged
-    /// discovery pool dedupes hop IPs across ~22 anycast traces, so its hop numbers are not
-    /// on a common path. For each ASN we pick the one discovery trace that covered the most
-    /// of that ASN's monitored hops and record each hop's TTL on it. Hops absent from that
-    /// trace get no row, so the gate conservatively declines to order them.
+    /// Persists traceroute hop order to UpstreamDiscoveries so ISP Health can confirm one
+    /// monitored target routes through another (same-path proof) before its jitter absolves
+    /// the other. Hop numbers must be comparable across ASNs (ISP hop vs transit hop), so we
+    /// record TTLs from a SINGLE global canonical trace per WAN - the one discovery trace that
+    /// covered the most monitored hops, i.e. the main path out to the internet. Hops not on
+    /// that trace (divergent side paths) get no row, so the gate conservatively declines to
+    /// order them - exactly the behavior we want for divergent routers.
     /// </summary>
     private async Task PersistHopOrderAsync(NetworkOptimizerDbContext db, string wanInterface, CancellationToken ct)
     {
@@ -1281,53 +1281,51 @@ public class UpstreamTracerService
                 .ToDictionary(g => g.Key, g => g.Min(h => h.HopNumber), StringComparer.OrdinalIgnoreCase)))
             .ToList();
 
+        // Global canonical trace: the single trace covering the most monitored hops across
+        // ALL ASNs, so ISP and transit hop numbers are comparable on one real path.
+        var monitoredAddrs = targets.Select(t => t.Address).Where(a => !string.IsNullOrEmpty(a))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        Dictionary<string, int>? canonicalMap = null;
+        string? canonicalTarget = null;
+        var bestCover = 0;
+        foreach (var (target, map) in traceMaps)
+        {
+            var cover = monitoredAddrs.Count(a => map.ContainsKey(a));
+            if (cover > bestCover) { bestCover = cover; canonicalMap = map; canonicalTarget = target; }
+        }
+        if (canonicalMap == null || bestCover == 0)
+        {
+            _logger.LogDebug("Tracer: no single trace covered the monitored hops for {Wan}; hop order not persisted", wanInterface);
+            await db.SaveChangesAsync(ct);
+            return;
+        }
+
         var now = DateTime.UtcNow;
         var written = 0;
-        foreach (var asnGroup in targets.GroupBy(t => t.AsnNumber!.Value))
+        foreach (var t in targets)
         {
-            var addrs = asnGroup.Select(t => t.Address).Where(a => !string.IsNullOrEmpty(a))
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-            // Canonical trace for this ASN: the single trace covering the most of its hops,
-            // so every recorded hop number is comparable on one real path.
-            Dictionary<string, int>? canonicalMap = null;
-            string? canonicalTarget = null;
-            var bestCover = 0;
-            foreach (var (target, map) in traceMaps)
+            if (!canonicalMap.TryGetValue(t.Address, out var ttl)) continue;
+            db.UpstreamDiscoveries.Add(new UpstreamDiscovery
             {
-                var cover = addrs.Count(a => map.ContainsKey(a));
-                if (cover > bestCover) { bestCover = cover; canonicalMap = map; canonicalTarget = target; }
-            }
-            if (canonicalMap == null || bestCover == 0)
-            {
-                _logger.LogDebug("Tracer: AS{Asn} hop order not persisted - no single trace covered its hops", asnGroup.Key);
-                continue;
-            }
-
-            foreach (var t in asnGroup)
-            {
-                if (!canonicalMap.TryGetValue(t.Address, out var ttl)) continue;
-                db.UpstreamDiscoveries.Add(new UpstreamDiscovery
-                {
-                    MonitoringTargetId = t.Id,
-                    AsnNumber = t.AsnNumber!.Value,
-                    AsnName = t.AsnName,
-                    HopIp = t.Address,
-                    HopNumber = ttl,
-                    Role = t.TargetType == MonitoringTargetType.AccessIsp ? UpstreamRole.AccessHop : UpstreamRole.Transit,
-                    WanInterface = wanInterface,
-                    LastValidated = now,
-                    LastTracerouteAt = now,
-                    IsActive = true
-                });
-                written++;
-                _logger.LogDebug("Tracer: AS{Asn} hop#{Ttl} {Ip} ({Name}) on trace to {Trace}",
-                    t.AsnNumber, ttl, t.Address, t.PtrHostname ?? t.Name, canonicalTarget);
-            }
+                MonitoringTargetId = t.Id,
+                AsnNumber = t.AsnNumber!.Value,
+                AsnName = t.AsnName,
+                HopIp = t.Address,
+                HopNumber = ttl,
+                Role = t.TargetType == MonitoringTargetType.AccessIsp ? UpstreamRole.AccessHop : UpstreamRole.Transit,
+                WanInterface = wanInterface,
+                LastValidated = now,
+                LastTracerouteAt = now,
+                IsActive = true
+            });
+            written++;
+            _logger.LogDebug("Tracer: AS{Asn} hop#{Ttl} {Ip} ({Name}) on global canonical trace to {Trace}",
+                t.AsnNumber, ttl, t.Address, t.PtrHostname ?? t.Name, canonicalTarget);
         }
 
         await db.SaveChangesAsync(ct);
-        _logger.LogInformation("Tracer: persisted {Count} upstream hop-order rows for {Wan}", written, wanInterface);
+        _logger.LogInformation("Tracer: persisted {Count} upstream hop-order rows for {Wan} (global canonical trace to {Trace})",
+            written, wanInterface, canonicalTarget);
     }
 
     private static async Task UpsertTargetAsync(NetworkOptimizerDbContext db, AccessHopCandidate hop, string wanInterface, CancellationToken ct)

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15737,6 +15737,12 @@ a.affected-client:hover {
     letter-spacing: 0.04em;
 }
 
+.isp-target-stat-value {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
 .isp-factor-link {
     color: var(--text-primary);
     text-decoration: underline;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15676,9 +15676,25 @@ a.affected-client:hover {
 
 .isp-target-row {
     display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.55rem 0;
+}
+
+.isp-target-detail {
+    display: flex;
     flex-direction: column;
     gap: 0.3rem;
-    padding: 0.55rem 0;
+    flex: 1;
+    min-width: 0;
+}
+
+.isp-target-score {
+    font-size: 0.95rem;
+    font-weight: 600;
+    min-width: 2rem;
+    text-align: right;
+    flex-shrink: 0;
 }
 
 .isp-target-row + .isp-target-row {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15665,47 +15665,44 @@ a.affected-client:hover {
     z-index: 5;
 }
 
-.isp-target-list {
+.isp-hop-list {
     display: flex;
     flex-direction: column;
-    gap: 0.35rem;
     margin-top: 0.25rem;
-    padding-top: 0.5rem;
+}
+
+.isp-hop {
+    padding: 0.6rem 0;
+}
+
+.isp-hop + .isp-hop {
     border-top: 1px solid var(--border-color);
 }
 
-.isp-target-row {
+.isp-hop-row {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.55rem 0;
+    gap: 0.75rem;
 }
 
-.isp-target-detail {
+.isp-hop-main {
     display: flex;
     flex-direction: column;
-    gap: 0.3rem;
+    gap: 0.35rem;
     flex: 1;
     min-width: 0;
 }
 
-.isp-target-score {
-    font-size: 0.95rem;
-    font-weight: 600;
-    min-width: 2rem;
-    text-align: right;
-    flex-shrink: 0;
-}
-
-.isp-target-row + .isp-target-row {
-    border-top: 1px solid var(--border-color);
-}
-
-.isp-target-name {
-    font-size: 0.82rem;
+.isp-hop-name {
+    font-size: 0.85rem;
     font-weight: 500;
     color: var(--text-primary);
-    min-width: 0;
+}
+
+.isp-hop-stats {
+    display: flex;
+    gap: 1.25rem;
+    margin-top: 0.45rem;
 }
 
 .isp-target-graded {
@@ -15718,12 +15715,6 @@ a.affected-client:hover {
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-}
-
-.isp-target-stats {
-    display: flex;
-    justify-content: space-between;
-    gap: 0.5rem;
 }
 
 .isp-target-stat {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15532,6 +15532,10 @@ a.affected-client:hover {
     font-size: 0.85rem;
 }
 
+.isp-asn-stat .tooltip-icon {
+    background-color: var(--btn-map-hover);
+}
+
 .isp-asn-score-track {
     height: 5px;
     border-radius: 0 3px 3px 0;

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -30,6 +30,7 @@ public class IspHealthScorerTests
         List<AsnSeries>? transit = null,
         List<AsnSeries>? ispAsn = null,
         List<AsnSeries>? ispTargets = null,
+        List<AsnSeries>? destinations = null,
         string? firstHopTargetId = null,
         List<CongestionEvent>? congestion = null,
         List<SpeedTestSample>? speedTests = null,
@@ -64,6 +65,7 @@ public class IspHealthScorerTests
             TransitAsnSeries = transit ?? new List<AsnSeries>(),
             IspAsnSeries = ispAsn ?? new List<AsnSeries>(),
             IspTargetSeries = ispTargets ?? new List<AsnSeries>(),
+            DestinationSeries = destinations ?? new List<AsnSeries>(),
             WanRates = rates,
             InternetMedianDeltaMs = internetDeltaMs,
             ExpectedDownloadMbps = withExpectedSpeeds ? 1000 : null,
@@ -705,6 +707,58 @@ public class IspHealthScorerTests
         var divergentGrade = report.IspTargets.Single(t => t.TargetId == "isp-divergent");
         onPathGrade.OverallScore.Should().BeGreaterThan(divergentGrade.OverallScore!.Value,
             "the transit absolves the hop it routes through, not the divergent one");
+    }
+
+    [Fact]
+    public void A_clean_destination_absolves_an_icmp_deprioritized_hop_it_routes_through()
+    {
+        // An ISP hop measures high jitter to itself (ICMP control-plane deprioritization),
+        // but a monitored destination reached THROUGH it (the hop is in the destination's
+        // ancestor set) has clean end-to-end jitter - proof the forwarding plane is smooth.
+        // The destination's jitter is a hard upper bound on the hop's true jitter, so it
+        // absolves the hop. No transit routes through the hop; only the destination does.
+        var hop = new AsnSeries
+        {
+            AsnNumber = 64496,
+            AsnName = "ISP",
+            TargetIds = { "isp-icmp-hop" },
+            RoleTargetIds = { "isp-icmp-hop" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 4.5, 7.0), // high self-jitter
+            HopIps = { "10.0.0.9" }
+        };
+        var cleanDestination = new AsnSeries
+        {
+            AsnNumber = 64512,
+            AsnName = "Destination",
+            TargetIds = { "dest-clean" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 6, 0.4), // smooth end-to-end
+            HopIps = { "30.0.0.1" },
+            AncestorIps = { "10.0.0.9" } // reached through the ICMP-deprioritized hop
+        };
+        var hops = new List<AsnSeries> { hop };
+
+        var absolved = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-icmp-hop",
+                destinations: new List<AsnSeries> { cleanDestination }, hopOrderKnown: true), Gpon)
+            .IspTargets.Single(t => t.TargetId == "isp-icmp-hop");
+
+        // Same hop, but the destination does NOT route through it (different ancestor): no absolve.
+        var divergentDest = new AsnSeries
+        {
+            AsnNumber = 64512,
+            AsnName = "Destination",
+            TargetIds = { "dest-clean" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 6, 0.4),
+            HopIps = { "30.0.0.1" },
+            AncestorIps = { "10.0.0.1" } // a different hop, not ours
+        };
+        var notAbsolved = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-icmp-hop",
+                destinations: new List<AsnSeries> { divergentDest }, hopOrderKnown: true), Gpon)
+            .IspTargets.Single(t => t.TargetId == "isp-icmp-hop");
+
+        absolved.OverallScore.Should().BeGreaterThan(notAbsolved.OverallScore!.Value,
+            "a clean destination routing through the hop proves its jitter is an ICMP artifact");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -665,6 +665,8 @@ public class IspHealthScorerTests
         graded.JitterScore.Should().BeGreaterThan(ungraded.JitterScore!.Value,
             "the clean farther cluster disproves the near hop's false jitter");
         graded.JitterScore.Should().BeGreaterThan(85);
+        graded.P95JitterMs.Should().BeApproximately(0.4, 0.1,
+            "the displayed jitter is the absolved value, not the near hop's 4 ms");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -474,6 +474,137 @@ public class IspHealthScorerTests
     }
 
     [Fact]
+    public void All_isp_hops_are_graded_independently()
+    {
+        var nearHop = new AsnSeries
+        {
+            AsnNumber = 64496,
+            AsnName = "Near ISP Hop",
+            TargetIds = { "isp-hop-near" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 2.0, 0.3),
+            RoleTargetIds = { "isp-hop-near" }
+        };
+        var farHop = new AsnSeries
+        {
+            AsnNumber = 64496,
+            AsnName = "Far ISP Hop",
+            TargetIds = { "isp-hop-far" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 6.0, 1.5, lossPct: 0.8),
+            RoleTargetIds = { "isp-hop-far" }
+        };
+
+        var report = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: new List<AsnSeries> { nearHop, farHop }), Gpon);
+
+        report.IspAsns.Should().HaveCount(2);
+        var near = report.IspAsns.Single(a => a.TargetIds.Contains("isp-hop-near"));
+        var far = report.IspAsns.Single(a => a.TargetIds.Contains("isp-hop-far"));
+        near.OverallScore.Should().NotBeNull();
+        far.OverallScore.Should().NotBeNull();
+        near.OverallScore.Should().BeGreaterThan(far.OverallScore!.Value,
+            "the near hop is clean while the far hop has jitter and loss");
+        report.IspAsnDimension.Score.Should().Be(
+            (int)Math.Round((near.OverallScore!.Value + far.OverallScore!.Value) / 2.0),
+            "the dimension score should average all ISP hop grades");
+    }
+
+    [Fact]
+    public void Congestion_on_non_first_hop_affects_isp_dimension()
+    {
+        var nearHop = new AsnSeries
+        {
+            AsnNumber = 64496,
+            AsnName = "Near ISP Hop",
+            TargetIds = { "isp-hop-near" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 2.0, 0.3),
+            RoleTargetIds = { "isp-hop-near" }
+        };
+        var farHop = new AsnSeries
+        {
+            AsnNumber = 64496,
+            AsnName = "Far ISP Hop",
+            TargetIds = { "isp-hop-far" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 5.0, 0.5),
+            RoleTargetIds = { "isp-hop-far" }
+        };
+        var congestion = new List<CongestionEvent>
+        {
+            new()
+            {
+                Start = TestSeries.Start.AddHours(18),
+                End = TestSeries.Start.AddHours(22),
+                AsnNumbers = { 64496 },
+                TargetIds = { "isp-hop-far" }
+            }
+        };
+
+        var withCongestion = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: new List<AsnSeries> { nearHop, farHop }, congestion: congestion), Gpon);
+        var withoutCongestion = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: new List<AsnSeries> { nearHop, farHop }), Gpon);
+
+        var farGraded = withCongestion.IspAsns.Single(a => a.TargetIds.Contains("isp-hop-far"));
+        farGraded.CongestionEventCount.Should().Be(1);
+        farGraded.CongestionScore.Should().Be(20);
+
+        var nearGraded = withCongestion.IspAsns.Single(a => a.TargetIds.Contains("isp-hop-near"));
+        nearGraded.CongestionEventCount.Should().Be(0, "congestion only fired on the far hop");
+
+        withCongestion.IspAsnDimension.Score.Should().BeLessThan(
+            withoutCongestion.IspAsnDimension.Score!.Value,
+            "congestion on any ISP hop should lower the ISP dimension score");
+    }
+
+    [Fact]
+    public void Isp_target_health_carries_per_target_grade()
+    {
+        var nearHop = new AsnSeries
+        {
+            AsnNumber = 64496,
+            AsnName = "Near ISP Hop",
+            TargetIds = { "isp-hop-near" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 2.0, 0.3),
+            RoleTargetIds = { "isp-hop-near" }
+        };
+        var farHop = new AsnSeries
+        {
+            AsnNumber = 64496,
+            AsnName = "Far ISP Hop",
+            TargetIds = { "isp-hop-far" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 6.0, 1.5, lossPct: 0.8),
+            RoleTargetIds = { "isp-hop-far" }
+        };
+        var inputs = BuildInputs(ispAsn: new List<AsnSeries> { nearHop, farHop });
+        inputs = new IspHealthInputs
+        {
+            WindowStart = inputs.WindowStart,
+            WindowEnd = inputs.WindowEnd,
+            FirstHopSeries = inputs.FirstHopSeries,
+            FirstHopTargetId = "isp-hop-near",
+            LossPoolSeries = inputs.LossPoolSeries,
+            IspAsnSeries = new List<AsnSeries> { nearHop, farHop },
+            IspTargetSeries = new List<AsnSeries> { nearHop, farHop },
+            WanRates = inputs.WanRates,
+            ExpectedDownloadMbps = inputs.ExpectedDownloadMbps,
+            ExpectedUploadMbps = inputs.ExpectedUploadMbps,
+            ExpectedSpeedSource = inputs.ExpectedSpeedSource,
+            WanSpeedTests = inputs.WanSpeedTests,
+            CongestionEvents = inputs.CongestionEvents
+        };
+
+        var report = new IspHealthScorer(Options).Score(inputs, Gpon);
+
+        report.IspTargets.Should().HaveCount(2);
+        var nearTarget = report.IspTargets.Single(t => t.TargetId == "isp-hop-near");
+        var farTarget = report.IspTargets.Single(t => t.TargetId == "isp-hop-far");
+        nearTarget.OverallScore.Should().NotBeNull();
+        farTarget.OverallScore.Should().NotBeNull();
+        nearTarget.OverallScore.Should().BeGreaterThan(farTarget.OverallScore!.Value);
+        nearTarget.IsGradedHop.Should().BeTrue();
+        farTarget.IsGradedHop.Should().BeFalse();
+    }
+
+    [Fact]
     public void Congestion_events_lower_the_asn_grade()
     {
         var series = new List<AsnSeries> { TestSeries.Asn(64500, "TransitOne", TestSeries.Flat(TestSeries.Start, Day, 10, 0.5)) };

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -35,7 +35,8 @@ public class IspHealthScorerTests
         List<SpeedTestSample>? speedTests = null,
         bool smartQueuesEnabled = false,
         double? internetDeltaMs = null,
-        bool lineIdle = false)
+        bool lineIdle = false,
+        bool hopOrderKnown = false)
     {
         // lineIdle: a near-zero, flat WAN with no load bursts (~0% average load), for
         // exercising the load-calibrated packet-loss ceiling at the idle end.
@@ -73,7 +74,8 @@ public class IspHealthScorerTests
                 new(TestSeries.Start.AddHours(6), 980, 490)
             },
             CongestionEvents = congestion ?? new List<CongestionEvent>(),
-            SmartQueuesEnabled = smartQueuesEnabled
+            SmartQueuesEnabled = smartQueuesEnabled,
+            HopOrderKnown = hopOrderKnown
         };
     }
 
@@ -658,6 +660,40 @@ public class IspHealthScorerTests
         withCongestion.IspAsnDimension.Score.Should().BeLessThan(
             withoutCongestion.IspAsnDimension.Score!.Value,
             "congestion on any ISP hop lowers the ISP dimension score");
+    }
+
+    [Fact]
+    public void With_hop_order_a_divergent_isp_hop_is_not_absolved_but_an_on_path_one_is()
+    {
+        // With ancestor data, a clean transit absolves only the ISP hop it routes through
+        // (the hop is in its ancestor set). A divergent hop the transit never traverses keeps
+        // its own jitter - closing the AT&T divergence hole.
+        var onPath = new AsnSeries
+        {
+            AsnNumber = 64496, AsnName = "ISP", TargetIds = { "isp-onpath" }, RoleTargetIds = { "isp-onpath" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 2.1, 3.0), HopIps = { "10.0.0.1" }
+        };
+        var divergent = new AsnSeries
+        {
+            AsnNumber = 64496, AsnName = "ISP", TargetIds = { "isp-divergent" }, RoleTargetIds = { "isp-divergent" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 2.1, 3.0), HopIps = { "10.0.0.9" }
+        };
+        var transit = new AsnSeries
+        {
+            AsnNumber = 64500, AsnName = "Transit", TargetIds = { "transit" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 8, 0.4),
+            HopIps = { "20.0.0.1" }, AncestorIps = { "10.0.0.1" } // routes through the on-path hop only
+        };
+        var hops = new List<AsnSeries> { onPath, divergent };
+
+        var report = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-onpath",
+                transit: new List<AsnSeries> { transit }, hopOrderKnown: true), Gpon);
+
+        var onPathGrade = report.IspTargets.Single(t => t.TargetId == "isp-onpath");
+        var divergentGrade = report.IspTargets.Single(t => t.TargetId == "isp-divergent");
+        onPathGrade.OverallScore.Should().BeGreaterThan(divergentGrade.OverallScore!.Value,
+            "the transit absolves the hop it routes through, not the divergent one");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -668,6 +668,29 @@ public class IspHealthScorerTests
     }
 
     [Fact]
+    public void Without_hop_order_a_transit_asn_is_graded_on_its_near_cluster()
+    {
+        // Backward compat: installs that have not re-run discovery have no stored hop
+        // order, so the service never sets JitterSourceSamples. The ASN must still grade
+        // cleanly - on its nearest cluster's own jitter, with no farther-cluster absolve.
+        var nearJittery = TestSeries.Flat(TestSeries.Start, Day, 10, 4.0);
+        var noHopOrder = new AsnSeries
+        {
+            AsnNumber = 64500,
+            AsnName = "TransitOne",
+            TargetIds = { "transit-near" },
+            Samples = nearJittery
+            // JitterSourceSamples intentionally empty (no hop order available)
+        };
+
+        var graded = new IspHealthScorer(Options).Score(
+            BuildInputs(transit: new List<AsnSeries> { noHopOrder }), Gpon).TransitAsns.Single();
+
+        graded.OverallScore.Should().NotBeNull();
+        graded.MedianJitterMs.Should().BeApproximately(4.0, 0.1, "jitter is the near cluster's own, never absolved without proof");
+    }
+
+    [Fact]
     public void A_jittery_farther_cluster_never_downgrades_the_nearer()
     {
         // The near cluster is clean (0.4 ms); the farther cluster is jittery (4 ms). The far

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -554,8 +554,8 @@ public class IspHealthScorerTests
     [Fact]
     public void Higher_isp_jitter_lowers_the_dimension()
     {
-        // Jitter is graded ISP-wide (mean of the ISP targets), not per hop. A jittery ISP
-        // (one hop well above the floor) lowers the dimension vs a clean ISP.
+        // Without hop order, an ISP sibling can't absolve another (we can't prove which is
+        // downstream), so a jittery hop stays jittery and lowers the dimension vs a clean ISP.
         var clean = new List<AsnSeries>
         {
             IspHop("a", "A", 2.1, 0.4),

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -29,6 +29,8 @@ public class IspHealthScorerTests
         bool withExpectedSpeeds = true,
         List<AsnSeries>? transit = null,
         List<AsnSeries>? ispAsn = null,
+        List<AsnSeries>? ispTargets = null,
+        string? firstHopTargetId = null,
         List<CongestionEvent>? congestion = null,
         List<SpeedTestSample>? speedTests = null,
         bool smartQueuesEnabled = false,
@@ -51,9 +53,11 @@ public class IspHealthScorerTests
             WindowStart = TestSeries.Start,
             WindowEnd = TestSeries.Start + Day,
             FirstHopSeries = firstHop,
+            FirstHopTargetId = firstHopTargetId,
             LossPoolSeries = new List<List<LatencySample>> { firstHop },
             TransitAsnSeries = transit ?? new List<AsnSeries>(),
             IspAsnSeries = ispAsn ?? new List<AsnSeries>(),
+            IspTargetSeries = ispTargets ?? new List<AsnSeries>(),
             WanRates = rates,
             InternetMedianDeltaMs = internetDeltaMs,
             ExpectedDownloadMbps = withExpectedSpeeds ? 1000 : null,
@@ -473,59 +477,88 @@ public class IspHealthScorerTests
         graded.OverallScore.Should().NotBeNull();
     }
 
+    private static AsnSeries IspHop(string targetId, string name, double rttMs, double jitterMs, double lossPct = 0) => new()
+    {
+        AsnNumber = 64496,
+        AsnName = name,
+        TargetIds = { targetId },
+        Samples = TestSeries.Flat(TestSeries.Start, Day, rttMs, jitterMs, lossPct),
+        RoleTargetIds = { targetId }
+    };
+
     [Fact]
     public void All_isp_hops_are_graded_independently()
     {
-        var nearHop = new AsnSeries
+        // Both hops are the same ISP ASN; each is graded on its own, and the dimension
+        // averages every hop grade (not just the first clean hop).
+        var hops = new List<AsnSeries>
         {
-            AsnNumber = 64496,
-            AsnName = "Near ISP Hop",
-            TargetIds = { "isp-hop-near" },
-            Samples = TestSeries.Flat(TestSeries.Start, Day, 2.0, 0.3),
-            RoleTargetIds = { "isp-hop-near" }
-        };
-        var farHop = new AsnSeries
-        {
-            AsnNumber = 64496,
-            AsnName = "Far ISP Hop",
-            TargetIds = { "isp-hop-far" },
-            Samples = TestSeries.Flat(TestSeries.Start, Day, 6.0, 1.5, lossPct: 0.8),
-            RoleTargetIds = { "isp-hop-far" }
+            IspHop("isp-hop-near", "Near ISP Hop", 2.0, 0.3),
+            IspHop("isp-hop-far", "Far ISP Hop", 6.0, 1.5, lossPct: 0.8)
         };
 
         var report = new IspHealthScorer(Options).Score(
-            BuildInputs(ispAsn: new List<AsnSeries> { nearHop, farHop }), Gpon);
+            BuildInputs(ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-hop-near"), Gpon);
 
-        report.IspAsns.Should().HaveCount(2);
-        var near = report.IspAsns.Single(a => a.TargetIds.Contains("isp-hop-near"));
-        var far = report.IspAsns.Single(a => a.TargetIds.Contains("isp-hop-far"));
-        near.OverallScore.Should().NotBeNull();
-        far.OverallScore.Should().NotBeNull();
+        report.IspAsns.Should().ContainSingle("the hops collapse to one ASN card on Networks on Your Path");
+        report.IspTargets.Should().HaveCount(2);
+        var near = report.IspTargets.Single(t => t.TargetId == "isp-hop-near");
+        var far = report.IspTargets.Single(t => t.TargetId == "isp-hop-far");
         near.OverallScore.Should().BeGreaterThan(far.OverallScore!.Value,
-            "the near hop is clean while the far hop has jitter and loss");
+            "the near hop is clean while the far hop has jitter, loss, and distance");
         report.IspAsnDimension.Score.Should().Be(
             (int)Math.Round((near.OverallScore!.Value + far.OverallScore!.Value) / 2.0),
-            "the dimension score should average all ISP hop grades");
+            "the dimension score averages all ISP hop grades");
+    }
+
+    [Fact]
+    public void Far_isp_hop_is_dinged_for_intra_asn_distance_not_perfect()
+    {
+        // A second POP on the same ISP, 2 ms further out and otherwise clean, should read
+        // "fine but not perfect" (~85), not a flawless 100.
+        var hops = new List<AsnSeries>
+        {
+            IspHop("isp-hop-near", "Near ISP Hop", 2.1, 0.3),
+            IspHop("isp-hop-far", "Far ISP Hop", 4.1, 0.3)
+        };
+
+        var report = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-hop-near"), Gpon);
+
+        var far = report.IspTargets.Single(t => t.TargetId == "isp-hop-far");
+        far.ReachDeltaMs.Should().BeApproximately(2.0, 0.2);
+        far.OverallScore.Should().BeInRange(80, 89);
+        report.IspTargets.Single(t => t.TargetId == "isp-hop-near").OverallScore.Should().Be(100);
+    }
+
+    [Fact]
+    public void Jitter_above_the_path_floor_is_dinged()
+    {
+        // Floor is 0.4 ms (the near hop). A hop at 2x the floor (0.8 ms) is a clear
+        // jitter signal and must score well below a hop sitting at the floor.
+        var hops = new List<AsnSeries>
+        {
+            IspHop("isp-hop-near", "Near ISP Hop", 2.1, 0.4),
+            IspHop("isp-hop-jittery", "Jittery ISP Hop", 2.1, 0.8)
+        };
+
+        var report = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-hop-near"), Gpon);
+
+        var atFloor = report.IspTargets.Single(t => t.TargetId == "isp-hop-near");
+        var jittery = report.IspTargets.Single(t => t.TargetId == "isp-hop-jittery");
+        atFloor.OverallScore.Should().Be(100);
+        (atFloor.OverallScore!.Value - jittery.OverallScore!.Value).Should().BeGreaterThanOrEqualTo(5,
+            "0.8 ms is 2x the 0.4 ms floor and must visibly ding the hop");
     }
 
     [Fact]
     public void Congestion_on_non_first_hop_affects_isp_dimension()
     {
-        var nearHop = new AsnSeries
+        var hops = new List<AsnSeries>
         {
-            AsnNumber = 64496,
-            AsnName = "Near ISP Hop",
-            TargetIds = { "isp-hop-near" },
-            Samples = TestSeries.Flat(TestSeries.Start, Day, 2.0, 0.3),
-            RoleTargetIds = { "isp-hop-near" }
-        };
-        var farHop = new AsnSeries
-        {
-            AsnNumber = 64496,
-            AsnName = "Far ISP Hop",
-            TargetIds = { "isp-hop-far" },
-            Samples = TestSeries.Flat(TestSeries.Start, Day, 5.0, 0.5),
-            RoleTargetIds = { "isp-hop-far" }
+            IspHop("isp-hop-near", "Near ISP Hop", 2.0, 0.3),
+            IspHop("isp-hop-far", "Far ISP Hop", 5.0, 0.5)
         };
         var congestion = new List<CongestionEvent>
         {
@@ -539,60 +572,27 @@ public class IspHealthScorerTests
         };
 
         var withCongestion = new IspHealthScorer(Options).Score(
-            BuildInputs(ispAsn: new List<AsnSeries> { nearHop, farHop }, congestion: congestion), Gpon);
+            BuildInputs(ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-hop-near", congestion: congestion), Gpon);
         var withoutCongestion = new IspHealthScorer(Options).Score(
-            BuildInputs(ispAsn: new List<AsnSeries> { nearHop, farHop }), Gpon);
+            BuildInputs(ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-hop-near"), Gpon);
 
-        var farGraded = withCongestion.IspAsns.Single(a => a.TargetIds.Contains("isp-hop-far"));
-        farGraded.CongestionEventCount.Should().Be(1);
-        farGraded.CongestionScore.Should().Be(20);
-
-        var nearGraded = withCongestion.IspAsns.Single(a => a.TargetIds.Contains("isp-hop-near"));
-        nearGraded.CongestionEventCount.Should().Be(0, "congestion only fired on the far hop");
-
+        withCongestion.IspAsns.Single().CongestionEventCount.Should().Be(1, "the event fired on a hop of this ASN");
         withCongestion.IspAsnDimension.Score.Should().BeLessThan(
             withoutCongestion.IspAsnDimension.Score!.Value,
-            "congestion on any ISP hop should lower the ISP dimension score");
+            "congestion on any ISP hop lowers the ISP dimension score");
     }
 
     [Fact]
     public void Isp_target_health_carries_per_target_grade()
     {
-        var nearHop = new AsnSeries
+        var hops = new List<AsnSeries>
         {
-            AsnNumber = 64496,
-            AsnName = "Near ISP Hop",
-            TargetIds = { "isp-hop-near" },
-            Samples = TestSeries.Flat(TestSeries.Start, Day, 2.0, 0.3),
-            RoleTargetIds = { "isp-hop-near" }
-        };
-        var farHop = new AsnSeries
-        {
-            AsnNumber = 64496,
-            AsnName = "Far ISP Hop",
-            TargetIds = { "isp-hop-far" },
-            Samples = TestSeries.Flat(TestSeries.Start, Day, 6.0, 1.5, lossPct: 0.8),
-            RoleTargetIds = { "isp-hop-far" }
-        };
-        var inputs = BuildInputs(ispAsn: new List<AsnSeries> { nearHop, farHop });
-        inputs = new IspHealthInputs
-        {
-            WindowStart = inputs.WindowStart,
-            WindowEnd = inputs.WindowEnd,
-            FirstHopSeries = inputs.FirstHopSeries,
-            FirstHopTargetId = "isp-hop-near",
-            LossPoolSeries = inputs.LossPoolSeries,
-            IspAsnSeries = new List<AsnSeries> { nearHop, farHop },
-            IspTargetSeries = new List<AsnSeries> { nearHop, farHop },
-            WanRates = inputs.WanRates,
-            ExpectedDownloadMbps = inputs.ExpectedDownloadMbps,
-            ExpectedUploadMbps = inputs.ExpectedUploadMbps,
-            ExpectedSpeedSource = inputs.ExpectedSpeedSource,
-            WanSpeedTests = inputs.WanSpeedTests,
-            CongestionEvents = inputs.CongestionEvents
+            IspHop("isp-hop-near", "Near ISP Hop", 2.0, 0.3),
+            IspHop("isp-hop-far", "Far ISP Hop", 6.0, 1.5, lossPct: 0.8)
         };
 
-        var report = new IspHealthScorer(Options).Score(inputs, Gpon);
+        var report = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-hop-near"), Gpon);
 
         report.IspTargets.Should().HaveCount(2);
         var nearTarget = report.IspTargets.Single(t => t.TargetId == "isp-hop-near");
@@ -602,6 +602,40 @@ public class IspHealthScorerTests
         nearTarget.OverallScore.Should().BeGreaterThan(farTarget.OverallScore!.Value);
         nearTarget.IsGradedHop.Should().BeTrue();
         farTarget.IsGradedHop.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Transit_jitter_is_graded_on_the_farther_cluster()
+    {
+        // The near cluster shows 4 ms jitter (false - ICMP deprioritization on that hop),
+        // but the farther cluster, reached through it, is clean at 0.4 ms. Jitter must be
+        // graded on the farther cluster, so the ASN is not punished for the false near jitter.
+        var nearCluster = TestSeries.Flat(TestSeries.Start, Day, 10, 4.0);
+        var farCluster = TestSeries.Flat(TestSeries.Start, Day, 13, 0.4);
+        var withFartherSource = new AsnSeries
+        {
+            AsnNumber = 64500,
+            AsnName = "TransitOne",
+            TargetIds = { "transit-near" },
+            Samples = nearCluster,
+            JitterSourceSamples = farCluster
+        };
+        var nearOnly = new AsnSeries
+        {
+            AsnNumber = 64500,
+            AsnName = "TransitOne",
+            TargetIds = { "transit-near" },
+            Samples = nearCluster
+        };
+
+        var graded = new IspHealthScorer(Options).Score(
+            BuildInputs(transit: new List<AsnSeries> { withFartherSource }), Gpon).TransitAsns.Single();
+        var ungraded = new IspHealthScorer(Options).Score(
+            BuildInputs(transit: new List<AsnSeries> { nearOnly }), Gpon).TransitAsns.Single();
+
+        graded.JitterScore.Should().BeGreaterThan(ungraded.JitterScore!.Value,
+            "the clean farther cluster disproves the near hop's false jitter");
+        graded.JitterScore.Should().BeGreaterThan(85);
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -532,24 +532,53 @@ public class IspHealthScorerTests
     }
 
     [Fact]
-    public void Jitter_above_the_path_floor_is_dinged()
+    public void Higher_isp_jitter_lowers_the_dimension()
     {
-        // Floor is 0.4 ms (the near hop). A hop at 2x the floor (0.8 ms) is a clear
-        // jitter signal and must score well below a hop sitting at the floor.
-        var hops = new List<AsnSeries>
+        // Jitter is graded ISP-wide (mean of the ISP targets), not per hop. A jittery ISP
+        // (one hop well above the floor) lowers the dimension vs a clean ISP.
+        var clean = new List<AsnSeries>
         {
-            IspHop("isp-hop-near", "Near ISP Hop", 2.1, 0.4),
-            IspHop("isp-hop-jittery", "Jittery ISP Hop", 2.1, 0.8)
+            IspHop("a", "A", 2.1, 0.4),
+            IspHop("b", "B", 2.1, 0.4)
+        };
+        var jittery = new List<AsnSeries>
+        {
+            IspHop("a", "A", 2.1, 0.4),
+            IspHop("b", "B", 2.1, 3.0)
         };
 
-        var report = new IspHealthScorer(Options).Score(
-            BuildInputs(ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-hop-near"), Gpon);
+        var cleanReport = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: clean, ispTargets: clean, firstHopTargetId: "a"), Gpon);
+        var jitteryReport = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: jittery, ispTargets: jittery, firstHopTargetId: "a"), Gpon);
 
-        var atFloor = report.IspTargets.Single(t => t.TargetId == "isp-hop-near");
-        var jittery = report.IspTargets.Single(t => t.TargetId == "isp-hop-jittery");
-        atFloor.OverallScore.Should().Be(100);
-        (atFloor.OverallScore!.Value - jittery.OverallScore!.Value).Should().BeGreaterThanOrEqualTo(5,
-            "0.8 ms is 2x the 0.4 ms floor and must visibly ding the hop");
+        jitteryReport.IspAsnDimension.Score.Should().BeLessThan(cleanReport.IspAsnDimension.Score!.Value,
+            "higher mean ISP jitter lowers the ISP grade");
+    }
+
+    [Fact]
+    public void Isp_jitter_is_capped_by_the_cleanest_transit_asn()
+    {
+        // The ISP hops look jittery (3 ms, likely ICMP deprioritization), but a transit ASN
+        // reached through the ISP is clean at 0.4 ms - proving the ISP path is steady. The
+        // ISP grade must not be punished for the false ISP-hop jitter.
+        var ispHops = new List<AsnSeries>
+        {
+            IspHop("isp-a", "ISP A", 2.1, 3.0),
+            IspHop("isp-b", "ISP B", 2.2, 3.0)
+        };
+        var cleanTransit = new List<AsnSeries>
+        {
+            TestSeries.Asn(64500, "TransitOne", TestSeries.Flat(TestSeries.Start, Day, 8, 0.4))
+        };
+
+        var withCleanTransit = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: ispHops, ispTargets: ispHops, firstHopTargetId: "isp-a", transit: cleanTransit), Gpon);
+        var noTransit = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: ispHops, ispTargets: ispHops, firstHopTargetId: "isp-a"), Gpon);
+
+        withCleanTransit.IspAsnDimension.Score.Should().BeGreaterThan(noTransit.IspAsnDimension.Score!.Value,
+            "a clean transit ASN beyond the ISP caps the ISP's jitter");
     }
 
     [Fact]
@@ -605,11 +634,11 @@ public class IspHealthScorerTests
     }
 
     [Fact]
-    public void Transit_jitter_is_graded_on_the_farther_cluster()
+    public void A_clean_farther_cluster_absolves_false_near_jitter()
     {
         // The near cluster shows 4 ms jitter (false - ICMP deprioritization on that hop),
-        // but the farther cluster, reached through it, is clean at 0.4 ms. Jitter must be
-        // graded on the farther cluster, so the ASN is not punished for the false near jitter.
+        // but the farther cluster, reached through it, is clean at 0.4 ms. The ASN must take
+        // the better of the two, so it is not punished for the false near jitter.
         var nearCluster = TestSeries.Flat(TestSeries.Start, Day, 10, 4.0);
         var farCluster = TestSeries.Flat(TestSeries.Start, Day, 13, 0.4);
         var withFartherSource = new AsnSeries
@@ -636,6 +665,39 @@ public class IspHealthScorerTests
         graded.JitterScore.Should().BeGreaterThan(ungraded.JitterScore!.Value,
             "the clean farther cluster disproves the near hop's false jitter");
         graded.JitterScore.Should().BeGreaterThan(85);
+    }
+
+    [Fact]
+    public void A_jittery_farther_cluster_never_downgrades_the_nearer()
+    {
+        // The near cluster is clean (0.4 ms); the farther cluster is jittery (4 ms). The far
+        // cluster's jitter is its own problem further along the path and must NOT drag the
+        // nearer cluster's grade down. Absolve-only: take the better, never the worse.
+        var nearClean = TestSeries.Flat(TestSeries.Start, Day, 10, 0.4);
+        var farJittery = TestSeries.Flat(TestSeries.Start, Day, 13, 4.0);
+        var withJitteryFar = new AsnSeries
+        {
+            AsnNumber = 64500,
+            AsnName = "TransitOne",
+            TargetIds = { "transit-near" },
+            Samples = nearClean,
+            JitterSourceSamples = farJittery
+        };
+        var nearOnly = new AsnSeries
+        {
+            AsnNumber = 64500,
+            AsnName = "TransitOne",
+            TargetIds = { "transit-near" },
+            Samples = nearClean
+        };
+
+        var withFar = new IspHealthScorer(Options).Score(
+            BuildInputs(transit: new List<AsnSeries> { withJitteryFar }), Gpon).TransitAsns.Single();
+        var without = new IspHealthScorer(Options).Score(
+            BuildInputs(transit: new List<AsnSeries> { nearOnly }), Gpon).TransitAsns.Single();
+
+        withFar.JitterScore.Should().Be(without.JitterScore,
+            "a jittery farther cluster must not downgrade the clean nearer cluster");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -582,6 +582,33 @@ public class IspHealthScorerTests
     }
 
     [Fact]
+    public void Transit_jitter_above_the_isp_mean_does_not_raise_isp_jitter()
+    {
+        // The cap is min, not max: a jittery transit ASN must never drag the ISP jitter UP.
+        // ISP hops are clean (0.3 ms); transit is jittery (2.0 ms). The ISP keeps its own
+        // mean for both score and display.
+        var ispHops = new List<AsnSeries>
+        {
+            IspHop("isp-a", "ISP A", 2.1, 0.3),
+            IspHop("isp-b", "ISP B", 2.1, 0.3)
+        };
+        var jitteryTransit = new List<AsnSeries>
+        {
+            TestSeries.Asn(64500, "TransitOne", TestSeries.Flat(TestSeries.Start, Day, 8, 2.0))
+        };
+
+        var withJitteryTransit = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: ispHops, ispTargets: ispHops, firstHopTargetId: "isp-a", transit: jitteryTransit), Gpon);
+        var noTransit = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: ispHops, ispTargets: ispHops, firstHopTargetId: "isp-a"), Gpon);
+
+        withJitteryTransit.IspAsnDimension.Score.Should().Be(noTransit.IspAsnDimension.Score,
+            "a jittery transit ASN must not raise the ISP jitter (cap is min, not max)");
+        withJitteryTransit.IspAsns.Single().P95JitterMs.Should().BeApproximately(0.3, 0.05,
+            "the displayed ISP jitter stays at the ISP mean when transit is not cleaner");
+    }
+
+    [Fact]
     public void Congestion_on_non_first_hop_affects_isp_dimension()
     {
         var hops = new List<AsnSeries>

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -579,6 +579,8 @@ public class IspHealthScorerTests
 
         withCleanTransit.IspAsnDimension.Score.Should().BeGreaterThan(noTransit.IspAsnDimension.Score!.Value,
             "a clean transit ASN beyond the ISP caps the ISP's jitter");
+        withCleanTransit.IspAsns.Single().JitterAssimilated.Should().BeTrue("the transit floor capped the ISP jitter");
+        noTransit.IspAsns.Single().JitterAssimilated.Should().BeFalse("no transit to assimilate from");
     }
 
     [Fact]
@@ -694,6 +696,8 @@ public class IspHealthScorerTests
         graded.JitterScore.Should().BeGreaterThan(85);
         graded.P95JitterMs.Should().BeApproximately(0.4, 0.1,
             "the displayed jitter is the absolved value, not the near hop's 4 ms");
+        graded.JitterAssimilated.Should().BeTrue("the farther cluster pulled the jitter down");
+        graded.RawJitterMs.Should().BeApproximately(4.0, 0.1, "the raw near reading is kept for the tooltip");
     }
 
     [Fact]
@@ -750,6 +754,7 @@ public class IspHealthScorerTests
 
         withFar.JitterScore.Should().Be(without.JitterScore,
             "a jittery farther cluster must not downgrade the clean nearer cluster");
+        withFar.JitterAssimilated.Should().BeFalse("nothing was assimilated - the near cluster was already cleaner");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -778,6 +778,21 @@ public class IspHealthScorerTests
     }
 
     [Fact]
+    public void Displayed_rtt_winsorizes_a_flap_so_one_spike_does_not_distort_it()
+    {
+        // 8 ms baseline all window with a 5-minute spike to 2000 ms (a route flap). The raw
+        // mean would jump to ~15 ms; the winsorized mean (P99-capped) stays at the baseline.
+        var spikeStart = TestSeries.Start.AddHours(6);
+        var series = TestSeries.Flat(TestSeries.Start, Day, 8, 0.5)
+            .WithSegment(spikeStart, spikeStart.AddMinutes(5), 2000, 0.5);
+        var transit = new List<AsnSeries> { TestSeries.Asn(64500, "TransitOne", series) };
+
+        var graded = new IspHealthScorer(Options).Score(BuildInputs(transit: transit), Gpon).TransitAsns.Single();
+
+        graded.MeanRttMs.Should().BeApproximately(8, 1.5, "a sub-1% flap is winsorized out of the displayed RTT");
+    }
+
+    [Fact]
     public void Congestion_events_lower_the_asn_grade()
     {
         var series = new List<AsnSeries> { TestSeries.Asn(64500, "TransitOne", TestSeries.Flat(TestSeries.Start, Day, 10, 0.5)) };

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -34,15 +34,20 @@ public class IspHealthScorerTests
         List<CongestionEvent>? congestion = null,
         List<SpeedTestSample>? speedTests = null,
         bool smartQueuesEnabled = false,
-        double? internetDeltaMs = null)
+        double? internetDeltaMs = null,
+        bool lineIdle = false)
     {
-        var rates = TestSeries.Throughput(TestSeries.Start, Day, 50, 5)
-            .Select(r => r.Time >= LoadedDownStart && r.Time < LoadedDownEnd
-                ? r with { DownloadBps = 800_000_000 }
-                : r.Time >= LoadedUpStart && r.Time < LoadedUpEnd
-                    ? r with { UploadBps = 400_000_000 }
-                    : r)
-            .ToList();
+        // lineIdle: a near-zero, flat WAN with no load bursts (~0% average load), for
+        // exercising the load-calibrated packet-loss ceiling at the idle end.
+        var rates = lineIdle
+            ? TestSeries.Throughput(TestSeries.Start, Day, 1, 1)
+            : TestSeries.Throughput(TestSeries.Start, Day, 50, 5)
+                .Select(r => r.Time >= LoadedDownStart && r.Time < LoadedDownEnd
+                    ? r with { DownloadBps = 800_000_000 }
+                    : r.Time >= LoadedUpStart && r.Time < LoadedUpEnd
+                        ? r with { UploadBps = 400_000_000 }
+                        : r)
+                .ToList();
 
         var firstHop = TestSeries.Flat(TestSeries.Start, Day, idleRtt, 0.3, lossPct)
             .WithSegment(LoadedDownStart, LoadedDownEnd, idleRtt + loadedDownDelta, 0.3)
@@ -151,10 +156,25 @@ public class IspHealthScorerTests
     [Fact]
     public void Loss_past_acceptable_drops_drastically()
     {
-        var report = new IspHealthScorer(Options).Score(BuildInputs(lossPct: 0.075), Gpon);
+        // On an idle line, 0.075% is well past the strict idle ceiling and collapses.
+        var report = new IspHealthScorer(Options).Score(BuildInputs(lossPct: 0.075, lineIdle: true), Gpon);
 
         var factor = report.AccessDimension.Factors.Single(f => f.Name == "Packet Loss");
         factor.Score.Should().BeLessThan(30);
+    }
+
+    [Fact]
+    public void Packet_loss_ceiling_is_calibrated_to_average_load()
+    {
+        // The same 0.3% loss is fine on a line that ran loaded much of the window but a
+        // real problem on an idle line, where ~no loss is expected.
+        var idle = new IspHealthScorer(Options).Score(BuildInputs(lossPct: 0.3, lineIdle: true), Gpon)
+            .AccessDimension.Factors.Single(f => f.Name == "Packet Loss").Score;
+        var loaded = new IspHealthScorer(Options).Score(BuildInputs(lossPct: 0.3), Gpon)
+            .AccessDimension.Factors.Single(f => f.Name == "Packet Loss").Score;
+
+        loaded.Should().BeGreaterThan(idle!.Value,
+            "the loss ceiling tolerates more when the line was busy over the window");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -667,22 +667,33 @@ public class IspHealthScorerTests
     {
         // With ancestor data, a clean transit absolves only the ISP hop it routes through
         // (the hop is in its ancestor set). A divergent hop the transit never traverses keeps
-        // its own jitter - closing the AT&T divergence hole.
+        // its own jitter - closing the divergent-path absolve hole.
         var onPath = new AsnSeries
         {
-            AsnNumber = 64496, AsnName = "ISP", TargetIds = { "isp-onpath" }, RoleTargetIds = { "isp-onpath" },
-            Samples = TestSeries.Flat(TestSeries.Start, Day, 2.1, 3.0), HopIps = { "10.0.0.1" }
+            AsnNumber = 64496,
+            AsnName = "ISP",
+            TargetIds = { "isp-onpath" },
+            RoleTargetIds = { "isp-onpath" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 2.1, 3.0),
+            HopIps = { "10.0.0.1" }
         };
         var divergent = new AsnSeries
         {
-            AsnNumber = 64496, AsnName = "ISP", TargetIds = { "isp-divergent" }, RoleTargetIds = { "isp-divergent" },
-            Samples = TestSeries.Flat(TestSeries.Start, Day, 2.1, 3.0), HopIps = { "10.0.0.9" }
+            AsnNumber = 64496,
+            AsnName = "ISP",
+            TargetIds = { "isp-divergent" },
+            RoleTargetIds = { "isp-divergent" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 2.1, 3.0),
+            HopIps = { "10.0.0.9" }
         };
         var transit = new AsnSeries
         {
-            AsnNumber = 64500, AsnName = "Transit", TargetIds = { "transit" },
+            AsnNumber = 64500,
+            AsnName = "Transit",
+            TargetIds = { "transit" },
             Samples = TestSeries.Flat(TestSeries.Start, Day, 8, 0.4),
-            HopIps = { "20.0.0.1" }, AncestorIps = { "10.0.0.1" } // routes through the on-path hop only
+            HopIps = { "20.0.0.1" },
+            AncestorIps = { "10.0.0.1" } // routes through the on-path hop only
         };
         var hops = new List<AsnSeries> { onPath, divergent };
 
@@ -849,23 +860,24 @@ public class IspHealthScorerTests
     [Fact]
     public void Same_asn_as_isp_and_transit_attributes_congestion_by_role()
     {
-        // AT&T is AS7018 for both the access ISP and a transit provider. A congestion
-        // event on the transit hops must credit only the transit card, not the ISP card.
+        // A vertically integrated carrier can be the same ASN for both the access ISP and a
+        // transit provider. A congestion event on the transit hops must credit only the
+        // transit card, not the ISP card.
         var ispSeries = new AsnSeries
         {
-            AsnNumber = 7018,
-            AsnName = "AT&T",
-            TargetIds = { "att-isp-hop" },
+            AsnNumber = 64500,
+            AsnName = "IntegratedCarrier",
+            TargetIds = { "carrier-isp-hop" },
             Samples = TestSeries.Flat(TestSeries.Start, Day, 2.0, 0.3),
-            RoleTargetIds = { "att-isp-hop" }
+            RoleTargetIds = { "carrier-isp-hop" }
         };
         var transitSeries = new AsnSeries
         {
-            AsnNumber = 7018,
-            AsnName = "AT&T",
-            TargetIds = { "att-transit-hop" },
+            AsnNumber = 64500,
+            AsnName = "IntegratedCarrier",
+            TargetIds = { "carrier-transit-hop" },
             Samples = TestSeries.Flat(TestSeries.Start, Day, 2.0, 0.3),
-            RoleTargetIds = { "att-transit-hop" }
+            RoleTargetIds = { "carrier-transit-hop" }
         };
         var congestion = new List<CongestionEvent>
         {
@@ -873,8 +885,8 @@ public class IspHealthScorerTests
             {
                 Start = TestSeries.Start.AddHours(19),
                 End = TestSeries.Start.AddHours(21),
-                AsnNumbers = { 7018 },
-                TargetIds = { "att-transit-hop" }
+                AsnNumbers = { 64500 },
+                TargetIds = { "carrier-transit-hop" }
             }
         };
         var report = new IspHealthScorer(Options).Score(

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -137,7 +137,7 @@ public class IspHealthScorerTests
 
         nearOnly.Score.Should().Be(100);
         withOlt.Score.Should().BeLessThan(100);
-        withOlt.ValueText.Should().Contain("6.00 ms down");
+        withOlt.ValueText.Should().Contain("6.0 ms down");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -137,7 +137,7 @@ public class IspHealthScorerTests
 
         nearOnly.Score.Should().Be(100);
         withOlt.Score.Should().BeLessThan(100);
-        withOlt.ValueText.Should().Contain("6.0 ms down");
+        withOlt.ValueText.Should().Contain("6.00 ms down");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -166,11 +166,11 @@ public class IspHealthScorerTests
     [Fact]
     public void Packet_loss_ceiling_is_calibrated_to_average_load()
     {
-        // The same 0.3% loss is fine on a line that ran loaded much of the window but a
+        // The same 0.1% loss is fine on a line that ran loaded much of the window but a
         // real problem on an idle line, where ~no loss is expected.
-        var idle = new IspHealthScorer(Options).Score(BuildInputs(lossPct: 0.3, lineIdle: true), Gpon)
+        var idle = new IspHealthScorer(Options).Score(BuildInputs(lossPct: 0.1, lineIdle: true), Gpon)
             .AccessDimension.Factors.Single(f => f.Name == "Packet Loss").Score;
-        var loaded = new IspHealthScorer(Options).Score(BuildInputs(lossPct: 0.3), Gpon)
+        var loaded = new IspHealthScorer(Options).Score(BuildInputs(lossPct: 0.1), Gpon)
             .AccessDimension.Factors.Single(f => f.Name == "Packet Loss").Score;
 
         loaded.Should().BeGreaterThan(idle!.Value,


### PR DESCRIPTION
## Summary

Reworks the ISP Network scoring in ISP Health so **every** ISP-network hop on the path is graded, not just the nearest one. Packet-loss and congestion signals are read across all ISP targets, and jitter attribution is topology-aware so a clean upstream path can't mask a congested hop it doesn't actually route through. Hop ancestry learned from the discovery traceroutes is what makes the attribution exact.

## ISP Network (Networks on Your Path)

- **Grade all ISP hops individually.** The ISP Network dimension reflects congestion or jitter on any hop in the path. The lowest-RTT hop still anchors the access idle-latency rating.
- **Divergence-correct jitter absolve.** A cleaner upstream (a transit ASN, a deeper ISP hop, or a monitored destination) only pulls a hop's jitter down when it provably routes through that hop - i.e. the hop is in its discovered ancestor set. A divergent clean transit can no longer clear a congested hop it never traverses.
- **Destination-based absolve.** A monitored endpoint's end-to-end jitter is a hard upper bound on any on-path hop's true jitter. So when a hop measures high jitter to itself (ICMP control-plane deprioritization) but traffic flowing through it to a real destination arrives smooth, the destination absolves it. Same strict routes-through gate; never on faith.
- **No trivial assimilation.** A witness must sit at least 0.05 ms below a hop's own jitter to count - within that band it's measurement noise, so the hop keeps its own reading (no absolve, no icon). Applies to ISP hops and transit ASNs.
- **Learned hop order.** Ancestor sets are computed from the discovery traceroutes (every trace contributes, including those to destinations) and persisted. Before any re-discovery the gate falls back to the prior lenient behavior, so existing installs see no change until they re-run discovery - and a CTA banner prompts them to.
- One card per ASN combining the bar and table views, with the RTT range across the ASN's hops. Each hop shows its effective (absolved) jitter with an info icon explaining when and why it was absolved. Intra-ASN reach is scored as distance, not a fault.

## Transit Health

- **RTT shown as a winsorized mean (P99-capped)** so a single bad probe or a brief route flap doesn't distort the displayed latency, while sustained elevation stays fully visible.

## Access Layer

- **Packet-loss ceiling calibrated to average WAN load** - quadratic in utilization, saturating at 75%, using the same windowed load metric that drives Loaded Loss.
- Latency display precision tidied: idle latency to 2 decimals, loaded-latency deltas to 1.

## UX

- **Re-run Upstream Discovery banner** when no trace map is persisted, so users get the divergence-correct attribution. It clears automatically once discovery is committed (the commit invalidates the ISP Health cache), with no manual refresh.
- "Last updated" ages on its own every 30 s.

## Storage

- Adds `AncestorHopIps` to `UpstreamDiscoveries` (migration included) to persist per-hop upstream ancestry, including destination endpoints.

## Tests

236 Web tests pass, covering the routes-through gate, divergent-hop attribution, destination absolve, the winsorized mean, the load-calibrated loss ceiling, and same-ASN role attribution.