### PR TITLE
ISP Health: don't show "last N days" for a window that doesn't end now

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -927,13 +927,13 @@ else
 
     /// <summary>
     /// The hero pill's window phrase. "last {span}" only reads correctly when the window actually
-    /// ends at (about) now; a custom window ending in the past would otherwise imply it runs up to the
-    /// present, so it gets an explicit date range instead.
+    /// ends at (about) now; a custom window ending in the past instead shows the span and its end
+    /// date ("7 days ending Jun 17") - the user picked the range, so the exact end time is implied.
     /// </summary>
     private static string ScoredWindowLabel(IspHealthReport r) =>
         DateTime.UtcNow - r.WindowEnd < TimeSpan.FromHours(1)
             ? $"last {WindowLabel(r)}"
-            : $"{r.WindowStart.ToLocalTime():MMM d, HH:mm} to {r.WindowEnd.ToLocalTime():MMM d, HH:mm}";
+            : $"{WindowLabel(r)} ending {r.WindowEnd.ToLocalTime():MMM d}";
 
     private static string WindowLabel(IspHealthReport r)
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -143,7 +143,7 @@ else
             <div class="isp-health-hero-gauge">
                 <IspHealthScoreGauge Score="r.OverallScore" Label="ISP Health" />
                 <div class="isp-health-profile-chip" data-tooltip="Thresholds are tuned to the access technology selected in Upstream Discovery">
-                    Scored as @r.Profile.DisplayName &middot; last @WindowLabel(r)
+                    Scored as @r.Profile.DisplayName &middot; @ScoredWindowLabel(r)
                 </div>
             </div>
             <a href="/wan-speedtest" class="isp-health-hero-speed">
@@ -924,6 +924,16 @@ else
 
     private static string OutageHopTooltip(OutageTierState t) =>
         t.WentDark ? $"Went dark; peak loss {t.PeakLossPct:0}%." : "Stayed reachable through the outage.";
+
+    /// <summary>
+    /// The hero pill's window phrase. "last {span}" only reads correctly when the window actually
+    /// ends at (about) now; a custom window ending in the past would otherwise imply it runs up to the
+    /// present, so it gets an explicit date range instead.
+    /// </summary>
+    private static string ScoredWindowLabel(IspHealthReport r) =>
+        DateTime.UtcNow - r.WindowEnd < TimeSpan.FromHours(1)
+            ? $"last {WindowLabel(r)}"
+            : $"{r.WindowStart.ToLocalTime():MMM d, HH:mm} to {r.WindowEnd.ToLocalTime():MMM d, HH:mm}";
 
     private static string WindowLabel(IspHealthReport r)
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -927,13 +927,23 @@ else
 
     /// <summary>
     /// The hero pill's window phrase. "last {span}" only reads correctly when the window actually
-    /// ends at (about) now; a custom window ending in the past instead shows the span and its end
-    /// date ("7 days ending Jun 17") - the user picked the range, so the exact end time is implied.
+    /// ends at (about) now; a custom window ending in the past instead shows a compact span pointing
+    /// to its end date ("7d -> Jun 17") - kept short so it doesn't widen the pill and shift the layout.
     /// </summary>
     private static string ScoredWindowLabel(IspHealthReport r) =>
         DateTime.UtcNow - r.WindowEnd < TimeSpan.FromHours(1)
             ? $"last {WindowLabel(r)}"
-            : $"{WindowLabel(r)} ending {r.WindowEnd.ToLocalTime():MMM d}";
+            : $"{ShortSpan(r)} → {r.WindowEnd.ToLocalTime():MMM d}";
+
+    /// <summary>Compact window span for the tight hero pill: "90m", "24h", "7d" - same tiering as
+    /// <see cref="WindowLabel"/>, abbreviated units, no space.</summary>
+    private static string ShortSpan(IspHealthReport r)
+    {
+        var span = r.WindowEnd - r.WindowStart;
+        if (span.TotalMinutes < 60) return $"{span.TotalMinutes:0}m";
+        if (span.TotalHours < 72) return $"{span.TotalHours:0.#}h";
+        return $"{span.TotalDays:0.#}d";
+    }
 
     private static string WindowLabel(IspHealthReport r)
     {


### PR DESCRIPTION
The ISP Health hero pill always prefixed the window span with "last" - so a custom date-filter window that ends in the past still read "last 7 days," implying it ran right up to the present.

Now the pill shows:
- **"last 7 days"** when the window ends at (about) now - the live view, or a custom window ending now. Unchanged.
- **"7d → Jun 17"** - a compact span (90m / 24h / 7d) pointing to its end date - when the window ends in the past, so it no longer implies "up to now." Kept short so it doesn't widen the pill and shift the hero layout. (You picked the custom range, so the exact end time is implied.)

The section headers (Outages, Path & Congestion Events, Per-Network RTT) were already correct: they show a bare duration like "(7 days)" with no "last," so they're untouched.
