### PR TITLE
Data Usage: pay-as-you-go (manual reset) bucket mode

### DIFF
--- a/src/NetworkOptimizer.Storage/Migrations/20260615155126_AddDataUsageResetMode.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260615155126_AddDataUsageResetMode.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260615155126_AddDataUsageResetMode")]
+    partial class AddDataUsageResetMode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260615155126_AddDataUsageResetMode.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260615155126_AddDataUsageResetMode.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDataUsageResetMode : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastResetAt",
+                table: "WanDataUsageConfigs",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ResetMode",
+                table: "WanDataUsageConfigs",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LastResetAt",
+                table: "WanDataUsageConfigs");
+
+            migrationBuilder.DropColumn(
+                name: "ResetMode",
+                table: "WanDataUsageConfigs");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/WanDataUsageConfig.cs
+++ b/src/NetworkOptimizer.Storage/Models/WanDataUsageConfig.cs
@@ -3,6 +3,21 @@ using System.ComponentModel.DataAnnotations;
 namespace NetworkOptimizer.Storage.Models;
 
 /// <summary>
+/// How a WAN's data usage cycle resets.
+/// </summary>
+public enum DataUsageResetMode
+{
+    /// <summary>Usage resets automatically on a calendar day each month (default, original behavior).</summary>
+    Monthly = 0,
+
+    /// <summary>
+    /// Pay-as-you-go bucket: usage accumulates open-ended and only resets when the user
+    /// manually resets it (e.g. after topping up a prepaid balance that never expires).
+    /// </summary>
+    Manual = 1
+}
+
+/// <summary>
 /// Per-WAN interface data usage tracking configuration.
 /// Tracks billing cycles and data caps for ISPs with usage limits.
 /// </summary>
@@ -38,15 +53,29 @@ public class WanDataUsageConfig
     public int WarningThresholdPercent { get; set; } = 80;
 
     /// <summary>
-    /// Day of month the billing cycle starts (1-28)
+    /// How the usage cycle resets. Monthly (default) resets on a calendar day each month.
+    /// Manual is an open-ended pay-as-you-go bucket the user resets when they top up.
+    /// </summary>
+    public DataUsageResetMode ResetMode { get; set; } = DataUsageResetMode.Monthly;
+
+    /// <summary>
+    /// Day of month the billing cycle starts (1-28). Only used in <see cref="DataUsageResetMode.Monthly"/> mode.
     /// </summary>
     public int BillingCycleDayOfMonth { get; set; } = 1;
+
+    /// <summary>
+    /// For <see cref="DataUsageResetMode.Manual"/> mode: when the bucket was last reset (UTC).
+    /// Usage is counted from this point forward. Null until the first reset, in which case
+    /// counting falls back to <see cref="CreatedAt"/>. Unused in Monthly mode.
+    /// </summary>
+    public DateTime? LastResetAt { get; set; }
 
     /// <summary>
     /// Manual usage adjustment in GB. Added to the calculated usage from snapshots.
     /// Allows users to set a starting point when enabling tracking mid-cycle,
     /// or to correct the calculated total if it's off.
-    /// Automatically resets to 0 when the background service detects a billing cycle rollover.
+    /// Automatically resets to 0 when the cycle rolls over (a billing-cycle rollover in
+    /// Monthly mode, or a manual reset in Manual mode).
     /// </summary>
     public double ManualAdjustmentGb { get; set; }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -404,6 +404,8 @@
                     var capGb = config?.DataCapGb ?? 0;
                     var warningPct = config?.WarningThresholdPercent ?? 80;
                     var billingDay = config?.BillingCycleDayOfMonth ?? 1;
+                    var resetMode = config?.ResetMode ?? DataUsageResetMode.Monthly;
+                    var isManual = resetMode == DataUsageResetMode.Manual;
                     var displayName = wan.Name;
                     var manualAdj = config?.ManualAdjustmentGb ?? 0;
                     var isAdjustmentUnlocked = _unlockedAdjustmentWans.Contains(wanGroup);
@@ -438,7 +440,7 @@
                                 {
                                     @* Usage display *@
                                     var savedBillingDay = summary?.BillingCycleStart.Day ?? billingDay;
-                                    var billingDayChanged = billingDay != savedBillingDay;
+                                    var billingDayChanged = !isManual && billingDay != savedBillingDay;
                                     @if (summary != null && capGb > 0 && !billingDayChanged)
                                     {
                                         var fillPct = Math.Min(summary.UsagePercent, 100);
@@ -483,18 +485,29 @@
                                                    @oninput="() => _dirtyConfigs.Add(wanGroup)"
                                                    @onchange="e => EditDataUsageConfig(wanGroup, warningPct: int.TryParse(e.Value?.ToString(), out var v) ? v : 80)" />
                                         </div>
-                                        <div class="form-group schedule-field schedule-field-compact" style="max-width: 180px;">
-                                            <label>Usage Resets On <span class="tooltip-icon tooltip-icon-sm" data-tooltip="The day of the month your ISP resets your data usage to zero. Check your carrier account for the renewal or due date.">?</span></label>
-                                            <select class="form-control" value="@billingDay"
-                                                    @onchange="e => EditDataUsageConfig(wanGroup, billingDay: int.TryParse(e.Value?.ToString(), out var v) ? v : 1)">
-                                                @for (var d = 1; d <= 28; d++)
-                                                {
-                                                    <option value="@d">@(DisplayFormatters.FormatOrdinal(d)) of month</option>
-                                                }
+                                        <div class="form-group schedule-field schedule-field-compact" style="max-width: 200px;">
+                                            <label>Usage Resets <span class="tooltip-icon tooltip-icon-sm" data-tooltip="Monthly: usage zeroes on a calendar day each month. Pay-as-you-go: an open-ended prepaid bucket you reset yourself when you top up (e.g. a prepaid 5G/LTE balance that never expires).">?</span></label>
+                                            <select class="form-control" value="@((int)resetMode)"
+                                                    @onchange="e => EditDataUsageConfig(wanGroup, resetMode: int.TryParse(e.Value?.ToString(), out var v) ? (DataUsageResetMode)v : DataUsageResetMode.Monthly)">
+                                                <option value="0">Monthly on a set day</option>
+                                                <option value="1">Pay-as-you-go bucket</option>
                                             </select>
                                         </div>
+                                        @if (!isManual)
+                                        {
+                                            <div class="form-group schedule-field schedule-field-compact" style="max-width: 180px;">
+                                                <label>Resets On <span class="tooltip-icon tooltip-icon-sm" data-tooltip="The day of the month your ISP resets your data usage to zero. Check your carrier account for the renewal or due date.">?</span></label>
+                                                <select class="form-control" value="@billingDay"
+                                                        @onchange="e => EditDataUsageConfig(wanGroup, billingDay: int.TryParse(e.Value?.ToString(), out var v) ? v : 1)">
+                                                    @for (var d = 1; d <= 28; d++)
+                                                    {
+                                                        <option value="@d">@(DisplayFormatters.FormatOrdinal(d)) of month</option>
+                                                    }
+                                                </select>
+                                            </div>
+                                        }
                                         <div class="form-group schedule-field schedule-field-compact">
-                                            <label>Usage Adjustment (GB) <span class="tooltip-icon tooltip-icon-sm" data-tooltip="Added to the tracked total. Use positive values for usage before tracking was enabled, or negative to correct an overcount. Resets to 0 each billing cycle.">?</span></label>
+                                            <label>Usage Adjustment (GB) <span class="tooltip-icon tooltip-icon-sm" data-tooltip="Added to the tracked total. Use positive values for usage before tracking was enabled, or negative to correct an overcount. Resets to 0 when the cycle resets.">?</span></label>
                                             <input type="number" class="form-control" value="@manualAdj" step="0.1"
                                                    readonly="@(!_unlockedAdjustmentWans.Contains(wanGroup))"
                                                    style="@(!_unlockedAdjustmentWans.Contains(wanGroup) ? "cursor: pointer; opacity: 0.7;" : "")"
@@ -505,7 +518,17 @@
                                     </div>
 
                                     @* Mid-cycle hint - show when first enabling tracking mid-cycle *@
-                                    @if (_newlyEnabledWans.Contains(wanGroup) && manualAdj == 0)
+                                    @if (_newlyEnabledWans.Contains(wanGroup) && manualAdj == 0 && isManual)
+                                    {
+                                        <div class="alert-info" style="margin-top: 0.75rem; padding: 0.625rem 0.75rem; font-size: 0.8125rem; line-height: 1.5;">
+                                            <span>
+                                                This bucket counts usage from now forward. If you've already used part of your current
+                                                balance, add it with the <strong>Usage Adjustment</strong> field above so the cap reflects
+                                                what's actually left. Hit <strong>Reset bucket</strong> each time you top up to start a fresh count.
+                                            </span>
+                                        </div>
+                                    }
+                                    else if (_newlyEnabledWans.Contains(wanGroup) && manualAdj == 0)
                                     {
                                         var now = DateTime.UtcNow;
                                         var (cycleStart, cycleEnd) = WanDataUsageService.GetBillingCycleDates(billingDay, now);
@@ -545,7 +568,24 @@
                                         </div>
                                     }
 
-                                    @* Billing cycle status - computed from in-memory billingDay so it updates live *@
+                                    @* Cycle status - computed live. Monthly shows the billing window; Manual shows the open bucket. *@
+                                    @if (isManual)
+                                    {
+                                        var bucketSince = (config?.LastResetAt ?? config?.CreatedAt ?? DateTime.UtcNow);
+                                        <div class="schedule-status" style="margin-top: 0.75rem; justify-content: space-between;">
+                                            <span class="schedule-status-item">
+                                                <span class="detail-label">Counting since:</span>
+                                                <span class="detail-value">@DateTime.SpecifyKind(bucketSince, DateTimeKind.Utc).ToLocalTime().ToString("MMM d, yyyy")</span>
+                                            </span>
+                                            @if (!isDirty)
+                                            {
+                                                <button class="btn btn-secondary btn-sm"
+                                                        @onclick="() => ResetUsageBucket(wanGroup)"
+                                                        data-tooltip="Archive the current total and start counting from zero - do this when you top up your balance.">Reset bucket</button>
+                                            }
+                                        </div>
+                                    }
+                                    else
                                     {
                                         var (dispCycleStart, dispCycleEnd) = WanDataUsageService.GetBillingCycleDates(billingDay, DateTime.Now);
                                         var dispDaysRemaining = Math.Max(0, (int)Math.Ceiling((dispCycleEnd - DateTime.UtcNow).TotalDays));
@@ -575,11 +615,11 @@
                                         if (history != null && history.Count > 0)
                                         {
                                             <details class="usage-history">
-                                                <summary>Usage history (@history.Count past @(history.Count == 1 ? "cycle" : "cycles"))</summary>
+                                                <summary>Usage history (@history.Count past @((isManual ? "bucket" : "cycle") + (history.Count == 1 ? "" : "s")))</summary>
                                                 <div class="table-responsive" style="margin-top: 0.5rem;">
                                                     <table class="data-table">
                                                         <thead>
-                                                            <tr><th>Billing cycle</th><th>Used</th><th>Cap</th></tr>
+                                                            <tr><th>@(isManual ? "Bucket" : "Billing cycle")</th><th>Used</th><th>Cap</th></tr>
                                                         </thead>
                                                         <tbody>
                                                             @foreach (var h in history)
@@ -3144,7 +3184,8 @@
     }
 
     private void EditDataUsageConfig(string wanKey,
-        double? capGb = null, int? warningPct = null, int? billingDay = null, double? manualAdj = null)
+        double? capGb = null, int? warningPct = null, int? billingDay = null, double? manualAdj = null,
+        DataUsageResetMode? resetMode = null)
     {
         if (!_dataUsageConfigs.TryGetValue(wanKey, out var config))
             return;
@@ -3153,8 +3194,22 @@
         if (warningPct.HasValue) config.WarningThresholdPercent = warningPct.Value;
         if (billingDay.HasValue) config.BillingCycleDayOfMonth = billingDay.Value;
         if (manualAdj.HasValue) config.ManualAdjustmentGb = manualAdj.Value;
+        if (resetMode.HasValue) config.ResetMode = resetMode.Value;
 
         _dirtyConfigs.Add(wanKey);
+    }
+
+    private async Task ResetUsageBucket(string wanKey)
+    {
+        try
+        {
+            await DataUsageService.ResetUsageAsync(wanKey);
+            await LoadDataUsageAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error resetting data usage bucket for {WanKey}", wanKey);
+        }
     }
 
     private async Task SaveDataUsageConfig(string wanKey)

--- a/src/NetworkOptimizer.Web/Services/WanDataUsageService.cs
+++ b/src/NetworkOptimizer.Web/Services/WanDataUsageService.cs
@@ -63,7 +63,7 @@ public class WanDataUsageService : BackgroundService
 
         foreach (var config in configs)
         {
-            var (cycleStart, cycleEnd) = GetBillingCycleDates(config.BillingCycleDayOfMonth, now);
+            var (cycleStart, cycleEnd) = GetCycleWindow(config, now);
             var usedBytes = await CalculateCycleUsageAsync(db, config.WanKey, cycleStart, now, ct);
             var usedGb = Math.Max(0, usedBytes / (1024.0 * 1024.0 * 1024.0) + config.ManualAdjustmentGb);
 
@@ -78,13 +78,14 @@ public class WanDataUsageService : BackgroundService
             {
                 WanKey = config.WanKey,
                 Name = config.Name,
+                ResetMode = config.ResetMode,
                 UsedGb = usedGb,
                 CapGb = config.DataCapGb,
                 WarningThresholdPercent = config.WarningThresholdPercent,
                 UsagePercent = config.DataCapGb > 0 ? usedGb / config.DataCapGb * 100.0 : 0,
                 BillingCycleStart = cycleStart,
                 BillingCycleEnd = cycleEnd,
-                DaysRemaining = Math.Max(0, (int)Math.Ceiling((cycleEnd - now).TotalDays)),
+                DaysRemaining = cycleEnd.HasValue ? Math.Max(0, (int)Math.Ceiling((cycleEnd.Value - now).TotalDays)) : null,
                 IsOverCap = config.DataCapGb > 0 && usedGb >= config.DataCapGb,
                 IsOverWarning = config.DataCapGb > 0 && usedGb >= config.DataCapGb * config.WarningThresholdPercent / 100.0,
                 Enabled = config.Enabled,
@@ -137,6 +138,13 @@ public class WanDataUsageService : BackgroundService
             existing.ManualAdjustmentGb = config.ManualAdjustmentGb;
             existing.WarningThresholdPercent = Math.Clamp(config.WarningThresholdPercent, 1, 100);
             existing.BillingCycleDayOfMonth = Math.Clamp(config.BillingCycleDayOfMonth, 1, 28);
+
+            // Switching into Manual mode anchors the bucket window now so usage counts forward
+            // from the switch (rather than from some arbitrary past calendar cycle start).
+            if (config.ResetMode == DataUsageResetMode.Manual && existing.ResetMode != DataUsageResetMode.Manual)
+                existing.LastResetAt = DateTime.UtcNow;
+            existing.ResetMode = config.ResetMode;
+
             existing.UpdatedAt = DateTime.UtcNow;
         }
         else
@@ -146,6 +154,7 @@ public class WanDataUsageService : BackgroundService
             config.BillingCycleDayOfMonth = Math.Clamp(config.BillingCycleDayOfMonth, 1, 28);
             config.CreatedAt = DateTime.UtcNow;
             config.UpdatedAt = DateTime.UtcNow;
+            // A new Manual bucket counts from creation; LastResetAt stays null until first reset.
             db.WanDataUsageConfigs.Add(config);
         }
 
@@ -159,6 +168,61 @@ public class WanDataUsageService : BackgroundService
         _currentUsage = [];
 
         return existing ?? config;
+    }
+
+    /// <summary>
+    /// Resets a Manual (pay-as-you-go) bucket: rolls the bucket's current usage into durable
+    /// history, stamps a new reset time so counting restarts from zero, and clears the manual
+    /// adjustment. No-op for Monthly configs, which roll over automatically on their billing day.
+    /// </summary>
+    public async Task ResetUsageAsync(string wanKey)
+    {
+        await using var db = await _dbFactory.CreateDbContextAsync();
+        var config = await db.WanDataUsageConfigs.FirstOrDefaultAsync(c => c.WanKey == wanKey);
+        if (config == null || config.ResetMode != DataUsageResetMode.Manual)
+            return;
+
+        var now = DateTime.UtcNow;
+        var (cycleStart, _) = GetCycleWindow(config, now);
+
+        // Capture the bucket's usage (including any manual adjustment) so history keeps a record.
+        var usedBytes = await CalculateCycleUsageAsync(db, config.WanKey, cycleStart, now, CancellationToken.None);
+        var usedGb = Math.Max(0, usedBytes / (1024.0 * 1024.0 * 1024.0) + config.ManualAdjustmentGb);
+
+        // Only write history for a non-empty, non-degenerate window, and never collide with an
+        // existing (WanKey, CycleStart) row (the table has a unique index on that pair).
+        if (usedGb > 0 && cycleStart < now)
+        {
+            var alreadyRecorded = await db.WanDataUsageHistory
+                .AnyAsync(h => h.WanKey == config.WanKey && h.CycleStart == cycleStart);
+            if (!alreadyRecorded)
+            {
+                db.WanDataUsageHistory.Add(new WanDataUsageHistory
+                {
+                    WanKey = config.WanKey,
+                    Name = config.Name,
+                    CycleStart = cycleStart,
+                    CycleEnd = now,
+                    UsedGb = usedGb,
+                    CapGb = config.DataCapGb,
+                    RecordedAt = now
+                });
+            }
+        }
+
+        config.LastResetAt = now;
+        config.ManualAdjustmentGb = 0;
+        config.UpdatedAt = now;
+
+        await db.SaveChangesAsync();
+
+        // Clear in-memory state so the fresh bucket can alert again and the cache recomputes.
+        _alertState.Remove(wanKey);
+        _lastCycleStart[wanKey] = now;
+        _currentUsage = [];
+
+        _logger.LogInformation("Manual data usage bucket reset for {WanName}: archived {UsedGb:F2} GB, counting restarts now",
+            config.Name, usedGb);
     }
 
     /// <summary>
@@ -292,11 +356,11 @@ public class WanDataUsageService : BackgroundService
                 var isReset = lastSnapshot != null &&
                     (wan.RxBytes < lastSnapshot.RxBytes || wan.TxBytes < lastSnapshot.TxBytes);
 
-                // First snapshot for this WAN: check if gateway booted within current billing cycle.
+                // First snapshot for this WAN: check if gateway booted within the current cycle.
                 // If so, the raw byte counters represent all usage since boot = all usage this cycle.
                 if (lastSnapshot == null && gatewayBootTime.HasValue)
                 {
-                    var (blCycleStart, _) = GetBillingCycleDates(config.BillingCycleDayOfMonth, now);
+                    var (blCycleStart, _) = GetCycleWindow(config, now);
                     isBaseline = gatewayBootTime.Value >= blCycleStart;
 
                     if (isBaseline)
@@ -316,15 +380,17 @@ public class WanDataUsageService : BackgroundService
                 });
             }
 
-            // Calculate billing cycle usage
-            var (cycleStart, cycleEnd) = GetBillingCycleDates(config.BillingCycleDayOfMonth, now);
+            // Calculate cycle usage window (monthly billing cycle, or open-ended manual bucket)
+            var (cycleStart, cycleEnd) = GetCycleWindow(config, now);
 
-            // Reset manual adjustment when a new billing cycle starts
+            // Reset manual adjustment when the cycle rolls over. In Monthly mode this fires when the
+            // calendar billing cycle changes. In Manual mode the window start only advances via an
+            // explicit reset (which already clears the adjustment), so this is a harmless backstop.
             if (_lastCycleStart.TryGetValue(config.WanKey, out var prevCycleStart) && prevCycleStart != cycleStart
                 && config.ManualAdjustmentGb != 0)
             {
                 config.ManualAdjustmentGb = 0;
-                _logger.LogInformation("Billing cycle rolled over for {WanName}, reset manual adjustment to 0", config.Name);
+                _logger.LogInformation("Usage cycle rolled over for {WanName}, reset manual adjustment to 0", config.Name);
             }
             _lastCycleStart[config.WanKey] = cycleStart;
 
@@ -343,6 +409,7 @@ public class WanDataUsageService : BackgroundService
             {
                 WanKey = config.WanKey,
                 Name = config.Name,
+                ResetMode = config.ResetMode,
                 WanType = wan?.Type,
                 IsUp = wan?.Up ?? false,
                 UsedGb = usedGb,
@@ -351,7 +418,7 @@ public class WanDataUsageService : BackgroundService
                 UsagePercent = config.DataCapGb > 0 ? usedGb / config.DataCapGb * 100.0 : 0,
                 BillingCycleStart = cycleStart,
                 BillingCycleEnd = cycleEnd,
-                DaysRemaining = Math.Max(0, (int)Math.Ceiling((cycleEnd - now).TotalDays)),
+                DaysRemaining = cycleEnd.HasValue ? Math.Max(0, (int)Math.Ceiling((cycleEnd.Value - now).TotalDays)) : null,
                 IsOverCap = config.DataCapGb > 0 && usedGb >= config.DataCapGb,
                 IsOverWarning = config.DataCapGb > 0 && usedGb >= config.DataCapGb * config.WarningThresholdPercent / 100.0,
                 Enabled = config.Enabled,
@@ -557,6 +624,26 @@ public class WanDataUsageService : BackgroundService
         return (cycleStart, cycleEnd);
     }
 
+    /// <summary>
+    /// Returns the usage cycle window for a config based on its reset mode.
+    /// Monthly: the calendar billing cycle containing <paramref name="now"/>, with an end date.
+    /// Manual: an open-ended window starting at the last reset (or creation if never reset),
+    /// with a null end date (the bucket has no scheduled rollover).
+    /// Public for testing.
+    /// </summary>
+    public static (DateTime CycleStart, DateTime? CycleEnd) GetCycleWindow(WanDataUsageConfig config, DateTime now)
+    {
+        if (config.ResetMode == DataUsageResetMode.Manual)
+        {
+            // Cycle/snapshot math operates in UTC; LastResetAt and CreatedAt are stored UTC.
+            var start = config.LastResetAt ?? config.CreatedAt;
+            return (DateTime.SpecifyKind(start, DateTimeKind.Utc), null);
+        }
+
+        var (cycleStart, cycleEnd) = GetBillingCycleDates(config.BillingCycleDayOfMonth, now);
+        return (cycleStart, cycleEnd);
+    }
+
     private async Task CheckThresholdsAsync(WanDataUsageConfig config, WanUsageSummary summary,
         DateTime cycleStart, CancellationToken ct)
     {
@@ -587,7 +674,7 @@ public class WanDataUsageService : BackgroundService
                     ["wanKey"] = config.WanKey,
                     ["usedGb"] = summary.UsedGb.ToString("F2"),
                     ["capGb"] = config.DataCapGb.ToString("F0"),
-                    ["daysRemaining"] = summary.DaysRemaining.ToString()
+                    ["daysRemaining"] = summary.DaysRemaining?.ToString() ?? ""
                 }
             }, ct);
 
@@ -614,7 +701,7 @@ public class WanDataUsageService : BackgroundService
                     ["wanKey"] = config.WanKey,
                     ["usedGb"] = summary.UsedGb.ToString("F2"),
                     ["capGb"] = config.DataCapGb.ToString("F0"),
-                    ["daysRemaining"] = summary.DaysRemaining.ToString()
+                    ["daysRemaining"] = summary.DaysRemaining?.ToString() ?? ""
                 }
             }, ct);
 
@@ -640,6 +727,11 @@ public class WanDataUsageService : BackgroundService
 
         foreach (var config in configs)
         {
+            // Manual (pay-as-you-go) buckets have no calendar cycles to roll up; their history
+            // rows are written on explicit reset via ResetUsageAsync.
+            if (config.ResetMode == DataUsageResetMode.Manual)
+                continue;
+
             var minTsRaw = await db.WanDataUsageSnapshots
                 .Where(s => s.WanKey == config.WanKey)
                 .MinAsync(s => (DateTime?)s.Timestamp, ct);
@@ -718,8 +810,20 @@ public class WanDataUsageService : BackgroundService
     {
         try
         {
-            // Keep 2 billing cycles worth of data
+            // Keep 2 billing cycles worth of data for monthly configs.
             var cutoff = now.AddMonths(-2);
+
+            // Never prune snapshots a Manual (pay-as-you-go) bucket still needs: its window can
+            // stay open for many months and usage is summed from the cycle start forward, so
+            // pull the cutoff back to the earliest active manual bucket start. Without this, an
+            // open bucket older than 2 months would lose its early deltas and undercount.
+            foreach (var config in configs.Where(c => c.ResetMode == DataUsageResetMode.Manual))
+            {
+                var (manualStart, _) = GetCycleWindow(config, now);
+                if (manualStart < cutoff)
+                    cutoff = manualStart;
+            }
+
             var deleted = await db.WanDataUsageSnapshots
                 .Where(s => s.Timestamp < cutoff)
                 .ExecuteDeleteAsync(ct);
@@ -785,15 +889,20 @@ public record WanUsageSummary
 {
     public string WanKey { get; init; } = string.Empty;
     public string Name { get; init; } = string.Empty;
+    /// <summary>How this WAN's usage cycle resets (monthly billing day vs. manual bucket).</summary>
+    public DataUsageResetMode ResetMode { get; init; } = DataUsageResetMode.Monthly;
     public string? WanType { get; init; }
     public bool IsUp { get; init; }
     public double UsedGb { get; init; }
     public double CapGb { get; init; }
     public int WarningThresholdPercent { get; init; }
     public double UsagePercent { get; init; }
+    /// <summary>Start of the current cycle. For Manual mode this is the last reset (or creation) time.</summary>
     public DateTime BillingCycleStart { get; init; }
-    public DateTime BillingCycleEnd { get; init; }
-    public int DaysRemaining { get; init; }
+    /// <summary>End of the current billing cycle, or null for an open-ended Manual bucket.</summary>
+    public DateTime? BillingCycleEnd { get; init; }
+    /// <summary>Days left in the current billing cycle, or null for an open-ended Manual bucket.</summary>
+    public int? DaysRemaining { get; init; }
     public bool IsOverCap { get; init; }
     public bool IsOverWarning { get; init; }
     public bool Enabled { get; init; }

--- a/src/NetworkOptimizer.Web/Services/WanDataUsageService.cs
+++ b/src/NetworkOptimizer.Web/Services/WanDataUsageService.cs
@@ -2,7 +2,6 @@ using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Alerts.Events;
 using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Storage.Models;
-using NetworkOptimizer.UniFi;
 
 namespace NetworkOptimizer.Web.Services;
 
@@ -139,10 +138,15 @@ public class WanDataUsageService : BackgroundService
             existing.WarningThresholdPercent = Math.Clamp(config.WarningThresholdPercent, 1, 100);
             existing.BillingCycleDayOfMonth = Math.Clamp(config.BillingCycleDayOfMonth, 1, 28);
 
-            // Switching into Manual mode anchors the bucket window now so usage counts forward
-            // from the switch (rather than from some arbitrary past calendar cycle start).
+            // Switching into Manual mode absorbs the current cycle's usage into the bucket by
+            // anchoring its window to the billing cycle start, so the displayed total is
+            // unchanged across the switch (no measured usage is silently discarded). If the user
+            // actually topped up mid-cycle, a single "Reset bucket" click zeroes it from now.
             if (config.ResetMode == DataUsageResetMode.Manual && existing.ResetMode != DataUsageResetMode.Manual)
-                existing.LastResetAt = DateTime.UtcNow;
+            {
+                var (cycleStart, _) = GetBillingCycleDates(existing.BillingCycleDayOfMonth, DateTime.UtcNow);
+                existing.LastResetAt = cycleStart;
+            }
             existing.ResetMode = config.ResetMode;
 
             existing.UpdatedAt = DateTime.UtcNow;

--- a/src/NetworkOptimizer.Web/Services/WanDataUsageService.cs
+++ b/src/NetworkOptimizer.Web/Services/WanDataUsageService.cs
@@ -181,52 +181,62 @@ public class WanDataUsageService : BackgroundService
     /// </summary>
     public async Task ResetUsageAsync(string wanKey)
     {
-        await using var db = await _dbFactory.CreateDbContextAsync();
-        var config = await db.WanDataUsageConfigs.FirstOrDefaultAsync(c => c.WanKey == wanKey);
-        if (config == null || config.ResetMode != DataUsageResetMode.Manual)
-            return;
-
-        var now = DateTime.UtcNow;
-        var (cycleStart, _) = GetCycleWindow(config, now);
-
-        // Capture the bucket's usage (including any manual adjustment) so history keeps a record.
-        var usedBytes = await CalculateCycleUsageAsync(db, config.WanKey, cycleStart, now, CancellationToken.None);
-        var usedGb = Math.Max(0, usedBytes / (1024.0 * 1024.0 * 1024.0) + config.ManualAdjustmentGb);
-
-        // Only write history for a non-empty, non-degenerate window, and never collide with an
-        // existing (WanKey, CycleStart) row (the table has a unique index on that pair).
-        if (usedGb > 0 && cycleStart < now)
+        // Serialize against the background poll: it mutates _alertState and _lastCycleStart
+        // (plain dictionaries) under this same lock, so we must hold it too before touching them.
+        await _pollLock.WaitAsync();
+        try
         {
-            var alreadyRecorded = await db.WanDataUsageHistory
-                .AnyAsync(h => h.WanKey == config.WanKey && h.CycleStart == cycleStart);
-            if (!alreadyRecorded)
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            var config = await db.WanDataUsageConfigs.FirstOrDefaultAsync(c => c.WanKey == wanKey);
+            if (config == null || config.ResetMode != DataUsageResetMode.Manual)
+                return;
+
+            var now = DateTime.UtcNow;
+            var (cycleStart, _) = GetCycleWindow(config, now);
+
+            // Capture the bucket's usage (including any manual adjustment) so history keeps a record.
+            var usedBytes = await CalculateCycleUsageAsync(db, config.WanKey, cycleStart, now, CancellationToken.None);
+            var usedGb = Math.Max(0, usedBytes / (1024.0 * 1024.0 * 1024.0) + config.ManualAdjustmentGb);
+
+            // Only write history for a non-empty, non-degenerate window, and never collide with an
+            // existing (WanKey, CycleStart) row (the table has a unique index on that pair).
+            if (usedGb > 0 && cycleStart < now)
             {
-                db.WanDataUsageHistory.Add(new WanDataUsageHistory
+                var alreadyRecorded = await db.WanDataUsageHistory
+                    .AnyAsync(h => h.WanKey == config.WanKey && h.CycleStart == cycleStart);
+                if (!alreadyRecorded)
                 {
-                    WanKey = config.WanKey,
-                    Name = config.Name,
-                    CycleStart = cycleStart,
-                    CycleEnd = now,
-                    UsedGb = usedGb,
-                    CapGb = config.DataCapGb,
-                    RecordedAt = now
-                });
+                    db.WanDataUsageHistory.Add(new WanDataUsageHistory
+                    {
+                        WanKey = config.WanKey,
+                        Name = config.Name,
+                        CycleStart = cycleStart,
+                        CycleEnd = now,
+                        UsedGb = usedGb,
+                        CapGb = config.DataCapGb,
+                        RecordedAt = now
+                    });
+                }
             }
+
+            config.LastResetAt = now;
+            config.ManualAdjustmentGb = 0;
+            config.UpdatedAt = now;
+
+            await db.SaveChangesAsync();
+
+            // Clear in-memory state so the fresh bucket can alert again and the cache recomputes.
+            _alertState.Remove(wanKey);
+            _lastCycleStart[wanKey] = now;
+            _currentUsage = [];
+
+            _logger.LogInformation("Manual data usage bucket reset for {WanName}: archived {UsedGb:F2} GB, counting restarts now",
+                config.Name, usedGb);
         }
-
-        config.LastResetAt = now;
-        config.ManualAdjustmentGb = 0;
-        config.UpdatedAt = now;
-
-        await db.SaveChangesAsync();
-
-        // Clear in-memory state so the fresh bucket can alert again and the cache recomputes.
-        _alertState.Remove(wanKey);
-        _lastCycleStart[wanKey] = now;
-        _currentUsage = [];
-
-        _logger.LogInformation("Manual data usage bucket reset for {WanName}: archived {UsedGb:F2} GB, counting restarts now",
-            config.Name, usedGb);
+        finally
+        {
+            _pollLock.Release();
+        }
     }
 
     /// <summary>

--- a/tests/NetworkOptimizer.Storage.Tests/WanDataUsageServiceTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/WanDataUsageServiceTests.cs
@@ -81,6 +81,63 @@ public class WanDataUsageServiceTests
         end.Should().Be(new DateTime(2026, 1, 14, 0, 0, 0, DateTimeKind.Unspecified));
     }
 
+    // ========== Cycle Window (reset mode) ==========
+
+    [Fact]
+    public void GetCycleWindow_Monthly_MatchesBillingCycleDates()
+    {
+        var now = new DateTime(2026, 3, 15, 12, 0, 0, DateTimeKind.Utc);
+        var config = new WanDataUsageConfig
+        {
+            ResetMode = DataUsageResetMode.Monthly,
+            BillingCycleDayOfMonth = 1
+        };
+
+        var (start, end) = WanDataUsageService.GetCycleWindow(config, now);
+        var (expectedStart, expectedEnd) = WanDataUsageService.GetBillingCycleDates(1, now);
+
+        start.Should().Be(expectedStart);
+        end.Should().Be(expectedEnd);
+    }
+
+    [Fact]
+    public void GetCycleWindow_ManualNeverReset_StartsAtCreatedAtWithNoEnd()
+    {
+        var created = new DateTime(2026, 1, 10, 8, 0, 0, DateTimeKind.Utc);
+        var now = new DateTime(2026, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+        var config = new WanDataUsageConfig
+        {
+            ResetMode = DataUsageResetMode.Manual,
+            CreatedAt = created,
+            LastResetAt = null
+        };
+
+        var (start, end) = WanDataUsageService.GetCycleWindow(config, now);
+
+        start.Should().Be(created);
+        start.Kind.Should().Be(DateTimeKind.Utc);
+        end.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetCycleWindow_ManualAfterReset_StartsAtLastResetWithNoEnd()
+    {
+        var created = new DateTime(2026, 1, 10, 8, 0, 0, DateTimeKind.Utc);
+        var lastReset = new DateTime(2026, 5, 2, 14, 30, 0, DateTimeKind.Utc);
+        var now = new DateTime(2026, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+        var config = new WanDataUsageConfig
+        {
+            ResetMode = DataUsageResetMode.Manual,
+            CreatedAt = created,
+            LastResetAt = lastReset
+        };
+
+        var (start, end) = WanDataUsageService.GetCycleWindow(config, now);
+
+        start.Should().Be(lastReset);
+        end.Should().BeNull();
+    }
+
     // ========== Usage Calculation from Snapshots ==========
 
     [Fact]


### PR DESCRIPTION
Adds a per-WAN reset mode to Data Usage tracking so prepaid / pay-as-you-go plans are handled correctly, not just calendar monthly cycles. Motivated by prepaid 5G/LTE backup plans (a fixed data bucket that never expires and only refills when you top up).

## What's new

- **Reset mode selector** per WAN: **Monthly on a set day** (existing behavior, unchanged default) or **Pay-as-you-go bucket**.
- **Pay-as-you-go bucket**: usage accumulates open-ended with no calendar rollover. A **Reset bucket** button archives the current total to history and restarts the count from zero, do this when you top up your balance.
- **Switching an existing WAN to bucket mode absorbs its current usage** rather than zeroing it, so the displayed total carries over across the switch. If you topped up mid-cycle, one Reset bucket click realigns it.
- **Counting since [date]** status replaces the billing-cycle window for buckets; usage history and cap/warning alerts work the same in both modes.

## Notes

- Existing monthly-tracked WANs are untouched: the monthly code path is unchanged and the new columns default to Monthly.
- Additive DB migration only (new `ResetMode` + `LastResetAt` columns with safe defaults).
- Snapshot pruning is held back for an open bucket so a long-running balance doesn't lose early usage.
- New unit tests cover the cycle-window logic for both modes.

Closes #809