### PR TITLE
v1.22.1 Release Changes

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1015,7 +1015,7 @@
                         <div class="form-group" style="flex: 2;">
                             <label class="form-label">Provider</label>
                             <select class="form-control" @bind="_editingCm.Provider">
-                                <option value="netgear">Netgear CM (HTTP)</option>
+                                <option value="netgear">Netgear / Nighthawk CM (HTTP)</option>
                                 <option value="arris-surfboard">ARRIS Surfboard (HTTP)</option>
                                 <option value="arris-surfboard-hnap">ARRIS Surfboard S33/S34 (HNAP)</option>
                                 <option value="motorola-hnap">Motorola MB8611, MB8600 (HNAP)</option>
@@ -4206,7 +4206,7 @@
 
     private static string GetCmProviderDisplayName(string provider) => provider switch
     {
-        "netgear" => "Netgear CM (HTTP)",
+        "netgear" => "Netgear / Nighthawk CM (HTTP)",
         "arris-surfboard" => "ARRIS Surfboard (HTTP)",
         "arris-surfboard-hnap" => "ARRIS Surfboard S33/S34 (HNAP)",
         "motorola-hnap" => "Motorola (HNAP)",

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
@@ -9,24 +9,32 @@ using NetworkOptimizer.Monitoring.Providers;
 namespace NetworkOptimizer.Web.Services.CableModemProviders;
 
 /// <summary>
-/// Cable modem provider for Netgear DOCSIS modems (CM600, CM700, CM1000, CM1200, etc.).
-/// Scrapes the DocsisStatus status page via HTTP Basic Auth and parses
-/// downstream/upstream channel tables using HtmlAgilityPack.
+/// Cable modem provider for Netgear DOCSIS modems. Scrapes the DocsisStatus status page and
+/// parses downstream/upstream channel tables. One provider auto-detects across the family so a
+/// user never has to know which page/auth their specific model uses. Confirmed against the
+/// CM600, CM1000 (.asp) and CM700, CM2050V (.htm); other models are reached by the same
+/// fallback without being individually verified.
 ///
-/// Netgear is inconsistent about the page extension: most models serve
-/// <c>DocsisStatus.asp</c> (e.g. CM600, CM1000) while some serve <c>DocsisStatus.htm</c>
-/// (e.g. CM700) and return 404 for the .asp path. Model number does not reliably
+/// Netgear is inconsistent about the page extension: some models serve
+/// <c>DocsisStatus.asp</c> (e.g. CM600, CM1000) while others serve <c>DocsisStatus.htm</c>
+/// (e.g. CM700, CM2050V) and return 404 for the .asp path. Model number does not reliably
 /// predict which (CM600 and CM700 are both DOCSIS 3.0 yet differ), so the provider tries
 /// the configured/default path and transparently falls back to the alternate extension.
 ///
-/// They also differ in how Basic auth is gated: the CM700 (server "NET-DK/1.0") only accepts
-/// the credentials once an anti-CSRF cookie it sets on the initial 401 is echoed back, so the
-/// first request primes the cookie jar and FetchPageAsync retries once to satisfy it.
+/// Auth also varies. Most models gate the page behind HTTP Basic auth (the CM700, server
+/// "NET-DK/1.0", additionally requires an anti-CSRF cookie it sets on the initial 401 to be
+/// echoed back - the first request primes the cookie jar and FetchPageAsync retries once to
+/// satisfy it). The CM2050V's .htm UI instead uses a form login: a GET to the root seeds an
+/// <c>XSRF_TOKEN</c> cookie, credentials are POSTed to <c>/goform/Login</c>, and the session is
+/// bound to the source IP. The fallback matrix tries Basic first (covers most models in one
+/// request) and form login last, remembering whichever works per config.
 ///
-/// The two pages also differ in how channel data is delivered: the .asp page renders the
+/// The pages also differ in how channel data is delivered: the .asp page renders the
 /// downstream/upstream tables server-side, while the .htm page ships empty tables and a
-/// JavaScript tagValueList that the browser expands client-side. The parser handles both -
-/// the server-rendered tables first, then the tagValueList for any table left empty.
+/// JavaScript tagValueList that the browser expands client-side. The parser handles both - the
+/// server-rendered tables first, then the tagValueList for any table left empty. The CM2050V's
+/// .htm page carries four such tables: SC-QAM + OFDM downstream and ATDMA + OFDMA upstream, each
+/// in its own Init function; all four are parsed.
 /// </summary>
 public sealed class NetgearCmProvider : ICableModemProvider
 {
@@ -34,9 +42,10 @@ public sealed class NetgearCmProvider : ICableModemProvider
     public string ProviderKey => "netgear";
 
     /// <inheritdoc/>
-    public string DisplayName => "Netgear CM (HTTP)";
+    public string DisplayName => "Netgear / Nighthawk CM (HTTP)";
 
     private const string DefaultStatusPath = "/DocsisStatus.asp";
+    private const string LoginPath = "/goform/Login";
     private const int TimeoutSeconds = 15;
     private const int MaxRetries = 3;
     private static readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(1);
@@ -61,14 +70,29 @@ public sealed class NetgearCmProvider : ICableModemProvider
     private static readonly Regex UsTagValueListRx =
         new(@"InitUsTableTagValue\s*\(\s*\)\s*\{.*?var\s+tagValueList\s*=\s*'([^']*)'",
             RegexOptions.Singleline | RegexOptions.Compiled);
+    // The CM2050V's .htm page carries two extra tables for the OFDM downstream and OFDMA
+    // upstream channels, each in its own Init function. Anchoring on the distinct function
+    // names keeps these separate from the SC-QAM/ATDMA tables above.
+    private static readonly Regex DsOfdmTagValueListRx =
+        new(@"InitDsOfdmTableTagValue\s*\(\s*\)\s*\{.*?var\s+tagValueList\s*=\s*'([^']*)'",
+            RegexOptions.Singleline | RegexOptions.Compiled);
+    private static readonly Regex UsOfdmaTagValueListRx =
+        new(@"InitUsOfdmaTableTagValue\s*\(\s*\)\s*\{.*?var\s+tagValueList\s*=\s*'([^']*)'",
+            RegexOptions.Singleline | RegexOptions.Compiled);
+
+    // The form-login page (.htm DOCSIS 3.1 models) bakes a per-load cache-buster id into its
+    // form action (e.g. action="/goform/Login?id=1248795675"); we reuse it when present.
+    private static readonly Regex LoginIdRx =
+        new(@"goform/Login\?id=(\d+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     private readonly ILogger<NetgearCmProvider> _logger;
 
     /// <summary>
-    /// Remembers the status-page path (.asp or .htm) that last succeeded per CmConfiguration.Id
-    /// so later polls go straight to it instead of re-probing the dead extension every interval.
+    /// Remembers the (status-page path, form-login) combination that last succeeded per
+    /// CmConfiguration.Id so later polls go straight to it instead of re-probing the dead
+    /// extension or wrong auth style every interval.
     /// </summary>
-    private readonly ConcurrentDictionary<int, string> _attemptCache = new();
+    private readonly ConcurrentDictionary<int, (string Path, bool FormLogin)> _attemptCache = new();
 
     public NetgearCmProvider(ILogger<NetgearCmProvider> logger)
     {
@@ -181,12 +205,14 @@ public sealed class NetgearCmProvider : ICableModemProvider
 
     /// <summary>
     /// Fetch the DOCSIS status page, transparently falling back across both Netgear page
-    /// extensions (.asp &lt;-&gt; .htm) since model number doesn't predict which a modem serves.
-    /// Credentials are sent when configured (Netgear gates the page behind HTTP Basic; the
-    /// CM700 additionally requires an anti-CSRF cookie, handled in FetchPageAsync). Any HTTP
-    /// status error or transport error advances to the next attempt; the last attempt's error
-    /// propagates, so a genuine auth failure (every attempt rejected) still surfaces. The
-    /// winning path is cached per config so later polls go straight to it.
+    /// extensions (.asp &lt;-&gt; .htm) AND auth styles (HTTP Basic, then a form login - POST to
+    /// /goform/Login - for models that bind the web session to the source IP, confirmed on the
+    /// CM2050V). Model number doesn't predict which combo a modem needs. A page is accepted only
+    /// when it actually looks like a status
+    /// page; a wrong combo that still returns HTTP 200 (e.g. a login/index page) advances to the
+    /// next attempt, as does any HTTP/transport error. The last attempt's error propagates, so a
+    /// genuine auth failure still surfaces. The winning combo is cached per config so later polls
+    /// go straight to it.
     /// </summary>
     private async Task<string?> FetchWithFallbackAsync(
         CmPollContext context,
@@ -194,56 +220,70 @@ public sealed class NetgearCmProvider : ICableModemProvider
         bool fullMatrix)
     {
         var attempts = ResolveAttempts(context, fullMatrix);
+        var hasCreds = !string.IsNullOrEmpty(context.Username) && !string.IsNullOrEmpty(context.Password);
 
         for (int i = 0; i < attempts.Count; i++)
         {
-            var (path, useCreds) = attempts[i];
+            var (path, formLogin) = attempts[i];
             var url = BuildUrl(context, path);
-            var user = useCreds ? context.Username : null;
-            var pass = useCreds ? context.Password : null;
+            var isLast = i == attempts.Count - 1;
             try
             {
-                var html = await FetchPageAsync(url, user, pass, cancellationToken);
-                if (context.Id > 0)
-                    _attemptCache[context.Id] = path;
-                return html;
+                var html = formLogin
+                    ? await FetchViaFormLoginAsync(url, context.Username, context.Password, cancellationToken)
+                    : await FetchPageAsync(url, hasCreds ? context.Username : null, hasCreds ? context.Password : null, cancellationToken);
+
+                // Accept only a real DocsisStatus page. A wrong extension or auth style can still
+                // return HTTP 200 with a login/index page (notably a Basic GET against a
+                // form-login model), which must not be cached as the winning combo.
+                if (IsStatusPage(html))
+                {
+                    if (context.Id > 0)
+                        _attemptCache[context.Id] = (path, formLogin);
+                    return html;
+                }
+
+                if (isLast)
+                    return html;
+
+                _logger.LogDebug(
+                    "Netgear CM {Name}: {Path} (form={Form}) returned a non-status page; trying next attempt",
+                    context.Name, path, formLogin);
             }
-            catch (HttpRequestException ex) when (i < attempts.Count - 1)
+            catch (HttpRequestException ex) when (!isLast)
             {
                 // Advance on any HTTP status error (404/403/5xx) or transport error (connection
                 // reset/closed, where StatusCode is null). Netgear firmware signals an
                 // unavailable path inconsistently - the wrong extension 404s on some models and
                 // closes the connection on others - so we don't gate on a specific code.
                 _logger.LogDebug(
-                    "Netgear CM {Name}: {Path} (creds={UseCreds}) failed ({Reason}); trying next attempt",
-                    context.Name, path, useCreds,
+                    "Netgear CM {Name}: {Path} (form={Form}) failed ({Reason}); trying next attempt",
+                    context.Name, path, formLogin,
                     ex.StatusCode is { } status ? $"HTTP {(int)status}" : ex.Message);
             }
         }
 
-        // Unreachable: the loop returns on the first success, and the last attempt's exception
-        // is not caught here (the when-guard requires a remaining attempt) so it propagates to
-        // PollAsync/TestConnectionAsync.
         return null;
     }
 
     /// <summary>
-    /// Build the ordered list of attempts: the configured/default path and the alternate Netgear
-    /// extension (.asp ↔ .htm), each carrying the configured credentials (or none, when the
-    /// config has no credentials). The path recorded as working for this config is moved to the
-    /// front.
+    /// Build the ordered list of (path, form-login) attempts: the configured/default path and the
+    /// alternate Netgear extension (.asp ↔ .htm) tried with HTTP Basic first (one request, covers
+    /// most models), then a form-login attempt on the .htm page for the newer models that need
+    /// it. Form login requires credentials to POST, so it's only added when the config has them.
+    /// The combo recorded as working for this config is moved to the front.
     /// </summary>
-    private List<(string Path, bool UseCreds)> ResolveAttempts(CmPollContext context, bool fullMatrix)
+    private List<(string Path, bool FormLogin)> ResolveAttempts(CmPollContext context, bool fullMatrix)
     {
         var hasCreds = !string.IsNullOrEmpty(context.Username) && !string.IsNullOrEmpty(context.Password);
 
-        // Fast path: a known-good path is cached and we're not forcing a re-probe. Return only
-        // that path so a transient blip self-recovers on the next poll retry instead of probing
-        // (and logging a 404 or connection error for) the wrong extension. The poll loop forces
-        // the full matrix on its final retry, so a path that has genuinely stopped working is
-        // still re-discovered.
-        if (!fullMatrix && context.Id > 0 && _attemptCache.TryGetValue(context.Id, out var cachedPath))
-            return new List<(string Path, bool UseCreds)> { (cachedPath, hasCreds) };
+        // Fast path: a known-good combo is cached and we're not forcing a re-probe. Return only
+        // that combo so a transient blip self-recovers on the next poll retry instead of probing
+        // (and logging a 404 or connection error for) the wrong extension/auth. The poll loop
+        // forces the full matrix on its final retry, so a combo that has genuinely stopped working
+        // is still re-discovered.
+        if (!fullMatrix && context.Id > 0 && _attemptCache.TryGetValue(context.Id, out var cached))
+            return new List<(string Path, bool FormLogin)> { cached };
 
         var configured = string.IsNullOrWhiteSpace(context.StatusPagePath)
             ? DefaultStatusPath
@@ -254,16 +294,21 @@ public sealed class NetgearCmProvider : ICableModemProvider
         if (alternate != null)
             paths.Add(alternate);
 
-        // Send credentials iff they're configured. Netgear CMs gate the DOCSIS status page
-        // behind HTTP Basic auth (the CM700 also wants an anti-CSRF cookie, primed in
-        // FetchPageAsync), so there's no "serves openly yet rejects creds" case to fall back to:
-        // a modem either needs the configured creds or has none. The page extension
-        // (.asp <-> .htm) is the only axis that actually varies, so it's the only one we probe.
-        var attempts = paths.Select(p => (Path: p, UseCreds: hasCreds)).ToList();
-
-        if (context.Id > 0 && _attemptCache.TryGetValue(context.Id, out var lastGoodPath))
+        // Basic-auth attempts first (the CM700 also wants an anti-CSRF cookie, primed in
+        // FetchPageAsync). Then a single form-login attempt on the .htm page for models that gate
+        // it behind a /goform/Login session (confirmed on the CM2050V). Form login needs
+        // credentials to POST, so it's only added when the config has them.
+        var attempts = paths.Select(p => (Path: p, FormLogin: false)).ToList();
+        if (hasCreds)
         {
-            var idx = attempts.FindIndex(a => a.Path == lastGoodPath);
+            var htmPath = paths.FirstOrDefault(p => p.EndsWith("DocsisStatus.htm", StringComparison.OrdinalIgnoreCase));
+            if (htmPath != null)
+                attempts.Add((htmPath, true));
+        }
+
+        if (context.Id > 0 && _attemptCache.TryGetValue(context.Id, out var lastGood))
+        {
+            var idx = attempts.FindIndex(a => a.Path == lastGood.Path && a.FormLogin == lastGood.FormLogin);
             if (idx > 0)
             {
                 var item = attempts[idx];
@@ -287,6 +332,87 @@ public sealed class NetgearCmProvider : ICableModemProvider
         if (path.EndsWith("DocsisStatus.htm", StringComparison.OrdinalIgnoreCase))
             return string.Concat(path.AsSpan(0, path.Length - 4), ".asp");
         return null;
+    }
+
+    /// <summary>
+    /// True when a fetched page is a DocsisStatus page - either the server-rendered ds/us tables
+    /// (.asp) or the client-side tagValueList Init functions (.htm) - rather than a login/index
+    /// page returned when the wrong extension or auth style is tried. Both forms contain the
+    /// "dsTable"/"usTable" token (as an element id, or inside InitDsTableTagValue/InitUsTableTagValue),
+    /// which a login page does not.
+    /// </summary>
+    private static bool IsStatusPage(string? html) =>
+        !string.IsNullOrEmpty(html)
+        && (html.Contains("dsTable", StringComparison.OrdinalIgnoreCase)
+            || html.Contains("usTable", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Fetch the status page via the form login observed on the CM2050V's .htm UI: GET the root
+    /// to seed the <c>XSRF_TOKEN</c> cookie and reuse the form action's cache-buster id, POST the
+    /// credentials to <c>/goform/Login</c>, then GET the status page on the same cookie jar. The
+    /// modem binds the session to the source IP, so a single HttpClient/CookieContainer carries
+    /// it across the three requests.
+    /// </summary>
+    private async Task<string?> FetchViaFormLoginAsync(
+        string statusUrl,
+        string? username,
+        string? password,
+        CancellationToken cancellationToken)
+    {
+        var baseUrl = new Uri(statusUrl).GetLeftPart(UriPartial.Authority);
+
+        using var handler = new HttpClientHandler
+        {
+            AutomaticDecompression = System.Net.DecompressionMethods.GZip | System.Net.DecompressionMethods.Deflate,
+            CookieContainer = new System.Net.CookieContainer(),
+            UseCookies = true,
+            AllowAutoRedirect = true,
+        };
+        using var client = new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromSeconds(TimeoutSeconds),
+        };
+
+        // Prime the XSRF_TOKEN cookie and reuse the form's cache-buster id. Non-fatal on failure -
+        // we fall back to a generated id and rely on the cookie the POST itself would set.
+        string? loginId = null;
+        try
+        {
+            using var loginPage = await client.GetAsync($"{baseUrl}/", cancellationToken);
+            if (loginPage.IsSuccessStatusCode)
+            {
+                var loginHtml = await loginPage.Content.ReadAsStringAsync(cancellationToken);
+                var idMatch = LoginIdRx.Match(loginHtml);
+                if (idMatch.Success)
+                    loginId = idMatch.Groups[1].Value;
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug(ex, "Netgear CM form login: could not pre-fetch login page at {BaseUrl}", baseUrl);
+        }
+
+        loginId ??= Random.Shared.Next(100_000_000, 999_999_999).ToString();
+
+        var loginContent = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("loginName", username ?? "admin"),
+            new KeyValuePair<string, string>("loginPassword", password ?? ""),
+        });
+
+        using (var loginResponse = await client.PostAsync($"{baseUrl}{LoginPath}?id={loginId}", loginContent, cancellationToken))
+        {
+            // Surface transport/HTTP errors (4xx/5xx) so the caller advances to the next combo.
+            // Wrong credentials usually 200 back to the login page rather than erroring, so that
+            // case isn't decided here - the status GET below plus the caller's IsStatusPage check
+            // reject it.
+            loginResponse.EnsureSuccessStatusCode();
+        }
+
+        using var response = await client.GetAsync(statusUrl, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        return string.IsNullOrWhiteSpace(content) ? null : content;
     }
 
     private async Task<string?> FetchPageAsync(
@@ -571,15 +697,58 @@ public sealed class NetgearCmProvider : ICableModemProvider
                 }
             }
         }
+
+        // The CM2050V's .htm page carries two further tables - OFDM downstream and OFDMA upstream -
+        // in their own Init functions. These are separate channels, so they're always appended
+        // (a modem with these has its SC-QAM/ATDMA channels populated above already).
+        var dsOfdm = DsOfdmTagValueListRx.Match(html);
+        if (dsOfdm.Success)
+        {
+            // Per channel: Channel, Lock Status, Profile IDs, Channel ID, Frequency, Power, SNR/MER,
+            // Active Subcarrier Range, Unerrored, Correctable, Uncorrectable codewords. The OFDM
+            // codeword counts run to the billions and would swamp the SC-QAM correctable/
+            // uncorrectable totals, so they are intentionally left out of the aggregates.
+            foreach (var f in ChunkTagValues(dsOfdm.Groups[1].Value, minPerChannel: 7))
+            {
+                stats.DownstreamChannels.Add(new DsChannel
+                {
+                    LockStatus = f[1],
+                    Modulation = "OFDM",
+                    ChannelId = ParseInt(f[3]),
+                    Frequency = ParseFrequency(f[4]),
+                    Power = ParseDouble(f[5]),
+                    Snr = ParseDouble(f[6]),
+                });
+            }
+        }
+
+        var usOfdma = UsOfdmaTagValueListRx.Match(html);
+        if (usOfdma.Success)
+        {
+            // Per channel: Channel, Lock Status, Profile IDs, Channel ID, Frequency, Power. OFDMA
+            // has no fixed symbol rate.
+            foreach (var f in ChunkTagValues(usOfdma.Groups[1].Value, minPerChannel: 6))
+            {
+                stats.UpstreamChannels.Add(new UsChannel
+                {
+                    LockStatus = f[1],
+                    ChannelType = "OFDMA",
+                    ChannelId = ParseInt(f[3]),
+                    Frequency = ParseFrequency(f[4]),
+                    Power = ParseDouble(f[5]),
+                });
+            }
+        }
     }
 
     /// <summary>
     /// Split a Netgear tagValueList - a leading channel count followed by pipe-delimited
     /// per-channel fields - into one field list per channel. A trailing pipe leaves an empty
     /// token that is ignored. Returns nothing if the count is missing/invalid or the fields
-    /// don't divide into per-channel groups of at least the seven shared columns.
+    /// don't divide into per-channel groups of at least <paramref name="minPerChannel"/> columns
+    /// (7 for the SC-QAM/ATDMA tables, fewer for the OFDMA upstream table).
     /// </summary>
-    private static IEnumerable<List<string>> ChunkTagValues(string tagValueList)
+    private static IEnumerable<List<string>> ChunkTagValues(string tagValueList, int minPerChannel = 7)
     {
         var tokens = tagValueList.Split('|');
         if (tokens.Length < 2 || !int.TryParse(tokens[0].Trim(), out var count) || count <= 0)
@@ -590,7 +759,7 @@ public sealed class NetgearCmProvider : ICableModemProvider
             fields.RemoveAt(fields.Count - 1);
 
         var perChannel = fields.Count / count;
-        if (perChannel < 7)
+        if (perChannel < minPerChannel)
             yield break;
 
         for (int c = 0; c < count; c++)

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
@@ -15,9 +15,13 @@ namespace NetworkOptimizer.Web.Services.CableModemProviders;
 ///
 /// Netgear is inconsistent about the page extension: most models serve
 /// <c>DocsisStatus.asp</c> (e.g. CM600, CM1000) while some serve <c>DocsisStatus.htm</c>
-/// (e.g. CM700) and return 401/404 for the .asp path. Model number does not reliably
+/// (e.g. CM700) and return 404 for the .asp path. Model number does not reliably
 /// predict which (CM600 and CM700 are both DOCSIS 3.0 yet differ), so the provider tries
 /// the configured/default path and transparently falls back to the alternate extension.
+///
+/// They also differ in how Basic auth is gated: the CM700 (server "NET-DK/1.0") only accepts
+/// the credentials once an anti-CSRF cookie it sets on the initial 401 is echoed back, so the
+/// first request primes the cookie jar and FetchPageAsync retries once to satisfy it.
 ///
 /// The two pages also differ in how channel data is delivered: the .asp page renders the
 /// downstream/upstream tables server-side, while the .htm page ships empty tables and a
@@ -61,11 +65,10 @@ public sealed class NetgearCmProvider : ICableModemProvider
     private readonly ILogger<NetgearCmProvider> _logger;
 
     /// <summary>
-    /// Remembers the (status-page path, send-credentials) combination that last succeeded per
-    /// CmConfiguration.Id so later polls go straight to it instead of re-probing the dead
-    /// extension or wrong auth mode every interval.
+    /// Remembers the status-page path (.asp or .htm) that last succeeded per CmConfiguration.Id
+    /// so later polls go straight to it instead of re-probing the dead extension every interval.
     /// </summary>
-    private readonly ConcurrentDictionary<int, (string Path, bool UseCreds)> _attemptCache = new();
+    private readonly ConcurrentDictionary<int, string> _attemptCache = new();
 
     public NetgearCmProvider(ILogger<NetgearCmProvider> logger)
     {
@@ -178,13 +181,12 @@ public sealed class NetgearCmProvider : ICableModemProvider
 
     /// <summary>
     /// Fetch the DOCSIS status page, transparently falling back across both Netgear page
-    /// extensions AND whether credentials are sent. Tries the configured/default path with
-    /// credentials first (modems like the CM600 gate the page behind HTTP Basic), then the
-    /// alternate extension, then the same paths WITHOUT credentials - some modems (e.g. CM700)
-    /// serve the page openly and 401 a request that presents unexpected credentials. Any HTTP
+    /// extensions (.asp &lt;-&gt; .htm) since model number doesn't predict which a modem serves.
+    /// Credentials are sent when configured (Netgear gates the page behind HTTP Basic; the
+    /// CM700 additionally requires an anti-CSRF cookie, handled in FetchPageAsync). Any HTTP
     /// status error or transport error advances to the next attempt; the last attempt's error
     /// propagates, so a genuine auth failure (every attempt rejected) still surfaces. The
-    /// winning combination is cached per config so later polls go straight to it.
+    /// winning path is cached per config so later polls go straight to it.
     /// </summary>
     private async Task<string?> FetchWithFallbackAsync(
         CmPollContext context,
@@ -203,16 +205,15 @@ public sealed class NetgearCmProvider : ICableModemProvider
             {
                 var html = await FetchPageAsync(url, user, pass, cancellationToken);
                 if (context.Id > 0)
-                    _attemptCache[context.Id] = (path, useCreds);
+                    _attemptCache[context.Id] = path;
                 return html;
             }
             catch (HttpRequestException ex) when (i < attempts.Count - 1)
             {
-                // Advance on any HTTP status error (401/403/404/5xx) or transport error
-                // (connection reset/closed, where StatusCode is null). Netgear firmware
-                // signals an unavailable path or unwanted credentials inconsistently - the
-                // CM700 returned 401, other models close the connection - so we don't gate on
-                // a specific code.
+                // Advance on any HTTP status error (404/403/5xx) or transport error (connection
+                // reset/closed, where StatusCode is null). Netgear firmware signals an
+                // unavailable path inconsistently - the wrong extension 404s on some models and
+                // closes the connection on others - so we don't gate on a specific code.
                 _logger.LogDebug(
                     "Netgear CM {Name}: {Path} (creds={UseCreds}) failed ({Reason}); trying next attempt",
                     context.Name, path, useCreds,
@@ -227,20 +228,22 @@ public sealed class NetgearCmProvider : ICableModemProvider
     }
 
     /// <summary>
-    /// Build the ordered list of (path, send-credentials) attempts: the configured/default
-    /// path and the alternate Netgear extension (.asp ↔ .htm), each tried with credentials
-    /// first (when configured) and then without. The attempt recorded as working for this
-    /// config is moved to the front.
+    /// Build the ordered list of attempts: the configured/default path and the alternate Netgear
+    /// extension (.asp ↔ .htm), each carrying the configured credentials (or none, when the
+    /// config has no credentials). The path recorded as working for this config is moved to the
+    /// front.
     /// </summary>
     private List<(string Path, bool UseCreds)> ResolveAttempts(CmPollContext context, bool fullMatrix)
     {
-        // Fast path: a known-good combo is cached and we're not forcing a re-probe. Return only
-        // that combo so a transient blip self-recovers on the next poll retry instead of probing
-        // (and logging a 401 or connection error for) every other path/credential combo. The
-        // poll loop forces the full matrix on its final retry, so a combo that has genuinely
-        // stopped working is still re-discovered.
-        if (!fullMatrix && context.Id > 0 && _attemptCache.TryGetValue(context.Id, out var cached))
-            return new List<(string Path, bool UseCreds)> { cached };
+        var hasCreds = !string.IsNullOrEmpty(context.Username) && !string.IsNullOrEmpty(context.Password);
+
+        // Fast path: a known-good path is cached and we're not forcing a re-probe. Return only
+        // that path so a transient blip self-recovers on the next poll retry instead of probing
+        // (and logging a 404 or connection error for) the wrong extension. The poll loop forces
+        // the full matrix on its final retry, so a path that has genuinely stopped working is
+        // still re-discovered.
+        if (!fullMatrix && context.Id > 0 && _attemptCache.TryGetValue(context.Id, out var cachedPath))
+            return new List<(string Path, bool UseCreds)> { (cachedPath, hasCreds) };
 
         var configured = string.IsNullOrWhiteSpace(context.StatusPagePath)
             ? DefaultStatusPath
@@ -251,22 +254,21 @@ public sealed class NetgearCmProvider : ICableModemProvider
         if (alternate != null)
             paths.Add(alternate);
 
-        var hasCreds = !string.IsNullOrEmpty(context.Username) && !string.IsNullOrEmpty(context.Password);
+        // Send credentials iff they're configured. Netgear CMs gate the DOCSIS status page
+        // behind HTTP Basic auth (the CM700 also wants an anti-CSRF cookie, primed in
+        // FetchPageAsync), so there's no "serves openly yet rejects creds" case to fall back to:
+        // a modem either needs the configured creds or has none. The page extension
+        // (.asp <-> .htm) is the only axis that actually varies, so it's the only one we probe.
+        var attempts = paths.Select(p => (Path: p, UseCreds: hasCreds)).ToList();
 
-        var attempts = new List<(string Path, bool UseCreds)>();
-        // Credentialed attempts first - required by modems that gate the page behind Basic auth.
-        if (hasCreds)
-            attempts.AddRange(paths.Select(p => (p, true)));
-        // Then anonymous attempts - for modems that serve openly and reject unexpected creds.
-        attempts.AddRange(paths.Select(p => (p, false)));
-
-        if (context.Id > 0 && _attemptCache.TryGetValue(context.Id, out var lastGood))
+        if (context.Id > 0 && _attemptCache.TryGetValue(context.Id, out var lastGoodPath))
         {
-            var idx = attempts.FindIndex(a => a.Path == lastGood.Path && a.UseCreds == lastGood.UseCreds);
+            var idx = attempts.FindIndex(a => a.Path == lastGoodPath);
             if (idx > 0)
             {
+                var item = attempts[idx];
                 attempts.RemoveAt(idx);
-                attempts.Insert(0, lastGood);
+                attempts.Insert(0, item);
             }
         }
 
@@ -317,6 +319,22 @@ public sealed class NetgearCmProvider : ICableModemProvider
         }
 
         var response = await GetFollowingRedirectsAsync(client, url, cancellationToken);
+
+        // Some Netgear modems (e.g. CM700, server "NET-DK/1.0") gate the status page behind HTTP
+        // Basic auth AND an anti-CSRF cookie: the first request is answered with 401 plus
+        // Set-Cookie: XSRF_TOKEN=..., and the Basic credentials are only accepted once that
+        // cookie is echoed back. The first request primes the cookie jar (the CookieContainer
+        // stores the cookie even on a 401), so retry once - the replayed XSRF_TOKEN now rides
+        // along with the preemptive Basic header and the modem returns 200. Modems that don't
+        // need this (e.g. CM600, which 200s/302s on the first request) never enter the retry.
+        if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized
+            && !string.IsNullOrEmpty(username)
+            && handler.CookieContainer.GetCookies(new Uri(url)).Count > 0)
+        {
+            response.Dispose();
+            response = await GetFollowingRedirectsAsync(client, url, cancellationToken);
+        }
+
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -83,17 +83,24 @@ public class IspHealthOptions
     public int LoadWindowSeconds { get; set; } = 7;
 
     /// <summary>
-    /// Forward shift applied to a latency/loss sample's timestamp before matching it to a
-    /// WAN rate window, to compensate if the SNMP rate series (end-stamped, derived from a
-    /// counter poll) lags the ping probe that saw the same load. Default 0: an offset sweep
-    /// over -7..+7 s on real GPON data showed 0 maximizes the down/up loaded-latency
-    /// separation. Both series are end-stamped so their cadence late-bias cancels; a positive
-    /// shift only smears upstream load into up-loaded windows (fabricating up bufferbloat and
-    /// inverting down-vs-up loss), while a negative shift drops real down signal. Raise only
-    /// if load-onset latency spikes start landing in idle windows. Applied consistently to
-    /// idle-baseline, loaded-latency, and loaded-loss classification.
+    /// Seconds the loaded-window leading edge is extended backward when matching loaded latency
+    /// and loaded loss samples. A load event has a ramp (queue fills before throughput crosses the
+    /// loaded threshold) whose early latency/loss falls in transition windows that are neither idle
+    /// nor loaded and would otherwise be dropped. Dilating the leading edge reclaims it. Bucket-
+    /// quantized to <see cref="LoadWindowSeconds"/>, so ~5 s extends by one window.
     /// </summary>
-    public int CounterLagOffsetSeconds { get; set; } = 0;
+    public int LoadedLeadSeconds { get; set; } = 5;
+
+    /// <summary>
+    /// Seconds the loaded-window trailing edge is extended forward when matching loaded latency and
+    /// loaded loss samples. Loss especially concentrates at the saturation tail / buffer drain and is
+    /// end-stamped at probe-burst completion, so it lands a few seconds after the WAN rate window that
+    /// defines the load (observed ~5 s after a GPON speed test's download phase ended). Dilation
+    /// captures it without the leading-edge loss a fixed back-shift causes. Dilation never crosses into
+    /// an opposite-direction loaded run, so a speed test's download tail cannot bleed into its upload
+    /// phase. Bucket-quantized to <see cref="LoadWindowSeconds"/>.
+    /// </summary>
+    public int LoadedTailSeconds { get; set; } = 5;
 
     /// <summary>
     /// How long a computed report stays fresh before the ISP Health tab recomputes it.

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -83,12 +83,17 @@ public class IspHealthOptions
     public int LoadWindowSeconds { get; set; } = 7;
 
     /// <summary>
-    /// SNMP interface counters lag behind real-time ping probes by several seconds.
-    /// When classifying a latency/loss sample as idle or loaded, the sample's timestamp
-    /// is shifted back by this amount so it aligns with the counter window that reflects
-    /// the actual throughput at the time the sample was taken.
+    /// Forward shift applied to a latency/loss sample's timestamp before matching it to a
+    /// WAN rate window, to compensate if the SNMP rate series (end-stamped, derived from a
+    /// counter poll) lags the ping probe that saw the same load. Default 0: an offset sweep
+    /// over -7..+7 s on real GPON data showed 0 maximizes the down/up loaded-latency
+    /// separation. Both series are end-stamped so their cadence late-bias cancels; a positive
+    /// shift only smears upstream load into up-loaded windows (fabricating up bufferbloat and
+    /// inverting down-vs-up loss), while a negative shift drops real down signal. Raise only
+    /// if load-onset latency spikes start landing in idle windows. Applied consistently to
+    /// idle-baseline, loaded-latency, and loaded-loss classification.
     /// </summary>
-    public int CounterLagOffsetSeconds { get; set; } = 4;
+    public int CounterLagOffsetSeconds { get; set; } = 0;
 
     /// <summary>
     /// How long a computed report stays fresh before the ISP Health tab recomputes it.

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -133,7 +133,10 @@ public class IspHealthScorer
     }
 
     /// <summary>Where the loaded latency evidence came from.</summary>
-    internal record LoadedDeltas(double? DownMs, double? UpMs, bool FromSpeedTests);
+    internal record LoadedDeltas(double? DownMs, double? UpMs, bool DownFromSpeedTest, bool UpFromSpeedTest)
+    {
+        public bool FromSpeedTests => DownFromSpeedTest || UpFromSpeedTest;
+    }
 
     /// <summary>
     /// Loaded latency deltas per direction. Passive evidence first: latency samples
@@ -153,7 +156,7 @@ public class IspHealthScorer
             up = LoadedLatencyDelta(inputs, loadWindows, w => w.IsLoadedUp);
         }
 
-        var fromSpeedTests = false;
+        bool downFromSpeedTest = false, upFromSpeedTest = false;
         if (down == null || up == null)
         {
             var (tests, _) = SelectSpeedTests(inputs);
@@ -168,15 +171,15 @@ public class IspHealthScorer
             if (down == null && downDeltas.Count > 0)
             {
                 down = SeriesStats.Median(downDeltas);
-                fromSpeedTests = true;
+                downFromSpeedTest = true;
             }
             if (up == null && upDeltas.Count > 0)
             {
                 up = SeriesStats.Median(upDeltas);
-                fromSpeedTests = true;
+                upFromSpeedTest = true;
             }
         }
-        return new LoadedDeltas(down, up, fromSpeedTests);
+        return new LoadedDeltas(down, up, downFromSpeedTest, upFromSpeedTest);
     }
 
     /// <summary>
@@ -189,8 +192,9 @@ public class IspHealthScorer
         var rtts = firstHop.Where(s => s.RttAvgMs.HasValue).ToList();
         if (rtts.Count == 0) return null;
 
+        var lagOffset = TimeSpan.FromSeconds(_options.CounterLagOffsetSeconds);
         var idleRtts = rtts
-            .Where(s => loadWindows.TryGetValue(FloorToWindow(s.Time), out var w) && w.IsIdle)
+            .Where(s => loadWindows.TryGetValue(FloorToWindow(s.Time + lagOffset), out var w) && w.IsIdle)
             .Select(s => s.RttAvgMs!.Value)
             .ToList();
         if (idleRtts.Count > 0) return SeriesStats.WinsorizedMean(idleRtts, _options.RttWinsorPercentile);
@@ -423,7 +427,12 @@ public class IspHealthScorer
         var parts = new List<string>();
         if (deltas.DownMs.HasValue) parts.Add($"+{FormatLoadedDelta(deltas.DownMs.Value)} down");
         if (deltas.UpMs.HasValue) parts.Add($"+{FormatLoadedDelta(deltas.UpMs.Value)} up");
-        var source = deltas.FromSpeedTests ? " Measured by WAN speed tests." : "";
+        var valuedDirections = (deltas.DownMs.HasValue ? 1 : 0) + (deltas.UpMs.HasValue ? 1 : 0);
+        var speedTestDirections = (deltas.DownMs.HasValue && deltas.DownFromSpeedTest ? 1 : 0)
+            + (deltas.UpMs.HasValue && deltas.UpFromSpeedTest ? 1 : 0);
+        var source = speedTestDirections == 0 ? ""
+            : speedTestDirections == valuedDirections ? " Measured by WAN speed tests."
+            : " Partially determined by WAN speed tests.";
 
         return (new IspScoreFactor
         {
@@ -451,8 +460,10 @@ public class IspHealthScorer
     /// samples are baseline-subtracted and pooled; the median of the pool (filtered
     /// > 0.5 ms) is the result. Pooling raw samples instead of per-target aggregates
     /// is stable even with sparse loaded data (typical residential). Sample timestamps
-    /// are shifted back by the counter lag offset so they align with the interface
-    /// counter window that reflects actual throughput at probe time.
+    /// are shifted forward by the counter lag offset so they align with the interface
+    /// counter window, which is end-stamped and arrives after the probe that saw the
+    /// same load (a load onset shows in latency about one counter interval before it
+    /// shows in the rate series).
     /// </summary>
     private double? LoadedLatencyDelta(
         IspHealthInputs inputs,
@@ -474,7 +485,7 @@ public class IspHealthScorer
 
             var deltas = hop
                 .Where(s => s.RttAvgMs.HasValue
-                    && loadWindows.TryGetValue(FloorToWindow(s.Time - lagOffset), out var w)
+                    && loadWindows.TryGetValue(FloorToWindow(s.Time + lagOffset), out var w)
                     && directionSelector(w))
                 .Select(s => s.RttAvgMs!.Value - baseline.Value);
 
@@ -551,7 +562,7 @@ public class IspHealthScorer
         var lagOffset = TimeSpan.FromSeconds(_options.CounterLagOffsetSeconds);
         var losses = lossPool.SelectMany(series => series)
             .Where(s => s.LossPercent.HasValue && !InOutage(s.Time)
-                && loadWindows.TryGetValue(FloorToWindow(s.Time - lagOffset), out var w)
+                && loadWindows.TryGetValue(FloorToWindow(s.Time + lagOffset), out var w)
                 && directionSelector(w))
             .Select(s => s.LossPercent!.Value)
             .ToList();

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -152,8 +152,8 @@ public class IspHealthScorer
         double? down = null, up = null;
         if (loadWindows.Count > 0)
         {
-            down = LoadedLatencyDelta(inputs, loadWindows, w => w.IsLoadedDown);
-            up = LoadedLatencyDelta(inputs, loadWindows, w => w.IsLoadedUp);
+            down = LoadedLatencyDelta(inputs, loadWindows, w => w.IsLoadedDown, w => w.IsLoadedUp);
+            up = LoadedLatencyDelta(inputs, loadWindows, w => w.IsLoadedUp, w => w.IsLoadedDown);
         }
 
         bool downFromSpeedTest = false, upFromSpeedTest = false;
@@ -192,9 +192,8 @@ public class IspHealthScorer
         var rtts = firstHop.Where(s => s.RttAvgMs.HasValue).ToList();
         if (rtts.Count == 0) return null;
 
-        var lagOffset = TimeSpan.FromSeconds(_options.CounterLagOffsetSeconds);
         var idleRtts = rtts
-            .Where(s => loadWindows.TryGetValue(FloorToWindow(s.Time + lagOffset), out var w) && w.IsIdle)
+            .Where(s => loadWindows.TryGetValue(FloorToWindow(s.Time), out var w) && w.IsIdle)
             .Select(s => s.RttAvgMs!.Value)
             .ToList();
         if (idleRtts.Count > 0) return SeriesStats.WinsorizedMean(idleRtts, _options.RttWinsorPercentile);
@@ -423,10 +422,13 @@ public class IspHealthScorer
         }
 
         // A negative delta means latency did not rise under load (noise/faster); show
-        // it as +0 ms rather than a confusing "+-0.1".
-        var parts = new List<string>();
-        if (deltas.DownMs.HasValue) parts.Add($"+{FormatLoadedDelta(deltas.DownMs.Value)} down");
-        if (deltas.UpMs.HasValue) parts.Add($"+{FormatLoadedDelta(deltas.UpMs.Value)} up");
+        // it as +0 ms rather than a confusing "+-0.1". Always show both directions; a
+        // direction with no loaded samples reads "n/a" (distinct from a measured +0 ms).
+        var parts = new List<string>
+        {
+            deltas.DownMs.HasValue ? $"+{FormatLoadedDelta(deltas.DownMs.Value)} down" : "n/a down",
+            deltas.UpMs.HasValue ? $"+{FormatLoadedDelta(deltas.UpMs.Value)} up" : "n/a up"
+        };
         var valuedDirections = (deltas.DownMs.HasValue ? 1 : 0) + (deltas.UpMs.HasValue ? 1 : 0);
         var speedTestDirections = (deltas.DownMs.HasValue && deltas.DownFromSpeedTest ? 1 : 0)
             + (deltas.UpMs.HasValue && deltas.UpFromSpeedTest ? 1 : 0);
@@ -455,23 +457,22 @@ public class IspHealthScorer
     }
 
     /// <summary>
-    /// <summary>
     /// Loaded-latency delta from ISP access hops only. Each access hop's loaded RTT
     /// samples are baseline-subtracted and pooled; the median of the pool (filtered
     /// > 0.5 ms) is the result. Pooling raw samples instead of per-target aggregates
-    /// is stable even with sparse loaded data (typical residential). Sample timestamps
-    /// are shifted forward by the counter lag offset so they align with the interface
-    /// counter window, which is end-stamped and arrives after the probe that saw the
-    /// same load (a load onset shows in latency about one counter interval before it
-    /// shows in the rate series).
+    /// is stable even with sparse loaded data (typical residential). Loaded windows are
+    /// dilated (see <see cref="DilateLoadedWindows"/>) so the ramp-in rise and drain tail of
+    /// an event - which fall in transition windows outside the strict rate threshold - are
+    /// captured rather than dropped.
     /// </summary>
     private double? LoadedLatencyDelta(
         IspHealthInputs inputs,
         Dictionary<DateTime, LoadWindow> loadWindows,
-        Func<LoadWindow, bool> directionSelector)
+        Func<LoadWindow, bool> directionSelector,
+        Func<LoadWindow, bool> oppositeSelector)
     {
         const double noiseFloor = 0.5;
-        var lagOffset = TimeSpan.FromSeconds(_options.CounterLagOffsetSeconds);
+        var loaded = DilateLoadedWindows(loadWindows, directionSelector, oppositeSelector);
 
         var accessCohort = inputs.AccessHopSeries.Count > 0
             ? inputs.AccessHopSeries
@@ -484,9 +485,7 @@ public class IspHealthScorer
             if (baseline == null) continue;
 
             var deltas = hop
-                .Where(s => s.RttAvgMs.HasValue
-                    && loadWindows.TryGetValue(FloorToWindow(s.Time + lagOffset), out var w)
-                    && directionSelector(w))
+                .Where(s => s.RttAvgMs.HasValue && loaded.Contains(FloorToWindow(s.Time)))
                 .Select(s => s.RttAvgMs!.Value - baseline.Value);
 
             pooledDeltas.AddRange(deltas);
@@ -512,8 +511,8 @@ public class IspHealthScorer
             }, false);
         }
 
-        var downLoss = LoadedMeanLoss(lossPool, loadWindows, w => w.IsLoadedDown);
-        var upLoss = LoadedMeanLoss(lossPool, loadWindows, w => w.IsLoadedUp);
+        var downLoss = LoadedMeanLoss(lossPool, loadWindows, w => w.IsLoadedDown, w => w.IsLoadedUp);
+        var upLoss = LoadedMeanLoss(lossPool, loadWindows, w => w.IsLoadedUp, w => w.IsLoadedDown);
 
         var scores = new List<double>();
         if (downLoss.HasValue) scores.Add(ScoreLossBand(downLoss.Value, profile.LoadedLossDownLowPct, profile.LoadedLossDownHighPct));
@@ -528,9 +527,13 @@ public class IspHealthScorer
             }, false);
         }
 
-        var parts = new List<string>();
-        if (downLoss.HasValue) parts.Add($"{FormatPct(downLoss.Value)} down");
-        if (upLoss.HasValue) parts.Add($"{FormatPct(upLoss.Value)} up");
+        // Always show both directions; a direction with no loaded samples reads "n/a"
+        // (distinct from a measured 0%).
+        var parts = new List<string>
+        {
+            downLoss.HasValue ? $"{FormatPct(downLoss.Value)} down" : "n/a down",
+            upLoss.HasValue ? $"{FormatPct(upLoss.Value)} up" : "n/a up"
+        };
 
         return (new IspScoreFactor
         {
@@ -557,17 +560,56 @@ public class IspHealthScorer
     private double? LoadedMeanLoss(
         List<List<LatencySample>> lossPool,
         Dictionary<DateTime, LoadWindow> loadWindows,
-        Func<LoadWindow, bool> directionSelector)
+        Func<LoadWindow, bool> directionSelector,
+        Func<LoadWindow, bool> oppositeSelector)
     {
-        var lagOffset = TimeSpan.FromSeconds(_options.CounterLagOffsetSeconds);
+        var loaded = DilateLoadedWindows(loadWindows, directionSelector, oppositeSelector);
         var losses = lossPool.SelectMany(series => series)
             .Where(s => s.LossPercent.HasValue && !InOutage(s.Time)
-                && loadWindows.TryGetValue(FloorToWindow(s.Time + lagOffset), out var w)
-                && directionSelector(w))
+                && loaded.Contains(FloorToWindow(s.Time)))
             .Select(s => s.LossPercent!.Value)
             .ToList();
         if (losses.Count < _options.MinLoadedSamples) return null;
         return losses.Average();
+    }
+
+    /// <summary>
+    /// Window keys that count as loaded in a direction for sample matching: the directly
+    /// loaded windows plus up to <see cref="IspHealthOptions.LoadedLeadSeconds"/> before and
+    /// <see cref="IspHealthOptions.LoadedTailSeconds"/> after each loaded run. The ramp fills
+    /// the queue before throughput crosses the loaded threshold and the drain (plus end-stamped
+    /// loss probes) trails it, so without dilation the edges of every event are dropped. Dilation
+    /// never crosses into a window loaded in the OPPOSITE direction, so a speed test's download
+    /// tail does not bleed into its upload phase. Idle classification is unaffected (this builds a
+    /// loaded set only), keeping the baseline a clean uncongested floor.
+    /// </summary>
+    private HashSet<DateTime> DilateLoadedWindows(
+        Dictionary<DateTime, LoadWindow> loadWindows,
+        Func<LoadWindow, bool> directionSelector,
+        Func<LoadWindow, bool> oppositeSelector)
+    {
+        var leadWindows = (int)Math.Ceiling((double)_options.LoadedLeadSeconds / _options.LoadWindowSeconds);
+        var tailWindows = (int)Math.Ceiling((double)_options.LoadedTailSeconds / _options.LoadWindowSeconds);
+
+        var loaded = new HashSet<DateTime>();
+        foreach (var (key, w) in loadWindows)
+        {
+            if (!directionSelector(w)) continue;
+            loaded.Add(key);
+            for (var i = 1; i <= leadWindows; i++)
+            {
+                var k = key.AddSeconds(-i * _options.LoadWindowSeconds);
+                if (loadWindows.TryGetValue(k, out var nw) && oppositeSelector(nw)) break;
+                loaded.Add(k);
+            }
+            for (var i = 1; i <= tailWindows; i++)
+            {
+                var k = key.AddSeconds(i * _options.LoadWindowSeconds);
+                if (loadWindows.TryGetValue(k, out var nw) && oppositeSelector(nw)) break;
+                loaded.Add(k);
+            }
+        }
+        return loaded;
     }
 
     /// <summary>
@@ -1244,8 +1286,8 @@ public class IspHealthScorer
         var loss = false;
         if (loadWindows.Count > 0)
         {
-            var downLoss = LoadedMeanLoss(inputs.LossPoolSeries, loadWindows, w => w.IsLoadedDown);
-            var upLoss = LoadedMeanLoss(inputs.LossPoolSeries, loadWindows, w => w.IsLoadedUp);
+            var downLoss = LoadedMeanLoss(inputs.LossPoolSeries, loadWindows, w => w.IsLoadedDown, w => w.IsLoadedUp);
+            var upLoss = LoadedMeanLoss(inputs.LossPoolSeries, loadWindows, w => w.IsLoadedUp, w => w.IsLoadedDown);
             loss = downLoss > profile.LoadedLossDownHighPct || upLoss > profile.LoadedLossUpHighPct;
         }
         return (latency, loss);

--- a/tests/NetworkOptimizer.Web.Tests/NetgearCmProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/NetgearCmProviderTests.cs
@@ -176,4 +176,109 @@ public class NetgearCmProviderTests
         ds.Correctables.Should().Be(1234);
         ds.Uncorrectables.Should().Be(5);
     }
+
+    // The CM2050V's DocsisStatus.htm carries FOUR tagValueList tables: SC-QAM + OFDM downstream
+    // and ATDMA + OFDMA upstream. Values are taken verbatim from a real CM2050V capture (trimmed
+    // to a couple of channels per table; the leading count matches). The unused upstream slots
+    // arrive as "Not Locked" placeholders, which - per the existing convention - are kept in the
+    // lists and excluded from the locked-only aggregates.
+    private const string Cm2050VHtml = """
+        <html><head><script>
+        function InitDsTableTagValue()
+        {
+            /* var tagValueList = "8" + "|1|Not Locked|Unknown|0|0|0.0|0.0|0|0"; */
+            var tagValueList = '2|1|Locked|QAM256|12|459000000 Hz|8.7|44.1|336|22|2|Locked|QAM256|1|393000000 Hz|8|43.9|445|1004|';
+            drawTable('dsTable', tagValueList, onAddDsRowCB);
+        }
+        function InitUsTableTagValue()
+        {
+            var tagValueList = '2|1|Locked|ATDMA|1|5120 Ksym/sec|16400000 Hz|39.5 dBmV|2|Not Locked|Unknown|0|0|0|0.0|';
+            drawTable('usTable', tagValueList, onAddUsRowCB);
+        }
+        function InitDsOfdmTableTagValue()
+        {
+            var tagValueList = '1|1|Locked|0 ,1 ,2 ,3|193|690000000 Hz|8.98 dBmV|43.4 dB|508 ~ 3587|80153994898|63946208630|3923|';
+            drawTable('dsOfdmTable', tagValueList, onAddDsOfdmRowCB);
+        }
+        function InitUsOfdmaTableTagValue()
+        {
+            var tagValueList = '2|1|Locked|12 ,13|41|36200000 Hz|37.5 dBmV|2|Not Locked|0|0|0 Hz|0 dBmV';
+            drawTable('usOfdmaTable', tagValueList, onAddUsOfdmaRowCB);
+        }
+        </script></head><body>
+        <table id="dsTable"><tr><td><span class="thead">Channel</span></td></tr></table>
+        <table id="usTable"><tr><td><span class="thead">Channel</span></td></tr></table>
+        </body></html>
+        """;
+
+    [Fact]
+    public void ParseDocsisStatus_ParsesCm2050VScQamAndOfdmDownstream()
+    {
+        var stats = NetgearCmProvider.ParseDocsisStatus(Cm2050VHtml, Context);
+
+        // 2 SC-QAM + 1 OFDM downstream channels.
+        stats.DownstreamChannels.Should().HaveCount(3);
+
+        var scqam = stats.DownstreamChannels[0];
+        scqam.ChannelId.Should().Be(12);
+        scqam.LockStatus.Should().Be("Locked");
+        scqam.Modulation.Should().Be("QAM256");
+        scqam.Frequency.Should().Be(459000000);
+        scqam.Power.Should().Be(8.7);
+        scqam.Snr.Should().Be(44.1);
+        scqam.Correctables.Should().Be(336);
+        scqam.Uncorrectables.Should().Be(22);
+
+        var ofdm = stats.DownstreamChannels.Single(c => c.ChannelId == 193);
+        ofdm.Modulation.Should().Be("OFDM");
+        ofdm.Frequency.Should().Be(690000000);
+        ofdm.Power.Should().Be(8.98);
+        ofdm.Snr.Should().Be(43.4);
+        // OFDM codeword counts (billions) are intentionally left out of the FEC aggregates.
+        ofdm.Correctables.Should().Be(0);
+        ofdm.Uncorrectables.Should().Be(0);
+    }
+
+    [Fact]
+    public void ParseDocsisStatus_ParsesCm2050VAtdmaAndOfdmaUpstream()
+    {
+        var stats = NetgearCmProvider.ParseDocsisStatus(Cm2050VHtml, Context);
+
+        // 2 ATDMA (one a placeholder) + 2 OFDMA (one a placeholder) = 4 entries kept.
+        stats.UpstreamChannels.Should().HaveCount(4);
+
+        var atdma = stats.UpstreamChannels[0];
+        atdma.ChannelId.Should().Be(1);
+        atdma.LockStatus.Should().Be("Locked");
+        atdma.ChannelType.Should().Be("ATDMA");
+        atdma.SymbolRate.Should().Be(5120);
+        atdma.Frequency.Should().Be(16400000);
+        atdma.Power.Should().Be(39.5);
+
+        var ofdma = stats.UpstreamChannels.Single(c => c.ChannelId == 41);
+        ofdma.LockStatus.Should().Be("Locked");
+        ofdma.ChannelType.Should().Be("OFDMA");
+        ofdma.Frequency.Should().Be(36200000);
+        ofdma.Power.Should().Be(37.5);
+        ofdma.SymbolRate.Should().Be(0);
+    }
+
+    [Fact]
+    public void ParseDocsisStatus_Cm2050VAggregatesAcrossAllFourTables()
+    {
+        var stats = NetgearCmProvider.ParseDocsisStatus(Cm2050VHtml, Context);
+
+        // All three downstream channels are locked; only the real upstream channels are.
+        stats.LockedDsChannels.Should().Be(3);
+        stats.LockedUsChannels.Should().Be(2);
+
+        // Averages span SC-QAM + OFDM downstream and ATDMA + OFDMA upstream, locked only.
+        stats.DownstreamPowerAvgDbmv.Should().BeApproximately((8.7 + 8 + 8.98) / 3, 0.0001);
+        stats.DownstreamSnrAvgDb.Should().BeApproximately((44.1 + 43.9 + 43.4) / 3, 0.0001);
+        stats.UpstreamPowerAvgDbmv.Should().BeApproximately((39.5 + 37.5) / 2, 0.0001);
+
+        // FEC totals come from the SC-QAM channels only (OFDM counts excluded).
+        stats.TotalCorrectables.Should().Be(336 + 445);
+        stats.TotalUncorrectables.Should().Be(22 + 1004);
+    }
 }


### PR DESCRIPTION
Release PR for v1.22.1.

## ISP Health

- **More accurate loaded latency and loaded loss.** Both are now matched against a dilated loaded window that captures the ramp-in and drain edges of a load event (which previously fell in transition windows and were dropped). Dilation never crosses into an opposite-direction loaded run, so a speed test's download phase can't be misattributed to its upload phase, and vice versa - it's direction-symmetric, so it's equally correct for download- and upload-bottlenecked connections. The idle baseline stays a strict, clean uncongested floor.
- **Loaded Latency and Loaded Loss always show both directions.** A direction with no loaded samples now reads "n/a" instead of disappearing, so a view can no longer show only "down".

## Cable modems

- **Netgear CM2050V support.** The Netgear / Nighthawk CM provider now also handles the CM2050V and the newer .htm web UI it serves: it auto-detects the form login (instead of HTTP Basic) and parses the DOCSIS 3.1 OFDM and OFDMA channels, all from the same provider entry with nothing new to pick.
- **Netgear CM700:** prime the anti-CSRF cookie before Basic auth. Should fix CM700 support.
