### PR TITLE
ISP Health: state outage score impact in the finding (v1.21.1)

### DIFF
--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -1029,11 +1029,17 @@ public class IspHealthScorer
             var count = inputs.Outages.Count == 1
                 ? $"An internet outage of {FormatOutageDuration(inputs.Outages[0].Duration)}"
                 : $"{inputs.Outages.Count} internet outages totaling {FormatOutageDuration(totalDown)}";
+            // Be transparent about the score hit: the outage penalty is applied at the top level
+            // and isn't tied to any one factor, so spell it out here or it's invisible.
+            var penalty = (int)Math.Round(OutageScorePenalty(totalDown.TotalMinutes));
+            var impact = penalty > 0
+                ? $" {(inputs.Outages.Count == 1 ? "It" : "Together they")} lowered your ISP Health score by {penalty} {(penalty == 1 ? "point" : "points")}."
+                : string.Empty;
             issues.Add(new IspHealthIssue
             {
                 Severity = IspIssueSeverity.Warning,
                 Title = inputs.Outages.Count == 1 ? "Internet outage in the window" : "Internet outages in the window",
-                Description = $"{count} occurred while the Monitoring Agent kept probing (so this is a real outage, not a monitoring gap).{where}",
+                Description = $"{count} occurred while the Monitoring Agent kept probing (so this is a real outage, not a monitoring gap).{where}{impact}",
                 Recommendation = "No action needed on your side for an upstream outage; it is logged here so you can correlate it with ISP incidents.",
                 LinkUrl = "#isp-outages",
                 LinkText = "The recovery shape is shown on the timeline below."

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -105,6 +105,22 @@ public class IspHealthScorerTests
     }
 
     [Fact]
+    public void Outage_finding_spells_out_the_score_impact()
+    {
+        var outage = new OutageEvent
+        {
+            Start = TestSeries.Start.AddHours(2),
+            End = TestSeries.Start.AddHours(2).AddMinutes(60)
+        };
+        var report = new IspHealthScorer(Options)
+            .Score(BuildInputs(outages: new List<OutageEvent> { outage }), Gpon);
+
+        // 60 min off a clean 100 is a 45-point penalty; the finding states it for transparency.
+        var finding = report.Issues.Single(i => i.Title == "Internet outage in the window");
+        finding.Description.Should().Contain("lowered your ISP Health score by 45 points");
+    }
+
+    [Fact]
     public void Ideal_gpon_inputs_score_excellent()
     {
         var report = new IspHealthScorer(Options).Score(BuildInputs(), Gpon);


### PR DESCRIPTION
Rolls into the pending v1.21.1 release.

The internet-outage finding now states its score impact - "lowered your ISP Health score by N points" - so the deduction is transparent instead of silently applied at the top level. The sentence pluralizes for multiple outages and is omitted when the penalty rounds to 0.