### PR TITLE
Add address search to Speed Test and Signal maps

### DIFF
--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -103,6 +103,7 @@
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/scrollRestoration.js")"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/updateCheck.js")"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/steppedScaleBar.js")"></script>
+    <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/map-address-search.js")"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "lib/heic2any.min.js")"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/floorPlanEditor.js")"></script>
     @if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DEMO_MODE_MAPPINGS")))

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestMap.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestMap.razor
@@ -806,6 +806,11 @@
                     if (typeof SteppedScaleBar !== 'undefined') {{
                         window._speedTestMaps['{mapId}'].scaleBar = SteppedScaleBar.create(map, 3);
                     }}
+
+                    // Collapsible address search (top-right)
+                    if (window.MapAddressSearch) {{
+                        window._speedTestMaps['{mapId}'].addrSearch = window.MapAddressSearch.add(map, {{ position: 'topright' }});
+                    }}
                 }})();
             ");
 

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestMap.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestMap.razor
@@ -1197,8 +1197,8 @@
 
     private string BuildApPopup(ApMapMarker ap)
     {
-        var name = ap.Name?.Replace("'", "\\'").Replace("\"", "&quot;") ?? "Unknown AP";
-        var model = ap.Model?.Replace("'", "\\'").Replace("\"", "&quot;") ?? "";
+        var name = System.Net.WebUtility.HtmlEncode(ap.Name) ?? "Unknown AP";
+        var model = System.Net.WebUtility.HtmlEncode(ap.Model) ?? "";
         var statusClass = ap.IsOnline ? "ap-status-online" : "ap-status-offline";
         var statusText = ap.IsOnline ? "Online" : "Offline";
 
@@ -1228,7 +1228,7 @@
             foreach (var radio in ap.Radios)
             {
                 var radioCode = radio.RadioCode ?? "";
-                var bandDisplay = radio.Band?.Replace("'", "\\'") ?? "";
+                var bandDisplay = System.Net.WebUtility.HtmlEncode(radio.Band) ?? "";
                 html += "<div class='ap-popup-radio'>";
 
                 // Band badge (uses standard wifi-band-ng/na/6e CSS classes)
@@ -1569,9 +1569,9 @@
         var apName = apHop?.DeviceName;
         var apMac = apHop?.DeviceMac;
 
-        // Escape for JS string
-        deviceName = deviceName?.Replace("'", "\\'").Replace("\"", "&quot;") ?? "Unknown";
-        apName = apName?.Replace("'", "\\'").Replace("\"", "&quot;");
+        // HTML-encode before rendering: hostnames are device-self-reported (DHCP/mDNS)
+        deviceName = System.Net.WebUtility.HtmlEncode(deviceName) ?? "Unknown";
+        apName = System.Net.WebUtility.HtmlEncode(apName);
 
         var html = $"<div class='map-popup'>";
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14767,6 +14767,9 @@ tr.stats-row-filtered {
 }
 
 .map-addr-search {
+    position: relative;
+}
+.map-addr-search-bar {
     display: flex;
     align-items: center;
     background: rgba(16, 24, 32, 0.82);
@@ -14776,6 +14779,9 @@ tr.stats-row-filtered {
     border-radius: 8px;
     overflow: hidden;
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+}
+.map-addr-search.is-error .map-addr-search-bar {
+    border-color: var(--danger-color);
 }
 .map-addr-search-input {
     width: 220px;
@@ -14799,9 +14805,6 @@ tr.stats-row-filtered {
 }
 .map-addr-search.is-error .map-addr-search-input {
     color: var(--danger-color);
-}
-.map-addr-search.is-error {
-    border-color: var(--danger-color);
 }
 .map-addr-search-toggle {
     position: relative;
@@ -14852,10 +14855,53 @@ tr.stats-row-filtered {
     line-height: 1.35;
     max-width: 220px;
 }
+.map-addr-search-results {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    width: 280px;
+    max-width: 78vw;
+    background: rgba(16, 24, 32, 0.92);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 8px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+    overflow: hidden;
+    max-height: 280px;
+    overflow-y: auto;
+    display: none;
+}
+.map-addr-search.is-open .map-addr-search-results {
+    display: block;
+}
+.map-addr-search-result {
+    padding: 0.5rem 0.6rem;
+    font-size: 0.8rem;
+    line-height: 1.3;
+    color: var(--text-secondary);
+    cursor: pointer;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+.map-addr-search-result:last-child {
+    border-bottom: none;
+}
+.map-addr-search-result:hover {
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--text-primary);
+}
+.map-addr-search-empty {
+    padding: 0.5rem 0.6rem;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+}
 @media (max-width: 768px) {
     .map-addr-search-input {
         width: 180px;
         max-width: 60vw;
+    }
+    .map-addr-search-results {
+        width: 240px;
     }
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14765,6 +14765,100 @@ tr.stats-row-filtered {
     outline: none;
     border-color: var(--primary-color);
 }
+
+.map-addr-search {
+    display: flex;
+    align-items: center;
+    background: rgba(16, 24, 32, 0.82);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+}
+.map-addr-search-input {
+    width: 220px;
+    max-width: 56vw;
+    border: none;
+    background: transparent;
+    color: var(--text-primary);
+    font-size: 0.85rem;
+    padding: 0.42rem 0.6rem;
+    outline: none;
+    transition: width 0.2s ease, padding 0.2s ease, opacity 0.15s ease;
+}
+.map-addr-search-input::placeholder {
+    color: var(--text-muted);
+}
+.map-addr-search.is-collapsed .map-addr-search-input {
+    width: 0;
+    padding-left: 0;
+    padding-right: 0;
+    opacity: 0;
+}
+.map-addr-search.is-error .map-addr-search-input {
+    color: var(--danger-color);
+}
+.map-addr-search.is-error {
+    border-color: var(--danger-color);
+}
+.map-addr-search-toggle {
+    position: relative;
+    flex-shrink: 0;
+    width: 34px;
+    height: 34px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: var(--text-secondary);
+    transition: color 0.15s ease, background 0.15s ease;
+}
+.map-addr-search-toggle:hover {
+    color: var(--text-primary);
+    background: rgba(255, 255, 255, 0.06);
+}
+.map-addr-search.is-loading .map-addr-search-toggle svg {
+    opacity: 0;
+}
+.map-addr-search.is-loading .map-addr-search-toggle::after {
+    content: "";
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    border: 2px solid rgba(255, 255, 255, 0.25);
+    border-top-color: var(--primary-color);
+    border-radius: 50%;
+    animation: map-addr-search-spin 0.7s linear infinite;
+}
+@keyframes map-addr-search-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+.map-addr-search-pin {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--primary-color);
+    border: 3px solid #fff;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3), 0 1px 4px rgba(0, 0, 0, 0.45);
+}
+.map-addr-search-popup {
+    font-size: 0.82rem;
+    line-height: 1.35;
+    max-width: 220px;
+}
+@media (max-width: 768px) {
+    .map-addr-search-input {
+        width: 180px;
+        max-width: 60vw;
+    }
+}
+
 .lan-flow-map-chips {
     display: flex;
     flex-wrap: wrap;

--- a/src/NetworkOptimizer.Web/wwwroot/js/floorPlanEditor.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/floorPlanEditor.js
@@ -416,6 +416,11 @@ window.fpEditor = {
             var initSteps = (window.innerWidth <= 768) ? 0 : 3;
             self._scaleBar = SteppedScaleBar.create(m, initSteps);
 
+            // Collapsible address search (top-right) - jump the floor plan to a street address
+            if (window.MapAddressSearch) {
+                self._addrSearch = window.MapAddressSearch.add(m, { position: 'topright' });
+            }
+
             resolveReady();
         }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/map-address-search.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/map-address-search.js
@@ -6,11 +6,14 @@
     if (window.MapAddressSearch) return;
 
     var GEOCODE_URL = 'https://nominatim.openstreetmap.org/search';
-    var RESULT_LIMIT = 5;
-    // Only bias results toward the current map view once the user is zoomed into a
-    // region. Below this the default view is continent-wide (e.g. the US-wide zoom 4
-    // start), and biasing would drag a far-away user's search toward the wrong place.
+    var RESULT_LIMIT = 10;
+    // Only do location-aware searching once the user is zoomed into a region. Below this
+    // the default view is continent-wide (e.g. the US-wide zoom 4 start), and biasing would
+    // drag a far-away user's search toward the wrong place.
     var BIAS_MIN_ZOOM = 8;
+    // Minimum half-size (degrees) of the "near me" box for the local-first pass, so a deeply
+    // zoomed-in user still searches a regional area (~110 km) rather than the visible sliver.
+    var LOCAL_MIN_HALF_DEG = 1.0;
 
     function searchIconSvg() {
         return '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"'
@@ -89,13 +92,39 @@
                         results.innerHTML = '';
                     }
 
-                    // Bias toward the current view only when zoomed into a region (see BIAS_MIN_ZOOM).
-                    function viewboxParam() {
-                        if (map.getZoom() < BIAS_MIN_ZOOM) return '';
+                    // A regional box around the current map center, used to constrain the
+                    // local-first pass. Returns null when zoomed out (see BIAS_MIN_ZOOM) so
+                    // a far-away user at the default view gets a plain global search.
+                    function localBox() {
+                        if (map.getZoom() < BIAS_MIN_ZOOM) return null;
+                        var c = map.getCenter();
                         var b = map.getBounds();
-                        var box = [b.getWest(), b.getNorth(), b.getEast(), b.getSouth()]
+                        var halfLat = Math.max(LOCAL_MIN_HALF_DEG, (b.getNorth() - b.getSouth()) / 2);
+                        var halfLng = Math.max(LOCAL_MIN_HALF_DEG, (b.getEast() - b.getWest()) / 2);
+                        return { c: c, west: c.lng - halfLng, east: c.lng + halfLng, north: c.lat + halfLat, south: c.lat - halfLat };
+                    }
+                    function boxParam(box) {
+                        return [box.west, box.north, box.east, box.south]
                             .map(function (n) { return n.toFixed(5); }).join(',');
-                        return '&viewbox=' + box; // soft bias - no &bounded=1, so far results still resolve
+                    }
+
+                    // Squared distance in degrees (longitude scaled by latitude) - good enough for ranking.
+                    function sortByProximity(list, center) {
+                        var cosLat = Math.cos(center.lat * Math.PI / 180);
+                        return list.slice().sort(function (a, b) {
+                            function d2(h) {
+                                var dy = parseFloat(h.lat) - center.lat;
+                                var dx = (parseFloat(h.lon) - center.lng) * cosLat;
+                                return dx * dx + dy * dy;
+                            }
+                            return d2(a) - d2(b);
+                        });
+                    }
+
+                    function geocode(url) {
+                        return fetch(url, { headers: { 'Accept': 'application/json' } })
+                            .then(function (r) { return r.ok ? r.json() : []; })
+                            .catch(function () { return []; });
                     }
 
                     function selectResult(hit) {
@@ -133,26 +162,36 @@
                         root.classList.add('is-open', 'is-error');
                     }
 
+                    function present(list, center) {
+                        root.classList.remove('is-loading');
+                        if (!list || !list.length) { showEmpty(); return; }
+                        if (center) list = sortByProximity(list, center);
+                        if (list.length === 1) { selectResult(list[0]); return; }
+                        renderResults(list);
+                    }
+
                     function doSearch() {
                         var q = (input.value || '').trim();
                         if (!q) { collapse(); return; }
                         root.classList.remove('is-error');
                         closeResults();
                         root.classList.add('is-loading');
-                        var url = GEOCODE_URL + '?format=jsonv2&addressdetails=1&limit=' + RESULT_LIMIT
-                            + viewboxParam() + '&q=' + encodeURIComponent(q);
-                        fetch(url, { headers: { 'Accept': 'application/json' } })
-                            .then(function (r) { return r.ok ? r.json() : []; })
-                            .then(function (list) {
-                                root.classList.remove('is-loading');
-                                if (!list || !list.length) { showEmpty(); return; }
-                                if (list.length === 1) { selectResult(list[0]); return; }
-                                renderResults(list);
-                            })
-                            .catch(function () {
-                                root.classList.remove('is-loading');
-                                showEmpty();
-                            });
+
+                        var base = GEOCODE_URL + '?format=jsonv2&addressdetails=1&limit=' + RESULT_LIMIT;
+                        var qParam = '&q=' + encodeURIComponent(q);
+                        var globalUrl = base + qParam;
+                        var box = localBox();
+
+                        if (!box) { geocode(globalUrl).then(function (list) { present(list, null); }); return; }
+
+                        // Local-first: hard-constrain to a box around the user, then fall back
+                        // to a global search if nothing matches nearby. Either way, rank by
+                        // proximity to the map center so the closest match leads.
+                        var localUrl = base + '&viewbox=' + boxParam(box) + '&bounded=1' + qParam;
+                        geocode(localUrl).then(function (list) {
+                            if (list && list.length) { present(list, box.c); return; }
+                            geocode(globalUrl).then(function (g) { present(g, box.c); });
+                        });
                     }
 
                     toggle.addEventListener('click', function () {

--- a/src/NetworkOptimizer.Web/wwwroot/js/map-address-search.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/map-address-search.js
@@ -166,7 +166,7 @@
                         // Soft viewbox bias around the user (a padded regional box) when zoomed
                         // in: it lifts a nearby match above a more "prominent" same-named place
                         // elsewhere, without hard-excluding far results or overriding an explicit
-                        // region in the query (e.g. "atlanta, ga" still resolves to Georgia).
+                        // region in the query (e.g. "paris, tx" still resolves to Texas).
                         var url = GEOCODE_URL + '?format=jsonv2&addressdetails=1&limit=' + RESULT_LIMIT;
                         var box = localBox();
                         if (box) url += '&viewbox=' + boxParam(box);

--- a/src/NetworkOptimizer.Web/wwwroot/js/map-address-search.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/map-address-search.js
@@ -101,24 +101,11 @@
                         var b = map.getBounds();
                         var halfLat = Math.max(LOCAL_MIN_HALF_DEG, (b.getNorth() - b.getSouth()) / 2);
                         var halfLng = Math.max(LOCAL_MIN_HALF_DEG, (b.getEast() - b.getWest()) / 2);
-                        return { c: c, west: c.lng - halfLng, east: c.lng + halfLng, north: c.lat + halfLat, south: c.lat - halfLat };
+                        return { west: c.lng - halfLng, east: c.lng + halfLng, north: c.lat + halfLat, south: c.lat - halfLat };
                     }
                     function boxParam(box) {
                         return [box.west, box.north, box.east, box.south]
                             .map(function (n) { return n.toFixed(5); }).join(',');
-                    }
-
-                    // Squared distance in degrees (longitude scaled by latitude) - good enough for ranking.
-                    function sortByProximity(list, center) {
-                        var cosLat = Math.cos(center.lat * Math.PI / 180);
-                        return list.slice().sort(function (a, b) {
-                            function d2(h) {
-                                var dy = parseFloat(h.lat) - center.lat;
-                                var dx = (parseFloat(h.lon) - center.lng) * cosLat;
-                                return dx * dx + dy * dy;
-                            }
-                            return d2(a) - d2(b);
-                        });
                     }
 
                     function geocode(url) {
@@ -162,10 +149,9 @@
                         root.classList.add('is-open', 'is-error');
                     }
 
-                    function present(list, center) {
+                    function present(list) {
                         root.classList.remove('is-loading');
                         if (!list || !list.length) { showEmpty(); return; }
-                        if (center) list = sortByProximity(list, center);
                         if (list.length === 1) { selectResult(list[0]); return; }
                         renderResults(list);
                     }
@@ -177,21 +163,15 @@
                         closeResults();
                         root.classList.add('is-loading');
 
-                        var base = GEOCODE_URL + '?format=jsonv2&addressdetails=1&limit=' + RESULT_LIMIT;
-                        var qParam = '&q=' + encodeURIComponent(q);
-                        var globalUrl = base + qParam;
+                        // Soft viewbox bias around the user (a padded regional box) when zoomed
+                        // in: it lifts a nearby match above a more "prominent" same-named place
+                        // elsewhere, without hard-excluding far results or overriding an explicit
+                        // region in the query (e.g. "atlanta, ga" still resolves to Georgia).
+                        var url = GEOCODE_URL + '?format=jsonv2&addressdetails=1&limit=' + RESULT_LIMIT;
                         var box = localBox();
-
-                        if (!box) { geocode(globalUrl).then(function (list) { present(list, null); }); return; }
-
-                        // Local-first: hard-constrain to a box around the user, then fall back
-                        // to a global search if nothing matches nearby. Either way, rank by
-                        // proximity to the map center so the closest match leads.
-                        var localUrl = base + '&viewbox=' + boxParam(box) + '&bounded=1' + qParam;
-                        geocode(localUrl).then(function (list) {
-                            if (list && list.length) { present(list, box.c); return; }
-                            geocode(globalUrl).then(function (g) { present(g, box.c); });
-                        });
+                        if (box) url += '&viewbox=' + boxParam(box);
+                        url += '&q=' + encodeURIComponent(q);
+                        geocode(url).then(present);
                     }
 
                     toggle.addEventListener('click', function () {

--- a/src/NetworkOptimizer.Web/wwwroot/js/map-address-search.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/map-address-search.js
@@ -1,0 +1,135 @@
+// Collapsible address search control for Leaflet maps (Speed Test Map, Signal Map).
+// Geocodes via the public OpenStreetMap Nominatim service. Commercial use is permitted
+// with attribution; per the Nominatim usage policy we only geocode on submit (Enter or
+// icon click), never per keystroke, and rely on the browser-sent Referer to identify the app.
+(function () {
+    if (window.MapAddressSearch) return;
+
+    var GEOCODE_URL = 'https://nominatim.openstreetmap.org/search';
+
+    function searchIconSvg() {
+        return '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"'
+            + ' fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">'
+            + '<circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>';
+    }
+
+    function pinIcon(L) {
+        return L.divIcon({
+            className: 'map-addr-search-pin-wrap',
+            html: '<div class="map-addr-search-pin"></div>',
+            iconSize: [24, 24],
+            iconAnchor: [12, 12],
+            popupAnchor: [0, -14]
+        });
+    }
+
+    function escapeHtml(s) {
+        if (!s) return '';
+        var d = document.createElement('div');
+        d.textContent = s;
+        return d.innerHTML;
+    }
+
+    window.MapAddressSearch = {
+        /**
+         * Adds a collapsible address-search control to a Leaflet map.
+         * @param {L.Map} map - the Leaflet map instance
+         * @param {Object} [opts]
+         * @param {string} [opts.position='topright'] - Leaflet control corner
+         * @param {string} [opts.placeholder='Search address or place...']
+         * @param {number} [opts.zoom=18] - minimum zoom to apply when centering on a result
+         * @param {function(number, number, string)} [opts.onResult] - callback(lat, lng, displayName)
+         * @returns {L.Control|null}
+         */
+        add: function (map, opts) {
+            opts = opts || {};
+            if (typeof L === 'undefined' || !map) return null;
+
+            var placeholder = opts.placeholder || 'Search address or place...';
+            var targetZoom = opts.zoom || 18;
+
+            var SearchControl = L.Control.extend({
+                options: { position: opts.position || 'topright' },
+                onAdd: function () {
+                    var root = L.DomUtil.create('div', 'map-addr-search is-collapsed');
+                    root.innerHTML =
+                        '<input class="map-addr-search-input" type="text" autocomplete="off" spellcheck="false"'
+                        + ' placeholder="' + escapeHtml(placeholder) + '" aria-label="Search address or place" />'
+                        + '<button class="map-addr-search-toggle" type="button" aria-label="Search address"'
+                        + ' title="Search address">' + searchIconSvg() + '</button>';
+
+                    var input = root.querySelector('.map-addr-search-input');
+                    var toggle = root.querySelector('.map-addr-search-toggle');
+                    var marker = null;
+
+                    // Keep clicks/scroll on the control from reaching the map underneath.
+                    L.DomEvent.disableClickPropagation(root);
+                    L.DomEvent.disableScrollPropagation(root);
+
+                    function expand() {
+                        root.classList.remove('is-collapsed');
+                        setTimeout(function () { input.focus(); }, 60);
+                    }
+                    function collapse() {
+                        root.classList.add('is-collapsed');
+                        root.classList.remove('is-error');
+                        input.blur();
+                    }
+
+                    function doSearch() {
+                        var q = (input.value || '').trim();
+                        if (!q) { collapse(); return; }
+                        root.classList.remove('is-error');
+                        root.classList.add('is-loading');
+                        var url = GEOCODE_URL + '?format=jsonv2&limit=1&q=' + encodeURIComponent(q);
+                        fetch(url, { headers: { 'Accept': 'application/json' } })
+                            .then(function (r) { return r.ok ? r.json() : []; })
+                            .then(function (results) {
+                                root.classList.remove('is-loading');
+                                if (!results || !results.length) { root.classList.add('is-error'); return; }
+                                var hit = results[0];
+                                var lat = parseFloat(hit.lat), lng = parseFloat(hit.lon);
+                                if (isNaN(lat) || isNaN(lng)) { root.classList.add('is-error'); return; }
+                                var z = Math.min(Math.max(map.getZoom(), targetZoom), map.getMaxZoom() || targetZoom);
+                                map.setView([lat, lng], z, { animate: true });
+                                if (marker) map.removeLayer(marker);
+                                marker = L.marker([lat, lng], { icon: pinIcon(L) })
+                                    .addTo(map)
+                                    .bindPopup('<div class="map-addr-search-popup">' + escapeHtml(hit.display_name) + '</div>');
+                                marker.openPopup();
+                                if (typeof opts.onResult === 'function') opts.onResult(lat, lng, hit.display_name);
+                            })
+                            .catch(function () {
+                                root.classList.remove('is-loading');
+                                root.classList.add('is-error');
+                            });
+                    }
+
+                    toggle.addEventListener('click', function () {
+                        if (root.classList.contains('is-collapsed')) { expand(); return; }
+                        if ((input.value || '').trim()) doSearch();
+                        else collapse();
+                    });
+                    input.addEventListener('keydown', function (e) {
+                        if (e.key === 'Enter') { e.preventDefault(); doSearch(); }
+                        else if (e.key === 'Escape') { e.preventDefault(); collapse(); }
+                    });
+                    input.addEventListener('input', function () { root.classList.remove('is-error'); });
+
+                    // Collapse when the user starts interacting with the map, but only if the
+                    // field is empty so we never discard a half-typed query.
+                    map.on('mousedown', function () {
+                        if (!root.classList.contains('is-collapsed') && !(input.value || '').trim()) collapse();
+                    });
+
+                    this._root = root;
+                    return root;
+                }
+            });
+
+            var ctrl = new SearchControl();
+            map.addControl(ctrl);
+            return ctrl;
+        }
+    };
+})();

--- a/src/NetworkOptimizer.Web/wwwroot/js/map-address-search.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/map-address-search.js
@@ -6,6 +6,11 @@
     if (window.MapAddressSearch) return;
 
     var GEOCODE_URL = 'https://nominatim.openstreetmap.org/search';
+    var RESULT_LIMIT = 5;
+    // Only bias results toward the current map view once the user is zoomed into a
+    // region. Below this the default view is continent-wide (e.g. the US-wide zoom 4
+    // start), and biasing would drag a far-away user's search toward the wrong place.
+    var BIAS_MIN_ZOOM = 8;
 
     function searchIconSvg() {
         return '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"'
@@ -53,13 +58,17 @@
                 onAdd: function () {
                     var root = L.DomUtil.create('div', 'map-addr-search is-collapsed');
                     root.innerHTML =
-                        '<input class="map-addr-search-input" type="text" autocomplete="off" spellcheck="false"'
+                        '<div class="map-addr-search-bar">'
+                        + '<input class="map-addr-search-input" type="text" autocomplete="off" spellcheck="false"'
                         + ' placeholder="' + escapeHtml(placeholder) + '" aria-label="Search address or place" />'
                         + '<button class="map-addr-search-toggle" type="button" aria-label="Search address"'
-                        + ' title="Search address">' + searchIconSvg() + '</button>';
+                        + ' title="Search address">' + searchIconSvg() + '</button>'
+                        + '</div>'
+                        + '<div class="map-addr-search-results" role="listbox"></div>';
 
                     var input = root.querySelector('.map-addr-search-input');
                     var toggle = root.querySelector('.map-addr-search-toggle');
+                    var results = root.querySelector('.map-addr-search-results');
                     var marker = null;
 
                     // Keep clicks/scroll on the control from reaching the map underneath.
@@ -72,36 +81,77 @@
                     }
                     function collapse() {
                         root.classList.add('is-collapsed');
-                        root.classList.remove('is-error');
+                        root.classList.remove('is-error', 'is-open');
                         input.blur();
+                    }
+                    function closeResults() {
+                        root.classList.remove('is-open');
+                        results.innerHTML = '';
+                    }
+
+                    // Bias toward the current view only when zoomed into a region (see BIAS_MIN_ZOOM).
+                    function viewboxParam() {
+                        if (map.getZoom() < BIAS_MIN_ZOOM) return '';
+                        var b = map.getBounds();
+                        var box = [b.getWest(), b.getNorth(), b.getEast(), b.getSouth()]
+                            .map(function (n) { return n.toFixed(5); }).join(',');
+                        return '&viewbox=' + box; // soft bias - no &bounded=1, so far results still resolve
+                    }
+
+                    function selectResult(hit) {
+                        var lat = parseFloat(hit.lat), lng = parseFloat(hit.lon);
+                        if (isNaN(lat) || isNaN(lng)) return;
+                        closeResults();
+                        var z = Math.min(Math.max(map.getZoom(), targetZoom), map.getMaxZoom() || targetZoom);
+                        if (marker) map.removeLayer(marker);
+                        marker = L.marker([lat, lng], { icon: pinIcon(L) })
+                            .addTo(map)
+                            // autoPan:false so opening the popup doesn't shove the result off-center
+                            .bindPopup('<div class="map-addr-search-popup">' + escapeHtml(hit.display_name) + '</div>',
+                                { autoPan: false });
+                        marker.openPopup();
+                        // Center last so the popup auto-pan can't pull us off the result.
+                        map.setView([lat, lng], z, { animate: true });
+                        if (typeof opts.onResult === 'function') opts.onResult(lat, lng, hit.display_name);
+                    }
+
+                    function renderResults(list) {
+                        results.innerHTML = '';
+                        list.forEach(function (hit) {
+                            var row = document.createElement('div');
+                            row.className = 'map-addr-search-result';
+                            row.setAttribute('role', 'option');
+                            row.textContent = hit.display_name;
+                            row.addEventListener('click', function () { selectResult(hit); });
+                            results.appendChild(row);
+                        });
+                        root.classList.add('is-open');
+                    }
+
+                    function showEmpty() {
+                        results.innerHTML = '<div class="map-addr-search-empty">No matches found</div>';
+                        root.classList.add('is-open', 'is-error');
                     }
 
                     function doSearch() {
                         var q = (input.value || '').trim();
                         if (!q) { collapse(); return; }
                         root.classList.remove('is-error');
+                        closeResults();
                         root.classList.add('is-loading');
-                        var url = GEOCODE_URL + '?format=jsonv2&limit=1&q=' + encodeURIComponent(q);
+                        var url = GEOCODE_URL + '?format=jsonv2&addressdetails=1&limit=' + RESULT_LIMIT
+                            + viewboxParam() + '&q=' + encodeURIComponent(q);
                         fetch(url, { headers: { 'Accept': 'application/json' } })
                             .then(function (r) { return r.ok ? r.json() : []; })
-                            .then(function (results) {
+                            .then(function (list) {
                                 root.classList.remove('is-loading');
-                                if (!results || !results.length) { root.classList.add('is-error'); return; }
-                                var hit = results[0];
-                                var lat = parseFloat(hit.lat), lng = parseFloat(hit.lon);
-                                if (isNaN(lat) || isNaN(lng)) { root.classList.add('is-error'); return; }
-                                var z = Math.min(Math.max(map.getZoom(), targetZoom), map.getMaxZoom() || targetZoom);
-                                map.setView([lat, lng], z, { animate: true });
-                                if (marker) map.removeLayer(marker);
-                                marker = L.marker([lat, lng], { icon: pinIcon(L) })
-                                    .addTo(map)
-                                    .bindPopup('<div class="map-addr-search-popup">' + escapeHtml(hit.display_name) + '</div>');
-                                marker.openPopup();
-                                if (typeof opts.onResult === 'function') opts.onResult(lat, lng, hit.display_name);
+                                if (!list || !list.length) { showEmpty(); return; }
+                                if (list.length === 1) { selectResult(list[0]); return; }
+                                renderResults(list);
                             })
                             .catch(function () {
                                 root.classList.remove('is-loading');
-                                root.classList.add('is-error');
+                                showEmpty();
                             });
                     }
 
@@ -112,9 +162,12 @@
                     });
                     input.addEventListener('keydown', function (e) {
                         if (e.key === 'Enter') { e.preventDefault(); doSearch(); }
-                        else if (e.key === 'Escape') { e.preventDefault(); collapse(); }
+                        else if (e.key === 'Escape') { e.preventDefault(); closeResults(); collapse(); }
                     });
-                    input.addEventListener('input', function () { root.classList.remove('is-error'); });
+                    input.addEventListener('input', function () {
+                        root.classList.remove('is-error');
+                        if (root.classList.contains('is-open')) closeResults();
+                    });
 
                     // Collapse when the user starts interacting with the map, but only if the
                     // field is empty so we never discard a half-typed query.


### PR DESCRIPTION
## What

Adds a collapsible address-search control to the Speed Test Map and the Signal Map (Floor Plan Editor), so you can jump the map to a street address or place name instead of panning by hand.

- Magnifying-glass toggle in the top-right that expands to a search field, matching the collapsible-control pattern used on the LAN Live View maps.
- Geocoding via OpenStreetMap Nominatim (free, commercial use permitted with attribution). Queries run only on submit (Enter or icon click), never per keystroke, to stay within the usage policy.
- A single result centers and drops a pin automatically; multiple results show a picker dropdown.
- Lays out on both desktop and mobile (field and dropdown clamp to viewport width under 768 px).

## Location bias

When you're zoomed into a region (zoom ≥ 8), the search is softly biased toward the visible area via a padded `viewbox`, so a nearby match floats above a more "prominent" same-named place elsewhere. The bias is soft (no hard `bounded` filter, no client-side re-sort), so an explicit region in the query still resolves correctly. Below zoom 8 (the continent-wide default view) no bias is applied, so a user starting at the default view isn't dragged toward the wrong place.

## Files

- `js/map-address-search.js` - shared `window.MapAddressSearch.add(map, opts)` control, reused by both maps
- `css/app.css` - styles for the collapsible bar, results dropdown, pin, and loading spinner
- `App.razor` - loads the shared script
- `SpeedTestMap.razor`, `floorPlanEditor.js` - wire the control into each map

User-rendered text (result names, popups) is HTML-escaped before display.
