### PR TITLE
v1.22.0: port-table byte counters and Netgear CM fallback resilience

### DIFF
--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
@@ -87,7 +87,10 @@ public sealed class NetgearCmProvider : ICableModemProvider
         {
             try
             {
-                var html = await FetchWithFallbackAsync(context, cancellationToken);
+                // Force the full path/credential matrix only on the final retry, so a cached
+                // combo's transient blip recovers via the earlier retries without probing
+                // (and logging) every other combo.
+                var html = await FetchWithFallbackAsync(context, cancellationToken, fullMatrix: attempt == MaxRetries);
                 if (html == null)
                 {
                     _logger.LogWarning(
@@ -138,7 +141,9 @@ public sealed class NetgearCmProvider : ICableModemProvider
 
         try
         {
-            var html = await FetchWithFallbackAsync(context, cancellationToken);
+            // A manual test should probe everything to find a working combo, so force the
+            // full matrix regardless of any cached result.
+            var html = await FetchWithFallbackAsync(context, cancellationToken, fullMatrix: true);
             if (html == null)
                 return (false, "No response from cable modem");
 
@@ -183,9 +188,10 @@ public sealed class NetgearCmProvider : ICableModemProvider
     /// </summary>
     private async Task<string?> FetchWithFallbackAsync(
         CmPollContext context,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool fullMatrix)
     {
-        var attempts = ResolveAttempts(context);
+        var attempts = ResolveAttempts(context, fullMatrix);
 
         for (int i = 0; i < attempts.Count; i++)
         {
@@ -226,8 +232,16 @@ public sealed class NetgearCmProvider : ICableModemProvider
     /// first (when configured) and then without. The attempt recorded as working for this
     /// config is moved to the front.
     /// </summary>
-    private List<(string Path, bool UseCreds)> ResolveAttempts(CmPollContext context)
+    private List<(string Path, bool UseCreds)> ResolveAttempts(CmPollContext context, bool fullMatrix)
     {
+        // Fast path: a known-good combo is cached and we're not forcing a re-probe. Return only
+        // that combo so a transient blip self-recovers on the next poll retry instead of probing
+        // (and logging a 401 or connection error for) every other path/credential combo. The
+        // poll loop forces the full matrix on its final retry, so a combo that has genuinely
+        // stopped working is still re-discovered.
+        if (!fullMatrix && context.Id > 0 && _attemptCache.TryGetValue(context.Id, out var cached))
+            return new List<(string Path, bool UseCreds)> { cached };
+
         var configured = string.IsNullOrWhiteSpace(context.StatusPagePath)
             ? DefaultStatusPath
             : context.StatusPagePath;

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -102,6 +102,17 @@ function fmtRate(bps) {
 
 const fmtCount = v => v == null ? '-' : Number(v).toLocaleString();
 
+// Cumulative byte counter boiled down to the largest sensible unit. Decimal (1000-based)
+// KB/MB/GB to match the decimal Kbps/Mbps/Gbps of fmtRate above.
+function fmtBytes(bytes) {
+    if (bytes == null) return '-';
+    if (bytes <= 0) return '0 B';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+    const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1000)), units.length - 1);
+    const v = bytes / Math.pow(1000, i);
+    return `${i === 0 ? v.toFixed(0) : v.toFixed(2)} ${units[i]}`;
+}
+
 // UniFi PortTable.SfpFound is authoritative; fall back to a name heuristic only
 // when the correlation hasn't populated isSfp (e.g. virtual interfaces).
 function portIsSfp(p) {
@@ -168,6 +179,8 @@ const COLUMNS = [
     { header: 'Client', format: v => v.html, sortable: false },
     { header: 'Rate In', format: fmtRate },
     { header: 'Rate Out', format: fmtRate },
+    { header: 'Bytes In', format: fmtBytes },
+    { header: 'Bytes Out', format: fmtBytes },
     { header: 'Unicast In', format: fmtCount },
     { header: 'Unicast Out', format: fmtCount },
     { header: 'Multicast In', format: fmtCount },
@@ -234,6 +247,7 @@ function buildRows() {
                     { html: portCell(p) },
                     { html: clientCell(p) },
                     p.rateInBps, p.rateOutBps,
+                    p.bytesIn, p.bytesOut,
                     p.ucastPktsIn, p.ucastPktsOut,
                     p.mcastPktsIn, p.mcastPktsOut,
                     p.bcastPktsIn, p.bcastPktsOut,


### PR DESCRIPTION
Two follow-on changes for the not-yet-tagged v1.22.0.

## Monitoring

### Live View

- **Bytes In/Out columns** - The per-port statistics table now shows cumulative bytes transferred in/out per port, next to the rate columns, formatted to the largest sensible decimal unit (KB/MB/GB) to match the Kbps/Mbps/Gbps rates. The counters were already captured; this surfaces them. Works in both live and historical playback.

### Cable Modem

- **More resilient Netgear fallback** - A modem whose working page/credential combination is already known now retries just that combination on a transient hiccup and self-recovers quietly, instead of probing every other combination on each poll. The full fallback sweep still runs when needed, so a combination that genuinely stops working is re-discovered.