### PR TITLE
Auto-tag ASN on custom transit and ISP targets

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
@@ -2,6 +2,7 @@
 @using Microsoft.EntityFrameworkCore
 @inject MonitoringLiveStats LiveStats
 @inject IDbContextFactory<NetworkOptimizerDbContext> DbFactory
+@inject NetworkOptimizer.Web.Services.Monitoring.AsnResolutionService AsnResolution
 
 <div class="card">
     <div class="card-header card-header-collapsible" @onclick="ToggleCollapse">
@@ -292,6 +293,31 @@
             var probeMode = _newTargetProbeMode == "Tcp" ? NetworkOptimizer.Core.Enums.ProbeMode.Tcp : NetworkOptimizer.Core.Enums.ProbeMode.Icmp;
             var targetId = $"custom-{Guid.NewGuid():N}"[..24];
 
+            int? asnNumber = null;
+            string? asnName = null;
+            if (targetType is MonitoringTargetType.Transit or MonitoringTargetType.AccessIsp)
+            {
+                var ip = address;
+                if (!System.Net.IPAddress.TryParse(address, out _))
+                {
+                    try
+                    {
+                        var entries = await System.Net.Dns.GetHostAddressesAsync(address);
+                        ip = entries.FirstOrDefault()?.ToString();
+                    }
+                    catch { ip = null; }
+                }
+                if (ip != null)
+                {
+                    var asn = await AsnResolution.ResolveAsync(ip);
+                    if (asn != null)
+                    {
+                        asnNumber = asn.Asn;
+                        asnName = asn.Name;
+                    }
+                }
+            }
+
             await using var db = await DbFactory.CreateDbContextAsync();
             db.MonitoringTargets.Add(new MonitoringTarget
             {
@@ -306,7 +332,9 @@
                 Enabled = true,
                 AutoDiscovered = false,
                 VantagePoint = "server",
-                CreatedAt = DateTime.UtcNow
+                CreatedAt = DateTime.UtcNow,
+                AsnNumber = asnNumber,
+                AsnName = asnName
             });
             await db.SaveChangesAsync();
 


### PR DESCRIPTION
## Summary

- When a user adds a custom monitoring target with type Transit or Access ISP, the ASN is now resolved automatically before saving
- Uses the existing `AsnResolutionService` which hits the in-memory GeoLite2 cache (no external call in most cases)
- Hostnames are DNS-resolved to an IP first; lookup failures are silently skipped so the target is still created

## Test plan

- [x] Add a transit target by IP (e.g. 4.2.2.2) - verify ASN populated in DB
- [x] Add a transit target by hostname - verify DNS resolution + ASN
- [x] Add a Custom or InternetService target - verify ASN fields remain null
- [x] Add a target with an unreachable hostname - verify target still created with null ASN