### PR TITLE
Fix Incident card actions, add bulk Incident acknowledge/resolve, harden Flex 2.5G exclusion

### DIFF
--- a/src/NetworkOptimizer.Agents/NetworkOptimizer.Agents.csproj
+++ b/src/NetworkOptimizer.Agents/NetworkOptimizer.Agents.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="SSH.NET" Version="2025.1.0" />
-    <PackageReference Include="Scriban" Version="7.2.0" />
+    <PackageReference Include="Scriban" Version="7.2.5" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />

--- a/src/NetworkOptimizer.Alerts/NetworkOptimizer.Alerts.csproj
+++ b/src/NetworkOptimizer.Alerts/NetworkOptimizer.Alerts.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="MailKit" Version="4.16.0" />
-    <PackageReference Include="Scriban" Version="7.2.0" />
+    <PackageReference Include="Scriban" Version="7.2.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -1025,6 +1025,16 @@
             }
             else
             {
+                <div class="alert-group-header">
+                    <h2 class="alert-group-title">Active Incidents</h2>
+                    <div class="alert-group-actions">
+                        @if (_incidents.Any(i => i.Status == AlertStatus.Active))
+                        {
+                            <button class="btn btn-sm btn-secondary" @onclick="AcknowledgeAllIncidents">Acknowledge All</button>
+                        }
+                        <button class="btn btn-sm btn-primary" @onclick="ResolveAllIncidents">Resolve All</button>
+                    </div>
+                </div>
                 @foreach (var incident in _incidents.Where(i => i.Status != AlertStatus.Resolved))
                 {
                     <div class="card" style="margin-bottom: 1rem;">
@@ -1059,11 +1069,11 @@
                                 @if (incident.Status == AlertStatus.Active)
                                 {
                                     <button class="btn btn-sm btn-secondary" @onclick="() => AcknowledgeIncident(incident)">
-                                        Acknowledge All
+                                        Acknowledge
                                     </button>
                                 }
                                 <button class="btn btn-sm btn-primary" @onclick="() => ResolveIncident(incident)">
-                                    Resolve All
+                                    Resolve
                                 </button>
                             </div>
                         </div>
@@ -2350,6 +2360,61 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error resolving incident {Id}", incident.Id);
+        }
+    }
+
+    private async Task AcknowledgeAllIncidents()
+    {
+        try
+        {
+            var now = DateTime.UtcNow;
+            foreach (var incident in _incidents.Where(i => i.Status == AlertStatus.Active).ToList())
+            {
+                var alerts = await AlertRepository.GetAlertsByIncidentIdAsync(incident.Id);
+                foreach (var alert in alerts.Where(a => a.Status == AlertStatus.Active))
+                {
+                    alert.Status = AlertStatus.Acknowledged;
+                    alert.AcknowledgedAt = now;
+                    await AlertRepository.UpdateAlertAsync(alert);
+                }
+
+                incident.Status = AlertStatus.Acknowledged;
+                await AlertRepository.UpdateIncidentAsync(incident);
+            }
+            await LoadIncidents();
+            await LoadActiveAlerts();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error acknowledging all incidents");
+        }
+    }
+
+    private async Task ResolveAllIncidents()
+    {
+        try
+        {
+            var now = DateTime.UtcNow;
+            foreach (var incident in _incidents.Where(i => i.Status != AlertStatus.Resolved).ToList())
+            {
+                var alerts = await AlertRepository.GetAlertsByIncidentIdAsync(incident.Id);
+                foreach (var alert in alerts.Where(a => a.Status != AlertStatus.Resolved))
+                {
+                    alert.Status = AlertStatus.Resolved;
+                    alert.ResolvedAt = now;
+                    await AlertRepository.UpdateAlertAsync(alert);
+                }
+
+                incident.Status = AlertStatus.Resolved;
+                incident.ResolvedAt = now;
+                await AlertRepository.UpdateIncidentAsync(incident);
+            }
+            await LoadIncidents();
+            await LoadActiveAlerts();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error resolving all incidents");
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -1526,6 +1526,22 @@ public class MonitoringCollectionAgent : BackgroundService
                     existing.Address = address;
                     changed = true;
                 }
+                // Flex 2.5G switches are poor latency/loss targets (high RTT/jitter),
+                // so they're disabled by default. The one-shot Flex25GLatencyMigrated
+                // pass can miss an existing target if the device's model hadn't resolved
+                // yet at that instant (offline, or just after a controller reconnect).
+                // Re-assert it here every reconcile so a missed target self-heals once
+                // the model is known. Only writes when currently enabled, so steady
+                // state is a no-op (no per-tick DB churn).
+                if (existing.AutoDiscovered && existing.Enabled
+                    && UniFi.UniFiProductDatabase.IsFlex25G(d.Model, d.Shortname))
+                {
+                    existing.Enabled = false;
+                    changed = true;
+                    _logger.LogInformation(
+                        "Disabled latency probing for Flex 2.5G target {Name} ({Mac})",
+                        existing.Name, existing.DeviceMac);
+                }
                 continue;
             }
 


### PR DESCRIPTION
## Incidents tab

- **Per-incident buttons relabeled** - The action buttons on each Incident card read "Acknowledge All" / "Resolve All" but only act on that single incident. Corrected to "Acknowledge" / "Resolve" to match the per-item buttons on Active Alerts.
- **Bulk Incident actions added** - New header on the Incidents tab with "Acknowledge All" (shown when any incident is active) and "Resolve All", so all open incidents can be cleared at once, mirroring the Active Alerts tab.

## Latency/loss monitoring

- **Flex 2.5G exclusion is now self-healing** - Flex 2.5G switches are disabled as latency/loss targets by default because they make poor ping targets. That was enforced only at target creation plus a one-time pass, which could miss an existing target if the device model hadn't resolved yet (device offline, or just after a controller reconnect). The exclusion is now re-asserted on each reconcile, so a missed target gets disabled automatically once the model is known. It only writes when a target is currently enabled, so steady state does no extra work. Manually added targets are left untouched.

## Dependencies

- **Scriban 7.2.0 -> 7.2.5** - Clears the NU1902 advisories (both fixed in 7.2.1).
