### PR TITLE
Wi-Fi Optimizer: cross-platform mesh re-pair, device status indicators, live refresh

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -272,6 +272,16 @@ The following were implemented in the WiFi Optimizer feature:
 - **v1 behavior:** detect the duplicate (preflight gate 2) and bail with a clear message explaining the collision and that alternate-IP DNAT support is planned. Do **not** silently deploy a route that hijacks the shared IP.
 - **Relevant code (once built):** Monitoring Interfaces deployment service (preflight checks + boot script generation), `UniFiNetworkConfig` enumeration for the overlap gate, `NetworkUtilities.IsIpInSubnet` for overlap math.
 
+### Topology / Status History
+- Placeholder for historical topology / connectivity replay (device + link state over time).
+- **When this lands, the topology/map JS needs full device-status support.** Today those spots
+  consume a single online/offline bool - `lan-flow-map.js` / `lan-flow-map-2d.js` (`node.online`),
+  `floorPlanEditor.js` (`ap.online`), and the SpeedTest coverage map (`apData.isOnline`) - so a
+  provisioning/updating device renders offline-grey. The C# side already centralizes this in
+  `UniFiDeviceStateMap` -> `DeviceStatus` (Online / Transitional / Offline / Error); thread that
+  through the marker DTOs and color markers yellow (provisioning) / red (error) instead of the
+  binary bool. The status-dot/badge/card spots already do this - only the JS map markers remain.
+
 ## Multi-Tenant / Multi-Site Support
 
 ### Multi-Tenant Architecture

--- a/src/NetworkOptimizer.Core/Models/DeviceStatus.cs
+++ b/src/NetworkOptimizer.Core/Models/DeviceStatus.cs
@@ -1,0 +1,54 @@
+namespace NetworkOptimizer.Core.Models;
+
+/// <summary>
+/// Coarse connection-status bucket for a managed device, independent of vendor. Drives the color
+/// of the status indicator in the UI: green / yellow / grey / red.
+/// </summary>
+public enum DeviceStatusKind
+{
+    /// <summary>Connected and operating normally (green). Safe to run actions against.</summary>
+    Online,
+
+    /// <summary>
+    /// A transient, in-progress state (provisioning, updating, adopting, pending) - not a fault,
+    /// but not yet fully online either (yellow).
+    /// </summary>
+    Transitional,
+
+    /// <summary>Not reachable by the controller (grey).</summary>
+    Offline,
+
+    /// <summary>A fault that needs attention - e.g. adoption failed, isolated (red).</summary>
+    Error
+}
+
+/// <summary>
+/// A device's connection status: a <see cref="DeviceStatusKind"/> bucket plus the specific
+/// human-readable label for the underlying state (e.g. "Provisioning", "Update Available").
+/// Map a vendor's raw state to this once, then drive every indicator off it.
+/// </summary>
+public readonly record struct DeviceStatus(DeviceStatusKind Kind, string Label)
+{
+    /// <summary>
+    /// True only for the <see cref="DeviceStatusKind.Online"/> bucket. Use this to gate actions
+    /// that require a fully-online device (e.g. running an optimization or speed test) - a device
+    /// that is provisioning or updating is not offline, but also can't be acted on yet.
+    /// </summary>
+    public bool IsOnline => Kind == DeviceStatusKind.Online;
+
+    /// <summary>True only for the <see cref="DeviceStatusKind.Offline"/> bucket (genuinely
+    /// unreachable). Provisioning/updating/error states are NOT offline.</summary>
+    public bool IsOffline => Kind == DeviceStatusKind.Offline;
+
+    /// <summary>
+    /// Status-dot CSS modifier (online / provisioning / offline / error). Transitional states all
+    /// share the "provisioning" (yellow) dot.
+    /// </summary>
+    public string CssClass => Kind switch
+    {
+        DeviceStatusKind.Online => "online",
+        DeviceStatusKind.Transitional => "provisioning",
+        DeviceStatusKind.Error => "error",
+        _ => "offline"
+    };
+}

--- a/src/NetworkOptimizer.UniFi/Models/UniFiDeviceState.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiDeviceState.cs
@@ -1,0 +1,64 @@
+using NetworkOptimizer.Core;
+using NetworkOptimizer.Core.Models;
+
+namespace NetworkOptimizer.UniFi.Models;
+
+/// <summary>
+/// The numeric values of the UniFi device <c>state</c> field, as defined by UniFi Network. Only a
+/// subset are "offline"; transient states (provisioning, updating, adopting) and update-available
+/// are NOT offline, which the legacy <c>state == 1</c> checks got wrong. Values mirror UniFi
+/// Network's own status enum.
+/// </summary>
+public enum UniFiDeviceState
+{
+    Disconnected = 0,
+    Connected = 1,
+    Pending = 2,
+    FirmwareMismatch = 3,
+    Upgrading = 4,
+    Provisioning = 5,
+    HeartbeatMissed = 6,
+    Adopting = 7,
+    Deleting = 8,
+    InformError = 9,
+    AdoptionFailed = 10,
+    Isolated = 11,
+    IncorrectTopology = 13
+}
+
+/// <summary>
+/// Maps the raw UniFi device <c>state</c> int to a vendor-neutral <see cref="DeviceStatus"/>
+/// (bucket + display label), mirroring the labels UniFi Network shows in its own UI.
+/// </summary>
+[VendorSpecific("UniFi", "state->status mapping; labels match the UniFi Console device states.")]
+public static class UniFiDeviceStateMap
+{
+    /// <summary>Resolve a raw UniFi <c>state</c> value to its display status.</summary>
+    public static DeviceStatus ToStatus(int state) => (UniFiDeviceState)state switch
+    {
+        UniFiDeviceState.Connected => new(DeviceStatusKind.Online, "Online"),
+        // In practice a device with a pending firmware update reports state=1 and signals the
+        // update via the separate `upgradable` flag, so this branch is effectively never hit
+        // (verified on live consoles). Kept for completeness, and it's correct if it ever appears.
+        UniFiDeviceState.FirmwareMismatch => new(DeviceStatusKind.Online, "Update Available"),
+
+        UniFiDeviceState.Pending => new(DeviceStatusKind.Transitional, "Pending"),
+        UniFiDeviceState.Upgrading => new(DeviceStatusKind.Transitional, "Updating"),
+        UniFiDeviceState.Provisioning => new(DeviceStatusKind.Transitional, "Provisioning"),
+        UniFiDeviceState.Adopting => new(DeviceStatusKind.Transitional, "Adopting"),
+        UniFiDeviceState.Deleting => new(DeviceStatusKind.Transitional, "Deleting"),
+
+        UniFiDeviceState.AdoptionFailed => new(DeviceStatusKind.Error, "Adoption Failed"),
+        UniFiDeviceState.Isolated => new(DeviceStatusKind.Error, "Isolated"),
+        UniFiDeviceState.IncorrectTopology => new(DeviceStatusKind.Error, "Incorrect Topology"),
+
+        // Disconnected (0), HeartbeatMissed (6), InformError (9), and anything unrecognized.
+        _ => new(DeviceStatusKind.Offline, "Offline")
+    };
+
+    /// <summary>
+    /// Whether a device in this state is fully online and actionable (the Online bucket). True for
+    /// Connected and Update-Available; false for transient, offline, and error states.
+    /// </summary>
+    public static bool IsOnline(int state) => ToStatus(state).IsOnline;
+}

--- a/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
@@ -206,9 +206,9 @@ public class UniFiDiscovery
     /// radio_table entries in the API but don't actually have Wi-Fi radios.
     /// SmartPower devices (USP-Strip, USP-Plug) are excluded via DeviceType classification.
     /// </summary>
-    public async Task<List<DiscoveredDevice>> DiscoverAccessPointsAsync(CancellationToken cancellationToken = default)
+    public async Task<List<DiscoveredDevice>> DiscoverAccessPointsAsync(CancellationToken cancellationToken = default, bool useCache = true)
     {
-        var devices = await DiscoverDevicesAsync(cancellationToken);
+        var devices = await DiscoverDevicesAsync(cancellationToken, useCache);
         return devices.Where(d =>
             d.Type == DeviceType.AccessPoint ||
             (d.Type == DeviceType.Gateway && d.RadioTable is { Count: > 0 } && !IsGatewayOnlyConsole(d))).ToList();

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -7,6 +7,7 @@
 @using NetworkOptimizer.Core.Interfaces
 @using NetworkOptimizer.Core.Helpers
 @using NetworkOptimizer.UniFi
+@using NetworkOptimizer.UniFi.Models
 @using Microsoft.EntityFrameworkCore
 @inject UniFiConnectionService ConnectionService
 @inject IGatewaySshService GatewaySshService
@@ -3467,7 +3468,7 @@
 
             var testableDevices = devices
                 .Where(d => testableTypes.Contains(d.Type)
-                            && d.State == 1 && !string.IsNullOrEmpty(d.IpAddress))
+                            && UniFiDeviceStateMap.IsOnline(d.State) && !string.IsNullOrEmpty(d.IpAddress))
                 .GroupBy(d => d.Type)
                 .SelectMany(g => g.OrderBy(d => d.Name).Select((d, i) => new { Device = d, Index = i }))
                 .OrderBy(x => x.Index) // Round-robin: all first-of-type, then all second-of-type, etc.

--- a/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
@@ -7,6 +7,7 @@
 @using NetworkOptimizer.Core.Enums
 @using NetworkOptimizer.UniFi
 @using NetworkOptimizer.UniFi.Models
+@using NetworkOptimizer.Core.Models
 @using NetworkOptimizer.Web.Models
 @inject Iperf3SpeedTestService SpeedTestService
 @inject UniFiSshService SshService
@@ -334,7 +335,15 @@
                     <tbody>
                         @foreach (var device in discoveredDevices)
                         {
-                            var isOnline = device.State == 1 && device.Adopted;
+                            var status = UniFiDeviceStateMap.ToStatus(device.State);
+                            var isOnline = status.IsOnline && device.Adopted;
+                            var badgeClass = status.Kind switch
+                            {
+                                DeviceStatusKind.Online => "status-connected",
+                                DeviceStatusKind.Transitional => "status-provisioning",
+                                DeviceStatusKind.Error => "status-error",
+                                _ => "status-disconnected"
+                            };
                             <tr>
                                 <td class="icon-cell"><DeviceIcon Model="@device.FriendlyModelName" Size="md" /></td>
                                 <td class="hide-mobile">@device.Name</td>
@@ -346,14 +355,7 @@
                                 <td class="hide-mobile"><code>@device.IpAddress</code></td>
                                 <td class="hide-mobile">@device.Type.ToDisplayName()</td>
                                 <td>
-                                    @if (isOnline)
-                                    {
-                                        <span class="status-badge status-connected">Online</span>
-                                    }
-                                    else
-                                    {
-                                        <span class="status-badge status-disconnected">Offline</span>
-                                    }
+                                    <span class="status-badge @badgeClass">@status.Label</span>
                                 </td>
                                 <td>
                                     <div class="action-buttons">

--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -587,7 +587,7 @@
                     <div class="ap-list">
                         @foreach (var ap in _accessPoints)
                         {
-                            <div class="ap-card @(ap.IsOnline ? "" : "ap-offline")">
+                            <div class="ap-card @(ap.Status.IsOffline ? "ap-offline" : "")">
                                 <div class="ap-header">
                                     <DeviceIcon Model="@ap.Model" Size="xl" />
                                     <div class="ap-header-text">
@@ -595,8 +595,8 @@
                                         <span class="ap-model">@ap.Model</span>
                                     </div>
                                     <div class="ap-status">
-                                        <span class="status-dot @(ap.IsOnline ? "online" : "offline")"></span>
-                                        <span class="ap-status-text">@(ap.IsOnline ? "Online" : "Offline")</span>
+                                        <span class="status-dot @ap.Status.CssClass"></span>
+                                        <span class="ap-status-text">@ap.Status.Label</span>
                                     </div>
                                 </div>
                                 <div class="ap-stats @(ap.IsMeshChild ? "ap-stats-mesh" : "")">

--- a/src/NetworkOptimizer.Web/Components/Shared/DeviceCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/DeviceCard.razor
@@ -1,7 +1,7 @@
 @if (Device != null)
 {
     var deviceHref = $"/monitoring?tab=devices&device={Uri.EscapeDataString(Device.Mac ?? "")}";
-    <a href="@deviceHref" class="device-card device-card-link device-@Device.Status.ToLower()">
+    <a href="@deviceHref" class="device-card device-card-link device-@Device.StatusInfo.CssClass">
         <div class="device-header">
             <div class="device-icon">
                 @{
@@ -21,8 +21,8 @@
                 <div class="device-meta">
                     <span class="device-type">@Device.TypeDisplayName</span>
                     <div class="device-status">
-                        <span class="status-dot @(Device.Status == "Online" ? "online" : "")"></span>
-                        <span class="status-text">@Device.Status</span>
+                        <span class="status-dot @Device.StatusInfo.CssClass"></span>
+                        <span class="status-text">@Device.StatusInfo.Label</span>
                     </div>
                 </div>
             </div>

--- a/src/NetworkOptimizer.Web/Services/CellularModemService.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemService.cs
@@ -4,6 +4,7 @@ using NetworkOptimizer.Storage.Interfaces;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
 using NetworkOptimizer.UniFi;
+using NetworkOptimizer.UniFi.Models;
 
 namespace NetworkOptimizer.Web.Services;
 
@@ -115,7 +116,7 @@ public class CellularModemService : ICellularModemService
                         Model = displayModel,
                         Host = device.Ip ?? "",
                         MacAddress = device.Mac,
-                        IsOnline = device.State == 1 && device.Adopted
+                        IsOnline = UniFiDeviceStateMap.IsOnline(device.State) && device.Adopted
                     });
                     _logger.LogInformation("Discovered cellular modem: {Name} ({Model}) at {Host}",
                         device.Name, displayModel, device.Ip);

--- a/src/NetworkOptimizer.Web/Services/DashboardService.cs
+++ b/src/NetworkOptimizer.Web/Services/DashboardService.cs
@@ -1,6 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Core.Models;
 using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.UniFi.Models;
 using NetworkOptimizer.WiFi;
 
 namespace NetworkOptimizer.Web.Services;
@@ -73,7 +75,7 @@ public class DashboardService : IDashboardService
                         Name = d.Name ?? d.Mac ?? "Unknown",
                         Mac = d.Mac ?? string.Empty,
                         Type = d.Type,
-                        Status = d.State == 1 ? "Online" : "Offline",
+                        StatusInfo = UniFiDeviceStateMap.ToStatus(d.State),
                         IpAddress = d.DisplayIpAddress ?? "",
                         Model = d.FriendlyModelName,
                         Firmware = d.Firmware,
@@ -269,7 +271,10 @@ public class DeviceInfo
     public string Name { get; set; } = "";
     public string Mac { get; set; } = "";
     public DeviceType Type { get; set; }
-    public string Status { get; set; } = "";
+
+    /// <summary>Connection status (bucket + label) derived from the UniFi device <c>state</c>.</summary>
+    public DeviceStatus StatusInfo { get; set; } = new(DeviceStatusKind.Online, "Online");
+
     public string IpAddress { get; set; } = "";
     public string? Model { get; set; }
     public string? Firmware { get; set; }

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -1144,7 +1144,7 @@ public class LanFlowMapService
                 Name = string.IsNullOrEmpty(d.Name) ? d.FriendlyModelName : d.Name,
                 Model = d.FriendlyModelName,
                 Placement = anchor,
-                Online = d.State == 1,
+                Online = UniFiDeviceStateMap.IsOnline(d.State),
             };
             if (string.Equals(d.UplinkType, "wireless", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/NetworkOptimizer.Web/Services/MeshOptimizationService.cs
+++ b/src/NetworkOptimizer.Web/Services/MeshOptimizationService.cs
@@ -60,8 +60,16 @@ public class MeshOptimizationService
         if (!sshConfigured)
             return MeshOptimizationResult.NoOp(iface, "Set up UniFi Device SSH in Settings to re-pair the uplink.");
 
-        // wpa_cli control socket is per-interface on the AP (BusyBox / POSIX sh, runtime only).
-        var wc = $"wpa_cli -p /var/run/wpa_supplicant/wpa_supplicant-{iface} -i {iface}";
+        // The per-interface wpa_supplicant control socket lives in different dirs across AP
+        // platforms. U7-class APs run one global wpa_supplicant and nest the socket under
+        // /var/run/wpa_supplicant/wpa_supplicant-<iface>/<iface>; U6-class APs run a per-interface
+        // wpa_supplicant whose socket is flat at /var/run/wpa_supplicant/<iface>. Both name the
+        // socket file <iface>, so probe both parents at call time and use whichever holds the live
+        // socket. iface is validated above (^vwiresta\d+$), so it's safe to interpolate into the
+        // shell. (BusyBox / POSIX sh, runtime only.)
+        var ctrlDir = $"\"$(for d in /var/run/wpa_supplicant/wpa_supplicant-{iface} /var/run/wpa_supplicant; " +
+            $"do [ -S \"$d/{iface}\" ] && {{ printf %s \"$d\"; break; }}; done)\"";
+        var wc = $"wpa_cli -p {ctrlDir} -i {iface}";
 
         var before = await ReadLinkAsync(host, wc, cancellationToken);
         if (before.Bssid == null)

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -1901,7 +1901,7 @@ public class MonitoringCollectionAgent : BackgroundService
 
             var devices = await _connectionService.Client.GetDevicesAsync(ct);
             var filtered = devices?.Where(d =>
-                d.Adopted && d.State == 1 && !string.IsNullOrEmpty(d.Ip) && !string.IsNullOrEmpty(d.Mac))
+                d.Adopted && UniFiDeviceStateMap.IsOnline(d.State) && !string.IsNullOrEmpty(d.Ip) && !string.IsNullOrEmpty(d.Mac))
                 .ToList() ?? new List<UniFiDeviceResponse>();
             _cachedDevices = filtered;
             _cachedDevicesAt = DateTime.UtcNow;

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -173,7 +173,7 @@ public class WiFiOptimizerService
             return _cachedAps;
         }
 
-        await RefreshDataAsync();
+        await RefreshDataAsync(bypassClientCache: forceRefresh);
         return _cachedAps ?? new List<AccessPointSnapshot>();
     }
 
@@ -289,7 +289,7 @@ public class WiFiOptimizerService
         return summary;
     }
 
-    private async Task RefreshDataAsync()
+    private async Task RefreshDataAsync(bool bypassClientCache = false)
     {
         if (_connectionService.Client == null)
         {
@@ -302,8 +302,10 @@ public class WiFiOptimizerService
             var provider = CreateProvider();
 
             // Fetch data in parallel - use Task.WhenAll to start all tasks,
-            // but handle individual failures so one bad task doesn't block everything
-            var apsTask = provider.GetAccessPointsAsync();
+            // but handle individual failures so one bad task doesn't block everything.
+            // On an explicit refresh (forceRefresh), bypass the client device-list cache so the
+            // AP snapshots reflect live state - e.g. a freshly re-paired mesh uplink.
+            var apsTask = provider.GetAccessPointsAsync(useCache: !bypassClientCache);
             var clientsTask = provider.GetWirelessClientsAsync();
             var roamingTask = provider.GetRoamingTopologyAsync();
             var wlanTask = provider.GetWlanConfigurationsAsync();

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1386,6 +1386,14 @@ a.stat-card-link:active {
     border-left-color: var(--danger-color);
 }
 
+.device-card.device-provisioning {
+    border-left-color: var(--warning-color);
+}
+
+.device-card.device-error {
+    border-left-color: var(--danger-color);
+}
+
 .device-header,
 .ap-header {
     display: flex;
@@ -1449,6 +1457,15 @@ a.stat-card-link:active {
 
 .status-dot.offline {
     background: var(--text-muted);
+}
+
+.status-dot.provisioning {
+    background: #fbbf24;
+    animation: pulse-yellow 2s infinite;
+}
+
+.status-dot.error {
+    background: var(--danger-color);
 }
 
 .device-body {
@@ -2045,6 +2062,11 @@ a.stat-card-link:active {
 .status-badge.status-error {
     background: rgba(239, 68, 68, 0.2);
     color: var(--danger-color);
+}
+
+.status-badge.status-provisioning {
+    background: rgba(231, 150, 19, 0.2);
+    color: var(--warning-color);
 }
 
 /* Buttons - Three colors only: primary (blue), secondary (grey), danger (red) */

--- a/src/NetworkOptimizer.WiFi/IWiFiDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/IWiFiDataProvider.cs
@@ -10,9 +10,11 @@ namespace NetworkOptimizer.WiFi;
 public interface IWiFiDataProvider
 {
     /// <summary>
-    /// Get current snapshot of all access points with Wi-Fi metrics
+    /// Get current snapshot of all access points with Wi-Fi metrics.
+    /// Pass <paramref name="useCache"/> = false to force a live device read, bypassing any
+    /// short-lived device-list cache (used by explicit user refresh and post-re-pair refresh).
     /// </summary>
-    Task<List<AccessPointSnapshot>> GetAccessPointsAsync(CancellationToken cancellationToken = default);
+    Task<List<AccessPointSnapshot>> GetAccessPointsAsync(CancellationToken cancellationToken = default, bool useCache = true);
 
     /// <summary>
     /// Get current snapshot of all wireless clients with connection details

--- a/src/NetworkOptimizer.WiFi/Models/AccessPointSnapshot.cs
+++ b/src/NetworkOptimizer.WiFi/Models/AccessPointSnapshot.cs
@@ -1,3 +1,5 @@
+using NetworkOptimizer.Core.Models;
+
 namespace NetworkOptimizer.WiFi.Models;
 
 /// <summary>
@@ -35,8 +37,18 @@ public class AccessPointSnapshot
     /// <summary>When this snapshot was taken</summary>
     public DateTimeOffset Timestamp { get; set; } = DateTimeOffset.UtcNow;
 
-    /// <summary>Whether this AP is currently online (State == 1 from UniFi API)</summary>
-    public bool IsOnline { get; set; } = true;
+    /// <summary>
+    /// Connection status derived from the UniFi device <c>state</c> (see UniFiDeviceStateMap).
+    /// Drives the status indicator; distinguishes provisioning/updating (yellow) from offline (grey).
+    /// </summary>
+    public DeviceStatus Status { get; set; } = new(DeviceStatusKind.Online, "Online");
+
+    /// <summary>
+    /// Whether this AP is fully online and actionable (the Online bucket: connected or
+    /// update-available). A provisioning/updating AP is not offline, but also not yet actionable -
+    /// use <see cref="Status"/> for display, this for gating actions like the backhaul re-scan.
+    /// </summary>
+    public bool IsOnline => Status.IsOnline;
 
     /// <summary>Whether this AP is a mesh child (has wireless uplink to another AP)</summary>
     public bool IsMeshChild { get; set; }

--- a/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
@@ -932,7 +932,7 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
             FirmwareVersion = ap.Firmware,
             Ip = ap.IpAddress,
             Satisfaction = ap.Satisfaction,
-            IsOnline = ap.State == 1,
+            Status = UniFiDeviceStateMap.ToStatus(ap.State),
             Timestamp = timestamp,
             Radios = new List<RadioSnapshot>(),
             Vaps = new List<VapSnapshot>(),

--- a/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
@@ -26,10 +26,10 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
     public string ProviderName => "UniFi Live";
     public bool SupportsHistoricalData => true; // Via stat/report endpoints
 
-    public async Task<List<AccessPointSnapshot>> GetAccessPointsAsync(CancellationToken cancellationToken = default)
+    public async Task<List<AccessPointSnapshot>> GetAccessPointsAsync(CancellationToken cancellationToken = default, bool useCache = true)
     {
         // Use UniFiDiscovery for centralized device classification (same as Audit and Speed Test)
-        var aps = await _discovery.DiscoverAccessPointsAsync(cancellationToken);
+        var aps = await _discovery.DiscoverAccessPointsAsync(cancellationToken, useCache);
         var timestamp = DateTimeOffset.UtcNow;
 
         // Build a set of AP MACs for mesh parent detection

--- a/tests/NetworkOptimizer.UniFi.Tests/UniFiDeviceStateTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/UniFiDeviceStateTests.cs
@@ -1,0 +1,57 @@
+using FluentAssertions;
+using NetworkOptimizer.Core.Models;
+using NetworkOptimizer.UniFi.Models;
+using Xunit;
+
+namespace NetworkOptimizer.UniFi.Tests;
+
+public class UniFiDeviceStateTests
+{
+    [Theory]
+    // Online bucket - green, actionable.
+    [InlineData(1, DeviceStatusKind.Online, "Online")]
+    [InlineData(3, DeviceStatusKind.Online, "Update Available")]
+    // Transitional bucket - yellow, not a fault but not actionable yet.
+    [InlineData(2, DeviceStatusKind.Transitional, "Pending")]
+    [InlineData(4, DeviceStatusKind.Transitional, "Updating")]
+    [InlineData(5, DeviceStatusKind.Transitional, "Provisioning")]
+    [InlineData(7, DeviceStatusKind.Transitional, "Adopting")]
+    [InlineData(8, DeviceStatusKind.Transitional, "Deleting")]
+    // Offline bucket - grey. All three map to the same label.
+    [InlineData(0, DeviceStatusKind.Offline, "Offline")]
+    [InlineData(6, DeviceStatusKind.Offline, "Offline")]
+    [InlineData(9, DeviceStatusKind.Offline, "Offline")]
+    // Error bucket - red.
+    [InlineData(10, DeviceStatusKind.Error, "Adoption Failed")]
+    [InlineData(11, DeviceStatusKind.Error, "Isolated")]
+    [InlineData(13, DeviceStatusKind.Error, "Incorrect Topology")]
+    // Unknown / unused values fall back to Offline rather than throwing.
+    [InlineData(12, DeviceStatusKind.Offline, "Offline")]
+    [InlineData(99, DeviceStatusKind.Offline, "Offline")]
+    public void ToStatus_maps_state_to_kind_and_label(int state, DeviceStatusKind kind, string label)
+    {
+        var status = UniFiDeviceStateMap.ToStatus(state);
+        status.Kind.Should().Be(kind);
+        status.Label.Should().Be(label);
+    }
+
+    [Theory]
+    // Only the Online bucket (connected, update-available) is actionable; provisioning is NOT.
+    [InlineData(1, true)]
+    [InlineData(3, true)]
+    [InlineData(5, false)]
+    [InlineData(4, false)]
+    [InlineData(0, false)]
+    [InlineData(10, false)]
+    public void IsOnline_is_true_only_for_the_online_bucket(int state, bool expected)
+        => UniFiDeviceStateMap.IsOnline(state).Should().Be(expected);
+
+    [Fact]
+    public void Provisioning_uses_the_yellow_dot_and_is_not_offline()
+    {
+        var status = UniFiDeviceStateMap.ToStatus((int)UniFiDeviceState.Provisioning);
+        status.CssClass.Should().Be("provisioning");
+        status.IsOffline.Should().BeFalse();
+        status.IsOnline.Should().BeFalse();
+    }
+}

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using NetworkOptimizer.Core.Models;
 using NetworkOptimizer.WiFi.Data;
 using NetworkOptimizer.WiFi.Helpers;
 using NetworkOptimizer.WiFi.Models;
@@ -29,7 +30,7 @@ public class ChannelRecommendationServiceTests
         {
             Mac = mac,
             Name = name,
-            IsOnline = true,
+            Status = new(DeviceStatusKind.Online, "Online"),
             IsMeshChild = isMeshChild,
             MeshParentMac = meshParentMac,
             MeshUplinkBand = meshUplinkBand,
@@ -74,7 +75,7 @@ public class ChannelRecommendationServiceTests
             CreateAp("aa:bb:cc:dd:ee:01", "AP-1", RadioBand.Band5GHz, 36),
             new()
             {
-                Mac = "aa:bb:cc:dd:ee:02", Name = "AP-Offline", IsOnline = false,
+                Mac = "aa:bb:cc:dd:ee:02", Name = "AP-Offline", Status = new(DeviceStatusKind.Offline, "Offline"),
                 Radios = new() { new RadioSnapshot { Band = RadioBand.Band5GHz, Channel = 36, ChannelWidth = 80 } }
             }
         };


### PR DESCRIPTION
## Mesh "Re-pair Uplink" now works across AP platforms

The Re-pair Uplink action hardcoded the `wpa_supplicant` control-socket path, which only matched U7-class APs (global `wpa_supplicant`, nested socket dir). U6-class APs run a per-interface `wpa_supplicant` with a flat socket path, so re-pair failed with "Couldn't read the mesh backhaul status" (#928). It now probes both layouts at call time and uses whichever holds the live socket, so it works on both. Verified live on a U7 Pro and confirmed against the U6 Pro reporter's socket layout.

## Device status: show Provisioning/transient states instead of Offline

Device online/offline was a binary `state == 1` check in several places, so a re-provisioning, updating, or pending device showed as grey "Offline." Status now maps the full UniFi `state` set to a shared `DeviceStatus` (Online / Provisioning / Updating / Adopting / Offline / Adoption Failed / ...), mirroring the labels UniFi Network shows, and every indicator drives off it - a provisioning AP shows a yellow "Provisioning" dot, not grey "Offline."

- Applies to the Wi-Fi Optimizer AP cards, the Dashboard's Device Status list, and the speed-test device list.
- The monitoring poll and speed-test target filters now key off the same "online" helper instead of raw `state == 1`, so a device isn't silently dropped while it briefly reprovisions.
- The topology/map markers keep their existing online/offline coloring for now (tracked in TODO for full status support).

## Wi-Fi Optimizer refresh reads live device data

The Overview "Refresh" and the post-re-pair refreshes pass `forceRefresh`, but it was dropped before the UniFi client, so they still read a 15s device-list cache - a just-re-paired uplink wouldn't show until that cache expired. `forceRefresh` now threads down to a live device read (which also repopulates the cache), including the +5s/+30s post-re-pair follow-ups that exist to catch the controller's lag after a roam.

## Tests

New unit tests cover the full `state` -> status mapping and the online-bucket helper. Existing suites updated and green.
