### PR TITLE
Gateway temperature: fall back to UniFi Network when SNMP omits it

### DIFF
--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -679,6 +679,7 @@ public class MonitoringCollectionAgent : BackgroundService
         var gatewayLanIp = await ResolveGatewayLanIpAsync(ct);
         var customOids = await LoadCustomOidsAsync(ct);
         var snmpHealthHits = new ConcurrentDictionary<string, bool>();
+        var snmpTempHits = new ConcurrentDictionary<string, bool>();
         var deviceTasks = devices.Select(async device =>
         {
             await _snmpGate.WaitAsync(ct);
@@ -705,6 +706,8 @@ public class MonitoringCollectionAgent : BackgroundService
 
                 if (cpu != null || memPct != null)
                     snmpHealthHits[NormalizeMac(device.Mac)] = true;
+                if (temp != null)
+                    snmpTempHits[NormalizeMac(device.Mac)] = true;
 
                 await _influx.WriteDeviceHealthAsync(
                     deviceMac: device.Mac,
@@ -760,14 +763,20 @@ public class MonitoringCollectionAgent : BackgroundService
                 double? temp = ParseDeviceTemperature(device);
 
                 // SNMP devices that actually returned health data: only supplement
-                // temp for switches. Devices where SNMP is configured but returned
-                // no health OIDs (e.g., USW-Flex-XG) fall through to full API data.
+                // temp for switches and gateways. Some gateways (e.g., UDM-SE / IPQ
+                // chipset) return CPU/mem over SNMP but not temperature; the UniFi API
+                // exposes it, so fill that gap. Devices where SNMP is configured but
+                // returned no health OIDs (e.g., USW-Flex-XG) fall through to full API data.
                 if (snmpActive && snmpHealthHits.ContainsKey(mac))
                 {
-                    if (device.DeviceType != NetworkOptimizer.Core.Enums.DeviceType.Switch) continue;
+                    if (device.DeviceType != NetworkOptimizer.Core.Enums.DeviceType.Switch
+                        && device.DeviceType != NetworkOptimizer.Core.Enums.DeviceType.Gateway) continue;
                     cpu = null;
                     mem = null;
                     uptime = null;
+                    // SNMP already reported a temperature for this device; don't
+                    // double-write it from the API (avoids conflicting data points).
+                    if (snmpTempHits.ContainsKey(mac)) continue;
                     if (temp == null) continue;
                 }
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -763,10 +763,13 @@ public class MonitoringCollectionAgent : BackgroundService
                 double? temp = ParseDeviceTemperature(device);
 
                 // SNMP devices that actually returned health data: only supplement
-                // temp for switches and gateways. Some gateways (e.g., UDM-SE / IPQ
-                // chipset) return CPU/mem over SNMP but not temperature; the UniFi API
-                // exposes it, so fill that gap. Devices where SNMP is configured but
-                // returned no health OIDs (e.g., USW-Flex-XG) fall through to full API data.
+                // temp for switches and gateways. Some gateways (e.g., the UDM family)
+                // return CPU/mem over SNMP but not temperature; the UniFi API exposes
+                // it, so fill that gap. This is keyed off whether SNMP actually returned
+                // a temperature at runtime (snmpTempHits), not off any model, so gateways
+                // that do report temp over SNMP are untouched. Devices where SNMP is
+                // configured but returned no health OIDs (e.g., USW-Flex-XG) fall through
+                // to full API data.
                 if (snmpActive && snmpHealthHits.ContainsKey(mac))
                 {
                     if (device.DeviceType != NetworkOptimizer.Core.Enums.DeviceType.Switch


### PR DESCRIPTION
Some gateways (the UDM family) report CPU and memory over SNMP but not temperature, so their temperature reading came up empty. Switches already have a fallback that pulls temperature from the UniFi Network API when SNMP doesn't provide it; this extends that same fallback to gateways.

## What changed

- Gateways now participate in the UniFi Network API temperature fallback, the same way switches already did.
- The fallback only fills temperature. CPU, memory, and uptime always stay SNMP-sourced and are never touched by the API pass.
- The decision is made at runtime from whether SNMP actually returned a temperature for that device, not from any model assumption. A new `snmpTempHits` set records which devices got a temperature over SNMP.
- Gateways (and switches) that do report temperature over SNMP keep using it. The API never double-writes temperature for them.

Net effect: the only newly-filled case is a gateway where SNMP returns CPU/mem but no temperature. Everything that already had SNMP temperature is unchanged.

Fixes #910