### PR TITLE
CM/ONT/Cellular Stats: hide orphaned series from deleted configs; add Cox CGM4981

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1003,7 +1003,7 @@
                                 <option value="arris-surfboard">ARRIS Surfboard (HTTP)</option>
                                 <option value="arris-surfboard-hnap">ARRIS Surfboard S33/S34 (HNAP)</option>
                                 <option value="motorola-hnap">Motorola MB8611, MB8600 (HNAP)</option>
-                                <option value="xfinity-gateway">Xfinity XB8, XB10 (HTTP)</option>
+                                <option value="xfinity-gateway">Xfinity XB8/XB10, Cox CGM4981 (HTTP)</option>
                             </select>
                         </div>
                     </div>

--- a/src/NetworkOptimizer.Web/Endpoints/CellularChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/CellularChartEndpoints.cs
@@ -38,14 +38,18 @@ public static class CellularChartEndpoints
             var modems = await modemService.GetModemsAsync();
             var nameMap = modems.ToDictionary(m => m.Id.ToString(), m => m.Name);
 
-            // Keys are "modemId" or "modemId:mode" (e.g. "3:LTE", "3:5G NSA")
-            var result = data.Select(kvp =>
+            // Keys are "modemId" or "modemId:mode" (e.g. "3:LTE", "3:5G NSA").
+            // Only surface modems that still have a config. Deleting a modem config
+            // leaves its historical series in InfluxDB; without this filter those
+            // orphaned modem_ids show up as phantom "Modem {id}" entries on the chart.
+            var result = data
+                .Where(kvp => nameMap.ContainsKey(kvp.Key.Split(':', 2)[0]))
+                .Select(kvp =>
             {
                 var parts = kvp.Key.Split(':', 2);
                 var rawModemId = parts[0];
                 var mode = parts.Length > 1 ? parts[1] : null;
-                nameMap.TryGetValue(rawModemId, out var modemName);
-                modemName ??= $"Modem {rawModemId}";
+                var modemName = nameMap[rawModemId];
 
                 var label = !string.IsNullOrEmpty(mode)
                     ? $"{modemName} ({mode})"

--- a/src/NetworkOptimizer.Web/Endpoints/CmChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/CmChartEndpoints.cs
@@ -37,10 +37,14 @@ public static class CmChartEndpoints
             var configs = await cmService.GetConfigsAsync();
             var nameMap = configs.ToDictionary(c => c.Id.ToString(), c => c.Name);
 
-            var result = data.Select(kvp =>
+            // Only surface modems that still have a config. Deleting a CM config
+            // leaves its historical series in InfluxDB; without this filter those
+            // orphaned cm_ids show up as phantom "CM {id}" entries on the chart.
+            var result = data
+                .Where(kvp => nameMap.ContainsKey(kvp.Key))
+                .Select(kvp =>
             {
-                nameMap.TryGetValue(kvp.Key, out var name);
-                name ??= $"CM {kvp.Key}";
+                var name = nameMap[kvp.Key];
 
                 return new
                 {

--- a/src/NetworkOptimizer.Web/Endpoints/OntChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/OntChartEndpoints.cs
@@ -37,10 +37,14 @@ public static class OntChartEndpoints
             var configs = await ontService.GetConfigsAsync();
             var nameMap = configs.ToDictionary(c => c.Id.ToString(), c => c.Name);
 
-            var result = data.Select(kvp =>
+            // Only surface ONTs that still have a config. Deleting an ONT config
+            // leaves its historical series in InfluxDB; without this filter those
+            // orphaned ont_ids show up as phantom "ONT {id}" entries on the chart.
+            var result = data
+                .Where(kvp => nameMap.ContainsKey(kvp.Key))
+                .Select(kvp =>
             {
-                nameMap.TryGetValue(kvp.Key, out var name);
-                name ??= $"ONT {kvp.Key}";
+                var name = nameMap[kvp.Key];
 
                 return new
                 {

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
@@ -6,7 +6,7 @@ using NetworkOptimizer.Monitoring.Providers;
 namespace NetworkOptimizer.Web.Services.CableModemProviders;
 
 /// <summary>
-/// Cable modem provider for Xfinity gateways (XB8, XB10).
+/// Cable modem provider for gateways sharing the Xfinity/Technicolor web UI (Xfinity XB8/XB10, Cox CGM4981).
 /// Authenticates via form POST to /check.jst, then scrapes DOCSIS channel
 /// tables from /network_setup.jst. The tables use a transposed layout where
 /// each row is a metric and each column is a channel.


### PR DESCRIPTION
## What changed

### Fixed phantom devices on monitoring charts
Deleting a cable modem, ONT, or cellular modem config left its historical series behind in InfluxDB. Once another device of the same type was configured, the chart endpoints surfaced those orphaned series as phantom entries with synthetic names ("CM 1", "ONT 1", "Modem 1") that had no settings entry and no live data.

The CM, ONT, and cellular chart endpoints now only return series whose id still maps to an existing config, so deleted devices no longer haunt the charts. This applies at every time window, including the long 7-30 day ranges used for trend analysis. Existing stale data stays in InfluxDB but is no longer displayed.

### Added Cox CGM4981 to the Xfinity gateway provider
The Cox CGM4981 (Panoramic Gateway) shares the same web UI as the Xfinity XB8/XB10, so the existing provider already works for it. Updated the provider dropdown label and class summary to list it explicitly so Cox users can find it.

## Why
Users reported a second modem ("CM 1") appearing in CM Stats with no information after configuring their own modem. It was a leftover InfluxDB series from a previously removed config. The same latent issue existed on the ONT and cellular chart endpoints.