### PR TITLE
Netgear CM: read modems that emit malformed HTTP (CM700)

### DIFF
--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
@@ -50,6 +50,10 @@ public sealed class NetgearCmProvider : ICableModemProvider
     private const int MaxRetries = 3;
     private static readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(1);
 
+    // Cap on the bytes read from the raw-socket fallback (the DOCSIS pages are tens of KB); guards
+    // against a modem that never closes the connection.
+    private const int MaxRawResponseBytes = 4 * 1024 * 1024;
+
     // Some Netgear modems (e.g. CM600) allow only one web session at a time. When another
     // session is active, any page 302-redirects to MultiLogin.asp, which offers to log out
     // the existing session. These patterns pull the takeover token and RetailSessionId from
@@ -84,6 +88,12 @@ public sealed class NetgearCmProvider : ICableModemProvider
     // form action (e.g. action="/goform/Login?id=1248795675"); we reuse it when present.
     private static readonly Regex LoginIdRx =
         new(@"goform/Login\?id=(\d+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    // NET-DK firmware (e.g. CM700) sets the anti-CSRF cookie on its initial 401. The raw-socket
+    // fallback pulls it straight from the response bytes so a corrupted Set-Cookie header name
+    // (the same byte-drop corruption that forces the raw path) can't hide it.
+    private static readonly Regex XsrfCookieRx =
+        new(@"XSRF_TOKEN=([^;\s]+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     private readonly ILogger<NetgearCmProvider> _logger;
 
@@ -415,7 +425,61 @@ public sealed class NetgearCmProvider : ICableModemProvider
         return string.IsNullOrWhiteSpace(content) ? null : content;
     }
 
+    /// <summary>
+    /// Fetch a page, falling back to a lenient raw-socket reader when the modem returns a
+    /// structurally malformed HTTP response that .NET's strict parser rejects. The NET-DK/1.0
+    /// server on some Netgear modems (e.g. the CM700) intermittently drops the leading bytes of
+    /// response header lines - "Content-Length" arrives as "ntent-Length", or a stray line loses
+    /// its colon - which makes the HttpClient stack throw "Received an invalid header line" even
+    /// though browsers parse the same bytes fine. There is no in-framework switch to relax that
+    /// parsing (the old .NET Framework useUnsafeHeaderParsing has no modern HttpClient/
+    /// SocketsHttpHandler equivalent - see dotnet/runtime#29927), so on exactly that failure we
+    /// re-fetch over a TcpClient and parse the headers leniently. Modems that return RFC-compliant
+    /// HTTP never throw it, so they never enter the raw path and are completely unaffected.
+    /// </summary>
     private async Task<string?> FetchPageAsync(
+        string url,
+        string? username,
+        string? password,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await FetchViaHttpClientAsync(url, username, password, cancellationToken);
+        }
+        catch (HttpRequestException ex) when (IsMalformedHttpResponse(ex))
+        {
+            _logger.LogDebug(
+                ex, "Netgear CM {Url}: HttpClient rejected a malformed HTTP response; retrying via lenient raw-socket reader",
+                url);
+            return await FetchViaRawSocketAsync(url, username, password, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// True when an HttpRequestException reflects a structurally malformed response that .NET
+    /// could not parse into an HTTP status, rather than a normal HTTP error status or a connection
+    /// failure. Gated on a null StatusCode so a real 401/404/5xx is never diverted to the raw
+    /// reader, and matched on the specific parser messages so an offline modem (connection
+    /// refused/timed out) isn't either.
+    /// </summary>
+    private static bool IsMalformedHttpResponse(HttpRequestException ex)
+    {
+        if (ex.StatusCode is not null)
+            return false;
+
+        return Mentions(ex.Message) || (ex.InnerException is { } inner && Mentions(inner.Message));
+
+        static bool Mentions(string m) =>
+            m.Contains("invalid header", StringComparison.OrdinalIgnoreCase)
+            || m.Contains("header line", StringComparison.OrdinalIgnoreCase)
+            || m.Contains("invalid status", StringComparison.OrdinalIgnoreCase)
+            || m.Contains("malformed", StringComparison.OrdinalIgnoreCase)
+            || m.Contains("response ended prematurely", StringComparison.OrdinalIgnoreCase)
+            || m.Contains("invalid chunk", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task<string?> FetchViaHttpClientAsync(
         string url,
         string? username,
         string? password,
@@ -551,6 +615,203 @@ public sealed class NetgearCmProvider : ICableModemProvider
         // The takeover POST returns a 302 redirect on success (we don't auto-follow it; the
         // caller re-fetches the status page). Treat any non-error status as accepted.
         return (int)postResponse.StatusCode < 400;
+    }
+
+    /// <summary>
+    /// Fetch the status page over a raw <see cref="System.Net.Sockets.TcpClient"/> with a tolerant
+    /// reader. Used only as a fallback when HttpClient rejects the modem's malformed HTTP (see
+    /// <see cref="FetchPageAsync"/>). Replicates the NET-DK two-step HTTP Basic + anti-CSRF cookie
+    /// handshake: the first GET primes the XSRF_TOKEN cookie the modem sets on its 401, and the
+    /// second GET replays it alongside the preemptive Basic header. HTTP/1.0 with Connection: close
+    /// keeps the response simple (no chunking, no keep-alive); the leniently parsed body is handed
+    /// back to the normal parse pipeline. This path covers the Basic + XSRF modems (the only family
+    /// observed to corrupt its HTTP); it does not re-implement the CM600 MultiLogin takeover, which
+    /// runs on a different server that returns compliant HTTP and so never reaches here.
+    /// </summary>
+    private async Task<string?> FetchViaRawSocketAsync(
+        string url,
+        string? username,
+        string? password,
+        CancellationToken cancellationToken)
+    {
+        var uri = new Uri(url);
+        var host = uri.Host;
+        var port = uri.Port > 0 ? uri.Port : 80;
+        var pathAndQuery = string.IsNullOrEmpty(uri.PathAndQuery) ? "/" : uri.PathAndQuery;
+
+        string? authHeader = null;
+        if (!string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))
+            authHeader = "Basic " + Convert.ToBase64String(Encoding.ASCII.GetBytes($"{username}:{password}"));
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(TimeoutSeconds));
+        var ct = timeoutCts.Token;
+
+        try
+        {
+            // First request primes the XSRF_TOKEN cookie the NET-DK modem sets alongside its 401.
+            var firstRaw = await RawHttpGetAsync(host, port, pathAndQuery, authHeader, cookie: null, ct);
+            var first = ParseRawHttpResponse(firstRaw, firstRaw.Length);
+
+            // Pull the cookie straight from the raw bytes so a corrupted Set-Cookie header name
+            // can't hide it. A modem that returns the page on the first request needs no retry.
+            var cookieMatch = XsrfCookieRx.Match(Encoding.Latin1.GetString(firstRaw));
+            var cookie = cookieMatch.Success ? "XSRF_TOKEN=" + cookieMatch.Groups[1].Value : null;
+
+            var resp = first;
+            if (first.StatusCode == 401 && cookie != null)
+            {
+                var secondRaw = await RawHttpGetAsync(host, port, pathAndQuery, authHeader, cookie, ct);
+                resp = ParseRawHttpResponse(secondRaw, secondRaw.Length);
+            }
+
+            if (resp.StatusCode >= 400)
+            {
+                throw new HttpRequestException(
+                    $"Netgear CM raw fetch of {pathAndQuery} returned HTTP {resp.StatusCode}",
+                    inner: null,
+                    statusCode: Enum.IsDefined(typeof(System.Net.HttpStatusCode), resp.StatusCode)
+                        ? (System.Net.HttpStatusCode)resp.StatusCode
+                        : null);
+            }
+
+            return string.IsNullOrWhiteSpace(resp.Body) ? null : resp.Body;
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Our own timeout fired (not the caller's token); surface it as a transient HTTP error
+            // so the poll loop's retry/fallback handling treats it like any other fetch failure.
+            throw new HttpRequestException($"Netgear CM raw fetch of {pathAndQuery} timed out after {TimeoutSeconds}s");
+        }
+        catch (Exception ex) when (ex is System.Net.Sockets.SocketException or IOException)
+        {
+            throw new HttpRequestException($"Netgear CM raw fetch of {pathAndQuery} failed: {ex.Message}", ex);
+        }
+    }
+
+    /// <summary>
+    /// Open a TCP connection and perform one HTTP/1.0 GET, returning the full raw response bytes
+    /// (headers and body) read until the server closes the connection. No Accept-Encoding is sent,
+    /// so the body comes back uncompressed and plain.
+    /// </summary>
+    private static async Task<byte[]> RawHttpGetAsync(
+        string host, int port, string pathAndQuery, string? authHeader, string? cookie,
+        CancellationToken cancellationToken)
+    {
+        var request = new StringBuilder();
+        request.Append("GET ").Append(pathAndQuery).Append(" HTTP/1.0\r\n");
+        request.Append("Host: ").Append(host).Append("\r\n");
+        if (authHeader != null)
+            request.Append("Authorization: ").Append(authHeader).Append("\r\n");
+        if (cookie != null)
+            request.Append("Cookie: ").Append(cookie).Append("\r\n");
+        request.Append("Accept: */*\r\n");
+        request.Append("Connection: close\r\n");
+        request.Append("\r\n");
+
+        using var tcp = new System.Net.Sockets.TcpClient();
+        await tcp.ConnectAsync(host, port, cancellationToken);
+        await using var stream = tcp.GetStream();
+
+        var reqBytes = Encoding.ASCII.GetBytes(request.ToString());
+        await stream.WriteAsync(reqBytes, cancellationToken);
+        await stream.FlushAsync(cancellationToken);
+
+        using var buffer = new MemoryStream();
+        var chunk = new byte[8192];
+        int read;
+        while ((read = await stream.ReadAsync(chunk, cancellationToken)) > 0)
+        {
+            buffer.Write(chunk, 0, read);
+            if (buffer.Length > MaxRawResponseBytes)
+                break;
+        }
+
+        return buffer.ToArray();
+    }
+
+    /// <summary>
+    /// A status code, leniently parsed headers, and decoded body extracted from a raw HTTP
+    /// response by <see cref="ParseRawHttpResponse"/>.
+    /// </summary>
+    internal sealed record RawHttpResponse(int StatusCode, IReadOnlyDictionary<string, string> Headers, string Body);
+
+    /// <summary>
+    /// Parse a raw HTTP response leniently, tolerating the malformations seen from NET-DK modems:
+    /// header lines whose leading bytes were dropped (a corrupted but colon-bearing name is kept
+    /// as-is; a line that lost its colon entirely is skipped rather than aborting the whole
+    /// response), and bare-LF line endings. The status code is taken from the first 3-digit token
+    /// on the status line, so a clipped "HTTP/1.1" prefix still yields the code. The body is decoded
+    /// as UTF-8; when a valid Content-Length survives it bounds the body, otherwise everything after
+    /// the header separator is returned (the modem closes the connection to signal the end).
+    /// </summary>
+    internal static RawHttpResponse ParseRawHttpResponse(byte[] data, int length)
+    {
+        length = Math.Min(length, data.Length);
+
+        var (headerEnd, bodyStart) = FindHeaderBodySplit(data, length);
+        var headerText = Encoding.Latin1.GetString(data, 0, headerEnd);
+        var lines = headerText.Split('\n');
+
+        int status = 0;
+        if (lines.Length > 0)
+        {
+            foreach (var token in lines[0].Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (token.Length == 3 && int.TryParse(token, out var s) && s is >= 100 and < 600)
+                {
+                    status = s;
+                    break;
+                }
+            }
+        }
+
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (int i = 1; i < lines.Length; i++)
+        {
+            var line = lines[i].TrimEnd('\r');
+            if (line.Length == 0)
+                continue;
+            var colon = line.IndexOf(':');
+            if (colon <= 0)
+                continue; // dropped-colon corruption - skip rather than reject the whole response
+            var name = line[..colon].Trim();
+            var value = line[(colon + 1)..].Trim();
+            if (name.Length == 0)
+                continue;
+            headers[name] = headers.TryGetValue(name, out var existing) ? existing + ", " + value : value;
+        }
+
+        int bodyLength = Math.Max(0, length - bodyStart);
+        if (headers.TryGetValue("Content-Length", out var clRaw)
+            && int.TryParse(clRaw.Trim(), out var contentLength)
+            && contentLength >= 0 && contentLength <= bodyLength)
+        {
+            bodyLength = contentLength;
+        }
+
+        var body = Encoding.UTF8.GetString(data, bodyStart, bodyLength);
+        return new RawHttpResponse(status, headers, body);
+    }
+
+    /// <summary>
+    /// Locate the header/body boundary, preferring the RFC CRLFCRLF separator and falling back to
+    /// the bare-LFLF some embedded servers emit. Returns the end of the header block and the start
+    /// of the body; when no separator is found the whole buffer is treated as headers.
+    /// </summary>
+    private static (int HeaderEnd, int BodyStart) FindHeaderBodySplit(byte[] data, int length)
+    {
+        for (int i = 0; i + 3 < length; i++)
+        {
+            if (data[i] == '\r' && data[i + 1] == '\n' && data[i + 2] == '\r' && data[i + 3] == '\n')
+                return (i, i + 4);
+        }
+        for (int i = 0; i + 1 < length; i++)
+        {
+            if (data[i] == '\n' && data[i + 1] == '\n')
+                return (i, i + 2);
+        }
+        return (length, length);
     }
 
     internal static CableModemStats ParseDocsisStatus(string html, CmPollContext context)

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
@@ -628,7 +628,7 @@ public sealed class NetgearCmProvider : ICableModemProvider
     /// observed to corrupt its HTTP); it does not re-implement the CM600 MultiLogin takeover, which
     /// runs on a different server that returns compliant HTTP and so never reaches here.
     /// </summary>
-    private async Task<string?> FetchViaRawSocketAsync(
+    internal async Task<string?> FetchViaRawSocketAsync(
         string url,
         string? username,
         string? password,
@@ -653,13 +653,19 @@ public sealed class NetgearCmProvider : ICableModemProvider
             var firstRaw = await RawHttpGetAsync(host, port, pathAndQuery, authHeader, cookie: null, ct);
             var first = ParseRawHttpResponse(firstRaw, firstRaw.Length);
 
-            // Pull the cookie straight from the raw bytes so a corrupted Set-Cookie header name
-            // can't hide it. A modem that returns the page on the first request needs no retry.
-            var cookieMatch = XsrfCookieRx.Match(Encoding.Latin1.GetString(firstRaw));
+            // Pull the cookie straight from the response header bytes so a corrupted Set-Cookie
+            // header name can't hide it. Scope the search to the header region (not the body) so a
+            // stray XSRF_TOKEN= occurrence in page content can't be mistaken for the real cookie.
+            var (firstHeaderEnd, _) = FindHeaderBodySplit(firstRaw, firstRaw.Length);
+            var cookieMatch = XsrfCookieRx.Match(Encoding.Latin1.GetString(firstRaw, 0, firstHeaderEnd));
             var cookie = cookieMatch.Success ? "XSRF_TOKEN=" + cookieMatch.Groups[1].Value : null;
 
+            // Replay the primed cookie unless the first request already returned the page. Gating on
+            // "not 200" rather than "exactly 401" means a 401 whose status line was itself corrupted
+            // (so it parsed as an unknown status) still gets the cookie retry instead of being
+            // dropped - the presence of the anti-CSRF cookie is the real signal the modem wants it.
             var resp = first;
-            if (first.StatusCode == 401 && cookie != null)
+            if (cookie != null && first.StatusCode != 200)
             {
                 var secondRaw = await RawHttpGetAsync(host, port, pathAndQuery, authHeader, cookie, ct);
                 resp = ParseRawHttpResponse(secondRaw, secondRaw.Length);

--- a/tests/NetworkOptimizer.Web.Tests/NetgearCmProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/NetgearCmProviderTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using FluentAssertions;
 using NetworkOptimizer.Monitoring.Providers;
 using NetworkOptimizer.Web.Services.CableModemProviders;
@@ -7,6 +8,119 @@ namespace NetworkOptimizer.Web.Tests;
 
 public class NetgearCmProviderTests
 {
+    private static byte[] Raw(string text) => Encoding.ASCII.GetBytes(text.Replace("\n", "\r\n"));
+
+    [Fact]
+    public void ParseRawHttpResponse_ParsesWellFormedResponse()
+    {
+        var raw = Raw(
+            "HTTP/1.1 200 OK\n" +
+            "Content-Type: text/html\n" +
+            "Content-Length: 5\n" +
+            "\n" +
+            "hello");
+
+        var resp = NetgearCmProvider.ParseRawHttpResponse(raw, raw.Length);
+
+        resp.StatusCode.Should().Be(200);
+        resp.Headers["Content-Type"].Should().Be("text/html");
+        resp.Body.Should().Be("hello");
+    }
+
+    // The CM700's NET-DK/1.0 server intermittently drops the leading bytes of a header line. The
+    // HAR for issue #869 shows "Content-Length" arriving as "ntent-Length" (the "Co" dropped).
+    // That line still has a colon, so the lenient reader keeps it (as an unrecognized header) and,
+    // with no usable Content-Length, returns the whole body that arrived before the connection
+    // closed. .NET's strict parser would not choke on this colon-bearing line, but the reader must
+    // still produce the right body without a real Content-Length.
+    [Fact]
+    public void ParseRawHttpResponse_ToleratesDroppedHeaderNameBytes()
+    {
+        var raw = Raw(
+            "HTTP/1.1 200 OK\n" +
+            "Content-Type: text/html\n" +
+            "ntent-Length: 50471\n" +
+            "Connection: close\n" +
+            "\n" +
+            "<html>dsTable</html>");
+
+        var resp = NetgearCmProvider.ParseRawHttpResponse(raw, raw.Length);
+
+        resp.StatusCode.Should().Be(200);
+        resp.Headers.Should().NotContainKey("Content-Length");
+        // No usable Content-Length, so the body is everything after the header separator.
+        resp.Body.Should().Be("<html>dsTable</html>");
+    }
+
+    // The reporter's log showed `Received an invalid header line: 'ceived response error'.` - the
+    // same byte-drop landing on a line that lost its colon entirely ("Received response error"
+    // minus "Re"). .NET aborts the whole response on such a line; the lenient reader skips it and
+    // still returns the status and body.
+    [Fact]
+    public void ParseRawHttpResponse_SkipsColonlessCorruptedLine()
+    {
+        var raw = Raw(
+            "HTTP/1.1 200 OK\n" +
+            "Content-Type: text/html\n" +
+            "ceived response error\n" +
+            "Connection: close\n" +
+            "\n" +
+            "<html>dsTable</html>");
+
+        var resp = NetgearCmProvider.ParseRawHttpResponse(raw, raw.Length);
+
+        resp.StatusCode.Should().Be(200);
+        resp.Headers["Content-Type"].Should().Be("text/html");
+        resp.Body.Should().Be("<html>dsTable</html>");
+    }
+
+    [Fact]
+    public void ParseRawHttpResponse_RecoversStatusFromClippedStatusLine()
+    {
+        // Leading bytes dropped from the status line too: "HTTP/1.1 401 Unauthorized" -> the code
+        // is still recovered from the first 3-digit token.
+        var raw = Raw(
+            "TP/1.1 401 Unauthorized\n" +
+            "WWW-Authenticate: Basic realm=\"NETGEAR CM700\"\n" +
+            "Set-Cookie: XSRF_TOKEN=2104060059; Path=/\n" +
+            "\n");
+
+        var resp = NetgearCmProvider.ParseRawHttpResponse(raw, raw.Length);
+
+        resp.StatusCode.Should().Be(401);
+        resp.Headers["Set-Cookie"].Should().Contain("XSRF_TOKEN=2104060059");
+    }
+
+    [Fact]
+    public void ParseRawHttpResponse_HandlesBareLfLineEndings()
+    {
+        var raw = Encoding.ASCII.GetBytes(
+            "HTTP/1.1 200 OK\n" +
+            "Content-Type: text/html\n" +
+            "\n" +
+            "body-bytes");
+
+        var resp = NetgearCmProvider.ParseRawHttpResponse(raw, raw.Length);
+
+        resp.StatusCode.Should().Be(200);
+        resp.Headers["Content-Type"].Should().Be("text/html");
+        resp.Body.Should().Be("body-bytes");
+    }
+
+    [Fact]
+    public void ParseRawHttpResponse_BoundsBodyByContentLengthWhenValid()
+    {
+        var raw = Raw(
+            "HTTP/1.1 200 OK\n" +
+            "Content-Length: 5\n" +
+            "\n" +
+            "helloEXTRA");
+
+        var resp = NetgearCmProvider.ParseRawHttpResponse(raw, raw.Length);
+
+        resp.Body.Should().Be("hello");
+    }
+
     private static CmPollContext Context => new()
     {
         Id = 1,

--- a/tests/NetworkOptimizer.Web.Tests/NetgearCmProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/NetgearCmProviderTests.cs
@@ -1,5 +1,8 @@
+using System.Net;
+using System.Net.Sockets;
 using System.Text;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using NetworkOptimizer.Monitoring.Providers;
 using NetworkOptimizer.Web.Services.CableModemProviders;
 using Xunit;
@@ -394,5 +397,195 @@ public class NetgearCmProviderTests
         // FEC totals come from the SC-QAM channels only (OFDM counts excluded).
         stats.TotalCorrectables.Should().Be(336 + 445);
         stats.TotalUncorrectables.Should().Be(22 + 1004);
+    }
+
+    // ----- Raw-socket fallback (FetchViaRawSocketAsync) -----
+    // These drive the lenient raw fetch end to end against a loopback "fake NET-DK modem" so the
+    // two-step Basic + anti-CSRF cookie handshake, the broadened retry gate, and the header-scoped
+    // cookie extraction are all exercised on real sockets.
+
+    // A status page minimal enough to round-trip: it contains the dsTable token (so it reads as a
+    // real status page) and a parseable tagValueList.
+    private const string RawStatusPage =
+        "<html><body><table id=\"dsTable\"></table><script>function InitDsTableTagValue(){ " +
+        "var tagValueList = '1|1|Locked|QAM 256|1|387000000 Hz|5.8|40.9|7|0|'; }</script></body></html>";
+
+    private static byte[] RawResponse(string statusLine, IEnumerable<string> headerLines, string body)
+    {
+        var sb = new StringBuilder();
+        sb.Append(statusLine).Append("\r\n");
+        foreach (var h in headerLines)
+            sb.Append(h).Append("\r\n");
+        sb.Append("\r\n").Append(body);
+        return Encoding.ASCII.GetBytes(sb.ToString());
+    }
+
+    [Fact]
+    public async Task FetchViaRawSocketAsync_PrimesCookieThenReturnsPage()
+    {
+        using var server = new FakeNetDkServer(
+            RawResponse("HTTP/1.0 401 Unauthorized",
+                new[] { "WWW-Authenticate: Basic realm=\"NETGEAR CM700\"", "Set-Cookie: XSRF_TOKEN=primed123; Path=/", "Connection: close" },
+                "<html>401</html>"),
+            RawResponse("HTTP/1.0 200 OK",
+                new[] { "Content-Type: text/html", "Connection: close" },
+                RawStatusPage));
+
+        var provider = new NetgearCmProvider(NullLogger<NetgearCmProvider>.Instance);
+        var body = await provider.FetchViaRawSocketAsync(
+            $"http://127.0.0.1:{server.Port}/DocsisStatus.htm", "admin", "password", CancellationToken.None);
+
+        body.Should().Be(RawStatusPage);
+        server.ReceivedRequests.Should().HaveCount(2);
+        // First request carries the preemptive Basic header but no cookie yet.
+        server.ReceivedRequests[0].Should().Contain("Authorization: Basic");
+        server.ReceivedRequests[0].Should().NotContain("Cookie:");
+        // Second request replays the primed cookie alongside Basic.
+        server.ReceivedRequests[1].Should().Contain("Cookie: XSRF_TOKEN=primed123");
+        server.ReceivedRequests[1].Should().Contain("Authorization: Basic");
+    }
+
+    [Fact]
+    public async Task FetchViaRawSocketAsync_ReadsBodyDespiteCorruptedContentLengthHeader()
+    {
+        // The 200 carries a corrupted "Content-Length" (the "Co" dropped, as in the HAR). With no
+        // usable length the reader falls back to reading until the connection closes.
+        using var server = new FakeNetDkServer(
+            RawResponse("HTTP/1.0 401 Unauthorized",
+                new[] { "Set-Cookie: XSRF_TOKEN=abc; Path=/", "Connection: close" }, "401"),
+            RawResponse("HTTP/1.0 200 OK",
+                new[] { "Content-Type: text/html", "ntent-Length: 99999", "Connection: close" }, RawStatusPage));
+
+        var provider = new NetgearCmProvider(NullLogger<NetgearCmProvider>.Instance);
+        var body = await provider.FetchViaRawSocketAsync(
+            $"http://127.0.0.1:{server.Port}/DocsisStatus.htm", "admin", "password", CancellationToken.None);
+
+        body.Should().Be(RawStatusPage);
+    }
+
+    [Fact]
+    public async Task FetchViaRawSocketAsync_RetriesWhenStatusLineCorruptedButCookiePresent()
+    {
+        // Hardening #1: the 401's status line was itself mangled past a recoverable code, so it
+        // parses as an unknown status. The retry must still fire because the anti-CSRF cookie is
+        // present - the broadened gate keys off the cookie, not an exact 401.
+        using var server = new FakeNetDkServer(
+            RawResponse("orized",
+                new[] { "Set-Cookie: XSRF_TOKEN=primed456; Path=/", "Connection: close" },
+                "<html>err</html>"),
+            RawResponse("HTTP/1.0 200 OK",
+                new[] { "Connection: close" },
+                RawStatusPage));
+
+        var provider = new NetgearCmProvider(NullLogger<NetgearCmProvider>.Instance);
+        var body = await provider.FetchViaRawSocketAsync(
+            $"http://127.0.0.1:{server.Port}/DocsisStatus.htm", "admin", "password", CancellationToken.None);
+
+        body.Should().Be(RawStatusPage);
+        server.ReceivedRequests.Should().HaveCount(2);
+        server.ReceivedRequests[1].Should().Contain("Cookie: XSRF_TOKEN=primed456");
+    }
+
+    [Fact]
+    public async Task FetchViaRawSocketAsync_IgnoresXsrfTokenInBodyAndDoesNotRetry()
+    {
+        // Hardening #2: no Set-Cookie header, but a stray XSRF_TOKEN= sits in the page body. The
+        // header-scoped search must not pick it up, so there is no cookie, no retry fires, and the
+        // 401 surfaces. A single received request proves the body token was ignored.
+        using var server = new FakeNetDkServer(
+            RawResponse("HTTP/1.0 401 Unauthorized",
+                new[] { "WWW-Authenticate: Basic realm=\"NETGEAR CM700\"", "Connection: close" },
+                "<html>var x='XSRF_TOKEN=frombody';</html>"));
+
+        var provider = new NetgearCmProvider(NullLogger<NetgearCmProvider>.Instance);
+        Func<Task> act = () => provider.FetchViaRawSocketAsync(
+            $"http://127.0.0.1:{server.Port}/DocsisStatus.htm", "admin", "wrongpw", CancellationToken.None);
+
+        (await act.Should().ThrowAsync<HttpRequestException>())
+            .Which.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        server.ReceivedRequests.Should().HaveCount(1);
+    }
+
+    /// <summary>
+    /// Minimal loopback HTTP server that serves a fixed list of raw (byte-exact) responses in
+    /// order, one per accepted connection, and records each request it received. Lets the
+    /// raw-socket fallback be tested end to end - including deliberately malformed responses - on
+    /// real sockets. Connections are handled sequentially, matching the provider's one-request-
+    /// per-connection (Connection: close) behavior.
+    /// </summary>
+    private sealed class FakeNetDkServer : IDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly List<byte[]> _responses;
+        private readonly object _gate = new();
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Task _loop;
+        private int _served;
+
+        public List<string> ReceivedRequests { get; } = new();
+        public int Port => ((IPEndPoint)_listener.LocalEndpoint).Port;
+
+        public FakeNetDkServer(params byte[][] responses)
+        {
+            _responses = responses.ToList();
+            _listener = new TcpListener(IPAddress.Loopback, 0);
+            _listener.Start();
+            _loop = Task.Run(AcceptLoopAsync);
+        }
+
+        private async Task AcceptLoopAsync()
+        {
+            try
+            {
+                while (!_cts.IsCancellationRequested)
+                {
+                    var client = await _listener.AcceptTcpClientAsync(_cts.Token);
+                    await HandleAsync(client);
+                }
+            }
+            catch (OperationCanceledException) { }
+            catch (ObjectDisposedException) { }
+            catch (SocketException) { }
+        }
+
+        private async Task HandleAsync(TcpClient client)
+        {
+            using (client)
+            {
+                using var stream = client.GetStream();
+
+                // Read the request headers (the provider sends a GET with no body) up to the blank line.
+                var requestText = new StringBuilder();
+                var buf = new byte[1024];
+                while (!requestText.ToString().Contains("\r\n\r\n"))
+                {
+                    var n = await stream.ReadAsync(buf, _cts.Token);
+                    if (n == 0)
+                        break;
+                    requestText.Append(Encoding.ASCII.GetString(buf, 0, n));
+                }
+
+                byte[] response;
+                lock (_gate)
+                {
+                    ReceivedRequests.Add(requestText.ToString());
+                    response = _responses[Math.Min(_served, _responses.Count - 1)];
+                    _served++;
+                }
+
+                await stream.WriteAsync(response, _cts.Token);
+                await stream.FlushAsync(_cts.Token);
+                // Disposing the connection closes the socket, so the client reads to EOF.
+            }
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            _listener.Stop();
+            try { _loop.Wait(TimeSpan.FromSeconds(2)); }
+            catch { /* shutdown best-effort */ }
+            _cts.Dispose();
+        }
     }
 }


### PR DESCRIPTION
## What

Adds a tolerant raw-socket fallback to the Netgear cable modem provider so it can read modems whose embedded HTTP server returns slightly non-compliant responses that .NET's HTTP stack refuses to parse.

## Why

The CM700 (and other modems running the `NET-DK/1.0` server) intermittently emit corrupted response headers: a dropped byte turns `Content-Length` into a non-standard line, or a header line loses its colon. Browsers parse these leniently and the modem's status page loads fine, but .NET's `HttpClient` rejects the whole response with `Received an invalid header line`, so polling failed even though authentication had succeeded. There is no in-framework switch to relax that parsing (the old .NET Framework `useUnsafeHeaderParsing` has no `SocketsHttpHandler` equivalent), so the only reliable option is to read the response ourselves.

This is the remaining blocker in #869 after the earlier anti-CSRF cookie fix got past the modem's auth.

## How

- `FetchPageAsync` now wraps the existing HttpClient path. Only when that path throws specifically because the response could not be parsed into an HTTP status does it retry over a raw `TcpClient`, reading the response and parsing the headers leniently (a corrupted but still colon-bearing header is kept, a colon-less line is skipped instead of aborting the whole response, bare-LF line endings are accepted, and the status code is recovered from the first numeric token).
- The raw path replays the same two-step Basic + anti-CSRF cookie handshake the modem expects, pulling the cookie straight from the response bytes so a corrupted `Set-Cookie` name can't hide it.
- Modems that return compliant HTTP never throw the malformed-response error, so they never enter the raw path and are entirely unaffected.

## Testing

- Added unit tests for the lenient parser covering the exact corruption seen in this case (dropped header-name bytes, a colon-less line, a clipped status line, bare-LF endings, and Content-Length bounding).
- Full Web test suite passes (381/381).
- Regression-checked on real CM600 hardware: it stays entirely on the unchanged HttpClient path and continues polling cleanly (24 downstream, 8 upstream channels).

Closes #869
