### PR TITLE
Upstream discovery: accurate transit detection for multi-homed and tier-1 access ISPs

### DIFF
--- a/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
+++ b/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
@@ -100,6 +100,14 @@ public class ScriptGenerator
         sb.AppendLine("    apt-get install -y speedtest");
         sb.AppendLine("fi");
         sb.AppendLine();
+        // Refresh the package index once if either base dependency is missing, so a
+        // console with stale/empty apt lists can still resolve bc/jq. The Ookla block
+        // above gets its index refresh from the packagecloud script; these don't.
+        sb.AppendLine("# Refresh package lists once if a base dependency is missing");
+        sb.AppendLine("if ! which bc > /dev/null 2>&1 || ! which jq > /dev/null 2>&1; then");
+        sb.AppendLine("    apt-get update");
+        sb.AppendLine("fi");
+        sb.AppendLine();
         sb.AppendLine("# Install bc if not present");
         sb.AppendLine("if ! which bc > /dev/null 2>&1; then");
         sb.AppendLine("    echo \"Installing bc...\" >> $LOG_FILE");

--- a/src/NetworkOptimizer.Web/Services/Monitoring/SshProbeExecutor.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/SshProbeExecutor.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Monitoring.Probes;
 using NetworkOptimizer.Web.Services.Ssh;
@@ -52,9 +51,14 @@ public class SshProbeExecutor : IProbeExecutor
             var traceOut0 = (traceHelp.Output + traceHelp.Error).ToLowerInvariant();
             if (traceHelp.ExitCode == 127 || traceOut0.Contains("not found"))
             {
-                _logger.LogDebug("traceroute not found on {Vantage}, attempting install", Vantage.Id);
+                _logger.LogDebug("traceroute not found on {Vantage}, attempting apt-get update + install", Vantage.Id);
+                // Refresh the package index first - a console with stale/empty apt lists can't
+                // resolve the package otherwise. update runs unconditionally before install (;),
+                // and the whole thing stays non-fatal (|| true) so a device without apt just
+                // falls through to the capability re-probe below.
                 await _ssh.ExecuteCommandAsync(_connection,
-                    "apt-get install -y traceroute 2>/dev/null || true", TimeSpan.FromSeconds(30), ct);
+                    "apt-get update 2>/dev/null; apt-get install -y traceroute 2>/dev/null || true",
+                    TimeSpan.FromSeconds(60), ct);
                 traceHelp = await _ssh.ExecuteCommandAsync(_connection, "traceroute -h 2>&1 || true", TimeSpan.FromSeconds(5), ct);
             }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -642,13 +642,18 @@ public class UpstreamTracerService
     private List<AttributedHop> _mergedHops = new();
     private List<AttributedHop> _accessHopsResolved = new();
 
-    // The first 2 distinct non-access ASNs walked off the merged path: the access
-    // ISP's direct upstream and that upstream's upstream. A transit-probe ASN (Lumen,
-    // AT&T, INDATEL) only counts as *our* ISP's transit when it lands in this window -
+    // The 1st/2nd-degree non-access ASNs off each trace (union): the access ISP's
+    // direct upstream and that upstream's upstream. A transit-probe ASN (Lumen, AT&T,
+    // INDATEL) only counts as *our* ISP's transit when it lands in this window -
     // probing toward a Lumen/AT&T anycast IP otherwise drags that tier-1 onto the path
     // as the destination's own network even when it isn't an upstream at all. Set in
     // TraceTransitAsnsAsync, read again when injecting transit witnesses.
     private readonly HashSet<int> _nearTransitAsns = new();
+
+    // Tier-1 ASNs excluded as transit because they only ever appear directly above
+    // another tier-1 on the path (core peering, not our access ISP's transit). Set in
+    // TraceTransitAsnsAsync, read again when injecting transit witnesses.
+    private readonly HashSet<int> _excludedTier1Asns = new();
 
     // Raw per-trace hop sequences from the last discovery sweep. Kept so commit can
     // persist SAME-PATH hop ordering to UpstreamDiscoveries: the merged pool (_mergedHops)
@@ -921,47 +926,30 @@ public class UpstreamTracerService
             if (probeAsn != null) transitProbeAsns.Add(probeAsn.Asn);
         }
 
-        // Near-transit = any ASN that appears as the 1st or 2nd distinct non-access
-        // ASN on at least one individual trace: the access ISP's direct upstream, or
-        // that upstream's upstream. A transit-probe ASN counts as our ISP's transit
-        // only when it lands in this window - a tier-1 reached 3+ ASN transitions out
-        // on every trace (e.g. access → upstream → Cogent → Lumen) is the probe
-        // destination's own network, not our transit.
-        //
-        // Computed PER TRACE, not over the merged pool: the merged pool orders hops
-        // by number across heterogeneous traces, so a multi-homed access ISP's other
-        // upstreams (or a near probe endpoint) can occupy the global "first two" slots
-        // at a lower hop number and crowd out a genuine direct upstream. Per-trace
-        // degree counting captures every direct upstream independently. Destination
-        // ASNs are skipped so a CDN endpoint can't consume a degree slot. Persisted to
-        // a field so the transit-witness injection (a later step) applies the same gate.
-        _nearTransitAsns.Clear();
+        // Per-trace ordered address sequences (responding hops only) feed both the
+        // near-transit window and the tier-1 adjacency check. We work per trace rather
+        // than over the merged pool: the merged pool orders hops by number across
+        // heterogeneous traces, so a multi-homed access ISP's other upstreams (or a
+        // near probe endpoint) can occupy the global "first two" slots at a lower hop
+        // number and crowd out a genuine direct upstream.
         var asnByIp = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         foreach (var h in _mergedHops)
             if (h.Asn != null) asnByIp.TryAdd(h.Address, h.Asn.Asn);
-        foreach (var trace in _lastTraces)
-        {
-            var degreesSeen = new HashSet<int>();
-            foreach (var hop in trace.Hops
+        var traceSequences = _lastTraces
+            .Select(t => (IReadOnlyList<string>)t.Hops
                 .Where(hp => hp.Responded && !string.IsNullOrEmpty(hp.Address))
-                .OrderBy(hp => hp.HopNumber))
-            {
-                if (!asnByIp.TryGetValue(hop.Address!, out var hopAsn)) continue;
-                if (accessAsnNumbers.Contains(hopAsn) || destinationAsns.Contains(hopAsn)) continue;
-                if (degreesSeen.Add(hopAsn))
-                {
-                    _nearTransitAsns.Add(hopAsn);
-                    if (degreesSeen.Count >= 2) break;
-                }
-            }
-        }
+                .OrderBy(hp => hp.HopNumber)
+                .Select(hp => hp.Address!)
+                .ToList())
+            .ToList();
 
-        _logger.LogDebug("Tracer near-transit DIAG: access=[{Access}] probeAsns=[{Probe}] dest=[{Dest}] nearTransit=[{Near}]",
-            string.Join(",", accessAsnNumbers), string.Join(",", transitProbeAsns),
-            string.Join(",", destinationAsns), string.Join(",", _nearTransitAsns));
-        _logger.LogDebug("Tracer merged-hop ASN order DIAG: {Seq}",
-            string.Join(" ", _mergedHops.Where(h => h.Asn != null)
-                .Select(h => $"h{h.HopNumber}:AS{h.Asn!.Asn}({h.Address})")));
+        _nearTransitAsns.Clear();
+        _nearTransitAsns.UnionWith(
+            ComputeNearTransitAsns(traceSequences, asnByIp, accessAsnNumbers, destinationAsns));
+
+        _excludedTier1Asns.Clear();
+        _excludedTier1Asns.UnionWith(
+            ComputeExcludedTier1Asns(traceSequences, asnByIp, Tier1Asns));
 
         var transitGroups = _mergedHops
             .Where(h => h.Asn != null
@@ -969,6 +957,7 @@ public class UpstreamTracerService
                         && !destinationAsns.Contains(h.Asn.Asn)
                         && !(h.Asn.Name != null && destinationOrgs.Contains(h.Asn.Name.Trim()))
                         && !transitProbeAddresses.Contains(h.Address)
+                        && !_excludedTier1Asns.Contains(h.Asn.Asn)
                         && (!transitProbeAsns.Contains(h.Asn.Asn)
                             || _nearTransitAsns.Contains(h.Asn.Asn)))
             .GroupBy(h => h.Asn!.Asn)
@@ -1184,13 +1173,13 @@ public class UpstreamTracerService
     {
         foreach (var (asn, address, name, label) in TransitWitnesses)
         {
-            _logger.LogDebug("Transit witness DIAG {Address} AS{Asn}: nearTransit={Near} mergedHasAsn={Merged}",
-                address, asn, _nearTransitAsns.Contains(asn), _mergedHops.Any(h => h.Asn?.Asn == asn));
             // Only when the ASN is genuinely near-transit (the access ISP's upstream
             // or its upstream's upstream). Mere presence on the path isn't enough -
             // tracing the Lumen probe drags AS3356 onto the path even when Lumen is
             // just the destination's own network, not our ISP's transit.
             if (!_nearTransitAsns.Contains(asn)) continue;
+            // And not when this tier-1 only ever sits above another tier-1 (core peering).
+            if (_excludedTier1Asns.Contains(asn)) continue;
             // Skip if any real router in this ASN already cleared the gate, or the witness exists.
             if (State.TransitAsns.Any(t => t.AsnNumber == asn && t.Enabled && !t.Unreachable)) continue;
             if (State.TransitAsns.Any(t => string.Equals(t.HopAddress, address, StringComparison.OrdinalIgnoreCase))) continue;
@@ -1664,6 +1653,96 @@ public class UpstreamTracerService
     /// </summary>
     internal static string CleanAsnName(string? name) =>
         NetworkOptimizer.Core.Helpers.NetworkFormatHelpers.CleanOrgName(name);
+
+    // Tier-1 (transit-free) networks, with the sibling ASNs that show up in real
+    // traces. Two tier-1s adjacent on a path is core peering, not our access ISP's
+    // transit, so a tier-1 sitting directly above another tier-1 is excluded as a
+    // candidate. Stable set - revisit only on major carrier M&A. Last reviewed 2026-06.
+    internal static readonly HashSet<int> Tier1Asns = new()
+    {
+        3356, 209, 3549,   // Lumen / Level 3 / CenturyLink / Global Crossing
+        7018,              // AT&T
+        701, 702, 703,     // Verizon (UUNET)
+        2914,              // NTT (GIN)
+        174,               // Cogent
+        1299,              // Arelion (ex-Telia)
+        3257,              // GTT
+        6453,              // Tata
+        6461,              // Zayo
+        6762,              // Telecom Italia Sparkle
+        3491,              // PCCW Global
+        5511,              // Orange
+        12956,             // Telxius (Telefonica)
+        3320,              // Deutsche Telekom
+        1239,              // Sprint / T-Mobile (legacy)
+    };
+
+    /// <summary>
+    /// Near-transit ASNs: every ASN that appears as the 1st or 2nd distinct non-access,
+    /// non-destination ASN on at least one trace - the access ISP's direct upstream or
+    /// its upstream's upstream, unioned across traces. A transit-probe ASN (Lumen, AT&amp;T,
+    /// INDATEL) counts as our ISP's transit only when it lands in this window; a tier-1
+    /// reached 3+ ASN transitions out on every trace is the probe destination's own
+    /// network, not our transit. Each trace is the responding hop addresses in hop order.
+    /// </summary>
+    internal static HashSet<int> ComputeNearTransitAsns(
+        IEnumerable<IReadOnlyList<string>> traceAddressSequences,
+        IReadOnlyDictionary<string, int> asnByIp,
+        IReadOnlySet<int> accessAsns,
+        IReadOnlySet<int> destinationAsns)
+    {
+        var near = new HashSet<int>();
+        foreach (var trace in traceAddressSequences)
+        {
+            var degreesSeen = new HashSet<int>();
+            foreach (var address in trace)
+            {
+                if (!asnByIp.TryGetValue(address, out var asn)) continue;
+                if (accessAsns.Contains(asn) || destinationAsns.Contains(asn)) continue;
+                if (degreesSeen.Add(asn))
+                {
+                    near.Add(asn);
+                    if (degreesSeen.Count >= 2) break;
+                }
+            }
+        }
+        return near;
+    }
+
+    /// <summary>
+    /// Tier-1 ASNs to exclude as transit because they only ever appear directly above
+    /// another tier-1 on the path - core peering in the internet core, not our access
+    /// ISP's transit. A tier-1 is kept when at least one trace shows a non-tier-1 ASN
+    /// immediately downstream (access side, lower TTL) of it: the access ISP itself, or
+    /// a regional transit it feeds. Consecutive same-ASN hops are collapsed; a tier-1
+    /// that is the first resolved ASN on a trace counts as grounded (downstream is us).
+    /// </summary>
+    internal static HashSet<int> ComputeExcludedTier1Asns(
+        IEnumerable<IReadOnlyList<string>> traceAddressSequences,
+        IReadOnlyDictionary<string, int> asnByIp,
+        IReadOnlySet<int> tier1Asns)
+    {
+        var seen = new HashSet<int>();
+        var grounded = new HashSet<int>();
+        foreach (var trace in traceAddressSequences)
+        {
+            int? prevAsn = null;
+            foreach (var address in trace)
+            {
+                if (!asnByIp.TryGetValue(address, out var asn)) continue;
+                if (asn == prevAsn) continue;
+                if (tier1Asns.Contains(asn))
+                {
+                    seen.Add(asn);
+                    if (prevAsn == null || !tier1Asns.Contains(prevAsn.Value))
+                        grounded.Add(asn);
+                }
+                prevAsn = asn;
+            }
+        }
+        seen.ExceptWith(grounded);
+        return seen;
+    }
 
     /// <summary>
     /// Generate a display label from a PTR hostname for transit targets.

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -945,7 +945,7 @@ public class UpstreamTracerService
 
         _nearTransitAsns.Clear();
         _nearTransitAsns.UnionWith(
-            ComputeNearTransitAsns(traceSequences, asnByIp, accessAsnNumbers, destinationAsns));
+            ComputeNearTransitAsns(traceSequences, asnByIp, accessAsnNumbers, destinationAsns, Tier1Asns));
 
         _excludedTier1Asns.Clear();
         _excludedTier1Asns.UnionWith(
@@ -1685,15 +1685,21 @@ public class UpstreamTracerService
     /// Near-transit ASNs: every ASN that appears as the 1st or 2nd distinct non-access,
     /// non-destination ASN on at least one trace - the access ISP's direct upstream or
     /// its upstream's upstream, unioned across traces. A transit-probe ASN (Lumen, AT&amp;T,
-    /// INDATEL) counts as our ISP's transit only when it lands in this window; a tier-1
-    /// reached 3+ ASN transitions out on every trace is the probe destination's own
-    /// network, not our transit. Each trace is the responding hop addresses in hop order.
+    /// INDATEL) counts as our ISP's transit only when it lands in this window.
+    ///
+    /// The walk stops at the first tier-1: your transit horizon ends there. An ASN reached
+    /// only by transiting a tier-1 (e.g. access → Arelion → INDATEL) is beyond your ISP's
+    /// transit, not adjacent to it, so it is not near-transit. The tier-1 itself is included
+    /// (it is the first upstream); the same INDATEL endpoint sitting one hop off the access
+    /// ISP (access → INDATEL) stays near-transit because no tier-1 intervenes. Each trace is
+    /// the responding hop addresses in hop order.
     /// </summary>
     internal static HashSet<int> ComputeNearTransitAsns(
         IEnumerable<IReadOnlyList<string>> traceAddressSequences,
         IReadOnlyDictionary<string, int> asnByIp,
         IReadOnlySet<int> accessAsns,
-        IReadOnlySet<int> destinationAsns)
+        IReadOnlySet<int> destinationAsns,
+        IReadOnlySet<int> tier1Asns)
     {
         var near = new HashSet<int>();
         foreach (var trace in traceAddressSequences)
@@ -1706,6 +1712,9 @@ public class UpstreamTracerService
                 if (degreesSeen.Add(asn))
                 {
                     near.Add(asn);
+                    // Transit horizon ends at the first tier-1: include it, then stop so
+                    // nothing reached only by transiting it counts as near-transit.
+                    if (tier1Asns.Contains(asn)) break;
                     if (degreesSeen.Count >= 2) break;
                 }
             }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -939,6 +939,13 @@ public class UpstreamTracerService
             }
         }
 
+        _logger.LogDebug("Tracer near-transit DIAG: access=[{Access}] probeAsns=[{Probe}] dest=[{Dest}] nearTransit=[{Near}]",
+            string.Join(",", accessAsnNumbers), string.Join(",", transitProbeAsns),
+            string.Join(",", destinationAsns), string.Join(",", _nearTransitAsns));
+        _logger.LogDebug("Tracer merged-hop ASN order DIAG: {Seq}",
+            string.Join(" ", _mergedHops.Where(h => h.Asn != null)
+                .Select(h => $"h{h.HopNumber}:AS{h.Asn!.Asn}({h.Address})")));
+
         var transitGroups = _mergedHops
             .Where(h => h.Asn != null
                         && !accessAsnNumbers.Contains(h.Asn.Asn)
@@ -1160,6 +1167,8 @@ public class UpstreamTracerService
     {
         foreach (var (asn, address, name, label) in TransitWitnesses)
         {
+            _logger.LogDebug("Transit witness DIAG {Address} AS{Asn}: nearTransit={Near} mergedHasAsn={Merged}",
+                address, asn, _nearTransitAsns.Contains(asn), _mergedHops.Any(h => h.Asn?.Asn == asn));
             // Only when the ASN is genuinely near-transit (the access ISP's upstream
             // or its upstream's upstream). Mere presence on the path isn't enough -
             // tracing the Lumen probe drags AS3356 onto the path even when Lumen is

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -921,21 +921,38 @@ public class UpstreamTracerService
             if (probeAsn != null) transitProbeAsns.Add(probeAsn.Asn);
         }
 
-        // The first 2 distinct non-access ASNs off the path: the access ISP's
-        // direct upstream, and that upstream's upstream. A transit-probe ASN counts
-        // as our ISP's transit only when it falls in this window - a tier-1 reached
-        // 3+ ASN transitions out (e.g. access → upstream → Cogent → Lumen) is the
-        // probe destination's own network, not our transit. Persisted to a field so
-        // the transit-witness injection (a later step) applies the same gate.
+        // Near-transit = any ASN that appears as the 1st or 2nd distinct non-access
+        // ASN on at least one individual trace: the access ISP's direct upstream, or
+        // that upstream's upstream. A transit-probe ASN counts as our ISP's transit
+        // only when it lands in this window - a tier-1 reached 3+ ASN transitions out
+        // on every trace (e.g. access → upstream → Cogent → Lumen) is the probe
+        // destination's own network, not our transit.
+        //
+        // Computed PER TRACE, not over the merged pool: the merged pool orders hops
+        // by number across heterogeneous traces, so a multi-homed access ISP's other
+        // upstreams (or a near probe endpoint) can occupy the global "first two" slots
+        // at a lower hop number and crowd out a genuine direct upstream. Per-trace
+        // degree counting captures every direct upstream independently. Destination
+        // ASNs are skipped so a CDN endpoint can't consume a degree slot. Persisted to
+        // a field so the transit-witness injection (a later step) applies the same gate.
         _nearTransitAsns.Clear();
-        var seenTransitAsns = new HashSet<int>();
+        var asnByIp = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         foreach (var h in _mergedHops)
+            if (h.Asn != null) asnByIp.TryAdd(h.Address, h.Asn.Asn);
+        foreach (var trace in _lastTraces)
         {
-            if (h.Asn == null || accessAsnNumbers.Contains(h.Asn.Asn)) continue;
-            if (seenTransitAsns.Add(h.Asn.Asn))
+            var degreesSeen = new HashSet<int>();
+            foreach (var hop in trace.Hops
+                .Where(hp => hp.Responded && !string.IsNullOrEmpty(hp.Address))
+                .OrderBy(hp => hp.HopNumber))
             {
-                _nearTransitAsns.Add(h.Asn.Asn);
-                if (seenTransitAsns.Count >= 2) break;
+                if (!asnByIp.TryGetValue(hop.Address!, out var hopAsn)) continue;
+                if (accessAsnNumbers.Contains(hopAsn) || destinationAsns.Contains(hopAsn)) continue;
+                if (degreesSeen.Add(hopAsn))
+                {
+                    _nearTransitAsns.Add(hopAsn);
+                    if (degreesSeen.Count >= 2) break;
+                }
             }
         }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1654,19 +1654,24 @@ public class UpstreamTracerService
     internal static string CleanAsnName(string? name) =>
         NetworkOptimizer.Core.Helpers.NetworkFormatHelpers.CleanOrgName(name);
 
-    // Tier-1 (transit-free) networks, with the sibling ASNs that show up in real
-    // traces. Two tier-1s adjacent on a path is core peering, not our access ISP's
+    // Tier-1 (settlement-free) networks, with the sibling ASNs that show up in real
+    // US traces. Two tier-1s adjacent on a path is core peering, not our access ISP's
     // transit, so a tier-1 sitting directly above another tier-1 is excluded as a
     // candidate. Stable set - revisit only on major carrier M&A. Last reviewed 2026-06.
+    //
+    // Hurricane Electric (AS6939) is deliberately NOT included: it isn't settlement-free
+    // on IPv4 (buys paid transit; Cogent won't peer), so its presence beneath a tier-1
+    // carries no reliable "core peering" signal. A tier-1 reached via HE still surfaces
+    // as a candidate and can simply be unchecked in the discovery review list.
     internal static readonly HashSet<int> Tier1Asns = new()
     {
-        3356, 209, 3549,   // Lumen / Level 3 / CenturyLink / Global Crossing
-        7018,              // AT&T
+        3356, 209, 3549, 3561,            // Lumen / Level 3 / CenturyLink / Global Crossing / Savvis
+        7018, 2386, 7132, 6389, 2686,     // AT&T (incl. legacy SBC / BellSouth ASNs seen in US traces)
         701, 702, 703,     // Verizon (UUNET)
         2914,              // NTT (GIN)
-        174,               // Cogent
+        174, 1239,         // Cogent (1239 = ex-SprintLink, sold to Cogent 2023)
         1299,              // Arelion (ex-Telia)
-        3257,              // GTT
+        3257,              // GTT (backbone now EXA Infrastructure; ASN still registered GTT)
         6453,              // Tata
         6461,              // Zayo
         6762,              // Telecom Italia Sparkle
@@ -1674,7 +1679,6 @@ public class UpstreamTracerService
         5511,              // Orange
         12956,             // Telxius (Telefonica)
         3320,              // Deutsche Telekom
-        1239,              // Sprint / T-Mobile (legacy)
     };
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -949,7 +949,7 @@ public class UpstreamTracerService
 
         _excludedTier1Asns.Clear();
         _excludedTier1Asns.UnionWith(
-            ComputeExcludedTier1Asns(traceSequences, asnByIp, Tier1Asns));
+            ComputeExcludedTier1Asns(traceSequences, asnByIp, Tier1Asns, accessAsnNumbers));
 
         var transitGroups = _mergedHops
             .Where(h => h.Asn != null
@@ -1716,15 +1716,20 @@ public class UpstreamTracerService
     /// <summary>
     /// Tier-1 ASNs to exclude as transit because they only ever appear directly above
     /// another tier-1 on the path - core peering in the internet core, not our access
-    /// ISP's transit. A tier-1 is kept when at least one trace shows a non-tier-1 ASN
-    /// immediately downstream (access side, lower TTL) of it: the access ISP itself, or
-    /// a regional transit it feeds. Consecutive same-ASN hops are collapsed; a tier-1
-    /// that is the first resolved ASN on a trace counts as grounded (downstream is us).
+    /// ISP's transit. A tier-1 is kept when at least one trace shows it "grounded": the
+    /// ASN immediately downstream (access side, lower TTL) is the access ISP itself, a
+    /// non-tier-1 (a regional transit it feeds), or nothing (the tier-1 is the first
+    /// resolved hop, so downstream is us). The access ISP is grounding even when it is
+    /// itself a tier-1 (e.g. an AT&amp;T or Verizon fiber customer): the first tier-1 above
+    /// the access edge is that ISP's upstream/peer and must stay, only tier-1s sitting
+    /// above *another, non-access* tier-1 are core peering. Consecutive same-ASN hops
+    /// are collapsed.
     /// </summary>
     internal static HashSet<int> ComputeExcludedTier1Asns(
         IEnumerable<IReadOnlyList<string>> traceAddressSequences,
         IReadOnlyDictionary<string, int> asnByIp,
-        IReadOnlySet<int> tier1Asns)
+        IReadOnlySet<int> tier1Asns,
+        IReadOnlySet<int> accessAsns)
     {
         var seen = new HashSet<int>();
         var grounded = new HashSet<int>();
@@ -1738,7 +1743,7 @@ public class UpstreamTracerService
                 if (tier1Asns.Contains(asn))
                 {
                     seen.Add(asn);
-                    if (prevAsn == null || !tier1Asns.Contains(prevAsn.Value))
+                    if (prevAsn == null || accessAsns.Contains(prevAsn.Value) || !tier1Asns.Contains(prevAsn.Value))
                         grounded.Add(asn);
                 }
                 prevAsn = asn;

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
@@ -697,10 +697,13 @@ public class ComputeNearTransitAsnsTests
     private const int UpstreamB = 64520;
     private const int Lumen = 3356;
     private const int Cogent = 174;
+    private const int Arelion = 1299;
+    private const int Indatel = 30517;
     private const int Cloudflare = 13335;
 
     private static IReadOnlySet<int> AccessSet => new HashSet<int> { Access };
     private static IReadOnlySet<int> NoDest => new HashSet<int>();
+    private static IReadOnlySet<int> Tier1 => new HashSet<int> { Lumen, Cogent, Arelion };
 
     private static Dictionary<string, int> Map(params (string Ip, int Asn)[] e)
         => e.ToDictionary(x => x.Ip, x => x.Asn, StringComparer.OrdinalIgnoreCase);
@@ -710,7 +713,7 @@ public class ComputeNearTransitAsnsTests
     {
         var map = Map(("192.0.2.1", Access), ("192.0.2.2", Lumen));
         var near = UpstreamTracerService.ComputeNearTransitAsns(
-            new[] { new[] { "192.0.2.1", "192.0.2.2" } }, map, AccessSet, NoDest);
+            new[] { new[] { "192.0.2.1", "192.0.2.2" } }, map, AccessSet, NoDest, Tier1);
         near.Should().Contain(Lumen);
     }
 
@@ -720,7 +723,7 @@ public class ComputeNearTransitAsnsTests
         // access -> UpstreamA -> Lumen: Lumen is 2nd-degree, still in window.
         var map = Map(("192.0.2.1", Access), ("192.0.2.2", UpstreamA), ("192.0.2.3", Lumen));
         var near = UpstreamTracerService.ComputeNearTransitAsns(
-            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" } }, map, AccessSet, NoDest);
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" } }, map, AccessSet, NoDest, Tier1);
         near.Should().BeEquivalentTo(new[] { UpstreamA, Lumen });
     }
 
@@ -731,7 +734,7 @@ public class ComputeNearTransitAsnsTests
         var map = Map(("192.0.2.1", Access), ("192.0.2.2", UpstreamA),
                       ("192.0.2.3", UpstreamB), ("192.0.2.4", Lumen));
         var near = UpstreamTracerService.ComputeNearTransitAsns(
-            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4" } }, map, AccessSet, NoDest);
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4" } }, map, AccessSet, NoDest, Tier1);
         near.Should().BeEquivalentTo(new[] { UpstreamA, UpstreamB });
         near.Should().NotContain(Lumen);
     }
@@ -747,7 +750,7 @@ public class ComputeNearTransitAsnsTests
             {
                 new[] { "192.0.2.1", "192.0.2.2" },
                 new[] { "198.51.100.1", "198.51.100.2" }
-            }, map, AccessSet, NoDest);
+            }, map, AccessSet, NoDest, Tier1);
         near.Should().BeEquivalentTo(new[] { Lumen, UpstreamA });
     }
 
@@ -765,7 +768,7 @@ public class ComputeNearTransitAsnsTests
             {
                 new[] { "198.51.100.1" },
                 new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4" }
-            }, map, AccessSet, NoDest);
+            }, map, AccessSet, NoDest, Tier1);
         near.Should().Contain(Lumen);
         near.Should().Contain(UpstreamA);
     }
@@ -773,14 +776,15 @@ public class ComputeNearTransitAsnsTests
     [Fact]
     public void Destination_asn_does_not_consume_a_degree_slot()
     {
-        // access -> Lumen -> Cloudflare(dest) -> Cogent: with dest skipped, the real
-        // 2nd-degree transit (Cogent) still fits in the window.
+        // access -> UpstreamA -> Cloudflare(dest) -> UpstreamB: with dest skipped, the
+        // real 2nd-degree transit (UpstreamB) still fits in the window. Non-tier-1 hops
+        // so the tier-1 horizon stop doesn't interfere with what this test isolates.
         var dest = new HashSet<int> { Cloudflare };
-        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Lumen),
-                      ("192.0.2.3", Cloudflare), ("192.0.2.4", Cogent));
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", UpstreamA),
+                      ("192.0.2.3", Cloudflare), ("192.0.2.4", UpstreamB));
         var near = UpstreamTracerService.ComputeNearTransitAsns(
-            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4" } }, map, AccessSet, dest);
-        near.Should().BeEquivalentTo(new[] { Lumen, Cogent });
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4" } }, map, AccessSet, dest, Tier1);
+        near.Should().BeEquivalentTo(new[] { UpstreamA, UpstreamB });
     }
 
     [Fact]
@@ -788,7 +792,7 @@ public class ComputeNearTransitAsnsTests
     {
         var map = Map(("192.0.2.1", Access), ("192.0.2.3", Lumen)); // .2 has no ASN (gap)
         var near = UpstreamTracerService.ComputeNearTransitAsns(
-            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" } }, map, AccessSet, NoDest);
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" } }, map, AccessSet, NoDest, Tier1);
         near.Should().Contain(Lumen);
     }
 
@@ -797,7 +801,7 @@ public class ComputeNearTransitAsnsTests
     {
         var map = Map(("192.0.2.1", Access), ("192.0.2.2", Access));
         var near = UpstreamTracerService.ComputeNearTransitAsns(
-            new[] { new[] { "192.0.2.1", "192.0.2.2" } }, map, AccessSet, NoDest);
+            new[] { new[] { "192.0.2.1", "192.0.2.2" } }, map, AccessSet, NoDest, Tier1);
         near.Should().BeEmpty();
     }
 
@@ -805,8 +809,44 @@ public class ComputeNearTransitAsnsTests
     public void No_traces_yields_nothing()
     {
         var near = UpstreamTracerService.ComputeNearTransitAsns(
-            Array.Empty<IReadOnlyList<string>>(), new Dictionary<string, int>(), AccessSet, NoDest);
+            Array.Empty<IReadOnlyList<string>>(), new Dictionary<string, int>(), AccessSet, NoDest, Tier1);
         near.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Asn_reached_through_a_tier1_is_not_near_transit()
+    {
+        // access -> Arelion(tier-1) -> INDATEL: the endpoint sits beyond a tier-1, so it
+        // is not adjacent to the ISP and must not be near-transit (the AT&T-via-Arelion
+        // case). The tier-1 itself is the first upstream and stays.
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Arelion), ("192.0.2.3", Indatel));
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" } }, map, AccessSet, NoDest, Tier1);
+        near.Should().Contain(Arelion);
+        near.Should().NotContain(Indatel);
+    }
+
+    [Fact]
+    public void Endpoint_one_hop_off_the_access_isp_is_near_transit()
+    {
+        // access -> INDATEL directly: no tier-1 in between, so it stays near-transit
+        // (the directly-adjacent case). Same endpoint ASN as above, opposite verdict.
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Indatel));
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2" } }, map, AccessSet, NoDest, Tier1);
+        near.Should().Contain(Indatel);
+    }
+
+    [Fact]
+    public void Walk_stops_at_the_first_tier1()
+    {
+        // access -> Lumen(tier-1) -> Cogent(tier-1): only the first tier-1 is near-transit;
+        // a second tier-1 reached through it is core peering, not our transit.
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Lumen), ("192.0.2.3", Cogent));
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" } }, map, AccessSet, NoDest, Tier1);
+        near.Should().Contain(Lumen);
+        near.Should().NotContain(Cogent);
     }
 }
 

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
@@ -915,8 +915,19 @@ public class ComputeExcludedTier1AsnsTests
     }
 
     [Fact]
-    public void Tier1Asns_constant_includes_major_carriers()
+    public void Tier1Asns_constant_includes_major_carriers_and_live_siblings()
     {
-        UpstreamTracerService.Tier1Asns.Should().Contain(new[] { 3356, 174, 7018, 2914, 1299, 6461 });
+        // Core tier-1s, plus the corrected AS1239 (now Cogent) and active AT&T/Lumen
+        // sibling ASNs that show up in US traces.
+        UpstreamTracerService.Tier1Asns.Should().Contain(
+            new[] { 3356, 174, 7018, 2914, 1299, 6461, 1239, 7132, 3561 });
+    }
+
+    [Fact]
+    public void Tier1Asns_excludes_hurricane_electric()
+    {
+        // AS6939 is not settlement-free on IPv4, so it carries no reliable core-peering
+        // signal and stays out of the adjacency set.
+        UpstreamTracerService.Tier1Asns.Should().NotContain(6939);
     }
 }

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
@@ -687,3 +687,236 @@ public class UpstreamCommitTests : IDisposable
             LastVerified = DateTime.UtcNow
         };
 }
+
+public class ComputeNearTransitAsnsTests
+{
+    // Generic private-use access ASN (not a real ISP); public tier-1 ASNs are real
+    // because the logic keys on them.
+    private const int Access = 64500;
+    private const int UpstreamA = 64510;
+    private const int UpstreamB = 64520;
+    private const int Lumen = 3356;
+    private const int Cogent = 174;
+    private const int Cloudflare = 13335;
+
+    private static IReadOnlySet<int> AccessSet => new HashSet<int> { Access };
+    private static IReadOnlySet<int> NoDest => new HashSet<int>();
+
+    private static Dictionary<string, int> Map(params (string Ip, int Asn)[] e)
+        => e.ToDictionary(x => x.Ip, x => x.Asn, StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void Direct_upstream_is_near_transit()
+    {
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Lumen));
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2" } }, map, AccessSet, NoDest);
+        near.Should().Contain(Lumen);
+    }
+
+    [Fact]
+    public void Upstreams_upstream_is_near_transit()
+    {
+        // access -> UpstreamA -> Lumen: Lumen is 2nd-degree, still in window.
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", UpstreamA), ("192.0.2.3", Lumen));
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" } }, map, AccessSet, NoDest);
+        near.Should().BeEquivalentTo(new[] { UpstreamA, Lumen });
+    }
+
+    [Fact]
+    public void Third_degree_asn_is_not_near_transit()
+    {
+        // access -> UpstreamA -> UpstreamB -> Lumen: Lumen is 3rd-degree, dropped.
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", UpstreamA),
+                      ("192.0.2.3", UpstreamB), ("192.0.2.4", Lumen));
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4" } }, map, AccessSet, NoDest);
+        near.Should().BeEquivalentTo(new[] { UpstreamA, UpstreamB });
+        near.Should().NotContain(Lumen);
+    }
+
+    [Fact]
+    public void Every_direct_upstream_of_a_multihomed_isp_is_captured()
+    {
+        // Different traces exit via different upstreams; the per-trace union keeps all.
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Lumen),
+                      ("198.51.100.1", Access), ("198.51.100.2", UpstreamA));
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            new[]
+            {
+                new[] { "192.0.2.1", "192.0.2.2" },
+                new[] { "198.51.100.1", "198.51.100.2" }
+            }, map, AccessSet, NoDest);
+        near.Should().BeEquivalentTo(new[] { Lumen, UpstreamA });
+    }
+
+    [Fact]
+    public void Per_trace_window_does_not_let_one_trace_crowd_out_another_upstream()
+    {
+        // Regression: a short trace reaching UpstreamA at hop 1 plus a long trace
+        // reaching Lumen only at hop 4. A merged-pool "first two ASNs by hop number"
+        // filled both slots on the low hops and dropped Lumen; per-trace keeps both.
+        var map = Map(("198.51.100.1", UpstreamA),
+                      ("192.0.2.1", Access), ("192.0.2.2", Access),
+                      ("192.0.2.3", Access), ("192.0.2.4", Lumen));
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            new[]
+            {
+                new[] { "198.51.100.1" },
+                new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4" }
+            }, map, AccessSet, NoDest);
+        near.Should().Contain(Lumen);
+        near.Should().Contain(UpstreamA);
+    }
+
+    [Fact]
+    public void Destination_asn_does_not_consume_a_degree_slot()
+    {
+        // access -> Lumen -> Cloudflare(dest) -> Cogent: with dest skipped, the real
+        // 2nd-degree transit (Cogent) still fits in the window.
+        var dest = new HashSet<int> { Cloudflare };
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Lumen),
+                      ("192.0.2.3", Cloudflare), ("192.0.2.4", Cogent));
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4" } }, map, AccessSet, dest);
+        near.Should().BeEquivalentTo(new[] { Lumen, Cogent });
+    }
+
+    [Fact]
+    public void Unresolved_hops_are_skipped()
+    {
+        var map = Map(("192.0.2.1", Access), ("192.0.2.3", Lumen)); // .2 has no ASN (gap)
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" } }, map, AccessSet, NoDest);
+        near.Should().Contain(Lumen);
+    }
+
+    [Fact]
+    public void Access_only_path_yields_nothing()
+    {
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Access));
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2" } }, map, AccessSet, NoDest);
+        near.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void No_traces_yields_nothing()
+    {
+        var near = UpstreamTracerService.ComputeNearTransitAsns(
+            Array.Empty<IReadOnlyList<string>>(), new Dictionary<string, int>(), AccessSet, NoDest);
+        near.Should().BeEmpty();
+    }
+}
+
+public class ComputeExcludedTier1AsnsTests
+{
+    private const int Access = 64500;
+    private const int Regional = 64510;
+    private const int Lumen = 3356;
+    private const int Cogent = 174;
+    private const int Gtt = 3257;
+
+    private static IReadOnlySet<int> Tier1 => new HashSet<int> { Lumen, Cogent, Gtt };
+
+    private static Dictionary<string, int> Map(params (string Ip, int Asn)[] e)
+        => e.ToDictionary(x => x.Ip, x => x.Asn, StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void Tier1_above_non_tier1_is_kept()
+    {
+        // access(non-T1) -> Lumen(T1): grounded, not excluded.
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Lumen));
+        var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2" } }, map, Tier1);
+        excluded.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Tier1_directly_above_another_tier1_is_excluded()
+    {
+        // access -> Cogent(T1) -> Lumen(T1): Lumen is core peering, excluded. Cogent
+        // sits above access (non-T1) so it stays.
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Cogent), ("192.0.2.3", Lumen));
+        var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" } }, map, Tier1);
+        excluded.Should().BeEquivalentTo(new[] { Lumen });
+    }
+
+    [Fact]
+    public void Kept_when_grounded_on_any_trace()
+    {
+        // One trace shows Lumen above Cogent; another shows Lumen directly above access.
+        // A single grounded sighting keeps it.
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Cogent), ("192.0.2.3", Lumen),
+                      ("198.51.100.1", Access), ("198.51.100.2", Lumen));
+        var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
+            new[]
+            {
+                new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" },
+                new[] { "198.51.100.1", "198.51.100.2" }
+            }, map, Tier1);
+        excluded.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Excluded_only_when_tier1_downstream_on_every_trace()
+    {
+        // Lumen sits above a tier-1 (Cogent, then GTT) on both traces -> excluded.
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Cogent), ("192.0.2.3", Lumen),
+                      ("198.51.100.1", Access), ("198.51.100.2", Gtt), ("198.51.100.3", Lumen));
+        var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
+            new[]
+            {
+                new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" },
+                new[] { "198.51.100.1", "198.51.100.2", "198.51.100.3" }
+            }, map, Tier1);
+        excluded.Should().BeEquivalentTo(new[] { Lumen });
+    }
+
+    [Fact]
+    public void Tier1_as_first_resolved_hop_is_grounded()
+    {
+        // Unresolved gateway hop then Lumen: downstream is us, so Lumen is grounded.
+        var map = Map(("192.0.2.2", Lumen)); // first hop has no ASN
+        var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
+            new[] { new[] { "10.0.0.1", "192.0.2.2" } }, map, Tier1);
+        excluded.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Consecutive_same_asn_hops_are_collapsed()
+    {
+        // access -> Lumen -> Lumen -> Cogent: Cogent's true downstream is Lumen(T1),
+        // so Cogent is excluded; Lumen is grounded by access and kept.
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Lumen),
+                      ("192.0.2.3", Lumen), ("192.0.2.4", Cogent));
+        var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4" } }, map, Tier1);
+        excluded.Should().BeEquivalentTo(new[] { Cogent });
+    }
+
+    [Fact]
+    public void Non_tier1_asns_are_never_excluded()
+    {
+        var map = Map(("192.0.2.1", Access), ("192.0.2.2", Regional));
+        var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2" } }, map, Tier1);
+        excluded.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void No_traces_yields_nothing()
+    {
+        var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
+            Array.Empty<IReadOnlyList<string>>(), new Dictionary<string, int>(), Tier1);
+        excluded.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Tier1Asns_constant_includes_major_carriers()
+    {
+        UpstreamTracerService.Tier1Asns.Should().Contain(new[] { 3356, 174, 7018, 2914, 1299, 6461 });
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
@@ -817,8 +817,10 @@ public class ComputeExcludedTier1AsnsTests
     private const int Lumen = 3356;
     private const int Cogent = 174;
     private const int Gtt = 3257;
+    private const int Att = 7018;
 
-    private static IReadOnlySet<int> Tier1 => new HashSet<int> { Lumen, Cogent, Gtt };
+    private static IReadOnlySet<int> Tier1 => new HashSet<int> { Lumen, Cogent, Gtt, Att };
+    private static IReadOnlySet<int> AccessSet => new HashSet<int> { Access };
 
     private static Dictionary<string, int> Map(params (string Ip, int Asn)[] e)
         => e.ToDictionary(x => x.Ip, x => x.Asn, StringComparer.OrdinalIgnoreCase);
@@ -829,7 +831,7 @@ public class ComputeExcludedTier1AsnsTests
         // access(non-T1) -> Lumen(T1): grounded, not excluded.
         var map = Map(("192.0.2.1", Access), ("192.0.2.2", Lumen));
         var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
-            new[] { new[] { "192.0.2.1", "192.0.2.2" } }, map, Tier1);
+            new[] { new[] { "192.0.2.1", "192.0.2.2" } }, map, Tier1, AccessSet);
         excluded.Should().BeEmpty();
     }
 
@@ -840,7 +842,7 @@ public class ComputeExcludedTier1AsnsTests
         // sits above access (non-T1) so it stays.
         var map = Map(("192.0.2.1", Access), ("192.0.2.2", Cogent), ("192.0.2.3", Lumen));
         var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
-            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" } }, map, Tier1);
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" } }, map, Tier1, AccessSet);
         excluded.Should().BeEquivalentTo(new[] { Lumen });
     }
 
@@ -856,7 +858,7 @@ public class ComputeExcludedTier1AsnsTests
             {
                 new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" },
                 new[] { "198.51.100.1", "198.51.100.2" }
-            }, map, Tier1);
+            }, map, Tier1, AccessSet);
         excluded.Should().BeEmpty();
     }
 
@@ -871,7 +873,7 @@ public class ComputeExcludedTier1AsnsTests
             {
                 new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" },
                 new[] { "198.51.100.1", "198.51.100.2", "198.51.100.3" }
-            }, map, Tier1);
+            }, map, Tier1, AccessSet);
         excluded.Should().BeEquivalentTo(new[] { Lumen });
     }
 
@@ -881,7 +883,7 @@ public class ComputeExcludedTier1AsnsTests
         // Unresolved gateway hop then Lumen: downstream is us, so Lumen is grounded.
         var map = Map(("192.0.2.2", Lumen)); // first hop has no ASN
         var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
-            new[] { new[] { "10.0.0.1", "192.0.2.2" } }, map, Tier1);
+            new[] { new[] { "10.0.0.1", "192.0.2.2" } }, map, Tier1, AccessSet);
         excluded.Should().BeEmpty();
     }
 
@@ -893,7 +895,7 @@ public class ComputeExcludedTier1AsnsTests
         var map = Map(("192.0.2.1", Access), ("192.0.2.2", Lumen),
                       ("192.0.2.3", Lumen), ("192.0.2.4", Cogent));
         var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
-            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4" } }, map, Tier1);
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4" } }, map, Tier1, AccessSet);
         excluded.Should().BeEquivalentTo(new[] { Cogent });
     }
 
@@ -902,7 +904,7 @@ public class ComputeExcludedTier1AsnsTests
     {
         var map = Map(("192.0.2.1", Access), ("192.0.2.2", Regional));
         var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
-            new[] { new[] { "192.0.2.1", "192.0.2.2" } }, map, Tier1);
+            new[] { new[] { "192.0.2.1", "192.0.2.2" } }, map, Tier1, AccessSet);
         excluded.Should().BeEmpty();
     }
 
@@ -910,8 +912,33 @@ public class ComputeExcludedTier1AsnsTests
     public void No_traces_yields_nothing()
     {
         var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
-            Array.Empty<IReadOnlyList<string>>(), new Dictionary<string, int>(), Tier1);
+            Array.Empty<IReadOnlyList<string>>(), new Dictionary<string, int>(), Tier1, AccessSet);
         excluded.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void First_tier1_above_a_tier1_access_isp_is_kept()
+    {
+        // AT&T fiber customer: access ASN is itself tier-1 (AS7018), and Lumen sits
+        // directly above it. Lumen is AT&T's upstream/peer - the thing to monitor - not
+        // core peering, so the access ASN grounds it even though it's a tier-1.
+        var access = new HashSet<int> { Att };
+        var map = Map(("192.0.2.1", Att), ("192.0.2.2", Lumen));
+        var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2" } }, map, Tier1, access);
+        excluded.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Second_tier1_above_a_tier1_access_isp_is_excluded()
+    {
+        // access=AT&T(T1) -> Lumen(T1) -> Cogent(T1): Lumen is grounded by the access
+        // ISP and kept; Cogent sits above a non-access tier-1 (Lumen) and is excluded.
+        var access = new HashSet<int> { Att };
+        var map = Map(("192.0.2.1", Att), ("192.0.2.2", Lumen), ("192.0.2.3", Cogent));
+        var excluded = UpstreamTracerService.ComputeExcludedTier1Asns(
+            new[] { new[] { "192.0.2.1", "192.0.2.2", "192.0.2.3" } }, map, Tier1, access);
+        excluded.Should().BeEquivalentTo(new[] { Cogent });
     }
 
     [Fact]


### PR DESCRIPTION
## Upstream Discovery / ISP Health

- **Multi-homed access ISPs surface every direct upstream.** The near-transit window (which decides whether a transit ASN such as Lumen or AT&T is genuinely your ISP's upstream) is now computed per individual trace and unioned across traces, instead of over the merged hop pool. On a multi-homed access ISP, a different trace's upstream could previously fill the global "first two" slots and crowd out a real direct upstream, so it never got monitored.

- **Your transit horizon ends at the first tier-1.** A transit ASN reached only by transiting a tier-1 is treated as beyond your ISP's transit and is not added as a candidate. This covers both a tier-1 sitting directly above another tier-1 (internet-core peering) and a regional carrier reached through a tier-1 (for example a regional transit probe that is several hops past a tier-1 backbone on one connection but directly adjacent to the ISP on another). The access ISP is exempt: if your access ISP is itself a tier-1 (for example an AT&T or Verizon fiber customer), the first tier-1 above it is that ISP's real upstream or peer and is kept.

- **Curated tier-1 ASN set.** Verified the settlement-free tier-1 list against authoritative sources: corrected AS1239 (now Cogent, post-2023 SprintLink sale) and added active AT&T and Lumen sibling ASNs seen in US traces. Hurricane Electric is intentionally excluded (not settlement-free on IPv4), with the rationale documented inline.

## SSH device probes

- **Refresh the package index before installing traceroute.** When an SSH-able device is missing traceroute, run an index refresh first so a console with stale or empty package lists can resolve it. Stays non-fatal on devices without apt.

## Adaptive SQM

- **Refresh the package index before installing bc/jq.** Same fix in the SQM boot script's dependency install, guarded so it only runs when a dependency is missing. The Ookla CLI already gets its refresh from the packagecloud setup script; these did not.

## Tests

Extracted the near-transit and tier-1 adjacency logic into testable static helpers with full unit coverage: per-trace union, 3rd-degree exclusion, destination skipping, multi-homing, transit-horizon stop at the first tier-1, tier-1 core-peering exclusion, multi-trace grounding, tier-1 access ISP exemption, and consecutive-hop collapse.