### PR TITLE
Fix recurring DbContext concurrency errors (sponsorship + threat dashboard)

### DIFF
--- a/src/NetworkOptimizer.Web/Services/SponsorshipService.cs
+++ b/src/NetworkOptimizer.Web/Services/SponsorshipService.cs
@@ -173,10 +173,12 @@ public class SponsorshipService : ISponsorshipService
 
         // Count all usage sources. These run sequentially rather than in parallel: the repositories
         // share a single scoped DbContext (and the factory context below is a single instance too),
-        // and a DbContext does not support concurrent operations. Fanning these out with Task.WhenAll
-        // throws "A second operation was started on this context instance" (or ObjectDisposedException
-        // when a disposal path wins the race). On SQLite the reads serialize at the DB level anyway,
-        // so parallelism buys nothing here.
+        // and a DbContext does not support concurrent operations regardless of the SQLite journal
+        // mode. Fanning these out with Task.WhenAll throws "A second operation was started on this
+        // context instance" (or ObjectDisposedException when a disposal path wins the race). WAL would
+        // permit truly concurrent reads, but only across separate connections - i.e. a distinct
+        // DbContext per query - which isn't worth it for a handful of cheap COUNT queries on a ~60s nag
+        // check.
         var manualAuditCount = await auditRepository.GetManualAuditCountAsync();
         var scheduledAuditCount = await auditRepository.GetScheduledAuditCountAsync();
         var speedTestCount = await speedTestRepository.GetIperf3ResultCountAsync();

--- a/src/NetworkOptimizer.Web/Services/SponsorshipService.cs
+++ b/src/NetworkOptimizer.Web/Services/SponsorshipService.cs
@@ -171,55 +171,56 @@ public class SponsorshipService : ISponsorshipService
         var speedTestRepository = scope.ServiceProvider.GetRequiredService<ISpeedTestRepository>();
         var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<NetworkOptimizerDbContext>>();
 
-        // Count all usage sources in parallel
-        var manualAuditCountTask = auditRepository.GetManualAuditCountAsync();
-        var scheduledAuditCountTask = auditRepository.GetScheduledAuditCountAsync();
-        var speedTestCountTask = speedTestRepository.GetIperf3ResultCountAsync();
-        var sqmWan1Task = speedTestRepository.GetSqmWanConfigAsync(1);
-        var sqmWan2Task = speedTestRepository.GetSqmWanConfigAsync(2);
+        // Count all usage sources. These run sequentially rather than in parallel: the repositories
+        // share a single scoped DbContext (and the factory context below is a single instance too),
+        // and a DbContext does not support concurrent operations. Fanning these out with Task.WhenAll
+        // throws "A second operation was started on this context instance" (or ObjectDisposedException
+        // when a disposal path wins the race). On SQLite the reads serialize at the DB level anyway,
+        // so parallelism buys nothing here.
+        var manualAuditCount = await auditRepository.GetManualAuditCountAsync();
+        var scheduledAuditCount = await auditRepository.GetScheduledAuditCountAsync();
+        var speedTestCount = await speedTestRepository.GetIperf3ResultCountAsync();
+        var sqmWan1 = await speedTestRepository.GetSqmWanConfigAsync(1);
+        var sqmWan2 = await speedTestRepository.GetSqmWanConfigAsync(2);
 
-        // Floor plan feature counts, perf tweaks, and monitoring via DbContext
-        Task<int> signalLogCountTask;
-        Task<int> placedApCountTask;
-        Task<int> plannedApCountTask;
-        Task<int> floorCountTask;
-        Task<int> perfTweakCountTask;
-        Task<int> monitoringTargetCountTask;
+        // Floor plan feature counts, perf tweaks, and monitoring via a short-lived DbContext
+        int signalLogCount;
+        int placedApCount;
+        int plannedApCount;
+        int floorCount;
+        int perfTweakCount;
+        int monitoringTargetCount;
         using (var db = await dbFactory.CreateDbContextAsync())
         {
-            signalLogCountTask = db.ClientSignalLogs.CountAsync();
-            placedApCountTask = db.ApLocations.CountAsync();
-            plannedApCountTask = db.PlannedAps.CountAsync();
-            floorCountTask = db.FloorPlans.CountAsync();
-            perfTweakCountTask = db.PerfTweakSettings.CountAsync();
-            monitoringTargetCountTask = db.MonitoringTargets.Where(t => t.Enabled).CountAsync();
-
-            await Task.WhenAll(manualAuditCountTask, scheduledAuditCountTask, speedTestCountTask, sqmWan1Task, sqmWan2Task,
-                signalLogCountTask, placedApCountTask, plannedApCountTask, floorCountTask, perfTweakCountTask,
-                monitoringTargetCountTask);
+            signalLogCount = await db.ClientSignalLogs.CountAsync();
+            placedApCount = await db.ApLocations.CountAsync();
+            plannedApCount = await db.PlannedAps.CountAsync();
+            floorCount = await db.FloorPlans.CountAsync();
+            perfTweakCount = await db.PerfTweakSettings.CountAsync();
+            monitoringTargetCount = await db.MonitoringTargets.Where(t => t.Enabled).CountAsync();
         }
 
         // Manual audits count as 1, scheduled audits count as 0.2 (~2 per workweek), speed tests count as 0.5
-        var count = manualAuditCountTask.Result + (scheduledAuditCountTask.Result / 5) + (speedTestCountTask.Result / 2);
+        var count = manualAuditCount + (scheduledAuditCount / 5) + (speedTestCount / 2);
 
         // 50 signal points = 1 audit equivalent
-        count += signalLogCountTask.Result / 50;
+        count += signalLogCount / 50;
 
         // 2 placed APs (real + planned) = 1 audit equivalent
-        count += (placedApCountTask.Result + plannedApCountTask.Result) / 2;
+        count += (placedApCount + plannedApCount) / 2;
 
         // 2 building-floors = 1 audit equivalent
-        count += floorCountTask.Result / 2;
+        count += floorCount / 2;
 
         // Add SQM bonus if enabled on either WAN
-        var sqmEnabled = sqmWan1Task.Result?.Enabled == true || sqmWan2Task.Result?.Enabled == true;
+        var sqmEnabled = sqmWan1?.Enabled == true || sqmWan2?.Enabled == true;
         if (sqmEnabled)
         {
             count += SqmEnabledBonus;
         }
 
         // 2 points per deployed performance tweak
-        count += perfTweakCountTask.Result * 2;
+        count += perfTweakCount * 2;
 
         // Monitoring: flat bonus if InfluxDB is connected, plus 1 per 5 enabled targets
         var influxClient = scope.ServiceProvider.GetRequiredService<MonitoringInfluxClient>();
@@ -227,7 +228,7 @@ public class SponsorshipService : ISponsorshipService
         {
             count += MonitoringEnabledBonus;
         }
-        count += monitoringTargetCountTask.Result / MonitoringTargetsDivisor;
+        count += monitoringTargetCount / MonitoringTargetsDivisor;
 
         return count;
     }

--- a/src/NetworkOptimizer.Web/Services/SponsorshipService.cs
+++ b/src/NetworkOptimizer.Web/Services/SponsorshipService.cs
@@ -19,6 +19,15 @@ public class SponsorshipService : ISponsorshipService
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<SponsorshipService> _logger;
 
+    // Earned level is derived from a ~11-query usage-count fan-out that's expensive relative to how
+    // often the banner asks for it (re-runs on every page load / nav). Usage barely changes minute to
+    // minute, so cache the computed level briefly. Guarded by a lock rather than Interlocked because
+    // the timestamp is a DateTime (Interlocked doesn't support it).
+    private static readonly TimeSpan EarnedLevelCacheTtl = TimeSpan.FromMinutes(5);
+    private readonly object _earnedLevelCacheLock = new();
+    private int _cachedEarnedLevel;
+    private DateTime _earnedLevelCachedAtUtc = DateTime.MinValue;
+
     // Tiered quips with their corresponding action text
     // Order: friendly → self-deprecating → edgy → absurd
     private static readonly (string Quip, string ActionText)[] Tiers =
@@ -85,20 +94,22 @@ public class SponsorshipService : ISponsorshipService
             var lastShownLevel = int.TryParse(lastShownLevelStr, out var level) ? level : 0;
             var lastNagTime = DateTime.TryParse(lastNagTimeStr, out var time) ? time : DateTime.MinValue;
 
+            var hoursSinceLastNag = (DateTime.UtcNow - lastNagTime).TotalHours;
+
+            // Within 48h of last dismiss - stay hidden (unless alwaysShow for Settings preview).
+            // Checked before computing the earned level so the common "nagged recently" path skips
+            // the expensive usage-count query entirely - the banner re-runs on every page load.
+            if (hoursSinceLastNag < 48 && lastShownLevel > 0 && !alwaysShow)
+            {
+                return null;
+            }
+
             // Get earned level based on usage
             var earnedLevel = await GetEarnedLevelInternalAsync(scope);
 
             if (earnedLevel == 0)
             {
                 // No usage yet
-                return null;
-            }
-
-            var hoursSinceLastNag = (DateTime.UtcNow - lastNagTime).TotalHours;
-
-            // Within 24h of last dismiss - stay hidden (unless alwaysShow for Settings preview)
-            if (hoursSinceLastNag < 48 && lastShownLevel > 0 && !alwaysShow)
-            {
                 return null;
             }
 
@@ -237,8 +248,28 @@ public class SponsorshipService : ISponsorshipService
 
     private async Task<int> GetEarnedLevelInternalAsync(IServiceScope scope)
     {
-        var usageCount = await GetUsageCountInternalAsync(scope);
+        lock (_earnedLevelCacheLock)
+        {
+            if (DateTime.UtcNow - _earnedLevelCachedAtUtc < EarnedLevelCacheTtl)
+            {
+                return _cachedEarnedLevel;
+            }
+        }
 
+        var usageCount = await GetUsageCountInternalAsync(scope);
+        var earnedLevel = UsageCountToLevel(usageCount);
+
+        lock (_earnedLevelCacheLock)
+        {
+            _cachedEarnedLevel = earnedLevel;
+            _earnedLevelCachedAtUtc = DateTime.UtcNow;
+        }
+
+        return earnedLevel;
+    }
+
+    private static int UsageCountToLevel(int usageCount)
+    {
         if (usageCount == 0)
         {
             return 0;

--- a/src/NetworkOptimizer.Web/Services/ThreatDashboardService.cs
+++ b/src/NetworkOptimizer.Web/Services/ThreatDashboardService.cs
@@ -15,7 +15,6 @@ namespace NetworkOptimizer.Web.Services;
 /// </summary>
 public class ThreatDashboardService
 {
-    private readonly IThreatRepository _repository;
     private readonly ExposureValidator _exposureValidator;
     private readonly CrowdSecEnrichmentService _crowdSecService;
     private readonly GeoEnrichmentService _geoService;
@@ -39,7 +38,6 @@ public class ThreatDashboardService
     public int[]? SeverityFilter { get; set; }
 
     public ThreatDashboardService(
-        IThreatRepository repository,
         ExposureValidator exposureValidator,
         CrowdSecEnrichmentService crowdSecService,
         GeoEnrichmentService geoService,
@@ -49,7 +47,6 @@ public class ThreatDashboardService
         IServiceProvider serviceProvider,
         ILogger<ThreatDashboardService> logger)
     {
-        _repository = repository;
         _exposureValidator = exposureValidator;
         _crowdSecService = crowdSecService;
         _geoService = geoService;
@@ -60,16 +57,31 @@ public class ThreatDashboardService
         _logger = logger;
     }
 
+    /// <summary>
+    /// Create a fresh DI scope and resolve a private <see cref="IThreatRepository"/> from it.
+    /// Each public operation gets its own repository instance - and therefore its own DbContext
+    /// and its own noise/severity filter state - so concurrent calls on the same circuit (e.g. a
+    /// dashboard load overlapping a fire-and-forget drilldown) never share a DbContext or clobber
+    /// each other's filters. The caller must dispose the returned scope (use a `using` statement).
+    /// </summary>
+    private IServiceScope NewRepositoryScope(out IThreatRepository repository)
+    {
+        var scope = _serviceProvider.CreateScope();
+        repository = scope.ServiceProvider.GetRequiredService<IThreatRepository>();
+        return scope;
+    }
+
     public async Task<ThreatDashboardData> GetDashboardDataAsync(DateTime from, DateTime to,
         CancellationToken cancellationToken = default)
     {
         try
         {
-            await ApplyNoiseFiltersToRepository(cancellationToken);
-            _repository.SetSeverityFilter(SeverityFilter);
-            var summary = await _repository.GetThreatSummaryAsync(from, to, cancellationToken);
-            var killChain = await _repository.GetKillChainDistributionAsync(from, to, cancellationToken);
-            var topSources = await _repository.GetTopSourcesAsync(from, to, 10, cancellationToken);
+            using var scope = NewRepositoryScope(out var repo);
+            await ApplyNoiseFiltersToRepository(repo, cancellationToken);
+            repo.SetSeverityFilter(SeverityFilter);
+            var summary = await repo.GetThreatSummaryAsync(from, to, cancellationToken);
+            var killChain = await repo.GetKillChainDistributionAsync(from, to, cancellationToken);
+            var topSources = await repo.GetTopSourcesAsync(from, to, 10, cancellationToken);
 
             // Re-enrich geo data directly on source IPs.
             // Event-level CountryCode/AsnOrg may reflect the destination for flow events with private sources.
@@ -82,12 +94,12 @@ public class ThreatDashboardService
                 source.AsnOrg = geo.AsnOrg;
             }
 
-            var topPorts = await _repository.GetTopTargetedPortsAsync(from, to, 10, cancellationToken);
-            var patterns = await _repository.GetPatternsAsync(from, to, limit: 20, cancellationToken: cancellationToken);
-            _repository.SetSeverityFilter(null);
+            var topPorts = await repo.GetTopTargetedPortsAsync(from, to, 10, cancellationToken);
+            var patterns = await repo.GetPatternsAsync(from, to, limit: 20, cancellationToken: cancellationToken);
+            repo.SetSeverityFilter(null);
 
             // Enrich from DB cache (instant, no API calls) so previously looked-up IPs show badges
-            await EnrichFromCacheAsync(topSources, cancellationToken);
+            await EnrichFromCacheAsync(repo, topSources, cancellationToken);
 
             // Determine which IPs need hydration and kick off background API calls.
             // Returns the count so the caller can schedule a follow-up refresh.
@@ -185,7 +197,7 @@ public class ThreatDashboardService
     /// This ensures previously looked-up IPs (both positive and negative hits) show their badge
     /// even for low-quota users who use manual lookups.
     /// </summary>
-    private async Task EnrichFromCacheAsync(List<SourceIpSummary> sources,
+    private async Task EnrichFromCacheAsync(IThreatRepository repository, List<SourceIpSummary> sources,
         CancellationToken cancellationToken)
     {
         foreach (var source in sources)
@@ -193,7 +205,7 @@ public class ThreatDashboardService
             if (source.CrowdSecReputation != null) continue;
             if (NetworkUtilities.IsPrivateIpAddress(source.SourceIp)) continue;
 
-            var cached = await GetCachedCtiAsync(source.SourceIp, cancellationToken);
+            var cached = await GetCachedCtiCoreAsync(repository, source.SourceIp, cancellationToken);
             if (cached == null) continue;
 
             source.CrowdSecReputation = cached.CrowdSecReputation;
@@ -210,9 +222,16 @@ public class ThreatDashboardService
     public async Task<SourceIpSummary?> GetCachedCtiAsync(string ip,
         CancellationToken cancellationToken = default)
     {
+        using var scope = NewRepositoryScope(out var repo);
+        return await GetCachedCtiCoreAsync(repo, ip, cancellationToken);
+    }
+
+    private async Task<SourceIpSummary?> GetCachedCtiCoreAsync(IThreatRepository repository, string ip,
+        CancellationToken cancellationToken = default)
+    {
         try
         {
-            var cached = await _repository.GetCrowdSecCacheAsync(ip, cancellationToken);
+            var cached = await repository.GetCrowdSecCacheAsync(ip, cancellationToken);
             if (cached == null) return null;
 
             CrowdSecIpInfo? info = null;
@@ -254,7 +273,8 @@ public class ThreatDashboardService
             var apiKey = await GetDecryptedApiKeyAsync(cancellationToken);
             if (apiKey == null) return (null, false);
 
-            var rateLimited = await EnrichSourcesAsync([source], apiKey, cancellationToken);
+            using var scope = NewRepositoryScope(out var repo);
+            var rateLimited = await EnrichSourcesAsync(repo, [source], apiKey, cancellationToken);
             return (source, rateLimited);
         }
         catch (Exception ex)
@@ -271,7 +291,7 @@ public class ThreatDashboardService
         return _credentialService.IsEncrypted(stored) ? _credentialService.Decrypt(stored) : stored;
     }
 
-    private async Task<bool> EnrichSourcesAsync(List<SourceIpSummary> sources, string apiKey,
+    private async Task<bool> EnrichSourcesAsync(IThreatRepository repository, List<SourceIpSummary> sources, string apiKey,
         CancellationToken cancellationToken)
     {
         foreach (var source in sources)
@@ -287,7 +307,7 @@ public class ThreatDashboardService
                 for (var attempt = 0; attempt < 3; attempt++)
                 {
                     (info, outcome) = await _crowdSecService.GetReputationAsync(
-                        source.SourceIp, apiKey, _repository, cancellationToken: cancellationToken);
+                        source.SourceIp, apiKey, repository, cancellationToken: cancellationToken);
 
                     if (outcome == CrowdSecLookupOutcome.QuotaExhausted)
                         return true; // daily quota exhausted - stop enriching and show banner
@@ -319,10 +339,11 @@ public class ThreatDashboardService
     {
         try
         {
-            await ApplyNoiseFiltersToRepository(cancellationToken);
+            using var scope = NewRepositoryScope(out var repo);
+            await ApplyNoiseFiltersToRepository(repo, cancellationToken);
             // Timeline returns per-severity columns; chart toggles visibility client-side.
             // Fetch without severity filter so all hourly buckets are present (preserves X-axis range).
-            _repository.SetSeverityFilter(null);
+            repo.SetSeverityFilter(null);
 
             // Adaptive bucket granularity based on time range
             var span = to - from;
@@ -333,7 +354,7 @@ public class ThreatDashboardService
                 _ => 60       // 24h+: hourly buckets
             };
 
-            var buckets = await _repository.GetTimelineAsync(from, to, bucketMinutes, cancellationToken);
+            var buckets = await repo.GetTimelineAsync(from, to, bucketMinutes, cancellationToken);
 
             // Fill gaps with zero-count buckets so the chart shows continuous time progression
             // instead of stalling at the last data point when there are no new threats.
@@ -352,8 +373,9 @@ public class ThreatDashboardService
     {
         try
         {
-            await ApplyNoiseFiltersToRepository(cancellationToken);
-            return await _repository.GetCountryDistributionAsync(from, to, cancellationToken: cancellationToken);
+            using var scope = NewRepositoryScope(out var repo);
+            await ApplyNoiseFiltersToRepository(repo, cancellationToken);
+            return await repo.GetCountryDistributionAsync(from, to, cancellationToken: cancellationToken);
         }
         catch (Exception ex)
         {
@@ -368,7 +390,8 @@ public class ThreatDashboardService
     {
         try
         {
-            await ApplyNoiseFiltersToRepository(cancellationToken);
+            using var scope = NewRepositoryScope(out var repo);
+            await ApplyNoiseFiltersToRepository(repo, cancellationToken);
 
             // Auto-fetch port forward rules from UniFi API
             List<UniFiPortForwardRule>? portForwardRules = null;
@@ -385,7 +408,7 @@ public class ThreatDashboardService
                 }
             }
 
-            return await _exposureValidator.ValidateAsync(portForwardRules, _repository, from, to, cancellationToken);
+            return await _exposureValidator.ValidateAsync(portForwardRules, repo, from, to, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -399,8 +422,9 @@ public class ThreatDashboardService
     {
         try
         {
-            await ApplyNoiseFiltersToRepository(cancellationToken);
-            return await _repository.GetEventsAsync(DateTime.UtcNow.AddDays(-7), DateTime.UtcNow,
+            using var scope = NewRepositoryScope(out var repo);
+            await ApplyNoiseFiltersToRepository(repo, cancellationToken);
+            return await repo.GetEventsAsync(DateTime.UtcNow.AddDays(-7), DateTime.UtcNow,
                 limit: limit, cancellationToken: cancellationToken);
         }
         catch (Exception ex)
@@ -413,7 +437,8 @@ public class ThreatDashboardService
     public async Task<CrowdSecIpInfo?> GetCrowdSecReputationAsync(string ip, string apiKey,
         int cacheTtlHours = 720, CancellationToken cancellationToken = default)
     {
-        var (info, _) = await _crowdSecService.GetReputationAsync(ip, apiKey, _repository, cacheTtlHours, cancellationToken);
+        using var scope = NewRepositoryScope(out var repo);
+        var (info, _) = await _crowdSecService.GetReputationAsync(ip, apiKey, repo, cacheTtlHours, cancellationToken);
         return info;
     }
 
@@ -425,10 +450,11 @@ public class ThreatDashboardService
     {
         try
         {
-            await ApplyNoiseFiltersToRepository(cancellationToken);
+            using var scope = NewRepositoryScope(out var repo);
+            await ApplyNoiseFiltersToRepository(repo, cancellationToken);
             var from = DateTime.UtcNow.AddHours(-hours);
             var to = DateTime.UtcNow;
-            var timeline = await _repository.GetTimelineAsync(from, to, cancellationToken: cancellationToken);
+            var timeline = await repo.GetTimelineAsync(from, to, cancellationToken: cancellationToken);
             var total = timeline.Sum(b => b.Total);
             var points = timeline.Select(b => new ThreatTrendPoint
             {
@@ -449,9 +475,10 @@ public class ThreatDashboardService
     {
         try
         {
+            using var scope = NewRepositoryScope(out var repo);
             // Search is unfiltered - show all data regardless of noise/severity filters
-            _repository.SetNoiseFilters([]);
-            _repository.SetSeverityFilter(null);
+            repo.SetNoiseFilters([]);
+            repo.SetSeverityFilter(null);
 
             // For CIDR searches, determine if we can use SQL prefix matching or need post-filtering
             string? ipPrefix = null;
@@ -478,7 +505,7 @@ public class ThreatDashboardService
                 }
             }
 
-            var results = await _repository.SearchIpsAsync(from, to,
+            var results = await repo.SearchIpsAsync(from, to,
                 ipExact: query.IpExact,
                 ipPrefix: ipPrefix ?? query.IpPrefix,
                 countryCode: query.CountryCode,
@@ -497,7 +524,7 @@ public class ThreatDashboardService
             var isGeoSearch = query.CountryCode != null || query.AsnNumber != null || query.AsnOrgLike != null;
             if (isGeoSearch)
             {
-                var topDests = await _repository.GetTopDestinationIpsAsync(from, to, 500, cancellationToken);
+                var topDests = await repo.GetTopDestinationIpsAsync(from, to, 500, cancellationToken);
                 var sourceIps = results.Select(r => r.Ip).ToHashSet();
 
                 foreach (var dest in topDests)
@@ -549,8 +576,9 @@ public class ThreatDashboardService
     {
         try
         {
-            await ApplyNoiseFiltersToRepository(cancellationToken);
-            return await _repository.GetAttackSequencesAsync(from, to, 50, cancellationToken);
+            using var scope = NewRepositoryScope(out var repo);
+            await ApplyNoiseFiltersToRepository(repo, cancellationToken);
+            return await repo.GetAttackSequencesAsync(from, to, 50, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -564,8 +592,9 @@ public class ThreatDashboardService
     {
         try
         {
-            await ApplyNoiseFiltersToRepository(cancellationToken);
-            var events = await _repository.GetEventsByIpAsync(ip, from, to, cancellationToken: cancellationToken);
+            using var scope = NewRepositoryScope(out var repo);
+            await ApplyNoiseFiltersToRepository(repo, cancellationToken);
+            var events = await repo.GetEventsByIpAsync(ip, from, to, cancellationToken: cancellationToken);
 
             var asSource = events.Where(e => e.SourceIp == ip).ToList();
             var asDest = events.Where(e => e.DestIp == ip).ToList();
@@ -642,8 +671,9 @@ public class ThreatDashboardService
     {
         try
         {
-            await ApplyNoiseFiltersToRepository(cancellationToken);
-            var events = await _repository.GetEventsByPortAsync(port, from, to, cancellationToken: cancellationToken);
+            using var scope = NewRepositoryScope(out var repo);
+            await ApplyNoiseFiltersToRepository(repo, cancellationToken);
+            var events = await repo.GetEventsByPortAsync(port, from, to, cancellationToken: cancellationToken);
 
             var topSources = BuildTopSources(events);
 
@@ -700,8 +730,9 @@ public class ThreatDashboardService
     {
         try
         {
-            await ApplyNoiseFiltersToRepository(cancellationToken);
-            var events = await _repository.GetEventsByProtocolAsync(protocol, from, to, cancellationToken: cancellationToken);
+            using var scope = NewRepositoryScope(out var repo);
+            await ApplyNoiseFiltersToRepository(repo, cancellationToken);
+            var events = await repo.GetEventsByProtocolAsync(protocol, from, to, cancellationToken: cancellationToken);
 
             var topSources = BuildTopSources(events);
 
@@ -929,51 +960,55 @@ public class ThreatDashboardService
         return filled;
     }
 
-    private async Task ApplyNoiseFiltersToRepository(CancellationToken cancellationToken)
+    private async Task ApplyNoiseFiltersToRepository(IThreatRepository repository, CancellationToken cancellationToken)
     {
         if (FiltersDisabled)
         {
-            _repository.SetNoiseFilters([]);
+            repository.SetNoiseFilters([]);
         }
         else
         {
-            var filters = await GetActiveFiltersAsync(cancellationToken);
-            _repository.SetNoiseFilters(filters);
+            var filters = await GetActiveFiltersAsync(repository, cancellationToken);
+            repository.SetNoiseFilters(filters);
         }
 
         // Severity filter is only applied by overview methods that explicitly opt in.
         // Clear it here so non-overview tabs (geographic, exposure, sequences, drilldowns) see all severities.
-        _repository.SetSeverityFilter(null);
+        repository.SetSeverityFilter(null);
     }
 
     // --- Noise Filter Management ---
 
     public async Task<List<ThreatNoiseFilter>> GetNoiseFiltersAsync(CancellationToken cancellationToken = default)
     {
-        return await _repository.GetNoiseFiltersAsync(cancellationToken);
+        using var scope = NewRepositoryScope(out var repo);
+        return await repo.GetNoiseFiltersAsync(cancellationToken);
     }
 
     public async Task SaveNoiseFilterAsync(ThreatNoiseFilter filter, CancellationToken cancellationToken = default)
     {
-        await _repository.SaveNoiseFilterAsync(filter, cancellationToken);
+        using var scope = NewRepositoryScope(out var repo);
+        await repo.SaveNoiseFilterAsync(filter, cancellationToken);
         _activeFilters = null; // Invalidate cache
     }
 
     public async Task DeleteNoiseFilterAsync(int filterId, CancellationToken cancellationToken = default)
     {
-        await _repository.DeleteNoiseFilterAsync(filterId, cancellationToken);
+        using var scope = NewRepositoryScope(out var repo);
+        await repo.DeleteNoiseFilterAsync(filterId, cancellationToken);
         _activeFilters = null;
     }
 
     public async Task ToggleNoiseFilterAsync(int filterId, bool enabled, CancellationToken cancellationToken = default)
     {
-        await _repository.ToggleNoiseFilterAsync(filterId, enabled, cancellationToken);
+        using var scope = NewRepositoryScope(out var repo);
+        await repo.ToggleNoiseFilterAsync(filterId, enabled, cancellationToken);
         _activeFilters = null;
     }
 
-    private async Task<List<ThreatNoiseFilter>> GetActiveFiltersAsync(CancellationToken cancellationToken = default)
+    private async Task<List<ThreatNoiseFilter>> GetActiveFiltersAsync(IThreatRepository repository, CancellationToken cancellationToken = default)
     {
-        _activeFilters ??= (await _repository.GetNoiseFiltersAsync(cancellationToken))
+        _activeFilters ??= (await repository.GetNoiseFiltersAsync(cancellationToken))
             .Where(f => f.Enabled).ToList();
         return _activeFilters;
     }


### PR DESCRIPTION
Fixes recurring `ObjectDisposedException` / "A second operation was started on this context instance" errors that fill the logs over time, in two independent spots that shared a single EF Core `DbContext` across overlapping work.

## Sponsorship usage count

`SponsorshipService.GetUsageCountInternalAsync` fanned out ~11 count queries with `Task.WhenAll` over a single shared scoped `DbContext` (audit + speed-test repos) and a single factory context. A `DbContext` doesn't support concurrent operations, so this intermittently threw mid-flight. The counts now run sequentially - on SQLite these reads serialize at the connection level anyway, so there's no real loss for a handful of cheap COUNTs.

While here, the banner was recomputing that whole fan-out on every page load even when it was going to stay hidden:
- The 48h "nagged recently" gate is now checked **before** the expensive usage-count query, so the common path skips it entirely.
- The derived earned level is cached for 5 minutes (usage barely changes minute to minute).

Fixes #843.

## Threat dashboard

`ThreatDashboardService` (scoped) shared one repository - and therefore one `DbContext` plus mutable noise/severity filter state - across concurrent calls on a circuit (a dashboard load overlapping a fire-and-forget drilldown). That raced both the context and the filter state.

Each public operation now resolves its own repository from a fresh DI scope, so every call gets an isolated `DbContext` and its own filter state. The repository and its interface are unchanged.

## Scope

Background threat collection and alerting are separate hosted services and are not affected. Tests: Threats 173/173, Alerts 81/81, Web 270/270.