### PR TITLE
v1.21.0 Release

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -259,6 +259,17 @@ The following were implemented in the WiFi Optimizer feature:
 - **Not required** - the confirmed-by-repeat version is correct and the worst edge (double glitch) self-heals in ~10-15 s with no spike written. Revisit only if logs show clusters of "Discarding implausible SNMP rate" WARNs that aren't explained by a single bad read. Keep a fallback for the (unrealistic) small-gap reset so nothing can wedge.
 - **Relevant code:** `InterfaceRateCalculator.Compute` (reset/candidate branch), `MonitoringCollectionAgent.WriteInterfaceCounters`.
 
+### Monitoring Interfaces: Duplicate Reachable IP (DNAT + SNAT to alternate IP)
+
+- **Context:** The Monitoring Interfaces feature (Setup tab) deploys a macvlan + `/32` route + SNAT on the gateway so the Network Optimizer server (a LAN client) and browsers can reach an ONT/modem management IP that sits behind the WAN. v1 runs two preflight gates before deploy and **bails with a report** if either fails:
+  1. The target IP's subnet overlaps a known UniFi Network/VLAN (we already enumerate these via `UniFiNetworkConfig`) - monitoring that device this way isn't possible; user must renumber.
+  2. The target IP is already pingable/reachable from the Network Optimizer server - either it already works (no plumbing needed) or it's a duplicate-IP collision we can't safely route to.
+- **The deferred case:** Two devices share the same management IP on different WANs - e.g. a cable modem on `192.168.100.1` (WAN1) and a Starlink dish also on `192.168.100.1` (WAN2). A plain `/32` route is ambiguous; only one can win. To monitor both, we'd need to give each an **alternate virtual IP** the server targets, then **DNAT** that virtual IP to the real `192.168.100.1` pinned to the correct egress interface, plus the matching **SNAT** so replies return through the same macvlan.
+  - Example shape: server polls `192.168.100.1` (modem) and `192.168.101.1` (alias for Starlink); gateway DNATs `192.168.101.1 -> 192.168.100.1 out <starlink-wan-macvlan>` and SNATs the LAN source to the per-WAN alias.
+  - Needs: per-target alternate-IP allocation, DNAT+SNAT rule generation in the boot/watchdog script, idempotent teardown, and UI to surface the alternate IP the user should point monitoring at (since it's no longer the device's real IP).
+- **v1 behavior:** detect the duplicate (preflight gate 2) and bail with a clear message explaining the collision and that alternate-IP DNAT support is planned. Do **not** silently deploy a route that hijacks the shared IP.
+- **Relevant code (once built):** Monitoring Interfaces deployment service (preflight checks + boot script generation), `UniFiNetworkConfig` enumeration for the overlap gate, `NetworkUtilities.IsIpInSubnet` for overlap math.
+
 ## Multi-Tenant / Multi-Site Support
 
 ### Multi-Tenant Architecture
@@ -403,6 +414,16 @@ The following were implemented in the WiFi Optimizer feature:
 - **Issue:** Two overloads of `TryProbePiholeEndpointAsync` and `TryProbeAdGuardHomeEndpointAsync` - one takes a full URL, one takes IP+port+scheme. The logic is nearly identical.
 - **Fix:** Unify into a single method that takes a URL string. The IP+port caller can construct the URL before calling.
 - **Scope:** `ThirdPartyDnsDetector.cs` only
+
+### Consolidate udm-boot handling on IUdmBootService
+
+- **Context:** udm-boot install was extracted into a shared `IUdmBootService` / `UdmBootService` (`src/NetworkOptimizer.Web/Services/Ssh/UdmBootService.cs`) when the Monitoring Interfaces feature landed. `SqmDeploymentService.InstallUdmBootAsync` now delegates to it, but several other call sites still hand-roll udm-boot logic and should adopt the shared service. Each is marked with a `TODO` comment in code.
+- **Sites to migrate (do not duplicate the systemd unit or the inline check):**
+  - `PerfTweaksDeploymentService.InstallUdmBootAsync` - currently routes through `SqmDeploymentService.InstallUdmBootAsync`; depend on `IUdmBootService` directly to drop the PerfTweaks -> SQM -> UdmBootService chain.
+  - `PerfTweaksDeploymentService.CheckAllStatusAsync` - inline `test -f /etc/systemd/system/udm-boot.service` check; use `IUdmBootService.IsInstalledAsync()`.
+  - `SqmDeploymentService.CheckDeploymentStatusAsync` - inline udm-boot test; use `IUdmBootService.IsInstalledAsync()`.
+  - `WanSteerDeploymentService` status check - inline udm-boot test; use `IUdmBootService.IsInstalledAsync()`.
+- **Note:** these inline checks are batched into larger delimited SSH status commands, so migrating them means either issuing a small extra call or having `IUdmBootService` expose the raw check fragment. Weigh the extra round-trip against the dedup; not blocking.
 
 ### Rename ISpeedTestRepository to IGatewayRepository
 - **Issue:** `ISpeedTestRepository` is a misleading name - it handles Gateway SSH settings, iperf3 results, AND SQM WAN configuration

--- a/src/NetworkOptimizer.Monitoring/Models/OntStats.cs
+++ b/src/NetworkOptimizer.Monitoring/Models/OntStats.cs
@@ -68,4 +68,13 @@ public class OntStats
 
     /// <summary>Estimated distance to OLT in meters</summary>
     public double? Distance { get; set; }
+
+    /// <summary>Seconds the PON link has been continuously up</summary>
+    public long? LinkUptimeSeconds { get; set; }
+
+    /// <summary>Upstream OLT vendor reported by the ONT (e.g. "CALX" for Calix)</summary>
+    public string? OltVendor { get; set; }
+
+    /// <summary>Upstream OLT model reported by the ONT (e.g. "E7")</summary>
+    public string? OltModel { get; set; }
 }

--- a/src/NetworkOptimizer.Storage/Interfaces/IMonitoringInterfaceRepository.cs
+++ b/src/NetworkOptimizer.Storage/Interfaces/IMonitoringInterfaceRepository.cs
@@ -1,0 +1,23 @@
+using NetworkOptimizer.Storage.Models;
+
+namespace NetworkOptimizer.Storage.Interfaces;
+
+/// <summary>
+/// Repository for monitoring interfaces (ONT/modem management access routes
+/// deployed to the gateway).
+/// </summary>
+public interface IMonitoringInterfaceRepository
+{
+    Task<List<MonitoringInterface>> GetMonitoringInterfacesAsync(CancellationToken cancellationToken = default);
+    Task<MonitoringInterface?> GetMonitoringInterfaceAsync(int id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the monitoring interface whose target IP matches the given address,
+    /// if one exists. Used to surface deployment status next to ONT/modem monitor
+    /// configs that share the same management IP.
+    /// </summary>
+    Task<MonitoringInterface?> GetByTargetIpAsync(string targetIp, CancellationToken cancellationToken = default);
+
+    Task SaveMonitoringInterfaceAsync(MonitoringInterface config, CancellationToken cancellationToken = default);
+    Task DeleteMonitoringInterfaceAsync(int id, CancellationToken cancellationToken = default);
+}

--- a/src/NetworkOptimizer.Storage/Migrations/20260616200358_AddMonitoringInterfaces.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260616200358_AddMonitoringInterfaces.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260616200358_AddMonitoringInterfaces")]
+    partial class AddMonitoringInterfaces
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260616200358_AddMonitoringInterfaces.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260616200358_AddMonitoringInterfaces.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMonitoringInterfaces : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "MonitoringInterfaces",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 15, nullable: false),
+                    WanIfName = table.Column<string>(type: "TEXT", maxLength: 50, nullable: false),
+                    WanKey = table.Column<string>(type: "TEXT", maxLength: 10, nullable: true),
+                    TargetIp = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
+                    SubnetPrefix = table.Column<int>(type: "INTEGER", nullable: false),
+                    GatewayLocalIp = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
+                    SnatEnabled = table.Column<bool>(type: "INTEGER", nullable: false),
+                    WatchdogIntervalMinutes = table.Column<int>(type: "INTEGER", nullable: false),
+                    IsManuallyDeployed = table.Column<bool>(type: "INTEGER", nullable: false),
+                    LastError = table.Column<string>(type: "TEXT", maxLength: 1000, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MonitoringInterfaces", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MonitoringInterfaces_TargetIp",
+                table: "MonitoringInterfaces",
+                column: "TargetIp");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MonitoringInterfaces_WanIfName_Name",
+                table: "MonitoringInterfaces",
+                columns: new[] { "WanIfName", "Name" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MonitoringInterfaces");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Migrations/20260616232246_AddMonitoringInterfaceVlan.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260616232246_AddMonitoringInterfaceVlan.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260616232246_AddMonitoringInterfaceVlan")]
+    partial class AddMonitoringInterfaceVlan
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260616232246_AddMonitoringInterfaceVlan.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260616232246_AddMonitoringInterfaceVlan.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMonitoringInterfaceVlan : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "WanVlanId",
+                table: "MonitoringInterfaces",
+                type: "INTEGER",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "WanVlanId",
+                table: "MonitoringInterfaces");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/MonitoringInterface.cs
+++ b/src/NetworkOptimizer.Storage/Models/MonitoringInterface.cs
@@ -32,6 +32,14 @@ public class MonitoringInterface
     public string WanIfName { get; set; } = "";
 
     /// <summary>
+    /// Optional 802.1Q VLAN ID for the WAN. When set, the macvlan attaches to the VLAN
+    /// subinterface (e.g. "eth6.100") instead of the bare physical port, so frames are
+    /// tagged. The gateway creates that subinterface if it doesn't already exist (UniFi
+    /// creates it itself when the WAN runs on the VLAN). Null = untagged (raw port).
+    /// </summary>
+    public int? WanVlanId { get; set; }
+
+    /// <summary>
     /// WAN object key this interface targets (e.g., "wan1", "wan2"), used to
     /// re-derive the WAN display label and disambiguate dual-WAN setups. Optional.
     /// </summary>

--- a/src/NetworkOptimizer.Storage/Models/MonitoringInterface.cs
+++ b/src/NetworkOptimizer.Storage/Models/MonitoringInterface.cs
@@ -1,0 +1,83 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace NetworkOptimizer.Storage.Models;
+
+/// <summary>
+/// A persisted "monitoring interface": a macvlan + route + optional SNAT that the
+/// gateway installs so the Network Optimizer server (a LAN client) and browsers can
+/// reach an ONT/modem management IP that sits behind the WAN. Deployed as a
+/// self-contained, idempotent boot script plus a cron watchdog so it survives reboots
+/// and UniFi reprovisioning (same model as Performance Tweaks and Adaptive SQM).
+/// </summary>
+public class MonitoringInterface
+{
+    [Key]
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Name of the macvlan interface created on the gateway (e.g., "modem0").
+    /// Editable for power users; kept short and interface-name safe.
+    /// </summary>
+    [Required]
+    [MaxLength(15)]
+    public string Name { get; set; } = "modem0";
+
+    /// <summary>
+    /// Physical WAN port the macvlan rides on (e.g., "eth6"). This is the
+    /// GatewayWanInterface.IfName (the parent port), NOT the logical uplink - for
+    /// PPPoE/VLAN WANs the macvlan must attach to the physical port, not ppp0/eth4.100.
+    /// </summary>
+    [Required]
+    [MaxLength(50)]
+    public string WanIfName { get; set; } = "";
+
+    /// <summary>
+    /// WAN object key this interface targets (e.g., "wan1", "wan2"), used to
+    /// re-derive the WAN display label and disambiguate dual-WAN setups. Optional.
+    /// </summary>
+    [MaxLength(10)]
+    public string? WanKey { get; set; }
+
+    /// <summary>Management IP of the ONT/modem to reach (e.g., "192.168.100.1").</summary>
+    [Required]
+    [MaxLength(64)]
+    public string TargetIp { get; set; } = "";
+
+    /// <summary>CIDR prefix length of the modem's management subnet (default /24).</summary>
+    public int SubnetPrefix { get; set; } = 24;
+
+    /// <summary>
+    /// The gateway's LAN-local IP on the modem subnet - the address assigned to the
+    /// macvlan that the gateway and SNAT'd LAN clients source from when reaching the
+    /// modem (e.g., "192.168.100.2"). Auto-suggested as target host +/-1, editable.
+    /// </summary>
+    [Required]
+    [MaxLength(64)]
+    public string GatewayLocalIp { get; set; } = "";
+
+    /// <summary>
+    /// Whether to add a narrow SNAT rule so LAN clients (including the Network
+    /// Optimizer server's pollers) masquerade to the gateway-local IP when reaching
+    /// the modem. Required for LAN-side access; on by default.
+    /// </summary>
+    public bool SnatEnabled { get; set; } = true;
+
+    /// <summary>How often (minutes) the cron watchdog re-applies the config. Default 5.</summary>
+    public int WatchdogIntervalMinutes { get; set; } = 5;
+
+    /// <summary>
+    /// True when the user set this up by hand on the gateway and we only track/monitor
+    /// it (no deploy/remove), mirroring the Performance Tweaks "manually deployed" mode.
+    /// </summary>
+    public bool IsManuallyDeployed { get; set; }
+
+    /// <summary>Last deployment/repair error message (null if last action succeeded).</summary>
+    [MaxLength(1000)]
+    public string? LastError { get; set; }
+
+    /// <summary>When this configuration was created.</summary>
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>When this configuration was last updated.</summary>
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/NetworkOptimizer.Storage/Models/NetworkOptimizerDbContext.cs
+++ b/src/NetworkOptimizer.Storage/Models/NetworkOptimizerDbContext.cs
@@ -59,6 +59,7 @@ public class NetworkOptimizerDbContext : DbContext
     public DbSet<OuiVendor> OuiVendors { get; set; }
     public DbSet<CmConfiguration> CmConfigurations { get; set; }
     public DbSet<OntConfiguration> OntConfigurations { get; set; }
+    public DbSet<MonitoringInterface> MonitoringInterfaces { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -122,6 +123,14 @@ public class NetworkOptimizerDbContext : DbContext
             entity.ToTable("OntConfigurations");
             entity.HasIndex(e => e.Host);
             entity.HasIndex(e => e.Enabled);
+        });
+
+        // MonitoringInterface configuration (one row per ONT/modem access route)
+        modelBuilder.Entity<MonitoringInterface>(entity =>
+        {
+            entity.ToTable("MonitoringInterfaces");
+            entity.HasIndex(e => e.TargetIp);
+            entity.HasIndex(e => new { e.WanIfName, e.Name }).IsUnique();
         });
 
         // DeviceSshConfiguration configuration

--- a/src/NetworkOptimizer.Storage/Repositories/MonitoringInterfaceRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/MonitoringInterfaceRepository.cs
@@ -1,0 +1,127 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NetworkOptimizer.Storage.Interfaces;
+using NetworkOptimizer.Storage.Models;
+
+namespace NetworkOptimizer.Storage.Repositories;
+
+/// <summary>
+/// Repository for monitoring interfaces (ONT/modem management access routes
+/// deployed to the gateway).
+/// </summary>
+public class MonitoringInterfaceRepository : IMonitoringInterfaceRepository
+{
+    private readonly NetworkOptimizerDbContext _context;
+    private readonly ILogger<MonitoringInterfaceRepository> _logger;
+
+    public MonitoringInterfaceRepository(NetworkOptimizerDbContext context, ILogger<MonitoringInterfaceRepository> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<List<MonitoringInterface>> GetMonitoringInterfacesAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await _context.MonitoringInterfaces
+                .AsNoTracking()
+                .OrderBy(m => m.Name)
+                .ToListAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get monitoring interfaces");
+            throw;
+        }
+    }
+
+    public async Task<MonitoringInterface?> GetMonitoringInterfaceAsync(int id, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await _context.MonitoringInterfaces
+                .AsNoTracking()
+                .FirstOrDefaultAsync(m => m.Id == id, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get monitoring interface {Id}", id);
+            throw;
+        }
+    }
+
+    public async Task<MonitoringInterface?> GetByTargetIpAsync(string targetIp, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await _context.MonitoringInterfaces
+                .AsNoTracking()
+                .FirstOrDefaultAsync(m => m.TargetIp == targetIp, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get monitoring interface for target {TargetIp}", targetIp);
+            throw;
+        }
+    }
+
+    public async Task SaveMonitoringInterfaceAsync(MonitoringInterface config, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (config.Id > 0)
+            {
+                var existing = await _context.MonitoringInterfaces
+                    .FirstOrDefaultAsync(m => m.Id == config.Id, cancellationToken);
+                if (existing != null)
+                {
+                    existing.Name = config.Name;
+                    existing.WanIfName = config.WanIfName;
+                    existing.WanKey = config.WanKey;
+                    existing.TargetIp = config.TargetIp;
+                    existing.SubnetPrefix = config.SubnetPrefix;
+                    existing.GatewayLocalIp = config.GatewayLocalIp;
+                    existing.SnatEnabled = config.SnatEnabled;
+                    existing.WatchdogIntervalMinutes = config.WatchdogIntervalMinutes;
+                    existing.IsManuallyDeployed = config.IsManuallyDeployed;
+                    existing.LastError = config.LastError;
+                    existing.UpdatedAt = DateTime.UtcNow;
+                }
+            }
+            else
+            {
+                config.CreatedAt = DateTime.UtcNow;
+                config.UpdatedAt = DateTime.UtcNow;
+                _context.MonitoringInterfaces.Add(config);
+            }
+
+            await _context.SaveChangesAsync(cancellationToken);
+            _logger.LogDebug("Saved monitoring interface {Name} ({TargetIp})", config.Name, config.TargetIp);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save monitoring interface {Name}", config.Name);
+            throw;
+        }
+    }
+
+    public async Task DeleteMonitoringInterfaceAsync(int id, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var config = await _context.MonitoringInterfaces.FindAsync([id], cancellationToken);
+            if (config != null)
+            {
+                _context.MonitoringInterfaces.Remove(config);
+                await _context.SaveChangesAsync(cancellationToken);
+                _logger.LogDebug("Deleted monitoring interface {Id}", id);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to delete monitoring interface {Id}", id);
+            throw;
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Repositories/MonitoringInterfaceRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/MonitoringInterfaceRepository.cs
@@ -78,6 +78,7 @@ public class MonitoringInterfaceRepository : IMonitoringInterfaceRepository
                 {
                     existing.Name = config.Name;
                     existing.WanIfName = config.WanIfName;
+                    existing.WanVlanId = config.WanVlanId;
                     existing.WanKey = config.WanKey;
                     existing.TargetIp = config.TargetIp;
                     existing.SubnetPrefix = config.SubnetPrefix;

--- a/src/NetworkOptimizer.UniFi/GatewayWanHelper.cs
+++ b/src/NetworkOptimizer.UniFi/GatewayWanHelper.cs
@@ -74,6 +74,58 @@ public static class GatewayWanHelper
     }
 
     /// <summary>
+    /// Builds a human-readable WAN label from up to four identifiers
+    /// (e.g. "Acme Fiber WAN1 (eth6 - Port 7)"), degrading gracefully when any
+    /// piece is missing so it never emits empty parentheses, doubled spaces, or
+    /// "null". The connection name and WAN index form the prefix; the physical
+    /// interface and port label form a parenthesized suffix. When neither name nor a
+    /// valid WAN index is present, falls back to the interface name, then to
+    /// "Unknown WAN".
+    /// </summary>
+    /// <param name="connectionName">ISP/connection name (GatewayWanInterface.Name), if any</param>
+    /// <param name="wanIndex">1-based WAN index (1 → "WAN1"); &lt;= 0 omits the WAN label</param>
+    /// <param name="ifName">Physical interface name (e.g. "eth6"), if any</param>
+    /// <param name="portLabel">Front-panel port label (e.g. "Port 7"), if any</param>
+    public static string FormatWanLabel(string? connectionName, int wanIndex, string? ifName, string? portLabel)
+    {
+        var name = string.IsNullOrWhiteSpace(connectionName) ? null : connectionName.Trim();
+        var iface = string.IsNullOrWhiteSpace(ifName) ? null : ifName.Trim();
+        var port = string.IsNullOrWhiteSpace(portLabel) ? null : portLabel.Trim();
+        var wanLabel = wanIndex >= 1 ? $"WAN{wanIndex}" : null;
+
+        // Drop a port label that just repeats another part (common when the port is named
+        // after the ISP), so we don't render "Acme Fiber WAN4 (eth1 - Acme Fiber)".
+        if (port != null && (
+                string.Equals(port, name, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(port, iface, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(port, wanLabel, StringComparison.OrdinalIgnoreCase)))
+        {
+            port = null;
+        }
+
+        var prefix = string.Join(" ", new[] { name, wanLabel }.Where(p => !string.IsNullOrEmpty(p)));
+        var suffixParts = new List<string?> { iface, port };
+
+        if (string.IsNullOrEmpty(prefix))
+        {
+            // No name and no WAN index: fall back to the interface as the prefix so it
+            // isn't repeated in the suffix; last resort is a generic label.
+            if (iface != null)
+            {
+                prefix = iface;
+                suffixParts = new List<string?> { port };
+            }
+            else
+            {
+                prefix = "Unknown WAN";
+            }
+        }
+
+        var suffix = string.Join(" - ", suffixParts.Where(p => !string.IsNullOrEmpty(p)));
+        return string.IsNullOrEmpty(suffix) ? prefix : $"{prefix} ({suffix})";
+    }
+
+    /// <summary>
     /// Network-group convention from a wan object key ("wan"/"wan1" → "WAN",
     /// "wan2" → "WAN2"). Used when iterating GetWanInterfaces() whose Key is the
     /// raw JSON property name.

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1306,7 +1306,10 @@ else
             _soloOntId = OntParam;
         }
 
-        if (!string.IsNullOrEmpty(MiTargetParam) && _activeTab == "setup")
+        // Expand on any funnel deep-link from the monitor forms. Those links always carry
+        // mitype (cm/wmodem/ont), even when the Host field was empty so mifip is blank, so
+        // mitype is the reliable "set up a monitoring interface" signal.
+        if ((!string.IsNullOrEmpty(MiTargetParam) || !string.IsNullOrEmpty(MiTypeParam)) && _activeTab == "setup")
         {
             _pendingExpandMiCard = true;
         }

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1092,6 +1092,10 @@ else
                             <p>Devices without per-device SNMP enabled will not report port-level traffic or health metrics.</p>
                         </div>
                     </details>
+
+                    <div style="margin-top: 1.25rem;">
+                        <MonitoringInterfacesCard @ref="_miCard" PrefillTargetIp="@MiTargetParam" PrefillSourceType="@MiTypeParam" />
+                    </div>
                 </div>
             </div>
         }
@@ -1137,6 +1141,12 @@ else
 
     [SupplyParameterFromQuery(Name = "ont")]
     public string? OntParam { get; set; }
+
+    [SupplyParameterFromQuery(Name = "mifip")]
+    public string? MiTargetParam { get; set; }
+
+    [SupplyParameterFromQuery(Name = "mitype")]
+    public string? MiTypeParam { get; set; }
 
     private string? _lastTabParam;
     private string? _soloCellularModemId;
@@ -1184,6 +1194,8 @@ else
     private IReadOnlyList<SnmpDeviceStatus> _snmpDeviceStatuses = Array.Empty<SnmpDeviceStatus>();
     private SnmpDeviceStatusCard? _snmpDeviceCard;
     private bool _pendingExpandSnmpCard;
+    private MonitoringInterfacesCard? _miCard;
+    private bool _pendingExpandMiCard;
 
 
     // Chart mount tracking
@@ -1292,6 +1304,11 @@ else
         if (!string.IsNullOrEmpty(OntParam) && _activeTab == "ont")
         {
             _soloOntId = OntParam;
+        }
+
+        if (!string.IsNullOrEmpty(MiTargetParam) && _activeTab == "setup")
+        {
+            _pendingExpandMiCard = true;
         }
 
         if (!string.IsNullOrEmpty(DeviceParam) && _activeTab == "devices")
@@ -1667,6 +1684,25 @@ else
         await JS.InvokeVoidAsync("eval", @"
             (function() {
                 var el = document.getElementById('snmp-devices');
+                if (el) {
+                    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                    el.style.transition = 'outline-color 0.3s';
+                    el.style.outline = '2px solid rgba(59, 130, 246, 0.5)';
+                    el.style.outlineOffset = '4px';
+                    el.style.borderRadius = '12px';
+                    setTimeout(function() { el.style.outline = ''; el.style.outlineOffset = ''; }, 2000);
+                }
+            })();");
+    }
+
+    private async Task ScrollToMonitoringInterfacesAsync()
+    {
+        // Mirror ScrollToSnmpDevicesAsync: wait for the expand animation, then scroll
+        // to the Monitoring Interfaces card with the same brief highlight outline.
+        await Task.Delay(400);
+        await JS.InvokeVoidAsync("eval", @"
+            (function() {
+                var el = document.getElementById('monitoring-interfaces');
                 if (el) {
                     el.scrollIntoView({ behavior: 'smooth', block: 'start' });
                     el.style.transition = 'outline-color 0.3s';
@@ -2342,6 +2378,15 @@ else
             _pendingExpandSnmpCard = false;
             _snmpDeviceCard.Expand();
             await ScrollToSnmpDevicesAsync();
+        }
+
+        // Auto-expand the Monitoring Interfaces card when deep-linked from a monitor
+        // form's "set up a monitoring interface" link (mifip query param).
+        if (_pendingExpandMiCard && _activeTab == "setup" && _miCard != null)
+        {
+            _pendingExpandMiCard = false;
+            _miCard.Expand();
+            await ScrollToMonitoringInterfacesAsync();
         }
 
         // Deep-linked investigation fires once the performance tab and its chart exist

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -437,6 +437,7 @@ else
                     <div class="chart-header"><h3 class="chart-title">Memory</h3></div>
                     <div class="health-mem-chart"></div>
                 </div>
+                <div class="health-stats-table"></div>
 
                 <details class="setup-guide" style="margin-top: 1.25rem;">
                     <summary>Why do these readings differ from UniFi Network?</summary>
@@ -517,6 +518,7 @@ else
                     <div class="chart-header"><h3 class="chart-title">Temperature</h3></div>
                     <div class="sfp-temp-chart"></div>
                 </div>
+                <div class="sfp-stats-table"></div>
             </div>
         </div>
         }
@@ -634,6 +636,7 @@ else
                     <div class="chart-header"><h3 class="chart-title">FEC Errors (per interval)</h3></div>
                     <div class="cm-errors-chart"></div>
                 </div>
+                <div class="cm-stats-table"></div>
             </div>
         </div>
         }
@@ -740,6 +743,7 @@ else
                     <div class="chart-header"><h3 class="chart-title">Temperature</h3></div>
                     <div class="ont-temp-chart"></div>
                 </div>
+                <div class="ont-stats-table"></div>
             </div>
         </div>
         }
@@ -840,6 +844,7 @@ else
                     <div class="chart-header"><h3 class="chart-title">Signal Quality</h3></div>
                     <div class="cellular-quality-chart"></div>
                 </div>
+                <div class="cellular-stats-table"></div>
             </div>
         </div>
         }

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1191,6 +1191,7 @@
                                 <option value="att-gateway">AT&T Gateway (HTTP)</option>
                                 <option value="realtek-ont">Realtek ONT Stick (HTTP)</option>
                                 <option value="8311">8311 Community Firmware (HTTP)</option>
+                                <option value="quantum-q1000k">Quantum Fiber Q1000K (HTTP)</option>
                                 <option value="generic-http-ont">Generic HTTP ONT</option>
                             </select>
                         </div>
@@ -4467,6 +4468,7 @@
     private static int GetOntProviderDefaultPort(string provider) => provider switch
     {
         "8311" => 443,
+        "quantum-q1000k" => 443,
         _ => 80,
     };
 
@@ -4475,6 +4477,7 @@
         "att-gateway" => "AT&T Gateway (HTTP)",
         "realtek-ont" => "Realtek ONT Stick (HTTP)",
         "8311" => "8311 Community Firmware (HTTP)",
+        "quantum-q1000k" => "Quantum Fiber Q1000K (HTTP)",
         "generic-http-ont" => "Generic HTTP ONT",
         _ => provider,
     };

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -813,6 +813,10 @@
                             <div class="form-group" style="flex: 2;">
                                 <label class="form-label">Host / IP</label>
                                 <input type="text" class="form-control" @bind="editingModem.Host" placeholder="192.168.1.100" />
+                                <small class="form-help">
+                                    Behind your WAN and unreachable for polling?
+                                    <a href="@MonitoringInterfaceLink(editingModem.Host, "wmodem")">Set up a monitoring interface →</a>
+                                </small>
                             </div>
                             <div class="form-group" style="flex: 1;">
                                 <label class="form-label">Polling Interval (sec)</label>
@@ -839,7 +843,7 @@
                                 </div>
                                 <div class="form-group" style="flex: 1;">
                                     <label class="form-label">SSH Password</label>
-                                    <input type="password" class="form-control" @bind="editingModem.Password" />
+                                    <input type="password" class="form-control" @bind="editingModem.Password" autocomplete="new-password" data-1p-ignore data-lpignore="true" data-bwignore />
                                 </div>
                                 <div class="form-group" style="flex: 1;">
                                     <label class="form-label">USB Bus Path (optional)</label>
@@ -853,7 +857,7 @@
                             <div class="form-row">
                                 <div class="form-group" style="flex: 2;">
                                     <label class="form-label">Admin Password (optional)</label>
-                                    <input type="password" class="form-control" @bind="editingModem.Password" placeholder="Leave empty for anonymous mode" />
+                                    <input type="password" class="form-control" @bind="editingModem.Password" placeholder="Leave empty for anonymous mode" autocomplete="new-password" data-1p-ignore data-lpignore="true" data-bwignore />
                                     <small class="form-help">
                                         Without a password, signal/band/cell metrics are still polled.
                                         Setting the admin password unlocks throughput counters.
@@ -877,6 +881,12 @@
                             {
                                 <div class="alert alert-@probeResultClass" style="margin-top: 0.5rem;">
                                     @probeResult
+                                    @if (LooksUnreachable(probeResult) && !string.IsNullOrWhiteSpace(editingModem.Host))
+                                    {
+                                        <div class="mi-funnel">
+                                            Can't reach it? <a href="@MonitoringInterfaceLink(editingModem.Host, "wmodem")">Set up a monitoring interface →</a>
+                                        </div>
+                                    }
                                 </div>
                             }
                         }
@@ -913,6 +923,12 @@
             {
                 <div class="alert alert-@modemMessageClass" style="margin-top: 1rem;">
                     @modemMessage
+                    @if (LooksUnreachable(modemMessage) && !string.IsNullOrWhiteSpace(_modemTestedHost))
+                    {
+                        <div class="mi-funnel">
+                            Can't reach it? <a href="@MonitoringInterfaceLink(_modemTestedHost, "wmodem")">Set up a monitoring interface →</a>
+                        </div>
+                    }
                 </div>
             }
         </div>
@@ -1012,6 +1028,10 @@
                         <div class="form-group" style="flex: 2;">
                             <label class="form-label">Host / IP</label>
                             <input type="text" class="form-control" @bind="_editingCm.Host" placeholder="192.168.100.1" required />
+                            <small class="form-help">
+                                Behind your WAN and unreachable for polling?
+                                <a href="@MonitoringInterfaceLink(_editingCm.Host, "cm")">Set up a monitoring interface →</a>
+                            </small>
                         </div>
                         <div class="form-group" style="flex: 1;">
                             <label class="form-label">Port</label>
@@ -1027,7 +1047,8 @@
                         <div class="form-group" style="flex: 1;">
                             <label class="form-label">Password</label>
                             <input type="password" class="form-control" @bind="_editingCm.Password"
-                                   placeholder="@(_editingCm.Id > 0 && !string.IsNullOrEmpty(_editingCm.Password) ? "••••••••" : "")" />
+                                   placeholder="@(_editingCm.Id > 0 && !string.IsNullOrEmpty(_editingCm.Password) ? "••••••••" : "")"
+                                   autocomplete="new-password" data-1p-ignore data-lpignore="true" data-bwignore />
                         </div>
                     </div>
 
@@ -1075,6 +1096,12 @@
             {
                 <div class="alert alert-@_cmTestResultClass" style="margin-top: 1rem;">
                     @_cmTestResult
+                    @if (LooksUnreachable(_cmTestResult) && !string.IsNullOrWhiteSpace(_cmTestedHost))
+                    {
+                        <div class="mi-funnel">
+                            Can't reach it? <a href="@MonitoringInterfaceLink(_cmTestedHost, "cm")">Set up a monitoring interface →</a>
+                        </div>
+                    }
                 </div>
             }
         </div>
@@ -1173,6 +1200,10 @@
                         <div class="form-group" style="flex: 2;">
                             <label class="form-label">Host / IP</label>
                             <input type="text" class="form-control" @bind="_editingOnt.Host" placeholder="192.168.1.254" required />
+                            <small class="form-help">
+                                Behind your WAN and unreachable for polling?
+                                <a href="@MonitoringInterfaceLink(_editingOnt.Host, "ont")">Set up a monitoring interface →</a>
+                            </small>
                         </div>
                         <div class="form-group" style="flex: 1;">
                             <label class="form-label">Port</label>
@@ -1188,7 +1219,8 @@
                         <div class="form-group" style="flex: 1;">
                             <label class="form-label">Password</label>
                             <input type="password" class="form-control" @bind="_editingOnt.Password"
-                                   placeholder="@(_editingOnt.Id > 0 && !string.IsNullOrEmpty(_editingOnt.Password) ? "••••••••" : "")" />
+                                   placeholder="@(_editingOnt.Id > 0 && !string.IsNullOrEmpty(_editingOnt.Password) ? "••••••••" : "")"
+                                   autocomplete="new-password" data-1p-ignore data-lpignore="true" data-bwignore />
                         </div>
                     </div>
 
@@ -1235,6 +1267,12 @@
             {
                 <div class="alert alert-@_ontTestResultClass" style="margin-top: 1rem;">
                     @_ontTestResult
+                    @if (LooksUnreachable(_ontTestResult) && !string.IsNullOrWhiteSpace(_ontTestedHost))
+                    {
+                        <div class="mi-funnel">
+                            Can't reach it? <a href="@MonitoringInterfaceLink(_ontTestedHost, "ont")">Set up a monitoring interface →</a>
+                        </div>
+                    }
                 </div>
             }
         </div>
@@ -2537,6 +2575,22 @@
 
 <SponsorshipBanner AlwaysShow="true" />
 
+<style>
+    .mi-funnel {
+        margin-top: 0.5rem;
+        color: var(--text-secondary);
+    }
+
+    .mi-funnel a,
+    .mi-funnel a:visited {
+        color: var(--primary-color);
+    }
+
+    .mi-funnel a:hover {
+        color: var(--primary-hover);
+    }
+</style>
+
 @code {
     // UniFi Controller
     private string controllerUrl = "https://192.168.1.1";
@@ -2573,6 +2627,7 @@
     private bool savingModem = false;
     private string modemMessage = "";
     private string modemMessageClass = "";
+    private string? _modemTestedHost;
     private List<DiscoveredModem> discoveredModems = new();
     private bool loadingDiscoveredModems = false;
     private bool modemFormExpanded = false;
@@ -2585,6 +2640,7 @@
     private string? _cmTestResult;
     private string _cmTestResultClass = "info";
     private int? _cmTestingId;
+    private string? _cmTestedHost;
     private string _cmStatus = "Inactive";
 
     // External ONT Monitoring
@@ -2594,6 +2650,33 @@
     private bool _savingOnt;
     private string? _ontTestResult;
     private string _ontTestResultClass = "info";
+    private string? _ontTestedHost;
+
+    /// <summary>
+    /// Deep-link to the Monitoring Interfaces section (Monitoring → Setup), absorbing the
+    /// in-progress modem/ONT IP (and source type, so the new interface gets a sensible
+    /// default name like cmodem0/wmodem0/ont0) so the add form opens pre-filled.
+    /// </summary>
+    private static string MonitoringInterfaceLink(string? host, string type)
+    {
+        var ip = string.IsNullOrWhiteSpace(host) ? "" : Uri.EscapeDataString(host.Trim());
+        return $"/monitoring?tab=setup&mifip={ip}&mitype={type}";
+    }
+
+    /// <summary>
+    /// Whether a failed Test/Probe message looks like the device couldn't be reached
+    /// (timeout, canceled, refused, no route) - the signature of a modem/ONT sitting
+    /// behind the WAN. Auth (401) or parse failures mean the device IS reachable, so we
+    /// don't funnel those toward a monitoring interface.
+    /// </summary>
+    private static bool LooksUnreachable(string? message)
+    {
+        if (string.IsNullOrEmpty(message)) return false;
+        var m = message.ToLowerInvariant();
+        return m.Contains("timeout") || m.Contains("timed out") || m.Contains("canceled") || m.Contains("cancelled")
+            || m.Contains("refused") || m.Contains("no route") || m.Contains("unreachable")
+            || m.Contains("no such host") || m.Contains("actively refused") || m.Contains("connection attempt failed");
+    }
     private int? _ontTestingId;
     private string _ontStatus = "Inactive";
 
@@ -4053,6 +4136,7 @@
 
     private async Task TestModemConnection(ModemConfiguration modem)
     {
+        _modemTestedHost = modem.Host;
         modemMessage = $"Polling {modem.Name}...";
         modemMessageClass = "info";
         StateHasChanged();
@@ -4162,6 +4246,7 @@
     private async Task TestCm(CmConfiguration config)
     {
         _cmTestingId = config.Id;
+        _cmTestedHost = config.Host;
         _cmTestResult = $"Testing {config.Name}...";
         _cmTestResultClass = "info";
         StateHasChanged();
@@ -4320,6 +4405,7 @@
     private async Task TestOnt(OntConfiguration config)
     {
         _ontTestingId = config.Id;
+        _ontTestedHost = config.Host;
         _ontTestResult = $"Testing {config.Name}...";
         _ontTestResultClass = "info";
         StateHasChanged();

--- a/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
@@ -2,6 +2,7 @@
 @using Microsoft.EntityFrameworkCore
 @inject MonitoringLiveStats LiveStats
 @inject IDbContextFactory<NetworkOptimizerDbContext> DbFactory
+@inject NetworkOptimizer.Web.Services.Monitoring.AsnResolutionService AsnResolution
 
 <div class="card">
     <div class="card-header card-header-collapsible" @onclick="ToggleCollapse">
@@ -292,6 +293,31 @@
             var probeMode = _newTargetProbeMode == "Tcp" ? NetworkOptimizer.Core.Enums.ProbeMode.Tcp : NetworkOptimizer.Core.Enums.ProbeMode.Icmp;
             var targetId = $"custom-{Guid.NewGuid():N}"[..24];
 
+            int? asnNumber = null;
+            string? asnName = null;
+            if (targetType is MonitoringTargetType.Transit or MonitoringTargetType.AccessIsp)
+            {
+                var ip = address;
+                if (!System.Net.IPAddress.TryParse(address, out _))
+                {
+                    try
+                    {
+                        var entries = await System.Net.Dns.GetHostAddressesAsync(address);
+                        ip = entries.FirstOrDefault()?.ToString();
+                    }
+                    catch { ip = null; }
+                }
+                if (ip != null)
+                {
+                    var asn = await AsnResolution.ResolveAsync(ip);
+                    if (asn != null)
+                    {
+                        asnNumber = asn.Asn;
+                        asnName = asn.Name;
+                    }
+                }
+            }
+
             await using var db = await DbFactory.CreateDbContextAsync();
             db.MonitoringTargets.Add(new MonitoringTarget
             {
@@ -306,7 +332,9 @@
                 Enabled = true,
                 AutoDiscovered = false,
                 VantagePoint = "server",
-                CreatedAt = DateTime.UtcNow
+                CreatedAt = DateTime.UtcNow,
+                AsnNumber = asnNumber,
+                AsnName = asnName
             });
             await db.SaveChangesAsync();
 

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -126,9 +126,11 @@
                     <div class="form-row">
                         <div class="form-group mi-grow-2">
                             <label class="form-label">Modem/ONT IP</label>
-                            <input type="text" class="form-control" @bind="_editing.TargetIp" @bind:after="OnTargetChanged" placeholder="192.168.100.1" />
+                            <input type="text" class="form-control" @bind="_editing.TargetIp" @bind:event="oninput" @bind:after="OnTargetChanged" placeholder="192.168.100.1" />
                             <small class="form-help">The management IP you're trying to reach (e.g. your modem or ONT status page).</small>
                         </div>
+                    </div>
+                    <div class="form-row">
                         <div class="form-group mi-grow-2">
                             <label class="form-label">WAN interface</label>
                             <select class="form-control" @bind="_editing.WanIfName" @bind:after="OnWanChanged">
@@ -147,6 +149,17 @@
                             </select>
                             <small class="form-help">The WAN your modem/ONT sits behind. The interface rides this port.</small>
                         </div>
+                        <div class="form-group mi-grow-2">
+                            <label class="form-label">VLAN</label>
+                            <div class="mi-vlan">
+                                <label class="checkbox-label mi-vlan-toggle">
+                                    <input type="checkbox" @bind="_vlanEnabled" @bind:after="OnVlanToggled" />
+                                    <span>Tagged</span>
+                                </label>
+                                <input type="number" class="form-control mi-vlan-id" @bind="_editing.WanVlanId" @bind:event="oninput" min="1" max="4094" placeholder="100" disabled="@(!_vlanEnabled)" />
+                            </div>
+                            <small class="form-help">Tag the interface when your WAN runs on a VLAN (some fiber ISPs). Leave off for a plain port.</small>
+                        </div>
                     </div>
 
                     <details class="setup-guide mi-advanced">
@@ -155,22 +168,22 @@
                             <div class="form-row">
                                 <div class="form-group mi-grow-2">
                                     <label class="form-label">Gateway-local IP</label>
-                                    <input type="text" class="form-control" @bind="_editing.GatewayLocalIp" placeholder="192.168.100.2" />
+                                    <input type="text" class="form-control" @bind="_editing.GatewayLocalIp" @bind:event="oninput" @bind:after="OnLocalIpEdited" placeholder="192.168.100.2" />
                                     <small class="form-help">The gateway's address on the modem's subnet. Auto-suggested; must be free and on the same subnet.</small>
                                 </div>
                                 <div class="form-group mi-grow-1">
                                     <label class="form-label">Subnet prefix</label>
-                                    <input type="number" class="form-control" @bind="_editing.SubnetPrefix" min="8" max="30" />
+                                    <input type="number" class="form-control" @bind="_editing.SubnetPrefix" @bind:event="oninput" min="8" max="30" />
                                 </div>
                                 <div class="form-group mi-grow-1">
                                     <label class="form-label">Interface name</label>
-                                    <input type="text" class="form-control" @bind="_editing.Name" placeholder="modem0" />
+                                    <input type="text" class="form-control" @bind="_editing.Name" @bind:event="oninput" placeholder="modem0" />
                                 </div>
                             </div>
                             <div class="form-row">
                                 <div class="form-group mi-grow-1">
                                     <label class="form-label">Watchdog interval (min)</label>
-                                    <input type="number" class="form-control" @bind="_editing.WatchdogIntervalMinutes" min="1" max="60" />
+                                    <input type="number" class="form-control" @bind="_editing.WatchdogIntervalMinutes" @bind:event="oninput" min="1" max="60" />
                                     <small class="form-help">How often the gateway re-applies the route so it survives reprovisioning.</small>
                                 </div>
                                 <div class="form-group mi-grow-2">
@@ -280,6 +293,20 @@
     .mi-grow-2 {
         flex: 2;
     }
+
+    .mi-vlan {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+    }
+
+    .mi-vlan-toggle {
+        white-space: nowrap;
+    }
+
+    .mi-vlan-id {
+        max-width: 6rem;
+    }
 </style>
 
 @code {
@@ -301,6 +328,12 @@
 
     private MonitoringInterface _editing = NewInterface();
     private MonitoringInterface? _editingOriginal;
+    private bool _vlanEnabled;
+
+    // True while GatewayLocalIp holds an auto-suggested value (not user-entered), so the
+    // suggestion keeps tracking the target as it's typed. Cleared once the user edits the
+    // gateway-local field themselves.
+    private bool _localIpAutoSuggested;
     private bool _collapsed = true;
     private bool _stateLoaded;
     private const string CollapseKey = "monitoring-interfaces-collapsed";
@@ -320,6 +353,7 @@
         Id = mi.Id,
         Name = mi.Name,
         WanIfName = mi.WanIfName,
+        WanVlanId = mi.WanVlanId,
         WanKey = mi.WanKey,
         TargetIp = mi.TargetIp,
         SubnetPrefix = mi.SubnetPrefix,
@@ -332,7 +366,8 @@
     // into the macvlan name, route, SNAT rule, or script filename - otherwise the old
     // artifacts (interface, route, SNAT, cron, /data/on_boot.d file) are orphaned.
     private static bool NeedsOldTeardown(MonitoringInterface a, MonitoringInterface b)
-        => a.Name != b.Name || a.WanIfName != b.WanIfName || a.TargetIp != b.TargetIp
+        => a.Name != b.Name || a.WanIfName != b.WanIfName || a.WanVlanId != b.WanVlanId
+            || a.TargetIp != b.TargetIp
             || a.GatewayLocalIp != b.GatewayLocalIp || a.SubnetPrefix != b.SubnetPrefix
             || a.SnatEnabled != b.SnatEnabled;
 
@@ -469,6 +504,8 @@
     {
         _editing = Snapshot(mi);
         _editingOriginal = Snapshot(mi);
+        _vlanEnabled = mi.WanVlanId.HasValue;
+        _localIpAutoSuggested = false;
         _collapsed = false;
         _message = null;
         _deploySteps.Clear();
@@ -478,14 +515,36 @@
     {
         _editing = NewInterface();
         _editingOriginal = null;
+        _vlanEnabled = false;
+        _localIpAutoSuggested = false;
         _message = null;
+    }
+
+    // When VLAN tagging is turned off, drop the stored VLAN so we deploy on the raw port.
+    private void OnVlanToggled()
+    {
+        if (!_vlanEnabled)
+            _editing.WanVlanId = null;
     }
 
     private void OnTargetChanged()
     {
-        if (string.IsNullOrWhiteSpace(_editing.GatewayLocalIp))
-            _editing.GatewayLocalIp = SuggestLocalIp(_editing.TargetIp);
+        // Keep the suggested gateway-local IP tracking the target until the user edits it
+        // themselves. With per-keystroke (oninput) binding, a one-shot "suggest only when
+        // empty" would lock onto a transient prefix - typing 10.10.10.100 passes through
+        // 10.10.10.1, suggesting .2 and then freezing. Re-suggesting while auto-suggested
+        // lets it follow through to the final octet.
+        if (string.IsNullOrWhiteSpace(_editing.GatewayLocalIp) || _localIpAutoSuggested)
+        {
+            var suggested = SuggestLocalIp(_editing.TargetIp);
+            _editing.GatewayLocalIp = suggested;
+            _localIpAutoSuggested = !string.IsNullOrEmpty(suggested);
+        }
     }
+
+    // The user edited the gateway-local IP by hand: stop auto-suggesting so we don't
+    // overwrite their value when the target changes.
+    private void OnLocalIpEdited() => _localIpAutoSuggested = false;
 
     private void OnWanChanged()
     {
@@ -517,6 +576,8 @@
         var saved = _interfaces.FirstOrDefault(i => i.TargetIp == _editing.TargetIp && i.WanIfName == _editing.WanIfName);
         _editing = NewInterface();
         _editingOriginal = null;
+        _vlanEnabled = false;
+        _localIpAutoSuggested = false;
 
         // Editing changed gateway-affecting fields: remove the old config first so we don't
         // leave a stale macvlan/route/SNAT/cron/boot-script behind.
@@ -540,6 +601,16 @@
     {
         _message = null;
         _deploySteps.Clear();
+
+        // "Tagged" is checked but no VLAN ID entered: the placeholder can read like a
+        // set value, so require an explicit ID rather than silently deploying untagged.
+        if (_vlanEnabled && _editing.WanVlanId is null)
+        {
+            _message = "Enter a VLAN ID, or uncheck Tagged.";
+            _messageSuccess = false;
+            return false;
+        }
+
         var error = MonitoringInterfaceDeploymentService.Validate(_editing);
         if (error != null)
         {
@@ -729,7 +800,12 @@
     /// </summary>
     private static string SuggestLocalIp(string? targetIp)
     {
-        if (!IPAddress.TryParse(targetIp, out var ip) || ip.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
+        // Require a complete dotted-quad. IPAddress.TryParse accepts shorthand like "1"
+        // (-> 0.0.0.1) or "192.168.100" (-> 192.168.0.100), which under per-keystroke
+        // (oninput) binding would suggest off a half-typed address (e.g. "0.0.0.2").
+        if (targetIp is null || targetIp.Split('.').Length != 4 ||
+            !IPAddress.TryParse(targetIp, out var ip) ||
+            ip.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
             return "";
         var bytes = ip.GetAddressBytes();
         int last = bytes[3];

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -1,0 +1,731 @@
+@using System.Net
+@using NetworkOptimizer.Storage.Interfaces
+@using NetworkOptimizer.Storage.Models
+@using NetworkOptimizer.UniFi
+@using NetworkOptimizer.Web.Services
+@inject IMonitoringInterfaceRepository Repo
+@inject MonitoringInterfaceDeploymentService Deploy
+@inject ISqmService SqmService
+@inject Microsoft.JSInterop.IJSRuntime JS
+@inject ILogger<MonitoringInterfacesCard> Logger
+
+<div class="card" id="monitoring-interfaces">
+    <div class="card-header card-header-collapsible" @onclick="ToggleCollapse">
+        <div class="card-title-group">
+            <h2 class="card-title">Monitoring Interfaces</h2>
+        </div>
+        <div class="card-header-right">
+            <span class="status-badge status-active" @onclick:stopPropagation="true">@SummaryLabel()</span>
+            <span class="issue-type-chevron">@(_collapsed ? "▼" : "▲")</span>
+        </div>
+    </div>
+    <div class="expand-wrapper @(!_collapsed && _stateLoaded ? "expanded" : "")" style="@(!_stateLoaded ? "display:none" : "")">
+        <div class="expand-content">
+            <div class="card-body">
+        <p class="section-description">
+            Having trouble reaching your ONT or modem for polling? When a modem or ONT management
+            page sits behind your WAN, the gateway can't route to it and monitoring (and your
+            browser) can't reach it. A monitoring interface adds a small, reboot-safe route on the
+            gateway so that device becomes reachable from the LAN.
+        </p>
+
+        <div class="mi-tip">
+            <strong>Try this first - a native static route may be all you need.</strong>
+            In UniFi Network, go to <strong>Settings → Policy Engine → Policy Table</strong> and add a
+            <strong>Static Route</strong> for the device's IP (for example <code>192.168.100.1/32</code>)
+            out the WAN interface it sits behind. No scripts and nothing to maintain. If the device
+            still isn't reachable afterward - common for modems and ONTs that only answer when the
+            gateway has an on-link address on their subnet - add a monitoring interface below.
+        </div>
+
+        @if (_interfaces.Count == 0)
+        {
+            <p class="empty-state">
+                No monitoring interfaces configured. Add one below if a modem/ONT management IP
+                isn't reachable for polling.
+            </p>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Modem/ONT IP</th>
+                            <th>WAN</th>
+                            <th>Gateway-local IP</th>
+                            <th>Status</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var mi in _interfaces)
+                        {
+                            <tr>
+                                <td><code>@mi.Name</code></td>
+                                <td><code>@mi.TargetIp</code></td>
+                                <td>@WanLabelFor(mi)</td>
+                                <td><code>@mi.GatewayLocalIp/@mi.SubnetPrefix</code></td>
+                                <td>@StatusBadge(mi)</td>
+                                <td>
+                                    <div class="btn-group-wrap">
+                                        <button class="btn btn-secondary btn-sm" @onclick="() => EditInterface(mi)" disabled="@(_busyId != null)">Edit</button>
+                                        <button class="btn btn-primary btn-sm" @onclick="() => DeployInterface(mi)" disabled="@(_busyId != null)">
+                                            @if (_busyId == mi.Id && _busyAction == "deploy")
+                                            {
+                                                <span class="spinner spinner-sm"></span>
+                                                <span>Deploying...</span>
+                                            }
+                                            else
+                                            {
+                                                <span>@(IsApplied(mi) ? "Re-apply" : "Deploy")</span>
+                                            }
+                                        </button>
+                                        <button class="btn btn-secondary btn-sm" @onclick="() => CheckStatus(mi)" disabled="@(_busyId != null)">Check status</button>
+                                        <button class="btn btn-danger btn-sm" @onclick="() => RemoveInterface(mi)" disabled="@(_busyId != null)">
+                                            @if (_busyId == mi.Id && _busyAction == "remove")
+                                            {
+                                                <span class="spinner spinner-sm"></span>
+                                                <span>Removing...</span>
+                                            }
+                                            else
+                                            {
+                                                <span>Remove</span>
+                                            }
+                                        </button>
+                                    </div>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+
+        @if (!string.IsNullOrEmpty(_message))
+        {
+            <div class="alert @(_messageSuccess ? "alert-success" : "alert-danger")" style="margin-top: 1rem;">@_message</div>
+        }
+
+                @if (_deploySteps.Count > 0)
+                {
+                    <div class="mi-deploy-log">
+                        <h4>Deployment progress</h4>
+                        <ul class="mi-step-list">
+                            @foreach (var step in _deploySteps)
+                            {
+                                <li>@step</li>
+                            }
+                        </ul>
+                    </div>
+                }
+
+                <div class="mi-add-section">
+                    <h3>@(_editing.Id > 0 ? "Edit monitoring interface" : "Add a monitoring interface")</h3>
+                    <div class="form-row">
+                        <div class="form-group mi-grow-2">
+                            <label class="form-label">Modem/ONT IP</label>
+                            <input type="text" class="form-control" @bind="_editing.TargetIp" @bind:after="OnTargetChanged" placeholder="192.168.100.1" />
+                            <small class="form-help">The management IP you're trying to reach (e.g. your modem or ONT status page).</small>
+                        </div>
+                        <div class="form-group mi-grow-2">
+                            <label class="form-label">WAN interface</label>
+                            <select class="form-control" @bind="_editing.WanIfName" @bind:after="OnWanChanged">
+                                <option value="">Select WAN...</option>
+                                @foreach (var w in _wans)
+                                {
+                                    @if (string.IsNullOrEmpty(w.PhysicalIfName))
+                                    {
+                                        <option value="" disabled>@WanOptionLabel(w) - no physical port</option>
+                                    }
+                                    else
+                                    {
+                                        <option value="@w.PhysicalIfName">@WanOptionLabel(w)</option>
+                                    }
+                                }
+                            </select>
+                            <small class="form-help">The WAN your modem/ONT sits behind. The interface rides this port.</small>
+                        </div>
+                    </div>
+
+                    <details class="setup-guide mi-advanced">
+                        <summary>Advanced</summary>
+                        <div class="setup-guide-content">
+                            <div class="form-row">
+                                <div class="form-group mi-grow-2">
+                                    <label class="form-label">Gateway-local IP</label>
+                                    <input type="text" class="form-control" @bind="_editing.GatewayLocalIp" placeholder="192.168.100.2" />
+                                    <small class="form-help">The gateway's address on the modem's subnet. Auto-suggested; must be free and on the same subnet.</small>
+                                </div>
+                                <div class="form-group mi-grow-1">
+                                    <label class="form-label">Subnet prefix</label>
+                                    <input type="number" class="form-control" @bind="_editing.SubnetPrefix" min="8" max="30" />
+                                </div>
+                                <div class="form-group mi-grow-1">
+                                    <label class="form-label">Interface name</label>
+                                    <input type="text" class="form-control" @bind="_editing.Name" placeholder="modem0" />
+                                </div>
+                            </div>
+                            <div class="form-row">
+                                <div class="form-group mi-grow-1">
+                                    <label class="form-label">Watchdog interval (min)</label>
+                                    <input type="number" class="form-control" @bind="_editing.WatchdogIntervalMinutes" min="1" max="60" />
+                                    <small class="form-help">How often the gateway re-applies the route so it survives reprovisioning.</small>
+                                </div>
+                                <div class="form-group mi-grow-2">
+                                    <label class="checkbox-label">
+                                        <input type="checkbox" @bind="_editing.SnatEnabled" />
+                                        <span>Allow LAN clients to reach the device (SNAT)</span>
+                                    </label>
+                                    <small class="form-help">Required for the Network Optimizer server and browsers to reach the device. Leave on unless you only need gateway-local access.</small>
+                                </div>
+                            </div>
+                        </div>
+                    </details>
+
+                    <div class="action-buttons">
+                        <button class="btn btn-primary" @onclick="SaveAndDeploy" disabled="@(_busyId != null || _saving)">
+                            @if (_saving)
+                            {
+                                <span class="spinner spinner-sm"></span>
+                                <span>Working...</span>
+                            }
+                            else
+                            {
+                                <span>Save &amp; Deploy</span>
+                            }
+                        </button>
+                        <button class="btn btn-secondary" @onclick="SaveOnly" disabled="@(_busyId != null || _saving)">Save without deploying</button>
+                        @if (_editing.Id > 0)
+                        {
+                            <button class="btn btn-secondary" @onclick="CancelEdit" disabled="@_saving">Cancel edit</button>
+                        }
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+    .mi-deploy-log {
+        margin-top: 1rem;
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--border-radius-lg);
+        padding: 1rem;
+    }
+
+    .mi-deploy-log h4 {
+        margin: 0 0 0.5rem 0;
+        font-size: 0.9rem;
+        color: var(--text-primary);
+    }
+
+    .mi-step-list {
+        margin: 0;
+        padding-left: 1.25rem;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+    }
+
+    .mi-step-list li {
+        margin: 0.25rem 0;
+    }
+
+    .mi-add-section {
+        margin-top: 1.5rem;
+        border: 1px solid var(--border-color);
+        border-radius: var(--border-radius-lg);
+        background: var(--bg-tertiary);
+        padding: 1rem 1.25rem 1.25rem 1.25rem;
+    }
+
+    .mi-add-section h3 {
+        margin: 0 0 1rem 0;
+        font-size: 1rem;
+        color: var(--text-primary);
+    }
+
+    .mi-tip {
+        background: rgba(71, 151, 255, 0.1);
+        border: 1px solid var(--info-color);
+        border-left: 4px solid var(--info-color);
+        border-radius: var(--border-radius);
+        padding: 1rem;
+        margin-top: 1rem;
+        margin-bottom: 1rem;
+        font-size: 0.875rem;
+        color: var(--text-primary);
+    }
+
+    .mi-tip strong {
+        color: var(--info-color);
+    }
+
+    .mi-advanced {
+        margin-bottom: 1rem;
+    }
+
+    .mi-advanced .setup-guide-content {
+        margin-top: 0.5rem;
+    }
+
+    .mi-grow-1 {
+        flex: 1;
+    }
+
+    .mi-grow-2 {
+        flex: 2;
+    }
+</style>
+
+@code {
+    /// <summary>
+    /// Optional modem/ONT IP to pre-fill into a new interface, used by the deep-links from
+    /// the CM/ONT/Cellular monitor forms ("can't reach it? set up an interface").
+    /// </summary>
+    [Parameter] public string? PrefillTargetIp { get; set; }
+
+    /// <summary>
+    /// Source type of the deep-link (cm/wmodem/ont) used to choose a sensible default
+    /// interface name (cmodem0, wmodem0, ont0), incremented past any existing ones.
+    /// </summary>
+    [Parameter] public string? PrefillSourceType { get; set; }
+
+    private List<MonitoringInterface> _interfaces = new();
+    private List<WanInterfaceInfo> _wans = new();
+    private readonly Dictionary<int, MonitoringInterfaceDeploymentService.InterfaceStatus> _statuses = new();
+
+    private MonitoringInterface _editing = NewInterface();
+    private MonitoringInterface? _editingOriginal;
+    private bool _collapsed = true;
+    private bool _stateLoaded;
+    private const string CollapseKey = "monitoring-interfaces-collapsed";
+    private bool _saving;
+    private int? _busyId;
+    private string? _busyAction;
+    private string? _message;
+    private bool _messageSuccess;
+    private List<string> _deploySteps = new();
+
+    private string? _appliedPrefill;
+
+    private static MonitoringInterface NewInterface() => new() { Name = "modem0", SubnetPrefix = 24, SnatEnabled = true, WatchdogIntervalMinutes = 5 };
+
+    private static MonitoringInterface Snapshot(MonitoringInterface mi) => new()
+    {
+        Id = mi.Id,
+        Name = mi.Name,
+        WanIfName = mi.WanIfName,
+        WanKey = mi.WanKey,
+        TargetIp = mi.TargetIp,
+        SubnetPrefix = mi.SubnetPrefix,
+        GatewayLocalIp = mi.GatewayLocalIp,
+        SnatEnabled = mi.SnatEnabled,
+        WatchdogIntervalMinutes = mi.WatchdogIntervalMinutes
+    };
+
+    // A gateway re-teardown is needed when an edit changes anything the boot script bakes
+    // into the macvlan name, route, SNAT rule, or script filename - otherwise the old
+    // artifacts (interface, route, SNAT, cron, /data/on_boot.d file) are orphaned.
+    private static bool NeedsOldTeardown(MonitoringInterface a, MonitoringInterface b)
+        => a.Name != b.Name || a.WanIfName != b.WanIfName || a.TargetIp != b.TargetIp
+            || a.GatewayLocalIp != b.GatewayLocalIp || a.SubnetPrefix != b.SubnetPrefix
+            || a.SnatEnabled != b.SnatEnabled;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+        // NOTE: collapse state is decided once in OnAfterRenderAsync (saved preference, else
+        // count-based default). Don't set _collapsed here - this runs after an await and can
+        // land after OnAfterRenderAsync, clobbering the loaded localStorage preference.
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+            return;
+
+        // Decide collapse state once, deterministically: a saved preference wins; with none,
+        // default to expanded when nothing is configured (discoverable) and collapsed once
+        // interfaces exist. A deep-link forcing the card open (PrefillTargetIp) skips this -
+        // OnParametersSet already expanded it.
+        if (string.IsNullOrWhiteSpace(PrefillTargetIp))
+        {
+            string? val = null;
+            try { val = await JS.InvokeAsync<string>("localStorage.getItem", CollapseKey); }
+            catch { }
+
+            if (val == "true") _collapsed = true;
+            else if (val == "false") _collapsed = false;
+            else _collapsed = _interfaces.Count > 0;
+        }
+
+        _stateLoaded = true;
+        StateHasChanged();
+    }
+
+    protected override void OnParametersSet()
+    {
+        // Absorb the IP the user was trying to reach (from a monitor form deep-link).
+        if (!string.IsNullOrWhiteSpace(PrefillTargetIp) && PrefillTargetIp != _appliedPrefill)
+        {
+            _appliedPrefill = PrefillTargetIp;
+            var existing = _interfaces.FirstOrDefault(i => i.TargetIp == PrefillTargetIp);
+            if (existing != null)
+            {
+                EditInterface(existing);
+            }
+            else
+            {
+                _editing = NewInterface();
+                _editingOriginal = null;
+                _editing.TargetIp = PrefillTargetIp!.Trim();
+                _editing.Name = NextFreeName(PrefixForType(PrefillSourceType));
+                OnTargetChanged();
+            }
+            _collapsed = false;
+        }
+    }
+
+    private static string PrefixForType(string? type) => type switch
+    {
+        "cm" => "cmodem",
+        "wmodem" => "wmodem",
+        "ont" => "ont",
+        _ => "modem"
+    };
+
+    /// <summary>Lowest free "{prefix}{n}" name (n from 0) not already used by an interface.</summary>
+    private string NextFreeName(string prefix)
+    {
+        var used = new HashSet<string>(_interfaces.Select(i => i.Name), StringComparer.OrdinalIgnoreCase);
+        for (var n = 0; ; n++)
+        {
+            var candidate = $"{prefix}{n}";
+            if (!used.Contains(candidate))
+                return candidate;
+        }
+    }
+
+    private async Task ToggleCollapse()
+    {
+        _collapsed = !_collapsed;
+        try { await JS.InvokeVoidAsync("localStorage.setItem", CollapseKey, _collapsed ? "true" : "false"); }
+        catch { }
+    }
+
+    /// <summary>Expand the card from outside (e.g. when a deep-link or banner jumps here).</summary>
+    public void Expand()
+    {
+        _collapsed = false;
+        _stateLoaded = true;
+        StateHasChanged();
+    }
+
+    private string SummaryLabel()
+        => _interfaces.Count == 0 ? "None configured"
+            : $"{_interfaces.Count} configured";
+
+    private async Task LoadAsync()
+    {
+        try
+        {
+            _interfaces = await Repo.GetMonitoringInterfacesAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load monitoring interfaces");
+            _interfaces = new();
+        }
+
+        try
+        {
+            _wans = await SqmService.GetWanInterfacesFromControllerAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Failed to load WAN interfaces for monitoring interface picker");
+            _wans = new();
+        }
+    }
+
+    private void EditInterface(MonitoringInterface mi)
+    {
+        _editing = Snapshot(mi);
+        _editingOriginal = Snapshot(mi);
+        _collapsed = false;
+        _message = null;
+        _deploySteps.Clear();
+    }
+
+    private void CancelEdit()
+    {
+        _editing = NewInterface();
+        _editingOriginal = null;
+        _message = null;
+    }
+
+    private void OnTargetChanged()
+    {
+        if (string.IsNullOrWhiteSpace(_editing.GatewayLocalIp))
+            _editing.GatewayLocalIp = SuggestLocalIp(_editing.TargetIp);
+    }
+
+    private void OnWanChanged()
+    {
+        var w = _wans.FirstOrDefault(x => x.PhysicalIfName == _editing.WanIfName);
+        _editing.WanKey = w != null && w.WanIndex > 0 ? $"wan{w.WanIndex}" : null;
+    }
+
+    private async Task SaveOnly()
+    {
+        if (!await ValidateAndSaveAsync())
+            return;
+        _message = "Saved. It won't take effect until you deploy.";
+        _messageSuccess = true;
+        CancelEdit();
+        await LoadAsync();
+    }
+
+    private async Task SaveAndDeploy()
+    {
+        // Capture the pre-edit config before save/reset so we can tear down any orphaned
+        // gateway state (renamed interface, changed WAN/target, disabled SNAT, etc.).
+        var original = _editingOriginal;
+
+        if (!await ValidateAndSaveAsync())
+            return;
+
+        // Reload so we have the persisted Id, then deploy that row.
+        await LoadAsync();
+        var saved = _interfaces.FirstOrDefault(i => i.TargetIp == _editing.TargetIp && i.WanIfName == _editing.WanIfName);
+        _editing = NewInterface();
+        _editingOriginal = null;
+
+        // Editing changed gateway-affecting fields: remove the old config first so we don't
+        // leave a stale macvlan/route/SNAT/cron/boot-script behind.
+        if (original != null && saved != null && NeedsOldTeardown(original, saved))
+        {
+            try
+            {
+                await Deploy.RemoveAsync(original);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(ex, "Failed to tear down previous monitoring interface config before re-deploy");
+            }
+        }
+
+        if (saved != null)
+            await DeployInterface(saved);
+    }
+
+    private async Task<bool> ValidateAndSaveAsync()
+    {
+        _message = null;
+        _deploySteps.Clear();
+        var error = MonitoringInterfaceDeploymentService.Validate(_editing);
+        if (error != null)
+        {
+            _message = error;
+            _messageSuccess = false;
+            return false;
+        }
+
+        _saving = true;
+        try
+        {
+            await Repo.SaveMonitoringInterfaceAsync(_editing);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to save monitoring interface");
+            _message = $"Save failed: {ex.Message}";
+            _messageSuccess = false;
+            return false;
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private async Task DeployInterface(MonitoringInterface mi)
+    {
+        _busyId = mi.Id;
+        _busyAction = "deploy";
+        _message = null;
+        _deploySteps.Clear();
+        StateHasChanged();
+        try
+        {
+            var result = await Deploy.DeployAsync(mi);
+            _deploySteps = result.Steps;
+            _message = result.Message;
+            _messageSuccess = result.Success;
+            if (result.Success)
+            {
+                mi.LastError = null;
+                await CheckStatus(mi, silent: true);
+            }
+            else
+            {
+                mi.LastError = result.Message;
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Deploy failed for monitoring interface {Id}", mi.Id);
+            _message = $"Deploy failed: {ex.Message}";
+            _messageSuccess = false;
+        }
+        finally
+        {
+            _busyId = null;
+            _busyAction = null;
+            StateHasChanged();
+        }
+    }
+
+    private async Task RemoveInterface(MonitoringInterface mi)
+    {
+        _busyId = mi.Id;
+        _busyAction = "remove";
+        _message = null;
+        _deploySteps.Clear();
+        StateHasChanged();
+        try
+        {
+            var (success, steps) = await Deploy.RemoveAsync(mi);
+            _deploySteps = steps;
+            await Repo.DeleteMonitoringInterfaceAsync(mi.Id);
+            _statuses.Remove(mi.Id);
+
+            // If we were editing the interface we just removed, drop back to the add form.
+            if (_editing.Id == mi.Id)
+            {
+                _editing = NewInterface();
+                _editingOriginal = null;
+            }
+
+            _message = success ? $"Removed monitoring interface {mi.Name}." : "Removed configuration; some gateway cleanup may have failed (see log).";
+            _messageSuccess = success;
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Remove failed for monitoring interface {Id}", mi.Id);
+            _message = $"Remove failed: {ex.Message}";
+            _messageSuccess = false;
+        }
+        finally
+        {
+            _busyId = null;
+            _busyAction = null;
+            StateHasChanged();
+        }
+    }
+
+    private async Task CheckStatus(MonitoringInterface mi, bool silent = false)
+    {
+        if (!silent)
+        {
+            _busyId = mi.Id;
+            _busyAction = "status";
+            StateHasChanged();
+        }
+        try
+        {
+            _statuses[mi.Id] = await Deploy.CheckStatusAsync(mi);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Status check failed for monitoring interface {Id}", mi.Id);
+        }
+        finally
+        {
+            if (!silent)
+            {
+                _busyId = null;
+                _busyAction = null;
+            }
+            StateHasChanged();
+        }
+    }
+
+    private bool IsApplied(MonitoringInterface mi)
+        => _statuses.TryGetValue(mi.Id, out var s) && s.IsFullyApplied(mi);
+
+    private RenderFragment StatusBadge(MonitoringInterface mi) => builder =>
+    {
+        string cls, text;
+        if (!_statuses.TryGetValue(mi.Id, out var s))
+        {
+            cls = "status-disconnected";
+            text = "Unknown";
+        }
+        else if (!s.GatewayReachable)
+        {
+            cls = "status-disconnected";
+            text = "Gateway unreachable";
+        }
+        else if (s.IsFullyApplied(mi))
+        {
+            cls = "status-connected";
+            text = "Active";
+        }
+        else if (s.InterfaceExists || s.BootScriptPresent)
+        {
+            cls = "status-disconnected";
+            text = "Needs re-apply";
+        }
+        else
+        {
+            cls = "status-disconnected";
+            text = "Not deployed";
+        }
+        builder.OpenElement(0, "span");
+        builder.AddAttribute(1, "class", $"status-badge {cls}");
+        builder.AddContent(2, text);
+        builder.CloseElement();
+    };
+
+    private string WanLabelFor(MonitoringInterface mi)
+    {
+        var w = _wans.FirstOrDefault(x => x.PhysicalIfName == mi.WanIfName);
+        if (w != null)
+            return GatewayWanHelper.FormatWanLabel(w.Name, w.WanIndex, w.PhysicalIfName, w.PortLabel);
+        // WAN not currently reported (down/absent) - fall back to the stored identifiers.
+        var index = ParseWanIndex(mi.WanKey);
+        return GatewayWanHelper.FormatWanLabel(null, index, mi.WanIfName, null);
+    }
+
+    private static string WanOptionLabel(WanInterfaceInfo w)
+        => GatewayWanHelper.FormatWanLabel(w.Name, w.WanIndex, w.PhysicalIfName, w.PortLabel);
+
+    private static int ParseWanIndex(string? wanKey)
+        => !string.IsNullOrEmpty(wanKey) && int.TryParse(wanKey.Replace("wan", ""), out var i) ? i : 0;
+
+    /// <summary>
+    /// Suggest a gateway-local IP on the modem's subnet: the target host +/-1, avoiding
+    /// .0/.255 and the target itself. Editable by the user.
+    /// </summary>
+    private static string SuggestLocalIp(string? targetIp)
+    {
+        if (!IPAddress.TryParse(targetIp, out var ip) || ip.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
+            return "";
+        var bytes = ip.GetAddressBytes();
+        int last = bytes[3];
+        int candidate = last + 1;
+        if (candidate >= 255) candidate = last - 1;
+        if (candidate <= 0) candidate = 2;
+        if (candidate == last) candidate = last == 1 ? 2 : last - 1;
+        bytes[3] = (byte)candidate;
+        return new IPAddress(bytes).ToString();
+    }
+}

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -351,9 +351,9 @@
 
         // Decide collapse state once, deterministically: a saved preference wins; with none,
         // default to expanded when nothing is configured (discoverable) and collapsed once
-        // interfaces exist. A deep-link forcing the card open (PrefillTargetIp) skips this -
-        // OnParametersSet already expanded it.
-        if (string.IsNullOrWhiteSpace(PrefillTargetIp))
+        // interfaces exist. A funnel deep-link (PrefillTargetIp OR PrefillSourceType) forces
+        // the card open in OnParametersSet, so skip this for it.
+        if (string.IsNullOrWhiteSpace(PrefillTargetIp) && string.IsNullOrWhiteSpace(PrefillSourceType))
         {
             string? val = null;
             try { val = await JS.InvokeAsync<string>("localStorage.getItem", CollapseKey); }
@@ -370,25 +370,37 @@
 
     protected override void OnParametersSet()
     {
-        // Absorb the IP the user was trying to reach (from a monitor form deep-link).
-        if (!string.IsNullOrWhiteSpace(PrefillTargetIp) && PrefillTargetIp != _appliedPrefill)
+        // A funnel deep-link from the monitor forms carries the source type (cm/wmodem/ont)
+        // and optionally the IP - the Host field may be empty, which is a valid use case.
+        // Absorb whatever's present, default a sensible name, and force the card open.
+        if (string.IsNullOrWhiteSpace(PrefillTargetIp) && string.IsNullOrWhiteSpace(PrefillSourceType))
+            return;
+
+        var prefillKey = $"{PrefillTargetIp}|{PrefillSourceType}";
+        if (prefillKey == _appliedPrefill)
+            return;
+        _appliedPrefill = prefillKey;
+
+        var existing = string.IsNullOrWhiteSpace(PrefillTargetIp)
+            ? null
+            : _interfaces.FirstOrDefault(i => i.TargetIp == PrefillTargetIp);
+        if (existing != null)
         {
-            _appliedPrefill = PrefillTargetIp;
-            var existing = _interfaces.FirstOrDefault(i => i.TargetIp == PrefillTargetIp);
-            if (existing != null)
+            EditInterface(existing);
+        }
+        else
+        {
+            _editing = NewInterface();
+            _editingOriginal = null;
+            if (!string.IsNullOrWhiteSpace(PrefillTargetIp))
             {
-                EditInterface(existing);
-            }
-            else
-            {
-                _editing = NewInterface();
-                _editingOriginal = null;
                 _editing.TargetIp = PrefillTargetIp!.Trim();
-                _editing.Name = NextFreeName(PrefixForType(PrefillSourceType));
                 OnTargetChanged();
             }
-            _collapsed = false;
+            if (!string.IsNullOrWhiteSpace(PrefillSourceType))
+                _editing.Name = NextFreeName(PrefixForType(PrefillSourceType));
         }
+        _collapsed = false;
     }
 
     private static string PrefixForType(string? type) => type switch

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -167,6 +167,7 @@ builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.IUniFiRepository,
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.IModemRepository, NetworkOptimizer.Storage.Repositories.ModemRepository>();
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.ICmRepository, NetworkOptimizer.Storage.Repositories.CmRepository>();
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.IOntRepository, NetworkOptimizer.Storage.Repositories.OntRepository>();
+builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.IMonitoringInterfaceRepository, NetworkOptimizer.Storage.Repositories.MonitoringInterfaceRepository>();
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.ISpeedTestRepository, NetworkOptimizer.Storage.Repositories.SpeedTestRepository>();
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.ISqmRepository, NetworkOptimizer.Storage.Repositories.SqmRepository>();
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.IAgentRepository, NetworkOptimizer.Storage.Repositories.AgentRepository>();
@@ -177,6 +178,10 @@ builder.Services.AddSingleton<SshClientService>();
 
 // Register Gateway SSH service (singleton - SSH access to UniFi gateway/UDM)
 builder.Services.AddSingleton<IGatewaySshService, GatewaySshService>();
+
+// Register udm-boot installer (singleton - shared gateway boot-script infrastructure
+// used by Adaptive SQM, Monitoring Interfaces, etc.)
+builder.Services.AddSingleton<IUdmBootService, UdmBootService>();
 
 // Register UniFi SSH service (singleton - shared SSH credentials for all UniFi devices)
 builder.Services.AddSingleton<UniFiSshService>();
@@ -408,6 +413,7 @@ builder.Services.AddScoped<ISqmService, SqmService>();
 builder.Services.AddScoped<SqmDeploymentService>();
 builder.Services.AddScoped<WanSteerDeploymentService>();
 builder.Services.AddScoped<PerfTweaksDeploymentService>();
+builder.Services.AddScoped<MonitoringInterfaceDeploymentService>();
 builder.Services.AddScoped<AgentService>();
 
 // Register WiFi Optimizer rules and engine

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -207,6 +207,7 @@ builder.Services.AddSingleton<CableModemMonitorService>();
 builder.Services.AddSingleton<IOntProvider, AttGatewayOntProvider>();
 builder.Services.AddSingleton<IOntProvider, RealtekOntProvider>();
 builder.Services.AddSingleton<IOntProvider, Lantiq8311OntProvider>();
+builder.Services.AddSingleton<IOntProvider, QuantumQ1000kOntProvider>();
 builder.Services.AddSingleton<IOntProvider, GenericHttpOntProvider>();
 builder.Services.AddSingleton<OntMonitorService>();
 

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/MotorolaHnapProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/MotorolaHnapProvider.cs
@@ -11,8 +11,11 @@ namespace NetworkOptimizer.Web.Services.CableModemProviders;
 
 /// <summary>
 /// Cable modem provider for Motorola DOCSIS modems that use the HNAP protocol
-/// (MB8611, MB8600, MB7621, etc.). Communicates via JSON-over-HTTPS to the /HNAP1/
-/// endpoint with HMAC-MD5 authentication.
+/// (MB8611, MB8600, MB7621, etc.). Communicates via JSON to the /HNAP1/ endpoint
+/// with HMAC-MD5 authentication. The transport scheme is detected on first contact
+/// and cached per configuration: HTTPS is tried first so modems already working over
+/// TLS are unaffected, with HTTP as a fallback for modems whose HTTPS handshake .NET
+/// cannot complete.
 /// </summary>
 public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
 {
@@ -50,6 +53,13 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
     /// </summary>
     private readonly ConcurrentDictionary<int, DateTime> _loginBackoffUntil = new();
 
+    /// <summary>
+    /// Per-config detected transport scheme: true = HTTPS, false = HTTP. Determined on
+    /// first successful contact (a Test press or the first poll) and reused so later
+    /// polls skip protocol detection. Re-detected after a process restart.
+    /// </summary>
+    private readonly ConcurrentDictionary<int, bool> _useHttps = new();
+
     public MotorolaHnapProvider(ILogger<MotorolaHnapProvider> logger)
     {
         _logger = logger;
@@ -82,14 +92,15 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         try
         {
             using var client = CreateHttpClient();
-            var baseUrl = BuildBaseUrl(context);
 
-            var session = await EnsureSessionAsync(client, baseUrl, context, cancellationToken);
-            if (session == null)
+            var sessionInfo = await EnsureSessionAsync(client, context, cancellationToken);
+            if (sessionInfo == null)
             {
                 _logger.LogWarning("Motorola HNAP {Name} at {Host}: login failed", context.Name, context.Host);
                 return null;
             }
+
+            var (session, baseUrl) = sessionInfo.Value;
 
             using var response = await CallMultipleHnapsAsync(
                 client, baseUrl, session,
@@ -137,13 +148,13 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         try
         {
             using var client = CreateHttpClient();
-            var baseUrl = BuildBaseUrl(context);
 
-            var session = await LoginAsync(client, baseUrl, context, cancellationToken);
-            if (session == null)
-                return (false, "Login failed. Check credentials, or wait 5 minutes if locked out from failed attempts.");
+            var sessionInfo = await EnsureSessionAsync(client, context, cancellationToken);
+            if (sessionInfo == null)
+                return (false, "Could not log in over HTTP or HTTPS. Check the host and credentials; " +
+                    "if there have been several failed logins, wait 5 minutes for the modem's lockout to clear.");
 
-            _sessions[context.Id] = session;
+            var (session, baseUrl) = sessionInfo.Value;
 
             using var response = await CallMultipleHnapsAsync(
                 client, baseUrl, session,
@@ -172,29 +183,85 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         }
     }
 
-    private async Task<HnapSession?> EnsureSessionAsync(
-        HttpClient client, string baseUrl, CmPollContext context, CancellationToken cancellationToken)
+    /// <summary>
+    /// Resolve a working session, detecting (and caching) the HTTP/HTTPS scheme the
+    /// modem's HNAP endpoint speaks. Returns the session and the base URL that worked,
+    /// or null if no scheme could log in.
+    /// </summary>
+    private async Task<SessionInfo?> EnsureSessionAsync(
+        HttpClient client, CmPollContext context, CancellationToken cancellationToken)
     {
-        if (_sessions.TryGetValue(context.Id, out var cached))
+        // Fast path: reuse a cached session over the scheme we already detected.
+        if (_useHttps.TryGetValue(context.Id, out var knownScheme) &&
+            _sessions.TryGetValue(context.Id, out var cached))
         {
+            var cachedUrl = BuildBaseUrl(context, knownScheme);
             using var testResponse = await CallMultipleHnapsAsync(
-                client, baseUrl, cached,
+                client, cachedUrl, cached,
                 ["GetMotoStatusConnectionInfo"],
                 cancellationToken);
 
             if (testResponse != null)
-                return cached;
+                return new SessionInfo(cached, cachedUrl);
 
             _sessions.TryRemove(context.Id, out _);
             _logger.LogDebug("Motorola HNAP session expired for {Name}, re-authenticating", context.Name);
         }
 
-        var session = await LoginAsync(client, baseUrl, context, cancellationToken);
-        if (session != null)
-            _sessions[context.Id] = session;
+        // Detect the scheme the modem's HNAP endpoint speaks. HTTPS is tried first so
+        // modems already working over TLS keep the exact same path they use today; HTTP
+        // is the fallback for modems whose HTTPS handshake .NET can't complete (it stalls
+        // until timeout, e.g. on macOS) - those modems also serve /HNAP1/ over plain HTTP.
+        foreach (var useHttps in SchemesToTry(context.Id))
+        {
+            var baseUrl = BuildBaseUrl(context, useHttps);
 
-        return session;
+            HnapSession? session;
+            try
+            {
+                session = await LoginAsync(client, baseUrl, context, cancellationToken);
+            }
+            catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                // Request stalled on this scheme (e.g. an HTTPS handshake .NET can't
+                // finish); move on and try the next candidate.
+                _logger.LogDebug("Motorola HNAP {Name}: {Scheme} attempt timed out, trying next scheme",
+                    context.Name, useHttps ? "HTTPS" : "HTTP");
+                continue;
+            }
+
+            if (session != null)
+            {
+                _sessions[context.Id] = session;
+                _useHttps[context.Id] = useHttps;
+                return new SessionInfo(session, baseUrl);
+            }
+
+            // The endpoint answered on this scheme but auth failed (lockout backoff is
+            // now set). The scheme is correct, so remember it and stop - retrying the
+            // other scheme would just burn another failed login against the lockout.
+            if (_loginBackoffUntil.ContainsKey(context.Id))
+            {
+                _useHttps[context.Id] = useHttps;
+                return null;
+            }
+
+            // Otherwise this scheme never reached the HNAP endpoint (e.g. an HTTP->HTTPS
+            // redirect); fall through and try the next scheme.
+        }
+
+        // Nothing worked and no scheme was confirmed - drop any stale cached scheme so
+        // the next attempt probes both again.
+        _useHttps.TryRemove(context.Id, out _);
+        return null;
     }
+
+    /// <summary>
+    /// Schemes to attempt for this config: the cached one if known, otherwise HTTPS
+    /// first (so modems already working over TLS are unchanged) then HTTP.
+    /// </summary>
+    private bool[] SchemesToTry(int id) =>
+        _useHttps.TryGetValue(id, out var scheme) ? [scheme] : [true, false];
 
     /// <summary>
     /// Two-phase HNAP login: request challenge, derive keys, authenticate.
@@ -205,6 +272,10 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         var endpoint = baseUrl + HnapPath;
         var username = context.Username ?? "admin";
         var password = context.Password ?? "";
+
+        // Phase 1 is unauthenticated; clear cookies left from any prior attempt (e.g. a
+        // different scheme on this reused client) so the challenge request is sent clean.
+        client.DefaultRequestHeaders.Remove("Cookie");
 
         // Phase 1: request challenge
         var requestPayload = new
@@ -370,6 +441,14 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
             _logger.LogDebug(ex, "HNAP POST {Action} failed", action);
             return null;
         }
+        catch (JsonException ex)
+        {
+            // A non-JSON response (e.g. an HTML error/redirect page from the wrong
+            // scheme) means this isn't a working HNAP endpoint; treat it as a failed
+            // call so scheme detection falls through to the next candidate.
+            _logger.LogDebug(ex, "HNAP POST {Action} returned non-JSON body", action);
+            return null;
+        }
     }
 
     private async Task LogoutAsync(HttpClient client, string baseUrl, CancellationToken cancellationToken)
@@ -504,11 +583,26 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         return 0;
     }
 
-    private static string BuildBaseUrl(CmPollContext context)
+    /// <summary>
+    /// Build the base URL for the given scheme. A user-specified non-default port is
+    /// honored; otherwise the standard port for the scheme is used (80 for HTTP, 443
+    /// for HTTPS). HTTPS is attempted first; HTTP is the fallback used when .NET cannot
+    /// complete a modem's HTTPS handshake (it stalls until the request times out, even
+    /// though the modem's TLS is otherwise standard and a browser connects fine). The
+    /// HTML web UI redirects HTTP to HTTPS, but the /HNAP1/ endpoint answers over HTTP.
+    /// </summary>
+    private static string BuildBaseUrl(CmPollContext context, bool useHttps)
     {
-        var port = context.Port > 0 ? context.Port : 443;
-        var portSuffix = port == 443 ? "" : $":{port}";
-        return $"https://{context.Host}{portSuffix}";
+        if (useHttps)
+        {
+            var httpsPort = context.Port is > 0 and not 80 ? context.Port : 443;
+            var httpsSuffix = httpsPort == 443 ? "" : $":{httpsPort}";
+            return $"https://{context.Host}{httpsSuffix}";
+        }
+
+        var port = context.Port is > 0 and not 443 ? context.Port : 80;
+        var portSuffix = port == 80 ? "" : $":{port}";
+        return $"http://{context.Host}{portSuffix}";
     }
 
     /// <summary>
@@ -551,8 +645,14 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         var handler = new HttpClientHandler
         {
             AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+            // Accept the modem's self-signed cert when the HTTPS fallback is used.
             ServerCertificateCustomValidationCallback = (_, _, _, _) => true,
             UseCookies = false,
+            // Don't follow redirects: a modem that only serves its UI over HTTPS will
+            // 301 an HTTP request, and following it would land on the HTTPS path .NET
+            // may not be able to complete. A 301 instead reads as "wrong scheme" so
+            // detection moves on to HTTPS.
+            AllowAutoRedirect = false,
         };
 
         return new HttpClient(handler)
@@ -623,7 +723,11 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
     {
         _sessions.Clear();
         _loginBackoffUntil.Clear();
+        _useHttps.Clear();
     }
 
     private sealed record HnapSession(string PrivateKey, string? Uid);
+
+    /// <summary>A logged-in session together with the base URL (scheme) that worked.</summary>
+    private readonly record struct SessionInfo(HnapSession Session, string BaseUrl);
 }

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Headers;
 using System.Text;
+using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
@@ -23,6 +24,15 @@ public sealed class NetgearCmProvider : ICableModemProvider
     private const int TimeoutSeconds = 15;
     private const int MaxRetries = 3;
     private static readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(1);
+
+    // Some Netgear modems (e.g. CM600) allow only one web session at a time. When another
+    // session is active, any page 302-redirects to MultiLogin.asp, which offers to log out
+    // the existing session. These patterns pull the takeover token and RetailSessionId from
+    // that page so polling can claim the session instead of failing.
+    private static readonly Regex MultiLoginSessionRx =
+        new(@"goform/MultiLogin\?session=([0-9A-Za-z]+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex RetailSessionRx =
+        new("name=[\"']?RetailSessionId[\"']?\\s+value=[\"']?([0-9A-Za-z]+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     private readonly ILogger<NetgearCmProvider> _logger;
 
@@ -147,9 +157,17 @@ public sealed class NetgearCmProvider : ICableModemProvider
         string? password,
         CancellationToken cancellationToken)
     {
+        // Follow redirects manually (AllowAutoRedirect = false) so the Basic auth header is
+        // sent on EVERY hop. .NET drops the Authorization header when auto-following a
+        // redirect, which breaks single-session modems (e.g. CM600) that 302 every page to
+        // MultiLogin.asp when another session is active - the redirected request would 401.
+        // The cookie jar keeps the session across the takeover (GET -> POST -> re-GET).
         using var handler = new HttpClientHandler
         {
             AutomaticDecompression = System.Net.DecompressionMethods.GZip | System.Net.DecompressionMethods.Deflate,
+            CookieContainer = new System.Net.CookieContainer(),
+            UseCookies = true,
+            AllowAutoRedirect = false,
         };
         using var client = new HttpClient(handler)
         {
@@ -162,11 +180,97 @@ public sealed class NetgearCmProvider : ICableModemProvider
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
         }
 
-        var response = await client.GetAsync(url, cancellationToken);
+        var response = await GetFollowingRedirectsAsync(client, url, cancellationToken);
         response.EnsureSuccessStatusCode();
-
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        // If we landed on the single-session takeover page (rather than the status page),
+        // claim the session and re-fetch. Modems without this behavior never hit this path,
+        // so the normal flow is unchanged.
+        if (IsMultiLoginPage(response.RequestMessage?.RequestUri, content))
+        {
+            if (await TryTakeOverSessionAsync(client, url, content, cancellationToken))
+            {
+                response = await GetFollowingRedirectsAsync(client, url, cancellationToken);
+                response.EnsureSuccessStatusCode();
+                content = await response.Content.ReadAsStringAsync(cancellationToken);
+            }
+        }
+
         return string.IsNullOrWhiteSpace(content) ? null : content;
+    }
+
+    /// <summary>
+    /// GET a URL, following same-style redirects manually so the client's default headers
+    /// (notably Basic auth) are re-sent on each hop - unlike HttpClient auto-redirect, which
+    /// strips the Authorization header. Resolves relative Location values (e.g.
+    /// "MultiLogin.asp"). Stops after a few hops to avoid loops.
+    /// </summary>
+    private static async Task<HttpResponseMessage> GetFollowingRedirectsAsync(
+        HttpClient client,
+        string url,
+        CancellationToken cancellationToken)
+    {
+        var current = url;
+        var response = await client.GetAsync(current, cancellationToken);
+
+        for (int hop = 0; hop < 5
+            && (int)response.StatusCode is >= 300 and < 400
+            && response.Headers.Location != null; hop++)
+        {
+            var next = new Uri(new Uri(current), response.Headers.Location);
+            response.Dispose();
+            current = next.ToString();
+            response = await client.GetAsync(current, cancellationToken);
+        }
+
+        return response;
+    }
+
+    /// <summary>
+    /// True when a response is the Netgear single-session "MultiLogin" takeover page
+    /// (another web session is active) rather than the requested status page.
+    /// </summary>
+    private static bool IsMultiLoginPage(Uri? finalUri, string content)
+    {
+        if (finalUri != null && finalUri.AbsolutePath.Contains("MultiLogin", StringComparison.OrdinalIgnoreCase))
+            return true;
+        return content.Contains("goform/MultiLogin", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Logs out the existing web session by POSTing the MultiLogin takeover form
+    /// (<c>yes=yes&amp;Act=yes&amp;RetailSessionId=...</c> to
+    /// <c>/goform/MultiLogin?session=...</c>). Returns true if the takeover was submitted.
+    /// </summary>
+    private async Task<bool> TryTakeOverSessionAsync(
+        HttpClient client,
+        string statusUrl,
+        string multiLoginHtml,
+        CancellationToken cancellationToken)
+    {
+        var sessionMatch = MultiLoginSessionRx.Match(multiLoginHtml);
+        var retailMatch = RetailSessionRx.Match(multiLoginHtml);
+        if (!sessionMatch.Success || !retailMatch.Success)
+        {
+            _logger.LogDebug("Netgear CM MultiLogin page seen but takeover tokens not found; cannot reclaim session");
+            return false;
+        }
+
+        var authority = new Uri(statusUrl).GetLeftPart(UriPartial.Authority);
+        var postUrl = $"{authority}/goform/MultiLogin?session={sessionMatch.Groups[1].Value}";
+        var form = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("yes", "yes"),
+            new KeyValuePair<string, string>("Act", "yes"),
+            new KeyValuePair<string, string>("RetailSessionId", retailMatch.Groups[1].Value),
+        });
+
+        _logger.LogDebug("Netgear CM: another web session active; logging it out via MultiLogin to poll");
+        var postResponse = await client.PostAsync(postUrl, form, cancellationToken);
+        // The takeover POST returns a 302 redirect on success (we don't auto-follow it; the
+        // caller re-fetches the status page). Treat any non-error status as accepted.
+        return (int)postResponse.StatusCode < 400;
     }
 
     private CableModemStats ParseDocsisStatus(string html, CmPollContext context)

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -90,6 +90,13 @@ public class LanFlowMapService
 
         var anchors = ProjectAnchors(markers, deviceLocations,
             out var centerLat, out var centerLng, out var lngScale);
+        var droppedAnchors = PruneAnchorOutliers(anchors);
+        if (droppedAnchors.Count > 0)
+        {
+            _logger.LogDebug(
+                "LAN map: dropped {Count} outlier anchor(s) far outside the cluster (bad/stale placement): {Macs}",
+                droppedAnchors.Count, string.Join(", ", droppedAnchors));
+        }
         snapshot.Bounds = ComputeBounds(anchors, centerLat, centerLng, lngScale);
         snapshot.Buildings = await BuildBuildingsAsync(centerLat, centerLng, lngScale, ct);
         snapshot.MaterialColors = new Dictionary<string, string>(
@@ -839,6 +846,41 @@ public class LanFlowMapService
         }
 
         return anchors;
+    }
+
+    // A single anchor placed wildly far from the rest (bad geocode, a mis-drag, or a
+    // stale placement from a since-relocated device) inflates the scene radius and
+    // collapses the whole map: the shared node/building scale is driven by the
+    // farthest anchor, so one outlier 1+ km out shrinks real buildings to a speck and
+    // skews the camera centroid. Drop anchors that sit BOTH far beyond the cluster
+    // (> OutlierMedianFactor x the median anchor distance) AND past an absolute sanity
+    // range. Requiring both conditions means legitimately spread-out layouts
+    // (multi-building / campus) are never touched - only a lone runaway spike is. A
+    // dropped node loses its pin and simply floats with the force layout instead.
+    private const double OutlierMedianFactor = 6.0;
+    private const double OutlierAbsoluteMetres = 200.0;
+
+    private static List<string> PruneAnchorOutliers(Dictionary<string, LanPlacement> anchors)
+    {
+        var removed = new List<string>();
+        // Need enough anchors for a median to be meaningful; with 1-2 we can't tell
+        // which one is the outlier, so leave them alone.
+        if (anchors.Count < 3) return removed;
+
+        var distances = anchors.ToDictionary(
+            kv => kv.Key,
+            kv => Math.Sqrt(kv.Value.X * kv.Value.X + kv.Value.Y * kv.Value.Y));
+
+        var sorted = distances.Values.OrderBy(d => d).ToList();
+        var median = sorted[sorted.Count / 2];
+        var threshold = Math.Max(OutlierMedianFactor * median, OutlierAbsoluteMetres);
+
+        foreach (var mac in distances.Where(kv => kv.Value > threshold).Select(kv => kv.Key).ToList())
+        {
+            anchors.Remove(mac);
+            removed.Add(mac);
+        }
+        return removed;
     }
 
     private static LanFlowMapBounds ComputeBounds(

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -557,7 +557,10 @@ public class MonitoringInfluxClient : IAsyncDisposable
         string? ponLinkStatus,
         int? bwpSpeedMbps,
         int? sfpLinkSpeedMbps,
-        DateTime timestamp)
+        DateTime timestamp,
+        long? linkUptimeSeconds = null,
+        string? oltVendor = null,
+        string? oltModel = null)
     {
         if (!IsConfigured) return Task.CompletedTask;
         var point = PointData.Measurement("ont")
@@ -567,6 +570,8 @@ public class MonitoringInfluxClient : IAsyncDisposable
 
         if (!string.IsNullOrEmpty(ponType)) point = point.Tag("pon_type", ponType);
         if (!string.IsNullOrEmpty(wavelength)) point = point.Tag("wavelength", wavelength);
+        if (!string.IsNullOrEmpty(oltVendor)) point = point.Tag("olt_vendor", oltVendor);
+        if (!string.IsNullOrEmpty(oltModel)) point = point.Tag("olt_model", oltModel);
 
         if (rxPowerDbm.HasValue) point = point.Field("rx_power_dbm", rxPowerDbm.Value);
         if (txPowerDbm.HasValue) point = point.Field("tx_power_dbm", txPowerDbm.Value);
@@ -578,6 +583,7 @@ public class MonitoringInfluxClient : IAsyncDisposable
         if (!string.IsNullOrEmpty(ponLinkStatus)) point = point.Field("pon_link_status", ponLinkStatus);
         if (bwpSpeedMbps.HasValue) point = point.Field("bwp_speed_mbps", bwpSpeedMbps.Value);
         if (sfpLinkSpeedMbps.HasValue) point = point.Field("sfp_link_speed_mbps", sfpLinkSpeedMbps.Value);
+        if (linkUptimeSeconds.HasValue) point = point.Field("link_uptime_seconds", linkUptimeSeconds.Value);
 
         Enqueue(point, longterm: true);
         return Task.CompletedTask;

--- a/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
@@ -1,0 +1,455 @@
+using System.Net;
+using System.Net.NetworkInformation;
+using NetworkOptimizer.Core.Helpers;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services.Ssh;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Deploys "monitoring interfaces" to the UniFi gateway: a macvlan on the physical WAN
+/// port plus a host route and optional SNAT so the Network Optimizer server (a LAN
+/// client) and browsers can reach an ONT/modem management IP that sits behind the WAN.
+/// The boot script is self-contained and idempotent and installs a cron watchdog so it
+/// survives reboots and UniFi reprovisioning - the same model as Adaptive SQM and
+/// Performance Tweaks. All gateway access goes through <see cref="IGatewaySshService"/>.
+/// </summary>
+public class MonitoringInterfaceDeploymentService
+{
+    private readonly ILogger<MonitoringInterfaceDeploymentService> _logger;
+    private readonly IGatewaySshService _gatewaySsh;
+    private readonly IUdmBootService _udmBoot;
+    private readonly UniFiConnectionService _connection;
+
+    private const string OnBootDir = "/data/on_boot.d";
+
+    public MonitoringInterfaceDeploymentService(
+        ILogger<MonitoringInterfaceDeploymentService> logger,
+        IGatewaySshService gatewaySsh,
+        IUdmBootService udmBoot,
+        UniFiConnectionService connection)
+    {
+        _logger = logger;
+        _gatewaySsh = gatewaySsh;
+        _udmBoot = udmBoot;
+        _connection = connection;
+    }
+
+    private static string ScriptName(MonitoringInterface mi) => $"30-monitoring-iface-{mi.Name}.sh";
+    private static string ScriptPath(MonitoringInterface mi) => $"{OnBootDir}/{ScriptName(mi)}";
+
+    /// <summary>
+    /// Validate a monitoring interface configuration. Returns null when valid, otherwise
+    /// a human-readable reason. Also enforces shell-safety of interpolated values.
+    /// </summary>
+    public static string? Validate(MonitoringInterface mi)
+    {
+        if (string.IsNullOrWhiteSpace(mi.Name) ||
+            !System.Text.RegularExpressions.Regex.IsMatch(mi.Name, "^[a-z][a-z0-9-]{0,14}$"))
+            return "Interface name must be 1-15 chars, start with a letter, and use only lowercase letters, digits, or hyphens.";
+
+        if (string.IsNullOrWhiteSpace(mi.WanIfName) ||
+            !System.Text.RegularExpressions.Regex.IsMatch(mi.WanIfName, "^[a-zA-Z0-9._-]{1,20}$"))
+            return "Select a WAN interface.";
+
+        if (!IPAddress.TryParse(mi.TargetIp, out var target) || target.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
+            return "Modem/ONT IP must be a valid IPv4 address.";
+
+        if (!IPAddress.TryParse(mi.GatewayLocalIp, out var local) || local.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
+            return "Gateway-local IP must be a valid IPv4 address.";
+
+        if (mi.SubnetPrefix < 8 || mi.SubnetPrefix > 30)
+            return "Subnet prefix must be between /8 and /30.";
+
+        if (mi.TargetIp == mi.GatewayLocalIp)
+            return "Gateway-local IP must differ from the modem/ONT IP.";
+
+        var subnet = $"{mi.TargetIp}/{mi.SubnetPrefix}";
+        if (!NetworkUtilities.IsIpInSubnet(mi.GatewayLocalIp, NetworkAddress(subnet)))
+            return "Gateway-local IP must be on the same subnet as the modem/ONT IP.";
+
+        if (mi.WatchdogIntervalMinutes < 1 || mi.WatchdogIntervalMinutes > 60)
+            return "Watchdog interval must be between 1 and 60 minutes.";
+
+        return null;
+    }
+
+    /// <summary>Reason a deploy preflight blocked, or <see cref="None"/> when clear to deploy.</summary>
+    public enum PreflightBlock
+    {
+        None,
+        InvalidInput,
+        UniFiOverlap,
+        AlreadyReachable,
+        LocalIpInUse,
+        GatewayUnreachable,
+
+        /// <summary>The on-gateway duplicate-IP check could not run (arping unavailable).</summary>
+        Skipped
+    }
+
+    public record PreflightResult(bool Ok, PreflightBlock Block, string Message);
+
+    /// <summary>
+    /// Server-side preflight (no gateway changes): validates input, checks that the
+    /// target subnet does not overlap a UniFi-managed network/VLAN, and checks that the
+    /// target is not already reachable from the Network Optimizer server. The local-IP
+    /// availability gate runs on the gateway during <see cref="DeployAsync"/>.
+    /// </summary>
+    public async Task<PreflightResult> PreflightAsync(MonitoringInterface mi, CancellationToken ct = default)
+    {
+        var invalid = Validate(mi);
+        if (invalid != null)
+            return new PreflightResult(false, PreflightBlock.InvalidInput, invalid);
+
+        // Gate 1: overlap with a UniFi-managed network/VLAN. If the gateway already owns
+        // this address space, a dedicated monitoring route isn't possible.
+        try
+        {
+            var networks = await _connection.GetNetworksAsync(ct);
+            foreach (var net in networks)
+            {
+                if (net.IsWan || !net.Enabled || string.IsNullOrEmpty(net.IpSubnet))
+                    continue;
+
+                if (NetworkUtilities.IsIpInSubnet(mi.TargetIp, net.IpSubnet) ||
+                    NetworkUtilities.IsIpInSubnet(mi.GatewayLocalIp, net.IpSubnet))
+                {
+                    return new PreflightResult(false, PreflightBlock.UniFiOverlap,
+                        $"{mi.TargetIp} overlaps your \"{net.Name}\" network ({net.IpSubnet}). " +
+                        "Monitoring this device via a dedicated interface isn't possible - renumber the modem or that network.");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not load UniFi networks for overlap preflight; continuing");
+        }
+
+        // Gate 2: target already reachable from the server. Either monitoring already
+        // works (no plumbing needed) or it's a duplicate-IP collision we can't safely
+        // route to (the alternate-IP DNAT case is a documented TODO).
+        if (await IsReachableFromServerAsync(mi.TargetIp))
+        {
+            return new PreflightResult(false, PreflightBlock.AlreadyReachable,
+                $"{mi.TargetIp} is already reachable from the Network Optimizer server. " +
+                "If monitoring already works, no interface is needed. If a different device also uses this IP, " +
+                "alternate-IP routing isn't supported yet.");
+        }
+
+        return new PreflightResult(true, PreflightBlock.None, "Ready to deploy.");
+    }
+
+    public record DeployResult(bool Success, PreflightBlock Block, string Message, List<string> Steps);
+
+    /// <summary>
+    /// Deploy (or re-apply) a monitoring interface: runs the server-side preflight,
+    /// ensures udm-boot, performs the on-gateway local-IP availability gate, then writes
+    /// and runs the idempotent boot script (which installs the cron watchdog).
+    /// </summary>
+    public async Task<DeployResult> DeployAsync(MonitoringInterface mi, CancellationToken ct = default)
+    {
+        var steps = new List<string>();
+
+        var preflight = await PreflightAsync(mi, ct);
+        if (!preflight.Ok)
+            return new DeployResult(false, preflight.Block, preflight.Message, steps);
+        steps.Add("Preflight passed: no UniFi network overlap, target not already reachable.");
+
+        // Ensure udm-boot so the interface survives reboots and firmware updates.
+        if (!await _udmBoot.IsInstalledAsync())
+        {
+            steps.Add("Installing udm-boot (gateway boot persistence)...");
+            var (udmOk, udmMsg) = await _udmBoot.InstallAsync();
+            if (!udmOk)
+                return new DeployResult(false, PreflightBlock.GatewayUnreachable, $"udm-boot install failed: {udmMsg}", steps);
+            steps.Add("udm-boot installed.");
+        }
+
+        // Gate 3 (on-gateway): ensure the chosen gateway-local IP isn't already in use on
+        // the modem subnet. Bring up a bare macvlan and run duplicate-address detection.
+        var dupCheck = await CheckLocalIpAvailableAsync(mi);
+        if (dupCheck == PreflightBlock.LocalIpInUse)
+        {
+            await RunAsync($"ip link del {mi.Name} 2>/dev/null || true");
+            return new DeployResult(false, PreflightBlock.LocalIpInUse,
+                $"{mi.GatewayLocalIp} is already in use on the modem subnet. Pick a different gateway-local IP.", steps);
+        }
+        steps.Add(dupCheck == PreflightBlock.None
+            ? $"Gateway-local IP {mi.GatewayLocalIp} is free."
+            : "Skipped duplicate-IP check (arping unavailable).");
+
+        // Write and run the idempotent boot script.
+        var script = GenerateBootScript(mi);
+        var unix = script.Replace("\r\n", "\n").Replace("\r", "\n");
+        var b64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(unix));
+        var path = ScriptPath(mi);
+
+        var write = await RunAsync($"mkdir -p {OnBootDir} && echo '{b64}' | base64 -d > '{path}' && chmod +x '{path}'");
+        if (!write.success)
+            return new DeployResult(false, PreflightBlock.GatewayUnreachable, $"Failed to write boot script: {write.output}", steps);
+        steps.Add($"Wrote boot script {ScriptName(mi)}.");
+
+        var run = await RunAsync($"'{path}'", TimeSpan.FromSeconds(30));
+        if (!run.success)
+            return new DeployResult(false, PreflightBlock.GatewayUnreachable, $"Boot script run failed: {run.output}", steps);
+        steps.Add("Applied macvlan, route" + (mi.SnatEnabled ? ", SNAT" : "") + ", and cron watchdog.");
+
+        return new DeployResult(true, PreflightBlock.None,
+            $"Monitoring interface {mi.Name} deployed. {mi.TargetIp} is now reachable from the LAN.", steps);
+    }
+
+    /// <summary>
+    /// Remove a monitoring interface from the gateway: cron entry, SNAT rule, route,
+    /// address, macvlan link, and the boot script. Idempotent.
+    /// </summary>
+    public async Task<(bool success, List<string> steps)> RemoveAsync(MonitoringInterface mi)
+    {
+        var steps = new List<string>();
+        var path = ScriptPath(mi);
+
+        await RunAsync($"crontab -l 2>/dev/null | grep -vF '{path}' | crontab - 2>/dev/null || true");
+        steps.Add("Removed cron watchdog.");
+
+        if (mi.SnatEnabled)
+        {
+            await RunAsync($"iptables -t nat -D POSTROUTING -o {mi.Name} -d {mi.TargetIp} -j SNAT --to-source {mi.GatewayLocalIp} 2>/dev/null || true");
+            steps.Add("Removed SNAT rule.");
+        }
+
+        await RunAsync($"ip route del {mi.TargetIp}/32 dev {mi.Name} 2>/dev/null || true");
+        await RunAsync($"ip link del {mi.Name} 2>/dev/null || true");
+        steps.Add("Removed route and macvlan interface.");
+
+        await RunAsync($"rm -f '{path}' /tmp/netopt-moniface-{mi.Name}.log 2>/dev/null || true");
+        steps.Add("Removed boot script.");
+
+        return (true, steps);
+    }
+
+    /// <summary>Live status of a deployed monitoring interface on the gateway.</summary>
+    public class InterfaceStatus
+    {
+        public bool GatewayReachable { get; set; }
+        public bool UdmBootInstalled { get; set; }
+        public bool InterfaceExists { get; set; }
+        public bool LocalIpAssigned { get; set; }
+        public bool RoutePresent { get; set; }
+        public bool SnatPresent { get; set; }
+        public bool WatchdogCronPresent { get; set; }
+        public bool BootScriptPresent { get; set; }
+
+        /// <summary>True when every expected component for the given config is in place.</summary>
+        public bool IsFullyApplied(MonitoringInterface mi) =>
+            InterfaceExists && LocalIpAssigned && RoutePresent &&
+            (!mi.SnatEnabled || SnatPresent) && WatchdogCronPresent && BootScriptPresent;
+    }
+
+    /// <summary>
+    /// Check the live state of a monitoring interface using a single delimited SSH call.
+    /// </summary>
+    public async Task<InterfaceStatus> CheckStatusAsync(MonitoringInterface mi)
+    {
+        var status = new InterfaceStatus();
+        var path = ScriptPath(mi);
+
+        var combined =
+            "echo '---UDM_BOOT---'; test -f /etc/systemd/system/udm-boot.service && echo y || echo n; " +
+            $"echo '---IFACE---'; ip link show {mi.Name} >/dev/null 2>&1 && echo y || echo n; " +
+            $"echo '---LOCALIP---'; ip -4 addr show dev {mi.Name} 2>/dev/null | grep -q 'inet {mi.GatewayLocalIp}/{mi.SubnetPrefix}' && echo y || echo n; " +
+            $"echo '---ROUTE---'; ip route show {mi.TargetIp}/32 2>/dev/null | grep -q 'dev {mi.Name}' && echo y || echo n; " +
+            $"echo '---SNAT---'; iptables -t nat -C POSTROUTING -o {mi.Name} -d {mi.TargetIp} -j SNAT --to-source {mi.GatewayLocalIp} 2>/dev/null && echo y || echo n; " +
+            $"echo '---CRON---'; crontab -l 2>/dev/null | grep -qF '{path}' && echo y || echo n; " +
+            $"echo '---SCRIPT---'; test -f '{path}' && echo y || echo n";
+
+        var result = await RunAsync(combined);
+        status.GatewayReachable = result.success;
+        if (!result.success)
+            return status;
+
+        var s = ParseDelimited(result.output);
+        bool Yes(string k) => s.TryGetValue(k, out var v) && v.Trim() == "y";
+        status.UdmBootInstalled = Yes("UDM_BOOT");
+        status.InterfaceExists = Yes("IFACE");
+        status.LocalIpAssigned = Yes("LOCALIP");
+        status.RoutePresent = Yes("ROUTE");
+        status.SnatPresent = Yes("SNAT");
+        status.WatchdogCronPresent = Yes("CRON");
+        status.BootScriptPresent = Yes("SCRIPT");
+        return status;
+    }
+
+    /// <summary>
+    /// On-gateway check that the chosen gateway-local IP isn't already answering on the
+    /// modem's L2 segment. Brings up a bare macvlan and sends a plain ARP probe (sender
+    /// 0.0.0.0) for the candidate: a reply means the address is taken. We deliberately do
+    /// NOT use <c>arping -D</c> - on UniFi OS that mode errors on a bare interface and
+    /// returns a non-zero code even for free addresses (it would false-positive every
+    /// deploy). A reply line ("reply from") is the only reliable signal here.
+    /// Returns <see cref="PreflightBlock.LocalIpInUse"/> when taken,
+    /// <see cref="PreflightBlock.Skipped"/> when arping is unavailable, otherwise
+    /// <see cref="PreflightBlock.None"/> (free, or we couldn't create the probe interface -
+    /// in which case the boot script will surface any real failure).
+    /// </summary>
+    private async Task<PreflightBlock> CheckLocalIpAvailableAsync(MonitoringInterface mi)
+    {
+        // Create the macvlan (idempotent) and bring it up so arping can transmit on the
+        // modem segment. The boot script reuses this interface.
+        var probe =
+            $"ip link show {mi.Name} >/dev/null 2>&1 || ip link add {mi.Name} link {mi.WanIfName} type macvlan mode bridge; " +
+            $"ip link set {mi.Name} up 2>/dev/null; " +
+            $"if ! ip link show {mi.Name} >/dev/null 2>&1; then echo RESULT:NOIFACE; " +
+            $"elif ! command -v arping >/dev/null 2>&1; then echo RESULT:SKIP; " +
+            $"else out=$(arping -c 2 -w 2 -I {mi.Name} -S 0.0.0.0 {mi.GatewayLocalIp} 2>&1); " +
+            $"if echo \"$out\" | grep -qi 'reply from'; then echo RESULT:INUSE; else echo RESULT:FREE; fi; fi";
+
+        var result = await RunAsync(probe, TimeSpan.FromSeconds(15));
+        if (!result.success)
+            return PreflightBlock.None; // can't verify; let the apply proceed
+
+        if (result.output.Contains("RESULT:INUSE"))
+            return PreflightBlock.LocalIpInUse;
+        if (result.output.Contains("RESULT:SKIP"))
+            return PreflightBlock.Skipped;
+
+        // RESULT:FREE, RESULT:NOIFACE, or anything unexpected -> don't block; let the
+        // boot-script apply proceed and surface any genuine error.
+        return PreflightBlock.None;
+    }
+
+    private async Task<bool> IsReachableFromServerAsync(string ip)
+    {
+        try
+        {
+            using var ping = new Ping();
+            var reply = await ping.SendPingAsync(ip, 2000);
+            return reply.Status == IPStatus.Success;
+        }
+        catch
+        {
+            return false; // can't ping (e.g. sandboxed) -> treat as not reachable, allow deploy
+        }
+    }
+
+    /// <summary>
+    /// Builds the self-contained, idempotent boot script. Uses token replacement rather
+    /// than string interpolation so the shell's own <c>${...}</c> syntax stays readable.
+    /// </summary>
+    public static string GenerateBootScript(MonitoringInterface mi)
+    {
+        return BootScriptTemplate
+            .Replace("__IFACE__", mi.Name)
+            .Replace("__WAN_IF__", mi.WanIfName)
+            .Replace("__LOCAL_IP__", mi.GatewayLocalIp)
+            .Replace("__PREFIX__", mi.SubnetPrefix.ToString())
+            .Replace("__TARGET_IP__", mi.TargetIp)
+            .Replace("__SNAT_ENABLED__", mi.SnatEnabled ? "1" : "0")
+            .Replace("__WATCHDOG_MIN__", mi.WatchdogIntervalMinutes.ToString())
+            .Replace("__SCRIPT_PATH__", ScriptPath(mi));
+    }
+
+    private const string BootScriptTemplate = @"#!/bin/sh
+# Network Optimizer - Monitoring Interface
+# Idempotently provides LAN/gateway access to a modem/ONT management IP that sits behind
+# the WAN, via a macvlan on the physical WAN port with a gateway-local IP, a host route to
+# the device, and (optionally) a narrow SNAT for LAN clients. Self-installs a cron watchdog
+# so it survives reboots and UniFi reprovisioning.
+# Managed by Network Optimizer - manual edits are overwritten on redeploy.
+
+IFACE=""__IFACE__""
+WAN_IF=""__WAN_IF__""
+LOCAL_IP=""__LOCAL_IP__""
+PREFIX=""__PREFIX__""
+TARGET_IP=""__TARGET_IP__""
+SNAT_ENABLED=""__SNAT_ENABLED__""
+WATCHDOG_MIN=""__WATCHDOG_MIN__""
+SCRIPT=""__SCRIPT_PATH__""
+LOG=""/tmp/netopt-moniface-__IFACE__.log""
+
+log() { echo ""$(date '+%Y-%m-%d %H:%M:%S') $1"" >> ""$LOG"" 2>/dev/null; }
+
+# The physical WAN port must exist; if not (boot race), let the watchdog retry later.
+ip link show ""$WAN_IF"" >/dev/null 2>&1 || { log ""wan $WAN_IF absent, deferring""; exit 0; }
+
+changed=0
+
+# 1. macvlan on the physical WAN port
+if ! ip link show ""$IFACE"" >/dev/null 2>&1; then
+    ip link add ""$IFACE"" link ""$WAN_IF"" type macvlan mode bridge && changed=1
+fi
+ip link set ""$IFACE"" up 2>/dev/null
+
+# 2. gateway-local IP on the macvlan
+if ! ip -4 addr show dev ""$IFACE"" 2>/dev/null | grep -q ""inet $LOCAL_IP/$PREFIX""; then
+    ip addr flush dev ""$IFACE"" 2>/dev/null
+    ip addr add ""$LOCAL_IP/$PREFIX"" dev ""$IFACE"" && changed=1
+fi
+
+# 3. host route to the modem/ONT, sourced from the gateway-local IP
+if ! ip route show ""$TARGET_IP/32"" 2>/dev/null | grep -q ""dev $IFACE""; then
+    ip route replace ""$TARGET_IP/32"" dev ""$IFACE"" src ""$LOCAL_IP"" && changed=1
+fi
+
+# 4. narrow SNAT so LAN clients reach the modem via the gateway-local IP
+if [ ""$SNAT_ENABLED"" = ""1"" ]; then
+    if ! iptables -t nat -C POSTROUTING -o ""$IFACE"" -d ""$TARGET_IP"" -j SNAT --to-source ""$LOCAL_IP"" 2>/dev/null; then
+        iptables -t nat -A POSTROUTING -o ""$IFACE"" -d ""$TARGET_IP"" -j SNAT --to-source ""$LOCAL_IP"" && changed=1
+    fi
+fi
+
+# 5. self-install the cron watchdog (re-applies after reprovision)
+if ! crontab -l 2>/dev/null | grep -qF ""$SCRIPT""; then
+    (crontab -l 2>/dev/null; echo ""*/$WATCHDOG_MIN * * * * $SCRIPT >/dev/null 2>&1"") | crontab -
+    changed=1
+fi
+
+# Log only when something actually changed, to spare the eMMC.
+[ ""$changed"" = ""1"" ] && log ""applied $IFACE on $WAN_IF: $LOCAL_IP/$PREFIX -> $TARGET_IP (snat=$SNAT_ENABLED)""
+exit 0
+";
+
+    // ─── helpers ───
+
+    private Task<(bool success, string output)> RunAsync(string command, TimeSpan? timeout = null)
+        => _gatewaySsh.RunCommandAsync(command, timeout);
+
+    /// <summary>Network (zero-host) address for a CIDR, e.g. "192.168.100.1/24" -> "192.168.100.0/24".</summary>
+    private static string NetworkAddress(string cidr)
+    {
+        var (addr, prefix) = NetworkUtilities.ParseCidr(cidr);
+        if (addr == null) return cidr;
+        var bytes = addr.GetAddressBytes();
+        var bits = prefix;
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            if (bits >= 8) { bits -= 8; continue; }
+            var mask = bits > 0 ? (byte)(0xFF << (8 - bits)) : (byte)0;
+            bytes[i] &= mask;
+            bits = 0;
+        }
+        return $"{new IPAddress(bytes)}/{prefix}";
+    }
+
+    private static Dictionary<string, string> ParseDelimited(string output)
+    {
+        var sections = new Dictionary<string, string>();
+        string? key = null;
+        var value = new List<string>();
+        foreach (var line in output.Split('\n'))
+        {
+            var t = line.Trim();
+            if (t.StartsWith("---") && t.EndsWith("---") && t.Length > 6)
+            {
+                if (key != null) sections[key] = string.Join("\n", value);
+                key = t.Trim('-');
+                value.Clear();
+            }
+            else if (key != null)
+            {
+                value.Add(line);
+            }
+        }
+        if (key != null) sections[key] = string.Join("\n", value);
+        return sections;
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
@@ -44,18 +44,27 @@ public class MonitoringInterfaceDeploymentService
     /// </summary>
     public static string? Validate(MonitoringInterface mi)
     {
+        // \A...\z anchors (not ^...$): in .NET, $ also matches just before a trailing
+        // newline, so "eth6\n" would pass and split the interpolated SSH command line.
         if (string.IsNullOrWhiteSpace(mi.Name) ||
-            !System.Text.RegularExpressions.Regex.IsMatch(mi.Name, "^[a-z][a-z0-9-]{0,14}$"))
+            !System.Text.RegularExpressions.Regex.IsMatch(mi.Name, @"\A[a-z][a-z0-9-]{0,14}\z"))
             return "Interface name must be 1-15 chars, start with a letter, and use only lowercase letters, digits, or hyphens.";
 
         if (string.IsNullOrWhiteSpace(mi.WanIfName) ||
-            !System.Text.RegularExpressions.Regex.IsMatch(mi.WanIfName, "^[a-zA-Z0-9._-]{1,20}$"))
+            !System.Text.RegularExpressions.Regex.IsMatch(mi.WanIfName, @"\A[a-zA-Z0-9._-]{1,20}\z"))
             return "Select a WAN interface.";
 
-        if (!IPAddress.TryParse(mi.TargetIp, out var target) || target.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
+        if (mi.WanVlanId is int vlan && (vlan < 1 || vlan > 4094))
+            return "VLAN ID must be between 1 and 4094.";
+
+        // Require dotted-quad: IPAddress.TryParse accepts shorthand ("192.168.100" ->
+        // 192.168.0.100), which would deploy a route/macvlan to the wrong address.
+        if ((mi.TargetIp ?? "").Split('.').Length != 4 ||
+            !IPAddress.TryParse(mi.TargetIp, out var target) || target.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
             return "Modem/ONT IP must be a valid IPv4 address.";
 
-        if (!IPAddress.TryParse(mi.GatewayLocalIp, out var local) || local.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
+        if ((mi.GatewayLocalIp ?? "").Split('.').Length != 4 ||
+            !IPAddress.TryParse(mi.GatewayLocalIp, out var local) || local.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
             return "Gateway-local IP must be a valid IPv4 address.";
 
         if (mi.SubnetPrefix < 8 || mi.SubnetPrefix > 30)
@@ -294,9 +303,16 @@ public class MonitoringInterfaceDeploymentService
     private async Task<PreflightBlock> CheckLocalIpAvailableAsync(MonitoringInterface mi)
     {
         // Create the macvlan (idempotent) and bring it up so arping can transmit on the
-        // modem segment. The boot script reuses this interface.
+        // modem segment. The boot script reuses this interface. On a VLAN WAN, the parent
+        // is the VLAN subinterface, which we ensure exists first (same as the boot script).
+        var parent = ParentInterface(mi);
+        var ensureVlan = mi.WanVlanId is int vlan
+            ? $"ip link show {parent} >/dev/null 2>&1 || ip link add link {mi.WanIfName} name {parent} type vlan id {vlan}; " +
+              $"ip link set {parent} up 2>/dev/null; "
+            : "";
         var probe =
-            $"ip link show {mi.Name} >/dev/null 2>&1 || ip link add {mi.Name} link {mi.WanIfName} type macvlan mode bridge; " +
+            ensureVlan +
+            $"ip link show {mi.Name} >/dev/null 2>&1 || ip link add {mi.Name} link {parent} type macvlan mode bridge; " +
             $"ip link set {mi.Name} up 2>/dev/null; " +
             $"if ! ip link show {mi.Name} >/dev/null 2>&1; then echo RESULT:NOIFACE; " +
             $"elif ! command -v arping >/dev/null 2>&1; then echo RESULT:SKIP; " +
@@ -340,6 +356,7 @@ public class MonitoringInterfaceDeploymentService
         return BootScriptTemplate
             .Replace("__IFACE__", mi.Name)
             .Replace("__WAN_IF__", mi.WanIfName)
+            .Replace("__VLAN_ID__", mi.WanVlanId?.ToString() ?? "")
             .Replace("__LOCAL_IP__", mi.GatewayLocalIp)
             .Replace("__PREFIX__", mi.SubnetPrefix.ToString())
             .Replace("__TARGET_IP__", mi.TargetIp)
@@ -358,6 +375,7 @@ public class MonitoringInterfaceDeploymentService
 
 IFACE=""__IFACE__""
 WAN_IF=""__WAN_IF__""
+VLAN_ID=""__VLAN_ID__""
 LOCAL_IP=""__LOCAL_IP__""
 PREFIX=""__PREFIX__""
 TARGET_IP=""__TARGET_IP__""
@@ -373,9 +391,21 @@ ip link show ""$WAN_IF"" >/dev/null 2>&1 || { log ""wan $WAN_IF absent, deferrin
 
 changed=0
 
-# 1. macvlan on the physical WAN port
+# 0. resolve the macvlan parent. With a VLAN, the parent is the subinterface (e.g.
+# eth6.100) so frames are tagged; UniFi creates it for a VLAN WAN, but if it's absent
+# we add it ourselves. We never tear it down on removal - reprovision reaps it.
+PARENT=""$WAN_IF""
+if [ -n ""$VLAN_ID"" ]; then
+    PARENT=""$WAN_IF.$VLAN_ID""
+    if ! ip link show ""$PARENT"" >/dev/null 2>&1; then
+        ip link add link ""$WAN_IF"" name ""$PARENT"" type vlan id ""$VLAN_ID"" && changed=1
+    fi
+    ip link set ""$PARENT"" up 2>/dev/null
+fi
+
+# 1. macvlan on the WAN parent (physical port, or VLAN subinterface)
 if ! ip link show ""$IFACE"" >/dev/null 2>&1; then
-    ip link add ""$IFACE"" link ""$WAN_IF"" type macvlan mode bridge && changed=1
+    ip link add ""$IFACE"" link ""$PARENT"" type macvlan mode bridge && changed=1
 fi
 ip link set ""$IFACE"" up 2>/dev/null
 
@@ -404,7 +434,7 @@ if ! crontab -l 2>/dev/null | grep -qF ""$SCRIPT""; then
 fi
 
 # Log only when something actually changed, to spare the eMMC.
-[ ""$changed"" = ""1"" ] && log ""applied $IFACE on $WAN_IF: $LOCAL_IP/$PREFIX -> $TARGET_IP (snat=$SNAT_ENABLED)""
+[ ""$changed"" = ""1"" ] && log ""applied $IFACE on $PARENT: $LOCAL_IP/$PREFIX -> $TARGET_IP (snat=$SNAT_ENABLED)""
 exit 0
 ";
 
@@ -412,6 +442,13 @@ exit 0
 
     private Task<(bool success, string output)> RunAsync(string command, TimeSpan? timeout = null)
         => _gatewaySsh.RunCommandAsync(command, timeout);
+
+    /// <summary>
+    /// The macvlan's parent interface: the VLAN subinterface (e.g. "eth6.100") when a
+    /// VLAN is configured, otherwise the bare physical WAN port.
+    /// </summary>
+    private static string ParentInterface(MonitoringInterface mi)
+        => mi.WanVlanId is int vlan ? $"{mi.WanIfName}.{vlan}" : mi.WanIfName;
 
     /// <summary>Network (zero-host) address for a CIDR, e.g. "192.168.100.1/24" -> "192.168.100.0/24".</summary>
     private static string NetworkAddress(string cidr)

--- a/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
@@ -260,7 +260,10 @@ public class OntMonitorService : IDisposable
                 ponLinkStatus: stats.PonLinkStatus != PonLinkState.Unknown ? stats.PonLinkStatus.ToInfluxValue() : null,
                 bwpSpeedMbps: stats.BwpSpeedMbps,
                 sfpLinkSpeedMbps: stats.SfpLinkSpeedMbps,
-                timestamp: stats.Timestamp);
+                timestamp: stats.Timestamp,
+                linkUptimeSeconds: stats.LinkUptimeSeconds,
+                oltVendor: stats.OltVendor,
+                oltModel: stats.OltModel);
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Services/OntProviders/QuantumQ1000kOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/QuantumQ1000kOntProvider.cs
@@ -1,0 +1,380 @@
+using System.Globalization;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Monitoring.Providers;
+
+namespace NetworkOptimizer.Web.Services.OntProviders;
+
+/// <summary>
+/// ONT provider for the Quantum Fiber Q1000K SmartNID (CenturyLink/Quantum Fiber GPON).
+/// The device exposes a React web UI backed by a CGI JSON API. Authentication is a
+/// form POST to /cgi/cgi_action which returns a Session-Id cookie; data is then read
+/// from /cgi/cgi_get?Object=... endpoints that return TR-181-style parameter objects.
+///
+/// The Device.Optical.Interface.1 object exposes full DDM optics (Rx/Tx power,
+/// temperature, voltage, bias current), link status, PON line rate, and BIP error
+/// counts, alongside device identity from Device.DeviceInfo.
+/// </summary>
+public sealed class QuantumQ1000kOntProvider : IOntProvider
+{
+    public string ProviderKey => "quantum-q1000k";
+    public string DisplayName => "Quantum Fiber Q1000K (HTTP)";
+
+    private const int TimeoutSeconds = 15;
+    private const string LoginPath = "/cgi/cgi_action";
+    private const string ConnectionStatusPath = "/cgi/cgi_get?Object=GetConnectionStatus";
+    private const string DeviceInfoPath =
+        "/cgi/cgi_get?Object=Device.DeviceInfo&SoftwareVersion=&ModelName=&HardwareVersion=&SerialNumber=";
+    private const string OpticalPath = "/cgi/cgi_get?Object=Device.Optical.Interface.1";
+
+    private readonly ILogger<QuantumQ1000kOntProvider> _logger;
+
+    public QuantumQ1000kOntProvider(ILogger<QuantumQ1000kOntProvider> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<OntStats?> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+        {
+            _logger.LogWarning("Quantum Q1000K ONT poll requested but Host is empty (config {Id})", context.Id);
+            return null;
+        }
+
+        try
+        {
+            var (baseUrl, client, handler) = await ResolveBaseUrlAsync(context, cancellationToken);
+            using var _ = handler;
+            using var __ = client;
+
+            if (!await LoginAsync(client, baseUrl, context, cancellationToken))
+            {
+                _logger.LogWarning("Quantum Q1000K ONT {Name}: login failed", context.Name);
+                return null;
+            }
+
+            var stats = new OntStats
+            {
+                Timestamp = DateTime.UtcNow,
+                DeviceHost = context.Host,
+                DeviceName = context.Name,
+                DeviceModel = "Quantum Q1000K",
+            };
+
+            var connectionJson = await client.GetStringAsync($"{baseUrl}{ConnectionStatusPath}", cancellationToken);
+            ApplyConnectionStatus(connectionJson, stats);
+
+            var deviceInfoJson = await client.GetStringAsync($"{baseUrl}{DeviceInfoPath}", cancellationToken);
+            ApplyDeviceInfo(deviceInfoJson, stats);
+
+            var opticalJson = await client.GetStringAsync($"{baseUrl}{OpticalPath}", cancellationToken);
+            ApplyOpticalInterface(opticalJson, stats);
+
+            _logger.LogDebug(
+                "Quantum Q1000K ONT {Name} polled: Rx={Rx} dBm, Tx={Tx} dBm, Temp={Temp} C, Link={Link}, {PonType}",
+                context.Name, stats.RxPowerDbm?.ToString("F2") ?? "-",
+                stats.TxPowerDbm?.ToString("F2") ?? "-",
+                stats.TemperatureC?.ToString("F0") ?? "-",
+                stats.LinkState ?? "-", stats.PonType ?? "-");
+
+            return stats;
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error polling Quantum Q1000K ONT {Name} at {Host}", context.Name, context.Host);
+            return null;
+        }
+    }
+
+    public async Task<(bool Success, string Message)> TestConnectionAsync(
+        OntPollContext context, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+            return (false, "Host is empty");
+
+        try
+        {
+            var (baseUrl, client, handler) = await ResolveBaseUrlAsync(context, cancellationToken);
+            using var _ = handler;
+            using var __ = client;
+
+            if (!await LoginAsync(client, baseUrl, context, cancellationToken))
+                return (false, "Login failed - check username/password (the admin password is printed on the device)");
+
+            var deviceInfoJson = await client.GetStringAsync($"{baseUrl}{DeviceInfoPath}", cancellationToken);
+            if (!deviceInfoJson.Contains("ModelName", StringComparison.OrdinalIgnoreCase))
+                return (false, "Connected but response does not contain expected device info fields");
+
+            var stats = new OntStats { DeviceModel = "Quantum Q1000K" };
+            ApplyDeviceInfo(deviceInfoJson, stats);
+
+            var opticalJson = await client.GetStringAsync($"{baseUrl}{OpticalPath}", cancellationToken);
+            ApplyOpticalInterface(opticalJson, stats);
+
+            var scheme = baseUrl.StartsWith("https") ? "HTTPS" : "HTTP";
+            var rx = stats.RxPowerDbm.HasValue ? $", RX: {stats.RxPowerDbm.Value:F2} dBm" : "";
+            return (true, $"Connected ({scheme}) - {stats.DeviceModel}{rx}");
+        }
+        catch (HttpRequestException ex) when (ex.Message.Contains("SSL", StringComparison.OrdinalIgnoreCase))
+        {
+            return (false, $"SSL connection failed: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Connection failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Form login: POST username/password to /cgi/cgi_action as a raw text/plain body,
+    /// replicating exactly what the device's React UI sends (content type included) since
+    /// that is the only request form we have confirmed yields a session. The device replies
+    /// with a Session-Id cookie stored by the CookieContainer. Unauthenticated /cgi/cgi_get
+    /// reads are rejected (HTTP 444), so we confirm success by probing GetConnectionStatus
+    /// and checking for the wan_status payload.
+    /// </summary>
+    private async Task<bool> LoginAsync(
+        HttpClient client, string baseUrl, OntPollContext context, CancellationToken ct)
+    {
+        var username = context.Username ?? "admin";
+        var password = context.Password ?? "";
+
+        var body = $"username={username}&password={password}";
+        using var content = new StringContent(body, Encoding.UTF8, "text/plain");
+
+        try { using var login = await client.PostAsync($"{baseUrl}{LoginPath}", content, ct); }
+        catch (HttpRequestException) { return false; }
+
+        try
+        {
+            var probe = await client.GetStringAsync($"{baseUrl}{ConnectionStatusPath}", ct);
+            return probe.Contains("wan_status", StringComparison.OrdinalIgnoreCase);
+        }
+        catch (HttpRequestException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Parses GetConnectionStatus: {"wan_status":{"link_state":"connected","net_state":"bridged",
+    /// "uplink_rate":"1244000","downlink_rate":"2488000",...}}. Rates are in kbps. Sets the link
+    /// health (Up/Down) and derives the PON type from the downstream line rate.
+    /// </summary>
+    internal static void ApplyConnectionStatus(string json, OntStats stats)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object
+                || !doc.RootElement.TryGetProperty("wan_status", out var wan))
+                return;
+
+            if (wan.TryGetProperty("link_state", out var linkEl))
+            {
+                var connected = string.Equals(linkEl.GetString(), "connected", StringComparison.OrdinalIgnoreCase);
+                stats.OperationalStatus = connected ? "Up" : "Down";
+                stats.LinkState = connected ? "Up" : "Down";
+            }
+
+            var downlinkKbps = ParseLong(GetStringProp(wan, "downlink_rate"));
+            if (downlinkKbps.HasValue)
+                stats.PonType = downlinkKbps.Value >= 9_000_000 ? "XGS-PON" : "GPON";
+        }
+        catch (JsonException) { }
+    }
+
+    /// <summary>
+    /// Parses Device.DeviceInfo parameters (ModelName, SerialNumber, SoftwareVersion).
+    /// ModelName drives the displayed model/part number; SerialNumber maps to the SN field.
+    /// </summary>
+    internal static void ApplyDeviceInfo(string json, OntStats stats)
+    {
+        var p = ParseParamObject(json);
+
+        if (p.TryGetValue("ModelName", out var model) && !string.IsNullOrWhiteSpace(model))
+        {
+            stats.DeviceModel = $"Quantum {model}";
+            stats.VendorPn = model;
+        }
+
+        if (p.TryGetValue("SerialNumber", out var serial) && !string.IsNullOrWhiteSpace(serial))
+            stats.VendorSn = serial;
+    }
+
+    /// <summary>
+    /// Parses the full Device.Optical.Interface.1 object (and its Stats sub-object).
+    /// DDM optics power/voltage/bias are reported in milli-units (0.001 dBm, mV, µA);
+    /// temperature is whole degrees Celsius. The standard TR-181 Status field
+    /// ("Up"/"Down") drives link health, with the X_AXON_LineStatus (GOOD/BAD) flag as
+    /// a fallback. The downstream line rate (Mbps) confirms the PON variant.
+    /// </summary>
+    internal static void ApplyOpticalInterface(string json, OntStats stats)
+    {
+        var p = ParseParamObject(json);
+
+        stats.RxPowerDbm = ParseMilli(GetValue(p, "OpticalSignalLevel")) ?? stats.RxPowerDbm;
+        stats.TxPowerDbm = ParseMilli(GetValue(p, "TransmitOpticalLevel")) ?? stats.TxPowerDbm;
+        stats.VoltageV = ParseMilli(GetValue(p, "X_CTL_Voltage")) ?? stats.VoltageV;
+        stats.BiasMa = ParseMilli(GetValue(p, "X_CTL_BiasCurrent")) ?? stats.BiasMa;
+
+        if (ParseDouble(GetValue(p, "X_CTL_Temperature")) is { } temp)
+            stats.TemperatureC = temp;
+
+        if (ParseLong(GetValue(p, "X_CTL_BIPErrorsReceived")) is { } bip)
+            stats.BipErrors = bip;
+
+        var status = GetValue(p, "Status");
+        if (!string.IsNullOrWhiteSpace(status))
+        {
+            stats.LinkState = status;
+            stats.OperationalStatus = status;
+        }
+        else if (p.TryGetValue("X_AXON_LineStatus", out var line) && !string.IsNullOrWhiteSpace(line))
+        {
+            var good = string.Equals(line, "GOOD", StringComparison.OrdinalIgnoreCase);
+            stats.LinkState ??= good ? "Up" : "Down";
+            stats.OperationalStatus ??= good ? "Up" : "Down";
+        }
+
+        if (ParseLong(GetValue(p, "X_AXON_DownstreamRate")) is { } downMbps)
+            stats.PonType = downMbps >= 9000 ? "XGS-PON" : "GPON";
+
+        stats.LinkUptimeSeconds = ParseLong(GetValue(p, "X_AXON_LinkUpTime")) ?? stats.LinkUptimeSeconds;
+
+        var oltVendor = GetValue(p, "X_CTL_OLTVendor");
+        if (!string.IsNullOrWhiteSpace(oltVendor)) stats.OltVendor = oltVendor;
+
+        var oltModel = GetValue(p, "X_CTL_OLTModel");
+        if (!string.IsNullOrWhiteSpace(oltModel)) stats.OltModel = oltModel;
+    }
+
+    /// <summary>
+    /// Flattens the TR-181-style response {"Objects":[{"Param":[{"ParamName":..,"ParamValue":..}]}]}
+    /// into a single name/value dictionary, merging the parameters of every object in the
+    /// array (the optical endpoint splits its data across Interface.1 and Interface.1.Stats).
+    /// </summary>
+    private static Dictionary<string, string> ParseParamObject(string json)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object
+                || !doc.RootElement.TryGetProperty("Objects", out var objects)
+                || objects.ValueKind != JsonValueKind.Array)
+                return result;
+
+            foreach (var obj in objects.EnumerateArray())
+            {
+                if (!obj.TryGetProperty("Param", out var pars) || pars.ValueKind != JsonValueKind.Array)
+                    continue;
+
+                foreach (var par in pars.EnumerateArray())
+                {
+                    var name = GetStringProp(par, "ParamName");
+                    var value = GetStringProp(par, "ParamValue");
+                    if (!string.IsNullOrEmpty(name) && value != null)
+                        result[name] = value;
+                }
+            }
+        }
+        catch (JsonException) { }
+
+        return result;
+    }
+
+    private static string? GetStringProp(JsonElement element, string name) =>
+        element.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.String
+            ? prop.GetString()
+            : null;
+
+    private static string? GetValue(Dictionary<string, string> p, string key) =>
+        p.TryGetValue(key, out var v) ? v : null;
+
+    private static long? ParseLong(string? text) =>
+        long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var val) ? val : null;
+
+    private static double? ParseDouble(string? text) =>
+        double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out var val) ? val : null;
+
+    /// <summary>Parses an integer reported in milli-units (0.001) into its base unit.</summary>
+    private static double? ParseMilli(string? text) =>
+        ParseLong(text) is { } v ? v / 1000.0 : null;
+
+    /// <summary>
+    /// Tries the port-based scheme first (HTTPS for 443, HTTP for 80), then falls back to the
+    /// opposite scheme. All HTTPS uses self-signed cert bypass since these are local devices.
+    /// </summary>
+    private async Task<(string BaseUrl, HttpClient Client, HttpClientHandler Handler)> ResolveBaseUrlAsync(
+        OntPollContext context, CancellationToken ct)
+    {
+        var port = context.Port > 0 ? context.Port : 443;
+        var primaryScheme = port == 80 ? "http" : "https";
+        var fallbackScheme = primaryScheme == "https" ? "http" : "https";
+
+        var primaryUrl = BuildBaseUrl(context.Host, port, primaryScheme);
+        var (handler, client) = CreateHttpClient();
+
+        try
+        {
+            using var response = await client.GetAsync($"{primaryUrl}/", ct);
+            return (primaryUrl, client, handler);
+        }
+        catch (HttpRequestException ex) when (
+            ex.InnerException is System.Security.Authentication.AuthenticationException
+            || ex.Message.Contains("SSL", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogDebug("{Scheme} failed with SSL error for {Host}, trying {Fallback}",
+                primaryScheme.ToUpperInvariant(), context.Host, fallbackScheme.ToUpperInvariant());
+        }
+        catch (HttpRequestException)
+        {
+            _logger.LogDebug("{Scheme} connection failed for {Host}, trying {Fallback}",
+                primaryScheme.ToUpperInvariant(), context.Host, fallbackScheme.ToUpperInvariant());
+        }
+
+        client.Dispose();
+        handler.Dispose();
+
+        var fallbackUrl = BuildBaseUrl(context.Host, port, fallbackScheme);
+        var (handler2, client2) = CreateHttpClient();
+
+        try
+        {
+            using var probe = await client2.GetAsync($"{fallbackUrl}/", ct);
+            _logger.LogInformation("Quantum Q1000K ONT {Host} reachable via {Scheme}",
+                context.Host, fallbackScheme.ToUpperInvariant());
+            return (fallbackUrl, client2, handler2);
+        }
+        catch
+        {
+            client2.Dispose();
+            handler2.Dispose();
+            throw;
+        }
+    }
+
+    private static (HttpClientHandler Handler, HttpClient Client) CreateHttpClient()
+    {
+        var handler = new HttpClientHandler
+        {
+            CookieContainer = new CookieContainer(),
+            UseCookies = true,
+            ServerCertificateCustomValidationCallback = (_, _, _, _) => true,
+        };
+        var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(TimeoutSeconds) };
+        return (handler, client);
+    }
+
+    private static string BuildBaseUrl(string host, int port, string scheme)
+    {
+        var portSuffix = (scheme == "http" && port == 80) || (scheme == "https" && port == 443)
+            ? "" : $":{port}";
+        return $"{scheme}://{host}{portSuffix}";
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
@@ -69,6 +69,8 @@ public class PerfTweaksDeploymentService
         {
             var combinedCommand =
                 // UDM boot
+                // TODO: use IUdmBootService.IsInstalledAsync() instead of this inline check
+                // (shared gateway boot infrastructure - NetworkOptimizer.Web.Services.Ssh.UdmBootService).
                 "echo '---UDM_BOOT_CHECK---'; test -f /etc/systemd/system/udm-boot.service && echo 'installed' || echo 'missing'; " +
                 "echo '---UDM_BOOT_ENABLED---'; systemctl is-enabled udm-boot 2>/dev/null || echo 'disabled'; " +
                 // Gateway model and firmware
@@ -748,6 +750,10 @@ public class PerfTweaksDeploymentService
         }
     }
 
+    // TODO: depend on IUdmBootService directly instead of routing udm-boot install through
+    // SqmDeploymentService. udm-boot is shared gateway boot infrastructure (see
+    // NetworkOptimizer.Web.Services.Ssh.UdmBootService); this delegation chain
+    // (PerfTweaks -> SQM -> UdmBootService) is incidental coupling.
     public async Task<(bool success, string message)> InstallUdmBootAsync()
     {
         return await _sqmDeployment.InstallUdmBootAsync();

--- a/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
@@ -15,6 +15,7 @@ public class SqmDeploymentService : ISqmDeploymentService
 {
     private readonly ILogger<SqmDeploymentService> _logger;
     private readonly IGatewaySshService _gatewaySsh;
+    private readonly IUdmBootService _udmBoot;
     private readonly IServiceProvider _serviceProvider;
 
     // Gateway paths
@@ -24,10 +25,12 @@ public class SqmDeploymentService : ISqmDeploymentService
     public SqmDeploymentService(
         ILogger<SqmDeploymentService> logger,
         IGatewaySshService gatewaySsh,
+        IUdmBootService udmBoot,
         IServiceProvider serviceProvider)
     {
         _logger = logger;
         _gatewaySsh = gatewaySsh;
+        _udmBoot = udmBoot;
         _serviceProvider = serviceProvider;
     }
 
@@ -54,64 +57,8 @@ public class SqmDeploymentService : ISqmDeploymentService
     /// This enables scripts in /data/on_boot.d/ to run automatically on boot
     /// and persist across firmware updates.
     /// </summary>
-    public async Task<(bool success, string message)> InstallUdmBootAsync()
-    {
-        var settings = await GetGatewaySettingsAsync();
-
-        try
-        {
-            _logger.LogInformation("Installing udm-boot on gateway {Host}", settings.Host);
-
-            // Create the udm-boot service file directly (works on all UDM/UCG devices)
-            // This matches the upstream unifios-utilities version exactly
-            // Note: In C# verbatim strings, "" produces a single ". The bash escape pattern '"'"'
-            // (end single quote, double-quoted single quote, resume single quote) is written as '""'""'
-            var serviceContent = @"[Unit]
-Description=Run On Startup UDM 2.x and above
-Wants=network-online.target
-After=network-online.target
-StartLimitIntervalSec=500
-StartLimitBurst=1
-
-[Service]
-Type=oneshot
-ExecStart=bash -c 'mkdir -p /data/on_boot.d && find -L /data/on_boot.d -mindepth 1 -maxdepth 1 -type f -print0 | sort -z | xargs -0 -r -n 1 -- sh -c '""'""'if test -x ""$0""; then echo ""%n: running $0""; ""$0""; else case ""$0"" in *.sh) echo ""%n: sourcing $0""; . ""$0"";; *) echo ""%n: ignoring $0"";; esac; fi'""'""''
-RemainAfterExit=true
-
-[Install]
-WantedBy=multi-user.target
-";
-
-            // Use base64 encoding to avoid all shell quoting issues when transferring via SSH
-            var base64Content = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(serviceContent));
-
-            // Write service file via base64 decode, enable and start
-            // Use --no-block so we don't wait for boot scripts to finish (they can take a while)
-            var installCmd = $"echo {base64Content} | base64 -d > /etc/systemd/system/udm-boot.service && " +
-                "mkdir -p /data/on_boot.d && " +
-                "systemctl daemon-reload && " +
-                "systemctl enable udm-boot && " +
-                "systemctl start --no-block udm-boot && " +
-                "echo udm-boot_installed_successfully";
-            var result = await RunCommandAsync(installCmd);
-
-            if (result.success && result.output.Contains("udm-boot_installed_successfully"))
-            {
-                _logger.LogInformation("udm-boot installed successfully on {Host}", settings.Host);
-                return (true, "udm-boot installed successfully. Scripts in /data/on_boot.d/ will now run on boot.");
-            }
-            else
-            {
-                _logger.LogError("udm-boot installation failed: {Output}", result.output);
-                return (false, $"Installation failed: {result.output}");
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to install udm-boot");
-            return (false, $"Error: {ex.Message}");
-        }
-    }
+    public Task<(bool success, string message)> InstallUdmBootAsync()
+        => _udmBoot.InstallAsync();
 
     /// <summary>
     /// Parse SSH output delimited by ---KEY--- markers into a dictionary.
@@ -167,6 +114,9 @@ WantedBy=multi-user.target
         try
         {
             // Run all status checks in a single SSH connection using delimiters
+            // TODO: use IUdmBootService.IsInstalledAsync() for the udm-boot check instead of
+            // this inline test (shared gateway boot infrastructure -
+            // NetworkOptimizer.Web.Services.Ssh.UdmBootService).
             var combinedCommand =
                 "echo '---UDM_BOOT_CHECK---'; test -f /etc/systemd/system/udm-boot.service && echo 'installed' || echo 'missing'; " +
                 "echo '---UDM_BOOT_ENABLED---'; systemctl is-enabled udm-boot 2>/dev/null || echo 'disabled'; " +

--- a/src/NetworkOptimizer.Web/Services/SqmService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmService.cs
@@ -338,19 +338,30 @@ public class SqmService : ISqmService
                 _logger.LogDebug("Examining gateway-capable device: type={DeviceType}, model={Model}, name={Name}",
                     deviceType, deviceModel2, deviceName ?? "(unnamed)");
 
-                // Build port_idx -> speed lookup from port_table (for WAN link speed capping)
+                // Build port_idx -> speed and port_idx -> label lookups from port_table
+                // (speed for WAN link speed capping, label for the WAN display name).
                 var portIdxToSpeed = new Dictionary<int, int>();
+                var portIdxToName = new Dictionary<int, string>();
                 if (device.TryGetProperty("port_table", out var portTable) &&
                     portTable.ValueKind == System.Text.Json.JsonValueKind.Array)
                 {
                     foreach (var port in portTable.EnumerateArray())
                     {
-                        var isUp = port.TryGetProperty("up", out var upProp) && upProp.GetBoolean();
                         var portIdx = port.TryGetProperty("port_idx", out var idxProp) && idxProp.TryGetInt32(out var idx) ? idx : -1;
+                        if (portIdx < 0)
+                            continue;
+
+                        var isUp = port.TryGetProperty("up", out var upProp) && upProp.GetBoolean();
                         var speed = port.TryGetProperty("speed", out var speedProp) && speedProp.TryGetInt32(out var spd) ? spd : 0;
-                        if (isUp && portIdx >= 0 && speed > 0)
+                        if (isUp && speed > 0)
                         {
                             portIdxToSpeed[portIdx] = speed;
+                        }
+
+                        var portName = port.TryGetProperty("name", out var portNameProp) ? portNameProp.GetString() : null;
+                        if (!string.IsNullOrEmpty(portName))
+                        {
+                            portIdxToName[portIdx] = portName;
                         }
                     }
                 }
@@ -463,6 +474,13 @@ public class SqmService : ISqmService
                             }
                         }
 
+                        // Physical WAN port index/label (port_table). Used by consumers that
+                        // must attach to the physical port, e.g. a monitoring-interface macvlan.
+                        int? wanPortIdxValue = wanObj.TryGetProperty("port_idx", out var wanPortIdxProp) &&
+                            wanPortIdxProp.TryGetInt32(out var pidx) ? pidx : null;
+                        string? portLabel = wanPortIdxValue.HasValue &&
+                            portIdxToName.TryGetValue(wanPortIdxValue.Value, out var pLabel) ? pLabel : null;
+
                         // TC monitor uses "ifb" + interface name format
                         var tcInterface = $"ifb{uplinkIfname}";
 
@@ -514,7 +532,11 @@ public class SqmService : ISqmService
                             SuggestedPingIp = suggestedPingIp,
                             SmartqEnabled = smartqEnabled,
                             SmartqDownRateMbps = smartqDownRateMbps,
-                            LinkSpeedMbps = linkSpeedMbps
+                            LinkSpeedMbps = linkSpeedMbps,
+                            WanIndex = i,
+                            PhysicalIfName = physicalIfname,
+                            PortIdx = wanPortIdxValue,
+                            PortLabel = portLabel
                         });
 
                         _logger.LogDebug("Accepted {WanKey}: interface={Interface}, name={Name}, networkGroup={NG}, smartQ={SQ}, wanType={WT}",
@@ -779,6 +801,23 @@ public class WanInterfaceInfo
 
     /// <summary>WAN network group identifier from UniFi (e.g., "WAN", "WAN2")</summary>
     public string? NetworkGroup { get; set; }
+
+    /// <summary>1-based WAN index from the device wan{i} key (1 for wan1, 2 for wan2, ...).</summary>
+    public int WanIndex { get; set; }
+
+    /// <summary>
+    /// Physical port backing this WAN (e.g., "eth6"), from the WAN object's ifname.
+    /// Differs from <see cref="Interface"/> on PPPoE/VLAN WANs where Interface is the
+    /// logical uplink (ppp3, eth6.100). Consumers that must attach to the physical port
+    /// (e.g. a monitoring-interface macvlan) use this. Null for virtual WANs (GRE).
+    /// </summary>
+    public string? PhysicalIfName { get; set; }
+
+    /// <summary>port_table index of the physical WAN port, when known.</summary>
+    public int? PortIdx { get; set; }
+
+    /// <summary>Front-panel port label from port_table (e.g., "Port 7"), when known.</summary>
+    public string? PortLabel { get; set; }
 
     /// <summary>Whether UniFi Smart Queues (SQM) is enabled for this WAN in the controller</summary>
     public bool SmartqEnabled { get; set; }

--- a/src/NetworkOptimizer.Web/Services/Ssh/UdmBootService.cs
+++ b/src/NetworkOptimizer.Web/Services/Ssh/UdmBootService.cs
@@ -1,0 +1,97 @@
+namespace NetworkOptimizer.Web.Services.Ssh;
+
+/// <summary>
+/// Installs and checks the generic udm-boot mechanism on a UniFi gateway: a systemd
+/// oneshot unit that runs every executable script in <c>/data/on_boot.d</c> at boot and
+/// persists across firmware updates. This is shared gateway infrastructure used by any
+/// feature that deploys self-contained boot scripts (Adaptive SQM, Monitoring
+/// Interfaces, etc.) - it is NOT specific to any one feature.
+/// </summary>
+public interface IUdmBootService
+{
+    /// <summary>Returns true when the udm-boot systemd unit is present on the gateway.</summary>
+    Task<bool> IsInstalledAsync();
+
+    /// <summary>
+    /// Install the udm-boot systemd unit (idempotent), enabling scripts in
+    /// /data/on_boot.d/ to run on boot.
+    /// </summary>
+    Task<(bool success, string message)> InstallAsync();
+}
+
+/// <inheritdoc />
+public class UdmBootService : IUdmBootService
+{
+    private readonly ILogger<UdmBootService> _logger;
+    private readonly IGatewaySshService _gatewaySsh;
+
+    public UdmBootService(ILogger<UdmBootService> logger, IGatewaySshService gatewaySsh)
+    {
+        _logger = logger;
+        _gatewaySsh = gatewaySsh;
+    }
+
+    public async Task<bool> IsInstalledAsync()
+    {
+        var result = await _gatewaySsh.RunCommandAsync(
+            "test -f /etc/systemd/system/udm-boot.service && echo 'installed' || echo 'missing'");
+        return result.success && result.output.Contains("installed");
+    }
+
+    public async Task<(bool success, string message)> InstallAsync()
+    {
+        var settings = await _gatewaySsh.GetSettingsAsync();
+
+        try
+        {
+            _logger.LogInformation("Installing udm-boot on gateway {Host}", settings.Host);
+
+            // Create the udm-boot service file directly (works on all UDM/UCG devices).
+            // This matches the upstream unifios-utilities version exactly.
+            // Note: In C# verbatim strings, "" produces a single ". The bash escape pattern '"'"'
+            // (end single quote, double-quoted single quote, resume single quote) is written as '""'""'
+            var serviceContent = @"[Unit]
+Description=Run On Startup UDM 2.x and above
+Wants=network-online.target
+After=network-online.target
+StartLimitIntervalSec=500
+StartLimitBurst=1
+
+[Service]
+Type=oneshot
+ExecStart=bash -c 'mkdir -p /data/on_boot.d && find -L /data/on_boot.d -mindepth 1 -maxdepth 1 -type f -print0 | sort -z | xargs -0 -r -n 1 -- sh -c '""'""'if test -x ""$0""; then echo ""%n: running $0""; ""$0""; else case ""$0"" in *.sh) echo ""%n: sourcing $0""; . ""$0"";; *) echo ""%n: ignoring $0"";; esac; fi'""'""''
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target
+";
+
+            // Use base64 encoding to avoid all shell quoting issues when transferring via SSH
+            var base64Content = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(serviceContent));
+
+            // Write service file via base64 decode, enable and start.
+            // Use --no-block so we don't wait for boot scripts to finish (they can take a while).
+            var installCmd = $"echo {base64Content} | base64 -d > /etc/systemd/system/udm-boot.service && " +
+                "mkdir -p /data/on_boot.d && " +
+                "systemctl daemon-reload && " +
+                "systemctl enable udm-boot && " +
+                "systemctl start --no-block udm-boot && " +
+                "echo udm-boot_installed_successfully";
+            var result = await _gatewaySsh.RunCommandAsync(installCmd);
+
+            if (result.success && result.output.Contains("udm-boot_installed_successfully"))
+            {
+                _logger.LogInformation("udm-boot installed successfully on {Host}", settings.Host);
+                return (true, "udm-boot installed successfully. Scripts in /data/on_boot.d/ will now run on boot.");
+            }
+
+            _logger.LogError("udm-boot installation failed: {Output}", result.output);
+            return (false, $"Installation failed: {result.output}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to install udm-boot");
+            return (false, $"Error: {ex.Message}");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/WanSteerDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/WanSteerDeploymentService.cs
@@ -46,6 +46,9 @@ public class WanSteerDeploymentService
 
         try
         {
+            // TODO: use IUdmBootService.IsInstalledAsync() for the udm-boot check instead of
+            // this inline test (shared gateway boot infrastructure -
+            // NetworkOptimizer.Web.Services.Ssh.UdmBootService).
             var combinedCommand =
                 "echo '---UDM_BOOT---'; test -f /etc/systemd/system/udm-boot.service && echo 'installed' || echo 'missing'; " +
                 "echo '---UDM_BOOT_ENABLED---'; systemctl is-enabled udm-boot 2>/dev/null || echo 'disabled'; " +

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14177,6 +14177,64 @@ a.affected-client:hover {
     color: var(--text-muted, #666);
 }
 
+.stat-filter-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.25rem 0.6rem;
+    border-radius: var(--border-radius-lg);
+    border: 1px solid transparent;
+    transition: border-color 0.15s;
+    white-space: nowrap;
+}
+
+td[data-stat-id] {
+    cursor: pointer;
+}
+
+td[data-stat-id]:hover .stat-filter-badge {
+    border-color: rgba(255, 255, 255, 0.5);
+}
+
+th[data-sort-col] {
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+}
+
+th[data-sort-col]:hover {
+    color: var(--text-primary);
+}
+
+th.stats-sort-active {
+    color: var(--primary-color);
+}
+
+tr.stats-row-filtered {
+    opacity: 0.35;
+}
+
+[class$="-stats-table"] .table-responsive {
+    scrollbar-color: var(--bg-tertiary) transparent;
+}
+
+[class$="-stats-table"] .table-responsive::-webkit-scrollbar {
+    height: 10px;
+}
+
+[class$="-stats-table"] .table-responsive::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+[class$="-stats-table"] .table-responsive::-webkit-scrollbar-thumb {
+    background: var(--bg-tertiary);
+    border-radius: 3px;
+}
+
+[class$="-stats-table"] .table-responsive::-webkit-scrollbar-thumb:hover {
+    background: var(--text-muted);
+}
+
 .wan-badge-dot {
     width: 10px;
     height: 10px;

--- a/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
@@ -2,10 +2,12 @@
 // Same control pattern as sfp-charts.js and device-health-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=2';
 
 const PALETTE = window.Apex?.colors || ['#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7'];
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
+
 const POLL_INTERVALS = { 0: 10000, 1: 10000, 6: 15000, 24: 30000, 168: 60000, 720: 60000 };
 const RANGE_MS = { 0: 15*60000, 1: 3600000, 6: 6*3600000, 24: 86400000, 168: 7*86400000, 720: 30*86400000 };
 
@@ -25,6 +27,7 @@ let modemMeta = [];
 let visibility = {};
 let visibilityObserver = null;
 let isInViewport = true;
+let lastData = null;
 
 function baseOpts(height, yTitle, yFormatter, extra) {
     return {
@@ -32,7 +35,7 @@ function baseOpts(height, yTitle, yFormatter, extra) {
             type: 'area', height,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            zoom: { enabled: !matchMedia('(pointer:coarse)').matches, type: 'x', allowMouseWheelZoom: false },
             events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },
@@ -122,6 +125,7 @@ function renderBadges(container) {
             }
             updateVisibility();
             renderBadges(container);
+            renderStatsTable(container, false);
         });
     }
 }
@@ -179,8 +183,47 @@ async function loadAndUpdate() {
     if (qualityChart) qualityChart.updateSeries(qualitySeries, false);
 
     updateVisibility();
+    lastData = data;
     const container = document.getElementById(containerId);
-    if (container) renderBadges(container);
+    if (container) {
+        renderBadges(container);
+        renderStatsTable(container);
+    }
+}
+
+const fmtDbm = v => v != null ? v.toFixed(2) : '-';
+const fmtDb = v => v != null ? v.toFixed(2) : '-';
+const fmtPct = v => v != null ? v.toFixed(0) + '%' : '-';
+
+function renderStatsTable(container, showAll) {
+    const el = container.querySelector('.cellular-stats-table');
+    if (!el || !lastData?.modems?.length) { if (el) el.innerHTML = ''; return; }
+
+    const rows = lastData.modems.map(m => {
+        const pts = m.data || [];
+        const rsrp = computeStats(pts.map(p => p.rsrp).filter(v => v != null));
+        const rsrq = computeStats(pts.map(p => p.rsrq).filter(v => v != null));
+        const snr = computeStats(pts.map(p => p.snr).filter(v => v != null));
+        const quality = computeStats(pts.map(p => p.quality).filter(v => v != null));
+        const meta = modemMeta.find(mm => mm.id === m.id);
+        return { id: m.id, label: m.label, color: meta?.color || '#9ca3af',
+            visible: meta && visibility[meta.id] !== false,
+            values: [rsrp?.mean, rsrp?.min, rsrp?.max, rsrq?.mean, rsrq?.min, rsrq?.max,
+                snr?.mean, snr?.min, snr?.max, quality?.mean, quality?.min, quality?.max] };
+    });
+
+    renderTable(el, container, {
+        nameHeader: 'Modem', rows, showAllRows: showAll,
+        columns: [
+            { header: 'RSRP Mean', format: fmtDbm }, { header: 'RSRP Min', format: fmtDbm }, { header: 'RSRP Max', format: fmtDbm },
+            { header: 'RSRQ Mean', format: fmtDb }, { header: 'RSRQ Min', format: fmtDb }, { header: 'RSRQ Max', format: fmtDb },
+            { header: 'SNR Mean', format: fmtDb }, { header: 'SNR Min', format: fmtDb }, { header: 'SNR Max', format: fmtDb },
+            { header: 'Qual Mean', format: fmtPct }, { header: 'Qual Min', format: fmtPct }, { header: 'Qual Max', format: fmtPct },
+        ],
+        filter: { meta: () => modemMeta, key: 'id', visibility: () => visibility,
+            resetVisibility: () => { visibility = {}; },
+            onChanged: (c) => { updateVisibility(); renderBadges(c); renderStatsTable(c, true); } },
+    });
 }
 
 function isVisible() { return isInViewport; }
@@ -423,7 +466,7 @@ export function soloModem(modemId) {
     modemMeta.forEach(m => { visibility[m.id] = m.id === modemId || m.id.startsWith(modemId + ':'); });
     updateVisibility();
     const container = document.getElementById(containerId);
-    if (container) renderBadges(container);
+    if (container) { renderBadges(container); renderStatsTable(container, false); }
 }
 
 export function unmount() {
@@ -437,6 +480,7 @@ export function unmount() {
     containerId = null;
     modemMeta = [];
     visibility = {};
+    lastData = null;
     currentRangeHours = 24;
     windowOffset = 0;
     isCustomRange = false;

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-stats.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-stats.js
@@ -1,0 +1,126 @@
+const _esc = document.createElement('span');
+function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
+
+export function percentile(sorted, p) {
+    if (sorted.length === 0) return null;
+    const idx = (p / 100) * (sorted.length - 1);
+    const lo = Math.floor(idx);
+    const hi = Math.ceil(idx);
+    if (lo === hi) return sorted[lo];
+    return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+}
+
+export function computeStats(values) {
+    if (!values || values.length === 0) return null;
+    const sorted = [...values].sort((a, b) => a - b);
+    return {
+        mean: values.reduce((s, v) => s + v, 0) / values.length,
+        min: sorted[0],
+        max: sorted[sorted.length - 1],
+        p95: percentile(sorted, 95),
+        p99: percentile(sorted, 99),
+    };
+}
+
+export function renderStatsTable(el, container, opts) {
+    if (!el) return;
+    const { nameHeader = 'Name', rows, columns, filter } = opts;
+
+    if (!rows || rows.length === 0) { el.innerHTML = ''; return; }
+
+    if (opts.showAllRows !== undefined) el._showAllRows = opts.showAllRows;
+    const display = (el._showAllRows ?? false) ? rows : rows.filter(r => r.visible !== false);
+    if (display.length === 0) { el.innerHTML = ''; return; }
+
+    const sortCol = el._sortCol ?? -1;
+    const sortDir = el._sortDir ?? 'asc';
+    const sorted = [...display];
+    if (sortCol >= 0 && sortCol < columns.length) {
+        sorted.sort((a, b) => {
+            const av = a.values[sortCol], bv = b.values[sortCol];
+            if (av == null && bv == null) return 0;
+            if (av == null) return 1;
+            if (bv == null) return -1;
+            return sortDir === 'asc' ? av - bv : bv - av;
+        });
+    }
+
+    const prev = el.querySelector('.table-responsive');
+    const scrollLeft = prev ? prev.scrollLeft : 0;
+
+    const headers = columns.map((col, i) => {
+        const active = i === sortCol;
+        const arrow = active ? (sortDir === 'asc' ? ' ▲' : ' ▼') : '';
+        return `<th data-sort-col="${i}"${active ? ' class="stats-sort-active"' : ''}>${col.header}${arrow}</th>`;
+    }).join('');
+
+    const rowsHtml = sorted.map(r => {
+        const filtered = r.visible === false;
+        const cls = filtered ? ' class="stats-row-filtered"' : '';
+        const cells = r.values.map((v, i) => `<td>${filtered ? '-' : columns[i].format(v)}</td>`).join('');
+        return `<tr${cls}>
+            <td data-stat-id="${r.id}"><span class="stat-filter-badge"><span class="wan-badge-dot" style="background-color:${r.color}"></span>${escapeHtml(r.label)}</span></td>
+            ${cells}
+        </tr>`;
+    }).join('');
+
+    el.innerHTML = `<div class="chart-card" style="margin-top:1rem">
+        <div class="chart-header"><h3 class="chart-title">Statistics</h3></div>
+        <div class="table-responsive">
+        <table class="data-table" style="font-size:0.8125rem">
+            <thead><tr>
+                <th>${nameHeader}</th>
+                ${headers}
+            </tr></thead>
+            <tbody>${rowsHtml}</tbody>
+        </table>
+        </div>
+    </div>`;
+
+    const next = el.querySelector('.table-responsive');
+    if (next && scrollLeft) next.scrollLeft = scrollLeft;
+
+    el._lastRenderOpts = opts;
+
+    if (!el._sortDelegated) {
+        el._sortDelegated = true;
+        el.addEventListener('click', (e) => {
+            const th = e.target.closest('th[data-sort-col]');
+            if (!th) return;
+            const col = parseInt(th.dataset.sortCol);
+            if (el._sortCol === col) {
+                if (el._sortDir === 'asc') { el._sortDir = 'desc'; }
+                else { el._sortCol = -1; el._sortDir = 'asc'; }
+            } else {
+                el._sortCol = col;
+                el._sortDir = 'asc';
+            }
+            if (el._lastRenderOpts) renderStatsTable(el, container, el._lastRenderOpts);
+        });
+    }
+
+    if (filter && !el._filterDelegated) {
+        el._filterDelegated = true;
+        el.addEventListener('click', (e) => {
+            if (e.target.closest('th[data-sort-col]')) return;
+            const td = e.target.closest('[data-stat-id]');
+            if (!td) return;
+            const id = td.dataset.statId;
+            const meta = filter.meta();
+            const key = filter.key;
+            const vis = filter.visibility();
+
+            if (e.ctrlKey || e.metaKey) {
+                vis[id] = vis[id] === false ? undefined : false;
+            } else {
+                const allVis = meta.every(m => vis[m[key]] !== false);
+                const onlyThis = vis[id] !== false
+                    && meta.filter(m => m[key] !== id).every(m => vis[m[key]] === false);
+                if (onlyThis) { filter.resetVisibility(); }
+                else if (allVis) { meta.forEach(m => { vis[m[key]] = m[key] === id; }); }
+                else { vis[id] = vis[id] === false; }
+            }
+            filter.onChanged(container);
+        });
+    }
+}

--- a/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
@@ -2,10 +2,12 @@
 // Same control pattern as cellular-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=2';
 
 const PALETTE = window.Apex?.colors || ['#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7'];
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
+
 const POLL_INTERVALS = { 0: 10000, 1: 10000, 6: 15000, 24: 30000, 168: 60000, 720: 60000 };
 const RANGE_MS = { 0: 15*60000, 1: 3600000, 6: 6*3600000, 24: 86400000, 168: 7*86400000, 720: 30*86400000 };
 
@@ -25,6 +27,7 @@ let deviceMeta = [];
 let visibility = {};
 let visibilityObserver = null;
 let isInViewport = true;
+let lastData = null;
 
 function baseOpts(height, yTitle, yFormatter, extra) {
     const base = {
@@ -32,7 +35,7 @@ function baseOpts(height, yTitle, yFormatter, extra) {
             type: 'area', height,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            zoom: { enabled: !matchMedia('(pointer:coarse)').matches, type: 'x', allowMouseWheelZoom: false },
             events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },
@@ -131,6 +134,7 @@ function renderBadges(container) {
             }
             updateVisibility();
             renderBadges(container);
+            renderStatsTable(container, false);
         });
     }
 }
@@ -209,8 +213,49 @@ async function loadAndUpdate() {
     if (errorsChart) errorsChart.updateSeries(errorsSeries, false);
 
     updateVisibility();
+    lastData = data;
     const container = document.getElementById(containerId);
-    if (container) renderBadges(container);
+    if (container) {
+        renderBadges(container);
+        renderStatsTable(container);
+    }
+}
+
+const fmtDbmv = v => v != null ? v.toFixed(2) : '-';
+const fmtDb = v => v != null ? v.toFixed(2) : '-';
+const fmtInt = v => v != null ? Math.round(v).toString() : '-';
+
+function renderStatsTable(container, showAll) {
+    const el = container.querySelector('.cm-stats-table');
+    if (!el || !lastData?.devices?.length) { if (el) el.innerHTML = ''; return; }
+
+    const rows = lastData.devices.map(d => {
+        const pts = d.data || [];
+        const dsPower = computeStats(pts.map(p => p.dsPower).filter(v => v != null));
+        const dsSnr = computeStats(pts.map(p => p.dsSnr).filter(v => v != null));
+        const usPower = computeStats(pts.map(p => p.usPower).filter(v => v != null));
+        const uncorr = computeStats(pts.map(p => p.uncorrDelta).filter(v => v != null));
+        const corr = computeStats(pts.map(p => p.corrDelta).filter(v => v != null));
+        const meta = deviceMeta.find(dm => dm.id === d.id);
+        return { id: d.id, label: d.label, color: meta?.color || '#9ca3af',
+            visible: meta && visibility[meta.id] !== false,
+            values: [dsPower?.mean, dsPower?.min, dsPower?.max, dsSnr?.mean, dsSnr?.min, dsSnr?.max,
+                usPower?.mean, usPower?.min, usPower?.max, uncorr?.mean, uncorr?.max, corr?.mean, corr?.max] };
+    });
+
+    renderTable(el, container, {
+        nameHeader: 'Device', rows, showAllRows: showAll,
+        columns: [
+            { header: 'DS Pwr Mean', format: fmtDbmv }, { header: 'DS Pwr Min', format: fmtDbmv }, { header: 'DS Pwr Max', format: fmtDbmv },
+            { header: 'DS SNR Mean', format: fmtDb }, { header: 'DS SNR Min', format: fmtDb }, { header: 'DS SNR Max', format: fmtDb },
+            { header: 'US Pwr Mean', format: fmtDbmv }, { header: 'US Pwr Min', format: fmtDbmv }, { header: 'US Pwr Max', format: fmtDbmv },
+            { header: 'Uncorr Mean', format: fmtInt }, { header: 'Uncorr Max', format: fmtInt },
+            { header: 'Corr Mean', format: fmtInt }, { header: 'Corr Max', format: fmtInt },
+        ],
+        filter: { meta: () => deviceMeta, key: 'id', visibility: () => visibility,
+            resetVisibility: () => { visibility = {}; },
+            onChanged: (c) => { updateVisibility(); renderBadges(c); renderStatsTable(c, true); } },
+    });
 }
 
 function isVisible() { return isInViewport; }
@@ -451,7 +496,7 @@ export function soloDevice(deviceId) {
     deviceMeta.forEach(m => { visibility[m.id] = m.id === deviceId; });
     updateVisibility();
     const container = document.getElementById(containerId);
-    if (container) renderBadges(container);
+    if (container) { renderBadges(container); renderStatsTable(container, false); }
 }
 
 export function unmount() {
@@ -465,6 +510,7 @@ export function unmount() {
     containerId = null;
     deviceMeta = [];
     visibility = {};
+    lastData = null;
     currentRangeHours = 24;
     windowOffset = 0;
     isCustomRange = false;

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -2,6 +2,7 @@
 // filter badges, poll interval scaling) into a shared module so latency-charts,
 // device-health-charts, and future chart sets share one implementation.
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=2';
 
 const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
 const _colorCache = {};
@@ -21,6 +22,7 @@ function hashColor(id) {
 }
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
+
 const POLL_INTERVALS = { 0: 5000, 1: 5000, 6: 10000, 24: 15000, 168: 30000, 720: 30000 };
 const RANGE_MS = { 0: 15*60000, 1: 3600000, 6: 6*3600000, 24: 86400000, 168: 7*86400000, 720: 30*86400000 };
 
@@ -39,6 +41,7 @@ let deviceMeta = [];
 let visibility = {};
 let visibilityObserver = null;
 let isInViewport = true;
+let lastData = null;
 
 function baseOpts(height, yTitle, yFormatter, extra) {
     return {
@@ -46,7 +49,7 @@ function baseOpts(height, yTitle, yFormatter, extra) {
             type: 'line', height,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            zoom: { enabled: !matchMedia('(pointer:coarse)').matches, type: 'x', allowMouseWheelZoom: false },
             events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },
@@ -134,6 +137,7 @@ function renderBadges(container) {
             }
             updateVisibility();
             renderBadges(container);
+            renderStatsTable(container, false);
         });
     }
 }
@@ -166,8 +170,42 @@ async function loadAndUpdate() {
     if (cpuChart) cpuChart.updateSeries(makeSeries('cpu'), false);
     if (memChart) memChart.updateSeries(makeSeries('mem'), false);
     updateVisibility();
+    lastData = data;
     const container = document.getElementById(containerId);
-    if (container) renderBadges(container);
+    if (container) {
+        renderBadges(container);
+        renderStatsTable(container);
+    }
+}
+
+const fmtTemp = v => v != null ? v.toFixed(1) : '-';
+const fmtPct = v => v != null ? v.toFixed(1) + '%' : '-';
+
+function renderStatsTable(container, showAll) {
+    const el = container.querySelector('.health-stats-table');
+    if (!el || !lastData?.devices?.length) { if (el) el.innerHTML = ''; return; }
+
+    const rows = lastData.devices.map(d => {
+        const pts = d.data || [];
+        const temp = computeStats(pts.map(p => p.temp).filter(v => v != null));
+        const cpu = computeStats(pts.map(p => p.cpu).filter(v => v != null));
+        const mem = computeStats(pts.map(p => p.mem).filter(v => v != null));
+        return { id: d.mac, label: d.name, color: hashColor(d.name),
+            visible: deviceMeta.some(dm => dm.mac === d.mac) && visibility[d.mac] !== false,
+            values: [temp?.mean, temp?.min, temp?.max, cpu?.mean, cpu?.min, cpu?.max, mem?.mean, mem?.min, mem?.max] };
+    });
+
+    renderTable(el, container, {
+        nameHeader: 'Device', rows, showAllRows: showAll,
+        columns: [
+            { header: 'Temp Mean', format: fmtTemp }, { header: 'Temp Min', format: fmtTemp }, { header: 'Temp Max', format: fmtTemp },
+            { header: 'CPU Mean', format: fmtPct }, { header: 'CPU Min', format: fmtPct }, { header: 'CPU Max', format: fmtPct },
+            { header: 'Mem Mean', format: fmtPct }, { header: 'Mem Min', format: fmtPct }, { header: 'Mem Max', format: fmtPct },
+        ],
+        filter: { meta: () => deviceMeta, key: 'mac', visibility: () => visibility,
+            resetVisibility: () => { visibility = {}; },
+            onChanged: (c) => { updateVisibility(); renderBadges(c); renderStatsTable(c, true); } },
+    });
 }
 
 function isVisible() { return isInViewport; }
@@ -393,7 +431,7 @@ export function soloDevice(mac) {
     deviceMeta.forEach(d => { visibility[d.mac] = d.mac === mac; });
     updateVisibility();
     const container = document.getElementById(containerId);
-    if (container) renderBadges(container);
+    if (container) { renderBadges(container); renderStatsTable(container, false); }
 }
 
 export function unmount() {
@@ -406,6 +444,7 @@ export function unmount() {
     containerId = null;
     deviceMeta = [];
     visibility = {};
+    lastData = null;
     currentRangeHours = 1;
     windowOffset = 0;
     isCustomRange = false;

--- a/src/NetworkOptimizer.Web/wwwroot/js/isp-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/isp-health-charts.js
@@ -20,7 +20,7 @@ function buildOpts() {
             height: 280,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            zoom: { enabled: !matchMedia('(pointer:coarse)').matches, type: 'x', allowMouseWheelZoom: false },
             parentHeightOffset: 0,
             animations: { enabled: false },
             events: {

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -5,6 +5,7 @@
 // device-health-charts, and future chart sets share one implementation.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=2';
 
 const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
 const _colorCache = {};
@@ -53,7 +54,7 @@ function baseChartOpts(type, yTitle, yFormatter, extraOpts) {
             height: type === 'area' ? 200 : 260,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            zoom: { enabled: !matchMedia('(pointer:coarse)').matches, type: 'x', allowMouseWheelZoom: false },
             events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },
@@ -202,7 +203,7 @@ function renderBadges(container) {
 
             updateChartVisibility();
             renderBadges(container);
-            if (lastFetchData) renderStatsTable(container, lastFetchData);
+            if (lastFetchData) renderStatsTable(container, false);
         });
     }
 }
@@ -253,7 +254,7 @@ async function loadAndUpdate() {
     const container = document.getElementById(containerId);
     if (container) {
         renderBadges(container);
-        renderStatsTable(container, data);
+        renderStatsTable(container);
     }
 
     // WAN rate chart - show for non-Fabric categories
@@ -278,26 +279,6 @@ async function loadAndUpdate() {
     }
 }
 
-function percentile(sorted, p) {
-    if (sorted.length === 0) return null;
-    const idx = (p / 100) * (sorted.length - 1);
-    const lo = Math.floor(idx);
-    const hi = Math.ceil(idx);
-    if (lo === hi) return sorted[lo];
-    return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
-}
-
-function computeStats(values) {
-    if (!values || values.length === 0) return null;
-    const sorted = [...values].sort((a, b) => a - b);
-    return {
-        mean: values.reduce((s, v) => s + v, 0) / values.length,
-        min: sorted[0],
-        max: sorted[sorted.length - 1],
-        p95: percentile(sorted, 95),
-        p99: percentile(sorted, 99),
-    };
-}
 
 function fmtRtt(v) { return v != null ? v.toFixed(3) : '-'; }
 function fmtLossColored(v, redAt, orangeAt, yellowAt, lightAt, subtleAt, decimals) {
@@ -313,44 +294,33 @@ function fmtLossColored(v, redAt, orangeAt, yellowAt, lightAt, subtleAt, decimal
 function fmtLossMean(v) { return fmtLossColored(v, 1, 0.2, 0.05, 0.005, 0.0005, 3); }
 function fmtLossMax(v) { return fmtLossColored(v, 5, 2, 0.5, 0.005, 0.005, 2); }
 
-function renderStatsTable(container, data) {
+function renderStatsTable(container, showAll) {
     const el = container.querySelector('.latency-stats-table');
+    const data = lastFetchData;
     if (!el || !data?.targets?.length) { if (el) el.innerHTML = ''; return; }
 
-    const visibleTargets = data.targets.filter((t, i) => {
-        const meta = targetMeta[i];
-        return meta && visibility[meta.id] !== false;
-    });
-
-    if (visibleTargets.length === 0) { el.innerHTML = ''; return; }
-
-    const rows = visibleTargets.map((t, i) => {
+    const rows = data.targets.map(t => {
         const rttVals = (t.rtt || []).map(p => p.value).filter(v => v != null && v > 0);
         const lossVals = (t.loss || []).map(p => p.value).filter(v => v != null);
         const rtt = computeStats(rttVals);
         const loss = computeStats(lossVals);
         const meta = targetMeta.find(m => m.id === t.targetId);
-        const color = meta?.color || '#9ca3af';
-        return `<tr>
-            <td><span class="wan-badge-dot" style="background-color:${color};display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:6px"></span>${escapeHtml(t.name)}</td>
-            <td>${fmtRtt(rtt?.mean)}</td><td>${fmtRtt(rtt?.min)}</td><td>${fmtRtt(rtt?.max)}</td><td>${fmtRtt(rtt?.p95)}</td><td>${fmtRtt(rtt?.p99)}</td>
-            <td>${fmtLossMean(loss?.mean)}</td><td>${fmtLossMax(loss?.max)}</td>
-        </tr>`;
+        return { id: t.targetId, label: t.name, color: meta?.color || '#9ca3af',
+            visible: meta && visibility[meta.id] !== false,
+            values: [rtt?.mean, rtt?.min, rtt?.max, rtt?.p95, rtt?.p99, loss?.mean, loss?.max] };
     });
 
-    el.innerHTML = `<div class="chart-card" style="margin-top:1rem">
-        <div class="chart-header"><h3 class="chart-title">Statistics</h3></div>
-        <div class="table-responsive">
-        <table class="data-table" style="font-size:0.8125rem">
-            <thead><tr>
-                <th>Target</th>
-                <th>RTT Mean</th><th>Min</th><th>Max</th><th>P95</th><th>P99</th>
-                <th>Loss Mean</th><th>Loss Max</th>
-            </tr></thead>
-            <tbody>${rows.join('')}</tbody>
-        </table>
-        </div>
-    </div>`;
+    renderTable(el, container, {
+        nameHeader: 'Target', rows, showAllRows: showAll,
+        columns: [
+            { header: 'RTT Mean', format: fmtRtt }, { header: 'Min', format: fmtRtt }, { header: 'Max', format: fmtRtt },
+            { header: 'P95', format: fmtRtt }, { header: 'P99', format: fmtRtt },
+            { header: 'Loss Mean', format: fmtLossMean }, { header: 'Loss Max', format: fmtLossMax },
+        ],
+        filter: { meta: () => targetMeta, key: 'id', visibility: () => visibility,
+            resetVisibility: () => { visibility = {}; },
+            onChanged: (c) => { updateChartVisibility(); renderBadges(c); renderStatsTable(c, true); } },
+    });
 }
 
 function isVisible() { return isInViewport; }
@@ -680,7 +650,7 @@ export function soloTarget(targetId) {
     const container = document.getElementById(containerId);
     if (container) {
         renderBadges(container);
-        if (lastFetchData) renderStatsTable(container, lastFetchData);
+        if (lastFetchData) renderStatsTable(container, false);
     }
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
@@ -2,10 +2,12 @@
 // Same control pattern as cellular-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=2';
 
 const PALETTE = window.Apex?.colors || ['#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7'];
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
+
 const POLL_INTERVALS = { 0: 10000, 1: 10000, 6: 15000, 24: 30000, 168: 60000, 720: 60000 };
 const RANGE_MS = { 0: 15*60000, 1: 3600000, 6: 6*3600000, 24: 86400000, 168: 7*86400000, 720: 30*86400000 };
 
@@ -23,6 +25,7 @@ let deviceMeta = [];
 let visibility = {};
 let visibilityObserver = null;
 let isInViewport = true;
+let lastData = null;
 
 function baseOpts(height, yTitle, yFormatter, extra) {
     const base = {
@@ -30,7 +33,7 @@ function baseOpts(height, yTitle, yFormatter, extra) {
             type: 'area', height,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            zoom: { enabled: !matchMedia('(pointer:coarse)').matches, type: 'x', allowMouseWheelZoom: false },
             events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },
@@ -127,6 +130,7 @@ function renderBadges(container) {
             }
             updateVisibility();
             renderBadges(container);
+            renderStatsTable(container, false);
         });
     }
 }
@@ -191,8 +195,43 @@ async function loadAndUpdate() {
     if (tempChart) tempChart.updateSeries(tempSeries, false);
 
     updateVisibility();
+    lastData = data;
     const container = document.getElementById(containerId);
-    if (container) renderBadges(container);
+    if (container) {
+        renderBadges(container);
+        renderStatsTable(container);
+    }
+}
+
+const fmtDbm = v => v != null ? v.toFixed(2) : '-';
+const fmtTemp = v => v != null ? v.toFixed(1) : '-';
+
+function renderStatsTable(container, showAll) {
+    const el = container.querySelector('.ont-stats-table');
+    if (!el || !lastData?.devices?.length) { if (el) el.innerHTML = ''; return; }
+
+    const rows = lastData.devices.map(d => {
+        const pts = d.data || [];
+        const rx = computeStats(pts.map(p => p.rx).filter(v => v != null));
+        const tx = computeStats(pts.map(p => p.tx).filter(v => v != null));
+        const temp = computeStats(pts.map(p => p.temp).filter(v => v != null));
+        const meta = deviceMeta.find(dm => dm.id === d.id);
+        return { id: d.id, label: d.label, color: meta?.color || '#9ca3af',
+            visible: meta && visibility[meta.id] !== false,
+            values: [rx?.mean, rx?.min, rx?.max, tx?.mean, tx?.min, tx?.max, temp?.mean, temp?.min, temp?.max] };
+    });
+
+    renderTable(el, container, {
+        nameHeader: 'Device', rows, showAllRows: showAll,
+        columns: [
+            { header: 'RX Mean', format: fmtDbm }, { header: 'RX Min', format: fmtDbm }, { header: 'RX Max', format: fmtDbm },
+            { header: 'TX Mean', format: fmtDbm }, { header: 'TX Min', format: fmtDbm }, { header: 'TX Max', format: fmtDbm },
+            { header: 'Temp Mean', format: fmtTemp }, { header: 'Temp Min', format: fmtTemp }, { header: 'Temp Max', format: fmtTemp },
+        ],
+        filter: { meta: () => deviceMeta, key: 'id', visibility: () => visibility,
+            resetVisibility: () => { visibility = {}; },
+            onChanged: (c) => { updateVisibility(); renderBadges(c); renderStatsTable(c, true); } },
+    });
 }
 
 function isVisible() { return isInViewport; }
@@ -417,7 +456,7 @@ export function soloDevice(deviceId) {
     deviceMeta.forEach(m => { visibility[m.id] = m.id === deviceId; });
     updateVisibility();
     const container = document.getElementById(containerId);
-    if (container) renderBadges(container);
+    if (container) { renderBadges(container); renderStatsTable(container, false); }
 }
 
 export function unmount() {
@@ -429,6 +468,7 @@ export function unmount() {
     containerId = null;
     deviceMeta = [];
     visibility = {};
+    lastData = null;
     currentRangeHours = 24;
     windowOffset = 0;
     isCustomRange = false;

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -2,10 +2,12 @@
 // Same control pattern as latency-charts.js and device-health-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=2';
 
 const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
+
 const POLL_INTERVALS = { 0: 10000, 1: 10000, 6: 15000, 24: 30000, 168: 60000, 720: 60000 };
 const RANGE_MS = { 0: 15*60000, 1: 3600000, 6: 6*3600000, 24: 86400000, 168: 7*86400000, 720: 30*86400000 };
 
@@ -23,6 +25,7 @@ let moduleMeta = [];
 let visibility = {};
 let visibilityObserver = null;
 let isInViewport = true;
+let lastData = null;
 
 function baseOpts(height, yTitle, yFormatter, extra) {
     const base = {
@@ -30,7 +33,7 @@ function baseOpts(height, yTitle, yFormatter, extra) {
             type: 'area', height,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            zoom: { enabled: !matchMedia('(pointer:coarse)').matches, type: 'x', allowMouseWheelZoom: false },
             events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },
@@ -128,6 +131,7 @@ function renderBadges(container) {
             }
             updateVisibility();
             renderBadges(container);
+            renderStatsTable(container, false);
         });
     }
 }
@@ -184,8 +188,43 @@ async function loadAndUpdate() {
     if (tempChart) tempChart.updateSeries(tSeries, false);
 
     updateVisibility();
+    lastData = data;
     const container = document.getElementById(containerId);
-    if (container) renderBadges(container);
+    if (container) {
+        renderBadges(container);
+        renderStatsTable(container);
+    }
+}
+
+const fmtDbm = v => v != null ? v.toFixed(2) : '-';
+const fmtTemp = v => v != null ? v.toFixed(1) : '-';
+
+function renderStatsTable(container, showAll) {
+    const el = container.querySelector('.sfp-stats-table');
+    if (!el || !lastData?.modules?.length) { if (el) el.innerHTML = ''; return; }
+
+    const rows = lastData.modules.map(m => {
+        const pts = m.data || [];
+        const rx = computeStats(pts.map(p => p.rx).filter(v => v != null));
+        const tx = computeStats(pts.map(p => p.tx).filter(v => v != null));
+        const temp = computeStats(pts.map(p => p.temp).filter(v => v != null));
+        const meta = moduleMeta.find(mm => mm.id === m.id);
+        return { id: m.id, label: m.label, color: meta?.color || '#9ca3af',
+            visible: meta && visibility[meta.id] !== false,
+            values: [rx?.mean, rx?.min, rx?.max, tx?.mean, tx?.min, tx?.max, temp?.mean, temp?.min, temp?.max] };
+    });
+
+    renderTable(el, container, {
+        nameHeader: 'Module', rows, showAllRows: showAll,
+        columns: [
+            { header: 'RX Mean', format: fmtDbm }, { header: 'RX Min', format: fmtDbm }, { header: 'RX Max', format: fmtDbm },
+            { header: 'TX Mean', format: fmtDbm }, { header: 'TX Min', format: fmtDbm }, { header: 'TX Max', format: fmtDbm },
+            { header: 'Temp Mean', format: fmtTemp }, { header: 'Temp Min', format: fmtTemp }, { header: 'Temp Max', format: fmtTemp },
+        ],
+        filter: { meta: () => moduleMeta, key: 'id', visibility: () => visibility,
+            resetVisibility: () => { visibility = {}; },
+            onChanged: (c) => { updateVisibility(); renderBadges(c); renderStatsTable(c, true); } },
+    });
 }
 
 function isVisible() { return isInViewport; }
@@ -421,7 +460,7 @@ export function soloModule(id) {
     moduleMeta.forEach(m => { visibility[m.id] = m.id === id; });
     updateVisibility();
     const container = document.getElementById(containerId);
-    if (container) renderBadges(container);
+    if (container) { renderBadges(container); renderStatsTable(container, false); }
 }
 
 export function unmount() {
@@ -433,6 +472,7 @@ export function unmount() {
     containerId = null;
     moduleMeta = [];
     visibility = {};
+    lastData = null;
     currentRangeHours = 24;
     windowOffset = 0;
     isCustomRange = false;

--- a/tests/NetworkOptimizer.UniFi.Tests/GatewayWanHelperTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/GatewayWanHelperTests.cs
@@ -72,6 +72,37 @@ public class GatewayWanHelperTests
     public void WanInterfaceKeyFromKey_lowercases_and_maps_primary(string key, string expected)
         => GatewayWanHelper.WanInterfaceKeyFromKey(key).Should().Be(expected);
 
+    // ─── FormatWanLabel: graceful four-identifier WAN label assembly. Must never
+    // emit empty parentheses, doubled spaces, or "null" when a piece is missing. ───
+
+    [Theory]
+    [InlineData("Acme Fiber", 1, "eth6", "Port 7", "Acme Fiber WAN1 (eth6 - Port 7)")]
+    [InlineData(null, 1, "eth6", "Port 7", "WAN1 (eth6 - Port 7)")]
+    [InlineData("Acme Fiber", 1, "eth6", null, "Acme Fiber WAN1 (eth6)")]
+    [InlineData("Acme Fiber", 1, null, "Port 7", "Acme Fiber WAN1 (Port 7)")]
+    [InlineData("Acme Fiber", 1, null, null, "Acme Fiber WAN1")]
+    [InlineData(null, 2, null, null, "WAN2")]
+    [InlineData(null, 0, "eth3", null, "eth3")]
+    [InlineData(null, 0, null, null, "Unknown WAN")]
+    public void FormatWanLabel_degrades_gracefully(string? name, int wanIndex, string? ifName, string? portLabel, string expected)
+        => GatewayWanHelper.FormatWanLabel(name, wanIndex, ifName, portLabel).Should().Be(expected);
+
+    [Theory]
+    [InlineData("Acme Fiber", 4, "eth1", "Acme Fiber", "Acme Fiber WAN4 (eth1)")]
+    [InlineData("Acme Fiber", 4, "eth1", "acme fiber", "Acme Fiber WAN4 (eth1)")]
+    [InlineData("Comcast", 2, "eth0", "WAN2", "Comcast WAN2 (eth0)")]
+    [InlineData("Comcast", 1, "eth0", "eth0", "Comcast WAN1 (eth0)")]
+    public void FormatWanLabel_drops_redundant_port_label(string? name, int wanIndex, string? ifName, string? portLabel, string expected)
+        => GatewayWanHelper.FormatWanLabel(name, wanIndex, ifName, portLabel).Should().Be(expected);
+
+    [Fact]
+    public void FormatWanLabel_treats_blank_pieces_as_missing()
+    {
+        // Whitespace-only inputs must not produce stray spaces or empty parentheses.
+        GatewayWanHelper.FormatWanLabel("  ", 1, "  ", "  ").Should().Be("WAN1");
+        GatewayWanHelper.FormatWanLabel("Comcast", 1, "  ", "Port 1").Should().Be("Comcast WAN1 (Port 1)");
+    }
+
     // ─── EnumerateWanInterfaces: typed field extraction from raw device JSON.
     // The physical (ifname) and data-path (uplink_ifname) extraction here is the
     // PPPoE/VLAN regression surface for the flow-map and upstream parsers, so it is

--- a/tests/NetworkOptimizer.Web.Tests/MonitoringInterfaceDeploymentServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/MonitoringInterfaceDeploymentServiceTests.cs
@@ -1,0 +1,69 @@
+using FluentAssertions;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class MonitoringInterfaceDeploymentServiceTests
+{
+    private static MonitoringInterface Valid(int? vlan = null) => new()
+    {
+        Name = "modem0",
+        WanIfName = "eth1",
+        WanVlanId = vlan,
+        TargetIp = "192.168.100.1",
+        GatewayLocalIp = "192.168.100.2",
+        SubnetPrefix = 24,
+        WatchdogIntervalMinutes = 5,
+    };
+
+    [Fact]
+    public void Validate_NoVlan_Ok()
+        => MonitoringInterfaceDeploymentService.Validate(Valid()).Should().BeNull();
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(100)]
+    [InlineData(4094)]
+    public void Validate_VlanInRange_Ok(int vlan)
+        => MonitoringInterfaceDeploymentService.Validate(Valid(vlan)).Should().BeNull();
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(4095)]
+    [InlineData(9999)]
+    public void Validate_VlanOutOfRange_Rejected(int vlan)
+        => MonitoringInterfaceDeploymentService.Validate(Valid(vlan)).Should().Contain("VLAN");
+
+    [Theory]
+    [InlineData("1")]
+    [InlineData("192.168.100")]
+    [InlineData("192.168.100.1.1")]
+    public void Validate_ShorthandOrMalformedTargetIp_Rejected(string targetIp)
+    {
+        var mi = Valid();
+        mi.TargetIp = targetIp;
+        MonitoringInterfaceDeploymentService.Validate(mi).Should().Contain("Modem/ONT IP");
+    }
+
+    [Fact]
+    public void BootScript_NoVlan_LeavesVlanIdEmpty()
+    {
+        var script = MonitoringInterfaceDeploymentService.GenerateBootScript(Valid());
+        script.Should().Contain("VLAN_ID=\"\"");
+        script.Should().Contain("WAN_IF=\"eth1\"");
+    }
+
+    [Fact]
+    public void BootScript_WithVlan_SetsVlanIdAndRidesTheSubinterface()
+    {
+        var script = MonitoringInterfaceDeploymentService.GenerateBootScript(Valid(100));
+        script.Should().Contain("VLAN_ID=\"100\"");
+        // The subinterface is created from the physical port + VLAN id, and the macvlan
+        // rides the resolved parent ($PARENT) rather than the bare port.
+        script.Should().Contain("type vlan id \"$VLAN_ID\"");
+        script.Should().Contain("link \"$PARENT\" type macvlan");
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/QuantumQ1000kOntProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/QuantumQ1000kOntProviderTests.cs
@@ -1,0 +1,154 @@
+using FluentAssertions;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Web.Services.OntProviders;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class QuantumQ1000kOntProviderTests
+{
+    [Fact]
+    public void ApplyConnectionStatus_ConnectedGponRates_SetsUpAndGpon()
+    {
+        var stats = new OntStats();
+        var json = """
+            {"wan_status":{"device":"pon","connname":"wan","connifname":"pon",
+            "ipaddr":"203.0.113.5/24","link_state":"connected","net_state":"bridged",
+            "type":"2","uplink_rate":"1244000","downlink_rate":"2488000",
+            "is_bridged":"false","is_walled_pppcred":"false","is_captived":"false"}}
+            """;
+
+        QuantumQ1000kOntProvider.ApplyConnectionStatus(json, stats);
+
+        stats.OperationalStatus.Should().Be("Up");
+        stats.LinkState.Should().Be("Up");
+        stats.PonType.Should().Be("GPON");
+    }
+
+    [Fact]
+    public void ApplyConnectionStatus_DisconnectedLink_SetsDown()
+    {
+        var stats = new OntStats();
+        var json = """{"wan_status":{"link_state":"disconnected","downlink_rate":"0"}}""";
+
+        QuantumQ1000kOntProvider.ApplyConnectionStatus(json, stats);
+
+        stats.OperationalStatus.Should().Be("Down");
+        stats.LinkState.Should().Be("Down");
+    }
+
+    [Fact]
+    public void ApplyConnectionStatus_TenGigDownstream_SetsXgsPon()
+    {
+        var stats = new OntStats();
+        var json = """{"wan_status":{"link_state":"connected","downlink_rate":"9953000"}}""";
+
+        QuantumQ1000kOntProvider.ApplyConnectionStatus(json, stats);
+
+        stats.PonType.Should().Be("XGS-PON");
+    }
+
+    [Fact]
+    public void ApplyDeviceInfo_ParsesModelAndSerial()
+    {
+        var stats = new OntStats { DeviceModel = "Quantum Q1000K" };
+        var json = """
+            {"Objects":[{"ObjName":"Device.DeviceInfo.","Param":[
+            {"ParamName":"HardwareVersion","ParamValue":"1.0"},
+            {"ParamName":"ModelName","ParamValue":"Q1000K"},
+            {"ParamName":"SerialNumber","ParamValue":"ABC123456789"},
+            {"ParamName":"SoftwareVersion","ParamValue":"QKX001-06.00.44.00"}]}]}
+            """;
+
+        QuantumQ1000kOntProvider.ApplyDeviceInfo(json, stats);
+
+        stats.DeviceModel.Should().Be("Quantum Q1000K");
+        stats.VendorPn.Should().Be("Q1000K");
+        stats.VendorSn.Should().Be("ABC123456789");
+    }
+
+    [Fact]
+    public void ApplyOpticalInterface_ParsesFullDdmDump()
+    {
+        var stats = new OntStats();
+        // Trimmed from a real Device.Optical.Interface.1 dump (issue #830).
+        var json = """
+            {"Objects":[
+              {"ObjName":"Device.Optical.Interface.1.","Param":[
+                {"ParamName":"OpticalSignalLevel","ParamValue":"-14449"},
+                {"ParamName":"Status","ParamValue":"Up"},
+                {"ParamName":"TransmitOpticalLevel","ParamValue":"2602"},
+                {"ParamName":"X_AXON_DownstreamRate","ParamValue":"2488"},
+                {"ParamName":"X_AXON_LineStatus","ParamValue":"GOOD"},
+                {"ParamName":"X_AXON_LinkUpTime","ParamValue":"943292"},
+                {"ParamName":"X_AXON_UpstreamRate","ParamValue":"1244"},
+                {"ParamName":"X_CTL_BiasCurrent","ParamValue":"13822"},
+                {"ParamName":"X_CTL_OLTModel","ParamValue":"E7"},
+                {"ParamName":"X_CTL_OLTVendor","ParamValue":"CALX"},
+                {"ParamName":"X_CTL_Temperature","ParamValue":"56"},
+                {"ParamName":"X_CTL_Voltage","ParamValue":"3317"}]},
+              {"ObjName":"Device.Optical.Interface.1.Stats.","Param":[
+                {"ParamName":"X_CTL_BIPErrorsReceived","ParamValue":"0"},
+                {"ParamName":"ErrorsReceived","ParamValue":"0"}]}]}
+            """;
+
+        QuantumQ1000kOntProvider.ApplyOpticalInterface(json, stats);
+
+        stats.RxPowerDbm.Should().BeApproximately(-14.449, 0.0001);
+        stats.TxPowerDbm.Should().BeApproximately(2.602, 0.0001);
+        stats.TemperatureC.Should().Be(56);
+        stats.VoltageV.Should().BeApproximately(3.317, 0.0001);
+        stats.BiasMa.Should().BeApproximately(13.822, 0.0001);
+        stats.BipErrors.Should().Be(0);
+        stats.LinkState.Should().Be("Up");
+        stats.OperationalStatus.Should().Be("Up");
+        stats.PonType.Should().Be("GPON");
+        stats.LinkUptimeSeconds.Should().Be(943292);
+        stats.OltVendor.Should().Be("CALX");
+        stats.OltModel.Should().Be("E7");
+    }
+
+    [Fact]
+    public void ApplyOpticalInterface_StatusIsAuthoritativeOverConnectionStatus()
+    {
+        var stats = new OntStats { LinkState = "Down", OperationalStatus = "Down" };
+        var json = """
+            {"Objects":[{"ObjName":"Device.Optical.Interface.1.","Param":[
+            {"ParamName":"Status","ParamValue":"Up"}]}]}
+            """;
+
+        QuantumQ1000kOntProvider.ApplyOpticalInterface(json, stats);
+
+        stats.LinkState.Should().Be("Up");
+        stats.OperationalStatus.Should().Be("Up");
+    }
+
+    [Fact]
+    public void ApplyOpticalInterface_FallsBackToLineStatusWhenNoStatusField()
+    {
+        var stats = new OntStats();
+        var json = """
+            {"Objects":[{"ObjName":"Device.Optical.Interface.1.","Param":[
+            {"ParamName":"X_AXON_LineStatus","ParamValue":"GOOD"}]}]}
+            """;
+
+        QuantumQ1000kOntProvider.ApplyOpticalInterface(json, stats);
+
+        stats.LinkState.Should().Be("Up");
+        stats.OperationalStatus.Should().Be("Up");
+    }
+
+    [Fact]
+    public void Parsers_InvalidJson_DoNotThrow()
+    {
+        var stats = new OntStats();
+        var act = () =>
+        {
+            QuantumQ1000kOntProvider.ApplyConnectionStatus("not json", stats);
+            QuantumQ1000kOntProvider.ApplyDeviceInfo("{}", stats);
+            QuantumQ1000kOntProvider.ApplyOpticalInterface("[]", stats);
+        };
+
+        act.Should().NotThrow();
+    }
+}


### PR DESCRIPTION
Pending for this release (everything on dev since the last main tag).

## Monitoring

- **Monitoring Interfaces: reach an ONT/modem behind your WAN** - New section under Monitoring -> Setup. When a modem or ONT management page sits behind the WAN, the gateway can't route to it, so monitoring (and your browser) can't reach it. A monitoring interface deploys a small, reboot-safe route to the gateway (a macvlan on the physical WAN port + host route + optional SNAT, self-installing via udm-boot and a cron watchdog) that makes the device reachable from the LAN. It recommends trying a native UniFi Policy Engine static route first, and refuses to deploy if the target overlaps a UniFi-managed network or is already reachable. It can also ride a tagged VLAN: when the device sits on an 802.1Q VLAN (for example an ONT whose data path or management plane is tagged), it attaches the macvlan to the WAN VLAN subinterface and creates that subinterface on the gateway if it isn't already there. Discoverable from the Cable Modem / ONT / Cellular monitor forms, which link here (pre-filling the device IP and a sensible default name) when a connection test can't reach the device.

- **Netgear cable modem single-session support** - Netgear modems (e.g. CM600) allow only one web session at a time and redirect every page to a "log out existing session" prompt when another session is active, which previously blocked polling while you were logged into the modem UI. The Netgear provider now claims that session and continues, so polling works regardless of an active browser login.

- **Motorola cable modem connection fix** - Motorola HNAP modems (MB8611, MB8600, etc.) now connect when the previous HTTPS-only path timed out. Some of these modems present an HTTPS endpoint that can't be completed even though the modem's web UI loads fine in a browser (seen most often on macOS-native installs); they also answer the HNAP API over plain HTTP. The provider now detects which one the modem speaks and uses it, trying HTTPS first so modems already polling over HTTPS are unaffected.

- **Quantum Fiber Q1000K SmartNID ONT monitoring** - New ONT provider for the Quantum Fiber / CenturyLink Q1000K (GPON). Reports the full optical set (RX/TX power, temperature, voltage, laser bias current), link status, PON type, and BIP error count; the dashboard ONT panel shows live RX power, link state, and link type like the other ONT providers.

- **Statistics tables on all monitoring chart tabs** - Network Performance, Device Stats, SFP, ONT, CM, and Cellular tabs now show a stats table with mean/min/max per metric over the selected window, with sortable columns and click-to-filter on device names. Mobile gets horizontal-scroll preservation across refreshes and drag-zoom suppression so scrolling doesn't trigger chart zoom.

- **Auto-tag ASN on transit / ISP targets** - Adding a Transit or Access ISP monitoring target now resolves its ASN automatically (DNS-resolving hostnames first) using the in-memory GeoLite2 cache; lookup failures are skipped so the target is still created.

## Settings

- **No autocomplete on device passwords** - Browser and password-manager autofill is disabled on the Cable Modem, ONT, and Cellular modem password fields.