### PR TITLE
Recognize Technitium DNS as a known LAN DNS provider

### DIFF
--- a/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
@@ -803,14 +803,14 @@ public class DnsSecurityAnalyzer
                 var dnsServerIps = result.ThirdPartyDnsServers.Select(t => t.DnsServerIp).Distinct().ToList();
                 var networkNames = result.ThirdPartyDnsServers.Select(t => t.NetworkName).Distinct().ToList();
 
-                // Known providers (Pi-hole, AdGuard Home, NextDNS CLI, ControlD) are trusted - neutral score impact
+                // Known providers (Pi-hole, AdGuard Home, Technitium DNS, NextDNS CLI, ControlD) are trusted - neutral score impact
                 // Unknown third-party DNS servers get a minor penalty since we can't verify their filtering
-                var isKnownProvider = result.IsPiholeDetected || result.IsAdGuardHomeDetected || result.IsNextDnsDetected || result.IsControlDDetected;
+                var isKnownProvider = result.IsPiholeDetected || result.IsAdGuardHomeDetected || result.IsTechnitiumDnsDetected || result.IsNextDnsDetected || result.IsControlDDetected;
                 var scoreImpact = isKnownProvider ? 0 : 3; // Minor penalty for unknown providers
                 var severity = isKnownProvider ? AuditSeverity.Informational : AuditSeverity.Recommended;
                 var recommendedAction = isKnownProvider
                     ? "Verify third-party DNS provides adequate security and filtering. Consider enabling DNS firewall rules to prevent bypass."
-                    : "Configure the third-party DNS management port in Settings to enable detection. Otherwise, consider a known DNS filtering solution (Pi-hole, AdGuard Home, NextDNS, ControlD) or CyberSecure Encrypted DNS (DoH).";
+                    : "Configure the third-party DNS management port or URL in Settings to enable detection. Otherwise, consider a known DNS filtering solution (Pi-hole, AdGuard Home, Technitium DNS, NextDNS, ControlD) or CyberSecure Encrypted DNS (DoH).";
 
                 result.Issues.Add(new AuditIssue
                 {
@@ -826,12 +826,13 @@ public class DnsSecurityAnalyzer
                         { "third_party_dns_ips", dnsServerIps },
                         { "is_pihole", result.IsPiholeDetected },
                         { "is_adguard_home", result.IsAdGuardHomeDetected },
+                        { "is_technitium_dns", result.IsTechnitiumDnsDetected },
                         { "is_nextdns", result.IsNextDnsDetected },
                         { "is_controld", result.IsControlDDetected },
                         { "is_known_provider", isKnownProvider },
                         { "affected_networks", networkNames },
                         { "provider_name", result.ThirdPartyDnsProviderName ?? "Third-Party LAN DNS" },
-                        { "configurable_setting", "Configure third-party DNS management port in Settings if detection fails" }
+                        { "configurable_setting", "Configure third-party DNS management port or URL in Settings if detection fails" }
                     }
                 });
 
@@ -1994,7 +1995,7 @@ public class DnsSecurityAnalyzer
             result.HasThirdPartyDns = true;
             result.ThirdPartyDnsServers.AddRange(thirdPartyResults);
 
-            // Determine provider name (Pi-hole takes precedence, then AdGuard Home, then NextDNS CLI)
+            // Determine provider name (Pi-hole takes precedence, then AdGuard Home, then Technitium DNS, then NextDNS CLI)
             if (thirdPartyResults.Any(t => t.IsPihole))
             {
                 result.ThirdPartyDnsProviderName = "Pi-hole";
@@ -2006,6 +2007,12 @@ public class DnsSecurityAnalyzer
                 result.ThirdPartyDnsProviderName = "AdGuard Home";
                 _logger.LogInformation("AdGuard Home detected as third-party DNS on {Count} network(s)",
                     thirdPartyResults.Count(t => t.IsAdGuardHome));
+            }
+            else if (thirdPartyResults.Any(t => t.IsTechnitiumDns))
+            {
+                result.ThirdPartyDnsProviderName = "Technitium DNS";
+                _logger.LogInformation("Technitium DNS detected as third-party DNS on {Count} network(s)",
+                    thirdPartyResults.Count(t => t.IsTechnitiumDns));
             }
             else if (thirdPartyResults.Any(t => t.IsNextDns))
             {
@@ -2843,6 +2850,7 @@ public class DnsSecurityResult
     public List<ThirdPartyDnsDetector.ThirdPartyDnsInfo> ThirdPartyDnsServers { get; } = new();
     public bool IsPiholeDetected => ThirdPartyDnsServers.Any(t => t.IsPihole);
     public bool IsAdGuardHomeDetected => ThirdPartyDnsServers.Any(t => t.IsAdGuardHome);
+    public bool IsTechnitiumDnsDetected => ThirdPartyDnsServers.Any(t => t.IsTechnitiumDns);
     public bool IsNextDnsDetected => ThirdPartyDnsServers.Any(t => t.IsNextDns);
     public bool IsControlDDetected => ThirdPartyDnsServers.Any(t => t.IsControlD);
     public string? ThirdPartyDnsProviderName { get; set; }

--- a/src/NetworkOptimizer.Audit/Dns/ThirdPartyDnsDetector.cs
+++ b/src/NetworkOptimizer.Audit/Dns/ThirdPartyDnsDetector.cs
@@ -989,13 +989,16 @@ public class ThirdPartyDnsDetector
         return false;
     }
 
-    private async Task<bool> TryProbeTechnitiumDnsEndpointAsync(string baseUrl)
+    /// <summary>
+    /// Probe a direct base URL for Technitium DNS (used for reverse proxy scenarios)
+    /// </summary>
+    private async Task<bool> TryProbeTechnitiumDnsEndpointAsync(string baseUrl, int timeoutSeconds = 3)
     {
         try
         {
             _logger.LogDebug("Probing Technitium DNS at {Url}", baseUrl);
 
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
             var response = await _httpClient.GetAsync(baseUrl, cts.Token);
 
             if (!response.IsSuccessStatusCode)
@@ -1025,7 +1028,9 @@ public class ThirdPartyDnsDetector
     {
         var scheme = useHttps ? "https" : "http";
         var baseUrl = $"{scheme}://{ipAddress}:{port}";
-        return await TryProbeTechnitiumDnsEndpointAsync(baseUrl);
+        // Per-IP-port probes use a short 1s timeout (matching Pi-hole/AdGuard); the
+        // longer 3s default is reserved for the custom-URL/reverse-proxy path.
+        return await TryProbeTechnitiumDnsEndpointAsync(baseUrl, timeoutSeconds: 1);
     }
 
     private static bool DetectTechnitiumDnsFromContent(string content)
@@ -1036,11 +1041,6 @@ public class ThirdPartyDnsDetector
             content.IndexOf("js/main.js", StringComparison.OrdinalIgnoreCase) >= 0 ||
             content.IndexOf("js/auth.js", StringComparison.OrdinalIgnoreCase) >= 0;
 
-        if (!hasTitle || !hasDistinctiveAsset)
-        {
-            return false;
-        }
-
-        return true;
+        return hasTitle && hasDistinctiveAsset;
     }
 }

--- a/src/NetworkOptimizer.Audit/Dns/ThirdPartyDnsDetector.cs
+++ b/src/NetworkOptimizer.Audit/Dns/ThirdPartyDnsDetector.cs
@@ -36,6 +36,7 @@ public class ThirdPartyDnsDetector
         public string? PiholeVersion { get; init; }
         public bool IsAdGuardHome { get; init; }
         public string? AdGuardHomeVersion { get; init; }
+        public bool IsTechnitiumDns { get; init; }
         public bool IsNextDns { get; init; }
         public string? NextDnsProfile { get; init; }
         public bool IsControlD { get; init; }
@@ -123,6 +124,7 @@ public class ThirdPartyDnsDetector
                 string? piholeVersion = null;
                 bool isAdGuardHome = false;
                 string? adGuardHomeVersion = null;
+                bool isTechnitiumDns = false;
                 bool isNextDns = false;
                 string? nextDnsProfile = null;
                 bool isControlD = false;
@@ -150,22 +152,33 @@ public class ThirdPartyDnsDetector
                         }
                         else
                         {
-                            // If not AdGuard Home, try NextDNS CLI detection. This is slower than
-                            // the local-HTTP probes (requires DNS query through the resolver plus
-                            // an HTTPS round-trip to NextDNS's test endpoint), so it goes last.
-                            (isNextDns, nextDnsProfile) = await ProbeNextDnsAsync(dnsServer);
-                            if (isNextDns)
+                            // If not AdGuard Home, try Technitium DNS detection before slower
+                            // DNS-based probes.
+                            isTechnitiumDns = await ProbeTechnitiumDnsAsync(dnsServer, customPort, customUrl);
+                            if (isTechnitiumDns)
                             {
-                                providerName = "NextDNS CLI";
-                                _logger.LogInformation("Detected NextDNS CLI at {Ip} (profile: {Profile})", dnsServer, nextDnsProfile ?? "unknown");
+                                providerName = "Technitium DNS";
+                                _logger.LogInformation("Detected Technitium DNS at {Ip}", dnsServer);
                             }
                             else
                             {
-                                isControlD = await ProbeControlDAsync(dnsServer);
-                                if (isControlD)
+                                // If not Technitium, try NextDNS CLI detection. This is slower than
+                                // the local-HTTP probes (requires DNS query through the resolver plus
+                                // an HTTPS round-trip to NextDNS's test endpoint), so it goes last.
+                                (isNextDns, nextDnsProfile) = await ProbeNextDnsAsync(dnsServer);
+                                if (isNextDns)
                                 {
-                                    providerName = "ControlD";
-                                    _logger.LogInformation("Detected ControlD at {Ip}", dnsServer);
+                                    providerName = "NextDNS CLI";
+                                    _logger.LogInformation("Detected NextDNS CLI at {Ip} (profile: {Profile})", dnsServer, nextDnsProfile ?? "unknown");
+                                }
+                                else
+                                {
+                                    isControlD = await ProbeControlDAsync(dnsServer);
+                                    if (isControlD)
+                                    {
+                                        providerName = "ControlD";
+                                        _logger.LogInformation("Detected ControlD at {Ip}", dnsServer);
+                                    }
                                 }
                             }
                         }
@@ -181,6 +194,7 @@ public class ThirdPartyDnsDetector
                         piholeVersion = existingResult.PiholeVersion;
                         isAdGuardHome = existingResult.IsAdGuardHome;
                         adGuardHomeVersion = existingResult.AdGuardHomeVersion;
+                        isTechnitiumDns = existingResult.IsTechnitiumDns;
                         isNextDns = existingResult.IsNextDns;
                         nextDnsProfile = existingResult.NextDnsProfile;
                         isControlD = existingResult.IsControlD;
@@ -198,6 +212,7 @@ public class ThirdPartyDnsDetector
                     PiholeVersion = piholeVersion,
                     IsAdGuardHome = isAdGuardHome,
                     AdGuardHomeVersion = adGuardHomeVersion,
+                    IsTechnitiumDns = isTechnitiumDns,
                     IsNextDns = isNextDns,
                     NextDnsProfile = nextDnsProfile,
                     IsControlD = isControlD,
@@ -937,5 +952,95 @@ public class ThirdPartyDnsDetector
             _logger.LogDebug("AdGuard Home probe to {Ip}:{Port} error: {Type} - {Message}", ipAddress, port, ex.GetType().Name, ex.Message);
             return (false, null);
         }
+    }
+
+    /// <summary>
+    /// Probe an IP address to detect if it's running Technitium DNS Server.
+    /// </summary>
+    private async Task<bool> ProbeTechnitiumDnsAsync(string ipAddress, int? customPort = null, string? customUrl = null)
+    {
+        if (!string.IsNullOrEmpty(customUrl))
+        {
+            var result = await TryProbeTechnitiumDnsEndpointAsync(customUrl.TrimEnd('/'));
+            if (result)
+                return true;
+        }
+
+        var portsToTry = new List<(int Port, bool UseHttps)>();
+
+        if (customPort.HasValue && customPort.Value > 0)
+        {
+            portsToTry.Add((customPort.Value, false));
+            portsToTry.Add((customPort.Value, true));
+        }
+
+        portsToTry.Add((5380, false));
+        portsToTry.Add((53443, true));
+        portsToTry.Add((80, false));
+        portsToTry.Add((443, true));
+
+        foreach (var (port, useHttps) in portsToTry)
+        {
+            var result = await TryProbeTechnitiumDnsEndpointAsync(ipAddress, port, useHttps);
+            if (result)
+                return true;
+        }
+
+        return false;
+    }
+
+    private async Task<bool> TryProbeTechnitiumDnsEndpointAsync(string baseUrl)
+    {
+        try
+        {
+            _logger.LogDebug("Probing Technitium DNS at {Url}", baseUrl);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+            var response = await _httpClient.GetAsync(baseUrl, cts.Token);
+
+            if (!response.IsSuccessStatusCode)
+                return false;
+
+            var content = await response.Content.ReadAsStringAsync(cts.Token);
+            return DetectTechnitiumDnsFromContent(content);
+        }
+        catch (TaskCanceledException)
+        {
+            _logger.LogDebug("Technitium DNS probe to {Url} timed out", baseUrl);
+            return false;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug("Technitium DNS probe to {Url} failed: {Message}", baseUrl, ex.Message);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug("Technitium DNS probe to {Url} error: {Type} - {Message}", baseUrl, ex.GetType().Name, ex.Message);
+            return false;
+        }
+    }
+
+    private async Task<bool> TryProbeTechnitiumDnsEndpointAsync(string ipAddress, int port, bool useHttps = false)
+    {
+        var scheme = useHttps ? "https" : "http";
+        var baseUrl = $"{scheme}://{ipAddress}:{port}";
+        return await TryProbeTechnitiumDnsEndpointAsync(baseUrl);
+    }
+
+    private static bool DetectTechnitiumDnsFromContent(string content)
+    {
+        var hasTitle = content.IndexOf("<title>Technitium DNS Server</title>", StringComparison.OrdinalIgnoreCase) >= 0;
+        var hasDistinctiveAsset =
+            content.IndexOf("js/common.js", StringComparison.OrdinalIgnoreCase) >= 0 ||
+            content.IndexOf("js/main.js", StringComparison.OrdinalIgnoreCase) >= 0 ||
+            content.IndexOf("js/auth.js", StringComparison.OrdinalIgnoreCase) >= 0;
+
+        if (!hasTitle || !hasDistinctiveAsset)
+        {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1698,7 +1698,7 @@
             <div class="form-group" style="margin-top: 1.5rem;">
                 <label class="form-label">Third-Party DNS Management (optional)</label>
                 <input type="text" class="form-control" @bind="piholeManagementEndpoint" placeholder="Port number or URL" style="width: 240px;" />
-                <small class="form-help">Custom port (e.g., 8080) or full URL (e.g., https://pihole.local) for the admin interface. Leave empty to auto-probe ports 80, 443, 3000, 8080.</small>
+                <small class="form-help">Custom port (e.g., 5380 or 8080) or full URL (e.g., https://dns.local) for the admin interface. Leave empty to auto-probe common Pi-hole, AdGuard Home, and Technitium DNS ports on each detected resolver IP.</small>
             </div>
 
             <div class="action-buttons">

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
@@ -2232,6 +2232,23 @@ public class DnsSecurityAnalyzerTests : IDisposable
     }
 
     [Fact]
+    public void DnsSecurityResult_IsTechnitiumDnsDetected_ReturnsTrue_WhenTechnitiumDnsInThirdPartyServers()
+    {
+        var result = new DnsSecurityResult();
+        result.ThirdPartyDnsServers.Add(new ThirdPartyDnsDetector.ThirdPartyDnsInfo
+        {
+            DnsServerIp = "192.168.1.5",
+            NetworkName = "Corporate",
+            IsTechnitiumDns = true,
+            DnsProviderName = "Technitium DNS"
+        });
+
+        result.IsPiholeDetected.Should().BeFalse();
+        result.IsAdGuardHomeDetected.Should().BeFalse();
+        result.IsTechnitiumDnsDetected.Should().BeTrue();
+    }
+
+    [Fact]
     public void DnsSecurityResult_BothPiholeAndAdGuardHome_WhenBothDetected()
     {
         var result = new DnsSecurityResult();
@@ -4171,6 +4188,48 @@ public class DnsSecurityAnalyzerTests : IDisposable
         thirdPartyIssue.Should().NotBeNull();
         thirdPartyIssue!.Metadata.Should().ContainKey("is_known_provider");
         thirdPartyIssue.Metadata!["is_known_provider"].Should().Be(false);
+    }
+
+    [Fact]
+    public async Task Analyze_TechnitiumDns_IsKnownProviderWithNoScoreImpact()
+    {
+        var networks = new List<NetworkInfo>
+        {
+            new NetworkInfo
+            {
+                Id = "net1",
+                Name = "Corporate",
+                VlanId = 10,
+                DhcpEnabled = true,
+                Gateway = "192.168.1.1",
+                DnsServers = new List<string> { "192.168.1.5" }
+            }
+        };
+        var switches = new List<SwitchInfo>
+        {
+            new SwitchInfo { Name = "Gateway", IsGateway = true }
+        };
+        var detectorLoggerMock = new Mock<ILogger<ThirdPartyDnsDetector>>();
+        var technitiumResponse = @"<html><head><title>Technitium DNS Server</title><script src=""js/common.js""></script><script src=""js/main.js""></script><script src=""js/auth.js""></script></head><body>Technitium</body></html>";
+        var detector = new ThirdPartyDnsDetector(detectorLoggerMock.Object, CreateMockHttpClient(HttpStatusCode.OK, technitiumResponse));
+        var analyzer = new DnsSecurityAnalyzer(_loggerMock.Object, detector);
+
+        var result = await analyzer.AnalyzeAsync(
+            settingsData: null,
+            firewallRules: null,
+            switches: switches,
+            networks: networks);
+
+        result.HasThirdPartyDns.Should().BeTrue();
+        result.ThirdPartyDnsProviderName.Should().Be("Technitium DNS");
+        result.IsTechnitiumDnsDetected.Should().BeTrue();
+
+        var thirdPartyIssue = result.Issues.FirstOrDefault(i => i.Type == IssueTypes.DnsThirdPartyDetected);
+        thirdPartyIssue.Should().NotBeNull();
+        thirdPartyIssue!.Severity.Should().Be(AuditSeverity.Informational);
+        thirdPartyIssue.ScoreImpact.Should().Be(0);
+        thirdPartyIssue.Metadata!["is_known_provider"].Should().Be(true);
+        thirdPartyIssue.Metadata!["is_technitium_dns"].Should().Be(true);
     }
 
     #endregion

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/ThirdPartyDnsDetectorTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/ThirdPartyDnsDetectorTests.cs
@@ -139,6 +139,66 @@ public class ThirdPartyDnsDetectorTests : IDisposable
         nextDnsProbeCalled.Should().BeFalse("NextDNS probe should be skipped when Pi-hole is detected first");
     }
 
+    [Fact]
+    public async Task DetectThirdPartyDnsAsync_TechnitiumDnsDetected_FlagsProviderAsTechnitiumDns()
+    {
+        var technitiumResponse = @"<html><head><title>Technitium DNS Server</title><script src=""js/common.js""></script><script src=""js/main.js""></script><script src=""js/auth.js""></script></head><body>Technitium</body></html>";
+        var httpClient = CreateMockHttpClient(HttpStatusCode.OK, technitiumResponse);
+        var detector = CreateDetector(httpClient);
+
+        var networks = new List<NetworkInfo>
+        {
+            new()
+            {
+                Id = "net1",
+                DhcpEnabled = true,
+                Name = "Trusted",
+                VlanId = 1,
+                Subnet = "10.0.0.0/24",
+                Gateway = "10.0.0.1",
+                DnsServers = new List<string> { "10.0.2.4" }
+            }
+        };
+
+        var result = await detector.DetectThirdPartyDnsAsync(networks);
+
+        result.Should().HaveCount(1);
+        result[0].DnsServerIp.Should().Be("10.0.2.4");
+        result[0].IsTechnitiumDns.Should().BeTrue();
+        result[0].IsPihole.Should().BeFalse();
+        result[0].IsAdGuardHome.Should().BeFalse();
+        result[0].IsNextDns.Should().BeFalse();
+        result[0].DnsProviderName.Should().Be("Technitium DNS");
+    }
+
+    [Fact]
+    public async Task DetectThirdPartyDnsAsync_TechnitiumTitleWithoutAssets_NotDetectedAsTechnitiumDns()
+    {
+        var technitiumLikeResponse = @"<html><head><title>Technitium DNS Server</title></head><body>Technitium</body></html>";
+        var httpClient = CreateMockHttpClient(HttpStatusCode.OK, technitiumLikeResponse);
+        var detector = CreateDetector(httpClient);
+
+        var networks = new List<NetworkInfo>
+        {
+            new()
+            {
+                Id = "net1",
+                DhcpEnabled = true,
+                Name = "Trusted",
+                VlanId = 1,
+                Subnet = "10.0.0.0/24",
+                Gateway = "10.0.0.1",
+                DnsServers = new List<string> { "10.0.2.4" }
+            }
+        };
+
+        var result = await detector.DetectThirdPartyDnsAsync(networks);
+
+        result.Should().HaveCount(1);
+        result[0].IsTechnitiumDns.Should().BeFalse();
+        result[0].DnsProviderName.Should().Be("Third-Party LAN DNS");
+    }
+
     private ThirdPartyDnsDetector CreateDetector(HttpClient? httpClient = null)
     {
         httpClient ??= new HttpClient { Timeout = TimeSpan.FromSeconds(3) };
@@ -1397,7 +1457,8 @@ public class ThirdPartyDnsDetectorTests : IDisposable
         // HTTP handler should only be called once per unique IP
         // Pi-hole probe: 3 attempts (port 80, 443, 8080)
         // AdGuard Home probe: 3 attempts (port 80, 443, 3000)
-        callCount.Should().BeLessThanOrEqualTo(6);
+        // Technitium DNS probe: 4 attempts (port 5380, 53443, 80, 443)
+        callCount.Should().BeLessThanOrEqualTo(10);
     }
 
     #endregion


### PR DESCRIPTION
## Summary

Adds Technitium DNS Server detection to the third-party LAN DNS audit path.

Technitium does not expose a useful unauthenticated health/status/version endpoint for provider detection, so this uses the unauthenticated admin `index.html` page and checks for stable Technitium UI markers:

- `<title>Technitium DNS Server</title>`
- bundled UI assets such as `js/common.js`, `js/main.js`, or `js/auth.js`

When detected, Technitium DNS is treated like the other known providers, so the third-party LAN DNS finding is informational with no score impact.

## Changes

- Add Technitium DNS provider detection
- Treat Technitium DNS as a known third-party DNS provider
- Add `is_technitium_dns` audit metadata
- Update audit/settings text to mention management port or URL
- Add focused detector/analyzer tests

## Validation

- `dotnet test tests/NetworkOptimizer.Audit.Tests/NetworkOptimizer.Audit.Tests.csproj --filter "FullyQualifiedName~Dns" --no-restore`

Fixes #836