### PR TITLE
v1.21.2

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -200,7 +200,7 @@ else
                             <p class="page-description">No ISP hop data in the window.</p>
                         }
                         <div class="isp-hop-list">
-                            @foreach (var target in r.IspTargets)
+                            @foreach (var target in r.IspTargets.OrderBy(t => t.RttMs ?? double.MaxValue))
                             {
                                 <div class="isp-hop">
                                     <div class="isp-hop-row">

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -198,6 +198,15 @@ public class IspHealthOptions
     public int OutageMinDurationMinutes { get; set; } = 2;
 
     /// <summary>
+    /// Two outage runs separated by a healthy gap no longer than this are coalesced into one
+    /// event. One real outage briefly clears the dark-fraction gate during staggered onset or
+    /// inside-out recovery (targets dark/heal at slightly different minutes); without this it
+    /// would fragment into several adjacent events. The sealed gap counts as downtime, so keep
+    /// it short - the over-count is bounded by this value per seam.
+    /// </summary>
+    public int OutageMaxGapMinutes { get; set; } = 3;
+
+    /// <summary>
     /// Recovery-time tolerance for collapsing per-target access ISP rows in the outage waterfall:
     /// access hops that recovered within this many seconds of each other share a signature and
     /// merge to one row; ones outside it stay separate (the inside-out heal).

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -198,6 +198,13 @@ public class IspHealthOptions
     public int OutageMinDurationMinutes { get; set; } = 2;
 
     /// <summary>
+    /// Recovery-time tolerance for collapsing per-target access ISP rows in the outage waterfall:
+    /// access hops that recovered within this many seconds of each other share a signature and
+    /// merge to one row; ones outside it stay separate (the inside-out heal).
+    /// </summary>
+    public int OutageAccessGroupToleranceSeconds { get; set; } = 10;
+
+    /// <summary>
     /// Outage severity curve: points deducted from the OVERALL score per (totalDowntimeMinutes,
     /// penaltyPoints) anchor, interpolated. Applied at the top level rather than buried in the
     /// Packet Loss factor (where the dimension weights would dilute a multi-hour outage to a

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -15,6 +15,12 @@ public class IspHealthService
 {
     private static readonly string[] AnycastDnsIps = ["1.1.1.1", "1.0.0.1", "8.8.8.8", "8.8.4.4"];
 
+    // The internet endpoints SHOWN on the outage waterfall: just the two canonical anycast
+    // resolvers (Cloudflare, Google). 5+ internet rows is just clutter - two well-known resolvers
+    // convey "internet reachable" plainly. Detection still triggers on every internet target; this
+    // only trims the displayed rows.
+    private static readonly string[] OutageInternetIps = ["1.1.1.1", "8.8.8.8"];
+
     private readonly MonitoringInfluxClient _influx;
     private readonly IDbContextFactory<NetworkOptimizerDbContext> _dbFactory;
     private readonly UniFiConnectionService _connectionService;
@@ -287,7 +293,8 @@ public class IspHealthService
                 && internetSeries.ContainsKey(t.TargetId))
             .Select(t => internetSeries[t.TargetId]));
 
-        var (ispGrading, transitGrading, allClusters, chartClusters) = BuildAsnSeriesSets(ispTargets, transitTargets, ispSeries, transitSeries, ancestorIpsByTargetId);
+        var (ispGrading, transitGrading, allClusters, ispChart, transitChart) = BuildAsnSeriesSets(ispTargets, transitTargets, ispSeries, transitSeries, ancestorIpsByTargetId);
+        var chartClusters = ispChart.Concat(transitChart).ToList();
         var internetTargetSeries = targets
             .Where(t => t.TargetType == MonitoringTargetType.InternetService && internetSeries.ContainsKey(t.TargetId))
             .Select(t => new AsnSeries
@@ -314,30 +321,77 @@ public class IspHealthService
         var pathShifts = StepChangeDetector.Detect(stepInput, _options);
 
         // Outage detection: the internet targets going dark defines an outage; every hop is
-        // carried (ordered nearest-first by median RTT, named from the DB) to shape it and
-        // attribute the break. A monitoring gap has no samples and so is never flagged.
+        // carried (ordered nearest-first by the hop map, RTT tiebreaker) to shape it and
+        // attribute the break. A monitoring gap has no samples and so is never flagged. The
+        // trigger keeps ALL internet targets (robust detection); only the waterfall's internet
+        // rows are trimmed to the two canonical resolvers below.
         var internetTriggerTargets = targets
             .Where(t => t.TargetType == MonitoringTargetType.InternetService && internetSeries.ContainsKey(t.TargetId))
             .Select(t => (IReadOnlyList<LatencySample>)internetSeries[t.TargetId])
             .ToList();
-        // Shape the outage on the SAME per-ASN RTT clusters as the Per-Network RTT card
-        // (chartClusters carry merged loss samples and the cluster names), plus each internet
-        // destination. Ordered nearest-first by the persisted hop map (canonical), RTT as the
-        // tiebreaker and the fallback for untraced targets. So a co-located ASN's hops collapse
-        // to one waterfall row while a distinct-distance hop like the OLT stays on its own.
         int ClusterHopNumber(AsnSeries s) => s.TargetIds
             .Select(tid => hopNumberByTargetId.TryGetValue(tid, out var hn) ? hn : int.MaxValue)
             .DefaultIfEmpty(int.MaxValue).Min();
-        var outageHops = chartClusters.Concat(internetTargetSeries)
-            .Select(s => new
+        double MedianRtt(AsnSeries s) => SeriesStats.Median(
+            s.Samples.Where(x => x.RttAvgMs.HasValue).Select(x => x.RttAvgMs!.Value).ToList()) ?? double.MaxValue;
+        // The two internet rows for the waterfall: prefer Cloudflare/Google, but if the user
+        // doesn't monitor them, fall back to the two nearest other internet targets so the
+        // waterfall still shows an internet-reachability row.
+        var displayInternet = internetTargetSeries
+            .Where(s => s.HopIps.Any(ip => OutageInternetIps.Contains(ip)))
+            .Concat(internetTargetSeries
+                .Where(s => !s.HopIps.Any(ip => OutageInternetIps.Contains(ip)))
+                .OrderBy(MedianRtt))
+            .Take(2)
+            .ToList();
+        // Each waterfall row is labeled by its ASN. Access ISP and Transit can both be the same
+        // ASN (e.g. AT&T is both the access network and a transit hop), so a transit row whose ASN
+        // also appears in the access layer is suffixed " Transit" to disambiguate it.
+        var accessAsnNumbers = ispTargets.Where(t => t.AsnNumber is > 0).Select(t => t.AsnNumber!.Value).ToHashSet();
+        var accessAsnName = ispTargets.Select(t => AsnNameCleanup.Clean(t.AsnName)).FirstOrDefault(n => !string.IsNullOrEmpty(n));
+        var transitAsnNameByNumber = transitTargets
+            .Where(t => t.AsnNumber is > 0 && !string.IsNullOrEmpty(t.AsnName))
+            .GroupBy(t => t.AsnNumber!.Value)
+            .ToDictionary(g => g.Key, g => AsnNameCleanup.Clean(g.Select(t => t.AsnName).First()) ?? "");
+        string TransitLabel(AsnSeries s)
+        {
+            // Single-member transit clusters carry the target's own name; prefer the ASN. Multi /
+            // deeper clusters already carry an ASN-based name ("ASN (+N ms hop)"), so keep it.
+            var asn = transitAsnNameByNumber.GetValueOrDefault(s.AsnNumber);
+            var label = s.TargetIds.Count == 1 && !string.IsNullOrEmpty(asn) ? asn : AsnNameCleanup.Clean(s.AsnName) ?? asn ?? "transit";
+            if (accessAsnNumbers.Contains(s.AsnNumber) && !label.EndsWith("Transit", StringComparison.OrdinalIgnoreCase))
+                label += " Transit";
+            return label;
+        }
+        // Waterfall composition:
+        //  - Access ISP targets broken out per target (Groupable, labeled by access ASN) so each
+        //    access hop's own outage timing shows; the detector re-collapses shared signatures.
+        //  - Transit kept as the per-ASN RTT clusters (the Per-Network RTT grouping), untouched.
+        //  - Internet trimmed to two rows (displayInternet).
+        var outageSources = ispTargets
+            .Where(t => ispSeries.ContainsKey(t.TargetId))
+            .Select(t => (Series: new AsnSeries
             {
-                Name = s.AsnName ?? s.TargetIds.FirstOrDefault() ?? "hop",
-                Series = (IReadOnlyList<LatencySample>)s.Samples,
-                HopNumber = ClusterHopNumber(s),
-                Rtt = SeriesStats.Median(s.Samples.Where(x => x.RttAvgMs.HasValue).Select(x => x.RttAvgMs!.Value).ToList()) ?? double.MaxValue
+                AsnNumber = t.AsnNumber ?? 0,
+                AsnName = t.Name,
+                TargetIds = { t.TargetId },
+                Samples = ispSeries[t.TargetId],
+                HopIps = { t.Address }
+            }, Groupable: true, AsnLabel: AsnNameCleanup.Clean(t.AsnName) ?? accessAsnName))
+            .Concat(transitChart.Select(s => (Series: s, Groupable: false, AsnLabel: (string?)TransitLabel(s))))
+            .Concat(displayInternet.Select(s => (Series: s, Groupable: false, AsnLabel: (string?)null)));
+        var outageHops = outageSources
+            .Select(x => new
+            {
+                x.Groupable,
+                x.AsnLabel,
+                Name = x.Series.AsnName ?? x.Series.TargetIds.FirstOrDefault() ?? "hop",
+                Series = (IReadOnlyList<LatencySample>)x.Series.Samples,
+                HopNumber = ClusterHopNumber(x.Series),
+                Rtt = MedianRtt(x.Series)
             })
             .OrderBy(x => x.HopNumber).ThenBy(x => x.Rtt)
-            .Select((x, i) => new OutageDetector.Hop(x.Name, i, x.Series))
+            .Select((x, i) => new OutageDetector.Hop(x.Name, i, x.Series, x.Groupable, x.AsnLabel))
             .ToList();
         var outages = OutageDetector.Detect(internetTriggerTargets, outageHops, _options);
 
@@ -613,7 +667,7 @@ public class IspHealthService
     ///   clusters still feed the detectors and chart as separately named series so
     ///   monitoring deep hops never inflates the ASN's grade.
     /// </summary>
-    private (List<AsnSeries> IspGrading, List<AsnSeries> TransitGrading, List<AsnSeries> AllClusters, List<AsnSeries> ChartClusters) BuildAsnSeriesSets(
+    private (List<AsnSeries> IspGrading, List<AsnSeries> TransitGrading, List<AsnSeries> AllClusters, List<AsnSeries> IspChart, List<AsnSeries> TransitChart) BuildAsnSeriesSets(
         List<MonitoringTarget> ispTargets,
         List<MonitoringTarget> transitTargets,
         Dictionary<string, List<LatencySample>> ispSeries,
@@ -661,7 +715,7 @@ public class IspHealthService
 
         return (ispGrading, transitGrading,
             ispClusters.Concat(transitClusters).ToList(),
-            ispChart.Concat(transitChart).ToList());
+            ispChart, transitChart);
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
@@ -48,19 +48,36 @@ public static class OutageDetector
 
         var hopBuckets = hops.ToDictionary(h => h, h => BucketTargets(new[] { h.Series }, windowSize));
 
-        var events = new List<OutageEvent>();
-        var minDuration = TimeSpan.FromMinutes(options.OutageMinDurationMinutes);
+        // Contiguous runs of outage buckets (gap of one window ends a run), then coalesce
+        // runs separated by a short healthy gap (OutageMaxGapMinutes). One real outage dips
+        // below the dark-fraction gate for a bucket or two during staggered onset/recovery
+        // (targets go dark and heal at slightly different times) - without the coalesce that
+        // shatters it into several events. Sealing the gap before duration-filtering also lets
+        // two sub-min-duration runs straddling a blip add up to one qualifying outage.
+        var runs = new List<(DateTime Start, DateTime End)>();
         for (var i = 0; i < outageBuckets.Count;)
         {
-            // Extend a run over adjacent (contiguous) outage buckets; a non-outage bucket ends it.
             var j = i;
             while (j + 1 < outageBuckets.Count && outageBuckets[j + 1] - outageBuckets[j] <= windowSize)
                 j++;
-
-            var start = outageBuckets[i];
-            var end = outageBuckets[j] + windowSize; // through the last dark bucket
+            runs.Add((outageBuckets[i], outageBuckets[j] + windowSize)); // through the last dark bucket
             i = j + 1;
+        }
 
+        var maxGap = TimeSpan.FromMinutes(options.OutageMaxGapMinutes);
+        var merged = new List<(DateTime Start, DateTime End)>();
+        foreach (var run in runs)
+        {
+            if (merged.Count > 0 && run.Start - merged[^1].End <= maxGap)
+                merged[^1] = (merged[^1].Start, run.End);
+            else
+                merged.Add(run);
+        }
+
+        var events = new List<OutageEvent>();
+        var minDuration = TimeSpan.FromMinutes(options.OutageMinDurationMinutes);
+        foreach (var (start, end) in merged)
+        {
             if (end - start < minDuration) continue;
             events.Add(BuildEvent(start, end, triggerTargets, hops, hopBuckets, options));
         }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
@@ -15,8 +15,15 @@ namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
 /// </summary>
 public static class OutageDetector
 {
-    /// <summary>One monitored hop, carried for the outage shape and break attribution.</summary>
-    public sealed record Hop(string Name, int Depth, IReadOnlyList<LatencySample> Series);
+    /// <summary>
+    /// One monitored hop, carried for the outage shape and break attribution. <paramref name="Groupable"/>
+    /// hops (the per-target access ISP rows) that end up sharing an outage signature are collapsed
+    /// into one waterfall row; non-groupable hops (transit clusters, internet endpoints) always
+    /// stay on their own. <paramref name="AsnLabel"/> is the ASN-level label a row prefers over its
+    /// per-target <paramref name="Name"/> (the PTR hostname); the detector disambiguates when one
+    /// ASN owns several rows. Null AsnLabel (internet endpoints) falls back to <paramref name="Name"/>.
+    /// </summary>
+    public sealed record Hop(string Name, int Depth, IReadOnlyList<LatencySample> Series, bool Groupable = false, string? AsnLabel = null);
 
     /// <param name="triggerTargets">The internet/destination loss series whose near-total loss defines an outage.</param>
     /// <param name="hops">Every monitored hop, ordered by distance (Depth ascending = nearest first), for the shape.</param>
@@ -91,7 +98,7 @@ public static class OutageDetector
         Dictionary<Hop, Dictionary<DateTime, List<double>>> hopBuckets,
         IspHealthOptions options)
     {
-        var states = new List<OutageTierState>();
+        var tiers = new List<(Hop Hop, OutageTierState State)>();
         // A hop on the broken path stays dark for (most of) the outage; a hop that merely
         // blipped at onset then held - like the OLT, which recovered ~10 min before the
         // upstream in the validation data - is NOT the break and must read as reachable.
@@ -116,8 +123,11 @@ public static class OutageDetector
                     lastDarkBucket = bucketStart;
                 }
             }
-            onBrokenPath[hop.Depth] = totalBuckets > 0 && (double)darkBuckets / totalBuckets >= 0.5;
-            states.Add(new OutageTierState
+            // No samples in the outage window means the target didn't exist or wasn't enabled
+            // then - it has nothing to say about this outage, so don't give it a row.
+            if (totalBuckets == 0) continue;
+            onBrokenPath[hop.Depth] = (double)darkBuckets / totalBuckets >= 0.5;
+            tiers.Add((hop, new OutageTierState
             {
                 Name = hop.Name,
                 Depth = hop.Depth,
@@ -130,11 +140,13 @@ public static class OutageDetector
                 RecoveredAt = lastDarkBucket.HasValue
                     ? RecoveryAfter(hop.Series, lastDarkBucket.Value, options.OutageDarkLossPct)
                     : null
-            });
+            }));
         }
 
         // The break sits just beyond the deepest hop that stayed reachable through the
         // outage. If even the nearest hop was dark for most of it, the whole WAN dropped.
+        // Attribution runs on the per-hop (ungrouped) states so it can name the precise hop.
+        var states = tiers.Select(t => t.State).ToList();
         var nearest = states.OrderBy(s => s.Depth).FirstOrDefault();
         var lastReachable = states.Where(s => !onBrokenPath[s.Depth]).OrderByDescending(s => s.Depth).FirstOrDefault();
         var scope = nearest == null || onBrokenPath[nearest.Depth] || lastReachable == null
@@ -153,9 +165,94 @@ public static class OutageDetector
             End = recovery,
             Scope = scope,
             LastReachableHop = scope == OutageScope.Upstream ? lastReachable!.Name : null,
-            Tiers = states
+            Tiers = GroupAccessTiers(tiers, options)
         };
     }
+
+    /// <summary>
+    /// Collapses groupable (access ISP) tiers that share an outage signature - recovery within
+    /// <see cref="IspHealthOptions.OutageAccessGroupToleranceSeconds"/> - into one row, so a handful
+    /// of near-identical access hops don't each take a row, and labels every row by its ASN.
+    /// Access hops that recovered at a distinctly different time (the inside-out heal, e.g. the OLT
+    /// coming back first) stay separate. When one ASN owns several rows they're disambiguated:
+    /// a merged group reads "ASN (N hops)", a lone hop "ASN (hostname tail)"; a unique ASN just
+    /// shows its name. Non-groupable tiers (transit clusters, internet endpoints) always keep their
+    /// own row. Returned nearest-first by depth.
+    /// </summary>
+    private static List<OutageTierState> GroupAccessTiers(
+        List<(Hop Hop, OutageTierState State)> tiers, IspHealthOptions options)
+    {
+        var tol = TimeSpan.FromSeconds(options.OutageAccessGroupToleranceSeconds);
+        var result = new List<OutageTierState>();
+
+        // Transit clusters and internet endpoints keep their own row, labeled by the ASN (transit)
+        // or the endpoint name (internet, AsnLabel null).
+        foreach (var (hop, state) in tiers.Where(t => !t.Hop.Groupable))
+            result.Add(Relabel(state, hop.AsnLabel ?? hop.Name));
+
+        // Access hops: WITHIN each ASN, cluster by outage signature - never merge across ASNs (a
+        // dual-WAN could have two access ISPs recover at the same instant). "Up" and "dark, never
+        // recovered" are each one shared signature; "dark and recovered" clusters by recovery time.
+        var groups = new List<List<(Hop Hop, OutageTierState State)>>();
+        void AddGroup(IEnumerable<(Hop, OutageTierState)> g) { var l = g.ToList(); if (l.Count > 0) groups.Add(l); }
+        foreach (var asnGroup in tiers.Where(t => t.Hop.Groupable).GroupBy(t => t.Hop.AsnLabel ?? t.Hop.Name))
+        {
+            var members = asnGroup.ToList();
+            AddGroup(members.Where(t => !t.State.WentDark));
+            AddGroup(members.Where(t => t.State.WentDark && !t.State.RecoveredAt.HasValue));
+            var cluster = new List<(Hop, OutageTierState)>();
+            foreach (var t in members.Where(t => t.State.WentDark && t.State.RecoveredAt.HasValue).OrderBy(t => t.State.RecoveredAt!.Value))
+            {
+                if (cluster.Count > 0 && t.State.RecoveredAt!.Value - cluster[0].Item2.RecoveredAt!.Value > tol)
+                {
+                    groups.Add(cluster);
+                    cluster = new List<(Hop, OutageTierState)>();
+                }
+                cluster.Add(t);
+            }
+            if (cluster.Count > 0) groups.Add(cluster);
+        }
+
+        // A unique ASN shows just its name; several rows split into "(N hops)" / "(hostname tail)".
+        // Key and lookup use the SAME nearest-hop expression so they never diverge.
+        static string AsnOf(List<(Hop Hop, OutageTierState State)> g)
+        {
+            var n = g.OrderBy(m => m.State.Depth).First().Hop;
+            return n.AsnLabel ?? n.Name;
+        }
+        var rowsPerAsn = groups.GroupBy(AsnOf).ToDictionary(x => x.Key, x => x.Count());
+        foreach (var g in groups)
+        {
+            var nearest = g.OrderBy(m => m.State.Depth).First();
+            var asn = AsnOf(g);
+            var name = rowsPerAsn[asn] == 1 ? asn
+                : g.Count > 1 ? $"{asn} ({g.Count} hops)"
+                : $"{asn} ({HostnameTail(nearest.Hop.Name, asn)})";
+            result.Add(new OutageTierState
+            {
+                Name = name,
+                Depth = nearest.State.Depth,
+                PeakLossPct = g.Max(m => m.State.PeakLossPct),
+                WentDark = g.Any(m => m.State.WentDark),
+                RecoveredAt = g.Where(m => m.State.RecoveredAt.HasValue).Select(m => m.State.RecoveredAt).DefaultIfEmpty(null).Min()
+            });
+        }
+
+        return result.OrderBy(s => s.Depth).ToList();
+    }
+
+    private static OutageTierState Relabel(OutageTierState s, string name) => new()
+    {
+        Name = name,
+        Depth = s.Depth,
+        PeakLossPct = s.PeakLossPct,
+        WentDark = s.WentDark,
+        RecoveredAt = s.RecoveredAt
+    };
+
+    /// <summary>The part of a per-target name after its ASN prefix ("AT&amp;T nokia-olt" -> "nokia-olt").</summary>
+    private static string HostnameTail(string name, string asn) =>
+        name.StartsWith(asn + " ", StringComparison.OrdinalIgnoreCase) ? name[(asn.Length + 1)..] : name;
 
     /// <summary>Actual timestamp of the first dark sample (loss at/above the dark threshold) in [start, end).</summary>
     private static DateTime? FirstDark(

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15342,7 +15342,7 @@ tr.stats-row-filtered {
 }
 
 .isp-health-card .issue-item + .issue-item {
-    margin-top: 0.5rem;
+    margin-top: 0.75rem;
 }
 
 .isp-health-card .issue-severity {

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
@@ -153,6 +153,72 @@ public class OutageDetectorTests
     }
 
     [Fact]
+    public void Brief_clear_during_staggered_recovery_does_not_split_one_outage()
+    {
+        // Two trigger targets, both dark across the outage but with a 1-minute healthy blip in
+        // the middle (staggered recovery / probe jitter clears the dark-fraction gate for one
+        // bucket). That must read as ONE outage, not two - the short gap is coalesced.
+        var clearStart = OutStart.AddMinutes(5);
+        var clearEnd = clearStart.AddMinutes(1);
+        List<LatencySample> WithBlip() => Series(0, (OutStart, clearStart, 100), (clearEnd, OutEnd, 100));
+        var internet1 = WithBlip();
+        var internet2 = WithBlip();
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), System.Array.Empty<OutageDetector.Hop>(), Options);
+
+        events.Should().ContainSingle();
+        events[0].Start.Should().Be(OutStart);
+        events[0].End.Should().Be(OutEnd);
+    }
+
+    [Fact]
+    public void Gap_longer_than_the_tolerance_stays_two_separate_outages()
+    {
+        // A long healthy stretch between two dark spans is a genuine recovery then a second
+        // outage - well beyond OutageMaxGapMinutes, so the two must NOT be coalesced.
+        var firstEnd = OutStart.AddMinutes(3);
+        var secondStart = OutStart.AddMinutes(12); // 9-minute clear gap, > OutageMaxGapMinutes
+        var secondEnd = secondStart.AddMinutes(3);
+        List<LatencySample> TwoSpans() => Series(0, (OutStart, firstEnd, 100), (secondStart, secondEnd, 100));
+        var internet1 = TwoSpans();
+        var internet2 = TwoSpans();
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), System.Array.Empty<OutageDetector.Hop>(), Options);
+
+        events.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Hop_with_no_data_during_the_outage_is_not_shown_as_reachable()
+    {
+        // A target added after the outage has no samples in the outage window. It must NOT
+        // render as a hop that "stayed reachable" through the outage, nor be picked as the
+        // last-reachable hop that attributes the break - it simply wasn't being measured.
+        var internet1 = Series(0, (OutStart, OutEnd, 100));
+        var internet2 = Series(0, (OutStart, OutEnd, 100));
+        var olt = Series(0); // measured throughout, stayed reachable
+        // Added after the outage: data only AFTER the outage window, none during it.
+        var lateTarget = TestSeries.Flat(OutEnd.AddMinutes(1), TimeSpan.FromMinutes(5), rttMs: 20, jitterMs: 0.5, lossPct: 0);
+
+        var hops = new[]
+        {
+            new OutageDetector.Hop("AT&T nokia-olt", 0, olt),
+            new OutageDetector.Hop("Late CDN", 1, lateTarget),
+            new OutageDetector.Hop("Cloudflare", 2, internet1),
+            new OutageDetector.Hop("Google", 2, internet2),
+        };
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), hops, Options);
+
+        events.Should().ContainSingle();
+        // The no-data hop is absent from the shape entirely.
+        events[0].Tiers.Should().NotContain(t => t.Name == "Late CDN");
+        // The break is attributed to the OLT, not the deeper no-data hop.
+        events[0].Scope.Should().Be(OutageScope.Upstream);
+        events[0].LastReachableHop.Should().Be("AT&T nokia-olt");
+    }
+
+    [Fact]
     public void Hop_that_recovers_early_is_not_dragged_to_the_end_by_a_late_blip()
     {
         // The validated AT&T shape: the OLT goes dark at onset, recovers early, then twitches

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
@@ -189,7 +189,7 @@ public class OutageDetectorTests
     }
 
     [Fact]
-    public void Hop_with_no_data_during_the_outage_is_not_shown_as_reachable()
+    public void No_data_hop_is_not_chosen_as_the_break_point()
     {
         // A target added after the outage has no samples in the outage window. It must NOT
         // render as a hop that "stayed reachable" through the outage, nor be picked as the

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
@@ -222,4 +222,103 @@ public class OutageDetectorTests
         events[0].Tiers.Where(t => t.RecoveredAt.HasValue)
             .Should().OnlyContain(t => t.RecoveredAt!.Value.Second == 17);
     }
+
+    [Fact]
+    public void Groupable_access_hops_with_the_same_signature_merge_distinct_ones_stay_separate()
+    {
+        var internet1 = Series(0, (OutStart, OutEnd, 100));
+        var internet2 = Series(0, (OutStart, OutEnd, 100));
+        // Two AT&T access hops recover together (dark the whole outage); the OLT recovers earlier.
+        var olt = Series(0, (OutStart, OutStart.AddMinutes(3), 100));
+        var accessLate1 = Series(0, (OutStart, OutEnd, 100));
+        var accessLate2 = Series(0, (OutStart, OutEnd, 100));
+
+        var hops = new[]
+        {
+            new OutageDetector.Hop("AT&T nokia-olt", 0, olt, Groupable: true, AsnLabel: "AT&T"),
+            new OutageDetector.Hop("AT&T hop-1", 1, accessLate1, Groupable: true, AsnLabel: "AT&T"),
+            new OutageDetector.Hop("AT&T hop-2", 2, accessLate2, Groupable: true, AsnLabel: "AT&T"),
+            new OutageDetector.Hop("Cloudflare", 3, internet1),
+            new OutageDetector.Hop("Google", 4, internet2),
+        };
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), hops, Options);
+
+        events.Should().ContainSingle();
+        var access = events[0].Tiers.Where(t => t.Name.StartsWith("AT&T")).ToList();
+        // Same ASN owns two rows, so each is disambiguated: the lone early OLT by its hostname
+        // tail, the two that recovered together by a hop count.
+        access.Should().HaveCount(2);
+        access.Should().Contain(t => t.Name == "AT&T (nokia-olt)");
+        access.Should().Contain(t => t.Name == "AT&T (2 hops)");
+        // Internet endpoints keep their own names and are never grouped.
+        events[0].Tiers.Should().Contain(t => t.Name == "Cloudflare");
+        events[0].Tiers.Should().Contain(t => t.Name == "Google");
+    }
+
+    [Fact]
+    public void A_unique_access_asn_shows_just_the_asn_name()
+    {
+        var internet1 = Series(0, (OutStart, OutEnd, 100));
+        var internet2 = Series(0, (OutStart, OutEnd, 100));
+        var access = Series(0, (OutStart, OutEnd, 100));
+
+        var hops = new[]
+        {
+            new OutageDetector.Hop("AT&T nokia-olt", 0, access, Groupable: true, AsnLabel: "AT&T"),
+            new OutageDetector.Hop("Cloudflare", 1, internet1),
+            new OutageDetector.Hop("Google", 2, internet2),
+        };
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), hops, Options);
+
+        events.Should().ContainSingle();
+        // One access row for the ASN -> no disambiguation, just the ASN name.
+        events[0].Tiers.Should().Contain(t => t.Name == "AT&T");
+        events[0].Tiers.Should().NotContain(t => t.Name.Contains("nokia-olt"));
+    }
+
+    [Fact]
+    public void A_target_with_no_data_during_the_outage_is_not_listed()
+    {
+        var internet1 = Series(0, (OutStart, OutEnd, 100));
+        var internet2 = Series(0, (OutStart, OutEnd, 100));
+        // A hop that only started reporting after the outage ended (didn't exist during it).
+        var addedLater = TestSeries.Flat(OutEnd, TimeSpan.FromMinutes(5), rttMs: 20, jitterMs: 0.5, lossPct: 0);
+
+        var hops = new[]
+        {
+            new OutageDetector.Hop("Late Hop", 0, addedLater, Groupable: true, AsnLabel: "Late"),
+            new OutageDetector.Hop("Cloudflare", 1, internet1),
+            new OutageDetector.Hop("Google", 2, internet2),
+        };
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), hops, Options);
+
+        events.Should().ContainSingle();
+        events[0].Tiers.Should().NotContain(t => t.Name.Contains("Late"));
+        events[0].Tiers.Should().Contain(t => t.Name == "Cloudflare");
+    }
+
+    [Fact]
+    public void Outage_with_no_in_window_hop_data_reports_with_no_tiers_and_does_not_throw()
+    {
+        // A fresh install backfilling: the internet trigger has data, but every monitored hop
+        // only started reporting after the window. The outage is still flagged; nothing crashes.
+        var internet1 = Series(0, (OutStart, OutEnd, 100));
+        var internet2 = Series(0, (OutStart, OutEnd, 100));
+        var lateOnly = TestSeries.Flat(OutEnd, TimeSpan.FromMinutes(5), rttMs: 20, jitterMs: 0.5, lossPct: 0);
+        var hops = new[]
+        {
+            new OutageDetector.Hop("Late A", 0, lateOnly, Groupable: true, AsnLabel: "Late"),
+            new OutageDetector.Hop("Late B", 1, lateOnly, Groupable: false),
+        };
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), hops, Options);
+
+        events.Should().ContainSingle();
+        events[0].Tiers.Should().BeEmpty();
+        events[0].Scope.Should().Be(OutageScope.FullWan);
+        events[0].LastReachableHop.Should().BeNull();
+    }
 }


### PR DESCRIPTION
## Summary

Refines the ISP Health internet-outage waterfall so it shows what actually happened inside your access ISP during an outage, with cleaner labels and more accurate outage boundaries.

## ISP Health

- **Access ISP detail in the outage waterfall** - Access hops are broken out per target instead of collapsed into one ASN row, so you can see which hop went down and which recovered first (the inside-out heal, e.g. the access OLT coming back before the rest). Hops that recovered within a few seconds of each other regroup into one row so near-identical hops don't each take a line.
- **ASN-based row labels** - Every waterfall row is labeled by its ASN ("Level 3", not a probe's target name). When one ASN owns several rows they're disambiguated - a merged access group reads "ASN (N hops)", a lone hop "ASN (hostname tail)", and an ASN that's both your access network and a transit hop gets a " Transit" suffix.
- **Internet rows trimmed to two** - The waterfall shows two internet endpoints (Cloudflare/Google, falling back to the two nearest others if those aren't monitored) rather than a long list. Outage detection still triggers on all internet targets - this is display-only.
- **No-data targets omitted** - A target that didn't exist or wasn't enabled during the outage window no longer shows as a spurious "stayed up" row, and can no longer be mistaken for the hop that pins where the break sat.
- **Outages no longer split into several** - A single outage that briefly clears during staggered recovery (hops healing a minute or two apart) was being reported as multiple back-to-back outages. Brief healthy gaps within an outage are now bridged into one event.
- **ISP Network ordered by RTT** - The ISP Network hop list is sorted by its displayed round-trip time, lowest first.
- **Spacing** - A touch more room between ISP Health findings.

Handles new installs and sparse data (no/one internet target, missing access or transit data, hops that only started reporting after the window) without errors. No InfluxDB schema or write-path changes.