### PR TITLE
Wi-Fi Optimizer: auto-refresh the Overview tab when data goes stale

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -925,7 +925,11 @@
                     // full refresh so it picks everything up - health, APs, speed tests, signal
                     // data, and channel recommendations. RefreshData re-pulls it all, so skip the
                     // lighter speed/signal update this tick.
-                    if (_activeTab == "overview" && !_refreshing && _healthScore != null
+                    // Only when connected: RefreshData doesn't wait for the console, so firing it
+                    // mid-reconnect (e.g. during a deploy) would hang on a dead connection. On
+                    // reconnect, OnConnectionChanged -> LoadDataAsync does a connection-aware reload.
+                    if (_activeTab == "overview" && ConnectionService.IsConnected && !_refreshing
+                        && _healthScore != null
                         && DateTimeOffset.UtcNow - _healthScore.Timestamp >= HealthScoreStaleAfter)
                     {
                         await RefreshData();

--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -874,6 +874,11 @@
     private List<SignalMapPoint> _signalMapPoints = new();
     private List<ApMapMarker> _apMapMarkers = new();
     private System.Threading.Timer? _mapPollTimer;
+
+    // Auto-refresh the Overview tab once the health score has aged past this, so a parked
+    // tab doesn't show indefinitely stale data. Checked on each map-poll tick.
+    private static readonly TimeSpan HealthScoreStaleAfter = TimeSpan.FromMinutes(5);
+
     private int _signalTimeRangeHours = 168; // 1 week default, matches FloorPlanEditor slider
     private int _speedTestTimeRangeHours = 720; // 30 days default, matches SpeedTestMap slider
 
@@ -915,6 +920,18 @@
             {
                 await InvokeAsync(async () =>
                 {
+                    // While the user sits on the Overview tab, the health score (and channel plan)
+                    // only refresh on load or manual refresh. Once the score goes stale, run the
+                    // full refresh so it picks everything up - health, APs, speed tests, signal
+                    // data, and channel recommendations. RefreshData re-pulls it all, so skip the
+                    // lighter speed/signal update this tick.
+                    if (_activeTab == "overview" && !_refreshing && _healthScore != null
+                        && DateTimeOffset.UtcNow - _healthScore.Timestamp >= HealthScoreStaleAfter)
+                    {
+                        await RefreshData();
+                        return;
+                    }
+
                     var now = DateTime.UtcNow;
                     var speedTestTask = SpeedTestService.GetResultsAsync(count: 0, hours: _speedTestTimeRangeHours);
                     var signalTask = DashboardService.GetSignalMapPointsAsync(

--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -877,7 +877,7 @@
 
     // Auto-refresh the Overview tab once the health score has aged past this, so a parked
     // tab doesn't show indefinitely stale data. Checked on each map-poll tick.
-    private static readonly TimeSpan HealthScoreStaleAfter = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan HealthScoreStaleAfter = TimeSpan.FromMinutes(1);
 
     private int _signalTimeRangeHours = 168; // 1 week default, matches FloorPlanEditor slider
     private int _speedTestTimeRangeHours = 720; // 30 days default, matches SpeedTestMap slider


### PR DESCRIPTION
## What

The Wi-Fi Optimizer Overview tab now refreshes itself once its data ages past one minute, instead of only updating on page load, manual refresh, or reconnect.

While a viewer sits on the tab, each poll tick checks the site health score's age. Once it passes the staleness window, a full refresh runs and picks everything up: health score, access points, speed test results, signal data, and channel recommendations.

## Why

Previously, leaving the Overview tab open showed a snapshot frozen at load time. The health score and channel optimization status could be many minutes old with no indication, since the only background poll updated speed-test and signal-map data.

## Notes

- The refresh only fires while the user is actually on the Overview tab, so nobody pays for it unless they're viewing it.
- It's gated on an active UniFi Console connection. `RefreshData` doesn't wait for the console, so firing it mid-reconnect would hang on a dead connection; reconnects are instead handled by the existing connection-changed reload, which waits for the console first.
- Self-throttling: a successful refresh stamps a fresh timestamp, so the next one is at least a minute out, and an in-flight refresh blocks overlapping runs.
