### PR TITLE
Live View: per-port statistics playback table

### DIFF
--- a/src/NetworkOptimizer.Storage/Migrations/20260620184613_AddInterfaceNameMapIsSfp.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260620184613_AddInterfaceNameMapIsSfp.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260620184613_AddInterfaceNameMapIsSfp")]
+    partial class AddInterfaceNameMapIsSfp
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260620184613_AddInterfaceNameMapIsSfp.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260620184613_AddInterfaceNameMapIsSfp.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInterfaceNameMapIsSfp : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsSfp",
+                table: "InterfaceNameMaps",
+                type: "INTEGER",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsSfp",
+                table: "InterfaceNameMaps");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/InterfaceNameMap.cs
+++ b/src/NetworkOptimizer.Storage/Models/InterfaceNameMap.cs
@@ -40,5 +40,12 @@ public class InterfaceNameMap
 
     public int? SpeedMbps { get; set; }
 
+    /// <summary>
+    /// True when the UniFi PortTable reports an SFP module in this port, false for
+    /// RJ45 copper, null when the media type is unknown (e.g. gateway interfaces
+    /// with no matching PortTable entry).
+    /// </summary>
+    public bool? IsSfp { get; set; }
+
     public DateTime LastUpdated { get; set; } = DateTime.UtcNow;
 }

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -859,10 +859,10 @@ from(bucket: ""{_bucket}"")
   |> last()
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
-        var results = new List<PortStatsPoint>();
+        var raw = new List<PortStatsPoint>();
         await foreach (var record in QueryFluxAsync(flux, ct))
         {
-            results.Add(new PortStatsPoint
+            raw.Add(new PortStatsPoint
             {
                 DeviceMac = record.GetValueByKey("device_mac") as string ?? "",
                 IfName = record.GetValueByKey("if_name") as string ?? "",
@@ -886,7 +886,58 @@ from(bucket: ""{_bucket}"")
                 Time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow),
             });
         }
-        return results;
+
+        // Different fields can land on different timestamps - rate_in/out are only
+        // written when a rate is computable, so a fresh point may carry oper_status
+        // and packet counters while the rates sit on an earlier point. pivot-by-time
+        // then splits one interface into several partial rows. Collapse to a single
+        // row per (device, interface), coalescing each field from the most recent
+        // sample that carries it.
+        return raw
+            .GroupBy(p => (p.DeviceMac, p.IfName), TupleMacIfComparer)
+            .Select(g =>
+            {
+                var ordered = g.OrderByDescending(p => p.Time).ToList();
+                long? FirstLong(Func<PortStatsPoint, long?> sel) => ordered.Select(sel).FirstOrDefault(v => v.HasValue);
+                double? FirstDouble(Func<PortStatsPoint, double?> sel) => ordered.Select(sel).FirstOrDefault(v => v.HasValue);
+                return new PortStatsPoint
+                {
+                    DeviceMac = g.Key.DeviceMac,
+                    IfName = g.Key.IfName,
+                    PortId = ordered.Select(p => p.PortId).FirstOrDefault(s => !string.IsNullOrEmpty(s)) ?? "",
+                    OperStatus = ordered.Select(p => p.OperStatus).FirstOrDefault(v => v.HasValue),
+                    SpeedBps = FirstLong(p => p.SpeedBps),
+                    RateInBps = FirstDouble(p => p.RateInBps),
+                    RateOutBps = FirstDouble(p => p.RateOutBps),
+                    BytesIn = FirstLong(p => p.BytesIn),
+                    BytesOut = FirstLong(p => p.BytesOut),
+                    UcastPktsIn = FirstLong(p => p.UcastPktsIn),
+                    UcastPktsOut = FirstLong(p => p.UcastPktsOut),
+                    McastPktsIn = FirstLong(p => p.McastPktsIn),
+                    McastPktsOut = FirstLong(p => p.McastPktsOut),
+                    BcastPktsIn = FirstLong(p => p.BcastPktsIn),
+                    BcastPktsOut = FirstLong(p => p.BcastPktsOut),
+                    ErrorsIn = FirstLong(p => p.ErrorsIn),
+                    ErrorsOut = FirstLong(p => p.ErrorsOut),
+                    DiscardsIn = FirstLong(p => p.DiscardsIn),
+                    DiscardsOut = FirstLong(p => p.DiscardsOut),
+                    Time = ordered[0].Time,
+                };
+            })
+            .ToList();
+    }
+
+    private static readonly IEqualityComparer<(string DeviceMac, string IfName)> TupleMacIfComparer =
+        new MacIfTupleComparer();
+
+    private sealed class MacIfTupleComparer : IEqualityComparer<(string DeviceMac, string IfName)>
+    {
+        public bool Equals((string DeviceMac, string IfName) x, (string DeviceMac, string IfName) y) =>
+            string.Equals(x.DeviceMac, y.DeviceMac, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(x.IfName, y.IfName, StringComparison.Ordinal);
+
+        public int GetHashCode((string DeviceMac, string IfName) obj) =>
+            HashCode.Combine(obj.DeviceMac.ToLowerInvariant(), obj.IfName);
     }
 
     public async Task<IReadOnlyList<WanRatePoint>> QueryGatewayWanRatesAsync(

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -813,6 +813,82 @@ from(bucket: ""{_bucket}"")
         return results;
     }
 
+    /// <summary>
+    /// Point-in-time snapshot of every interface_counters field for one or more
+    /// devices. Returns the most recent point per (device, interface) within a
+    /// short window around <paramref name="at"/> (or the latest available when
+    /// <paramref name="at"/> is null). Used by the Live View port stats table,
+    /// which reads the value at the current map scrubber position.
+    /// </summary>
+    /// <param name="deviceMacs">Devices to include; null or empty returns all polled devices.</param>
+    /// <param name="at">Historic playback instant, or null for the latest sample.</param>
+    public async Task<IReadOnlyList<PortStatsPoint>> QueryPortStatsAsync(
+        IReadOnlyList<string>? deviceMacs,
+        DateTime? at,
+        CancellationToken ct = default)
+    {
+        if (!IsConfigured) return Array.Empty<PortStatsPoint>();
+
+        string rangeClause;
+        if (at.HasValue)
+        {
+            // Mirror the historic snapshot window used elsewhere on the Live tab so
+            // the table lines up with the map and WAN chart at the same scrub point.
+            var center = at.Value.ToUniversalTime();
+            rangeClause = $"range(start: {ToFluxInstant(center.AddSeconds(-90))}, stop: {ToFluxInstant(center.AddSeconds(30))})";
+        }
+        else
+        {
+            // Wide enough to catch the newest sample on the slowest SNMP tier;
+            // last() collapses it to the single most recent point per interface.
+            rangeClause = "range(start: -120s)";
+        }
+
+        var macFilter = "";
+        if (deviceMacs != null && deviceMacs.Count > 0)
+        {
+            var macs = deviceMacs.Select(NormalizeMac).Distinct().ToList();
+            macFilter = "\n  |> filter(fn: (r) => " +
+                string.Join(" or ", macs.Select(m => $@"r.device_mac == ""{m}""")) + ")";
+        }
+
+        var flux = $@"
+from(bucket: ""{_bucket}"")
+  |> {rangeClause}
+  |> filter(fn: (r) => r._measurement == ""interface_counters""){macFilter}
+  |> last()
+  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
+";
+        var results = new List<PortStatsPoint>();
+        await foreach (var record in QueryFluxAsync(flux, ct))
+        {
+            results.Add(new PortStatsPoint
+            {
+                DeviceMac = record.GetValueByKey("device_mac") as string ?? "",
+                IfName = record.GetValueByKey("if_name") as string ?? "",
+                PortId = record.GetValueByKey("port_id") as string ?? "",
+                OperStatus = AsIntOrNull(record.GetValueByKey("oper_status")),
+                SpeedBps = AsLongOrNull(record.GetValueByKey("speed_bps")),
+                RateInBps = AsDoubleOrNull(record.GetValueByKey("rate_in_bps")),
+                RateOutBps = AsDoubleOrNull(record.GetValueByKey("rate_out_bps")),
+                BytesIn = AsLongOrNull(record.GetValueByKey("bytes_in")),
+                BytesOut = AsLongOrNull(record.GetValueByKey("bytes_out")),
+                UcastPktsIn = AsLongOrNull(record.GetValueByKey("ucast_pkts_in")),
+                UcastPktsOut = AsLongOrNull(record.GetValueByKey("ucast_pkts_out")),
+                McastPktsIn = AsLongOrNull(record.GetValueByKey("mcast_pkts_in")),
+                McastPktsOut = AsLongOrNull(record.GetValueByKey("mcast_pkts_out")),
+                BcastPktsIn = AsLongOrNull(record.GetValueByKey("bcast_pkts_in")),
+                BcastPktsOut = AsLongOrNull(record.GetValueByKey("bcast_pkts_out")),
+                ErrorsIn = AsLongOrNull(record.GetValueByKey("errors_in")),
+                ErrorsOut = AsLongOrNull(record.GetValueByKey("errors_out")),
+                DiscardsIn = AsLongOrNull(record.GetValueByKey("discards_in")),
+                DiscardsOut = AsLongOrNull(record.GetValueByKey("discards_out")),
+                Time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow),
+            });
+        }
+        return results;
+    }
+
     public async Task<IReadOnlyList<WanRatePoint>> QueryGatewayWanRatesAsync(
         string deviceMac,
         IReadOnlyList<string> wanIfNames,
@@ -1919,6 +1995,35 @@ from(bucket: ""{_longtermBucket}"")
         public required string IfName { get; init; }
         public double? RateInBps { get; init; }
         public double? RateOutBps { get; init; }
+    }
+
+    /// <summary>
+    /// Full set of interface_counters fields for a single port at one instant.
+    /// Packet-counter fields (ucast/mcast/bcast) are nullable so the table renders
+    /// gracefully on data written before those fields were collected.
+    /// </summary>
+    public record PortStatsPoint
+    {
+        public required DateTime Time { get; init; }
+        public required string DeviceMac { get; init; }
+        public required string IfName { get; init; }
+        public string PortId { get; init; } = "";
+        public int? OperStatus { get; init; }
+        public long? SpeedBps { get; init; }
+        public double? RateInBps { get; init; }
+        public double? RateOutBps { get; init; }
+        public long? BytesIn { get; init; }
+        public long? BytesOut { get; init; }
+        public long? UcastPktsIn { get; init; }
+        public long? UcastPktsOut { get; init; }
+        public long? McastPktsIn { get; init; }
+        public long? McastPktsOut { get; init; }
+        public long? BcastPktsIn { get; init; }
+        public long? BcastPktsOut { get; init; }
+        public long? ErrorsIn { get; init; }
+        public long? ErrorsOut { get; init; }
+        public long? DiscardsIn { get; init; }
+        public long? DiscardsOut { get; init; }
     }
 
     public record DeviceHealthPoint

--- a/src/NetworkOptimizer.UniFi/InterfaceLabelResolver.cs
+++ b/src/NetworkOptimizer.UniFi/InterfaceLabelResolver.cs
@@ -76,63 +76,63 @@ public static class InterfaceLabelResolver
             return n?.Name?.Trim();
         }
 
-        // Resolves the label of a base interface (for SQM and VLAN sub-interface
-        // labels): WAN label, then WireGuard, then the custom UniFi port name, then raw.
-        string BaseLabel(string ifName) =>
-            wanMap.TryGetValue(ifName, out var w) ? w
-            : wgMap.TryGetValue(ifName, out var g) ? g
-            : portNameByIfName.TryGetValue(ifName, out var pn) ? pn
-            : ifName;
-
-        foreach (var ifName in ifNames)
+        // Recursively resolves a friendly label, or null when we can't confidently name
+        // the interface. SQM (ifb*) is checked before the VLAN sub-interface rule so
+        // "ifbeth6.228" resolves as "<eth6.228 label> SQM", not as a sub-interface.
+        string? Resolve(string ifName)
         {
-            if (string.IsNullOrWhiteSpace(ifName)) continue;
+            if (string.IsNullOrWhiteSpace(ifName)) return null;
             var lower = ifName.ToLowerInvariant();
 
-            // A VLAN sub-interface is "{base port label} ({network name})", e.g.
-            // "Office Backhaul (Management)" or "WAN1 - Fiber ISP (Guest)". The tag is
-            // the network on that VLAN, falling back to the raw VLAN number when the
-            // VLAN has no named network (e.g. a carrier-proprietary tag).
-            var sub = SubInterface.Match(ifName);
-            if (sub.Success)
-            {
-                var subVlan = sub.Groups[2].Value;
-                var tag = int.TryParse(subVlan, out var subVlanId)
-                    && NetworkNameForVlan(subVlanId) is { } subNet ? subNet : subVlan;
-                result[ifName] = $"{BaseLabel(sub.Groups[1].Value)} ({tag})";
-                continue;
-            }
-
-            if (wanMap.TryGetValue(ifName, out var wan)) { result[ifName] = wan; continue; }
-            if (wgMap.TryGetValue(ifName, out var wg)) { result[ifName] = wg; continue; }
+            if (wanMap.TryGetValue(ifName, out var w)) return w;
+            if (wgMap.TryGetValue(ifName, out var g)) return g;
 
             if (lower.StartsWith("ifb"))
             {
-                // Only per-parent shaping interfaces (ifbeth0.100 → eth0.100) get an SQM
-                // label; the bare ifb0/ifb1 root devices are left unresolved (and hidden
-                // by the table when down).
+                // SQM shaping attached to a parent (ifbeth6.228 → eth6.228); the bare
+                // ifb0/ifb1 root devices are left unresolved (and hidden when down).
                 var parent = ifName[3..];
-                if (parent.Length > 0 && !parent.All(char.IsDigit))
-                    result[ifName] = $"{BaseLabel(parent)} SQM";
+                if (parent.Length == 0 || parent.All(char.IsDigit)) return null;
+                return $"{BaseOf(parent)} SQM";
             }
-            else if (lower.StartsWith("honeypot"))
+
+            // VLAN sub-interface: "{base port label} ({network name})", e.g.
+            // "Office Backhaul (Management)" or "WAN1 - Fiber ISP (Guest)"; the tag falls
+            // back to the raw VLAN number when the VLAN has no named network.
+            var sub = SubInterface.Match(ifName);
+            if (sub.Success)
+            {
+                var vlan = sub.Groups[2].Value;
+                var tag = int.TryParse(vlan, out var v) && NetworkNameForVlan(v) is { } net ? net : vlan;
+                return $"{BaseOf(sub.Groups[1].Value)} ({tag})";
+            }
+
+            if (lower.StartsWith("honeypot"))
             {
                 var vlan = TrailingVlanId(ifName);
                 var net = vlan.HasValue ? NetworkNameForVlan(vlan.Value) : null;
-                result[ifName] = net != null ? $"Honeypot ({net})"
+                return net != null ? $"Honeypot ({net})"
                     : vlan is > 0 ? $"Honeypot (VLAN {vlan})" : "Honeypot";
             }
-            else if (lower.StartsWith("br"))
+            if (lower.StartsWith("br"))
             {
                 var vlan = TrailingVlanId(ifName);
-                var net = vlan.HasValue ? NetworkNameForVlan(vlan.Value) : null;
-                if (net != null) result[ifName] = net;
+                return vlan.HasValue ? NetworkNameForVlan(vlan.Value) : null;
             }
-            else if (lower.StartsWith("tun") || lower.StartsWith("ovpn") || lower.StartsWith("vtun"))
-            {
-                result[ifName] = ovpnLabel;
-            }
+            if (lower.StartsWith("tun") || lower.StartsWith("ovpn") || lower.StartsWith("vtun"))
+                return ovpnLabel;
+
+            return null;
         }
+
+        // Base label for a SQM/VLAN parent: its own resolved label, then the custom
+        // UniFi port name, then the raw ifname.
+        string BaseOf(string ifName) =>
+            Resolve(ifName) ?? (portNameByIfName.TryGetValue(ifName, out var pn) ? pn : ifName);
+
+        foreach (var ifName in ifNames)
+            if (Resolve(ifName) is { } label)
+                result[ifName] = label;
 
         return result;
     }

--- a/src/NetworkOptimizer.UniFi/InterfaceLabelResolver.cs
+++ b/src/NetworkOptimizer.UniFi/InterfaceLabelResolver.cs
@@ -45,13 +45,21 @@ public static class InterfaceLabelResolver
 
         var wanMap = BuildWanLabels(device);
 
-        // WireGuard clients: wgclt{wireguard_id} → configured tunnel name.
+        // WireGuard clients: wgclt{wireguard_id} → "{configured tunnel name} (WG VPN)".
         var wgMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var n in networks)
             if (n.WireguardId is int wid
                 && !string.IsNullOrWhiteSpace(n.Name)
                 && (n.VpnType?.Contains("wireguard", StringComparison.OrdinalIgnoreCase) ?? false))
-                wgMap[$"wgclt{wid}"] = n.Name.Trim();
+                wgMap[$"wgclt{wid}"] = $"{n.Name.Trim()} (WG VPN)";
+
+        // Custom UniFi port names keyed by Linux ifname, for VLAN sub-interface and SQM
+        // base labels on non-WAN ports.
+        var portNameByIfName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (device.PortTable != null)
+            foreach (var p in device.PortTable)
+                if (!string.IsNullOrWhiteSpace(p.IfName) && !string.IsNullOrWhiteSpace(p.Name))
+                    portNameByIfName[p.IfName!] = p.Name.Trim();
 
         // OpenVPN client interface naming is firmware-specific; if there's exactly one
         // configured OpenVPN client, use its name, otherwise a generic label.
@@ -68,10 +76,12 @@ public static class InterfaceLabelResolver
             return n?.Name?.Trim();
         }
 
-        // Resolves the label of a base interface for SQM (ifb) parent lookups.
+        // Resolves the label of a base interface (for SQM and VLAN sub-interface
+        // labels): WAN label, then WireGuard, then the custom UniFi port name, then raw.
         string BaseLabel(string ifName) =>
             wanMap.TryGetValue(ifName, out var w) ? w
             : wgMap.TryGetValue(ifName, out var g) ? g
+            : portNameByIfName.TryGetValue(ifName, out var pn) ? pn
             : ifName;
 
         foreach (var ifName in ifNames)
@@ -79,25 +89,18 @@ public static class InterfaceLabelResolver
             if (string.IsNullOrWhiteSpace(ifName)) continue;
             var lower = ifName.ToLowerInvariant();
 
-            // A VLAN sub-interface inherits from its base: a WAN base gives the WAN
-            // label plus the tag (eth0.100 → "WAN1 - Fiber ISP (100)"); otherwise name
-            // it after the network on that VLAN (eth0.100 → "Management (100)"), the
-            // same VLAN→network resolution used for honeypot interfaces.
+            // A VLAN sub-interface is "{base port label} ({network name})", e.g.
+            // "Office Backhaul (Management)" or "WAN1 - Fiber ISP (Guest)". The tag is
+            // the network on that VLAN, falling back to the raw VLAN number when the
+            // VLAN has no named network (e.g. a carrier-proprietary tag).
             var sub = SubInterface.Match(ifName);
             if (sub.Success)
             {
                 var subVlan = sub.Groups[2].Value;
-                if (wanMap.TryGetValue(sub.Groups[1].Value, out var baseWan))
-                {
-                    result[ifName] = $"{baseWan} ({subVlan})";
-                    continue;
-                }
-                if (int.TryParse(subVlan, out var subVlanId)
-                    && NetworkNameForVlan(subVlanId) is { } subNet)
-                {
-                    result[ifName] = $"{subNet} ({subVlan})";
-                    continue;
-                }
+                var tag = int.TryParse(subVlan, out var subVlanId)
+                    && NetworkNameForVlan(subVlanId) is { } subNet ? subNet : subVlan;
+                result[ifName] = $"{BaseLabel(sub.Groups[1].Value)} ({tag})";
+                continue;
             }
 
             if (wanMap.TryGetValue(ifName, out var wan)) { result[ifName] = wan; continue; }
@@ -110,7 +113,7 @@ public static class InterfaceLabelResolver
                 // by the table when down).
                 var parent = ifName[3..];
                 if (parent.Length > 0 && !parent.All(char.IsDigit))
-                    result[ifName] = $"SQM ({BaseLabel(parent)})";
+                    result[ifName] = $"{BaseLabel(parent)} SQM";
             }
             else if (lower.StartsWith("honeypot"))
             {

--- a/src/NetworkOptimizer.UniFi/InterfaceLabelResolver.cs
+++ b/src/NetworkOptimizer.UniFi/InterfaceLabelResolver.cs
@@ -6,34 +6,137 @@ namespace NetworkOptimizer.UniFi;
 
 /// <summary>
 /// Resolves friendly display labels for a gateway's Linux interface names from the
-/// authoritative UniFi sources (the device's WAN objects, port table, last_geo_info
-/// and mbb cellular state). Runs agent-side so the resolved map can later be
-/// persisted as time series; for now the polling agent caches it in memory.
+/// authoritative UniFi sources (the device's WAN objects, port table, last_geo_info,
+/// mbb cellular state, and the network configuration). Runs agent-side so the
+/// resolved map can later be persisted as time series; for now the polling agent
+/// caches it in memory and the port stats endpoint reads it.
 ///
-/// Pass 1 covers WAN interfaces (incl. cellular GRE tunnels like "gre1"); WireGuard /
-/// OpenVPN / SQM (ifb) labels that need networkconf land in a later pass.
+/// Coverage: physical/WAN ports (incl. cellular GRE like "gre1"), WireGuard clients
+/// ("wgclt{wireguard_id}"), OpenVPN, SQM shaping ("ifb{parent}") and honeypot/bridge
+/// interfaces (by VLAN → network name).
 /// </summary>
 public static class InterfaceLabelResolver
 {
-    // UniFi's default, unnamed port labels ("Port 7", "SFP 1", "SFP+ 2"). When a WAN
-    // port still carries one of these we prefer the carrier name over it.
     private static readonly Regex DefaultPortName =
         new(@"^(port|sfp\+?|rj45)\s*\d+$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex TrailingVlan = new(@"(\d+)$", RegexOptions.Compiled);
+
+    // VLAN sub-interface: "<base>.<vlan>" (e.g. "eth0.100").
+    private static readonly Regex SubInterface = new(@"^(.+)\.(\d+)$", RegexOptions.Compiled);
 
     /// <summary>True for UniFi's generic placeholder port names ("Port 7", "SFP+ 1").</summary>
     public static bool IsDefaultPortName(string? name) =>
         !string.IsNullOrWhiteSpace(name) && DefaultPortName.IsMatch(name.Trim());
 
     /// <summary>
-    /// Builds a Linux-ifname → display-label map for the device's WAN interfaces.
-    /// Every interface that can carry a WAN (its name, ifname and uplink ifname) maps
-    /// to "WANn - {name}", where {name} is the custom UniFi port name when present,
-    /// otherwise the resolved carrier. Cellular WANs get a "(5G)"/"(LTE)" suffix.
+    /// Builds a Linux-ifname → display-label map for the given interface names, using
+    /// the device config and networkconf. Only interfaces we can confidently name are
+    /// included; callers fall back to the raw ifname for the rest.
     /// </summary>
-    public static Dictionary<string, string> BuildWanLabels(UniFiDeviceResponse device)
+    public static Dictionary<string, string> BuildLabels(
+        UniFiDeviceResponse device,
+        IReadOnlyList<NetworkInfo>? networks,
+        IEnumerable<string> ifNames)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (device == null) return result;
+        networks ??= Array.Empty<NetworkInfo>();
+
+        var wanMap = BuildWanLabels(device);
+
+        // WireGuard clients: wgclt{wireguard_id} → configured tunnel name.
+        var wgMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var n in networks)
+            if (n.WireguardId is int wid
+                && !string.IsNullOrWhiteSpace(n.Name)
+                && (n.VpnType?.Contains("wireguard", StringComparison.OrdinalIgnoreCase) ?? false))
+                wgMap[$"wgclt{wid}"] = n.Name.Trim();
+
+        // OpenVPN client interface naming is firmware-specific; if there's exactly one
+        // configured OpenVPN client, use its name, otherwise a generic label.
+        var ovpnNames = networks
+            .Where(n => n.VpnType?.Contains("openvpn", StringComparison.OrdinalIgnoreCase) ?? false)
+            .Select(n => n.Name).Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
+        var ovpnLabel = ovpnNames.Count == 1 ? ovpnNames[0]!.Trim() : "OpenVPN";
+
+        // VLAN id → corporate/LAN network name (for honeypot/bridge interfaces).
+        string? NetworkNameForVlan(int vlan)
+        {
+            var n = networks.FirstOrDefault(x =>
+                !x.IsWan && (x.VlanId ?? 0) == vlan && !string.IsNullOrWhiteSpace(x.Name));
+            return n?.Name?.Trim();
+        }
+
+        // Resolves the label of a base interface for SQM (ifb) parent lookups.
+        string BaseLabel(string ifName) =>
+            wanMap.TryGetValue(ifName, out var w) ? w
+            : wgMap.TryGetValue(ifName, out var g) ? g
+            : ifName;
+
+        foreach (var ifName in ifNames)
+        {
+            if (string.IsNullOrWhiteSpace(ifName)) continue;
+            var lower = ifName.ToLowerInvariant();
+
+            // A VLAN sub-interface of a WAN base inherits the WAN label plus its tag,
+            // e.g. eth0.100 → "WAN1 - Fiber ISP (100)". (The sub-if itself is not in
+            // the WAN object list, so check the base before the direct WAN lookup.)
+            var sub = SubInterface.Match(ifName);
+            if (sub.Success && wanMap.TryGetValue(sub.Groups[1].Value, out var baseWan))
+            {
+                result[ifName] = $"{baseWan} ({sub.Groups[2].Value})";
+                continue;
+            }
+
+            if (wanMap.TryGetValue(ifName, out var wan)) { result[ifName] = wan; continue; }
+            if (wgMap.TryGetValue(ifName, out var wg)) { result[ifName] = wg; continue; }
+
+            if (lower.StartsWith("ifb"))
+            {
+                // Only per-parent shaping interfaces (ifbeth0.100 → eth0.100) get an SQM
+                // label; the bare ifb0/ifb1 root devices are left unresolved (and hidden
+                // by the table when down).
+                var parent = ifName[3..];
+                if (parent.Length > 0 && !parent.All(char.IsDigit))
+                    result[ifName] = $"SQM ({BaseLabel(parent)})";
+            }
+            else if (lower.StartsWith("honeypot"))
+            {
+                var vlan = TrailingVlanId(ifName);
+                var net = vlan.HasValue ? NetworkNameForVlan(vlan.Value) : null;
+                result[ifName] = net != null ? $"Honeypot ({net})"
+                    : vlan is > 0 ? $"Honeypot (VLAN {vlan})" : "Honeypot";
+            }
+            else if (lower.StartsWith("br"))
+            {
+                var vlan = TrailingVlanId(ifName);
+                var net = vlan.HasValue ? NetworkNameForVlan(vlan.Value) : null;
+                if (net != null) result[ifName] = net;
+            }
+            else if (lower.StartsWith("tun") || lower.StartsWith("ovpn") || lower.StartsWith("vtun"))
+            {
+                result[ifName] = ovpnLabel;
+            }
+        }
+
+        return result;
+    }
+
+    private static int? TrailingVlanId(string ifName)
+    {
+        var m = TrailingVlan.Match(ifName);
+        return m.Success && int.TryParse(m.Groups[1].Value, out var v) ? v : null;
+    }
+
+    /// <summary>
+    /// Linux-ifname → "WANn - {name}" for the device's WAN interfaces, where {name} is
+    /// the custom UniFi port name when present, otherwise the resolved carrier; cellular
+    /// WANs get a "(5G)"/"(LTE)" suffix.
+    /// </summary>
+    private static Dictionary<string, string> BuildWanLabels(UniFiDeviceResponse device)
     {
         var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        if (device == null) return map;
 
         var portNameByIdx = new Dictionary<int, string>();
         if (device.PortTable != null)
@@ -43,10 +146,8 @@ public static class InterfaceLabelResolver
 
         foreach (var wan in device.GetWanInterfaces())
         {
-            // "wan"/"wan2" → "WAN1"/"WAN2" (canonical UniFi UI naming).
             var wanDisplay = NetworkFormatHelpers.FormatWanInterfaceName(wan.Key);
 
-            // Custom (non-default) UniFi port name wins; otherwise the carrier.
             string? custom = null;
             if (wan.PortIdx is int idx
                 && portNameByIdx.TryGetValue(idx, out var pn)

--- a/src/NetworkOptimizer.UniFi/InterfaceLabelResolver.cs
+++ b/src/NetworkOptimizer.UniFi/InterfaceLabelResolver.cs
@@ -84,7 +84,6 @@ public static class InterfaceLabelResolver
             if (string.IsNullOrWhiteSpace(ifName)) return null;
             var lower = ifName.ToLowerInvariant();
 
-            if (wanMap.TryGetValue(ifName, out var w)) return w;
             if (wgMap.TryGetValue(ifName, out var g)) return g;
 
             if (lower.StartsWith("ifb"))
@@ -96,16 +95,21 @@ public static class InterfaceLabelResolver
                 return $"{BaseOf(parent)} SQM";
             }
 
-            // VLAN sub-interface: "{base port label} ({network name})", e.g.
-            // "Office Backhaul (Management)" or "WAN1 - Fiber ISP (Guest)"; the tag falls
-            // back to the raw VLAN number when the VLAN has no named network.
+            // VLAN sub-interface: "{base port label} ({network name | VLAN id})", e.g.
+            // "Office Backhaul (Management)" or "WAN1 - Fiber ISP (Guest)". Checked before
+            // the direct WAN lookup so a WAN tagged on the sub-interface itself still
+            // surfaces its VLAN id (e.g. "WAN1 - Fiber ISP (100)") instead of the bare
+            // WAN label.
             var sub = SubInterface.Match(ifName);
             if (sub.Success)
             {
                 var vlan = sub.Groups[2].Value;
                 var tag = int.TryParse(vlan, out var v) && NetworkNameForVlan(v) is { } net ? net : vlan;
-                return $"{BaseOf(sub.Groups[1].Value)} ({tag})";
+                var baseLabel = wanMap.TryGetValue(ifName, out var wsub) ? wsub : BaseOf(sub.Groups[1].Value);
+                return $"{baseLabel} ({tag})";
             }
+
+            if (wanMap.TryGetValue(ifName, out var w)) return w;
 
             if (lower.StartsWith("honeypot"))
             {

--- a/src/NetworkOptimizer.UniFi/InterfaceLabelResolver.cs
+++ b/src/NetworkOptimizer.UniFi/InterfaceLabelResolver.cs
@@ -79,14 +79,25 @@ public static class InterfaceLabelResolver
             if (string.IsNullOrWhiteSpace(ifName)) continue;
             var lower = ifName.ToLowerInvariant();
 
-            // A VLAN sub-interface of a WAN base inherits the WAN label plus its tag,
-            // e.g. eth0.100 → "WAN1 - Fiber ISP (100)". (The sub-if itself is not in
-            // the WAN object list, so check the base before the direct WAN lookup.)
+            // A VLAN sub-interface inherits from its base: a WAN base gives the WAN
+            // label plus the tag (eth0.100 → "WAN1 - Fiber ISP (100)"); otherwise name
+            // it after the network on that VLAN (eth0.100 → "Management (100)"), the
+            // same VLAN→network resolution used for honeypot interfaces.
             var sub = SubInterface.Match(ifName);
-            if (sub.Success && wanMap.TryGetValue(sub.Groups[1].Value, out var baseWan))
+            if (sub.Success)
             {
-                result[ifName] = $"{baseWan} ({sub.Groups[2].Value})";
-                continue;
+                var subVlan = sub.Groups[2].Value;
+                if (wanMap.TryGetValue(sub.Groups[1].Value, out var baseWan))
+                {
+                    result[ifName] = $"{baseWan} ({subVlan})";
+                    continue;
+                }
+                if (int.TryParse(subVlan, out var subVlanId)
+                    && NetworkNameForVlan(subVlanId) is { } subNet)
+                {
+                    result[ifName] = $"{subNet} ({subVlan})";
+                    continue;
+                }
             }
 
             if (wanMap.TryGetValue(ifName, out var wan)) { result[ifName] = wan; continue; }
@@ -159,9 +170,11 @@ public static class InterfaceLabelResolver
 
             if (wan.IsCellular)
             {
+                // No parens: a parenthesised tag doubles up when this label is later
+                // wrapped (e.g. "SQM (WAN3 - Carrier 5G)").
                 var tag = wan.Type is "lte" or "wireless_lte" ? "LTE" : "5G";
                 if (!label.Contains(tag, StringComparison.OrdinalIgnoreCase))
-                    label += $" ({tag})";
+                    label += $" {tag}";
             }
 
             foreach (var ifName in new[] { wan.Name, wan.IfName, wan.UplinkIfName })

--- a/src/NetworkOptimizer.UniFi/InterfaceLabelResolver.cs
+++ b/src/NetworkOptimizer.UniFi/InterfaceLabelResolver.cs
@@ -1,0 +1,88 @@
+using System.Text.RegularExpressions;
+using NetworkOptimizer.Core.Helpers;
+using NetworkOptimizer.UniFi.Models;
+
+namespace NetworkOptimizer.UniFi;
+
+/// <summary>
+/// Resolves friendly display labels for a gateway's Linux interface names from the
+/// authoritative UniFi sources (the device's WAN objects, port table, last_geo_info
+/// and mbb cellular state). Runs agent-side so the resolved map can later be
+/// persisted as time series; for now the polling agent caches it in memory.
+///
+/// Pass 1 covers WAN interfaces (incl. cellular GRE tunnels like "gre1"); WireGuard /
+/// OpenVPN / SQM (ifb) labels that need networkconf land in a later pass.
+/// </summary>
+public static class InterfaceLabelResolver
+{
+    // UniFi's default, unnamed port labels ("Port 7", "SFP 1", "SFP+ 2"). When a WAN
+    // port still carries one of these we prefer the carrier name over it.
+    private static readonly Regex DefaultPortName =
+        new(@"^(port|sfp\+?|rj45)\s*\d+$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>True for UniFi's generic placeholder port names ("Port 7", "SFP+ 1").</summary>
+    public static bool IsDefaultPortName(string? name) =>
+        !string.IsNullOrWhiteSpace(name) && DefaultPortName.IsMatch(name.Trim());
+
+    /// <summary>
+    /// Builds a Linux-ifname → display-label map for the device's WAN interfaces.
+    /// Every interface that can carry a WAN (its name, ifname and uplink ifname) maps
+    /// to "WANn - {name}", where {name} is the custom UniFi port name when present,
+    /// otherwise the resolved carrier. Cellular WANs get a "(5G)"/"(LTE)" suffix.
+    /// </summary>
+    public static Dictionary<string, string> BuildWanLabels(UniFiDeviceResponse device)
+    {
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (device == null) return map;
+
+        var portNameByIdx = new Dictionary<int, string>();
+        if (device.PortTable != null)
+            foreach (var p in device.PortTable)
+                if (p.PortIdx > 0 && !string.IsNullOrWhiteSpace(p.Name))
+                    portNameByIdx[p.PortIdx] = p.Name;
+
+        foreach (var wan in device.GetWanInterfaces())
+        {
+            // "wan"/"wan2" → "WAN1"/"WAN2" (canonical UniFi UI naming).
+            var wanDisplay = NetworkFormatHelpers.FormatWanInterfaceName(wan.Key);
+
+            // Custom (non-default) UniFi port name wins; otherwise the carrier.
+            string? custom = null;
+            if (wan.PortIdx is int idx
+                && portNameByIdx.TryGetValue(idx, out var pn)
+                && !IsDefaultPortName(pn))
+                custom = pn.Trim();
+
+            var namePart = custom ?? ResolveCarrier(device, GatewayWanHelper.WanNetworkGroupFromKey(wan.Key));
+            var label = string.IsNullOrWhiteSpace(namePart) ? wanDisplay : $"{wanDisplay} - {namePart}";
+
+            if (wan.IsCellular)
+            {
+                var tag = wan.Type is "lte" or "wireless_lte" ? "LTE" : "5G";
+                if (!label.Contains(tag, StringComparison.OrdinalIgnoreCase))
+                    label += $" ({tag})";
+            }
+
+            foreach (var ifName in new[] { wan.Name, wan.IfName, wan.UplinkIfName })
+                if (!string.IsNullOrWhiteSpace(ifName))
+                    map[ifName!] = label;
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// Carrier/ISP for a WAN group: the active SIM's serving operator (mbb) when the
+    /// device has cellular state, otherwise the geo-IP ISP from last_geo_info.
+    /// </summary>
+    private static string? ResolveCarrier(UniFiDeviceResponse device, string wanGroup)
+    {
+        var sim = device.Mbb?.Sim?.FirstOrDefault(s => s.Active == true)
+                  ?? device.Mbb?.Sim?.FirstOrDefault();
+        if (!string.IsNullOrWhiteSpace(sim?.CarrierName)) return sim!.CarrierName;
+
+        if (device.LastGeoInfo != null && device.LastGeoInfo.TryGetValue(wanGroup, out var geo))
+            return geo.AnyName;
+        return null;
+    }
+}

--- a/src/NetworkOptimizer.UniFi/InterfaceLabelResolver.cs
+++ b/src/NetworkOptimizer.UniFi/InterfaceLabelResolver.cs
@@ -78,7 +78,7 @@ public static class InterfaceLabelResolver
 
         // Recursively resolves a friendly label, or null when we can't confidently name
         // the interface. SQM (ifb*) is checked before the VLAN sub-interface rule so
-        // "ifbeth6.228" resolves as "<eth6.228 label> SQM", not as a sub-interface.
+        // "ifbeth0.100" resolves as "<eth0.100 label> SQM", not as a sub-interface.
         string? Resolve(string ifName)
         {
             if (string.IsNullOrWhiteSpace(ifName)) return null;
@@ -89,7 +89,7 @@ public static class InterfaceLabelResolver
 
             if (lower.StartsWith("ifb"))
             {
-                // SQM shaping attached to a parent (ifbeth6.228 → eth6.228); the bare
+                // SQM shaping attached to a parent (ifbeth0.100 → eth0.100); the bare
                 // ifb0/ifb1 root devices are left unresolved (and hidden when down).
                 var parent = ifName[3..];
                 if (parent.Length == 0 || parent.All(char.IsDigit)) return null;

--- a/src/NetworkOptimizer.UniFi/InterfaceLabelResolver.cs
+++ b/src/NetworkOptimizer.UniFi/InterfaceLabelResolver.cs
@@ -66,7 +66,7 @@ public static class InterfaceLabelResolver
         var ovpnNames = networks
             .Where(n => n.VpnType?.Contains("openvpn", StringComparison.OrdinalIgnoreCase) ?? false)
             .Select(n => n.Name).Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
-        var ovpnLabel = ovpnNames.Count == 1 ? ovpnNames[0]!.Trim() : "OpenVPN";
+        var ovpnLabel = ovpnNames.Count == 1 ? $"{ovpnNames[0]!.Trim()} (OpenVPN)" : "OpenVPN";
 
         // VLAN id → corporate/LAN network name (for honeypot/bridge interfaces).
         string? NetworkNameForVlan(int vlan)

--- a/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
@@ -264,6 +264,22 @@ public class UniFiDeviceResponse
     public bool? FlowControlEnabled { get; set; }
 
     /// <summary>
+    /// Per-WAN geo/ISP info keyed by WAN network group ("WAN", "WAN2", "WAN3").
+    /// Each entry carries the resolved ISP name (e.g. "AT&amp;T Wireless"). Geo-IP
+    /// derived, so it is the fallback carrier source behind <see cref="Mbb"/>.
+    /// </summary>
+    [JsonPropertyName("last_geo_info")]
+    public Dictionary<string, WanGeoInfo>? LastGeoInfo { get; set; }
+
+    /// <summary>
+    /// Mobile-broadband (cellular) state, present on gateways/modems with an
+    /// integrated or attached cellular radio. The SIM's networkoperator/spn is the
+    /// preferred carrier source for a cellular WAN.
+    /// </summary>
+    [JsonPropertyName("mbb")]
+    public MbbInfo? Mbb { get; set; }
+
+    /// <summary>
     /// Captures additional JSON properties not mapped to typed properties.
     /// Used to extract WAN interface objects (wan, wan1, wan2, etc.) which are dynamic keys.
     /// </summary>
@@ -389,6 +405,52 @@ public class GatewayWanInterface
     /// Whether this is a cellular WAN interface (5G, LTE)
     /// </summary>
     public bool IsCellular => Type is "wireless_5g" or "lte" or "wireless_lte";
+}
+
+/// <summary>Geo/ISP info for a WAN (last_geo_info entry, and the mbb SIM geo_info).</summary>
+public class WanGeoInfo
+{
+    [JsonPropertyName("isp_name")]
+    public string? IspName { get; set; }
+
+    [JsonPropertyName("isp")]
+    public string? Isp { get; set; }
+
+    /// <summary>Either field, whichever the source populated.</summary>
+    public string? AnyName => string.IsNullOrWhiteSpace(IspName) ? Isp : IspName;
+}
+
+/// <summary>Mobile-broadband state with one entry per SIM slot.</summary>
+public class MbbInfo
+{
+    [JsonPropertyName("mode")]
+    public string? Mode { get; set; }
+
+    [JsonPropertyName("sim")]
+    public List<MbbSim>? Sim { get; set; }
+}
+
+/// <summary>A single cellular SIM slot's carrier identity.</summary>
+public class MbbSim
+{
+    [JsonPropertyName("active")]
+    public bool? Active { get; set; }
+
+    /// <summary>Live serving-network operator (preferred over the SIM's SPN when roaming).</summary>
+    [JsonPropertyName("networkoperator")]
+    public string? NetworkOperator { get; set; }
+
+    /// <summary>Service Provider Name from the SIM card.</summary>
+    [JsonPropertyName("spn")]
+    public string? Spn { get; set; }
+
+    [JsonPropertyName("geo_info")]
+    public WanGeoInfo? GeoInfo { get; set; }
+
+    /// <summary>Best carrier name for this SIM: serving operator, then SPN, then geo ISP.</summary>
+    public string? CarrierName =>
+        new[] { NetworkOperator, Spn, GeoInfo?.AnyName }
+            .FirstOrDefault(s => !string.IsNullOrWhiteSpace(s));
 }
 
 public class EthernetPort

--- a/src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs
@@ -335,7 +335,12 @@ public class UniFiNetworkConfig
 
     // VPN configuration
     [JsonPropertyName("vpn_type")]
-    public string? VpnType { get; set; } // "pptp", "l2tp", "openvpn", "wireguard"
+    public string? VpnType { get; set; } // "pptp", "l2tp", "openvpn", "wireguard", "wireguard-client", "openvpn-client"
+
+    /// <summary>WireGuard client id; maps directly to the Linux interface "wgclt{id}".</summary>
+    [JsonPropertyName("wireguard_id")]
+    [JsonConverter(typeof(FlexibleIntConverter))]
+    public int? WireguardId { get; set; }
 
     [JsonPropertyName("radiusprofile_id")]
     public string? RadiusprofileId { get; set; }

--- a/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
@@ -901,6 +901,13 @@ public class NetworkInfo
     public bool Enabled { get; set; }
     public int? VlanId { get; set; }
     public string? IpSubnet { get; set; }
+
+    /// <summary>VPN type when this network is a VPN client ("wireguard-client", "openvpn-client").</summary>
+    public string? VpnType { get; set; }
+
+    /// <summary>WireGuard client id; maps to the Linux interface "wgclt{id}".</summary>
+    public int? WireguardId { get; set; }
+
     public bool IsDhcpEnabled { get; set; }
     public string? DhcpRange { get; set; }
     public string? Gateway { get; set; }

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -134,9 +134,9 @@
                 <div class="identity-info">
                     <h2 class="identity-name">@_client.DisplayName</h2>
                     <div class="identity-meta">
-                        <span data-tooltip="MAC Address">@_client.Mac</span>
+                        <span>@_client.Mac</span>
                         <span class="meta-sep">·</span>
-                        <span data-tooltip="IP Address">@_client.Ip</span>
+                        <span>@_client.Ip</span>
                         @if (!string.IsNullOrEmpty(_client.Essid))
                         {
                             <span class="meta-sep">·</span>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -291,6 +291,7 @@ else
             </div>
             <div class="card-body">
                 <div class="health-filter-badges wan-filter-badges" id="port-stats-filter-badges"></div>
+                <div class="port-stats-scroll-top" id="port-stats-scroll-top" style="display: none;"><div></div></div>
                 <div class="port-stats-table" id="port-stats-table"></div>
                 <div class="port-speed-legend" id="port-stats-legend"></div>
             </div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -287,6 +287,7 @@ else
         <div class="card" id="port-stats-card" style="display: none; margin-top: 1rem;">
             <div class="card-header">
                 <h2 class="card-title">Port Statistics</h2>
+                <div class="tab-bar" id="port-stats-tabs"></div>
             </div>
             <div class="card-body">
                 <div class="health-filter-badges wan-filter-badges" id="port-stats-filter-badges"></div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1815,11 +1815,23 @@ else
     [JSInvokable]
     public void OnMapPlayStateChanged(bool paused, string mode)
     {
-        if (!_wanLiveChartMounted) return;
-        if (paused)
-            _ = JS.InvokeVoidAsync("eval", "window.__wanLiveChart?.pause();");
-        else if (mode == "live")
-            _ = JS.InvokeVoidAsync("eval", "window.__wanLiveChart?.resume();");
+        // Drive each live consumer independently so one being unmounted doesn't starve
+        // the other. Historic playback (at any speed) flows through OnMapTimeChanged;
+        // this only gates live auto-refresh on pause/resume.
+        if (_wanLiveChartMounted)
+        {
+            if (paused)
+                _ = JS.InvokeVoidAsync("eval", "window.__wanLiveChart?.pause();");
+            else if (mode == "live")
+                _ = JS.InvokeVoidAsync("eval", "window.__wanLiveChart?.resume();");
+        }
+        if (_portStatsMounted)
+        {
+            if (paused)
+                _ = JS.InvokeVoidAsync("eval", "window.__portStatsTable?.pause();");
+            else if (mode == "live")
+                _ = JS.InvokeVoidAsync("eval", "window.__portStatsTable?.resume();");
+        }
     }
 
     [JSInvokable]

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -287,7 +287,7 @@ else
         <div class="card" id="port-stats-card" style="display: none; margin-top: 1rem;">
             <div class="card-header">
                 <h2 class="card-title">Port Statistics</h2>
-                <div class="tab-bar" id="port-stats-tabs"></div>
+                <div class="time-range-selector" id="port-stats-tabs"></div>
             </div>
             <div class="card-body">
                 <div class="health-filter-badges wan-filter-badges" id="port-stats-filter-badges"></div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -290,7 +290,7 @@ else
             </div>
             <div class="card-body">
                 <div class="health-filter-badges wan-filter-badges" id="port-stats-filter-badges"></div>
-                <div id="port-stats-table"></div>
+                <div class="port-stats-table" id="port-stats-table"></div>
                 <div class="port-speed-legend" id="port-stats-legend"></div>
             </div>
         </div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -282,6 +282,18 @@ else
             @GatewayStatCards
             <div style="margin-top: 1rem;">@Map2dCard</div>
         }
+
+        <!-- Port stats playback table: per-port interface counters at the current scrubber position -->
+        <div class="card" id="port-stats-card" style="display: none; margin-top: 1rem;">
+            <div class="card-header">
+                <h2 class="card-title">Port Statistics</h2>
+            </div>
+            <div class="card-body">
+                <div class="health-filter-badges wan-filter-badges" id="port-stats-filter-badges"></div>
+                <div id="port-stats-table"></div>
+                <div class="port-speed-legend" id="port-stats-legend"></div>
+            </div>
+        </div>
     }
 
     @* ──────────────── Tab: ISP Health ──────────────── *@
@@ -1227,6 +1239,7 @@ else
     private bool _mapMounted = false;
     private bool _map2dMounted = false;
     private bool _wanLiveChartMounted = false;
+    private bool _portStatsMounted = false;
     private bool _latencyChartsMounted;
     private bool _healthChartsMounted;
     private bool _sfpChartsMounted;
@@ -1815,6 +1828,13 @@ else
         if (_wanLiveChartMounted)
         {
             try { await JS.InvokeVoidAsync("eval", $"window.__wanLiveChart?.seekTime({(isoTimestamp != null ? $"'{isoTimestamp}'" : "null")});"); }
+            catch { }
+        }
+
+        // Sync the port stats table to the same timeline position
+        if (_portStatsMounted)
+        {
+            try { await JS.InvokeVoidAsync("eval", $"window.__portStatsTable?.seekTime({(isoTimestamp != null ? $"'{isoTimestamp}'" : "null")});"); }
             catch { }
         }
 
@@ -2538,6 +2558,24 @@ else
             catch { }
         }
 
+        // Port stats playback table - Live tab only
+        if (_activeTab == "live" && _monitoringReady && !_portStatsMounted)
+        {
+            _portStatsMounted = true;
+            try
+            {
+                await JS.InvokeVoidAsync("eval",
+                    $"(async () => {{ const m = await import('{VersionedJs("/js/port-stats-table.js")}'); window.__portStatsTableModule = m; m.mount(document.getElementById('port-stats-card')); }})();");
+            }
+            catch (Exception ex) { _portStatsMounted = false; Logger.LogDebug(ex, "Port stats table mount failed; will retry on next render"); }
+        }
+        else if (_activeTab != "live" && _portStatsMounted)
+        {
+            _portStatsMounted = false;
+            try { await JS.InvokeVoidAsync("eval", "window.__portStatsTable?.unmount();"); }
+            catch { }
+        }
+
         // Latency charts - Performance tab only
         if (_activeTab == "performance" && _monitoringReady && !_latencyChartsMounted)
         {
@@ -2746,6 +2784,11 @@ else
         if (_wanLiveChartMounted)
         {
             try { _ = JS.InvokeVoidAsync("eval", "window.__wanLiveChart?.unmount();").AsTask(); }
+            catch { }
+        }
+        if (_portStatsMounted)
+        {
+            try { _ = JS.InvokeVoidAsync("eval", "window.__portStatsTable?.unmount();").AsTask(); }
             catch { }
         }
         if (_mapMounted)

--- a/src/NetworkOptimizer.Web/Endpoints/PortStatsEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/PortStatsEndpoints.cs
@@ -2,6 +2,7 @@ using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
+using NetworkOptimizer.Web.Services;
 
 namespace NetworkOptimizer.Web.Endpoints;
 
@@ -22,6 +23,7 @@ public static class PortStatsEndpoints
     {
         app.MapGet("/api/monitoring/port-stats", async (
             MonitoringInfluxClient influx,
+            MonitoringLiveStats liveStats,
             IDbContextFactory<NetworkOptimizerDbContext> dbFactory,
             string? macs,
             DateTime? at,
@@ -30,11 +32,13 @@ public static class PortStatsEndpoints
             var requested = (macs ?? "")
                 .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .ToList();
+            var filterMacs = requested.Count > 0 ? requested : null;
 
-            var points = await influx.QueryPortStatsAsync(
-                requested.Count > 0 ? requested : null,
-                at?.ToUniversalTime(),
-                ct);
+            // Live mode is served from the in-memory cache (sub-ms, no InfluxDB load);
+            // only historic scrubbing (an explicit timestamp) hits InfluxDB.
+            IReadOnlyList<MonitoringInfluxClient.PortStatsPoint> points = at.HasValue
+                ? await influx.QueryPortStatsAsync(filterMacs, at.Value.ToUniversalTime(), ct)
+                : liveStats.GetPortStatsSnapshot(filterMacs);
 
             await using var db = await dbFactory.CreateDbContextAsync(ct);
 
@@ -87,13 +91,20 @@ public static class PortStatsEndpoints
                             .Select(p =>
                             {
                                 mapByKey.TryGetValue((mac, p.IfName), out var nm);
+                                // VLAN sub-interfaces sit on a physical port, so they inherit
+                                // the parent port's number and media when their own row has
+                                // none (eth6.228 takes eth6's port number and SFP flag).
+                                InterfaceNameMap? parent = null;
+                                var sub = SubInterface.Match(p.IfName);
+                                if (sub.Success)
+                                    mapByKey.TryGetValue((mac, sub.Groups["base"].Value), out parent);
                                 return new
                                 {
                                     ifName = p.IfName,
                                     portId = p.PortId,
-                                    portNumber = nm?.PortNumber,
+                                    portNumber = nm?.PortNumber ?? parent?.PortNumber,
                                     friendlyName = ResolveFriendly(mac, p.IfName),
-                                    isSfp = nm?.IsSfp,
+                                    isSfp = nm?.IsSfp ?? parent?.IsSfp,
                                     linkSpeedMbps = nm?.SpeedMbps,
                                     operStatus = p.OperStatus,
                                     rateInBps = p.RateInBps,

--- a/src/NetworkOptimizer.Web/Endpoints/PortStatsEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/PortStatsEndpoints.cs
@@ -98,11 +98,19 @@ public static class PortStatsEndpoints
                                 var sub = SubInterface.Match(p.IfName);
                                 if (sub.Success)
                                     mapByKey.TryGetValue((mac, sub.Groups["base"].Value), out parent);
+                                var portNumber = nm?.PortNumber ?? parent?.PortNumber;
+                                // Single wired client on this physical port (links to the
+                                // Client Dashboard). Keyed on the port's OWN number so a
+                                // VLAN sub-interface doesn't borrow the parent's client.
+                                var client = nm?.PortNumber is int pnum ? liveStats.GetPortClient(mac, pnum) : null;
                                 return new
                                 {
                                     ifName = p.IfName,
                                     portId = p.PortId,
-                                    portNumber = nm?.PortNumber ?? parent?.PortNumber,
+                                    portNumber,
+                                    connectedMac = client?.Mac,
+                                    connectedIp = client?.Ip,
+                                    connectedName = client?.Name,
                                     // Agent-resolved WAN/carrier label wins (e.g. gre1 ->
                                     // "WAN3 - AT&T Wireless"); otherwise the port_table /
                                     // sub-interface friendly name.

--- a/src/NetworkOptimizer.Web/Endpoints/PortStatsEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/PortStatsEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
@@ -7,10 +8,16 @@ namespace NetworkOptimizer.Web.Endpoints;
 /// <summary>
 /// Point-in-time per-port statistics for the Live View port playback table.
 /// Reads <c>interface_counters</c> at the current map scrubber position (or the
-/// latest sample when no instant is supplied).
+/// latest sample when no instant is supplied) and enriches each port with the
+/// UniFi-correlated friendly name, port number, media type and negotiated link
+/// speed from <see cref="InterfaceNameMap"/>.
 /// </summary>
 public static class PortStatsEndpoints
 {
+    // Matches a VLAN sub-interface such as "eth6.228" or "switch0.99": a base
+    // interface name followed by a dotted numeric VLAN id.
+    private static readonly Regex SubInterface = new(@"^(?<base>.+)\.(?<vlan>\d+)$", RegexOptions.Compiled);
+
     public static void Map(WebApplication app)
     {
         app.MapGet("/api/monitoring/port-stats", async (
@@ -29,45 +36,88 @@ public static class PortStatsEndpoints
                 at?.ToUniversalTime(),
                 ct);
 
-            // Map device MAC -> display name from the fabric monitoring targets,
-            // matching how the device health chart resolves device names.
             await using var db = await dbFactory.CreateDbContextAsync(ct);
-            var nameByMac = await db.MonitoringTargets.AsNoTracking()
+
+            // Device display name + type ("ap" / "switch" / "gateway") from the fabric
+            // monitoring targets, matching how the device health chart resolves names.
+            var targets = await db.MonitoringTargets.AsNoTracking()
                 .Where(t => t.TargetType == MonitoringTargetType.Fabric && t.DeviceMac != null)
-                .Select(t => new { t.DeviceMac, t.Name })
-                .ToDictionaryAsync(t => t.DeviceMac!, t => t.Name, StringComparer.OrdinalIgnoreCase, ct);
+                .Select(t => new { t.DeviceMac, t.Name, t.AutoLabel })
+                .ToListAsync(ct);
+            var targetByMac = targets
+                .GroupBy(t => Norm(t.DeviceMac!))
+                .ToDictionary(g => g.Key, g => g.First());
+
+            // UniFi-correlated interface metadata keyed by (mac, ifName).
+            var nameMaps = await db.InterfaceNameMaps.AsNoTracking().ToListAsync(ct);
+            var mapByKey = new Dictionary<(string mac, string ifName), InterfaceNameMap>();
+            var friendlyByMacIf = new Dictionary<(string mac, string ifName), string>();
+            foreach (var m in nameMaps)
+            {
+                var k = (Norm(m.DeviceMac), m.IfName);
+                mapByKey[k] = m;
+                if (!string.IsNullOrWhiteSpace(m.FriendlyName))
+                    friendlyByMacIf[k] = m.FriendlyName!;
+            }
+
+            string? ResolveFriendly(string mac, string ifName)
+            {
+                if (friendlyByMacIf.TryGetValue((mac, ifName), out var direct))
+                    return direct;
+                // VLAN sub-interface: inherit the parent port's friendly name and tag
+                // it with the VLAN id, e.g. eth6.228 -> "Fiber ISP (228)".
+                var sub = SubInterface.Match(ifName);
+                if (sub.Success && friendlyByMacIf.TryGetValue((mac, sub.Groups["base"].Value), out var parent))
+                    return $"{parent} ({sub.Groups["vlan"].Value})";
+                return null;
+            }
 
             var devices = points
                 .GroupBy(p => p.DeviceMac, StringComparer.OrdinalIgnoreCase)
-                .Select(g => new
+                .Select(g =>
                 {
-                    mac = g.Key,
-                    name = nameByMac.TryGetValue(g.Key, out var n) && !string.IsNullOrWhiteSpace(n) ? n : g.Key,
-                    ports = g
-                        .OrderBy(p => p.PortId, StringComparer.OrdinalIgnoreCase)
-                        .ThenBy(p => p.IfName, StringComparer.OrdinalIgnoreCase)
-                        .Select(p => new
-                        {
-                            ifName = p.IfName,
-                            portId = p.PortId,
-                            operStatus = p.OperStatus,
-                            speedBps = p.SpeedBps,
-                            rateInBps = p.RateInBps,
-                            rateOutBps = p.RateOutBps,
-                            bytesIn = p.BytesIn,
-                            bytesOut = p.BytesOut,
-                            ucastPktsIn = p.UcastPktsIn,
-                            ucastPktsOut = p.UcastPktsOut,
-                            mcastPktsIn = p.McastPktsIn,
-                            mcastPktsOut = p.McastPktsOut,
-                            bcastPktsIn = p.BcastPktsIn,
-                            bcastPktsOut = p.BcastPktsOut,
-                            errorsIn = p.ErrorsIn,
-                            errorsOut = p.ErrorsOut,
-                            discardsIn = p.DiscardsIn,
-                            discardsOut = p.DiscardsOut,
-                        })
-                        .ToList()
+                    var mac = Norm(g.Key);
+                    targetByMac.TryGetValue(mac, out var target);
+                    return new
+                    {
+                        mac = g.Key,
+                        name = !string.IsNullOrWhiteSpace(target?.Name) ? target!.Name : g.Key,
+                        type = NormalizeType(target?.AutoLabel),
+                        ports = g
+                            .Select(p =>
+                            {
+                                mapByKey.TryGetValue((mac, p.IfName), out var nm);
+                                return new
+                                {
+                                    ifName = p.IfName,
+                                    portId = p.PortId,
+                                    portNumber = nm?.PortNumber,
+                                    friendlyName = ResolveFriendly(mac, p.IfName),
+                                    isSfp = nm?.IsSfp,
+                                    linkSpeedMbps = nm?.SpeedMbps,
+                                    operStatus = p.OperStatus,
+                                    rateInBps = p.RateInBps,
+                                    rateOutBps = p.RateOutBps,
+                                    bytesIn = p.BytesIn,
+                                    bytesOut = p.BytesOut,
+                                    ucastPktsIn = p.UcastPktsIn,
+                                    ucastPktsOut = p.UcastPktsOut,
+                                    mcastPktsIn = p.McastPktsIn,
+                                    mcastPktsOut = p.McastPktsOut,
+                                    bcastPktsIn = p.BcastPktsIn,
+                                    bcastPktsOut = p.BcastPktsOut,
+                                    errorsIn = p.ErrorsIn,
+                                    errorsOut = p.ErrorsOut,
+                                    discardsIn = p.DiscardsIn,
+                                    discardsOut = p.DiscardsOut,
+                                };
+                            })
+                            // Physical ports first, ordered by port number; virtual /
+                            // sub-interfaces (no port number) fall to the bottom by name.
+                            .OrderBy(p => p.portNumber ?? int.MaxValue)
+                            .ThenBy(p => p.ifName, StringComparer.OrdinalIgnoreCase)
+                            .ToList()
+                    };
                 })
                 .OrderBy(d => d.name, StringComparer.OrdinalIgnoreCase)
                 .ToList();
@@ -75,4 +125,15 @@ public static class PortStatsEndpoints
             return Results.Ok(new { at = at?.ToUniversalTime().ToString("o"), devices });
         });
     }
+
+    private static string Norm(string mac) =>
+        string.IsNullOrEmpty(mac) ? string.Empty : mac.ToLowerInvariant().Replace('-', ':');
+
+    private static string NormalizeType(string? autoLabel) => (autoLabel ?? "").ToLowerInvariant() switch
+    {
+        "ap" => "ap",
+        "switch" => "switch",
+        "gateway" => "gateway",
+        _ => "unknown"
+    };
 }

--- a/src/NetworkOptimizer.Web/Endpoints/PortStatsEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/PortStatsEndpoints.cs
@@ -1,0 +1,78 @@
+using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Storage.Services;
+
+namespace NetworkOptimizer.Web.Endpoints;
+
+/// <summary>
+/// Point-in-time per-port statistics for the Live View port playback table.
+/// Reads <c>interface_counters</c> at the current map scrubber position (or the
+/// latest sample when no instant is supplied).
+/// </summary>
+public static class PortStatsEndpoints
+{
+    public static void Map(WebApplication app)
+    {
+        app.MapGet("/api/monitoring/port-stats", async (
+            MonitoringInfluxClient influx,
+            IDbContextFactory<NetworkOptimizerDbContext> dbFactory,
+            string? macs,
+            DateTime? at,
+            CancellationToken ct) =>
+        {
+            var requested = (macs ?? "")
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToList();
+
+            var points = await influx.QueryPortStatsAsync(
+                requested.Count > 0 ? requested : null,
+                at?.ToUniversalTime(),
+                ct);
+
+            // Map device MAC -> display name from the fabric monitoring targets,
+            // matching how the device health chart resolves device names.
+            await using var db = await dbFactory.CreateDbContextAsync(ct);
+            var nameByMac = await db.MonitoringTargets.AsNoTracking()
+                .Where(t => t.TargetType == MonitoringTargetType.Fabric && t.DeviceMac != null)
+                .Select(t => new { t.DeviceMac, t.Name })
+                .ToDictionaryAsync(t => t.DeviceMac!, t => t.Name, StringComparer.OrdinalIgnoreCase, ct);
+
+            var devices = points
+                .GroupBy(p => p.DeviceMac, StringComparer.OrdinalIgnoreCase)
+                .Select(g => new
+                {
+                    mac = g.Key,
+                    name = nameByMac.TryGetValue(g.Key, out var n) && !string.IsNullOrWhiteSpace(n) ? n : g.Key,
+                    ports = g
+                        .OrderBy(p => p.PortId, StringComparer.OrdinalIgnoreCase)
+                        .ThenBy(p => p.IfName, StringComparer.OrdinalIgnoreCase)
+                        .Select(p => new
+                        {
+                            ifName = p.IfName,
+                            portId = p.PortId,
+                            operStatus = p.OperStatus,
+                            speedBps = p.SpeedBps,
+                            rateInBps = p.RateInBps,
+                            rateOutBps = p.RateOutBps,
+                            bytesIn = p.BytesIn,
+                            bytesOut = p.BytesOut,
+                            ucastPktsIn = p.UcastPktsIn,
+                            ucastPktsOut = p.UcastPktsOut,
+                            mcastPktsIn = p.McastPktsIn,
+                            mcastPktsOut = p.McastPktsOut,
+                            bcastPktsIn = p.BcastPktsIn,
+                            bcastPktsOut = p.BcastPktsOut,
+                            errorsIn = p.ErrorsIn,
+                            errorsOut = p.ErrorsOut,
+                            discardsIn = p.DiscardsIn,
+                            discardsOut = p.DiscardsOut,
+                        })
+                        .ToList()
+                })
+                .OrderBy(d => d.name, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            return Results.Ok(new { at = at?.ToUniversalTime().ToString("o"), devices });
+        });
+    }
+}

--- a/src/NetworkOptimizer.Web/Endpoints/PortStatsEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/PortStatsEndpoints.cs
@@ -15,7 +15,7 @@ namespace NetworkOptimizer.Web.Endpoints;
 /// </summary>
 public static class PortStatsEndpoints
 {
-    // Matches a VLAN sub-interface such as "eth6.228" or "switch0.99": a base
+    // Matches a VLAN sub-interface such as "eth0.100" or "switch0.99": a base
     // interface name followed by a dotted numeric VLAN id.
     private static readonly Regex SubInterface = new(@"^(?<base>.+)\.(?<vlan>\d+)$", RegexOptions.Compiled);
 
@@ -69,7 +69,7 @@ public static class PortStatsEndpoints
                 if (friendlyByMacIf.TryGetValue((mac, ifName), out var direct))
                     return direct;
                 // VLAN sub-interface: inherit the parent port's friendly name and tag
-                // it with the VLAN id, e.g. eth6.228 -> "Fiber ISP (228)".
+                // it with the VLAN id, e.g. eth0.100 -> "Fiber ISP (100)".
                 var sub = SubInterface.Match(ifName);
                 if (sub.Success && friendlyByMacIf.TryGetValue((mac, sub.Groups["base"].Value), out var parent))
                     return $"{parent} ({sub.Groups["vlan"].Value})";
@@ -93,7 +93,7 @@ public static class PortStatsEndpoints
                                 mapByKey.TryGetValue((mac, p.IfName), out var nm);
                                 // VLAN sub-interfaces sit on a physical port, so they inherit
                                 // the parent port's number and media when their own row has
-                                // none (eth6.228 takes eth6's port number and SFP flag).
+                                // none (eth0.100 takes eth0's port number and SFP flag).
                                 InterfaceNameMap? parent = null;
                                 var sub = SubInterface.Match(p.IfName);
                                 if (sub.Success)

--- a/src/NetworkOptimizer.Web/Endpoints/PortStatsEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/PortStatsEndpoints.cs
@@ -103,7 +103,11 @@ public static class PortStatsEndpoints
                                     ifName = p.IfName,
                                     portId = p.PortId,
                                     portNumber = nm?.PortNumber ?? parent?.PortNumber,
-                                    friendlyName = ResolveFriendly(mac, p.IfName),
+                                    // Agent-resolved WAN/carrier label wins (e.g. gre1 ->
+                                    // "WAN3 - AT&T Wireless"); otherwise the port_table /
+                                    // sub-interface friendly name.
+                                    friendlyName = liveStats.GetInterfaceLabel(mac, p.IfName)
+                                        ?? ResolveFriendly(mac, p.IfName),
                                     isSfp = nm?.IsSfp ?? parent?.IsSfp,
                                     linkSpeedMbps = nm?.SpeedMbps,
                                     operStatus = p.OperStatus,

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -1657,6 +1657,7 @@ IspHealthEndpoints.Map(app);
 MonitoringInvestigateEndpoints.Map(app);
 FlakyTargetEndpoints.Map(app);
 DeviceHealthChartEndpoints.Map(app);
+PortStatsEndpoints.Map(app);
 SfpChartEndpoints.Map(app);
 CellularChartEndpoints.Map(app);
 CmChartEndpoints.Map(app);

--- a/src/NetworkOptimizer.Web/Services/ClientDashboardService.cs
+++ b/src/NetworkOptimizer.Web/Services/ClientDashboardService.cs
@@ -86,7 +86,8 @@ public class ClientDashboardService
 
                 // Verify the IP still matches - if another device took this IP
                 // (DHCP reassignment), the MAC lookup returns the wrong device.
-                if (client != null && client.Ip != clientIp)
+                // Match on BestIp so fixed/reservation devices (empty live ip) still match.
+                if (client != null && client.BestIp != clientIp)
                 {
                     _logger.LogTrace("Identify {Ip}: IP mismatch (device now at {NewIp}), invalidating cache", clientIp, client.Ip);
                     client = null;
@@ -105,7 +106,7 @@ public class ClientDashboardService
             {
                 _logger.LogTrace("Identify {Ip}: slow path via stat/sta (all clients)", clientIp);
                 var clients = await _connectionService.Client.GetClientsAsync();
-                client = clients?.FirstOrDefault(c => c.Ip == clientIp);
+                client = clients?.FirstOrDefault(c => c.BestIp == clientIp);
             }
 
             if (client != null)

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -853,6 +853,13 @@ public class MonitoringCollectionAgent : BackgroundService
         var devices = await GetMonitorableDevicesAsync(ct);
         if (devices.Count == 0) return;
 
+        // Resolve WAN/carrier interface labels (e.g. gre1 -> "WAN3 - AT&T Wireless (5G)")
+        // from the UniFi device config and cache them for the Live View port table.
+        // Done agent-side so this can become persisted time series in a later build.
+        foreach (var device in devices)
+            _liveStats.RecordInterfaceLabels(NormalizeMac(device.Mac),
+                InterfaceLabelResolver.BuildWanLabels(device));
+
         var poller = GetOrBuildPoller(settings);
         if (poller == null) return;
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -928,10 +928,12 @@ public class MonitoringCollectionAgent : BackgroundService
                     //  - Gateways: ifIndex != PortIdx; PortTable.IfName joins to SNMP
                     //    iface.Name (Linux name like "eth4"). Direct numeric match
                     //    first, fall back to ifname match.
-                    int? portNumber = null;
+                    // The matched port supplies BOTH the port number and the UniFi
+                    // friendly name, so gateways (which only resolve via the IfName
+                    // fallback) get a friendly name too, not just switches.
+                    SwitchPort? portMatch = null;
                     if (device.PortTable != null)
                     {
-                        SwitchPort? portMatch = null;
                         if (iface.Index > 0)
                             portMatch = device.PortTable.FirstOrDefault(p => p.PortIdx == iface.Index);
                         if (portMatch == null && !string.IsNullOrEmpty(ifName))
@@ -941,9 +943,27 @@ public class MonitoringCollectionAgent : BackgroundService
                                 && string.Equals(p.IfName, ifName, StringComparison.OrdinalIgnoreCase)
                                 && p.PortIdx > 0);
                         }
-                        if (portMatch != null && portMatch.PortIdx > 0)
-                            portNumber = portMatch.PortIdx;
                     }
+                    int? portNumber = portMatch is { PortIdx: > 0 } ? portMatch.PortIdx : null;
+                    var friendlyName = string.IsNullOrEmpty(portMatch?.Name) ? null : portMatch.Name;
+                    var isSfp = portMatch?.SfpFound;
+
+                    // Link speed: "lower of the two wins". SNMP is fresh and correct on
+                    // switches, but a gateway inflates copper ports to their 10G capability
+                    // (ifHighSpeed/ifSpeed both report the max, not the negotiated rate).
+                    // Negotiated speed can never exceed SNMP's reported value, so when
+                    // UniFi's PortTable reports a lower negotiated speed we take it.
+                    int? snmpSpeedMbps = iface.HighSpeed > 0
+                        ? (int)iface.HighSpeed
+                        : (iface.Speed > 0 ? (int)(iface.Speed / 1_000_000) : (int?)null);
+                    int? unifiSpeedMbps = portMatch is { Speed: > 0 } ? portMatch.Speed : (int?)null;
+                    int? linkSpeedMbps = (snmpSpeedMbps, unifiSpeedMbps) switch
+                    {
+                        (null, null) => null,
+                        (null, var u) => u,
+                        (var s, null) => s,
+                        var (s, u) => Math.Min(s.Value, u.Value),
+                    };
 
                     if (!existingMaps.TryGetValue(key, out var mapping))
                     {
@@ -953,9 +973,10 @@ public class MonitoringCollectionAgent : BackgroundService
                             IfName = ifName,
                             IfIndex = iface.Index,
                             IfAlias = iface.Description,
-                            SpeedMbps = (int?)(iface.HighSpeed > 0 ? iface.HighSpeed : iface.Speed / 1_000_000),
-                            FriendlyName = LookupUniFiPortName(device, iface),
+                            SpeedMbps = linkSpeedMbps,
+                            FriendlyName = friendlyName,
                             PortNumber = portNumber,
+                            IsSfp = isSfp,
                             LastUpdated = DateTime.UtcNow
                         };
                         db.InterfaceNameMaps.Add(mapping);
@@ -968,11 +989,10 @@ public class MonitoringCollectionAgent : BackgroundService
                     {
                         mapping.IfIndex = iface.Index;
                         mapping.IfAlias = iface.Description;
-                        if (iface.HighSpeed > 0) mapping.SpeedMbps = (int)iface.HighSpeed;
-                        else if (iface.Speed > 0) mapping.SpeedMbps = (int)(iface.Speed / 1_000_000);
-                        var unifiName = LookupUniFiPortName(device, iface);
-                        if (!string.IsNullOrEmpty(unifiName)) mapping.FriendlyName = unifiName;
+                        if (linkSpeedMbps.HasValue) mapping.SpeedMbps = linkSpeedMbps;
+                        if (!string.IsNullOrEmpty(friendlyName)) mapping.FriendlyName = friendlyName;
                         if (portNumber.HasValue) mapping.PortNumber = portNumber;
+                        if (isSfp.HasValue) mapping.IsSfp = isSfp;
                         mapping.LastUpdated = DateTime.UtcNow;
                     }
                 }
@@ -1785,19 +1805,6 @@ public class MonitoringCollectionAgent : BackgroundService
         NetworkOptimizer.Core.Enums.DeviceType.AccessPoint => "ap",
         _ => "unknown"
     };
-
-    private static string? LookupUniFiPortName(UniFiDeviceResponse device, InterfaceMetrics iface)
-    {
-        // PortTable entries on switches/gateways have user-defined per-port names. Match by
-        // port index (UniFi's "port_idx") to the SNMP ifIndex when possible. For the MVP we
-        // fall back to the SNMP description / name; the topology-driven match comes later.
-        if (device.PortTable != null)
-        {
-            var match = device.PortTable.FirstOrDefault(p => p.PortIdx == iface.Index);
-            if (match != null && !string.IsNullOrEmpty(match.Name)) return match.Name;
-        }
-        return null;
-    }
 
     private void CollectSfpForDevice(
         UniFiDeviceResponse device,

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -1071,6 +1071,30 @@ public class MonitoringCollectionAgent : BackgroundService
         var wifiCount = clients.Count(c => !c.IsWired);
         var wiredCount = clients.Count(c => c.IsWired);
         _logger.LogDebug("WiFi tier: {Total} clients ({Wifi} wifi, {Wired} wired)", clients.Length, wifiCount, wiredCount);
+
+        // Map each switch/gateway port that has exactly one wired client to that client,
+        // for the Live View port stats "Client" column. Ports with multiple MACs
+        // (uplinks/trunks) are skipped so we never label them with an arbitrary client.
+        var wiredByPort = new Dictionary<(string, int), List<UniFiClientResponse>>();
+        foreach (var c in clients)
+        {
+            if (!c.IsWired || string.IsNullOrEmpty(c.Mac) || string.IsNullOrEmpty(c.SwMac)
+                || c.SwPort is not int swp || swp <= 0) continue;
+            var key = (NormalizeMac(c.SwMac), swp);
+            if (!wiredByPort.TryGetValue(key, out var list)) { list = new(); wiredByPort[key] = list; }
+            list.Add(c);
+        }
+        var portClients = new Dictionary<(string DeviceMac, int Port), MonitoringLiveStats.PortClient>();
+        foreach (var (key, list) in wiredByPort)
+        {
+            if (list.Count != 1) continue;
+            var pc = list[0];
+            var pcName = !string.IsNullOrWhiteSpace(pc.Name) ? pc.Name
+                : !string.IsNullOrWhiteSpace(pc.Hostname) ? pc.Hostname : pc.Mac;
+            portClients[key] = new MonitoringLiveStats.PortClient(pc.Mac, pc.Ip ?? string.Empty, pcName);
+        }
+        _liveStats.RecordPortClients(portClients);
+
         long tickOffset = 0; // nanosecond offset per client to avoid InfluxDB dedup
         foreach (var c in clients)
         {

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -1572,6 +1572,32 @@ public class MonitoringCollectionAgent : BackgroundService
             bcastPktsOut: iface.OutBroadcastPkts > 0 ? iface.OutBroadcastPkts : null,
             timestamp: now);
 
+        // Mirror the full per-port snapshot into the live cache so the Live View port
+        // stats table can serve live mode from memory instead of querying InfluxDB.
+        _liveStats.RecordPortStats(new MonitoringInfluxClient.PortStatsPoint
+        {
+            DeviceMac = mac,
+            IfName = ifName,
+            PortId = iface.PortId ?? "",
+            OperStatus = iface.OperStatus,
+            SpeedBps = speedBps > 0 ? speedBps : (long?)null,
+            RateInBps = rateInBps,
+            RateOutBps = rateOutBps,
+            BytesIn = iface.InOctets,
+            BytesOut = iface.OutOctets,
+            UcastPktsIn = iface.InUcastPkts,
+            UcastPktsOut = iface.OutUcastPkts,
+            McastPktsIn = iface.InMulticastPkts,
+            McastPktsOut = iface.OutMulticastPkts,
+            BcastPktsIn = iface.InBroadcastPkts,
+            BcastPktsOut = iface.OutBroadcastPkts,
+            ErrorsIn = iface.InErrors,
+            ErrorsOut = iface.OutErrors,
+            DiscardsIn = iface.InDiscards,
+            DiscardsOut = iface.OutDiscards,
+            Time = now,
+        });
+
         // SNMP per-interface rates feed the port-keyed cache. Match SNMP ifName to
         // UniFi PortTable.Name (both Linux names like "eth4") then write keyed by
         // PortTable.PortIdx (the UniFi-side port number the post-process looks up).

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -1008,7 +1008,13 @@ public class MonitoringCollectionAgent : BackgroundService
 
                 // Resolve friendly interface labels (WANn - carrier, WireGuard, SQM,
                 // honeypot, ...) from the device config + networkconf and cache them for
-                // the Live View port table. Agent-side so it can become time series later.
+                // the Live View port table.
+                //
+                // FUTURE TIME SERIES TOUCH POINT: this is where per-interface identity
+                // (label, WAN group, carrier, media) and status (oper_status) would also
+                // be written to InfluxDB so the port table can play back historical
+                // identity/status, not just the current snapshot. Resolved here, agent-
+                // side, precisely so that move is a localized addition.
                 _liveStats.RecordInterfaceLabels(NormalizeMac(device.Mac),
                     InterfaceLabelResolver.BuildLabels(device, networkConfigs, deviceIfNames));
             }

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -853,12 +853,12 @@ public class MonitoringCollectionAgent : BackgroundService
         var devices = await GetMonitorableDevicesAsync(ct);
         if (devices.Count == 0) return;
 
-        // Resolve WAN/carrier interface labels (e.g. gre1 -> "WAN3 - AT&T Wireless (5G)")
-        // from the UniFi device config and cache them for the Live View port table.
-        // Done agent-side so this can become persisted time series in a later build.
-        foreach (var device in devices)
-            _liveStats.RecordInterfaceLabels(NormalizeMac(device.Mac),
-                InterfaceLabelResolver.BuildWanLabels(device));
+        // Network config (cached ~5 min) feeds the WireGuard / OpenVPN / honeypot /
+        // bridge interface labels resolved below. Best-effort: a fetch failure just
+        // means those families fall back to their raw ifname.
+        IReadOnlyList<NetworkInfo> networkConfigs = Array.Empty<NetworkInfo>();
+        try { networkConfigs = await _connectionService.GetNetworksAsync(ct); }
+        catch (Exception ex) { _logger.LogDebug(ex, "networkconf fetch for interface labels failed"); }
 
         var poller = GetOrBuildPoller(settings);
         if (poller == null) return;
@@ -924,10 +924,12 @@ public class MonitoringCollectionAgent : BackgroundService
                     NoteSnmpFailure(NormalizeMac(device.Mac));
                     continue;
                 }
+                var deviceIfNames = new List<string>();
                 foreach (var iface in interfaces)
                 {
                     var ifName = string.IsNullOrEmpty(iface.Name) ? iface.Description : iface.Name;
                     if (string.IsNullOrEmpty(ifName)) continue;
+                    deviceIfNames.Add(ifName);
                     var key = (NormalizeMac(device.Mac), ifName);
 
                     // Map SNMP ifIndex to UniFi PortTable.PortIdx. Two strategies:
@@ -1003,6 +1005,12 @@ public class MonitoringCollectionAgent : BackgroundService
                         mapping.LastUpdated = DateTime.UtcNow;
                     }
                 }
+
+                // Resolve friendly interface labels (WANn - carrier, WireGuard, SQM,
+                // honeypot, ...) from the device config + networkconf and cache them for
+                // the Live View port table. Agent-side so it can become time series later.
+                _liveStats.RecordInterfaceLabels(NormalizeMac(device.Mac),
+                    InterfaceLabelResolver.BuildLabels(device, networkConfigs, deviceIfNames));
             }
             catch (Exception ex)
             {

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -1091,7 +1091,9 @@ public class MonitoringCollectionAgent : BackgroundService
             var pc = list[0];
             var pcName = !string.IsNullOrWhiteSpace(pc.Name) ? pc.Name
                 : !string.IsNullOrWhiteSpace(pc.Hostname) ? pc.Hostname : pc.Mac;
-            portClients[key] = new MonitoringLiveStats.PortClient(pc.Mac, pc.Ip ?? string.Empty, pcName);
+            // BestIp falls back ip -> last_ip -> fixed_ip, so fixed/reservation devices
+            // (no live DHCP lease) still resolve, matching the UniFi client table.
+            portClients[key] = new MonitoringLiveStats.PortClient(pc.Mac, pc.BestIp ?? string.Empty, pcName);
         }
         _liveStats.RecordPortClients(portClients);
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
@@ -216,6 +216,27 @@ public class MonitoringLiveStats
             : point;
     }
 
+    // Agent-resolved interface display labels (ifname -> friendly label) per device,
+    // e.g. "gre1" -> "WAN3 - AT&T Wireless (5G)". Resolved live by the polling agent
+    // from UniFi config so this can become persisted time series later; for now it is
+    // an in-memory snapshot read by the port stats endpoint. Purely additive.
+    private readonly ConcurrentDictionary<string, IReadOnlyDictionary<string, string>> _interfaceLabels = new();
+
+    /// <summary>Replaces the resolved ifname→label map for a device.</summary>
+    public void RecordInterfaceLabels(string deviceMac, IReadOnlyDictionary<string, string> labels)
+    {
+        if (string.IsNullOrEmpty(deviceMac) || labels == null) return;
+        _interfaceLabels[Normalize(deviceMac)] = labels;
+    }
+
+    /// <summary>Resolved label for a device interface, or null when none is known.</summary>
+    public string? GetInterfaceLabel(string deviceMac, string ifName)
+    {
+        if (string.IsNullOrEmpty(deviceMac) || string.IsNullOrEmpty(ifName)) return null;
+        return _interfaceLabels.TryGetValue(Normalize(deviceMac), out var map)
+            && map.TryGetValue(ifName, out var label) ? label : null;
+    }
+
     /// <summary>Latest cached per-port snapshot, optionally filtered to specific device MACs.</summary>
     public IReadOnlyList<MonitoringInfluxClient.PortStatsPoint> GetPortStatsSnapshot(IReadOnlyCollection<string>? deviceMacs)
     {

--- a/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Storage.Services;
 
 namespace NetworkOptimizer.Web.Services;
 
@@ -174,6 +175,56 @@ public class MonitoringLiveStats
     {
         if (string.IsNullOrEmpty(deviceMac) || string.IsNullOrEmpty(ifName)) return null;
         return _portRates.TryGetValue((Normalize(deviceMac), ifName), out var v) ? v : null;
+    }
+
+    // Full per-port snapshot (status, speed, packets, errors, discards + rates) for
+    // the Live View port stats table, letting live mode skip an InfluxDB round-trip.
+    // Independent of _portRates above (which the 3D map leaf rates depend on) - this
+    // is purely additive and read only by the port stats endpoint's live path.
+    private readonly ConcurrentDictionary<(string DeviceMac, string IfName), MonitoringInfluxClient.PortStatsPoint> _portStats = new();
+
+    public void RecordPortStats(MonitoringInfluxClient.PortStatsPoint point)
+    {
+        if (string.IsNullOrEmpty(point.DeviceMac) || string.IsNullOrEmpty(point.IfName)) return;
+        var key = (Normalize(point.DeviceMac), point.IfName);
+        // Carry forward any field the latest sample didn't carry (rates are only
+        // computed when a delta is available), so a partial cycle never blanks a column.
+        _portStats[key] = _portStats.TryGetValue(key, out var prior)
+            ? new MonitoringInfluxClient.PortStatsPoint
+            {
+                DeviceMac = point.DeviceMac,
+                IfName = point.IfName,
+                PortId = string.IsNullOrEmpty(point.PortId) ? prior.PortId : point.PortId,
+                OperStatus = point.OperStatus ?? prior.OperStatus,
+                SpeedBps = point.SpeedBps ?? prior.SpeedBps,
+                RateInBps = point.RateInBps ?? prior.RateInBps,
+                RateOutBps = point.RateOutBps ?? prior.RateOutBps,
+                BytesIn = point.BytesIn ?? prior.BytesIn,
+                BytesOut = point.BytesOut ?? prior.BytesOut,
+                UcastPktsIn = point.UcastPktsIn ?? prior.UcastPktsIn,
+                UcastPktsOut = point.UcastPktsOut ?? prior.UcastPktsOut,
+                McastPktsIn = point.McastPktsIn ?? prior.McastPktsIn,
+                McastPktsOut = point.McastPktsOut ?? prior.McastPktsOut,
+                BcastPktsIn = point.BcastPktsIn ?? prior.BcastPktsIn,
+                BcastPktsOut = point.BcastPktsOut ?? prior.BcastPktsOut,
+                ErrorsIn = point.ErrorsIn ?? prior.ErrorsIn,
+                ErrorsOut = point.ErrorsOut ?? prior.ErrorsOut,
+                DiscardsIn = point.DiscardsIn ?? prior.DiscardsIn,
+                DiscardsOut = point.DiscardsOut ?? prior.DiscardsOut,
+                Time = point.Time,
+            }
+            : point;
+    }
+
+    /// <summary>Latest cached per-port snapshot, optionally filtered to specific device MACs.</summary>
+    public IReadOnlyList<MonitoringInfluxClient.PortStatsPoint> GetPortStatsSnapshot(IReadOnlyCollection<string>? deviceMacs)
+    {
+        if (deviceMacs != null && deviceMacs.Count > 0)
+        {
+            var set = deviceMacs.Select(Normalize).ToHashSet();
+            return _portStats.Values.Where(p => set.Contains(Normalize(p.DeviceMac))).ToList();
+        }
+        return _portStats.Values.ToList();
     }
 
     /// <summary>Latest probe result for a specific monitoring target ID.</summary>
@@ -420,6 +471,11 @@ public class MonitoringLiveStats
         {
             if (kvp.Value.LastUpdate < cutoff)
                 _portRates.TryRemove(kvp.Key, out _);
+        }
+        foreach (var kvp in _portStats)
+        {
+            if (kvp.Value.Time < cutoff)
+                _portStats.TryRemove(kvp.Key, out _);
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
@@ -237,6 +237,28 @@ public class MonitoringLiveStats
             && map.TryGetValue(ifName, out var label) ? label : null;
     }
 
+    /// <summary>The single wired client on a switch/gateway port (for the port stats table).</summary>
+    public readonly record struct PortClient(string Mac, string Ip, string Name);
+
+    // Wired client per (device mac, port number), for ports with exactly one client.
+    // Refreshed by the WiFi/client tier; swapped atomically. Additive - nothing else
+    // reads this, so it can't regress existing consumers.
+    private volatile IReadOnlyDictionary<(string DeviceMac, int Port), PortClient> _portClients =
+        new Dictionary<(string, int), PortClient>();
+
+    /// <summary>Replaces the whole (device, port) → wired-client map.</summary>
+    public void RecordPortClients(IReadOnlyDictionary<(string DeviceMac, int Port), PortClient> map)
+    {
+        if (map != null) _portClients = map;
+    }
+
+    /// <summary>The wired client on a device port, or null when none / ambiguous.</summary>
+    public PortClient? GetPortClient(string deviceMac, int port)
+    {
+        if (string.IsNullOrEmpty(deviceMac)) return null;
+        return _portClients.TryGetValue((Normalize(deviceMac), port), out var c) ? c : null;
+    }
+
     /// <summary>Latest cached per-port snapshot, optionally filtered to specific device MACs.</summary>
     public IReadOnlyList<MonitoringInfluxClient.PortStatsPoint> GetPortStatsSnapshot(IReadOnlyCollection<string>? deviceMacs)
     {

--- a/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
@@ -49,7 +49,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     private DateTime _deviceCacheTime = DateTime.MinValue;
     private static readonly TimeSpan DeviceCacheDuration = TimeSpan.FromSeconds(30);
 
-    // Network cache (5 minute TTL - networks change rarely)
+    // Network cache (1 minute TTL - keeps Live View interface labels fresh)
     private List<NetworkInfo>? _cachedNetworks;
     private DateTime _networkCacheTime = DateTime.MinValue;
     private static readonly TimeSpan NetworkCacheDuration = TimeSpan.FromMinutes(1);

--- a/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
@@ -854,6 +854,8 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
             Enabled = n.Enabled,
             VlanId = n.Vlan,
             IpSubnet = n.IpSubnet,
+            VpnType = n.VpnType,
+            WireguardId = n.WireguardId,
             IsDhcpEnabled = n.DhcpdEnabled,
             DhcpRange = n.DhcpdEnabled ? $"{n.DhcpdStart} - {n.DhcpdStop}" : null,
             Gateway = n.DhcpdGateway,

--- a/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
@@ -5,7 +5,6 @@ using NetworkOptimizer.Storage.Interfaces;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
 using NetworkOptimizer.UniFi;
-using NetworkOptimizer.UniFi.Models;
 
 namespace NetworkOptimizer.Web.Services;
 
@@ -53,7 +52,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     // Network cache (5 minute TTL - networks change rarely)
     private List<NetworkInfo>? _cachedNetworks;
     private DateTime _networkCacheTime = DateTime.MinValue;
-    private static readonly TimeSpan NetworkCacheDuration = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan NetworkCacheDuration = TimeSpan.FromMinutes(1);
 
     // Lazy initialization for async config loading
     private Task? _initializationTask;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -16323,8 +16323,6 @@ body.kiosk-mode .status-indicators {
     align-items: center;
     gap: 0.4rem;
     white-space: nowrap;
-    user-select: none;
-    cursor: default;
 }
 
 .port-label {
@@ -16335,6 +16333,8 @@ body.kiosk-mode .status-indicators {
     display: inline-flex;
     align-items: center;
     color: var(--text-secondary);
+    user-select: none;
+    cursor: default;
 }
 
 .port-icon.port-icon-down {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -16323,6 +16323,8 @@ body.kiosk-mode .status-indicators {
     align-items: center;
     gap: 0.4rem;
     white-space: nowrap;
+    user-select: none;
+    cursor: default;
 }
 
 .port-label {
@@ -16338,24 +16340,6 @@ body.kiosk-mode .status-indicators {
 .port-icon.port-icon-down {
     color: var(--text-muted);
     opacity: 0.5;
-}
-
-.port-status {
-    display: inline-block;
-    padding: 0.1rem 0.45rem;
-    border-radius: 4px;
-    font-size: 0.7rem;
-    font-weight: 600;
-}
-
-.port-status-up {
-    color: var(--success-color);
-    background-color: rgba(36, 188, 112, 0.15);
-}
-
-.port-status-down {
-    color: var(--danger-color);
-    background-color: rgba(238, 99, 104, 0.15);
 }
 
 .port-speed-legend {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14299,7 +14299,7 @@ a.affected-client:hover {
     gap: 0.5rem;
     flex-wrap: wrap;
     justify-content: center;
-    padding-bottom: 1rem;
+    padding-bottom: 0.5rem;
 }
 
 .wan-filter-badge {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -16312,3 +16312,77 @@ body.kiosk-mode .header-actions {
 body.kiosk-mode .status-indicators {
     display: none;
 }
+
+.port-cell {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    white-space: nowrap;
+}
+
+.port-label {
+    color: var(--text-primary);
+}
+
+.port-icon {
+    display: inline-flex;
+    align-items: center;
+    color: var(--text-secondary);
+}
+
+.port-icon.port-icon-down {
+    color: var(--text-muted);
+    opacity: 0.5;
+}
+
+.port-status {
+    display: inline-block;
+    padding: 0.1rem 0.45rem;
+    border-radius: 4px;
+    font-size: 0.7rem;
+    font-weight: 600;
+}
+
+.port-status-up {
+    color: var(--success-color);
+    background-color: rgba(36, 188, 112, 0.15);
+}
+
+.port-status-down {
+    color: var(--danger-color);
+    background-color: rgba(238, 99, 104, 0.15);
+}
+
+.port-speed-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem 0.9rem;
+    margin-top: 0.75rem;
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+}
+
+.port-speed-key {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.port-speed-swatch {
+    width: 11px;
+    height: 11px;
+    border-radius: 2px;
+    background-color: currentColor;
+}
+
+.port-speed-10m { color: #6b7280; }
+.port-speed-100m { color: #8b5cf6; }
+.port-speed-1g { color: #3b82f6; }
+.port-speed-2_5g { color: #06b6d4; }
+.port-speed-5g { color: #14b8a6; }
+.port-speed-10g { color: #10b981; }
+.port-speed-20g { color: #22c55e; }
+.port-speed-25g { color: #84cc16; }
+.port-speed-40g { color: #eab308; }
+.port-speed-50g { color: #f97316; }
+.port-speed-100g { color: #ef4444; }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -16313,6 +16313,11 @@ body.kiosk-mode .status-indicators {
     display: none;
 }
 
+.port-stats-table .data-table th,
+.port-stats-table .data-table td {
+    white-space: nowrap;
+}
+
 .port-cell {
     display: inline-flex;
     align-items: center;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -16356,6 +16356,14 @@ body.kiosk-mode .status-indicators {
     color: var(--text-primary);
 }
 
+.port-client-link {
+    color: var(--info-color);
+}
+
+.port-client-link:hover {
+    text-decoration: underline;
+}
+
 @media (max-width: 768px) {
     .port-stats-1dev .data-table thead th:first-child,
     .port-stats-1dev .data-table td[data-stat-id] {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -16356,7 +16356,8 @@ body.kiosk-mode .status-indicators {
     color: var(--text-primary);
 }
 
-.port-client-link {
+.port-client-link,
+.port-client-link:visited {
     color: var(--info-color);
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -16356,6 +16356,13 @@ body.kiosk-mode .status-indicators {
     color: var(--text-primary);
 }
 
+@media (max-width: 768px) {
+    .port-stats-1dev .data-table thead th:first-child,
+    .port-stats-1dev .data-table td[data-stat-id] {
+        display: none;
+    }
+}
+
 .port-icon {
     display: inline-flex;
     align-items: center;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -16325,6 +16325,33 @@ body.kiosk-mode .status-indicators {
     white-space: nowrap;
 }
 
+.port-stats-scroll-top {
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-color: var(--bg-tertiary) transparent;
+}
+
+.port-stats-scroll-top > div {
+    height: 1px;
+}
+
+.port-stats-scroll-top::-webkit-scrollbar {
+    height: 10px;
+}
+
+.port-stats-scroll-top::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.port-stats-scroll-top::-webkit-scrollbar-thumb {
+    background: var(--bg-tertiary);
+    border-radius: 3px;
+}
+
+.port-stats-scroll-top::-webkit-scrollbar-thumb:hover {
+    background: var(--text-muted);
+}
+
 .port-label {
     color: var(--text-primary);
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
@@ -2,7 +2,7 @@
 // Same control pattern as sfp-charts.js and device-health-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=3';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=4';
 
 const PALETTE = window.Apex?.colors || ['#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7'];
 const _esc = document.createElement('span');

--- a/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
@@ -2,7 +2,7 @@
 // Same control pattern as sfp-charts.js and device-health-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=2';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=3';
 
 const PALETTE = window.Apex?.colors || ['#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7'];
 const _esc = document.createElement('span');

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-stats.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-stats.js
@@ -49,6 +49,10 @@ export function renderStatsTable(el, container, opts) {
     const scrollLeft = prev ? prev.scrollLeft : 0;
 
     const headers = columns.map((col, i) => {
+        // Columns can opt out of sorting (e.g. cells holding HTML, not a sortable value).
+        if (col.sortable === false) {
+            return `<th${col.cls ? ` class="${col.cls}"` : ''}>${col.header}</th>`;
+        }
         const active = i === sortCol;
         const arrow = active ? (sortDir === 'asc' ? ' ▲' : ' ▼') : '';
         const classes = [active ? 'stats-sort-active' : '', col.cls || ''].filter(Boolean).join(' ');

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-stats.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-stats.js
@@ -24,7 +24,7 @@ export function computeStats(values) {
 
 export function renderStatsTable(el, container, opts) {
     if (!el) return;
-    const { nameHeader = 'Name', rows, columns, filter } = opts;
+    const { nameHeader = 'Name', rows, columns, filter, title = 'Statistics' } = opts;
 
     if (!rows || rows.length === 0) { el.innerHTML = ''; return; }
 
@@ -51,13 +51,17 @@ export function renderStatsTable(el, container, opts) {
     const headers = columns.map((col, i) => {
         const active = i === sortCol;
         const arrow = active ? (sortDir === 'asc' ? ' ▲' : ' ▼') : '';
-        return `<th data-sort-col="${i}"${active ? ' class="stats-sort-active"' : ''}>${col.header}${arrow}</th>`;
+        const classes = [active ? 'stats-sort-active' : '', col.cls || ''].filter(Boolean).join(' ');
+        return `<th data-sort-col="${i}"${classes ? ` class="${classes}"` : ''}>${col.header}${arrow}</th>`;
     }).join('');
 
     const rowsHtml = sorted.map(r => {
         const filtered = r.visible === false;
         const cls = filtered ? ' class="stats-row-filtered"' : '';
-        const cells = r.values.map((v, i) => `<td>${filtered ? '-' : columns[i].format(v)}</td>`).join('');
+        const cells = r.values.map((v, i) => {
+            const colCls = columns[i].cls ? ` class="${columns[i].cls}"` : '';
+            return `<td${colCls}>${filtered ? '-' : columns[i].format(v)}</td>`;
+        }).join('');
         return `<tr${cls}>
             <td data-stat-id="${r.id}"><span class="stat-filter-badge"><span class="wan-badge-dot" style="background-color:${r.color}"></span>${escapeHtml(r.label)}</span></td>
             ${cells}
@@ -65,7 +69,7 @@ export function renderStatsTable(el, container, opts) {
     }).join('');
 
     el.innerHTML = `<div class="chart-card" style="margin-top:1rem">
-        <div class="chart-header"><h3 class="chart-title">Statistics</h3></div>
+        ${title ? `<div class="chart-header"><h3 class="chart-title">${title}</h3></div>` : ''}
         <div class="table-responsive">
         <table class="data-table" style="font-size:0.8125rem">
             <thead><tr>

--- a/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
@@ -2,7 +2,7 @@
 // Same control pattern as cellular-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=2';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=3';
 
 const PALETTE = window.Apex?.colors || ['#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7'];
 const _esc = document.createElement('span');

--- a/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
@@ -2,7 +2,7 @@
 // Same control pattern as cellular-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=3';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=4';
 
 const PALETTE = window.Apex?.colors || ['#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7'];
 const _esc = document.createElement('span');

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -2,7 +2,7 @@
 // filter badges, poll interval scaling) into a shared module so latency-charts,
 // device-health-charts, and future chart sets share one implementation.
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=2';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=3';
 
 const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
 const _colorCache = {};

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -2,7 +2,7 @@
 // filter badges, poll interval scaling) into a shared module so latency-charts,
 // device-health-charts, and future chart sets share one implementation.
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=3';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=4';
 
 const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
 const _colorCache = {};

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -824,6 +824,14 @@ class LanFlowMap2D {
         const hit=this._nodeAt(e.clientX-rect.left,e.clientY-rect.top);
         if(!hit)return;
         const d=hit.d;
+        // Switches and gateways scroll to the port stats table and isolate that device.
+        if(d.kind===NK.Switch||d.kind===NK.Gateway){
+            if(d.mac&&window.__portStatsTable){
+                window.__portStatsTable.selectDevice(d.mac);
+                document.getElementById('port-stats-card')?.scrollIntoView({behavior:'smooth',block:'start'});
+            }
+            return;
+        }
         if(d.kind!==NK.WifiClient&&d.kind!==NK.WiredClient)return;
         if(!d.ip)return;
         // Wi-Fi clients land on the Signal tab; wired clients go to the default tab.

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2898,6 +2898,14 @@ export class LanFlowMap {
         while (g && !(g.userData?.node)) g = g.parent;
         if (!g) return;
         const node = g.userData.node;
+        // Switches and gateways scroll to the port stats table and isolate that device.
+        if (node.kind === NODE_KIND.Switch || node.kind === NODE_KIND.Gateway) {
+            if (node.mac && window.__portStatsTable) {
+                window.__portStatsTable.selectDevice(node.mac);
+                document.getElementById('port-stats-card')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+            return;
+        }
         if (node.kind !== NODE_KIND.WifiClient && node.kind !== NODE_KIND.WiredClient) return;
         const ip = node.ip;
         if (!ip) return;

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -5,7 +5,7 @@
 // device-health-charts, and future chart sets share one implementation.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=3';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=4';
 
 const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
 const _colorCache = {};

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -5,7 +5,7 @@
 // device-health-charts, and future chart sets share one implementation.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=2';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=3';
 
 const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
 const _colorCache = {};

--- a/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
@@ -2,7 +2,7 @@
 // Same control pattern as cellular-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=2';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=3';
 
 const PALETTE = window.Apex?.colors || ['#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7'];
 const _esc = document.createElement('span');

--- a/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
@@ -2,7 +2,7 @@
 // Same control pattern as cellular-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=3';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=4';
 
 const PALETTE = window.Apex?.colors || ['#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7'];
 const _esc = document.createElement('span');

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -280,9 +280,11 @@ function renderTableNow(showAll) {
     if (!tableEl) return;
     const rows = buildRows();
     // When a single device is in view, the Device column is redundant - drop it on
-    // mobile (the CSS does the hiding; all other columns stay).
+    // mobile (the CSS does the hiding; all other columns stay). The flag goes on the
+    // container, not the table element, so the table's class stays exactly
+    // "port-stats-table" and keeps matching the [class$="-stats-table"] scrollbar style.
     const visibleDevices = tabDevices().filter(d => visibility[d.mac] !== false).length;
-    tableEl.classList.toggle('port-stats-1dev', visibleDevices <= 1);
+    if (container) container.classList.toggle('port-stats-1dev', visibleDevices <= 1);
     if (rows.length === 0) { tableEl.innerHTML = ''; syncTopScrollbar(); return; }
     renderTable(tableEl, container, {
         nameHeader: 'Device', title: '', rows, columns: COLUMNS, showAllRows: showAll,

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -113,15 +113,16 @@ function connectorGlyph(p) {
     const head = '<svg width="28" height="26" viewBox="0 0 28 26" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round">';
     const num = (cy) => `<text x="14" y="${cy}" text-anchor="middle" dominant-baseline="central" font-size="${String(n).length > 1 ? 9 : 11}" font-weight="700" fill="currentColor" stroke="none">${n}</text>`;
     if (sfp) {
-        // SFP/SFP+ cage: wide and short (~1.8:1), vertically centred, bottom key notch.
-        const body = '<rect x="3" y="7.5" width="22" height="12" rx="1.5"/><path d="M11 19.5 v-2.5 h6 v2.5"/>';
+        // SFP/SFP+ cage: wider and shorter than the RJ45, vertically centred, bottom key notch.
+        const body = '<rect x="3" y="7" width="22" height="13" rx="1.5"/><path d="M11 20 v-2.5 h6 v2.5"/>';
         return head + body + (n != null ? num(13.5) : '') + '</svg>';
     }
-    // RJ45 8P8C jack: tall, nearly square, with the bottom locking-tab slot.
-    const body = '<rect x="5" y="2.5" width="18" height="16" rx="1.5"/><path d="M10.5 18.5 v4.5 h7 V18.5"/>';
+    // RJ45 8P8C jack: wider than tall (between the female receptacle and the plug),
+    // with the bottom locking-tab slot.
+    const body = '<rect x="3.5" y="3" width="21" height="15" rx="1.5"/><path d="M10.5 18 v4 h7 V18"/>';
     const detail = n != null
         ? num(10.5)
-        : '<path d="M8 6 v5.5 M11 6 v5.5 M14 6 v5.5 M17 6 v5.5 M20 6 v5.5"/>';  // RJ45 pins
+        : '<path d="M8 6 v6 M11.5 6 v6 M15 6 v6 M18.5 6 v6 M22 6 v6"/>';  // RJ45 pins
     return head + body + detail + '</svg>';
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -39,6 +39,11 @@ let tableEl = null;
 let legendEl = null;
 let topScrollEl = null;     // mirror horizontal scrollbar above the table
 let scrollSyncing = null;   // re-entrancy guard for the two scrollbars ('top'|'resp')
+
+// Touch-primary devices scroll the table natively, and the mirror's scroll sync
+// interferes with momentum scrolling, so the top scrollbar is desktop-only.
+const IS_TOUCH = typeof window !== 'undefined'
+    && window.matchMedia && window.matchMedia('(pointer: coarse)').matches;
 let opts = {};
 
 let deviceMeta = [];        // [{ mac, name, color }]
@@ -296,6 +301,7 @@ function renderTableNow(showAll) {
 // re-created on every render, so re-measure and (re)wire its listener each time.
 function syncTopScrollbar() {
     if (!topScrollEl) return;
+    if (IS_TOUCH) { topScrollEl.style.display = 'none'; return; }   // native touch scroll only
     const resp = tableEl && tableEl.querySelector('.table-responsive');
     const inner = topScrollEl.firstElementChild;
     if (!resp || !inner) { topScrollEl.style.display = 'none'; return; }
@@ -437,7 +443,7 @@ export function mount(el, mountOpts = {}) {
     tabsEl = container.querySelector('#port-stats-tabs');
     legendEl = container.querySelector('#port-stats-legend');
     topScrollEl = container.querySelector('#port-stats-scroll-top');
-    if (topScrollEl && !topScrollEl._sync) {
+    if (topScrollEl && !IS_TOUCH && !topScrollEl._sync) {
         topScrollEl._sync = true;
         topScrollEl.addEventListener('scroll', () => {
             if (scrollSyncing === 'resp') return;   // don't fight an in-progress table scroll

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -2,7 +2,7 @@
 // at the current map scrubber position (or live), renders them via the shared
 // renderStatsTable(), and exposes selectDevice() so a map double-click can
 // isolate a single switch/gateway.
-import { renderStatsTable as renderTable } from './chart-stats.js?v=3';
+import { renderStatsTable as renderTable } from './chart-stats.js?v=4';
 
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s == null ? '' : String(s); return _esc.innerHTML; }
@@ -164,8 +164,8 @@ function clientCell(p) {
 }
 
 const COLUMNS = [
-    { header: 'Port', format: v => v.html },
-    { header: 'Client', format: v => v.html },
+    { header: 'Port', format: v => v.html, sortable: false },
+    { header: 'Client', format: v => v.html, sortable: false },
     { header: 'Rate In', format: fmtRate },
     { header: 'Rate Out', format: fmtRate },
     { header: 'Unicast In', format: fmtCount },

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -153,8 +153,20 @@ function portCell(p) {
     return `<span class="port-cell">${portIcon(p)}<span class="port-label"${tip}>${escapeHtml(name)}</span></span>`;
 }
 
+// The single wired client on this port, linked to its Client Dashboard by IP.
+function clientCell(p) {
+    const label = p.connectedName || p.connectedMac || p.connectedIp;
+    if (!label) return '';
+    if (p.connectedIp) {
+        const mac = p.connectedMac ? ` data-tooltip="${escapeHtml(p.connectedMac)}"` : '';
+        return `<a class="port-client-link" href="/client-dashboard?ip=${encodeURIComponent(p.connectedIp)}"${mac}>${escapeHtml(label)}</a>`;
+    }
+    return escapeHtml(label);
+}
+
 const COLUMNS = [
     { header: 'Port', format: v => v.html },
+    { header: 'Client', format: v => v.html },
     { header: 'Rate In', format: fmtRate },
     { header: 'Rate Out', format: fmtRate },
     { header: 'Unicast In', format: fmtCount },
@@ -221,6 +233,7 @@ function buildRows() {
                 visible: vis,
                 values: [
                     { html: portCell(p) },
+                    { html: clientCell(p) },
                     p.rateInBps, p.rateOutBps,
                     p.ucastPktsIn, p.ucastPktsOut,
                     p.mcastPktsIn, p.mcastPktsOut,

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -85,29 +85,39 @@ function portIsSfp(p) {
     return `${p.ifName || ''} ${p.portId || ''}`.toLowerCase().includes('sfp');
 }
 
-const RJ45_SVG = '<svg width="20" height="15" viewBox="0 0 20 15" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round">' +
-    '<rect x="3" y="2" width="14" height="8" rx="1"/>' +
-    '<path d="M7.5 10 v2.5 h5 V10"/>' +
-    '<path d="M6 4 v3 M8 4 v3 M10 4 v3 M12 4 v3 M14 4 v3"/></svg>';
-
-const SFP_SVG = '<svg width="22" height="15" viewBox="0 0 22 15" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round">' +
-    '<rect x="3" y="2.5" width="16" height="9" rx="1.5"/>' +
-    '<path d="M8.5 11.5 v-2.5 h5 v2.5"/></svg>';
+// Connector glyph (RJ45 jack or SFP cage), speed-coloured. When the port has a
+// number it is rendered on the connector face like a labelled patch panel;
+// numberless virtual interfaces keep the detailed RJ45 pins / SFP cage.
+function connectorGlyph(p) {
+    const sfp = portIsSfp(p);
+    const head = '<svg width="28" height="20" viewBox="0 0 28 20" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round">';
+    const body = sfp
+        ? '<rect x="4" y="3" width="20" height="11" rx="1.5"/><path d="M11 14 v-2.5 h6 v2.5"/>'
+        : '<rect x="4" y="2.5" width="20" height="11" rx="1.5"/><path d="M11 13.5 v3.5 h6 V13.5"/>';
+    let detail;
+    if (p.portNumber != null) {
+        const fs = String(p.portNumber).length > 1 ? 8 : 10;
+        detail = `<text x="14" y="${sfp ? 9 : 8.5}" text-anchor="middle" dominant-baseline="central" font-size="${fs}" font-weight="700" fill="currentColor" stroke="none">${p.portNumber}</text>`;
+    } else if (!sfp) {
+        detail = '<path d="M8 5 v4 M11 5 v4 M14 5 v4 M17 5 v4 M20 5 v4"/>';  // RJ45 pins
+    } else {
+        detail = '';  // bare SFP cage
+    }
+    return head + body + detail + '</svg>';
+}
 
 function portIcon(p) {
     const cls = speedClassMbps(p.linkSpeedMbps);
     const down = p.operStatus != null && p.operStatus !== 1;
-    const inner = portIsSfp(p) ? SFP_SVG : RJ45_SVG;
     const tip = p.linkSpeedMbps ? fmtLinkSpeed(p.linkSpeedMbps) : (down ? 'Down' : '');
-    return `<span class="port-icon ${cls}${down ? ' port-icon-down' : ''}"${tip ? ` data-tooltip="${escapeHtml(tip)}"` : ''}>${inner}</span>`;
+    return `<span class="port-icon ${cls}${down ? ' port-icon-down' : ''}"${tip ? ` data-tooltip="${escapeHtml(tip)}"` : ''}>${connectorGlyph(p)}</span>`;
 }
 
 function portCell(p) {
-    // UniFi friendly name (mapped from the Linux ifName) when we have one, with the
-    // port number prefixed as "[N] Name"; otherwise the raw interface name.
+    // Port number rides on the connector glyph; the label is just the UniFi
+    // friendly name (mapped from the Linux ifName), or the raw name as fallback.
     const name = p.friendlyName || p.ifName || (p.portId ? `Port ${p.portId}` : '');
-    const label = (p.portNumber != null) ? `[${p.portNumber}] ${name}` : name;
-    return `<span class="port-cell">${portIcon(p)}<span class="port-label">${escapeHtml(label)}</span></span>`;
+    return `<span class="port-cell">${portIcon(p)}<span class="port-label">${escapeHtml(name)}</span></span>`;
 }
 
 function mediaText(isSfp) {
@@ -156,7 +166,7 @@ function renderTabs() {
     if (!(hasAps && hasInfra)) { tabsEl.innerHTML = ''; return; }
     const tabs = [['infra', 'Gateways & Switches'], ['aps', 'APs']];
     tabsEl.innerHTML = tabs.map(([k, label]) =>
-        `<button class="tab-btn ${activeTab === k ? 'active' : ''}" data-tab="${k}">${label}</button>`).join('');
+        `<button class="time-btn ${activeTab === k ? 'active' : ''}" data-tab="${k}">${label}</button>`).join('');
     if (!tabsEl._delegated) {
         tabsEl._delegated = true;
         tabsEl.addEventListener('click', (e) => {

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -137,10 +137,12 @@ function portIcon(p) {
 }
 
 function portCell(p) {
-    // Port number rides on the connector glyph; the label is just the UniFi
-    // friendly name (mapped from the Linux ifName), or the raw name as fallback.
+    // Port number rides on the connector glyph; the label is the UniFi friendly name
+    // (mapped from the Linux ifName), or the raw name as fallback. The label tooltip
+    // shows the raw interface name when we have it.
     const name = p.friendlyName || p.ifName || (p.portId ? `Port ${p.portId}` : '');
-    return `<span class="port-cell">${portIcon(p)}<span class="port-label">${escapeHtml(name)}</span></span>`;
+    const tip = p.ifName ? ` data-tooltip="${escapeHtml(p.ifName)}"` : '';
+    return `<span class="port-cell">${portIcon(p)}<span class="port-label"${tip}>${escapeHtml(name)}</span></span>`;
 }
 
 const COLUMNS = [
@@ -278,7 +280,9 @@ function renderTableNow(showAll) {
             key: 'mac',
             visibility: () => visibility,
             resetVisibility: () => { visibility = {}; },
-            onChanged: () => { savePrefs(); renderBadges(); renderTableNow(true); },
+            // Hide filtered devices entirely (showAllRows=false), not grey them out,
+            // matching the pill behaviour; re-enable via the pills.
+            onChanged: () => { savePrefs(); renderBadges(); renderTableNow(false); },
         },
     });
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -153,13 +153,12 @@ function portCell(p) {
     return `<span class="port-cell">${portIcon(p)}<span class="port-label"${tip}>${escapeHtml(name)}</span></span>`;
 }
 
-// The single wired client on this port, linked to its Client Dashboard by IP.
+// The single wired client on this port, linked to its Client Performance dashboard.
 function clientCell(p) {
     const label = p.connectedName || p.connectedMac || p.connectedIp;
     if (!label) return '';
     if (p.connectedIp) {
-        const mac = p.connectedMac ? ` data-tooltip="${escapeHtml(p.connectedMac)}"` : '';
-        return `<a class="port-client-link" href="/client-dashboard?ip=${encodeURIComponent(p.connectedIp)}"${mac}>${escapeHtml(label)}</a>`;
+        return `<a class="port-client-link" href="/client-dashboard?ip=${encodeURIComponent(p.connectedIp)}" data-tooltip="Open the Client Performance dashboard" data-tooltip-hover-only>${escapeHtml(label)}</a>`;
     }
     return escapeHtml(label);
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -209,7 +209,7 @@ function buildRows() {
                 // toggle the whole device; multiple port rows share the same id.
                 id: d.mac,
                 label: d.name || d.mac,
-                color: hashColor(d.mac),
+                color: hashColor(d.name || d.mac),
                 visible: vis,
                 values: [
                     { html: portCell(p) },
@@ -229,7 +229,9 @@ function buildRows() {
 function rebuildMeta(devices) {
     deviceMeta = devices.map(d => {
         const name = (d.name && d.name !== d.mac) ? d.name : (nameOverrides[d.mac] || d.name || d.mac);
-        return { mac: d.mac, name, color: hashColor(d.mac) };
+        // Colour by device name (same determinant as the Device Stats / Network
+        // Performance tabs) so a device keeps one colour across the app.
+        return { mac: d.mac, name, color: hashColor(d.name || d.mac) };
     });
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -193,11 +193,17 @@ function renderTabs() {
     }
 }
 
+// Down, unnamed tunnel/shaping root interfaces (gre0, ifb1, ip6gre0) are noise -
+// hide them. Named or up ones (e.g. gre1 = a WAN, ifbeth0 = SQM) still show.
+const NOISE_IF = /^(gre|ifb|ip6gre)\d+$/i;
+
 function buildRows() {
     const rows = [];
     for (const d of tabDevices()) {
         const vis = visibility[d.mac] !== false;
         for (const p of (d.ports || [])) {
+            const down = p.operStatus !== 1;
+            if (down && !p.friendlyName && NOISE_IF.test(p.ifName || '')) continue;
             rows.push({
                 // Row id is the device mac so the name-column click filter (and pills)
                 // toggle the whole device; multiple port rows share the same id.

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -51,21 +51,19 @@ let fetchController = null;
 let seekDebounce = null;
 let io = null;
 let isVisibleInViewport = true;
+let visInitialized = false;
 
-function speedClass(speedBps) {
-    if (speedBps == null) return '';
-    const m = speedBps / 1e6;
+function speedClassMbps(mbps) {
+    if (mbps == null || mbps <= 0) return '';
     let cls = SPEED_STEPS[0][1];
-    for (const [mbps, c] of SPEED_STEPS) if (m >= mbps * 0.9) cls = c;
+    for (const [step, c] of SPEED_STEPS) if (mbps >= step * 0.9) cls = c;
     return 'port-speed-' + cls;
 }
 
-function fmtLinkSpeed(bps) {
-    if (bps == null) return '';
-    const m = bps / 1e6;
-    if (m >= 1000) { const g = m / 1000; return `${g % 1 === 0 ? g.toFixed(0) : g.toFixed(1)} Gbps`; }
-    if (m >= 1) return `${m.toFixed(0)} Mbps`;
-    return `${Math.round(bps / 1e3)} Kbps`;
+function fmtLinkSpeed(mbps) {
+    if (mbps == null || mbps <= 0) return '';
+    if (mbps >= 1000) { const g = mbps / 1000; return `${g % 1 === 0 ? g.toFixed(0) : g.toFixed(1)} Gbps`; }
+    return `${mbps.toFixed(0)} Mbps`;
 }
 
 function fmtRate(bps) {
@@ -78,10 +76,12 @@ function fmtRate(bps) {
 
 const fmtCount = v => v == null ? '-' : Number(v).toLocaleString();
 
-function isSfp(p) {
-    const n = `${p.ifName || ''} ${p.portId || ''}`.toLowerCase();
-    if (n.includes('sfp')) return true;
-    return (p.speedBps || 0) >= 10e9;  // 10G+ uplinks are typically SFP+
+// UniFi PortTable.SfpFound is authoritative; fall back to a name heuristic only
+// when the correlation hasn't populated isSfp (e.g. virtual interfaces).
+function portIsSfp(p) {
+    if (p.isSfp === true) return true;
+    if (p.isSfp === false) return false;
+    return `${p.ifName || ''} ${p.portId || ''}`.toLowerCase().includes('sfp');
 }
 
 const RJ45_SVG = '<svg width="20" height="15" viewBox="0 0 20 15" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round">' +
@@ -89,23 +89,30 @@ const RJ45_SVG = '<svg width="20" height="15" viewBox="0 0 20 15" fill="none" st
     '<path d="M7.5 10 v2.5 h5 V10"/>' +
     '<path d="M6 4 v3 M8 4 v3 M10 4 v3 M12 4 v3 M14 4 v3"/></svg>';
 
-const SFP_SVG = '<svg width="22" height="15" viewBox="0 0 22 15" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round" stroke-linecap="round">' +
-    '<rect x="7" y="3" width="12" height="9" rx="1.5"/>' +
-    '<path d="M7 5 C3 5 3 10 7 10"/>' +
-    '<path d="M11 3 V12"/>' +
-    '<path d="M14 7.5 H17.5"/></svg>';
+const SFP_SVG = '<svg width="22" height="15" viewBox="0 0 22 15" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round">' +
+    '<rect x="3" y="2.5" width="16" height="9" rx="1.5"/>' +
+    '<path d="M8.5 11.5 v-2.5 h5 v2.5"/></svg>';
 
 function portIcon(p) {
-    const cls = speedClass(p.speedBps);
+    const cls = speedClassMbps(p.linkSpeedMbps);
     const down = p.operStatus != null && p.operStatus !== 1;
-    const inner = isSfp(p) ? SFP_SVG : RJ45_SVG;
-    const tip = p.speedBps ? fmtLinkSpeed(p.speedBps) : (down ? 'Down' : '');
+    const inner = portIsSfp(p) ? SFP_SVG : RJ45_SVG;
+    const tip = p.linkSpeedMbps ? fmtLinkSpeed(p.linkSpeedMbps) : (down ? 'Down' : '');
     return `<span class="port-icon ${cls}${down ? ' port-icon-down' : ''}"${tip ? ` data-tooltip="${escapeHtml(tip)}"` : ''}>${inner}</span>`;
 }
 
 function portCell(p) {
-    const label = p.ifName || (p.portId ? `Port ${p.portId}` : '');
+    // UniFi friendly name (mapped from the Linux ifName) when we have one, with the
+    // port number prefixed as "[N] Name"; otherwise the raw interface name.
+    const name = p.friendlyName || p.ifName || (p.portId ? `Port ${p.portId}` : '');
+    const label = (p.portNumber != null) ? `[${p.portNumber}] ${name}` : name;
     return `<span class="port-cell">${portIcon(p)}<span class="port-label">${escapeHtml(label)}</span></span>`;
+}
+
+function mediaText(isSfp) {
+    if (isSfp === true) return 'SFP';
+    if (isSfp === false) return 'RJ45';
+    return '-';
 }
 
 function statusBadge(operStatus) {
@@ -116,6 +123,7 @@ function statusBadge(operStatus) {
 
 const COLUMNS = [
     { header: 'Port', format: v => v.html },
+    { header: 'Media', format: mediaText, cls: 'hide-mobile' },
     { header: 'Status', format: statusBadge },
     { header: 'Rate In', format: fmtRate },
     { header: 'Rate Out', format: fmtRate },
@@ -137,12 +145,15 @@ function buildRows() {
         const vis = visibility[d.mac] !== false;
         for (const p of (d.ports || [])) {
             rows.push({
-                id: `${d.mac}|${p.ifName || p.portId}`,
+                // Row id is the device mac so the name-column click filter (and pills)
+                // toggle the whole device; multiple port rows share the same id.
+                id: d.mac,
                 label: d.name || d.mac,
                 color: hashColor(d.mac),
                 visible: vis,
                 values: [
                     { html: portCell(p) },
+                    p.isSfp,
                     p.operStatus,
                     p.rateInBps, p.rateOutBps,
                     p.ucastPktsIn, p.ucastPktsOut,
@@ -160,7 +171,7 @@ function buildRows() {
 function rebuildMeta(devices) {
     deviceMeta = devices.map(d => {
         const name = (d.name && d.name !== d.mac) ? d.name : (nameOverrides[d.mac] || d.name || d.mac);
-        return { mac: d.mac, name, color: hashColor(d.mac) };
+        return { mac: d.mac, name, color: hashColor(d.mac), isAp: (d.type || '').toLowerCase() === 'ap' };
     });
 }
 
@@ -191,16 +202,26 @@ function renderBadges() {
                 else visibility[mac] = visibility[mac] === false;
             }
             renderBadges();
-            renderTableNow();
+            renderTableNow(false);
         });
     }
 }
 
-function renderTableNow() {
+function renderTableNow(showAll) {
     if (!tableEl) return;
     const rows = buildRows();
     if (rows.length === 0) { tableEl.innerHTML = ''; return; }
-    renderTable(tableEl, container, { nameHeader: 'Device', title: '', rows, columns: COLUMNS });
+    renderTable(tableEl, container, {
+        nameHeader: 'Device', title: '', rows, columns: COLUMNS, showAllRows: showAll,
+        // Clicking a device name in the table filters that device, mirroring the pills.
+        filter: {
+            meta: () => deviceMeta,
+            key: 'mac',
+            visibility: () => visibility,
+            resetVisibility: () => { visibility = {}; },
+            onChanged: () => { renderBadges(); renderTableNow(true); },
+        },
+    });
 }
 
 function renderLegend() {
@@ -234,6 +255,11 @@ async function loadAndRender() {
     if (!data) return;
     lastDevices = data.devices || [];
     rebuildMeta(lastDevices);
+    // Default to APs deselected on first load; user toggles persist afterwards.
+    if (!visInitialized && deviceMeta.length) {
+        deviceMeta.forEach(d => { if (d.isAp) visibility[d.mac] = false; });
+        visInitialized = true;
+    }
     if (pendingSelect) {
         const match = deviceMeta.find(d => d.mac.toLowerCase() === pendingSelect.toLowerCase());
         if (match) deviceMeta.forEach(d => visibility[d.mac] = d.mac === match.mac);

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -37,6 +37,7 @@ let container = null;
 let badgesEl = null;
 let tableEl = null;
 let legendEl = null;
+let topScrollEl = null;     // mirror horizontal scrollbar above the table
 let opts = {};
 
 let deviceMeta = [];        // [{ mac, name, color }]
@@ -141,7 +142,8 @@ function portCell(p) {
     // (mapped from the Linux ifName), or the raw name as fallback. The label tooltip
     // shows the raw interface name when we have it.
     const name = p.friendlyName || p.ifName || (p.portId ? `Port ${p.portId}` : '');
-    const tip = p.ifName ? ` data-tooltip="${escapeHtml(p.ifName)}"` : '';
+    // Tooltip only when the shown label isn't already the raw interface name.
+    const tip = (p.ifName && p.ifName !== name) ? ` data-tooltip="${escapeHtml(p.ifName)}"` : '';
     return `<span class="port-cell">${portIcon(p)}<span class="port-label"${tip}>${escapeHtml(name)}</span></span>`;
 }
 
@@ -271,7 +273,7 @@ function renderBadges() {
 function renderTableNow(showAll) {
     if (!tableEl) return;
     const rows = buildRows();
-    if (rows.length === 0) { tableEl.innerHTML = ''; return; }
+    if (rows.length === 0) { tableEl.innerHTML = ''; syncTopScrollbar(); return; }
     renderTable(tableEl, container, {
         nameHeader: 'Device', title: '', rows, columns: COLUMNS, showAllRows: showAll,
         // Clicking a device name in the table filters that device, mirroring the pills.
@@ -285,6 +287,26 @@ function renderTableNow(showAll) {
             onChanged: () => { savePrefs(); renderBadges(); renderTableNow(false); },
         },
     });
+    syncTopScrollbar();
+}
+
+// Mirror the table's horizontal scroll into a scrollbar above it, so a wide table
+// can be panned without scrolling down to the native bar. The .table-responsive is
+// re-created on every render, so re-measure and (re)wire its listener each time.
+function syncTopScrollbar() {
+    if (!topScrollEl) return;
+    const resp = tableEl && tableEl.querySelector('.table-responsive');
+    const inner = topScrollEl.firstElementChild;
+    if (!resp || !inner) { topScrollEl.style.display = 'none'; return; }
+    const overflow = resp.scrollWidth > resp.clientWidth + 1;
+    topScrollEl.style.display = overflow ? '' : 'none';
+    if (!overflow) return;
+    inner.style.width = resp.scrollWidth + 'px';
+    topScrollEl.scrollLeft = resp.scrollLeft;
+    if (!resp._topSync) {
+        resp._topSync = true;
+        resp.addEventListener('scroll', () => { if (topScrollEl) topScrollEl.scrollLeft = resp.scrollLeft; });
+    }
 }
 
 function renderLegend() {
@@ -392,7 +414,7 @@ const api = {
         clearTimeout(seekDebounce);
         if (fetchController) fetchController.abort();
         if (window.__portStatsTable === api) window.__portStatsTable = null;
-        container = badgesEl = tableEl = tabsEl = null;
+        container = badgesEl = tableEl = tabsEl = topScrollEl = null;
         lastDevices = [];
         deviceMeta = [];
         visibility = {};
@@ -408,6 +430,14 @@ export function mount(el, mountOpts = {}) {
     tableEl = container.querySelector('#port-stats-table');
     tabsEl = container.querySelector('#port-stats-tabs');
     legendEl = container.querySelector('#port-stats-legend');
+    topScrollEl = container.querySelector('#port-stats-scroll-top');
+    if (topScrollEl && !topScrollEl._sync) {
+        topScrollEl._sync = true;
+        topScrollEl.addEventListener('scroll', () => {
+            const resp = tableEl && tableEl.querySelector('.table-responsive');
+            if (resp) resp.scrollLeft = topScrollEl.scrollLeft;
+        });
+    }
     renderLegend();
     if (Array.isArray(mountOpts.deviceMeta)) {
         for (const d of mountOpts.deviceMeta) if (d && d.mac && d.name) nameOverrides[d.mac] = d.name;

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -1,0 +1,330 @@
+// Port playback table for the Live View tab. Reads per-port interface_counters
+// at the current map scrubber position (or live), renders them via the shared
+// renderStatsTable(), and exposes selectDevice() so a map double-click can
+// isolate a single switch/gateway.
+import { renderStatsTable as renderTable } from './chart-stats.js?v=3';
+
+const _esc = document.createElement('span');
+function escapeHtml(s) { _esc.textContent = s == null ? '' : String(s); return _esc.innerHTML; }
+
+const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
+const _colorCache = {};
+function hashColor(id) {
+    if (_colorCache[id]) return _colorCache[id];
+    let h = 0;
+    for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0;
+    const used = new Set(Object.values(_colorCache));
+    let idx = h % PALETTE.length;
+    const start = idx;
+    while (used.has(PALETTE[idx])) {
+        idx = (idx + 1) % PALETTE.length;
+        if (idx === start) break;
+    }
+    _colorCache[id] = PALETTE[idx];
+    return PALETTE[idx];
+}
+
+const LIVE_POLL_MS = 5000;
+
+// Standard negotiated rates (Mbps) mapped to the link-speed colour spectrum.
+const SPEED_STEPS = [
+    [10, '10m', '10M'], [100, '100m', '100M'], [1000, '1g', '1G'], [2500, '2_5g', '2.5G'],
+    [5000, '5g', '5G'], [10000, '10g', '10G'], [20000, '20g', '20G'], [25000, '25g', '25G'],
+    [40000, '40g', '40G'], [50000, '50g', '50G'], [100000, '100g', '100G'],
+];
+
+let container = null;
+let badgesEl = null;
+let tableEl = null;
+let legendEl = null;
+let opts = {};
+
+let deviceMeta = [];        // [{ mac, name, color }]
+let visibility = {};        // mac -> false hides the device
+let nameOverrides = {};     // mac -> name supplied by the map snapshot
+let lastDevices = [];       // raw devices from the most recent fetch
+let pendingSelect = null;   // mac to isolate once data arrives
+
+let currentAt = null;       // ISO timestamp for historic playback, null = live
+let pollTimer = null;
+let fetchController = null;
+let seekDebounce = null;
+let io = null;
+let isVisibleInViewport = true;
+
+function speedClass(speedBps) {
+    if (speedBps == null) return '';
+    const m = speedBps / 1e6;
+    let cls = SPEED_STEPS[0][1];
+    for (const [mbps, c] of SPEED_STEPS) if (m >= mbps * 0.9) cls = c;
+    return 'port-speed-' + cls;
+}
+
+function fmtLinkSpeed(bps) {
+    if (bps == null) return '';
+    const m = bps / 1e6;
+    if (m >= 1000) { const g = m / 1000; return `${g % 1 === 0 ? g.toFixed(0) : g.toFixed(1)} Gbps`; }
+    if (m >= 1) return `${m.toFixed(0)} Mbps`;
+    return `${Math.round(bps / 1e3)} Kbps`;
+}
+
+function fmtRate(bps) {
+    if (bps == null) return '-';
+    if (bps >= 1e9) return `${(bps / 1e9).toFixed(2)} Gbps`;
+    if (bps >= 1e6) return `${(bps / 1e6).toFixed(1)} Mbps`;
+    if (bps >= 1e3) return `${(bps / 1e3).toFixed(0)} Kbps`;
+    return `${Math.round(bps)} bps`;
+}
+
+const fmtCount = v => v == null ? '-' : Number(v).toLocaleString();
+
+function isSfp(p) {
+    const n = `${p.ifName || ''} ${p.portId || ''}`.toLowerCase();
+    if (n.includes('sfp')) return true;
+    return (p.speedBps || 0) >= 10e9;  // 10G+ uplinks are typically SFP+
+}
+
+const RJ45_SVG = '<svg width="20" height="15" viewBox="0 0 20 15" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round">' +
+    '<rect x="3" y="2" width="14" height="8" rx="1"/>' +
+    '<path d="M7.5 10 v2.5 h5 V10"/>' +
+    '<path d="M6 4 v3 M8 4 v3 M10 4 v3 M12 4 v3 M14 4 v3"/></svg>';
+
+const SFP_SVG = '<svg width="22" height="15" viewBox="0 0 22 15" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round">' +
+    '<rect x="2" y="4" width="13" height="7" rx="1"/>' +
+    '<path d="M15 5.5 h4 a1 1 0 0 1 1 1 v2 a1 1 0 0 1 -1 1 h-4"/>' +
+    '<path d="M5 4 V2 M9 4 V2"/></svg>';
+
+function portIcon(p) {
+    const cls = speedClass(p.speedBps);
+    const down = p.operStatus != null && p.operStatus !== 1;
+    const inner = isSfp(p) ? SFP_SVG : RJ45_SVG;
+    const tip = p.speedBps ? fmtLinkSpeed(p.speedBps) : (down ? 'Down' : '');
+    return `<span class="port-icon ${cls}${down ? ' port-icon-down' : ''}"${tip ? ` data-tooltip="${escapeHtml(tip)}"` : ''}>${inner}</span>`;
+}
+
+function portCell(p) {
+    const label = p.ifName || (p.portId ? `Port ${p.portId}` : '');
+    return `<span class="port-cell">${portIcon(p)}<span class="port-label">${escapeHtml(label)}</span></span>`;
+}
+
+function statusBadge(operStatus) {
+    if (operStatus == null) return '-';
+    const up = operStatus === 1;
+    return `<span class="port-status ${up ? 'port-status-up' : 'port-status-down'}">${up ? 'Up' : 'Down'}</span>`;
+}
+
+const COLUMNS = [
+    { header: 'Port', format: v => v.html },
+    { header: 'Status', format: statusBadge },
+    { header: 'Rate In', format: fmtRate },
+    { header: 'Rate Out', format: fmtRate },
+    { header: 'Unicast In', format: fmtCount, cls: 'hide-mobile' },
+    { header: 'Unicast Out', format: fmtCount, cls: 'hide-mobile' },
+    { header: 'Multicast In', format: fmtCount, cls: 'hide-mobile' },
+    { header: 'Multicast Out', format: fmtCount, cls: 'hide-mobile' },
+    { header: 'Broadcast In', format: fmtCount, cls: 'hide-mobile' },
+    { header: 'Broadcast Out', format: fmtCount, cls: 'hide-mobile' },
+    { header: 'Errors In', format: fmtCount, cls: 'hide-mobile' },
+    { header: 'Errors Out', format: fmtCount, cls: 'hide-mobile' },
+    { header: 'Discards In', format: fmtCount, cls: 'hide-mobile' },
+    { header: 'Discards Out', format: fmtCount, cls: 'hide-mobile' },
+];
+
+function buildRows() {
+    const rows = [];
+    for (const d of lastDevices) {
+        const vis = visibility[d.mac] !== false;
+        for (const p of (d.ports || [])) {
+            rows.push({
+                id: `${d.mac}|${p.ifName || p.portId}`,
+                label: d.name || d.mac,
+                color: hashColor(d.mac),
+                visible: vis,
+                values: [
+                    { html: portCell(p) },
+                    p.operStatus,
+                    p.rateInBps, p.rateOutBps,
+                    p.ucastPktsIn, p.ucastPktsOut,
+                    p.mcastPktsIn, p.mcastPktsOut,
+                    p.bcastPktsIn, p.bcastPktsOut,
+                    p.errorsIn, p.errorsOut,
+                    p.discardsIn, p.discardsOut,
+                ],
+            });
+        }
+    }
+    return rows;
+}
+
+function rebuildMeta(devices) {
+    deviceMeta = devices.map(d => {
+        const name = (d.name && d.name !== d.mac) ? d.name : (nameOverrides[d.mac] || d.name || d.mac);
+        return { mac: d.mac, name, color: hashColor(d.mac) };
+    });
+}
+
+function renderBadges() {
+    if (!badgesEl) return;
+    if (deviceMeta.length <= 1) { badgesEl.innerHTML = ''; return; }
+    badgesEl.innerHTML = deviceMeta.map(d => {
+        const vis = visibility[d.mac] !== false;
+        return `<button class="wan-filter-badge ${vis ? 'active' : 'inactive'}" data-mac="${escapeHtml(d.mac)}">
+            <span class="wan-badge-dot" style="background-color: ${d.color}"></span>
+            <span>${escapeHtml(d.name)}</span>
+        </button>`;
+    }).join('');
+    if (!badgesEl._delegated) {
+        badgesEl._delegated = true;
+        badgesEl.addEventListener('click', (e) => {
+            const btn = e.target.closest('button[data-mac]');
+            if (!btn) return;
+            const mac = btn.dataset.mac;
+            if (e.ctrlKey || e.metaKey) {
+                visibility[mac] = visibility[mac] === false ? undefined : false;
+            } else {
+                const allVis = deviceMeta.every(d => visibility[d.mac] !== false);
+                const onlyThis = visibility[mac] !== false
+                    && deviceMeta.filter(d => d.mac !== mac).every(d => visibility[d.mac] === false);
+                if (onlyThis) visibility = {};
+                else if (allVis) deviceMeta.forEach(d => visibility[d.mac] = d.mac === mac);
+                else visibility[mac] = visibility[mac] === false;
+            }
+            renderBadges();
+            renderTableNow();
+        });
+    }
+}
+
+function renderTableNow() {
+    if (!tableEl) return;
+    const rows = buildRows();
+    if (rows.length === 0) { tableEl.innerHTML = ''; return; }
+    renderTable(tableEl, container, { nameHeader: 'Device', title: '', rows, columns: COLUMNS });
+}
+
+function renderLegend() {
+    if (!legendEl || legendEl._rendered) return;
+    legendEl.innerHTML = SPEED_STEPS.map(([, cls, label]) =>
+        `<span class="port-speed-key"><span class="port-speed-swatch port-speed-${cls}"></span>${label}</span>`).join('');
+    legendEl._rendered = true;
+}
+
+function updateCardVisibility() {
+    if (!container) return;
+    container.style.display = lastDevices.length > 0 ? '' : 'none';
+}
+
+async function fetchData() {
+    if (fetchController) fetchController.abort();
+    fetchController = new AbortController();
+    const params = new URLSearchParams();
+    if (currentAt) params.set('at', currentAt);
+    try {
+        const resp = await fetch(`/api/monitoring/port-stats?${params.toString()}`, { signal: fetchController.signal });
+        if (!resp.ok) return null;
+        return await resp.json();
+    } catch {
+        return null;
+    }
+}
+
+async function loadAndRender() {
+    const data = await fetchData();
+    if (!data) return;
+    lastDevices = data.devices || [];
+    rebuildMeta(lastDevices);
+    if (pendingSelect) {
+        const match = deviceMeta.find(d => d.mac.toLowerCase() === pendingSelect.toLowerCase());
+        if (match) deviceMeta.forEach(d => visibility[d.mac] = d.mac === match.mac);
+        pendingSelect = null;
+    }
+    updateCardVisibility();
+    renderBadges();
+    renderTableNow();
+}
+
+function startPoll() {
+    stopPoll();
+    if (currentAt) return;            // historic playback: no polling
+    if (!isVisibleInViewport) return;
+    pollTimer = setInterval(loadAndRender, LIVE_POLL_MS);
+}
+function stopPoll() { if (pollTimer) { clearInterval(pollTimer); pollTimer = null; } }
+
+function setupObserver() {
+    if (!('IntersectionObserver' in window) || !container) { isVisibleInViewport = true; return; }
+    io = new IntersectionObserver((entries) => {
+        isVisibleInViewport = entries.some(e => e.isIntersecting);
+        if (isVisibleInViewport && !currentAt) startPoll();
+        else stopPoll();
+    }, { threshold: 0 });
+    io.observe(container);
+}
+
+const api = {
+    seekTime(isoTimestamp) {
+        currentAt = isoTimestamp || null;
+        if (currentAt) {
+            stopPoll();
+            clearTimeout(seekDebounce);
+            seekDebounce = setTimeout(loadAndRender, 200);
+        } else {
+            loadAndRender();
+            startPoll();
+        }
+    },
+    selectDevice(mac) {
+        if (!mac) return;
+        const match = deviceMeta.find(d => d.mac.toLowerCase() === mac.toLowerCase());
+        if (match) {
+            deviceMeta.forEach(d => visibility[d.mac] = d.mac === match.mac);
+            renderBadges();
+            renderTableNow();
+        } else {
+            pendingSelect = mac;
+            loadAndRender();
+        }
+        if (typeof opts.onDeviceSelected === 'function') opts.onDeviceSelected(mac);
+    },
+    updateDeviceMeta(meta) {
+        if (!Array.isArray(meta)) return;
+        for (const d of meta) if (d && d.mac && d.name) nameOverrides[d.mac] = d.name;
+        rebuildMeta(lastDevices);
+        renderBadges();
+    },
+    unmount() {
+        stopPoll();
+        clearTimeout(seekDebounce);
+        if (fetchController) fetchController.abort();
+        if (io) { io.disconnect(); io = null; }
+        if (window.__portStatsTable === api) window.__portStatsTable = null;
+        container = badgesEl = tableEl = null;
+        lastDevices = [];
+        deviceMeta = [];
+        visibility = {};
+    },
+};
+
+export function mount(el, mountOpts = {}) {
+    container = typeof el === 'string' ? document.getElementById(el) : el;
+    if (!container) return;
+    opts = mountOpts;
+    badgesEl = container.querySelector('#port-stats-filter-badges') || container.querySelector('.health-filter-badges');
+    tableEl = container.querySelector('#port-stats-table');
+    legendEl = container.querySelector('#port-stats-legend');
+    renderLegend();
+    if (Array.isArray(mountOpts.deviceMeta)) {
+        for (const d of mountOpts.deviceMeta) if (d && d.mac && d.name) nameOverrides[d.mac] = d.name;
+    }
+    currentAt = null;
+    isVisibleInViewport = true;
+    window.__portStatsTable = api;
+    setupObserver();
+    loadAndRender();
+    startPoll();
+}
+
+export const seekTime = (...a) => api.seekTime(...a);
+export const selectDevice = (...a) => api.selectDevice(...a);
+export const updateDeviceMeta = (...a) => api.updateDeviceMeta(...a);
+export const unmount = () => api.unmount();

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -54,6 +54,25 @@ let isVisibleInViewport = true;
 let tabsEl = null;
 let activeTab = 'infra';   // 'infra' = gateways + switches, 'aps' = access points
 
+const STORE_TAB = 'portStats.activeTab';
+const STORE_VIS = 'portStats.visibility';
+
+function savePrefs() {
+    try {
+        localStorage.setItem(STORE_TAB, activeTab);
+        localStorage.setItem(STORE_VIS, JSON.stringify(visibility));
+    } catch { /* localStorage unavailable */ }
+}
+
+function loadPrefs() {
+    try {
+        const t = localStorage.getItem(STORE_TAB);
+        if (t === 'infra' || t === 'aps') activeTab = t;
+        const v = JSON.parse(localStorage.getItem(STORE_VIS) || '{}');
+        if (v && typeof v === 'object') visibility = v;
+    } catch { /* localStorage unavailable */ }
+}
+
 function speedClassMbps(mbps) {
     if (mbps == null || mbps <= 0) return '';
     let cls = SPEED_STEPS[0][1];
@@ -90,26 +109,29 @@ function portIsSfp(p) {
 // numberless virtual interfaces keep the detailed RJ45 pins / SFP cage.
 function connectorGlyph(p) {
     const sfp = portIsSfp(p);
-    const head = '<svg width="28" height="20" viewBox="0 0 28 20" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round">';
-    const body = sfp
-        ? '<rect x="4" y="3" width="20" height="11" rx="1.5"/><path d="M11 14 v-2.5 h6 v2.5"/>'
-        : '<rect x="4" y="2.5" width="20" height="11" rx="1.5"/><path d="M11 13.5 v3.5 h6 V13.5"/>';
-    let detail;
-    if (p.portNumber != null) {
-        const fs = String(p.portNumber).length > 1 ? 8 : 10;
-        detail = `<text x="14" y="${sfp ? 9 : 8.5}" text-anchor="middle" dominant-baseline="central" font-size="${fs}" font-weight="700" fill="currentColor" stroke="none">${p.portNumber}</text>`;
-    } else if (!sfp) {
-        detail = '<path d="M8 5 v4 M11 5 v4 M14 5 v4 M17 5 v4 M20 5 v4"/>';  // RJ45 pins
-    } else {
-        detail = '';  // bare SFP cage
+    const n = p.portNumber;
+    const head = '<svg width="28" height="26" viewBox="0 0 28 26" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round">';
+    const num = (cy) => `<text x="14" y="${cy}" text-anchor="middle" dominant-baseline="central" font-size="${String(n).length > 1 ? 9 : 11}" font-weight="700" fill="currentColor" stroke="none">${n}</text>`;
+    if (sfp) {
+        // SFP/SFP+ cage: wide and short (~1.8:1), vertically centred, bottom key notch.
+        const body = '<rect x="3" y="7.5" width="22" height="12" rx="1.5"/><path d="M11 19.5 v-2.5 h6 v2.5"/>';
+        return head + body + (n != null ? num(13.5) : '') + '</svg>';
     }
+    // RJ45 8P8C jack: tall, nearly square, with the bottom locking-tab slot.
+    const body = '<rect x="5" y="2.5" width="18" height="16" rx="1.5"/><path d="M10.5 18.5 v4.5 h7 V18.5"/>';
+    const detail = n != null
+        ? num(10.5)
+        : '<path d="M8 6 v5.5 M11 6 v5.5 M14 6 v5.5 M17 6 v5.5 M20 6 v5.5"/>';  // RJ45 pins
     return head + body + detail + '</svg>';
 }
 
 function portIcon(p) {
     const cls = speedClassMbps(p.linkSpeedMbps);
     const down = p.operStatus != null && p.operStatus !== 1;
-    const tip = p.linkSpeedMbps ? fmtLinkSpeed(p.linkSpeedMbps) : (down ? 'Down' : '');
+    // The glyph colour already conveys link state, so the tooltip carries the
+    // detail: "Status - Speed" (e.g. "Up - 1 Gbps", or just "Down").
+    const status = p.operStatus == null ? '' : (down ? 'Down' : 'Up');
+    const tip = [status, fmtLinkSpeed(p.linkSpeedMbps)].filter(Boolean).join(' - ');
     return `<span class="port-icon ${cls}${down ? ' port-icon-down' : ''}"${tip ? ` data-tooltip="${escapeHtml(tip)}"` : ''}>${connectorGlyph(p)}</span>`;
 }
 
@@ -120,22 +142,8 @@ function portCell(p) {
     return `<span class="port-cell">${portIcon(p)}<span class="port-label">${escapeHtml(name)}</span></span>`;
 }
 
-function mediaText(isSfp) {
-    if (isSfp === true) return 'SFP';
-    if (isSfp === false) return 'RJ45';
-    return '-';
-}
-
-function statusBadge(operStatus) {
-    if (operStatus == null) return '-';
-    const up = operStatus === 1;
-    return `<span class="port-status ${up ? 'port-status-up' : 'port-status-down'}">${up ? 'Up' : 'Down'}</span>`;
-}
-
 const COLUMNS = [
     { header: 'Port', format: v => v.html },
-    { header: 'Media', format: mediaText, cls: 'hide-mobile' },
-    { header: 'Status', format: statusBadge },
     { header: 'Rate In', format: fmtRate },
     { header: 'Rate Out', format: fmtRate },
     { header: 'Unicast In', format: fmtCount, cls: 'hide-mobile' },
@@ -173,6 +181,7 @@ function renderTabs() {
             const btn = e.target.closest('button[data-tab]');
             if (!btn || btn.dataset.tab === activeTab) return;
             activeTab = btn.dataset.tab;
+            savePrefs();
             rebuildMeta(tabDevices());
             renderTabs();
             renderBadges();
@@ -195,8 +204,6 @@ function buildRows() {
                 visible: vis,
                 values: [
                     { html: portCell(p) },
-                    p.isSfp,
-                    p.operStatus,
                     p.rateInBps, p.rateOutBps,
                     p.ucastPktsIn, p.ucastPktsOut,
                     p.mcastPktsIn, p.mcastPktsOut,
@@ -243,6 +250,7 @@ function renderBadges() {
                 else if (allVis) deviceMeta.forEach(d => visibility[d.mac] = d.mac === mac);
                 else visibility[mac] = visibility[mac] === false;
             }
+            savePrefs();
             renderBadges();
             renderTableNow(false);
         });
@@ -261,7 +269,7 @@ function renderTableNow(showAll) {
             key: 'mac',
             visibility: () => visibility,
             resetVisibility: () => { visibility = {}; },
-            onChanged: () => { renderBadges(); renderTableNow(true); },
+            onChanged: () => { savePrefs(); renderBadges(); renderTableNow(true); },
         },
     });
 }
@@ -299,7 +307,7 @@ async function loadAndRender() {
     rebuildMeta(tabDevices());
     if (pendingSelect) {
         const match = deviceMeta.find(d => d.mac.toLowerCase() === pendingSelect.toLowerCase());
-        if (match) deviceMeta.forEach(d => visibility[d.mac] = d.mac === match.mac);
+        if (match) { deviceMeta.forEach(d => visibility[d.mac] = d.mac === match.mac); savePrefs(); }
         pendingSelect = null;
     }
     updateCardVisibility();
@@ -353,6 +361,7 @@ const api = {
             pendingSelect = mac;
             loadAndRender();
         }
+        savePrefs();
         if (typeof opts.onDeviceSelected === 'function') opts.onDeviceSelected(mac);
     },
     updateDeviceMeta(meta) {
@@ -378,6 +387,7 @@ export function mount(el, mountOpts = {}) {
     container = typeof el === 'string' ? document.getElementById(el) : el;
     if (!container) return;
     opts = mountOpts;
+    loadPrefs();
     badgesEl = container.querySelector('#port-stats-filter-badges') || container.querySelector('.health-filter-badges');
     tableEl = container.querySelector('#port-stats-table');
     tabsEl = container.querySelector('#port-stats-tabs');

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -51,7 +51,8 @@ let fetchController = null;
 let seekDebounce = null;
 let io = null;
 let isVisibleInViewport = true;
-let visInitialized = false;
+let tabsEl = null;
+let activeTab = 'infra';   // 'infra' = gateways + switches, 'aps' = access points
 
 function speedClassMbps(mbps) {
     if (mbps == null || mbps <= 0) return '';
@@ -139,9 +140,40 @@ const COLUMNS = [
     { header: 'Discards Out', format: fmtCount, cls: 'hide-mobile' },
 ];
 
+function isApDevice(d) { return (d.type || '').toLowerCase() === 'ap'; }
+
+// Devices shown under the current tab: APs on the "APs" tab, everything else
+// (gateways, switches, unknown) on the "Gateways & Switches" tab.
+function tabDevices() {
+    return lastDevices.filter(d => activeTab === 'aps' ? isApDevice(d) : !isApDevice(d));
+}
+
+function renderTabs() {
+    if (!tabsEl) return;
+    const hasAps = lastDevices.some(isApDevice);
+    const hasInfra = lastDevices.some(d => !isApDevice(d));
+    // Only worth splitting when both classes are present.
+    if (!(hasAps && hasInfra)) { tabsEl.innerHTML = ''; return; }
+    const tabs = [['infra', 'Gateways & Switches'], ['aps', 'APs']];
+    tabsEl.innerHTML = tabs.map(([k, label]) =>
+        `<button class="tab-btn ${activeTab === k ? 'active' : ''}" data-tab="${k}">${label}</button>`).join('');
+    if (!tabsEl._delegated) {
+        tabsEl._delegated = true;
+        tabsEl.addEventListener('click', (e) => {
+            const btn = e.target.closest('button[data-tab]');
+            if (!btn || btn.dataset.tab === activeTab) return;
+            activeTab = btn.dataset.tab;
+            rebuildMeta(tabDevices());
+            renderTabs();
+            renderBadges();
+            renderTableNow();
+        });
+    }
+}
+
 function buildRows() {
     const rows = [];
-    for (const d of lastDevices) {
+    for (const d of tabDevices()) {
         const vis = visibility[d.mac] !== false;
         for (const p of (d.ports || [])) {
             rows.push({
@@ -171,7 +203,7 @@ function buildRows() {
 function rebuildMeta(devices) {
     deviceMeta = devices.map(d => {
         const name = (d.name && d.name !== d.mac) ? d.name : (nameOverrides[d.mac] || d.name || d.mac);
-        return { mac: d.mac, name, color: hashColor(d.mac), isAp: (d.type || '').toLowerCase() === 'ap' };
+        return { mac: d.mac, name, color: hashColor(d.mac) };
     });
 }
 
@@ -254,18 +286,14 @@ async function loadAndRender() {
     const data = await fetchData();
     if (!data) return;
     lastDevices = data.devices || [];
-    rebuildMeta(lastDevices);
-    // Default to APs deselected on first load; user toggles persist afterwards.
-    if (!visInitialized && deviceMeta.length) {
-        deviceMeta.forEach(d => { if (d.isAp) visibility[d.mac] = false; });
-        visInitialized = true;
-    }
+    rebuildMeta(tabDevices());
     if (pendingSelect) {
         const match = deviceMeta.find(d => d.mac.toLowerCase() === pendingSelect.toLowerCase());
         if (match) deviceMeta.forEach(d => visibility[d.mac] = d.mac === match.mac);
         pendingSelect = null;
     }
     updateCardVisibility();
+    renderTabs();
     renderBadges();
     renderTableNow();
 }
@@ -302,6 +330,10 @@ const api = {
     },
     selectDevice(mac) {
         if (!mac) return;
+        // Map double-click only fires for switches/gateways, so land on that tab.
+        activeTab = 'infra';
+        rebuildMeta(tabDevices());
+        renderTabs();
         const match = deviceMeta.find(d => d.mac.toLowerCase() === mac.toLowerCase());
         if (match) {
             deviceMeta.forEach(d => visibility[d.mac] = d.mac === match.mac);
@@ -316,7 +348,7 @@ const api = {
     updateDeviceMeta(meta) {
         if (!Array.isArray(meta)) return;
         for (const d of meta) if (d && d.mac && d.name) nameOverrides[d.mac] = d.name;
-        rebuildMeta(lastDevices);
+        rebuildMeta(tabDevices());
         renderBadges();
     },
     unmount() {
@@ -325,7 +357,7 @@ const api = {
         if (fetchController) fetchController.abort();
         if (io) { io.disconnect(); io = null; }
         if (window.__portStatsTable === api) window.__portStatsTable = null;
-        container = badgesEl = tableEl = null;
+        container = badgesEl = tableEl = tabsEl = null;
         lastDevices = [];
         deviceMeta = [];
         visibility = {};
@@ -338,6 +370,7 @@ export function mount(el, mountOpts = {}) {
     opts = mountOpts;
     badgesEl = container.querySelector('#port-stats-filter-badges') || container.querySelector('.health-filter-badges');
     tableEl = container.querySelector('#port-stats-table');
+    tabsEl = container.querySelector('#port-stats-tabs');
     legendEl = container.querySelector('#port-stats-legend');
     renderLegend();
     if (Array.isArray(mountOpts.deviceMeta)) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -117,14 +117,14 @@ function connectorGlyph(p) {
         // SFP/SFP+ cage: wider than the RJ45 and tall enough to seat the port number,
         // vertically centred, with the bottom key notch.
         const body = '<rect x="2.5" y="5" width="23" height="16" rx="1.5"/><path d="M11 21 v-2.5 h6 v2.5"/>';
-        return head + body + (n != null ? num(13) : '') + '</svg>';
+        return head + body + (n != null ? num(12) : '') + '</svg>';
     }
     // RJ45 8P8C jack: wider than tall (between the female receptacle and the plug),
-    // with the bottom locking-tab slot.
-    const body = '<rect x="3.5" y="3" width="21" height="15" rx="1.5"/><path d="M10.5 18 v4 h7 V18"/>';
+    // with the latch-tab slot on top (how UniFi mounts them).
+    const body = '<rect x="3.5" y="6" width="21" height="15" rx="1.5"/><path d="M10.5 6 v-4 h7 V6"/>';
     const detail = n != null
-        ? num(10.5)
-        : '<path d="M8 6 v6 M11 6 v6 M14 6 v6 M17 6 v6 M20 6 v6"/>';  // RJ45 pins, centred on x=14
+        ? num(13.5)
+        : '<path d="M8 9 v4.5 M11 9 v4.5 M14 9 v4.5 M17 9 v4.5 M20 9 v4.5"/>';  // RJ45 pins, centred on x=14
     return head + body + detail + '</svg>';
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -157,16 +157,16 @@ const COLUMNS = [
     { header: 'Port', format: v => v.html },
     { header: 'Rate In', format: fmtRate },
     { header: 'Rate Out', format: fmtRate },
-    { header: 'Unicast In', format: fmtCount, cls: 'hide-mobile' },
-    { header: 'Unicast Out', format: fmtCount, cls: 'hide-mobile' },
-    { header: 'Multicast In', format: fmtCount, cls: 'hide-mobile' },
-    { header: 'Multicast Out', format: fmtCount, cls: 'hide-mobile' },
-    { header: 'Broadcast In', format: fmtCount, cls: 'hide-mobile' },
-    { header: 'Broadcast Out', format: fmtCount, cls: 'hide-mobile' },
-    { header: 'Errors In', format: fmtCount, cls: 'hide-mobile' },
-    { header: 'Errors Out', format: fmtCount, cls: 'hide-mobile' },
-    { header: 'Discards In', format: fmtCount, cls: 'hide-mobile' },
-    { header: 'Discards Out', format: fmtCount, cls: 'hide-mobile' },
+    { header: 'Unicast In', format: fmtCount },
+    { header: 'Unicast Out', format: fmtCount },
+    { header: 'Multicast In', format: fmtCount },
+    { header: 'Multicast Out', format: fmtCount },
+    { header: 'Broadcast In', format: fmtCount },
+    { header: 'Broadcast Out', format: fmtCount },
+    { header: 'Errors In', format: fmtCount },
+    { header: 'Errors Out', format: fmtCount },
+    { header: 'Discards In', format: fmtCount },
+    { header: 'Discards Out', format: fmtCount },
 ];
 
 function isApDevice(d) { return (d.type || '').toLowerCase() === 'ap'; }
@@ -279,6 +279,10 @@ function renderBadges() {
 function renderTableNow(showAll) {
     if (!tableEl) return;
     const rows = buildRows();
+    // When a single device is in view, the Device column is redundant - drop it on
+    // mobile (the CSS does the hiding; all other columns stay).
+    const visibleDevices = tabDevices().filter(d => visibility[d.mac] !== false).length;
+    tableEl.classList.toggle('port-stats-1dev', visibleDevices <= 1);
     if (rows.length === 0) { tableEl.innerHTML = ''; syncTopScrollbar(); return; }
     renderTable(tableEl, container, {
         nameHeader: 'Device', title: '', rows, columns: COLUMNS, showAllRows: showAll,

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -89,10 +89,11 @@ const RJ45_SVG = '<svg width="20" height="15" viewBox="0 0 20 15" fill="none" st
     '<path d="M7.5 10 v2.5 h5 V10"/>' +
     '<path d="M6 4 v3 M8 4 v3 M10 4 v3 M12 4 v3 M14 4 v3"/></svg>';
 
-const SFP_SVG = '<svg width="22" height="15" viewBox="0 0 22 15" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round">' +
-    '<rect x="2" y="4" width="13" height="7" rx="1"/>' +
-    '<path d="M15 5.5 h4 a1 1 0 0 1 1 1 v2 a1 1 0 0 1 -1 1 h-4"/>' +
-    '<path d="M5 4 V2 M9 4 V2"/></svg>';
+const SFP_SVG = '<svg width="22" height="15" viewBox="0 0 22 15" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round" stroke-linecap="round">' +
+    '<rect x="7" y="3" width="12" height="9" rx="1.5"/>' +
+    '<path d="M7 5 C3 5 3 10 7 10"/>' +
+    '<path d="M11 3 V12"/>' +
+    '<path d="M14 7.5 H17.5"/></svg>';
 
 function portIcon(p) {
     const cls = speedClass(p.speedBps);

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -38,6 +38,7 @@ let badgesEl = null;
 let tableEl = null;
 let legendEl = null;
 let topScrollEl = null;     // mirror horizontal scrollbar above the table
+let scrollSyncing = null;   // re-entrancy guard for the two scrollbars ('top'|'resp')
 let opts = {};
 
 let deviceMeta = [];        // [{ mac, name, color }]
@@ -305,7 +306,12 @@ function syncTopScrollbar() {
     topScrollEl.scrollLeft = resp.scrollLeft;
     if (!resp._topSync) {
         resp._topSync = true;
-        resp.addEventListener('scroll', () => { if (topScrollEl) topScrollEl.scrollLeft = resp.scrollLeft; });
+        resp.addEventListener('scroll', () => {
+            if (scrollSyncing === 'top' || !topScrollEl) return;   // don't fight the mirror
+            scrollSyncing = 'resp';
+            topScrollEl.scrollLeft = resp.scrollLeft;
+            requestAnimationFrame(() => { scrollSyncing = null; });
+        });
     }
 }
 
@@ -434,8 +440,12 @@ export function mount(el, mountOpts = {}) {
     if (topScrollEl && !topScrollEl._sync) {
         topScrollEl._sync = true;
         topScrollEl.addEventListener('scroll', () => {
+            if (scrollSyncing === 'resp') return;   // don't fight an in-progress table scroll
             const resp = tableEl && tableEl.querySelector('.table-responsive');
-            if (resp) resp.scrollLeft = topScrollEl.scrollLeft;
+            if (!resp) return;
+            scrollSyncing = 'top';
+            resp.scrollLeft = topScrollEl.scrollLeft;
+            requestAnimationFrame(() => { scrollSyncing = null; });
         });
     }
     renderLegend();

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -49,8 +49,6 @@ let currentAt = null;       // ISO timestamp for historic playback, null = live
 let pollTimer = null;
 let fetchController = null;
 let seekDebounce = null;
-let io = null;
-let isVisibleInViewport = true;
 let paused = false;        // timeline paused on the live edge (distinct from historic scrub)
 let tabsEl = null;
 let activeTab = 'infra';   // 'infra' = gateways + switches, 'aps' = access points
@@ -331,20 +329,12 @@ function startPoll() {
     stopPoll();
     if (currentAt) return;            // historic playback: no polling
     if (paused) return;               // timeline paused on the live edge
-    if (!isVisibleInViewport) return;
+    // Poll whenever live on the tab (live reads the in-memory cache, so this is
+    // cheap). No viewport gating - a display:none card while the cache is cold must
+    // keep polling so it recovers once data arrives, instead of dead-loading.
     pollTimer = setInterval(loadAndRender, LIVE_POLL_MS);
 }
 function stopPoll() { if (pollTimer) { clearInterval(pollTimer); pollTimer = null; } }
-
-function setupObserver() {
-    if (!('IntersectionObserver' in window) || !container) { isVisibleInViewport = true; return; }
-    io = new IntersectionObserver((entries) => {
-        isVisibleInViewport = entries.some(e => e.isIntersecting);
-        if (isVisibleInViewport && !currentAt && !paused) startPoll();
-        else stopPoll();
-    }, { threshold: 0 });
-    io.observe(container);
-}
 
 const api = {
     seekTime(isoTimestamp) {
@@ -397,7 +387,6 @@ const api = {
         stopPoll();
         clearTimeout(seekDebounce);
         if (fetchController) fetchController.abort();
-        if (io) { io.disconnect(); io = null; }
         if (window.__portStatsTable === api) window.__portStatsTable = null;
         container = badgesEl = tableEl = tabsEl = null;
         lastDevices = [];
@@ -420,9 +409,7 @@ export function mount(el, mountOpts = {}) {
         for (const d of mountOpts.deviceMeta) if (d && d.mac && d.name) nameOverrides[d.mac] = d.name;
     }
     currentAt = null;
-    isVisibleInViewport = true;
     window.__portStatsTable = api;
-    setupObserver();
     loadAndRender();
     startPoll();
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -124,7 +124,7 @@ function connectorGlyph(p) {
     const body = '<rect x="3.5" y="6" width="21" height="15" rx="1.5"/><path d="M10.5 6 v-4 h7 V6"/>';
     const detail = n != null
         ? num(13.5)
-        : '<path d="M8 9 v4.5 M11 9 v4.5 M14 9 v4.5 M17 9 v4.5 M20 9 v4.5"/>';  // RJ45 pins, centred on x=14
+        : '<path d="M8 14.5 v4.5 M11 14.5 v4.5 M14 14.5 v4.5 M17 14.5 v4.5 M20 14.5 v4.5"/>';  // RJ45 pins, bottom (opposite the top tab), centred on x=14
     return head + body + detail + '</svg>';
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -51,6 +51,7 @@ let fetchController = null;
 let seekDebounce = null;
 let io = null;
 let isVisibleInViewport = true;
+let paused = false;        // timeline paused on the live edge (distinct from historic scrub)
 let tabsEl = null;
 let activeTab = 'infra';   // 'infra' = gateways + switches, 'aps' = access points
 
@@ -113,16 +114,17 @@ function connectorGlyph(p) {
     const head = '<svg width="28" height="26" viewBox="0 0 28 26" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round">';
     const num = (cy) => `<text x="14" y="${cy}" text-anchor="middle" dominant-baseline="central" font-size="${String(n).length > 1 ? 9 : 11}" font-weight="700" fill="currentColor" stroke="none">${n}</text>`;
     if (sfp) {
-        // SFP/SFP+ cage: wider and shorter than the RJ45, vertically centred, bottom key notch.
-        const body = '<rect x="3" y="7" width="22" height="13" rx="1.5"/><path d="M11 20 v-2.5 h6 v2.5"/>';
-        return head + body + (n != null ? num(13.5) : '') + '</svg>';
+        // SFP/SFP+ cage: wider than the RJ45 and tall enough to seat the port number,
+        // vertically centred, with the bottom key notch.
+        const body = '<rect x="2.5" y="5" width="23" height="16" rx="1.5"/><path d="M11 21 v-2.5 h6 v2.5"/>';
+        return head + body + (n != null ? num(13) : '') + '</svg>';
     }
     // RJ45 8P8C jack: wider than tall (between the female receptacle and the plug),
     // with the bottom locking-tab slot.
     const body = '<rect x="3.5" y="3" width="21" height="15" rx="1.5"/><path d="M10.5 18 v4 h7 V18"/>';
     const detail = n != null
         ? num(10.5)
-        : '<path d="M8 6 v6 M11.5 6 v6 M15 6 v6 M18.5 6 v6 M22 6 v6"/>';  // RJ45 pins
+        : '<path d="M8 6 v6 M11 6 v6 M14 6 v6 M17 6 v6 M20 6 v6"/>';  // RJ45 pins, centred on x=14
     return head + body + detail + '</svg>';
 }
 
@@ -320,6 +322,7 @@ async function loadAndRender() {
 function startPoll() {
     stopPoll();
     if (currentAt) return;            // historic playback: no polling
+    if (paused) return;               // timeline paused on the live edge
     if (!isVisibleInViewport) return;
     pollTimer = setInterval(loadAndRender, LIVE_POLL_MS);
 }
@@ -329,7 +332,7 @@ function setupObserver() {
     if (!('IntersectionObserver' in window) || !container) { isVisibleInViewport = true; return; }
     io = new IntersectionObserver((entries) => {
         isVisibleInViewport = entries.some(e => e.isIntersecting);
-        if (isVisibleInViewport && !currentAt) startPoll();
+        if (isVisibleInViewport && !currentAt && !paused) startPoll();
         else stopPoll();
     }, { threshold: 0 });
     io.observe(container);
@@ -343,9 +346,20 @@ const api = {
             clearTimeout(seekDebounce);
             seekDebounce = setTimeout(loadAndRender, 200);
         } else {
+            // Back at the live edge: refresh + resume polling unless paused.
             loadAndRender();
             startPoll();
         }
+    },
+    // Timeline paused/resumed on the live edge (mirrors the WAN live chart). Historic
+    // scrubbing is handled by seekTime; pause only gates live auto-refresh.
+    pause() {
+        paused = true;
+        stopPoll();
+    },
+    resume() {
+        paused = false;
+        if (!currentAt) { loadAndRender(); startPoll(); }
     },
     selectDevice(mac) {
         if (!mac) return;

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -2,7 +2,7 @@
 // Same control pattern as latency-charts.js and device-health-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=3';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=4';
 
 const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
 const _esc = document.createElement('span');

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -2,7 +2,7 @@
 // Same control pattern as latency-charts.js and device-health-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=2';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=3';
 
 const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
 const _esc = document.createElement('span');


### PR DESCRIPTION
Adds a per-port statistics table to the Monitoring -> Live View tab, below the maps.

## Monitoring (Live View)

- **Port Statistics table** - per-port link rate (in/out), packet counters (unicast/multicast/broadcast), errors and discards for SNMP-polled switches and gateways. Each port shows a connector glyph (RJ45 jack or SFP cage) colour-coded across an 11-step link-speed spectrum, with a colour legend.
- **Connected client** - a Client column links each access port (single wired client) to its Client Performance dashboard.
- **Synced to the timeline** - live by default, historical playback as you scrub, and it respects pause/resume. Live mode is served from an in-memory snapshot (no InfluxDB query per refresh); only historical scrubbing reads InfluxDB.
- **Filtering** - device pills and a clickable device column, split into "Gateways & Switches" / "APs" tabs. Tab and selection persist. Double-clicking a switch or gateway on the 2D/3D map scrolls to the table and isolates that device. Device colours match the determinant used on the Device Stats and Network Performance tabs.
- **Friendly interface names from UniFi config** - physical ports use their UniFi port name; WAN interfaces show as "WANn - <carrier>" (including the cellular carrier and 5G/LTE); WireGuard and OpenVPN tunnels by name; VLAN sub-interfaces and honeypot/bridge interfaces by their network name; SQM shaping interfaces too. Down, unnamed tunnel/shaping interfaces are hidden.
- A wide table can be panned from a top mirror scrollbar (desktop), and the table is mobile-friendly (full columns with horizontal scroll, native touch scrolling, Device column dropped when a single device is shown).

## Accuracy / fixes

- **Negotiated link speed** - the relational interface speed now takes the lower of SNMP and the UniFi-reported speed, since some gateways report only the interface capability over SNMP. This also sharpens the LAN map's wired link speeds.
- **Client identification by best IP** - the Client Dashboard now identifies active clients by ip -> last_ip -> fixed_ip (consistent with its offline/history path), so fixed/reservation devices resolve.
- Drop the redundant MAC/IP tooltips on the Client Dashboard identity line.

## Under the hood

- New point-in-time `interface_counters` read that returns one coherent snapshot per interface; no change to what is written to InfluxDB.
- `InterfaceNameMap` gains an SFP/RJ45 media flag (additive migration).
- Interface labels and the per-port client map are resolved agent-side and cached in memory (additive), so they can become persisted time series later.
