### PR TITLE
v1.21.5 Release Changes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,16 @@
   <ItemGroup>
     <PackageReference Include="MinVer" Version="6.*" PrivateAssets="all" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- SQLitePCLRaw.lib.e_sqlite3 2.1.11 (pulled transitively by Microsoft.Data.Sqlite /
+         EF Core Sqlite 10.0.7) is flagged for GHSA-2m69-gcr7-jv3q, a vulnerability in the
+         bundled native SQLite. We are not in the affected code path: the app opens only its
+         own EF-managed database, never foreign .db files or untrusted SQL. The EF team's
+         sanctioned interim is to suppress this advisory (they cannot bump the managed bundle
+         to v3 in a patch - it's a breaking change); the real fix ships in EF 10.0.11.
+         See https://github.com/dotnet/efcore/issues/38257 - REMOVE this when we move to 10.0.11. -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
   <PropertyGroup>
     <!-- MinVer derives version from git tags (e.g., v0.7.3 -> 0.7.3) -->
     <MinVerTagPrefix>v</MinVerTagPrefix>

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -1031,6 +1031,45 @@ from(bucket: ""{_bucket}"")
         return results;
     }
 
+    /// <summary>
+    /// Per-window rtt/jitter/loss detail for a single target by its id - used to pull just the LAN
+    /// gateway's loss for outage scoping without loading every fabric device's series.
+    /// </summary>
+    public async Task<List<LatencySeriesPoint>> QueryLatencyDetailByTargetIdAsync(
+        string targetId,
+        DateTime from,
+        DateTime to,
+        TimeSpan? aggregateWindow = null,
+        CancellationToken ct = default)
+    {
+        if (!IsConfigured) await ReconfigureAsync(ct);
+        if (!IsConfigured) return new List<LatencySeriesPoint>();
+        var window = aggregateWindow ?? PickAggregateWindow(to - from);
+        var flux = $@"
+from(bucket: ""{_bucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""latency"")
+  |> filter(fn: (r) => r.target_id == ""{targetId}"")
+  |> filter(fn: (r) => r._field == ""rtt_avg_ms"" or r._field == ""rtt_max_ms"" or r._field == ""jitter_ms"" or r._field == ""loss_percent"")
+  |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
+  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
+";
+        var list = new List<LatencySeriesPoint>();
+        await foreach (var record in QueryFluxAsync(flux, ct))
+        {
+            list.Add(new LatencySeriesPoint
+            {
+                Time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow),
+                RttAvgMs = AsDoubleOrNull(record.GetValueByKey("rtt_avg_ms")),
+                RttMaxMs = AsDoubleOrNull(record.GetValueByKey("rtt_max_ms")),
+                JitterMs = AsDoubleOrNull(record.GetValueByKey("jitter_ms")),
+                LossPercent = AsDoubleOrNull(record.GetValueByKey("loss_percent"))
+            });
+        }
+        list.Sort((a, b) => a.Time.CompareTo(b.Time));
+        return list;
+    }
+
     public record LatencySeriesPoint
     {
         public required DateTime Time { get; init; }

--- a/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
@@ -619,7 +619,18 @@
                             @foreach (var test in _recentSpeedTests)
                             {
                                 <div class="speed-test-row">
-                                    <span class="speed-test-device">@(test.DeviceName ?? "Unknown")</span>
+                                    @if (!string.IsNullOrEmpty(test.DeviceName))
+                                    {
+                                        <span class="speed-test-device">@test.DeviceName</span>
+                                    }
+                                    else if (!string.IsNullOrEmpty(test.DeviceHost))
+                                    {
+                                        <span class="speed-test-device"><code>@test.DeviceHost</code></span>
+                                    }
+                                    else
+                                    {
+                                        <span class="speed-test-device">Unknown</span>
+                                    }
                                     <span class="speed-test-speeds">
                                         <span class="speed-down">↓@test.DownloadMbps.ToString("F0")</span>
                                         <span class="speed-up">↑@test.UploadMbps.ToString("F0")</span>

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -5,6 +5,58 @@
 @inject IJSRuntime JS
 @inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
 
+@* Date/time filter (left) + Refresh. Default 48 h is the live/cached view and the only state
+   where Refresh is enabled; any other selection recomputes off-cache and locks Refresh. Always
+   rendered (once past initial load) so a custom window with no data can still be switched back. *@
+@if (!_loading)
+{
+    <div class="isp-health-toolbar">
+        @if (_showCustomPopover)
+        {
+            <div class="isp-popover-backdrop" @onclick="() => _showCustomPopover = false"></div>
+        }
+        <div class="time-range-selector @(_showCustomPopover ? "isp-filter-raised" : "")" style="position: relative;">
+            @foreach (var p in FilterPresets)
+            {
+                <button class="time-btn @(!_isCustom && _selectedPreset == p.Hours ? "active" : "")"
+                        @onclick="() => SelectPresetAsync(p.Hours)" disabled="@_windowComputing">@p.Label</button>
+            }
+            <button class="time-btn custom-range-btn @(_isCustom ? "active" : "")" @onclick="ToggleCustomPopover"
+                    data-tooltip="Custom date range (max 1 month)" data-tooltip-hover-only>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2" /><line x1="16" y1="2" x2="16" y2="6" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="3" y1="10" x2="21" y2="10" /></svg>
+            </button>
+            <div class="custom-range-popover @(_showCustomPopover ? "open" : "")">
+                <div class="custom-range-form">
+                    <div class="custom-range-title">Custom Range</div>
+                    <div class="custom-range-field">
+                        <label>From</label>
+                        <input type="datetime-local" data-input="from" class="custom-range-input" @bind="_customFrom" />
+                    </div>
+                    <div class="custom-range-field">
+                        <label>To</label>
+                        <input type="datetime-local" data-input="to" class="custom-range-input" @bind="_customTo" />
+                    </div>
+                    <div class="custom-range-actions">
+                        <button class="btn btn-sm btn-secondary" @onclick="() => _showCustomPopover = false">Cancel</button>
+                        <button class="btn btn-sm btn-primary" @onclick="ApplyCustomAsync">Apply</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <button class="btn btn-sm btn-secondary" @onclick="RefreshAsync" disabled="@(_refreshing || _windowComputing)"
+                data-tooltip="Recompute ISP Health for the selected window" data-tooltip-hover-only>
+            @if (_refreshing || _windowComputing)
+            {
+                <span class="spinner-sm"></span> <span>@(_refreshing ? "Refreshing" : "Loading")</span>
+            }
+            else
+            {
+                <span>Refresh</span>
+            }
+        </button>
+    </div>
+}
+
 @if (_loading)
 {
     <div class="loading-container">
@@ -85,19 +137,6 @@ else
             </div>
         </div>
     }
-    <div class="isp-health-toolbar">
-        <button class="btn btn-sm btn-secondary" @onclick="RefreshAsync" disabled="@_refreshing"
-                data-tooltip="Recompute ISP Health now from the latest monitoring data" data-tooltip-hover-only>
-            @if (_refreshing)
-            {
-                <span class="spinner-sm"></span> <span>Refreshing</span>
-            }
-            else
-            {
-                <span>Refresh</span>
-            }
-        </button>
-    </div>
     <div class="isp-health-hero card">
         <span class="isp-health-updated">Last updated: @TimeFormatHelper.FormatRelativeTimeShort(r.ComputedAt)</span>
         <div class="card-body isp-health-hero-body">
@@ -371,10 +410,10 @@ else
                     {
                         <div class="isp-outage">
                             <div class="isp-outage-head">
-                                <span class="isp-event-badge isp-event-badge-danger">Outage</span>
+                                <span class="isp-event-badge isp-event-badge-danger" data-tooltip="@OutageScoreTooltip(outage)">Outage</span>
                                 <span class="isp-outage-duration">@FormatDuration(outage.Duration)</span>
                                 <span class="isp-outage-window">@outage.Start.ToLocalTime().ToString("MMM d, HH:mm:ss") &ndash; @outage.End.ToLocalTime().ToString("HH:mm:ss")</span>
-                                <span class="isp-outage-scope">@OutageScopeLabel(outage)</span>
+                                <span class="isp-outage-scope" data-tooltip="@OutageScoreTooltip(outage)">@OutageScopeLabel(outage)</span>
                             </div>
                             @if (outage.Tiers.Any(t => t.WentDark))
                             {
@@ -412,7 +451,7 @@ else
                     {
                         <div class="isp-event-item">
                             <span class="isp-event-badge @entry.BadgeClass">@entry.Badge</span>
-                            <span class="isp-event-time">@entry.Time.ToLocalTime().ToString("HH:mm")</span>
+                            <span class="isp-event-time">@EventTimeLabel(entry.Time)</span>
                             <span class="isp-event-text">@entry.Text</span>
                         </div>
                     }
@@ -421,7 +460,7 @@ else
         </div>
     </div>
 
-    <div class="card isp-health-card">
+    <div class="card isp-health-card isp-health-chart-card">
         <div class="card-header"><h2 class="card-title">Per-Network RTT (@WindowLabel(r))</h2></div>
         <div class="card-body">
             <div id="isp-health-asn-chart"></div>
@@ -456,6 +495,26 @@ else
     private bool _showAllIspHops;
     private System.Threading.Timer? _ageTimer;
 
+    // Date/time filter. Never persisted: OnInitializedAsync always starts on 48 h, so leaving
+    // and returning to the tab (and every auto-computed path) resets to the live window.
+    private static readonly (string Label, int Hours)[] FilterPresets =
+    {
+        ("24h", 24), ("48h", 48), ("7d", 168), ("14d", 336), ("30d", 720)
+    };
+    private const int DefaultPresetHours = 48;
+    private const int MaxRangeHours = 720;   // 30-day / 1-month hard cap
+    private const int MinRangeHours = 4;     // smallest custom window
+    private int _selectedPreset = DefaultPresetHours;
+    private bool _isCustom;
+    private bool _showCustomPopover;
+    private bool _windowComputing;
+    private DateTime? _windowStart;
+    private DateTime? _windowEnd;
+    private DateTime _customFrom = DateTime.Now.AddDays(-2);
+    private DateTime _customTo = DateTime.Now;
+
+    private bool IsLiveWindow => !_isCustom && _selectedPreset == DefaultPresetHours;
+
     protected override async Task OnInitializedAsync()
     {
         try
@@ -484,14 +543,24 @@ else
 
     private async Task RefreshAsync()
     {
-        if (_refreshing) return;
+        if (_refreshing || _windowComputing) return;
         _refreshing = true;
         try
         {
-            _report = await IspHealth.GetReportAsync(forceRefresh: true);
-            // The chart fetches its own series from the freshly cached report.
-            try { await JS.InvokeVoidAsync("eval", "window.__ispHealthCharts?.reload?.();"); }
-            catch { /* chart not mounted yet */ }
+            if (IsLiveWindow)
+            {
+                _report = await IspHealth.GetReportAsync(forceRefresh: true);
+                // The chart fetches its own series from the freshly cached report.
+                try { await JS.InvokeVoidAsync("eval", "window.__ispHealthCharts?.reload?.();"); }
+                catch { /* chart not mounted yet */ }
+            }
+            else if (_windowStart.HasValue && _windowEnd.HasValue)
+            {
+                // Recompute the current window, bypassing the custom-window cache; the chart's
+                // follow-up fetch then hits the freshly recomputed result for the same window.
+                _report = await IspHealth.GetReportForWindowAsync(_windowStart.Value, _windowEnd.Value, forceRefresh: true);
+                await ChartSetWindowAsync(_windowStart, _windowEnd);
+            }
         }
         finally
         {
@@ -501,15 +570,99 @@ else
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (_report == null || _chartMounted) return;
+        if (_report == null)
+        {
+            // The content (and the chart element) is gone; drop the chart so it re-mounts
+            // cleanly when a report shows again (e.g. switching back to 48 h from an empty window).
+            if (_chartMounted)
+            {
+                _chartMounted = false;
+                try { await JS.InvokeVoidAsync("eval", "window.__ispHealthCharts?.unmount?.();"); }
+                catch { /* nothing mounted */ }
+            }
+            return;
+        }
+        if (_chartMounted) return;
         _chartMounted = true;
+        var fromArg = _windowStart.HasValue ? $"'{_windowStart.Value:o}'" : "null";
+        var toArg = _windowEnd.HasValue ? $"'{_windowEnd.Value:o}'" : "null";
         try
         {
             await JS.InvokeVoidAsync("eval",
                 $"(async () => {{ const m = await import('{VersionedJs("/js/isp-health-charts.js")}'); " +
-                "window.__ispHealthCharts = m; await m.mount('isp-health-asn-chart'); })();");
+                $"window.__ispHealthCharts = m; await m.mount('isp-health-asn-chart', {fromArg}, {toArg}); }})();");
         }
         catch { _chartMounted = false; }
+    }
+
+    private void ToggleCustomPopover()
+    {
+        _showCustomPopover = !_showCustomPopover;
+        if (_showCustomPopover)
+        {
+            // Seed both pickers from the active window so they reflect the current filter.
+            _customTo = (_windowEnd ?? DateTime.UtcNow).ToLocalTime();
+            _customFrom = (_windowStart ?? DateTime.UtcNow.AddHours(-DefaultPresetHours)).ToLocalTime();
+        }
+    }
+
+    private async Task SelectPresetAsync(int hours)
+    {
+        _showCustomPopover = false;
+        _isCustom = false;
+        _selectedPreset = hours;
+        if (hours == DefaultPresetHours)
+            await LoadWindowAsync(null, null);   // back to the live/cached 48 h report
+        else
+        {
+            var end = DateTime.UtcNow;
+            await LoadWindowAsync(end.AddHours(-hours), end);
+        }
+    }
+
+    private async Task ApplyCustomAsync()
+    {
+        _showCustomPopover = false;
+        // datetime-local binds local wall-clock (Kind=Unspecified); treat it as local -> UTC.
+        var startUtc = _customFrom.ToUniversalTime();
+        var endUtc = _customTo.ToUniversalTime();
+        if (endUtc <= startUtc) return;
+        if (endUtc - startUtc < TimeSpan.FromHours(MinRangeHours))
+            startUtc = endUtc.AddHours(-MinRangeHours);   // enforce the minimum window
+        if (endUtc - startUtc > TimeSpan.FromHours(MaxRangeHours))
+            startUtc = endUtc.AddHours(-MaxRangeHours);   // clamp to the 1-month cap
+        _isCustom = true;
+        _selectedPreset = -1;
+        await LoadWindowAsync(startUtc, endUtc);
+    }
+
+    private async Task LoadWindowAsync(DateTime? fromUtc, DateTime? toUtc)
+    {
+        _windowComputing = true;
+        _windowStart = fromUtc;
+        _windowEnd = toUtc;
+        StateHasChanged();
+        try
+        {
+            // Default (null window) serves the cached 48 h report; an explicit window computes
+            // off-cache and never disturbs it. Stale report stays on screen until the swap.
+            _report = fromUtc.HasValue && toUtc.HasValue
+                ? await IspHealth.GetReportForWindowAsync(fromUtc.Value, toUtc.Value)
+                : await IspHealth.GetReportAsync();
+        }
+        catch { _report = null; }
+        finally { _windowComputing = false; }
+
+        if (_report != null) await ChartSetWindowAsync(fromUtc, toUtc);
+    }
+
+    private async Task ChartSetWindowAsync(DateTime? fromUtc, DateTime? toUtc)
+    {
+        if (!_chartMounted) return;
+        var fromArg = fromUtc.HasValue ? $"'{fromUtc.Value:o}'" : "null";
+        var toArg = toUtc.HasValue ? $"'{toUtc.Value:o}'" : "null";
+        try { await JS.InvokeVoidAsync("eval", $"window.__ispHealthCharts?.setWindow?.({fromArg}, {toArg});"); }
+        catch { /* chart not mounted yet */ }
     }
 
     private record TimelineEntry(DateTime Time, string Badge, string BadgeClass, string Text);
@@ -519,11 +672,35 @@ else
         var entries = new List<TimelineEntry>();
         foreach (var evt in r.CongestionEvents)
         {
-            var scope = evt.IsShared
-                ? $"shared across {evt.AsnNames.Count} networks (likely a shared upstream or return path)"
-                : string.Join(", ", evt.AsnNames);
-            entries.Add(new TimelineEntry(evt.Start, "Congestion", "isp-event-badge-warning",
-                $"{FormatDuration(evt.Duration)} of elevated latency and jitter on {scope}: {evt.BaselineRttMs:0.#} ms baseline to {evt.PeakRttMs:0.#} ms peak"));
+            var where = evt.IsShared
+                ? $"{evt.AsnNames.Count} networks at once (could not be localized)"
+                : (string.IsNullOrEmpty(evt.BottleneckLabel) ? string.Join(", ", evt.AsnNames) : evt.BottleneckLabel);
+            var span = FormatDuration(evt.Duration);
+            // Show both signals - congestion is detected on latency AND jitter together (or a
+            // jitter-driven p90 burst), so reporting only RTT reads as latency-only.
+            var mag = $"latency {evt.BaselineRttMs:0.#} to {evt.PeakRttMs:0.#} ms, jitter {evt.BaselineJitterMs:0.#} to {evt.PeakJitterMs:0.#} ms";
+            var load = evt.LoadCoincident ? " under heavy WAN load" : "";
+            // One shape for every line: "{duration} of elevated latency and jitter on {hop}{load}
+            // ({mag}). {one plain sentence}." The badge always reads "Congestion"; the disposition
+            // shows through colour (confirmed prominent, the rest muted) and that closing sentence,
+            // so the feed stays readable and still agrees with the cards (which badge only confirmed).
+            var lead = $"{span} of elevated latency and jitter on {where}{load} ({mag}).";
+            var (badge, badgeClass, text) = evt.Disposition switch
+            {
+                CongestionDisposition.SelfInflicted => ("Congestion", "isp-event-badge-info",
+                    $"{lead} Self-inflicted bufferbloat from your own load, not the ISP."),
+                CongestionDisposition.ControlPlaneNoise => ("Congestion", "isp-event-badge-info",
+                    $"{lead} Its next hop stayed clean, so these are this hop's own delayed ping replies (ICMP handling), not a forwarding bottleneck - any wobble on farther hops under the same load is separate, not carried through here."),
+                CongestionDisposition.Unverifiable => ("Congestion", "isp-event-badge-info",
+                    $"{lead}"),
+                _ when evt.ConfirmedBySibling => ("Congestion", "isp-event-badge-warning",
+                    $"{lead}"),
+                _ when evt.LoadCoincident && evt.CleanParallelPaths > 0 => ("Congestion", "isp-event-badge-warning",
+                    $"{lead} {evt.CleanParallelPaths} other monitored paths stayed clean under the same load, so it is this hop's own capacity, not your access link."),
+                _ => ("Congestion", "isp-event-badge-warning",
+                    $"{lead} It propagates to the hops beyond it, so it is a real bottleneck here.")
+            };
+            entries.Add(new TimelineEntry(evt.Start, badge, badgeClass, text));
         }
         foreach (var shift in r.PathShifts)
         {
@@ -533,16 +710,33 @@ else
             entries.Add(new TimelineEntry(shift.Time, "Path shift", "isp-event-badge-info",
                 $"RTT stepped {direction} {Math.Abs(shift.DeltaMs):0.#} ms on {where} ({shift.BeforeMedianMs:0.#} to {shift.AfterMedianMs:0.#} ms){correlated}. BGP or transport fabric change."));
         }
-        return entries.OrderByDescending(e => e.Time);
+        return entries.OrderBy(e => e.Time);
     }
 
     private static string FormatDuration(TimeSpan d) =>
         d.TotalHours >= 1 ? $"{d.TotalHours:0.#} h" : $"{d.TotalMinutes:0} min";
 
-    private static string OutageScopeLabel(OutageEvent o) =>
-        o.Scope == OutageScope.Upstream && !string.IsNullOrEmpty(o.LastReachableHop)
-            ? $"Break upstream of {o.LastReachableHop}"
-            : "Whole-WAN outage";
+    // Event time in local time, prefixed with the date when it is not today so events in a
+    // multi-day (7d/30d/custom) window are unambiguous.
+    private static string EventTimeLabel(DateTime utc)
+    {
+        var local = utc.ToLocalTime();
+        return local.Date == DateTime.Now.Date ? $"Today, {local:HH:mm}" : local.ToString("MMM d, HH:mm");
+    }
+
+    private static string OutageScopeLabel(OutageEvent o) => o.Scope switch
+    {
+        OutageScope.Local => "LAN / Gateway outage",
+        OutageScope.Upstream when !string.IsNullOrEmpty(o.LastReachableHop) => $"Break upstream of {o.LastReachableHop}",
+        _ => "Whole-WAN outage"
+    };
+
+    private static string OutageScoreTooltip(OutageEvent o) =>
+        o.Scope == OutageScope.Local
+            ? "Not scored; a LAN/gateway outage is your own network, not the ISP."
+            : o.ScorePenaltyPoints > 0
+                ? $"Lowered your ISP Health score by {o.ScorePenaltyPoints} {(o.ScorePenaltyPoints == 1 ? "point" : "points")}."
+                : "No score impact.";
 
     // Share of the outage window this hop spent dark (red), for the recovery-waterfall bar.
     // Capped at 95% so a sliver of the blue "up" track always shows on even the longest bars -
@@ -564,8 +758,15 @@ else
     private static string OutageHopTooltip(OutageTierState t) =>
         t.WentDark ? $"Went dark; peak loss {t.PeakLossPct:0}%." : "Stayed reachable through the outage.";
 
-    private static string WindowLabel(IspHealthReport r) =>
-        $"{(r.WindowEnd - r.WindowStart).TotalHours:0} h";
+    private static string WindowLabel(IspHealthReport r)
+    {
+        var span = r.WindowEnd - r.WindowStart;
+        if (span.TotalMinutes < 60)
+            return $"{span.TotalMinutes:0} min";
+        if (span.TotalHours < 72)
+            return $"{span.TotalHours:0.#} hr";
+        return $"{span.TotalDays:0.#} {(Math.Abs(span.TotalDays - 1) < 0.05 ? "day" : "days")}";
+    }
 
     private static string? FactorInvestigateUrl(string factorName) => factorName switch
     {

--- a/src/NetworkOptimizer.Web/Endpoints/IspHealthEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/IspHealthEndpoints.cs
@@ -11,10 +11,24 @@ public static class IspHealthEndpoints
     public static void Map(WebApplication app)
     {
         app.MapGet("/api/monitoring/isp-health/asn-series", async (
+            DateTime? from,
+            DateTime? to,
             IspHealthService ispHealth,
             CancellationToken ct) =>
         {
-            var (series, report) = await ispHealth.GetAsnChartDataAsync(ct);
+            // from/to (the tab's date/time filter) make the chart follow a custom window off
+            // the 48 h cache; absent, it serves the cached 48 h report.
+            var (series, report) = await ispHealth.GetAsnChartDataAsync(from, to, ct);
+
+            // Cap the chart payload only for long windows: bucket toward a target point count,
+            // but never finer than per-minute. Anything <= ~50 h stays at the prior per-minute
+            // density (48 h ~ 2880 points/line); a 30-day view coarsens to ~3000 instead of ~21k.
+            // Detectors still run on the full-resolution samples; this is display only.
+            const int ChartTargetPoints = 3000;
+            var spanTicks = from.HasValue && to.HasValue ? (to.Value - from.Value).Ticks
+                : report != null ? (report.WindowEnd - report.WindowStart).Ticks
+                : TimeSpan.TicksPerDay * 2;
+            var bucketTicks = Math.Max(TimeSpan.TicksPerMinute, spanTicks / ChartTargetPoints);
 
             var asnBuckets = series.Select(s => new
             {
@@ -22,7 +36,7 @@ public static class IspHealthEndpoints
                 name = string.IsNullOrEmpty(s.AsnName) ? $"AS{s.AsnNumber}" : s.AsnName,
                 buckets = s.Samples
                     .Where(p => p.RttAvgMs.HasValue)
-                    .GroupBy(p => new DateTime(p.Time.Ticks - p.Time.Ticks % TimeSpan.TicksPerMinute, DateTimeKind.Utc))
+                    .GroupBy(p => new DateTime(p.Time.Ticks - p.Time.Ticks % bucketTicks, DateTimeKind.Utc))
                     .ToDictionary(g => g.Key, g => Math.Round(g.Average(p => p.RttAvgMs!.Value), 2))
             }).ToList();
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionDetector.cs
@@ -7,7 +7,7 @@ namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
 /// because multi-path congestion usually indicates a shared upstream or return-path
 /// bottleneck rather than independent problems in every transit network.
 /// Thresholds live in <see cref="IspHealthOptions"/>; defaults are provisional until
-/// validated against real incident data (see research/isp-health-spec.md Appendix B).
+/// validated against real incident data.
 /// </summary>
 public static class CongestionDetector
 {
@@ -67,7 +67,11 @@ public static class CongestionDetector
                 && bucket.RttMs.Value > rttThreshold
                 && jitterThreshold.HasValue
                 && bucket.JitterMs.HasValue
-                && bucket.JitterMs.Value > jitterThreshold.Value;
+                && bucket.JitterMs.Value > jitterThreshold.Value
+                // Absolute floor on the jitter rise, so an ultra-stable far hop (baseline
+                // jitter near zero) does not trip the multiplicative gate on a fraction of a
+                // millisecond of shared return-path wobble.
+                && bucket.JitterMs.Value - baselineJitter!.Value >= options.CongestionJitterMinDeltaMs;
             // Burst shape only: p90 elevated while the median stays near baseline.
             // A flat fully-elevated bucket with no jitter is a route detour, not
             // congestion; that shape belongs to the step detector

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
@@ -1,0 +1,364 @@
+namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+
+/// <summary>
+/// The local access egress, the saved trace map's hop distances, and WAN load over time -
+/// everything the localizer needs beyond the latency series themselves.
+/// </summary>
+public sealed class CongestionTopology
+{
+    /// <summary>IPs of the nearest public access hop(s). A bottleneck here under heavy WAN load, with nothing clean downstream, is self-inflicted bufferbloat.</summary>
+    public HashSet<string> AccessEgressHopIps { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Hop distance (lowest TTL seen) per monitored hop IP, from Upstream Discovery. The ordering the bottleneck walk uses.</summary>
+    public IReadOnlyDictionary<string, int> HopNumberByIp { get; init; } = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>WAN utilization (worst direction, fraction of expected plan speed) per sample. Utilization is null when expected speeds are unknown, leaving load-coincidence undetermined.</summary>
+    public IReadOnlyList<(DateTime Time, double? Utilization)> Load { get; init; } = Array.Empty<(DateTime, double?)>();
+
+    /// <summary>True when a trace map is persisted. When false the localizer can only report Unlocalized.</summary>
+    public bool HasTraceMap { get; init; }
+}
+
+/// <summary>
+/// Turns raw per-ASN congestion candidates into attributed events. Instead of merging
+/// anything co-temporal into a "shared upstream" event, it localizes each elevation to the
+/// bottleneck hop on the saved trace map, then classifies what it is: real congestion,
+/// self-inflicted access bufferbloat under load, absolved control-plane (ICMP) noise, or
+/// unverifiable for lack of downstream coverage.
+///
+/// The bottleneck of an elevated target is the shallowest hop in the unbroken run of elevated
+/// hops ending at that target. A clean hop between two elevated ones breaks the run, so an
+/// ICMP-deprioritized near hop (elevated but not forwarding-congested) is correctly excluded
+/// from a deeper, real bottleneck and falls out as its own control-plane-noise event. This is
+/// the transit farther-cluster absolve generalized to detection: an elevation that does not
+/// propagate to proven-downstream hops is not congestion.
+///
+/// Attribution climbs a specificity ladder (<see cref="CongestionScope"/>) and reports the
+/// highest tier the trace map and clean controls support, recording why it could not go deeper.
+/// </summary>
+public static class CongestionLocalizer
+{
+    public static List<CongestionEvent> Localize(
+        IReadOnlyList<AsnSeries> allSeries,
+        CongestionTopology topology,
+        IspHealthOptions options)
+    {
+        var eventsBySeries = new Dictionary<AsnSeries, List<CongestionEvent>>();
+        foreach (var s in allSeries)
+            eventsBySeries[s] = CongestionDetector.DetectForSeries(s, options);
+
+        // Destinations (CDN/anycast endpoints) are witnesses only - they confirm or refute
+        // propagation past a hop, but an event is never *named* after a destination.
+        var candidates = allSeries
+            .Where(s => !s.IsDestination)
+            .SelectMany(s => eventsBySeries[s].Select(e => (Series: s, Evt: e)))
+            .ToList();
+        if (candidates.Count == 0) return new List<CongestionEvent>();
+
+        // A hop counts as elevated if it fired its own event OR shows in-window RTT excursions
+        // above its baseline. The softer test matters for propagation: a downstream hop inherits
+        // a real bottleneck's delay as spikes that are often too sparse to fire a sustained event,
+        // and without it the localizer would wrongly absolve a genuine bottleneck as noise.
+        bool IsElevated(AsnSeries s, DateTime start, DateTime end) =>
+            (eventsBySeries.TryGetValue(s, out var evs) && evs.Any(e => Overlaps(e.Start, e.End, start, end)))
+            || ElevatedInWindow(s, start, end, options);
+
+        var anchored = allSeries.Where(s => HasTrace(s, topology)).ToList();
+
+        var result = new List<CongestionEvent>();
+        foreach (var cluster in ClusterByTime(candidates))
+        {
+            var window = (Start: cluster.Min(c => c.Evt.Start), End: cluster.Max(c => c.Evt.End));
+            var elevatedSeries = cluster.Select(c => c.Series).Distinct().ToList();
+
+            // Every monitored hop IP elevated somewhere in this window (own-hop level), so the
+            // bottleneck walk knows which hops on a path are congested.
+            var elevatedIps = new HashSet<string>(
+                allSeries.Where(s => IsElevated(s, window.Start, window.End)).SelectMany(s => s.HopIps),
+                StringComparer.OrdinalIgnoreCase);
+
+            var byBottleneck = new Dictionary<string, List<AsnSeries>>(StringComparer.OrdinalIgnoreCase);
+            var unanchored = new List<AsnSeries>();
+            foreach (var s in elevatedSeries)
+            {
+                var bn = Bottleneck(s, elevatedIps, topology.HopNumberByIp);
+                if (bn == null) { unanchored.Add(s); continue; }
+                if (!byBottleneck.TryGetValue(bn, out var list)) byBottleneck[bn] = list = new List<AsnSeries>();
+                list.Add(s);
+            }
+
+            var loadCoincident = LoadCoincident(window.Start, window.End, topology, options);
+            // A clean anchored series anywhere means the elevation is NOT line-wide, which rules
+            // out access-egress self-infliction (that bloats everything that crosses the egress).
+            var cleanControlExists = anchored.Any(s => !IsElevated(s, window.Start, window.End));
+
+            foreach (var (bnIp, members) in byBottleneck)
+                result.Add(BuildLocalized(bnIp, members, allSeries, eventsBySeries, window,
+                    topology, options, loadCoincident, cleanControlExists, IsElevated));
+
+            if (unanchored.Count > 0)
+                result.Add(BuildUnlocalized(unanchored, eventsBySeries, window, topology, loadCoincident));
+        }
+
+        // An Unverifiable hop (dead-end, nothing monitored beyond it) inherits Confirmed from a
+        // confirmed sibling on the SAME ASN overlapping in time: the same network degrading in the
+        // same window is almost certainly the same incident, so the dead-end twin is real too.
+        var confirmedEvents = result.Where(e => e.Disposition == CongestionDisposition.Confirmed).ToList();
+        foreach (var evt in result)
+        {
+            if (evt.Disposition != CongestionDisposition.Unverifiable) continue;
+            var sibling = confirmedEvents.FirstOrDefault(c =>
+                c.AsnNumbers.Any(a => a > 0 && evt.AsnNumbers.Contains(a))
+                && Overlaps(c.Start, c.End, evt.Start, evt.End));
+            if (sibling == null) continue;
+            evt.Disposition = CongestionDisposition.Confirmed;
+            evt.ConfirmedBySibling = true;
+            evt.Confidence = 70;
+            evt.AttributionReason = "Confirmed by a sibling hop on the same network congesting in the same window; no monitored hop sits beyond this one to verify it directly.";
+        }
+
+        return result.OrderBy(e => e.Start).ToList();
+    }
+
+    /// <summary>
+    /// The shallowest hop in the unbroken elevated run ending at <paramref name="series"/>. A
+    /// clean hop between two elevated ones terminates the run, so the bottleneck never jumps
+    /// across a clean middle hop to a shallower (noisy) one.
+    /// </summary>
+    private static string? Bottleneck(AsnSeries series, HashSet<string> elevatedIps,
+        IReadOnlyDictionary<string, int> hopNumberByIp)
+    {
+        var path = series.HopIps.Concat(series.AncestorIps)
+            .Where(hopNumberByIp.ContainsKey)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(ip => hopNumberByIp[ip])
+            .ToList();
+        if (path.Count == 0) return null;
+
+        string? bottleneck = null;
+        for (var i = path.Count - 1; i >= 0; i--)
+        {
+            if (elevatedIps.Contains(path[i])) bottleneck = path[i];
+            else break;
+        }
+        return bottleneck;
+    }
+
+    private static CongestionEvent BuildLocalized(
+        string bottleneckIp,
+        List<AsnSeries> members,
+        IReadOnlyList<AsnSeries> allSeries,
+        Dictionary<AsnSeries, List<CongestionEvent>> eventsBySeries,
+        (DateTime Start, DateTime End) window,
+        CongestionTopology topology,
+        IspHealthOptions options,
+        bool loadCoincident,
+        bool cleanControlExists,
+        Func<AsnSeries, DateTime, DateTime, bool> isElevated)
+    {
+        var hopNum = topology.HopNumberByIp.TryGetValue(bottleneckIp, out var hn) ? hn : int.MaxValue;
+        // The hop the congestion sits ON owns the event - that ASN is the culprit, the deeper
+        // members are downstream victims and must not be penalized for it. Prefer a real hop
+        // (non-destination) bearing this IP.
+        var bottleneckSeries =
+            allSeries.FirstOrDefault(s => !s.IsDestination && s.HopIps.Contains(bottleneckIp, StringComparer.OrdinalIgnoreCase))
+            ?? allSeries.FirstOrDefault(s => s.HopIps.Contains(bottleneckIp, StringComparer.OrdinalIgnoreCase));
+
+        // Monitored targets that provably route THROUGH the bottleneck (it is in their ancestry).
+        var descendants = allSeries
+            .Where(s => s.AncestorIps.Contains(bottleneckIp, StringComparer.OrdinalIgnoreCase))
+            .ToList();
+        var hasDescendant = descendants.Count > 0;
+        // Propagation = the elevation reaches the FIRST monitored hop past the bottleneck. A
+        // deeper elevated member of this same group counts; otherwise the nearest downstream
+        // witness must be elevated. A clean immediate-downstream hop means the elevation did
+        // not forward through - control-plane noise, not congestion (the transit
+        // farther-cluster absolve, generalized).
+        var immediateHop = descendants
+            .Select(d => DeepestHopNum(d, topology))
+            .Where(h => h > hopNum)
+            .DefaultIfEmpty(int.MaxValue)
+            .Min();
+        var propagated =
+            members.Any(m => DeepestHopNum(m, topology) > hopNum)
+            || descendants.Any(d => DeepestHopNum(d, topology) == immediateHop
+                && isElevated(d, window.Start, window.End));
+
+        var isAccessEgress = topology.AccessEgressHopIps.Contains(bottleneckIp);
+
+        // Anchored paths that do NOT cross this bottleneck and stayed clean through the window.
+        // A non-zero count under load proves the elevation is this hop's own capacity, not
+        // access-layer bufferbloat (which would lift every path that shares your access link).
+        var cleanParallelPaths = allSeries.Count(s => HasTrace(s, topology)
+            && !s.HopIps.Contains(bottleneckIp, StringComparer.OrdinalIgnoreCase)
+            && !s.AncestorIps.Contains(bottleneckIp, StringComparer.OrdinalIgnoreCase)
+            && !isElevated(s, window.Start, window.End));
+
+        CongestionDisposition disposition;
+        string reason;
+        if (isAccessEgress && loadCoincident && !cleanControlExists)
+        {
+            disposition = CongestionDisposition.SelfInflicted;
+            reason = "Bottleneck at your access egress while the WAN was saturated and every monitored path was affected - self-inflicted bufferbloat, not external congestion.";
+        }
+        else if (propagated)
+        {
+            disposition = CongestionDisposition.Confirmed;
+            reason = "Elevation propagates to monitored hops downstream of this bottleneck.";
+            if (loadCoincident)
+                reason += cleanParallelPaths > 0
+                    ? $" It coincided with heavy WAN load, but {cleanParallelPaths} other monitored paths stayed clean under the same load, so it is this hop's own capacity, not your access egress."
+                    : " It coincided with heavy WAN load (load-induced), but localizes to a specific hop rather than your access egress.";
+        }
+        else if (hasDescendant)
+        {
+            disposition = CongestionDisposition.ControlPlaneNoise;
+            reason = "Elevation does not reach monitored hops downstream of this one - control-plane (ICMP) deprioritization at the hop, not a forwarding bottleneck.";
+        }
+        else
+        {
+            disposition = CongestionDisposition.Unverifiable;
+            reason = "No monitored target sits downstream of this hop, so forwarding congestion cannot be confirmed. Add a probe past it to verify.";
+        }
+
+        var label = bottleneckSeries?.AsnName
+            ?? (bottleneckSeries != null ? $"AS{bottleneckSeries.AsnNumber}" : bottleneckIp);
+
+        var confidence = disposition switch
+        {
+            CongestionDisposition.SelfInflicted => 80,
+            CongestionDisposition.Confirmed => cleanControlExists ? 85 : 70,
+            CongestionDisposition.ControlPlaneNoise => 75,
+            CongestionDisposition.Unverifiable => 35,
+            _ => 50
+        };
+
+        var evt = NewEvent(bottleneckSeries, members, eventsBySeries, window);
+        evt.Scope = CongestionScope.Hop;
+        evt.Disposition = disposition;
+        evt.BottleneckHopIp = bottleneckIp;
+        evt.BottleneckLabel = label;
+        evt.LoadCoincident = loadCoincident;
+        evt.CleanParallelPaths = cleanParallelPaths;
+        evt.Confidence = confidence;
+        evt.AttributionReason = reason;
+        return evt;
+    }
+
+    private static CongestionEvent BuildUnlocalized(
+        List<AsnSeries> members,
+        Dictionary<AsnSeries, List<CongestionEvent>> eventsBySeries,
+        (DateTime Start, DateTime End) window,
+        CongestionTopology topology,
+        bool loadCoincident)
+    {
+        var evt = NewEvent(null, members, eventsBySeries, window);
+        evt.Scope = CongestionScope.Unlocalized;
+        evt.Disposition = CongestionDisposition.Confirmed;
+        evt.LoadCoincident = loadCoincident;
+        evt.Confidence = 25;
+        evt.AttributionReason = topology.HasTraceMap
+            ? "These targets are not on the trace map, so the bottleneck cannot be placed. Re-run Upstream Discovery to localize."
+            : "No trace map is saved, so congestion cannot be localized. Run Upstream Discovery to enable hop attribution.";
+        return evt;
+    }
+
+    private static CongestionEvent NewEvent(
+        AsnSeries? identity,
+        List<AsnSeries> members,
+        Dictionary<AsnSeries, List<CongestionEvent>> eventsBySeries,
+        (DateTime Start, DateTime End) window)
+    {
+        // Metrics come from the culprit hop when it has its own elevation, else the worst member.
+        var metricSource = identity != null
+            && eventsBySeries.TryGetValue(identity, out var idEvents)
+            && idEvents.Any(e => Overlaps(e.Start, e.End, window.Start, window.End))
+            ? new List<AsnSeries> { identity }
+            : members;
+        var worst = metricSource
+            .SelectMany(m => eventsBySeries[m].Where(e => Overlaps(e.Start, e.End, window.Start, window.End)))
+            .OrderByDescending(e => e.PeakRttMs - e.BaselineRttMs)
+            .First();
+        // The penalized ASN/targets are the bottleneck hop when localized; downstream victims
+        // are excluded. An unlocalized event has no single culprit, so it keeps the full set.
+        var id = identity != null ? new List<AsnSeries> { identity } : members;
+        return new CongestionEvent
+        {
+            Start = window.Start,
+            End = window.End,
+            AsnNumbers = id.Select(m => m.AsnNumber).Distinct().ToList(),
+            AsnNames = id.Select(m => m.AsnName ?? $"AS{m.AsnNumber}").Distinct().ToList(),
+            TargetIds = id.SelectMany(m => m.TargetIds).Distinct().ToList(),
+            BaselineRttMs = worst.BaselineRttMs,
+            PeakRttMs = worst.PeakRttMs,
+            BaselineJitterMs = worst.BaselineJitterMs,
+            PeakJitterMs = worst.PeakJitterMs
+        };
+    }
+
+    private static bool LoadCoincident(DateTime start, DateTime end, CongestionTopology topology, IspHealthOptions options)
+    {
+        var inWindow = topology.Load
+            .Where(l => l.Time >= start && l.Time <= end && l.Utilization.HasValue)
+            .ToList();
+        if (inWindow.Count == 0) return false; // unknown load -> never claim self-inflicted
+        var high = inWindow.Count(l => l.Utilization!.Value >= options.CongestionLoadHighFraction);
+        return (double)high / inWindow.Count >= options.CongestionLoadCoincidenceFraction;
+    }
+
+    /// <summary>
+    /// A softer "elevated in this window" test than firing a full congestion event: true when a
+    /// meaningful fraction of in-window RTT samples exceed the hop's own baseline p90 by the
+    /// congestion RTT floor. A real bottleneck's added delay reaches downstream hops as excursions
+    /// that may be too sparse to fire their own sustained event; using this for the propagation
+    /// and clean-control checks stops the localizer from absolving a genuine bottleneck as
+    /// control-plane noise just because nothing downstream fired. Clean off-path hops sit near zero.
+    /// </summary>
+    internal static bool ElevatedInWindow(AsnSeries series, DateTime start, DateTime end, IspHealthOptions options)
+    {
+        var inWindow = series.Samples
+            .Where(x => x.Time >= start && x.Time <= end && x.RttAvgMs.HasValue)
+            .Select(x => x.RttAvgMs!.Value).ToList();
+        var baseline = series.Samples
+            .Where(x => (x.Time < start || x.Time > end) && x.RttAvgMs.HasValue)
+            .Select(x => x.RttAvgMs!.Value).ToList();
+        if (inWindow.Count == 0 || baseline.Count == 0) return false;
+
+        var baselineP90 = SeriesStats.Percentile(baseline, 0.90);
+        if (!baselineP90.HasValue) return false;
+        var threshold = baselineP90.Value + options.CongestionRttMinDeltaMs;
+        var excursionFraction = inWindow.Count(v => v > threshold) / (double)inWindow.Count;
+        return excursionFraction >= options.CongestionPropagationExcursionFraction;
+    }
+
+    private static int DeepestHopNum(AsnSeries series, CongestionTopology topology) => series.HopIps
+        .Select(ip => topology.HopNumberByIp.TryGetValue(ip, out var n) ? n : int.MinValue)
+        .DefaultIfEmpty(int.MinValue)
+        .Max();
+
+    private static bool HasTrace(AsnSeries series, CongestionTopology topology) =>
+        series.AncestorIps.Count > 0 || series.HopIps.Any(topology.HopNumberByIp.ContainsKey);
+
+    private static List<List<(AsnSeries Series, CongestionEvent Evt)>> ClusterByTime(
+        List<(AsnSeries Series, CongestionEvent Evt)> candidates)
+    {
+        var clusters = new List<List<(AsnSeries, CongestionEvent)>>();
+        List<(AsnSeries, CongestionEvent)>? current = null;
+        var currentEnd = DateTime.MinValue;
+        foreach (var c in candidates.OrderBy(c => c.Evt.Start))
+        {
+            if (current == null || c.Evt.Start > currentEnd)
+            {
+                current = new List<(AsnSeries, CongestionEvent)>();
+                clusters.Add(current);
+                currentEnd = c.Evt.End;
+            }
+            current.Add(c);
+            if (c.Evt.End > currentEnd) currentEnd = c.Evt.End;
+        }
+        return clusters;
+    }
+
+    private static bool Overlaps(DateTime aStart, DateTime aEnd, DateTime bStart, DateTime bEnd) =>
+        aStart < bEnd && bStart < aEnd;
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -152,9 +152,46 @@ public class IspHealthIssue
 }
 
 /// <summary>
-/// A sustained latency and jitter elevation. Events spanning multiple ASNs at the
-/// same time are merged into a single shared event, since simultaneous multi-path
-/// congestion usually indicates a shared upstream or return-path bottleneck.
+/// How precisely a congestion event was localized, most specific first. The localizer
+/// reports the highest tier the trace map and clean controls affirmatively support and
+/// stops there, recording in <see cref="CongestionEvent.AttributionReason"/> why it could
+/// not go deeper - it never collapses to <see cref="Unlocalized"/> just because the exact
+/// hop was ambiguous, and never asserts <see cref="Hop"/> without the proof.
+/// </summary>
+public enum CongestionScope
+{
+    /// <summary>Pinned to a single bottleneck hop: the deepest hop all affected traced targets route through, with clean off-path controls.</summary>
+    Hop,
+    /// <summary>Isolated to the link between the last clean hop and the first elevated hop, but the far end is not a single hop.</summary>
+    Segment,
+    /// <summary>Attributed to one ASN's network (its hops elevated, its upstream clean) but not a single hop.</summary>
+    Asn,
+    /// <summary>Narrowed to the set of affected paths/corridors, but the bottleneck link could not be isolated.</summary>
+    Corridor,
+    /// <summary>Could not be localized; a shared elevation across networks. Lowest confidence.</summary>
+    Unlocalized
+}
+
+/// <summary>What the localizer concluded a congestion candidate actually is, after the
+/// downstream-propagation and load-correlation gates.</summary>
+public enum CongestionDisposition
+{
+    /// <summary>Real congestion: the elevation is the deepest hop and/or propagated to proven-downstream traced targets.</summary>
+    Confirmed,
+    /// <summary>Self-inflicted access-egress bufferbloat: bottleneck at the local access egress while heavy local WAN load coincided. Not external congestion.</summary>
+    SelfInflicted,
+    /// <summary>Near-hop elevation that did NOT propagate to proven-downstream targets - ICMP/control-plane deprioritization, not a forwarding bottleneck. The transit farther-cluster absolve, applied to detection.</summary>
+    ControlPlaneNoise,
+    /// <summary>Elevated, but no traced downstream target exists to confirm or refute it (e.g. a dead-end transit hop). Reported at low confidence, never asserted.</summary>
+    Unverifiable
+}
+
+/// <summary>
+/// A sustained latency and jitter elevation. After detection each event is run through the
+/// localizer, which attributes it to a bottleneck (<see cref="Scope"/>) and decides what it
+/// is (<see cref="Disposition"/>): real congestion, self-inflicted bufferbloat, absolved
+/// control-plane noise, or unverifiable. Co-temporal per-ASN candidates are merged only when
+/// they share a bottleneck on the trace map, not merely because they overlap in time.
 /// </summary>
 public class CongestionEvent
 {
@@ -176,6 +213,43 @@ public class CongestionEvent
     public double PeakRttMs { get; init; }
     public double BaselineJitterMs { get; init; }
     public double PeakJitterMs { get; init; }
+
+    /// <summary>The specificity tier the localizer could defend for this event.</summary>
+    public CongestionScope Scope { get; set; } = CongestionScope.Unlocalized;
+
+    /// <summary>What the localizer concluded this elevation actually is.</summary>
+    public CongestionDisposition Disposition { get; set; } = CongestionDisposition.Confirmed;
+
+    /// <summary>IP of the attributed bottleneck hop, when <see cref="Scope"/> is <see cref="CongestionScope.Hop"/>.</summary>
+    public string? BottleneckHopIp { get; set; }
+
+    /// <summary>Human-readable bottleneck label (hop name, segment, ASN, or corridor) for the report.</summary>
+    public string? BottleneckLabel { get; set; }
+
+    /// <summary>True when the event overlapped heavy local WAN load (input to the self-inflicted gate).</summary>
+    public bool LoadCoincident { get; set; }
+
+    /// <summary>
+    /// How many other monitored paths (different routes/networks, and the access hops ahead of
+    /// the bottleneck) stayed clean during this event. A non-zero count under load is the proof
+    /// the elevation is this hop's own capacity, not access-layer bufferbloat - which would lift
+    /// every path that shares your access link.
+    /// </summary>
+    public int CleanParallelPaths { get; set; }
+
+    /// <summary>True when this hop's congestion was confirmed indirectly by a sibling hop on the
+    /// same ASN congesting in the same window, rather than by its own downstream propagation
+    /// (used for a dead-end hop whose confirmed sibling proves the network is really degrading).</summary>
+    public bool ConfirmedBySibling { get; set; }
+
+    /// <summary>Localizer confidence 0-100; lowest for <see cref="CongestionDisposition.Unverifiable"/> / <see cref="CongestionScope.Unlocalized"/>.</summary>
+    public int Confidence { get; set; } = 50;
+
+    /// <summary>Why the localizer stopped at this tier or reached this disposition - doubles as a coverage to-do (e.g. "no downstream probe past this hop").</summary>
+    public string? AttributionReason { get; set; }
+
+    /// <summary>True when this event must not penalize the score: self-inflicted bufferbloat or absolved control-plane noise.</summary>
+    public bool Suppressed => Disposition is CongestionDisposition.SelfInflicted or CongestionDisposition.ControlPlaneNoise;
 
     public bool IsShared => AsnNumbers.Count > 1;
     public TimeSpan Duration => End - Start;
@@ -211,7 +285,11 @@ public enum OutageScope
     FullWan,
 
     /// <summary>The access hop stayed reachable while transit and the internet went dark - the break sat upstream of it.</summary>
-    Upstream
+    Upstream,
+
+    /// <summary>The LAN gateway itself was unreachable through the outage - a local LAN/switch/gateway
+    /// outage, not the ISP's WAN. Surfaced but not score-affecting (the ISP isn't at fault).</summary>
+    Local
 }
 
 /// <summary>
@@ -238,6 +316,13 @@ public class OutageEvent
 
     /// <summary>Per-tier loss and recovery, nearest first, for the outage-shape display.</summary>
     public List<OutageTierState> Tiers { get; init; } = new();
+
+    /// <summary>
+    /// Points this outage contributed to the ISP Health penalty - its duration share of the
+    /// total (curve-based) outage penalty. 0 for Local (LAN/gateway) outages, which are never
+    /// scored. Set by the scorer so each outage row can show its own "-N points".
+    /// </summary>
+    public int ScorePenaltyPoints { get; set; }
 }
 
 /// <summary>One network tier's behavior during an outage, for the recovery-shape display.</summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -5,8 +5,7 @@ namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
 /// <summary>
 /// All ISP Health tunables in one place: score weights, load classification
 /// thresholds, congestion and step-change detector parameters, and the SQM
-/// recommendation rule. The authoritative reference for these values is
-/// research/isp-health-spec.md (local-only); keep both in sync when tuning.
+/// recommendation rule. Defaults are provisional and tuned against real incident data.
 /// </summary>
 public class IspHealthOptions
 {
@@ -146,6 +145,41 @@ public class IspHealthOptions
 
     /// <summary>Minimum time overlap (fraction of the shorter event) for events to be considered simultaneous.</summary>
     public double SharedEventOverlapFraction { get; set; } = 0.5;
+
+    /// <summary>
+    /// Absolute floor in ms a bucket's jitter delta must clear, on top of the
+    /// <see cref="CongestionJitterFactor"/> ratio gate, to count as elevated. An
+    /// ultra-stable far hop with a near-zero baseline (e.g. a 0.26 ms transit hop) trips
+    /// the multiplicative gate on a fraction of a millisecond of shared return-path wobble;
+    /// this stops that. Sustained genuine congestion clears it easily.
+    /// </summary>
+    public double CongestionJitterMinDeltaMs { get; set; } = 0.8;
+
+    /// <summary>
+    /// WAN utilization (fraction of the expected plan speed, worst direction) at or above
+    /// which a congestion bucket is treated as coinciding with heavy local load. The
+    /// self-inflicted classifier uses this to tell access-egress bufferbloat (your own
+    /// traffic saturating your access link) from external path congestion. Requires known
+    /// expected speeds; without them load-coincidence is left undetermined and the event is
+    /// reported, never suppressed.
+    /// </summary>
+    public double CongestionLoadHighFraction { get; set; } = 0.5;
+
+    /// <summary>
+    /// Fraction of an event's buckets that must coincide with heavy WAN load before the
+    /// event is considered load-driven (the input to self-inflicted classification).
+    /// </summary>
+    public double CongestionLoadCoincidenceFraction { get; set; } = 0.5;
+
+    /// <summary>
+    /// Fraction of a hop's in-window RTT samples that must exceed its own baseline p90 (by the
+    /// congestion RTT floor) for the localizer to count it as elevated when testing propagation.
+    /// A real bottleneck's delay reaches downstream hops as excursions that are often too sparse
+    /// to fire their own sustained congestion event; without this softer test the localizer would
+    /// wrongly absolve a genuine bottleneck as control-plane noise because nothing downstream
+    /// "fired". Clean off-path hops sit near zero, so a low bar separates them cleanly.
+    /// </summary>
+    public double CongestionPropagationExcursionFraction { get; set; } = 0.05;
 
     /// <summary>Window size in minutes for step-change median comparison.</summary>
     public int StepWindowMinutes { get; set; } = 30;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -5,8 +5,8 @@ namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
 /// <summary>
 /// Pure scoring engine for ISP Health. Takes pre-assembled inputs (latency series,
 /// throughput, detected events) plus an access technology profile and produces the
-/// full report. No I/O; fully unit-testable. Formulas and anchor points are
-/// documented in research/isp-health-spec.md (local-only) and must stay in sync.
+/// full report. No I/O; fully unit-testable. Formulas and anchor points are tuned
+/// against real incident data.
 /// </summary>
 public class IspHealthScorer
 {
@@ -81,10 +81,19 @@ public class IspHealthScorer
         // An outage is scored once, here at the top level, on a duration curve - so a long
         // outage actually drives the score down instead of being diluted to a couple of
         // points inside one factor. Scored by total downtime alone, shape-independent.
-        var outageMinutes = inputs.Outages.Sum(o => o.Duration.TotalMinutes);
+        // Local (LAN/gateway) outages are surfaced but never penalize the ISP - the gateway being
+        // unreachable is the user's own LAN, not the ISP's fault (they still mask their dark window
+        // from the other factors via InOutage, so that loss isn't double-counted against the ISP).
+        var wanOutages = inputs.Outages.Where(o => o.Scope != OutageScope.Local).ToList();
+        var outageMinutes = wanOutages.Sum(o => o.Duration.TotalMinutes);
         if (outageMinutes > 0)
         {
             var penalty = OutageScorePenalty(outageMinutes);
+            // Attribute the total (curve-based) penalty across the WAN outages by duration share so
+            // each outage row can show its own "-N points". Rounded shares may differ from the curve
+            // total by <=1 pt - cosmetic; the actual score deduction uses the curve total below.
+            foreach (var o in wanOutages)
+                o.ScorePenaltyPoints = (int)Math.Round(penalty * (o.Duration.TotalMinutes / outageMinutes));
             _logger?.LogDebug("ISP Health: outage penalty {Penalty} pts over {Min} min downtime ({Before} -> {After})",
                 penalty.ToString("0.#", CultureInfo.InvariantCulture), outageMinutes.ToString("0", CultureInfo.InvariantCulture),
                 overall, (int)Math.Max(0, Math.Round(overall - penalty)));
@@ -681,11 +690,18 @@ public class IspHealthScorer
         // tests) fall back to ASN matching.
         var roleTargets = series.RoleTargetIds.Count > 0 ? series.RoleTargetIds : series.TargetIds;
         var roleTargetSet = new HashSet<string>(roleTargets);
+        // Only confirmed congestion penalizes a network. Self-inflicted bufferbloat,
+        // absolved control-plane (ICMP) noise, and unverifiable dead-end elevations are
+        // surfaced in the report but never ding the ASN's grade.
         var asnEvents = congestionEvents
-            .Where(e => e.AsnNumbers.Contains(series.AsnNumber)
+            .Where(e => e.Disposition == CongestionDisposition.Confirmed
+                && e.AsnNumbers.Contains(series.AsnNumber)
                 && (e.TargetIds.Count == 0 || e.TargetIds.Any(t => roleTargetSet.Contains(t))))
             .ToList();
-        var eventHours = asnEvents.Sum(e => e.Duration.TotalHours);
+        // Union of the event windows, not the sum - two hops of the same ASN degrading in the
+        // same window (e.g. parallel backbone links, or a dead-end hop confirmed by its sibling)
+        // are one incident and must not double-count the congestion hours.
+        var eventHours = UnionHours(asnEvents);
         var congestionScore = (int)Math.Round(Math.Max(0, 100 - _options.CongestionPenaltyPerHour * eventHours));
 
         int? overall = null;
@@ -921,6 +937,22 @@ public class IspHealthScorer
     private static bool RoutesThrough(List<string> witnessAncestors, List<string> hopIps) =>
         hopIps.Any(ip => witnessAncestors.Contains(ip, StringComparer.OrdinalIgnoreCase));
 
+    /// <summary>Total hours covered by the union of the events' time windows (overlaps counted once).</summary>
+    private static double UnionHours(IReadOnlyList<CongestionEvent> events)
+    {
+        double total = 0;
+        DateTime curStart = default, curEnd = default;
+        var open = false;
+        foreach (var e in events.OrderBy(e => e.Start))
+        {
+            if (!open) { curStart = e.Start; curEnd = e.End; open = true; }
+            else if (e.Start > curEnd) { total += (curEnd - curStart).TotalHours; curStart = e.Start; curEnd = e.End; }
+            else if (e.End > curEnd) curEnd = e.End;
+        }
+        if (open) total += (curEnd - curStart).TotalHours;
+        return total;
+    }
+
     /// <summary>
     /// Collapses per-hop ISP grades to one entry per ASN for the Networks on Your Path
     /// card: mean RTT and jitter across the hops, averaged grade, and the union of the
@@ -935,7 +967,8 @@ public class IspHealthScorer
             var targetIds = hops.SelectMany(h => h.TargetIds).Distinct().ToList();
             var targetSet = new HashSet<string>(targetIds);
             var asnEvents = congestionEvents
-                .Where(e => e.AsnNumbers.Contains(group.Key)
+                .Where(e => e.Disposition == CongestionDisposition.Confirmed
+                    && e.AsnNumbers.Contains(group.Key)
                     && (e.TargetIds.Count == 0 || e.TargetIds.Any(t => targetSet.Contains(t))))
                 .ToList();
             var means = hops.Select(h => h.MeanRttMs).Where(m => m.HasValue).Select(m => m!.Value).ToList();
@@ -1052,28 +1085,39 @@ public class IspHealthScorer
     {
         var issues = new List<IspHealthIssue>();
 
-        if (inputs.Outages.Count > 0)
+        // Local (LAN/gateway) outages are surfaced in the waterfall but are not internet outages and
+        // don't affect the score, so they never appear in this ISP-impact issue.
+        var wanOutages = inputs.Outages.Where(o => o.Scope != OutageScope.Local).ToList();
+        if (wanOutages.Count > 0)
         {
-            var totalDown = TimeSpan.FromMinutes(inputs.Outages.Sum(o => o.Duration.TotalMinutes));
-            var upstream = inputs.Outages.Where(o => o.Scope == OutageScope.Upstream && !string.IsNullOrEmpty(o.LastReachableHop)).ToList();
-            var where = inputs.Outages.All(o => o.Scope == OutageScope.Upstream) && upstream.Count > 0
-                ? $" The break sat upstream of {string.Join(", ", upstream.Select(o => o.LastReachableHop).Distinct())} - your equipment stayed reachable, so this was an ISP-side fault, not your network."
+            var multiple = wanOutages.Count > 1;
+            var totalDown = TimeSpan.FromMinutes(wanOutages.Sum(o => o.Duration.TotalMinutes));
+            var upstream = wanOutages.Where(o => o.Scope == OutageScope.Upstream && !string.IsNullOrEmpty(o.LastReachableHop)).ToList();
+            var allUpstream = wanOutages.All(o => o.Scope == OutageScope.Upstream) && upstream.Count > 0;
+            var where = allUpstream
+                ? $" The break sat upstream of {string.Join(", ", upstream.Select(o => o.LastReachableHop).Distinct())} - your equipment stayed reachable, so {(multiple ? "these were" : "this was")} an ISP-side fault, not your network."
                 : " At least one event took the whole WAN dark, including the first ISP hop.";
-            var count = inputs.Outages.Count == 1
-                ? $"An internet outage of {FormatOutageDuration(inputs.Outages[0].Duration)}"
-                : $"{inputs.Outages.Count} internet outages totaling {FormatOutageDuration(totalDown)}";
+            var count = multiple
+                ? $"{wanOutages.Count} internet outages totaling {FormatOutageDuration(totalDown)}"
+                : $"An internet outage of {FormatOutageDuration(wanOutages[0].Duration)}";
             // Be transparent about the score hit: the outage penalty is applied at the top level
-            // and isn't tied to any one factor, so spell it out here or it's invisible.
+            // and isn't tied to any one factor, so spell it out here or it's invisible. Matches the
+            // actual penalty (both exclude Local outages).
             var penalty = (int)Math.Round(OutageScorePenalty(totalDown.TotalMinutes));
             var impact = penalty > 0
-                ? $" {(inputs.Outages.Count == 1 ? "It" : "Together they")} lowered your ISP Health score by {penalty} {(penalty == 1 ? "point" : "points")}."
+                ? $" {(multiple ? "Together they" : "It")} lowered your ISP Health score by {penalty} {(penalty == 1 ? "point" : "points")}."
                 : string.Empty;
+            var realPhrase = multiple
+                ? "so these are real outages, not monitoring gaps"
+                : "so this is a real outage, not a monitoring gap";
             issues.Add(new IspHealthIssue
             {
                 Severity = IspIssueSeverity.Warning,
-                Title = inputs.Outages.Count == 1 ? "Internet outage in the window" : "Internet outages in the window",
-                Description = $"{count} occurred while the Monitoring Agent kept probing (so this is a real outage, not a monitoring gap).{where}{impact}",
-                Recommendation = "No action needed on your side for an upstream outage; it is logged here so you can correlate it with ISP incidents.",
+                Title = multiple ? "Internet outages in the window" : "Internet outage in the window",
+                Description = $"{count} occurred while the Monitoring Agent kept probing ({realPhrase}).{where}{impact}",
+                Recommendation = allUpstream
+                    ? "No action needed on your side for an upstream outage; it is logged here so you can correlate it with ISP incidents."
+                    : "Logged here so you can correlate it with ISP incidents; if the first ISP hop keeps dropping, check your modem/ONT and the line to your ISP.",
                 LinkUrl = "#isp-outages",
                 LinkText = "The recovery shape is shown on the timeline below."
             });
@@ -1096,7 +1140,7 @@ public class IspHealthScorer
             var recommendation = inputs.SmartQueuesEnabled
                 ? "Smart Queues is enabled on this WAN but the line still degrades under load; check that its configured rates match what the line actually delivers."
                 : "Enable Smart Queues (SQM) on this WAN in UniFi Network (Settings, Internet, your WAN, Smart Queues).";
-            if (inputs.CongestionEvents.Count >= _options.SqmRecurringCongestionEvents)
+            if (inputs.CongestionEvents.Count(e => e.Disposition == CongestionDisposition.Confirmed) >= _options.SqmRecurringCongestionEvents)
             {
                 recommendation += " This connection also shows a recurring congestion pattern; consider Adaptive SQM, which tracks time-of-day capacity changes automatically.";
             }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -34,7 +34,13 @@ public class IspHealthService
     // "+N ms hop" line labels must match the report's event labels). Single-reference
     // assignment makes the swap atomic; readers take one local copy.
     private sealed record Snapshot(IspHealthReport Report, List<AsnSeries> ChartClusters);
+    // Result of one core compute, before it is published (or not) to instance state.
+    private sealed record ComputeOutcome(IspHealthStatus Status, IspHealthReport? Report, List<AsnSeries> ChartClusters);
+    // Most-recent custom-window result, so the chart's follow-up fetch for the same window
+    // reuses it instead of re-running the heavy query. Never read by the canonical 48 h paths.
+    private sealed record CustomWindowSnapshot(DateTime Start, DateTime End, IspHealthReport Report, List<AsnSeries> ChartClusters, DateTime ComputedAt);
     private Snapshot? _cached;
+    private CustomWindowSnapshot? _customCache;
     private IspHealthStatus _status = IspHealthStatus.Computing;
     private volatile bool _computing;
 
@@ -121,14 +127,80 @@ public class IspHealthService
 
     private async Task<(IspHealthReport? Report, List<AsnSeries> ChartClusters)> ComputeAsync(CancellationToken ct)
     {
-        if (!_influx.IsConfigured && !await _influx.ReconfigureAsync(ct))
+        // Canonical/auto-computed path: always the trailing ScoreWindowHours (48 h). Publishes
+        // the readiness status the dashboard tile reads.
+        var windowEnd = DateTime.UtcNow;
+        var windowStart = windowEnd.AddHours(-_options.ScoreWindowHours);
+        var outcome = await ComputeCoreAsync(windowStart, windowEnd, null, ct);
+        _status = outcome.Status;
+        return (outcome.Report, outcome.ChartClusters);
+    }
+
+    /// <summary>
+    /// Report for the ISP Health tab's date/time filter over an arbitrary window. Never touches
+    /// the cached 48 h report, the readiness status, or the dashboard tile - the default and
+    /// auto-computed paths stay on the trailing 48 h window. The most recent custom window is
+    /// briefly cached so the chart's follow-up fetch for the same window skips the heavy query.
+    /// </summary>
+    public async Task<(IspHealthReport? Report, List<AsnSeries> ChartClusters)> ComputeForWindowAsync(
+        DateTime windowStart, DateTime windowEnd, bool forceRefresh = false, CancellationToken ct = default)
+    {
+        var cached = _customCache;
+        if (!forceRefresh && cached != null && cached.Start == windowStart && cached.End == windowEnd
+            && DateTime.UtcNow - cached.ComputedAt < _options.CacheTtl)
+            return (cached.Report, cached.ChartClusters);
+
+        // A window longer than the canonical re-covers the recent period at a coarser aggregate,
+        // which can inflate bucket-p90 burst detection into congestion events the authoritative
+        // fine-resolution 48 h view never sees. Gate the recent (canonical-covered) portion against
+        // the canonical report so those artifacts drop, while older history keeps its own detection.
+        // Only when the canonical computed successfully (non-null); otherwise no gating (never drop
+        // events against a missing reference). GetReportAsync is cache-served, so this is cheap.
+        IReadOnlyList<CongestionEvent>? referenceEvents = null;
+        if ((windowEnd - windowStart).TotalHours > _options.ScoreWindowHours + 0.5
+            && DateTime.UtcNow - windowEnd < TimeSpan.FromHours(1))
         {
-            _status = IspHealthStatus.NotConfigured;
-            return (null, new List<AsnSeries>());
+            referenceEvents = (await GetReportAsync(ct: ct))?.CongestionEvents;
         }
+
+        var outcome = await ComputeCoreAsync(windowStart, windowEnd, referenceEvents, ct);
+        if (outcome.Report != null)
+            _customCache = new CustomWindowSnapshot(windowStart, windowEnd, outcome.Report, outcome.ChartClusters, DateTime.UtcNow);
+        return (outcome.Report, outcome.ChartClusters);
+    }
+
+    /// <summary>
+    /// Drops congestion events in the canonical-covered recent window (the trailing
+    /// <see cref="IspHealthOptions.ScoreWindowHours"/>) that the fine-resolution canonical report
+    /// did not also find - coarse-aggregate burst artifacts a long viewing window invents. An event
+    /// older than that window has no canonical counterpart to check against, so it is kept. A match
+    /// is a time overlap plus a shared bottleneck hop or ASN (loose, so a real event the canonical
+    /// localized to a slightly different hop is never dropped).
+    /// </summary>
+    private List<CongestionEvent> GateAgainstCanonical(
+        List<CongestionEvent> events, IReadOnlyList<CongestionEvent> canonical, DateTime windowEnd)
+    {
+        var recentStart = windowEnd.AddHours(-_options.ScoreWindowHours);
+        return events.Where(e =>
+            e.Start < recentStart
+            || canonical.Any(r =>
+                r.Start < e.End && e.Start < r.End
+                && ((e.BottleneckHopIp != null && r.BottleneckHopIp == e.BottleneckHopIp)
+                    || r.AsnNumbers.Any(a => a != 0 && e.AsnNumbers.Contains(a)))))
+            .ToList();
+    }
+
+    private async Task<ComputeOutcome> ComputeCoreAsync(DateTime windowStart, DateTime windowEnd,
+        IReadOnlyList<CongestionEvent>? referenceEvents, CancellationToken ct)
+    {
+        if (!_influx.IsConfigured && !await _influx.ReconfigureAsync(ct))
+            return new ComputeOutcome(IspHealthStatus.NotConfigured, null, new List<AsnSeries>());
 
         AccessTechnology technology;
         List<MonitoringTarget> targets;
+        // Enabled fabric (UniFi device) targets, used only to find the LAN gateway's monitoring
+        // target for outage scoping (gateway-unreachable => LAN/gateway outage, not WAN).
+        List<MonitoringTarget> fabricTargets;
         // TargetId -> the monitored hop IPs proven upstream of it (its ancestors), from
         // Upstream Discovery's traces. ISP Health uses these to confirm one hop routes
         // through another before its jitter absolves the other. No live traceroute here.
@@ -142,10 +214,7 @@ public class IspHealthService
         {
             var settings = await db.MonitoringSettings.AsNoTracking().FirstOrDefaultAsync(ct);
             if (settings == null || !settings.Enabled)
-            {
-                _status = IspHealthStatus.NotConfigured;
-                return (null, new List<AsnSeries>());
-            }
+                return new ComputeOutcome(IspHealthStatus.NotConfigured, null, new List<AsnSeries>());
 
             // Access technology lives per-WAN in WanDiscoveryContexts (the wizard's
             // store, which replaced the global MonitoringSettings column); prefer the
@@ -160,6 +229,10 @@ public class IspHealthService
                 .Where(t => t.Enabled && (t.TargetType == MonitoringTargetType.AccessIsp
                     || t.TargetType == MonitoringTargetType.Transit
                     || t.TargetType == MonitoringTargetType.InternetService))
+                .ToListAsync(ct);
+
+            fabricTargets = await db.MonitoringTargets.AsNoTracking()
+                .Where(t => t.Enabled && t.TargetType == MonitoringTargetType.Fabric && t.DeviceMac != null)
                 .ToListAsync(ct);
 
             // TODO (multi-WAN): discoveries are read across ALL WANs, not scoped to the WAN
@@ -192,31 +265,38 @@ public class IspHealthService
         var ispTargets = targets.Where(t => t.TargetType == MonitoringTargetType.AccessIsp).ToList();
         var transitTargets = targets.Where(t => t.TargetType == MonitoringTargetType.Transit).ToList();
         if (ispTargets.Count == 0 && transitTargets.Count == 0)
-        {
-            _status = IspHealthStatus.NeedsDiscovery;
-            return (null, new List<AsnSeries>());
-        }
+            return new ComputeOutcome(IspHealthStatus.NeedsDiscovery, null, new List<AsnSeries>());
 
         var profile = IspHealthProfiles.GetProfile(technology);
         if (profile == null)
-        {
-            _status = IspHealthStatus.NeedsTechnology;
-            return (null, new List<AsnSeries>());
-        }
+            return new ComputeOutcome(IspHealthStatus.NeedsTechnology, null, new List<AsnSeries>());
 
-        var windowEnd = DateTime.UtcNow;
-        var windowStart = windowEnd.AddHours(-_options.ScoreWindowHours);
-        // Fine-grained join window so short load bursts (speed tests, downloads)
-        // classify as loaded instead of diluting into minute-level means
-        var aggregate = TimeSpan.FromSeconds(_options.LoadWindowSeconds);
+        // First gateway from the cached UniFi device list (shadow-mode multi-gateway isn't handled
+        // yet - first gateway is fine), matched to its fabric monitoring target by MAC so we can pull
+        // its loss for outage scoping. Null when no gateway is monitored - outage scoping then stays
+        // unchanged (no Local scope possible).
+        static string MacKey(string? m) => new string((m ?? "").Where(Uri.IsHexDigit).ToArray()).ToLowerInvariant();
+        var gatewayDevice = (await _connectionService.GetDiscoveredDevicesAsync(ct)).FirstOrDefault(d => d.Type.IsGateway());
+        var gatewayTarget = gatewayDevice == null ? null
+            : fabricTargets.FirstOrDefault(t => MacKey(t.DeviceMac) == MacKey(gatewayDevice.Mac));
+
+        // Fine-grained join window so short load bursts (speed tests, downloads) classify as
+        // loaded instead of diluting into minute-level means. Longer (filter-selected) windows
+        // coarsen it to keep the point count bounded; the canonical 48 h window lands on exactly
+        // LoadWindowSeconds, so the auto-computed report is unchanged.
+        var aggregate = TimeSpan.FromSeconds(Math.Max(
+            _options.LoadWindowSeconds, (windowEnd - windowStart).TotalSeconds / 25000.0));
 
         var ispSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.AccessIsp, windowStart, windowEnd, aggregate, ct);
         var transitSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.Transit, windowStart, windowEnd, aggregate, ct);
         var internetSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.InternetService, windowStart, windowEnd, aggregate, ct);
         var ratesTask = QueryWanRatesAsync(windowStart, windowEnd, aggregate, ct);
         var speedsTask = ResolveExpectedSpeedsAsync(ct);
-        var speedTestsTask = LoadWanSpeedTestsAsync(windowEnd, ct);
-        await Task.WhenAll(ispSeriesTask, transitSeriesTask, internetSeriesTask, ratesTask, speedsTask, speedTestsTask);
+        var speedTestsTask = LoadWanSpeedTestsAsync(windowStart, windowEnd, ct);
+        var gatewaySeriesTask = gatewayTarget == null
+            ? Task.FromResult(new List<MonitoringInfluxClient.LatencySeriesPoint>())
+            : _influx.QueryLatencyDetailByTargetIdAsync(gatewayTarget.TargetId, windowStart, windowEnd, aggregate, ct);
+        await Task.WhenAll(ispSeriesTask, transitSeriesTask, internetSeriesTask, ratesTask, speedsTask, speedTestsTask, gatewaySeriesTask);
 
         var ispSeries = ToSamples(await ispSeriesTask);
         var transitSeries = ToSamples(await transitSeriesTask);
@@ -224,6 +304,8 @@ public class IspHealthService
         var wanRates = await ratesTask;
         var (expectedDown, expectedUp, expectedSource, smartQueuesEnabled) = await speedsTask;
         var wanSpeedTests = await speedTestsTask;
+        var gatewaySamples = (await gatewaySeriesTask)
+            .Select(p => new LatencySample(p.Time, p.RttAvgMs, p.RttMaxMs, p.JitterMs, p.LossPercent)).ToList();
 
         // New installs: grade once a few hours of latency data exist, not before.
         // Enabled targets only - a disabled target's stale history must not satisfy the
@@ -235,10 +317,7 @@ public class IspHealthService
             .DefaultIfEmpty(windowEnd)
             .Min();
         if ((windowEnd - earliestSample).TotalHours < _options.MinDataHours)
-        {
-            _status = IspHealthStatus.InsufficientData;
-            return (null, new List<AsnSeries>());
-        }
+            return new ComputeOutcome(IspHealthStatus.InsufficientData, null, new List<AsnSeries>());
 
         var (firstHop, firstHopTargetId) = PickFirstCleanHop(ispTargets, ispSeries);
         // Public access hops only - the loaded-latency worst-hop scan must not include a
@@ -314,7 +393,70 @@ public class IspHealthService
             })
             .ToList();
 
-        var congestionEvents = CongestionDetector.Detect(allClusters, _options);
+        // Per-target (hop-granularity) series for the congestion localizer: clustering would
+        // lump a clean middle hop with a hot one and re-merge an off-path ASN, so detection and
+        // localization run at the individual hop. Destinations come in as witnesses only.
+        AsnSeries PerTargetSeries(MonitoringTarget t, Dictionary<string, List<LatencySample>> series, bool isDestination) => new()
+        {
+            AsnNumber = t.AsnNumber ?? 0,
+            AsnName = t.Name,
+            TargetIds = { t.TargetId },
+            Samples = series[t.TargetId],
+            HopIps = { t.Address },
+            AncestorIps = ancestorIpsByTargetId.TryGetValue(t.TargetId, out var anc) ? anc : new List<string>(),
+            IsDestination = isDestination
+        };
+        var localizerSeries = new List<AsnSeries>();
+        localizerSeries.AddRange(ispTargets
+            .Where(t => ispSeries.ContainsKey(t.TargetId))
+            .Select(t => PerTargetSeries(t, ispSeries, false)));
+        localizerSeries.AddRange(transitTargets
+            .Where(t => t.AsnNumber is > 0 && transitSeries.ContainsKey(t.TargetId))
+            .Select(t => PerTargetSeries(t, transitSeries, false)));
+        localizerSeries.AddRange(internetTargetSeries);
+
+        // Hop distance per IP (from the saved trace map), the nearest public access hop(s),
+        // and WAN utilization over time - the localizer's topology and load context.
+        var hopNumberByIp = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var t in targets)
+        {
+            if (string.IsNullOrEmpty(t.Address) || !hopNumberByTargetId.TryGetValue(t.TargetId, out var hop)) continue;
+            if (!hopNumberByIp.TryGetValue(t.Address, out var existing) || hop < existing)
+                hopNumberByIp[t.Address] = hop;
+        }
+        var accessEgressIps = ispTargets
+            .Where(t => !string.IsNullOrEmpty(t.Address) && !NetworkUtilities.IsPrivateIpAddress(t.Address)
+                && hopNumberByTargetId.ContainsKey(t.TargetId))
+            .GroupBy(t => hopNumberByTargetId[t.TargetId])
+            .OrderBy(g => g.Key)
+            .FirstOrDefault()?.Select(t => t.Address)
+            ?? Enumerable.Empty<string>();
+        var loadByTime = wanRates.Select(r =>
+        {
+            double? util = null;
+            if (expectedDown is > 0 || expectedUp is > 0)
+            {
+                var d = expectedDown is > 0 && r.DownloadBps.HasValue ? r.DownloadBps.Value / (expectedDown.Value * 1_000_000) : 0;
+                var u = expectedUp is > 0 && r.UploadBps.HasValue ? r.UploadBps.Value / (expectedUp.Value * 1_000_000) : 0;
+                util = Math.Max(d, u);
+            }
+            return (r.Time, Utilization: util);
+        }).ToList();
+        var congestionTopology = new CongestionTopology
+        {
+            AccessEgressHopIps = new HashSet<string>(accessEgressIps, StringComparer.OrdinalIgnoreCase),
+            HopNumberByIp = hopNumberByIp,
+            Load = loadByTime,
+            HasTraceMap = hopOrderKnown
+        };
+        var congestionEvents = CongestionLocalizer.Localize(localizerSeries, congestionTopology, _options);
+        if (referenceEvents != null)
+            congestionEvents = GateAgainstCanonical(congestionEvents, referenceEvents, windowEnd);
+        foreach (var ce in congestionEvents)
+            _logger.LogDebug(
+                "ISP Health congestion: {Disposition} at {Hop} ({Label}) conf={Confidence} load={Load} - {Reason}",
+                ce.Disposition, ce.BottleneckHopIp ?? "?",
+                ce.BottleneckLabel ?? string.Join(",", ce.AsnNames), ce.Confidence, ce.LoadCoincident, ce.AttributionReason);
 
         // Internet/CDN targets join step detection because routing shifts in a transit
         // network show up on every path that crosses it (per the real shift examples)
@@ -381,7 +523,7 @@ public class IspHealthService
             }, Groupable: true, AsnLabel: AsnNameCleanup.Clean(t.AsnName) ?? accessAsnName))
             .Concat(transitChart.Select(s => (Series: s, Groupable: false, AsnLabel: (string?)TransitLabel(s))))
             .Concat(displayInternet.Select(s => (Series: s, Groupable: false, AsnLabel: (string?)null)));
-        var outageHops = outageSources
+        var orderedWanHops = outageSources
             .Select(x => new
             {
                 x.Groupable,
@@ -392,7 +534,17 @@ public class IspHealthService
                 Rtt = MedianRtt(x.Series)
             })
             .OrderBy(x => x.HopNumber).ThenBy(x => x.Rtt)
-            .Select((x, i) => new OutageDetector.Hop(x.Name, i, x.Series, x.Groupable, x.AsnLabel))
+            .ToList();
+        // The LAN gateway is the nearest hop (Depth 0) when monitored; WAN hops shift one deeper.
+        // Its loss lets the detector tell a LAN/gateway outage from a WAN outage. Absent => unchanged.
+        var gatewayHop = gatewaySamples.Count > 0
+            ? new OutageDetector.Hop(gatewayDevice?.Name is { Length: > 0 } gn ? gn : "Gateway",
+                0, gatewaySamples, Groupable: false, AsnLabel: null, IsGateway: true)
+            : null;
+        var baseDepth = gatewayHop != null ? 1 : 0;
+        var outageHops = (gatewayHop != null ? new[] { gatewayHop } : Array.Empty<OutageDetector.Hop>())
+            .Concat(orderedWanHops.Select((x, i) =>
+                new OutageDetector.Hop(x.Name, baseDepth + i, x.Series, x.Groupable, x.AsnLabel)))
             .ToList();
         var outages = OutageDetector.Detect(internetTriggerTargets, outageHops, _options);
 
@@ -429,18 +581,25 @@ public class IspHealthService
         };
 
         var report = new IspHealthScorer(_options, _logger).Score(inputs, profile);
-        _status = IspHealthStatus.Ready;
         _logger.LogDebug("ISP Health computed: {Score} ({Tech}), {Events} congestion events, {Shifts} path shifts",
             report.OverallScore, profile.DisplayName, congestionEvents.Count, pathShifts.Count);
-        return (report, chartClusters);
+        return new ComputeOutcome(IspHealthStatus.Ready, report, chartClusters);
     }
 
     /// <summary>
-    /// Per-ASN RTT series for the tab chart (ISP + transit, 24 h, per-minute means)
-    /// plus the cached report's events for chart annotations.
+    /// Per-ASN RTT series for the tab chart (ISP + transit) plus the report's events for chart
+    /// annotations. With no window it serves the cached 48 h report; with an explicit window
+    /// (the tab's date/time filter) it computes that window off-cache, so the chart follows the
+    /// filter without disturbing the canonical 48 h view.
     /// </summary>
-    public async Task<(List<AsnSeries> Series, IspHealthReport? Report)> GetAsnChartDataAsync(CancellationToken ct = default)
+    public async Task<(List<AsnSeries> Series, IspHealthReport? Report)> GetAsnChartDataAsync(
+        DateTime? from = null, DateTime? to = null, CancellationToken ct = default)
     {
+        if (from.HasValue && to.HasValue)
+        {
+            var (windowReport, windowClusters) = await ComputeForWindowAsync(from.Value, to.Value, ct: ct);
+            return (windowClusters, windowReport);
+        }
         // Return the exact clusters the report's events were detected on, so chart
         // line labels and the event labels are guaranteed to agree (re-clustering
         // independently would round the "+N ms hop" names differently). Read the
@@ -448,6 +607,16 @@ public class IspHealthService
         await GetReportAsync(ct: ct);
         var snap = _cached;
         return (snap?.ChartClusters ?? new List<AsnSeries>(), snap?.Report);
+    }
+
+    /// <summary>
+    /// Report for an explicit window (the ISP Health tab's date/time filter). Bypasses the 48 h
+    /// cache and never publishes status, so the dashboard tile and default view stay on 48 h.
+    /// </summary>
+    public async Task<IspHealthReport?> GetReportForWindowAsync(DateTime windowStart, DateTime windowEnd, bool forceRefresh = false, CancellationToken ct = default)
+    {
+        var (report, _) = await ComputeForWindowAsync(windowStart, windowEnd, forceRefresh, ct);
+        return report;
     }
 
     private async Task<List<ThroughputSample>> QueryWanRatesAsync(DateTime from, DateTime to, TimeSpan aggregate, CancellationToken ct)
@@ -601,15 +770,21 @@ public class IspHealthService
     /// WAN tests (OpenSpeedTest from a browser via an external server) are excluded
     /// because the client's own link contaminates the measurement.
     /// </summary>
-    private async Task<List<SpeedTestSample>> LoadWanSpeedTestsAsync(DateTime windowEnd, CancellationToken ct)
+    private async Task<List<SpeedTestSample>> LoadWanSpeedTestsAsync(DateTime windowStart, DateTime windowEnd, CancellationToken ct)
     {
         try
         {
-            var since = windowEnd.AddDays(-_options.SpeedTestFallbackDays);
+            // Reach back the WIDER of the selected window or the fallback floor: a long window
+            // (e.g. 30 d) finds its best demonstrated capacity across the whole window, while a
+            // short window keeps the SpeedTestFallbackDays floor so a sparse run of tests still
+            // yields a recent capacity number. Bounded above by windowEnd for historical windows.
+            var fallbackStart = windowEnd.AddDays(-_options.SpeedTestFallbackDays);
+            var since = windowStart < fallbackStart ? windowStart : fallbackStart;
             await using var db = await _dbFactory.CreateDbContextAsync(ct);
             var results = await db.Iperf3Results.AsNoTracking()
                 .Where(r => r.Success
                     && r.TestTime >= since
+                    && r.TestTime <= windowEnd
                     && (r.Direction == SpeedTestDirection.CloudflareWan
                         || r.Direction == SpeedTestDirection.CloudflareWanGateway
                         || r.Direction == SpeedTestDirection.UwnWan
@@ -824,7 +999,13 @@ public class IspHealthService
                     AsnNumber = group.Key,
                     AsnName = chartName,
                     TargetIds = clusterTargets.Select(t => t.TargetId).ToList(),
-                    Samples = clusterTargets.SelectMany(t => seriesByTarget[t.TargetId]).OrderBy(s => s.Time).ToList()
+                    Samples = clusterTargets.SelectMany(t => seriesByTarget[t.TargetId]).OrderBy(s => s.Time).ToList(),
+                    // Hop IPs and proven-upstream ancestors so the congestion localizer can
+                    // place this cluster on the trace map and walk the bottleneck.
+                    HopIps = clusterTargets.Select(t => t.Address).ToList(),
+                    AncestorIps = clusterTargets
+                        .SelectMany(t => ancestorIpsByTargetId.TryGetValue(t.TargetId, out var anc) ? anc : Enumerable.Empty<string>())
+                        .Distinct(StringComparer.OrdinalIgnoreCase).ToList()
                 });
 
                 // The graded series keeps the ASN name for the Networks on Your Path card.
@@ -888,7 +1069,11 @@ public class IspHealthService
                         AsnNumber = group.Key,
                         AsnName = others.Count == 1 ? others[0].Name : $"{asnName} (other hops)",
                         TargetIds = others.Select(t => t.TargetId).ToList(),
-                        Samples = others.SelectMany(t => seriesByTarget[t.TargetId]).OrderBy(s => s.Time).ToList()
+                        Samples = others.SelectMany(t => seriesByTarget[t.TargetId]).OrderBy(s => s.Time).ToList(),
+                        HopIps = others.Select(t => t.Address).ToList(),
+                        AncestorIps = others
+                            .SelectMany(t => ancestorIpsByTargetId.TryGetValue(t.TargetId, out var anc) ? anc : Enumerable.Empty<string>())
+                            .Distinct(StringComparer.OrdinalIgnoreCase).ToList()
                     });
                 }
             }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
@@ -23,7 +23,7 @@ public static class OutageDetector
     /// per-target <paramref name="Name"/> (the PTR hostname); the detector disambiguates when one
     /// ASN owns several rows. Null AsnLabel (internet endpoints) falls back to <paramref name="Name"/>.
     /// </summary>
-    public sealed record Hop(string Name, int Depth, IReadOnlyList<LatencySample> Series, bool Groupable = false, string? AsnLabel = null);
+    public sealed record Hop(string Name, int Depth, IReadOnlyList<LatencySample> Series, bool Groupable = false, string? AsnLabel = null, bool IsGateway = false);
 
     /// <param name="triggerTargets">The internet/destination loss series whose near-total loss defines an outage.</param>
     /// <param name="hops">Every monitored hop, ordered by distance (Depth ascending = nearest first), for the shape.</param>
@@ -163,12 +163,20 @@ public static class OutageDetector
         // The break sits just beyond the deepest hop that stayed reachable through the
         // outage. If even the nearest hop was dark for most of it, the whole WAN dropped.
         // Attribution runs on the per-hop (ungrouped) states so it can name the precise hop.
-        var states = tiers.Select(t => t.State).ToList();
-        var nearest = states.OrderBy(s => s.Depth).FirstOrDefault();
-        var lastReachable = states.Where(s => !onBrokenPath[s.Depth]).OrderByDescending(s => s.Depth).FirstOrDefault();
-        var scope = nearest == null || onBrokenPath[nearest.Depth] || lastReachable == null
-            ? OutageScope.FullWan
-            : OutageScope.Upstream;
+        // The LAN gateway is excluded from WAN break attribution (FullWan/Upstream) and only decides
+        // the Local override: when the gateway itself stayed dark through the outage, the agent could
+        // not reach its own gateway - a LAN/switch/gateway outage, not the ISP's WAN. With no gateway
+        // hop, wanStates == all states and the FullWan/Upstream logic is byte-for-byte unchanged.
+        var gwTier = tiers.FirstOrDefault(t => t.Hop.IsGateway);
+        var gatewayDark = gwTier.Hop != null && onBrokenPath.TryGetValue(gwTier.State.Depth, out var gwd) && gwd;
+        var wanStates = tiers.Where(t => !t.Hop.IsGateway).Select(t => t.State).ToList();
+        var nearest = wanStates.OrderBy(s => s.Depth).FirstOrDefault();
+        var lastReachable = wanStates.Where(s => !onBrokenPath[s.Depth]).OrderByDescending(s => s.Depth).FirstOrDefault();
+        var scope = gatewayDark
+            ? OutageScope.Local
+            : nearest == null || onBrokenPath[nearest.Depth] || lastReachable == null
+                ? OutageScope.FullWan
+                : OutageScope.Upstream;
 
         // Bucket edges are minute-aligned; report the real onset and recovery instants from
         // the pooled trigger stream so the window carries seconds. Fall back to the bucket

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15359,7 +15359,27 @@ tr.stats-row-filtered {
 .isp-health-toolbar {
     display: flex;
     justify-content: flex-end;
+    align-items: center;
+    gap: 0.75rem;
     margin-bottom: 0.75rem;
+}
+
+.isp-health-toolbar .time-range-selector {
+    background: var(--bg-tertiary);
+}
+
+.isp-health-toolbar .custom-range-btn {
+    justify-content: center;
+}
+
+.isp-popover-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 40;
+}
+
+.isp-filter-raised {
+    z-index: 50;
 }
 
 .isp-health-updated {
@@ -15739,17 +15759,19 @@ a.isp-health-hero-speed:hover {
 
 .isp-event-item {
     position: relative;
-    display: flex;
+    display: grid;
+    grid-template-columns: 6rem 5.5rem 1fr;
+    justify-items: start;
     align-items: baseline;
-    gap: 0.6rem;
-    flex-wrap: wrap;
+    column-gap: 0.6rem;
+    row-gap: 0.3rem;
 }
 
 .isp-event-item::before {
     content: "";
     position: absolute;
     left: calc(-1rem - 7.5px);
-    top: 0.25rem;
+    top: 0.325rem;
     width: 9px;
     height: 9px;
     border-radius: 50%;
@@ -15951,6 +15973,14 @@ a.isp-health-hero-speed:hover {
     .isp-event-timeline {
         padding-left: 0.75rem;
     }
+    .isp-event-item {
+        grid-template-columns: auto auto;
+        row-gap: 0.15rem;
+    }
+    .isp-event-text {
+        grid-column: 1 / -1;
+        padding-top: 0.25rem;
+    }
     .isp-event-item::before {
         left: calc(-0.75rem - 7.5px);
     }
@@ -15964,6 +15994,10 @@ a.isp-health-hero-speed:hover {
 
 .isp-chart-wrap {
     position: relative;
+}
+
+.isp-health-chart-card {
+    overflow-y: visible;
 }
 
 .isp-chart-reset-btn {

--- a/src/NetworkOptimizer.Web/wwwroot/js/isp-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/isp-health-charts.js
@@ -12,6 +12,8 @@ let pollTimer = null;
 let fetchController = null;
 let resetBtn = null;
 let isZoomed = false;
+// null = default 48 h cached view; { from, to } ISO strings = a filter-selected window.
+let win = null;
 
 function buildOpts() {
     return {
@@ -20,7 +22,7 @@ function buildOpts() {
             height: 280,
             background: 'transparent',
             toolbar: { show: false },
-            zoom: { enabled: !matchMedia('(pointer:coarse)').matches, type: 'x', allowMouseWheelZoom: false },
+            zoom: { enabled: !matchMedia('(pointer:coarse)').matches, type: 'x', autoScaleYaxis: true, allowMouseWheelZoom: false },
             parentHeightOffset: 0,
             animations: { enabled: false },
             events: {
@@ -121,8 +123,9 @@ async function loadAndUpdate() {
     fetchController?.abort();
     fetchController = new AbortController();
     try {
-        const resp = await fetch('/api/monitoring/isp-health/asn-series',
-            { credentials: 'same-origin', signal: fetchController.signal });
+        let url = '/api/monitoring/isp-health/asn-series';
+        if (win) url += `?from=${encodeURIComponent(win.from)}&to=${encodeURIComponent(win.to)}`;
+        const resp = await fetch(url, { credentials: 'same-origin', signal: fetchController.signal });
         if (!resp.ok) return;
         const json = await resp.json();
 
@@ -140,9 +143,10 @@ async function loadAndUpdate() {
     }
 }
 
-export async function mount(elId) {
+export async function mount(elId, fromISO = null, toISO = null) {
     const el = document.getElementById(elId);
     if (!el) return;
+    win = (fromISO && toISO) ? { from: fromISO, to: toISO } : null;
 
     resetBtn = document.createElement('button');
     resetBtn.type = 'button';
@@ -163,10 +167,20 @@ export async function reload() {
     await loadAndUpdate();
 }
 
+// Follow a filter-selected window (or null, null for the default 48 h view). Clears any
+// drag-zoom and reloads, so the chart resets and refetches on every filter change.
+export async function setWindow(fromISO, toISO) {
+    win = (fromISO && toISO) ? { from: fromISO, to: toISO } : null;
+    if (chart) chart.updateOptions({ xaxis: { min: undefined, max: undefined } }, false, false);
+    setZoomed(false);
+    await loadAndUpdate();
+}
+
 export function unmount() {
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     fetchController?.abort();
     if (resetBtn) { resetBtn.remove(); resetBtn = null; }
     isZoomed = false;
+    win = null;
     if (chart) { chart.destroy(); chart = null; }
 }

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -3,4 +3,11 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)FluentAssertionsLicense.cs" Link="FluentAssertionsLicense.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- Mirrors the root Directory.Build.props (which this file shadows, not merges):
+         suppress GHSA-2m69-gcr7-jv3q on the transitive native SQLite pulled by test
+         projects. We are not in the affected code path; fix ships in EF 10.0.11.
+         See https://github.com/dotnet/efcore/issues/38257 - remove when we move to 10.0.11. -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
 </Project>

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
@@ -1,0 +1,272 @@
+using FluentAssertions;
+using NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.IspHealth;
+
+/// <summary>
+/// Scenario tests for the bottleneck localizer: a localized backhaul hop, a dead-end
+/// off-path transit, self-inflicted access bufferbloat, an obvious whole-transit
+/// congestion, and absolved near-hop control-plane noise.
+///
+/// Synthetic topology (ip / hopNumber), RFC1918 addresses and placeholder ASNs:
+///   10.0.0.1 h1  access egress              ASN 100
+///   10.0.0.2 h2  clean middle hop           ASN 100   ancestors: .1
+///   10.0.0.3 h3  backhaul hop               ASN 100   ancestors: .1 .2
+///   10.0.1.1 h4  transit                    ASN 200   ancestors: .1 .2 .3
+///   10.0.2.1 h3  dead-end off-path transit  ASN 300   ancestors: .1 .2   (branches at .2, off the .3 corridor)
+///   10.0.3.1 h5  destination via corridor   dest      ancestors: .1 .2 .3 10.0.1.1
+///   10.0.4.1 h5  destination off corridor   dest      ancestors: .1 .2   (clean control)
+/// </summary>
+public class CongestionLocalizerTests
+{
+    private static readonly IspHealthOptions Options = new();
+    private static readonly TimeSpan Day = TimeSpan.FromHours(24);
+    private static readonly DateTime HumpStart = TestSeries.Start.AddHours(12);
+    private static readonly DateTime HumpEnd = HumpStart.AddMinutes(45);
+
+    private const string Bng = "10.0.0.1";
+    private const string Border = "10.0.0.2";
+    private const string Backhaul = "10.0.0.3";
+    private const string Transit = "10.0.1.1";
+    private const string DeadEnd = "10.0.2.1";
+    private const string DestCorridor = "10.0.3.1";
+    private const string DestControl = "10.0.4.1";
+
+    private static readonly Dictionary<string, int> HopNumbers = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [Bng] = 1, [Border] = 2, [Backhaul] = 3, [Transit] = 4, [DeadEnd] = 3, [DestCorridor] = 5, [DestControl] = 5
+    };
+
+    private static List<LatencySample> Flat(double rtt = 5) => TestSeries.Flat(TestSeries.Start, Day, rtt, jitterMs: 0.5);
+    private static List<LatencySample> Elevated(double rtt = 5) => Flat(rtt).WithSegment(HumpStart, HumpEnd, rttMs: rtt + 25, jitterMs: 6);
+
+    private static AsnSeries Hop(int asn, string ip, List<LatencySample> samples, params string[] ancestors) => new()
+    {
+        AsnNumber = asn,
+        AsnName = $"AS{asn}-{ip}",
+        TargetIds = { ip },
+        Samples = samples,
+        HopIps = { ip },
+        AncestorIps = ancestors.ToList()
+    };
+
+    private static AsnSeries Dest(string ip, List<LatencySample> samples, params string[] ancestors)
+    {
+        var s = Hop(0, ip, samples, ancestors);
+        return new AsnSeries
+        {
+            AsnNumber = 0, AsnName = ip, TargetIds = { ip }, Samples = samples,
+            HopIps = { ip }, AncestorIps = ancestors.ToList(), IsDestination = true
+        };
+    }
+
+    private static List<(DateTime Time, double? Utilization)> HighLoad()
+    {
+        var list = new List<(DateTime, double?)>();
+        for (var t = HumpStart; t < HumpEnd; t = t.AddMinutes(1)) list.Add((t, 0.9));
+        return list;
+    }
+
+    private static CongestionTopology Topo(bool load) => new()
+    {
+        AccessEgressHopIps = new HashSet<string>(new[] { Bng }, StringComparer.OrdinalIgnoreCase),
+        HopNumberByIp = HopNumbers,
+        Load = load ? HighLoad() : new List<(DateTime, double?)>(),
+        HasTraceMap = true
+    };
+
+    [Fact]
+    public void Localizes_to_backhaul_hop_and_does_not_blame_downstream_transit()
+    {
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Flat()),
+            Hop(100, Border, Flat()),
+            Hop(100, Backhaul, Elevated(), Bng, Border),
+            Hop(200, Transit, Elevated(), Bng, Border, Backhaul),
+            Hop(300, DeadEnd, Flat(), Bng, Border),
+            Dest(DestCorridor, Elevated(), Bng, Border, Backhaul, Transit),
+            Dest(DestControl, Flat(), Bng, Border)
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: true), Options);
+
+        events.Should().HaveCount(1);
+        var e = events[0];
+        e.Disposition.Should().Be(CongestionDisposition.Confirmed);
+        e.Scope.Should().Be(CongestionScope.Hop);
+        e.BottleneckHopIp.Should().Be(Backhaul);
+        e.AsnNumbers.Should().Equal(100);          // the backhaul ASN, not transit 200
+        e.LoadCoincident.Should().BeTrue();
+        e.Suppressed.Should().BeFalse();
+        e.CleanParallelPaths.Should().BeGreaterThan(0);   // off-path hops stayed clean -> hop-isolated, not access-wide
+    }
+
+    [Fact]
+    public void Dead_end_transit_is_unverifiable_and_not_merged_into_the_corridor_event()
+    {
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Flat()),
+            Hop(100, Border, Flat()),
+            Hop(100, Backhaul, Elevated(), Bng, Border),
+            Hop(200, Transit, Elevated(), Bng, Border, Backhaul),
+            Hop(300, DeadEnd, Elevated(), Bng, Border),          // off-path dead-end: elevated, no monitored descendant
+            Dest(DestCorridor, Elevated(), Bng, Border, Backhaul, Transit),
+            Dest(DestControl, Flat(), Bng, Border)
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: true), Options);
+
+        events.Should().HaveCount(2);
+        var corridor = events.Single(e => e.BottleneckHopIp == Backhaul);
+        var deadEnd = events.Single(e => e.BottleneckHopIp == DeadEnd);
+
+        corridor.Disposition.Should().Be(CongestionDisposition.Confirmed);
+        corridor.AsnNumbers.Should().NotContain(300);            // off-path dead-end not folded in
+        deadEnd.Disposition.Should().Be(CongestionDisposition.Unverifiable);
+        deadEnd.AsnNumbers.Should().Equal(300);
+        deadEnd.Suppressed.Should().BeFalse();                   // surfaced, but...
+        deadEnd.Confidence.Should().BeLessThan(corridor.Confidence);
+    }
+
+    [Fact]
+    public void Access_wide_elevation_under_load_is_self_inflicted_and_suppressed()
+    {
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Elevated()),
+            Hop(100, Border, Elevated(), Bng),
+            Hop(100, Backhaul, Elevated(), Bng, Border),
+            Hop(200, Transit, Elevated(), Bng, Border, Backhaul),
+            Hop(300, DeadEnd, Elevated(), Bng, Border),
+            Dest(DestCorridor, Elevated(), Bng, Border, Backhaul, Transit),
+            Dest(DestControl, Elevated(), Bng, Border)
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: true), Options);
+
+        events.Should().ContainSingle(e => e.Disposition == CongestionDisposition.SelfInflicted);
+        var self = events.Single(e => e.Disposition == CongestionDisposition.SelfInflicted);
+        self.BottleneckHopIp.Should().Be(Bng);
+        self.Suppressed.Should().BeTrue();
+        events.Should().NotContain(e => e.Disposition == CongestionDisposition.Confirmed);
+    }
+
+    [Fact]
+    public void Obvious_whole_transit_congestion_with_no_load_is_confirmed_against_the_transit()
+    {
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Flat()),
+            Hop(100, Border, Flat()),
+            Hop(100, Backhaul, Flat()),
+            Hop(200, Transit, Elevated(), Bng, Border, Backhaul),
+            Hop(300, DeadEnd, Flat(), Bng, Border),
+            Dest(DestCorridor, Elevated(), Bng, Border, Backhaul, Transit),  // downstream of transit, confirms propagation
+            Dest(DestControl, Flat(), Bng, Border)
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        events.Should().HaveCount(1);
+        var e = events[0];
+        e.Disposition.Should().Be(CongestionDisposition.Confirmed);
+        e.BottleneckHopIp.Should().Be(Transit);
+        e.AsnNumbers.Should().Equal(200);
+        e.LoadCoincident.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Near_hop_elevation_that_does_not_propagate_is_absolved_as_control_plane_noise()
+    {
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Flat()),
+            Hop(100, Border, Elevated(), Bng),                   // elevated near hop...
+            Hop(100, Backhaul, Flat(), Bng, Border),             // ...but immediate downstream is clean
+            Hop(200, Transit, Flat(), Bng, Border, Backhaul),
+            Hop(300, DeadEnd, Flat(), Bng, Border),
+            Dest(DestCorridor, Flat(), Bng, Border, Backhaul, Transit),
+            Dest(DestControl, Flat(), Bng, Border)
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        events.Should().HaveCount(1);
+        events[0].Disposition.Should().Be(CongestionDisposition.ControlPlaneNoise);
+        events[0].BottleneckHopIp.Should().Be(Border);
+        events[0].Suppressed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Bottleneck_is_confirmed_when_a_downstream_hop_is_elevated_but_did_not_fire_its_own_event()
+    {
+        // The downstream transit inherits the bottleneck's delay as a short spike - real, but too
+        // brief to fire its own sustained event. Propagation must still see it via the softer
+        // in-window excursion test, not absolve the real bottleneck as control-plane noise.
+        var shortSpike = Flat(8).WithSegment(HumpStart, HumpStart.AddMinutes(10), rttMs: 33, jitterMs: 6);
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Flat()),
+            Hop(100, Border, Flat()),
+            Hop(100, Backhaul, Elevated(), Bng, Border),            // bottleneck: fires its own event
+            Hop(200, Transit, shortSpike, Bng, Border, Backhaul),   // downstream: elevated, does NOT fire
+            Hop(300, DeadEnd, Flat(), Bng, Border),
+            Dest(DestControl, Flat(), Bng, Border)
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        var backhaul = events.Single(e => e.BottleneckHopIp == Backhaul);
+        backhaul.Disposition.Should().Be(CongestionDisposition.Confirmed);
+    }
+
+    [Fact]
+    public void Unverifiable_hop_inherits_confirmed_from_a_same_asn_sibling_in_the_same_window()
+    {
+        // Two hops on AS 500 elevated in the same window: one has a downstream witness (Confirmed),
+        // the other is a dead-end (would be Unverifiable) - it inherits Confirmed from the sibling.
+        var hopNumbers = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["10.0.0.1"] = 1,
+            ["10.0.5.1"] = 4,
+            ["10.0.5.2"] = 4,
+            ["10.0.6.1"] = 5
+        };
+        var series = new List<AsnSeries>
+        {
+            Hop(100, "10.0.0.1", Flat()),
+            Hop(500, "10.0.5.1", Elevated(), "10.0.0.1"),                 // AS500 hop with a witness beyond it
+            Hop(500, "10.0.5.2", Elevated(), "10.0.0.1"),                 // AS500 dead-end hop (no descendant)
+            Hop(600, "10.0.6.1", Elevated(), "10.0.0.1", "10.0.5.1")      // downstream of 10.0.5.1, confirms it
+        };
+        var topo = new CongestionTopology
+        {
+            AccessEgressHopIps = new HashSet<string>(new[] { "10.0.0.1" }, StringComparer.OrdinalIgnoreCase),
+            HopNumberByIp = hopNumbers,
+            Load = new List<(DateTime, double?)>(),
+            HasTraceMap = true
+        };
+
+        var events = CongestionLocalizer.Localize(series, topo, Options);
+
+        var deadEnd = events.Single(e => e.BottleneckHopIp == "10.0.5.2");
+        deadEnd.Disposition.Should().Be(CongestionDisposition.Confirmed);
+        deadEnd.ConfirmedBySibling.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Jitter_rise_below_the_absolute_floor_does_not_fire()
+    {
+        // RTT clearly elevated and jitter ratio over 2x, but the absolute jitter rise
+        // (0.4 ms) is under CongestionJitterMinDeltaMs - a stable far hop's ICMP wobble.
+        var samples = TestSeries.Flat(TestSeries.Start, Day, rttMs: 20, jitterMs: 0.2)
+            .WithSegment(HumpStart, HumpEnd, rttMs: 26, jitterMs: 0.6);
+
+        var events = CongestionDetector.DetectForSeries(TestSeries.Asn(64500, "FarHop", samples), Options);
+
+        events.Should().BeEmpty();
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
@@ -101,6 +101,50 @@ public class OutageDetectorTests
     }
 
     [Fact]
+    public void Gateway_dark_reads_as_a_local_lan_outage()
+    {
+        var internet1 = Series(0, (OutStart, OutEnd, 100));
+        var internet2 = Series(0, (OutStart, OutEnd, 100));
+        var gateway = Series(0, (OutStart, OutEnd, 100)); // the LAN gateway itself went dark
+        var olt = Series(0, (OutStart, OutEnd, 100));
+
+        var hops = new[]
+        {
+            new OutageDetector.Hop("Gateway", 0, gateway, IsGateway: true),
+            new OutageDetector.Hop("AT&T nokia-olt", 1, olt),
+            new OutageDetector.Hop("Cloudflare", 2, internet1),
+        };
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), hops, Options);
+
+        events.Should().ContainSingle();
+        events[0].Scope.Should().Be(OutageScope.Local);
+    }
+
+    [Fact]
+    public void Reachable_gateway_does_not_alter_wan_scope()
+    {
+        // Gateway stayed up while the access hop and everything beyond went dark - still a whole-WAN
+        // outage, never Local, and the gateway's presence must not flip FullWan to Upstream.
+        var internet1 = Series(0, (OutStart, OutEnd, 100));
+        var internet2 = Series(0, (OutStart, OutEnd, 100));
+        var gateway = Series(0); // reachable throughout
+        var olt = Series(0, (OutStart, OutEnd, 100));
+
+        var hops = new[]
+        {
+            new OutageDetector.Hop("Gateway", 0, gateway, IsGateway: true),
+            new OutageDetector.Hop("AT&T nokia-olt", 1, olt),
+            new OutageDetector.Hop("Cloudflare", 2, internet1),
+        };
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), hops, Options);
+
+        events.Should().ContainSingle();
+        events[0].Scope.Should().Be(OutageScope.FullWan);
+    }
+
+    [Fact]
     public void Monitoring_gap_with_no_samples_is_not_an_outage()
     {
         // No samples at all during the span (the Monitoring Agent stopped collecting) -


### PR DESCRIPTION
Everything landing in v1.21.5 since v1.21.4. Most of it is a major ISP Health pass (merged via #866); the rest is a LAN Speed Test tweak.

## ISP Health

### Congestion
- **Bottleneck localization** - congestion is attributed to the specific hop that is actually congested, instead of being merged into a time-based blur of networks.
- **Dispositions** - each event says whether it is a confirmed bottleneck, control-plane (ICMP) noise, self-inflicted bufferbloat, or unverifiable, with a plain-language reason.
- **Sibling confirmation** - a dead-end hop (nothing monitored beyond it) is confirmed when a sibling hop on the same network is congested in the same window.
- **Latency and jitter** - the feed reports both, and shows when other monitored paths stayed clean under the same load, so you can tell a single-hop problem from your access link.

### Date/time filter
- The standard Monitoring date/time filter is now on the ISP Health tab (24h / 48h / 7d / 14d / 30d / custom up to one month), defaulting to 48h. The chart and report follow the selected window.
- Longer windows stay fast by coarsening aggregation, and a consistency check keeps the longer view from inventing short burst events the 48h view never sees.

### Outages
- **LAN/gateway outages** are now distinguished from WAN outages. If your own gateway was unreachable, it is surfaced but does not lower the ISP score, since it is not the ISP's fault.
- Each outage's score impact shows on hover.
- Clearer outage wording.

### Speed
- The speed-vs-plan factor reaches back across the whole selected window (with a recent-days floor for short windows), so a long view scores against the best demonstrated capacity in that window.

### Polish
- "Today" labels on events, scaled long-form time units, click-outside to close the date picker, aligned event columns, and Y-axis autoscale on chart zoom.

## LAN Speed Test
- For a client that does not match a known device (e.g. a VPN client), the dashboard panel shows its IP in a code block instead of "Unknown". Known clients still show their name.

## Under the hood
- Suppressed a transitive dependency advisory at the build level (no functional change).