### PR TITLE
Channel plan: stop marginal channel suggestions flickering between scans

### DIFF
--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -537,6 +537,14 @@ public class WiFiOptimizerService
     private List<ChannelScanResult>? _cachedScanResults;
     private string? _cachedScanResultsTimeKey;
 
+    // Rolling per-(AP, band) neighbor sighting history, so a channel's external load reflects the
+    // fullest recent scan rather than a single under-detecting one. A neighbor that isn't
+    // transmitting during one scan window would otherwise drop out and make its channel look
+    // spuriously clean, which flickers marginal channel-plan moves in and out. See NeighborSightingPool.
+    private readonly object _sightingHistoryLock = new();
+    private readonly Dictionary<string, List<(NeighborNetwork Neighbor, DateTimeOffset SeenAt)>> _neighborSightingHistory = new();
+    private static readonly TimeSpan NeighborSightingWindow = TimeSpan.FromMinutes(10);
+
     /// <summary>
     /// Get RF environment channel scan results from APs
     /// </summary>
@@ -577,10 +585,11 @@ public class WiFiOptimizerService
         {
             var provider = CreateProvider();
 
-            _cachedScanResults = await provider.GetChannelScanResultsAsync(
+            var fresh = await provider.GetChannelScanResultsAsync(
                 apMac: null,
                 startTime: startTime,
                 endTime: endTime);
+            _cachedScanResults = PoolNeighborSightings(fresh);
             _cachedScanResultsTimeKey = timeKey;
             return _cachedScanResults;
         }
@@ -588,6 +597,41 @@ public class WiFiOptimizerService
         {
             _logger.LogError(ex, "Failed to get channel scan results");
             return new List<ChannelScanResult>();
+        }
+    }
+
+    /// <summary>
+    /// Fold each fresh scan's neighbor list into a short rolling per-(AP, band) history and replace
+    /// it with the union of recent sightings, so a channel's external load reflects the fullest
+    /// recent scan rather than a single under-detecting snapshot. This stabilizes marginal
+    /// channel-plan moves that would otherwise flicker as consecutive scans detect slightly
+    /// different neighbor sets. See <see cref="NeighborSightingPool"/>.
+    /// </summary>
+    private List<ChannelScanResult> PoolNeighborSightings(List<ChannelScanResult> fresh)
+    {
+        var now = DateTimeOffset.UtcNow;
+        lock (_sightingHistoryLock)
+        {
+            foreach (var scan in fresh)
+            {
+                var key = $"{scan.ApMac.ToLowerInvariant()}|{scan.Band}";
+                if (!_neighborSightingHistory.TryGetValue(key, out var history))
+                {
+                    history = new List<(NeighborNetwork, DateTimeOffset)>();
+                    _neighborSightingHistory[key] = history;
+                }
+
+                foreach (var nb in scan.Neighbors)
+                {
+                    if (!string.IsNullOrEmpty(nb.Bssid))
+                        history.Add((nb, now));
+                }
+                history.RemoveAll(s => now - s.SeenAt > NeighborSightingWindow);
+
+                scan.Neighbors = NeighborSightingPool.Union(history, now, NeighborSightingWindow);
+            }
+
+            return fresh;
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -1,15 +1,12 @@
 using System.Text.Json;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Audit.Analyzers;
-using NetworkOptimizer.Storage.Services;
 using NetworkOptimizer.UniFi;
 using NetworkOptimizer.WiFi;
 using NetworkOptimizer.WiFi.Analyzers;
+using NetworkOptimizer.WiFi.Helpers;
 using NetworkOptimizer.WiFi.Models;
 using NetworkOptimizer.WiFi.Providers;
 using NetworkOptimizer.WiFi.Rules;
-using NetworkOptimizer.WiFi.Helpers;
 using NetworkOptimizer.WiFi.Services;
 using AuditNetworkInfo = NetworkOptimizer.Audit.Models.NetworkInfo;
 
@@ -589,7 +586,11 @@ public class WiFiOptimizerService
                 apMac: null,
                 startTime: startTime,
                 endTime: endTime);
-            _cachedScanResults = PoolNeighborSightings(fresh);
+            // Record raw sightings for the rolling window, but cache and return the RAW scan -
+            // the live RF Environment view must show the current scan, not a pooled union. Only
+            // the channel recommendation reads the pooled view (see PoolNeighborSightings).
+            RecordNeighborSightings(fresh);
+            _cachedScanResults = fresh;
             _cachedScanResultsTimeKey = timeKey;
             return _cachedScanResults;
         }
@@ -601,13 +602,11 @@ public class WiFiOptimizerService
     }
 
     /// <summary>
-    /// Fold each fresh scan's neighbor list into a short rolling per-(AP, band) history and replace
-    /// it with the union of recent sightings, so a channel's external load reflects the fullest
-    /// recent scan rather than a single under-detecting snapshot. This stabilizes marginal
-    /// channel-plan moves that would otherwise flicker as consecutive scans detect slightly
-    /// different neighbor sets. See <see cref="NeighborSightingPool"/>.
+    /// Record each fresh scan's neighbor sightings into the rolling per-(AP, band) history (and
+    /// prune anything past the window). Called once per fresh scan fetch; does not modify the
+    /// scans, so callers still get the raw live scan back.
     /// </summary>
-    private List<ChannelScanResult> PoolNeighborSightings(List<ChannelScanResult> fresh)
+    private void RecordNeighborSightings(List<ChannelScanResult> fresh)
     {
         var now = DateTimeOffset.UtcNow;
         lock (_sightingHistoryLock)
@@ -627,11 +626,43 @@ public class WiFiOptimizerService
                         history.Add((nb, now));
                 }
                 history.RemoveAll(s => now - s.SeenAt > NeighborSightingWindow);
+            }
+        }
+    }
 
-                scan.Neighbors = NeighborSightingPool.Union(history, now, NeighborSightingWindow);
+    /// <summary>
+    /// Return a copy of the scans with each AP/band's neighbor list replaced by the rolling union
+    /// of recent sightings, so a channel's external load reflects the fullest recent scan rather
+    /// than a single under-detecting snapshot. This stabilizes marginal channel-plan moves that
+    /// would otherwise flicker as consecutive scans detect slightly different neighbor sets. Used by
+    /// the channel recommendation ONLY - the raw scan still drives the live RF Environment view. The
+    /// originals are not mutated (the cache is shared with that view). See <see cref="NeighborSightingPool"/>.
+    /// </summary>
+    private List<ChannelScanResult> PoolNeighborSightings(List<ChannelScanResult> raw)
+    {
+        var now = DateTimeOffset.UtcNow;
+        lock (_sightingHistoryLock)
+        {
+            var pooled = new List<ChannelScanResult>(raw.Count);
+            foreach (var scan in raw)
+            {
+                var key = $"{scan.ApMac.ToLowerInvariant()}|{scan.Band}";
+                var neighbors = _neighborSightingHistory.TryGetValue(key, out var history)
+                    ? NeighborSightingPool.Union(history, now, NeighborSightingWindow)
+                    : scan.Neighbors;
+
+                pooled.Add(new ChannelScanResult
+                {
+                    ApMac = scan.ApMac,
+                    ApName = scan.ApName,
+                    Band = scan.Band,
+                    ScanTime = scan.ScanTime,
+                    Channels = scan.Channels,
+                    Neighbors = neighbors
+                });
             }
 
-            return fresh;
+            return pooled;
         }
     }
 
@@ -836,7 +867,9 @@ public class WiFiOptimizerService
 
             var aps = apsTask.Result;
             var regulatoryData = regulatoryTask.Result;
-            var scanResults = scanTask.Result;
+            // Pool neighbor sightings across the rolling window so a single under-detecting scan
+            // can't flip marginal channel moves (the live RF Environment view still uses raw scans).
+            var scanResults = PoolNeighborSightings(scanTask.Result);
 
             if (aps.Count == 0)
             {

--- a/src/NetworkOptimizer.WiFi/Helpers/NeighborSightingPool.cs
+++ b/src/NetworkOptimizer.WiFi/Helpers/NeighborSightingPool.cs
@@ -1,0 +1,33 @@
+using NetworkOptimizer.WiFi.Models;
+
+namespace NetworkOptimizer.WiFi.Helpers;
+
+/// <summary>
+/// Stabilizes scan-derived neighbor lists by unioning recent sightings. A single UniFi RF scan
+/// under-detects neighbors that aren't transmitting during its window, so an unchanged channel can
+/// read busy one scan and clear the next. That makes marginal channel-plan moves flicker in and
+/// out between runs. Pooling keeps a neighbor in the picture - at its strongest recent signal -
+/// until it has been absent for the whole retention window, so a channel only reads clean when it
+/// is consistently clean, not just in one sparse scan.
+/// </summary>
+public static class NeighborSightingPool
+{
+    /// <summary>
+    /// Union the sightings by BSSID, keeping the strongest-signal sighting of each that falls within
+    /// <paramref name="window"/> of <paramref name="now"/>. Sightings outside the window, or without
+    /// a BSSID, are dropped. The bias is intentionally conservative (strongest, not latest): a
+    /// channel won't be treated as clean just because the most recent scan happened to miss a
+    /// neighbor it saw moments ago.
+    /// </summary>
+    public static List<NeighborNetwork> Union(
+        IEnumerable<(NeighborNetwork Neighbor, DateTimeOffset SeenAt)> sightings,
+        DateTimeOffset now,
+        TimeSpan window)
+    {
+        return sightings
+            .Where(s => now - s.SeenAt <= window && !string.IsNullOrEmpty(s.Neighbor.Bssid))
+            .GroupBy(s => s.Neighbor.Bssid, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.OrderByDescending(s => s.Neighbor.Signal ?? int.MinValue).First().Neighbor)
+            .ToList();
+    }
+}

--- a/tests/NetworkOptimizer.WiFi.Tests/NeighborSightingPoolTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/NeighborSightingPoolTests.cs
@@ -1,0 +1,76 @@
+using FluentAssertions;
+using NetworkOptimizer.WiFi.Helpers;
+using NetworkOptimizer.WiFi.Models;
+using Xunit;
+
+namespace NetworkOptimizer.WiFi.Tests;
+
+public class NeighborSightingPoolTests
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.UnixEpoch.AddHours(1);
+    private static readonly TimeSpan Window = TimeSpan.FromMinutes(10);
+
+    private static (NeighborNetwork, DateTimeOffset) Sighting(string bssid, int channel, int signal, TimeSpan ago)
+        => (new NeighborNetwork { Bssid = bssid, Channel = channel, Signal = signal }, Now - ago);
+
+    [Fact]
+    public void Union_NeighborMissingFromLatestScan_HeldWhileWithinWindow()
+    {
+        // Seen 3 minutes ago, absent from the latest scan - must still count.
+        var pooled = NeighborSightingPool.Union(
+            new[] { Sighting("aa:bb:cc:00:00:01", 1, -60, TimeSpan.FromMinutes(3)) },
+            Now, Window);
+
+        pooled.Should().ContainSingle(n => n.Bssid == "aa:bb:cc:00:00:01");
+    }
+
+    [Fact]
+    public void Union_NeighborAbsentBeyondWindow_AgesOut()
+    {
+        var pooled = NeighborSightingPool.Union(
+            new[] { Sighting("aa:bb:cc:00:00:01", 1, -60, TimeSpan.FromMinutes(15)) },
+            Now, Window);
+
+        pooled.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Union_SameBssidMultipleSightings_KeepsStrongestSignal()
+    {
+        var pooled = NeighborSightingPool.Union(
+            new[]
+            {
+                Sighting("aa:bb:cc:00:00:01", 1, -75, TimeSpan.FromMinutes(5)),
+                Sighting("aa:bb:cc:00:00:01", 1, -55, TimeSpan.FromMinutes(2)),
+                Sighting("aa:bb:cc:00:00:01", 1, -80, TimeSpan.Zero)
+            },
+            Now, Window);
+
+        pooled.Should().ContainSingle();
+        pooled[0].Signal.Should().Be(-55);
+    }
+
+    [Fact]
+    public void Union_DistinctBssids_AllRetained()
+    {
+        var pooled = NeighborSightingPool.Union(
+            new[]
+            {
+                Sighting("aa:bb:cc:00:00:01", 1, -60, TimeSpan.Zero),
+                Sighting("aa:bb:cc:00:00:02", 6, -65, TimeSpan.FromMinutes(4))
+            },
+            Now, Window);
+
+        pooled.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Union_EmptyBssid_Ignored()
+    {
+        var pooled = NeighborSightingPool.Union(
+            new[] { Sighting("", 1, -60, TimeSpan.Zero) },
+            Now, Window);
+
+        pooled.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
Stops marginal channel-plan suggestions from flickering in and out between runs.

## The problem

A single UniFi RF scan under-detects neighbors that aren't transmitting during its scan window, so an unchanged channel can read busy one scan and clear the next. When a channel briefly looks clean, the planner surfaces a marginal "move this AP here" suggestion; the next scan it's gone. The physical environment didn't change - the measurement did - but the recommendation blinked.

## The fix

Pool each AP/band's neighbor sightings across a short rolling window (10 minutes) and feed the engine the union - the strongest recent signal per BSSID - instead of a single snapshot. A neighbor stays in the picture until it's been absent for the whole window, so a channel only reads clean when it's *consistently* clean, not because one sparse scan happened to miss it. The bias is intentionally conservative: it won't bet on a channel that was busy moments ago.

The live RF Environment view is unaffected - it still shows the raw current scan. Only the channel recommendation reads the pooled view, and it does so on a copy, so nothing the view shares is mutated. The smoothing is in-memory and self-heals within the window after a restart.

## Result

A channel's external load holds steady run-to-run instead of swinging, so a genuinely-busy channel no longer momentarily looks clean and an AP stops bouncing between two channels across consecutive runs.

## Tests

Pure union logic is covered: a neighbor missing from the latest scan is held while within the window, ages out past it, the strongest recent signal wins per BSSID, distinct BSSIDs are all retained, and empty BSSIDs are ignored.
