### PR TITLE
Release: TBD

### DIFF
--- a/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
+++ b/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
@@ -425,17 +425,25 @@ public class PerformanceAnalyzer
         return issues;
     }
 
-    private static readonly HashSet<string> SqmFirmwareAffectedGateways = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "UCG-Fiber", "UXG-Fiber", "UCG-Max", "UXG-Max"
-    };
-
     private static readonly Version SqmLastGoodFirmware = new(5, 0, 10);
 
+    // Firmware version that fixes the SQM regression, keyed by gateway model. The UXG line
+    // ships fixes behind the UCG line, so it lands the fix a couple of point releases earlier
+    // in the affected window; the two lines eventually converge.
+    private static readonly Dictionary<string, Version> SqmFixedFirmwareByGateway = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["UXG-Fiber"] = new(5, 1, 17),
+        ["UXG-Max"] = new(5, 1, 17),
+        ["UCG-Fiber"] = new(5, 1, 19),
+        ["UCG-Max"] = new(5, 1, 19),
+    };
+
     /// <summary>
-    /// Check if SQM is enabled on a gateway with firmware newer than 5.0.10.
-    /// Firmware versions after 5.0.10 have a known SQM download throughput regression
-    /// on high-bandwidth connections (bottlenecked to ~800 Mbps or less).
+    /// Check if SQM is enabled on a gateway running firmware within the affected window.
+    /// Firmware versions after 5.0.10 introduced a SQM download throughput regression
+    /// on high-bandwidth connections (bottlenecked to ~800 Mbps or less). It was fixed in
+    /// 5.1.17 on UXG models and 5.1.19 on UCG models, so only firmware below the gateway's
+    /// fixed version (and above 5.0.10) is flagged.
     /// </summary>
     internal List<PerformanceIssue> CheckSqmFirmwareRegression(
         List<UniFiDeviceResponse> devices,
@@ -447,14 +455,14 @@ public class PerformanceAnalyzer
         if (gateway == null)
             return issues;
 
-        if (!SqmFirmwareAffectedGateways.Contains(gateway.FriendlyModelName))
+        if (!SqmFixedFirmwareByGateway.TryGetValue(gateway.FriendlyModelName, out var fixedFirmware))
             return issues;
 
         var firmwareStr = gateway.DisplayableVersion ?? gateway.Version;
         if (string.IsNullOrEmpty(firmwareStr) || !Version.TryParse(firmwareStr, out var firmware))
             return issues;
 
-        if (firmware <= SqmLastGoodFirmware)
+        if (firmware <= SqmLastGoodFirmware || firmware >= fixedFirmware)
             return issues;
 
         var sqmWans = networks.Where(n =>
@@ -472,9 +480,8 @@ public class PerformanceAnalyzer
         {
             Title = "SQM Performance Regression on Current Firmware",
             Description = $"Your {gateway.FriendlyModelName} is running firmware {firmwareStr} with SQM enabled on {wanNames}. " +
-                $"UniFi OS versions after 5.0.10 have a known SQM download throughput regression that can bottleneck speeds to 800 Mbps or less on faster connections.",
-            Recommendation = "UniFi OS 5.0.10 provides significantly better SQM download performance on high-speed connections. " +
-                "Rolling back firmware is non-trivial and may require a backup, factory reset, and restore.",
+                $"UniFi OS versions from after 5.0.10 through 5.1.15 have a known SQM download throughput regression that can bottleneck speeds to 800 Mbps or less on faster connections. UniFi OS {fixedFirmware} fixes it on this gateway.",
+            Recommendation = $"Upgrade to UniFi OS {fixedFirmware} or later, which restores full SQM download performance on high-speed connections.",
             Severity = PerformanceSeverity.Recommendation,
             Category = PerformanceCategory.Performance,
             DeviceName = gateway.Name

--- a/src/NetworkOptimizer.Threats/Analysis/ExposureValidator.cs
+++ b/src/NetworkOptimizer.Threats/Analysis/ExposureValidator.cs
@@ -50,6 +50,10 @@ public class ExposureValidator
 
         foreach (var rule in portForwardRules)
         {
+            // Disabled static rules aren't actually forwarding traffic, so they're not exposed.
+            // UPnP rules leave Enabled null and are inherently active.
+            if (rule.Enabled == false) continue;
+
             var ports = ParsePorts(rule.DstPort);
             foreach (var port in ports)
             {

--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -103,6 +103,7 @@
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/scrollRestoration.js")"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/updateCheck.js")"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/steppedScaleBar.js")"></script>
+    <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/map-address-search.js")"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "lib/heic2any.min.js")"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/floorPlanEditor.js")"></script>
     @if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DEMO_MODE_MAPPINGS")))

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestMap.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestMap.razor
@@ -806,6 +806,11 @@
                     if (typeof SteppedScaleBar !== 'undefined') {{
                         window._speedTestMaps['{mapId}'].scaleBar = SteppedScaleBar.create(map, 3);
                     }}
+
+                    // Collapsible address search (top-right)
+                    if (window.MapAddressSearch) {{
+                        window._speedTestMaps['{mapId}'].addrSearch = window.MapAddressSearch.add(map, {{ position: 'topright' }});
+                    }}
                 }})();
             ");
 
@@ -1192,8 +1197,8 @@
 
     private string BuildApPopup(ApMapMarker ap)
     {
-        var name = ap.Name?.Replace("'", "\\'").Replace("\"", "&quot;") ?? "Unknown AP";
-        var model = ap.Model?.Replace("'", "\\'").Replace("\"", "&quot;") ?? "";
+        var name = System.Net.WebUtility.HtmlEncode(ap.Name) ?? "Unknown AP";
+        var model = System.Net.WebUtility.HtmlEncode(ap.Model) ?? "";
         var statusClass = ap.IsOnline ? "ap-status-online" : "ap-status-offline";
         var statusText = ap.IsOnline ? "Online" : "Offline";
 
@@ -1223,7 +1228,7 @@
             foreach (var radio in ap.Radios)
             {
                 var radioCode = radio.RadioCode ?? "";
-                var bandDisplay = radio.Band?.Replace("'", "\\'") ?? "";
+                var bandDisplay = System.Net.WebUtility.HtmlEncode(radio.Band) ?? "";
                 html += "<div class='ap-popup-radio'>";
 
                 // Band badge (uses standard wifi-band-ng/na/6e CSS classes)
@@ -1564,9 +1569,9 @@
         var apName = apHop?.DeviceName;
         var apMac = apHop?.DeviceMac;
 
-        // Escape for JS string
-        deviceName = deviceName?.Replace("'", "\\'").Replace("\"", "&quot;") ?? "Unknown";
-        apName = apName?.Replace("'", "\\'").Replace("\"", "&quot;");
+        // HTML-encode before rendering: hostnames are device-self-reported (DHCP/mDNS)
+        deviceName = System.Net.WebUtility.HtmlEncode(deviceName) ?? "Unknown";
+        apName = System.Net.WebUtility.HtmlEncode(apName);
 
         var html = $"<div class='map-popup'>";
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14765,6 +14765,146 @@ tr.stats-row-filtered {
     outline: none;
     border-color: var(--primary-color);
 }
+
+.map-addr-search {
+    position: relative;
+}
+.map-addr-search-bar {
+    display: flex;
+    align-items: center;
+    background: rgba(16, 24, 32, 0.82);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+}
+.map-addr-search.is-error .map-addr-search-bar {
+    border-color: var(--danger-color);
+}
+.map-addr-search-input {
+    width: 220px;
+    max-width: 56vw;
+    border: none;
+    background: transparent;
+    color: var(--text-primary);
+    font-size: 0.85rem;
+    padding: 0.42rem 0.6rem;
+    outline: none;
+    transition: width 0.2s ease, padding 0.2s ease, opacity 0.15s ease;
+}
+.map-addr-search-input::placeholder {
+    color: var(--text-muted);
+}
+.map-addr-search.is-collapsed .map-addr-search-input {
+    width: 0;
+    padding-left: 0;
+    padding-right: 0;
+    opacity: 0;
+}
+.map-addr-search.is-error .map-addr-search-input {
+    color: var(--danger-color);
+}
+.map-addr-search-toggle {
+    position: relative;
+    flex-shrink: 0;
+    width: 34px;
+    height: 34px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: var(--text-secondary);
+    transition: color 0.15s ease, background 0.15s ease;
+}
+.map-addr-search-toggle:hover {
+    color: var(--text-primary);
+    background: rgba(255, 255, 255, 0.06);
+}
+.map-addr-search.is-loading .map-addr-search-toggle svg {
+    opacity: 0;
+}
+.map-addr-search.is-loading .map-addr-search-toggle::after {
+    content: "";
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    border: 2px solid rgba(255, 255, 255, 0.25);
+    border-top-color: var(--primary-color);
+    border-radius: 50%;
+    animation: map-addr-search-spin 0.7s linear infinite;
+}
+@keyframes map-addr-search-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+.map-addr-search-pin {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--primary-color);
+    border: 3px solid #fff;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3), 0 1px 4px rgba(0, 0, 0, 0.45);
+}
+.map-addr-search-popup {
+    font-size: 0.82rem;
+    line-height: 1.35;
+    max-width: 220px;
+}
+.map-addr-search-results {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    width: 280px;
+    max-width: 78vw;
+    background: rgba(16, 24, 32, 0.92);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 8px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+    overflow: hidden;
+    max-height: 280px;
+    overflow-y: auto;
+    display: none;
+}
+.map-addr-search.is-open .map-addr-search-results {
+    display: block;
+}
+.map-addr-search-result {
+    padding: 0.5rem 0.6rem;
+    font-size: 0.8rem;
+    line-height: 1.3;
+    color: var(--text-secondary);
+    cursor: pointer;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+.map-addr-search-result:last-child {
+    border-bottom: none;
+}
+.map-addr-search-result:hover {
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--text-primary);
+}
+.map-addr-search-empty {
+    padding: 0.5rem 0.6rem;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+}
+@media (max-width: 768px) {
+    .map-addr-search-input {
+        width: 180px;
+        max-width: 60vw;
+    }
+    .map-addr-search-results {
+        width: 240px;
+    }
+}
+
 .lan-flow-map-chips {
     display: flex;
     flex-wrap: wrap;

--- a/src/NetworkOptimizer.Web/wwwroot/js/floorPlanEditor.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/floorPlanEditor.js
@@ -416,6 +416,11 @@ window.fpEditor = {
             var initSteps = (window.innerWidth <= 768) ? 0 : 3;
             self._scaleBar = SteppedScaleBar.create(m, initSteps);
 
+            // Collapsible address search (top-right) - jump the floor plan to a street address
+            if (window.MapAddressSearch) {
+                self._addrSearch = window.MapAddressSearch.add(m, { position: 'topright' });
+            }
+
             resolveReady();
         }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/map-address-search.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/map-address-search.js
@@ -1,0 +1,207 @@
+// Collapsible address search control for Leaflet maps (Speed Test Map, Signal Map).
+// Geocodes via the public OpenStreetMap Nominatim service. Commercial use is permitted
+// with attribution; per the Nominatim usage policy we only geocode on submit (Enter or
+// icon click), never per keystroke, and rely on the browser-sent Referer to identify the app.
+(function () {
+    if (window.MapAddressSearch) return;
+
+    var GEOCODE_URL = 'https://nominatim.openstreetmap.org/search';
+    var RESULT_LIMIT = 10;
+    // Only do location-aware searching once the user is zoomed into a region. Below this
+    // the default view is continent-wide (e.g. the US-wide zoom 4 start), and biasing would
+    // drag a far-away user's search toward the wrong place.
+    var BIAS_MIN_ZOOM = 8;
+    // Minimum half-size (degrees) of the "near me" box for the local-first pass, so a deeply
+    // zoomed-in user still searches a regional area (~110 km) rather than the visible sliver.
+    var LOCAL_MIN_HALF_DEG = 1.0;
+
+    function searchIconSvg() {
+        return '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"'
+            + ' fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">'
+            + '<circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>';
+    }
+
+    function pinIcon(L) {
+        return L.divIcon({
+            className: 'map-addr-search-pin-wrap',
+            html: '<div class="map-addr-search-pin"></div>',
+            iconSize: [24, 24],
+            iconAnchor: [12, 12],
+            popupAnchor: [0, -14]
+        });
+    }
+
+    function escapeHtml(s) {
+        if (!s) return '';
+        var d = document.createElement('div');
+        d.textContent = s;
+        return d.innerHTML;
+    }
+
+    window.MapAddressSearch = {
+        /**
+         * Adds a collapsible address-search control to a Leaflet map.
+         * @param {L.Map} map - the Leaflet map instance
+         * @param {Object} [opts]
+         * @param {string} [opts.position='topright'] - Leaflet control corner
+         * @param {string} [opts.placeholder='Search address or place...']
+         * @param {number} [opts.zoom=18] - minimum zoom to apply when centering on a result
+         * @param {function(number, number, string)} [opts.onResult] - callback(lat, lng, displayName)
+         * @returns {L.Control|null}
+         */
+        add: function (map, opts) {
+            opts = opts || {};
+            if (typeof L === 'undefined' || !map) return null;
+
+            var placeholder = opts.placeholder || 'Search address or place...';
+            var targetZoom = opts.zoom || 18;
+
+            var SearchControl = L.Control.extend({
+                options: { position: opts.position || 'topright' },
+                onAdd: function () {
+                    var root = L.DomUtil.create('div', 'map-addr-search is-collapsed');
+                    root.innerHTML =
+                        '<div class="map-addr-search-bar">'
+                        + '<input class="map-addr-search-input" type="text" autocomplete="off" spellcheck="false"'
+                        + ' placeholder="' + escapeHtml(placeholder) + '" aria-label="Search address or place" />'
+                        + '<button class="map-addr-search-toggle" type="button" aria-label="Search address"'
+                        + ' title="Search address">' + searchIconSvg() + '</button>'
+                        + '</div>'
+                        + '<div class="map-addr-search-results" role="listbox"></div>';
+
+                    var input = root.querySelector('.map-addr-search-input');
+                    var toggle = root.querySelector('.map-addr-search-toggle');
+                    var results = root.querySelector('.map-addr-search-results');
+                    var marker = null;
+
+                    // Keep clicks/scroll on the control from reaching the map underneath.
+                    L.DomEvent.disableClickPropagation(root);
+                    L.DomEvent.disableScrollPropagation(root);
+
+                    function expand() {
+                        root.classList.remove('is-collapsed');
+                        setTimeout(function () { input.focus(); }, 60);
+                    }
+                    function collapse() {
+                        root.classList.add('is-collapsed');
+                        root.classList.remove('is-error', 'is-open');
+                        input.blur();
+                    }
+                    function closeResults() {
+                        root.classList.remove('is-open');
+                        results.innerHTML = '';
+                    }
+
+                    // A regional box around the current map center, used to constrain the
+                    // local-first pass. Returns null when zoomed out (see BIAS_MIN_ZOOM) so
+                    // a far-away user at the default view gets a plain global search.
+                    function localBox() {
+                        if (map.getZoom() < BIAS_MIN_ZOOM) return null;
+                        var c = map.getCenter();
+                        var b = map.getBounds();
+                        var halfLat = Math.max(LOCAL_MIN_HALF_DEG, (b.getNorth() - b.getSouth()) / 2);
+                        var halfLng = Math.max(LOCAL_MIN_HALF_DEG, (b.getEast() - b.getWest()) / 2);
+                        return { west: c.lng - halfLng, east: c.lng + halfLng, north: c.lat + halfLat, south: c.lat - halfLat };
+                    }
+                    function boxParam(box) {
+                        return [box.west, box.north, box.east, box.south]
+                            .map(function (n) { return n.toFixed(5); }).join(',');
+                    }
+
+                    function geocode(url) {
+                        return fetch(url, { headers: { 'Accept': 'application/json' } })
+                            .then(function (r) { return r.ok ? r.json() : []; })
+                            .catch(function () { return []; });
+                    }
+
+                    function selectResult(hit) {
+                        var lat = parseFloat(hit.lat), lng = parseFloat(hit.lon);
+                        if (isNaN(lat) || isNaN(lng)) return;
+                        closeResults();
+                        var z = Math.min(Math.max(map.getZoom(), targetZoom), map.getMaxZoom() || targetZoom);
+                        if (marker) map.removeLayer(marker);
+                        marker = L.marker([lat, lng], { icon: pinIcon(L) })
+                            .addTo(map)
+                            // autoPan:false so opening the popup doesn't shove the result off-center
+                            .bindPopup('<div class="map-addr-search-popup">' + escapeHtml(hit.display_name) + '</div>',
+                                { autoPan: false });
+                        marker.openPopup();
+                        // Center last so the popup auto-pan can't pull us off the result.
+                        map.setView([lat, lng], z, { animate: true });
+                        if (typeof opts.onResult === 'function') opts.onResult(lat, lng, hit.display_name);
+                    }
+
+                    function renderResults(list) {
+                        results.innerHTML = '';
+                        list.forEach(function (hit) {
+                            var row = document.createElement('div');
+                            row.className = 'map-addr-search-result';
+                            row.setAttribute('role', 'option');
+                            row.textContent = hit.display_name;
+                            row.addEventListener('click', function () { selectResult(hit); });
+                            results.appendChild(row);
+                        });
+                        root.classList.add('is-open');
+                    }
+
+                    function showEmpty() {
+                        results.innerHTML = '<div class="map-addr-search-empty">No matches found</div>';
+                        root.classList.add('is-open', 'is-error');
+                    }
+
+                    function present(list) {
+                        root.classList.remove('is-loading');
+                        if (!list || !list.length) { showEmpty(); return; }
+                        if (list.length === 1) { selectResult(list[0]); return; }
+                        renderResults(list);
+                    }
+
+                    function doSearch() {
+                        var q = (input.value || '').trim();
+                        if (!q) { collapse(); return; }
+                        root.classList.remove('is-error');
+                        closeResults();
+                        root.classList.add('is-loading');
+
+                        // Soft viewbox bias around the user (a padded regional box) when zoomed
+                        // in: it lifts a nearby match above a more "prominent" same-named place
+                        // elsewhere, without hard-excluding far results or overriding an explicit
+                        // region in the query (e.g. "paris, tx" still resolves to Texas).
+                        var url = GEOCODE_URL + '?format=jsonv2&addressdetails=1&limit=' + RESULT_LIMIT;
+                        var box = localBox();
+                        if (box) url += '&viewbox=' + boxParam(box);
+                        url += '&q=' + encodeURIComponent(q);
+                        geocode(url).then(present);
+                    }
+
+                    toggle.addEventListener('click', function () {
+                        if (root.classList.contains('is-collapsed')) { expand(); return; }
+                        if ((input.value || '').trim()) doSearch();
+                        else collapse();
+                    });
+                    input.addEventListener('keydown', function (e) {
+                        if (e.key === 'Enter') { e.preventDefault(); doSearch(); }
+                        else if (e.key === 'Escape') { e.preventDefault(); closeResults(); collapse(); }
+                    });
+                    input.addEventListener('input', function () {
+                        root.classList.remove('is-error');
+                        if (root.classList.contains('is-open')) closeResults();
+                    });
+
+                    // Collapse when the user starts interacting with the map, but only if the
+                    // field is empty so we never discard a half-typed query.
+                    map.on('mousedown', function () {
+                        if (!root.classList.contains('is-collapsed') && !(input.value || '').trim()) collapse();
+                    });
+
+                    this._root = root;
+                    return root;
+                }
+            });
+
+            var ctrl = new SearchControl();
+            map.addControl(ctrl);
+            return ctrl;
+        }
+    };
+})();

--- a/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PerformanceAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PerformanceAnalyzerTests.cs
@@ -1852,6 +1852,76 @@ public class PerformanceAnalyzerTests
         result.Should().HaveCount(1);
     }
 
+    [Theory]
+    // UXG line is fixed in 5.1.17; UCG line in 5.1.19.
+    [InlineData("UXGA6AA", "5.1.17")] // UXG-Fiber at its fixed version
+    [InlineData("UXGB", "5.1.17")]    // UXG-Max at its fixed version
+    [InlineData("UDMA6A8", "5.1.19")] // UCG-Fiber at its fixed version
+    [InlineData("UCGMAX", "5.1.19")]  // UCG-Max at its fixed version
+    [InlineData("UDMA6A8", "5.2.0")]  // above the UCG fix
+    public void CheckSqmFirmwareRegression_FirmwareAtOrAboveFixedVersion_ReturnsEmpty(string model, string version)
+    {
+        var devices = new List<UniFiDeviceResponse>
+        {
+            new() { Id = "gw1", Mac = "aa:bb:cc:00:00:01", Name = "Gateway", Type = "ugw",
+                    Model = model, DisplayableVersion = version }
+        };
+        var networks = new List<UniFiNetworkConfig>
+        {
+            new() { Id = "wan1", Name = "WAN", Purpose = "wan", WanSmartqEnabled = true,
+                    WanProviderCapabilities = new WanProviderCapabilities { DownloadKilobitsPerSecond = 1_000_000 } }
+        };
+
+        var result = _analyzer.CheckSqmFirmwareRegression(devices, networks);
+
+        result.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("UXGA6AA", "5.1.16")] // UXG-Fiber just below its fix
+    [InlineData("UDMA6A8", "5.1.18")] // UCG-Fiber just below its fix (UXG would already be fixed here)
+    public void CheckSqmFirmwareRegression_FirmwareJustBelowFixedVersion_ReturnsIssue(string model, string version)
+    {
+        var devices = new List<UniFiDeviceResponse>
+        {
+            new() { Id = "gw1", Mac = "aa:bb:cc:00:00:01", Name = "Gateway", Type = "ugw",
+                    Model = model, DisplayableVersion = version }
+        };
+        var networks = new List<UniFiNetworkConfig>
+        {
+            new() { Id = "wan1", Name = "WAN", Purpose = "wan", WanSmartqEnabled = true,
+                    WanProviderCapabilities = new WanProviderCapabilities { DownloadKilobitsPerSecond = 1_000_000 } }
+        };
+
+        var result = _analyzer.CheckSqmFirmwareRegression(devices, networks);
+
+        result.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void CheckSqmFirmwareRegression_Firmware5118_FixedOnUxgButNotUcg()
+    {
+        var networks = new List<UniFiNetworkConfig>
+        {
+            new() { Id = "wan1", Name = "WAN", Purpose = "wan", WanSmartqEnabled = true,
+                    WanProviderCapabilities = new WanProviderCapabilities { DownloadKilobitsPerSecond = 1_000_000 } }
+        };
+
+        var uxg = new List<UniFiDeviceResponse>
+        {
+            new() { Id = "gw1", Mac = "aa:bb:cc:00:00:01", Name = "Gateway", Type = "ugw",
+                    Model = "UXGA6AA", DisplayableVersion = "5.1.18" }
+        };
+        var ucg = new List<UniFiDeviceResponse>
+        {
+            new() { Id = "gw1", Mac = "aa:bb:cc:00:00:02", Name = "Gateway", Type = "ugw",
+                    Model = "UDMA6A8", DisplayableVersion = "5.1.18" }
+        };
+
+        _analyzer.CheckSqmFirmwareRegression(uxg, networks).Should().BeEmpty();
+        _analyzer.CheckSqmFirmwareRegression(ucg, networks).Should().HaveCount(1);
+    }
+
     [Fact]
     public void CheckSqmFirmwareRegression_SqmDisabled_ReturnsEmpty()
     {

--- a/tests/NetworkOptimizer.Threats.Tests/ExposureValidatorTests.cs
+++ b/tests/NetworkOptimizer.Threats.Tests/ExposureValidatorTests.cs
@@ -27,7 +27,8 @@ public class ExposureValidatorTests
         string? fwd = "198.51.100.10",
         string? fwdPort = null,
         string? name = null,
-        string? proto = "tcp")
+        string? proto = "tcp",
+        bool? enabled = null)
     {
         return new UniFiPortForwardRule
         {
@@ -35,7 +36,8 @@ public class ExposureValidatorTests
             Fwd = fwd,
             FwdPort = fwdPort,
             Name = name,
-            Proto = proto
+            Proto = proto,
+            Enabled = enabled
         };
     }
 
@@ -171,6 +173,53 @@ public class ExposureValidatorTests
 
         Assert.Empty(report.ExposedServices);
         Assert.Equal(0, report.TotalExposedPorts);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_DisabledRule_ExcludedFromExposure()
+    {
+        var rules = new List<UniFiPortForwardRule>
+        {
+            CreatePortForwardRule("443", name: "Disabled Web Server", enabled: false)
+        };
+
+        _mockRepo.Setup(r => r.GetEventsAsync(_from, _to, null, 443, null, 5000, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ThreatEvent>
+            {
+                CreateThreatEvent("192.0.2.10", 443),
+                CreateThreatEvent("192.0.2.11", 443)
+            });
+
+        _mockRepo.Setup(r => r.GetCountryDistributionAsync(_from, _to, It.IsAny<ThreatAction?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, int>());
+
+        var report = await _validator.ValidateAsync(rules, _mockRepo.Object, _from, _to);
+
+        Assert.Empty(report.ExposedServices);
+        Assert.Equal(0, report.TotalExposedPorts);
+        Assert.Equal(0, report.TotalThreatsTargetingExposed);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_EnabledRule_IncludedInExposure()
+    {
+        var rules = new List<UniFiPortForwardRule>
+        {
+            CreatePortForwardRule("443", name: "Web Server", enabled: true)
+        };
+
+        _mockRepo.Setup(r => r.GetEventsAsync(_from, _to, null, 443, null, 5000, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ThreatEvent>
+            {
+                CreateThreatEvent("192.0.2.10", 443)
+            });
+
+        _mockRepo.Setup(r => r.GetCountryDistributionAsync(_from, _to, It.IsAny<ThreatAction?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, int>());
+
+        var report = await _validator.ValidateAsync(rules, _mockRepo.Object, _from, _to);
+
+        Assert.Single(report.ExposedServices);
     }
 
     [Fact]


### PR DESCRIPTION
Release placeholder (version TBD).

## Changes since last release

- **Address search on the Speed Test and Signal maps** - A collapsible search box in the top-right corner lets you jump either map to a street address or place name instead of panning by hand. Geocoding uses OpenStreetMap; when you're zoomed into a region the search is biased toward what's on screen, and a single match centers and drops a pin automatically. Device and AP names in the Speed Test Map marker popups are now HTML-encoded before display.
- **Threat Intelligence: disabled port-forward rules no longer count as exposure** - Port forwarding rules that are turned off are excluded from the exposed-services assessment, so a disabled rule no longer shows up as an open exposure.
- **SQM firmware regression advisory now knows the fix** - The "SQM Performance Regression on Current Firmware" finding stops flagging gateways once they're on a firmware that fixes the regression (UniFi OS 5.1.17 on the UXG line, 5.1.19 on the UCG line). It now points users to upgrade forward instead of recommending a rollback to 5.0.10.
