### PR TITLE
ISP Health: capture loaded-event edges via window dilation

### DIFF
--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -83,29 +83,24 @@ public class IspHealthOptions
     public int LoadWindowSeconds { get; set; } = 7;
 
     /// <summary>
-    /// Forward shift applied to a latency/loss sample's timestamp before matching it to a
-    /// WAN rate window, to compensate if the SNMP rate series (end-stamped, derived from a
-    /// counter poll) lags the ping probe that saw the same load. Default 0: an offset sweep
-    /// over -7..+7 s on real GPON data showed 0 maximizes the down/up loaded-latency
-    /// separation. Both series are end-stamped so their cadence late-bias cancels; a positive
-    /// shift only smears upstream load into up-loaded windows (fabricating up bufferbloat and
-    /// inverting down-vs-up loss), while a negative shift drops real down signal. Raise only
-    /// if load-onset latency spikes start landing in idle windows. Applied to idle-baseline
-    /// and loaded-latency classification; loaded loss uses <see cref="LoadedLossOffsetSeconds"/>.
+    /// Seconds the loaded-window leading edge is extended backward when matching loaded latency
+    /// and loaded loss samples. A load event has a ramp (queue fills before throughput crosses the
+    /// loaded threshold) whose early latency/loss falls in transition windows that are neither idle
+    /// nor loaded and would otherwise be dropped. Dilating the leading edge reclaims it. Bucket-
+    /// quantized to <see cref="LoadWindowSeconds"/>, so ~5 s extends by one window.
     /// </summary>
-    public int CounterLagOffsetSeconds { get; set; } = 0;
+    public int LoadedLeadSeconds { get; set; } = 5;
 
     /// <summary>
-    /// Counter-lag offset for loaded packet loss, separate from <see cref="CounterLagOffsetSeconds"/>
-    /// because loss needs a different shift than loaded latency. Loaded latency is elevated across
-    /// the whole load period, so 0 works; loss concentrates at the saturation tail / buffer overflow
-    /// and is end-stamped at probe-burst completion, so it lands a few seconds AFTER the WAN rate
-    /// window that defines the load. Default -5: observed on a GPON speed test where drops registered
-    /// ~5 s after the download phase ended, and confirmed by an offset sweep (the negative band
-    /// maximized down loaded loss and drove up loaded loss to 0). Negative shifts the loss sample
-    /// earlier so it bins into the load window that actually caused it.
+    /// Seconds the loaded-window trailing edge is extended forward when matching loaded latency and
+    /// loaded loss samples. Loss especially concentrates at the saturation tail / buffer drain and is
+    /// end-stamped at probe-burst completion, so it lands a few seconds after the WAN rate window that
+    /// defines the load (observed ~5 s after a GPON speed test's download phase ended). Dilation
+    /// captures it without the leading-edge loss a fixed back-shift causes. Dilation never crosses into
+    /// an opposite-direction loaded run, so a speed test's download tail cannot bleed into its upload
+    /// phase. Bucket-quantized to <see cref="LoadWindowSeconds"/>.
     /// </summary>
-    public int LoadedLossOffsetSeconds { get; set; } = -5;
+    public int LoadedTailSeconds { get; set; } = 5;
 
     /// <summary>
     /// How long a computed report stays fresh before the ISP Health tab recomputes it.

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -90,10 +90,22 @@ public class IspHealthOptions
     /// separation. Both series are end-stamped so their cadence late-bias cancels; a positive
     /// shift only smears upstream load into up-loaded windows (fabricating up bufferbloat and
     /// inverting down-vs-up loss), while a negative shift drops real down signal. Raise only
-    /// if load-onset latency spikes start landing in idle windows. Applied consistently to
-    /// idle-baseline, loaded-latency, and loaded-loss classification.
+    /// if load-onset latency spikes start landing in idle windows. Applied to idle-baseline
+    /// and loaded-latency classification; loaded loss uses <see cref="LoadedLossOffsetSeconds"/>.
     /// </summary>
     public int CounterLagOffsetSeconds { get; set; } = 0;
+
+    /// <summary>
+    /// Counter-lag offset for loaded packet loss, separate from <see cref="CounterLagOffsetSeconds"/>
+    /// because loss needs a different shift than loaded latency. Loaded latency is elevated across
+    /// the whole load period, so 0 works; loss concentrates at the saturation tail / buffer overflow
+    /// and is end-stamped at probe-burst completion, so it lands a few seconds AFTER the WAN rate
+    /// window that defines the load. Default -5: observed on a GPON speed test where drops registered
+    /// ~5 s after the download phase ended, and confirmed by an offset sweep (the negative band
+    /// maximized down loaded loss and drove up loaded loss to 0). Negative shifts the loss sample
+    /// earlier so it bins into the load window that actually caused it.
+    /// </summary>
+    public int LoadedLossOffsetSeconds { get; set; } = -5;
 
     /// <summary>
     /// How long a computed report stays fresh before the ISP Health tab recomputes it.

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -152,8 +152,8 @@ public class IspHealthScorer
         double? down = null, up = null;
         if (loadWindows.Count > 0)
         {
-            down = LoadedLatencyDelta(inputs, loadWindows, w => w.IsLoadedDown);
-            up = LoadedLatencyDelta(inputs, loadWindows, w => w.IsLoadedUp);
+            down = LoadedLatencyDelta(inputs, loadWindows, w => w.IsLoadedDown, w => w.IsLoadedUp);
+            up = LoadedLatencyDelta(inputs, loadWindows, w => w.IsLoadedUp, w => w.IsLoadedDown);
         }
 
         bool downFromSpeedTest = false, upFromSpeedTest = false;
@@ -192,9 +192,8 @@ public class IspHealthScorer
         var rtts = firstHop.Where(s => s.RttAvgMs.HasValue).ToList();
         if (rtts.Count == 0) return null;
 
-        var lagOffset = TimeSpan.FromSeconds(_options.CounterLagOffsetSeconds);
         var idleRtts = rtts
-            .Where(s => loadWindows.TryGetValue(FloorToWindow(s.Time + lagOffset), out var w) && w.IsIdle)
+            .Where(s => loadWindows.TryGetValue(FloorToWindow(s.Time), out var w) && w.IsIdle)
             .Select(s => s.RttAvgMs!.Value)
             .ToList();
         if (idleRtts.Count > 0) return SeriesStats.WinsorizedMean(idleRtts, _options.RttWinsorPercentile);
@@ -455,23 +454,22 @@ public class IspHealthScorer
     }
 
     /// <summary>
-    /// <summary>
     /// Loaded-latency delta from ISP access hops only. Each access hop's loaded RTT
     /// samples are baseline-subtracted and pooled; the median of the pool (filtered
     /// > 0.5 ms) is the result. Pooling raw samples instead of per-target aggregates
-    /// is stable even with sparse loaded data (typical residential). Sample timestamps
-    /// are shifted forward by the counter lag offset so they align with the interface
-    /// counter window, which is end-stamped and arrives after the probe that saw the
-    /// same load (a load onset shows in latency about one counter interval before it
-    /// shows in the rate series).
+    /// is stable even with sparse loaded data (typical residential). Loaded windows are
+    /// dilated (see <see cref="DilateLoadedWindows"/>) so the ramp-in rise and drain tail of
+    /// an event - which fall in transition windows outside the strict rate threshold - are
+    /// captured rather than dropped.
     /// </summary>
     private double? LoadedLatencyDelta(
         IspHealthInputs inputs,
         Dictionary<DateTime, LoadWindow> loadWindows,
-        Func<LoadWindow, bool> directionSelector)
+        Func<LoadWindow, bool> directionSelector,
+        Func<LoadWindow, bool> oppositeSelector)
     {
         const double noiseFloor = 0.5;
-        var lagOffset = TimeSpan.FromSeconds(_options.CounterLagOffsetSeconds);
+        var loaded = DilateLoadedWindows(loadWindows, directionSelector, oppositeSelector);
 
         var accessCohort = inputs.AccessHopSeries.Count > 0
             ? inputs.AccessHopSeries
@@ -484,9 +482,7 @@ public class IspHealthScorer
             if (baseline == null) continue;
 
             var deltas = hop
-                .Where(s => s.RttAvgMs.HasValue
-                    && loadWindows.TryGetValue(FloorToWindow(s.Time + lagOffset), out var w)
-                    && directionSelector(w))
+                .Where(s => s.RttAvgMs.HasValue && loaded.Contains(FloorToWindow(s.Time)))
                 .Select(s => s.RttAvgMs!.Value - baseline.Value);
 
             pooledDeltas.AddRange(deltas);
@@ -512,8 +508,8 @@ public class IspHealthScorer
             }, false);
         }
 
-        var downLoss = LoadedMeanLoss(lossPool, loadWindows, w => w.IsLoadedDown);
-        var upLoss = LoadedMeanLoss(lossPool, loadWindows, w => w.IsLoadedUp);
+        var downLoss = LoadedMeanLoss(lossPool, loadWindows, w => w.IsLoadedDown, w => w.IsLoadedUp);
+        var upLoss = LoadedMeanLoss(lossPool, loadWindows, w => w.IsLoadedUp, w => w.IsLoadedDown);
 
         var scores = new List<double>();
         if (downLoss.HasValue) scores.Add(ScoreLossBand(downLoss.Value, profile.LoadedLossDownLowPct, profile.LoadedLossDownHighPct));
@@ -557,17 +553,77 @@ public class IspHealthScorer
     private double? LoadedMeanLoss(
         List<List<LatencySample>> lossPool,
         Dictionary<DateTime, LoadWindow> loadWindows,
-        Func<LoadWindow, bool> directionSelector)
+        Func<LoadWindow, bool> directionSelector,
+        Func<LoadWindow, bool> oppositeSelector)
     {
-        var lagOffset = TimeSpan.FromSeconds(_options.LoadedLossOffsetSeconds);
+        var loaded = DilateLoadedWindows(loadWindows, directionSelector, oppositeSelector);
         var losses = lossPool.SelectMany(series => series)
             .Where(s => s.LossPercent.HasValue && !InOutage(s.Time)
-                && loadWindows.TryGetValue(FloorToWindow(s.Time + lagOffset), out var w)
-                && directionSelector(w))
+                && loaded.Contains(FloorToWindow(s.Time)))
             .Select(s => s.LossPercent!.Value)
             .ToList();
         if (losses.Count < _options.MinLoadedSamples) return null;
         return losses.Average();
+    }
+
+    /// <summary>
+    /// Window keys that count as loaded in a direction for sample matching: the directly
+    /// loaded windows plus up to <see cref="IspHealthOptions.LoadedLeadSeconds"/> before and
+    /// <see cref="IspHealthOptions.LoadedTailSeconds"/> after each loaded run. The ramp fills
+    /// the queue before throughput crosses the loaded threshold and the drain (plus end-stamped
+    /// loss probes) trails it, so without dilation the edges of every event are dropped. Dilation
+    /// never crosses into a window loaded in the OPPOSITE direction, so a speed test's download
+    /// tail does not bleed into its upload phase. Idle classification is unaffected (this builds a
+    /// loaded set only), keeping the baseline a clean uncongested floor.
+    /// </summary>
+    private HashSet<DateTime> DilateLoadedWindows(
+        Dictionary<DateTime, LoadWindow> loadWindows,
+        Func<LoadWindow, bool> directionSelector,
+        Func<LoadWindow, bool> oppositeSelector)
+    {
+        var leadWindows = (int)Math.Ceiling((double)_options.LoadedLeadSeconds / _options.LoadWindowSeconds);
+        var tailWindows = (int)Math.Ceiling((double)_options.LoadedTailSeconds / _options.LoadWindowSeconds);
+
+        var loaded = new HashSet<DateTime>();
+        foreach (var (key, w) in loadWindows)
+        {
+            if (!directionSelector(w)) continue;
+            loaded.Add(key);
+            for (var i = 1; i <= leadWindows; i++)
+            {
+                var k = key.AddSeconds(-i * _options.LoadWindowSeconds);
+                if (loadWindows.TryGetValue(k, out var nw) && oppositeSelector(nw)) break;
+                loaded.Add(k);
+            }
+            for (var i = 1; i <= tailWindows; i++)
+            {
+                var k = key.AddSeconds(i * _options.LoadWindowSeconds);
+                if (loadWindows.TryGetValue(k, out var nw) && oppositeSelector(nw)) break;
+                loaded.Add(k);
+            }
+        }
+        return loaded;
+    }
+
+    /// <summary>
+    /// TEMP DIAGNOSTIC (dilation sweep): the passive loaded-latency and loaded-loss values
+    /// (down/up) for the current options, using the exact production classification. Lead/tail
+    /// of 0 reproduces the strict (offset-0) baseline. Remove together with the sweep in
+    /// IspHealthService.
+    /// </summary>
+    public (double? DownLatencyMs, double? UpLatencyMs, double? DownLossPct, double? UpLossPct, int LoadedWindows)
+        DiagnoseLoadedFactors(IspHealthInputs inputs)
+    {
+        var loadWindows = LoadClassifier.Classify(
+            inputs.WanRates, inputs.ExpectedDownloadMbps, inputs.ExpectedUploadMbps,
+            _options, inputs.LoadExclusionWindows, _logger);
+        if (loadWindows.Count == 0) return (null, null, null, null, 0);
+        var downLat = LoadedLatencyDelta(inputs, loadWindows, w => w.IsLoadedDown, w => w.IsLoadedUp);
+        var upLat = LoadedLatencyDelta(inputs, loadWindows, w => w.IsLoadedUp, w => w.IsLoadedDown);
+        var downLoss = LoadedMeanLoss(inputs.LossPoolSeries, loadWindows, w => w.IsLoadedDown, w => w.IsLoadedUp);
+        var upLoss = LoadedMeanLoss(inputs.LossPoolSeries, loadWindows, w => w.IsLoadedUp, w => w.IsLoadedDown);
+        var loaded = loadWindows.Values.Count(w => w.IsLoadedDown || w.IsLoadedUp);
+        return (downLat, upLat, downLoss, upLoss, loaded);
     }
 
     /// <summary>
@@ -1244,8 +1300,8 @@ public class IspHealthScorer
         var loss = false;
         if (loadWindows.Count > 0)
         {
-            var downLoss = LoadedMeanLoss(inputs.LossPoolSeries, loadWindows, w => w.IsLoadedDown);
-            var upLoss = LoadedMeanLoss(inputs.LossPoolSeries, loadWindows, w => w.IsLoadedUp);
+            var downLoss = LoadedMeanLoss(inputs.LossPoolSeries, loadWindows, w => w.IsLoadedDown, w => w.IsLoadedUp);
+            var upLoss = LoadedMeanLoss(inputs.LossPoolSeries, loadWindows, w => w.IsLoadedUp, w => w.IsLoadedDown);
             loss = downLoss > profile.LoadedLossDownHighPct || upLoss > profile.LoadedLossUpHighPct;
         }
         return (latency, loss);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -606,27 +606,6 @@ public class IspHealthScorer
     }
 
     /// <summary>
-    /// TEMP DIAGNOSTIC (dilation sweep): the passive loaded-latency and loaded-loss values
-    /// (down/up) for the current options, using the exact production classification. Lead/tail
-    /// of 0 reproduces the strict (offset-0) baseline. Remove together with the sweep in
-    /// IspHealthService.
-    /// </summary>
-    public (double? DownLatencyMs, double? UpLatencyMs, double? DownLossPct, double? UpLossPct, int LoadedWindows)
-        DiagnoseLoadedFactors(IspHealthInputs inputs)
-    {
-        var loadWindows = LoadClassifier.Classify(
-            inputs.WanRates, inputs.ExpectedDownloadMbps, inputs.ExpectedUploadMbps,
-            _options, inputs.LoadExclusionWindows, _logger);
-        if (loadWindows.Count == 0) return (null, null, null, null, 0);
-        var downLat = LoadedLatencyDelta(inputs, loadWindows, w => w.IsLoadedDown, w => w.IsLoadedUp);
-        var upLat = LoadedLatencyDelta(inputs, loadWindows, w => w.IsLoadedUp, w => w.IsLoadedDown);
-        var downLoss = LoadedMeanLoss(inputs.LossPoolSeries, loadWindows, w => w.IsLoadedDown, w => w.IsLoadedUp);
-        var upLoss = LoadedMeanLoss(inputs.LossPoolSeries, loadWindows, w => w.IsLoadedUp, w => w.IsLoadedDown);
-        var loaded = loadWindows.Values.Count(w => w.IsLoadedDown || w.IsLoadedUp);
-        return (downLat, upLat, downLoss, upLoss, loaded);
-    }
-
-    /// <summary>
     /// Grades one ASN (transit) or one ISP hop: a quality blend (stability, jitter,
     /// loss, congestion) capped by a reach ceiling. Jitter and stability come from
     /// <see cref="AsnSeries.JitterSourceSamples"/> when set (a transit ASN's farther

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -422,10 +422,13 @@ public class IspHealthScorer
         }
 
         // A negative delta means latency did not rise under load (noise/faster); show
-        // it as +0 ms rather than a confusing "+-0.1".
-        var parts = new List<string>();
-        if (deltas.DownMs.HasValue) parts.Add($"+{FormatLoadedDelta(deltas.DownMs.Value)} down");
-        if (deltas.UpMs.HasValue) parts.Add($"+{FormatLoadedDelta(deltas.UpMs.Value)} up");
+        // it as +0 ms rather than a confusing "+-0.1". Always show both directions; a
+        // direction with no loaded samples reads "n/a" (distinct from a measured +0 ms).
+        var parts = new List<string>
+        {
+            deltas.DownMs.HasValue ? $"+{FormatLoadedDelta(deltas.DownMs.Value)} down" : "n/a down",
+            deltas.UpMs.HasValue ? $"+{FormatLoadedDelta(deltas.UpMs.Value)} up" : "n/a up"
+        };
         var valuedDirections = (deltas.DownMs.HasValue ? 1 : 0) + (deltas.UpMs.HasValue ? 1 : 0);
         var speedTestDirections = (deltas.DownMs.HasValue && deltas.DownFromSpeedTest ? 1 : 0)
             + (deltas.UpMs.HasValue && deltas.UpFromSpeedTest ? 1 : 0);
@@ -524,9 +527,13 @@ public class IspHealthScorer
             }, false);
         }
 
-        var parts = new List<string>();
-        if (downLoss.HasValue) parts.Add($"{FormatPct(downLoss.Value)} down");
-        if (upLoss.HasValue) parts.Add($"{FormatPct(upLoss.Value)} up");
+        // Always show both directions; a direction with no loaded samples reads "n/a"
+        // (distinct from a measured 0%).
+        var parts = new List<string>
+        {
+            downLoss.HasValue ? $"{FormatPct(downLoss.Value)} down" : "n/a down",
+            upLoss.HasValue ? $"{FormatPct(upLoss.Value)} up" : "n/a up"
+        };
 
         return (new IspScoreFactor
         {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -559,7 +559,7 @@ public class IspHealthScorer
         Dictionary<DateTime, LoadWindow> loadWindows,
         Func<LoadWindow, bool> directionSelector)
     {
-        var lagOffset = TimeSpan.FromSeconds(_options.CounterLagOffsetSeconds);
+        var lagOffset = TimeSpan.FromSeconds(_options.LoadedLossOffsetSeconds);
         var losses = lossPool.SelectMany(series => series)
             .Where(s => s.LossPercent.HasValue && !InOutage(s.Time)
                 && loadWindows.TryGetValue(FloorToWindow(s.Time + lagOffset), out var w)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -597,25 +597,6 @@ public class IspHealthService
         };
 
         var report = new IspHealthScorer(_options, _logger).Score(inputs, profile);
-
-        // TEMP DIAGNOSTIC: loaded-window dilation sweep over identical inputs. lead/tail in
-        // seconds (0/5/10 -> 0/1/2 buckets); lead=tail=0 reproduces the strict offset-0 baseline
-        // so it lines up with the earlier offset sweep. Remove with IspHealthScorer.DiagnoseLoadedFactors.
-        var sweepHours = Math.Round((windowEnd - windowStart).TotalHours);
-        foreach (var lead in new[] { 0, 5, 10 })
-        {
-            foreach (var tail in new[] { 0, 5, 10 })
-            {
-                var d = new IspHealthScorer(new IspHealthOptions { LoadedLeadSeconds = lead, LoadedTailSeconds = tail }, _logger)
-                    .DiagnoseLoadedFactors(inputs);
-                _logger.LogDebug(
-                    "ISP Health dilation sweep [{Hours}h]: lead={Lead}s tail={Tail}s loadedWindows={Windows} | loaded latency down={DownLat} up={UpLat} ms | loaded loss down={DownLoss} up={UpLoss} %",
-                    sweepHours, lead, tail, d.LoadedWindows,
-                    d.DownLatencyMs?.ToString("F2") ?? "n/a", d.UpLatencyMs?.ToString("F2") ?? "n/a",
-                    d.DownLossPct?.ToString("F3") ?? "n/a", d.UpLossPct?.ToString("F3") ?? "n/a");
-            }
-        }
-
         _logger.LogDebug("ISP Health computed: {Score} ({Tech}), {Events} congestion events, {Shifts} path shifts",
             report.OverallScore, profile.DisplayName, congestionEvents.Count, pathShifts.Count);
         return new ComputeOutcome(IspHealthStatus.Ready, report, chartClusters);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -597,6 +597,25 @@ public class IspHealthService
         };
 
         var report = new IspHealthScorer(_options, _logger).Score(inputs, profile);
+
+        // TEMP DIAGNOSTIC: loaded-window dilation sweep over identical inputs. lead/tail in
+        // seconds (0/5/10 -> 0/1/2 buckets); lead=tail=0 reproduces the strict offset-0 baseline
+        // so it lines up with the earlier offset sweep. Remove with IspHealthScorer.DiagnoseLoadedFactors.
+        var sweepHours = Math.Round((windowEnd - windowStart).TotalHours);
+        foreach (var lead in new[] { 0, 5, 10 })
+        {
+            foreach (var tail in new[] { 0, 5, 10 })
+            {
+                var d = new IspHealthScorer(new IspHealthOptions { LoadedLeadSeconds = lead, LoadedTailSeconds = tail }, _logger)
+                    .DiagnoseLoadedFactors(inputs);
+                _logger.LogDebug(
+                    "ISP Health dilation sweep [{Hours}h]: lead={Lead}s tail={Tail}s loadedWindows={Windows} | loaded latency down={DownLat} up={UpLat} ms | loaded loss down={DownLoss} up={UpLoss} %",
+                    sweepHours, lead, tail, d.LoadedWindows,
+                    d.DownLatencyMs?.ToString("F2") ?? "n/a", d.UpLatencyMs?.ToString("F2") ?? "n/a",
+                    d.DownLossPct?.ToString("F3") ?? "n/a", d.UpLossPct?.ToString("F3") ?? "n/a");
+            }
+        }
+
         _logger.LogDebug("ISP Health computed: {Score} ({Tech}), {Events} congestion events, {Shifts} path shifts",
             report.OverallScore, profile.DisplayName, congestionEvents.Count, pathShifts.Count);
         return new ComputeOutcome(IspHealthStatus.Ready, report, chartClusters);


### PR DESCRIPTION
Loaded latency and loaded loss now match samples against a *dilated* loaded window instead of the strict rate-threshold windows, so the edges of a load event are no longer dropped.

## What changed

- **Edge capture.** A load event has a ramp (the queue fills before throughput crosses the loaded threshold) and a drain tail (loss especially concentrates there, and loss probes are end-stamped at burst completion). Those edges land in transition windows that are neither idle nor loaded, so they were silently dropped. Each loaded run is now extended `LoadedLeadSeconds` (5) back and `LoadedTailSeconds` (5) forward when matching loaded latency and loaded loss samples, reclaiming them.
- **No cross-direction bleed.** Dilation never crosses into a window loaded in the opposite direction, so a speed test's download tail cannot be attributed to its upload phase (and vice versa). This is direction-symmetric, so it's equally correct for download-bottlenecked and upload-bottlenecked connections.
- **Idle baseline stays strict** (no dilation), keeping it a clean uncongested floor.
- **Always show both directions.** Loaded Latency and Loaded Loss now render both down and up in the UI; a direction with no loaded samples reads "n/a" (distinct from a measured 0% / +0 ms) instead of vanishing. Previously the absent direction was omitted, so e.g. a 48 h view could show only "down".
- Replaces the previous fixed counter-lag time offset, which could only correct one edge at a time and had no guard against cross-phase misattribution.

## Why

On short, ad-hoc-speed-test-heavy windows the strict windows mis-graded loaded loss/latency around event transitions (including inverted down/up loss). Dilation makes those sparse windows converge to the clean shape seen on rich, sustained-load windows, without dragging upload-phase samples into the download direction. Long/active-connection windows are unchanged (the dilation is below their aggregate resolution).
