### PR TITLE
Make adding multiple WAN/LAN speed tests discoverable

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -268,7 +268,7 @@
                     }
                 @if (!_editingWanScheduleId.HasValue)
                 {
-                    @WanScheduleForm
+                    <div id="wan-add-form">@WanScheduleForm</div>
                 }
             </div>
 
@@ -373,7 +373,7 @@
                 }
                 @if (_lanDeviceOptions.Count > 0 && !_editingLanScheduleId.HasValue)
                 {
-                    @LanScheduleForm
+                    <div id="lan-add-form">@LanScheduleForm</div>
                 }
                 else if (_lanDeviceOptions.Count == 0 && lanTasks.Count == 0)
                 {
@@ -2882,8 +2882,13 @@
         }
     }
 
-    // Exits any active edit so the add form at the bottom of the section is shown.
-    private void StartAddWanSchedule() => CancelEditWanSchedule();
+    // Exits any active edit so the add form at the bottom of the section is shown,
+    // then scrolls to it with a brief highlight (mirrors the Monitoring page pattern).
+    private async Task StartAddWanSchedule()
+    {
+        CancelEditWanSchedule();
+        await ScrollToAddFormAsync("wan-add-form");
+    }
 
     private void CancelEditWanSchedule()
     {
@@ -2987,8 +2992,31 @@
             : new TimeOnly(6, 0);
     }
 
-    // Exits any active edit so the add form at the bottom of the section is shown.
-    private void StartAddLanSchedule() => CancelEditLanSchedule();
+    // Exits any active edit so the add form at the bottom of the section is shown,
+    // then scrolls to it with a brief highlight (mirrors the Monitoring page pattern).
+    private async Task StartAddLanSchedule()
+    {
+        CancelEditLanSchedule();
+        await ScrollToAddFormAsync("lan-add-form");
+    }
+
+    // Scrolls to the add-schedule form and applies a brief outline highlight.
+    private async Task ScrollToAddFormAsync(string elementId)
+    {
+        await Task.Delay(300);
+        await JS.InvokeVoidAsync("eval", $@"
+            (function() {{
+                var el = document.getElementById('{elementId}');
+                if (el) {{
+                    el.scrollIntoView({{ behavior: 'smooth', block: 'center' }});
+                    el.style.transition = 'outline-color 0.3s';
+                    el.style.outline = '2px solid rgba(59, 130, 246, 0.5)';
+                    el.style.outlineOffset = '4px';
+                    el.style.borderRadius = '12px';
+                    setTimeout(function() {{ el.style.outline = ''; el.style.outlineOffset = ''; }}, 2000);
+                }}
+            }})();");
+    }
 
     private void CancelEditLanSchedule()
     {

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -165,7 +165,11 @@
             </div>
 
             <div class="schedule-section">
-                <h2 class="schedule-section-title">WAN Speed Tests</h2>
+                <div class="schedule-section-header">
+                    <h2 class="schedule-section-title">WAN Speed Tests</h2>
+                    <button class="btn btn-sm btn-primary" @onclick="StartAddWanSchedule">+ Add Test</button>
+                </div>
+                <p class="schedule-section-desc">Add a separate test for each WAN line - schedule as many as you like.</p>
                 @{ var wanTasks = _scheduledTasks.Where(t => t.TaskType == "wan_speedtest").ToList(); }
                 @foreach (var task in wanTasks)
                     {
@@ -269,7 +273,14 @@
             </div>
 
             <div class="schedule-section">
-                <h2 class="schedule-section-title">LAN Speed Tests</h2>
+                <div class="schedule-section-header">
+                    <h2 class="schedule-section-title">LAN Speed Tests</h2>
+                    @if (_lanDeviceOptions.Count > 0)
+                    {
+                        <button class="btn btn-sm btn-primary" @onclick="StartAddLanSchedule">+ Add Test</button>
+                    }
+                </div>
+                <p class="schedule-section-desc">Add a separate test for each device - schedule as many as you like.</p>
                 @{ var lanTasks = _scheduledTasks.Where(t => t.TaskType == "lan_speedtest").ToList(); }
                 @foreach (var task in lanTasks)
                 {
@@ -1236,6 +1247,28 @@
         margin-bottom: 0.75rem;
         padding-bottom: 0.5rem;
         border-bottom: 1px solid var(--border-color);
+    }
+
+    .schedule-section-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 0.75rem;
+        margin-bottom: 0.5rem;
+        padding-bottom: 0.5rem;
+        border-bottom: 1px solid var(--border-color);
+    }
+
+    .schedule-section-header .schedule-section-title {
+        margin-bottom: 0;
+        padding-bottom: 0;
+        border-bottom: none;
+    }
+
+    .schedule-section-desc {
+        font-size: 0.8125rem;
+        color: var(--text-secondary);
+        margin: 0 0 0.75rem;
     }
     .schedule-card {
         background: var(--bg-card);
@@ -2849,6 +2882,9 @@
         }
     }
 
+    // Exits any active edit so the add form at the bottom of the section is shown.
+    private void StartAddWanSchedule() => CancelEditWanSchedule();
+
     private void CancelEditWanSchedule()
     {
         _editingWanScheduleId = null;
@@ -2950,6 +2986,9 @@
             ? UtcToLocalTimeOnly(task.CustomMorningHour.Value, task.CustomMorningMinute ?? 0)
             : new TimeOnly(6, 0);
     }
+
+    // Exits any active edit so the add form at the bottom of the section is shown.
+    private void StartAddLanSchedule() => CancelEditLanSchedule();
 
     private void CancelEditLanSchedule()
     {


### PR DESCRIPTION
## What

Adds an always-visible **+ Add Test** button to the WAN Speed Tests and LAN Speed Tests section headers on the Alerts page, plus a one-line subtitle under each heading noting that multiple tests are supported.

## Why

Scheduling a second speed test was effectively hidden. The add form and the edit form are the same control, and the add form only appears when nothing is being edited. If a user's single existing test was in edit mode, there was no visible way to create another one - the only escape was to Cancel the edit, which isn't signposted anywhere. Users reasonably concluded only one test could be scheduled (#906).

The new button exits any active edit and brings the add form back, so there's never a dead-end. It mirrors the existing "Add Rule" button pattern already used on the same page, and the subtitle sets the expectation up front ("schedule as many as you like").

## Notes

- LAN button only shows when devices are available to test.
- WAN and LAN sections both get the button and subtitle.

Closes #906
