### PR TITLE
Configurable temperature and SFP alert thresholds

### DIFF
--- a/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
+++ b/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
@@ -240,6 +240,16 @@ public static class DefaultAlertRules
             ThresholdPercent = 95,
             CooldownSeconds = 1800 // 30 minutes
         },
+        new AlertRule
+        {
+            // Threshold (Celsius) is configured per device type in Monitoring -> Device Stats.
+            Name = "Device: Temperature High",
+            IsEnabled = true,
+            EventTypePattern = "device.high_temperature",
+            Source = "device",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 1800 // 30 minutes
+        },
 
         // --- Cable modem (disabled until user configures a cable modem) ---
         new AlertRule

--- a/src/NetworkOptimizer.Storage/Migrations/20260624182049_AddDeviceTempThresholds.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260624182049_AddDeviceTempThresholds.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260624182049_AddDeviceTempThresholds")]
+    partial class AddDeviceTempThresholds
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260624182049_AddDeviceTempThresholds.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260624182049_AddDeviceTempThresholds.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDeviceTempThresholds : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "GatewayTempHighC",
+                table: "MonitoringSettings",
+                type: "REAL",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "SwitchTempHighC",
+                table: "MonitoringSettings",
+                type: "REAL",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "GatewayTempHighC",
+                table: "MonitoringSettings");
+
+            migrationBuilder.DropColumn(
+                name: "SwitchTempHighC",
+                table: "MonitoringSettings");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Migrations/20260624183353_AddSfpDdmThresholds.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260624183353_AddSfpDdmThresholds.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260624183353_AddSfpDdmThresholds")]
+    partial class AddSfpDdmThresholds
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260624183353_AddSfpDdmThresholds.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260624183353_AddSfpDdmThresholds.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSfpDdmThresholds : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "AeRxPowerLowDbm",
+                table: "MonitoringSettings",
+                type: "REAL",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "AeTempHighC",
+                table: "MonitoringSettings",
+                type: "REAL",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "AeTxPowerHighDbm",
+                table: "MonitoringSettings",
+                type: "REAL",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "PonRxPowerLowDbm",
+                table: "MonitoringSettings",
+                type: "REAL",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "PonTempHighC",
+                table: "MonitoringSettings",
+                type: "REAL",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "PonTxPowerHighDbm",
+                table: "MonitoringSettings",
+                type: "REAL",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "SfpTempHighGenericC",
+                table: "MonitoringSettings",
+                type: "REAL",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AeRxPowerLowDbm",
+                table: "MonitoringSettings");
+
+            migrationBuilder.DropColumn(
+                name: "AeTempHighC",
+                table: "MonitoringSettings");
+
+            migrationBuilder.DropColumn(
+                name: "AeTxPowerHighDbm",
+                table: "MonitoringSettings");
+
+            migrationBuilder.DropColumn(
+                name: "PonRxPowerLowDbm",
+                table: "MonitoringSettings");
+
+            migrationBuilder.DropColumn(
+                name: "PonTempHighC",
+                table: "MonitoringSettings");
+
+            migrationBuilder.DropColumn(
+                name: "PonTxPowerHighDbm",
+                table: "MonitoringSettings");
+
+            migrationBuilder.DropColumn(
+                name: "SfpTempHighGenericC",
+                table: "MonitoringSettings");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/MonitoringSettings.cs
+++ b/src/NetworkOptimizer.Storage/Models/MonitoringSettings.cs
@@ -108,6 +108,18 @@ public class MonitoringSettings
     public double? SwitchTempHighC { get; set; }
     public double? GatewayTempHighC { get; set; }
 
+    // User-configurable SFP DDM alert thresholds, per transceiver category. Null
+    // means use the built-in default (PonThresholds). PON and Active Ethernet
+    // modules have well-defined optical envelopes (RX low / TX high); generic SFP+
+    // only gets a temperature ceiling. See SfpDdmThresholds for resolution.
+    public double? PonRxPowerLowDbm { get; set; }
+    public double? PonTxPowerHighDbm { get; set; }
+    public double? PonTempHighC { get; set; }
+    public double? AeRxPowerLowDbm { get; set; }
+    public double? AeTxPowerHighDbm { get; set; }
+    public double? AeTempHighC { get; set; }
+    public double? SfpTempHighGenericC { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 

--- a/src/NetworkOptimizer.Storage/Models/MonitoringSettings.cs
+++ b/src/NetworkOptimizer.Storage/Models/MonitoringSettings.cs
@@ -102,6 +102,12 @@ public class MonitoringSettings
 
     public bool Flex25GLatencyMigrated { get; set; }
 
+    // User-configurable high-temperature alert thresholds (Celsius). Null means
+    // use the built-in default (DeviceHealthAlertEvaluator.DefaultDeviceTempHighC).
+    // Switches and gateways are configured independently.
+    public double? SwitchTempHighC { get; set; }
+    public double? GatewayTempHighC { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -508,12 +508,12 @@ else
                     <div class="form-group">
                         <label class="form-label">Switch high temperature (&deg;C)</label>
                         <input type="number" class="form-control" min="40" max="120" step="1"
-                               placeholder="@DefaultTempPlaceholder" @bind="_switchTempThresholdInput" />
+                               placeholder="@DefaultTempPlaceholder" @bind="_switchTempThresholdInput" @bind:after="ResetThresholdSavedFlags" />
                     </div>
                     <div class="form-group">
                         <label class="form-label">Gateway high temperature (&deg;C)</label>
                         <input type="number" class="form-control" min="40" max="120" step="1"
-                               placeholder="@DefaultTempPlaceholder" @bind="_gatewayTempThresholdInput" />
+                               placeholder="@DefaultTempPlaceholder" @bind="_gatewayTempThresholdInput" @bind:after="ResetThresholdSavedFlags" />
                     </div>
                 </div>
                 <div class="input-with-button" style="margin-top: 1rem;">
@@ -636,17 +636,17 @@ else
                     <div class="form-group">
                         <label class="form-label">Temperature high (&deg;C)</label>
                         <input type="number" class="form-control" min="40" max="120" step="1"
-                               placeholder="@PhPonTemp" @bind="_sfpPonTemp" />
+                               placeholder="@PhPonTemp" @bind="_sfpPonTemp" @bind:after="ResetThresholdSavedFlags" />
                     </div>
                     <div class="form-group">
                         <label class="form-label">RX power low (dBm)</label>
                         <input type="number" class="form-control" min="-40" max="0" step="0.1"
-                               placeholder="@PhPonRx" @bind="_sfpPonRx" />
+                               placeholder="@PhPonRx" @bind="_sfpPonRx" @bind:after="ResetThresholdSavedFlags" />
                     </div>
                     <div class="form-group">
                         <label class="form-label">TX power high (dBm)</label>
                         <input type="number" class="form-control" min="-10" max="20" step="0.1"
-                               placeholder="@PhPonTx" @bind="_sfpPonTx" />
+                               placeholder="@PhPonTx" @bind="_sfpPonTx" @bind:after="ResetThresholdSavedFlags" />
                     </div>
                 </div>
 
@@ -655,17 +655,17 @@ else
                     <div class="form-group">
                         <label class="form-label">Temperature high (&deg;C)</label>
                         <input type="number" class="form-control" min="40" max="120" step="1"
-                               placeholder="@PhAeTemp" @bind="_sfpAeTemp" />
+                               placeholder="@PhAeTemp" @bind="_sfpAeTemp" @bind:after="ResetThresholdSavedFlags" />
                     </div>
                     <div class="form-group">
                         <label class="form-label">RX power low (dBm)</label>
                         <input type="number" class="form-control" min="-40" max="0" step="0.1"
-                               placeholder="@PhAeRx" @bind="_sfpAeRx" />
+                               placeholder="@PhAeRx" @bind="_sfpAeRx" @bind:after="ResetThresholdSavedFlags" />
                     </div>
                     <div class="form-group">
                         <label class="form-label">TX power high (dBm)</label>
                         <input type="number" class="form-control" min="-10" max="20" step="0.1"
-                               placeholder="@PhAeTx" @bind="_sfpAeTx" />
+                               placeholder="@PhAeTx" @bind="_sfpAeTx" @bind:after="ResetThresholdSavedFlags" />
                     </div>
                 </div>
 
@@ -674,7 +674,7 @@ else
                     <div class="form-group">
                         <label class="form-label">Temperature high (&deg;C)</label>
                         <input type="number" class="form-control" min="40" max="120" step="1"
-                               placeholder="@PhGenericTemp" @bind="_sfpGenericTemp" />
+                               placeholder="@PhGenericTemp" @bind="_sfpGenericTemp" @bind:after="ResetThresholdSavedFlags" />
                     </div>
                 </div>
                 <p class="form-help">Generic SFP+ modules have no standard optical envelope, so only a temperature ceiling is checked.</p>
@@ -1397,6 +1397,7 @@ else
             if (!confirmed) return;
         }
         _activeTab = tab;
+        ResetThresholdSavedFlags();
         var uri = "/monitoring?tab=" + tab;
         NavigationManager.NavigateTo(uri, forceLoad: false, replace: false);
         _lastTabParam = tab;
@@ -1422,6 +1423,7 @@ else
             if (newTab != _activeTab)
             {
                 _activeTab = newTab;
+                ResetThresholdSavedFlags();
                 StateHasChanged();
             }
         }
@@ -1591,6 +1593,14 @@ else
     private bool _tempThresholdsSaved;
     private bool _deviceTempCollapsed = true;
     private bool _sfpThresholdsCollapsed = true;
+
+    // Clear the transient "Saved" confirmations so they don't linger after the
+    // user edits a field or navigates back into the tab.
+    private void ResetThresholdSavedFlags()
+    {
+        _tempThresholdsSaved = false;
+        _sfpThresholdsSaved = false;
+    }
 
     private static string DefaultTempPlaceholder =>
         NetworkOptimizer.Web.Services.Monitoring.DeviceHealthAlertEvaluator.DefaultDeviceTempHighC.ToString("0");

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -612,6 +612,76 @@ else
                 }
             </div>
         </div>
+
+        <div class="card" style="margin-top: 1.5rem;">
+            <div class="card-header">
+                <h2 class="card-title">SFP Alert Thresholds</h2>
+            </div>
+            <div class="card-body">
+                <p class="page-description">
+                    Thresholds for the <a href="/alerts?tab=rules">SFP temperature and power</a> alerts, per transceiver type.
+                    Leave a field blank to use the built-in default. The type of each module is set on its row in the table above.
+                </p>
+
+                <h3 class="chart-title" style="margin-top: 0.5rem;">PON</h3>
+                <div class="threshold-fields">
+                    <div class="form-group">
+                        <label class="form-label">Temperature high (&deg;C)</label>
+                        <input type="number" class="form-control" min="40" max="120" step="1"
+                               placeholder="@PhPonTemp" @bind="_sfpPonTemp" />
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">RX power low (dBm)</label>
+                        <input type="number" class="form-control" min="-40" max="0" step="0.1"
+                               placeholder="@PhPonRx" @bind="_sfpPonRx" />
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">TX power high (dBm)</label>
+                        <input type="number" class="form-control" min="-10" max="20" step="0.1"
+                               placeholder="@PhPonTx" @bind="_sfpPonTx" />
+                    </div>
+                </div>
+
+                <h3 class="chart-title" style="margin-top: 1rem;">Active Ethernet</h3>
+                <div class="threshold-fields">
+                    <div class="form-group">
+                        <label class="form-label">Temperature high (&deg;C)</label>
+                        <input type="number" class="form-control" min="40" max="120" step="1"
+                               placeholder="@PhAeTemp" @bind="_sfpAeTemp" />
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">RX power low (dBm)</label>
+                        <input type="number" class="form-control" min="-40" max="0" step="0.1"
+                               placeholder="@PhAeRx" @bind="_sfpAeRx" />
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">TX power high (dBm)</label>
+                        <input type="number" class="form-control" min="-10" max="20" step="0.1"
+                               placeholder="@PhAeTx" @bind="_sfpAeTx" />
+                    </div>
+                </div>
+
+                <h3 class="chart-title" style="margin-top: 1rem;">Generic SFP+</h3>
+                <div class="threshold-fields">
+                    <div class="form-group">
+                        <label class="form-label">Temperature high (&deg;C)</label>
+                        <input type="number" class="form-control" min="40" max="120" step="1"
+                               placeholder="@PhGenericTemp" @bind="_sfpGenericTemp" />
+                    </div>
+                </div>
+                <p class="form-help">Generic SFP+ modules have no standard optical envelope, so only a temperature ceiling is checked.</p>
+
+                <div class="input-with-button" style="margin-top: 1rem;">
+                    <button class="btn btn-primary btn-sm" @onclick="SaveSfpThresholdsAsync" disabled="@_savingSfpThresholds">
+                        @(_savingSfpThresholds ? "Saving..." : "Save thresholds")
+                    </button>
+                    @if (_sfpThresholdsSaved)
+                    {
+                        <span class="form-help signal-good" style="align-self: center;">Saved</span>
+                    }
+                </div>
+            </div>
+        </div>
     }
 
     @* ──────────────── Tab: CM Stats ──────────────── *@
@@ -1408,6 +1478,7 @@ else
         LoadInfluxStateFromSettings(settings);
         _switchTempThresholdInput = settings.SwitchTempHighC;
         _gatewayTempThresholdInput = settings.GatewayTempHighC;
+        LoadSfpThresholdInputs(settings);
         await LoadTargetsAsync();
 
         var cmConfigs = await CmMonitorService.GetConfigsAsync();
@@ -1537,6 +1608,66 @@ else
         finally
         {
             _savingTempThresholds = false;
+            StateHasChanged();
+        }
+    }
+
+    private static readonly NetworkOptimizer.Web.Services.Monitoring.SfpDdmThresholds _sfpDefaults
+        = NetworkOptimizer.Web.Services.Monitoring.SfpDdmThresholds.Defaults;
+
+    private double? _sfpPonTemp, _sfpPonRx, _sfpPonTx;
+    private double? _sfpAeTemp, _sfpAeRx, _sfpAeTx;
+    private double? _sfpGenericTemp;
+    private bool _savingSfpThresholds;
+    private bool _sfpThresholdsSaved;
+
+    private string PhPonTemp => _sfpDefaults.PonTempHighC.ToString("0");
+    private string PhPonRx => _sfpDefaults.PonRxPowerLowDbm.ToString("0.#");
+    private string PhPonTx => _sfpDefaults.PonTxPowerHighDbm.ToString("0.#");
+    private string PhAeTemp => _sfpDefaults.AeTempHighC.ToString("0");
+    private string PhAeRx => _sfpDefaults.AeRxPowerLowDbm.ToString("0.#");
+    private string PhAeTx => _sfpDefaults.AeTxPowerHighDbm.ToString("0.#");
+    private string PhGenericTemp => _sfpDefaults.SfpTempHighGenericC.ToString("0");
+
+    private void LoadSfpThresholdInputs(MonitoringSettings settings)
+    {
+        _sfpPonTemp = settings.PonTempHighC;
+        _sfpPonRx = settings.PonRxPowerLowDbm;
+        _sfpPonTx = settings.PonTxPowerHighDbm;
+        _sfpAeTemp = settings.AeTempHighC;
+        _sfpAeRx = settings.AeRxPowerLowDbm;
+        _sfpAeTx = settings.AeTxPowerHighDbm;
+        _sfpGenericTemp = settings.SfpTempHighGenericC;
+    }
+
+    private async Task SaveSfpThresholdsAsync()
+    {
+        _savingSfpThresholds = true;
+        _sfpThresholdsSaved = false;
+        StateHasChanged();
+        try
+        {
+            await using var db = await DbFactory.CreateDbContextAsync();
+            var settings = await db.MonitoringSettings.FirstOrDefaultAsync()
+                ?? new MonitoringSettings();
+            if (settings.Id == 0) db.MonitoringSettings.Add(settings);
+            // Temperature must be positive; power thresholds may legitimately be
+            // negative (RX low) so a blank field (null) is the only "use default".
+            settings.PonTempHighC = NormalizeTempThreshold(_sfpPonTemp);
+            settings.PonRxPowerLowDbm = _sfpPonRx;
+            settings.PonTxPowerHighDbm = _sfpPonTx;
+            settings.AeTempHighC = NormalizeTempThreshold(_sfpAeTemp);
+            settings.AeRxPowerLowDbm = _sfpAeRx;
+            settings.AeTxPowerHighDbm = _sfpAeTx;
+            settings.SfpTempHighGenericC = NormalizeTempThreshold(_sfpGenericTemp);
+            settings.UpdatedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync();
+            LoadSfpThresholdInputs(settings);
+            _sfpThresholdsSaved = true;
+        }
+        finally
+        {
+            _savingSfpThresholds = false;
             StateHasChanged();
         }
     }

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -493,15 +493,18 @@ else
         </div>
 
         <div class="card" style="margin-top: 1rem;">
-            <div class="card-header">
+            <div class="card-header card-header-collapsible" @onclick="() => _deviceTempCollapsed = !_deviceTempCollapsed">
                 <h2 class="card-title">Temperature Alert Thresholds</h2>
+                <span class="issue-type-chevron">@(_deviceTempCollapsed ? "▼" : "▲")</span>
             </div>
+            <div class="expand-wrapper @(!_deviceTempCollapsed ? "expanded" : "")">
+            <div class="expand-content">
             <div class="card-body">
                 <p class="page-description">
                     Raise a <a href="/alerts?tab=rules">Device: Temperature High</a> alert when a device runs above these limits.
                     Leave blank to use the default of @DefaultTempPlaceholder&deg;C. Hot-running models (e.g. high-PoE switches) may need a higher value to avoid noise.
                 </p>
-                <div class="threshold-fields">
+                <div class="threshold-fields" style="margin-top: 0.75rem;">
                     <div class="form-group">
                         <label class="form-label">Switch high temperature (&deg;C)</label>
                         <input type="number" class="form-control" min="40" max="120" step="1"
@@ -522,6 +525,8 @@ else
                         <span class="form-help signal-good" style="align-self: center;">Saved</span>
                     }
                 </div>
+            </div>
+            </div>
             </div>
         </div>
     }
@@ -614,16 +619,19 @@ else
         </div>
 
         <div class="card" style="margin-top: 1.5rem;">
-            <div class="card-header">
+            <div class="card-header card-header-collapsible" @onclick="() => _sfpThresholdsCollapsed = !_sfpThresholdsCollapsed">
                 <h2 class="card-title">SFP Alert Thresholds</h2>
+                <span class="issue-type-chevron">@(_sfpThresholdsCollapsed ? "▼" : "▲")</span>
             </div>
+            <div class="expand-wrapper @(!_sfpThresholdsCollapsed ? "expanded" : "")">
+            <div class="expand-content">
             <div class="card-body">
                 <p class="page-description">
                     Thresholds for the <a href="/alerts?tab=rules">SFP temperature and power</a> alerts, per transceiver type.
                     Leave a field blank to use the built-in default. The type of each module is set on its row in the table above.
                 </p>
 
-                <h3 class="chart-title" style="margin-top: 0.5rem;">PON</h3>
+                <h3 class="chart-title" style="margin-top: 0.75rem;">PON</h3>
                 <div class="threshold-fields">
                     <div class="form-group">
                         <label class="form-label">Temperature high (&deg;C)</label>
@@ -680,6 +688,8 @@ else
                         <span class="form-help signal-good" style="align-self: center;">Saved</span>
                     }
                 </div>
+            </div>
+            </div>
             </div>
         </div>
     }
@@ -1579,6 +1589,8 @@ else
     private double? _gatewayTempThresholdInput;
     private bool _savingTempThresholds;
     private bool _tempThresholdsSaved;
+    private bool _deviceTempCollapsed = true;
+    private bool _sfpThresholdsCollapsed = true;
 
     private static string DefaultTempPlaceholder =>
         NetworkOptimizer.Web.Services.Monitoring.DeviceHealthAlertEvaluator.DefaultDeviceTempHighC.ToString("0");

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -491,6 +491,39 @@ else
                 </details>
             </div>
         </div>
+
+        <div class="card" style="margin-top: 1rem;">
+            <div class="card-header">
+                <h2 class="card-title">Temperature Alert Thresholds</h2>
+            </div>
+            <div class="card-body">
+                <p class="page-description">
+                    Raise a <a href="/alerts?tab=rules">Device: Temperature High</a> alert when a device runs above these limits.
+                    Leave blank to use the default of @DefaultTempPlaceholder&deg;C. Hot-running models (e.g. high-PoE switches) may need a higher value to avoid noise.
+                </p>
+                <div class="threshold-fields">
+                    <div class="form-group">
+                        <label class="form-label">Switch high temperature (&deg;C)</label>
+                        <input type="number" class="form-control" min="40" max="120" step="1"
+                               placeholder="@DefaultTempPlaceholder" @bind="_switchTempThresholdInput" />
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Gateway high temperature (&deg;C)</label>
+                        <input type="number" class="form-control" min="40" max="120" step="1"
+                               placeholder="@DefaultTempPlaceholder" @bind="_gatewayTempThresholdInput" />
+                    </div>
+                </div>
+                <div class="input-with-button" style="margin-top: 1rem;">
+                    <button class="btn btn-primary btn-sm" @onclick="SaveTempThresholdsAsync" disabled="@_savingTempThresholds">
+                        @(_savingTempThresholds ? "Saving..." : "Save thresholds")
+                    </button>
+                    @if (_tempThresholdsSaved)
+                    {
+                        <span class="form-help signal-good" style="align-self: center;">Saved</span>
+                    }
+                </div>
+            </div>
+        </div>
     }
 
     @* ──────────────── Tab: SFP Stats ──────────────── *@
@@ -1373,6 +1406,8 @@ else
         var settings = await SnmpDetection.GetOrCreateSettingsAsync();
         _snmpState = settings.SnmpDetectionState;
         LoadInfluxStateFromSettings(settings);
+        _switchTempThresholdInput = settings.SwitchTempHighC;
+        _gatewayTempThresholdInput = settings.GatewayTempHighC;
         await LoadTargetsAsync();
 
         var cmConfigs = await CmMonitorService.GetConfigsAsync();
@@ -1467,6 +1502,43 @@ else
         _influxReachable = health.Reachable;
         _influxError = health.Error;
         StateHasChanged();
+    }
+
+    private double? _switchTempThresholdInput;
+    private double? _gatewayTempThresholdInput;
+    private bool _savingTempThresholds;
+    private bool _tempThresholdsSaved;
+
+    private static string DefaultTempPlaceholder =>
+        NetworkOptimizer.Web.Services.Monitoring.DeviceHealthAlertEvaluator.DefaultDeviceTempHighC.ToString("0");
+
+    // Blank/zero/negative entries mean "use the built-in default" (stored as null).
+    private static double? NormalizeTempThreshold(double? value) => value is > 0 ? value : null;
+
+    private async Task SaveTempThresholdsAsync()
+    {
+        _savingTempThresholds = true;
+        _tempThresholdsSaved = false;
+        StateHasChanged();
+        try
+        {
+            await using var db = await DbFactory.CreateDbContextAsync();
+            var settings = await db.MonitoringSettings.FirstOrDefaultAsync()
+                ?? new MonitoringSettings();
+            if (settings.Id == 0) db.MonitoringSettings.Add(settings);
+            settings.SwitchTempHighC = NormalizeTempThreshold(_switchTempThresholdInput);
+            settings.GatewayTempHighC = NormalizeTempThreshold(_gatewayTempThresholdInput);
+            settings.UpdatedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync();
+            _switchTempThresholdInput = settings.SwitchTempHighC;
+            _gatewayTempThresholdInput = settings.GatewayTempHighC;
+            _tempThresholdsSaved = true;
+        }
+        finally
+        {
+            _savingTempThresholds = false;
+            StateHasChanged();
+        }
     }
 
     private async Task SetMonitoringEnabled(bool enabled)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/DeviceHealthAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/DeviceHealthAlertEvaluator.cs
@@ -10,6 +10,9 @@ namespace NetworkOptimizer.Web.Services.Monitoring;
 /// (~2.5-5 minutes at typical poll intervals) to avoid alerting on transient
 /// spikes. Memory is evaluated per-sample since sustained high memory is
 /// immediately actionable.
+///
+/// Temperature is evaluated for gateways and switches against a user-configurable
+/// high threshold (per device type, falling back to <see cref="DefaultDeviceTempHighC"/>).
 /// </summary>
 public class DeviceHealthAlertEvaluator
 {
@@ -18,6 +21,13 @@ public class DeviceHealthAlertEvaluator
     private const double CpuClearThresholdPercent = 55.0;
     private const double MemoryHighThresholdPercent = 95.0;
     private const double MemoryClearThresholdPercent = 85.0;
+
+    /// <summary>Default high-temperature alert threshold (Celsius) when the user hasn't set one.</summary>
+    public const double DefaultDeviceTempHighC = 85.0;
+
+    // Temperature must drop this far below the threshold before the alert re-arms,
+    // preventing flapping for devices hovering near their limit.
+    private const double TempClearMarginC = 5.0;
 
     private readonly IAlertEventBus _eventBus;
     private readonly ILogger<DeviceHealthAlertEvaluator> _logger;
@@ -32,15 +42,20 @@ public class DeviceHealthAlertEvaluator
     public async ValueTask EvaluateAsync(
         string deviceMac, string? deviceName, string deviceType,
         double? cpuPercent, double? memoryUsedPercent,
+        double? temperatureC = null, double? tempHighThresholdC = null,
         CancellationToken ct = default)
     {
-        if (!string.Equals(deviceType, "gateway", StringComparison.OrdinalIgnoreCase))
+        var isGateway = string.Equals(deviceType, "gateway", StringComparison.OrdinalIgnoreCase);
+        var isSwitch = string.Equals(deviceType, "switch", StringComparison.OrdinalIgnoreCase);
+
+        // CPU and memory alerting is gateway-only; temperature covers gateways and switches.
+        if (!isGateway && !isSwitch)
             return;
 
         var state = _states.GetOrAdd(deviceMac, _ => new DeviceHealthState());
         var label = deviceName ?? deviceMac;
 
-        if (cpuPercent.HasValue)
+        if (isGateway && cpuPercent.HasValue)
         {
             state.CpuWindow.Enqueue(cpuPercent.Value);
             while (state.CpuWindow.Count > CpuWindowSize) state.CpuWindow.Dequeue();
@@ -65,7 +80,7 @@ public class DeviceHealthAlertEvaluator
                         DeviceName = deviceName,
                         MetricValue = avg,
                         ThresholdValue = CpuHighThresholdPercent,
-                        SourceUrl = "/monitoring?tab=health",
+                        SourceUrl = "/monitoring?tab=devices",
                         Tags = ["device", "gateway", "cpu"],
                         Context = new Dictionary<string, string>
                         {
@@ -82,7 +97,7 @@ public class DeviceHealthAlertEvaluator
             }
         }
 
-        if (memoryUsedPercent.HasValue)
+        if (isGateway && memoryUsedPercent.HasValue)
         {
             if (!state.MemoryBreached && memoryUsedPercent.Value >= MemoryHighThresholdPercent)
             {
@@ -100,7 +115,7 @@ public class DeviceHealthAlertEvaluator
                     DeviceName = deviceName,
                     MetricValue = memoryUsedPercent.Value,
                     ThresholdValue = MemoryHighThresholdPercent,
-                    SourceUrl = "/monitoring?tab=health",
+                    SourceUrl = "/monitoring?tab=devices",
                     Tags = ["device", "gateway", "memory"],
                     Context = new Dictionary<string, string>
                     {
@@ -115,6 +130,44 @@ public class DeviceHealthAlertEvaluator
                 state.MemoryBreached = false;
             }
         }
+
+        if (temperatureC.HasValue)
+        {
+            var threshold = tempHighThresholdC ?? DefaultDeviceTempHighC;
+            var typeLabel = isGateway ? "Gateway" : "Switch";
+
+            if (!state.TempBreached && temperatureC.Value >= threshold)
+            {
+                state.TempBreached = true;
+                _logger.LogDebug("Device temperature threshold breached: {DeviceMac} temp={Temp:0.#}C threshold={Threshold:0.#}C",
+                    deviceMac, temperatureC.Value, threshold);
+
+                await _eventBus.PublishAsync(new AlertEvent
+                {
+                    EventType = "device.high_temperature",
+                    Source = "device",
+                    Severity = AlertSeverity.Warning,
+                    Title = $"{label} temperature high",
+                    Message = $"{typeLabel} {label} temperature at {temperatureC.Value:0.#} C, exceeding the {threshold:0.#} C threshold.",
+                    DeviceId = deviceMac,
+                    DeviceName = deviceName,
+                    MetricValue = temperatureC.Value,
+                    ThresholdValue = threshold,
+                    SourceUrl = "/monitoring?tab=devices",
+                    Tags = ["device", deviceType, "temperature"],
+                    Context = new Dictionary<string, string>
+                    {
+                        ["device_mac"] = deviceMac,
+                        ["device_type"] = deviceType,
+                        ["metric"] = "temperature_c"
+                    }
+                }, ct);
+            }
+            else if (state.TempBreached && temperatureC.Value <= threshold - TempClearMarginC)
+            {
+                state.TempBreached = false;
+            }
+        }
     }
 
     private class DeviceHealthState
@@ -122,5 +175,6 @@ public class DeviceHealthAlertEvaluator
         public Queue<double> CpuWindow { get; } = new();
         public bool CpuBreached;
         public bool MemoryBreached;
+        public bool TempBreached;
     }
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringAlertEvaluator.cs
@@ -97,7 +97,7 @@ public class MonitoringAlertEvaluator
         DeviceId = target.DeviceMac,
         DeviceName = target.Name,
         DeviceIp = target.Address,
-        SourceUrl = "/monitoring",
+        SourceUrl = "/monitoring?tab=performance",
         Tags = ["monitoring", target.TargetType.ToString().ToLowerInvariant()],
         Context = new Dictionary<string, string>
         {
@@ -118,7 +118,7 @@ public class MonitoringAlertEvaluator
         DeviceName = target.Name,
         DeviceIp = target.Address,
         MetricValue = result.RttAvgMs,
-        SourceUrl = "/monitoring",
+        SourceUrl = "/monitoring?tab=performance",
         Tags = ["monitoring", target.TargetType.ToString().ToLowerInvariant()],
         Context = new Dictionary<string, string>
         {
@@ -139,7 +139,7 @@ public class MonitoringAlertEvaluator
         DeviceIp = target.Address,
         MetricValue = avgLossPercent,
         ThresholdValue = SustainedLossThresholdPercent,
-        SourceUrl = "/monitoring",
+        SourceUrl = "/monitoring?tab=performance",
         Tags = ["monitoring", "packet-loss", target.TargetType.ToString().ToLowerInvariant()],
         Context = new Dictionary<string, string>
         {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/PonThresholds.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/PonThresholds.cs
@@ -1,7 +1,11 @@
+using NetworkOptimizer.Storage.Models;
+
 namespace NetworkOptimizer.Web.Services.Monitoring;
 
 /// <summary>
-/// Single source-of-truth for PON and SFP optical thresholds.
+/// Single source-of-truth for the default PON and SFP optical thresholds. These
+/// are the fallbacks used when the user hasn't overridden a value; the effective
+/// thresholds are resolved by <see cref="SfpDdmThresholds"/>.
 /// </summary>
 public static class PonThresholds
 {
@@ -21,4 +25,39 @@ public static class PonThresholds
 
     // --- Generic SFP thresholds ---
     public const double SfpTempHighGenericC = 87.0;
+}
+
+/// <summary>
+/// Effective SFP DDM alert thresholds, per transceiver category. Each value falls
+/// back to its <see cref="PonThresholds"/> default when the user hasn't set an
+/// override in <see cref="MonitoringSettings"/>.
+/// </summary>
+public sealed record SfpDdmThresholds(
+    double PonRxPowerLowDbm,
+    double PonTxPowerHighDbm,
+    double PonTempHighC,
+    double AeRxPowerLowDbm,
+    double AeTxPowerHighDbm,
+    double AeTempHighC,
+    double SfpTempHighGenericC)
+{
+    /// <summary>The built-in defaults, used when no monitoring settings exist.</summary>
+    public static SfpDdmThresholds Defaults { get; } = new(
+        PonThresholds.PonRxPowerLowDbm,
+        PonThresholds.PonTxPowerHighDbm,
+        PonThresholds.PonTempHighC,
+        PonThresholds.AeRxPowerLowDbm,
+        PonThresholds.AeTxPowerHighDbm,
+        PonThresholds.AeTempHighC,
+        PonThresholds.SfpTempHighGenericC);
+
+    /// <summary>Resolves effective thresholds from settings, defaulting any unset value.</summary>
+    public static SfpDdmThresholds FromSettings(MonitoringSettings s) => new(
+        s.PonRxPowerLowDbm ?? PonThresholds.PonRxPowerLowDbm,
+        s.PonTxPowerHighDbm ?? PonThresholds.PonTxPowerHighDbm,
+        s.PonTempHighC ?? PonThresholds.PonTempHighC,
+        s.AeRxPowerLowDbm ?? PonThresholds.AeRxPowerLowDbm,
+        s.AeTxPowerHighDbm ?? PonThresholds.AeTxPowerHighDbm,
+        s.AeTempHighC ?? PonThresholds.AeTempHighC,
+        s.SfpTempHighGenericC ?? PonThresholds.SfpTempHighGenericC);
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/SfpAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/SfpAlertEvaluator.cs
@@ -12,16 +12,6 @@ namespace NetworkOptimizer.Web.Services.Monitoring;
 /// </summary>
 public class SfpAlertEvaluator
 {
-    private const double PonRxPowerLowDbm = PonThresholds.PonRxPowerLowDbm;
-    private const double PonTxPowerHighDbm = PonThresholds.PonTxPowerHighDbm;
-    private const double PonTempHighC = PonThresholds.PonTempHighC;
-
-    private const double AeRxPowerLowDbm = PonThresholds.AeRxPowerLowDbm;
-    private const double AeTxPowerHighDbm = PonThresholds.AeTxPowerHighDbm;
-    private const double AeTempHighC = PonThresholds.AeTempHighC;
-
-    private const double SfpTempHighC = PonThresholds.SfpTempHighGenericC;
-
     private const double TempHysteresisC = PonThresholds.TempHysteresisC;
     private const double PowerHysteresisDbm = PonThresholds.PowerHysteresisDbm;
 
@@ -39,6 +29,7 @@ public class SfpAlertEvaluator
         string deviceMac, string portName, string? deviceName,
         SfpCategory category,
         double? rxPowerDbm, double? txPowerDbm, double? temperatureC,
+        SfpDdmThresholds thresholds,
         CancellationToken ct = default)
     {
         var key = $"{deviceMac}:{portName}";
@@ -50,9 +41,9 @@ public class SfpAlertEvaluator
         {
             var threshold = category switch
             {
-                SfpCategory.Pon => PonTempHighC,
-                SfpCategory.ActiveEthernet => AeTempHighC,
-                _ => SfpTempHighC
+                SfpCategory.Pon => thresholds.PonTempHighC,
+                SfpCategory.ActiveEthernet => thresholds.AeTempHighC,
+                _ => thresholds.SfpTempHighGenericC
             };
             await CheckHighThreshold(state, "temp", temperatureC.Value, threshold, TempHysteresisC,
                 "monitoring.sfp_temperature",
@@ -63,7 +54,7 @@ public class SfpAlertEvaluator
 
         if (category != SfpCategory.Standard && rxPowerDbm.HasValue)
         {
-            var rxThreshold = category == SfpCategory.Pon ? PonRxPowerLowDbm : AeRxPowerLowDbm;
+            var rxThreshold = category == SfpCategory.Pon ? thresholds.PonRxPowerLowDbm : thresholds.AeRxPowerLowDbm;
             await CheckLowThreshold(state, "rx", rxPowerDbm.Value, rxThreshold, PowerHysteresisDbm,
                 "monitoring.sfp_rx_power",
                 $"{catLabel} RX power on {portLabel}",
@@ -73,7 +64,7 @@ public class SfpAlertEvaluator
 
         if (category != SfpCategory.Standard && txPowerDbm.HasValue)
         {
-            var txThreshold = category == SfpCategory.Pon ? PonTxPowerHighDbm : AeTxPowerHighDbm;
+            var txThreshold = category == SfpCategory.Pon ? thresholds.PonTxPowerHighDbm : thresholds.AeTxPowerHighDbm;
             await CheckHighThreshold(state, "tx", txPowerDbm.Value, txThreshold, PowerHysteresisDbm,
                 "monitoring.sfp_tx_power",
                 $"{catLabel} TX power on {portLabel}",

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -724,7 +724,9 @@ public class MonitoringCollectionAgent : BackgroundService
 
                 await _deviceHealthAlertEvaluator.EvaluateAsync(
                     device.Mac, device.Name, DescribeDeviceType(device.DeviceType),
-                    cpu, memPct);
+                    cpu, memPct,
+                    temperatureC: temp,
+                    tempHighThresholdC: ResolveTempThreshold(settings, device.DeviceType));
             }
             catch (Exception ex)
             {
@@ -786,7 +788,9 @@ public class MonitoringCollectionAgent : BackgroundService
 
                 await _deviceHealthAlertEvaluator.EvaluateAsync(
                     device.Mac, device.Name, DescribeDeviceType(device.DeviceType),
-                    cpu, mem);
+                    cpu, mem,
+                    temperatureC: temp,
+                    tempHighThresholdC: ResolveTempThreshold(settings, device.DeviceType));
             }
             catch (Exception ex)
             {
@@ -1892,6 +1896,13 @@ public class MonitoringCollectionAgent : BackgroundService
         NetworkOptimizer.Core.Enums.DeviceType.AccessPoint => "ap",
         _ => "unknown"
     };
+
+    // Per-device-type high-temperature alert threshold (Celsius). Null falls back to
+    // DeviceHealthAlertEvaluator.DefaultDeviceTempHighC inside the evaluator.
+    private static double? ResolveTempThreshold(MonitoringSettings settings, NetworkOptimizer.Core.Enums.DeviceType type) =>
+        type == NetworkOptimizer.Core.Enums.DeviceType.Gateway
+            ? settings.GatewayTempHighC
+            : settings.SwitchTempHighC;
 
     private void CollectSfpForDevice(
         UniFiDeviceResponse device,

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -885,7 +885,9 @@ public class MonitoringCollectionAgent : BackgroundService
             CollectSfpForDevice(device, db, existingSfps, nowSfp);
         }
 
-        // SFP threshold evaluation: check DDM values against alert thresholds.
+        // SFP threshold evaluation: check DDM values against alert thresholds
+        // (per-category, user-configurable with built-in fallbacks).
+        var sfpThresholds = NetworkOptimizer.Web.Services.Monitoring.SfpDdmThresholds.FromSettings(settings);
         foreach (var device in devices)
         {
             if (device.PortTable == null || device.PortTable.Count == 0) continue;
@@ -903,7 +905,7 @@ public class MonitoringCollectionAgent : BackgroundService
                 {
                     await _sfpAlertEvaluator.EvaluateAsync(
                         sfpMac, sfpPortName, device.Name, sfpCategory,
-                        port.SfpRxPower, port.SfpTxPower, port.SfpTemperature, ct);
+                        port.SfpRxPower, port.SfpTxPower, port.SfpTemperature, sfpThresholds, ct);
                 }
                 catch (Exception ex)
                 {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2334,6 +2334,18 @@ select.form-control {
     gap: 0.75rem;
 }
 
+.threshold-fields {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.threshold-fields .form-group {
+    flex: 1;
+    min-width: 180px;
+    margin-bottom: 0;
+}
+
 .input-with-button {
     display: flex;
     gap: 0.5rem;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2338,6 +2338,7 @@ select.form-control {
     display: flex;
     gap: 1rem;
     flex-wrap: wrap;
+    margin-top: 0.5rem;
 }
 
 .threshold-fields .form-group {


### PR DESCRIPTION
## Summary

Makes the previously hard-coded temperature and SFP alert thresholds user-configurable, and adds switch/gateway temperature alerting (which didn't exist before).

## Device temperature alerts (switches and gateways)

- New `Device: Temperature High` alert, enabled by default. Switches and gateways are evaluated against a configurable high-temperature threshold, defaulting to 85 C when unset.
- Thresholds are set independently per device type in **Monitoring -> Device Stats**. Hot-running models (e.g. high-PoE switches) can be given a higher limit to avoid noise.
- 5 C clearing margin so a device hovering near its limit doesn't flap.

## SFP threshold configurability

- The per-transceiver-type SFP DDM thresholds (PON, Active Ethernet, generic SFP+) are now editable in **Monitoring -> SFP Stats** instead of being hard-coded. PON and Active Ethernet expose temperature, RX-power-low, and TX-power-high; generic SFP+ exposes a temperature ceiling.
- Each field falls back to the existing built-in default when left blank, so behaviour is unchanged until a user overrides a value.

## Alert deep-link fixes

- Device CPU/memory alerts linked to a tab that doesn't exist; they now open **Monitoring -> Device Stats**.
- Latency-target alerts now deep-link to **Monitoring -> Network Performance** instead of the bare monitoring page.

## Storage

- Nine nullable columns added to `MonitoringSettings` (two device-temp, seven SFP DDM), with two additive EF migrations. Null means "use the built-in default", so existing installs are unaffected on upgrade.
