### PR TITLE
v1.22.3 - Satellite imagery, address search UX, and Signal map Esc

### DIFF
--- a/src/NetworkOptimizer.Storage/Models/SystemSetting.cs
+++ b/src/NetworkOptimizer.Storage/Models/SystemSetting.cs
@@ -56,4 +56,7 @@ public static class SystemSettingKeys
 
     // Monitoring Live View map order ("3d-first" or "2d-first")
     public const string MonitoringLiveMapOrder = "ui.monitoring_live_map_order";
+
+    // Map / Satellite settings
+    public const string MapboxApiKey = "map.mapbox_token";
 }

--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -104,6 +104,7 @@
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/updateCheck.js")"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/steppedScaleBar.js")"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/map-address-search.js")"></script>
+    <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/map-satellite.js")"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "lib/heic2any.min.js")"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/floorPlanEditor.js")"></script>
     @if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DEMO_MODE_MAPPINGS")))

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -2309,7 +2309,60 @@
         </div>
     </div>
 
-    <!-- 13. Data Management -->
+    <!-- 13. Map / Satellite -->
+    <div class="card" id="map">
+        <div class="card-header">
+            <h2 class="card-title">Satellite Imagery</h2>
+            <span class="status-badge status-@(!string.IsNullOrEmpty(_mapboxToken) ? "connected" : "")">
+                @(!string.IsNullOrEmpty(_mapboxToken) ? "Mapbox (commercial)" : "Esri (non-commercial)")
+            </span>
+        </div>
+        <div class="card-body">
+            <p class="section-description">
+                The satellite toggle on the Speed Test and Signal maps works out of the box using
+                <a href="https://www.arcgis.com/home/item.html?id=10df2279f9684e4a9f6a7f08febac2a9" target="_blank" rel="noopener">Esri World Imagery</a>,
+                which needs no account or API key.
+            </p>
+            <div class="alert alert-warning" style="margin-bottom: 1rem;">
+                <strong>Non-commercial use only.</strong> The built-in Esri imagery is free for personal,
+                non-commercial use. If you use this app commercially, do not rely on it - add a Mapbox token
+                below to switch the satellite layer to commercially licensed imagery.
+            </div>
+            <div class="form-group">
+                <label class="form-label">Mapbox Public Token <span class="form-help">(optional - for commercial use)</span></label>
+                <input type="password" class="form-control" @bind="_mapboxToken" placeholder="pk.eyJ..." autocomplete="new-password" data-1p-ignore data-lpignore="true" data-bwignore />
+                <small class="form-help">
+                    Create a <a href="https://account.mapbox.com/access-tokens/" target="_blank" rel="noopener">Mapbox public token</a>
+                    (scope it to your domain). Used client-side only. When set, the satellite layer uses Mapbox instead of Esri.
+                </small>
+            </div>
+            <div class="action-buttons">
+                <button class="btn btn-primary" @onclick="SaveMapboxToken" disabled="@_savingMapboxToken">
+                    @if (_savingMapboxToken)
+                    {
+                        <span class="spinner"></span>
+                        <span>Saving...</span>
+                    }
+                    else
+                    {
+                        <span>Save Token</span>
+                    }
+                </button>
+                @if (!string.IsNullOrEmpty(_mapboxToken))
+                {
+                    <button class="btn btn-secondary" @onclick="ClearMapboxToken" disabled="@_savingMapboxToken">
+                        Clear Token
+                    </button>
+                }
+            </div>
+            @if (!string.IsNullOrEmpty(_mapboxTokenMessage))
+            {
+                <div class="alert alert-@_mapboxTokenMessageClass">@_mapboxTokenMessage</div>
+            }
+        </div>
+    </div>
+
+    <!-- 14. Data Management -->
     <div class="card">
         <div class="card-header">
             <h2 class="card-title">Data Management</h2>
@@ -2755,6 +2808,12 @@
     private string crowdsecMessage = "";
     private string crowdsecMessageClass = "";
 
+    // Map / Satellite settings
+    private string _mapboxToken = "";
+    private bool _savingMapboxToken = false;
+    private string _mapboxTokenMessage = "";
+    private string _mapboxTokenMessageClass = "";
+
     // UI / Display Settings - per-device, persisted in localStorage (not the DB)
     private bool _kioskMode = false;
 
@@ -2806,6 +2865,7 @@
         await LoadAlertChannels();
         await LoadThreatSettings();
         await LoadMonitoringSettings();
+        await LoadMapboxToken();
     }
 
     private async Task LoadIperf3Settings()
@@ -5487,6 +5547,58 @@
         finally
         {
             testingCrowdsec = false;
+        }
+    }
+
+    private async Task LoadMapboxToken()
+    {
+        _mapboxToken = await SystemSettings.GetAsync(SystemSettingKeys.MapboxApiKey) ?? "";
+    }
+
+    private async Task SaveMapboxToken()
+    {
+        _savingMapboxToken = true;
+        _mapboxTokenMessage = "";
+        StateHasChanged();
+        try
+        {
+            await SystemSettings.SetAsync(SystemSettingKeys.MapboxApiKey, string.IsNullOrWhiteSpace(_mapboxToken) ? null : _mapboxToken.Trim());
+            _mapboxTokenMessage = "Mapbox token saved. Reload any open maps to apply.";
+            _mapboxTokenMessageClass = "success";
+        }
+        catch (Exception ex)
+        {
+            _mapboxTokenMessage = $"Error saving token: {ex.Message}";
+            _mapboxTokenMessageClass = "danger";
+        }
+        finally
+        {
+            _savingMapboxToken = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task ClearMapboxToken()
+    {
+        _savingMapboxToken = true;
+        _mapboxTokenMessage = "";
+        StateHasChanged();
+        try
+        {
+            await SystemSettings.SetAsync(SystemSettingKeys.MapboxApiKey, null);
+            _mapboxToken = "";
+            _mapboxTokenMessage = "Mapbox token cleared.";
+            _mapboxTokenMessageClass = "success";
+        }
+        catch (Exception ex)
+        {
+            _mapboxTokenMessage = $"Error clearing token: {ex.Message}";
+            _mapboxTokenMessageClass = "danger";
+        }
+        finally
+        {
+            _savingMapboxToken = false;
+            StateHasChanged();
         }
     }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestMap.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestMap.razor
@@ -11,6 +11,7 @@
 @inject IJSRuntime JS
 @inject UniFiConnectionService ConnectionService
 @inject Iperf3SpeedTestService SpeedTestService
+@inject SystemSettingsService SystemSettings
 
 @if (HasAnyMapData)
 {
@@ -620,6 +621,8 @@
                 await Task.Delay(100);
             }
 
+            var _mapboxToken = await SystemSettings.GetAsync(SystemSettingKeys.MapboxApiKey) ?? "";
+
             // Initialize the map using inline JS
             await JS.InvokeVoidAsync("eval", $@"
                 (function() {{
@@ -639,7 +642,7 @@
                         : 'https://{{s}}.tile.openstreetmap.org/{{z}}/{{x}}/{{y}}.png';
                     const tileAttribution = isDemoMode ? '© CartoDB © OpenStreetMap' : '© OpenStreetMap';
                     const maxNative = isDemoMode ? 18 : 19;
-                    L.tileLayer(tileUrl, {{
+                    const osmLayer = L.tileLayer(tileUrl, {{
                         maxZoom: 22,
                         maxNativeZoom: maxNative,
                         attribution: tileAttribution
@@ -805,6 +808,11 @@
                     // Stepped distance scale bar
                     if (typeof SteppedScaleBar !== 'undefined') {{
                         window._speedTestMaps['{mapId}'].scaleBar = SteppedScaleBar.create(map, 3);
+                    }}
+
+                    // Satellite toggle (bottom-left, above scale bar — added after scale bar so it stacks on top)
+                    if (window.MapSatelliteToggle && !isDemoMode) {{
+                        window.MapSatelliteToggle.add(map, osmLayer, {System.Text.Json.JsonSerializer.Serialize(_mapboxToken)});
                     }}
 
                     // Collapsible address search (top-right)

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/FloorPlanEditor.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/FloorPlanEditor.razor
@@ -8,6 +8,7 @@
 @using NetworkOptimizer.UniFi.Models
 @using Microsoft.JSInterop
 @using NetworkOptimizer.Core.Helpers
+@inject SystemSettingsService SystemSettings
 @inject FloorPlanService FloorPlanSvc
 @inject ApMapService ApMapSvc
 @inject PlannedApService PlannedApSvc
@@ -1823,7 +1824,8 @@
             }
         }
 
-        await JS.InvokeVoidAsync("fpEditor.initMap", _mapId, centerLat, centerLng, zoom);
+        var mapboxToken = await SystemSettings.GetAsync(SystemSettingKeys.MapboxApiKey) ?? "";
+        await JS.InvokeVoidAsync("fpEditor.initMap", _mapId, centerLat, centerLng, zoom, mapboxToken);
         await JS.InvokeVoidAsync("fpEditor.setDotNetRef", _dotNetRef);
         _mapInitialized = true;
 

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/FloorPlanEditor.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/FloorPlanEditor.razor
@@ -3952,6 +3952,8 @@
             await TogglePlanApMode();
         else if (_selectedBuilding != null)
             await DeselectBuilding();
+        else if (_isFullscreen)
+            await ToggleFullscreen();
         StateHasChanged();
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14824,6 +14824,26 @@ tr.stats-row-filtered {
     color: var(--text-primary);
     background: rgba(255, 255, 255, 0.06);
 }
+.map-addr-search-clear {
+    flex-shrink: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 34px;
+    padding: 0;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: var(--text-muted);
+    transition: color 0.15s ease;
+}
+.map-addr-search.is-dirty:not(.is-collapsed) .map-addr-search-clear {
+    display: flex;
+}
+.map-addr-search-clear:hover {
+    color: var(--text-primary);
+}
 .map-addr-search.is-loading .map-addr-search-toggle svg {
     opacity: 0;
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -14905,6 +14905,119 @@ tr.stats-row-filtered {
     }
 }
 
+/* Satellite tile toggle button (bottom-left, above scale bar) */
+.map-sat-ctrl {
+    position: relative;
+    /* Leaflet stacks bottom-left controls tight together; add a gap above the scale bar */
+    margin-bottom: 8px !important;
+    border: none;
+    background: transparent;
+    box-shadow: none;
+}
+.map-sat-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    background: rgba(16, 24, 32, 0.82);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 4px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.map-sat-btn:hover {
+    background: rgba(30, 40, 55, 0.92);
+    color: var(--text-primary);
+    border-color: rgba(255, 255, 255, 0.2);
+}
+.map-sat-btn.is-active {
+    background: rgba(5, 89, 201, 0.35);
+    border-color: var(--primary-color);
+    color: #fff;
+}
+/* One-time non-commercial confirm dialog for the free Esri satellite layer */
+.map-sat-confirm-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 10001;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.55);
+    padding: 1rem;
+}
+.map-sat-confirm {
+    background: var(--bg-card);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 10px;
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.45);
+    max-width: 420px;
+    width: 100%;
+    padding: 1.25rem 1.4rem;
+}
+.map-sat-confirm h3 {
+    margin: 0 0 0.6rem;
+    font-size: 1.05rem;
+    color: var(--text-primary);
+}
+.map-sat-confirm p {
+    margin: 0 0 1.1rem;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    color: var(--text-secondary);
+}
+.map-sat-confirm-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+}
+
+/* Leaflet zoom buttons on the Signal / floor plan and Speed Test maps —
+   styled to match the 2D topology map */
+.fp-map-container .leaflet-control-zoom a,
+.map-container .leaflet-control-zoom a {
+    width: 32px;
+    height: 32px;
+    line-height: 32px;
+    font-size: 16px;
+    background: rgba(26, 29, 35, 0.9);
+    color: var(--text-secondary);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 6px !important;
+}
+.fp-map-container .leaflet-control-zoom a:hover,
+.map-container .leaflet-control-zoom a:hover {
+    background: rgba(51, 56, 68, 0.9);
+    color: var(--text-primary);
+}
+/* Disabled state at min/max zoom — muted, no hover lift */
+.fp-map-container .leaflet-control-zoom a.leaflet-disabled,
+.map-container .leaflet-control-zoom a.leaflet-disabled,
+.fp-map-container .leaflet-control-zoom a.leaflet-disabled:hover,
+.map-container .leaflet-control-zoom a.leaflet-disabled:hover {
+    background: rgba(26, 29, 35, 0.6);
+    color: var(--text-muted);
+    cursor: default;
+}
+/* Leaflet's .leaflet-touch .leaflet-bar adds a 2px outer border; its CSS is injected
+   after app.css, so we need the extra .leaflet-touch class to win specificity. */
+.fp-map-container .leaflet-touch .leaflet-bar,
+.map-container .leaflet-touch .leaflet-bar,
+.fp-map-container .leaflet-bar,
+.map-container .leaflet-bar {
+    border: none;
+    box-shadow: none;
+}
+/* Gap between the stacked + and - buttons, matching the 2D map's 4px */
+.fp-map-container .leaflet-control-zoom-in,
+.map-container .leaflet-control-zoom-in {
+    margin-bottom: 4px;
+}
+
 .lan-flow-map-chips {
     display: flex;
     flex-wrap: wrap;

--- a/src/NetworkOptimizer.Web/wwwroot/js/floorPlanEditor.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/floorPlanEditor.js
@@ -219,7 +219,7 @@ window.fpEditor = {
 
     // ── Map Initialization ───────────────────────────────────────────
 
-    initMap: function (containerId, centerLat, centerLng, zoom) {
+    initMap: function (containerId, centerLat, centerLng, zoom, mapboxToken) {
         var self = this;
         this._txPowerOverrides = {};
         this._antennaModeOverrides = {};
@@ -269,7 +269,7 @@ window.fpEditor = {
             if (!container) { setTimeout(init, 100); return; }
 
             var m = L.map(containerId, { center: [centerLat, centerLng], zoom: zoom, zoomControl: true, maxZoom: 24, zoomSnap: 0.5, zoomDelta: zoom >= 21 ? 0.5 : 1 });
-            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            var osmLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
                 maxZoom: 24, maxNativeZoom: 19, attribution: 'OpenStreetMap'
             }).addTo(m);
             self._map = m;
@@ -415,6 +415,11 @@ window.fpEditor = {
             // Stepped distance scale bar (3 steps normal, 5 fullscreen, hidden on mobile non-fullscreen)
             var initSteps = (window.innerWidth <= 768) ? 0 : 3;
             self._scaleBar = SteppedScaleBar.create(m, initSteps);
+
+            // Satellite toggle (bottom-left) — added after the scale bar so it stacks above it
+            if (window.MapSatelliteToggle) {
+                window.MapSatelliteToggle.add(m, osmLayer, mapboxToken || '');
+            }
 
             // Collapsible address search (top-right) - jump the floor plan to a street address
             if (window.MapAddressSearch) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/map-address-search.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/map-address-search.js
@@ -45,7 +45,6 @@
          * @param {Object} [opts]
          * @param {string} [opts.position='topright'] - Leaflet control corner
          * @param {string} [opts.placeholder='Search address or place...']
-         * @param {number} [opts.zoom=18] - minimum zoom to apply when centering on a result
          * @param {function(number, number, string)} [opts.onResult] - callback(lat, lng, displayName)
          * @returns {L.Control|null}
          */
@@ -54,7 +53,6 @@
             if (typeof L === 'undefined' || !map) return null;
 
             var placeholder = opts.placeholder || 'Search address or place...';
-            var targetZoom = opts.zoom || 18;
 
             var SearchControl = L.Control.extend({
                 options: { position: opts.position || 'topright' },
@@ -114,11 +112,52 @@
                             .catch(function () { return []; });
                     }
 
+                    // addresstype drives zoom; place_rank covers types without a clean addresstype
+                    // (e.g. roads, interpolated house numbers). Berlin is a city-state with
+                    // place_rank 8 but addresstype "city" — addresstype gives the right answer.
+                    function zoomForResult(hit) {
+                        var at = (hit.addresstype || '').toLowerCase();
+                        if (at === 'shop')                                                               return 19;
+                        if (at === 'amenity' || at === 'tourism')                                        return 17;
+                        if (at === 'building')                                                           return 20;
+                        if (at === 'aeroway')                                                            return 15;
+                        if (at === 'park')                                                               return 15;
+                        if (at === 'nature_reserve')                                                     return 10;
+                        // Specific address / street
+                        if (at === 'house')                                                              return 20;
+                        if (at === 'road' || at === 'path' || at === 'footway' || at === 'cycleway')    return 17;
+                        // Sub-city areas
+                        if (at === 'suburb' || at === 'neighbourhood' || at === 'quarter')              return 15;
+                        // Settlements (largest to smallest)
+                        if (at === 'city' || at === 'municipality')                                     return 13;
+                        if (at === 'town')                                                               return 14;
+                        if (at === 'village')                                                            return 16;
+                        if (at === 'hamlet' || at === 'isolated_dwelling' || at === 'farm')             return 17;
+                        // Natural features — zoom out enough to see surroundings
+                        if (at === 'peak' || at === 'valley' || at === 'ridge')                        return 14;
+                        if (at === 'river' || at === 'stream' || at === 'water' || at === 'bay')       return 13;
+                        // Areas (parks, forests, lakes) — zoom like a county
+                        if (at === 'landuse' || at === 'natural' || at === 'leisure' || at === 'protected_area') return 11;
+                        // Admin boundaries
+                        if (at === 'county' || at === 'district')                                       return 11;
+                        if (at === 'state' || at === 'region')                                          return 8;
+                        if (at === 'country')                                                            return 5;
+                        // Fallback for anything not matched above.
+                        var rank = hit.place_rank || 0;
+                        if (rank >= 30) return 20;
+                        if (rank >= 26) return 17;
+                        if (rank >= 22) return 15;
+                        if (rank >= 16) return 13;
+                        if (rank >= 12) return 11;
+                        if (rank >= 8)  return 8;
+                        return 5;
+                    }
+
                     function selectResult(hit) {
                         var lat = parseFloat(hit.lat), lng = parseFloat(hit.lon);
                         if (isNaN(lat) || isNaN(lng)) return;
                         closeResults();
-                        var z = Math.min(Math.max(map.getZoom(), targetZoom), map.getMaxZoom() || targetZoom);
+                        var z = Math.min(zoomForResult(hit), map.getMaxZoom() || 24);
                         if (marker) map.removeLayer(marker);
                         marker = L.marker([lat, lng], { icon: pinIcon(L) })
                             .addTo(map)
@@ -156,6 +195,21 @@
                         renderResults(list);
                     }
 
+                    // Grid-style addresses (e.g. "1234 N 5678 W") use a cardinal direction
+                    // between the house number and the street number. Nominatim often fails to
+                    // match these but succeeds when the cardinal is omitted ("1234 5678 W").
+                    var GRID_ADDR_RE = /^(\d+)\s+(?:North|South|East|West|N|S|E|W)\b\s+(.*)/i;
+
+                    function buildUrl(q, box) {
+                        var url = GEOCODE_URL + '?format=jsonv2&addressdetails=1&limit=' + RESULT_LIMIT;
+                        if (box) url += '&viewbox=' + boxParam(box);
+                        return url + '&q=' + encodeURIComponent(q);
+                    }
+
+                    function hasHouseMatch(list) {
+                        return list.some(function (h) { return (h.place_rank || 0) >= 30; });
+                    }
+
                     function doSearch() {
                         var q = (input.value || '').trim();
                         if (!q) { collapse(); return; }
@@ -167,11 +221,23 @@
                         // in: it lifts a nearby match above a more "prominent" same-named place
                         // elsewhere, without hard-excluding far results or overriding an explicit
                         // region in the query (e.g. "paris, tx" still resolves to Texas).
-                        var url = GEOCODE_URL + '?format=jsonv2&addressdetails=1&limit=' + RESULT_LIMIT;
                         var box = localBox();
-                        if (box) url += '&viewbox=' + boxParam(box);
-                        url += '&q=' + encodeURIComponent(q);
-                        geocode(url).then(present);
+                        geocode(buildUrl(q, box)).then(function (list) {
+                            // If the first pass returned results but none are a specific house
+                            // match, and the query looks like a grid-style address with a cardinal
+                            // direction after the house number, retry without the cardinal.
+                            // e.g. "1234 N 5678 W" -> "1234 5678 W"
+                            if (list && list.length && !hasHouseMatch(list)) {
+                                var m = q.match(GRID_ADDR_RE);
+                                if (m) {
+                                    var fallback = (m[1] + ' ' + m[2]).trim();
+                                    return geocode(buildUrl(fallback, box)).then(function (fb) {
+                                        present(fb && fb.length ? fb : list);
+                                    });
+                                }
+                            }
+                            present(list);
+                        });
                     }
 
                     toggle.addEventListener('click', function () {

--- a/src/NetworkOptimizer.Web/wwwroot/js/map-address-search.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/map-address-search.js
@@ -21,6 +21,12 @@
             + '<circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>';
     }
 
+    function clearIconSvg() {
+        return '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"'
+            + ' fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">'
+            + '<line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>';
+    }
+
     function pinIcon(L) {
         return L.divIcon({
             className: 'map-addr-search-pin-wrap',
@@ -62,12 +68,15 @@
                         '<div class="map-addr-search-bar">'
                         + '<input class="map-addr-search-input" type="text" autocomplete="off" spellcheck="false"'
                         + ' placeholder="' + escapeHtml(placeholder) + '" aria-label="Search address or place" />'
+                        + '<button class="map-addr-search-clear" type="button" aria-label="Clear search"'
+                        + ' title="Clear" tabindex="-1">' + clearIconSvg() + '</button>'
                         + '<button class="map-addr-search-toggle" type="button" aria-label="Search address"'
                         + ' title="Search address">' + searchIconSvg() + '</button>'
                         + '</div>'
                         + '<div class="map-addr-search-results" role="listbox"></div>';
 
                     var input = root.querySelector('.map-addr-search-input');
+                    var clearBtn = root.querySelector('.map-addr-search-clear');
                     var toggle = root.querySelector('.map-addr-search-toggle');
                     var results = root.querySelector('.map-addr-search-results');
                     var marker = null;
@@ -88,6 +97,22 @@
                     function closeResults() {
                         root.classList.remove('is-open');
                         results.innerHTML = '';
+                    }
+                    // Remove the dropped result pin (and its popup) from the map, if any.
+                    function removeMarker() {
+                        if (marker) { map.removeLayer(marker); marker = null; }
+                    }
+                    // Show the clear (X) button only while the field holds text.
+                    function syncClear() {
+                        root.classList.toggle('is-dirty', !!(input.value || '').trim());
+                    }
+                    // Empty the field, drop the result pin, and reset to a fresh search.
+                    function clearInput() {
+                        input.value = '';
+                        syncClear();
+                        closeResults();
+                        removeMarker();
+                        root.classList.remove('is-error');
                     }
 
                     // A regional box around the current map center, used to constrain the
@@ -245,12 +270,32 @@
                         if ((input.value || '').trim()) doSearch();
                         else collapse();
                     });
+                    // Clear (X): empty the field but stay expanded and focused.
+                    clearBtn.addEventListener('click', function () {
+                        clearInput();
+                        input.focus();
+                    });
                     input.addEventListener('keydown', function (e) {
                         if (e.key === 'Enter') { e.preventDefault(); doSearch(); }
-                        else if (e.key === 'Escape') { e.preventDefault(); closeResults(); collapse(); }
+                        else if (e.key === 'Escape') {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            // Staged dismissal, one level per press: close the results
+                            // popup -> clear the text -> collapse the control.
+                            if (root.classList.contains('is-open')) {
+                                closeResults();
+                            } else if ((input.value || '').trim()) {
+                                clearInput();
+                            } else {
+                                collapse();
+                            }
+                        }
                     });
                     input.addEventListener('input', function () {
                         root.classList.remove('is-error');
+                        syncClear();
+                        // Deleting the query down to empty also dismisses the result pin.
+                        if (!(input.value || '').trim()) removeMarker();
                         if (root.classList.contains('is-open')) closeResults();
                     });
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/map-satellite.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/map-satellite.js
@@ -1,0 +1,151 @@
+// Satellite tile toggle control for Leaflet maps (Speed Test Map, Signal Map).
+// Switches between the OSM base layer and a satellite layer.
+//
+// Provider selection:
+//   - No Mapbox token configured: uses Esri World Imagery, which needs no API key
+//     and no signup. It is free for NON-COMMERCIAL use only (attribution required).
+//   - Mapbox token configured (Settings > Satellite Imagery): uses Mapbox satellite,
+//     which is licensed for commercial use under the account's plan. This lets
+//     commercial users enable satellite without relying on the non-commercial Esri tiles.
+(function () {
+    if (window.MapSatelliteToggle) return;
+
+    var ESRI_TILE = 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}';
+    var ESRI_ATTR = 'Imagery &copy; <a href="https://www.esri.com" target="_blank" rel="noopener">Esri</a>,'
+                  + ' Maxar, Earthstar Geographics &mdash; non-commercial use only';
+
+    var MAPBOX_TILE = 'https://api.mapbox.com/styles/v1/mapbox/satellite-v9/tiles/256/{z}/{x}/{y}@2x?access_token=';
+    var MAPBOX_ATTR = '&copy; <a href="https://www.mapbox.com/about/maps/" target="_blank" rel="noopener">Mapbox</a>'
+                    + ' &copy; <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">OpenStreetMap</a>';
+
+    function layersIcon() {
+        return '<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24"'
+            + ' fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">'
+            + '<polygon points="12 2 2 7 12 12 22 7 12 2"/>'
+            + '<polyline points="2 17 12 22 22 17"/>'
+            + '<polyline points="2 12 12 17 22 12"/>'
+            + '</svg>';
+    }
+
+    function buildSatLayer(mapboxToken) {
+        if (mapboxToken) {
+            return L.tileLayer(MAPBOX_TILE + mapboxToken, {
+                maxZoom: 24, maxNativeZoom: 22, tileSize: 256, attribution: MAPBOX_ATTR
+            });
+        }
+        return L.tileLayer(ESRI_TILE, {
+            maxZoom: 24, maxNativeZoom: 19, attribution: ESRI_ATTR
+        });
+    }
+
+    // One-time, per-browser acknowledgement that the built-in (Esri) imagery is
+    // non-commercial. Only relevant when no Mapbox token is set; once a server-side
+    // token is configured the confirm never shows, so per-browser scope is fine.
+    var ACK_KEY = 'networkOptimizerSatelliteNonCommercialAck';
+    function ackGiven() {
+        try { return localStorage.getItem(ACK_KEY) === '1'; } catch (e) { return false; }
+    }
+    function setAck() {
+        try { localStorage.setItem(ACK_KEY, '1'); } catch (e) { }
+    }
+
+    // Styled confirm shown the first time a user enables the free non-commercial
+    // imagery. Resolves true if they accept, false on cancel/backdrop/Escape.
+    function confirmNonCommercial() {
+        return new Promise(function (resolve) {
+            var backdrop = document.createElement('div');
+            backdrop.className = 'map-sat-confirm-backdrop';
+            backdrop.innerHTML =
+                '<div class="map-sat-confirm" role="dialog" aria-modal="true" aria-labelledby="map-sat-confirm-title">'
+                + '<h3 id="map-sat-confirm-title">Enable satellite imagery?</h3>'
+                + '<p>The built-in satellite imagery (Esri World Imagery) is free for <strong>personal,'
+                + ' non-commercial use only</strong>. If you use Network Optimizer commercially (an MSP,'
+                + ' installer, or any paid-service delivery), add a Mapbox token in Settings to use'
+                + ' commercially licensed imagery instead.</p>'
+                + '<div class="map-sat-confirm-actions">'
+                + '<button class="btn btn-secondary" data-act="cancel" type="button">Cancel</button>'
+                + '<button class="btn btn-primary" data-act="ok" type="button">I understand, continue</button>'
+                + '</div></div>';
+
+            function close(result) {
+                document.removeEventListener('keydown', onKey, true);
+                backdrop.remove();
+                resolve(result);
+            }
+            function onKey(e) {
+                if (e.key === 'Escape') { e.preventDefault(); close(false); }
+            }
+            backdrop.addEventListener('click', function (e) {
+                if (e.target === backdrop) { close(false); return; }
+                var act = e.target.getAttribute('data-act');
+                if (act === 'ok') close(true);
+                else if (act === 'cancel') close(false);
+            });
+            document.addEventListener('keydown', onKey, true);
+            document.body.appendChild(backdrop);
+        });
+    }
+
+    window.MapSatelliteToggle = {
+        /**
+         * Adds a satellite toggle button to a Leaflet map (bottom-left, above the scale bar).
+         * @param {L.Map} map
+         * @param {L.TileLayer} osmLayer - the existing OSM base layer to swap in/out
+         * @param {string} mapboxToken - optional Mapbox token; empty = use free Esri imagery
+         */
+        add: function (map, osmLayer, mapboxToken) {
+            if (typeof L === 'undefined' || !map) return;
+
+            var SatControl = L.Control.extend({
+                options: { position: 'bottomleft' },
+                onAdd: function () {
+                    var root = L.DomUtil.create('div', 'map-sat-ctrl');
+                    L.DomEvent.disableClickPropagation(root);
+                    L.DomEvent.disableScrollPropagation(root);
+
+                    var btn = document.createElement('button');
+                    btn.className = 'map-sat-btn';
+                    btn.type = 'button';
+                    btn.setAttribute('aria-label', 'Toggle satellite view');
+                    btn.setAttribute('title', 'Satellite view');
+                    btn.innerHTML = layersIcon();
+                    root.appendChild(btn);
+
+                    var satLayer = null;
+                    var active = false;
+                    var token = mapboxToken || '';
+
+                    function enableSat() {
+                        if (!satLayer) satLayer = buildSatLayer(token);
+                        map.removeLayer(osmLayer);
+                        satLayer.addTo(map);
+                        satLayer.bringToBack();
+                        btn.classList.add('is-active');
+                        active = true;
+                    }
+                    function disableSat() {
+                        if (satLayer) map.removeLayer(satLayer);
+                        osmLayer.addTo(map);
+                        osmLayer.bringToBack();
+                        btn.classList.remove('is-active');
+                        active = false;
+                    }
+
+                    btn.addEventListener('click', function () {
+                        if (active) { disableSat(); return; }
+                        // Licensed (token) or already acknowledged: switch immediately.
+                        if (token || ackGiven()) { enableSat(); return; }
+                        // First time on the free non-commercial layer: confirm once.
+                        confirmNonCommercial().then(function (ok) {
+                            if (ok) { setAck(); enableSat(); }
+                        });
+                    });
+
+                    return root;
+                }
+            });
+
+            map.addControl(new SatControl());
+        }
+    };
+})();


### PR DESCRIPTION
Release changes for v1.22.3.

## Satellite imagery

- Satellite toggle on the Speed Test and Signal maps, swapping the OSM base layer for satellite imagery.
- Works out of the box with Esri World Imagery (no account or API key); a one-time, per-browser confirm notes it is free for non-commercial use only.
- New Settings > Satellite Imagery section accepts an optional Mapbox public token. When set, the satellite layer uses Mapbox (commercially licensed) instead of Esri, with a status badge showing the active provider.

## Address search

- Result zoom now derives from the result's type (and rank as a fallback), so a country zooms to a wide view while a specific house zooms in close, instead of one fixed zoom for everything.
- Grid-style addresses (e.g. `1234 S 5678 W`) retry without the cardinal direction when the first pass finds no house-level match, which Nominatim otherwise misses.
- Clear (X) button inside the field, shown only when it holds text; clears and refocuses while staying open.
- Staged Esc dismissal: close the results popup, then clear the text, then collapse the control, one level per press, so dismissing suggestions no longer discards the query.
- The dropped result pin is tied to the query and removed when the field is cleared.

## Signal map

- Esc now exits fullscreen as the final step, after backing out of any open dialog, mode, or building selection.
- Leaflet zoom buttons on the Signal and Speed Test maps match the 2D topology map, including a muted disabled state at min/max zoom.
