### PR TITLE
Signal Map: frame to real content, not placeholder building/floor coordinates

### DIFF
--- a/src/NetworkOptimizer.Core/Helpers/MapBoundsHelper.cs
+++ b/src/NetworkOptimizer.Core/Helpers/MapBoundsHelper.cs
@@ -1,0 +1,112 @@
+namespace NetworkOptimizer.Core.Helpers;
+
+/// <summary>
+/// Geometry helpers for framing the floor-plan / signal map to real content.
+///
+/// Floor and building records are created with placeholder coordinates: a new floor
+/// inherits its building's center, and a building created before any AP is placed
+/// falls back to the app's default map center. Fitting the map to those raw records
+/// drags the view to the placeholder (e.g. a German user's map zooming out to the
+/// central-US default). These helpers fit only to coordinates that represent
+/// deliberate user content: placed APs, drawn walls, and floors with real content
+/// (walls or an uploaded image). Bare placeholder records are excluded.
+/// </summary>
+public static class MapBoundsHelper
+{
+    /// <summary>A south-west / north-east lat-lng bounding box.</summary>
+    public readonly record struct GeoBounds(double SwLat, double SwLng, double NeLat, double NeLng);
+
+    /// <summary>
+    /// A floor's stored overlay bounds plus whether the floor has real user content.
+    /// A floor with no walls and no image sits at its building's placeholder center and
+    /// must not participate in the map fit.
+    /// </summary>
+    public readonly record struct FloorRecord(double SwLat, double SwLng, double NeLat, double NeLng, bool HasContent);
+
+    /// <summary>
+    /// True if a lat/lng pair is a usable real coordinate rather than an unset default.
+    /// Some record paths default to (0, 0) null island; both that and out-of-range
+    /// values are rejected.
+    /// </summary>
+    public static bool IsPositioned(double lat, double lng)
+    {
+        if (Math.Abs(lat) < 0.0001 && Math.Abs(lng) < 0.0001) return false;
+        return lat is >= -90 and <= 90 && lng is >= -180 and <= 180;
+    }
+
+    /// <summary>
+    /// Bounds of all positioned content for a set of buildings: drawn walls if any exist,
+    /// otherwise the overlay bounds of floors that have real content. Bare floors sitting
+    /// at their building's placeholder center are excluded. Returns null when there is no
+    /// positioned content.
+    /// </summary>
+    public static GeoBounds? ComputeBuildingBounds(
+        IEnumerable<(double Lat, double Lng)> wallPoints,
+        IEnumerable<FloorRecord> floors)
+    {
+        var acc = new BoundsAccumulator();
+
+        foreach (var p in wallPoints)
+            if (IsPositioned(p.Lat, p.Lng)) acc.Add(p.Lat, p.Lng);
+
+        // Real, drawn walls are the most reliable signal; prefer them outright.
+        if (acc.HasData) return acc.ToBounds();
+
+        foreach (var f in floors)
+            if (f.HasContent && IsPositioned(f.SwLat, f.SwLng) && IsPositioned(f.NeLat, f.NeLng))
+            {
+                acc.Add(f.SwLat, f.SwLng);
+                acc.Add(f.NeLat, f.NeLng);
+            }
+
+        return acc.HasData ? acc.ToBounds() : null;
+    }
+
+    /// <summary>
+    /// Bounds spanning placed APs plus positioned building content. APs anchor the frame;
+    /// wall / floor content extends it. Placeholder records never participate. Returns null
+    /// when nothing positioned is present.
+    /// </summary>
+    public static GeoBounds? ComputeAllContentBounds(
+        IEnumerable<(double Lat, double Lng)> apPoints,
+        IEnumerable<(double Lat, double Lng)> wallPoints,
+        IEnumerable<FloorRecord> floors)
+    {
+        var acc = new BoundsAccumulator();
+
+        foreach (var p in apPoints)
+            if (IsPositioned(p.Lat, p.Lng)) acc.Add(p.Lat, p.Lng);
+
+        var building = ComputeBuildingBounds(wallPoints, floors);
+        if (building.HasValue)
+        {
+            acc.Add(building.Value.SwLat, building.Value.SwLng);
+            acc.Add(building.Value.NeLat, building.Value.NeLng);
+        }
+
+        return acc.HasData ? acc.ToBounds() : null;
+    }
+
+    private struct BoundsAccumulator
+    {
+        private double _swLat, _swLng, _neLat, _neLng;
+        public bool HasData { get; private set; }
+
+        public void Add(double lat, double lng)
+        {
+            if (!HasData)
+            {
+                _swLat = _neLat = lat;
+                _swLng = _neLng = lng;
+                HasData = true;
+                return;
+            }
+            _swLat = Math.Min(_swLat, lat);
+            _swLng = Math.Min(_swLng, lng);
+            _neLat = Math.Max(_neLat, lat);
+            _neLng = Math.Max(_neLng, lng);
+        }
+
+        public readonly GeoBounds ToBounds() => new(_swLat, _swLng, _neLat, _neLng);
+    }
+}

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/FloorPlanEditor.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/FloorPlanEditor.razor
@@ -1809,25 +1809,28 @@
         }
         else if (_buildings.Count > 0)
         {
-            // No placed APs - fit to all buildings (positioned floors/buildings only)
-            var positionedFloors = _buildings.SelectMany(b => b.Floors)
-                .Where(f => IsPositioned(f.SwLatitude, f.SwLongitude) && IsPositioned(f.NeLatitude, f.NeLongitude))
+            // No placed APs - fit to floors/buildings that have real content. Bare
+            // placeholder records (no walls, no image) are skipped so they can't drag the
+            // initial center to the app's default map location.
+            var contentFloors = _buildings.SelectMany(b => b.Floors)
+                .Where(f => FloorHasContent(f)
+                    && IsPositioned(f.SwLatitude, f.SwLongitude) && IsPositioned(f.NeLatitude, f.NeLongitude))
                 .ToList();
-            if (positionedFloors.Count > 0)
+            if (contentFloors.Count > 0)
             {
-                centerLat = positionedFloors.Average(f => (f.SwLatitude + f.NeLatitude) / 2);
-                centerLng = positionedFloors.Average(f => (f.SwLongitude + f.NeLongitude) / 2);
+                centerLat = contentFloors.Average(f => (f.SwLatitude + f.NeLatitude) / 2);
+                centerLng = contentFloors.Average(f => (f.SwLongitude + f.NeLongitude) / 2);
                 zoom = 19;
             }
             else
             {
-                var positionedBuildings = _buildings
-                    .Where(b => IsPositioned(b.CenterLatitude, b.CenterLongitude))
+                var contentBuildings = _buildings
+                    .Where(b => b.Floors.Any(FloorHasContent) && IsPositioned(b.CenterLatitude, b.CenterLongitude))
                     .ToList();
-                if (positionedBuildings.Count > 0)
+                if (contentBuildings.Count > 0)
                 {
-                    centerLat = positionedBuildings.Average(b => b.CenterLatitude);
-                    centerLng = positionedBuildings.Average(b => b.CenterLongitude);
+                    centerLat = contentBuildings.Average(b => b.CenterLatitude);
+                    centerLng = contentBuildings.Average(b => b.CenterLongitude);
                     zoom = 19;
                 }
             }
@@ -1870,6 +1873,23 @@
         }
     }
 
+    /// <summary>
+    /// The current live map center, used to seed new buildings/floors at the location the
+    /// user is actually looking at instead of a hard-coded default. Returns null when the
+    /// map is not yet initialized or the JS call fails.
+    /// </summary>
+    private async Task<(double lat, double lng)?> GetMapCenterAsync()
+    {
+        if (!_mapInitialized) return null;
+        try
+        {
+            var c = await JS.InvokeAsync<double[]?>("fpEditor.getCenter");
+            if (c is { Length: 2 } && IsPositioned(c[0], c[1])) return (c[0], c[1]);
+        }
+        catch { }
+        return null;
+    }
+
     private async Task LoadBuildings()
     {
         try
@@ -1886,6 +1906,7 @@
                     NeLatitude = f.NeLatitude, NeLongitude = f.NeLongitude,
                     Opacity = f.Opacity, WallsJson = f.WallsJson,
                     HasImage = !string.IsNullOrEmpty(f.ImagePath),
+                    HasOverlayImages = f.Images.Count > 0,
                     FloorMaterial = f.FloorMaterial
                 }).ToList()
             }).ToList();
@@ -2042,10 +2063,8 @@
 
     private (double swLat, double swLng, double neLat, double neLng) ComputeAllBuildingBounds()
     {
-        double swLat = double.MaxValue, swLng = double.MaxValue;
-        double neLat = double.MinValue, neLng = double.MinValue;
-        bool hasData = false;
-
+        // Real, drawn walls are the most reliable positioning signal; collect their points.
+        var wallPoints = new List<(double Lat, double Lng)>();
         var jsonOpts = new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true };
         foreach (var b in _buildings)
         {
@@ -2058,49 +2077,41 @@
                     if (walls == null) continue;
                     foreach (var wall in walls)
                         foreach (var pt in wall.Points)
-                        {
-                            swLat = Math.Min(swLat, pt.Lat);
-                            swLng = Math.Min(swLng, pt.Lng);
-                            neLat = Math.Max(neLat, pt.Lat);
-                            neLng = Math.Max(neLng, pt.Lng);
-                            hasData = true;
-                        }
+                            wallPoints.Add((pt.Lat, pt.Lng));
                 }
                 catch { }
             }
         }
 
-        if (!hasData)
-        {
-            // Fall back to floor record bounds. Skip floors that were created but never
-            // positioned: their SwLatitude/NeLatitude default to 0, and a single such floor
-            // would drag the fit bounds out to null island and zoom the map to the whole globe.
-            var positionedFloors = _buildings.SelectMany(b2 => b2.Floors)
-                .Where(f => IsPositioned(f.SwLatitude, f.SwLongitude) && IsPositioned(f.NeLatitude, f.NeLongitude))
-                .ToList();
-            if (positionedFloors.Count > 0)
-            {
-                swLat = positionedFloors.Min(f => f.SwLatitude);
-                swLng = positionedFloors.Min(f => f.SwLongitude);
-                neLat = positionedFloors.Max(f => f.NeLatitude);
-                neLng = positionedFloors.Max(f => f.NeLongitude);
-            }
-        }
+        // Fall back to floor overlay bounds, but only for floors with real content (walls
+        // or an image). A bare floor sits at its building's placeholder center - which is
+        // an in-range coordinate (the app's default map center), so a coordinate-only guard
+        // would let it through and drag the fit halfway across the globe.
+        var floorRecords = _buildings.SelectMany(b => b.Floors)
+            .Select(f => new MapBoundsHelper.FloorRecord(
+                f.SwLatitude, f.SwLongitude, f.NeLatitude, f.NeLongitude, FloorHasContent(f)));
 
-        return (swLat, swLng, neLat, neLng);
+        var bounds = MapBoundsHelper.ComputeBuildingBounds(wallPoints, floorRecords);
+        return bounds.HasValue
+            ? (bounds.Value.SwLat, bounds.Value.SwLng, bounds.Value.NeLat, bounds.Value.NeLng)
+            : (double.MaxValue, double.MaxValue, double.MinValue, double.MinValue);
     }
 
     /// <summary>
     /// True if a lat/lng pair represents a real placed location rather than an unset
-    /// default. Floor/building records use non-nullable doubles that default to 0, so an
-    /// un-positioned floor reads as (0, 0) (null island) and must be excluded from map
-    /// fit-bounds calculations or it zooms the map out to the whole world.
+    /// default. Forwards to <see cref="MapBoundsHelper.IsPositioned"/> (the single source
+    /// of truth, unit-tested) so every fit-bounds call site agrees.
     /// </summary>
-    private static bool IsPositioned(double lat, double lng)
-    {
-        if (Math.Abs(lat) < 0.0001 && Math.Abs(lng) < 0.0001) return false;
-        return lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180;
-    }
+    private static bool IsPositioned(double lat, double lng) => MapBoundsHelper.IsPositioned(lat, lng);
+
+    /// <summary>
+    /// True if a floor has real user-established content - drawn walls or an uploaded
+    /// image - so its stored bounds reflect a deliberate position. A bare floor inherits
+    /// its building's placeholder center at creation and must not drag the map fit, even
+    /// though its coordinates are technically in-range (e.g. the app's default map center).
+    /// </summary>
+    private static bool FloorHasContent(FloorDto f) =>
+        (!string.IsNullOrWhiteSpace(f.WallsJson) && f.WallsJson != "[]") || f.HasImage || f.HasOverlayImages;
 
     private async Task SelectFloor(int floorId)
     {
@@ -3665,7 +3676,14 @@
         {
             var centerLat = _selectedBuilding.CenterLatitude;
             var centerLng = _selectedBuilding.CenterLongitude;
-            if (centerLat == 0 && centerLng == 0) { centerLat = 38.0; centerLng = -92.0; }
+            // Uploading an image marks the floor as content, so its bounds now feed the map
+            // fit. Never seed them at the hard-coded default: prefer the live map center, and
+            // only fall back to the default for a genuinely empty map.
+            if (centerLat == 0 && centerLng == 0)
+            {
+                if (await GetMapCenterAsync() is { } c) { centerLat = c.lat; centerLng = c.lng; }
+                else { centerLat = 38.0; centerLng = -92.0; }
+            }
             var latOffset = 25.0 / 111320.0;
             var lngOffset = 25.0 / (111320.0 * Math.Cos(centerLat * Math.PI / 180));
             _selectedFloor.SwLatitude = centerLat - latOffset;
@@ -3714,10 +3732,15 @@
     {
         _newBuildingName = _newBuildingName.Trim();
         if (string.IsNullOrWhiteSpace(_newBuildingName)) return;
+        // Seed the new building at a real location so its floors don't inherit a placeholder
+        // center: a placed AP first, otherwise wherever the user has the map pointed. Only
+        // fall back to the default when nothing better is available (genuinely empty map).
         var lat = 38.0;
         var lng = -92.0;
-        var firstAp = _apMarkers.FirstOrDefault(a => a.Latitude.HasValue);
+        var firstAp = _apMarkers.FirstOrDefault(a => a.Latitude.HasValue && a.Longitude.HasValue
+            && IsPositioned(a.Latitude.Value, a.Longitude.Value));
         if (firstAp != null) { lat = firstAp.Latitude!.Value; lng = firstAp.Longitude!.Value; }
+        else if (await GetMapCenterAsync() is { } center) { lat = center.lat; lng = center.lng; }
 
         var building = await FloorPlanSvc.CreateBuildingAsync(_newBuildingName, lat, lng);
         HeatmapCache.Invalidate();
@@ -4084,20 +4107,23 @@
             floor.SwLongitude = swLng;
             floor.NeLatitude = neLat;
             floor.NeLongitude = neLng;
+            // Keep the in-memory floor consistent so content/position checks below see the walls.
+            floor.WallsJson = wallsJson;
             await FloorPlanSvc.UpdateFloorAsync(floor.Id, swLat: swLat, swLng: swLng, neLat: neLat, neLng: neLng);
 
-            // Update building center from union of all positioned floor bounds. Excluding
-            // un-positioned floors (default 0 bounds) keeps the persisted building center
-            // from being pulled toward null island when a floor hasn't been placed yet.
-            var positionedFloors = _floors
-                .Where(f => IsPositioned(f.SwLatitude, f.SwLongitude) && IsPositioned(f.NeLatitude, f.NeLongitude))
+            // Update building center from the union of floors that have real content. A bare
+            // floor sits at the building's placeholder center, so including it would drag the
+            // persisted building center away from where the user actually drew.
+            var contentFloors = _floors
+                .Where(f => FloorHasContent(f)
+                    && IsPositioned(f.SwLatitude, f.SwLongitude) && IsPositioned(f.NeLatitude, f.NeLongitude))
                 .ToList();
-            if (_selectedBuilding != null && positionedFloors.Count > 0)
+            if (_selectedBuilding != null && contentFloors.Count > 0)
             {
-                var unionSwLat = positionedFloors.Min(f => f.SwLatitude);
-                var unionSwLng = positionedFloors.Min(f => f.SwLongitude);
-                var unionNeLat = positionedFloors.Max(f => f.NeLatitude);
-                var unionNeLng = positionedFloors.Max(f => f.NeLongitude);
+                var unionSwLat = contentFloors.Min(f => f.SwLatitude);
+                var unionSwLng = contentFloors.Min(f => f.SwLongitude);
+                var unionNeLat = contentFloors.Max(f => f.NeLatitude);
+                var unionNeLng = contentFloors.Max(f => f.NeLongitude);
                 var centerLat = (unionSwLat + unionNeLat) / 2;
                 var centerLng = (unionSwLng + unionNeLng) / 2;
                 _selectedBuilding.CenterLatitude = centerLat;
@@ -4139,6 +4165,7 @@
         public double Opacity { get; set; } = 0.7;
         public string? WallsJson { get; set; }
         public bool HasImage { get; set; }
+        public bool HasOverlayImages { get; set; }
         public string FloorMaterial { get; set; } = "floor_wood";
     }
 

--- a/src/NetworkOptimizer.Web/Services/FloorPlanService.cs
+++ b/src/NetworkOptimizer.Web/Services/FloorPlanService.cs
@@ -52,7 +52,9 @@ public class FloorPlanService
     public async Task<List<Building>> GetBuildingsAsync()
     {
         using var db = await _dbFactory.CreateDbContextAsync();
-        return await db.Buildings.Include(b => b.Floors).OrderBy(b => b.Name).ToListAsync();
+        return await db.Buildings
+            .Include(b => b.Floors).ThenInclude(f => f.Images)
+            .OrderBy(b => b.Name).ToListAsync();
     }
 
     public async Task<Building?> GetBuildingAsync(int id)

--- a/src/NetworkOptimizer.Web/wwwroot/js/floorPlanEditor.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/floorPlanEditor.js
@@ -459,6 +459,14 @@ window.fpEditor = {
         }
     },
 
+    getCenter: function () {
+        if (this._map) {
+            var c = this._map.getCenter();
+            return [c.lat, c.lng];
+        }
+        return null;
+    },
+
     saveMapView: function (buildingLat, buildingLng) {
         var self = this;
         if (this._map) {

--- a/tests/NetworkOptimizer.Core.Tests/Helpers/MapBoundsHelperTests.cs
+++ b/tests/NetworkOptimizer.Core.Tests/Helpers/MapBoundsHelperTests.cs
@@ -1,0 +1,164 @@
+using FluentAssertions;
+using NetworkOptimizer.Core.Helpers;
+using Xunit;
+
+namespace NetworkOptimizer.Core.Tests.Helpers;
+
+public class MapBoundsHelperTests
+{
+    // A real home location (used as a stand-in for any placed content).
+    private const double HomeLat = 51.0;
+    private const double HomeLng = 7.0;
+
+    // The app's default map center - what a building created before any AP placement
+    // inherits, and the coordinate that used to drag the fit across the globe.
+    private const double DefaultLat = 38.0;
+    private const double DefaultLng = -92.0;
+
+    #region IsPositioned
+
+    [Theory]
+    [InlineData(51.0, 7.0, true)]      // real location
+    [InlineData(38.0, -92.0, true)]    // default center is still a valid coordinate
+    [InlineData(0.0, 0.0, false)]      // null island
+    [InlineData(0.00005, -0.00005, false)] // effectively null island
+    [InlineData(91.0, 7.0, false)]     // latitude out of range
+    [InlineData(51.0, 181.0, false)]   // longitude out of range
+    public void IsPositioned_ClassifiesCoordinates(double lat, double lng, bool expected)
+    {
+        MapBoundsHelper.IsPositioned(lat, lng).Should().Be(expected);
+    }
+
+    #endregion
+
+    #region ComputeBuildingBounds
+
+    [Fact]
+    public void ComputeBuildingBounds_PrefersWalls_WhenPresent()
+    {
+        var walls = new[] { (HomeLat, HomeLng), (HomeLat + 0.001, HomeLng + 0.001) };
+        // A bare floor at the default center must be ignored once walls exist.
+        var floors = new[] { Bare(DefaultLat, DefaultLng) };
+
+        var bounds = MapBoundsHelper.ComputeBuildingBounds(walls, floors);
+
+        bounds.Should().NotBeNull();
+        bounds!.Value.SwLat.Should().BeApproximately(HomeLat, 1e-9);
+        bounds.Value.NeLat.Should().BeApproximately(HomeLat + 0.001, 1e-9);
+    }
+
+    [Fact]
+    public void ComputeBuildingBounds_UsesContentFloors_WhenNoWalls()
+    {
+        var floors = new[]
+        {
+            Content(HomeLat - 0.001, HomeLng - 0.001, HomeLat + 0.001, HomeLng + 0.001),
+            Bare(DefaultLat, DefaultLng), // placeholder floor must not extend the fit
+        };
+
+        var bounds = MapBoundsHelper.ComputeBuildingBounds(NoWalls(), floors);
+
+        bounds.Should().NotBeNull();
+        bounds!.Value.SwLat.Should().BeApproximately(HomeLat - 0.001, 1e-9);
+        bounds.Value.NeLat.Should().BeApproximately(HomeLat + 0.001, 1e-9);
+        bounds.Value.SwLng.Should().BeApproximately(HomeLng - 0.001, 1e-9);
+    }
+
+    [Fact]
+    public void ComputeBuildingBounds_ReturnsNull_ForBareFloorsOnly()
+    {
+        var floors = new[] { Bare(DefaultLat, DefaultLng), Bare(DefaultLat, DefaultLng) };
+
+        MapBoundsHelper.ComputeBuildingBounds(NoWalls(), floors).Should().BeNull();
+    }
+
+    [Fact]
+    public void ComputeBuildingBounds_ReturnsNull_WhenEmpty()
+    {
+        MapBoundsHelper.ComputeBuildingBounds(NoWalls(), System.Array.Empty<MapBoundsHelper.FloorRecord>())
+            .Should().BeNull();
+    }
+
+    #endregion
+
+    #region ComputeAllContentBounds
+
+    /// <summary>
+    /// The reported regression: a German user with placed APs at home but a building/floor
+    /// created earlier at the central-US default. The fit must frame the APs, not span the
+    /// Atlantic to the placeholder floor.
+    /// </summary>
+    [Fact]
+    public void ComputeAllContentBounds_IgnoresPlaceholderFloor_WhenApsPlaced()
+    {
+        var aps = new[] { (HomeLat, HomeLng) };
+        var bareFloorAtDefault = new[] { Bare(DefaultLat, DefaultLng) };
+
+        var bounds = MapBoundsHelper.ComputeAllContentBounds(aps, NoWalls(), bareFloorAtDefault);
+
+        bounds.Should().NotBeNull();
+        bounds!.Value.SwLat.Should().BeApproximately(HomeLat, 1e-9);
+        bounds.Value.NeLat.Should().BeApproximately(HomeLat, 1e-9);
+        bounds.Value.SwLng.Should().BeApproximately(HomeLng, 1e-9);
+        bounds.Value.NeLng.Should().BeApproximately(HomeLng, 1e-9);
+    }
+
+    [Fact]
+    public void ComputeAllContentBounds_ExtendsToContentFloor()
+    {
+        var aps = new[] { (HomeLat, HomeLng) };
+        var floors = new[] { Content(HomeLat + 0.01, HomeLng + 0.01, HomeLat + 0.02, HomeLng + 0.02) };
+
+        var bounds = MapBoundsHelper.ComputeAllContentBounds(aps, NoWalls(), floors);
+
+        bounds.Should().NotBeNull();
+        bounds!.Value.SwLat.Should().BeApproximately(HomeLat, 1e-9);
+        bounds.Value.NeLat.Should().BeApproximately(HomeLat + 0.02, 1e-9);
+    }
+
+    [Fact]
+    public void ComputeAllContentBounds_ExcludesNullIslandAps()
+    {
+        var aps = new[] { (HomeLat, HomeLng), (0.0, 0.0) };
+
+        var bounds = MapBoundsHelper.ComputeAllContentBounds(aps, NoWalls(),
+            System.Array.Empty<MapBoundsHelper.FloorRecord>());
+
+        bounds.Should().NotBeNull();
+        bounds!.Value.SwLat.Should().BeApproximately(HomeLat, 1e-9);
+        bounds.Value.NeLat.Should().BeApproximately(HomeLat, 1e-9);
+    }
+
+    [Fact]
+    public void ComputeAllContentBounds_FramesContentFloor_WhenNoAps()
+    {
+        var floors = new[] { Content(HomeLat - 0.001, HomeLng - 0.001, HomeLat + 0.001, HomeLng + 0.001) };
+
+        var bounds = MapBoundsHelper.ComputeAllContentBounds(
+            System.Array.Empty<(double, double)>(), NoWalls(), floors);
+
+        bounds.Should().NotBeNull();
+        bounds!.Value.SwLat.Should().BeApproximately(HomeLat - 0.001, 1e-9);
+    }
+
+    [Fact]
+    public void ComputeAllContentBounds_ReturnsNull_WhenNothingPlaced()
+    {
+        var bounds = MapBoundsHelper.ComputeAllContentBounds(
+            System.Array.Empty<(double, double)>(),
+            NoWalls(),
+            new[] { Bare(DefaultLat, DefaultLng) });
+
+        bounds.Should().BeNull();
+    }
+
+    #endregion
+
+    private static (double, double)[] NoWalls() => System.Array.Empty<(double, double)>();
+
+    private static MapBoundsHelper.FloorRecord Bare(double lat, double lng) =>
+        new(lat - 0.0002, lng - 0.0002, lat + 0.0002, lng + 0.0002, HasContent: false);
+
+    private static MapBoundsHelper.FloorRecord Content(double swLat, double swLng, double neLat, double neLng) =>
+        new(swLat, swLng, neLat, neLng, HasContent: true);
+}


### PR DESCRIPTION
## What

The Signal Map (and read-only Client Performance map) could open zoomed out across the globe even when APs were placed at home. The earlier framing fix excluded only `(0, 0)` null-island coordinates, but an un-positioned building/floor doesn't sit at null island - a building created before any AP is placed inherits the app's default map center, and its floors inherit that. Those are valid, in-range coordinates, so they slipped past the guard and dragged the fit from home to the default location.

## Changes

- New unit-tested `MapBoundsHelper` in Core: frames the map only to coordinates that represent deliberate content - placed APs, drawn walls, and floors with walls or an image. Bare placeholder records are excluded.
- `FloorPlanEditor` now uses that helper at every fit-bounds site (initial center, all-content fit, building-center union).
- Content detection counts both legacy single images and multi-image overlays.
- New buildings/floors and image overlays seed from a placed AP, otherwise the live map center, instead of a hard-coded default - so future records aren't created in the wrong place.

## Why it's safe

- No-AP / signal-only / speed-only behavior is unchanged: with no APs and no wall/image content, the fit is skipped exactly as before.
- Speed Map is untouched.
- 15 `MapBoundsHelper` unit tests, including the exact reported regression. Clean build, all tests pass.

Deployed to NAS and Mac test sites.