### PR TITLE
LAN map: live + historic playback of device state, client stats & roam

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -220,7 +220,7 @@ else
                 <div class="stat-label">ISP Loss</div>
             </div>
             @{ var transitTarget = GetMeanTargetStats(MonitoringTargetType.Transit); }
-            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&category=Transit"))">
+            <div class="monitoring-stat-card clickable-stat-card stat-card-no-minheight" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&category=Transit"))">
                 @if (hasTransitTargets)
                 {
                     <div class="stat-value">@FormatRtt(transitTarget.rtt)</div>
@@ -231,7 +231,7 @@ else
                 }
                 <div class="stat-label">Transit RTT</div>
             </div>
-            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&category=Transit"))">
+            <div class="monitoring-stat-card clickable-stat-card stat-card-no-minheight" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&category=Transit"))">
                 @if (hasTransitTargets)
                 {
                     <div class="stat-value @(transitTarget.loss > 0 ? "stat-danger" : "")">@FormatLoss(transitTarget.loss)</div>

--- a/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
@@ -116,7 +116,7 @@
                     @if (_gatewayConnected && _status?.FirmwareSupported == false && !string.IsNullOrEmpty(_status?.FirmwareVersion))
                     {
                         <div class="alert alert-danger" style="margin-top: 1rem;">
-                            <strong>Unsupported Firmware:</strong> Performance tweaks are currently tested and supported up to UniFi OS 5.1.18. Your gateway is running @_status.FirmwareVersion. Deploying new tweaks is disabled until we validate compatibility with this version. Existing tweaks will continue to run.
+                            <strong>Unsupported Firmware:</strong> Performance tweaks are currently tested and supported up to UniFi OS 5.1.19. Your gateway is running @_status.FirmwareVersion. Deploying new tweaks is disabled until we validate compatibility with this version. Existing tweaks will continue to run.
                         </div>
                     }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -66,11 +66,11 @@ else
                 <div class="stat-label">ISP Loss</div>
             </div>
             @{ var transitTarget = GetMeanTargetStats(MonitoringTargetType.Transit); }
-            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&category=Transit"))">
+            <div class="monitoring-stat-card clickable-stat-card stat-card-no-minheight" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&category=Transit"))">
                 <div class="stat-value">@FormatRtt(transitTarget.rtt)</div>
                 <div class="stat-label">Transit RTT</div>
             </div>
-            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&category=Transit"))">
+            <div class="monitoring-stat-card clickable-stat-card stat-card-no-minheight" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&category=Transit"))">
                 <div class="stat-value @(transitTarget.loss > 0 ? "stat-danger" : "")">@FormatLoss(transitTarget.loss)</div>
                 <div class="stat-label">Transit Loss</div>
             </div>

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
@@ -295,6 +295,21 @@ public class LanFlowMapLiveUpdate
     public Dictionary<string, LinkLiveRates> LinkRates { get; set; } = new();
     public Dictionary<string, NodeLiveBadge> NodeBadges { get; set; } = new();
     public Dictionary<string, CloudLiveStats> CloudStats { get; set; } = new();
+
+    /// <summary>Per-client connection stats (band/signal/PHY rate) keyed by client node id.
+    /// Lets the maps override the snapshot-frozen values. Populated for historic playback;
+    /// the live tick leaves it empty (snapshot rebuilds keep live values fresh enough).</summary>
+    public Dictionary<string, NodeClientStats> ClientStats { get; set; } = new();
+}
+
+/// <summary>Point-in-time wireless connection stats for a single client. Mirrors the
+/// snapshot's client node fields so the renderers can prefer these during playback.</summary>
+public class NodeClientStats
+{
+    public string? Band { get; set; }
+    public int? SignalDbm { get; set; }
+    public long? PhyTxKbps { get; set; }
+    public long? PhyRxKbps { get; set; }
 }
 
 public class NodeLiveBadge
@@ -331,6 +346,11 @@ public class LanFlowMapHistoricUpdate
     public Dictionary<string, LinkLiveRates> LinkRates { get; set; } = new();
     public Dictionary<string, NodeLiveBadge> NodeBadges { get; set; } = new();
     public Dictionary<string, CloudLiveStats> CloudStats { get; set; } = new();
+
+    /// <summary>Per-client connection stats (band/signal/PHY rate) at the scrub instant,
+    /// keyed by client node id. Lets the maps show the client's real wireless state then
+    /// instead of the current snapshot's frozen values.</summary>
+    public Dictionary<string, NodeClientStats> ClientStats { get; set; } = new();
 
     /// <summary>Speed tests whose TestTime falls within the scrub window (or just before it).</summary>
     public List<SpeedTestOverlayItem> SpeedTests { get; set; } = new();

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
@@ -310,6 +310,10 @@ public class NodeClientStats
     public int? SignalDbm { get; set; }
     public long? PhyTxKbps { get; set; }
     public long? PhyRxKbps { get; set; }
+    /// <summary>Node id ("dev-{mac}") of the AP the client was associated with at the
+    /// scrub instant, so the maps can re-attach the client to its historic AP (roam).
+    /// Null when unknown.</summary>
+    public string? ApNodeId { get; set; }
 }
 
 public class NodeLiveBadge

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -742,9 +742,22 @@ public class LanFlowMapService
                 var onlineAtT = healthPt != null
                     && Math.Abs((healthPt.Time - at).TotalSeconds) <= HistoricOnlineWindowSeconds;
 
+                bool infraOnline = false;
                 if (isInfra)
                 {
-                    if (!onlineAtT)
+                    // device_health is the authoritative liveness signal, but only when we
+                    // actually collect it for this device. If we never recorded health for
+                    // it (SNMP-only / third-party gear), don't force it dark across the
+                    // whole timeline: fall back to rate telemetry, then to the current
+                    // snapshot state. Devices we DO monitor get accurate per-instant state.
+                    var hasHealthHistory =
+                        cached.HealthByDevice.TryGetValue(mac, out var hh) && hh.Count > 0;
+                    if (hasHealthHistory)
+                        infraOnline = onlineAtT;
+                    else
+                        infraOnline = (fabIn != null || aggIn != null) || node.Online;
+
+                    if (!infraOnline)
                     {
                         update.NodeBadges[node.Id] = new NodeLiveBadge { Online = false };
                         continue;
@@ -757,7 +770,7 @@ public class LanFlowMapService
 
                 update.NodeBadges[node.Id] = new NodeLiveBadge
                 {
-                    Online = isInfra ? onlineAtT : node.Online,
+                    Online = isInfra ? infraOnline : node.Online,
                     CpuPercent = healthPt?.CpuPercent,
                     MemoryUsedPercent = healthPt?.MemoryUsedPercent,
                     TemperatureC = healthPt?.TemperatureC,

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -515,7 +515,9 @@ public class LanFlowMapService
         foreach (var (mac, p) in wifiClientRates)
         {
             var band = NormalizeBand(p.Band);
-            if (band == null && p.SignalDbm == null && p.TxRateKbps == null && p.RxRateKbps == null)
+            var apNodeId = string.IsNullOrEmpty(p.ApMac) ? null : "dev-" + NormalizeMac(p.ApMac);
+            if (band == null && p.SignalDbm == null && p.TxRateKbps == null
+                && p.RxRateKbps == null && apNodeId == null)
                 continue;
             update.ClientStats["cli-" + mac] = new NodeClientStats
             {
@@ -523,6 +525,7 @@ public class LanFlowMapService
                 SignalDbm = p.SignalDbm,
                 PhyTxKbps = p.TxRateKbps,
                 PhyRxKbps = p.RxRateKbps,
+                ApNodeId = apNodeId,
             };
         }
 

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -509,6 +509,23 @@ public class LanFlowMapService
                 wiredClientRates[p.ClientMac] = p;
         }
 
+        // WiFi client connection stats at the scrub instant (band/signal/PHY rate). Keyed
+        // by client node id ("cli-{mac}") so the maps can override the snapshot-frozen
+        // values. The band tag is "2.4ghz"/"5ghz"/"6ghz" - normalize to match snapshot.
+        foreach (var (mac, p) in wifiClientRates)
+        {
+            var band = NormalizeBand(p.Band);
+            if (band == null && p.SignalDbm == null && p.TxRateKbps == null && p.RxRateKbps == null)
+                continue;
+            update.ClientStats["cli-" + mac] = new NodeClientStats
+            {
+                Band = band,
+                SignalDbm = p.SignalDbm,
+                PhyTxKbps = p.TxRateKbps,
+                PhyRxKbps = p.RxRateKbps,
+            };
+        }
+
         // Resolve each link, mirroring the live endpoint's kind-aware dispatch.
         foreach (var link in snapshot.Links)
         {

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -167,6 +167,20 @@ public class LanFlowMapService
     }
 
     /// <summary>
+    /// Tolerance for deriving historic online state from telemetry proximity. There is
+    /// no stored online/state field, so a device counts as online at the scrub instant
+    /// when a device_health point falls within this window of it. device_health is written
+    /// ~every 30 s while a device is reachable, so this allows for one dropped sample plus
+    /// jitter without flapping an online device to offline.
+    /// </summary>
+    private const double HistoricOnlineWindowSeconds = 60;
+
+    /// <summary>Gateway / switch / AP - the fabric devices the map renders an explicit
+    /// online/offline appearance for (clients track association, not device state).</summary>
+    private static bool IsInfraKind(LanNodeKind kind) =>
+        kind is LanNodeKind.Gateway or LanNodeKind.Switch or LanNodeKind.AccessPoint;
+
+    /// <summary>
     /// Polling endpoint. Refreshes link rates + per-device aggregates + cloud RTT
     /// from in-memory sources (<see cref="MonitoringLiveStats"/>, <see cref="MonitoringPathView.GetWansAsync"/>).
     /// Does NOT rebuild the snapshot topology - that happens on its own TTL inside the cache.
@@ -339,7 +353,17 @@ public class LanFlowMapService
         {
             if (string.IsNullOrEmpty(node.Mac)) continue;
             var dev = _liveStats.GetForDevice(node.Mac);
-            if (dev == null) continue;
+            if (dev == null)
+            {
+                // No live telemetry for this device. For infrastructure (offline
+                // APs/switches/gateways report no stats) still emit a badge so the
+                // map can render the offline state and zero out its rates instead
+                // of freezing the last sample it ever saw. node.Online comes from
+                // the UniFi device State in the latest snapshot rebuild.
+                if (IsInfraKind(node.Kind))
+                    update.NodeBadges[node.Id] = new NodeLiveBadge { Online = node.Online };
+                continue;
+            }
 
             // For SNMP-free switches the only aggregate we have is the parent
             // switch's port rate (RateIn/RateOut), and parent-port direction
@@ -707,11 +731,33 @@ public class LanFlowMapService
                     }
                 }
 
-                if (healthPt == null && fabIn == null && aggIn == null) continue;
+                // No explicit online/state is stored in the time series, so derive
+                // historic liveness from telemetry proximity: device_health is written
+                // roughly every 30 s only while a device is reachable, so a health point
+                // close to the scrub instant means the device was online then. For
+                // infrastructure we always emit a badge (offline ones get Online=false
+                // and no rates) so playback reflects the real state at T instead of
+                // freezing the current snapshot's live online state across the timeline.
+                var isInfra = IsInfraKind(node.Kind);
+                var onlineAtT = healthPt != null
+                    && Math.Abs((healthPt.Time - at).TotalSeconds) <= HistoricOnlineWindowSeconds;
+
+                if (isInfra)
+                {
+                    if (!onlineAtT)
+                    {
+                        update.NodeBadges[node.Id] = new NodeLiveBadge { Online = false };
+                        continue;
+                    }
+                }
+                else if (healthPt == null && fabIn == null && aggIn == null)
+                {
+                    continue;
+                }
 
                 update.NodeBadges[node.Id] = new NodeLiveBadge
                 {
-                    Online = node.Online,
+                    Online = isInfra ? onlineAtT : node.Online,
                     CpuPercent = healthPt?.CpuPercent,
                     MemoryUsedPercent = healthPt?.MemoryUsedPercent,
                     TemperatureC = healthPt?.TemperatureC,

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -352,18 +352,21 @@ public class LanFlowMapService
         foreach (var node in snapshot.Nodes)
         {
             if (string.IsNullOrEmpty(node.Mac)) continue;
-            var dev = _liveStats.GetForDevice(node.Mac);
-            if (dev == null)
+
+            // Offline infra: emit a bare offline badge (no rates) so the map dims the
+            // device and zeros its links. node.Online is the UniFi device State from the
+            // latest snapshot rebuild. We do this before reading live stats on purpose:
+            // GetForDevice keeps the last sample until the next prune, so an offline
+            // device can still have a stale entry - reading it would paint a dead device
+            // with phantom throughput.
+            if (IsInfraKind(node.Kind) && !node.Online)
             {
-                // No live telemetry for this device. For infrastructure (offline
-                // APs/switches/gateways report no stats) still emit a badge so the
-                // map can render the offline state and zero out its rates instead
-                // of freezing the last sample it ever saw. node.Online comes from
-                // the UniFi device State in the latest snapshot rebuild.
-                if (IsInfraKind(node.Kind))
-                    update.NodeBadges[node.Id] = new NodeLiveBadge { Online = node.Online };
+                update.NodeBadges[node.Id] = new NodeLiveBadge { Online = false };
                 continue;
             }
+
+            var dev = _liveStats.GetForDevice(node.Mac);
+            if (dev == null) continue;
 
             // For SNMP-free switches the only aggregate we have is the parent
             // switch's port rate (RateIn/RateOut), and parent-port direction

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxClient.cs
@@ -1380,6 +1380,14 @@ from(bucket: ""{_longtermBucket}"")
         public string? ClientMac { get; init; }
         public double? TxThroughputBps { get; init; }
         public double? RxThroughputBps { get; init; }
+        /// <summary>Connection stats - populated for wifi_client only; null for wired_client.</summary>
+        public int? SignalDbm { get; init; }
+        public long? TxRateKbps { get; init; }
+        public long? RxRateKbps { get; init; }
+        /// <summary>Raw band tag ("2.4ghz"/"5ghz"/"6ghz"); caller normalizes for display.</summary>
+        public string? Band { get; init; }
+        /// <summary>AP the client was associated with (device_mac tag).</summary>
+        public string? ApMac { get; init; }
     }
 
     public async Task<IReadOnlyList<ClientThroughputPoint>> QueryAllClientThroughputAsync(
@@ -1389,10 +1397,13 @@ from(bucket: ""{_longtermBucket}"")
         CancellationToken ct = default)
     {
         if (!IsConfigured) return Array.Empty<ClientThroughputPoint>();
+        // signal_dbm / tx_rate_kbps / rx_rate_kbps only exist on wifi_client; harmless to
+        // request for wired_client (no rows match, columns come back absent -> null). band
+        // and device_mac are tags and survive the pivot as columns.
         var flux = $@"from(bucket: ""{_bucket}"")
   |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
   |> filter(fn: (r) => r._measurement == ""{measurement}"")
-  |> filter(fn: (r) => r._field == ""tx_throughput_bps"" or r._field == ""rx_throughput_bps"" or r._field == ""client_mac"")
+  |> filter(fn: (r) => r._field == ""tx_throughput_bps"" or r._field == ""rx_throughput_bps"" or r._field == ""client_mac"" or r._field == ""signal_dbm"" or r._field == ""tx_rate_kbps"" or r._field == ""rx_rate_kbps"")
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
   |> filter(fn: (r) => (exists r.tx_throughput_bps and r.tx_throughput_bps > 0.0) or (exists r.rx_throughput_bps and r.rx_throughput_bps > 0.0))";
 
@@ -1405,6 +1416,11 @@ from(bucket: ""{_longtermBucket}"")
                 ClientMac = record.GetValueByKey("client_mac") as string,
                 TxThroughputBps = AsDoubleOrNull(record.GetValueByKey("tx_throughput_bps")),
                 RxThroughputBps = AsDoubleOrNull(record.GetValueByKey("rx_throughput_bps")),
+                SignalDbm = (int?)AsDoubleOrNull(record.GetValueByKey("signal_dbm")),
+                TxRateKbps = (long?)AsDoubleOrNull(record.GetValueByKey("tx_rate_kbps")),
+                RxRateKbps = (long?)AsDoubleOrNull(record.GetValueByKey("rx_rate_kbps")),
+                Band = record.GetValueByKey("band") as string,
+                ApMac = record.GetValueByKey("device_mac") as string,
             });
         }
         return results;

--- a/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
@@ -18,7 +18,7 @@ public class PerfTweaksDeploymentService
     private const string OnBootDir = "/data/on_boot.d";
     private const string PerfTweaksDir = "/data/perf-tweaks";
     private const string SfpModuleDir = "/data/sfp-sgmiiplus";
-    private static readonly Version MaxSupportedFirmware = new(5, 1, 18);
+    private static readonly Version MaxSupportedFirmware = new(5, 1, 19);
 
     private static readonly Dictionary<string, string> BootScriptFiles = new()
     {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -830,9 +830,14 @@ a.stat-card-link:active {
 .monitoring-stat-card .stat-danger {
     color: var(--danger-color);
 }
+@media (max-width: 1200px) {
+    .monitoring-stat-card {
+        min-height: 99px;
+    }
+}
 @media (max-width: 1024px) {
     .monitoring-stat-rate {
-        min-height: 98px;
+        min-height: 99px;
     }
 }
 @media (max-width: 768px) {
@@ -843,6 +848,7 @@ a.stat-card-link:active {
         flex: 1 1 80px;
         min-width: 70px;
         padding: 0.5rem 0.5rem;
+        min-height: auto;
     }
     .monitoring-stat-card .stat-value {
         font-size: 1rem;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -830,9 +830,13 @@ a.stat-card-link:active {
 .monitoring-stat-card .stat-danger {
     color: var(--danger-color);
 }
-@media (max-width: 1200px) {
+@media (min-width: 769px) and (max-width: 1200px) {
     .monitoring-stat-card {
         min-height: 99px;
+    }
+    .monitoring-stat-pair .monitoring-stat-card,
+    .monitoring-stat-card.stat-card-no-minheight {
+        min-height: auto;
     }
 }
 @media (max-width: 1024px) {
@@ -848,7 +852,6 @@ a.stat-card-link:active {
         flex: 1 1 80px;
         min-width: 70px;
         padding: 0.5rem 0.5rem;
-        min-height: auto;
     }
     .monitoring-stat-card .stat-value {
         font-size: 1rem;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-data.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-data.js
@@ -6,6 +6,7 @@ let _snapshot = null;
 let _liveRates = {};
 let _cloudStats = {};
 let _nodeBadges = {};
+let _clientStats = {};
 let _paused = false;
 let _mode = 'live';
 let _scrubberValue = 10000;
@@ -17,6 +18,7 @@ export function getSnapshot()  { return _snapshot; }
 export function getLiveRates()  { return _liveRates; }
 export function getCloudStats() { return _cloudStats; }
 export function getNodeBadges() { return _nodeBadges; }
+export function getClientStats() { return _clientStats; }
 export function isPaused()       { return _paused; }
 export function getMode()        { return _mode; }
 export function getScrubber()    { return { value: _scrubberValue, right: _scrubberRight, speed: _playbackSpeed }; }
@@ -45,6 +47,10 @@ export function publishLive(update) {
     if (update.linkRates)   Object.assign(_liveRates, update.linkRates);
     if (update.cloudStats)  _cloudStats = update.cloudStats;
     if (update.nodeBadges)  _nodeBadges = update.nodeBadges;
+    // Wholesale replace (not merge): historic ticks carry client stats, live ticks
+    // don't, so this clears them when returning to live - renderers then fall back to
+    // the snapshot values, which live snapshot rebuilds keep current.
+    _clientStats = update.clientStats || {};
     _notify('live');
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1343,10 +1343,21 @@ class LanFlowMap2D {
 
     // ---- Rate updates ----
 
+    // A device with an offline badge can't be moving traffic. Badges only carry
+    // online for infra (gateway/switch/AP); a node with no badge is assumed online so
+    // clients (which have no badge) are never spuriously zeroed.
+    _isOffline(nodeId){
+        const b=flowData.getNodeBadges()?.[nodeId];
+        return b?b.online===false:false;
+    }
+
     _updateStreamRates(){
         for(const e of this._edges){
             if(!e._sDown)continue;
-            const r=this._liveRates[e.lk.portKey]||this._liveRates[e.lk.id];
+            // Force idle when an endpoint is offline - _liveRates is merged, not
+            // replaced, so the last sample would otherwise stream forever.
+            const off=this._isOffline(e.lk.fromNodeId)||this._isOffline(e.lk.toNodeId);
+            const r=off?null:(this._liveRates[e.lk.portKey]||this._liveRates[e.lk.id]);
             e._sDown.setRate(r?.downstreamBps??0);
             e._sUp.setRate(r?.upstreamBps??0);
         }
@@ -1443,7 +1454,8 @@ class LanFlowMap2D {
                 const child=e.tn||e.fn;
                 if(child&&!this._isNodeVisible(child))continue;
             }
-            const r=this._liveRates[e.lk.portKey]||this._liveRates[e.lk.id];
+            const off=this._isOffline(e.lk.fromNodeId)||this._isOffline(e.lk.toNodeId);
+            const r=off?null:(this._liveRates[e.lk.portKey]||this._liveRates[e.lk.id]);
             const dn=r?.downstreamBps??0,up=r?.upstreamBps??0;
             const cap=e.lk.capacityBps||1e9;
             const u=Math.max(dn,up)/cap;
@@ -1496,7 +1508,9 @@ class LanFlowMap2D {
                     txt=formatSpeed(e.lk.capacityBps/1e6);
                 }
 
-                if(txt) this._pendingLinkLabels.push({mx,my,txt,txtColor,txtItalic});
+                // Suppress the speed/throughput label for a link to an offline device -
+                // a down port has no meaningful negotiated speed or throughput.
+                if(txt&&!off) this._pendingLinkLabels.push({mx,my,txt,txtColor,txtItalic});
             }
         }
         ctx.globalAlpha=1;
@@ -1627,7 +1641,11 @@ class LanFlowMap2D {
     _drawInfraNode(ctx,n){
         const x=n.x, y=n.y, color=nodeClr(n.d.kind);
         const hw=G.boxW/2, hh=G.boxH/2;
-        const op=n.d.online?1:0.35;
+        // Prefer the live/historic badge online state over the snapshot's build-time
+        // value so the dimming tracks the timeline and live changes between rebuilds.
+        const badge=flowData.getNodeBadges()?.[n.d.id];
+        const online=badge?badge.online!==false:n.d.online;
+        const op=online?1:0.35;
 
         // Glow
         ctx.fillStyle=withAlpha(color,0.07);
@@ -1682,7 +1700,9 @@ class LanFlowMap2D {
 
     _drawClientNode(ctx,n){
         const x=n.x, y=n.y, color=nodeClr(n.d.kind,n.d.band);
-        const r=G.clientR, op=n.d.online?0.7:0.2;
+        const badge=flowData.getNodeBadges()?.[n.d.id];
+        const online=badge?badge.online!==false:n.d.online;
+        const r=G.clientR, op=online?0.7:0.2;
 
         ctx.globalAlpha=op;
         if(n.d.kind===NK.WifiClient){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -850,14 +850,18 @@ class LanFlowMap2D {
         const d=node.d;
         const esc=(s)=>(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;');
         const m=demoMask;
+        // During playback prefer the client's wireless stats at the scrubbed instant.
+        const cs=flowData.getClientStats()?.[d.id];
+        const band=cs?.band??d.band;
+        const signalDbm=cs?.signalDbm??d.signalDbm;
         const rows=[];
         if(d.ip)rows.push(['IP',m(d.ip)]);
         if(d.mac)rows.push(['MAC',m(d.mac)]);
         if(d.model)rows.push(['Model',d.model]);
-        if(d.band)rows.push(['Band',`${d.band} GHz`]);
+        if(band)rows.push(['Band',`${band} GHz`]);
         if(d.ssid)rows.push(['SSID',m(d.ssid)]);
         if(d.network)rows.push(['Network',m(d.network)]);
-        if(d.signalDbm)rows.push(['Signal',`${d.signalDbm} dBm`]);
+        if(signalDbm)rows.push(['Signal',`${signalDbm} dBm`]);
         if(d.switchPortName)rows.push(['Switch port',m(d.switchPortName)]);
 
         const badges=flowData.getNodeBadges();
@@ -1496,11 +1500,14 @@ class LanFlowMap2D {
                         }
                     }
                 }else if(e.lk.kind===LK.MeshBackhaul||e.lk.band){
-                    // Mesh/wireless: show asymmetric PHY rates
+                    // Mesh/wireless: show asymmetric PHY rates. During playback prefer the
+                    // client's PHY rate at the scrubbed instant over the frozen snapshot.
                     const n1=e.fn?.d, n2=e.tn?.d;
                     const phy=n2?.phyTxKbps?n2:n1?.phyTxKbps?n1:null;
-                    if(phy?.phyTxKbps&&phy?.phyRxKbps){
-                        txt=`↓${formatSpeed(phy.phyRxKbps/1000)}  ↑${formatSpeed(phy.phyTxKbps/1000)}`;
+                    const cs=phy?flowData.getClientStats()?.[phy.id]:null;
+                    const phyTx=cs?.phyTxKbps??phy?.phyTxKbps, phyRx=cs?.phyRxKbps??phy?.phyRxKbps;
+                    if(phyTx&&phyRx){
+                        txt=`↓${formatSpeed(phyRx/1000)}  ↑${formatSpeed(phyTx/1000)}`;
                     }else if(e.lk.capacityBps>0){
                         txt=formatSpeed(e.lk.capacityBps/1e6);
                     }
@@ -1699,7 +1706,9 @@ class LanFlowMap2D {
     }
 
     _drawClientNode(ctx,n){
-        const x=n.x, y=n.y, color=nodeClr(n.d.kind,n.d.band);
+        const cs=flowData.getClientStats()?.[n.d.id];
+        const band=cs?.band??n.d.band;
+        const x=n.x, y=n.y, color=nodeClr(n.d.kind,band);
         const badge=flowData.getNodeBadges()?.[n.d.id];
         const online=badge?badge.online!==false:n.d.online;
         const r=G.clientR, op=online?0.7:0.2;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1237,6 +1237,9 @@ class LanFlowMap2D {
         for(const n of snap.nodes){
             const tn=this._treeMap.get(n.id);
             if(tn){
+                // A client that roamed to a different AP (live) keeps its node id, so the
+                // only signal is its parent changing. Rebuild so it moves to the new AP.
+                if(isClient(n.kind)&&tn.d.parentId!==n.parentId)clientsChanged=true;
                 tn.d.online=n.online;
                 tn.d.phyTxKbps=n.phyTxKbps;
                 tn.d.phyRxKbps=n.phyRxKbps;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -85,6 +85,10 @@ function nodeClr(k,b) {
 function isInfra(k) { return k<=NK.AP||k===NK.VirtualHub; }
 function isClient(k) { return k===NK.WiredClient||k===NK.WifiClient; }
 
+// Duration of the fade-in applied to a client that gets re-attached to a different
+// AP during historic playback (roam), so it doesn't pop at its new position.
+const ROAM_FADE_MS = 350;
+
 function pipeClr(u,band) {
     const cool=bandClr(band)||C.pipeCool;
     if(u<0.7)return cool;
@@ -306,6 +310,7 @@ class LanFlowMap2D {
                 }
             }else if(ev==='live'){
                 Object.assign(this._liveRates,flowData.getLiveRates());
+                this._applyClientAssoc();
                 this._updateStreamRates();
                 this._updateCloudStats();
                 this._needsStaticRedraw=true;
@@ -951,6 +956,9 @@ class LanFlowMap2D {
 
     _buildLayout(snap){
         this._snapshot=snap;
+        // Tree is rebuilt from the snapshot's (current) associations, so any historic
+        // roam re-parenting is gone - reset the applied map so _applyClientAssoc re-diffs.
+        this._appliedAssoc=new Map();
         const byId=new Map();
         for(const n of snap.nodes)byId.set(n.id,new TN(n));
         this._treeMap=byId;
@@ -1021,6 +1029,36 @@ class LanFlowMap2D {
         this._calcBounds();
         this._updateStreamRates();
         this._needsStaticRedraw=true;
+    }
+
+    // Re-attach wifi clients to the AP they were on at the scrubbed instant (roam
+    // playback). The historic update carries clientStats[clientId].apNodeId; in live
+    // mode it's empty, so every client falls back to its snapshot parent (reset).
+    // Only relayouts when an association actually changed, so steady live is free.
+    _applyClientAssoc(){
+        if(!this._root)return;
+        const stats=flowData.getClientStats()||{};
+        if(!this._appliedAssoc)this._appliedAssoc=new Map();
+        const now=performance.now();
+        let changed=false;
+        for(const[id,tn]of this._treeMap){
+            if(!isClient(tn.d.kind))continue;
+            const baseline=tn.d.parentId;
+            const desired=stats[id]?.apNodeId||baseline;
+            const cur=this._appliedAssoc.get(id)||baseline;
+            if(desired===cur)continue;
+            const newParent=this._treeMap.get(desired);
+            if(!newParent)continue; // historic AP not in current topology - leave in place
+            const curParent=this._treeMap.get(cur);
+            if(curParent){const i=curParent.clients.indexOf(tn);if(i>=0)curParent.clients.splice(i,1);}
+            newParent.clients.push(tn);
+            const edge=this._edges.find(e=>e.tn===tn||e.fn===tn);
+            if(edge){if(edge.tn===tn)edge.fn=newParent;else edge.tn=newParent;}
+            this._appliedAssoc.set(id,desired);
+            tn._roamFadeUntil=now+ROAM_FADE_MS;
+            changed=true;
+        }
+        if(changed){this._roamFadeUntil=now+ROAM_FADE_MS;this._relayout();}
     }
 
     // Compute contour (left/right extent at each depth relative to node x=0)
@@ -1269,9 +1307,11 @@ class LanFlowMap2D {
             }
             for(const c of n.clients.slice(0,G.maxClients)){
                 const cT=c.y-G.clientR;
-                const edge=this._edges.find(e=>
-                    (e.lk.fromNodeId===n.d.id&&e.lk.toNodeId===c.d.id)
-                    ||(e.lk.fromNodeId===c.d.id&&e.lk.toNodeId===n.d.id));
+                // Match the client's uplink edge by TN identity, not link ids: during
+                // roam playback the client is re-parented to its historic AP, so the
+                // edge must follow the tree without mutating the shared snapshot link.
+                // A client has exactly one tree edge (its uplink), so this is unambiguous.
+                const edge=this._edges.find(e=>e.tn===c||e.fn===c);
                 if(edge){edge._x1=n.x;edge._y1=pB;edge._x2=c.x;edge._y2=cT;edge._isCl=true;edge._band=edge.lk.band;sibEdges.push(edge);}
             }
 
@@ -1711,7 +1751,12 @@ class LanFlowMap2D {
         const x=n.x, y=n.y, color=nodeClr(n.d.kind,band);
         const badge=flowData.getNodeBadges()?.[n.d.id];
         const online=badge?badge.online!==false:n.d.online;
-        const r=G.clientR, op=online?0.7:0.2;
+        const r=G.clientR; let op=online?0.7:0.2;
+        // Fade the client in after a roam re-attach so it doesn't pop at its new spot.
+        if(n._roamFadeUntil){
+            const t=1-Math.max(0,(n._roamFadeUntil-performance.now())/ROAM_FADE_MS);
+            if(t>=1)n._roamFadeUntil=null; else op*=t;
+        }
 
         ctx.globalAlpha=op;
         if(n.d.kind===NK.WifiClient){
@@ -1860,6 +1905,9 @@ class LanFlowMap2D {
         if(this._liveOnly||!flowData.isPaused()){
             for(const s of this._streams)s.advance(dt);
         }
+        // Clients live on the cached static layer; force it to redraw while a roam
+        // fade is in flight so the fade-in actually animates.
+        if(this._roamFadeUntil&&now<this._roamFadeUntil)this._needsStaticRedraw=true;
         this._draw();
 
         this._animId=requestAnimationFrame(()=>this._animate());

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1347,21 +1347,28 @@ class LanFlowMap2D {
 
     _calcBounds(visibleOnly){
         let x0=Infinity,y0=Infinity,x1=-Infinity,y1=-Infinity;
-        const exp=(x,y,r)=>{x0=Math.min(x0,x-r);y0=Math.min(y0,y-r);x1=Math.max(x1,x+r);y1=Math.max(y1,y+r);};
+        // Vertical extent is asymmetric on purpose: name + throughput labels sit BELOW a
+        // node and there's nothing above the top node, so reserve only the node's top
+        // half upward and the label band downward. (The old code used boxW - the box
+        // WIDTH - for all four sides, padding empty space above the gateway and clipping
+        // the bottom node's rate label, which biased the whole map downward.)
+        const exp=(x,y,rx,up,down)=>{
+            x0=Math.min(x0,x-rx); x1=Math.max(x1,x+rx);
+            y0=Math.min(y0,y-up); y1=Math.max(y1,y+down);
+        };
+        const INFRA_UP=G.boxH/2+6, INFRA_DOWN=G.boxH/2+44;   // box top ; box + name + rate label
+        const CLIENT_UP=G.clientR+4, CLIENT_DOWN=G.clientR+24; // dot top ; dot + name label
         const walk=(n)=>{
-            exp(n.x,n.y,G.boxW);
+            exp(n.x,n.y,G.boxW,INFRA_UP,INFRA_DOWN);
             for(const c of n.infra)walk(c);
-            if(!visibleOnly){
-                for(const c of n.clients.slice(0,G.maxClients))exp(c.x,c.y,G.clientCellW/2);
-            }else{
-                for(const c of n.clients.slice(0,G.maxClients)){
-                    if(this._isNodeVisible(c))exp(c.x,c.y,G.clientCellW/2);
-                }
+            for(const c of n.clients.slice(0,G.maxClients)){
+                if(visibleOnly&&!this._isNodeVisible(c))continue;
+                exp(c.x,c.y,G.clientCellW/2,CLIENT_UP,CLIENT_DOWN);
             }
         };
         walk(this._root);
         if(!visibleOnly||this._isCloudVisible()){
-            for(const c of this._clouds)exp(c.x,c.y,G.cloudR+30);
+            for(const c of this._clouds)exp(c.x,c.y,G.cloudR+30,G.cloudR+30,G.cloudR+30);
         }
         const p=20;
         this._bx=x0-p; this._by=y0-p;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -3,7 +3,7 @@
 // zero duplicate API calls. GPU-composited canvas for smooth particle animation.
 
 // KEEP IN SYNC: lan-flow-map.js imports the same module. Both must use the same ?v= or they get separate instances.
-import * as flowData from './lan-flow-data.js?v=2';
+import * as flowData from './lan-flow-data.js?v=3';
 
 function demoMask(text) {
     const dm = window.DemoMask;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -550,6 +550,7 @@ export class LanFlowMap {
             const update = await res.json();
             flowData.publishLive(update);
             this._currentBadges = update.nodeBadges || {};
+            this._applyOnlineState();
             this._applyLiveRates(update.linkRates || {});
         } catch (err) {
             // Keep ticking; transient network errors are fine.
@@ -784,7 +785,7 @@ export class LanFlowMap {
                 core.material.transparent = true;
                 halo.material.opacity = 0.05;
             }
-            group.userData = { node, core, baseEmissive };
+            group.userData = { node, core, halo, baseEmissive };
             this.nodeGroup.add(group);
             this._nodeMeshes.set(node.id, group);
 
@@ -1204,9 +1205,15 @@ export class LanFlowMap {
         // (every 30s). A wholesale replace was wiping wired client rates 2 seconds
         // after each snapshot, leaving the leaf pipes idle forever.
         this._currentRates = { ...(this._currentRates || {}), ...rates };
+        const badges = this._currentBadges || {};
+        const isOffline = (nodeId) => badges[nodeId]?.online === false;
         for (const [linkId, link] of this._linkMeshes) {
             const r = this._currentRates[linkId];
-            if (!r) {
+            // An offline endpoint can't be moving traffic. Because the rate map is
+            // merged (not replaced) the last sample would otherwise stay frozen on the
+            // pipe forever, so force its links idle the moment a device goes offline.
+            const endpointOffline = isOffline(link.link?.fromNodeId) || isOffline(link.link?.toNodeId);
+            if (!r || endpointOffline) {
                 link.down.setRate(0);
                 link.up.setRate(0);
                 this._setPipeHealth(link.pipe, 0);
@@ -1228,6 +1235,28 @@ export class LanFlowMap {
         this._refreshDeviceLabelRates();
         this._refreshLinkLabels();
         this._refreshCloudRttLabels();
+    }
+
+    _applyOnlineState() {
+        // Online/offline isn't baked into the mesh - it changes between snapshot
+        // rebuilds (live) and across the timeline (historic). Re-skin every node from
+        // the latest badge each tick so a device that was online when the mesh was
+        // built doesn't stay lit after it drops (and vice versa during playback).
+        // Badges only carry online for infrastructure; a node with no badge is left
+        // untouched (clients track association, not device state).
+        const badges = this._currentBadges || {};
+        for (const [id, group] of this._nodeMeshes) {
+            const badge = badges[id];
+            if (!badge) continue;
+            const online = badge.online !== false;
+            const { core, halo, node } = group.userData || {};
+            if (node) node.online = online;
+            if (core?.material) {
+                core.material.transparent = true;
+                core.material.opacity = online ? 1 : 0.55;
+            }
+            if (halo?.material) halo.material.opacity = online ? 0.12 : 0.05;
+        }
     }
 
     _refreshLinkLabels() {
@@ -2297,8 +2326,11 @@ export class LanFlowMap {
             const update = await res.json();
             if (gen !== this._historicGen) return;
             flowData.publishLive(update);
+            // Set badges before applying rates: _applyOnlineState re-skins the nodes and
+            // _applyLiveRates reads the badges to force offline endpoints' pipes idle.
+            this._currentBadges = update.nodeBadges || {};
+            this._applyOnlineState();
             this._applyLiveRates(update.linkRates || {});
-            if (update.nodeBadges) this._currentBadges = update.nodeBadges;
         } catch (err) {
             // Keep ticking; transient errors are fine.
         }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1299,20 +1299,35 @@ export class LanFlowMap {
         }
     }
 
+    // Historic roam: re-point with baseline restore. On reset (newApId === the live
+    // snapshot parent) the client returns to its exact original spot; otherwise it
+    // scatters near the historic AP.
     _repointClientLink(clientId, newApId, baselineApId) {
         const pos = this._positions.get(clientId);
-        const group = this._nodeMeshes.get(clientId);
-        const apPos = this._positions.get(newApId);
-        if (!pos || !group || !apPos) return;
-        // Remember the client's original spot the first time it's moved, so resetting
-        // back to its live AP restores it exactly instead of re-scattering.
+        if (!pos) return;
         if (!this._roamBasePos.has(clientId)) {
             this._roamBasePos.set(clientId, { x: pos.x, y: pos.y, z: pos.z });
         }
         if (newApId === baselineApId && this._roamBasePos.has(clientId)) {
             const b = this._roamBasePos.get(clientId);
-            pos.x = b.x; pos.y = b.y; pos.z = b.z;
             this._roamBasePos.delete(clientId);
+            this._attachClientToAp(clientId, newApId, b);
+        } else {
+            this._attachClientToAp(clientId, newApId);
+        }
+    }
+
+    // Move a client next to an AP and rebuild its uplink pipe + particle streams from
+    // the new endpoints (geometry is baked, so it must be recreated). Shared by historic
+    // roam playback and live roam (snapshot parent changed). explicitPos restores an
+    // exact spot; otherwise the client scatters to a stable spot near the AP.
+    _attachClientToAp(clientId, apId, explicitPos) {
+        const pos = this._positions.get(clientId);
+        const group = this._nodeMeshes.get(clientId);
+        const apPos = this._positions.get(apId);
+        if (!pos || !group || !apPos) return;
+        if (explicitPos) {
+            pos.x = explicitPos.x; pos.y = explicitPos.y; pos.z = explicitPos.z;
         } else {
             const angle = _roamAngle(clientId);
             const dist = 8;
@@ -1322,8 +1337,6 @@ export class LanFlowMap {
         }
         group.position.set(pos.x, pos.y, pos.z);
 
-        // Rebuild the client's single uplink pipe + particle streams from the new
-        // endpoints (geometry is baked at build time, so it has to be recreated).
         let linkId = null;
         for (const [lid, eps] of this._nodesByLink) {
             if (eps[0] === clientId || eps[1] === clientId) { linkId = lid; break; }
@@ -1342,11 +1355,29 @@ export class LanFlowMap {
             const up = new ParticleStream({ from: pos, to: apPos, color: COLORS.upstream, particleCount: 0 });
             this.particleGroup.add(down.mesh, up.mesh);
             this._linkMeshes.set(linkId, { pipe, down, up, link: old.link });
-            this._nodesByLink.set(linkId, [newApId, clientId]);
+            this._nodesByLink.set(linkId, [apId, clientId]);
         }
 
         if (!this._roamFade3D) this._roamFade3D = new Map();
         this._roamFade3D.set(clientId, performance.now() + ROAM_FADE_MS);
+    }
+
+    // Live roam: a persisting wifi client whose snapshot parent changed (no add/remove).
+    // The snapshot diff doesn't catch this, so re-attach it to the new AP here. The new
+    // parent becomes the baseline, so any later historic re-point/reset is relative to it.
+    _applyLiveRoam(prev, snap) {
+        const prevById = new Map((prev?.nodes ?? []).map(n => [n.id, n]));
+        for (const node of (snap.nodes ?? [])) {
+            if (node.kind !== NODE_KIND.WifiClient) continue;
+            const pn = prevById.get(node.id);
+            if (!pn || pn.parentId === node.parentId) continue;
+            if (!this._nodeMeshes.has(node.id) || !this._positions.get(node.parentId)) continue;
+            const group = this._nodeMeshes.get(node.id);
+            if (group?.userData) group.userData.node = node; // refresh parentId/band/etc.
+            this._roamBasePos?.delete(node.id);
+            this._appliedAssoc3D?.delete(node.id);
+            this._attachClientToAp(node.id, node.parentId);
+        }
     }
 
     _refreshLinkLabels() {
@@ -1617,6 +1648,9 @@ export class LanFlowMap {
                         const removed = [...prevNodeIds].filter(id => !newNodeIds.has(id));
                         for (const id of removed) this._removeNodeIncremental(id);
                         for (const node of added) this._addNodeIncremental(node, snap);
+                        // Seamless roam keeps the client's node id, so add/remove misses
+                        // it - re-attach any persisting client whose parent AP changed.
+                        this._applyLiveRoam(prev, snap);
                         // Don't apply snapshot liveRates - they're stale vs the 1s
                         // live poll and would clobber fresh rates momentarily.
                         this._refreshCloudRttLabels();

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -56,6 +56,17 @@ function bandBaseColor(band) {
     return COLORS.pipeCool;
 }
 
+// Fade-in (ms) applied to a client re-attached to a different AP during roam playback.
+const ROAM_FADE_MS = 350;
+
+// Stable pseudo-angle from a node id so a client scatters to a consistent spot near
+// its historic AP (no jitter if re-pointed again to the same AP).
+function _roamAngle(id) {
+    let h = 0;
+    for (let i = 0; i < id.length; i += 1) h = (h * 31 + id.charCodeAt(i)) | 0;
+    return ((h >>> 0) % 360) * Math.PI / 180;
+}
+
 const NODE_RADIUS = {
     gateway: 1.6,
     switch: 1.2,
@@ -479,6 +490,10 @@ export class LanFlowMap {
         this._cloudMeshes.clear();
         this._positions.clear();
         this._currentRates = {};
+        // Mesh refs are recreated below, so any roam re-pointing state is now stale.
+        this._appliedAssoc3D?.clear();
+        this._roamBasePos?.clear();
+        this._roamFade3D?.clear();
         if (this._labelsLayer) {
             for (const { el } of this._floatingLabels.values()) el.remove();
             for (const { el } of this._linkLabels.values()) el.remove();
@@ -552,6 +567,7 @@ export class LanFlowMap {
             this._currentBadges = update.nodeBadges || {};
             this._currentClientStats = update.clientStats || {};
             this._applyOnlineState();
+            this._applyClientAssoc3D();
             this._applyLiveRates(update.linkRates || {});
         } catch (err) {
             // Keep ticking; transient network errors are fine.
@@ -1260,6 +1276,79 @@ export class LanFlowMap {
         }
     }
 
+    // Re-attach wifi clients to the AP they were on at the scrubbed instant (roam
+    // playback). Historic ticks carry clientStats[id].apNodeId; live ticks send none,
+    // so every client falls back to its snapshot parent (reset). Only mutates on an
+    // actual association change, so steady live is a no-op. Snapshot polls are paused
+    // during historic, so this never races the live incremental add/remove path.
+    _applyClientAssoc3D() {
+        const stats = this._currentClientStats || {};
+        if (!this._appliedAssoc3D) this._appliedAssoc3D = new Map();
+        if (!this._roamBasePos) this._roamBasePos = new Map();
+        for (const [id, group] of this._nodeMeshes) {
+            const node = group.userData?.node;
+            if (!node || node.kind !== NODE_KIND.WifiClient) continue;
+            const baseline = node.parentId;
+            const desired = stats[id]?.apNodeId || baseline;
+            const cur = this._appliedAssoc3D.get(id) || baseline;
+            if (desired === cur) continue;
+            if (!this._positions.get(desired)) continue; // historic AP not present - leave put
+            this._repointClientLink(id, desired, baseline);
+            if (desired === baseline) this._appliedAssoc3D.delete(id);
+            else this._appliedAssoc3D.set(id, desired);
+        }
+    }
+
+    _repointClientLink(clientId, newApId, baselineApId) {
+        const pos = this._positions.get(clientId);
+        const group = this._nodeMeshes.get(clientId);
+        const apPos = this._positions.get(newApId);
+        if (!pos || !group || !apPos) return;
+        // Remember the client's original spot the first time it's moved, so resetting
+        // back to its live AP restores it exactly instead of re-scattering.
+        if (!this._roamBasePos.has(clientId)) {
+            this._roamBasePos.set(clientId, { x: pos.x, y: pos.y, z: pos.z });
+        }
+        if (newApId === baselineApId && this._roamBasePos.has(clientId)) {
+            const b = this._roamBasePos.get(clientId);
+            pos.x = b.x; pos.y = b.y; pos.z = b.z;
+            this._roamBasePos.delete(clientId);
+        } else {
+            const angle = _roamAngle(clientId);
+            const dist = 8;
+            pos.x = apPos.x + Math.cos(angle) * dist;
+            pos.y = apPos.y - 1.5;
+            pos.z = apPos.z + Math.sin(angle) * dist;
+        }
+        group.position.set(pos.x, pos.y, pos.z);
+
+        // Rebuild the client's single uplink pipe + particle streams from the new
+        // endpoints (geometry is baked at build time, so it has to be recreated).
+        let linkId = null;
+        for (const [lid, eps] of this._nodesByLink) {
+            if (eps[0] === clientId || eps[1] === clientId) { linkId = lid; break; }
+        }
+        const old = linkId ? this._linkMeshes.get(linkId) : null;
+        if (old) {
+            this.linkGroup.remove(old.pipe);
+            old.pipe.geometry?.dispose();
+            old.pipe.material?.dispose();
+            this.particleGroup.remove(old.down.mesh, old.up.mesh);
+            old.down.mesh.geometry?.dispose();
+            old.up.mesh.geometry?.dispose();
+            const pipe = this._makePipeMesh(apPos, pos, old.link);
+            this.linkGroup.add(pipe);
+            const down = new ParticleStream({ from: apPos, to: pos, color: COLORS.downstream, particleCount: 0 });
+            const up = new ParticleStream({ from: pos, to: apPos, color: COLORS.upstream, particleCount: 0 });
+            this.particleGroup.add(down.mesh, up.mesh);
+            this._linkMeshes.set(linkId, { pipe, down, up, link: old.link });
+            this._nodesByLink.set(linkId, [newApId, clientId]);
+        }
+
+        if (!this._roamFade3D) this._roamFade3D = new Map();
+        this._roamFade3D.set(clientId, performance.now() + ROAM_FADE_MS);
+    }
+
     _refreshLinkLabels() {
         if (!this._linkLabels || this._linkLabels.size === 0) return;
         for (const [linkId, { el, kind }] of this._linkLabels) {
@@ -1477,6 +1566,18 @@ export class LanFlowMap {
             const base = group.userData?.baseEmissive;
             if (!core || base == null) continue;
             core.material.emissiveIntensity = base * factor;
+        }
+        // Ramp opacity back up on clients that just roamed to a new AP so they fade in
+        // rather than pop. _applyOnlineState re-asserts the correct opacity afterwards.
+        if (this._roamFade3D && this._roamFade3D.size) {
+            for (const [id, until] of this._roamFade3D) {
+                const core = this._nodeMeshes.get(id)?.userData?.core;
+                if (!core) { this._roamFade3D.delete(id); continue; }
+                const t = 1 - Math.max(0, (until - nowMs) / ROAM_FADE_MS);
+                core.material.transparent = true;
+                core.material.opacity = Math.max(0.15, t);
+                if (t >= 1) this._roamFade3D.delete(id);
+            }
         }
     }
 
@@ -2332,6 +2433,7 @@ export class LanFlowMap {
             this._currentBadges = update.nodeBadges || {};
             this._currentClientStats = update.clientStats || {};
             this._applyOnlineState();
+            this._applyClientAssoc3D();
             this._applyLiveRates(update.linkRates || {});
         } catch (err) {
             // Keep ticking; transient errors are fine.

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -59,12 +59,22 @@ function bandBaseColor(band) {
 // Fade-in (ms) applied to a client re-attached to a different AP during roam playback.
 const ROAM_FADE_MS = 350;
 
-// Stable pseudo-angle from a node id so a client scatters to a consistent spot near
-// its historic AP (no jitter if re-pointed again to the same AP).
-function _roamAngle(id) {
-    let h = 0;
-    for (let i = 0; i < id.length; i += 1) h = (h * 31 + id.charCodeAt(i)) | 0;
-    return ((h >>> 0) % 360) * Math.PI / 180;
+// Deterministic PRNG (mulberry32) seeded off a node id. Lets a roamed client scatter
+// near its AP using the same distribution as a freshly-added client, while staying
+// stable across scrub crossings (no re-jitter when re-pointed to the same AP).
+function _roamSeed(id) {
+    let h = 1779033703 ^ id.length;
+    for (let i = 0; i < id.length; i += 1) {
+        h = Math.imul(h ^ id.charCodeAt(i), 3432918353);
+        h = (h << 13) | (h >>> 19);
+    }
+    let a = h >>> 0;
+    return function () {
+        a = (a + 0x6D2B79F5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
 }
 
 const NODE_RADIUS = {
@@ -1329,10 +1339,14 @@ export class LanFlowMap {
         if (explicitPos) {
             pos.x = explicitPos.x; pos.y = explicitPos.y; pos.z = explicitPos.z;
         } else {
-            const angle = _roamAngle(clientId);
-            const dist = 8;
+            // Same scatter as a freshly-attached client (_addNodeIncremental): random
+            // angle, 6-12 units out, slight y jitter - but seeded off the client id so
+            // it's stable across scrub crossings instead of re-rolling each time.
+            const rnd = _roamSeed(clientId);
+            const angle = rnd() * Math.PI * 2;
+            const dist = 6 + rnd() * 6;
             pos.x = apPos.x + Math.cos(angle) * dist;
-            pos.y = apPos.y - 1.5;
+            pos.y = apPos.y - 1.5 + rnd();
             pos.z = apPos.z + Math.sin(angle) * dist;
         }
         group.position.set(pos.x, pos.y, pos.z);
@@ -2682,6 +2696,10 @@ export class LanFlowMap {
         for (const [linkId, { el }] of this._linkLabels) {
             const link = this._linkMeshes.get(linkId);
             if (!link || !el._hasData) { el.classList.remove('is-visible'); continue; }
+            // Respect the band/overlay filter: _applyFilter hides a filtered client
+            // link's pipe, so its throughput label must hide too (device labels already
+            // gate on group.visible; link labels need the same check).
+            if (!link.pipe.visible) { el.classList.remove('is-visible'); continue; }
             const fromPos = this._positions.get(link.link.fromNodeId);
             const toPos = this._positions.get(link.link.toNodeId);
             if (!fromPos || !toPos) continue;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -550,6 +550,7 @@ export class LanFlowMap {
             const update = await res.json();
             flowData.publishLive(update);
             this._currentBadges = update.nodeBadges || {};
+            this._currentClientStats = update.clientStats || {};
             this._applyOnlineState();
             this._applyLiveRates(update.linkRates || {});
         } catch (err) {
@@ -2329,6 +2330,7 @@ export class LanFlowMap {
             // Set badges before applying rates: _applyOnlineState re-skins the nodes and
             // _applyLiveRates reads the badges to force offline endpoints' pipes idle.
             this._currentBadges = update.nodeBadges || {};
+            this._currentClientStats = update.clientStats || {};
             this._applyOnlineState();
             this._applyLiveRates(update.linkRates || {});
         } catch (err) {
@@ -2737,13 +2739,18 @@ export class LanFlowMap {
     _showHover(node) {
         if (!this._tooltipEl) return;
         const rows = [];
+        // During playback prefer the client's wireless stats at the scrubbed instant
+        // over the snapshot-frozen values (band/signal/PHY rate below).
+        const cs = this._currentClientStats?.[node.id];
+        const band = cs?.band ?? node.band;
+        const signalDbm = cs?.signalDbm ?? node.signalDbm;
         if (node.ip) rows.push(['IP', node.ip]);
         if (node.mac) rows.push(['MAC', node.mac]);
         if (node.model) rows.push(['Model', node.model]);
-        if (node.band) rows.push(['Band', `${node.band} GHz`]);
+        if (band) rows.push(['Band', `${band} GHz`]);
         if (node.ssid) rows.push(['SSID', node.ssid]);
         if (node.network) rows.push(['Network', node.network]);
-        if (node.signalDbm) rows.push(['Signal', `${node.signalDbm} dBm`]);
+        if (signalDbm) rows.push(['Signal', `${signalDbm} dBm`]);
         if (node.switchPortName) rows.push(['Switch port', node.switchPortName]);
         // Device health from NodeLiveBadge (infrastructure nodes only)
         const badge = this._currentBadges?.[node.id];
@@ -2824,11 +2831,14 @@ export class LanFlowMap {
         // above the live throughput so the capable rate sits over the actual rate.
         if (node.wiredLinkSpeedMbps) {
             rows.push(['Link speed', formatLinkSpeed(node.wiredLinkSpeedMbps)]);
-        } else if (node.phyTxKbps || node.phyRxKbps) {
+        } else if (node.phyTxKbps || node.phyRxKbps || cs?.phyTxKbps || cs?.phyRxKbps) {
             // Device perspective: download (↓) is the AP's TX to a Wi-Fi client, upload
-            // (↑) is the AP's RX. A mesh uplink's Tx/Rx is the reverse, so swap.
-            const downKbps = isMeshUplink ? node.phyRxKbps : node.phyTxKbps;
-            const upKbps = isMeshUplink ? node.phyTxKbps : node.phyRxKbps;
+            // (↑) is the AP's RX. A mesh uplink's Tx/Rx is the reverse, so swap. Prefer
+            // the scrubbed-instant PHY rate during playback.
+            const pTx = cs?.phyTxKbps ?? node.phyTxKbps;
+            const pRx = cs?.phyRxKbps ?? node.phyRxKbps;
+            const downKbps = isMeshUplink ? pRx : pTx;
+            const upKbps = isMeshUplink ? pTx : pRx;
             const dl = downKbps ? `↓${formatLinkSpeed(Math.round(downKbps / 1000))}` : '';
             const ul = upKbps ? `↑${formatLinkSpeed(Math.round(upKbps / 1000))}` : '';
             rows.push(['Link speed', `${dl}${dl && ul ? '  ' : ''}${ul}`]);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -15,7 +15,7 @@ import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js'
 import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 import { buildBuildings } from './lan-flow-buildings.js?v=1';
 // KEEP IN SYNC: lan-flow-map-2d.js imports the same module. Both must use the same ?v= or they get separate instances.
-import * as flowData from './lan-flow-data.js?v=2';
+import * as flowData from './lan-flow-data.js?v=3';
 
 const COLORS = {
     background: 0x202023,

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1357,6 +1357,9 @@ export class LanFlowMap {
         }
         const old = linkId ? this._linkMeshes.get(linkId) : null;
         if (old) {
+            // Carry the old pipe's visibility onto the rebuilt one - a fresh mesh defaults
+            // to visible, which would resurrect the pipe of a filtered-out client.
+            const wasVisible = old.pipe.visible;
             this.linkGroup.remove(old.pipe);
             old.pipe.geometry?.dispose();
             old.pipe.material?.dispose();
@@ -1364,9 +1367,12 @@ export class LanFlowMap {
             old.down.mesh.geometry?.dispose();
             old.up.mesh.geometry?.dispose();
             const pipe = this._makePipeMesh(apPos, pos, old.link);
+            pipe.visible = wasVisible;
             this.linkGroup.add(pipe);
             const down = new ParticleStream({ from: apPos, to: pos, color: COLORS.downstream, particleCount: 0 });
             const up = new ParticleStream({ from: pos, to: apPos, color: COLORS.upstream, particleCount: 0 });
+            down.mesh.visible = wasVisible;
+            up.mesh.visible = wasVisible;
             this.particleGroup.add(down.mesh, up.mesh);
             this._linkMeshes.set(linkId, { pipe, down, up, link: old.link });
             this._nodesByLink.set(linkId, [apId, clientId]);
@@ -1729,14 +1735,25 @@ export class LanFlowMap {
         // Build link pipe + particles
         const a = this._positions.get(link.fromNodeId);
         const b = this._positions.get(link.toNodeId);
+        let pipe = null, down = null, up = null;
         if (a && b) {
-            const pipe = this._makePipeMesh(a, b, link);
+            pipe = this._makePipeMesh(a, b, link);
             this.linkGroup.add(pipe);
-            const down = new ParticleStream({ from: a, to: b, color: COLORS.downstream, particleCount: 0 });
-            const up = new ParticleStream({ from: b, to: a, color: COLORS.upstream, particleCount: 0 });
+            down = new ParticleStream({ from: a, to: b, color: COLORS.downstream, particleCount: 0 });
+            up = new ParticleStream({ from: b, to: a, color: COLORS.upstream, particleCount: 0 });
             this.particleGroup.add(down.mesh, up.mesh);
             this._linkMeshes.set(link.id, { pipe, down, up, link });
             this._nodesByLink.set(link.id, [link.fromNodeId, link.toNodeId]);
+        }
+
+        // Respect the active band/overlay filter: a client that connects while filtered
+        // out shouldn't pop into view (node or pipe).
+        const isClient = node.kind === NODE_KIND.WifiClient || node.kind === NODE_KIND.WiredClient;
+        if (isClient && !this._isClientVisible(node)) {
+            group.visible = false;
+            if (pipe) pipe.visible = false;
+            if (down) down.mesh.visible = false;
+            if (up) up.mesh.visible = false;
         }
     }
 


### PR DESCRIPTION
## What

Makes the LAN flow map (2D and 3D) reflect what the network was actually doing - both live and across the timeline - instead of freezing the current snapshot and missing live changes.

**Device online/offline**
- Plays back correctly through the timeline (offline at T shows offline at T), and updates live instead of lagging.
- Offline devices dim and drop to zero link speed/throughput instead of holding their last sample.

**Wi-Fi client connection stats**
- Band, signal, and PHY link rate play back at the scrubbed instant rather than showing current values.

**Wi-Fi client roam**
- A client appears on the AP it was actually connected to - during historic playback and live. A seamless roam (no disconnect) previously never moved the client on either map; only a disconnect or page refresh did.

**Map polish**
- 3D: link throughput labels and re-pointed/added client pipes respect the band/overlay/name filter (no orphaned pipes after a redraw); roamed clients are placed with the same scatter as freshly-attached ones.
- 2D: tighter, label-aware vertical fit so the map sits up near the top instead of biased downward.

**Monitoring stat cards**
- min-height below 1200px (scoped to 769-1200px) so cards line up, with Transit RTT/Loss and the Fabric Ingress/Egress pair exempted (they wrap to their own row). Applied on both the Monitoring page and the dashboard live view.

**Also**
- Performance Tweaks: bump the supported gateway firmware gate to UniFi OS 5.1.19.

## Why

There is no stored online/state field in the time series, so historic state was backfilled from the current snapshot and client band/signal/AP were frozen. Live online only refreshed on the topology poll, offline devices kept streaming their last rate (the rate map is merged, not replaced), the live diff never compared a client's parent AP (so seamless roams were invisible), and several render paths didn't re-apply the filter after a redraw.

## How

- Historic infra liveness is derived from device_health proximity at the scrub instant, with a rate/snapshot fallback so unmonitored gear isn't stuck dark.
- Live emits an explicit offline badge for infra with no fresh stats; both maps re-skin from the latest badge each tick and idle the links of offline endpoints.
- Client band/signal/PHY and the historic AP come from the existing wifi_client series, pushed as a per-client stats map the renderers read first.
- Roam re-points the client (2D re-parents + relayouts; 3D repositions and rebuilds its pipe/streams, carrying visibility) with a fade; the live snapshot diff now detects a changed parent.

Read-side only: no InfluxDB write path, schema, or migration changes.