### PR TITLE
Stop flagging the SQM firmware regression on patched gateways

### DIFF
--- a/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
+++ b/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
@@ -480,7 +480,7 @@ public class PerformanceAnalyzer
         {
             Title = "SQM Performance Regression on Current Firmware",
             Description = $"Your {gateway.FriendlyModelName} is running firmware {firmwareStr} with SQM enabled on {wanNames}. " +
-                $"UniFi OS versions from after 5.0.10 up to {fixedFirmware} have a known SQM download throughput regression that can bottleneck speeds to 800 Mbps or less on faster connections. UniFi OS {fixedFirmware} fixes it on this gateway.",
+                $"UniFi OS versions from after 5.0.10 through 5.1.15 have a known SQM download throughput regression that can bottleneck speeds to 800 Mbps or less on faster connections. UniFi OS {fixedFirmware} fixes it on this gateway.",
             Recommendation = $"Upgrade to UniFi OS {fixedFirmware} or later, which restores full SQM download performance on high-speed connections.",
             Severity = PerformanceSeverity.Recommendation,
             Category = PerformanceCategory.Performance,

--- a/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
+++ b/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
@@ -425,17 +425,25 @@ public class PerformanceAnalyzer
         return issues;
     }
 
-    private static readonly HashSet<string> SqmFirmwareAffectedGateways = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "UCG-Fiber", "UXG-Fiber", "UCG-Max", "UXG-Max"
-    };
-
     private static readonly Version SqmLastGoodFirmware = new(5, 0, 10);
 
+    // Firmware version that fixes the SQM regression, keyed by gateway model. The UXG line
+    // ships fixes behind the UCG line, so it lands the fix a couple of point releases earlier
+    // in the affected window; the two lines eventually converge.
+    private static readonly Dictionary<string, Version> SqmFixedFirmwareByGateway = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["UXG-Fiber"] = new(5, 1, 17),
+        ["UXG-Max"] = new(5, 1, 17),
+        ["UCG-Fiber"] = new(5, 1, 19),
+        ["UCG-Max"] = new(5, 1, 19),
+    };
+
     /// <summary>
-    /// Check if SQM is enabled on a gateway with firmware newer than 5.0.10.
-    /// Firmware versions after 5.0.10 have a known SQM download throughput regression
-    /// on high-bandwidth connections (bottlenecked to ~800 Mbps or less).
+    /// Check if SQM is enabled on a gateway running firmware within the affected window.
+    /// Firmware versions after 5.0.10 introduced a SQM download throughput regression
+    /// on high-bandwidth connections (bottlenecked to ~800 Mbps or less). It was fixed in
+    /// 5.1.17 on UXG models and 5.1.19 on UCG models, so only firmware below the gateway's
+    /// fixed version (and above 5.0.10) is flagged.
     /// </summary>
     internal List<PerformanceIssue> CheckSqmFirmwareRegression(
         List<UniFiDeviceResponse> devices,
@@ -447,14 +455,14 @@ public class PerformanceAnalyzer
         if (gateway == null)
             return issues;
 
-        if (!SqmFirmwareAffectedGateways.Contains(gateway.FriendlyModelName))
+        if (!SqmFixedFirmwareByGateway.TryGetValue(gateway.FriendlyModelName, out var fixedFirmware))
             return issues;
 
         var firmwareStr = gateway.DisplayableVersion ?? gateway.Version;
         if (string.IsNullOrEmpty(firmwareStr) || !Version.TryParse(firmwareStr, out var firmware))
             return issues;
 
-        if (firmware <= SqmLastGoodFirmware)
+        if (firmware <= SqmLastGoodFirmware || firmware >= fixedFirmware)
             return issues;
 
         var sqmWans = networks.Where(n =>
@@ -472,9 +480,8 @@ public class PerformanceAnalyzer
         {
             Title = "SQM Performance Regression on Current Firmware",
             Description = $"Your {gateway.FriendlyModelName} is running firmware {firmwareStr} with SQM enabled on {wanNames}. " +
-                $"UniFi OS versions after 5.0.10 have a known SQM download throughput regression that can bottleneck speeds to 800 Mbps or less on faster connections.",
-            Recommendation = "UniFi OS 5.0.10 provides significantly better SQM download performance on high-speed connections. " +
-                "Rolling back firmware is non-trivial and may require a backup, factory reset, and restore.",
+                $"UniFi OS versions from after 5.0.10 up to {fixedFirmware} have a known SQM download throughput regression that can bottleneck speeds to 800 Mbps or less on faster connections. UniFi OS {fixedFirmware} fixes it on this gateway.",
+            Recommendation = $"Upgrade to UniFi OS {fixedFirmware} or later, which restores full SQM download performance on high-speed connections.",
             Severity = PerformanceSeverity.Recommendation,
             Category = PerformanceCategory.Performance,
             DeviceName = gateway.Name

--- a/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PerformanceAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PerformanceAnalyzerTests.cs
@@ -1852,6 +1852,76 @@ public class PerformanceAnalyzerTests
         result.Should().HaveCount(1);
     }
 
+    [Theory]
+    // UXG line is fixed in 5.1.17; UCG line in 5.1.19.
+    [InlineData("UXGA6AA", "5.1.17")] // UXG-Fiber at its fixed version
+    [InlineData("UXGB", "5.1.17")]    // UXG-Max at its fixed version
+    [InlineData("UDMA6A8", "5.1.19")] // UCG-Fiber at its fixed version
+    [InlineData("UCGMAX", "5.1.19")]  // UCG-Max at its fixed version
+    [InlineData("UDMA6A8", "5.2.0")]  // above the UCG fix
+    public void CheckSqmFirmwareRegression_FirmwareAtOrAboveFixedVersion_ReturnsEmpty(string model, string version)
+    {
+        var devices = new List<UniFiDeviceResponse>
+        {
+            new() { Id = "gw1", Mac = "aa:bb:cc:00:00:01", Name = "Gateway", Type = "ugw",
+                    Model = model, DisplayableVersion = version }
+        };
+        var networks = new List<UniFiNetworkConfig>
+        {
+            new() { Id = "wan1", Name = "WAN", Purpose = "wan", WanSmartqEnabled = true,
+                    WanProviderCapabilities = new WanProviderCapabilities { DownloadKilobitsPerSecond = 1_000_000 } }
+        };
+
+        var result = _analyzer.CheckSqmFirmwareRegression(devices, networks);
+
+        result.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("UXGA6AA", "5.1.16")] // UXG-Fiber just below its fix
+    [InlineData("UDMA6A8", "5.1.18")] // UCG-Fiber just below its fix (UXG would already be fixed here)
+    public void CheckSqmFirmwareRegression_FirmwareJustBelowFixedVersion_ReturnsIssue(string model, string version)
+    {
+        var devices = new List<UniFiDeviceResponse>
+        {
+            new() { Id = "gw1", Mac = "aa:bb:cc:00:00:01", Name = "Gateway", Type = "ugw",
+                    Model = model, DisplayableVersion = version }
+        };
+        var networks = new List<UniFiNetworkConfig>
+        {
+            new() { Id = "wan1", Name = "WAN", Purpose = "wan", WanSmartqEnabled = true,
+                    WanProviderCapabilities = new WanProviderCapabilities { DownloadKilobitsPerSecond = 1_000_000 } }
+        };
+
+        var result = _analyzer.CheckSqmFirmwareRegression(devices, networks);
+
+        result.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void CheckSqmFirmwareRegression_Firmware5118_FixedOnUxgButNotUcg()
+    {
+        var networks = new List<UniFiNetworkConfig>
+        {
+            new() { Id = "wan1", Name = "WAN", Purpose = "wan", WanSmartqEnabled = true,
+                    WanProviderCapabilities = new WanProviderCapabilities { DownloadKilobitsPerSecond = 1_000_000 } }
+        };
+
+        var uxg = new List<UniFiDeviceResponse>
+        {
+            new() { Id = "gw1", Mac = "aa:bb:cc:00:00:01", Name = "Gateway", Type = "ugw",
+                    Model = "UXGA6AA", DisplayableVersion = "5.1.18" }
+        };
+        var ucg = new List<UniFiDeviceResponse>
+        {
+            new() { Id = "gw1", Mac = "aa:bb:cc:00:00:02", Name = "Gateway", Type = "ugw",
+                    Model = "UDMA6A8", DisplayableVersion = "5.1.18" }
+        };
+
+        _analyzer.CheckSqmFirmwareRegression(uxg, networks).Should().BeEmpty();
+        _analyzer.CheckSqmFirmwareRegression(ucg, networks).Should().HaveCount(1);
+    }
+
     [Fact]
     public void CheckSqmFirmwareRegression_SqmDisabled_ReturnsEmpty()
     {


### PR DESCRIPTION
## What

The "SQM Performance Regression on Current Firmware" advisory now knows which firmware fixes the regression and stops flagging gateways that are already on a patched build.

- The download-throughput regression that bottlenecks SQM to ~800 Mbps is fixed in **UniFi OS 5.1.17 on the UXG line** and **5.1.19 on the UCG line** (UXG ships the fix a couple of point releases ahead; the lines converge).
- The finding only fires for firmware in the affected window: after 5.0.10 and below the gateway's fixed version. Gateways on the fixed build or later no longer see it.
- The advice now points users **forward** ("upgrade to {fixed version} or later") instead of recommending a non-trivial rollback to 5.0.10.

## Why

The advisory previously fired on every firmware after 5.0.10 with no upper bound, so users who had already upgraded past the regression kept seeing a stale recommendation telling them to roll back, even though a forward fix exists.

## Tests

Added per-line boundary coverage, including a 5.1.18 case that is fixed on UXG but still affected on UCG. All `CheckSqmFirmwareRegression` tests pass.
