### PR TITLE
ISP Health: stop outages fragmenting and hide hops with no data during the outage

### DIFF
--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -198,6 +198,15 @@ public class IspHealthOptions
     public int OutageMinDurationMinutes { get; set; } = 2;
 
     /// <summary>
+    /// Two outage runs separated by a healthy gap no longer than this are coalesced into one
+    /// event. One real outage briefly clears the dark-fraction gate during staggered onset or
+    /// inside-out recovery (targets dark/heal at slightly different minutes); without this it
+    /// would fragment into several adjacent events. The sealed gap counts as downtime, so keep
+    /// it short - the over-count is bounded by this value per seam.
+    /// </summary>
+    public int OutageMaxGapMinutes { get; set; } = 3;
+
+    /// <summary>
     /// Recovery-time tolerance for collapsing per-target access ISP rows in the outage waterfall:
     /// access hops that recovered within this many seconds of each other share a signature and
     /// merge to one row; ones outside it stay separate (the inside-out heal).

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
@@ -48,19 +48,36 @@ public static class OutageDetector
 
         var hopBuckets = hops.ToDictionary(h => h, h => BucketTargets(new[] { h.Series }, windowSize));
 
-        var events = new List<OutageEvent>();
-        var minDuration = TimeSpan.FromMinutes(options.OutageMinDurationMinutes);
+        // Contiguous runs of outage buckets (gap of one window ends a run), then coalesce
+        // runs separated by a short healthy gap (OutageMaxGapMinutes). One real outage dips
+        // below the dark-fraction gate for a bucket or two during staggered onset/recovery
+        // (targets go dark and heal at slightly different times) - without the coalesce that
+        // shatters it into several events. Sealing the gap before duration-filtering also lets
+        // two sub-min-duration runs straddling a blip add up to one qualifying outage.
+        var runs = new List<(DateTime Start, DateTime End)>();
         for (var i = 0; i < outageBuckets.Count;)
         {
-            // Extend a run over adjacent (contiguous) outage buckets; a non-outage bucket ends it.
             var j = i;
             while (j + 1 < outageBuckets.Count && outageBuckets[j + 1] - outageBuckets[j] <= windowSize)
                 j++;
-
-            var start = outageBuckets[i];
-            var end = outageBuckets[j] + windowSize; // through the last dark bucket
+            runs.Add((outageBuckets[i], outageBuckets[j] + windowSize)); // through the last dark bucket
             i = j + 1;
+        }
 
+        var maxGap = TimeSpan.FromMinutes(options.OutageMaxGapMinutes);
+        var merged = new List<(DateTime Start, DateTime End)>();
+        foreach (var run in runs)
+        {
+            if (merged.Count > 0 && run.Start - merged[^1].End <= maxGap)
+                merged[^1] = (merged[^1].Start, run.End);
+            else
+                merged.Add(run);
+        }
+
+        var events = new List<OutageEvent>();
+        var minDuration = TimeSpan.FromMinutes(options.OutageMinDurationMinutes);
+        foreach (var (start, end) in merged)
+        {
             if (end - start < minDuration) continue;
             events.Add(BuildEvent(start, end, triggerTargets, hops, hopBuckets, options));
         }

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
@@ -153,6 +153,72 @@ public class OutageDetectorTests
     }
 
     [Fact]
+    public void Brief_clear_during_staggered_recovery_does_not_split_one_outage()
+    {
+        // Two trigger targets, both dark across the outage but with a 1-minute healthy blip in
+        // the middle (staggered recovery / probe jitter clears the dark-fraction gate for one
+        // bucket). That must read as ONE outage, not two - the short gap is coalesced.
+        var clearStart = OutStart.AddMinutes(5);
+        var clearEnd = clearStart.AddMinutes(1);
+        List<LatencySample> WithBlip() => Series(0, (OutStart, clearStart, 100), (clearEnd, OutEnd, 100));
+        var internet1 = WithBlip();
+        var internet2 = WithBlip();
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), System.Array.Empty<OutageDetector.Hop>(), Options);
+
+        events.Should().ContainSingle();
+        events[0].Start.Should().Be(OutStart);
+        events[0].End.Should().Be(OutEnd);
+    }
+
+    [Fact]
+    public void Gap_longer_than_the_tolerance_stays_two_separate_outages()
+    {
+        // A long healthy stretch between two dark spans is a genuine recovery then a second
+        // outage - well beyond OutageMaxGapMinutes, so the two must NOT be coalesced.
+        var firstEnd = OutStart.AddMinutes(3);
+        var secondStart = OutStart.AddMinutes(12); // 9-minute clear gap, > OutageMaxGapMinutes
+        var secondEnd = secondStart.AddMinutes(3);
+        List<LatencySample> TwoSpans() => Series(0, (OutStart, firstEnd, 100), (secondStart, secondEnd, 100));
+        var internet1 = TwoSpans();
+        var internet2 = TwoSpans();
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), System.Array.Empty<OutageDetector.Hop>(), Options);
+
+        events.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Hop_with_no_data_during_the_outage_is_not_shown_as_reachable()
+    {
+        // A target added after the outage has no samples in the outage window. It must NOT
+        // render as a hop that "stayed reachable" through the outage, nor be picked as the
+        // last-reachable hop that attributes the break - it simply wasn't being measured.
+        var internet1 = Series(0, (OutStart, OutEnd, 100));
+        var internet2 = Series(0, (OutStart, OutEnd, 100));
+        var olt = Series(0); // measured throughout, stayed reachable
+        // Added after the outage: data only AFTER the outage window, none during it.
+        var lateTarget = TestSeries.Flat(OutEnd.AddMinutes(1), TimeSpan.FromMinutes(5), rttMs: 20, jitterMs: 0.5, lossPct: 0);
+
+        var hops = new[]
+        {
+            new OutageDetector.Hop("AT&T nokia-olt", 0, olt),
+            new OutageDetector.Hop("Late CDN", 1, lateTarget),
+            new OutageDetector.Hop("Cloudflare", 2, internet1),
+            new OutageDetector.Hop("Google", 2, internet2),
+        };
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), hops, Options);
+
+        events.Should().ContainSingle();
+        // The no-data hop is absent from the shape entirely.
+        events[0].Tiers.Should().NotContain(t => t.Name == "Late CDN");
+        // The break is attributed to the OLT, not the deeper no-data hop.
+        events[0].Scope.Should().Be(OutageScope.Upstream);
+        events[0].LastReachableHop.Should().Be("AT&T nokia-olt");
+    }
+
+    [Fact]
     public void Hop_that_recovers_early_is_not_dragged_to_the_end_by_a_late_blip()
     {
         // The validated AT&T shape: the OLT goes dark at onset, recovers early, then twitches


### PR DESCRIPTION
Two fixes to how internet outages are detected and shaped in ISP Health.

## Outages no longer fragment into several

A single real outage that briefly clears the dark-fraction gate, during staggered onset or inside-out recovery where targets go dark and heal a minute or two apart, was being split into multiple back-to-back outage events.

Adjacent outage runs separated by a healthy gap no longer than `OutageMaxGapMinutes` (new, default 3 min) are now coalesced into one event. The dark-fraction gate itself is unchanged. The sealed gap counts as downtime, so the tolerance is kept short; the over-count is bounded to a few minutes per seam.

## Hops with no data during an outage are no longer shown as "reachable"

A monitored hop that has no samples during the outage window, for example an internet target added after the outage happened, was being rendered as a hop that "stayed reachable" through the outage (a blue/up row in the waterfall), and could even be picked as the last-reachable hop that attributes where the break sat.

Such a hop was not being measured during the outage, so it is now dropped from the outage shape and break attribution entirely rather than counted as reachable.

## Tests

Added coverage for: a brief mid-outage clear staying one event, a long gap staying two events, and a no-data hop being excluded from the shape and attribution. All outage detector tests pass.