### PR TITLE
Monitoring Interfaces: optional VLAN-tagged WAN

### DIFF
--- a/src/NetworkOptimizer.Storage/Migrations/20260616232246_AddMonitoringInterfaceVlan.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260616232246_AddMonitoringInterfaceVlan.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260616232246_AddMonitoringInterfaceVlan")]
+    partial class AddMonitoringInterfaceVlan
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260616232246_AddMonitoringInterfaceVlan.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260616232246_AddMonitoringInterfaceVlan.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMonitoringInterfaceVlan : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "WanVlanId",
+                table: "MonitoringInterfaces",
+                type: "INTEGER",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "WanVlanId",
+                table: "MonitoringInterfaces");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/MonitoringInterface.cs
+++ b/src/NetworkOptimizer.Storage/Models/MonitoringInterface.cs
@@ -32,6 +32,14 @@ public class MonitoringInterface
     public string WanIfName { get; set; } = "";
 
     /// <summary>
+    /// Optional 802.1Q VLAN ID for the WAN. When set, the macvlan attaches to the VLAN
+    /// subinterface (e.g. "eth6.100") instead of the bare physical port, so frames are
+    /// tagged. The gateway creates that subinterface if it doesn't already exist (UniFi
+    /// creates it itself when the WAN runs on the VLAN). Null = untagged (raw port).
+    /// </summary>
+    public int? WanVlanId { get; set; }
+
+    /// <summary>
     /// WAN object key this interface targets (e.g., "wan1", "wan2"), used to
     /// re-derive the WAN display label and disambiguate dual-WAN setups. Optional.
     /// </summary>

--- a/src/NetworkOptimizer.Storage/Repositories/MonitoringInterfaceRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/MonitoringInterfaceRepository.cs
@@ -78,6 +78,7 @@ public class MonitoringInterfaceRepository : IMonitoringInterfaceRepository
                 {
                     existing.Name = config.Name;
                     existing.WanIfName = config.WanIfName;
+                    existing.WanVlanId = config.WanVlanId;
                     existing.WanKey = config.WanKey;
                     existing.TargetIp = config.TargetIp;
                     existing.SubnetPrefix = config.SubnetPrefix;

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -126,7 +126,7 @@
                     <div class="form-row">
                         <div class="form-group mi-grow-2">
                             <label class="form-label">Modem/ONT IP</label>
-                            <input type="text" class="form-control" @bind="_editing.TargetIp" @bind:after="OnTargetChanged" placeholder="192.168.100.1" />
+                            <input type="text" class="form-control" @bind="_editing.TargetIp" @bind:event="oninput" @bind:after="OnTargetChanged" placeholder="192.168.100.1" />
                             <small class="form-help">The management IP you're trying to reach (e.g. your modem or ONT status page).</small>
                         </div>
                     </div>
@@ -168,22 +168,22 @@
                             <div class="form-row">
                                 <div class="form-group mi-grow-2">
                                     <label class="form-label">Gateway-local IP</label>
-                                    <input type="text" class="form-control" @bind="_editing.GatewayLocalIp" placeholder="192.168.100.2" />
+                                    <input type="text" class="form-control" @bind="_editing.GatewayLocalIp" @bind:event="oninput" placeholder="192.168.100.2" />
                                     <small class="form-help">The gateway's address on the modem's subnet. Auto-suggested; must be free and on the same subnet.</small>
                                 </div>
                                 <div class="form-group mi-grow-1">
                                     <label class="form-label">Subnet prefix</label>
-                                    <input type="number" class="form-control" @bind="_editing.SubnetPrefix" min="8" max="30" />
+                                    <input type="number" class="form-control" @bind="_editing.SubnetPrefix" @bind:event="oninput" min="8" max="30" />
                                 </div>
                                 <div class="form-group mi-grow-1">
                                     <label class="form-label">Interface name</label>
-                                    <input type="text" class="form-control" @bind="_editing.Name" placeholder="modem0" />
+                                    <input type="text" class="form-control" @bind="_editing.Name" @bind:event="oninput" placeholder="modem0" />
                                 </div>
                             </div>
                             <div class="form-row">
                                 <div class="form-group mi-grow-1">
                                     <label class="form-label">Watchdog interval (min)</label>
-                                    <input type="number" class="form-control" @bind="_editing.WatchdogIntervalMinutes" min="1" max="60" />
+                                    <input type="number" class="form-control" @bind="_editing.WatchdogIntervalMinutes" @bind:event="oninput" min="1" max="60" />
                                     <small class="form-help">How often the gateway re-applies the route so it survives reprovisioning.</small>
                                 </div>
                                 <div class="form-group mi-grow-2">

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -580,6 +580,16 @@
     {
         _message = null;
         _deploySteps.Clear();
+
+        // "Tagged" is checked but no VLAN ID entered: the placeholder can read like a
+        // set value, so require an explicit ID rather than silently deploying untagged.
+        if (_vlanEnabled && _editing.WanVlanId is null)
+        {
+            _message = "Enter a VLAN ID, or uncheck Tagged.";
+            _messageSuccess = false;
+            return false;
+        }
+
         var error = MonitoringInterfaceDeploymentService.Validate(_editing);
         if (error != null)
         {

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -129,6 +129,8 @@
                             <input type="text" class="form-control" @bind="_editing.TargetIp" @bind:after="OnTargetChanged" placeholder="192.168.100.1" />
                             <small class="form-help">The management IP you're trying to reach (e.g. your modem or ONT status page).</small>
                         </div>
+                    </div>
+                    <div class="form-row">
                         <div class="form-group mi-grow-2">
                             <label class="form-label">WAN interface</label>
                             <select class="form-control" @bind="_editing.WanIfName" @bind:after="OnWanChanged">
@@ -146,6 +148,17 @@
                                 }
                             </select>
                             <small class="form-help">The WAN your modem/ONT sits behind. The interface rides this port.</small>
+                        </div>
+                        <div class="form-group mi-grow-2">
+                            <label class="form-label">VLAN</label>
+                            <div class="mi-vlan">
+                                <label class="checkbox-label mi-vlan-toggle">
+                                    <input type="checkbox" @bind="_vlanEnabled" @bind:after="OnVlanToggled" />
+                                    <span>Tagged</span>
+                                </label>
+                                <input type="number" class="form-control mi-vlan-id" @bind="_editing.WanVlanId" min="1" max="4094" placeholder="100" disabled="@(!_vlanEnabled)" />
+                            </div>
+                            <small class="form-help">Tag the interface when your WAN runs on a VLAN (some fiber ISPs). Leave off for a plain port.</small>
                         </div>
                     </div>
 
@@ -280,6 +293,20 @@
     .mi-grow-2 {
         flex: 2;
     }
+
+    .mi-vlan {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+    }
+
+    .mi-vlan-toggle {
+        white-space: nowrap;
+    }
+
+    .mi-vlan-id {
+        max-width: 6rem;
+    }
 </style>
 
 @code {
@@ -301,6 +328,7 @@
 
     private MonitoringInterface _editing = NewInterface();
     private MonitoringInterface? _editingOriginal;
+    private bool _vlanEnabled;
     private bool _collapsed = true;
     private bool _stateLoaded;
     private const string CollapseKey = "monitoring-interfaces-collapsed";
@@ -320,6 +348,7 @@
         Id = mi.Id,
         Name = mi.Name,
         WanIfName = mi.WanIfName,
+        WanVlanId = mi.WanVlanId,
         WanKey = mi.WanKey,
         TargetIp = mi.TargetIp,
         SubnetPrefix = mi.SubnetPrefix,
@@ -332,7 +361,8 @@
     // into the macvlan name, route, SNAT rule, or script filename - otherwise the old
     // artifacts (interface, route, SNAT, cron, /data/on_boot.d file) are orphaned.
     private static bool NeedsOldTeardown(MonitoringInterface a, MonitoringInterface b)
-        => a.Name != b.Name || a.WanIfName != b.WanIfName || a.TargetIp != b.TargetIp
+        => a.Name != b.Name || a.WanIfName != b.WanIfName || a.WanVlanId != b.WanVlanId
+            || a.TargetIp != b.TargetIp
             || a.GatewayLocalIp != b.GatewayLocalIp || a.SubnetPrefix != b.SubnetPrefix
             || a.SnatEnabled != b.SnatEnabled;
 
@@ -469,6 +499,7 @@
     {
         _editing = Snapshot(mi);
         _editingOriginal = Snapshot(mi);
+        _vlanEnabled = mi.WanVlanId.HasValue;
         _collapsed = false;
         _message = null;
         _deploySteps.Clear();
@@ -478,7 +509,15 @@
     {
         _editing = NewInterface();
         _editingOriginal = null;
+        _vlanEnabled = false;
         _message = null;
+    }
+
+    // When VLAN tagging is turned off, drop the stored VLAN so we deploy on the raw port.
+    private void OnVlanToggled()
+    {
+        if (!_vlanEnabled)
+            _editing.WanVlanId = null;
     }
 
     private void OnTargetChanged()
@@ -517,6 +556,7 @@
         var saved = _interfaces.FirstOrDefault(i => i.TargetIp == _editing.TargetIp && i.WanIfName == _editing.WanIfName);
         _editing = NewInterface();
         _editingOriginal = null;
+        _vlanEnabled = false;
 
         // Editing changed gateway-affecting fields: remove the old config first so we don't
         // leave a stale macvlan/route/SNAT/cron/boot-script behind.

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -769,7 +769,12 @@
     /// </summary>
     private static string SuggestLocalIp(string? targetIp)
     {
-        if (!IPAddress.TryParse(targetIp, out var ip) || ip.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
+        // Require a complete dotted-quad. IPAddress.TryParse accepts shorthand like "1"
+        // (-> 0.0.0.1) or "192.168.100" (-> 192.168.0.100), which under per-keystroke
+        // (oninput) binding would suggest off a half-typed address (e.g. "0.0.0.2").
+        if (targetIp is null || targetIp.Split('.').Length != 4 ||
+            !IPAddress.TryParse(targetIp, out var ip) ||
+            ip.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
             return "";
         var bytes = ip.GetAddressBytes();
         int last = bytes[3];

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -156,7 +156,7 @@
                                     <input type="checkbox" @bind="_vlanEnabled" @bind:after="OnVlanToggled" />
                                     <span>Tagged</span>
                                 </label>
-                                <input type="number" class="form-control mi-vlan-id" @bind="_editing.WanVlanId" min="1" max="4094" placeholder="100" disabled="@(!_vlanEnabled)" />
+                                <input type="number" class="form-control mi-vlan-id" @bind="_editing.WanVlanId" @bind:event="oninput" min="1" max="4094" placeholder="100" disabled="@(!_vlanEnabled)" />
                             </div>
                             <small class="form-help">Tag the interface when your WAN runs on a VLAN (some fiber ISPs). Leave off for a plain port.</small>
                         </div>

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -168,7 +168,7 @@
                             <div class="form-row">
                                 <div class="form-group mi-grow-2">
                                     <label class="form-label">Gateway-local IP</label>
-                                    <input type="text" class="form-control" @bind="_editing.GatewayLocalIp" @bind:event="oninput" placeholder="192.168.100.2" />
+                                    <input type="text" class="form-control" @bind="_editing.GatewayLocalIp" @bind:event="oninput" @bind:after="OnLocalIpEdited" placeholder="192.168.100.2" />
                                     <small class="form-help">The gateway's address on the modem's subnet. Auto-suggested; must be free and on the same subnet.</small>
                                 </div>
                                 <div class="form-group mi-grow-1">
@@ -329,6 +329,11 @@
     private MonitoringInterface _editing = NewInterface();
     private MonitoringInterface? _editingOriginal;
     private bool _vlanEnabled;
+
+    // True while GatewayLocalIp holds an auto-suggested value (not user-entered), so the
+    // suggestion keeps tracking the target as it's typed. Cleared once the user edits the
+    // gateway-local field themselves.
+    private bool _localIpAutoSuggested;
     private bool _collapsed = true;
     private bool _stateLoaded;
     private const string CollapseKey = "monitoring-interfaces-collapsed";
@@ -500,6 +505,7 @@
         _editing = Snapshot(mi);
         _editingOriginal = Snapshot(mi);
         _vlanEnabled = mi.WanVlanId.HasValue;
+        _localIpAutoSuggested = false;
         _collapsed = false;
         _message = null;
         _deploySteps.Clear();
@@ -510,6 +516,7 @@
         _editing = NewInterface();
         _editingOriginal = null;
         _vlanEnabled = false;
+        _localIpAutoSuggested = false;
         _message = null;
     }
 
@@ -522,9 +529,22 @@
 
     private void OnTargetChanged()
     {
-        if (string.IsNullOrWhiteSpace(_editing.GatewayLocalIp))
-            _editing.GatewayLocalIp = SuggestLocalIp(_editing.TargetIp);
+        // Keep the suggested gateway-local IP tracking the target until the user edits it
+        // themselves. With per-keystroke (oninput) binding, a one-shot "suggest only when
+        // empty" would lock onto a transient prefix - typing 10.10.10.100 passes through
+        // 10.10.10.1, suggesting .2 and then freezing. Re-suggesting while auto-suggested
+        // lets it follow through to the final octet.
+        if (string.IsNullOrWhiteSpace(_editing.GatewayLocalIp) || _localIpAutoSuggested)
+        {
+            var suggested = SuggestLocalIp(_editing.TargetIp);
+            _editing.GatewayLocalIp = suggested;
+            _localIpAutoSuggested = !string.IsNullOrEmpty(suggested);
+        }
     }
+
+    // The user edited the gateway-local IP by hand: stop auto-suggesting so we don't
+    // overwrite their value when the target changes.
+    private void OnLocalIpEdited() => _localIpAutoSuggested = false;
 
     private void OnWanChanged()
     {
@@ -557,6 +577,7 @@
         _editing = NewInterface();
         _editingOriginal = null;
         _vlanEnabled = false;
+        _localIpAutoSuggested = false;
 
         // Editing changed gateway-affecting fields: remove the old config first so we don't
         // leave a stale macvlan/route/SNAT/cron/boot-script behind.

--- a/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
@@ -44,13 +44,18 @@ public class MonitoringInterfaceDeploymentService
     /// </summary>
     public static string? Validate(MonitoringInterface mi)
     {
+        // \A...\z anchors (not ^...$): in .NET, $ also matches just before a trailing
+        // newline, so "eth6\n" would pass and split the interpolated SSH command line.
         if (string.IsNullOrWhiteSpace(mi.Name) ||
-            !System.Text.RegularExpressions.Regex.IsMatch(mi.Name, "^[a-z][a-z0-9-]{0,14}$"))
+            !System.Text.RegularExpressions.Regex.IsMatch(mi.Name, @"\A[a-z][a-z0-9-]{0,14}\z"))
             return "Interface name must be 1-15 chars, start with a letter, and use only lowercase letters, digits, or hyphens.";
 
         if (string.IsNullOrWhiteSpace(mi.WanIfName) ||
-            !System.Text.RegularExpressions.Regex.IsMatch(mi.WanIfName, "^[a-zA-Z0-9._-]{1,20}$"))
+            !System.Text.RegularExpressions.Regex.IsMatch(mi.WanIfName, @"\A[a-zA-Z0-9._-]{1,20}\z"))
             return "Select a WAN interface.";
+
+        if (mi.WanVlanId is int vlan && (vlan < 1 || vlan > 4094))
+            return "VLAN ID must be between 1 and 4094.";
 
         if (!IPAddress.TryParse(mi.TargetIp, out var target) || target.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
             return "Modem/ONT IP must be a valid IPv4 address.";
@@ -294,9 +299,16 @@ public class MonitoringInterfaceDeploymentService
     private async Task<PreflightBlock> CheckLocalIpAvailableAsync(MonitoringInterface mi)
     {
         // Create the macvlan (idempotent) and bring it up so arping can transmit on the
-        // modem segment. The boot script reuses this interface.
+        // modem segment. The boot script reuses this interface. On a VLAN WAN, the parent
+        // is the VLAN subinterface, which we ensure exists first (same as the boot script).
+        var parent = ParentInterface(mi);
+        var ensureVlan = mi.WanVlanId is int vlan
+            ? $"ip link show {parent} >/dev/null 2>&1 || ip link add link {mi.WanIfName} name {parent} type vlan id {vlan}; " +
+              $"ip link set {parent} up 2>/dev/null; "
+            : "";
         var probe =
-            $"ip link show {mi.Name} >/dev/null 2>&1 || ip link add {mi.Name} link {mi.WanIfName} type macvlan mode bridge; " +
+            ensureVlan +
+            $"ip link show {mi.Name} >/dev/null 2>&1 || ip link add {mi.Name} link {parent} type macvlan mode bridge; " +
             $"ip link set {mi.Name} up 2>/dev/null; " +
             $"if ! ip link show {mi.Name} >/dev/null 2>&1; then echo RESULT:NOIFACE; " +
             $"elif ! command -v arping >/dev/null 2>&1; then echo RESULT:SKIP; " +
@@ -340,6 +352,7 @@ public class MonitoringInterfaceDeploymentService
         return BootScriptTemplate
             .Replace("__IFACE__", mi.Name)
             .Replace("__WAN_IF__", mi.WanIfName)
+            .Replace("__VLAN_ID__", mi.WanVlanId?.ToString() ?? "")
             .Replace("__LOCAL_IP__", mi.GatewayLocalIp)
             .Replace("__PREFIX__", mi.SubnetPrefix.ToString())
             .Replace("__TARGET_IP__", mi.TargetIp)
@@ -358,6 +371,7 @@ public class MonitoringInterfaceDeploymentService
 
 IFACE=""__IFACE__""
 WAN_IF=""__WAN_IF__""
+VLAN_ID=""__VLAN_ID__""
 LOCAL_IP=""__LOCAL_IP__""
 PREFIX=""__PREFIX__""
 TARGET_IP=""__TARGET_IP__""
@@ -373,9 +387,21 @@ ip link show ""$WAN_IF"" >/dev/null 2>&1 || { log ""wan $WAN_IF absent, deferrin
 
 changed=0
 
-# 1. macvlan on the physical WAN port
+# 0. resolve the macvlan parent. With a VLAN, the parent is the subinterface (e.g.
+# eth6.100) so frames are tagged; UniFi creates it for a VLAN WAN, but if it's absent
+# we add it ourselves. We never tear it down on removal - reprovision reaps it.
+PARENT=""$WAN_IF""
+if [ -n ""$VLAN_ID"" ]; then
+    PARENT=""$WAN_IF.$VLAN_ID""
+    if ! ip link show ""$PARENT"" >/dev/null 2>&1; then
+        ip link add link ""$WAN_IF"" name ""$PARENT"" type vlan id ""$VLAN_ID"" && changed=1
+    fi
+    ip link set ""$PARENT"" up 2>/dev/null
+fi
+
+# 1. macvlan on the WAN parent (physical port, or VLAN subinterface)
 if ! ip link show ""$IFACE"" >/dev/null 2>&1; then
-    ip link add ""$IFACE"" link ""$WAN_IF"" type macvlan mode bridge && changed=1
+    ip link add ""$IFACE"" link ""$PARENT"" type macvlan mode bridge && changed=1
 fi
 ip link set ""$IFACE"" up 2>/dev/null
 
@@ -404,7 +430,7 @@ if ! crontab -l 2>/dev/null | grep -qF ""$SCRIPT""; then
 fi
 
 # Log only when something actually changed, to spare the eMMC.
-[ ""$changed"" = ""1"" ] && log ""applied $IFACE on $WAN_IF: $LOCAL_IP/$PREFIX -> $TARGET_IP (snat=$SNAT_ENABLED)""
+[ ""$changed"" = ""1"" ] && log ""applied $IFACE on $PARENT: $LOCAL_IP/$PREFIX -> $TARGET_IP (snat=$SNAT_ENABLED)""
 exit 0
 ";
 
@@ -412,6 +438,13 @@ exit 0
 
     private Task<(bool success, string output)> RunAsync(string command, TimeSpan? timeout = null)
         => _gatewaySsh.RunCommandAsync(command, timeout);
+
+    /// <summary>
+    /// The macvlan's parent interface: the VLAN subinterface (e.g. "eth6.100") when a
+    /// VLAN is configured, otherwise the bare physical WAN port.
+    /// </summary>
+    private static string ParentInterface(MonitoringInterface mi)
+        => mi.WanVlanId is int vlan ? $"{mi.WanIfName}.{vlan}" : mi.WanIfName;
 
     /// <summary>Network (zero-host) address for a CIDR, e.g. "192.168.100.1/24" -> "192.168.100.0/24".</summary>
     private static string NetworkAddress(string cidr)

--- a/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
@@ -57,10 +57,14 @@ public class MonitoringInterfaceDeploymentService
         if (mi.WanVlanId is int vlan && (vlan < 1 || vlan > 4094))
             return "VLAN ID must be between 1 and 4094.";
 
-        if (!IPAddress.TryParse(mi.TargetIp, out var target) || target.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
+        // Require dotted-quad: IPAddress.TryParse accepts shorthand ("192.168.100" ->
+        // 192.168.0.100), which would deploy a route/macvlan to the wrong address.
+        if ((mi.TargetIp ?? "").Split('.').Length != 4 ||
+            !IPAddress.TryParse(mi.TargetIp, out var target) || target.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
             return "Modem/ONT IP must be a valid IPv4 address.";
 
-        if (!IPAddress.TryParse(mi.GatewayLocalIp, out var local) || local.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
+        if ((mi.GatewayLocalIp ?? "").Split('.').Length != 4 ||
+            !IPAddress.TryParse(mi.GatewayLocalIp, out var local) || local.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
             return "Gateway-local IP must be a valid IPv4 address.";
 
         if (mi.SubnetPrefix < 8 || mi.SubnetPrefix > 30)

--- a/tests/NetworkOptimizer.Web.Tests/MonitoringInterfaceDeploymentServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/MonitoringInterfaceDeploymentServiceTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class MonitoringInterfaceDeploymentServiceTests
+{
+    private static MonitoringInterface Valid(int? vlan = null) => new()
+    {
+        Name = "modem0",
+        WanIfName = "eth1",
+        WanVlanId = vlan,
+        TargetIp = "192.168.100.1",
+        GatewayLocalIp = "192.168.100.2",
+        SubnetPrefix = 24,
+        WatchdogIntervalMinutes = 5,
+    };
+
+    [Fact]
+    public void Validate_NoVlan_Ok()
+        => MonitoringInterfaceDeploymentService.Validate(Valid()).Should().BeNull();
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(100)]
+    [InlineData(4094)]
+    public void Validate_VlanInRange_Ok(int vlan)
+        => MonitoringInterfaceDeploymentService.Validate(Valid(vlan)).Should().BeNull();
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(4095)]
+    [InlineData(9999)]
+    public void Validate_VlanOutOfRange_Rejected(int vlan)
+        => MonitoringInterfaceDeploymentService.Validate(Valid(vlan)).Should().Contain("VLAN");
+
+    [Fact]
+    public void BootScript_NoVlan_LeavesVlanIdEmpty()
+    {
+        var script = MonitoringInterfaceDeploymentService.GenerateBootScript(Valid());
+        script.Should().Contain("VLAN_ID=\"\"");
+        script.Should().Contain("WAN_IF=\"eth1\"");
+    }
+
+    [Fact]
+    public void BootScript_WithVlan_SetsVlanIdAndRidesTheSubinterface()
+    {
+        var script = MonitoringInterfaceDeploymentService.GenerateBootScript(Valid(100));
+        script.Should().Contain("VLAN_ID=\"100\"");
+        // The subinterface is created from the physical port + VLAN id, and the macvlan
+        // rides the resolved parent ($PARENT) rather than the bare port.
+        script.Should().Contain("type vlan id \"$VLAN_ID\"");
+        script.Should().Contain("link \"$PARENT\" type macvlan");
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/MonitoringInterfaceDeploymentServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/MonitoringInterfaceDeploymentServiceTests.cs
@@ -37,6 +37,17 @@ public class MonitoringInterfaceDeploymentServiceTests
     public void Validate_VlanOutOfRange_Rejected(int vlan)
         => MonitoringInterfaceDeploymentService.Validate(Valid(vlan)).Should().Contain("VLAN");
 
+    [Theory]
+    [InlineData("1")]
+    [InlineData("192.168.100")]
+    [InlineData("192.168.100.1.1")]
+    public void Validate_ShorthandOrMalformedTargetIp_Rejected(string targetIp)
+    {
+        var mi = Valid();
+        mi.TargetIp = targetIp;
+        MonitoringInterfaceDeploymentService.Validate(mi).Should().Contain("Modem/ONT IP");
+    }
+
     [Fact]
     public void BootScript_NoVlan_LeavesVlanIdEmpty()
     {


### PR DESCRIPTION
Follow-up to the Monitoring Interfaces feature (#776).

## What

A monitoring interface can now optionally ride a tagged VLAN. Some WANs (notably several fiber ISPs) are delivered over an 802.1Q VLAN, so to reach a device on that segment the macvlan has to attach to the WAN's VLAN subinterface (e.g. `eth1.100`) rather than the bare physical port.

- New optional VLAN on the add/edit form: a "Tagged" checkbox + VLAN ID field (1-4094), paired with the WAN selector, wraps on mobile. **Off by default** - the raw physical port, exactly as before.
- When a VLAN is set, deploy (and the reboot-safe boot script) create the VLAN subinterface if it doesn't already exist, then parent the macvlan to it. The subinterface is left in place on removal - a UniFi reprovision reaps it - so we never risk tearing down one the WAN itself uses.
- Stored as a nullable `WanVlanId` column (additive migration); the WAN list/selection is unchanged.

## Validation hardening

- Interface-name and WAN-interface validators now anchor with `\A…\z` instead of `^…$`, so a trailing newline can't slip a value into an interpolated gateway command.
- The modem/ONT and gateway-local IP fields now require a full dotted-quad (rejecting shorthand like `192.168.100`, which .NET would otherwise expand to `192.168.0.100`).

No behavior change for existing non-VLAN monitoring interfaces.