### PR TITLE
ISP Health: cut InfluxDB load from periodic recomputes

### DIFF
--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -79,8 +79,21 @@ public class IspHealthOptions
     /// </summary>
     public int LoadWindowSeconds { get; set; } = 15;
 
-    /// <summary>How long a computed report stays fresh before recompute.</summary>
-    public TimeSpan CacheTtl { get; set; } = TimeSpan.FromMinutes(5);
+    /// <summary>
+    /// How long a computed report stays fresh before the ISP Health tab recomputes it.
+    /// The score is a 48 h rolling metric, so a few minutes of staleness is invisible; the
+    /// "Last updated" label discloses the age. Each recompute is a heavy Influx query burst,
+    /// so this is kept generous.
+    /// </summary>
+    public TimeSpan CacheTtl { get; set; } = TimeSpan.FromMinutes(15);
+
+    /// <summary>
+    /// Max report age the glanceable dashboard / Live View score tile tolerates before it
+    /// triggers a background recompute. Longer than <see cref="CacheTtl"/> because the tile is
+    /// a summary, not the detail view - this decouples the tile from the recompute cadence so
+    /// simply watching Live View doesn't drive a full ISP Health query every few minutes.
+    /// </summary>
+    public TimeSpan DashboardScoreTtl { get; set; } = TimeSpan.FromMinutes(30);
 
     /// <summary>Bucket size in minutes for congestion detection.</summary>
     public int CongestionBucketMinutes { get; set; } = 15;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -51,8 +51,12 @@ public class IspHealthService
     /// </summary>
     public IspHealthSnapshot GetCachedScore()
     {
+        // The glanceable tile tolerates a longer staleness than the detail tab, so sitting on
+        // Live View doesn't drive a full Influx recompute every CacheTtl. A recompute is still
+        // kicked off once the tile crosses DashboardScoreTtl (or on first populate); the ISP
+        // Health tab uses the shorter CacheTtl (via GetReportAsync) for fresher detail.
         var report = _cached?.Report;
-        if (report != null && DateTime.UtcNow - report.ComputedAt < _options.CacheTtl)
+        if (report != null && DateTime.UtcNow - report.ComputedAt < _options.DashboardScoreTtl)
             return new IspHealthSnapshot(IspHealthStatus.Ready, report.OverallScore, report.ComputedAt);
 
         if (!_computing)


### PR DESCRIPTION
## Summary

Each ISP Health recompute runs a heavy InfluxDB read (a 48-hour range aggregated into 15-second buckets, across access/transit/internet target types plus WAN rates). On a cold page cache that's a real DB CPU spike. The problem: the glanceable ISP Health **score tile** on the dashboard and Live View was triggering a *full* recompute every `CacheTtl` (5 minutes) just by being on screen - so simply watching Live View drove a heavy query every few minutes, whether or not anyone was looking at the ISP Health detail.

## Change

- The dashboard / Live View tile (`GetCachedScore`) now tolerates a longer staleness (`DashboardScoreTtl`, 30 min) before kicking off a background recompute. Watching Live View no longer forces a full query every few minutes; the tile serves the last score and discloses its age.
- `CacheTtl` raised 5 → 15 min for the ISP Health detail tab.

## Safety

This is purely a caching/cadence change. The query window, 15-second aggregation, load classification, and the loaded-latency / loaded-loss math are all untouched - any report that does compute is identical to before, it just recomputes less often. The only visible effect is the score may be a few minutes older, shown in the "Last updated" label. A manual Refresh still forces an immediate recompute.

Net effect: on Live View, the periodic recompute drops from every ~5 min to at most every ~30 min, with no change to scoring accuracy.