### PR TITLE
Exclude UniFi power-device internal ports from port VLAN audit

### DIFF
--- a/src/NetworkOptimizer.Audit/Analyzers/PortSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/PortSecurityAnalyzer.cs
@@ -365,6 +365,7 @@ public class PortSecurityAnalyzer
         var model = device.GetStringOrNull("model");
         var shortname = device.GetStringOrNull("shortname");
         var modelName = NetworkOptimizer.UniFi.UniFiProductDatabase.GetBestProductName(model, shortname);
+        var isPowerDevice = NetworkOptimizer.UniFi.UniFiProductDatabase.IsPowerDevice(model, shortname);
         var ip = device.GetStringOrNull("ip");
         var capabilities = ParseSwitchCapabilities(device);
 
@@ -392,6 +393,7 @@ public class PortSecurityAnalyzer
             NetworkConfigType = networkConfigType,
             IsGateway = isGateway,
             IsAccessPoint = isAccessPoint,
+            IsPowerDevice = isPowerDevice,
             Capabilities = capabilities
         };
 
@@ -432,6 +434,7 @@ public class PortSecurityAnalyzer
             NetworkConfigType = networkConfigType,
             IsGateway = isGateway,
             IsAccessPoint = isAccessPoint,
+            IsPowerDevice = isPowerDevice,
             Capabilities = capabilities,
             Ports = ports
         };
@@ -717,10 +720,10 @@ public class PortSecurityAnalyzer
         foreach (var switchInfo in switches)
         {
             // Skip port-level audit issues for devices whose ports aren't manageable
-            // in UniFi Port Manager (e.g., UX/UX7 in AP mode)
+            // in UniFi Port Manager (e.g., UX/UX7 in AP mode, UPS/PDU power devices)
             if (switchInfo.HasUnmanageablePorts)
             {
-                _logger.LogDebug("Skipping audit for {SwitchName} ({ModelName}) - ports not manageable in AP mode",
+                _logger.LogDebug("Skipping audit for {SwitchName} ({ModelName}) - ports not manageable",
                     switchInfo.Name, switchInfo.ModelName);
                 continue;
             }

--- a/src/NetworkOptimizer.Audit/Models/SwitchInfo.cs
+++ b/src/NetworkOptimizer.Audit/Models/SwitchInfo.cs
@@ -62,12 +62,20 @@ public class SwitchInfo
     public bool IsAccessPoint { get; init; }
 
     /// <summary>
+    /// Whether this is a UniFi power device (UPS, PDU, RPS, smart plug/strip).
+    /// Ubiquiti reports these with SWITCH device capabilities, so they expose a single
+    /// internal/management port_table row that is not a controllable downstream edge port.
+    /// </summary>
+    public bool IsPowerDevice { get; init; }
+
+    /// <summary>
     /// Whether this device's ports are unmanageable in UniFi Port Manager.
     /// UX and UX7 devices in AP mode don't expose their switch ports for configuration,
-    /// so port-level audit issues are not actionable.
+    /// and UniFi power devices (UPS/PDU/RPS) expose only a non-controllable internal port,
+    /// so port-level audit issues are not actionable for either.
     /// </summary>
     public bool HasUnmanageablePorts =>
-        IsAccessPoint && ModelName is "UX" or "UX7";
+        (IsAccessPoint && ModelName is "UX" or "UX7") || IsPowerDevice;
 
     /// <summary>
     /// Switch capabilities

--- a/src/NetworkOptimizer.UniFi/UniFiProductDatabase.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiProductDatabase.cs
@@ -738,6 +738,53 @@ public static class UniFiProductDatabase
     }
 
     /// <summary>
+    /// UniFi power devices (UPS, PDU, redundant power supplies, smart plugs/strips).
+    /// Ubiquiti reports these with SWITCH device capabilities, so the API exposes a
+    /// single internal/management port_table row. That port is not a controllable
+    /// downstream edge port - it cannot be reconfigured with an access/trunk profile -
+    /// so port-level VLAN/profile audits are not actionable for these devices.
+    ///
+    /// HOW TO MAINTAIN THIS LIST:
+    /// Derive it from Ubiquiti's device database at https://static.ui.com/fingerprint/ui/public.json
+    /// A true power device reports type "usw", deviceCapabilities containing "SWITCH" together with
+    /// power capabilities (SMART_POWER / SMART_OUTLET / BATTERY_MANAGEMENT / REDUNDANT_POWER), AND
+    /// numberOfPorts == 1 (the single internal/management port). Add the product name (the value
+    /// GetBestProductName resolves to) here.
+    ///
+    /// DO NOT exclude on power capabilities alone. Some real, fully manageable switches carry the
+    /// same power caps - e.g. USW-Mission-Critical (USL8MP) reports SWITCH + SMART_POWER +
+    /// BATTERY_MANAGEMENT but is a genuine 9-port switch whose ports MUST still be audited. The
+    /// distinguishing signal is the single-port internal view, which is why this is an explicit
+    /// product allow-list rather than a capability heuristic. (USP-Plug / USP-Strip report type
+    /// "uap" with one port and are already skipped as small APs, but are listed here for clarity.)
+    /// </summary>
+    private static readonly HashSet<string> PowerDeviceProductNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "UPS-Tower",
+        "UPS-2U",
+        "USP-PDU-Pro",
+        "USP-PDU-HD",
+        "USP-RPS",
+        "USP-RPS-Pro",
+        "USP-Plug",
+        "USP-Strip",
+    };
+
+    /// <summary>
+    /// Check if a device is a UniFi power device (UPS, PDU, RPS, smart plug/strip).
+    /// These expose a non-controllable internal port view that should be excluded
+    /// from port-level audits.
+    /// </summary>
+    /// <param name="model">The model field (internal code)</param>
+    /// <param name="shortname">The shortname field</param>
+    /// <returns>True if the device is a UniFi power device</returns>
+    public static bool IsPowerDevice(string? model, string? shortname)
+    {
+        var productName = GetBestProductName(model, shortname);
+        return !string.IsNullOrEmpty(productName) && PowerDeviceProductNames.Contains(productName);
+    }
+
+    /// <summary>
     /// Check if a model code represents a cellular/LTE modem
     /// </summary>
     /// <param name="modelCode">The model or shortname from the UniFi API</param>

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/PortSecurityAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/PortSecurityAnalyzerTests.cs
@@ -476,6 +476,72 @@ public class PortSecurityAnalyzerTests
         result.Should().NotBeNull();
     }
 
+    [Fact]
+    public void ExtractSwitches_PowerDevice_MarkedAsPowerDevice()
+    {
+        // USP-PDU-Pro reports SWITCH capabilities, so it appears with a port_table
+        var deviceData = JsonDocument.Parse(@"[
+            {
+                ""type"": ""usw"",
+                ""name"": ""USP-PDU-Pro"",
+                ""model"": ""USPPDUP"",
+                ""port_table"": [
+                    { ""port_idx"": 1, ""name"": ""Port 1"", ""up"": true, ""forward"": ""all"" }
+                ]
+            }
+        ]").RootElement;
+        var networks = new List<NetworkInfo>();
+
+        var result = _engine.ExtractSwitches(deviceData, networks);
+
+        result.Should().HaveCount(1);
+        result[0].IsPowerDevice.Should().BeTrue();
+        result[0].HasUnmanageablePorts.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AnalyzePorts_PowerDevice_SkipsAuditIssues()
+    {
+        // A power device's internal port is forward=all with no connected device,
+        // which would otherwise trigger AccessPortVlanRule (excessive tagged VLANs).
+        var networks = new List<NetworkInfo>
+        {
+            new() { Id = "net-1", Name = "Default", VlanId = 1 },
+            new() { Id = "net-2", Name = "IoT", VlanId = 20 },
+            new() { Id = "net-3", Name = "Cameras", VlanId = 30 }
+        };
+
+        var pduSwitch = new SwitchInfo
+        {
+            Name = "USP-PDU-Pro",
+            ModelName = "USP-PDU-Pro",
+            IsPowerDevice = true
+        };
+
+        var switchWithPorts = new SwitchInfo
+        {
+            Name = pduSwitch.Name,
+            ModelName = pduSwitch.ModelName,
+            IsPowerDevice = pduSwitch.IsPowerDevice,
+            Ports = new List<PortInfo>
+            {
+                new()
+                {
+                    PortIndex = 1,
+                    Name = "Port 1",
+                    IsUp = true,
+                    ForwardMode = "all",
+                    Switch = pduSwitch
+                }
+            }
+        };
+
+        switchWithPorts.HasUnmanageablePorts.Should().BeTrue();
+        var result = _engine.AnalyzePorts(new List<SwitchInfo> { switchWithPorts }, networks);
+
+        result.Should().BeEmpty("power-device internal ports are not actionable");
+    }
+
     #endregion
 
     #region AnalyzeHardening Tests

--- a/tests/NetworkOptimizer.UniFi.Tests/UniFiProductDatabaseTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/UniFiProductDatabaseTests.cs
@@ -1268,6 +1268,81 @@ public class UniFiProductDatabaseTests
 
     #endregion
 
+    #region IsPowerDevice Tests
+
+    [Theory]
+    [InlineData("USWDA23", null)]   // UPS-Tower
+    [InlineData("USWDA25", null)]   // UPS-2U
+    [InlineData("USWDA26", null)]   // UPS-2U (EU)
+    [InlineData("USPPDUP", null)]   // USP-PDU-Pro
+    [InlineData("USPPDUHD", null)]  // USP-PDU-HD
+    [InlineData("USPRPS", null)]    // USP-RPS
+    [InlineData("USPRPSP", null)]   // USP-RPS-Pro
+    [InlineData("UP1", null)]       // USP-Plug
+    [InlineData("UP6", null)]       // USP-Strip
+    public void IsPowerDevice_PowerDeviceModelCodes_ReturnsTrue(string? model, string? shortname)
+    {
+        // Act
+        var result = UniFiProductDatabase.IsPowerDevice(model, shortname);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    // Real API model codes (unifi.network.model in public.json) must resolve to the
+    // non-region-suffixed friendly name in PowerDeviceProductNames - not the region SKU
+    // (e.g. USWDA25 -> "UPS-2U", never "UPS-2U-US"). If this regresses, IsPowerDevice
+    // silently stops matching and the audit re-flags these ports.
+    [Theory]
+    [InlineData("USWDA23", "UPS-Tower")]
+    [InlineData("USWDA24", "UPS-Tower")]
+    [InlineData("USWDA25", "UPS-2U")]
+    [InlineData("USWDA26", "UPS-2U")]
+    [InlineData("USPPDUP", "USP-PDU-Pro")]
+    [InlineData("USPPDUHD", "USP-PDU-HD")]
+    [InlineData("USPRPS", "USP-RPS")]
+    [InlineData("USPRPSP", "USP-RPS-Pro")]
+    public void GetBestProductName_PowerDeviceModelCodes_ResolveToNonRegionName(string model, string expected)
+    {
+        // Act
+        var result = UniFiProductDatabase.GetBestProductName(model, shortname: null);
+
+        // Assert
+        result.Should().Be(expected);
+        UniFiProductDatabase.IsPowerDevice(model, null).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(null, "USP-PDU-Pro")]
+    [InlineData(null, "UPS-2U")]
+    [InlineData(null, "USPPLUG")]
+    [InlineData(null, "USPSTRIP")]
+    public void IsPowerDevice_PowerDeviceShortnames_ReturnsTrue(string? model, string? shortname)
+    {
+        // Act
+        var result = UniFiProductDatabase.IsPowerDevice(model, shortname);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("USW-Pro-24", null)]   // Real switch
+    [InlineData("UDMPRO", null)]       // Gateway
+    [InlineData("U7PRO", null)]        // Access point
+    [InlineData(null, null)]
+    [InlineData("", "")]
+    public void IsPowerDevice_NonPowerDevices_ReturnsFalse(string? model, string? shortname)
+    {
+        // Act
+        var result = UniFiProductDatabase.IsPowerDevice(model, shortname);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    #endregion
+
     #region GetDefaultQmiDevicePath Tests
 
     [Theory]


### PR DESCRIPTION
Closes #842

## Problem

The Security Audit flags UniFi power devices (UPS, PDU, RPS) for "Port Issue: Excessive Tagged VLANs". Ubiquiti reports these devices with `SWITCH` device capabilities, so the controller exposes a single internal/management port. That port isn't a normal downstream switch port and can't be reconfigured with an access/trunk profile, so the finding isn't actionable. The actual upstream switch port the device plugs into is already audited separately.

This also resolves an inconsistency where `UPS-2U` was skipped (UniFi sets `is_uplink` on its internal port) while `USP-PDU-Pro` was flagged (UniFi doesn't), even though both are the same class of non-actionable internal port.

## Change

- Add `UniFiProductDatabase.IsPowerDevice(model, shortname)` backed by an explicit product allow-list (UPS-Tower, UPS-2U, USP-PDU-Pro/HD, USP-RPS/-Pro, USP-Plug/Strip).
- Add a `SwitchInfo.IsPowerDevice` flag, set during device parsing, that folds into `HasUnmanageablePorts`.
- `PortSecurityAnalyzer` now skips port-level rules for power devices the same way it already does for UX/UX7 APs in AP mode, regardless of UniFi's inconsistent `is_uplink` flag.

The exclusion is an explicit product list rather than a capability heuristic on purpose: real managed switches such as USW-Mission-Critical also report `SMART_POWER`/`BATTERY_MANAGEMENT` but have real, auditable ports. The list comment documents how to maintain it from Ubiquiti's public device database.

## Tests

- `IsPowerDevice` positive (model codes + shortnames) and negative (switches, gateways, APs, null/empty) cases.
- Regression guard asserting power-device model codes resolve to the non-region friendly name (e.g. `USWDA25` → `UPS-2U`, never `UPS-2U-US`).
- End-to-end: `ExtractSwitches` marks a USP-PDU-Pro as a power device and `AnalyzePorts` returns no findings for its `forward=all` internal port.

UniFi (933) and Audit (3402) suites pass; build is warning-free.