### PR TITLE
v1.23.3 Release Changes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -548,3 +548,26 @@ The app auto-detects controller type via login response, but needs testing with 
 - Path detection logic in `UniFiApiClient`
 - All API endpoints work correctly
 - Authentication flow differences (if any)
+
+## Channel Recommendation: Learn From Tried Configs (Outcome History)
+
+Track the channel combinations the user has actually run over time and the util/interference that
+resulted, then weight recommendations toward combos that measurably performed better - a real
+feedback loop instead of inference. UniFi's own metrics history is too short and only reflects the
+current channel, so we need our own longer-term store of tried configs and their outcomes.
+
+**Motivation:** The engine can produce confident false positives. Example (2.4 GHz, two co-located
+APs): it scored a straight 1<->11 swap as ~17% better, but the operator who set these channels up
+knows the swap is actually worse for util/interference. The "improvement" came almost entirely from:
+- **Propagated stress** - each AP's score on the channel it would move TO is inferred from the
+  *other* AP's measurement (halved by proximity), not measured. Circular.
+- **Self-induced load treated as environmental** - a channel's high utilization largely reflects
+  that AP's own clients, which move with it; the model assumes switching channels escapes it.
+- **Thin external margins, no direct scan data** - the only location-specific neighbor signal was
+  triangulated (logs showed "no scan channel data"), with tiny per-channel deltas.
+
+- [ ] Persist each observed (AP, channel, width) -> rolling util/interference/tx-retry outcome, long-term
+- [ ] Attribute metrics to the combo that was actually live (key off channel-change events)
+- [ ] When a candidate assignment matches a previously-tried combo, prefer measured outcome over inferred score
+- [ ] Down-weight (or flag) recommendations whose predicted gain rests mostly on propagated stress
+- [ ] Distinguish self-induced load from environmental interference - don't credit a move for escaping the AP's own traffic

--- a/src/NetworkOptimizer.Core/Helpers/MapBoundsHelper.cs
+++ b/src/NetworkOptimizer.Core/Helpers/MapBoundsHelper.cs
@@ -1,0 +1,112 @@
+namespace NetworkOptimizer.Core.Helpers;
+
+/// <summary>
+/// Geometry helpers for framing the floor-plan / signal map to real content.
+///
+/// Floor and building records are created with placeholder coordinates: a new floor
+/// inherits its building's center, and a building created before any AP is placed
+/// falls back to the app's default map center. Fitting the map to those raw records
+/// drags the view to the placeholder (e.g. a German user's map zooming out to the
+/// central-US default). These helpers fit only to coordinates that represent
+/// deliberate user content: placed APs, drawn walls, and floors with real content
+/// (walls or an uploaded image). Bare placeholder records are excluded.
+/// </summary>
+public static class MapBoundsHelper
+{
+    /// <summary>A south-west / north-east lat-lng bounding box.</summary>
+    public readonly record struct GeoBounds(double SwLat, double SwLng, double NeLat, double NeLng);
+
+    /// <summary>
+    /// A floor's stored overlay bounds plus whether the floor has real user content.
+    /// A floor with no walls and no image sits at its building's placeholder center and
+    /// must not participate in the map fit.
+    /// </summary>
+    public readonly record struct FloorRecord(double SwLat, double SwLng, double NeLat, double NeLng, bool HasContent);
+
+    /// <summary>
+    /// True if a lat/lng pair is a usable real coordinate rather than an unset default.
+    /// Some record paths default to (0, 0) null island; both that and out-of-range
+    /// values are rejected.
+    /// </summary>
+    public static bool IsPositioned(double lat, double lng)
+    {
+        if (Math.Abs(lat) < 0.0001 && Math.Abs(lng) < 0.0001) return false;
+        return lat is >= -90 and <= 90 && lng is >= -180 and <= 180;
+    }
+
+    /// <summary>
+    /// Bounds of all positioned content for a set of buildings: drawn walls if any exist,
+    /// otherwise the overlay bounds of floors that have real content. Bare floors sitting
+    /// at their building's placeholder center are excluded. Returns null when there is no
+    /// positioned content.
+    /// </summary>
+    public static GeoBounds? ComputeBuildingBounds(
+        IEnumerable<(double Lat, double Lng)> wallPoints,
+        IEnumerable<FloorRecord> floors)
+    {
+        var acc = new BoundsAccumulator();
+
+        foreach (var p in wallPoints)
+            if (IsPositioned(p.Lat, p.Lng)) acc.Add(p.Lat, p.Lng);
+
+        // Real, drawn walls are the most reliable signal; prefer them outright.
+        if (acc.HasData) return acc.ToBounds();
+
+        foreach (var f in floors)
+            if (f.HasContent && IsPositioned(f.SwLat, f.SwLng) && IsPositioned(f.NeLat, f.NeLng))
+            {
+                acc.Add(f.SwLat, f.SwLng);
+                acc.Add(f.NeLat, f.NeLng);
+            }
+
+        return acc.HasData ? acc.ToBounds() : null;
+    }
+
+    /// <summary>
+    /// Bounds spanning placed APs plus positioned building content. APs anchor the frame;
+    /// wall / floor content extends it. Placeholder records never participate. Returns null
+    /// when nothing positioned is present.
+    /// </summary>
+    public static GeoBounds? ComputeAllContentBounds(
+        IEnumerable<(double Lat, double Lng)> apPoints,
+        IEnumerable<(double Lat, double Lng)> wallPoints,
+        IEnumerable<FloorRecord> floors)
+    {
+        var acc = new BoundsAccumulator();
+
+        foreach (var p in apPoints)
+            if (IsPositioned(p.Lat, p.Lng)) acc.Add(p.Lat, p.Lng);
+
+        var building = ComputeBuildingBounds(wallPoints, floors);
+        if (building.HasValue)
+        {
+            acc.Add(building.Value.SwLat, building.Value.SwLng);
+            acc.Add(building.Value.NeLat, building.Value.NeLng);
+        }
+
+        return acc.HasData ? acc.ToBounds() : null;
+    }
+
+    private struct BoundsAccumulator
+    {
+        private double _swLat, _swLng, _neLat, _neLng;
+        public bool HasData { get; private set; }
+
+        public void Add(double lat, double lng)
+        {
+            if (!HasData)
+            {
+                _swLat = _neLat = lat;
+                _swLng = _neLng = lng;
+                HasData = true;
+                return;
+            }
+            _swLat = Math.Min(_swLat, lat);
+            _swLng = Math.Min(_swLng, lng);
+            _neLat = Math.Max(_neLat, lat);
+            _neLng = Math.Max(_neLng, lng);
+        }
+
+        public readonly GeoBounds ToBounds() => new(_swLat, _swLng, _neLat, _neLng);
+    }
+}

--- a/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
@@ -1019,6 +1019,15 @@ public class RadioTableStats
     public int? Channel { get; set; }
 
     /// <summary>
+    /// Operating channel width in MHz (the width the radio is actually running at right now).
+    /// Distinct from radio_table's configured "ht" - a mesh backhaul radio can be configured
+    /// for 160 MHz but negotiate down to the parent's width (e.g. 80 MHz) on the link.
+    /// </summary>
+    [JsonPropertyName("bw")]
+    [JsonConverter(typeof(FlexibleIntConverter))]
+    public int? Bw { get; set; }
+
+    /// <summary>
     /// Extension channel for 40MHz+ widths
     /// </summary>
     [JsonPropertyName("extchannel")]

--- a/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
@@ -90,6 +90,11 @@ public class UniFiDiscovery
                 UplinkTxRateKbps = d.Uplink?.TxRate ?? 0,
                 UplinkRxRateKbps = d.Uplink?.RxRate ?? 0,
                 UplinkType = d.Uplink?.Type,
+                // Active uplink interface name. For a wireless mesh child this is the
+                // wpa_supplicant STA backhaul iface (e.g. "vwiresta7"); for wired APs/gateways
+                // it's the wired/WAN iface. Callers must validate the "vwiresta" prefix before
+                // treating it as a mesh backhaul interface.
+                UplinkInterface = d.Uplink?.Name,
                 UplinkRadioBand = d.Uplink?.RadioBand,
                 UplinkChannel = d.Uplink?.Channel,
                 UplinkSignalDbm = d.Uplink?.Signal,
@@ -725,6 +730,12 @@ public class DiscoveredDevice
     /// <summary>RX rate in Kbps for wireless uplinks</summary>
     public long UplinkRxRateKbps { get; set; }
     public string? UplinkType { get; set; }  // "wire" or "wireless"
+    /// <summary>
+    /// Active uplink interface name (uplink.name). For a wireless mesh child this is the
+    /// wpa_supplicant STA backhaul iface (e.g. "vwiresta7"); for wired APs/gateways it's the
+    /// wired/WAN iface. Validate the "vwiresta" prefix before using as a mesh backhaul iface.
+    /// </summary>
+    public string? UplinkInterface { get; set; }
     public string? UplinkRadioBand { get; set; }  // "ng" (2.4GHz), "na" (5GHz), "6e" (6GHz)
     public int? UplinkChannel { get; set; }
     public int? UplinkSignalDbm { get; set; }

--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -11,6 +11,7 @@
 @inject UniFiConnectionService ConnectionService
 @inject NavigationManager NavigationManager
 @inject ApMapService ApMapService
+@inject MeshOptimizationService MeshService
 @inject PullToRefreshState PtrState
 @implements IDisposable
 @rendermode InteractiveServer
@@ -41,6 +42,17 @@
             </div>
             <a href="/settings" class="btn btn-primary">@(!string.IsNullOrEmpty(ConnectionService.LastError) ? "Check Settings" : "Connect Now")</a>
         </div>
+    </div>
+}
+
+@if (!string.IsNullOrEmpty(_toastMessage))
+{
+    <div class="wifi-toast alert @_toastClass">
+        <div>@_toastMessage</div>
+        @if (!string.IsNullOrEmpty(_toastNote))
+        {
+            <div class="wifi-toast-note">@_toastNote</div>
+        }
     </div>
 }
 
@@ -587,31 +599,52 @@
                                         <span class="ap-status-text">@(ap.IsOnline ? "Online" : "Offline")</span>
                                     </div>
                                 </div>
-                                <div class="ap-stats">
+                                <div class="ap-stats @(ap.IsMeshChild ? "ap-stats-mesh" : "")">
                                     <div class="ap-stat clickable" @onclick="@(() => NavigateToTab("client", ap.Mac))" @onclick:stopPropagation="true">
                                         <span class="ap-stat-value">@ap.TotalClients</span>
                                         <span class="ap-stat-label">Clients</span>
                                     </div>
-                                    @if (ap.IsMeshChild && ap.MeshUplinkSignalDbm.HasValue)
+                                    @if (ap.IsMeshChild && (ap.MeshUplinkSignalDbm.HasValue || !string.IsNullOrEmpty(ap.MeshUplinkInterface)))
                                     {
-                                        <div class="ap-mesh-info">
-                                            <div class="mesh-signal">
-                                                <span class="mesh-signal-value"><span class="@SignalClassification.GetSignalClass(ap.MeshUplinkSignalDbm.Value, ap.MeshUplinkBand ?? RadioBand.Band5GHz)">@ap.MeshUplinkSignalDbm</span> <span class="mesh-unit">dBm</span></span>
-                                                @if (ap.MeshUplinkTxRateMbps.HasValue || ap.MeshUplinkRxRateMbps.HasValue)
-                                                {
-                                                    <span class="mesh-rates">
-                                                        @if (ap.MeshUplinkTxRateMbps.HasValue)
-                                                        {
-                                                            <span class="mesh-rate wifi-speed-tx">TX @ap.MeshUplinkTxRateMbps</span>
-                                                        }
-                                                        @if (ap.MeshUplinkRxRateMbps.HasValue)
-                                                        {
-                                                            <span class="mesh-rate wifi-speed-rx">RX @ap.MeshUplinkRxRateMbps</span>
-                                                        }
-                                                    </span>
-                                                }
-                                            </div>
-                                            <span class="ap-stat-label"><strong>Mesh Uplink</strong>@(ap.MeshParentName != null ? $" to {ap.MeshParentName}" : "")</span>
+                                        <div class="ap-mesh-info @(!string.IsNullOrEmpty(ap.MeshUplinkInterface) ? "ap-mesh-info-with-action" : "")">
+                                            @if (!string.IsNullOrEmpty(ap.MeshUplinkInterface))
+                                            {
+                                                <button class="btn btn-sm btn-primary optimize-mesh-btn"
+                                                        @onclick="@(() => OptimizeMeshAsync(ap))"
+                                                        disabled="@(!ap.IsOnline || _optimizingMacs.Contains(ap.Mac))"
+                                                        data-tooltip="Re-scans the mesh uplink so this AP reconnects to its highest Uplink Priority parent when it's stuck on a weaker one. Safe to re-run.">
+                                                    @if (_optimizingMacs.Contains(ap.Mac))
+                                                    {
+                                                        <span class="spinner-sm"></span>
+                                                        <span>Re-pairing...</span>
+                                                    }
+                                                    else
+                                                    {
+                                                        <span class="optimize-mesh-icon">&#x21bb;</span>
+                                                        <span>Re-pair Uplink</span>
+                                                    }
+                                                </button>
+                                            }
+                                            @if (ap.MeshUplinkSignalDbm.HasValue)
+                                            {
+                                                <div class="mesh-signal">
+                                                    <span class="mesh-signal-value"><span class="@SignalClassification.GetSignalClass(ap.MeshUplinkSignalDbm.Value, ap.MeshUplinkBand ?? RadioBand.Band5GHz)">@ap.MeshUplinkSignalDbm</span> <span class="mesh-unit">dBm</span></span>
+                                                    @if (ap.MeshUplinkTxRateMbps.HasValue || ap.MeshUplinkRxRateMbps.HasValue)
+                                                    {
+                                                        <span class="mesh-rates">
+                                                            @if (ap.MeshUplinkTxRateMbps.HasValue)
+                                                            {
+                                                                <span class="mesh-rate wifi-speed-tx">TX @ap.MeshUplinkTxRateMbps</span>
+                                                            }
+                                                            @if (ap.MeshUplinkRxRateMbps.HasValue)
+                                                            {
+                                                                <span class="mesh-rate wifi-speed-rx">RX @ap.MeshUplinkRxRateMbps</span>
+                                                            }
+                                                        </span>
+                                                    }
+                                                </div>
+                                                <span class="ap-stat-label"><strong>Mesh Uplink</strong>@(ap.MeshParentName != null ? $" to {ap.MeshParentName}" : "")</span>
+                                            }
                                         </div>
                                     }
                                     @if (ap.MeshChildren.Count > 0)
@@ -875,6 +908,12 @@
     private List<ApMapMarker> _apMapMarkers = new();
     private System.Threading.Timer? _mapPollTimer;
 
+    // MACs of mesh children with an in-flight Optimize Mesh action (drives the per-card spinner).
+    private readonly HashSet<string> _optimizingMacs = new();
+    private string? _toastMessage;
+    private string? _toastNote;
+    private string _toastClass = "alert-info";
+
     // Auto-refresh the Overview tab once the health score has aged past this, so a parked
     // tab doesn't show indefinitely stale data. Checked on each map-poll tick.
     private static readonly TimeSpan HealthScoreStaleAfter = TimeSpan.FromMinutes(1);
@@ -1031,6 +1070,81 @@
         // Channel recommendations run the full engine; compute in the background so they don't
         // delay the overview paint. The card shows its own loading state until ready.
         _ = LoadChannelRecommendationsAsync();
+    }
+
+    private async Task OptimizeMeshAsync(AccessPointSnapshot ap)
+    {
+        if (_optimizingMacs.Contains(ap.Mac)) return;
+
+        _optimizingMacs.Add(ap.Mac);
+        StateHasChanged();
+
+        try
+        {
+            var result = await MeshService.OptimizeAsync(ap.Ip, ap.MeshUplinkInterface, ap.Name);
+            // Only warn about the data lag when it actually roamed - there's nothing to wait for
+            // on a noop or a failure.
+            var note = result.Action == "moved"
+                ? "It may take a minute for the AP data to update."
+                : null;
+            ShowToast(result.Message, result.Ok ? "alert-success" : "alert-warning", note);
+
+            // Pull once now in case the controller already caught up, then again after delays:
+            // the UniFi controller's device list lags the actual roam by ~30s, so the immediate
+            // pull usually still shows the old parent. The +5s catches a fast update and the +30s
+            // catches the typical controller lag.
+            _accessPoints = await WiFiService.GetAccessPointsAsync(forceRefresh: true);
+            _ = RefreshAccessPointsLater(TimeSpan.FromSeconds(5));
+            _ = RefreshAccessPointsLater(TimeSpan.FromSeconds(30));
+        }
+        catch
+        {
+            // The service logs the detail; surface a friendly message to the user.
+            ShowToast("Couldn't optimize the mesh uplink. Check the AP's SSH connection.", "alert-warning");
+        }
+        finally
+        {
+            _optimizingMacs.Remove(ap.Mac);
+            StateHasChanged();
+        }
+    }
+
+    private async Task RefreshAccessPointsLater(TimeSpan delay)
+    {
+        try
+        {
+            await Task.Delay(delay);
+            var aps = await WiFiService.GetAccessPointsAsync(forceRefresh: true);
+            await InvokeAsync(() =>
+            {
+                _accessPoints = aps;
+                StateHasChanged();
+            });
+        }
+        catch
+        {
+            // Best-effort follow-up refresh; ignore failures (e.g., the circuit went away).
+        }
+    }
+
+    private void ShowToast(string message, string cssClass, string? note = null)
+    {
+        _toastMessage = message;
+        _toastNote = note;
+        _toastClass = cssClass;
+        StateHasChanged();
+
+        // Auto-dismiss after a few seconds without blocking.
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(TimeSpan.FromSeconds(6));
+            await InvokeAsync(() =>
+            {
+                _toastMessage = null;
+                _toastNote = null;
+                StateHasChanged();
+            });
+        });
     }
 
     private async Task RefreshData()

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/FloorPlanEditor.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/FloorPlanEditor.razor
@@ -1809,25 +1809,28 @@
         }
         else if (_buildings.Count > 0)
         {
-            // No placed APs - fit to all buildings (positioned floors/buildings only)
-            var positionedFloors = _buildings.SelectMany(b => b.Floors)
-                .Where(f => IsPositioned(f.SwLatitude, f.SwLongitude) && IsPositioned(f.NeLatitude, f.NeLongitude))
+            // No placed APs - fit to floors/buildings that have real content. Bare
+            // placeholder records (no walls, no image) are skipped so they can't drag the
+            // initial center to the app's default map location.
+            var contentFloors = _buildings.SelectMany(b => b.Floors)
+                .Where(f => FloorHasContent(f)
+                    && IsPositioned(f.SwLatitude, f.SwLongitude) && IsPositioned(f.NeLatitude, f.NeLongitude))
                 .ToList();
-            if (positionedFloors.Count > 0)
+            if (contentFloors.Count > 0)
             {
-                centerLat = positionedFloors.Average(f => (f.SwLatitude + f.NeLatitude) / 2);
-                centerLng = positionedFloors.Average(f => (f.SwLongitude + f.NeLongitude) / 2);
+                centerLat = contentFloors.Average(f => (f.SwLatitude + f.NeLatitude) / 2);
+                centerLng = contentFloors.Average(f => (f.SwLongitude + f.NeLongitude) / 2);
                 zoom = 19;
             }
             else
             {
-                var positionedBuildings = _buildings
-                    .Where(b => IsPositioned(b.CenterLatitude, b.CenterLongitude))
+                var contentBuildings = _buildings
+                    .Where(b => b.Floors.Any(FloorHasContent) && IsPositioned(b.CenterLatitude, b.CenterLongitude))
                     .ToList();
-                if (positionedBuildings.Count > 0)
+                if (contentBuildings.Count > 0)
                 {
-                    centerLat = positionedBuildings.Average(b => b.CenterLatitude);
-                    centerLng = positionedBuildings.Average(b => b.CenterLongitude);
+                    centerLat = contentBuildings.Average(b => b.CenterLatitude);
+                    centerLng = contentBuildings.Average(b => b.CenterLongitude);
                     zoom = 19;
                 }
             }
@@ -1870,6 +1873,23 @@
         }
     }
 
+    /// <summary>
+    /// The current live map center, used to seed new buildings/floors at the location the
+    /// user is actually looking at instead of a hard-coded default. Returns null when the
+    /// map is not yet initialized or the JS call fails.
+    /// </summary>
+    private async Task<(double lat, double lng)?> GetMapCenterAsync()
+    {
+        if (!_mapInitialized) return null;
+        try
+        {
+            var c = await JS.InvokeAsync<double[]?>("fpEditor.getCenter");
+            if (c is { Length: 2 } && IsPositioned(c[0], c[1])) return (c[0], c[1]);
+        }
+        catch { }
+        return null;
+    }
+
     private async Task LoadBuildings()
     {
         try
@@ -1886,6 +1906,7 @@
                     NeLatitude = f.NeLatitude, NeLongitude = f.NeLongitude,
                     Opacity = f.Opacity, WallsJson = f.WallsJson,
                     HasImage = !string.IsNullOrEmpty(f.ImagePath),
+                    HasOverlayImages = f.Images.Count > 0,
                     FloorMaterial = f.FloorMaterial
                 }).ToList()
             }).ToList();
@@ -2042,10 +2063,8 @@
 
     private (double swLat, double swLng, double neLat, double neLng) ComputeAllBuildingBounds()
     {
-        double swLat = double.MaxValue, swLng = double.MaxValue;
-        double neLat = double.MinValue, neLng = double.MinValue;
-        bool hasData = false;
-
+        // Real, drawn walls are the most reliable positioning signal; collect their points.
+        var wallPoints = new List<(double Lat, double Lng)>();
         var jsonOpts = new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true };
         foreach (var b in _buildings)
         {
@@ -2058,49 +2077,41 @@
                     if (walls == null) continue;
                     foreach (var wall in walls)
                         foreach (var pt in wall.Points)
-                        {
-                            swLat = Math.Min(swLat, pt.Lat);
-                            swLng = Math.Min(swLng, pt.Lng);
-                            neLat = Math.Max(neLat, pt.Lat);
-                            neLng = Math.Max(neLng, pt.Lng);
-                            hasData = true;
-                        }
+                            wallPoints.Add((pt.Lat, pt.Lng));
                 }
                 catch { }
             }
         }
 
-        if (!hasData)
-        {
-            // Fall back to floor record bounds. Skip floors that were created but never
-            // positioned: their SwLatitude/NeLatitude default to 0, and a single such floor
-            // would drag the fit bounds out to null island and zoom the map to the whole globe.
-            var positionedFloors = _buildings.SelectMany(b2 => b2.Floors)
-                .Where(f => IsPositioned(f.SwLatitude, f.SwLongitude) && IsPositioned(f.NeLatitude, f.NeLongitude))
-                .ToList();
-            if (positionedFloors.Count > 0)
-            {
-                swLat = positionedFloors.Min(f => f.SwLatitude);
-                swLng = positionedFloors.Min(f => f.SwLongitude);
-                neLat = positionedFloors.Max(f => f.NeLatitude);
-                neLng = positionedFloors.Max(f => f.NeLongitude);
-            }
-        }
+        // Fall back to floor overlay bounds, but only for floors with real content (walls
+        // or an image). A bare floor sits at its building's placeholder center - which is
+        // an in-range coordinate (the app's default map center), so a coordinate-only guard
+        // would let it through and drag the fit halfway across the globe.
+        var floorRecords = _buildings.SelectMany(b => b.Floors)
+            .Select(f => new MapBoundsHelper.FloorRecord(
+                f.SwLatitude, f.SwLongitude, f.NeLatitude, f.NeLongitude, FloorHasContent(f)));
 
-        return (swLat, swLng, neLat, neLng);
+        var bounds = MapBoundsHelper.ComputeBuildingBounds(wallPoints, floorRecords);
+        return bounds.HasValue
+            ? (bounds.Value.SwLat, bounds.Value.SwLng, bounds.Value.NeLat, bounds.Value.NeLng)
+            : (double.MaxValue, double.MaxValue, double.MinValue, double.MinValue);
     }
 
     /// <summary>
     /// True if a lat/lng pair represents a real placed location rather than an unset
-    /// default. Floor/building records use non-nullable doubles that default to 0, so an
-    /// un-positioned floor reads as (0, 0) (null island) and must be excluded from map
-    /// fit-bounds calculations or it zooms the map out to the whole world.
+    /// default. Forwards to <see cref="MapBoundsHelper.IsPositioned"/> (the single source
+    /// of truth, unit-tested) so every fit-bounds call site agrees.
     /// </summary>
-    private static bool IsPositioned(double lat, double lng)
-    {
-        if (Math.Abs(lat) < 0.0001 && Math.Abs(lng) < 0.0001) return false;
-        return lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180;
-    }
+    private static bool IsPositioned(double lat, double lng) => MapBoundsHelper.IsPositioned(lat, lng);
+
+    /// <summary>
+    /// True if a floor has real user-established content - drawn walls or an uploaded
+    /// image - so its stored bounds reflect a deliberate position. A bare floor inherits
+    /// its building's placeholder center at creation and must not drag the map fit, even
+    /// though its coordinates are technically in-range (e.g. the app's default map center).
+    /// </summary>
+    private static bool FloorHasContent(FloorDto f) =>
+        (!string.IsNullOrWhiteSpace(f.WallsJson) && f.WallsJson != "[]") || f.HasImage || f.HasOverlayImages;
 
     private async Task SelectFloor(int floorId)
     {
@@ -3665,7 +3676,14 @@
         {
             var centerLat = _selectedBuilding.CenterLatitude;
             var centerLng = _selectedBuilding.CenterLongitude;
-            if (centerLat == 0 && centerLng == 0) { centerLat = 38.0; centerLng = -92.0; }
+            // Uploading an image marks the floor as content, so its bounds now feed the map
+            // fit. Never seed them at the hard-coded default: prefer the live map center, and
+            // only fall back to the default for a genuinely empty map.
+            if (centerLat == 0 && centerLng == 0)
+            {
+                if (await GetMapCenterAsync() is { } c) { centerLat = c.lat; centerLng = c.lng; }
+                else { centerLat = 38.0; centerLng = -92.0; }
+            }
             var latOffset = 25.0 / 111320.0;
             var lngOffset = 25.0 / (111320.0 * Math.Cos(centerLat * Math.PI / 180));
             _selectedFloor.SwLatitude = centerLat - latOffset;
@@ -3714,10 +3732,15 @@
     {
         _newBuildingName = _newBuildingName.Trim();
         if (string.IsNullOrWhiteSpace(_newBuildingName)) return;
+        // Seed the new building at a real location so its floors don't inherit a placeholder
+        // center: a placed AP first, otherwise wherever the user has the map pointed. Only
+        // fall back to the default when nothing better is available (genuinely empty map).
         var lat = 38.0;
         var lng = -92.0;
-        var firstAp = _apMarkers.FirstOrDefault(a => a.Latitude.HasValue);
+        var firstAp = _apMarkers.FirstOrDefault(a => a.Latitude.HasValue && a.Longitude.HasValue
+            && IsPositioned(a.Latitude.Value, a.Longitude.Value));
         if (firstAp != null) { lat = firstAp.Latitude!.Value; lng = firstAp.Longitude!.Value; }
+        else if (await GetMapCenterAsync() is { } center) { lat = center.lat; lng = center.lng; }
 
         var building = await FloorPlanSvc.CreateBuildingAsync(_newBuildingName, lat, lng);
         HeatmapCache.Invalidate();
@@ -4084,20 +4107,23 @@
             floor.SwLongitude = swLng;
             floor.NeLatitude = neLat;
             floor.NeLongitude = neLng;
+            // Keep the in-memory floor consistent so content/position checks below see the walls.
+            floor.WallsJson = wallsJson;
             await FloorPlanSvc.UpdateFloorAsync(floor.Id, swLat: swLat, swLng: swLng, neLat: neLat, neLng: neLng);
 
-            // Update building center from union of all positioned floor bounds. Excluding
-            // un-positioned floors (default 0 bounds) keeps the persisted building center
-            // from being pulled toward null island when a floor hasn't been placed yet.
-            var positionedFloors = _floors
-                .Where(f => IsPositioned(f.SwLatitude, f.SwLongitude) && IsPositioned(f.NeLatitude, f.NeLongitude))
+            // Update building center from the union of floors that have real content. A bare
+            // floor sits at the building's placeholder center, so including it would drag the
+            // persisted building center away from where the user actually drew.
+            var contentFloors = _floors
+                .Where(f => FloorHasContent(f)
+                    && IsPositioned(f.SwLatitude, f.SwLongitude) && IsPositioned(f.NeLatitude, f.NeLongitude))
                 .ToList();
-            if (_selectedBuilding != null && positionedFloors.Count > 0)
+            if (_selectedBuilding != null && contentFloors.Count > 0)
             {
-                var unionSwLat = positionedFloors.Min(f => f.SwLatitude);
-                var unionSwLng = positionedFloors.Min(f => f.SwLongitude);
-                var unionNeLat = positionedFloors.Max(f => f.NeLatitude);
-                var unionNeLng = positionedFloors.Max(f => f.NeLongitude);
+                var unionSwLat = contentFloors.Min(f => f.SwLatitude);
+                var unionSwLng = contentFloors.Min(f => f.SwLongitude);
+                var unionNeLat = contentFloors.Max(f => f.NeLatitude);
+                var unionNeLng = contentFloors.Max(f => f.NeLongitude);
                 var centerLat = (unionSwLat + unionNeLat) / 2;
                 var centerLng = (unionSwLng + unionNeLng) / 2;
                 _selectedBuilding.CenterLatitude = centerLat;
@@ -4139,6 +4165,7 @@
         public double Opacity { get; set; } = 0.7;
         public string? WallsJson { get; set; }
         public bool HasImage { get; set; }
+        public bool HasOverlayImages { get; set; }
         public string FloorMaterial { get; set; } = "floor_wood";
     }
 

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -444,6 +444,8 @@ builder.Services.AddSingleton<NetworkOptimizer.WiFi.Rules.IWiFiOptimizerRule, Ne
 builder.Services.AddSingleton<NetworkOptimizer.WiFi.Rules.IWiFiOptimizerRule, NetworkOptimizer.WiFi.Rules.WideChannelWidthRule>();
 builder.Services.AddSingleton<NetworkOptimizer.WiFi.Rules.WiFiOptimizerEngine>();
 builder.Services.AddScoped<WiFiOptimizerService>();
+// Mesh backhaul re-scan (Optimize Mesh button); stateless, uses UniFiSshService singleton.
+builder.Services.AddSingleton<MeshOptimizationService>();
 builder.Services.AddScoped<ApMapService>();
 builder.Services.AddSingleton<FloorPlanService>();
 builder.Services.AddSingleton<HeatmapDataCache>();

--- a/src/NetworkOptimizer.Web/Services/FloorPlanService.cs
+++ b/src/NetworkOptimizer.Web/Services/FloorPlanService.cs
@@ -52,7 +52,9 @@ public class FloorPlanService
     public async Task<List<Building>> GetBuildingsAsync()
     {
         using var db = await _dbFactory.CreateDbContextAsync();
-        return await db.Buildings.Include(b => b.Floors).OrderBy(b => b.Name).ToListAsync();
+        return await db.Buildings
+            .Include(b => b.Floors).ThenInclude(f => f.Images)
+            .OrderBy(b => b.Name).ToListAsync();
     }
 
     public async Task<Building?> GetBuildingAsync(int id)

--- a/src/NetworkOptimizer.Web/Services/MeshOptimizationService.cs
+++ b/src/NetworkOptimizer.Web/Services/MeshOptimizationService.cs
@@ -1,0 +1,197 @@
+using System.Text.RegularExpressions;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Triggers a backhaul re-scan on a mesh-child AP over SSH so it self-roams to the strongest
+/// available parent. The parent set is decided by UniFi Network (Auto, or a constrained/pinned
+/// parent); this service never chooses the parent - it only prompts the scan and reports the
+/// before/after link. On-demand, re-runnable, idempotent.
+/// </summary>
+public class MeshOptimizationService
+{
+    private readonly UniFiSshService _ssh;
+    private readonly ILogger<MeshOptimizationService> _logger;
+
+    /// <summary>
+    /// After the scan, the AP evaluates results and roams on its own - which can take well over
+    /// ten seconds. Poll the link this many times, waiting <see cref="RoamPollInterval"/> between
+    /// reads, stopping early once it lands on a new parent.
+    /// </summary>
+    private const int RoamPollAttempts = 7;
+
+    /// <summary>Delay between post-scan link reads (also the initial settle after the scan).</summary>
+    private static readonly TimeSpan RoamPollInterval = TimeSpan.FromSeconds(3);
+
+    /// <summary>
+    /// The STA backhaul iface is interpolated into a shell command, so its format is locked down
+    /// to the known UniFi pattern (e.g. "vwiresta7") to prevent command injection.
+    /// </summary>
+    private static readonly Regex ValidStaIface = new(@"^vwiresta\d+$", RegexOptions.Compiled);
+
+    public MeshOptimizationService(UniFiSshService ssh, ILogger<MeshOptimizationService> logger)
+    {
+        _ssh = ssh;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Run a backhaul re-scan on the given mesh-child AP and report whether it moved to a
+    /// stronger parent.
+    /// </summary>
+    /// <param name="host">The AP's IP/host for SSH.</param>
+    /// <param name="iface">The STA backhaul interface (e.g. "vwiresta7").</param>
+    /// <param name="apName">AP display name, used only for log/message context.</param>
+    public async Task<MeshOptimizationResult> OptimizeAsync(
+        string? host, string? iface, string? apName, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(host))
+            return MeshOptimizationResult.NoOp(iface, "This AP has no reachable address.");
+
+        if (string.IsNullOrWhiteSpace(iface) || !ValidStaIface.IsMatch(iface))
+            return MeshOptimizationResult.NoOp(iface, "This AP isn't a wireless mesh child.");
+
+        // The action runs over the shared UniFi device SSH credentials. Without them every
+        // wpa_cli call just fails with a generic error, so check up front and point the user at
+        // where to set it up.
+        var sshSettings = await _ssh.GetSettingsAsync();
+        var sshConfigured = !string.IsNullOrEmpty(sshSettings.Username) &&
+            (!string.IsNullOrEmpty(sshSettings.Password) || !string.IsNullOrEmpty(sshSettings.PrivateKeyPath));
+        if (!sshConfigured)
+            return MeshOptimizationResult.NoOp(iface, "Set up UniFi Device SSH in Settings to re-pair the uplink.");
+
+        // wpa_cli control socket is per-interface on the AP (BusyBox / POSIX sh, runtime only).
+        var wc = $"wpa_cli -p /var/run/wpa_supplicant/wpa_supplicant-{iface} -i {iface}";
+
+        var before = await ReadLinkAsync(host, wc, cancellationToken);
+        if (before.Bssid == null)
+        {
+            _logger.LogDebug("[MeshOptimize] {Ap}: could not read backhaul status on {Iface}", apName, iface);
+            return MeshOptimizationResult.Failed(iface, "Couldn't read the mesh backhaul status.");
+        }
+
+        var (scanOk, _) = await _ssh.RunCommandAsync(host, $"{wc} scan", cancellationToken: cancellationToken);
+        if (!scanOk)
+            return MeshOptimizationResult.Failed(iface, "Couldn't start the backhaul scan.");
+
+        // The scan blips the backhaul, then the AP evaluates results and roams on its own, which
+        // can land several seconds after the scan returns. A single early read sees the old parent
+        // and wrongly reports "already on best", so poll the link and stop as soon as the BSSID
+        // changes (or the window closes). Reads during the blip can come back empty; keep the last
+        // good one.
+        (string? Bssid, int? Rssi, int? LinkSpeedMbps) after = (null, null, null);
+        var moved = false;
+        for (var attempt = 0; attempt < RoamPollAttempts; attempt++)
+        {
+            try
+            {
+                await Task.Delay(RoamPollInterval, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return MeshOptimizationResult.Failed(iface, "Mesh optimization was cancelled.");
+            }
+
+            var read = await ReadLinkAsync(host, wc, cancellationToken);
+            if (read.Bssid == null) continue;
+
+            after = read;
+            if (!string.Equals(read.Bssid, before.Bssid, StringComparison.OrdinalIgnoreCase))
+            {
+                moved = true;
+                break;
+            }
+        }
+
+        // Every read came back empty (the scan can drop the SSH session). Don't assert "already on
+        // best" - the card refresh that follows is the source of truth for the current parent.
+        if (after.Bssid == null)
+        {
+            return new MeshOptimizationResult
+            {
+                Iface = iface,
+                BeforeBssid = before.Bssid,
+                BeforeRssi = before.Rssi,
+                Action = "noop",
+                Ok = true,
+                Message = "Backhaul re-scan done. Refreshing to show the current parent."
+            };
+        }
+
+        var result = new MeshOptimizationResult
+        {
+            Iface = iface,
+            BeforeBssid = before.Bssid,
+            BeforeRssi = before.Rssi,
+            AfterBssid = after.Bssid,
+            AfterRssi = after.Rssi,
+            AfterLinkSpeedMbps = after.LinkSpeedMbps,
+            Action = moved ? "moved" : "noop",
+            Ok = true,
+            Message = moved
+                ? $"Moved to a stronger parent ({Describe(after.Rssi)})."
+                : $"Already on the best parent ({Describe(after.Rssi)})."
+        };
+
+        _logger.LogInformation(
+            "[MeshOptimize] {Ap} ({Iface}): {Action} {BeforeBssid}({BeforeRssi}) -> {AfterBssid}({AfterRssi})",
+            apName, iface, result.Action, before.Bssid, before.Rssi, after.Bssid, after.Rssi);
+
+        return result;
+    }
+
+    /// <summary>Read the current backhaul BSSID and RSSI in a single SSH round trip.</summary>
+    private async Task<(string? Bssid, int? Rssi, int? LinkSpeedMbps)> ReadLinkAsync(
+        string host, string wc, CancellationToken cancellationToken)
+    {
+        var (ok, output) = await _ssh.RunCommandAsync(
+            host, $"{wc} status; {wc} signal_poll", cancellationToken: cancellationToken);
+        if (!ok || string.IsNullOrWhiteSpace(output))
+            return (null, null, null);
+
+        var bssid = MatchValue(output, @"(?im)^bssid=([0-9a-f:]{17})");
+        var rssi = MatchInt(output, @"(?im)^RSSI=(-?\d+)");
+        var linkSpeed = MatchInt(output, @"(?im)^LINKSPEED=(\d+)");
+        return (bssid, rssi, linkSpeed);
+    }
+
+    private static string? MatchValue(string text, string pattern)
+    {
+        var m = Regex.Match(text, pattern);
+        return m.Success ? m.Groups[1].Value : null;
+    }
+
+    private static int? MatchInt(string text, string pattern)
+    {
+        var m = Regex.Match(text, pattern);
+        return m.Success && int.TryParse(m.Groups[1].Value, out var v) ? v : null;
+    }
+
+    private static string Describe(int? rssi) => rssi.HasValue ? $"{rssi} dBm" : "signal unknown";
+}
+
+/// <summary>Outcome of a mesh backhaul re-scan. Returned to the page; not shown raw to the user.</summary>
+public class MeshOptimizationResult
+{
+    public string? Iface { get; set; }
+    public string? BeforeBssid { get; set; }
+    public int? BeforeRssi { get; set; }
+    public string? AfterBssid { get; set; }
+    public int? AfterRssi { get; set; }
+    public int? AfterLinkSpeedMbps { get; set; }
+
+    /// <summary>"moved" if the backhaul roamed to a different parent, otherwise "noop".</summary>
+    public string Action { get; set; } = "noop";
+
+    /// <summary>True when the action ran; false when it couldn't (no iface, SSH failure, etc.).</summary>
+    public bool Ok { get; set; }
+
+    /// <summary>User-facing summary for the toast.</summary>
+    public string Message { get; set; } = string.Empty;
+
+    public static MeshOptimizationResult NoOp(string? iface, string message) =>
+        new() { Iface = iface, Action = "noop", Ok = false, Message = message };
+
+    public static MeshOptimizationResult Failed(string? iface, string message) =>
+        new() { Iface = iface, Action = "noop", Ok = false, Message = message };
+}

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -679,6 +679,7 @@ public class MonitoringCollectionAgent : BackgroundService
         var gatewayLanIp = await ResolveGatewayLanIpAsync(ct);
         var customOids = await LoadCustomOidsAsync(ct);
         var snmpHealthHits = new ConcurrentDictionary<string, bool>();
+        var snmpTempHits = new ConcurrentDictionary<string, bool>();
         var deviceTasks = devices.Select(async device =>
         {
             await _snmpGate.WaitAsync(ct);
@@ -705,6 +706,8 @@ public class MonitoringCollectionAgent : BackgroundService
 
                 if (cpu != null || memPct != null)
                     snmpHealthHits[NormalizeMac(device.Mac)] = true;
+                if (temp != null)
+                    snmpTempHits[NormalizeMac(device.Mac)] = true;
 
                 await _influx.WriteDeviceHealthAsync(
                     deviceMac: device.Mac,
@@ -760,14 +763,23 @@ public class MonitoringCollectionAgent : BackgroundService
                 double? temp = ParseDeviceTemperature(device);
 
                 // SNMP devices that actually returned health data: only supplement
-                // temp for switches. Devices where SNMP is configured but returned
-                // no health OIDs (e.g., USW-Flex-XG) fall through to full API data.
+                // temp for switches and gateways. Some gateways (e.g., the UDM family)
+                // return CPU/mem over SNMP but not temperature; the UniFi API exposes
+                // it, so fill that gap. This is keyed off whether SNMP actually returned
+                // a temperature at runtime (snmpTempHits), not off any model, so gateways
+                // that do report temp over SNMP are untouched. Devices where SNMP is
+                // configured but returned no health OIDs (e.g., USW-Flex-XG) fall through
+                // to full API data.
                 if (snmpActive && snmpHealthHits.ContainsKey(mac))
                 {
-                    if (device.DeviceType != NetworkOptimizer.Core.Enums.DeviceType.Switch) continue;
+                    if (device.DeviceType != NetworkOptimizer.Core.Enums.DeviceType.Switch
+                        && device.DeviceType != NetworkOptimizer.Core.Enums.DeviceType.Gateway) continue;
                     cpu = null;
                     mem = null;
                     uptime = null;
+                    // SNMP already reported a temperature for this device; don't
+                    // double-write it from the API (avoids conflicting data points).
+                    if (snmpTempHits.ContainsKey(mac)) continue;
                     if (temp == null) continue;
                 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -8175,11 +8175,53 @@ a.path-hop.hop-clickable:hover {
     align-items: center;
     gap: 0.35rem;
     margin-left: auto;
+    margin-top: -1.3rem;
 }
 
 .ap-status-text {
     font-size: 0.7rem;
     color: var(--text-muted);
+}
+
+.optimize-mesh-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    white-space: nowrap;
+    align-self: flex-end;
+    margin-bottom: 0.25rem;
+}
+
+.optimize-mesh-icon {
+    font-size: 0.95rem;
+    line-height: 1;
+}
+
+.wifi-toast {
+    position: fixed;
+    bottom: 5rem;
+    right: 3rem;
+    z-index: 1080;
+    max-width: 22rem;
+    background: rgba(22, 22, 24, 0.8);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.wifi-toast-note {
+    margin-top: 0.35rem;
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+}
+
+@media (max-width: 768px) {
+    .wifi-toast {
+        right: auto;
+        left: 50%;
+        bottom: 1rem;
+        width: 80vw;
+        max-width: 80vw;
+        transform: translateX(-50%);
+    }
 }
 
 .ap-header-text {
@@ -8201,8 +8243,12 @@ a.path-hop.hop-clickable:hover {
 .ap-stats {
     display: flex;
     gap: 1.5rem;
-    margin-bottom: 0.75rem;
+    margin-bottom: 0.5rem;
     margin-left: 0.25rem;
+}
+
+.ap-stats-mesh .ap-stat {
+    justify-content: flex-end;
 }
 
 .ap-stat {
@@ -8237,6 +8283,10 @@ a.path-hop.hop-clickable:hover {
     display: flex;
     flex-direction: column;
     margin-left: auto;
+}
+
+.ap-mesh-info-with-action {
+    margin-top: -1.75rem;
 }
 
 .mesh-signal {

--- a/src/NetworkOptimizer.Web/wwwroot/js/floorPlanEditor.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/floorPlanEditor.js
@@ -459,6 +459,14 @@ window.fpEditor = {
         }
     },
 
+    getCenter: function () {
+        if (this._map) {
+            var c = this._map.getCenter();
+            return [c.lat, c.lng];
+        }
+        return null;
+    },
+
     saveMapView: function (buildingLat, buildingLng) {
         var self = this;
         if (this._map) {

--- a/src/NetworkOptimizer.WiFi/Models/AccessPointSnapshot.cs
+++ b/src/NetworkOptimizer.WiFi/Models/AccessPointSnapshot.cs
@@ -50,6 +50,12 @@ public class AccessPointSnapshot
     /// <summary>Channel used for mesh uplink (if mesh child)</summary>
     public int? MeshUplinkChannel { get; set; }
 
+    /// <summary>
+    /// wpa_supplicant STA backhaul interface for the mesh uplink (e.g. "vwiresta7"), if this is
+    /// a mesh child. Null for wired APs. Used to target the backhaul re-scan/roam over SSH.
+    /// </summary>
+    public string? MeshUplinkInterface { get; set; }
+
     /// <summary>Signal strength of mesh uplink in dBm (if mesh child)</summary>
     public int? MeshUplinkSignalDbm { get; set; }
 

--- a/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
@@ -905,6 +905,7 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
         string? meshParentMac = null;
         RadioBand? meshUplinkBand = null;
         int? meshUplinkChannel = null;
+        string? meshUplinkInterface = null;
 
         if (ap.UplinkType?.Equals("wireless", StringComparison.OrdinalIgnoreCase) == true &&
             !string.IsNullOrEmpty(ap.UplinkMac))
@@ -916,6 +917,10 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
                 meshParentMac = uplinkMacLower;
                 meshUplinkBand = RadioBandExtensions.FromUniFiCode(ap.UplinkRadioBand);
                 meshUplinkChannel = ap.UplinkChannel;
+                // Only the STA backhaul iface (vwiresta*) is a valid wpa_supplicant target;
+                // never the AP-side VAP (vwireap*) or a wired iface.
+                if (ap.UplinkInterface?.StartsWith("vwiresta", StringComparison.OrdinalIgnoreCase) == true)
+                    meshUplinkInterface = ap.UplinkInterface;
             }
         }
 
@@ -935,6 +940,7 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
             MeshParentMac = meshParentMac,
             MeshUplinkBand = meshUplinkBand,
             MeshUplinkChannel = meshUplinkChannel,
+            MeshUplinkInterface = meshUplinkInterface,
             MeshUplinkSignalDbm = isMeshChild ? ap.UplinkSignalDbm : null,
             MeshUplinkTxRateMbps = isMeshChild && ap.UplinkTxRateKbps > 0 ? (int)(ap.UplinkTxRateKbps / 1000) : null,
             MeshUplinkRxRateMbps = isMeshChild && ap.UplinkRxRateKbps > 0 ? (int)(ap.UplinkRxRateKbps / 1000) : null,
@@ -972,7 +978,13 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
                     Name = radioStats.Name,
                     Band = RadioBandExtensions.FromUniFiCode(radioStats.Radio),
                     Channel = radioStats.Channel,
-                    ChannelWidth = radioConfig?.ChannelWidth,
+                    // Prefer the operating width (radio_table_stats "bw") over the configured
+                    // width (radio_table "ht"). A mesh backhaul radio can be configured for
+                    // 160 MHz but negotiate down to the parent's width (e.g. 80 MHz) on the
+                    // link; "ht" still reads 160 while "bw" reflects the real 80. Fall back to
+                    // the configured width when "bw" is absent (older firmware) or non-positive
+                    // (e.g. an idle radio reporting 0), which "ht" never is for an enabled radio.
+                    ChannelWidth = radioStats.Bw is > 0 ? radioStats.Bw : radioConfig?.ChannelWidth,
                     ExtChannel = radioStats.ExtChannel,
                     TxPower = radioStats.TxPower,
                     TxPowerMode = radioConfig?.TxPowerMode,

--- a/tests/NetworkOptimizer.Core.Tests/Helpers/MapBoundsHelperTests.cs
+++ b/tests/NetworkOptimizer.Core.Tests/Helpers/MapBoundsHelperTests.cs
@@ -1,0 +1,164 @@
+using FluentAssertions;
+using NetworkOptimizer.Core.Helpers;
+using Xunit;
+
+namespace NetworkOptimizer.Core.Tests.Helpers;
+
+public class MapBoundsHelperTests
+{
+    // A real home location (used as a stand-in for any placed content).
+    private const double HomeLat = 51.0;
+    private const double HomeLng = 7.0;
+
+    // The app's default map center - what a building created before any AP placement
+    // inherits, and the coordinate that used to drag the fit across the globe.
+    private const double DefaultLat = 38.0;
+    private const double DefaultLng = -92.0;
+
+    #region IsPositioned
+
+    [Theory]
+    [InlineData(51.0, 7.0, true)]      // real location
+    [InlineData(38.0, -92.0, true)]    // default center is still a valid coordinate
+    [InlineData(0.0, 0.0, false)]      // null island
+    [InlineData(0.00005, -0.00005, false)] // effectively null island
+    [InlineData(91.0, 7.0, false)]     // latitude out of range
+    [InlineData(51.0, 181.0, false)]   // longitude out of range
+    public void IsPositioned_ClassifiesCoordinates(double lat, double lng, bool expected)
+    {
+        MapBoundsHelper.IsPositioned(lat, lng).Should().Be(expected);
+    }
+
+    #endregion
+
+    #region ComputeBuildingBounds
+
+    [Fact]
+    public void ComputeBuildingBounds_PrefersWalls_WhenPresent()
+    {
+        var walls = new[] { (HomeLat, HomeLng), (HomeLat + 0.001, HomeLng + 0.001) };
+        // A bare floor at the default center must be ignored once walls exist.
+        var floors = new[] { Bare(DefaultLat, DefaultLng) };
+
+        var bounds = MapBoundsHelper.ComputeBuildingBounds(walls, floors);
+
+        bounds.Should().NotBeNull();
+        bounds!.Value.SwLat.Should().BeApproximately(HomeLat, 1e-9);
+        bounds.Value.NeLat.Should().BeApproximately(HomeLat + 0.001, 1e-9);
+    }
+
+    [Fact]
+    public void ComputeBuildingBounds_UsesContentFloors_WhenNoWalls()
+    {
+        var floors = new[]
+        {
+            Content(HomeLat - 0.001, HomeLng - 0.001, HomeLat + 0.001, HomeLng + 0.001),
+            Bare(DefaultLat, DefaultLng), // placeholder floor must not extend the fit
+        };
+
+        var bounds = MapBoundsHelper.ComputeBuildingBounds(NoWalls(), floors);
+
+        bounds.Should().NotBeNull();
+        bounds!.Value.SwLat.Should().BeApproximately(HomeLat - 0.001, 1e-9);
+        bounds.Value.NeLat.Should().BeApproximately(HomeLat + 0.001, 1e-9);
+        bounds.Value.SwLng.Should().BeApproximately(HomeLng - 0.001, 1e-9);
+    }
+
+    [Fact]
+    public void ComputeBuildingBounds_ReturnsNull_ForBareFloorsOnly()
+    {
+        var floors = new[] { Bare(DefaultLat, DefaultLng), Bare(DefaultLat, DefaultLng) };
+
+        MapBoundsHelper.ComputeBuildingBounds(NoWalls(), floors).Should().BeNull();
+    }
+
+    [Fact]
+    public void ComputeBuildingBounds_ReturnsNull_WhenEmpty()
+    {
+        MapBoundsHelper.ComputeBuildingBounds(NoWalls(), System.Array.Empty<MapBoundsHelper.FloorRecord>())
+            .Should().BeNull();
+    }
+
+    #endregion
+
+    #region ComputeAllContentBounds
+
+    /// <summary>
+    /// The reported regression: a German user with placed APs at home but a building/floor
+    /// created earlier at the central-US default. The fit must frame the APs, not span the
+    /// Atlantic to the placeholder floor.
+    /// </summary>
+    [Fact]
+    public void ComputeAllContentBounds_IgnoresPlaceholderFloor_WhenApsPlaced()
+    {
+        var aps = new[] { (HomeLat, HomeLng) };
+        var bareFloorAtDefault = new[] { Bare(DefaultLat, DefaultLng) };
+
+        var bounds = MapBoundsHelper.ComputeAllContentBounds(aps, NoWalls(), bareFloorAtDefault);
+
+        bounds.Should().NotBeNull();
+        bounds!.Value.SwLat.Should().BeApproximately(HomeLat, 1e-9);
+        bounds.Value.NeLat.Should().BeApproximately(HomeLat, 1e-9);
+        bounds.Value.SwLng.Should().BeApproximately(HomeLng, 1e-9);
+        bounds.Value.NeLng.Should().BeApproximately(HomeLng, 1e-9);
+    }
+
+    [Fact]
+    public void ComputeAllContentBounds_ExtendsToContentFloor()
+    {
+        var aps = new[] { (HomeLat, HomeLng) };
+        var floors = new[] { Content(HomeLat + 0.01, HomeLng + 0.01, HomeLat + 0.02, HomeLng + 0.02) };
+
+        var bounds = MapBoundsHelper.ComputeAllContentBounds(aps, NoWalls(), floors);
+
+        bounds.Should().NotBeNull();
+        bounds!.Value.SwLat.Should().BeApproximately(HomeLat, 1e-9);
+        bounds.Value.NeLat.Should().BeApproximately(HomeLat + 0.02, 1e-9);
+    }
+
+    [Fact]
+    public void ComputeAllContentBounds_ExcludesNullIslandAps()
+    {
+        var aps = new[] { (HomeLat, HomeLng), (0.0, 0.0) };
+
+        var bounds = MapBoundsHelper.ComputeAllContentBounds(aps, NoWalls(),
+            System.Array.Empty<MapBoundsHelper.FloorRecord>());
+
+        bounds.Should().NotBeNull();
+        bounds!.Value.SwLat.Should().BeApproximately(HomeLat, 1e-9);
+        bounds.Value.NeLat.Should().BeApproximately(HomeLat, 1e-9);
+    }
+
+    [Fact]
+    public void ComputeAllContentBounds_FramesContentFloor_WhenNoAps()
+    {
+        var floors = new[] { Content(HomeLat - 0.001, HomeLng - 0.001, HomeLat + 0.001, HomeLng + 0.001) };
+
+        var bounds = MapBoundsHelper.ComputeAllContentBounds(
+            System.Array.Empty<(double, double)>(), NoWalls(), floors);
+
+        bounds.Should().NotBeNull();
+        bounds!.Value.SwLat.Should().BeApproximately(HomeLat - 0.001, 1e-9);
+    }
+
+    [Fact]
+    public void ComputeAllContentBounds_ReturnsNull_WhenNothingPlaced()
+    {
+        var bounds = MapBoundsHelper.ComputeAllContentBounds(
+            System.Array.Empty<(double, double)>(),
+            NoWalls(),
+            new[] { Bare(DefaultLat, DefaultLng) });
+
+        bounds.Should().BeNull();
+    }
+
+    #endregion
+
+    private static (double, double)[] NoWalls() => System.Array.Empty<(double, double)>();
+
+    private static MapBoundsHelper.FloorRecord Bare(double lat, double lng) =>
+        new(lat - 0.0002, lng - 0.0002, lat + 0.0002, lng + 0.0002, HasContent: false);
+
+    private static MapBoundsHelper.FloorRecord Content(double swLat, double swLng, double neLat, double neLng) =>
+        new(swLat, swLng, neLat, neLng, HasContent: true);
+}

--- a/tests/NetworkOptimizer.UniFi.Tests/RadioTableStatsTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/RadioTableStatsTests.cs
@@ -1,0 +1,81 @@
+using System.Text.Json;
+using NetworkOptimizer.UniFi.Models;
+using Xunit;
+
+namespace NetworkOptimizer.UniFi.Tests;
+
+public class RadioTableStatsTests
+{
+    [Fact]
+    public void Parses_operating_width_from_bw()
+    {
+        // radio_table_stats reports the live operating width in "bw". A mesh backhaul radio
+        // configured for 160 MHz can negotiate down to the parent's 80 MHz - "bw" reflects the
+        // real 80 while radio_table's "ht" still reads 160 (issue #921).
+        const string json = """
+        {
+            "name": "wifi1",
+            "radio": "na",
+            "channel": 36,
+            "bw": 80,
+            "extchannel": -1
+        }
+        """;
+
+        var stats = JsonSerializer.Deserialize<RadioTableStats>(json);
+
+        Assert.NotNull(stats);
+        Assert.Equal(36, stats!.Channel);
+        Assert.Equal(80, stats.Bw);
+    }
+
+    [Theory]
+    [InlineData("80", 80)]
+    [InlineData("\"160\"", 160)]
+    [InlineData("20", 20)]
+    public void Parses_bw_as_number_or_string(string bwJson, int expected)
+    {
+        var json = $"{{\"name\":\"wifi1\",\"radio\":\"na\",\"bw\":{bwJson}}}";
+
+        var stats = JsonSerializer.Deserialize<RadioTableStats>(json);
+
+        Assert.Equal(expected, stats!.Bw);
+    }
+
+    [Fact]
+    public void Bw_is_null_when_absent()
+    {
+        const string json = """{"name":"wifi1","radio":"na","channel":36}""";
+
+        var stats = JsonSerializer.Deserialize<RadioTableStats>(json);
+
+        Assert.Null(stats!.Bw);
+    }
+
+    [Fact]
+    public void Parses_real_radio_table_stats_array()
+    {
+        // Captured radio_table_stats from a real device (issue #921): the 5 GHz radio operates at
+        // 80 MHz (bw) even though it's configured for a wider channel, which is the whole point of
+        // reading bw over radio_table's ht.
+        const string json = """
+        [
+            { "name": "wifi0", "radio": "ng", "channel": 6,  "bw": 20, "state": "RUN", "extchannel": 0 },
+            { "name": "wifi1", "radio": "na", "channel": 36, "bw": 80, "state": "RUN", "extchannel": 1 }
+        ]
+        """;
+
+        var stats = JsonSerializer.Deserialize<List<RadioTableStats>>(json);
+
+        Assert.NotNull(stats);
+        Assert.Equal(2, stats!.Count);
+
+        var ng = stats.Single(r => r.Radio == "ng");
+        Assert.Equal(6, ng.Channel);
+        Assert.Equal(20, ng.Bw);
+
+        var na = stats.Single(r => r.Radio == "na");
+        Assert.Equal(36, na.Channel);
+        Assert.Equal(80, na.Bw);
+    }
+}


### PR DESCRIPTION
Release v1.23.3. Net changes since v1.23.2.

## Wi-Fi Optimizer

- **Re-pair Uplink action for mesh APs** - A per-AP button that re-scans a wireless mesh child's backhaul over SSH so it self-roams to its strongest available parent when it's stuck on a weaker one. Idempotent and safe to re-run. The action only prompts the scan; UniFi Network still decides the parent set.
- **Real mesh operating width** - The radio panel now shows the width a mesh backhaul radio is actually running at (radio_table_stats `bw`) instead of the configured width. A radio configured for 160 MHz but negotiated down to the parent's 80 MHz now reads 80 MHz. Falls back to the configured width on older firmware that omits `bw`.

## Signal Map

- **Frame to real content** - The Signal Map and Floor Plan editor now fit the view to deliberately placed content (APs, drawn walls, floors with an uploaded image) rather than bare placeholder records. A newly created building or floor inherits a placeholder center, and fitting to those raw records could drag the map to the app's default location. New buildings/floors are now seeded at the live map center or a placed AP instead. The positioning logic is consolidated into a unit-tested `MapBoundsHelper`.

## Monitoring

- **Gateway temperature fallback** - Some gateways (e.g. the UDM family) report CPU and memory over SNMP but not temperature. The gateway temperature now falls back to the UniFi Network API when SNMP omits it, keyed off whether SNMP actually returned a temperature at runtime so gateways that do report it over SNMP are untouched.
