### PR TITLE
Netgear CM700 support, gateway live port-state resilience, and Live View port-table cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Coming Soon: Multi-WAN support for both Monitoring and ISP Health. The per-WAN s
 
 Track signal quality on your cable modem, fiber ONT, and cellular modems over time - the same InfluxDB time-series charting as the rest of your network monitoring data. Instead of logging into each device's admin page to spot-check levels, everything is polled automatically and charted with the same time range controls, filter badges, and dashboard panels as your LAN and WAN metrics.
 
-**Cable Modem (DOCSIS)** - Downstream/upstream power levels, SNR, and FEC error rates (correctable and uncorrectable) with per-channel charting. Supports Netgear CM (CM600, CM1000, CM1200), ARRIS Surfboard (SB8200, SB6183, S33/S34), Motorola (MB8611, MB8600, MB7621), and Xfinitiy / Cox (XB8 / XB10 and CGM4981).
+**Cable Modem (DOCSIS)** - Downstream/upstream power levels, SNR, and FEC error rates (correctable and uncorrectable) with per-channel charting. Supports Netgear CM (CM600, CM700, CM1000, CM1200), ARRIS Surfboard (SB8200, SB6183, S33/S34), Motorola (MB8611, MB8600, MB7621), and Xfinitiy / Cox (XB8 / XB10 and CGM4981).
 
 **Fiber ONT** - RX/TX optical power, temperature, voltage, and bias current for external and SFP ONTs. Supports AT&T residential gateways (BGW320, BGW210), Quantum Q1000K, Realtek-based GPON sticks (ODI DFP-34X-2C2, V-SOL V2801F, T&W TWCGPON657), and 8311 community firmware sticks (WAS-110, PRX126, Nokia G-010S-P). SFP-based ONT monitoring (modules plugged into your gateway that expose DDM optical data) is part of the Network Monitoring feature below.
 

--- a/src/NetworkOptimizer.Web/Endpoints/PortStatsEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/PortStatsEndpoints.cs
@@ -19,6 +19,15 @@ public static class PortStatsEndpoints
     // interface name followed by a dotted numeric VLAN id.
     private static readonly Regex SubInterface = new(@"^(?<base>.+)\.(?<vlan>\d+)$", RegexOptions.Compiled);
 
+    // Switch SNMP ifTables expose logical interfaces - link aggregations, VLAN SVIs, and
+    // stack / tunnel / VPN / user-defined ports - alongside the real physical ports. They are
+    // noise in the port stats table. Real ports ("Port 1", "SFP+ 1") and renamed ports never
+    // match these patterns, and VLAN sub-interfaces ("eth0.150") keep their dotted form. This
+    // is a reader-side display filter only; nothing is removed from InfluxDB or the live cache.
+    private static readonly Regex JunkSwitchInterface = new(
+        @"^(Port-Channel\d+|Logical-int \d+|User Defined Port \d+|stack-port|tunnel\d+|OpenVPN|\d+)$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
     public static void Map(WebApplication app)
     {
         app.MapGet("/api/monitoring/port-stats", async (
@@ -82,12 +91,16 @@ public static class PortStatsEndpoints
                 {
                     var mac = Norm(g.Key);
                     targetByMac.TryGetValue(mac, out var target);
+                    var type = NormalizeType(target?.AutoLabel);
                     return new
                     {
                         mac = g.Key,
                         name = !string.IsNullOrWhiteSpace(target?.Name) ? target!.Name : g.Key,
-                        type = NormalizeType(target?.AutoLabel),
+                        type,
+                        // Switches only: drop logical-interface noise before the friendly-name
+                        // resolution below. Physical and renamed ports pass through untouched.
                         ports = g
+                            .Where(p => type != "switch" || !IsJunkSwitchInterface(p.IfName))
                             .Select(p =>
                             {
                                 mapByKey.TryGetValue((mac, p.IfName), out var nm);
@@ -151,6 +164,11 @@ public static class PortStatsEndpoints
 
     private static string Norm(string mac) =>
         string.IsNullOrEmpty(mac) ? string.Empty : mac.ToLowerInvariant().Replace('-', ':');
+
+    // True when a switch interface is logical noise that should not appear in the port stats
+    // table (see JunkSwitchInterface). Callers gate this on device type == "switch".
+    private static bool IsJunkSwitchInterface(string? ifName) =>
+        !string.IsNullOrEmpty(ifName) && JunkSwitchInterface.IsMatch(ifName);
 
     private static string NormalizeType(string? autoLabel) => (autoLabel ?? "").ToLowerInvariant() switch
     {

--- a/src/NetworkOptimizer.Web/Endpoints/PortStatsEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/PortStatsEndpoints.cs
@@ -22,7 +22,7 @@ public static class PortStatsEndpoints
     // Switch SNMP ifTables expose logical interfaces - link aggregations, VLAN SVIs, and
     // stack / tunnel / VPN / user-defined ports - alongside the real physical ports. They are
     // noise in the port stats table. Real ports ("Port 1", "SFP+ 1") and renamed ports never
-    // match these patterns, and VLAN sub-interfaces ("eth0.150") keep their dotted form. This
+    // match these patterns, and VLAN sub-interfaces ("eth0.100") keep their dotted form. This
     // is a reader-side display filter only; nothing is removed from InfluxDB or the live cache.
     private static readonly Regex JunkSwitchInterface = new(
         @"^(Port-Channel\d+|Logical-int \d+|User Defined Port \d+|stack-port|tunnel\d+|OpenVPN|\d+)$",

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
@@ -61,10 +61,11 @@ public sealed class NetgearCmProvider : ICableModemProvider
     private readonly ILogger<NetgearCmProvider> _logger;
 
     /// <summary>
-    /// Remembers the status-page path that last succeeded per CmConfiguration.Id so later
-    /// polls skip the dead extension instead of 401/404-ing on it every interval.
+    /// Remembers the (status-page path, send-credentials) combination that last succeeded per
+    /// CmConfiguration.Id so later polls go straight to it instead of re-probing the dead
+    /// extension or wrong auth mode every interval.
     /// </summary>
-    private readonly ConcurrentDictionary<int, string> _pathCache = new();
+    private readonly ConcurrentDictionary<int, (string Path, bool UseCreds)> _attemptCache = new();
 
     public NetgearCmProvider(ILogger<NetgearCmProvider> logger)
     {
@@ -171,73 +172,91 @@ public sealed class NetgearCmProvider : ICableModemProvider
     }
 
     /// <summary>
-    /// Fetch the DOCSIS status page, transparently falling back between the two known
-    /// Netgear page extensions. Tries the configured/default path first, then the alternate
-    /// extension if the first request fails with ANY HTTP status error or transport error,
-    /// and remembers whichever worked per config so later polls go straight to it. If the
-    /// alternate also fails, the last error propagates to the retry loop - so a genuine
-    /// auth failure (both extensions reject the credentials) still surfaces.
+    /// Fetch the DOCSIS status page, transparently falling back across both Netgear page
+    /// extensions AND whether credentials are sent. Tries the configured/default path with
+    /// credentials first (modems like the CM600 gate the page behind HTTP Basic), then the
+    /// alternate extension, then the same paths WITHOUT credentials - some modems (e.g. CM700)
+    /// serve the page openly and 401 a request that presents unexpected credentials. Any HTTP
+    /// status error or transport error advances to the next attempt; the last attempt's error
+    /// propagates, so a genuine auth failure (every attempt rejected) still surfaces. The
+    /// winning combination is cached per config so later polls go straight to it.
     /// </summary>
     private async Task<string?> FetchWithFallbackAsync(
         CmPollContext context,
         CancellationToken cancellationToken)
     {
-        var candidates = ResolvePathCandidates(context);
+        var attempts = ResolveAttempts(context);
 
-        for (int i = 0; i < candidates.Count; i++)
+        for (int i = 0; i < attempts.Count; i++)
         {
-            var url = BuildUrl(context, candidates[i]);
+            var (path, useCreds) = attempts[i];
+            var url = BuildUrl(context, path);
+            var user = useCreds ? context.Username : null;
+            var pass = useCreds ? context.Password : null;
             try
             {
-                var html = await FetchPageAsync(url, context.Username, context.Password, cancellationToken);
+                var html = await FetchPageAsync(url, user, pass, cancellationToken);
                 if (context.Id > 0)
-                    _pathCache[context.Id] = candidates[i];
+                    _attemptCache[context.Id] = (path, useCreds);
                 return html;
             }
-            catch (HttpRequestException ex) when (i < candidates.Count - 1)
+            catch (HttpRequestException ex) when (i < attempts.Count - 1)
             {
-                // Fall back on any HTTP status error (401/403/404/5xx) or transport error
+                // Advance on any HTTP status error (401/403/404/5xx) or transport error
                 // (connection reset/closed, where StatusCode is null). Netgear firmware
-                // signals an unavailable .asp path inconsistently - the reporter's CM700
-                // returned 401, while other models simply close the connection - so we don't
-                // gate the fallback on a specific code.
+                // signals an unavailable path or unwanted credentials inconsistently - the
+                // CM700 returned 401, other models close the connection - so we don't gate on
+                // a specific code.
                 _logger.LogDebug(
-                    "Netgear CM {Name}: {Path} failed ({Reason}); trying alternate page extension",
-                    context.Name, candidates[i],
+                    "Netgear CM {Name}: {Path} (creds={UseCreds}) failed ({Reason}); trying next attempt",
+                    context.Name, path, useCreds,
                     ex.StatusCode is { } status ? $"HTTP {(int)status}" : ex.Message);
             }
         }
 
-        // Unreachable: the loop returns on the first success, and the last candidate's
-        // exception is not caught here (the when-guard requires a remaining candidate) so it
-        // propagates to PollAsync/TestConnectionAsync.
+        // Unreachable: the loop returns on the first success, and the last attempt's exception
+        // is not caught here (the when-guard requires a remaining attempt) so it propagates to
+        // PollAsync/TestConnectionAsync.
         return null;
     }
 
     /// <summary>
-    /// Build the ordered list of status-page paths to try: the configured (or default) path
-    /// first, then the alternate Netgear extension (.asp ↔ .htm) when the path is a
-    /// DocsisStatus page. A path recorded as working for this config is moved to the front.
+    /// Build the ordered list of (path, send-credentials) attempts: the configured/default
+    /// path and the alternate Netgear extension (.asp ↔ .htm), each tried with credentials
+    /// first (when configured) and then without. The attempt recorded as working for this
+    /// config is moved to the front.
     /// </summary>
-    private List<string> ResolvePathCandidates(CmPollContext context)
+    private List<(string Path, bool UseCreds)> ResolveAttempts(CmPollContext context)
     {
         var configured = string.IsNullOrWhiteSpace(context.StatusPagePath)
             ? DefaultStatusPath
             : context.StatusPagePath;
 
-        var candidates = new List<string> { configured };
+        var paths = new List<string> { configured };
         var alternate = AlternateNetgearPath(configured);
         if (alternate != null)
-            candidates.Add(alternate);
+            paths.Add(alternate);
 
-        if (context.Id > 0
-            && _pathCache.TryGetValue(context.Id, out var lastGood)
-            && candidates.Remove(lastGood))
+        var hasCreds = !string.IsNullOrEmpty(context.Username) && !string.IsNullOrEmpty(context.Password);
+
+        var attempts = new List<(string Path, bool UseCreds)>();
+        // Credentialed attempts first - required by modems that gate the page behind Basic auth.
+        if (hasCreds)
+            attempts.AddRange(paths.Select(p => (p, true)));
+        // Then anonymous attempts - for modems that serve openly and reject unexpected creds.
+        attempts.AddRange(paths.Select(p => (p, false)));
+
+        if (context.Id > 0 && _attemptCache.TryGetValue(context.Id, out var lastGood))
         {
-            candidates.Insert(0, lastGood);
+            var idx = attempts.FindIndex(a => a.Path == lastGood.Path && a.UseCreds == lastGood.UseCreds);
+            if (idx > 0)
+            {
+                attempts.RemoveAt(idx);
+                attempts.Insert(0, lastGood);
+            }
         }
 
-        return candidates;
+        return attempts;
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -8,9 +9,20 @@ using NetworkOptimizer.Monitoring.Providers;
 namespace NetworkOptimizer.Web.Services.CableModemProviders;
 
 /// <summary>
-/// Cable modem provider for Netgear DOCSIS modems (CM1000, CM1100, CM1200, etc.).
-/// Scrapes the DocsisStatus.asp page via HTTP Basic Auth and parses
+/// Cable modem provider for Netgear DOCSIS modems (CM600, CM700, CM1000, CM1200, etc.).
+/// Scrapes the DocsisStatus status page via HTTP Basic Auth and parses
 /// downstream/upstream channel tables using HtmlAgilityPack.
+///
+/// Netgear is inconsistent about the page extension: most models serve
+/// <c>DocsisStatus.asp</c> (e.g. CM600, CM1000) while some serve <c>DocsisStatus.htm</c>
+/// (e.g. CM700) and return 401/404 for the .asp path. Model number does not reliably
+/// predict which (CM600 and CM700 are both DOCSIS 3.0 yet differ), so the provider tries
+/// the configured/default path and transparently falls back to the alternate extension.
+///
+/// The two pages also differ in how channel data is delivered: the .asp page renders the
+/// downstream/upstream tables server-side, while the .htm page ships empty tables and a
+/// JavaScript tagValueList that the browser expands client-side. The parser handles both -
+/// the server-rendered tables first, then the tagValueList for any table left empty.
 /// </summary>
 public sealed class NetgearCmProvider : ICableModemProvider
 {
@@ -34,7 +46,25 @@ public sealed class NetgearCmProvider : ICableModemProvider
     private static readonly Regex RetailSessionRx =
         new("name=[\"']?RetailSessionId[\"']?\\s+value=[\"']?([0-9A-Za-z]+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
+    // CM700 (and similar) serve DocsisStatus.htm with empty channel tables that the browser
+    // fills client-side from a JavaScript tagValueList: a leading channel count followed by
+    // pipe-delimited per-channel fields. Capture the live single-quoted assignment for each
+    // table (the placeholder/example assignment in the function is double-quoted and inside a
+    // /* */ comment, so the single-quote match skips it).
+    private static readonly Regex DsTagValueListRx =
+        new(@"InitDsTableTagValue\s*\(\s*\)\s*\{.*?var\s+tagValueList\s*=\s*'([^']*)'",
+            RegexOptions.Singleline | RegexOptions.Compiled);
+    private static readonly Regex UsTagValueListRx =
+        new(@"InitUsTableTagValue\s*\(\s*\)\s*\{.*?var\s+tagValueList\s*=\s*'([^']*)'",
+            RegexOptions.Singleline | RegexOptions.Compiled);
+
     private readonly ILogger<NetgearCmProvider> _logger;
+
+    /// <summary>
+    /// Remembers the status-page path that last succeeded per CmConfiguration.Id so later
+    /// polls skip the dead extension instead of 401/404-ing on it every interval.
+    /// </summary>
+    private readonly ConcurrentDictionary<int, string> _pathCache = new();
 
     public NetgearCmProvider(ILogger<NetgearCmProvider> logger)
     {
@@ -52,13 +82,11 @@ public sealed class NetgearCmProvider : ICableModemProvider
             return null;
         }
 
-        var url = BuildUrl(context);
-
         for (int attempt = 1; attempt <= MaxRetries; attempt++)
         {
             try
             {
-                var html = await FetchPageAsync(url, context.Username, context.Password, cancellationToken);
+                var html = await FetchWithFallbackAsync(context, cancellationToken);
                 if (html == null)
                 {
                     _logger.LogWarning(
@@ -107,27 +135,22 @@ public sealed class NetgearCmProvider : ICableModemProvider
         if (string.IsNullOrWhiteSpace(context.Host))
             return (false, "Host is empty");
 
-        var url = BuildUrl(context);
-
         try
         {
-            var html = await FetchPageAsync(url, context.Username, context.Password, cancellationToken);
+            var html = await FetchWithFallbackAsync(context, cancellationToken);
             if (html == null)
                 return (false, "No response from cable modem");
 
-            var doc = new HtmlDocument();
-            doc.LoadHtml(html);
+            // Parse through the full pipeline so both the server-rendered table format
+            // (.asp) and the JavaScript tagValueList format (.htm, e.g. CM700) are counted.
+            var stats = ParseDocsisStatus(html, context);
+            var dsCount = stats.DownstreamChannels.Count;
+            var usCount = stats.UpstreamChannels.Count;
 
-            var dsTable = doc.DocumentNode.SelectSingleNode("//table[@id='dsTable']");
-            var usTable = doc.DocumentNode.SelectSingleNode("//table[@id='usTable']");
+            if (dsCount == 0 && usCount == 0)
+                return (false, "Connected but no DOCSIS channels found. Check the status page path.");
 
-            if (dsTable == null && usTable == null)
-                return (false, "Connected but DOCSIS status tables not found. Check the status page path.");
-
-            var dsRows = dsTable?.SelectNodes(".//tr[position()>1]")?.Count ?? 0;
-            var usRows = usTable?.SelectNodes(".//tr[position()>1]")?.Count ?? 0;
-
-            return (true, $"Connected - {dsRows} downstream, {usRows} upstream channels detected");
+            return (true, $"Connected - {dsCount} downstream, {usCount} upstream channels detected");
         }
         catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Unauthorized)
         {
@@ -139,16 +162,91 @@ public sealed class NetgearCmProvider : ICableModemProvider
         }
     }
 
-    private string BuildUrl(CmPollContext context)
+    private static string BuildUrl(CmPollContext context, string path)
     {
-        var path = string.IsNullOrWhiteSpace(context.StatusPagePath)
-            ? DefaultStatusPath
-            : context.StatusPagePath;
-
         var port = context.Port > 0 ? context.Port : 80;
         var portSuffix = port == 80 ? "" : $":{port}";
 
         return $"http://{context.Host}{portSuffix}{path}";
+    }
+
+    /// <summary>
+    /// Fetch the DOCSIS status page, transparently falling back between the two known
+    /// Netgear page extensions. Tries the configured/default path first, then the alternate
+    /// extension if the first returns 401 or 404, and remembers whichever worked per config
+    /// so later polls go straight to it. Other failures propagate to the retry loop.
+    /// </summary>
+    private async Task<string?> FetchWithFallbackAsync(
+        CmPollContext context,
+        CancellationToken cancellationToken)
+    {
+        var candidates = ResolvePathCandidates(context);
+
+        for (int i = 0; i < candidates.Count; i++)
+        {
+            var url = BuildUrl(context, candidates[i]);
+            try
+            {
+                var html = await FetchPageAsync(url, context.Username, context.Password, cancellationToken);
+                if (context.Id > 0)
+                    _pathCache[context.Id] = candidates[i];
+                return html;
+            }
+            catch (HttpRequestException ex) when (
+                i < candidates.Count - 1
+                && ex.StatusCode is System.Net.HttpStatusCode.Unauthorized
+                                 or System.Net.HttpStatusCode.NotFound)
+            {
+                _logger.LogDebug(
+                    "Netgear CM {Name}: {Path} returned {Status}; trying alternate page extension",
+                    context.Name, candidates[i], (int)ex.StatusCode);
+            }
+        }
+
+        // Unreachable: the loop returns on the first success, and the last candidate's
+        // exception is not caught here (the when-guard requires a remaining candidate) so it
+        // propagates to PollAsync/TestConnectionAsync.
+        return null;
+    }
+
+    /// <summary>
+    /// Build the ordered list of status-page paths to try: the configured (or default) path
+    /// first, then the alternate Netgear extension (.asp ↔ .htm) when the path is a
+    /// DocsisStatus page. A path recorded as working for this config is moved to the front.
+    /// </summary>
+    private List<string> ResolvePathCandidates(CmPollContext context)
+    {
+        var configured = string.IsNullOrWhiteSpace(context.StatusPagePath)
+            ? DefaultStatusPath
+            : context.StatusPagePath;
+
+        var candidates = new List<string> { configured };
+        var alternate = AlternateNetgearPath(configured);
+        if (alternate != null)
+            candidates.Add(alternate);
+
+        if (context.Id > 0
+            && _pathCache.TryGetValue(context.Id, out var lastGood)
+            && candidates.Remove(lastGood))
+        {
+            candidates.Insert(0, lastGood);
+        }
+
+        return candidates;
+    }
+
+    /// <summary>
+    /// Returns the other Netgear DOCSIS status-page extension for a given path, or null if
+    /// the path is not a recognized DocsisStatus page. CM600/CM1000 use <c>.asp</c>; CM700
+    /// uses <c>.htm</c>, and model number does not reliably predict which.
+    /// </summary>
+    private static string? AlternateNetgearPath(string path)
+    {
+        if (path.EndsWith("DocsisStatus.asp", StringComparison.OrdinalIgnoreCase))
+            return string.Concat(path.AsSpan(0, path.Length - 4), ".htm");
+        if (path.EndsWith("DocsisStatus.htm", StringComparison.OrdinalIgnoreCase))
+            return string.Concat(path.AsSpan(0, path.Length - 4), ".asp");
+        return null;
     }
 
     private async Task<string?> FetchPageAsync(
@@ -273,7 +371,7 @@ public sealed class NetgearCmProvider : ICableModemProvider
         return (int)postResponse.StatusCode < 400;
     }
 
-    private CableModemStats ParseDocsisStatus(string html, CmPollContext context)
+    internal static CableModemStats ParseDocsisStatus(string html, CmPollContext context)
     {
         var doc = new HtmlDocument();
         doc.LoadHtml(html);
@@ -358,7 +456,94 @@ public sealed class NetgearCmProvider : ICableModemProvider
             }
         }
 
+        // Models that build the tables client-side (e.g. CM700 on DocsisStatus.htm) leave the
+        // server-rendered tables empty, so fall back to the JavaScript tagValueList data.
+        ParseTagValueTables(html, stats);
+
         return stats;
+    }
+
+    /// <summary>
+    /// Parse channel data from the JavaScript tagValueList assignments used by models that
+    /// render the DOCSIS tables client-side (e.g. CM700). Only runs for tables the
+    /// HtmlAgilityPack pass left empty, so it never overrides server-rendered data.
+    /// </summary>
+    private static void ParseTagValueTables(string html, CableModemStats stats)
+    {
+        if (stats.DownstreamChannels.Count == 0)
+        {
+            var match = DsTagValueListRx.Match(html);
+            if (match.Success)
+            {
+                // Per channel: Channel, Lock Status, Modulation, Channel ID, Frequency, Power,
+                // SNR, and (on firmware that reports them) Correctables, UnCorrectables.
+                foreach (var f in ChunkTagValues(match.Groups[1].Value))
+                {
+                    stats.DownstreamChannels.Add(new DsChannel
+                    {
+                        LockStatus = f[1],
+                        Modulation = f[2],
+                        ChannelId = ParseInt(f[3]),
+                        Frequency = ParseFrequency(f[4]),
+                        Power = ParseDouble(f[5]),
+                        Snr = ParseDouble(f[6]),
+                        Correctables = f.Count > 7 ? ParseLong(f[7]) : 0,
+                        Uncorrectables = f.Count > 8 ? ParseLong(f[8]) : 0,
+                    });
+                }
+            }
+        }
+
+        if (stats.UpstreamChannels.Count == 0)
+        {
+            var match = UsTagValueListRx.Match(html);
+            if (match.Success)
+            {
+                // Per channel: Channel, Lock Status, US Channel Type, Channel ID, Symbol Rate,
+                // Frequency, Power.
+                foreach (var f in ChunkTagValues(match.Groups[1].Value))
+                {
+                    stats.UpstreamChannels.Add(new UsChannel
+                    {
+                        LockStatus = f[1],
+                        ChannelType = f[2],
+                        ChannelId = ParseInt(f[3]),
+                        SymbolRate = ParseSymbolRate(f[4]),
+                        Frequency = ParseFrequency(f[5]),
+                        Power = ParseDouble(f[6]),
+                    });
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Split a Netgear tagValueList - a leading channel count followed by pipe-delimited
+    /// per-channel fields - into one field list per channel. A trailing pipe leaves an empty
+    /// token that is ignored. Returns nothing if the count is missing/invalid or the fields
+    /// don't divide into per-channel groups of at least the seven shared columns.
+    /// </summary>
+    private static IEnumerable<List<string>> ChunkTagValues(string tagValueList)
+    {
+        var tokens = tagValueList.Split('|');
+        if (tokens.Length < 2 || !int.TryParse(tokens[0].Trim(), out var count) || count <= 0)
+            yield break;
+
+        var fields = tokens.Skip(1).ToList();
+        while (fields.Count > 0 && string.IsNullOrEmpty(fields[^1]))
+            fields.RemoveAt(fields.Count - 1);
+
+        var perChannel = fields.Count / count;
+        if (perChannel < 7)
+            yield break;
+
+        for (int c = 0; c < count; c++)
+        {
+            var start = c * perChannel;
+            if (start + perChannel > fields.Count)
+                yield break;
+            yield return fields.GetRange(start, perChannel);
+        }
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
@@ -542,7 +542,10 @@ public sealed class NetgearCmProvider : ICableModemProvider
             var start = c * perChannel;
             if (start + perChannel > fields.Count)
                 yield break;
-            yield return fields.GetRange(start, perChannel);
+            // Trim each field to mirror the server-rendered path (InnerText.Trim()). Lock
+            // status is matched exactly, so stray whitespace would otherwise zero out every
+            // locked count and null the power/SNR averages.
+            yield return fields.GetRange(start, perChannel).Select(f => f.Trim()).ToList();
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
@@ -173,8 +173,10 @@ public sealed class NetgearCmProvider : ICableModemProvider
     /// <summary>
     /// Fetch the DOCSIS status page, transparently falling back between the two known
     /// Netgear page extensions. Tries the configured/default path first, then the alternate
-    /// extension if the first returns 401 or 404, and remembers whichever worked per config
-    /// so later polls go straight to it. Other failures propagate to the retry loop.
+    /// extension if the first request fails with ANY HTTP status error or transport error,
+    /// and remembers whichever worked per config so later polls go straight to it. If the
+    /// alternate also fails, the last error propagates to the retry loop - so a genuine
+    /// auth failure (both extensions reject the credentials) still surfaces.
     /// </summary>
     private async Task<string?> FetchWithFallbackAsync(
         CmPollContext context,
@@ -192,14 +194,17 @@ public sealed class NetgearCmProvider : ICableModemProvider
                     _pathCache[context.Id] = candidates[i];
                 return html;
             }
-            catch (HttpRequestException ex) when (
-                i < candidates.Count - 1
-                && ex.StatusCode is System.Net.HttpStatusCode.Unauthorized
-                                 or System.Net.HttpStatusCode.NotFound)
+            catch (HttpRequestException ex) when (i < candidates.Count - 1)
             {
+                // Fall back on any HTTP status error (401/403/404/5xx) or transport error
+                // (connection reset/closed, where StatusCode is null). Netgear firmware
+                // signals an unavailable .asp path inconsistently - the reporter's CM700
+                // returned 401, while other models simply close the connection - so we don't
+                // gate the fallback on a specific code.
                 _logger.LogDebug(
-                    "Netgear CM {Name}: {Path} returned {Status}; trying alternate page extension",
-                    context.Name, candidates[i], (int)ex.StatusCode);
+                    "Netgear CM {Name}: {Path} failed ({Reason}); trying alternate page extension",
+                    context.Name, candidates[i],
+                    ex.StatusCode is { } status ? $"HTTP {(int)status}" : ex.Message);
             }
         }
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -1619,6 +1619,20 @@ public class MonitoringCollectionAgent : BackgroundService
             bcastPktsOut: iface.OutBroadcastPkts > 0 ? iface.OutBroadcastPkts : null,
             timestamp: now);
 
+        // Live port-state resilience for gateways: when UniFi's last poll says the port is
+        // down or disabled, mark the live port down - UNLESS the SNMP frame counters moved
+        // this poll, which proves it is passing traffic and UniFi's state is stale. Scoped to
+        // the in-memory live cache; the InfluxDB write above keeps the raw SNMP ifOperStatus.
+        int liveOperStatus = iface.OperStatus;
+        if (device.DeviceType == NetworkOptimizer.Core.Enums.DeviceType.Gateway && !(rateInBps > 0) && !(rateOutBps > 0))
+        {
+            var uniPort = device.PortTable?.FirstOrDefault(p =>
+                !string.IsNullOrEmpty(p.IfName)
+                && string.Equals(p.IfName, ifName, StringComparison.OrdinalIgnoreCase));
+            if (uniPort != null && (!uniPort.Up || !uniPort.Enable))
+                liveOperStatus = 2; // ifOperStatus down
+        }
+
         // Mirror the full per-port snapshot into the live cache so the Live View port
         // stats table can serve live mode from memory instead of querying InfluxDB.
         _liveStats.RecordPortStats(new MonitoringInfluxClient.PortStatsPoint
@@ -1626,7 +1640,7 @@ public class MonitoringCollectionAgent : BackgroundService
             DeviceMac = mac,
             IfName = ifName,
             PortId = iface.PortId ?? "",
-            OperStatus = iface.OperStatus,
+            OperStatus = liveOperStatus,
             SpeedBps = speedBps > 0 ? speedBps : (long?)null,
             RateInBps = rateInBps,
             RateOutBps = rateOutBps,

--- a/tests/NetworkOptimizer.Web.Tests/NetgearCmProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/NetgearCmProviderTests.cs
@@ -1,0 +1,136 @@
+using FluentAssertions;
+using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.CableModemProviders;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class NetgearCmProviderTests
+{
+    private static CmPollContext Context => new()
+    {
+        Id = 1,
+        Name = "TestModem",
+        Host = "192.168.100.1",
+    };
+
+    // Mirrors the CM700 DocsisStatus.htm shape: the dsTable/usTable elements carry only a
+    // header row (the example data rows are inside an HTML comment), and the live channel
+    // data lives in a JavaScript tagValueList - a leading channel count followed by
+    // pipe-delimited per-channel fields. The placeholder assignment in each function is
+    // double-quoted and commented out; the live one is single-quoted.
+    private const string Cm700JsHtml = """
+        <html><head><script>
+        function InitUsTableTagValue()
+        {
+            /* Channel | Lock Status | US Channel Type | Channel ID | Symbol Rate | Frequency | Power */
+            /* var tagValueList = "4" + "|1|Not Locked|Unknown|0|0|0|0.0"; */
+            var tagValueList = '2|1|Locked|ATDMA|17|5120|16400000 Hz|40.7|2|Locked|ATDMA|18|5120|22800000 Hz|39.4|';
+            drawTable('usTable', tagValueList, onAddUsRowCB);
+        }
+        function InitDsTableTagValue()
+        {
+            /* Channel | Lock Status | Modulation | Channel ID | Frequency | Power | SNR */
+            /* var tagValueList = "8" + "|1|Not Locked|Unknown|0|0|0.0|0.0"; */
+            var tagValueList = '3|1|Locked|QAM 256|1|387000000 Hz|5.8|40.9|7|0|2|Locked|QAM 256|2|393000000 Hz|5.8|41.0|0|0|3|Locked|OFDM PLC|159|960000000 Hz|6.0|41.2|1148|12|';
+            drawTable('dsTable', tagValueList, onAddDsRowCB);
+        }
+        </script></head><body>
+        <table id="dsTable" class="TableStyle">
+          <tr><td><span class="thead">Channel</span></td><td><span class="thead">UnCorrectables</span></td></tr>
+        <!--
+          <tr><td>1</td><td>Locked</td><td>unknown</td><td>0</td><td>0 Hz</td><td>0.0 dBmV</td><td>0.0 dB</td></tr>
+        -->
+        </table>
+        <table id="usTable" class="TableStyle">
+          <tr><td><span class="thead">Channel</span></td></tr>
+        </table>
+        </body></html>
+        """;
+
+    // Server-rendered .asp shape (CM600/CM1000): full downstream table including the FEC
+    // counters. Guards the HtmlAgilityPack path and confirms the JS fallback does not run
+    // when the tables already have data.
+    private const string ServerRenderedHtml = """
+        <table id="dsTable" class="TableStyle">
+          <tr>
+            <td><span class="thead">Channel</span></td>
+            <td><span class="thead">Lock Status</span></td>
+            <td><span class="thead">Modulation</span></td>
+            <td><span class="thead">Channel ID</span></td>
+            <td><span class="thead">Frequency</span></td>
+            <td><span class="thead">Power</span></td>
+            <td><span class="thead">SNR</span></td>
+            <td><span class="thead">Correctables</span></td>
+            <td><span class="thead">UnCorrectables</span></td>
+          </tr>
+          <tr><td>1</td><td>Locked</td><td>256QAM</td><td>1</td><td>591000000 Hz</td><td>-2.5 dBmV</td><td> 40.0 dB</td><td>1234</td><td>5</td></tr>
+        </table>
+        """;
+
+    [Fact]
+    public void ParseDocsisStatus_ParsesDownstreamFromJavaScriptTagValueList()
+    {
+        var stats = NetgearCmProvider.ParseDocsisStatus(Cm700JsHtml, Context);
+
+        stats.DownstreamChannels.Should().HaveCount(3);
+
+        var first = stats.DownstreamChannels[0];
+        first.ChannelId.Should().Be(1);
+        first.LockStatus.Should().Be("Locked");
+        first.Modulation.Should().Be("QAM 256");
+        first.Frequency.Should().Be(387000000);
+        first.Power.Should().Be(5.8);
+        first.Snr.Should().Be(40.9);
+        first.Correctables.Should().Be(7);
+        first.Uncorrectables.Should().Be(0);
+
+        // Channel ID column (not the sequential index) wins, and the FEC counters carry through.
+        var third = stats.DownstreamChannels[2];
+        third.ChannelId.Should().Be(159);
+        third.Modulation.Should().Be("OFDM PLC");
+        third.Correctables.Should().Be(1148);
+        third.Uncorrectables.Should().Be(12);
+    }
+
+    [Fact]
+    public void ParseDocsisStatus_ParsesUpstreamFromJavaScriptTagValueList()
+    {
+        var stats = NetgearCmProvider.ParseDocsisStatus(Cm700JsHtml, Context);
+
+        stats.UpstreamChannels.Should().HaveCount(2);
+
+        var first = stats.UpstreamChannels[0];
+        first.ChannelId.Should().Be(17);
+        first.LockStatus.Should().Be("Locked");
+        first.ChannelType.Should().Be("ATDMA");
+        first.SymbolRate.Should().Be(5120);
+        first.Frequency.Should().Be(16400000);
+        first.Power.Should().Be(40.7);
+    }
+
+    [Fact]
+    public void ParseDocsisStatus_IgnoresCommentedPlaceholderRows()
+    {
+        // The only non-JS rows in the CM700 page are commented out; parsing must come solely
+        // from the tagValueList, not the 0-valued placeholder row.
+        var stats = NetgearCmProvider.ParseDocsisStatus(Cm700JsHtml, Context);
+
+        stats.DownstreamChannels.Should().OnlyContain(c => c.LockStatus == "Locked");
+        stats.DownstreamChannels.Should().Contain(c => c.Frequency == 387000000);
+    }
+
+    [Fact]
+    public void ParseDocsisStatus_StillParsesServerRenderedTables()
+    {
+        var stats = NetgearCmProvider.ParseDocsisStatus(ServerRenderedHtml, Context);
+
+        var ds = stats.DownstreamChannels.Should().ContainSingle().Subject;
+        ds.ChannelId.Should().Be(1);
+        ds.Modulation.Should().Be("256QAM");
+        ds.Power.Should().Be(-2.5);
+        ds.Snr.Should().Be(40.0);
+        ds.Correctables.Should().Be(1234);
+        ds.Uncorrectables.Should().Be(5);
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/NetgearCmProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/NetgearCmProviderTests.cs
@@ -120,6 +120,49 @@ public class NetgearCmProviderTests
         stats.DownstreamChannels.Should().Contain(c => c.Frequency == 387000000);
     }
 
+    // Mixed lock states (as the real CM700 capture has 3 "Not Locked" upstream channels with
+    // 0.0 power): the aggregates written to InfluxDB must count and average only locked
+    // channels, so unlocked 0-value channels don't drag the averages down.
+    private const string Cm700MixedLockHtml = """
+        <html><head><script>
+        function InitUsTableTagValue()
+        {
+            var tagValueList = '2|1|Locked|ATDMA|17|5120|16400000 Hz|45.0|2|Not Locked|N/A|Unknown|0|0 Hz|0.0|';
+        }
+        function InitDsTableTagValue()
+        {
+            var tagValueList = '2|1|Locked|QAM 256|1|387000000 Hz|5.0|40.0|10|2|2|Not Locked|Unknown|0|0 Hz|0.0|0.0|0|0|';
+        }
+        </script></head><body>
+        <table id="dsTable"><tr><td><span class="thead">Channel</span></td></tr></table>
+        <table id="usTable"><tr><td><span class="thead">Channel</span></td></tr></table>
+        </body></html>
+        """;
+
+    [Fact]
+    public void ParseDocsisStatus_AggregatesOnlyLockedChannels()
+    {
+        var stats = NetgearCmProvider.ParseDocsisStatus(Cm700MixedLockHtml, Context);
+
+        // Both channels are parsed and cached, but only the locked ones count toward the
+        // metrics written to InfluxDB.
+        stats.DownstreamChannels.Should().HaveCount(2);
+        stats.UpstreamChannels.Should().HaveCount(2);
+
+        stats.LockedDsChannels.Should().Be(1);
+        stats.LockedUsChannels.Should().Be(1);
+
+        // Averages exclude the unlocked 0.0-value channels rather than being pulled toward 0.
+        stats.DownstreamPowerAvgDbmv.Should().Be(5.0);
+        stats.DownstreamSnrAvgDb.Should().Be(40.0);
+        stats.UpstreamPowerAvgDbmv.Should().Be(45.0);
+
+        // FEC counters sum across the downstream channels.
+        stats.TotalCorrectables.Should().Be(10);
+        stats.TotalUncorrectables.Should().Be(2);
+        stats.ChannelsWithUncorrectables.Should().Be(1);
+    }
+
     [Fact]
     public void ParseDocsisStatus_StillParsesServerRenderedTables()
     {


### PR DESCRIPTION
## Netgear CM700 cable modem support

Adds support for Netgear modems that serve `DocsisStatus.htm` (e.g. CM700) alongside the existing `.asp` models (CM600, CM1000):

- Automatically falls back between the `.asp` and `.htm` status pages, and between sending and not sending credentials, so the modem is reached whether it gates the page behind HTTP Basic auth or serves it openly (and rejects unexpected credentials). The working combination is remembered per modem to keep steady-state polling to a single request.
- Parses the `.htm` page's JavaScript-embedded channel data - these models ship the DOCSIS tables empty and fill them client-side - in addition to the existing server-rendered table format.
- CM700 added to the supported-modem list.

## Gateway live port-state resilience

The Live View port table now defers to UniFi's port state for gateway ports: when UniFi reports a port down or disabled, it is shown down unless the SNMP frame counters moved since the last poll (which proves the port is actually passing traffic). This prevents a stale SNMP `ifOperStatus` from showing a port up when it isn't. Scoped to the in-memory live view; the historical record keeps the raw SNMP value.

## Live View port-table cleanup

Managed switches expose logical interfaces - link aggregations, VLAN SVIs, and stack / tunnel / VPN / user-defined ports - in SNMP alongside their physical ports. These are now hidden from the port stats table for switch devices. Physical ports and renamed ports are unaffected.

## Tests

New `NetgearCmProviderTests` cover the JavaScript `tagValueList` parsing, the server-rendered table format, commented-placeholder immunity, and locked-channel aggregation.