### PR TITLE
Security Audit: more precise DNS leak detection and rule-level findings

### DIFF
--- a/src/NetworkOptimizer.Audit/Dns/DnatDnsAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnatDnsAnalyzer.cs
@@ -61,6 +61,12 @@ public class DnatCoverageResult
     /// Parsed DNAT rules targeting DNS
     /// </summary>
     public List<DnatRuleInfo> Rules { get; } = new();
+
+    /// <summary>
+    /// Maps each contributing DNAT rule name (description, or a placeholder when unnamed)
+    /// to the network names it covers. Used to surface rule-level detail in partial-coverage findings.
+    /// </summary>
+    public Dictionary<string, List<string>> RuleCoverage { get; } = new(StringComparer.OrdinalIgnoreCase);
 }
 
 /// <summary>
@@ -190,6 +196,26 @@ public class DnatDnsAnalyzer
 
         // Track covered networks
         var coveredNetworkIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var networkNameById = allNetworks.ToDictionary(n => n.Id, n => n.Name, StringComparer.OrdinalIgnoreCase);
+
+        // Record that a rule covers a given network, both in the global covered set and the
+        // per-rule map used to surface rule-level detail in partial-coverage findings.
+        void Cover(DnatRuleInfo rule, string networkId)
+        {
+            coveredNetworkIds.Add(networkId);
+
+            if (!networkNameById.TryGetValue(networkId, out var networkName))
+                return;
+
+            var key = !string.IsNullOrWhiteSpace(rule.Description) ? rule.Description! : "(unnamed DNAT rule)";
+            if (!result.RuleCoverage.TryGetValue(key, out var covered))
+            {
+                covered = new List<string>();
+                result.RuleCoverage[key] = covered;
+            }
+            if (!covered.Contains(networkName))
+                covered.Add(networkName);
+        }
 
         foreach (var rule in dnatDnsRules)
         {
@@ -206,14 +232,14 @@ public class DnatDnsAnalyzer
                             {
                                 if (!string.Equals(network.Id, rule.NetworkId, StringComparison.OrdinalIgnoreCase))
                                 {
-                                    coveredNetworkIds.Add(network.Id);
+                                    Cover(rule, network.Id);
                                 }
                             }
                         }
                         else
                         {
                             // Normal: covers only the specified network
-                            coveredNetworkIds.Add(rule.NetworkId);
+                            Cover(rule, rule.NetworkId);
                         }
                     }
                     break;
@@ -222,7 +248,7 @@ public class DnatDnsAnalyzer
                     // in_interface scoping - full coverage for that network
                     if (!string.IsNullOrEmpty(rule.NetworkId))
                     {
-                        coveredNetworkIds.Add(rule.NetworkId);
+                        Cover(rule, rule.NetworkId);
                     }
                     break;
 
@@ -235,7 +261,7 @@ public class DnatDnsAnalyzer
                             if (!string.IsNullOrEmpty(network.Subnet) &&
                                 rule.SubnetCidrs.Any(cidr => CidrCoversSubnet(cidr, network.Subnet)))
                             {
-                                coveredNetworkIds.Add(network.Id);
+                                Cover(rule, network.Id);
                             }
                         }
                     }
@@ -245,7 +271,7 @@ public class DnatDnsAnalyzer
                     // Inverted source address covers all networks (excludes only specific IPs)
                     foreach (var network in allNetworks)
                     {
-                        coveredNetworkIds.Add(network.Id);
+                        Cover(rule, network.Id);
                     }
                     break;
 

--- a/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
@@ -1116,8 +1116,51 @@ public class DnsSecurityAnalyzer
                 var uncovered = networks
                     .Select(n => n.Name)
                     .Where(name => !string.IsNullOrEmpty(name) && !protectedNetworks.Contains(name));
-                (_, _, exposedNetworks) = CategorizeUncoveredNetworks(uncovered, networks, result, zoneLookup);
+                var (dmzExposed, guestExposed, regularExposed) = CategorizeUncoveredNetworks(uncovered, networks, result, zoneLookup);
+                exposedNetworks = regularExposed;
                 shouldFire = exposedNetworks.Any();
+
+                // Parity with the DNAT partial-coverage path: carved-out DMZ / guest-on-third-party-DNS
+                // networks get a courtesy Informational note rather than being silently dropped. Deduped by
+                // type so we don't double up with the third-party-DNS consistency check (which runs earlier
+                // and emits the same finding types when third-party DNS is configured).
+                if (dmzExposed.Any() && !result.Issues.Any(i => i.Type == IssueTypes.DnsDmzNetworkInfo))
+                {
+                    result.Issues.Add(new AuditIssue
+                    {
+                        Type = IssueTypes.DnsDmzNetworkInfo,
+                        Severity = AuditSeverity.Informational,
+                        DeviceName = result.GatewayName,
+                        Message = $"DMZ network(s) ({string.Join(", ", dmzExposed)}) have no DNS leak protection (no firewall port 53 block or DNAT redirect). This is expected for DMZ networks.",
+                        RecommendedAction = "If internal DNS resolution or filtering is desired for DMZ networks, create firewall rules to allow DNS traffic from DMZ to your internal DNS server or gateway.",
+                        RuleId = "DNS-DMZ-001",
+                        ScoreImpact = 0,
+                        Metadata = new Dictionary<string, object>
+                        {
+                            { "dmz_networks", dmzExposed },
+                            { "network_type", "dmz" }
+                        }
+                    });
+                }
+                if (guestExposed.Any() && !result.Issues.Any(i => i.Type == IssueTypes.DnsGuestThirdPartyInfo))
+                {
+                    result.Issues.Add(new AuditIssue
+                    {
+                        Type = IssueTypes.DnsGuestThirdPartyInfo,
+                        Severity = AuditSeverity.Informational,
+                        DeviceName = result.GatewayName,
+                        Message = $"Guest network(s) ({string.Join(", ", guestExposed)}) using third-party LAN DNS have no DNS leak protection (no firewall port 53 block or DNAT redirect).",
+                        RecommendedAction = "If internal DNS resolution or filtering is desired for Guest networks using third-party DNS, create firewall rules to allow DNS traffic from the Guest network to your internal DNS server.",
+                        RuleId = "DNS-GUEST-001",
+                        ScoreImpact = 0,
+                        Metadata = new Dictionary<string, object>
+                        {
+                            { "guest_networks", guestExposed },
+                            { "network_type", "guest" },
+                            { "third_party_dns", result.ThirdPartyDnsProviderName ?? "unknown" }
+                        }
+                    });
+                }
             }
             else
             {

--- a/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
@@ -1212,34 +1212,37 @@ public class DnsSecurityAnalyzer
                 var totalNetworks = result.DnatCoveredNetworks.Count + regularUncoveredNetworks.Count;
                 var coverageRatio = totalNetworks > 0 ? (double)result.DnatCoveredNetworks.Count / totalNetworks : 0;
 
-                // Determine severity based on whether DNS53 blocking is the primary protection
+                // Severity is shaped by absolute block coverage, evaluated PER NETWORK: a DNAT gap on a
+                // network that firewall port 53 blocking already covers can't leak (a strategy gap), but a
+                // gap on a network with neither DNAT nor a port-53 block is genuinely exposed. The global
+                // HasDns53BlockRule flag must not be used here - firewall blocking on Management/Security
+                // says nothing about whether the uncovered Main/IoT networks are protected.
+                var firewallBlockedNetworks = new HashSet<string>(result.Dns53CoveredNetworks, StringComparer.OrdinalIgnoreCase);
+                var exposedNetworks = regularUncoveredNetworks.Where(n => !firewallBlockedNetworks.Contains(n)).ToList();
+                var firewallBackstoppedNetworks = regularUncoveredNetworks.Where(n => firewallBlockedNetworks.Contains(n)).ToList();
+
                 AuditSeverity severity;
                 int scoreImpact;
                 string message;
                 string action;
 
-                if (result.HasDns53BlockRule && result.Dns53ProvidesFullCoverage)
+                if (!exposedNetworks.Any())
                 {
-                    // DNS53 blocking provides full coverage - DNAT partial coverage is just informational
+                    // Every DNAT gap is already blocked at port 53 by the firewall - not exposed, just a
+                    // strategy gap worth noting.
                     severity = AuditSeverity.Informational;
                     scoreImpact = 0;
-                    message = $"DNAT DNS rules don't cover all networks ({string.Join(", ", regularUncoveredNetworks)} not covered). Your firewall already blocks external DNS for all networks, so this is just for your awareness.";
+                    message = $"DNAT DNS rules don't cover all networks ({string.Join(", ", firewallBackstoppedNetworks)} not covered), but firewall port 53 blocking covers them. This is just for your awareness.";
                     action = "If you intend to use DNAT as primary DNS control, add rules for uncovered networks. Otherwise, this can be ignored.";
-                }
-                else if (result.HasDns53BlockRule)
-                {
-                    // DNS53 blocking exists but partial - DNAT partial is lower priority
-                    severity = AuditSeverity.Recommended;
-                    scoreImpact = 3;
-                    message = $"DNAT DNS rules provide partial coverage. Networks without DNAT coverage: {string.Join(", ", regularUncoveredNetworks)}. Firewall port 53 blocking is also present.";
-                    action = "Consider whether you want to use firewall blocking or DNAT as your primary DNS control method, then ensure full coverage for your chosen approach";
                 }
                 else
                 {
-                    // No DNS53 blocking - DNAT is primary protection, partial coverage is significant
+                    // Some networks have neither a DNAT redirect nor a port-53 block - genuinely exposed.
                     severity = coverageRatio >= 2.0 / 3.0 ? AuditSeverity.Recommended : AuditSeverity.Critical;
                     scoreImpact = severity == AuditSeverity.Recommended ? 6 : 10;
-                    message = $"DNAT DNS rules provide partial coverage. Networks without DNAT coverage: {string.Join(", ", regularUncoveredNetworks)}. Devices on these networks can bypass DNS settings.";
+                    message = $"DNAT DNS rules provide partial coverage. Networks without DNAT coverage: {string.Join(", ", exposedNetworks)}. Devices on these networks can bypass DNS settings.";
+                    if (firewallBackstoppedNetworks.Any())
+                        message += $" ({string.Join(", ", firewallBackstoppedNetworks)} are not redirected but are covered by firewall port 53 blocking.)";
                     action = "Add DNAT rules for the remaining networks, create a firewall rule to block outbound UDP port 53, or exclude intentionally uncovered networks in Settings";
                 }
 
@@ -1257,6 +1260,8 @@ public class DnsSecurityAnalyzer
                     {
                         { "covered_networks", result.DnatCoveredNetworks.ToList() },
                         { "uncovered_networks", regularUncoveredNetworks },
+                        { "exposed_networks", exposedNetworks },
+                        { "firewall_backstopped_networks", firewallBackstoppedNetworks },
                         { "dmz_networks_excluded", dmzNetworks },
                         { "guest_networks_excluded", guestNetworksWithThirdPartyDns },
                         { "redirect_target", result.DnatRedirectTarget ?? "" },

--- a/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
@@ -539,9 +539,15 @@ public class DnsSecurityAnalyzer
                 if (targetsExternalZone && FirewallGroupHelper.RuleBlocksPortAndProtocol(rule, "53", "udp"))
                 {
                     result.HasDns53BlockRule = true;
+                    // A rule that specifically targets port 53 (a normal-mode port list, not a blanket
+                    // all-ports block and not an inverted "all except" match) signals an intentional
+                    // DNS-53 blocking strategy. A blanket "block all internet" rule still counts as block
+                    // coverage above, but must not be read as a DNS-53 strategy.
+                    if (!string.IsNullOrEmpty(rule.DestinationPort) && !rule.DestinationMatchOppositePorts)
+                        result.HasDns53BlockStrategy = true;
                     result.Dns53RuleName = name;
-                    _logger.LogDebug("Found DNS53 block rule: {Name} (protocol={Protocol}, opposite={Opposite}, zone={Zone})",
-                        name, protocol, matchOppositeProtocol, destZoneId ?? "any");
+                    _logger.LogDebug("Found DNS53 block rule: {Name} (protocol={Protocol}, opposite={Opposite}, zone={Zone}, dedicatedPort={Dedicated})",
+                        name, protocol, matchOppositeProtocol, destZoneId ?? "any", !string.IsNullOrEmpty(rule.DestinationPort) && !rule.DestinationMatchOppositePorts);
 
                     // Track network coverage for this rule
                     if (networks != null)
@@ -666,6 +672,9 @@ public class DnsSecurityAnalyzer
                     if (legacyAllProtocols || blocksUdp)
                     {
                         result.HasDns53BlockRule = true;
+                        // App-based DNS rules target the DNS app (port 53) specifically, so this is always
+                        // an intentional DNS-53 blocking strategy, not incidental blanket coverage.
+                        result.HasDns53BlockStrategy = true;
                         result.Dns53RuleName ??= name;
                         _logger.LogDebug("Found app-based DNS53 block rule: {Name} (appIds={AppIds}, protocol={Protocol})",
                             name, string.Join(",", appIds!), protocol ?? "all");
@@ -1044,22 +1053,48 @@ public class DnsSecurityAnalyzer
             });
         }
 
-        // Issue: DNS53 firewall rules provide partial coverage (some networks not covered)
-        // This happens when rules use source network restrictions with or without Match Opposite
-        if (result.HasDns53BlockRule && !result.Dns53ProvidesFullCoverage && result.Dns53UncoveredNetworks.Any() && !dnatIsValidAlternative)
+        // Issue: DNS53 firewall blocking *strategy* provides partial coverage (some networks not covered).
+        // Gated on HasDns53BlockStrategy (a dedicated port-53 rule), NOT raw block coverage: a blanket
+        // "block all internet" isolation rule provides block coverage for its networks but doesn't mean
+        // the user runs a DNS-53 blocking strategy, so it must not, on its own, trigger this enforcement.
+        // Reported independently of DNAT (belt-and-suspenders). DNAT only shapes severity here: a network
+        // the block misses but DNAT redirects can't leak, so it softens the finding rather than suppressing it.
+        if (result.HasDns53BlockStrategy && !result.Dns53ProvidesFullCoverage && result.Dns53UncoveredNetworks.Any())
         {
+            var dnatCoveredNetworks = new HashSet<string>(result.DnatCoveredNetworks, StringComparer.OrdinalIgnoreCase);
+            var exposedNetworks = result.Dns53UncoveredNetworks.Where(n => !dnatCoveredNetworks.Contains(n)).ToList();
+            var dnatBackstoppedNetworks = result.Dns53UncoveredNetworks.Where(n => dnatCoveredNetworks.Contains(n)).ToList();
+
             var totalNetworks = result.Dns53CoveredNetworks.Count + result.Dns53UncoveredNetworks.Count;
             var coverageRatio = totalNetworks > 0 ? (double)result.Dns53CoveredNetworks.Count / totalNetworks : 0;
-            // If 2/3 or more networks are covered, use Recommended severity; otherwise Critical
-            var severity = coverageRatio >= 2.0 / 3.0 ? AuditSeverity.Recommended : AuditSeverity.Critical;
-            var scoreImpact = severity == AuditSeverity.Recommended ? 6 : 10;
+
+            AuditSeverity severity;
+            int scoreImpact;
+            string message;
+            if (exposedNetworks.Any())
+            {
+                // Networks with neither a port-53 block nor a DNAT redirect can leak DNS.
+                // If 2/3 or more networks are covered, use Recommended severity; otherwise Critical.
+                severity = coverageRatio >= 2.0 / 3.0 ? AuditSeverity.Recommended : AuditSeverity.Critical;
+                scoreImpact = severity == AuditSeverity.Recommended ? 6 : 10;
+                message = $"DNS port 53 blocking rules provide partial network coverage. Uncovered networks: {string.Join(", ", exposedNetworks)}. Devices on these networks can bypass DNS settings.";
+                if (dnatBackstoppedNetworks.Any())
+                    message += $" ({string.Join(", ", dnatBackstoppedNetworks)} are not blocked but are covered by DNAT redirection.)";
+            }
+            else
+            {
+                // Every network the block misses is redirected by DNAT - not exposed, just a strategy gap.
+                severity = AuditSeverity.Informational;
+                scoreImpact = 0;
+                message = $"DNS port 53 blocking rules don't cover all networks ({string.Join(", ", dnatBackstoppedNetworks)} not blocked), but DNAT redirection covers them. This is just for your awareness.";
+            }
 
             result.Issues.Add(new AuditIssue
             {
                 Type = IssueTypes.Dns53PartialCoverage,
                 Severity = severity,
                 DeviceName = result.GatewayName,
-                Message = $"DNS port 53 blocking rules provide partial network coverage. Uncovered networks: {string.Join(", ", result.Dns53UncoveredNetworks)}. Devices on these networks can bypass DNS settings.",
+                Message = message,
                 RecommendedAction = "Update firewall rules to cover all networks, or create separate rules for uncovered networks, or configure DNAT rules as an alternative.",
                 RuleId = "DNS-LEAK-002",
                 ScoreImpact = scoreImpact,
@@ -1068,6 +1103,8 @@ public class DnsSecurityAnalyzer
                 {
                     { "covered_networks", result.Dns53CoveredNetworks },
                     { "uncovered_networks", result.Dns53UncoveredNetworks },
+                    { "exposed_networks", exposedNetworks },
+                    { "dnat_backstopped_networks", dnatBackstoppedNetworks },
                     { "coverage_ratio", coverageRatio }
                 }
             });
@@ -2835,7 +2872,20 @@ public class DnsSecurityResult
     public string? ExpectedDnsProvider { get; set; }
 
     // Firewall Rules
+    /// <summary>
+    /// Absolute block-coverage fact: at least one enabled firewall rule blocks external port 53 for
+    /// some network. Includes incidental coverage from blanket "block all internet" isolation rules.
+    /// Use this to reason about whether a network can actually leak DNS.
+    /// </summary>
     public bool HasDns53BlockRule { get; set; }
+    /// <summary>
+    /// Strategy detection: a *dedicated* DNS port-53 block rule exists (a rule that specifically targets
+    /// port 53), indicating the user intentionally runs DNS-53 firewall blocking. A blanket "block all
+    /// internet" rule sets HasDns53BlockRule (block coverage) but NOT this flag. Drives the application
+    /// and severity of the DNS-53 partial-coverage finding so incidental isolation rules don't fabricate
+    /// a blocking strategy that isn't there.
+    /// </summary>
+    public bool HasDns53BlockStrategy { get; set; }
     public string? Dns53RuleName { get; set; }
     public bool HasDotBlockRule { get; set; }
     public string? DotRuleName { get; set; }

--- a/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
@@ -818,6 +818,60 @@ public class DnsSecurityAnalyzer
             .ToList();
     }
 
+    /// <summary>
+    /// Categorize a set of uncovered network names into DMZ, Guest-with-third-party-DNS, and regular
+    /// buckets, dropping any network the user intentionally excluded from coverage checks. Shared by the
+    /// DNAT partial-coverage finding and the no-protection finding so carve-out handling stays consistent.
+    /// </summary>
+    private static (List<string> Dmz, List<string> GuestThirdParty, List<string> Regular) CategorizeUncoveredNetworks(
+        IEnumerable<string> uncoveredNetworkNames,
+        List<NetworkInfo>? networks,
+        DnsSecurityResult result,
+        Services.FirewallZoneLookup? zoneLookup)
+    {
+        var networksByName = networks?
+            .Where(n => !string.IsNullOrEmpty(n.Name))
+            .ToDictionary(n => n.Name, n => n, StringComparer.OrdinalIgnoreCase)
+            ?? new Dictionary<string, NetworkInfo>(StringComparer.OrdinalIgnoreCase);
+        var excluded = new HashSet<string>(result.ExcludedFromCoverageNetworks, StringComparer.OrdinalIgnoreCase);
+
+        var dmz = new List<string>();
+        var guestThirdParty = new List<string>();
+        var regular = new List<string>();
+
+        foreach (var networkName in uncoveredNetworkNames)
+        {
+            // Intentionally excluded from coverage checks - never report as uncovered/exposed
+            if (excluded.Contains(networkName))
+                continue;
+
+            if (networksByName.TryGetValue(networkName, out var network))
+            {
+                // Check if this is a DMZ network (by firewall zone)
+                var isDmz = zoneLookup?.IsDmzZone(network.FirewallZoneId) ?? false;
+
+                // Check if this is a Guest network with 3rd party LAN DNS
+                // Guest networks are identified by IsUniFiGuestNetwork or Purpose == Guest
+                var isGuest = network.IsUniFiGuestNetwork || network.Purpose == NetworkPurpose.Guest;
+                var hasThirdPartyLanDns = result.HasThirdPartyDns && result.IsSiteWideThirdPartyDns;
+
+                if (isDmz)
+                    dmz.Add(networkName);
+                else if (isGuest && hasThirdPartyLanDns)
+                    guestThirdParty.Add(networkName);
+                else
+                    regular.Add(networkName);
+            }
+            else
+            {
+                // Network not found in lookup - treat as regular
+                regular.Add(networkName);
+            }
+        }
+
+        return (dmz, guestThirdParty, regular);
+    }
+
     private static string GetCorrectDnsOrder(List<string> servers, List<string?> ptrResults)
     {
         // Pair IPs with their PTR results and sort by dns1 first, dns2 second
@@ -1031,26 +1085,62 @@ public class DnsSecurityAnalyzer
             && result.DnatRedirectTargetIsValid
             && result.DnatDestinationFilterIsValid;
 
-        // Partial DNAT coverage is better than nothing - don't double-penalize
-        // The partial coverage issue (6 pts) is more actionable than the generic no-block issue (12 pts)
-        var hasPartialDnatCoverage = result.HasDnatDnsRules
-            && !result.DnatProvidesFullCoverage
-            && hasDnsControlSolution
-            && result.DnatRedirectTargetIsValid
-            && result.DnatDestinationFilterIsValid;
-
-        if (!result.HasDns53BlockRule && !dnatIsValidAlternative && !hasPartialDnatCoverage)
+        // Issue: networks with NO DNS leak protection (catch-all exposure).
+        // Fires only when neither a dedicated DNS-53 blocking strategy nor DNAT rules are in play - the
+        // strategy-specific findings own those cases and report their own gaps (belt-and-suspenders).
+        // Exposure is computed from ABSOLUTE block coverage: a blanket "block all internet" rule counts as
+        // a port-53 block, so a network is exposed only when it has neither a port-53 block nor a DNAT
+        // redirect. Without this, blanket isolation rules set HasDns53BlockRule=true and silently
+        // suppressed the no-block finding while no strategy reported the genuinely exposed networks - so
+        // removing all DNS protection paradoxically improved the score.
+        if (!result.HasDns53BlockStrategy && !result.HasDnatDnsRules)
         {
-            result.Issues.Add(new AuditIssue
+            // A network is exposed when it has neither a port-53 block nor a DNAT redirect. Compute from the
+            // full network list, not Dns53UncoveredNetworks - that set is only populated when a block rule
+            // exists, so it's empty in the "nothing blocks anything" case even though every network leaks.
+            var exposedNetworks = new List<string>();
+            bool shouldFire;
+            if (networks != null && networks.Count > 0)
             {
-                Type = IssueTypes.DnsNo53Block,
-                Severity = AuditSeverity.Critical,
-                DeviceName = result.GatewayName,
-                Message = "No firewall rule blocks external DNS (port 53). Devices can bypass network DNS settings and leak queries to untrusted servers.",
-                RecommendedAction = "Create firewall rule: Block outbound UDP port 53 to Internet for all VLANs (except gateway), or configure DNAT rules to redirect DNS traffic.",
-                RuleId = "DNS-LEAK-001",
-                ScoreImpact = 12
-            });
+                var protectedNetworks = new HashSet<string>(result.Dns53CoveredNetworks, StringComparer.OrdinalIgnoreCase);
+                protectedNetworks.UnionWith(result.DnatCoveredNetworks);
+                var uncovered = networks
+                    .Select(n => n.Name)
+                    .Where(name => !string.IsNullOrEmpty(name) && !protectedNetworks.Contains(name));
+                (_, _, exposedNetworks) = CategorizeUncoveredNetworks(uncovered, networks, result, zoneLookup);
+                shouldFire = exposedNetworks.Any();
+            }
+            else
+            {
+                // No network list to enumerate - fall back to the absolute signal: if nothing blocks port 53
+                // anywhere, every network can leak.
+                shouldFire = !result.HasDns53BlockRule;
+            }
+
+            if (shouldFire)
+            {
+                // Name the exposed networks when a partial block exists; otherwise nothing is blocked
+                // anywhere and the generic wording applies.
+                var message = exposedNetworks.Any() && result.HasDns53BlockRule
+                    ? $"Networks with no DNS leak protection: {string.Join(", ", exposedNetworks)}. These networks have no firewall port 53 block and no DNAT redirect, so devices on them can bypass network DNS settings and leak queries to untrusted servers."
+                    : "No firewall rule blocks external DNS (port 53). Devices can bypass network DNS settings and leak queries to untrusted servers.";
+
+                result.Issues.Add(new AuditIssue
+                {
+                    Type = IssueTypes.DnsNo53Block,
+                    Severity = AuditSeverity.Critical,
+                    DeviceName = result.GatewayName,
+                    Message = message,
+                    RecommendedAction = "Create firewall rule: Block outbound UDP port 53 to Internet for all VLANs (except gateway), or configure DNAT rules to redirect DNS traffic.",
+                    RuleId = "DNS-LEAK-001",
+                    ScoreImpact = 12,
+                    Metadata = new Dictionary<string, object>
+                    {
+                        { "exposed_networks", exposedNetworks },
+                        { "block_covered_networks", result.Dns53CoveredNetworks }
+                    }
+                });
+            }
         }
 
         // Issue: DNS53 firewall blocking *strategy* provides partial coverage (some networks not covered).
@@ -1122,48 +1212,9 @@ public class DnsSecurityAnalyzer
         // Special handling for DMZ and Guest networks - they get Info issues instead of Recommended/Critical
         if (result.HasDnatDnsRules && !result.DnatProvidesFullCoverage && result.DnatUncoveredNetworks.Any())
         {
-            // Build lookup of network name -> NetworkInfo for zone identification
-            var networksByName = networks?
-                .Where(n => !string.IsNullOrEmpty(n.Name))
-                .ToDictionary(n => n.Name, n => n, StringComparer.OrdinalIgnoreCase)
-                ?? new Dictionary<string, NetworkInfo>(StringComparer.OrdinalIgnoreCase);
-
             // Separate DMZ and Guest networks with 3rd party LAN DNS from regular uncovered networks
-            var dmzNetworks = new List<string>();
-            var guestNetworksWithThirdPartyDns = new List<string>();
-            var regularUncoveredNetworks = new List<string>();
-
-            foreach (var networkName in result.DnatUncoveredNetworks)
-            {
-                if (networksByName.TryGetValue(networkName, out var network))
-                {
-                    // Check if this is a DMZ network (by firewall zone)
-                    var isDmz = zoneLookup?.IsDmzZone(network.FirewallZoneId) ?? false;
-
-                    // Check if this is a Guest network with 3rd party LAN DNS
-                    // Guest networks are identified by IsUniFiGuestNetwork or Purpose == Guest
-                    var isGuest = network.IsUniFiGuestNetwork || network.Purpose == NetworkPurpose.Guest;
-                    var hasThirdPartyLanDns = result.HasThirdPartyDns && result.IsSiteWideThirdPartyDns;
-
-                    if (isDmz)
-                    {
-                        dmzNetworks.Add(networkName);
-                    }
-                    else if (isGuest && hasThirdPartyLanDns)
-                    {
-                        guestNetworksWithThirdPartyDns.Add(networkName);
-                    }
-                    else
-                    {
-                        regularUncoveredNetworks.Add(networkName);
-                    }
-                }
-                else
-                {
-                    // Network not found in lookup - treat as regular
-                    regularUncoveredNetworks.Add(networkName);
-                }
-            }
+            var (dmzNetworks, guestNetworksWithThirdPartyDns, regularUncoveredNetworks) =
+                CategorizeUncoveredNetworks(result.DnatUncoveredNetworks, networks, result, zoneLookup);
 
             // Create Info issue for DMZ networks that need firewall rules for internal DNS
             if (dmzNetworks.Any())
@@ -2565,6 +2616,7 @@ public class DnsSecurityAnalyzer
         result.DnatCoveredNetworks.AddRange(coverageResult.CoveredNetworkNames);
         result.DnatUncoveredNetworks.AddRange(coverageResult.UncoveredNetworkNames);
         result.DnatSingleIpRules.AddRange(coverageResult.SingleIpRules);
+        result.ExcludedFromCoverageNetworks.AddRange(coverageResult.ExcludedNetworkNames);
         foreach (var kvp in coverageResult.RuleCoverage)
             result.DnatRuleCoverage[kvp.Key] = kvp.Value;
 
@@ -2978,6 +3030,11 @@ public class DnsSecurityResult
     public List<string> DnatSingleIpRules { get; } = new();
     /// <summary>Maps each contributing DNAT DNS rule name to the network names it covers</summary>
     public Dictionary<string, List<string>> DnatRuleCoverage { get; } = new(StringComparer.OrdinalIgnoreCase);
+    /// <summary>
+    /// Networks the user intentionally excluded from DNS coverage checks (Audit Settings → excluded VLANs).
+    /// These are carved out of all DNS coverage findings so an excluded VLAN never reads as exposed.
+    /// </summary>
+    public List<string> ExcludedFromCoverageNetworks { get; } = new();
 
     // DNAT Redirect Destination Validation
     public bool DnatRedirectTargetIsValid { get; set; } = true;

--- a/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
@@ -138,6 +138,15 @@ public class DnsSecurityAnalyzer
             await AnalyzeThirdPartyDnsAsync(networks, result, customDnsManagementPort, zoneLookup, customDnsManagementUrl);
         }
 
+        // Capture networks the user excluded from coverage checks up front, independent of NAT data, so the
+        // carve-out applies to every DNS coverage finding even when no NAT rules are supplied.
+        if (dnatExcludedVlanIds != null && dnatExcludedVlanIds.Count > 0 && networks != null)
+        {
+            var excludedVlanSet = dnatExcludedVlanIds.ToHashSet();
+            result.ExcludedFromCoverageNetworks.AddRange(
+                networks.Where(n => excludedVlanSet.Contains(n.VlanId) && !string.IsNullOrEmpty(n.Name)).Select(n => n.Name));
+        }
+
         // Analyze DNAT DNS rules (alternative to firewall blocking)
         if (natRulesData.HasValue && networks?.Any() == true)
         {
@@ -1119,6 +1128,14 @@ public class DnsSecurityAnalyzer
 
             if (shouldFire)
             {
+                // Scale severity to how much is exposed, consistent with the two partial-coverage findings
+                // (so the score moves monotonically with protection). When the whole network list is exposed
+                // - or unavailable - this is the "no DNS protection at all" case, which stays Critical.
+                var totalNetworks = networks?.Count ?? 0;
+                var coverageRatio = totalNetworks > 0 ? (double)(totalNetworks - exposedNetworks.Count) / totalNetworks : 0;
+                var severity = coverageRatio >= 2.0 / 3.0 ? AuditSeverity.Recommended : AuditSeverity.Critical;
+                var scoreImpact = severity == AuditSeverity.Recommended ? 6 : 10;
+
                 // Name the exposed networks when a partial block exists; otherwise nothing is blocked
                 // anywhere and the generic wording applies.
                 var message = exposedNetworks.Any() && result.HasDns53BlockRule
@@ -1128,16 +1145,17 @@ public class DnsSecurityAnalyzer
                 result.Issues.Add(new AuditIssue
                 {
                     Type = IssueTypes.DnsNo53Block,
-                    Severity = AuditSeverity.Critical,
+                    Severity = severity,
                     DeviceName = result.GatewayName,
                     Message = message,
                     RecommendedAction = "Create firewall rule: Block outbound UDP port 53 to Internet for all VLANs (except gateway), or configure DNAT rules to redirect DNS traffic.",
                     RuleId = "DNS-LEAK-001",
-                    ScoreImpact = 12,
+                    ScoreImpact = scoreImpact,
                     Metadata = new Dictionary<string, object>
                     {
                         { "exposed_networks", exposedNetworks },
-                        { "block_covered_networks", result.Dns53CoveredNetworks }
+                        { "block_covered_networks", result.Dns53CoveredNetworks },
+                        { "coverage_ratio", coverageRatio }
                     }
                 });
             }
@@ -1286,9 +1304,20 @@ public class DnsSecurityAnalyzer
                     message = $"DNAT DNS rules don't cover all networks ({string.Join(", ", firewallBackstoppedNetworks)} not covered), but firewall port 53 blocking covers them. This is just for your awareness.";
                     action = "If you intend to use DNAT as primary DNS control, add rules for uncovered networks. Otherwise, this can be ignored.";
                 }
+                else if (result.HasDns53BlockStrategy && !result.Dns53ProvidesFullCoverage)
+                {
+                    // A dedicated DNS-53 blocking strategy is also in play, and its partial-coverage finding
+                    // already scores these exposed networks. Report the DNAT gap for visibility
+                    // (belt-and-suspenders) but don't double-deduct - the exposure is scored once, there.
+                    severity = AuditSeverity.Informational;
+                    scoreImpact = 0;
+                    message = $"DNAT DNS rules don't cover {string.Join(", ", exposedNetworks)}. These networks are also flagged as exposed by your firewall DNS-53 coverage (scored there); this notes the DNAT gap.";
+                    action = "Add DNAT rules for these networks, or extend the firewall port 53 block to cover them.";
+                }
                 else
                 {
-                    // Some networks have neither a DNAT redirect nor a port-53 block - genuinely exposed.
+                    // Some networks have neither a DNAT redirect nor a port-53 block - genuinely exposed,
+                    // and DNAT is the only DNS-control strategy in play, so this finding owns the score.
                     severity = coverageRatio >= 2.0 / 3.0 ? AuditSeverity.Recommended : AuditSeverity.Critical;
                     scoreImpact = severity == AuditSeverity.Recommended ? 6 : 10;
                     message = $"DNAT DNS rules provide partial coverage. Networks without DNAT coverage: {string.Join(", ", exposedNetworks)}. Devices on these networks can bypass DNS settings.";
@@ -2616,7 +2645,6 @@ public class DnsSecurityAnalyzer
         result.DnatCoveredNetworks.AddRange(coverageResult.CoveredNetworkNames);
         result.DnatUncoveredNetworks.AddRange(coverageResult.UncoveredNetworkNames);
         result.DnatSingleIpRules.AddRange(coverageResult.SingleIpRules);
-        result.ExcludedFromCoverageNetworks.AddRange(coverageResult.ExcludedNetworkNames);
         foreach (var kvp in coverageResult.RuleCoverage)
             result.DnatRuleCoverage[kvp.Key] = kvp.Value;
 

--- a/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Dns/DnsSecurityAnalyzer.cs
@@ -546,7 +546,7 @@ public class DnsSecurityAnalyzer
                     // Track network coverage for this rule
                     if (networks != null)
                     {
-                        AddCoveredNetworks(networks, rule, result.Dns53CoveredNetworkIds);
+                        AddCoveredNetworks(networks, rule, result.Dns53CoveredNetworkIds, result.Dns53RuleCoverage, name);
                     }
                 }
 
@@ -560,7 +560,7 @@ public class DnsSecurityAnalyzer
                         name, protocol, matchOppositeProtocol, destZoneId ?? "any");
 
                     if (networks != null)
-                        AddCoveredNetworks(networks, rule, result.DotCoveredNetworkIds);
+                        AddCoveredNetworks(networks, rule, result.DotCoveredNetworkIds, result.DotRuleCoverage, name);
                 }
 
                 // Check for DNS over QUIC (port 853 UDP) blocking (RFC 9250)
@@ -572,7 +572,7 @@ public class DnsSecurityAnalyzer
                         name, protocol, matchOppositeProtocol, destZoneId ?? "any");
 
                     if (networks != null)
-                        AddCoveredNetworks(networks, rule, result.DoqCoveredNetworkIds);
+                        AddCoveredNetworks(networks, rule, result.DoqCoveredNetworkIds, result.DoqRuleCoverage, name);
                 }
             }
 
@@ -673,7 +673,7 @@ public class DnsSecurityAnalyzer
                         // Track network coverage
                         if (networks != null)
                         {
-                            AddCoveredNetworks(networks, rule, result.Dns53CoveredNetworkIds);
+                            AddCoveredNetworks(networks, rule, result.Dns53CoveredNetworkIds, result.Dns53RuleCoverage, name);
                         }
                     }
                 }
@@ -689,7 +689,7 @@ public class DnsSecurityAnalyzer
                             name, string.Join(",", appIds!), protocol ?? "all");
 
                         if (networks != null)
-                            AddCoveredNetworks(networks, rule, result.DotCoveredNetworkIds);
+                            AddCoveredNetworks(networks, rule, result.DotCoveredNetworkIds, result.DotRuleCoverage, name);
                     }
                     if (legacyAllProtocols || blocksUdp)
                     {
@@ -699,7 +699,7 @@ public class DnsSecurityAnalyzer
                             name, string.Join(",", appIds!), protocol ?? "all");
 
                         if (networks != null)
-                            AddCoveredNetworks(networks, rule, result.DoqCoveredNetworkIds);
+                            AddCoveredNetworks(networks, rule, result.DoqCoveredNetworkIds, result.DoqRuleCoverage, name);
                     }
                 }
 
@@ -743,12 +743,28 @@ public class DnsSecurityAnalyzer
     private static void AddCoveredNetworks(
         List<NetworkInfo> networks,
         FirewallRule rule,
-        HashSet<string> coveredNetworkIds)
+        HashSet<string> coveredNetworkIds,
+        Dictionary<string, List<string>>? ruleCoverage = null,
+        string? ruleName = null)
     {
         foreach (var network in networks)
         {
-            if (rule.AppliesToSourceNetwork(network))
-                coveredNetworkIds.Add(network.Id);
+            if (!rule.AppliesToSourceNetwork(network))
+                continue;
+
+            coveredNetworkIds.Add(network.Id);
+
+            if (ruleCoverage != null)
+            {
+                var key = string.IsNullOrWhiteSpace(ruleName) ? "(unnamed rule)" : ruleName;
+                if (!ruleCoverage.TryGetValue(key, out var covered))
+                {
+                    covered = new List<string>();
+                    ruleCoverage[key] = covered;
+                }
+                if (!covered.Contains(network.Name))
+                    covered.Add(network.Name);
+            }
         }
     }
 
@@ -776,6 +792,21 @@ public class DnsSecurityAnalyzer
         }
 
         return fullCoverage;
+    }
+
+    /// <summary>
+    /// Convert a rule-name -> covered-network-names map into the CoveringRuleInfo list
+    /// attached to a partial-coverage finding. Returns null when no rules contributed,
+    /// so the UI only renders the detail when there's something to show.
+    /// </summary>
+    private static List<CoveringRuleInfo>? BuildCoveringRules(Dictionary<string, List<string>> ruleCoverage)
+    {
+        if (ruleCoverage.Count == 0)
+            return null;
+
+        return ruleCoverage
+            .Select(kvp => new CoveringRuleInfo { RuleName = kvp.Key, CoveredNetworks = kvp.Value })
+            .ToList();
     }
 
     private static string GetCorrectDnsOrder(List<string> servers, List<string?> ptrResults)
@@ -1032,6 +1063,7 @@ public class DnsSecurityAnalyzer
                 RecommendedAction = "Update firewall rules to cover all networks, or create separate rules for uncovered networks, or configure DNAT rules as an alternative.",
                 RuleId = "DNS-LEAK-002",
                 ScoreImpact = scoreImpact,
+                CoveringRules = BuildCoveringRules(result.Dns53RuleCoverage),
                 Metadata = new Dictionary<string, object>
                 {
                     { "covered_networks", result.Dns53CoveredNetworks },
@@ -1183,6 +1215,7 @@ public class DnsSecurityAnalyzer
                     RecommendedAction = action,
                     RuleId = "DNS-DNAT-001",
                     ScoreImpact = scoreImpact,
+                    CoveringRules = BuildCoveringRules(result.DnatRuleCoverage),
                     Metadata = new Dictionary<string, object>
                     {
                         { "covered_networks", result.DnatCoveredNetworks.ToList() },
@@ -1284,7 +1317,8 @@ public class DnsSecurityAnalyzer
                 Message = $"DNS-over-TLS (port 853) blocking has partial coverage. Uncovered networks: {string.Join(", ", result.DotUncoveredNetworks)}",
                 RecommendedAction = "Extend DoT blocking rule to cover all networks, or create additional rules for uncovered networks.",
                 RuleId = "DNS-LEAK-002",
-                ScoreImpact = 4
+                ScoreImpact = 4,
+                CoveringRules = BuildCoveringRules(result.DotRuleCoverage)
             });
         }
 
@@ -1331,7 +1365,8 @@ public class DnsSecurityAnalyzer
                 Message = $"DNS over QUIC (DoQ) blocking has partial coverage. Uncovered networks: {string.Join(", ", result.DoqUncoveredNetworks)}",
                 RecommendedAction = "Extend DoQ blocking rule to cover all networks, or create additional rules for uncovered networks.",
                 RuleId = "DNS-LEAK-004",
-                ScoreImpact = 3
+                ScoreImpact = 3,
+                CoveringRules = BuildCoveringRules(result.DoqRuleCoverage)
             });
         }
 
@@ -2488,6 +2523,8 @@ public class DnsSecurityAnalyzer
         result.DnatCoveredNetworks.AddRange(coverageResult.CoveredNetworkNames);
         result.DnatUncoveredNetworks.AddRange(coverageResult.UncoveredNetworkNames);
         result.DnatSingleIpRules.AddRange(coverageResult.SingleIpRules);
+        foreach (var kvp in coverageResult.RuleCoverage)
+            result.DnatRuleCoverage[kvp.Key] = kvp.Value;
 
         if (coverageResult.HasDnatDnsRules)
         {
@@ -2819,6 +2856,8 @@ public class DnsSecurityResult
     public List<string> Dns53CoveredNetworks { get; } = new();
     /// <summary>Network names not covered by any DNS53 blocking rule</summary>
     public List<string> Dns53UncoveredNetworks { get; } = new();
+    /// <summary>Maps each contributing DNS53 blocking rule name to the network names it covers</summary>
+    public Dictionary<string, List<string>> Dns53RuleCoverage { get; } = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>DoT (port 853/TCP) firewall rule network coverage</summary>
     public bool DotProvidesFullCoverage { get; set; }
@@ -2828,6 +2867,8 @@ public class DnsSecurityResult
     public List<string> DotCoveredNetworks { get; } = new();
     /// <summary>Network names not covered by any DoT blocking rule</summary>
     public List<string> DotUncoveredNetworks { get; } = new();
+    /// <summary>Maps each contributing DoT blocking rule name to the network names it covers</summary>
+    public Dictionary<string, List<string>> DotRuleCoverage { get; } = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>DoQ (port 853/UDP) firewall rule network coverage</summary>
     public bool DoqProvidesFullCoverage { get; set; }
@@ -2837,6 +2878,8 @@ public class DnsSecurityResult
     public List<string> DoqCoveredNetworks { get; } = new();
     /// <summary>Network names not covered by any DoQ blocking rule</summary>
     public List<string> DoqUncoveredNetworks { get; } = new();
+    /// <summary>Maps each contributing DoQ blocking rule name to the network names it covers</summary>
+    public Dictionary<string, List<string>> DoqRuleCoverage { get; } = new(StringComparer.OrdinalIgnoreCase);
 
     // Device DNS Configuration
     public bool DeviceDnsPointsToGateway { get; set; } = true;
@@ -2878,6 +2921,8 @@ public class DnsSecurityResult
     public List<string> DnatCoveredNetworks { get; } = new();
     public List<string> DnatUncoveredNetworks { get; } = new();
     public List<string> DnatSingleIpRules { get; } = new();
+    /// <summary>Maps each contributing DNAT DNS rule name to the network names it covers</summary>
+    public Dictionary<string, List<string>> DnatRuleCoverage { get; } = new(StringComparer.OrdinalIgnoreCase);
 
     // DNAT Redirect Destination Validation
     public bool DnatRedirectTargetIsValid { get; set; } = true;

--- a/src/NetworkOptimizer.Audit/Models/AuditIssue.cs
+++ b/src/NetworkOptimizer.Audit/Models/AuditIssue.cs
@@ -110,4 +110,28 @@ public class AuditIssue
     /// Whether this issue is for a wireless client
     /// </summary>
     public bool IsWireless { get; init; }
+
+    /// <summary>
+    /// Firewall or DNAT rules that contribute the partial coverage behind this finding,
+    /// along with the networks each rule covers. Surfaced in the UI so users can see
+    /// exactly which rules drive a "partial coverage" DNS finding.
+    /// </summary>
+    public IReadOnlyList<CoveringRuleInfo>? CoveringRules { get; init; }
+}
+
+/// <summary>
+/// A single firewall or DNAT rule that provides partial coverage for a DNS finding,
+/// paired with the networks it covers.
+/// </summary>
+public class CoveringRuleInfo
+{
+    /// <summary>
+    /// Display name of the rule (firewall rule name or DNAT rule description).
+    /// </summary>
+    public required string RuleName { get; init; }
+
+    /// <summary>
+    /// Names of the networks this rule covers.
+    /// </summary>
+    public IReadOnlyList<string> CoveredNetworks { get; init; } = new List<string>();
 }

--- a/src/NetworkOptimizer.Web/Components/Pages/Audit.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Audit.razor
@@ -219,6 +219,10 @@
                                         {
                                             <span class="context-item"><strong>Network:</strong> @issue.CurrentNetwork@(issue.CurrentVlan.HasValue ? $" (VLAN {issue.CurrentVlan})" : "")</span>
                                         }
+                                        @if (issue.CoveringRules?.Count > 0)
+                                        {
+                                            <span class="context-item"><strong>Rules:</strong> @FormatCoveringRules(issue.CoveringRules)</span>
+                                        }
                                     </div>
                                 }
                                 </div>
@@ -310,6 +314,10 @@
                                                 @if (!string.IsNullOrEmpty(issue.CurrentNetwork))
                                                 {
                                                     <span class="context-item"><strong>Network:</strong> @issue.CurrentNetwork@(issue.CurrentVlan.HasValue ? $" (VLAN {issue.CurrentVlan})" : "")</span>
+                                                }
+                                                @if (issue.CoveringRules?.Count > 0)
+                                                {
+                                                    <span class="context-item"><strong>Rules:</strong> @FormatCoveringRules(issue.CoveringRules)</span>
                                                 }
                                             </div>
                                         }
@@ -407,6 +415,10 @@
                                                                 @if (!string.IsNullOrEmpty(issue.CurrentNetwork))
                                                                 {
                                                                     <span class="context-item"><strong>Network:</strong> @issue.CurrentNetwork@(issue.CurrentVlan.HasValue ? $" (VLAN {issue.CurrentVlan})" : "")</span>
+                                                                }
+                                                                @if (issue.CoveringRules?.Count > 0)
+                                                                {
+                                                                    <span class="context-item"><strong>Rules:</strong> @FormatCoveringRules(issue.CoveringRules)</span>
                                                                 }
                                                                 <button class="btn btn-sm btn-ghost issue-action" @onclick="() => DismissIssue(issue)" @onclick:stopPropagation="true" title="Dismiss this issue">
                                                                     Dismiss
@@ -864,6 +876,14 @@
 </div>
 
 @code {
+    private static string FormatCoveringRules(IReadOnlyList<CoveringRuleInfo> rules)
+    {
+        return string.Join("; ", rules.Select(r =>
+            r.CoveredNetworks.Count > 0
+                ? $"{r.RuleName} (covers {string.Join(", ", r.CoveredNetworks)})"
+                : r.RuleName));
+    }
+
     private bool isRunning = false;
     private bool hasResults = false;
     private string currentStep = "";

--- a/src/NetworkOptimizer.Web/Services/AuditService.cs
+++ b/src/NetworkOptimizer.Web/Services/AuditService.cs
@@ -1556,7 +1556,9 @@ public class AuditService
                 AccessPoint = issue.AccessPoint,
                 WifiBand = issue.WifiBand,
                 // Settings link
-                ConfigurableSetting = configurableSetting
+                ConfigurableSetting = configurableSetting,
+                // Rule-level detail for partial-coverage findings
+                CoveringRules = issue.CoveringRules
             });
         }
 
@@ -2205,6 +2207,12 @@ public class AuditIssue
     /// If set, UI shows a link to configure this setting
     /// </summary>
     public string? ConfigurableSetting { get; set; }
+
+    /// <summary>
+    /// Firewall/DNAT rules contributing partial coverage for this finding (with covered networks).
+    /// Surfaced as a "Rules:" context line so users can see which rules drive the finding.
+    /// </summary>
+    public IReadOnlyList<AuditModels.CoveringRuleInfo>? CoveringRules { get; set; }
 }
 
 public class AuditSummary

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/DnatDnsAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/DnatDnsAnalyzerTests.cs
@@ -167,6 +167,10 @@ public class DnatDnsAnalyzerTests
         Assert.Contains("net1", result.CoveredNetworkIds);
         Assert.Single(result.UncoveredNetworkIds);
         Assert.Contains("net2", result.UncoveredNetworkIds);
+
+        // Per-rule coverage maps the rule's description to the network names it covers
+        Assert.True(result.RuleCoverage.ContainsKey("Test DNAT"));
+        Assert.Equal(new[] { "LAN" }, result.RuleCoverage["Test DNAT"]);
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
@@ -6068,6 +6068,45 @@ public class DnsSecurityAnalyzerTests : IDisposable
     }
 
     [Fact]
+    public async Task Analyze_CatchAll_DmzNetworkUncovered_GetsInfoParity()
+    {
+        // Parity with the DNAT path: in the no-strategy, no-DNAT exposure path, a carved-out DMZ network
+        // gets a courtesy Informational note instead of being silently dropped, while a regular network is
+        // flagged as exposed.
+        var dmzZoneId = "zone-dmz-001";
+        var zones = new List<UniFiFirewallZone>
+        {
+            new() { Id = "zone-internal-001", ZoneKey = "internal", Name = "Internal" },
+            new() { Id = dmzZoneId, ZoneKey = "dmz", Name = "DMZ" }
+        };
+        var zoneLookup = new FirewallZoneLookup(zones);
+
+        var networks = new List<NetworkInfo>
+        {
+            new NetworkInfo { Id = "net1", Name = "LAN", VlanId = 1, Subnet = "192.168.1.0/24", DhcpEnabled = true, Gateway = "192.168.1.1", DnsServers = new List<string> { "192.168.1.1" }, FirewallZoneId = "zone-internal-001" },
+            new NetworkInfo { Id = "net2", Name = "DMZ Servers", VlanId = 100, Subnet = "192.168.100.0/24", DhcpEnabled = true, Gateway = "192.168.100.1", DnsServers = new List<string> { "192.168.100.1" }, FirewallZoneId = dmzZoneId }
+        };
+
+        // No firewall, no NAT, no third-party DNS (so the consistency check doesn't emit the DMZ note)
+        var result = await _analyzer.AnalyzeAsync(
+            settingsData: null, firewallRules: null, switches: null, networks: networks,
+            deviceData: null, customDnsManagementPort: null, natRulesData: null,
+            dnatExcludedVlanIds: null, externalZoneId: null, zoneLookup: zoneLookup);
+
+        result.HasThirdPartyDns.Should().BeFalse();
+
+        // Regular network drives the exposure finding
+        result.Issues.Should().ContainSingle(i => i.Type == IssueTypes.DnsNo53Block);
+
+        // DMZ network gets the courtesy Info note (parity with the DNAT path), not a Critical exposure
+        var dmzIssue = result.Issues.Should().ContainSingle(i => i.Type == IssueTypes.DnsDmzNetworkInfo).Subject;
+        dmzIssue.Severity.Should().Be(AuditSeverity.Informational);
+        dmzIssue.ScoreImpact.Should().Be(0);
+        dmzIssue.Message.Should().Contain("DMZ Servers");
+        dmzIssue.Message.Should().Contain("expected for DMZ");
+    }
+
+    [Fact]
     public async Task Analyze_DnatWithIpRange_MatchesMultipleThirdPartyDnsServers()
     {
         // Arrange - Two third-party DNS servers (Pi-hole style redundancy)

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
@@ -5798,20 +5798,20 @@ public class DnsSecurityAnalyzerTests : IDisposable
         var networks = CreateDhcpNetworks(
             ("net1", "Main Network", "192.168.1.0/24"),
             ("net2", "IoT", "192.168.2.0/24"),
-            ("net3", "Management", "192.168.150.0/24"),
-            ("net4", "Security", "192.168.17.0/24"));
+            ("net3", "Management", "192.0.2.0/24"),
+            ("net4", "Security", "198.51.100.0/24"));
 
         // Blanket "block all internet" rules on Management and Security (no port = all ports, including 53)
         var firewall = JsonDocument.Parse(@"[
             {
-                ""name"": ""Block 192.168.150.0/24 Internet Access"",
+                ""name"": ""Block 192.0.2.0/24 Internet Access"",
                 ""enabled"": true,
                 ""action"": ""drop"",
                 ""source"": { ""matching_target"": ""NETWORK"", ""network_ids"": [""net3""] },
                 ""destination"": { ""port_matching_type"": ""ANY"", ""matching_target"": ""ANY"" }
             },
             {
-                ""name"": ""Block 192.168.17.0/24 Internet Access"",
+                ""name"": ""Block 198.51.100.0/24 Internet Access"",
                 ""enabled"": true,
                 ""action"": ""drop"",
                 ""source"": { ""matching_target"": ""NETWORK"", ""network_ids"": [""net4""] },
@@ -5861,19 +5861,19 @@ public class DnsSecurityAnalyzerTests : IDisposable
         var networks = CreateDhcpNetworks(
             ("net1", "Main Network", "192.168.1.0/24"),
             ("net2", "IoT", "192.168.2.0/24"),
-            ("net3", "Management", "192.168.150.0/24"),
-            ("net4", "Security", "192.168.17.0/24"));
+            ("net3", "Management", "192.0.2.0/24"),
+            ("net4", "Security", "198.51.100.0/24"));
 
         var firewall = JsonDocument.Parse(@"[
             {
-                ""name"": ""Block 192.168.150.0/24 Internet Access"",
+                ""name"": ""Block 192.0.2.0/24 Internet Access"",
                 ""enabled"": true,
                 ""action"": ""drop"",
                 ""source"": { ""matching_target"": ""NETWORK"", ""network_ids"": [""net3""] },
                 ""destination"": { ""port_matching_type"": ""ANY"", ""matching_target"": ""ANY"" }
             },
             {
-                ""name"": ""Block 192.168.17.0/24 Internet Access"",
+                ""name"": ""Block 198.51.100.0/24 Internet Access"",
                 ""enabled"": true,
                 ""action"": ""drop"",
                 ""source"": { ""matching_target"": ""NETWORK"", ""network_ids"": [""net4""] },
@@ -5883,8 +5883,8 @@ public class DnsSecurityAnalyzerTests : IDisposable
 
         // DNAT redirects only Management + Security; Main + IoT DNAT rules are disabled (absent)
         var natRules = CreateDnatNatRules(
-            ("net3", "192.168.150.1"),
-            ("net4", "192.168.17.1"));
+            ("net3", "192.0.2.1"),
+            ("net4", "198.51.100.1"));
 
         var settings = JsonDocument.Parse(@"[
             {
@@ -5921,19 +5921,19 @@ public class DnsSecurityAnalyzerTests : IDisposable
         var networks = CreateDhcpNetworks(
             ("net1", "Main Network", "192.168.1.0/24"),
             ("net2", "IoT", "192.168.2.0/24"),
-            ("net3", "Management", "192.168.150.0/24"),
-            ("net4", "Security", "192.168.17.0/24"));
+            ("net3", "Management", "192.0.2.0/24"),
+            ("net4", "Security", "198.51.100.0/24"));
 
         var firewall = JsonDocument.Parse(@"[
             {
-                ""name"": ""Block 192.168.150.0/24 Internet Access"",
+                ""name"": ""Block 192.0.2.0/24 Internet Access"",
                 ""enabled"": true,
                 ""action"": ""drop"",
                 ""source"": { ""matching_target"": ""NETWORK"", ""network_ids"": [""net3""] },
                 ""destination"": { ""port_matching_type"": ""ANY"", ""matching_target"": ""ANY"" }
             },
             {
-                ""name"": ""Block 192.168.17.0/24 Internet Access"",
+                ""name"": ""Block 198.51.100.0/24 Internet Access"",
                 ""enabled"": true,
                 ""action"": ""drop"",
                 ""source"": { ""matching_target"": ""NETWORK"", ""network_ids"": [""net4""] },

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
@@ -5838,9 +5838,71 @@ public class DnsSecurityAnalyzerTests : IDisposable
         // No phantom DNS-53 partial-coverage finding (this is the bug)
         result.Issues.Should().NotContain(i => i.Type == IssueTypes.Dns53PartialCoverage);
 
-        // The real gap surfaces: IoT lost its DNAT redirect
+        // The real gap surfaces: IoT lost its DNAT redirect. IoT isn't firewall-blocked either, so it's
+        // genuinely exposed - the finding must not falsely claim firewall blocking backstops it.
         var dnatIssue = result.Issues.Should().ContainSingle(i => i.Type == IssueTypes.DnsDnatPartialCoverage).Subject;
         dnatIssue.Message.Should().Contain("IoT");
+        dnatIssue.Message.Should().Contain("bypass DNS settings");
+        dnatIssue.Message.Should().NotContain("covered by firewall");
+    }
+
+    [Fact]
+    public async Task Analyze_DnatGapOnNetworksWithoutFirewallBlock_FlagsExposedNotBackstopped()
+    {
+        // The reported case (issue #868): partial DNS-53 blockage from two internet-block rules covers
+        // Management + Security, but Main + IoT are covered by neither the firewall nor DNAT (their DNAT
+        // rules were disabled). The DNAT finding must flag Main + IoT as genuinely exposed, NOT claim that
+        // firewall port 53 blocking backstops them - that blocking only covers Management + Security.
+        var networks = CreateDhcpNetworks(
+            ("net1", "Main Network", "192.168.1.0/24"),
+            ("net2", "IoT", "192.168.2.0/24"),
+            ("net3", "Management", "192.168.150.0/24"),
+            ("net4", "Security", "192.168.17.0/24"));
+
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block 192.168.150.0/24 Internet Access"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""source"": { ""matching_target"": ""NETWORK"", ""network_ids"": [""net3""] },
+                ""destination"": { ""port_matching_type"": ""ANY"", ""matching_target"": ""ANY"" }
+            },
+            {
+                ""name"": ""Block 192.168.17.0/24 Internet Access"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""source"": { ""matching_target"": ""NETWORK"", ""network_ids"": [""net4""] },
+                ""destination"": { ""port_matching_type"": ""ANY"", ""matching_target"": ""ANY"" }
+            }
+        ]").RootElement;
+
+        // DNAT redirects only Management + Security; Main + IoT DNAT rules are disabled (absent)
+        var natRules = CreateDnatNatRules(
+            ("net3", "192.168.150.1"),
+            ("net4", "192.168.17.1"));
+
+        var settings = JsonDocument.Parse(@"[
+            {
+                ""key"": ""doh"",
+                ""state"": ""auto"",
+                ""server_names"": [""NextDNS-test""]
+            }
+        ]").RootElement;
+
+        // Act
+        var result = await _analyzer.AnalyzeAsync(settings, ParseFirewallRules(firewall), null, networks, null, null, natRules);
+
+        // No phantom DNS-53 strategy finding
+        result.HasDns53BlockStrategy.Should().BeFalse();
+        result.Issues.Should().NotContain(i => i.Type == IssueTypes.Dns53PartialCoverage);
+
+        // DNAT gap reports Main + IoT as exposed, with no false firewall reassurance
+        var dnatIssue = result.Issues.Should().ContainSingle(i => i.Type == IssueTypes.DnsDnatPartialCoverage).Subject;
+        dnatIssue.Message.Should().Contain("Main Network");
+        dnatIssue.Message.Should().Contain("IoT");
+        dnatIssue.Message.Should().Contain("bypass DNS settings");
+        dnatIssue.Message.Should().NotContain("covered by firewall");
+        dnatIssue.Severity.Should().Be(AuditSeverity.Critical); // 2 of 4 networks exposed
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
@@ -5964,6 +5964,76 @@ public class DnsSecurityAnalyzerTests : IDisposable
     }
 
     [Fact]
+    public async Task Analyze_DedicatedBlockAndDnatBothPartial_ExposureScoredOnce()
+    {
+        // Belt-and-suspenders: a dedicated port-53 block strategy AND DNAT, both partial, with IoT + Cameras
+        // exposed under both. Both findings report (visibility), but the exposure is scored ONCE - the
+        // DNS-53 partial finding owns it (Critical); the DNAT finding reports the gap as Informational so
+        // the same exposed network isn't deducted twice.
+        var networks = CreateDhcpNetworks(
+            ("net1", "LAN", "192.168.1.0/24"),
+            ("net2", "IoT", "192.168.2.0/24"),
+            ("net3", "Cameras", "192.168.3.0/24"));
+
+        // Dedicated DNS-53 block (port 53 specified -> strategy), source = LAN only
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block DNS for LAN"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""protocol"": ""udp"",
+                ""source"": { ""matching_target"": ""NETWORK"", ""network_ids"": [""net1""] },
+                ""destination"": { ""port"": ""53"" }
+            }
+        ]").RootElement;
+
+        // DNAT covers LAN only -> IoT, Cameras exposed under both mechanisms
+        var natRules = CreateDnatNatRules(("net1", "192.168.1.1"));
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall), null, networks, null, null, natRules);
+
+        result.HasDns53BlockStrategy.Should().BeTrue();
+        result.HasDnatDnsRules.Should().BeTrue();
+        result.Issues.Should().NotContain(i => i.Type == IssueTypes.DnsNo53Block);
+
+        // DNS-53 partial owns the exposure score (Critical, deducts)
+        var dns53 = result.Issues.Should().ContainSingle(i => i.Type == IssueTypes.Dns53PartialCoverage).Subject;
+        dns53.Severity.Should().Be(AuditSeverity.Critical);
+        dns53.ScoreImpact.Should().BeGreaterThan(0);
+
+        // DNAT finding reports the same gap for visibility but does NOT double-deduct
+        var dnat = result.Issues.Should().ContainSingle(i => i.Type == IssueTypes.DnsDnatPartialCoverage).Subject;
+        dnat.Severity.Should().Be(AuditSeverity.Informational);
+        dnat.ScoreImpact.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Analyze_ExcludedVlan_NotFlaggedAsExposed_WithoutNatData()
+    {
+        // A VLAN the user explicitly excluded from coverage checks must not be reported as exposed, even
+        // when no NAT data is supplied (the exclusion is captured from the VLAN-id list directly).
+        var networks = new List<NetworkInfo>
+        {
+            new NetworkInfo { Id = "net1", Name = "LAN", VlanId = 1, Subnet = "192.168.1.0/24", DhcpEnabled = true, Gateway = "192.168.1.1" },
+            new NetworkInfo { Id = "net2", Name = "Lab", VlanId = 99, Subnet = "192.168.99.0/24", DhcpEnabled = true, Gateway = "192.168.99.1" }
+        };
+
+        // No firewall, no NAT; user excluded VLAN 99 (Lab) from coverage checks
+        var result = await _analyzer.AnalyzeAsync(
+            settingsData: null, firewallRules: null, switches: null, networks: networks,
+            deviceData: null, customDnsManagementPort: null, natRulesData: null,
+            dnatExcludedVlanIds: new List<int> { 99 });
+
+        result.ExcludedFromCoverageNetworks.Should().Contain("Lab");
+
+        // The catch-all flags LAN (exposed) but carves out the excluded Lab VLAN
+        var exposure = result.Issues.Should().ContainSingle(i => i.Type == IssueTypes.DnsNo53Block).Subject;
+        var exposed = (List<string>)exposure.Metadata!["exposed_networks"];
+        exposed.Should().Contain("LAN");
+        exposed.Should().NotContain("Lab");
+    }
+
+    [Fact]
     public async Task Analyze_BlanketBlocksCoverAllNetworks_NoDnat_NoExposureFinding()
     {
         // Blanket internet blocks on every network: block coverage is complete (not a strategy), so nothing

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
@@ -4441,7 +4441,7 @@ public class DnsSecurityAnalyzerTests : IDisposable
     }
 
     [Fact]
-    public async Task Analyze_WithDnatPartialCoverage_GeneratesBothIssues()
+    public async Task Analyze_WithDnatPartialCoverage_GeneratesDnatPartialNotNoBlock()
     {
         // Arrange - DNAT only covers one of two networks
         var networks = CreateDhcpNetworks(
@@ -4452,11 +4452,13 @@ public class DnsSecurityAnalyzerTests : IDisposable
         // Act
         var result = await _analyzer.AnalyzeAsync(null, null, null, networks, null, null, natRules);
 
-        // Assert - Should have both DNS_NO_53_BLOCK and partial coverage issue
+        // Assert - DNAT is the DNS-control strategy in play, so the DNAT partial-coverage finding owns the
+        // exposed network (IoT). The generic no-block finding is not also raised (no double-penalty).
         result.HasDnatDnsRules.Should().BeTrue();
         result.DnatProvidesFullCoverage.Should().BeFalse();
-        result.Issues.Should().Contain(i => i.Type == IssueTypes.DnsNo53Block);
-        result.Issues.Should().Contain(i => i.Type == IssueTypes.DnsDnatPartialCoverage);
+        result.Issues.Should().NotContain(i => i.Type == IssueTypes.DnsNo53Block);
+        var dnatIssue = result.Issues.Should().ContainSingle(i => i.Type == IssueTypes.DnsDnatPartialCoverage).Subject;
+        dnatIssue.Message.Should().Contain("IoT");
     }
 
     [Fact]
@@ -4524,8 +4526,9 @@ public class DnsSecurityAnalyzerTests : IDisposable
         // Assert - Should still have DNS_NO_DOH issue (DNAT doesn't replace DoH)
         result.DnatProvidesFullCoverage.Should().BeTrue();
         result.Issues.Should().Contain(i => i.Type == IssueTypes.DnsNoDoh);
-        // But should suppress DNS_NO_53_BLOCK since no DNS control solution
-        result.Issues.Should().Contain(i => i.Type == IssueTypes.DnsNo53Block);
+        // DNAT fully redirects DNS for every network, so nothing leaks - the no-block finding is
+        // suppressed. (DoH is a separate concern, flagged above.)
+        result.Issues.Should().NotContain(i => i.Type == IssueTypes.DnsNo53Block);
     }
 
     [Fact]
@@ -5468,9 +5471,9 @@ public class DnsSecurityAnalyzerTests : IDisposable
     }
 
     [Fact]
-    public async Task Analyze_DnatWrongDestination_WillNotSuppressDnsNo53Block()
+    public async Task Analyze_DnatWrongDestination_FlagsWrongDestinationNotNoBlock()
     {
-        // Arrange - DoH configured, DNAT has wrong destination - should NOT suppress DNS_NO_53_BLOCK
+        // Arrange - DoH configured, DNAT has wrong destination
         var settings = JsonDocument.Parse(@"[
             {
                 ""key"": ""doh"",
@@ -5492,10 +5495,12 @@ public class DnsSecurityAnalyzerTests : IDisposable
         // Act
         var result = await _analyzer.AnalyzeAsync(settings, null, null, networks, null, null, natRules);
 
-        // Assert - DNAT is not a valid alternative due to wrong destination
+        // Assert - DNAT redirects all DNS (full coverage), just to the wrong server. That's a
+        // wrong-destination problem (its own finding), not an absence of DNS control, so the generic
+        // no-block finding is suppressed in favor of the specific one.
         result.DnatProvidesFullCoverage.Should().BeTrue(); // Coverage is full
         result.DnatRedirectTargetIsValid.Should().BeFalse(); // But destination is wrong
-        result.Issues.Should().Contain(i => i.Type == IssueTypes.DnsNo53Block); // So DNS leak issue raised
+        result.Issues.Should().NotContain(i => i.Type == IssueTypes.DnsNo53Block);
         result.Issues.Should().Contain(i => i.Type == IssueTypes.DnsDnatWrongDestination);
     }
 
@@ -5903,6 +5908,93 @@ public class DnsSecurityAnalyzerTests : IDisposable
         dnatIssue.Message.Should().Contain("bypass DNS settings");
         dnatIssue.Message.Should().NotContain("covered by firewall");
         dnatIssue.Severity.Should().Be(AuditSeverity.Critical); // 2 of 4 networks exposed
+    }
+
+    [Fact]
+    public async Task Analyze_BlanketBlocksPartial_NoDnat_FlagsExposedNetworks()
+    {
+        // Regression (issue #868): DNS control was via DNAT; the user disabled ALL DNAT rules, leaving two
+        // "block all internet" isolation rules covering Management + Security. Main + IoT then have no
+        // port-53 block and no DNAT redirect - genuinely exposed - but every strategy-specific finding
+        // stays silent (no dedicated DNS-53 strategy, no DNAT rules in play). The catch-all must flag them,
+        // so removing all DNS protection no longer paradoxically improves the score.
+        var networks = CreateDhcpNetworks(
+            ("net1", "Main Network", "192.168.1.0/24"),
+            ("net2", "IoT", "192.168.2.0/24"),
+            ("net3", "Management", "192.168.150.0/24"),
+            ("net4", "Security", "192.168.17.0/24"));
+
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block 192.168.150.0/24 Internet Access"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""source"": { ""matching_target"": ""NETWORK"", ""network_ids"": [""net3""] },
+                ""destination"": { ""port_matching_type"": ""ANY"", ""matching_target"": ""ANY"" }
+            },
+            {
+                ""name"": ""Block 192.168.17.0/24 Internet Access"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""source"": { ""matching_target"": ""NETWORK"", ""network_ids"": [""net4""] },
+                ""destination"": { ""port_matching_type"": ""ANY"", ""matching_target"": ""ANY"" }
+            }
+        ]").RootElement;
+
+        // Act - no DNAT rules at all
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall), null, networks);
+
+        // Blanket blocks are block coverage, not a strategy; no DNAT in play
+        result.HasDns53BlockRule.Should().BeTrue();
+        result.HasDns53BlockStrategy.Should().BeFalse();
+        result.HasDnatDnsRules.Should().BeFalse();
+
+        // No strategy-specific findings fire...
+        result.Issues.Should().NotContain(i => i.Type == IssueTypes.Dns53PartialCoverage);
+        result.Issues.Should().NotContain(i => i.Type == IssueTypes.DnsDnatPartialCoverage);
+
+        // ...but the catch-all flags the genuinely exposed networks (and deducts score)
+        var exposure = result.Issues.Should().ContainSingle(i => i.Type == IssueTypes.DnsNo53Block).Subject;
+        exposure.Severity.Should().Be(AuditSeverity.Critical);
+        exposure.ScoreImpact.Should().BeGreaterThan(0);
+        exposure.Message.Should().Contain("Main Network");
+        exposure.Message.Should().Contain("IoT");
+        exposure.Message.Should().NotContain("Management"); // blocked, not exposed
+        exposure.Message.Should().NotContain("Security");
+    }
+
+    [Fact]
+    public async Task Analyze_BlanketBlocksCoverAllNetworks_NoDnat_NoExposureFinding()
+    {
+        // Blanket internet blocks on every network: block coverage is complete (not a strategy), so nothing
+        // is exposed and the catch-all does not fire.
+        var networks = CreateDhcpNetworks(
+            ("net1", "Main Network", "192.168.1.0/24"),
+            ("net2", "IoT", "192.168.2.0/24"));
+
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block Main Internet Access"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""source"": { ""matching_target"": ""NETWORK"", ""network_ids"": [""net1""] },
+                ""destination"": { ""port_matching_type"": ""ANY"", ""matching_target"": ""ANY"" }
+            },
+            {
+                ""name"": ""Block IoT Internet Access"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""source"": { ""matching_target"": ""NETWORK"", ""network_ids"": [""net2""] },
+                ""destination"": { ""port_matching_type"": ""ANY"", ""matching_target"": ""ANY"" }
+            }
+        ]").RootElement;
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall), null, networks);
+
+        result.HasDns53BlockRule.Should().BeTrue();
+        result.HasDns53BlockStrategy.Should().BeFalse();
+        result.Dns53ProvidesFullCoverage.Should().BeTrue();
+        result.Issues.Should().NotContain(i => i.Type == IssueTypes.DnsNo53Block);
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
@@ -5536,7 +5536,13 @@ public class DnsSecurityAnalyzerTests : IDisposable
         result.Dns53CoveredNetworks.Should().Contain("Guest");
         result.Dns53CoveredNetworks.Should().NotContain("IoT");
         result.Dns53UncoveredNetworks.Should().Contain("IoT");
-        result.Issues.Should().Contain(i => i.Type == IssueTypes.Dns53PartialCoverage);
+        var partialIssue = result.Issues.Should().ContainSingle(i => i.Type == IssueTypes.Dns53PartialCoverage).Subject;
+
+        // The finding surfaces the contributing rule and the networks it covers
+        partialIssue.CoveringRules.Should().ContainSingle();
+        var coveringRule = partialIssue.CoveringRules![0];
+        coveringRule.RuleName.Should().Be("Block DNS (Match Opposite)");
+        coveringRule.CoveredNetworks.Should().BeEquivalentTo(new[] { "LAN", "Guest" });
     }
 
     [Fact]
@@ -5570,7 +5576,12 @@ public class DnsSecurityAnalyzerTests : IDisposable
         result.Dns53ProvidesFullCoverage.Should().BeFalse();
         result.Dns53CoveredNetworks.Should().Contain("LAN");
         result.Dns53UncoveredNetworks.Should().Contain("IoT");
-        result.Issues.Should().Contain(i => i.Type == IssueTypes.Dns53PartialCoverage);
+        var partialIssue = result.Issues.Should().ContainSingle(i => i.Type == IssueTypes.Dns53PartialCoverage).Subject;
+
+        // The finding names the rule that only covers LAN
+        partialIssue.CoveringRules.Should().ContainSingle();
+        partialIssue.CoveringRules![0].RuleName.Should().Be("Block DNS for LAN Only");
+        partialIssue.CoveringRules![0].CoveredNetworks.Should().BeEquivalentTo(new[] { "LAN" });
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
@@ -926,6 +926,7 @@ public class DnsSecurityAnalyzerTests : IDisposable
         var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall));
 
         result.HasDns53BlockRule.Should().BeTrue("a block-all rule with port_matching_type=ANY blocks all ports including 53");
+        result.HasDns53BlockStrategy.Should().BeFalse("a blanket block-all rule provides block coverage but is not a dedicated DNS-53 blocking strategy");
         result.Dns53RuleName.Should().Be("Block All Traffic");
     }
 
@@ -5732,9 +5733,11 @@ public class DnsSecurityAnalyzerTests : IDisposable
     }
 
     [Fact]
-    public async Task Analyze_WithDns53PartialCoverage_DnatFullCoverage_SuppressesPartialIssue()
+    public async Task Analyze_WithDns53PartialCoverage_DnatFullCoverage_ReportsInformationalNotExposed()
     {
-        // Arrange - DNS53 firewall rule covers only LAN, but DNAT covers all
+        // Arrange - dedicated DNS53 firewall rule covers only LAN, but DNAT covers all networks.
+        // Belt-and-suspenders: the DNS-53 strategy gap is still reported (not suppressed by DNAT), but
+        // because DNAT backstops IoT it is Informational, not an exposure.
         var networks = CreateDhcpNetworks(
             ("net1", "LAN", "192.168.1.0/24"),
             ("net2", "IoT", "192.168.2.0/24"));
@@ -5766,12 +5769,78 @@ public class DnsSecurityAnalyzerTests : IDisposable
         // Act
         var result = await _analyzer.AnalyzeAsync(settings, ParseFirewallRules(firewall), null, networks, null, null, natRules);
 
-        // Assert - DNAT provides full coverage, so no partial coverage issue
+        // Assert - DNS-53 strategy is partial; DNAT fully backstops it
         result.HasDns53BlockRule.Should().BeTrue();
+        result.HasDns53BlockStrategy.Should().BeTrue(); // dedicated port-53 rule
         result.Dns53ProvidesFullCoverage.Should().BeFalse(); // Firewall alone is partial
         result.DnatProvidesFullCoverage.Should().BeTrue(); // But DNAT covers all
-        result.Issues.Should().NotContain(i => i.Type == IssueTypes.Dns53PartialCoverage); // Suppressed by DNAT
+
+        // The strategy gap is reported, but Informational (IoT is DNAT-backstopped, not exposed)
+        var partialIssue = result.Issues.Should().ContainSingle(i => i.Type == IssueTypes.Dns53PartialCoverage).Subject;
+        partialIssue.Severity.Should().Be(AuditSeverity.Informational);
+        partialIssue.ScoreImpact.Should().Be(0);
         result.Issues.Should().NotContain(i => i.Type == IssueTypes.DnsNo53Block); // Firewall handles part of it
+    }
+
+    [Fact]
+    public async Task Analyze_BlanketInternetBlocksPlusPartialDnat_NoPhantomDns53Finding_ReportsDnatGap()
+    {
+        // Regression (issue #868 follow-up): DNS control is via DNAT redirection. Two "block all internet"
+        // isolation rules fully isolate Management and Security (incidentally blocking port 53). One DNAT
+        // rule is disabled, leaving IoT uncovered. The blanket isolation rules must NOT be read as a DNS-53
+        // blocking strategy and fabricate a Critical "partial DNS-53 coverage" finding listing the
+        // DNAT-controlled networks. The real gap (IoT lost its DNAT redirect) should surface instead.
+        var networks = CreateDhcpNetworks(
+            ("net1", "Main Network", "192.168.1.0/24"),
+            ("net2", "IoT", "192.168.2.0/24"),
+            ("net3", "Management", "192.168.150.0/24"),
+            ("net4", "Security", "192.168.17.0/24"));
+
+        // Blanket "block all internet" rules on Management and Security (no port = all ports, including 53)
+        var firewall = JsonDocument.Parse(@"[
+            {
+                ""name"": ""Block 192.168.150.0/24 Internet Access"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""source"": { ""matching_target"": ""NETWORK"", ""network_ids"": [""net3""] },
+                ""destination"": { ""port_matching_type"": ""ANY"", ""matching_target"": ""ANY"" }
+            },
+            {
+                ""name"": ""Block 192.168.17.0/24 Internet Access"",
+                ""enabled"": true,
+                ""action"": ""drop"",
+                ""source"": { ""matching_target"": ""NETWORK"", ""network_ids"": [""net4""] },
+                ""destination"": { ""port_matching_type"": ""ANY"", ""matching_target"": ""ANY"" }
+            }
+        ]").RootElement;
+
+        // DNAT redirects Main, Management, Security - IoT's rule is "disabled" (absent)
+        var natRules = CreateDnatNatRules(
+            ("net1", "192.168.1.1"),
+            ("net3", "192.168.1.1"),
+            ("net4", "192.168.1.1"));
+
+        var settings = JsonDocument.Parse(@"[
+            {
+                ""key"": ""doh"",
+                ""state"": ""auto"",
+                ""server_names"": [""NextDNS-test""]
+            }
+        ]").RootElement;
+
+        // Act
+        var result = await _analyzer.AnalyzeAsync(settings, ParseFirewallRules(firewall), null, networks, null, null, natRules);
+
+        // Assert - blanket blocks are block coverage, not a DNS-53 strategy
+        result.HasDns53BlockRule.Should().BeTrue("blanket internet blocks do block port 53");
+        result.HasDns53BlockStrategy.Should().BeFalse("blanket internet blocks are not a dedicated DNS-53 blocking strategy");
+
+        // No phantom DNS-53 partial-coverage finding (this is the bug)
+        result.Issues.Should().NotContain(i => i.Type == IssueTypes.Dns53PartialCoverage);
+
+        // The real gap surfaces: IoT lost its DNAT redirect
+        var dnatIssue = result.Issues.Should().ContainSingle(i => i.Type == IssueTypes.DnsDnatPartialCoverage).Subject;
+        dnatIssue.Message.Should().Contain("IoT");
     }
 
     [Fact]


### PR DESCRIPTION
## What

Sharpens the DNS leak prevention checks in the Security Audit so findings are accurate, actionable, and scored sensibly.

- **Rule-level detail on partial-coverage findings** - Each DNS partial-coverage finding now lists the firewall/DNAT rule(s) responsible and the networks each one covers, shown next to the gateway. No more guessing which rule drove a finding.
- **Tells "DNS blocking" apart from "block all internet"** - A blanket internet-isolation rule incidentally blocks port 53, but it isn't a DNS-blocking strategy. The audit no longer treats it as one, so it won't raise a misleading "partial DNS-53 coverage" alert listing networks that are actually controlled by DNAT.
- **Per-network severity** - A DNAT or firewall gap is judged per network: a network the other mechanism still protects is informational; a network protected by neither is flagged as genuinely exposed. No more "firewall blocking is also present" reassurance about a network the firewall doesn't actually cover.
- **New "no DNS leak protection" finding** - Networks with neither a port 53 block nor a DNAT redirect are now always surfaced. Previously they could slip through every check, and removing DNS protection could paradoxically improve the score.
- **Belt-and-suspenders friendly scoring** - When both firewall blocking and DNAT are in use, both coverage gaps are reported, but a single exposed network is only deducted once.
- **Carve-outs respected consistently** - DMZ networks, guest networks on third-party DNS, and VLANs excluded from coverage checks are handled the same way (informational, never a false critical) across every finding.

## Why

From a real audit (#868): a DNAT-based DNS setup with one rule disabled produced a misleading Critical "DNS port 53 blocking partial coverage" finding pointing at networks that were actually fine, while genuinely exposed networks went unreported and the score moved the wrong way.

## Tests

Adds coverage for the full scenario matrix (firewall strategy x DNAT x blanket blocks), the scoring dedup, the excluded-VLAN carve-out without NAT data, and DMZ/Guest info-note parity.