### PR TITLE
Upstream Discovery: fall back to an ISP test server when no hop in the ISP's ASN answers ICMP

### DIFF
--- a/src/NetworkOptimizer.Storage/Models/MonitoringTarget.cs
+++ b/src/NetworkOptimizer.Storage/Models/MonitoringTarget.cs
@@ -30,7 +30,11 @@ public enum DiscoveryMethod
     /// interface (ip neigh show). This is the L2 neighbor - typically the OLT on GPON,
     /// CMTS on DOCSIS, or BNG on PPPoE. Closest upstream device; may not appear in
     /// traceroutes if it's L2-transparent.</summary>
-    L2Neighbor = 4
+    L2Neighbor = 4,
+    /// <summary>A curated public endpoint (typically the ISP's own speedtest server) from our
+    /// per-ASN fallback list, adopted as the access target when no first-mile router answers ICMP.
+    /// Not discovered on the path - resolved and ping-selected from a hardcoded map.</summary>
+    ConfiguredFallback = 5
 }
 
 public class MonitoringTarget

--- a/src/NetworkOptimizer.Storage/Models/MonitoringTargetTypeExtensions.cs
+++ b/src/NetworkOptimizer.Storage/Models/MonitoringTargetTypeExtensions.cs
@@ -54,6 +54,7 @@ public static class MonitoringEnumDisplay
         UpstreamRole.PathProxy => "Path proxy",
         UpstreamRole.AccessHop => "ISP hop", // not "Access hop" - post-access-layer hops were confusingly labeled
         UpstreamRole.AccessGateway => "Access gateway",
+        UpstreamRole.Speedtest => "Speedtest",
         _ => r.ToString()
     };
 
@@ -73,6 +74,7 @@ public static class MonitoringEnumDisplay
         DiscoveryMethod.UserProvided => "User-added",
         DiscoveryMethod.Unresolved => "Unresolved",
         DiscoveryMethod.L2Neighbor => "L2 neighbor",
+        DiscoveryMethod.ConfiguredFallback => "Curated",
         _ => m.ToString()
     };
 }

--- a/src/NetworkOptimizer.Storage/Models/UpstreamDiscovery.cs
+++ b/src/NetworkOptimizer.Storage/Models/UpstreamDiscovery.cs
@@ -12,7 +12,10 @@ public enum UpstreamRole
     Transit = 5,
     PathProxy = 6,
     AccessHop = 7,
-    AccessGateway = 8
+    AccessGateway = 8,
+    /// <summary>A curated public endpoint (typically the ISP's own speedtest server) adopted
+    /// as the access target when no first-mile router answers ICMP. Not an on-path hop.</summary>
+    Speedtest = 9
 }
 
 public class UpstreamDiscovery

--- a/src/NetworkOptimizer.Web/Components/Shared/SnmpDeviceStatusCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SnmpDeviceStatusCard.razor
@@ -14,7 +14,7 @@
 <div class="card">
     <div class="card-header card-header-collapsible" @onclick="ToggleCollapse">
         <div class="card-title-group">
-            <h2 class="card-title">SNMP Devices</h2>
+            <h2 class="card-title">SNMP Devices (and Custom OIDs)</h2>
         </div>
         <div class="card-header-right">
             <span class="status-badge status-active" @onclick:stopPropagation="true">@SummaryLabel()</span>
@@ -53,7 +53,8 @@
                                 @foreach (var d in Devices.OrderBy(d => d.DeviceType).ThenBy(d => d.Name))
                                 {
                                     var isExpanded = _expandedDeviceMac == d.Mac;
-                                    <tr class="@(isExpanded ? "snmp-row-expanded" : "")" @onclick="() => ToggleDevice(d.Mac)" style="cursor: pointer;">
+                                    <tr class="@(isExpanded ? "snmp-row-expanded" : "")" @onclick="() => ToggleDevice(d.Mac)" style="cursor: pointer;"
+                                        data-tooltip-hover-only data-tooltip-wrap data-tooltip="@(isExpanded ? null : "Click to set up custom OID polling")">
                                         <td>
                                             <span class="snmp-device-name">@d.Name</span>
                                             <span class="status-badge status-neutral snmp-device-type">@d.DeviceType.ToDisplayName()</span>

--- a/src/NetworkOptimizer.Web/Components/Shared/SnmpDeviceStatusCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SnmpDeviceStatusCard.razor
@@ -14,7 +14,7 @@
 <div class="card">
     <div class="card-header card-header-collapsible" @onclick="ToggleCollapse">
         <div class="card-title-group">
-            <h2 class="card-title">SNMP Devices <span class="card-title-suffix">(and Custom OIDs)</span></h2>
+            <h2 class="card-title">SNMP Devices <span class="card-title-suffix">and Custom OIDs</span></h2>
         </div>
         <div class="card-header-right">
             <span class="status-badge status-active" @onclick:stopPropagation="true">@SummaryLabel()</span>
@@ -243,18 +243,30 @@
 
     protected override async Task OnParametersSetAsync()
     {
-        // Auto-expand the first device once the list is populated so the Custom OID Polling
-        // section (and its "Add OID" action) is visible without needing a hint. Only on the
-        // first populate, and only if the user hasn't already opened a row themselves.
-        if (!_autoExpandedFirst && Devices.Count > 0 && _expandedDeviceMac == null)
+        // Nudge users who haven't touched custom OIDs yet: auto-expand the first device so the
+        // Custom OID Polling section (and its "Add OID" action) is visible without a hint. But if
+        // ANY device already has a custom OID configured, the feature is discovered - leave it
+        // collapsed. Runs once, and never overrides a row the user opened themselves.
+        if (_autoExpandedFirst || Devices.Count == 0 || _expandedDeviceMac != null) return;
+        _autoExpandedFirst = true;
+
+        bool anyCustomOids;
+        try
         {
-            _autoExpandedFirst = true;
-            var first = Devices.OrderBy(d => d.DeviceType).ThenBy(d => d.Name).FirstOrDefault();
-            if (first != null)
-            {
-                _expandedDeviceMac = first.Mac;
-                await LoadCustomOids(first.Mac);
-            }
+            await using var db = await DbFactory.CreateDbContextAsync();
+            anyCustomOids = await db.CustomOidConfigurations.AnyAsync();
+        }
+        catch
+        {
+            anyCustomOids = true; // fail safe: if we can't tell, don't auto-expand
+        }
+        if (anyCustomOids) return;
+
+        var first = Devices.OrderBy(d => d.DeviceType).ThenBy(d => d.Name).FirstOrDefault();
+        if (first != null)
+        {
+            _expandedDeviceMac = first.Mac;
+            await LoadCustomOids(first.Mac);
         }
     }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/SnmpDeviceStatusCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SnmpDeviceStatusCard.razor
@@ -14,7 +14,7 @@
 <div class="card">
     <div class="card-header card-header-collapsible" @onclick="ToggleCollapse">
         <div class="card-title-group">
-            <h2 class="card-title">SNMP Devices (and Custom OIDs)</h2>
+            <h2 class="card-title">SNMP Devices <span class="card-title-suffix">(and Custom OIDs)</span></h2>
         </div>
         <div class="card-header-right">
             <span class="status-badge status-active" @onclick:stopPropagation="true">@SummaryLabel()</span>
@@ -53,8 +53,7 @@
                                 @foreach (var d in Devices.OrderBy(d => d.DeviceType).ThenBy(d => d.Name))
                                 {
                                     var isExpanded = _expandedDeviceMac == d.Mac;
-                                    <tr class="@(isExpanded ? "snmp-row-expanded" : "")" @onclick="() => ToggleDevice(d.Mac)" style="cursor: pointer;"
-                                        data-tooltip-hover-only data-tooltip-wrap data-tooltip="@(isExpanded ? null : "Click to set up custom OID polling")">
+                                    <tr class="@(isExpanded ? "snmp-row-expanded" : "")" @onclick="() => ToggleDevice(d.Mac)" style="cursor: pointer;">
                                         <td>
                                             <span class="snmp-device-name">@d.Name</span>
                                             <span class="status-badge status-neutral snmp-device-type">@d.DeviceType.ToDisplayName()</span>
@@ -225,6 +224,7 @@
 
     private bool _collapsed = true;
     private string? _expandedDeviceMac;
+    private bool _autoExpandedFirst;
     private List<CustomOidDto> _customOids = new();
 
     // Add/edit form state
@@ -240,6 +240,23 @@
     // Test OID state
     private bool _testingOid;
     private TestOidResult? _testResult;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        // Auto-expand the first device once the list is populated so the Custom OID Polling
+        // section (and its "Add OID" action) is visible without needing a hint. Only on the
+        // first populate, and only if the user hasn't already opened a row themselves.
+        if (!_autoExpandedFirst && Devices.Count > 0 && _expandedDeviceMac == null)
+        {
+            _autoExpandedFirst = true;
+            var first = Devices.OrderBy(d => d.DeviceType).ThenBy(d => d.Name).FirstOrDefault();
+            if (first != null)
+            {
+                _expandedDeviceMac = first.Mac;
+                await LoadCustomOids(first.Mac);
+            }
+        }
+    }
 
     private void ToggleCollapse() => _collapsed = !_collapsed;
 

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -183,7 +183,7 @@
                                                        disabled="@hop.Unreachable" />
                                             </td>
                                             <td><code>@hop.Address</code> @(string.IsNullOrEmpty(hop.PtrHostname) ? "" : $"({hop.PtrHostname})")</td>
-                                            <td>@(hop.Method == DiscoveryMethod.L2Neighbor ? "L2 neighbor" : $"Hop {hop.HopNumber}")</td>
+                                            <td>@(hop.Method == DiscoveryMethod.L2Neighbor ? "L2 neighbor" : hop.Method == DiscoveryMethod.ConfiguredFallback ? "Curated" : $"Hop {hop.HopNumber}")</td>
                                             <td>@hop.Role.ToDisplayName()</td>
                                             <td>@(hop.Unreachable ? "Unreachable" : hop.VerifiedRttMs.HasValue ? $"{hop.VerifiedRttMs:F1} ms" : "-")</td>
                                         </tr>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1260,6 +1260,91 @@ public class UpstreamTracerService
                 "speedtest.denver.intrepidfiber.com",
                 "speedtest.minneapolis.intrepidfiber.com",
             },
+
+            // Charter / Spectrum - Ookla speedtest hosts (*.st.charter.com), all verified
+            // ICMP-pingable. Spectrum customers span 10 ASNs from the Charter / Time Warner Cable /
+            // Bright House / Bresnan mergers, so there is one key per ASN, each listing only the
+            // hosts that actually resolve into that ASN - a customer only ever probes the handful
+            // in its own detected ASN (16 for AS20115, 1-5 elsewhere), well within the rapid burst.
+            [20115] = new[]   // Charter Communications LLC
+            {
+                "aldlmi-speedtest-ookla-01.st.charter.com",   // Allendale, MI
+                "euclwi-speedtest-ookla-01.st.charter.com",   // Eau Claire, WI
+                "ftwotx-speedtest-ookla-01.st.charter.com",   // Fort Worth, TX
+                "kgpttn-speedtest-ookla-01.st.charter.com",   // Kingsport, TN
+                "krnyne-speedtest-ookla-01.st.charter.com",   // Kearney, NE
+                "ledsal-speedtest-ookla-01.st.charter.com",   // Leeds, AL
+                "mdfdor-speedtest-ookla-01.st.charter.com",   // Medford, OR
+                "mtpkca-speedtest-ookla-01.st.charter.com",   // Monterey Park, CA
+                "olvemo-speedtest-ookla-01.st.charter.com",   // Olivette, MO
+                "oxfrma-speedtest-ookla-01.st.charter.com",   // Oxford, MA
+                "ptldor-speedtest-ookla-01.st.charter.com",   // Portland, OR
+                "renonv-speedtest-ookla-01.st.charter.com",   // Reno, NV
+                "sghlga-speedtest-ookla-01.st.charter.com",   // Sugar Hill, GA
+                "slidla-speedtest-ookla-01.st.charter.com",   // Slidell, LA
+                "snloca-speedtest-ookla-01.st.charter.com",   // San Luis Obispo, CA
+                "stcdmn-speedtest-ookla-01.st.charter.com",   // St Cloud, MN
+            },
+            [7843] = new[]    // Charter (legacy Time Warner Cable)
+            {
+                "dnvrco-speedtest-ookla-01.st.charter.com",   // Centennial, CO
+            },
+            [10796] = new[]   // Charter (legacy Time Warner Cable)
+            {
+                "clboh-speedtest-ookla-03.st.charter.com",    // Columbus, OH
+                "lxtnky-speedtest-ookla-01.st.charter.com",   // Lexington, KY
+            },
+            [11351] = new[]   // Charter (legacy Time Warner Cable)
+            {
+                "ptldme-speedtest-ookla-01.st.charter.com",   // Portland, ME
+                "syrny-speedtest-ookla-02.st.charter.com",    // Syracuse, NY
+            },
+            [11426] = new[]   // Charter (legacy Time Warner Cable)
+            {
+                "radnc-speedtest-ookla-01.st.charter.com",    // Durham, NC
+            },
+            [11427] = new[]   // Charter (legacy Time Warner Cable)
+            {
+                "houstx-speedtest-ookla-01.st.charter.com",   // Houston, TX
+                "ksczks-speedtest-ookla-01.st.charter.com",   // Kansas City, KS
+                "snantx-speedtest-ookla-01.st.charter.com",   // San Antonio, TX
+            },
+            [12271] = new[]   // Charter (legacy Time Warner Cable)
+            {
+                "nycny-speedtest-ookla-01.st.charter.com",    // New York, NY
+            },
+            [20001] = new[]   // Charter (legacy Time Warner Cable)
+            {
+                "kmlahi-speedtest-ookla-01.st.charter.com",   // Mauna Lani, HI
+                "lsanca-speedtest-ookla-02.st.charter.com",   // Los Angeles, CA
+                "milnhi-speedtest-ookla-01.st.charter.com",   // Mililani, HI
+            },
+            [33363] = new[]   // Charter (Bright House Networks)
+            {
+                "detmi-speedtest-ookla-01.st.charter.com",    // Livonia, MI
+                "tampfl-speedtest-ookla-01.st.charter.com",   // Tampa, FL
+            },
+            [33588] = new[]   // Charter (Bresnan)
+            {
+                "blngmt-speedtest-ookla-01.st.charter.com",   // Billings, MT
+                "chynwy-speedtest-ookla-01.st.charter.com",   // Cheyenne, WY
+                "csprwy-speedtest-ookla-01.st.charter.com",   // Casper, WY
+                "gdjtco-speedtest-ookla-01.st.charter.com",   // Grand Junction, CO
+                "msslmt-speedtest-ookla-01.st.charter.com",   // Missoula, MT
+            },
+
+            // Orange S.A. (AS3215, France) - NOT YET ENABLED. These hosts BLOCK ICMP (0/3) but
+            // answer TCP:8080, so enabling them needs per-endpoint TCP probe support added to this
+            // map + InjectAccessIspFallbackAsync. The probe layer (TcpPingAsync) and the live agent
+            // (MonitoringCollectionAgent) already honor ProbeMode.Tcp + Port; only the fallback
+            // map/injection are ICMP-only today. When TCP support lands, key AS3215 -> TCP:8080:
+            //   montsouris3.d2m.c2d.liveservices.fr   // Paris
+            //   lyon3.d2m.c2d.liveservices.fr         // Lyon
+            //   lille3.d2m.c2d.liveservices.fr        // Lille
+            //   marseille3.d2m.c2d.liveservices.fr    // Marseille
+            //   strasbourg3.d2m.c2d.liveservices.fr   // Strasbourg
+            //   puteaux3.d2m.c2d.liveservices.fr      // Puteaux
+            //   poitiers3.d2m.c2d.liveservices.fr     // Poitiers
         };
 
     private async Task InjectTransitWitnessesAsync(int minSuccesses, CancellationToken ct)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -680,6 +680,11 @@ public class UpstreamTracerService
     private List<AttributedHop> _mergedHops = new();
     private List<AttributedHop> _accessHopsResolved = new();
 
+    // The detected access ISP ASN from the last TraceAccessIspAsync. Kept as a field so
+    // the reachability step can fall back to a curated endpoint even when none of the
+    // access hops responded (the access pool can be empty/unreachable yet the ASN known).
+    private int? _accessAsn;
+
     // The 1st/2nd-degree non-access ASNs off each trace (union): the access ISP's
     // direct upstream and that upstream's upstream. A transit-probe ASN (Lumen, AT&T,
     // INDATEL) only counts as *our* ISP's transit when it lands in this window -
@@ -772,6 +777,9 @@ public class UpstreamTracerService
         // skipped over; they don't have a public ASN.
         var firstPublicHop = candidateHops.FirstOrDefault(h => h.Asn != null);
         var accessAsn = firstPublicHop?.Asn?.Asn;
+        // Remember it so the reachability step can reach for a curated fallback endpoint
+        // even when the access pool ends up empty or entirely unreachable.
+        _accessAsn = accessAsn;
 
         // Collect ALL hops in the access ASN from the merged pool. Filter-based,
         // not sequential - the merged pool interleaves hops from different traces
@@ -1193,6 +1201,10 @@ public class UpstreamTracerService
         // 4.2.2.2 as a transit witness so ISP Health still has Lumen transit data.
         await InjectTransitWitnessesAsync(minSuccesses, ct);
 
+        // If the access ASN is one we have curated endpoints for and none of its first-mile
+        // hops cleared the gate, adopt the lowest-RTT reachable curated endpoint as the access target.
+        await InjectAccessIspFallbackAsync(minSuccesses, ct);
+
         State.CurrentActivity = unreachable > 0
             ? $"Reachability check complete: {unreachable} of {allTargets.Count} target(s) did not respond and were excluded."
             : $"All {allTargets.Count} target(s) responded to ping.";
@@ -1206,6 +1218,25 @@ public class UpstreamTracerService
     {
         (3356, "4.2.2.2", "Level 3", "Level 3 DNS (transit witness)")
     };
+
+    // Curated access-ISP endpoints for carriers whose first-mile routers commonly ICMP-deprioritize,
+    // leaving the access cloud with no probed target. When the detected access ASN is in this map and
+    // none of the discovered access hops clear the reachability gate, we resolve + ping these published
+    // hosts and adopt the lowest-RTT reachable one as the access target (InjectAccessIspFallbackAsync).
+    // Hosts must answer ICMP (the same gate post-traceroute hops face); non-pingable PoPs are omitted.
+    // The label follows the standard convention (stripped ASN name + stripped hostname via
+    // FormatTransitHopLabel), e.g. "Deutsche Telekom ffm.wsqm".
+    internal static readonly IReadOnlyDictionary<int, IReadOnlyList<string>> AccessIspFallbackHosts =
+        new Dictionary<int, IReadOnlyList<string>>
+        {
+            // AS3320 Deutsche Telekom AG - WSQM endpoints (Düsseldorf omitted: not ICMP-pingable).
+            [3320] = new[]
+            {
+                "ffm.wsqm.telekom-dienste.de",   // Frankfurt am Main
+                "ham.wsqm.telekom-dienste.de",   // Hamburg
+                "mue.wsqm.telekom-dienste.de",   // Munich
+            },
+        };
 
     private async Task InjectTransitWitnessesAsync(int minSuccesses, CancellationToken ct)
     {
@@ -1246,6 +1277,102 @@ public class UpstreamTracerService
             });
             _logger.LogInformation("Injected transit witness {Address} (AS{Asn} {Name}) - no reachable {Name} router",
                 address, asn, name, name);
+        }
+    }
+
+    /// <summary>
+    /// When the detected access ASN is one we have curated endpoints for and discovery surfaced
+    /// no reachable first-mile hop, resolve + ICMP-ping the curated hosts and adopt the single
+    /// lowest-RTT reachable one as the access target. The carrier's own routers commonly
+    /// ICMP-deprioritize, so without this the access cloud would have nothing to probe. Same
+    /// reachability gate as the post-traceroute hops; same label convention (stripped ASN name +
+    /// stripped hostname) as every other discovered target.
+    /// </summary>
+    private async Task InjectAccessIspFallbackAsync(int minSuccesses, CancellationToken ct)
+    {
+        if (_accessAsn is not int asn) return;
+        if (!AccessIspFallbackHosts.TryGetValue(asn, out var hosts)) return;
+
+        // Only when discovery produced no reachable access target. A real first-mile router that
+        // cleared the gate is always the better monitor than a city-PoP speedtest endpoint.
+        if (State.AccessHops.Any(h => h.Enabled && !h.Unreachable)) return;
+
+        var orgName = CleanAsnName(_accessHopsResolved.FirstOrDefault()?.Asn?.Name);
+        if (string.IsNullOrEmpty(orgName)) orgName = $"AS{asn}";
+
+        // Resolve + ping each curated host; keep the reachable ones with their measured RTT.
+        var probed = new List<AccessFallbackProbe>();
+        foreach (var host in hosts)
+        {
+            var ip = await ResolveIPv4Async(host, ct);
+            if (ip == null)
+            {
+                _logger.LogDebug("Access fallback {Host} (AS{Asn}) did not resolve to an IPv4 address", host, asn);
+                continue;
+            }
+            var result = await ProbeReachabilityAsync(ip, ProbeMode.Icmp, ct);
+            if (result.Received >= minSuccesses && result.RttAvgMs is double rtt)
+                probed.Add(new AccessFallbackProbe(host, ip, rtt));
+            else
+                _logger.LogDebug("Access fallback {Host} ({Ip}) only {Recv}/{Sent} - skipping",
+                    host, ip, result.Received, result.Sent);
+        }
+
+        var winner = SelectLowestRtt(probed);
+        if (winner == null)
+        {
+            _logger.LogDebug("Access fallback for AS{Asn} {Org}: no curated host cleared the gate", asn, orgName);
+            return;
+        }
+
+        var ptrLabel = FormatTransitHopLabel(winner.Host, winner.Ip);
+        State.AccessHops.Add(new AccessHopCandidate
+        {
+            TargetId = $"access-fallback-as{asn}-{NormalizeMacForId(winner.Host)}",
+            Label = ptrLabel != null ? $"{orgName} {ptrLabel}" : $"{orgName} {winner.Host}",
+            Address = winner.Ip,
+            PtrHostname = winner.Host,
+            AsnNumber = asn,
+            AsnName = orgName,
+            Role = UpstreamRole.AccessHop,
+            HopNumber = 0,
+            RespondedTo = ProbeMode.Icmp,
+            Method = DiscoveryMethod.DirectRouter,
+            VerifiedRttMs = winner.Rtt,
+            Enabled = true
+        });
+        _logger.LogInformation("Injected access fallback {Host} ({Ip}) for AS{Asn} {Org} - {Rtt:F1} ms, no reachable first-mile router",
+            winner.Host, winner.Ip, asn, orgName, winner.Rtt);
+    }
+
+    /// <summary>A curated access-ISP host that resolved and cleared the reachability gate.</summary>
+    internal sealed record AccessFallbackProbe(string Host, string Ip, double Rtt);
+
+    /// <summary>
+    /// Pick the lowest-RTT reachable curated endpoint, or null when none cleared the gate.
+    /// Pure selection split out so it can be unit-tested without DNS or ICMP.
+    /// </summary>
+    internal static AccessFallbackProbe? SelectLowestRtt(IEnumerable<AccessFallbackProbe> probes) =>
+        probes.OrderBy(p => p.Rtt).FirstOrDefault();
+
+    /// <summary>
+    /// Resolve a hostname to its first IPv4 (A-record) address, or null on failure. Uses the OS
+    /// resolver via <see cref="System.Net.Dns"/>; the curated fallback hosts are plain unicast
+    /// FQDNs so a single A lookup is sufficient.
+    /// </summary>
+    private async Task<string?> ResolveIPv4Async(string host, CancellationToken ct)
+    {
+        try
+        {
+            var addresses = await System.Net.Dns.GetHostAddressesAsync(host, ct);
+            return addresses
+                .FirstOrDefault(a => a.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
+                ?.ToString();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Access fallback DNS resolution failed for {Host}", host);
+            return null;
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1236,6 +1236,29 @@ public class UpstreamTracerService
                 "ham.wsqm.telekom-dienste.de",   // Hamburg
                 "mue.wsqm.telekom-dienste.de",   // Munich
             },
+            // AS12912 T-Mobile Polska - public speedtest PoPs inside T-Mobile PL's own network.
+            [12912] = new[]
+            {
+                "gda1.t-mobile.pl",   // Gdańsk
+                "poz1.t-mobile.pl",   // Poznań
+                "waw2.t-mobile.pl",   // Warsaw
+                "kra1.t-mobile.pl",   // Kraków
+            },
+            // AS13036 T-Mobile Czech Republic - public speedtest PoPs inside its own network.
+            [13036] = new[]
+            {
+                "speedtest5.t-mobile.cz",   // Prague
+                "speedtest6.t-mobile.cz",   // Brno
+            },
+            // AS394056 Intrepid Fiber - delivers "T-Mobile Fiber" in several US metros. The endpoints
+            // sit in Intrepid's own ASN (not T-Mobile's AS21928), so a subscriber's access ASN
+            // resolves to 394056 - that's the key the discovery path matches against.
+            [394056] = new[]
+            {
+                "speedtest.sandiego.intrepidfiber.com",
+                "speedtest.denver.intrepidfiber.com",
+                "speedtest.minneapolis.intrepidfiber.com",
+            },
         };
 
     private async Task InjectTransitWitnessesAsync(int minSuccesses, CancellationToken ct)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1251,14 +1251,15 @@ public class UpstreamTracerService
                 "speedtest5.t-mobile.cz",   // Prague
                 "speedtest6.t-mobile.cz",   // Brno
             },
-            // AS394056 Intrepid Fiber - delivers "T-Mobile Fiber" in several US metros. The endpoints
-            // sit in Intrepid's own ASN (not T-Mobile's AS21928), so a subscriber's access ASN
-            // resolves to 394056 - that's the key the discovery path matches against.
+            // AS394056 Intrepid Fiber - the access-layer fiber network. T-Mobile Fiber is a retail
+            // brand that rides on Intrepid in several US metros (and some markets sell Intrepid
+            // Fiber direct). Either way the subscriber's access ASN is 394056 (not T-Mobile's
+            // mobile AS21928), so that's the key matched here.
             [394056] = new[]
             {
-                "speedtest.sandiego.intrepidfiber.com",
-                "speedtest.denver.intrepidfiber.com",
-                "speedtest.minneapolis.intrepidfiber.com",
+                "speedtest.sandiego.intrepidfiber.com",     // San Diego
+                "speedtest.denver.intrepidfiber.com",       // Denver
+                "speedtest.minneapolis.intrepidfiber.com",  // Minneapolis
             },
 
             // Charter / Spectrum - Ookla speedtest hosts (*.st.charter.com), all verified
@@ -1390,9 +1391,10 @@ public class UpstreamTracerService
     }
 
     /// <summary>
-    /// When the detected access ASN is one we have curated endpoints for and discovery surfaced
-    /// no reachable first-mile hop, resolve + ICMP-ping the curated hosts and adopt the single
-    /// lowest-RTT reachable one as the access target. The carrier's own routers commonly
+    /// When the detected access ASN is one we have curated endpoints for and NO discovered hop in
+    /// that ASN answered ICMP (the whole access-ISP hop set - the L2 neighbor plus any aggregation
+    /// and border routers - came back unreachable), resolve + ICMP-ping the curated hosts and adopt
+    /// the single lowest-RTT reachable one as the access target. The carrier's own routers commonly
     /// ICMP-deprioritize, so without this the access cloud would have nothing to probe. Same
     /// reachability gate as the post-traceroute hops; same label convention (stripped ASN name +
     /// stripped hostname) as every other discovered target.

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1235,6 +1235,7 @@ public class UpstreamTracerService
                 "ffm.wsqm.telekom-dienste.de",   // Frankfurt am Main
                 "ham.wsqm.telekom-dienste.de",   // Hamburg
                 "mue.wsqm.telekom-dienste.de",   // Munich
+                "ber.wsqm.telekom-dienste.de",   // Berlin
             },
             // AS12912 T-Mobile Polska - public speedtest PoPs inside T-Mobile PL's own network.
             [12912] = new[]

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1334,10 +1334,10 @@ public class UpstreamTracerService
             PtrHostname = winner.Host,
             AsnNumber = asn,
             AsnName = orgName,
-            Role = UpstreamRole.AccessHop,
+            Role = UpstreamRole.Speedtest,
             HopNumber = 0,
             RespondedTo = ProbeMode.Icmp,
-            Method = DiscoveryMethod.DirectRouter,
+            Method = DiscoveryMethod.ConfiguredFallback,
             VerifiedRttMs = winner.Rtt,
             Enabled = true
         });

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -475,6 +475,12 @@ a:hover {
     margin: 0;
 }
 
+.card-title-suffix {
+    font-size: 0.8125rem;
+    font-weight: 400;
+    color: var(--text-muted);
+}
+
 @media (max-width: 412px) {
     .card-title {
         font-size: 1rem;

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
@@ -998,3 +998,61 @@ public class ComputeExcludedTier1AsnsTests
         UpstreamTracerService.Tier1Asns.Should().NotContain(6939);
     }
 }
+
+public class AccessIspFallbackTests
+{
+    [Fact]
+    public void AccessIspFallbackHosts_AS3320_has_the_three_pingable_telekom_pops()
+    {
+        UpstreamTracerService.AccessIspFallbackHosts.Should().ContainKey(3320);
+        UpstreamTracerService.AccessIspFallbackHosts[3320].Should().BeEquivalentTo(new[]
+        {
+            "ffm.wsqm.telekom-dienste.de",
+            "ham.wsqm.telekom-dienste.de",
+            "mue.wsqm.telekom-dienste.de",
+        });
+    }
+
+    [Fact]
+    public void AccessIspFallbackHosts_AS3320_omits_non_pingable_dusseldorf()
+    {
+        // dssd-tc.wsqm.telekom-dienste.de does not answer ICMP, so it must stay out of the map.
+        UpstreamTracerService.AccessIspFallbackHosts[3320]
+            .Should().NotContain(h => h.StartsWith("dssd"));
+    }
+
+    [Fact]
+    public void SelectLowestRtt_picks_the_lowest_rtt_candidate()
+    {
+        var probes = new[]
+        {
+            new UpstreamTracerService.AccessFallbackProbe("ffm.wsqm.telekom-dienste.de", "203.0.113.10", 24.5),
+            new UpstreamTracerService.AccessFallbackProbe("ham.wsqm.telekom-dienste.de", "203.0.113.20", 11.2),
+            new UpstreamTracerService.AccessFallbackProbe("mue.wsqm.telekom-dienste.de", "203.0.113.30", 31.0),
+        };
+
+        var winner = UpstreamTracerService.SelectLowestRtt(probes);
+
+        winner.Should().NotBeNull();
+        winner!.Host.Should().Be("ham.wsqm.telekom-dienste.de");
+        winner.Rtt.Should().Be(11.2);
+    }
+
+    [Fact]
+    public void SelectLowestRtt_returns_the_single_candidate_when_only_one_reachable()
+    {
+        var probes = new[]
+        {
+            new UpstreamTracerService.AccessFallbackProbe("mue.wsqm.telekom-dienste.de", "203.0.113.30", 31.0),
+        };
+
+        UpstreamTracerService.SelectLowestRtt(probes)!.Host.Should().Be("mue.wsqm.telekom-dienste.de");
+    }
+
+    [Fact]
+    public void SelectLowestRtt_returns_null_when_none_reachable()
+    {
+        UpstreamTracerService.SelectLowestRtt(Array.Empty<UpstreamTracerService.AccessFallbackProbe>())
+            .Should().BeNull();
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
@@ -1002,7 +1002,7 @@ public class ComputeExcludedTier1AsnsTests
 public class AccessIspFallbackTests
 {
     [Fact]
-    public void AccessIspFallbackHosts_AS3320_has_the_three_pingable_telekom_pops()
+    public void AccessIspFallbackHosts_AS3320_has_the_pingable_telekom_pops()
     {
         UpstreamTracerService.AccessIspFallbackHosts.Should().ContainKey(3320);
         UpstreamTracerService.AccessIspFallbackHosts[3320].Should().BeEquivalentTo(new[]
@@ -1010,6 +1010,7 @@ public class AccessIspFallbackTests
             "ffm.wsqm.telekom-dienste.de",
             "ham.wsqm.telekom-dienste.de",
             "mue.wsqm.telekom-dienste.de",
+            "ber.wsqm.telekom-dienste.de",
         });
     }
 


### PR DESCRIPTION
## What's new

Some ISPs drop or deprioritize ICMP across their own network, so none of their routers answer. When that happens, ISP Health has no target to measure the access leg (you to your ISP), and that part of the path shows up empty.

Now, for a growing list of those ISPs, Network Optimizer falls back to monitoring one of the ISP's own public servers (inside the ISP's ASN) instead, so you still get live latency and jitter for the access leg, with no setup.

## ISPs covered so far

- Deutsche Telekom (Germany)
- T-Mobile (Poland and Czechia)
- T-Mobile Fiber / Intrepid Fiber (US)
- Spectrum (US)

More can be added over time.

## How it works

- It only runs when no hop in your ISP's ASN answers ICMP. Discovery finds every hop in that ASN (the device your gateway attaches to, plus the ISP's aggregation and border routers); the fallback fires only if all of them are silent. If any one responds, that's used instead and this never runs.
- It then picks the ISP server with the lowest RTT to you.
- The chosen target appears in the discovery review screen labeled "Speedtest", so it's clear it's a test server rather than an on-path router. Rename or disable it like any other target.

## Also in this PR

- SNMP setup: the "SNMP Devices" card is now "SNMP Devices (and Custom OIDs)", and it auto-expands the first device so the custom OID polling controls are visible right away, making that feature easier to find.

## Still to come

- Orange (France): identified but not enabled yet. Its servers block ICMP but answer TCP on 8080, which needs a probe type we haven't wired up yet.
