### PR TITLE
ISP Health: align loaded latency/loss classification with WAN rate windows

### DIFF
--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -83,14 +83,15 @@ public class IspHealthOptions
     public int LoadWindowSeconds { get; set; } = 7;
 
     /// <summary>
-    /// SNMP interface rate samples are end-stamped and arrive after the ping probe that
-    /// saw the same load: a load onset shows up in latency about one counter interval
-    /// before it shows in the rate series. When classifying a latency/loss sample as idle
-    /// or loaded, the sample's timestamp is shifted forward by this amount so it aligns
-    /// with the (later) counter window that reflects the throughput it actually experienced.
-    /// Applied consistently to idle-baseline, loaded-latency, and loaded-loss classification.
+    /// Forward shift applied to a latency/loss sample's timestamp before matching it to a
+    /// WAN rate window, in case the SNMP rate series (end-stamped, derived from a counter
+    /// poll) lands a few seconds after the ping probe that saw the same load. Default 0:
+    /// the differing probe-burst and counter-poll cadences are both end-stamped, so their
+    /// late-bias largely cancels and the two series align without a shift. Raise it only if
+    /// load-onset latency spikes are landing in idle windows. Applied consistently to
+    /// idle-baseline, loaded-latency, and loaded-loss classification.
     /// </summary>
-    public int CounterLagOffsetSeconds { get; set; } = 4;
+    public int CounterLagOffsetSeconds { get; set; } = 0;
 
     /// <summary>
     /// How long a computed report stays fresh before the ISP Health tab recomputes it.

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -84,11 +84,13 @@ public class IspHealthOptions
 
     /// <summary>
     /// Forward shift applied to a latency/loss sample's timestamp before matching it to a
-    /// WAN rate window, in case the SNMP rate series (end-stamped, derived from a counter
-    /// poll) lands a few seconds after the ping probe that saw the same load. Default 0:
-    /// the differing probe-burst and counter-poll cadences are both end-stamped, so their
-    /// late-bias largely cancels and the two series align without a shift. Raise it only if
-    /// load-onset latency spikes are landing in idle windows. Applied consistently to
+    /// WAN rate window, to compensate if the SNMP rate series (end-stamped, derived from a
+    /// counter poll) lags the ping probe that saw the same load. Default 0: an offset sweep
+    /// over -7..+7 s on real GPON data showed 0 maximizes the down/up loaded-latency
+    /// separation. Both series are end-stamped so their cadence late-bias cancels; a positive
+    /// shift only smears upstream load into up-loaded windows (fabricating up bufferbloat and
+    /// inverting down-vs-up loss), while a negative shift drops real down signal. Raise only
+    /// if load-onset latency spikes start landing in idle windows. Applied consistently to
     /// idle-baseline, loaded-latency, and loaded-loss classification.
     /// </summary>
     public int CounterLagOffsetSeconds { get; set; } = 0;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -83,10 +83,12 @@ public class IspHealthOptions
     public int LoadWindowSeconds { get; set; } = 7;
 
     /// <summary>
-    /// SNMP interface counters lag behind real-time ping probes by several seconds.
-    /// When classifying a latency/loss sample as idle or loaded, the sample's timestamp
-    /// is shifted back by this amount so it aligns with the counter window that reflects
-    /// the actual throughput at the time the sample was taken.
+    /// SNMP interface rate samples are end-stamped and arrive after the ping probe that
+    /// saw the same load: a load onset shows up in latency about one counter interval
+    /// before it shows in the rate series. When classifying a latency/loss sample as idle
+    /// or loaded, the sample's timestamp is shifted forward by this amount so it aligns
+    /// with the (later) counter window that reflects the throughput it actually experienced.
+    /// Applied consistently to idle-baseline, loaded-latency, and loaded-loss classification.
     /// </summary>
     public int CounterLagOffsetSeconds { get; set; } = 4;
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -133,7 +133,10 @@ public class IspHealthScorer
     }
 
     /// <summary>Where the loaded latency evidence came from.</summary>
-    internal record LoadedDeltas(double? DownMs, double? UpMs, bool FromSpeedTests);
+    internal record LoadedDeltas(double? DownMs, double? UpMs, bool DownFromSpeedTest, bool UpFromSpeedTest)
+    {
+        public bool FromSpeedTests => DownFromSpeedTest || UpFromSpeedTest;
+    }
 
     /// <summary>
     /// Loaded latency deltas per direction. Passive evidence first: latency samples
@@ -153,7 +156,7 @@ public class IspHealthScorer
             up = LoadedLatencyDelta(inputs, loadWindows, w => w.IsLoadedUp);
         }
 
-        var fromSpeedTests = false;
+        bool downFromSpeedTest = false, upFromSpeedTest = false;
         if (down == null || up == null)
         {
             var (tests, _) = SelectSpeedTests(inputs);
@@ -168,15 +171,15 @@ public class IspHealthScorer
             if (down == null && downDeltas.Count > 0)
             {
                 down = SeriesStats.Median(downDeltas);
-                fromSpeedTests = true;
+                downFromSpeedTest = true;
             }
             if (up == null && upDeltas.Count > 0)
             {
                 up = SeriesStats.Median(upDeltas);
-                fromSpeedTests = true;
+                upFromSpeedTest = true;
             }
         }
-        return new LoadedDeltas(down, up, fromSpeedTests);
+        return new LoadedDeltas(down, up, downFromSpeedTest, upFromSpeedTest);
     }
 
     /// <summary>
@@ -424,7 +427,12 @@ public class IspHealthScorer
         var parts = new List<string>();
         if (deltas.DownMs.HasValue) parts.Add($"+{FormatLoadedDelta(deltas.DownMs.Value)} down");
         if (deltas.UpMs.HasValue) parts.Add($"+{FormatLoadedDelta(deltas.UpMs.Value)} up");
-        var source = deltas.FromSpeedTests ? " Measured by WAN speed tests." : "";
+        var valuedDirections = (deltas.DownMs.HasValue ? 1 : 0) + (deltas.UpMs.HasValue ? 1 : 0);
+        var speedTestDirections = (deltas.DownMs.HasValue && deltas.DownFromSpeedTest ? 1 : 0)
+            + (deltas.UpMs.HasValue && deltas.UpFromSpeedTest ? 1 : 0);
+        var source = speedTestDirections == 0 ? ""
+            : speedTestDirections == valuedDirections ? " Measured by WAN speed tests."
+            : " Partially determined by WAN speed tests.";
 
         return (new IspScoreFactor
         {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -189,8 +189,9 @@ public class IspHealthScorer
         var rtts = firstHop.Where(s => s.RttAvgMs.HasValue).ToList();
         if (rtts.Count == 0) return null;
 
+        var lagOffset = TimeSpan.FromSeconds(_options.CounterLagOffsetSeconds);
         var idleRtts = rtts
-            .Where(s => loadWindows.TryGetValue(FloorToWindow(s.Time), out var w) && w.IsIdle)
+            .Where(s => loadWindows.TryGetValue(FloorToWindow(s.Time + lagOffset), out var w) && w.IsIdle)
             .Select(s => s.RttAvgMs!.Value)
             .ToList();
         if (idleRtts.Count > 0) return SeriesStats.WinsorizedMean(idleRtts, _options.RttWinsorPercentile);
@@ -451,8 +452,10 @@ public class IspHealthScorer
     /// samples are baseline-subtracted and pooled; the median of the pool (filtered
     /// > 0.5 ms) is the result. Pooling raw samples instead of per-target aggregates
     /// is stable even with sparse loaded data (typical residential). Sample timestamps
-    /// are shifted back by the counter lag offset so they align with the interface
-    /// counter window that reflects actual throughput at probe time.
+    /// are shifted forward by the counter lag offset so they align with the interface
+    /// counter window, which is end-stamped and arrives after the probe that saw the
+    /// same load (a load onset shows in latency about one counter interval before it
+    /// shows in the rate series).
     /// </summary>
     private double? LoadedLatencyDelta(
         IspHealthInputs inputs,
@@ -474,7 +477,7 @@ public class IspHealthScorer
 
             var deltas = hop
                 .Where(s => s.RttAvgMs.HasValue
-                    && loadWindows.TryGetValue(FloorToWindow(s.Time - lagOffset), out var w)
+                    && loadWindows.TryGetValue(FloorToWindow(s.Time + lagOffset), out var w)
                     && directionSelector(w))
                 .Select(s => s.RttAvgMs!.Value - baseline.Value);
 
@@ -551,7 +554,7 @@ public class IspHealthScorer
         var lagOffset = TimeSpan.FromSeconds(_options.CounterLagOffsetSeconds);
         var losses = lossPool.SelectMany(series => series)
             .Where(s => s.LossPercent.HasValue && !InOutage(s.Time)
-                && loadWindows.TryGetValue(FloorToWindow(s.Time - lagOffset), out var w)
+                && loadWindows.TryGetValue(FloorToWindow(s.Time + lagOffset), out var w)
                 && directionSelector(w))
             .Select(s => s.LossPercent!.Value)
             .ToList();


### PR DESCRIPTION
Two related improvements to ISP Health loaded-latency/loss scoring.

## Loaded latency/loss alignment

Loaded latency, loaded loss, and the idle baseline they are measured against now align latency/loss probes to the WAN throughput windows with the same, consistent time offset, defaulting to **no shift** (`CounterLagOffsetSeconds = 0`).

- **Consistent, correct alignment.** All three classifiers (idle baseline, loaded latency, loaded loss) now apply `CounterLagOffsetSeconds` the same way when matching a probe to its WAN rate window. Previously loaded latency/loss shifted samples one direction while the idle baseline applied no offset at all, so a probe could be judged against a different load window than its own baseline.
- **Default offset is 0.** The WAN rate series (end-stamped from a counter poll) and the latency probes (end-stamped at burst completion) already line up, so no shift is needed by default. The previous default mis-binned samples around load transitions, which on a download-dominant line could pull spurious upstream "loaded latency" into the score and mis-order loaded loss. `CounterLagOffsetSeconds` remains a single tunable for sites where the rate series genuinely lags the probe.

## Loaded latency source label

The "Loaded Latency" factor backfills a direction from WAN speed tests when it lacks enough passive loaded samples. The description now reflects the source per direction:

- Both scored directions from speed tests: "Measured by WAN speed tests." (unchanged)
- Only one direction backfilled (the other is passive): "Partially determined by WAN speed tests."
- Neither: no source note.

No behavior change for idle scoring; loaded latency/loss become more accurate around load transitions, and the source label is now precise when only one direction relies on speed tests.
