### PR TITLE
Add Quantum Fiber Q1000K SmartNID ONT monitoring

### DIFF
--- a/src/NetworkOptimizer.Monitoring/Models/OntStats.cs
+++ b/src/NetworkOptimizer.Monitoring/Models/OntStats.cs
@@ -68,4 +68,13 @@ public class OntStats
 
     /// <summary>Estimated distance to OLT in meters</summary>
     public double? Distance { get; set; }
+
+    /// <summary>Seconds the PON link has been continuously up</summary>
+    public long? LinkUptimeSeconds { get; set; }
+
+    /// <summary>Upstream OLT vendor reported by the ONT (e.g. "CALX" for Calix)</summary>
+    public string? OltVendor { get; set; }
+
+    /// <summary>Upstream OLT model reported by the ONT (e.g. "E7")</summary>
+    public string? OltModel { get; set; }
 }

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1191,6 +1191,7 @@
                                 <option value="att-gateway">AT&T Gateway (HTTP)</option>
                                 <option value="realtek-ont">Realtek ONT Stick (HTTP)</option>
                                 <option value="8311">8311 Community Firmware (HTTP)</option>
+                                <option value="quantum-q1000k">Quantum Fiber Q1000K (HTTP)</option>
                                 <option value="generic-http-ont">Generic HTTP ONT</option>
                             </select>
                         </div>
@@ -4467,6 +4468,7 @@
     private static int GetOntProviderDefaultPort(string provider) => provider switch
     {
         "8311" => 443,
+        "quantum-q1000k" => 443,
         _ => 80,
     };
 
@@ -4475,6 +4477,7 @@
         "att-gateway" => "AT&T Gateway (HTTP)",
         "realtek-ont" => "Realtek ONT Stick (HTTP)",
         "8311" => "8311 Community Firmware (HTTP)",
+        "quantum-q1000k" => "Quantum Fiber Q1000K (HTTP)",
         "generic-http-ont" => "Generic HTTP ONT",
         _ => provider,
     };

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -207,6 +207,7 @@ builder.Services.AddSingleton<CableModemMonitorService>();
 builder.Services.AddSingleton<IOntProvider, AttGatewayOntProvider>();
 builder.Services.AddSingleton<IOntProvider, RealtekOntProvider>();
 builder.Services.AddSingleton<IOntProvider, Lantiq8311OntProvider>();
+builder.Services.AddSingleton<IOntProvider, QuantumQ1000kOntProvider>();
 builder.Services.AddSingleton<IOntProvider, GenericHttpOntProvider>();
 builder.Services.AddSingleton<OntMonitorService>();
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -557,7 +557,10 @@ public class MonitoringInfluxClient : IAsyncDisposable
         string? ponLinkStatus,
         int? bwpSpeedMbps,
         int? sfpLinkSpeedMbps,
-        DateTime timestamp)
+        DateTime timestamp,
+        long? linkUptimeSeconds = null,
+        string? oltVendor = null,
+        string? oltModel = null)
     {
         if (!IsConfigured) return Task.CompletedTask;
         var point = PointData.Measurement("ont")
@@ -567,6 +570,8 @@ public class MonitoringInfluxClient : IAsyncDisposable
 
         if (!string.IsNullOrEmpty(ponType)) point = point.Tag("pon_type", ponType);
         if (!string.IsNullOrEmpty(wavelength)) point = point.Tag("wavelength", wavelength);
+        if (!string.IsNullOrEmpty(oltVendor)) point = point.Tag("olt_vendor", oltVendor);
+        if (!string.IsNullOrEmpty(oltModel)) point = point.Tag("olt_model", oltModel);
 
         if (rxPowerDbm.HasValue) point = point.Field("rx_power_dbm", rxPowerDbm.Value);
         if (txPowerDbm.HasValue) point = point.Field("tx_power_dbm", txPowerDbm.Value);
@@ -578,6 +583,7 @@ public class MonitoringInfluxClient : IAsyncDisposable
         if (!string.IsNullOrEmpty(ponLinkStatus)) point = point.Field("pon_link_status", ponLinkStatus);
         if (bwpSpeedMbps.HasValue) point = point.Field("bwp_speed_mbps", bwpSpeedMbps.Value);
         if (sfpLinkSpeedMbps.HasValue) point = point.Field("sfp_link_speed_mbps", sfpLinkSpeedMbps.Value);
+        if (linkUptimeSeconds.HasValue) point = point.Field("link_uptime_seconds", linkUptimeSeconds.Value);
 
         Enqueue(point, longterm: true);
         return Task.CompletedTask;

--- a/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
@@ -260,7 +260,10 @@ public class OntMonitorService : IDisposable
                 ponLinkStatus: stats.PonLinkStatus != PonLinkState.Unknown ? stats.PonLinkStatus.ToInfluxValue() : null,
                 bwpSpeedMbps: stats.BwpSpeedMbps,
                 sfpLinkSpeedMbps: stats.SfpLinkSpeedMbps,
-                timestamp: stats.Timestamp);
+                timestamp: stats.Timestamp,
+                linkUptimeSeconds: stats.LinkUptimeSeconds,
+                oltVendor: stats.OltVendor,
+                oltModel: stats.OltModel);
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Services/OntProviders/QuantumQ1000kOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/QuantumQ1000kOntProvider.cs
@@ -130,10 +130,12 @@ public sealed class QuantumQ1000kOntProvider : IOntProvider
     }
 
     /// <summary>
-    /// Form login: POST username/password (text/plain, matching the device's React UI) to
-    /// /cgi/cgi_action. The device replies with a Session-Id cookie stored by the
-    /// CookieContainer. Unauthenticated /cgi/cgi_get reads are rejected (HTTP 444), so we
-    /// confirm success by probing GetConnectionStatus and checking for the wan_status payload.
+    /// Form login: POST username/password to /cgi/cgi_action as a raw text/plain body,
+    /// replicating exactly what the device's React UI sends (content type included) since
+    /// that is the only request form we have confirmed yields a session. The device replies
+    /// with a Session-Id cookie stored by the CookieContainer. Unauthenticated /cgi/cgi_get
+    /// reads are rejected (HTTP 444), so we confirm success by probing GetConnectionStatus
+    /// and checking for the wan_status payload.
     /// </summary>
     private async Task<bool> LoginAsync(
         HttpClient client, string baseUrl, OntPollContext context, CancellationToken ct)

--- a/src/NetworkOptimizer.Web/Services/OntProviders/QuantumQ1000kOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/QuantumQ1000kOntProvider.cs
@@ -13,9 +13,9 @@ namespace NetworkOptimizer.Web.Services.OntProviders;
 /// form POST to /cgi/cgi_action which returns a Session-Id cookie; data is then read
 /// from /cgi/cgi_get?Object=... endpoints that return TR-181-style parameter objects.
 ///
-/// The SmartNID only reports line status (GOOD/BAD), PON line rates, and device
-/// identity - it does not expose DDM optics (Rx/Tx power, temperature, voltage), so
-/// those OntStats fields are left null.
+/// The Device.Optical.Interface.1 object exposes full DDM optics (Rx/Tx power,
+/// temperature, voltage, bias current), link status, PON line rate, and BIP error
+/// counts, alongside device identity from Device.DeviceInfo.
 /// </summary>
 public sealed class QuantumQ1000kOntProvider : IOntProvider
 {
@@ -27,8 +27,7 @@ public sealed class QuantumQ1000kOntProvider : IOntProvider
     private const string ConnectionStatusPath = "/cgi/cgi_get?Object=GetConnectionStatus";
     private const string DeviceInfoPath =
         "/cgi/cgi_get?Object=Device.DeviceInfo&SoftwareVersion=&ModelName=&HardwareVersion=&SerialNumber=";
-    private const string OpticalPath =
-        "/cgi/cgi_get?Object=Device.Optical.Interface.1&X_AXON_LineStatus=";
+    private const string OpticalPath = "/cgi/cgi_get?Object=Device.Optical.Interface.1";
 
     private readonly ILogger<QuantumQ1000kOntProvider> _logger;
 
@@ -75,8 +74,11 @@ public sealed class QuantumQ1000kOntProvider : IOntProvider
             ApplyOpticalInterface(opticalJson, stats);
 
             _logger.LogDebug(
-                "Quantum Q1000K ONT {Name} polled: LineStatus={Line}, Link={Link}, {PonType}",
-                context.Name, stats.OperationalStatus ?? "-", stats.LinkState ?? "-", stats.PonType ?? "-");
+                "Quantum Q1000K ONT {Name} polled: Rx={Rx} dBm, Tx={Tx} dBm, Temp={Temp} C, Link={Link}, {PonType}",
+                context.Name, stats.RxPowerDbm?.ToString("F2") ?? "-",
+                stats.TxPowerDbm?.ToString("F2") ?? "-",
+                stats.TemperatureC?.ToString("F0") ?? "-",
+                stats.LinkState ?? "-", stats.PonType ?? "-");
 
             return stats;
         }
@@ -110,8 +112,12 @@ public sealed class QuantumQ1000kOntProvider : IOntProvider
             var stats = new OntStats { DeviceModel = "Quantum Q1000K" };
             ApplyDeviceInfo(deviceInfoJson, stats);
 
+            var opticalJson = await client.GetStringAsync($"{baseUrl}{OpticalPath}", cancellationToken);
+            ApplyOpticalInterface(opticalJson, stats);
+
             var scheme = baseUrl.StartsWith("https") ? "HTTPS" : "HTTP";
-            return (true, $"Connected ({scheme}) - {stats.DeviceModel}");
+            var rx = stats.RxPowerDbm.HasValue ? $", RX: {stats.RxPowerDbm.Value:F2} dBm" : "";
+            return (true, $"Connected ({scheme}) - {stats.DeviceModel}{rx}");
         }
         catch (HttpRequestException ex) when (ex.Message.Contains("SSL", StringComparison.OrdinalIgnoreCase))
         {
@@ -199,19 +205,42 @@ public sealed class QuantumQ1000kOntProvider : IOntProvider
     }
 
     /// <summary>
-    /// Parses Device.Optical.Interface.1 X_AXON_LineStatus (GOOD/BAD). When the WAN link
-    /// state was unavailable, a GOOD line status is treated as Up.
+    /// Parses the full Device.Optical.Interface.1 object (and its Stats sub-object).
+    /// DDM optics power/voltage/bias are reported in milli-units (0.001 dBm, mV, µA);
+    /// temperature is whole degrees Celsius. The standard TR-181 Status field
+    /// ("Up"/"Down") drives link health, with the X_AXON_LineStatus (GOOD/BAD) flag as
+    /// a fallback. The downstream line rate (Mbps) confirms the PON variant.
     /// </summary>
     internal static void ApplyOpticalInterface(string json, OntStats stats)
     {
         var p = ParseParamObject(json);
 
-        if (p.TryGetValue("X_AXON_LineStatus", out var line) && !string.IsNullOrWhiteSpace(line))
+        stats.RxPowerDbm = ParseMilli(GetValue(p, "OpticalSignalLevel")) ?? stats.RxPowerDbm;
+        stats.TxPowerDbm = ParseMilli(GetValue(p, "TransmitOpticalLevel")) ?? stats.TxPowerDbm;
+        stats.VoltageV = ParseMilli(GetValue(p, "X_CTL_Voltage")) ?? stats.VoltageV;
+        stats.BiasMa = ParseMilli(GetValue(p, "X_CTL_BiasCurrent")) ?? stats.BiasMa;
+
+        if (ParseDouble(GetValue(p, "X_CTL_Temperature")) is { } temp)
+            stats.TemperatureC = temp;
+
+        if (ParseLong(GetValue(p, "X_CTL_BIPErrorsReceived")) is { } bip)
+            stats.BipErrors = bip;
+
+        var status = GetValue(p, "Status");
+        if (!string.IsNullOrWhiteSpace(status))
+        {
+            stats.LinkState = status;
+            stats.OperationalStatus = status;
+        }
+        else if (p.TryGetValue("X_AXON_LineStatus", out var line) && !string.IsNullOrWhiteSpace(line))
         {
             var good = string.Equals(line, "GOOD", StringComparison.OrdinalIgnoreCase);
-            stats.OperationalStatus ??= good ? "Up" : "Down";
             stats.LinkState ??= good ? "Up" : "Down";
+            stats.OperationalStatus ??= good ? "Up" : "Down";
         }
+
+        if (ParseLong(GetValue(p, "X_AXON_DownstreamRate")) is { } downMbps)
+            stats.PonType = downMbps >= 9000 ? "XGS-PON" : "GPON";
     }
 
     /// <summary>
@@ -253,8 +282,18 @@ public sealed class QuantumQ1000kOntProvider : IOntProvider
             ? prop.GetString()
             : null;
 
+    private static string? GetValue(Dictionary<string, string> p, string key) =>
+        p.TryGetValue(key, out var v) ? v : null;
+
     private static long? ParseLong(string? text) =>
         long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var val) ? val : null;
+
+    private static double? ParseDouble(string? text) =>
+        double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out var val) ? val : null;
+
+    /// <summary>Parses an integer reported in milli-units (0.001) into its base unit.</summary>
+    private static double? ParseMilli(string? text) =>
+        ParseLong(text) is { } v ? v / 1000.0 : null;
 
     /// <summary>
     /// Tries the port-based scheme first (HTTPS for 443, HTTP for 80), then falls back to the

--- a/src/NetworkOptimizer.Web/Services/OntProviders/QuantumQ1000kOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/QuantumQ1000kOntProvider.cs
@@ -241,6 +241,14 @@ public sealed class QuantumQ1000kOntProvider : IOntProvider
 
         if (ParseLong(GetValue(p, "X_AXON_DownstreamRate")) is { } downMbps)
             stats.PonType = downMbps >= 9000 ? "XGS-PON" : "GPON";
+
+        stats.LinkUptimeSeconds = ParseLong(GetValue(p, "X_AXON_LinkUpTime")) ?? stats.LinkUptimeSeconds;
+
+        var oltVendor = GetValue(p, "X_CTL_OLTVendor");
+        if (!string.IsNullOrWhiteSpace(oltVendor)) stats.OltVendor = oltVendor;
+
+        var oltModel = GetValue(p, "X_CTL_OLTModel");
+        if (!string.IsNullOrWhiteSpace(oltModel)) stats.OltModel = oltModel;
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/OntProviders/QuantumQ1000kOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/QuantumQ1000kOntProvider.cs
@@ -1,0 +1,330 @@
+using System.Globalization;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Monitoring.Providers;
+
+namespace NetworkOptimizer.Web.Services.OntProviders;
+
+/// <summary>
+/// ONT provider for the Quantum Fiber Q1000K SmartNID (CenturyLink/Quantum Fiber GPON).
+/// The device exposes a React web UI backed by a CGI JSON API. Authentication is a
+/// form POST to /cgi/cgi_action which returns a Session-Id cookie; data is then read
+/// from /cgi/cgi_get?Object=... endpoints that return TR-181-style parameter objects.
+///
+/// The SmartNID only reports line status (GOOD/BAD), PON line rates, and device
+/// identity - it does not expose DDM optics (Rx/Tx power, temperature, voltage), so
+/// those OntStats fields are left null.
+/// </summary>
+public sealed class QuantumQ1000kOntProvider : IOntProvider
+{
+    public string ProviderKey => "quantum-q1000k";
+    public string DisplayName => "Quantum Fiber Q1000K (HTTP)";
+
+    private const int TimeoutSeconds = 15;
+    private const string LoginPath = "/cgi/cgi_action";
+    private const string ConnectionStatusPath = "/cgi/cgi_get?Object=GetConnectionStatus";
+    private const string DeviceInfoPath =
+        "/cgi/cgi_get?Object=Device.DeviceInfo&SoftwareVersion=&ModelName=&HardwareVersion=&SerialNumber=";
+    private const string OpticalPath =
+        "/cgi/cgi_get?Object=Device.Optical.Interface.1&X_AXON_LineStatus=";
+
+    private readonly ILogger<QuantumQ1000kOntProvider> _logger;
+
+    public QuantumQ1000kOntProvider(ILogger<QuantumQ1000kOntProvider> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<OntStats?> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+        {
+            _logger.LogWarning("Quantum Q1000K ONT poll requested but Host is empty (config {Id})", context.Id);
+            return null;
+        }
+
+        try
+        {
+            var (baseUrl, client, handler) = await ResolveBaseUrlAsync(context, cancellationToken);
+            using var _ = handler;
+            using var __ = client;
+
+            if (!await LoginAsync(client, baseUrl, context, cancellationToken))
+            {
+                _logger.LogWarning("Quantum Q1000K ONT {Name}: login failed", context.Name);
+                return null;
+            }
+
+            var stats = new OntStats
+            {
+                Timestamp = DateTime.UtcNow,
+                DeviceHost = context.Host,
+                DeviceName = context.Name,
+                DeviceModel = "Quantum Q1000K",
+            };
+
+            var connectionJson = await client.GetStringAsync($"{baseUrl}{ConnectionStatusPath}", cancellationToken);
+            ApplyConnectionStatus(connectionJson, stats);
+
+            var deviceInfoJson = await client.GetStringAsync($"{baseUrl}{DeviceInfoPath}", cancellationToken);
+            ApplyDeviceInfo(deviceInfoJson, stats);
+
+            var opticalJson = await client.GetStringAsync($"{baseUrl}{OpticalPath}", cancellationToken);
+            ApplyOpticalInterface(opticalJson, stats);
+
+            _logger.LogDebug(
+                "Quantum Q1000K ONT {Name} polled: LineStatus={Line}, Link={Link}, {PonType}",
+                context.Name, stats.OperationalStatus ?? "-", stats.LinkState ?? "-", stats.PonType ?? "-");
+
+            return stats;
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error polling Quantum Q1000K ONT {Name} at {Host}", context.Name, context.Host);
+            return null;
+        }
+    }
+
+    public async Task<(bool Success, string Message)> TestConnectionAsync(
+        OntPollContext context, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+            return (false, "Host is empty");
+
+        try
+        {
+            var (baseUrl, client, handler) = await ResolveBaseUrlAsync(context, cancellationToken);
+            using var _ = handler;
+            using var __ = client;
+
+            if (!await LoginAsync(client, baseUrl, context, cancellationToken))
+                return (false, "Login failed - check username/password (the admin password is printed on the device)");
+
+            var deviceInfoJson = await client.GetStringAsync($"{baseUrl}{DeviceInfoPath}", cancellationToken);
+            if (!deviceInfoJson.Contains("ModelName", StringComparison.OrdinalIgnoreCase))
+                return (false, "Connected but response does not contain expected device info fields");
+
+            var stats = new OntStats { DeviceModel = "Quantum Q1000K" };
+            ApplyDeviceInfo(deviceInfoJson, stats);
+
+            var scheme = baseUrl.StartsWith("https") ? "HTTPS" : "HTTP";
+            return (true, $"Connected ({scheme}) - {stats.DeviceModel}");
+        }
+        catch (HttpRequestException ex) when (ex.Message.Contains("SSL", StringComparison.OrdinalIgnoreCase))
+        {
+            return (false, $"SSL connection failed: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Connection failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Form login: POST username/password (text/plain, matching the device's React UI) to
+    /// /cgi/cgi_action. The device replies with a Session-Id cookie stored by the
+    /// CookieContainer. Unauthenticated /cgi/cgi_get reads are rejected (HTTP 444), so we
+    /// confirm success by probing GetConnectionStatus and checking for the wan_status payload.
+    /// </summary>
+    private async Task<bool> LoginAsync(
+        HttpClient client, string baseUrl, OntPollContext context, CancellationToken ct)
+    {
+        var username = context.Username ?? "admin";
+        var password = context.Password ?? "";
+
+        var body = $"username={username}&password={password}";
+        using var content = new StringContent(body, Encoding.UTF8, "text/plain");
+
+        try { using var login = await client.PostAsync($"{baseUrl}{LoginPath}", content, ct); }
+        catch (HttpRequestException) { return false; }
+
+        try
+        {
+            var probe = await client.GetStringAsync($"{baseUrl}{ConnectionStatusPath}", ct);
+            return probe.Contains("wan_status", StringComparison.OrdinalIgnoreCase);
+        }
+        catch (HttpRequestException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Parses GetConnectionStatus: {"wan_status":{"link_state":"connected","net_state":"bridged",
+    /// "uplink_rate":"1244000","downlink_rate":"2488000",...}}. Rates are in kbps. Sets the link
+    /// health (Up/Down) and derives the PON type from the downstream line rate.
+    /// </summary>
+    internal static void ApplyConnectionStatus(string json, OntStats stats)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object
+                || !doc.RootElement.TryGetProperty("wan_status", out var wan))
+                return;
+
+            if (wan.TryGetProperty("link_state", out var linkEl))
+            {
+                var connected = string.Equals(linkEl.GetString(), "connected", StringComparison.OrdinalIgnoreCase);
+                stats.OperationalStatus = connected ? "Up" : "Down";
+                stats.LinkState = connected ? "Up" : "Down";
+            }
+
+            var downlinkKbps = ParseLong(GetStringProp(wan, "downlink_rate"));
+            if (downlinkKbps.HasValue)
+                stats.PonType = downlinkKbps.Value >= 9_000_000 ? "XGS-PON" : "GPON";
+        }
+        catch (JsonException) { }
+    }
+
+    /// <summary>
+    /// Parses Device.DeviceInfo parameters (ModelName, SerialNumber, SoftwareVersion).
+    /// ModelName drives the displayed model/part number; SerialNumber maps to the SN field.
+    /// </summary>
+    internal static void ApplyDeviceInfo(string json, OntStats stats)
+    {
+        var p = ParseParamObject(json);
+
+        if (p.TryGetValue("ModelName", out var model) && !string.IsNullOrWhiteSpace(model))
+        {
+            stats.DeviceModel = $"Quantum {model}";
+            stats.VendorPn = model;
+        }
+
+        if (p.TryGetValue("SerialNumber", out var serial) && !string.IsNullOrWhiteSpace(serial))
+            stats.VendorSn = serial;
+    }
+
+    /// <summary>
+    /// Parses Device.Optical.Interface.1 X_AXON_LineStatus (GOOD/BAD). When the WAN link
+    /// state was unavailable, a GOOD line status is treated as Up.
+    /// </summary>
+    internal static void ApplyOpticalInterface(string json, OntStats stats)
+    {
+        var p = ParseParamObject(json);
+
+        if (p.TryGetValue("X_AXON_LineStatus", out var line) && !string.IsNullOrWhiteSpace(line))
+        {
+            var good = string.Equals(line, "GOOD", StringComparison.OrdinalIgnoreCase);
+            stats.OperationalStatus ??= good ? "Up" : "Down";
+            stats.LinkState ??= good ? "Up" : "Down";
+        }
+    }
+
+    /// <summary>
+    /// Flattens the TR-181-style response {"Objects":[{"Param":[{"ParamName":..,"ParamValue":..}]}]}
+    /// into a name/value dictionary from the first object.
+    /// </summary>
+    private static Dictionary<string, string> ParseParamObject(string json)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object
+                || !doc.RootElement.TryGetProperty("Objects", out var objects)
+                || objects.ValueKind != JsonValueKind.Array)
+                return result;
+
+            foreach (var obj in objects.EnumerateArray())
+            {
+                if (!obj.TryGetProperty("Param", out var pars) || pars.ValueKind != JsonValueKind.Array)
+                    continue;
+
+                foreach (var par in pars.EnumerateArray())
+                {
+                    var name = GetStringProp(par, "ParamName");
+                    var value = GetStringProp(par, "ParamValue");
+                    if (!string.IsNullOrEmpty(name) && value != null)
+                        result[name] = value;
+                }
+            }
+        }
+        catch (JsonException) { }
+
+        return result;
+    }
+
+    private static string? GetStringProp(JsonElement element, string name) =>
+        element.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.String
+            ? prop.GetString()
+            : null;
+
+    private static long? ParseLong(string? text) =>
+        long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var val) ? val : null;
+
+    /// <summary>
+    /// Tries the port-based scheme first (HTTPS for 443, HTTP for 80), then falls back to the
+    /// opposite scheme. All HTTPS uses self-signed cert bypass since these are local devices.
+    /// </summary>
+    private async Task<(string BaseUrl, HttpClient Client, HttpClientHandler Handler)> ResolveBaseUrlAsync(
+        OntPollContext context, CancellationToken ct)
+    {
+        var port = context.Port > 0 ? context.Port : 443;
+        var primaryScheme = port == 80 ? "http" : "https";
+        var fallbackScheme = primaryScheme == "https" ? "http" : "https";
+
+        var primaryUrl = BuildBaseUrl(context.Host, port, primaryScheme);
+        var (handler, client) = CreateHttpClient();
+
+        try
+        {
+            using var response = await client.GetAsync($"{primaryUrl}/", ct);
+            return (primaryUrl, client, handler);
+        }
+        catch (HttpRequestException ex) when (
+            ex.InnerException is System.Security.Authentication.AuthenticationException
+            || ex.Message.Contains("SSL", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogDebug("{Scheme} failed with SSL error for {Host}, trying {Fallback}",
+                primaryScheme.ToUpperInvariant(), context.Host, fallbackScheme.ToUpperInvariant());
+        }
+        catch (HttpRequestException)
+        {
+            _logger.LogDebug("{Scheme} connection failed for {Host}, trying {Fallback}",
+                primaryScheme.ToUpperInvariant(), context.Host, fallbackScheme.ToUpperInvariant());
+        }
+
+        client.Dispose();
+        handler.Dispose();
+
+        var fallbackUrl = BuildBaseUrl(context.Host, port, fallbackScheme);
+        var (handler2, client2) = CreateHttpClient();
+
+        try
+        {
+            using var probe = await client2.GetAsync($"{fallbackUrl}/", ct);
+            _logger.LogInformation("Quantum Q1000K ONT {Host} reachable via {Scheme}",
+                context.Host, fallbackScheme.ToUpperInvariant());
+            return (fallbackUrl, client2, handler2);
+        }
+        catch
+        {
+            client2.Dispose();
+            handler2.Dispose();
+            throw;
+        }
+    }
+
+    private static (HttpClientHandler Handler, HttpClient Client) CreateHttpClient()
+    {
+        var handler = new HttpClientHandler
+        {
+            CookieContainer = new CookieContainer(),
+            UseCookies = true,
+            ServerCertificateCustomValidationCallback = (_, _, _, _) => true,
+        };
+        var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(TimeoutSeconds) };
+        return (handler, client);
+    }
+
+    private static string BuildBaseUrl(string host, int port, string scheme)
+    {
+        var portSuffix = (scheme == "http" && port == 80) || (scheme == "https" && port == 443)
+            ? "" : $":{port}";
+        return $"{scheme}://{host}{portSuffix}";
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/OntProviders/QuantumQ1000kOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/QuantumQ1000kOntProvider.cs
@@ -253,7 +253,8 @@ public sealed class QuantumQ1000kOntProvider : IOntProvider
 
     /// <summary>
     /// Flattens the TR-181-style response {"Objects":[{"Param":[{"ParamName":..,"ParamValue":..}]}]}
-    /// into a name/value dictionary from the first object.
+    /// into a single name/value dictionary, merging the parameters of every object in the
+    /// array (the optical endpoint splits its data across Interface.1 and Interface.1.Stats).
     /// </summary>
     private static Dictionary<string, string> ParseParamObject(string json)
     {

--- a/tests/NetworkOptimizer.Web.Tests/QuantumQ1000kOntProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/QuantumQ1000kOntProviderTests.cs
@@ -80,8 +80,11 @@ public class QuantumQ1000kOntProviderTests
                 {"ParamName":"TransmitOpticalLevel","ParamValue":"2602"},
                 {"ParamName":"X_AXON_DownstreamRate","ParamValue":"2488"},
                 {"ParamName":"X_AXON_LineStatus","ParamValue":"GOOD"},
+                {"ParamName":"X_AXON_LinkUpTime","ParamValue":"943292"},
                 {"ParamName":"X_AXON_UpstreamRate","ParamValue":"1244"},
                 {"ParamName":"X_CTL_BiasCurrent","ParamValue":"13822"},
+                {"ParamName":"X_CTL_OLTModel","ParamValue":"E7"},
+                {"ParamName":"X_CTL_OLTVendor","ParamValue":"CALX"},
                 {"ParamName":"X_CTL_Temperature","ParamValue":"56"},
                 {"ParamName":"X_CTL_Voltage","ParamValue":"3317"}]},
               {"ObjName":"Device.Optical.Interface.1.Stats.","Param":[
@@ -100,6 +103,9 @@ public class QuantumQ1000kOntProviderTests
         stats.LinkState.Should().Be("Up");
         stats.OperationalStatus.Should().Be("Up");
         stats.PonType.Should().Be("GPON");
+        stats.LinkUptimeSeconds.Should().Be(943292);
+        stats.OltVendor.Should().Be("CALX");
+        stats.OltModel.Should().Be("E7");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/QuantumQ1000kOntProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/QuantumQ1000kOntProviderTests.cs
@@ -1,0 +1,113 @@
+using FluentAssertions;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Web.Services.OntProviders;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class QuantumQ1000kOntProviderTests
+{
+    [Fact]
+    public void ApplyConnectionStatus_ConnectedGponRates_SetsUpAndGpon()
+    {
+        var stats = new OntStats();
+        var json = """
+            {"wan_status":{"device":"pon","connname":"wan","connifname":"pon",
+            "ipaddr":"203.0.113.5/24","link_state":"connected","net_state":"bridged",
+            "type":"2","uplink_rate":"1244000","downlink_rate":"2488000",
+            "is_bridged":"false","is_walled_pppcred":"false","is_captived":"false"}}
+            """;
+
+        QuantumQ1000kOntProvider.ApplyConnectionStatus(json, stats);
+
+        stats.OperationalStatus.Should().Be("Up");
+        stats.LinkState.Should().Be("Up");
+        stats.PonType.Should().Be("GPON");
+    }
+
+    [Fact]
+    public void ApplyConnectionStatus_DisconnectedLink_SetsDown()
+    {
+        var stats = new OntStats();
+        var json = """{"wan_status":{"link_state":"disconnected","downlink_rate":"0"}}""";
+
+        QuantumQ1000kOntProvider.ApplyConnectionStatus(json, stats);
+
+        stats.OperationalStatus.Should().Be("Down");
+        stats.LinkState.Should().Be("Down");
+    }
+
+    [Fact]
+    public void ApplyConnectionStatus_TenGigDownstream_SetsXgsPon()
+    {
+        var stats = new OntStats();
+        var json = """{"wan_status":{"link_state":"connected","downlink_rate":"9953000"}}""";
+
+        QuantumQ1000kOntProvider.ApplyConnectionStatus(json, stats);
+
+        stats.PonType.Should().Be("XGS-PON");
+    }
+
+    [Fact]
+    public void ApplyDeviceInfo_ParsesModelAndSerial()
+    {
+        var stats = new OntStats { DeviceModel = "Quantum Q1000K" };
+        var json = """
+            {"Objects":[{"ObjName":"Device.DeviceInfo.","Param":[
+            {"ParamName":"HardwareVersion","ParamValue":"1.0"},
+            {"ParamName":"ModelName","ParamValue":"Q1000K"},
+            {"ParamName":"SerialNumber","ParamValue":"ABC123456789"},
+            {"ParamName":"SoftwareVersion","ParamValue":"QKX001-06.00.44.00"}]}]}
+            """;
+
+        QuantumQ1000kOntProvider.ApplyDeviceInfo(json, stats);
+
+        stats.DeviceModel.Should().Be("Quantum Q1000K");
+        stats.VendorPn.Should().Be("Q1000K");
+        stats.VendorSn.Should().Be("ABC123456789");
+    }
+
+    [Fact]
+    public void ApplyOpticalInterface_GoodLineStatus_SetsUpWhenLinkUnknown()
+    {
+        var stats = new OntStats();
+        var json = """
+            {"Objects":[{"ObjName":"Device.Optical.Interface.1.","Param":[
+            {"ParamName":"X_AXON_LineStatus","ParamValue":"GOOD"}]}]}
+            """;
+
+        QuantumQ1000kOntProvider.ApplyOpticalInterface(json, stats);
+
+        stats.LinkState.Should().Be("Up");
+        stats.OperationalStatus.Should().Be("Up");
+    }
+
+    [Fact]
+    public void ApplyOpticalInterface_DoesNotOverrideExistingLinkState()
+    {
+        var stats = new OntStats { LinkState = "Down", OperationalStatus = "Down" };
+        var json = """
+            {"Objects":[{"ObjName":"Device.Optical.Interface.1.","Param":[
+            {"ParamName":"X_AXON_LineStatus","ParamValue":"GOOD"}]}]}
+            """;
+
+        QuantumQ1000kOntProvider.ApplyOpticalInterface(json, stats);
+
+        stats.LinkState.Should().Be("Down");
+        stats.OperationalStatus.Should().Be("Down");
+    }
+
+    [Fact]
+    public void Parsers_InvalidJson_DoNotThrow()
+    {
+        var stats = new OntStats();
+        var act = () =>
+        {
+            QuantumQ1000kOntProvider.ApplyConnectionStatus("not json", stats);
+            QuantumQ1000kOntProvider.ApplyDeviceInfo("{}", stats);
+            QuantumQ1000kOntProvider.ApplyOpticalInterface("[]", stats);
+        };
+
+        act.Should().NotThrow();
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/QuantumQ1000kOntProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/QuantumQ1000kOntProviderTests.cs
@@ -68,7 +68,57 @@ public class QuantumQ1000kOntProviderTests
     }
 
     [Fact]
-    public void ApplyOpticalInterface_GoodLineStatus_SetsUpWhenLinkUnknown()
+    public void ApplyOpticalInterface_ParsesFullDdmDump()
+    {
+        var stats = new OntStats();
+        // Trimmed from a real Device.Optical.Interface.1 dump (issue #830).
+        var json = """
+            {"Objects":[
+              {"ObjName":"Device.Optical.Interface.1.","Param":[
+                {"ParamName":"OpticalSignalLevel","ParamValue":"-14449"},
+                {"ParamName":"Status","ParamValue":"Up"},
+                {"ParamName":"TransmitOpticalLevel","ParamValue":"2602"},
+                {"ParamName":"X_AXON_DownstreamRate","ParamValue":"2488"},
+                {"ParamName":"X_AXON_LineStatus","ParamValue":"GOOD"},
+                {"ParamName":"X_AXON_UpstreamRate","ParamValue":"1244"},
+                {"ParamName":"X_CTL_BiasCurrent","ParamValue":"13822"},
+                {"ParamName":"X_CTL_Temperature","ParamValue":"56"},
+                {"ParamName":"X_CTL_Voltage","ParamValue":"3317"}]},
+              {"ObjName":"Device.Optical.Interface.1.Stats.","Param":[
+                {"ParamName":"X_CTL_BIPErrorsReceived","ParamValue":"0"},
+                {"ParamName":"ErrorsReceived","ParamValue":"0"}]}]}
+            """;
+
+        QuantumQ1000kOntProvider.ApplyOpticalInterface(json, stats);
+
+        stats.RxPowerDbm.Should().BeApproximately(-14.449, 0.0001);
+        stats.TxPowerDbm.Should().BeApproximately(2.602, 0.0001);
+        stats.TemperatureC.Should().Be(56);
+        stats.VoltageV.Should().BeApproximately(3.317, 0.0001);
+        stats.BiasMa.Should().BeApproximately(13.822, 0.0001);
+        stats.BipErrors.Should().Be(0);
+        stats.LinkState.Should().Be("Up");
+        stats.OperationalStatus.Should().Be("Up");
+        stats.PonType.Should().Be("GPON");
+    }
+
+    [Fact]
+    public void ApplyOpticalInterface_StatusIsAuthoritativeOverConnectionStatus()
+    {
+        var stats = new OntStats { LinkState = "Down", OperationalStatus = "Down" };
+        var json = """
+            {"Objects":[{"ObjName":"Device.Optical.Interface.1.","Param":[
+            {"ParamName":"Status","ParamValue":"Up"}]}]}
+            """;
+
+        QuantumQ1000kOntProvider.ApplyOpticalInterface(json, stats);
+
+        stats.LinkState.Should().Be("Up");
+        stats.OperationalStatus.Should().Be("Up");
+    }
+
+    [Fact]
+    public void ApplyOpticalInterface_FallsBackToLineStatusWhenNoStatusField()
     {
         var stats = new OntStats();
         var json = """
@@ -80,21 +130,6 @@ public class QuantumQ1000kOntProviderTests
 
         stats.LinkState.Should().Be("Up");
         stats.OperationalStatus.Should().Be("Up");
-    }
-
-    [Fact]
-    public void ApplyOpticalInterface_DoesNotOverrideExistingLinkState()
-    {
-        var stats = new OntStats { LinkState = "Down", OperationalStatus = "Down" };
-        var json = """
-            {"Objects":[{"ObjName":"Device.Optical.Interface.1.","Param":[
-            {"ParamName":"X_AXON_LineStatus","ParamValue":"GOOD"}]}]}
-            """;
-
-        QuantumQ1000kOntProvider.ApplyOpticalInterface(json, stats);
-
-        stats.LinkState.Should().Be("Down");
-        stats.OperationalStatus.Should().Be("Down");
     }
 
     [Fact]


### PR DESCRIPTION
Adds external ONT monitoring support for the Quantum Fiber Q1000K SmartNID (CenturyLink/Quantum Fiber GPON), closing #830.

## What's new

- **Quantum Fiber Q1000K provider** - select it under Settings > ONT Monitoring. It logs into the SmartNID's web UI and reads the optical/WAN status the device exposes.
- Reports the full DDM optical set the modem's Fiber Status page shows: receive and transmit optical power, temperature, voltage, and laser bias current, plus link status, PON type, and BIP error count.
- The dashboard ONT panel now shows live RX optical power, link state, and link type for the Q1000K, just like the other ONT providers.

## Also in this PR

- Captures PON link uptime and the upstream OLT vendor/model the ONT reports, and persists them to the monitoring time-series store for future use. These are additive and optional - existing ONT data, queries, and the other providers (AT&T, Realtek, 8311) are unaffected.

## Testing

- Unit tests cover the response parsing for connection status, device info, and the full optical DDM dump (including unit scaling and link-state precedence), plus malformed-input handling.
- Field mappings and unit scaling were verified against a real device capture from the issue (optical power values match the modem's own Fiber Status page).
- Build is clean with no warnings.

Note: the provider was validated against captured device responses; a live Test-button run against a real Q1000K from a Quantum Fiber subscriber is still worth doing before release.