### PR TITLE
ISP Health outages: per-hop access detail, ASN labels, trimmed internet rows

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -200,7 +200,7 @@ else
                             <p class="page-description">No ISP hop data in the window.</p>
                         }
                         <div class="isp-hop-list">
-                            @foreach (var target in r.IspTargets)
+                            @foreach (var target in r.IspTargets.OrderBy(t => t.RttMs ?? double.MaxValue))
                             {
                                 <div class="isp-hop">
                                     <div class="isp-hop-row">

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -198,6 +198,13 @@ public class IspHealthOptions
     public int OutageMinDurationMinutes { get; set; } = 2;
 
     /// <summary>
+    /// Recovery-time tolerance for collapsing per-target access ISP rows in the outage waterfall:
+    /// access hops that recovered within this many seconds of each other share a signature and
+    /// merge to one row; ones outside it stay separate (the inside-out heal).
+    /// </summary>
+    public int OutageAccessGroupToleranceSeconds { get; set; } = 10;
+
+    /// <summary>
     /// Outage severity curve: points deducted from the OVERALL score per (totalDowntimeMinutes,
     /// penaltyPoints) anchor, interpolated. Applied at the top level rather than buried in the
     /// Packet Loss factor (where the dimension weights would dilute a multi-hour outage to a

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -15,10 +15,10 @@ public class IspHealthService
 {
     private static readonly string[] AnycastDnsIps = ["1.1.1.1", "1.0.0.1", "8.8.8.8", "8.8.4.4"];
 
-    // The internet endpoints that drive outage detection and the outage waterfall: just the two
-    // canonical anycast resolvers (Cloudflare, Google). 5+ internet rows on the waterfall is just
-    // clutter - two well-known resolvers convey "internet reachable" plainly. The rest still feed
-    // jitter-absolve and path-shift.
+    // The internet endpoints SHOWN on the outage waterfall: just the two canonical anycast
+    // resolvers (Cloudflare, Google). 5+ internet rows is just clutter - two well-known resolvers
+    // convey "internet reachable" plainly. Detection still triggers on every internet target; this
+    // only trims the displayed rows.
     private static readonly string[] OutageInternetIps = ["1.1.1.1", "8.8.8.8"];
 
     private readonly MonitoringInfluxClient _influx;
@@ -322,22 +322,52 @@ public class IspHealthService
 
         // Outage detection: the internet targets going dark defines an outage; every hop is
         // carried (ordered nearest-first by the hop map, RTT tiebreaker) to shape it and
-        // attribute the break. A monitoring gap has no samples and so is never flagged. Both
-        // the trigger and the internet rows are limited to the two canonical resolvers.
+        // attribute the break. A monitoring gap has no samples and so is never flagged. The
+        // trigger keeps ALL internet targets (robust detection); only the waterfall's internet
+        // rows are trimmed to the two canonical resolvers below.
         var internetTriggerTargets = targets
-            .Where(t => t.TargetType == MonitoringTargetType.InternetService
-                && OutageInternetIps.Contains(t.Address)
-                && internetSeries.ContainsKey(t.TargetId))
+            .Where(t => t.TargetType == MonitoringTargetType.InternetService && internetSeries.ContainsKey(t.TargetId))
             .Select(t => (IReadOnlyList<LatencySample>)internetSeries[t.TargetId])
             .ToList();
         int ClusterHopNumber(AsnSeries s) => s.TargetIds
             .Select(tid => hopNumberByTargetId.TryGetValue(tid, out var hn) ? hn : int.MaxValue)
             .DefaultIfEmpty(int.MaxValue).Min();
+        double MedianRtt(AsnSeries s) => SeriesStats.Median(
+            s.Samples.Where(x => x.RttAvgMs.HasValue).Select(x => x.RttAvgMs!.Value).ToList()) ?? double.MaxValue;
+        // The two internet rows for the waterfall: prefer Cloudflare/Google, but if the user
+        // doesn't monitor them, fall back to the two nearest other internet targets so the
+        // waterfall still shows an internet-reachability row.
+        var displayInternet = internetTargetSeries
+            .Where(s => s.HopIps.Any(ip => OutageInternetIps.Contains(ip)))
+            .Concat(internetTargetSeries
+                .Where(s => !s.HopIps.Any(ip => OutageInternetIps.Contains(ip)))
+                .OrderBy(MedianRtt))
+            .Take(2)
+            .ToList();
+        // Each waterfall row is labeled by its ASN. Access ISP and Transit can both be the same
+        // ASN (e.g. AT&T is both the access network and a transit hop), so a transit row whose ASN
+        // also appears in the access layer is suffixed " Transit" to disambiguate it.
+        var accessAsnNumbers = ispTargets.Where(t => t.AsnNumber is > 0).Select(t => t.AsnNumber!.Value).ToHashSet();
+        var accessAsnName = ispTargets.Select(t => AsnNameCleanup.Clean(t.AsnName)).FirstOrDefault(n => !string.IsNullOrEmpty(n));
+        var transitAsnNameByNumber = transitTargets
+            .Where(t => t.AsnNumber is > 0 && !string.IsNullOrEmpty(t.AsnName))
+            .GroupBy(t => t.AsnNumber!.Value)
+            .ToDictionary(g => g.Key, g => AsnNameCleanup.Clean(g.Select(t => t.AsnName).First()) ?? "");
+        string TransitLabel(AsnSeries s)
+        {
+            // Single-member transit clusters carry the target's own name; prefer the ASN. Multi /
+            // deeper clusters already carry an ASN-based name ("ASN (+N ms hop)"), so keep it.
+            var asn = transitAsnNameByNumber.GetValueOrDefault(s.AsnNumber);
+            var label = s.TargetIds.Count == 1 && !string.IsNullOrEmpty(asn) ? asn : AsnNameCleanup.Clean(s.AsnName) ?? asn ?? "transit";
+            if (accessAsnNumbers.Contains(s.AsnNumber) && !label.EndsWith("Transit", StringComparison.OrdinalIgnoreCase))
+                label += " Transit";
+            return label;
+        }
         // Waterfall composition:
-        //  - Access ISP targets broken out per target (Groupable) so each access hop's own
-        //    outage timing shows; the detector re-collapses ones that share a signature.
+        //  - Access ISP targets broken out per target (Groupable, labeled by access ASN) so each
+        //    access hop's own outage timing shows; the detector re-collapses shared signatures.
         //  - Transit kept as the per-ASN RTT clusters (the Per-Network RTT grouping), untouched.
-        //  - Internet limited to the two trigger resolvers (Cloudflare, Google).
+        //  - Internet trimmed to two rows (displayInternet).
         var outageSources = ispTargets
             .Where(t => ispSeries.ContainsKey(t.TargetId))
             .Select(t => (Series: new AsnSeries
@@ -347,22 +377,21 @@ public class IspHealthService
                 TargetIds = { t.TargetId },
                 Samples = ispSeries[t.TargetId],
                 HopIps = { t.Address }
-            }, Groupable: true))
-            .Concat(transitChart.Select(s => (Series: s, Groupable: false)))
-            .Concat(internetTargetSeries
-                .Where(s => s.HopIps.Any(ip => OutageInternetIps.Contains(ip)))
-                .Select(s => (Series: s, Groupable: false)));
+            }, Groupable: true, AsnLabel: AsnNameCleanup.Clean(t.AsnName) ?? accessAsnName))
+            .Concat(transitChart.Select(s => (Series: s, Groupable: false, AsnLabel: (string?)TransitLabel(s))))
+            .Concat(displayInternet.Select(s => (Series: s, Groupable: false, AsnLabel: (string?)null)));
         var outageHops = outageSources
             .Select(x => new
             {
                 x.Groupable,
+                x.AsnLabel,
                 Name = x.Series.AsnName ?? x.Series.TargetIds.FirstOrDefault() ?? "hop",
                 Series = (IReadOnlyList<LatencySample>)x.Series.Samples,
                 HopNumber = ClusterHopNumber(x.Series),
-                Rtt = SeriesStats.Median(x.Series.Samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList()) ?? double.MaxValue
+                Rtt = MedianRtt(x.Series)
             })
             .OrderBy(x => x.HopNumber).ThenBy(x => x.Rtt)
-            .Select((x, i) => new OutageDetector.Hop(x.Name, i, x.Series, x.Groupable))
+            .Select((x, i) => new OutageDetector.Hop(x.Name, i, x.Series, x.Groupable, x.AsnLabel))
             .ToList();
         var outages = OutageDetector.Detect(internetTriggerTargets, outageHops, _options);
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -15,6 +15,12 @@ public class IspHealthService
 {
     private static readonly string[] AnycastDnsIps = ["1.1.1.1", "1.0.0.1", "8.8.8.8", "8.8.4.4"];
 
+    // The internet endpoints that drive outage detection and the outage waterfall: just the two
+    // canonical anycast resolvers (Cloudflare, Google). 5+ internet rows on the waterfall is just
+    // clutter - two well-known resolvers convey "internet reachable" plainly. The rest still feed
+    // jitter-absolve and path-shift.
+    private static readonly string[] OutageInternetIps = ["1.1.1.1", "8.8.8.8"];
+
     private readonly MonitoringInfluxClient _influx;
     private readonly IDbContextFactory<NetworkOptimizerDbContext> _dbFactory;
     private readonly UniFiConnectionService _connectionService;
@@ -287,7 +293,8 @@ public class IspHealthService
                 && internetSeries.ContainsKey(t.TargetId))
             .Select(t => internetSeries[t.TargetId]));
 
-        var (ispGrading, transitGrading, allClusters, chartClusters) = BuildAsnSeriesSets(ispTargets, transitTargets, ispSeries, transitSeries, ancestorIpsByTargetId);
+        var (ispGrading, transitGrading, allClusters, ispChart, transitChart) = BuildAsnSeriesSets(ispTargets, transitTargets, ispSeries, transitSeries, ancestorIpsByTargetId);
+        var chartClusters = ispChart.Concat(transitChart).ToList();
         var internetTargetSeries = targets
             .Where(t => t.TargetType == MonitoringTargetType.InternetService && internetSeries.ContainsKey(t.TargetId))
             .Select(t => new AsnSeries
@@ -314,30 +321,48 @@ public class IspHealthService
         var pathShifts = StepChangeDetector.Detect(stepInput, _options);
 
         // Outage detection: the internet targets going dark defines an outage; every hop is
-        // carried (ordered nearest-first by median RTT, named from the DB) to shape it and
-        // attribute the break. A monitoring gap has no samples and so is never flagged.
+        // carried (ordered nearest-first by the hop map, RTT tiebreaker) to shape it and
+        // attribute the break. A monitoring gap has no samples and so is never flagged. Both
+        // the trigger and the internet rows are limited to the two canonical resolvers.
         var internetTriggerTargets = targets
-            .Where(t => t.TargetType == MonitoringTargetType.InternetService && internetSeries.ContainsKey(t.TargetId))
+            .Where(t => t.TargetType == MonitoringTargetType.InternetService
+                && OutageInternetIps.Contains(t.Address)
+                && internetSeries.ContainsKey(t.TargetId))
             .Select(t => (IReadOnlyList<LatencySample>)internetSeries[t.TargetId])
             .ToList();
-        // Shape the outage on the SAME per-ASN RTT clusters as the Per-Network RTT card
-        // (chartClusters carry merged loss samples and the cluster names), plus each internet
-        // destination. Ordered nearest-first by the persisted hop map (canonical), RTT as the
-        // tiebreaker and the fallback for untraced targets. So a co-located ASN's hops collapse
-        // to one waterfall row while a distinct-distance hop like the OLT stays on its own.
         int ClusterHopNumber(AsnSeries s) => s.TargetIds
             .Select(tid => hopNumberByTargetId.TryGetValue(tid, out var hn) ? hn : int.MaxValue)
             .DefaultIfEmpty(int.MaxValue).Min();
-        var outageHops = chartClusters.Concat(internetTargetSeries)
-            .Select(s => new
+        // Waterfall composition:
+        //  - Access ISP targets broken out per target (Groupable) so each access hop's own
+        //    outage timing shows; the detector re-collapses ones that share a signature.
+        //  - Transit kept as the per-ASN RTT clusters (the Per-Network RTT grouping), untouched.
+        //  - Internet limited to the two trigger resolvers (Cloudflare, Google).
+        var outageSources = ispTargets
+            .Where(t => ispSeries.ContainsKey(t.TargetId))
+            .Select(t => (Series: new AsnSeries
             {
-                Name = s.AsnName ?? s.TargetIds.FirstOrDefault() ?? "hop",
-                Series = (IReadOnlyList<LatencySample>)s.Samples,
-                HopNumber = ClusterHopNumber(s),
-                Rtt = SeriesStats.Median(s.Samples.Where(x => x.RttAvgMs.HasValue).Select(x => x.RttAvgMs!.Value).ToList()) ?? double.MaxValue
+                AsnNumber = t.AsnNumber ?? 0,
+                AsnName = t.Name,
+                TargetIds = { t.TargetId },
+                Samples = ispSeries[t.TargetId],
+                HopIps = { t.Address }
+            }, Groupable: true))
+            .Concat(transitChart.Select(s => (Series: s, Groupable: false)))
+            .Concat(internetTargetSeries
+                .Where(s => s.HopIps.Any(ip => OutageInternetIps.Contains(ip)))
+                .Select(s => (Series: s, Groupable: false)));
+        var outageHops = outageSources
+            .Select(x => new
+            {
+                x.Groupable,
+                Name = x.Series.AsnName ?? x.Series.TargetIds.FirstOrDefault() ?? "hop",
+                Series = (IReadOnlyList<LatencySample>)x.Series.Samples,
+                HopNumber = ClusterHopNumber(x.Series),
+                Rtt = SeriesStats.Median(x.Series.Samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList()) ?? double.MaxValue
             })
             .OrderBy(x => x.HopNumber).ThenBy(x => x.Rtt)
-            .Select((x, i) => new OutageDetector.Hop(x.Name, i, x.Series))
+            .Select((x, i) => new OutageDetector.Hop(x.Name, i, x.Series, x.Groupable))
             .ToList();
         var outages = OutageDetector.Detect(internetTriggerTargets, outageHops, _options);
 
@@ -613,7 +638,7 @@ public class IspHealthService
     ///   clusters still feed the detectors and chart as separately named series so
     ///   monitoring deep hops never inflates the ASN's grade.
     /// </summary>
-    private (List<AsnSeries> IspGrading, List<AsnSeries> TransitGrading, List<AsnSeries> AllClusters, List<AsnSeries> ChartClusters) BuildAsnSeriesSets(
+    private (List<AsnSeries> IspGrading, List<AsnSeries> TransitGrading, List<AsnSeries> AllClusters, List<AsnSeries> IspChart, List<AsnSeries> TransitChart) BuildAsnSeriesSets(
         List<MonitoringTarget> ispTargets,
         List<MonitoringTarget> transitTargets,
         Dictionary<string, List<LatencySample>> ispSeries,
@@ -661,7 +686,7 @@ public class IspHealthService
 
         return (ispGrading, transitGrading,
             ispClusters.Concat(transitClusters).ToList(),
-            ispChart.Concat(transitChart).ToList());
+            ispChart, transitChart);
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
@@ -19,9 +19,11 @@ public static class OutageDetector
     /// One monitored hop, carried for the outage shape and break attribution. <paramref name="Groupable"/>
     /// hops (the per-target access ISP rows) that end up sharing an outage signature are collapsed
     /// into one waterfall row; non-groupable hops (transit clusters, internet endpoints) always
-    /// stay on their own.
+    /// stay on their own. <paramref name="AsnLabel"/> is the ASN-level label a row prefers over its
+    /// per-target <paramref name="Name"/> (the PTR hostname); the detector disambiguates when one
+    /// ASN owns several rows. Null AsnLabel (internet endpoints) falls back to <paramref name="Name"/>.
     /// </summary>
-    public sealed record Hop(string Name, int Depth, IReadOnlyList<LatencySample> Series, bool Groupable = false);
+    public sealed record Hop(string Name, int Depth, IReadOnlyList<LatencySample> Series, bool Groupable = false, string? AsnLabel = null);
 
     /// <param name="triggerTargets">The internet/destination loss series whose near-total loss defines an outage.</param>
     /// <param name="hops">Every monitored hop, ordered by distance (Depth ascending = nearest first), for the shape.</param>
@@ -167,53 +169,79 @@ public static class OutageDetector
     /// <summary>
     /// Collapses groupable (access ISP) tiers that share an outage signature - recovery within
     /// <see cref="IspHealthOptions.OutageAccessGroupToleranceSeconds"/> - into one row, so a handful
-    /// of near-identical access hops don't each take a row. Access hops that recovered at a
-    /// distinctly different time (the inside-out heal, e.g. the OLT coming back first) stay
-    /// separate, and non-groupable tiers (transit clusters, internet endpoints) always do.
-    /// Returned nearest-first by depth.
+    /// of near-identical access hops don't each take a row, and labels every row by its ASN.
+    /// Access hops that recovered at a distinctly different time (the inside-out heal, e.g. the OLT
+    /// coming back first) stay separate. When one ASN owns several rows they're disambiguated:
+    /// a merged group reads "ASN (N hops)", a lone hop "ASN (hostname tail)"; a unique ASN just
+    /// shows its name. Non-groupable tiers (transit clusters, internet endpoints) always keep their
+    /// own row. Returned nearest-first by depth.
     /// </summary>
     private static List<OutageTierState> GroupAccessTiers(
         List<(Hop Hop, OutageTierState State)> tiers, IspHealthOptions options)
     {
         var tol = TimeSpan.FromSeconds(options.OutageAccessGroupToleranceSeconds);
-        var result = tiers.Where(t => !t.Hop.Groupable).Select(t => t.State).ToList();
-        var groupable = tiers.Where(t => t.Hop.Groupable).Select(t => t.State).ToList();
+        var result = new List<OutageTierState>();
 
-        // Stayed reachable, and went dark but never recovered, are each one shared signature.
-        AddMergedTier(result, groupable.Where(s => !s.WentDark).ToList());
-        AddMergedTier(result, groupable.Where(s => s.WentDark && !s.RecoveredAt.HasValue).ToList());
+        // Transit clusters and internet endpoints keep their own row, labeled by the ASN (transit)
+        // or the endpoint name (internet, AsnLabel null).
+        foreach (var (hop, state) in tiers.Where(t => !t.Hop.Groupable))
+            result.Add(Relabel(state, hop.AsnLabel ?? hop.Name));
 
-        // Dark and recovered: cluster by recovery time, a new cluster when the gap exceeds tol.
-        var cluster = new List<OutageTierState>();
-        foreach (var s in groupable.Where(s => s.WentDark && s.RecoveredAt.HasValue).OrderBy(s => s.RecoveredAt!.Value))
+        // Access hops: cluster by outage signature. "Up" and "dark, never recovered" are each one
+        // shared signature; "dark and recovered" clusters by recovery time within tolerance.
+        var groupable = tiers.Where(t => t.Hop.Groupable).ToList();
+        var groups = new List<List<(Hop Hop, OutageTierState State)>>();
+        void AddGroup(IEnumerable<(Hop, OutageTierState)> g) { var l = g.ToList(); if (l.Count > 0) groups.Add(l); }
+        AddGroup(groupable.Where(t => !t.State.WentDark));
+        AddGroup(groupable.Where(t => t.State.WentDark && !t.State.RecoveredAt.HasValue));
+        var cluster = new List<(Hop, OutageTierState)>();
+        foreach (var t in groupable.Where(t => t.State.WentDark && t.State.RecoveredAt.HasValue).OrderBy(t => t.State.RecoveredAt!.Value))
         {
-            if (cluster.Count > 0 && s.RecoveredAt!.Value - cluster[0].RecoveredAt!.Value > tol)
+            if (cluster.Count > 0 && t.State.RecoveredAt!.Value - cluster[0].Item2.RecoveredAt!.Value > tol)
             {
-                AddMergedTier(result, cluster);
-                cluster = new List<OutageTierState>();
+                groups.Add(cluster);
+                cluster = new List<(Hop, OutageTierState)>();
             }
-            cluster.Add(s);
+            cluster.Add(t);
         }
-        AddMergedTier(result, cluster);
+        if (cluster.Count > 0) groups.Add(cluster);
+
+        // A unique ASN shows just its name; several rows split into "(N hops)" / "(hostname tail)".
+        var rowsPerAsn = groups
+            .GroupBy(g => g[0].Hop.AsnLabel ?? g[0].Hop.Name)
+            .ToDictionary(x => x.Key, x => x.Count());
+        foreach (var g in groups)
+        {
+            var nearest = g.OrderBy(m => m.State.Depth).First();
+            var asn = nearest.Hop.AsnLabel ?? nearest.State.Name;
+            var name = rowsPerAsn[asn] == 1 ? asn
+                : g.Count > 1 ? $"{asn} ({g.Count} hops)"
+                : $"{asn} ({HostnameTail(nearest.Hop.Name, asn)})";
+            result.Add(new OutageTierState
+            {
+                Name = name,
+                Depth = nearest.State.Depth,
+                PeakLossPct = g.Max(m => m.State.PeakLossPct),
+                WentDark = g.Any(m => m.State.WentDark),
+                RecoveredAt = g.Where(m => m.State.RecoveredAt.HasValue).Select(m => m.State.RecoveredAt).DefaultIfEmpty(null).Min()
+            });
+        }
 
         return result.OrderBy(s => s.Depth).ToList();
     }
 
-    /// <summary>Adds a group of tiers as one row: a single member keeps its own row; several merge.</summary>
-    private static void AddMergedTier(List<OutageTierState> result, List<OutageTierState> members)
+    private static OutageTierState Relabel(OutageTierState s, string name) => new()
     {
-        if (members.Count == 0) return;
-        if (members.Count == 1) { result.Add(members[0]); return; }
-        var nearest = members.OrderBy(m => m.Depth).First();
-        result.Add(new OutageTierState
-        {
-            Name = $"{nearest.Name} +{members.Count - 1}",
-            Depth = nearest.Depth,
-            PeakLossPct = members.Max(m => m.PeakLossPct),
-            WentDark = members.Any(m => m.WentDark),
-            RecoveredAt = members.Where(m => m.RecoveredAt.HasValue).Select(m => m.RecoveredAt).DefaultIfEmpty(null).Min()
-        });
-    }
+        Name = name,
+        Depth = s.Depth,
+        PeakLossPct = s.PeakLossPct,
+        WentDark = s.WentDark,
+        RecoveredAt = s.RecoveredAt
+    };
+
+    /// <summary>The part of a per-target name after its ASN prefix ("AT&amp;T nokia-olt" -> "nokia-olt").</summary>
+    private static string HostnameTail(string name, string asn) =>
+        name.StartsWith(asn + " ", StringComparison.OrdinalIgnoreCase) ? name[(asn.Length + 1)..] : name;
 
     /// <summary>Actual timestamp of the first dark sample (loss at/above the dark threshold) in [start, end).</summary>
     private static DateTime? FirstDark(

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
@@ -190,33 +190,41 @@ public static class OutageDetector
         foreach (var (hop, state) in tiers.Where(t => !t.Hop.Groupable))
             result.Add(Relabel(state, hop.AsnLabel ?? hop.Name));
 
-        // Access hops: cluster by outage signature. "Up" and "dark, never recovered" are each one
-        // shared signature; "dark and recovered" clusters by recovery time within tolerance.
-        var groupable = tiers.Where(t => t.Hop.Groupable).ToList();
+        // Access hops: WITHIN each ASN, cluster by outage signature - never merge across ASNs (a
+        // dual-WAN could have two access ISPs recover at the same instant). "Up" and "dark, never
+        // recovered" are each one shared signature; "dark and recovered" clusters by recovery time.
         var groups = new List<List<(Hop Hop, OutageTierState State)>>();
         void AddGroup(IEnumerable<(Hop, OutageTierState)> g) { var l = g.ToList(); if (l.Count > 0) groups.Add(l); }
-        AddGroup(groupable.Where(t => !t.State.WentDark));
-        AddGroup(groupable.Where(t => t.State.WentDark && !t.State.RecoveredAt.HasValue));
-        var cluster = new List<(Hop, OutageTierState)>();
-        foreach (var t in groupable.Where(t => t.State.WentDark && t.State.RecoveredAt.HasValue).OrderBy(t => t.State.RecoveredAt!.Value))
+        foreach (var asnGroup in tiers.Where(t => t.Hop.Groupable).GroupBy(t => t.Hop.AsnLabel ?? t.Hop.Name))
         {
-            if (cluster.Count > 0 && t.State.RecoveredAt!.Value - cluster[0].Item2.RecoveredAt!.Value > tol)
+            var members = asnGroup.ToList();
+            AddGroup(members.Where(t => !t.State.WentDark));
+            AddGroup(members.Where(t => t.State.WentDark && !t.State.RecoveredAt.HasValue));
+            var cluster = new List<(Hop, OutageTierState)>();
+            foreach (var t in members.Where(t => t.State.WentDark && t.State.RecoveredAt.HasValue).OrderBy(t => t.State.RecoveredAt!.Value))
             {
-                groups.Add(cluster);
-                cluster = new List<(Hop, OutageTierState)>();
+                if (cluster.Count > 0 && t.State.RecoveredAt!.Value - cluster[0].Item2.RecoveredAt!.Value > tol)
+                {
+                    groups.Add(cluster);
+                    cluster = new List<(Hop, OutageTierState)>();
+                }
+                cluster.Add(t);
             }
-            cluster.Add(t);
+            if (cluster.Count > 0) groups.Add(cluster);
         }
-        if (cluster.Count > 0) groups.Add(cluster);
 
         // A unique ASN shows just its name; several rows split into "(N hops)" / "(hostname tail)".
-        var rowsPerAsn = groups
-            .GroupBy(g => g[0].Hop.AsnLabel ?? g[0].Hop.Name)
-            .ToDictionary(x => x.Key, x => x.Count());
+        // Key and lookup use the SAME nearest-hop expression so they never diverge.
+        static string AsnOf(List<(Hop Hop, OutageTierState State)> g)
+        {
+            var n = g.OrderBy(m => m.State.Depth).First().Hop;
+            return n.AsnLabel ?? n.Name;
+        }
+        var rowsPerAsn = groups.GroupBy(AsnOf).ToDictionary(x => x.Key, x => x.Count());
         foreach (var g in groups)
         {
             var nearest = g.OrderBy(m => m.State.Depth).First();
-            var asn = nearest.Hop.AsnLabel ?? nearest.State.Name;
+            var asn = AsnOf(g);
             var name = rowsPerAsn[asn] == 1 ? asn
                 : g.Count > 1 ? $"{asn} ({g.Count} hops)"
                 : $"{asn} ({HostnameTail(nearest.Hop.Name, asn)})";

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
@@ -15,8 +15,13 @@ namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
 /// </summary>
 public static class OutageDetector
 {
-    /// <summary>One monitored hop, carried for the outage shape and break attribution.</summary>
-    public sealed record Hop(string Name, int Depth, IReadOnlyList<LatencySample> Series);
+    /// <summary>
+    /// One monitored hop, carried for the outage shape and break attribution. <paramref name="Groupable"/>
+    /// hops (the per-target access ISP rows) that end up sharing an outage signature are collapsed
+    /// into one waterfall row; non-groupable hops (transit clusters, internet endpoints) always
+    /// stay on their own.
+    /// </summary>
+    public sealed record Hop(string Name, int Depth, IReadOnlyList<LatencySample> Series, bool Groupable = false);
 
     /// <param name="triggerTargets">The internet/destination loss series whose near-total loss defines an outage.</param>
     /// <param name="hops">Every monitored hop, ordered by distance (Depth ascending = nearest first), for the shape.</param>
@@ -91,7 +96,7 @@ public static class OutageDetector
         Dictionary<Hop, Dictionary<DateTime, List<double>>> hopBuckets,
         IspHealthOptions options)
     {
-        var states = new List<OutageTierState>();
+        var tiers = new List<(Hop Hop, OutageTierState State)>();
         // A hop on the broken path stays dark for (most of) the outage; a hop that merely
         // blipped at onset then held - like the OLT, which recovered ~10 min before the
         // upstream in the validation data - is NOT the break and must read as reachable.
@@ -117,7 +122,7 @@ public static class OutageDetector
                 }
             }
             onBrokenPath[hop.Depth] = totalBuckets > 0 && (double)darkBuckets / totalBuckets >= 0.5;
-            states.Add(new OutageTierState
+            tiers.Add((hop, new OutageTierState
             {
                 Name = hop.Name,
                 Depth = hop.Depth,
@@ -130,11 +135,13 @@ public static class OutageDetector
                 RecoveredAt = lastDarkBucket.HasValue
                     ? RecoveryAfter(hop.Series, lastDarkBucket.Value, options.OutageDarkLossPct)
                     : null
-            });
+            }));
         }
 
         // The break sits just beyond the deepest hop that stayed reachable through the
         // outage. If even the nearest hop was dark for most of it, the whole WAN dropped.
+        // Attribution runs on the per-hop (ungrouped) states so it can name the precise hop.
+        var states = tiers.Select(t => t.State).ToList();
         var nearest = states.OrderBy(s => s.Depth).FirstOrDefault();
         var lastReachable = states.Where(s => !onBrokenPath[s.Depth]).OrderByDescending(s => s.Depth).FirstOrDefault();
         var scope = nearest == null || onBrokenPath[nearest.Depth] || lastReachable == null
@@ -153,8 +160,59 @@ public static class OutageDetector
             End = recovery,
             Scope = scope,
             LastReachableHop = scope == OutageScope.Upstream ? lastReachable!.Name : null,
-            Tiers = states
+            Tiers = GroupAccessTiers(tiers, options)
         };
+    }
+
+    /// <summary>
+    /// Collapses groupable (access ISP) tiers that share an outage signature - recovery within
+    /// <see cref="IspHealthOptions.OutageAccessGroupToleranceSeconds"/> - into one row, so a handful
+    /// of near-identical access hops don't each take a row. Access hops that recovered at a
+    /// distinctly different time (the inside-out heal, e.g. the OLT coming back first) stay
+    /// separate, and non-groupable tiers (transit clusters, internet endpoints) always do.
+    /// Returned nearest-first by depth.
+    /// </summary>
+    private static List<OutageTierState> GroupAccessTiers(
+        List<(Hop Hop, OutageTierState State)> tiers, IspHealthOptions options)
+    {
+        var tol = TimeSpan.FromSeconds(options.OutageAccessGroupToleranceSeconds);
+        var result = tiers.Where(t => !t.Hop.Groupable).Select(t => t.State).ToList();
+        var groupable = tiers.Where(t => t.Hop.Groupable).Select(t => t.State).ToList();
+
+        // Stayed reachable, and went dark but never recovered, are each one shared signature.
+        AddMergedTier(result, groupable.Where(s => !s.WentDark).ToList());
+        AddMergedTier(result, groupable.Where(s => s.WentDark && !s.RecoveredAt.HasValue).ToList());
+
+        // Dark and recovered: cluster by recovery time, a new cluster when the gap exceeds tol.
+        var cluster = new List<OutageTierState>();
+        foreach (var s in groupable.Where(s => s.WentDark && s.RecoveredAt.HasValue).OrderBy(s => s.RecoveredAt!.Value))
+        {
+            if (cluster.Count > 0 && s.RecoveredAt!.Value - cluster[0].RecoveredAt!.Value > tol)
+            {
+                AddMergedTier(result, cluster);
+                cluster = new List<OutageTierState>();
+            }
+            cluster.Add(s);
+        }
+        AddMergedTier(result, cluster);
+
+        return result.OrderBy(s => s.Depth).ToList();
+    }
+
+    /// <summary>Adds a group of tiers as one row: a single member keeps its own row; several merge.</summary>
+    private static void AddMergedTier(List<OutageTierState> result, List<OutageTierState> members)
+    {
+        if (members.Count == 0) return;
+        if (members.Count == 1) { result.Add(members[0]); return; }
+        var nearest = members.OrderBy(m => m.Depth).First();
+        result.Add(new OutageTierState
+        {
+            Name = $"{nearest.Name} +{members.Count - 1}",
+            Depth = nearest.Depth,
+            PeakLossPct = members.Max(m => m.PeakLossPct),
+            WentDark = members.Any(m => m.WentDark),
+            RecoveredAt = members.Where(m => m.RecoveredAt.HasValue).Select(m => m.RecoveredAt).DefaultIfEmpty(null).Min()
+        });
     }
 
     /// <summary>Actual timestamp of the first dark sample (loss at/above the dark threshold) in [start, end).</summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
@@ -123,7 +123,10 @@ public static class OutageDetector
                     lastDarkBucket = bucketStart;
                 }
             }
-            onBrokenPath[hop.Depth] = totalBuckets > 0 && (double)darkBuckets / totalBuckets >= 0.5;
+            // No samples in the outage window means the target didn't exist or wasn't enabled
+            // then - it has nothing to say about this outage, so don't give it a row.
+            if (totalBuckets == 0) continue;
+            onBrokenPath[hop.Depth] = (double)darkBuckets / totalBuckets >= 0.5;
             tiers.Add((hop, new OutageTierState
             {
                 Name = hop.Name,

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15342,7 +15342,7 @@ tr.stats-row-filtered {
 }
 
 .isp-health-card .issue-item + .issue-item {
-    margin-top: 0.5rem;
+    margin-top: 0.75rem;
 }
 
 .isp-health-card .issue-severity {

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
@@ -236,8 +236,8 @@ public class OutageDetectorTests
         var hops = new[]
         {
             new OutageDetector.Hop("AT&T nokia-olt", 0, olt, Groupable: true, AsnLabel: "AT&T"),
-            new OutageDetector.Hop("AT&T lightspeed-1", 1, accessLate1, Groupable: true, AsnLabel: "AT&T"),
-            new OutageDetector.Hop("AT&T lightspeed-2", 2, accessLate2, Groupable: true, AsnLabel: "AT&T"),
+            new OutageDetector.Hop("AT&T hop-1", 1, accessLate1, Groupable: true, AsnLabel: "AT&T"),
+            new OutageDetector.Hop("AT&T hop-2", 2, accessLate2, Groupable: true, AsnLabel: "AT&T"),
             new OutageDetector.Hop("Cloudflare", 3, internet1),
             new OutageDetector.Hop("Google", 4, internet2),
         };

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
@@ -222,4 +222,36 @@ public class OutageDetectorTests
         events[0].Tiers.Where(t => t.RecoveredAt.HasValue)
             .Should().OnlyContain(t => t.RecoveredAt!.Value.Second == 17);
     }
+
+    [Fact]
+    public void Groupable_access_hops_with_the_same_signature_merge_distinct_ones_stay_separate()
+    {
+        var internet1 = Series(0, (OutStart, OutEnd, 100));
+        var internet2 = Series(0, (OutStart, OutEnd, 100));
+        // Two access hops recover together (dark the whole outage); one recovers minutes earlier.
+        var accessEarly = Series(0, (OutStart, OutStart.AddMinutes(3), 100));
+        var accessLate1 = Series(0, (OutStart, OutEnd, 100));
+        var accessLate2 = Series(0, (OutStart, OutEnd, 100));
+
+        var hops = new[]
+        {
+            new OutageDetector.Hop("Access A", 0, accessEarly, Groupable: true),
+            new OutageDetector.Hop("Access B", 1, accessLate1, Groupable: true),
+            new OutageDetector.Hop("Access C", 2, accessLate2, Groupable: true),
+            new OutageDetector.Hop("Cloudflare", 3, internet1),
+            new OutageDetector.Hop("Google", 4, internet2),
+        };
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), hops, Options);
+
+        events.Should().ContainSingle();
+        var access = events[0].Tiers.Where(t => t.Name.StartsWith("Access")).ToList();
+        // The early hop keeps its own row; the two that recovered together collapse into one.
+        access.Should().HaveCount(2);
+        access.Should().Contain(t => t.Name == "Access A");
+        access.Should().Contain(t => t.Name == "Access B +1");
+        // Internet endpoints are never grouped.
+        events[0].Tiers.Should().Contain(t => t.Name == "Cloudflare");
+        events[0].Tiers.Should().Contain(t => t.Name == "Google");
+    }
 }

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
@@ -277,4 +277,26 @@ public class OutageDetectorTests
         events[0].Tiers.Should().Contain(t => t.Name == "AT&T");
         events[0].Tiers.Should().NotContain(t => t.Name.Contains("nokia-olt"));
     }
+
+    [Fact]
+    public void A_target_with_no_data_during_the_outage_is_not_listed()
+    {
+        var internet1 = Series(0, (OutStart, OutEnd, 100));
+        var internet2 = Series(0, (OutStart, OutEnd, 100));
+        // A hop that only started reporting after the outage ended (didn't exist during it).
+        var addedLater = TestSeries.Flat(OutEnd, TimeSpan.FromMinutes(5), rttMs: 20, jitterMs: 0.5, lossPct: 0);
+
+        var hops = new[]
+        {
+            new OutageDetector.Hop("Late Hop", 0, addedLater, Groupable: true, AsnLabel: "Late"),
+            new OutageDetector.Hop("Cloudflare", 1, internet1),
+            new OutageDetector.Hop("Google", 2, internet2),
+        };
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), hops, Options);
+
+        events.Should().ContainSingle();
+        events[0].Tiers.Should().NotContain(t => t.Name.Contains("Late"));
+        events[0].Tiers.Should().Contain(t => t.Name == "Cloudflare");
+    }
 }

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
@@ -299,4 +299,26 @@ public class OutageDetectorTests
         events[0].Tiers.Should().NotContain(t => t.Name.Contains("Late"));
         events[0].Tiers.Should().Contain(t => t.Name == "Cloudflare");
     }
+
+    [Fact]
+    public void Outage_with_no_in_window_hop_data_reports_with_no_tiers_and_does_not_throw()
+    {
+        // A fresh install backfilling: the internet trigger has data, but every monitored hop
+        // only started reporting after the window. The outage is still flagged; nothing crashes.
+        var internet1 = Series(0, (OutStart, OutEnd, 100));
+        var internet2 = Series(0, (OutStart, OutEnd, 100));
+        var lateOnly = TestSeries.Flat(OutEnd, TimeSpan.FromMinutes(5), rttMs: 20, jitterMs: 0.5, lossPct: 0);
+        var hops = new[]
+        {
+            new OutageDetector.Hop("Late A", 0, lateOnly, Groupable: true, AsnLabel: "Late"),
+            new OutageDetector.Hop("Late B", 1, lateOnly, Groupable: false),
+        };
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), hops, Options);
+
+        events.Should().ContainSingle();
+        events[0].Tiers.Should().BeEmpty();
+        events[0].Scope.Should().Be(OutageScope.FullWan);
+        events[0].LastReachableHop.Should().BeNull();
+    }
 }

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
@@ -228,16 +228,16 @@ public class OutageDetectorTests
     {
         var internet1 = Series(0, (OutStart, OutEnd, 100));
         var internet2 = Series(0, (OutStart, OutEnd, 100));
-        // Two access hops recover together (dark the whole outage); one recovers minutes earlier.
-        var accessEarly = Series(0, (OutStart, OutStart.AddMinutes(3), 100));
+        // Two AT&T access hops recover together (dark the whole outage); the OLT recovers earlier.
+        var olt = Series(0, (OutStart, OutStart.AddMinutes(3), 100));
         var accessLate1 = Series(0, (OutStart, OutEnd, 100));
         var accessLate2 = Series(0, (OutStart, OutEnd, 100));
 
         var hops = new[]
         {
-            new OutageDetector.Hop("Access A", 0, accessEarly, Groupable: true),
-            new OutageDetector.Hop("Access B", 1, accessLate1, Groupable: true),
-            new OutageDetector.Hop("Access C", 2, accessLate2, Groupable: true),
+            new OutageDetector.Hop("AT&T nokia-olt", 0, olt, Groupable: true, AsnLabel: "AT&T"),
+            new OutageDetector.Hop("AT&T lightspeed-1", 1, accessLate1, Groupable: true, AsnLabel: "AT&T"),
+            new OutageDetector.Hop("AT&T lightspeed-2", 2, accessLate2, Groupable: true, AsnLabel: "AT&T"),
             new OutageDetector.Hop("Cloudflare", 3, internet1),
             new OutageDetector.Hop("Google", 4, internet2),
         };
@@ -245,13 +245,36 @@ public class OutageDetectorTests
         var events = OutageDetector.Detect(Triggers(internet1, internet2), hops, Options);
 
         events.Should().ContainSingle();
-        var access = events[0].Tiers.Where(t => t.Name.StartsWith("Access")).ToList();
-        // The early hop keeps its own row; the two that recovered together collapse into one.
+        var access = events[0].Tiers.Where(t => t.Name.StartsWith("AT&T")).ToList();
+        // Same ASN owns two rows, so each is disambiguated: the lone early OLT by its hostname
+        // tail, the two that recovered together by a hop count.
         access.Should().HaveCount(2);
-        access.Should().Contain(t => t.Name == "Access A");
-        access.Should().Contain(t => t.Name == "Access B +1");
-        // Internet endpoints are never grouped.
+        access.Should().Contain(t => t.Name == "AT&T (nokia-olt)");
+        access.Should().Contain(t => t.Name == "AT&T (2 hops)");
+        // Internet endpoints keep their own names and are never grouped.
         events[0].Tiers.Should().Contain(t => t.Name == "Cloudflare");
         events[0].Tiers.Should().Contain(t => t.Name == "Google");
+    }
+
+    [Fact]
+    public void A_unique_access_asn_shows_just_the_asn_name()
+    {
+        var internet1 = Series(0, (OutStart, OutEnd, 100));
+        var internet2 = Series(0, (OutStart, OutEnd, 100));
+        var access = Series(0, (OutStart, OutEnd, 100));
+
+        var hops = new[]
+        {
+            new OutageDetector.Hop("AT&T nokia-olt", 0, access, Groupable: true, AsnLabel: "AT&T"),
+            new OutageDetector.Hop("Cloudflare", 1, internet1),
+            new OutageDetector.Hop("Google", 2, internet2),
+        };
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), hops, Options);
+
+        events.Should().ContainSingle();
+        // One access row for the ASN -> no disambiguation, just the ASN name.
+        events[0].Tiers.Should().Contain(t => t.Name == "AT&T");
+        events[0].Tiers.Should().NotContain(t => t.Name.Contains("nokia-olt"));
     }
 }


### PR DESCRIPTION
## Summary

Refines the internet-outage waterfall so it shows what actually happened inside your access ISP during an outage, and cleans up the row labels.

## What changed

- **Access ISP hops are broken out per target.** The waterfall used to collapse every access hop in an ASN into one merged row, hiding which hop went down and which recovered first. Each access target now shows its own outage timing, so the inside-out heal (e.g. the access OLT coming back before the rest) is visible.
- **Same-signature access hops regroup.** Access hops that recovered within a few seconds of each other (default 10s) collapse back into one row, so a handful of near-identical hops don't each take a line. Different recovery times stay separate.
- **Every row is labeled by its ASN.** A transit row shows the ASN ("Level 3") instead of a probe's target name; when an ASN owns several rows they're disambiguated - a merged access group reads "ASN (N hops)", a lone hop "ASN (hostname tail)". An ASN that's both your access network and a transit hop gets a " Transit" suffix on the transit row.
- **Internet rows trimmed to two.** The waterfall shows just two internet endpoints (Cloudflare/Google, falling back to the two nearest others if those aren't monitored) - more than that is clutter. Outage **detection still triggers on all internet targets**, so this is display-only.
- **Targets with no data during the outage are omitted.** A target that didn't exist or wasn't enabled during the outage window no longer appears as a spurious "stayed up" row.

## Robustness

Handles new installs and sparse data: no/one internet target, missing access or transit data, and hops that only started reporting after the window all degrade gracefully rather than throwing. No InfluxDB schema or write-path changes (read/compute only).

## Tests

New coverage for the signature grouping, ASN-based labels and disambiguation, omission of no-data targets, and the empty-tiers fresh-install path.