### PR TITLE
Fix Realtek ONT stick login (#844)

### DIFF
--- a/src/NetworkOptimizer.Web/Services/OntProviders/RealtekOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/RealtekOntProvider.cs
@@ -169,7 +169,11 @@ public sealed class RealtekOntProvider : IOntProvider
     }
 
     /// <summary>
-    /// Form-based login: POST username and plain-text password to /boaform/admin/formLogin.
+    /// Form-based login: POST plain-text credentials to /boaform/admin/formLogin.
+    /// Sends a superset of the fields used across Realtek Boa firmware variants. The
+    /// modern firmware reads <c>password</c>/<c>challenge</c>/<c>save</c>; the older SDK
+    /// reads <c>psd</c>. Boa's CGI reads only the params it recognizes and ignores the
+    /// rest, so unrecognized fields are inert and the same POST works on either variant.
     /// </summary>
     private async Task<bool> LoginAsync(
         HttpClient client, string baseUrl, OntPollContext context, CancellationToken ct)
@@ -180,26 +184,31 @@ public sealed class RealtekOntProvider : IOntProvider
         var loginUrl = $"{baseUrl}/boaform/admin/formLogin";
         var content = new FormUrlEncodedContent(new Dictionary<string, string>
         {
+            ["challenge"] = "",
             ["username"] = username,
+            ["password"] = password,
             ["psd"] = password,
+            ["save"] = "Login",
             ["submit-url"] = "/admin/login.asp",
         });
 
         var response = await client.PostAsync(loginUrl, content, ct);
+        if (!response.IsSuccessStatusCode)
+            return false;
 
-        if (response.StatusCode == HttpStatusCode.Redirect ||
-            response.StatusCode == HttpStatusCode.MovedPermanently ||
-            response.StatusCode == HttpStatusCode.OK)
-        {
-            var body = await response.Content.ReadAsStringAsync(ct);
-            if (body.Contains("login.asp", StringComparison.OrdinalIgnoreCase) &&
-                body.Contains("error", StringComparison.OrdinalIgnoreCase))
-                return false;
+        // Redirects are auto-followed: a successful login lands on the device home (/),
+        // a failed one bounces back to the login page. Treat landing on the login page
+        // (by final URL, page title, or a re-rendered login form) as failure so a real
+        // auth error surfaces as "Login failed" rather than a later malformed-response error.
+        var finalPath = response.RequestMessage?.RequestUri?.AbsolutePath ?? "";
+        var body = await response.Content.ReadAsStringAsync(ct);
 
-            return true;
-        }
+        var landedOnLogin =
+            finalPath.Contains("login.asp", StringComparison.OrdinalIgnoreCase) ||
+            body.Contains("<title>Login</title>", StringComparison.OrdinalIgnoreCase) ||
+            body.Contains("formLogin", StringComparison.OrdinalIgnoreCase);
 
-        return false;
+        return !landedOnLogin;
     }
 
     private OntStats ParseStatusPon(string html, OntPollContext context)

--- a/src/NetworkOptimizer.Web/Services/OntProviders/RealtekOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/RealtekOntProvider.cs
@@ -193,22 +193,20 @@ public sealed class RealtekOntProvider : IOntProvider
         });
 
         var response = await client.PostAsync(loginUrl, content, ct);
-        if (!response.IsSuccessStatusCode)
-            return false;
 
-        // Redirects are auto-followed: a successful login lands on the device home (/),
-        // a failed one bounces back to the login page. Treat landing on the login page
-        // (by final URL, page title, or a re-rendered login form) as failure so a real
-        // auth error surfaces as "Login failed" rather than a later malformed-response error.
-        var finalPath = response.RequestMessage?.RequestUri?.AbsolutePath ?? "";
-        var body = await response.Content.ReadAsStringAsync(ct);
+        if (response.StatusCode == HttpStatusCode.Redirect ||
+            response.StatusCode == HttpStatusCode.MovedPermanently ||
+            response.StatusCode == HttpStatusCode.OK)
+        {
+            var body = await response.Content.ReadAsStringAsync(ct);
+            if (body.Contains("login.asp", StringComparison.OrdinalIgnoreCase) &&
+                body.Contains("error", StringComparison.OrdinalIgnoreCase))
+                return false;
 
-        var landedOnLogin =
-            finalPath.Contains("login.asp", StringComparison.OrdinalIgnoreCase) ||
-            body.Contains("<title>Login</title>", StringComparison.OrdinalIgnoreCase) ||
-            body.Contains("formLogin", StringComparison.OrdinalIgnoreCase);
+            return true;
+        }
 
-        return !landedOnLogin;
+        return false;
     }
 
     private OntStats ParseStatusPon(string html, OntPollContext context)


### PR DESCRIPTION
## Summary

Realtek GPON stick monitoring failed to authenticate, so the Test/poll reported `Connection failed: Received an invalid status line: '<HTML>...<TITLE>Login</TITLE>'` and never returned DDM data.

The login POST sent the password as `psd` with no `challenge`/`save` fields, which does not match the `formLogin` contract the Realtek Boa web UI on these sticks expects. Login silently failed, and the subsequent unauthenticated status page fetch came back as a headerless login stub that the HTTP client can't parse.

## Change

Send a superset of the credential fields used across Realtek Boa firmware variants in the login POST: `challenge`, `username`, `password`, `psd`, `save`, `submit-url`. Boa's CGI reads only the params it recognizes and ignores the rest, so the same POST authenticates on both the modern (`password`) and older SDK (`psd`) firmware. This is strictly additive: installs that work today keep the `psd` field they rely on.

Fixes #844.