### PR TITLE
Detect on-gateway NextDNS CLI and ControlD; expand public DNS provider IPs

### DIFF
--- a/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
@@ -803,14 +803,14 @@ public class DnsSecurityAnalyzer
                 var dnsServerIps = result.ThirdPartyDnsServers.Select(t => t.DnsServerIp).Distinct().ToList();
                 var networkNames = result.ThirdPartyDnsServers.Select(t => t.NetworkName).Distinct().ToList();
 
-                // Known providers (Pi-hole, AdGuard Home, NextDNS CLI) are trusted - neutral score impact
+                // Known providers (Pi-hole, AdGuard Home, NextDNS CLI, ControlD) are trusted - neutral score impact
                 // Unknown third-party DNS servers get a minor penalty since we can't verify their filtering
-                var isKnownProvider = result.IsPiholeDetected || result.IsAdGuardHomeDetected || result.IsNextDnsDetected;
+                var isKnownProvider = result.IsPiholeDetected || result.IsAdGuardHomeDetected || result.IsNextDnsDetected || result.IsControlDDetected;
                 var scoreImpact = isKnownProvider ? 0 : 3; // Minor penalty for unknown providers
                 var severity = isKnownProvider ? AuditSeverity.Informational : AuditSeverity.Recommended;
                 var recommendedAction = isKnownProvider
                     ? "Verify third-party DNS provides adequate security and filtering. Consider enabling DNS firewall rules to prevent bypass."
-                    : "Configure the third-party DNS management port in Settings to enable detection. Otherwise, consider a known DNS filtering solution (Pi-hole, AdGuard Home, NextDNS) or CyberSecure Encrypted DNS (DoH).";
+                    : "Configure the third-party DNS management port in Settings to enable detection. Otherwise, consider a known DNS filtering solution (Pi-hole, AdGuard Home, NextDNS, ControlD) or CyberSecure Encrypted DNS (DoH).";
 
                 result.Issues.Add(new AuditIssue
                 {
@@ -827,6 +827,7 @@ public class DnsSecurityAnalyzer
                         { "is_pihole", result.IsPiholeDetected },
                         { "is_adguard_home", result.IsAdGuardHomeDetected },
                         { "is_nextdns", result.IsNextDnsDetected },
+                        { "is_controld", result.IsControlDDetected },
                         { "is_known_provider", isKnownProvider },
                         { "affected_networks", networkNames },
                         { "provider_name", result.ThirdPartyDnsProviderName ?? "Third-Party LAN DNS" },
@@ -2012,6 +2013,12 @@ public class DnsSecurityAnalyzer
                 _logger.LogInformation("NextDNS CLI detected as third-party DNS on {Count} network(s)",
                     thirdPartyResults.Count(t => t.IsNextDns));
             }
+            else if (thirdPartyResults.Any(t => t.IsControlD))
+            {
+                result.ThirdPartyDnsProviderName = "ControlD";
+                _logger.LogInformation("ControlD detected as third-party DNS on {Count} network(s)",
+                    thirdPartyResults.Count(t => t.IsControlD));
+            }
             else
             {
                 result.ThirdPartyDnsProviderName = "Third-Party LAN DNS";
@@ -2051,6 +2058,58 @@ public class DnsSecurityAnalyzer
             else
             {
                 _logger.LogInformation("Third-party DNS only on Corporate networks - treating as specialized internal DNS, not site-wide");
+            }
+        }
+
+        // Probe gateway IPs for on-gateway DNS services (NextDNS CLI, ControlD ctrld).
+        // Only when DoH is not configured - these services handle encryption themselves,
+        // so detecting them prevents false "DoH not configured" warnings.
+        if (!result.DohConfigured)
+        {
+            var gatewayResults = await _thirdPartyDetector.ProbeGatewayDnsAsync(networks);
+            if (gatewayResults.Any())
+            {
+                result.HasThirdPartyDns = true;
+                result.ThirdPartyDnsServers.AddRange(gatewayResults);
+
+                if (result.ThirdPartyDnsProviderName == null)
+                {
+                    if (gatewayResults.Any(t => t.IsNextDns))
+                    {
+                        result.ThirdPartyDnsProviderName = "NextDNS CLI";
+                        _logger.LogInformation("NextDNS CLI detected on gateway across {Count} network(s)",
+                            gatewayResults.Count(t => t.IsNextDns));
+                    }
+                    else if (gatewayResults.Any(t => t.IsControlD))
+                    {
+                        result.ThirdPartyDnsProviderName = "ControlD";
+                        _logger.LogInformation("ControlD detected on gateway across {Count} network(s)",
+                            gatewayResults.Count(t => t.IsControlD));
+                    }
+                }
+
+                if (!result.IsSiteWideThirdPartyDns)
+                {
+                    var gatewayNetworkNames = gatewayResults
+                        .Select(r => r.NetworkName)
+                        .Distinct()
+                        .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                    var nonCorporateGatewayNetworks = networks
+                        .Where(n => gatewayNetworkNames.Contains(n.Name))
+                        .Where(n => n.Purpose != NetworkPurpose.Corporate)
+                        .ToList();
+
+                    if (nonCorporateGatewayNetworks.Count > 0)
+                    {
+                        result.IsSiteWideThirdPartyDns = true;
+                        var siteWideDnsIps = gatewayResults
+                            .Select(r => r.DnsServerIp)
+                            .Distinct()
+                            .ToList();
+                        result.SiteWideDnsServerIps.AddRange(siteWideDnsIps);
+                    }
+                }
             }
         }
 
@@ -2784,6 +2843,7 @@ public class DnsSecurityResult
     public bool IsPiholeDetected => ThirdPartyDnsServers.Any(t => t.IsPihole);
     public bool IsAdGuardHomeDetected => ThirdPartyDnsServers.Any(t => t.IsAdGuardHome);
     public bool IsNextDnsDetected => ThirdPartyDnsServers.Any(t => t.IsNextDns);
+    public bool IsControlDDetected => ThirdPartyDnsServers.Any(t => t.IsControlD);
     public string? ThirdPartyDnsProviderName { get; set; }
 
     /// <summary>

--- a/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
@@ -2061,9 +2061,10 @@ public class DnsSecurityAnalyzer
             }
         }
 
-        // Probe gateway IPs for on-gateway DNS services (NextDNS CLI, ControlD ctrld).
-        // Only when DoH is not configured - these services handle encryption themselves,
-        // so detecting them prevents false "DoH not configured" warnings.
+        // Probe for user-installed DNS tunnels on the gateway (NextDNS CLI, ControlD ctrld).
+        // These are manually installed via SSH, distinct from UniFi's built-in CyberSecure
+        // DoH. Only probe when DoH is not configured, since these services handle encryption
+        // themselves and their presence prevents false "DoH not configured" warnings.
         if (!result.DohConfigured)
         {
             var gatewayResults = await _thirdPartyDetector.ProbeGatewayDnsAsync(networks);

--- a/src/NetworkOptimizer.Audit/Dns/ThirdPartyDnsDetector.cs
+++ b/src/NetworkOptimizer.Audit/Dns/ThirdPartyDnsDetector.cs
@@ -546,11 +546,12 @@ public class ThirdPartyDnsDetector
     }
 
     /// <summary>
-    /// Probe gateway IPs for on-gateway DNS services (NextDNS CLI, ControlD ctrld).
-    /// These services listen on the gateway itself, so the normal per-network
-    /// detection skips them (it filters out DNS servers that match the gateway IP).
-    /// Only NextDNS and ControlD probes run here - Pi-hole and AdGuard Home are
-    /// LAN appliances, not gateway-resident services.
+    /// Probe gateway IPs for user-installed DNS tunnels (NextDNS CLI, ControlD ctrld).
+    /// These are daemons the user manually installs on the gateway via SSH - distinct
+    /// from UniFi's built-in CyberSecure Encrypted DNS, which is detected via the
+    /// DoH settings API. The normal per-network detection skips them because they
+    /// listen on the gateway IP itself. Only NextDNS and ControlD probes run here;
+    /// Pi-hole and AdGuard Home are LAN appliances, not gateway-resident services.
     /// </summary>
     public async Task<List<ThirdPartyDnsInfo>> ProbeGatewayDnsAsync(List<NetworkInfo> networks)
     {

--- a/src/NetworkOptimizer.Audit/Dns/ThirdPartyDnsDetector.cs
+++ b/src/NetworkOptimizer.Audit/Dns/ThirdPartyDnsDetector.cs
@@ -38,6 +38,7 @@ public class ThirdPartyDnsDetector
         public string? AdGuardHomeVersion { get; init; }
         public bool IsNextDns { get; init; }
         public string? NextDnsProfile { get; init; }
+        public bool IsControlD { get; init; }
         public string DnsProviderName { get; init; } = "Third-Party LAN DNS";
     }
 
@@ -124,6 +125,7 @@ public class ThirdPartyDnsDetector
                 string? adGuardHomeVersion = null;
                 bool isNextDns = false;
                 string? nextDnsProfile = null;
+                bool isControlD = false;
                 string providerName = "Third-Party LAN DNS";
 
                 if (!probedIps.Contains(dnsServer))
@@ -157,6 +159,15 @@ public class ThirdPartyDnsDetector
                                 providerName = "NextDNS CLI";
                                 _logger.LogInformation("Detected NextDNS CLI at {Ip} (profile: {Profile})", dnsServer, nextDnsProfile ?? "unknown");
                             }
+                            else
+                            {
+                                isControlD = await ProbeControlDAsync(dnsServer);
+                                if (isControlD)
+                                {
+                                    providerName = "ControlD";
+                                    _logger.LogInformation("Detected ControlD at {Ip}", dnsServer);
+                                }
+                            }
                         }
                     }
                 }
@@ -172,6 +183,7 @@ public class ThirdPartyDnsDetector
                         adGuardHomeVersion = existingResult.AdGuardHomeVersion;
                         isNextDns = existingResult.IsNextDns;
                         nextDnsProfile = existingResult.NextDnsProfile;
+                        isControlD = existingResult.IsControlD;
                         providerName = existingResult.DnsProviderName;
                     }
                 }
@@ -188,6 +200,7 @@ public class ThirdPartyDnsDetector
                     AdGuardHomeVersion = adGuardHomeVersion,
                     IsNextDns = isNextDns,
                     NextDnsProfile = nextDnsProfile,
+                    IsControlD = isControlD,
                     DnsProviderName = providerName
                 });
             }
@@ -261,14 +274,23 @@ public class ThirdPartyDnsDetector
     {
         return ipAddress switch
         {
-            "1.1.1.1" or "1.0.0.1" => "Cloudflare",
+            "1.1.1.1" or "1.0.0.1"
+                or "1.1.1.2" or "1.0.0.2"
+                or "1.1.1.3" or "1.0.0.3" => "Cloudflare",
             "8.8.8.8" or "8.8.4.4" => "Google",
-            "9.9.9.9" or "149.112.112.112" => "Quad9",
-            "208.67.222.222" or "208.67.220.220" => "OpenDNS",
-            "94.140.14.14" or "94.140.15.15" => "AdGuard DNS",
-            "45.90.28.0" or "45.90.30.0" => "NextDNS",
-            "76.76.2.0" or "76.76.10.0" => "Control D",
-            "185.228.168.9" or "185.228.169.9" => "CleanBrowsing",
+            "9.9.9.9" or "149.112.112.112"
+                or "9.9.9.10" or "149.112.112.10"
+                or "9.9.9.11" or "149.112.112.11" => "Quad9",
+            "208.67.222.222" or "208.67.220.220"
+                or "208.67.222.123" or "208.67.220.123" => "OpenDNS",
+            "94.140.14.14" or "94.140.15.15"
+                or "94.140.14.15" or "94.140.15.16"
+                or "94.140.14.140" or "94.140.14.141" => "AdGuard DNS",
+            "185.228.168.9" or "185.228.169.9"
+                or "185.228.168.168" or "185.228.169.168"
+                or "185.228.168.10" or "185.228.169.11" => "CleanBrowsing",
+            _ when ipAddress.StartsWith("45.90.28.") || ipAddress.StartsWith("45.90.30.") => "NextDNS",
+            _ when ipAddress.StartsWith("76.76.2.") || ipAddress.StartsWith("76.76.10.") => "ControlD",
             _ => null
         };
     }
@@ -452,6 +474,150 @@ public class ThirdPartyDnsDetector
             probeClient?.Dispose();
             probeHandler?.Dispose();
         }
+    }
+
+    /// <summary>
+    /// Test hook for ControlD probe, same pattern as <see cref="NextDnsProbeOverride"/>.
+    /// </summary>
+    internal static Func<string, CancellationToken, Task<bool>>? ControlDProbeOverride { get; set; }
+
+    /// <summary>
+    /// Probe an IP address to detect if it's forwarding DNS to ControlD.
+    /// </summary>
+    /// <remarks>
+    /// ControlD doesn't have a random-subdomain correlation endpoint like NextDNS.
+    /// Instead we query <c>verify.controld.com</c> through the audited resolver and
+    /// check whether the CNAME chain includes <c>api.controld.com</c>. When the
+    /// resolver is the local ctrld daemon, it forwards the query upstream to
+    /// ControlD's authoritative servers which return the expected CNAME.
+    /// </remarks>
+    private async Task<bool> ProbeControlDAsync(string ipAddress, CancellationToken ct = default)
+    {
+        if (ControlDProbeOverride != null)
+            return await ControlDProbeOverride(ipAddress, ct);
+
+        if (!IPAddress.TryParse(ipAddress, out var resolverIp))
+            return false;
+
+        try
+        {
+            var lookup = new LookupClient(new LookupClientOptions(resolverIp)
+            {
+                Timeout = TimeSpan.FromSeconds(2),
+                UseCache = false,
+                Retries = 0,
+                ContinueOnDnsError = false
+            });
+
+            var dnsResult = await lookup.QueryAsync("verify.controld.com", QueryType.CNAME, cancellationToken: ct);
+            if (dnsResult.HasError)
+            {
+                _logger.LogDebug("ControlD probe: lookup error for verify.controld.com via {Resolver}: {Error}",
+                    ipAddress, dnsResult.ErrorMessage);
+                return false;
+            }
+
+            var hasCname = dnsResult.Answers
+                .OfType<DnsClient.Protocol.CNameRecord>()
+                .Any(r => r.CanonicalName.Value
+                    .TrimEnd('.')
+                    .EndsWith("controld.com", StringComparison.OrdinalIgnoreCase));
+
+            if (!hasCname)
+            {
+                var aRecords = dnsResult.Answers
+                    .OfType<DnsClient.Protocol.ARecord>()
+                    .Select(r => r.Address.ToString())
+                    .ToList();
+
+                hasCname = aRecords.Any(ip => ip.StartsWith("147.185.34."));
+            }
+
+            if (hasCname)
+                _logger.LogDebug("ControlD probe: detected via verify.controld.com CNAME through {Resolver}", ipAddress);
+
+            return hasCname;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "ControlD probe: exception querying verify.controld.com via {Resolver}", ipAddress);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Probe gateway IPs for on-gateway DNS services (NextDNS CLI, ControlD ctrld).
+    /// These services listen on the gateway itself, so the normal per-network
+    /// detection skips them (it filters out DNS servers that match the gateway IP).
+    /// Only NextDNS and ControlD probes run here - Pi-hole and AdGuard Home are
+    /// LAN appliances, not gateway-resident services.
+    /// </summary>
+    public async Task<List<ThirdPartyDnsInfo>> ProbeGatewayDnsAsync(List<NetworkInfo> networks)
+    {
+        var results = new List<ThirdPartyDnsInfo>();
+        var probedGateways = new HashSet<string>();
+
+        foreach (var network in networks)
+        {
+            if (!network.Enabled || !network.DhcpEnabled)
+                continue;
+
+            var gatewayIp = network.Gateway;
+            if (string.IsNullOrEmpty(gatewayIp) || !probedGateways.Add(gatewayIp))
+                continue;
+
+            var usesGatewayDns = network.DnsServers == null
+                || !network.DnsServers.Any()
+                || network.DnsServers.Any(d => d == gatewayIp);
+
+            if (!usesGatewayDns)
+                continue;
+
+            _logger.LogDebug("Probing gateway {Gateway} for on-gateway DNS services", gatewayIp);
+
+            var (isNextDns, nextDnsProfile) = await ProbeNextDnsAsync(gatewayIp);
+            if (isNextDns)
+            {
+                _logger.LogInformation("Detected NextDNS CLI on gateway {Gateway} (profile: {Profile})", gatewayIp, nextDnsProfile ?? "unknown");
+
+                foreach (var net in networks.Where(n => n.Enabled && n.DhcpEnabled && n.Gateway == gatewayIp))
+                {
+                    results.Add(new ThirdPartyDnsInfo
+                    {
+                        DnsServerIp = gatewayIp,
+                        NetworkName = net.Name,
+                        NetworkVlanId = net.VlanId,
+                        IsLanIp = true,
+                        IsNextDns = true,
+                        NextDnsProfile = nextDnsProfile,
+                        DnsProviderName = "NextDNS CLI"
+                    });
+                }
+
+                continue;
+            }
+
+            var isControlD = await ProbeControlDAsync(gatewayIp);
+            if (isControlD)
+            {
+                _logger.LogInformation("Detected ControlD (ctrld) on gateway {Gateway}", gatewayIp);
+
+                foreach (var net in networks.Where(n => n.Enabled && n.DhcpEnabled && n.Gateway == gatewayIp))
+                {
+                    results.Add(new ThirdPartyDnsInfo
+                    {
+                        DnsServerIp = gatewayIp,
+                        NetworkName = net.Name,
+                        NetworkVlanId = net.VlanId,
+                        IsLanIp = true,
+                        IsControlD = true,
+                        DnsProviderName = "ControlD"
+                    });
+                }
+            }
+        }
+
+        return results;
     }
 
     /// <summary>

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/ThirdPartyDnsDetectorTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/ThirdPartyDnsDetectorTests.cs
@@ -1639,7 +1639,10 @@ public class ThirdPartyDnsDetectorTests : IDisposable
     [InlineData("208.67.222.222", "OpenDNS")]
     [InlineData("94.140.14.14", "AdGuard DNS")]
     [InlineData("45.90.28.0", "NextDNS")]
+    [InlineData("45.90.28.109", "NextDNS")]
     [InlineData("45.90.30.0", "NextDNS")]
+    [InlineData("76.76.2.0", "ControlD")]
+    [InlineData("76.76.10.11", "ControlD")]
     public void DetectExternalDns_KnownProviders_ReturnsCorrectProviderName(string dnsIp, string expectedProvider)
     {
         var detector = CreateDetector();
@@ -1875,6 +1878,140 @@ public class ThirdPartyDnsDetectorTests : IDisposable
         result.Should().HaveCount(1);
         result[0].IsPihole.Should().BeFalse();
         result[0].IsAdGuardHome.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region Gateway DNS Probe Tests
+
+    [Fact]
+    public async Task ProbeGatewayDnsAsync_NextDnsOnGateway_DetectsAcrossAllNetworks()
+    {
+        ThirdPartyDnsDetector.NextDnsProbeOverride = (ip, ct) =>
+            ip == "192.168.1.1"
+                ? Task.FromResult<(bool, string?)>((true, "abc123"))
+                : Task.FromResult<(bool, string?)>((false, null));
+
+        var detector = CreateDetector();
+        var networks = new List<NetworkInfo>
+        {
+            new() { Id = "n1", Name = "Default", VlanId = 1, Enabled = true, DhcpEnabled = true,
+                    Subnet = "192.168.1.0/24", Gateway = "192.168.1.1" },
+            new() { Id = "n2", Name = "IoT", VlanId = 20, Enabled = true, DhcpEnabled = true,
+                    Subnet = "192.168.20.0/24", Gateway = "192.168.1.1" }
+        };
+
+        var result = await detector.ProbeGatewayDnsAsync(networks);
+
+        result.Should().HaveCount(2);
+        result.Should().AllSatisfy(r =>
+        {
+            r.IsNextDns.Should().BeTrue();
+            r.DnsServerIp.Should().Be("192.168.1.1");
+            r.NextDnsProfile.Should().Be("abc123");
+            r.DnsProviderName.Should().Be("NextDNS CLI");
+        });
+        result.Select(r => r.NetworkName).Should().BeEquivalentTo("Default", "IoT");
+    }
+
+    [Fact]
+    public async Task ProbeGatewayDnsAsync_ControlDOnGateway_DetectsIt()
+    {
+        ThirdPartyDnsDetector.ControlDProbeOverride = (ip, ct) =>
+            Task.FromResult(ip == "192.168.1.1");
+
+        var detector = CreateDetector();
+        var networks = new List<NetworkInfo>
+        {
+            new() { Id = "n1", Name = "Default", VlanId = 1, Enabled = true, DhcpEnabled = true,
+                    Subnet = "192.168.1.0/24", Gateway = "192.168.1.1" }
+        };
+
+        var result = await detector.ProbeGatewayDnsAsync(networks);
+
+        result.Should().HaveCount(1);
+        result[0].IsControlD.Should().BeTrue();
+        result[0].IsNextDns.Should().BeFalse();
+        result[0].DnsServerIp.Should().Be("192.168.1.1");
+        result[0].DnsProviderName.Should().Be("ControlD");
+    }
+
+    [Fact]
+    public async Task ProbeGatewayDnsAsync_NothingOnGateway_ReturnsEmpty()
+    {
+        var detector = CreateDetector();
+        var networks = new List<NetworkInfo>
+        {
+            new() { Id = "n1", Name = "Default", VlanId = 1, Enabled = true, DhcpEnabled = true,
+                    Subnet = "192.168.1.0/24", Gateway = "192.168.1.1" }
+        };
+
+        var result = await detector.ProbeGatewayDnsAsync(networks);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ProbeGatewayDnsAsync_SkipsNetworksWithCustomDns()
+    {
+        ThirdPartyDnsDetector.NextDnsProbeOverride = (ip, ct) =>
+            Task.FromResult<(bool, string?)>((true, "abc123"));
+
+        var detector = CreateDetector();
+        var networks = new List<NetworkInfo>
+        {
+            new() { Id = "n1", Name = "Default", VlanId = 1, Enabled = true, DhcpEnabled = true,
+                    Subnet = "192.168.1.0/24", Gateway = "192.168.1.1",
+                    DnsServers = new List<string> { "10.0.0.53" } }
+        };
+
+        var result = await detector.ProbeGatewayDnsAsync(networks);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ProbeGatewayDnsAsync_ExplicitGatewayDns_StillProbes()
+    {
+        ThirdPartyDnsDetector.ControlDProbeOverride = (ip, ct) =>
+            Task.FromResult(ip == "192.168.1.1");
+
+        var detector = CreateDetector();
+        var networks = new List<NetworkInfo>
+        {
+            new() { Id = "n1", Name = "Default", VlanId = 1, Enabled = true, DhcpEnabled = true,
+                    Subnet = "192.168.1.0/24", Gateway = "192.168.1.1",
+                    DnsServers = new List<string> { "192.168.1.1" } }
+        };
+
+        var result = await detector.ProbeGatewayDnsAsync(networks);
+
+        result.Should().HaveCount(1);
+        result[0].IsControlD.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DetectThirdPartyDnsAsync_ControlDOnLanServer_DetectsIt()
+    {
+        ThirdPartyDnsDetector.ControlDProbeOverride = (ip, ct) =>
+            Task.FromResult(ip == "10.0.100.53");
+
+        var httpClient = CreateMockHttpClient(HttpStatusCode.NotFound);
+        var detector = CreateDetector(httpClient);
+        var networks = new List<NetworkInfo>
+        {
+            new() { Id = "n1", Name = "Trusted", VlanId = 1, Enabled = true, DhcpEnabled = true,
+                    Subnet = "10.0.0.0/24", Gateway = "10.0.0.1",
+                    DnsServers = new List<string> { "10.0.100.53" } }
+        };
+
+        var result = await detector.DetectThirdPartyDnsAsync(networks);
+
+        result.Should().HaveCount(1);
+        result[0].IsControlD.Should().BeTrue();
+        result[0].IsPihole.Should().BeFalse();
+        result[0].IsNextDns.Should().BeFalse();
+        result[0].DnsProviderName.Should().Be("ControlD");
     }
 
     #endregion

--- a/tests/NetworkOptimizer.Audit.Tests/TestAssemblyInit.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/TestAssemblyInit.cs
@@ -10,7 +10,7 @@ namespace NetworkOptimizer.Audit.Tests;
 /// per-class constructor boilerplate.
 /// </summary>
 /// <remarks>
-/// Currently this only owns ThirdPartyDnsDetector.NextDnsProbeOverride.
+/// Currently this owns ThirdPartyDnsDetector.NextDnsProbeOverride and ControlDProbeOverride.
 /// DohProviderRegistry.DnsResolver continues to use the existing per-file
 /// constructor/Dispose pattern - it's set in only two test classes and that
 /// scale is fine. If future work adds more test injection points, or if the
@@ -23,16 +23,15 @@ internal static class TestAssemblyInit
     internal static void Init() => SetSafeDefault();
 
     /// <summary>
-    /// Sets ThirdPartyDnsDetector.NextDnsProbeOverride to a no-op that returns
-    /// (false, null) for any input. Tests that exercise the NextDNS probe path
-    /// explicitly override this with their own outcome, then call this method
-    /// in Dispose to restore the assembly-wide default rather than nulling out
-    /// the override (which would expose subsequent tests to the real DNS+HTTPS
-    /// probe and burn their 2s DnsClient timeout).
+    /// Sets probe overrides to no-ops so tests don't hit real DNS/HTTPS endpoints.
+    /// Tests that exercise a specific probe path override it with their own outcome,
+    /// then call this method in Dispose to restore the assembly-wide default.
     /// </summary>
     internal static void SetSafeDefault()
     {
         ThirdPartyDnsDetector.NextDnsProbeOverride = (_, _) =>
             Task.FromResult<(bool IsNextDns, string? Profile)>((false, null));
+        ThirdPartyDnsDetector.ControlDProbeOverride = (_, _) =>
+            Task.FromResult(false);
     }
 }


### PR DESCRIPTION
## Summary

- **On-gateway DNS detection** - The security audit's third-party DNS detector skipped gateway IPs entirely, so NextDNS CLI or ControlD's ctrld daemon running directly on the gateway went undetected. This caused false "DoH not configured" critical findings for users who manually installed these encrypted DNS tunnels on their UniFi gateway via SSH. Now probes the gateway when DoH is disabled, using the existing test.nextdns.io correlation probe for NextDNS and a new verify.controld.com CNAME probe for ControlD. Detected providers get zero score impact (informational), same as Pi-hole and AdGuard Home.
- **ControlD detection for LAN-hosted instances** - ControlD running on a separate LAN server (not gateway) is now detected alongside existing Pi-hole, AdGuard Home, and NextDNS CLI detection.
- **Expanded public DNS provider IPs** - The WAN DNS provider identification now covers all filtering tiers: Cloudflare (1.1.1.2/3 malware/family), Quad9 (9.9.9.10/11 unsecured/ECS), OpenDNS FamilyShield, AdGuard DNS Family/Non-filtering, and all three CleanBrowsing tiers. NextDNS and ControlD use prefix matching for per-profile IPs instead of only matching the unlinked resolver addresses.

## Test plan

- [ ] Run security audit on a site with NextDNS CLI on the gateway - should detect as "NextDNS CLI" (informational) instead of flagging "DoH not configured" (critical)
- [ ] Run security audit on a site with ControlD ctrld on the gateway - should detect as "ControlD" (informational)
- [ ] Run security audit on a site with DoH enabled - gateway probe should not run (no overhead)
- [ ] Verify WAN DNS validation correctly identifies NextDNS with per-profile IPs (e.g. 45.90.28.109)
- [ ] Verify existing Pi-hole / AdGuard Home detection still works