### PR TITLE
Threat Intelligence: don't count disabled forwarding rules as exposed

### DIFF
--- a/src/NetworkOptimizer.Threats/Analysis/ExposureValidator.cs
+++ b/src/NetworkOptimizer.Threats/Analysis/ExposureValidator.cs
@@ -50,6 +50,10 @@ public class ExposureValidator
 
         foreach (var rule in portForwardRules)
         {
+            // Disabled static rules aren't actually forwarding traffic, so they're not exposed.
+            // UPnP rules leave Enabled null and are inherently active.
+            if (rule.Enabled == false) continue;
+
             var ports = ParsePorts(rule.DstPort);
             foreach (var port in ports)
             {

--- a/tests/NetworkOptimizer.Threats.Tests/ExposureValidatorTests.cs
+++ b/tests/NetworkOptimizer.Threats.Tests/ExposureValidatorTests.cs
@@ -27,7 +27,8 @@ public class ExposureValidatorTests
         string? fwd = "198.51.100.10",
         string? fwdPort = null,
         string? name = null,
-        string? proto = "tcp")
+        string? proto = "tcp",
+        bool? enabled = null)
     {
         return new UniFiPortForwardRule
         {
@@ -35,7 +36,8 @@ public class ExposureValidatorTests
             Fwd = fwd,
             FwdPort = fwdPort,
             Name = name,
-            Proto = proto
+            Proto = proto,
+            Enabled = enabled
         };
     }
 
@@ -171,6 +173,53 @@ public class ExposureValidatorTests
 
         Assert.Empty(report.ExposedServices);
         Assert.Equal(0, report.TotalExposedPorts);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_DisabledRule_ExcludedFromExposure()
+    {
+        var rules = new List<UniFiPortForwardRule>
+        {
+            CreatePortForwardRule("443", name: "Disabled Web Server", enabled: false)
+        };
+
+        _mockRepo.Setup(r => r.GetEventsAsync(_from, _to, null, 443, null, 5000, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ThreatEvent>
+            {
+                CreateThreatEvent("192.0.2.10", 443),
+                CreateThreatEvent("192.0.2.11", 443)
+            });
+
+        _mockRepo.Setup(r => r.GetCountryDistributionAsync(_from, _to, It.IsAny<ThreatAction?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, int>());
+
+        var report = await _validator.ValidateAsync(rules, _mockRepo.Object, _from, _to);
+
+        Assert.Empty(report.ExposedServices);
+        Assert.Equal(0, report.TotalExposedPorts);
+        Assert.Equal(0, report.TotalThreatsTargetingExposed);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_EnabledRule_IncludedInExposure()
+    {
+        var rules = new List<UniFiPortForwardRule>
+        {
+            CreatePortForwardRule("443", name: "Web Server", enabled: true)
+        };
+
+        _mockRepo.Setup(r => r.GetEventsAsync(_from, _to, null, 443, null, 5000, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ThreatEvent>
+            {
+                CreateThreatEvent("192.0.2.10", 443)
+            });
+
+        _mockRepo.Setup(r => r.GetCountryDistributionAsync(_from, _to, It.IsAny<ThreatAction?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, int>());
+
+        var report = await _validator.ValidateAsync(rules, _mockRepo.Object, _from, _to);
+
+        Assert.Single(report.ExposedServices);
     }
 
     [Fact]


### PR DESCRIPTION
## What

Disabled port forwarding rules are no longer included in the Threat Intelligence exposure report.

## Why

A disabled static forwarding rule isn't actually passing traffic, so it shouldn't show up as an exposed service under attack. Previously every rule returned by the UniFi API was processed regardless of its enabled state, so a disabled rule could still appear in exposure with a threat count.

## Details

`ExposureValidator` now skips rules where `Enabled == false`. UPnP rules leave `Enabled` null and remain treated as active (they're inherently live), so only explicitly-disabled static rules are excluded.

Added tests covering the disabled-excluded and enabled-included cases.
