### PR TITLE
Add statistics tables to all monitoring chart tabs

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -437,6 +437,7 @@ else
                     <div class="chart-header"><h3 class="chart-title">Memory</h3></div>
                     <div class="health-mem-chart"></div>
                 </div>
+                <div class="health-stats-table"></div>
 
                 <details class="setup-guide" style="margin-top: 1.25rem;">
                     <summary>Why do these readings differ from UniFi Network?</summary>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -517,6 +517,7 @@ else
                     <div class="chart-header"><h3 class="chart-title">Temperature</h3></div>
                     <div class="sfp-temp-chart"></div>
                 </div>
+                <div class="sfp-stats-table"></div>
             </div>
         </div>
         }
@@ -634,6 +635,7 @@ else
                     <div class="chart-header"><h3 class="chart-title">FEC Errors (per interval)</h3></div>
                     <div class="cm-errors-chart"></div>
                 </div>
+                <div class="cm-stats-table"></div>
             </div>
         </div>
         }
@@ -740,6 +742,7 @@ else
                     <div class="chart-header"><h3 class="chart-title">Temperature</h3></div>
                     <div class="ont-temp-chart"></div>
                 </div>
+                <div class="ont-stats-table"></div>
             </div>
         </div>
         }
@@ -840,6 +843,7 @@ else
                     <div class="chart-header"><h3 class="chart-title">Signal Quality</h3></div>
                     <div class="cellular-quality-chart"></div>
                 </div>
+                <div class="cellular-stats-table"></div>
             </div>
         </div>
         }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14214,6 +14214,28 @@ tr.stats-row-filtered {
     opacity: 0.35;
 }
 
+[class$="-stats-table"] .table-responsive {
+    scrollbar-width: thin;
+    scrollbar-color: var(--bg-tertiary) transparent;
+}
+
+[class$="-stats-table"] .table-responsive::-webkit-scrollbar {
+    height: 6px;
+}
+
+[class$="-stats-table"] .table-responsive::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+[class$="-stats-table"] .table-responsive::-webkit-scrollbar-thumb {
+    background: var(--bg-tertiary);
+    border-radius: 3px;
+}
+
+[class$="-stats-table"] .table-responsive::-webkit-scrollbar-thumb:hover {
+    background: var(--text-muted);
+}
+
 .wan-badge-dot {
     width: 10px;
     height: 10px;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14177,6 +14177,22 @@ a.affected-client:hover {
     color: var(--text-muted, #666);
 }
 
+.stat-filter-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.25rem 0.6rem;
+    border-radius: var(--border-radius-lg);
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: border-color 0.15s;
+    white-space: nowrap;
+}
+
+.stat-filter-badge:hover {
+    border-color: rgba(255, 255, 255, 0.5);
+}
+
 .wan-badge-dot {
     width: 10px;
     height: 10px;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -8626,6 +8626,7 @@ a.path-hop.hop-clickable:hover {
 /* ApexCharts dark theme overrides */
 .apexcharts-canvas {
     background: transparent !important;
+    touch-action: pan-y;
 }
 
 /* ApexCharts dark theme overrides annotation label fill - needs double class

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -8626,7 +8626,6 @@ a.path-hop.hop-clickable:hover {
 /* ApexCharts dark theme overrides */
 .apexcharts-canvas {
     background: transparent !important;
-    touch-action: pan-y;
 }
 
 /* ApexCharts dark theme overrides annotation label fill - needs double class

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14196,6 +14196,24 @@ td[data-stat-id]:hover .stat-filter-badge {
     border-color: rgba(255, 255, 255, 0.5);
 }
 
+th[data-sort-col] {
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+}
+
+th[data-sort-col]:hover {
+    color: var(--text-primary);
+}
+
+th.stats-sort-active {
+    color: var(--primary-color);
+}
+
+tr.stats-row-filtered {
+    opacity: 0.35;
+}
+
 .wan-badge-dot {
     width: 10px;
     height: 10px;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14215,12 +14215,11 @@ tr.stats-row-filtered {
 }
 
 [class$="-stats-table"] .table-responsive {
-    scrollbar-width: thin;
     scrollbar-color: var(--bg-tertiary) transparent;
 }
 
 [class$="-stats-table"] .table-responsive::-webkit-scrollbar {
-    height: 6px;
+    height: 10px;
 }
 
 [class$="-stats-table"] .table-responsive::-webkit-scrollbar-track {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14184,12 +14184,15 @@ a.affected-client:hover {
     padding: 0.25rem 0.6rem;
     border-radius: var(--border-radius-lg);
     border: 1px solid transparent;
-    cursor: pointer;
     transition: border-color 0.15s;
     white-space: nowrap;
 }
 
-.stat-filter-badge:hover {
+td[data-stat-id] {
+    cursor: pointer;
+}
+
+td[data-stat-id]:hover .stat-filter-badge {
     border-color: rgba(255, 255, 255, 0.5);
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
@@ -209,8 +209,8 @@ async function loadAndUpdate() {
     }
 }
 
-function fmtDbm(v) { return v != null ? v.toFixed(0) : '-'; }
-function fmtDb(v) { return v != null ? v.toFixed(1) : '-'; }
+function fmtDbm(v) { return v != null ? v.toFixed(2) : '-'; }
+function fmtDb(v) { return v != null ? v.toFixed(2) : '-'; }
 function fmtPct(v) { return v != null ? v.toFixed(0) + '%' : '-'; }
 
 function renderStatsTable(container) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
@@ -35,7 +35,7 @@ function baseOpts(height, yTitle, yFormatter, extra) {
             type: 'area', height,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            zoom: { enabled: !matchMedia('(pointer:coarse)').matches, type: 'x', allowMouseWheelZoom: false },
             events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },

--- a/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
@@ -6,6 +6,26 @@ import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 const PALETTE = window.Apex?.colors || ['#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7'];
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
+
+function percentile(sorted, p) {
+    if (sorted.length === 0) return null;
+    const idx = (p / 100) * (sorted.length - 1);
+    const lo = Math.floor(idx);
+    const hi = Math.ceil(idx);
+    if (lo === hi) return sorted[lo];
+    return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+}
+
+function computeStats(values) {
+    if (!values || values.length === 0) return null;
+    const sorted = [...values].sort((a, b) => a - b);
+    return {
+        mean: values.reduce((s, v) => s + v, 0) / values.length,
+        min: sorted[0],
+        max: sorted[sorted.length - 1],
+    };
+}
+
 const POLL_INTERVALS = { 0: 10000, 1: 10000, 6: 15000, 24: 30000, 168: 60000, 720: 60000 };
 const RANGE_MS = { 0: 15*60000, 1: 3600000, 6: 6*3600000, 24: 86400000, 168: 7*86400000, 720: 30*86400000 };
 
@@ -25,6 +45,7 @@ let modemMeta = [];
 let visibility = {};
 let visibilityObserver = null;
 let isInViewport = true;
+let lastData = null;
 
 function baseOpts(height, yTitle, yFormatter, extra) {
     return {
@@ -122,6 +143,7 @@ function renderBadges(container) {
             }
             updateVisibility();
             renderBadges(container);
+            renderStatsTable(container);
         });
     }
 }
@@ -179,8 +201,71 @@ async function loadAndUpdate() {
     if (qualityChart) qualityChart.updateSeries(qualitySeries, false);
 
     updateVisibility();
+    lastData = data;
     const container = document.getElementById(containerId);
-    if (container) renderBadges(container);
+    if (container) {
+        renderBadges(container);
+        renderStatsTable(container);
+    }
+}
+
+function fmtDbm(v) { return v != null ? v.toFixed(0) : '-'; }
+function fmtDb(v) { return v != null ? v.toFixed(1) : '-'; }
+function fmtPct(v) { return v != null ? v.toFixed(0) + '%' : '-'; }
+
+function renderStatsTable(container) {
+    const el = container.querySelector('.cellular-stats-table');
+    if (!el || !lastData?.modems?.length) { if (el) el.innerHTML = ''; return; }
+
+    const visibleModems = lastData.modems.filter(m => {
+        const meta = modemMeta.find(mm => mm.id === m.id);
+        return meta && visibility[meta.id] !== false;
+    });
+
+    if (visibleModems.length === 0) { el.innerHTML = ''; return; }
+
+    const prev = el.querySelector('.table-responsive');
+    const scrollLeft = prev ? prev.scrollLeft : 0;
+
+    const rows = visibleModems.map(m => {
+        const pts = m.data || [];
+        const rsrpVals = pts.map(p => p.rsrp).filter(v => v != null);
+        const rsrqVals = pts.map(p => p.rsrq).filter(v => v != null);
+        const snrVals = pts.map(p => p.snr).filter(v => v != null);
+        const qualityVals = pts.map(p => p.quality).filter(v => v != null);
+        const rsrp = computeStats(rsrpVals);
+        const rsrq = computeStats(rsrqVals);
+        const snr = computeStats(snrVals);
+        const quality = computeStats(qualityVals);
+        const meta = modemMeta.find(mm => mm.id === m.id);
+        const color = meta?.color || '#9ca3af';
+        return `<tr>
+            <td><span class="wan-badge-dot" style="background-color:${color};display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:6px"></span>${escapeHtml(m.label)}</td>
+            <td>${fmtDbm(rsrp?.mean)}</td><td>${fmtDbm(rsrp?.min)}</td><td>${fmtDbm(rsrp?.max)}</td>
+            <td>${fmtDb(rsrq?.mean)}</td><td>${fmtDb(rsrq?.min)}</td><td>${fmtDb(rsrq?.max)}</td>
+            <td>${fmtDb(snr?.mean)}</td><td>${fmtDb(snr?.min)}</td><td>${fmtDb(snr?.max)}</td>
+            <td>${fmtPct(quality?.mean)}</td><td>${fmtPct(quality?.min)}</td><td>${fmtPct(quality?.max)}</td>
+        </tr>`;
+    });
+
+    el.innerHTML = `<div class="chart-card" style="margin-top:1rem">
+        <div class="chart-header"><h3 class="chart-title">Statistics</h3></div>
+        <div class="table-responsive">
+        <table class="data-table" style="font-size:0.8125rem">
+            <thead><tr>
+                <th>Modem</th>
+                <th>RSRP Mean</th><th>RSRP Min</th><th>RSRP Max</th>
+                <th>RSRQ Mean</th><th>RSRQ Min</th><th>RSRQ Max</th>
+                <th>SNR Mean</th><th>SNR Min</th><th>SNR Max</th>
+                <th>Qual Mean</th><th>Qual Min</th><th>Qual Max</th>
+            </tr></thead>
+            <tbody>${rows.join('')}</tbody>
+        </table>
+        </div>
+    </div>`;
+
+    const next = el.querySelector('.table-responsive');
+    if (next && scrollLeft) next.scrollLeft = scrollLeft;
 }
 
 function isVisible() { return isInViewport; }
@@ -437,6 +522,7 @@ export function unmount() {
     containerId = null;
     modemMeta = [];
     visibility = {};
+    lastData = null;
     currentRangeHours = 24;
     windowOffset = 0;
     isCustomRange = false;

--- a/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
@@ -2,29 +2,11 @@
 // Same control pattern as sfp-charts.js and device-health-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
+import { computeStats, initStatsFilter } from './chart-stats.js?v=1';
 
 const PALETTE = window.Apex?.colors || ['#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7'];
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
-
-function percentile(sorted, p) {
-    if (sorted.length === 0) return null;
-    const idx = (p / 100) * (sorted.length - 1);
-    const lo = Math.floor(idx);
-    const hi = Math.ceil(idx);
-    if (lo === hi) return sorted[lo];
-    return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
-}
-
-function computeStats(values) {
-    if (!values || values.length === 0) return null;
-    const sorted = [...values].sort((a, b) => a - b);
-    return {
-        mean: values.reduce((s, v) => s + v, 0) / values.length,
-        min: sorted[0],
-        max: sorted[sorted.length - 1],
-    };
-}
 
 const POLL_INTERVALS = { 0: 10000, 1: 10000, 6: 15000, 24: 30000, 168: 60000, 720: 60000 };
 const RANGE_MS = { 0: 15*60000, 1: 3600000, 6: 6*3600000, 24: 86400000, 168: 7*86400000, 720: 30*86400000 };
@@ -240,7 +222,7 @@ function renderStatsTable(container) {
         const meta = modemMeta.find(mm => mm.id === m.id);
         const color = meta?.color || '#9ca3af';
         return `<tr>
-            <td><span class="stat-filter-badge" data-stat-id="${m.id}"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(m.label)}</span></td>
+            <td data-stat-id="${m.id}"><span class="stat-filter-badge"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(m.label)}</span></td>
             <td>${fmtDbm(rsrp?.mean)}</td><td>${fmtDbm(rsrp?.min)}</td><td>${fmtDbm(rsrp?.max)}</td>
             <td>${fmtDb(rsrq?.mean)}</td><td>${fmtDb(rsrq?.min)}</td><td>${fmtDb(rsrq?.max)}</td>
             <td>${fmtDb(snr?.mean)}</td><td>${fmtDb(snr?.min)}</td><td>${fmtDb(snr?.max)}</td>
@@ -267,27 +249,13 @@ function renderStatsTable(container) {
     const next = el.querySelector('.table-responsive');
     if (next && scrollLeft) next.scrollLeft = scrollLeft;
 
-    if (!el._delegated) {
-        el._delegated = true;
-        el.addEventListener('click', (e) => {
-            const badge = e.target.closest('[data-stat-id]');
-            if (!badge) return;
-            const id = badge.dataset.statId;
-            if (e.ctrlKey || e.metaKey) {
-                visibility[id] = visibility[id] === false ? undefined : false;
-            } else {
-                const allVis = modemMeta.every(m => visibility[m.id] !== false);
-                const onlyThis = visibility[id] !== false
-                    && modemMeta.filter(m => m.id !== id).every(m => visibility[m.id] === false);
-                if (onlyThis) { visibility = {}; }
-                else if (allVis) { modemMeta.forEach(m => visibility[m.id] = m.id === id); }
-                else { visibility[id] = visibility[id] === false; }
-            }
-            updateVisibility();
-            renderBadges(container);
-            renderStatsTable(container);
-        });
-    }
+    initStatsFilter(el, container, {
+        meta: () => modemMeta,
+        key: 'id',
+        visibility: () => visibility,
+        resetVisibility: () => { visibility = {}; },
+        onChanged: (c) => { updateVisibility(); renderBadges(c); renderStatsTable(c); },
+    });
 }
 
 function isVisible() { return isInViewport; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
@@ -240,7 +240,7 @@ function renderStatsTable(container) {
         const meta = modemMeta.find(mm => mm.id === m.id);
         const color = meta?.color || '#9ca3af';
         return `<tr>
-            <td><span class="wan-badge-dot" style="background-color:${color};display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:6px"></span>${escapeHtml(m.label)}</td>
+            <td><span class="stat-filter-badge" data-stat-id="${m.id}"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(m.label)}</span></td>
             <td>${fmtDbm(rsrp?.mean)}</td><td>${fmtDbm(rsrp?.min)}</td><td>${fmtDbm(rsrp?.max)}</td>
             <td>${fmtDb(rsrq?.mean)}</td><td>${fmtDb(rsrq?.min)}</td><td>${fmtDb(rsrq?.max)}</td>
             <td>${fmtDb(snr?.mean)}</td><td>${fmtDb(snr?.min)}</td><td>${fmtDb(snr?.max)}</td>
@@ -266,6 +266,28 @@ function renderStatsTable(container) {
 
     const next = el.querySelector('.table-responsive');
     if (next && scrollLeft) next.scrollLeft = scrollLeft;
+
+    if (!el._delegated) {
+        el._delegated = true;
+        el.addEventListener('click', (e) => {
+            const badge = e.target.closest('[data-stat-id]');
+            if (!badge) return;
+            const id = badge.dataset.statId;
+            if (e.ctrlKey || e.metaKey) {
+                visibility[id] = visibility[id] === false ? undefined : false;
+            } else {
+                const allVis = modemMeta.every(m => visibility[m.id] !== false);
+                const onlyThis = visibility[id] !== false
+                    && modemMeta.filter(m => m.id !== id).every(m => visibility[m.id] === false);
+                if (onlyThis) { visibility = {}; }
+                else if (allVis) { modemMeta.forEach(m => visibility[m.id] = m.id === id); }
+                else { visibility[id] = visibility[id] === false; }
+            }
+            updateVisibility();
+            renderBadges(container);
+            renderStatsTable(container);
+        });
+    }
 }
 
 function isVisible() { return isInViewport; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
@@ -125,7 +125,7 @@ function renderBadges(container) {
             }
             updateVisibility();
             renderBadges(container);
-            renderStatsTable(container);
+            renderStatsTable(container, false);
         });
     }
 }
@@ -466,7 +466,7 @@ export function soloModem(modemId) {
     modemMeta.forEach(m => { visibility[m.id] = m.id === modemId || m.id.startsWith(modemId + ':'); });
     updateVisibility();
     const container = document.getElementById(containerId);
-    if (container) renderBadges(container);
+    if (container) { renderBadges(container); renderStatsTable(container, false); }
 }
 
 export function unmount() {

--- a/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
@@ -2,7 +2,7 @@
 // Same control pattern as sfp-charts.js and device-health-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, initStatsFilter } from './chart-stats.js?v=1';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=2';
 
 const PALETTE = window.Apex?.colors || ['#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7'];
 const _esc = document.createElement('span');
@@ -191,70 +191,38 @@ async function loadAndUpdate() {
     }
 }
 
-function fmtDbm(v) { return v != null ? v.toFixed(2) : '-'; }
-function fmtDb(v) { return v != null ? v.toFixed(2) : '-'; }
-function fmtPct(v) { return v != null ? v.toFixed(0) + '%' : '-'; }
+const fmtDbm = v => v != null ? v.toFixed(2) : '-';
+const fmtDb = v => v != null ? v.toFixed(2) : '-';
+const fmtPct = v => v != null ? v.toFixed(0) + '%' : '-';
 
-function renderStatsTable(container) {
+function renderStatsTable(container, showAll) {
     const el = container.querySelector('.cellular-stats-table');
     if (!el || !lastData?.modems?.length) { if (el) el.innerHTML = ''; return; }
 
-    const visibleModems = lastData.modems.filter(m => {
-        const meta = modemMeta.find(mm => mm.id === m.id);
-        return meta && visibility[meta.id] !== false;
-    });
-
-    if (visibleModems.length === 0) { el.innerHTML = ''; return; }
-
-    const prev = el.querySelector('.table-responsive');
-    const scrollLeft = prev ? prev.scrollLeft : 0;
-
-    const rows = visibleModems.map(m => {
+    const rows = lastData.modems.map(m => {
         const pts = m.data || [];
-        const rsrpVals = pts.map(p => p.rsrp).filter(v => v != null);
-        const rsrqVals = pts.map(p => p.rsrq).filter(v => v != null);
-        const snrVals = pts.map(p => p.snr).filter(v => v != null);
-        const qualityVals = pts.map(p => p.quality).filter(v => v != null);
-        const rsrp = computeStats(rsrpVals);
-        const rsrq = computeStats(rsrqVals);
-        const snr = computeStats(snrVals);
-        const quality = computeStats(qualityVals);
+        const rsrp = computeStats(pts.map(p => p.rsrp).filter(v => v != null));
+        const rsrq = computeStats(pts.map(p => p.rsrq).filter(v => v != null));
+        const snr = computeStats(pts.map(p => p.snr).filter(v => v != null));
+        const quality = computeStats(pts.map(p => p.quality).filter(v => v != null));
         const meta = modemMeta.find(mm => mm.id === m.id);
-        const color = meta?.color || '#9ca3af';
-        return `<tr>
-            <td data-stat-id="${m.id}"><span class="stat-filter-badge"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(m.label)}</span></td>
-            <td>${fmtDbm(rsrp?.mean)}</td><td>${fmtDbm(rsrp?.min)}</td><td>${fmtDbm(rsrp?.max)}</td>
-            <td>${fmtDb(rsrq?.mean)}</td><td>${fmtDb(rsrq?.min)}</td><td>${fmtDb(rsrq?.max)}</td>
-            <td>${fmtDb(snr?.mean)}</td><td>${fmtDb(snr?.min)}</td><td>${fmtDb(snr?.max)}</td>
-            <td>${fmtPct(quality?.mean)}</td><td>${fmtPct(quality?.min)}</td><td>${fmtPct(quality?.max)}</td>
-        </tr>`;
+        return { id: m.id, label: m.label, color: meta?.color || '#9ca3af',
+            visible: meta && visibility[meta.id] !== false,
+            values: [rsrp?.mean, rsrp?.min, rsrp?.max, rsrq?.mean, rsrq?.min, rsrq?.max,
+                snr?.mean, snr?.min, snr?.max, quality?.mean, quality?.min, quality?.max] };
     });
 
-    el.innerHTML = `<div class="chart-card" style="margin-top:1rem">
-        <div class="chart-header"><h3 class="chart-title">Statistics</h3></div>
-        <div class="table-responsive">
-        <table class="data-table" style="font-size:0.8125rem">
-            <thead><tr>
-                <th>Modem</th>
-                <th>RSRP Mean</th><th>RSRP Min</th><th>RSRP Max</th>
-                <th>RSRQ Mean</th><th>RSRQ Min</th><th>RSRQ Max</th>
-                <th>SNR Mean</th><th>SNR Min</th><th>SNR Max</th>
-                <th>Qual Mean</th><th>Qual Min</th><th>Qual Max</th>
-            </tr></thead>
-            <tbody>${rows.join('')}</tbody>
-        </table>
-        </div>
-    </div>`;
-
-    const next = el.querySelector('.table-responsive');
-    if (next && scrollLeft) next.scrollLeft = scrollLeft;
-
-    initStatsFilter(el, container, {
-        meta: () => modemMeta,
-        key: 'id',
-        visibility: () => visibility,
-        resetVisibility: () => { visibility = {}; },
-        onChanged: (c) => { updateVisibility(); renderBadges(c); renderStatsTable(c); },
+    renderTable(el, container, {
+        nameHeader: 'Modem', rows, showAllRows: showAll,
+        columns: [
+            { header: 'RSRP Mean', format: fmtDbm }, { header: 'RSRP Min', format: fmtDbm }, { header: 'RSRP Max', format: fmtDbm },
+            { header: 'RSRQ Mean', format: fmtDb }, { header: 'RSRQ Min', format: fmtDb }, { header: 'RSRQ Max', format: fmtDb },
+            { header: 'SNR Mean', format: fmtDb }, { header: 'SNR Min', format: fmtDb }, { header: 'SNR Max', format: fmtDb },
+            { header: 'Qual Mean', format: fmtPct }, { header: 'Qual Min', format: fmtPct }, { header: 'Qual Max', format: fmtPct },
+        ],
+        filter: { meta: () => modemMeta, key: 'id', visibility: () => visibility,
+            resetVisibility: () => { visibility = {}; },
+            onChanged: (c) => { updateVisibility(); renderBadges(c); renderStatsTable(c, true); } },
     });
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-stats.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-stats.js
@@ -28,7 +28,8 @@ export function renderStatsTable(el, container, opts) {
 
     if (!rows || rows.length === 0) { el.innerHTML = ''; return; }
 
-    const display = opts.showAllRows ? rows : rows.filter(r => r.visible !== false);
+    if (opts.showAllRows !== undefined) el._showAllRows = opts.showAllRows;
+    const display = (el._showAllRows ?? false) ? rows : rows.filter(r => r.visible !== false);
     if (display.length === 0) { el.innerHTML = ''; return; }
 
     const sortCol = el._sortCol ?? -1;

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-stats.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-stats.js
@@ -89,7 +89,8 @@ export function renderStatsTable(el, container, opts) {
             if (!th) return;
             const col = parseInt(th.dataset.sortCol);
             if (el._sortCol === col) {
-                el._sortDir = (el._sortDir ?? 'asc') === 'asc' ? 'desc' : 'asc';
+                if (el._sortDir === 'asc') { el._sortDir = 'desc'; }
+                else { el._sortCol = -1; el._sortDir = 'asc'; }
             } else {
                 el._sortCol = col;
                 el._sortDir = 'asc';

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-stats.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-stats.js
@@ -1,0 +1,45 @@
+export function percentile(sorted, p) {
+    if (sorted.length === 0) return null;
+    const idx = (p / 100) * (sorted.length - 1);
+    const lo = Math.floor(idx);
+    const hi = Math.ceil(idx);
+    if (lo === hi) return sorted[lo];
+    return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+}
+
+export function computeStats(values) {
+    if (!values || values.length === 0) return null;
+    const sorted = [...values].sort((a, b) => a - b);
+    return {
+        mean: values.reduce((s, v) => s + v, 0) / values.length,
+        min: sorted[0],
+        max: sorted[sorted.length - 1],
+        p95: percentile(sorted, 95),
+        p99: percentile(sorted, 99),
+    };
+}
+
+export function initStatsFilter(el, container, opts) {
+    if (el._delegated) return;
+    el._delegated = true;
+    el.addEventListener('click', (e) => {
+        const td = e.target.closest('[data-stat-id]');
+        if (!td) return;
+        const id = td.dataset.statId;
+        const meta = opts.meta();
+        const key = opts.key;
+        const vis = opts.visibility();
+
+        if (e.ctrlKey || e.metaKey) {
+            vis[id] = vis[id] === false ? undefined : false;
+        } else {
+            const allVis = meta.every(m => vis[m[key]] !== false);
+            const onlyThis = vis[id] !== false
+                && meta.filter(m => m[key] !== id).every(m => vis[m[key]] === false);
+            if (onlyThis) { opts.resetVisibility(); }
+            else if (allVis) { meta.forEach(m => { vis[m[key]] = m[key] === id; }); }
+            else { vis[id] = vis[id] === false; }
+        }
+        opts.onChanged(container);
+    });
+}

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-stats.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-stats.js
@@ -1,3 +1,6 @@
+const _esc = document.createElement('span');
+function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
+
 export function percentile(sorted, p) {
     if (sorted.length === 0) return null;
     const idx = (p / 100) * (sorted.length - 1);
@@ -19,27 +22,103 @@ export function computeStats(values) {
     };
 }
 
-export function initStatsFilter(el, container, opts) {
-    if (el._delegated) return;
-    el._delegated = true;
-    el.addEventListener('click', (e) => {
-        const td = e.target.closest('[data-stat-id]');
-        if (!td) return;
-        const id = td.dataset.statId;
-        const meta = opts.meta();
-        const key = opts.key;
-        const vis = opts.visibility();
+export function renderStatsTable(el, container, opts) {
+    if (!el) return;
+    const { nameHeader = 'Name', rows, columns, filter } = opts;
 
-        if (e.ctrlKey || e.metaKey) {
-            vis[id] = vis[id] === false ? undefined : false;
-        } else {
-            const allVis = meta.every(m => vis[m[key]] !== false);
-            const onlyThis = vis[id] !== false
-                && meta.filter(m => m[key] !== id).every(m => vis[m[key]] === false);
-            if (onlyThis) { opts.resetVisibility(); }
-            else if (allVis) { meta.forEach(m => { vis[m[key]] = m[key] === id; }); }
-            else { vis[id] = vis[id] === false; }
-        }
-        opts.onChanged(container);
-    });
+    if (!rows || rows.length === 0) { el.innerHTML = ''; return; }
+
+    const display = opts.showAllRows ? rows : rows.filter(r => r.visible !== false);
+    if (display.length === 0) { el.innerHTML = ''; return; }
+
+    const sortCol = el._sortCol ?? -1;
+    const sortDir = el._sortDir ?? 'asc';
+    const sorted = [...display];
+    if (sortCol >= 0 && sortCol < columns.length) {
+        sorted.sort((a, b) => {
+            const av = a.values[sortCol], bv = b.values[sortCol];
+            if (av == null && bv == null) return 0;
+            if (av == null) return 1;
+            if (bv == null) return -1;
+            return sortDir === 'asc' ? av - bv : bv - av;
+        });
+    }
+
+    const prev = el.querySelector('.table-responsive');
+    const scrollLeft = prev ? prev.scrollLeft : 0;
+
+    const headers = columns.map((col, i) => {
+        const active = i === sortCol;
+        const arrow = active ? (sortDir === 'asc' ? ' ▲' : ' ▼') : '';
+        return `<th data-sort-col="${i}"${active ? ' class="stats-sort-active"' : ''}>${col.header}${arrow}</th>`;
+    }).join('');
+
+    const rowsHtml = sorted.map(r => {
+        const filtered = r.visible === false;
+        const cls = filtered ? ' class="stats-row-filtered"' : '';
+        const cells = r.values.map((v, i) => `<td>${filtered ? '-' : columns[i].format(v)}</td>`).join('');
+        return `<tr${cls}>
+            <td data-stat-id="${r.id}"><span class="stat-filter-badge"><span class="wan-badge-dot" style="background-color:${r.color}"></span>${escapeHtml(r.label)}</span></td>
+            ${cells}
+        </tr>`;
+    }).join('');
+
+    el.innerHTML = `<div class="chart-card" style="margin-top:1rem">
+        <div class="chart-header"><h3 class="chart-title">Statistics</h3></div>
+        <div class="table-responsive">
+        <table class="data-table" style="font-size:0.8125rem">
+            <thead><tr>
+                <th>${nameHeader}</th>
+                ${headers}
+            </tr></thead>
+            <tbody>${rowsHtml}</tbody>
+        </table>
+        </div>
+    </div>`;
+
+    const next = el.querySelector('.table-responsive');
+    if (next && scrollLeft) next.scrollLeft = scrollLeft;
+
+    el._lastRenderOpts = opts;
+
+    if (!el._sortDelegated) {
+        el._sortDelegated = true;
+        el.addEventListener('click', (e) => {
+            const th = e.target.closest('th[data-sort-col]');
+            if (!th) return;
+            const col = parseInt(th.dataset.sortCol);
+            if (el._sortCol === col) {
+                el._sortDir = (el._sortDir ?? 'asc') === 'asc' ? 'desc' : 'asc';
+            } else {
+                el._sortCol = col;
+                el._sortDir = 'asc';
+            }
+            if (el._lastRenderOpts) renderStatsTable(el, container, el._lastRenderOpts);
+        });
+    }
+
+    if (filter && !el._filterDelegated) {
+        el._filterDelegated = true;
+        el.addEventListener('click', (e) => {
+            if (e.target.closest('th[data-sort-col]')) return;
+            const td = e.target.closest('[data-stat-id]');
+            if (!td) return;
+            const id = td.dataset.statId;
+            const meta = filter.meta();
+            const key = filter.key;
+            const vis = filter.visibility();
+
+            if (e.ctrlKey || e.metaKey) {
+                vis[id] = vis[id] === false ? undefined : false;
+            } else {
+                const allVis = meta.every(m => vis[m[key]] !== false);
+                const onlyThis = vis[id] !== false
+                    && meta.filter(m => m[key] !== id).every(m => vis[m[key]] === false);
+                if (onlyThis) { filter.resetVisibility(); }
+                else if (allVis) { meta.forEach(m => { vis[m[key]] = m[key] === id; }); }
+                else { vis[id] = vis[id] === false; }
+            }
+            filter.onChanged(container);
+        });
+    }
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
@@ -35,7 +35,7 @@ function baseOpts(height, yTitle, yFormatter, extra) {
             type: 'area', height,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            zoom: { enabled: !matchMedia('(pointer:coarse)').matches, type: 'x', allowMouseWheelZoom: false },
             events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },

--- a/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
@@ -6,6 +6,26 @@ import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 const PALETTE = window.Apex?.colors || ['#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7'];
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
+
+function percentile(sorted, p) {
+    if (sorted.length === 0) return null;
+    const idx = (p / 100) * (sorted.length - 1);
+    const lo = Math.floor(idx);
+    const hi = Math.ceil(idx);
+    if (lo === hi) return sorted[lo];
+    return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+}
+
+function computeStats(values) {
+    if (!values || values.length === 0) return null;
+    const sorted = [...values].sort((a, b) => a - b);
+    return {
+        mean: values.reduce((s, v) => s + v, 0) / values.length,
+        min: sorted[0],
+        max: sorted[sorted.length - 1],
+    };
+}
+
 const POLL_INTERVALS = { 0: 10000, 1: 10000, 6: 15000, 24: 30000, 168: 60000, 720: 60000 };
 const RANGE_MS = { 0: 15*60000, 1: 3600000, 6: 6*3600000, 24: 86400000, 168: 7*86400000, 720: 30*86400000 };
 
@@ -25,6 +45,7 @@ let deviceMeta = [];
 let visibility = {};
 let visibilityObserver = null;
 let isInViewport = true;
+let lastData = null;
 
 function baseOpts(height, yTitle, yFormatter, extra) {
     const base = {
@@ -131,6 +152,7 @@ function renderBadges(container) {
             }
             updateVisibility();
             renderBadges(container);
+            renderStatsTable(container);
         });
     }
 }
@@ -209,8 +231,75 @@ async function loadAndUpdate() {
     if (errorsChart) errorsChart.updateSeries(errorsSeries, false);
 
     updateVisibility();
+    lastData = data;
     const container = document.getElementById(containerId);
-    if (container) renderBadges(container);
+    if (container) {
+        renderBadges(container);
+        renderStatsTable(container);
+    }
+}
+
+function fmtDbmv(v) { return v != null ? v.toFixed(1) : '-'; }
+function fmtDb(v) { return v != null ? v.toFixed(1) : '-'; }
+function fmtInt(v) { return v != null ? Math.round(v).toString() : '-'; }
+
+function renderStatsTable(container) {
+    const el = container.querySelector('.cm-stats-table');
+    if (!el || !lastData?.devices?.length) { if (el) el.innerHTML = ''; return; }
+
+    const visibleDevices = lastData.devices.filter(d => {
+        const meta = deviceMeta.find(dm => dm.id === d.id);
+        return meta && visibility[meta.id] !== false;
+    });
+
+    if (visibleDevices.length === 0) { el.innerHTML = ''; return; }
+
+    const prev = el.querySelector('.table-responsive');
+    const scrollLeft = prev ? prev.scrollLeft : 0;
+
+    const rows = visibleDevices.map(d => {
+        const pts = d.data || [];
+        const dsPowerVals = pts.map(p => p.dsPower).filter(v => v != null);
+        const dsSnrVals = pts.map(p => p.dsSnr).filter(v => v != null);
+        const usPowerVals = pts.map(p => p.usPower).filter(v => v != null);
+        const uncorrVals = pts.map(p => p.uncorrDelta).filter(v => v != null);
+        const corrVals = pts.map(p => p.corrDelta).filter(v => v != null);
+        const dsPower = computeStats(dsPowerVals);
+        const dsSnr = computeStats(dsSnrVals);
+        const usPower = computeStats(usPowerVals);
+        const uncorr = computeStats(uncorrVals);
+        const corr = computeStats(corrVals);
+        const meta = deviceMeta.find(dm => dm.id === d.id);
+        const color = meta?.color || '#9ca3af';
+        return `<tr>
+            <td><span class="wan-badge-dot" style="background-color:${color};display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:6px"></span>${escapeHtml(d.label)}</td>
+            <td>${fmtDbmv(dsPower?.mean)}</td><td>${fmtDbmv(dsPower?.min)}</td><td>${fmtDbmv(dsPower?.max)}</td>
+            <td>${fmtDb(dsSnr?.mean)}</td><td>${fmtDb(dsSnr?.min)}</td><td>${fmtDb(dsSnr?.max)}</td>
+            <td>${fmtDbmv(usPower?.mean)}</td><td>${fmtDbmv(usPower?.min)}</td><td>${fmtDbmv(usPower?.max)}</td>
+            <td>${fmtInt(uncorr?.mean)}</td><td>${fmtInt(uncorr?.max)}</td>
+            <td>${fmtInt(corr?.mean)}</td><td>${fmtInt(corr?.max)}</td>
+        </tr>`;
+    });
+
+    el.innerHTML = `<div class="chart-card" style="margin-top:1rem">
+        <div class="chart-header"><h3 class="chart-title">Statistics</h3></div>
+        <div class="table-responsive">
+        <table class="data-table" style="font-size:0.8125rem">
+            <thead><tr>
+                <th>Device</th>
+                <th>DS Pwr Mean</th><th>DS Pwr Min</th><th>DS Pwr Max</th>
+                <th>DS SNR Mean</th><th>DS SNR Min</th><th>DS SNR Max</th>
+                <th>US Pwr Mean</th><th>US Pwr Min</th><th>US Pwr Max</th>
+                <th>Uncorr Mean</th><th>Uncorr Max</th>
+                <th>Corr Mean</th><th>Corr Max</th>
+            </tr></thead>
+            <tbody>${rows.join('')}</tbody>
+        </table>
+        </div>
+    </div>`;
+
+    const next = el.querySelector('.table-responsive');
+    if (next && scrollLeft) next.scrollLeft = scrollLeft;
 }
 
 function isVisible() { return isInViewport; }
@@ -465,6 +554,7 @@ export function unmount() {
     containerId = null;
     deviceMeta = [];
     visibility = {};
+    lastData = null;
     currentRangeHours = 24;
     windowOffset = 0;
     isCustomRange = false;

--- a/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
@@ -272,7 +272,7 @@ function renderStatsTable(container) {
         const meta = deviceMeta.find(dm => dm.id === d.id);
         const color = meta?.color || '#9ca3af';
         return `<tr>
-            <td><span class="wan-badge-dot" style="background-color:${color};display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:6px"></span>${escapeHtml(d.label)}</td>
+            <td><span class="stat-filter-badge" data-stat-id="${d.id}"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(d.label)}</span></td>
             <td>${fmtDbmv(dsPower?.mean)}</td><td>${fmtDbmv(dsPower?.min)}</td><td>${fmtDbmv(dsPower?.max)}</td>
             <td>${fmtDb(dsSnr?.mean)}</td><td>${fmtDb(dsSnr?.min)}</td><td>${fmtDb(dsSnr?.max)}</td>
             <td>${fmtDbmv(usPower?.mean)}</td><td>${fmtDbmv(usPower?.min)}</td><td>${fmtDbmv(usPower?.max)}</td>
@@ -300,6 +300,28 @@ function renderStatsTable(container) {
 
     const next = el.querySelector('.table-responsive');
     if (next && scrollLeft) next.scrollLeft = scrollLeft;
+
+    if (!el._delegated) {
+        el._delegated = true;
+        el.addEventListener('click', (e) => {
+            const badge = e.target.closest('[data-stat-id]');
+            if (!badge) return;
+            const id = badge.dataset.statId;
+            if (e.ctrlKey || e.metaKey) {
+                visibility[id] = visibility[id] === false ? undefined : false;
+            } else {
+                const allVis = deviceMeta.every(m => visibility[m.id] !== false);
+                const onlyThis = visibility[id] !== false
+                    && deviceMeta.filter(m => m.id !== id).every(m => visibility[m.id] === false);
+                if (onlyThis) { visibility = {}; }
+                else if (allVis) { deviceMeta.forEach(m => visibility[m.id] = m.id === id); }
+                else { visibility[id] = visibility[id] === false; }
+            }
+            updateVisibility();
+            renderBadges(container);
+            renderStatsTable(container);
+        });
+    }
 }
 
 function isVisible() { return isInViewport; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
@@ -2,7 +2,7 @@
 // Same control pattern as cellular-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, initStatsFilter } from './chart-stats.js?v=1';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=2';
 
 const PALETTE = window.Apex?.colors || ['#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7'];
 const _esc = document.createElement('span');
@@ -221,74 +221,40 @@ async function loadAndUpdate() {
     }
 }
 
-function fmtDbmv(v) { return v != null ? v.toFixed(2) : '-'; }
-function fmtDb(v) { return v != null ? v.toFixed(2) : '-'; }
-function fmtInt(v) { return v != null ? Math.round(v).toString() : '-'; }
+const fmtDbmv = v => v != null ? v.toFixed(2) : '-';
+const fmtDb = v => v != null ? v.toFixed(2) : '-';
+const fmtInt = v => v != null ? Math.round(v).toString() : '-';
 
-function renderStatsTable(container) {
+function renderStatsTable(container, showAll) {
     const el = container.querySelector('.cm-stats-table');
     if (!el || !lastData?.devices?.length) { if (el) el.innerHTML = ''; return; }
 
-    const visibleDevices = lastData.devices.filter(d => {
-        const meta = deviceMeta.find(dm => dm.id === d.id);
-        return meta && visibility[meta.id] !== false;
-    });
-
-    if (visibleDevices.length === 0) { el.innerHTML = ''; return; }
-
-    const prev = el.querySelector('.table-responsive');
-    const scrollLeft = prev ? prev.scrollLeft : 0;
-
-    const rows = visibleDevices.map(d => {
+    const rows = lastData.devices.map(d => {
         const pts = d.data || [];
-        const dsPowerVals = pts.map(p => p.dsPower).filter(v => v != null);
-        const dsSnrVals = pts.map(p => p.dsSnr).filter(v => v != null);
-        const usPowerVals = pts.map(p => p.usPower).filter(v => v != null);
-        const uncorrVals = pts.map(p => p.uncorrDelta).filter(v => v != null);
-        const corrVals = pts.map(p => p.corrDelta).filter(v => v != null);
-        const dsPower = computeStats(dsPowerVals);
-        const dsSnr = computeStats(dsSnrVals);
-        const usPower = computeStats(usPowerVals);
-        const uncorr = computeStats(uncorrVals);
-        const corr = computeStats(corrVals);
+        const dsPower = computeStats(pts.map(p => p.dsPower).filter(v => v != null));
+        const dsSnr = computeStats(pts.map(p => p.dsSnr).filter(v => v != null));
+        const usPower = computeStats(pts.map(p => p.usPower).filter(v => v != null));
+        const uncorr = computeStats(pts.map(p => p.uncorrDelta).filter(v => v != null));
+        const corr = computeStats(pts.map(p => p.corrDelta).filter(v => v != null));
         const meta = deviceMeta.find(dm => dm.id === d.id);
-        const color = meta?.color || '#9ca3af';
-        return `<tr>
-            <td data-stat-id="${d.id}"><span class="stat-filter-badge"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(d.label)}</span></td>
-            <td>${fmtDbmv(dsPower?.mean)}</td><td>${fmtDbmv(dsPower?.min)}</td><td>${fmtDbmv(dsPower?.max)}</td>
-            <td>${fmtDb(dsSnr?.mean)}</td><td>${fmtDb(dsSnr?.min)}</td><td>${fmtDb(dsSnr?.max)}</td>
-            <td>${fmtDbmv(usPower?.mean)}</td><td>${fmtDbmv(usPower?.min)}</td><td>${fmtDbmv(usPower?.max)}</td>
-            <td>${fmtInt(uncorr?.mean)}</td><td>${fmtInt(uncorr?.max)}</td>
-            <td>${fmtInt(corr?.mean)}</td><td>${fmtInt(corr?.max)}</td>
-        </tr>`;
+        return { id: d.id, label: d.label, color: meta?.color || '#9ca3af',
+            visible: meta && visibility[meta.id] !== false,
+            values: [dsPower?.mean, dsPower?.min, dsPower?.max, dsSnr?.mean, dsSnr?.min, dsSnr?.max,
+                usPower?.mean, usPower?.min, usPower?.max, uncorr?.mean, uncorr?.max, corr?.mean, corr?.max] };
     });
 
-    el.innerHTML = `<div class="chart-card" style="margin-top:1rem">
-        <div class="chart-header"><h3 class="chart-title">Statistics</h3></div>
-        <div class="table-responsive">
-        <table class="data-table" style="font-size:0.8125rem">
-            <thead><tr>
-                <th>Device</th>
-                <th>DS Pwr Mean</th><th>DS Pwr Min</th><th>DS Pwr Max</th>
-                <th>DS SNR Mean</th><th>DS SNR Min</th><th>DS SNR Max</th>
-                <th>US Pwr Mean</th><th>US Pwr Min</th><th>US Pwr Max</th>
-                <th>Uncorr Mean</th><th>Uncorr Max</th>
-                <th>Corr Mean</th><th>Corr Max</th>
-            </tr></thead>
-            <tbody>${rows.join('')}</tbody>
-        </table>
-        </div>
-    </div>`;
-
-    const next = el.querySelector('.table-responsive');
-    if (next && scrollLeft) next.scrollLeft = scrollLeft;
-
-    initStatsFilter(el, container, {
-        meta: () => deviceMeta,
-        key: 'id',
-        visibility: () => visibility,
-        resetVisibility: () => { visibility = {}; },
-        onChanged: (c) => { updateVisibility(); renderBadges(c); renderStatsTable(c); },
+    renderTable(el, container, {
+        nameHeader: 'Device', rows, showAllRows: showAll,
+        columns: [
+            { header: 'DS Pwr Mean', format: fmtDbmv }, { header: 'DS Pwr Min', format: fmtDbmv }, { header: 'DS Pwr Max', format: fmtDbmv },
+            { header: 'DS SNR Mean', format: fmtDb }, { header: 'DS SNR Min', format: fmtDb }, { header: 'DS SNR Max', format: fmtDb },
+            { header: 'US Pwr Mean', format: fmtDbmv }, { header: 'US Pwr Min', format: fmtDbmv }, { header: 'US Pwr Max', format: fmtDbmv },
+            { header: 'Uncorr Mean', format: fmtInt }, { header: 'Uncorr Max', format: fmtInt },
+            { header: 'Corr Mean', format: fmtInt }, { header: 'Corr Max', format: fmtInt },
+        ],
+        filter: { meta: () => deviceMeta, key: 'id', visibility: () => visibility,
+            resetVisibility: () => { visibility = {}; },
+            onChanged: (c) => { updateVisibility(); renderBadges(c); renderStatsTable(c, true); } },
     });
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
@@ -239,8 +239,8 @@ async function loadAndUpdate() {
     }
 }
 
-function fmtDbmv(v) { return v != null ? v.toFixed(1) : '-'; }
-function fmtDb(v) { return v != null ? v.toFixed(1) : '-'; }
+function fmtDbmv(v) { return v != null ? v.toFixed(2) : '-'; }
+function fmtDb(v) { return v != null ? v.toFixed(2) : '-'; }
 function fmtInt(v) { return v != null ? Math.round(v).toString() : '-'; }
 
 function renderStatsTable(container) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
@@ -2,29 +2,11 @@
 // Same control pattern as cellular-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
+import { computeStats, initStatsFilter } from './chart-stats.js?v=1';
 
 const PALETTE = window.Apex?.colors || ['#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7'];
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
-
-function percentile(sorted, p) {
-    if (sorted.length === 0) return null;
-    const idx = (p / 100) * (sorted.length - 1);
-    const lo = Math.floor(idx);
-    const hi = Math.ceil(idx);
-    if (lo === hi) return sorted[lo];
-    return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
-}
-
-function computeStats(values) {
-    if (!values || values.length === 0) return null;
-    const sorted = [...values].sort((a, b) => a - b);
-    return {
-        mean: values.reduce((s, v) => s + v, 0) / values.length,
-        min: sorted[0],
-        max: sorted[sorted.length - 1],
-    };
-}
 
 const POLL_INTERVALS = { 0: 10000, 1: 10000, 6: 15000, 24: 30000, 168: 60000, 720: 60000 };
 const RANGE_MS = { 0: 15*60000, 1: 3600000, 6: 6*3600000, 24: 86400000, 168: 7*86400000, 720: 30*86400000 };
@@ -272,7 +254,7 @@ function renderStatsTable(container) {
         const meta = deviceMeta.find(dm => dm.id === d.id);
         const color = meta?.color || '#9ca3af';
         return `<tr>
-            <td><span class="stat-filter-badge" data-stat-id="${d.id}"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(d.label)}</span></td>
+            <td data-stat-id="${d.id}"><span class="stat-filter-badge"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(d.label)}</span></td>
             <td>${fmtDbmv(dsPower?.mean)}</td><td>${fmtDbmv(dsPower?.min)}</td><td>${fmtDbmv(dsPower?.max)}</td>
             <td>${fmtDb(dsSnr?.mean)}</td><td>${fmtDb(dsSnr?.min)}</td><td>${fmtDb(dsSnr?.max)}</td>
             <td>${fmtDbmv(usPower?.mean)}</td><td>${fmtDbmv(usPower?.min)}</td><td>${fmtDbmv(usPower?.max)}</td>
@@ -301,27 +283,13 @@ function renderStatsTable(container) {
     const next = el.querySelector('.table-responsive');
     if (next && scrollLeft) next.scrollLeft = scrollLeft;
 
-    if (!el._delegated) {
-        el._delegated = true;
-        el.addEventListener('click', (e) => {
-            const badge = e.target.closest('[data-stat-id]');
-            if (!badge) return;
-            const id = badge.dataset.statId;
-            if (e.ctrlKey || e.metaKey) {
-                visibility[id] = visibility[id] === false ? undefined : false;
-            } else {
-                const allVis = deviceMeta.every(m => visibility[m.id] !== false);
-                const onlyThis = visibility[id] !== false
-                    && deviceMeta.filter(m => m.id !== id).every(m => visibility[m.id] === false);
-                if (onlyThis) { visibility = {}; }
-                else if (allVis) { deviceMeta.forEach(m => visibility[m.id] = m.id === id); }
-                else { visibility[id] = visibility[id] === false; }
-            }
-            updateVisibility();
-            renderBadges(container);
-            renderStatsTable(container);
-        });
-    }
+    initStatsFilter(el, container, {
+        meta: () => deviceMeta,
+        key: 'id',
+        visibility: () => visibility,
+        resetVisibility: () => { visibility = {}; },
+        onChanged: (c) => { updateVisibility(); renderBadges(c); renderStatsTable(c); },
+    });
 }
 
 function isVisible() { return isInViewport; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
@@ -134,7 +134,7 @@ function renderBadges(container) {
             }
             updateVisibility();
             renderBadges(container);
-            renderStatsTable(container);
+            renderStatsTable(container, false);
         });
     }
 }
@@ -496,7 +496,7 @@ export function soloDevice(deviceId) {
     deviceMeta.forEach(m => { visibility[m.id] = m.id === deviceId; });
     updateVisibility();
     const container = document.getElementById(containerId);
-    if (container) renderBadges(container);
+    if (container) { renderBadges(container); renderStatsTable(container, false); }
 }
 
 export function unmount() {

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -21,6 +21,17 @@ function hashColor(id) {
 }
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
+
+function computeStats(values) {
+    if (!values || values.length === 0) return null;
+    const sorted = [...values].sort((a, b) => a - b);
+    return {
+        mean: values.reduce((s, v) => s + v, 0) / values.length,
+        min: sorted[0],
+        max: sorted[sorted.length - 1],
+    };
+}
+
 const POLL_INTERVALS = { 0: 5000, 1: 5000, 6: 10000, 24: 15000, 168: 30000, 720: 30000 };
 const RANGE_MS = { 0: 15*60000, 1: 3600000, 6: 6*3600000, 24: 86400000, 168: 7*86400000, 720: 30*86400000 };
 
@@ -39,6 +50,7 @@ let deviceMeta = [];
 let visibility = {};
 let visibilityObserver = null;
 let isInViewport = true;
+let lastData = null;
 
 function baseOpts(height, yTitle, yFormatter, extra) {
     return {
@@ -134,6 +146,7 @@ function renderBadges(container) {
             }
             updateVisibility();
             renderBadges(container);
+            renderStatsTable(container);
         });
     }
 }
@@ -166,8 +179,65 @@ async function loadAndUpdate() {
     if (cpuChart) cpuChart.updateSeries(makeSeries('cpu'), false);
     if (memChart) memChart.updateSeries(makeSeries('mem'), false);
     updateVisibility();
+    lastData = data;
     const container = document.getElementById(containerId);
-    if (container) renderBadges(container);
+    if (container) {
+        renderBadges(container);
+        renderStatsTable(container);
+    }
+}
+
+function fmtTemp(v) { return v != null ? v.toFixed(1) : '-'; }
+function fmtPct(v) { return v != null ? v.toFixed(1) + '%' : '-'; }
+
+function renderStatsTable(container) {
+    const el = container.querySelector('.health-stats-table');
+    if (!el || !lastData?.devices?.length) { if (el) el.innerHTML = ''; return; }
+
+    const visibleDevices = lastData.devices.filter(d => {
+        const meta = deviceMeta.find(dm => dm.mac === d.mac);
+        return meta && visibility[meta.mac] !== false;
+    });
+
+    if (visibleDevices.length === 0) { el.innerHTML = ''; return; }
+
+    const prev = el.querySelector('.table-responsive');
+    const scrollLeft = prev ? prev.scrollLeft : 0;
+
+    const rows = visibleDevices.map(d => {
+        const pts = d.data || [];
+        const tempVals = pts.map(p => p.temp).filter(v => v != null);
+        const cpuVals = pts.map(p => p.cpu).filter(v => v != null);
+        const memVals = pts.map(p => p.mem).filter(v => v != null);
+        const temp = computeStats(tempVals);
+        const cpu = computeStats(cpuVals);
+        const mem = computeStats(memVals);
+        const color = hashColor(d.name);
+        return `<tr>
+            <td><span class="wan-badge-dot" style="background-color:${color};display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:6px"></span>${escapeHtml(d.name)}</td>
+            <td>${fmtTemp(temp?.mean)}</td><td>${fmtTemp(temp?.min)}</td><td>${fmtTemp(temp?.max)}</td>
+            <td>${fmtPct(cpu?.mean)}</td><td>${fmtPct(cpu?.min)}</td><td>${fmtPct(cpu?.max)}</td>
+            <td>${fmtPct(mem?.mean)}</td><td>${fmtPct(mem?.min)}</td><td>${fmtPct(mem?.max)}</td>
+        </tr>`;
+    });
+
+    el.innerHTML = `<div class="chart-card" style="margin-top:1rem">
+        <div class="chart-header"><h3 class="chart-title">Statistics</h3></div>
+        <div class="table-responsive">
+        <table class="data-table" style="font-size:0.8125rem">
+            <thead><tr>
+                <th>Device</th>
+                <th>Temp Mean</th><th>Temp Min</th><th>Temp Max</th>
+                <th>CPU Mean</th><th>CPU Min</th><th>CPU Max</th>
+                <th>Mem Mean</th><th>Mem Min</th><th>Mem Max</th>
+            </tr></thead>
+            <tbody>${rows.join('')}</tbody>
+        </table>
+        </div>
+    </div>`;
+
+    const next = el.querySelector('.table-responsive');
+    if (next && scrollLeft) next.scrollLeft = scrollLeft;
 }
 
 function isVisible() { return isInViewport; }
@@ -406,6 +476,7 @@ export function unmount() {
     containerId = null;
     deviceMeta = [];
     visibility = {};
+    lastData = null;
     currentRangeHours = 1;
     windowOffset = 0;
     isCustomRange = false;

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -214,7 +214,7 @@ function renderStatsTable(container) {
         const mem = computeStats(memVals);
         const color = hashColor(d.name);
         return `<tr>
-            <td><span class="wan-badge-dot" style="background-color:${color};display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:6px"></span>${escapeHtml(d.name)}</td>
+            <td><span class="stat-filter-badge" data-stat-id="${d.mac}"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(d.name)}</span></td>
             <td>${fmtTemp(temp?.mean)}</td><td>${fmtTemp(temp?.min)}</td><td>${fmtTemp(temp?.max)}</td>
             <td>${fmtPct(cpu?.mean)}</td><td>${fmtPct(cpu?.min)}</td><td>${fmtPct(cpu?.max)}</td>
             <td>${fmtPct(mem?.mean)}</td><td>${fmtPct(mem?.min)}</td><td>${fmtPct(mem?.max)}</td>
@@ -238,6 +238,28 @@ function renderStatsTable(container) {
 
     const next = el.querySelector('.table-responsive');
     if (next && scrollLeft) next.scrollLeft = scrollLeft;
+
+    if (!el._delegated) {
+        el._delegated = true;
+        el.addEventListener('click', (e) => {
+            const badge = e.target.closest('[data-stat-id]');
+            if (!badge) return;
+            const mac = badge.dataset.statId;
+            if (e.ctrlKey || e.metaKey) {
+                visibility[mac] = visibility[mac] === false ? undefined : false;
+            } else {
+                const allVis = deviceMeta.every(d => visibility[d.mac] !== false);
+                const onlyThis = visibility[mac] !== false
+                    && deviceMeta.filter(d => d.mac !== mac).every(d => visibility[d.mac] === false);
+                if (onlyThis) { visibility = {}; }
+                else if (allVis) { deviceMeta.forEach(d => visibility[d.mac] = d.mac === mac); }
+                else { visibility[mac] = visibility[mac] === false; }
+            }
+            updateVisibility();
+            renderBadges(container);
+            renderStatsTable(container);
+        });
+    }
 }
 
 function isVisible() { return isInViewport; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -2,6 +2,7 @@
 // filter badges, poll interval scaling) into a shared module so latency-charts,
 // device-health-charts, and future chart sets share one implementation.
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
+import { computeStats, initStatsFilter } from './chart-stats.js?v=1';
 
 const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
 const _colorCache = {};
@@ -21,16 +22,6 @@ function hashColor(id) {
 }
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
-
-function computeStats(values) {
-    if (!values || values.length === 0) return null;
-    const sorted = [...values].sort((a, b) => a - b);
-    return {
-        mean: values.reduce((s, v) => s + v, 0) / values.length,
-        min: sorted[0],
-        max: sorted[sorted.length - 1],
-    };
-}
 
 const POLL_INTERVALS = { 0: 5000, 1: 5000, 6: 10000, 24: 15000, 168: 30000, 720: 30000 };
 const RANGE_MS = { 0: 15*60000, 1: 3600000, 6: 6*3600000, 24: 86400000, 168: 7*86400000, 720: 30*86400000 };
@@ -214,7 +205,7 @@ function renderStatsTable(container) {
         const mem = computeStats(memVals);
         const color = hashColor(d.name);
         return `<tr>
-            <td><span class="stat-filter-badge" data-stat-id="${d.mac}"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(d.name)}</span></td>
+            <td data-stat-id="${d.mac}"><span class="stat-filter-badge"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(d.name)}</span></td>
             <td>${fmtTemp(temp?.mean)}</td><td>${fmtTemp(temp?.min)}</td><td>${fmtTemp(temp?.max)}</td>
             <td>${fmtPct(cpu?.mean)}</td><td>${fmtPct(cpu?.min)}</td><td>${fmtPct(cpu?.max)}</td>
             <td>${fmtPct(mem?.mean)}</td><td>${fmtPct(mem?.min)}</td><td>${fmtPct(mem?.max)}</td>
@@ -239,27 +230,13 @@ function renderStatsTable(container) {
     const next = el.querySelector('.table-responsive');
     if (next && scrollLeft) next.scrollLeft = scrollLeft;
 
-    if (!el._delegated) {
-        el._delegated = true;
-        el.addEventListener('click', (e) => {
-            const badge = e.target.closest('[data-stat-id]');
-            if (!badge) return;
-            const mac = badge.dataset.statId;
-            if (e.ctrlKey || e.metaKey) {
-                visibility[mac] = visibility[mac] === false ? undefined : false;
-            } else {
-                const allVis = deviceMeta.every(d => visibility[d.mac] !== false);
-                const onlyThis = visibility[mac] !== false
-                    && deviceMeta.filter(d => d.mac !== mac).every(d => visibility[d.mac] === false);
-                if (onlyThis) { visibility = {}; }
-                else if (allVis) { deviceMeta.forEach(d => visibility[d.mac] = d.mac === mac); }
-                else { visibility[mac] = visibility[mac] === false; }
-            }
-            updateVisibility();
-            renderBadges(container);
-            renderStatsTable(container);
-        });
-    }
+    initStatsFilter(el, container, {
+        meta: () => deviceMeta,
+        key: 'mac',
+        visibility: () => visibility,
+        resetVisibility: () => { visibility = {}; },
+        onChanged: (c) => { updateVisibility(); renderBadges(c); renderStatsTable(c); },
+    });
 }
 
 function isVisible() { return isInViewport; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -49,7 +49,7 @@ function baseOpts(height, yTitle, yFormatter, extra) {
             type: 'line', height,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            zoom: { enabled: !matchMedia('(pointer:coarse)').matches, type: 'x', allowMouseWheelZoom: false },
             events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -137,7 +137,7 @@ function renderBadges(container) {
             }
             updateVisibility();
             renderBadges(container);
-            renderStatsTable(container);
+            renderStatsTable(container, false);
         });
     }
 }
@@ -431,7 +431,7 @@ export function soloDevice(mac) {
     deviceMeta.forEach(d => { visibility[d.mac] = d.mac === mac; });
     updateVisibility();
     const container = document.getElementById(containerId);
-    if (container) renderBadges(container);
+    if (container) { renderBadges(container); renderStatsTable(container, false); }
 }
 
 export function unmount() {

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -2,7 +2,7 @@
 // filter badges, poll interval scaling) into a shared module so latency-charts,
 // device-health-charts, and future chart sets share one implementation.
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, initStatsFilter } from './chart-stats.js?v=1';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=2';
 
 const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
 const _colorCache = {};
@@ -178,64 +178,33 @@ async function loadAndUpdate() {
     }
 }
 
-function fmtTemp(v) { return v != null ? v.toFixed(1) : '-'; }
-function fmtPct(v) { return v != null ? v.toFixed(1) + '%' : '-'; }
+const fmtTemp = v => v != null ? v.toFixed(1) : '-';
+const fmtPct = v => v != null ? v.toFixed(1) + '%' : '-';
 
-function renderStatsTable(container) {
+function renderStatsTable(container, showAll) {
     const el = container.querySelector('.health-stats-table');
     if (!el || !lastData?.devices?.length) { if (el) el.innerHTML = ''; return; }
 
-    const visibleDevices = lastData.devices.filter(d => {
-        const meta = deviceMeta.find(dm => dm.mac === d.mac);
-        return meta && visibility[meta.mac] !== false;
-    });
-
-    if (visibleDevices.length === 0) { el.innerHTML = ''; return; }
-
-    const prev = el.querySelector('.table-responsive');
-    const scrollLeft = prev ? prev.scrollLeft : 0;
-
-    const rows = visibleDevices.map(d => {
+    const rows = lastData.devices.map(d => {
         const pts = d.data || [];
-        const tempVals = pts.map(p => p.temp).filter(v => v != null);
-        const cpuVals = pts.map(p => p.cpu).filter(v => v != null);
-        const memVals = pts.map(p => p.mem).filter(v => v != null);
-        const temp = computeStats(tempVals);
-        const cpu = computeStats(cpuVals);
-        const mem = computeStats(memVals);
-        const color = hashColor(d.name);
-        return `<tr>
-            <td data-stat-id="${d.mac}"><span class="stat-filter-badge"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(d.name)}</span></td>
-            <td>${fmtTemp(temp?.mean)}</td><td>${fmtTemp(temp?.min)}</td><td>${fmtTemp(temp?.max)}</td>
-            <td>${fmtPct(cpu?.mean)}</td><td>${fmtPct(cpu?.min)}</td><td>${fmtPct(cpu?.max)}</td>
-            <td>${fmtPct(mem?.mean)}</td><td>${fmtPct(mem?.min)}</td><td>${fmtPct(mem?.max)}</td>
-        </tr>`;
+        const temp = computeStats(pts.map(p => p.temp).filter(v => v != null));
+        const cpu = computeStats(pts.map(p => p.cpu).filter(v => v != null));
+        const mem = computeStats(pts.map(p => p.mem).filter(v => v != null));
+        return { id: d.mac, label: d.name, color: hashColor(d.name),
+            visible: deviceMeta.some(dm => dm.mac === d.mac) && visibility[d.mac] !== false,
+            values: [temp?.mean, temp?.min, temp?.max, cpu?.mean, cpu?.min, cpu?.max, mem?.mean, mem?.min, mem?.max] };
     });
 
-    el.innerHTML = `<div class="chart-card" style="margin-top:1rem">
-        <div class="chart-header"><h3 class="chart-title">Statistics</h3></div>
-        <div class="table-responsive">
-        <table class="data-table" style="font-size:0.8125rem">
-            <thead><tr>
-                <th>Device</th>
-                <th>Temp Mean</th><th>Temp Min</th><th>Temp Max</th>
-                <th>CPU Mean</th><th>CPU Min</th><th>CPU Max</th>
-                <th>Mem Mean</th><th>Mem Min</th><th>Mem Max</th>
-            </tr></thead>
-            <tbody>${rows.join('')}</tbody>
-        </table>
-        </div>
-    </div>`;
-
-    const next = el.querySelector('.table-responsive');
-    if (next && scrollLeft) next.scrollLeft = scrollLeft;
-
-    initStatsFilter(el, container, {
-        meta: () => deviceMeta,
-        key: 'mac',
-        visibility: () => visibility,
-        resetVisibility: () => { visibility = {}; },
-        onChanged: (c) => { updateVisibility(); renderBadges(c); renderStatsTable(c); },
+    renderTable(el, container, {
+        nameHeader: 'Device', rows, showAllRows: showAll,
+        columns: [
+            { header: 'Temp Mean', format: fmtTemp }, { header: 'Temp Min', format: fmtTemp }, { header: 'Temp Max', format: fmtTemp },
+            { header: 'CPU Mean', format: fmtPct }, { header: 'CPU Min', format: fmtPct }, { header: 'CPU Max', format: fmtPct },
+            { header: 'Mem Mean', format: fmtPct }, { header: 'Mem Min', format: fmtPct }, { header: 'Mem Max', format: fmtPct },
+        ],
+        filter: { meta: () => deviceMeta, key: 'mac', visibility: () => visibility,
+            resetVisibility: () => { visibility = {}; },
+            onChanged: (c) => { updateVisibility(); renderBadges(c); renderStatsTable(c, true); } },
     });
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/isp-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/isp-health-charts.js
@@ -20,7 +20,7 @@ function buildOpts() {
             height: 280,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            zoom: { enabled: !matchMedia('(pointer:coarse)').matches, type: 'x', allowMouseWheelZoom: false },
             parentHeightOffset: 0,
             animations: { enabled: false },
             events: {

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -335,7 +335,7 @@ function renderStatsTable(container, data) {
         const meta = targetMeta.find(m => m.id === t.targetId);
         const color = meta?.color || '#9ca3af';
         return `<tr>
-            <td><span class="wan-badge-dot" style="background-color:${color};display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:6px"></span>${escapeHtml(t.name)}</td>
+            <td><span class="stat-filter-badge" data-stat-id="${t.targetId}"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(t.name)}</span></td>
             <td>${fmtRtt(rtt?.mean)}</td><td>${fmtRtt(rtt?.min)}</td><td>${fmtRtt(rtt?.max)}</td><td>${fmtRtt(rtt?.p95)}</td><td>${fmtRtt(rtt?.p99)}</td>
             <td>${fmtLossMean(loss?.mean)}</td><td>${fmtLossMax(loss?.max)}</td>
         </tr>`;
@@ -357,6 +357,28 @@ function renderStatsTable(container, data) {
 
     const next = el.querySelector('.table-responsive');
     if (next && scrollLeft) next.scrollLeft = scrollLeft;
+
+    if (!el._delegated) {
+        el._delegated = true;
+        el.addEventListener('click', (e) => {
+            const badge = e.target.closest('[data-stat-id]');
+            if (!badge) return;
+            const id = badge.dataset.statId;
+            if (e.ctrlKey || e.metaKey) {
+                visibility[id] = visibility[id] === false ? undefined : false;
+            } else {
+                const allVis = targetMeta.every(t => visibility[t.id] !== false);
+                const onlyThis = visibility[id] !== false
+                    && targetMeta.filter(t => t.id !== id).every(t => visibility[t.id] === false);
+                if (onlyThis) { visibility = {}; }
+                else if (allVis) { targetMeta.forEach(t => visibility[t.id] = t.id === id); }
+                else { visibility[id] = visibility[id] === false; }
+            }
+            updateChartVisibility();
+            renderBadges(container);
+            renderStatsTable(container, lastFetchData);
+        });
+    }
 }
 
 function isVisible() { return isInViewport; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -54,7 +54,7 @@ function baseChartOpts(type, yTitle, yFormatter, extraOpts) {
             height: type === 'area' ? 200 : 260,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            zoom: { enabled: !matchMedia('(pointer:coarse)').matches, type: 'x', allowMouseWheelZoom: false },
             events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -324,6 +324,9 @@ function renderStatsTable(container, data) {
 
     if (visibleTargets.length === 0) { el.innerHTML = ''; return; }
 
+    const prev = el.querySelector('.table-responsive');
+    const scrollLeft = prev ? prev.scrollLeft : 0;
+
     const rows = visibleTargets.map((t, i) => {
         const rttVals = (t.rtt || []).map(p => p.value).filter(v => v != null && v > 0);
         const lossVals = (t.loss || []).map(p => p.value).filter(v => v != null);
@@ -351,6 +354,9 @@ function renderStatsTable(container, data) {
         </table>
         </div>
     </div>`;
+
+    const next = el.querySelector('.table-responsive');
+    if (next && scrollLeft) next.scrollLeft = scrollLeft;
 }
 
 function isVisible() { return isInViewport; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -203,7 +203,7 @@ function renderBadges(container) {
 
             updateChartVisibility();
             renderBadges(container);
-            if (lastFetchData) renderStatsTable(container);
+            if (lastFetchData) renderStatsTable(container, false);
         });
     }
 }
@@ -650,7 +650,7 @@ export function soloTarget(targetId) {
     const container = document.getElementById(containerId);
     if (container) {
         renderBadges(container);
-        if (lastFetchData) renderStatsTable(container);
+        if (lastFetchData) renderStatsTable(container, false);
     }
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -5,7 +5,7 @@
 // device-health-charts, and future chart sets share one implementation.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, initStatsFilter } from './chart-stats.js?v=1';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=2';
 
 const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
 const _colorCache = {};
@@ -203,7 +203,7 @@ function renderBadges(container) {
 
             updateChartVisibility();
             renderBadges(container);
-            if (lastFetchData) renderStatsTable(container, lastFetchData);
+            if (lastFetchData) renderStatsTable(container);
         });
     }
 }
@@ -254,7 +254,7 @@ async function loadAndUpdate() {
     const container = document.getElementById(containerId);
     if (container) {
         renderBadges(container);
-        renderStatsTable(container, data);
+        renderStatsTable(container);
     }
 
     // WAN rate chart - show for non-Fabric categories
@@ -294,57 +294,32 @@ function fmtLossColored(v, redAt, orangeAt, yellowAt, lightAt, subtleAt, decimal
 function fmtLossMean(v) { return fmtLossColored(v, 1, 0.2, 0.05, 0.005, 0.0005, 3); }
 function fmtLossMax(v) { return fmtLossColored(v, 5, 2, 0.5, 0.005, 0.005, 2); }
 
-function renderStatsTable(container, data) {
+function renderStatsTable(container, showAll) {
     const el = container.querySelector('.latency-stats-table');
+    const data = lastFetchData;
     if (!el || !data?.targets?.length) { if (el) el.innerHTML = ''; return; }
 
-    const visibleTargets = data.targets.filter((t, i) => {
-        const meta = targetMeta[i];
-        return meta && visibility[meta.id] !== false;
-    });
-
-    if (visibleTargets.length === 0) { el.innerHTML = ''; return; }
-
-    const prev = el.querySelector('.table-responsive');
-    const scrollLeft = prev ? prev.scrollLeft : 0;
-
-    const rows = visibleTargets.map((t, i) => {
+    const rows = data.targets.map(t => {
         const rttVals = (t.rtt || []).map(p => p.value).filter(v => v != null && v > 0);
         const lossVals = (t.loss || []).map(p => p.value).filter(v => v != null);
         const rtt = computeStats(rttVals);
         const loss = computeStats(lossVals);
         const meta = targetMeta.find(m => m.id === t.targetId);
-        const color = meta?.color || '#9ca3af';
-        return `<tr>
-            <td data-stat-id="${t.targetId}"><span class="stat-filter-badge"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(t.name)}</span></td>
-            <td>${fmtRtt(rtt?.mean)}</td><td>${fmtRtt(rtt?.min)}</td><td>${fmtRtt(rtt?.max)}</td><td>${fmtRtt(rtt?.p95)}</td><td>${fmtRtt(rtt?.p99)}</td>
-            <td>${fmtLossMean(loss?.mean)}</td><td>${fmtLossMax(loss?.max)}</td>
-        </tr>`;
+        return { id: t.targetId, label: t.name, color: meta?.color || '#9ca3af',
+            visible: meta && visibility[meta.id] !== false,
+            values: [rtt?.mean, rtt?.min, rtt?.max, rtt?.p95, rtt?.p99, loss?.mean, loss?.max] };
     });
 
-    el.innerHTML = `<div class="chart-card" style="margin-top:1rem">
-        <div class="chart-header"><h3 class="chart-title">Statistics</h3></div>
-        <div class="table-responsive">
-        <table class="data-table" style="font-size:0.8125rem">
-            <thead><tr>
-                <th>Target</th>
-                <th>RTT Mean</th><th>Min</th><th>Max</th><th>P95</th><th>P99</th>
-                <th>Loss Mean</th><th>Loss Max</th>
-            </tr></thead>
-            <tbody>${rows.join('')}</tbody>
-        </table>
-        </div>
-    </div>`;
-
-    const next = el.querySelector('.table-responsive');
-    if (next && scrollLeft) next.scrollLeft = scrollLeft;
-
-    initStatsFilter(el, container, {
-        meta: () => targetMeta,
-        key: 'id',
-        visibility: () => visibility,
-        resetVisibility: () => { visibility = {}; },
-        onChanged: (c) => { updateChartVisibility(); renderBadges(c); renderStatsTable(c, lastFetchData); },
+    renderTable(el, container, {
+        nameHeader: 'Target', rows, showAllRows: showAll,
+        columns: [
+            { header: 'RTT Mean', format: fmtRtt }, { header: 'Min', format: fmtRtt }, { header: 'Max', format: fmtRtt },
+            { header: 'P95', format: fmtRtt }, { header: 'P99', format: fmtRtt },
+            { header: 'Loss Mean', format: fmtLossMean }, { header: 'Loss Max', format: fmtLossMax },
+        ],
+        filter: { meta: () => targetMeta, key: 'id', visibility: () => visibility,
+            resetVisibility: () => { visibility = {}; },
+            onChanged: (c) => { updateChartVisibility(); renderBadges(c); renderStatsTable(c, true); } },
     });
 }
 
@@ -675,7 +650,7 @@ export function soloTarget(targetId) {
     const container = document.getElementById(containerId);
     if (container) {
         renderBadges(container);
-        if (lastFetchData) renderStatsTable(container, lastFetchData);
+        if (lastFetchData) renderStatsTable(container);
     }
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -5,6 +5,7 @@
 // device-health-charts, and future chart sets share one implementation.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
+import { computeStats, initStatsFilter } from './chart-stats.js?v=1';
 
 const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
 const _colorCache = {};
@@ -278,26 +279,6 @@ async function loadAndUpdate() {
     }
 }
 
-function percentile(sorted, p) {
-    if (sorted.length === 0) return null;
-    const idx = (p / 100) * (sorted.length - 1);
-    const lo = Math.floor(idx);
-    const hi = Math.ceil(idx);
-    if (lo === hi) return sorted[lo];
-    return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
-}
-
-function computeStats(values) {
-    if (!values || values.length === 0) return null;
-    const sorted = [...values].sort((a, b) => a - b);
-    return {
-        mean: values.reduce((s, v) => s + v, 0) / values.length,
-        min: sorted[0],
-        max: sorted[sorted.length - 1],
-        p95: percentile(sorted, 95),
-        p99: percentile(sorted, 99),
-    };
-}
 
 function fmtRtt(v) { return v != null ? v.toFixed(3) : '-'; }
 function fmtLossColored(v, redAt, orangeAt, yellowAt, lightAt, subtleAt, decimals) {
@@ -335,7 +316,7 @@ function renderStatsTable(container, data) {
         const meta = targetMeta.find(m => m.id === t.targetId);
         const color = meta?.color || '#9ca3af';
         return `<tr>
-            <td><span class="stat-filter-badge" data-stat-id="${t.targetId}"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(t.name)}</span></td>
+            <td data-stat-id="${t.targetId}"><span class="stat-filter-badge"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(t.name)}</span></td>
             <td>${fmtRtt(rtt?.mean)}</td><td>${fmtRtt(rtt?.min)}</td><td>${fmtRtt(rtt?.max)}</td><td>${fmtRtt(rtt?.p95)}</td><td>${fmtRtt(rtt?.p99)}</td>
             <td>${fmtLossMean(loss?.mean)}</td><td>${fmtLossMax(loss?.max)}</td>
         </tr>`;
@@ -358,27 +339,13 @@ function renderStatsTable(container, data) {
     const next = el.querySelector('.table-responsive');
     if (next && scrollLeft) next.scrollLeft = scrollLeft;
 
-    if (!el._delegated) {
-        el._delegated = true;
-        el.addEventListener('click', (e) => {
-            const badge = e.target.closest('[data-stat-id]');
-            if (!badge) return;
-            const id = badge.dataset.statId;
-            if (e.ctrlKey || e.metaKey) {
-                visibility[id] = visibility[id] === false ? undefined : false;
-            } else {
-                const allVis = targetMeta.every(t => visibility[t.id] !== false);
-                const onlyThis = visibility[id] !== false
-                    && targetMeta.filter(t => t.id !== id).every(t => visibility[t.id] === false);
-                if (onlyThis) { visibility = {}; }
-                else if (allVis) { targetMeta.forEach(t => visibility[t.id] = t.id === id); }
-                else { visibility[id] = visibility[id] === false; }
-            }
-            updateChartVisibility();
-            renderBadges(container);
-            renderStatsTable(container, lastFetchData);
-        });
-    }
+    initStatsFilter(el, container, {
+        meta: () => targetMeta,
+        key: 'id',
+        visibility: () => visibility,
+        resetVisibility: () => { visibility = {}; },
+        onChanged: (c) => { updateChartVisibility(); renderBadges(c); renderStatsTable(c, lastFetchData); },
+    });
 }
 
 function isVisible() { return isInViewport; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
@@ -33,7 +33,7 @@ function baseOpts(height, yTitle, yFormatter, extra) {
             type: 'area', height,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            zoom: { enabled: !matchMedia('(pointer:coarse)').matches, type: 'x', allowMouseWheelZoom: false },
             events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },

--- a/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
@@ -2,7 +2,7 @@
 // Same control pattern as cellular-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, initStatsFilter } from './chart-stats.js?v=1';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=2';
 
 const PALETTE = window.Apex?.colors || ['#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7'];
 const _esc = document.createElement('span');
@@ -203,65 +203,34 @@ async function loadAndUpdate() {
     }
 }
 
-function fmtDbm(v) { return v != null ? v.toFixed(2) : '-'; }
-function fmtTemp(v) { return v != null ? v.toFixed(1) : '-'; }
+const fmtDbm = v => v != null ? v.toFixed(2) : '-';
+const fmtTemp = v => v != null ? v.toFixed(1) : '-';
 
-function renderStatsTable(container) {
+function renderStatsTable(container, showAll) {
     const el = container.querySelector('.ont-stats-table');
     if (!el || !lastData?.devices?.length) { if (el) el.innerHTML = ''; return; }
 
-    const visibleDevices = lastData.devices.filter(d => {
-        const meta = deviceMeta.find(dm => dm.id === d.id);
-        return meta && visibility[meta.id] !== false;
-    });
-
-    if (visibleDevices.length === 0) { el.innerHTML = ''; return; }
-
-    const prev = el.querySelector('.table-responsive');
-    const scrollLeft = prev ? prev.scrollLeft : 0;
-
-    const rows = visibleDevices.map(d => {
+    const rows = lastData.devices.map(d => {
         const pts = d.data || [];
-        const rxVals = pts.map(p => p.rx).filter(v => v != null);
-        const txVals = pts.map(p => p.tx).filter(v => v != null);
-        const tempVals = pts.map(p => p.temp).filter(v => v != null);
-        const rx = computeStats(rxVals);
-        const tx = computeStats(txVals);
-        const temp = computeStats(tempVals);
+        const rx = computeStats(pts.map(p => p.rx).filter(v => v != null));
+        const tx = computeStats(pts.map(p => p.tx).filter(v => v != null));
+        const temp = computeStats(pts.map(p => p.temp).filter(v => v != null));
         const meta = deviceMeta.find(dm => dm.id === d.id);
-        const color = meta?.color || '#9ca3af';
-        return `<tr>
-            <td data-stat-id="${d.id}"><span class="stat-filter-badge"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(d.label)}</span></td>
-            <td>${fmtDbm(rx?.mean)}</td><td>${fmtDbm(rx?.min)}</td><td>${fmtDbm(rx?.max)}</td>
-            <td>${fmtDbm(tx?.mean)}</td><td>${fmtDbm(tx?.min)}</td><td>${fmtDbm(tx?.max)}</td>
-            <td>${fmtTemp(temp?.mean)}</td><td>${fmtTemp(temp?.min)}</td><td>${fmtTemp(temp?.max)}</td>
-        </tr>`;
+        return { id: d.id, label: d.label, color: meta?.color || '#9ca3af',
+            visible: meta && visibility[meta.id] !== false,
+            values: [rx?.mean, rx?.min, rx?.max, tx?.mean, tx?.min, tx?.max, temp?.mean, temp?.min, temp?.max] };
     });
 
-    el.innerHTML = `<div class="chart-card" style="margin-top:1rem">
-        <div class="chart-header"><h3 class="chart-title">Statistics</h3></div>
-        <div class="table-responsive">
-        <table class="data-table" style="font-size:0.8125rem">
-            <thead><tr>
-                <th>Device</th>
-                <th>RX Mean</th><th>RX Min</th><th>RX Max</th>
-                <th>TX Mean</th><th>TX Min</th><th>TX Max</th>
-                <th>Temp Mean</th><th>Temp Min</th><th>Temp Max</th>
-            </tr></thead>
-            <tbody>${rows.join('')}</tbody>
-        </table>
-        </div>
-    </div>`;
-
-    const next = el.querySelector('.table-responsive');
-    if (next && scrollLeft) next.scrollLeft = scrollLeft;
-
-    initStatsFilter(el, container, {
-        meta: () => deviceMeta,
-        key: 'id',
-        visibility: () => visibility,
-        resetVisibility: () => { visibility = {}; },
-        onChanged: (c) => { updateVisibility(); renderBadges(c); renderStatsTable(c); },
+    renderTable(el, container, {
+        nameHeader: 'Device', rows, showAllRows: showAll,
+        columns: [
+            { header: 'RX Mean', format: fmtDbm }, { header: 'RX Min', format: fmtDbm }, { header: 'RX Max', format: fmtDbm },
+            { header: 'TX Mean', format: fmtDbm }, { header: 'TX Min', format: fmtDbm }, { header: 'TX Max', format: fmtDbm },
+            { header: 'Temp Mean', format: fmtTemp }, { header: 'Temp Min', format: fmtTemp }, { header: 'Temp Max', format: fmtTemp },
+        ],
+        filter: { meta: () => deviceMeta, key: 'id', visibility: () => visibility,
+            resetVisibility: () => { visibility = {}; },
+            onChanged: (c) => { updateVisibility(); renderBadges(c); renderStatsTable(c, true); } },
     });
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
@@ -6,6 +6,26 @@ import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 const PALETTE = window.Apex?.colors || ['#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7'];
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
+
+function percentile(sorted, p) {
+    if (sorted.length === 0) return null;
+    const idx = (p / 100) * (sorted.length - 1);
+    const lo = Math.floor(idx);
+    const hi = Math.ceil(idx);
+    if (lo === hi) return sorted[lo];
+    return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+}
+
+function computeStats(values) {
+    if (!values || values.length === 0) return null;
+    const sorted = [...values].sort((a, b) => a - b);
+    return {
+        mean: values.reduce((s, v) => s + v, 0) / values.length,
+        min: sorted[0],
+        max: sorted[sorted.length - 1],
+    };
+}
+
 const POLL_INTERVALS = { 0: 10000, 1: 10000, 6: 15000, 24: 30000, 168: 60000, 720: 60000 };
 const RANGE_MS = { 0: 15*60000, 1: 3600000, 6: 6*3600000, 24: 86400000, 168: 7*86400000, 720: 30*86400000 };
 
@@ -23,6 +43,7 @@ let deviceMeta = [];
 let visibility = {};
 let visibilityObserver = null;
 let isInViewport = true;
+let lastData = null;
 
 function baseOpts(height, yTitle, yFormatter, extra) {
     const base = {
@@ -127,6 +148,7 @@ function renderBadges(container) {
             }
             updateVisibility();
             renderBadges(container);
+            renderStatsTable(container);
         });
     }
 }
@@ -191,8 +213,66 @@ async function loadAndUpdate() {
     if (tempChart) tempChart.updateSeries(tempSeries, false);
 
     updateVisibility();
+    lastData = data;
     const container = document.getElementById(containerId);
-    if (container) renderBadges(container);
+    if (container) {
+        renderBadges(container);
+        renderStatsTable(container);
+    }
+}
+
+function fmtDbm(v) { return v != null ? v.toFixed(1) : '-'; }
+function fmtTemp(v) { return v != null ? v.toFixed(1) : '-'; }
+
+function renderStatsTable(container) {
+    const el = container.querySelector('.ont-stats-table');
+    if (!el || !lastData?.devices?.length) { if (el) el.innerHTML = ''; return; }
+
+    const visibleDevices = lastData.devices.filter(d => {
+        const meta = deviceMeta.find(dm => dm.id === d.id);
+        return meta && visibility[meta.id] !== false;
+    });
+
+    if (visibleDevices.length === 0) { el.innerHTML = ''; return; }
+
+    const prev = el.querySelector('.table-responsive');
+    const scrollLeft = prev ? prev.scrollLeft : 0;
+
+    const rows = visibleDevices.map(d => {
+        const pts = d.data || [];
+        const rxVals = pts.map(p => p.rx).filter(v => v != null);
+        const txVals = pts.map(p => p.tx).filter(v => v != null);
+        const tempVals = pts.map(p => p.temp).filter(v => v != null);
+        const rx = computeStats(rxVals);
+        const tx = computeStats(txVals);
+        const temp = computeStats(tempVals);
+        const meta = deviceMeta.find(dm => dm.id === d.id);
+        const color = meta?.color || '#9ca3af';
+        return `<tr>
+            <td><span class="wan-badge-dot" style="background-color:${color};display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:6px"></span>${escapeHtml(d.label)}</td>
+            <td>${fmtDbm(rx?.mean)}</td><td>${fmtDbm(rx?.min)}</td><td>${fmtDbm(rx?.max)}</td>
+            <td>${fmtDbm(tx?.mean)}</td><td>${fmtDbm(tx?.min)}</td><td>${fmtDbm(tx?.max)}</td>
+            <td>${fmtTemp(temp?.mean)}</td><td>${fmtTemp(temp?.min)}</td><td>${fmtTemp(temp?.max)}</td>
+        </tr>`;
+    });
+
+    el.innerHTML = `<div class="chart-card" style="margin-top:1rem">
+        <div class="chart-header"><h3 class="chart-title">Statistics</h3></div>
+        <div class="table-responsive">
+        <table class="data-table" style="font-size:0.8125rem">
+            <thead><tr>
+                <th>Device</th>
+                <th>RX Mean</th><th>RX Min</th><th>RX Max</th>
+                <th>TX Mean</th><th>TX Min</th><th>TX Max</th>
+                <th>Temp Mean</th><th>Temp Min</th><th>Temp Max</th>
+            </tr></thead>
+            <tbody>${rows.join('')}</tbody>
+        </table>
+        </div>
+    </div>`;
+
+    const next = el.querySelector('.table-responsive');
+    if (next && scrollLeft) next.scrollLeft = scrollLeft;
 }
 
 function isVisible() { return isInViewport; }
@@ -429,6 +509,7 @@ export function unmount() {
     containerId = null;
     deviceMeta = [];
     visibility = {};
+    lastData = null;
     currentRangeHours = 24;
     windowOffset = 0;
     isCustomRange = false;

--- a/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
@@ -221,7 +221,7 @@ async function loadAndUpdate() {
     }
 }
 
-function fmtDbm(v) { return v != null ? v.toFixed(1) : '-'; }
+function fmtDbm(v) { return v != null ? v.toFixed(2) : '-'; }
 function fmtTemp(v) { return v != null ? v.toFixed(1) : '-'; }
 
 function renderStatsTable(container) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
@@ -249,7 +249,7 @@ function renderStatsTable(container) {
         const meta = deviceMeta.find(dm => dm.id === d.id);
         const color = meta?.color || '#9ca3af';
         return `<tr>
-            <td><span class="wan-badge-dot" style="background-color:${color};display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:6px"></span>${escapeHtml(d.label)}</td>
+            <td><span class="stat-filter-badge" data-stat-id="${d.id}"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(d.label)}</span></td>
             <td>${fmtDbm(rx?.mean)}</td><td>${fmtDbm(rx?.min)}</td><td>${fmtDbm(rx?.max)}</td>
             <td>${fmtDbm(tx?.mean)}</td><td>${fmtDbm(tx?.min)}</td><td>${fmtDbm(tx?.max)}</td>
             <td>${fmtTemp(temp?.mean)}</td><td>${fmtTemp(temp?.min)}</td><td>${fmtTemp(temp?.max)}</td>
@@ -273,6 +273,28 @@ function renderStatsTable(container) {
 
     const next = el.querySelector('.table-responsive');
     if (next && scrollLeft) next.scrollLeft = scrollLeft;
+
+    if (!el._delegated) {
+        el._delegated = true;
+        el.addEventListener('click', (e) => {
+            const badge = e.target.closest('[data-stat-id]');
+            if (!badge) return;
+            const id = badge.dataset.statId;
+            if (e.ctrlKey || e.metaKey) {
+                visibility[id] = visibility[id] === false ? undefined : false;
+            } else {
+                const allVis = deviceMeta.every(m => visibility[m.id] !== false);
+                const onlyThis = visibility[id] !== false
+                    && deviceMeta.filter(m => m.id !== id).every(m => visibility[m.id] === false);
+                if (onlyThis) { visibility = {}; }
+                else if (allVis) { deviceMeta.forEach(m => visibility[m.id] = m.id === id); }
+                else { visibility[id] = visibility[id] === false; }
+            }
+            updateVisibility();
+            renderBadges(container);
+            renderStatsTable(container);
+        });
+    }
 }
 
 function isVisible() { return isInViewport; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
@@ -130,7 +130,7 @@ function renderBadges(container) {
             }
             updateVisibility();
             renderBadges(container);
-            renderStatsTable(container);
+            renderStatsTable(container, false);
         });
     }
 }
@@ -456,7 +456,7 @@ export function soloDevice(deviceId) {
     deviceMeta.forEach(m => { visibility[m.id] = m.id === deviceId; });
     updateVisibility();
     const container = document.getElementById(containerId);
-    if (container) renderBadges(container);
+    if (container) { renderBadges(container); renderStatsTable(container, false); }
 }
 
 export function unmount() {

--- a/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
@@ -2,29 +2,11 @@
 // Same control pattern as cellular-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
+import { computeStats, initStatsFilter } from './chart-stats.js?v=1';
 
 const PALETTE = window.Apex?.colors || ['#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7'];
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
-
-function percentile(sorted, p) {
-    if (sorted.length === 0) return null;
-    const idx = (p / 100) * (sorted.length - 1);
-    const lo = Math.floor(idx);
-    const hi = Math.ceil(idx);
-    if (lo === hi) return sorted[lo];
-    return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
-}
-
-function computeStats(values) {
-    if (!values || values.length === 0) return null;
-    const sorted = [...values].sort((a, b) => a - b);
-    return {
-        mean: values.reduce((s, v) => s + v, 0) / values.length,
-        min: sorted[0],
-        max: sorted[sorted.length - 1],
-    };
-}
 
 const POLL_INTERVALS = { 0: 10000, 1: 10000, 6: 15000, 24: 30000, 168: 60000, 720: 60000 };
 const RANGE_MS = { 0: 15*60000, 1: 3600000, 6: 6*3600000, 24: 86400000, 168: 7*86400000, 720: 30*86400000 };
@@ -249,7 +231,7 @@ function renderStatsTable(container) {
         const meta = deviceMeta.find(dm => dm.id === d.id);
         const color = meta?.color || '#9ca3af';
         return `<tr>
-            <td><span class="stat-filter-badge" data-stat-id="${d.id}"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(d.label)}</span></td>
+            <td data-stat-id="${d.id}"><span class="stat-filter-badge"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(d.label)}</span></td>
             <td>${fmtDbm(rx?.mean)}</td><td>${fmtDbm(rx?.min)}</td><td>${fmtDbm(rx?.max)}</td>
             <td>${fmtDbm(tx?.mean)}</td><td>${fmtDbm(tx?.min)}</td><td>${fmtDbm(tx?.max)}</td>
             <td>${fmtTemp(temp?.mean)}</td><td>${fmtTemp(temp?.min)}</td><td>${fmtTemp(temp?.max)}</td>
@@ -274,27 +256,13 @@ function renderStatsTable(container) {
     const next = el.querySelector('.table-responsive');
     if (next && scrollLeft) next.scrollLeft = scrollLeft;
 
-    if (!el._delegated) {
-        el._delegated = true;
-        el.addEventListener('click', (e) => {
-            const badge = e.target.closest('[data-stat-id]');
-            if (!badge) return;
-            const id = badge.dataset.statId;
-            if (e.ctrlKey || e.metaKey) {
-                visibility[id] = visibility[id] === false ? undefined : false;
-            } else {
-                const allVis = deviceMeta.every(m => visibility[m.id] !== false);
-                const onlyThis = visibility[id] !== false
-                    && deviceMeta.filter(m => m.id !== id).every(m => visibility[m.id] === false);
-                if (onlyThis) { visibility = {}; }
-                else if (allVis) { deviceMeta.forEach(m => visibility[m.id] = m.id === id); }
-                else { visibility[id] = visibility[id] === false; }
-            }
-            updateVisibility();
-            renderBadges(container);
-            renderStatsTable(container);
-        });
-    }
+    initStatsFilter(el, container, {
+        meta: () => deviceMeta,
+        key: 'id',
+        visibility: () => visibility,
+        resetVisibility: () => { visibility = {}; },
+        onChanged: (c) => { updateVisibility(); renderBadges(c); renderStatsTable(c); },
+    });
 }
 
 function isVisible() { return isInViewport; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -214,7 +214,7 @@ async function loadAndUpdate() {
     }
 }
 
-function fmtDbm(v) { return v != null ? v.toFixed(1) : '-'; }
+function fmtDbm(v) { return v != null ? v.toFixed(2) : '-'; }
 function fmtTemp(v) { return v != null ? v.toFixed(1) : '-'; }
 
 function renderStatsTable(container) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -6,6 +6,26 @@ import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
+
+function percentile(sorted, p) {
+    if (sorted.length === 0) return null;
+    const idx = (p / 100) * (sorted.length - 1);
+    const lo = Math.floor(idx);
+    const hi = Math.ceil(idx);
+    if (lo === hi) return sorted[lo];
+    return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+}
+
+function computeStats(values) {
+    if (!values || values.length === 0) return null;
+    const sorted = [...values].sort((a, b) => a - b);
+    return {
+        mean: values.reduce((s, v) => s + v, 0) / values.length,
+        min: sorted[0],
+        max: sorted[sorted.length - 1],
+    };
+}
+
 const POLL_INTERVALS = { 0: 10000, 1: 10000, 6: 15000, 24: 30000, 168: 60000, 720: 60000 };
 const RANGE_MS = { 0: 15*60000, 1: 3600000, 6: 6*3600000, 24: 86400000, 168: 7*86400000, 720: 30*86400000 };
 
@@ -23,6 +43,7 @@ let moduleMeta = [];
 let visibility = {};
 let visibilityObserver = null;
 let isInViewport = true;
+let lastData = null;
 
 function baseOpts(height, yTitle, yFormatter, extra) {
     const base = {
@@ -128,6 +149,7 @@ function renderBadges(container) {
             }
             updateVisibility();
             renderBadges(container);
+            renderStatsTable(container);
         });
     }
 }
@@ -184,8 +206,66 @@ async function loadAndUpdate() {
     if (tempChart) tempChart.updateSeries(tSeries, false);
 
     updateVisibility();
+    lastData = data;
     const container = document.getElementById(containerId);
-    if (container) renderBadges(container);
+    if (container) {
+        renderBadges(container);
+        renderStatsTable(container);
+    }
+}
+
+function fmtDbm(v) { return v != null ? v.toFixed(1) : '-'; }
+function fmtTemp(v) { return v != null ? v.toFixed(1) : '-'; }
+
+function renderStatsTable(container) {
+    const el = container.querySelector('.sfp-stats-table');
+    if (!el || !lastData?.modules?.length) { if (el) el.innerHTML = ''; return; }
+
+    const visibleModules = lastData.modules.filter(m => {
+        const meta = moduleMeta.find(mm => mm.id === m.id);
+        return meta && visibility[meta.id] !== false;
+    });
+
+    if (visibleModules.length === 0) { el.innerHTML = ''; return; }
+
+    const prev = el.querySelector('.table-responsive');
+    const scrollLeft = prev ? prev.scrollLeft : 0;
+
+    const rows = visibleModules.map(m => {
+        const pts = m.data || [];
+        const rxVals = pts.map(p => p.rx).filter(v => v != null);
+        const txVals = pts.map(p => p.tx).filter(v => v != null);
+        const tempVals = pts.map(p => p.temp).filter(v => v != null);
+        const rx = computeStats(rxVals);
+        const tx = computeStats(txVals);
+        const temp = computeStats(tempVals);
+        const meta = moduleMeta.find(mm => mm.id === m.id);
+        const color = meta?.color || '#9ca3af';
+        return `<tr>
+            <td><span class="wan-badge-dot" style="background-color:${color};display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:6px"></span>${escapeHtml(m.label)}</td>
+            <td>${fmtDbm(rx?.mean)}</td><td>${fmtDbm(rx?.min)}</td><td>${fmtDbm(rx?.max)}</td>
+            <td>${fmtDbm(tx?.mean)}</td><td>${fmtDbm(tx?.min)}</td><td>${fmtDbm(tx?.max)}</td>
+            <td>${fmtTemp(temp?.mean)}</td><td>${fmtTemp(temp?.min)}</td><td>${fmtTemp(temp?.max)}</td>
+        </tr>`;
+    });
+
+    el.innerHTML = `<div class="chart-card" style="margin-top:1rem">
+        <div class="chart-header"><h3 class="chart-title">Statistics</h3></div>
+        <div class="table-responsive">
+        <table class="data-table" style="font-size:0.8125rem">
+            <thead><tr>
+                <th>Module</th>
+                <th>RX Mean</th><th>RX Min</th><th>RX Max</th>
+                <th>TX Mean</th><th>TX Min</th><th>TX Max</th>
+                <th>Temp Mean</th><th>Temp Min</th><th>Temp Max</th>
+            </tr></thead>
+            <tbody>${rows.join('')}</tbody>
+        </table>
+        </div>
+    </div>`;
+
+    const next = el.querySelector('.table-responsive');
+    if (next && scrollLeft) next.scrollLeft = scrollLeft;
 }
 
 function isVisible() { return isInViewport; }
@@ -433,6 +513,7 @@ export function unmount() {
     containerId = null;
     moduleMeta = [];
     visibility = {};
+    lastData = null;
     currentRangeHours = 24;
     windowOffset = 0;
     isCustomRange = false;

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -131,7 +131,7 @@ function renderBadges(container) {
             }
             updateVisibility();
             renderBadges(container);
-            renderStatsTable(container);
+            renderStatsTable(container, false);
         });
     }
 }
@@ -460,7 +460,7 @@ export function soloModule(id) {
     moduleMeta.forEach(m => { visibility[m.id] = m.id === id; });
     updateVisibility();
     const container = document.getElementById(containerId);
-    if (container) renderBadges(container);
+    if (container) { renderBadges(container); renderStatsTable(container, false); }
 }
 
 export function unmount() {

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -33,7 +33,7 @@ function baseOpts(height, yTitle, yFormatter, extra) {
             type: 'area', height,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: true, type: 'x', allowMouseWheelZoom: false },
+            zoom: { enabled: !matchMedia('(pointer:coarse)').matches, type: 'x', allowMouseWheelZoom: false },
             events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
             animations: { enabled: false },
         },

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -2,7 +2,7 @@
 // Same control pattern as latency-charts.js and device-health-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, initStatsFilter } from './chart-stats.js?v=1';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=2';
 
 const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
 const _esc = document.createElement('span');
@@ -196,65 +196,34 @@ async function loadAndUpdate() {
     }
 }
 
-function fmtDbm(v) { return v != null ? v.toFixed(2) : '-'; }
-function fmtTemp(v) { return v != null ? v.toFixed(1) : '-'; }
+const fmtDbm = v => v != null ? v.toFixed(2) : '-';
+const fmtTemp = v => v != null ? v.toFixed(1) : '-';
 
-function renderStatsTable(container) {
+function renderStatsTable(container, showAll) {
     const el = container.querySelector('.sfp-stats-table');
     if (!el || !lastData?.modules?.length) { if (el) el.innerHTML = ''; return; }
 
-    const visibleModules = lastData.modules.filter(m => {
-        const meta = moduleMeta.find(mm => mm.id === m.id);
-        return meta && visibility[meta.id] !== false;
-    });
-
-    if (visibleModules.length === 0) { el.innerHTML = ''; return; }
-
-    const prev = el.querySelector('.table-responsive');
-    const scrollLeft = prev ? prev.scrollLeft : 0;
-
-    const rows = visibleModules.map(m => {
+    const rows = lastData.modules.map(m => {
         const pts = m.data || [];
-        const rxVals = pts.map(p => p.rx).filter(v => v != null);
-        const txVals = pts.map(p => p.tx).filter(v => v != null);
-        const tempVals = pts.map(p => p.temp).filter(v => v != null);
-        const rx = computeStats(rxVals);
-        const tx = computeStats(txVals);
-        const temp = computeStats(tempVals);
+        const rx = computeStats(pts.map(p => p.rx).filter(v => v != null));
+        const tx = computeStats(pts.map(p => p.tx).filter(v => v != null));
+        const temp = computeStats(pts.map(p => p.temp).filter(v => v != null));
         const meta = moduleMeta.find(mm => mm.id === m.id);
-        const color = meta?.color || '#9ca3af';
-        return `<tr>
-            <td data-stat-id="${m.id}"><span class="stat-filter-badge"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(m.label)}</span></td>
-            <td>${fmtDbm(rx?.mean)}</td><td>${fmtDbm(rx?.min)}</td><td>${fmtDbm(rx?.max)}</td>
-            <td>${fmtDbm(tx?.mean)}</td><td>${fmtDbm(tx?.min)}</td><td>${fmtDbm(tx?.max)}</td>
-            <td>${fmtTemp(temp?.mean)}</td><td>${fmtTemp(temp?.min)}</td><td>${fmtTemp(temp?.max)}</td>
-        </tr>`;
+        return { id: m.id, label: m.label, color: meta?.color || '#9ca3af',
+            visible: meta && visibility[meta.id] !== false,
+            values: [rx?.mean, rx?.min, rx?.max, tx?.mean, tx?.min, tx?.max, temp?.mean, temp?.min, temp?.max] };
     });
 
-    el.innerHTML = `<div class="chart-card" style="margin-top:1rem">
-        <div class="chart-header"><h3 class="chart-title">Statistics</h3></div>
-        <div class="table-responsive">
-        <table class="data-table" style="font-size:0.8125rem">
-            <thead><tr>
-                <th>Module</th>
-                <th>RX Mean</th><th>RX Min</th><th>RX Max</th>
-                <th>TX Mean</th><th>TX Min</th><th>TX Max</th>
-                <th>Temp Mean</th><th>Temp Min</th><th>Temp Max</th>
-            </tr></thead>
-            <tbody>${rows.join('')}</tbody>
-        </table>
-        </div>
-    </div>`;
-
-    const next = el.querySelector('.table-responsive');
-    if (next && scrollLeft) next.scrollLeft = scrollLeft;
-
-    initStatsFilter(el, container, {
-        meta: () => moduleMeta,
-        key: 'id',
-        visibility: () => visibility,
-        resetVisibility: () => { visibility = {}; },
-        onChanged: (c) => { updateVisibility(); renderBadges(c); renderStatsTable(c); },
+    renderTable(el, container, {
+        nameHeader: 'Module', rows, showAllRows: showAll,
+        columns: [
+            { header: 'RX Mean', format: fmtDbm }, { header: 'RX Min', format: fmtDbm }, { header: 'RX Max', format: fmtDbm },
+            { header: 'TX Mean', format: fmtDbm }, { header: 'TX Min', format: fmtDbm }, { header: 'TX Max', format: fmtDbm },
+            { header: 'Temp Mean', format: fmtTemp }, { header: 'Temp Min', format: fmtTemp }, { header: 'Temp Max', format: fmtTemp },
+        ],
+        filter: { meta: () => moduleMeta, key: 'id', visibility: () => visibility,
+            resetVisibility: () => { visibility = {}; },
+            onChanged: (c) => { updateVisibility(); renderBadges(c); renderStatsTable(c, true); } },
     });
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -2,29 +2,11 @@
 // Same control pattern as latency-charts.js and device-health-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
+import { computeStats, initStatsFilter } from './chart-stats.js?v=1';
 
 const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
-
-function percentile(sorted, p) {
-    if (sorted.length === 0) return null;
-    const idx = (p / 100) * (sorted.length - 1);
-    const lo = Math.floor(idx);
-    const hi = Math.ceil(idx);
-    if (lo === hi) return sorted[lo];
-    return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
-}
-
-function computeStats(values) {
-    if (!values || values.length === 0) return null;
-    const sorted = [...values].sort((a, b) => a - b);
-    return {
-        mean: values.reduce((s, v) => s + v, 0) / values.length,
-        min: sorted[0],
-        max: sorted[sorted.length - 1],
-    };
-}
 
 const POLL_INTERVALS = { 0: 10000, 1: 10000, 6: 15000, 24: 30000, 168: 60000, 720: 60000 };
 const RANGE_MS = { 0: 15*60000, 1: 3600000, 6: 6*3600000, 24: 86400000, 168: 7*86400000, 720: 30*86400000 };
@@ -242,7 +224,7 @@ function renderStatsTable(container) {
         const meta = moduleMeta.find(mm => mm.id === m.id);
         const color = meta?.color || '#9ca3af';
         return `<tr>
-            <td><span class="stat-filter-badge" data-stat-id="${m.id}"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(m.label)}</span></td>
+            <td data-stat-id="${m.id}"><span class="stat-filter-badge"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(m.label)}</span></td>
             <td>${fmtDbm(rx?.mean)}</td><td>${fmtDbm(rx?.min)}</td><td>${fmtDbm(rx?.max)}</td>
             <td>${fmtDbm(tx?.mean)}</td><td>${fmtDbm(tx?.min)}</td><td>${fmtDbm(tx?.max)}</td>
             <td>${fmtTemp(temp?.mean)}</td><td>${fmtTemp(temp?.min)}</td><td>${fmtTemp(temp?.max)}</td>
@@ -267,27 +249,13 @@ function renderStatsTable(container) {
     const next = el.querySelector('.table-responsive');
     if (next && scrollLeft) next.scrollLeft = scrollLeft;
 
-    if (!el._delegated) {
-        el._delegated = true;
-        el.addEventListener('click', (e) => {
-            const badge = e.target.closest('[data-stat-id]');
-            if (!badge) return;
-            const id = badge.dataset.statId;
-            if (e.ctrlKey || e.metaKey) {
-                visibility[id] = visibility[id] === false ? undefined : false;
-            } else {
-                const allVis = moduleMeta.every(m => visibility[m.id] !== false);
-                const onlyThis = visibility[id] !== false
-                    && moduleMeta.filter(m => m.id !== id).every(m => visibility[m.id] === false);
-                if (onlyThis) { visibility = {}; }
-                else if (allVis) { moduleMeta.forEach(m => visibility[m.id] = m.id === id); }
-                else { visibility[id] = visibility[id] === false; }
-            }
-            updateVisibility();
-            renderBadges(container);
-            renderStatsTable(container);
-        });
-    }
+    initStatsFilter(el, container, {
+        meta: () => moduleMeta,
+        key: 'id',
+        visibility: () => visibility,
+        resetVisibility: () => { visibility = {}; },
+        onChanged: (c) => { updateVisibility(); renderBadges(c); renderStatsTable(c); },
+    });
 }
 
 function isVisible() { return isInViewport; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -242,7 +242,7 @@ function renderStatsTable(container) {
         const meta = moduleMeta.find(mm => mm.id === m.id);
         const color = meta?.color || '#9ca3af';
         return `<tr>
-            <td><span class="wan-badge-dot" style="background-color:${color};display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:6px"></span>${escapeHtml(m.label)}</td>
+            <td><span class="stat-filter-badge" data-stat-id="${m.id}"><span class="wan-badge-dot" style="background-color:${color}"></span>${escapeHtml(m.label)}</span></td>
             <td>${fmtDbm(rx?.mean)}</td><td>${fmtDbm(rx?.min)}</td><td>${fmtDbm(rx?.max)}</td>
             <td>${fmtDbm(tx?.mean)}</td><td>${fmtDbm(tx?.min)}</td><td>${fmtDbm(tx?.max)}</td>
             <td>${fmtTemp(temp?.mean)}</td><td>${fmtTemp(temp?.min)}</td><td>${fmtTemp(temp?.max)}</td>
@@ -266,6 +266,28 @@ function renderStatsTable(container) {
 
     const next = el.querySelector('.table-responsive');
     if (next && scrollLeft) next.scrollLeft = scrollLeft;
+
+    if (!el._delegated) {
+        el._delegated = true;
+        el.addEventListener('click', (e) => {
+            const badge = e.target.closest('[data-stat-id]');
+            if (!badge) return;
+            const id = badge.dataset.statId;
+            if (e.ctrlKey || e.metaKey) {
+                visibility[id] = visibility[id] === false ? undefined : false;
+            } else {
+                const allVis = moduleMeta.every(m => visibility[m.id] !== false);
+                const onlyThis = visibility[id] !== false
+                    && moduleMeta.filter(m => m.id !== id).every(m => visibility[m.id] === false);
+                if (onlyThis) { visibility = {}; }
+                else if (allVis) { moduleMeta.forEach(m => visibility[m.id] = m.id === id); }
+                else { visibility[id] = visibility[id] === false; }
+            }
+            updateVisibility();
+            renderBadges(container);
+            renderStatsTable(container);
+        });
+    }
 }
 
 function isVisible() { return isInViewport; }


### PR DESCRIPTION
Closes #826

## Summary

- **Statistics tables** on all 6 monitoring chart tabs (Network Performance, Device Stats, SFP, ONT, CM, Cellular) showing mean/min/max for each metric in the time window
- **Shared `chart-stats.js` module** centralizes stats computation, table rendering, column sorting, scroll preservation, and click-to-filter logic across all chart files
- **Column sorting** - click headers to cycle asc/desc/clear, active column highlighted in blue
- **Click-to-filter on device names** - same solo/show-all/toggle behavior as the filter badges; table-initiated filtering greys out hidden rows (35% opacity) so they stay clickable, while badge-initiated filtering pares down the table
- **Scroll preservation** - horizontal scroll position maintained across data refreshes on mobile
- **Dark-themed scrollbar** for stats tables (10 px, `--bg-tertiary` thumb)
- **Disable drag-zoom on touch devices** - prevents accidental chart zoom when scrolling on mobile; uses `matchMedia('(pointer:coarse)')` so touchscreen laptops keep drag-zoom
- Signal/power values shown to 2 decimal places; temperature to 1

## Test plan

- [x] Network Performance tab: stats table renders below charts, sorting works on all columns, loss coloring preserved
- [x] Device Stats tab: stats table with temp/CPU/mem, filter from device badge pares down table
- [x] SFP tab: click module in SFP card to solo - table pares to that module; click name in table to solo with grey-out
- [x] CM/ONT/Cellular tabs: stats tables render with correct metrics and units
- [x] Mobile: vertical scroll through charts works without triggering drag-zoom
- [x] Mobile: stats table horizontal scroll preserved on data refresh
- [x] Sort: click header toggles asc -> desc -> clear across all tabs