### PR TITLE
ISP Health: brief & partial-loss disruptions, congestion accuracy, timeline UX, and faster loads

### DIFF
--- a/src/NetworkOptimizer.Storage/NetworkOptimizer.Storage.csproj
+++ b/src/NetworkOptimizer.Storage/NetworkOptimizer.Storage.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="NetworkOptimizer.Storage.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\NetworkOptimizer.Alerts\NetworkOptimizer.Alerts.csproj" />
     <ProjectReference Include="..\NetworkOptimizer.Core\NetworkOptimizer.Core.csproj" />
     <ProjectReference Include="..\NetworkOptimizer.Threats\NetworkOptimizer.Threats.csproj" />

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -1234,28 +1234,7 @@ from(bucket: ""{_bucket}"")
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
-        var results = new Dictionary<string, List<LatencySeriesPoint>>();
-        await foreach (var record in QueryFluxAsync(flux, ct))
-        {
-            var targetId = record.GetValueByKey("target_id") as string;
-            if (string.IsNullOrEmpty(targetId)) continue;
-            if (!results.TryGetValue(targetId, out var list))
-            {
-                list = new List<LatencySeriesPoint>();
-                results[targetId] = list;
-            }
-            list.Add(new LatencySeriesPoint
-            {
-                Time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow),
-                RttAvgMs = AsDoubleOrNull(record.GetValueByKey("rtt_avg_ms")),
-                RttMaxMs = AsDoubleOrNull(record.GetValueByKey("rtt_max_ms")),
-                JitterMs = AsDoubleOrNull(record.GetValueByKey("jitter_ms")),
-                LossPercent = AsDoubleOrNull(record.GetValueByKey("loss_percent"))
-            });
-        }
-        foreach (var list in results.Values)
-            list.Sort((a, b) => a.Time.CompareTo(b.Time));
-        return results;
+        return ParseLatencyDetailCsv(await QueryRawAsync(flux, ct));
     }
 
     /// <summary>
@@ -1281,18 +1260,9 @@ from(bucket: ""{_bucket}"")
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
-        var list = new List<LatencySeriesPoint>();
-        await foreach (var record in QueryFluxAsync(flux, ct))
-        {
-            list.Add(new LatencySeriesPoint
-            {
-                Time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow),
-                RttAvgMs = AsDoubleOrNull(record.GetValueByKey("rtt_avg_ms")),
-                RttMaxMs = AsDoubleOrNull(record.GetValueByKey("rtt_max_ms")),
-                JitterMs = AsDoubleOrNull(record.GetValueByKey("jitter_ms")),
-                LossPercent = AsDoubleOrNull(record.GetValueByKey("loss_percent"))
-            });
-        }
+        var byTarget = ParseLatencyDetailCsv(await QueryRawAsync(flux, ct));
+        // Single target filter, but flatten defensively in case the pivot emits more than one key.
+        var list = byTarget.Values.SelectMany(x => x).ToList();
         list.Sort((a, b) => a.Time.CompareTo(b.Time));
         return list;
     }
@@ -1835,6 +1805,154 @@ from(bucket: ""{_longtermBucket}"")
                 System.Globalization.CultureInfo.InvariantCulture, out var parsed)
             ? parsed : null
     };
+
+    /// <summary>
+    /// Runs a Flux query and returns the raw annotated CSV. Used for the high-volume latency-detail
+    /// reads, where the client's buffered FluxRecord model (a Dictionary&lt;string,object&gt; with
+    /// boxed values per record) is the dominant cost; <see cref="ParseLatencyDetailCsv"/> stream-parses
+    /// this directly into points with no per-record allocation. Same error handling as QueryFluxAsync.
+    /// </summary>
+    // The annotated CSV dialect (datatype/group/default header rows) - same as the client's default
+    // query dialect, so QueryRawAsync returns the format ParseLatencyDetailCsv expects.
+    private static readonly InfluxDB.Client.Api.Domain.Dialect AnnotatedCsvDialect = new(
+        header: true,
+        delimiter: ",",
+        annotations: new List<InfluxDB.Client.Api.Domain.Dialect.AnnotationsEnum>
+        {
+            InfluxDB.Client.Api.Domain.Dialect.AnnotationsEnum.Group,
+            InfluxDB.Client.Api.Domain.Dialect.AnnotationsEnum.Datatype,
+            InfluxDB.Client.Api.Domain.Dialect.AnnotationsEnum.Default,
+        },
+        commentPrefix: "#",
+        dateTimeFormat: null);
+
+    private async Task<string> QueryRawAsync(string flux, CancellationToken ct)
+    {
+        if (_client == null || string.IsNullOrEmpty(_org)) return string.Empty;
+        try
+        {
+            return await _client.GetQueryApi().QueryRawAsync(flux, AnnotatedCsvDialect, _org, ct);
+        }
+        catch (Exception ex) when (
+            ex is InfluxDB.Client.Core.Exceptions.NotFoundException
+            or InfluxDB.Client.Core.Exceptions.BadRequestException
+            or InfluxDB.Client.Core.Exceptions.UnauthorizedException)
+        {
+            _logger.LogWarning("InfluxDB query failed ({Error}) — check Settings > Monitoring", ex.Message);
+            _ = PersistHealthAsync(false, ex.Message, CancellationToken.None);
+            return string.Empty;
+        }
+    }
+
+    /// <summary>
+    /// Parses the annotated-CSV result of a latency-detail pivot query (columns target_id, _time,
+    /// rtt_avg_ms, rtt_max_ms, jitter_ms, loss_percent) directly into per-target point lists. Span-
+    /// based: the only allocations are the per-target list, the distinct target_id keys, and the
+    /// points themselves - no FluxRecord, no boxing, no intermediate copy. Annotation rows (#...) are
+    /// skipped and the column header is re-read whenever Flux emits one (default annotated dialect),
+    /// so column order is never assumed. Tag/field values in this measurement never contain commas,
+    /// so a plain comma split is safe.
+    /// </summary>
+    internal static Dictionary<string, List<LatencySeriesPoint>> ParseLatencyDetailCsv(string csv)
+    {
+        var result = new Dictionary<string, List<LatencySeriesPoint>>();
+        if (string.IsNullOrEmpty(csv)) return result;
+
+        int iTime = -1, iTarget = -1, iRtt = -1, iRttMax = -1, iJitter = -1, iLoss = -1;
+        var expectHeader = true; // first non-# line is a header (annotated dialect re-arms this after each #-block)
+        string? lastKey = null;
+        List<LatencySeriesPoint>? lastList = null;
+
+        var span = csv.AsSpan();
+        int pos = 0;
+        while (pos < span.Length)
+        {
+            var nl = span.Slice(pos).IndexOf('\n');
+            var line = nl < 0 ? span.Slice(pos) : span.Slice(pos, nl);
+            pos = nl < 0 ? span.Length : pos + nl + 1;
+            if (line.Length > 0 && line[line.Length - 1] == '\r') line = line.Slice(0, line.Length - 1);
+            if (line.IsEmpty) continue;
+            if (line[0] == '#') { expectHeader = true; continue; }
+
+            if (expectHeader)
+            {
+                iTime = iTarget = iRtt = iRttMax = iJitter = iLoss = -1;
+                int col = 0, p = 0;
+                while (true)
+                {
+                    var comma = line.Slice(p).IndexOf(',');
+                    var cell = comma < 0 ? line.Slice(p) : line.Slice(p, comma);
+                    if (cell.SequenceEqual("_time")) iTime = col;
+                    else if (cell.SequenceEqual("target_id")) iTarget = col;
+                    else if (cell.SequenceEqual("rtt_avg_ms")) iRtt = col;
+                    else if (cell.SequenceEqual("rtt_max_ms")) iRttMax = col;
+                    else if (cell.SequenceEqual("jitter_ms")) iJitter = col;
+                    else if (cell.SequenceEqual("loss_percent")) iLoss = col;
+                    col++;
+                    if (comma < 0) break;
+                    p += comma + 1;
+                }
+                expectHeader = false;
+                continue;
+            }
+
+            if (iTime < 0 || iTarget < 0) continue;
+
+            ReadOnlySpan<char> tTime = default, tTarget = default, tRtt = default, tRttMax = default, tJitter = default, tLoss = default;
+            int c = 0, q = 0;
+            while (true)
+            {
+                var comma = line.Slice(q).IndexOf(',');
+                var cell = comma < 0 ? line.Slice(q) : line.Slice(q, comma);
+                if (c == iTime) tTime = cell;
+                else if (c == iTarget) tTarget = cell;
+                else if (c == iRtt) tRtt = cell;
+                else if (c == iRttMax) tRttMax = cell;
+                else if (c == iJitter) tJitter = cell;
+                else if (c == iLoss) tLoss = cell;
+                c++;
+                if (comma < 0) break;
+                q += comma + 1;
+            }
+
+            if (tTarget.IsEmpty || tTime.IsEmpty) continue;
+            if (!DateTime.TryParse(tTime, System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.RoundtripKind, out var time))
+                continue;
+
+            // Rows are grouped by target, so reuse the key/list across a run rather than re-allocating.
+            List<LatencySeriesPoint>? list;
+            if (lastKey != null && tTarget.SequenceEqual(lastKey))
+            {
+                list = lastList;
+            }
+            else
+            {
+                var key = tTarget.ToString();
+                if (!result.TryGetValue(key, out list)) { list = new List<LatencySeriesPoint>(); result[key] = list; }
+                lastKey = key;
+                lastList = list;
+            }
+
+            list!.Add(new LatencySeriesPoint
+            {
+                Time = ToUtc(time),
+                RttAvgMs = ParseDoubleOrNull(tRtt),
+                RttMaxMs = ParseDoubleOrNull(tRttMax),
+                JitterMs = ParseDoubleOrNull(tJitter),
+                LossPercent = ParseDoubleOrNull(tLoss)
+            });
+        }
+
+        foreach (var list in result.Values)
+            list.Sort((a, b) => a.Time.CompareTo(b.Time));
+        return result;
+    }
+
+    private static double? ParseDoubleOrNull(ReadOnlySpan<char> s) =>
+        s.IsEmpty ? null
+        : double.TryParse(s, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var v) ? v
+        : null;
 
     private static int? AsIntOrNull(object? v) => v switch
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -403,17 +403,21 @@ else
     @if (r.Outages.Count > 0)
     {
         <div class="card isp-health-card" id="isp-outages">
-            <div class="card-header"><h2 class="card-title">@(r.Outages.Any(o => !o.IsBrief) ? "Internet Outages" : "Brief Internet Disruptions") (@WindowLabel(r))</h2></div>
+            <div class="card-header"><h2 class="card-title">@OutageSectionTitle(r) (@WindowLabel(r))</h2></div>
             <div class="card-body">
                 <div class="isp-outage-list">
                     @foreach (var outage in r.Outages)
                     {
                         <div class="isp-outage">
                             <div class="isp-outage-head">
-                                <span class="isp-event-badge @(outage.IsBrief ? "isp-event-badge-warning" : "isp-event-badge-danger")" data-tooltip="@OutageScoreTooltip(outage)">@(outage.IsBrief ? "Brief" : "Outage")</span>
+                                <span class="isp-event-badge @OutageBadgeClass(outage)" data-tooltip="@OutageScoreTooltip(outage)">@OutageBadgeText(outage)</span>
                                 <span class="isp-outage-duration">@FormatDuration(outage.Duration)</span>
                                 <span class="isp-outage-window">@outage.Start.ToLocalTime().ToString("MMM d, HH:mm:ss") &ndash; @outage.End.ToLocalTime().ToString("HH:mm:ss")</span>
                                 <span class="isp-outage-scope" data-tooltip="@OutageScoreTooltip(outage)">@OutageScopeLabel(outage)</span>
+                                @if (outage.IsPartial)
+                                {
+                                    <span class="isp-outage-window">peak @outage.PeakLossPct.ToString("0")% &middot; @outage.DegradedTargetCount/@outage.PathTargetCount targets</span>
+                                }
                             </div>
                             @if (outage.Tiers.Any(t => t.WentDark))
                             {
@@ -426,6 +430,18 @@ else
                                                 <div class="isp-outage-hop-dark" style="width: @(OutageHopDarkPercent(outage, tier).ToString("0.#", System.Globalization.CultureInfo.InvariantCulture))%"></div>
                                             </div>
                                             <span class="isp-outage-hop-status @(tier.WentDark ? "" : "isp-outage-hop-up")">@OutageHopStatus(tier)</span>
+                                        </div>
+                                    }
+                                </div>
+                            }
+                            else if (outage.IsPartial && outage.Tiers.Count > 0)
+                            {
+                                <div class="isp-outage-shape">
+                                    @foreach (var tier in outage.Tiers)
+                                    {
+                                        <div class="isp-outage-hop">
+                                            <span class="isp-outage-hop-name">@tier.Name</span>
+                                            <span class="isp-outage-hop-status">peak @tier.PeakLossPct.ToString("0")% loss</span>
                                         </div>
                                     }
                                 </div>
@@ -735,10 +751,24 @@ else
         return local.Date == DateTime.Now.Date ? $"Today, {local:HH:mm}" : local.ToString("MMM d, HH:mm");
     }
 
+    private static string OutageBadgeClass(OutageEvent o) =>
+        o.IsPartial ? "isp-event-badge-info"
+        : o.IsBrief ? "isp-event-badge-warning"
+        : "isp-event-badge-danger";
+
+    private static string OutageBadgeText(OutageEvent o) =>
+        o.IsPartial ? "Partial loss" : o.IsBrief ? "Brief" : "Outage";
+
+    private static string OutageSectionTitle(IspHealthReport r) =>
+        r.Outages.Any(o => !o.IsPartial && !o.IsBrief) ? "Internet Outages"
+        : r.Outages.All(o => o.IsPartial) ? "Internet Disruptions"
+        : "Brief Internet Disruptions";
+
     private static string OutageScopeLabel(OutageEvent o) => o.Scope switch
     {
         OutageScope.Local => "LAN / Gateway outage",
         OutageScope.Upstream when !string.IsNullOrEmpty(o.LastReachableHop) => $"Break upstream of {o.LastReachableHop}",
+        _ when o.IsPartial => "Path-wide partial loss",
         _ => "Whole-WAN outage"
     };
 

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -261,7 +261,7 @@ else
                                             @FormatJitter(target.P95JitterMs)
                                             @if (target.JitterAssimilated)
                                             {
-                                                <span class="tooltip-icon tooltip-icon-sm" data-tooltip="@JitterAssimilationTooltip(target)">i</span>
+                                                <span class="tooltip-icon tooltip-icon-sm isp-jitter-tip" data-tooltip="@JitterAssimilationTooltip(target)">i</span>
                                             }
                                         </span>
                                     </span>
@@ -376,7 +376,7 @@ else
                                         @FormatJitter(asn.P95JitterMs)
                                         @if (asn.JitterAssimilated)
                                         {
-                                            <span class="tooltip-icon tooltip-icon-sm" data-tooltip="@JitterAssimilationTooltip(asn, isIspAsn)">i</span>
+                                            <span class="tooltip-icon tooltip-icon-sm isp-jitter-tip" data-tooltip="@JitterAssimilationTooltip(asn, isIspAsn)">i</span>
                                         }
                                     </span>
                                 </div>
@@ -538,6 +538,9 @@ else
     // Set when reset-zoom expands the list (which sits above the chart); scrolls the chart back
     // into view after the next render so it doesn't get pushed off-screen.
     private bool _scrollChartAfterRender;
+    // Last report the absolved-jitter tooltips were refreshed against; a new report means their
+    // data-tooltip changed and the cached Tippy content needs rebuilding.
+    private IspHealthReport? _lastTooltipReport;
     private DateTime _customFrom = DateTime.Now.AddDays(-2);
     private DateTime _customTo = DateTime.Now;
 
@@ -615,6 +618,23 @@ else
                 catch { /* nothing mounted */ }
             }
             return;
+        }
+        // Absolved-jitter tooltip-icons cache their content when Tippy first builds them; on a window
+        // recompute Blazor swaps only their data-tooltip attribute (no node re-add, so the global
+        // observer never re-fires) and the value goes stale. When the report changes, push the current
+        // attribute into each icon's existing Tippy with setContent - scoped to these icons only, and
+        // it leaves all other tooltips and the shared init untouched.
+        if (!ReferenceEquals(_report, _lastTooltipReport))
+        {
+            _lastTooltipReport = _report;
+            try
+            {
+                await JS.InvokeVoidAsync("eval",
+                    "document.querySelectorAll('.isp-jitter-tip').forEach(function(el){" +
+                    "if(el._tippy&&el.dataset.tooltip&&el._tippy.props.content!==el.dataset.tooltip)" +
+                    "el._tippy.setContent(el.dataset.tooltip);});");
+            }
+            catch { /* tooltip refresh is best-effort */ }
         }
         if (_chartMounted) return;
         _chartMounted = true;

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -535,6 +535,9 @@ else
     private DateTime? _zoomFrom;
     private DateTime? _zoomTo;
     private bool IsZoomed => _zoomFrom.HasValue && _zoomTo.HasValue;
+    // Set when reset-zoom expands the list (which sits above the chart); scrolls the chart back
+    // into view after the next render so it doesn't get pushed off-screen.
+    private bool _scrollChartAfterRender;
     private DateTime _customFrom = DateTime.Now.AddDays(-2);
     private DateTime _customTo = DateTime.Now;
 
@@ -595,6 +598,12 @@ else
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (_scrollChartAfterRender)
+        {
+            _scrollChartAfterRender = false;
+            try { await JS.InvokeVoidAsync("__ispHealthCharts.scrollChartIntoView"); }
+            catch { /* chart not mounted */ }
+        }
         if (_report == null)
         {
             // The content (and the chart element) is gone; drop the chart so it re-mounts
@@ -698,10 +707,12 @@ else
     /// change) so the Path &amp; Congestion Events list filters to the visible range.
     /// </summary>
     [JSInvokable]
-    public Task OnChartZoom(double? minMs, double? maxMs)
+    public Task OnChartZoom(double? minMs, double? maxMs, bool scrollToChart)
     {
         _zoomFrom = minMs.HasValue ? DateTimeOffset.FromUnixTimeMilliseconds((long)minMs.Value).UtcDateTime : null;
         _zoomTo = maxMs.HasValue ? DateTimeOffset.FromUnixTimeMilliseconds((long)maxMs.Value).UtcDateTime : null;
+        // On reset the list above the chart expands; keep the chart the user was on in view.
+        if (scrollToChart) _scrollChartAfterRender = true;
         return InvokeAsync(StateHasChanged);
     }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -457,16 +457,17 @@ else
     }
 
     <div class="card isp-health-card">
-        <div class="card-header"><h2 class="card-title">Path &amp; Congestion Events (@WindowLabel(r))</h2></div>
+        <div class="card-header"><h2 class="card-title">Path &amp; Congestion Events (@EventsWindowLabel(r))</h2></div>
         <div class="card-body">
-            @if (r.CongestionEvents.Count == 0 && r.PathShifts.Count == 0)
+            @{ var timeline = EventTimeline(r).Where(InZoomWindow).ToList(); }
+            @if (timeline.Count == 0)
             {
-                <p class="page-description">No congestion events or path shifts detected in the window.</p>
+                <p class="page-description">@(IsZoomed ? "No congestion events or path shifts in this range. Reset the chart zoom to see the full window." : "No congestion events or path shifts detected in the window.")</p>
             }
             else
             {
                 <div class="isp-event-timeline">
-                    @foreach (var entry in EventTimeline(r))
+                    @foreach (var entry in timeline)
                     {
                         <div class="isp-event-item">
                             <span class="isp-event-badge @entry.BadgeClass">@entry.Badge</span>
@@ -529,6 +530,11 @@ else
     private bool _windowComputing;
     private DateTime? _windowStart;
     private DateTime? _windowEnd;
+    private DotNetObjectReference<IspHealthPanel>? _selfRef;
+    // Chart drag-zoom range (UTC) the events list is filtered to; null = show the whole window.
+    private DateTime? _zoomFrom;
+    private DateTime? _zoomTo;
+    private bool IsZoomed => _zoomFrom.HasValue && _zoomTo.HasValue;
     private DateTime _customFrom = DateTime.Now.AddDays(-2);
     private DateTime _customTo = DateTime.Now;
 
@@ -607,9 +613,12 @@ else
         var toArg = _windowEnd.HasValue ? $"'{_windowEnd.Value:o}'" : "null";
         try
         {
+            _selfRef ??= DotNetObjectReference.Create(this);
             await JS.InvokeVoidAsync("eval",
                 $"(async () => {{ const m = await import('{VersionedJs("/js/isp-health-charts.js")}'); " +
                 $"window.__ispHealthCharts = m; await m.mount('isp-health-asn-chart', {fromArg}, {toArg}); }})();");
+            // Hand the chart a callback so its drag-zoom can filter the events list to the visible window.
+            await JS.InvokeVoidAsync("__ispHealthCharts.setDotNetRef", _selfRef);
         }
         catch { _chartMounted = false; }
     }
@@ -684,7 +693,28 @@ else
         catch { /* chart not mounted yet */ }
     }
 
-    private record TimelineEntry(DateTime Time, string Badge, string BadgeClass, string Text);
+    /// <summary>
+    /// Called by the per-network RTT chart on drag-zoom (epoch ms, or null/null on reset/window
+    /// change) so the Path &amp; Congestion Events list filters to the visible range.
+    /// </summary>
+    [JSInvokable]
+    public Task OnChartZoom(double? minMs, double? maxMs)
+    {
+        _zoomFrom = minMs.HasValue ? DateTimeOffset.FromUnixTimeMilliseconds((long)minMs.Value).UtcDateTime : null;
+        _zoomTo = maxMs.HasValue ? DateTimeOffset.FromUnixTimeMilliseconds((long)maxMs.Value).UtcDateTime : null;
+        return InvokeAsync(StateHasChanged);
+    }
+
+    // An event shows when its span overlaps the zoom window (instant events: when the instant is in it).
+    private bool InZoomWindow(TimelineEntry e) =>
+        !IsZoomed || ((e.End ?? e.Time) >= _zoomFrom!.Value && e.Time <= _zoomTo!.Value);
+
+    private string EventsWindowLabel(IspHealthReport r) =>
+        IsZoomed
+            ? $"zoomed: {_zoomFrom!.Value.ToLocalTime():MMM d, HH:mm} to {_zoomTo!.Value.ToLocalTime():MMM d, HH:mm}"
+            : WindowLabel(r);
+
+    private record TimelineEntry(DateTime Time, string Badge, string BadgeClass, string Text, DateTime? End = null);
 
     private static IEnumerable<TimelineEntry> EventTimeline(IspHealthReport r)
     {
@@ -728,7 +758,7 @@ else
                 _ => ("Congestion", "isp-event-badge-warning",
                     $"{lead}")
             };
-            entries.Add(new TimelineEntry(evt.Start, badge, badgeClass, text));
+            entries.Add(new TimelineEntry(evt.Start, badge, badgeClass, text, evt.End));
         }
         foreach (var shift in r.PathShifts)
         {
@@ -874,5 +904,6 @@ else
             try { _ = JS.InvokeVoidAsync("eval", "window.__ispHealthCharts?.unmount();"); }
             catch { }
         }
+        _selfRef?.Dispose();
     }
 }

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -441,6 +441,9 @@ else
                                     {
                                         <div class="isp-outage-hop">
                                             <span class="isp-outage-hop-name">@tier.Name</span>
+                                            <div class="isp-outage-hop-track">
+                                                <div class="isp-outage-hop-loss" style="width: @(tier.PeakLossPct.ToString("0.#", System.Globalization.CultureInfo.InvariantCulture))%"></div>
+                                            </div>
                                             <span class="isp-outage-hop-status">peak @tier.PeakLossPct.ToString("0")% loss</span>
                                         </div>
                                     }

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -403,14 +403,14 @@ else
     @if (r.Outages.Count > 0)
     {
         <div class="card isp-health-card" id="isp-outages">
-            <div class="card-header"><h2 class="card-title">Internet Outages (@WindowLabel(r))</h2></div>
+            <div class="card-header"><h2 class="card-title">@(r.Outages.Any(o => !o.IsBrief) ? "Internet Outages" : "Brief Internet Disruptions") (@WindowLabel(r))</h2></div>
             <div class="card-body">
                 <div class="isp-outage-list">
                     @foreach (var outage in r.Outages)
                     {
                         <div class="isp-outage">
                             <div class="isp-outage-head">
-                                <span class="isp-event-badge isp-event-badge-danger" data-tooltip="@OutageScoreTooltip(outage)">Outage</span>
+                                <span class="isp-event-badge @(outage.IsBrief ? "isp-event-badge-warning" : "isp-event-badge-danger")" data-tooltip="@OutageScoreTooltip(outage)">@(outage.IsBrief ? "Brief" : "Outage")</span>
                                 <span class="isp-outage-duration">@FormatDuration(outage.Duration)</span>
                                 <span class="isp-outage-window">@outage.Start.ToLocalTime().ToString("MMM d, HH:mm:ss") &ndash; @outage.End.ToLocalTime().ToString("HH:mm:ss")</span>
                                 <span class="isp-outage-scope" data-tooltip="@OutageScoreTooltip(outage)">@OutageScopeLabel(outage)</span>
@@ -723,7 +723,9 @@ else
     }
 
     private static string FormatDuration(TimeSpan d) =>
-        d.TotalHours >= 1 ? $"{d.TotalHours:0.#} h" : $"{d.TotalMinutes:0} min";
+        d.TotalHours >= 1 ? $"{d.TotalHours:0.#} h"
+        : d.TotalMinutes >= 1 ? $"{d.TotalMinutes:0} min"
+        : $"{d.TotalSeconds:0} sec";
 
     // Event time in local time, prefixed with the date when it is not today so events in a
     // multi-day (7d/30d/custom) window are unambiguous.

--- a/src/NetworkOptimizer.Web/Endpoints/IspHealthEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/IspHealthEndpoints.cs
@@ -14,8 +14,10 @@ public static class IspHealthEndpoints
             DateTime? from,
             DateTime? to,
             IspHealthService ispHealth,
+            ILoggerFactory loggerFactory,
             CancellationToken ct) =>
         {
+            var __rt = System.Diagnostics.Stopwatch.StartNew();
             // from/to (the tab's date/time filter) make the chart follow a custom window off
             // the 48 h cache; absent, it serves the cached 48 h report.
             var (series, report) = await ispHealth.GetAsnChartDataAsync(from, to, ct);
@@ -78,6 +80,9 @@ public static class IspHealthEndpoints
                 }));
             }
 
+            loggerFactory.CreateLogger("IspHealthEndpoints").LogInformation(
+                "ISPRT endpoint asn-series total={T}ms window={W}",
+                __rt.ElapsedMilliseconds, from.HasValue && to.HasValue ? $"{(to.Value - from.Value).TotalHours:0}h" : "48h-cache");
             return Results.Ok(new { asns, events });
         });
     }

--- a/src/NetworkOptimizer.Web/Endpoints/IspHealthEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/IspHealthEndpoints.cs
@@ -14,10 +14,8 @@ public static class IspHealthEndpoints
             DateTime? from,
             DateTime? to,
             IspHealthService ispHealth,
-            ILoggerFactory loggerFactory,
             CancellationToken ct) =>
         {
-            var __rt = System.Diagnostics.Stopwatch.StartNew();
             // from/to (the tab's date/time filter) make the chart follow a custom window off
             // the 48 h cache; absent, it serves the cached 48 h report.
             var (series, report) = await ispHealth.GetAsnChartDataAsync(from, to, ct);
@@ -80,9 +78,6 @@ public static class IspHealthEndpoints
                 }));
             }
 
-            loggerFactory.CreateLogger("IspHealthEndpoints").LogInformation(
-                "ISPRT endpoint asn-series total={T}ms window={W}",
-                __rt.ElapsedMilliseconds, from.HasValue && to.HasValue ? $"{(to.Value - from.Value).TotalHours:0}h" : "48h-cache");
             return Results.Ok(new { asns, events });
         });
     }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionDetector.cs
@@ -66,13 +66,16 @@ public static class CongestionDetector
         bool StillElevated(Bucket b)
         {
             var f = options.CongestionSustainFraction;
+            // Continuation requires the congestion SIGNATURE to persist, not merely an elevated
+            // level: jitter still up, or p90 still spiking above the bucket's OWN median
+            // (intermittent bursts). A flat elevated plateau - raised median, baseline jitter,
+            // p90 about equal to the median - is a path/route shift (the step detector's job) and
+            // must not hold a congestion run open.
             var jitterOk = b.JitterMs.HasValue && baselineJitter.HasValue
                 && b.JitterMs.Value - baselineJitter.Value >= options.CongestionJitterMinDeltaMs * f;
-            var rttOk = b.RttMs.HasValue
-                && b.RttMs.Value > baselineRtt.Value + (rttThreshold - baselineRtt.Value) * f;
-            var burstOk = b.P90Ms.HasValue
-                && b.P90Ms.Value > baselineP90.Value + (burstThreshold - baselineP90.Value) * f;
-            return jitterOk || rttOk || burstOk;
+            var burstOk = b.P90Ms.HasValue && b.RttMs.HasValue
+                && b.P90Ms.Value - b.RttMs.Value >= (burstThreshold - baselineP90.Value) * f;
+            return jitterOk || burstOk;
         }
 
         var events = new List<CongestionEvent>();

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionDetector.cs
@@ -66,15 +66,18 @@ public static class CongestionDetector
         bool StillElevated(Bucket b)
         {
             var f = options.CongestionSustainFraction;
-            // Continuation requires the congestion SIGNATURE to persist, not merely an elevated
-            // level: jitter still up, or p90 still spiking above the bucket's OWN median
-            // (intermittent bursts). A flat elevated plateau - raised median, baseline jitter,
-            // p90 about equal to the median - is a path/route shift (the step detector's job) and
-            // must not hold a congestion run open.
+            // Continuation requires the congestion SIGNATURE to persist RELATIVE TO THIS HOP'S OWN
+            // BASELINE, not merely an absolute delta or the bucket's own internal spread: jitter still
+            // up versus baseline (both an absolute floor AND a ratio, so a naturally jittery hop's
+            // normal wobble doesn't qualify), or p90 still elevated above the BASELINE p90 (mirroring
+            // entry), not just a wide p90-median spread that a chronically bursty hop always shows.
+            // Without the relative bar a bursty/jittery hop holds a run open for hours past the real
+            // event (the false long tail). A flat plateau back at baseline ends the run.
             var jitterOk = b.JitterMs.HasValue && baselineJitter.HasValue
-                && b.JitterMs.Value - baselineJitter.Value >= options.CongestionJitterMinDeltaMs * f;
-            var burstOk = b.P90Ms.HasValue && b.RttMs.HasValue
-                && b.P90Ms.Value - b.RttMs.Value >= (burstThreshold - baselineP90.Value) * f;
+                && b.JitterMs.Value - baselineJitter.Value >= options.CongestionJitterMinDeltaMs * f
+                && b.JitterMs.Value >= baselineJitter.Value * (1 + (options.CongestionJitterFactor - 1) * f);
+            var burstOk = b.P90Ms.HasValue
+                && b.P90Ms.Value - baselineP90.Value >= (burstThreshold - baselineP90.Value) * f;
             return jitterOk || burstOk;
         }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionDetector.cs
@@ -58,6 +58,23 @@ public static class CongestionDetector
         var burstSpread = Math.Max(baselineP90.Value - baselineRtt.Value, 0.5);
         var burstThreshold = baselineP90.Value + Math.Max(options.CongestionRttMinDeltaMs, options.CongestionBurstDeltaFactor * burstSpread);
 
+        // Continuation (hysteresis) gate: once a run is active it survives while any signal stays
+        // at least CongestionSustainFraction of the way from baseline to its entry threshold. This
+        // does NOT start a run (entry below still requires the full strict gate), so it only keeps
+        // a legitimately-started event alive through its milder tail and brief dips instead of
+        // truncating to the peak.
+        bool StillElevated(Bucket b)
+        {
+            var f = options.CongestionSustainFraction;
+            var jitterOk = b.JitterMs.HasValue && baselineJitter.HasValue
+                && b.JitterMs.Value - baselineJitter.Value >= options.CongestionJitterMinDeltaMs * f;
+            var rttOk = b.RttMs.HasValue
+                && b.RttMs.Value > baselineRtt.Value + (rttThreshold - baselineRtt.Value) * f;
+            var burstOk = b.P90Ms.HasValue
+                && b.P90Ms.Value > baselineP90.Value + (burstThreshold - baselineP90.Value) * f;
+            return jitterOk || rttOk || burstOk;
+        }
+
         var events = new List<CongestionEvent>();
         var run = new List<Bucket>();
         var gap = 0;
@@ -83,6 +100,11 @@ public static class CongestionDetector
             var elevated = sustainedElevated || burstElevated;
 
             if (elevated)
+            {
+                run.Add(bucket);
+                gap = 0;
+            }
+            else if (run.Count > 0 && StillElevated(bucket))
             {
                 run.Add(bucket);
                 gap = 0;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
@@ -432,12 +432,14 @@ public static class CongestionLocalizer
     }
 
     /// <summary>
-    /// A softer "elevated in this window" test than firing a full congestion event: true when a
-    /// meaningful fraction of in-window RTT samples exceed the hop's own baseline p90 by the
-    /// congestion RTT floor. A real bottleneck's added delay reaches downstream hops as excursions
-    /// that may be too sparse to fire their own sustained event; using this for the propagation
-    /// and clean-control checks stops the localizer from absolving a genuine bottleneck as
-    /// control-plane noise just because nothing downstream fired. Clean off-path hops sit near zero.
+    /// A softer "elevated in this window" test than firing a full congestion event, used for the
+    /// propagation and clean-control checks so the localizer doesn't absolve a genuine bottleneck as
+    /// control-plane noise just because nothing downstream fired its own event. A hop counts as
+    /// elevated if EITHER its RTT rose (a meaningful fraction of in-window RTT samples exceed its own
+    /// baseline p90 by the congestion RTT floor) OR its jitter rose relative to its own baseline.
+    /// The jitter arm matters because many incidents are jitter-driven with flat RTT - an RTT-only
+    /// test reads the downstream as clean and shatters one chain-wide rise into per-hop noise rows.
+    /// Both arms are relative to the hop's OWN baseline; clean off-path hops sit near zero on both.
     /// </summary>
     internal static bool ElevatedInWindow(AsnSeries series, DateTime start, DateTime end, IspHealthOptions options)
     {
@@ -450,10 +452,30 @@ public static class CongestionLocalizer
         if (inWindow.Count == 0 || baseline.Count == 0) return false;
 
         var baselineP90 = SeriesStats.Percentile(baseline, 0.90);
-        if (!baselineP90.HasValue) return false;
-        var threshold = baselineP90.Value + options.CongestionRttMinDeltaMs;
-        var excursionFraction = inWindow.Count(v => v > threshold) / (double)inWindow.Count;
-        return excursionFraction >= options.CongestionPropagationExcursionFraction;
+        if (baselineP90.HasValue)
+        {
+            var threshold = baselineP90.Value + options.CongestionRttMinDeltaMs;
+            var excursionFraction = inWindow.Count(v => v > threshold) / (double)inWindow.Count;
+            if (excursionFraction >= options.CongestionPropagationExcursionFraction) return true;
+        }
+
+        // Jitter arm: the downstream of a real bottleneck often inherits the delay as jitter while its
+        // median RTT barely moves, so RTT-only propagation misses it. Compare in-window median jitter
+        // to this hop's OWN baseline median (relative, with a small absolute floor so a near-zero hop
+        // isn't tripped by a sub-ms ratio swing).
+        var inJitter = series.Samples
+            .Where(x => x.Time >= start && x.Time <= end).Select(x => x.EffectiveJitterMs)
+            .Where(j => j.HasValue).Select(j => j!.Value).ToList();
+        var baseJitter = series.Samples
+            .Where(x => x.Time < start || x.Time > end).Select(x => x.EffectiveJitterMs)
+            .Where(j => j.HasValue).Select(j => j!.Value).ToList();
+        if (inJitter.Count == 0 || baseJitter.Count == 0) return false;
+
+        var inJitMedian = SeriesStats.Median(inJitter);
+        var baseJitMedian = SeriesStats.Median(baseJitter);
+        return inJitMedian.HasValue && baseJitMedian.HasValue
+            && inJitMedian.Value >= baseJitMedian.Value * options.CongestionPropagationJitterFactor
+            && inJitMedian.Value - baseJitMedian.Value >= options.CongestionPropagationJitterFloorMs;
     }
 
     private static int DeepestHopNum(AsnSeries series, CongestionTopology topology) => series.HopIps

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
@@ -104,6 +104,24 @@ public static class CongestionLocalizer
                 && anchoredWithData.Count(s => RoseInWindow(s, window.Start, window.End, options))
                     >= anchoredWithData.Count * options.CongestionLineWideRiseFraction;
 
+            // SHARED-INCIDENT COLLAPSE. The per-hop separation below is the default and stays
+            // authoritative. This narrow exception fires only when a strict majority of monitored
+            // paths are elevated RELATIVE TO THEIR OWN baselines (IsElevated - the same per-hop
+            // relative test the bottleneck walk trusts, NOT an absolute ms floor) AND the rise reaches
+            // the access egress (rooted at your network, not a deep mid-path cluster). That is one
+            // incident - your access link under load, or a shared upstream otherwise - so it collapses
+            // to a single event instead of N rows. A localized bottleneck, a propagation-to-victim, or
+            // a partial rise all fail this gate and fall through to the per-hop logic, unchanged.
+            var relElevated = anchoredWithData.Where(s => IsElevated(s, window.Start, window.End)).ToList();
+            var accessRooted = relElevated.Any(s => s.HopIps.Any(ip => topology.AccessEgressHopIps.Contains(ip)));
+            if (accessRooted && anchoredWithData.Count > 0
+                && relElevated.Count >= anchoredWithData.Count * options.CongestionLineWideRiseFraction)
+            {
+                result.Add(BuildSharedIncident(relElevated, eventsBySeries, anchoredWithData, window,
+                    topology, options, loadCoincident, IsElevated));
+                continue;
+            }
+
             foreach (var (bnIp, members) in byBottleneck)
                 result.Add(BuildLocalized(bnIp, members, allSeries, eventsBySeries, window,
                     topology, options, loadCoincident, cleanControlExists, lineWideUnderLoad, IsElevated));
@@ -130,6 +148,81 @@ public static class CongestionLocalizer
         }
 
         return result.OrderBy(e => e.Start).ToList();
+    }
+
+    /// <summary>
+    /// Builds the single event for a shared incident (a relative-line-wide, access-rooted cluster).
+    /// Attributed to the convergence hop nearest the user; Loaded Latency under load (your access
+    /// link, suppressed), else real shared upstream congestion (Confirmed, scored). The span is
+    /// trimmed to the sub-window where the breadth actually holds, so one hop lingering past the rest
+    /// doesn't stretch it, and the worst single hop is named in the reason.
+    /// </summary>
+    private static CongestionEvent BuildSharedIncident(
+        List<AsnSeries> elevated,
+        Dictionary<AsnSeries, List<CongestionEvent>> eventsBySeries,
+        List<AsnSeries> anchoredWithData,
+        (DateTime Start, DateTime End) window,
+        CongestionTopology topology,
+        IspHealthOptions options,
+        bool loadCoincident,
+        Func<AsnSeries, DateTime, DateTime, bool> isElevated)
+    {
+        int HopNum(AsnSeries s) => s.HopIps.Concat(s.AncestorIps)
+            .Where(topology.HopNumberByIp.ContainsKey)
+            .Select(ip => topology.HopNumberByIp[ip]).DefaultIfEmpty(int.MaxValue).Min();
+
+        // Decision 3: span only the contiguous sub-window where the breadth still holds, so a single
+        // hop lingering past the rest cannot stretch the incident's reported (and scored) duration.
+        var bucket = TimeSpan.FromMinutes(options.CongestionBucketMinutes);
+        var need = anchoredWithData.Count * options.CongestionLineWideRiseFraction;
+        var wide = new List<DateTime>();
+        for (var b = CongestionDetector.FloorTime(window.Start, bucket); b < window.End; b += bucket)
+            if (anchoredWithData.Count(s => isElevated(s, b, b + bucket)) >= need)
+                wide.Add(b);
+        var start = wide.Count > 0 ? wide.Min() : window.Start;
+        var end = wide.Count > 0 ? wide.Max() + bucket : window.End;
+
+        Func<AsnSeries, IEnumerable<CongestionEvent>> evts = s =>
+            (eventsBySeries.TryGetValue(s, out var es) ? es : Enumerable.Empty<CongestionEvent>())
+                .Where(e => Overlaps(e.Start, e.End, start, end));
+
+        // The convergence hop nearest the user owns the event (usually the access egress); this also
+        // keeps the score attributed to your ISP card rather than every downstream transit victim.
+        var owner = elevated.OrderBy(HopNum).First();
+        var ownerEvt = evts(owner).FirstOrDefault();
+
+        // Decision 2: name the single worst hop (largest relative RTT rise among the fired members).
+        var worst = elevated
+            .SelectMany(s => evts(s).Select(e => (Series: s, Rise: e.BaselineRttMs > 0 ? (e.PeakRttMs - e.BaselineRttMs) / e.BaselineRttMs : 0)))
+            .OrderByDescending(x => x.Rise)
+            .Select(x => x.Series)
+            .FirstOrDefault();
+
+        var reason = loadCoincident
+            ? $"{elevated.Count} monitored paths rose together under heavy WAN load, so the limit was your access link (bufferbloat or a congested shared-access network), not one hop."
+            : $"{elevated.Count} monitored paths across independent networks rose together with no heavy local load - a shared upstream bottleneck lifting the whole path, not one hop.";
+        if (worst != null && worst != owner && worst.AsnName is { Length: > 0 } worstName)
+            reason += $" Worst at {worstName}.";
+
+        return new CongestionEvent
+        {
+            Start = start,
+            End = end,
+            AsnNumbers = owner.AsnNumber > 0 ? new List<int> { owner.AsnNumber } : new List<int>(),
+            AsnNames = owner.AsnName is { Length: > 0 } ? new List<string> { owner.AsnName } : new List<string>(),
+            TargetIds = owner.TargetIds.ToList(),
+            BaselineRttMs = ownerEvt?.BaselineRttMs ?? 0,
+            PeakRttMs = ownerEvt?.PeakRttMs ?? ownerEvt?.BaselineRttMs ?? 0,
+            BaselineJitterMs = ownerEvt?.BaselineJitterMs ?? 0,
+            PeakJitterMs = ownerEvt?.PeakJitterMs ?? 0,
+            Scope = CongestionScope.Unlocalized,
+            Disposition = loadCoincident ? CongestionDisposition.SelfInflicted : CongestionDisposition.Confirmed,
+            BottleneckHopIp = owner.HopIps.FirstOrDefault(),
+            BottleneckLabel = owner.AsnName,
+            LoadCoincident = loadCoincident,
+            Confidence = 70,
+            AttributionReason = reason
+        };
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
@@ -53,7 +53,8 @@ public static class CongestionLocalizer
             .Where(s => !s.IsDestination)
             .SelectMany(s => eventsBySeries[s].Select(e => (Series: s, Evt: e)))
             .ToList();
-        if (candidates.Count == 0) return new List<CongestionEvent>();
+
+        var anchored = allSeries.Where(s => HasTrace(s, topology)).ToList();
 
         // A hop counts as elevated if it fired its own event OR shows in-window RTT excursions
         // above its baseline. The softer test matters for propagation: a downstream hop inherits
@@ -62,8 +63,6 @@ public static class CongestionLocalizer
         bool IsElevated(AsnSeries s, DateTime start, DateTime end) =>
             (eventsBySeries.TryGetValue(s, out var evs) && evs.Any(e => Overlaps(e.Start, e.End, start, end)))
             || ElevatedInWindow(s, start, end, options);
-
-        var anchored = allSeries.Where(s => HasTrace(s, topology)).ToList();
 
         var result = new List<CongestionEvent>();
         foreach (var cluster in ClusterByTime(candidates))
@@ -129,8 +128,144 @@ public static class CongestionLocalizer
             evt.AttributionReason = "Confirmed by a sibling hop on the same network congesting in the same window; no monitored hop sits beyond this one to verify it directly.";
         }
 
+        // Collapse genuinely shared incidents: where many independent hops are up TOGETHER (whether
+        // each crossed its own gate or merely drifted up sub-threshold), replace the per-hop events
+        // with one shared-upstream event spanning the concurrent window. Catches both the line-wide
+        // cluster the per-hop localizer would scatter into N rows and the sub-gate rise it misses
+        // entirely - keyed on bucket-level concurrency, so one hop lingering past the rest neither
+        // hides the coincidence nor stretches the collapsed event's duration.
+        ApplySharedUpstream(result, anchored, eventsBySeries, topology, options);
+
         return result.OrderBy(e => e.Start).ToList();
     }
+
+    /// <summary>
+    /// Collapses genuinely shared incidents into one event. A hop is "up" in a bucket if it fired its
+    /// own congestion event there OR merely drifted up sub-threshold (its bucket median rose past
+    /// baseline by a scale-relative margin a fixed millisecond gate would miss). Where a majority of
+    /// independent hops are up TOGETHER, that is one shared upstream bottleneck, not N per-hop events:
+    /// the per-hop events overlapping the concurrent window are removed and replaced with a single
+    /// event attributed to the convergence hop closest to the user. Keyed on bucket-level concurrency
+    /// (not the cluster's outer span), so one hop lingering past the rest neither hides the
+    /// coincidence nor stretches the collapsed duration. Under load it reads as self-inflicted Loaded
+    /// Latency (suppressed); otherwise it is real shared upstream congestion (Confirmed, scored).
+    /// </summary>
+    private static void ApplySharedUpstream(
+        List<CongestionEvent> result,
+        IReadOnlyList<AsnSeries> anchored,
+        Dictionary<AsnSeries, List<CongestionEvent>> eventsBySeries,
+        CongestionTopology topology,
+        IspHealthOptions options)
+    {
+        var hops = anchored.Where(s => !s.IsDestination).ToList();
+        if (hops.Count < options.CoincidentCongestionMinHops) return;
+
+        var bucketSize = TimeSpan.FromMinutes(options.CongestionBucketMinutes);
+        var perHop = new List<(AsnSeries Hop, double Base, Dictionary<DateTime, double> Buckets)>();
+        foreach (var h in hops)
+        {
+            var rtts = h.Samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
+            var baseRtt = SeriesStats.Median(rtts);
+            if (!baseRtt.HasValue) continue;
+            var buckets = h.Samples.Where(s => s.RttAvgMs.HasValue)
+                .GroupBy(s => CongestionDetector.FloorTime(s.Time, bucketSize))
+                .ToDictionary(g => g.Key, g => SeriesStats.Median(g.Select(s => s.RttAvgMs!.Value).ToList()) ?? baseRtt.Value);
+            perHop.Add((h, baseRtt.Value, buckets));
+        }
+        if (perHop.Count < options.CoincidentCongestionMinHops) return;
+
+        // "Up" in a bucket: fired an event covering it, or drifted up sub-threshold (scale-relative).
+        bool Up((AsnSeries Hop, double Base, Dictionary<DateTime, double> Buckets) p, DateTime t)
+        {
+            if (eventsBySeries.TryGetValue(p.Hop, out var evs) && evs.Any(e => Overlaps(e.Start, e.End, t, t + bucketSize)))
+                return true;
+            return p.Buckets.TryGetValue(t, out var med)
+                && med >= p.Base + Math.Max(options.CongestionLineWideMinShiftMs, p.Base * options.CoincidentCongestionRttRisePct);
+        }
+
+        var upAt = new Dictionary<DateTime, List<AsnSeries>>();
+        foreach (var t in perHop.SelectMany(p => p.Buckets.Keys).Distinct())
+        {
+            var withData = perHop.Where(p => p.Buckets.ContainsKey(t)).ToList();
+            if (withData.Count < options.CoincidentCongestionMinHops) continue;
+            var up = withData.Where(p => Up(p, t)).Select(p => p.Hop).ToList();
+            if (up.Count >= options.CoincidentCongestionMinHops
+                && up.Count >= withData.Count * options.CoincidentCongestionRiseFraction)
+                upAt[t] = up;
+        }
+        if (upAt.Count == 0) return;
+
+        // Group consecutive concurrent buckets (allowing a single-bucket gap) into windows.
+        var groups = new List<List<DateTime>>();
+        foreach (var t in upAt.Keys.OrderBy(t => t))
+        {
+            if (groups.Count > 0 && t - groups[^1][^1] <= bucketSize + bucketSize)
+                groups[^1].Add(t);
+            else
+                groups.Add(new List<DateTime> { t });
+        }
+
+        int HopNum(AsnSeries s) => s.HopIps.Concat(s.AncestorIps)
+            .Where(topology.HopNumberByIp.ContainsKey)
+            .Select(ip => topology.HopNumberByIp[ip]).DefaultIfEmpty(int.MaxValue).Min();
+
+        foreach (var g in groups)
+        {
+            var start = g[0];
+            var end = g[^1] + bucketSize;
+            var upHops = g.SelectMany(t => upAt[t]).Distinct().ToList();
+            if (upHops.Count < options.CoincidentCongestionMinHops) continue;
+
+            // The nearest up hop owns the event: the shared bottleneck sits at or behind the
+            // convergence point closest to the user, and attributing there avoids penalizing every
+            // downstream transit ASN that merely inherited the upstream rise.
+            var owner = upHops.OrderBy(HopNum).First();
+            var ownerPer = perHop.First(p => p.Hop == owner);
+            var peakRtt = g.Where(t => ownerPer.Buckets.ContainsKey(t)).Select(t => ownerPer.Buckets[t]).DefaultIfEmpty(ownerPer.Base).Max();
+            var ownerJits = owner.Samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
+            var baseJit = SeriesStats.Median(ownerJits) ?? 0;
+            var peakJit = owner.Samples.Where(s => s.Time >= start && s.Time < end)
+                .Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).DefaultIfEmpty(baseJit).Max();
+            var loadCoincident = LoadCoincident(start, end, topology, options);
+
+            // This concurrent window is one shared incident: drop the per-hop events it subsumes and
+            // replace them with a single shared-upstream event spanning only the concurrent window.
+            result.RemoveAll(e => !e.SharedUpstream && Overlaps(e.Start, e.End, start, end));
+            result.Add(SharedUpstreamEvent(owner, ownerPer.Base, peakRtt, baseJit, peakJit, start, end, upHops.Count, loadCoincident));
+        }
+    }
+
+    /// <summary>
+    /// Builds one shared-upstream congestion event attributed to <paramref name="owner"/> (the
+    /// convergence hop closest to the user). Under load it reads as self-inflicted "Loaded Latency"
+    /// (your access link is the limit, suppressed from the score); otherwise it is real shared
+    /// upstream congestion (Confirmed, scored). Used both to collapse a line-wide cluster of per-hop
+    /// events and to surface a sub-gate coincident rise.
+    /// </summary>
+    private static CongestionEvent SharedUpstreamEvent(
+        AsnSeries owner, double baselineRtt, double peakRtt, double baselineJit, double peakJit,
+        DateTime start, DateTime end, int riseCount, bool loadCoincident) => new()
+    {
+        Start = start,
+        End = end,
+        AsnNumbers = owner.AsnNumber > 0 ? new List<int> { owner.AsnNumber } : new List<int>(),
+        AsnNames = owner.AsnName is { Length: > 0 } ? new List<string> { owner.AsnName } : new List<string>(),
+        TargetIds = owner.TargetIds.ToList(),
+        BaselineRttMs = baselineRtt,
+        PeakRttMs = peakRtt,
+        BaselineJitterMs = baselineJit,
+        PeakJitterMs = peakJit,
+        Scope = CongestionScope.Unlocalized,
+        Disposition = loadCoincident ? CongestionDisposition.SelfInflicted : CongestionDisposition.Confirmed,
+        BottleneckHopIp = owner.HopIps.FirstOrDefault(),
+        BottleneckLabel = owner.AsnName,
+        SharedUpstream = true,
+        LoadCoincident = loadCoincident,
+        Confidence = 70,
+        AttributionReason = loadCoincident
+            ? "Every monitored path rose together under heavy WAN load, so the limit was your access link (bufferbloat or a congested shared-access network), not a single hop."
+            : $"{riseCount} monitored paths across independent networks rose together this window - a shared upstream bottleneck lifting the whole path, not any one hop."
+    };
 
     /// <summary>
     /// The shallowest hop in the unbroken elevated run ending at <paramref name="series"/>. A

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
@@ -158,10 +158,10 @@ public static class CongestionLocalizer
         IspHealthOptions options)
     {
         var hops = anchored.Where(s => !s.IsDestination).ToList();
-        if (hops.Count == 0) return;
+        if (hops.Count < options.CoincidentCongestionMinHops) return;
 
         var bucketSize = TimeSpan.FromMinutes(options.CongestionBucketMinutes);
-        var perHop = new List<(AsnSeries Hop, double Base, Dictionary<DateTime, double> Buckets, bool IsAccess)>();
+        var perHop = new List<(AsnSeries Hop, double Base, Dictionary<DateTime, double> Buckets)>();
         foreach (var h in hops)
         {
             var rtts = h.Samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
@@ -170,13 +170,12 @@ public static class CongestionLocalizer
             var buckets = h.Samples.Where(s => s.RttAvgMs.HasValue)
                 .GroupBy(s => CongestionDetector.FloorTime(s.Time, bucketSize))
                 .ToDictionary(g => g.Key, g => SeriesStats.Median(g.Select(s => s.RttAvgMs!.Value).ToList()) ?? baseRtt.Value);
-            var isAccess = h.HopIps.Any(ip => topology.AccessEgressHopIps.Contains(ip));
-            perHop.Add((h, baseRtt.Value, buckets, isAccess));
+            perHop.Add((h, baseRtt.Value, buckets));
         }
-        if (perHop.Count == 0) return;
+        if (perHop.Count < options.CoincidentCongestionMinHops) return;
 
         // "Up" in a bucket: fired an event covering it, or drifted up sub-threshold (scale-relative).
-        bool Up((AsnSeries Hop, double Base, Dictionary<DateTime, double> Buckets, bool IsAccess) p, DateTime t)
+        bool Up((AsnSeries Hop, double Base, Dictionary<DateTime, double> Buckets) p, DateTime t)
         {
             if (eventsBySeries.TryGetValue(p.Hop, out var evs) && evs.Any(e => Overlaps(e.Start, e.End, t, t + bucketSize)))
                 return true;
@@ -187,15 +186,12 @@ public static class CongestionLocalizer
         var upAt = new Dictionary<DateTime, List<AsnSeries>>();
         foreach (var t in perHop.SelectMany(p => p.Buckets.Keys).Distinct())
         {
-            var up = perHop.Where(p => p.Buckets.ContainsKey(t) && Up(p, t)).ToList();
-            // Shared upstream: the elevation is rooted at the access egress (the hop nearest you is up,
-            // not merely a deeper hop with clean upstream) AND spans multiple independent networks.
-            // That separates one shared incident from a single localized bottleneck that simply
-            // propagated to its downstream victim - which must still localize, not collapse.
-            var accessUp = up.Any(p => p.IsAccess);
-            var asns = up.Select(p => p.Hop.AsnNumber).Where(a => a > 0).Distinct().Count();
-            if (accessUp && asns >= options.SharedEventMinAsns)
-                upAt[t] = up.Select(p => p.Hop).ToList();
+            var withData = perHop.Where(p => p.Buckets.ContainsKey(t)).ToList();
+            if (withData.Count < options.CoincidentCongestionMinHops) continue;
+            var up = withData.Where(p => Up(p, t)).Select(p => p.Hop).ToList();
+            if (up.Count >= options.CoincidentCongestionMinHops
+                && up.Count >= withData.Count * options.CoincidentCongestionRiseFraction)
+                upAt[t] = up;
         }
         if (upAt.Count == 0) return;
 
@@ -218,7 +214,7 @@ public static class CongestionLocalizer
             var start = g[0];
             var end = g[^1] + bucketSize;
             var upHops = g.SelectMany(t => upAt[t]).Distinct().ToList();
-            if (upHops.Select(h => h.AsnNumber).Where(a => a > 0).Distinct().Count() < options.SharedEventMinAsns) continue;
+            if (upHops.Count < options.CoincidentCongestionMinHops) continue;
 
             // The nearest up hop owns the event: the shared bottleneck sits at or behind the
             // convergence point closest to the user, and attributing there avoids penalizing every

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
@@ -88,30 +88,10 @@ public static class CongestionLocalizer
             }
 
             var loadCoincident = LoadCoincident(window.Start, window.End, topology, options);
-            // A clean anchored series anywhere means the elevation is NOT line-wide. Kept for the
-            // Confirmed confidence below (NOT the self-infliction gate - see lineWideUnderLoad).
-            // Must have data in the window - a no-data series (newer target / gap) isn't "clean".
-            var cleanControlExists = anchored.Any(s =>
-                HasDataInWindow(s, window.Start, window.End) && !IsElevated(s, window.Start, window.End));
-            // Self-inflicted access bufferbloat adds a near-constant rise to (almost) every monitored
-            // path crossing the egress under load. The absolute elevation bar misses that on high-
-            // baseline / high-variance paths (their inflated p90 hides a ~1 ms drift), so one such path
-            // reading "clean" wrongly vetoes self-infliction. This robust median-shift test keys on
-            // "did everything drift up together": the fraction of anchored paths (with data) whose
-            // in-window median rose above baseline by a small margin. Only consulted for the egress hop.
             var anchoredWithData = anchored.Where(s => HasDataInWindow(s, window.Start, window.End)).ToList();
-            var lineWideUnderLoad = anchoredWithData.Count > 0
-                && anchoredWithData.Count(s => RoseInWindow(s, window.Start, window.End, options))
-                    >= anchoredWithData.Count * options.CongestionLineWideRiseFraction;
 
-            // SHARED-INCIDENT COLLAPSE (narrow exception; the per-hop separation below is the default
-            // and stays authoritative). Collapse to ONE event only when the rise is genuinely UNIFORM:
-            // a strict majority of paths rose in RTT over baseline (lineWideUnderLoad) AND no path rose
-            // MATERIALLY above the shared floor. Under load every path picks up a floor of added delay
-            // (loaded latency); but if a few paths are much worse than that floor, those are localized
-            // congestion on top of the load - stay per-hop so the localizer surfaces them as "this
-            // hop's own capacity", not "everything slowed". A jitter-only floor (queuing jitter lifts
-            // every path) is NOT enough on its own - lineWideUnderLoad keys on RTT.
+            // Each anchored path's RTT rise over its OWN baseline. Under load every path picks up a
+            // shared FLOOR of added delay; localized congestion is the rise ABOVE that floor.
             double RttRise(AsnSeries s)
             {
                 var inW = s.Samples.Where(x => x.Time >= window.Start && x.Time <= window.End && x.RttAvgMs.HasValue)
@@ -125,6 +105,29 @@ public static class CongestionLocalizer
             var relElevated = anchoredWithData.Where(s => IsElevated(s, window.Start, window.End)).ToList();
             var rises = relElevated.Select(RttRise).Where(r => r > 0).OrderBy(r => r).ToList();
             var floorRise = SeriesStats.Median(rises) ?? 0;
+
+            // A CLEAN control rose no more than the shared floor in RTT - it picked up the load floor
+            // but NOT localized congestion. Using RTT (not the jitter-inclusive IsElevated) is the point:
+            // under load the jitter floor lifts every path, so IsElevated would mark even Cox "elevated"
+            // and erase every clean control - which is exactly what suppressed the "this hop's own
+            // capacity, not your access egress" messaging. A non-zero count of clean parallel paths is
+            // the proof an elevation is a single hop's capacity rather than access-layer bufferbloat.
+            bool IsClean(AsnSeries s) => RttRise(s) <= floorRise * options.CongestionCleanControlFloorFactor;
+            var cleanControlExists = anchoredWithData.Any(IsClean);
+
+            // Self-inflicted access bufferbloat lifts (almost) every monitored path crossing the egress
+            // under load. The robust median-shift test keys on "did everything drift up together": the
+            // fraction of anchored paths (with data) whose in-window median rose above baseline.
+            var lineWideUnderLoad = anchoredWithData.Count > 0
+                && anchoredWithData.Count(s => RoseInWindow(s, window.Start, window.End, options))
+                    >= anchoredWithData.Count * options.CongestionLineWideRiseFraction;
+
+            // SHARED-INCIDENT COLLAPSE (narrow exception; the per-hop separation below is the default
+            // and stays authoritative). Collapse to ONE event only when the rise is genuinely UNIFORM:
+            // a strict majority rose in RTT (lineWideUnderLoad) AND no path rose MATERIALLY above the
+            // shared floor. If a few paths are much worse than the floor, those are localized congestion
+            // on top of the load - stay per-hop so the localizer surfaces them as "this hop's own
+            // capacity", not "everything slowed".
             var uniform = rises.Count == 0 || floorRise <= 0
                 || rises[^1] <= floorRise * options.CongestionLoadedUniformityFactor;
             if (lineWideUnderLoad && uniform && relElevated.Count > 0)
@@ -136,7 +139,7 @@ public static class CongestionLocalizer
 
             foreach (var (bnIp, members) in byBottleneck)
                 result.Add(BuildLocalized(bnIp, members, allSeries, eventsBySeries, window,
-                    topology, options, loadCoincident, cleanControlExists, lineWideUnderLoad, IsElevated));
+                    topology, options, loadCoincident, cleanControlExists, lineWideUnderLoad, IsElevated, IsClean));
 
             if (unanchored.Count > 0)
                 result.Add(BuildUnlocalized(unanchored, eventsBySeries, window, topology, loadCoincident, options));
@@ -295,7 +298,8 @@ public static class CongestionLocalizer
         bool loadCoincident,
         bool cleanControlExists,
         bool lineWideUnderLoad,
-        Func<AsnSeries, DateTime, DateTime, bool> isElevated)
+        Func<AsnSeries, DateTime, DateTime, bool> isElevated,
+        Func<AsnSeries, bool> isClean)
     {
         var hopNum = topology.HopNumberByIp.TryGetValue(bottleneckIp, out var hn) ? hn : int.MaxValue;
         // The hop the congestion sits ON owns the event - that ASN is the culprit, the deeper
@@ -332,11 +336,14 @@ public static class CongestionLocalizer
         // access-layer bufferbloat (which would lift every path that shares your access link).
         // Require samples IN the window: a series with no data then (a newer target added after a
         // past event, or a monitoring gap) is unknown, not clean, and must not pad this evidence.
+        // Clean = rose no more than the shared load floor in RTT (isClean), NOT merely "not elevated":
+        // under load the jitter floor lifts every path, so a jitter-inclusive test would count zero
+        // clean controls and wrongly drop the "this hop's own capacity, not your access egress" finding.
         var cleanParallelPaths = allSeries.Count(s => HasTrace(s, topology)
             && HasDataInWindow(s, window.Start, window.End)
             && !s.HopIps.Contains(bottleneckIp, StringComparer.OrdinalIgnoreCase)
             && !s.AncestorIps.Contains(bottleneckIp, StringComparer.OrdinalIgnoreCase)
-            && !isElevated(s, window.Start, window.End));
+            && isClean(s));
 
         CongestionDisposition disposition;
         string reason;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
@@ -158,10 +158,10 @@ public static class CongestionLocalizer
         IspHealthOptions options)
     {
         var hops = anchored.Where(s => !s.IsDestination).ToList();
-        if (hops.Count < options.CoincidentCongestionMinHops) return;
+        if (hops.Count == 0) return;
 
         var bucketSize = TimeSpan.FromMinutes(options.CongestionBucketMinutes);
-        var perHop = new List<(AsnSeries Hop, double Base, Dictionary<DateTime, double> Buckets)>();
+        var perHop = new List<(AsnSeries Hop, double Base, Dictionary<DateTime, double> Buckets, bool IsAccess)>();
         foreach (var h in hops)
         {
             var rtts = h.Samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
@@ -170,12 +170,13 @@ public static class CongestionLocalizer
             var buckets = h.Samples.Where(s => s.RttAvgMs.HasValue)
                 .GroupBy(s => CongestionDetector.FloorTime(s.Time, bucketSize))
                 .ToDictionary(g => g.Key, g => SeriesStats.Median(g.Select(s => s.RttAvgMs!.Value).ToList()) ?? baseRtt.Value);
-            perHop.Add((h, baseRtt.Value, buckets));
+            var isAccess = h.HopIps.Any(ip => topology.AccessEgressHopIps.Contains(ip));
+            perHop.Add((h, baseRtt.Value, buckets, isAccess));
         }
-        if (perHop.Count < options.CoincidentCongestionMinHops) return;
+        if (perHop.Count == 0) return;
 
         // "Up" in a bucket: fired an event covering it, or drifted up sub-threshold (scale-relative).
-        bool Up((AsnSeries Hop, double Base, Dictionary<DateTime, double> Buckets) p, DateTime t)
+        bool Up((AsnSeries Hop, double Base, Dictionary<DateTime, double> Buckets, bool IsAccess) p, DateTime t)
         {
             if (eventsBySeries.TryGetValue(p.Hop, out var evs) && evs.Any(e => Overlaps(e.Start, e.End, t, t + bucketSize)))
                 return true;
@@ -186,12 +187,15 @@ public static class CongestionLocalizer
         var upAt = new Dictionary<DateTime, List<AsnSeries>>();
         foreach (var t in perHop.SelectMany(p => p.Buckets.Keys).Distinct())
         {
-            var withData = perHop.Where(p => p.Buckets.ContainsKey(t)).ToList();
-            if (withData.Count < options.CoincidentCongestionMinHops) continue;
-            var up = withData.Where(p => Up(p, t)).Select(p => p.Hop).ToList();
-            if (up.Count >= options.CoincidentCongestionMinHops
-                && up.Count >= withData.Count * options.CoincidentCongestionRiseFraction)
-                upAt[t] = up;
+            var up = perHop.Where(p => p.Buckets.ContainsKey(t) && Up(p, t)).ToList();
+            // Shared upstream: the elevation is rooted at the access egress (the hop nearest you is up,
+            // not merely a deeper hop with clean upstream) AND spans multiple independent networks.
+            // That separates one shared incident from a single localized bottleneck that simply
+            // propagated to its downstream victim - which must still localize, not collapse.
+            var accessUp = up.Any(p => p.IsAccess);
+            var asns = up.Select(p => p.Hop.AsnNumber).Where(a => a > 0).Distinct().Count();
+            if (accessUp && asns >= options.SharedEventMinAsns)
+                upAt[t] = up.Select(p => p.Hop).ToList();
         }
         if (upAt.Count == 0) return;
 
@@ -214,7 +218,7 @@ public static class CongestionLocalizer
             var start = g[0];
             var end = g[^1] + bucketSize;
             var upHops = g.SelectMany(t => upAt[t]).Distinct().ToList();
-            if (upHops.Count < options.CoincidentCongestionMinHops) continue;
+            if (upHops.Select(h => h.AsnNumber).Where(a => a > 0).Distinct().Count() < options.SharedEventMinAsns) continue;
 
             // The nearest up hop owns the event: the shared bottleneck sits at or behind the
             // convergence point closest to the user, and attributing there avoids penalizing every

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
@@ -53,8 +53,7 @@ public static class CongestionLocalizer
             .Where(s => !s.IsDestination)
             .SelectMany(s => eventsBySeries[s].Select(e => (Series: s, Evt: e)))
             .ToList();
-
-        var anchored = allSeries.Where(s => HasTrace(s, topology)).ToList();
+        if (candidates.Count == 0) return new List<CongestionEvent>();
 
         // A hop counts as elevated if it fired its own event OR shows in-window RTT excursions
         // above its baseline. The softer test matters for propagation: a downstream hop inherits
@@ -63,6 +62,8 @@ public static class CongestionLocalizer
         bool IsElevated(AsnSeries s, DateTime start, DateTime end) =>
             (eventsBySeries.TryGetValue(s, out var evs) && evs.Any(e => Overlaps(e.Start, e.End, start, end)))
             || ElevatedInWindow(s, start, end, options);
+
+        var anchored = allSeries.Where(s => HasTrace(s, topology)).ToList();
 
         var result = new List<CongestionEvent>();
         foreach (var cluster in ClusterByTime(candidates))
@@ -128,144 +129,8 @@ public static class CongestionLocalizer
             evt.AttributionReason = "Confirmed by a sibling hop on the same network congesting in the same window; no monitored hop sits beyond this one to verify it directly.";
         }
 
-        // Collapse genuinely shared incidents: where many independent hops are up TOGETHER (whether
-        // each crossed its own gate or merely drifted up sub-threshold), replace the per-hop events
-        // with one shared-upstream event spanning the concurrent window. Catches both the line-wide
-        // cluster the per-hop localizer would scatter into N rows and the sub-gate rise it misses
-        // entirely - keyed on bucket-level concurrency, so one hop lingering past the rest neither
-        // hides the coincidence nor stretches the collapsed event's duration.
-        ApplySharedUpstream(result, anchored, eventsBySeries, topology, options);
-
         return result.OrderBy(e => e.Start).ToList();
     }
-
-    /// <summary>
-    /// Collapses genuinely shared incidents into one event. A hop is "up" in a bucket if it fired its
-    /// own congestion event there OR merely drifted up sub-threshold (its bucket median rose past
-    /// baseline by a scale-relative margin a fixed millisecond gate would miss). Where a majority of
-    /// independent hops are up TOGETHER, that is one shared upstream bottleneck, not N per-hop events:
-    /// the per-hop events overlapping the concurrent window are removed and replaced with a single
-    /// event attributed to the convergence hop closest to the user. Keyed on bucket-level concurrency
-    /// (not the cluster's outer span), so one hop lingering past the rest neither hides the
-    /// coincidence nor stretches the collapsed duration. Under load it reads as self-inflicted Loaded
-    /// Latency (suppressed); otherwise it is real shared upstream congestion (Confirmed, scored).
-    /// </summary>
-    private static void ApplySharedUpstream(
-        List<CongestionEvent> result,
-        IReadOnlyList<AsnSeries> anchored,
-        Dictionary<AsnSeries, List<CongestionEvent>> eventsBySeries,
-        CongestionTopology topology,
-        IspHealthOptions options)
-    {
-        var hops = anchored.Where(s => !s.IsDestination).ToList();
-        if (hops.Count < options.CoincidentCongestionMinHops) return;
-
-        var bucketSize = TimeSpan.FromMinutes(options.CongestionBucketMinutes);
-        var perHop = new List<(AsnSeries Hop, double Base, Dictionary<DateTime, double> Buckets)>();
-        foreach (var h in hops)
-        {
-            var rtts = h.Samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
-            var baseRtt = SeriesStats.Median(rtts);
-            if (!baseRtt.HasValue) continue;
-            var buckets = h.Samples.Where(s => s.RttAvgMs.HasValue)
-                .GroupBy(s => CongestionDetector.FloorTime(s.Time, bucketSize))
-                .ToDictionary(g => g.Key, g => SeriesStats.Median(g.Select(s => s.RttAvgMs!.Value).ToList()) ?? baseRtt.Value);
-            perHop.Add((h, baseRtt.Value, buckets));
-        }
-        if (perHop.Count < options.CoincidentCongestionMinHops) return;
-
-        // "Up" in a bucket: fired an event covering it, or drifted up sub-threshold (scale-relative).
-        bool Up((AsnSeries Hop, double Base, Dictionary<DateTime, double> Buckets) p, DateTime t)
-        {
-            if (eventsBySeries.TryGetValue(p.Hop, out var evs) && evs.Any(e => Overlaps(e.Start, e.End, t, t + bucketSize)))
-                return true;
-            return p.Buckets.TryGetValue(t, out var med)
-                && med >= p.Base + Math.Max(options.CongestionLineWideMinShiftMs, p.Base * options.CoincidentCongestionRttRisePct);
-        }
-
-        var upAt = new Dictionary<DateTime, List<AsnSeries>>();
-        foreach (var t in perHop.SelectMany(p => p.Buckets.Keys).Distinct())
-        {
-            var withData = perHop.Where(p => p.Buckets.ContainsKey(t)).ToList();
-            if (withData.Count < options.CoincidentCongestionMinHops) continue;
-            var up = withData.Where(p => Up(p, t)).Select(p => p.Hop).ToList();
-            if (up.Count >= options.CoincidentCongestionMinHops
-                && up.Count >= withData.Count * options.CoincidentCongestionRiseFraction)
-                upAt[t] = up;
-        }
-        if (upAt.Count == 0) return;
-
-        // Group consecutive concurrent buckets (allowing a single-bucket gap) into windows.
-        var groups = new List<List<DateTime>>();
-        foreach (var t in upAt.Keys.OrderBy(t => t))
-        {
-            if (groups.Count > 0 && t - groups[^1][^1] <= bucketSize + bucketSize)
-                groups[^1].Add(t);
-            else
-                groups.Add(new List<DateTime> { t });
-        }
-
-        int HopNum(AsnSeries s) => s.HopIps.Concat(s.AncestorIps)
-            .Where(topology.HopNumberByIp.ContainsKey)
-            .Select(ip => topology.HopNumberByIp[ip]).DefaultIfEmpty(int.MaxValue).Min();
-
-        foreach (var g in groups)
-        {
-            var start = g[0];
-            var end = g[^1] + bucketSize;
-            var upHops = g.SelectMany(t => upAt[t]).Distinct().ToList();
-            if (upHops.Count < options.CoincidentCongestionMinHops) continue;
-
-            // The nearest up hop owns the event: the shared bottleneck sits at or behind the
-            // convergence point closest to the user, and attributing there avoids penalizing every
-            // downstream transit ASN that merely inherited the upstream rise.
-            var owner = upHops.OrderBy(HopNum).First();
-            var ownerPer = perHop.First(p => p.Hop == owner);
-            var peakRtt = g.Where(t => ownerPer.Buckets.ContainsKey(t)).Select(t => ownerPer.Buckets[t]).DefaultIfEmpty(ownerPer.Base).Max();
-            var ownerJits = owner.Samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
-            var baseJit = SeriesStats.Median(ownerJits) ?? 0;
-            var peakJit = owner.Samples.Where(s => s.Time >= start && s.Time < end)
-                .Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).DefaultIfEmpty(baseJit).Max();
-            var loadCoincident = LoadCoincident(start, end, topology, options);
-
-            // This concurrent window is one shared incident: drop the per-hop events it subsumes and
-            // replace them with a single shared-upstream event spanning only the concurrent window.
-            result.RemoveAll(e => !e.SharedUpstream && Overlaps(e.Start, e.End, start, end));
-            result.Add(SharedUpstreamEvent(owner, ownerPer.Base, peakRtt, baseJit, peakJit, start, end, upHops.Count, loadCoincident));
-        }
-    }
-
-    /// <summary>
-    /// Builds one shared-upstream congestion event attributed to <paramref name="owner"/> (the
-    /// convergence hop closest to the user). Under load it reads as self-inflicted "Loaded Latency"
-    /// (your access link is the limit, suppressed from the score); otherwise it is real shared
-    /// upstream congestion (Confirmed, scored). Used both to collapse a line-wide cluster of per-hop
-    /// events and to surface a sub-gate coincident rise.
-    /// </summary>
-    private static CongestionEvent SharedUpstreamEvent(
-        AsnSeries owner, double baselineRtt, double peakRtt, double baselineJit, double peakJit,
-        DateTime start, DateTime end, int riseCount, bool loadCoincident) => new()
-    {
-        Start = start,
-        End = end,
-        AsnNumbers = owner.AsnNumber > 0 ? new List<int> { owner.AsnNumber } : new List<int>(),
-        AsnNames = owner.AsnName is { Length: > 0 } ? new List<string> { owner.AsnName } : new List<string>(),
-        TargetIds = owner.TargetIds.ToList(),
-        BaselineRttMs = baselineRtt,
-        PeakRttMs = peakRtt,
-        BaselineJitterMs = baselineJit,
-        PeakJitterMs = peakJit,
-        Scope = CongestionScope.Unlocalized,
-        Disposition = loadCoincident ? CongestionDisposition.SelfInflicted : CongestionDisposition.Confirmed,
-        BottleneckHopIp = owner.HopIps.FirstOrDefault(),
-        BottleneckLabel = owner.AsnName,
-        SharedUpstream = true,
-        LoadCoincident = loadCoincident,
-        Confidence = 70,
-        AttributionReason = loadCoincident
-            ? "Every monitored path rose together under heavy WAN load, so the limit was your access link (bufferbloat or a congested shared-access network), not a single hop."
-            : $"{riseCount} monitored paths across independent networks rose together this window - a shared upstream bottleneck lifting the whole path, not any one hop."
-    };
 
     /// <summary>
     /// The shallowest hop in the unbroken elevated run ending at <paramref name="series"/>. A

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
@@ -295,17 +295,21 @@ public static class CongestionLocalizer
             && idEvents.Any(e => Overlaps(e.Start, e.End, window.Start, window.End))
             ? new List<AsnSeries> { identity }
             : members;
-        var worst = metricSource
+        var sourceEvents = metricSource
             .SelectMany(m => eventsBySeries[m].Where(e => Overlaps(e.Start, e.End, window.Start, window.End)))
-            .OrderByDescending(e => e.PeakRttMs - e.BaselineRttMs)
-            .First();
+            .ToList();
+        var worst = sourceEvents.OrderByDescending(e => e.PeakRttMs - e.BaselineRttMs).First();
         // The penalized ASN/targets are the bottleneck hop when localized; downstream victims
         // are excluded. An unlocalized event has no single culprit, so it keeps the full set.
         var id = identity != null ? new List<AsnSeries> { identity } : members;
+        // This event spans its OWN bottleneck's elevation, not the full time-cluster window: a hop
+        // that cleared in 45 min must not inherit a co-occurring hop's multi-hour span just because
+        // they shared a cluster. The cluster window is still used for the correlation, propagation,
+        // and clean-control checks above; only the reported (and scored) duration is per-member.
         return new CongestionEvent
         {
-            Start = window.Start,
-            End = window.End,
+            Start = sourceEvents.Min(e => e.Start),
+            End = sourceEvents.Max(e => e.End),
             AsnNumbers = id.Select(m => m.AsnNumber).Distinct().ToList(),
             AsnNames = id.Select(m => m.AsnName ?? $"AS{m.AsnNumber}").Distinct().ToList(),
             TargetIds = id.SelectMany(m => m.TargetIds).Distinct().ToList(),

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
@@ -104,18 +104,30 @@ public static class CongestionLocalizer
                 && anchoredWithData.Count(s => RoseInWindow(s, window.Start, window.End, options))
                     >= anchoredWithData.Count * options.CongestionLineWideRiseFraction;
 
-            // SHARED-INCIDENT COLLAPSE. The per-hop separation below is the default and stays
-            // authoritative. This narrow exception fires only when a strict majority of monitored
-            // paths are elevated RELATIVE TO THEIR OWN baselines (IsElevated - the same per-hop
-            // relative test the bottleneck walk trusts, NOT an absolute ms floor) AND the rise reaches
-            // the access egress (rooted at your network, not a deep mid-path cluster). That is one
-            // incident - your access link under load, or a shared upstream otherwise - so it collapses
-            // to a single event instead of N rows. A localized bottleneck, a propagation-to-victim, or
-            // a partial rise all fail this gate and fall through to the per-hop logic, unchanged.
+            // SHARED-INCIDENT COLLAPSE (narrow exception; the per-hop separation below is the default
+            // and stays authoritative). Collapse to ONE event only when the rise is genuinely UNIFORM:
+            // a strict majority of paths rose in RTT over baseline (lineWideUnderLoad) AND no path rose
+            // MATERIALLY above the shared floor. Under load every path picks up a floor of added delay
+            // (loaded latency); but if a few paths are much worse than that floor, those are localized
+            // congestion on top of the load - stay per-hop so the localizer surfaces them as "this
+            // hop's own capacity", not "everything slowed". A jitter-only floor (queuing jitter lifts
+            // every path) is NOT enough on its own - lineWideUnderLoad keys on RTT.
+            double RttRise(AsnSeries s)
+            {
+                var inW = s.Samples.Where(x => x.Time >= window.Start && x.Time <= window.End && x.RttAvgMs.HasValue)
+                    .Select(x => x.RttAvgMs!.Value).ToList();
+                var baseW = s.Samples.Where(x => (x.Time < window.Start || x.Time > window.End) && x.RttAvgMs.HasValue)
+                    .Select(x => x.RttAvgMs!.Value).ToList();
+                var im = SeriesStats.Median(inW);
+                var bm = SeriesStats.Median(baseW);
+                return im.HasValue && bm.HasValue ? Math.Max(0, im.Value - bm.Value) : 0;
+            }
             var relElevated = anchoredWithData.Where(s => IsElevated(s, window.Start, window.End)).ToList();
-            var accessRooted = relElevated.Any(s => s.HopIps.Any(ip => topology.AccessEgressHopIps.Contains(ip)));
-            if (accessRooted && anchoredWithData.Count > 0
-                && relElevated.Count >= anchoredWithData.Count * options.CongestionLineWideRiseFraction)
+            var rises = relElevated.Select(RttRise).Where(r => r > 0).OrderBy(r => r).ToList();
+            var floorRise = SeriesStats.Median(rises) ?? 0;
+            var uniform = rises.Count == 0 || floorRise <= 0
+                || rises[^1] <= floorRise * options.CongestionLoadedUniformityFactor;
+            if (lineWideUnderLoad && uniform && relElevated.Count > 0)
             {
                 result.Add(BuildSharedIncident(relElevated, eventsBySeries, anchoredWithData, window,
                     topology, options, loadCoincident, IsElevated));
@@ -191,6 +203,29 @@ public static class CongestionLocalizer
         var owner = elevated.OrderBy(HopNum).First();
         var ownerEvt = evts(owner).FirstOrDefault();
 
+        // Owner magnitudes from its fired event when it has one; otherwise (the owner was elevated via
+        // the relative jitter/excursion arm with no fired RTT event) compute them from its samples, so
+        // the row never reports 0 -> 0.
+        double baseRtt, peakRtt, baseJit, peakJit;
+        if (ownerEvt != null)
+        {
+            baseRtt = ownerEvt.BaselineRttMs;
+            peakRtt = ownerEvt.PeakRttMs;
+            baseJit = ownerEvt.BaselineJitterMs;
+            peakJit = ownerEvt.PeakJitterMs;
+        }
+        else
+        {
+            var inR = owner.Samples.Where(x => x.Time >= start && x.Time <= end && x.RttAvgMs.HasValue).Select(x => x.RttAvgMs!.Value).ToList();
+            var baseR = owner.Samples.Where(x => (x.Time < start || x.Time > end) && x.RttAvgMs.HasValue).Select(x => x.RttAvgMs!.Value).ToList();
+            var inJ = owner.Samples.Where(x => x.Time >= start && x.Time <= end).Select(x => x.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
+            var baseJ = owner.Samples.Where(x => x.Time < start || x.Time > end).Select(x => x.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
+            baseRtt = SeriesStats.Median(baseR) ?? 0;
+            peakRtt = inR.Count > 0 ? SeriesStats.Percentile(inR, 0.90) ?? baseRtt : baseRtt;
+            baseJit = SeriesStats.Median(baseJ) ?? 0;
+            peakJit = inJ.Count > 0 ? inJ.Max() : baseJit;
+        }
+
         // Decision 2: name the single worst hop (largest relative RTT rise among the fired members).
         var worst = elevated
             .SelectMany(s => evts(s).Select(e => (Series: s, Rise: e.BaselineRttMs > 0 ? (e.PeakRttMs - e.BaselineRttMs) / e.BaselineRttMs : 0)))
@@ -211,10 +246,10 @@ public static class CongestionLocalizer
             AsnNumbers = owner.AsnNumber > 0 ? new List<int> { owner.AsnNumber } : new List<int>(),
             AsnNames = owner.AsnName is { Length: > 0 } ? new List<string> { owner.AsnName } : new List<string>(),
             TargetIds = owner.TargetIds.ToList(),
-            BaselineRttMs = ownerEvt?.BaselineRttMs ?? 0,
-            PeakRttMs = ownerEvt?.PeakRttMs ?? ownerEvt?.BaselineRttMs ?? 0,
-            BaselineJitterMs = ownerEvt?.BaselineJitterMs ?? 0,
-            PeakJitterMs = ownerEvt?.PeakJitterMs ?? 0,
+            BaselineRttMs = baseRtt,
+            PeakRttMs = peakRtt,
+            BaselineJitterMs = baseJit,
+            PeakJitterMs = peakJit,
             Scope = CongestionScope.Unlocalized,
             Disposition = loadCoincident ? CongestionDisposition.SelfInflicted : CongestionDisposition.Confirmed,
             BottleneckHopIp = owner.HopIps.FirstOrDefault(),

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
@@ -230,6 +230,15 @@ public static class CongestionLocalizer
                     ? $" It coincided with heavy WAN load, but {cleanParallelPaths} other monitored paths stayed clean under the same load, so it was this hop's own capacity, not your access egress."
                     : " It coincided with heavy WAN load (load-induced), but localizes to a specific hop rather than your access egress.";
         }
+        else if (hasDescendant && lineWideUnderLoad)
+        {
+            // The elevation didn't forward to THIS hop's immediate downstream witness, which alone
+            // would read as control-plane noise. But nearly every monitored path rose together this
+            // window (line-wide, with or without local load) - that's a shared upstream bottleneck
+            // lifting the whole path, not one hop's own ICMP handling. Real congestion, so scored.
+            disposition = CongestionDisposition.Confirmed;
+            reason = "Elevation rose across nearly every monitored path this window - a shared upstream bottleneck, not this hop's own control-plane handling.";
+        }
         else if (hasDescendant)
         {
             disposition = CongestionDisposition.ControlPlaneNoise;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
@@ -139,7 +139,7 @@ public static class CongestionLocalizer
 
             foreach (var (bnIp, members) in byBottleneck)
                 result.Add(BuildLocalized(bnIp, members, allSeries, eventsBySeries, window,
-                    topology, options, loadCoincident, cleanControlExists, lineWideUnderLoad, IsElevated, IsClean));
+                    topology, options, loadCoincident, cleanControlExists, lineWideUnderLoad, uniform, IsElevated, IsClean));
 
             if (unanchored.Count > 0)
                 result.Add(BuildUnlocalized(unanchored, eventsBySeries, window, topology, loadCoincident, options));
@@ -298,6 +298,7 @@ public static class CongestionLocalizer
         bool loadCoincident,
         bool cleanControlExists,
         bool lineWideUnderLoad,
+        bool uniform,
         Func<AsnSeries, DateTime, DateTime, bool> isElevated,
         Func<AsnSeries, bool> isClean)
     {
@@ -347,12 +348,15 @@ public static class CongestionLocalizer
 
         CongestionDisposition disposition;
         string reason;
-        if (isAccessEgress && loadCoincident && lineWideUnderLoad)
+        if (isAccessEgress && loadCoincident && lineWideUnderLoad && uniform)
         {
-            // Bottleneck is the access egress AND every monitored path drifted up together under load
-            // (line-wide). That's loaded latency where all your traffic converges, not a distinct ISP
-            // hop. Surfaced as "Loaded Latency" (not Congestion), not scored (Suppressed). We assert
-            // location + correlation only; the mechanism (CPE buffer, OLT, policing) is unknowable here.
+            // Bottleneck is the access egress AND every monitored path drifted up TOGETHER and UNIFORMLY
+            // under load (line-wide, no path materially worse than the shared floor). That's loaded
+            // latency where all your traffic converges, not a distinct ISP hop. The uniform gate mirrors
+            // the collapse: a shared floor plus a few materially-worse hops is localized congestion on
+            // top of load, not bufferbloat, so it must NOT read as self-inflicted here either. Surfaced
+            // as "Loaded Latency" (not Congestion), not scored (Suppressed). We assert location +
+            // correlation only; the mechanism (CPE buffer, OLT, policing) is unknowable here.
             disposition = CongestionDisposition.SelfInflicted;
             reason = "Every monitored path rose together under load, so the limit was your access link, not a single hop - consistent with bufferbloat or a congested shared-access network.";
         }
@@ -550,8 +554,13 @@ public static class CongestionLocalizer
             .Select(x => x.RttAvgMs!.Value).ToList();
         if (inWindow.Count == 0 || baseline.Count == 0) return false;
         var bMed = SeriesStats.Median(baseline);
-        var eMed = SeriesStats.Median(inWindow);
-        return bMed.HasValue && eMed.HasValue && eMed.Value > bMed.Value + options.CongestionLineWideMinShiftMs;
+        // Use a high in-window percentile, not the median: an event with a strong core and a long
+        // mild tail dilutes the median toward baseline, so a path that genuinely rose for a good part
+        // of the window flickers in and out of "rose" across recomputes and the line-wide breadth
+        // hovers at its threshold. The percentile captures the strong portion robustly; a flat path
+        // (or one that only nudged the tail) still sits at baseline and does not count.
+        var eHigh = SeriesStats.Percentile(inWindow, options.CongestionLineWideRisePercentile);
+        return bMed.HasValue && eHigh.HasValue && eHigh.Value > bMed.Value + options.CongestionLineWideMinShiftMs;
     }
 
     private static List<List<(AsnSeries Series, CongestionEvent Evt)>> ClusterByTime(

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
@@ -109,7 +109,7 @@ public static class CongestionLocalizer
                     topology, options, loadCoincident, cleanControlExists, lineWideUnderLoad, IsElevated));
 
             if (unanchored.Count > 0)
-                result.Add(BuildUnlocalized(unanchored, eventsBySeries, window, topology, loadCoincident));
+                result.Add(BuildUnlocalized(unanchored, eventsBySeries, window, topology, loadCoincident, options));
         }
 
         // An Unverifiable hop (dead-end, nothing monitored beyond it) inherits Confirmed from a
@@ -253,7 +253,7 @@ public static class CongestionLocalizer
             _ => 50
         };
 
-        var evt = NewEvent(bottleneckSeries, members, eventsBySeries, window);
+        var evt = NewEvent(bottleneckSeries, members, eventsBySeries, window, options);
         evt.Scope = CongestionScope.Hop;
         evt.Disposition = disposition;
         evt.BottleneckHopIp = bottleneckIp;
@@ -270,9 +270,10 @@ public static class CongestionLocalizer
         Dictionary<AsnSeries, List<CongestionEvent>> eventsBySeries,
         (DateTime Start, DateTime End) window,
         CongestionTopology topology,
-        bool loadCoincident)
+        bool loadCoincident,
+        IspHealthOptions options)
     {
-        var evt = NewEvent(null, members, eventsBySeries, window);
+        var evt = NewEvent(null, members, eventsBySeries, window, options);
         evt.Scope = CongestionScope.Unlocalized;
         evt.Disposition = CongestionDisposition.Confirmed;
         evt.LoadCoincident = loadCoincident;
@@ -287,7 +288,8 @@ public static class CongestionLocalizer
         AsnSeries? identity,
         List<AsnSeries> members,
         Dictionary<AsnSeries, List<CongestionEvent>> eventsBySeries,
-        (DateTime Start, DateTime End) window)
+        (DateTime Start, DateTime End) window,
+        IspHealthOptions options)
     {
         // Metrics come from the culprit hop when it has its own elevation, else the worst member.
         var metricSource = identity != null
@@ -302,14 +304,20 @@ public static class CongestionLocalizer
         // The penalized ASN/targets are the bottleneck hop when localized; downstream victims
         // are excluded. An unlocalized event has no single culprit, so it keeps the full set.
         var id = identity != null ? new List<AsnSeries> { identity } : members;
-        // This event spans its OWN bottleneck's elevation, not the full time-cluster window: a hop
-        // that cleared in 45 min must not inherit a co-occurring hop's multi-hour span just because
-        // they shared a cluster. The cluster window is still used for the correlation, propagation,
-        // and clean-control checks above; only the reported (and scored) duration is per-member.
+        // Report the shared cluster window when this bottleneck's own elevation covers most of it,
+        // so a genuine co-temporal event reads as one clean window across its per-hop rows. Only a
+        // member that cleared much earlier than the others (an outlier) reports its own shorter span
+        // - so a hop that resolved in 45 min isn't stamped with a co-occurring hop's multi-hour span.
+        // Correlation/propagation/disposition above still use the full cluster window regardless.
+        var ownStart = sourceEvents.Min(e => e.Start);
+        var ownEnd = sourceEvents.Max(e => e.End);
+        var clusterSpan = (window.End - window.Start).TotalSeconds;
+        var sharesWindow = clusterSpan <= 0
+            || (ownEnd - ownStart).TotalSeconds >= clusterSpan * options.CongestionSharedWindowMinFraction;
         return new CongestionEvent
         {
-            Start = sourceEvents.Min(e => e.Start),
-            End = sourceEvents.Max(e => e.End),
+            Start = sharesWindow ? window.Start : ownStart,
+            End = sharesWindow ? window.End : ownEnd,
             AsnNumbers = id.Select(m => m.AsnNumber).Distinct().ToList(),
             AsnNames = id.Select(m => m.AsnName ?? $"AS{m.AsnNumber}").Distinct().ToList(),
             TargetIds = id.SelectMany(m => m.TargetIds).Distinct().ToList(),

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
@@ -230,15 +230,6 @@ public static class CongestionLocalizer
                     ? $" It coincided with heavy WAN load, but {cleanParallelPaths} other monitored paths stayed clean under the same load, so it was this hop's own capacity, not your access egress."
                     : " It coincided with heavy WAN load (load-induced), but localizes to a specific hop rather than your access egress.";
         }
-        else if (hasDescendant && lineWideUnderLoad)
-        {
-            // The elevation didn't forward to THIS hop's immediate downstream witness, which alone
-            // would read as control-plane noise. But nearly every monitored path rose together this
-            // window (line-wide, with or without local load) - that's a shared upstream bottleneck
-            // lifting the whole path, not one hop's own ICMP handling. Real congestion, so scored.
-            disposition = CongestionDisposition.Confirmed;
-            reason = "Elevation rose across nearly every monitored path this window - a shared upstream bottleneck, not this hop's own control-plane handling.";
-        }
         else if (hasDescendant)
         {
             disposition = CongestionDisposition.ControlPlaneNoise;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -253,14 +253,6 @@ public class CongestionEvent
     /// <summary>True when this event must not penalize the score: self-inflicted bufferbloat or absolved control-plane noise.</summary>
     public bool Suppressed => Disposition is CongestionDisposition.SelfInflicted or CongestionDisposition.ControlPlaneNoise;
 
-    /// <summary>
-    /// True when this event came from coincident-rise (shared-upstream) detection rather than a
-    /// per-hop gate crossing: many independent hops rose together while each stayed individually
-    /// sub-threshold. Such events are sub-gate by design, so the fine-resolution boundary-refine
-    /// must not treat "no per-hop run reproduces it" as a phantom and drop it.
-    /// </summary>
-    public bool SharedUpstream { get; set; }
-
     public bool IsShared => AsnNumbers.Count > 1;
     public TimeSpan Duration => End - Start;
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -195,8 +195,10 @@ public enum CongestionDisposition
 /// </summary>
 public class CongestionEvent
 {
-    public DateTime Start { get; init; }
-    public DateTime End { get; init; }
+    // Settable (not init) so a long-window report can snap these to fine-resolution boundaries
+    // after detection - see IspHealthService.RefineCongestionBoundariesAsync.
+    public DateTime Start { get; set; }
+    public DateTime End { get; set; }
 
     /// <summary>ASNs affected. More than one means a shared upstream event.</summary>
     public List<int> AsnNumbers { get; init; } = new();

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -297,13 +297,23 @@ public enum OutageScope
 /// near-total loss while probes kept reporting. A monitoring gap (console offline) has no
 /// samples at all and is never an outage. Scored by duration alone via a capped Packet
 /// Loss penalty - independent of shape or which hops dropped; the scope, break point, and
-/// per-tier recovery shape are presentation only.
+/// per-tier recovery shape are presentation only. Spans below
+/// <see cref="IspHealthOptions.OutageBriefMaxSeconds"/> are flagged <see cref="IsBrief"/> -
+/// short transit/upstream flaps surfaced on the timeline with only a fraction-of-a-point score hit.
 /// </summary>
 public class OutageEvent
 {
     public DateTime Start { get; init; }
     public DateTime End { get; init; }
     public TimeSpan Duration => End - Start;
+
+    /// <summary>
+    /// True when this span is a brief disruption (shorter than
+    /// <see cref="IspHealthOptions.OutageBriefMaxSeconds"/>) rather than a full outage. Brief
+    /// disruptions are reported distinctly and ride the low end of the severity curve, so their
+    /// score impact is at most a point. Set by the detector.
+    /// </summary>
+    public bool IsBrief { get; init; }
 
     /// <summary>Whether even the access hop went dark, or it held while everything beyond it dropped.</summary>
     public OutageScope Scope { get; init; }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -315,6 +315,23 @@ public class OutageEvent
     /// </summary>
     public bool IsBrief { get; init; }
 
+    /// <summary>
+    /// True when this is a partial-loss disruption (degradation): a coincident burst of elevated
+    /// loss across many path targets that never reached the near-total dark threshold, so nothing
+    /// went fully dark. Distinct from a blackout outage - reported by peak loss and breadth rather
+    /// than a dark/recovery waterfall, and its loss is NOT masked from the Packet Loss factor.
+    /// </summary>
+    public bool IsPartial { get; init; }
+
+    /// <summary>Worst per-target mean loss reached during the event, for the partial-loss summary.</summary>
+    public double PeakLossPct { get; init; }
+
+    /// <summary>Distinct path targets that degraded during the event (partial-loss breadth).</summary>
+    public int DegradedTargetCount { get; init; }
+
+    /// <summary>Total path targets reporting during the event, the denominator for the breadth summary.</summary>
+    public int PathTargetCount { get; init; }
+
     /// <summary>Whether even the access hop went dark, or it held while everything beyond it dropped.</summary>
     public OutageScope Scope { get; init; }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -253,6 +253,14 @@ public class CongestionEvent
     /// <summary>True when this event must not penalize the score: self-inflicted bufferbloat or absolved control-plane noise.</summary>
     public bool Suppressed => Disposition is CongestionDisposition.SelfInflicted or CongestionDisposition.ControlPlaneNoise;
 
+    /// <summary>
+    /// True when this event came from coincident-rise (shared-upstream) detection rather than a
+    /// per-hop gate crossing: many independent hops rose together while each stayed individually
+    /// sub-threshold. Such events are sub-gate by design, so the fine-resolution boundary-refine
+    /// must not treat "no per-hop run reproduces it" as a phantom and drop it.
+    /// </summary>
+    public bool SharedUpstream { get; set; }
+
     public bool IsShared => AsnNumbers.Count > 1;
     public TimeSpan Duration => End - Start;
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -266,6 +266,14 @@ public class IspHealthOptions
     /// </summary>
     public double CongestionLineWideMinShiftMs { get; set; } = 0.5;
 
+    /// <summary>
+    /// In-window percentile used by the line-wide rise test. A high percentile (vs the median) keeps a
+    /// path that rose strongly for a good part of the window counted as "rose" even when a long mild
+    /// tail dilutes its median toward baseline - otherwise the line-wide breadth flickers across
+    /// recomputes for an event with a strong core and a long tail. A flat path still sits at baseline.
+    /// </summary>
+    public double CongestionLineWideRisePercentile { get; set; } = 0.75;
+
     /// <summary>Window size in minutes for step-change median comparison.</summary>
     public int StepWindowMinutes { get; set; } = 30;
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -232,8 +232,13 @@ public class IspHealthOptions
     /// </summary>
     public double StepStableIqrFraction { get; set; } = 0.15;
 
-    /// <summary>Bucket size in minutes for outage detection.</summary>
-    public int OutageBucketMinutes { get; set; } = 1;
+    /// <summary>
+    /// Bucket size in seconds for outage detection. Sub-minute so a brief (~30 s) drop resolves
+    /// into its own fully-dark buckets instead of being diluted to a partial-loss bucket inside a
+    /// one-minute window and failing the dark-fraction gate. At the internet targets' ~7-10 s
+    /// effective sample cadence a 15 s bucket still holds one or two samples per target.
+    /// </summary>
+    public int OutageBucketSeconds { get; set; } = 15;
 
     /// <summary>
     /// Mean loss (percent) at or above which a tier counts as dark in an outage bucket.
@@ -256,17 +261,30 @@ public class IspHealthOptions
     /// </summary>
     public int OutageMinReportingTargets { get; set; } = 2;
 
-    /// <summary>Minimum sustained duration in minutes for an outage event.</summary>
-    public int OutageMinDurationMinutes { get; set; } = 2;
+    /// <summary>
+    /// Minimum sustained duration in seconds before a near-total-loss span is reported at all.
+    /// Set above a momentary blip (a single lost probe group) but well below the brief/full
+    /// divider, so a clean 30 s transit drop is captured rather than discarded.
+    /// </summary>
+    public int OutageMinDurationSeconds { get; set; } = 30;
+
+    /// <summary>
+    /// Spans shorter than this are classified as brief disruptions (short transit/upstream flaps);
+    /// at or above it they are full outages. This is the prior two-minute outage threshold, kept as
+    /// the divider so what users already understood as an outage is unchanged - brief disruptions are
+    /// a new, lighter tier beneath it that rides the low end of the severity curve. See
+    /// <see cref="OutageEvent.IsBrief"/>.
+    /// </summary>
+    public int OutageBriefMaxSeconds { get; set; } = 120;
 
     /// <summary>
     /// Two outage runs separated by a healthy gap no longer than this are coalesced into one
     /// event. One real outage briefly clears the dark-fraction gate during staggered onset or
-    /// inside-out recovery (targets dark/heal at slightly different minutes); without this it
+    /// inside-out recovery (targets dark/heal at slightly different times); without this it
     /// would fragment into several adjacent events. The sealed gap counts as downtime, so keep
     /// it short - the over-count is bounded by this value per seam.
     /// </summary>
-    public int OutageMaxGapMinutes { get; set; } = 3;
+    public int OutageMaxGapSeconds { get; set; } = 180;
 
     /// <summary>
     /// Recovery-time tolerance for collapsing per-target access ISP rows in the outage waterfall:

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -179,6 +179,16 @@ public class IspHealthOptions
     public double CongestionSustainFraction { get; set; } = 0.5;
 
     /// <summary>
+    /// A localized congestion event reports the shared time-cluster window when its own bottleneck's
+    /// elevation covers at least this fraction of that window; a member substantially shorter (an
+    /// outlier that cleared early while co-occurring hops lingered) reports its own span instead.
+    /// Keeps a genuine co-temporal shared event presented as one clean window, while still breaking
+    /// out a hop whose duration is very different. At 1.0 every member uses its own exact span; at 0
+    /// every member uses the full cluster window.
+    /// </summary>
+    public double CongestionSharedWindowMinFraction { get; set; } = 0.7;
+
+    /// <summary>
     /// WAN utilization (fraction of the expected plan speed, worst direction) at or above
     /// which a congestion bucket is treated as coinciding with heavy local load. The
     /// self-inflicted classifier uses this to tell access-egress bufferbloat (your own

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -215,6 +215,22 @@ public class IspHealthOptions
     public double CongestionPropagationExcursionFraction { get; set; } = 0.05;
 
     /// <summary>
+    /// Factor a hop's in-window median jitter must clear over its own baseline median jitter to count
+    /// as elevated for PROPAGATION. Many congestion incidents are jitter-driven with flat RTT, so an
+    /// RTT-only propagation test reads the downstream as "clean" and wrongly absolves a real chain-wide
+    /// rise as per-hop control-plane noise. Softer than the detection jitter factor; paired with an
+    /// absolute floor below so a near-zero-baseline hop is not tripped by a sub-ms ratio swing.
+    /// </summary>
+    public double CongestionPropagationJitterFactor { get; set; } = 1.5;
+
+    /// <summary>
+    /// Minimum absolute median-jitter rise (ms) for the propagation jitter test, on top of the
+    /// <see cref="CongestionPropagationJitterFactor"/> ratio - a 0.05 -> 0.10 ms doubling is still
+    /// noise, not propagation.
+    /// </summary>
+    public double CongestionPropagationJitterFloorMs { get; set; } = 0.25;
+
+    /// <summary>
     /// Self-inflicted access bufferbloat is a line-wide rise under load: this fraction of monitored
     /// paths (with data) must have their in-window median rise above baseline for an access-egress
     /// bottleneck under load to read as self-inflicted rather than a hop bottleneck. A robust majority

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -230,6 +230,29 @@ public class IspHealthOptions
     /// </summary>
     public double CongestionLineWideMinShiftMs { get; set; } = 0.5;
 
+    /// <summary>
+    /// Shared-upstream (coincident-rise) detection: the minimum number of independent monitored hops
+    /// that must rise together in a bucket for it to count as shared congestion. Each hop's rise is
+    /// individually sub-threshold (below the per-hop congestion gate); the coincidence across
+    /// unrelated ASNs is the signal a per-hop threshold can't see.
+    /// </summary>
+    public int CoincidentCongestionMinHops { get; set; } = 4;
+
+    /// <summary>
+    /// Shared-upstream detection: the fraction of monitored hops (with data in the bucket) that must
+    /// have risen for the bucket to count as a shared-upstream bucket. Lower than the self-infliction
+    /// line-wide fraction because there is no local-load corroboration to lean on.
+    /// </summary>
+    public double CoincidentCongestionRiseFraction { get; set; } = 0.6;
+
+    /// <summary>
+    /// Shared-upstream detection: a hop's bucket median counts as "risen" when it sits at least this
+    /// fraction of its baseline above baseline (with <see cref="CongestionLineWideMinShiftMs"/> as the
+    /// absolute floor). Scale-relative so a real proportional rise on a low-latency fiber hop registers
+    /// where a fixed millisecond floor would miss it.
+    /// </summary>
+    public double CoincidentCongestionRttRisePct { get; set; } = 0.15;
+
     /// <summary>Window size in minutes for step-change median comparison.</summary>
     public int StepWindowMinutes { get; set; } = 30;
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -231,25 +231,12 @@ public class IspHealthOptions
     public double CongestionLineWideMinShiftMs { get; set; } = 0.5;
 
     /// <summary>
-    /// Shared-upstream (coincident-rise) detection: the minimum number of independent monitored hops
-    /// that must rise together in a bucket for it to count as shared congestion. Each hop's rise is
-    /// individually sub-threshold (below the per-hop congestion gate); the coincidence across
-    /// unrelated ASNs is the signal a per-hop threshold can't see.
-    /// </summary>
-    public int CoincidentCongestionMinHops { get; set; } = 4;
-
-    /// <summary>
-    /// Shared-upstream detection: the fraction of monitored hops (with data in the bucket) that must
-    /// have risen for the bucket to count as a shared-upstream bucket. Lower than the self-infliction
-    /// line-wide fraction because there is no local-load corroboration to lean on.
-    /// </summary>
-    public double CoincidentCongestionRiseFraction { get; set; } = 0.6;
-
-    /// <summary>
-    /// Shared-upstream detection: a hop's bucket median counts as "risen" when it sits at least this
-    /// fraction of its baseline above baseline (with <see cref="CongestionLineWideMinShiftMs"/> as the
-    /// absolute floor). Scale-relative so a real proportional rise on a low-latency fiber hop registers
-    /// where a fixed millisecond floor would miss it.
+    /// Shared-upstream (coincident-rise) detection: a hop's bucket median counts as "risen" when it
+    /// sits at least this fraction of its baseline above baseline (with
+    /// <see cref="CongestionLineWideMinShiftMs"/> as the absolute floor). Scale-relative so a real
+    /// proportional rise on a low-latency fiber hop registers where a fixed millisecond floor would
+    /// miss it. A shared-upstream event needs the elevation rooted at the access egress and spanning
+    /// at least <see cref="SharedEventMinAsns"/> independent networks.
     /// </summary>
     public double CoincidentCongestionRttRisePct { get; set; } = 0.15;
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -168,6 +168,17 @@ public class IspHealthOptions
     public double CongestionJitterMinDeltaMs { get; set; } = 0.8;
 
     /// <summary>
+    /// Hysteresis for congestion run continuation. Starting a run still requires the full entry
+    /// gate (RTT+jitter, or the burst shape); but once a run is active it stays alive while any
+    /// signal remains at least this fraction of the way from baseline to its entry threshold.
+    /// Without it a long event whose tail hovers just under the entry gate (the milder second half
+    /// of a real multi-hour event) flickers in and out and truncates to its peak. Entry is
+    /// unchanged, so this only extends events that already legitimately started - never creates new
+    /// ones.
+    /// </summary>
+    public double CongestionSustainFraction { get; set; } = 0.5;
+
+    /// <summary>
     /// WAN utilization (fraction of the expected plan speed, worst direction) at or above
     /// which a congestion bucket is treated as coinciding with heavy local load. The
     /// self-inflicted classifier uses this to tell access-egress bufferbloat (your own

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -241,6 +241,16 @@ public class IspHealthOptions
     public double CongestionLoadedUniformityFactor { get; set; } = 2.0;
 
     /// <summary>
+    /// Clean-control floor multiple. A parallel path counts as a CLEAN control (proof a hop's
+    /// elevation is its own capacity, not access bufferbloat) when its RTT rose no more than this
+    /// multiple of the shared floor - i.e. it only picked up the load floor, not localized congestion.
+    /// Must be tighter than <see cref="CongestionLoadedUniformityFactor"/> so the materially-worse
+    /// hops are NOT counted as clean. Uses RTT (not jitter): under load the jitter floor lifts every
+    /// path, so a jitter-inclusive "elevated" test would erase every clean control.
+    /// </summary>
+    public double CongestionCleanControlFloorFactor { get; set; } = 1.5;
+
+    /// <summary>
     /// Self-inflicted access bufferbloat is a line-wide rise under load: this fraction of monitored
     /// paths (with data) must have their in-window median rise above baseline for an access-egress
     /// bottleneck under load to read as self-inflicted rather than a hop bottleneck. A robust majority

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -231,12 +231,25 @@ public class IspHealthOptions
     public double CongestionLineWideMinShiftMs { get; set; } = 0.5;
 
     /// <summary>
-    /// Shared-upstream (coincident-rise) detection: a hop's bucket median counts as "risen" when it
-    /// sits at least this fraction of its baseline above baseline (with
-    /// <see cref="CongestionLineWideMinShiftMs"/> as the absolute floor). Scale-relative so a real
-    /// proportional rise on a low-latency fiber hop registers where a fixed millisecond floor would
-    /// miss it. A shared-upstream event needs the elevation rooted at the access egress and spanning
-    /// at least <see cref="SharedEventMinAsns"/> independent networks.
+    /// Shared-upstream (coincident-rise) detection: the minimum number of independent monitored hops
+    /// that must rise together in a bucket for it to count as shared congestion. Each hop's rise is
+    /// individually sub-threshold (below the per-hop congestion gate); the coincidence across
+    /// unrelated ASNs is the signal a per-hop threshold can't see.
+    /// </summary>
+    public int CoincidentCongestionMinHops { get; set; } = 4;
+
+    /// <summary>
+    /// Shared-upstream detection: the fraction of monitored hops (with data in the bucket) that must
+    /// have risen for the bucket to count as a shared-upstream bucket. Lower than the self-infliction
+    /// line-wide fraction because there is no local-load corroboration to lean on.
+    /// </summary>
+    public double CoincidentCongestionRiseFraction { get; set; } = 0.6;
+
+    /// <summary>
+    /// Shared-upstream detection: a hop's bucket median counts as "risen" when it sits at least this
+    /// fraction of its baseline above baseline (with <see cref="CongestionLineWideMinShiftMs"/> as the
+    /// absolute floor). Scale-relative so a real proportional rise on a low-latency fiber hop registers
+    /// where a fixed millisecond floor would miss it.
     /// </summary>
     public double CoincidentCongestionRttRisePct { get; set; } = 0.15;
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -228,7 +228,7 @@ public class IspHealthOptions
     /// <see cref="CongestionPropagationJitterFactor"/> ratio - a 0.05 -> 0.10 ms doubling is still
     /// noise, not propagation.
     /// </summary>
-    public double CongestionPropagationJitterFloorMs { get; set; } = 0.25;
+    public double CongestionPropagationJitterFloorMs { get; set; } = 0.2;
 
     /// <summary>
     /// Self-inflicted access bufferbloat is a line-wide rise under load: this fraction of monitored

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -287,6 +287,47 @@ public class IspHealthOptions
     public int OutageMaxGapSeconds { get; set; } = 180;
 
     /// <summary>
+    /// Bucket size in seconds for the partial-loss (degradation) pass. Wider than the blackout
+    /// bucket because partial loss is route-specific: independent targets degrade at slightly
+    /// different instants across the event, so a 15 s bucket holds only a couple at once. A 30 s
+    /// window lets the coincident-but-staggered degradations land together for the breadth gate.
+    /// </summary>
+    public int OutagePartialBucketSeconds { get; set; } = 30;
+
+    /// <summary>
+    /// Loss (percent) at or above which a target counts as degraded for partial-loss detection.
+    /// Below the near-total <see cref="OutageDarkLossPct"/> - a partial-loss burst is the path
+    /// getting lossy, not unreachable.
+    /// </summary>
+    public double OutagePartialLossPct { get; set; } = 50.0;
+
+    /// <summary>
+    /// Minimum distinct path targets simultaneously degraded (within one partial bucket) for a
+    /// partial-loss disruption. Coincident loss across many independent destinations is a real
+    /// path event; one or two lossy targets are noise (ICMP rate-limiting, a single bad CDN node).
+    /// </summary>
+    public int OutagePartialMinTargets { get; set; } = 4;
+
+    /// <summary>
+    /// Minimum distinct ASNs/destinations spanned by the degraded targets, alongside
+    /// <see cref="OutagePartialMinTargets"/>. Guards against several targets behind one ASN all
+    /// degrading together (that ASN's own issue, not a path-wide event) tripping detection.
+    /// </summary>
+    public int OutagePartialMinAsns { get; set; } = 2;
+
+    /// <summary>Minimum sustained duration in seconds for a partial-loss disruption.</summary>
+    public int OutagePartialMinDurationSeconds { get; set; } = 20;
+
+    /// <summary>
+    /// Scales a partial-loss disruption's severity-curve penalty relative to a full outage of the
+    /// same duration: the curve input is duration x (peak loss fraction) x this weight, so the ding
+    /// stays tiny (a 30 s / 80% event is about a point). Partial loss also still feeds the Packet
+    /// Loss factor (these events are deliberately not masked from it), so this is a small additional
+    /// nudge for visibility, with the minor overlap accepted by design.
+    /// </summary>
+    public double OutagePartialPenaltyWeight { get; set; } = 1.0;
+
+    /// <summary>
     /// Recovery-time tolerance for collapsing per-target access ISP rows in the outage waterfall:
     /// access hops that recovered within this many seconds of each other share a signature and
     /// merge to one row; ones outside it stay separate (the inside-out heal).

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -231,6 +231,16 @@ public class IspHealthOptions
     public double CongestionPropagationJitterFloorMs { get; set; } = 0.2;
 
     /// <summary>
+    /// Loaded-latency uniformity gate. Under heavy WAN load every path picks up a shared FLOOR of
+    /// added delay (that floor alone is loaded latency). A shared/loaded-latency event collapses to a
+    /// single row only when the rise is UNIFORM: the worst path's RTT rise over its own baseline is
+    /// within this factor of the median path's rise. If a few paths rose materially further than the
+    /// floor (high variance), those are localized congestion ON TOP of the load - the event stays
+    /// per-hop so the localizer surfaces them as "this hop's own capacity", not "everything slowed".
+    /// </summary>
+    public double CongestionLoadedUniformityFactor { get; set; } = 2.0;
+
+    /// <summary>
     /// Self-inflicted access bufferbloat is a line-wide rise under load: this fraction of monitored
     /// paths (with data) must have their in-window median rise above baseline for an access-egress
     /// bottleneck under load to read as self-inflicted rather than a hop bottleneck. A robust majority

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -230,29 +230,6 @@ public class IspHealthOptions
     /// </summary>
     public double CongestionLineWideMinShiftMs { get; set; } = 0.5;
 
-    /// <summary>
-    /// Shared-upstream (coincident-rise) detection: the minimum number of independent monitored hops
-    /// that must rise together in a bucket for it to count as shared congestion. Each hop's rise is
-    /// individually sub-threshold (below the per-hop congestion gate); the coincidence across
-    /// unrelated ASNs is the signal a per-hop threshold can't see.
-    /// </summary>
-    public int CoincidentCongestionMinHops { get; set; } = 4;
-
-    /// <summary>
-    /// Shared-upstream detection: the fraction of monitored hops (with data in the bucket) that must
-    /// have risen for the bucket to count as a shared-upstream bucket. Lower than the self-infliction
-    /// line-wide fraction because there is no local-load corroboration to lean on.
-    /// </summary>
-    public double CoincidentCongestionRiseFraction { get; set; } = 0.6;
-
-    /// <summary>
-    /// Shared-upstream detection: a hop's bucket median counts as "risen" when it sits at least this
-    /// fraction of its baseline above baseline (with <see cref="CongestionLineWideMinShiftMs"/> as the
-    /// absolute floor). Scale-relative so a real proportional rise on a low-latency fiber hop registers
-    /// where a fixed millisecond floor would miss it.
-    /// </summary>
-    public double CoincidentCongestionRttRisePct { get; set; } = 0.15;
-
     /// <summary>Window size in minutes for step-change median comparison.</summary>
     public int StepWindowMinutes { get; set; } = 30;
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -95,10 +95,14 @@ public class IspHealthScorer
         var outageMinutes = wanOutages.Sum(EffectiveMinutes);
         if (outageMinutes > 0)
         {
-            var penalty = OutageScorePenalty(outageMinutes);
-            // Attribute the total (curve-based) penalty across the WAN outages by effective-minute
-            // share so each row can show its own "-N points". Rounded shares may differ from the
-            // curve total by <=1 pt - cosmetic; the actual deduction uses the curve total below.
+            // Floor a flagged WAN event at one point: if we surfaced it on the timeline it should
+            // visibly register, not round to a silent zero (a brief/partial event can curve to a
+            // fraction of a point otherwise). The floor is on the total, so many tiny events still
+            // cost at least a point rather than each.
+            var penalty = Math.Max(1.0, OutageScorePenalty(outageMinutes));
+            // Attribute the total penalty across the WAN outages by effective-minute share so each
+            // row can show its own "-N points". Rounded shares may differ from the curve total by
+            // <=1 pt - cosmetic; the actual deduction uses the total below.
             foreach (var o in wanOutages)
                 o.ScorePenaltyPoints = (int)Math.Round(penalty * (EffectiveMinutes(o) / outageMinutes));
             _logger?.LogDebug("ISP Health: outage penalty {Penalty} pts over {Min} effective min downtime ({Before} -> {After})",
@@ -1224,9 +1228,7 @@ public class IspHealthScorer
                 ? $"{partialDisruptions.Count} partial-loss disruptions totaling {FormatBriefDuration(totalDown)}"
                 : $"A partial-loss disruption of {FormatBriefDuration(partialDisruptions[0].Duration)}";
             var breadth = $" Peak loss reached {worst.PeakLossPct:0}% across {worst.DegradedTargetCount} of {worst.PathTargetCount} path targets, so the loss was widespread rather than one bad target.";
-            var impact = penalty > 0
-                ? $" {(multiple ? "Together they" : "It")} lowered your ISP Health score by {penalty} {(penalty == 1 ? "point" : "points")}."
-                : " Minimal direct score impact; the loss also feeds the Packet Loss factor.";
+            var impact = $" {(multiple ? "Together they" : "It")} lowered your ISP Health score by {penalty} {(penalty == 1 ? "point" : "points")} (the loss also feeds the Packet Loss factor).";
             issues.Add(new IspHealthIssue
             {
                 Severity = IspIssueSeverity.Info,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -23,7 +23,10 @@ public class IspHealthScorer
     // band (Item E) used to grade ISP and transit jitter against the access medium's inherent floor.
     private AccessProfile? _profile;
 
-    private bool InOutage(DateTime time) => _outages.Any(o => time >= o.Start && time < o.End);
+    // Only blackout outages mask their loss from the other factors; partial-loss disruptions are
+    // deliberately left in the Packet Loss factor (their loss IS the degradation signal), so they
+    // are excluded here.
+    private bool InOutage(DateTime time) => _outages.Any(o => !o.IsPartial && time >= o.Start && time < o.End);
 
     public IspHealthScorer(IspHealthOptions options, ILogger? logger = null)
     {
@@ -80,22 +83,26 @@ public class IspHealthScorer
         var overall = CombineDimensions(accessDimension, transitDimension, ispAsnDimension);
         // An outage is scored once, here at the top level, on a duration curve - so a long
         // outage actually drives the score down instead of being diluted to a couple of
-        // points inside one factor. Scored by total downtime alone, shape-independent.
+        // points inside one factor. A partial-loss disruption counts as a fraction of that:
+        // its duration is weighted by its peak loss fraction (and a tunable weight), so a brief
+        // degradation is a near-zero ding while a blackout of the same length scores in full.
         // Local (LAN/gateway) outages are surfaced but never penalize the ISP - the gateway being
         // unreachable is the user's own LAN, not the ISP's fault (they still mask their dark window
         // from the other factors via InOutage, so that loss isn't double-counted against the ISP).
         var wanOutages = inputs.Outages.Where(o => o.Scope != OutageScope.Local).ToList();
-        var outageMinutes = wanOutages.Sum(o => o.Duration.TotalMinutes);
+        double EffectiveMinutes(OutageEvent o) => o.Duration.TotalMinutes *
+            (o.IsPartial ? Math.Clamp(o.PeakLossPct / 100.0, 0, 1) * _options.OutagePartialPenaltyWeight : 1.0);
+        var outageMinutes = wanOutages.Sum(EffectiveMinutes);
         if (outageMinutes > 0)
         {
             var penalty = OutageScorePenalty(outageMinutes);
-            // Attribute the total (curve-based) penalty across the WAN outages by duration share so
-            // each outage row can show its own "-N points". Rounded shares may differ from the curve
-            // total by <=1 pt - cosmetic; the actual score deduction uses the curve total below.
+            // Attribute the total (curve-based) penalty across the WAN outages by effective-minute
+            // share so each row can show its own "-N points". Rounded shares may differ from the
+            // curve total by <=1 pt - cosmetic; the actual deduction uses the curve total below.
             foreach (var o in wanOutages)
-                o.ScorePenaltyPoints = (int)Math.Round(penalty * (o.Duration.TotalMinutes / outageMinutes));
-            _logger?.LogDebug("ISP Health: outage penalty {Penalty} pts over {Min} min downtime ({Before} -> {After})",
-                penalty.ToString("0.#", CultureInfo.InvariantCulture), outageMinutes.ToString("0", CultureInfo.InvariantCulture),
+                o.ScorePenaltyPoints = (int)Math.Round(penalty * (EffectiveMinutes(o) / outageMinutes));
+            _logger?.LogDebug("ISP Health: outage penalty {Penalty} pts over {Min} effective min downtime ({Before} -> {After})",
+                penalty.ToString("0.#", CultureInfo.InvariantCulture), outageMinutes.ToString("0.#", CultureInfo.InvariantCulture),
                 overall, (int)Math.Max(0, Math.Round(overall - penalty)));
             overall = (int)Math.Max(0, Math.Round(overall - penalty));
         }
@@ -1145,8 +1152,9 @@ public class IspHealthScorer
         // curve (a brief disruption costs at most a point), so the per-event score share is taken
         // from the already-attributed ScorePenaltyPoints rather than recomputing the curve per group.
         var wanOutages = inputs.Outages.Where(o => o.Scope != OutageScope.Local).ToList();
-        var fullOutages = wanOutages.Where(o => !o.IsBrief).ToList();
-        var briefDisruptions = wanOutages.Where(o => o.IsBrief).ToList();
+        var fullOutages = wanOutages.Where(o => !o.IsPartial && !o.IsBrief).ToList();
+        var briefDisruptions = wanOutages.Where(o => !o.IsPartial && o.IsBrief).ToList();
+        var partialDisruptions = wanOutages.Where(o => o.IsPartial).ToList();
         if (fullOutages.Count > 0)
         {
             var multiple = fullOutages.Count > 1;
@@ -1202,6 +1210,29 @@ public class IspHealthScorer
                 Title = multiple ? "Brief internet disruptions in the window" : "Brief internet disruption in the window",
                 Description = $"{count} occurred while the Monitoring Agent kept probing (so {(multiple ? "these are real, not monitoring gaps" : "this is real, not a monitoring gap")}).{where}{impact}",
                 Recommendation = "Short drops like these are usually transient upstream or transit events; logged here so you can spot a pattern of flapping.",
+                LinkUrl = "#isp-outages",
+                LinkText = "Shown on the timeline below."
+            });
+        }
+        if (partialDisruptions.Count > 0)
+        {
+            var multiple = partialDisruptions.Count > 1;
+            var totalDown = TimeSpan.FromSeconds(partialDisruptions.Sum(o => o.Duration.TotalSeconds));
+            var worst = partialDisruptions.OrderByDescending(o => o.PeakLossPct).First();
+            var penalty = partialDisruptions.Sum(o => o.ScorePenaltyPoints);
+            var count = multiple
+                ? $"{partialDisruptions.Count} partial-loss disruptions totaling {FormatBriefDuration(totalDown)}"
+                : $"A partial-loss disruption of {FormatBriefDuration(partialDisruptions[0].Duration)}";
+            var breadth = $" Peak loss reached {worst.PeakLossPct:0}% across {worst.DegradedTargetCount} of {worst.PathTargetCount} path targets, so the loss was widespread rather than one bad target.";
+            var impact = penalty > 0
+                ? $" {(multiple ? "Together they" : "It")} lowered your ISP Health score by {penalty} {(penalty == 1 ? "point" : "points")}."
+                : " Minimal direct score impact; the loss also feeds the Packet Loss factor.";
+            issues.Add(new IspHealthIssue
+            {
+                Severity = IspIssueSeverity.Info,
+                Title = multiple ? "Partial-loss disruptions in the window" : "Partial-loss disruption in the window",
+                Description = $"{count} hit the path: many targets degraded at once without going fully dark, so the internet was lossy but not unreachable.{breadth}{impact}",
+                Recommendation = "Coincident partial loss across many targets is usually upstream/transit congestion or a brief routing wobble; logged so you can correlate it with ISP incidents or watch for a pattern.",
                 LinkUrl = "#isp-outages",
                 LinkText = "Shown on the timeline below."
             });

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -1140,23 +1140,28 @@ public class IspHealthScorer
 
         // Local (LAN/gateway) outages are surfaced in the waterfall but are not internet outages and
         // don't affect the score, so they never appear in this ISP-impact issue.
+        // Full outages and brief disruptions are surfaced as separate findings: a 30 s transit flap
+        // shouldn't read as the same event as a multi-minute outage. Both ride the same severity
+        // curve (a brief disruption costs at most a point), so the per-event score share is taken
+        // from the already-attributed ScorePenaltyPoints rather than recomputing the curve per group.
         var wanOutages = inputs.Outages.Where(o => o.Scope != OutageScope.Local).ToList();
-        if (wanOutages.Count > 0)
+        var fullOutages = wanOutages.Where(o => !o.IsBrief).ToList();
+        var briefDisruptions = wanOutages.Where(o => o.IsBrief).ToList();
+        if (fullOutages.Count > 0)
         {
-            var multiple = wanOutages.Count > 1;
-            var totalDown = TimeSpan.FromMinutes(wanOutages.Sum(o => o.Duration.TotalMinutes));
-            var upstream = wanOutages.Where(o => o.Scope == OutageScope.Upstream && !string.IsNullOrEmpty(o.LastReachableHop)).ToList();
-            var allUpstream = wanOutages.All(o => o.Scope == OutageScope.Upstream) && upstream.Count > 0;
+            var multiple = fullOutages.Count > 1;
+            var totalDown = TimeSpan.FromMinutes(fullOutages.Sum(o => o.Duration.TotalMinutes));
+            var upstream = fullOutages.Where(o => o.Scope == OutageScope.Upstream && !string.IsNullOrEmpty(o.LastReachableHop)).ToList();
+            var allUpstream = fullOutages.All(o => o.Scope == OutageScope.Upstream) && upstream.Count > 0;
             var where = allUpstream
                 ? $" The break sat upstream of {string.Join(", ", upstream.Select(o => o.LastReachableHop).Distinct())} - your equipment stayed reachable, so {(multiple ? "these were" : "this was")} an ISP-side fault, not your network."
                 : " At least one event took the whole WAN dark, including the first ISP hop.";
             var count = multiple
-                ? $"{wanOutages.Count} internet outages totaling {FormatOutageDuration(totalDown)}"
-                : $"An internet outage of {FormatOutageDuration(wanOutages[0].Duration)}";
+                ? $"{fullOutages.Count} internet outages totaling {FormatOutageDuration(totalDown)}"
+                : $"An internet outage of {FormatOutageDuration(fullOutages[0].Duration)}";
             // Be transparent about the score hit: the outage penalty is applied at the top level
-            // and isn't tied to any one factor, so spell it out here or it's invisible. Matches the
-            // actual penalty (both exclude Local outages).
-            var penalty = (int)Math.Round(OutageScorePenalty(totalDown.TotalMinutes));
+            // and isn't tied to any one factor, so spell it out here or it's invisible.
+            var penalty = fullOutages.Sum(o => o.ScorePenaltyPoints);
             var impact = penalty > 0
                 ? $" {(multiple ? "Together they" : "It")} lowered your ISP Health score by {penalty} {(penalty == 1 ? "point" : "points")}."
                 : string.Empty;
@@ -1173,6 +1178,32 @@ public class IspHealthScorer
                     : "Logged here so you can correlate it with ISP incidents; if the first ISP hop keeps dropping, check your modem/ONT and the line to your ISP.",
                 LinkUrl = "#isp-outages",
                 LinkText = "The recovery shape is shown on the timeline below."
+            });
+        }
+        if (briefDisruptions.Count > 0)
+        {
+            var multiple = briefDisruptions.Count > 1;
+            var totalDown = TimeSpan.FromSeconds(briefDisruptions.Sum(o => o.Duration.TotalSeconds));
+            var upstream = briefDisruptions.Where(o => o.Scope == OutageScope.Upstream && !string.IsNullOrEmpty(o.LastReachableHop)).ToList();
+            var allUpstream = briefDisruptions.All(o => o.Scope == OutageScope.Upstream) && upstream.Count > 0;
+            var count = multiple
+                ? $"{briefDisruptions.Count} brief internet disruptions totaling {FormatBriefDuration(totalDown)}"
+                : $"A brief internet disruption of {FormatBriefDuration(briefDisruptions[0].Duration)}";
+            var where = allUpstream
+                ? $" {(multiple ? "They sat" : "It sat")} upstream of {string.Join(", ", upstream.Select(o => o.LastReachableHop).Distinct())}, so your equipment stayed reachable - short ISP-side flaps."
+                : string.Empty;
+            var penalty = briefDisruptions.Sum(o => o.ScorePenaltyPoints);
+            var impact = penalty > 0
+                ? $" {(multiple ? "Together they" : "It")} lowered your ISP Health score by {penalty} {(penalty == 1 ? "point" : "points")}."
+                : " Too short to meaningfully affect your score; logged for visibility.";
+            issues.Add(new IspHealthIssue
+            {
+                Severity = IspIssueSeverity.Info,
+                Title = multiple ? "Brief internet disruptions in the window" : "Brief internet disruption in the window",
+                Description = $"{count} occurred while the Monitoring Agent kept probing (so {(multiple ? "these are real, not monitoring gaps" : "this is real, not a monitoring gap")}).{where}{impact}",
+                Recommendation = "Short drops like these are usually transient upstream or transit events; logged here so you can spot a pattern of flapping.",
+                LinkUrl = "#isp-outages",
+                LinkText = "Shown on the timeline below."
             });
         }
 
@@ -1306,6 +1337,9 @@ public class IspHealthScorer
 
     private static string FormatOutageDuration(TimeSpan d) =>
         d.TotalMinutes < 90 ? $"{d.TotalMinutes:0} min" : $"{d.TotalHours:0.#} h";
+
+    private static string FormatBriefDuration(TimeSpan d) =>
+        d.TotalSeconds < 90 ? $"{d.TotalSeconds:0} sec" : $"{d.TotalMinutes:0.#} min";
 
     private static string FormatMs(double ms) =>
         $"{ms.ToString("0.00", CultureInfo.InvariantCulture)} ms";

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -1228,7 +1228,7 @@ public class IspHealthScorer
                 ? $"{partialDisruptions.Count} partial-loss disruptions totaling {FormatBriefDuration(totalDown)}"
                 : $"A partial-loss disruption of {FormatBriefDuration(partialDisruptions[0].Duration)}";
             var breadth = $" Peak loss reached {worst.PeakLossPct:0}% across {worst.DegradedTargetCount} of {worst.PathTargetCount} path targets, so the loss was widespread rather than one bad target.";
-            var impact = $" {(multiple ? "Together they" : "It")} lowered your ISP Health score by {penalty} {(penalty == 1 ? "point" : "points")} (the loss also feeds the Packet Loss factor).";
+            var impact = $" {(multiple ? "Together they" : "It")} lowered your ISP Health score by {penalty} {(penalty == 1 ? "point" : "points")}.";
             issues.Add(new IspHealthIssue
             {
                 Severity = IspIssueSeverity.Info,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -306,10 +306,7 @@ public class IspHealthService
         var gatewaySeriesTask = gatewayTarget == null
             ? Task.FromResult(new List<MonitoringInfluxClient.LatencySeriesPoint>())
             : _influx.QueryLatencyDetailByTargetIdAsync(gatewayTarget.TargetId, windowStart, windowEnd, aggregate, ct);
-        var __perfQ = System.Diagnostics.Stopwatch.StartNew();
         await Task.WhenAll(ispSeriesTask, transitSeriesTask, internetSeriesTask, ratesTask, speedsTask, speedTestsTask, gatewaySeriesTask);
-        __perfQ.Stop();
-        var __perfPrep = System.Diagnostics.Stopwatch.StartNew();
 
         var ispSeries = ToSamples(await ispSeriesTask);
         var transitSeries = ToSamples(await transitSeriesTask);
@@ -608,16 +605,7 @@ public class IspHealthService
             LoadExclusionWindows = loadExclusions
         };
 
-        __perfPrep.Stop();
-        var __perfScore = System.Diagnostics.Stopwatch.StartNew();
         var report = new IspHealthScorer(_options, _logger).Score(inputs, profile);
-        __perfScore.Stop();
-        _logger.LogInformation(
-            "ISPPERF win={Win}h agg={Agg}s queries={Q}ms prep+detect={P}ms score={S}ms targets(isp/transit/inet)={Ti}/{Tt}/{Tn}",
-            ((windowEnd - windowStart).TotalHours).ToString("0", System.Globalization.CultureInfo.InvariantCulture),
-            aggregate.TotalSeconds.ToString("0", System.Globalization.CultureInfo.InvariantCulture),
-            __perfQ.ElapsedMilliseconds, __perfPrep.ElapsedMilliseconds, __perfScore.ElapsedMilliseconds,
-            ispSeries.Count, transitSeries.Count, internetSeries.Count);
         _logger.LogDebug("ISP Health computed: {Score} ({Tech}), {Events} congestion events, {Shifts} path shifts",
             report.OverallScore, profile.DisplayName, congestionEvents.Count, pathShifts.Count);
         return new ComputeOutcome(IspHealthStatus.Ready, report, chartClusters);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -90,23 +90,16 @@ public class IspHealthService
 
     public async Task<IspHealthReport?> GetReportAsync(bool forceRefresh = false, CancellationToken ct = default)
     {
-        var __rt = System.Diagnostics.Stopwatch.StartNew();
         var cached = _cached?.Report;
         if (!forceRefresh && cached != null && DateTime.UtcNow - cached.ComputedAt < _options.CacheTtl)
-        {
-            _logger.LogInformation("ISPRT win=48h total={T}ms cacheHit=true force={F}", __rt.ElapsedMilliseconds, forceRefresh);
             return cached;
-        }
 
         await _computeLock.WaitAsync(ct);
         try
         {
             cached = _cached?.Report;
             if (!forceRefresh && cached != null && DateTime.UtcNow - cached.ComputedAt < _options.CacheTtl)
-            {
-                _logger.LogInformation("ISPRT win=48h total={T}ms cacheHit=true force={F}", __rt.ElapsedMilliseconds, forceRefresh);
                 return cached;
-            }
 
             if (forceRefresh)
                 _connectionService.ClearCaches();
@@ -114,7 +107,6 @@ public class IspHealthService
             _computing = true;
             var (report, chartClusters) = await ComputeAsync(ct);
             if (report != null) _cached = new Snapshot(report, chartClusters);
-            _logger.LogInformation("ISPRT win=48h total={T}ms cacheHit=false force={F}", __rt.ElapsedMilliseconds, forceRefresh);
             return report;
         }
         finally

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -90,16 +90,23 @@ public class IspHealthService
 
     public async Task<IspHealthReport?> GetReportAsync(bool forceRefresh = false, CancellationToken ct = default)
     {
+        var __rt = System.Diagnostics.Stopwatch.StartNew();
         var cached = _cached?.Report;
         if (!forceRefresh && cached != null && DateTime.UtcNow - cached.ComputedAt < _options.CacheTtl)
+        {
+            _logger.LogInformation("ISPRT win=48h total={T}ms cacheHit=true force={F}", __rt.ElapsedMilliseconds, forceRefresh);
             return cached;
+        }
 
         await _computeLock.WaitAsync(ct);
         try
         {
             cached = _cached?.Report;
             if (!forceRefresh && cached != null && DateTime.UtcNow - cached.ComputedAt < _options.CacheTtl)
+            {
+                _logger.LogInformation("ISPRT win=48h total={T}ms cacheHit=true force={F}", __rt.ElapsedMilliseconds, forceRefresh);
                 return cached;
+            }
 
             if (forceRefresh)
                 _connectionService.ClearCaches();
@@ -107,6 +114,7 @@ public class IspHealthService
             _computing = true;
             var (report, chartClusters) = await ComputeAsync(ct);
             if (report != null) _cached = new Snapshot(report, chartClusters);
+            _logger.LogInformation("ISPRT win=48h total={T}ms cacheHit=false force={F}", __rt.ElapsedMilliseconds, forceRefresh);
             return report;
         }
         finally

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -150,6 +150,7 @@ public class IspHealthService
         // single chokepoint every custom-window caller (report and chart endpoint) funnels through, so a
         // sub-minimum (or over-max) request can't slip past into an empty result. Pin the end and expand
         // the start back, exactly as the UI does; min ties to the scoring floor, max is the 30-day cap.
+        var __rt = System.Diagnostics.Stopwatch.StartNew();
         var minSpan = TimeSpan.FromHours(_options.MinDataHours);
         var maxSpan = TimeSpan.FromHours(MaxCustomWindowHours);
         if (windowEnd - windowStart < minSpan) windowStart = windowEnd - minSpan;
@@ -158,7 +159,12 @@ public class IspHealthService
         var cached = _customCache;
         if (!forceRefresh && cached != null && cached.Start == windowStart && cached.End == windowEnd
             && DateTime.UtcNow - cached.ComputedAt < _options.CacheTtl)
+        {
+            _logger.LogInformation("ISPRT win={Win}h total={T}ms cacheHit=true force={Force}",
+                ((windowEnd - windowStart).TotalHours).ToString("0", System.Globalization.CultureInfo.InvariantCulture),
+                __rt.ElapsedMilliseconds, forceRefresh);
             return (cached.Report, cached.ChartClusters);
+        }
 
         // A window longer than the canonical re-covers the recent period at a coarser aggregate,
         // which can inflate bucket-p90 burst detection into congestion events the authoritative
@@ -176,6 +182,9 @@ public class IspHealthService
         var outcome = await ComputeCoreAsync(windowStart, windowEnd, referenceEvents, ct);
         if (outcome.Report != null)
             _customCache = new CustomWindowSnapshot(windowStart, windowEnd, outcome.Report, outcome.ChartClusters, DateTime.UtcNow);
+        _logger.LogInformation("ISPRT win={Win}h total={T}ms cacheHit=false force={Force}",
+            ((windowEnd - windowStart).TotalHours).ToString("0", System.Globalization.CultureInfo.InvariantCulture),
+            __rt.ElapsedMilliseconds, forceRefresh);
         return (outcome.Report, outcome.ChartClusters);
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -306,7 +306,10 @@ public class IspHealthService
         var gatewaySeriesTask = gatewayTarget == null
             ? Task.FromResult(new List<MonitoringInfluxClient.LatencySeriesPoint>())
             : _influx.QueryLatencyDetailByTargetIdAsync(gatewayTarget.TargetId, windowStart, windowEnd, aggregate, ct);
+        var __perfQ = System.Diagnostics.Stopwatch.StartNew();
         await Task.WhenAll(ispSeriesTask, transitSeriesTask, internetSeriesTask, ratesTask, speedsTask, speedTestsTask, gatewaySeriesTask);
+        __perfQ.Stop();
+        var __perfPrep = System.Diagnostics.Stopwatch.StartNew();
 
         var ispSeries = ToSamples(await ispSeriesTask);
         var transitSeries = ToSamples(await transitSeriesTask);
@@ -605,7 +608,16 @@ public class IspHealthService
             LoadExclusionWindows = loadExclusions
         };
 
+        __perfPrep.Stop();
+        var __perfScore = System.Diagnostics.Stopwatch.StartNew();
         var report = new IspHealthScorer(_options, _logger).Score(inputs, profile);
+        __perfScore.Stop();
+        _logger.LogInformation(
+            "ISPPERF win={Win}h agg={Agg}s queries={Q}ms prep+detect={P}ms score={S}ms targets(isp/transit/inet)={Ti}/{Tt}/{Tn}",
+            ((windowEnd - windowStart).TotalHours).ToString("0", System.Globalization.CultureInfo.InvariantCulture),
+            aggregate.TotalSeconds.ToString("0", System.Globalization.CultureInfo.InvariantCulture),
+            __perfQ.ElapsedMilliseconds, __perfPrep.ElapsedMilliseconds, __perfScore.ElapsedMilliseconds,
+            ispSeries.Count, transitSeries.Count, internetSeries.Count);
         _logger.LogDebug("ISP Health computed: {Score} ({Tech}), {Events} congestion events, {Shifts} path shifts",
             report.OverallScore, profile.DisplayName, congestionEvents.Count, pathShifts.Count);
         return new ComputeOutcome(IspHealthStatus.Ready, report, chartClusters);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -468,6 +468,10 @@ public class IspHealthService
         var congestionEvents = CongestionLocalizer.Localize(localizerSeries, congestionTopology, _options);
         if (referenceEvents != null)
             congestionEvents = GateAgainstCanonical(congestionEvents, referenceEvents, windowEnd);
+        // On a long (coarse-aggregate) window, snap congestion boundaries back to fine resolution so
+        // a marginal event's 15-min bucket edges don't land off where the canonical view would place
+        // them. No-op at canonical resolution; reads run concurrently (see method).
+        await RefineCongestionBoundariesAsync(congestionEvents, aggregate, ct);
         foreach (var ce in congestionEvents)
             _logger.LogDebug(
                 "ISP Health congestion: {Disposition} at {Hop} ({Label}) conf={Confidence} load={Load} - {Reason}",
@@ -1120,6 +1124,52 @@ public class IspHealthService
             .SelectMany(c => ancestorIpsByTargetId.TryGetValue(c.Target.TargetId, out var anc) ? anc : Enumerable.Empty<string>())
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
         return nearIps.Overlaps(farAncestors);
+    }
+
+    /// <summary>
+    /// On a long viewing window the report is computed on a coarse aggregate (the point-count cap),
+    /// so a marginal congestion event's 15-min bucket boundaries can land a bucket off from where the
+    /// fine-resolution canonical view places them. For each event, re-query its target(s) at the
+    /// canonical fine aggregate over just the event's neighborhood, re-run detection, and snap
+    /// Start/End to the overlapping fine run. No-op at canonical resolution (aggregate already fine);
+    /// the per-event neighborhood reads fire concurrently so the added wall-clock is ~one small read.
+    /// </summary>
+    private async Task RefineCongestionBoundariesAsync(
+        List<CongestionEvent> events, TimeSpan aggregate, CancellationToken ct)
+    {
+        var fine = TimeSpan.FromSeconds(_options.LoadWindowSeconds);
+        if (events.Count == 0 || aggregate <= fine) return;
+
+        // Enough clean baseline on each side of a bounded event for fine re-detection to anchor.
+        var pad = TimeSpan.FromHours(2);
+
+        var refined = await Task.WhenAll(events.Select(async e =>
+        {
+            var runs = new List<(DateTime Start, DateTime End)>();
+            foreach (var tid in e.TargetIds)
+            {
+                var pts = await _influx.QueryLatencyDetailByTargetIdAsync(tid, e.Start - pad, e.End + pad, fine, ct);
+                if (pts.Count == 0) continue;
+                var series = new AsnSeries
+                {
+                    TargetIds = { tid },
+                    Samples = pts.Select(p => new LatencySample(p.Time, p.RttAvgMs, p.RttMaxMs, p.JitterMs, p.LossPercent)).ToList()
+                };
+                foreach (var r in CongestionDetector.DetectForSeries(series, _options))
+                    if (r.Start < e.End && e.Start < r.End) // overlaps the coarse event
+                        runs.Add((r.Start, r.End));
+            }
+            return (Event: e, Runs: runs);
+        }));
+
+        foreach (var (e, runs) in refined)
+        {
+            // No overlapping fine run (the fine pass didn't reproduce it) - keep the coarse boundaries
+            // rather than risk dropping or distorting a real event.
+            if (runs.Count == 0) continue;
+            e.Start = runs.Min(r => r.Start);
+            e.End = runs.Max(r => r.End);
+        }
     }
 
     private static Dictionary<string, List<LatencySample>> ToSamples(

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -1162,14 +1162,19 @@ public class IspHealthService
             return (Event: e, Runs: runs);
         }));
 
+        // Fine re-detection (with a 2 h clean pad on each side for a baseline, read across the view's
+        // edge) is ground truth. Coarse aggregation INFLATES bucket-p90, so "fires at the coarse
+        // aggregate but not at full resolution" is the signature of a coarse artifact - e.g. a
+        // window-edge p90 phantom on a flat hop - not a real event. Drop those; a genuine event
+        // reproduces against the padded fine baseline at both resolutions.
+        var phantoms = refined.Where(r => r.Runs.Count == 0).Select(r => r.Event).ToHashSet();
         foreach (var (e, runs) in refined)
         {
-            // No overlapping fine run (the fine pass didn't reproduce it) - keep the coarse boundaries
-            // rather than risk dropping or distorting a real event.
             if (runs.Count == 0) continue;
             e.Start = runs.Min(r => r.Start);
             e.End = runs.Max(r => r.End);
         }
+        events.RemoveAll(phantoms.Contains);
     }
 
     private static Dictionary<string, List<LatencySample>> ToSamples(

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -1138,12 +1138,18 @@ public class IspHealthService
         List<CongestionEvent> events, TimeSpan aggregate, CancellationToken ct)
     {
         var fine = TimeSpan.FromSeconds(_options.LoadWindowSeconds);
-        if (events.Count == 0 || aggregate <= fine) return;
+        if (aggregate <= fine) return;
+
+        // Shared-upstream events are sub-gate by design - no single hop fires, so per-hop fine
+        // re-detection would never reproduce them and the phantom-drop below would wrongly remove
+        // them. They are validated by cross-hop coincidence, not boundary-refined here.
+        var refinable = events.Where(e => !e.SharedUpstream).ToList();
+        if (refinable.Count == 0) return;
 
         // Enough clean baseline on each side of a bounded event for fine re-detection to anchor.
         var pad = TimeSpan.FromHours(2);
 
-        var refined = await Task.WhenAll(events.Select(async e =>
+        var refined = await Task.WhenAll(refinable.Select(async e =>
         {
             var runs = new List<(DateTime Start, DateTime End)>();
             foreach (var tid in e.TargetIds)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -150,7 +150,6 @@ public class IspHealthService
         // single chokepoint every custom-window caller (report and chart endpoint) funnels through, so a
         // sub-minimum (or over-max) request can't slip past into an empty result. Pin the end and expand
         // the start back, exactly as the UI does; min ties to the scoring floor, max is the 30-day cap.
-        var __rt = System.Diagnostics.Stopwatch.StartNew();
         var minSpan = TimeSpan.FromHours(_options.MinDataHours);
         var maxSpan = TimeSpan.FromHours(MaxCustomWindowHours);
         if (windowEnd - windowStart < minSpan) windowStart = windowEnd - minSpan;
@@ -159,12 +158,7 @@ public class IspHealthService
         var cached = _customCache;
         if (!forceRefresh && cached != null && cached.Start == windowStart && cached.End == windowEnd
             && DateTime.UtcNow - cached.ComputedAt < _options.CacheTtl)
-        {
-            _logger.LogInformation("ISPRT win={Win}h total={T}ms cacheHit=true force={Force}",
-                ((windowEnd - windowStart).TotalHours).ToString("0", System.Globalization.CultureInfo.InvariantCulture),
-                __rt.ElapsedMilliseconds, forceRefresh);
             return (cached.Report, cached.ChartClusters);
-        }
 
         // A window longer than the canonical re-covers the recent period at a coarser aggregate,
         // which can inflate bucket-p90 burst detection into congestion events the authoritative
@@ -182,9 +176,6 @@ public class IspHealthService
         var outcome = await ComputeCoreAsync(windowStart, windowEnd, referenceEvents, ct);
         if (outcome.Report != null)
             _customCache = new CustomWindowSnapshot(windowStart, windowEnd, outcome.Report, outcome.ChartClusters, DateTime.UtcNow);
-        _logger.LogInformation("ISPRT win={Win}h total={T}ms cacheHit=false force={Force}",
-            ((windowEnd - windowStart).TotalHours).ToString("0", System.Globalization.CultureInfo.InvariantCulture),
-            __rt.ElapsedMilliseconds, forceRefresh);
         return (outcome.Report, outcome.ChartClusters);
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -1138,18 +1138,12 @@ public class IspHealthService
         List<CongestionEvent> events, TimeSpan aggregate, CancellationToken ct)
     {
         var fine = TimeSpan.FromSeconds(_options.LoadWindowSeconds);
-        if (aggregate <= fine) return;
-
-        // Shared-upstream events are sub-gate by design - no single hop fires, so per-hop fine
-        // re-detection would never reproduce them and the phantom-drop below would wrongly remove
-        // them. They are validated by cross-hop coincidence, not boundary-refined here.
-        var refinable = events.Where(e => !e.SharedUpstream).ToList();
-        if (refinable.Count == 0) return;
+        if (events.Count == 0 || aggregate <= fine) return;
 
         // Enough clean baseline on each side of a bounded event for fine re-detection to anchor.
         var pad = TimeSpan.FromHours(2);
 
-        var refined = await Task.WhenAll(refinable.Select(async e =>
+        var refined = await Task.WhenAll(events.Select(async e =>
         {
             var runs = new List<(DateTime Start, DateTime End)>();
             foreach (var tid in e.TargetIds)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -563,6 +563,11 @@ public class IspHealthService
                 new OutageDetector.Hop(x.Name, baseDepth + i, x.Series, x.Groupable, x.AsnLabel)))
             .ToList();
         var outages = OutageDetector.Detect(internetTriggerTargets, outageHops, _options);
+        // Second pass: coincident partial-loss disruptions (the path getting lossy but not dark)
+        // across the full set of monitored hops, excluding windows already flagged as blackouts.
+        var partialDisruptions = OutageDetector.DetectPartial(
+            outageHops, outages.Select(o => (o.Start, o.End)).ToList(), _options);
+        outages = outages.Concat(partialDisruptions).OrderBy(o => o.Start).ToList();
 
         // chartClusters (one line per cluster) is the chart view computed from the same
         // snapshot the detectors ran on, so deeper-cluster "+N ms hop" labels still match

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
@@ -34,7 +34,7 @@ public static class OutageDetector
     {
         if (triggerTargets.Count == 0) return new List<OutageEvent>();
 
-        var windowSize = TimeSpan.FromMinutes(options.OutageBucketMinutes);
+        var windowSize = TimeSpan.FromSeconds(options.OutageBucketSeconds);
         var triggerByBucket = BucketTargets(triggerTargets, windowSize);
 
         // Outage buckets: enough internet targets reporting (a bucket with none is a
@@ -49,7 +49,7 @@ public static class OutageDetector
         var hopBuckets = hops.ToDictionary(h => h, h => BucketTargets(new[] { h.Series }, windowSize));
 
         // Contiguous runs of outage buckets (gap of one window ends a run), then coalesce
-        // runs separated by a short healthy gap (OutageMaxGapMinutes). One real outage dips
+        // runs separated by a short healthy gap (OutageMaxGapSeconds). One real outage dips
         // below the dark-fraction gate for a bucket or two during staggered onset/recovery
         // (targets go dark and heal at slightly different times) - without the coalesce that
         // shatters it into several events. Sealing the gap before duration-filtering also lets
@@ -64,7 +64,7 @@ public static class OutageDetector
             i = j + 1;
         }
 
-        var maxGap = TimeSpan.FromMinutes(options.OutageMaxGapMinutes);
+        var maxGap = TimeSpan.FromSeconds(options.OutageMaxGapSeconds);
         var merged = new List<(DateTime Start, DateTime End)>();
         foreach (var run in runs)
         {
@@ -75,7 +75,7 @@ public static class OutageDetector
         }
 
         var events = new List<OutageEvent>();
-        var minDuration = TimeSpan.FromMinutes(options.OutageMinDurationMinutes);
+        var minDuration = TimeSpan.FromSeconds(options.OutageMinDurationSeconds);
         foreach (var (start, end) in merged)
         {
             if (end - start < minDuration) continue;
@@ -188,6 +188,7 @@ public static class OutageDetector
         {
             Start = onset,
             End = recovery,
+            IsBrief = recovery - onset < TimeSpan.FromSeconds(options.OutageBriefMaxSeconds),
             Scope = scope,
             LastReachableHop = scope == OutageScope.Upstream ? lastReachable!.Name : null,
             Tiers = GroupAccessTiers(tiers, options)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
@@ -161,10 +161,10 @@ public static class OutageDetector
         IspHealthOptions options)
     {
         var partialPct = options.OutagePartialLossPct;
-        var tiers = new List<OutageTierState>();
         // Degraded duty cycle per hop, mirroring the blackout attribution but at the partial
         // threshold: the break sits just beyond the deepest hop that stayed clean.
         var degradedDepth = new Dictionary<int, bool>();
+        var degraded = new List<(Hop Hop, double Peak)>();
         double eventPeak = 0;
         foreach (var hop in pool.OrderBy(h => h.Depth))
         {
@@ -182,16 +182,26 @@ public static class OutageDetector
             if (degradedBuckets > 0)
             {
                 eventPeak = Math.Max(eventPeak, peak);
-                tiers.Add(new OutageTierState
-                {
-                    Name = hop.AsnLabel ?? hop.Name,
-                    Depth = hop.Depth,
-                    PeakLossPct = peak,
-                    WentDark = false,
-                    RecoveredAt = null
-                });
+                degraded.Add((hop, peak));
             }
         }
+
+        // Unlike the blackout waterfall (which groups access hops via GroupAccessTiers), partial-loss
+        // tiers are per-hop, so several hops of one ASN would all read as just the ASN label. Only when
+        // a label repeats in this list, disambiguate it with the specific hop's name/hostname tail.
+        var labelCounts = degraded.GroupBy(d => d.Hop.AsnLabel ?? d.Hop.Name).ToDictionary(g => g.Key, g => g.Count());
+        var tiers = degraded.Select(d =>
+        {
+            var label = d.Hop.AsnLabel ?? d.Hop.Name;
+            return new OutageTierState
+            {
+                Name = DisambiguateTierLabel(label, d.Hop.Name, labelCounts[label] > 1),
+                Depth = d.Hop.Depth,
+                PeakLossPct = d.Peak,
+                WentDark = false,
+                RecoveredAt = null
+            };
+        }).ToList();
 
         var nearest = pool.Where(h => degradedDepth.ContainsKey(h.Depth)).OrderBy(h => h.Depth).FirstOrDefault();
         var lastClean = pool.Where(h => degradedDepth.TryGetValue(h.Depth, out var d) && !d).OrderByDescending(h => h.Depth).FirstOrDefault();
@@ -414,6 +424,21 @@ public static class OutageDetector
     /// <summary>The part of a per-target name after its ASN prefix ("AT&amp;T nokia-olt" -> "nokia-olt").</summary>
     private static string HostnameTail(string name, string asn) =>
         name.StartsWith(asn + " ", StringComparison.OrdinalIgnoreCase) ? name[(asn.Length + 1)..] : name;
+
+    /// <summary>
+    /// When a tier label repeats within one event's list (e.g. several hops of one access ISP), make
+    /// it specific: keep the hop's own name if it already extends the label (e.g. a cluster's
+    /// "+N ms hop"), otherwise append the hostname tail as "ASN (tail)" - matching the blackout
+    /// waterfall's style. A unique label is returned unchanged.
+    /// </summary>
+    private static string DisambiguateTierLabel(string label, string hopName, bool repeats)
+    {
+        if (!repeats || string.IsNullOrEmpty(hopName) || string.Equals(hopName, label, StringComparison.OrdinalIgnoreCase))
+            return label;
+        if (hopName.StartsWith(label + " ", StringComparison.OrdinalIgnoreCase))
+            return hopName; // already "label hostname" or "label (+N ms hop)"
+        return $"{label} ({HostnameTail(hopName, label)})";
+    }
 
     /// <summary>Actual timestamp of the first sample at/above the loss threshold in [start, end).</summary>
     private static DateTime? FirstDark(

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
@@ -84,6 +84,141 @@ public static class OutageDetector
         return events;
     }
 
+    /// <summary>
+    /// Detects brief partial-loss disruptions: short windows where many independent path targets
+    /// degrade together (loss >= <see cref="IspHealthOptions.OutagePartialLossPct"/>) without any
+    /// reaching the near-total dark threshold. Distinct from <see cref="Detect"/> (blackouts) - it
+    /// keys on coincident breadth across targets and ASNs, the signal that partial loss is a real
+    /// path event rather than one lossy probe target. The breadth gate uses a wider bucket than the
+    /// blackout pass because partial loss is route-specific: independent targets degrade at slightly
+    /// different instants, so they only land together over a longer window. Windows overlapping a
+    /// blackout in <paramref name="darkWindows"/> are skipped so the two passes don't double-count.
+    /// </summary>
+    /// <param name="pathHops">Every monitored non-gateway path hop (access/transit/internet), for breadth and shape.</param>
+    /// <param name="darkWindows">Blackout outage spans already found by <see cref="Detect"/>, to exclude.</param>
+    public static List<OutageEvent> DetectPartial(
+        IReadOnlyList<Hop> pathHops,
+        IReadOnlyList<(DateTime Start, DateTime End)> darkWindows,
+        IspHealthOptions options)
+    {
+        var pool = pathHops.Where(h => !h.IsGateway).ToList();
+        if (pool.Count == 0) return new List<OutageEvent>();
+
+        var windowSize = TimeSpan.FromSeconds(options.OutagePartialBucketSeconds);
+        var hopBuckets = pool.ToDictionary(h => h, h => BucketTargets(new[] { h.Series }, windowSize));
+        var partialPct = options.OutagePartialLossPct;
+
+        // A bucket qualifies when enough distinct targets across enough distinct ASNs degrade
+        // together: coincident loss across independent destinations is a path event, a lone lossy
+        // target is noise.
+        bool BucketQualifies(DateTime t)
+        {
+            var degraded = pool.Where(h => hopBuckets[h].TryGetValue(t, out var l) && l.Count > 0 && l[0] >= partialPct).ToList();
+            var asns = degraded.Select(h => h.AsnLabel ?? h.Name).Distinct().Count();
+            return degraded.Count >= options.OutagePartialMinTargets && asns >= options.OutagePartialMinAsns;
+        }
+
+        var qualifying = hopBuckets.Values.SelectMany(d => d.Keys).Distinct()
+            .Where(BucketQualifies)
+            .OrderBy(t => t).ToList();
+        if (qualifying.Count == 0) return new List<OutageEvent>();
+
+        // Contiguous runs (gap of one window ends a run), then coalesce across a short healthy gap.
+        var runs = new List<(DateTime Start, DateTime End)>();
+        for (var i = 0; i < qualifying.Count;)
+        {
+            var j = i;
+            while (j + 1 < qualifying.Count && qualifying[j + 1] - qualifying[j] <= windowSize) j++;
+            runs.Add((qualifying[i], qualifying[j] + windowSize));
+            i = j + 1;
+        }
+        var maxGap = TimeSpan.FromSeconds(options.OutageMaxGapSeconds);
+        var merged = new List<(DateTime Start, DateTime End)>();
+        foreach (var run in runs)
+        {
+            if (merged.Count > 0 && run.Start - merged[^1].End <= maxGap)
+                merged[^1] = (merged[^1].Start, run.End);
+            else merged.Add(run);
+        }
+
+        var events = new List<OutageEvent>();
+        var minDuration = TimeSpan.FromSeconds(options.OutagePartialMinDurationSeconds);
+        foreach (var (start, end) in merged)
+        {
+            if (end - start < minDuration) continue;
+            // A blackout also clears the partial threshold, so a window already flagged as a
+            // blackout would otherwise surface twice - skip any that overlaps one.
+            if (darkWindows.Any(w => start < w.End && w.Start < end)) continue;
+            events.Add(BuildPartialEvent(start, end, pool, hopBuckets, options));
+        }
+        return events;
+    }
+
+    private static OutageEvent BuildPartialEvent(
+        DateTime start, DateTime end,
+        List<Hop> pool,
+        Dictionary<Hop, Dictionary<DateTime, List<double>>> hopBuckets,
+        IspHealthOptions options)
+    {
+        var partialPct = options.OutagePartialLossPct;
+        var tiers = new List<OutageTierState>();
+        // Degraded duty cycle per hop, mirroring the blackout attribution but at the partial
+        // threshold: the break sits just beyond the deepest hop that stayed clean.
+        var degradedDepth = new Dictionary<int, bool>();
+        double eventPeak = 0;
+        foreach (var hop in pool.OrderBy(h => h.Depth))
+        {
+            double peak = 0;
+            int degradedBuckets = 0, totalBuckets = 0;
+            foreach (var (_, losses) in hopBuckets[hop].Where(kv => kv.Key >= start && kv.Key < end))
+            {
+                if (losses.Count == 0) continue;
+                totalBuckets++;
+                peak = Math.Max(peak, losses[0]);
+                if (losses[0] >= partialPct) degradedBuckets++;
+            }
+            if (totalBuckets == 0) continue;
+            degradedDepth[hop.Depth] = (double)degradedBuckets / totalBuckets >= 0.5;
+            if (degradedBuckets > 0)
+            {
+                eventPeak = Math.Max(eventPeak, peak);
+                tiers.Add(new OutageTierState
+                {
+                    Name = hop.AsnLabel ?? hop.Name,
+                    Depth = hop.Depth,
+                    PeakLossPct = peak,
+                    WentDark = false,
+                    RecoveredAt = null
+                });
+            }
+        }
+
+        var nearest = pool.Where(h => degradedDepth.ContainsKey(h.Depth)).OrderBy(h => h.Depth).FirstOrDefault();
+        var lastClean = pool.Where(h => degradedDepth.TryGetValue(h.Depth, out var d) && !d).OrderByDescending(h => h.Depth).FirstOrDefault();
+        var scope = nearest == null || degradedDepth[nearest.Depth] || lastClean == null
+            ? OutageScope.FullWan
+            : OutageScope.Upstream;
+
+        var poolSeries = pool.Select(h => (IReadOnlyList<LatencySample>)h.Series).ToList();
+        var onset = FirstDark(poolSeries, start, end, partialPct) ?? start;
+        var recovery = PreciseRecovery(poolSeries, start, end, partialPct) ?? end;
+        var reporting = pool.Count(h => hopBuckets[h].Any(kv => kv.Key >= start && kv.Key < end && kv.Value.Count > 0));
+
+        return new OutageEvent
+        {
+            Start = onset,
+            End = recovery,
+            IsPartial = true,
+            IsBrief = recovery - onset < TimeSpan.FromSeconds(options.OutageBriefMaxSeconds),
+            PeakLossPct = eventPeak,
+            DegradedTargetCount = tiers.Count,
+            PathTargetCount = reporting,
+            Scope = scope,
+            LastReachableHop = scope == OutageScope.Upstream ? (lastClean!.AsnLabel ?? lastClean.Name) : null,
+            Tiers = tiers.OrderBy(t => t.Depth).ToList()
+        };
+    }
+
     /// <summary>Per bucket, the list of each reporting target's mean loss in that bucket.</summary>
     private static Dictionary<DateTime, List<double>> BucketTargets(
         IReadOnlyList<IReadOnlyList<LatencySample>> targets, TimeSpan windowSize)
@@ -181,8 +316,8 @@ public static class OutageDetector
         // Bucket edges are minute-aligned; report the real onset and recovery instants from
         // the pooled trigger stream so the window carries seconds. Fall back to the bucket
         // edges if the precise edges can't be found (e.g. outage still ongoing at window end).
-        var onset = FirstDark(triggerTargets, start, end, options) ?? start;
-        var recovery = PreciseRecovery(triggerTargets, start, end, options) ?? end;
+        var onset = FirstDark(triggerTargets, start, end, options.OutageDarkLossPct) ?? start;
+        var recovery = PreciseRecovery(triggerTargets, start, end, options.OutageDarkLossPct) ?? end;
 
         return new OutageEvent
         {
@@ -280,13 +415,13 @@ public static class OutageDetector
     private static string HostnameTail(string name, string asn) =>
         name.StartsWith(asn + " ", StringComparison.OrdinalIgnoreCase) ? name[(asn.Length + 1)..] : name;
 
-    /// <summary>Actual timestamp of the first dark sample (loss at/above the dark threshold) in [start, end).</summary>
+    /// <summary>Actual timestamp of the first sample at/above the loss threshold in [start, end).</summary>
     private static DateTime? FirstDark(
         IReadOnlyList<IReadOnlyList<LatencySample>> targets,
-        DateTime start, DateTime end, IspHealthOptions options) =>
+        DateTime start, DateTime end, double threshold) =>
         targets.SelectMany(t => t)
             .Where(s => s.LossPercent.HasValue && s.Time >= start && s.Time < end
-                && s.LossPercent.Value >= options.OutageDarkLossPct)
+                && s.LossPercent.Value >= threshold)
             .OrderBy(s => s.Time)
             .Select(s => (DateTime?)s.Time)
             .FirstOrDefault();
@@ -312,9 +447,8 @@ public static class OutageDetector
     /// </summary>
     private static DateTime? PreciseRecovery(
         IReadOnlyList<IReadOnlyList<LatencySample>> targets,
-        DateTime start, DateTime end, IspHealthOptions options)
+        DateTime start, DateTime end, double dark)
     {
-        var dark = options.OutageDarkLossPct;
         DateTime? lastDark = targets.SelectMany(t => t)
             .Where(s => s.LossPercent.HasValue && s.Time >= start && s.Time < end
                 && s.LossPercent.Value >= dark)

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -16440,6 +16440,13 @@ a.isp-health-hero-speed:hover {
     transition: width 0.6s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
+.isp-outage-hop-loss {
+    height: 100%;
+    border-radius: 4px 0 0 4px;
+    background: var(--warning-color);
+    transition: width 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
 .isp-outage-hop-status {
     font-size: 0.72rem;
     color: var(--text-secondary);

--- a/src/NetworkOptimizer.Web/wwwroot/js/isp-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/isp-health-charts.js
@@ -117,9 +117,10 @@ function setZoomed(zoomed) {
 }
 
 // Tell the Blazor panel the current zoom range (epoch ms), or null/null when cleared, so it can
-// filter the Path & Congestion Events list to the visible window.
-function notifyZoom(min, max) {
-    try { dotNetRef?.invokeMethodAsync('OnChartZoom', min ?? null, max ?? null); }
+// filter the Path & Congestion Events list to the visible window. scrollToChart is set only on the
+// Reset zoom button, so the panel can keep the chart in view when the list expands above it.
+function notifyZoom(min, max, scrollToChart = false) {
+    try { dotNetRef?.invokeMethodAsync('OnChartZoom', min ?? null, max ?? null, scrollToChart); }
     catch { /* ref disposed / not set */ }
 }
 
@@ -127,7 +128,7 @@ function resetZoom() {
     if (!chart) return;
     chart.updateOptions({ xaxis: { min: undefined, max: undefined } }, false, false);
     setZoomed(false);
-    notifyZoom(null, null);
+    notifyZoom(null, null, true);
     loadAndUpdate();
 }
 
@@ -192,6 +193,10 @@ export async function setWindow(fromISO, toISO) {
 
 export function setDotNetRef(ref) {
     dotNetRef = ref;
+}
+
+export function scrollChartIntoView() {
+    document.getElementById('isp-health-asn-chart')?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
 }
 
 export function unmount() {

--- a/src/NetworkOptimizer.Web/wwwroot/js/isp-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/isp-health-charts.js
@@ -12,6 +12,7 @@ let pollTimer = null;
 let fetchController = null;
 let resetBtn = null;
 let isZoomed = false;
+let dotNetRef = null;
 // null = default 48 h cached view; { from, to } ISO strings = a filter-selected window.
 let win = null;
 
@@ -26,7 +27,11 @@ function buildOpts() {
             parentHeightOffset: 0,
             animations: { enabled: false },
             events: {
-                zoomed: (ctx, opts) => setZoomed(opts?.xaxis?.min != null),
+                zoomed: (ctx, opts) => {
+                    const min = opts?.xaxis?.min, max = opts?.xaxis?.max;
+                    setZoomed(min != null);
+                    notifyZoom(min, max);
+                },
             },
         },
         series: [],
@@ -111,10 +116,18 @@ function setZoomed(zoomed) {
     if (resetBtn) resetBtn.style.display = zoomed ? 'inline-flex' : 'none';
 }
 
+// Tell the Blazor panel the current zoom range (epoch ms), or null/null when cleared, so it can
+// filter the Path & Congestion Events list to the visible window.
+function notifyZoom(min, max) {
+    try { dotNetRef?.invokeMethodAsync('OnChartZoom', min ?? null, max ?? null); }
+    catch { /* ref disposed / not set */ }
+}
+
 function resetZoom() {
     if (!chart) return;
     chart.updateOptions({ xaxis: { min: undefined, max: undefined } }, false, false);
     setZoomed(false);
+    notifyZoom(null, null);
     loadAndUpdate();
 }
 
@@ -173,7 +186,12 @@ export async function setWindow(fromISO, toISO) {
     win = (fromISO && toISO) ? { from: fromISO, to: toISO } : null;
     if (chart) chart.updateOptions({ xaxis: { min: undefined, max: undefined } }, false, false);
     setZoomed(false);
+    notifyZoom(null, null);
     await loadAndUpdate();
+}
+
+export function setDotNetRef(ref) {
+    dotNetRef = ref;
 }
 
 export function unmount() {
@@ -181,6 +199,7 @@ export function unmount() {
     fetchController?.abort();
     if (resetBtn) { resetBtn.remove(); resetBtn = null; }
     isZoomed = false;
+    dotNetRef = null;
     win = null;
     if (chart) { chart.destroy(); chart = null; }
 }

--- a/tests/NetworkOptimizer.Storage.Tests/MonitoringInfluxCsvParserTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/MonitoringInfluxCsvParserTests.cs
@@ -1,0 +1,72 @@
+using FluentAssertions;
+using NetworkOptimizer.Storage.Services;
+using Xunit;
+
+namespace NetworkOptimizer.Storage.Tests;
+
+/// <summary>
+/// Verifies the span-based annotated-CSV parser that replaced the buffered FluxRecord path for the
+/// high-volume latency-detail reads. A parser is all-or-nothing, so these pin the exact column
+/// mapping, UTC handling, null handling, sort, and line-ending tolerance.
+/// </summary>
+public class MonitoringInfluxCsvParserTests
+{
+    // Annotated CSV exactly as Flux returns the latency-detail pivot query. The field columns are in
+    // a deliberately non-positional order (jitter, loss, rtt_avg, rtt_max) to prove the parser maps
+    // by column name, not index.
+    private const string Csv =
+        "#group,false,false,true,true,false,true,true,false,false,false,false\r\n" +
+        "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double,double,double,double\r\n" +
+        "#default,_result,,,,,,,,,,\r\n" +
+        ",result,table,_start,_stop,_time,target_id,target_type,jitter_ms,loss_percent,rtt_avg_ms,rtt_max_ms\r\n" +
+        ",,0,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T01:00:00Z,transit-x,transit,0.7,0,3,3.4\r\n" +
+        ",,0,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,transit-x,transit,0.3,0,2.8,3.1\r\n" +
+        ",,1,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,cdn-y,internetservice,,,12.3,\r\n";
+
+    [Fact]
+    public void Parses_points_per_target_mapping_columns_by_name()
+    {
+        var result = MonitoringInfluxClient.ParseLatencyDetailCsv(Csv);
+
+        result.Should().ContainKeys("transit-x", "cdn-y");
+        result["transit-x"].Should().HaveCount(2);
+        result["cdn-y"].Should().HaveCount(1);
+
+        // Sorted by time within target, even though the 01:00 row appeared before the 00:45 row.
+        var tx = result["transit-x"];
+        tx[0].Time.Should().Be(new DateTime(2026, 6, 19, 0, 45, 0, DateTimeKind.Utc));
+        tx[0].Time.Kind.Should().Be(DateTimeKind.Utc);
+        tx[0].RttAvgMs.Should().Be(2.8);
+        tx[0].RttMaxMs.Should().Be(3.1);
+        tx[0].JitterMs.Should().Be(0.3);
+        tx[0].LossPercent.Should().Be(0);
+        tx[1].Time.Should().Be(new DateTime(2026, 6, 19, 1, 0, 0, DateTimeKind.Utc));
+        tx[1].JitterMs.Should().Be(0.7);
+        tx[1].RttAvgMs.Should().Be(3);
+    }
+
+    [Fact]
+    public void Empty_cells_become_null()
+    {
+        var cdn = MonitoringInfluxClient.ParseLatencyDetailCsv(Csv)["cdn-y"][0];
+        cdn.RttAvgMs.Should().Be(12.3);
+        cdn.JitterMs.Should().BeNull();
+        cdn.LossPercent.Should().BeNull();
+        cdn.RttMaxMs.Should().BeNull();
+    }
+
+    [Fact]
+    public void Empty_or_null_csv_returns_empty()
+    {
+        MonitoringInfluxClient.ParseLatencyDetailCsv("").Should().BeEmpty();
+        MonitoringInfluxClient.ParseLatencyDetailCsv(null!).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Tolerates_lf_only_line_endings()
+    {
+        var result = MonitoringInfluxClient.ParseLatencyDetailCsv(Csv.Replace("\r\n", "\n"));
+        result["transit-x"].Should().HaveCount(2);
+        result["cdn-y"][0].RttAvgMs.Should().Be(12.3);
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionDetectorTests.cs
@@ -54,14 +54,14 @@ public class CongestionDetectorTests
     [Fact]
     public void Sustained_event_with_a_dip_and_milder_tail_stays_one_event()
     {
-        // A peak, a brief dip, then a milder-but-still-elevated tail - one event spanning the whole
-        // span, not truncated to the peak. Mirrors a real multi-hour event whose second half hovered
-        // just under the entry gate.
+        // A peak, a brief dip, then a milder-but-still-jittery tail - one event spanning the whole
+        // span, not truncated to the peak. Mirrors a real multi-hour event whose second half stayed
+        // elevated (jitter still up) just under the strict entry gate.
         var start = TestSeries.Start.AddHours(12);
         var samples = TestSeries.Flat(TestSeries.Start, Day, rttMs: 5, jitterMs: 0.5)
             .WithSegment(start, start.AddMinutes(45), rttMs: 9, jitterMs: 3)                  // peak: clears entry gate
-            .WithSegment(start.AddMinutes(45), start.AddMinutes(60), rttMs: 6.1, jitterMs: 0.6)  // dip: below entry, above sustain
-            .WithSegment(start.AddMinutes(60), start.AddMinutes(135), rttMs: 6.5, jitterMs: 0.7); // milder tail: sustain only
+            .WithSegment(start.AddMinutes(45), start.AddMinutes(60), rttMs: 6.1, jitterMs: 1.0)  // dip: below entry, jitter sustains
+            .WithSegment(start.AddMinutes(60), start.AddMinutes(135), rttMs: 6.5, jitterMs: 1.0); // milder tail: jitter sustains
 
         var events = CongestionDetector.DetectForSeries(TestSeries.Asn(64500, "TransitOne", samples), Options);
 
@@ -77,7 +77,24 @@ public class CongestionDetectorTests
         // continues an active run; it must never start one, so nothing is flagged here.
         var start = TestSeries.Start.AddHours(12);
         var samples = TestSeries.Flat(TestSeries.Start, Day, rttMs: 5, jitterMs: 0.5)
-            .WithSegment(start, start.AddMinutes(60), rttMs: 6.5, jitterMs: 0.7);
+            .WithSegment(start, start.AddMinutes(60), rttMs: 6.5, jitterMs: 1.0);
+
+        var events = CongestionDetector.DetectForSeries(TestSeries.Asn(64500, "TransitOne", samples), Options);
+
+        events.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Path_shift_plateau_with_baseline_jitter_does_not_become_congestion()
+    {
+        // A transit path change: RTT steps up to a flat plateau and back, jitter at baseline the
+        // whole time (a brief blip at the transition can fire the entry gate). With jitter flat there
+        // is no congestion signature to sustain, so the run collapses to the sub-30-min transition
+        // and nothing is flagged. The step detector owns this shape, not congestion.
+        var start = TestSeries.Start.AddHours(12);
+        var samples = TestSeries.Flat(TestSeries.Start, Day, rttMs: 16, jitterMs: 0.5)
+            .WithSegment(start, start.AddMinutes(15), rttMs: 24, jitterMs: 3)            // transition turbulence
+            .WithSegment(start.AddMinutes(15), start.AddHours(3), rttMs: 24, jitterMs: 0.5); // flat plateau, baseline jitter
 
         var events = CongestionDetector.DetectForSeries(TestSeries.Asn(64500, "TransitOne", samples), Options);
 

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionDetectorTests.cs
@@ -52,6 +52,39 @@ public class CongestionDetectorTests
     }
 
     [Fact]
+    public void Sustained_event_with_a_dip_and_milder_tail_stays_one_event()
+    {
+        // A peak, a brief dip, then a milder-but-still-elevated tail - one event spanning the whole
+        // span, not truncated to the peak. Mirrors a real multi-hour event whose second half hovered
+        // just under the entry gate.
+        var start = TestSeries.Start.AddHours(12);
+        var samples = TestSeries.Flat(TestSeries.Start, Day, rttMs: 5, jitterMs: 0.5)
+            .WithSegment(start, start.AddMinutes(45), rttMs: 9, jitterMs: 3)                  // peak: clears entry gate
+            .WithSegment(start.AddMinutes(45), start.AddMinutes(60), rttMs: 6.1, jitterMs: 0.6)  // dip: below entry, above sustain
+            .WithSegment(start.AddMinutes(60), start.AddMinutes(135), rttMs: 6.5, jitterMs: 0.7); // milder tail: sustain only
+
+        var events = CongestionDetector.DetectForSeries(TestSeries.Asn(64500, "TransitOne", samples), Options);
+
+        events.Should().HaveCount(1);
+        events[0].Start.Should().Be(start);
+        events[0].End.Should().Be(start.AddMinutes(135));
+    }
+
+    [Fact]
+    public void Mild_elevation_that_never_meets_the_entry_gate_is_not_congestion()
+    {
+        // An hour at the sustain level but never the strict entry gate (no peak). The hysteresis gate
+        // continues an active run; it must never start one, so nothing is flagged here.
+        var start = TestSeries.Start.AddHours(12);
+        var samples = TestSeries.Flat(TestSeries.Start, Day, rttMs: 5, jitterMs: 0.5)
+            .WithSegment(start, start.AddMinutes(60), rttMs: 6.5, jitterMs: 0.7);
+
+        var events = CongestionDetector.DetectForSeries(TestSeries.Asn(64500, "TransitOne", samples), Options);
+
+        events.Should().BeEmpty();
+    }
+
+    [Fact]
     public void Simultaneous_events_across_asns_merge_into_shared_event()
     {
         var humpStart = TestSeries.Start.AddHours(19);

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
@@ -539,28 +539,6 @@ public class CongestionLocalizerTests
     }
 
     [Fact]
-    public void Access_rooted_rise_across_a_few_networks_collapses_despite_low_hop_count()
-    {
-        // Only three hops up - access egress plus two independent transit ASNs - too few for any
-        // hop-count threshold, but rooted at the access egress and spanning multiple networks. That's
-        // one shared incident and must collapse to a single event, not three separate rows.
-        var series = new List<AsnSeries>
-        {
-            Hop(100, Bng, Elevated()),                          // access egress
-            Hop(100, Border, Flat(), Bng),
-            Hop(100, Backhaul, Flat(), Bng, Border),
-            Hop(200, Transit, Elevated(), Bng, Border, Backhaul),
-            Hop(300, DeadEnd, Elevated(), Bng, Border),
-        };
-
-        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
-
-        events.Should().ContainSingle();
-        events[0].SharedUpstream.Should().BeTrue();
-        events[0].BottleneckHopIp.Should().Be(Bng);
-    }
-
-    [Fact]
     public void Jitter_rise_below_the_absolute_floor_does_not_fire()
     {
         // RTT clearly elevated and jitter ratio over 2x, but the absolute jitter rise

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
@@ -309,6 +309,33 @@ public class CongestionLocalizerTests
     }
 
     [Fact]
+    public void Non_propagating_hop_during_a_line_wide_rise_is_confirmed_as_shared_upstream_not_noise()
+    {
+        // Border is elevated but its immediate downstream reads clean on the absolute bar - alone that
+        // absolves as control-plane noise. But nearly every monitored path drifted up together this
+        // window (line-wide, no local load needed), so it's a shared upstream bottleneck lifting the
+        // whole path, not the hop's own ICMP handling: Confirmed and scored, not suppressed.
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, SmallRise()),
+            Hop(100, Border, Elevated(), Bng),                            // bottleneck, elevated
+            Hop(100, Backhaul, SmallRise(), Bng, Border),                 // immediate downstream rose but not "elevated" -> propagated=false
+            Hop(200, Transit, SmallRise(), Bng, Border, Backhaul),
+            Hop(300, DeadEnd, SmallRise(), Bng, Border),
+            Dest(DestCorridor, SmallRise(), Bng, Border, Backhaul, Transit),
+            Dest(DestControl, SmallRise(), Bng, Border)
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        events.Should().HaveCount(1);
+        events[0].BottleneckHopIp.Should().Be(Border);
+        events[0].Disposition.Should().Be(CongestionDisposition.Confirmed);
+        events[0].Suppressed.Should().BeFalse();
+        events[0].LoadCoincident.Should().BeFalse();
+    }
+
+    [Fact]
     public void Bottleneck_is_confirmed_when_a_downstream_hop_is_elevated_but_did_not_fire_its_own_event()
     {
         // The downstream transit inherits the bottleneck's delay as a short spike - real, but too

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
@@ -35,7 +35,13 @@ public class CongestionLocalizerTests
 
     private static readonly Dictionary<string, int> HopNumbers = new(StringComparer.OrdinalIgnoreCase)
     {
-        [Bng] = 1, [Border] = 2, [Backhaul] = 3, [Transit] = 4, [DeadEnd] = 3, [DestCorridor] = 5, [DestControl] = 5
+        [Bng] = 1,
+        [Border] = 2,
+        [Backhaul] = 3,
+        [Transit] = 4,
+        [DeadEnd] = 3,
+        [DestCorridor] = 5,
+        [DestControl] = 5
     };
 
     private static List<LatencySample> Flat(double rtt = 5) => TestSeries.Flat(TestSeries.Start, Day, rtt, jitterMs: 0.5);
@@ -60,8 +66,13 @@ public class CongestionLocalizerTests
         var s = Hop(0, ip, samples, ancestors);
         return new AsnSeries
         {
-            AsnNumber = 0, AsnName = ip, TargetIds = { ip }, Samples = samples,
-            HopIps = { ip }, AncestorIps = ancestors.ToList(), IsDestination = true
+            AsnNumber = 0,
+            AsnName = ip,
+            TargetIds = { ip },
+            Samples = samples,
+            HopIps = { ip },
+            AncestorIps = ancestors.ToList(),
+            IsDestination = true
         };
     }
 
@@ -386,6 +397,32 @@ public class CongestionLocalizerTests
         var deadEnd = events.Single(e => e.BottleneckHopIp == "10.0.5.2");
         deadEnd.Disposition.Should().Be(CongestionDisposition.Confirmed);
         deadEnd.ConfirmedBySibling.Should().BeTrue();
+    }
+
+    [Fact]
+    public void A_parallel_path_that_only_picked_up_the_jitter_floor_counts_as_a_clean_control()
+    {
+        // Backhaul is the localized bottleneck under load. A parallel branch (DeadEnd) only picked up
+        // the load's jitter floor - its RTT stayed at baseline - so it did NOT get localized congestion
+        // and must count as a clean control (evidence Backhaul is its own capacity, not access
+        // bufferbloat). A jitter-inclusive "elevated" test would wrongly exclude it and drop the count.
+        var jitterFloor = Flat(5).WithSegment(HumpStart, HumpEnd, rttMs: 5, jitterMs: 3);
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Flat()),
+            Hop(100, Border, Flat(), Bng),
+            Hop(100, Backhaul, Elevated(), Bng, Border),            // localized bottleneck
+            Hop(200, Transit, Elevated(), Bng, Border, Backhaul),   // downstream victim
+            Hop(300, DeadEnd, jitterFloor, Bng, Border),            // parallel branch: jitter floor only, RTT flat
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: true), Options);
+
+        var backhaul = events.Single(e => e.BottleneckHopIp == Backhaul);
+        backhaul.Disposition.Should().Be(CongestionDisposition.Confirmed);
+        // Bng, Border, and the jitter-floor DeadEnd all stayed at the floor -> all clean controls.
+        // Without the floor-relative test, the jitter-floor DeadEnd would be excluded (count would be 2).
+        backhaul.CleanParallelPaths.Should().Be(3);
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
@@ -110,6 +110,33 @@ public class CongestionLocalizerTests
     }
 
     [Fact]
+    public void Similar_duration_bottlenecks_share_one_clean_window()
+    {
+        // Two bottlenecks elevated for roughly the same long span (slightly staggered). Each covers
+        // most of the cluster, so both report the SAME shared window instead of fragmenting into
+        // slightly different per-hop start/end - the genuine co-temporal event reads as one window.
+        List<LatencySample> ElevatedBetween(DateTime from, DateTime to, double rtt) =>
+            Flat(rtt).WithSegment(from, to, rttMs: rtt + 25, jitterMs: 6);
+
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Flat()),
+            Hop(100, Border, Flat()),
+            Hop(100, Backhaul, ElevatedBetween(HumpStart, HumpStart.AddHours(3), 5), Bng, Border),       // 3 h
+            Hop(200, Transit, Flat(8), Bng, Border, Backhaul),                                            // clean witness
+            Hop(300, DeadEnd, ElevatedBetween(HumpStart.AddMinutes(15), HumpStart.AddMinutes(165), 5), Bng, Border), // 2.5 h, staggered
+            Dest(DestControl, Flat(), Bng, Border),
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        var backhaul = events.Single(e => e.BottleneckHopIp == Backhaul);
+        var deadEnd = events.Single(e => e.BottleneckHopIp == DeadEnd);
+        backhaul.Start.Should().Be(deadEnd.Start);
+        backhaul.End.Should().Be(deadEnd.End);
+    }
+
+    [Fact]
     public void Localizes_to_backhaul_hop_and_does_not_blame_downstream_transit()
     {
         var series = new List<AsnSeries>

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
@@ -539,6 +539,28 @@ public class CongestionLocalizerTests
     }
 
     [Fact]
+    public void Access_rooted_rise_across_a_few_networks_collapses_despite_low_hop_count()
+    {
+        // Only three hops up - access egress plus two independent transit ASNs - too few for any
+        // hop-count threshold, but rooted at the access egress and spanning multiple networks. That's
+        // one shared incident and must collapse to a single event, not three separate rows.
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Elevated()),                          // access egress
+            Hop(100, Border, Flat(), Bng),
+            Hop(100, Backhaul, Flat(), Bng, Border),
+            Hop(200, Transit, Elevated(), Bng, Border, Backhaul),
+            Hop(300, DeadEnd, Elevated(), Bng, Border),
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        events.Should().ContainSingle();
+        events[0].SharedUpstream.Should().BeTrue();
+        events[0].BottleneckHopIp.Should().Be(Bng);
+    }
+
+    [Fact]
     public void Jitter_rise_below_the_absolute_floor_does_not_fire()
     {
         // RTT clearly elevated and jitter ratio over 2x, but the absolute jitter rise

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
@@ -328,11 +328,11 @@ public class CongestionLocalizerTests
 
         var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
 
-        events.Should().ContainSingle();
-        events[0].SharedUpstream.Should().BeTrue();
+        events.Should().HaveCount(1);
+        events[0].BottleneckHopIp.Should().Be(Border);
         events[0].Disposition.Should().Be(CongestionDisposition.Confirmed);
         events[0].Suppressed.Should().BeFalse();
-        events[0].BottleneckHopIp.Should().Be(Bng);   // collapsed onto the convergence hop, not Border
+        events[0].LoadCoincident.Should().BeFalse();
     }
 
     [Fact]
@@ -430,112 +430,6 @@ public class CongestionLocalizerTests
         // Access hop + 10.0.7.1 (both clean, with data in the window) count; 10.0.8.1 (no data during
         // the event) does not - it would be 3 without the data-presence guard.
         evt.CleanParallelPaths.Should().Be(2);
-    }
-
-    [Fact]
-    public void Coincident_sub_gate_rise_across_many_hops_is_shared_upstream_congestion()
-    {
-        // Each hop rises only ~1 ms - below the per-hop gate, so none fires its own event - but
-        // several independent hops rise together in the same window. That coincidence is shared
-        // upstream congestion the per-hop thresholds can't see.
-        var series = new List<AsnSeries>
-        {
-            Hop(100, Bng, SmallRise()),
-            Hop(100, Border, SmallRise(), Bng),
-            Hop(100, Backhaul, SmallRise(), Bng, Border),
-            Hop(200, Transit, SmallRise(), Bng, Border, Backhaul),
-            Hop(300, DeadEnd, SmallRise(), Bng, Border),
-        };
-
-        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
-
-        events.Should().ContainSingle();
-        var e = events[0];
-        e.SharedUpstream.Should().BeTrue();
-        e.Disposition.Should().Be(CongestionDisposition.Confirmed);
-        e.Suppressed.Should().BeFalse();
-        e.BottleneckHopIp.Should().Be(Bng); // nearest risen hop (the convergence point) owns it
-    }
-
-    [Fact]
-    public void A_lone_sub_gate_rise_is_not_shared_upstream()
-    {
-        // One hop drifts up ~1 ms while every other path stays flat - not a shared event, no signal.
-        var series = new List<AsnSeries>
-        {
-            Hop(100, Bng, SmallRise()),
-            Hop(100, Border, Flat(), Bng),
-            Hop(100, Backhaul, Flat(), Bng, Border),
-            Hop(200, Transit, Flat(), Bng, Border, Backhaul),
-            Hop(300, DeadEnd, Flat(), Bng, Border),
-        };
-
-        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
-
-        events.Should().NotContain(e => e.SharedUpstream);
-    }
-
-    [Fact]
-    public void A_fired_per_hop_event_in_a_line_wide_window_is_subsumed_by_the_shared_event()
-    {
-        // A per-hop bottleneck fires while the line is broadly up. The whole incident collapses into
-        // ONE shared-upstream event - the per-hop event is removed, not left alongside a duplicate.
-        var series = new List<AsnSeries>
-        {
-            Hop(100, Bng, SmallRise()),
-            Hop(100, Border, SmallRise(), Bng),
-            Hop(100, Backhaul, Elevated(), Bng, Border),
-            Hop(200, Transit, SmallRise(), Bng, Border, Backhaul),
-            Hop(300, DeadEnd, SmallRise(), Bng, Border),
-        };
-
-        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
-
-        events.Should().ContainSingle();
-        events[0].SharedUpstream.Should().BeTrue();
-    }
-
-    [Fact]
-    public void Line_wide_cluster_of_per_hop_events_collapses_into_one_shared_upstream_event()
-    {
-        // Many independent hops cross the gate in the same window (no local load) - one shared
-        // upstream incident, not N per-hop rows. Collapse to a single shared-upstream Confirmed event.
-        var series = new List<AsnSeries>
-        {
-            Hop(100, Bng, Elevated()),
-            Hop(100, Border, Elevated(), Bng),
-            Hop(100, Backhaul, Elevated(), Bng, Border),
-            Hop(200, Transit, Elevated(), Bng, Border, Backhaul),
-            Hop(300, DeadEnd, Elevated(), Bng, Border),
-        };
-
-        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
-
-        events.Should().ContainSingle();
-        events[0].SharedUpstream.Should().BeTrue();
-        events[0].Disposition.Should().Be(CongestionDisposition.Confirmed);
-    }
-
-    [Fact]
-    public void Line_wide_collapse_spans_only_the_shared_window_not_a_lingering_hop()
-    {
-        // Four hops rise for ~45 min together; one lingers 3 h past the rest. The collapsed event
-        // must span only the shared window (~45 min), not be dragged out to the lingering hop's 3 h.
-        var lingering = Flat(5).WithSegment(HumpStart, HumpStart.AddHours(3), rttMs: 30, jitterMs: 6);
-        var series = new List<AsnSeries>
-        {
-            Hop(100, Bng, Elevated()),
-            Hop(100, Border, Elevated(), Bng),
-            Hop(100, Backhaul, Elevated(), Bng, Border),
-            Hop(200, Transit, Elevated(), Bng, Border, Backhaul),
-            Hop(300, DeadEnd, lingering, Bng, Border),
-        };
-
-        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
-
-        events.Should().ContainSingle();
-        events[0].SharedUpstream.Should().BeTrue();
-        events[0].Duration.Should().BeLessThan(TimeSpan.FromHours(1.5));
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
@@ -328,11 +328,11 @@ public class CongestionLocalizerTests
 
         var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
 
-        events.Should().HaveCount(1);
-        events[0].BottleneckHopIp.Should().Be(Border);
+        events.Should().ContainSingle();
+        events[0].SharedUpstream.Should().BeTrue();
         events[0].Disposition.Should().Be(CongestionDisposition.Confirmed);
         events[0].Suppressed.Should().BeFalse();
-        events[0].LoadCoincident.Should().BeFalse();
+        events[0].BottleneckHopIp.Should().Be(Bng);   // collapsed onto the convergence hop, not Border
     }
 
     [Fact]
@@ -430,6 +430,112 @@ public class CongestionLocalizerTests
         // Access hop + 10.0.7.1 (both clean, with data in the window) count; 10.0.8.1 (no data during
         // the event) does not - it would be 3 without the data-presence guard.
         evt.CleanParallelPaths.Should().Be(2);
+    }
+
+    [Fact]
+    public void Coincident_sub_gate_rise_across_many_hops_is_shared_upstream_congestion()
+    {
+        // Each hop rises only ~1 ms - below the per-hop gate, so none fires its own event - but
+        // several independent hops rise together in the same window. That coincidence is shared
+        // upstream congestion the per-hop thresholds can't see.
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, SmallRise()),
+            Hop(100, Border, SmallRise(), Bng),
+            Hop(100, Backhaul, SmallRise(), Bng, Border),
+            Hop(200, Transit, SmallRise(), Bng, Border, Backhaul),
+            Hop(300, DeadEnd, SmallRise(), Bng, Border),
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        events.Should().ContainSingle();
+        var e = events[0];
+        e.SharedUpstream.Should().BeTrue();
+        e.Disposition.Should().Be(CongestionDisposition.Confirmed);
+        e.Suppressed.Should().BeFalse();
+        e.BottleneckHopIp.Should().Be(Bng); // nearest risen hop (the convergence point) owns it
+    }
+
+    [Fact]
+    public void A_lone_sub_gate_rise_is_not_shared_upstream()
+    {
+        // One hop drifts up ~1 ms while every other path stays flat - not a shared event, no signal.
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, SmallRise()),
+            Hop(100, Border, Flat(), Bng),
+            Hop(100, Backhaul, Flat(), Bng, Border),
+            Hop(200, Transit, Flat(), Bng, Border, Backhaul),
+            Hop(300, DeadEnd, Flat(), Bng, Border),
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        events.Should().NotContain(e => e.SharedUpstream);
+    }
+
+    [Fact]
+    public void A_fired_per_hop_event_in_a_line_wide_window_is_subsumed_by_the_shared_event()
+    {
+        // A per-hop bottleneck fires while the line is broadly up. The whole incident collapses into
+        // ONE shared-upstream event - the per-hop event is removed, not left alongside a duplicate.
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, SmallRise()),
+            Hop(100, Border, SmallRise(), Bng),
+            Hop(100, Backhaul, Elevated(), Bng, Border),
+            Hop(200, Transit, SmallRise(), Bng, Border, Backhaul),
+            Hop(300, DeadEnd, SmallRise(), Bng, Border),
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        events.Should().ContainSingle();
+        events[0].SharedUpstream.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Line_wide_cluster_of_per_hop_events_collapses_into_one_shared_upstream_event()
+    {
+        // Many independent hops cross the gate in the same window (no local load) - one shared
+        // upstream incident, not N per-hop rows. Collapse to a single shared-upstream Confirmed event.
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Elevated()),
+            Hop(100, Border, Elevated(), Bng),
+            Hop(100, Backhaul, Elevated(), Bng, Border),
+            Hop(200, Transit, Elevated(), Bng, Border, Backhaul),
+            Hop(300, DeadEnd, Elevated(), Bng, Border),
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        events.Should().ContainSingle();
+        events[0].SharedUpstream.Should().BeTrue();
+        events[0].Disposition.Should().Be(CongestionDisposition.Confirmed);
+    }
+
+    [Fact]
+    public void Line_wide_collapse_spans_only_the_shared_window_not_a_lingering_hop()
+    {
+        // Four hops rise for ~45 min together; one lingers 3 h past the rest. The collapsed event
+        // must span only the shared window (~45 min), not be dragged out to the lingering hop's 3 h.
+        var lingering = Flat(5).WithSegment(HumpStart, HumpStart.AddHours(3), rttMs: 30, jitterMs: 6);
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Elevated()),
+            Hop(100, Border, Elevated(), Bng),
+            Hop(100, Backhaul, Elevated(), Bng, Border),
+            Hop(200, Transit, Elevated(), Bng, Border, Backhaul),
+            Hop(300, DeadEnd, lingering, Bng, Border),
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        events.Should().ContainSingle();
+        events[0].SharedUpstream.Should().BeTrue();
+        events[0].Duration.Should().BeLessThan(TimeSpan.FromHours(1.5));
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
@@ -332,6 +332,29 @@ public class CongestionLocalizerTests
     }
 
     [Fact]
+    public void Propagation_recognizes_a_jitter_rise_downstream_not_just_rtt()
+    {
+        // The bottleneck's delay reaches the downstream hop as JITTER while its RTT stays flat.
+        // RTT-only propagation would absolve the bottleneck as control-plane noise; the jitter arm
+        // must see the propagation and confirm the real bottleneck.
+        var jitterOnly = Flat(5).WithSegment(HumpStart, HumpEnd, rttMs: 5, jitterMs: 3);
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Flat()),
+            Hop(100, Border, Flat()),
+            Hop(100, Backhaul, Elevated(), Bng, Border),             // bottleneck, fires (rtt + jitter)
+            Hop(200, Transit, jitterOnly, Bng, Border, Backhaul),    // downstream: jitter up, RTT flat
+            Hop(300, DeadEnd, Flat(), Bng, Border),
+            Dest(DestControl, Flat(), Bng, Border)
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        var backhaul = events.Single(e => e.BottleneckHopIp == Backhaul);
+        backhaul.Disposition.Should().Be(CongestionDisposition.Confirmed);
+    }
+
+    [Fact]
     public void Unverifiable_hop_inherits_confirmed_from_a_same_asn_sibling_in_the_same_window()
     {
         // Two hops on AS 500 elevated in the same window: one has a downstream witness (Confirmed),

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
@@ -309,33 +309,6 @@ public class CongestionLocalizerTests
     }
 
     [Fact]
-    public void Non_propagating_hop_during_a_line_wide_rise_is_confirmed_as_shared_upstream_not_noise()
-    {
-        // Border is elevated but its immediate downstream reads clean on the absolute bar - alone that
-        // absolves as control-plane noise. But nearly every monitored path drifted up together this
-        // window (line-wide, no local load needed), so it's a shared upstream bottleneck lifting the
-        // whole path, not the hop's own ICMP handling: Confirmed and scored, not suppressed.
-        var series = new List<AsnSeries>
-        {
-            Hop(100, Bng, SmallRise()),
-            Hop(100, Border, Elevated(), Bng),                            // bottleneck, elevated
-            Hop(100, Backhaul, SmallRise(), Bng, Border),                 // immediate downstream rose but not "elevated" -> propagated=false
-            Hop(200, Transit, SmallRise(), Bng, Border, Backhaul),
-            Hop(300, DeadEnd, SmallRise(), Bng, Border),
-            Dest(DestCorridor, SmallRise(), Bng, Border, Backhaul, Transit),
-            Dest(DestControl, SmallRise(), Bng, Border)
-        };
-
-        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
-
-        events.Should().HaveCount(1);
-        events[0].BottleneckHopIp.Should().Be(Border);
-        events[0].Disposition.Should().Be(CongestionDisposition.Confirmed);
-        events[0].Suppressed.Should().BeFalse();
-        events[0].LoadCoincident.Should().BeFalse();
-    }
-
-    [Fact]
     public void Bottleneck_is_confirmed_when_a_downstream_hop_is_elevated_but_did_not_fire_its_own_event()
     {
         // The downstream transit inherits the bottleneck's delay as a short spike - real, but too

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
@@ -466,6 +466,54 @@ public class CongestionLocalizerTests
     }
 
     [Fact]
+    public void A_uniform_line_wide_rise_with_a_long_mild_tail_still_collapses()
+    {
+        // The Jun 23 shape: every path has a strong ~1 h core plus a long jitter tail whose RTT sits
+        // back at baseline (the jitter keeps the run alive). The MEDIAN RTT over the full window
+        // dilutes toward baseline, so a median-based line-wide test flickers below threshold and the
+        // incident fragments into per-hop rows. The high-percentile test sees the strong core, so a
+        // genuinely line-wide, uniform incident collapses to one shared event even with a long tail.
+        List<LatencySample> CoreThenTail() => Flat(5)
+            .WithSegment(HumpStart, HumpStart.AddHours(1), rttMs: 30, jitterMs: 6)
+            .WithSegment(HumpStart.AddHours(1), HumpStart.AddHours(3), rttMs: 5, jitterMs: 3);
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, CoreThenTail()),
+            Hop(100, Border, CoreThenTail(), Bng),
+            Hop(100, Backhaul, CoreThenTail(), Bng, Border),
+            Hop(200, Transit, CoreThenTail(), Bng, Border, Backhaul),
+            Hop(300, DeadEnd, CoreThenTail(), Bng, Border),
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        events.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void A_high_variance_rise_under_load_is_not_loaded_latency_even_when_breadth_passes()
+    {
+        // The 19:15 shape: the access egress rose hard while the rest only picked up the shared load
+        // floor (jitter up, RTT barely moved). The high-percentile breadth test now counts the floor
+        // paths as "rose", so line-wide breadth passes - but the rise is NOT uniform (one path far above
+        // the floor). The uniformity gate must keep this from reading as self-inflicted Loaded Latency;
+        // it's localized congestion on top of load, not your access link slowing everything equally.
+        List<LatencySample> Floor() => Flat(5).WithSegment(HumpStart, HumpEnd, rttMs: 6, jitterMs: 3);
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Elevated()),                  // access egress: hard rise
+            Hop(100, Border, Floor(), Bng),             // the rest: shared floor only (jitter up, RTT flat)
+            Hop(100, Backhaul, Floor(), Bng, Border),
+            Hop(200, Transit, Floor(), Bng, Border, Backhaul),
+            Hop(300, DeadEnd, Floor(), Bng, Border),
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: true), Options);
+
+        events.Should().NotContain(e => e.Disposition == CongestionDisposition.SelfInflicted);
+    }
+
+    [Fact]
     public void Floor_jitter_rise_with_only_some_paths_risen_in_rtt_does_not_collapse_to_loaded_latency()
     {
         // Under load the jitter floor lifts every path, but only some paths actually rose in RTT.

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
@@ -406,6 +406,50 @@ public class CongestionLocalizerTests
     }
 
     [Fact]
+    public void Relative_line_wide_with_no_load_collapses_to_one_shared_confirmed_event()
+    {
+        // Every monitored path is elevated relative to its own baseline, rooted at the access egress,
+        // with no heavy local load: one shared upstream incident attributed to the convergence hop,
+        // Confirmed (scored) - not N separate per-hop rows.
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Elevated()),
+            Hop(100, Border, Elevated(), Bng),
+            Hop(100, Backhaul, Elevated(), Bng, Border),
+            Hop(200, Transit, Elevated(), Bng, Border, Backhaul),
+            Hop(300, DeadEnd, Elevated(), Bng, Border),
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        events.Should().ContainSingle();
+        events[0].Disposition.Should().Be(CongestionDisposition.Confirmed);
+        events[0].BottleneckHopIp.Should().Be(Bng);
+        events[0].AttributionReason.Should().Contain("shared upstream");
+    }
+
+    [Fact]
+    public void Shared_incident_span_trims_a_lingering_hop()
+    {
+        // Four hops rise together for ~45 min; one lingers 3 h past the rest. The collapsed incident
+        // must span only the shared window (~45 min), not be dragged out to the lingering hop's 3 h.
+        var lingering = Flat(5).WithSegment(HumpStart, HumpStart.AddHours(3), rttMs: 30, jitterMs: 6);
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Elevated()),
+            Hop(100, Border, Elevated(), Bng),
+            Hop(100, Backhaul, Elevated(), Bng, Border),
+            Hop(200, Transit, Elevated(), Bng, Border, Backhaul),
+            Hop(300, DeadEnd, lingering, Bng, Border),
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        events.Should().ContainSingle();
+        events[0].Duration.Should().BeLessThan(TimeSpan.FromHours(1.5));
+    }
+
+    [Fact]
     public void Jitter_rise_below_the_absolute_floor_does_not_fire()
     {
         // RTT clearly elevated and jitter ratio over 2x, but the absolute jitter rise

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
@@ -429,6 +429,27 @@ public class CongestionLocalizerTests
     }
 
     [Fact]
+    public void Floor_jitter_rise_with_only_some_paths_risen_in_rtt_does_not_collapse_to_loaded_latency()
+    {
+        // Under load the jitter floor lifts every path, but only some paths actually rose in RTT.
+        // That's a shared floor + localized congestion, not "everything slowed" - it must NOT collapse
+        // to one Loaded Latency event; the RTT-risen paths localize per-hop instead.
+        var jitterOnly = Flat(5).WithSegment(HumpStart, HumpEnd, rttMs: 5, jitterMs: 3);
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, jitterOnly),
+            Hop(100, Border, jitterOnly, Bng),
+            Hop(100, Backhaul, Elevated(), Bng, Border),
+            Hop(200, Transit, Elevated(), Bng, Border, Backhaul),
+            Hop(300, DeadEnd, jitterOnly, Bng, Border),
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: true), Options);
+
+        events.Should().NotContain(e => e.Disposition == CongestionDisposition.SelfInflicted);
+    }
+
+    [Fact]
     public void Relative_line_wide_with_no_load_collapses_to_one_shared_confirmed_event()
     {
         // Every monitored path is elevated relative to its own baseline, rooted at the access egress,

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
@@ -81,6 +81,35 @@ public class CongestionLocalizerTests
     };
 
     [Fact]
+    public void Each_bottleneck_reports_its_own_duration_not_the_cluster_span()
+    {
+        // Two independent bottlenecks overlap in time: a near backhaul hop that clears in 45 min,
+        // and an off-corridor dead-end hop elevated for 3 h. They land in one time-cluster, but each
+        // event must report its OWN elevation span - the short one must not inherit the long one's.
+        var shortEnd = HumpStart.AddMinutes(45);
+        var longEnd = HumpStart.AddHours(3);
+        List<LatencySample> ElevatedUntil(DateTime end, double rtt) =>
+            Flat(rtt).WithSegment(HumpStart, end, rttMs: rtt + 25, jitterMs: 6);
+
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Flat()),
+            Hop(100, Border, Flat()),
+            Hop(100, Backhaul, ElevatedUntil(shortEnd, 5), Bng, Border), // 45 min; next hop clean -> own bottleneck
+            Hop(200, Transit, Flat(8), Bng, Border, Backhaul),           // clean downstream witness
+            Hop(300, DeadEnd, ElevatedUntil(longEnd, 5), Bng, Border),   // 3 h; off-corridor dead-end -> own bottleneck
+            Dest(DestControl, Flat(), Bng, Border),
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        var backhaul = events.Single(e => e.BottleneckHopIp == Backhaul);
+        var deadEnd = events.Single(e => e.BottleneckHopIp == DeadEnd);
+        backhaul.Duration.Should().BeLessThan(TimeSpan.FromHours(1));
+        deadEnd.Duration.Should().BeGreaterThan(TimeSpan.FromHours(2));
+    }
+
+    [Fact]
     public void Localizes_to_backhaul_hop_and_does_not_blame_downstream_transit()
     {
         var series = new List<AsnSeries>

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
@@ -26,6 +26,15 @@ public class OutageDetectorTests
 
     private static IReadOnlyList<IReadOnlyList<LatencySample>> Triggers(params List<LatencySample>[] series) => series;
 
+    /// <summary>A target sampled every 5 s across the window, dark (100% loss) where the predicate holds.</summary>
+    private static List<LatencySample> Cadenced(Func<DateTime, bool> isDark)
+    {
+        var s = new List<LatencySample>();
+        for (var t = TestSeries.Start; t < TestSeries.Start + Window; t += TimeSpan.FromSeconds(5))
+            s.Add(new LatencySample(t, 20, 20.5, 0.5, isDark(t) ? 100 : 0));
+        return s;
+    }
+
     [Fact]
     public void Detects_upstream_outage_and_attributes_break_beyond_olt()
     {
@@ -48,6 +57,7 @@ public class OutageDetectorTests
         events[0].Scope.Should().Be(OutageScope.Upstream);
         events[0].LastReachableHop.Should().Be("AT&T nokia-olt");
         events[0].Duration.Should().BeCloseTo(TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(1));
+        events[0].IsBrief.Should().BeFalse();
     }
 
     [Fact]
@@ -161,14 +171,33 @@ public class OutageDetectorTests
     }
 
     [Fact]
-    public void Brief_blip_below_min_duration_is_ignored()
+    public void Momentary_blip_below_the_minimum_is_ignored()
     {
-        var internet1 = Series(0, (OutStart, OutStart.AddMinutes(1), 100));
-        var internet2 = Series(0, (OutStart, OutStart.AddMinutes(1), 100));
+        // ~20 s of total loss - below the 30 s floor, a momentary blip, not reported.
+        var darkEnd = OutStart.AddSeconds(20);
+        var internet1 = Cadenced(t => t >= OutStart && t < darkEnd);
+        var internet2 = Cadenced(t => t >= OutStart && t < darkEnd);
 
         var events = OutageDetector.Detect(Triggers(internet1, internet2), System.Array.Empty<OutageDetector.Hop>(), Options);
 
         events.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Drop_between_30s_and_2min_is_flagged_as_a_brief_disruption()
+    {
+        // A clean 45 s drop: above the 30 s floor, below the 2 min brief/full divider. It is
+        // reported but classified brief - the lighter tier for short transit/upstream flaps.
+        var darkEnd = OutStart.AddSeconds(45);
+        var internet1 = Cadenced(t => t >= OutStart && t < darkEnd);
+        var internet2 = Cadenced(t => t >= OutStart && t < darkEnd);
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), System.Array.Empty<OutageDetector.Hop>(), Options);
+
+        events.Should().ContainSingle();
+        events[0].IsBrief.Should().BeTrue();
+        events[0].Duration.Should().BeGreaterThanOrEqualTo(TimeSpan.FromSeconds(30));
+        events[0].Duration.Should().BeLessThan(TimeSpan.FromMinutes(2));
     }
 
     [Fact]
@@ -219,9 +248,9 @@ public class OutageDetectorTests
     public void Gap_longer_than_the_tolerance_stays_two_separate_outages()
     {
         // A long healthy stretch between two dark spans is a genuine recovery then a second
-        // outage - well beyond OutageMaxGapMinutes, so the two must NOT be coalesced.
+        // outage - well beyond OutageMaxGapSeconds, so the two must NOT be coalesced.
         var firstEnd = OutStart.AddMinutes(3);
-        var secondStart = OutStart.AddMinutes(12); // 9-minute clear gap, > OutageMaxGapMinutes
+        var secondStart = OutStart.AddMinutes(12); // 9-minute clear gap, > OutageMaxGapSeconds
         var secondEnd = secondStart.AddMinutes(3);
         List<LatencySample> TwoSpans() => Series(0, (OutStart, firstEnd, 100), (secondStart, secondEnd, 100));
         var internet1 = TwoSpans();
@@ -302,9 +331,9 @@ public class OutageDetectorTests
     [Fact]
     public void Window_and_recovery_carry_real_seconds_not_minute_buckets()
     {
-        // Samples land at :17 past each minute. Detection still buckets by minute, but the
-        // reported onset, recovery, and per-hop recovery must come from the actual sample
-        // instants - otherwise every time renders :00.
+        // Samples land at :17 past each minute. Detection buckets internally, but the reported
+        // onset, recovery, and per-hop recovery must come from the actual sample instants -
+        // otherwise every time renders on a bucket edge.
         var offset = TimeSpan.FromSeconds(17);
         List<LatencySample> Build()
         {

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
@@ -35,6 +35,17 @@ public class OutageDetectorTests
         return s;
     }
 
+    /// <summary>A target sampled every 10 s, at <paramref name="loss"/> within [from, to) and clean otherwise.</summary>
+    private static List<LatencySample> LossSeries(DateTime from, DateTime to, double loss)
+    {
+        var s = new List<LatencySample>();
+        for (var t = TestSeries.Start; t < TestSeries.Start + Window; t += TimeSpan.FromSeconds(10))
+            s.Add(new LatencySample(t, 20, 20.5, 0.5, t >= from && t < to ? loss : 0));
+        return s;
+    }
+
+    private static readonly (DateTime Start, DateTime End)[] NoDarkWindows = System.Array.Empty<(DateTime, DateTime)>();
+
     [Fact]
     public void Detects_upstream_outage_and_attributes_break_beyond_olt()
     {
@@ -198,6 +209,91 @@ public class OutageDetectorTests
         events[0].IsBrief.Should().BeTrue();
         events[0].Duration.Should().BeGreaterThanOrEqualTo(TimeSpan.FromSeconds(30));
         events[0].Duration.Should().BeLessThan(TimeSpan.FromMinutes(2));
+    }
+
+    [Fact]
+    public void Coincident_partial_loss_across_many_targets_and_asns_is_a_partial_disruption()
+    {
+        // ~40 s where four independent destinations across four ASNs degrade together at 60-80%
+        // loss - never the 95% dark threshold. That is a partial-loss disruption, not a blackout.
+        var ds = OutStart;
+        var de = OutStart.AddSeconds(40);
+        var hops = new[]
+        {
+            new OutageDetector.Hop("Cloudflare", 0, LossSeries(ds, de, 60), AsnLabel: "Cloudflare"),
+            new OutageDetector.Hop("Fastly", 1, LossSeries(ds, de, 80), AsnLabel: "Fastly"),
+            new OutageDetector.Hop("AS3356", 2, LossSeries(ds, de, 60), AsnLabel: "AS3356"),
+            new OutageDetector.Hop("AS22773", 3, LossSeries(ds, de, 80), AsnLabel: "AS22773"),
+            new OutageDetector.Hop("CleanA", 4, LossSeries(ds, de, 0), AsnLabel: "CleanA"),
+            new OutageDetector.Hop("CleanB", 5, LossSeries(ds, de, 0), AsnLabel: "CleanB"),
+        };
+
+        var events = OutageDetector.DetectPartial(hops, NoDarkWindows, Options);
+
+        events.Should().ContainSingle();
+        events[0].IsPartial.Should().BeTrue();
+        events[0].IsBrief.Should().BeTrue();
+        events[0].PeakLossPct.Should().BeGreaterThanOrEqualTo(60);
+        events[0].DegradedTargetCount.Should().Be(4);
+        events[0].PathTargetCount.Should().Be(6);
+    }
+
+    [Fact]
+    public void A_single_lossy_target_is_not_a_partial_disruption()
+    {
+        var ds = OutStart;
+        var de = OutStart.AddMinutes(5);
+        var hops = new[]
+        {
+            new OutageDetector.Hop("Fastly", 0, LossSeries(ds, de, 80), AsnLabel: "Fastly"),
+            new OutageDetector.Hop("CleanA", 1, LossSeries(ds, de, 0), AsnLabel: "CleanA"),
+            new OutageDetector.Hop("CleanB", 2, LossSeries(ds, de, 0), AsnLabel: "CleanB"),
+            new OutageDetector.Hop("CleanC", 3, LossSeries(ds, de, 0), AsnLabel: "CleanC"),
+        };
+
+        var events = OutageDetector.DetectPartial(hops, NoDarkWindows, Options);
+
+        events.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Many_degraded_targets_behind_one_asn_do_not_trip_partial_detection()
+    {
+        // Four lossy targets, but all one ASN - that ASN's own issue, not a path-wide event.
+        var ds = OutStart;
+        var de = OutStart.AddSeconds(40);
+        var hops = new[]
+        {
+            new OutageDetector.Hop("AS3356 a", 0, LossSeries(ds, de, 80), AsnLabel: "AS3356"),
+            new OutageDetector.Hop("AS3356 b", 1, LossSeries(ds, de, 80), AsnLabel: "AS3356"),
+            new OutageDetector.Hop("AS3356 c", 2, LossSeries(ds, de, 80), AsnLabel: "AS3356"),
+            new OutageDetector.Hop("AS3356 d", 3, LossSeries(ds, de, 80), AsnLabel: "AS3356"),
+            new OutageDetector.Hop("CleanA", 4, LossSeries(ds, de, 0), AsnLabel: "CleanA"),
+        };
+
+        var events = OutageDetector.DetectPartial(hops, NoDarkWindows, Options);
+
+        events.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Partial_window_overlapping_a_blackout_is_excluded()
+    {
+        // A blackout also clears the partial threshold; the partial pass must not surface it again.
+        var ds = OutStart;
+        var de = OutStart.AddSeconds(40);
+        var hops = new[]
+        {
+            new OutageDetector.Hop("Cloudflare", 0, LossSeries(ds, de, 60), AsnLabel: "Cloudflare"),
+            new OutageDetector.Hop("Fastly", 1, LossSeries(ds, de, 80), AsnLabel: "Fastly"),
+            new OutageDetector.Hop("AS3356", 2, LossSeries(ds, de, 60), AsnLabel: "AS3356"),
+            new OutageDetector.Hop("AS22773", 3, LossSeries(ds, de, 80), AsnLabel: "AS22773"),
+        };
+        var darkWindows = new[] { (OutStart.AddSeconds(-5), OutStart.AddSeconds(45)) };
+
+        var events = OutageDetector.DetectPartial(hops, darkWindows, Options);
+
+        events.Should().BeEmpty();
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
@@ -277,6 +277,32 @@ public class OutageDetectorTests
     }
 
     [Fact]
+    public void Partial_disruption_disambiguates_repeated_asn_labels()
+    {
+        // Several hops of one access ISP would all read as just "AT&T"; only the repeated label gets
+        // disambiguated to the specific hop, while unique labels are left as the clean ASN name.
+        var ds = OutStart;
+        var de = OutStart.AddSeconds(40);
+        var hops = new[]
+        {
+            new OutageDetector.Hop("AT&T nokia-olt", 0, LossSeries(ds, de, 80), AsnLabel: "AT&T"),
+            new OutageDetector.Hop("AT&T mtnview-border", 1, LossSeries(ds, de, 80), AsnLabel: "AT&T"),
+            new OutageDetector.Hop("Cloudflare", 2, LossSeries(ds, de, 80), AsnLabel: "Cloudflare"),
+            new OutageDetector.Hop("Fastly", 3, LossSeries(ds, de, 80), AsnLabel: "Fastly"),
+        };
+
+        var events = OutageDetector.DetectPartial(hops, NoDarkWindows, Options);
+
+        events.Should().ContainSingle();
+        var names = events[0].Tiers.Select(t => t.Name).ToList();
+        names.Should().Contain("AT&T nokia-olt");
+        names.Should().Contain("AT&T mtnview-border");
+        names.Should().NotContain("AT&T");                 // the bare duplicate label is replaced
+        names.Should().Contain("Cloudflare");              // unique labels stay clean
+        names.Should().Contain("Fastly");
+    }
+
+    [Fact]
     public void Partial_window_overlapping_a_blackout_is_excluded()
     {
         // A blackout also clears the partial threshold; the partial pass must not surface it again.


### PR DESCRIPTION
## What

Sharpens ISP Health's outage and congestion detection, the Path & Congestion timeline, and load performance.

### Outages
- **Brief outages** - near-total loss (>=95%) lasting 30s-2min is now detected and surfaced as a distinct "Brief" tier instead of being dropped by the old two-minute floor (15s detection buckets).
- **Partial-loss disruptions** - a new signal for coincident packet loss across many path targets that never goes fully dark (the path getting lossy, not unreachable). Flagged only when several independent targets across multiple networks degrade together; surfaced with peak-loss/breadth, an intensity bar, and a per-event score impact scaled by peak loss.
- Repeated ASN labels in a partial-loss tier list (several hops of one access ISP) are disambiguated to the specific hop instead of all reading as the bare ASN name.

### Congestion
- **Jitter-aware propagation.** The localizer's propagation/elevation test now recognizes a jitter rise relative to a hop's own baseline, not just RTT. Many incidents are jitter-driven with flat RTT, where an RTT-only test read the next hop as "clean" and shattered one connected, chain-wide rise into a pile of per-hop "control-plane noise" rows.
- **Shared incidents collapse to one event.** A genuinely uniform line-wide rise (a strict majority of paths up in RTT, none materially above the shared floor) collapses to a single event - Loaded Latency under heavy WAN load, or shared upstream otherwise - attributed to the convergence hop nearest you, spanning only the concurrent window. When a few paths rose materially above the floor (a shared load floor plus localized congestion), it stays per-hop so those surface as "this hop's own capacity, not your access egress," with the floor treated as the expected load baseline. The line-wide test reads each path's strong portion (a high in-window percentile), so an incident with a long mild tail still collapses instead of flickering between one row and many across refreshes; the Loaded Latency / self-inflicted call requires that same uniform rise.
- **No false long tails.** Continuation now keeps a run open only while the signature persists relative to the hop's OWN baseline (p90 above baseline p90, jitter up by both an absolute and a relative margin), so a chronically bursty/jittery hop no longer holds a 40-minute event open for hours.
- **No window-edge phantoms.** On a long (coarse-aggregate) window, congestion events that don't reproduce at full resolution are dropped - the coarse aggregate inflates bucket p90 and could invent a multi-hour event on a flat hop at the window's leading edge.
- Plus: hysteresis so an event keeps its milder tail, continuation requires the congestion signature (not just an elevated level), each hop reports its own duration rather than the cluster span, and a threshold so co-temporal hops present as one clean window.

### Path & Congestion timeline
- Drag-zoom the per-network RTT chart to filter the events list to the visible range; reset returns to the full window and keeps the chart in view.
- Fixed absolved-jitter tooltips that could show a stale value after a date-range change.

### Performance
- **Faster ISP Health loads.** The heavy latency reads now stream-parse the Influx CSV directly instead of materializing the client's buffered record model (a dictionary + boxed values per record). First-load time drops, scaling with window: ~20% off 7d/14d and ~24% off a 30-day view. Resolution and results unchanged.

## Why

These come from real incidents on the test sites: short transit drops that went unrecorded, multi-hop partial-loss invisible to the blackout detector, jitter-driven congestion mislabeled as per-hop noise, "everything slowed" misattributed when only some paths were actually worse, false multi-hour tails on bursty hops, and slow loads dominated by per-record deserialization. New detection thresholds live in `IspHealthOptions` for tuning.

A known follow-up (congestion events shifting as the view window widens, because detection baselines are window-relative) is tracked separately in #892.

## Tests

New unit tests across brief/partial outages, the CSV parser, and the congestion localizer (jitter propagation, shared-incident collapse + uniformity, span-trim, floor-relative clean controls, per-member duration). Full suite green.
