### PR TITLE
ISP Health: transit witness, reachability stringency, scoring calibration, and flaky-target detection

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -31,6 +31,7 @@
 @inject CellularModemService CellularModemService
 @inject MonitoringCollectionAgent CollectionAgent
 @inject IspHealthService IspHealthService
+@inject NetworkOptimizer.Web.Services.Monitoring.FlakyTargetService FlakyTargets
 @inject ILogger<Monitoring> Logger
 
 <NavigationLock OnBeforeInternalNavigation="OnBeforeInternalNavigation"
@@ -143,6 +144,24 @@ else
                     </div>
                     <div class="banner-actions">
                         <button class="btn btn-sm btn-primary" @onclick="GoToSnmpDevices">Review SNMP devices</button>
+                    </div>
+                </div>
+            </div>
+        }
+
+        @if (_flakyTargetCount > 0)
+        {
+            <div class="alert alert-info" style="margin-bottom: 1rem;">
+                <div class="banner-content">
+                    <span class="banner-icon banner-icon-info">i</span>
+                    <div class="banner-text" style="flex: 1;">
+                        @(_flakyTargetCount == 1
+                            ? "1 monitoring target looks flaky"
+                            : $"{_flakyTargetCount} monitoring targets look flaky")
+                        - high packet loss versus their peers, usually ICMP deprioritization. Review and disable them so they don't skew ISP Health.
+                    </div>
+                    <div class="banner-actions">
+                        <button class="btn btn-sm btn-primary" @onclick="GoToFlakyTargets">Review flaky targets</button>
                     </div>
                 </div>
             </div>
@@ -377,6 +396,10 @@ else
         <!-- Upstream tracer wizard -->
         <div id="upstream-discovery" style="margin-top: 1.5rem;">
             <UpstreamTracerPanel ForceExpand="_forceExpandUpstream" OnSaved="StateHasChanged" />
+        </div>
+
+        <div style="margin-top: 1.5rem;">
+            <FlakyTargetsCard OnTargetsChanged="OnTargetsChanged" />
         </div>
 
         <div style="margin-top: 1.5rem;">
@@ -1579,6 +1602,12 @@ else
         SetActiveTab("setup");
     }
 
+    // Flaky-target banner state (#849). Detected once when Live View first loads; never polled.
+    private int _flakyTargetCount;
+    private bool _flakyChecked;
+
+    private void GoToFlakyTargets() => SetActiveTab("performance");
+
     private async Task LoadTargetsAsync()
     {
         try
@@ -2402,6 +2431,18 @@ else
 
         // Mount/unmount charts based on active tab. Only mount when the container
         // div exists in the DOM (i.e., the tab is active). Unmount when switching away.
+
+        // Flaky-target banner (#849): detect once, on the first time Live View is shown. No polling.
+        if (_activeTab == "live" && _monitoringReady && !_flakyChecked)
+        {
+            _flakyChecked = true;
+            try
+            {
+                _flakyTargetCount = (await FlakyTargets.DetectAsync()).Count;
+                if (_flakyTargetCount > 0) StateHasChanged();
+            }
+            catch (Exception ex) { Logger.LogDebug(ex, "Flaky-target banner check failed"); }
+        }
 
         // 3D map - Live tab only
         if (_activeTab == "live" && _monitoringReady && !_mapMounted)

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -398,8 +398,8 @@ else
             <UpstreamTracerPanel ForceExpand="_forceExpandUpstream" OnSaved="StateHasChanged" />
         </div>
 
-        <div style="margin-top: 1.5rem;">
-            <FlakyTargetsCard OnTargetsChanged="OnTargetsChanged" />
+        <div id="flaky-targets" style="margin-top: 1.5rem;">
+            <FlakyTargetsCard ForceExpand="_forceExpandFlaky" OnTargetsChanged="OnTargetsChanged" />
         </div>
 
         <div style="margin-top: 1.5rem;">
@@ -1274,6 +1274,8 @@ else
 
     private bool _scrollToDiscoveryPending;
     private bool _scrollToSfpChartsPending;
+    private bool _scrollToFlakyPending;
+    private bool _forceExpandFlaky;
     private string? _soloSfpModuleId;
     private string? _soloDeviceMac;
     private string? _preSelectCategory;
@@ -1606,7 +1608,12 @@ else
     private int _flakyTargetCount;
     private bool _flakyChecked;
 
-    private void GoToFlakyTargets() => SetActiveTab("performance");
+    private void GoToFlakyTargets()
+    {
+        _forceExpandFlaky = true;
+        _scrollToFlakyPending = true;
+        SetActiveTab("performance");
+    }
 
     private async Task LoadTargetsAsync()
     {
@@ -1696,6 +1703,23 @@ else
         await JS.InvokeVoidAsync("eval", @"
             (function() {
                 var el = document.getElementById('upstream-discovery');
+                if (el) {
+                    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                    el.style.transition = 'outline-color 0.3s';
+                    el.style.outline = '2px solid rgba(59, 130, 246, 0.5)';
+                    el.style.outlineOffset = '4px';
+                    el.style.borderRadius = '12px';
+                    setTimeout(function() { el.style.outline = ''; el.style.outlineOffset = ''; }, 2000);
+                }
+            })();");
+    }
+
+    private async Task ScrollToFlakyTargetsAsync()
+    {
+        await Task.Delay(500);
+        await JS.InvokeVoidAsync("eval", @"
+            (function() {
+                var el = document.getElementById('flaky-targets');
                 if (el) {
                     el.scrollIntoView({ behavior: 'smooth', block: 'start' });
                     el.style.transition = 'outline-color 0.3s';
@@ -2545,6 +2569,13 @@ else
             _scrollToDiscoveryPending = false;
             _forceExpandUpstream = false;
             await ScrollToUpstreamDiscoveryAsync();
+        }
+
+        if (_scrollToFlakyPending && _activeTab == "performance")
+        {
+            _scrollToFlakyPending = false;
+            _forceExpandFlaky = false;
+            await ScrollToFlakyTargetsAsync();
         }
 
         // Device health charts - Devices tab only

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/FlakyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/FlakyTargetsCard.razor
@@ -25,7 +25,7 @@
         {
             <div class="card-body">
                 <p class="page-description flaky-intro">
-                    These targets show packet loss well above their peers over the last couple of days,
+                    These targets show packet loss well above their peers over recent monitoring,
                     usually ICMP deprioritization rather than a real problem. Disabling one keeps it out
                     of ISP Health scoring; you can re-enable it anytime in Latency Targets below.
                 </p>

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/FlakyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/FlakyTargetsCard.razor
@@ -1,0 +1,130 @@
+@using Microsoft.EntityFrameworkCore
+@using NetworkOptimizer.Storage.Models
+@using NetworkOptimizer.Web.Services.Monitoring
+@inject FlakyTargetService FlakyTargets
+@inject IDbContextFactory<NetworkOptimizerDbContext> DbFactory
+
+@* Issue #849: flaky-target advisory. Hidden entirely when there are no candidates. Reuses the
+   shared card / button styles; only the row layout is scoped below. *@
+@if (_flaky.Count > 0)
+{
+    <div class="card flaky-card">
+        <div class="card-header flaky-header" @onclick="Toggle">
+            <h2 class="card-title">
+                <span class="flaky-warn">&#9888;</span>
+                Flaky monitoring targets (@_flaky.Count)
+            </h2>
+            <div class="flaky-header-actions" @onclick:stopPropagation="true">
+                <button class="btn btn-sm btn-secondary" @onclick="DisableAllAsync" disabled="@_busy"
+                        data-tooltip="Disable every flagged target">Disable all</button>
+                <button class="btn btn-sm btn-secondary flaky-collapse" @onclick="Toggle"
+                        data-tooltip="@(_expanded ? "Collapse" : "Expand")">@(_expanded ? "▲" : "▼")</button>
+            </div>
+        </div>
+        @if (_expanded)
+        {
+            <div class="card-body">
+                <p class="page-description flaky-intro">
+                    These targets show packet loss well above their peers over the last couple of days,
+                    usually ICMP deprioritization rather than a real problem. Disabling one keeps it out
+                    of ISP Health scoring; you can re-enable it anytime in Latency Targets below.
+                </p>
+                <div class="flaky-list">
+                    @foreach (var f in _flaky)
+                    {
+                        <div class="flaky-row">
+                            <div class="flaky-info">
+                                <span class="flaky-name">@f.Name</span>
+                                <span class="flaky-tag">@TypeLabel(f.Type)</span>
+                                <span class="flaky-evidence">@f.Evidence</span>
+                            </div>
+                            <button class="btn btn-sm btn-secondary" @onclick="() => DisableAsync(f)" disabled="@_busy">
+                                Disable
+                            </button>
+                        </div>
+                    }
+                </div>
+            </div>
+        }
+    </div>
+}
+
+<style>
+    .flaky-card { border-left: 3px solid var(--warning-color); }
+    .flaky-header { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; cursor: pointer; }
+    .flaky-warn { color: var(--warning-color); margin-right: 0.4rem; }
+    .flaky-header-actions { display: flex; align-items: center; gap: 0.5rem; }
+    .flaky-collapse { min-width: 2.25rem; }
+    .flaky-intro { margin-top: 0; margin-bottom: 1rem; }
+    .flaky-list { display: flex; flex-direction: column; gap: 0.5rem; }
+    .flaky-row { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem;
+                 padding: 0.6rem 0.75rem; background: var(--bg-tertiary); border-radius: 6px; }
+    .flaky-info { display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; min-width: 0; }
+    .flaky-name { color: var(--text-primary); font-weight: 600; }
+    .flaky-tag { color: var(--text-secondary); font-size: 0.78rem; padding: 0.1rem 0.45rem;
+                 background: var(--bg-hover); border-radius: 4px; }
+    .flaky-evidence { color: var(--warning-color); font-size: 0.85rem; }
+
+    @@media (max-width: 768px) {
+        .flaky-row { flex-direction: column; align-items: stretch; }
+        .flaky-row .btn { width: 100%; }
+        .flaky-info { justify-content: flex-start; }
+    }
+</style>
+
+@code {
+    [Parameter] public EventCallback OnTargetsChanged { get; set; }
+
+    private IReadOnlyList<FlakyTargetService.FlakyTarget> _flaky = System.Array.Empty<FlakyTargetService.FlakyTarget>();
+    private bool _expanded = true;
+    private bool _busy;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try { _flaky = await FlakyTargets.DetectAsync(); }
+        catch { _flaky = System.Array.Empty<FlakyTargetService.FlakyTarget>(); }
+    }
+
+    private void Toggle() => _expanded = !_expanded;
+
+    private async Task DisableAsync(FlakyTargetService.FlakyTarget target)
+    {
+        _busy = true;
+        try
+        {
+            await SetEnabledFalseAsync(new[] { target.Id });
+            _flaky = _flaky.Where(f => f.Id != target.Id).ToList();
+            await OnTargetsChanged.InvokeAsync();
+        }
+        finally { _busy = false; }
+    }
+
+    private async Task DisableAllAsync()
+    {
+        if (_flaky.Count == 0) return;
+        _busy = true;
+        try
+        {
+            await SetEnabledFalseAsync(_flaky.Select(f => f.Id).ToList());
+            _flaky = System.Array.Empty<FlakyTargetService.FlakyTarget>();
+            await OnTargetsChanged.InvokeAsync();
+        }
+        finally { _busy = false; }
+    }
+
+    private async Task SetEnabledFalseAsync(IReadOnlyCollection<int> ids)
+    {
+        await using var db = await DbFactory.CreateDbContextAsync();
+        var rows = await db.MonitoringTargets.Where(t => ids.Contains(t.Id)).ToListAsync();
+        foreach (var row in rows) row.Enabled = false;
+        await db.SaveChangesAsync();
+    }
+
+    private static string TypeLabel(MonitoringTargetType type) => type switch
+    {
+        MonitoringTargetType.AccessIsp => "ISP",
+        MonitoringTargetType.Transit => "Transit",
+        MonitoringTargetType.InternetService => "Internet",
+        _ => type.ToString()
+    };
+}

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/FlakyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/FlakyTargetsCard.razor
@@ -62,12 +62,17 @@
     .flaky-card { border-left: 3px solid var(--warning-color); }
     .flaky-warn { color: var(--warning-color); margin-right: 0.4rem; }
     .flaky-evidence { color: var(--warning-color); }
-    .flaky-toolbar { display: flex; justify-content: flex-end; margin-bottom: 0.75rem; }
+    /* Scoped to this card only - don't touch the global .section-description. */
+    .flaky-card .section-description { margin-bottom: 0.75rem; }
+    /* margin-right matches the data-table cell right padding so "Disable all" lines up exactly
+       with the per-row Disable buttons (cell padding is 1rem on desktop, 0.4rem on mobile). */
+    .flaky-toolbar { display: flex; justify-content: flex-end; margin-bottom: 0.75rem; margin-right: 1rem; }
 
     @@media (max-width: 768px) {
         /* Scoped override of the global .data-table min-width:500px so this table fits the phone
            (Type + peer-median already hidden, name truncated) instead of forcing horizontal scroll. */
         .data-table.flaky-table { min-width: 0; }
+        .flaky-toolbar { margin-right: 0.4rem; }
     }
 </style>
 

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/FlakyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/FlakyTargetsCard.razor
@@ -11,11 +11,7 @@
     <div class="card flaky-card">
         <div class="card-header card-header-collapsible" @onclick="ToggleCollapse">
             <h2 class="card-title"><span class="flaky-warn">&#9888;</span> Flaky monitoring targets (@_flaky.Count)</h2>
-            <div class="card-header-right">
-                <button class="btn btn-sm btn-primary" @onclick="DisableAllAsync" disabled="@_busy"
-                        @onclick:stopPropagation="true" data-tooltip="Disable every flagged target">Disable all</button>
-                <span class="issue-type-chevron">@(_collapsed ? "▼" : "▲")</span>
-            </div>
+            <span class="issue-type-chevron">@(_collapsed ? "▼" : "▲")</span>
         </div>
         <div class="expand-wrapper @(!_collapsed ? "expanded" : "")">
             <div class="expand-content">
@@ -25,8 +21,12 @@
                         usually ICMP deprioritization rather than a real problem. Disabling one keeps it
                         out of ISP Health scoring; you can re-enable it anytime in Latency Targets below.
                     </p>
+                    <div class="flaky-toolbar">
+                        <button class="btn btn-sm btn-primary" @onclick="DisableAllAsync" disabled="@_busy"
+                                data-tooltip="Disable every flagged target">Disable all</button>
+                    </div>
                     <div class="table-responsive">
-                        <table class="data-table">
+                        <table class="data-table flaky-table">
                             <thead>
                                 <tr>
                                     <th>Target</th>
@@ -62,6 +62,13 @@
     .flaky-card { border-left: 3px solid var(--warning-color); }
     .flaky-warn { color: var(--warning-color); margin-right: 0.4rem; }
     .flaky-evidence { color: var(--warning-color); }
+    .flaky-toolbar { display: flex; justify-content: flex-end; margin-bottom: 0.75rem; }
+
+    @@media (max-width: 768px) {
+        /* Scoped override of the global .data-table min-width:500px so this table fits the phone
+           (Type + peer-median already hidden, name truncated) instead of forcing horizontal scroll. */
+        .data-table.flaky-table { min-width: 0; }
+    }
 </style>
 
 @code {

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/FlakyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/FlakyTargetsCard.razor
@@ -4,80 +4,77 @@
 @inject FlakyTargetService FlakyTargets
 @inject IDbContextFactory<NetworkOptimizerDbContext> DbFactory
 
-@* Issue #849: flaky-target advisory. Hidden entirely when there are no candidates. Reuses the
-   shared card / button styles; only the row layout is scoped below. *@
+@* Issue #849: flaky-target advisory. Hidden entirely when there are no candidates. Uses the
+   standard collapsible-card convention (card-header-collapsible + issue-type-chevron + expand-wrapper). *@
 @if (_flaky.Count > 0)
 {
     <div class="card flaky-card">
-        <div class="card-header flaky-header" @onclick="Toggle">
-            <h2 class="card-title">
-                <span class="flaky-warn">&#9888;</span>
-                Flaky monitoring targets (@_flaky.Count)
-            </h2>
-            <div class="flaky-header-actions" @onclick:stopPropagation="true">
-                <button class="btn btn-sm btn-secondary" @onclick="DisableAllAsync" disabled="@_busy"
-                        data-tooltip="Disable every flagged target">Disable all</button>
-                <button class="btn btn-sm btn-secondary flaky-collapse" @onclick="Toggle"
-                        data-tooltip="@(_expanded ? "Collapse" : "Expand")">@(_expanded ? "▲" : "▼")</button>
+        <div class="card-header card-header-collapsible" @onclick="ToggleCollapse">
+            <h2 class="card-title"><span class="flaky-warn">&#9888;</span> Flaky monitoring targets (@_flaky.Count)</h2>
+            <div style="display: flex; align-items: center; gap: 0.5rem;">
+                <button class="btn btn-sm btn-outline-primary" @onclick="DisableAllAsync" disabled="@_busy"
+                        @onclick:stopPropagation="true" data-tooltip="Disable every flagged target">Disable all</button>
+                <span class="issue-type-chevron">@(_collapsed ? "▼" : "▲")</span>
             </div>
         </div>
-        @if (_expanded)
-        {
-            <div class="card-body">
-                <p class="page-description flaky-intro">
-                    These targets show packet loss well above their peers over recent monitoring,
-                    usually ICMP deprioritization rather than a real problem. Disabling one keeps it out
-                    of ISP Health scoring; you can re-enable it anytime in Latency Targets below.
-                </p>
-                <div class="flaky-list">
-                    @foreach (var f in _flaky)
-                    {
-                        <div class="flaky-row">
-                            <div class="flaky-info">
-                                <span class="flaky-name">@f.Name</span>
-                                <span class="flaky-tag">@TypeLabel(f.Type)</span>
-                                <span class="flaky-evidence">@f.Evidence</span>
-                            </div>
-                            <button class="btn btn-sm btn-secondary" @onclick="() => DisableAsync(f)" disabled="@_busy">
-                                Disable
-                            </button>
-                        </div>
-                    }
+        <div class="expand-wrapper @(!_collapsed ? "expanded" : "")">
+            <div class="expand-content">
+                <div class="card-body">
+                    <p class="section-description">
+                        These targets show packet loss well above their peers over recent monitoring,
+                        usually ICMP deprioritization rather than a real problem. Disabling one keeps it
+                        out of ISP Health scoring; you can re-enable it anytime in Latency Targets below.
+                    </p>
+                    <div class="table-responsive">
+                        <table class="data-table">
+                            <thead>
+                                <tr>
+                                    <th>Target</th>
+                                    <th>Type</th>
+                                    <th>Loss vs peers</th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var f in _flaky)
+                                {
+                                    <tr>
+                                        <td>@f.Name</td>
+                                        <td>@TypeLabel(f.Type)</td>
+                                        <td class="flaky-evidence">@f.Evidence</td>
+                                        <td class="flaky-action">
+                                            <button class="btn btn-sm btn-outline-primary" @onclick="() => DisableAsync(f)" disabled="@_busy">Disable</button>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
             </div>
-        }
+        </div>
     </div>
 }
 
 <style>
     .flaky-card { border-left: 3px solid var(--warning-color); }
-    .flaky-header { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; cursor: pointer; }
     .flaky-warn { color: var(--warning-color); margin-right: 0.4rem; }
-    .flaky-header-actions { display: flex; align-items: center; gap: 0.5rem; }
-    .flaky-collapse { min-width: 2.25rem; }
-    .flaky-intro { margin-top: 0; margin-bottom: 1rem; }
-    .flaky-list { display: flex; flex-direction: column; gap: 0.5rem; }
-    .flaky-row { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem;
-                 padding: 0.6rem 0.75rem; background: var(--bg-tertiary); border-radius: 6px; }
-    .flaky-info { display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; min-width: 0; }
-    .flaky-name { color: var(--text-primary); font-weight: 600; }
-    .flaky-tag { color: var(--text-secondary); font-size: 0.78rem; padding: 0.1rem 0.45rem;
-                 background: var(--bg-hover); border-radius: 4px; }
-    .flaky-evidence { color: var(--warning-color); font-size: 0.85rem; }
-
-    @@media (max-width: 768px) {
-        .flaky-row { flex-direction: column; align-items: stretch; }
-        .flaky-row .btn { width: 100%; }
-        .flaky-info { justify-content: flex-start; }
-    }
+    .flaky-evidence { color: var(--warning-color); }
+    .flaky-action { text-align: right; white-space: nowrap; }
 </style>
 
 @code {
     [Parameter] public EventCallback OnTargetsChanged { get; set; }
+    [Parameter] public bool ForceExpand { get; set; }
 
     private IReadOnlyList<FlakyTargetService.FlakyTarget> _flaky = System.Array.Empty<FlakyTargetService.FlakyTarget>();
-    private bool _expanded = true;
+    private bool _collapsed; // expanded by default when candidates exist
     private bool _busy;
+
+    protected override void OnParametersSet()
+    {
+        if (ForceExpand && _collapsed) _collapsed = false;
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -85,7 +82,7 @@
         catch { _flaky = System.Array.Empty<FlakyTargetService.FlakyTarget>(); }
     }
 
-    private void Toggle() => _expanded = !_expanded;
+    private void ToggleCollapse() => _collapsed = !_collapsed;
 
     private async Task DisableAsync(FlakyTargetService.FlakyTarget target)
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/FlakyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/FlakyTargetsCard.razor
@@ -11,8 +11,8 @@
     <div class="card flaky-card">
         <div class="card-header card-header-collapsible" @onclick="ToggleCollapse">
             <h2 class="card-title"><span class="flaky-warn">&#9888;</span> Flaky monitoring targets (@_flaky.Count)</h2>
-            <div style="display: flex; align-items: center; gap: 0.5rem;">
-                <button class="btn btn-sm btn-outline-primary" @onclick="DisableAllAsync" disabled="@_busy"
+            <div class="card-header-right">
+                <button class="btn btn-sm btn-primary" @onclick="DisableAllAsync" disabled="@_busy"
                         @onclick:stopPropagation="true" data-tooltip="Disable every flagged target">Disable all</button>
                 <span class="issue-type-chevron">@(_collapsed ? "▼" : "▲")</span>
             </div>
@@ -30,20 +30,22 @@
                             <thead>
                                 <tr>
                                     <th>Target</th>
-                                    <th>Type</th>
+                                    <th class="hide-mobile">Type</th>
                                     <th>Loss vs peers</th>
-                                    <th></th>
+                                    <th class="col-actions"></th>
                                 </tr>
                             </thead>
                             <tbody>
                                 @foreach (var f in _flaky)
                                 {
                                     <tr>
-                                        <td>@f.Name</td>
-                                        <td>@TypeLabel(f.Type)</td>
-                                        <td class="flaky-evidence">@f.Evidence</td>
-                                        <td class="flaky-action">
-                                            <button class="btn btn-sm btn-outline-primary" @onclick="() => DisableAsync(f)" disabled="@_busy">Disable</button>
+                                        <td><span class="host-truncate">@f.Name</span></td>
+                                        <td class="hide-mobile">@TypeLabel(f.Type)</td>
+                                        <td class="flaky-evidence">
+                                            @($"{f.LossPct:0.0}% loss")<span class="hide-mobile"> vs @($"{f.BaselinePct:0.0}% peer median")</span>
+                                        </td>
+                                        <td class="col-actions">
+                                            <button class="btn btn-sm btn-primary" @onclick="() => DisableAsync(f)" disabled="@_busy">Disable</button>
                                         </td>
                                     </tr>
                                 }
@@ -60,7 +62,6 @@
     .flaky-card { border-left: 3px solid var(--warning-color); }
     .flaky-warn { color: var(--warning-color); margin-right: 0.4rem; }
     .flaky-evidence { color: var(--warning-color); }
-    .flaky-action { text-align: right; white-space: nowrap; }
 </style>
 
 @code {

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -179,9 +179,8 @@
                                             </td>
                                             <td>
                                                 <input type="text" class="form-control form-control-sm"
-                                                       value="@hop.Label"
-                                                       disabled="@hop.Unreachable"
-                                                       @onchange="e => hop.Label = (string)e.Value!" />
+                                                       @bind="hop.Label" @bind:event="oninput"
+                                                       disabled="@hop.Unreachable" />
                                             </td>
                                             <td><code>@hop.Address</code> @(string.IsNullOrEmpty(hop.PtrHostname) ? "" : $"({hop.PtrHostname})")</td>
                                             <td>@(hop.Method == DiscoveryMethod.L2Neighbor ? "L2 neighbor" : $"Hop {hop.HopNumber}")</td>
@@ -222,9 +221,8 @@
                                             </td>
                                             <td>
                                                 <input type="text" class="form-control form-control-sm"
-                                                       value="@asn.Label"
-                                                       disabled="@asn.Unreachable"
-                                                       @onchange="e => asn.Label = (string)e.Value!" />
+                                                       @bind="asn.Label" @bind:event="oninput"
+                                                       disabled="@asn.Unreachable" />
                                             </td>
                                             <td><code>@asn.HopAddress</code></td>
                                             <td><code>AS@(asn.AsnNumber)</code> <span class="text-muted">@asn.AsnName</span></td>
@@ -262,8 +260,7 @@
                                             </td>
                                             <td>
                                                 <input type="text" class="form-control form-control-sm"
-                                                       value="@host.Label"
-                                                       @onchange="e => host.Label = (string)e.Value!" />
+                                                       @bind="host.Label" @bind:event="oninput" />
                                             </td>
                                             <td><code>@host.PathProxyTarget</code></td>
                                             <td><code>AS@(host.AsnNumber)</code> <span class="text-muted">@host.AsnName</span></td>

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -323,7 +323,9 @@
     private UpstreamTracerState _state = new();
     private System.Threading.Timer? _pollTimer;
     private bool _needsReview;
-    private List<TransitAsnCandidate> TransitRouters => _state.TransitAsns.Where(a => a.Method == DiscoveryMethod.DirectRouter).ToList();
+    // Group by ASN so every hop in the same transit network (including an injected witness like
+    // 4.2.2.2 for AS3356, which is added last) lists together; stable within each ASN.
+    private List<TransitAsnCandidate> TransitRouters => _state.TransitAsns.Where(a => a.Method == DiscoveryMethod.DirectRouter).OrderBy(a => a.AsnNumber).ToList();
     private List<TransitAsnCandidate> PathEndHosts => _state.TransitAsns.Where(a => a.Method == DiscoveryMethod.PathProxy).ToList();
     private bool _collapsed;
     private DateTime _lastReviewCheck = DateTime.MinValue;

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -323,9 +323,15 @@
     private UpstreamTracerState _state = new();
     private System.Threading.Timer? _pollTimer;
     private bool _needsReview;
-    // Group by ASN so every hop in the same transit network (including an injected witness like
-    // 4.2.2.2 for AS3356, which is added last) lists together; stable within each ASN.
-    private List<TransitAsnCandidate> TransitRouters => _state.TransitAsns.Where(a => a.Method == DiscoveryMethod.DirectRouter).OrderBy(a => a.AsnNumber).ToList();
+    // Group by ASN so every hop in the same transit network lists together (including an injected
+    // witness like 4.2.2.2 for AS3356, which is added last). Networks are ordered nearest-first by
+    // their best RTT, and within each network by RTT ascending; unreachable hops sort to the end.
+    private List<TransitAsnCandidate> TransitRouters =>
+        _state.TransitAsns.Where(a => a.Method == DiscoveryMethod.DirectRouter)
+            .GroupBy(a => a.AsnNumber)
+            .OrderBy(g => g.Min(a => a.VerifiedRttMs ?? double.MaxValue))
+            .SelectMany(g => g.OrderBy(a => a.VerifiedRttMs ?? double.MaxValue))
+            .ToList();
     private List<TransitAsnCandidate> PathEndHosts => _state.TransitAsns.Where(a => a.Method == DiscoveryMethod.PathProxy).ToList();
     private bool _collapsed;
     private DateTime _lastReviewCheck = DateTime.MinValue;

--- a/src/NetworkOptimizer.Web/Endpoints/FlakyTargetEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/FlakyTargetEndpoints.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics;
+using NetworkOptimizer.Web.Services.Monitoring;
+
+namespace NetworkOptimizer.Web.Endpoints;
+
+/// <summary>
+/// Flaky-target detector (#849) result, with a server-side timing field so we can measure the cost
+/// of the 10-min-bin / 48 h loss sweep on real data. The Blazor banner + panel call
+/// <see cref="FlakyTargetService"/> directly; this endpoint exists for timing/validation and as a
+/// JS-hittable view of the result. Authenticated like the rest of /api/monitoring.
+/// </summary>
+public static class FlakyTargetEndpoints
+{
+    public static void Map(WebApplication app)
+    {
+        app.MapGet("/api/monitoring/flaky-targets", async (FlakyTargetService svc, CancellationToken ct) =>
+        {
+            var sw = Stopwatch.StartNew();
+            var flaky = await svc.DetectAsync(ct);
+            sw.Stop();
+            return Results.Ok(new
+            {
+                elapsedMs = Math.Round(sw.Elapsed.TotalMilliseconds, 1),
+                count = flaky.Count,
+                targets = flaky.Select(f => new
+                {
+                    f.Name,
+                    type = f.Type.ToString(),
+                    lossPct = Math.Round(f.LossPct, 2),
+                    baselinePct = Math.Round(f.BaselinePct, 2),
+                    f.OverBins,
+                    f.TotalBins,
+                    evidence = f.Evidence
+                })
+            });
+        });
+    }
+}

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -372,6 +372,7 @@ builder.Services.AddSingleton<MonitoringInfluxClient>();
 builder.Services.AddSingleton<MonitoringLiveStats>();
 builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.WanSummaryCache>();
 builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.IspHealth.IspHealthService>();
+builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.FlakyTargetService>();
 builder.Services.AddScoped<NetworkOptimizer.Web.Services.Monitoring.MonitoringPathView>();
 builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.AsnResolutionService>();
 builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.MonitoringAlertEvaluator>();

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -1654,6 +1654,7 @@ LanFlowMapEndpoints.Map(app);
 MonitoringChartEndpoints.Map(app);
 IspHealthEndpoints.Map(app);
 MonitoringInvestigateEndpoints.Map(app);
+FlakyTargetEndpoints.Map(app);
 DeviceHealthChartEndpoints.Map(app);
 SfpChartEndpoints.Map(app);
 CellularChartEndpoints.Map(app);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/FlakyTargetService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/FlakyTargetService.cs
@@ -29,8 +29,10 @@ public class FlakyTargetService
         _logger = logger;
     }
 
-    /// <summary>Lookback window. We bin hourly, so this is also the max bin count.</summary>
+    /// <summary>Lookback window; we use all available data up to this, never require it.</summary>
     private const int LookbackHours = 48;
+    /// <summary>Bin size. Fine enough (loss arrives every 10-15 s) that we can help within ~30 min of monitoring.</summary>
+    private const int BinMinutes = 10;
     /// <summary>A target is "over" in a bin when its loss is at least this multiple of the peer median.</summary>
     private const double LossMultiplier = 4.0;
     /// <summary>...and at least this absolute loss, so trivial loss on a near-zero baseline isn't flagged.</summary>
@@ -41,8 +43,8 @@ public class FlakyTargetService
     private const double SharedLossPoolFraction = 0.5;
     /// <summary>Loss at or above this in a bin counts as "losing heavily" for the shared-loss test.</summary>
     private const double SharedLossHeavyPct = 5.0;
-    /// <summary>A target needs at least this many surviving bins of data before we'll judge it (the "couple hours").</summary>
-    private const int MinTargetBins = 6;
+    /// <summary>Minimum surviving bins before we'll judge a target. 3 x 10 min = help from ~30 min in, not 6 h.</summary>
+    private const int MinTargetBins = 3;
 
     /// <summary>One flagged target plus the evidence behind the call.</summary>
     public record FlakyTarget(
@@ -84,9 +86,9 @@ public class FlakyTargetService
         var byId = pool.ToDictionary(t => t.TargetId, t => t);
         var to = DateTime.UtcNow;
         var from = to.AddHours(-LookbackHours);
-        var hourly = TimeSpan.FromHours(1);
+        var binSize = TimeSpan.FromMinutes(BinMinutes);
 
-        // Per-target hourly loss (the aggregateWindow already bins to the hour). Pull all three
+        // Per-target binned loss (the aggregateWindow does the binning). Pull all three
         // WAN-path types and keep only enabled pool targets.
         var lossByTarget = new Dictionary<string, Dictionary<DateTime, double>>();
         foreach (var type in new[] { MonitoringTargetType.AccessIsp, MonitoringTargetType.Transit, MonitoringTargetType.InternetService })
@@ -94,7 +96,7 @@ public class FlakyTargetService
             Dictionary<string, List<MonitoringInfluxClient.LatencySeriesPoint>> series;
             try
             {
-                series = await _influx.QueryLatencyDetailByTargetTypeAsync(type, from, to, hourly, ct);
+                series = await _influx.QueryLatencyDetailByTargetTypeAsync(type, from, to, binSize, ct);
             }
             catch (Exception ex)
             {
@@ -108,7 +110,7 @@ public class FlakyTargetService
                 foreach (var p in points)
                 {
                     if (!p.LossPercent.HasValue) continue;
-                    bins[FloorToHour(p.Time)] = p.LossPercent.Value;
+                    bins[FloorToBin(p.Time, binSize)] = p.LossPercent.Value;
                 }
             }
         }
@@ -163,8 +165,8 @@ public class FlakyTargetService
         return flaky.OrderByDescending(f => f.LossPct).ToList();
     }
 
-    private static DateTime FloorToHour(DateTime t) =>
-        new DateTime(t.Year, t.Month, t.Day, t.Hour, 0, 0, DateTimeKind.Utc);
+    private static DateTime FloorToBin(DateTime t, TimeSpan bin) =>
+        new DateTime(t.Ticks - (t.Ticks % bin.Ticks), DateTimeKind.Utc);
 
     private static double Median(List<double> values)
     {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/FlakyTargetService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/FlakyTargetService.cs
@@ -1,0 +1,176 @@
+using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Storage.Models;
+
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Detects flaky WAN-path monitoring targets (issue #849): an AccessIsp / Transit / InternetService
+/// target whose packet loss is notably above the peer baseline, consistently, over the retained
+/// window - usually ICMP-deprioritized routers. Relative-to-peers so it auto-calibrates per
+/// connection (congested DOCSIS at 0.5% across the board doesn't false-positive; a transit router
+/// at 10% against a 0.2% baseline does).
+///
+/// Computed on demand (Live View banner + Network Performance panel initial loads) - never polled.
+/// Reuses the existing per-target loss query; adds no Influx measurements.
+/// </summary>
+public class FlakyTargetService
+{
+    private readonly IDbContextFactory<NetworkOptimizerDbContext> _dbFactory;
+    private readonly MonitoringInfluxClient _influx;
+    private readonly ILogger<FlakyTargetService> _logger;
+
+    public FlakyTargetService(
+        IDbContextFactory<NetworkOptimizerDbContext> dbFactory,
+        MonitoringInfluxClient influx,
+        ILogger<FlakyTargetService> logger)
+    {
+        _dbFactory = dbFactory;
+        _influx = influx;
+        _logger = logger;
+    }
+
+    /// <summary>Lookback window. We bin hourly, so this is also the max bin count.</summary>
+    private const int LookbackHours = 48;
+    /// <summary>A target is "over" in a bin when its loss is at least this multiple of the peer median.</summary>
+    private const double LossMultiplier = 4.0;
+    /// <summary>...and at least this absolute loss, so trivial loss on a near-zero baseline isn't flagged.</summary>
+    private const double LossAbsoluteFloorPct = 3.0;
+    /// <summary>Flagged only when over-threshold in at least this fraction of its surviving bins.</summary>
+    private const double ConsistencyFraction = 0.70;
+    /// <summary>A bin is a shared-loss event (excluded) when at least this fraction of the pool loses heavily in it.</summary>
+    private const double SharedLossPoolFraction = 0.5;
+    /// <summary>Loss at or above this in a bin counts as "losing heavily" for the shared-loss test.</summary>
+    private const double SharedLossHeavyPct = 5.0;
+    /// <summary>A target needs at least this many surviving bins of data before we'll judge it (the "couple hours").</summary>
+    private const int MinTargetBins = 6;
+
+    /// <summary>One flagged target plus the evidence behind the call.</summary>
+    public record FlakyTarget(
+        string TargetId,
+        int Id,
+        string Name,
+        MonitoringTargetType Type,
+        double LossPct,
+        double BaselinePct,
+        int OverBins,
+        int TotalBins)
+    {
+        public string Evidence => $"{LossPct:0.0}% loss vs {BaselinePct:0.0}% peer median";
+    }
+
+    /// <summary>
+    /// Returns the flaky targets, worst loss first. Empty when there isn't enough data yet,
+    /// Influx isn't configured, or nothing is flaky.
+    /// </summary>
+    public async Task<IReadOnlyList<FlakyTarget>> DetectAsync(CancellationToken ct = default)
+    {
+        List<MonitoringTarget> pool;
+        try
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync(ct);
+            pool = await db.MonitoringTargets.AsNoTracking()
+                .Where(t => t.Enabled && (t.TargetType == MonitoringTargetType.AccessIsp
+                    || t.TargetType == MonitoringTargetType.Transit
+                    || t.TargetType == MonitoringTargetType.InternetService))
+                .ToListAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Flaky-target detect: failed to load pool");
+            return System.Array.Empty<FlakyTarget>();
+        }
+        if (pool.Count < 2) return System.Array.Empty<FlakyTarget>();
+
+        var byId = pool.ToDictionary(t => t.TargetId, t => t);
+        var to = DateTime.UtcNow;
+        var from = to.AddHours(-LookbackHours);
+        var hourly = TimeSpan.FromHours(1);
+
+        // Per-target hourly loss (the aggregateWindow already bins to the hour). Pull all three
+        // WAN-path types and keep only enabled pool targets.
+        var lossByTarget = new Dictionary<string, Dictionary<DateTime, double>>();
+        foreach (var type in new[] { MonitoringTargetType.AccessIsp, MonitoringTargetType.Transit, MonitoringTargetType.InternetService })
+        {
+            Dictionary<string, List<MonitoringInfluxClient.LatencySeriesPoint>> series;
+            try
+            {
+                series = await _influx.QueryLatencyDetailByTargetTypeAsync(type, from, to, hourly, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Flaky-target detect: loss query failed for {Type}", type);
+                return System.Array.Empty<FlakyTarget>();
+            }
+            foreach (var (targetId, points) in series)
+            {
+                if (!byId.ContainsKey(targetId)) continue;
+                var bins = lossByTarget.TryGetValue(targetId, out var existing) ? existing : lossByTarget[targetId] = new();
+                foreach (var p in points)
+                {
+                    if (!p.LossPercent.HasValue) continue;
+                    bins[FloorToHour(p.Time)] = p.LossPercent.Value;
+                }
+            }
+        }
+        if (lossByTarget.Count < 2) return System.Array.Empty<FlakyTarget>();
+
+        // Shared-loss exclusion: drop bins where at least half the reporting pool is losing heavily
+        // - a path-wide event (outage/congestion), not one flaky target. Cheap proxy for the real
+        // outage detector: no dark-fraction gating, just "are most targets hurting this hour?".
+        var allBins = lossByTarget.Values.SelectMany(b => b.Keys).ToHashSet();
+        var excludedBins = new HashSet<DateTime>();
+        foreach (var bin in allBins)
+        {
+            var reporting = lossByTarget.Values.Where(b => b.ContainsKey(bin)).Select(b => b[bin]).ToList();
+            if (reporting.Count == 0) continue;
+            var heavy = reporting.Count(l => l >= SharedLossHeavyPct);
+            if ((double)heavy / reporting.Count >= SharedLossPoolFraction)
+                excludedBins.Add(bin);
+        }
+
+        var survivingBins = allBins.Count - excludedBins.Count;
+        if (survivingBins < MinTargetBins)
+        {
+            _logger.LogDebug("Flaky-target detect: only {Bins} surviving bins (< {Min}); not enough data yet", survivingBins, MinTargetBins);
+            return System.Array.Empty<FlakyTarget>();
+        }
+
+        // Peer baseline: median of every surviving (target, bin) loss value. Median, not mean, so the
+        // flaky targets we're hunting don't inflate the baseline and mask each other.
+        var allLosses = new List<double>();
+        foreach (var bins in lossByTarget.Values)
+            foreach (var (bin, loss) in bins)
+                if (!excludedBins.Contains(bin)) allLosses.Add(loss);
+        if (allLosses.Count == 0) return System.Array.Empty<FlakyTarget>();
+        var baseline = Median(allLosses);
+        var threshold = Math.Max(LossMultiplier * baseline, LossAbsoluteFloorPct);
+
+        var flaky = new List<FlakyTarget>();
+        foreach (var (targetId, bins) in lossByTarget)
+        {
+            var survivors = bins.Where(kv => !excludedBins.Contains(kv.Key)).Select(kv => kv.Value).ToList();
+            if (survivors.Count < MinTargetBins) continue;
+            var over = survivors.Count(l => l >= threshold);
+            if ((double)over / survivors.Count < ConsistencyFraction) continue;
+
+            var t = byId[targetId];
+            flaky.Add(new FlakyTarget(targetId, t.Id, string.IsNullOrEmpty(t.Name) ? t.Address : t.Name,
+                t.TargetType, Median(survivors), baseline, over, survivors.Count));
+        }
+
+        _logger.LogDebug("Flaky-target detect: {Count} flagged, baseline {Base:0.00}%, threshold {Thr:0.00}%, {Bins} surviving bins",
+            flaky.Count, baseline, threshold, survivingBins);
+        return flaky.OrderByDescending(f => f.LossPct).ToList();
+    }
+
+    private static DateTime FloorToHour(DateTime t) =>
+        new DateTime(t.Year, t.Month, t.Day, t.Hour, 0, 0, DateTimeKind.Utc);
+
+    private static double Median(List<double> values)
+    {
+        var sorted = values.OrderBy(v => v).ToList();
+        var n = sorted.Count;
+        if (n == 0) return 0;
+        return n % 2 == 1 ? sorted[n / 2] : (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0;
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/FlakyTargetService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/FlakyTargetService.cs
@@ -119,12 +119,14 @@ public class FlakyTargetService
 
     /// <summary>
     /// Pure analysis (no I/O): given per-target binned loss, flag the flaky ones. A target is flaky
-    /// when its MEDIAN surviving-bin loss is at or above the threshold (>= <see cref="LossMultiplier"/>x
-    /// the peer-median loss AND >= <see cref="LossAbsoluteFloorPct"/>). Median - not a per-bin
-    /// over-threshold count - so a target that's notably lossy most of the time is caught even when
-    /// bursty (e.g. 0/1/6/6/3/17% reads a 4.5% median), while a single spike on an otherwise-clean
-    /// target (median ~0) is not. Bins where >= half the pool loses heavily are excluded first as
-    /// path-wide events, and a target needs <see cref="MinTargetBins"/> surviving bins to be judged.
+    /// when its TRIMMED-MEAN surviving-bin loss (drop the single highest + lowest bin, average the
+    /// rest) is at or above the threshold (>= <see cref="LossMultiplier"/>x the peer-median loss AND
+    /// >= <see cref="LossAbsoluteFloorPct"/>). Trimmed mean is spike-robust like a median (a single
+    /// 100% bin on an otherwise-clean target trims away) but, unlike a small-sample median, it does
+    /// not flap when one clean bin rolls in - the median of ~6 bursty bins can swing across the floor
+    /// (e.g. 2.86% -> 4.5%), the trimmed mean stays put (~4%). Bins where >= half the pool loses
+    /// heavily are excluded first as path-wide events, and a target needs <see cref="MinTargetBins"/>
+    /// surviving bins to be judged. The peer baseline still uses a plain median across the pool.
     /// </summary>
     internal static IReadOnlyList<FlakyTarget> Analyze(
         Dictionary<string, Dictionary<DateTime, double>> lossByTarget,
@@ -167,13 +169,13 @@ public class FlakyTargetService
         {
             var survivors = bins.Where(kv => !excludedBins.Contains(kv.Key)).Select(kv => kv.Value).ToList();
             if (survivors.Count < MinTargetBins) continue;
-            var median = Median(survivors);
-            if (median < threshold) continue;
+            var metric = TrimmedMean(survivors);
+            if (metric < threshold) continue;
 
             if (!byId.TryGetValue(targetId, out var t)) continue;
             var over = survivors.Count(l => l >= threshold);
             flaky.Add(new FlakyTarget(targetId, t.Id, string.IsNullOrEmpty(t.Name) ? t.Address : t.Name,
-                t.TargetType, median, baseline, over, survivors.Count));
+                t.TargetType, metric, baseline, over, survivors.Count));
         }
 
         logger?.LogDebug("Flaky-target detect: {Count} flagged, baseline {Base:0.00}%, threshold {Thr:0.00}%, {Bins} surviving bins",
@@ -190,5 +192,18 @@ public class FlakyTargetService
         var n = sorted.Count;
         if (n == 0) return 0;
         return n % 2 == 1 ? sorted[n / 2] : (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0;
+    }
+
+    /// <summary>
+    /// Mean after dropping the single lowest and single highest value. Spike-robust (one bad bin
+    /// trims away) without the small-sample jumpiness of a median. Callers gate on Count &gt;= 3, so
+    /// at least one value always remains.
+    /// </summary>
+    private static double TrimmedMean(List<double> values)
+    {
+        var sorted = values.OrderBy(v => v).ToList();
+        if (sorted.Count < 3) return sorted.Count == 0 ? 0 : sorted.Average();
+        var core = sorted.GetRange(1, sorted.Count - 2);
+        return core.Average();
     }
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/FlakyTargetService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/FlakyTargetService.cs
@@ -37,8 +37,6 @@ public class FlakyTargetService
     private const double LossMultiplier = 4.0;
     /// <summary>...and at least this absolute loss, so trivial loss on a near-zero baseline isn't flagged.</summary>
     private const double LossAbsoluteFloorPct = 3.0;
-    /// <summary>Flagged only when over-threshold in at least this fraction of its surviving bins.</summary>
-    private const double ConsistencyFraction = 0.70;
     /// <summary>A bin is a shared-loss event (excluded) when at least this fraction of the pool loses heavily in it.</summary>
     private const double SharedLossPoolFraction = 0.5;
     /// <summary>Loss at or above this in a bin counts as "losing heavily" for the shared-loss test.</summary>
@@ -116,9 +114,26 @@ public class FlakyTargetService
         }
         if (lossByTarget.Count < 2) return System.Array.Empty<FlakyTarget>();
 
+        return Analyze(lossByTarget, byId, _logger);
+    }
+
+    /// <summary>
+    /// Pure analysis (no I/O): given per-target binned loss, flag the flaky ones. A target is flaky
+    /// when its MEDIAN surviving-bin loss is at or above the threshold (>= <see cref="LossMultiplier"/>x
+    /// the peer-median loss AND >= <see cref="LossAbsoluteFloorPct"/>). Median - not a per-bin
+    /// over-threshold count - so a target that's notably lossy most of the time is caught even when
+    /// bursty (e.g. 0/1/6/6/3/17% reads a 4.5% median), while a single spike on an otherwise-clean
+    /// target (median ~0) is not. Bins where >= half the pool loses heavily are excluded first as
+    /// path-wide events, and a target needs <see cref="MinTargetBins"/> surviving bins to be judged.
+    /// </summary>
+    internal static IReadOnlyList<FlakyTarget> Analyze(
+        Dictionary<string, Dictionary<DateTime, double>> lossByTarget,
+        IReadOnlyDictionary<string, MonitoringTarget> byId,
+        ILogger? logger = null)
+    {
         // Shared-loss exclusion: drop bins where at least half the reporting pool is losing heavily
         // - a path-wide event (outage/congestion), not one flaky target. Cheap proxy for the real
-        // outage detector: no dark-fraction gating, just "are most targets hurting this hour?".
+        // outage detector: no dark-fraction gating, just "are most targets hurting this bin?".
         var allBins = lossByTarget.Values.SelectMany(b => b.Keys).ToHashSet();
         var excludedBins = new HashSet<DateTime>();
         foreach (var bin in allBins)
@@ -133,7 +148,7 @@ public class FlakyTargetService
         var survivingBins = allBins.Count - excludedBins.Count;
         if (survivingBins < MinTargetBins)
         {
-            _logger.LogDebug("Flaky-target detect: only {Bins} surviving bins (< {Min}); not enough data yet", survivingBins, MinTargetBins);
+            logger?.LogDebug("Flaky-target detect: only {Bins} surviving bins (< {Min}); not enough data yet", survivingBins, MinTargetBins);
             return System.Array.Empty<FlakyTarget>();
         }
 
@@ -152,15 +167,16 @@ public class FlakyTargetService
         {
             var survivors = bins.Where(kv => !excludedBins.Contains(kv.Key)).Select(kv => kv.Value).ToList();
             if (survivors.Count < MinTargetBins) continue;
-            var over = survivors.Count(l => l >= threshold);
-            if ((double)over / survivors.Count < ConsistencyFraction) continue;
+            var median = Median(survivors);
+            if (median < threshold) continue;
 
-            var t = byId[targetId];
+            if (!byId.TryGetValue(targetId, out var t)) continue;
+            var over = survivors.Count(l => l >= threshold);
             flaky.Add(new FlakyTarget(targetId, t.Id, string.IsNullOrEmpty(t.Name) ? t.Address : t.Name,
-                t.TargetType, Median(survivors), baseline, over, survivors.Count));
+                t.TargetType, median, baseline, over, survivors.Count));
         }
 
-        _logger.LogDebug("Flaky-target detect: {Count} flagged, baseline {Base:0.00}%, threshold {Thr:0.00}%, {Bins} surviving bins",
+        logger?.LogDebug("Flaky-target detect: {Count} flagged, baseline {Base:0.00}%, threshold {Thr:0.00}%, {Bins} surviving bins",
             flaky.Count, baseline, threshold, survivingBins);
         return flaky.OrderByDescending(f => f.LossPct).ToList();
     }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -265,6 +265,15 @@ public class IspHealthOptions
     public double JitterAssimilationMinDeltaMs { get; set; } = 0.05;
 
     /// <summary>
+    /// Item D - how strongly the internet-relative reach ceiling absolves an ISP access hop's
+    /// intra-ASN distance penalty. finalCeiling = C_intra + alpha * max(0, C_net - C_intra), so it
+    /// only ever lifts (never lowers) and partially (alpha &lt; 1) - genuine distance/glass always
+    /// leaves a mark, but a hop that's modest relative to where the internet actually sits isn't
+    /// hammered for normal in-region distance on a geographically large access network.
+    /// </summary>
+    public double AccessReachInternetBlendAlpha { get; set; } = 0.40;
+
+    /// <summary>
     /// Average WAN load at which packet loss reaches its worst on shared-medium access
     /// (DOCSIS, PON, fixed wireless). The load-calibrated loss ceiling reaches the
     /// connection's loaded-loss band at this utilization and holds there above it, rather
@@ -298,7 +307,15 @@ public sealed record AccessProfile(
     double LoadedLossUpHighPct,
     double LoadedDeltaExcellentMs,
     double LoadedDeltaAcceptableMs,
-    bool IsNeutral = false);
+    bool IsNeutral = false,
+    // Per-tech jitter band (P95 jitter, ms). When set, jitter is scored straight off the band -
+    // (ideal,100) (typical,90) (poor,25) (2*poor,0) - so a medium's inherent jitter (e.g. DOCSIS's
+    // ~3 ms request-grant) reads as normal instead of being graded against a sub-ms path floor.
+    // Null (neutral / PPPoE / Other) keeps the measured-path-floor jitter curve. Applies path-wide
+    // to ISP and transit jitter, since every probe crosses the access medium.
+    double? JitterIdealMs = null,
+    double? JitterTypicalMs = null,
+    double? JitterPoorMs = null);
 
 /// <summary>
 /// Static catalog of access technology profiles. Returns null for
@@ -315,56 +332,64 @@ public static class IspHealthProfiles
             IdleLossIdealPct: 0.02, IdleLossAcceptablePct: 0.05,
             LoadedLossDownLowPct: 1.0, LoadedLossDownHighPct: 2.0,
             LoadedLossUpLowPct: 0.5, LoadedLossUpHighPct: 1.0,
-            LoadedDeltaExcellentMs: 2.0, LoadedDeltaAcceptableMs: 10.0),
+            LoadedDeltaExcellentMs: 2.0, LoadedDeltaAcceptableMs: 10.0,
+            JitterIdealMs: 0.4, JitterTypicalMs: 0.7, JitterPoorMs: 3.0),
 
         AccessTechnology.XgsPon => new AccessProfile("XGS-PON",
             IdleRttIdealMs: 1.5, IdleRttNormalLowMs: 2.0, IdleRttNormalHighMs: 3.0, IdleRttPoorMs: 8.0,
             IdleLossIdealPct: 0.02, IdleLossAcceptablePct: 0.05,
             LoadedLossDownLowPct: 0.5, LoadedLossDownHighPct: 1.0,
             LoadedLossUpLowPct: 0.25, LoadedLossUpHighPct: 0.5,
-            LoadedDeltaExcellentMs: 2.0, LoadedDeltaAcceptableMs: 10.0),
+            LoadedDeltaExcellentMs: 2.0, LoadedDeltaAcceptableMs: 10.0,
+            JitterIdealMs: 0.4, JitterTypicalMs: 0.7, JitterPoorMs: 3.0),
 
         AccessTechnology.Docsis => new AccessProfile("DOCSIS",
             IdleRttIdealMs: 7.0, IdleRttNormalLowMs: 9.0, IdleRttNormalHighMs: 12.0, IdleRttPoorMs: 25.0,
             IdleLossIdealPct: 0.02, IdleLossAcceptablePct: 0.2,
             LoadedLossDownLowPct: 3.0, LoadedLossDownHighPct: 5.0,
             LoadedLossUpLowPct: 3.0, LoadedLossUpHighPct: 5.0,
-            LoadedDeltaExcellentMs: 5.0, LoadedDeltaAcceptableMs: 20.0),
+            LoadedDeltaExcellentMs: 5.0, LoadedDeltaAcceptableMs: 20.0,
+            JitterIdealMs: 1.75, JitterTypicalMs: 3.0, JitterPoorMs: 6.0),
 
         AccessTechnology.Satellite => new AccessProfile("Satellite (LEO)",
             IdleRttIdealMs: 23.0, IdleRttNormalLowMs: 30.0, IdleRttNormalHighMs: 45.0, IdleRttPoorMs: 80.0,
             IdleLossIdealPct: 0.2, IdleLossAcceptablePct: 0.5,
             LoadedLossDownLowPct: 0.5, LoadedLossDownHighPct: 1.0,
             LoadedLossUpLowPct: 0.25, LoadedLossUpHighPct: 0.5,
-            LoadedDeltaExcellentMs: 5.0, LoadedDeltaAcceptableMs: 25.0),
+            LoadedDeltaExcellentMs: 5.0, LoadedDeltaAcceptableMs: 25.0,
+            JitterIdealMs: 5.0, JitterTypicalMs: 6.5, JitterPoorMs: 15.0),
 
         AccessTechnology.DirectEthernet => new AccessProfile("Active Ethernet",
             IdleRttIdealMs: 0.5, IdleRttNormalLowMs: 1.0, IdleRttNormalHighMs: 3.0, IdleRttPoorMs: 8.0,
             IdleLossIdealPct: 0.02, IdleLossAcceptablePct: 0.05,
             LoadedLossDownLowPct: 1.0, LoadedLossDownHighPct: 2.0,
             LoadedLossUpLowPct: 0.5, LoadedLossUpHighPct: 1.0,
-            LoadedDeltaExcellentMs: 2.0, LoadedDeltaAcceptableMs: 10.0),
+            LoadedDeltaExcellentMs: 2.0, LoadedDeltaAcceptableMs: 10.0,
+            JitterIdealMs: 0.4, JitterTypicalMs: 0.7, JitterPoorMs: 3.0),
 
         AccessTechnology.FixedWireless => new AccessProfile("Fixed Wireless",
             IdleRttIdealMs: 5.0, IdleRttNormalLowMs: 8.0, IdleRttNormalHighMs: 15.0, IdleRttPoorMs: 35.0,
             IdleLossIdealPct: 0.3, IdleLossAcceptablePct: 0.5,
             LoadedLossDownLowPct: 2.0, LoadedLossDownHighPct: 4.0,
             LoadedLossUpLowPct: 1.0, LoadedLossUpHighPct: 2.0,
-            LoadedDeltaExcellentMs: 10.0, LoadedDeltaAcceptableMs: 20.0),
+            LoadedDeltaExcellentMs: 10.0, LoadedDeltaAcceptableMs: 20.0,
+            JitterIdealMs: 2.5, JitterTypicalMs: 4.0, JitterPoorMs: 12.0),
 
         AccessTechnology.Cellular => new AccessProfile("Cellular",
             IdleRttIdealMs: 20.0, IdleRttNormalLowMs: 25.0, IdleRttNormalHighMs: 50.0, IdleRttPoorMs: 90.0,
             IdleLossIdealPct: 0.3, IdleLossAcceptablePct: 0.5,
             LoadedLossDownLowPct: 2.0, LoadedLossDownHighPct: 4.0,
             LoadedLossUpLowPct: 2.0, LoadedLossUpHighPct: 4.0,
-            LoadedDeltaExcellentMs: 20.0, LoadedDeltaAcceptableMs: 50.0),
+            LoadedDeltaExcellentMs: 20.0, LoadedDeltaAcceptableMs: 50.0,
+            JitterIdealMs: 4.0, JitterTypicalMs: 6.0, JitterPoorMs: 20.0),
 
         AccessTechnology.Dsl => new AccessProfile("DSL",
             IdleRttIdealMs: 6.0, IdleRttNormalLowMs: 10.0, IdleRttNormalHighMs: 25.0, IdleRttPoorMs: 50.0,
             IdleLossIdealPct: 0.05, IdleLossAcceptablePct: 0.2,
             LoadedLossDownLowPct: 3.0, LoadedLossDownHighPct: 5.0,
             LoadedLossUpLowPct: 3.0, LoadedLossUpHighPct: 5.0,
-            LoadedDeltaExcellentMs: 5.0, LoadedDeltaAcceptableMs: 20.0),
+            LoadedDeltaExcellentMs: 5.0, LoadedDeltaAcceptableMs: 20.0,
+            JitterIdealMs: 1.0, JitterTypicalMs: 2.0, JitterPoorMs: 5.0),
 
         AccessTechnology.PppoE => NeutralProfile("PPPoE"),
         AccessTechnology.Other => NeutralProfile("Other"),

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -19,6 +19,10 @@ public class IspHealthScorer
     // they would double-count and tank the Transit/ISP dimensions. Set per Score() call.
     private IReadOnlyList<OutageEvent> _outages = System.Array.Empty<OutageEvent>();
 
+    // The access profile for the current report, set per Score() call. Carries the per-tech jitter
+    // band (Item E) used to grade ISP and transit jitter against the access medium's inherent floor.
+    private AccessProfile? _profile;
+
     private bool InOutage(DateTime time) => _outages.Any(o => time >= o.Start && time < o.End);
 
     public IspHealthScorer(IspHealthOptions options, ILogger? logger = null)
@@ -30,6 +34,7 @@ public class IspHealthScorer
     public IspHealthReport Score(IspHealthInputs inputs, AccessProfile profile)
     {
         _outages = inputs.Outages;
+        _profile = profile;
         if (inputs.LoadExclusionWindows.Count > 0)
         {
             foreach (var (exStart, exEnd) in inputs.LoadExclusionWindows)
@@ -66,7 +71,7 @@ public class IspHealthScorer
         // absolves a hop it is proven downstream of), so a divergent clean transit can't
         // clear a congested hop it never traverses. Hops further out on the same ISP also
         // get a soft intra-ASN reach ceiling. Access layer idle latency still uses FirstHopSeries.
-        var ispHopGrades = GradeIspHops(inputs.IspAsnSeries, inputs.TransitAsnSeries, transitAsns, inputs.DestinationSeries, inputs.CongestionEvents, jitterFloor, inputs.HopOrderKnown);
+        var ispHopGrades = GradeIspHops(inputs.IspAsnSeries, inputs.TransitAsnSeries, transitAsns, inputs.DestinationSeries, inputs.CongestionEvents, jitterFloor, inputs.HopOrderKnown, accessMedianRtt, inputs.InternetMedianDeltaMs);
         // Collapse the per-hop grades to one entry per ASN for the Networks on Your Path card.
         var ispAsns = AggregateIspAsns(ispHopGrades, inputs.CongestionEvents, _options.JitterAssimilationMinDeltaMs);
         var transitDimension = BuildAsnDimension("Transit Health", _options.TransitWeight, transitAsns);
@@ -622,8 +627,23 @@ public class IspHealthScorer
             // couple ms out is two sites a real distance apart - nominal, not a fault -
             // so it tops out short of perfect rather than getting dinged hard.
             reachDelta = Math.Max(0, medianRtt.Value - intraAsnFloorRttMs.Value);
-            reachCeiling = (int)Math.Round(ScoreCurve.Interpolate(reachDelta.Value,
-                (0, 100), (1, 93), (2, 85), (4, 70), (8, 50), (16, 35)));
+            var cIntra = ScoreCurve.Interpolate(reachDelta.Value,
+                (0, 100), (1, 93), (2, 85), (4, 70), (8, 50), (16, 35));
+
+            // Item D: lift-only blend toward the internet-relative ceiling. Keeps the intra-ASN
+            // distance truth as the floor, but absolves a hop that's modest relative to where the
+            // internet actually sits, so a geographically large access network isn't punished for
+            // normal in-region distance. Never lowers; partial so genuine distance always shows.
+            var ceiling = cIntra;
+            if (accessBaselineRtt.HasValue && internetMedianDeltaMs is > 0)
+            {
+                var netDelta = Math.Max(0, medianRtt.Value - accessBaselineRtt.Value);
+                var ratio = netDelta / Math.Max(internetMedianDeltaMs.Value, 2.0);
+                var cNet = ScoreCurve.Interpolate(ratio,
+                    (0.5, 100), (1.0, 93), (1.5, 90), (2.0, 85), (3.0, 65), (5.0, 40));
+                ceiling = cIntra + _options.AccessReachInternetBlendAlpha * Math.Max(0, cNet - cIntra);
+            }
+            reachCeiling = (int)Math.Round(ceiling);
         }
         else if (accessBaselineRtt.HasValue && medianRtt.HasValue)
         {
@@ -780,6 +800,17 @@ public class IspHealthScorer
     /// </summary>
     private double ScoreJitterVsFloor(double jitterMs, double? floorMs)
     {
+        // Item E: when the access technology defines a jitter band, grade straight off it so the
+        // medium's inherent jitter (e.g. DOCSIS ~3 ms) reads as normal. The floor is the per-tech
+        // ideal - not the measured path floor - so a single quiet sample can't drag the 100-anchor
+        // below what the medium really does. Applies to ISP and transit alike (every probe crosses
+        // the access medium). Techs with no band (neutral / PPPoE / Other) keep the floor curve.
+        if (_profile is { JitterIdealMs: { } ideal, JitterTypicalMs: { } typical, JitterPoorMs: { } poor })
+        {
+            return ScoreCurve.Interpolate(jitterMs,
+                (ideal, 100), (typical, 90), (poor, 25), (2.0 * poor, 0));
+        }
+
         var f = Math.Clamp(floorMs ?? 0.4, _options.JitterFloorMinMs, _options.JitterFloorMaxMs);
         return ScoreCurve.Interpolate(jitterMs,
             (f, 100), (1.25 * f, 96), (1.5 * f, 91), (2.0 * f, 70), (5.0, 22), (12.0, 0));
@@ -804,7 +835,9 @@ public class IspHealthScorer
         List<AsnSeries> destinationSeries,
         List<CongestionEvent> congestionEvents,
         double? jitterFloorMs,
-        bool hopOrderKnown)
+        bool hopOrderKnown,
+        double? accessBaselineRtt,
+        double? internetMedianDeltaMs)
     {
         // Transit witnesses: each transit ASN's ancestor IPs + its effective jitter.
         var transitJitterByAsn = transitAsns
@@ -867,7 +900,7 @@ public class IspHealthScorer
                 if (witnesses.Count > 0)
                     effective = measured.HasValue ? Math.Min(measured.Value, witnesses.Min()) : witnesses.Min();
 
-                var grade = GradeAsn(hop, congestionEvents, jitterFloorMs, accessBaselineRtt: null, internetMedianDeltaMs: null,
+                var grade = GradeAsn(hop, congestionEvents, jitterFloorMs, accessBaselineRtt, internetMedianDeltaMs,
                     intraAsnFloorRttMs: intraFloor, jitterOverrideMs: effective);
                 // Log the graded effective (post sub-0.05 ms assimilation snap in GradeAsn),
                 // not the raw witness min, so the log matches what the hop is actually scored on.

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1060,6 +1060,31 @@ public class UpstreamTracerService
             : "No transit ASNs or path-end targets identified.";
     }
 
+    // Reachability gate: a candidate must answer enough pings in a short rapid burst (200 ms
+    // spacing) to be auto-selected, so flaky, ICMP-deprioritized routers don't get monitored - and
+    // so the Level 3 transit witness (4.2.2.2) is injected exactly when no real AS3356 router clears
+    // the gate. We always send 3; the required successes depend on the connection's access medium
+    // (Item B): air-interface mediums (WISP, cellular) and the unconfigured Unknown case allow one
+    // dropped reply (2/3); stable wired/fiber/LEO mediums demand 3/3.
+    private const int ReachabilityPingCount = 3;
+
+    /// <summary>
+    /// Required successful pings (out of <see cref="ReachabilityPingCount"/>) for a candidate to be
+    /// auto-selected, by the connection's access technology. WISP / cellular have inherent
+    /// air-interface transient loss, and Unknown is unconfigured, so we don't penalize them for a
+    /// single drop; everything else (including LEO, which is stable) demands all three.
+    /// </summary>
+    private static int RequiredReachabilitySuccesses(AccessTechnology tech) => tech switch
+    {
+        AccessTechnology.FixedWireless or AccessTechnology.Cellular or AccessTechnology.Unknown => 2,
+        _ => 3
+    };
+
+    /// <summary>Rapid ping burst used for reachability verification.</summary>
+    private Task<PingProbeResult> ProbeReachabilityAsync(string address, ProbeMode mode, CancellationToken ct) =>
+        _localProbe.PingAsync(new ProbeTarget(address, mode),
+            count: ReachabilityPingCount, perPingTimeout: TimeSpan.FromSeconds(2), ct: ct);
+
     private async Task VerifyReachabilityAsync(CancellationToken ct)
     {
         State.Step = TracerStep.VerifyingReachability;
@@ -1072,23 +1097,17 @@ public class UpstreamTracerService
 
         if (allTargets.Count == 0) return;
 
-        State.CurrentActivity = $"Pinging {allTargets.Count} candidate(s) to verify reachability...";
+        // One gate for the whole run: every probe crosses the same access medium, so a WISP's
+        // air-link loss hits the transit-router pings just as it hits the access-hop pings.
+        var minSuccesses = RequiredReachabilitySuccesses(State.AccessTechnology);
+        State.CurrentActivity = $"Pinging {allTargets.Count} candidate(s) to verify reachability ({minSuccesses}/{ReachabilityPingCount} required)...";
 
-        var tasks = allTargets.Select(async t =>
-        {
-            var result = await _localProbe.PingAsync(
-                new ProbeTarget(t.Address, t.Mode),
-                count: 2,
-                perPingTimeout: TimeSpan.FromSeconds(2),
-                ct: ct);
-            return (t, result);
-        });
-
-        var results = await Task.WhenAll(tasks);
+        var results = await Task.WhenAll(allTargets.Select(async t =>
+            (t, Result: await ProbeReachabilityAsync(t.Address, t.Mode, ct))));
         var unreachable = 0;
         foreach (var (t, result) in results)
         {
-            if (result.Success)
+            if (result.Received >= minSuccesses)
             {
                 t.ApplyRtt(result.RttAvgMs);
             }
@@ -1096,13 +1115,64 @@ public class UpstreamTracerService
             {
                 t.MarkUnreachable();
                 unreachable++;
-                _logger.LogDebug("Ping check failed for {Address} - marked unreachable", t.Address);
+                _logger.LogDebug("Ping check {Recv}/{Sent} for {Address} - below {Min} required, marked unreachable",
+                    result.Received, result.Sent, t.Address, minSuccesses);
             }
         }
+
+        // Item A: if Level 3 (AS3356) is on the path but no AS3356 router cleared the gate, inject
+        // 4.2.2.2 as a transit witness so ISP Health still has Lumen transit data.
+        await InjectTransitWitnessesAsync(minSuccesses, ct);
 
         State.CurrentActivity = unreachable > 0
             ? $"Reachability check complete: {unreachable} of {allTargets.Count} target(s) did not respond and were excluded."
             : $"All {allTargets.Count} target(s) responded to ping.";
+    }
+
+    // Item A: anycast DNS witnesses for transit ASNs whose routers commonly ICMP-deprioritize or
+    // hide behind L2-transparent infra. Used only when the ASN is on the path but no router clears
+    // the reachability gate. The endpoint is anycast (nearest edge), hence the "transit witness"
+    // label. Extend this table to add witnesses for other transit ASNs (e.g. AS7018 AT&T).
+    private static readonly (int Asn, string Address, string Name, string Label)[] TransitWitnesses =
+    {
+        (3356, "4.2.2.2", "Level 3", "Level 3 DNS (transit witness)")
+    };
+
+    private async Task InjectTransitWitnessesAsync(int minSuccesses, CancellationToken ct)
+    {
+        foreach (var (asn, address, name, label) in TransitWitnesses)
+        {
+            // Only when the ASN is actually on the traced path.
+            if (!_mergedHops.Any(h => h.Asn?.Asn == asn)) continue;
+            // Skip if any real router in this ASN already cleared the gate, or the witness exists.
+            if (State.TransitAsns.Any(t => t.AsnNumber == asn && t.Enabled && !t.Unreachable)) continue;
+            if (State.TransitAsns.Any(t => string.Equals(t.HopAddress, address, StringComparison.OrdinalIgnoreCase))) continue;
+
+            // The witness must itself clear the gate before we enable it.
+            var result = await ProbeReachabilityAsync(address, ProbeMode.Icmp, ct);
+            var reachable = result.Received >= minSuccesses;
+            if (!reachable)
+            {
+                _logger.LogDebug("Transit witness {Address} (AS{Asn}) only {Recv}/{Sent} - not injecting",
+                    address, asn, result.Received, result.Sent);
+                continue;
+            }
+
+            State.TransitAsns.Add(new TransitAsnCandidate
+            {
+                AsnNumber = asn,
+                AsnName = name,
+                Label = label,
+                Method = DiscoveryMethod.DirectRouter,
+                TargetId = $"transit-witness-as{asn}-{NormalizeMacForId(address)}",
+                HopAddress = address,
+                RespondedTo = ProbeMode.Icmp,
+                VerifiedRttMs = result.RttAvgMs,
+                Enabled = true
+            });
+            _logger.LogInformation("Injected transit witness {Address} (AS{Asn} {Name}) - no reachable {Name} router",
+                address, asn, name, name);
+        }
     }
 
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1304,6 +1304,7 @@ public class UpstreamTracerService
 
         foreach (var hop in State.AccessHops.Where(h => h.Enabled))
         {
+            _logger.LogDebug("Commit access hop: id={TargetId} label='{Label}' addr={Address}", hop.TargetId, hop.Label, hop.Address);
             await UpsertTargetAsync(db, hop, wanInterface, ct);
         }
         foreach (var hop in State.AccessHops.Where(h => !h.Enabled))
@@ -1318,6 +1319,8 @@ public class UpstreamTracerService
         }
         foreach (var transit in State.TransitAsns.Where(t => t.Enabled))
         {
+            _logger.LogDebug("Commit transit: id={TargetId} label='{Label}' addr={Address} method={Method}",
+                transit.TargetId, transit.Label, transit.HopAddress ?? transit.PathProxyTarget, transit.Method);
             await UpsertTransitTargetAsync(db, transit, wanInterface, ct);
         }
         foreach (var transit in State.TransitAsns.Where(t => !t.Enabled))

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/FlakyTargetServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/FlakyTargetServiceTests.cs
@@ -1,0 +1,92 @@
+using FluentAssertions;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services.Monitoring;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.IspHealth;
+
+/// <summary>
+/// Flaky-target detector (#849) analysis logic. Targets the median-bin-loss criterion: a target is
+/// flagged when its median surviving-bin loss is at/above the threshold (>= 4x peer median AND >= 3%
+/// absolute), which catches a bursty-but-consistently-lossy hop while ignoring a one-off spike.
+/// </summary>
+public class FlakyTargetServiceTests
+{
+    private static readonly DateTime Base = new(2026, 6, 18, 12, 0, 0, DateTimeKind.Utc);
+
+    private static (Dictionary<string, Dictionary<DateTime, double>> Loss, Dictionary<string, MonitoringTarget> Meta) Build(
+        params (string Id, double[] Losses)[] targets)
+    {
+        var loss = new Dictionary<string, Dictionary<DateTime, double>>();
+        var meta = new Dictionary<string, MonitoringTarget>();
+        foreach (var (id, losses) in targets)
+        {
+            var bins = new Dictionary<DateTime, double>();
+            for (var i = 0; i < losses.Length; i++)
+                bins[Base.AddMinutes(10 * i)] = losses[i];
+            loss[id] = bins;
+            meta[id] = new MonitoringTarget
+            {
+                TargetId = id,
+                Id = meta.Count + 1,
+                Name = id,
+                Address = id,
+                TargetType = MonitoringTargetType.Transit
+            };
+        }
+        return (loss, meta);
+    }
+
+    [Fact]
+    public void Bursty_but_consistently_lossy_target_is_flagged()
+    {
+        // The real Mac case: a Level 3 edge hop reading ~7.4% mean / ~4.5% median against
+        // zero-loss peers. The old 70%-of-bins rule missed it (only 3 of 6 bins clear 3%).
+        var (loss, meta) = Build(
+            ("level3-edge", new[] { 0.0, 1.05, 6.21, 6.4, 2.86, 17.5 }),
+            ("clean-a", new[] { 0.0, 0, 0, 0, 0, 0 }),
+            ("clean-b", new[] { 0.0, 0, 0, 0, 0, 0 }));
+
+        var flaky = FlakyTargetService.Analyze(loss, meta);
+
+        flaky.Should().ContainSingle().Which.TargetId.Should().Be("level3-edge");
+        flaky[0].LossPct.Should().BeApproximately(4.5, 0.6);
+    }
+
+    [Fact]
+    public void Single_spike_on_an_otherwise_clean_target_is_not_flagged()
+    {
+        // Median stays ~0, so one bad bin can't masquerade as a flaky target.
+        var (loss, meta) = Build(
+            ("one-spike", new[] { 0.0, 0, 0, 0, 0, 30.0 }),
+            ("clean-a", new[] { 0.0, 0, 0, 0, 0, 0 }),
+            ("clean-b", new[] { 0.0, 0, 0, 0, 0, 0 }));
+
+        FlakyTargetService.Analyze(loss, meta).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Target_with_too_few_bins_is_not_judged()
+    {
+        // Only 2 surviving bins (< MinTargetBins of 3) - not enough data yet.
+        var (loss, meta) = Build(
+            ("new-lossy", new[] { 20.0, 20.0 }),
+            ("clean-a", new[] { 0.0, 0, 0, 0, 0, 0 }),
+            ("clean-b", new[] { 0.0, 0, 0, 0, 0, 0 }));
+
+        FlakyTargetService.Analyze(loss, meta).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Shared_loss_bins_are_excluded_so_an_outage_does_not_flag_everyone()
+    {
+        // All three lose heavily in the first three bins (a path-wide outage), clean after.
+        // Those bins are excluded, leaving every target with a clean median.
+        var (loss, meta) = Build(
+            ("a", new[] { 30.0, 30, 30, 0, 0, 0 }),
+            ("b", new[] { 30.0, 30, 30, 0, 0, 0 }),
+            ("c", new[] { 30.0, 30, 30, 0, 0, 0 }));
+
+        FlakyTargetService.Analyze(loss, meta).Should().BeEmpty();
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/FlakyTargetServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/FlakyTargetServiceTests.cs
@@ -40,8 +40,8 @@ public class FlakyTargetServiceTests
     [Fact]
     public void Bursty_but_consistently_lossy_target_is_flagged()
     {
-        // The real Mac case: a Level 3 edge hop reading ~7.4% mean / ~4.5% median against
-        // zero-loss peers. The old 70%-of-bins rule missed it (only 3 of 6 bins clear 3%).
+        // The real Mac case: a Level 3 edge hop against zero-loss peers. Trimmed mean drops the
+        // 0% and 17.5% bins and averages the rest -> ~4.1%.
         var (loss, meta) = Build(
             ("level3-edge", new[] { 0.0, 1.05, 6.21, 6.4, 2.86, 17.5 }),
             ("clean-a", new[] { 0.0, 0, 0, 0, 0, 0 }),
@@ -50,7 +50,21 @@ public class FlakyTargetServiceTests
         var flaky = FlakyTargetService.Analyze(loss, meta);
 
         flaky.Should().ContainSingle().Which.TargetId.Should().Be("level3-edge");
-        flaky[0].LossPct.Should().BeApproximately(4.5, 0.6);
+        flaky[0].LossPct.Should().BeApproximately(4.13, 0.3);
+    }
+
+    [Fact]
+    public void Trimmed_mean_holds_where_a_small_sample_median_would_flap()
+    {
+        // The 5-bin snapshot from the observed flap: median is 2.86% (< 3%, would DROP the target)
+        // but the trimmed mean is 3.37% (>= 3%, stays flagged). This is the anti-flap fix.
+        var (loss, meta) = Build(
+            ("level3-edge", new[] { 0.0, 1.05, 2.86, 6.21, 6.4 }),
+            ("clean-a", new[] { 0.0, 0, 0, 0, 0 }),
+            ("clean-b", new[] { 0.0, 0, 0, 0, 0 }));
+
+        FlakyTargetService.Analyze(loss, meta).Should().ContainSingle()
+            .Which.TargetId.Should().Be("level3-edge");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -1076,6 +1076,52 @@ public class IspHealthScorerTests
 
         ResolvedDownDelta(inputs).Should().BeApproximately(3, 1.0);
     }
+
+    // ── Item E: per-tech jitter band applied to scoring ───────────────────────────
+
+    [Fact]
+    public void Docsis_inherent_jitter_is_not_penalized_like_fiber()
+    {
+        // The same ISP hop at DOCSIS-typical 3 ms jitter: normal for cable, poor for fiber.
+        var docsis = IspHealthProfiles.GetProfile(AccessTechnology.Docsis)!;
+        var hops = new List<AsnSeries> { IspHop("isp-a", "ISP A", 8.0, 3.0) };
+
+        var docsisReport = new IspHealthScorer(Options).Score(
+            BuildInputs(idleRtt: 8.0, ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-a"), docsis);
+        var fiberReport = new IspHealthScorer(Options).Score(
+            BuildInputs(idleRtt: 8.0, ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-a"), Gpon);
+
+        docsisReport.IspAsnDimension.Score.Should().BeGreaterThan(
+            fiberReport.IspAsnDimension.Score!.Value + 10,
+            "3 ms jitter is normal on DOCSIS but poor on fiber");
+    }
+
+    // ── Item D: ISP access-hop reach blend (internet-relative lift) ────────────────
+
+    [Fact]
+    public void Far_isp_hop_is_lifted_when_modest_versus_internet_distance()
+    {
+        // Two hops in one ISP ASN; the far hop sits 4 ms past the near one but the internet
+        // itself is 30 ms out, so that distance is modest in context and should be absolved up.
+        var hops = new List<AsnSeries>
+        {
+            IspHop("isp-near", "Near", 2.0, 0.3),
+            IspHop("isp-far", "Far", 6.0, 0.3)
+        };
+
+        var withContext = new IspHealthScorer(Options).Score(
+            BuildInputs(idleRtt: 2.0, ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-near", internetDeltaMs: 30.0), Gpon);
+        var without = new IspHealthScorer(Options).Score(
+            BuildInputs(idleRtt: 2.0, ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-near"), Gpon);
+
+        var farWith = withContext.IspTargets.Single(t => t.TargetId == "isp-far").OverallScore;
+        var farWithout = without.IspTargets.Single(t => t.TargetId == "isp-far").OverallScore;
+
+        farWith.Should().BeGreaterThan(farWithout!.Value,
+            "the internet-relative blend lifts a hop that's modest relative to internet distance");
+        // Lift only - the near (zero-distance) hop is untouched at the top.
+        withContext.IspTargets.Single(t => t.TargetId == "isp-near").OverallScore.Should().Be(100);
+    }
 }
 
 public class IspHealthProfilesTests
@@ -1118,5 +1164,28 @@ public class IspHealthProfilesTests
             var p = IspHealthProfiles.GetProfile(tech)!;
             p.LoadedLossUpHighPct.Should().BeLessThanOrEqualTo(p.LoadedLossDownHighPct, $"{tech} upstream band should not exceed downstream");
         }
+    }
+
+    // ── Item E: per-tech jitter band ──────────────────────────────────────────────
+
+    [Fact]
+    public void Jitter_bands_are_set_for_known_techs_and_null_for_neutral()
+    {
+        foreach (var tech in new[]
+        {
+            AccessTechnology.Gpon, AccessTechnology.XgsPon, AccessTechnology.Docsis,
+            AccessTechnology.Satellite, AccessTechnology.DirectEthernet,
+            AccessTechnology.FixedWireless, AccessTechnology.Cellular, AccessTechnology.Dsl
+        })
+        {
+            var p = IspHealthProfiles.GetProfile(tech)!;
+            p.JitterIdealMs.Should().NotBeNull($"{tech} should carry a jitter band");
+            p.JitterTypicalMs.Should().NotBeNull();
+            p.JitterPoorMs.Should().NotBeNull();
+        }
+
+        // Neutral techs keep the measured-floor curve - no band.
+        IspHealthProfiles.GetProfile(AccessTechnology.PppoE)!.JitterTypicalMs.Should().BeNull();
+        IspHealthProfiles.GetProfile(AccessTechnology.Other)!.JitterTypicalMs.Should().BeNull();
     }
 }


### PR DESCRIPTION
## Upstream discovery

- **Level 3 transit witness** - when AS3356 is on the traced path but no AS3356 router clears the reachability gate, inject `4.2.2.2` as a Transit target ("Level 3 DNS (transit witness)") so ISP Health still has Lumen transit data. Driven by a small AS-to-witness table for future extension.
- **Reachability stringency** - the discovery gate now requires 3 of 3 pings (2 of 3 for WISP, cellular, and unconfigured connections, which have inherent air-interface loss). Set once per run from the access technology and applied to all candidates. Flaky, ICMP-deprioritized routers no longer get auto-selected.
- **Transit list grouped by ASN** - hops in the same transit network list together, networks ordered nearest-first by RTT.
- **Label edits** - target name inputs bind on input so a rename can't be lost to focus/refresh timing.

## ISP Health scoring

- **Access-hop reach calibration** - ISP access hops now get the same internet-relative reach context transit already used, blended lift-only with the existing intra-ASN distance penalty. A geographically large access network is no longer punished for normal in-region distance, while genuine extra latency still counts.
- **Per-technology jitter band** - jitter is graded against a per-tech band (e.g. DOCSIS ~3 ms, fiber sub-ms, LEO ~6.5 ms) instead of a one-size sub-ms floor, so a medium's inherent jitter reads as normal. Applies to ISP and transit hops alike.

## Flaky-target detection (#849)

- Detects AccessISP / Transit / InternetService targets whose loss is notably above the peer median (>= 4x and >= 3% absolute), surfacing within ~30 minutes of monitoring. Spike-robust and stable (trimmed-mean of 10-minute bins; path-wide loss events excluded).
- Advisory panel above Latency Targets (hidden when clean) with one-click disable and disable-all, plus a Live View banner that scrolls to it. Detection runs only on those tabs' initial load - no polling, no new InfluxDB measurements.

## Testing

- New unit tests for the per-tech jitter band, the access reach blend, and the flaky detector (bursty-flags, single-spike-ignored, too-few-bins, shared-loss-excluded, anti-flap). Full suite green, zero build warnings.