### PR TITLE
Monitoring Interfaces (reach ONT/modem behind WAN) + Netgear CM single-session support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -259,6 +259,17 @@ The following were implemented in the WiFi Optimizer feature:
 - **Not required** - the confirmed-by-repeat version is correct and the worst edge (double glitch) self-heals in ~10-15 s with no spike written. Revisit only if logs show clusters of "Discarding implausible SNMP rate" WARNs that aren't explained by a single bad read. Keep a fallback for the (unrealistic) small-gap reset so nothing can wedge.
 - **Relevant code:** `InterfaceRateCalculator.Compute` (reset/candidate branch), `MonitoringCollectionAgent.WriteInterfaceCounters`.
 
+### Monitoring Interfaces: Duplicate Reachable IP (DNAT + SNAT to alternate IP)
+
+- **Context:** The Monitoring Interfaces feature (Setup tab) deploys a macvlan + `/32` route + SNAT on the gateway so the Network Optimizer server (a LAN client) and browsers can reach an ONT/modem management IP that sits behind the WAN. v1 runs two preflight gates before deploy and **bails with a report** if either fails:
+  1. The target IP's subnet overlaps a known UniFi Network/VLAN (we already enumerate these via `UniFiNetworkConfig`) - monitoring that device this way isn't possible; user must renumber.
+  2. The target IP is already pingable/reachable from the Network Optimizer server - either it already works (no plumbing needed) or it's a duplicate-IP collision we can't safely route to.
+- **The deferred case:** Two devices share the same management IP on different WANs - e.g. a cable modem on `192.168.100.1` (WAN1) and a Starlink dish also on `192.168.100.1` (WAN2). A plain `/32` route is ambiguous; only one can win. To monitor both, we'd need to give each an **alternate virtual IP** the server targets, then **DNAT** that virtual IP to the real `192.168.100.1` pinned to the correct egress interface, plus the matching **SNAT** so replies return through the same macvlan.
+  - Example shape: server polls `192.168.100.1` (modem) and `192.168.101.1` (alias for Starlink); gateway DNATs `192.168.101.1 -> 192.168.100.1 out <starlink-wan-macvlan>` and SNATs the LAN source to the per-WAN alias.
+  - Needs: per-target alternate-IP allocation, DNAT+SNAT rule generation in the boot/watchdog script, idempotent teardown, and UI to surface the alternate IP the user should point monitoring at (since it's no longer the device's real IP).
+- **v1 behavior:** detect the duplicate (preflight gate 2) and bail with a clear message explaining the collision and that alternate-IP DNAT support is planned. Do **not** silently deploy a route that hijacks the shared IP.
+- **Relevant code (once built):** Monitoring Interfaces deployment service (preflight checks + boot script generation), `UniFiNetworkConfig` enumeration for the overlap gate, `NetworkUtilities.IsIpInSubnet` for overlap math.
+
 ## Multi-Tenant / Multi-Site Support
 
 ### Multi-Tenant Architecture
@@ -403,6 +414,16 @@ The following were implemented in the WiFi Optimizer feature:
 - **Issue:** Two overloads of `TryProbePiholeEndpointAsync` and `TryProbeAdGuardHomeEndpointAsync` - one takes a full URL, one takes IP+port+scheme. The logic is nearly identical.
 - **Fix:** Unify into a single method that takes a URL string. The IP+port caller can construct the URL before calling.
 - **Scope:** `ThirdPartyDnsDetector.cs` only
+
+### Consolidate udm-boot handling on IUdmBootService
+
+- **Context:** udm-boot install was extracted into a shared `IUdmBootService` / `UdmBootService` (`src/NetworkOptimizer.Web/Services/Ssh/UdmBootService.cs`) when the Monitoring Interfaces feature landed. `SqmDeploymentService.InstallUdmBootAsync` now delegates to it, but several other call sites still hand-roll udm-boot logic and should adopt the shared service. Each is marked with a `TODO` comment in code.
+- **Sites to migrate (do not duplicate the systemd unit or the inline check):**
+  - `PerfTweaksDeploymentService.InstallUdmBootAsync` - currently routes through `SqmDeploymentService.InstallUdmBootAsync`; depend on `IUdmBootService` directly to drop the PerfTweaks -> SQM -> UdmBootService chain.
+  - `PerfTweaksDeploymentService.CheckAllStatusAsync` - inline `test -f /etc/systemd/system/udm-boot.service` check; use `IUdmBootService.IsInstalledAsync()`.
+  - `SqmDeploymentService.CheckDeploymentStatusAsync` - inline udm-boot test; use `IUdmBootService.IsInstalledAsync()`.
+  - `WanSteerDeploymentService` status check - inline udm-boot test; use `IUdmBootService.IsInstalledAsync()`.
+- **Note:** these inline checks are batched into larger delimited SSH status commands, so migrating them means either issuing a small extra call or having `IUdmBootService` expose the raw check fragment. Weigh the extra round-trip against the dedup; not blocking.
 
 ### Rename ISpeedTestRepository to IGatewayRepository
 - **Issue:** `ISpeedTestRepository` is a misleading name - it handles Gateway SSH settings, iperf3 results, AND SQM WAN configuration

--- a/src/NetworkOptimizer.Storage/Interfaces/IMonitoringInterfaceRepository.cs
+++ b/src/NetworkOptimizer.Storage/Interfaces/IMonitoringInterfaceRepository.cs
@@ -1,0 +1,23 @@
+using NetworkOptimizer.Storage.Models;
+
+namespace NetworkOptimizer.Storage.Interfaces;
+
+/// <summary>
+/// Repository for monitoring interfaces (ONT/modem management access routes
+/// deployed to the gateway).
+/// </summary>
+public interface IMonitoringInterfaceRepository
+{
+    Task<List<MonitoringInterface>> GetMonitoringInterfacesAsync(CancellationToken cancellationToken = default);
+    Task<MonitoringInterface?> GetMonitoringInterfaceAsync(int id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the monitoring interface whose target IP matches the given address,
+    /// if one exists. Used to surface deployment status next to ONT/modem monitor
+    /// configs that share the same management IP.
+    /// </summary>
+    Task<MonitoringInterface?> GetByTargetIpAsync(string targetIp, CancellationToken cancellationToken = default);
+
+    Task SaveMonitoringInterfaceAsync(MonitoringInterface config, CancellationToken cancellationToken = default);
+    Task DeleteMonitoringInterfaceAsync(int id, CancellationToken cancellationToken = default);
+}

--- a/src/NetworkOptimizer.Storage/Migrations/20260616200358_AddMonitoringInterfaces.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260616200358_AddMonitoringInterfaces.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260616200358_AddMonitoringInterfaces")]
+    partial class AddMonitoringInterfaces
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260616200358_AddMonitoringInterfaces.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260616200358_AddMonitoringInterfaces.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMonitoringInterfaces : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "MonitoringInterfaces",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 15, nullable: false),
+                    WanIfName = table.Column<string>(type: "TEXT", maxLength: 50, nullable: false),
+                    WanKey = table.Column<string>(type: "TEXT", maxLength: 10, nullable: true),
+                    TargetIp = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
+                    SubnetPrefix = table.Column<int>(type: "INTEGER", nullable: false),
+                    GatewayLocalIp = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false),
+                    SnatEnabled = table.Column<bool>(type: "INTEGER", nullable: false),
+                    WatchdogIntervalMinutes = table.Column<int>(type: "INTEGER", nullable: false),
+                    IsManuallyDeployed = table.Column<bool>(type: "INTEGER", nullable: false),
+                    LastError = table.Column<string>(type: "TEXT", maxLength: 1000, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MonitoringInterfaces", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MonitoringInterfaces_TargetIp",
+                table: "MonitoringInterfaces",
+                column: "TargetIp");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MonitoringInterfaces_WanIfName_Name",
+                table: "MonitoringInterfaces",
+                columns: new[] { "WanIfName", "Name" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MonitoringInterfaces");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/MonitoringInterface.cs
+++ b/src/NetworkOptimizer.Storage/Models/MonitoringInterface.cs
@@ -1,0 +1,83 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace NetworkOptimizer.Storage.Models;
+
+/// <summary>
+/// A persisted "monitoring interface": a macvlan + route + optional SNAT that the
+/// gateway installs so the Network Optimizer server (a LAN client) and browsers can
+/// reach an ONT/modem management IP that sits behind the WAN. Deployed as a
+/// self-contained, idempotent boot script plus a cron watchdog so it survives reboots
+/// and UniFi reprovisioning (same model as Performance Tweaks and Adaptive SQM).
+/// </summary>
+public class MonitoringInterface
+{
+    [Key]
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Name of the macvlan interface created on the gateway (e.g., "modem0").
+    /// Editable for power users; kept short and interface-name safe.
+    /// </summary>
+    [Required]
+    [MaxLength(15)]
+    public string Name { get; set; } = "modem0";
+
+    /// <summary>
+    /// Physical WAN port the macvlan rides on (e.g., "eth6"). This is the
+    /// GatewayWanInterface.IfName (the parent port), NOT the logical uplink - for
+    /// PPPoE/VLAN WANs the macvlan must attach to the physical port, not ppp0/eth4.100.
+    /// </summary>
+    [Required]
+    [MaxLength(50)]
+    public string WanIfName { get; set; } = "";
+
+    /// <summary>
+    /// WAN object key this interface targets (e.g., "wan1", "wan2"), used to
+    /// re-derive the WAN display label and disambiguate dual-WAN setups. Optional.
+    /// </summary>
+    [MaxLength(10)]
+    public string? WanKey { get; set; }
+
+    /// <summary>Management IP of the ONT/modem to reach (e.g., "192.168.100.1").</summary>
+    [Required]
+    [MaxLength(64)]
+    public string TargetIp { get; set; } = "";
+
+    /// <summary>CIDR prefix length of the modem's management subnet (default /24).</summary>
+    public int SubnetPrefix { get; set; } = 24;
+
+    /// <summary>
+    /// The gateway's LAN-local IP on the modem subnet - the address assigned to the
+    /// macvlan that the gateway and SNAT'd LAN clients source from when reaching the
+    /// modem (e.g., "192.168.100.2"). Auto-suggested as target host +/-1, editable.
+    /// </summary>
+    [Required]
+    [MaxLength(64)]
+    public string GatewayLocalIp { get; set; } = "";
+
+    /// <summary>
+    /// Whether to add a narrow SNAT rule so LAN clients (including the Network
+    /// Optimizer server's pollers) masquerade to the gateway-local IP when reaching
+    /// the modem. Required for LAN-side access; on by default.
+    /// </summary>
+    public bool SnatEnabled { get; set; } = true;
+
+    /// <summary>How often (minutes) the cron watchdog re-applies the config. Default 5.</summary>
+    public int WatchdogIntervalMinutes { get; set; } = 5;
+
+    /// <summary>
+    /// True when the user set this up by hand on the gateway and we only track/monitor
+    /// it (no deploy/remove), mirroring the Performance Tweaks "manually deployed" mode.
+    /// </summary>
+    public bool IsManuallyDeployed { get; set; }
+
+    /// <summary>Last deployment/repair error message (null if last action succeeded).</summary>
+    [MaxLength(1000)]
+    public string? LastError { get; set; }
+
+    /// <summary>When this configuration was created.</summary>
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>When this configuration was last updated.</summary>
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/NetworkOptimizer.Storage/Models/NetworkOptimizerDbContext.cs
+++ b/src/NetworkOptimizer.Storage/Models/NetworkOptimizerDbContext.cs
@@ -59,6 +59,7 @@ public class NetworkOptimizerDbContext : DbContext
     public DbSet<OuiVendor> OuiVendors { get; set; }
     public DbSet<CmConfiguration> CmConfigurations { get; set; }
     public DbSet<OntConfiguration> OntConfigurations { get; set; }
+    public DbSet<MonitoringInterface> MonitoringInterfaces { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -122,6 +123,14 @@ public class NetworkOptimizerDbContext : DbContext
             entity.ToTable("OntConfigurations");
             entity.HasIndex(e => e.Host);
             entity.HasIndex(e => e.Enabled);
+        });
+
+        // MonitoringInterface configuration (one row per ONT/modem access route)
+        modelBuilder.Entity<MonitoringInterface>(entity =>
+        {
+            entity.ToTable("MonitoringInterfaces");
+            entity.HasIndex(e => e.TargetIp);
+            entity.HasIndex(e => new { e.WanIfName, e.Name }).IsUnique();
         });
 
         // DeviceSshConfiguration configuration

--- a/src/NetworkOptimizer.Storage/Repositories/MonitoringInterfaceRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/MonitoringInterfaceRepository.cs
@@ -1,0 +1,127 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NetworkOptimizer.Storage.Interfaces;
+using NetworkOptimizer.Storage.Models;
+
+namespace NetworkOptimizer.Storage.Repositories;
+
+/// <summary>
+/// Repository for monitoring interfaces (ONT/modem management access routes
+/// deployed to the gateway).
+/// </summary>
+public class MonitoringInterfaceRepository : IMonitoringInterfaceRepository
+{
+    private readonly NetworkOptimizerDbContext _context;
+    private readonly ILogger<MonitoringInterfaceRepository> _logger;
+
+    public MonitoringInterfaceRepository(NetworkOptimizerDbContext context, ILogger<MonitoringInterfaceRepository> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<List<MonitoringInterface>> GetMonitoringInterfacesAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await _context.MonitoringInterfaces
+                .AsNoTracking()
+                .OrderBy(m => m.Name)
+                .ToListAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get monitoring interfaces");
+            throw;
+        }
+    }
+
+    public async Task<MonitoringInterface?> GetMonitoringInterfaceAsync(int id, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await _context.MonitoringInterfaces
+                .AsNoTracking()
+                .FirstOrDefaultAsync(m => m.Id == id, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get monitoring interface {Id}", id);
+            throw;
+        }
+    }
+
+    public async Task<MonitoringInterface?> GetByTargetIpAsync(string targetIp, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await _context.MonitoringInterfaces
+                .AsNoTracking()
+                .FirstOrDefaultAsync(m => m.TargetIp == targetIp, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get monitoring interface for target {TargetIp}", targetIp);
+            throw;
+        }
+    }
+
+    public async Task SaveMonitoringInterfaceAsync(MonitoringInterface config, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (config.Id > 0)
+            {
+                var existing = await _context.MonitoringInterfaces
+                    .FirstOrDefaultAsync(m => m.Id == config.Id, cancellationToken);
+                if (existing != null)
+                {
+                    existing.Name = config.Name;
+                    existing.WanIfName = config.WanIfName;
+                    existing.WanKey = config.WanKey;
+                    existing.TargetIp = config.TargetIp;
+                    existing.SubnetPrefix = config.SubnetPrefix;
+                    existing.GatewayLocalIp = config.GatewayLocalIp;
+                    existing.SnatEnabled = config.SnatEnabled;
+                    existing.WatchdogIntervalMinutes = config.WatchdogIntervalMinutes;
+                    existing.IsManuallyDeployed = config.IsManuallyDeployed;
+                    existing.LastError = config.LastError;
+                    existing.UpdatedAt = DateTime.UtcNow;
+                }
+            }
+            else
+            {
+                config.CreatedAt = DateTime.UtcNow;
+                config.UpdatedAt = DateTime.UtcNow;
+                _context.MonitoringInterfaces.Add(config);
+            }
+
+            await _context.SaveChangesAsync(cancellationToken);
+            _logger.LogDebug("Saved monitoring interface {Name} ({TargetIp})", config.Name, config.TargetIp);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save monitoring interface {Name}", config.Name);
+            throw;
+        }
+    }
+
+    public async Task DeleteMonitoringInterfaceAsync(int id, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var config = await _context.MonitoringInterfaces.FindAsync([id], cancellationToken);
+            if (config != null)
+            {
+                _context.MonitoringInterfaces.Remove(config);
+                await _context.SaveChangesAsync(cancellationToken);
+                _logger.LogDebug("Deleted monitoring interface {Id}", id);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to delete monitoring interface {Id}", id);
+            throw;
+        }
+    }
+}

--- a/src/NetworkOptimizer.UniFi/GatewayWanHelper.cs
+++ b/src/NetworkOptimizer.UniFi/GatewayWanHelper.cs
@@ -93,6 +93,16 @@ public static class GatewayWanHelper
         var port = string.IsNullOrWhiteSpace(portLabel) ? null : portLabel.Trim();
         var wanLabel = wanIndex >= 1 ? $"WAN{wanIndex}" : null;
 
+        // Drop a port label that just repeats another part (common when the port is named
+        // after the ISP), so we don't render "Acme Fiber WAN4 (eth1 - Acme Fiber)".
+        if (port != null && (
+                string.Equals(port, name, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(port, iface, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(port, wanLabel, StringComparison.OrdinalIgnoreCase)))
+        {
+            port = null;
+        }
+
         var prefix = string.Join(" ", new[] { name, wanLabel }.Where(p => !string.IsNullOrEmpty(p)));
         var suffixParts = new List<string?> { iface, port };
 

--- a/src/NetworkOptimizer.UniFi/GatewayWanHelper.cs
+++ b/src/NetworkOptimizer.UniFi/GatewayWanHelper.cs
@@ -74,6 +74,48 @@ public static class GatewayWanHelper
     }
 
     /// <summary>
+    /// Builds a human-readable WAN label from up to four identifiers
+    /// (e.g. "Acme Fiber WAN1 (eth6 - Port 7)"), degrading gracefully when any
+    /// piece is missing so it never emits empty parentheses, doubled spaces, or
+    /// "null". The connection name and WAN index form the prefix; the physical
+    /// interface and port label form a parenthesized suffix. When neither name nor a
+    /// valid WAN index is present, falls back to the interface name, then to
+    /// "Unknown WAN".
+    /// </summary>
+    /// <param name="connectionName">ISP/connection name (GatewayWanInterface.Name), if any</param>
+    /// <param name="wanIndex">1-based WAN index (1 → "WAN1"); &lt;= 0 omits the WAN label</param>
+    /// <param name="ifName">Physical interface name (e.g. "eth6"), if any</param>
+    /// <param name="portLabel">Front-panel port label (e.g. "Port 7"), if any</param>
+    public static string FormatWanLabel(string? connectionName, int wanIndex, string? ifName, string? portLabel)
+    {
+        var name = string.IsNullOrWhiteSpace(connectionName) ? null : connectionName.Trim();
+        var iface = string.IsNullOrWhiteSpace(ifName) ? null : ifName.Trim();
+        var port = string.IsNullOrWhiteSpace(portLabel) ? null : portLabel.Trim();
+        var wanLabel = wanIndex >= 1 ? $"WAN{wanIndex}" : null;
+
+        var prefix = string.Join(" ", new[] { name, wanLabel }.Where(p => !string.IsNullOrEmpty(p)));
+        var suffixParts = new List<string?> { iface, port };
+
+        if (string.IsNullOrEmpty(prefix))
+        {
+            // No name and no WAN index: fall back to the interface as the prefix so it
+            // isn't repeated in the suffix; last resort is a generic label.
+            if (iface != null)
+            {
+                prefix = iface;
+                suffixParts = new List<string?> { port };
+            }
+            else
+            {
+                prefix = "Unknown WAN";
+            }
+        }
+
+        var suffix = string.Join(" - ", suffixParts.Where(p => !string.IsNullOrEmpty(p)));
+        return string.IsNullOrEmpty(suffix) ? prefix : $"{prefix} ({suffix})";
+    }
+
+    /// <summary>
     /// Network-group convention from a wan object key ("wan"/"wan1" → "WAN",
     /// "wan2" → "WAN2"). Used when iterating GetWanInterfaces() whose Key is the
     /// raw JSON property name.

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1094,7 +1094,7 @@ else
                     </details>
 
                     <div style="margin-top: 1.25rem;">
-                        <MonitoringInterfacesCard @ref="_miCard" PrefillTargetIp="@MiTargetParam" />
+                        <MonitoringInterfacesCard @ref="_miCard" PrefillTargetIp="@MiTargetParam" PrefillSourceType="@MiTypeParam" />
                     </div>
                 </div>
             </div>
@@ -1144,6 +1144,9 @@ else
 
     [SupplyParameterFromQuery(Name = "mifip")]
     public string? MiTargetParam { get; set; }
+
+    [SupplyParameterFromQuery(Name = "mitype")]
+    public string? MiTypeParam { get; set; }
 
     private string? _lastTabParam;
     private string? _soloCellularModemId;

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1079,10 +1079,6 @@ else
                         <SnmpDeviceStatusCard @ref="_snmpDeviceCard" Devices="_snmpDeviceStatuses" />
                     </div>
 
-                    <div style="margin-top: 1.25rem;">
-                        <MonitoringInterfacesCard PrefillTargetIp="@MiTargetParam" />
-                    </div>
-
                     <details class="setup-guide" style="margin-top: 1.25rem;">
                         <summary>Not seeing data for some devices?</summary>
                         <div class="setup-guide-content">
@@ -1096,6 +1092,10 @@ else
                             <p>Devices without per-device SNMP enabled will not report port-level traffic or health metrics.</p>
                         </div>
                     </details>
+
+                    <div style="margin-top: 1.25rem;">
+                        <MonitoringInterfacesCard @ref="_miCard" PrefillTargetIp="@MiTargetParam" />
+                    </div>
                 </div>
             </div>
         }
@@ -1191,6 +1191,8 @@ else
     private IReadOnlyList<SnmpDeviceStatus> _snmpDeviceStatuses = Array.Empty<SnmpDeviceStatus>();
     private SnmpDeviceStatusCard? _snmpDeviceCard;
     private bool _pendingExpandSnmpCard;
+    private MonitoringInterfacesCard? _miCard;
+    private bool _pendingExpandMiCard;
 
 
     // Chart mount tracking
@@ -1299,6 +1301,11 @@ else
         if (!string.IsNullOrEmpty(OntParam) && _activeTab == "ont")
         {
             _soloOntId = OntParam;
+        }
+
+        if (!string.IsNullOrEmpty(MiTargetParam) && _activeTab == "setup")
+        {
+            _pendingExpandMiCard = true;
         }
 
         if (!string.IsNullOrEmpty(DeviceParam) && _activeTab == "devices")
@@ -1674,6 +1681,25 @@ else
         await JS.InvokeVoidAsync("eval", @"
             (function() {
                 var el = document.getElementById('snmp-devices');
+                if (el) {
+                    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                    el.style.transition = 'outline-color 0.3s';
+                    el.style.outline = '2px solid rgba(59, 130, 246, 0.5)';
+                    el.style.outlineOffset = '4px';
+                    el.style.borderRadius = '12px';
+                    setTimeout(function() { el.style.outline = ''; el.style.outlineOffset = ''; }, 2000);
+                }
+            })();");
+    }
+
+    private async Task ScrollToMonitoringInterfacesAsync()
+    {
+        // Mirror ScrollToSnmpDevicesAsync: wait for the expand animation, then scroll
+        // to the Monitoring Interfaces card with the same brief highlight outline.
+        await Task.Delay(400);
+        await JS.InvokeVoidAsync("eval", @"
+            (function() {
+                var el = document.getElementById('monitoring-interfaces');
                 if (el) {
                     el.scrollIntoView({ behavior: 'smooth', block: 'start' });
                     el.style.transition = 'outline-color 0.3s';
@@ -2349,6 +2375,15 @@ else
             _pendingExpandSnmpCard = false;
             _snmpDeviceCard.Expand();
             await ScrollToSnmpDevicesAsync();
+        }
+
+        // Auto-expand the Monitoring Interfaces card when deep-linked from a monitor
+        // form's "set up a monitoring interface" link (mifip query param).
+        if (_pendingExpandMiCard && _activeTab == "setup" && _miCard != null)
+        {
+            _pendingExpandMiCard = false;
+            _miCard.Expand();
+            await ScrollToMonitoringInterfacesAsync();
         }
 
         // Deep-linked investigation fires once the performance tab and its chart exist

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1079,6 +1079,10 @@ else
                         <SnmpDeviceStatusCard @ref="_snmpDeviceCard" Devices="_snmpDeviceStatuses" />
                     </div>
 
+                    <div style="margin-top: 1.25rem;">
+                        <MonitoringInterfacesCard PrefillTargetIp="@MiTargetParam" />
+                    </div>
+
                     <details class="setup-guide" style="margin-top: 1.25rem;">
                         <summary>Not seeing data for some devices?</summary>
                         <div class="setup-guide-content">
@@ -1137,6 +1141,9 @@ else
 
     [SupplyParameterFromQuery(Name = "ont")]
     public string? OntParam { get; set; }
+
+    [SupplyParameterFromQuery(Name = "mifip")]
+    public string? MiTargetParam { get; set; }
 
     private string? _lastTabParam;
     private string? _soloCellularModemId;

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -843,7 +843,7 @@
                                 </div>
                                 <div class="form-group" style="flex: 1;">
                                     <label class="form-label">SSH Password</label>
-                                    <input type="password" class="form-control" @bind="editingModem.Password" />
+                                    <input type="password" class="form-control" @bind="editingModem.Password" autocomplete="new-password" data-1p-ignore data-lpignore="true" data-bwignore />
                                 </div>
                                 <div class="form-group" style="flex: 1;">
                                     <label class="form-label">USB Bus Path (optional)</label>
@@ -857,7 +857,7 @@
                             <div class="form-row">
                                 <div class="form-group" style="flex: 2;">
                                     <label class="form-label">Admin Password (optional)</label>
-                                    <input type="password" class="form-control" @bind="editingModem.Password" placeholder="Leave empty for anonymous mode" />
+                                    <input type="password" class="form-control" @bind="editingModem.Password" placeholder="Leave empty for anonymous mode" autocomplete="new-password" data-1p-ignore data-lpignore="true" data-bwignore />
                                     <small class="form-help">
                                         Without a password, signal/band/cell metrics are still polled.
                                         Setting the admin password unlocks throughput counters.
@@ -1047,7 +1047,8 @@
                         <div class="form-group" style="flex: 1;">
                             <label class="form-label">Password</label>
                             <input type="password" class="form-control" @bind="_editingCm.Password"
-                                   placeholder="@(_editingCm.Id > 0 && !string.IsNullOrEmpty(_editingCm.Password) ? "••••••••" : "")" />
+                                   placeholder="@(_editingCm.Id > 0 && !string.IsNullOrEmpty(_editingCm.Password) ? "••••••••" : "")"
+                                   autocomplete="new-password" data-1p-ignore data-lpignore="true" data-bwignore />
                         </div>
                     </div>
 
@@ -1218,7 +1219,8 @@
                         <div class="form-group" style="flex: 1;">
                             <label class="form-label">Password</label>
                             <input type="password" class="form-control" @bind="_editingOnt.Password"
-                                   placeholder="@(_editingOnt.Id > 0 && !string.IsNullOrEmpty(_editingOnt.Password) ? "••••••••" : "")" />
+                                   placeholder="@(_editingOnt.Id > 0 && !string.IsNullOrEmpty(_editingOnt.Password) ? "••••••••" : "")"
+                                   autocomplete="new-password" data-1p-ignore data-lpignore="true" data-bwignore />
                         </div>
                     </div>
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -813,6 +813,10 @@
                             <div class="form-group" style="flex: 2;">
                                 <label class="form-label">Host / IP</label>
                                 <input type="text" class="form-control" @bind="editingModem.Host" placeholder="192.168.1.100" />
+                                <small class="form-help">
+                                    Behind your WAN and unreachable for polling?
+                                    <a href="@MonitoringInterfaceLink(editingModem.Host)">Set up a monitoring interface →</a>
+                                </small>
                             </div>
                             <div class="form-group" style="flex: 1;">
                                 <label class="form-label">Polling Interval (sec)</label>
@@ -1012,6 +1016,10 @@
                         <div class="form-group" style="flex: 2;">
                             <label class="form-label">Host / IP</label>
                             <input type="text" class="form-control" @bind="_editingCm.Host" placeholder="192.168.100.1" required />
+                            <small class="form-help">
+                                Behind your WAN and unreachable for polling?
+                                <a href="@MonitoringInterfaceLink(_editingCm.Host)">Set up a monitoring interface →</a>
+                            </small>
                         </div>
                         <div class="form-group" style="flex: 1;">
                             <label class="form-label">Port</label>
@@ -1075,6 +1083,12 @@
             {
                 <div class="alert alert-@_cmTestResultClass" style="margin-top: 1rem;">
                     @_cmTestResult
+                    @if (_cmTestResultClass == "danger" && !string.IsNullOrWhiteSpace(_editingCm.Host))
+                    {
+                        <div style="margin-top: 0.5rem;">
+                            If it's behind your WAN, <a href="@MonitoringInterfaceLink(_editingCm.Host)">set up a monitoring interface →</a>
+                        </div>
+                    }
                 </div>
             }
         </div>
@@ -1173,6 +1187,10 @@
                         <div class="form-group" style="flex: 2;">
                             <label class="form-label">Host / IP</label>
                             <input type="text" class="form-control" @bind="_editingOnt.Host" placeholder="192.168.1.254" required />
+                            <small class="form-help">
+                                Behind your WAN and unreachable for polling?
+                                <a href="@MonitoringInterfaceLink(_editingOnt.Host)">Set up a monitoring interface →</a>
+                            </small>
                         </div>
                         <div class="form-group" style="flex: 1;">
                             <label class="form-label">Port</label>
@@ -1235,6 +1253,12 @@
             {
                 <div class="alert alert-@_ontTestResultClass" style="margin-top: 1rem;">
                     @_ontTestResult
+                    @if (_ontTestResultClass == "danger" && !string.IsNullOrWhiteSpace(_editingOnt.Host))
+                    {
+                        <div style="margin-top: 0.5rem;">
+                            If it's behind your WAN, <a href="@MonitoringInterfaceLink(_editingOnt.Host)">set up a monitoring interface →</a>
+                        </div>
+                    }
                 </div>
             }
         </div>
@@ -2594,6 +2618,16 @@
     private bool _savingOnt;
     private string? _ontTestResult;
     private string _ontTestResultClass = "info";
+
+    /// <summary>
+    /// Deep-link to the Monitoring Interfaces section (Monitoring → Setup), absorbing the
+    /// in-progress modem/ONT IP so the add form opens pre-filled.
+    /// </summary>
+    private static string MonitoringInterfaceLink(string? host)
+    {
+        var ip = string.IsNullOrWhiteSpace(host) ? "" : Uri.EscapeDataString(host.Trim());
+        return $"/monitoring?tab=setup&mifip={ip}";
+    }
     private int? _ontTestingId;
     private string _ontStatus = "Inactive";
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -883,7 +883,7 @@
                                     @probeResult
                                     @if (LooksUnreachable(probeResult) && !string.IsNullOrWhiteSpace(editingModem.Host))
                                     {
-                                        <div style="margin-top: 0.5rem;">
+                                        <div class="mi-funnel">
                                             Can't reach it? <a href="@MonitoringInterfaceLink(editingModem.Host)">Set up a monitoring interface →</a>
                                         </div>
                                     }
@@ -925,7 +925,7 @@
                     @modemMessage
                     @if (LooksUnreachable(modemMessage) && !string.IsNullOrWhiteSpace(_modemTestedHost))
                     {
-                        <div style="margin-top: 0.5rem;">
+                        <div class="mi-funnel">
                             Can't reach it? <a href="@MonitoringInterfaceLink(_modemTestedHost)">Set up a monitoring interface →</a>
                         </div>
                     }
@@ -1097,7 +1097,7 @@
                     @_cmTestResult
                     @if (LooksUnreachable(_cmTestResult) && !string.IsNullOrWhiteSpace(_cmTestedHost))
                     {
-                        <div style="margin-top: 0.5rem;">
+                        <div class="mi-funnel">
                             Can't reach it? <a href="@MonitoringInterfaceLink(_cmTestedHost)">Set up a monitoring interface →</a>
                         </div>
                     }
@@ -1267,7 +1267,7 @@
                     @_ontTestResult
                     @if (LooksUnreachable(_ontTestResult) && !string.IsNullOrWhiteSpace(_ontTestedHost))
                     {
-                        <div style="margin-top: 0.5rem;">
+                        <div class="mi-funnel">
                             Can't reach it? <a href="@MonitoringInterfaceLink(_ontTestedHost)">Set up a monitoring interface →</a>
                         </div>
                     }
@@ -2572,6 +2572,22 @@
 </div>
 
 <SponsorshipBanner AlwaysShow="true" />
+
+<style>
+    .mi-funnel {
+        margin-top: 0.5rem;
+        color: var(--text-secondary);
+    }
+
+    .mi-funnel a,
+    .mi-funnel a:visited {
+        color: var(--primary-color);
+    }
+
+    .mi-funnel a:hover {
+        color: var(--primary-hover);
+    }
+</style>
 
 @code {
     // UniFi Controller

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -815,7 +815,7 @@
                                 <input type="text" class="form-control" @bind="editingModem.Host" placeholder="192.168.1.100" />
                                 <small class="form-help">
                                     Behind your WAN and unreachable for polling?
-                                    <a href="@MonitoringInterfaceLink(editingModem.Host)">Set up a monitoring interface →</a>
+                                    <a href="@MonitoringInterfaceLink(editingModem.Host, "wmodem")">Set up a monitoring interface →</a>
                                 </small>
                             </div>
                             <div class="form-group" style="flex: 1;">
@@ -884,7 +884,7 @@
                                     @if (LooksUnreachable(probeResult) && !string.IsNullOrWhiteSpace(editingModem.Host))
                                     {
                                         <div class="mi-funnel">
-                                            Can't reach it? <a href="@MonitoringInterfaceLink(editingModem.Host)">Set up a monitoring interface →</a>
+                                            Can't reach it? <a href="@MonitoringInterfaceLink(editingModem.Host, "wmodem")">Set up a monitoring interface →</a>
                                         </div>
                                     }
                                 </div>
@@ -926,7 +926,7 @@
                     @if (LooksUnreachable(modemMessage) && !string.IsNullOrWhiteSpace(_modemTestedHost))
                     {
                         <div class="mi-funnel">
-                            Can't reach it? <a href="@MonitoringInterfaceLink(_modemTestedHost)">Set up a monitoring interface →</a>
+                            Can't reach it? <a href="@MonitoringInterfaceLink(_modemTestedHost, "wmodem")">Set up a monitoring interface →</a>
                         </div>
                     }
                 </div>
@@ -1030,7 +1030,7 @@
                             <input type="text" class="form-control" @bind="_editingCm.Host" placeholder="192.168.100.1" required />
                             <small class="form-help">
                                 Behind your WAN and unreachable for polling?
-                                <a href="@MonitoringInterfaceLink(_editingCm.Host)">Set up a monitoring interface →</a>
+                                <a href="@MonitoringInterfaceLink(_editingCm.Host, "cm")">Set up a monitoring interface →</a>
                             </small>
                         </div>
                         <div class="form-group" style="flex: 1;">
@@ -1098,7 +1098,7 @@
                     @if (LooksUnreachable(_cmTestResult) && !string.IsNullOrWhiteSpace(_cmTestedHost))
                     {
                         <div class="mi-funnel">
-                            Can't reach it? <a href="@MonitoringInterfaceLink(_cmTestedHost)">Set up a monitoring interface →</a>
+                            Can't reach it? <a href="@MonitoringInterfaceLink(_cmTestedHost, "cm")">Set up a monitoring interface →</a>
                         </div>
                     }
                 </div>
@@ -1201,7 +1201,7 @@
                             <input type="text" class="form-control" @bind="_editingOnt.Host" placeholder="192.168.1.254" required />
                             <small class="form-help">
                                 Behind your WAN and unreachable for polling?
-                                <a href="@MonitoringInterfaceLink(_editingOnt.Host)">Set up a monitoring interface →</a>
+                                <a href="@MonitoringInterfaceLink(_editingOnt.Host, "ont")">Set up a monitoring interface →</a>
                             </small>
                         </div>
                         <div class="form-group" style="flex: 1;">
@@ -1268,7 +1268,7 @@
                     @if (LooksUnreachable(_ontTestResult) && !string.IsNullOrWhiteSpace(_ontTestedHost))
                     {
                         <div class="mi-funnel">
-                            Can't reach it? <a href="@MonitoringInterfaceLink(_ontTestedHost)">Set up a monitoring interface →</a>
+                            Can't reach it? <a href="@MonitoringInterfaceLink(_ontTestedHost, "ont")">Set up a monitoring interface →</a>
                         </div>
                     }
                 </div>
@@ -2652,12 +2652,13 @@
 
     /// <summary>
     /// Deep-link to the Monitoring Interfaces section (Monitoring → Setup), absorbing the
-    /// in-progress modem/ONT IP so the add form opens pre-filled.
+    /// in-progress modem/ONT IP (and source type, so the new interface gets a sensible
+    /// default name like cmodem0/wmodem0/ont0) so the add form opens pre-filled.
     /// </summary>
-    private static string MonitoringInterfaceLink(string? host)
+    private static string MonitoringInterfaceLink(string? host, string type)
     {
         var ip = string.IsNullOrWhiteSpace(host) ? "" : Uri.EscapeDataString(host.Trim());
-        return $"/monitoring?tab=setup&mifip={ip}";
+        return $"/monitoring?tab=setup&mifip={ip}&mitype={type}";
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -923,6 +923,12 @@
             {
                 <div class="alert alert-@modemMessageClass" style="margin-top: 1rem;">
                     @modemMessage
+                    @if (LooksUnreachable(modemMessage) && !string.IsNullOrWhiteSpace(_modemTestedHost))
+                    {
+                        <div style="margin-top: 0.5rem;">
+                            Can't reach it? <a href="@MonitoringInterfaceLink(_modemTestedHost)">Set up a monitoring interface →</a>
+                        </div>
+                    }
                 </div>
             }
         </div>
@@ -1089,10 +1095,10 @@
             {
                 <div class="alert alert-@_cmTestResultClass" style="margin-top: 1rem;">
                     @_cmTestResult
-                    @if (LooksUnreachable(_cmTestResult) && !string.IsNullOrWhiteSpace(_editingCm.Host))
+                    @if (LooksUnreachable(_cmTestResult) && !string.IsNullOrWhiteSpace(_cmTestedHost))
                     {
                         <div style="margin-top: 0.5rem;">
-                            Can't reach it? <a href="@MonitoringInterfaceLink(_editingCm.Host)">Set up a monitoring interface →</a>
+                            Can't reach it? <a href="@MonitoringInterfaceLink(_cmTestedHost)">Set up a monitoring interface →</a>
                         </div>
                     }
                 </div>
@@ -1259,10 +1265,10 @@
             {
                 <div class="alert alert-@_ontTestResultClass" style="margin-top: 1rem;">
                     @_ontTestResult
-                    @if (LooksUnreachable(_ontTestResult) && !string.IsNullOrWhiteSpace(_editingOnt.Host))
+                    @if (LooksUnreachable(_ontTestResult) && !string.IsNullOrWhiteSpace(_ontTestedHost))
                     {
                         <div style="margin-top: 0.5rem;">
-                            Can't reach it? <a href="@MonitoringInterfaceLink(_editingOnt.Host)">Set up a monitoring interface →</a>
+                            Can't reach it? <a href="@MonitoringInterfaceLink(_ontTestedHost)">Set up a monitoring interface →</a>
                         </div>
                     }
                 </div>
@@ -2603,6 +2609,7 @@
     private bool savingModem = false;
     private string modemMessage = "";
     private string modemMessageClass = "";
+    private string? _modemTestedHost;
     private List<DiscoveredModem> discoveredModems = new();
     private bool loadingDiscoveredModems = false;
     private bool modemFormExpanded = false;
@@ -2615,6 +2622,7 @@
     private string? _cmTestResult;
     private string _cmTestResultClass = "info";
     private int? _cmTestingId;
+    private string? _cmTestedHost;
     private string _cmStatus = "Inactive";
 
     // External ONT Monitoring
@@ -2624,6 +2632,7 @@
     private bool _savingOnt;
     private string? _ontTestResult;
     private string _ontTestResultClass = "info";
+    private string? _ontTestedHost;
 
     /// <summary>
     /// Deep-link to the Monitoring Interfaces section (Monitoring → Setup), absorbing the
@@ -4108,6 +4117,7 @@
 
     private async Task TestModemConnection(ModemConfiguration modem)
     {
+        _modemTestedHost = modem.Host;
         modemMessage = $"Polling {modem.Name}...";
         modemMessageClass = "info";
         StateHasChanged();
@@ -4217,6 +4227,7 @@
     private async Task TestCm(CmConfiguration config)
     {
         _cmTestingId = config.Id;
+        _cmTestedHost = config.Host;
         _cmTestResult = $"Testing {config.Name}...";
         _cmTestResultClass = "info";
         StateHasChanged();
@@ -4375,6 +4386,7 @@
     private async Task TestOnt(OntConfiguration config)
     {
         _ontTestingId = config.Id;
+        _ontTestedHost = config.Host;
         _ontTestResult = $"Testing {config.Name}...";
         _ontTestResultClass = "info";
         StateHasChanged();

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -881,6 +881,12 @@
                             {
                                 <div class="alert alert-@probeResultClass" style="margin-top: 0.5rem;">
                                     @probeResult
+                                    @if (LooksUnreachable(probeResult) && !string.IsNullOrWhiteSpace(editingModem.Host))
+                                    {
+                                        <div style="margin-top: 0.5rem;">
+                                            Can't reach it? <a href="@MonitoringInterfaceLink(editingModem.Host)">Set up a monitoring interface →</a>
+                                        </div>
+                                    }
                                 </div>
                             }
                         }
@@ -1083,10 +1089,10 @@
             {
                 <div class="alert alert-@_cmTestResultClass" style="margin-top: 1rem;">
                     @_cmTestResult
-                    @if (_cmTestResultClass == "danger" && !string.IsNullOrWhiteSpace(_editingCm.Host))
+                    @if (LooksUnreachable(_cmTestResult) && !string.IsNullOrWhiteSpace(_editingCm.Host))
                     {
                         <div style="margin-top: 0.5rem;">
-                            If it's behind your WAN, <a href="@MonitoringInterfaceLink(_editingCm.Host)">set up a monitoring interface →</a>
+                            Can't reach it? <a href="@MonitoringInterfaceLink(_editingCm.Host)">Set up a monitoring interface →</a>
                         </div>
                     }
                 </div>
@@ -1253,10 +1259,10 @@
             {
                 <div class="alert alert-@_ontTestResultClass" style="margin-top: 1rem;">
                     @_ontTestResult
-                    @if (_ontTestResultClass == "danger" && !string.IsNullOrWhiteSpace(_editingOnt.Host))
+                    @if (LooksUnreachable(_ontTestResult) && !string.IsNullOrWhiteSpace(_editingOnt.Host))
                     {
                         <div style="margin-top: 0.5rem;">
-                            If it's behind your WAN, <a href="@MonitoringInterfaceLink(_editingOnt.Host)">set up a monitoring interface →</a>
+                            Can't reach it? <a href="@MonitoringInterfaceLink(_editingOnt.Host)">Set up a monitoring interface →</a>
                         </div>
                     }
                 </div>
@@ -2627,6 +2633,21 @@
     {
         var ip = string.IsNullOrWhiteSpace(host) ? "" : Uri.EscapeDataString(host.Trim());
         return $"/monitoring?tab=setup&mifip={ip}";
+    }
+
+    /// <summary>
+    /// Whether a failed Test/Probe message looks like the device couldn't be reached
+    /// (timeout, canceled, refused, no route) - the signature of a modem/ONT sitting
+    /// behind the WAN. Auth (401) or parse failures mean the device IS reachable, so we
+    /// don't funnel those toward a monitoring interface.
+    /// </summary>
+    private static bool LooksUnreachable(string? message)
+    {
+        if (string.IsNullOrEmpty(message)) return false;
+        var m = message.ToLowerInvariant();
+        return m.Contains("timeout") || m.Contains("timed out") || m.Contains("canceled") || m.Contains("cancelled")
+            || m.Contains("refused") || m.Contains("no route") || m.Contains("unreachable")
+            || m.Contains("no such host") || m.Contains("actively refused") || m.Contains("connection attempt failed");
     }
     private int? _ontTestingId;
     private string _ontStatus = "Inactive";

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -310,6 +310,10 @@
     protected override async Task OnInitializedAsync()
     {
         await LoadAsync();
+        // Start expanded when nothing is configured yet so the feature is discoverable;
+        // collapse once interfaces exist. A deep-link from Settings overrides this in
+        // OnParametersSet (it always expands).
+        _collapsed = _interfaces.Count > 0;
     }
 
     protected override void OnParametersSet()

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -339,10 +339,9 @@
     protected override async Task OnInitializedAsync()
     {
         await LoadAsync();
-        // Start expanded when nothing is configured yet so the feature is discoverable;
-        // collapse once interfaces exist. A deep-link from Settings overrides this in
-        // OnParametersSet (it always expands).
-        _collapsed = _interfaces.Count > 0;
+        // NOTE: collapse state is decided once in OnAfterRenderAsync (saved preference, else
+        // count-based default). Don't set _collapsed here - this runs after an await and can
+        // land after OnAfterRenderAsync, clobbering the loaded localStorage preference.
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -350,18 +349,19 @@
         if (!firstRender)
             return;
 
-        // Honor the user's saved collapse preference, unless a deep-link is forcing the
-        // card open (in which case OnParametersSet already expanded it). With no saved
-        // preference, the count-based default from OnInitializedAsync stands.
+        // Decide collapse state once, deterministically: a saved preference wins; with none,
+        // default to expanded when nothing is configured (discoverable) and collapsed once
+        // interfaces exist. A deep-link forcing the card open (PrefillTargetIp) skips this -
+        // OnParametersSet already expanded it.
         if (string.IsNullOrWhiteSpace(PrefillTargetIp))
         {
-            try
-            {
-                var val = await JS.InvokeAsync<string>("localStorage.getItem", CollapseKey);
-                if (val == "true") _collapsed = true;
-                else if (val == "false") _collapsed = false;
-            }
+            string? val = null;
+            try { val = await JS.InvokeAsync<string>("localStorage.getItem", CollapseKey); }
             catch { }
+
+            if (val == "true") _collapsed = true;
+            else if (val == "false") _collapsed = false;
+            else _collapsed = _interfaces.Count > 0;
         }
 
         _stateLoaded = true;

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -28,7 +28,7 @@
             gateway so that device becomes reachable from the LAN.
         </p>
 
-        <div class="alert alert-info">
+        <div class="mi-tip">
             <strong>Try this first - a native static route may be all you need.</strong>
             In UniFi Network, go to <strong>Settings → Policy Engine → Policy Table</strong> and add a
             <strong>Static Route</strong> for the device's IP (for example <code>192.168.100.1/32</code>)
@@ -246,6 +246,22 @@
         margin: 0 0 1rem 0;
         font-size: 1rem;
         color: var(--text-primary);
+    }
+
+    .mi-tip {
+        background: rgba(71, 151, 255, 0.1);
+        border: 1px solid var(--info-color);
+        border-left: 4px solid var(--info-color);
+        border-radius: var(--border-radius);
+        padding: 1rem;
+        margin-top: 1rem;
+        margin-bottom: 1rem;
+        font-size: 0.875rem;
+        color: var(--text-primary);
+    }
+
+    .mi-tip strong {
+        color: var(--info-color);
     }
 
     .mi-advanced {

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -1,0 +1,526 @@
+@using System.Net
+@using NetworkOptimizer.Storage.Interfaces
+@using NetworkOptimizer.Storage.Models
+@using NetworkOptimizer.UniFi
+@using NetworkOptimizer.Web.Services
+@inject IMonitoringInterfaceRepository Repo
+@inject MonitoringInterfaceDeploymentService Deploy
+@inject ISqmService SqmService
+@inject ILogger<MonitoringInterfacesCard> Logger
+
+<div class="card" id="monitoring-interfaces">
+    <div class="card-header">
+        <h2 class="card-title">Monitoring Interfaces</h2>
+    </div>
+    <div class="card-body">
+        <p class="section-description">
+            Having trouble reaching your ONT or modem for polling? When a modem or ONT management
+            page sits behind your WAN, the gateway can't route to it and monitoring (and your
+            browser) can't reach it. A monitoring interface adds a small, reboot-safe route on the
+            gateway so that device becomes reachable from the LAN.
+        </p>
+
+        @if (_interfaces.Count == 0)
+        {
+            <p class="empty-state">
+                No monitoring interfaces configured. Add one below if a modem/ONT management IP
+                isn't reachable for polling.
+            </p>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Modem/ONT IP</th>
+                            <th>WAN</th>
+                            <th>Gateway-local IP</th>
+                            <th>Status</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var mi in _interfaces)
+                        {
+                            <tr>
+                                <td><code>@mi.Name</code></td>
+                                <td><code>@mi.TargetIp</code></td>
+                                <td>@WanLabelFor(mi)</td>
+                                <td><code>@mi.GatewayLocalIp/@mi.SubnetPrefix</code></td>
+                                <td>@StatusBadge(mi)</td>
+                                <td>
+                                    <div class="btn-group-wrap">
+                                        <button class="btn btn-secondary btn-sm" @onclick="() => EditInterface(mi)" disabled="@(_busyId != null)">Edit</button>
+                                        <button class="btn btn-primary btn-sm" @onclick="() => DeployInterface(mi)" disabled="@(_busyId != null)">
+                                            @if (_busyId == mi.Id && _busyAction == "deploy")
+                                            {
+                                                <span class="spinner spinner-sm"></span>
+                                                <span>Deploying...</span>
+                                            }
+                                            else
+                                            {
+                                                <span>@(IsApplied(mi) ? "Re-apply" : "Deploy")</span>
+                                            }
+                                        </button>
+                                        <button class="btn btn-secondary btn-sm" @onclick="() => CheckStatus(mi)" disabled="@(_busyId != null)">Check status</button>
+                                        <button class="btn btn-danger btn-sm" @onclick="() => RemoveInterface(mi)" disabled="@(_busyId != null)">
+                                            @if (_busyId == mi.Id && _busyAction == "remove")
+                                            {
+                                                <span class="spinner spinner-sm"></span>
+                                                <span>Removing...</span>
+                                            }
+                                            else
+                                            {
+                                                <span>Remove</span>
+                                            }
+                                        </button>
+                                    </div>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+
+        @if (!string.IsNullOrEmpty(_message))
+        {
+            <div class="alert @(_messageSuccess ? "alert-success" : "alert-danger")" style="margin-top: 1rem;">@_message</div>
+        }
+
+        @if (_deploySteps.Count > 0)
+        {
+            <div class="deployment-log" style="margin-top: 1rem;">
+                <h4>Deployment progress</h4>
+                <ul class="step-list">
+                    @foreach (var step in _deploySteps)
+                    {
+                        <li>@step</li>
+                    }
+                </ul>
+            </div>
+        }
+
+        <details class="add-form" open="@_formVisible">
+            <summary @onclick="ToggleForm">@(_editing.Id > 0 ? "Edit Monitoring Interface" : "Add Monitoring Interface")</summary>
+            <div class="add-form-content add-form-content-spaced">
+                <div class="form-row">
+                    <div class="form-group" style="flex: 2;">
+                        <label class="form-label">Modem/ONT IP</label>
+                        <input type="text" class="form-control" @bind="_editing.TargetIp" @bind:after="OnTargetChanged" placeholder="192.168.100.1" />
+                        <small class="form-help">The management IP you're trying to reach (e.g. your modem or ONT status page).</small>
+                    </div>
+                    <div class="form-group" style="flex: 2;">
+                        <label class="form-label">WAN interface</label>
+                        <select class="form-control" @bind="_editing.WanIfName" @bind:after="OnWanChanged">
+                            <option value="">Select WAN...</option>
+                            @foreach (var w in _wans)
+                            {
+                                @if (string.IsNullOrEmpty(w.PhysicalIfName))
+                                {
+                                    <option value="" disabled>@WanOptionLabel(w) - no physical port</option>
+                                }
+                                else
+                                {
+                                    <option value="@w.PhysicalIfName">@WanOptionLabel(w)</option>
+                                }
+                            }
+                        </select>
+                        <small class="form-help">The WAN your modem/ONT sits behind. The interface rides this port.</small>
+                    </div>
+                </div>
+
+                <details class="setup-guide">
+                    <summary>Advanced</summary>
+                    <div class="setup-guide-content">
+                        <div class="form-row">
+                            <div class="form-group" style="flex: 2;">
+                                <label class="form-label">Gateway-local IP</label>
+                                <input type="text" class="form-control" @bind="_editing.GatewayLocalIp" placeholder="192.168.100.2" />
+                                <small class="form-help">The gateway's address on the modem's subnet. Auto-suggested; must be free and on the same subnet.</small>
+                            </div>
+                            <div class="form-group" style="flex: 1;">
+                                <label class="form-label">Subnet prefix</label>
+                                <input type="number" class="form-control" @bind="_editing.SubnetPrefix" min="8" max="30" />
+                            </div>
+                            <div class="form-group" style="flex: 1;">
+                                <label class="form-label">Interface name</label>
+                                <input type="text" class="form-control" @bind="_editing.Name" placeholder="modem0" />
+                            </div>
+                        </div>
+                        <div class="form-row">
+                            <div class="form-group" style="flex: 1;">
+                                <label class="form-label">Watchdog interval (min)</label>
+                                <input type="number" class="form-control" @bind="_editing.WatchdogIntervalMinutes" min="1" max="60" />
+                                <small class="form-help">How often the gateway re-applies the route so it survives reprovisioning.</small>
+                            </div>
+                            <div class="form-group" style="flex: 2;">
+                                <label class="checkbox-label">
+                                    <input type="checkbox" @bind="_editing.SnatEnabled" />
+                                    <span>Allow LAN clients to reach the device (SNAT)</span>
+                                </label>
+                                <small class="form-help">Required for the Network Optimizer server and browsers to reach the device. Leave on unless you only need gateway-local access.</small>
+                            </div>
+                        </div>
+                    </div>
+                </details>
+
+                <div class="action-buttons">
+                    <button class="btn btn-primary" @onclick="SaveAndDeploy" disabled="@(_busyId != null || _saving)">
+                        @if (_saving)
+                        {
+                            <span class="spinner spinner-sm"></span>
+                            <span>Working...</span>
+                        }
+                        else
+                        {
+                            <span>Save &amp; Deploy</span>
+                        }
+                    </button>
+                    <button class="btn btn-secondary" @onclick="SaveOnly" disabled="@(_busyId != null || _saving)">Save without deploying</button>
+                    @if (_editing.Id > 0 || _formVisible)
+                    {
+                        <button class="btn btn-secondary" @onclick="CancelEdit" disabled="@_saving">Cancel</button>
+                    }
+                </div>
+            </div>
+        </details>
+    </div>
+</div>
+
+@code {
+    /// <summary>
+    /// Optional modem/ONT IP to pre-fill into a new interface, used by the deep-links from
+    /// the CM/ONT/Cellular monitor forms ("can't reach it? set up an interface").
+    /// </summary>
+    [Parameter] public string? PrefillTargetIp { get; set; }
+
+    private List<MonitoringInterface> _interfaces = new();
+    private List<WanInterfaceInfo> _wans = new();
+    private readonly Dictionary<int, MonitoringInterfaceDeploymentService.InterfaceStatus> _statuses = new();
+
+    private MonitoringInterface _editing = NewInterface();
+    private bool _formVisible;
+    private bool _saving;
+    private int? _busyId;
+    private string? _busyAction;
+    private string? _message;
+    private bool _messageSuccess;
+    private List<string> _deploySteps = new();
+
+    private string? _appliedPrefill;
+
+    private static MonitoringInterface NewInterface() => new() { Name = "modem0", SubnetPrefix = 24, SnatEnabled = true, WatchdogIntervalMinutes = 5 };
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    protected override void OnParametersSet()
+    {
+        // Absorb the IP the user was trying to reach (from a monitor form deep-link).
+        if (!string.IsNullOrWhiteSpace(PrefillTargetIp) && PrefillTargetIp != _appliedPrefill)
+        {
+            _appliedPrefill = PrefillTargetIp;
+            var existing = _interfaces.FirstOrDefault(i => i.TargetIp == PrefillTargetIp);
+            if (existing != null)
+            {
+                EditInterface(existing);
+            }
+            else
+            {
+                _editing = NewInterface();
+                _editing.TargetIp = PrefillTargetIp!.Trim();
+                OnTargetChanged();
+                _formVisible = true;
+            }
+        }
+    }
+
+    private async Task LoadAsync()
+    {
+        try
+        {
+            _interfaces = await Repo.GetMonitoringInterfacesAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load monitoring interfaces");
+            _interfaces = new();
+        }
+
+        try
+        {
+            _wans = await SqmService.GetWanInterfacesFromControllerAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Failed to load WAN interfaces for monitoring interface picker");
+            _wans = new();
+        }
+    }
+
+    private void ToggleForm() => _formVisible = !_formVisible;
+
+    private void EditInterface(MonitoringInterface mi)
+    {
+        _editing = new MonitoringInterface
+        {
+            Id = mi.Id,
+            Name = mi.Name,
+            WanIfName = mi.WanIfName,
+            WanKey = mi.WanKey,
+            TargetIp = mi.TargetIp,
+            SubnetPrefix = mi.SubnetPrefix,
+            GatewayLocalIp = mi.GatewayLocalIp,
+            SnatEnabled = mi.SnatEnabled,
+            WatchdogIntervalMinutes = mi.WatchdogIntervalMinutes
+        };
+        _formVisible = true;
+        _message = null;
+        _deploySteps.Clear();
+    }
+
+    private void CancelEdit()
+    {
+        _editing = NewInterface();
+        _formVisible = false;
+        _message = null;
+    }
+
+    private void OnTargetChanged()
+    {
+        if (string.IsNullOrWhiteSpace(_editing.GatewayLocalIp))
+            _editing.GatewayLocalIp = SuggestLocalIp(_editing.TargetIp);
+    }
+
+    private void OnWanChanged()
+    {
+        var w = _wans.FirstOrDefault(x => x.PhysicalIfName == _editing.WanIfName);
+        _editing.WanKey = w != null && w.WanIndex > 0 ? $"wan{w.WanIndex}" : null;
+    }
+
+    private async Task SaveOnly()
+    {
+        if (!await ValidateAndSaveAsync())
+            return;
+        _message = "Saved. It won't take effect until you deploy.";
+        _messageSuccess = true;
+        CancelEdit();
+        await LoadAsync();
+    }
+
+    private async Task SaveAndDeploy()
+    {
+        if (!await ValidateAndSaveAsync())
+            return;
+
+        // Reload so we have the persisted Id, then deploy that row.
+        await LoadAsync();
+        var saved = _interfaces.FirstOrDefault(i => i.TargetIp == _editing.TargetIp && i.WanIfName == _editing.WanIfName);
+        _formVisible = false;
+        _editing = NewInterface();
+        if (saved != null)
+            await DeployInterface(saved);
+    }
+
+    private async Task<bool> ValidateAndSaveAsync()
+    {
+        _message = null;
+        _deploySteps.Clear();
+        var error = MonitoringInterfaceDeploymentService.Validate(_editing);
+        if (error != null)
+        {
+            _message = error;
+            _messageSuccess = false;
+            return false;
+        }
+
+        _saving = true;
+        try
+        {
+            await Repo.SaveMonitoringInterfaceAsync(_editing);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to save monitoring interface");
+            _message = $"Save failed: {ex.Message}";
+            _messageSuccess = false;
+            return false;
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private async Task DeployInterface(MonitoringInterface mi)
+    {
+        _busyId = mi.Id;
+        _busyAction = "deploy";
+        _message = null;
+        _deploySteps.Clear();
+        StateHasChanged();
+        try
+        {
+            var result = await Deploy.DeployAsync(mi);
+            _deploySteps = result.Steps;
+            _message = result.Message;
+            _messageSuccess = result.Success;
+            if (result.Success)
+            {
+                mi.LastError = null;
+                await CheckStatus(mi, silent: true);
+            }
+            else
+            {
+                mi.LastError = result.Message;
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Deploy failed for monitoring interface {Id}", mi.Id);
+            _message = $"Deploy failed: {ex.Message}";
+            _messageSuccess = false;
+        }
+        finally
+        {
+            _busyId = null;
+            _busyAction = null;
+            StateHasChanged();
+        }
+    }
+
+    private async Task RemoveInterface(MonitoringInterface mi)
+    {
+        _busyId = mi.Id;
+        _busyAction = "remove";
+        _message = null;
+        _deploySteps.Clear();
+        StateHasChanged();
+        try
+        {
+            var (success, steps) = await Deploy.RemoveAsync(mi);
+            _deploySteps = steps;
+            await Repo.DeleteMonitoringInterfaceAsync(mi.Id);
+            _statuses.Remove(mi.Id);
+            _message = success ? $"Removed monitoring interface {mi.Name}." : "Removed configuration; some gateway cleanup may have failed (see log).";
+            _messageSuccess = success;
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Remove failed for monitoring interface {Id}", mi.Id);
+            _message = $"Remove failed: {ex.Message}";
+            _messageSuccess = false;
+        }
+        finally
+        {
+            _busyId = null;
+            _busyAction = null;
+            StateHasChanged();
+        }
+    }
+
+    private async Task CheckStatus(MonitoringInterface mi, bool silent = false)
+    {
+        if (!silent)
+        {
+            _busyId = mi.Id;
+            _busyAction = "status";
+            StateHasChanged();
+        }
+        try
+        {
+            _statuses[mi.Id] = await Deploy.CheckStatusAsync(mi);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Status check failed for monitoring interface {Id}", mi.Id);
+        }
+        finally
+        {
+            if (!silent)
+            {
+                _busyId = null;
+                _busyAction = null;
+            }
+            StateHasChanged();
+        }
+    }
+
+    private bool IsApplied(MonitoringInterface mi)
+        => _statuses.TryGetValue(mi.Id, out var s) && s.IsFullyApplied(mi);
+
+    private RenderFragment StatusBadge(MonitoringInterface mi) => builder =>
+    {
+        string cls, text;
+        if (!_statuses.TryGetValue(mi.Id, out var s))
+        {
+            cls = "status-disconnected";
+            text = "Unknown";
+        }
+        else if (!s.GatewayReachable)
+        {
+            cls = "status-disconnected";
+            text = "Gateway unreachable";
+        }
+        else if (s.IsFullyApplied(mi))
+        {
+            cls = "status-connected";
+            text = "Active";
+        }
+        else if (s.InterfaceExists || s.BootScriptPresent)
+        {
+            cls = "status-disconnected";
+            text = "Needs re-apply";
+        }
+        else
+        {
+            cls = "status-disconnected";
+            text = "Not deployed";
+        }
+        builder.OpenElement(0, "span");
+        builder.AddAttribute(1, "class", $"status-badge {cls}");
+        builder.AddContent(2, text);
+        builder.CloseElement();
+    };
+
+    private string WanLabelFor(MonitoringInterface mi)
+    {
+        var w = _wans.FirstOrDefault(x => x.PhysicalIfName == mi.WanIfName);
+        if (w != null)
+            return GatewayWanHelper.FormatWanLabel(w.Name, w.WanIndex, w.PhysicalIfName, w.PortLabel);
+        // WAN not currently reported (down/absent) - fall back to the stored identifiers.
+        var index = ParseWanIndex(mi.WanKey);
+        return GatewayWanHelper.FormatWanLabel(null, index, mi.WanIfName, null);
+    }
+
+    private static string WanOptionLabel(WanInterfaceInfo w)
+        => GatewayWanHelper.FormatWanLabel(w.Name, w.WanIndex, w.PhysicalIfName, w.PortLabel);
+
+    private static int ParseWanIndex(string? wanKey)
+        => !string.IsNullOrEmpty(wanKey) && int.TryParse(wanKey.Replace("wan", ""), out var i) ? i : 0;
+
+    /// <summary>
+    /// Suggest a gateway-local IP on the modem's subnet: the target host +/-1, avoiding
+    /// .0/.255 and the target itself. Editable by the user.
+    /// </summary>
+    private static string SuggestLocalIp(string? targetIp)
+    {
+        if (!IPAddress.TryParse(targetIp, out var ip) || ip.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
+            return "";
+        var bytes = ip.GetAddressBytes();
+        int last = bytes[3];
+        int candidate = last + 1;
+        if (candidate >= 255) candidate = last - 1;
+        if (candidate <= 0) candidate = 2;
+        if (candidate == last) candidate = last == 1 ? 2 : last - 1;
+        bytes[3] = (byte)candidate;
+        return new IPAddress(bytes).ToString();
+    }
+}

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -20,6 +20,15 @@
             gateway so that device becomes reachable from the LAN.
         </p>
 
+        <div class="alert alert-info">
+            <strong>Try this first - a native static route may be all you need.</strong>
+            In UniFi Network, go to <strong>Settings → Policy Engine → Policy Table</strong> and add a
+            <strong>Static Route</strong> for the device's IP (for example <code>192.168.100.1/32</code>)
+            out the WAN interface it sits behind. No scripts and nothing to maintain. If the device
+            still isn't reachable afterward - common for modems and ONTs that only answer when the
+            gateway has an on-link address on their subnet - add a monitoring interface below.
+        </div>
+
         @if (_interfaces.Count == 0)
         {
             <p class="empty-state">

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -288,6 +288,12 @@
     /// </summary>
     [Parameter] public string? PrefillTargetIp { get; set; }
 
+    /// <summary>
+    /// Source type of the deep-link (cm/wmodem/ont) used to choose a sensible default
+    /// interface name (cmodem0, wmodem0, ont0), incremented past any existing ones.
+    /// </summary>
+    [Parameter] public string? PrefillSourceType { get; set; }
+
     private List<MonitoringInterface> _interfaces = new();
     private List<WanInterfaceInfo> _wans = new();
     private readonly Dictionary<int, MonitoringInterfaceDeploymentService.InterfaceStatus> _statuses = new();
@@ -352,9 +358,30 @@
                 _editing = NewInterface();
                 _editingOriginal = null;
                 _editing.TargetIp = PrefillTargetIp!.Trim();
+                _editing.Name = NextFreeName(PrefixForType(PrefillSourceType));
                 OnTargetChanged();
             }
             _collapsed = false;
+        }
+    }
+
+    private static string PrefixForType(string? type) => type switch
+    {
+        "cm" => "cmodem",
+        "wmodem" => "wmodem",
+        "ont" => "ont",
+        _ => "modem"
+    };
+
+    /// <summary>Lowest free "{prefix}{n}" name (n from 0) not already used by an interface.</summary>
+    private string NextFreeName(string prefix)
+    {
+        var used = new HashSet<string>(_interfaces.Select(i => i.Name), StringComparer.OrdinalIgnoreCase);
+        for (var n = 0; ; n++)
+        {
+            var candidate = $"{prefix}{n}";
+            if (!used.Contains(candidate))
+                return candidate;
         }
     }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -268,6 +268,10 @@
         margin-bottom: 1rem;
     }
 
+    .mi-advanced .setup-guide-content {
+        margin-top: 0.5rem;
+    }
+
     .mi-grow-1 {
         flex: 1;
     }

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -9,10 +9,18 @@
 @inject ILogger<MonitoringInterfacesCard> Logger
 
 <div class="card" id="monitoring-interfaces">
-    <div class="card-header">
-        <h2 class="card-title">Monitoring Interfaces</h2>
+    <div class="card-header card-header-collapsible" @onclick="ToggleCollapse">
+        <div class="card-title-group">
+            <h2 class="card-title">Monitoring Interfaces</h2>
+        </div>
+        <div class="card-header-right">
+            <span class="status-badge status-active" @onclick:stopPropagation="true">@SummaryLabel()</span>
+            <span class="issue-type-chevron">@(_collapsed ? "▼" : "▲")</span>
+        </div>
     </div>
-    <div class="card-body">
+    <div class="expand-wrapper @(!_collapsed ? "expanded" : "")">
+        <div class="expand-content">
+            <div class="card-body">
         <p class="section-description">
             Having trouble reaching your ONT or modem for polling? When a modem or ONT management
             page sits behind your WAN, the gateway can't route to it and monitoring (and your
@@ -99,105 +107,159 @@
             <div class="alert @(_messageSuccess ? "alert-success" : "alert-danger")" style="margin-top: 1rem;">@_message</div>
         }
 
-        @if (_deploySteps.Count > 0)
-        {
-            <div class="deployment-log" style="margin-top: 1rem;">
-                <h4>Deployment progress</h4>
-                <ul class="step-list">
-                    @foreach (var step in _deploySteps)
-                    {
-                        <li>@step</li>
-                    }
-                </ul>
-            </div>
-        }
-
-        <details class="add-form" open="@_formVisible">
-            <summary @onclick="ToggleForm">@(_editing.Id > 0 ? "Edit Monitoring Interface" : "Add Monitoring Interface")</summary>
-            <div class="add-form-content add-form-content-spaced">
-                <div class="form-row">
-                    <div class="form-group" style="flex: 2;">
-                        <label class="form-label">Modem/ONT IP</label>
-                        <input type="text" class="form-control" @bind="_editing.TargetIp" @bind:after="OnTargetChanged" placeholder="192.168.100.1" />
-                        <small class="form-help">The management IP you're trying to reach (e.g. your modem or ONT status page).</small>
-                    </div>
-                    <div class="form-group" style="flex: 2;">
-                        <label class="form-label">WAN interface</label>
-                        <select class="form-control" @bind="_editing.WanIfName" @bind:after="OnWanChanged">
-                            <option value="">Select WAN...</option>
-                            @foreach (var w in _wans)
+                @if (_deploySteps.Count > 0)
+                {
+                    <div class="mi-deploy-log">
+                        <h4>Deployment progress</h4>
+                        <ul class="mi-step-list">
+                            @foreach (var step in _deploySteps)
                             {
-                                @if (string.IsNullOrEmpty(w.PhysicalIfName))
-                                {
-                                    <option value="" disabled>@WanOptionLabel(w) - no physical port</option>
-                                }
-                                else
-                                {
-                                    <option value="@w.PhysicalIfName">@WanOptionLabel(w)</option>
-                                }
+                                <li>@step</li>
                             }
-                        </select>
-                        <small class="form-help">The WAN your modem/ONT sits behind. The interface rides this port.</small>
+                        </ul>
                     </div>
-                </div>
+                }
 
-                <details class="setup-guide">
-                    <summary>Advanced</summary>
-                    <div class="setup-guide-content">
-                        <div class="form-row">
-                            <div class="form-group" style="flex: 2;">
-                                <label class="form-label">Gateway-local IP</label>
-                                <input type="text" class="form-control" @bind="_editing.GatewayLocalIp" placeholder="192.168.100.2" />
-                                <small class="form-help">The gateway's address on the modem's subnet. Auto-suggested; must be free and on the same subnet.</small>
-                            </div>
-                            <div class="form-group" style="flex: 1;">
-                                <label class="form-label">Subnet prefix</label>
-                                <input type="number" class="form-control" @bind="_editing.SubnetPrefix" min="8" max="30" />
-                            </div>
-                            <div class="form-group" style="flex: 1;">
-                                <label class="form-label">Interface name</label>
-                                <input type="text" class="form-control" @bind="_editing.Name" placeholder="modem0" />
-                            </div>
+                <div class="mi-add-section">
+                    <h3>@(_editing.Id > 0 ? "Edit monitoring interface" : "Add a monitoring interface")</h3>
+                    <div class="form-row">
+                        <div class="form-group mi-grow-2">
+                            <label class="form-label">Modem/ONT IP</label>
+                            <input type="text" class="form-control" @bind="_editing.TargetIp" @bind:after="OnTargetChanged" placeholder="192.168.100.1" />
+                            <small class="form-help">The management IP you're trying to reach (e.g. your modem or ONT status page).</small>
                         </div>
-                        <div class="form-row">
-                            <div class="form-group" style="flex: 1;">
-                                <label class="form-label">Watchdog interval (min)</label>
-                                <input type="number" class="form-control" @bind="_editing.WatchdogIntervalMinutes" min="1" max="60" />
-                                <small class="form-help">How often the gateway re-applies the route so it survives reprovisioning.</small>
-                            </div>
-                            <div class="form-group" style="flex: 2;">
-                                <label class="checkbox-label">
-                                    <input type="checkbox" @bind="_editing.SnatEnabled" />
-                                    <span>Allow LAN clients to reach the device (SNAT)</span>
-                                </label>
-                                <small class="form-help">Required for the Network Optimizer server and browsers to reach the device. Leave on unless you only need gateway-local access.</small>
-                            </div>
+                        <div class="form-group mi-grow-2">
+                            <label class="form-label">WAN interface</label>
+                            <select class="form-control" @bind="_editing.WanIfName" @bind:after="OnWanChanged">
+                                <option value="">Select WAN...</option>
+                                @foreach (var w in _wans)
+                                {
+                                    @if (string.IsNullOrEmpty(w.PhysicalIfName))
+                                    {
+                                        <option value="" disabled>@WanOptionLabel(w) - no physical port</option>
+                                    }
+                                    else
+                                    {
+                                        <option value="@w.PhysicalIfName">@WanOptionLabel(w)</option>
+                                    }
+                                }
+                            </select>
+                            <small class="form-help">The WAN your modem/ONT sits behind. The interface rides this port.</small>
                         </div>
                     </div>
-                </details>
 
-                <div class="action-buttons">
-                    <button class="btn btn-primary" @onclick="SaveAndDeploy" disabled="@(_busyId != null || _saving)">
-                        @if (_saving)
+                    <details class="setup-guide mi-advanced">
+                        <summary>Advanced</summary>
+                        <div class="setup-guide-content">
+                            <div class="form-row">
+                                <div class="form-group mi-grow-2">
+                                    <label class="form-label">Gateway-local IP</label>
+                                    <input type="text" class="form-control" @bind="_editing.GatewayLocalIp" placeholder="192.168.100.2" />
+                                    <small class="form-help">The gateway's address on the modem's subnet. Auto-suggested; must be free and on the same subnet.</small>
+                                </div>
+                                <div class="form-group mi-grow-1">
+                                    <label class="form-label">Subnet prefix</label>
+                                    <input type="number" class="form-control" @bind="_editing.SubnetPrefix" min="8" max="30" />
+                                </div>
+                                <div class="form-group mi-grow-1">
+                                    <label class="form-label">Interface name</label>
+                                    <input type="text" class="form-control" @bind="_editing.Name" placeholder="modem0" />
+                                </div>
+                            </div>
+                            <div class="form-row">
+                                <div class="form-group mi-grow-1">
+                                    <label class="form-label">Watchdog interval (min)</label>
+                                    <input type="number" class="form-control" @bind="_editing.WatchdogIntervalMinutes" min="1" max="60" />
+                                    <small class="form-help">How often the gateway re-applies the route so it survives reprovisioning.</small>
+                                </div>
+                                <div class="form-group mi-grow-2">
+                                    <label class="checkbox-label">
+                                        <input type="checkbox" @bind="_editing.SnatEnabled" />
+                                        <span>Allow LAN clients to reach the device (SNAT)</span>
+                                    </label>
+                                    <small class="form-help">Required for the Network Optimizer server and browsers to reach the device. Leave on unless you only need gateway-local access.</small>
+                                </div>
+                            </div>
+                        </div>
+                    </details>
+
+                    <div class="action-buttons">
+                        <button class="btn btn-primary" @onclick="SaveAndDeploy" disabled="@(_busyId != null || _saving)">
+                            @if (_saving)
+                            {
+                                <span class="spinner spinner-sm"></span>
+                                <span>Working...</span>
+                            }
+                            else
+                            {
+                                <span>Save &amp; Deploy</span>
+                            }
+                        </button>
+                        <button class="btn btn-secondary" @onclick="SaveOnly" disabled="@(_busyId != null || _saving)">Save without deploying</button>
+                        @if (_editing.Id > 0)
                         {
-                            <span class="spinner spinner-sm"></span>
-                            <span>Working...</span>
+                            <button class="btn btn-secondary" @onclick="CancelEdit" disabled="@_saving">Cancel edit</button>
                         }
-                        else
-                        {
-                            <span>Save &amp; Deploy</span>
-                        }
-                    </button>
-                    <button class="btn btn-secondary" @onclick="SaveOnly" disabled="@(_busyId != null || _saving)">Save without deploying</button>
-                    @if (_editing.Id > 0 || _formVisible)
-                    {
-                        <button class="btn btn-secondary" @onclick="CancelEdit" disabled="@_saving">Cancel</button>
-                    }
+                    </div>
                 </div>
             </div>
-        </details>
+        </div>
     </div>
 </div>
+
+<style>
+    .mi-deploy-log {
+        margin-top: 1rem;
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-color);
+        border-radius: var(--border-radius-lg);
+        padding: 1rem;
+    }
+
+    .mi-deploy-log h4 {
+        margin: 0 0 0.5rem 0;
+        font-size: 0.9rem;
+        color: var(--text-primary);
+    }
+
+    .mi-step-list {
+        margin: 0;
+        padding-left: 1.25rem;
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+    }
+
+    .mi-step-list li {
+        margin: 0.25rem 0;
+    }
+
+    .mi-add-section {
+        margin-top: 1.5rem;
+        border: 1px solid var(--border-color);
+        border-radius: var(--border-radius-lg);
+        background: var(--bg-tertiary);
+        padding: 1rem 1.25rem 1.25rem 1.25rem;
+    }
+
+    .mi-add-section h3 {
+        margin: 0 0 1rem 0;
+        font-size: 1rem;
+        color: var(--text-primary);
+    }
+
+    .mi-advanced {
+        margin-bottom: 1rem;
+    }
+
+    .mi-grow-1 {
+        flex: 1;
+    }
+
+    .mi-grow-2 {
+        flex: 2;
+    }
+</style>
 
 @code {
     /// <summary>
@@ -211,7 +273,7 @@
     private readonly Dictionary<int, MonitoringInterfaceDeploymentService.InterfaceStatus> _statuses = new();
 
     private MonitoringInterface _editing = NewInterface();
-    private bool _formVisible;
+    private bool _collapsed = true;
     private bool _saving;
     private int? _busyId;
     private string? _busyAction;
@@ -244,10 +306,23 @@
                 _editing = NewInterface();
                 _editing.TargetIp = PrefillTargetIp!.Trim();
                 OnTargetChanged();
-                _formVisible = true;
             }
+            _collapsed = false;
         }
     }
+
+    private void ToggleCollapse() => _collapsed = !_collapsed;
+
+    /// <summary>Expand the card from outside (e.g. when a deep-link or banner jumps here).</summary>
+    public void Expand()
+    {
+        _collapsed = false;
+        StateHasChanged();
+    }
+
+    private string SummaryLabel()
+        => _interfaces.Count == 0 ? "None configured"
+            : $"{_interfaces.Count} configured";
 
     private async Task LoadAsync()
     {
@@ -272,8 +347,6 @@
         }
     }
 
-    private void ToggleForm() => _formVisible = !_formVisible;
-
     private void EditInterface(MonitoringInterface mi)
     {
         _editing = new MonitoringInterface
@@ -288,7 +361,7 @@
             SnatEnabled = mi.SnatEnabled,
             WatchdogIntervalMinutes = mi.WatchdogIntervalMinutes
         };
-        _formVisible = true;
+        _collapsed = false;
         _message = null;
         _deploySteps.Clear();
     }
@@ -296,7 +369,6 @@
     private void CancelEdit()
     {
         _editing = NewInterface();
-        _formVisible = false;
         _message = null;
     }
 
@@ -330,7 +402,6 @@
         // Reload so we have the persisted Id, then deploy that row.
         await LoadAsync();
         var saved = _interfaces.FirstOrDefault(i => i.TargetIp == _editing.TargetIp && i.WanIfName == _editing.WanIfName);
-        _formVisible = false;
         _editing = NewInterface();
         if (saved != null)
             await DeployInterface(saved);

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -6,6 +6,7 @@
 @inject IMonitoringInterfaceRepository Repo
 @inject MonitoringInterfaceDeploymentService Deploy
 @inject ISqmService SqmService
+@inject Microsoft.JSInterop.IJSRuntime JS
 @inject ILogger<MonitoringInterfacesCard> Logger
 
 <div class="card" id="monitoring-interfaces">
@@ -18,7 +19,7 @@
             <span class="issue-type-chevron">@(_collapsed ? "▼" : "▲")</span>
         </div>
     </div>
-    <div class="expand-wrapper @(!_collapsed ? "expanded" : "")">
+    <div class="expand-wrapper @(!_collapsed && _stateLoaded ? "expanded" : "")" style="@(!_stateLoaded ? "display:none" : "")">
         <div class="expand-content">
             <div class="card-body">
         <p class="section-description">
@@ -301,6 +302,8 @@
     private MonitoringInterface _editing = NewInterface();
     private MonitoringInterface? _editingOriginal;
     private bool _collapsed = true;
+    private bool _stateLoaded;
+    private const string CollapseKey = "monitoring-interfaces-collapsed";
     private bool _saving;
     private int? _busyId;
     private string? _busyAction;
@@ -340,6 +343,29 @@
         // collapse once interfaces exist. A deep-link from Settings overrides this in
         // OnParametersSet (it always expands).
         _collapsed = _interfaces.Count > 0;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+            return;
+
+        // Honor the user's saved collapse preference, unless a deep-link is forcing the
+        // card open (in which case OnParametersSet already expanded it). With no saved
+        // preference, the count-based default from OnInitializedAsync stands.
+        if (string.IsNullOrWhiteSpace(PrefillTargetIp))
+        {
+            try
+            {
+                var val = await JS.InvokeAsync<string>("localStorage.getItem", CollapseKey);
+                if (val == "true") _collapsed = true;
+                else if (val == "false") _collapsed = false;
+            }
+            catch { }
+        }
+
+        _stateLoaded = true;
+        StateHasChanged();
     }
 
     protected override void OnParametersSet()
@@ -385,12 +411,18 @@
         }
     }
 
-    private void ToggleCollapse() => _collapsed = !_collapsed;
+    private async Task ToggleCollapse()
+    {
+        _collapsed = !_collapsed;
+        try { await JS.InvokeVoidAsync("localStorage.setItem", CollapseKey, _collapsed ? "true" : "false"); }
+        catch { }
+    }
 
     /// <summary>Expand the card from outside (e.g. when a deep-link or banner jumps here).</summary>
     public void Expand()
     {
         _collapsed = false;
+        _stateLoaded = true;
         StateHasChanged();
     }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -273,6 +273,7 @@
     private readonly Dictionary<int, MonitoringInterfaceDeploymentService.InterfaceStatus> _statuses = new();
 
     private MonitoringInterface _editing = NewInterface();
+    private MonitoringInterface? _editingOriginal;
     private bool _collapsed = true;
     private bool _saving;
     private int? _busyId;
@@ -284,6 +285,27 @@
     private string? _appliedPrefill;
 
     private static MonitoringInterface NewInterface() => new() { Name = "modem0", SubnetPrefix = 24, SnatEnabled = true, WatchdogIntervalMinutes = 5 };
+
+    private static MonitoringInterface Snapshot(MonitoringInterface mi) => new()
+    {
+        Id = mi.Id,
+        Name = mi.Name,
+        WanIfName = mi.WanIfName,
+        WanKey = mi.WanKey,
+        TargetIp = mi.TargetIp,
+        SubnetPrefix = mi.SubnetPrefix,
+        GatewayLocalIp = mi.GatewayLocalIp,
+        SnatEnabled = mi.SnatEnabled,
+        WatchdogIntervalMinutes = mi.WatchdogIntervalMinutes
+    };
+
+    // A gateway re-teardown is needed when an edit changes anything the boot script bakes
+    // into the macvlan name, route, SNAT rule, or script filename - otherwise the old
+    // artifacts (interface, route, SNAT, cron, /data/on_boot.d file) are orphaned.
+    private static bool NeedsOldTeardown(MonitoringInterface a, MonitoringInterface b)
+        => a.Name != b.Name || a.WanIfName != b.WanIfName || a.TargetIp != b.TargetIp
+            || a.GatewayLocalIp != b.GatewayLocalIp || a.SubnetPrefix != b.SubnetPrefix
+            || a.SnatEnabled != b.SnatEnabled;
 
     protected override async Task OnInitializedAsync()
     {
@@ -304,6 +326,7 @@
             else
             {
                 _editing = NewInterface();
+                _editingOriginal = null;
                 _editing.TargetIp = PrefillTargetIp!.Trim();
                 OnTargetChanged();
             }
@@ -349,18 +372,8 @@
 
     private void EditInterface(MonitoringInterface mi)
     {
-        _editing = new MonitoringInterface
-        {
-            Id = mi.Id,
-            Name = mi.Name,
-            WanIfName = mi.WanIfName,
-            WanKey = mi.WanKey,
-            TargetIp = mi.TargetIp,
-            SubnetPrefix = mi.SubnetPrefix,
-            GatewayLocalIp = mi.GatewayLocalIp,
-            SnatEnabled = mi.SnatEnabled,
-            WatchdogIntervalMinutes = mi.WatchdogIntervalMinutes
-        };
+        _editing = Snapshot(mi);
+        _editingOriginal = Snapshot(mi);
         _collapsed = false;
         _message = null;
         _deploySteps.Clear();
@@ -369,6 +382,7 @@
     private void CancelEdit()
     {
         _editing = NewInterface();
+        _editingOriginal = null;
         _message = null;
     }
 
@@ -396,6 +410,10 @@
 
     private async Task SaveAndDeploy()
     {
+        // Capture the pre-edit config before save/reset so we can tear down any orphaned
+        // gateway state (renamed interface, changed WAN/target, disabled SNAT, etc.).
+        var original = _editingOriginal;
+
         if (!await ValidateAndSaveAsync())
             return;
 
@@ -403,6 +421,22 @@
         await LoadAsync();
         var saved = _interfaces.FirstOrDefault(i => i.TargetIp == _editing.TargetIp && i.WanIfName == _editing.WanIfName);
         _editing = NewInterface();
+        _editingOriginal = null;
+
+        // Editing changed gateway-affecting fields: remove the old config first so we don't
+        // leave a stale macvlan/route/SNAT/cron/boot-script behind.
+        if (original != null && saved != null && NeedsOldTeardown(original, saved))
+        {
+            try
+            {
+                await Deploy.RemoveAsync(original);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(ex, "Failed to tear down previous monitoring interface config before re-deploy");
+            }
+        }
+
         if (saved != null)
             await DeployInterface(saved);
     }
@@ -488,6 +522,14 @@
             _deploySteps = steps;
             await Repo.DeleteMonitoringInterfaceAsync(mi.Id);
             _statuses.Remove(mi.Id);
+
+            // If we were editing the interface we just removed, drop back to the add form.
+            if (_editing.Id == mi.Id)
+            {
+                _editing = NewInterface();
+                _editingOriginal = null;
+            }
+
             _message = success ? $"Removed monitoring interface {mi.Name}." : "Removed configuration; some gateway cleanup may have failed (see log).";
             _messageSuccess = success;
             await LoadAsync();

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -167,6 +167,7 @@ builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.IUniFiRepository,
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.IModemRepository, NetworkOptimizer.Storage.Repositories.ModemRepository>();
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.ICmRepository, NetworkOptimizer.Storage.Repositories.CmRepository>();
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.IOntRepository, NetworkOptimizer.Storage.Repositories.OntRepository>();
+builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.IMonitoringInterfaceRepository, NetworkOptimizer.Storage.Repositories.MonitoringInterfaceRepository>();
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.ISpeedTestRepository, NetworkOptimizer.Storage.Repositories.SpeedTestRepository>();
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.ISqmRepository, NetworkOptimizer.Storage.Repositories.SqmRepository>();
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.IAgentRepository, NetworkOptimizer.Storage.Repositories.AgentRepository>();
@@ -177,6 +178,10 @@ builder.Services.AddSingleton<SshClientService>();
 
 // Register Gateway SSH service (singleton - SSH access to UniFi gateway/UDM)
 builder.Services.AddSingleton<IGatewaySshService, GatewaySshService>();
+
+// Register udm-boot installer (singleton - shared gateway boot-script infrastructure
+// used by Adaptive SQM, Monitoring Interfaces, etc.)
+builder.Services.AddSingleton<IUdmBootService, UdmBootService>();
 
 // Register UniFi SSH service (singleton - shared SSH credentials for all UniFi devices)
 builder.Services.AddSingleton<UniFiSshService>();
@@ -408,6 +413,7 @@ builder.Services.AddScoped<ISqmService, SqmService>();
 builder.Services.AddScoped<SqmDeploymentService>();
 builder.Services.AddScoped<WanSteerDeploymentService>();
 builder.Services.AddScoped<PerfTweaksDeploymentService>();
+builder.Services.AddScoped<MonitoringInterfaceDeploymentService>();
 builder.Services.AddScoped<AgentService>();
 
 // Register WiFi Optimizer rules and engine

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
@@ -157,14 +157,17 @@ public sealed class NetgearCmProvider : ICableModemProvider
         string? password,
         CancellationToken cancellationToken)
     {
-        // A cookie jar keeps the session across the optional MultiLogin takeover (GET ->
-        // POST -> re-GET). AllowAutoRedirect (the default) lets the modem 302 us onto
-        // MultiLogin.asp when another session is active.
+        // Follow redirects manually (AllowAutoRedirect = false) so the Basic auth header is
+        // sent on EVERY hop. .NET drops the Authorization header when auto-following a
+        // redirect, which breaks single-session modems (e.g. CM600) that 302 every page to
+        // MultiLogin.asp when another session is active - the redirected request would 401.
+        // The cookie jar keeps the session across the takeover (GET -> POST -> re-GET).
         using var handler = new HttpClientHandler
         {
             AutomaticDecompression = System.Net.DecompressionMethods.GZip | System.Net.DecompressionMethods.Deflate,
             CookieContainer = new System.Net.CookieContainer(),
             UseCookies = true,
+            AllowAutoRedirect = false,
         };
         using var client = new HttpClient(handler)
         {
@@ -177,7 +180,7 @@ public sealed class NetgearCmProvider : ICableModemProvider
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
         }
 
-        var response = await client.GetAsync(url, cancellationToken);
+        var response = await GetFollowingRedirectsAsync(client, url, cancellationToken);
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
 
@@ -188,13 +191,40 @@ public sealed class NetgearCmProvider : ICableModemProvider
         {
             if (await TryTakeOverSessionAsync(client, url, content, cancellationToken))
             {
-                response = await client.GetAsync(url, cancellationToken);
+                response = await GetFollowingRedirectsAsync(client, url, cancellationToken);
                 response.EnsureSuccessStatusCode();
                 content = await response.Content.ReadAsStringAsync(cancellationToken);
             }
         }
 
         return string.IsNullOrWhiteSpace(content) ? null : content;
+    }
+
+    /// <summary>
+    /// GET a URL, following same-style redirects manually so the client's default headers
+    /// (notably Basic auth) are re-sent on each hop - unlike HttpClient auto-redirect, which
+    /// strips the Authorization header. Resolves relative Location values (e.g.
+    /// "MultiLogin.asp"). Stops after a few hops to avoid loops.
+    /// </summary>
+    private static async Task<HttpResponseMessage> GetFollowingRedirectsAsync(
+        HttpClient client,
+        string url,
+        CancellationToken cancellationToken)
+    {
+        var current = url;
+        var response = await client.GetAsync(current, cancellationToken);
+
+        for (int hop = 0; hop < 5
+            && (int)response.StatusCode is >= 300 and < 400
+            && response.Headers.Location != null; hop++)
+        {
+            var next = new Uri(new Uri(current), response.Headers.Location);
+            response.Dispose();
+            current = next.ToString();
+            response = await client.GetAsync(current, cancellationToken);
+        }
+
+        return response;
     }
 
     /// <summary>
@@ -238,7 +268,9 @@ public sealed class NetgearCmProvider : ICableModemProvider
 
         _logger.LogDebug("Netgear CM: another web session active; logging it out via MultiLogin to poll");
         var postResponse = await client.PostAsync(postUrl, form, cancellationToken);
-        return postResponse.IsSuccessStatusCode;
+        // The takeover POST returns a 302 redirect on success (we don't auto-follow it; the
+        // caller re-fetches the status page). Treat any non-error status as accepted.
+        return (int)postResponse.StatusCode < 400;
     }
 
     private CableModemStats ParseDocsisStatus(string html, CmPollContext context)

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Headers;
 using System.Text;
+using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
@@ -23,6 +24,15 @@ public sealed class NetgearCmProvider : ICableModemProvider
     private const int TimeoutSeconds = 15;
     private const int MaxRetries = 3;
     private static readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(1);
+
+    // Some Netgear modems (e.g. CM600) allow only one web session at a time. When another
+    // session is active, any page 302-redirects to MultiLogin.asp, which offers to log out
+    // the existing session. These patterns pull the takeover token and RetailSessionId from
+    // that page so polling can claim the session instead of failing.
+    private static readonly Regex MultiLoginSessionRx =
+        new(@"goform/MultiLogin\?session=([0-9A-Za-z]+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex RetailSessionRx =
+        new("name=[\"']?RetailSessionId[\"']?\\s+value=[\"']?([0-9A-Za-z]+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     private readonly ILogger<NetgearCmProvider> _logger;
 
@@ -147,9 +157,14 @@ public sealed class NetgearCmProvider : ICableModemProvider
         string? password,
         CancellationToken cancellationToken)
     {
+        // A cookie jar keeps the session across the optional MultiLogin takeover (GET ->
+        // POST -> re-GET). AllowAutoRedirect (the default) lets the modem 302 us onto
+        // MultiLogin.asp when another session is active.
         using var handler = new HttpClientHandler
         {
             AutomaticDecompression = System.Net.DecompressionMethods.GZip | System.Net.DecompressionMethods.Deflate,
+            CookieContainer = new System.Net.CookieContainer(),
+            UseCookies = true,
         };
         using var client = new HttpClient(handler)
         {
@@ -164,9 +179,66 @@ public sealed class NetgearCmProvider : ICableModemProvider
 
         var response = await client.GetAsync(url, cancellationToken);
         response.EnsureSuccessStatusCode();
-
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        // If we landed on the single-session takeover page (rather than the status page),
+        // claim the session and re-fetch. Modems without this behavior never hit this path,
+        // so the normal flow is unchanged.
+        if (IsMultiLoginPage(response.RequestMessage?.RequestUri, content))
+        {
+            if (await TryTakeOverSessionAsync(client, url, content, cancellationToken))
+            {
+                response = await client.GetAsync(url, cancellationToken);
+                response.EnsureSuccessStatusCode();
+                content = await response.Content.ReadAsStringAsync(cancellationToken);
+            }
+        }
+
         return string.IsNullOrWhiteSpace(content) ? null : content;
+    }
+
+    /// <summary>
+    /// True when a response is the Netgear single-session "MultiLogin" takeover page
+    /// (another web session is active) rather than the requested status page.
+    /// </summary>
+    private static bool IsMultiLoginPage(Uri? finalUri, string content)
+    {
+        if (finalUri != null && finalUri.AbsolutePath.Contains("MultiLogin", StringComparison.OrdinalIgnoreCase))
+            return true;
+        return content.Contains("goform/MultiLogin", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Logs out the existing web session by POSTing the MultiLogin takeover form
+    /// (<c>yes=yes&amp;Act=yes&amp;RetailSessionId=...</c> to
+    /// <c>/goform/MultiLogin?session=...</c>). Returns true if the takeover was submitted.
+    /// </summary>
+    private async Task<bool> TryTakeOverSessionAsync(
+        HttpClient client,
+        string statusUrl,
+        string multiLoginHtml,
+        CancellationToken cancellationToken)
+    {
+        var sessionMatch = MultiLoginSessionRx.Match(multiLoginHtml);
+        var retailMatch = RetailSessionRx.Match(multiLoginHtml);
+        if (!sessionMatch.Success || !retailMatch.Success)
+        {
+            _logger.LogDebug("Netgear CM MultiLogin page seen but takeover tokens not found; cannot reclaim session");
+            return false;
+        }
+
+        var authority = new Uri(statusUrl).GetLeftPart(UriPartial.Authority);
+        var postUrl = $"{authority}/goform/MultiLogin?session={sessionMatch.Groups[1].Value}";
+        var form = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("yes", "yes"),
+            new KeyValuePair<string, string>("Act", "yes"),
+            new KeyValuePair<string, string>("RetailSessionId", retailMatch.Groups[1].Value),
+        });
+
+        _logger.LogDebug("Netgear CM: another web session active; logging it out via MultiLogin to poll");
+        var postResponse = await client.PostAsync(postUrl, form, cancellationToken);
+        return postResponse.IsSuccessStatusCode;
     }
 
     private CableModemStats ParseDocsisStatus(string html, CmPollContext context)

--- a/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
@@ -280,29 +280,41 @@ public class MonitoringInterfaceDeploymentService
     }
 
     /// <summary>
-    /// On-gateway duplicate-address detection for the chosen gateway-local IP. Brings up a
-    /// bare macvlan (no address) and runs arping in DAD mode. Returns
-    /// <see cref="PreflightBlock.LocalIpInUse"/> if the address answers, <see cref="PreflightBlock.None"/>
-    /// if free or if arping is unavailable to verify.
+    /// On-gateway check that the chosen gateway-local IP isn't already answering on the
+    /// modem's L2 segment. Brings up a bare macvlan and sends a plain ARP probe (sender
+    /// 0.0.0.0) for the candidate: a reply means the address is taken. We deliberately do
+    /// NOT use <c>arping -D</c> - on UniFi OS that mode errors on a bare interface and
+    /// returns a non-zero code even for free addresses (it would false-positive every
+    /// deploy). A reply line ("reply from") is the only reliable signal here.
+    /// Returns <see cref="PreflightBlock.LocalIpInUse"/> when taken,
+    /// <see cref="PreflightBlock.Skipped"/> when arping is unavailable, otherwise
+    /// <see cref="PreflightBlock.None"/> (free, or we couldn't create the probe interface -
+    /// in which case the boot script will surface any real failure).
     /// </summary>
     private async Task<PreflightBlock> CheckLocalIpAvailableAsync(MonitoringInterface mi)
     {
-        // Create the macvlan (idempotent) and bring it up so arping can transmit. The boot
-        // script will reuse this interface. arping -D returns 1 when a duplicate replies.
+        // Create the macvlan (idempotent) and bring it up so arping can transmit on the
+        // modem segment. The boot script reuses this interface.
         var probe =
             $"ip link show {mi.Name} >/dev/null 2>&1 || ip link add {mi.Name} link {mi.WanIfName} type macvlan mode bridge; " +
             $"ip link set {mi.Name} up 2>/dev/null; " +
-            $"if command -v arping >/dev/null 2>&1; then arping -D -q -c 2 -w 3 -I {mi.Name} {mi.GatewayLocalIp}; echo RC:$?; else echo RC:SKIP; fi";
+            $"if ! ip link show {mi.Name} >/dev/null 2>&1; then echo RESULT:NOIFACE; " +
+            $"elif ! command -v arping >/dev/null 2>&1; then echo RESULT:SKIP; " +
+            $"else out=$(arping -c 2 -w 2 -I {mi.Name} -S 0.0.0.0 {mi.GatewayLocalIp} 2>&1); " +
+            $"if echo \"$out\" | grep -qi 'reply from'; then echo RESULT:INUSE; else echo RESULT:FREE; fi; fi";
 
         var result = await RunAsync(probe, TimeSpan.FromSeconds(15));
         if (!result.success)
             return PreflightBlock.None; // can't verify; let the apply proceed
 
-        if (result.output.Contains("RC:SKIP"))
+        if (result.output.Contains("RESULT:INUSE"))
+            return PreflightBlock.LocalIpInUse;
+        if (result.output.Contains("RESULT:SKIP"))
             return PreflightBlock.Skipped;
 
-        // arping -D exit code: 0 = address free, non-zero = duplicate detected
-        return result.output.Contains("RC:0") ? PreflightBlock.None : PreflightBlock.LocalIpInUse;
+        // RESULT:FREE, RESULT:NOIFACE, or anything unexpected -> don't block; let the
+        // boot-script apply proceed and surface any genuine error.
+        return PreflightBlock.None;
     }
 
     private async Task<bool> IsReachableFromServerAsync(string ip)

--- a/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
@@ -1,0 +1,443 @@
+using System.Net;
+using System.Net.NetworkInformation;
+using NetworkOptimizer.Core.Helpers;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services.Ssh;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Deploys "monitoring interfaces" to the UniFi gateway: a macvlan on the physical WAN
+/// port plus a host route and optional SNAT so the Network Optimizer server (a LAN
+/// client) and browsers can reach an ONT/modem management IP that sits behind the WAN.
+/// The boot script is self-contained and idempotent and installs a cron watchdog so it
+/// survives reboots and UniFi reprovisioning - the same model as Adaptive SQM and
+/// Performance Tweaks. All gateway access goes through <see cref="IGatewaySshService"/>.
+/// </summary>
+public class MonitoringInterfaceDeploymentService
+{
+    private readonly ILogger<MonitoringInterfaceDeploymentService> _logger;
+    private readonly IGatewaySshService _gatewaySsh;
+    private readonly IUdmBootService _udmBoot;
+    private readonly UniFiConnectionService _connection;
+
+    private const string OnBootDir = "/data/on_boot.d";
+
+    public MonitoringInterfaceDeploymentService(
+        ILogger<MonitoringInterfaceDeploymentService> logger,
+        IGatewaySshService gatewaySsh,
+        IUdmBootService udmBoot,
+        UniFiConnectionService connection)
+    {
+        _logger = logger;
+        _gatewaySsh = gatewaySsh;
+        _udmBoot = udmBoot;
+        _connection = connection;
+    }
+
+    private static string ScriptName(MonitoringInterface mi) => $"30-monitoring-iface-{mi.Name}.sh";
+    private static string ScriptPath(MonitoringInterface mi) => $"{OnBootDir}/{ScriptName(mi)}";
+
+    /// <summary>
+    /// Validate a monitoring interface configuration. Returns null when valid, otherwise
+    /// a human-readable reason. Also enforces shell-safety of interpolated values.
+    /// </summary>
+    public static string? Validate(MonitoringInterface mi)
+    {
+        if (string.IsNullOrWhiteSpace(mi.Name) ||
+            !System.Text.RegularExpressions.Regex.IsMatch(mi.Name, "^[a-z][a-z0-9-]{0,14}$"))
+            return "Interface name must be 1-15 chars, start with a letter, and use only lowercase letters, digits, or hyphens.";
+
+        if (string.IsNullOrWhiteSpace(mi.WanIfName) ||
+            !System.Text.RegularExpressions.Regex.IsMatch(mi.WanIfName, "^[a-zA-Z0-9._-]{1,20}$"))
+            return "Select a WAN interface.";
+
+        if (!IPAddress.TryParse(mi.TargetIp, out var target) || target.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
+            return "Modem/ONT IP must be a valid IPv4 address.";
+
+        if (!IPAddress.TryParse(mi.GatewayLocalIp, out var local) || local.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
+            return "Gateway-local IP must be a valid IPv4 address.";
+
+        if (mi.SubnetPrefix < 8 || mi.SubnetPrefix > 30)
+            return "Subnet prefix must be between /8 and /30.";
+
+        if (mi.TargetIp == mi.GatewayLocalIp)
+            return "Gateway-local IP must differ from the modem/ONT IP.";
+
+        var subnet = $"{mi.TargetIp}/{mi.SubnetPrefix}";
+        if (!NetworkUtilities.IsIpInSubnet(mi.GatewayLocalIp, NetworkAddress(subnet)))
+            return "Gateway-local IP must be on the same subnet as the modem/ONT IP.";
+
+        if (mi.WatchdogIntervalMinutes < 1 || mi.WatchdogIntervalMinutes > 60)
+            return "Watchdog interval must be between 1 and 60 minutes.";
+
+        return null;
+    }
+
+    /// <summary>Reason a deploy preflight blocked, or <see cref="None"/> when clear to deploy.</summary>
+    public enum PreflightBlock
+    {
+        None,
+        InvalidInput,
+        UniFiOverlap,
+        AlreadyReachable,
+        LocalIpInUse,
+        GatewayUnreachable,
+
+        /// <summary>The on-gateway duplicate-IP check could not run (arping unavailable).</summary>
+        Skipped
+    }
+
+    public record PreflightResult(bool Ok, PreflightBlock Block, string Message);
+
+    /// <summary>
+    /// Server-side preflight (no gateway changes): validates input, checks that the
+    /// target subnet does not overlap a UniFi-managed network/VLAN, and checks that the
+    /// target is not already reachable from the Network Optimizer server. The local-IP
+    /// availability gate runs on the gateway during <see cref="DeployAsync"/>.
+    /// </summary>
+    public async Task<PreflightResult> PreflightAsync(MonitoringInterface mi, CancellationToken ct = default)
+    {
+        var invalid = Validate(mi);
+        if (invalid != null)
+            return new PreflightResult(false, PreflightBlock.InvalidInput, invalid);
+
+        // Gate 1: overlap with a UniFi-managed network/VLAN. If the gateway already owns
+        // this address space, a dedicated monitoring route isn't possible.
+        try
+        {
+            var networks = await _connection.GetNetworksAsync(ct);
+            foreach (var net in networks)
+            {
+                if (net.IsWan || !net.Enabled || string.IsNullOrEmpty(net.IpSubnet))
+                    continue;
+
+                if (NetworkUtilities.IsIpInSubnet(mi.TargetIp, net.IpSubnet) ||
+                    NetworkUtilities.IsIpInSubnet(mi.GatewayLocalIp, net.IpSubnet))
+                {
+                    return new PreflightResult(false, PreflightBlock.UniFiOverlap,
+                        $"{mi.TargetIp} overlaps your \"{net.Name}\" network ({net.IpSubnet}). " +
+                        "Monitoring this device via a dedicated interface isn't possible - renumber the modem or that network.");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not load UniFi networks for overlap preflight; continuing");
+        }
+
+        // Gate 2: target already reachable from the server. Either monitoring already
+        // works (no plumbing needed) or it's a duplicate-IP collision we can't safely
+        // route to (the alternate-IP DNAT case is a documented TODO).
+        if (await IsReachableFromServerAsync(mi.TargetIp))
+        {
+            return new PreflightResult(false, PreflightBlock.AlreadyReachable,
+                $"{mi.TargetIp} is already reachable from the Network Optimizer server. " +
+                "If monitoring already works, no interface is needed. If a different device also uses this IP, " +
+                "alternate-IP routing isn't supported yet.");
+        }
+
+        return new PreflightResult(true, PreflightBlock.None, "Ready to deploy.");
+    }
+
+    public record DeployResult(bool Success, PreflightBlock Block, string Message, List<string> Steps);
+
+    /// <summary>
+    /// Deploy (or re-apply) a monitoring interface: runs the server-side preflight,
+    /// ensures udm-boot, performs the on-gateway local-IP availability gate, then writes
+    /// and runs the idempotent boot script (which installs the cron watchdog).
+    /// </summary>
+    public async Task<DeployResult> DeployAsync(MonitoringInterface mi, CancellationToken ct = default)
+    {
+        var steps = new List<string>();
+
+        var preflight = await PreflightAsync(mi, ct);
+        if (!preflight.Ok)
+            return new DeployResult(false, preflight.Block, preflight.Message, steps);
+        steps.Add("Preflight passed: no UniFi network overlap, target not already reachable.");
+
+        // Ensure udm-boot so the interface survives reboots and firmware updates.
+        if (!await _udmBoot.IsInstalledAsync())
+        {
+            steps.Add("Installing udm-boot (gateway boot persistence)...");
+            var (udmOk, udmMsg) = await _udmBoot.InstallAsync();
+            if (!udmOk)
+                return new DeployResult(false, PreflightBlock.GatewayUnreachable, $"udm-boot install failed: {udmMsg}", steps);
+            steps.Add("udm-boot installed.");
+        }
+
+        // Gate 3 (on-gateway): ensure the chosen gateway-local IP isn't already in use on
+        // the modem subnet. Bring up a bare macvlan and run duplicate-address detection.
+        var dupCheck = await CheckLocalIpAvailableAsync(mi);
+        if (dupCheck == PreflightBlock.LocalIpInUse)
+        {
+            await RunAsync($"ip link del {mi.Name} 2>/dev/null || true");
+            return new DeployResult(false, PreflightBlock.LocalIpInUse,
+                $"{mi.GatewayLocalIp} is already in use on the modem subnet. Pick a different gateway-local IP.", steps);
+        }
+        steps.Add(dupCheck == PreflightBlock.None
+            ? $"Gateway-local IP {mi.GatewayLocalIp} is free."
+            : "Skipped duplicate-IP check (arping unavailable).");
+
+        // Write and run the idempotent boot script.
+        var script = GenerateBootScript(mi);
+        var unix = script.Replace("\r\n", "\n").Replace("\r", "\n");
+        var b64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(unix));
+        var path = ScriptPath(mi);
+
+        var write = await RunAsync($"mkdir -p {OnBootDir} && echo '{b64}' | base64 -d > '{path}' && chmod +x '{path}'");
+        if (!write.success)
+            return new DeployResult(false, PreflightBlock.GatewayUnreachable, $"Failed to write boot script: {write.output}", steps);
+        steps.Add($"Wrote boot script {ScriptName(mi)}.");
+
+        var run = await RunAsync($"'{path}'", TimeSpan.FromSeconds(30));
+        if (!run.success)
+            return new DeployResult(false, PreflightBlock.GatewayUnreachable, $"Boot script run failed: {run.output}", steps);
+        steps.Add("Applied macvlan, route" + (mi.SnatEnabled ? ", SNAT" : "") + ", and cron watchdog.");
+
+        return new DeployResult(true, PreflightBlock.None,
+            $"Monitoring interface {mi.Name} deployed. {mi.TargetIp} is now reachable from the LAN.", steps);
+    }
+
+    /// <summary>
+    /// Remove a monitoring interface from the gateway: cron entry, SNAT rule, route,
+    /// address, macvlan link, and the boot script. Idempotent.
+    /// </summary>
+    public async Task<(bool success, List<string> steps)> RemoveAsync(MonitoringInterface mi)
+    {
+        var steps = new List<string>();
+        var path = ScriptPath(mi);
+
+        await RunAsync($"crontab -l 2>/dev/null | grep -vF '{path}' | crontab - 2>/dev/null || true");
+        steps.Add("Removed cron watchdog.");
+
+        if (mi.SnatEnabled)
+        {
+            await RunAsync($"iptables -t nat -D POSTROUTING -o {mi.Name} -d {mi.TargetIp} -j SNAT --to-source {mi.GatewayLocalIp} 2>/dev/null || true");
+            steps.Add("Removed SNAT rule.");
+        }
+
+        await RunAsync($"ip route del {mi.TargetIp}/32 dev {mi.Name} 2>/dev/null || true");
+        await RunAsync($"ip link del {mi.Name} 2>/dev/null || true");
+        steps.Add("Removed route and macvlan interface.");
+
+        await RunAsync($"rm -f '{path}' /tmp/netopt-moniface-{mi.Name}.log 2>/dev/null || true");
+        steps.Add("Removed boot script.");
+
+        return (true, steps);
+    }
+
+    /// <summary>Live status of a deployed monitoring interface on the gateway.</summary>
+    public class InterfaceStatus
+    {
+        public bool GatewayReachable { get; set; }
+        public bool UdmBootInstalled { get; set; }
+        public bool InterfaceExists { get; set; }
+        public bool LocalIpAssigned { get; set; }
+        public bool RoutePresent { get; set; }
+        public bool SnatPresent { get; set; }
+        public bool WatchdogCronPresent { get; set; }
+        public bool BootScriptPresent { get; set; }
+
+        /// <summary>True when every expected component for the given config is in place.</summary>
+        public bool IsFullyApplied(MonitoringInterface mi) =>
+            InterfaceExists && LocalIpAssigned && RoutePresent &&
+            (!mi.SnatEnabled || SnatPresent) && WatchdogCronPresent && BootScriptPresent;
+    }
+
+    /// <summary>
+    /// Check the live state of a monitoring interface using a single delimited SSH call.
+    /// </summary>
+    public async Task<InterfaceStatus> CheckStatusAsync(MonitoringInterface mi)
+    {
+        var status = new InterfaceStatus();
+        var path = ScriptPath(mi);
+
+        var combined =
+            "echo '---UDM_BOOT---'; test -f /etc/systemd/system/udm-boot.service && echo y || echo n; " +
+            $"echo '---IFACE---'; ip link show {mi.Name} >/dev/null 2>&1 && echo y || echo n; " +
+            $"echo '---LOCALIP---'; ip -4 addr show dev {mi.Name} 2>/dev/null | grep -q 'inet {mi.GatewayLocalIp}/{mi.SubnetPrefix}' && echo y || echo n; " +
+            $"echo '---ROUTE---'; ip route show {mi.TargetIp}/32 2>/dev/null | grep -q 'dev {mi.Name}' && echo y || echo n; " +
+            $"echo '---SNAT---'; iptables -t nat -C POSTROUTING -o {mi.Name} -d {mi.TargetIp} -j SNAT --to-source {mi.GatewayLocalIp} 2>/dev/null && echo y || echo n; " +
+            $"echo '---CRON---'; crontab -l 2>/dev/null | grep -qF '{path}' && echo y || echo n; " +
+            $"echo '---SCRIPT---'; test -f '{path}' && echo y || echo n";
+
+        var result = await RunAsync(combined);
+        status.GatewayReachable = result.success;
+        if (!result.success)
+            return status;
+
+        var s = ParseDelimited(result.output);
+        bool Yes(string k) => s.TryGetValue(k, out var v) && v.Trim() == "y";
+        status.UdmBootInstalled = Yes("UDM_BOOT");
+        status.InterfaceExists = Yes("IFACE");
+        status.LocalIpAssigned = Yes("LOCALIP");
+        status.RoutePresent = Yes("ROUTE");
+        status.SnatPresent = Yes("SNAT");
+        status.WatchdogCronPresent = Yes("CRON");
+        status.BootScriptPresent = Yes("SCRIPT");
+        return status;
+    }
+
+    /// <summary>
+    /// On-gateway duplicate-address detection for the chosen gateway-local IP. Brings up a
+    /// bare macvlan (no address) and runs arping in DAD mode. Returns
+    /// <see cref="PreflightBlock.LocalIpInUse"/> if the address answers, <see cref="PreflightBlock.None"/>
+    /// if free or if arping is unavailable to verify.
+    /// </summary>
+    private async Task<PreflightBlock> CheckLocalIpAvailableAsync(MonitoringInterface mi)
+    {
+        // Create the macvlan (idempotent) and bring it up so arping can transmit. The boot
+        // script will reuse this interface. arping -D returns 1 when a duplicate replies.
+        var probe =
+            $"ip link show {mi.Name} >/dev/null 2>&1 || ip link add {mi.Name} link {mi.WanIfName} type macvlan mode bridge; " +
+            $"ip link set {mi.Name} up 2>/dev/null; " +
+            $"if command -v arping >/dev/null 2>&1; then arping -D -q -c 2 -w 3 -I {mi.Name} {mi.GatewayLocalIp}; echo RC:$?; else echo RC:SKIP; fi";
+
+        var result = await RunAsync(probe, TimeSpan.FromSeconds(15));
+        if (!result.success)
+            return PreflightBlock.None; // can't verify; let the apply proceed
+
+        if (result.output.Contains("RC:SKIP"))
+            return PreflightBlock.Skipped;
+
+        // arping -D exit code: 0 = address free, non-zero = duplicate detected
+        return result.output.Contains("RC:0") ? PreflightBlock.None : PreflightBlock.LocalIpInUse;
+    }
+
+    private async Task<bool> IsReachableFromServerAsync(string ip)
+    {
+        try
+        {
+            using var ping = new Ping();
+            var reply = await ping.SendPingAsync(ip, 2000);
+            return reply.Status == IPStatus.Success;
+        }
+        catch
+        {
+            return false; // can't ping (e.g. sandboxed) -> treat as not reachable, allow deploy
+        }
+    }
+
+    /// <summary>
+    /// Builds the self-contained, idempotent boot script. Uses token replacement rather
+    /// than string interpolation so the shell's own <c>${...}</c> syntax stays readable.
+    /// </summary>
+    public static string GenerateBootScript(MonitoringInterface mi)
+    {
+        return BootScriptTemplate
+            .Replace("__IFACE__", mi.Name)
+            .Replace("__WAN_IF__", mi.WanIfName)
+            .Replace("__LOCAL_IP__", mi.GatewayLocalIp)
+            .Replace("__PREFIX__", mi.SubnetPrefix.ToString())
+            .Replace("__TARGET_IP__", mi.TargetIp)
+            .Replace("__SNAT_ENABLED__", mi.SnatEnabled ? "1" : "0")
+            .Replace("__WATCHDOG_MIN__", mi.WatchdogIntervalMinutes.ToString())
+            .Replace("__SCRIPT_PATH__", ScriptPath(mi));
+    }
+
+    private const string BootScriptTemplate = @"#!/bin/sh
+# Network Optimizer - Monitoring Interface
+# Idempotently provides LAN/gateway access to a modem/ONT management IP that sits behind
+# the WAN, via a macvlan on the physical WAN port with a gateway-local IP, a host route to
+# the device, and (optionally) a narrow SNAT for LAN clients. Self-installs a cron watchdog
+# so it survives reboots and UniFi reprovisioning.
+# Managed by Network Optimizer - manual edits are overwritten on redeploy.
+
+IFACE=""__IFACE__""
+WAN_IF=""__WAN_IF__""
+LOCAL_IP=""__LOCAL_IP__""
+PREFIX=""__PREFIX__""
+TARGET_IP=""__TARGET_IP__""
+SNAT_ENABLED=""__SNAT_ENABLED__""
+WATCHDOG_MIN=""__WATCHDOG_MIN__""
+SCRIPT=""__SCRIPT_PATH__""
+LOG=""/tmp/netopt-moniface-__IFACE__.log""
+
+log() { echo ""$(date '+%Y-%m-%d %H:%M:%S') $1"" >> ""$LOG"" 2>/dev/null; }
+
+# The physical WAN port must exist; if not (boot race), let the watchdog retry later.
+ip link show ""$WAN_IF"" >/dev/null 2>&1 || { log ""wan $WAN_IF absent, deferring""; exit 0; }
+
+changed=0
+
+# 1. macvlan on the physical WAN port
+if ! ip link show ""$IFACE"" >/dev/null 2>&1; then
+    ip link add ""$IFACE"" link ""$WAN_IF"" type macvlan mode bridge && changed=1
+fi
+ip link set ""$IFACE"" up 2>/dev/null
+
+# 2. gateway-local IP on the macvlan
+if ! ip -4 addr show dev ""$IFACE"" 2>/dev/null | grep -q ""inet $LOCAL_IP/$PREFIX""; then
+    ip addr flush dev ""$IFACE"" 2>/dev/null
+    ip addr add ""$LOCAL_IP/$PREFIX"" dev ""$IFACE"" && changed=1
+fi
+
+# 3. host route to the modem/ONT, sourced from the gateway-local IP
+if ! ip route show ""$TARGET_IP/32"" 2>/dev/null | grep -q ""dev $IFACE""; then
+    ip route replace ""$TARGET_IP/32"" dev ""$IFACE"" src ""$LOCAL_IP"" && changed=1
+fi
+
+# 4. narrow SNAT so LAN clients reach the modem via the gateway-local IP
+if [ ""$SNAT_ENABLED"" = ""1"" ]; then
+    if ! iptables -t nat -C POSTROUTING -o ""$IFACE"" -d ""$TARGET_IP"" -j SNAT --to-source ""$LOCAL_IP"" 2>/dev/null; then
+        iptables -t nat -A POSTROUTING -o ""$IFACE"" -d ""$TARGET_IP"" -j SNAT --to-source ""$LOCAL_IP"" && changed=1
+    fi
+fi
+
+# 5. self-install the cron watchdog (re-applies after reprovision)
+if ! crontab -l 2>/dev/null | grep -qF ""$SCRIPT""; then
+    (crontab -l 2>/dev/null; echo ""*/$WATCHDOG_MIN * * * * $SCRIPT >/dev/null 2>&1"") | crontab -
+    changed=1
+fi
+
+# Log only when something actually changed, to spare the eMMC.
+[ ""$changed"" = ""1"" ] && log ""applied $IFACE on $WAN_IF: $LOCAL_IP/$PREFIX -> $TARGET_IP (snat=$SNAT_ENABLED)""
+exit 0
+";
+
+    // ─── helpers ───
+
+    private Task<(bool success, string output)> RunAsync(string command, TimeSpan? timeout = null)
+        => _gatewaySsh.RunCommandAsync(command, timeout);
+
+    /// <summary>Network (zero-host) address for a CIDR, e.g. "192.168.100.1/24" -> "192.168.100.0/24".</summary>
+    private static string NetworkAddress(string cidr)
+    {
+        var (addr, prefix) = NetworkUtilities.ParseCidr(cidr);
+        if (addr == null) return cidr;
+        var bytes = addr.GetAddressBytes();
+        var bits = prefix;
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            if (bits >= 8) { bits -= 8; continue; }
+            var mask = bits > 0 ? (byte)(0xFF << (8 - bits)) : (byte)0;
+            bytes[i] &= mask;
+            bits = 0;
+        }
+        return $"{new IPAddress(bytes)}/{prefix}";
+    }
+
+    private static Dictionary<string, string> ParseDelimited(string output)
+    {
+        var sections = new Dictionary<string, string>();
+        string? key = null;
+        var value = new List<string>();
+        foreach (var line in output.Split('\n'))
+        {
+            var t = line.Trim();
+            if (t.StartsWith("---") && t.EndsWith("---") && t.Length > 6)
+            {
+                if (key != null) sections[key] = string.Join("\n", value);
+                key = t.Trim('-');
+                value.Clear();
+            }
+            else if (key != null)
+            {
+                value.Add(line);
+            }
+        }
+        if (key != null) sections[key] = string.Join("\n", value);
+        return sections;
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
@@ -69,6 +69,8 @@ public class PerfTweaksDeploymentService
         {
             var combinedCommand =
                 // UDM boot
+                // TODO: use IUdmBootService.IsInstalledAsync() instead of this inline check
+                // (shared gateway boot infrastructure - NetworkOptimizer.Web.Services.Ssh.UdmBootService).
                 "echo '---UDM_BOOT_CHECK---'; test -f /etc/systemd/system/udm-boot.service && echo 'installed' || echo 'missing'; " +
                 "echo '---UDM_BOOT_ENABLED---'; systemctl is-enabled udm-boot 2>/dev/null || echo 'disabled'; " +
                 // Gateway model and firmware
@@ -748,6 +750,10 @@ public class PerfTweaksDeploymentService
         }
     }
 
+    // TODO: depend on IUdmBootService directly instead of routing udm-boot install through
+    // SqmDeploymentService. udm-boot is shared gateway boot infrastructure (see
+    // NetworkOptimizer.Web.Services.Ssh.UdmBootService); this delegation chain
+    // (PerfTweaks -> SQM -> UdmBootService) is incidental coupling.
     public async Task<(bool success, string message)> InstallUdmBootAsync()
     {
         return await _sqmDeployment.InstallUdmBootAsync();

--- a/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
@@ -15,6 +15,7 @@ public class SqmDeploymentService : ISqmDeploymentService
 {
     private readonly ILogger<SqmDeploymentService> _logger;
     private readonly IGatewaySshService _gatewaySsh;
+    private readonly IUdmBootService _udmBoot;
     private readonly IServiceProvider _serviceProvider;
 
     // Gateway paths
@@ -24,10 +25,12 @@ public class SqmDeploymentService : ISqmDeploymentService
     public SqmDeploymentService(
         ILogger<SqmDeploymentService> logger,
         IGatewaySshService gatewaySsh,
+        IUdmBootService udmBoot,
         IServiceProvider serviceProvider)
     {
         _logger = logger;
         _gatewaySsh = gatewaySsh;
+        _udmBoot = udmBoot;
         _serviceProvider = serviceProvider;
     }
 
@@ -54,64 +57,8 @@ public class SqmDeploymentService : ISqmDeploymentService
     /// This enables scripts in /data/on_boot.d/ to run automatically on boot
     /// and persist across firmware updates.
     /// </summary>
-    public async Task<(bool success, string message)> InstallUdmBootAsync()
-    {
-        var settings = await GetGatewaySettingsAsync();
-
-        try
-        {
-            _logger.LogInformation("Installing udm-boot on gateway {Host}", settings.Host);
-
-            // Create the udm-boot service file directly (works on all UDM/UCG devices)
-            // This matches the upstream unifios-utilities version exactly
-            // Note: In C# verbatim strings, "" produces a single ". The bash escape pattern '"'"'
-            // (end single quote, double-quoted single quote, resume single quote) is written as '""'""'
-            var serviceContent = @"[Unit]
-Description=Run On Startup UDM 2.x and above
-Wants=network-online.target
-After=network-online.target
-StartLimitIntervalSec=500
-StartLimitBurst=1
-
-[Service]
-Type=oneshot
-ExecStart=bash -c 'mkdir -p /data/on_boot.d && find -L /data/on_boot.d -mindepth 1 -maxdepth 1 -type f -print0 | sort -z | xargs -0 -r -n 1 -- sh -c '""'""'if test -x ""$0""; then echo ""%n: running $0""; ""$0""; else case ""$0"" in *.sh) echo ""%n: sourcing $0""; . ""$0"";; *) echo ""%n: ignoring $0"";; esac; fi'""'""''
-RemainAfterExit=true
-
-[Install]
-WantedBy=multi-user.target
-";
-
-            // Use base64 encoding to avoid all shell quoting issues when transferring via SSH
-            var base64Content = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(serviceContent));
-
-            // Write service file via base64 decode, enable and start
-            // Use --no-block so we don't wait for boot scripts to finish (they can take a while)
-            var installCmd = $"echo {base64Content} | base64 -d > /etc/systemd/system/udm-boot.service && " +
-                "mkdir -p /data/on_boot.d && " +
-                "systemctl daemon-reload && " +
-                "systemctl enable udm-boot && " +
-                "systemctl start --no-block udm-boot && " +
-                "echo udm-boot_installed_successfully";
-            var result = await RunCommandAsync(installCmd);
-
-            if (result.success && result.output.Contains("udm-boot_installed_successfully"))
-            {
-                _logger.LogInformation("udm-boot installed successfully on {Host}", settings.Host);
-                return (true, "udm-boot installed successfully. Scripts in /data/on_boot.d/ will now run on boot.");
-            }
-            else
-            {
-                _logger.LogError("udm-boot installation failed: {Output}", result.output);
-                return (false, $"Installation failed: {result.output}");
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to install udm-boot");
-            return (false, $"Error: {ex.Message}");
-        }
-    }
+    public Task<(bool success, string message)> InstallUdmBootAsync()
+        => _udmBoot.InstallAsync();
 
     /// <summary>
     /// Parse SSH output delimited by ---KEY--- markers into a dictionary.
@@ -167,6 +114,9 @@ WantedBy=multi-user.target
         try
         {
             // Run all status checks in a single SSH connection using delimiters
+            // TODO: use IUdmBootService.IsInstalledAsync() for the udm-boot check instead of
+            // this inline test (shared gateway boot infrastructure -
+            // NetworkOptimizer.Web.Services.Ssh.UdmBootService).
             var combinedCommand =
                 "echo '---UDM_BOOT_CHECK---'; test -f /etc/systemd/system/udm-boot.service && echo 'installed' || echo 'missing'; " +
                 "echo '---UDM_BOOT_ENABLED---'; systemctl is-enabled udm-boot 2>/dev/null || echo 'disabled'; " +

--- a/src/NetworkOptimizer.Web/Services/SqmService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmService.cs
@@ -338,19 +338,30 @@ public class SqmService : ISqmService
                 _logger.LogDebug("Examining gateway-capable device: type={DeviceType}, model={Model}, name={Name}",
                     deviceType, deviceModel2, deviceName ?? "(unnamed)");
 
-                // Build port_idx -> speed lookup from port_table (for WAN link speed capping)
+                // Build port_idx -> speed and port_idx -> label lookups from port_table
+                // (speed for WAN link speed capping, label for the WAN display name).
                 var portIdxToSpeed = new Dictionary<int, int>();
+                var portIdxToName = new Dictionary<int, string>();
                 if (device.TryGetProperty("port_table", out var portTable) &&
                     portTable.ValueKind == System.Text.Json.JsonValueKind.Array)
                 {
                     foreach (var port in portTable.EnumerateArray())
                     {
-                        var isUp = port.TryGetProperty("up", out var upProp) && upProp.GetBoolean();
                         var portIdx = port.TryGetProperty("port_idx", out var idxProp) && idxProp.TryGetInt32(out var idx) ? idx : -1;
+                        if (portIdx < 0)
+                            continue;
+
+                        var isUp = port.TryGetProperty("up", out var upProp) && upProp.GetBoolean();
                         var speed = port.TryGetProperty("speed", out var speedProp) && speedProp.TryGetInt32(out var spd) ? spd : 0;
-                        if (isUp && portIdx >= 0 && speed > 0)
+                        if (isUp && speed > 0)
                         {
                             portIdxToSpeed[portIdx] = speed;
+                        }
+
+                        var portName = port.TryGetProperty("name", out var portNameProp) ? portNameProp.GetString() : null;
+                        if (!string.IsNullOrEmpty(portName))
+                        {
+                            portIdxToName[portIdx] = portName;
                         }
                     }
                 }
@@ -463,6 +474,13 @@ public class SqmService : ISqmService
                             }
                         }
 
+                        // Physical WAN port index/label (port_table). Used by consumers that
+                        // must attach to the physical port, e.g. a monitoring-interface macvlan.
+                        int? wanPortIdxValue = wanObj.TryGetProperty("port_idx", out var wanPortIdxProp) &&
+                            wanPortIdxProp.TryGetInt32(out var pidx) ? pidx : null;
+                        string? portLabel = wanPortIdxValue.HasValue &&
+                            portIdxToName.TryGetValue(wanPortIdxValue.Value, out var pLabel) ? pLabel : null;
+
                         // TC monitor uses "ifb" + interface name format
                         var tcInterface = $"ifb{uplinkIfname}";
 
@@ -514,7 +532,11 @@ public class SqmService : ISqmService
                             SuggestedPingIp = suggestedPingIp,
                             SmartqEnabled = smartqEnabled,
                             SmartqDownRateMbps = smartqDownRateMbps,
-                            LinkSpeedMbps = linkSpeedMbps
+                            LinkSpeedMbps = linkSpeedMbps,
+                            WanIndex = i,
+                            PhysicalIfName = physicalIfname,
+                            PortIdx = wanPortIdxValue,
+                            PortLabel = portLabel
                         });
 
                         _logger.LogDebug("Accepted {WanKey}: interface={Interface}, name={Name}, networkGroup={NG}, smartQ={SQ}, wanType={WT}",
@@ -779,6 +801,23 @@ public class WanInterfaceInfo
 
     /// <summary>WAN network group identifier from UniFi (e.g., "WAN", "WAN2")</summary>
     public string? NetworkGroup { get; set; }
+
+    /// <summary>1-based WAN index from the device wan{i} key (1 for wan1, 2 for wan2, ...).</summary>
+    public int WanIndex { get; set; }
+
+    /// <summary>
+    /// Physical port backing this WAN (e.g., "eth6"), from the WAN object's ifname.
+    /// Differs from <see cref="Interface"/> on PPPoE/VLAN WANs where Interface is the
+    /// logical uplink (ppp3, eth6.100). Consumers that must attach to the physical port
+    /// (e.g. a monitoring-interface macvlan) use this. Null for virtual WANs (GRE).
+    /// </summary>
+    public string? PhysicalIfName { get; set; }
+
+    /// <summary>port_table index of the physical WAN port, when known.</summary>
+    public int? PortIdx { get; set; }
+
+    /// <summary>Front-panel port label from port_table (e.g., "Port 7"), when known.</summary>
+    public string? PortLabel { get; set; }
 
     /// <summary>Whether UniFi Smart Queues (SQM) is enabled for this WAN in the controller</summary>
     public bool SmartqEnabled { get; set; }

--- a/src/NetworkOptimizer.Web/Services/Ssh/UdmBootService.cs
+++ b/src/NetworkOptimizer.Web/Services/Ssh/UdmBootService.cs
@@ -1,0 +1,97 @@
+namespace NetworkOptimizer.Web.Services.Ssh;
+
+/// <summary>
+/// Installs and checks the generic udm-boot mechanism on a UniFi gateway: a systemd
+/// oneshot unit that runs every executable script in <c>/data/on_boot.d</c> at boot and
+/// persists across firmware updates. This is shared gateway infrastructure used by any
+/// feature that deploys self-contained boot scripts (Adaptive SQM, Monitoring
+/// Interfaces, etc.) - it is NOT specific to any one feature.
+/// </summary>
+public interface IUdmBootService
+{
+    /// <summary>Returns true when the udm-boot systemd unit is present on the gateway.</summary>
+    Task<bool> IsInstalledAsync();
+
+    /// <summary>
+    /// Install the udm-boot systemd unit (idempotent), enabling scripts in
+    /// /data/on_boot.d/ to run on boot.
+    /// </summary>
+    Task<(bool success, string message)> InstallAsync();
+}
+
+/// <inheritdoc />
+public class UdmBootService : IUdmBootService
+{
+    private readonly ILogger<UdmBootService> _logger;
+    private readonly IGatewaySshService _gatewaySsh;
+
+    public UdmBootService(ILogger<UdmBootService> logger, IGatewaySshService gatewaySsh)
+    {
+        _logger = logger;
+        _gatewaySsh = gatewaySsh;
+    }
+
+    public async Task<bool> IsInstalledAsync()
+    {
+        var result = await _gatewaySsh.RunCommandAsync(
+            "test -f /etc/systemd/system/udm-boot.service && echo 'installed' || echo 'missing'");
+        return result.success && result.output.Contains("installed");
+    }
+
+    public async Task<(bool success, string message)> InstallAsync()
+    {
+        var settings = await _gatewaySsh.GetSettingsAsync();
+
+        try
+        {
+            _logger.LogInformation("Installing udm-boot on gateway {Host}", settings.Host);
+
+            // Create the udm-boot service file directly (works on all UDM/UCG devices).
+            // This matches the upstream unifios-utilities version exactly.
+            // Note: In C# verbatim strings, "" produces a single ". The bash escape pattern '"'"'
+            // (end single quote, double-quoted single quote, resume single quote) is written as '""'""'
+            var serviceContent = @"[Unit]
+Description=Run On Startup UDM 2.x and above
+Wants=network-online.target
+After=network-online.target
+StartLimitIntervalSec=500
+StartLimitBurst=1
+
+[Service]
+Type=oneshot
+ExecStart=bash -c 'mkdir -p /data/on_boot.d && find -L /data/on_boot.d -mindepth 1 -maxdepth 1 -type f -print0 | sort -z | xargs -0 -r -n 1 -- sh -c '""'""'if test -x ""$0""; then echo ""%n: running $0""; ""$0""; else case ""$0"" in *.sh) echo ""%n: sourcing $0""; . ""$0"";; *) echo ""%n: ignoring $0"";; esac; fi'""'""''
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target
+";
+
+            // Use base64 encoding to avoid all shell quoting issues when transferring via SSH
+            var base64Content = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(serviceContent));
+
+            // Write service file via base64 decode, enable and start.
+            // Use --no-block so we don't wait for boot scripts to finish (they can take a while).
+            var installCmd = $"echo {base64Content} | base64 -d > /etc/systemd/system/udm-boot.service && " +
+                "mkdir -p /data/on_boot.d && " +
+                "systemctl daemon-reload && " +
+                "systemctl enable udm-boot && " +
+                "systemctl start --no-block udm-boot && " +
+                "echo udm-boot_installed_successfully";
+            var result = await _gatewaySsh.RunCommandAsync(installCmd);
+
+            if (result.success && result.output.Contains("udm-boot_installed_successfully"))
+            {
+                _logger.LogInformation("udm-boot installed successfully on {Host}", settings.Host);
+                return (true, "udm-boot installed successfully. Scripts in /data/on_boot.d/ will now run on boot.");
+            }
+
+            _logger.LogError("udm-boot installation failed: {Output}", result.output);
+            return (false, $"Installation failed: {result.output}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to install udm-boot");
+            return (false, $"Error: {ex.Message}");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/WanSteerDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/WanSteerDeploymentService.cs
@@ -46,6 +46,9 @@ public class WanSteerDeploymentService
 
         try
         {
+            // TODO: use IUdmBootService.IsInstalledAsync() for the udm-boot check instead of
+            // this inline test (shared gateway boot infrastructure -
+            // NetworkOptimizer.Web.Services.Ssh.UdmBootService).
             var combinedCommand =
                 "echo '---UDM_BOOT---'; test -f /etc/systemd/system/udm-boot.service && echo 'installed' || echo 'missing'; " +
                 "echo '---UDM_BOOT_ENABLED---'; systemctl is-enabled udm-boot 2>/dev/null || echo 'disabled'; " +

--- a/tests/NetworkOptimizer.UniFi.Tests/GatewayWanHelperTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/GatewayWanHelperTests.cs
@@ -72,6 +72,29 @@ public class GatewayWanHelperTests
     public void WanInterfaceKeyFromKey_lowercases_and_maps_primary(string key, string expected)
         => GatewayWanHelper.WanInterfaceKeyFromKey(key).Should().Be(expected);
 
+    // ─── FormatWanLabel: graceful four-identifier WAN label assembly. Must never
+    // emit empty parentheses, doubled spaces, or "null" when a piece is missing. ───
+
+    [Theory]
+    [InlineData("Acme Fiber", 1, "eth6", "Port 7", "Acme Fiber WAN1 (eth6 - Port 7)")]
+    [InlineData(null, 1, "eth6", "Port 7", "WAN1 (eth6 - Port 7)")]
+    [InlineData("Acme Fiber", 1, "eth6", null, "Acme Fiber WAN1 (eth6)")]
+    [InlineData("Acme Fiber", 1, null, "Port 7", "Acme Fiber WAN1 (Port 7)")]
+    [InlineData("Acme Fiber", 1, null, null, "Acme Fiber WAN1")]
+    [InlineData(null, 2, null, null, "WAN2")]
+    [InlineData(null, 0, "eth3", null, "eth3")]
+    [InlineData(null, 0, null, null, "Unknown WAN")]
+    public void FormatWanLabel_degrades_gracefully(string? name, int wanIndex, string? ifName, string? portLabel, string expected)
+        => GatewayWanHelper.FormatWanLabel(name, wanIndex, ifName, portLabel).Should().Be(expected);
+
+    [Fact]
+    public void FormatWanLabel_treats_blank_pieces_as_missing()
+    {
+        // Whitespace-only inputs must not produce stray spaces or empty parentheses.
+        GatewayWanHelper.FormatWanLabel("  ", 1, "  ", "  ").Should().Be("WAN1");
+        GatewayWanHelper.FormatWanLabel("Comcast", 1, "  ", "Port 1").Should().Be("Comcast WAN1 (Port 1)");
+    }
+
     // ─── EnumerateWanInterfaces: typed field extraction from raw device JSON.
     // The physical (ifname) and data-path (uplink_ifname) extraction here is the
     // PPPoE/VLAN regression surface for the flow-map and upstream parsers, so it is

--- a/tests/NetworkOptimizer.UniFi.Tests/GatewayWanHelperTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/GatewayWanHelperTests.cs
@@ -87,6 +87,14 @@ public class GatewayWanHelperTests
     public void FormatWanLabel_degrades_gracefully(string? name, int wanIndex, string? ifName, string? portLabel, string expected)
         => GatewayWanHelper.FormatWanLabel(name, wanIndex, ifName, portLabel).Should().Be(expected);
 
+    [Theory]
+    [InlineData("Acme Fiber", 4, "eth1", "Acme Fiber", "Acme Fiber WAN4 (eth1)")]
+    [InlineData("Acme Fiber", 4, "eth1", "acme fiber", "Acme Fiber WAN4 (eth1)")]
+    [InlineData("Comcast", 2, "eth0", "WAN2", "Comcast WAN2 (eth0)")]
+    [InlineData("Comcast", 1, "eth0", "eth0", "Comcast WAN1 (eth0)")]
+    public void FormatWanLabel_drops_redundant_port_label(string? name, int wanIndex, string? ifName, string? portLabel, string expected)
+        => GatewayWanHelper.FormatWanLabel(name, wanIndex, ifName, portLabel).Should().Be(expected);
+
     [Fact]
     public void FormatWanLabel_treats_blank_pieces_as_missing()
     {


### PR DESCRIPTION
## Monitoring Interfaces (Monitoring → Setup)

When an ONT or modem management page sits behind your WAN, the gateway can't route to it, so monitoring (and your browser) can't reach it. This adds a "monitoring interface": a small, reboot-safe route deployed to the gateway that makes such a device reachable from the LAN.

- Lives under **Monitoring → Setup**, below SNMP Devices. Collapsible (state saved per browser); expanded by default until you've configured one so it's discoverable.
- Leads with the lightweight option: try a native **UniFi Policy Engine → Policy Table → Static Route** first. If that isn't enough (common for modems/ONTs that only answer when the gateway has an on-link address on their subnet), deploy a managed interface: a macvlan on the physical WAN port + host route + optional SNAT for LAN clients, self-installing a `udm-boot` script and cron watchdog so it survives reboots and reprovisioning. Same self-contained model as Adaptive SQM and Performance Tweaks.
- WAN picker labels each WAN by connection name, WAN number, interface, and port (gracefully dropping any piece that's missing or redundant).
- Preflight safety: refuses to deploy if the target subnet overlaps a UniFi-managed network/VLAN or if the device is already reachable, and verifies the chosen gateway-local IP isn't already in use on the modem subnet.
- Discoverable from the existing Cable Modem / ONT / Cellular monitor forms: a link appears next to the Host/IP field and on connectivity-type test failures, pre-filling the target IP and a sensible default name (`cmodem0` / `wmodem0` / `ont0`, incremented).

## Netgear cable modem: single-session support

Netgear modems (e.g. CM600, CM1000) allow only one web session at a time and redirect every page to a "log out existing session" prompt when another session is active, which prevented polling while you were logged into the modem UI. The Netgear provider now claims that session (preserving Basic auth across the redirect) and re-fetches the status page. Modems without this behavior take the normal path unchanged.

## Other

- Disable browser/password-manager autocomplete on the Cable Modem / ONT / Cellular password fields, matching the convention used elsewhere.
- Extract a shared `UdmBootService` for the `udm-boot` install; Adaptive SQM now delegates to it (other call sites flagged in TODO.md to migrate).