### PR TITLE
ISP Health: collapsible ISP Network list + fix broken CSS animations

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -195,14 +195,18 @@ else
                 <div class="card-body">
                     @if (dimension == r.IspAsnDimension)
                     {
-                        @if (r.IspTargets.Count == 0)
+                        var ispTargets = r.IspTargets.OrderBy(t => t.RttMs ?? double.MaxValue).ToList();
+                        var hiddenIspHopCount = ispTargets.Count - NetworkPreviewCount;
+                        var visibleIspTargets = _showAllIspHops ? ispTargets : ispTargets.Take(NetworkPreviewCount).ToList();
+                        @if (ispTargets.Count == 0)
                         {
                             <p class="page-description">No ISP hop data in the window.</p>
                         }
                         <div class="isp-hop-list">
-                            @foreach (var target in r.IspTargets.OrderBy(t => t.RttMs ?? double.MaxValue))
+                            @for (var i = 0; i < visibleIspTargets.Count; i++)
                             {
-                                <div class="isp-hop">
+                                var target = visibleIspTargets[i];
+                                <div class="isp-hop @(i >= NetworkPreviewCount ? "isp-hop-revealed" : "")" @key="target">
                                     <div class="isp-hop-row">
                                         <div class="isp-hop-main">
                                             <div class="isp-hop-name">
@@ -239,6 +243,14 @@ else
                                 </div>
                             }
                         </div>
+                        @if (hiddenIspHopCount > 0)
+                        {
+                            <button type="button" class="isp-network-toggle" aria-expanded="@_showAllIspHops"
+                                    @onclick="() => _showAllIspHops = !_showAllIspHops">
+                                <span>@(_showAllIspHops ? "Show less" : $"Show {hiddenIspHopCount} more")</span>
+                                <span class="isp-network-toggle-chevron @(_showAllIspHops ? "expanded" : "")">▼</span>
+                            </button>
+                        }
                     }
                     else
                     {
@@ -283,20 +295,16 @@ else
 
     @if (r.TransitAsns.Count > 0 || r.IspAsns.Count > 0)
     {
-        var pathAsns = r.IspAsns.Concat(r.TransitAsns).ToList();
-        var hiddenNetworkCount = pathAsns.Count - NetworkPreviewCount;
-        var visibleAsns = _showAllNetworks ? pathAsns : pathAsns.Take(NetworkPreviewCount).ToList();
         <div class="card isp-health-card">
             <div class="card-header"><h2 class="card-title">Networks on Your Path</h2></div>
             <div class="card-body">
                 <div class="isp-asn-grid">
-                    @for (var i = 0; i < visibleAsns.Count; i++)
+                    @foreach (var asn in r.IspAsns.Concat(r.TransitAsns))
                     {
-                        var asn = visibleAsns[i];
                         var isIspAsn = r.IspAsns.Contains(asn);
                         var showRange = isIspAsn && asn.MinRttMs.HasValue && asn.MaxRttMs.HasValue
                             && asn.MaxRttMs.Value - asn.MinRttMs.Value > 0.05;
-                        <div class="isp-asn-card @(i >= NetworkPreviewCount ? "isp-asn-card-revealed" : "")" @key="asn">
+                        <div class="isp-asn-card">
                             <div class="isp-asn-card-header">
                                 <div>
                                     <div class="isp-asn-name">@(string.IsNullOrEmpty(asn.AsnName) ? $"AS{asn.AsnNumber}" : asn.AsnName)</div>
@@ -339,14 +347,6 @@ else
                         </div>
                     }
                 </div>
-                @if (hiddenNetworkCount > 0)
-                {
-                    <button type="button" class="isp-network-toggle" aria-expanded="@_showAllNetworks"
-                            @onclick="() => _showAllNetworks = !_showAllNetworks">
-                        <span>@(_showAllNetworks ? "Show less" : $"Show {hiddenNetworkCount} more")</span>
-                        <span class="isp-network-toggle-chevron @(_showAllNetworks ? "expanded" : "")">▾</span>
-                    </button>
-                }
             </div>
         </div>
     }
@@ -443,7 +443,7 @@ else
     private bool _loading = true;
     private bool _chartMounted;
     private bool _refreshing;
-    private bool _showAllNetworks;
+    private bool _showAllIspHops;
     private System.Threading.Timer? _ageTimer;
 
     protected override async Task OnInitializedAsync()

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -197,54 +197,64 @@ else
                     {
                         var ispTargets = r.IspTargets.OrderBy(t => t.RttMs ?? double.MaxValue).ToList();
                         var hiddenIspHopCount = ispTargets.Count - NetworkPreviewCount;
-                        var visibleIspTargets = _showAllIspHops ? ispTargets : ispTargets.Take(NetworkPreviewCount).ToList();
+                        RenderFragment<IspTargetHealth> hopRow = target =>
+                            @<div class="isp-hop">
+                                <div class="isp-hop-row">
+                                    <div class="isp-hop-main">
+                                        <div class="isp-hop-name">
+                                            @target.Name
+                                            @if (target.IsGradedHop)
+                                            {
+                                                <span class="isp-target-graded" data-tooltip="The lowest-RTT ISP hop; access-layer idle latency is measured from it">Lowest RTT</span>
+                                            }
+                                        </div>
+                                        <div class="isp-factor-bar-track">
+                                            <div class="isp-factor-bar @BarClass(target.OverallScore)" style="width: @(target.OverallScore ?? 0)%"></div>
+                                        </div>
+                                    </div>
+                                    <span class="isp-factor-score @ScoreTextClass(target.OverallScore)">@(target.OverallScore?.ToString() ?? "--")</span>
+                                </div>
+                                <div class="isp-hop-stats">
+                                    <span class="isp-target-stat"><span class="isp-target-stat-label">RTT</span>@FormatRtt(target.RttMs)</span>
+                                    <span class="isp-target-stat">
+                                        <span class="isp-target-stat-label">P95 Jitter</span>
+                                        <span class="isp-target-stat-value">
+                                            @FormatJitter(target.P95JitterMs)
+                                            @if (target.JitterAssimilated)
+                                            {
+                                                <span class="tooltip-icon tooltip-icon-sm" data-tooltip="@JitterAssimilationTooltip(target)">i</span>
+                                            }
+                                        </span>
+                                    </span>
+                                    <span class="isp-target-stat"><span class="isp-target-stat-label">Loss</span>@FormatLossPct(target.LossPct)</span>
+                                    @if (target.ReachDeltaMs is > 0.15)
+                                    {
+                                        <span class="isp-target-stat"><span class="isp-target-stat-label">Beyond nearest</span>+@FormatMs(target.ReachDeltaMs)</span>
+                                    }
+                                </div>
+                            </div>;
                         @if (ispTargets.Count == 0)
                         {
                             <p class="page-description">No ISP hop data in the window.</p>
                         }
                         <div class="isp-hop-list">
-                            @for (var i = 0; i < visibleIspTargets.Count; i++)
+                            @foreach (var target in ispTargets.Take(NetworkPreviewCount))
                             {
-                                var target = visibleIspTargets[i];
-                                <div class="isp-hop @(i >= NetworkPreviewCount ? "isp-hop-revealed" : "")" @key="target">
-                                    <div class="isp-hop-row">
-                                        <div class="isp-hop-main">
-                                            <div class="isp-hop-name">
-                                                @target.Name
-                                                @if (target.IsGradedHop)
-                                                {
-                                                    <span class="isp-target-graded" data-tooltip="The lowest-RTT ISP hop; access-layer idle latency is measured from it">Lowest RTT</span>
-                                                }
-                                            </div>
-                                            <div class="isp-factor-bar-track">
-                                                <div class="isp-factor-bar @BarClass(target.OverallScore)" style="width: @(target.OverallScore ?? 0)%"></div>
-                                            </div>
-                                        </div>
-                                        <span class="isp-factor-score @ScoreTextClass(target.OverallScore)">@(target.OverallScore?.ToString() ?? "--")</span>
-                                    </div>
-                                    <div class="isp-hop-stats">
-                                        <span class="isp-target-stat"><span class="isp-target-stat-label">RTT</span>@FormatRtt(target.RttMs)</span>
-                                        <span class="isp-target-stat">
-                                            <span class="isp-target-stat-label">P95 Jitter</span>
-                                            <span class="isp-target-stat-value">
-                                                @FormatJitter(target.P95JitterMs)
-                                                @if (target.JitterAssimilated)
-                                                {
-                                                    <span class="tooltip-icon tooltip-icon-sm" data-tooltip="@JitterAssimilationTooltip(target)">i</span>
-                                                }
-                                            </span>
-                                        </span>
-                                        <span class="isp-target-stat"><span class="isp-target-stat-label">Loss</span>@FormatLossPct(target.LossPct)</span>
-                                        @if (target.ReachDeltaMs is > 0.15)
-                                        {
-                                            <span class="isp-target-stat"><span class="isp-target-stat-label">Beyond nearest</span>+@FormatMs(target.ReachDeltaMs)</span>
-                                        }
-                                    </div>
-                                </div>
+                                @hopRow(target)
                             }
                         </div>
                         @if (hiddenIspHopCount > 0)
                         {
+                            <div class="expand-wrapper @(_showAllIspHops ? "expanded" : "")">
+                                <div class="expand-content">
+                                    <div class="isp-hop-list isp-hop-list-overflow">
+                                        @foreach (var target in ispTargets.Skip(NetworkPreviewCount))
+                                        {
+                                            @hopRow(target)
+                                        }
+                                    </div>
+                                </div>
+                            </div>
                             <button type="button" class="isp-network-toggle" aria-expanded="@_showAllIspHops"
                                     @onclick="() => _showAllIspHops = !_showAllIspHops">
                                 <span>@(_showAllIspHops ? "Show less" : $"Show {hiddenIspHopCount} more")</span>

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -283,16 +283,20 @@ else
 
     @if (r.TransitAsns.Count > 0 || r.IspAsns.Count > 0)
     {
+        var pathAsns = r.IspAsns.Concat(r.TransitAsns).ToList();
+        var hiddenNetworkCount = pathAsns.Count - NetworkPreviewCount;
+        var visibleAsns = _showAllNetworks ? pathAsns : pathAsns.Take(NetworkPreviewCount).ToList();
         <div class="card isp-health-card">
             <div class="card-header"><h2 class="card-title">Networks on Your Path</h2></div>
             <div class="card-body">
                 <div class="isp-asn-grid">
-                    @foreach (var asn in r.IspAsns.Concat(r.TransitAsns))
+                    @for (var i = 0; i < visibleAsns.Count; i++)
                     {
+                        var asn = visibleAsns[i];
                         var isIspAsn = r.IspAsns.Contains(asn);
                         var showRange = isIspAsn && asn.MinRttMs.HasValue && asn.MaxRttMs.HasValue
                             && asn.MaxRttMs.Value - asn.MinRttMs.Value > 0.05;
-                        <div class="isp-asn-card">
+                        <div class="isp-asn-card @(i >= NetworkPreviewCount ? "isp-asn-card-revealed" : "")" @key="asn">
                             <div class="isp-asn-card-header">
                                 <div>
                                     <div class="isp-asn-name">@(string.IsNullOrEmpty(asn.AsnName) ? $"AS{asn.AsnNumber}" : asn.AsnName)</div>
@@ -335,6 +339,14 @@ else
                         </div>
                     }
                 </div>
+                @if (hiddenNetworkCount > 0)
+                {
+                    <button type="button" class="isp-network-toggle" aria-expanded="@_showAllNetworks"
+                            @onclick="() => _showAllNetworks = !_showAllNetworks">
+                        <span>@(_showAllNetworks ? "Show less" : $"Show {hiddenNetworkCount} more")</span>
+                        <span class="isp-network-toggle-chevron @(_showAllNetworks ? "expanded" : "")">▾</span>
+                    </button>
+                }
             </div>
         </div>
     }
@@ -425,10 +437,13 @@ else
 }
 
 @code {
+    private const int NetworkPreviewCount = 5;
+
     private IspHealthReport? _report;
     private bool _loading = true;
     private bool _chartMounted;
     private bool _refreshing;
+    private bool _showAllNetworks;
     private System.Threading.Timer? _ageTimer;
 
     protected override async Task OnInitializedAsync()

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15635,6 +15635,50 @@ a.isp-health-hero-speed:hover {
     transform: translateY(-2px);
 }
 
+.isp-asn-card-revealed {
+    animation: ispAsnReveal 0.25s ease-out both;
+}
+
+@@keyframes ispAsnReveal {
+    from { opacity: 0; transform: translateY(-6px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.isp-network-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    width: 100%;
+    margin-top: 0.85rem;
+    padding: 0.55rem 0.75rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius-lg);
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+}
+
+.isp-network-toggle:hover {
+    border-color: var(--primary-hover);
+    color: var(--text-primary);
+    background: var(--bg-hover);
+}
+
+.isp-network-toggle-chevron {
+    display: inline-block;
+    font-size: 0.7rem;
+    line-height: 1;
+    transition: transform 0.25s ease;
+}
+
+.isp-network-toggle-chevron.expanded {
+    transform: rotate(180deg);
+}
+
 .isp-asn-card-header {
     display: flex;
     justify-content: space-between;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14055,7 +14055,7 @@ a.affected-client:hover {
     border-bottom-color: var(--accent-color);
 }
 
-@@media (max-width: 768px) {
+@media (max-width: 768px) {
     .wan-history-tab {
         padding: 0.5rem 0.75rem;
         font-size: 0.8rem;
@@ -15639,7 +15639,7 @@ a.isp-health-hero-speed:hover {
     animation: ispHopReveal 0.25s ease-out both;
 }
 
-@@keyframes ispHopReveal {
+@keyframes ispHopReveal {
     from { opacity: 0; transform: translateY(-6px); }
     to { opacity: 1; transform: translateY(0); }
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1148,7 +1148,7 @@ a.stat-card-link:active {
     animation: toast-fade-in 0.2s ease;
 }
 
-@@keyframes toast-fade-in {
+@keyframes toast-fade-in {
     from { opacity: 0; transform: translateY(-4px); }
     to { opacity: 1; transform: translateY(0); }
 }
@@ -3574,7 +3574,7 @@ select.form-control {
     left: calc(140px + 0.5rem);
 }
 
-@@keyframes purposeFadeIn {
+@keyframes purposeFadeIn {
     from { opacity: 0; transform: translateX(-4px); }
     to { opacity: 1; transform: translateX(0); }
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15635,11 +15635,11 @@ a.isp-health-hero-speed:hover {
     transform: translateY(-2px);
 }
 
-.isp-asn-card-revealed {
-    animation: ispAsnReveal 0.25s ease-out both;
+.isp-hop-revealed {
+    animation: ispHopReveal 0.25s ease-out both;
 }
 
-@@keyframes ispAsnReveal {
+@@keyframes ispHopReveal {
     from { opacity: 0; transform: translateY(-6px); }
     to { opacity: 1; transform: translateY(0); }
 }
@@ -15670,8 +15670,9 @@ a.isp-health-hero-speed:hover {
 
 .isp-network-toggle-chevron {
     display: inline-block;
-    font-size: 0.7rem;
+    font-size: 0.75rem;
     line-height: 1;
+    color: var(--text-muted);
     transition: transform 0.25s ease;
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14055,13 +14055,6 @@ a.affected-client:hover {
     border-bottom-color: var(--accent-color);
 }
 
-@media (max-width: 768px) {
-    .wan-history-tab {
-        padding: 0.5rem 0.75rem;
-        font-size: 0.8rem;
-    }
-}
-
 
 /* Loaded Latency Legend */
 .loaded-latency-chart-wrapper {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15628,13 +15628,12 @@ a.isp-health-hero-speed:hover {
     transform: translateY(-2px);
 }
 
-.isp-hop-revealed {
-    animation: ispHopReveal 0.25s ease-out both;
+.isp-hop-list-overflow {
+    margin-top: 0;
 }
 
-@keyframes ispHopReveal {
-    from { opacity: 0; transform: translateY(-6px); }
-    to { opacity: 1; transform: translateY(0); }
+.isp-hop-list-overflow .isp-hop:first-child {
+    border-top: 1px solid var(--border-color);
 }
 
 .isp-network-toggle {


### PR DESCRIPTION
## ISP Health

- **Collapsible ISP Network list** - The ISP Network card now shows the first 5 hops and tucks the rest behind a "Show N more / Show less" toggle. The overflow rows slide open and closed with the same smooth height animation used elsewhere for expandable sections, so long hop lists no longer dominate the panel. With 5 or fewer hops the card looks exactly as before (no toggle).

## Fixes

- **Restored two broken entrance animations** - A couple of keyframe animations were silently dead because they were written with a double `@@` (only valid inside Razor `<style>` blocks, not in a plain stylesheet). They now run as intended:
  - The Dashboard edit-mode toast ("card moved to Hidden Cards") fades and slides in.
  - The "Saved" indicator next to a network's Purpose dropdown on the Security Audit page fades in.
- **WAN History tabs sizing** - Removed a mobile style rule that never actually applied (same double-`@` issue). The Speed / Latency / Jitter tabs keep their larger, easier-to-tap sizing on phones.