### PR TITLE
Performance Tweaks: support UniFi OS 5.1.21 on UCG-Fiber

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
@@ -116,7 +116,7 @@
                     @if (_gatewayConnected && _status?.FirmwareSupported == false && !string.IsNullOrEmpty(_status?.FirmwareVersion))
                     {
                         <div class="alert alert-danger" style="margin-top: 1rem;">
-                            <strong>Unsupported Firmware:</strong> Performance tweaks are currently tested and supported up to UniFi OS 5.1.19. Your gateway is running @_status.FirmwareVersion. Deploying new tweaks is disabled until we validate compatibility with this version. Existing tweaks will continue to run.
+                            <strong>Unsupported Firmware:</strong> Performance tweaks are currently tested and supported up to UniFi OS 5.1.21. Your gateway is running @_status.FirmwareVersion. Deploying new tweaks is disabled until we validate compatibility with this version. Existing tweaks will continue to run.
                         </div>
                     }
 

--- a/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
@@ -18,7 +18,7 @@ public class PerfTweaksDeploymentService
     private const string OnBootDir = "/data/on_boot.d";
     private const string PerfTweaksDir = "/data/perf-tweaks";
     private const string SfpModuleDir = "/data/sfp-sgmiiplus";
-    private static readonly Version MaxSupportedFirmware = new(5, 1, 19);
+    private static readonly Version MaxSupportedFirmware = new(5, 1, 21);
 
     private static readonly Dictionary<string, string> BootScriptFiles = new()
     {


### PR DESCRIPTION
Bumps the Performance Tweaks firmware gate from 5.1.19 to 5.1.21 after verifying the tweaks deploy and run correctly on 5.1.21 EA on UCG-Fiber.

Gateways on 5.1.20/5.1.21 EA can now deploy new tweaks instead of hitting the "Unsupported Firmware" block.

## Changes
- `PerfTweaksDeploymentService.cs` - `MaxSupportedFirmware` 5.1.19 → 5.1.21
- `PerformanceTweaks.razor` - "supported up to UniFi OS 5.1.19" → 5.1.21

## Verification
https://github.com/Ozark-Connect/unifi-perf-tweaks/blob/main/docs/compat-5.1.21.md
