### PR TITLE
Module update banner + lighter MongoDB eMMC backups

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -62,6 +62,8 @@
             </div>
         </header>
 
+        <UpdateNotificationBanner />
+
         <main class="page-content">
             <article class="content">
                 @Body

--- a/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
@@ -3,6 +3,7 @@
 @inject UniFiConnectionService ConnectionService
 @inject IGatewaySshService GatewaySshService
 @inject PerfTweaksDeploymentService DeployService
+@inject ModuleUpdateNotificationService ModuleUpdates
 @inject ILogger<PerformanceTweaks> Logger
 @inject PullToRefreshState PtrState
 @rendermode InteractiveServer
@@ -1084,6 +1085,7 @@ ls -la /var/config/run-syslog.sh</code></pre>
 
             _status = await DeployService.CheckAllStatusAsync();
             _gatewayConnected = _status.Error == null;
+            if (_status.Error == null) ModuleUpdates.NotifyPerfTweaksStatus(_status);
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
@@ -158,6 +158,14 @@
                             </button>
                         </div>
                     }
+
+                    @if (OutdatedTweakTitles is { Count: > 0 } outdated)
+                    {
+                        <div class="alert alert-warning" style="margin-top: 1rem;">
+                            <strong>Update@(outdated.Count > 1 ? "s" : "") available:</strong>
+                            @(string.Join(", ", outdated)) @(outdated.Count > 1 ? "have" : "has") a newer version. Redeploy @(outdated.Count > 1 ? "them" : "it") below to update.
+                        </div>
+                    }
                 }
             </div>
         </div>
@@ -981,6 +989,13 @@ ls -la /var/config/run-syslog.sh</code></pre>
     private readonly Dictionary<string, DateTime> _sfpDeployTimes = new();
     private bool _allConfirmed => _confirmBackup && _confirmBackupDownloaded && _confirmWarranty && _confirmRisk;
     private bool _canDeploy => _status?.UdmBootInstalled == true && _status?.FirmwareSupported == true;
+
+    // Titles of compatible tweaks whose deployed boot script is out of date.
+    private List<string> OutdatedTweakTitles => _tweakDefs
+        .Where(d => d.IsCompatibleWith(_status?.GatewayModel)
+                    && _status?.Tweaks.GetValueOrDefault(d.Id)?.ScriptOutdated == true)
+        .Select(d => d.Title)
+        .ToList();
     private List<string> _deploySteps = new();
     private PerfTweaksStatus? _status;
 

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSteering.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSteering.razor
@@ -7,6 +7,7 @@
 @inject ILogger<WanSteering> Logger
 @inject PullToRefreshState PtrState
 @inject SqmDeploymentService SqmDeploymentService
+@inject ModuleUpdateNotificationService ModuleUpdates
 @rendermode InteractiveServer
 @using NetworkOptimizer.Storage.Models
 @using NetworkOptimizer.Web.Services.Ssh
@@ -97,7 +98,7 @@
                         }
                     </div>
                 </div>
-                @if (_deployedAt.HasValue && (DateTime.UtcNow - _deployedAt.Value).TotalSeconds < 45)
+                @if (_deployedAt.HasValue && (DateTime.UtcNow - _deployedAt.Value).TotalSeconds < VersionWarningGraceSeconds)
                 {
                     <div class="metric">
                         <div class="metric-label">Version</div>
@@ -543,6 +544,9 @@
     private ParsedDaemonStatus? _parsedStatus;
     private bool _showVersionWarning;
     private DateTime? _deployedAt;
+    // Briefly suppress the version warning right after a deploy to bridge the daemon restart +
+    // next status poll. The check reads the new binary's -version directly, so this can be short.
+    private const int VersionWarningGraceSeconds = 15;
 
     // Rule editing
     private int? _editingRuleId; // null = not editing, 0 = adding new, >0 = editing existing
@@ -618,6 +622,7 @@
             if (_gatewayConfigured)
             {
                 _status = await DeployService.GetStatusAsync();
+                if (_status.BinaryDeployed) ModuleUpdates.NotifyWanSteerStatus(_status);
                 ParseStatusJson();
             }
             else
@@ -645,6 +650,7 @@
         try
         {
             _status = await DeployService.GetStatusAsync();
+            if (_status.BinaryDeployed) ModuleUpdates.NotifyWanSteerStatus(_status);
             ParseStatusJson();
         }
         catch (Exception ex)
@@ -913,8 +919,9 @@
             {
                 _hasUndeployedChanges = false;
                 _showVersionWarning = false;
-                // Suppress version check until the new binary has time to start
-                // and write its status file (startup grace period is ~30s).
+                // Briefly suppress the version warning so it doesn't flash "outdated" between the
+                // deploy completing and the next status poll. The new binary's -version is readable
+                // immediately, so the grace is short (VersionWarningGraceSeconds).
                 _deployedAt = DateTime.UtcNow;
             }
 
@@ -1177,7 +1184,7 @@
 
         // After a deploy, suppress for 45s so a stale read can't briefly flash a warning before
         // the freshly deployed binary is in place.
-        if (_deployedAt.HasValue && (DateTime.UtcNow - _deployedAt.Value).TotalSeconds < 45)
+        if (_deployedAt.HasValue && (DateTime.UtcNow - _deployedAt.Value).TotalSeconds < VersionWarningGraceSeconds)
             return;
 
         // Advisory only - the Deploy/Redeploy buttons are never gated on this. The service returns

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSteering.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSteering.razor
@@ -544,9 +544,10 @@
     private ParsedDaemonStatus? _parsedStatus;
     private bool _showVersionWarning;
     private DateTime? _deployedAt;
-    // Briefly suppress the version warning right after a deploy to bridge the daemon restart +
-    // next status poll. The check reads the new binary's -version directly, so this can be short.
-    private const int VersionWarningGraceSeconds = 15;
+    // Suppress the version warning/display after a deploy until the restarted daemon rewrites its
+    // status file (the shown version reads that file). The daemon rewrites on its ~30s reconcile
+    // interval, so the grace must exceed it.
+    private const int VersionWarningGraceSeconds = 45;
 
     // Rule editing
     private int? _editingRuleId; // null = not editing, 0 = adding new, >0 = editing existing
@@ -919,9 +920,8 @@
             {
                 _hasUndeployedChanges = false;
                 _showVersionWarning = false;
-                // Briefly suppress the version warning so it doesn't flash "outdated" between the
-                // deploy completing and the next status poll. The new binary's -version is readable
-                // immediately, so the grace is short (VersionWarningGraceSeconds).
+                // Suppress until the restarted daemon rewrites its status file (~30s reconcile
+                // interval); the shown version reads that file. See VersionWarningGraceSeconds.
                 _deployedAt = DateTime.UtcNow;
             }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSteering.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSteering.razor
@@ -98,18 +98,11 @@
                         }
                     </div>
                 </div>
-                @if (_deployedAt.HasValue && (DateTime.UtcNow - _deployedAt.Value).TotalSeconds < VersionWarningGraceSeconds)
+                @if (!string.IsNullOrEmpty(_status.Version))
                 {
                     <div class="metric">
                         <div class="metric-label">Version</div>
-                        <div class="metric-value"><span class="spinner spinner-sm"></span></div>
-                    </div>
-                }
-                else if (_parsedStatus != null && !string.IsNullOrEmpty(_parsedStatus.Version))
-                {
-                    <div class="metric">
-                        <div class="metric-label">Version</div>
-                        <div class="metric-value">@_parsedStatus.Version</div>
+                        <div class="metric-value">@_status.Version</div>
                     </div>
                 }
                 <div class="metric">
@@ -543,11 +536,6 @@
     private WanSteerStatus? _status;
     private ParsedDaemonStatus? _parsedStatus;
     private bool _showVersionWarning;
-    private DateTime? _deployedAt;
-    // Suppress the version warning/display after a deploy until the restarted daemon rewrites its
-    // status file (the shown version reads that file). The daemon rewrites on its ~30s reconcile
-    // interval, so the grace must exceed it.
-    private const int VersionWarningGraceSeconds = 45;
 
     // Rule editing
     private int? _editingRuleId; // null = not editing, 0 = adding new, >0 = editing existing
@@ -919,10 +907,6 @@
             if (success)
             {
                 _hasUndeployedChanges = false;
-                _showVersionWarning = false;
-                // Suppress until the restarted daemon rewrites its status file (~30s reconcile
-                // interval); the shown version reads that file. See VersionWarningGraceSeconds.
-                _deployedAt = DateTime.UtcNow;
             }
 
             await RefreshStatusQuietAsync();
@@ -1180,15 +1164,9 @@
 
     private void CheckBinaryVersion()
     {
-        _showVersionWarning = false;
-
-        // After a deploy, suppress for 45s so a stale read can't briefly flash a warning before
-        // the freshly deployed binary is in place.
-        if (_deployedAt.HasValue && (DateTime.UtcNow - _deployedAt.Value).TotalSeconds < VersionWarningGraceSeconds)
-            return;
-
         // Advisory only - the Deploy/Redeploy buttons are never gated on this. The service returns
-        // false before anything is deployed, so a first deploy is never flagged or blocked.
+        // false before anything is deployed, so a first deploy is never flagged or blocked. The
+        // check reads the binary's -version directly, so it is correct immediately after a deploy.
         _showVersionWarning = WanSteerDeploymentService.IsBinaryOutdated(_status);
     }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/UpdateChecker.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpdateChecker.razor
@@ -5,7 +5,11 @@
 {
     <div class="connection-banner" style="background: linear-gradient(135deg, #12261d 0%, #0c1a14 100%); border-color: #1e3d2e;">
         <div class="banner-content">
-            <span class="banner-icon" style="background: #24bc70; color: white;">⬆</span>
+            <span class="banner-icon" style="background: #24bc70; color: white;">
+                <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="white">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 10.5 12 3m0 0 7.5 7.5M12 3v18" />
+                </svg>
+            </span>
             <div class="banner-text">
                 <strong style="color: #4ade80;">Update Available: v@(latestVersion)</strong>
                 <span style="color: #86b89a;">A new version of Network Optimizer is available.</span>

--- a/src/NetworkOptimizer.Web/Components/Shared/UpdateNotificationBanner.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpdateNotificationBanner.razor
@@ -6,18 +6,22 @@
 {
     <div class="connection-banner">
         <div class="banner-content">
-            <span class="banner-icon banner-icon-warning">⬆</span>
+            <span class="banner-icon">
+                <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="white">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 10.5 12 3m0 0 7.5 7.5M12 3v18" />
+                </svg>
+            </span>
             <div class="banner-text">
                 <strong>Module updates available</strong>
                 <span>@Message</span>
             </div>
             @if (Updates.PerfTweaksUpdateAvailable)
             {
-                <a href="/perf-tweaks" class="btn btn-outline-light">Performance Tweaks</a>
+                <a href="/perf-tweaks" class="btn btn-secondary">Performance Tweaks</a>
             }
             @if (Updates.WanSteerUpdateAvailable)
             {
-                <a href="/wan-steering" class="btn btn-outline-light">WAN Steering</a>
+                <a href="/wan-steering" class="btn btn-secondary">WAN Steering</a>
             }
         </div>
     </div>

--- a/src/NetworkOptimizer.Web/Components/Shared/UpdateNotificationBanner.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpdateNotificationBanner.razor
@@ -1,0 +1,54 @@
+@using NetworkOptimizer.Web.Services
+@implements IDisposable
+@inject ModuleUpdateNotificationService Updates
+
+@if (Updates.AnyUpdateAvailable)
+{
+    <div class="connection-banner">
+        <div class="banner-content">
+            <span class="banner-icon banner-icon-warning">⬆</span>
+            <div class="banner-text">
+                <strong>Module updates available</strong>
+                <span>@Message</span>
+            </div>
+            @if (Updates.PerfTweaksUpdateAvailable)
+            {
+                <a href="/perf-tweaks" class="btn btn-outline-light">Performance Tweaks</a>
+            }
+            @if (Updates.WanSteerUpdateAvailable)
+            {
+                <a href="/wan-steering" class="btn btn-outline-light">WAN Steering</a>
+            }
+        </div>
+    </div>
+}
+
+@code {
+    private string Message
+    {
+        get
+        {
+            if (Updates.PerfTweaksUpdateAvailable && Updates.WanSteerUpdateAvailable)
+                return "Performance Tweaks and WAN Steering have updates ready - redeploy to pick up the latest.";
+            if (Updates.PerfTweaksUpdateAvailable)
+                return "Your Performance Tweaks are out of date - redeploy to pick up the latest.";
+            return "Your WAN Steering binary is out of date - redeploy to pick up the latest.";
+        }
+    }
+
+    protected override void OnInitialized()
+    {
+        Updates.OnStateChanged += HandleStateChanged;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        // Triggers the once-per-startup check; no-ops if already computed or not yet connected.
+        if (firstRender)
+            await Updates.ComputeOnceAsync();
+    }
+
+    private void HandleStateChanged() => _ = InvokeAsync(StateHasChanged);
+
+    public void Dispose() => Updates.OnStateChanged -= HandleStateChanged;
+}

--- a/src/NetworkOptimizer.Web/Components/Shared/UpdateNotificationBanner.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpdateNotificationBanner.razor
@@ -4,10 +4,10 @@
 
 @if (Updates.AnyUpdateAvailable)
 {
-    <div class="connection-banner">
+    <div class="connection-banner module-update-banner">
         <div class="banner-content">
             <span class="banner-icon">
-                <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="white">
+                <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 10.5 12 3m0 0 7.5 7.5M12 3v18" />
                 </svg>
             </span>
@@ -17,11 +17,11 @@
             </div>
             @if (Updates.PerfTweaksUpdateAvailable)
             {
-                <a href="/perf-tweaks" class="btn btn-secondary">Performance Tweaks</a>
+                <a href="/perf-tweaks" class="btn">Performance Tweaks</a>
             }
             @if (Updates.WanSteerUpdateAvailable)
             {
-                <a href="/wan-steering" class="btn btn-secondary">WAN Steering</a>
+                <a href="/wan-steering" class="btn">WAN Steering</a>
             }
         </div>
     </div>

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -416,6 +416,7 @@ builder.Services.AddScoped<ISqmService, SqmService>();
 builder.Services.AddScoped<SqmDeploymentService>();
 builder.Services.AddScoped<WanSteerDeploymentService>();
 builder.Services.AddScoped<PerfTweaksDeploymentService>();
+builder.Services.AddSingleton<ModuleUpdateNotificationService>(); // caches module update state, computed once per startup post-connect
 builder.Services.AddScoped<MonitoringInterfaceDeploymentService>();
 builder.Services.AddScoped<AgentService>();
 

--- a/src/NetworkOptimizer.Web/Resources/PerfTweaks/07-mongodb-ssd-backup.sh
+++ b/src/NetworkOptimizer.Web/Resources/PerfTweaks/07-mongodb-ssd-backup.sh
@@ -1,16 +1,22 @@
 #!/bin/bash
-# 07-mongodb-ssd-backup.sh: MongoDB backup to SSD, with optional weekly eMMC sync
+# 07-mongodb-ssd-backup.sh: MongoDB backup to SSD, with weekly compressed eMMC failover archive
 #
 # Companion to 06-mongodb-ssd-offload.sh. Installs a cron that runs:
 #  - Daily at 1:30am: mongodump to SSD only (fast, zero eMMC impact)
-#  - Weekly (Sunday 1:35am): mongodump to SSD + copy to eMMC as failover
+#  - Weekly (Sunday 1:35am): mongodump to SSD + a compressed archive to eMMC
 #
-# The eMMC copy is a safety net - if the SSD mount breaks or after a firmware
-# upgrade, MongoDB can start from eMMC without needing mongorestore.
+# The eMMC archive is off-SSD insurance: the daily backups live on the SSD, so
+# if the SSD itself dies this is a recent copy to hand-restore from with
+#   mongorestore --gzip --archive=/data/unifi/data/db-backup/unifi-db.archive.gz
+# It is a mongodump archive, NOT a live database: it is not auto-loaded and is
+# not the boot fallback. Zero-touch boot recovery is handled by 06, which on
+# SSD loss leaves MongoDB on the stock eMMC data directory for mongod to open
+# directly. Stored gzip-compressed (~12x smaller than a raw dump) to keep eMMC
+# overlay usage minimal.
 #
 # Can also be run manually:
 #   backup.sh           # SSD-only mongodump
-#   backup.sh --emmc    # SSD mongodump + copy to eMMC
+#   backup.sh --emmc    # SSD mongodump + compressed eMMC archive
 #
 # Requires: 06-mongodb-ssd-offload.sh deployed first.
 
@@ -127,15 +133,24 @@ fi
 SSD_SIZE=$(du -sh "$SSD_BACKUP" | cut -f1)
 log "mongodump complete: $SSD_SIZE on SSD"
 
-# Step 2: optional eMMC sync (weekly failover copy)
+# Step 2: optional eMMC failover archive (weekly, off-SSD insurance)
+# A compressed mongodump archive (~12x smaller than a raw dump dir), restorable
+# with: mongorestore --gzip --archive=<file>. This is NOT a live DB and is not
+# auto-loaded; zero-touch boot recovery is handled by 06 via the stock eMMC
+# data directory, not this file.
 if [ "$1" = "--emmc" ]; then
+    EMMC_ARCHIVE="$EMMC_BACKUP/unifi-db.archive.gz"
     mkdir -p "$EMMC_BACKUP"
-    log "Copying to eMMC (weekly failover sync)..."
-    if ! cp -a "$SSD_BACKUP"/* "$EMMC_BACKUP/"; then
-        log "ERROR: eMMC copy failed"
+    # Reclaim space from legacy uncompressed dump dirs left by older versions
+    find "$EMMC_BACKUP" -mindepth 1 -maxdepth 1 ! -name "unifi-db.archive.gz" -exec rm -rf {} +
+    log "Writing compressed eMMC failover archive..."
+    if ! mongodump --port 27117 --gzip --archive="$EMMC_ARCHIVE.tmp" --quiet 2>&1; then
+        log "ERROR: eMMC archive dump failed"
+        rm -f "$EMMC_ARCHIVE.tmp"
         exit 1
     fi
-    log "eMMC sync complete"
+    mv -f "$EMMC_ARCHIVE.tmp" "$EMMC_ARCHIVE"
+    log "eMMC failover archive complete: $(du -sh "$EMMC_ARCHIVE" | cut -f1)"
 fi
 SCRIPT_EOF
 chmod +x "$BACKUP_SCRIPT"

--- a/src/NetworkOptimizer.Web/Resources/PerfTweaks/07-mongodb-ssd-backup.sh
+++ b/src/NetworkOptimizer.Web/Resources/PerfTweaks/07-mongodb-ssd-backup.sh
@@ -80,6 +80,33 @@ fi
 SSD_BACKUP="$SSD_MOUNT/$SSD_BACKUP_SUBDIR"
 log "SSD mount: $SSD_MOUNT"
 
+# ─── One-time: compress a legacy uncompressed eMMC backup in place ───
+# Older versions left a raw mongodump dir at $EMMC_BACKUP (~hundreds of MB on
+# the overlay). If one is present, tar.gz it now and drop the raw dirs - so the
+# overlay space is reclaimed on this run instead of waiting for the next weekly
+# --emmc run. The temp tarball is written to a sibling path so tar does not
+# archive its own output.
+EMMC_ARCHIVE="$EMMC_BACKUP/unifi-db.tar.gz"
+if [ -d "$EMMC_BACKUP" ] && \
+   [ -n "$(find "$EMMC_BACKUP" -mindepth 1 -maxdepth 1 ! -name 'unifi-db.tar.gz' -print -quit 2>/dev/null)" ]; then
+    if [ -f "$EMMC_ARCHIVE" ]; then
+        # A current archive already exists; the raw entries are stale leftovers.
+        log "Removing stale uncompressed eMMC backup leftovers..."
+        find "$EMMC_BACKUP" -mindepth 1 -maxdepth 1 ! -name 'unifi-db.tar.gz' -exec rm -rf {} +
+    else
+        log "Found legacy uncompressed eMMC backup. Compressing in place (one-time)..."
+        TMP_TGZ="$EMMC_BACKUP.migrate.tar.gz"
+        if tar czf "$TMP_TGZ" -C "$EMMC_BACKUP" .; then
+            find "$EMMC_BACKUP" -mindepth 1 -maxdepth 1 ! -name 'unifi-db.tar.gz' -exec rm -rf {} +
+            mv -f "$TMP_TGZ" "$EMMC_ARCHIVE"
+            log "Legacy eMMC backup compressed: $(du -sh "$EMMC_ARCHIVE" | cut -f1)"
+        else
+            rm -f "$TMP_TGZ"
+            log "WARNING: legacy eMMC compression failed; leaving as-is"
+        fi
+    fi
+fi
+
 # ─── Install the backup script to /data (persists across reboots) ───
 mkdir -p "$(dirname "$BACKUP_SCRIPT")"
 cat > "$BACKUP_SCRIPT" << 'SCRIPT_EOF'

--- a/src/NetworkOptimizer.Web/Resources/PerfTweaks/07-mongodb-ssd-backup.sh
+++ b/src/NetworkOptimizer.Web/Resources/PerfTweaks/07-mongodb-ssd-backup.sh
@@ -6,13 +6,13 @@
 #  - Weekly (Sunday 1:35am): mongodump to SSD + a compressed archive to eMMC
 #
 # The eMMC archive is off-SSD insurance: the daily backups live on the SSD, so
-# if the SSD itself dies this is a recent copy to hand-restore from with
-#   mongorestore --gzip --archive=/data/unifi/data/db-backup/unifi-db.archive.gz
-# It is a mongodump archive, NOT a live database: it is not auto-loaded and is
-# not the boot fallback. Zero-touch boot recovery is handled by 06, which on
-# SSD loss leaves MongoDB on the stock eMMC data directory for mongod to open
-# directly. Stored gzip-compressed (~12x smaller than a raw dump) to keep eMMC
-# overlay usage minimal.
+# if the SSD itself dies this is a recent copy to hand-restore from (extract it,
+# then mongorestore the dump - see docs). It is a compressed mongodump, NOT a
+# live database: it is not auto-loaded and is not the boot fallback. Zero-touch
+# boot recovery is handled by 06, which on SSD loss leaves MongoDB on the stock
+# eMMC data directory for mongod to open directly. It is produced by compressing
+# the SSD dump with tar (no second mongodump, so it is light on RAM) and is ~12x
+# smaller than a raw dump, keeping eMMC writes and overlay usage minimal.
 #
 # Can also be run manually:
 #   backup.sh           # SSD-only mongodump
@@ -134,18 +134,19 @@ SSD_SIZE=$(du -sh "$SSD_BACKUP" | cut -f1)
 log "mongodump complete: $SSD_SIZE on SSD"
 
 # Step 2: optional eMMC failover archive (weekly, off-SSD insurance)
-# A compressed mongodump archive (~12x smaller than a raw dump dir), restorable
-# with: mongorestore --gzip --archive=<file>. This is NOT a live DB and is not
-# auto-loaded; zero-touch boot recovery is handled by 06 via the stock eMMC
-# data directory, not this file.
+# Compress the SSD dump we just made straight to eMMC. No second mongodump, so
+# this is light on RAM (tar|gzip streams) - the only compression cost, once a
+# week. ~12x smaller than the raw dump. Restore: extract, then mongorestore the
+# dump dir (see docs). This is NOT a live DB and is not auto-loaded; zero-touch
+# boot recovery is handled by 06 via the stock eMMC data directory, not this file.
 if [ "$1" = "--emmc" ]; then
-    EMMC_ARCHIVE="$EMMC_BACKUP/unifi-db.archive.gz"
+    EMMC_ARCHIVE="$EMMC_BACKUP/unifi-db.tar.gz"
     mkdir -p "$EMMC_BACKUP"
     # Reclaim space from legacy uncompressed dump dirs left by older versions
-    find "$EMMC_BACKUP" -mindepth 1 -maxdepth 1 ! -name "unifi-db.archive.gz" -exec rm -rf {} +
-    log "Writing compressed eMMC failover archive..."
-    if ! mongodump --port 27117 --gzip --archive="$EMMC_ARCHIVE.tmp" --quiet 2>&1; then
-        log "ERROR: eMMC archive dump failed"
+    find "$EMMC_BACKUP" -mindepth 1 -maxdepth 1 ! -name "unifi-db.tar.gz" -exec rm -rf {} +
+    log "Compressing SSD dump to eMMC failover archive..."
+    if ! tar czf "$EMMC_ARCHIVE.tmp" -C "$SSD_BACKUP" .; then
+        log "ERROR: eMMC archive failed"
         rm -f "$EMMC_ARCHIVE.tmp"
         exit 1
     fi

--- a/src/NetworkOptimizer.Web/Services/ModuleUpdateNotificationService.cs
+++ b/src/NetworkOptimizer.Web/Services/ModuleUpdateNotificationService.cs
@@ -1,0 +1,103 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Computes whether deployed modules (Performance Tweaks boot scripts, WAN Steering
+/// binary) are out of date versus the embedded copies, once per application startup
+/// after the UniFi Console connects, and caches the result. Backs the app-wide update
+/// banner so the SSH-bound status checks run sparingly rather than on every page load.
+/// </summary>
+public sealed class ModuleUpdateNotificationService : IDisposable
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly UniFiConnectionService _connection;
+    private readonly ILogger<ModuleUpdateNotificationService> _logger;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private bool _computed;
+
+    /// <summary>Raised when the cached update state changes so consumers can re-render.</summary>
+    public event Action? OnStateChanged;
+
+    /// <summary>True when one or more deployed Performance Tweaks boot scripts are out of date.</summary>
+    public bool PerfTweaksUpdateAvailable { get; private set; }
+
+    /// <summary>True when the deployed WAN Steering binary is older than the embedded version.</summary>
+    public bool WanSteerUpdateAvailable { get; private set; }
+
+    // TODO: Adaptive SQM update detection. SqmDeploymentService has no deployed-vs-embedded
+    // version/hash comparison yet. The SQM scripts have been stable, so we are deferring the
+    // versioning work to avoid opening that can of worms. Once SqmDeploymentService tracks a
+    // version, add an AdaptiveSqmUpdateAvailable check here and surface it in the banner
+    // alongside Performance Tweaks and WAN Steering.
+
+    /// <summary>True when any tracked module has an update available.</summary>
+    public bool AnyUpdateAvailable => PerfTweaksUpdateAvailable || WanSteerUpdateAvailable;
+
+    public ModuleUpdateNotificationService(
+        IServiceScopeFactory scopeFactory,
+        UniFiConnectionService connection,
+        ILogger<ModuleUpdateNotificationService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _connection = connection;
+        _logger = logger;
+        _connection.OnConnectionChanged += HandleConnectionChanged;
+        // If the Console is already connected when this singleton is first resolved,
+        // compute now; otherwise the connection event will trigger it.
+        if (_connection.IsConnected)
+            _ = ComputeOnceAsync();
+    }
+
+    private void HandleConnectionChanged()
+    {
+        if (_connection.IsConnected && !_computed)
+            _ = ComputeOnceAsync();
+    }
+
+    /// <summary>
+    /// Runs the update checks once per application lifetime, after the Console is
+    /// connected. No-ops if already computed or if the Console is not connected.
+    /// </summary>
+    public async Task ComputeOnceAsync()
+    {
+        if (_computed || !_connection.IsConnected)
+            return;
+
+        await _gate.WaitAsync();
+        try
+        {
+            if (_computed || !_connection.IsConnected)
+                return;
+
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var perf = scope.ServiceProvider.GetRequiredService<PerfTweaksDeploymentService>();
+            var wan = scope.ServiceProvider.GetRequiredService<WanSteerDeploymentService>();
+
+            var perfStatus = await perf.CheckAllStatusAsync();
+            PerfTweaksUpdateAvailable = perfStatus.Tweaks.Values.Any(t => t.ScriptOutdated);
+
+            var wanStatus = await wan.GetStatusAsync();
+            WanSteerUpdateAvailable = WanSteerDeploymentService.IsBinaryOutdated(wanStatus);
+
+            _computed = true;
+            OnStateChanged?.Invoke();
+        }
+        catch (Exception ex)
+        {
+            // Non-critical: leave _computed false so a later connection event retries.
+            _logger.LogDebug(ex, "Module update check failed; will retry on next Console connect.");
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public void Dispose()
+    {
+        _connection.OnConnectionChanged -= HandleConnectionChanged;
+        _gate.Dispose();
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/ModuleUpdateNotificationService.cs
+++ b/src/NetworkOptimizer.Web/Services/ModuleUpdateNotificationService.cs
@@ -95,6 +95,35 @@ public sealed class ModuleUpdateNotificationService : IDisposable
         }
     }
 
+    /// <summary>
+    /// Updates the cached Performance Tweaks state from a freshly fetched status (e.g. a page
+    /// refreshed after a deploy). Reuses the caller's status to avoid a redundant SSH round-trip
+    /// and notifies consumers only on an actual change, so the banner dismisses promptly once a
+    /// tweak is redeployed. Callers should pass a successfully-read status (Error == null).
+    /// </summary>
+    public void NotifyPerfTweaksStatus(PerfTweaksStatus status)
+    {
+        var available = status.Tweaks.Values.Any(t => t.ScriptOutdated);
+        if (available == PerfTweaksUpdateAvailable)
+            return;
+        PerfTweaksUpdateAvailable = available;
+        OnStateChanged?.Invoke();
+    }
+
+    /// <summary>
+    /// Updates the cached WAN Steering state from a freshly fetched status. See
+    /// <see cref="NotifyPerfTweaksStatus"/>. Callers should pass a status whose binary was
+    /// actually read (BinaryDeployed) so a transient SSH failure doesn't clear the banner.
+    /// </summary>
+    public void NotifyWanSteerStatus(WanSteerStatus status)
+    {
+        var available = WanSteerDeploymentService.IsBinaryOutdated(status);
+        if (available == WanSteerUpdateAvailable)
+            return;
+        WanSteerUpdateAvailable = available;
+        OnStateChanged?.Invoke();
+    }
+
     public void Dispose()
     {
         _connection.OnConnectionChanged -= HandleConnectionChanged;

--- a/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
@@ -30,6 +30,14 @@ public class PerfTweaksDeploymentService
         ["sfp-sgmiiplus"] = "20-sfp-sgmiiplus.sh"
     };
 
+    // Additional boot scripts a tweak deploys beyond its primary, for out-of-date
+    // detection. mongodb-ssd deploys 07 as a backup companion (see DeployTweakAsync),
+    // so a 07-only change must also flag the tweak as outdated.
+    private static readonly Dictionary<string, string[]> CompanionScripts = new()
+    {
+        ["mongodb-ssd"] = new[] { "07-mongodb-ssd-backup.sh" }
+    };
+
     private static readonly Lazy<Dictionary<string, string>> ExpectedHashes = new(() =>
     {
         var hashes = new Dictionary<string, string>();
@@ -355,16 +363,21 @@ public class PerfTweaksDeploymentService
             {
                 if (!tweak.BootScriptDeployed) continue;
 
-                var scriptName = BootScriptFiles.GetValueOrDefault(tweakId);
-                if (scriptName == null) continue;
+                var scriptNames = new List<string>();
+                if (BootScriptFiles.GetValueOrDefault(tweakId) is { } primary)
+                    scriptNames.Add(primary);
+                if (CompanionScripts.GetValueOrDefault(tweakId) is { } companions)
+                    scriptNames.AddRange(companions);
 
-                if (remoteHashes.TryGetValue(scriptName, out var remoteHash) &&
-                    ExpectedHashes.Value.TryGetValue(scriptName, out var expectedHash))
+                foreach (var scriptName in scriptNames)
                 {
-                    if (remoteHash != expectedHash)
+                    if (remoteHashes.TryGetValue(scriptName, out var remoteHash) &&
+                        ExpectedHashes.Value.TryGetValue(scriptName, out var expectedHash) &&
+                        remoteHash != expectedHash)
                     {
                         tweak.ScriptOutdated = true;
                         tweak.HealthChecks.Add(new("Boot Script", "Update available", HealthCheckStatus.Warning));
+                        break;
                     }
                 }
             }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -3898,6 +3898,27 @@ tr:hover .snmp-row-chevron {
     background: rgba(255, 255, 255, 0.9);
 }
 
+.connection-banner.module-update-banner {
+    background: var(--bg-tertiary);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.module-update-banner .banner-icon {
+    background: rgba(231, 150, 19, 0.15);
+    color: var(--warning-color);
+}
+
+.module-update-banner .btn {
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--text-primary);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.module-update-banner .btn:hover {
+    background: rgba(255, 255, 255, 0.12);
+    border-color: var(--text-secondary);
+}
+
 @media (max-width: 768px) {
     .connection-banner .banner-content {
         flex-wrap: wrap;


### PR DESCRIPTION
## Module update banner (#728)

An app-wide banner now prompts you to redeploy Performance Tweaks or WAN Steering when the gateway is running an older version than the app ships. It's computed once per app startup (after the Console connects) and cached, so it adds no SSH overhead on normal page loads, and it dismisses on its own once you redeploy the out-of-date module. The Performance Tweaks page also gains a small callout in its Deployment Status card listing exactly which tweaks are behind.

## Smaller MongoDB eMMC backups

The weekly MongoDB failover copy to eMMC is now a compressed archive (`unifi-db.tar.gz`) built by gzipping the SSD dump, instead of a raw uncompressed copy. That's roughly 12x smaller (e.g. ~40 MB vs ~450 MB), which matters because the writable overlay on UCG gateways is space-constrained. On deploy, any pre-existing uncompressed backup is compressed in place so the space is reclaimed immediately rather than at the next weekly run. The stock eMMC database (the zero-touch boot fallback) is never touched, and the only recurring compression is the existing weekly job.

## Fixes

- **Performance Tweaks out-of-date detection**: the MongoDB tweak deploys a companion backup script; a change to only that companion now correctly flags the tweak as out-of-date (previously only the primary script was checked).
- **WAN Steering version display**: the shown daemon version now reads from the binary directly, so it updates immediately after a redeploy instead of lagging while the daemon rewrites its status file.
- The app-version update banner uses an SVG icon instead of an emoji.
