### PR TITLE
WAN globes: throughput fix, clearer labels, hide unused, friendlier discovery messaging

### DIFF
--- a/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
@@ -348,6 +348,7 @@ public class GatewayWanInterface
     public string? Type { get; set; }
 
     [JsonPropertyName("up")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
     public bool Up { get; set; }
 
     [JsonPropertyName("ip")]

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1984,15 +1984,26 @@ else
 
     private async Task OnTargetsChanged()
     {
-        // A target change can flip which upstream hops count toward the map's
-        // discovery-complete (greyed) state, so drop the cached flow-map snapshot.
-        // Returning to Live View rebuilds it with the new state; the banner and stat
-        // cards re-query the DB live. Target edits are infrequent, so the occasional
-        // extra rebuild is cheap.
-        LanFlowMapCache.Invalidate();
+        // Only a change to the enabled ISP/Transit set affects the map's discovery-complete
+        // (greyed) state and ASN label, so invalidate the cached flow-map snapshot only when
+        // that set actually changed - not for interval edits or other target types. Rebuilds
+        // cost a UniFi API call plus Influx queries, so this avoids needless hits. The banner
+        // and stat cards re-query the DB live regardless.
+        var before = UpstreamTargetSignature();
         await LoadTargetsAsync();
+        if (UpstreamTargetSignature() != before)
+            LanFlowMapCache.Invalidate();
         StateHasChanged();
     }
+
+    // Enabled ISP/Transit target IDs - the set that drives the flow-map globe's greyed
+    // state and ASN label. Used to detect when a target change should invalidate the map.
+    private string UpstreamTargetSignature() =>
+        string.Join("|", _targets
+            .Where(t => t.Enabled
+                && t.TargetType is MonitoringTargetType.AccessIsp or MonitoringTargetType.Transit)
+            .OrderBy(t => t.Id)
+            .Select(t => t.Id));
 
     private async Task OnSfpChanged()
     {

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -185,7 +185,10 @@ else
         var hasIspTargets = HasUpstreamTargets(MonitoringTargetType.AccessIsp);
         var hasTransitTargets = HasUpstreamTargets(MonitoringTargetType.Transit);
 
-        if (!hasIspTargets || !hasTransitTargets)
+        // Discovery counts as complete if EITHER access ISP or transit hops were
+        // found - some access networks expose no pingable ICMP target, so the path
+        // is proven via transit alone. Only nag when there is no upstream evidence.
+        if (!hasIspTargets && !hasTransitTargets)
         {
             <div class="alert alert-info" style="margin-bottom: 1rem;">
                 <div class="banner-content">

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -32,6 +32,7 @@
 @inject MonitoringCollectionAgent CollectionAgent
 @inject IspHealthService IspHealthService
 @inject NetworkOptimizer.Web.Services.Monitoring.FlakyTargetService FlakyTargets
+@inject NetworkOptimizer.Web.Services.LanFlowMap.LanFlowMapCache LanFlowMapCache
 @inject ILogger<Monitoring> Logger
 
 <NavigationLock OnBeforeInternalNavigation="OnBeforeInternalNavigation"
@@ -1983,6 +1984,12 @@ else
 
     private async Task OnTargetsChanged()
     {
+        // A target change can flip which upstream hops count toward the map's
+        // discovery-complete (greyed) state, so drop the cached flow-map snapshot.
+        // Returning to Live View rebuilds it with the new state; the banner and stat
+        // cards re-query the DB live. Target edits are infrequent, so the occasional
+        // extra rebuild is cheap.
+        LanFlowMapCache.Invalidate();
         await LoadTargetsAsync();
         StateHasChanged();
     }

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -1398,10 +1398,26 @@ public class LanFlowMapService
                 : null;
             if (string.IsNullOrEmpty(gwId)) continue;
 
+            // Render WAN globes by activity, read from the gateway's wanN device JSON
+            // (up + ip; networkconf can't distinguish an unused WAN). Active (up, has
+            // IP) renders normally; a half-state (up without an IP, or down still
+            // holding an IP) renders greyed like a discovery-pending cloud; an
+            // effectively-unused WAN (down, no IP) is not shown at all.
+            var hasIp = !string.IsNullOrEmpty(wan.IpAddress);
+            if (!wan.Up && !hasIp) continue;
+            var inactiveGrey = wan.Up != hasIp;
+
             UpstreamPathSnapshot? upstream = null;
             try { upstream = await _pathView.GetUpstreamPathAsync(wan.WanInterface, ct); }
             catch (Exception ex) { _logger.LogDebug(ex, "Upstream path fetch failed for {Wan}", wan.WanInterface); }
             if (upstream == null) continue;
+
+            // Discovery counts as complete if EITHER access ISP hops or transit hops
+            // were resolved - some access networks expose no pingable ICMP target, so
+            // the path is proven via transit alone. (Only the primary WAN is traced.)
+            var discoveryPending = wan.IsPrimary
+                && upstream.Access.Hops.Count == 0
+                && upstream.Transits.Count == 0;
 
             var accessCloud = new LanCloud
             {
@@ -1419,8 +1435,10 @@ public class LanFlowMapService
                 // runs upstream tracing, so secondary WANs always have 0 hops.
                 // Suppress the "discovery pending" state for them until multi-WAN
                 // tracing is implemented.
-                IsDiscoveryPending = wan.IsPrimary && upstream.Access.Hops.Count == 0,
-                Tier = wan.IsPrimary && upstream.Access.Hops.Count == 0 ? LanCloudTier.Unresolved : LanCloudTier.Solid,
+                IsDiscoveryPending = discoveryPending,
+                Tier = inactiveGrey || discoveryPending
+                    ? LanCloudTier.Unresolved
+                    : LanCloudTier.Solid,
             };
             // Collect all access hop target IDs so the live tick can pick the
             // lowest RTT across all of them (closest ISP infrastructure).

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -1407,7 +1407,7 @@ public class LanFlowMapService
             {
                 Id = $"cloud-access-{wan.WanInterface}",
                 Kind = LanCloudKind.AccessIsp,
-                Name = upstream.Access.AsnName ?? wan.FriendlyName ?? "Access ISP",
+                Name = FormatWanGlobeName(upstream.Access.AsnName, wan.FriendlyName, wan.WanInterface, wans.Count > 1),
                 Asn = upstream.Access.AsnNumber,
                 AsnName = upstream.Access.AsnName,
                 Order = 0,
@@ -1529,20 +1529,36 @@ public class LanFlowMapService
             //     });
             // }
         }
-
-        // Disambiguate access clouds that resolve to the same ISP (same ASN) across
-        // multiple WANs by suffixing each with its WAN number, e.g. "Acme Fiber
-        // (WAN1)" / "Acme Fiber (WAN2)". No-op today since only the primary WAN is
-        // traced (at most one cloud carries an AsnName); applies automatically once
-        // secondary WANs get upstream tracing. Singletons keep the bare ISP name.
-        var sharedAsnGroups = snapshot.Clouds
-            .Where(c => c.Kind == LanCloudKind.AccessIsp && !string.IsNullOrEmpty(c.AsnName))
-            .GroupBy(c => c.AsnName, StringComparer.OrdinalIgnoreCase)
-            .Where(g => g.Count() > 1);
-        foreach (var group in sharedAsnGroups)
-            foreach (var cloud in group)
-                cloud.Name = $"{cloud.AsnName} ({DisplayFormatters.NormalizeWanDisplay(GatewayWanHelper.WanNetworkGroupFromKey(cloud.WanInterface!))})";
     }
+
+    /// <summary>
+    /// Builds the access-cloud display name shown on the flow-map globe. The discovered
+    /// ISP (ASN) or a genuinely custom WAN/port name leads, with the WAN number trailing
+    /// as a qualifier ("Acme Fiber (WAN2)"); on a single-WAN gateway the number is
+    /// dropped as redundant. When there is no real name, a default port label is kept but
+    /// led by the WAN number ("WAN2 (SFP+ 2)"), while a generic name ("Internet 2") is
+    /// dropped to a bare WAN number. The WAN number suffix also disambiguates two WANs
+    /// that resolve to the same ISP. Reuses the shared WAN-display/placeholder helpers.
+    /// </summary>
+    private static string FormatWanGlobeName(string? asnName, string? friendlyName, string wanKey, bool multiWan)
+    {
+        var wanNum = DisplayFormatters.NormalizeWanDisplay(GatewayWanHelper.WanNetworkGroupFromKey(wanKey));
+        var name = !string.IsNullOrWhiteSpace(asnName)
+            ? asnName.Trim()
+            : (!string.IsNullOrWhiteSpace(friendlyName) && !IsPlaceholderWanName(friendlyName))
+                ? friendlyName!.Trim()
+                : null;
+        if (name != null)
+            return multiWan ? $"{name} ({wanNum})" : name;
+        if (!string.IsNullOrWhiteSpace(friendlyName) && InterfaceLabelResolver.IsDefaultPortName(friendlyName))
+            return $"{wanNum} ({friendlyName!.Trim()})";
+        return wanNum;
+    }
+
+    /// <summary>True for names that aren't a real user identity: default port placeholders
+    /// ("SFP+ 2") and generic WAN names ("WAN2", "Internet 2").</summary>
+    private static bool IsPlaceholderWanName(string name)
+        => InterfaceLabelResolver.IsDefaultPortName(name) || DisplayFormatters.IsGenericWanName(name);
 
     private static void InterpolateInteriorPlacements(LanFlowMapSnapshot snapshot, NetworkTopology topology)
     {

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -4,8 +4,8 @@ using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Core.Helpers;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
-using NetworkOptimizer.UniFi.Models;
 using NetworkOptimizer.UniFi;
+using NetworkOptimizer.UniFi.Models;
 using NetworkOptimizer.Web.Services.Monitoring;
 using NetworkOptimizer.WiFi.Models;
 
@@ -1391,6 +1391,11 @@ public class LanFlowMapService
         var primary = wans.FirstOrDefault(w => w.IsPrimary) ?? wans[0];
         snapshot.PrimaryWanInterface = primary.WanInterface;
 
+        // Only WANs that pass the activity gate (up, or still holding an IP) render a
+        // globe; base the "tag with WAN number" decision on that visible count so a lone
+        // globe isn't labelled "(WAN1)" even when other WANs are configured but hidden.
+        var shownWanCount = wans.Count(w => w.Up || !string.IsNullOrEmpty(w.IpAddress));
+
         foreach (var wan in wans)
         {
             var gwId = !string.IsNullOrEmpty(wan.GatewayMac)
@@ -1423,7 +1428,7 @@ public class LanFlowMapService
             {
                 Id = $"cloud-access-{wan.WanInterface}",
                 Kind = LanCloudKind.AccessIsp,
-                Name = FormatWanGlobeName(upstream.Access.AsnName, wan.FriendlyName, wan.WanInterface, wans.Count > 1),
+                Name = FormatWanGlobeName(upstream.Access.AsnName, wan.FriendlyName, wan.WanInterface, shownWanCount > 1),
                 Asn = upstream.Access.AsnNumber,
                 AsnName = upstream.Access.AsnName,
                 Order = 0,

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -1529,6 +1529,19 @@ public class LanFlowMapService
             //     });
             // }
         }
+
+        // Disambiguate access clouds that resolve to the same ISP (same ASN) across
+        // multiple WANs by suffixing each with its WAN number, e.g. "Acme Fiber
+        // (WAN1)" / "Acme Fiber (WAN2)". No-op today since only the primary WAN is
+        // traced (at most one cloud carries an AsnName); applies automatically once
+        // secondary WANs get upstream tracing. Singletons keep the bare ISP name.
+        var sharedAsnGroups = snapshot.Clouds
+            .Where(c => c.Kind == LanCloudKind.AccessIsp && !string.IsNullOrEmpty(c.AsnName))
+            .GroupBy(c => c.AsnName, StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Count() > 1);
+        foreach (var group in sharedAsnGroups)
+            foreach (var cloud in group)
+                cloud.Name = $"{cloud.AsnName} ({DisplayFormatters.NormalizeWanDisplay(GatewayWanHelper.WanNetworkGroupFromKey(cloud.WanInterface!))})";
     }
 
     private static void InterpolateInteriorPlacements(LanFlowMapSnapshot snapshot, NetworkTopology topology)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -255,12 +255,7 @@ public class MonitoringPathView
                         portInfo.TryGetValue(wan.PortIdx.Value, out var pi))
                     {
                         interfaceKey = pi.networkName;
-                        // Prefix the port label with the WAN number ("SFP+ 2" -> "WAN2
-                        // (SFP+ 2)") so the flow-map globe carries the WAN identity, not a
-                        // bare port name. Reuses the WAN-group/display convention.
-                        friendlyName = string.IsNullOrEmpty(pi.name)
-                            ? pi.name
-                            : $"{DisplayFormatters.NormalizeWanDisplay(GatewayWanHelper.WanNetworkGroupFromKey(wan.Key))} ({pi.name})";
+                        friendlyName = pi.name;
                         if (linkSpeed == 0 && pi.speed > 0) linkSpeed = pi.speed;
                     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -76,6 +76,7 @@ public class MonitoringPathView
         // WanInterface only when the requested WAN is the primary (single-WAN heritage).
         var accessHops = await db.MonitoringTargets.AsNoTracking()
             .Where(t => t.TargetType == MonitoringTargetType.AccessIsp
+                        && t.Enabled
                         && (t.WanInterface == resolvedWanInterface
                             || (isPrimary && t.WanInterface == null)))
             .OrderBy(t => t.Id)
@@ -118,6 +119,7 @@ public class MonitoringPathView
         {
             var transitRows = await db.MonitoringTargets.AsNoTracking()
                 .Where(t => t.TargetType == MonitoringTargetType.Transit
+                            && t.Enabled
                             && (t.WanInterface == resolvedWanInterface || t.WanInterface == null))
                 .OrderBy(t => t.AsnNumber)
                 .ToListAsync(ct);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -335,18 +335,6 @@ public class MonitoringPathView
         if (string.IsNullOrEmpty(gwMac)) return;
         foreach (var wan in wans)
         {
-            // A down WAN carries no traffic. Its physical port has no live per-port
-            // rate, so without this guard it falls through to the device-level
-            // aggregate fallback below and inherits the gateway's total WAN
-            // throughput - i.e. the active WAN's rate bleeds onto the idle WAN's
-            // globe. Only down interfaces are affected; an up WAN always has its
-            // own per-port rate and never hits the fallback.
-            if (!wan.Up)
-            {
-                wan.LiveRateInBps = 0;
-                wan.LiveRateOutBps = 0;
-                continue;
-            }
             // ppp* tunnel for PPPoE, physical port otherwise (issue #669): the
             // physical port stays active under PPPoE and over-counts (overhead +
             // sibling VLANs), while VLAN sub-interfaces double-count on some
@@ -366,6 +354,18 @@ public class MonitoringPathView
                 //           RX = from internet = downloads (LiveRateOutBps).
                 wan.LiveRateInBps = portRate.DownBps;
                 wan.LiveRateOutBps = portRate.UpBps;
+                continue;
+            }
+            // No per-port rate for this WAN. A down WAN carries no traffic, so report
+            // zero rather than the device-level aggregate fallback below - otherwise a
+            // down WAN inherits the gateway's total WAN throughput and the active WAN's
+            // rate bleeds onto the idle WAN's globe. Gating on the port-rate miss (not
+            // the up flag alone) keeps a real measured rate for any WAN actually passing
+            // traffic, including PPPoE ppp* whose up flag the API may misreport.
+            if (!wan.Up)
+            {
+                wan.LiveRateInBps = 0;
+                wan.LiveRateOutBps = 0;
                 continue;
             }
             var deviceLive = _liveStats.GetForDevice(gwMac);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -255,7 +255,12 @@ public class MonitoringPathView
                         portInfo.TryGetValue(wan.PortIdx.Value, out var pi))
                     {
                         interfaceKey = pi.networkName;
-                        friendlyName = pi.name;
+                        // Prefix the port label with the WAN number ("SFP+ 2" -> "WAN2
+                        // (SFP+ 2)") so the flow-map globe carries the WAN identity, not a
+                        // bare port name. Reuses the WAN-group/display convention.
+                        friendlyName = string.IsNullOrEmpty(pi.name)
+                            ? pi.name
+                            : $"{DisplayFormatters.NormalizeWanDisplay(GatewayWanHelper.WanNetworkGroupFromKey(wan.Key))} ({pi.name})";
                         if (linkSpeed == 0 && pi.speed > 0) linkSpeed = pi.speed;
                     }
 
@@ -284,6 +289,7 @@ public class MonitoringPathView
                         WanInterface = interfaceKey,
                         FriendlyName = string.IsNullOrEmpty(friendlyName) ? null : friendlyName,
                         IsPrimary = false,
+                        Up = wan.Up,
                         GatewayMac = gwMac,
                         GatewayPortName = friendlyName,
                         UplinkIfName = uplinkIfname,
@@ -329,6 +335,18 @@ public class MonitoringPathView
         if (string.IsNullOrEmpty(gwMac)) return;
         foreach (var wan in wans)
         {
+            // A down WAN carries no traffic. Its physical port has no live per-port
+            // rate, so without this guard it falls through to the device-level
+            // aggregate fallback below and inherits the gateway's total WAN
+            // throughput - i.e. the active WAN's rate bleeds onto the idle WAN's
+            // globe. Only down interfaces are affected; an up WAN always has its
+            // own per-port rate and never hits the fallback.
+            if (!wan.Up)
+            {
+                wan.LiveRateInBps = 0;
+                wan.LiveRateOutBps = 0;
+                continue;
+            }
             // ppp* tunnel for PPPoE, physical port otherwise (issue #669): the
             // physical port stays active under PPPoE and over-counts (overhead +
             // sibling VLANs), while VLAN sub-interfaces double-count on some
@@ -446,6 +464,7 @@ public record WanSummary
     public required string WanInterface { get; init; }
     public string? FriendlyName { get; init; }
     public required bool IsPrimary { get; set; }
+    public bool Up { get; init; }
     public string? GatewayMac { get; init; }
     public string? GatewayPortName { get; init; }
     public string? UplinkIfName { get; init; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1642,7 +1642,7 @@ class LanFlowMap2D {
             ctx.globalAlpha=1;
 
             // Name
-            const name=demoMask(cloud.d.asnName||cloud.d.name||'WAN');
+            const name=demoMask(cloud.d.name||cloud.d.asnName||'WAN');
             ctx.fillStyle=C.textSec;
             ctx.font=`500 ${G.nameFont}px ${FONT}`;
             ctx.textAlign='center'; ctx.textBaseline='top';

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1612,16 +1612,19 @@ class LanFlowMap2D {
     _drawAllClouds(ctx){
         for(const cloud of this._clouds){
             const cx=cloud.x, cy=cloud.y, r=G.cloudR;
+            // Unresolved tier (LanCloudTier.Unresolved=2): inactive WAN or discovery
+            // pending - render the globe greyed, matching the 3D map.
+            const greyed=cloud.d.tier===2;
 
             // Subtle radial fill
             const grad=ctx.createRadialGradient(cx-r*0.3,cy-r*0.3,0,cx,cy,r);
-            grad.addColorStop(0,'rgba(59,130,246,0.08)');
-            grad.addColorStop(1,'rgba(59,130,246,0.02)');
+            grad.addColorStop(0,greyed?'rgba(120,130,145,0.06)':'rgba(59,130,246,0.08)');
+            grad.addColorStop(1,greyed?'rgba(120,130,145,0.02)':'rgba(59,130,246,0.02)');
             ctx.fillStyle=grad;
             ctx.beginPath(); ctx.arc(cx,cy,r,0,Math.PI*2); ctx.fill();
 
             // Outer circle
-            ctx.strokeStyle=C.globeStroke;
+            ctx.strokeStyle=greyed?'#3a4455':C.globeStroke;
             ctx.lineWidth=1.5; ctx.globalAlpha=0.8;
             ctx.beginPath(); ctx.arc(cx,cy,r,0,Math.PI*2); ctx.stroke();
 
@@ -1643,7 +1646,7 @@ class LanFlowMap2D {
 
             // Name
             const name=demoMask(cloud.d.name||cloud.d.asnName||'WAN');
-            ctx.fillStyle=C.textSec;
+            ctx.fillStyle=greyed?C.textMuted:C.textSec;
             ctx.font=`500 ${G.nameFont}px ${FONT}`;
             ctx.textAlign='center'; ctx.textBaseline='top';
             ctx.fillText(name,cx,cy+r+8);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -38,6 +38,7 @@ const C = {
 
 const NK = { Gateway:0, Switch:1, AP:2, WiredClient:3, WifiClient:4, Cloud:5, VirtualHub:6 };
 const LK = { Uplink:0, WiredClient:1, WifiClient:2, Wan:3, Transit:4, MeshBackhaul:5 };
+const CT = { Solid:0, PathProxy:1, Unresolved:2 }; // LanCloudTier
 
 // ---- Layout geometry ----
 const G = {
@@ -1612,9 +1613,9 @@ class LanFlowMap2D {
     _drawAllClouds(ctx){
         for(const cloud of this._clouds){
             const cx=cloud.x, cy=cloud.y, r=G.cloudR;
-            // Unresolved tier (LanCloudTier.Unresolved=2): inactive WAN or discovery
-            // pending - render the globe greyed, matching the 3D map.
-            const greyed=cloud.d.tier===2;
+            // Unresolved tier: inactive WAN or discovery pending - render the globe
+            // greyed, matching the 3D map.
+            const greyed=cloud.d.tier===CT.Unresolved;
 
             // Subtle radial fill
             const grad=ctx.createRadialGradient(cx-r*0.3,cy-r*0.3,0,cx,cy,r);


### PR DESCRIPTION
Improvements to the WAN globes shown on the 2D and 3D network maps.

## Live throughput

- **Inactive WAN no longer borrows the active WAN's throughput.** A WAN with no per-port rate was falling back to the gateway's aggregate WAN throughput, so an idle WAN globe showed the active WAN's traffic. It now reports zero. The fallback is gated on a missing per-port rate rather than the `up` flag, so PPPoE (`ppp*`) and any WAN actually passing traffic keep their real measured rate even if the gateway misreports `up`.

## Globe labels

- **Name leads, WAN number trails:** e.g. "Acme Fiber (WAN2)". A port with no real name shows "WAN2 (SFP+ 2)"; a generic name falls back to a bare "WAN2". A single visible globe omits the redundant WAN number. Two WANs that resolve to the same ISP are disambiguated by their WAN number.
- **2D map uses the same composed name as the 3D map** (it previously showed only the bare ISP/ASN, dropping the WAN number).

## Hiding unused WANs

- A WAN that is down with no IP is **hidden** on both maps. A half-state (up without an IP, or down still holding an IP) renders **greyed**, matching the discovery-pending look. The 2D map now greys that state too (it previously ignored the tier).

## Upstream discovery

- **Discovery counts as complete when either an access-ISP hop or a transit hop is found**, so an access network with no pingable ICMP target is still considered discovered via transit. Applies to both the map's greyed state and the "Run Upstream Discovery" banner.
- The map and the banner now count only **enabled** monitoring targets.
- Toggling an ISP/Transit target refreshes the map when you return to Live View; the cached snapshot is invalidated only when the enabled ISP/Transit set actually changes, avoiding needless rebuilds.
