### PR TITLE
v1.20.7

### DIFF
--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -80,6 +80,14 @@ public class IspHealthOptions
     public int LoadWindowSeconds { get; set; } = 7;
 
     /// <summary>
+    /// SNMP interface counters lag behind real-time ping probes by several seconds.
+    /// When classifying a latency/loss sample as idle or loaded, the sample's timestamp
+    /// is shifted back by this amount so it aligns with the counter window that reflects
+    /// the actual throughput at the time the sample was taken.
+    /// </summary>
+    public int CounterLagOffsetSeconds { get; set; } = 4;
+
+    /// <summary>
     /// How long a computed report stays fresh before the ISP Health tab recomputes it.
     /// The score is a 48 h rolling metric, so a few minutes of staleness is invisible; the
     /// "Last updated" label discloses the age. Each recompute is a heavy Influx query burst,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -34,14 +34,13 @@ public class IspHealthScorer
         var (speedVsPlan, bestSpeedTest, typicalDownMbps, typicalUpMbps) = ScoreSpeedVsPlan(inputs);
         var idleLatency = ScoreIdleLatency(idleBaseline, profile);
         var idleLoss = ScoreIdleLoss(inputs.LossPoolSeries, profile, avgLoad);
+        var loadedDeltas = ResolveLoadedDeltas(inputs, loadWindows);
+
         // The path jitter floor: the quietest median jitter measured anywhere along the
         // path (ISP hops and transit clusters). It represents the access layer's inherent
         // stability - every probe crosses it - so jitter is graded relative to this floor.
-        // Also used as the noise gate for loaded-latency deltas.
         var jitterFloor = ComputeJitterFloor(inputs);
         _logger?.LogDebug("ISP Health: path jitter floor {Floor} ms", FormatMsOrNull(jitterFloor));
-
-        var loadedDeltas = ResolveLoadedDeltas(inputs, loadWindows, jitterFloor);
         var (loadedLatency, hasLoadedLatency) = ScoreLoadedLatency(loadedDeltas, profile);
         var (loadedLoss, hasLoadedLoss) = ScoreLoadedLoss(inputs.LossPoolSeries, loadWindows, profile);
 
@@ -109,14 +108,13 @@ public class IspHealthScorer
     /// </summary>
     internal LoadedDeltas ResolveLoadedDeltas(
         IspHealthInputs inputs,
-        Dictionary<DateTime, LoadWindow> loadWindows,
-        double? jitterFloor = null)
+        Dictionary<DateTime, LoadWindow> loadWindows)
     {
         double? down = null, up = null;
         if (loadWindows.Count > 0)
         {
-            down = LoadedLatencyDelta(inputs, loadWindows, w => w.IsLoadedDown, jitterFloor);
-            up = LoadedLatencyDelta(inputs, loadWindows, w => w.IsLoadedUp, jitterFloor);
+            down = LoadedLatencyDelta(inputs, loadWindows, w => w.IsLoadedDown);
+            up = LoadedLatencyDelta(inputs, loadWindows, w => w.IsLoadedUp);
         }
 
         var fromSpeedTests = false;
@@ -410,81 +408,43 @@ public class IspHealthScorer
 
     /// <summary>
     /// <summary>
-    /// Global loaded-latency delta across all monitored targets (ISP access hops,
-    /// transit, and internet destinations). Each target's p80 loaded RTT minus its own
-    /// idle baseline produces a delta in ms-above-idle. Targets below the jitter floor
-    /// are noise, not load signal; the p25 of the remaining deltas is the result.
-    ///
-    /// Why p25: any target inflated beyond the real bottleneck (ICMP deprioritization,
-    /// destination degradation, peering congestion) reads HIGH. The lowest quartile
-    /// reflects real access-layer queueing without being pulled down by one target
-    /// that happened to sample the edge of a load burst due to poll timing.
+    /// Loaded-latency delta from ISP access hops only. Each access hop's loaded RTT
+    /// samples are baseline-subtracted and pooled; the median of the pool (filtered
+    /// > 0.5 ms) is the result. Pooling raw samples instead of per-target aggregates
+    /// is stable even with sparse loaded data (typical residential). Sample timestamps
+    /// are shifted back by the counter lag offset so they align with the interface
+    /// counter window that reflects actual throughput at probe time.
     /// </summary>
     private double? LoadedLatencyDelta(
         IspHealthInputs inputs,
         Dictionary<DateTime, LoadWindow> loadWindows,
-        Func<LoadWindow, bool> directionSelector,
-        double? jitterFloor)
+        Func<LoadWindow, bool> directionSelector)
     {
-        var noiseFloor = Math.Clamp(jitterFloor ?? 0.4, _options.JitterFloorMinMs, _options.JitterFloorMaxMs);
+        const double noiseFloor = 0.5;
+        var lagOffset = TimeSpan.FromSeconds(_options.CounterLagOffsetSeconds);
 
         var accessCohort = inputs.AccessHopSeries.Count > 0
             ? inputs.AccessHopSeries
             : new List<List<LatencySample>> { inputs.FirstHopSeries };
 
-        var transitSeries = inputs.TransitAsnSeries
-            .Select(s => (IReadOnlyList<LatencySample>)s.Samples)
-            .ToList();
-
-        var destSeries = inputs.DestinationSeries
-            .Select(d => (IReadOnlyList<LatencySample>)d.Samples)
-            .ToList();
-
-        var allDeltas = CohortDeltas(accessCohort, loadWindows, directionSelector)
-            .Concat(CohortDeltas(transitSeries, loadWindows, directionSelector))
-            .Concat(CohortDeltas(destSeries, loadWindows, directionSelector))
-            .Where(d => d >= noiseFloor)
-            .ToList();
-
-        return allDeltas.Count > 0 ? Math.Max(0, SeriesStats.Percentile(allDeltas, 0.25)!.Value) : null;
-    }
-
-    /// <summary>
-    /// Per-target loaded deltas for a cohort: each target's p80 loaded-window RTT minus its
-    /// own idle baseline (delta space, so targets at different distances are comparable). Each
-    /// target keeps all its loaded samples; a target without a usable baseline or enough loaded
-    /// samples is skipped - the window is not.
-    /// </summary>
-    private List<double> CohortDeltas(
-        IReadOnlyList<IReadOnlyList<LatencySample>> cohort,
-        Dictionary<DateTime, LoadWindow> loadWindows,
-        Func<LoadWindow, bool> directionSelector)
-    {
-        var deltas = new List<double>();
-        foreach (var target in cohort)
+        var pooledDeltas = new List<double>();
+        foreach (var hop in accessCohort)
         {
-            var baseline = ComputeIdleBaseline(target, loadWindows);
+            var baseline = ComputeIdleBaseline(hop, loadWindows);
             if (baseline == null) continue;
-            var delta = LoadedDelta(target, loadWindows, baseline.Value, directionSelector);
-            if (delta != null) deltas.Add(delta.Value);
-        }
-        return deltas;
-    }
 
-    private double? LoadedDelta(
-        IReadOnlyList<LatencySample> hop,
-        Dictionary<DateTime, LoadWindow> loadWindows,
-        double idleBaseline,
-        Func<LoadWindow, bool> directionSelector)
-    {
-        var rtts = hop
-            .Where(s => s.RttAvgMs.HasValue
-                && loadWindows.TryGetValue(FloorToWindow(s.Time), out var w)
-                && directionSelector(w))
-            .Select(s => s.RttAvgMs!.Value)
-            .ToList();
-        if (rtts.Count < _options.MinLoadedSamples) return null;
-        return SeriesStats.Percentile(rtts, 0.80)!.Value - idleBaseline;
+            var deltas = hop
+                .Where(s => s.RttAvgMs.HasValue
+                    && loadWindows.TryGetValue(FloorToWindow(s.Time - lagOffset), out var w)
+                    && directionSelector(w))
+                .Select(s => s.RttAvgMs!.Value - baseline.Value);
+
+            pooledDeltas.AddRange(deltas);
+        }
+
+        var credible = pooledDeltas.Where(d => d >= noiseFloor).ToList();
+        if (credible.Count < _options.MinLoadedSamples) return null;
+        return Math.Max(0, SeriesStats.Median(credible)!.Value);
     }
 
     private (IspScoreFactor Factor, bool HasData) ScoreLoadedLoss(
@@ -549,9 +509,10 @@ public class IspHealthScorer
         Dictionary<DateTime, LoadWindow> loadWindows,
         Func<LoadWindow, bool> directionSelector)
     {
+        var lagOffset = TimeSpan.FromSeconds(_options.CounterLagOffsetSeconds);
         var losses = lossPool.SelectMany(series => series)
             .Where(s => s.LossPercent.HasValue
-                && loadWindows.TryGetValue(FloorToWindow(s.Time), out var w)
+                && loadWindows.TryGetValue(FloorToWindow(s.Time - lagOffset), out var w)
                 && directionSelector(w))
             .Select(s => s.LossPercent!.Value)
             .ToList();

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -148,7 +148,7 @@ function buildOpts() {
         tooltip: {
             theme: 'dark',
             shared: true,
-            x: { format: 'HH:mm:ss' },
+            x: { format: 'HH:mm:ss', formatter: (val) => new Date(val).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' }) },
             y: [
                 { formatter: v => formatBps(v) },
                 { formatter: v => formatBps(v) },

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -971,98 +971,73 @@ public class IspHealthScorerTests
         withShifts.PathShifts.Should().HaveCount(1);
     }
 
-    // ─── Global-min loaded-latency: pool ISP access, transit, and internet targets,
-    // filter below jitter floor, take the global minimum. The cleanest credible witness
-    // of real access-layer queueing. ───
+    // ─── Pooled loaded-latency: ISP access hops only, raw baseline-subtracted samples
+    // pooled across all hops, filtered > 0.5 ms, p25 of the pool. Stable with sparse
+    // residential data and robust to ICMP deprioritization. ───
 
     private static List<LatencySample> LoadedDownHop(double idle, double loadedDelta) =>
         TestSeries.Flat(TestSeries.Start, Day, idle, 0.2, 0)
             .WithSegment(LoadedDownStart, LoadedDownEnd, idle + loadedDelta, 0.2);
 
-    private static AsnSeries Destination(int asn, double idle, double loadedDelta) =>
-        new() { AsnNumber = asn, Samples = LoadedDownHop(idle, loadedDelta) };
-
-    private static AsnSeries TransitHop(int asn, double idle, double loadedDelta) =>
-        new() { AsnNumber = asn, Samples = LoadedDownHop(idle, loadedDelta) };
-
     private static double? ResolvedDownDelta(IspHealthInputs inputs)
     {
         var lw = LoadClassifier.Classify(inputs.WanRates, inputs.ExpectedDownloadMbps, inputs.ExpectedUploadMbps, Options);
-        return new IspHealthScorer(Options).ResolveLoadedDeltas(inputs, lw, jitterFloor: 0.4).DownMs;
+        return new IspHealthScorer(Options).ResolveLoadedDeltas(inputs, lw).DownMs;
     }
 
     [Fact]
-    public void Loaded_latency_takes_global_min_when_all_targets_agree()
+    public void Loaded_latency_pools_access_hop_samples()
     {
+        // Two access hops with similar deltas - pooled p25 reflects the common signal.
         var inputs = BuildInputs(
-            accessHops: new() { LoadedDownHop(2, 4), LoadedDownHop(3, 4.5) },
-            transit: new() { TransitHop(3356, 8, 4.2) },
-            destinations: new() { Destination(15169, 13, 4), Destination(13335, 14, 3.8) });
+            accessHops: new() { LoadedDownHop(2, 4), LoadedDownHop(3, 4.5) });
 
-        ResolvedDownDelta(inputs).Should().BeApproximately(3.8, 0.7);
+        ResolvedDownDelta(inputs).Should().BeApproximately(4, 1.0);
     }
 
     [Fact]
     public void Loaded_latency_rejects_icmp_deprioritized_access_hop()
     {
-        // One access hop slams to +12 ms under load (control-plane ICMP throttle). Global
-        // min picks the cleanest credible target at +3 - the inflated hop is ignored.
+        // One access hop slams to +12 ms under load (ICMP throttle). The other two are
+        // at +3. With pooled samples, the deprioritized hop's samples are in the top of
+        // the distribution and p25 lands on the real +3 signal.
         var inputs = BuildInputs(
-            accessHops: new() { LoadedDownHop(2, 3), LoadedDownHop(3, 3), LoadedDownHop(2.5, 12) },
-            destinations: new() { Destination(15169, 13, 3), Destination(13335, 14, 3) });
+            accessHops: new() { LoadedDownHop(2, 3), LoadedDownHop(3, 3), LoadedDownHop(2.5, 12) });
 
-        ResolvedDownDelta(inputs).Should().BeApproximately(3, 0.8);
+        ResolvedDownDelta(inputs).Should().BeApproximately(3, 1.0);
         ResolvedDownDelta(inputs).Should().BeLessThan(6);
     }
 
     [Fact]
-    public void Loaded_latency_rejects_single_degraded_destination()
+    public void Loaded_latency_uses_thin_single_hop_data()
     {
-        // One destination hits +100 ms (bad night on 1.1.1.1). Global min picks +3
-        // from the clean targets - external degradation doesn't ding access.
-        var inputs = BuildInputs(
-            accessHops: new() { LoadedDownHop(2, 3), LoadedDownHop(3, 3) },
-            destinations: new() { Destination(15169, 13, 3), Destination(13335, 14, 100), Destination(19281, 16, 3) });
-
-        ResolvedDownDelta(inputs).Should().BeApproximately(3, 0.8);
-        ResolvedDownDelta(inputs).Should().BeLessThan(10);
-    }
-
-    [Fact]
-    public void Loaded_latency_uses_thin_single_hop_data_without_discarding()
-    {
-        // Data-scarce residential window: one access hop sampled the loaded burst, no
-        // destination or transit samples. The lone observation must be used.
+        // One access hop with loaded data - pooled samples from that hop are used.
         var inputs = BuildInputs(accessHops: new() { LoadedDownHop(2, 5) });
 
-        ResolvedDownDelta(inputs).Should().BeApproximately(5, 0.8);
+        ResolvedDownDelta(inputs).Should().BeApproximately(5, 1.0);
     }
 
     [Fact]
-    public void Loaded_latency_filters_noise_below_jitter_floor()
+    public void Loaded_latency_filters_sub_half_ms_deltas()
     {
-        // Access hops show near-zero delta under load (no real bufferbloat). These are
-        // below the jitter floor and should be filtered, leaving null.
+        // Access hops show sub-0.5 ms delta under load (no meaningful bufferbloat).
+        // All samples filtered out, returns null (falls back to speed tests).
         var inputs = BuildInputs(
-            accessHops: new() { LoadedDownHop(2, 0.1), LoadedDownHop(3, 0.2) },
-            destinations: new() { Destination(15169, 13, 0.1), Destination(13335, 14, 0.15) });
+            accessHops: new() { LoadedDownHop(2, 0.1), LoadedDownHop(3, 0.2) });
 
         ResolvedDownDelta(inputs).Should().BeNull();
     }
 
     [Fact]
-    public void Loaded_latency_includes_transit_in_global_pool()
+    public void Loaded_latency_ignores_transit_and_destinations()
     {
-        // Transit hops with lower deltas pull the p25 down compared to access-only.
-        var withTransit = BuildInputs(
-            accessHops: new() { LoadedDownHop(2, 5), LoadedDownHop(3, 5.5) },
-            transit: new() { TransitHop(3356, 8, 3), TransitHop(174, 10, 3.5) },
-            destinations: new() { Destination(15169, 13, 6), Destination(13335, 14, 6) });
-        var withoutTransit = BuildInputs(
-            accessHops: new() { LoadedDownHop(2, 5), LoadedDownHop(3, 5.5) },
-            destinations: new() { Destination(15169, 13, 6), Destination(13335, 14, 6) });
+        // Transit and internet targets do not contribute to loaded latency.
+        // Access hops at +3, destinations at +100 - result is still ~+3.
+        var inputs = BuildInputs(
+            accessHops: new() { LoadedDownHop(2, 3), LoadedDownHop(3, 3) },
+            destinations: new() { new() { AsnNumber = 15169, Samples = LoadedDownHop(13, 100) } });
 
-        ResolvedDownDelta(withTransit).Should().BeLessThan(ResolvedDownDelta(withoutTransit)!.Value);
+        ResolvedDownDelta(inputs).Should().BeApproximately(3, 1.0);
     }
 }
 


### PR DESCRIPTION
## Summary

- **Loaded latency scoring overhaul** - Pooled raw baseline-subtracted samples from ISP access hops, median of credible samples (> 0.5 ms). Stable with sparse residential loaded data; clean-under-load evidence from speed tests moderates the score while real bufferbloat pushes it up.
- **Counter lag compensation** - SNMP interface counters lag behind real-time ping probes by ~4 seconds, causing the highest-latency samples to be misclassified as idle. Applied to both loaded latency and loaded packet loss.
- **Live WAN chart tooltip timezone** - Tooltips now show local time instead of UTC.