### PR TITLE
Wi-Fi channel recommendations: physical interference model + smarter per-AP moves

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -476,7 +476,7 @@
                             </svg>
                             <span>Channels look optimal</span>
                         </div>
-                        <button class="btn-recommend" @onclick="NavigateToChannelRecommendations">Review Channels</button>
+                        <button class="btn-recommend" @onclick="NavigateToChannelRecommendations">Review Channel Plan</button>
                     </div>
                 }
                 else

--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -382,7 +382,8 @@
             </div>
         </div>
 
-        <!-- Client Band Distribution Card -->
+        <!-- Client Band Distribution + Channel Optimization (stacked in one grid cell) -->
+        <div class="wifi-overview-stack">
         <div class="card">
             <div class="card-header">
                 <h2 class="card-title">Client Band Distribution</h2>
@@ -445,6 +446,65 @@
                     </div>
                 }
             </div>
+        </div>
+
+        <!-- Channel Optimization Card -->
+        <div class="card channel-rec-card">
+            <div class="card-header">
+                <h2 class="card-title">Channel Optimization</h2>
+            </div>
+            <div class="card-body">
+                @if (_loading || _loadingRecs)
+                {
+                    <div class="loading-state">
+                        <span class="spinner-sm"></span>
+                        <span>Analyzing channels...</span>
+                    </div>
+                }
+                else if (_channelPlans == null || _channelPlans.Count == 0)
+                {
+                    <div class="empty-state">
+                        <p>Channel analysis unavailable. Ensure APs are online.</p>
+                    </div>
+                }
+                else if (TotalChannelChanges == 0)
+                {
+                    <div class="channel-rec-summary">
+                        <div class="channel-rec-status optimal">
+                            <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20">
+                                <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/>
+                            </svg>
+                            <span>Channels look optimal</span>
+                        </div>
+                        <button class="btn-recommend" @onclick="NavigateToChannelRecommendations">Review Channels</button>
+                    </div>
+                }
+                else
+                {
+                    <div class="channel-rec-summary">
+                        <div class="channel-rec-status">
+                            <span class="channel-rec-count">@TotalChannelChanges</span>
+                            <span>channel change@(TotalChannelChanges != 1 ? "s" : "") suggested</span>
+                        </div>
+                        <div class="channel-rec-bands">
+                            @if (ChannelChangeCount(RadioBand.Band2_4GHz) > 0)
+                            {
+                                <span class="band-badge band-2ghz">2.4 GHz: @ChannelChangeCount(RadioBand.Band2_4GHz)</span>
+                            }
+                            @if (ChannelChangeCount(RadioBand.Band5GHz) > 0)
+                            {
+                                <span class="band-badge band-5ghz">5 GHz: @ChannelChangeCount(RadioBand.Band5GHz)</span>
+                            }
+                            @if (ChannelChangeCount(RadioBand.Band6GHz) > 0)
+                            {
+                                <span class="band-badge band-6ghz">6 GHz: @ChannelChangeCount(RadioBand.Band6GHz)</span>
+                            }
+                        </div>
+                        <button class="btn-recommend" @onclick="NavigateToChannelRecommendations">Recommend Best Channels</button>
+                    </div>
+                }
+            </div>
+        </div>
         </div>
 
         <!-- Issues Card -->
@@ -758,6 +818,55 @@
         _ => null
     };
 
+    // --- Channel Optimization overview card ---
+    private Dictionary<RadioBand, ChannelPlan>? _channelPlans;
+    private bool _loadingRecs;
+
+    private int ChannelChangeCount(RadioBand band) =>
+        _channelPlans != null && _channelPlans.TryGetValue(band, out var plan)
+            ? plan.Recommendations.Count(r => r.IsChanged)
+            : 0;
+
+    private int TotalChannelChanges =>
+        _channelPlans?.Values.Sum(p => p.Recommendations.Count(r => r.IsChanged)) ?? 0;
+
+    /// <summary>
+    /// Compute channel recommendations for the overview summary card. Runs the full engine,
+    /// so it is kicked off in the background after the overview paints rather than blocking it.
+    /// </summary>
+    private async Task LoadChannelRecommendationsAsync()
+    {
+        if (_loadingRecs) return;
+        _loadingRecs = true;
+        await InvokeAsync(StateHasChanged);
+        try
+        {
+            _channelPlans = await WiFiService.GetAllChannelRecommendationsAsync(new RecommendationOptions());
+        }
+        catch
+        {
+            _channelPlans = null;
+        }
+        finally
+        {
+            _loadingRecs = false;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private void NavigateToChannelRecommendations()
+    {
+        _activeTab = "channels";
+        _initialApMac = null;
+        _initialBand = null;
+        _initialChannel = null;
+        _initialClientMac = null;
+        _initialEdge = null;
+        _autoRunRecommendation = true;
+        NavigationManager.NavigateTo("/wifi-optimizer?tab=channels&recommend=true", forceLoad: false, replace: false);
+        _lastTabParam = "channels";
+    }
+
     private SiteHealthScore? _healthScore;
     private WiFiSummary? _summary;
     private List<AccessPointSnapshot> _accessPoints = new();
@@ -897,6 +1006,10 @@
             _loading = false;
             await InvokeAsync(StateHasChanged);
         }
+
+        // Channel recommendations run the full engine; compute in the background so they don't
+        // delay the overview paint. The card shows its own loading state until ready.
+        _ = LoadChannelRecommendationsAsync();
     }
 
     private async Task RefreshData()
@@ -931,6 +1044,9 @@
             _refreshing = false;
             StateHasChanged();
         }
+
+        // Refresh cleared the cache, so recompute the channel recommendations summary too.
+        _ = LoadChannelRecommendationsAsync();
     }
 
     private async Task LoadApMarkers()

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -79,7 +79,7 @@
                 var bandData = GetBandData(band);
                 var hasRecForBand = _showRecommendations && _channelPlans.ContainsKey(band);
                 <button class="band-tab @GetBandClass(band) @(_selectedBand == band ? "active" : "") @(bandData.HasIssues ? "has-issues" : "")"
-                        @onclick="() => { _selectedBand = band; _selectedChannel = null; }">
+                        @onclick="() => { _selectedBand = band; _selectedChannel = null; _bandManuallySelected = true; }">
                     @band.ToDisplayString()
                     @if (_showRecommendations && hasRecForBand)
                     {
@@ -518,6 +518,8 @@
     private SiteHealthScore? _healthScore;
     private RadioBand _selectedBand = RadioBand.Band5GHz;
     private int? _selectedChannel;
+    // True once the user (or explicit navigation) picks a band, so auto-select won't override it.
+    private bool _bandManuallySelected;
 
     // Channel disclaimer
     private bool _channelDisclaimerDismissed;
@@ -557,9 +559,12 @@
 
         await LoadDataAsync();
 
-        // Apply initial filters from parent navigation
+        // Apply initial filters from parent navigation (explicit band is treated as a manual pick)
         if (InitialBand.HasValue)
+        {
             _selectedBand = InitialBand.Value;
+            _bandManuallySelected = true;
+        }
         if (InitialChannel.HasValue)
             _selectedChannel = InitialChannel.Value;
 
@@ -843,11 +848,36 @@
 
             _channelPlans = await WiFiService.GetAllChannelRecommendationsAsync(options);
             _showRecommendations = _channelPlans.Count > 0;
+            AutoSelectBandWithRecommendations();
         }
         finally
         {
             _loadingRecommendations = false;
             StateHasChanged();
+        }
+    }
+
+    private bool BandHasChanges(RadioBand band) =>
+        _channelPlans.TryGetValue(band, out var plan) && plan.Recommendations.Any(r => r.IsChanged);
+
+    /// <summary>
+    /// After running the engine, land on a band that actually has recommendations instead of
+    /// the static default. Skips if the user explicitly picked a band, or if the current band
+    /// already has changes, so we never yank someone off a band they're deliberately viewing.
+    /// </summary>
+    private void AutoSelectBandWithRecommendations()
+    {
+        if (_bandManuallySelected) return;
+        if (BandHasChanges(_selectedBand)) return;
+
+        foreach (var band in _bands)
+        {
+            if (BandHasChanges(band))
+            {
+                _selectedBand = band;
+                _selectedChannel = null;
+                break;
+            }
         }
     }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -263,21 +263,23 @@
                     <!-- How This Works -->
                     <details class="recommendation-explainer">
                         <summary>How This Works</summary>
-                        <p>
-                            Most channel pickers just count nearby networks. This builds a physical model of your
-                            RF environment and solves for the channel plan that minimizes real interference:
-                        </p>
-                        <ul>
-                            <li><strong>Signal propagation</strong> - models how far each AP's signal actually reaches using your floor plan, wall materials, and per-radio antenna patterns, not distance alone.</li>
-                            <li><strong>Transmit-power aware</strong> - each AP's real EIRP is applied directionally, so a low-power AP correctly counts as a gentler neighbor than a full-power one.</li>
-                            <li><strong>Real contention, not raw signal</strong> - interference is measured against the CCA threshold (where radios actually defer), so barely-audible signals aren't over-counted.</li>
-                            <li><strong>Neighboring networks</strong> - folds in UniFi's RF scan of networks you don't control, triangulated across all your APs for a fuller picture than any single AP sees.</li>
-                            <li><strong>30 days of history</strong> - per-channel utilization, interference, and TX-retry trends, so the plan reflects how channels behave over time, not one noisy snapshot.</li>
-                            <li><strong>Honest about the unknown</strong> - channels with no scan data are penalized for that uncertainty, so it won't push you onto an unseen channel unless your known channels are clearly worse.</li>
-                            <li><strong>Whole-network and per-AP</strong> - minimizes total interference across the site, then checks each AP individually, only suggesting a move that genuinely helps and never wrecking one AP to slightly help another.</li>
-                            <li><strong>Mesh and DFS aware</strong> - mesh APs stay on their parent's channel; DFS channels are handled per your preference.</li>
-                        </ul>
-                        <p>Lower scores mean less interference.</p>
+                        <div class="recommendation-explainer-content">
+                            <p>
+                                Most channel pickers just count nearby networks. This builds a physical model of your
+                                RF environment and solves for the channel plan that minimizes real interference:
+                            </p>
+                            <ul>
+                                <li><strong>Signal propagation</strong> - models how far each AP's signal actually reaches using your floor plan, wall materials, and per-radio antenna patterns, not distance alone.</li>
+                                <li><strong>Transmit-power aware</strong> - each AP's real EIRP is applied directionally, so a low-power AP correctly counts as a gentler neighbor than a full-power one.</li>
+                                <li><strong>Real contention, not raw signal</strong> - interference is measured against the CCA threshold (where radios actually defer), so barely-audible signals aren't over-counted.</li>
+                                <li><strong>Neighboring networks</strong> - folds in UniFi's RF scan of networks you don't control, triangulated across all your APs for a fuller picture than any single AP sees.</li>
+                                <li><strong>30 days of history</strong> - per-channel utilization, interference, and TX-retry trends, so the plan reflects how channels behave over time, not one noisy snapshot.</li>
+                                <li><strong>Honest about the unknown</strong> - channels with no scan data are penalized for that uncertainty, so it won't push you onto an unseen channel unless your known channels are clearly worse.</li>
+                                <li><strong>Whole-network and per-AP</strong> - minimizes total interference across the site, then checks each AP individually, only suggesting a move that genuinely helps and never wrecking one AP to slightly help another.</li>
+                                <li><strong>Mesh and DFS aware</strong> - mesh APs stay on their parent's channel; DFS channels are handled per your preference.</li>
+                            </ul>
+                            <p>Lower scores mean less interference.</p>
+                        </div>
                     </details>
                 }
                 else

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -106,7 +106,7 @@
             <div class="recommendation-view">
                 <div class="section-header">
                     <h4>Recommended Channel Plan - @_selectedBand.ToDisplayString()</h4>
-                    <button class="btn btn-sm btn-ghost" @onclick="() => { _showRecommendations = false; _channelPlans.Clear(); }">Back to Current</button>
+                    <button class="btn btn-sm btn-ghost" @onclick="() => { _showRecommendations = false; _channelPlans.Clear(); }">Show Current Channels</button>
                 </div>
 
                 @if (!_channelDisclaimerDismissed)

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -264,10 +264,20 @@
                     <details class="recommendation-explainer">
                         <summary>How This Works</summary>
                         <p>
-                            We model how far each AP's signal reaches using your floor plan, wall materials, and antenna patterns.
-                            Then we find the channel assignment that minimizes total interference between your APs and neighboring networks.
-                            Mesh APs are kept on the same channel as their parent. Lower scores mean less interference.
+                            Most channel pickers just count nearby networks. This builds a physical model of your
+                            RF environment and solves for the channel plan that minimizes real interference:
                         </p>
+                        <ul>
+                            <li><strong>Signal propagation</strong> - models how far each AP's signal actually reaches using your floor plan, wall materials, and per-radio antenna patterns, not distance alone.</li>
+                            <li><strong>Transmit-power aware</strong> - each AP's real EIRP is applied directionally, so a low-power AP correctly counts as a gentler neighbor than a full-power one.</li>
+                            <li><strong>Real contention, not raw signal</strong> - interference is measured against the CCA threshold (where radios actually defer), so barely-audible signals aren't over-counted.</li>
+                            <li><strong>Neighboring networks</strong> - folds in UniFi's RF scan of networks you don't control, triangulated across all your APs for a fuller picture than any single AP sees.</li>
+                            <li><strong>30 days of history</strong> - per-channel utilization, interference, and TX-retry trends, so the plan reflects how channels behave over time, not one noisy snapshot.</li>
+                            <li><strong>Honest about the unknown</strong> - channels with no scan data are penalized for that uncertainty, so it won't push you onto an unseen channel unless your known channels are clearly worse.</li>
+                            <li><strong>Whole-network and per-AP</strong> - minimizes total interference across the site, then checks each AP individually, only suggesting a move that genuinely helps and never wrecking one AP to slightly help another.</li>
+                            <li><strong>Mesh and DFS aware</strong> - mesh APs stay on their parent's channel; DFS channels are handled per your preference.</li>
+                        </ul>
+                        <p>Lower scores mean less interference.</p>
                     </details>
                 }
                 else

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/Metrics.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/Metrics.razor
@@ -698,7 +698,11 @@
             _ => null
         };
 
-        if (events.Count == 0 && currentChannel == null)
+        // Only show a channel timeline for APs that actually changed channels in this window.
+        // A constant-channel AP renders nothing here (its channel is already shown in the header),
+        // which also avoids the fallback below picking up a stale current-channel value from a
+        // previously-selected AP - the cause of one AP's channel bleeding onto another's chart.
+        if (events.Count == 0)
             return;
 
         // Build timeline: for each metric timestamp, find the active channel

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/Metrics.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/Metrics.razor
@@ -100,7 +100,7 @@
         <!-- 2.4 GHz Chart -->
         @if (Show24)
         {
-            <div class="band-chart-container" @key="@($"chart24-{VisibleBandCount}")">
+            <div class="band-chart-container" @key="@($"chart24-{VisibleBandCount}-{_selectedApMac}-{_selectedRange}")">
                 <div class="band-chart-header">
                     <span class="band-label band-2ghz">2.4 GHz</span>
                     @if (!string.IsNullOrEmpty(_selectedApMac) && _currentChannel24 != null)
@@ -147,7 +147,7 @@
         <!-- 5 GHz Chart -->
         @if (Show5)
         {
-            <div class="band-chart-container" @key="@($"chart5-{VisibleBandCount}")">
+            <div class="band-chart-container" @key="@($"chart5-{VisibleBandCount}-{_selectedApMac}-{_selectedRange}")">
                 <div class="band-chart-header">
                     <span class="band-label band-5ghz">5 GHz</span>
                     @if (!string.IsNullOrEmpty(_selectedApMac) && _currentChannel5 != null)
@@ -194,7 +194,7 @@
         <!-- 6 GHz Chart -->
         @if (Show6)
         {
-            <div class="band-chart-container" @key="@($"chart6-{VisibleBandCount}")">
+            <div class="band-chart-container" @key="@($"chart6-{VisibleBandCount}-{_selectedApMac}-{_selectedRange}")">
                 <div class="band-chart-header">
                     <span class="band-label band-6ghz">6 GHz</span>
                     @if (!string.IsNullOrEmpty(_selectedApMac) && _currentChannel6 != null)
@@ -272,8 +272,6 @@
     private ApexChart<ChartDataPoint>? _chart24;
     private ApexChart<ChartDataPoint>? _chart5;
     private ApexChart<ChartDataPoint>? _chart6;
-    // True once the first render has initialized the charts; RenderAsync NREs before that.
-    private bool _chartsReady;
 
     // Chart options
     private ApexChartOptions<ChartDataPoint> _chartOptions24 = new();
@@ -337,8 +335,6 @@
         if (firstRender)
         {
             await LoadDataAsync();
-            // Charts are initialized now; later reloads may safely re-render to refresh annotations.
-            _chartsReady = true;
         }
     }
 
@@ -500,26 +496,6 @@
         {
             _loading = false;
             StateHasChanged();
-        }
-
-        // ApexCharts keeps previously-rendered annotations and series when only the bound data
-        // object changes, so switching the AP filter would otherwise leave a prior AP's channel
-        // markers on the chart (e.g. Ch 11 from another AP). Re-render to apply the rebuilt
-        // annotations/series. Skip on the first load: the charts are still initializing then and
-        // RenderAsync would throw an NRE (and there is nothing stale to clear yet).
-        if (_chartsReady)
-        {
-            await Task.Yield();
-            try
-            {
-                if (_chart24 != null) await _chart24.RenderAsync();
-                if (_chart5 != null) await _chart5.RenderAsync();
-                if (_chart6 != null) await _chart6.RenderAsync();
-            }
-            catch (Exception ex)
-            {
-                Logger.LogDebug(ex, "Chart re-render after data reload failed (non-fatal)");
-            }
         }
     }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/Metrics.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/Metrics.razor
@@ -272,6 +272,8 @@
     private ApexChart<ChartDataPoint>? _chart24;
     private ApexChart<ChartDataPoint>? _chart5;
     private ApexChart<ChartDataPoint>? _chart6;
+    // True once the first render has initialized the charts; RenderAsync NREs before that.
+    private bool _chartsReady;
 
     // Chart options
     private ApexChartOptions<ChartDataPoint> _chartOptions24 = new();
@@ -335,6 +337,8 @@
         if (firstRender)
         {
             await LoadDataAsync();
+            // Charts are initialized now; later reloads may safely re-render to refresh annotations.
+            _chartsReady = true;
         }
     }
 
@@ -500,13 +504,23 @@
 
         // ApexCharts keeps previously-rendered annotations and series when only the bound data
         // object changes, so switching the AP filter would otherwise leave a prior AP's channel
-        // markers on the chart (e.g. Ch 11 from another AP). Force an explicit re-render to apply
-        // the rebuilt annotations/series. Refs are null on the very first load (nothing stale to
-        // clear), so the null-guards make this a no-op there.
-        await Task.Yield();
-        if (_chart24 != null) await _chart24.RenderAsync();
-        if (_chart5 != null) await _chart5.RenderAsync();
-        if (_chart6 != null) await _chart6.RenderAsync();
+        // markers on the chart (e.g. Ch 11 from another AP). Re-render to apply the rebuilt
+        // annotations/series. Skip on the first load: the charts are still initializing then and
+        // RenderAsync would throw an NRE (and there is nothing stale to clear yet).
+        if (_chartsReady)
+        {
+            await Task.Yield();
+            try
+            {
+                if (_chart24 != null) await _chart24.RenderAsync();
+                if (_chart5 != null) await _chart5.RenderAsync();
+                if (_chart6 != null) await _chart6.RenderAsync();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogDebug(ex, "Chart re-render after data reload failed (non-fatal)");
+            }
+        }
     }
 
     private void TransformDataForCharts()

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/Metrics.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/Metrics.razor
@@ -497,6 +497,16 @@
             _loading = false;
             StateHasChanged();
         }
+
+        // ApexCharts keeps previously-rendered annotations and series when only the bound data
+        // object changes, so switching the AP filter would otherwise leave a prior AP's channel
+        // markers on the chart (e.g. Ch 11 from another AP). Force an explicit re-render to apply
+        // the rebuilt annotations/series. Refs are null on the very first load (nothing stale to
+        // clear), so the null-guards make this a no-op there.
+        await Task.Yield();
+        if (_chart24 != null) await _chart24.RenderAsync();
+        if (_chart5 != null) await _chart5.RenderAsync();
+        if (_chart6 != null) await _chart6.RenderAsync();
     }
 
     private void TransformDataForCharts()

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/Metrics.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/Metrics.razor
@@ -100,7 +100,7 @@
         <!-- 2.4 GHz Chart -->
         @if (Show24)
         {
-            <div class="band-chart-container" @key="@($"chart24-{VisibleBandCount}-{_selectedApMac}-{_selectedRange}")">
+            <div class="band-chart-container" @key="@($"chart24-{VisibleBandCount}")">
                 <div class="band-chart-header">
                     <span class="band-label band-2ghz">2.4 GHz</span>
                     @if (!string.IsNullOrEmpty(_selectedApMac) && _currentChannel24 != null)
@@ -147,7 +147,7 @@
         <!-- 5 GHz Chart -->
         @if (Show5)
         {
-            <div class="band-chart-container" @key="@($"chart5-{VisibleBandCount}-{_selectedApMac}-{_selectedRange}")">
+            <div class="band-chart-container" @key="@($"chart5-{VisibleBandCount}")">
                 <div class="band-chart-header">
                     <span class="band-label band-5ghz">5 GHz</span>
                     @if (!string.IsNullOrEmpty(_selectedApMac) && _currentChannel5 != null)
@@ -194,7 +194,7 @@
         <!-- 6 GHz Chart -->
         @if (Show6)
         {
-            <div class="band-chart-container" @key="@($"chart6-{VisibleBandCount}-{_selectedApMac}-{_selectedRange}")">
+            <div class="band-chart-container" @key="@($"chart6-{VisibleBandCount}")">
                 <div class="band-chart-header">
                     <span class="band-label band-6ghz">6 GHz</span>
                     @if (!string.IsNullOrEmpty(_selectedApMac) && _currentChannel6 != null)

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -554,8 +554,15 @@ public class WiFiOptimizerService
             return new List<ChannelScanResult>();
         }
 
-        // Create cache key based on time range
-        var timeKey = $"{startTime?.ToUnixTimeSeconds()}_{endTime?.ToUnixTimeSeconds()}";
+        // Create cache key based on the time range, bucketed to the minute. The recommendation
+        // engine requests startTime = now - lookback, which moves every second; keying on the
+        // exact second meant the key changed on every call and the cache never hit - every run
+        // re-fetched scans from the controller, and the overview card and channel-plan tab could
+        // land on different scan snapshots (showing different recommendations). Bucketing lets
+        // calls within the cache window reuse the same snapshot.
+        static long MinuteBucket(DateTimeOffset? t) =>
+            t.HasValue ? (long)Math.Round(t.Value.ToUnixTimeSeconds() / 60.0) : -1;
+        var timeKey = $"{MinuteBucket(startTime)}_{MinuteBucket(endTime)}";
         var cacheValid = !forceRefresh
             && _cachedScanResults != null
             && _cachedScanResultsTimeKey == timeKey

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -7832,7 +7832,7 @@ a.path-hop.hop-clickable:hover {
     display: flex;
     justify-content: center;
     gap: 3rem;
-    padding: 1rem 0;
+    padding: 0.5rem 0;
 }
 
 .band-item {
@@ -7854,7 +7854,7 @@ a.path-hop.hop-clickable:hover {
 
 .band-bar-container {
     width: 60px;
-    height: 120px;
+    height: 96px;
     background: var(--bg-tertiary);
     border-radius: 6px 6px 0 0;
     overflow: hidden;
@@ -7888,9 +7888,70 @@ a.path-hop.hop-clickable:hover {
     display: flex;
     justify-content: center;
     gap: 2rem;
-    margin-top: 1rem;
-    padding-top: 1rem;
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
     border-top: 1px solid var(--border-color);
+}
+
+/* Overview: Client Band Distribution + Channel Optimization stacked in one grid cell */
+.wifi-overview-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    min-width: 0;
+}
+
+.channel-rec-card .card-body {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.channel-rec-summary {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.875rem;
+    padding: 0.5rem 0;
+    text-align: center;
+}
+
+.channel-rec-status {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+}
+
+.channel-rec-status.optimal {
+    color: var(--success-color);
+}
+
+.channel-rec-count {
+    font-size: 1.75rem;
+    font-weight: 700;
+    line-height: 1;
+    color: var(--accent-color);
+}
+
+.channel-rec-bands {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.channel-rec-summary .btn-recommend {
+    width: 100%;
+    max-width: 260px;
+    height: 38px;
+}
+
+@media (max-width: 768px) {
+    .wifi-overview-stack {
+        gap: 16px;
+    }
 }
 
 .band-stat {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -7912,7 +7912,7 @@ a.path-hop.hop-clickable:hover {
     flex-direction: column;
     align-items: center;
     gap: 0.875rem;
-    padding: 0.5rem 0;
+    padding-bottom: 0.5rem;
     text-align: center;
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -10207,6 +10207,9 @@ a.path-hop.hop-clickable:hover {
     cursor: pointer;
     transition: all 0.15s ease;
     position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .band-tab:hover {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -10986,27 +10986,60 @@ a.path-hop.hop-clickable:hover {
 
 /* How This Works expandable */
 .recommendation-explainer {
-    font-size: 0.8125rem;
-    color: var(--text-muted);
     margin: 0 0.5rem 0.5rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius-lg);
+    background: var(--bg-tertiary);
 }
 .recommendation-explainer summary {
+    padding: 0.6rem 0.85rem;
     cursor: pointer;
+    font-weight: 500;
+    font-size: 0.8125rem;
     color: var(--text-secondary);
+    user-select: none;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
 }
-.recommendation-explainer p {
-    margin: 0.5rem 0 0;
+.recommendation-explainer summary::-webkit-details-marker {
+    display: none;
+}
+.recommendation-explainer summary::before {
+    content: "▶";
+    font-size: 0.6rem;
+    transition: transform 0.2s ease;
+}
+.recommendation-explainer[open] summary::before {
+    transform: rotate(90deg);
+}
+.recommendation-explainer summary:hover {
+    color: var(--text-primary);
+    background: var(--bg-elevated);
+    border-radius: var(--border-radius-lg) var(--border-radius-lg) 0 0;
+}
+.recommendation-explainer:not([open]) summary:hover {
+    border-radius: var(--border-radius-lg);
+}
+.recommendation-explainer-content {
+    padding: 0 0.85rem 0.85rem 0.85rem;
+    border-top: 1px solid var(--border-color);
+    color: var(--text-muted);
+    font-size: 0.75rem;
     line-height: 1.5;
 }
-.recommendation-explainer ul {
-    margin: 0.5rem 0 0;
+.recommendation-explainer-content p {
+    margin: 0.6rem 0;
+}
+.recommendation-explainer-content ul {
+    margin: 0.6rem 0;
     padding-left: 1.1rem;
-    line-height: 1.5;
 }
-.recommendation-explainer li {
+.recommendation-explainer-content li {
     margin-bottom: 0.35rem;
 }
-.recommendation-explainer li strong {
+.recommendation-explainer-content li strong {
     color: var(--text-secondary);
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -7645,7 +7645,7 @@ a.path-hop.hop-clickable:hover {
 .wifi-content-grid {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
-    gap: 1.5rem;
+    gap: 0.25rem 1.25rem;
 }
 
 /* Override main dashboard min-height for WiFi overview cards */
@@ -7897,7 +7897,7 @@ a.path-hop.hop-clickable:hover {
 .wifi-overview-stack {
     display: flex;
     flex-direction: column;
-    gap: 1.5rem;
+    gap: 0.25rem;
     min-width: 0;
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -8099,6 +8099,8 @@ a.path-hop.hop-clickable:hover {
 /* Success State */
 .success-state {
     color: #22c55e;
+    padding-top: 2rem;
+    padding-bottom: 2rem;
 }
 
 .success-state svg {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -10998,6 +10998,17 @@ a.path-hop.hop-clickable:hover {
     margin: 0.5rem 0 0;
     line-height: 1.5;
 }
+.recommendation-explainer ul {
+    margin: 0.5rem 0 0;
+    padding-left: 1.1rem;
+    line-height: 1.5;
+}
+.recommendation-explainer li {
+    margin-bottom: 0.35rem;
+}
+.recommendation-explainer li strong {
+    color: var(--text-secondary);
+}
 
 /* Improvement stat highlighting */
 .stat-improvement .channel-stat-value { color: var(--success-color); }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -33,6 +33,7 @@
 
     /* Dark Mode Backgrounds - neutral dark, Linear/Vercel inspired */
     --bg-primary: #0f0f11;
+    --bg-inset: #131315;
     --bg-secondary: #161618;
     --bg-tertiary: #232326;
     --bg-elevated: #2c2c30;
@@ -10719,6 +10720,7 @@ a.path-hop.hop-clickable:hover {
 }
 
 .aps-band-table {
+    background: var(--bg-inset);
     border: 1px solid var(--border-color);
     border-radius: 6px;
     overflow: hidden;
@@ -10986,7 +10988,7 @@ a.path-hop.hop-clickable:hover {
 
 /* How This Works expandable */
 .recommendation-explainer {
-    margin: 0 0.5rem 0.5rem;
+    margin: 0.5rem 0.5rem 0.5rem;
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius-lg);
     background: var(--bg-tertiary);
@@ -10995,7 +10997,7 @@ a.path-hop.hop-clickable:hover {
     padding: 0.6rem 0.85rem;
     cursor: pointer;
     font-weight: 500;
-    font-size: 0.8125rem;
+    font-size: 0.85rem;
     color: var(--text-secondary);
     user-select: none;
     list-style: none;
@@ -11008,7 +11010,7 @@ a.path-hop.hop-clickable:hover {
 }
 .recommendation-explainer summary::before {
     content: "▶";
-    font-size: 0.6rem;
+    font-size: 0.65rem;
     transition: transform 0.2s ease;
 }
 .recommendation-explainer[open] summary::before {
@@ -11026,7 +11028,7 @@ a.path-hop.hop-clickable:hover {
     padding: 0 0.85rem 0.85rem 0.85rem;
     border-top: 1px solid var(--border-color);
     color: var(--text-muted);
-    font-size: 0.75rem;
+    font-size: 0.8rem;
     line-height: 1.5;
 }
 .recommendation-explainer-content p {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -7646,6 +7646,7 @@ a.path-hop.hop-clickable:hover {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     gap: 0.25rem 1.25rem;
+    margin-bottom: 0.25rem;
 }
 
 /* Override main dashboard min-height for WiFi overview cards */
@@ -7664,6 +7665,7 @@ a.path-hop.hop-clickable:hover {
         display: flex;
         flex-direction: column;
         gap: 16px;
+        margin-bottom: 16px;
     }
 }
 

--- a/src/NetworkOptimizer.WiFi/Helpers/ChannelSpanHelper.cs
+++ b/src/NetworkOptimizer.WiFi/Helpers/ChannelSpanHelper.cs
@@ -99,11 +99,22 @@ public static class ChannelSpanHelper
         a.Low <= b.High && b.Low <= a.High;
 
     /// <summary>
-    /// Convert signal strength to interference weight using the standard formula.
-    /// Maps -90 dBm → 0.1 (barely audible) through -50 dBm → 1.0 (very close).
+    /// CCA threshold (dBm). At or below this a radio does not detect a co-channel transmission and
+    /// won't defer, so it suffers no contention - the interference weight curve is anchored here.
+    /// </summary>
+    private const double CcaThresholdDbm = -82.0;
+
+    /// <summary>Signal (dBm) at or above which a co-channel interferer fully saturates (weight 1.0).</summary>
+    private const double SaturationDbm = -50.0;
+
+    /// <summary>
+    /// Convert a received signal strength to a co-channel interference weight in [0, 1], anchored at
+    /// the CCA threshold: a signal at or below CCA (-82 dBm) causes no contention (weight 0 - the
+    /// radio doesn't defer), ramping linearly to 1.0 at a saturating -50 dBm. Operates on the
+    /// received signal, which already accounts for band-specific propagation, so it is band-agnostic.
     /// </summary>
     public static double SignalToInterferenceWeight(int signalDbm) =>
-        Math.Clamp((signalDbm + 90) / 40.0, 0.1, 1.0);
+        Math.Clamp((signalDbm - CcaThresholdDbm) / (SaturationDbm - CcaThresholdDbm), 0.0, 1.0);
 
     /// <summary>
     /// Compute the channel overlap factor between two channel assignments.

--- a/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
@@ -72,8 +72,20 @@ public class InterferenceGraph
     /// <summary>True when DFS avoidance was requested but at least one AP had to fall back to DFS channels</summary>
     public bool DfsAvoidanceFallback { get; set; }
 
-    /// <summary>Pairwise internal interference weights [i,j]</summary>
+    /// <summary>
+    /// Pairwise internal interference weights [i,j], symmetric (worst case of both directions).
+    /// Models mutual co-channel contention - used for the global objective and proximity.
+    /// </summary>
     public double[,] InternalWeights { get; set; } = new double[0, 0];
+
+    /// <summary>
+    /// Directional internal interference weights [aggressor, victim] = how much the aggressor AP
+    /// interferes AT the victim, based on the aggressor's signal reaching the victim (its EIRP).
+    /// Used where interference is one-directional: an AP's own suffered interference and the
+    /// degradation guard. A low-power AP correctly interferes with neighbors less than the
+    /// symmetric worst case implies.
+    /// </summary>
+    public double[,] DirectionalWeights { get; set; } = new double[0, 0];
 
     /// <summary>Per-AP external load by channel number. ExternalLoad[apIndex][channel] = weight</summary>
     public Dictionary<int, double>[] ExternalLoad { get; set; } = [];

--- a/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
-using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.UniFi;
 using NetworkOptimizer.UniFi.Models;
 using NetworkOptimizer.WiFi.Models;
@@ -262,10 +261,12 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
             var data = await _client.GetApChannelChangeEventsAsync(start, end, apMac, cancellationToken);
             var events = ParseChannelChangeEvents(data);
 
-            // The controller's system-log query filters by clientDeviceMacs, which does not scope
-            // AP "changed channels" events to a single device - it can return every AP's channel
-            // changes. Filter by the AP MAC here so callers only see the requested AP's events
-            // (otherwise one AP's change is misattributed onto another AP's chart/timeline).
+            // Defensive scoping. The controller's system-log query already filters these events to
+            // the requested device via clientDeviceMacs (verified against the console: filtering to
+            // an AP with no channel changes returns no other AP's events). We re-filter by AP MAC
+            // here so every consumer is guaranteed to see only the requested AP's events even if that
+            // controller-side behavior ever changes - a stale value from another AP would otherwise
+            // be misattributed onto this AP's chart/timeline.
             if (!string.IsNullOrEmpty(apMac))
                 events = events.Where(e => e.ApMac.Equals(apMac, StringComparison.OrdinalIgnoreCase)).ToList();
 

--- a/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
@@ -260,7 +260,16 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
         try
         {
             var data = await _client.GetApChannelChangeEventsAsync(start, end, apMac, cancellationToken);
-            return ParseChannelChangeEvents(data);
+            var events = ParseChannelChangeEvents(data);
+
+            // The controller's system-log query filters by clientDeviceMacs, which does not scope
+            // AP "changed channels" events to a single device - it can return every AP's channel
+            // changes. Filter by the AP MAC here so callers only see the requested AP's events
+            // (otherwise one AP's change is misattributed onto another AP's chart/timeline).
+            if (!string.IsNullOrEmpty(apMac))
+                events = events.Where(e => e.ApMac.Equals(apMac, StringComparison.OrdinalIgnoreCase)).ToList();
+
+            return events;
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.WiFi/Rules/LoadImbalanceRule.cs
+++ b/src/NetworkOptimizer.WiFi/Rules/LoadImbalanceRule.cs
@@ -101,18 +101,17 @@ public class LoadImbalanceRule : IWiFiOptimizerRule
                         .Where(c => c.ApMac.Equals(maxAp.Mac, StringComparison.OrdinalIgnoreCase))
                         .ToList();
 
-                    // Suppress only when every client on the busy AP is confirmed well-served: it
-                    // has a reported signal that is not weak FOR ITS BAND, using the same per-band
-                    // scale as the client list coloring (a 2.4 GHz client at -66 is fine, a 6 GHz
-                    // client at -66 is not). A missing signal (unverifiable) keeps the issue visible.
-                    var allClientsWellServed = clientsOnMaxAp.Count > 0 &&
-                        clientsOnMaxAp.All(c => c.Signal.HasValue &&
-                            !SignalClassification.IsWeakSignal(c.Signal.Value, c.Band));
+                    // Suppress unless a client on the busy AP is genuinely weak FOR ITS BAND, using
+                    // the same per-band scale as the client list coloring. Higher bands tolerate
+                    // weaker signal: -75 is weak on 2.4 GHz (< -73) but fine on 5/6 GHz (weak only
+                    // below -78 / -87). Clients with no reported signal are ignored - a missing
+                    // reading usually just means an offline/idle device, not a weak one.
+                    var hasWeakClient = clientsOnMaxAp.Any(c => c.Signal.HasValue &&
+                        SignalClassification.IsWeakSignal(c.Signal.Value, c.Band));
 
-                    if (allClientsWellServed)
+                    if (!hasWeakClient)
                     {
-                        // Separate coverage zone and every client is well-served for its band -
-                        // this is definitively a separate zone, suppress entirely.
+                        // Separate coverage zone with no genuinely weak clients - suppress entirely.
                         return null;
                     }
 

--- a/src/NetworkOptimizer.WiFi/Rules/LoadImbalanceRule.cs
+++ b/src/NetworkOptimizer.WiFi/Rules/LoadImbalanceRule.cs
@@ -1,3 +1,4 @@
+using NetworkOptimizer.WiFi.Helpers;
 using NetworkOptimizer.WiFi.Models;
 using NetworkOptimizer.WiFi.Services;
 
@@ -24,11 +25,6 @@ public class LoadImbalanceRule : IWiFiOptimizerRule
     /// Coefficient of variation threshold (percentage) above which to warn.
     /// </summary>
     private const double ImbalanceThreshold = 50;
-
-    /// <summary>
-    /// Signal strength (dBm) at or above which a client is considered well-connected.
-    /// </summary>
-    private const int StrongSignalThreshold = -65;
 
     public HealthIssue? Evaluate(WiFiOptimizerContext ctx)
     {
@@ -105,13 +101,18 @@ public class LoadImbalanceRule : IWiFiOptimizerRule
                         .Where(c => c.ApMac.Equals(maxAp.Mac, StringComparison.OrdinalIgnoreCase))
                         .ToList();
 
-                    var allStrongSignal = clientsOnMaxAp.Count > 0 &&
-                        clientsOnMaxAp.All(c => c.Signal.HasValue && c.Signal.Value >= StrongSignalThreshold);
+                    // Suppress only when every client on the busy AP is confirmed well-served: it
+                    // has a reported signal that is not weak FOR ITS BAND, using the same per-band
+                    // scale as the client list coloring (a 2.4 GHz client at -66 is fine, a 6 GHz
+                    // client at -66 is not). A missing signal (unverifiable) keeps the issue visible.
+                    var allClientsWellServed = clientsOnMaxAp.Count > 0 &&
+                        clientsOnMaxAp.All(c => c.Signal.HasValue &&
+                            !SignalClassification.IsWeakSignal(c.Signal.Value, c.Band));
 
-                    if (allStrongSignal)
+                    if (allClientsWellServed)
                     {
-                        // All clients on the busy AP have strong signal and the quiet AP is
-                        // far away - this is definitively a separate coverage zone, suppress entirely
+                        // Separate coverage zone and every client is well-served for its band -
+                        // this is definitively a separate zone, suppress entirely.
                         return null;
                     }
 

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -119,14 +119,26 @@ public class ChannelRecommendationService
     private const double MinTriangulatedWeight = 0.2;
 
     /// <summary>
-    /// Uncertainty multiplier for external load on channels with no direct neighbor
-    /// observations. Triangulation discovers some neighbors but not all - the observer
-    /// AP may miss neighbors visible from the target's location. This multiplier inflates
-    /// the triangulated estimate to account for missing neighbors. The full penalty only
-    /// applies to channels we have no other evidence for; channels we have historic
-    /// occupancy or a resident sibling AP for are scaled down via <see cref="ObservationConfidence"/>.
+    /// Uncertainty multipliers for external load on channels with no direct neighbor
+    /// observations, by band. Triangulation discovers some neighbors but not all - the observer
+    /// AP may miss neighbors visible from the target's location. The multiplier inflates the
+    /// triangulated estimate to account for missing neighbors (base + base * multiplier).
+    ///
+    /// It is band-dependent because scan completeness tracks propagation range:
+    /// - 2.4 GHz penetrates walls and travels far, so an observer hears nearly every neighbor
+    ///   the target would, and those neighbors genuinely reach the target. The picture is close
+    ///   to complete, so unobserved channels are barely uncertain (1.5).
+    /// - 5 GHz: the ~3x underestimate (2.0) calibrated in testing.
+    /// - 6 GHz dies fastest through walls, so observers miss the most near-target neighbors and
+    ///   uncertainty is highest (2.5). Tempered by 6 GHz being sparsely populated today.
+    ///
+    /// This is the right caution for a genuinely unknown channel; channels we DO have evidence
+    /// for are scaled down separately via <see cref="ObservationConfidence"/>, which is where
+    /// the softening belongs. 2.4/6 GHz values are physically motivated; only 5 GHz is calibrated.
     /// </summary>
-    private const double UnobservedChannelMultiplier = 1.5;
+    private const double UnobservedChannelMultiplier2_4GHz = 1.5;
+    private const double UnobservedChannelMultiplier5GHz = 2.0;
+    private const double UnobservedChannelMultiplier6GHz = 2.5;
 
     /// <summary>
     /// Observation confidence for a candidate channel this AP has measured historic occupancy
@@ -863,9 +875,21 @@ public class ChannelRecommendationService
         }
         if (minDirectLoad == double.MaxValue) minDirectLoad = 0;
 
-        var basePenalty = Math.Max(triangulatedLoad * UnobservedChannelMultiplier, minDirectLoad);
+        var basePenalty = Math.Max(triangulatedLoad * GetUnobservedMultiplier(band), minDirectLoad);
         return (1.0 - confidence) * basePenalty;
     }
+
+    /// <summary>
+    /// Band-specific uncertainty multiplier for unobserved channels. Lower bands see a more
+    /// complete scan picture (better propagation), so their unobserved channels are less
+    /// uncertain. See the multiplier constants for rationale.
+    /// </summary>
+    private static double GetUnobservedMultiplier(RadioBand band) => band switch
+    {
+        RadioBand.Band2_4GHz => UnobservedChannelMultiplier2_4GHz,
+        RadioBand.Band6GHz => UnobservedChannelMultiplier6GHz,
+        _ => UnobservedChannelMultiplier5GHz
+    };
 
     /// <summary>
     /// How confident we are in the external-load estimate for an AP's assigned channel span,

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -218,6 +218,7 @@ public class ChannelRecommendationService
         {
             Nodes = new List<ApNode>(n),
             InternalWeights = new double[n, n],
+            DirectionalWeights = new double[n, n],
             ExternalLoad = new Dictionary<int, double>[n],
             DirectlyObservedChannels = new HashSet<int>[n],
             ScanChannelData = new Dictionary<int, (int Utilization, int Interference)>[n],
@@ -269,10 +270,13 @@ public class ChannelRecommendationService
         {
             for (int j = i + 1; j < n; j++)
             {
-                var weight = ComputeInternalWeight(
+                var w = ComputeInternalWeight(
                     bandAps[i], bandAps[j], band, bandStr, propContext);
-                graph.InternalWeights[i, j] = weight;
-                graph.InternalWeights[j, i] = weight;
+                graph.InternalWeights[i, j] = w.Symmetric;
+                graph.InternalWeights[j, i] = w.Symmetric;
+                // Directional [aggressor, victim]: Forward is i's signal at j, Reverse is j's at i.
+                graph.DirectionalWeights[i, j] = w.Forward;
+                graph.DirectionalWeights[j, i] = w.Reverse;
             }
         }
 
@@ -582,7 +586,7 @@ public class ChannelRecommendationService
                                 if (!jChanged) continue;
                                 if (!jNode.ValidChannels.Contains(jNode.CurrentChannel)) continue;
 
-                                var contribution = graph.InternalWeights[i, j] *
+                                var contribution = graph.DirectionalWeights[j, i] *
                                     ChannelSpanHelper.ComputeOverlapFactor(band,
                                         finalAssignment[i].Channel, finalAssignment[i].Width,
                                         finalAssignment[j].Channel, finalAssignment[j].Width) *
@@ -796,7 +800,8 @@ public class ChannelRecommendationService
         double score = 0;
         var n = graph.Nodes.Count;
 
-        // Internal interference from all other APs
+        // Internal interference this AP SUFFERS from all other APs. Directional [j, apIndex]:
+        // how much j's signal reaches this AP - so a low-EIRP neighbor interferes with it less.
         for (int j = 0; j < n; j++)
         {
             if (j == apIndex) continue;
@@ -807,7 +812,7 @@ public class ChannelRecommendationService
                 assignment[apIndex].Channel, assignment[apIndex].Width,
                 assignment[j].Channel, assignment[j].Width);
 
-            score += graph.InternalWeights[apIndex, j] * overlapFactor * InternalCoChannelMultiplier;
+            score += graph.DirectionalWeights[j, apIndex] * overlapFactor * InternalCoChannelMultiplier;
         }
 
         // External interference
@@ -1049,7 +1054,8 @@ public class ChannelRecommendationService
             if (j == apIndex) continue;
             if (AreMeshPair(graph, apIndex, j)) continue;
 
-            var weight = graph.InternalWeights[apIndex, j];
+            // Directional: co-channel load this AP suffers from j (j's signal reaching apIndex).
+            var weight = graph.DirectionalWeights[j, apIndex];
             if (weight <= 0) continue;
 
             // Current internal co-channel load (weighted, not just count)
@@ -1094,7 +1100,12 @@ public class ChannelRecommendationService
         return Math.Max(internalScale, externalFloor);
     }
 
-    private double ComputeInternalWeight(
+    /// <summary>
+    /// Compute internal interference weights between two APs. Returns the symmetric worst-case
+    /// weight (for mutual contention), plus the two directional weights: Forward = ap1's signal
+    /// reaching ap2 (ap1 as aggressor at ap2), Reverse = ap2's signal reaching ap1.
+    /// </summary>
+    private (double Symmetric, double Forward, double Reverse) ComputeInternalWeight(
         AccessPointSnapshot ap1, AccessPointSnapshot ap2,
         RadioBand band, string bandStr,
         ApPropagationContext? propContext)
@@ -1139,15 +1150,19 @@ public class ChannelRecommendationService
                 ap1.Name, ap2.Name, signal1to2, signal2to1, worstSignal,
                 ChannelSpanHelper.SignalToInterferenceWeight(worstSignal));
 
-            return ChannelSpanHelper.SignalToInterferenceWeight(worstSignal);
+            return (
+                ChannelSpanHelper.SignalToInterferenceWeight(worstSignal),
+                ChannelSpanHelper.SignalToInterferenceWeight((int)signal1to2),
+                ChannelSpanHelper.SignalToInterferenceWeight((int)signal2to1));
         }
 
-        // One or both unplaced - use conservative default
+        // One or both unplaced - use conservative default (symmetric)
+        var defaultWeight = ChannelSpanHelper.SignalToInterferenceWeight(DefaultUnplacedSignalDbm);
         _logger.LogDebug(
             "[ChannelRec] Internal weight {AP1} <-> {AP2}: weight={Weight:F3} (default, unplaced)",
-            ap1.Name, ap2.Name, ChannelSpanHelper.SignalToInterferenceWeight(DefaultUnplacedSignalDbm));
+            ap1.Name, ap2.Name, defaultWeight);
 
-        return ChannelSpanHelper.SignalToInterferenceWeight(DefaultUnplacedSignalDbm);
+        return (defaultWeight, defaultWeight, defaultWeight);
     }
 
     private static PropagationAp ClonePropAp(PropagationAp source, RadioSnapshot radio)
@@ -1981,7 +1996,7 @@ public class ChannelRecommendationService
                     var overlap = ChannelSpanHelper.ComputeOverlapFactor(
                         band, ch, currentAssignment[i].Width,
                         testAssignment[j].Channel, testAssignment[j].Width);
-                    internalScore += graph.InternalWeights[i, j] * overlap * InternalCoChannelMultiplier;
+                    internalScore += graph.DirectionalWeights[j, i] * overlap * InternalCoChannelMultiplier;
                 }
 
                 var apSpan = ChannelSpanHelper.GetChannelSpan(band, ch, currentAssignment[i].Width);

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -105,6 +105,14 @@ public class ChannelRecommendationService
     private const double MaxApScoreDegradation = 1.5;
 
     /// <summary>
+    /// Hard cap on how much a single per-AP fallback move may degrade another AP, regardless of
+    /// net benefit. A net-positive standalone move (the moving AP gains more than the total it
+    /// degrades others) is allowed past MaxApScoreDegradation, but never past this - so we never
+    /// wreck one AP to slightly help the site. 2.0 = the victim's score may at most double.
+    /// </summary>
+    private const double CatastrophicDegradation = 2.0;
+
+    /// <summary>
     /// Minimum neighbor signal to count as external interference. Matches the CCA
     /// (Clear Channel Assessment) threshold: below -82 dBm, radios don't defer
     /// transmission so the neighbor causes no real co-channel interference.
@@ -661,27 +669,42 @@ public class ChannelRecommendationService
                     pctImprovement < MinApImprovementPercent)
                     continue;
 
-                // Check no other AP gets degraded beyond threshold
-                bool degradesOther = false;
+                // A standalone move may degrade other APs, but only if it still improves the site
+                // overall (this AP's gain exceeds the total degradation it causes) and never pushes
+                // any single AP past the catastrophic cap.
+                bool reject = false;
+                double totalDegradation = 0;
                 for (int j = 0; j < n; j++)
                 {
                     if (j == i) continue;
                     var otherCurrent = currentApScores[j];
                     if (otherCurrent <= 0) continue;
                     var otherScore = ScoreAp(graph, trial, j, band);
-                    if (otherScore / otherCurrent > MaxApScoreDegradation)
+                    if (otherScore > otherCurrent) totalDegradation += otherScore - otherCurrent;
+
+                    if (otherScore / otherCurrent > CatastrophicDegradation)
                     {
                         _logger.LogDebug(
-                            "[ChannelRec] Per-AP fallback: {ApName} -> ch{Ch} improves ({Abs:F3}/{Pct:P0}) but " +
-                            "degrades {Victim} {From:F3}->{To:F3} ({Ratio:F2}x > {Max:P0}), skipping",
-                            node.Name, candidateCh, absImprovement, pctImprovement,
-                            graph.Nodes[j].Name, otherCurrent, otherScore,
-                            otherScore / otherCurrent, MaxApScoreDegradation);
-                        degradesOther = true;
+                            "[ChannelRec] Per-AP fallback: {ApName} -> ch{Ch} would wreck {Victim} " +
+                            "{From:F3}->{To:F3} ({Ratio:F2}x > {Cap:P0} cap), skipping",
+                            node.Name, candidateCh, graph.Nodes[j].Name, otherCurrent, otherScore,
+                            otherScore / otherCurrent, CatastrophicDegradation);
+                        reject = true;
                         break;
                     }
                 }
-                if (degradesOther) continue;
+                if (reject) continue;
+
+                // Net-benefit: the AP's own improvement must outweigh the total degradation it
+                // causes to others, otherwise the move makes the site no better.
+                if (absImprovement <= totalDegradation)
+                {
+                    _logger.LogDebug(
+                        "[ChannelRec] Per-AP fallback: {ApName} -> ch{Ch} improves {Abs:F3} but degrades " +
+                        "others by {Deg:F3} total (not net-positive for the site), skipping",
+                        node.Name, candidateCh, absImprovement, totalDegradation);
+                    continue;
+                }
 
                 if (candidateScore < fallbackScore)
                 {

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -671,6 +671,12 @@ public class ChannelRecommendationService
                     var otherScore = ScoreAp(graph, trial, j, band);
                     if (otherScore / otherCurrent > MaxApScoreDegradation)
                     {
+                        _logger.LogDebug(
+                            "[ChannelRec] Per-AP fallback: {ApName} -> ch{Ch} improves ({Abs:F3}/{Pct:P0}) but " +
+                            "degrades {Victim} {From:F3}->{To:F3} ({Ratio:F2}x > {Max:P0}), skipping",
+                            node.Name, candidateCh, absImprovement, pctImprovement,
+                            graph.Nodes[j].Name, otherCurrent, otherScore,
+                            otherScore / otherCurrent, MaxApScoreDegradation);
                         degradesOther = true;
                         break;
                     }

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -918,7 +918,12 @@ public class ChannelRecommendationService
         }
         if (minDirectLoad == double.MaxValue) minDirectLoad = 0;
 
-        var basePenalty = Math.Max(triangulatedLoad * GetUnobservedMultiplier(band), minDirectLoad);
+        // Apply the band uncertainty multiplier to the best available estimate - the triangulated
+        // load OR the floor. A channel with zero observations falls back to the floor, and it must
+        // carry the SAME uncertainty premium as a partially-triangulated one. Otherwise a totally-
+        // blind channel would be penalized LESS than a barely-seen one, and the engine would too
+        // eagerly recommend moving onto a channel it has no scan data for.
+        var basePenalty = Math.Max(triangulatedLoad, minDirectLoad) * GetUnobservedMultiplier(band);
         return (1.0 - confidence) * basePenalty;
     }
 

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -105,12 +105,16 @@ public class ChannelRecommendationService
     private const double MaxApScoreDegradation = 1.5;
 
     /// <summary>
-    /// Hard cap on how much a single per-AP fallback move may degrade another AP, regardless of
-    /// net benefit. A net-positive standalone move (the moving AP gains more than the total it
-    /// degrades others) is allowed past MaxApScoreDegradation, but never past this - so we never
-    /// wreck one AP to slightly help the site. 2.0 = the victim's score may at most double.
+    /// Absolute score a per-AP fallback move may never push another AP to, regardless of net
+    /// benefit. A net-positive standalone move (the moving AP gains more than the total it degrades
+    /// others) is allowed even past MaxApScoreDegradation, but never if it leaves a victim above
+    /// this score - so we never put one AP into genuinely bad shape to help the site. Absolute
+    /// (not a multiple of the victim's base) because "bad" is an absolute condition: a high score
+    /// means heavy interference regardless of where the AP started. 5.0 ~ where an AP is clearly
+    /// suffering (a real AP at ~5.3 already gets flagged for improvement); a modest sacrifice like
+    /// pushing a neighbor 1.9 -> 2.9 stays well clear of it.
     /// </summary>
-    private const double CatastrophicDegradation = 2.0;
+    private const double CatastrophicAbsoluteScore = 5.0;
 
     /// <summary>
     /// Minimum neighbor signal to count as external interference. Matches the CCA
@@ -682,13 +686,14 @@ public class ChannelRecommendationService
                     var otherScore = ScoreAp(graph, trial, j, band);
                     if (otherScore > otherCurrent) totalDegradation += otherScore - otherCurrent;
 
-                    if (otherScore / otherCurrent > CatastrophicDegradation)
+                    // Catastrophic: this move would push a victim into genuinely bad territory.
+                    if (otherScore > CatastrophicAbsoluteScore && otherScore > otherCurrent)
                     {
                         _logger.LogDebug(
-                            "[ChannelRec] Per-AP fallback: {ApName} -> ch{Ch} would wreck {Victim} " +
-                            "{From:F3}->{To:F3} ({Ratio:F2}x > {Cap:P0} cap), skipping",
+                            "[ChannelRec] Per-AP fallback: {ApName} -> ch{Ch} would push {Victim} " +
+                            "{From:F3}->{To:F3} above the {Cap:F1} ceiling, skipping",
                             node.Name, candidateCh, graph.Nodes[j].Name, otherCurrent, otherScore,
-                            otherScore / otherCurrent, CatastrophicDegradation);
+                            CatastrophicAbsoluteScore);
                         reject = true;
                         break;
                     }
@@ -717,7 +722,7 @@ public class ChannelRecommendationService
             {
                 _logger.LogDebug(
                     "[ChannelRec] Per-AP fallback: {ApName} ch{Current} (score {CurrentScore:F3}) → " +
-                    "ch{Best} (score {BestScore:F3}), no degradation to others",
+                    "ch{Best} (score {BestScore:F3}), net-positive for the site",
                     node.Name, node.CurrentChannel, scoreInFinal, fallbackChannel, fallbackScore);
                 rec.RecommendedChannel = fallbackChannel;
                 rec.RecommendedWidth = fallbackWidth;

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -76,14 +76,18 @@ public class ChannelRecommendationService
     /// Prevents churn when the gain is negligible (e.g., 0.7 → 0.1 = 0.6 gain).
     /// Both this AND MinApImprovementPercent must be met.
     /// </summary>
-    private const double MinApAbsoluteImprovement = 1.0;
+    // Tuned to 0.6 (from 1.0): surfaces moderate real gains (e.g. a quieter co-channel) now that
+    // scoring is position-independent, so loosening cannot oscillate. Both gates AND'd.
+    private const double MinApAbsoluteImprovement = 0.6;
 
     /// <summary>
     /// Minimum percentage score improvement for an individual AP to justify a move.
     /// Prevents moving APs where the improvement is small relative to current score
     /// (e.g., 3.0 → 2.8 = 7%). Both this AND MinApAbsoluteImprovement must be met.
     /// </summary>
-    private const double MinApImprovementPercent = 0.30;
+    // Tuned to 0.15 (from 0.30): 30% missed genuinely-better channels whose gain was real but
+    // moderate (~15-25%). Both this AND MinApAbsoluteImprovement must be met.
+    private const double MinApImprovementPercent = 0.15;
 
     /// <summary>
     /// Penalty for channels with no historical data. Unknown channels carry more
@@ -1628,7 +1632,7 @@ public class ChannelRecommendationService
         return baseScore + penalty;
     }
 
-    private (( int Channel, int Width)[] Assignment, double Score) ExhaustiveSearch(
+    private ((int Channel, int Width)[] Assignment, double Score) ExhaustiveSearch(
         InterferenceGraph graph,
         RadioBand band,
         HashSet<int> pinnedIndices,

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -122,12 +122,31 @@ public class ChannelRecommendationService
     /// Uncertainty multiplier for external load on channels with no direct neighbor
     /// observations. Triangulation discovers some neighbors but not all - the observer
     /// AP may miss neighbors visible from the target's location. This multiplier inflates
-    /// the triangulated estimate to account for missing neighbors. Applied on top of the
-    /// base triangulated load: total = base + base * multiplier = base * (1 + multiplier).
-    /// 2.0 means unobserved channels see 3x their triangulated estimate, which roughly
-    /// matches the ~3x underestimate observed in testing.
+    /// the triangulated estimate to account for missing neighbors. The full penalty only
+    /// applies to channels we have no other evidence for; channels we have historic
+    /// occupancy or a resident sibling AP for are scaled down via <see cref="ObservationConfidence"/>.
     /// </summary>
-    private const double UnobservedChannelMultiplier = 2.0;
+    private const double UnobservedChannelMultiplier = 1.5;
+
+    /// <summary>
+    /// Observation confidence for a candidate channel this AP has measured historic occupancy
+    /// of (within the metrics window). We have real airtime data for it, so the uncertainty
+    /// penalty is mostly - but not entirely (data can be stale) - waived.
+    /// </summary>
+    private const double HistoricOccupancyConfidence = 0.85;
+
+    /// <summary>
+    /// Observation confidence for a candidate channel a sibling AP is currently resident on
+    /// and this AP hears well. The sibling is a live observer of that channel's conditions,
+    /// though from its own location, so confidence is high but below historic/direct.
+    /// </summary>
+    private const double SiblingResidentConfidence = 0.70;
+
+    /// <summary>
+    /// Minimum internal (propagation) weight for a resident sibling AP to count as an observer
+    /// of a channel. Below this the sibling is too far to characterize this AP's RF environment.
+    /// </summary>
+    private const double SiblingObserverMinWeight = 0.4;
 
     /// <summary>
     /// Multiplier for internal (own AP) co-channel interference. Co-channeling your
@@ -742,38 +761,9 @@ public class ChannelRecommendationService
             score += historicalPenalty + fallbackPenalty * bandStress;
         }
 
-        // Unobserved channel uncertainty: inflate triangulated load on channels where the
-        // AP has no direct neighbor observations. Uses max of (triangulated × multiplier)
-        // and (minimum direct load) as a floor so zero-data channels don't score 0.0.
+        // Unobserved channel uncertainty (confidence-weighted, see ComputeUnobservedPenalty)
         for (int i = 0; i < n; i++)
-        {
-            var directChannels = graph.DirectlyObservedChannels[i];
-            if (directChannels.Count == 0) continue;
-
-            var apSpan = ChannelSpanHelper.GetChannelSpan(band, assignment[i].Channel, assignment[i].Width);
-            bool hasDirectOnAssigned = directChannels.Any(dc =>
-                ChannelSpanHelper.SpansOverlap(apSpan, (dc, dc)));
-
-            if (!hasDirectOnAssigned)
-            {
-                double triangulatedLoad = 0;
-                foreach (var (extChannel, extWeight) in graph.ExternalLoad[i])
-                {
-                    if (ChannelSpanHelper.SpansOverlap(apSpan, (extChannel, extChannel)))
-                        triangulatedLoad += extWeight;
-                }
-
-                double minDirectLoad = double.MaxValue;
-                foreach (var dc in directChannels)
-                {
-                    if (graph.ExternalLoad[i].TryGetValue(dc, out var directWeight))
-                        minDirectLoad = Math.Min(minDirectLoad, directWeight);
-                }
-                if (minDirectLoad == double.MaxValue) minDirectLoad = 0;
-
-                score += Math.Max(triangulatedLoad * UnobservedChannelMultiplier, minDirectLoad);
-            }
-        }
+            score += ComputeUnobservedPenalty(graph, band, i, assignment);
 
         return score;
     }
@@ -813,44 +803,6 @@ public class ChannelRecommendationService
                 score += extWeight;
         }
 
-        // Unobserved channel uncertainty: if this AP has direct neighbor observations on
-        // some channels but NOT on the candidate channel, the external load is based only
-        // on triangulated estimates which typically underestimate (observers miss neighbors
-        // visible from the target's location). Two adjustments:
-        // 1. Inflate existing triangulated load by a multiplier (accounts for missed neighbors)
-        // 2. Apply a floor = minimum direct external load across observed channels (prevents
-        //    channels with zero triangulated data from scoring 0.0 when the site has active neighbors)
-        var directChannels = graph.DirectlyObservedChannels[apIndex];
-        if (directChannels.Count > 0)
-        {
-            bool hasDirectOnAssigned = directChannels.Any(dc =>
-                ChannelSpanHelper.SpansOverlap(apSpan, (dc, dc)));
-
-            if (!hasDirectOnAssigned)
-            {
-                // Sum up the external load already added for this channel (all triangulated)
-                double triangulatedLoad = 0;
-                foreach (var (extChannel, extWeight) in graph.ExternalLoad[apIndex])
-                {
-                    if (ChannelSpanHelper.SpansOverlap(apSpan, (extChannel, extChannel)))
-                        triangulatedLoad += extWeight;
-                }
-
-                // Minimum direct external load across observed channels as a floor.
-                // "An unobserved channel is at least as good as your best known channel."
-                double minDirectLoad = double.MaxValue;
-                foreach (var dc in directChannels)
-                {
-                    if (graph.ExternalLoad[apIndex].TryGetValue(dc, out var directWeight))
-                        minDirectLoad = Math.Min(minDirectLoad, directWeight);
-                }
-                if (minDirectLoad == double.MaxValue) minDirectLoad = 0;
-
-                var uncertainty = Math.Max(triangulatedLoad * UnobservedChannelMultiplier, minDirectLoad);
-                score += uncertainty;
-            }
-        }
-
         // Channel scan data (scaled by band stress multiplier)
         var bandStress = GetBandStressMultiplier(band);
         var ch = assignment[apIndex].Channel;
@@ -864,7 +816,109 @@ public class ChannelRecommendationService
         var (histPenalty, fallbackPenalty) = ComputeStressPenalty(graph, band, apIndex, assignment);
         score += histPenalty + fallbackPenalty * bandStress;
 
+        // Unobserved channel uncertainty (confidence-weighted)
+        score += ComputeUnobservedPenalty(graph, band, apIndex, assignment);
+
         return score;
+    }
+
+    /// <summary>
+    /// Unobserved-channel uncertainty penalty for an AP on its assigned channel. Triangulated
+    /// external load under-counts neighbors the observing AP can't hear, so a channel with no
+    /// direct observation would otherwise look artificially clean. This taxes that uncertainty,
+    /// scaled by how much real evidence we already have for the channel (see
+    /// <see cref="ObservationConfidence"/>): a channel we have historic occupancy of, or a
+    /// resident sibling AP on, is mostly trusted. The penalty is computed identically whether
+    /// the AP is resident on the channel or a candidate moving onto it, and draws confidence
+    /// only from stable signals (direct scan, historic occupancy, sibling CURRENT channel) so
+    /// it does not swing with transient scan coverage or the assignment being evaluated.
+    /// </summary>
+    private double ComputeUnobservedPenalty(
+        InterferenceGraph graph,
+        RadioBand band,
+        int apIndex,
+        (int Channel, int Width)[] assignment)
+    {
+        var directChannels = graph.DirectlyObservedChannels[apIndex];
+        if (directChannels.Count == 0) return 0;
+
+        var apSpan = ChannelSpanHelper.GetChannelSpan(band, assignment[apIndex].Channel, assignment[apIndex].Width);
+
+        var confidence = ObservationConfidence(graph, band, apIndex, apSpan, directChannels);
+        if (confidence >= 1.0) return 0;
+
+        double triangulatedLoad = 0;
+        foreach (var (extChannel, extWeight) in graph.ExternalLoad[apIndex])
+        {
+            if (ChannelSpanHelper.SpansOverlap(apSpan, (extChannel, extChannel)))
+                triangulatedLoad += extWeight;
+        }
+
+        // Floor: an unobserved channel is at least as loaded as this AP's best observed channel.
+        double minDirectLoad = double.MaxValue;
+        foreach (var dc in directChannels)
+        {
+            if (graph.ExternalLoad[apIndex].TryGetValue(dc, out var directWeight))
+                minDirectLoad = Math.Min(minDirectLoad, directWeight);
+        }
+        if (minDirectLoad == double.MaxValue) minDirectLoad = 0;
+
+        var basePenalty = Math.Max(triangulatedLoad * UnobservedChannelMultiplier, minDirectLoad);
+        return (1.0 - confidence) * basePenalty;
+    }
+
+    /// <summary>
+    /// How confident we are in the external-load estimate for an AP's assigned channel span,
+    /// in [0, 1]. 1.0 = a direct scan sighting on the channel (fully observed). Otherwise we
+    /// fall back to weaker-but-real evidence: this AP's measured historic occupancy of the
+    /// channel, or a sibling AP currently resident on it that this AP hears well. Uses each
+    /// sibling's CURRENT channel (not the assignment under evaluation) so confidence is stable.
+    /// </summary>
+    private double ObservationConfidence(
+        InterferenceGraph graph,
+        RadioBand band,
+        int apIndex,
+        (int Low, int High) apSpan,
+        HashSet<int> directChannels)
+    {
+        // Direct scan sighting on the assigned channel - fully observed, no uncertainty.
+        if (directChannels.Any(dc => ChannelSpanHelper.SpansOverlap(apSpan, (dc, dc))))
+            return 1.0;
+
+        double confidence = 0;
+        var node = graph.Nodes[apIndex];
+
+        // Historic occupancy: we have measured airtime for this AP on an overlapping channel.
+        if (node.HistoricalStress != null)
+        {
+            foreach (var histChannel in node.HistoricalStress.Keys)
+            {
+                var histSpan = ChannelSpanHelper.GetChannelSpan(band, histChannel, node.CurrentWidth);
+                if (ChannelSpanHelper.SpansOverlap(apSpan, histSpan))
+                {
+                    confidence = Math.Max(confidence, HistoricOccupancyConfidence);
+                    break;
+                }
+            }
+        }
+
+        // Sibling AP currently resident on the channel that this AP hears well - a live observer.
+        var n = graph.Nodes.Count;
+        for (int j = 0; j < n; j++)
+        {
+            if (j == apIndex) continue;
+            if (graph.InternalWeights[apIndex, j] < SiblingObserverMinWeight) continue;
+
+            var siblingNode = graph.Nodes[j];
+            var siblingSpan = ChannelSpanHelper.GetChannelSpan(band, siblingNode.CurrentChannel, siblingNode.CurrentWidth);
+            if (ChannelSpanHelper.SpansOverlap(apSpan, siblingSpan))
+            {
+                confidence = Math.Max(confidence, SiblingResidentConfidence);
+                break;
+            }
+        }
+
+        return confidence;
     }
 
     /// <summary>
@@ -1949,25 +2003,8 @@ public class ChannelRecommendationService
                     }
                 }
 
-                // Unobserved channel uncertainty
-                double unobservedPenalty = 0;
-                var directChannels = graph.DirectlyObservedChannels[i];
-                if (directChannels.Count > 0)
-                {
-                    bool hasDirectOnCh = directChannels.Any(dc =>
-                        ChannelSpanHelper.SpansOverlap(apSpan, (dc, dc)));
-                    if (!hasDirectOnCh)
-                    {
-                        double minDirectLoad = double.MaxValue;
-                        foreach (var dc in directChannels)
-                        {
-                            if (graph.ExternalLoad[i].TryGetValue(dc, out var dw))
-                                minDirectLoad = Math.Min(minDirectLoad, dw);
-                        }
-                        if (minDirectLoad == double.MaxValue) minDirectLoad = 0;
-                        unobservedPenalty = Math.Max(externalScore * UnobservedChannelMultiplier, minDirectLoad);
-                    }
-                }
+                // Unobserved channel uncertainty (confidence-weighted, matches ScoreAp/ScoreAssignment)
+                double unobservedPenalty = ComputeUnobservedPenalty(graph, band, i, testAssignment);
 
                 var total = internalScore + externalScore + scanScore + stressScore + unobservedPenalty;
                 var marker = ch == currentAssignment[i].Channel ? " <<<" : "";

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -110,11 +110,11 @@ public class ChannelRecommendationService
     /// others) is allowed even past MaxApScoreDegradation, but never if it leaves a victim above
     /// this score - so we never put one AP into genuinely bad shape to help the site. Absolute
     /// (not a multiple of the victim's base) because "bad" is an absolute condition: a high score
-    /// means heavy interference regardless of where the AP started. 5.0 ~ where an AP is clearly
-    /// suffering (a real AP at ~5.3 already gets flagged for improvement); a modest sacrifice like
-    /// pushing a neighbor 1.9 -> 2.9 stays well clear of it.
+    /// means heavy interference regardless of where the AP started. 4.0 ~ where an AP is clearly
+    /// suffering on the CCA-anchored scale (the worst real APs sit ~4); a modest sacrifice like
+    /// pushing a neighbor 1.2 -> 2.0 stays well clear of it.
     /// </summary>
-    private const double CatastrophicAbsoluteScore = 5.0;
+    private const double CatastrophicAbsoluteScore = 4.0;
 
     /// <summary>
     /// Minimum neighbor signal to count as external interference. Matches the CCA

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -224,6 +224,85 @@ public class ChannelRecommendationServiceTests
         score.Should().Be(0);
     }
 
+    // --- Unobserved-channel uncertainty (confidence-weighted) ---
+
+    // Builds a 2-AP graph where the sibling sits on a non-overlapping channel, so the
+    // subject AP (index 0) is the only contributor to the score - isolating its external
+    // + unobserved-uncertainty terms.
+    private InterferenceGraph BuildSubjectGraph(int siblingChannel = 100)
+    {
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "Subject", RadioBand.Band5GHz, 149),
+            CreateAp("aa:bb:cc:dd:ee:02", "Sibling", RadioBand.Band5GHz, siblingChannel)
+        };
+        var graph = _service.BuildInterferenceGraph(aps, RadioBand.Band5GHz, null, null, null);
+        graph.DirectlyObservedChannels[0] = new HashSet<int> { 36 };
+        graph.ExternalLoad[0] = new Dictionary<int, double> { { 36, 1.0 }, { 149, 0.5 } };
+        return graph;
+    }
+
+    [Fact]
+    public void ScoreAssignment_HistoricOccupancy_SoftensUnobservedPenalty()
+    {
+        // ch149 is triangulated-only (not directly scanned), so it normally carries the full
+        // uncertainty penalty. But if the AP has measured historic occupancy of ch149, we have
+        // real data for it and the penalty should be mostly waived (confidence 0.85).
+        var graph = BuildSubjectGraph();
+        var assignment = new[] { (149, 80), (100, 80) };
+
+        graph.Nodes[0].HistoricalStress = null;
+        var scoreNoHistory = _service.ScoreAssignment(graph, assignment, RadioBand.Band5GHz);
+
+        graph.Nodes[0].HistoricalStress = new Dictionary<int, (double, double, double)>
+        {
+            { 149, (0, 0, 0) } // benign measured airtime - isolates the unobserved term
+        };
+        var scoreWithHistory = _service.ScoreAssignment(graph, assignment, RadioBand.Band5GHz);
+
+        scoreWithHistory.Should().BeLessThan(scoreNoHistory);
+        // Penalty scaled by (1 - 0.85): the historic channel keeps only 15% of the cliff.
+        (scoreNoHistory - scoreWithHistory).Should().BeApproximately(0.85, 0.05);
+    }
+
+    [Fact]
+    public void ScoreAssignment_UnobservedChannelNoEvidence_StillPenalized()
+    {
+        // Soundness guard: a channel with no direct scan, no historic occupancy, and no resident
+        // sibling must still be taxed, so genuinely-unknown channels can't win by looking empty.
+        var graph = BuildSubjectGraph();
+        graph.Nodes[0].HistoricalStress = null;
+
+        var onObserved = _service.ScoreAssignment(
+            graph, new[] { (36, 80), (100, 80) }, RadioBand.Band5GHz);
+        var onUnobserved = _service.ScoreAssignment(
+            graph, new[] { (149, 80), (100, 80) }, RadioBand.Band5GHz);
+
+        onUnobserved.Should().BeGreaterThan(onObserved);
+    }
+
+    [Fact]
+    public void ScoreAssignment_UnobservedPenalty_IndependentOfApCurrentChannel()
+    {
+        // Anti-oscillation invariant: a candidate channel must score the same whether the AP is
+        // currently resident on it or moving onto it. Confidence is drawn from stable signals
+        // (historic occupancy), not the AP's current position, so the score doesn't swing on moves.
+        var graph = BuildSubjectGraph();
+        graph.Nodes[0].HistoricalStress = new Dictionary<int, (double, double, double)>
+        {
+            { 149, (0, 0, 0) }
+        };
+        var assignment = new[] { (149, 80), (100, 80) };
+
+        graph.Nodes[0].CurrentChannel = 36;  // ch149 is a candidate the AP is moving to
+        var asCandidate = _service.ScoreAssignment(graph, assignment, RadioBand.Band5GHz);
+
+        graph.Nodes[0].CurrentChannel = 149; // AP is resident on ch149
+        var asResident = _service.ScoreAssignment(graph, assignment, RadioBand.Band5GHz);
+
+        asCandidate.Should().BeApproximately(asResident, 0.001);
+    }
+
     // --- Optimization ---
 
     [Fact]

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -261,8 +261,9 @@ public class ChannelRecommendationServiceTests
         var scoreWithHistory = _service.ScoreAssignment(graph, assignment, RadioBand.Band5GHz);
 
         scoreWithHistory.Should().BeLessThan(scoreNoHistory);
-        // Penalty scaled by (1 - 0.85): the historic channel keeps only 15% of the cliff.
-        (scoreNoHistory - scoreWithHistory).Should().BeApproximately(0.85, 0.05);
+        // History keeps only 15% of the cliff, so the gap is 0.85 of the full penalty. The floor
+        // now carries the band uncertainty multiplier (x2.0 on 5 GHz), so the base penalty is 2.0.
+        (scoreNoHistory - scoreWithHistory).Should().BeApproximately(1.7, 0.05);
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -303,6 +303,33 @@ public class ChannelRecommendationServiceTests
         asCandidate.Should().BeApproximately(asResident, 0.001);
     }
 
+    [Fact]
+    public void ScoreAssignment_UnobservedPenalty_LowerForBandsWithBetterPropagation()
+    {
+        // Scan completeness tracks propagation: 2.4 GHz sees nearly every neighbor, so its
+        // unobserved channels are less uncertain than 6 GHz, which dies fastest through walls.
+        // The uncertainty multiplier must therefore order 2.4 < 5 < 6.
+        double UnobservedScore(RadioBand band, int observedCh, int unobservedCh)
+        {
+            var aps = new List<AccessPointSnapshot>
+            {
+                CreateAp("aa:bb:cc:dd:ee:01", "Subject", band, observedCh, width: 20)
+            };
+            var graph = _service.BuildInterferenceGraph(aps, band, null, null, null);
+            graph.DirectlyObservedChannels[0] = new HashSet<int> { observedCh };
+            graph.ExternalLoad[0] = new Dictionary<int, double> { { observedCh, 0.1 }, { unobservedCh, 1.0 } };
+            graph.Nodes[0].HistoricalStress = null;
+            return _service.ScoreAssignment(graph, new[] { (unobservedCh, 20) }, band);
+        }
+
+        var score2_4 = UnobservedScore(RadioBand.Band2_4GHz, 1, 11);
+        var score5 = UnobservedScore(RadioBand.Band5GHz, 36, 149);
+        var score6 = UnobservedScore(RadioBand.Band6GHz, 5, 213);
+
+        score2_4.Should().BeLessThan(score5);
+        score5.Should().BeLessThan(score6);
+    }
+
     // --- Optimization ---
 
     [Fact]

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -26,15 +26,15 @@ public class ChannelRecommendationServiceTests
         int width = 80, int txPower = 20, bool hasDfs = false,
         bool isMeshChild = false, string? meshParentMac = null,
         RadioBand? meshUplinkBand = null, int? meshUplinkChannel = null) => new()
-    {
-        Mac = mac,
-        Name = name,
-        IsOnline = true,
-        IsMeshChild = isMeshChild,
-        MeshParentMac = meshParentMac,
-        MeshUplinkBand = meshUplinkBand,
-        MeshUplinkChannel = meshUplinkChannel,
-        Radios = new()
+        {
+            Mac = mac,
+            Name = name,
+            IsOnline = true,
+            IsMeshChild = isMeshChild,
+            MeshParentMac = meshParentMac,
+            MeshUplinkBand = meshUplinkBand,
+            MeshUplinkChannel = meshUplinkChannel,
+            Radios = new()
         {
             new RadioSnapshot
             {
@@ -46,7 +46,7 @@ public class ChannelRecommendationServiceTests
                 HasDfs = hasDfs
             }
         }
-    };
+        };
 
     // --- Graph Building ---
 
@@ -328,6 +328,76 @@ public class ChannelRecommendationServiceTests
 
         score2_4.Should().BeLessThan(score5);
         score5.Should().BeLessThan(score6);
+    }
+
+    // --- Directional interference (EIRP-aware) ---
+
+    // Two placed APs ~45 m apart, same channel, with the given TX powers. Returns the graph.
+    private InterferenceGraph BuildPlacedPair(int txPowerA, int txPowerB)
+    {
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "AP-A", RadioBand.Band5GHz, 36, txPower: txPowerA),
+            CreateAp("aa:bb:cc:dd:ee:02", "AP-B", RadioBand.Band5GHz, 36, txPower: txPowerB)
+        };
+        var propCtx = new ApPropagationContext
+        {
+            ApsByMac = new Dictionary<string, PropagationAp>
+            {
+                ["aa:bb:cc:dd:ee:01"] = new()
+                {
+                    Mac = "aa:bb:cc:dd:ee:01",
+                    Model = "U6-Pro",
+                    Latitude = 36.0000,
+                    Longitude = -94.0000,
+                    Floor = 1,
+                    TxPowerDbm = txPowerA,
+                    AntennaGainDbi = 3,
+                    MountType = "ceiling"
+                },
+                ["aa:bb:cc:dd:ee:02"] = new()
+                {
+                    Mac = "aa:bb:cc:dd:ee:02",
+                    Model = "U6-Pro",
+                    Latitude = 36.0004,
+                    Longitude = -94.0000,
+                    Floor = 1,
+                    TxPowerDbm = txPowerB,
+                    AntennaGainDbi = 3,
+                    MountType = "ceiling"
+                }
+            },
+            WallsByFloor = new Dictionary<int, List<PropagationWall>>(),
+            Buildings = null
+        };
+        return _service.BuildInterferenceGraph(aps, RadioBand.Band5GHz, propCtx, null, null);
+    }
+
+    [Fact]
+    public void BuildInterferenceGraph_AsymmetricEirp_DirectionalWeightLowerForLowerPowerAggressor()
+    {
+        // AP-A full power (20 dBm), AP-B intentionally low (5 dBm).
+        var graph = BuildPlacedPair(txPowerA: 20, txPowerB: 5);
+
+        // Directional [aggressor, victim]: the low-power AP-B interferes with AP-A LESS than the
+        // full-power AP-A interferes with AP-B (B transmits weaker, so its signal at A is lower).
+        graph.DirectionalWeights[1, 0].Should().BeLessThan(graph.DirectionalWeights[0, 1]);
+
+        // The symmetric weight is the worst case of both directions - it equals the stronger one,
+        // so it does NOT credit B's low power (which is exactly why the degradation guard needs
+        // the directional weight instead).
+        graph.InternalWeights[0, 1].Should().Be(graph.InternalWeights[1, 0]);
+        graph.InternalWeights[0, 1].Should().BeApproximately(graph.DirectionalWeights[0, 1], 0.001);
+    }
+
+    [Fact]
+    public void BuildInterferenceGraph_EqualEirp_DirectionalWeightsSymmetric()
+    {
+        // With equal TX power, the two directions are the same - confirms the asymmetry above is
+        // driven by EIRP, not by anything else.
+        var graph = BuildPlacedPair(txPowerA: 20, txPowerB: 20);
+
+        graph.DirectionalWeights[0, 1].Should().BeApproximately(graph.DirectionalWeights[1, 0], 0.001);
     }
 
     // --- Optimization ---

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -109,8 +109,8 @@ public class ChannelRecommendationServiceTests
 
         var graph = _service.BuildInterferenceGraph(aps, RadioBand.Band5GHz, null, null, null);
 
-        // -65 dBm → weight 0.625
-        graph.InternalWeights[0, 1].Should().BeApproximately(0.625, 0.01);
+        // -65 dBm, CCA-anchored: (-65 + 82) / 32 = 0.531
+        graph.InternalWeights[0, 1].Should().BeApproximately(0.531, 0.01);
     }
 
     [Fact]
@@ -721,14 +721,14 @@ public class ChannelRecommendationServiceTests
 
         // AP-1 (index 0) should have triangulated external load on ch36
         graph.ExternalLoad[0].Should().ContainKey(36);
-        // Unplaced APs have internal weight 0.625. Neighbor at -55 dBm → weight 0.875.
+        // Unplaced APs have internal weight 0.531. Neighbor at -55 dBm → weight 0.844 (CCA-anchored).
         // Width matches AP (80=80), no width scaling.
-        // Triangulated weight = 0.875 * 0.625 = 0.547
-        graph.ExternalLoad[0][36].Should().BeApproximately(0.547, 0.05);
+        // Triangulated weight = 0.844 * 0.531 = 0.448
+        graph.ExternalLoad[0][36].Should().BeApproximately(0.448, 0.05);
 
         // AP-2 (index 1) should also have direct external load on ch36
         graph.ExternalLoad[1].Should().ContainKey(36);
-        graph.ExternalLoad[1][36].Should().BeApproximately(0.875, 0.05);
+        graph.ExternalLoad[1][36].Should().BeApproximately(0.844, 0.05);
     }
 
     [Fact]
@@ -758,8 +758,8 @@ public class ChannelRecommendationServiceTests
         var graph = _service.BuildInterferenceGraph(aps, RadioBand.Band5GHz, null, scans, null);
 
         graph.ExternalLoad[0].Should().ContainKey(36);
-        // -60 dBm → 0.75, -70 dBm → 0.5, sum = 1.25
-        graph.ExternalLoad[0][36].Should().BeApproximately(1.25, 0.05);
+        // -60 dBm → 0.6875, -70 dBm → 0.375, sum = 1.0625 (CCA-anchored)
+        graph.ExternalLoad[0][36].Should().BeApproximately(1.0625, 0.05);
     }
 
     [Fact]
@@ -834,9 +834,9 @@ public class ChannelRecommendationServiceTests
         // AP-3 (index 2) should have external load on ch100 from the best estimate
         graph.ExternalLoad[2].Should().ContainKey(100);
 
-        // The stronger sighting (-55 dBm → weight 0.875) × proximity 0.625 = 0.547
-        // beats the weaker sighting (-75 dBm → weight 0.375) × proximity 0.625 = 0.234
-        graph.ExternalLoad[2][100].Should().BeApproximately(0.547, 0.05);
+        // The stronger sighting (-55 dBm → weight 0.844) × proximity 0.531 = 0.448
+        // beats the weaker sighting (-75 dBm → weight 0.219) × proximity 0.531 = 0.116
+        graph.ExternalLoad[2][100].Should().BeApproximately(0.448, 0.05);
     }
 
     // --- Re-validation after per-AP filtering ---

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelSpanHelperTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelSpanHelperTests.cs
@@ -105,15 +105,23 @@ public class ChannelSpanHelperTests
     }
 
     [Fact]
-    public void SignalToInterferenceWeight_WeakSignal_Returns0_1()
+    public void SignalToInterferenceWeight_BelowCca_ReturnsZero()
     {
-        ChannelSpanHelper.SignalToInterferenceWeight(-90).Should().BeApproximately(0.1, 0.01);
+        // -90 dBm is below the -82 CCA threshold: the radio doesn't defer, so no contention.
+        ChannelSpanHelper.SignalToInterferenceWeight(-90).Should().Be(0.0);
     }
 
     [Fact]
-    public void SignalToInterferenceWeight_TypicalSpacing_Returns0_625()
+    public void SignalToInterferenceWeight_AtCca_ReturnsZero()
     {
-        ChannelSpanHelper.SignalToInterferenceWeight(-65).Should().BeApproximately(0.625, 0.01);
+        ChannelSpanHelper.SignalToInterferenceWeight(-82).Should().Be(0.0);
+    }
+
+    [Fact]
+    public void SignalToInterferenceWeight_TypicalSpacing_Returns0_531()
+    {
+        // -65 dBm, CCA-anchored: (-65 + 82) / 32 = 0.531
+        ChannelSpanHelper.SignalToInterferenceWeight(-65).Should().BeApproximately(0.531, 0.01);
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.WiFi.Tests/LoadImbalanceRuleTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/LoadImbalanceRuleTests.cs
@@ -279,7 +279,7 @@ public class LoadImbalanceRuleTests
     }
 
     [Fact]
-    public void FarApart_ClientWithNullSignal_NotSuppressed()
+    public void FarApart_NullSignalClientIgnored_Suppressed()
     {
         var aps = new List<AccessPointSnapshot>
         {
@@ -287,11 +287,11 @@ public class LoadImbalanceRuleTests
             CreateAp("aa:bb:cc:dd:ee:02", "AP-Garage", 2)
         };
 
-        // One client missing signal data
+        // One client missing signal data (e.g. an offline/idle device)
         var clients = new List<WirelessClientSnapshot>
         {
             CreateClient("aa:bb:cc:dd:ee:01", signal: -45),
-            CreateClient("aa:bb:cc:dd:ee:01", signal: null), // missing signal
+            CreateClient("aa:bb:cc:dd:ee:01", signal: null), // missing signal - ignored, not weak
         };
         for (int i = 0; i < 15; i++)
             clients.Add(CreateClient("aa:bb:cc:dd:ee:01", signal: -45));
@@ -303,9 +303,9 @@ public class LoadImbalanceRuleTests
         var ctx = CreateContext(aps, clients, propCtx);
         var issue = _rule.Evaluate(ctx);
 
-        // Should NOT suppress entirely because one client has null signal
-        issue.Should().NotBeNull();
-        issue!.Severity.Should().Be(HealthIssueSeverity.Info, "null signal prevents full suppression");
+        // A missing signal is treated as offline/idle, not weak. With every other client strong,
+        // the separate-zone imbalance is suppressed entirely.
+        issue.Should().BeNull();
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.WiFi.Tests/LoadImbalanceRuleTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/LoadImbalanceRuleTests.cs
@@ -236,7 +236,7 @@ public class LoadImbalanceRuleTests
         {
             CreateClient("aa:bb:cc:dd:ee:01", signal: -45),
             CreateClient("aa:bb:cc:dd:ee:01", signal: -45),
-            CreateClient("aa:bb:cc:dd:ee:01", signal: -75), // weak
+            CreateClient("aa:bb:cc:dd:ee:01", signal: -85), // weak for its band (< -78 on 5 GHz)
         };
         // Pad to match TotalClients
         for (int i = 0; i < 14; i++)


### PR DESCRIPTION
A substantial upgrade to the Wi-Fi Channel Recommendation engine, plus supporting UI and a few fixes surfaced along the way.

## Channel recommendation engine

- **Directional, EIRP-aware co-channel interference** - interference between your APs is now computed in the direction it actually travels. A low-power AP correctly counts as a gentler neighbor than a full-power one, rather than both being treated as the symmetric worst case.
- **CCA-anchored interference curve** - signal-to-interference weighting is anchored at the CCA threshold (-82 dBm), where radios actually stop deferring. Barely-audible neighbors are no longer over-counted; strong ones are essentially unchanged.
- **Net-benefit per-AP moves** - a single-AP channel change is suggested when it improves the whole site (the moving AP gains more than the total it costs its neighbors), with an absolute ceiling so a move can never push another AP into genuinely-bad territory. This replaces a flat per-AP degradation cap that over-protected low-scoring APs.
- **Uncertainty-aware unobserved channels** - channels with no scan data are taxed for that uncertainty (band-aware, since scan completeness tracks propagation range), and that tax is confidence-weighted down when we do have evidence (measured historic occupancy, or a resident sibling AP we hear well). A channel we've never seen no longer looks artificially clean, a totally-blind channel is no longer penalized less than a barely-seen one, and the penalty no longer swings with transient scan coverage.
- **Retuned move thresholds** now that scoring is position-independent (so loosening them can't oscillate).
- **Consistent recommendations** - the scan cache key is bucketed to the minute, so the Overview card and the Channel Plan tab compute against the same scan snapshot instead of drifting onto different recommendations.

## Wi-Fi Overview

- **Channel Optimization card** under Client Band Distribution, summarizing available channel improvements and linking to the plan, auto-selecting a band that has recommendations.
- Expanded, restyled **"How This Works"** explainer on the Channel Plan that lays out what the engine actually models.

## Fixes

- **Metrics channel timeline** - the channel-change timeline now only renders for APs that actually changed channels in the window, and events are filtered by AP at the source, so one AP's channel marker no longer bleeds onto another AP's chart after switching the AP filter.
- **Load imbalance** - weak-signal suppression is judged per band (-75 dBm is weak on 2.4 GHz but fine on 5/6 GHz), and clients with no reported signal are ignored rather than assumed weak (a missing reading usually just means an idle/offline device).
- **Band tabs** - center their contents so a mesh/issue badge no longer shifts the label.
- Assorted Channel Plan and Overview layout polish.

## Tests

193 passing, including added directional-weight, confidence/unobserved-penalty, CCA-curve, and per-band load-imbalance cases.
