### PR TITLE
Fix Network Tools double-highlighting the Monitoring nav item (#709)

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Layout/NavMenu.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/NavMenu.razor
@@ -16,7 +16,7 @@
             </NavLink>
         </li>
         <li class="nav-item nav-sub-item" @onclick="HandleNavClick">
-            <NavLink class="nav-link" href="/monitoring/tools">
+            <NavLink class="nav-link" href="/network-tools">
                 <span class="nav-sub-icon">└</span>
                 <span class="nav-text">Network Tools</span>
             </NavLink>

--- a/src/NetworkOptimizer.Web/Components/Pages/MonitoringTools.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/MonitoringTools.razor
@@ -1,4 +1,4 @@
-@page "/monitoring/tools"
+@page "/network-tools"
 @rendermode InteractiveServer
 @using NetworkOptimizer.Web.Services
 @using NetworkOptimizer.Web.Services.Monitoring

--- a/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
@@ -8,7 +8,7 @@
         <h2 class="card-title">Latency targets</h2>
         <div style="display: flex; align-items: center; gap: 0.5rem;">
             <span class="status-badge status-active" @onclick:stopPropagation="true">@Targets.Count(t => t.Enabled) active</span>
-            <a href="/monitoring/tools" class="tooltip-icon settings-link" data-tooltip="Run an ad-hoc probe" @onclick:stopPropagation="true">
+            <a href="/network-tools" class="tooltip-icon settings-link" data-tooltip="Run an ad-hoc probe" @onclick:stopPropagation="true">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="16" height="16">
                     <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM5.5 8.5a.5.5 0 010-1h2.793L7.146 6.354a.5.5 0 11.708-.708l2 2a.5.5 0 010 .708l-2 2a.5.5 0 11-.708-.708L8.293 8.5H5.5zm6.354-1.146a.5.5 0 010 .708L10.707 9.207H13.5a.5.5 0 010 1h-2.793l1.147 1.147a.5.5 0 11-.708.708l-2-2a.5.5 0 010-.708l2-2a.5.5 0 01.708 0z" clip-rule="evenodd" />
                 </svg>


### PR DESCRIPTION
Fixes #709.

Network Tools lived at `/monitoring/tools`. Because that path is nested under `/monitoring`, the Monitoring nav item's default prefix match also lit up whenever Network Tools was open, so both menu items highlighted at once - inconsistent with every other menu item.

Moving the page to `/network-tools` takes it out from under `/monitoring`, so only Network Tools highlights now. It still appears visually nested as a sub-item in the menu.