### PR TITLE
v1.23.0 Release Changes

### DIFF
--- a/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
+++ b/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
@@ -240,6 +240,16 @@ public static class DefaultAlertRules
             ThresholdPercent = 95,
             CooldownSeconds = 1800 // 30 minutes
         },
+        new AlertRule
+        {
+            // Threshold (Celsius) is configured per device type in Monitoring -> Device Stats.
+            Name = "Device: Temperature High",
+            IsEnabled = true,
+            EventTypePattern = "device.high_temperature",
+            Source = "device",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 1800 // 30 minutes
+        },
 
         // --- Cable modem (disabled until user configures a cable modem) ---
         new AlertRule

--- a/src/NetworkOptimizer.Storage/Migrations/20260624182049_AddDeviceTempThresholds.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260624182049_AddDeviceTempThresholds.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260624182049_AddDeviceTempThresholds")]
+    partial class AddDeviceTempThresholds
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");
@@ -1525,15 +1528,6 @@ namespace NetworkOptimizer.Storage.Migrations
                     b.Property<int>("AccessTechnology")
                         .HasColumnType("INTEGER");
 
-                    b.Property<double?>("AeRxPowerLowDbm")
-                        .HasColumnType("REAL");
-
-                    b.Property<double?>("AeTempHighC")
-                        .HasColumnType("REAL");
-
-                    b.Property<double?>("AeTxPowerHighDbm")
-                        .HasColumnType("REAL");
-
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("TEXT");
 
@@ -1594,18 +1588,6 @@ namespace NetworkOptimizer.Storage.Migrations
 
                     b.Property<int>("MediumPollIntervalSeconds")
                         .HasColumnType("INTEGER");
-
-                    b.Property<double?>("PonRxPowerLowDbm")
-                        .HasColumnType("REAL");
-
-                    b.Property<double?>("PonTempHighC")
-                        .HasColumnType("REAL");
-
-                    b.Property<double?>("PonTxPowerHighDbm")
-                        .HasColumnType("REAL");
-
-                    b.Property<double?>("SfpTempHighGenericC")
-                        .HasColumnType("REAL");
 
                     b.Property<int>("SlowPollIntervalSeconds")
                         .HasColumnType("INTEGER");

--- a/src/NetworkOptimizer.Storage/Migrations/20260624182049_AddDeviceTempThresholds.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260624182049_AddDeviceTempThresholds.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDeviceTempThresholds : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "GatewayTempHighC",
+                table: "MonitoringSettings",
+                type: "REAL",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "SwitchTempHighC",
+                table: "MonitoringSettings",
+                type: "REAL",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "GatewayTempHighC",
+                table: "MonitoringSettings");
+
+            migrationBuilder.DropColumn(
+                name: "SwitchTempHighC",
+                table: "MonitoringSettings");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Migrations/20260624183353_AddSfpDdmThresholds.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260624183353_AddSfpDdmThresholds.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260624183353_AddSfpDdmThresholds")]
+    partial class AddSfpDdmThresholds
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260624183353_AddSfpDdmThresholds.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260624183353_AddSfpDdmThresholds.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSfpDdmThresholds : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "AeRxPowerLowDbm",
+                table: "MonitoringSettings",
+                type: "REAL",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "AeTempHighC",
+                table: "MonitoringSettings",
+                type: "REAL",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "AeTxPowerHighDbm",
+                table: "MonitoringSettings",
+                type: "REAL",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "PonRxPowerLowDbm",
+                table: "MonitoringSettings",
+                type: "REAL",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "PonTempHighC",
+                table: "MonitoringSettings",
+                type: "REAL",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "PonTxPowerHighDbm",
+                table: "MonitoringSettings",
+                type: "REAL",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "SfpTempHighGenericC",
+                table: "MonitoringSettings",
+                type: "REAL",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AeRxPowerLowDbm",
+                table: "MonitoringSettings");
+
+            migrationBuilder.DropColumn(
+                name: "AeTempHighC",
+                table: "MonitoringSettings");
+
+            migrationBuilder.DropColumn(
+                name: "AeTxPowerHighDbm",
+                table: "MonitoringSettings");
+
+            migrationBuilder.DropColumn(
+                name: "PonRxPowerLowDbm",
+                table: "MonitoringSettings");
+
+            migrationBuilder.DropColumn(
+                name: "PonTempHighC",
+                table: "MonitoringSettings");
+
+            migrationBuilder.DropColumn(
+                name: "PonTxPowerHighDbm",
+                table: "MonitoringSettings");
+
+            migrationBuilder.DropColumn(
+                name: "SfpTempHighGenericC",
+                table: "MonitoringSettings");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/MonitoringSettings.cs
+++ b/src/NetworkOptimizer.Storage/Models/MonitoringSettings.cs
@@ -102,6 +102,24 @@ public class MonitoringSettings
 
     public bool Flex25GLatencyMigrated { get; set; }
 
+    // User-configurable high-temperature alert thresholds (Celsius). Null means
+    // use the built-in default (DeviceHealthAlertEvaluator.DefaultDeviceTempHighC).
+    // Switches and gateways are configured independently.
+    public double? SwitchTempHighC { get; set; }
+    public double? GatewayTempHighC { get; set; }
+
+    // User-configurable SFP DDM alert thresholds, per transceiver category. Null
+    // means use the built-in default (PonThresholds). PON and Active Ethernet
+    // modules have well-defined optical envelopes (RX low / TX high); generic SFP+
+    // only gets a temperature ceiling. See SfpDdmThresholds for resolution.
+    public double? PonRxPowerLowDbm { get; set; }
+    public double? PonTxPowerHighDbm { get; set; }
+    public double? PonTempHighC { get; set; }
+    public double? AeRxPowerLowDbm { get; set; }
+    public double? AeTxPowerHighDbm { get; set; }
+    public double? AeTempHighC { get; set; }
+    public double? SfpTempHighGenericC { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 

--- a/src/NetworkOptimizer.Storage/NetworkOptimizer.Storage.csproj
+++ b/src/NetworkOptimizer.Storage/NetworkOptimizer.Storage.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="NetworkOptimizer.Storage.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\NetworkOptimizer.Alerts\NetworkOptimizer.Alerts.csproj" />
     <ProjectReference Include="..\NetworkOptimizer.Core\NetworkOptimizer.Core.csproj" />
     <ProjectReference Include="..\NetworkOptimizer.Threats\NetworkOptimizer.Threats.csproj" />

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -1234,28 +1234,7 @@ from(bucket: ""{_bucket}"")
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
-        var results = new Dictionary<string, List<LatencySeriesPoint>>();
-        await foreach (var record in QueryFluxAsync(flux, ct))
-        {
-            var targetId = record.GetValueByKey("target_id") as string;
-            if (string.IsNullOrEmpty(targetId)) continue;
-            if (!results.TryGetValue(targetId, out var list))
-            {
-                list = new List<LatencySeriesPoint>();
-                results[targetId] = list;
-            }
-            list.Add(new LatencySeriesPoint
-            {
-                Time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow),
-                RttAvgMs = AsDoubleOrNull(record.GetValueByKey("rtt_avg_ms")),
-                RttMaxMs = AsDoubleOrNull(record.GetValueByKey("rtt_max_ms")),
-                JitterMs = AsDoubleOrNull(record.GetValueByKey("jitter_ms")),
-                LossPercent = AsDoubleOrNull(record.GetValueByKey("loss_percent"))
-            });
-        }
-        foreach (var list in results.Values)
-            list.Sort((a, b) => a.Time.CompareTo(b.Time));
-        return results;
+        return ParseLatencyDetailCsv(await QueryRawAsync(flux, ct));
     }
 
     /// <summary>
@@ -1281,18 +1260,9 @@ from(bucket: ""{_bucket}"")
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
-        var list = new List<LatencySeriesPoint>();
-        await foreach (var record in QueryFluxAsync(flux, ct))
-        {
-            list.Add(new LatencySeriesPoint
-            {
-                Time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow),
-                RttAvgMs = AsDoubleOrNull(record.GetValueByKey("rtt_avg_ms")),
-                RttMaxMs = AsDoubleOrNull(record.GetValueByKey("rtt_max_ms")),
-                JitterMs = AsDoubleOrNull(record.GetValueByKey("jitter_ms")),
-                LossPercent = AsDoubleOrNull(record.GetValueByKey("loss_percent"))
-            });
-        }
+        var byTarget = ParseLatencyDetailCsv(await QueryRawAsync(flux, ct));
+        // Single target filter, but flatten defensively in case the pivot emits more than one key.
+        var list = byTarget.Values.SelectMany(x => x).ToList();
         list.Sort((a, b) => a.Time.CompareTo(b.Time));
         return list;
     }
@@ -1835,6 +1805,154 @@ from(bucket: ""{_longtermBucket}"")
                 System.Globalization.CultureInfo.InvariantCulture, out var parsed)
             ? parsed : null
     };
+
+    /// <summary>
+    /// Runs a Flux query and returns the raw annotated CSV. Used for the high-volume latency-detail
+    /// reads, where the client's buffered FluxRecord model (a Dictionary&lt;string,object&gt; with
+    /// boxed values per record) is the dominant cost; <see cref="ParseLatencyDetailCsv"/> stream-parses
+    /// this directly into points with no per-record allocation. Same error handling as QueryFluxAsync.
+    /// </summary>
+    // The annotated CSV dialect (datatype/group/default header rows) - same as the client's default
+    // query dialect, so QueryRawAsync returns the format ParseLatencyDetailCsv expects.
+    private static readonly InfluxDB.Client.Api.Domain.Dialect AnnotatedCsvDialect = new(
+        header: true,
+        delimiter: ",",
+        annotations: new List<InfluxDB.Client.Api.Domain.Dialect.AnnotationsEnum>
+        {
+            InfluxDB.Client.Api.Domain.Dialect.AnnotationsEnum.Group,
+            InfluxDB.Client.Api.Domain.Dialect.AnnotationsEnum.Datatype,
+            InfluxDB.Client.Api.Domain.Dialect.AnnotationsEnum.Default,
+        },
+        commentPrefix: "#",
+        dateTimeFormat: null);
+
+    private async Task<string> QueryRawAsync(string flux, CancellationToken ct)
+    {
+        if (_client == null || string.IsNullOrEmpty(_org)) return string.Empty;
+        try
+        {
+            return await _client.GetQueryApi().QueryRawAsync(flux, AnnotatedCsvDialect, _org, ct);
+        }
+        catch (Exception ex) when (
+            ex is InfluxDB.Client.Core.Exceptions.NotFoundException
+            or InfluxDB.Client.Core.Exceptions.BadRequestException
+            or InfluxDB.Client.Core.Exceptions.UnauthorizedException)
+        {
+            _logger.LogWarning("InfluxDB query failed ({Error}) — check Settings > Monitoring", ex.Message);
+            _ = PersistHealthAsync(false, ex.Message, CancellationToken.None);
+            return string.Empty;
+        }
+    }
+
+    /// <summary>
+    /// Parses the annotated-CSV result of a latency-detail pivot query (columns target_id, _time,
+    /// rtt_avg_ms, rtt_max_ms, jitter_ms, loss_percent) directly into per-target point lists. Span-
+    /// based: the only allocations are the per-target list, the distinct target_id keys, and the
+    /// points themselves - no FluxRecord, no boxing, no intermediate copy. Annotation rows (#...) are
+    /// skipped and the column header is re-read whenever Flux emits one (default annotated dialect),
+    /// so column order is never assumed. Tag/field values in this measurement never contain commas,
+    /// so a plain comma split is safe.
+    /// </summary>
+    internal static Dictionary<string, List<LatencySeriesPoint>> ParseLatencyDetailCsv(string csv)
+    {
+        var result = new Dictionary<string, List<LatencySeriesPoint>>();
+        if (string.IsNullOrEmpty(csv)) return result;
+
+        int iTime = -1, iTarget = -1, iRtt = -1, iRttMax = -1, iJitter = -1, iLoss = -1;
+        var expectHeader = true; // first non-# line is a header (annotated dialect re-arms this after each #-block)
+        string? lastKey = null;
+        List<LatencySeriesPoint>? lastList = null;
+
+        var span = csv.AsSpan();
+        int pos = 0;
+        while (pos < span.Length)
+        {
+            var nl = span.Slice(pos).IndexOf('\n');
+            var line = nl < 0 ? span.Slice(pos) : span.Slice(pos, nl);
+            pos = nl < 0 ? span.Length : pos + nl + 1;
+            if (line.Length > 0 && line[line.Length - 1] == '\r') line = line.Slice(0, line.Length - 1);
+            if (line.IsEmpty) continue;
+            if (line[0] == '#') { expectHeader = true; continue; }
+
+            if (expectHeader)
+            {
+                iTime = iTarget = iRtt = iRttMax = iJitter = iLoss = -1;
+                int col = 0, p = 0;
+                while (true)
+                {
+                    var comma = line.Slice(p).IndexOf(',');
+                    var cell = comma < 0 ? line.Slice(p) : line.Slice(p, comma);
+                    if (cell.SequenceEqual("_time")) iTime = col;
+                    else if (cell.SequenceEqual("target_id")) iTarget = col;
+                    else if (cell.SequenceEqual("rtt_avg_ms")) iRtt = col;
+                    else if (cell.SequenceEqual("rtt_max_ms")) iRttMax = col;
+                    else if (cell.SequenceEqual("jitter_ms")) iJitter = col;
+                    else if (cell.SequenceEqual("loss_percent")) iLoss = col;
+                    col++;
+                    if (comma < 0) break;
+                    p += comma + 1;
+                }
+                expectHeader = false;
+                continue;
+            }
+
+            if (iTime < 0 || iTarget < 0) continue;
+
+            ReadOnlySpan<char> tTime = default, tTarget = default, tRtt = default, tRttMax = default, tJitter = default, tLoss = default;
+            int c = 0, q = 0;
+            while (true)
+            {
+                var comma = line.Slice(q).IndexOf(',');
+                var cell = comma < 0 ? line.Slice(q) : line.Slice(q, comma);
+                if (c == iTime) tTime = cell;
+                else if (c == iTarget) tTarget = cell;
+                else if (c == iRtt) tRtt = cell;
+                else if (c == iRttMax) tRttMax = cell;
+                else if (c == iJitter) tJitter = cell;
+                else if (c == iLoss) tLoss = cell;
+                c++;
+                if (comma < 0) break;
+                q += comma + 1;
+            }
+
+            if (tTarget.IsEmpty || tTime.IsEmpty) continue;
+            if (!DateTime.TryParse(tTime, System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.RoundtripKind, out var time))
+                continue;
+
+            // Rows are grouped by target, so reuse the key/list across a run rather than re-allocating.
+            List<LatencySeriesPoint>? list;
+            if (lastKey != null && tTarget.SequenceEqual(lastKey))
+            {
+                list = lastList;
+            }
+            else
+            {
+                var key = tTarget.ToString();
+                if (!result.TryGetValue(key, out list)) { list = new List<LatencySeriesPoint>(); result[key] = list; }
+                lastKey = key;
+                lastList = list;
+            }
+
+            list!.Add(new LatencySeriesPoint
+            {
+                Time = ToUtc(time),
+                RttAvgMs = ParseDoubleOrNull(tRtt),
+                RttMaxMs = ParseDoubleOrNull(tRttMax),
+                JitterMs = ParseDoubleOrNull(tJitter),
+                LossPercent = ParseDoubleOrNull(tLoss)
+            });
+        }
+
+        foreach (var list in result.Values)
+            list.Sort((a, b) => a.Time.CompareTo(b.Time));
+        return result;
+    }
+
+    private static double? ParseDoubleOrNull(ReadOnlySpan<char> s) =>
+        s.IsEmpty ? null
+        : double.TryParse(s, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var v) ? v
+        : null;
 
     private static int? AsIntOrNull(object? v) => v switch
     {

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -491,6 +491,44 @@ else
                 </details>
             </div>
         </div>
+
+        <div class="card" style="margin-top: 1rem;">
+            <div class="card-header card-header-collapsible" @onclick="() => _deviceTempCollapsed = !_deviceTempCollapsed">
+                <h2 class="card-title">Temperature Alert Thresholds</h2>
+                <span class="issue-type-chevron">@(_deviceTempCollapsed ? "▼" : "▲")</span>
+            </div>
+            <div class="expand-wrapper @(!_deviceTempCollapsed ? "expanded" : "")">
+            <div class="expand-content">
+            <div class="card-body">
+                <p class="page-description">
+                    Raise a <a href="/alerts?tab=rules">Device: Temperature High</a> alert when a device runs above these limits.
+                    Leave blank to use the default of @DefaultTempPlaceholder&deg;C. Hot-running models (e.g. high-PoE switches) may need a higher value to avoid noise.
+                </p>
+                <div class="threshold-fields" style="margin-top: 0.75rem;">
+                    <div class="form-group">
+                        <label class="form-label">Switch high temperature (&deg;C)</label>
+                        <input type="number" class="form-control" min="40" max="120" step="1"
+                               placeholder="@DefaultTempPlaceholder" @bind="_switchTempThresholdInput" @bind:after="ResetThresholdSavedFlags" />
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Gateway high temperature (&deg;C)</label>
+                        <input type="number" class="form-control" min="40" max="120" step="1"
+                               placeholder="@DefaultTempPlaceholder" @bind="_gatewayTempThresholdInput" @bind:after="ResetThresholdSavedFlags" />
+                    </div>
+                </div>
+                <div class="input-with-button" style="margin-top: 1rem;">
+                    <button class="btn btn-primary btn-sm" @onclick="SaveTempThresholdsAsync" disabled="@_savingTempThresholds">
+                        @(_savingTempThresholds ? "Saving..." : "Save thresholds")
+                    </button>
+                    @if (_tempThresholdsSaved)
+                    {
+                        <span class="form-help signal-good" style="align-self: center;">Saved</span>
+                    }
+                </div>
+            </div>
+            </div>
+            </div>
+        </div>
     }
 
     @* ──────────────── Tab: SFP Stats ──────────────── *@
@@ -577,6 +615,81 @@ else
                 {
                     <span class="page-description" style="align-self: center;">@_sfpInvestigateResult</span>
                 }
+            </div>
+        </div>
+
+        <div class="card" style="margin-top: 1.5rem;">
+            <div class="card-header card-header-collapsible" @onclick="() => _sfpThresholdsCollapsed = !_sfpThresholdsCollapsed">
+                <h2 class="card-title">SFP Alert Thresholds</h2>
+                <span class="issue-type-chevron">@(_sfpThresholdsCollapsed ? "▼" : "▲")</span>
+            </div>
+            <div class="expand-wrapper @(!_sfpThresholdsCollapsed ? "expanded" : "")">
+            <div class="expand-content">
+            <div class="card-body">
+                <p class="page-description">
+                    Thresholds for the <a href="/alerts?tab=rules">SFP temperature and power</a> alerts, per transceiver type.
+                    Leave a field blank to use the built-in default. The type of each module is set on its row in the table above.
+                </p>
+
+                <h3 class="chart-title" style="margin-top: 0.75rem;">PON</h3>
+                <div class="threshold-fields">
+                    <div class="form-group">
+                        <label class="form-label">Temperature high (&deg;C)</label>
+                        <input type="number" class="form-control" min="40" max="120" step="1"
+                               placeholder="@PhPonTemp" @bind="_sfpPonTemp" @bind:after="ResetThresholdSavedFlags" />
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">RX power low (dBm)</label>
+                        <input type="number" class="form-control" min="-40" max="0" step="0.1"
+                               placeholder="@PhPonRx" @bind="_sfpPonRx" @bind:after="ResetThresholdSavedFlags" />
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">TX power high (dBm)</label>
+                        <input type="number" class="form-control" min="-10" max="20" step="0.1"
+                               placeholder="@PhPonTx" @bind="_sfpPonTx" @bind:after="ResetThresholdSavedFlags" />
+                    </div>
+                </div>
+
+                <h3 class="chart-title" style="margin-top: 1rem;">Active Ethernet</h3>
+                <div class="threshold-fields">
+                    <div class="form-group">
+                        <label class="form-label">Temperature high (&deg;C)</label>
+                        <input type="number" class="form-control" min="40" max="120" step="1"
+                               placeholder="@PhAeTemp" @bind="_sfpAeTemp" @bind:after="ResetThresholdSavedFlags" />
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">RX power low (dBm)</label>
+                        <input type="number" class="form-control" min="-40" max="0" step="0.1"
+                               placeholder="@PhAeRx" @bind="_sfpAeRx" @bind:after="ResetThresholdSavedFlags" />
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">TX power high (dBm)</label>
+                        <input type="number" class="form-control" min="-10" max="20" step="0.1"
+                               placeholder="@PhAeTx" @bind="_sfpAeTx" @bind:after="ResetThresholdSavedFlags" />
+                    </div>
+                </div>
+
+                <h3 class="chart-title" style="margin-top: 1rem;">Generic SFP+</h3>
+                <div class="threshold-fields">
+                    <div class="form-group">
+                        <label class="form-label">Temperature high (&deg;C)</label>
+                        <input type="number" class="form-control" min="40" max="120" step="1"
+                               placeholder="@PhGenericTemp" @bind="_sfpGenericTemp" @bind:after="ResetThresholdSavedFlags" />
+                    </div>
+                </div>
+                <p class="form-help">Generic SFP+ modules have no standard optical envelope, so only a temperature ceiling is checked.</p>
+
+                <div class="input-with-button" style="margin-top: 1rem;">
+                    <button class="btn btn-primary btn-sm" @onclick="SaveSfpThresholdsAsync" disabled="@_savingSfpThresholds">
+                        @(_savingSfpThresholds ? "Saving..." : "Save thresholds")
+                    </button>
+                    @if (_sfpThresholdsSaved)
+                    {
+                        <span class="form-help signal-good" style="align-self: center;">Saved</span>
+                    }
+                </div>
+            </div>
+            </div>
             </div>
         </div>
     }
@@ -1284,6 +1397,7 @@ else
             if (!confirmed) return;
         }
         _activeTab = tab;
+        ResetThresholdSavedFlags();
         var uri = "/monitoring?tab=" + tab;
         NavigationManager.NavigateTo(uri, forceLoad: false, replace: false);
         _lastTabParam = tab;
@@ -1309,6 +1423,7 @@ else
             if (newTab != _activeTab)
             {
                 _activeTab = newTab;
+                ResetThresholdSavedFlags();
                 StateHasChanged();
             }
         }
@@ -1373,6 +1488,9 @@ else
         var settings = await SnmpDetection.GetOrCreateSettingsAsync();
         _snmpState = settings.SnmpDetectionState;
         LoadInfluxStateFromSettings(settings);
+        _switchTempThresholdInput = settings.SwitchTempHighC;
+        _gatewayTempThresholdInput = settings.GatewayTempHighC;
+        LoadSfpThresholdInputs(settings);
         await LoadTargetsAsync();
 
         var cmConfigs = await CmMonitorService.GetConfigsAsync();
@@ -1467,6 +1585,113 @@ else
         _influxReachable = health.Reachable;
         _influxError = health.Error;
         StateHasChanged();
+    }
+
+    private double? _switchTempThresholdInput;
+    private double? _gatewayTempThresholdInput;
+    private bool _savingTempThresholds;
+    private bool _tempThresholdsSaved;
+    private bool _deviceTempCollapsed = true;
+    private bool _sfpThresholdsCollapsed = true;
+
+    // Clear the transient "Saved" confirmations so they don't linger after the
+    // user edits a field or navigates back into the tab.
+    private void ResetThresholdSavedFlags()
+    {
+        _tempThresholdsSaved = false;
+        _sfpThresholdsSaved = false;
+    }
+
+    private static string DefaultTempPlaceholder =>
+        NetworkOptimizer.Web.Services.Monitoring.DeviceHealthAlertEvaluator.DefaultDeviceTempHighC.ToString("0");
+
+    // Blank/zero/negative entries mean "use the built-in default" (stored as null).
+    private static double? NormalizeTempThreshold(double? value) => value is > 0 ? value : null;
+
+    private async Task SaveTempThresholdsAsync()
+    {
+        _savingTempThresholds = true;
+        _tempThresholdsSaved = false;
+        StateHasChanged();
+        try
+        {
+            await using var db = await DbFactory.CreateDbContextAsync();
+            var settings = await db.MonitoringSettings.FirstOrDefaultAsync()
+                ?? new MonitoringSettings();
+            if (settings.Id == 0) db.MonitoringSettings.Add(settings);
+            settings.SwitchTempHighC = NormalizeTempThreshold(_switchTempThresholdInput);
+            settings.GatewayTempHighC = NormalizeTempThreshold(_gatewayTempThresholdInput);
+            settings.UpdatedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync();
+            _switchTempThresholdInput = settings.SwitchTempHighC;
+            _gatewayTempThresholdInput = settings.GatewayTempHighC;
+            _tempThresholdsSaved = true;
+        }
+        finally
+        {
+            _savingTempThresholds = false;
+            StateHasChanged();
+        }
+    }
+
+    private static readonly NetworkOptimizer.Web.Services.Monitoring.SfpDdmThresholds _sfpDefaults
+        = NetworkOptimizer.Web.Services.Monitoring.SfpDdmThresholds.Defaults;
+
+    private double? _sfpPonTemp, _sfpPonRx, _sfpPonTx;
+    private double? _sfpAeTemp, _sfpAeRx, _sfpAeTx;
+    private double? _sfpGenericTemp;
+    private bool _savingSfpThresholds;
+    private bool _sfpThresholdsSaved;
+
+    private string PhPonTemp => _sfpDefaults.PonTempHighC.ToString("0");
+    private string PhPonRx => _sfpDefaults.PonRxPowerLowDbm.ToString("0.#");
+    private string PhPonTx => _sfpDefaults.PonTxPowerHighDbm.ToString("0.#");
+    private string PhAeTemp => _sfpDefaults.AeTempHighC.ToString("0");
+    private string PhAeRx => _sfpDefaults.AeRxPowerLowDbm.ToString("0.#");
+    private string PhAeTx => _sfpDefaults.AeTxPowerHighDbm.ToString("0.#");
+    private string PhGenericTemp => _sfpDefaults.SfpTempHighGenericC.ToString("0");
+
+    private void LoadSfpThresholdInputs(MonitoringSettings settings)
+    {
+        _sfpPonTemp = settings.PonTempHighC;
+        _sfpPonRx = settings.PonRxPowerLowDbm;
+        _sfpPonTx = settings.PonTxPowerHighDbm;
+        _sfpAeTemp = settings.AeTempHighC;
+        _sfpAeRx = settings.AeRxPowerLowDbm;
+        _sfpAeTx = settings.AeTxPowerHighDbm;
+        _sfpGenericTemp = settings.SfpTempHighGenericC;
+    }
+
+    private async Task SaveSfpThresholdsAsync()
+    {
+        _savingSfpThresholds = true;
+        _sfpThresholdsSaved = false;
+        StateHasChanged();
+        try
+        {
+            await using var db = await DbFactory.CreateDbContextAsync();
+            var settings = await db.MonitoringSettings.FirstOrDefaultAsync()
+                ?? new MonitoringSettings();
+            if (settings.Id == 0) db.MonitoringSettings.Add(settings);
+            // Temperature must be positive; power thresholds may legitimately be
+            // negative (RX low) so a blank field (null) is the only "use default".
+            settings.PonTempHighC = NormalizeTempThreshold(_sfpPonTemp);
+            settings.PonRxPowerLowDbm = _sfpPonRx;
+            settings.PonTxPowerHighDbm = _sfpPonTx;
+            settings.AeTempHighC = NormalizeTempThreshold(_sfpAeTemp);
+            settings.AeRxPowerLowDbm = _sfpAeRx;
+            settings.AeTxPowerHighDbm = _sfpAeTx;
+            settings.SfpTempHighGenericC = NormalizeTempThreshold(_sfpGenericTemp);
+            settings.UpdatedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync();
+            LoadSfpThresholdInputs(settings);
+            _sfpThresholdsSaved = true;
+        }
+        finally
+        {
+            _savingSfpThresholds = false;
+            StateHasChanged();
+        }
     }
 
     private async Task SetMonitoringEnabled(bool enabled)

--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -874,6 +874,11 @@
     private List<SignalMapPoint> _signalMapPoints = new();
     private List<ApMapMarker> _apMapMarkers = new();
     private System.Threading.Timer? _mapPollTimer;
+
+    // Auto-refresh the Overview tab once the health score has aged past this, so a parked
+    // tab doesn't show indefinitely stale data. Checked on each map-poll tick.
+    private static readonly TimeSpan HealthScoreStaleAfter = TimeSpan.FromMinutes(1);
+
     private int _signalTimeRangeHours = 168; // 1 week default, matches FloorPlanEditor slider
     private int _speedTestTimeRangeHours = 720; // 30 days default, matches SpeedTestMap slider
 
@@ -915,6 +920,22 @@
             {
                 await InvokeAsync(async () =>
                 {
+                    // While the user sits on the Overview tab, the health score (and channel plan)
+                    // only refresh on load or manual refresh. Once the score goes stale, run the
+                    // full refresh so it picks everything up - health, APs, speed tests, signal
+                    // data, and channel recommendations. RefreshData re-pulls it all, so skip the
+                    // lighter speed/signal update this tick.
+                    // Only when connected: RefreshData doesn't wait for the console, so firing it
+                    // mid-reconnect (e.g. during a deploy) would hang on a dead connection. On
+                    // reconnect, OnConnectionChanged -> LoadDataAsync does a connection-aware reload.
+                    if (_activeTab == "overview" && ConnectionService.IsConnected && !_refreshing
+                        && _healthScore != null
+                        && DateTimeOffset.UtcNow - _healthScore.Timestamp >= HealthScoreStaleAfter)
+                    {
+                        await RefreshData();
+                        return;
+                    }
+
                     var now = DateTime.UtcNow;
                     var speedTestTask = SpeedTestService.GetResultsAsync(count: 0, hours: _speedTestTimeRangeHours);
                     var signalTask = DashboardService.GetSignalMapPointsAsync(

--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -382,7 +382,8 @@
             </div>
         </div>
 
-        <!-- Client Band Distribution Card -->
+        <!-- Client Band Distribution + Channel Optimization (stacked in one grid cell) -->
+        <div class="wifi-overview-stack">
         <div class="card">
             <div class="card-header">
                 <h2 class="card-title">Client Band Distribution</h2>
@@ -445,6 +446,65 @@
                     </div>
                 }
             </div>
+        </div>
+
+        <!-- Channel Optimization Card -->
+        <div class="card channel-rec-card">
+            <div class="card-header">
+                <h2 class="card-title">Channel Optimization</h2>
+            </div>
+            <div class="card-body">
+                @if (_loading || _loadingRecs)
+                {
+                    <div class="loading-state">
+                        <span class="spinner-sm"></span>
+                        <span>Analyzing channels...</span>
+                    </div>
+                }
+                else if (_channelPlans == null || _channelPlans.Count == 0)
+                {
+                    <div class="empty-state">
+                        <p>Channel analysis unavailable. Ensure APs are online.</p>
+                    </div>
+                }
+                else if (TotalChannelChanges == 0)
+                {
+                    <div class="channel-rec-summary">
+                        <div class="channel-rec-status optimal">
+                            <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20">
+                                <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/>
+                            </svg>
+                            <span>Channels look optimal</span>
+                        </div>
+                        <button class="btn-recommend" @onclick="NavigateToChannelRecommendations">Review Channel Plan</button>
+                    </div>
+                }
+                else
+                {
+                    <div class="channel-rec-summary">
+                        <div class="channel-rec-status">
+                            <span class="channel-rec-count">@TotalChannelChanges</span>
+                            <span>channel change@(TotalChannelChanges != 1 ? "s" : "") suggested</span>
+                        </div>
+                        <div class="channel-rec-bands">
+                            @if (ChannelChangeCount(RadioBand.Band2_4GHz) > 0)
+                            {
+                                <span class="band-badge band-2ghz">2.4 GHz: @ChannelChangeCount(RadioBand.Band2_4GHz)</span>
+                            }
+                            @if (ChannelChangeCount(RadioBand.Band5GHz) > 0)
+                            {
+                                <span class="band-badge band-5ghz">5 GHz: @ChannelChangeCount(RadioBand.Band5GHz)</span>
+                            }
+                            @if (ChannelChangeCount(RadioBand.Band6GHz) > 0)
+                            {
+                                <span class="band-badge band-6ghz">6 GHz: @ChannelChangeCount(RadioBand.Band6GHz)</span>
+                            }
+                        </div>
+                        <button class="btn-recommend" @onclick="NavigateToChannelRecommendations">Recommend Best Channels</button>
+                    </div>
+                }
+            </div>
+        </div>
         </div>
 
         <!-- Issues Card -->
@@ -758,6 +818,55 @@
         _ => null
     };
 
+    // --- Channel Optimization overview card ---
+    private Dictionary<RadioBand, ChannelPlan>? _channelPlans;
+    private bool _loadingRecs;
+
+    private int ChannelChangeCount(RadioBand band) =>
+        _channelPlans != null && _channelPlans.TryGetValue(band, out var plan)
+            ? plan.Recommendations.Count(r => r.IsChanged)
+            : 0;
+
+    private int TotalChannelChanges =>
+        _channelPlans?.Values.Sum(p => p.Recommendations.Count(r => r.IsChanged)) ?? 0;
+
+    /// <summary>
+    /// Compute channel recommendations for the overview summary card. Runs the full engine,
+    /// so it is kicked off in the background after the overview paints rather than blocking it.
+    /// </summary>
+    private async Task LoadChannelRecommendationsAsync()
+    {
+        if (_loadingRecs) return;
+        _loadingRecs = true;
+        await InvokeAsync(StateHasChanged);
+        try
+        {
+            _channelPlans = await WiFiService.GetAllChannelRecommendationsAsync(new RecommendationOptions());
+        }
+        catch
+        {
+            _channelPlans = null;
+        }
+        finally
+        {
+            _loadingRecs = false;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private void NavigateToChannelRecommendations()
+    {
+        _activeTab = "channels";
+        _initialApMac = null;
+        _initialBand = null;
+        _initialChannel = null;
+        _initialClientMac = null;
+        _initialEdge = null;
+        _autoRunRecommendation = true;
+        NavigationManager.NavigateTo("/wifi-optimizer?tab=channels&recommend=true", forceLoad: false, replace: false);
+        _lastTabParam = "channels";
+    }
+
     private SiteHealthScore? _healthScore;
     private WiFiSummary? _summary;
     private List<AccessPointSnapshot> _accessPoints = new();
@@ -897,6 +1006,10 @@
             _loading = false;
             await InvokeAsync(StateHasChanged);
         }
+
+        // Channel recommendations run the full engine; compute in the background so they don't
+        // delay the overview paint. The card shows its own loading state until ready.
+        _ = LoadChannelRecommendationsAsync();
     }
 
     private async Task RefreshData()
@@ -931,6 +1044,9 @@
             _refreshing = false;
             StateHasChanged();
         }
+
+        // Refresh cleared the cache, so recompute the channel recommendations summary too.
+        _ = LoadChannelRecommendationsAsync();
     }
 
     private async Task LoadApMarkers()

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -261,7 +261,7 @@ else
                                             @FormatJitter(target.P95JitterMs)
                                             @if (target.JitterAssimilated)
                                             {
-                                                <span class="tooltip-icon tooltip-icon-sm" data-tooltip="@JitterAssimilationTooltip(target)">i</span>
+                                                <span class="tooltip-icon tooltip-icon-sm isp-jitter-tip" data-tooltip="@JitterAssimilationTooltip(target)">i</span>
                                             }
                                         </span>
                                     </span>
@@ -376,7 +376,7 @@ else
                                         @FormatJitter(asn.P95JitterMs)
                                         @if (asn.JitterAssimilated)
                                         {
-                                            <span class="tooltip-icon tooltip-icon-sm" data-tooltip="@JitterAssimilationTooltip(asn, isIspAsn)">i</span>
+                                            <span class="tooltip-icon tooltip-icon-sm isp-jitter-tip" data-tooltip="@JitterAssimilationTooltip(asn, isIspAsn)">i</span>
                                         }
                                     </span>
                                 </div>
@@ -403,17 +403,21 @@ else
     @if (r.Outages.Count > 0)
     {
         <div class="card isp-health-card" id="isp-outages">
-            <div class="card-header"><h2 class="card-title">Internet Outages (@WindowLabel(r))</h2></div>
+            <div class="card-header"><h2 class="card-title">@OutageSectionTitle(r) (@WindowLabel(r))</h2></div>
             <div class="card-body">
                 <div class="isp-outage-list">
                     @foreach (var outage in r.Outages)
                     {
                         <div class="isp-outage">
                             <div class="isp-outage-head">
-                                <span class="isp-event-badge isp-event-badge-danger" data-tooltip="@OutageScoreTooltip(outage)">Outage</span>
+                                <span class="isp-event-badge @OutageBadgeClass(outage)" data-tooltip="@OutageScoreTooltip(outage)">@OutageBadgeText(outage)</span>
                                 <span class="isp-outage-duration">@FormatDuration(outage.Duration)</span>
                                 <span class="isp-outage-window">@outage.Start.ToLocalTime().ToString("MMM d, HH:mm:ss") &ndash; @outage.End.ToLocalTime().ToString("HH:mm:ss")</span>
                                 <span class="isp-outage-scope" data-tooltip="@OutageScoreTooltip(outage)">@OutageScopeLabel(outage)</span>
+                                @if (outage.IsPartial)
+                                {
+                                    <span class="isp-outage-window">peak @outage.PeakLossPct.ToString("0")% &middot; @outage.DegradedTargetCount/@outage.PathTargetCount targets</span>
+                                }
                             </div>
                             @if (outage.Tiers.Any(t => t.WentDark))
                             {
@@ -430,6 +434,21 @@ else
                                     }
                                 </div>
                             }
+                            else if (outage.IsPartial && outage.Tiers.Count > 0)
+                            {
+                                <div class="isp-outage-shape">
+                                    @foreach (var tier in outage.Tiers)
+                                    {
+                                        <div class="isp-outage-hop">
+                                            <span class="isp-outage-hop-name">@tier.Name</span>
+                                            <div class="isp-outage-hop-track">
+                                                <div class="isp-outage-hop-loss" style="width: @(tier.PeakLossPct.ToString("0.#", System.Globalization.CultureInfo.InvariantCulture))%"></div>
+                                            </div>
+                                            <span class="isp-outage-hop-status">peak @tier.PeakLossPct.ToString("0")% loss</span>
+                                        </div>
+                                    }
+                                </div>
+                            }
                         </div>
                     }
                 </div>
@@ -438,16 +457,17 @@ else
     }
 
     <div class="card isp-health-card">
-        <div class="card-header"><h2 class="card-title">Path &amp; Congestion Events (@WindowLabel(r))</h2></div>
+        <div class="card-header"><h2 class="card-title">Path &amp; Congestion Events (@EventsWindowLabel(r))</h2></div>
         <div class="card-body">
-            @if (r.CongestionEvents.Count == 0 && r.PathShifts.Count == 0)
+            @{ var timeline = EventTimeline(r).Where(InZoomWindow).ToList(); }
+            @if (timeline.Count == 0)
             {
-                <p class="page-description">No congestion events or path shifts detected in the window.</p>
+                <p class="page-description">@(IsZoomed ? "No congestion events or path shifts in this range. Reset the chart zoom to see the full window." : "No congestion events or path shifts detected in the window.")</p>
             }
             else
             {
                 <div class="isp-event-timeline">
-                    @foreach (var entry in EventTimeline(r))
+                    @foreach (var entry in timeline)
                     {
                         <div class="isp-event-item">
                             <span class="isp-event-badge @entry.BadgeClass">@entry.Badge</span>
@@ -510,6 +530,17 @@ else
     private bool _windowComputing;
     private DateTime? _windowStart;
     private DateTime? _windowEnd;
+    private DotNetObjectReference<IspHealthPanel>? _selfRef;
+    // Chart drag-zoom range (UTC) the events list is filtered to; null = show the whole window.
+    private DateTime? _zoomFrom;
+    private DateTime? _zoomTo;
+    private bool IsZoomed => _zoomFrom.HasValue && _zoomTo.HasValue;
+    // Set when reset-zoom expands the list (which sits above the chart); scrolls the chart back
+    // into view after the next render so it doesn't get pushed off-screen.
+    private bool _scrollChartAfterRender;
+    // Last report the absolved-jitter tooltips were refreshed against; a new report means their
+    // data-tooltip changed and the cached Tippy content needs rebuilding.
+    private IspHealthReport? _lastTooltipReport;
     private DateTime _customFrom = DateTime.Now.AddDays(-2);
     private DateTime _customTo = DateTime.Now;
 
@@ -570,6 +601,12 @@ else
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (_scrollChartAfterRender)
+        {
+            _scrollChartAfterRender = false;
+            try { await JS.InvokeVoidAsync("__ispHealthCharts.scrollChartIntoView"); }
+            catch { /* chart not mounted */ }
+        }
         if (_report == null)
         {
             // The content (and the chart element) is gone; drop the chart so it re-mounts
@@ -582,15 +619,35 @@ else
             }
             return;
         }
+        // Absolved-jitter tooltip-icons cache their content when Tippy first builds them; on a window
+        // recompute Blazor swaps only their data-tooltip attribute (no node re-add, so the global
+        // observer never re-fires) and the value goes stale. When the report changes, push the current
+        // attribute into each icon's existing Tippy with setContent - scoped to these icons only, and
+        // it leaves all other tooltips and the shared init untouched.
+        if (!ReferenceEquals(_report, _lastTooltipReport))
+        {
+            _lastTooltipReport = _report;
+            try
+            {
+                await JS.InvokeVoidAsync("eval",
+                    "document.querySelectorAll('.isp-jitter-tip').forEach(function(el){" +
+                    "if(el._tippy&&el.dataset.tooltip&&el._tippy.props.content!==el.dataset.tooltip)" +
+                    "el._tippy.setContent(el.dataset.tooltip);});");
+            }
+            catch { /* tooltip refresh is best-effort */ }
+        }
         if (_chartMounted) return;
         _chartMounted = true;
         var fromArg = _windowStart.HasValue ? $"'{_windowStart.Value:o}'" : "null";
         var toArg = _windowEnd.HasValue ? $"'{_windowEnd.Value:o}'" : "null";
         try
         {
+            _selfRef ??= DotNetObjectReference.Create(this);
             await JS.InvokeVoidAsync("eval",
                 $"(async () => {{ const m = await import('{VersionedJs("/js/isp-health-charts.js")}'); " +
                 $"window.__ispHealthCharts = m; await m.mount('isp-health-asn-chart', {fromArg}, {toArg}); }})();");
+            // Hand the chart a callback so its drag-zoom can filter the events list to the visible window.
+            await JS.InvokeVoidAsync("__ispHealthCharts.setDotNetRef", _selfRef);
         }
         catch { _chartMounted = false; }
     }
@@ -665,7 +722,30 @@ else
         catch { /* chart not mounted yet */ }
     }
 
-    private record TimelineEntry(DateTime Time, string Badge, string BadgeClass, string Text);
+    /// <summary>
+    /// Called by the per-network RTT chart on drag-zoom (epoch ms, or null/null on reset/window
+    /// change) so the Path &amp; Congestion Events list filters to the visible range.
+    /// </summary>
+    [JSInvokable]
+    public Task OnChartZoom(double? minMs, double? maxMs, bool scrollToChart)
+    {
+        _zoomFrom = minMs.HasValue ? DateTimeOffset.FromUnixTimeMilliseconds((long)minMs.Value).UtcDateTime : null;
+        _zoomTo = maxMs.HasValue ? DateTimeOffset.FromUnixTimeMilliseconds((long)maxMs.Value).UtcDateTime : null;
+        // On reset the list above the chart expands; keep the chart the user was on in view.
+        if (scrollToChart) _scrollChartAfterRender = true;
+        return InvokeAsync(StateHasChanged);
+    }
+
+    // An event shows when its span overlaps the zoom window (instant events: when the instant is in it).
+    private bool InZoomWindow(TimelineEntry e) =>
+        !IsZoomed || ((e.End ?? e.Time) >= _zoomFrom!.Value && e.Time <= _zoomTo!.Value);
+
+    private string EventsWindowLabel(IspHealthReport r) =>
+        IsZoomed
+            ? $"zoomed: {_zoomFrom!.Value.ToLocalTime():MMM d, HH:mm} to {_zoomTo!.Value.ToLocalTime():MMM d, HH:mm}"
+            : WindowLabel(r);
+
+    private record TimelineEntry(DateTime Time, string Badge, string BadgeClass, string Text, DateTime? End = null);
 
     private static IEnumerable<TimelineEntry> EventTimeline(IspHealthReport r)
     {
@@ -709,7 +789,7 @@ else
                 _ => ("Congestion", "isp-event-badge-warning",
                     $"{lead}")
             };
-            entries.Add(new TimelineEntry(evt.Start, badge, badgeClass, text));
+            entries.Add(new TimelineEntry(evt.Start, badge, badgeClass, text, evt.End));
         }
         foreach (var shift in r.PathShifts)
         {
@@ -723,7 +803,9 @@ else
     }
 
     private static string FormatDuration(TimeSpan d) =>
-        d.TotalHours >= 1 ? $"{d.TotalHours:0.#} h" : $"{d.TotalMinutes:0} min";
+        d.TotalHours >= 1 ? $"{d.TotalHours:0.#} h"
+        : d.TotalMinutes >= 1 ? $"{d.TotalMinutes:0} min"
+        : $"{d.TotalSeconds:0} sec";
 
     // Event time in local time, prefixed with the date when it is not today so events in a
     // multi-day (7d/30d/custom) window are unambiguous.
@@ -733,10 +815,24 @@ else
         return local.Date == DateTime.Now.Date ? $"Today, {local:HH:mm}" : local.ToString("MMM d, HH:mm");
     }
 
+    private static string OutageBadgeClass(OutageEvent o) =>
+        o.IsPartial ? "isp-event-badge-info"
+        : o.IsBrief ? "isp-event-badge-warning"
+        : "isp-event-badge-danger";
+
+    private static string OutageBadgeText(OutageEvent o) =>
+        o.IsPartial ? "Partial loss" : o.IsBrief ? "Brief" : "Outage";
+
+    private static string OutageSectionTitle(IspHealthReport r) =>
+        r.Outages.Any(o => !o.IsPartial && !o.IsBrief) ? "Internet Outages"
+        : r.Outages.All(o => o.IsPartial) ? "Internet Disruptions"
+        : "Brief Internet Disruptions";
+
     private static string OutageScopeLabel(OutageEvent o) => o.Scope switch
     {
         OutageScope.Local => "LAN / Gateway outage",
         OutageScope.Upstream when !string.IsNullOrEmpty(o.LastReachableHop) => $"Break upstream of {o.LastReachableHop}",
+        _ when o.IsPartial => "Path-wide partial loss",
         _ => "Whole-WAN outage"
     };
 
@@ -839,5 +935,6 @@ else
             try { _ = JS.InvokeVoidAsync("eval", "window.__ispHealthCharts?.unmount();"); }
             catch { }
         }
+        _selfRef?.Dispose();
     }
 }

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -79,7 +79,7 @@
                 var bandData = GetBandData(band);
                 var hasRecForBand = _showRecommendations && _channelPlans.ContainsKey(band);
                 <button class="band-tab @GetBandClass(band) @(_selectedBand == band ? "active" : "") @(bandData.HasIssues ? "has-issues" : "")"
-                        @onclick="() => { _selectedBand = band; _selectedChannel = null; }">
+                        @onclick="() => { _selectedBand = band; _selectedChannel = null; _bandManuallySelected = true; }">
                     @band.ToDisplayString()
                     @if (_showRecommendations && hasRecForBand)
                     {
@@ -106,7 +106,7 @@
             <div class="recommendation-view">
                 <div class="section-header">
                     <h4>Recommended Channel Plan - @_selectedBand.ToDisplayString()</h4>
-                    <button class="btn btn-sm btn-ghost" @onclick="() => { _showRecommendations = false; _channelPlans.Clear(); }">Back to Current</button>
+                    <button class="btn btn-sm btn-ghost" @onclick="() => { _showRecommendations = false; _channelPlans.Clear(); }">Show Current Channels</button>
                 </div>
 
                 @if (!_channelDisclaimerDismissed)
@@ -263,11 +263,23 @@
                     <!-- How This Works -->
                     <details class="recommendation-explainer">
                         <summary>How This Works</summary>
-                        <p>
-                            We model how far each AP's signal reaches using your floor plan, wall materials, and antenna patterns.
-                            Then we find the channel assignment that minimizes total interference between your APs and neighboring networks.
-                            Mesh APs are kept on the same channel as their parent. Lower scores mean less interference.
-                        </p>
+                        <div class="recommendation-explainer-content">
+                            <p>
+                                Most channel pickers just count nearby networks. This builds a physical model of your
+                                RF environment and solves for the channel plan that minimizes real interference:
+                            </p>
+                            <ul>
+                                <li><strong>Signal propagation</strong> - models how far each AP's signal actually reaches using your floor plan, wall materials, and per-radio antenna patterns, not distance alone.</li>
+                                <li><strong>Transmit-power aware</strong> - each AP's real EIRP is applied directionally, so a low-power AP correctly counts as a gentler neighbor than a full-power one.</li>
+                                <li><strong>Real contention, not raw signal</strong> - interference is measured against the CCA threshold (where radios actually defer), so barely-audible signals aren't over-counted.</li>
+                                <li><strong>Neighboring networks</strong> - folds in UniFi's RF scan of networks you don't control, triangulated across all your APs for a fuller picture than any single AP sees.</li>
+                                <li><strong>30 days of history</strong> - per-channel utilization, interference, and TX-retry trends, so the plan reflects how channels behave over time, not one noisy snapshot.</li>
+                                <li><strong>Honest about the unknown</strong> - channels with no scan data are penalized for that uncertainty, so it won't push you onto an unseen channel unless your known channels are clearly worse.</li>
+                                <li><strong>Whole-network and per-AP</strong> - minimizes total interference across the site, then checks each AP individually, only suggesting a move that genuinely helps and never wrecking one AP to slightly help another.</li>
+                                <li><strong>Mesh and DFS aware</strong> - mesh APs stay on their parent's channel; DFS channels are handled per your preference.</li>
+                            </ul>
+                            <p>Lower scores mean less interference.</p>
+                        </div>
                     </details>
                 }
                 else
@@ -518,6 +530,8 @@
     private SiteHealthScore? _healthScore;
     private RadioBand _selectedBand = RadioBand.Band5GHz;
     private int? _selectedChannel;
+    // True once the user (or explicit navigation) picks a band, so auto-select won't override it.
+    private bool _bandManuallySelected;
 
     // Channel disclaimer
     private bool _channelDisclaimerDismissed;
@@ -557,9 +571,12 @@
 
         await LoadDataAsync();
 
-        // Apply initial filters from parent navigation
+        // Apply initial filters from parent navigation (explicit band is treated as a manual pick)
         if (InitialBand.HasValue)
+        {
             _selectedBand = InitialBand.Value;
+            _bandManuallySelected = true;
+        }
         if (InitialChannel.HasValue)
             _selectedChannel = InitialChannel.Value;
 
@@ -843,11 +860,36 @@
 
             _channelPlans = await WiFiService.GetAllChannelRecommendationsAsync(options);
             _showRecommendations = _channelPlans.Count > 0;
+            AutoSelectBandWithRecommendations();
         }
         finally
         {
             _loadingRecommendations = false;
             StateHasChanged();
+        }
+    }
+
+    private bool BandHasChanges(RadioBand band) =>
+        _channelPlans.TryGetValue(band, out var plan) && plan.Recommendations.Any(r => r.IsChanged);
+
+    /// <summary>
+    /// After running the engine, land on a band that actually has recommendations instead of
+    /// the static default. Skips if the user explicitly picked a band, or if the current band
+    /// already has changes, so we never yank someone off a band they're deliberately viewing.
+    /// </summary>
+    private void AutoSelectBandWithRecommendations()
+    {
+        if (_bandManuallySelected) return;
+        if (BandHasChanges(_selectedBand)) return;
+
+        foreach (var band in _bands)
+        {
+            if (BandHasChanges(band))
+            {
+                _selectedBand = band;
+                _selectedChannel = null;
+                break;
+            }
         }
     }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/Metrics.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/Metrics.razor
@@ -698,7 +698,11 @@
             _ => null
         };
 
-        if (events.Count == 0 && currentChannel == null)
+        // Only show a channel timeline for APs that actually changed channels in this window.
+        // A constant-channel AP renders nothing here (its channel is already shown in the header),
+        // which also avoids the fallback below picking up a stale current-channel value from a
+        // previously-selected AP - the cause of one AP's channel bleeding onto another's chart.
+        if (events.Count == 0)
             return;
 
         // Build timeline: for each metric timestamp, find the active channel

--- a/src/NetworkOptimizer.Web/Services/Monitoring/DeviceHealthAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/DeviceHealthAlertEvaluator.cs
@@ -10,6 +10,9 @@ namespace NetworkOptimizer.Web.Services.Monitoring;
 /// (~2.5-5 minutes at typical poll intervals) to avoid alerting on transient
 /// spikes. Memory is evaluated per-sample since sustained high memory is
 /// immediately actionable.
+///
+/// Temperature is evaluated for gateways and switches against a user-configurable
+/// high threshold (per device type, falling back to <see cref="DefaultDeviceTempHighC"/>).
 /// </summary>
 public class DeviceHealthAlertEvaluator
 {
@@ -18,6 +21,13 @@ public class DeviceHealthAlertEvaluator
     private const double CpuClearThresholdPercent = 55.0;
     private const double MemoryHighThresholdPercent = 95.0;
     private const double MemoryClearThresholdPercent = 85.0;
+
+    /// <summary>Default high-temperature alert threshold (Celsius) when the user hasn't set one.</summary>
+    public const double DefaultDeviceTempHighC = 85.0;
+
+    // Temperature must drop this far below the threshold before the alert re-arms,
+    // preventing flapping for devices hovering near their limit.
+    private const double TempClearMarginC = 5.0;
 
     private readonly IAlertEventBus _eventBus;
     private readonly ILogger<DeviceHealthAlertEvaluator> _logger;
@@ -32,15 +42,20 @@ public class DeviceHealthAlertEvaluator
     public async ValueTask EvaluateAsync(
         string deviceMac, string? deviceName, string deviceType,
         double? cpuPercent, double? memoryUsedPercent,
+        double? temperatureC = null, double? tempHighThresholdC = null,
         CancellationToken ct = default)
     {
-        if (!string.Equals(deviceType, "gateway", StringComparison.OrdinalIgnoreCase))
+        var isGateway = string.Equals(deviceType, "gateway", StringComparison.OrdinalIgnoreCase);
+        var isSwitch = string.Equals(deviceType, "switch", StringComparison.OrdinalIgnoreCase);
+
+        // CPU and memory alerting is gateway-only; temperature covers gateways and switches.
+        if (!isGateway && !isSwitch)
             return;
 
         var state = _states.GetOrAdd(deviceMac, _ => new DeviceHealthState());
         var label = deviceName ?? deviceMac;
 
-        if (cpuPercent.HasValue)
+        if (isGateway && cpuPercent.HasValue)
         {
             state.CpuWindow.Enqueue(cpuPercent.Value);
             while (state.CpuWindow.Count > CpuWindowSize) state.CpuWindow.Dequeue();
@@ -65,7 +80,7 @@ public class DeviceHealthAlertEvaluator
                         DeviceName = deviceName,
                         MetricValue = avg,
                         ThresholdValue = CpuHighThresholdPercent,
-                        SourceUrl = "/monitoring?tab=health",
+                        SourceUrl = "/monitoring?tab=devices",
                         Tags = ["device", "gateway", "cpu"],
                         Context = new Dictionary<string, string>
                         {
@@ -82,7 +97,7 @@ public class DeviceHealthAlertEvaluator
             }
         }
 
-        if (memoryUsedPercent.HasValue)
+        if (isGateway && memoryUsedPercent.HasValue)
         {
             if (!state.MemoryBreached && memoryUsedPercent.Value >= MemoryHighThresholdPercent)
             {
@@ -100,7 +115,7 @@ public class DeviceHealthAlertEvaluator
                     DeviceName = deviceName,
                     MetricValue = memoryUsedPercent.Value,
                     ThresholdValue = MemoryHighThresholdPercent,
-                    SourceUrl = "/monitoring?tab=health",
+                    SourceUrl = "/monitoring?tab=devices",
                     Tags = ["device", "gateway", "memory"],
                     Context = new Dictionary<string, string>
                     {
@@ -115,6 +130,44 @@ public class DeviceHealthAlertEvaluator
                 state.MemoryBreached = false;
             }
         }
+
+        if (temperatureC.HasValue)
+        {
+            var threshold = tempHighThresholdC ?? DefaultDeviceTempHighC;
+            var typeLabel = isGateway ? "Gateway" : "Switch";
+
+            if (!state.TempBreached && temperatureC.Value >= threshold)
+            {
+                state.TempBreached = true;
+                _logger.LogDebug("Device temperature threshold breached: {DeviceMac} temp={Temp:0.#}C threshold={Threshold:0.#}C",
+                    deviceMac, temperatureC.Value, threshold);
+
+                await _eventBus.PublishAsync(new AlertEvent
+                {
+                    EventType = "device.high_temperature",
+                    Source = "device",
+                    Severity = AlertSeverity.Warning,
+                    Title = $"{label} temperature high",
+                    Message = $"{typeLabel} {label} temperature at {temperatureC.Value:0.#} C, exceeding the {threshold:0.#} C threshold.",
+                    DeviceId = deviceMac,
+                    DeviceName = deviceName,
+                    MetricValue = temperatureC.Value,
+                    ThresholdValue = threshold,
+                    SourceUrl = "/monitoring?tab=devices",
+                    Tags = ["device", deviceType, "temperature"],
+                    Context = new Dictionary<string, string>
+                    {
+                        ["device_mac"] = deviceMac,
+                        ["device_type"] = deviceType,
+                        ["metric"] = "temperature_c"
+                    }
+                }, ct);
+            }
+            else if (state.TempBreached && temperatureC.Value <= threshold - TempClearMarginC)
+            {
+                state.TempBreached = false;
+            }
+        }
     }
 
     private class DeviceHealthState
@@ -122,5 +175,6 @@ public class DeviceHealthAlertEvaluator
         public Queue<double> CpuWindow { get; } = new();
         public bool CpuBreached;
         public bool MemoryBreached;
+        public bool TempBreached;
     }
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionDetector.cs
@@ -58,6 +58,29 @@ public static class CongestionDetector
         var burstSpread = Math.Max(baselineP90.Value - baselineRtt.Value, 0.5);
         var burstThreshold = baselineP90.Value + Math.Max(options.CongestionRttMinDeltaMs, options.CongestionBurstDeltaFactor * burstSpread);
 
+        // Continuation (hysteresis) gate: once a run is active it survives while any signal stays
+        // at least CongestionSustainFraction of the way from baseline to its entry threshold. This
+        // does NOT start a run (entry below still requires the full strict gate), so it only keeps
+        // a legitimately-started event alive through its milder tail and brief dips instead of
+        // truncating to the peak.
+        bool StillElevated(Bucket b)
+        {
+            var f = options.CongestionSustainFraction;
+            // Continuation requires the congestion SIGNATURE to persist RELATIVE TO THIS HOP'S OWN
+            // BASELINE, not merely an absolute delta or the bucket's own internal spread: jitter still
+            // up versus baseline (both an absolute floor AND a ratio, so a naturally jittery hop's
+            // normal wobble doesn't qualify), or p90 still elevated above the BASELINE p90 (mirroring
+            // entry), not just a wide p90-median spread that a chronically bursty hop always shows.
+            // Without the relative bar a bursty/jittery hop holds a run open for hours past the real
+            // event (the false long tail). A flat plateau back at baseline ends the run.
+            var jitterOk = b.JitterMs.HasValue && baselineJitter.HasValue
+                && b.JitterMs.Value - baselineJitter.Value >= options.CongestionJitterMinDeltaMs * f
+                && b.JitterMs.Value >= baselineJitter.Value * (1 + (options.CongestionJitterFactor - 1) * f);
+            var burstOk = b.P90Ms.HasValue
+                && b.P90Ms.Value - baselineP90.Value >= (burstThreshold - baselineP90.Value) * f;
+            return jitterOk || burstOk;
+        }
+
         var events = new List<CongestionEvent>();
         var run = new List<Bucket>();
         var gap = 0;
@@ -83,6 +106,11 @@ public static class CongestionDetector
             var elevated = sustainedElevated || burstElevated;
 
             if (elevated)
+            {
+                run.Add(bucket);
+                gap = 0;
+            }
+            else if (run.Count > 0 && StillElevated(bucket))
             {
                 run.Add(bucket);
                 gap = 0;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
@@ -88,28 +88,61 @@ public static class CongestionLocalizer
             }
 
             var loadCoincident = LoadCoincident(window.Start, window.End, topology, options);
-            // A clean anchored series anywhere means the elevation is NOT line-wide. Kept for the
-            // Confirmed confidence below (NOT the self-infliction gate - see lineWideUnderLoad).
-            // Must have data in the window - a no-data series (newer target / gap) isn't "clean".
-            var cleanControlExists = anchored.Any(s =>
-                HasDataInWindow(s, window.Start, window.End) && !IsElevated(s, window.Start, window.End));
-            // Self-inflicted access bufferbloat adds a near-constant rise to (almost) every monitored
-            // path crossing the egress under load. The absolute elevation bar misses that on high-
-            // baseline / high-variance paths (their inflated p90 hides a ~1 ms drift), so one such path
-            // reading "clean" wrongly vetoes self-infliction. This robust median-shift test keys on
-            // "did everything drift up together": the fraction of anchored paths (with data) whose
-            // in-window median rose above baseline by a small margin. Only consulted for the egress hop.
             var anchoredWithData = anchored.Where(s => HasDataInWindow(s, window.Start, window.End)).ToList();
+
+            // Each anchored path's RTT rise over its OWN baseline. Under load every path picks up a
+            // shared FLOOR of added delay; localized congestion is the rise ABOVE that floor.
+            double RttRise(AsnSeries s)
+            {
+                var inW = s.Samples.Where(x => x.Time >= window.Start && x.Time <= window.End && x.RttAvgMs.HasValue)
+                    .Select(x => x.RttAvgMs!.Value).ToList();
+                var baseW = s.Samples.Where(x => (x.Time < window.Start || x.Time > window.End) && x.RttAvgMs.HasValue)
+                    .Select(x => x.RttAvgMs!.Value).ToList();
+                var im = SeriesStats.Median(inW);
+                var bm = SeriesStats.Median(baseW);
+                return im.HasValue && bm.HasValue ? Math.Max(0, im.Value - bm.Value) : 0;
+            }
+            var relElevated = anchoredWithData.Where(s => IsElevated(s, window.Start, window.End)).ToList();
+            var rises = relElevated.Select(RttRise).Where(r => r > 0).OrderBy(r => r).ToList();
+            var floorRise = SeriesStats.Median(rises) ?? 0;
+
+            // A CLEAN control rose no more than the shared floor in RTT - it picked up the load floor
+            // but NOT localized congestion. Using RTT (not the jitter-inclusive IsElevated) is the point:
+            // under load the jitter floor lifts every path, so IsElevated would mark even Cox "elevated"
+            // and erase every clean control - which is exactly what suppressed the "this hop's own
+            // capacity, not your access egress" messaging. A non-zero count of clean parallel paths is
+            // the proof an elevation is a single hop's capacity rather than access-layer bufferbloat.
+            bool IsClean(AsnSeries s) => RttRise(s) <= floorRise * options.CongestionCleanControlFloorFactor;
+            var cleanControlExists = anchoredWithData.Any(IsClean);
+
+            // Self-inflicted access bufferbloat lifts (almost) every monitored path crossing the egress
+            // under load. The robust median-shift test keys on "did everything drift up together": the
+            // fraction of anchored paths (with data) whose in-window median rose above baseline.
             var lineWideUnderLoad = anchoredWithData.Count > 0
                 && anchoredWithData.Count(s => RoseInWindow(s, window.Start, window.End, options))
                     >= anchoredWithData.Count * options.CongestionLineWideRiseFraction;
 
+            // SHARED-INCIDENT COLLAPSE (narrow exception; the per-hop separation below is the default
+            // and stays authoritative). Collapse to ONE event only when the rise is genuinely UNIFORM:
+            // a strict majority rose in RTT (lineWideUnderLoad) AND no path rose MATERIALLY above the
+            // shared floor. If a few paths are much worse than the floor, those are localized congestion
+            // on top of the load - stay per-hop so the localizer surfaces them as "this hop's own
+            // capacity", not "everything slowed".
+            var uniform = rises.Count == 0 || floorRise <= 0
+                || rises[^1] <= floorRise * options.CongestionLoadedUniformityFactor;
+            if (lineWideUnderLoad && uniform && relElevated.Count > 0)
+            {
+                result.Add(BuildSharedIncident(relElevated, eventsBySeries, anchoredWithData, window,
+                    topology, options, loadCoincident, IsElevated));
+                continue;
+            }
+
             foreach (var (bnIp, members) in byBottleneck)
                 result.Add(BuildLocalized(bnIp, members, allSeries, eventsBySeries, window,
-                    topology, options, loadCoincident, cleanControlExists, lineWideUnderLoad, IsElevated));
+                    topology, options, loadCoincident, cleanControlExists, lineWideUnderLoad, uniform, IsElevated, IsClean));
 
             if (unanchored.Count > 0)
-                result.Add(BuildUnlocalized(unanchored, eventsBySeries, window, topology, loadCoincident));
+                result.Add(BuildUnlocalized(unanchored, eventsBySeries, window, topology, loadCoincident, options));
         }
 
         // An Unverifiable hop (dead-end, nothing monitored beyond it) inherits Confirmed from a
@@ -130,6 +163,104 @@ public static class CongestionLocalizer
         }
 
         return result.OrderBy(e => e.Start).ToList();
+    }
+
+    /// <summary>
+    /// Builds the single event for a shared incident (a relative-line-wide, access-rooted cluster).
+    /// Attributed to the convergence hop nearest the user; Loaded Latency under load (your access
+    /// link, suppressed), else real shared upstream congestion (Confirmed, scored). The span is
+    /// trimmed to the sub-window where the breadth actually holds, so one hop lingering past the rest
+    /// doesn't stretch it, and the worst single hop is named in the reason.
+    /// </summary>
+    private static CongestionEvent BuildSharedIncident(
+        List<AsnSeries> elevated,
+        Dictionary<AsnSeries, List<CongestionEvent>> eventsBySeries,
+        List<AsnSeries> anchoredWithData,
+        (DateTime Start, DateTime End) window,
+        CongestionTopology topology,
+        IspHealthOptions options,
+        bool loadCoincident,
+        Func<AsnSeries, DateTime, DateTime, bool> isElevated)
+    {
+        int HopNum(AsnSeries s) => s.HopIps.Concat(s.AncestorIps)
+            .Where(topology.HopNumberByIp.ContainsKey)
+            .Select(ip => topology.HopNumberByIp[ip]).DefaultIfEmpty(int.MaxValue).Min();
+
+        // Decision 3: span only the contiguous sub-window where the breadth still holds, so a single
+        // hop lingering past the rest cannot stretch the incident's reported (and scored) duration.
+        var bucket = TimeSpan.FromMinutes(options.CongestionBucketMinutes);
+        var need = anchoredWithData.Count * options.CongestionLineWideRiseFraction;
+        var wide = new List<DateTime>();
+        for (var b = CongestionDetector.FloorTime(window.Start, bucket); b < window.End; b += bucket)
+            if (anchoredWithData.Count(s => isElevated(s, b, b + bucket)) >= need)
+                wide.Add(b);
+        var start = wide.Count > 0 ? wide.Min() : window.Start;
+        var end = wide.Count > 0 ? wide.Max() + bucket : window.End;
+
+        Func<AsnSeries, IEnumerable<CongestionEvent>> evts = s =>
+            (eventsBySeries.TryGetValue(s, out var es) ? es : Enumerable.Empty<CongestionEvent>())
+                .Where(e => Overlaps(e.Start, e.End, start, end));
+
+        // The convergence hop nearest the user owns the event (usually the access egress); this also
+        // keeps the score attributed to your ISP card rather than every downstream transit victim.
+        var owner = elevated.OrderBy(HopNum).First();
+        var ownerEvt = evts(owner).FirstOrDefault();
+
+        // Owner magnitudes from its fired event when it has one; otherwise (the owner was elevated via
+        // the relative jitter/excursion arm with no fired RTT event) compute them from its samples, so
+        // the row never reports 0 -> 0.
+        double baseRtt, peakRtt, baseJit, peakJit;
+        if (ownerEvt != null)
+        {
+            baseRtt = ownerEvt.BaselineRttMs;
+            peakRtt = ownerEvt.PeakRttMs;
+            baseJit = ownerEvt.BaselineJitterMs;
+            peakJit = ownerEvt.PeakJitterMs;
+        }
+        else
+        {
+            var inR = owner.Samples.Where(x => x.Time >= start && x.Time <= end && x.RttAvgMs.HasValue).Select(x => x.RttAvgMs!.Value).ToList();
+            var baseR = owner.Samples.Where(x => (x.Time < start || x.Time > end) && x.RttAvgMs.HasValue).Select(x => x.RttAvgMs!.Value).ToList();
+            var inJ = owner.Samples.Where(x => x.Time >= start && x.Time <= end).Select(x => x.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
+            var baseJ = owner.Samples.Where(x => x.Time < start || x.Time > end).Select(x => x.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
+            baseRtt = SeriesStats.Median(baseR) ?? 0;
+            peakRtt = inR.Count > 0 ? SeriesStats.Percentile(inR, 0.90) ?? baseRtt : baseRtt;
+            baseJit = SeriesStats.Median(baseJ) ?? 0;
+            peakJit = inJ.Count > 0 ? inJ.Max() : baseJit;
+        }
+
+        // Decision 2: name the single worst hop (largest relative RTT rise among the fired members).
+        var worst = elevated
+            .SelectMany(s => evts(s).Select(e => (Series: s, Rise: e.BaselineRttMs > 0 ? (e.PeakRttMs - e.BaselineRttMs) / e.BaselineRttMs : 0)))
+            .OrderByDescending(x => x.Rise)
+            .Select(x => x.Series)
+            .FirstOrDefault();
+
+        var reason = loadCoincident
+            ? $"{elevated.Count} monitored paths rose together under heavy WAN load, so the limit was your access link (bufferbloat or a congested shared-access network), not one hop."
+            : $"{elevated.Count} monitored paths across independent networks rose together with no heavy local load - a shared upstream bottleneck lifting the whole path, not one hop.";
+        if (worst != null && worst != owner && worst.AsnName is { Length: > 0 } worstName)
+            reason += $" Worst at {worstName}.";
+
+        return new CongestionEvent
+        {
+            Start = start,
+            End = end,
+            AsnNumbers = owner.AsnNumber > 0 ? new List<int> { owner.AsnNumber } : new List<int>(),
+            AsnNames = owner.AsnName is { Length: > 0 } ? new List<string> { owner.AsnName } : new List<string>(),
+            TargetIds = owner.TargetIds.ToList(),
+            BaselineRttMs = baseRtt,
+            PeakRttMs = peakRtt,
+            BaselineJitterMs = baseJit,
+            PeakJitterMs = peakJit,
+            Scope = CongestionScope.Unlocalized,
+            Disposition = loadCoincident ? CongestionDisposition.SelfInflicted : CongestionDisposition.Confirmed,
+            BottleneckHopIp = owner.HopIps.FirstOrDefault(),
+            BottleneckLabel = owner.AsnName,
+            LoadCoincident = loadCoincident,
+            Confidence = 70,
+            AttributionReason = reason
+        };
     }
 
     /// <summary>
@@ -167,7 +298,9 @@ public static class CongestionLocalizer
         bool loadCoincident,
         bool cleanControlExists,
         bool lineWideUnderLoad,
-        Func<AsnSeries, DateTime, DateTime, bool> isElevated)
+        bool uniform,
+        Func<AsnSeries, DateTime, DateTime, bool> isElevated,
+        Func<AsnSeries, bool> isClean)
     {
         var hopNum = topology.HopNumberByIp.TryGetValue(bottleneckIp, out var hn) ? hn : int.MaxValue;
         // The hop the congestion sits ON owns the event - that ASN is the culprit, the deeper
@@ -204,20 +337,26 @@ public static class CongestionLocalizer
         // access-layer bufferbloat (which would lift every path that shares your access link).
         // Require samples IN the window: a series with no data then (a newer target added after a
         // past event, or a monitoring gap) is unknown, not clean, and must not pad this evidence.
+        // Clean = rose no more than the shared load floor in RTT (isClean), NOT merely "not elevated":
+        // under load the jitter floor lifts every path, so a jitter-inclusive test would count zero
+        // clean controls and wrongly drop the "this hop's own capacity, not your access egress" finding.
         var cleanParallelPaths = allSeries.Count(s => HasTrace(s, topology)
             && HasDataInWindow(s, window.Start, window.End)
             && !s.HopIps.Contains(bottleneckIp, StringComparer.OrdinalIgnoreCase)
             && !s.AncestorIps.Contains(bottleneckIp, StringComparer.OrdinalIgnoreCase)
-            && !isElevated(s, window.Start, window.End));
+            && isClean(s));
 
         CongestionDisposition disposition;
         string reason;
-        if (isAccessEgress && loadCoincident && lineWideUnderLoad)
+        if (isAccessEgress && loadCoincident && lineWideUnderLoad && uniform)
         {
-            // Bottleneck is the access egress AND every monitored path drifted up together under load
-            // (line-wide). That's loaded latency where all your traffic converges, not a distinct ISP
-            // hop. Surfaced as "Loaded Latency" (not Congestion), not scored (Suppressed). We assert
-            // location + correlation only; the mechanism (CPE buffer, OLT, policing) is unknowable here.
+            // Bottleneck is the access egress AND every monitored path drifted up TOGETHER and UNIFORMLY
+            // under load (line-wide, no path materially worse than the shared floor). That's loaded
+            // latency where all your traffic converges, not a distinct ISP hop. The uniform gate mirrors
+            // the collapse: a shared floor plus a few materially-worse hops is localized congestion on
+            // top of load, not bufferbloat, so it must NOT read as self-inflicted here either. Surfaced
+            // as "Loaded Latency" (not Congestion), not scored (Suppressed). We assert location +
+            // correlation only; the mechanism (CPE buffer, OLT, policing) is unknowable here.
             disposition = CongestionDisposition.SelfInflicted;
             reason = "Every monitored path rose together under load, so the limit was your access link, not a single hop - consistent with bufferbloat or a congested shared-access network.";
         }
@@ -253,7 +392,7 @@ public static class CongestionLocalizer
             _ => 50
         };
 
-        var evt = NewEvent(bottleneckSeries, members, eventsBySeries, window);
+        var evt = NewEvent(bottleneckSeries, members, eventsBySeries, window, options);
         evt.Scope = CongestionScope.Hop;
         evt.Disposition = disposition;
         evt.BottleneckHopIp = bottleneckIp;
@@ -270,9 +409,10 @@ public static class CongestionLocalizer
         Dictionary<AsnSeries, List<CongestionEvent>> eventsBySeries,
         (DateTime Start, DateTime End) window,
         CongestionTopology topology,
-        bool loadCoincident)
+        bool loadCoincident,
+        IspHealthOptions options)
     {
-        var evt = NewEvent(null, members, eventsBySeries, window);
+        var evt = NewEvent(null, members, eventsBySeries, window, options);
         evt.Scope = CongestionScope.Unlocalized;
         evt.Disposition = CongestionDisposition.Confirmed;
         evt.LoadCoincident = loadCoincident;
@@ -287,7 +427,8 @@ public static class CongestionLocalizer
         AsnSeries? identity,
         List<AsnSeries> members,
         Dictionary<AsnSeries, List<CongestionEvent>> eventsBySeries,
-        (DateTime Start, DateTime End) window)
+        (DateTime Start, DateTime End) window,
+        IspHealthOptions options)
     {
         // Metrics come from the culprit hop when it has its own elevation, else the worst member.
         var metricSource = identity != null
@@ -295,17 +436,27 @@ public static class CongestionLocalizer
             && idEvents.Any(e => Overlaps(e.Start, e.End, window.Start, window.End))
             ? new List<AsnSeries> { identity }
             : members;
-        var worst = metricSource
+        var sourceEvents = metricSource
             .SelectMany(m => eventsBySeries[m].Where(e => Overlaps(e.Start, e.End, window.Start, window.End)))
-            .OrderByDescending(e => e.PeakRttMs - e.BaselineRttMs)
-            .First();
+            .ToList();
+        var worst = sourceEvents.OrderByDescending(e => e.PeakRttMs - e.BaselineRttMs).First();
         // The penalized ASN/targets are the bottleneck hop when localized; downstream victims
         // are excluded. An unlocalized event has no single culprit, so it keeps the full set.
         var id = identity != null ? new List<AsnSeries> { identity } : members;
+        // Report the shared cluster window when this bottleneck's own elevation covers most of it,
+        // so a genuine co-temporal event reads as one clean window across its per-hop rows. Only a
+        // member that cleared much earlier than the others (an outlier) reports its own shorter span
+        // - so a hop that resolved in 45 min isn't stamped with a co-occurring hop's multi-hour span.
+        // Correlation/propagation/disposition above still use the full cluster window regardless.
+        var ownStart = sourceEvents.Min(e => e.Start);
+        var ownEnd = sourceEvents.Max(e => e.End);
+        var clusterSpan = (window.End - window.Start).TotalSeconds;
+        var sharesWindow = clusterSpan <= 0
+            || (ownEnd - ownStart).TotalSeconds >= clusterSpan * options.CongestionSharedWindowMinFraction;
         return new CongestionEvent
         {
-            Start = window.Start,
-            End = window.End,
+            Start = sharesWindow ? window.Start : ownStart,
+            End = sharesWindow ? window.End : ownEnd,
             AsnNumbers = id.Select(m => m.AsnNumber).Distinct().ToList(),
             AsnNames = id.Select(m => m.AsnName ?? $"AS{m.AsnNumber}").Distinct().ToList(),
             TargetIds = id.SelectMany(m => m.TargetIds).Distinct().ToList(),
@@ -327,12 +478,14 @@ public static class CongestionLocalizer
     }
 
     /// <summary>
-    /// A softer "elevated in this window" test than firing a full congestion event: true when a
-    /// meaningful fraction of in-window RTT samples exceed the hop's own baseline p90 by the
-    /// congestion RTT floor. A real bottleneck's added delay reaches downstream hops as excursions
-    /// that may be too sparse to fire their own sustained event; using this for the propagation
-    /// and clean-control checks stops the localizer from absolving a genuine bottleneck as
-    /// control-plane noise just because nothing downstream fired. Clean off-path hops sit near zero.
+    /// A softer "elevated in this window" test than firing a full congestion event, used for the
+    /// propagation and clean-control checks so the localizer doesn't absolve a genuine bottleneck as
+    /// control-plane noise just because nothing downstream fired its own event. A hop counts as
+    /// elevated if EITHER its RTT rose (a meaningful fraction of in-window RTT samples exceed its own
+    /// baseline p90 by the congestion RTT floor) OR its jitter rose relative to its own baseline.
+    /// The jitter arm matters because many incidents are jitter-driven with flat RTT - an RTT-only
+    /// test reads the downstream as clean and shatters one chain-wide rise into per-hop noise rows.
+    /// Both arms are relative to the hop's OWN baseline; clean off-path hops sit near zero on both.
     /// </summary>
     internal static bool ElevatedInWindow(AsnSeries series, DateTime start, DateTime end, IspHealthOptions options)
     {
@@ -345,10 +498,30 @@ public static class CongestionLocalizer
         if (inWindow.Count == 0 || baseline.Count == 0) return false;
 
         var baselineP90 = SeriesStats.Percentile(baseline, 0.90);
-        if (!baselineP90.HasValue) return false;
-        var threshold = baselineP90.Value + options.CongestionRttMinDeltaMs;
-        var excursionFraction = inWindow.Count(v => v > threshold) / (double)inWindow.Count;
-        return excursionFraction >= options.CongestionPropagationExcursionFraction;
+        if (baselineP90.HasValue)
+        {
+            var threshold = baselineP90.Value + options.CongestionRttMinDeltaMs;
+            var excursionFraction = inWindow.Count(v => v > threshold) / (double)inWindow.Count;
+            if (excursionFraction >= options.CongestionPropagationExcursionFraction) return true;
+        }
+
+        // Jitter arm: the downstream of a real bottleneck often inherits the delay as jitter while its
+        // median RTT barely moves, so RTT-only propagation misses it. Compare in-window median jitter
+        // to this hop's OWN baseline median (relative, with a small absolute floor so a near-zero hop
+        // isn't tripped by a sub-ms ratio swing).
+        var inJitter = series.Samples
+            .Where(x => x.Time >= start && x.Time <= end).Select(x => x.EffectiveJitterMs)
+            .Where(j => j.HasValue).Select(j => j!.Value).ToList();
+        var baseJitter = series.Samples
+            .Where(x => x.Time < start || x.Time > end).Select(x => x.EffectiveJitterMs)
+            .Where(j => j.HasValue).Select(j => j!.Value).ToList();
+        if (inJitter.Count == 0 || baseJitter.Count == 0) return false;
+
+        var inJitMedian = SeriesStats.Median(inJitter);
+        var baseJitMedian = SeriesStats.Median(baseJitter);
+        return inJitMedian.HasValue && baseJitMedian.HasValue
+            && inJitMedian.Value >= baseJitMedian.Value * options.CongestionPropagationJitterFactor
+            && inJitMedian.Value - baseJitMedian.Value >= options.CongestionPropagationJitterFloorMs;
     }
 
     private static int DeepestHopNum(AsnSeries series, CongestionTopology topology) => series.HopIps
@@ -381,8 +554,13 @@ public static class CongestionLocalizer
             .Select(x => x.RttAvgMs!.Value).ToList();
         if (inWindow.Count == 0 || baseline.Count == 0) return false;
         var bMed = SeriesStats.Median(baseline);
-        var eMed = SeriesStats.Median(inWindow);
-        return bMed.HasValue && eMed.HasValue && eMed.Value > bMed.Value + options.CongestionLineWideMinShiftMs;
+        // Use a high in-window percentile, not the median: an event with a strong core and a long
+        // mild tail dilutes the median toward baseline, so a path that genuinely rose for a good part
+        // of the window flickers in and out of "rose" across recomputes and the line-wide breadth
+        // hovers at its threshold. The percentile captures the strong portion robustly; a flat path
+        // (or one that only nudged the tail) still sits at baseline and does not count.
+        var eHigh = SeriesStats.Percentile(inWindow, options.CongestionLineWideRisePercentile);
+        return bMed.HasValue && eHigh.HasValue && eHigh.Value > bMed.Value + options.CongestionLineWideMinShiftMs;
     }
 
     private static List<List<(AsnSeries Series, CongestionEvent Evt)>> ClusterByTime(

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -195,8 +195,10 @@ public enum CongestionDisposition
 /// </summary>
 public class CongestionEvent
 {
-    public DateTime Start { get; init; }
-    public DateTime End { get; init; }
+    // Settable (not init) so a long-window report can snap these to fine-resolution boundaries
+    // after detection - see IspHealthService.RefineCongestionBoundariesAsync.
+    public DateTime Start { get; set; }
+    public DateTime End { get; set; }
 
     /// <summary>ASNs affected. More than one means a shared upstream event.</summary>
     public List<int> AsnNumbers { get; init; } = new();
@@ -297,13 +299,40 @@ public enum OutageScope
 /// near-total loss while probes kept reporting. A monitoring gap (console offline) has no
 /// samples at all and is never an outage. Scored by duration alone via a capped Packet
 /// Loss penalty - independent of shape or which hops dropped; the scope, break point, and
-/// per-tier recovery shape are presentation only.
+/// per-tier recovery shape are presentation only. Spans below
+/// <see cref="IspHealthOptions.OutageBriefMaxSeconds"/> are flagged <see cref="IsBrief"/> -
+/// short transit/upstream flaps surfaced on the timeline with only a fraction-of-a-point score hit.
 /// </summary>
 public class OutageEvent
 {
     public DateTime Start { get; init; }
     public DateTime End { get; init; }
     public TimeSpan Duration => End - Start;
+
+    /// <summary>
+    /// True when this span is a brief disruption (shorter than
+    /// <see cref="IspHealthOptions.OutageBriefMaxSeconds"/>) rather than a full outage. Brief
+    /// disruptions are reported distinctly and ride the low end of the severity curve, so their
+    /// score impact is at most a point. Set by the detector.
+    /// </summary>
+    public bool IsBrief { get; init; }
+
+    /// <summary>
+    /// True when this is a partial-loss disruption (degradation): a coincident burst of elevated
+    /// loss across many path targets that never reached the near-total dark threshold, so nothing
+    /// went fully dark. Distinct from a blackout outage - reported by peak loss and breadth rather
+    /// than a dark/recovery waterfall, and its loss is NOT masked from the Packet Loss factor.
+    /// </summary>
+    public bool IsPartial { get; init; }
+
+    /// <summary>Worst per-target mean loss reached during the event, for the partial-loss summary.</summary>
+    public double PeakLossPct { get; init; }
+
+    /// <summary>Distinct path targets that degraded during the event (partial-loss breadth).</summary>
+    public int DegradedTargetCount { get; init; }
+
+    /// <summary>Total path targets reporting during the event, the denominator for the breadth summary.</summary>
+    public int PathTargetCount { get; init; }
 
     /// <summary>Whether even the access hop went dark, or it held while everything beyond it dropped.</summary>
     public OutageScope Scope { get; init; }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -168,6 +168,27 @@ public class IspHealthOptions
     public double CongestionJitterMinDeltaMs { get; set; } = 0.8;
 
     /// <summary>
+    /// Hysteresis for congestion run continuation. Starting a run still requires the full entry
+    /// gate (RTT+jitter, or the burst shape); but once a run is active it stays alive while any
+    /// signal remains at least this fraction of the way from baseline to its entry threshold.
+    /// Without it a long event whose tail hovers just under the entry gate (the milder second half
+    /// of a real multi-hour event) flickers in and out and truncates to its peak. Entry is
+    /// unchanged, so this only extends events that already legitimately started - never creates new
+    /// ones.
+    /// </summary>
+    public double CongestionSustainFraction { get; set; } = 0.5;
+
+    /// <summary>
+    /// A localized congestion event reports the shared time-cluster window when its own bottleneck's
+    /// elevation covers at least this fraction of that window; a member substantially shorter (an
+    /// outlier that cleared early while co-occurring hops lingered) reports its own span instead.
+    /// Keeps a genuine co-temporal shared event presented as one clean window, while still breaking
+    /// out a hop whose duration is very different. At 1.0 every member uses its own exact span; at 0
+    /// every member uses the full cluster window.
+    /// </summary>
+    public double CongestionSharedWindowMinFraction { get; set; } = 0.7;
+
+    /// <summary>
     /// WAN utilization (fraction of the expected plan speed, worst direction) at or above
     /// which a congestion bucket is treated as coinciding with heavy local load. The
     /// self-inflicted classifier uses this to tell access-egress bufferbloat (your own
@@ -194,6 +215,42 @@ public class IspHealthOptions
     public double CongestionPropagationExcursionFraction { get; set; } = 0.05;
 
     /// <summary>
+    /// Factor a hop's in-window median jitter must clear over its own baseline median jitter to count
+    /// as elevated for PROPAGATION. Many congestion incidents are jitter-driven with flat RTT, so an
+    /// RTT-only propagation test reads the downstream as "clean" and wrongly absolves a real chain-wide
+    /// rise as per-hop control-plane noise. Softer than the detection jitter factor; paired with an
+    /// absolute floor below so a near-zero-baseline hop is not tripped by a sub-ms ratio swing.
+    /// </summary>
+    public double CongestionPropagationJitterFactor { get; set; } = 1.5;
+
+    /// <summary>
+    /// Minimum absolute median-jitter rise (ms) for the propagation jitter test, on top of the
+    /// <see cref="CongestionPropagationJitterFactor"/> ratio - a 0.05 -> 0.10 ms doubling is still
+    /// noise, not propagation.
+    /// </summary>
+    public double CongestionPropagationJitterFloorMs { get; set; } = 0.2;
+
+    /// <summary>
+    /// Loaded-latency uniformity gate. Under heavy WAN load every path picks up a shared FLOOR of
+    /// added delay (that floor alone is loaded latency). A shared/loaded-latency event collapses to a
+    /// single row only when the rise is UNIFORM: the worst path's RTT rise over its own baseline is
+    /// within this factor of the median path's rise. If a few paths rose materially further than the
+    /// floor (high variance), those are localized congestion ON TOP of the load - the event stays
+    /// per-hop so the localizer surfaces them as "this hop's own capacity", not "everything slowed".
+    /// </summary>
+    public double CongestionLoadedUniformityFactor { get; set; } = 2.0;
+
+    /// <summary>
+    /// Clean-control floor multiple. A parallel path counts as a CLEAN control (proof a hop's
+    /// elevation is its own capacity, not access bufferbloat) when its RTT rose no more than this
+    /// multiple of the shared floor - i.e. it only picked up the load floor, not localized congestion.
+    /// Must be tighter than <see cref="CongestionLoadedUniformityFactor"/> so the materially-worse
+    /// hops are NOT counted as clean. Uses RTT (not jitter): under load the jitter floor lifts every
+    /// path, so a jitter-inclusive "elevated" test would erase every clean control.
+    /// </summary>
+    public double CongestionCleanControlFloorFactor { get; set; } = 1.5;
+
+    /// <summary>
     /// Self-inflicted access bufferbloat is a line-wide rise under load: this fraction of monitored
     /// paths (with data) must have their in-window median rise above baseline for an access-egress
     /// bottleneck under load to read as self-inflicted rather than a hop bottleneck. A robust majority
@@ -208,6 +265,14 @@ public class IspHealthOptions
     /// high-baseline hops where it sits under the absolute elevation floor.
     /// </summary>
     public double CongestionLineWideMinShiftMs { get; set; } = 0.5;
+
+    /// <summary>
+    /// In-window percentile used by the line-wide rise test. A high percentile (vs the median) keeps a
+    /// path that rose strongly for a good part of the window counted as "rose" even when a long mild
+    /// tail dilutes its median toward baseline - otherwise the line-wide breadth flickers across
+    /// recomputes for an event with a strong core and a long tail. A flat path still sits at baseline.
+    /// </summary>
+    public double CongestionLineWideRisePercentile { get; set; } = 0.75;
 
     /// <summary>Window size in minutes for step-change median comparison.</summary>
     public int StepWindowMinutes { get; set; } = 30;
@@ -232,8 +297,13 @@ public class IspHealthOptions
     /// </summary>
     public double StepStableIqrFraction { get; set; } = 0.15;
 
-    /// <summary>Bucket size in minutes for outage detection.</summary>
-    public int OutageBucketMinutes { get; set; } = 1;
+    /// <summary>
+    /// Bucket size in seconds for outage detection. Sub-minute so a brief (~30 s) drop resolves
+    /// into its own fully-dark buckets instead of being diluted to a partial-loss bucket inside a
+    /// one-minute window and failing the dark-fraction gate. At the internet targets' ~7-10 s
+    /// effective sample cadence a 15 s bucket still holds one or two samples per target.
+    /// </summary>
+    public int OutageBucketSeconds { get; set; } = 15;
 
     /// <summary>
     /// Mean loss (percent) at or above which a tier counts as dark in an outage bucket.
@@ -256,17 +326,71 @@ public class IspHealthOptions
     /// </summary>
     public int OutageMinReportingTargets { get; set; } = 2;
 
-    /// <summary>Minimum sustained duration in minutes for an outage event.</summary>
-    public int OutageMinDurationMinutes { get; set; } = 2;
+    /// <summary>
+    /// Minimum sustained duration in seconds before a near-total-loss span is reported at all.
+    /// Set above a momentary blip (a single lost probe group) but well below the brief/full
+    /// divider, so a clean 30 s transit drop is captured rather than discarded.
+    /// </summary>
+    public int OutageMinDurationSeconds { get; set; } = 30;
+
+    /// <summary>
+    /// Spans shorter than this are classified as brief disruptions (short transit/upstream flaps);
+    /// at or above it they are full outages. This is the prior two-minute outage threshold, kept as
+    /// the divider so what users already understood as an outage is unchanged - brief disruptions are
+    /// a new, lighter tier beneath it that rides the low end of the severity curve. See
+    /// <see cref="OutageEvent.IsBrief"/>.
+    /// </summary>
+    public int OutageBriefMaxSeconds { get; set; } = 120;
 
     /// <summary>
     /// Two outage runs separated by a healthy gap no longer than this are coalesced into one
     /// event. One real outage briefly clears the dark-fraction gate during staggered onset or
-    /// inside-out recovery (targets dark/heal at slightly different minutes); without this it
+    /// inside-out recovery (targets dark/heal at slightly different times); without this it
     /// would fragment into several adjacent events. The sealed gap counts as downtime, so keep
     /// it short - the over-count is bounded by this value per seam.
     /// </summary>
-    public int OutageMaxGapMinutes { get; set; } = 3;
+    public int OutageMaxGapSeconds { get; set; } = 180;
+
+    /// <summary>
+    /// Bucket size in seconds for the partial-loss (degradation) pass. Wider than the blackout
+    /// bucket because partial loss is route-specific: independent targets degrade at slightly
+    /// different instants across the event, so a 15 s bucket holds only a couple at once. A 30 s
+    /// window lets the coincident-but-staggered degradations land together for the breadth gate.
+    /// </summary>
+    public int OutagePartialBucketSeconds { get; set; } = 30;
+
+    /// <summary>
+    /// Loss (percent) at or above which a target counts as degraded for partial-loss detection.
+    /// Below the near-total <see cref="OutageDarkLossPct"/> - a partial-loss burst is the path
+    /// getting lossy, not unreachable.
+    /// </summary>
+    public double OutagePartialLossPct { get; set; } = 50.0;
+
+    /// <summary>
+    /// Minimum distinct path targets simultaneously degraded (within one partial bucket) for a
+    /// partial-loss disruption. Coincident loss across many independent destinations is a real
+    /// path event; one or two lossy targets are noise (ICMP rate-limiting, a single bad CDN node).
+    /// </summary>
+    public int OutagePartialMinTargets { get; set; } = 4;
+
+    /// <summary>
+    /// Minimum distinct ASNs/destinations spanned by the degraded targets, alongside
+    /// <see cref="OutagePartialMinTargets"/>. Guards against several targets behind one ASN all
+    /// degrading together (that ASN's own issue, not a path-wide event) tripping detection.
+    /// </summary>
+    public int OutagePartialMinAsns { get; set; } = 2;
+
+    /// <summary>Minimum sustained duration in seconds for a partial-loss disruption.</summary>
+    public int OutagePartialMinDurationSeconds { get; set; } = 20;
+
+    /// <summary>
+    /// Scales a partial-loss disruption's severity-curve penalty relative to a full outage of the
+    /// same duration: the curve input is duration x (peak loss fraction) x this weight, so the ding
+    /// stays tiny (a 30 s / 80% event is about a point). Partial loss also still feeds the Packet
+    /// Loss factor (these events are deliberately not masked from it), so this is a small additional
+    /// nudge for visibility, with the minor overlap accepted by design.
+    /// </summary>
+    public double OutagePartialPenaltyWeight { get; set; } = 1.0;
 
     /// <summary>
     /// Recovery-time tolerance for collapsing per-target access ISP rows in the outage waterfall:

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -23,7 +23,10 @@ public class IspHealthScorer
     // band (Item E) used to grade ISP and transit jitter against the access medium's inherent floor.
     private AccessProfile? _profile;
 
-    private bool InOutage(DateTime time) => _outages.Any(o => time >= o.Start && time < o.End);
+    // Only blackout outages mask their loss from the other factors; partial-loss disruptions are
+    // deliberately left in the Packet Loss factor (their loss IS the degradation signal), so they
+    // are excluded here.
+    private bool InOutage(DateTime time) => _outages.Any(o => !o.IsPartial && time >= o.Start && time < o.End);
 
     public IspHealthScorer(IspHealthOptions options, ILogger? logger = null)
     {
@@ -80,22 +83,30 @@ public class IspHealthScorer
         var overall = CombineDimensions(accessDimension, transitDimension, ispAsnDimension);
         // An outage is scored once, here at the top level, on a duration curve - so a long
         // outage actually drives the score down instead of being diluted to a couple of
-        // points inside one factor. Scored by total downtime alone, shape-independent.
+        // points inside one factor. A partial-loss disruption counts as a fraction of that:
+        // its duration is weighted by its peak loss fraction (and a tunable weight), so a brief
+        // degradation is a near-zero ding while a blackout of the same length scores in full.
         // Local (LAN/gateway) outages are surfaced but never penalize the ISP - the gateway being
         // unreachable is the user's own LAN, not the ISP's fault (they still mask their dark window
         // from the other factors via InOutage, so that loss isn't double-counted against the ISP).
         var wanOutages = inputs.Outages.Where(o => o.Scope != OutageScope.Local).ToList();
-        var outageMinutes = wanOutages.Sum(o => o.Duration.TotalMinutes);
+        double EffectiveMinutes(OutageEvent o) => o.Duration.TotalMinutes *
+            (o.IsPartial ? Math.Clamp(o.PeakLossPct / 100.0, 0, 1) * _options.OutagePartialPenaltyWeight : 1.0);
+        var outageMinutes = wanOutages.Sum(EffectiveMinutes);
         if (outageMinutes > 0)
         {
-            var penalty = OutageScorePenalty(outageMinutes);
-            // Attribute the total (curve-based) penalty across the WAN outages by duration share so
-            // each outage row can show its own "-N points". Rounded shares may differ from the curve
-            // total by <=1 pt - cosmetic; the actual score deduction uses the curve total below.
+            // Floor a flagged WAN event at one point: if we surfaced it on the timeline it should
+            // visibly register, not round to a silent zero (a brief/partial event can curve to a
+            // fraction of a point otherwise). The floor is on the total, so many tiny events still
+            // cost at least a point rather than each.
+            var penalty = Math.Max(1.0, OutageScorePenalty(outageMinutes));
+            // Attribute the total penalty across the WAN outages by effective-minute share so each
+            // row can show its own "-N points". Rounded shares may differ from the curve total by
+            // <=1 pt - cosmetic; the actual deduction uses the total below.
             foreach (var o in wanOutages)
-                o.ScorePenaltyPoints = (int)Math.Round(penalty * (o.Duration.TotalMinutes / outageMinutes));
-            _logger?.LogDebug("ISP Health: outage penalty {Penalty} pts over {Min} min downtime ({Before} -> {After})",
-                penalty.ToString("0.#", CultureInfo.InvariantCulture), outageMinutes.ToString("0", CultureInfo.InvariantCulture),
+                o.ScorePenaltyPoints = (int)Math.Round(penalty * (EffectiveMinutes(o) / outageMinutes));
+            _logger?.LogDebug("ISP Health: outage penalty {Penalty} pts over {Min} effective min downtime ({Before} -> {After})",
+                penalty.ToString("0.#", CultureInfo.InvariantCulture), outageMinutes.ToString("0.#", CultureInfo.InvariantCulture),
                 overall, (int)Math.Max(0, Math.Round(overall - penalty)));
             overall = (int)Math.Max(0, Math.Round(overall - penalty));
         }
@@ -1140,23 +1151,29 @@ public class IspHealthScorer
 
         // Local (LAN/gateway) outages are surfaced in the waterfall but are not internet outages and
         // don't affect the score, so they never appear in this ISP-impact issue.
+        // Full outages and brief disruptions are surfaced as separate findings: a 30 s transit flap
+        // shouldn't read as the same event as a multi-minute outage. Both ride the same severity
+        // curve (a brief disruption costs at most a point), so the per-event score share is taken
+        // from the already-attributed ScorePenaltyPoints rather than recomputing the curve per group.
         var wanOutages = inputs.Outages.Where(o => o.Scope != OutageScope.Local).ToList();
-        if (wanOutages.Count > 0)
+        var fullOutages = wanOutages.Where(o => !o.IsPartial && !o.IsBrief).ToList();
+        var briefDisruptions = wanOutages.Where(o => !o.IsPartial && o.IsBrief).ToList();
+        var partialDisruptions = wanOutages.Where(o => o.IsPartial).ToList();
+        if (fullOutages.Count > 0)
         {
-            var multiple = wanOutages.Count > 1;
-            var totalDown = TimeSpan.FromMinutes(wanOutages.Sum(o => o.Duration.TotalMinutes));
-            var upstream = wanOutages.Where(o => o.Scope == OutageScope.Upstream && !string.IsNullOrEmpty(o.LastReachableHop)).ToList();
-            var allUpstream = wanOutages.All(o => o.Scope == OutageScope.Upstream) && upstream.Count > 0;
+            var multiple = fullOutages.Count > 1;
+            var totalDown = TimeSpan.FromMinutes(fullOutages.Sum(o => o.Duration.TotalMinutes));
+            var upstream = fullOutages.Where(o => o.Scope == OutageScope.Upstream && !string.IsNullOrEmpty(o.LastReachableHop)).ToList();
+            var allUpstream = fullOutages.All(o => o.Scope == OutageScope.Upstream) && upstream.Count > 0;
             var where = allUpstream
                 ? $" The break sat upstream of {string.Join(", ", upstream.Select(o => o.LastReachableHop).Distinct())} - your equipment stayed reachable, so {(multiple ? "these were" : "this was")} an ISP-side fault, not your network."
                 : " At least one event took the whole WAN dark, including the first ISP hop.";
             var count = multiple
-                ? $"{wanOutages.Count} internet outages totaling {FormatOutageDuration(totalDown)}"
-                : $"An internet outage of {FormatOutageDuration(wanOutages[0].Duration)}";
+                ? $"{fullOutages.Count} internet outages totaling {FormatOutageDuration(totalDown)}"
+                : $"An internet outage of {FormatOutageDuration(fullOutages[0].Duration)}";
             // Be transparent about the score hit: the outage penalty is applied at the top level
-            // and isn't tied to any one factor, so spell it out here or it's invisible. Matches the
-            // actual penalty (both exclude Local outages).
-            var penalty = (int)Math.Round(OutageScorePenalty(totalDown.TotalMinutes));
+            // and isn't tied to any one factor, so spell it out here or it's invisible.
+            var penalty = fullOutages.Sum(o => o.ScorePenaltyPoints);
             var impact = penalty > 0
                 ? $" {(multiple ? "Together they" : "It")} lowered your ISP Health score by {penalty} {(penalty == 1 ? "point" : "points")}."
                 : string.Empty;
@@ -1173,6 +1190,53 @@ public class IspHealthScorer
                     : "Logged here so you can correlate it with ISP incidents; if the first ISP hop keeps dropping, check your modem/ONT and the line to your ISP.",
                 LinkUrl = "#isp-outages",
                 LinkText = "The recovery shape is shown on the timeline below."
+            });
+        }
+        if (briefDisruptions.Count > 0)
+        {
+            var multiple = briefDisruptions.Count > 1;
+            var totalDown = TimeSpan.FromSeconds(briefDisruptions.Sum(o => o.Duration.TotalSeconds));
+            var upstream = briefDisruptions.Where(o => o.Scope == OutageScope.Upstream && !string.IsNullOrEmpty(o.LastReachableHop)).ToList();
+            var allUpstream = briefDisruptions.All(o => o.Scope == OutageScope.Upstream) && upstream.Count > 0;
+            var count = multiple
+                ? $"{briefDisruptions.Count} brief internet disruptions totaling {FormatBriefDuration(totalDown)}"
+                : $"A brief internet disruption of {FormatBriefDuration(briefDisruptions[0].Duration)}";
+            var where = allUpstream
+                ? $" {(multiple ? "They sat" : "It sat")} upstream of {string.Join(", ", upstream.Select(o => o.LastReachableHop).Distinct())}, so your equipment stayed reachable - short ISP-side flaps."
+                : string.Empty;
+            var penalty = briefDisruptions.Sum(o => o.ScorePenaltyPoints);
+            var impact = penalty > 0
+                ? $" {(multiple ? "Together they" : "It")} lowered your ISP Health score by {penalty} {(penalty == 1 ? "point" : "points")}."
+                : " Too short to meaningfully affect your score; logged for visibility.";
+            issues.Add(new IspHealthIssue
+            {
+                Severity = IspIssueSeverity.Info,
+                Title = multiple ? "Brief internet disruptions in the window" : "Brief internet disruption in the window",
+                Description = $"{count} occurred while the Monitoring Agent kept probing (so {(multiple ? "these are real, not monitoring gaps" : "this is real, not a monitoring gap")}).{where}{impact}",
+                Recommendation = "Short drops like these are usually transient upstream or transit events; logged here so you can spot a pattern of flapping.",
+                LinkUrl = "#isp-outages",
+                LinkText = "Shown on the timeline below."
+            });
+        }
+        if (partialDisruptions.Count > 0)
+        {
+            var multiple = partialDisruptions.Count > 1;
+            var totalDown = TimeSpan.FromSeconds(partialDisruptions.Sum(o => o.Duration.TotalSeconds));
+            var worst = partialDisruptions.OrderByDescending(o => o.PeakLossPct).First();
+            var penalty = partialDisruptions.Sum(o => o.ScorePenaltyPoints);
+            var count = multiple
+                ? $"{partialDisruptions.Count} partial-loss disruptions totaling {FormatBriefDuration(totalDown)}"
+                : $"A partial-loss disruption of {FormatBriefDuration(partialDisruptions[0].Duration)}";
+            var breadth = $" Peak loss reached {worst.PeakLossPct:0}% across {worst.DegradedTargetCount} of {worst.PathTargetCount} path targets, so the loss was widespread rather than one bad target.";
+            var impact = $" {(multiple ? "Together they" : "It")} lowered your ISP Health score by {penalty} {(penalty == 1 ? "point" : "points")}.";
+            issues.Add(new IspHealthIssue
+            {
+                Severity = IspIssueSeverity.Info,
+                Title = multiple ? "Partial-loss disruptions in the window" : "Partial-loss disruption in the window",
+                Description = $"{count} hit the path: many targets degraded at once without going fully dark, so the internet was lossy but not unreachable.{breadth}{impact}",
+                Recommendation = "Coincident partial loss across many targets is usually upstream/transit congestion or a brief routing wobble; logged so you can correlate it with ISP incidents or watch for a pattern.",
+                LinkUrl = "#isp-outages",
+                LinkText = "Shown on the timeline below."
             });
         }
 
@@ -1306,6 +1370,9 @@ public class IspHealthScorer
 
     private static string FormatOutageDuration(TimeSpan d) =>
         d.TotalMinutes < 90 ? $"{d.TotalMinutes:0} min" : $"{d.TotalHours:0.#} h";
+
+    private static string FormatBriefDuration(TimeSpan d) =>
+        d.TotalSeconds < 90 ? $"{d.TotalSeconds:0} sec" : $"{d.TotalMinutes:0.#} min";
 
     private static string FormatMs(double ms) =>
         $"{ms.ToString("0.00", CultureInfo.InvariantCulture)} ms";

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -468,6 +468,10 @@ public class IspHealthService
         var congestionEvents = CongestionLocalizer.Localize(localizerSeries, congestionTopology, _options);
         if (referenceEvents != null)
             congestionEvents = GateAgainstCanonical(congestionEvents, referenceEvents, windowEnd);
+        // On a long (coarse-aggregate) window, snap congestion boundaries back to fine resolution so
+        // a marginal event's 15-min bucket edges don't land off where the canonical view would place
+        // them. No-op at canonical resolution; reads run concurrently (see method).
+        await RefineCongestionBoundariesAsync(congestionEvents, aggregate, ct);
         foreach (var ce in congestionEvents)
             _logger.LogDebug(
                 "ISP Health congestion: {Disposition} at {Hop} ({Label}) conf={Confidence} load={Load} - {Reason}",
@@ -563,6 +567,11 @@ public class IspHealthService
                 new OutageDetector.Hop(x.Name, baseDepth + i, x.Series, x.Groupable, x.AsnLabel)))
             .ToList();
         var outages = OutageDetector.Detect(internetTriggerTargets, outageHops, _options);
+        // Second pass: coincident partial-loss disruptions (the path getting lossy but not dark)
+        // across the full set of monitored hops, excluding windows already flagged as blackouts.
+        var partialDisruptions = OutageDetector.DetectPartial(
+            outageHops, outages.Select(o => (o.Start, o.End)).ToList(), _options);
+        outages = outages.Concat(partialDisruptions).OrderBy(o => o.Start).ToList();
 
         // chartClusters (one line per cluster) is the chart view computed from the same
         // snapshot the detectors ran on, so deeper-cluster "+N ms hop" labels still match
@@ -1115,6 +1124,57 @@ public class IspHealthService
             .SelectMany(c => ancestorIpsByTargetId.TryGetValue(c.Target.TargetId, out var anc) ? anc : Enumerable.Empty<string>())
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
         return nearIps.Overlaps(farAncestors);
+    }
+
+    /// <summary>
+    /// On a long viewing window the report is computed on a coarse aggregate (the point-count cap),
+    /// so a marginal congestion event's 15-min bucket boundaries can land a bucket off from where the
+    /// fine-resolution canonical view places them. For each event, re-query its target(s) at the
+    /// canonical fine aggregate over just the event's neighborhood, re-run detection, and snap
+    /// Start/End to the overlapping fine run. No-op at canonical resolution (aggregate already fine);
+    /// the per-event neighborhood reads fire concurrently so the added wall-clock is ~one small read.
+    /// </summary>
+    private async Task RefineCongestionBoundariesAsync(
+        List<CongestionEvent> events, TimeSpan aggregate, CancellationToken ct)
+    {
+        var fine = TimeSpan.FromSeconds(_options.LoadWindowSeconds);
+        if (events.Count == 0 || aggregate <= fine) return;
+
+        // Enough clean baseline on each side of a bounded event for fine re-detection to anchor.
+        var pad = TimeSpan.FromHours(2);
+
+        var refined = await Task.WhenAll(events.Select(async e =>
+        {
+            var runs = new List<(DateTime Start, DateTime End)>();
+            foreach (var tid in e.TargetIds)
+            {
+                var pts = await _influx.QueryLatencyDetailByTargetIdAsync(tid, e.Start - pad, e.End + pad, fine, ct);
+                if (pts.Count == 0) continue;
+                var series = new AsnSeries
+                {
+                    TargetIds = { tid },
+                    Samples = pts.Select(p => new LatencySample(p.Time, p.RttAvgMs, p.RttMaxMs, p.JitterMs, p.LossPercent)).ToList()
+                };
+                foreach (var r in CongestionDetector.DetectForSeries(series, _options))
+                    if (r.Start < e.End && e.Start < r.End) // overlaps the coarse event
+                        runs.Add((r.Start, r.End));
+            }
+            return (Event: e, Runs: runs);
+        }));
+
+        // Fine re-detection (with a 2 h clean pad on each side for a baseline, read across the view's
+        // edge) is ground truth. Coarse aggregation INFLATES bucket-p90, so "fires at the coarse
+        // aggregate but not at full resolution" is the signature of a coarse artifact - e.g. a
+        // window-edge p90 phantom on a flat hop - not a real event. Drop those; a genuine event
+        // reproduces against the padded fine baseline at both resolutions.
+        var phantoms = refined.Where(r => r.Runs.Count == 0).Select(r => r.Event).ToHashSet();
+        foreach (var (e, runs) in refined)
+        {
+            if (runs.Count == 0) continue;
+            e.Start = runs.Min(r => r.Start);
+            e.End = runs.Max(r => r.End);
+        }
+        events.RemoveAll(phantoms.Contains);
     }
 
     private static Dictionary<string, List<LatencySample>> ToSamples(

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
@@ -34,7 +34,7 @@ public static class OutageDetector
     {
         if (triggerTargets.Count == 0) return new List<OutageEvent>();
 
-        var windowSize = TimeSpan.FromMinutes(options.OutageBucketMinutes);
+        var windowSize = TimeSpan.FromSeconds(options.OutageBucketSeconds);
         var triggerByBucket = BucketTargets(triggerTargets, windowSize);
 
         // Outage buckets: enough internet targets reporting (a bucket with none is a
@@ -49,7 +49,7 @@ public static class OutageDetector
         var hopBuckets = hops.ToDictionary(h => h, h => BucketTargets(new[] { h.Series }, windowSize));
 
         // Contiguous runs of outage buckets (gap of one window ends a run), then coalesce
-        // runs separated by a short healthy gap (OutageMaxGapMinutes). One real outage dips
+        // runs separated by a short healthy gap (OutageMaxGapSeconds). One real outage dips
         // below the dark-fraction gate for a bucket or two during staggered onset/recovery
         // (targets go dark and heal at slightly different times) - without the coalesce that
         // shatters it into several events. Sealing the gap before duration-filtering also lets
@@ -64,7 +64,7 @@ public static class OutageDetector
             i = j + 1;
         }
 
-        var maxGap = TimeSpan.FromMinutes(options.OutageMaxGapMinutes);
+        var maxGap = TimeSpan.FromSeconds(options.OutageMaxGapSeconds);
         var merged = new List<(DateTime Start, DateTime End)>();
         foreach (var run in runs)
         {
@@ -75,13 +75,158 @@ public static class OutageDetector
         }
 
         var events = new List<OutageEvent>();
-        var minDuration = TimeSpan.FromMinutes(options.OutageMinDurationMinutes);
+        var minDuration = TimeSpan.FromSeconds(options.OutageMinDurationSeconds);
         foreach (var (start, end) in merged)
         {
             if (end - start < minDuration) continue;
             events.Add(BuildEvent(start, end, triggerTargets, hops, hopBuckets, options));
         }
         return events;
+    }
+
+    /// <summary>
+    /// Detects brief partial-loss disruptions: short windows where many independent path targets
+    /// degrade together (loss >= <see cref="IspHealthOptions.OutagePartialLossPct"/>) without any
+    /// reaching the near-total dark threshold. Distinct from <see cref="Detect"/> (blackouts) - it
+    /// keys on coincident breadth across targets and ASNs, the signal that partial loss is a real
+    /// path event rather than one lossy probe target. The breadth gate uses a wider bucket than the
+    /// blackout pass because partial loss is route-specific: independent targets degrade at slightly
+    /// different instants, so they only land together over a longer window. Windows overlapping a
+    /// blackout in <paramref name="darkWindows"/> are skipped so the two passes don't double-count.
+    /// </summary>
+    /// <param name="pathHops">Every monitored non-gateway path hop (access/transit/internet), for breadth and shape.</param>
+    /// <param name="darkWindows">Blackout outage spans already found by <see cref="Detect"/>, to exclude.</param>
+    public static List<OutageEvent> DetectPartial(
+        IReadOnlyList<Hop> pathHops,
+        IReadOnlyList<(DateTime Start, DateTime End)> darkWindows,
+        IspHealthOptions options)
+    {
+        var pool = pathHops.Where(h => !h.IsGateway).ToList();
+        if (pool.Count == 0) return new List<OutageEvent>();
+
+        var windowSize = TimeSpan.FromSeconds(options.OutagePartialBucketSeconds);
+        var hopBuckets = pool.ToDictionary(h => h, h => BucketTargets(new[] { h.Series }, windowSize));
+        var partialPct = options.OutagePartialLossPct;
+
+        // A bucket qualifies when enough distinct targets across enough distinct ASNs degrade
+        // together: coincident loss across independent destinations is a path event, a lone lossy
+        // target is noise.
+        bool BucketQualifies(DateTime t)
+        {
+            var degraded = pool.Where(h => hopBuckets[h].TryGetValue(t, out var l) && l.Count > 0 && l[0] >= partialPct).ToList();
+            var asns = degraded.Select(h => h.AsnLabel ?? h.Name).Distinct().Count();
+            return degraded.Count >= options.OutagePartialMinTargets && asns >= options.OutagePartialMinAsns;
+        }
+
+        var qualifying = hopBuckets.Values.SelectMany(d => d.Keys).Distinct()
+            .Where(BucketQualifies)
+            .OrderBy(t => t).ToList();
+        if (qualifying.Count == 0) return new List<OutageEvent>();
+
+        // Contiguous runs (gap of one window ends a run), then coalesce across a short healthy gap.
+        var runs = new List<(DateTime Start, DateTime End)>();
+        for (var i = 0; i < qualifying.Count;)
+        {
+            var j = i;
+            while (j + 1 < qualifying.Count && qualifying[j + 1] - qualifying[j] <= windowSize) j++;
+            runs.Add((qualifying[i], qualifying[j] + windowSize));
+            i = j + 1;
+        }
+        var maxGap = TimeSpan.FromSeconds(options.OutageMaxGapSeconds);
+        var merged = new List<(DateTime Start, DateTime End)>();
+        foreach (var run in runs)
+        {
+            if (merged.Count > 0 && run.Start - merged[^1].End <= maxGap)
+                merged[^1] = (merged[^1].Start, run.End);
+            else merged.Add(run);
+        }
+
+        var events = new List<OutageEvent>();
+        var minDuration = TimeSpan.FromSeconds(options.OutagePartialMinDurationSeconds);
+        foreach (var (start, end) in merged)
+        {
+            if (end - start < minDuration) continue;
+            // A blackout also clears the partial threshold, so a window already flagged as a
+            // blackout would otherwise surface twice - skip any that overlaps one.
+            if (darkWindows.Any(w => start < w.End && w.Start < end)) continue;
+            events.Add(BuildPartialEvent(start, end, pool, hopBuckets, options));
+        }
+        return events;
+    }
+
+    private static OutageEvent BuildPartialEvent(
+        DateTime start, DateTime end,
+        List<Hop> pool,
+        Dictionary<Hop, Dictionary<DateTime, List<double>>> hopBuckets,
+        IspHealthOptions options)
+    {
+        var partialPct = options.OutagePartialLossPct;
+        // Degraded duty cycle per hop, mirroring the blackout attribution but at the partial
+        // threshold: the break sits just beyond the deepest hop that stayed clean.
+        var degradedDepth = new Dictionary<int, bool>();
+        var degraded = new List<(Hop Hop, double Peak)>();
+        double eventPeak = 0;
+        foreach (var hop in pool.OrderBy(h => h.Depth))
+        {
+            double peak = 0;
+            int degradedBuckets = 0, totalBuckets = 0;
+            foreach (var (_, losses) in hopBuckets[hop].Where(kv => kv.Key >= start && kv.Key < end))
+            {
+                if (losses.Count == 0) continue;
+                totalBuckets++;
+                peak = Math.Max(peak, losses[0]);
+                if (losses[0] >= partialPct) degradedBuckets++;
+            }
+            if (totalBuckets == 0) continue;
+            degradedDepth[hop.Depth] = (double)degradedBuckets / totalBuckets >= 0.5;
+            if (degradedBuckets > 0)
+            {
+                eventPeak = Math.Max(eventPeak, peak);
+                degraded.Add((hop, peak));
+            }
+        }
+
+        // Unlike the blackout waterfall (which groups access hops via GroupAccessTiers), partial-loss
+        // tiers are per-hop, so several hops of one ASN would all read as just the ASN label. Only when
+        // a label repeats in this list, disambiguate it with the specific hop's name/hostname tail.
+        var labelCounts = degraded.GroupBy(d => d.Hop.AsnLabel ?? d.Hop.Name).ToDictionary(g => g.Key, g => g.Count());
+        var tiers = degraded.Select(d =>
+        {
+            var label = d.Hop.AsnLabel ?? d.Hop.Name;
+            return new OutageTierState
+            {
+                Name = DisambiguateTierLabel(label, d.Hop.Name, labelCounts[label] > 1),
+                Depth = d.Hop.Depth,
+                PeakLossPct = d.Peak,
+                WentDark = false,
+                RecoveredAt = null
+            };
+        }).ToList();
+
+        var nearest = pool.Where(h => degradedDepth.ContainsKey(h.Depth)).OrderBy(h => h.Depth).FirstOrDefault();
+        var lastClean = pool.Where(h => degradedDepth.TryGetValue(h.Depth, out var d) && !d).OrderByDescending(h => h.Depth).FirstOrDefault();
+        var scope = nearest == null || degradedDepth[nearest.Depth] || lastClean == null
+            ? OutageScope.FullWan
+            : OutageScope.Upstream;
+
+        var poolSeries = pool.Select(h => (IReadOnlyList<LatencySample>)h.Series).ToList();
+        var onset = FirstDark(poolSeries, start, end, partialPct) ?? start;
+        var recovery = PreciseRecovery(poolSeries, start, end, partialPct) ?? end;
+        var reporting = pool.Count(h => hopBuckets[h].Any(kv => kv.Key >= start && kv.Key < end && kv.Value.Count > 0));
+
+        return new OutageEvent
+        {
+            Start = onset,
+            End = recovery,
+            IsPartial = true,
+            IsBrief = recovery - onset < TimeSpan.FromSeconds(options.OutageBriefMaxSeconds),
+            PeakLossPct = eventPeak,
+            DegradedTargetCount = tiers.Count,
+            PathTargetCount = reporting,
+            Scope = scope,
+            LastReachableHop = scope == OutageScope.Upstream ? (lastClean!.AsnLabel ?? lastClean.Name) : null,
+            Tiers = tiers.OrderBy(t => t.Depth).ToList()
+        };
     }
 
     /// <summary>Per bucket, the list of each reporting target's mean loss in that bucket.</summary>
@@ -181,13 +326,14 @@ public static class OutageDetector
         // Bucket edges are minute-aligned; report the real onset and recovery instants from
         // the pooled trigger stream so the window carries seconds. Fall back to the bucket
         // edges if the precise edges can't be found (e.g. outage still ongoing at window end).
-        var onset = FirstDark(triggerTargets, start, end, options) ?? start;
-        var recovery = PreciseRecovery(triggerTargets, start, end, options) ?? end;
+        var onset = FirstDark(triggerTargets, start, end, options.OutageDarkLossPct) ?? start;
+        var recovery = PreciseRecovery(triggerTargets, start, end, options.OutageDarkLossPct) ?? end;
 
         return new OutageEvent
         {
             Start = onset,
             End = recovery,
+            IsBrief = recovery - onset < TimeSpan.FromSeconds(options.OutageBriefMaxSeconds),
             Scope = scope,
             LastReachableHop = scope == OutageScope.Upstream ? lastReachable!.Name : null,
             Tiers = GroupAccessTiers(tiers, options)
@@ -279,13 +425,28 @@ public static class OutageDetector
     private static string HostnameTail(string name, string asn) =>
         name.StartsWith(asn + " ", StringComparison.OrdinalIgnoreCase) ? name[(asn.Length + 1)..] : name;
 
-    /// <summary>Actual timestamp of the first dark sample (loss at/above the dark threshold) in [start, end).</summary>
+    /// <summary>
+    /// When a tier label repeats within one event's list (e.g. several hops of one access ISP), make
+    /// it specific: keep the hop's own name if it already extends the label (e.g. a cluster's
+    /// "+N ms hop"), otherwise append the hostname tail as "ASN (tail)" - matching the blackout
+    /// waterfall's style. A unique label is returned unchanged.
+    /// </summary>
+    private static string DisambiguateTierLabel(string label, string hopName, bool repeats)
+    {
+        if (!repeats || string.IsNullOrEmpty(hopName) || string.Equals(hopName, label, StringComparison.OrdinalIgnoreCase))
+            return label;
+        if (hopName.StartsWith(label + " ", StringComparison.OrdinalIgnoreCase))
+            return hopName; // already "label hostname" or "label (+N ms hop)"
+        return $"{label} ({HostnameTail(hopName, label)})";
+    }
+
+    /// <summary>Actual timestamp of the first sample at/above the loss threshold in [start, end).</summary>
     private static DateTime? FirstDark(
         IReadOnlyList<IReadOnlyList<LatencySample>> targets,
-        DateTime start, DateTime end, IspHealthOptions options) =>
+        DateTime start, DateTime end, double threshold) =>
         targets.SelectMany(t => t)
             .Where(s => s.LossPercent.HasValue && s.Time >= start && s.Time < end
-                && s.LossPercent.Value >= options.OutageDarkLossPct)
+                && s.LossPercent.Value >= threshold)
             .OrderBy(s => s.Time)
             .Select(s => (DateTime?)s.Time)
             .FirstOrDefault();
@@ -311,9 +472,8 @@ public static class OutageDetector
     /// </summary>
     private static DateTime? PreciseRecovery(
         IReadOnlyList<IReadOnlyList<LatencySample>> targets,
-        DateTime start, DateTime end, IspHealthOptions options)
+        DateTime start, DateTime end, double dark)
     {
-        var dark = options.OutageDarkLossPct;
         DateTime? lastDark = targets.SelectMany(t => t)
             .Where(s => s.LossPercent.HasValue && s.Time >= start && s.Time < end
                 && s.LossPercent.Value >= dark)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringAlertEvaluator.cs
@@ -97,7 +97,7 @@ public class MonitoringAlertEvaluator
         DeviceId = target.DeviceMac,
         DeviceName = target.Name,
         DeviceIp = target.Address,
-        SourceUrl = "/monitoring",
+        SourceUrl = "/monitoring?tab=performance",
         Tags = ["monitoring", target.TargetType.ToString().ToLowerInvariant()],
         Context = new Dictionary<string, string>
         {
@@ -118,7 +118,7 @@ public class MonitoringAlertEvaluator
         DeviceName = target.Name,
         DeviceIp = target.Address,
         MetricValue = result.RttAvgMs,
-        SourceUrl = "/monitoring",
+        SourceUrl = "/monitoring?tab=performance",
         Tags = ["monitoring", target.TargetType.ToString().ToLowerInvariant()],
         Context = new Dictionary<string, string>
         {
@@ -139,7 +139,7 @@ public class MonitoringAlertEvaluator
         DeviceIp = target.Address,
         MetricValue = avgLossPercent,
         ThresholdValue = SustainedLossThresholdPercent,
-        SourceUrl = "/monitoring",
+        SourceUrl = "/monitoring?tab=performance",
         Tags = ["monitoring", "packet-loss", target.TargetType.ToString().ToLowerInvariant()],
         Context = new Dictionary<string, string>
         {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/PonThresholds.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/PonThresholds.cs
@@ -1,7 +1,11 @@
+using NetworkOptimizer.Storage.Models;
+
 namespace NetworkOptimizer.Web.Services.Monitoring;
 
 /// <summary>
-/// Single source-of-truth for PON and SFP optical thresholds.
+/// Single source-of-truth for the default PON and SFP optical thresholds. These
+/// are the fallbacks used when the user hasn't overridden a value; the effective
+/// thresholds are resolved by <see cref="SfpDdmThresholds"/>.
 /// </summary>
 public static class PonThresholds
 {
@@ -21,4 +25,39 @@ public static class PonThresholds
 
     // --- Generic SFP thresholds ---
     public const double SfpTempHighGenericC = 87.0;
+}
+
+/// <summary>
+/// Effective SFP DDM alert thresholds, per transceiver category. Each value falls
+/// back to its <see cref="PonThresholds"/> default when the user hasn't set an
+/// override in <see cref="MonitoringSettings"/>.
+/// </summary>
+public sealed record SfpDdmThresholds(
+    double PonRxPowerLowDbm,
+    double PonTxPowerHighDbm,
+    double PonTempHighC,
+    double AeRxPowerLowDbm,
+    double AeTxPowerHighDbm,
+    double AeTempHighC,
+    double SfpTempHighGenericC)
+{
+    /// <summary>The built-in defaults, used when no monitoring settings exist.</summary>
+    public static SfpDdmThresholds Defaults { get; } = new(
+        PonThresholds.PonRxPowerLowDbm,
+        PonThresholds.PonTxPowerHighDbm,
+        PonThresholds.PonTempHighC,
+        PonThresholds.AeRxPowerLowDbm,
+        PonThresholds.AeTxPowerHighDbm,
+        PonThresholds.AeTempHighC,
+        PonThresholds.SfpTempHighGenericC);
+
+    /// <summary>Resolves effective thresholds from settings, defaulting any unset value.</summary>
+    public static SfpDdmThresholds FromSettings(MonitoringSettings s) => new(
+        s.PonRxPowerLowDbm ?? PonThresholds.PonRxPowerLowDbm,
+        s.PonTxPowerHighDbm ?? PonThresholds.PonTxPowerHighDbm,
+        s.PonTempHighC ?? PonThresholds.PonTempHighC,
+        s.AeRxPowerLowDbm ?? PonThresholds.AeRxPowerLowDbm,
+        s.AeTxPowerHighDbm ?? PonThresholds.AeTxPowerHighDbm,
+        s.AeTempHighC ?? PonThresholds.AeTempHighC,
+        s.SfpTempHighGenericC ?? PonThresholds.SfpTempHighGenericC);
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/SfpAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/SfpAlertEvaluator.cs
@@ -12,16 +12,6 @@ namespace NetworkOptimizer.Web.Services.Monitoring;
 /// </summary>
 public class SfpAlertEvaluator
 {
-    private const double PonRxPowerLowDbm = PonThresholds.PonRxPowerLowDbm;
-    private const double PonTxPowerHighDbm = PonThresholds.PonTxPowerHighDbm;
-    private const double PonTempHighC = PonThresholds.PonTempHighC;
-
-    private const double AeRxPowerLowDbm = PonThresholds.AeRxPowerLowDbm;
-    private const double AeTxPowerHighDbm = PonThresholds.AeTxPowerHighDbm;
-    private const double AeTempHighC = PonThresholds.AeTempHighC;
-
-    private const double SfpTempHighC = PonThresholds.SfpTempHighGenericC;
-
     private const double TempHysteresisC = PonThresholds.TempHysteresisC;
     private const double PowerHysteresisDbm = PonThresholds.PowerHysteresisDbm;
 
@@ -39,6 +29,7 @@ public class SfpAlertEvaluator
         string deviceMac, string portName, string? deviceName,
         SfpCategory category,
         double? rxPowerDbm, double? txPowerDbm, double? temperatureC,
+        SfpDdmThresholds thresholds,
         CancellationToken ct = default)
     {
         var key = $"{deviceMac}:{portName}";
@@ -50,9 +41,9 @@ public class SfpAlertEvaluator
         {
             var threshold = category switch
             {
-                SfpCategory.Pon => PonTempHighC,
-                SfpCategory.ActiveEthernet => AeTempHighC,
-                _ => SfpTempHighC
+                SfpCategory.Pon => thresholds.PonTempHighC,
+                SfpCategory.ActiveEthernet => thresholds.AeTempHighC,
+                _ => thresholds.SfpTempHighGenericC
             };
             await CheckHighThreshold(state, "temp", temperatureC.Value, threshold, TempHysteresisC,
                 "monitoring.sfp_temperature",
@@ -63,7 +54,7 @@ public class SfpAlertEvaluator
 
         if (category != SfpCategory.Standard && rxPowerDbm.HasValue)
         {
-            var rxThreshold = category == SfpCategory.Pon ? PonRxPowerLowDbm : AeRxPowerLowDbm;
+            var rxThreshold = category == SfpCategory.Pon ? thresholds.PonRxPowerLowDbm : thresholds.AeRxPowerLowDbm;
             await CheckLowThreshold(state, "rx", rxPowerDbm.Value, rxThreshold, PowerHysteresisDbm,
                 "monitoring.sfp_rx_power",
                 $"{catLabel} RX power on {portLabel}",
@@ -73,7 +64,7 @@ public class SfpAlertEvaluator
 
         if (category != SfpCategory.Standard && txPowerDbm.HasValue)
         {
-            var txThreshold = category == SfpCategory.Pon ? PonTxPowerHighDbm : AeTxPowerHighDbm;
+            var txThreshold = category == SfpCategory.Pon ? thresholds.PonTxPowerHighDbm : thresholds.AeTxPowerHighDbm;
             await CheckHighThreshold(state, "tx", txPowerDbm.Value, txThreshold, PowerHysteresisDbm,
                 "monitoring.sfp_tx_power",
                 $"{catLabel} TX power on {portLabel}",

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -724,7 +724,9 @@ public class MonitoringCollectionAgent : BackgroundService
 
                 await _deviceHealthAlertEvaluator.EvaluateAsync(
                     device.Mac, device.Name, DescribeDeviceType(device.DeviceType),
-                    cpu, memPct);
+                    cpu, memPct,
+                    temperatureC: temp,
+                    tempHighThresholdC: ResolveTempThreshold(settings, device.DeviceType));
             }
             catch (Exception ex)
             {
@@ -786,7 +788,9 @@ public class MonitoringCollectionAgent : BackgroundService
 
                 await _deviceHealthAlertEvaluator.EvaluateAsync(
                     device.Mac, device.Name, DescribeDeviceType(device.DeviceType),
-                    cpu, mem);
+                    cpu, mem,
+                    temperatureC: temp,
+                    tempHighThresholdC: ResolveTempThreshold(settings, device.DeviceType));
             }
             catch (Exception ex)
             {
@@ -881,7 +885,9 @@ public class MonitoringCollectionAgent : BackgroundService
             CollectSfpForDevice(device, db, existingSfps, nowSfp);
         }
 
-        // SFP threshold evaluation: check DDM values against alert thresholds.
+        // SFP threshold evaluation: check DDM values against alert thresholds
+        // (per-category, user-configurable with built-in fallbacks).
+        var sfpThresholds = NetworkOptimizer.Web.Services.Monitoring.SfpDdmThresholds.FromSettings(settings);
         foreach (var device in devices)
         {
             if (device.PortTable == null || device.PortTable.Count == 0) continue;
@@ -899,7 +905,7 @@ public class MonitoringCollectionAgent : BackgroundService
                 {
                     await _sfpAlertEvaluator.EvaluateAsync(
                         sfpMac, sfpPortName, device.Name, sfpCategory,
-                        port.SfpRxPower, port.SfpTxPower, port.SfpTemperature, ct);
+                        port.SfpRxPower, port.SfpTxPower, port.SfpTemperature, sfpThresholds, ct);
                 }
                 catch (Exception ex)
                 {
@@ -1892,6 +1898,13 @@ public class MonitoringCollectionAgent : BackgroundService
         NetworkOptimizer.Core.Enums.DeviceType.AccessPoint => "ap",
         _ => "unknown"
     };
+
+    // Per-device-type high-temperature alert threshold (Celsius). Null falls back to
+    // DeviceHealthAlertEvaluator.DefaultDeviceTempHighC inside the evaluator.
+    private static double? ResolveTempThreshold(MonitoringSettings settings, NetworkOptimizer.Core.Enums.DeviceType type) =>
+        type == NetworkOptimizer.Core.Enums.DeviceType.Gateway
+            ? settings.GatewayTempHighC
+            : settings.SwitchTempHighC;
 
     private void CollectSfpForDevice(
         UniFiDeviceResponse device,

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -1,15 +1,12 @@
 using System.Text.Json;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Audit.Analyzers;
-using NetworkOptimizer.Storage.Services;
 using NetworkOptimizer.UniFi;
 using NetworkOptimizer.WiFi;
 using NetworkOptimizer.WiFi.Analyzers;
+using NetworkOptimizer.WiFi.Helpers;
 using NetworkOptimizer.WiFi.Models;
 using NetworkOptimizer.WiFi.Providers;
 using NetworkOptimizer.WiFi.Rules;
-using NetworkOptimizer.WiFi.Helpers;
 using NetworkOptimizer.WiFi.Services;
 using AuditNetworkInfo = NetworkOptimizer.Audit.Models.NetworkInfo;
 
@@ -537,6 +534,14 @@ public class WiFiOptimizerService
     private List<ChannelScanResult>? _cachedScanResults;
     private string? _cachedScanResultsTimeKey;
 
+    // Rolling per-(AP, band) neighbor sighting history, so a channel's external load reflects the
+    // fullest recent scan rather than a single under-detecting one. A neighbor that isn't
+    // transmitting during one scan window would otherwise drop out and make its channel look
+    // spuriously clean, which flickers marginal channel-plan moves in and out. See NeighborSightingPool.
+    private readonly object _sightingHistoryLock = new();
+    private readonly Dictionary<string, List<(NeighborNetwork Neighbor, DateTimeOffset SeenAt)>> _neighborSightingHistory = new();
+    private static readonly TimeSpan NeighborSightingWindow = TimeSpan.FromMinutes(10);
+
     /// <summary>
     /// Get RF environment channel scan results from APs
     /// </summary>
@@ -577,10 +582,15 @@ public class WiFiOptimizerService
         {
             var provider = CreateProvider();
 
-            _cachedScanResults = await provider.GetChannelScanResultsAsync(
+            var fresh = await provider.GetChannelScanResultsAsync(
                 apMac: null,
                 startTime: startTime,
                 endTime: endTime);
+            // Record raw sightings for the rolling window, but cache and return the RAW scan -
+            // the live RF Environment view must show the current scan, not a pooled union. Only
+            // the channel recommendation reads the pooled view (see PoolNeighborSightings).
+            RecordNeighborSightings(fresh);
+            _cachedScanResults = fresh;
             _cachedScanResultsTimeKey = timeKey;
             return _cachedScanResults;
         }
@@ -588,6 +598,71 @@ public class WiFiOptimizerService
         {
             _logger.LogError(ex, "Failed to get channel scan results");
             return new List<ChannelScanResult>();
+        }
+    }
+
+    /// <summary>
+    /// Record each fresh scan's neighbor sightings into the rolling per-(AP, band) history (and
+    /// prune anything past the window). Called once per fresh scan fetch; does not modify the
+    /// scans, so callers still get the raw live scan back.
+    /// </summary>
+    private void RecordNeighborSightings(List<ChannelScanResult> fresh)
+    {
+        var now = DateTimeOffset.UtcNow;
+        lock (_sightingHistoryLock)
+        {
+            foreach (var scan in fresh)
+            {
+                var key = $"{scan.ApMac.ToLowerInvariant()}|{scan.Band}";
+                if (!_neighborSightingHistory.TryGetValue(key, out var history))
+                {
+                    history = new List<(NeighborNetwork, DateTimeOffset)>();
+                    _neighborSightingHistory[key] = history;
+                }
+
+                foreach (var nb in scan.Neighbors)
+                {
+                    if (!string.IsNullOrEmpty(nb.Bssid))
+                        history.Add((nb, now));
+                }
+                history.RemoveAll(s => now - s.SeenAt > NeighborSightingWindow);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Return a copy of the scans with each AP/band's neighbor list replaced by the rolling union
+    /// of recent sightings, so a channel's external load reflects the fullest recent scan rather
+    /// than a single under-detecting snapshot. This stabilizes marginal channel-plan moves that
+    /// would otherwise flicker as consecutive scans detect slightly different neighbor sets. Used by
+    /// the channel recommendation ONLY - the raw scan still drives the live RF Environment view. The
+    /// originals are not mutated (the cache is shared with that view). See <see cref="NeighborSightingPool"/>.
+    /// </summary>
+    private List<ChannelScanResult> PoolNeighborSightings(List<ChannelScanResult> raw)
+    {
+        var now = DateTimeOffset.UtcNow;
+        lock (_sightingHistoryLock)
+        {
+            var pooled = new List<ChannelScanResult>(raw.Count);
+            foreach (var scan in raw)
+            {
+                var key = $"{scan.ApMac.ToLowerInvariant()}|{scan.Band}";
+                var neighbors = _neighborSightingHistory.TryGetValue(key, out var history)
+                    ? NeighborSightingPool.Union(history, now, NeighborSightingWindow)
+                    : scan.Neighbors;
+
+                pooled.Add(new ChannelScanResult
+                {
+                    ApMac = scan.ApMac,
+                    ApName = scan.ApName,
+                    Band = scan.Band,
+                    ScanTime = scan.ScanTime,
+                    Channels = scan.Channels,
+                    Neighbors = neighbors
+                });
+            }
+
+            return pooled;
         }
     }
 
@@ -792,7 +867,9 @@ public class WiFiOptimizerService
 
             var aps = apsTask.Result;
             var regulatoryData = regulatoryTask.Result;
-            var scanResults = scanTask.Result;
+            // Pool neighbor sightings across the rolling window so a single under-detecting scan
+            // can't flip marginal channel moves (the live RF Environment view still uses raw scans).
+            var scanResults = PoolNeighborSightings(scanTask.Result);
 
             if (aps.Count == 0)
             {

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -554,8 +554,15 @@ public class WiFiOptimizerService
             return new List<ChannelScanResult>();
         }
 
-        // Create cache key based on time range
-        var timeKey = $"{startTime?.ToUnixTimeSeconds()}_{endTime?.ToUnixTimeSeconds()}";
+        // Create cache key based on the time range, bucketed to the minute. The recommendation
+        // engine requests startTime = now - lookback, which moves every second; keying on the
+        // exact second meant the key changed on every call and the cache never hit - every run
+        // re-fetched scans from the controller, and the overview card and channel-plan tab could
+        // land on different scan snapshots (showing different recommendations). Bucketing lets
+        // calls within the cache window reuse the same snapshot.
+        static long MinuteBucket(DateTimeOffset? t) =>
+            t.HasValue ? (long)Math.Round(t.Value.ToUnixTimeSeconds() / 60.0) : -1;
+        var timeKey = $"{MinuteBucket(startTime)}_{MinuteBucket(endTime)}";
         var cacheValid = !forceRefresh
             && _cachedScanResults != null
             && _cachedScanResultsTimeKey == timeKey

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -33,6 +33,7 @@
 
     /* Dark Mode Backgrounds - neutral dark, Linear/Vercel inspired */
     --bg-primary: #0f0f11;
+    --bg-inset: #131315;
     --bg-secondary: #161618;
     --bg-tertiary: #232326;
     --bg-elevated: #2c2c30;
@@ -7645,7 +7646,8 @@ a.path-hop.hop-clickable:hover {
 .wifi-content-grid {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
-    gap: 1.5rem;
+    gap: 0.25rem 1.25rem;
+    margin-bottom: 0.25rem;
 }
 
 /* Override main dashboard min-height for WiFi overview cards */
@@ -7664,6 +7666,7 @@ a.path-hop.hop-clickable:hover {
         display: flex;
         flex-direction: column;
         gap: 16px;
+        margin-bottom: 16px;
     }
 }
 
@@ -7832,7 +7835,7 @@ a.path-hop.hop-clickable:hover {
     display: flex;
     justify-content: center;
     gap: 3rem;
-    padding: 1rem 0;
+    padding: 0.5rem 0;
 }
 
 .band-item {
@@ -7854,7 +7857,7 @@ a.path-hop.hop-clickable:hover {
 
 .band-bar-container {
     width: 60px;
-    height: 120px;
+    height: 96px;
     background: var(--bg-tertiary);
     border-radius: 6px 6px 0 0;
     overflow: hidden;
@@ -7888,9 +7891,70 @@ a.path-hop.hop-clickable:hover {
     display: flex;
     justify-content: center;
     gap: 2rem;
-    margin-top: 1rem;
-    padding-top: 1rem;
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
     border-top: 1px solid var(--border-color);
+}
+
+/* Overview: Client Band Distribution + Channel Optimization stacked in one grid cell */
+.wifi-overview-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 0;
+}
+
+.channel-rec-card .card-body {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.channel-rec-summary {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.875rem;
+    padding-bottom: 0.5rem;
+    text-align: center;
+}
+
+.channel-rec-status {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+}
+
+.channel-rec-status.optimal {
+    color: var(--success-color);
+}
+
+.channel-rec-count {
+    font-size: 1.75rem;
+    font-weight: 700;
+    line-height: 1;
+    color: var(--accent-color);
+}
+
+.channel-rec-bands {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.channel-rec-summary .btn-recommend {
+    width: 100%;
+    max-width: 260px;
+    height: 38px;
+}
+
+@media (max-width: 768px) {
+    .wifi-overview-stack {
+        gap: 16px;
+    }
 }
 
 .band-stat {
@@ -8036,6 +8100,8 @@ a.path-hop.hop-clickable:hover {
 /* Success State */
 .success-state {
     color: #22c55e;
+    padding-top: 2rem;
+    padding-bottom: 2rem;
 }
 
 .success-state svg {
@@ -10141,6 +10207,9 @@ a.path-hop.hop-clickable:hover {
     cursor: pointer;
     transition: all 0.15s ease;
     position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .band-tab:hover {
@@ -10654,6 +10723,7 @@ a.path-hop.hop-clickable:hover {
 }
 
 .aps-band-table {
+    background: var(--bg-inset);
     border: 1px solid var(--border-color);
     border-radius: 6px;
     overflow: hidden;
@@ -10921,17 +10991,61 @@ a.path-hop.hop-clickable:hover {
 
 /* How This Works expandable */
 .recommendation-explainer {
-    font-size: 0.8125rem;
-    color: var(--text-muted);
-    margin: 0 0.5rem 0.5rem;
+    margin: 0.5rem 0.5rem 0.5rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius-lg);
+    background: var(--bg-tertiary);
 }
 .recommendation-explainer summary {
+    padding: 0.6rem 0.85rem;
     cursor: pointer;
+    font-weight: 500;
+    font-size: 0.85rem;
     color: var(--text-secondary);
+    user-select: none;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
 }
-.recommendation-explainer p {
-    margin: 0.5rem 0 0;
+.recommendation-explainer summary::-webkit-details-marker {
+    display: none;
+}
+.recommendation-explainer summary::before {
+    content: "▶";
+    font-size: 0.65rem;
+    transition: transform 0.2s ease;
+}
+.recommendation-explainer[open] summary::before {
+    transform: rotate(90deg);
+}
+.recommendation-explainer summary:hover {
+    color: var(--text-primary);
+    background: var(--bg-elevated);
+    border-radius: var(--border-radius-lg) var(--border-radius-lg) 0 0;
+}
+.recommendation-explainer:not([open]) summary:hover {
+    border-radius: var(--border-radius-lg);
+}
+.recommendation-explainer-content {
+    padding: 0 0.85rem 0.85rem 0.85rem;
+    border-top: 1px solid var(--border-color);
+    color: var(--text-muted);
+    font-size: 0.8rem;
     line-height: 1.5;
+}
+.recommendation-explainer-content p {
+    margin: 0.6rem 0;
+}
+.recommendation-explainer-content ul {
+    margin: 0.6rem 0;
+    padding-left: 1.1rem;
+}
+.recommendation-explainer-content li {
+    margin-bottom: 0.35rem;
+}
+.recommendation-explainer-content li strong {
+    color: var(--text-secondary);
 }
 
 /* Improvement stat highlighting */

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2334,6 +2334,19 @@ select.form-control {
     gap: 0.75rem;
 }
 
+.threshold-fields {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-top: 0.5rem;
+}
+
+.threshold-fields .form-group {
+    flex: 1;
+    min-width: 180px;
+    margin-bottom: 0;
+}
+
 .input-with-button {
     display: flex;
     gap: 0.5rem;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -16440,6 +16440,13 @@ a.isp-health-hero-speed:hover {
     transition: width 0.6s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
+.isp-outage-hop-loss {
+    height: 100%;
+    border-radius: 4px 0 0 4px;
+    background: var(--warning-color);
+    transition: width 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
 .isp-outage-hop-status {
     font-size: 0.72rem;
     color: var(--text-secondary);

--- a/src/NetworkOptimizer.Web/wwwroot/js/isp-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/isp-health-charts.js
@@ -12,6 +12,7 @@ let pollTimer = null;
 let fetchController = null;
 let resetBtn = null;
 let isZoomed = false;
+let dotNetRef = null;
 // null = default 48 h cached view; { from, to } ISO strings = a filter-selected window.
 let win = null;
 
@@ -26,7 +27,11 @@ function buildOpts() {
             parentHeightOffset: 0,
             animations: { enabled: false },
             events: {
-                zoomed: (ctx, opts) => setZoomed(opts?.xaxis?.min != null),
+                zoomed: (ctx, opts) => {
+                    const min = opts?.xaxis?.min, max = opts?.xaxis?.max;
+                    setZoomed(min != null);
+                    notifyZoom(min, max);
+                },
             },
         },
         series: [],
@@ -111,10 +116,19 @@ function setZoomed(zoomed) {
     if (resetBtn) resetBtn.style.display = zoomed ? 'inline-flex' : 'none';
 }
 
+// Tell the Blazor panel the current zoom range (epoch ms), or null/null when cleared, so it can
+// filter the Path & Congestion Events list to the visible window. scrollToChart is set only on the
+// Reset zoom button, so the panel can keep the chart in view when the list expands above it.
+function notifyZoom(min, max, scrollToChart = false) {
+    try { dotNetRef?.invokeMethodAsync('OnChartZoom', min ?? null, max ?? null, scrollToChart); }
+    catch { /* ref disposed / not set */ }
+}
+
 function resetZoom() {
     if (!chart) return;
     chart.updateOptions({ xaxis: { min: undefined, max: undefined } }, false, false);
     setZoomed(false);
+    notifyZoom(null, null, true);
     loadAndUpdate();
 }
 
@@ -173,7 +187,16 @@ export async function setWindow(fromISO, toISO) {
     win = (fromISO && toISO) ? { from: fromISO, to: toISO } : null;
     if (chart) chart.updateOptions({ xaxis: { min: undefined, max: undefined } }, false, false);
     setZoomed(false);
+    notifyZoom(null, null);
     await loadAndUpdate();
+}
+
+export function setDotNetRef(ref) {
+    dotNetRef = ref;
+}
+
+export function scrollChartIntoView() {
+    document.getElementById('isp-health-asn-chart')?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
 }
 
 export function unmount() {
@@ -181,6 +204,7 @@ export function unmount() {
     fetchController?.abort();
     if (resetBtn) { resetBtn.remove(); resetBtn = null; }
     isZoomed = false;
+    dotNetRef = null;
     win = null;
     if (chart) { chart.destroy(); chart = null; }
 }

--- a/src/NetworkOptimizer.WiFi/Helpers/ChannelSpanHelper.cs
+++ b/src/NetworkOptimizer.WiFi/Helpers/ChannelSpanHelper.cs
@@ -99,11 +99,22 @@ public static class ChannelSpanHelper
         a.Low <= b.High && b.Low <= a.High;
 
     /// <summary>
-    /// Convert signal strength to interference weight using the standard formula.
-    /// Maps -90 dBm → 0.1 (barely audible) through -50 dBm → 1.0 (very close).
+    /// CCA threshold (dBm). At or below this a radio does not detect a co-channel transmission and
+    /// won't defer, so it suffers no contention - the interference weight curve is anchored here.
+    /// </summary>
+    private const double CcaThresholdDbm = -82.0;
+
+    /// <summary>Signal (dBm) at or above which a co-channel interferer fully saturates (weight 1.0).</summary>
+    private const double SaturationDbm = -50.0;
+
+    /// <summary>
+    /// Convert a received signal strength to a co-channel interference weight in [0, 1], anchored at
+    /// the CCA threshold: a signal at or below CCA (-82 dBm) causes no contention (weight 0 - the
+    /// radio doesn't defer), ramping linearly to 1.0 at a saturating -50 dBm. Operates on the
+    /// received signal, which already accounts for band-specific propagation, so it is band-agnostic.
     /// </summary>
     public static double SignalToInterferenceWeight(int signalDbm) =>
-        Math.Clamp((signalDbm + 90) / 40.0, 0.1, 1.0);
+        Math.Clamp((signalDbm - CcaThresholdDbm) / (SaturationDbm - CcaThresholdDbm), 0.0, 1.0);
 
     /// <summary>
     /// Compute the channel overlap factor between two channel assignments.

--- a/src/NetworkOptimizer.WiFi/Helpers/NeighborSightingPool.cs
+++ b/src/NetworkOptimizer.WiFi/Helpers/NeighborSightingPool.cs
@@ -1,0 +1,33 @@
+using NetworkOptimizer.WiFi.Models;
+
+namespace NetworkOptimizer.WiFi.Helpers;
+
+/// <summary>
+/// Stabilizes scan-derived neighbor lists by unioning recent sightings. A single UniFi RF scan
+/// under-detects neighbors that aren't transmitting during its window, so an unchanged channel can
+/// read busy one scan and clear the next. That makes marginal channel-plan moves flicker in and
+/// out between runs. Pooling keeps a neighbor in the picture - at its strongest recent signal -
+/// until it has been absent for the whole retention window, so a channel only reads clean when it
+/// is consistently clean, not just in one sparse scan.
+/// </summary>
+public static class NeighborSightingPool
+{
+    /// <summary>
+    /// Union the sightings by BSSID, keeping the strongest-signal sighting of each that falls within
+    /// <paramref name="window"/> of <paramref name="now"/>. Sightings outside the window, or without
+    /// a BSSID, are dropped. The bias is intentionally conservative (strongest, not latest): a
+    /// channel won't be treated as clean just because the most recent scan happened to miss a
+    /// neighbor it saw moments ago.
+    /// </summary>
+    public static List<NeighborNetwork> Union(
+        IEnumerable<(NeighborNetwork Neighbor, DateTimeOffset SeenAt)> sightings,
+        DateTimeOffset now,
+        TimeSpan window)
+    {
+        return sightings
+            .Where(s => now - s.SeenAt <= window && !string.IsNullOrEmpty(s.Neighbor.Bssid))
+            .GroupBy(s => s.Neighbor.Bssid, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.OrderByDescending(s => s.Neighbor.Signal ?? int.MinValue).First().Neighbor)
+            .ToList();
+    }
+}

--- a/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
@@ -72,8 +72,20 @@ public class InterferenceGraph
     /// <summary>True when DFS avoidance was requested but at least one AP had to fall back to DFS channels</summary>
     public bool DfsAvoidanceFallback { get; set; }
 
-    /// <summary>Pairwise internal interference weights [i,j]</summary>
+    /// <summary>
+    /// Pairwise internal interference weights [i,j], symmetric (worst case of both directions).
+    /// Models mutual co-channel contention - used for the global objective and proximity.
+    /// </summary>
     public double[,] InternalWeights { get; set; } = new double[0, 0];
+
+    /// <summary>
+    /// Directional internal interference weights [aggressor, victim] = how much the aggressor AP
+    /// interferes AT the victim, based on the aggressor's signal reaching the victim (its EIRP).
+    /// Used where interference is one-directional: an AP's own suffered interference and the
+    /// degradation guard. A low-power AP correctly interferes with neighbors less than the
+    /// symmetric worst case implies.
+    /// </summary>
+    public double[,] DirectionalWeights { get; set; } = new double[0, 0];
 
     /// <summary>Per-AP external load by channel number. ExternalLoad[apIndex][channel] = weight</summary>
     public Dictionary<int, double>[] ExternalLoad { get; set; } = [];

--- a/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
-using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.UniFi;
 using NetworkOptimizer.UniFi.Models;
 using NetworkOptimizer.WiFi.Models;
@@ -260,7 +259,18 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
         try
         {
             var data = await _client.GetApChannelChangeEventsAsync(start, end, apMac, cancellationToken);
-            return ParseChannelChangeEvents(data);
+            var events = ParseChannelChangeEvents(data);
+
+            // Defensive scoping. The controller's system-log query already filters these events to
+            // the requested device via clientDeviceMacs (verified against the console: filtering to
+            // an AP with no channel changes returns no other AP's events). We re-filter by AP MAC
+            // here so every consumer is guaranteed to see only the requested AP's events even if that
+            // controller-side behavior ever changes - a stale value from another AP would otherwise
+            // be misattributed onto this AP's chart/timeline.
+            if (!string.IsNullOrEmpty(apMac))
+                events = events.Where(e => e.ApMac.Equals(apMac, StringComparison.OrdinalIgnoreCase)).ToList();
+
+            return events;
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.WiFi/Rules/LoadImbalanceRule.cs
+++ b/src/NetworkOptimizer.WiFi/Rules/LoadImbalanceRule.cs
@@ -1,3 +1,4 @@
+using NetworkOptimizer.WiFi.Helpers;
 using NetworkOptimizer.WiFi.Models;
 using NetworkOptimizer.WiFi.Services;
 
@@ -24,11 +25,6 @@ public class LoadImbalanceRule : IWiFiOptimizerRule
     /// Coefficient of variation threshold (percentage) above which to warn.
     /// </summary>
     private const double ImbalanceThreshold = 50;
-
-    /// <summary>
-    /// Signal strength (dBm) at or above which a client is considered well-connected.
-    /// </summary>
-    private const int StrongSignalThreshold = -65;
 
     public HealthIssue? Evaluate(WiFiOptimizerContext ctx)
     {
@@ -105,13 +101,17 @@ public class LoadImbalanceRule : IWiFiOptimizerRule
                         .Where(c => c.ApMac.Equals(maxAp.Mac, StringComparison.OrdinalIgnoreCase))
                         .ToList();
 
-                    var allStrongSignal = clientsOnMaxAp.Count > 0 &&
-                        clientsOnMaxAp.All(c => c.Signal.HasValue && c.Signal.Value >= StrongSignalThreshold);
+                    // Suppress unless a client on the busy AP is genuinely weak FOR ITS BAND, using
+                    // the same per-band scale as the client list coloring. Higher bands tolerate
+                    // weaker signal: -75 is weak on 2.4 GHz (< -73) but fine on 5/6 GHz (weak only
+                    // below -78 / -87). Clients with no reported signal are ignored - a missing
+                    // reading usually just means an offline/idle device, not a weak one.
+                    var hasWeakClient = clientsOnMaxAp.Any(c => c.Signal.HasValue &&
+                        SignalClassification.IsWeakSignal(c.Signal.Value, c.Band));
 
-                    if (allStrongSignal)
+                    if (!hasWeakClient)
                     {
-                        // All clients on the busy AP have strong signal and the quiet AP is
-                        // far away - this is definitively a separate coverage zone, suppress entirely
+                        // Separate coverage zone with no genuinely weak clients - suppress entirely.
                         return null;
                     }
 

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -76,14 +76,18 @@ public class ChannelRecommendationService
     /// Prevents churn when the gain is negligible (e.g., 0.7 → 0.1 = 0.6 gain).
     /// Both this AND MinApImprovementPercent must be met.
     /// </summary>
-    private const double MinApAbsoluteImprovement = 1.0;
+    // Tuned to 0.6 (from 1.0): surfaces moderate real gains (e.g. a quieter co-channel) now that
+    // scoring is position-independent, so loosening cannot oscillate. Both gates AND'd.
+    private const double MinApAbsoluteImprovement = 0.6;
 
     /// <summary>
     /// Minimum percentage score improvement for an individual AP to justify a move.
     /// Prevents moving APs where the improvement is small relative to current score
     /// (e.g., 3.0 → 2.8 = 7%). Both this AND MinApAbsoluteImprovement must be met.
     /// </summary>
-    private const double MinApImprovementPercent = 0.30;
+    // Tuned to 0.15 (from 0.30): 30% missed genuinely-better channels whose gain was real but
+    // moderate (~15-25%). Both this AND MinApAbsoluteImprovement must be met.
+    private const double MinApImprovementPercent = 0.15;
 
     /// <summary>
     /// Penalty for channels with no historical data. Unknown channels carry more
@@ -99,6 +103,18 @@ public class ChannelRecommendationService
     /// too heavily for network-wide improvement.
     /// </summary>
     private const double MaxApScoreDegradation = 1.5;
+
+    /// <summary>
+    /// Absolute score a per-AP fallback move may never push another AP to, regardless of net
+    /// benefit. A net-positive standalone move (the moving AP gains more than the total it degrades
+    /// others) is allowed even past MaxApScoreDegradation, but never if it leaves a victim above
+    /// this score - so we never put one AP into genuinely bad shape to help the site. Absolute
+    /// (not a multiple of the victim's base) because "bad" is an absolute condition: a high score
+    /// means heavy interference regardless of where the AP started. 4.0 ~ where an AP is clearly
+    /// suffering on the CCA-anchored scale (the worst real APs sit ~4); a modest sacrifice like
+    /// pushing a neighbor 1.2 -> 2.0 stays well clear of it.
+    /// </summary>
+    private const double CatastrophicAbsoluteScore = 4.0;
 
     /// <summary>
     /// Minimum neighbor signal to count as external interference. Matches the CCA
@@ -119,15 +135,46 @@ public class ChannelRecommendationService
     private const double MinTriangulatedWeight = 0.2;
 
     /// <summary>
-    /// Uncertainty multiplier for external load on channels with no direct neighbor
-    /// observations. Triangulation discovers some neighbors but not all - the observer
-    /// AP may miss neighbors visible from the target's location. This multiplier inflates
-    /// the triangulated estimate to account for missing neighbors. Applied on top of the
-    /// base triangulated load: total = base + base * multiplier = base * (1 + multiplier).
-    /// 2.0 means unobserved channels see 3x their triangulated estimate, which roughly
-    /// matches the ~3x underestimate observed in testing.
+    /// Uncertainty multipliers for external load on channels with no direct neighbor
+    /// observations, by band. Triangulation discovers some neighbors but not all - the observer
+    /// AP may miss neighbors visible from the target's location. The multiplier inflates the
+    /// triangulated estimate to account for missing neighbors (base + base * multiplier).
+    ///
+    /// It is band-dependent because scan completeness tracks propagation range:
+    /// - 2.4 GHz penetrates walls and travels far, so an observer hears nearly every neighbor
+    ///   the target would, and those neighbors genuinely reach the target. The picture is close
+    ///   to complete, so unobserved channels are barely uncertain (1.5).
+    /// - 5 GHz: the ~3x underestimate (2.0) calibrated in testing.
+    /// - 6 GHz dies fastest through walls, so observers miss the most near-target neighbors and
+    ///   uncertainty is highest (2.5). Tempered by 6 GHz being sparsely populated today.
+    ///
+    /// This is the right caution for a genuinely unknown channel; channels we DO have evidence
+    /// for are scaled down separately via <see cref="ObservationConfidence"/>, which is where
+    /// the softening belongs. 2.4/6 GHz values are physically motivated; only 5 GHz is calibrated.
     /// </summary>
-    private const double UnobservedChannelMultiplier = 2.0;
+    private const double UnobservedChannelMultiplier2_4GHz = 1.5;
+    private const double UnobservedChannelMultiplier5GHz = 2.0;
+    private const double UnobservedChannelMultiplier6GHz = 2.5;
+
+    /// <summary>
+    /// Observation confidence for a candidate channel this AP has measured historic occupancy
+    /// of (within the metrics window). We have real airtime data for it, so the uncertainty
+    /// penalty is mostly - but not entirely (data can be stale) - waived.
+    /// </summary>
+    private const double HistoricOccupancyConfidence = 0.85;
+
+    /// <summary>
+    /// Observation confidence for a candidate channel a sibling AP is currently resident on
+    /// and this AP hears well. The sibling is a live observer of that channel's conditions,
+    /// though from its own location, so confidence is high but below historic/direct.
+    /// </summary>
+    private const double SiblingResidentConfidence = 0.70;
+
+    /// <summary>
+    /// Minimum internal (propagation) weight for a resident sibling AP to count as an observer
+    /// of a channel. Below this the sibling is too far to characterize this AP's RF environment.
+    /// </summary>
+    private const double SiblingObserverMinWeight = 0.4;
 
     /// <summary>
     /// Multiplier for internal (own AP) co-channel interference. Co-channeling your
@@ -183,6 +230,7 @@ public class ChannelRecommendationService
         {
             Nodes = new List<ApNode>(n),
             InternalWeights = new double[n, n],
+            DirectionalWeights = new double[n, n],
             ExternalLoad = new Dictionary<int, double>[n],
             DirectlyObservedChannels = new HashSet<int>[n],
             ScanChannelData = new Dictionary<int, (int Utilization, int Interference)>[n],
@@ -234,10 +282,13 @@ public class ChannelRecommendationService
         {
             for (int j = i + 1; j < n; j++)
             {
-                var weight = ComputeInternalWeight(
+                var w = ComputeInternalWeight(
                     bandAps[i], bandAps[j], band, bandStr, propContext);
-                graph.InternalWeights[i, j] = weight;
-                graph.InternalWeights[j, i] = weight;
+                graph.InternalWeights[i, j] = w.Symmetric;
+                graph.InternalWeights[j, i] = w.Symmetric;
+                // Directional [aggressor, victim]: Forward is i's signal at j, Reverse is j's at i.
+                graph.DirectionalWeights[i, j] = w.Forward;
+                graph.DirectionalWeights[j, i] = w.Reverse;
             }
         }
 
@@ -547,7 +598,7 @@ public class ChannelRecommendationService
                                 if (!jChanged) continue;
                                 if (!jNode.ValidChannels.Contains(jNode.CurrentChannel)) continue;
 
-                                var contribution = graph.InternalWeights[i, j] *
+                                var contribution = graph.DirectionalWeights[j, i] *
                                     ChannelSpanHelper.ComputeOverlapFactor(band,
                                         finalAssignment[i].Channel, finalAssignment[i].Width,
                                         finalAssignment[j].Channel, finalAssignment[j].Width) *
@@ -622,21 +673,43 @@ public class ChannelRecommendationService
                     pctImprovement < MinApImprovementPercent)
                     continue;
 
-                // Check no other AP gets degraded beyond threshold
-                bool degradesOther = false;
+                // A standalone move may degrade other APs, but only if it still improves the site
+                // overall (this AP's gain exceeds the total degradation it causes) and never pushes
+                // any single AP past the catastrophic cap.
+                bool reject = false;
+                double totalDegradation = 0;
                 for (int j = 0; j < n; j++)
                 {
                     if (j == i) continue;
                     var otherCurrent = currentApScores[j];
                     if (otherCurrent <= 0) continue;
                     var otherScore = ScoreAp(graph, trial, j, band);
-                    if (otherScore / otherCurrent > MaxApScoreDegradation)
+                    if (otherScore > otherCurrent) totalDegradation += otherScore - otherCurrent;
+
+                    // Catastrophic: this move would push a victim into genuinely bad territory.
+                    if (otherScore > CatastrophicAbsoluteScore && otherScore > otherCurrent)
                     {
-                        degradesOther = true;
+                        _logger.LogDebug(
+                            "[ChannelRec] Per-AP fallback: {ApName} -> ch{Ch} would push {Victim} " +
+                            "{From:F3}->{To:F3} above the {Cap:F1} ceiling, skipping",
+                            node.Name, candidateCh, graph.Nodes[j].Name, otherCurrent, otherScore,
+                            CatastrophicAbsoluteScore);
+                        reject = true;
                         break;
                     }
                 }
-                if (degradesOther) continue;
+                if (reject) continue;
+
+                // Net-benefit: the AP's own improvement must outweigh the total degradation it
+                // causes to others, otherwise the move makes the site no better.
+                if (absImprovement <= totalDegradation)
+                {
+                    _logger.LogDebug(
+                        "[ChannelRec] Per-AP fallback: {ApName} -> ch{Ch} improves {Abs:F3} but degrades " +
+                        "others by {Deg:F3} total (not net-positive for the site), skipping",
+                        node.Name, candidateCh, absImprovement, totalDegradation);
+                    continue;
+                }
 
                 if (candidateScore < fallbackScore)
                 {
@@ -649,7 +722,7 @@ public class ChannelRecommendationService
             {
                 _logger.LogDebug(
                     "[ChannelRec] Per-AP fallback: {ApName} ch{Current} (score {CurrentScore:F3}) → " +
-                    "ch{Best} (score {BestScore:F3}), no degradation to others",
+                    "ch{Best} (score {BestScore:F3}), net-positive for the site",
                     node.Name, node.CurrentChannel, scoreInFinal, fallbackChannel, fallbackScore);
                 rec.RecommendedChannel = fallbackChannel;
                 rec.RecommendedWidth = fallbackWidth;
@@ -742,38 +815,9 @@ public class ChannelRecommendationService
             score += historicalPenalty + fallbackPenalty * bandStress;
         }
 
-        // Unobserved channel uncertainty: inflate triangulated load on channels where the
-        // AP has no direct neighbor observations. Uses max of (triangulated × multiplier)
-        // and (minimum direct load) as a floor so zero-data channels don't score 0.0.
+        // Unobserved channel uncertainty (confidence-weighted, see ComputeUnobservedPenalty)
         for (int i = 0; i < n; i++)
-        {
-            var directChannels = graph.DirectlyObservedChannels[i];
-            if (directChannels.Count == 0) continue;
-
-            var apSpan = ChannelSpanHelper.GetChannelSpan(band, assignment[i].Channel, assignment[i].Width);
-            bool hasDirectOnAssigned = directChannels.Any(dc =>
-                ChannelSpanHelper.SpansOverlap(apSpan, (dc, dc)));
-
-            if (!hasDirectOnAssigned)
-            {
-                double triangulatedLoad = 0;
-                foreach (var (extChannel, extWeight) in graph.ExternalLoad[i])
-                {
-                    if (ChannelSpanHelper.SpansOverlap(apSpan, (extChannel, extChannel)))
-                        triangulatedLoad += extWeight;
-                }
-
-                double minDirectLoad = double.MaxValue;
-                foreach (var dc in directChannels)
-                {
-                    if (graph.ExternalLoad[i].TryGetValue(dc, out var directWeight))
-                        minDirectLoad = Math.Min(minDirectLoad, directWeight);
-                }
-                if (minDirectLoad == double.MaxValue) minDirectLoad = 0;
-
-                score += Math.Max(triangulatedLoad * UnobservedChannelMultiplier, minDirectLoad);
-            }
-        }
+            score += ComputeUnobservedPenalty(graph, band, i, assignment);
 
         return score;
     }
@@ -790,7 +834,8 @@ public class ChannelRecommendationService
         double score = 0;
         var n = graph.Nodes.Count;
 
-        // Internal interference from all other APs
+        // Internal interference this AP SUFFERS from all other APs. Directional [j, apIndex]:
+        // how much j's signal reaches this AP - so a low-EIRP neighbor interferes with it less.
         for (int j = 0; j < n; j++)
         {
             if (j == apIndex) continue;
@@ -801,7 +846,7 @@ public class ChannelRecommendationService
                 assignment[apIndex].Channel, assignment[apIndex].Width,
                 assignment[j].Channel, assignment[j].Width);
 
-            score += graph.InternalWeights[apIndex, j] * overlapFactor * InternalCoChannelMultiplier;
+            score += graph.DirectionalWeights[j, apIndex] * overlapFactor * InternalCoChannelMultiplier;
         }
 
         // External interference
@@ -811,44 +856,6 @@ public class ChannelRecommendationService
             var extSpan = (Low: extChannel, High: extChannel);
             if (ChannelSpanHelper.SpansOverlap(apSpan, extSpan))
                 score += extWeight;
-        }
-
-        // Unobserved channel uncertainty: if this AP has direct neighbor observations on
-        // some channels but NOT on the candidate channel, the external load is based only
-        // on triangulated estimates which typically underestimate (observers miss neighbors
-        // visible from the target's location). Two adjustments:
-        // 1. Inflate existing triangulated load by a multiplier (accounts for missed neighbors)
-        // 2. Apply a floor = minimum direct external load across observed channels (prevents
-        //    channels with zero triangulated data from scoring 0.0 when the site has active neighbors)
-        var directChannels = graph.DirectlyObservedChannels[apIndex];
-        if (directChannels.Count > 0)
-        {
-            bool hasDirectOnAssigned = directChannels.Any(dc =>
-                ChannelSpanHelper.SpansOverlap(apSpan, (dc, dc)));
-
-            if (!hasDirectOnAssigned)
-            {
-                // Sum up the external load already added for this channel (all triangulated)
-                double triangulatedLoad = 0;
-                foreach (var (extChannel, extWeight) in graph.ExternalLoad[apIndex])
-                {
-                    if (ChannelSpanHelper.SpansOverlap(apSpan, (extChannel, extChannel)))
-                        triangulatedLoad += extWeight;
-                }
-
-                // Minimum direct external load across observed channels as a floor.
-                // "An unobserved channel is at least as good as your best known channel."
-                double minDirectLoad = double.MaxValue;
-                foreach (var dc in directChannels)
-                {
-                    if (graph.ExternalLoad[apIndex].TryGetValue(dc, out var directWeight))
-                        minDirectLoad = Math.Min(minDirectLoad, directWeight);
-                }
-                if (minDirectLoad == double.MaxValue) minDirectLoad = 0;
-
-                var uncertainty = Math.Max(triangulatedLoad * UnobservedChannelMultiplier, minDirectLoad);
-                score += uncertainty;
-            }
         }
 
         // Channel scan data (scaled by band stress multiplier)
@@ -864,7 +871,126 @@ public class ChannelRecommendationService
         var (histPenalty, fallbackPenalty) = ComputeStressPenalty(graph, band, apIndex, assignment);
         score += histPenalty + fallbackPenalty * bandStress;
 
+        // Unobserved channel uncertainty (confidence-weighted)
+        score += ComputeUnobservedPenalty(graph, band, apIndex, assignment);
+
         return score;
+    }
+
+    /// <summary>
+    /// Unobserved-channel uncertainty penalty for an AP on its assigned channel. Triangulated
+    /// external load under-counts neighbors the observing AP can't hear, so a channel with no
+    /// direct observation would otherwise look artificially clean. This taxes that uncertainty,
+    /// scaled by how much real evidence we already have for the channel (see
+    /// <see cref="ObservationConfidence"/>): a channel we have historic occupancy of, or a
+    /// resident sibling AP on, is mostly trusted. The penalty is computed identically whether
+    /// the AP is resident on the channel or a candidate moving onto it, and draws confidence
+    /// only from stable signals (direct scan, historic occupancy, sibling CURRENT channel) so
+    /// it does not swing with transient scan coverage or the assignment being evaluated.
+    /// </summary>
+    private double ComputeUnobservedPenalty(
+        InterferenceGraph graph,
+        RadioBand band,
+        int apIndex,
+        (int Channel, int Width)[] assignment)
+    {
+        var directChannels = graph.DirectlyObservedChannels[apIndex];
+        if (directChannels.Count == 0) return 0;
+
+        var apSpan = ChannelSpanHelper.GetChannelSpan(band, assignment[apIndex].Channel, assignment[apIndex].Width);
+
+        var confidence = ObservationConfidence(graph, band, apIndex, apSpan, directChannels);
+        if (confidence >= 1.0) return 0;
+
+        double triangulatedLoad = 0;
+        foreach (var (extChannel, extWeight) in graph.ExternalLoad[apIndex])
+        {
+            if (ChannelSpanHelper.SpansOverlap(apSpan, (extChannel, extChannel)))
+                triangulatedLoad += extWeight;
+        }
+
+        // Floor: an unobserved channel is at least as loaded as this AP's best observed channel.
+        double minDirectLoad = double.MaxValue;
+        foreach (var dc in directChannels)
+        {
+            if (graph.ExternalLoad[apIndex].TryGetValue(dc, out var directWeight))
+                minDirectLoad = Math.Min(minDirectLoad, directWeight);
+        }
+        if (minDirectLoad == double.MaxValue) minDirectLoad = 0;
+
+        // Apply the band uncertainty multiplier to the best available estimate - the triangulated
+        // load OR the floor. A channel with zero observations falls back to the floor, and it must
+        // carry the SAME uncertainty premium as a partially-triangulated one. Otherwise a totally-
+        // blind channel would be penalized LESS than a barely-seen one, and the engine would too
+        // eagerly recommend moving onto a channel it has no scan data for.
+        var basePenalty = Math.Max(triangulatedLoad, minDirectLoad) * GetUnobservedMultiplier(band);
+        return (1.0 - confidence) * basePenalty;
+    }
+
+    /// <summary>
+    /// Band-specific uncertainty multiplier for unobserved channels. Lower bands see a more
+    /// complete scan picture (better propagation), so their unobserved channels are less
+    /// uncertain. See the multiplier constants for rationale.
+    /// </summary>
+    private static double GetUnobservedMultiplier(RadioBand band) => band switch
+    {
+        RadioBand.Band2_4GHz => UnobservedChannelMultiplier2_4GHz,
+        RadioBand.Band6GHz => UnobservedChannelMultiplier6GHz,
+        _ => UnobservedChannelMultiplier5GHz
+    };
+
+    /// <summary>
+    /// How confident we are in the external-load estimate for an AP's assigned channel span,
+    /// in [0, 1]. 1.0 = a direct scan sighting on the channel (fully observed). Otherwise we
+    /// fall back to weaker-but-real evidence: this AP's measured historic occupancy of the
+    /// channel, or a sibling AP currently resident on it that this AP hears well. Uses each
+    /// sibling's CURRENT channel (not the assignment under evaluation) so confidence is stable.
+    /// </summary>
+    private double ObservationConfidence(
+        InterferenceGraph graph,
+        RadioBand band,
+        int apIndex,
+        (int Low, int High) apSpan,
+        HashSet<int> directChannels)
+    {
+        // Direct scan sighting on the assigned channel - fully observed, no uncertainty.
+        if (directChannels.Any(dc => ChannelSpanHelper.SpansOverlap(apSpan, (dc, dc))))
+            return 1.0;
+
+        double confidence = 0;
+        var node = graph.Nodes[apIndex];
+
+        // Historic occupancy: we have measured airtime for this AP on an overlapping channel.
+        if (node.HistoricalStress != null)
+        {
+            foreach (var histChannel in node.HistoricalStress.Keys)
+            {
+                var histSpan = ChannelSpanHelper.GetChannelSpan(band, histChannel, node.CurrentWidth);
+                if (ChannelSpanHelper.SpansOverlap(apSpan, histSpan))
+                {
+                    confidence = Math.Max(confidence, HistoricOccupancyConfidence);
+                    break;
+                }
+            }
+        }
+
+        // Sibling AP currently resident on the channel that this AP hears well - a live observer.
+        var n = graph.Nodes.Count;
+        for (int j = 0; j < n; j++)
+        {
+            if (j == apIndex) continue;
+            if (graph.InternalWeights[apIndex, j] < SiblingObserverMinWeight) continue;
+
+            var siblingNode = graph.Nodes[j];
+            var siblingSpan = ChannelSpanHelper.GetChannelSpan(band, siblingNode.CurrentChannel, siblingNode.CurrentWidth);
+            if (ChannelSpanHelper.SpansOverlap(apSpan, siblingSpan))
+            {
+                confidence = Math.Max(confidence, SiblingResidentConfidence);
+                break;
+            }
+        }
+
+        return confidence;
     }
 
     /// <summary>
@@ -967,7 +1093,8 @@ public class ChannelRecommendationService
             if (j == apIndex) continue;
             if (AreMeshPair(graph, apIndex, j)) continue;
 
-            var weight = graph.InternalWeights[apIndex, j];
+            // Directional: co-channel load this AP suffers from j (j's signal reaching apIndex).
+            var weight = graph.DirectionalWeights[j, apIndex];
             if (weight <= 0) continue;
 
             // Current internal co-channel load (weighted, not just count)
@@ -1012,7 +1139,12 @@ public class ChannelRecommendationService
         return Math.Max(internalScale, externalFloor);
     }
 
-    private double ComputeInternalWeight(
+    /// <summary>
+    /// Compute internal interference weights between two APs. Returns the symmetric worst-case
+    /// weight (for mutual contention), plus the two directional weights: Forward = ap1's signal
+    /// reaching ap2 (ap1 as aggressor at ap2), Reverse = ap2's signal reaching ap1.
+    /// </summary>
+    private (double Symmetric, double Forward, double Reverse) ComputeInternalWeight(
         AccessPointSnapshot ap1, AccessPointSnapshot ap2,
         RadioBand band, string bandStr,
         ApPropagationContext? propContext)
@@ -1057,15 +1189,19 @@ public class ChannelRecommendationService
                 ap1.Name, ap2.Name, signal1to2, signal2to1, worstSignal,
                 ChannelSpanHelper.SignalToInterferenceWeight(worstSignal));
 
-            return ChannelSpanHelper.SignalToInterferenceWeight(worstSignal);
+            return (
+                ChannelSpanHelper.SignalToInterferenceWeight(worstSignal),
+                ChannelSpanHelper.SignalToInterferenceWeight((int)signal1to2),
+                ChannelSpanHelper.SignalToInterferenceWeight((int)signal2to1));
         }
 
-        // One or both unplaced - use conservative default
+        // One or both unplaced - use conservative default (symmetric)
+        var defaultWeight = ChannelSpanHelper.SignalToInterferenceWeight(DefaultUnplacedSignalDbm);
         _logger.LogDebug(
             "[ChannelRec] Internal weight {AP1} <-> {AP2}: weight={Weight:F3} (default, unplaced)",
-            ap1.Name, ap2.Name, ChannelSpanHelper.SignalToInterferenceWeight(DefaultUnplacedSignalDbm));
+            ap1.Name, ap2.Name, defaultWeight);
 
-        return ChannelSpanHelper.SignalToInterferenceWeight(DefaultUnplacedSignalDbm);
+        return (defaultWeight, defaultWeight, defaultWeight);
     }
 
     private static PropagationAp ClonePropAp(PropagationAp source, RadioSnapshot radio)
@@ -1550,7 +1686,7 @@ public class ChannelRecommendationService
         return baseScore + penalty;
     }
 
-    private (( int Channel, int Width)[] Assignment, double Score) ExhaustiveSearch(
+    private ((int Channel, int Width)[] Assignment, double Score) ExhaustiveSearch(
         InterferenceGraph graph,
         RadioBand band,
         HashSet<int> pinnedIndices,
@@ -1899,7 +2035,7 @@ public class ChannelRecommendationService
                     var overlap = ChannelSpanHelper.ComputeOverlapFactor(
                         band, ch, currentAssignment[i].Width,
                         testAssignment[j].Channel, testAssignment[j].Width);
-                    internalScore += graph.InternalWeights[i, j] * overlap * InternalCoChannelMultiplier;
+                    internalScore += graph.DirectionalWeights[j, i] * overlap * InternalCoChannelMultiplier;
                 }
 
                 var apSpan = ChannelSpanHelper.GetChannelSpan(band, ch, currentAssignment[i].Width);
@@ -1949,25 +2085,8 @@ public class ChannelRecommendationService
                     }
                 }
 
-                // Unobserved channel uncertainty
-                double unobservedPenalty = 0;
-                var directChannels = graph.DirectlyObservedChannels[i];
-                if (directChannels.Count > 0)
-                {
-                    bool hasDirectOnCh = directChannels.Any(dc =>
-                        ChannelSpanHelper.SpansOverlap(apSpan, (dc, dc)));
-                    if (!hasDirectOnCh)
-                    {
-                        double minDirectLoad = double.MaxValue;
-                        foreach (var dc in directChannels)
-                        {
-                            if (graph.ExternalLoad[i].TryGetValue(dc, out var dw))
-                                minDirectLoad = Math.Min(minDirectLoad, dw);
-                        }
-                        if (minDirectLoad == double.MaxValue) minDirectLoad = 0;
-                        unobservedPenalty = Math.Max(externalScore * UnobservedChannelMultiplier, minDirectLoad);
-                    }
-                }
+                // Unobserved channel uncertainty (confidence-weighted, matches ScoreAp/ScoreAssignment)
+                double unobservedPenalty = ComputeUnobservedPenalty(graph, band, i, testAssignment);
 
                 var total = internalScore + externalScore + scanScore + stressScore + unobservedPenalty;
                 var marker = ch == currentAssignment[i].Channel ? " <<<" : "";

--- a/tests/NetworkOptimizer.Storage.Tests/MonitoringInfluxCsvParserTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/MonitoringInfluxCsvParserTests.cs
@@ -1,0 +1,72 @@
+using FluentAssertions;
+using NetworkOptimizer.Storage.Services;
+using Xunit;
+
+namespace NetworkOptimizer.Storage.Tests;
+
+/// <summary>
+/// Verifies the span-based annotated-CSV parser that replaced the buffered FluxRecord path for the
+/// high-volume latency-detail reads. A parser is all-or-nothing, so these pin the exact column
+/// mapping, UTC handling, null handling, sort, and line-ending tolerance.
+/// </summary>
+public class MonitoringInfluxCsvParserTests
+{
+    // Annotated CSV exactly as Flux returns the latency-detail pivot query. The field columns are in
+    // a deliberately non-positional order (jitter, loss, rtt_avg, rtt_max) to prove the parser maps
+    // by column name, not index.
+    private const string Csv =
+        "#group,false,false,true,true,false,true,true,false,false,false,false\r\n" +
+        "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double,double,double,double\r\n" +
+        "#default,_result,,,,,,,,,,\r\n" +
+        ",result,table,_start,_stop,_time,target_id,target_type,jitter_ms,loss_percent,rtt_avg_ms,rtt_max_ms\r\n" +
+        ",,0,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T01:00:00Z,transit-x,transit,0.7,0,3,3.4\r\n" +
+        ",,0,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,transit-x,transit,0.3,0,2.8,3.1\r\n" +
+        ",,1,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,cdn-y,internetservice,,,12.3,\r\n";
+
+    [Fact]
+    public void Parses_points_per_target_mapping_columns_by_name()
+    {
+        var result = MonitoringInfluxClient.ParseLatencyDetailCsv(Csv);
+
+        result.Should().ContainKeys("transit-x", "cdn-y");
+        result["transit-x"].Should().HaveCount(2);
+        result["cdn-y"].Should().HaveCount(1);
+
+        // Sorted by time within target, even though the 01:00 row appeared before the 00:45 row.
+        var tx = result["transit-x"];
+        tx[0].Time.Should().Be(new DateTime(2026, 6, 19, 0, 45, 0, DateTimeKind.Utc));
+        tx[0].Time.Kind.Should().Be(DateTimeKind.Utc);
+        tx[0].RttAvgMs.Should().Be(2.8);
+        tx[0].RttMaxMs.Should().Be(3.1);
+        tx[0].JitterMs.Should().Be(0.3);
+        tx[0].LossPercent.Should().Be(0);
+        tx[1].Time.Should().Be(new DateTime(2026, 6, 19, 1, 0, 0, DateTimeKind.Utc));
+        tx[1].JitterMs.Should().Be(0.7);
+        tx[1].RttAvgMs.Should().Be(3);
+    }
+
+    [Fact]
+    public void Empty_cells_become_null()
+    {
+        var cdn = MonitoringInfluxClient.ParseLatencyDetailCsv(Csv)["cdn-y"][0];
+        cdn.RttAvgMs.Should().Be(12.3);
+        cdn.JitterMs.Should().BeNull();
+        cdn.LossPercent.Should().BeNull();
+        cdn.RttMaxMs.Should().BeNull();
+    }
+
+    [Fact]
+    public void Empty_or_null_csv_returns_empty()
+    {
+        MonitoringInfluxClient.ParseLatencyDetailCsv("").Should().BeEmpty();
+        MonitoringInfluxClient.ParseLatencyDetailCsv(null!).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Tolerates_lf_only_line_endings()
+    {
+        var result = MonitoringInfluxClient.ParseLatencyDetailCsv(Csv.Replace("\r\n", "\n"));
+        result["transit-x"].Should().HaveCount(2);
+        result["cdn-y"][0].RttAvgMs.Should().Be(12.3);
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionDetectorTests.cs
@@ -52,6 +52,56 @@ public class CongestionDetectorTests
     }
 
     [Fact]
+    public void Sustained_event_with_a_dip_and_milder_tail_stays_one_event()
+    {
+        // A peak, a brief dip, then a milder-but-still-jittery tail - one event spanning the whole
+        // span, not truncated to the peak. Mirrors a real multi-hour event whose second half stayed
+        // elevated (jitter still up) just under the strict entry gate.
+        var start = TestSeries.Start.AddHours(12);
+        var samples = TestSeries.Flat(TestSeries.Start, Day, rttMs: 5, jitterMs: 0.5)
+            .WithSegment(start, start.AddMinutes(45), rttMs: 9, jitterMs: 3)                  // peak: clears entry gate
+            .WithSegment(start.AddMinutes(45), start.AddMinutes(60), rttMs: 6.1, jitterMs: 1.0)  // dip: below entry, jitter sustains
+            .WithSegment(start.AddMinutes(60), start.AddMinutes(135), rttMs: 6.5, jitterMs: 1.0); // milder tail: jitter sustains
+
+        var events = CongestionDetector.DetectForSeries(TestSeries.Asn(64500, "TransitOne", samples), Options);
+
+        events.Should().HaveCount(1);
+        events[0].Start.Should().Be(start);
+        events[0].End.Should().Be(start.AddMinutes(135));
+    }
+
+    [Fact]
+    public void Mild_elevation_that_never_meets_the_entry_gate_is_not_congestion()
+    {
+        // An hour at the sustain level but never the strict entry gate (no peak). The hysteresis gate
+        // continues an active run; it must never start one, so nothing is flagged here.
+        var start = TestSeries.Start.AddHours(12);
+        var samples = TestSeries.Flat(TestSeries.Start, Day, rttMs: 5, jitterMs: 0.5)
+            .WithSegment(start, start.AddMinutes(60), rttMs: 6.5, jitterMs: 1.0);
+
+        var events = CongestionDetector.DetectForSeries(TestSeries.Asn(64500, "TransitOne", samples), Options);
+
+        events.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Path_shift_plateau_with_baseline_jitter_does_not_become_congestion()
+    {
+        // A transit path change: RTT steps up to a flat plateau and back, jitter at baseline the
+        // whole time (a brief blip at the transition can fire the entry gate). With jitter flat there
+        // is no congestion signature to sustain, so the run collapses to the sub-30-min transition
+        // and nothing is flagged. The step detector owns this shape, not congestion.
+        var start = TestSeries.Start.AddHours(12);
+        var samples = TestSeries.Flat(TestSeries.Start, Day, rttMs: 16, jitterMs: 0.5)
+            .WithSegment(start, start.AddMinutes(15), rttMs: 24, jitterMs: 3)            // transition turbulence
+            .WithSegment(start.AddMinutes(15), start.AddHours(3), rttMs: 24, jitterMs: 0.5); // flat plateau, baseline jitter
+
+        var events = CongestionDetector.DetectForSeries(TestSeries.Asn(64500, "TransitOne", samples), Options);
+
+        events.Should().BeEmpty();
+    }
+
+    [Fact]
     public void Simultaneous_events_across_asns_merge_into_shared_event()
     {
         var humpStart = TestSeries.Start.AddHours(19);

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
@@ -35,7 +35,13 @@ public class CongestionLocalizerTests
 
     private static readonly Dictionary<string, int> HopNumbers = new(StringComparer.OrdinalIgnoreCase)
     {
-        [Bng] = 1, [Border] = 2, [Backhaul] = 3, [Transit] = 4, [DeadEnd] = 3, [DestCorridor] = 5, [DestControl] = 5
+        [Bng] = 1,
+        [Border] = 2,
+        [Backhaul] = 3,
+        [Transit] = 4,
+        [DeadEnd] = 3,
+        [DestCorridor] = 5,
+        [DestControl] = 5
     };
 
     private static List<LatencySample> Flat(double rtt = 5) => TestSeries.Flat(TestSeries.Start, Day, rtt, jitterMs: 0.5);
@@ -60,8 +66,13 @@ public class CongestionLocalizerTests
         var s = Hop(0, ip, samples, ancestors);
         return new AsnSeries
         {
-            AsnNumber = 0, AsnName = ip, TargetIds = { ip }, Samples = samples,
-            HopIps = { ip }, AncestorIps = ancestors.ToList(), IsDestination = true
+            AsnNumber = 0,
+            AsnName = ip,
+            TargetIds = { ip },
+            Samples = samples,
+            HopIps = { ip },
+            AncestorIps = ancestors.ToList(),
+            IsDestination = true
         };
     }
 
@@ -79,6 +90,62 @@ public class CongestionLocalizerTests
         Load = load ? HighLoad() : new List<(DateTime, double?)>(),
         HasTraceMap = true
     };
+
+    [Fact]
+    public void Each_bottleneck_reports_its_own_duration_not_the_cluster_span()
+    {
+        // Two independent bottlenecks overlap in time: a near backhaul hop that clears in 45 min,
+        // and an off-corridor dead-end hop elevated for 3 h. They land in one time-cluster, but each
+        // event must report its OWN elevation span - the short one must not inherit the long one's.
+        var shortEnd = HumpStart.AddMinutes(45);
+        var longEnd = HumpStart.AddHours(3);
+        List<LatencySample> ElevatedUntil(DateTime end, double rtt) =>
+            Flat(rtt).WithSegment(HumpStart, end, rttMs: rtt + 25, jitterMs: 6);
+
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Flat()),
+            Hop(100, Border, Flat()),
+            Hop(100, Backhaul, ElevatedUntil(shortEnd, 5), Bng, Border), // 45 min; next hop clean -> own bottleneck
+            Hop(200, Transit, Flat(8), Bng, Border, Backhaul),           // clean downstream witness
+            Hop(300, DeadEnd, ElevatedUntil(longEnd, 5), Bng, Border),   // 3 h; off-corridor dead-end -> own bottleneck
+            Dest(DestControl, Flat(), Bng, Border),
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        var backhaul = events.Single(e => e.BottleneckHopIp == Backhaul);
+        var deadEnd = events.Single(e => e.BottleneckHopIp == DeadEnd);
+        backhaul.Duration.Should().BeLessThan(TimeSpan.FromHours(1));
+        deadEnd.Duration.Should().BeGreaterThan(TimeSpan.FromHours(2));
+    }
+
+    [Fact]
+    public void Similar_duration_bottlenecks_share_one_clean_window()
+    {
+        // Two bottlenecks elevated for roughly the same long span (slightly staggered). Each covers
+        // most of the cluster, so both report the SAME shared window instead of fragmenting into
+        // slightly different per-hop start/end - the genuine co-temporal event reads as one window.
+        List<LatencySample> ElevatedBetween(DateTime from, DateTime to, double rtt) =>
+            Flat(rtt).WithSegment(from, to, rttMs: rtt + 25, jitterMs: 6);
+
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Flat()),
+            Hop(100, Border, Flat()),
+            Hop(100, Backhaul, ElevatedBetween(HumpStart, HumpStart.AddHours(3), 5), Bng, Border),       // 3 h
+            Hop(200, Transit, Flat(8), Bng, Border, Backhaul),                                            // clean witness
+            Hop(300, DeadEnd, ElevatedBetween(HumpStart.AddMinutes(15), HumpStart.AddMinutes(165), 5), Bng, Border), // 2.5 h, staggered
+            Dest(DestControl, Flat(), Bng, Border),
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        var backhaul = events.Single(e => e.BottleneckHopIp == Backhaul);
+        var deadEnd = events.Single(e => e.BottleneckHopIp == DeadEnd);
+        backhaul.Start.Should().Be(deadEnd.Start);
+        backhaul.End.Should().Be(deadEnd.End);
+    }
 
     [Fact]
     public void Localizes_to_backhaul_hop_and_does_not_blame_downstream_transit()
@@ -276,6 +343,29 @@ public class CongestionLocalizerTests
     }
 
     [Fact]
+    public void Propagation_recognizes_a_jitter_rise_downstream_not_just_rtt()
+    {
+        // The bottleneck's delay reaches the downstream hop as JITTER while its RTT stays flat.
+        // RTT-only propagation would absolve the bottleneck as control-plane noise; the jitter arm
+        // must see the propagation and confirm the real bottleneck.
+        var jitterOnly = Flat(5).WithSegment(HumpStart, HumpEnd, rttMs: 5, jitterMs: 3);
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Flat()),
+            Hop(100, Border, Flat()),
+            Hop(100, Backhaul, Elevated(), Bng, Border),             // bottleneck, fires (rtt + jitter)
+            Hop(200, Transit, jitterOnly, Bng, Border, Backhaul),    // downstream: jitter up, RTT flat
+            Hop(300, DeadEnd, Flat(), Bng, Border),
+            Dest(DestControl, Flat(), Bng, Border)
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        var backhaul = events.Single(e => e.BottleneckHopIp == Backhaul);
+        backhaul.Disposition.Should().Be(CongestionDisposition.Confirmed);
+    }
+
+    [Fact]
     public void Unverifiable_hop_inherits_confirmed_from_a_same_asn_sibling_in_the_same_window()
     {
         // Two hops on AS 500 elevated in the same window: one has a downstream witness (Confirmed),
@@ -307,6 +397,32 @@ public class CongestionLocalizerTests
         var deadEnd = events.Single(e => e.BottleneckHopIp == "10.0.5.2");
         deadEnd.Disposition.Should().Be(CongestionDisposition.Confirmed);
         deadEnd.ConfirmedBySibling.Should().BeTrue();
+    }
+
+    [Fact]
+    public void A_parallel_path_that_only_picked_up_the_jitter_floor_counts_as_a_clean_control()
+    {
+        // Backhaul is the localized bottleneck under load. A parallel branch (DeadEnd) only picked up
+        // the load's jitter floor - its RTT stayed at baseline - so it did NOT get localized congestion
+        // and must count as a clean control (evidence Backhaul is its own capacity, not access
+        // bufferbloat). A jitter-inclusive "elevated" test would wrongly exclude it and drop the count.
+        var jitterFloor = Flat(5).WithSegment(HumpStart, HumpEnd, rttMs: 5, jitterMs: 3);
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Flat()),
+            Hop(100, Border, Flat(), Bng),
+            Hop(100, Backhaul, Elevated(), Bng, Border),            // localized bottleneck
+            Hop(200, Transit, Elevated(), Bng, Border, Backhaul),   // downstream victim
+            Hop(300, DeadEnd, jitterFloor, Bng, Border),            // parallel branch: jitter floor only, RTT flat
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: true), Options);
+
+        var backhaul = events.Single(e => e.BottleneckHopIp == Backhaul);
+        backhaul.Disposition.Should().Be(CongestionDisposition.Confirmed);
+        // Bng, Border, and the jitter-floor DeadEnd all stayed at the floor -> all clean controls.
+        // Without the floor-relative test, the jitter-floor DeadEnd would be excluded (count would be 2).
+        backhaul.CleanParallelPaths.Should().Be(3);
     }
 
     [Fact]
@@ -347,6 +463,119 @@ public class CongestionLocalizerTests
         // Access hop + 10.0.7.1 (both clean, with data in the window) count; 10.0.8.1 (no data during
         // the event) does not - it would be 3 without the data-presence guard.
         evt.CleanParallelPaths.Should().Be(2);
+    }
+
+    [Fact]
+    public void A_uniform_line_wide_rise_with_a_long_mild_tail_still_collapses()
+    {
+        // The Jun 23 shape: every path has a strong ~1 h core plus a long jitter tail whose RTT sits
+        // back at baseline (the jitter keeps the run alive). The MEDIAN RTT over the full window
+        // dilutes toward baseline, so a median-based line-wide test flickers below threshold and the
+        // incident fragments into per-hop rows. The high-percentile test sees the strong core, so a
+        // genuinely line-wide, uniform incident collapses to one shared event even with a long tail.
+        List<LatencySample> CoreThenTail() => Flat(5)
+            .WithSegment(HumpStart, HumpStart.AddHours(1), rttMs: 30, jitterMs: 6)
+            .WithSegment(HumpStart.AddHours(1), HumpStart.AddHours(3), rttMs: 5, jitterMs: 3);
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, CoreThenTail()),
+            Hop(100, Border, CoreThenTail(), Bng),
+            Hop(100, Backhaul, CoreThenTail(), Bng, Border),
+            Hop(200, Transit, CoreThenTail(), Bng, Border, Backhaul),
+            Hop(300, DeadEnd, CoreThenTail(), Bng, Border),
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        events.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void A_high_variance_rise_under_load_is_not_loaded_latency_even_when_breadth_passes()
+    {
+        // The 19:15 shape: the access egress rose hard while the rest only picked up the shared load
+        // floor (jitter up, RTT barely moved). The high-percentile breadth test now counts the floor
+        // paths as "rose", so line-wide breadth passes - but the rise is NOT uniform (one path far above
+        // the floor). The uniformity gate must keep this from reading as self-inflicted Loaded Latency;
+        // it's localized congestion on top of load, not your access link slowing everything equally.
+        List<LatencySample> Floor() => Flat(5).WithSegment(HumpStart, HumpEnd, rttMs: 6, jitterMs: 3);
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Elevated()),                  // access egress: hard rise
+            Hop(100, Border, Floor(), Bng),             // the rest: shared floor only (jitter up, RTT flat)
+            Hop(100, Backhaul, Floor(), Bng, Border),
+            Hop(200, Transit, Floor(), Bng, Border, Backhaul),
+            Hop(300, DeadEnd, Floor(), Bng, Border),
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: true), Options);
+
+        events.Should().NotContain(e => e.Disposition == CongestionDisposition.SelfInflicted);
+    }
+
+    [Fact]
+    public void Floor_jitter_rise_with_only_some_paths_risen_in_rtt_does_not_collapse_to_loaded_latency()
+    {
+        // Under load the jitter floor lifts every path, but only some paths actually rose in RTT.
+        // That's a shared floor + localized congestion, not "everything slowed" - it must NOT collapse
+        // to one Loaded Latency event; the RTT-risen paths localize per-hop instead.
+        var jitterOnly = Flat(5).WithSegment(HumpStart, HumpEnd, rttMs: 5, jitterMs: 3);
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, jitterOnly),
+            Hop(100, Border, jitterOnly, Bng),
+            Hop(100, Backhaul, Elevated(), Bng, Border),
+            Hop(200, Transit, Elevated(), Bng, Border, Backhaul),
+            Hop(300, DeadEnd, jitterOnly, Bng, Border),
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: true), Options);
+
+        events.Should().NotContain(e => e.Disposition == CongestionDisposition.SelfInflicted);
+    }
+
+    [Fact]
+    public void Relative_line_wide_with_no_load_collapses_to_one_shared_confirmed_event()
+    {
+        // Every monitored path is elevated relative to its own baseline, rooted at the access egress,
+        // with no heavy local load: one shared upstream incident attributed to the convergence hop,
+        // Confirmed (scored) - not N separate per-hop rows.
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Elevated()),
+            Hop(100, Border, Elevated(), Bng),
+            Hop(100, Backhaul, Elevated(), Bng, Border),
+            Hop(200, Transit, Elevated(), Bng, Border, Backhaul),
+            Hop(300, DeadEnd, Elevated(), Bng, Border),
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        events.Should().ContainSingle();
+        events[0].Disposition.Should().Be(CongestionDisposition.Confirmed);
+        events[0].BottleneckHopIp.Should().Be(Bng);
+        events[0].AttributionReason.Should().Contain("shared upstream");
+    }
+
+    [Fact]
+    public void Shared_incident_span_trims_a_lingering_hop()
+    {
+        // Four hops rise together for ~45 min; one lingers 3 h past the rest. The collapsed incident
+        // must span only the shared window (~45 min), not be dragged out to the lingering hop's 3 h.
+        var lingering = Flat(5).WithSegment(HumpStart, HumpStart.AddHours(3), rttMs: 30, jitterMs: 6);
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, Elevated()),
+            Hop(100, Border, Elevated(), Bng),
+            Hop(100, Backhaul, Elevated(), Bng, Border),
+            Hop(200, Transit, Elevated(), Bng, Border, Backhaul),
+            Hop(300, DeadEnd, lingering, Bng, Border),
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        events.Should().ContainSingle();
+        events[0].Duration.Should().BeLessThan(TimeSpan.FromHours(1.5));
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
@@ -26,6 +26,26 @@ public class OutageDetectorTests
 
     private static IReadOnlyList<IReadOnlyList<LatencySample>> Triggers(params List<LatencySample>[] series) => series;
 
+    /// <summary>A target sampled every 5 s across the window, dark (100% loss) where the predicate holds.</summary>
+    private static List<LatencySample> Cadenced(Func<DateTime, bool> isDark)
+    {
+        var s = new List<LatencySample>();
+        for (var t = TestSeries.Start; t < TestSeries.Start + Window; t += TimeSpan.FromSeconds(5))
+            s.Add(new LatencySample(t, 20, 20.5, 0.5, isDark(t) ? 100 : 0));
+        return s;
+    }
+
+    /// <summary>A target sampled every 10 s, at <paramref name="loss"/> within [from, to) and clean otherwise.</summary>
+    private static List<LatencySample> LossSeries(DateTime from, DateTime to, double loss)
+    {
+        var s = new List<LatencySample>();
+        for (var t = TestSeries.Start; t < TestSeries.Start + Window; t += TimeSpan.FromSeconds(10))
+            s.Add(new LatencySample(t, 20, 20.5, 0.5, t >= from && t < to ? loss : 0));
+        return s;
+    }
+
+    private static readonly (DateTime Start, DateTime End)[] NoDarkWindows = System.Array.Empty<(DateTime, DateTime)>();
+
     [Fact]
     public void Detects_upstream_outage_and_attributes_break_beyond_olt()
     {
@@ -48,6 +68,7 @@ public class OutageDetectorTests
         events[0].Scope.Should().Be(OutageScope.Upstream);
         events[0].LastReachableHop.Should().Be("AT&T nokia-olt");
         events[0].Duration.Should().BeCloseTo(TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(1));
+        events[0].IsBrief.Should().BeFalse();
     }
 
     [Fact]
@@ -161,12 +182,142 @@ public class OutageDetectorTests
     }
 
     [Fact]
-    public void Brief_blip_below_min_duration_is_ignored()
+    public void Momentary_blip_below_the_minimum_is_ignored()
     {
-        var internet1 = Series(0, (OutStart, OutStart.AddMinutes(1), 100));
-        var internet2 = Series(0, (OutStart, OutStart.AddMinutes(1), 100));
+        // ~20 s of total loss - below the 30 s floor, a momentary blip, not reported.
+        var darkEnd = OutStart.AddSeconds(20);
+        var internet1 = Cadenced(t => t >= OutStart && t < darkEnd);
+        var internet2 = Cadenced(t => t >= OutStart && t < darkEnd);
 
         var events = OutageDetector.Detect(Triggers(internet1, internet2), System.Array.Empty<OutageDetector.Hop>(), Options);
+
+        events.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Drop_between_30s_and_2min_is_flagged_as_a_brief_disruption()
+    {
+        // A clean 45 s drop: above the 30 s floor, below the 2 min brief/full divider. It is
+        // reported but classified brief - the lighter tier for short transit/upstream flaps.
+        var darkEnd = OutStart.AddSeconds(45);
+        var internet1 = Cadenced(t => t >= OutStart && t < darkEnd);
+        var internet2 = Cadenced(t => t >= OutStart && t < darkEnd);
+
+        var events = OutageDetector.Detect(Triggers(internet1, internet2), System.Array.Empty<OutageDetector.Hop>(), Options);
+
+        events.Should().ContainSingle();
+        events[0].IsBrief.Should().BeTrue();
+        events[0].Duration.Should().BeGreaterThanOrEqualTo(TimeSpan.FromSeconds(30));
+        events[0].Duration.Should().BeLessThan(TimeSpan.FromMinutes(2));
+    }
+
+    [Fact]
+    public void Coincident_partial_loss_across_many_targets_and_asns_is_a_partial_disruption()
+    {
+        // ~40 s where four independent destinations across four ASNs degrade together at 60-80%
+        // loss - never the 95% dark threshold. That is a partial-loss disruption, not a blackout.
+        var ds = OutStart;
+        var de = OutStart.AddSeconds(40);
+        var hops = new[]
+        {
+            new OutageDetector.Hop("Cloudflare", 0, LossSeries(ds, de, 60), AsnLabel: "Cloudflare"),
+            new OutageDetector.Hop("Fastly", 1, LossSeries(ds, de, 80), AsnLabel: "Fastly"),
+            new OutageDetector.Hop("AS3356", 2, LossSeries(ds, de, 60), AsnLabel: "AS3356"),
+            new OutageDetector.Hop("AS22773", 3, LossSeries(ds, de, 80), AsnLabel: "AS22773"),
+            new OutageDetector.Hop("CleanA", 4, LossSeries(ds, de, 0), AsnLabel: "CleanA"),
+            new OutageDetector.Hop("CleanB", 5, LossSeries(ds, de, 0), AsnLabel: "CleanB"),
+        };
+
+        var events = OutageDetector.DetectPartial(hops, NoDarkWindows, Options);
+
+        events.Should().ContainSingle();
+        events[0].IsPartial.Should().BeTrue();
+        events[0].IsBrief.Should().BeTrue();
+        events[0].PeakLossPct.Should().BeGreaterThanOrEqualTo(60);
+        events[0].DegradedTargetCount.Should().Be(4);
+        events[0].PathTargetCount.Should().Be(6);
+    }
+
+    [Fact]
+    public void A_single_lossy_target_is_not_a_partial_disruption()
+    {
+        var ds = OutStart;
+        var de = OutStart.AddMinutes(5);
+        var hops = new[]
+        {
+            new OutageDetector.Hop("Fastly", 0, LossSeries(ds, de, 80), AsnLabel: "Fastly"),
+            new OutageDetector.Hop("CleanA", 1, LossSeries(ds, de, 0), AsnLabel: "CleanA"),
+            new OutageDetector.Hop("CleanB", 2, LossSeries(ds, de, 0), AsnLabel: "CleanB"),
+            new OutageDetector.Hop("CleanC", 3, LossSeries(ds, de, 0), AsnLabel: "CleanC"),
+        };
+
+        var events = OutageDetector.DetectPartial(hops, NoDarkWindows, Options);
+
+        events.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Many_degraded_targets_behind_one_asn_do_not_trip_partial_detection()
+    {
+        // Four lossy targets, but all one ASN - that ASN's own issue, not a path-wide event.
+        var ds = OutStart;
+        var de = OutStart.AddSeconds(40);
+        var hops = new[]
+        {
+            new OutageDetector.Hop("AS3356 a", 0, LossSeries(ds, de, 80), AsnLabel: "AS3356"),
+            new OutageDetector.Hop("AS3356 b", 1, LossSeries(ds, de, 80), AsnLabel: "AS3356"),
+            new OutageDetector.Hop("AS3356 c", 2, LossSeries(ds, de, 80), AsnLabel: "AS3356"),
+            new OutageDetector.Hop("AS3356 d", 3, LossSeries(ds, de, 80), AsnLabel: "AS3356"),
+            new OutageDetector.Hop("CleanA", 4, LossSeries(ds, de, 0), AsnLabel: "CleanA"),
+        };
+
+        var events = OutageDetector.DetectPartial(hops, NoDarkWindows, Options);
+
+        events.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Partial_disruption_disambiguates_repeated_asn_labels()
+    {
+        // Several hops of one access ISP would all read as just "AT&T"; only the repeated label gets
+        // disambiguated to the specific hop, while unique labels are left as the clean ASN name.
+        var ds = OutStart;
+        var de = OutStart.AddSeconds(40);
+        var hops = new[]
+        {
+            new OutageDetector.Hop("AT&T nokia-olt", 0, LossSeries(ds, de, 80), AsnLabel: "AT&T"),
+            new OutageDetector.Hop("AT&T mtnview-border", 1, LossSeries(ds, de, 80), AsnLabel: "AT&T"),
+            new OutageDetector.Hop("Cloudflare", 2, LossSeries(ds, de, 80), AsnLabel: "Cloudflare"),
+            new OutageDetector.Hop("Fastly", 3, LossSeries(ds, de, 80), AsnLabel: "Fastly"),
+        };
+
+        var events = OutageDetector.DetectPartial(hops, NoDarkWindows, Options);
+
+        events.Should().ContainSingle();
+        var names = events[0].Tiers.Select(t => t.Name).ToList();
+        names.Should().Contain("AT&T nokia-olt");
+        names.Should().Contain("AT&T mtnview-border");
+        names.Should().NotContain("AT&T");                 // the bare duplicate label is replaced
+        names.Should().Contain("Cloudflare");              // unique labels stay clean
+        names.Should().Contain("Fastly");
+    }
+
+    [Fact]
+    public void Partial_window_overlapping_a_blackout_is_excluded()
+    {
+        // A blackout also clears the partial threshold; the partial pass must not surface it again.
+        var ds = OutStart;
+        var de = OutStart.AddSeconds(40);
+        var hops = new[]
+        {
+            new OutageDetector.Hop("Cloudflare", 0, LossSeries(ds, de, 60), AsnLabel: "Cloudflare"),
+            new OutageDetector.Hop("Fastly", 1, LossSeries(ds, de, 80), AsnLabel: "Fastly"),
+            new OutageDetector.Hop("AS3356", 2, LossSeries(ds, de, 60), AsnLabel: "AS3356"),
+            new OutageDetector.Hop("AS22773", 3, LossSeries(ds, de, 80), AsnLabel: "AS22773"),
+        };
+        var darkWindows = new[] { (OutStart.AddSeconds(-5), OutStart.AddSeconds(45)) };
+
+        var events = OutageDetector.DetectPartial(hops, darkWindows, Options);
 
         events.Should().BeEmpty();
     }
@@ -219,9 +370,9 @@ public class OutageDetectorTests
     public void Gap_longer_than_the_tolerance_stays_two_separate_outages()
     {
         // A long healthy stretch between two dark spans is a genuine recovery then a second
-        // outage - well beyond OutageMaxGapMinutes, so the two must NOT be coalesced.
+        // outage - well beyond OutageMaxGapSeconds, so the two must NOT be coalesced.
         var firstEnd = OutStart.AddMinutes(3);
-        var secondStart = OutStart.AddMinutes(12); // 9-minute clear gap, > OutageMaxGapMinutes
+        var secondStart = OutStart.AddMinutes(12); // 9-minute clear gap, > OutageMaxGapSeconds
         var secondEnd = secondStart.AddMinutes(3);
         List<LatencySample> TwoSpans() => Series(0, (OutStart, firstEnd, 100), (secondStart, secondEnd, 100));
         var internet1 = TwoSpans();
@@ -302,9 +453,9 @@ public class OutageDetectorTests
     [Fact]
     public void Window_and_recovery_carry_real_seconds_not_minute_buckets()
     {
-        // Samples land at :17 past each minute. Detection still buckets by minute, but the
-        // reported onset, recovery, and per-hop recovery must come from the actual sample
-        // instants - otherwise every time renders :00.
+        // Samples land at :17 past each minute. Detection buckets internally, but the reported
+        // onset, recovery, and per-hop recovery must come from the actual sample instants -
+        // otherwise every time renders on a bucket edge.
         var offset = TimeSpan.FromSeconds(17);
         List<LatencySample> Build()
         {

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -26,15 +26,15 @@ public class ChannelRecommendationServiceTests
         int width = 80, int txPower = 20, bool hasDfs = false,
         bool isMeshChild = false, string? meshParentMac = null,
         RadioBand? meshUplinkBand = null, int? meshUplinkChannel = null) => new()
-    {
-        Mac = mac,
-        Name = name,
-        IsOnline = true,
-        IsMeshChild = isMeshChild,
-        MeshParentMac = meshParentMac,
-        MeshUplinkBand = meshUplinkBand,
-        MeshUplinkChannel = meshUplinkChannel,
-        Radios = new()
+        {
+            Mac = mac,
+            Name = name,
+            IsOnline = true,
+            IsMeshChild = isMeshChild,
+            MeshParentMac = meshParentMac,
+            MeshUplinkBand = meshUplinkBand,
+            MeshUplinkChannel = meshUplinkChannel,
+            Radios = new()
         {
             new RadioSnapshot
             {
@@ -46,7 +46,7 @@ public class ChannelRecommendationServiceTests
                 HasDfs = hasDfs
             }
         }
-    };
+        };
 
     // --- Graph Building ---
 
@@ -109,8 +109,8 @@ public class ChannelRecommendationServiceTests
 
         var graph = _service.BuildInterferenceGraph(aps, RadioBand.Band5GHz, null, null, null);
 
-        // -65 dBm → weight 0.625
-        graph.InternalWeights[0, 1].Should().BeApproximately(0.625, 0.01);
+        // -65 dBm, CCA-anchored: (-65 + 82) / 32 = 0.531
+        graph.InternalWeights[0, 1].Should().BeApproximately(0.531, 0.01);
     }
 
     [Fact]
@@ -222,6 +222,183 @@ public class ChannelRecommendationServiceTests
             graph, new[] { (36, 80), (36, 80) }, RadioBand.Band5GHz);
 
         score.Should().Be(0);
+    }
+
+    // --- Unobserved-channel uncertainty (confidence-weighted) ---
+
+    // Builds a 2-AP graph where the sibling sits on a non-overlapping channel, so the
+    // subject AP (index 0) is the only contributor to the score - isolating its external
+    // + unobserved-uncertainty terms.
+    private InterferenceGraph BuildSubjectGraph(int siblingChannel = 100)
+    {
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "Subject", RadioBand.Band5GHz, 149),
+            CreateAp("aa:bb:cc:dd:ee:02", "Sibling", RadioBand.Band5GHz, siblingChannel)
+        };
+        var graph = _service.BuildInterferenceGraph(aps, RadioBand.Band5GHz, null, null, null);
+        graph.DirectlyObservedChannels[0] = new HashSet<int> { 36 };
+        graph.ExternalLoad[0] = new Dictionary<int, double> { { 36, 1.0 }, { 149, 0.5 } };
+        return graph;
+    }
+
+    [Fact]
+    public void ScoreAssignment_HistoricOccupancy_SoftensUnobservedPenalty()
+    {
+        // ch149 is triangulated-only (not directly scanned), so it normally carries the full
+        // uncertainty penalty. But if the AP has measured historic occupancy of ch149, we have
+        // real data for it and the penalty should be mostly waived (confidence 0.85).
+        var graph = BuildSubjectGraph();
+        var assignment = new[] { (149, 80), (100, 80) };
+
+        graph.Nodes[0].HistoricalStress = null;
+        var scoreNoHistory = _service.ScoreAssignment(graph, assignment, RadioBand.Band5GHz);
+
+        graph.Nodes[0].HistoricalStress = new Dictionary<int, (double, double, double)>
+        {
+            { 149, (0, 0, 0) } // benign measured airtime - isolates the unobserved term
+        };
+        var scoreWithHistory = _service.ScoreAssignment(graph, assignment, RadioBand.Band5GHz);
+
+        scoreWithHistory.Should().BeLessThan(scoreNoHistory);
+        // History keeps only 15% of the cliff, so the gap is 0.85 of the full penalty. The floor
+        // now carries the band uncertainty multiplier (x2.0 on 5 GHz), so the base penalty is 2.0.
+        (scoreNoHistory - scoreWithHistory).Should().BeApproximately(1.7, 0.05);
+    }
+
+    [Fact]
+    public void ScoreAssignment_UnobservedChannelNoEvidence_StillPenalized()
+    {
+        // Soundness guard: a channel with no direct scan, no historic occupancy, and no resident
+        // sibling must still be taxed, so genuinely-unknown channels can't win by looking empty.
+        var graph = BuildSubjectGraph();
+        graph.Nodes[0].HistoricalStress = null;
+
+        var onObserved = _service.ScoreAssignment(
+            graph, new[] { (36, 80), (100, 80) }, RadioBand.Band5GHz);
+        var onUnobserved = _service.ScoreAssignment(
+            graph, new[] { (149, 80), (100, 80) }, RadioBand.Band5GHz);
+
+        onUnobserved.Should().BeGreaterThan(onObserved);
+    }
+
+    [Fact]
+    public void ScoreAssignment_UnobservedPenalty_IndependentOfApCurrentChannel()
+    {
+        // Anti-oscillation invariant: a candidate channel must score the same whether the AP is
+        // currently resident on it or moving onto it. Confidence is drawn from stable signals
+        // (historic occupancy), not the AP's current position, so the score doesn't swing on moves.
+        var graph = BuildSubjectGraph();
+        graph.Nodes[0].HistoricalStress = new Dictionary<int, (double, double, double)>
+        {
+            { 149, (0, 0, 0) }
+        };
+        var assignment = new[] { (149, 80), (100, 80) };
+
+        graph.Nodes[0].CurrentChannel = 36;  // ch149 is a candidate the AP is moving to
+        var asCandidate = _service.ScoreAssignment(graph, assignment, RadioBand.Band5GHz);
+
+        graph.Nodes[0].CurrentChannel = 149; // AP is resident on ch149
+        var asResident = _service.ScoreAssignment(graph, assignment, RadioBand.Band5GHz);
+
+        asCandidate.Should().BeApproximately(asResident, 0.001);
+    }
+
+    [Fact]
+    public void ScoreAssignment_UnobservedPenalty_LowerForBandsWithBetterPropagation()
+    {
+        // Scan completeness tracks propagation: 2.4 GHz sees nearly every neighbor, so its
+        // unobserved channels are less uncertain than 6 GHz, which dies fastest through walls.
+        // The uncertainty multiplier must therefore order 2.4 < 5 < 6.
+        double UnobservedScore(RadioBand band, int observedCh, int unobservedCh)
+        {
+            var aps = new List<AccessPointSnapshot>
+            {
+                CreateAp("aa:bb:cc:dd:ee:01", "Subject", band, observedCh, width: 20)
+            };
+            var graph = _service.BuildInterferenceGraph(aps, band, null, null, null);
+            graph.DirectlyObservedChannels[0] = new HashSet<int> { observedCh };
+            graph.ExternalLoad[0] = new Dictionary<int, double> { { observedCh, 0.1 }, { unobservedCh, 1.0 } };
+            graph.Nodes[0].HistoricalStress = null;
+            return _service.ScoreAssignment(graph, new[] { (unobservedCh, 20) }, band);
+        }
+
+        var score2_4 = UnobservedScore(RadioBand.Band2_4GHz, 1, 11);
+        var score5 = UnobservedScore(RadioBand.Band5GHz, 36, 149);
+        var score6 = UnobservedScore(RadioBand.Band6GHz, 5, 213);
+
+        score2_4.Should().BeLessThan(score5);
+        score5.Should().BeLessThan(score6);
+    }
+
+    // --- Directional interference (EIRP-aware) ---
+
+    // Two placed APs ~45 m apart, same channel, with the given TX powers. Returns the graph.
+    private InterferenceGraph BuildPlacedPair(int txPowerA, int txPowerB)
+    {
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "AP-A", RadioBand.Band5GHz, 36, txPower: txPowerA),
+            CreateAp("aa:bb:cc:dd:ee:02", "AP-B", RadioBand.Band5GHz, 36, txPower: txPowerB)
+        };
+        var propCtx = new ApPropagationContext
+        {
+            ApsByMac = new Dictionary<string, PropagationAp>
+            {
+                ["aa:bb:cc:dd:ee:01"] = new()
+                {
+                    Mac = "aa:bb:cc:dd:ee:01",
+                    Model = "U6-Pro",
+                    Latitude = 36.0000,
+                    Longitude = -94.0000,
+                    Floor = 1,
+                    TxPowerDbm = txPowerA,
+                    AntennaGainDbi = 3,
+                    MountType = "ceiling"
+                },
+                ["aa:bb:cc:dd:ee:02"] = new()
+                {
+                    Mac = "aa:bb:cc:dd:ee:02",
+                    Model = "U6-Pro",
+                    Latitude = 36.0004,
+                    Longitude = -94.0000,
+                    Floor = 1,
+                    TxPowerDbm = txPowerB,
+                    AntennaGainDbi = 3,
+                    MountType = "ceiling"
+                }
+            },
+            WallsByFloor = new Dictionary<int, List<PropagationWall>>(),
+            Buildings = null
+        };
+        return _service.BuildInterferenceGraph(aps, RadioBand.Band5GHz, propCtx, null, null);
+    }
+
+    [Fact]
+    public void BuildInterferenceGraph_AsymmetricEirp_DirectionalWeightLowerForLowerPowerAggressor()
+    {
+        // AP-A full power (20 dBm), AP-B intentionally low (5 dBm).
+        var graph = BuildPlacedPair(txPowerA: 20, txPowerB: 5);
+
+        // Directional [aggressor, victim]: the low-power AP-B interferes with AP-A LESS than the
+        // full-power AP-A interferes with AP-B (B transmits weaker, so its signal at A is lower).
+        graph.DirectionalWeights[1, 0].Should().BeLessThan(graph.DirectionalWeights[0, 1]);
+
+        // The symmetric weight is the worst case of both directions - it equals the stronger one,
+        // so it does NOT credit B's low power (which is exactly why the degradation guard needs
+        // the directional weight instead).
+        graph.InternalWeights[0, 1].Should().Be(graph.InternalWeights[1, 0]);
+        graph.InternalWeights[0, 1].Should().BeApproximately(graph.DirectionalWeights[0, 1], 0.001);
+    }
+
+    [Fact]
+    public void BuildInterferenceGraph_EqualEirp_DirectionalWeightsSymmetric()
+    {
+        // With equal TX power, the two directions are the same - confirms the asymmetry above is
+        // driven by EIRP, not by anything else.
+        var graph = BuildPlacedPair(txPowerA: 20, txPowerB: 20);
+
+        graph.DirectionalWeights[0, 1].Should().BeApproximately(graph.DirectionalWeights[1, 0], 0.001);
     }
 
     // --- Optimization ---
@@ -545,14 +722,14 @@ public class ChannelRecommendationServiceTests
 
         // AP-1 (index 0) should have triangulated external load on ch36
         graph.ExternalLoad[0].Should().ContainKey(36);
-        // Unplaced APs have internal weight 0.625. Neighbor at -55 dBm → weight 0.875.
+        // Unplaced APs have internal weight 0.531. Neighbor at -55 dBm → weight 0.844 (CCA-anchored).
         // Width matches AP (80=80), no width scaling.
-        // Triangulated weight = 0.875 * 0.625 = 0.547
-        graph.ExternalLoad[0][36].Should().BeApproximately(0.547, 0.05);
+        // Triangulated weight = 0.844 * 0.531 = 0.448
+        graph.ExternalLoad[0][36].Should().BeApproximately(0.448, 0.05);
 
         // AP-2 (index 1) should also have direct external load on ch36
         graph.ExternalLoad[1].Should().ContainKey(36);
-        graph.ExternalLoad[1][36].Should().BeApproximately(0.875, 0.05);
+        graph.ExternalLoad[1][36].Should().BeApproximately(0.844, 0.05);
     }
 
     [Fact]
@@ -582,8 +759,8 @@ public class ChannelRecommendationServiceTests
         var graph = _service.BuildInterferenceGraph(aps, RadioBand.Band5GHz, null, scans, null);
 
         graph.ExternalLoad[0].Should().ContainKey(36);
-        // -60 dBm → 0.75, -70 dBm → 0.5, sum = 1.25
-        graph.ExternalLoad[0][36].Should().BeApproximately(1.25, 0.05);
+        // -60 dBm → 0.6875, -70 dBm → 0.375, sum = 1.0625 (CCA-anchored)
+        graph.ExternalLoad[0][36].Should().BeApproximately(1.0625, 0.05);
     }
 
     [Fact]
@@ -658,9 +835,9 @@ public class ChannelRecommendationServiceTests
         // AP-3 (index 2) should have external load on ch100 from the best estimate
         graph.ExternalLoad[2].Should().ContainKey(100);
 
-        // The stronger sighting (-55 dBm → weight 0.875) × proximity 0.625 = 0.547
-        // beats the weaker sighting (-75 dBm → weight 0.375) × proximity 0.625 = 0.234
-        graph.ExternalLoad[2][100].Should().BeApproximately(0.547, 0.05);
+        // The stronger sighting (-55 dBm → weight 0.844) × proximity 0.531 = 0.448
+        // beats the weaker sighting (-75 dBm → weight 0.219) × proximity 0.531 = 0.116
+        graph.ExternalLoad[2][100].Should().BeApproximately(0.448, 0.05);
     }
 
     // --- Re-validation after per-AP filtering ---

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelSpanHelperTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelSpanHelperTests.cs
@@ -105,15 +105,23 @@ public class ChannelSpanHelperTests
     }
 
     [Fact]
-    public void SignalToInterferenceWeight_WeakSignal_Returns0_1()
+    public void SignalToInterferenceWeight_BelowCca_ReturnsZero()
     {
-        ChannelSpanHelper.SignalToInterferenceWeight(-90).Should().BeApproximately(0.1, 0.01);
+        // -90 dBm is below the -82 CCA threshold: the radio doesn't defer, so no contention.
+        ChannelSpanHelper.SignalToInterferenceWeight(-90).Should().Be(0.0);
     }
 
     [Fact]
-    public void SignalToInterferenceWeight_TypicalSpacing_Returns0_625()
+    public void SignalToInterferenceWeight_AtCca_ReturnsZero()
     {
-        ChannelSpanHelper.SignalToInterferenceWeight(-65).Should().BeApproximately(0.625, 0.01);
+        ChannelSpanHelper.SignalToInterferenceWeight(-82).Should().Be(0.0);
+    }
+
+    [Fact]
+    public void SignalToInterferenceWeight_TypicalSpacing_Returns0_531()
+    {
+        // -65 dBm, CCA-anchored: (-65 + 82) / 32 = 0.531
+        ChannelSpanHelper.SignalToInterferenceWeight(-65).Should().BeApproximately(0.531, 0.01);
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.WiFi.Tests/LoadImbalanceRuleTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/LoadImbalanceRuleTests.cs
@@ -236,7 +236,7 @@ public class LoadImbalanceRuleTests
         {
             CreateClient("aa:bb:cc:dd:ee:01", signal: -45),
             CreateClient("aa:bb:cc:dd:ee:01", signal: -45),
-            CreateClient("aa:bb:cc:dd:ee:01", signal: -75), // weak
+            CreateClient("aa:bb:cc:dd:ee:01", signal: -85), // weak for its band (< -78 on 5 GHz)
         };
         // Pad to match TotalClients
         for (int i = 0; i < 14; i++)
@@ -279,7 +279,7 @@ public class LoadImbalanceRuleTests
     }
 
     [Fact]
-    public void FarApart_ClientWithNullSignal_NotSuppressed()
+    public void FarApart_NullSignalClientIgnored_Suppressed()
     {
         var aps = new List<AccessPointSnapshot>
         {
@@ -287,11 +287,11 @@ public class LoadImbalanceRuleTests
             CreateAp("aa:bb:cc:dd:ee:02", "AP-Garage", 2)
         };
 
-        // One client missing signal data
+        // One client missing signal data (e.g. an offline/idle device)
         var clients = new List<WirelessClientSnapshot>
         {
             CreateClient("aa:bb:cc:dd:ee:01", signal: -45),
-            CreateClient("aa:bb:cc:dd:ee:01", signal: null), // missing signal
+            CreateClient("aa:bb:cc:dd:ee:01", signal: null), // missing signal - ignored, not weak
         };
         for (int i = 0; i < 15; i++)
             clients.Add(CreateClient("aa:bb:cc:dd:ee:01", signal: -45));
@@ -303,9 +303,9 @@ public class LoadImbalanceRuleTests
         var ctx = CreateContext(aps, clients, propCtx);
         var issue = _rule.Evaluate(ctx);
 
-        // Should NOT suppress entirely because one client has null signal
-        issue.Should().NotBeNull();
-        issue!.Severity.Should().Be(HealthIssueSeverity.Info, "null signal prevents full suppression");
+        // A missing signal is treated as offline/idle, not weak. With every other client strong,
+        // the separate-zone imbalance is suppressed entirely.
+        issue.Should().BeNull();
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.WiFi.Tests/NeighborSightingPoolTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/NeighborSightingPoolTests.cs
@@ -1,0 +1,76 @@
+using FluentAssertions;
+using NetworkOptimizer.WiFi.Helpers;
+using NetworkOptimizer.WiFi.Models;
+using Xunit;
+
+namespace NetworkOptimizer.WiFi.Tests;
+
+public class NeighborSightingPoolTests
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.UnixEpoch.AddHours(1);
+    private static readonly TimeSpan Window = TimeSpan.FromMinutes(10);
+
+    private static (NeighborNetwork, DateTimeOffset) Sighting(string bssid, int channel, int signal, TimeSpan ago)
+        => (new NeighborNetwork { Bssid = bssid, Channel = channel, Signal = signal }, Now - ago);
+
+    [Fact]
+    public void Union_NeighborMissingFromLatestScan_HeldWhileWithinWindow()
+    {
+        // Seen 3 minutes ago, absent from the latest scan - must still count.
+        var pooled = NeighborSightingPool.Union(
+            new[] { Sighting("aa:bb:cc:00:00:01", 1, -60, TimeSpan.FromMinutes(3)) },
+            Now, Window);
+
+        pooled.Should().ContainSingle(n => n.Bssid == "aa:bb:cc:00:00:01");
+    }
+
+    [Fact]
+    public void Union_NeighborAbsentBeyondWindow_AgesOut()
+    {
+        var pooled = NeighborSightingPool.Union(
+            new[] { Sighting("aa:bb:cc:00:00:01", 1, -60, TimeSpan.FromMinutes(15)) },
+            Now, Window);
+
+        pooled.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Union_SameBssidMultipleSightings_KeepsStrongestSignal()
+    {
+        var pooled = NeighborSightingPool.Union(
+            new[]
+            {
+                Sighting("aa:bb:cc:00:00:01", 1, -75, TimeSpan.FromMinutes(5)),
+                Sighting("aa:bb:cc:00:00:01", 1, -55, TimeSpan.FromMinutes(2)),
+                Sighting("aa:bb:cc:00:00:01", 1, -80, TimeSpan.Zero)
+            },
+            Now, Window);
+
+        pooled.Should().ContainSingle();
+        pooled[0].Signal.Should().Be(-55);
+    }
+
+    [Fact]
+    public void Union_DistinctBssids_AllRetained()
+    {
+        var pooled = NeighborSightingPool.Union(
+            new[]
+            {
+                Sighting("aa:bb:cc:00:00:01", 1, -60, TimeSpan.Zero),
+                Sighting("aa:bb:cc:00:00:02", 6, -65, TimeSpan.FromMinutes(4))
+            },
+            Now, Window);
+
+        pooled.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Union_EmptyBssid_Ignored()
+    {
+        var pooled = NeighborSightingPool.Union(
+            new[] { Sighting("", 1, -60, TimeSpan.Zero) },
+            Now, Window);
+
+        pooled.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
Release of everything on `dev` since v1.22.3.

## Wi-Fi Optimizer

- **Smarter channel recommendations** - Fixes and improvements to the physical interference model behind channel planning, with better per-AP channel moves. (#890)
- **Stable suggestions between scans** - Marginal channel suggestions no longer flicker on and off as conditions shift slightly between scans. (#893)
- **Overview auto-refresh** - The Overview tab refreshes itself when its data goes stale instead of showing old numbers until a manual reload. (#895)

## Monitoring

- **ISP Health improvements** - Detects brief and partial-loss disruptions, more accurate congestion scoring, a clearer timeline, and faster data loading (initial load and when switching tabs). (#891)
- **Configurable temperature and SFP alert thresholds** - Switch and gateway high-temperature alerts are now user-configurable per device type (Monitoring -> Device Stats), and the per-transceiver-type SFP DDM thresholds (PON / Active Ethernet / generic SFP+) are editable (Monitoring -> SFP Stats) instead of hard-coded. Each falls back to the built-in default when unset. Also fixes alert deep-links that pointed at the wrong Monitoring tab. (#894)
