### PR TITLE
Add Kiosk mode to hide the side menu for mini-display presentation (#782)

### DIFF
--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -79,6 +79,15 @@
 </head>
 
 <body>
+    <script>
+        // Apply kiosk mode before the app renders so the sidebar never flashes
+        // in on a kiosk display. Per-device preference; see Settings > UI / Display.
+        try {
+            if (localStorage.getItem('networkOptimizerKioskMode') === '1') {
+                document.body.classList.add('kiosk-mode');
+            }
+        } catch (e) { }
+    </script>
     <Routes />
 
     <!-- Custom reconnect modal (prevents Blazor from injecting shadow DOM version) -->
@@ -101,6 +110,28 @@
         <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/demo-mask.js")"></script>
     }
     <script>
+        // Kiosk mode: per-device (localStorage), forces the collapsed hamburger
+        // layout at any width so a mini-display shows just the content.
+        function setKioskMode(enabled) {
+            try {
+                if (enabled) {
+                    localStorage.setItem('networkOptimizerKioskMode', '1');
+                    document.body.classList.add('kiosk-mode');
+                } else {
+                    localStorage.removeItem('networkOptimizerKioskMode');
+                    document.body.classList.remove('kiosk-mode');
+                }
+            } catch (e) { }
+        }
+
+        function getKioskMode() {
+            try {
+                return localStorage.getItem('networkOptimizerKioskMode') === '1';
+            } catch (e) {
+                return false;
+            }
+        }
+
         function downloadFile(fileName, contentType, base64Data) {
             const linkSource = `data:${contentType};base64,${base64Data}`;
             const downloadLink = document.createElement('a');

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -2349,7 +2349,23 @@
         </div>
     </div>
 
-    <!-- 12. Data Management -->
+    <!-- 12. UI / Display Settings -->
+    <div class="card">
+        <div class="card-header">
+            <h2 class="card-title">UI / Display Settings</h2>
+        </div>
+        <div class="card-body">
+            <div class="form-group">
+                <label class="checkbox-label">
+                    <input type="checkbox" checked="@_kioskMode" @onchange="OnKioskModeChanged" />
+                    <span>Kiosk mode</span>
+                </label>
+                <small class="form-help">Collapses the side menu into the hamburger button at any window size, giving the content full width - handy for presenting graphs on a mini display. This preference is saved per device (this browser only).</small>
+            </div>
+        </div>
+    </div>
+
+    <!-- 13. Data Management -->
     <div class="card">
         <div class="card-header">
             <h2 class="card-title">Data Management</h2>
@@ -2749,6 +2765,24 @@
     private bool testingCrowdsec = false;
     private string crowdsecMessage = "";
     private string crowdsecMessageClass = "";
+
+    // UI / Display Settings - per-device, persisted in localStorage (not the DB)
+    private bool _kioskMode = false;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _kioskMode = await JS.InvokeAsync<bool>("getKioskMode");
+            StateHasChanged();
+        }
+    }
+
+    private async Task OnKioskModeChanged(ChangeEventArgs e)
+    {
+        _kioskMode = e.Value is true;
+        await JS.InvokeVoidAsync("setKioskMode", _kioskMode);
+    }
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15753,3 +15753,59 @@ a.affected-client:hover {
 .isp-factor-link:hover {
     color: var(--primary-hover);
 }
+
+body.kiosk-mode .hamburger-btn {
+    display: block;
+}
+
+body.kiosk-mode .mobile-logo {
+    display: block;
+    height: 60px;
+    margin: -0.5rem 0;
+    max-height: 20vw;
+}
+
+body.kiosk-mode .mobile-logo img {
+    height: 100%;
+    width: auto;
+}
+
+body.kiosk-mode .sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100vh;
+    height: 100dvh;
+    width: 280px;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    z-index: 1000;
+    overflow-y: auto;
+}
+
+body.kiosk-mode .sidebar.open {
+    transform: translateX(0);
+}
+
+body.kiosk-mode .sidebar-overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 999;
+}
+
+body.kiosk-mode .sidebar-overlay.visible {
+    display: block;
+}
+
+body.kiosk-mode .main-content {
+    width: 100%;
+}
+
+body.kiosk-mode .status-indicators {
+    display: none;
+}

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15806,6 +15806,17 @@ body.kiosk-mode .main-content {
     width: 100%;
 }
 
+body.kiosk-mode .top-bar {
+    height: auto;
+    padding: 0.75rem 1rem;
+    gap: 0.5rem;
+}
+
+body.kiosk-mode .header-actions {
+    flex: 1;
+    justify-content: flex-end;
+}
+
 body.kiosk-mode .status-indicators {
     display: none;
 }


### PR DESCRIPTION
Fixes #782.

## What this adds
A new **UI / Display Settings** section in Settings (above Data Management) with a **Kiosk mode** toggle. When enabled, the left side menu collapses into the hamburger button at any window width and the content takes the full width - useful for presenting the dashboard graphs on a mini display where the sidebar otherwise eats half the screen.

## How it behaves
- Reuses the existing responsive collapsed layout, just forced regardless of viewport width (previously you could only get it by being under the mobile breakpoint).
- Scoped to the navigation chrome, so on a wide display the dashboard keeps its full-width multi-column layout rather than dropping to the narrow single-column mobile view.
- Logout and the hamburger stay in the top bar, so the menu is always reachable and the toggle is easy to turn back off.
- The preference is **per device** (saved in that browser only), so enabling it on a kiosk screen doesn't affect your normal workstation.
- Applied before the app renders, so a kiosk screen never flashes the sidebar in on load or reboot.