### PR TITLE
ISP Health: internet outage detection + ASN naming and path-shift fixes

### DIFF
--- a/src/NetworkOptimizer.Core/Helpers/NetworkFormatHelpers.cs
+++ b/src/NetworkOptimizer.Core/Helpers/NetworkFormatHelpers.cs
@@ -135,8 +135,14 @@ public static class NetworkFormatHelpers
     };
 
     /// <summary>
-    /// Strip corporate/industry suffixes from an organization name
-    /// ("Hisense Broadband Technologies Co Ltd" -> "Hisense").
+    /// The storage-time ASN/org-name cleaner: strips industry suffixes (Communications, Telecom,
+    /// Broadband, Networks, Services, Parent, Holdings ...) and legal forms (LLC, Inc, AB ...) off
+    /// the tail ("Hisense Broadband Technologies Co Ltd" -> "Hisense", "Level 3 Parent, LLC" ->
+    /// "Level 3"). Applied once when a target's AsnName is persisted - auto-discovery
+    /// (UpstreamTracerService.CleanAsnName) and manual target add (LatencyTargetsCard) both call it,
+    /// so the two paths store identical names. This is the HEAVIER of the two ASN-name cleaners;
+    /// the lighter resolve/display pass that also carries brand overrides (e.g. Arelion Sweden ->
+    /// Arelion, applied without re-discovery) is AsnNameCleanup in AsnResolutionService.
     /// </summary>
     public static string CleanOrgName(string? name)
     {

--- a/src/NetworkOptimizer.Core/Helpers/NetworkFormatHelpers.cs
+++ b/src/NetworkOptimizer.Core/Helpers/NetworkFormatHelpers.cs
@@ -125,7 +125,7 @@ public static class NetworkFormatHelpers
     private static readonly string[] OrgSuffixes =
     {
         "Communications", "Telephone", "Telecom", "Telecommunications",
-        "Broadband", "Internet", "Fiber", "Cable", "Wireless",
+        "Broadband", "Bandwidth", "Internet", "Fiber", "Cable", "Wireless",
         "Enterprises", "Services", "Technologies", "Networks", "Network",
         "Electric Cooperative", "Cooperative", "Co-op",
         "Corporation", "Incorporated", "Company", "Holdings", "Group", "Parent",

--- a/src/NetworkOptimizer.Monitoring/InterfaceRateCalculator.cs
+++ b/src/NetworkOptimizer.Monitoring/InterfaceRateCalculator.cs
@@ -62,7 +62,9 @@ public static class InterfaceRateCalculator
     /// <summary>
     /// Per-interface counter state carried between polls: the last trusted
     /// baseline plus an optional "reset candidate" (a below-baseline reading
-    /// awaiting confirmation before we trust it).
+    /// awaiting confirmation before we trust it). <see cref="ProvisionalSeed"/>
+    /// marks a baseline seeded from an all-zero read that is not yet trusted: the
+    /// real baseline is established from the first nonzero read instead (see Compute).
     /// </summary>
     public readonly record struct State(
         long InOctets,
@@ -70,7 +72,8 @@ public static class InterfaceRateCalculator
         DateTime Timestamp,
         long? CandidateInOctets = null,
         long? CandidateOutOctets = null,
-        DateTime? CandidateTimestamp = null);
+        DateTime? CandidateTimestamp = null,
+        bool ProvisionalSeed = false);
 
     public readonly record struct Result(
         double? RateInBps,
@@ -105,7 +108,29 @@ public static class InterfaceRateCalculator
         var fresh = new State(inOctets, outOctets, now);
 
         if (previous is not { } prev)
+        {
+            // An all-zero 64-bit counter read is almost never a real baseline - it is a
+            // corrupt poll (or a device caught mid-boot). Trusting it as the baseline
+            // makes the next true read snap back to a near-link-speed phantom that the
+            // link-speed ceiling is far too loose to reject on a fast port carrying a
+            // slow circuit: a 10G WAN port seeded a (0,0) read after a console reboot,
+            // and the recovery read computed ~6.7 Gbps - under the 14 Gbps ceiling, so it
+            // was emitted. Seed provisionally and wait for the first trustworthy nonzero
+            // read before establishing the baseline.
+            if (useHcCounters && inOctets == 0 && outOctets == 0)
+                return new Result(null, null, fresh with { ProvisionalSeed = true }, Outcome.SeededBaseline);
             return new Result(null, null, fresh, Outcome.SeededBaseline);
+        }
+
+        // A provisional seed (from an earlier all-zero read) is not a trusted baseline,
+        // so never compute a rate against it: a nonzero read now establishes the real
+        // baseline; another all-zero read keeps waiting. Either way no rate is emitted.
+        if (prev.ProvisionalSeed)
+        {
+            if (inOctets == 0 && outOctets == 0)
+                return new Result(null, null, fresh with { ProvisionalSeed = true }, Outcome.SeededBaseline);
+            return new Result(null, null, fresh, Outcome.SeededBaseline);
+        }
 
         var elapsed = (now - prev.Timestamp).TotalSeconds;
         if (elapsed <= 0.5)

--- a/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
@@ -313,7 +313,10 @@
                     if (asn != null)
                     {
                         asnNumber = asn.Asn;
-                        asnName = asn.Name;
+                        // Apply the same industry-suffix cleanup auto-discovery uses
+                        // (UpstreamTracerService.CleanAsnName), so a manually-added transit hop
+                        // stores "Level 3", not "Level 3 Parent" / "Lumen", matching discovery.
+                        asnName = NetworkOptimizer.Core.Helpers.NetworkFormatHelpers.CleanOrgName(asn.Name);
                     }
                 }
             }

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -519,14 +519,16 @@ else
             ? $"Break upstream of {o.LastReachableHop}"
             : "Whole-WAN outage";
 
-    // Share of the outage window this hop spent dark, for the recovery-waterfall bar.
+    // Share of the outage window this hop spent dark (red), for the recovery-waterfall bar.
+    // Capped at 95% so a sliver of the blue "up" track always shows on even the longest bars -
+    // making it obvious the path came back when the outage ended.
     private static double OutageHopDarkPercent(OutageEvent o, OutageTierState t)
     {
         if (!t.WentDark) return 0;
         var span = (o.End - o.Start).TotalSeconds;
-        if (span <= 0) return 100;
+        if (span <= 0) return 95;
         var dark = t.RecoveredAt.HasValue ? (t.RecoveredAt.Value - o.Start).TotalSeconds : span;
-        return Math.Clamp(dark / span * 100, 0, 100);
+        return Math.Clamp(dark / span * 100, 0, 95);
     }
 
     private static string OutageHopStatus(OutageTierState t) =>

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -166,7 +166,14 @@ else
                                     @issue.Recommendation
                                     @if (!string.IsNullOrEmpty(issue.LinkUrl))
                                     {
-                                        <a href="@issue.LinkUrl" style="margin-left: 0.4rem;">@(issue.LinkText ?? "Open")</a>
+                                        @if (issue.LinkUrl!.StartsWith("#"))
+                                        {
+                                            <a href="javascript:void(0)" onclick="document.getElementById('@(issue.LinkUrl.TrimStart('#'))').scrollIntoView({ behavior: 'smooth', block: 'start' });" style="margin-left: 0.4rem;">@(issue.LinkText ?? "Open")</a>
+                                        }
+                                        else
+                                        {
+                                            <a href="@issue.LinkUrl" style="margin-left: 0.4rem;">@(issue.LinkText ?? "Open")</a>
+                                        }
                                     }
                                 </div>
                             }
@@ -334,7 +341,7 @@ else
 
     @if (r.Outages.Count > 0)
     {
-        <div class="card isp-health-card">
+        <div class="card isp-health-card" id="isp-outages">
             <div class="card-header"><h2 class="card-title">Internet Outages (@WindowLabel(r))</h2></div>
             <div class="card-body">
                 <div class="isp-outage-list">

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -332,6 +332,43 @@ else
         </div>
     }
 
+    @if (r.Outages.Count > 0)
+    {
+        <div class="card isp-health-card">
+            <div class="card-header"><h2 class="card-title">Internet Outages (@WindowLabel(r))</h2></div>
+            <div class="card-body">
+                <div class="isp-outage-list">
+                    @foreach (var outage in r.Outages)
+                    {
+                        <div class="isp-outage">
+                            <div class="isp-outage-head">
+                                <span class="isp-event-badge isp-event-badge-danger">Outage</span>
+                                <span class="isp-outage-duration">@FormatDuration(outage.Duration)</span>
+                                <span class="isp-outage-window">@outage.Start.ToLocalTime().ToString("MMM d, HH:mm") &ndash; @outage.End.ToLocalTime().ToString("HH:mm")</span>
+                                <span class="isp-outage-scope">@OutageScopeLabel(outage)</span>
+                            </div>
+                            @if (outage.Tiers.Any(t => t.WentDark))
+                            {
+                                <div class="isp-outage-shape">
+                                    @foreach (var tier in outage.Tiers)
+                                    {
+                                        <div class="isp-outage-hop">
+                                            <span class="isp-outage-hop-name" data-tooltip="@OutageHopTooltip(tier)">@tier.Name</span>
+                                            <div class="isp-outage-hop-track">
+                                                <div class="isp-outage-hop-dark" style="width: @(OutageHopDarkPercent(outage, tier).ToString("0.#", System.Globalization.CultureInfo.InvariantCulture))%"></div>
+                                            </div>
+                                            <span class="isp-outage-hop-status @(tier.WentDark ? "" : "isp-outage-hop-up")">@OutageHopStatus(tier)</span>
+                                        </div>
+                                    }
+                                </div>
+                            }
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+    }
+
     <div class="card isp-health-card">
         <div class="card-header"><h2 class="card-title">Path &amp; Congestion Events (@WindowLabel(r))</h2></div>
         <div class="card-body">
@@ -469,6 +506,29 @@ else
 
     private static string FormatDuration(TimeSpan d) =>
         d.TotalHours >= 1 ? $"{d.TotalHours:0.#} h" : $"{d.TotalMinutes:0} min";
+
+    private static string OutageScopeLabel(OutageEvent o) =>
+        o.Scope == OutageScope.Upstream && !string.IsNullOrEmpty(o.LastReachableHop)
+            ? $"Break upstream of {o.LastReachableHop}"
+            : "Whole-WAN outage";
+
+    // Share of the outage window this hop spent dark, for the recovery-waterfall bar.
+    private static double OutageHopDarkPercent(OutageEvent o, OutageTierState t)
+    {
+        if (!t.WentDark) return 0;
+        var span = (o.End - o.Start).TotalSeconds;
+        if (span <= 0) return 100;
+        var dark = t.RecoveredAt.HasValue ? (t.RecoveredAt.Value - o.Start).TotalSeconds : span;
+        return Math.Clamp(dark / span * 100, 0, 100);
+    }
+
+    private static string OutageHopStatus(OutageTierState t) =>
+        !t.WentDark ? "stayed up"
+        : t.RecoveredAt.HasValue ? $"back {t.RecoveredAt.Value.ToLocalTime():HH:mm}"
+        : "down";
+
+    private static string OutageHopTooltip(OutageTierState t) =>
+        t.WentDark ? $"Went dark; peak loss {t.PeakLossPct:0}%." : "Stayed reachable through the outage.";
 
     private static string WindowLabel(IspHealthReport r) =>
         $"{(r.WindowEnd - r.WindowStart).TotalHours:0} h";

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -351,7 +351,7 @@ else
                             <div class="isp-outage-head">
                                 <span class="isp-event-badge isp-event-badge-danger">Outage</span>
                                 <span class="isp-outage-duration">@FormatDuration(outage.Duration)</span>
-                                <span class="isp-outage-window">@outage.Start.ToLocalTime().ToString("MMM d, HH:mm") &ndash; @outage.End.ToLocalTime().ToString("HH:mm")</span>
+                                <span class="isp-outage-window">@outage.Start.ToLocalTime().ToString("MMM d, HH:mm:ss") &ndash; @outage.End.ToLocalTime().ToString("HH:mm:ss")</span>
                                 <span class="isp-outage-scope">@OutageScopeLabel(outage)</span>
                             </div>
                             @if (outage.Tiers.Any(t => t.WentDark))
@@ -533,7 +533,7 @@ else
 
     private static string OutageHopStatus(OutageTierState t) =>
         !t.WentDark ? "stayed up"
-        : t.RecoveredAt.HasValue ? $"back {t.RecoveredAt.Value.ToLocalTime():HH:mm}"
+        : t.RecoveredAt.HasValue ? $"back @ {t.RecoveredAt.Value.ToLocalTime():HH:mm:ss}"
         : "down";
 
     private static string OutageHopTooltip(OutageTierState t) =>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/AsnResolutionService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/AsnResolutionService.cs
@@ -173,6 +173,18 @@ internal static class AsnNameCleanup
         ["Arelion Sweden"] = "Arelion",
     };
 
+    // Brand tokens: collapse the whole name to this brand when it appears as a standalone word.
+    // Unlike NameOverrides (exact-match, for a single geographic/rebrand word on one entity), this
+    // is for a brand spread across many regional legal entities under different names - e.g.
+    // "TELECOM ITALIA SPARKLE S.p.A.", "TI Sparkle Turkey ...", "TTi Sparkle Greece SA" all
+    // canonicalize to "Sparkle". Use only for tokens distinctive enough that no unrelated ISP
+    // shares them as a whole word ("Sparkle" won't match Cable One's "Sparklight").
+    private static readonly string[] BrandTokens = { "Sparkle" };
+
+    private static readonly Regex BrandTokenPattern = new(
+        @"\b(" + string.Join('|', BrandTokens) + @")\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
     public static string? Clean(string? raw)
     {
         if (string.IsNullOrWhiteSpace(raw)) return raw;
@@ -183,6 +195,9 @@ internal static class AsnNameCleanup
             if (next.Length == 0 || next == s) break;
             s = next;
         }
+        var brand = BrandTokenPattern.Match(s);
+        if (brand.Success)
+            return BrandTokens.First(t => string.Equals(t, brand.Value, StringComparison.OrdinalIgnoreCase));
         return NameOverrides.TryGetValue(s, out var canonical) ? canonical : s;
     }
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/AsnResolutionService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/AsnResolutionService.cs
@@ -138,6 +138,19 @@ public class AsnResolutionService
 
 public record AsnLookup(int Asn, string Name);
 
+/// <summary>
+/// The resolve/display ASN-name cleaner. Runs on every IP-&gt;ASN resolve (<see cref="AsnResolutionService"/>)
+/// and again when ISP Health renders a "Networks on Your Path" card, so brand overrides apply
+/// to already-stored names without re-discovery. Strips legal-entity suffixes (LLC, Inc, AB,
+/// B.V. ...) and applies exact-match brand overrides for the cases suffix-stripping can't infer -
+/// a geographic or rebrand word, e.g. "Arelion Sweden" -&gt; "Arelion".
+///
+/// This is the LIGHTER of the two ASN-name cleaners. The heavier industry-suffix pass
+/// (Communications, Telecom, Networks, Parent ...) is <see cref="NetworkOptimizer.Core.Helpers.NetworkFormatHelpers.CleanOrgName"/>,
+/// which runs once at STORAGE time (auto-discovery via UpstreamTracerService.CleanAsnName, and
+/// manual add via LatencyTargetsCard). A stored AsnName has therefore been through both passes;
+/// this one re-runs cheaply at display purely so the brand overrides stay applied.
+/// </summary>
 internal static class AsnNameCleanup
 {
     // Strip the most common corporate-form suffixes off the tail of an ASN name
@@ -149,8 +162,11 @@ internal static class AsnNameCleanup
         @"\s*,?\s+(LLC|L\.L\.C\.?|Inc\.?|Incorporated|Corp\.?|Corporation|Co\.?|Company|Ltd\.?|Limited|B\.V\.?|BV|AB|AG|GmbH|S\.A\.?S?\.?|S\.r\.l\.?|SA|PLC|Pte\.?|N\.V\.?|NV|OY|OYJ)\.?\s*$",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-    // Specific brand overrides, applied AFTER suffix stripping. Deliberately exact-match and
-    // not a generic geographic strip - a real ISP could legitimately be named "<x> Sweden".
+    // Specific brand overrides, applied AFTER suffix stripping. This is the ONLY place a name is
+    // canonicalized on a non-suffix word (geography, legacy brand, rebrand) - the suffix strippers
+    // (here and CleanOrgName) can't infer those. Deliberately exact-match and not a generic
+    // geographic strip: a real ISP could legitimately be named "<x> Sweden". Keys are the
+    // post-suffix-strip form (e.g. "Arelion Sweden AB" -> strip "AB" -> match "Arelion Sweden").
     private static readonly Dictionary<string, string> NameOverrides = new(StringComparer.OrdinalIgnoreCase)
     {
         // Arelion (AS1299, ex-Telia Carrier) resolves as "Arelion Sweden AB"; show just "Arelion".

--- a/src/NetworkOptimizer.Web/Services/Monitoring/AsnResolutionService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/AsnResolutionService.cs
@@ -149,6 +149,14 @@ internal static class AsnNameCleanup
         @"\s*,?\s+(LLC|L\.L\.C\.?|Inc\.?|Incorporated|Corp\.?|Corporation|Co\.?|Company|Ltd\.?|Limited|B\.V\.?|BV|AB|AG|GmbH|S\.A\.?S?\.?|S\.r\.l\.?|SA|PLC|Pte\.?|N\.V\.?|NV|OY|OYJ)\.?\s*$",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
+    // Specific brand overrides, applied AFTER suffix stripping. Deliberately exact-match and
+    // not a generic geographic strip - a real ISP could legitimately be named "<x> Sweden".
+    private static readonly Dictionary<string, string> NameOverrides = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Arelion (AS1299, ex-Telia Carrier) resolves as "Arelion Sweden AB"; show just "Arelion".
+        ["Arelion Sweden"] = "Arelion",
+    };
+
     public static string? Clean(string? raw)
     {
         if (string.IsNullOrWhiteSpace(raw)) return raw;
@@ -159,6 +167,6 @@ internal static class AsnNameCleanup
             if (next.Length == 0 || next == s) break;
             s = next;
         }
-        return s;
+        return NameOverrides.TryGetValue(s, out var canonical) ? canonical : s;
     }
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -198,6 +198,10 @@ public class PathShiftEvent
 
     /// <summary>Number of targets showing a correlated step at the same boundary.</summary>
     public int CorrelatedTargetCount { get; init; } = 1;
+
+    /// <summary>True when this shift came from an internet/CDN destination (by DB TargetType),
+    /// not an on-path ISP/transit hop. Correlation prefers a non-destination as the label.</summary>
+    public bool IsDestination { get; init; }
 }
 
 /// <summary>Whether the access/first hop itself went dark, or only everything beyond it.</summary>
@@ -356,6 +360,10 @@ public class AsnSeries
     /// iff X's IP is in the witness's ancestor set. Empty for a first hop.
     /// </summary>
     public List<string> AncestorIps { get; init; } = new();
+
+    /// <summary>True for an internet/CDN destination series (DB TargetType InternetService).
+    /// Carried onto path-shift events so correlation can prefer an on-path hop as the label.</summary>
+    public bool IsDestination { get; init; }
 }
 
 /// <summary>Load classification of one aggregate window.</summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -200,6 +200,60 @@ public class PathShiftEvent
     public int CorrelatedTargetCount { get; init; } = 1;
 }
 
+/// <summary>Whether the access/first hop itself went dark, or only everything beyond it.</summary>
+public enum OutageScope
+{
+    /// <summary>Even the access/first ISP hop stopped responding - the whole WAN went dark.</summary>
+    FullWan,
+
+    /// <summary>The access hop stayed reachable while transit and the internet went dark - the break sat upstream of it.</summary>
+    Upstream
+}
+
+/// <summary>
+/// A period where the internet was unreachable: the destination/internet targets went to
+/// near-total loss while probes kept reporting. A monitoring gap (console offline) has no
+/// samples at all and is never an outage. Scored by duration alone via a capped Packet
+/// Loss penalty - independent of shape or which hops dropped; the scope, break point, and
+/// per-tier recovery shape are presentation only.
+/// </summary>
+public class OutageEvent
+{
+    public DateTime Start { get; init; }
+    public DateTime End { get; init; }
+    public TimeSpan Duration => End - Start;
+
+    /// <summary>Whether even the access hop went dark, or it held while everything beyond it dropped.</summary>
+    public OutageScope Scope { get; init; }
+
+    /// <summary>
+    /// The deepest tier/hop that stayed reachable through the outage - the break sat just
+    /// beyond it. Null when even the access hop went dark (a full WAN outage).
+    /// </summary>
+    public string? LastReachableHop { get; init; }
+
+    /// <summary>Per-tier loss and recovery, nearest first, for the outage-shape display.</summary>
+    public List<OutageTierState> Tiers { get; init; } = new();
+}
+
+/// <summary>One network tier's behavior during an outage, for the recovery-shape display.</summary>
+public class OutageTierState
+{
+    public required string Name { get; init; }
+
+    /// <summary>Distance rank: 0 = nearest (access/OLT), higher = farther out (transit, internet).</summary>
+    public int Depth { get; init; }
+
+    /// <summary>Worst mean loss this tier reached during the outage.</summary>
+    public double PeakLossPct { get; init; }
+
+    /// <summary>True when this tier reached the dark threshold at some point in the outage.</summary>
+    public bool WentDark { get; init; }
+
+    /// <summary>First time this tier fell back below the dark threshold after going dark; null if it never went dark or never recovered in-window.</summary>
+    public DateTime? RecoveredAt { get; init; }
+}
+
 /// <summary>The full ISP Health report for the trailing window.</summary>
 public class IspHealthReport
 {
@@ -217,6 +271,7 @@ public class IspHealthReport
     public List<IspHealthIssue> Issues { get; init; } = new();
     public List<CongestionEvent> CongestionEvents { get; init; } = new();
     public List<PathShiftEvent> PathShifts { get; init; } = new();
+    public List<OutageEvent> Outages { get; init; } = new();
 
     /// <summary>False when expected WAN speeds were unavailable and loaded analysis was skipped.</summary>
     public bool HasExpectedSpeeds { get; init; }
@@ -383,6 +438,9 @@ public class IspHealthInputs
 
     /// <summary>Pre-detected path shift events. Informational only.</summary>
     public List<PathShiftEvent> PathShifts { get; init; } = new();
+
+    /// <summary>Pre-detected internet-unreachable outages in the window.</summary>
+    public List<OutageEvent> Outages { get; init; } = new();
 
     /// <summary>
     /// True when Upstream Discovery has persisted hop-ancestor data for this WAN. When false

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -29,16 +29,20 @@ public class IspHealthOptions
     public double SpeedVsPlanWeight { get; set; } = 0.30;
 
     /// <summary>Weight of idle latency within the access dimension.</summary>
-    public double IdleLatencyWeight { get; set; } = 0.15;
+    public double IdleLatencyWeight { get; set; } = 0.10;
 
-    /// <summary>Weight of idle packet loss within the access dimension.</summary>
-    public double IdleLossWeight { get; set; } = 0.15;
+    /// <summary>
+    /// Weight of packet loss within the access dimension. Loss is the heaviest signal
+    /// after speed: it captures both steady physical-layer loss and (via the capped
+    /// outage penalty) internet-unreachable outages, which users care about most.
+    /// </summary>
+    public double IdleLossWeight { get; set; } = 0.25;
 
     /// <summary>Weight of loaded latency delta within the access dimension.</summary>
-    public double LoadedLatencyWeight { get; set; } = 0.20;
+    public double LoadedLatencyWeight { get; set; } = 0.175;
 
     /// <summary>Weight of loaded packet loss within the access dimension.</summary>
-    public double LoadedLossWeight { get; set; } = 0.20;
+    public double LoadedLossWeight { get; set; } = 0.175;
 
     /// <summary>How far back to fall when no WAN speed test ran inside the score window.</summary>
     public int SpeedTestFallbackDays { get; set; } = 7;
@@ -165,6 +169,43 @@ public class IspHealthOptions
     /// down (seen in real data).
     /// </summary>
     public double StepStableIqrFraction { get; set; } = 0.15;
+
+    /// <summary>Bucket size in minutes for outage detection.</summary>
+    public int OutageBucketMinutes { get; set; } = 1;
+
+    /// <summary>
+    /// Mean loss (percent) at or above which a tier counts as dark in an outage bucket.
+    /// Near-total loss, not the lower congestion thresholds: an outage is the internet
+    /// going unreachable, not slow.
+    /// </summary>
+    public double OutageDarkLossPct { get; set; } = 95.0;
+
+    /// <summary>
+    /// Fraction of the internet/destination targets that must be dark in a bucket for it
+    /// to count as an outage bucket. A strong majority, so one dead probe target or a
+    /// single unreachable CDN does not read as an internet outage.
+    /// </summary>
+    public double OutageCoverageFraction { get; set; } = 0.75;
+
+    /// <summary>
+    /// Minimum internet/destination targets that must be reporting (have a sample) in a
+    /// bucket before an outage can be declared. Below this the evidence is too thin, and
+    /// a bucket with no samples at all is a monitoring gap (console offline), never an outage.
+    /// </summary>
+    public int OutageMinReportingTargets { get; set; } = 2;
+
+    /// <summary>Minimum sustained duration in minutes for an outage event.</summary>
+    public int OutageMinDurationMinutes { get; set; } = 2;
+
+    /// <summary>
+    /// Points deducted from the Packet Loss factor per minute of internet-unreachable time,
+    /// capped by <see cref="OutagePenaltyCapPoints"/>. Outages are scored by duration alone,
+    /// independent of shape or which hops dropped; the shape is presentation only.
+    /// </summary>
+    public double OutagePenaltyPerMinute { get; set; } = 2.0;
+
+    /// <summary>Maximum total points an outage (or outages) can deduct from the Packet Loss factor.</summary>
+    public double OutagePenaltyCapPoints { get; set; } = 40.0;
 
     /// <summary>Loaded delta beyond excellent by this many band-widths triggers the SQM recommendation.</summary>
     public double SqmDeviationFactor { get; set; } = 1.0;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -198,14 +198,16 @@ public class IspHealthOptions
     public int OutageMinDurationMinutes { get; set; } = 2;
 
     /// <summary>
-    /// Points deducted from the Packet Loss factor per minute of internet-unreachable time,
-    /// capped by <see cref="OutagePenaltyCapPoints"/>. Outages are scored by duration alone,
-    /// independent of shape or which hops dropped; the shape is presentation only.
+    /// Outage severity curve: points deducted from the OVERALL score per (totalDowntimeMinutes,
+    /// penaltyPoints) anchor, interpolated. Applied at the top level rather than buried in the
+    /// Packet Loss factor (where the dimension weights would dilute a multi-hour outage to a
+    /// couple of points). Scored by total duration alone - shape-independent. A brief blip barely
+    /// registers; ~10 min is a clear ding; multi-hour drives the score toward zero.
     /// </summary>
-    public double OutagePenaltyPerMinute { get; set; } = 2.0;
-
-    /// <summary>Maximum total points an outage (or outages) can deduct from the Packet Loss factor.</summary>
-    public double OutagePenaltyCapPoints { get; set; } = 40.0;
+    public (double Minutes, double Penalty)[] OutageSeverityCurve { get; set; } =
+    {
+        (0, 0), (5, 7), (10, 14), (30, 28), (60, 45), (180, 70), (480, 90)
+    };
 
     /// <summary>Loaded delta beyond excellent by this many band-widths triggers the SQM recommendation.</summary>
     public double SqmDeviationFactor { get; set; } = 1.0;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -13,6 +13,14 @@ public class IspHealthScorer
     private readonly IspHealthOptions _options;
     private readonly ILogger? _logger;
 
+    // Outage windows for the current report. An outage's only score impact is the single
+    // capped Packet Loss penalty, so its near-total-loss samples are excluded from every
+    // other loss aggregation (per-ASN/hop grades, loaded loss, displayed loss) - otherwise
+    // they would double-count and tank the Transit/ISP dimensions. Set per Score() call.
+    private IReadOnlyList<OutageEvent> _outages = System.Array.Empty<OutageEvent>();
+
+    private bool InOutage(DateTime time) => _outages.Any(o => time >= o.Start && time < o.End);
+
     public IspHealthScorer(IspHealthOptions options, ILogger? logger = null)
     {
         _options = options;
@@ -21,6 +29,7 @@ public class IspHealthScorer
 
     public IspHealthReport Score(IspHealthInputs inputs, AccessProfile profile)
     {
+        _outages = inputs.Outages;
         if (inputs.LoadExclusionWindows.Count > 0)
         {
             foreach (var (exStart, exEnd) in inputs.LoadExclusionWindows)
@@ -33,7 +42,7 @@ public class IspHealthScorer
         var avgLoad = ComputeAverageLoad(inputs);
         var (speedVsPlan, bestSpeedTest, typicalDownMbps, typicalUpMbps) = ScoreSpeedVsPlan(inputs);
         var idleLatency = ScoreIdleLatency(idleBaseline, profile);
-        var idleLoss = ScoreIdleLoss(inputs.LossPoolSeries, profile, avgLoad, inputs.Outages);
+        var idleLoss = ScoreIdleLoss(inputs.LossPoolSeries, profile, avgLoad);
         var loadedDeltas = ResolveLoadedDeltas(inputs, loadWindows);
 
         // The path jitter floor: the quietest median jitter measured anywhere along the
@@ -64,6 +73,18 @@ public class IspHealthScorer
         var ispAsnDimension = BuildIspDimension(_options.IspAsnWeight, ispHopGrades);
 
         var overall = CombineDimensions(accessDimension, transitDimension, ispAsnDimension);
+        // An outage is scored once, here at the top level, on a duration curve - so a long
+        // outage actually drives the score down instead of being diluted to a couple of
+        // points inside one factor. Scored by total downtime alone, shape-independent.
+        var outageMinutes = inputs.Outages.Sum(o => o.Duration.TotalMinutes);
+        if (outageMinutes > 0)
+        {
+            var penalty = OutageScorePenalty(outageMinutes);
+            _logger?.LogDebug("ISP Health: outage penalty {Penalty} pts over {Min} min downtime ({Before} -> {After})",
+                penalty.ToString("0.#", CultureInfo.InvariantCulture), outageMinutes.ToString("0", CultureInfo.InvariantCulture),
+                overall, (int)Math.Max(0, Math.Round(overall - penalty)));
+            overall = (int)Math.Max(0, Math.Round(overall - penalty));
+        }
 
         var report = new IspHealthReport
         {
@@ -296,40 +317,22 @@ public class IspHealthScorer
         };
     }
 
-    private IspScoreFactor ScoreIdleLoss(List<List<LatencySample>> lossPool, AccessProfile profile, double avgLoad, List<OutageEvent> outages)
+    private IspScoreFactor ScoreIdleLoss(List<List<LatencySample>> lossPool, AccessProfile profile, double avgLoad)
     {
         // Steady loss is graded on samples OUTSIDE any outage span, so the number reflects
-        // true physical-layer loss rather than a discrete internet-down event. The outage
-        // is scored separately as a capped, duration-based penalty (shape-independent).
+        // true physical-layer loss rather than a discrete internet-down event. Outages are
+        // scored separately at the top level (see the outage severity penalty in Score).
         var losses = lossPool.SelectMany(series => series)
-            .Where(s => s.LossPercent.HasValue && !InAnyOutage(s.Time, outages))
+            .Where(s => s.LossPercent.HasValue && !InOutage(s.Time))
             .Select(s => s.LossPercent!.Value)
             .ToList();
-
-        var outageMinutes = outages.Sum(o => o.Duration.TotalMinutes);
-        var outagePenalty = outageMinutes > 0
-            ? Math.Min(_options.OutagePenaltyCapPoints, _options.OutagePenaltyPerMinute * outageMinutes)
-            : 0;
-
         if (losses.Count == 0)
         {
-            if (outageMinutes <= 0)
-            {
-                return new IspScoreFactor
-                {
-                    Name = "Packet Loss",
-                    Weight = _options.IdleLossWeight,
-                    Description = "No loss data in the window."
-                };
-            }
-            // Outage(s) but no steady-loss samples to grade: penalize from a clean baseline.
             return new IspScoreFactor
             {
                 Name = "Packet Loss",
-                Score = (int)Math.Round(Math.Max(0, 100 - outagePenalty)),
                 Weight = _options.IdleLossWeight,
-                ValueText = "outage",
-                Description = $"No steady packet loss outside {DescribeOutages(outages)}."
+                Description = "No loss data in the window."
             };
         }
 
@@ -342,19 +345,13 @@ public class IspHealthScorer
         var t = Math.Clamp(Math.Clamp(avgLoad, 0, 1) / _options.LossSaturationLoadFraction, 0, 1);
         var acceptable = profile.IdleLossAcceptablePct
             + t * t * (profile.LoadedLossDownLowPct - profile.IdleLossAcceptablePct);
-        var steadyScore = meanLoss <= acceptable
+        var score = meanLoss <= acceptable
             ? ScoreCurve.Interpolate(meanLoss, (0, 100), (profile.IdleLossIdealPct, 95), (acceptable, 70))
             : ScoreCurve.ExponentialFalloff(meanLoss, acceptable, 70);
-        // An outage drops the score by duration alone, capped, on top of the steady grade.
-        var score = Math.Max(0, steadyScore - outagePenalty);
 
-        _logger?.LogDebug("ISP Health: packet loss {Loss}% vs load-calibrated ceiling {Ceiling}% ({Load} avg load); outage penalty {Penalty} over {Mins} min",
+        _logger?.LogDebug("ISP Health: packet loss {Loss}% vs load-calibrated ceiling {Ceiling}% ({Load} avg load)",
             meanLoss.ToString("0.###", CultureInfo.InvariantCulture), acceptable.ToString("0.###", CultureInfo.InvariantCulture),
-            avgLoad.ToString("0%", CultureInfo.InvariantCulture), outagePenalty.ToString("0.#", CultureInfo.InvariantCulture),
-            outageMinutes.ToString("0", CultureInfo.InvariantCulture));
-
-        var description = $"Average loss across ISP, transit, and anycast DNS targets vs the {FormatPct(acceptable)} ceiling for {profile.DisplayName} at {avgLoad.ToString("0%", CultureInfo.InvariantCulture)} average load.";
-        if (outageMinutes > 0) description += $" Includes {DescribeOutages(outages)}.";
+            avgLoad.ToString("0%", CultureInfo.InvariantCulture));
 
         return new IspScoreFactor
         {
@@ -362,7 +359,7 @@ public class IspHealthScorer
             Score = (int)Math.Round(score),
             Weight = _options.IdleLossWeight,
             ValueText = FormatPct(meanLoss),
-            Description = description
+            Description = $"Average loss across ISP, transit, and anycast DNS targets vs the {FormatPct(acceptable)} ceiling for {profile.DisplayName} at {avgLoad.ToString("0%", CultureInfo.InvariantCulture)} average load."
         };
     }
 
@@ -539,7 +536,7 @@ public class IspHealthScorer
     {
         var lagOffset = TimeSpan.FromSeconds(_options.CounterLagOffsetSeconds);
         var losses = lossPool.SelectMany(series => series)
-            .Where(s => s.LossPercent.HasValue
+            .Where(s => s.LossPercent.HasValue && !InOutage(s.Time)
                 && loadWindows.TryGetValue(FloorToWindow(s.Time - lagOffset), out var w)
                 && directionSelector(w))
             .Select(s => s.LossPercent!.Value)
@@ -569,7 +566,7 @@ public class IspHealthScorer
         double? jitterOverrideMs = null)
     {
         var rtts = series.Samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
-        var losses = series.Samples.Where(s => s.LossPercent.HasValue).Select(s => s.LossPercent!.Value).ToList();
+        var losses = series.Samples.Where(s => s.LossPercent.HasValue && !InOutage(s.Time)).Select(s => s.LossPercent!.Value).ToList();
         var jitters = series.Samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
 
         var medianRtt = SeriesStats.Median(rtts);
@@ -940,11 +937,11 @@ public class IspHealthScorer
         return result;
     }
 
-    private static IspTargetHealth BuildIspTargetHealth(AsnSeries series, string? firstHopTargetId, List<IspAsnHealth> hopGrades, double winsorPercentile)
+    private IspTargetHealth BuildIspTargetHealth(AsnSeries series, string? firstHopTargetId, List<IspAsnHealth> hopGrades, double winsorPercentile)
     {
         var rtts = series.Samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
         var jitters = series.Samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
-        var losses = series.Samples.Where(s => s.LossPercent.HasValue).Select(s => s.LossPercent!.Value).ToList();
+        var losses = series.Samples.Where(s => s.LossPercent.HasValue && !InOutage(s.Time)).Select(s => s.LossPercent!.Value).ToList();
         var targetId = series.TargetIds.FirstOrDefault() ?? "";
         var grade = hopGrades.FirstOrDefault(g => g.TargetIds.Contains(targetId));
         // Jitter comes from the grade (the effective/absolved value the hop is scored on), so
@@ -1037,7 +1034,9 @@ public class IspHealthScorer
                 Severity = IspIssueSeverity.Warning,
                 Title = inputs.Outages.Count == 1 ? "Internet outage in the window" : "Internet outages in the window",
                 Description = $"{count} occurred while the Monitoring Agent kept probing (so this is a real outage, not a monitoring gap).{where}",
-                Recommendation = "No action needed on your side for an upstream outage; it is logged here so you can correlate it with ISP incidents. The recovery shape is shown on the timeline below."
+                Recommendation = "No action needed on your side for an upstream outage; it is logged here so you can correlate it with ISP incidents.",
+                LinkUrl = "#isp-outages",
+                LinkText = "The recovery shape is shown on the timeline below."
             });
         }
 
@@ -1161,23 +1160,13 @@ public class IspHealthScorer
     private DateTime FloorToWindow(DateTime time) =>
         CongestionDetector.FloorTime(time, TimeSpan.FromSeconds(_options.LoadWindowSeconds));
 
-    private static bool InAnyOutage(DateTime time, List<OutageEvent> outages) =>
-        outages.Any(o => time >= o.Start && time < o.End);
-
-    /// <summary>Short human phrase for the outage(s), for the Packet Loss verbiage and the finding.</summary>
-    private static string DescribeOutages(List<OutageEvent> outages)
-    {
-        if (outages.Count == 1)
-        {
-            var o = outages[0];
-            var where = o.Scope == OutageScope.Upstream && !string.IsNullOrEmpty(o.LastReachableHop)
-                ? $"upstream of {o.LastReachableHop}"
-                : "of the whole WAN";
-            return $"a {FormatOutageDuration(o.Duration)} outage {where}";
-        }
-        var total = TimeSpan.FromMinutes(outages.Sum(o => o.Duration.TotalMinutes));
-        return $"{outages.Count} outages totaling {FormatOutageDuration(total)}";
-    }
+    /// <summary>
+    /// The overall-score deduction for outages of the given total downtime, interpolated on the
+    /// configured severity curve. Applied at the top level (not inside a factor) so a long
+    /// outage isn't diluted by the dimension weights; scored by duration alone, shape-independent.
+    /// </summary>
+    private double OutageScorePenalty(double totalDowntimeMinutes) =>
+        ScoreCurve.Interpolate(totalDowntimeMinutes, _options.OutageSeverityCurve);
 
     private static string FormatOutageDuration(TimeSpan d) =>
         d.TotalMinutes < 90 ? $"{d.TotalMinutes:0} min" : $"{d.TotalHours:0.#} h";

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -33,7 +33,7 @@ public class IspHealthScorer
         var avgLoad = ComputeAverageLoad(inputs);
         var (speedVsPlan, bestSpeedTest, typicalDownMbps, typicalUpMbps) = ScoreSpeedVsPlan(inputs);
         var idleLatency = ScoreIdleLatency(idleBaseline, profile);
-        var idleLoss = ScoreIdleLoss(inputs.LossPoolSeries, profile, avgLoad);
+        var idleLoss = ScoreIdleLoss(inputs.LossPoolSeries, profile, avgLoad, inputs.Outages);
         var loadedDeltas = ResolveLoadedDeltas(inputs, loadWindows);
 
         // The path jitter floor: the quietest median jitter measured anywhere along the
@@ -80,6 +80,7 @@ public class IspHealthScorer
             IspTargets = inputs.IspTargetSeries.Select(s => BuildIspTargetHealth(s, inputs.FirstHopTargetId, ispHopGrades, _options.RttWinsorPercentile)).ToList(),
             CongestionEvents = inputs.CongestionEvents,
             PathShifts = inputs.PathShifts,
+            Outages = inputs.Outages,
             HasExpectedSpeeds = hasExpectedSpeeds,
             HasUpstreamTraceMap = inputs.HopOrderKnown,
             HasLoadedSamples = hasLoadedLatency || hasLoadedLoss,
@@ -295,19 +296,40 @@ public class IspHealthScorer
         };
     }
 
-    private IspScoreFactor ScoreIdleLoss(List<List<LatencySample>> lossPool, AccessProfile profile, double avgLoad)
+    private IspScoreFactor ScoreIdleLoss(List<List<LatencySample>> lossPool, AccessProfile profile, double avgLoad, List<OutageEvent> outages)
     {
+        // Steady loss is graded on samples OUTSIDE any outage span, so the number reflects
+        // true physical-layer loss rather than a discrete internet-down event. The outage
+        // is scored separately as a capped, duration-based penalty (shape-independent).
         var losses = lossPool.SelectMany(series => series)
-            .Where(s => s.LossPercent.HasValue)
+            .Where(s => s.LossPercent.HasValue && !InAnyOutage(s.Time, outages))
             .Select(s => s.LossPercent!.Value)
             .ToList();
+
+        var outageMinutes = outages.Sum(o => o.Duration.TotalMinutes);
+        var outagePenalty = outageMinutes > 0
+            ? Math.Min(_options.OutagePenaltyCapPoints, _options.OutagePenaltyPerMinute * outageMinutes)
+            : 0;
+
         if (losses.Count == 0)
         {
+            if (outageMinutes <= 0)
+            {
+                return new IspScoreFactor
+                {
+                    Name = "Packet Loss",
+                    Weight = _options.IdleLossWeight,
+                    Description = "No loss data in the window."
+                };
+            }
+            // Outage(s) but no steady-loss samples to grade: penalize from a clean baseline.
             return new IspScoreFactor
             {
                 Name = "Packet Loss",
+                Score = (int)Math.Round(Math.Max(0, 100 - outagePenalty)),
                 Weight = _options.IdleLossWeight,
-                Description = "No loss data in the window."
+                ValueText = "outage",
+                Description = $"No steady packet loss outside {DescribeOutages(outages)}."
             };
         }
 
@@ -320,13 +342,19 @@ public class IspHealthScorer
         var t = Math.Clamp(Math.Clamp(avgLoad, 0, 1) / _options.LossSaturationLoadFraction, 0, 1);
         var acceptable = profile.IdleLossAcceptablePct
             + t * t * (profile.LoadedLossDownLowPct - profile.IdleLossAcceptablePct);
-        var score = meanLoss <= acceptable
+        var steadyScore = meanLoss <= acceptable
             ? ScoreCurve.Interpolate(meanLoss, (0, 100), (profile.IdleLossIdealPct, 95), (acceptable, 70))
             : ScoreCurve.ExponentialFalloff(meanLoss, acceptable, 70);
+        // An outage drops the score by duration alone, capped, on top of the steady grade.
+        var score = Math.Max(0, steadyScore - outagePenalty);
 
-        _logger?.LogDebug("ISP Health: packet loss {Loss}% vs load-calibrated ceiling {Ceiling}% ({Load} avg load)",
+        _logger?.LogDebug("ISP Health: packet loss {Loss}% vs load-calibrated ceiling {Ceiling}% ({Load} avg load); outage penalty {Penalty} over {Mins} min",
             meanLoss.ToString("0.###", CultureInfo.InvariantCulture), acceptable.ToString("0.###", CultureInfo.InvariantCulture),
-            avgLoad.ToString("0%", CultureInfo.InvariantCulture));
+            avgLoad.ToString("0%", CultureInfo.InvariantCulture), outagePenalty.ToString("0.#", CultureInfo.InvariantCulture),
+            outageMinutes.ToString("0", CultureInfo.InvariantCulture));
+
+        var description = $"Average loss across ISP, transit, and anycast DNS targets vs the {FormatPct(acceptable)} ceiling for {profile.DisplayName} at {avgLoad.ToString("0%", CultureInfo.InvariantCulture)} average load.";
+        if (outageMinutes > 0) description += $" Includes {DescribeOutages(outages)}.";
 
         return new IspScoreFactor
         {
@@ -334,7 +362,7 @@ public class IspHealthScorer
             Score = (int)Math.Round(score),
             Weight = _options.IdleLossWeight,
             ValueText = FormatPct(meanLoss),
-            Description = $"Average loss across ISP, transit, and anycast DNS targets vs the {FormatPct(acceptable)} ceiling for {profile.DisplayName} at {avgLoad.ToString("0%", CultureInfo.InvariantCulture)} average load."
+            Description = description
         };
     }
 
@@ -994,6 +1022,25 @@ public class IspHealthScorer
     {
         var issues = new List<IspHealthIssue>();
 
+        if (inputs.Outages.Count > 0)
+        {
+            var totalDown = TimeSpan.FromMinutes(inputs.Outages.Sum(o => o.Duration.TotalMinutes));
+            var upstream = inputs.Outages.Where(o => o.Scope == OutageScope.Upstream && !string.IsNullOrEmpty(o.LastReachableHop)).ToList();
+            var where = inputs.Outages.All(o => o.Scope == OutageScope.Upstream) && upstream.Count > 0
+                ? $" The break sat upstream of {string.Join(", ", upstream.Select(o => o.LastReachableHop).Distinct())} - your equipment stayed reachable, so this was an ISP-side fault, not your network."
+                : " At least one event took the whole WAN dark, including the first ISP hop.";
+            var count = inputs.Outages.Count == 1
+                ? $"An internet outage of {FormatOutageDuration(inputs.Outages[0].Duration)}"
+                : $"{inputs.Outages.Count} internet outages totaling {FormatOutageDuration(totalDown)}";
+            issues.Add(new IspHealthIssue
+            {
+                Severity = IspIssueSeverity.Warning,
+                Title = inputs.Outages.Count == 1 ? "Internet outage in the window" : "Internet outages in the window",
+                Description = $"{count} occurred while the Monitoring Agent kept probing (so this is a real outage, not a monitoring gap).{where}",
+                Recommendation = "No action needed on your side for an upstream outage; it is logged here so you can correlate it with ISP incidents. The recovery shape is shown on the timeline below."
+            });
+        }
+
         if (!report.HasExpectedSpeeds)
         {
             issues.Add(new IspHealthIssue
@@ -1113,6 +1160,27 @@ public class IspHealthScorer
 
     private DateTime FloorToWindow(DateTime time) =>
         CongestionDetector.FloorTime(time, TimeSpan.FromSeconds(_options.LoadWindowSeconds));
+
+    private static bool InAnyOutage(DateTime time, List<OutageEvent> outages) =>
+        outages.Any(o => time >= o.Start && time < o.End);
+
+    /// <summary>Short human phrase for the outage(s), for the Packet Loss verbiage and the finding.</summary>
+    private static string DescribeOutages(List<OutageEvent> outages)
+    {
+        if (outages.Count == 1)
+        {
+            var o = outages[0];
+            var where = o.Scope == OutageScope.Upstream && !string.IsNullOrEmpty(o.LastReachableHop)
+                ? $"upstream of {o.LastReachableHop}"
+                : "of the whole WAN";
+            return $"a {FormatOutageDuration(o.Duration)} outage {where}";
+        }
+        var total = TimeSpan.FromMinutes(outages.Sum(o => o.Duration.TotalMinutes));
+        return $"{outages.Count} outages totaling {FormatOutageDuration(total)}";
+    }
+
+    private static string FormatOutageDuration(TimeSpan d) =>
+        d.TotalMinutes < 90 ? $"{d.TotalMinutes:0} min" : $"{d.TotalHours:0.#} h";
 
     private static string FormatMs(double ms) =>
         $"{ms.ToString("0.00", CultureInfo.InvariantCulture)} ms";

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -126,6 +126,10 @@ public class IspHealthService
         // Upstream Discovery's traces. ISP Health uses these to confirm one hop routes
         // through another before its jitter absolves the other. No live traceroute here.
         Dictionary<string, List<string>> ancestorIpsByTargetId;
+        // TargetId -> persisted hop distance (lowest TTL seen across traces). The canonical
+        // nearest-first ordering for the outage shape; absent for targets never traced
+        // (the trace map landed post-launch), where the caller falls back to RTT.
+        Dictionary<string, int> hopNumberByTargetId;
         bool hopOrderKnown;
         await using (var db = await _dbFactory.CreateDbContextAsync(ct))
         {
@@ -171,6 +175,11 @@ public class IspHealthService
             // Ancestor data exists when any row carries the (non-null) column - distinguishes
             // "no discovery yet / pre-ancestor data" from "on-path but no upstream ancestors".
             hopOrderKnown = discoveries.Any(d => d.AncestorHopIps != null);
+            // Canonical hop distance per target (lowest TTL across traces) for outage ordering.
+            hopNumberByTargetId = discoveries
+                .Where(d => targetIdById.ContainsKey(d.MonitoringTargetId!.Value))
+                .GroupBy(d => targetIdById[d.MonitoringTargetId!.Value])
+                .ToDictionary(g => g.Key, g => g.Min(d => d.HopNumber));
         }
 
         var ispTargets = targets.Where(t => t.TargetType == MonitoringTargetType.AccessIsp).ToList();
@@ -301,6 +310,30 @@ public class IspHealthService
         var stepInput = allClusters.Concat(internetTargetSeries).ToList();
         var pathShifts = StepChangeDetector.Detect(stepInput, _options);
 
+        // Outage detection: the internet targets going dark defines an outage; every hop is
+        // carried (ordered nearest-first by median RTT, named from the DB) to shape it and
+        // attribute the break. A monitoring gap has no samples and so is never flagged.
+        var internetTriggerTargets = targets
+            .Where(t => t.TargetType == MonitoringTargetType.InternetService && internetSeries.ContainsKey(t.TargetId))
+            .Select(t => (IReadOnlyList<LatencySample>)internetSeries[t.TargetId])
+            .ToList();
+        var outageHops = ispTargets.Where(t => ispSeries.ContainsKey(t.TargetId)).Select(t => (Target: t, Series: ispSeries[t.TargetId]))
+            .Concat(transitTargets.Where(t => transitSeries.ContainsKey(t.TargetId)).Select(t => (Target: t, Series: transitSeries[t.TargetId])))
+            .Concat(targets.Where(t => t.TargetType == MonitoringTargetType.InternetService && internetSeries.ContainsKey(t.TargetId)).Select(t => (Target: t, Series: internetSeries[t.TargetId])))
+            .Select(x => new
+            {
+                x.Target.Name,
+                x.Series,
+                // Canonical hop distance from the persisted trace map first; RTT is only a
+                // tiebreaker and the fallback for untraced targets (trace map is post-launch).
+                HopNumber = hopNumberByTargetId.TryGetValue(x.Target.TargetId, out var hn) ? hn : int.MaxValue,
+                Rtt = SeriesStats.Median(x.Series.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList()) ?? double.MaxValue
+            })
+            .OrderBy(x => x.HopNumber).ThenBy(x => x.Rtt)
+            .Select((x, i) => new OutageDetector.Hop(x.Name, i, x.Series))
+            .ToList();
+        var outages = OutageDetector.Detect(internetTriggerTargets, outageHops, _options);
+
         // chartClusters (one line per cluster) is the chart view computed from the same
         // snapshot the detectors ran on, so deeper-cluster "+N ms hop" labels still match
         // event labels. It is published together with the report (see Snapshot).
@@ -327,6 +360,7 @@ public class IspHealthService
             WanSpeedTests = wanSpeedTests,
             CongestionEvents = congestionEvents,
             PathShifts = pathShifts,
+            Outages = outages,
             SmartQueuesEnabled = smartQueuesEnabled,
             HopOrderKnown = hopOrderKnown,
             LoadExclusionWindows = loadExclusions

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -705,8 +705,9 @@ public class IspHealthService
 
         foreach (var group in groups)
         {
-            // Re-run the name cleanup at display so brand overrides (e.g. Arelion Sweden ->
-            // Arelion) apply to already-stored ASN names without needing re-discovery.
+            // The stored AsnName was cleaned by CleanOrgName at discovery/add time (industry
+            // suffixes). Re-run the lighter AsnNameCleanup here so brand overrides (e.g. Arelion
+            // Sweden -> Arelion) apply to already-stored names without needing re-discovery.
             var asnName = AsnNameCleanup.Clean(
                 group.Select(t => t.AsnName).FirstOrDefault(n => !string.IsNullOrEmpty(n))
                 ?? (asnOverrides != null

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -705,11 +705,14 @@ public class IspHealthService
 
         foreach (var group in groups)
         {
-            var asnName = group.Select(t => t.AsnName).FirstOrDefault(n => !string.IsNullOrEmpty(n))
+            // Re-run the name cleanup at display so brand overrides (e.g. Arelion Sweden ->
+            // Arelion) apply to already-stored ASN names without needing re-discovery.
+            var asnName = AsnNameCleanup.Clean(
+                group.Select(t => t.AsnName).FirstOrDefault(n => !string.IsNullOrEmpty(n))
                 ?? (asnOverrides != null
                     ? group.Select(t => asnOverrides.TryGetValue(t.TargetId, out var o) ? o.Name : null).FirstOrDefault(n => !string.IsNullOrEmpty(n))
                     : null)
-                ?? group.Select(t => t.Name).FirstOrDefault();
+                ?? group.Select(t => t.Name).FirstOrDefault());
 
             var byMedian = group
                 .Select(t => (Target: t, Median: SeriesStats.Median(

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -299,7 +299,10 @@ public class IspHealthService
                 HopIps = { t.Address },
                 // Hops proven upstream of this destination, so its clean end-to-end jitter
                 // can absolve an ICMP-deprioritized ISP hop it provably routes through.
-                AncestorIps = ancestorIpsByTargetId.TryGetValue(t.TargetId, out var destAnc) ? destAnc : new List<string>()
+                AncestorIps = ancestorIpsByTargetId.TryGetValue(t.TargetId, out var destAnc) ? destAnc : new List<string>(),
+                // Internet/CDN endpoint (by TargetType): path-shift correlation prefers an
+                // on-path ISP/transit hop over these as the event label.
+                IsDestination = true
             })
             .ToList();
 
@@ -317,17 +320,21 @@ public class IspHealthService
             .Where(t => t.TargetType == MonitoringTargetType.InternetService && internetSeries.ContainsKey(t.TargetId))
             .Select(t => (IReadOnlyList<LatencySample>)internetSeries[t.TargetId])
             .ToList();
-        var outageHops = ispTargets.Where(t => ispSeries.ContainsKey(t.TargetId)).Select(t => (Target: t, Series: ispSeries[t.TargetId]))
-            .Concat(transitTargets.Where(t => transitSeries.ContainsKey(t.TargetId)).Select(t => (Target: t, Series: transitSeries[t.TargetId])))
-            .Concat(targets.Where(t => t.TargetType == MonitoringTargetType.InternetService && internetSeries.ContainsKey(t.TargetId)).Select(t => (Target: t, Series: internetSeries[t.TargetId])))
-            .Select(x => new
+        // Shape the outage on the SAME per-ASN RTT clusters as the Per-Network RTT card
+        // (chartClusters carry merged loss samples and the cluster names), plus each internet
+        // destination. Ordered nearest-first by the persisted hop map (canonical), RTT as the
+        // tiebreaker and the fallback for untraced targets. So a co-located ASN's hops collapse
+        // to one waterfall row while a distinct-distance hop like the OLT stays on its own.
+        int ClusterHopNumber(AsnSeries s) => s.TargetIds
+            .Select(tid => hopNumberByTargetId.TryGetValue(tid, out var hn) ? hn : int.MaxValue)
+            .DefaultIfEmpty(int.MaxValue).Min();
+        var outageHops = chartClusters.Concat(internetTargetSeries)
+            .Select(s => new
             {
-                x.Target.Name,
-                x.Series,
-                // Canonical hop distance from the persisted trace map first; RTT is only a
-                // tiebreaker and the fallback for untraced targets (trace map is post-launch).
-                HopNumber = hopNumberByTargetId.TryGetValue(x.Target.TargetId, out var hn) ? hn : int.MaxValue,
-                Rtt = SeriesStats.Median(x.Series.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList()) ?? double.MaxValue
+                Name = s.AsnName ?? s.TargetIds.FirstOrDefault() ?? "hop",
+                Series = (IReadOnlyList<LatencySample>)s.Samples,
+                HopNumber = ClusterHopNumber(s),
+                Rtt = SeriesStats.Median(s.Samples.Where(x => x.RttAvgMs.HasValue).Select(x => x.RttAvgMs!.Value).ToList()) ?? double.MaxValue
             })
             .OrderBy(x => x.HopNumber).ThenBy(x => x.Rtt)
             .Select((x, i) => new OutageDetector.Hop(x.Name, i, x.Series))

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
@@ -55,7 +55,7 @@ public static class OutageDetector
             i = j + 1;
 
             if (end - start < minDuration) continue;
-            events.Add(BuildEvent(start, end, hops, hopBuckets, windowSize, options));
+            events.Add(BuildEvent(start, end, triggerTargets, hops, hopBuckets, options));
         }
         return events;
     }
@@ -86,9 +86,10 @@ public static class OutageDetector
 
     private static OutageEvent BuildEvent(
         DateTime start, DateTime end,
+        IReadOnlyList<IReadOnlyList<LatencySample>> triggerTargets,
         IReadOnlyList<Hop> hops,
         Dictionary<Hop, Dictionary<DateTime, List<double>>> hopBuckets,
-        TimeSpan windowSize, IspHealthOptions options)
+        IspHealthOptions options)
     {
         var states = new List<OutageTierState>();
         // A hop on the broken path stays dark for (most of) the outage; a hop that merely
@@ -100,7 +101,6 @@ public static class OutageDetector
         {
             double peakLoss = 0;
             int darkBuckets = 0, totalBuckets = 0;
-            DateTime? lastDark = null;
             foreach (var (bucketStart, losses) in hopBuckets[hop]
                          .Where(kv => kv.Key >= start && kv.Key < end)
                          .OrderBy(kv => kv.Key))
@@ -109,11 +109,7 @@ public static class OutageDetector
                 totalBuckets++;
                 var mean = losses.Average();
                 peakLoss = Math.Max(peakLoss, mean);
-                if (mean >= options.OutageDarkLossPct)
-                {
-                    darkBuckets++;
-                    lastDark = bucketStart;
-                }
+                if (mean >= options.OutageDarkLossPct) darkBuckets++;
             }
             onBrokenPath[hop.Depth] = totalBuckets > 0 && (double)darkBuckets / totalBuckets >= 0.5;
             states.Add(new OutageTierState
@@ -122,7 +118,10 @@ public static class OutageDetector
                 Depth = hop.Depth,
                 PeakLossPct = peakLoss,
                 WentDark = darkBuckets > 0,
-                RecoveredAt = darkBuckets > 0 && lastDark.HasValue ? lastDark.Value + windowSize : null
+                // Bucket detection decides whether the hop went dark; the displayed recovery
+                // time comes from the real sample stream so it carries seconds, not a
+                // minute-aligned bucket edge.
+                RecoveredAt = darkBuckets > 0 ? PreciseRecovery(hop.Series, start, end, options) : null
             });
         }
 
@@ -134,13 +133,60 @@ public static class OutageDetector
             ? OutageScope.FullWan
             : OutageScope.Upstream;
 
+        // Bucket edges are minute-aligned; report the real onset and recovery instants from
+        // the pooled trigger stream so the window carries seconds. Fall back to the bucket
+        // edges if the precise edges can't be found (e.g. outage still ongoing at window end).
+        var onset = FirstDark(triggerTargets, start, end, options) ?? start;
+        var recovery = PreciseRecovery(triggerTargets, start, end, options) ?? end;
+
         return new OutageEvent
         {
-            Start = start,
-            End = end,
+            Start = onset,
+            End = recovery,
             Scope = scope,
             LastReachableHop = scope == OutageScope.Upstream ? lastReachable!.Name : null,
             Tiers = states
         };
+    }
+
+    /// <summary>Actual timestamp of the first dark sample (loss at/above the dark threshold) in [start, end).</summary>
+    private static DateTime? FirstDark(
+        IReadOnlyList<IReadOnlyList<LatencySample>> targets,
+        DateTime start, DateTime end, IspHealthOptions options) =>
+        targets.SelectMany(t => t)
+            .Where(s => s.LossPercent.HasValue && s.Time >= start && s.Time < end
+                && s.LossPercent.Value >= options.OutageDarkLossPct)
+            .OrderBy(s => s.Time)
+            .Select(s => (DateTime?)s.Time)
+            .FirstOrDefault();
+
+    /// <summary>
+    /// When the targets came back: the first reporting sample below the dark threshold that
+    /// follows the last dark sample in [start, end). That is the instant recovery was actually
+    /// observed, with seconds. Null when nothing went dark or it never recovered in-window.
+    /// </summary>
+    private static DateTime? PreciseRecovery(
+        IReadOnlyList<LatencySample> series,
+        DateTime start, DateTime end, IspHealthOptions options) =>
+        PreciseRecovery(new[] { series }, start, end, options);
+
+    private static DateTime? PreciseRecovery(
+        IReadOnlyList<IReadOnlyList<LatencySample>> targets,
+        DateTime start, DateTime end, IspHealthOptions options)
+    {
+        var dark = options.OutageDarkLossPct;
+        DateTime? lastDark = targets.SelectMany(t => t)
+            .Where(s => s.LossPercent.HasValue && s.Time >= start && s.Time < end
+                && s.LossPercent.Value >= dark)
+            .OrderBy(s => s.Time)
+            .Select(s => (DateTime?)s.Time)
+            .LastOrDefault();
+        if (!lastDark.HasValue) return null;
+
+        return targets.SelectMany(t => t)
+            .Where(s => s.LossPercent.HasValue && s.LossPercent.Value < dark && s.Time > lastDark.Value)
+            .OrderBy(s => s.Time)
+            .Select(s => (DateTime?)s.Time)
+            .FirstOrDefault();
     }
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
@@ -1,0 +1,146 @@
+namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+
+/// <summary>
+/// Detects internet-unreachable outages: spans where the destination/internet targets go
+/// to near-total packet loss while probes keep reporting. The reporting requirement is the
+/// crux of the gap-vs-outage distinction - when the UniFi Console (gateway) drops, the
+/// Monitoring Agent stops probing, so there are no samples at all and nothing is flagged; a
+/// real upstream outage keeps the gateway up and the Monitoring Agent records 100% loss.
+/// Detection is
+/// group-based on the internet tier alone (shape-independent), because an outage is scored
+/// by duration regardless of which hops dropped. The per-hop series shape the event only:
+/// the deepest hop that stayed reachable is where the break sat, and each hop's recovery
+/// time draws the inside-out heal (validated on a real AT&T outage where the OLT recovered
+/// ~10 min before the upstream). Thresholds live in <see cref="IspHealthOptions"/>.
+/// </summary>
+public static class OutageDetector
+{
+    /// <summary>One monitored hop, carried for the outage shape and break attribution.</summary>
+    public sealed record Hop(string Name, int Depth, IReadOnlyList<LatencySample> Series);
+
+    /// <param name="triggerTargets">The internet/destination loss series whose near-total loss defines an outage.</param>
+    /// <param name="hops">Every monitored hop, ordered by distance (Depth ascending = nearest first), for the shape.</param>
+    public static List<OutageEvent> Detect(
+        IReadOnlyList<IReadOnlyList<LatencySample>> triggerTargets,
+        IReadOnlyList<Hop> hops,
+        IspHealthOptions options)
+    {
+        if (triggerTargets.Count == 0) return new List<OutageEvent>();
+
+        var windowSize = TimeSpan.FromMinutes(options.OutageBucketMinutes);
+        var triggerByBucket = BucketTargets(triggerTargets, windowSize);
+
+        // Outage buckets: enough internet targets reporting (a bucket with none is a
+        // monitoring gap, not an outage), and a strong majority of them dark.
+        var outageBuckets = triggerByBucket
+            .Where(kv => kv.Value.Count >= options.OutageMinReportingTargets
+                && DarkFraction(kv.Value, options) >= options.OutageCoverageFraction)
+            .Select(kv => kv.Key)
+            .OrderBy(t => t)
+            .ToList();
+
+        var hopBuckets = hops.ToDictionary(h => h, h => BucketTargets(new[] { h.Series }, windowSize));
+
+        var events = new List<OutageEvent>();
+        var minDuration = TimeSpan.FromMinutes(options.OutageMinDurationMinutes);
+        for (var i = 0; i < outageBuckets.Count;)
+        {
+            // Extend a run over adjacent (contiguous) outage buckets; a non-outage bucket ends it.
+            var j = i;
+            while (j + 1 < outageBuckets.Count && outageBuckets[j + 1] - outageBuckets[j] <= windowSize)
+                j++;
+
+            var start = outageBuckets[i];
+            var end = outageBuckets[j] + windowSize; // through the last dark bucket
+            i = j + 1;
+
+            if (end - start < minDuration) continue;
+            events.Add(BuildEvent(start, end, hops, hopBuckets, windowSize, options));
+        }
+        return events;
+    }
+
+    /// <summary>Per bucket, the list of each reporting target's mean loss in that bucket.</summary>
+    private static Dictionary<DateTime, List<double>> BucketTargets(
+        IReadOnlyList<IReadOnlyList<LatencySample>> targets, TimeSpan windowSize)
+    {
+        var perBucket = new Dictionary<DateTime, List<double>>();
+        foreach (var target in targets)
+        {
+            foreach (var g in target.Where(s => s.LossPercent.HasValue)
+                         .GroupBy(s => CongestionDetector.FloorTime(s.Time, windowSize)))
+            {
+                if (!perBucket.TryGetValue(g.Key, out var list))
+                {
+                    list = new List<double>();
+                    perBucket[g.Key] = list;
+                }
+                list.Add(g.Average(s => s.LossPercent!.Value));
+            }
+        }
+        return perBucket;
+    }
+
+    private static double DarkFraction(List<double> targetLosses, IspHealthOptions options) =>
+        targetLosses.Count == 0 ? 0 : (double)targetLosses.Count(l => l >= options.OutageDarkLossPct) / targetLosses.Count;
+
+    private static OutageEvent BuildEvent(
+        DateTime start, DateTime end,
+        IReadOnlyList<Hop> hops,
+        Dictionary<Hop, Dictionary<DateTime, List<double>>> hopBuckets,
+        TimeSpan windowSize, IspHealthOptions options)
+    {
+        var states = new List<OutageTierState>();
+        // A hop on the broken path stays dark for (most of) the outage; a hop that merely
+        // blipped at onset then held - like the OLT, which recovered ~10 min before the
+        // upstream in the validation data - is NOT the break and must read as reachable.
+        // So attribution uses the dark duty cycle, not "ever went dark".
+        var onBrokenPath = new Dictionary<int, bool>();
+        foreach (var hop in hops.OrderBy(h => h.Depth))
+        {
+            double peakLoss = 0;
+            int darkBuckets = 0, totalBuckets = 0;
+            DateTime? lastDark = null;
+            foreach (var (bucketStart, losses) in hopBuckets[hop]
+                         .Where(kv => kv.Key >= start && kv.Key < end)
+                         .OrderBy(kv => kv.Key))
+            {
+                if (losses.Count == 0) continue;
+                totalBuckets++;
+                var mean = losses.Average();
+                peakLoss = Math.Max(peakLoss, mean);
+                if (mean >= options.OutageDarkLossPct)
+                {
+                    darkBuckets++;
+                    lastDark = bucketStart;
+                }
+            }
+            onBrokenPath[hop.Depth] = totalBuckets > 0 && (double)darkBuckets / totalBuckets >= 0.5;
+            states.Add(new OutageTierState
+            {
+                Name = hop.Name,
+                Depth = hop.Depth,
+                PeakLossPct = peakLoss,
+                WentDark = darkBuckets > 0,
+                RecoveredAt = darkBuckets > 0 && lastDark.HasValue ? lastDark.Value + windowSize : null
+            });
+        }
+
+        // The break sits just beyond the deepest hop that stayed reachable through the
+        // outage. If even the nearest hop was dark for most of it, the whole WAN dropped.
+        var nearest = states.OrderBy(s => s.Depth).FirstOrDefault();
+        var lastReachable = states.Where(s => !onBrokenPath[s.Depth]).OrderByDescending(s => s.Depth).FirstOrDefault();
+        var scope = nearest == null || onBrokenPath[nearest.Depth] || lastReachable == null
+            ? OutageScope.FullWan
+            : OutageScope.Upstream;
+
+        return new OutageEvent
+        {
+            Start = start,
+            End = end,
+            Scope = scope,
+            LastReachableHop = scope == OutageScope.Upstream ? lastReachable!.Name : null,
+            Tiers = states
+        };
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
@@ -101,6 +101,7 @@ public static class OutageDetector
         {
             double peakLoss = 0;
             int darkBuckets = 0, totalBuckets = 0;
+            DateTime? lastDarkBucket = null;
             foreach (var (bucketStart, losses) in hopBuckets[hop]
                          .Where(kv => kv.Key >= start && kv.Key < end)
                          .OrderBy(kv => kv.Key))
@@ -109,7 +110,11 @@ public static class OutageDetector
                 totalBuckets++;
                 var mean = losses.Average();
                 peakLoss = Math.Max(peakLoss, mean);
-                if (mean >= options.OutageDarkLossPct) darkBuckets++;
+                if (mean >= options.OutageDarkLossPct)
+                {
+                    darkBuckets++;
+                    lastDarkBucket = bucketStart;
+                }
             }
             onBrokenPath[hop.Depth] = totalBuckets > 0 && (double)darkBuckets / totalBuckets >= 0.5;
             states.Add(new OutageTierState
@@ -118,10 +123,13 @@ public static class OutageDetector
                 Depth = hop.Depth,
                 PeakLossPct = peakLoss,
                 WentDark = darkBuckets > 0,
-                // Bucket detection decides whether the hop went dark; the displayed recovery
-                // time comes from the real sample stream so it carries seconds, not a
-                // minute-aligned bucket edge.
-                RecoveredAt = darkBuckets > 0 ? PreciseRecovery(hop.Series, start, end, options) : null
+                // Recovery is anchored to the last *sustained* dark bucket, not the last dark
+                // sample: a hop can twitch dark for a single probe late in the outage (the OLT
+                // blipping as the upstream heals) without that being a real relapse. We then read
+                // the first good sample at/after that bucket, so the time still carries seconds.
+                RecoveredAt = lastDarkBucket.HasValue
+                    ? RecoveryAfter(hop.Series, lastDarkBucket.Value, options.OutageDarkLossPct)
+                    : null
             });
         }
 
@@ -161,15 +169,24 @@ public static class OutageDetector
             .FirstOrDefault();
 
     /// <summary>
+    /// First reporting sample below the dark threshold at or after a floor time - the instant
+    /// the series came back (with seconds). Used with the last sustained dark bucket as the
+    /// floor so a late single-probe twitch doesn't push recovery to the end of the outage.
+    /// Null when no good sample follows (never recovered in-window).
+    /// </summary>
+    private static DateTime? RecoveryAfter(
+        IReadOnlyList<LatencySample> series, DateTime floor, double darkPct) =>
+        series
+            .Where(s => s.LossPercent.HasValue && s.Time >= floor && s.LossPercent.Value < darkPct)
+            .OrderBy(s => s.Time)
+            .Select(s => (DateTime?)s.Time)
+            .FirstOrDefault();
+
+    /// <summary>
     /// When the targets came back: the first reporting sample below the dark threshold that
     /// follows the last dark sample in [start, end). That is the instant recovery was actually
     /// observed, with seconds. Null when nothing went dark or it never recovered in-window.
     /// </summary>
-    private static DateTime? PreciseRecovery(
-        IReadOnlyList<LatencySample> series,
-        DateTime start, DateTime end, IspHealthOptions options) =>
-        PreciseRecovery(new[] { series }, start, end, options);
-
     private static DateTime? PreciseRecovery(
         IReadOnlyList<IReadOnlyList<LatencySample>> targets,
         DateTime start, DateTime end, IspHealthOptions options)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/StepChangeDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/StepChangeDetector.cs
@@ -61,7 +61,8 @@ public static class StepChangeDetector
                 AsnName = series.AsnName,
                 TargetId = series.TargetIds.Count == 1 ? series.TargetIds[0] : null,
                 BeforeMedianMs = before.MedianMs,
-                AfterMedianMs = after.MedianMs
+                AfterMedianMs = after.MedianMs,
+                IsDestination = series.IsDestination
             });
 
             var revert = TryDetectRevert(windows, samples, before, after, afterIdx, windowSize, series, options);
@@ -243,7 +244,8 @@ public static class StepChangeDetector
                 AsnName = series.AsnName,
                 TargetId = series.TargetIds.Count == 1 ? series.TargetIds[0] : null,
                 BeforeMedianMs = revertBefore.MedianMs,
-                AfterMedianMs = revertAfter.MedianMs
+                AfterMedianMs = revertAfter.MedianMs,
+                IsDestination = series.IsDestination
             };
 
             return (evt, lastRequired);
@@ -255,9 +257,11 @@ public static class StepChangeDetector
     /// <summary>
     /// Collapses shifts that occur at the same boundary (within one window) and in the
     /// same direction into a single event, because a routing change usually steps every
-    /// affected path at once. The representative is the nearest hop (lowest before-level)
-    /// so the reported absolute RTTs match the path being graded; the group size is
-    /// carried as the correlated-path count.
+    /// affected path at once. The representative prefers a transit/ISP path hop over an
+    /// internet/CDN destination - a fabric shift is best named by the transit ASN it
+    /// occurred in, not a CDN endpoint that merely routes through it - and within that
+    /// class the nearest hop (lowest before-level), so the reported RTTs match a graded
+    /// path; the group size is carried as the correlated-path count.
     /// </summary>
     public static List<PathShiftEvent> CorrelateAcrossSeries(List<PathShiftEvent> events, IspHealthOptions options)
     {
@@ -276,8 +280,12 @@ public static class StepChangeDetector
 
         foreach (var group in groups)
         {
+            // Prefer an on-path ISP/transit hop over an internet/CDN destination. Destination
+            // is set from the DB TargetType (InternetService), not the target_id - prefixes
+            // lie: transit hops are often custom-named and "transit-as7018" is actually an
+            // access hop. Within the preferred class the nearest hop (lowest before-level) wins.
             var representative = group
-                .OrderByDescending(e => e.TargetId?.StartsWith("transit") == true)
+                .OrderBy(e => e.IsDestination ? 1 : 0)
                 .ThenBy(e => e.BeforeMedianMs)
                 .First();
             merged.Add(new PathShiftEvent
@@ -288,7 +296,8 @@ public static class StepChangeDetector
                 TargetId = representative.TargetId,
                 BeforeMedianMs = representative.BeforeMedianMs,
                 AfterMedianMs = representative.AfterMedianMs,
-                CorrelatedTargetCount = group.Count
+                CorrelatedTargetCount = group.Count,
+                IsDestination = representative.IsDestination
             });
         }
         return merged.OrderBy(e => e.Time).ToList();

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/StepChangeDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/StepChangeDetector.cs
@@ -220,8 +220,17 @@ public static class StepChangeDetector
 
             var revertBoundary = r - 1;
             if (revertBoundary < stepAfterIdx) return null;
-            var revertBefore = windows[revertBoundary];
             var revertAfter = windows[r];
+
+            // Report the revert as the move from the elevated level that actually held
+            // (stepAfter) down to the settled reverted level - not windows[r-1] -> windows[r].
+            // The window just before the first stable reverted window is usually a
+            // transition window already sitting near the reverted level (its wide IQR is
+            // why it failed IsStableLevel and r skipped past it), so windows[r-1] -> windows[r]
+            // reports a near-zero delta for a genuinely large revert (production showed a
+            // ~23 -> 11 ms revert reported as "0 ms"). The crossing search keeps the
+            // transition window's start so the pinpointed time still lands on the drop.
+            var revertBefore = windows[revertBoundary] with { MedianMs = stepAfter.MedianMs, Iqr = stepAfter.Iqr };
 
             var crossing = FindCrossingTime(samples, revertBefore, revertAfter,
                 searchStart: revertBefore.Start,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1504,6 +1504,12 @@ public class UpstreamTracerService
         await Task.WhenAll(tasks);
     }
 
+    /// <summary>
+    /// Storage-time ASN-name cleanup for discovered hops - delegates to the shared
+    /// <see cref="NetworkOptimizer.Core.Helpers.NetworkFormatHelpers.CleanOrgName"/> (industry +
+    /// legal suffixes). Manual target add (LatencyTargetsCard) calls the same helper, so a
+    /// hand-added transit hop stores the same name discovery would ("Level 3", not "Level 3 Parent").
+    /// </summary>
     internal static string CleanAsnName(string? name) =>
         NetworkOptimizer.Core.Helpers.NetworkFormatHelpers.CleanOrgName(name);
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15811,7 +15811,7 @@ a.isp-health-hero-speed:hover {
 
 .isp-outage-hop {
     display: grid;
-    grid-template-columns: minmax(0, 8.5rem) 1fr minmax(0, 5rem);
+    grid-template-columns: minmax(0, 8rem) 1fr minmax(0, 7rem);
     align-items: center;
     gap: 0.6rem;
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15834,7 +15834,7 @@ a.isp-health-hero-speed:hover {
 .isp-outage-hop-dark {
     height: 100%;
     border-radius: 4px 0 0 4px;
-    background: repeating-linear-gradient(45deg, var(--text-muted) 0, var(--text-muted) 2px, var(--bg-tertiary) 2px, var(--bg-tertiary) 5px);
+    background: repeating-linear-gradient(45deg, var(--danger-color) 0, var(--danger-color) 2px, var(--bg-tertiary) 2px, var(--bg-tertiary) 5px);
     transition: width 0.6s cubic-bezier(0.22, 1, 0.36, 1);
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15827,14 +15827,16 @@ a.isp-health-hero-speed:hover {
 .isp-outage-hop-track {
     height: 7px;
     border-radius: 4px;
-    background: var(--primary-color);
+    background: linear-gradient(90deg, var(--bg-tertiary) 0, var(--bg-tertiary) 3px, var(--primary-color) 3px);
     overflow: hidden;
 }
 
 .isp-outage-hop-dark {
     height: 100%;
     border-radius: 4px 0 0 4px;
-    background: repeating-linear-gradient(45deg, var(--danger-color) 0, var(--danger-color) 2px, var(--bg-tertiary) 2px, var(--bg-tertiary) 5px);
+    background:
+        repeating-linear-gradient(45deg, transparent 0, transparent 2px, var(--bg-tertiary) 2px, var(--bg-tertiary) 5px),
+        linear-gradient(90deg, var(--text-muted), 75%, var(--primary-color));
     transition: width 0.6s cubic-bezier(0.22, 1, 0.36, 1);
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15827,13 +15827,13 @@ a.isp-health-hero-speed:hover {
 .isp-outage-hop-track {
     height: 7px;
     border-radius: 4px;
-    background: var(--bg-primary);
+    background: var(--primary-color);
     overflow: hidden;
 }
 
 .isp-outage-hop-dark {
     height: 100%;
-    border-radius: 4px;
+    border-radius: 4px 0 0 4px;
     background: linear-gradient(90deg, #dc2626, #ef4444);
     transition: width 0.6s cubic-bezier(0.22, 1, 0.36, 1);
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15834,7 +15834,7 @@ a.isp-health-hero-speed:hover {
 .isp-outage-hop-dark {
     height: 100%;
     border-radius: 4px 0 0 4px;
-    background: repeating-linear-gradient(45deg, var(--text-muted) 0, var(--text-muted) 2px, transparent 2px, transparent 5px);
+    background: repeating-linear-gradient(45deg, var(--text-muted) 0, var(--text-muted) 2px, var(--bg-tertiary) 2px, var(--bg-tertiary) 5px);
     transition: width 0.6s cubic-bezier(0.22, 1, 0.36, 1);
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15834,7 +15834,7 @@ a.isp-health-hero-speed:hover {
 .isp-outage-hop-dark {
     height: 100%;
     border-radius: 4px 0 0 4px;
-    background: linear-gradient(90deg, #dc2626, #ef4444);
+    background: repeating-linear-gradient(45deg, var(--text-muted) 0, var(--text-muted) 2px, transparent 2px, transparent 5px);
     transition: width 0.6s cubic-bezier(0.22, 1, 0.36, 1);
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15741,6 +15741,11 @@ a.isp-health-hero-speed:hover {
     background: rgba(59, 130, 246, 0.15);
 }
 
+.isp-event-badge-danger {
+    color: var(--danger-color);
+    background: rgba(238, 99, 104, 0.15);
+}
+
 .isp-event-time {
     font-size: 0.78rem;
     font-weight: 600;
@@ -15752,6 +15757,118 @@ a.isp-health-hero-speed:hover {
     font-size: 0.85rem;
     color: var(--text-secondary);
     flex: 1 1 240px;
+}
+
+.isp-outage-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.isp-outage {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 0.9rem 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius-lg);
+    background: var(--bg-tertiary);
+}
+
+.isp-outage-head {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 0.4rem 0.7rem;
+}
+
+.isp-outage-duration {
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    font-variant-numeric: tabular-nums;
+}
+
+.isp-outage-window {
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+}
+
+.isp-outage-scope {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-left: auto;
+}
+
+.isp-outage-shape {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+}
+
+.isp-outage-hop {
+    display: grid;
+    grid-template-columns: minmax(0, 8.5rem) 1fr minmax(0, 5rem);
+    align-items: center;
+    gap: 0.6rem;
+}
+
+.isp-outage-hop-name {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.isp-outage-hop-track {
+    height: 7px;
+    border-radius: 4px;
+    background: var(--bg-primary);
+    overflow: hidden;
+}
+
+.isp-outage-hop-dark {
+    height: 100%;
+    border-radius: 4px;
+    background: linear-gradient(90deg, #dc2626, #ef4444);
+    transition: width 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.isp-outage-hop-status {
+    font-size: 0.72rem;
+    color: var(--text-secondary);
+    text-align: right;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+}
+
+.isp-outage-hop-up {
+    color: var(--success-color);
+}
+
+@media (max-width: 768px) {
+    .isp-outage-hop {
+        grid-template-columns: 1fr auto;
+        grid-template-areas: "name status" "track track";
+        gap: 0.3rem 0.6rem;
+    }
+    .isp-outage-hop-name {
+        grid-area: name;
+    }
+    .isp-outage-hop-status {
+        grid-area: status;
+    }
+    .isp-outage-hop-track {
+        grid-area: track;
+    }
+    .isp-outage-scope {
+        margin-left: 0;
+        flex-basis: 100%;
+    }
 }
 
 @media (max-width: 1024px) {

--- a/tests/NetworkOptimizer.Core.Tests/Helpers/NetworkFormatHelpersTests.cs
+++ b/tests/NetworkOptimizer.Core.Tests/Helpers/NetworkFormatHelpersTests.cs
@@ -1,0 +1,25 @@
+using FluentAssertions;
+using NetworkOptimizer.Core.Helpers;
+using Xunit;
+
+namespace NetworkOptimizer.Core.Tests.Helpers;
+
+public class NetworkFormatHelpersTests
+{
+    [Theory]
+    // Industry suffixes (the storage-time cleaner used by discovery and manual target add).
+    [InlineData("Cogent Communications, LLC", "Cogent")]
+    [InlineData("Level 3 Parent, LLC", "Level 3")]
+    [InlineData("Hisense Broadband Technologies Co Ltd", "Hisense")]
+    // "Bandwidth" is an industry suffix too, so Zayo's two GeoLite2 forms ("Zayo Bandwidth"
+    // and "Zayo Group, LLC") both collapse to the same household name.
+    [InlineData("Zayo Bandwidth", "Zayo")]
+    [InlineData("Zayo Group, LLC", "Zayo")]
+    public void CleanOrgName_strips_industry_and_legal_suffixes(string raw, string expected)
+        => NetworkFormatHelpers.CleanOrgName(raw).Should().Be(expected);
+
+    [Fact]
+    public void CleanOrgName_keeps_bandwidth_when_it_is_the_whole_brand()
+        // "Bandwidth" only strips as a trailing word; it must not erase a standalone brand.
+        => NetworkFormatHelpers.CleanOrgName("Bandwidth Inc").Should().Be("Bandwidth");
+}

--- a/tests/NetworkOptimizer.Monitoring.Tests/InterfaceRateCalculatorTests.cs
+++ b/tests/NetworkOptimizer.Monitoring.Tests/InterfaceRateCalculatorTests.cs
@@ -14,6 +14,7 @@ public class InterfaceRateCalculatorTests
 {
     private static readonly DateTime T0 = new(2026, 6, 11, 4, 43, 0, DateTimeKind.Utc);
     private const long TwoPointFiveGbps = 2_500_000_000L;
+    private const long TenGbps = 10_000_000_000L;
 
     private static InterfaceRateCalculator.State Seed(long inO, long outO, DateTime ts) =>
         new(inO, outO, ts);
@@ -194,6 +195,100 @@ public class InterfaceRateCalculatorTests
         recovered.Outcome.Should().Be(InterfaceRateCalculator.Outcome.Normal);
         recovered.RateInBps.Should().BeGreaterThan(0);
         recovered.RateInBps.Should().BeLessThan(TwoPointFiveGbps);
+    }
+
+    // ─── All-zero seed read (corrupt first poll after a cache reset) ───
+
+    [Fact]
+    public void ZeroSeed_OnHcCounters_DefersBaseline_NoRate()
+    {
+        // First poll after the counter cache cleared (e.g. console reboot) returns a
+        // corrupt (0,0). It must not become the baseline.
+        var r = InterfaceRateCalculator.Compute(
+            previous: null, inOctets: 0, outOctets: 0, now: T0,
+            useHcCounters: true, linkSpeedBps: TenGbps);
+
+        r.Outcome.Should().Be(InterfaceRateCalculator.Outcome.SeededBaseline);
+        r.RateInBps.Should().BeNull();
+        r.RateOutBps.Should().BeNull();
+        r.NewState.ProvisionalSeed.Should().BeTrue("a (0,0) seed is provisional until a real read");
+    }
+
+    [Fact]
+    public void ZeroSeed_ThenRealCounter_ReseedsWithoutSpike()
+    {
+        // Reproduces Mac eth5 on 2026-06-17 18:33: a (0,0) read seeded the baseline
+        // after a console reboot, then the true ~4.29 GB / ~5.0 GB counters returned
+        // ~5.93 s later. Untreated this emitted 5.79 / 6.75 Gbps - under the 10G x1.4
+        // ceiling, so it slipped through. It must emit nothing and reseed instead.
+        var seed = InterfaceRateCalculator.Compute(
+            previous: null, inOctets: 0, outOctets: 0, now: T0,
+            useHcCounters: true, linkSpeedBps: TenGbps);
+        seed.NewState.ProvisionalSeed.Should().BeTrue();
+
+        var recovered = InterfaceRateCalculator.Compute(
+            seed.NewState, inOctets: 4_291_840_953, outOctets: 4_997_948_108, now: T0.AddSeconds(5.93),
+            useHcCounters: true, linkSpeedBps: TenGbps);
+
+        recovered.Outcome.Should().Be(InterfaceRateCalculator.Outcome.SeededBaseline);
+        recovered.RateInBps.Should().BeNull("the phantom ~5.8/6.7 Gbps snap-back must not be emitted");
+        recovered.RateOutBps.Should().BeNull();
+        recovered.NewState.InOctets.Should().Be(4_291_840_953, "the real read is now the trusted baseline");
+        recovered.NewState.ProvisionalSeed.Should().BeFalse();
+
+        // The next real read computes a normal rate from the now-trusted baseline
+        // (~12.36 MB over 5.21 s = ~18.97 Mbps, the actual Mac value at 18:33:13).
+        var next = InterfaceRateCalculator.Compute(
+            recovered.NewState, inOctets: 4_304_200_890, outOctets: 4_998_357_079, now: T0.AddSeconds(11.14),
+            useHcCounters: true, linkSpeedBps: TenGbps);
+        next.Outcome.Should().Be(InterfaceRateCalculator.Outcome.Normal);
+        next.RateInBps.Should().BeApproximately(18_970_000, 200_000);
+        next.RateInBps.Should().BeLessThan(TenGbps);
+    }
+
+    [Fact]
+    public void ZeroSeed_ThenAnotherZero_StaysProvisional()
+    {
+        var seed = InterfaceRateCalculator.Compute(
+            previous: null, inOctets: 0, outOctets: 0, now: T0,
+            useHcCounters: true, linkSpeedBps: TenGbps);
+
+        var still = InterfaceRateCalculator.Compute(
+            seed.NewState, inOctets: 0, outOctets: 0, now: T0.AddSeconds(5),
+            useHcCounters: true, linkSpeedBps: TenGbps);
+
+        still.Outcome.Should().Be(InterfaceRateCalculator.Outcome.SeededBaseline);
+        still.RateInBps.Should().BeNull();
+        still.NewState.ProvisionalSeed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EstablishedZeroBaseline_StillComputesRate_DeferralIsSeedTimeOnly()
+    {
+        // A (0,0) that is an ESTABLISHED baseline (ProvisionalSeed false - e.g. a
+        // low-speed interface idle since the baseline was taken) must still compute a
+        // rate. The deferral applies only to a (0,0) seeded as the first read.
+        var prev = Seed(0, 0, T0);
+        var r = InterfaceRateCalculator.Compute(
+            prev, inOctets: 1_250_000, outOctets: 0, now: T0.AddSeconds(10),
+            useHcCounters: true, linkSpeedBps: TenGbps);
+
+        r.Outcome.Should().Be(InterfaceRateCalculator.Outcome.Normal);
+        r.RateInBps.Should().BeApproximately(1_000_000, 1);
+    }
+
+    [Fact]
+    public void ZeroSeed_On32BitCounters_SeedsNormally_NotDeferred()
+    {
+        // 32-bit counters wrap and a (0,0) is plausible on an idle low-speed interface;
+        // a snap-back there exceeds the low link ceiling and is caught by ImplausibleRate.
+        // The seed deferral is scoped to 64-bit HC counters, so this seeds normally.
+        var r = InterfaceRateCalculator.Compute(
+            previous: null, inOctets: 0, outOctets: 0, now: T0,
+            useHcCounters: false, linkSpeedBps: 1_000_000_000L);
+
+        r.Outcome.Should().Be(InterfaceRateCalculator.Outcome.SeededBaseline);
+        r.NewState.ProvisionalSeed.Should().BeFalse();
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -38,7 +38,8 @@ public class IspHealthScorerTests
         bool smartQueuesEnabled = false,
         double? internetDeltaMs = null,
         bool lineIdle = false,
-        bool hopOrderKnown = false)
+        bool hopOrderKnown = false,
+        List<OutageEvent>? outages = null)
     {
         // lineIdle: a near-zero, flat WAN with no load bursts (~0% average load), for
         // exercising the load-calibrated packet-loss ceiling at the idle end.
@@ -79,8 +80,28 @@ public class IspHealthScorerTests
             },
             CongestionEvents = congestion ?? new List<CongestionEvent>(),
             SmartQueuesEnabled = smartQueuesEnabled,
-            HopOrderKnown = hopOrderKnown
+            HopOrderKnown = hopOrderKnown,
+            Outages = outages ?? new List<OutageEvent>()
         };
+    }
+
+    [Fact]
+    public void Outage_drops_overall_by_the_duration_curve()
+    {
+        new IspHealthScorer(Options).Score(BuildInputs(), Gpon).OverallScore.Should().Be(100);
+
+        OutageEvent Outage(double mins) => new()
+        {
+            Start = TestSeries.Start.AddHours(2),
+            End = TestSeries.Start.AddHours(2).AddMinutes(mins)
+        };
+        int OverallWith(double mins) => new IspHealthScorer(Options)
+            .Score(BuildInputs(outages: new List<OutageEvent> { Outage(mins) }), Gpon).OverallScore;
+
+        // Default severity curve: 10 min -> 14, 60 min -> 45, 8 h -> 90 (off a clean 100).
+        OverallWith(10).Should().Be(86);
+        OverallWith(60).Should().Be(55);
+        OverallWith(480).Should().Be(10);
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
@@ -151,4 +151,38 @@ public class OutageDetectorTests
 
         events.Should().BeEmpty();
     }
+
+    [Fact]
+    public void Window_and_recovery_carry_real_seconds_not_minute_buckets()
+    {
+        // Samples land at :17 past each minute. Detection still buckets by minute, but the
+        // reported onset, recovery, and per-hop recovery must come from the actual sample
+        // instants - otherwise every time renders :00.
+        var offset = TimeSpan.FromSeconds(17);
+        List<LatencySample> Build()
+        {
+            var s = new List<LatencySample>();
+            for (var t = TestSeries.Start + offset; t < TestSeries.Start + Window + offset; t = t.AddMinutes(1))
+            {
+                var dark = t >= OutStart + offset && t < OutEnd + offset;
+                s.Add(new LatencySample(t, 20, 20.5, 0.5, dark ? 100 : 0));
+            }
+            return s;
+        }
+        var internet1 = Build();
+        var internet2 = Build();
+        var hops = new[]
+        {
+            new OutageDetector.Hop("Cloudflare", 1, internet1),
+            new OutageDetector.Hop("Google", 1, internet2),
+        };
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), hops, Options);
+
+        events.Should().ContainSingle();
+        events[0].Start.Should().Be(OutStart + offset);
+        events[0].End.Should().Be(OutEnd + offset);
+        events[0].Tiers.Where(t => t.RecoveredAt.HasValue)
+            .Should().OnlyContain(t => t.RecoveredAt!.Value.Second == 17);
+    }
 }

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
@@ -1,0 +1,154 @@
+using FluentAssertions;
+using NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.IspHealth;
+
+/// <summary>
+/// Tests for internet-outage detection and shaping, calibrated to the real AT&T outage on
+/// the Mac site (2026-06-17): the OLT briefly went dark at onset then recovered ~10 min
+/// before the upstream, which stayed dark. Detection is internet-tier only (shape- and
+/// trace-map-independent); the per-hop shape and break attribution use the ordered hops.
+/// </summary>
+public class OutageDetectorTests
+{
+    private static readonly IspHealthOptions Options = new();
+    private static readonly TimeSpan Window = TimeSpan.FromMinutes(30);
+    private static readonly DateTime OutStart = TestSeries.Start.AddMinutes(10);
+    private static readonly DateTime OutEnd = TestSeries.Start.AddMinutes(20);
+
+    private static List<LatencySample> Series(double normalLoss, params (DateTime From, DateTime To, double Loss)[] dark)
+    {
+        var s = TestSeries.Flat(TestSeries.Start, Window, rttMs: 20, jitterMs: 0.5, lossPct: normalLoss);
+        foreach (var d in dark) s = s.WithSegment(d.From, d.To, rttMs: 20, jitterMs: 0.5, lossPct: d.Loss);
+        return s;
+    }
+
+    private static IReadOnlyList<IReadOnlyList<LatencySample>> Triggers(params List<LatencySample>[] series) => series;
+
+    [Fact]
+    public void Detects_upstream_outage_and_attributes_break_beyond_olt()
+    {
+        var internet1 = Series(0, (OutStart, OutEnd, 100));
+        var internet2 = Series(0, (OutStart, OutEnd, 100));
+        var olt = Series(0); // never dark - stays reachable throughout
+        var transit = Series(0, (OutStart, OutEnd, 100));
+
+        var hops = new[]
+        {
+            new OutageDetector.Hop("AT&T nokia-olt", 0, olt),
+            new OutageDetector.Hop("AT&T Transit", 1, transit),
+            new OutageDetector.Hop("Cloudflare", 2, internet1),
+            new OutageDetector.Hop("Google", 2, internet2),
+        };
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), hops, Options);
+
+        events.Should().ContainSingle();
+        events[0].Scope.Should().Be(OutageScope.Upstream);
+        events[0].LastReachableHop.Should().Be("AT&T nokia-olt");
+        events[0].Duration.Should().BeCloseTo(TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(1));
+    }
+
+    [Fact]
+    public void Olt_blip_at_onset_then_recovery_still_reads_upstream_and_leads_the_waterfall()
+    {
+        var internet1 = Series(0, (OutStart, OutEnd, 100));
+        var internet2 = Series(0, (OutStart, OutEnd, 100));
+        // OLT dark for one minute at onset, then recovers - the validated AT&T shape.
+        var olt = Series(0, (OutStart, OutStart.AddMinutes(1), 100));
+        var transit = Series(0, (OutStart, OutEnd, 100));
+
+        var hops = new[]
+        {
+            new OutageDetector.Hop("AT&T nokia-olt", 0, olt),
+            new OutageDetector.Hop("AT&T Transit", 1, transit),
+            new OutageDetector.Hop("Cloudflare", 2, internet1),
+        };
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), hops, Options);
+
+        events.Should().ContainSingle();
+        // A brief onset blip must NOT read as the break - the OLT held for the majority.
+        events[0].Scope.Should().Be(OutageScope.Upstream);
+        events[0].LastReachableHop.Should().Be("AT&T nokia-olt");
+
+        var oltState = events[0].Tiers.Single(t => t.Name == "AT&T nokia-olt");
+        var transitState = events[0].Tiers.Single(t => t.Name == "AT&T Transit");
+        oltState.RecoveredAt.Should().NotBeNull();
+        transitState.RecoveredAt.Should().NotBeNull();
+        oltState.RecoveredAt!.Value.Should().BeBefore(transitState.RecoveredAt!.Value);
+    }
+
+    [Fact]
+    public void Full_wan_outage_when_even_the_nearest_hop_stays_dark()
+    {
+        var internet1 = Series(0, (OutStart, OutEnd, 100));
+        var internet2 = Series(0, (OutStart, OutEnd, 100));
+        var olt = Series(0, (OutStart, OutEnd, 100)); // dark the whole outage
+
+        var hops = new[]
+        {
+            new OutageDetector.Hop("AT&T nokia-olt", 0, olt),
+            new OutageDetector.Hop("Cloudflare", 1, internet1),
+        };
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), hops, Options);
+
+        events.Should().ContainSingle();
+        events[0].Scope.Should().Be(OutageScope.FullWan);
+        events[0].LastReachableHop.Should().BeNull();
+    }
+
+    [Fact]
+    public void Monitoring_gap_with_no_samples_is_not_an_outage()
+    {
+        // No samples at all during the span (the Monitoring Agent stopped collecting) -
+        // a gap, never an outage.
+        List<LatencySample> Gapped() => TestSeries.Flat(TestSeries.Start, TimeSpan.FromMinutes(10), 20, 0.5, 0)
+            .Concat(TestSeries.Flat(OutEnd, TimeSpan.FromMinutes(10), 20, 0.5, 0))
+            .ToList();
+        var internet1 = Gapped();
+        var internet2 = Gapped();
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), System.Array.Empty<OutageDetector.Hop>(), Options);
+
+        events.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Brief_blip_below_min_duration_is_ignored()
+    {
+        var internet1 = Series(0, (OutStart, OutStart.AddMinutes(1), 100));
+        var internet2 = Series(0, (OutStart, OutStart.AddMinutes(1), 100));
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), System.Array.Empty<OutageDetector.Hop>(), Options);
+
+        events.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Detects_outage_without_a_hop_map_still_noting_it()
+    {
+        // No hops passed (no trace map / no monitored intermediate hops): the outage is
+        // still flagged with its duration; only the per-hop shape and attribution degrade.
+        var internet1 = Series(0, (OutStart, OutEnd, 100));
+        var internet2 = Series(0, (OutStart, OutEnd, 100));
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), System.Array.Empty<OutageDetector.Hop>(), Options);
+
+        events.Should().ContainSingle();
+        events[0].Duration.Should().BeCloseTo(TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(1));
+        events[0].Tiers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Single_reporting_target_is_too_thin_to_declare_an_outage()
+    {
+        var internet1 = Series(0, (OutStart, OutEnd, 100));
+
+        var events = OutageDetector.Detect(Triggers(internet1), System.Array.Empty<OutageDetector.Hop>(), Options);
+
+        events.Should().BeEmpty();
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
@@ -153,6 +153,43 @@ public class OutageDetectorTests
     }
 
     [Fact]
+    public void Hop_that_recovers_early_is_not_dragged_to_the_end_by_a_late_blip()
+    {
+        // The validated AT&T shape: the OLT goes dark at onset, recovers early, then twitches
+        // dark for a single probe much later as the upstream heals. That lone late sample must
+        // NOT be read as the OLT's recovery - it came back early. Recovery anchors to the last
+        // sustained dark bucket, which a single sub-minute sample can't form.
+        var cadence = TimeSpan.FromSeconds(5);
+        var recover = OutStart.AddMinutes(2);
+        var lateBlip = OutStart.AddMinutes(9);
+        List<LatencySample> Build(Func<DateTime, bool> isDark)
+        {
+            var s = new List<LatencySample>();
+            for (var t = TestSeries.Start; t < TestSeries.Start + Window; t += cadence)
+                s.Add(new LatencySample(t, 20, 20.5, 0.5, isDark(t) ? 100 : 0));
+            return s;
+        }
+        var internet1 = Build(t => t >= OutStart && t < OutEnd);
+        var internet2 = Build(t => t >= OutStart && t < OutEnd);
+        var olt = Build(t => (t >= OutStart && t < recover) || (t >= lateBlip && t < lateBlip + cadence));
+
+        var hops = new[]
+        {
+            new OutageDetector.Hop("AT&T nokia-olt", 0, olt),
+            new OutageDetector.Hop("Cloudflare", 1, internet1),
+            new OutageDetector.Hop("Google", 1, internet2),
+        };
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), hops, Options);
+
+        events.Should().ContainSingle();
+        var oltState = events[0].Tiers.Single(t => t.Name == "AT&T nokia-olt");
+        oltState.RecoveredAt.Should().NotBeNull();
+        oltState.RecoveredAt!.Value.Should().BeCloseTo(recover, TimeSpan.FromSeconds(10));
+        oltState.RecoveredAt.Value.Should().BeBefore(OutStart.AddMinutes(5));
+    }
+
+    [Fact]
     public void Window_and_recovery_carry_real_seconds_not_minute_buckets()
     {
         // Samples land at :17 past each minute. Detection still buckets by minute, but the

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
@@ -6,7 +6,7 @@ namespace NetworkOptimizer.Web.Tests.IspHealth;
 
 /// <summary>
 /// Tests for internet-outage detection and shaping, calibrated to the real AT&T outage on
-/// the Mac site (2026-06-17): the OLT briefly went dark at onset then recovered ~10 min
+/// a test site (2026-06-17): the OLT briefly went dark at onset then recovered ~10 min
 /// before the upstream, which stayed dark. Detection is internet-tier only (shape- and
 /// trace-map-independent); the per-hop shape and break attribution use the ordered hops.
 /// </summary>

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/StepChangeDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/StepChangeDetectorTests.cs
@@ -172,4 +172,26 @@ public class StepChangeDetectorTests
         // Representative is the nearest hop (lowest before-level).
         events[0].BeforeMedianMs.Should().BeApproximately(10, 0.5);
     }
+
+    [Fact]
+    public void Correlated_shift_is_labeled_from_an_on_path_hop_not_a_nearer_destination()
+    {
+        // A transit hop (higher RTT) and an internet/CDN destination (lower RTT) step at the
+        // same boundary. The label must come from the on-path transit hop, not the nearer
+        // destination - even though the destination has the lower before-level.
+        var stepAt = TestSeries.Start.AddHours(12);
+        var transitSamples = TestSeries.Flat(TestSeries.Start, Day, rttMs: 20, jitterMs: 0.5)
+            .WithSegment(stepAt, TestSeries.Start + Day, rttMs: 30, jitterMs: 0.5);
+        var destSamples = TestSeries.Flat(TestSeries.Start, Day, rttMs: 10, jitterMs: 0.5)
+            .WithSegment(stepAt, TestSeries.Start + Day, rttMs: 20, jitterMs: 0.5);
+
+        var transit = new AsnSeries { AsnNumber = 3356, AsnName = "Level 3", TargetIds = { "custom-abc" }, Samples = transitSamples };
+        var destination = new AsnSeries { AsnNumber = 19281, AsnName = "Quad9 DFW", TargetIds = { "path-quad9" }, Samples = destSamples, IsDestination = true };
+
+        var events = StepChangeDetector.Detect(new[] { transit, destination }, Options);
+
+        events.Should().ContainSingle();
+        events[0].CorrelatedTargetCount.Should().Be(2);
+        events[0].AsnName.Should().Be("Level 3");
+    }
 }

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/StepChangeDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/StepChangeDetectorTests.cs
@@ -125,6 +125,33 @@ public class StepChangeDetectorTests
     }
 
     [Fact]
+    public void Revert_reports_elevated_to_reverted_magnitude_not_transition_window()
+    {
+        // Production shape: a path steps up and holds for hours, then reverts. The drop
+        // lands mid-window, so the transition window (wide IQR) fails the stability gate
+        // and is skipped; the window just before the first settled reverted window then
+        // sits at the reverted level. Reporting windows[r-1] -> windows[r] yielded a
+        // "0 ms" delta for a real ~12 ms revert. The revert must report the elevated
+        // level it actually came down from, not the transition-adjacent window.
+        var stepUp = TestSeries.Start.AddHours(10);
+        var revertAt = TestSeries.Start.AddHours(22).AddMinutes(7); // mid 22:00-22:30 window
+        var span = TimeSpan.FromHours(34);
+        var samples = TestSeries.Flat(TestSeries.Start, span, rttMs: 10, jitterMs: 0.5)
+            .WithSegment(stepUp, TestSeries.Start.AddHours(22), rttMs: 23, jitterMs: 0.5)
+            .WithSegment(revertAt, TestSeries.Start + span, rttMs: 11, jitterMs: 0.5);
+
+        var events = StepChangeDetector.DetectForSeries(TestSeries.Asn(64500, "TransitOne", samples), Options);
+
+        events.Should().HaveCount(2);
+        events[0].Direction.Should().Be(PathShiftDirection.Up);
+        var revert = events[1];
+        revert.Direction.Should().Be(PathShiftDirection.Down);
+        revert.BeforeMedianMs.Should().BeApproximately(23, 1.0);
+        revert.AfterMedianMs.Should().BeApproximately(11, 1.0);
+        Math.Abs(revert.DeltaMs).Should().BeGreaterThan(10);
+    }
+
+    [Fact]
     public void Correlated_steps_across_targets_merge_into_one_event()
     {
         var stepAt = TestSeries.Start.AddHours(12);

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/AsnNameCleanupTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/AsnNameCleanupTests.cs
@@ -1,0 +1,22 @@
+using FluentAssertions;
+using NetworkOptimizer.Web.Services.Monitoring;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Monitoring;
+
+public class AsnNameCleanupTests
+{
+    [Theory]
+    [InlineData("Cloudflare, Inc.", "Cloudflare")]
+    [InlineData("Akamai International B.V.", "Akamai International")]
+    [InlineData("Arelion Sweden AB", "Arelion")]
+    [InlineData("Arelion Sweden", "Arelion")]
+    public void Strips_corporate_suffixes_and_applies_brand_overrides(string raw, string expected)
+        => AsnNameCleanup.Clean(raw).Should().Be(expected);
+
+    [Fact]
+    public void Does_not_strip_geographic_words_generically()
+        // The Arelion override is exact-match, not a blanket "Sweden" strip - a real ISP
+        // could legitimately be named this way.
+        => AsnNameCleanup.Clean("Acme Sweden").Should().Be("Acme Sweden");
+}

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/AsnNameCleanupTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/AsnNameCleanupTests.cs
@@ -14,6 +14,21 @@ public class AsnNameCleanupTests
     public void Strips_corporate_suffixes_and_applies_brand_overrides(string raw, string expected)
         => AsnNameCleanup.Clean(raw).Should().Be(expected);
 
+    [Theory]
+    // Sparkle (AS6762 and regional subsidiaries) appears under many legal-entity names; a
+    // whole-word brand token collapses them all to the household name.
+    [InlineData("TELECOM ITALIA SPARKLE S.p.A.", "Sparkle")]
+    [InlineData("Telecom Italia Sparkle Singapore Pte Ltd", "Sparkle")]
+    [InlineData("TI Sparkle Turkey Telekomunukasyon A.S", "Sparkle")]
+    [InlineData("TTi Sparkle Greece SA", "Sparkle")]
+    public void Collapses_brand_token_across_regional_entities(string raw, string expected)
+        => AsnNameCleanup.Clean(raw).Should().Be(expected);
+
+    [Fact]
+    public void Brand_token_requires_a_whole_word_so_it_does_not_clobber_lookalikes()
+        // "Sparklight" (Cable One) contains "Sparkl" but not the whole word "Sparkle".
+        => AsnNameCleanup.Clean("Sparklight").Should().Be("Sparklight");
+
     [Fact]
     public void Does_not_strip_geographic_words_generically()
         // The Arelion override is exact-match, not a blanket "Sweden" strip - a real ISP


### PR DESCRIPTION
## Summary

Adds internet-outage detection to ISP Health and tightens several monitoring accuracy issues.

## Internet outage detection

- Detects internet-unreachable outages and distinguishes them from monitoring gaps: an outage is when the destination/internet targets go to near-total loss **while the Monitoring Agent keeps probing**. When the gateway itself drops, probing stops and there are no samples - that's a gap, never flagged.
- Attributes the break point: the deepest hop that stayed reachable through the outage is where the break sat (e.g. the access OLT held while everything upstream went dark = an ISP-side fault, not your network).
- Scores outages once at the top level on a duration curve, so a multi-hour outage actually drives the score down instead of being diluted inside a single factor. Brief blips barely move it.
- Excludes outage windows from all packet-loss evaluation, so a discrete internet-down event doesn't double-count against the per-network loss grades.
- Renders a clustered recovery-shape waterfall in the ISP Health panel showing each tier's recovery, with a finding that links to it.

## Path-shift accuracy

- Reports path RTT reverts at their true magnitude instead of near-zero when the pre-revert window sits in a transition.
- Labels a correlated path shift from the transit/ISP hop it occurred in rather than a CDN endpoint that merely routes through it, using the DB target type rather than target-id prefixes.

## WAN interface rate

- Don't seed an interface counter baseline from an all-zero high-counter read (a corrupt poll or a device caught mid-boot). Trusting it let the next real read compute a phantom near-link-speed rate on a fast port carrying a slower circuit. The baseline is now established from the first trustworthy nonzero read.

## ASN naming

- Manually-added transit/ISP targets now clean their ASN name through the same helper auto-discovery uses, so a hand-added hop stores the same household name (e.g. "Level 3", not "Level 3 Parent").
- Brand handling for providers whose registered name differs from the household name: an Arelion exact-match override, a whole-word "Sparkle" brand token covering its regional entities, and "Bandwidth" added to the industry-suffix list (so "Zayo Bandwidth" collapses to "Zayo"). Documented the two cleaners and where each runs.

## Tests

New coverage for outage detection/shaping, the interface zero-counter seed, path-shift revert magnitude and labeling, and the ASN name cleaners.