### PR TITLE
Live View: fix overlapping time labels in half-width and constrained layouts (#807)

### DIFF
--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -162,12 +162,22 @@ function buildOpts() {
 
 // Time labels pinned to a fixed grid, rendered as x-axis annotations so
 // they scroll with the data. Full 24-hour time on every tick, placed below
-// the axis in the space freed by the hidden built-in labels. The 20s grid
-// fits ~15 HH:mm:ss labels on desktop widths; narrow (mobile) charts drop
-// to a 60s grid so the labels don't collide.
+// the axis in the space freed by the hidden built-in labels. The grid
+// interval is chosen from the chart's own rendered width (clientWidth), not
+// the viewport, so half-view panels and mobile - which constrain the chart
+// below full width while the viewport stays wide - step out to a sparser
+// grid instead of colliding. Full width keeps the dense 20s grid.
 function buildTimeTicks(minMs, maxMs) {
     const width = document.getElementById(elId)?.clientWidth || 800;
-    const GRID_MS = width < 640 ? 60000 : 20000;
+    // An HH:mm:ss label is ~46px at 10px; budget 64px per slot for breathing
+    // room, then pick the densest grid whose tick count fits that budget.
+    const slots = Math.max(2, Math.floor(width / 64));
+    const spanMs = maxMs - minMs;
+    const GRIDS = [20000, 30000, 60000, 120000];
+    let GRID_MS = GRIDS[GRIDS.length - 1];
+    for (const g of GRIDS) {
+        if (spanMs / g <= slots) { GRID_MS = g; break; }
+    }
     const ticks = [];
     for (let t = Math.ceil(minMs / GRID_MS) * GRID_MS; t <= maxMs; t += GRID_MS) {
         const d = new Date(t);


### PR DESCRIPTION
Fixes #807.

## What changed
The Live View throughput chart's X-axis time labels overlapped into an unreadable smear when the widget was shown at half width on the Dashboard. Full width rendered fine.

The time-label grid switched between a dense 20s spacing and a sparse 60s spacing based on a hardcoded 640px threshold that assumed the chart filled the viewport. In half-view the panel constrains the chart to roughly half the page (~680px) while the viewport stays wide, so the chart kept the dense 20s grid (15 `HH:mm:ss` labels) in half the space and the labels collided.

The label spacing is now chosen from the chart's own rendered width: it budgets room per label and steps the grid out (20s → 30s → 60s → 120s) as the chart gets narrower. Full width is unchanged (20s); half-view now uses 30s; mobile stays at 60s.

## Why it covers everything
Both the Dashboard widget and the Monitoring Live tab render through the same chart module and read their own container width, so the fix applies to both, plus tablet and mobile layouts, without any per-layout plumbing.