### PR TITLE
v1.21.4 Release Changes

### DIFF
--- a/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
+++ b/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
@@ -100,6 +100,14 @@ public class ScriptGenerator
         sb.AppendLine("    apt-get install -y speedtest");
         sb.AppendLine("fi");
         sb.AppendLine();
+        // Refresh the package index once if either base dependency is missing, so a
+        // console with stale/empty apt lists can still resolve bc/jq. The Ookla block
+        // above gets its index refresh from the packagecloud script; these don't.
+        sb.AppendLine("# Refresh package lists once if a base dependency is missing");
+        sb.AppendLine("if ! which bc > /dev/null 2>&1 || ! which jq > /dev/null 2>&1; then");
+        sb.AppendLine("    apt-get update");
+        sb.AppendLine("fi");
+        sb.AppendLine();
         sb.AppendLine("# Install bc if not present");
         sb.AppendLine("if ! which bc > /dev/null 2>&1; then");
         sb.AppendLine("    echo \"Installing bc...\" >> $LOG_FILE");

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -195,50 +195,72 @@ else
                 <div class="card-body">
                     @if (dimension == r.IspAsnDimension)
                     {
-                        @if (r.IspTargets.Count == 0)
+                        var ispTargets = r.IspTargets.OrderBy(t => t.RttMs ?? double.MaxValue).ToList();
+                        var hiddenIspHopCount = ispTargets.Count - NetworkPreviewCount;
+                        RenderFragment<IspTargetHealth> hopRow = target =>
+                            @<div class="isp-hop">
+                                <div class="isp-hop-row">
+                                    <div class="isp-hop-main">
+                                        <div class="isp-hop-name">
+                                            @target.Name
+                                            @if (target.IsGradedHop)
+                                            {
+                                                <span class="isp-target-graded" data-tooltip="The lowest-RTT ISP hop; access-layer idle latency is measured from it">Lowest RTT</span>
+                                            }
+                                        </div>
+                                        <div class="isp-factor-bar-track">
+                                            <div class="isp-factor-bar @BarClass(target.OverallScore)" style="width: @(target.OverallScore ?? 0)%"></div>
+                                        </div>
+                                    </div>
+                                    <span class="isp-factor-score @ScoreTextClass(target.OverallScore)">@(target.OverallScore?.ToString() ?? "--")</span>
+                                </div>
+                                <div class="isp-hop-stats">
+                                    <span class="isp-target-stat"><span class="isp-target-stat-label">RTT</span>@FormatRtt(target.RttMs)</span>
+                                    <span class="isp-target-stat">
+                                        <span class="isp-target-stat-label">P95 Jitter</span>
+                                        <span class="isp-target-stat-value">
+                                            @FormatJitter(target.P95JitterMs)
+                                            @if (target.JitterAssimilated)
+                                            {
+                                                <span class="tooltip-icon tooltip-icon-sm" data-tooltip="@JitterAssimilationTooltip(target)">i</span>
+                                            }
+                                        </span>
+                                    </span>
+                                    <span class="isp-target-stat"><span class="isp-target-stat-label">Loss</span>@FormatLossPct(target.LossPct)</span>
+                                    @if (target.ReachDeltaMs is > 0.15)
+                                    {
+                                        <span class="isp-target-stat"><span class="isp-target-stat-label">Beyond nearest</span>+@FormatMs(target.ReachDeltaMs)</span>
+                                    }
+                                </div>
+                            </div>;
+                        @if (ispTargets.Count == 0)
                         {
                             <p class="page-description">No ISP hop data in the window.</p>
                         }
                         <div class="isp-hop-list">
-                            @foreach (var target in r.IspTargets.OrderBy(t => t.RttMs ?? double.MaxValue))
+                            @foreach (var target in ispTargets.Take(NetworkPreviewCount))
                             {
-                                <div class="isp-hop">
-                                    <div class="isp-hop-row">
-                                        <div class="isp-hop-main">
-                                            <div class="isp-hop-name">
-                                                @target.Name
-                                                @if (target.IsGradedHop)
-                                                {
-                                                    <span class="isp-target-graded" data-tooltip="The lowest-RTT ISP hop; access-layer idle latency is measured from it">Lowest RTT</span>
-                                                }
-                                            </div>
-                                            <div class="isp-factor-bar-track">
-                                                <div class="isp-factor-bar @BarClass(target.OverallScore)" style="width: @(target.OverallScore ?? 0)%"></div>
-                                            </div>
-                                        </div>
-                                        <span class="isp-factor-score @ScoreTextClass(target.OverallScore)">@(target.OverallScore?.ToString() ?? "--")</span>
-                                    </div>
-                                    <div class="isp-hop-stats">
-                                        <span class="isp-target-stat"><span class="isp-target-stat-label">RTT</span>@FormatRtt(target.RttMs)</span>
-                                        <span class="isp-target-stat">
-                                            <span class="isp-target-stat-label">P95 Jitter</span>
-                                            <span class="isp-target-stat-value">
-                                                @FormatJitter(target.P95JitterMs)
-                                                @if (target.JitterAssimilated)
-                                                {
-                                                    <span class="tooltip-icon tooltip-icon-sm" data-tooltip="@JitterAssimilationTooltip(target)">i</span>
-                                                }
-                                            </span>
-                                        </span>
-                                        <span class="isp-target-stat"><span class="isp-target-stat-label">Loss</span>@FormatLossPct(target.LossPct)</span>
-                                        @if (target.ReachDeltaMs is > 0.15)
+                                @hopRow(target)
+                            }
+                        </div>
+                        @if (hiddenIspHopCount > 0)
+                        {
+                            <div class="expand-wrapper @(_showAllIspHops ? "expanded" : "")">
+                                <div class="expand-content">
+                                    <div class="isp-hop-list isp-hop-list-overflow">
+                                        @foreach (var target in ispTargets.Skip(NetworkPreviewCount))
                                         {
-                                            <span class="isp-target-stat"><span class="isp-target-stat-label">Beyond nearest</span>+@FormatMs(target.ReachDeltaMs)</span>
+                                            @hopRow(target)
                                         }
                                     </div>
                                 </div>
-                            }
-                        </div>
+                            </div>
+                            <button type="button" class="isp-network-toggle" aria-expanded="@_showAllIspHops"
+                                    @onclick="() => _showAllIspHops = !_showAllIspHops">
+                                <span>@(_showAllIspHops ? "Show less" : $"Show {hiddenIspHopCount} more")</span>
+                                <span class="isp-network-toggle-chevron @(_showAllIspHops ? "expanded" : "")">▼</span>
+                            </button>
+                        }
                     }
                     else
                     {
@@ -425,10 +447,13 @@ else
 }
 
 @code {
+    private const int NetworkPreviewCount = 5;
+
     private IspHealthReport? _report;
     private bool _loading = true;
     private bool _chartMounted;
     private bool _refreshing;
+    private bool _showAllIspHops;
     private System.Threading.Timer? _ageTimer;
 
     protected override async Task OnInitializedAsync()

--- a/src/NetworkOptimizer.Web/Services/Monitoring/SshProbeExecutor.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/SshProbeExecutor.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Monitoring.Probes;
 using NetworkOptimizer.Web.Services.Ssh;
@@ -52,9 +51,14 @@ public class SshProbeExecutor : IProbeExecutor
             var traceOut0 = (traceHelp.Output + traceHelp.Error).ToLowerInvariant();
             if (traceHelp.ExitCode == 127 || traceOut0.Contains("not found"))
             {
-                _logger.LogDebug("traceroute not found on {Vantage}, attempting install", Vantage.Id);
+                _logger.LogDebug("traceroute not found on {Vantage}, attempting apt-get update + install", Vantage.Id);
+                // Refresh the package index first - a console with stale/empty apt lists can't
+                // resolve the package otherwise. update runs unconditionally before install (;),
+                // and the whole thing stays non-fatal (|| true) so a device without apt just
+                // falls through to the capability re-probe below.
                 await _ssh.ExecuteCommandAsync(_connection,
-                    "apt-get install -y traceroute 2>/dev/null || true", TimeSpan.FromSeconds(30), ct);
+                    "apt-get update 2>/dev/null; apt-get install -y traceroute 2>/dev/null || true",
+                    TimeSpan.FromSeconds(60), ct);
                 traceHelp = await _ssh.ExecuteCommandAsync(_connection, "traceroute -h 2>&1 || true", TimeSpan.FromSeconds(5), ct);
             }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -642,13 +642,18 @@ public class UpstreamTracerService
     private List<AttributedHop> _mergedHops = new();
     private List<AttributedHop> _accessHopsResolved = new();
 
-    // The first 2 distinct non-access ASNs walked off the merged path: the access
-    // ISP's direct upstream and that upstream's upstream. A transit-probe ASN (Lumen,
-    // AT&T, INDATEL) only counts as *our* ISP's transit when it lands in this window -
+    // The 1st/2nd-degree non-access ASNs off each trace (union): the access ISP's
+    // direct upstream and that upstream's upstream. A transit-probe ASN (Lumen, AT&T,
+    // INDATEL) only counts as *our* ISP's transit when it lands in this window -
     // probing toward a Lumen/AT&T anycast IP otherwise drags that tier-1 onto the path
     // as the destination's own network even when it isn't an upstream at all. Set in
     // TraceTransitAsnsAsync, read again when injecting transit witnesses.
     private readonly HashSet<int> _nearTransitAsns = new();
+
+    // Tier-1 ASNs excluded as transit because they only ever appear directly above
+    // another tier-1 on the path (core peering, not our access ISP's transit). Set in
+    // TraceTransitAsnsAsync, read again when injecting transit witnesses.
+    private readonly HashSet<int> _excludedTier1Asns = new();
 
     // Raw per-trace hop sequences from the last discovery sweep. Kept so commit can
     // persist SAME-PATH hop ordering to UpstreamDiscoveries: the merged pool (_mergedHops)
@@ -921,23 +926,30 @@ public class UpstreamTracerService
             if (probeAsn != null) transitProbeAsns.Add(probeAsn.Asn);
         }
 
-        // The first 2 distinct non-access ASNs off the path: the access ISP's
-        // direct upstream, and that upstream's upstream. A transit-probe ASN counts
-        // as our ISP's transit only when it falls in this window - a tier-1 reached
-        // 3+ ASN transitions out (e.g. access → upstream → Cogent → Lumen) is the
-        // probe destination's own network, not our transit. Persisted to a field so
-        // the transit-witness injection (a later step) applies the same gate.
-        _nearTransitAsns.Clear();
-        var seenTransitAsns = new HashSet<int>();
+        // Per-trace ordered address sequences (responding hops only) feed both the
+        // near-transit window and the tier-1 adjacency check. We work per trace rather
+        // than over the merged pool: the merged pool orders hops by number across
+        // heterogeneous traces, so a multi-homed access ISP's other upstreams (or a
+        // near probe endpoint) can occupy the global "first two" slots at a lower hop
+        // number and crowd out a genuine direct upstream.
+        var asnByIp = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         foreach (var h in _mergedHops)
-        {
-            if (h.Asn == null || accessAsnNumbers.Contains(h.Asn.Asn)) continue;
-            if (seenTransitAsns.Add(h.Asn.Asn))
-            {
-                _nearTransitAsns.Add(h.Asn.Asn);
-                if (seenTransitAsns.Count >= 2) break;
-            }
-        }
+            if (h.Asn != null) asnByIp.TryAdd(h.Address, h.Asn.Asn);
+        var traceSequences = _lastTraces
+            .Select(t => (IReadOnlyList<string>)t.Hops
+                .Where(hp => hp.Responded && !string.IsNullOrEmpty(hp.Address))
+                .OrderBy(hp => hp.HopNumber)
+                .Select(hp => hp.Address!)
+                .ToList())
+            .ToList();
+
+        _nearTransitAsns.Clear();
+        _nearTransitAsns.UnionWith(
+            ComputeNearTransitAsns(traceSequences, asnByIp, accessAsnNumbers, destinationAsns, Tier1Asns));
+
+        _excludedTier1Asns.Clear();
+        _excludedTier1Asns.UnionWith(
+            ComputeExcludedTier1Asns(traceSequences, asnByIp, Tier1Asns, accessAsnNumbers));
 
         var transitGroups = _mergedHops
             .Where(h => h.Asn != null
@@ -945,6 +957,7 @@ public class UpstreamTracerService
                         && !destinationAsns.Contains(h.Asn.Asn)
                         && !(h.Asn.Name != null && destinationOrgs.Contains(h.Asn.Name.Trim()))
                         && !transitProbeAddresses.Contains(h.Address)
+                        && !_excludedTier1Asns.Contains(h.Asn.Asn)
                         && (!transitProbeAsns.Contains(h.Asn.Asn)
                             || _nearTransitAsns.Contains(h.Asn.Asn)))
             .GroupBy(h => h.Asn!.Asn)
@@ -1165,6 +1178,8 @@ public class UpstreamTracerService
             // tracing the Lumen probe drags AS3356 onto the path even when Lumen is
             // just the destination's own network, not our ISP's transit.
             if (!_nearTransitAsns.Contains(asn)) continue;
+            // And not when this tier-1 only ever sits above another tier-1 (core peering).
+            if (_excludedTier1Asns.Contains(asn)) continue;
             // Skip if any real router in this ASN already cleared the gate, or the witness exists.
             if (State.TransitAsns.Any(t => t.AsnNumber == asn && t.Enabled && !t.Unreachable)) continue;
             if (State.TransitAsns.Any(t => string.Equals(t.HopAddress, address, StringComparison.OrdinalIgnoreCase))) continue;
@@ -1638,6 +1653,114 @@ public class UpstreamTracerService
     /// </summary>
     internal static string CleanAsnName(string? name) =>
         NetworkOptimizer.Core.Helpers.NetworkFormatHelpers.CleanOrgName(name);
+
+    // Tier-1 (settlement-free) networks, with the sibling ASNs that show up in real
+    // US traces. Two tier-1s adjacent on a path is core peering, not our access ISP's
+    // transit, so a tier-1 sitting directly above another tier-1 is excluded as a
+    // candidate. Stable set - revisit only on major carrier M&A. Last reviewed 2026-06.
+    //
+    // Hurricane Electric (AS6939) is deliberately NOT included: it isn't settlement-free
+    // on IPv4 (buys paid transit; Cogent won't peer), so its presence beneath a tier-1
+    // carries no reliable "core peering" signal. A tier-1 reached via HE still surfaces
+    // as a candidate and can simply be unchecked in the discovery review list.
+    internal static readonly HashSet<int> Tier1Asns = new()
+    {
+        3356, 209, 3549, 3561,            // Lumen / Level 3 / CenturyLink / Global Crossing / Savvis
+        7018, 2386, 7132, 6389, 2686,     // AT&T (incl. legacy SBC / BellSouth ASNs seen in US traces)
+        701, 702, 703,     // Verizon (UUNET)
+        2914,              // NTT (GIN)
+        174, 1239,         // Cogent (1239 = ex-SprintLink, sold to Cogent 2023)
+        1299,              // Arelion (ex-Telia)
+        3257,              // GTT (backbone now EXA Infrastructure; ASN still registered GTT)
+        6453,              // Tata
+        6461,              // Zayo
+        6762,              // Telecom Italia Sparkle
+        3491,              // PCCW Global
+        5511,              // Orange
+        12956,             // Telxius (Telefonica)
+        3320,              // Deutsche Telekom
+    };
+
+    /// <summary>
+    /// Near-transit ASNs: every ASN that appears as the 1st or 2nd distinct non-access,
+    /// non-destination ASN on at least one trace - the access ISP's direct upstream or
+    /// its upstream's upstream, unioned across traces. A transit-probe ASN (Lumen, AT&amp;T,
+    /// INDATEL) counts as our ISP's transit only when it lands in this window.
+    ///
+    /// The walk stops at the first tier-1: your transit horizon ends there. An ASN reached
+    /// only by transiting a tier-1 (e.g. access → Arelion → INDATEL) is beyond your ISP's
+    /// transit, not adjacent to it, so it is not near-transit. The tier-1 itself is included
+    /// (it is the first upstream); the same INDATEL endpoint sitting one hop off the access
+    /// ISP (access → INDATEL) stays near-transit because no tier-1 intervenes. Each trace is
+    /// the responding hop addresses in hop order.
+    /// </summary>
+    internal static HashSet<int> ComputeNearTransitAsns(
+        IEnumerable<IReadOnlyList<string>> traceAddressSequences,
+        IReadOnlyDictionary<string, int> asnByIp,
+        IReadOnlySet<int> accessAsns,
+        IReadOnlySet<int> destinationAsns,
+        IReadOnlySet<int> tier1Asns)
+    {
+        var near = new HashSet<int>();
+        foreach (var trace in traceAddressSequences)
+        {
+            var degreesSeen = new HashSet<int>();
+            foreach (var address in trace)
+            {
+                if (!asnByIp.TryGetValue(address, out var asn)) continue;
+                if (accessAsns.Contains(asn) || destinationAsns.Contains(asn)) continue;
+                if (degreesSeen.Add(asn))
+                {
+                    near.Add(asn);
+                    // Transit horizon ends at the first tier-1: include it, then stop so
+                    // nothing reached only by transiting it counts as near-transit.
+                    if (tier1Asns.Contains(asn)) break;
+                    if (degreesSeen.Count >= 2) break;
+                }
+            }
+        }
+        return near;
+    }
+
+    /// <summary>
+    /// Tier-1 ASNs to exclude as transit because they only ever appear directly above
+    /// another tier-1 on the path - core peering in the internet core, not our access
+    /// ISP's transit. A tier-1 is kept when at least one trace shows it "grounded": the
+    /// ASN immediately downstream (access side, lower TTL) is the access ISP itself, a
+    /// non-tier-1 (a regional transit it feeds), or nothing (the tier-1 is the first
+    /// resolved hop, so downstream is us). The access ISP is grounding even when it is
+    /// itself a tier-1 (e.g. an AT&amp;T or Verizon fiber customer): the first tier-1 above
+    /// the access edge is that ISP's upstream/peer and must stay, only tier-1s sitting
+    /// above *another, non-access* tier-1 are core peering. Consecutive same-ASN hops
+    /// are collapsed.
+    /// </summary>
+    internal static HashSet<int> ComputeExcludedTier1Asns(
+        IEnumerable<IReadOnlyList<string>> traceAddressSequences,
+        IReadOnlyDictionary<string, int> asnByIp,
+        IReadOnlySet<int> tier1Asns,
+        IReadOnlySet<int> accessAsns)
+    {
+        var seen = new HashSet<int>();
+        var grounded = new HashSet<int>();
+        foreach (var trace in traceAddressSequences)
+        {
+            int? prevAsn = null;
+            foreach (var address in trace)
+            {
+                if (!asnByIp.TryGetValue(address, out var asn)) continue;
+                if (asn == prevAsn) continue;
+                if (tier1Asns.Contains(asn))
+                {
+                    seen.Add(asn);
+                    if (prevAsn == null || accessAsns.Contains(prevAsn.Value) || !tier1Asns.Contains(prevAsn.Value))
+                        grounded.Add(asn);
+                }
+                prevAsn = asn;
+            }
+        }
+        seen.ExceptWith(grounded);
+        return seen;
+    }
 
     /// <summary>
     /// Generate a display label from a PTR hostname for transit targets.

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -642,6 +642,14 @@ public class UpstreamTracerService
     private List<AttributedHop> _mergedHops = new();
     private List<AttributedHop> _accessHopsResolved = new();
 
+    // The first 2 distinct non-access ASNs walked off the merged path: the access
+    // ISP's direct upstream and that upstream's upstream. A transit-probe ASN (Lumen,
+    // AT&T, INDATEL) only counts as *our* ISP's transit when it lands in this window -
+    // probing toward a Lumen/AT&T anycast IP otherwise drags that tier-1 onto the path
+    // as the destination's own network even when it isn't an upstream at all. Set in
+    // TraceTransitAsnsAsync, read again when injecting transit witnesses.
+    private readonly HashSet<int> _nearTransitAsns = new();
+
     // Raw per-trace hop sequences from the last discovery sweep. Kept so commit can
     // persist SAME-PATH hop ordering to UpstreamDiscoveries: the merged pool (_mergedHops)
     // dedupes hop IPs across ~22 anycast traces, so its hop numbers are not on a common
@@ -894,30 +902,40 @@ public class UpstreamTracerService
         // routers surface - the endpoint IP itself is far away and not useful
         // as a monitoring target. Exception: EndpointIsTransitHop means the
         // endpoint itself is the transit router (small networks with one hop),
-        // but only if its ASN is near the access network (within 2 ASN
-        // transitions: access → transit, or access → upstream → transit).
+        // so it stays eligible as a target - the near-transit ASN gate below
+        // decides whether it's actually our ISP's transit.
         var transitProbeAddresses = new HashSet<string>(
             CdnRotation.Where(e => e.IsTransitProbe && !e.EndpointIsTransitHop).Select(e => e.Address),
             StringComparer.OrdinalIgnoreCase);
 
-        // For EndpointIsTransitHop probes, build the set of ASNs that are
-        // within 2 ASN transitions of the access network. If the endpoint's
-        // ASN isn't in this set, it's not really our ISP's transit.
-        var endpointTransitHopAddresses = new HashSet<string>(
-            CdnRotation.Where(e => e.EndpointIsTransitHop).Select(e => e.Address),
-            StringComparer.OrdinalIgnoreCase);
-        var nearTransitAsns = new HashSet<int>();
-        if (endpointTransitHopAddresses.Count > 0)
+        // Resolve the ASN of every transit probe (Lumen AS3356, AT&T AS7018,
+        // INDATEL AS30517). Tracing toward one of these anycast IPs always enters
+        // that ASN near the destination edge - so on its own, a probe ASN's
+        // presence on the path proves nothing about whether it's *our* ISP's
+        // upstream. We only keep it when it also lands in the near-transit window.
+        var transitProbeAsns = new HashSet<int>();
+        foreach (var endpoint in CdnRotation)
         {
-            var seen = new HashSet<int>();
-            foreach (var h in _mergedHops)
+            if (!endpoint.IsTransitProbe) continue;
+            var probeAsn = await _asnResolution.ResolveAsync(endpoint.Address, ct);
+            if (probeAsn != null) transitProbeAsns.Add(probeAsn.Asn);
+        }
+
+        // The first 2 distinct non-access ASNs off the path: the access ISP's
+        // direct upstream, and that upstream's upstream. A transit-probe ASN counts
+        // as our ISP's transit only when it falls in this window - a tier-1 reached
+        // 3+ ASN transitions out (e.g. access → upstream → Cogent → Lumen) is the
+        // probe destination's own network, not our transit. Persisted to a field so
+        // the transit-witness injection (a later step) applies the same gate.
+        _nearTransitAsns.Clear();
+        var seenTransitAsns = new HashSet<int>();
+        foreach (var h in _mergedHops)
+        {
+            if (h.Asn == null || accessAsnNumbers.Contains(h.Asn.Asn)) continue;
+            if (seenTransitAsns.Add(h.Asn.Asn))
             {
-                if (h.Asn == null || accessAsnNumbers.Contains(h.Asn.Asn)) continue;
-                if (seen.Add(h.Asn.Asn))
-                {
-                    nearTransitAsns.Add(h.Asn.Asn);
-                    if (seen.Count >= 2) break;
-                }
+                _nearTransitAsns.Add(h.Asn.Asn);
+                if (seenTransitAsns.Count >= 2) break;
             }
         }
 
@@ -927,8 +945,8 @@ public class UpstreamTracerService
                         && !destinationAsns.Contains(h.Asn.Asn)
                         && !(h.Asn.Name != null && destinationOrgs.Contains(h.Asn.Name.Trim()))
                         && !transitProbeAddresses.Contains(h.Address)
-                        && (!endpointTransitHopAddresses.Contains(h.Address)
-                            || nearTransitAsns.Contains(h.Asn.Asn)))
+                        && (!transitProbeAsns.Contains(h.Asn.Asn)
+                            || _nearTransitAsns.Contains(h.Asn.Asn)))
             .GroupBy(h => h.Asn!.Asn)
             .ToList();
 
@@ -1142,8 +1160,11 @@ public class UpstreamTracerService
     {
         foreach (var (asn, address, name, label) in TransitWitnesses)
         {
-            // Only when the ASN is actually on the traced path.
-            if (!_mergedHops.Any(h => h.Asn?.Asn == asn)) continue;
+            // Only when the ASN is genuinely near-transit (the access ISP's upstream
+            // or its upstream's upstream). Mere presence on the path isn't enough -
+            // tracing the Lumen probe drags AS3356 onto the path even when Lumen is
+            // just the destination's own network, not our ISP's transit.
+            if (!_nearTransitAsns.Contains(asn)) continue;
             // Skip if any real router in this ASN already cleared the gate, or the witness exists.
             if (State.TransitAsns.Any(t => t.AsnNumber == asn && t.Enabled && !t.Unreachable)) continue;
             if (State.TransitAsns.Any(t => string.Equals(t.HopAddress, address, StringComparison.OrdinalIgnoreCase))) continue;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1148,7 +1148,7 @@ a.stat-card-link:active {
     animation: toast-fade-in 0.2s ease;
 }
 
-@@keyframes toast-fade-in {
+@keyframes toast-fade-in {
     from { opacity: 0; transform: translateY(-4px); }
     to { opacity: 1; transform: translateY(0); }
 }
@@ -3574,7 +3574,7 @@ select.form-control {
     left: calc(140px + 0.5rem);
 }
 
-@@keyframes purposeFadeIn {
+@keyframes purposeFadeIn {
     from { opacity: 0; transform: translateX(-4px); }
     to { opacity: 1; transform: translateX(0); }
 }
@@ -14055,13 +14055,6 @@ a.affected-client:hover {
     border-bottom-color: var(--accent-color);
 }
 
-@@media (max-width: 768px) {
-    .wan-history-tab {
-        padding: 0.5rem 0.75rem;
-        font-size: 0.8rem;
-    }
-}
-
 
 /* Loaded Latency Legend */
 .loaded-latency-chart-wrapper {
@@ -15633,6 +15626,50 @@ a.isp-health-hero-speed:hover {
 .isp-asn-card:hover {
     border-color: var(--primary-hover);
     transform: translateY(-2px);
+}
+
+.isp-hop-list-overflow {
+    margin-top: 0;
+}
+
+.isp-hop-list-overflow .isp-hop:first-child {
+    border-top: 1px solid var(--border-color);
+}
+
+.isp-network-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    width: 100%;
+    margin-top: 0.85rem;
+    padding: 0.55rem 0.75rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius-lg);
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+}
+
+.isp-network-toggle:hover {
+    border-color: var(--primary-hover);
+    color: var(--text-primary);
+    background: var(--bg-hover);
+}
+
+.isp-network-toggle-chevron {
+    display: inline-block;
+    font-size: 0.75rem;
+    line-height: 1;
+    color: var(--text-muted);
+    transition: transform 0.25s ease;
+}
+
+.isp-network-toggle-chevron.expanded {
+    transform: rotate(180deg);
 }
 
 .isp-asn-card-header {

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
@@ -687,3 +687,314 @@ public class UpstreamCommitTests : IDisposable
             LastVerified = DateTime.UtcNow
         };
 }
+
+public class ComputeNearTransitAsnsTests
+{
+    // Generic private-use access ASN (not a real ISP); public tier-1 ASNs are real
+    // because the logic keys on them.
+    private const int Access = 64500;
+    private const int UpstreamA = 64510;
+    private const int UpstreamB = 64520;
+    private const int Lumen = 3356;
+    private const int Cogent = 174;
+    private const int Arelion = 1299;
+    private const int Indatel = 30517;
+    private const int Cloudflare = 13335;
+
+    private static IReadOnlySet<int> AccessSet => new HashSet<int> { Access };
+    private static IReadOnlySet<int> NoDest => new HashSet<int>();
+    private static IReadOnlySet<int> Tier1 => new HashSet<int> { Lumen, Cogent, Arelion };
+
+    private static Dictionary<string, int> Map(params (string Ip, int Asn)[] e)
+        => e.ToDictionary(x => x.Ip, x => x.Asn, StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void Direct_upstream_is_near_transit()
+    {
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Lumen));
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2" } }, map, AccessSet, NoDest, Tier1);
+        near.Should().Contain(Lumen);
+    }
+
+    [Fact]
+    public void Upstreams_upstream_is_near_transit()
+    {
+        // access -> UpstreamA -> Lumen: Lumen is 2nd-degree, still in window.
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", UpstreamA), ("192.0.2.3", Lumen));
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" } }, map, AccessSet, NoDest, Tier1);
+        near.Should().BeEquivalentTo(new[] { UpstreamA, Lumen });
+    }
+
+    [Fact]
+    public void Third_degree_asn_is_not_near_transit()
+    {
+        // access -> UpstreamA -> UpstreamB -> Lumen: Lumen is 3rd-degree, dropped.
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", UpstreamA),
+                      ("192.0.2.3", UpstreamB), ("192.0.2.4", Lumen));
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4" } }, map, AccessSet, NoDest, Tier1);
+        near.Should().BeEquivalentTo(new[] { UpstreamA, UpstreamB });
+        near.Should().NotContain(Lumen);
+    }
+
+    [Fact]
+    public void Every_direct_upstream_of_a_multihomed_isp_is_captured()
+    {
+        // Different traces exit via different upstreams; the per-trace union keeps all.
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Lumen),
+                      ("198.51.100.1", Access), ("198.51.100.2", UpstreamA));
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            new[]
+            {
+                new[] { "192.0.2.1", "192.0.2.2" },
+                new[] { "198.51.100.1", "198.51.100.2" }
+            }, map, AccessSet, NoDest, Tier1);
+        near.Should().BeEquivalentTo(new[] { Lumen, UpstreamA });
+    }
+
+    [Fact]
+    public void Per_trace_window_does_not_let_one_trace_crowd_out_another_upstream()
+    {
+        // Regression: a short trace reaching UpstreamA at hop 1 plus a long trace
+        // reaching Lumen only at hop 4. A merged-pool "first two ASNs by hop number"
+        // filled both slots on the low hops and dropped Lumen; per-trace keeps both.
+        var map = Map(("198.51.100.1", UpstreamA),
+                      ("192.0.2.1", Access), ("192.0.2.2", Access),
+                      ("192.0.2.3", Access), ("192.0.2.4", Lumen));
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            new[]
+            {
+                new[] { "198.51.100.1" },
+                new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4" }
+            }, map, AccessSet, NoDest, Tier1);
+        near.Should().Contain(Lumen);
+        near.Should().Contain(UpstreamA);
+    }
+
+    [Fact]
+    public void Destination_asn_does_not_consume_a_degree_slot()
+    {
+        // access -> UpstreamA -> Cloudflare(dest) -> UpstreamB: with dest skipped, the
+        // real 2nd-degree transit (UpstreamB) still fits in the window. Non-tier-1 hops
+        // so the tier-1 horizon stop doesn't interfere with what this test isolates.
+        var dest = new HashSet<int> { Cloudflare };
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", UpstreamA),
+                      ("192.0.2.3", Cloudflare), ("192.0.2.4", UpstreamB));
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4" } }, map, AccessSet, dest, Tier1);
+        near.Should().BeEquivalentTo(new[] { UpstreamA, UpstreamB });
+    }
+
+    [Fact]
+    public void Unresolved_hops_are_skipped()
+    {
+        var map = Map(("192.0.2.1", Access), ("192.0.2.3", Lumen)); // .2 has no ASN (gap)
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" } }, map, AccessSet, NoDest, Tier1);
+        near.Should().Contain(Lumen);
+    }
+
+    [Fact]
+    public void Access_only_path_yields_nothing()
+    {
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Access));
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2" } }, map, AccessSet, NoDest, Tier1);
+        near.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void No_traces_yields_nothing()
+    {
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            Array.Empty<IReadOnlyList<string>>(), new Dictionary<string, int>(), AccessSet, NoDest, Tier1);
+        near.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Asn_reached_through_a_tier1_is_not_near_transit()
+    {
+        // access -> Arelion(tier-1) -> INDATEL: the endpoint sits beyond a tier-1, so it
+        // is not adjacent to the ISP and must not be near-transit (the AT&T-via-Arelion
+        // case). The tier-1 itself is the first upstream and stays.
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Arelion), ("192.0.2.3", Indatel));
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" } }, map, AccessSet, NoDest, Tier1);
+        near.Should().Contain(Arelion);
+        near.Should().NotContain(Indatel);
+    }
+
+    [Fact]
+    public void Endpoint_one_hop_off_the_access_isp_is_near_transit()
+    {
+        // access -> INDATEL directly: no tier-1 in between, so it stays near-transit
+        // (the directly-adjacent case). Same endpoint ASN as above, opposite verdict.
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Indatel));
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2" } }, map, AccessSet, NoDest, Tier1);
+        near.Should().Contain(Indatel);
+    }
+
+    [Fact]
+    public void Walk_stops_at_the_first_tier1()
+    {
+        // access -> Lumen(tier-1) -> Cogent(tier-1): only the first tier-1 is near-transit;
+        // a second tier-1 reached through it is core peering, not our transit.
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Lumen), ("192.0.2.3", Cogent));
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" } }, map, AccessSet, NoDest, Tier1);
+        near.Should().Contain(Lumen);
+        near.Should().NotContain(Cogent);
+    }
+}
+
+public class ComputeExcludedTier1AsnsTests
+{
+    private const int Access = 64500;
+    private const int Regional = 64510;
+    private const int Lumen = 3356;
+    private const int Cogent = 174;
+    private const int Gtt = 3257;
+    private const int Att = 7018;
+
+    private static IReadOnlySet<int> Tier1 => new HashSet<int> { Lumen, Cogent, Gtt, Att };
+    private static IReadOnlySet<int> AccessSet => new HashSet<int> { Access };
+
+    private static Dictionary<string, int> Map(params (string Ip, int Asn)[] e)
+        => e.ToDictionary(x => x.Ip, x => x.Asn, StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void Tier1_above_non_tier1_is_kept()
+    {
+        // access(non-T1) -> Lumen(T1): grounded, not excluded.
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Lumen));
+        var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2" } }, map, Tier1, AccessSet);
+        excluded.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Tier1_directly_above_another_tier1_is_excluded()
+    {
+        // access -> Cogent(T1) -> Lumen(T1): Lumen is core peering, excluded. Cogent
+        // sits above access (non-T1) so it stays.
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Cogent), ("192.0.2.3", Lumen));
+        var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" } }, map, Tier1, AccessSet);
+        excluded.Should().BeEquivalentTo(new[] { Lumen });
+    }
+
+    [Fact]
+    public void Kept_when_grounded_on_any_trace()
+    {
+        // One trace shows Lumen above Cogent; another shows Lumen directly above access.
+        // A single grounded sighting keeps it.
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Cogent), ("192.0.2.3", Lumen),
+                      ("198.51.100.1", Access), ("198.51.100.2", Lumen));
+        var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
+            new[]
+            {
+                new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" },
+                new[] { "198.51.100.1", "198.51.100.2" }
+            }, map, Tier1, AccessSet);
+        excluded.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Excluded_only_when_tier1_downstream_on_every_trace()
+    {
+        // Lumen sits above a tier-1 (Cogent, then GTT) on both traces -> excluded.
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Cogent), ("192.0.2.3", Lumen),
+                      ("198.51.100.1", Access), ("198.51.100.2", Gtt), ("198.51.100.3", Lumen));
+        var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
+            new[]
+            {
+                new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" },
+                new[] { "198.51.100.1", "198.51.100.2", "198.51.100.3" }
+            }, map, Tier1, AccessSet);
+        excluded.Should().BeEquivalentTo(new[] { Lumen });
+    }
+
+    [Fact]
+    public void Tier1_as_first_resolved_hop_is_grounded()
+    {
+        // Unresolved gateway hop then Lumen: downstream is us, so Lumen is grounded.
+        var map = Map(("192.0.2.2", Lumen)); // first hop has no ASN
+        var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
+            new[] { new[] { "10.0.0.1", "192.0.2.2" } }, map, Tier1, AccessSet);
+        excluded.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Consecutive_same_asn_hops_are_collapsed()
+    {
+        // access -> Lumen -> Lumen -> Cogent: Cogent's true downstream is Lumen(T1),
+        // so Cogent is excluded; Lumen is grounded by access and kept.
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Lumen),
+                      ("192.0.2.3", Lumen), ("192.0.2.4", Cogent));
+        var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4" } }, map, Tier1, AccessSet);
+        excluded.Should().BeEquivalentTo(new[] { Cogent });
+    }
+
+    [Fact]
+    public void Non_tier1_asns_are_never_excluded()
+    {
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Regional));
+        var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2" } }, map, Tier1, AccessSet);
+        excluded.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void No_traces_yields_nothing()
+    {
+        var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
+            Array.Empty<IReadOnlyList<string>>(), new Dictionary<string, int>(), Tier1, AccessSet);
+        excluded.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void First_tier1_above_a_tier1_access_isp_is_kept()
+    {
+        // AT&T fiber customer: access ASN is itself tier-1 (AS7018), and Lumen sits
+        // directly above it. Lumen is AT&T's upstream/peer - the thing to monitor - not
+        // core peering, so the access ASN grounds it even though it's a tier-1.
+        var access = new HashSet<int> { Att };
+        var map = Map(("192.0.2.1", Att), ("192.0.2.2", Lumen));
+        var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2" } }, map, Tier1, access);
+        excluded.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Second_tier1_above_a_tier1_access_isp_is_excluded()
+    {
+        // access=AT&T(T1) -> Lumen(T1) -> Cogent(T1): Lumen is grounded by the access
+        // ISP and kept; Cogent sits above a non-access tier-1 (Lumen) and is excluded.
+        var access = new HashSet<int> { Att };
+        var map = Map(("192.0.2.1", Att), ("192.0.2.2", Lumen), ("192.0.2.3", Cogent));
+        var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" } }, map, Tier1, access);
+        excluded.Should().BeEquivalentTo(new[] { Cogent });
+    }
+
+    [Fact]
+    public void Tier1Asns_constant_includes_major_carriers_and_live_siblings()
+    {
+        // Core tier-1s, plus the corrected AS1239 (now Cogent) and active AT&T/Lumen
+        // sibling ASNs that show up in US traces.
+        UpstreamTracerService.Tier1Asns.Should().Contain(
+            new[] { 3356, 174, 7018, 2914, 1299, 6461, 1239, 7132, 3561 });
+    }
+
+    [Fact]
+    public void Tier1Asns_excludes_hurricane_electric()
+    {
+        // AS6939 is not settlement-free on IPv4, so it carries no reliable core-peering
+        // signal and stays out of the adjacency set.
+        UpstreamTracerService.Tier1Asns.Should().NotContain(6939);
+    }
+}


### PR DESCRIPTION
## Upstream Discovery

- **Multi-homed access ISPs surface every direct upstream** - The near-transit window (which decides whether a transit ASN such as Lumen or AT&T is genuinely your ISP's upstream) is now computed per individual trace and unioned across traces, instead of over the merged hop pool. On a multi-homed access ISP, a different trace's upstream could previously fill the global "first two" slots and crowd out a real direct upstream, so it never got monitored.

- **Your transit horizon ends at the first tier-1** - A transit ASN reached only by transiting a tier-1 is treated as beyond your ISP's transit and is not added as a candidate. This covers both a tier-1 sitting directly above another tier-1 (internet-core peering) and a regional carrier reached through a tier-1 (several hops past a tier-1 backbone on one connection but directly adjacent to the ISP on another). The access ISP is exempt: if it is itself a tier-1 (for example an AT&T or Verizon fiber customer), the first tier-1 above it is that ISP's real upstream or peer and is kept.

- **Curated tier-1 ASN set** - Verified the settlement-free tier-1 list against authoritative sources: corrected AS1239 (now Cogent) and added active AT&T and Lumen sibling ASNs seen in US traces. Hurricane Electric is intentionally excluded (not settlement-free on IPv4), documented inline.

## ISP Health

- **Collapsible ISP Network list** - The ISP Network card now shows the first 5 hops and tucks the rest behind a "Show N more / Show less" toggle. The overflow rows slide open and closed with the same smooth height animation used elsewhere for expandable sections, so long hop lists no longer dominate the panel. With 5 or fewer hops the card looks exactly as before (no toggle).

## SSH device probes

- **Refresh the package index before installing traceroute** - When an SSH-able device is missing traceroute, run an index refresh first so a console with stale or empty package lists can resolve it. Stays non-fatal on devices without apt.

## Adaptive SQM

- **Refresh the package index before installing bc/jq** - Same fix in the SQM boot script's dependency install, guarded so it only runs when a dependency is missing. The Ookla CLI already gets its refresh from the packagecloud setup script; these did not.

## Fixes

- **Restored two broken entrance animations** - A couple of keyframe animations were silently dead because they were written with a double \`@@\` (only valid inside Razor \`<style>\` blocks, not in a plain stylesheet). They now run as intended:
  - The Dashboard edit-mode toast ("card moved to Hidden Cards") fades and slides in.
  - The "Saved" indicator next to a network's Purpose dropdown on the Security Audit page fades in.
- **WAN History tabs sizing** - Removed a mobile style rule that never actually applied (same double-\`@\` issue). The Speed / Latency / Jitter tabs keep their larger, easier-to-tap sizing on phones.