### PR TITLE
Wi-Fi Optimizer: real mesh operating width + Re-pair Uplink action

### DIFF
--- a/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
@@ -1019,6 +1019,15 @@ public class RadioTableStats
     public int? Channel { get; set; }
 
     /// <summary>
+    /// Operating channel width in MHz (the width the radio is actually running at right now).
+    /// Distinct from radio_table's configured "ht" - a mesh backhaul radio can be configured
+    /// for 160 MHz but negotiate down to the parent's width (e.g. 80 MHz) on the link.
+    /// </summary>
+    [JsonPropertyName("bw")]
+    [JsonConverter(typeof(FlexibleIntConverter))]
+    public int? Bw { get; set; }
+
+    /// <summary>
     /// Extension channel for 40MHz+ widths
     /// </summary>
     [JsonPropertyName("extchannel")]

--- a/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
@@ -90,6 +90,11 @@ public class UniFiDiscovery
                 UplinkTxRateKbps = d.Uplink?.TxRate ?? 0,
                 UplinkRxRateKbps = d.Uplink?.RxRate ?? 0,
                 UplinkType = d.Uplink?.Type,
+                // Active uplink interface name. For a wireless mesh child this is the
+                // wpa_supplicant STA backhaul iface (e.g. "vwiresta7"); for wired APs/gateways
+                // it's the wired/WAN iface. Callers must validate the "vwiresta" prefix before
+                // treating it as a mesh backhaul interface.
+                UplinkInterface = d.Uplink?.Name,
                 UplinkRadioBand = d.Uplink?.RadioBand,
                 UplinkChannel = d.Uplink?.Channel,
                 UplinkSignalDbm = d.Uplink?.Signal,
@@ -725,6 +730,12 @@ public class DiscoveredDevice
     /// <summary>RX rate in Kbps for wireless uplinks</summary>
     public long UplinkRxRateKbps { get; set; }
     public string? UplinkType { get; set; }  // "wire" or "wireless"
+    /// <summary>
+    /// Active uplink interface name (uplink.name). For a wireless mesh child this is the
+    /// wpa_supplicant STA backhaul iface (e.g. "vwiresta7"); for wired APs/gateways it's the
+    /// wired/WAN iface. Validate the "vwiresta" prefix before using as a mesh backhaul iface.
+    /// </summary>
+    public string? UplinkInterface { get; set; }
     public string? UplinkRadioBand { get; set; }  // "ng" (2.4GHz), "na" (5GHz), "6e" (6GHz)
     public int? UplinkChannel { get; set; }
     public int? UplinkSignalDbm { get; set; }

--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -593,7 +593,7 @@
                                         <span class="ap-status-text">@(ap.IsOnline ? "Online" : "Offline")</span>
                                     </div>
                                 </div>
-                                <div class="ap-stats">
+                                <div class="ap-stats @(ap.IsMeshChild ? "ap-stats-mesh" : "")">
                                     <div class="ap-stat clickable" @onclick="@(() => NavigateToTab("client", ap.Mac))" @onclick:stopPropagation="true">
                                         <span class="ap-stat-value">@ap.TotalClients</span>
                                         <span class="ap-stat-label">Clients</span>

--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -610,12 +610,12 @@
                                                     @if (_optimizingMacs.Contains(ap.Mac))
                                                     {
                                                         <span class="spinner-sm"></span>
-                                                        <span>Scanning...</span>
+                                                        <span>Re-pairing...</span>
                                                     }
                                                     else
                                                     {
                                                         <span class="optimize-mesh-icon">&#x21bb;</span>
-                                                        <span>Re-scan Uplink</span>
+                                                        <span>Re-pair Uplink</span>
                                                     }
                                                 </button>
                                             }

--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -11,6 +11,7 @@
 @inject UniFiConnectionService ConnectionService
 @inject NavigationManager NavigationManager
 @inject ApMapService ApMapService
+@inject MeshOptimizationService MeshService
 @inject PullToRefreshState PtrState
 @implements IDisposable
 @rendermode InteractiveServer
@@ -42,6 +43,11 @@
             <a href="/settings" class="btn btn-primary">@(!string.IsNullOrEmpty(ConnectionService.LastError) ? "Check Settings" : "Connect Now")</a>
         </div>
     </div>
+}
+
+@if (!string.IsNullOrEmpty(_toastMessage))
+{
+    <div class="wifi-toast alert @_toastClass">@_toastMessage</div>
 }
 
 @if (ConnectionService.IsConnected)
@@ -586,6 +592,24 @@
                                         <span class="status-dot @(ap.IsOnline ? "online" : "offline")"></span>
                                         <span class="ap-status-text">@(ap.IsOnline ? "Online" : "Offline")</span>
                                     </div>
+                                    @if (ap.IsMeshChild && !string.IsNullOrEmpty(ap.MeshUplinkInterface))
+                                    {
+                                        <button class="btn btn-sm btn-outline-primary optimize-mesh-btn"
+                                                @onclick="@(() => OptimizeMeshAsync(ap))"
+                                                disabled="@(!ap.IsOnline || _optimizingMacs.Contains(ap.Mac))"
+                                                data-tooltip="Runs a Wi-Fi scan that nudges this AP onto the strongest available mesh parent (or the one you've pinned in UniFi Network) when it's stuck on a weaker uplink. Safe to re-run.">
+                                            @if (_optimizingMacs.Contains(ap.Mac))
+                                            {
+                                                <span class="spinner-sm"></span>
+                                                <span>Optimizing...</span>
+                                            }
+                                            else
+                                            {
+                                                <span class="optimize-mesh-icon">&#x21bb;</span>
+                                                <span>Optimize Mesh</span>
+                                            }
+                                        </button>
+                                    }
                                 </div>
                                 <div class="ap-stats">
                                     <div class="ap-stat clickable" @onclick="@(() => NavigateToTab("client", ap.Mac))" @onclick:stopPropagation="true">
@@ -875,6 +899,11 @@
     private List<ApMapMarker> _apMapMarkers = new();
     private System.Threading.Timer? _mapPollTimer;
 
+    // MACs of mesh children with an in-flight Optimize Mesh action (drives the per-card spinner).
+    private readonly HashSet<string> _optimizingMacs = new();
+    private string? _toastMessage;
+    private string _toastClass = "alert-info";
+
     // Auto-refresh the Overview tab once the health score has aged past this, so a parked
     // tab doesn't show indefinitely stale data. Checked on each map-poll tick.
     private static readonly TimeSpan HealthScoreStaleAfter = TimeSpan.FromMinutes(1);
@@ -1031,6 +1060,52 @@
         // Channel recommendations run the full engine; compute in the background so they don't
         // delay the overview paint. The card shows its own loading state until ready.
         _ = LoadChannelRecommendationsAsync();
+    }
+
+    private async Task OptimizeMeshAsync(AccessPointSnapshot ap)
+    {
+        if (_optimizingMacs.Contains(ap.Mac)) return;
+
+        _optimizingMacs.Add(ap.Mac);
+        StateHasChanged();
+
+        try
+        {
+            var result = await MeshService.OptimizeAsync(ap.Ip, ap.MeshUplinkInterface, ap.Name);
+            ShowToast(result.Message, result.Ok ? "alert-success" : "alert-warning");
+
+            // The action already waited for the backhaul to settle; pull the AP list once so the
+            // card reflects the new parent now rather than waiting for the ~1 min auto-refresh.
+            _accessPoints = await WiFiService.GetAccessPointsAsync(forceRefresh: true);
+        }
+        catch
+        {
+            // The service logs the detail; surface a friendly message to the user.
+            ShowToast("Couldn't optimize the mesh uplink. Check the AP's SSH connection.", "alert-warning");
+        }
+        finally
+        {
+            _optimizingMacs.Remove(ap.Mac);
+            StateHasChanged();
+        }
+    }
+
+    private void ShowToast(string message, string cssClass)
+    {
+        _toastMessage = message;
+        _toastClass = cssClass;
+        StateHasChanged();
+
+        // Auto-dismiss after a few seconds without blocking.
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(TimeSpan.FromSeconds(6));
+            await InvokeAsync(() =>
+            {
+                _toastMessage = null;
+                StateHasChanged();
+            });
+        });
     }
 
     private async Task RefreshData()

--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -1085,7 +1085,7 @@
             // Only warn about the data lag when it actually roamed - there's nothing to wait for
             // on a noop or a failure.
             var note = result.Action == "moved"
-                ? "It may take a minute for the AP data to reflect the new parent."
+                ? "It may take a minute for the AP data to update."
                 : null;
             ShowToast(result.Message, result.Ok ? "alert-success" : "alert-warning", note);
 

--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -600,10 +600,10 @@
                                     </div>
                                     @if (ap.IsMeshChild && (ap.MeshUplinkSignalDbm.HasValue || !string.IsNullOrEmpty(ap.MeshUplinkInterface)))
                                     {
-                                        <div class="ap-mesh-info">
+                                        <div class="ap-mesh-info @(!string.IsNullOrEmpty(ap.MeshUplinkInterface) ? "ap-mesh-info-with-action" : "")">
                                             @if (!string.IsNullOrEmpty(ap.MeshUplinkInterface))
                                             {
-                                                <button class="btn btn-sm btn-secondary optimize-mesh-btn"
+                                                <button class="btn btn-sm btn-primary optimize-mesh-btn"
                                                         @onclick="@(() => OptimizeMeshAsync(ap))"
                                                         disabled="@(!ap.IsOnline || _optimizingMacs.Contains(ap.Mac))"
                                                         data-tooltip="Runs a Wi-Fi scan that nudges this AP onto the strongest available mesh parent (or the one you've pinned in UniFi Network) when it's stuck on a weaker uplink. Safe to re-run.">

--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -592,50 +592,53 @@
                                         <span class="status-dot @(ap.IsOnline ? "online" : "offline")"></span>
                                         <span class="ap-status-text">@(ap.IsOnline ? "Online" : "Offline")</span>
                                     </div>
-                                    @if (ap.IsMeshChild && !string.IsNullOrEmpty(ap.MeshUplinkInterface))
-                                    {
-                                        <button class="btn btn-sm btn-outline-primary optimize-mesh-btn"
-                                                @onclick="@(() => OptimizeMeshAsync(ap))"
-                                                disabled="@(!ap.IsOnline || _optimizingMacs.Contains(ap.Mac))"
-                                                data-tooltip="Runs a Wi-Fi scan that nudges this AP onto the strongest available mesh parent (or the one you've pinned in UniFi Network) when it's stuck on a weaker uplink. Safe to re-run.">
-                                            @if (_optimizingMacs.Contains(ap.Mac))
-                                            {
-                                                <span class="spinner-sm"></span>
-                                                <span>Optimizing...</span>
-                                            }
-                                            else
-                                            {
-                                                <span class="optimize-mesh-icon">&#x21bb;</span>
-                                                <span>Optimize Mesh</span>
-                                            }
-                                        </button>
-                                    }
                                 </div>
                                 <div class="ap-stats">
                                     <div class="ap-stat clickable" @onclick="@(() => NavigateToTab("client", ap.Mac))" @onclick:stopPropagation="true">
                                         <span class="ap-stat-value">@ap.TotalClients</span>
                                         <span class="ap-stat-label">Clients</span>
                                     </div>
-                                    @if (ap.IsMeshChild && ap.MeshUplinkSignalDbm.HasValue)
+                                    @if (ap.IsMeshChild && (ap.MeshUplinkSignalDbm.HasValue || !string.IsNullOrEmpty(ap.MeshUplinkInterface)))
                                     {
                                         <div class="ap-mesh-info">
-                                            <div class="mesh-signal">
-                                                <span class="mesh-signal-value"><span class="@SignalClassification.GetSignalClass(ap.MeshUplinkSignalDbm.Value, ap.MeshUplinkBand ?? RadioBand.Band5GHz)">@ap.MeshUplinkSignalDbm</span> <span class="mesh-unit">dBm</span></span>
-                                                @if (ap.MeshUplinkTxRateMbps.HasValue || ap.MeshUplinkRxRateMbps.HasValue)
-                                                {
-                                                    <span class="mesh-rates">
-                                                        @if (ap.MeshUplinkTxRateMbps.HasValue)
-                                                        {
-                                                            <span class="mesh-rate wifi-speed-tx">TX @ap.MeshUplinkTxRateMbps</span>
-                                                        }
-                                                        @if (ap.MeshUplinkRxRateMbps.HasValue)
-                                                        {
-                                                            <span class="mesh-rate wifi-speed-rx">RX @ap.MeshUplinkRxRateMbps</span>
-                                                        }
-                                                    </span>
-                                                }
-                                            </div>
-                                            <span class="ap-stat-label"><strong>Mesh Uplink</strong>@(ap.MeshParentName != null ? $" to {ap.MeshParentName}" : "")</span>
+                                            @if (!string.IsNullOrEmpty(ap.MeshUplinkInterface))
+                                            {
+                                                <button class="btn btn-sm btn-secondary optimize-mesh-btn"
+                                                        @onclick="@(() => OptimizeMeshAsync(ap))"
+                                                        disabled="@(!ap.IsOnline || _optimizingMacs.Contains(ap.Mac))"
+                                                        data-tooltip="Runs a Wi-Fi scan that nudges this AP onto the strongest available mesh parent (or the one you've pinned in UniFi Network) when it's stuck on a weaker uplink. Safe to re-run.">
+                                                    @if (_optimizingMacs.Contains(ap.Mac))
+                                                    {
+                                                        <span class="spinner-sm"></span>
+                                                        <span>Optimizing...</span>
+                                                    }
+                                                    else
+                                                    {
+                                                        <span class="optimize-mesh-icon">&#x21bb;</span>
+                                                        <span>Optimize Mesh</span>
+                                                    }
+                                                </button>
+                                            }
+                                            @if (ap.MeshUplinkSignalDbm.HasValue)
+                                            {
+                                                <div class="mesh-signal">
+                                                    <span class="mesh-signal-value"><span class="@SignalClassification.GetSignalClass(ap.MeshUplinkSignalDbm.Value, ap.MeshUplinkBand ?? RadioBand.Band5GHz)">@ap.MeshUplinkSignalDbm</span> <span class="mesh-unit">dBm</span></span>
+                                                    @if (ap.MeshUplinkTxRateMbps.HasValue || ap.MeshUplinkRxRateMbps.HasValue)
+                                                    {
+                                                        <span class="mesh-rates">
+                                                            @if (ap.MeshUplinkTxRateMbps.HasValue)
+                                                            {
+                                                                <span class="mesh-rate wifi-speed-tx">TX @ap.MeshUplinkTxRateMbps</span>
+                                                            }
+                                                            @if (ap.MeshUplinkRxRateMbps.HasValue)
+                                                            {
+                                                                <span class="mesh-rate wifi-speed-rx">RX @ap.MeshUplinkRxRateMbps</span>
+                                                            }
+                                                        </span>
+                                                    }
+                                                </div>
+                                                <span class="ap-stat-label"><strong>Mesh Uplink</strong>@(ap.MeshParentName != null ? $" to {ap.MeshParentName}" : "")</span>
+                                            }
                                         </div>
                                     }
                                     @if (ap.MeshChildren.Count > 0)

--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -1077,9 +1077,13 @@
             var result = await MeshService.OptimizeAsync(ap.Ip, ap.MeshUplinkInterface, ap.Name);
             ShowToast(result.Message, result.Ok ? "alert-success" : "alert-warning");
 
-            // The action already waited for the backhaul to settle; pull the AP list once so the
-            // card reflects the new parent now rather than waiting for the ~1 min auto-refresh.
+            // Pull once now in case the controller already caught up, then again after delays:
+            // the UniFi controller's device list lags the actual roam by ~30s, so the immediate
+            // pull usually still shows the old parent. The +5s catches a fast update and the +30s
+            // catches the typical controller lag.
             _accessPoints = await WiFiService.GetAccessPointsAsync(forceRefresh: true);
+            _ = RefreshAccessPointsLater(TimeSpan.FromSeconds(5));
+            _ = RefreshAccessPointsLater(TimeSpan.FromSeconds(30));
         }
         catch
         {
@@ -1090,6 +1094,24 @@
         {
             _optimizingMacs.Remove(ap.Mac);
             StateHasChanged();
+        }
+    }
+
+    private async Task RefreshAccessPointsLater(TimeSpan delay)
+    {
+        try
+        {
+            await Task.Delay(delay);
+            var aps = await WiFiService.GetAccessPointsAsync(forceRefresh: true);
+            await InvokeAsync(() =>
+            {
+                _accessPoints = aps;
+                StateHasChanged();
+            });
+        }
+        catch
+        {
+            // Best-effort follow-up refresh; ignore failures (e.g., the circuit went away).
         }
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -606,16 +606,16 @@
                                                 <button class="btn btn-sm btn-primary optimize-mesh-btn"
                                                         @onclick="@(() => OptimizeMeshAsync(ap))"
                                                         disabled="@(!ap.IsOnline || _optimizingMacs.Contains(ap.Mac))"
-                                                        data-tooltip="Runs a Wi-Fi scan that nudges this AP onto the strongest available mesh parent (or the one you've pinned in UniFi Network) when it's stuck on a weaker uplink. Safe to re-run.">
+                                                        data-tooltip="Re-scans the mesh uplink so this AP reconnects to its highest Uplink Priority parent when it's stuck on a weaker one. Safe to re-run.">
                                                     @if (_optimizingMacs.Contains(ap.Mac))
                                                     {
                                                         <span class="spinner-sm"></span>
-                                                        <span>Optimizing...</span>
+                                                        <span>Scanning...</span>
                                                     }
                                                     else
                                                     {
                                                         <span class="optimize-mesh-icon">&#x21bb;</span>
-                                                        <span>Optimize Mesh</span>
+                                                        <span>Re-scan Uplink</span>
                                                     }
                                                 </button>
                                             }

--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -47,7 +47,13 @@
 
 @if (!string.IsNullOrEmpty(_toastMessage))
 {
-    <div class="wifi-toast alert @_toastClass">@_toastMessage</div>
+    <div class="wifi-toast alert @_toastClass">
+        <div>@_toastMessage</div>
+        @if (!string.IsNullOrEmpty(_toastNote))
+        {
+            <div class="wifi-toast-note">@_toastNote</div>
+        }
+    </div>
 }
 
 @if (ConnectionService.IsConnected)
@@ -905,6 +911,7 @@
     // MACs of mesh children with an in-flight Optimize Mesh action (drives the per-card spinner).
     private readonly HashSet<string> _optimizingMacs = new();
     private string? _toastMessage;
+    private string? _toastNote;
     private string _toastClass = "alert-info";
 
     // Auto-refresh the Overview tab once the health score has aged past this, so a parked
@@ -1075,7 +1082,12 @@
         try
         {
             var result = await MeshService.OptimizeAsync(ap.Ip, ap.MeshUplinkInterface, ap.Name);
-            ShowToast(result.Message, result.Ok ? "alert-success" : "alert-warning");
+            // Only warn about the data lag when it actually roamed - there's nothing to wait for
+            // on a noop or a failure.
+            var note = result.Action == "moved"
+                ? "It may take a minute for the AP data to reflect the new parent."
+                : null;
+            ShowToast(result.Message, result.Ok ? "alert-success" : "alert-warning", note);
 
             // Pull once now in case the controller already caught up, then again after delays:
             // the UniFi controller's device list lags the actual roam by ~30s, so the immediate
@@ -1115,9 +1127,10 @@
         }
     }
 
-    private void ShowToast(string message, string cssClass)
+    private void ShowToast(string message, string cssClass, string? note = null)
     {
         _toastMessage = message;
+        _toastNote = note;
         _toastClass = cssClass;
         StateHasChanged();
 
@@ -1128,6 +1141,7 @@
             await InvokeAsync(() =>
             {
                 _toastMessage = null;
+                _toastNote = null;
                 StateHasChanged();
             });
         });

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -444,6 +444,8 @@ builder.Services.AddSingleton<NetworkOptimizer.WiFi.Rules.IWiFiOptimizerRule, Ne
 builder.Services.AddSingleton<NetworkOptimizer.WiFi.Rules.IWiFiOptimizerRule, NetworkOptimizer.WiFi.Rules.WideChannelWidthRule>();
 builder.Services.AddSingleton<NetworkOptimizer.WiFi.Rules.WiFiOptimizerEngine>();
 builder.Services.AddScoped<WiFiOptimizerService>();
+// Mesh backhaul re-scan (Optimize Mesh button); stateless, uses UniFiSshService singleton.
+builder.Services.AddSingleton<MeshOptimizationService>();
 builder.Services.AddScoped<ApMapService>();
 builder.Services.AddSingleton<FloorPlanService>();
 builder.Services.AddSingleton<HeatmapDataCache>();

--- a/src/NetworkOptimizer.Web/Services/MeshOptimizationService.cs
+++ b/src/NetworkOptimizer.Web/Services/MeshOptimizationService.cs
@@ -51,6 +51,15 @@ public class MeshOptimizationService
         if (string.IsNullOrWhiteSpace(iface) || !ValidStaIface.IsMatch(iface))
             return MeshOptimizationResult.NoOp(iface, "This AP isn't a wireless mesh child.");
 
+        // The action runs over the shared UniFi device SSH credentials. Without them every
+        // wpa_cli call just fails with a generic error, so check up front and point the user at
+        // where to set it up.
+        var sshSettings = await _ssh.GetSettingsAsync();
+        var sshConfigured = !string.IsNullOrEmpty(sshSettings.Username) &&
+            (!string.IsNullOrEmpty(sshSettings.Password) || !string.IsNullOrEmpty(sshSettings.PrivateKeyPath));
+        if (!sshConfigured)
+            return MeshOptimizationResult.NoOp(iface, "Set up UniFi Device SSH in Settings to re-pair the uplink.");
+
         // wpa_cli control socket is per-interface on the AP (BusyBox / POSIX sh, runtime only).
         var wc = $"wpa_cli -p /var/run/wpa_supplicant/wpa_supplicant-{iface} -i {iface}";
 

--- a/src/NetworkOptimizer.Web/Services/MeshOptimizationService.cs
+++ b/src/NetworkOptimizer.Web/Services/MeshOptimizationService.cs
@@ -13,8 +13,15 @@ public class MeshOptimizationService
     private readonly UniFiSshService _ssh;
     private readonly ILogger<MeshOptimizationService> _logger;
 
-    /// <summary>How long to wait after issuing the scan before re-reading the link.</summary>
-    private static readonly TimeSpan ScanSettleDelay = TimeSpan.FromSeconds(6);
+    /// <summary>
+    /// After the scan, the AP evaluates results and roams on its own - which can take well over
+    /// ten seconds. Poll the link this many times, waiting <see cref="RoamPollInterval"/> between
+    /// reads, stopping early once it lands on a new parent.
+    /// </summary>
+    private const int RoamPollAttempts = 7;
+
+    /// <summary>Delay between post-scan link reads (also the initial settle after the scan).</summary>
+    private static readonly TimeSpan RoamPollInterval = TimeSpan.FromSeconds(3);
 
     /// <summary>
     /// The STA backhaul iface is interpolated into a shell command, so its format is locked down
@@ -58,22 +65,37 @@ public class MeshOptimizationService
         if (!scanOk)
             return MeshOptimizationResult.Failed(iface, "Couldn't start the backhaul scan.");
 
-        // The scan briefly blips the backhaul (and this SSH session); give it time to settle and
-        // re-associate before re-reading.
-        try
+        // The scan blips the backhaul, then the AP evaluates results and roams on its own, which
+        // can land several seconds after the scan returns. A single early read sees the old parent
+        // and wrongly reports "already on best", so poll the link and stop as soon as the BSSID
+        // changes (or the window closes). Reads during the blip can come back empty; keep the last
+        // good one.
+        (string? Bssid, int? Rssi, int? LinkSpeedMbps) after = (null, null, null);
+        var moved = false;
+        for (var attempt = 0; attempt < RoamPollAttempts; attempt++)
         {
-            await Task.Delay(ScanSettleDelay, cancellationToken);
-        }
-        catch (OperationCanceledException)
-        {
-            return MeshOptimizationResult.Failed(iface, "Mesh optimization was cancelled.");
+            try
+            {
+                await Task.Delay(RoamPollInterval, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return MeshOptimizationResult.Failed(iface, "Mesh optimization was cancelled.");
+            }
+
+            var read = await ReadLinkAsync(host, wc, cancellationToken);
+            if (read.Bssid == null) continue;
+
+            after = read;
+            if (!string.Equals(read.Bssid, before.Bssid, StringComparison.OrdinalIgnoreCase))
+            {
+                moved = true;
+                break;
+            }
         }
 
-        var after = await ReadLinkAsync(host, wc, cancellationToken);
-
-        // The scan blips the backhaul (and this SSH session), so the post-scan read can come back
-        // empty even though the scan/roam happened. Don't assert "already on best" in that case -
-        // the card refresh that follows is the source of truth for the current parent.
+        // Every read came back empty (the scan can drop the SSH session). Don't assert "already on
+        // best" - the card refresh that follows is the source of truth for the current parent.
         if (after.Bssid == null)
         {
             return new MeshOptimizationResult
@@ -86,8 +108,6 @@ public class MeshOptimizationService
                 Message = "Backhaul re-scan done. Refreshing to show the current parent."
             };
         }
-
-        var moved = !string.Equals(after.Bssid, before.Bssid, StringComparison.OrdinalIgnoreCase);
 
         var result = new MeshOptimizationResult
         {

--- a/src/NetworkOptimizer.Web/Services/MeshOptimizationService.cs
+++ b/src/NetworkOptimizer.Web/Services/MeshOptimizationService.cs
@@ -1,0 +1,168 @@
+using System.Text.RegularExpressions;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Triggers a backhaul re-scan on a mesh-child AP over SSH so it self-roams to the strongest
+/// available parent. The parent set is decided by UniFi Network (Auto, or a constrained/pinned
+/// parent); this service never chooses the parent - it only prompts the scan and reports the
+/// before/after link. On-demand, re-runnable, idempotent.
+/// </summary>
+public class MeshOptimizationService
+{
+    private readonly UniFiSshService _ssh;
+    private readonly ILogger<MeshOptimizationService> _logger;
+
+    /// <summary>How long to wait after issuing the scan before re-reading the link.</summary>
+    private static readonly TimeSpan ScanSettleDelay = TimeSpan.FromSeconds(6);
+
+    /// <summary>
+    /// The STA backhaul iface is interpolated into a shell command, so its format is locked down
+    /// to the known UniFi pattern (e.g. "vwiresta7") to prevent command injection.
+    /// </summary>
+    private static readonly Regex ValidStaIface = new(@"^vwiresta\d+$", RegexOptions.Compiled);
+
+    public MeshOptimizationService(UniFiSshService ssh, ILogger<MeshOptimizationService> logger)
+    {
+        _ssh = ssh;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Run a backhaul re-scan on the given mesh-child AP and report whether it moved to a
+    /// stronger parent.
+    /// </summary>
+    /// <param name="host">The AP's IP/host for SSH.</param>
+    /// <param name="iface">The STA backhaul interface (e.g. "vwiresta7").</param>
+    /// <param name="apName">AP display name, used only for log/message context.</param>
+    public async Task<MeshOptimizationResult> OptimizeAsync(
+        string? host, string? iface, string? apName, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(host))
+            return MeshOptimizationResult.NoOp(iface, "This AP has no reachable address.");
+
+        if (string.IsNullOrWhiteSpace(iface) || !ValidStaIface.IsMatch(iface))
+            return MeshOptimizationResult.NoOp(iface, "This AP isn't a wireless mesh child.");
+
+        // wpa_cli control socket is per-interface on the AP (BusyBox / POSIX sh, runtime only).
+        var wc = $"wpa_cli -p /var/run/wpa_supplicant/wpa_supplicant-{iface} -i {iface}";
+
+        var before = await ReadLinkAsync(host, wc, cancellationToken);
+        if (before.Bssid == null)
+        {
+            _logger.LogDebug("[MeshOptimize] {Ap}: could not read backhaul status on {Iface}", apName, iface);
+            return MeshOptimizationResult.Failed(iface, "Couldn't read the mesh backhaul status.");
+        }
+
+        var (scanOk, _) = await _ssh.RunCommandAsync(host, $"{wc} scan", cancellationToken: cancellationToken);
+        if (!scanOk)
+            return MeshOptimizationResult.Failed(iface, "Couldn't start the backhaul scan.");
+
+        // The scan briefly blips the backhaul (and this SSH session); give it time to settle and
+        // re-associate before re-reading.
+        try
+        {
+            await Task.Delay(ScanSettleDelay, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            return MeshOptimizationResult.Failed(iface, "Mesh optimization was cancelled.");
+        }
+
+        var after = await ReadLinkAsync(host, wc, cancellationToken);
+
+        // The scan blips the backhaul (and this SSH session), so the post-scan read can come back
+        // empty even though the scan/roam happened. Don't assert "already on best" in that case -
+        // the card refresh that follows is the source of truth for the current parent.
+        if (after.Bssid == null)
+        {
+            return new MeshOptimizationResult
+            {
+                Iface = iface,
+                BeforeBssid = before.Bssid,
+                BeforeRssi = before.Rssi,
+                Action = "noop",
+                Ok = true,
+                Message = "Backhaul re-scan done. Refreshing to show the current parent."
+            };
+        }
+
+        var moved = !string.Equals(after.Bssid, before.Bssid, StringComparison.OrdinalIgnoreCase);
+
+        var result = new MeshOptimizationResult
+        {
+            Iface = iface,
+            BeforeBssid = before.Bssid,
+            BeforeRssi = before.Rssi,
+            AfterBssid = after.Bssid,
+            AfterRssi = after.Rssi,
+            AfterLinkSpeedMbps = after.LinkSpeedMbps,
+            Action = moved ? "moved" : "noop",
+            Ok = true,
+            Message = moved
+                ? $"Moved to a stronger parent ({Describe(after.Rssi)})."
+                : $"Already on the best parent ({Describe(after.Rssi)})."
+        };
+
+        _logger.LogInformation(
+            "[MeshOptimize] {Ap} ({Iface}): {Action} {BeforeBssid}({BeforeRssi}) -> {AfterBssid}({AfterRssi})",
+            apName, iface, result.Action, before.Bssid, before.Rssi, after.Bssid, after.Rssi);
+
+        return result;
+    }
+
+    /// <summary>Read the current backhaul BSSID and RSSI in a single SSH round trip.</summary>
+    private async Task<(string? Bssid, int? Rssi, int? LinkSpeedMbps)> ReadLinkAsync(
+        string host, string wc, CancellationToken cancellationToken)
+    {
+        var (ok, output) = await _ssh.RunCommandAsync(
+            host, $"{wc} status; {wc} signal_poll", cancellationToken: cancellationToken);
+        if (!ok || string.IsNullOrWhiteSpace(output))
+            return (null, null, null);
+
+        var bssid = MatchValue(output, @"(?im)^bssid=([0-9a-f:]{17})");
+        var rssi = MatchInt(output, @"(?im)^RSSI=(-?\d+)");
+        var linkSpeed = MatchInt(output, @"(?im)^LINKSPEED=(\d+)");
+        return (bssid, rssi, linkSpeed);
+    }
+
+    private static string? MatchValue(string text, string pattern)
+    {
+        var m = Regex.Match(text, pattern);
+        return m.Success ? m.Groups[1].Value : null;
+    }
+
+    private static int? MatchInt(string text, string pattern)
+    {
+        var m = Regex.Match(text, pattern);
+        return m.Success && int.TryParse(m.Groups[1].Value, out var v) ? v : null;
+    }
+
+    private static string Describe(int? rssi) => rssi.HasValue ? $"{rssi} dBm" : "signal unknown";
+}
+
+/// <summary>Outcome of a mesh backhaul re-scan. Returned to the page; not shown raw to the user.</summary>
+public class MeshOptimizationResult
+{
+    public string? Iface { get; set; }
+    public string? BeforeBssid { get; set; }
+    public int? BeforeRssi { get; set; }
+    public string? AfterBssid { get; set; }
+    public int? AfterRssi { get; set; }
+    public int? AfterLinkSpeedMbps { get; set; }
+
+    /// <summary>"moved" if the backhaul roamed to a different parent, otherwise "noop".</summary>
+    public string Action { get; set; } = "noop";
+
+    /// <summary>True when the action ran; false when it couldn't (no iface, SSH failure, etc.).</summary>
+    public bool Ok { get; set; }
+
+    /// <summary>User-facing summary for the toast.</summary>
+    public string Message { get; set; } = string.Empty;
+
+    public static MeshOptimizationResult NoOp(string? iface, string message) =>
+        new() { Iface = iface, Action = "noop", Ok = false, Message = message };
+
+    public static MeshOptimizationResult Failed(string? iface, string message) =>
+        new() { Iface = iface, Action = "noop", Ok = false, Message = message };
+}

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -8182,6 +8182,27 @@ a.path-hop.hop-clickable:hover {
     color: var(--text-muted);
 }
 
+.optimize-mesh-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    white-space: nowrap;
+}
+
+.optimize-mesh-icon {
+    font-size: 0.95rem;
+    line-height: 1;
+}
+
+.wifi-toast {
+    position: fixed;
+    top: 1rem;
+    right: 1rem;
+    z-index: 1080;
+    max-width: 22rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
 .ap-header-text {
     display: flex;
     flex-direction: column;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -8218,6 +8218,7 @@ a.path-hop.hop-clickable:hover {
         right: auto;
         left: 50%;
         bottom: 1rem;
+        width: 80vw;
         max-width: 80vw;
         transform: translateX(-50%);
     }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -8199,7 +8199,7 @@ a.path-hop.hop-clickable:hover {
 
 .wifi-toast {
     position: fixed;
-    bottom: 1rem;
+    bottom: 5rem;
     right: 3rem;
     z-index: 1080;
     max-width: 22rem;
@@ -8210,6 +8210,7 @@ a.path-hop.hop-clickable:hover {
     .wifi-toast {
         right: auto;
         left: 50%;
+        bottom: 1rem;
         transform: translateX(-50%);
     }
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -8224,8 +8224,12 @@ a.path-hop.hop-clickable:hover {
 .ap-stats {
     display: flex;
     gap: 1.5rem;
-    margin-bottom: 0.75rem;
+    margin-bottom: 0.5rem;
     margin-left: 0.25rem;
+}
+
+.ap-stats-mesh .ap-stat {
+    justify-content: flex-end;
 }
 
 .ap-stat {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -8203,6 +8203,7 @@ a.path-hop.hop-clickable:hover {
     right: 3rem;
     z-index: 1080;
     max-width: 22rem;
+    background: rgba(22, 22, 24, 0.8);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -8199,7 +8199,7 @@ a.path-hop.hop-clickable:hover {
 
 .wifi-toast {
     position: fixed;
-    top: 1rem;
+    bottom: 1rem;
     right: 1rem;
     z-index: 1080;
     max-width: 22rem;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -8207,11 +8207,18 @@ a.path-hop.hop-clickable:hover {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
 
+.wifi-toast-note {
+    margin-top: 0.35rem;
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+}
+
 @media (max-width: 768px) {
     .wifi-toast {
         right: auto;
         left: 50%;
         bottom: 1rem;
+        max-width: 80vw;
         transform: translateX(-50%);
     }
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -8175,6 +8175,7 @@ a.path-hop.hop-clickable:hover {
     align-items: center;
     gap: 0.35rem;
     margin-left: auto;
+    margin-top: -1.3rem;
 }
 
 .ap-status-text {
@@ -8188,7 +8189,6 @@ a.path-hop.hop-clickable:hover {
     gap: 0.3rem;
     white-space: nowrap;
     align-self: flex-end;
-    margin-bottom: 0.5rem;
 }
 
 .optimize-mesh-icon {
@@ -8260,6 +8260,10 @@ a.path-hop.hop-clickable:hover {
     display: flex;
     flex-direction: column;
     margin-left: auto;
+}
+
+.ap-mesh-info-with-action {
+    margin-top: -1.5rem;
 }
 
 .mesh-signal {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -8200,10 +8200,18 @@ a.path-hop.hop-clickable:hover {
 .wifi-toast {
     position: fixed;
     bottom: 1rem;
-    right: 1rem;
+    right: 3rem;
     z-index: 1080;
     max-width: 22rem;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+@media (max-width: 768px) {
+    .wifi-toast {
+        right: auto;
+        left: 50%;
+        transform: translateX(-50%);
+    }
 }
 
 .ap-header-text {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -8189,6 +8189,7 @@ a.path-hop.hop-clickable:hover {
     gap: 0.3rem;
     white-space: nowrap;
     align-self: flex-end;
+    margin-bottom: 0.25rem;
 }
 
 .optimize-mesh-icon {
@@ -8267,7 +8268,7 @@ a.path-hop.hop-clickable:hover {
 }
 
 .ap-mesh-info-with-action {
-    margin-top: -1.5rem;
+    margin-top: -1.75rem;
 }
 
 .mesh-signal {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -8187,6 +8187,8 @@ a.path-hop.hop-clickable:hover {
     align-items: center;
     gap: 0.3rem;
     white-space: nowrap;
+    align-self: flex-end;
+    margin-bottom: 0.5rem;
 }
 
 .optimize-mesh-icon {

--- a/src/NetworkOptimizer.WiFi/Models/AccessPointSnapshot.cs
+++ b/src/NetworkOptimizer.WiFi/Models/AccessPointSnapshot.cs
@@ -50,6 +50,12 @@ public class AccessPointSnapshot
     /// <summary>Channel used for mesh uplink (if mesh child)</summary>
     public int? MeshUplinkChannel { get; set; }
 
+    /// <summary>
+    /// wpa_supplicant STA backhaul interface for the mesh uplink (e.g. "vwiresta7"), if this is
+    /// a mesh child. Null for wired APs. Used to target the backhaul re-scan/roam over SSH.
+    /// </summary>
+    public string? MeshUplinkInterface { get; set; }
+
     /// <summary>Signal strength of mesh uplink in dBm (if mesh child)</summary>
     public int? MeshUplinkSignalDbm { get; set; }
 

--- a/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
@@ -972,7 +972,13 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
                     Name = radioStats.Name,
                     Band = RadioBandExtensions.FromUniFiCode(radioStats.Radio),
                     Channel = radioStats.Channel,
-                    ChannelWidth = radioConfig?.ChannelWidth,
+                    // Prefer the operating width (radio_table_stats "bw") over the configured
+                    // width (radio_table "ht"). A mesh backhaul radio can be configured for
+                    // 160 MHz but negotiate down to the parent's width (e.g. 80 MHz) on the
+                    // link; "ht" still reads 160 while "bw" reflects the real 80. Fall back to
+                    // the configured width when "bw" is absent (older firmware) or non-positive
+                    // (e.g. an idle radio reporting 0), which "ht" never is for an enabled radio.
+                    ChannelWidth = radioStats.Bw is > 0 ? radioStats.Bw : radioConfig?.ChannelWidth,
                     ExtChannel = radioStats.ExtChannel,
                     TxPower = radioStats.TxPower,
                     TxPowerMode = radioConfig?.TxPowerMode,

--- a/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
@@ -905,6 +905,7 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
         string? meshParentMac = null;
         RadioBand? meshUplinkBand = null;
         int? meshUplinkChannel = null;
+        string? meshUplinkInterface = null;
 
         if (ap.UplinkType?.Equals("wireless", StringComparison.OrdinalIgnoreCase) == true &&
             !string.IsNullOrEmpty(ap.UplinkMac))
@@ -916,6 +917,10 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
                 meshParentMac = uplinkMacLower;
                 meshUplinkBand = RadioBandExtensions.FromUniFiCode(ap.UplinkRadioBand);
                 meshUplinkChannel = ap.UplinkChannel;
+                // Only the STA backhaul iface (vwiresta*) is a valid wpa_supplicant target;
+                // never the AP-side VAP (vwireap*) or a wired iface.
+                if (ap.UplinkInterface?.StartsWith("vwiresta", StringComparison.OrdinalIgnoreCase) == true)
+                    meshUplinkInterface = ap.UplinkInterface;
             }
         }
 
@@ -935,6 +940,7 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
             MeshParentMac = meshParentMac,
             MeshUplinkBand = meshUplinkBand,
             MeshUplinkChannel = meshUplinkChannel,
+            MeshUplinkInterface = meshUplinkInterface,
             MeshUplinkSignalDbm = isMeshChild ? ap.UplinkSignalDbm : null,
             MeshUplinkTxRateMbps = isMeshChild && ap.UplinkTxRateKbps > 0 ? (int)(ap.UplinkTxRateKbps / 1000) : null,
             MeshUplinkRxRateMbps = isMeshChild && ap.UplinkRxRateKbps > 0 ? (int)(ap.UplinkRxRateKbps / 1000) : null,

--- a/tests/NetworkOptimizer.UniFi.Tests/RadioTableStatsTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/RadioTableStatsTests.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using NetworkOptimizer.UniFi.Models;
+using Xunit;
+
+namespace NetworkOptimizer.UniFi.Tests;
+
+public class RadioTableStatsTests
+{
+    [Fact]
+    public void Parses_operating_width_from_bw()
+    {
+        // radio_table_stats reports the live operating width in "bw". A mesh backhaul radio
+        // configured for 160 MHz can negotiate down to the parent's 80 MHz - "bw" reflects the
+        // real 80 while radio_table's "ht" still reads 160 (issue #921).
+        const string json = """
+        {
+            "name": "wifi1",
+            "radio": "na",
+            "channel": 36,
+            "bw": 80,
+            "extchannel": -1
+        }
+        """;
+
+        var stats = JsonSerializer.Deserialize<RadioTableStats>(json);
+
+        Assert.NotNull(stats);
+        Assert.Equal(36, stats!.Channel);
+        Assert.Equal(80, stats.Bw);
+    }
+
+    [Theory]
+    [InlineData("80", 80)]
+    [InlineData("\"160\"", 160)]
+    [InlineData("20", 20)]
+    public void Parses_bw_as_number_or_string(string bwJson, int expected)
+    {
+        var json = $"{{\"name\":\"wifi1\",\"radio\":\"na\",\"bw\":{bwJson}}}";
+
+        var stats = JsonSerializer.Deserialize<RadioTableStats>(json);
+
+        Assert.Equal(expected, stats!.Bw);
+    }
+
+    [Fact]
+    public void Bw_is_null_when_absent()
+    {
+        const string json = """{"name":"wifi1","radio":"na","channel":36}""";
+
+        var stats = JsonSerializer.Deserialize<RadioTableStats>(json);
+
+        Assert.Null(stats!.Bw);
+    }
+}

--- a/tests/NetworkOptimizer.UniFi.Tests/RadioTableStatsTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/RadioTableStatsTests.cs
@@ -51,4 +51,31 @@ public class RadioTableStatsTests
 
         Assert.Null(stats!.Bw);
     }
+
+    [Fact]
+    public void Parses_real_radio_table_stats_array()
+    {
+        // Captured radio_table_stats from a real device (issue #921): the 5 GHz radio operates at
+        // 80 MHz (bw) even though it's configured for a wider channel, which is the whole point of
+        // reading bw over radio_table's ht.
+        const string json = """
+        [
+            { "name": "wifi0", "radio": "ng", "channel": 6,  "bw": 20, "state": "RUN", "extchannel": 0 },
+            { "name": "wifi1", "radio": "na", "channel": 36, "bw": 80, "state": "RUN", "extchannel": 1 }
+        ]
+        """;
+
+        var stats = JsonSerializer.Deserialize<List<RadioTableStats>>(json);
+
+        Assert.NotNull(stats);
+        Assert.Equal(2, stats!.Count);
+
+        var ng = stats.Single(r => r.Radio == "ng");
+        Assert.Equal(6, ng.Channel);
+        Assert.Equal(20, ng.Bw);
+
+        var na = stats.Single(r => r.Radio == "na");
+        Assert.Equal(36, na.Channel);
+        Assert.Equal(80, na.Bw);
+    }
 }


### PR DESCRIPTION
## What

Two related mesh improvements on the Wi-Fi Optimizer.

### Show a meshed AP's real operating channel width

The Channel Analysis panel showed meshed APs at the wrong width (e.g. a repeater running 80 MHz displayed as 160 MHz, with a phantom "current to recommended" change). We were reading each radio's *configured* width (`radio_table` `ht`) instead of its *operating* width (`radio_table_stats` `bw`). A mesh backhaul radio can be configured for 160 MHz but negotiate down to its parent's width, so the configured value misrepresents reality. We now read `bw` (parsed with the flexible int converter), preferring it over the configured width and falling back when it's absent or non-positive. This corrects the width everywhere it's shown (Channel Analysis, the heatmap/signal views, and the wide-channel audit rule).

### "Re-pair Uplink" action for mesh children

A new on-demand button on each mesh-child AP card triggers a backhaul re-scan over SSH so the AP reconnects to its highest Uplink Priority parent when it's stuck on a weaker one. UniFi Network still decides the parent set (Auto or pinned) - this only prompts the scan and reports the result.

- Runs one `wpa_cli` scan on the STA backhaul interface, then polls the link read-only until it lands on a new parent, and reports before/after over a toast.
- The card refreshes itself after the action (with follow-ups to ride out the controller's data lag), so the new parent shows without a manual refresh.
- Requires UniFi Device SSH; if it isn't set up, the button explains where to configure it.
- Hidden on wired APs and any AP without a wireless mesh uplink.

## Notes

- The operating-width change applies to all APs, not just mesh, which is strictly more accurate for "current" state.
- The backhaul interface is sourced from the UniFi API (`uplink.name`) and validated to the STA pattern before use.

## Tests

- New tests covering `bw` parsing, including a real captured `radio_table_stats` payload where the 5 GHz radio operates at 80 MHz.
- Full UniFi and Wi-Fi suites pass; build is warning-free.
