### PR TITLE
v1.20.5 Release

### DIFF
--- a/src/NetworkOptimizer.Storage/Migrations/20260615155126_AddDataUsageResetMode.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260615155126_AddDataUsageResetMode.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260615155126_AddDataUsageResetMode")]
+    partial class AddDataUsageResetMode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260615155126_AddDataUsageResetMode.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260615155126_AddDataUsageResetMode.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDataUsageResetMode : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastResetAt",
+                table: "WanDataUsageConfigs",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ResetMode",
+                table: "WanDataUsageConfigs",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LastResetAt",
+                table: "WanDataUsageConfigs");
+
+            migrationBuilder.DropColumn(
+                name: "ResetMode",
+                table: "WanDataUsageConfigs");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/WanDataUsageConfig.cs
+++ b/src/NetworkOptimizer.Storage/Models/WanDataUsageConfig.cs
@@ -3,6 +3,21 @@ using System.ComponentModel.DataAnnotations;
 namespace NetworkOptimizer.Storage.Models;
 
 /// <summary>
+/// How a WAN's data usage cycle resets.
+/// </summary>
+public enum DataUsageResetMode
+{
+    /// <summary>Usage resets automatically on a calendar day each month (default, original behavior).</summary>
+    Monthly = 0,
+
+    /// <summary>
+    /// Pay-as-you-go bucket: usage accumulates open-ended and only resets when the user
+    /// manually resets it (e.g. after topping up a prepaid balance that never expires).
+    /// </summary>
+    Manual = 1
+}
+
+/// <summary>
 /// Per-WAN interface data usage tracking configuration.
 /// Tracks billing cycles and data caps for ISPs with usage limits.
 /// </summary>
@@ -38,15 +53,29 @@ public class WanDataUsageConfig
     public int WarningThresholdPercent { get; set; } = 80;
 
     /// <summary>
-    /// Day of month the billing cycle starts (1-28)
+    /// How the usage cycle resets. Monthly (default) resets on a calendar day each month.
+    /// Manual is an open-ended pay-as-you-go bucket the user resets when they top up.
+    /// </summary>
+    public DataUsageResetMode ResetMode { get; set; } = DataUsageResetMode.Monthly;
+
+    /// <summary>
+    /// Day of month the billing cycle starts (1-28). Only used in <see cref="DataUsageResetMode.Monthly"/> mode.
     /// </summary>
     public int BillingCycleDayOfMonth { get; set; } = 1;
+
+    /// <summary>
+    /// For <see cref="DataUsageResetMode.Manual"/> mode: when the bucket was last reset (UTC).
+    /// Usage is counted from this point forward. Null until the first reset, in which case
+    /// counting falls back to <see cref="CreatedAt"/>. Unused in Monthly mode.
+    /// </summary>
+    public DateTime? LastResetAt { get; set; }
 
     /// <summary>
     /// Manual usage adjustment in GB. Added to the calculated usage from snapshots.
     /// Allows users to set a starting point when enabling tracking mid-cycle,
     /// or to correct the calculated total if it's off.
-    /// Automatically resets to 0 when the background service detects a billing cycle rollover.
+    /// Automatically resets to 0 when the cycle rolls over (a billing-cycle rollover in
+    /// Monthly mode, or a manual reset in Manual mode).
     /// </summary>
     public double ManualAdjustmentGb { get; set; }
 

--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -79,6 +79,15 @@
 </head>
 
 <body>
+    <script>
+        // Apply kiosk mode before the app renders so the sidebar never flashes
+        // in on a kiosk display. Per-device preference; see Settings > UI / Display.
+        try {
+            if (localStorage.getItem('networkOptimizerKioskMode') === '1') {
+                document.body.classList.add('kiosk-mode');
+            }
+        } catch (e) { }
+    </script>
     <Routes />
 
     <!-- Custom reconnect modal (prevents Blazor from injecting shadow DOM version) -->
@@ -101,6 +110,28 @@
         <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/demo-mask.js")"></script>
     }
     <script>
+        // Kiosk mode: per-device (localStorage), forces the collapsed hamburger
+        // layout at any width so a mini-display shows just the content.
+        function setKioskMode(enabled) {
+            try {
+                if (enabled) {
+                    localStorage.setItem('networkOptimizerKioskMode', '1');
+                    document.body.classList.add('kiosk-mode');
+                } else {
+                    localStorage.removeItem('networkOptimizerKioskMode');
+                    document.body.classList.remove('kiosk-mode');
+                }
+            } catch (e) { }
+        }
+
+        function getKioskMode() {
+            try {
+                return localStorage.getItem('networkOptimizerKioskMode') === '1';
+            } catch (e) {
+                return false;
+            }
+        }
+
         function downloadFile(fileName, contentType, base64Data) {
             const linkSource = `data:${contentType};base64,${base64Data}`;
             const downloadLink = document.createElement('a');

--- a/src/NetworkOptimizer.Web/Components/Layout/NavMenu.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/NavMenu.razor
@@ -16,7 +16,7 @@
             </NavLink>
         </li>
         <li class="nav-item nav-sub-item" @onclick="HandleNavClick">
-            <NavLink class="nav-link" href="/monitoring/tools">
+            <NavLink class="nav-link" href="/network-tools">
                 <span class="nav-sub-icon">└</span>
                 <span class="nav-text">Network Tools</span>
             </NavLink>

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -404,6 +404,8 @@
                     var capGb = config?.DataCapGb ?? 0;
                     var warningPct = config?.WarningThresholdPercent ?? 80;
                     var billingDay = config?.BillingCycleDayOfMonth ?? 1;
+                    var resetMode = config?.ResetMode ?? DataUsageResetMode.Monthly;
+                    var isManual = resetMode == DataUsageResetMode.Manual;
                     var displayName = wan.Name;
                     var manualAdj = config?.ManualAdjustmentGb ?? 0;
                     var isAdjustmentUnlocked = _unlockedAdjustmentWans.Contains(wanGroup);
@@ -438,7 +440,7 @@
                                 {
                                     @* Usage display *@
                                     var savedBillingDay = summary?.BillingCycleStart.Day ?? billingDay;
-                                    var billingDayChanged = billingDay != savedBillingDay;
+                                    var billingDayChanged = !isManual && billingDay != savedBillingDay;
                                     @if (summary != null && capGb > 0 && !billingDayChanged)
                                     {
                                         var fillPct = Math.Min(summary.UsagePercent, 100);
@@ -483,18 +485,29 @@
                                                    @oninput="() => _dirtyConfigs.Add(wanGroup)"
                                                    @onchange="e => EditDataUsageConfig(wanGroup, warningPct: int.TryParse(e.Value?.ToString(), out var v) ? v : 80)" />
                                         </div>
-                                        <div class="form-group schedule-field schedule-field-compact" style="max-width: 180px;">
-                                            <label>Usage Resets On <span class="tooltip-icon tooltip-icon-sm" data-tooltip="The day of the month your ISP resets your data usage to zero. Check your carrier account for the renewal or due date.">?</span></label>
-                                            <select class="form-control" value="@billingDay"
-                                                    @onchange="e => EditDataUsageConfig(wanGroup, billingDay: int.TryParse(e.Value?.ToString(), out var v) ? v : 1)">
-                                                @for (var d = 1; d <= 28; d++)
-                                                {
-                                                    <option value="@d">@(DisplayFormatters.FormatOrdinal(d)) of month</option>
-                                                }
+                                        <div class="form-group schedule-field schedule-field-compact" style="max-width: 200px;">
+                                            <label>Usage Resets <span class="tooltip-icon tooltip-icon-sm" data-tooltip="Monthly: usage zeroes on a calendar day each month. Pay-as-you-go: an open-ended prepaid bucket you reset yourself when you top up (e.g. a prepaid 5G/LTE balance that never expires).">?</span></label>
+                                            <select class="form-control" value="@((int)resetMode)"
+                                                    @onchange="e => EditDataUsageConfig(wanGroup, resetMode: int.TryParse(e.Value?.ToString(), out var v) ? (DataUsageResetMode)v : DataUsageResetMode.Monthly)">
+                                                <option value="0">Monthly on a set day</option>
+                                                <option value="1">Pay-as-you-go bucket</option>
                                             </select>
                                         </div>
+                                        @if (!isManual)
+                                        {
+                                            <div class="form-group schedule-field schedule-field-compact" style="max-width: 180px;">
+                                                <label>Resets On <span class="tooltip-icon tooltip-icon-sm" data-tooltip="The day of the month your ISP resets your data usage to zero. Check your carrier account for the renewal or due date.">?</span></label>
+                                                <select class="form-control" value="@billingDay"
+                                                        @onchange="e => EditDataUsageConfig(wanGroup, billingDay: int.TryParse(e.Value?.ToString(), out var v) ? v : 1)">
+                                                    @for (var d = 1; d <= 28; d++)
+                                                    {
+                                                        <option value="@d">@(DisplayFormatters.FormatOrdinal(d)) of month</option>
+                                                    }
+                                                </select>
+                                            </div>
+                                        }
                                         <div class="form-group schedule-field schedule-field-compact">
-                                            <label>Usage Adjustment (GB) <span class="tooltip-icon tooltip-icon-sm" data-tooltip="Added to the tracked total. Use positive values for usage before tracking was enabled, or negative to correct an overcount. Resets to 0 each billing cycle.">?</span></label>
+                                            <label>Usage Adjustment (GB) <span class="tooltip-icon tooltip-icon-sm" data-tooltip="Added to the tracked total. Use positive values for usage before tracking was enabled, or negative to correct an overcount. Resets to 0 when the cycle resets.">?</span></label>
                                             <input type="number" class="form-control" value="@manualAdj" step="0.1"
                                                    readonly="@(!_unlockedAdjustmentWans.Contains(wanGroup))"
                                                    style="@(!_unlockedAdjustmentWans.Contains(wanGroup) ? "cursor: pointer; opacity: 0.7;" : "")"
@@ -505,7 +518,17 @@
                                     </div>
 
                                     @* Mid-cycle hint - show when first enabling tracking mid-cycle *@
-                                    @if (_newlyEnabledWans.Contains(wanGroup) && manualAdj == 0)
+                                    @if (_newlyEnabledWans.Contains(wanGroup) && manualAdj == 0 && isManual)
+                                    {
+                                        <div class="alert-info" style="margin-top: 0.75rem; padding: 0.625rem 0.75rem; font-size: 0.8125rem; line-height: 1.5;">
+                                            <span>
+                                                This bucket counts usage from now forward. If you've already used part of your current
+                                                balance, add it with the <strong>Usage Adjustment</strong> field above so the cap reflects
+                                                what's actually left. Hit <strong>Reset bucket</strong> each time you top up to start a fresh count.
+                                            </span>
+                                        </div>
+                                    }
+                                    else if (_newlyEnabledWans.Contains(wanGroup) && manualAdj == 0)
                                     {
                                         var now = DateTime.UtcNow;
                                         var (cycleStart, cycleEnd) = WanDataUsageService.GetBillingCycleDates(billingDay, now);
@@ -545,7 +568,24 @@
                                         </div>
                                     }
 
-                                    @* Billing cycle status - computed from in-memory billingDay so it updates live *@
+                                    @* Cycle status - computed live. Monthly shows the billing window; Manual shows the open bucket. *@
+                                    @if (isManual)
+                                    {
+                                        var bucketSince = (config?.LastResetAt ?? config?.CreatedAt ?? DateTime.UtcNow);
+                                        <div class="schedule-status" style="margin-top: 0.75rem; justify-content: space-between;">
+                                            <span class="schedule-status-item">
+                                                <span class="detail-label">Counting since:</span>
+                                                <span class="detail-value">@DateTime.SpecifyKind(bucketSince, DateTimeKind.Utc).ToLocalTime().ToString("MMM d, yyyy")</span>
+                                            </span>
+                                            @if (!isDirty)
+                                            {
+                                                <button class="btn btn-secondary btn-sm"
+                                                        @onclick="() => ResetUsageBucket(wanGroup)"
+                                                        data-tooltip="Archive the current total and start counting from zero - do this when you top up your balance.">Reset bucket</button>
+                                            }
+                                        </div>
+                                    }
+                                    else
                                     {
                                         var (dispCycleStart, dispCycleEnd) = WanDataUsageService.GetBillingCycleDates(billingDay, DateTime.Now);
                                         var dispDaysRemaining = Math.Max(0, (int)Math.Ceiling((dispCycleEnd - DateTime.UtcNow).TotalDays));
@@ -575,11 +615,11 @@
                                         if (history != null && history.Count > 0)
                                         {
                                             <details class="usage-history">
-                                                <summary>Usage history (@history.Count past @(history.Count == 1 ? "cycle" : "cycles"))</summary>
+                                                <summary>Usage history (@history.Count past @((isManual ? "bucket" : "cycle") + (history.Count == 1 ? "" : "s")))</summary>
                                                 <div class="table-responsive" style="margin-top: 0.5rem;">
                                                     <table class="data-table">
                                                         <thead>
-                                                            <tr><th>Billing cycle</th><th>Used</th><th>Cap</th></tr>
+                                                            <tr><th>@(isManual ? "Bucket" : "Billing cycle")</th><th>Used</th><th>Cap</th></tr>
                                                         </thead>
                                                         <tbody>
                                                             @foreach (var h in history)
@@ -3144,7 +3184,8 @@
     }
 
     private void EditDataUsageConfig(string wanKey,
-        double? capGb = null, int? warningPct = null, int? billingDay = null, double? manualAdj = null)
+        double? capGb = null, int? warningPct = null, int? billingDay = null, double? manualAdj = null,
+        DataUsageResetMode? resetMode = null)
     {
         if (!_dataUsageConfigs.TryGetValue(wanKey, out var config))
             return;
@@ -3153,8 +3194,22 @@
         if (warningPct.HasValue) config.WarningThresholdPercent = warningPct.Value;
         if (billingDay.HasValue) config.BillingCycleDayOfMonth = billingDay.Value;
         if (manualAdj.HasValue) config.ManualAdjustmentGb = manualAdj.Value;
+        if (resetMode.HasValue) config.ResetMode = resetMode.Value;
 
         _dirtyConfigs.Add(wanKey);
+    }
+
+    private async Task ResetUsageBucket(string wanKey)
+    {
+        try
+        {
+            await DataUsageService.ResetUsageAsync(wanKey);
+            await LoadDataUsageAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error resetting data usage bucket for {WanKey}", wanKey);
+        }
     }
 
     private async Task SaveDataUsageConfig(string wanKey)

--- a/src/NetworkOptimizer.Web/Components/Pages/MonitoringTools.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/MonitoringTools.razor
@@ -1,4 +1,4 @@
-@page "/monitoring/tools"
+@page "/network-tools"
 @rendermode InteractiveServer
 @using NetworkOptimizer.Web.Services
 @using NetworkOptimizer.Web.Services.Monitoring

--- a/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
@@ -116,7 +116,7 @@
                     @if (_gatewayConnected && _status?.FirmwareSupported == false && !string.IsNullOrEmpty(_status?.FirmwareVersion))
                     {
                         <div class="alert alert-danger" style="margin-top: 1rem;">
-                            <strong>Unsupported Firmware:</strong> Performance tweaks are currently tested and supported up to UniFi OS 5.1.15. Your gateway is running @_status.FirmwareVersion. Deploying new tweaks is disabled until we validate compatibility with this version. Existing tweaks will continue to run.
+                            <strong>Unsupported Firmware:</strong> Performance tweaks are currently tested and supported up to UniFi OS 5.1.18. Your gateway is running @_status.FirmwareVersion. Deploying new tweaks is disabled until we validate compatibility with this version. Existing tweaks will continue to run.
                         </div>
                     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1003,7 +1003,7 @@
                                 <option value="arris-surfboard">ARRIS Surfboard (HTTP)</option>
                                 <option value="arris-surfboard-hnap">ARRIS Surfboard S33/S34 (HNAP)</option>
                                 <option value="motorola-hnap">Motorola MB8611, MB8600 (HNAP)</option>
-                                <option value="xfinity-gateway">Xfinity XB8, XB10 (HTTP)</option>
+                                <option value="xfinity-gateway">Xfinity XB8/XB10, Cox CGM4981 (HTTP)</option>
                             </select>
                         </div>
                     </div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -2349,7 +2349,23 @@
         </div>
     </div>
 
-    <!-- 12. Data Management -->
+    <!-- 12. UI / Display Settings -->
+    <div class="card">
+        <div class="card-header">
+            <h2 class="card-title">UI / Display Settings</h2>
+        </div>
+        <div class="card-body">
+            <div class="form-group">
+                <label class="checkbox-label">
+                    <input type="checkbox" checked="@_kioskMode" @onchange="OnKioskModeChanged" />
+                    <span>Kiosk mode</span>
+                </label>
+                <small class="form-help">Collapses the side menu into the hamburger button at any window size, giving the content full width - handy for presenting graphs on a mini display. This preference is saved per device (this browser only).</small>
+            </div>
+        </div>
+    </div>
+
+    <!-- 13. Data Management -->
     <div class="card">
         <div class="card-header">
             <h2 class="card-title">Data Management</h2>
@@ -2749,6 +2765,24 @@
     private bool testingCrowdsec = false;
     private string crowdsecMessage = "";
     private string crowdsecMessageClass = "";
+
+    // UI / Display Settings - per-device, persisted in localStorage (not the DB)
+    private bool _kioskMode = false;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _kioskMode = await JS.InvokeAsync<bool>("getKioskMode");
+            StateHasChanged();
+        }
+    }
+
+    private async Task OnKioskModeChanged(ChangeEventArgs e)
+    {
+        _kioskMode = e.Value is true;
+        await JS.InvokeVoidAsync("setKioskMode", _kioskMode);
+    }
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
@@ -8,7 +8,7 @@
         <h2 class="card-title">Latency targets</h2>
         <div style="display: flex; align-items: center; gap: 0.5rem;">
             <span class="status-badge status-active" @onclick:stopPropagation="true">@Targets.Count(t => t.Enabled) active</span>
-            <a href="/monitoring/tools" class="tooltip-icon settings-link" data-tooltip="Run an ad-hoc probe" @onclick:stopPropagation="true">
+            <a href="/network-tools" class="tooltip-icon settings-link" data-tooltip="Run an ad-hoc probe" @onclick:stopPropagation="true">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="16" height="16">
                     <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM5.5 8.5a.5.5 0 010-1h2.793L7.146 6.354a.5.5 0 11.708-.708l2 2a.5.5 0 010 .708l-2 2a.5.5 0 11-.708-.708L8.293 8.5H5.5zm6.354-1.146a.5.5 0 010 .708L10.707 9.207H13.5a.5.5 0 010 1h-2.793l1.147 1.147a.5.5 0 11-.708.708l-2-2a.5.5 0 010-.708l2-2a.5.5 0 01.708 0z" clip-rule="evenodd" />
                 </svg>

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -224,7 +224,7 @@ else
                         "window.__dashMountMap3d = async function(canvasId) {" +
                         $"  const m = await import('{VersionedJs("/js/lan-flow-map.js")}');" +
                         "  window.__dashLanFlowMap = m;" +
-                        "  await m.mount(canvasId,{storagePrefix:'dashLanFlowMap'});" +
+                        "  await m.mount(canvasId,{storagePrefix:'dashLanFlowMap',signalHint:false});" +
                         "}");
                     await JS.InvokeVoidAsync("__dashMountMap3d", "dashboard-lan-flow-map-canvas");
                 }

--- a/src/NetworkOptimizer.Web/Endpoints/CellularChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/CellularChartEndpoints.cs
@@ -38,14 +38,18 @@ public static class CellularChartEndpoints
             var modems = await modemService.GetModemsAsync();
             var nameMap = modems.ToDictionary(m => m.Id.ToString(), m => m.Name);
 
-            // Keys are "modemId" or "modemId:mode" (e.g. "3:LTE", "3:5G NSA")
-            var result = data.Select(kvp =>
+            // Keys are "modemId" or "modemId:mode" (e.g. "3:LTE", "3:5G NSA").
+            // Only surface modems that still have a config. Deleting a modem config
+            // leaves its historical series in InfluxDB; without this filter those
+            // orphaned modem_ids show up as phantom "Modem {id}" entries on the chart.
+            var result = data
+                .Where(kvp => nameMap.ContainsKey(kvp.Key.Split(':', 2)[0]))
+                .Select(kvp =>
             {
                 var parts = kvp.Key.Split(':', 2);
                 var rawModemId = parts[0];
                 var mode = parts.Length > 1 ? parts[1] : null;
-                nameMap.TryGetValue(rawModemId, out var modemName);
-                modemName ??= $"Modem {rawModemId}";
+                var modemName = nameMap[rawModemId];
 
                 var label = !string.IsNullOrEmpty(mode)
                     ? $"{modemName} ({mode})"

--- a/src/NetworkOptimizer.Web/Endpoints/CmChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/CmChartEndpoints.cs
@@ -37,10 +37,14 @@ public static class CmChartEndpoints
             var configs = await cmService.GetConfigsAsync();
             var nameMap = configs.ToDictionary(c => c.Id.ToString(), c => c.Name);
 
-            var result = data.Select(kvp =>
+            // Only surface modems that still have a config. Deleting a CM config
+            // leaves its historical series in InfluxDB; without this filter those
+            // orphaned cm_ids show up as phantom "CM {id}" entries on the chart.
+            var result = data
+                .Where(kvp => nameMap.ContainsKey(kvp.Key))
+                .Select(kvp =>
             {
-                nameMap.TryGetValue(kvp.Key, out var name);
-                name ??= $"CM {kvp.Key}";
+                var name = nameMap[kvp.Key];
 
                 return new
                 {

--- a/src/NetworkOptimizer.Web/Endpoints/OntChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/OntChartEndpoints.cs
@@ -37,10 +37,14 @@ public static class OntChartEndpoints
             var configs = await ontService.GetConfigsAsync();
             var nameMap = configs.ToDictionary(c => c.Id.ToString(), c => c.Name);
 
-            var result = data.Select(kvp =>
+            // Only surface ONTs that still have a config. Deleting an ONT config
+            // leaves its historical series in InfluxDB; without this filter those
+            // orphaned ont_ids show up as phantom "ONT {id}" entries on the chart.
+            var result = data
+                .Where(kvp => nameMap.ContainsKey(kvp.Key))
+                .Select(kvp =>
             {
-                nameMap.TryGetValue(kvp.Key, out var name);
-                name ??= $"ONT {kvp.Key}";
+                var name = nameMap[kvp.Key];
 
                 return new
                 {

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
@@ -6,7 +6,7 @@ using NetworkOptimizer.Monitoring.Providers;
 namespace NetworkOptimizer.Web.Services.CableModemProviders;
 
 /// <summary>
-/// Cable modem provider for Xfinity gateways (XB8, XB10).
+/// Cable modem provider for gateways sharing the Xfinity/Technicolor web UI (Xfinity XB8/XB10, Cox CGM4981).
 /// Authenticates via form POST to /check.jst, then scrapes DOCSIS channel
 /// tables from /network_setup.jst. The tables use a transposed layout where
 /// each row is a metric and each column is a channel.

--- a/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
@@ -18,7 +18,7 @@ public class PerfTweaksDeploymentService
     private const string OnBootDir = "/data/on_boot.d";
     private const string PerfTweaksDir = "/data/perf-tweaks";
     private const string SfpModuleDir = "/data/sfp-sgmiiplus";
-    private static readonly Version MaxSupportedFirmware = new(5, 1, 15);
+    private static readonly Version MaxSupportedFirmware = new(5, 1, 18);
 
     private static readonly Dictionary<string, string> BootScriptFiles = new()
     {

--- a/src/NetworkOptimizer.Web/Services/WanDataUsageService.cs
+++ b/src/NetworkOptimizer.Web/Services/WanDataUsageService.cs
@@ -2,7 +2,6 @@ using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Alerts.Events;
 using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Storage.Models;
-using NetworkOptimizer.UniFi;
 
 namespace NetworkOptimizer.Web.Services;
 
@@ -63,7 +62,7 @@ public class WanDataUsageService : BackgroundService
 
         foreach (var config in configs)
         {
-            var (cycleStart, cycleEnd) = GetBillingCycleDates(config.BillingCycleDayOfMonth, now);
+            var (cycleStart, cycleEnd) = GetCycleWindow(config, now);
             var usedBytes = await CalculateCycleUsageAsync(db, config.WanKey, cycleStart, now, ct);
             var usedGb = Math.Max(0, usedBytes / (1024.0 * 1024.0 * 1024.0) + config.ManualAdjustmentGb);
 
@@ -78,13 +77,14 @@ public class WanDataUsageService : BackgroundService
             {
                 WanKey = config.WanKey,
                 Name = config.Name,
+                ResetMode = config.ResetMode,
                 UsedGb = usedGb,
                 CapGb = config.DataCapGb,
                 WarningThresholdPercent = config.WarningThresholdPercent,
                 UsagePercent = config.DataCapGb > 0 ? usedGb / config.DataCapGb * 100.0 : 0,
                 BillingCycleStart = cycleStart,
                 BillingCycleEnd = cycleEnd,
-                DaysRemaining = Math.Max(0, (int)Math.Ceiling((cycleEnd - now).TotalDays)),
+                DaysRemaining = cycleEnd.HasValue ? Math.Max(0, (int)Math.Ceiling((cycleEnd.Value - now).TotalDays)) : null,
                 IsOverCap = config.DataCapGb > 0 && usedGb >= config.DataCapGb,
                 IsOverWarning = config.DataCapGb > 0 && usedGb >= config.DataCapGb * config.WarningThresholdPercent / 100.0,
                 Enabled = config.Enabled,
@@ -137,6 +137,18 @@ public class WanDataUsageService : BackgroundService
             existing.ManualAdjustmentGb = config.ManualAdjustmentGb;
             existing.WarningThresholdPercent = Math.Clamp(config.WarningThresholdPercent, 1, 100);
             existing.BillingCycleDayOfMonth = Math.Clamp(config.BillingCycleDayOfMonth, 1, 28);
+
+            // Switching into Manual mode absorbs the current cycle's usage into the bucket by
+            // anchoring its window to the billing cycle start, so the displayed total is
+            // unchanged across the switch (no measured usage is silently discarded). If the user
+            // actually topped up mid-cycle, a single "Reset bucket" click zeroes it from now.
+            if (config.ResetMode == DataUsageResetMode.Manual && existing.ResetMode != DataUsageResetMode.Manual)
+            {
+                var (cycleStart, _) = GetBillingCycleDates(existing.BillingCycleDayOfMonth, DateTime.UtcNow);
+                existing.LastResetAt = cycleStart;
+            }
+            existing.ResetMode = config.ResetMode;
+
             existing.UpdatedAt = DateTime.UtcNow;
         }
         else
@@ -146,6 +158,7 @@ public class WanDataUsageService : BackgroundService
             config.BillingCycleDayOfMonth = Math.Clamp(config.BillingCycleDayOfMonth, 1, 28);
             config.CreatedAt = DateTime.UtcNow;
             config.UpdatedAt = DateTime.UtcNow;
+            // A new Manual bucket counts from creation; LastResetAt stays null until first reset.
             db.WanDataUsageConfigs.Add(config);
         }
 
@@ -159,6 +172,71 @@ public class WanDataUsageService : BackgroundService
         _currentUsage = [];
 
         return existing ?? config;
+    }
+
+    /// <summary>
+    /// Resets a Manual (pay-as-you-go) bucket: rolls the bucket's current usage into durable
+    /// history, stamps a new reset time so counting restarts from zero, and clears the manual
+    /// adjustment. No-op for Monthly configs, which roll over automatically on their billing day.
+    /// </summary>
+    public async Task ResetUsageAsync(string wanKey)
+    {
+        // Serialize against the background poll: it mutates _alertState and _lastCycleStart
+        // (plain dictionaries) under this same lock, so we must hold it too before touching them.
+        await _pollLock.WaitAsync();
+        try
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            var config = await db.WanDataUsageConfigs.FirstOrDefaultAsync(c => c.WanKey == wanKey);
+            if (config == null || config.ResetMode != DataUsageResetMode.Manual)
+                return;
+
+            var now = DateTime.UtcNow;
+            var (cycleStart, _) = GetCycleWindow(config, now);
+
+            // Capture the bucket's usage (including any manual adjustment) so history keeps a record.
+            var usedBytes = await CalculateCycleUsageAsync(db, config.WanKey, cycleStart, now, CancellationToken.None);
+            var usedGb = Math.Max(0, usedBytes / (1024.0 * 1024.0 * 1024.0) + config.ManualAdjustmentGb);
+
+            // Only write history for a non-empty, non-degenerate window, and never collide with an
+            // existing (WanKey, CycleStart) row (the table has a unique index on that pair).
+            if (usedGb > 0 && cycleStart < now)
+            {
+                var alreadyRecorded = await db.WanDataUsageHistory
+                    .AnyAsync(h => h.WanKey == config.WanKey && h.CycleStart == cycleStart);
+                if (!alreadyRecorded)
+                {
+                    db.WanDataUsageHistory.Add(new WanDataUsageHistory
+                    {
+                        WanKey = config.WanKey,
+                        Name = config.Name,
+                        CycleStart = cycleStart,
+                        CycleEnd = now,
+                        UsedGb = usedGb,
+                        CapGb = config.DataCapGb,
+                        RecordedAt = now
+                    });
+                }
+            }
+
+            config.LastResetAt = now;
+            config.ManualAdjustmentGb = 0;
+            config.UpdatedAt = now;
+
+            await db.SaveChangesAsync();
+
+            // Clear in-memory state so the fresh bucket can alert again and the cache recomputes.
+            _alertState.Remove(wanKey);
+            _lastCycleStart[wanKey] = now;
+            _currentUsage = [];
+
+            _logger.LogInformation("Manual data usage bucket reset for {WanName}: archived {UsedGb:F2} GB, counting restarts now",
+                config.Name, usedGb);
+        }
+        finally
+        {
+            _pollLock.Release();
+        }
     }
 
     /// <summary>
@@ -292,11 +370,11 @@ public class WanDataUsageService : BackgroundService
                 var isReset = lastSnapshot != null &&
                     (wan.RxBytes < lastSnapshot.RxBytes || wan.TxBytes < lastSnapshot.TxBytes);
 
-                // First snapshot for this WAN: check if gateway booted within current billing cycle.
+                // First snapshot for this WAN: check if gateway booted within the current cycle.
                 // If so, the raw byte counters represent all usage since boot = all usage this cycle.
                 if (lastSnapshot == null && gatewayBootTime.HasValue)
                 {
-                    var (blCycleStart, _) = GetBillingCycleDates(config.BillingCycleDayOfMonth, now);
+                    var (blCycleStart, _) = GetCycleWindow(config, now);
                     isBaseline = gatewayBootTime.Value >= blCycleStart;
 
                     if (isBaseline)
@@ -316,15 +394,17 @@ public class WanDataUsageService : BackgroundService
                 });
             }
 
-            // Calculate billing cycle usage
-            var (cycleStart, cycleEnd) = GetBillingCycleDates(config.BillingCycleDayOfMonth, now);
+            // Calculate cycle usage window (monthly billing cycle, or open-ended manual bucket)
+            var (cycleStart, cycleEnd) = GetCycleWindow(config, now);
 
-            // Reset manual adjustment when a new billing cycle starts
+            // Reset manual adjustment when the cycle rolls over. In Monthly mode this fires when the
+            // calendar billing cycle changes. In Manual mode the window start only advances via an
+            // explicit reset (which already clears the adjustment), so this is a harmless backstop.
             if (_lastCycleStart.TryGetValue(config.WanKey, out var prevCycleStart) && prevCycleStart != cycleStart
                 && config.ManualAdjustmentGb != 0)
             {
                 config.ManualAdjustmentGb = 0;
-                _logger.LogInformation("Billing cycle rolled over for {WanName}, reset manual adjustment to 0", config.Name);
+                _logger.LogInformation("Usage cycle rolled over for {WanName}, reset manual adjustment to 0", config.Name);
             }
             _lastCycleStart[config.WanKey] = cycleStart;
 
@@ -343,6 +423,7 @@ public class WanDataUsageService : BackgroundService
             {
                 WanKey = config.WanKey,
                 Name = config.Name,
+                ResetMode = config.ResetMode,
                 WanType = wan?.Type,
                 IsUp = wan?.Up ?? false,
                 UsedGb = usedGb,
@@ -351,7 +432,7 @@ public class WanDataUsageService : BackgroundService
                 UsagePercent = config.DataCapGb > 0 ? usedGb / config.DataCapGb * 100.0 : 0,
                 BillingCycleStart = cycleStart,
                 BillingCycleEnd = cycleEnd,
-                DaysRemaining = Math.Max(0, (int)Math.Ceiling((cycleEnd - now).TotalDays)),
+                DaysRemaining = cycleEnd.HasValue ? Math.Max(0, (int)Math.Ceiling((cycleEnd.Value - now).TotalDays)) : null,
                 IsOverCap = config.DataCapGb > 0 && usedGb >= config.DataCapGb,
                 IsOverWarning = config.DataCapGb > 0 && usedGb >= config.DataCapGb * config.WarningThresholdPercent / 100.0,
                 Enabled = config.Enabled,
@@ -557,6 +638,26 @@ public class WanDataUsageService : BackgroundService
         return (cycleStart, cycleEnd);
     }
 
+    /// <summary>
+    /// Returns the usage cycle window for a config based on its reset mode.
+    /// Monthly: the calendar billing cycle containing <paramref name="now"/>, with an end date.
+    /// Manual: an open-ended window starting at the last reset (or creation if never reset),
+    /// with a null end date (the bucket has no scheduled rollover).
+    /// Public for testing.
+    /// </summary>
+    public static (DateTime CycleStart, DateTime? CycleEnd) GetCycleWindow(WanDataUsageConfig config, DateTime now)
+    {
+        if (config.ResetMode == DataUsageResetMode.Manual)
+        {
+            // Cycle/snapshot math operates in UTC; LastResetAt and CreatedAt are stored UTC.
+            var start = config.LastResetAt ?? config.CreatedAt;
+            return (DateTime.SpecifyKind(start, DateTimeKind.Utc), null);
+        }
+
+        var (cycleStart, cycleEnd) = GetBillingCycleDates(config.BillingCycleDayOfMonth, now);
+        return (cycleStart, cycleEnd);
+    }
+
     private async Task CheckThresholdsAsync(WanDataUsageConfig config, WanUsageSummary summary,
         DateTime cycleStart, CancellationToken ct)
     {
@@ -587,7 +688,7 @@ public class WanDataUsageService : BackgroundService
                     ["wanKey"] = config.WanKey,
                     ["usedGb"] = summary.UsedGb.ToString("F2"),
                     ["capGb"] = config.DataCapGb.ToString("F0"),
-                    ["daysRemaining"] = summary.DaysRemaining.ToString()
+                    ["daysRemaining"] = summary.DaysRemaining?.ToString() ?? ""
                 }
             }, ct);
 
@@ -614,7 +715,7 @@ public class WanDataUsageService : BackgroundService
                     ["wanKey"] = config.WanKey,
                     ["usedGb"] = summary.UsedGb.ToString("F2"),
                     ["capGb"] = config.DataCapGb.ToString("F0"),
-                    ["daysRemaining"] = summary.DaysRemaining.ToString()
+                    ["daysRemaining"] = summary.DaysRemaining?.ToString() ?? ""
                 }
             }, ct);
 
@@ -640,6 +741,11 @@ public class WanDataUsageService : BackgroundService
 
         foreach (var config in configs)
         {
+            // Manual (pay-as-you-go) buckets have no calendar cycles to roll up; their history
+            // rows are written on explicit reset via ResetUsageAsync.
+            if (config.ResetMode == DataUsageResetMode.Manual)
+                continue;
+
             var minTsRaw = await db.WanDataUsageSnapshots
                 .Where(s => s.WanKey == config.WanKey)
                 .MinAsync(s => (DateTime?)s.Timestamp, ct);
@@ -718,8 +824,20 @@ public class WanDataUsageService : BackgroundService
     {
         try
         {
-            // Keep 2 billing cycles worth of data
+            // Keep 2 billing cycles worth of data for monthly configs.
             var cutoff = now.AddMonths(-2);
+
+            // Never prune snapshots a Manual (pay-as-you-go) bucket still needs: its window can
+            // stay open for many months and usage is summed from the cycle start forward, so
+            // pull the cutoff back to the earliest active manual bucket start. Without this, an
+            // open bucket older than 2 months would lose its early deltas and undercount.
+            foreach (var config in configs.Where(c => c.ResetMode == DataUsageResetMode.Manual))
+            {
+                var (manualStart, _) = GetCycleWindow(config, now);
+                if (manualStart < cutoff)
+                    cutoff = manualStart;
+            }
+
             var deleted = await db.WanDataUsageSnapshots
                 .Where(s => s.Timestamp < cutoff)
                 .ExecuteDeleteAsync(ct);
@@ -785,15 +903,20 @@ public record WanUsageSummary
 {
     public string WanKey { get; init; } = string.Empty;
     public string Name { get; init; } = string.Empty;
+    /// <summary>How this WAN's usage cycle resets (monthly billing day vs. manual bucket).</summary>
+    public DataUsageResetMode ResetMode { get; init; } = DataUsageResetMode.Monthly;
     public string? WanType { get; init; }
     public bool IsUp { get; init; }
     public double UsedGb { get; init; }
     public double CapGb { get; init; }
     public int WarningThresholdPercent { get; init; }
     public double UsagePercent { get; init; }
+    /// <summary>Start of the current cycle. For Manual mode this is the last reset (or creation) time.</summary>
     public DateTime BillingCycleStart { get; init; }
-    public DateTime BillingCycleEnd { get; init; }
-    public int DaysRemaining { get; init; }
+    /// <summary>End of the current billing cycle, or null for an open-ended Manual bucket.</summary>
+    public DateTime? BillingCycleEnd { get; init; }
+    /// <summary>Days left in the current billing cycle, or null for an open-ended Manual bucket.</summary>
+    public int? DaysRemaining { get; init; }
     public bool IsOverCap { get; init; }
     public bool IsOverWarning { get; init; }
     public bool Enabled { get; init; }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14556,6 +14556,7 @@ a.affected-client:hover {
     flex-wrap: wrap;
     gap: 0.3rem;
     margin-top: 0.45rem;
+    margin-bottom: 0.15rem;
 }
 .lan-flow-map-chip {
     display: inline-flex;
@@ -14683,6 +14684,65 @@ a.affected-client:hover {
     line-height: 1;
 }
 .lan-flow-map-speed-step:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+}
+.lan-flow-map-signal-hint {
+    position: absolute;
+    z-index: 6;
+    left: 50%;
+    top: 3.5rem;
+    transform: translateX(-50%);
+    max-width: min(520px, calc(100% - 2rem));
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem 0.75rem;
+    padding: 0.5rem 0.55rem 0.5rem 0.9rem;
+    background: rgba(16, 24, 32, 0.88);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 10px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    text-align: center;
+}
+.lan-flow-map-signal-hint-text {
+    flex: 1 1 auto;
+    min-width: 0;
+    line-height: 1.3;
+}
+.lan-flow-map-signal-hint-link {
+    flex-shrink: 0;
+    color: var(--primary-hover);
+    text-decoration: none;
+    font-weight: 600;
+    white-space: nowrap;
+}
+.lan-flow-map-signal-hint-link:hover {
+    color: var(--info-color);
+    text-decoration: underline;
+}
+.lan-flow-map-signal-hint-close {
+    flex-shrink: 0;
+    width: 1.5rem;
+    height: 1.5rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    background: transparent;
+    border: none;
+    border-radius: 0.3rem;
+    color: var(--text-muted);
+    font-size: 1.1rem;
+    line-height: 1;
+    cursor: pointer;
+}
+.lan-flow-map-signal-hint-close:hover {
     background: var(--bg-hover);
     color: var(--text-primary);
 }
@@ -15001,6 +15061,17 @@ a.affected-client:hover {
     }
     .lan-flow-map-speed-control {
         display: none;
+    }
+    .lan-flow-map-signal-hint {
+        top: 0.5rem;
+        max-width: calc(100% - 1rem);
+        font-size: 0.72rem;
+        padding: 0.45rem 0.5rem 0.45rem 0.75rem;
+    }
+    .lan-flow-map-signal-hint-close {
+        width: 1.85rem;
+        height: 1.85rem;
+        font-size: 1.2rem;
     }
 }
 /* 2D LAN Flow Map */

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15753,3 +15753,70 @@ a.affected-client:hover {
 .isp-factor-link:hover {
     color: var(--primary-hover);
 }
+
+body.kiosk-mode .hamburger-btn {
+    display: block;
+}
+
+body.kiosk-mode .mobile-logo {
+    display: block;
+    height: 60px;
+    margin: -0.5rem 0;
+    max-height: 20vw;
+}
+
+body.kiosk-mode .mobile-logo img {
+    height: 100%;
+    width: auto;
+}
+
+body.kiosk-mode .sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100vh;
+    height: 100dvh;
+    width: 280px;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    z-index: 1000;
+    overflow-y: auto;
+}
+
+body.kiosk-mode .sidebar.open {
+    transform: translateX(0);
+}
+
+body.kiosk-mode .sidebar-overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 999;
+}
+
+body.kiosk-mode .sidebar-overlay.visible {
+    display: block;
+}
+
+body.kiosk-mode .main-content {
+    width: 100%;
+}
+
+body.kiosk-mode .top-bar {
+    height: auto;
+    padding: 0.75rem 1rem;
+    gap: 0.5rem;
+}
+
+body.kiosk-mode .header-actions {
+    flex: 1;
+    justify-content: flex-end;
+}
+
+body.kiosk-mode .status-indicators {
+    display: none;
+}

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -123,6 +123,10 @@ export class LanFlowMap {
         this.pollIntervalMs = options.pollIntervalMs ?? 1000;
         this.onError = options.onError ?? ((err) => console.error('[LanFlowMap]', err));
         this._storagePrefix = options.storagePrefix ?? 'lanFlowMap';
+        // The embedded dashboard Live View panel opts out of the Signal Map
+        // discovery hint to keep its compact chrome clean (it also hides the
+        // scrubber/status). Full Monitoring page leaves it on.
+        this._signalHintEnabled = options.signalHint ?? true;
 
         this._snapshot = null;
         this._nodesByLink = new Map();
@@ -511,6 +515,7 @@ export class LanFlowMap {
             this._applyOverlayVisibility();
             this._applyLiveRates(snap.liveRates || {});
             this._refreshCloudRttLabels();
+            this._updateSignalMapHint();
         } catch (err) {
             this.onError(err);
         }
@@ -628,6 +633,16 @@ export class LanFlowMap {
         const springRest = 6.0;
         const springK = 0.22;
         const damping = 0.78;
+        // Per-iteration displacement cap. This explicit-Euler integrator has no dt
+        // and is unstable for graphs with few/no pinned anchors: spring + repulsion
+        // forces can compound ~4x per iteration, blowing positions past Double.MAX to
+        // Infinity within ~65 iters, then Infinity - Infinity = NaN poisons every
+        // position (camera centroid becomes NaN -> entire scene blanks, no error
+        // thrown). Anchored APs normally bleed enough energy to stay bounded, so this
+        // only bites users with no Signal-Map AP placements. Clamping each node's step
+        // makes the system bounded for any graph; it never triggers on already-stable
+        // (anchored) layouts since their velocities stay well under the cap.
+        const maxStep = 4.0;
 
         const velocities = new Map(ids.map((id) => [id, { vx: 0, vy: 0, vz: 0 }]));
         for (let iter = 0; iter < 350; iter += 1) {
@@ -677,11 +692,17 @@ export class LanFlowMap {
                     v.vz -= uz * f;
                 }
             }
-            // Integrate.
+            // Integrate. Clamp the step magnitude so an unstable graph (few/no
+            // pinned anchors) can't diverge to Infinity/NaN; see maxStep above.
             for (const id of ids) {
                 const p = positions.get(id);
                 if (p.pinned) continue;
                 const v = velocities.get(id);
+                const step = Math.sqrt(v.vx * v.vx + v.vy * v.vy + v.vz * v.vz);
+                if (step > maxStep) {
+                    const k = maxStep / step;
+                    v.vx *= k; v.vy *= k; v.vz *= k;
+                }
                 p.x += v.vx;
                 p.y += v.vy;
                 p.z += v.vz;
@@ -707,6 +728,23 @@ export class LanFlowMap {
             p.x = pp.x + dx * WIFI_SPREAD;
             p.y = pp.y + dy * WIFI_SPREAD;
             p.z = pp.z + dz * WIFI_SPREAD;
+        }
+
+        // Safety net: should never trigger given the step clamp above, but if any
+        // position is still non-finite from any source, snap it to a small bounded
+        // scatter. One NaN position would otherwise blank the whole scene (NaN
+        // camera centroid) with no error, so we never let a non-finite leak through.
+        let nonFinite = 0;
+        for (const [id, p] of positions) {
+            if (!Number.isFinite(p.x) || !Number.isFinite(p.y) || !Number.isFinite(p.z)) {
+                nonFinite += 1;
+                const theta = (Math.random() * 2 - 1) * Math.PI;
+                const r = 12 + Math.random() * 8;
+                positions.set(id, { x: Math.cos(theta) * r, y: (Math.random() - 0.5) * 5, z: Math.sin(theta) * r, pinned: false });
+            }
+        }
+        if (nonFinite > 0) {
+            console.warn(`[LanFlowMap] Layout produced ${nonFinite} non-finite position(s); reset to bounded scatter.`);
         }
 
         this._positions = positions;
@@ -1452,6 +1490,10 @@ export class LanFlowMap {
                         // live poll and would clobber fresh rates momentarily.
                         this._refreshCloudRttLabels();
                     }
+                    // Anchor count can flip (e.g. user just placed APs on the
+                    // Signal Map) without infra membership changing, so refresh
+                    // the discovery hint on every snapshot poll.
+                    this._updateSignalMapHint();
                 } catch { /* transient */ }
             }
         }, 30000);
@@ -1947,6 +1989,53 @@ export class LanFlowMap {
         this._panels.scrubberPlayPause = playPause;
         this._paused = false;
         this._syncSpeedLabel();
+
+        this._buildSignalMapHint();
+    }
+
+    // One-time discovery nudge. A user with no AP placements on the Signal Map gets
+    // no spatial anchoring here (devices fall back to the abstract force layout and
+    // buildings have nothing to anchor to), so they may not realize the map can show
+    // their real floor plan and device positions. Surface a small, dismissible pill
+    // pointing to Wi-Fi Optimizer > Signal Map. Shown only when there are zero anchors
+    // and the user hasn't dismissed it - invisible for anyone who has placed their APs.
+    _buildSignalMapHint() {
+        if (!this._signalHintEnabled) return;
+        const hint = document.createElement('div');
+        hint.className = 'lan-flow-map-signal-hint';
+        hint.style.display = 'none';
+
+        const text = document.createElement('span');
+        text.className = 'lan-flow-map-signal-hint-text';
+        text.textContent = 'Add your floor plan and AP spots in the Signal Map to see them here.';
+
+        const link = document.createElement('a');
+        link.className = 'lan-flow-map-signal-hint-link';
+        link.href = '/wifi-optimizer?tab=floorplan';
+        link.textContent = 'Open Signal Map ↗';
+
+        const close = document.createElement('button');
+        close.type = 'button';
+        close.className = 'lan-flow-map-signal-hint-close';
+        close.setAttribute('aria-label', 'Dismiss');
+        close.textContent = '×';
+        close.addEventListener('click', () => {
+            hint.style.display = 'none';
+            try { localStorage.setItem(this._storagePrefix + 'SignalHintDismissed', '1'); } catch { /* localStorage unavailable */ }
+        });
+
+        hint.append(text, link, close);
+        this.stage.appendChild(hint);
+        this._panels.signalHint = hint;
+    }
+
+    _updateSignalMapHint() {
+        const hint = this._panels?.signalHint;
+        if (!hint) return;
+        let dismissed = false;
+        try { dismissed = localStorage.getItem(this._storagePrefix + 'SignalHintDismissed') === '1'; } catch { /* localStorage unavailable */ }
+        const anchorCount = this._snapshot?.bounds?.anchorCount ?? 0;
+        hint.style.display = (!dismissed && anchorCount === 0) ? 'flex' : 'none';
     }
 
     _makePanel(extraClass) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -162,12 +162,22 @@ function buildOpts() {
 
 // Time labels pinned to a fixed grid, rendered as x-axis annotations so
 // they scroll with the data. Full 24-hour time on every tick, placed below
-// the axis in the space freed by the hidden built-in labels. The 20s grid
-// fits ~15 HH:mm:ss labels on desktop widths; narrow (mobile) charts drop
-// to a 60s grid so the labels don't collide.
+// the axis in the space freed by the hidden built-in labels. The grid
+// interval is chosen from the chart's own rendered width (clientWidth), not
+// the viewport, so half-view panels and mobile - which constrain the chart
+// below full width while the viewport stays wide - step out to a sparser
+// grid instead of colliding. Full width keeps the dense 20s grid.
 function buildTimeTicks(minMs, maxMs) {
     const width = document.getElementById(elId)?.clientWidth || 800;
-    const GRID_MS = width < 640 ? 60000 : 20000;
+    // An HH:mm:ss label is ~46px at 10px; budget 64px per slot for breathing
+    // room, then pick the densest grid whose tick count fits that budget.
+    const slots = Math.max(2, Math.floor(width / 64));
+    const spanMs = maxMs - minMs;
+    const GRIDS = [20000, 30000, 60000, 120000];
+    let GRID_MS = GRIDS[GRIDS.length - 1];
+    for (const g of GRIDS) {
+        if (spanMs / g <= slots) { GRID_MS = g; break; }
+    }
     const ticks = [];
     for (let t = Math.ceil(minMs / GRID_MS) * GRID_MS; t <= maxMs; t += GRID_MS) {
         const d = new Date(t);

--- a/tests/NetworkOptimizer.Storage.Tests/WanDataUsageServiceTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/WanDataUsageServiceTests.cs
@@ -81,6 +81,63 @@ public class WanDataUsageServiceTests
         end.Should().Be(new DateTime(2026, 1, 14, 0, 0, 0, DateTimeKind.Unspecified));
     }
 
+    // ========== Cycle Window (reset mode) ==========
+
+    [Fact]
+    public void GetCycleWindow_Monthly_MatchesBillingCycleDates()
+    {
+        var now = new DateTime(2026, 3, 15, 12, 0, 0, DateTimeKind.Utc);
+        var config = new WanDataUsageConfig
+        {
+            ResetMode = DataUsageResetMode.Monthly,
+            BillingCycleDayOfMonth = 1
+        };
+
+        var (start, end) = WanDataUsageService.GetCycleWindow(config, now);
+        var (expectedStart, expectedEnd) = WanDataUsageService.GetBillingCycleDates(1, now);
+
+        start.Should().Be(expectedStart);
+        end.Should().Be(expectedEnd);
+    }
+
+    [Fact]
+    public void GetCycleWindow_ManualNeverReset_StartsAtCreatedAtWithNoEnd()
+    {
+        var created = new DateTime(2026, 1, 10, 8, 0, 0, DateTimeKind.Utc);
+        var now = new DateTime(2026, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+        var config = new WanDataUsageConfig
+        {
+            ResetMode = DataUsageResetMode.Manual,
+            CreatedAt = created,
+            LastResetAt = null
+        };
+
+        var (start, end) = WanDataUsageService.GetCycleWindow(config, now);
+
+        start.Should().Be(created);
+        start.Kind.Should().Be(DateTimeKind.Utc);
+        end.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetCycleWindow_ManualAfterReset_StartsAtLastResetWithNoEnd()
+    {
+        var created = new DateTime(2026, 1, 10, 8, 0, 0, DateTimeKind.Utc);
+        var lastReset = new DateTime(2026, 5, 2, 14, 30, 0, DateTimeKind.Utc);
+        var now = new DateTime(2026, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+        var config = new WanDataUsageConfig
+        {
+            ResetMode = DataUsageResetMode.Manual,
+            CreatedAt = created,
+            LastResetAt = lastReset
+        };
+
+        var (start, end) = WanDataUsageService.GetCycleWindow(config, now);
+
+        start.Should().Be(lastReset);
+        end.Should().BeNull();
+    }
+
     // ========== Usage Calculation from Snapshots ==========
 
     [Fact]


### PR DESCRIPTION
Release v1.20.5: monitoring and data-usage improvements, plus a 3D map stability fix.

## Data Usage

- **Pay-as-you-go (manual reset) bucket mode** - Data usage tracking now supports an open-ended bucket that accumulates until you manually reset it, instead of resetting on a calendar billing day. Designed for prepaid balances that don't expire on a monthly cycle. Hit "Reset bucket" when you top up to start a fresh count; the previous total is archived to history.

## Monitoring

- **LAN flow map: fixed blank 3D view on networks without AP placements** - On networks with no Signal Map AP placements, the force layout could diverge to non-finite positions and blank the entire scene with no error. The integrator now clamps per-step movement and snaps any stray non-finite position back into bounds.
- **WAN live chart: smarter time-label density** - The x-axis tick spacing now sizes to the chart's own rendered width rather than the viewport, so half-view and mobile panels step out to a sparser grid instead of overlapping labels.
- **CM / ONT / Cellular stats: hide orphaned series** - Deleting a modem/ONT/cellular config no longer leaves phantom series on the charts from leftover historical data.
- **Added Cox CGM4981** - Recognized as sharing the Xfinity/Technicolor web UI for cable modem stats.

## Network Tools

- **Moved to /network-tools** - Network Tools now lives at its own route so it no longer double-highlights the Monitoring nav section.

## Kiosk Mode

- **New kiosk display mode** - A per-device setting that forces the collapsed layout at any width, hiding the side menu so a mini-display shows just the content. Applied before render so the sidebar never flashes in.

## Performance Tweaks

- **Raised supported firmware gate to UniFi OS 5.1.18** - Performance tweaks are now validated through UniFi OS 5.1.18.
