### PR TITLE
Release: ISP Health Physical Link + outage scoring, Wi-Fi Optimizer mesh & status

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -272,6 +272,16 @@ The following were implemented in the WiFi Optimizer feature:
 - **v1 behavior:** detect the duplicate (preflight gate 2) and bail with a clear message explaining the collision and that alternate-IP DNAT support is planned. Do **not** silently deploy a route that hijacks the shared IP.
 - **Relevant code (once built):** Monitoring Interfaces deployment service (preflight checks + boot script generation), `UniFiNetworkConfig` enumeration for the overlap gate, `NetworkUtilities.IsIpInSubnet` for overlap math.
 
+### Topology / Status History
+- Placeholder for historical topology / connectivity replay (device + link state over time).
+- **When this lands, the topology/map JS needs full device-status support.** Today those spots
+  consume a single online/offline bool - `lan-flow-map.js` / `lan-flow-map-2d.js` (`node.online`),
+  `floorPlanEditor.js` (`ap.online`), and the SpeedTest coverage map (`apData.isOnline`) - so a
+  provisioning/updating device renders offline-grey. The C# side already centralizes this in
+  `UniFiDeviceStateMap` -> `DeviceStatus` (Online / Transitional / Offline / Error); thread that
+  through the marker DTOs and color markers yellow (provisioning) / red (error) instead of the
+  binary bool. The status-dot/badge/card spots already do this - only the JS map markers remain.
+
 ## Multi-Tenant / Multi-Site Support
 
 ### Multi-Tenant Architecture

--- a/src/NetworkOptimizer.Core/Models/DeviceStatus.cs
+++ b/src/NetworkOptimizer.Core/Models/DeviceStatus.cs
@@ -1,0 +1,54 @@
+namespace NetworkOptimizer.Core.Models;
+
+/// <summary>
+/// Coarse connection-status bucket for a managed device, independent of vendor. Drives the color
+/// of the status indicator in the UI: green / yellow / grey / red.
+/// </summary>
+public enum DeviceStatusKind
+{
+    /// <summary>Connected and operating normally (green). Safe to run actions against.</summary>
+    Online,
+
+    /// <summary>
+    /// A transient, in-progress state (provisioning, updating, adopting, pending) - not a fault,
+    /// but not yet fully online either (yellow).
+    /// </summary>
+    Transitional,
+
+    /// <summary>Not reachable by the controller (grey).</summary>
+    Offline,
+
+    /// <summary>A fault that needs attention - e.g. adoption failed, isolated (red).</summary>
+    Error
+}
+
+/// <summary>
+/// A device's connection status: a <see cref="DeviceStatusKind"/> bucket plus the specific
+/// human-readable label for the underlying state (e.g. "Provisioning", "Update Available").
+/// Map a vendor's raw state to this once, then drive every indicator off it.
+/// </summary>
+public readonly record struct DeviceStatus(DeviceStatusKind Kind, string Label)
+{
+    /// <summary>
+    /// True only for the <see cref="DeviceStatusKind.Online"/> bucket. Use this to gate actions
+    /// that require a fully-online device (e.g. running an optimization or speed test) - a device
+    /// that is provisioning or updating is not offline, but also can't be acted on yet.
+    /// </summary>
+    public bool IsOnline => Kind == DeviceStatusKind.Online;
+
+    /// <summary>True only for the <see cref="DeviceStatusKind.Offline"/> bucket (genuinely
+    /// unreachable). Provisioning/updating/error states are NOT offline.</summary>
+    public bool IsOffline => Kind == DeviceStatusKind.Offline;
+
+    /// <summary>
+    /// Status-dot CSS modifier (online / provisioning / offline / error). Transitional states all
+    /// share the "provisioning" (yellow) dot.
+    /// </summary>
+    public string CssClass => Kind switch
+    {
+        DeviceStatusKind.Online => "online",
+        DeviceStatusKind.Transitional => "provisioning",
+        DeviceStatusKind.Error => "error",
+        _ => "offline"
+    };
+}

--- a/src/NetworkOptimizer.Monitoring/Models/OntStats.cs
+++ b/src/NetworkOptimizer.Monitoring/Models/OntStats.cs
@@ -60,10 +60,11 @@ public class OntStats
     public int? SfpLinkSpeedMbps { get; set; }
 
     // Error counters
-    /// <summary>FEC corrected error count</summary>
+    /// <summary>FEC error count - the data-loss signal: uncorrectable FEC codewords where the device
+    /// distinguishes them (corrected codewords are benign and excluded). Cumulative.</summary>
     public long? FecErrors { get; set; }
 
-    /// <summary>BIP error count</summary>
+    /// <summary>BIP (bit-interleaved-parity) error count. Cumulative; reads 0 on a healthy link.</summary>
     public long? BipErrors { get; set; }
 
     /// <summary>Estimated distance to OLT in meters</summary>

--- a/src/NetworkOptimizer.Storage/Migrations/20260628120000_AddPhysicalLinkSourceKey.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260628120000_AddPhysicalLinkSourceKey.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260628120000_AddPhysicalLinkSourceKey")]
+    partial class AddPhysicalLinkSourceKey
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260628120000_AddPhysicalLinkSourceKey.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260628120000_AddPhysicalLinkSourceKey.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPhysicalLinkSourceKey : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PhysicalLinkSourceKey",
+                table: "MonitoringSettings",
+                type: "TEXT",
+                maxLength: 120,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PhysicalLinkSourceKey",
+                table: "MonitoringSettings");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/MonitoringSettings.cs
+++ b/src/NetworkOptimizer.Storage/Models/MonitoringSettings.cs
@@ -120,6 +120,15 @@ public class MonitoringSettings
     public double? AeTempHighC { get; set; }
     public double? SfpTempHighGenericC { get; set; }
 
+    /// <summary>
+    /// When more than one monitored physical source (ONT, SFP, cable modem, cellular modem)
+    /// matches the WAN's access technology, the user's chosen source for the ISP Health
+    /// Physical Link factor, as a token: "cm:3", "ont:2", "modem:1",
+    /// "sfp:aa:bb:cc:dd:ee:ff/Port 1". Null = single unambiguous match, or not yet picked.
+    /// </summary>
+    [MaxLength(120)]
+    public string? PhysicalLinkSourceKey { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -1399,19 +1399,24 @@ from(bucket: ""{_bucket}"")
     {
         if (!IsConfigured) await ReconfigureAsync(ct);
         if (!IsConfigured || modules.Count == 0) return new Dictionary<string, List<SfpPoint>>();
-        var window = aggregateWindow ?? PickAggregateWindow(to - from);
+        // TimeSpan.Zero requests RAW (un-aggregated) points. ISP Health needs this so DDM read
+        // artifacts (a single glitchy sample where RX dives and temperature jumps) stay isolated for
+        // rejection - mean aggregation would smear a glitch into a bucket that defeats the filter.
+        var raw = aggregateWindow == TimeSpan.Zero;
+        var window = (aggregateWindow is null or { Ticks: 0 }) ? PickAggregateWindow(to - from) : aggregateWindow.Value;
 
         var macFilter = string.Join(" or ", modules.Select(m =>
             $@"(r.device_mac == ""{NormalizeMac(m.DeviceMac)}"" and r.port_name == ""{SanitizeFluxString(m.PortName)}"")"));
 
+        var aggregateLine = raw ? "" : $@"  |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
+";
         var flux = $@"
 from(bucket: ""{_longtermBucket}"")
   |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
   |> filter(fn: (r) => r._measurement == ""sfp"")
   |> filter(fn: (r) => {macFilter})
   |> filter(fn: (r) => r._field == ""rx_power_dbm"" or r._field == ""tx_power_dbm"" or r._field == ""temperature_c"" or r._field == ""voltage_v"")
-  |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
-  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
+{aggregateLine}  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
         var results = new Dictionary<string, List<SfpPoint>>();
         await foreach (var record in QueryFluxAsync(flux, ct))
@@ -1568,20 +1573,24 @@ union(tables: [gauges, deltas])
     {
         if (!IsConfigured) await ReconfigureAsync(ct);
         if (!IsConfigured) return new Dictionary<string, List<OntPoint>>();
-        var window = aggregateWindow ?? PickAggregateWindow(to - from);
+        // TimeSpan.Zero requests RAW points so ISP Health gets per-poll FEC/BIP deltas comparable to
+        // the alert spike threshold (aggregation would conflate several polls into one bucket).
+        var raw = aggregateWindow == TimeSpan.Zero;
+        var window = (aggregateWindow is null or { Ticks: 0 }) ? PickAggregateWindow(to - from) : aggregateWindow.Value;
 
         var ontFilter = !string.IsNullOrEmpty(ontId)
             ? $@"|> filter(fn: (r) => r.ont_id == ""{SanitizeFluxString(ontId)}"")"
             : "";
 
+        var aggregateLine = raw ? "" : $@"  |> aggregateWindow(every: {ToFluxDuration(window)}, fn: last, createEmpty: false)
+";
         var flux = $@"
 from(bucket: ""{_longtermBucket}"")
   |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
   |> filter(fn: (r) => r._measurement == ""ont"")
   {ontFilter}
-  |> filter(fn: (r) => r._field == ""rx_power_dbm"" or r._field == ""tx_power_dbm"" or r._field == ""temperature_c"" or r._field == ""voltage_v"" or r._field == ""bias_ma"")
-  |> aggregateWindow(every: {ToFluxDuration(window)}, fn: last, createEmpty: false)
-  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
+  |> filter(fn: (r) => r._field == ""rx_power_dbm"" or r._field == ""tx_power_dbm"" or r._field == ""temperature_c"" or r._field == ""voltage_v"" or r._field == ""bias_ma"" or r._field == ""fec_errors"" or r._field == ""bip_errors"" or r._field == ""pon_link_status"")
+{aggregateLine}  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
         var results = new Dictionary<string, List<OntPoint>>();
         await foreach (var record in QueryFluxAsync(flux, ct))
@@ -1600,6 +1609,9 @@ from(bucket: ""{_longtermBucket}"")
                 TemperatureC = AsDoubleOrNull(record.GetValueByKey("temperature_c")),
                 VoltageV = AsDoubleOrNull(record.GetValueByKey("voltage_v")),
                 BiasMa = AsDoubleOrNull(record.GetValueByKey("bias_ma")),
+                FecErrors = AsLongOrNull(record.GetValueByKey("fec_errors")),
+                BipErrors = AsLongOrNull(record.GetValueByKey("bip_errors")),
+                PonLinkStatus = record.GetValueByKey("pon_link_status") as string,
             });
         }
         return results;
@@ -2253,6 +2265,11 @@ from(bucket: ""{_longtermBucket}"")
         public double? TemperatureC { get; init; }
         public double? VoltageV { get; init; }
         public double? BiasMa { get; init; }
+        public long? FecErrors { get; init; }
+        public long? BipErrors { get; init; }
+        /// <summary>Raw PON link status influx value ("operation", "popup", ...); null when the
+        /// source didn't report an O-state on that poll (DDM sticks, a stats-page hiccup).</summary>
+        public string? PonLinkStatus { get; init; }
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.UniFi/Models/UniFiDeviceState.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiDeviceState.cs
@@ -1,0 +1,64 @@
+using NetworkOptimizer.Core;
+using NetworkOptimizer.Core.Models;
+
+namespace NetworkOptimizer.UniFi.Models;
+
+/// <summary>
+/// The numeric values of the UniFi device <c>state</c> field, as defined by UniFi Network. Only a
+/// subset are "offline"; transient states (provisioning, updating, adopting) and update-available
+/// are NOT offline, which the legacy <c>state == 1</c> checks got wrong. Values mirror UniFi
+/// Network's own status enum.
+/// </summary>
+public enum UniFiDeviceState
+{
+    Disconnected = 0,
+    Connected = 1,
+    Pending = 2,
+    FirmwareMismatch = 3,
+    Upgrading = 4,
+    Provisioning = 5,
+    HeartbeatMissed = 6,
+    Adopting = 7,
+    Deleting = 8,
+    InformError = 9,
+    AdoptionFailed = 10,
+    Isolated = 11,
+    IncorrectTopology = 13
+}
+
+/// <summary>
+/// Maps the raw UniFi device <c>state</c> int to a vendor-neutral <see cref="DeviceStatus"/>
+/// (bucket + display label), mirroring the labels UniFi Network shows in its own UI.
+/// </summary>
+[VendorSpecific("UniFi", "state->status mapping; labels match the UniFi Console device states.")]
+public static class UniFiDeviceStateMap
+{
+    /// <summary>Resolve a raw UniFi <c>state</c> value to its display status.</summary>
+    public static DeviceStatus ToStatus(int state) => (UniFiDeviceState)state switch
+    {
+        UniFiDeviceState.Connected => new(DeviceStatusKind.Online, "Online"),
+        // In practice a device with a pending firmware update reports state=1 and signals the
+        // update via the separate `upgradable` flag, so this branch is effectively never hit
+        // (verified on live consoles). Kept for completeness, and it's correct if it ever appears.
+        UniFiDeviceState.FirmwareMismatch => new(DeviceStatusKind.Online, "Update Available"),
+
+        UniFiDeviceState.Pending => new(DeviceStatusKind.Transitional, "Pending"),
+        UniFiDeviceState.Upgrading => new(DeviceStatusKind.Transitional, "Updating"),
+        UniFiDeviceState.Provisioning => new(DeviceStatusKind.Transitional, "Provisioning"),
+        UniFiDeviceState.Adopting => new(DeviceStatusKind.Transitional, "Adopting"),
+        UniFiDeviceState.Deleting => new(DeviceStatusKind.Transitional, "Deleting"),
+
+        UniFiDeviceState.AdoptionFailed => new(DeviceStatusKind.Error, "Adoption Failed"),
+        UniFiDeviceState.Isolated => new(DeviceStatusKind.Error, "Isolated"),
+        UniFiDeviceState.IncorrectTopology => new(DeviceStatusKind.Error, "Incorrect Topology"),
+
+        // Disconnected (0), HeartbeatMissed (6), InformError (9), and anything unrecognized.
+        _ => new(DeviceStatusKind.Offline, "Offline")
+    };
+
+    /// <summary>
+    /// Whether a device in this state is fully online and actionable (the Online bucket). True for
+    /// Connected and Update-Available; false for transient, offline, and error states.
+    /// </summary>
+    public static bool IsOnline(int state) => ToStatus(state).IsOnline;
+}

--- a/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
@@ -206,9 +206,9 @@ public class UniFiDiscovery
     /// radio_table entries in the API but don't actually have Wi-Fi radios.
     /// SmartPower devices (USP-Strip, USP-Plug) are excluded via DeviceType classification.
     /// </summary>
-    public async Task<List<DiscoveredDevice>> DiscoverAccessPointsAsync(CancellationToken cancellationToken = default)
+    public async Task<List<DiscoveredDevice>> DiscoverAccessPointsAsync(CancellationToken cancellationToken = default, bool useCache = true)
     {
-        var devices = await DiscoverDevicesAsync(cancellationToken);
+        var devices = await DiscoverDevicesAsync(cancellationToken, useCache);
         return devices.Where(d =>
             d.Type == DeviceType.AccessPoint ||
             (d.Type == DeviceType.Gateway && d.RadioTable is { Count: > 0 } && !IsGatewayOnlyConsole(d))).ToList();

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -1602,8 +1602,10 @@
                     </div>
                 </div>
                 <div>
-                    <h4 class="event-type-group-header">Gateway Health</h4>
+                    <h4 class="event-type-group-header">Device Health</h4>
                     <div class="event-type-key-list">
+                        <div @onclick='() => SelectEventType("device.offline")'><code>device.offline</code> <span>Device went offline</span></div>
+                        <div @onclick='() => SelectEventType("device.high_temperature")'><code>device.high_temperature</code> <span>Device (switch, gateway, or AP) temperature above threshold</span></div>
                         <div @onclick='() => SelectEventType("device.gateway_high_cpu")'><code>device.gateway_high_cpu</code> <span>Gateway CPU sustained above threshold</span></div>
                         <div @onclick='() => SelectEventType("device.gateway_high_memory")'><code>device.gateway_high_memory</code> <span>Gateway memory above threshold</span></div>
                         <div @onclick='() => SelectEventType("device.*")'><code>device.*</code> <span>All device events</span></div>
@@ -1650,7 +1652,6 @@
                     <div class="event-type-key-list">
                         <div @onclick='() => SelectEventType("schedule.task_completed")'><code>schedule.task_completed</code> <span>Scheduled task succeeded</span></div>
                         <div @onclick='() => SelectEventType("schedule.task_failed")'><code>schedule.task_failed</code> <span>Scheduled task failed</span></div>
-                        <div @onclick='() => SelectEventType("device.offline")'><code>device.offline</code> <span>Device went offline</span></div>
                         <div @onclick='() => SelectEventType("wifi.congestion")'><code>wifi.congestion</code> <span>Wi-Fi channel congestion detected</span></div>
                     </div>
                 </div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -7,6 +7,7 @@
 @using NetworkOptimizer.Core.Interfaces
 @using NetworkOptimizer.Core.Helpers
 @using NetworkOptimizer.UniFi
+@using NetworkOptimizer.UniFi.Models
 @using Microsoft.EntityFrameworkCore
 @inject UniFiConnectionService ConnectionService
 @inject IGatewaySshService GatewaySshService
@@ -3467,7 +3468,7 @@
 
             var testableDevices = devices
                 .Where(d => testableTypes.Contains(d.Type)
-                            && d.State == 1 && !string.IsNullOrEmpty(d.IpAddress))
+                            && UniFiDeviceStateMap.IsOnline(d.State) && !string.IsNullOrEmpty(d.IpAddress))
                 .GroupBy(d => d.Type)
                 .SelectMany(g => g.OrderBy(d => d.Name).Select((d, i) => new { Device = d, Index = i }))
                 .OrderBy(x => x.Index) // Round-robin: all first-of-type, then all second-of-type, etc.

--- a/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
@@ -7,6 +7,7 @@
 @using NetworkOptimizer.Core.Enums
 @using NetworkOptimizer.UniFi
 @using NetworkOptimizer.UniFi.Models
+@using NetworkOptimizer.Core.Models
 @using NetworkOptimizer.Web.Models
 @inject Iperf3SpeedTestService SpeedTestService
 @inject UniFiSshService SshService
@@ -334,7 +335,15 @@
                     <tbody>
                         @foreach (var device in discoveredDevices)
                         {
-                            var isOnline = device.State == 1 && device.Adopted;
+                            var status = UniFiDeviceStateMap.ToStatus(device.State);
+                            var isOnline = status.IsOnline && device.Adopted;
+                            var badgeClass = status.Kind switch
+                            {
+                                DeviceStatusKind.Online => "status-connected",
+                                DeviceStatusKind.Transitional => "status-provisioning",
+                                DeviceStatusKind.Error => "status-error",
+                                _ => "status-disconnected"
+                            };
                             <tr>
                                 <td class="icon-cell"><DeviceIcon Model="@device.FriendlyModelName" Size="md" /></td>
                                 <td class="hide-mobile">@device.Name</td>
@@ -346,14 +355,7 @@
                                 <td class="hide-mobile"><code>@device.IpAddress</code></td>
                                 <td class="hide-mobile">@device.Type.ToDisplayName()</td>
                                 <td>
-                                    @if (isOnline)
-                                    {
-                                        <span class="status-badge status-connected">Online</span>
-                                    }
-                                    else
-                                    {
-                                        <span class="status-badge status-disconnected">Offline</span>
-                                    }
+                                    <span class="status-badge @badgeClass">@status.Label</span>
                                 </td>
                                 <td>
                                     <div class="action-buttons">

--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -587,7 +587,7 @@
                     <div class="ap-list">
                         @foreach (var ap in _accessPoints)
                         {
-                            <div class="ap-card @(ap.IsOnline ? "" : "ap-offline")">
+                            <div class="ap-card @(ap.Status.IsOffline ? "ap-offline" : "")">
                                 <div class="ap-header">
                                     <DeviceIcon Model="@ap.Model" Size="xl" />
                                     <div class="ap-header-text">
@@ -595,8 +595,8 @@
                                         <span class="ap-model">@ap.Model</span>
                                     </div>
                                     <div class="ap-status">
-                                        <span class="status-dot @(ap.IsOnline ? "online" : "offline")"></span>
-                                        <span class="ap-status-text">@(ap.IsOnline ? "Online" : "Offline")</span>
+                                        <span class="status-dot @ap.Status.CssClass"></span>
+                                        <span class="ap-status-text">@ap.Status.Label</span>
                                     </div>
                                 </div>
                                 <div class="ap-stats @(ap.IsMeshChild ? "ap-stats-mesh" : "")">

--- a/src/NetworkOptimizer.Web/Components/Shared/DeviceCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/DeviceCard.razor
@@ -1,7 +1,7 @@
 @if (Device != null)
 {
     var deviceHref = $"/monitoring?tab=devices&device={Uri.EscapeDataString(Device.Mac ?? "")}";
-    <a href="@deviceHref" class="device-card device-card-link device-@Device.Status.ToLower()">
+    <a href="@deviceHref" class="device-card device-card-link device-@Device.StatusInfo.CssClass">
         <div class="device-header">
             <div class="device-icon">
                 @{
@@ -21,8 +21,8 @@
                 <div class="device-meta">
                     <span class="device-type">@Device.TypeDisplayName</span>
                     <div class="device-status">
-                        <span class="status-dot @(Device.Status == "Online" ? "online" : "")"></span>
-                        <span class="status-text">@Device.Status</span>
+                        <span class="status-dot @Device.StatusInfo.CssClass"></span>
+                        <span class="status-text">@Device.StatusInfo.Label</span>
                     </div>
                 </div>
             </div>

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -143,7 +143,7 @@ else
             <div class="isp-health-hero-gauge">
                 <IspHealthScoreGauge Score="r.OverallScore" Label="ISP Health" />
                 <div class="isp-health-profile-chip" data-tooltip="Thresholds are tuned to the access technology selected in Upstream Discovery">
-                    Scored as @r.Profile.DisplayName &middot; last @WindowLabel(r)
+                    Scored as @r.Profile.DisplayName &middot; @ScoredWindowLabel(r)
                 </div>
             </div>
             <a href="/wan-speedtest" class="isp-health-hero-speed">
@@ -924,6 +924,26 @@ else
 
     private static string OutageHopTooltip(OutageTierState t) =>
         t.WentDark ? $"Went dark; peak loss {t.PeakLossPct:0}%." : "Stayed reachable through the outage.";
+
+    /// <summary>
+    /// The hero pill's window phrase. "last {span}" only reads correctly when the window actually
+    /// ends at (about) now; a custom window ending in the past instead shows a compact span pointing
+    /// to its end date ("7d -> Jun 17") - kept short so it doesn't widen the pill and shift the layout.
+    /// </summary>
+    private static string ScoredWindowLabel(IspHealthReport r) =>
+        DateTime.UtcNow - r.WindowEnd < TimeSpan.FromHours(1)
+            ? $"last {WindowLabel(r)}"
+            : $"{ShortSpan(r)} → {r.WindowEnd.ToLocalTime():MMM d}";
+
+    /// <summary>Compact window span for the tight hero pill: "90m", "24h", "7d" - same tiering as
+    /// <see cref="WindowLabel"/>, abbreviated units, no space.</summary>
+    private static string ShortSpan(IspHealthReport r)
+    {
+        var span = r.WindowEnd - r.WindowStart;
+        if (span.TotalMinutes < 60) return $"{span.TotalMinutes:0}m";
+        if (span.TotalHours < 72) return $"{span.TotalHours:0.#}h";
+        return $"{span.TotalDays:0.#}d";
+    }
 
     private static string WindowLabel(IspHealthReport r)
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -231,7 +231,7 @@ else
                     <h2 class="card-title">@dimension.Name</h2>
                     <span class="isp-dimension-score @ScoreTextClass(dimension.Score)">@(dimension.Score?.ToString() ?? "--")</span>
                 </div>
-                <div class="card-body">
+                <div class="card-body isp-card-body-tight-top">
                     @if (dimension == r.IspAsnDimension)
                     {
                         var ispTargets = r.IspTargets.OrderBy(t => t.RttMs ?? double.MaxValue).ToList();
@@ -331,9 +331,26 @@ else
                                 </div>
                                 <span class="isp-factor-score @ScoreTextClass(factor.Score)">@(factor.Score?.ToString() ?? "--")</span>
                             </div>
-                            @if (!string.IsNullOrEmpty(factor.Description))
+                            @if (!string.IsNullOrEmpty(factor.Description)
+                                 && !(factor.Name == "Physical Link" && r.PhysicalLinkCandidates.Count > 1))
                             {
                                 <div class="isp-factor-description">@factor.Description</div>
+                            }
+                            @if (factor.Name == "Physical Link" && r.PhysicalLinkCandidates.Count > 1)
+                            {
+                                <div class="isp-factor-description">
+                                    @(r.PhysicalLinkAmbiguous
+                                        ? "More than one monitored access-link device matches this WAN. Choose which one feeds the score:"
+                                        : "Scoring the selected access-link device. Change it here if needed:")
+                                </div>
+                                <select class="form-control" style="max-width: 320px;"
+                                        value="@(r.PhysicalLinkSelectedKey ?? "")" @onchange="OnPhysicalLinkSourceChanged">
+                                    <option value="">Choose a source...</option>
+                                    @foreach (var cand in r.PhysicalLinkCandidates)
+                                    {
+                                        <option value="@cand.Key" selected="@(cand.Key == r.PhysicalLinkSelectedKey)">@cand.Label</option>
+                                    }
+                                </select>
                             }
                         }
                     }
@@ -482,7 +499,7 @@ else
 
     <div class="card isp-health-card isp-health-chart-card">
         <div class="card-header"><h2 class="card-title">Per-Network RTT (@WindowLabel(r))</h2></div>
-        <div class="card-body">
+        <div class="card-body isp-card-body-tight-top">
             <div id="isp-health-asn-chart"></div>
 
             @{ var ispAsn = r.IspAsns.FirstOrDefault(a => a.AsnNumber > 0); }
@@ -512,6 +529,7 @@ else
     private bool _loading = true;
     private bool _chartMounted;
     private bool _refreshing;
+    private bool _autoReloading;
     private bool _showAllIspHops;
     private System.Threading.Timer? _ageTimer;
 
@@ -563,13 +581,42 @@ else
             _loading = false;
         }
 
-        // Re-render every 30 s so "Last updated: N min ago" ages on its own, without
-        // waiting for a tab reload or a manual refresh.
+        // Re-render every 30 s so "Last updated: N min ago" ages on its own, and - on the live
+        // 48 h view - pull the latest cached snapshot so the tab follows the background recompute
+        // instead of sitting on a stale "Last updated" until a manual refresh.
         _ageTimer = new System.Threading.Timer(_ =>
         {
-            try { _ = InvokeAsync(StateHasChanged); }
+            try { _ = InvokeAsync(AutoReloadTickAsync); }
             catch { /* never let a render fault kill the timer */ }
         }, null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
+    }
+
+    /// <summary>
+    /// Periodic tick: always re-render so the relative "Last updated" ages, and on the live 48 h
+    /// view fetch the latest snapshot. This is a non-forced GetReportAsync - it serves the cache
+    /// and recomputes at most once per CacheTtl when stale, never the heavy forced refresh (which
+    /// clears caches and recomputes unconditionally). The display only swaps when a newer snapshot
+    /// actually arrives, so the chart isn't reloaded on every tick. Custom windows are left alone.
+    /// </summary>
+    private async Task AutoReloadTickAsync()
+    {
+        if (IsLiveWindow && !_autoReloading && !_loading && !_refreshing && !_windowComputing)
+        {
+            _autoReloading = true;
+            try
+            {
+                var latest = await IspHealth.GetReportAsync();
+                if (latest != null && (_report == null || latest.ComputedAt != _report.ComputedAt))
+                {
+                    _report = latest;
+                    try { await JS.InvokeVoidAsync("eval", "window.__ispHealthCharts?.reload?.();"); }
+                    catch { /* chart not mounted yet */ }
+                }
+            }
+            catch { /* never let a fetch fault kill the timer */ }
+            finally { _autoReloading = false; }
+        }
+        StateHasChanged();
     }
 
     private async Task RefreshAsync()
@@ -597,6 +644,21 @@ else
         {
             _refreshing = false;
         }
+    }
+
+    /// <summary>
+    /// Persists the user's chosen physical-link source (the ambiguity dropdown) and reloads the
+    /// report for the current window so the Physical Link factor reflects the pick.
+    /// </summary>
+    private async Task OnPhysicalLinkSourceChanged(ChangeEventArgs e)
+    {
+        var key = e.Value?.ToString();
+        await IspHealth.SetPhysicalLinkSourceAsync(string.IsNullOrEmpty(key) ? null : key);
+        if (IsLiveWindow)
+            _report = await IspHealth.GetReportAsync();
+        else if (_windowStart.HasValue && _windowEnd.HasValue)
+            _report = await IspHealth.GetReportForWindowAsync(_windowStart.Value, _windowEnd.Value, forceRefresh: true);
+        StateHasChanged();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -372,6 +372,7 @@ builder.Services.AddScoped<SnmpDetectionService>();
 builder.Services.AddSingleton<MonitoringInfluxClient>();
 builder.Services.AddSingleton<MonitoringLiveStats>();
 builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.WanSummaryCache>();
+builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.IspHealth.PhysicalLinkResolver>();
 builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.IspHealth.IspHealthService>();
 builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.FlakyTargetService>();
 builder.Services.AddScoped<NetworkOptimizer.Web.Services.Monitoring.MonitoringPathView>();

--- a/src/NetworkOptimizer.Web/Services/CellularModemService.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemService.cs
@@ -4,6 +4,7 @@ using NetworkOptimizer.Storage.Interfaces;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
 using NetworkOptimizer.UniFi;
+using NetworkOptimizer.UniFi.Models;
 
 namespace NetworkOptimizer.Web.Services;
 
@@ -115,7 +116,7 @@ public class CellularModemService : ICellularModemService
                         Model = displayModel,
                         Host = device.Ip ?? "",
                         MacAddress = device.Mac,
-                        IsOnline = device.State == 1 && device.Adopted
+                        IsOnline = UniFiDeviceStateMap.IsOnline(device.State) && device.Adopted
                     });
                     _logger.LogInformation("Discovered cellular modem: {Name} ({Model}) at {Host}",
                         device.Name, displayModel, device.Ip);

--- a/src/NetworkOptimizer.Web/Services/DashboardService.cs
+++ b/src/NetworkOptimizer.Web/Services/DashboardService.cs
@@ -1,6 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Core.Models;
 using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.UniFi.Models;
 using NetworkOptimizer.WiFi;
 
 namespace NetworkOptimizer.Web.Services;
@@ -73,7 +75,7 @@ public class DashboardService : IDashboardService
                         Name = d.Name ?? d.Mac ?? "Unknown",
                         Mac = d.Mac ?? string.Empty,
                         Type = d.Type,
-                        Status = d.State == 1 ? "Online" : "Offline",
+                        StatusInfo = UniFiDeviceStateMap.ToStatus(d.State),
                         IpAddress = d.DisplayIpAddress ?? "",
                         Model = d.FriendlyModelName,
                         Firmware = d.Firmware,
@@ -269,7 +271,10 @@ public class DeviceInfo
     public string Name { get; set; } = "";
     public string Mac { get; set; } = "";
     public DeviceType Type { get; set; }
-    public string Status { get; set; } = "";
+
+    /// <summary>Connection status (bucket + label) derived from the UniFi device <c>state</c>.</summary>
+    public DeviceStatus StatusInfo { get; set; } = new(DeviceStatusKind.Online, "Online");
+
     public string IpAddress { get; set; } = "";
     public string? Model { get; set; }
     public string? Firmware { get; set; }

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -1144,7 +1144,7 @@ public class LanFlowMapService
                 Name = string.IsNullOrEmpty(d.Name) ? d.FriendlyModelName : d.Name,
                 Model = d.FriendlyModelName,
                 Placement = anchor,
-                Online = d.State == 1,
+                Online = UniFiDeviceStateMap.IsOnline(d.State),
             };
             if (string.Equals(d.UplinkType, "wireless", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/NetworkOptimizer.Web/Services/MeshOptimizationService.cs
+++ b/src/NetworkOptimizer.Web/Services/MeshOptimizationService.cs
@@ -60,8 +60,16 @@ public class MeshOptimizationService
         if (!sshConfigured)
             return MeshOptimizationResult.NoOp(iface, "Set up UniFi Device SSH in Settings to re-pair the uplink.");
 
-        // wpa_cli control socket is per-interface on the AP (BusyBox / POSIX sh, runtime only).
-        var wc = $"wpa_cli -p /var/run/wpa_supplicant/wpa_supplicant-{iface} -i {iface}";
+        // The per-interface wpa_supplicant control socket lives in different dirs across AP
+        // platforms. U7-class APs run one global wpa_supplicant and nest the socket under
+        // /var/run/wpa_supplicant/wpa_supplicant-<iface>/<iface>; U6-class APs run a per-interface
+        // wpa_supplicant whose socket is flat at /var/run/wpa_supplicant/<iface>. Both name the
+        // socket file <iface>, so probe both parents at call time and use whichever holds the live
+        // socket. iface is validated above (^vwiresta\d+$), so it's safe to interpolate into the
+        // shell. (BusyBox / POSIX sh, runtime only.)
+        var ctrlDir = $"\"$(for d in /var/run/wpa_supplicant/wpa_supplicant-{iface} /var/run/wpa_supplicant; " +
+            $"do [ -S \"$d/{iface}\" ] && {{ printf %s \"$d\"; break; }}; done)\"";
+        var wc = $"wpa_cli -p {ctrlDir} -i {iface}";
 
         var before = await ReadLinkAsync(host, wc, cancellationToken);
         if (before.Bssid == null)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/DocsisHealthThresholds.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/DocsisHealthThresholds.cs
@@ -1,0 +1,69 @@
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Single source-of-truth for DOCSIS cable-modem RF HEALTH thresholds used by ISP
+/// Health physical-link scoring. These are distinct from the alert thresholds in
+/// <c>CableModemAlertEvaluator</c> (which fire hard faults); these describe the
+/// ideal/marginal/poor anchors a 0-100 health curve interpolates over.
+///
+/// Numbers are grounded in CableLabs DOCSIS PHY guidance and field practice:
+/// DS power ideal -7..+7 dBmV (pad above +8); US power ideal 40..47 dBmV, straining
+/// above 51; DS MER ideal ~40 dB, floor 33 (256-QAM SC-QAM) / 36 (4096-QAM OFDM).
+/// On DOCSIS 3.1 OFDM/OFDMA with LDPC, high CORRECTABLE counts are normal/benign and
+/// only the UNCORRECTABLE fraction matters; DOCSIS 3.0 SC-QAM is graded more strictly.
+/// </summary>
+public static class DocsisHealthThresholds
+{
+    // --- Downstream receive power (dBmV), per channel. Tent curve peaks near 0. ---
+    public const double DsPowerIdealLowDbmv = -7.0;
+    public const double DsPowerIdealHighDbmv = 7.0;
+    /// <summary>Above this, recommend a forward-path attenuator (pad).</summary>
+    public const double DsPowerPadAdviseDbmv = 8.0;
+    public const double DsPowerStarvedDbmv = -10.0;
+    public const double DsPowerOutOfSpecLowDbmv = -15.0;
+    public const double DsPowerOutOfSpecHighDbmv = 15.0;
+
+    // --- Upstream transmit power (dBmV). Higher beyond ideal = modem straining. ---
+    public const double UsPowerIdealHighDbmv = 47.0;
+    public const double UsPowerDriftingDbmv = 48.0;
+    /// <summary>Marginal: running out of headroom (matches the existing alert line).</summary>
+    public const double UsPowerMarginalDbmv = 51.0;
+    public const double UsPowerCriticalDbmv = 53.0;
+    public const double UsPowerMaxDbmv = 57.0;
+
+    // --- Downstream MER/SNR (dB). Floor depends on plant generation. ---
+    public const double DsMerIdealDb = 40.0;
+    public const double DsMerFloorScQamDb = 33.0;   // 256-QAM SC-QAM (DOCSIS 3.0)
+    public const double DsMerFloorOfdmDb = 36.0;    // 4096-QAM OFDM (DOCSIS 3.1)
+
+    // --- FEC scoring: a 50/50 blend of the uncorrectable RATIO and the uncorrectable RATE. ---
+    // The ratio unc / (corr + unc) is "how dominant are uncorrectables among errored codewords" -
+    // a texture signal, NOT unc/total-codewords (the time-series lacks error-free counts), so a
+    // moderate ratio is normal when the absolute rate is low. The rate (uncorrectables per day) is
+    // the magnitude gate. Both halves average into the FEC sub-score.
+    /// <summary>Uncorrectable fraction of errored codewords that still scores well (texture, not a fault).</summary>
+    public const double FecUncorrRatioGood = 0.30;
+    /// <summary>Uncorrectable fraction at which the ratio half bottoms out.</summary>
+    public const double FecUncorrRatioPoor = 0.90;
+    /// <summary>Uncorrectable fraction above which an issue is raised regardless of rate.</summary>
+    public const double FecUncorrRatioIssue = 0.40;
+    // Uncorrectable codewords per day - the magnitude gate. DOCSIS 3.1 OFDM runs ~10x the throughput
+    // of 3.0 SC-QAM, so it processes ~10x the codewords and a healthy 3.1 link logs proportionally
+    // more absolute uncorrectables; its allowable rate scales up accordingly.
+    /// <summary>DOCSIS 3.0 SC-QAM: uncorrectables/day that are fine.</summary>
+    public const double UncorrPerDayGoodScQam = 2000.0;
+    /// <summary>DOCSIS 3.0 SC-QAM: uncorrectables/day at which the rate half bottoms out (and an issue is raised).</summary>
+    public const double UncorrPerDayPoorScQam = 20000.0;
+    /// <summary>DOCSIS 3.1 OFDM: uncorrectables/day that are fine (~10x SC-QAM).</summary>
+    public const double UncorrPerDayGoodOfdm = 20000.0;
+    /// <summary>DOCSIS 3.1 OFDM: uncorrectables/day at which the rate half bottoms out (and an issue is raised).</summary>
+    public const double UncorrPerDayPoorOfdm = 200000.0;
+
+    /// <summary>
+    /// Provisioned upstream above this (Mbps) is a hint the plant is DOCSIS 3.1 OFDMA
+    /// mid/high-split: a single legacy ATDMA channel caps ~27-30 Mbps and operators
+    /// avoid stacking four in the noisy low-split band. A HINT only - an active OFDMA
+    /// upstream channel in the live snapshot is the authoritative tell.
+    /// </summary>
+    public const double OfdmaLikelyUpstreamMbps = 50.0;
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -325,13 +325,15 @@ public class OutageEvent
     /// </summary>
     public bool IsPartial { get; init; }
 
-    /// <summary>Worst per-target mean loss reached during the event, for the partial-loss summary.</summary>
+    /// <summary>Worst per-target loss reached during the event. Feeds the partial-loss summary and the
+    /// scorer's severity depth (peak loss fraction). Populated for blackouts and partials alike.</summary>
     public double PeakLossPct { get; init; }
 
-    /// <summary>Distinct path targets that degraded during the event (partial-loss breadth).</summary>
+    /// <summary>Targets that dropped during the event (dark for a blackout, degraded for a partial) -
+    /// the numerator of the severity breadth fraction.</summary>
     public int DegradedTargetCount { get; init; }
 
-    /// <summary>Total path targets reporting during the event, the denominator for the breadth summary.</summary>
+    /// <summary>Total targets reporting during the event, the denominator for the breadth fraction.</summary>
     public int PathTargetCount { get; init; }
 
     /// <summary>Whether even the access hop went dark, or it held while everything beyond it dropped.</summary>
@@ -352,6 +354,14 @@ public class OutageEvent
     /// scored. Set by the scorer so each outage row can show its own "-N points".
     /// </summary>
     public int ScorePenaltyPoints { get; set; }
+
+    /// <summary>
+    /// Time-of-day usage weight 0..1: how heavily the line is typically in use during this event's
+    /// local hours, relative to its busiest hour, floored by <see cref="IspHealthOptions.UsageWeightFloor"/>.
+    /// 1.0 when usage weighting is off or the fingerprint is unavailable. Scales the outage's score
+    /// penalty so a drop during a quiet hour dings less than the same drop at peak. Set by the service.
+    /// </summary>
+    public double UsageWeight { get; set; } = 1.0;
 }
 
 /// <summary>One network tier's behavior during an outage, for the recovery-shape display.</summary>
@@ -416,6 +426,18 @@ public class IspHealthReport
     public double? TypicalDownloadMbps { get; init; }
     public double? TypicalUploadMbps { get; init; }
     public DateTime? SpeedTestTime { get; init; }
+
+    /// <summary>
+    /// Physical-link source candidates for the WAN. More than one means the match was
+    /// ambiguous; the panel renders a picker. Set by the service after scoring (display only).
+    /// </summary>
+    public List<PhysicalLinkCandidate> PhysicalLinkCandidates { get; set; } = new();
+
+    /// <summary>The currently selected physical-link source key (e.g. "cm:3"), if any.</summary>
+    public string? PhysicalLinkSelectedKey { get; set; }
+
+    /// <summary>True when multiple sources matched and the user has not yet picked one.</summary>
+    public bool PhysicalLinkAmbiguous { get; set; }
 
     public static string GradeLabel(int score) => score switch
     {
@@ -570,6 +592,13 @@ public class IspHealthInputs
     /// transit (transit is always downstream of the ISP) and stays closed for ISP siblings.
     /// </summary>
     public bool HopOrderKnown { get; init; }
+
+    /// <summary>
+    /// Window-aggregated physical-link metrics for the one source matched to the WAN, or null
+    /// when no source matched (or the match was ambiguous and unresolved). Drives the Access
+    /// Layer Physical Link factor.
+    /// </summary>
+    public PhysicalLinkInput? PhysicalLink { get; init; }
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -24,24 +24,39 @@ public class IspHealthOptions
     /// <summary>Weight of the ISP-ASN-health dimension in the overall score.</summary>
     public double IspAsnWeight { get; set; } = 1.0 / 3.0;
 
+    // The five symptom factors below were rebalanced to 0.85 of their original weights
+    // (0.30/0.10/0.25/0.175/0.175 -> scaled by 0.85) to make room for the Physical Link
+    // factor at 0.15. It is kept a mid-weight signal rather than the dimension's heaviest
+    // because a degraded physical layer usually also surfaces in the loss/latency/speed
+    // factors; its unique value is the early-warning / root-cause case. BuildDimension
+    // renormalizes by the weight of the factors that actually scored, so a line with no
+    // matched physical source (Physical Link omitted) keeps the five's original proportions.
+
     /// <summary>Weight of WAN speed test throughput vs the configured plan within the access dimension.</summary>
-    public double SpeedVsPlanWeight { get; set; } = 0.30;
+    public double SpeedVsPlanWeight { get; set; } = 0.255;
 
     /// <summary>Weight of idle latency within the access dimension.</summary>
-    public double IdleLatencyWeight { get; set; } = 0.10;
+    public double IdleLatencyWeight { get; set; } = 0.085;
 
     /// <summary>
     /// Weight of packet loss within the access dimension. Loss is the heaviest signal
     /// after speed: it captures both steady physical-layer loss and (via the capped
     /// outage penalty) internet-unreachable outages, which users care about most.
     /// </summary>
-    public double IdleLossWeight { get; set; } = 0.25;
+    public double IdleLossWeight { get; set; } = 0.2125;
 
     /// <summary>Weight of loaded latency delta within the access dimension.</summary>
-    public double LoadedLatencyWeight { get; set; } = 0.175;
+    public double LoadedLatencyWeight { get; set; } = 0.14875;
 
     /// <summary>Weight of loaded packet loss within the access dimension.</summary>
-    public double LoadedLossWeight { get; set; } = 0.175;
+    public double LoadedLossWeight { get; set; } = 0.14875;
+
+    /// <summary>
+    /// Weight of the Physical Link factor within the access dimension: the access medium's
+    /// own physical layer (optical RX power, DOCSIS RF/FEC, cellular signal). 0.15 of the
+    /// dimension when a source is matched; omitted (no penalty) when none is.
+    /// </summary>
+    public double PhysicalLinkWeight { get; set; } = 0.15;
 
     /// <summary>How far back to fall when no WAN speed test ran inside the score window.</summary>
     public int SpeedTestFallbackDays { get; set; } = 7;
@@ -401,15 +416,76 @@ public class IspHealthOptions
 
     /// <summary>
     /// Outage severity curve: points deducted from the OVERALL score per (totalDowntimeMinutes,
-    /// penaltyPoints) anchor, interpolated. Applied at the top level rather than buried in the
-    /// Packet Loss factor (where the dimension weights would dilute a multi-hour outage to a
-    /// couple of points). Scored by total duration alone - shape-independent. A brief blip barely
-    /// registers; ~10 min is a clear ding; multi-hour drives the score toward zero.
+    /// penaltyPoints) anchor, interpolated. This is the DURATION component of the outage penalty,
+    /// applied at the top level rather than buried in the Packet Loss factor (where the dimension
+    /// weights would dilute a multi-hour outage to a couple of points). The front is deliberately
+    /// steep - a 30 s drop is felt out of all proportion to its seconds (a dropped call, a stalled
+    /// stream), so a sub-minute outage carries a couple of points on duration alone rather than
+    /// rounding to zero; ~10 min is a clear ding; multi-hour drives the score toward zero. Recurrence
+    /// is scored separately by <see cref="OutageEventCost"/>, so this curve need not also encode "many
+    /// short drops are bad".
     /// </summary>
     public (double Minutes, double Penalty)[] OutageSeverityCurve { get; set; } =
     {
-        (0, 0), (5, 7), (10, 14), (30, 28), (60, 45), (180, 70), (480, 90)
+        (0, 0), (0.5, 1.5), (1, 2.5), (2, 4), (5, 7), (10, 14), (30, 28), (60, 45), (180, 70), (480, 90)
     };
+
+    /// <summary>
+    /// Per-event occurrence cost: the OCCURRENCE component of the outage penalty, summed across every
+    /// WAN outage on top of the duration curve. Each event contributes OutageEventCost x severity,
+    /// where severity = breadth (fraction of monitored targets that dropped) x depth (peak loss
+    /// fraction), 0..1. This is what makes recurrence bite: ten separate micro-drops cost ~ten times
+    /// a single one, where the duration curve alone would treat them as one slightly-longer drop. It
+    /// also lifts a single felt short outage off the floor. Kept modest because these events still
+    /// feed the Packet Loss factor (not masked), so we don't want to triple-count.
+    /// </summary>
+    public double OutageEventCost { get; set; } = 3.0;
+
+    /// <summary>
+    /// Cap on the summed occurrence component so a pathologically flaky window doesn't run the penalty
+    /// away on its own (the duration curve still adds on top, uncapped). Set high - a line dropping
+    /// dozens of times in the window SHOULD score badly - but bounded so occurrence can't alone zero a
+    /// score that the duration barely touched.
+    /// </summary>
+    public double OutageOccurrenceCap { get; set; } = 35.0;
+
+    /// <summary>
+    /// Weight outage severity by a time-of-day usage fingerprint: an outage during the hours the user
+    /// actually uses the connection bites in full, one during typically-idle hours dings less. The
+    /// fingerprint is built from the WAN throughput we already record (no new measurement) - per
+    /// local hour-of-day, the fraction of time the line was actively in use. Off => every outage is
+    /// weighted 1.0 (the prior behavior).
+    /// </summary>
+    public bool UsageWeightingEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Floor for the time-of-day usage weight: even at the quietest hour an outage still costs this
+    /// fraction of its full penalty (an outage is an outage). 1.0 would disable softening entirely.
+    /// </summary>
+    public double UsageWeightFloor { get; set; } = 0.5;
+
+    /// <summary>Downstream bits/sec above which the line counts as "actively in use" for the usage
+    /// fingerprint. ~1.5 Mbps so HD streaming registers as active, idle keep-alive traffic does not.</summary>
+    public double UsageActiveDownstreamBps { get; set; } = 1_500_000;
+
+    /// <summary>Upstream bits/sec above which the line counts as "actively in use" for the usage
+    /// fingerprint (~1 Mbps: a video call, an upload, a backup).</summary>
+    public double UsageActiveUpstreamBps { get; set; } = 1_000_000;
+
+    /// <summary>How far back to look when building the usage fingerprint. Longer = a cleaner, more
+    /// stable hour-of-day profile, independent of the (possibly short) scoring window.</summary>
+    public int UsageFingerprintLookbackDays { get; set; } = 14;
+
+    /// <summary>Minimum span of throughput data (hours from earliest to latest sample) before the usage
+    /// fingerprint is trusted. We only need roughly a full daily cycle to attempt a profile, not the
+    /// whole lookback - the lookback is a ceiling on history used, not a requirement. Below this it's
+    /// too little to read a time-of-day pattern, so weighting falls back to a flat 1.0 (cold start, no
+    /// grade-down).</summary>
+    public int UsageFingerprintMinHours { get; set; } = 24;
+
+    /// <summary>Usage weight at or below which a finding adds the "during a typically quiet time" note.
+    /// Purely cosmetic - the score impact already reflects the weight; this just explains it.</summary>
+    public double UsageQuietWeightThreshold { get; set; } = 0.7;
 
     /// <summary>Loaded delta beyond excellent by this many band-widths triggers the SQM recommendation.</summary>
     public double SqmDeviationFactor { get; set; } = 1.0;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -61,7 +61,30 @@ public class IspHealthScorer
         var (loadedLatency, hasLoadedLatency) = ScoreLoadedLatency(loadedDeltas, profile);
         var (loadedLoss, hasLoadedLoss) = ScoreLoadedLoss(inputs.LossPoolSeries, loadWindows, profile);
 
-        var accessFactors = new List<IspScoreFactor> { speedVsPlan, idleLatency, idleLoss, loadedLatency, loadedLoss };
+        // Physical Link: the access medium's own physical layer (optical RX, DOCSIS RF/FEC,
+        // cellular signal). Null factor (omitted, no penalty) when no source matched the WAN.
+        var physicalIssues = new List<IspHealthIssue>();
+        IspScoreFactor physicalLink;
+        if (inputs.PhysicalLink is not null)
+        {
+            var physical = PhysicalLinkScorer.Score(inputs.PhysicalLink, inputs.ExpectedUploadMbps, _options.PhysicalLinkWeight, _logger);
+            physicalLink = physical.Factor;
+            physicalIssues = physical.Issues;
+            _logger?.LogDebug("ISP Health physical link factor: {Medium} '{Source}' -> {Score} ({Value})",
+                inputs.PhysicalLink.Medium, inputs.PhysicalLink.SourceName, physicalLink.Score, physicalLink.ValueText ?? "n/a");
+        }
+        else
+        {
+            physicalLink = new IspScoreFactor
+            {
+                Name = "Physical Link",
+                Score = null,
+                Weight = _options.PhysicalLinkWeight,
+                Description = "No monitored access-link device (ONT, cable modem, or cellular modem) matched this WAN."
+            };
+        }
+
+        var accessFactors = new List<IspScoreFactor> { speedVsPlan, idleLatency, idleLoss, loadedLatency, loadedLoss, physicalLink };
         var accessDimension = BuildDimension("Access Layer", _options.AccessWeight, accessFactors);
 
         var accessMedianRtt = SeriesStats.Median(
@@ -81,32 +104,80 @@ public class IspHealthScorer
         var ispAsnDimension = BuildIspDimension(_options.IspAsnWeight, ispHopGrades);
 
         var overall = CombineDimensions(accessDimension, transitDimension, ispAsnDimension);
-        // An outage is scored once, here at the top level, on a duration curve - so a long
-        // outage actually drives the score down instead of being diluted to a couple of
-        // points inside one factor. A partial-loss disruption counts as a fraction of that:
-        // its duration is weighted by its peak loss fraction (and a tunable weight), so a brief
-        // degradation is a near-zero ding while a blackout of the same length scores in full.
+        // Outages are scored once, here at the top level (not inside a factor, where the dimension
+        // weights would dilute a multi-hour outage to a couple of points), as TWO components:
+        //   - DURATION: one severity-curve lookup on the summed effective downtime. A partial-loss
+        //     disruption's minutes are weighted by its peak loss fraction (and a tunable weight), so a
+        //     shallow degradation dings less than a blackout of the same length.
+        //   - OCCURRENCE: each event's severity (breadth x depth) x a per-event cost, summed and
+        //     capped. This is what makes recurrence bite - ten separate micro-drops cost ~ten times a
+        //     single one, where the duration curve alone treats them as one slightly-longer drop - and
+        //     lifts a single felt short outage off the floor.
         // Local (LAN/gateway) outages are surfaced but never penalize the ISP - the gateway being
         // unreachable is the user's own LAN, not the ISP's fault (they still mask their dark window
         // from the other factors via InOutage, so that loss isn't double-counted against the ISP).
+        // Both components are scaled by the event's time-of-day usage weight (1.0 unless the service
+        // set it): an outage during the user's heavy-usage hours counts in full, one during typically
+        // idle hours dings less.
         var wanOutages = inputs.Outages.Where(o => o.Scope != OutageScope.Local).ToList();
         double EffectiveMinutes(OutageEvent o) => o.Duration.TotalMinutes *
-            (o.IsPartial ? Math.Clamp(o.PeakLossPct / 100.0, 0, 1) * _options.OutagePartialPenaltyWeight : 1.0);
-        var outageMinutes = wanOutages.Sum(EffectiveMinutes);
-        if (outageMinutes > 0)
+            (o.IsPartial ? Math.Clamp(o.PeakLossPct / 100.0, 0, 1) * _options.OutagePartialPenaltyWeight : 1.0)
+            * o.UsageWeight;
+        // Severity 0..1 = breadth (fraction of monitored targets that dropped) x depth (peak loss
+        // fraction) x usage weight. A widespread near-total event at a busy hour reads hottest.
+        double Severity(OutageEvent o)
         {
+            var depth = Math.Clamp(o.PeakLossPct / 100.0, 0, 1);
+            var breadth = o.PathTargetCount > 0
+                ? Math.Clamp((double)o.DegradedTargetCount / o.PathTargetCount, 0, 1)
+                : 0.0;
+            return depth * breadth * o.UsageWeight;
+        }
+        if (wanOutages.Count > 0)
+        {
+            var outageMinutes = wanOutages.Sum(EffectiveMinutes);
+            var durationPenalty = outageMinutes > 0 ? OutageScorePenalty(outageMinutes) : 0.0;
+            // Occurrence is a FREQUENCY signal, so judge it as a RATE against the canonical window:
+            // the same few micro-drops spread over a week is a steadier line than the same number in
+            // 48 h. Dilute occurrence for windows LONGER than the reference; never amplify a shorter
+            // (e.g. zoomed-in) window. Duration is left absolute, so a long outage weighs the same in
+            // any window - only the count-based part rescales.
+            var windowHours = (inputs.WindowEnd - inputs.WindowStart).TotalHours;
+            var occurrenceWindowScale = _options.ScoreWindowHours > 0 && windowHours > _options.ScoreWindowHours
+                ? _options.ScoreWindowHours / windowHours
+                : 1.0;
+            double EventOccurrence(OutageEvent o) => _options.OutageEventCost * Severity(o) * occurrenceWindowScale;
+            var rawOccurrence = wanOutages.Sum(EventOccurrence);
+            var occurrencePenalty = Math.Min(_options.OutageOccurrenceCap, rawOccurrence);
+            var occCapScale = rawOccurrence > 0 ? occurrencePenalty / rawOccurrence : 0.0;
             // Floor a flagged WAN event at one point: if we surfaced it on the timeline it should
-            // visibly register, not round to a silent zero (a brief/partial event can curve to a
-            // fraction of a point otherwise). The floor is on the total, so many tiny events still
-            // cost at least a point rather than each.
-            var penalty = Math.Max(1.0, OutageScorePenalty(outageMinutes));
-            // Attribute the total penalty across the WAN outages by effective-minute share so each
-            // row can show its own "-N points". Rounded shares may differ from the curve total by
-            // <=1 pt - cosmetic; the actual deduction uses the total below.
+            // visibly register, not round to a silent zero.
+            var penalty = Math.Max(1.0, durationPenalty + occurrencePenalty);
+            // Attribute the total across events so each row shows its own "-N points": its duration
+            // share (by effective-minute) plus its (capped) occurrence cost. Rounded shares may differ
+            // from the total by <=1 pt - cosmetic; the actual deduction uses the total below.
             foreach (var o in wanOutages)
-                o.ScorePenaltyPoints = (int)Math.Round(penalty * (EffectiveMinutes(o) / outageMinutes));
-            _logger?.LogDebug("ISP Health: outage penalty {Penalty} pts over {Min} effective min downtime ({Before} -> {After})",
-                penalty.ToString("0.#", CultureInfo.InvariantCulture), outageMinutes.ToString("0.#", CultureInfo.InvariantCulture),
+            {
+                var durShare = outageMinutes > 0 ? durationPenalty * (EffectiveMinutes(o) / outageMinutes) : 0.0;
+                var occShare = EventOccurrence(o) * occCapScale;
+                o.ScorePenaltyPoints = (int)Math.Round(durShare + occShare);
+                // Per-event "show your work": time, kind, duration, depth (peak loss), breadth, and the
+                // time-of-day usage weight that scaled it, then the duration/occurrence point split.
+                _logger?.LogDebug(
+                    "ISP Health: outage {Start:HH:mm:ss} {Kind} {Dur}s peakLoss={Peak}% breadth={Deg}/{Tot} usageWeight={UW} -> {Pts} pts ({DurShare} dur + {OccShare} occ)",
+                    o.Start, o.IsPartial ? "partial" : o.IsBrief ? "brief" : "full",
+                    o.Duration.TotalSeconds.ToString("0", CultureInfo.InvariantCulture),
+                    o.PeakLossPct.ToString("0", CultureInfo.InvariantCulture),
+                    o.DegradedTargetCount, o.PathTargetCount,
+                    o.UsageWeight.ToString("0.00", CultureInfo.InvariantCulture),
+                    o.ScorePenaltyPoints,
+                    durShare.ToString("0.0", CultureInfo.InvariantCulture),
+                    occShare.ToString("0.0", CultureInfo.InvariantCulture));
+            }
+            _logger?.LogDebug("ISP Health: outage penalty {Penalty} pts = {Dur} duration + {Occ} occurrence over {N} event(s), {Min} eff min ({Before} -> {After})",
+                penalty.ToString("0.#", CultureInfo.InvariantCulture), durationPenalty.ToString("0.#", CultureInfo.InvariantCulture),
+                occurrencePenalty.ToString("0.#", CultureInfo.InvariantCulture), wanOutages.Count,
+                outageMinutes.ToString("0.#", CultureInfo.InvariantCulture),
                 overall, (int)Math.Max(0, Math.Round(overall - penalty)));
             overall = (int)Math.Max(0, Math.Round(overall - penalty));
         }
@@ -140,6 +211,7 @@ public class IspHealthScorer
             SpeedTestTime = bestSpeedTest?.Time
         };
         report.Issues.AddRange(CollectIssues(inputs, profile, report, loadWindows, loadedDeltas));
+        report.Issues.AddRange(physicalIssues);
         return report;
     }
 
@@ -1184,7 +1256,7 @@ public class IspHealthScorer
             {
                 Severity = IspIssueSeverity.Warning,
                 Title = multiple ? "Internet outages in the window" : "Internet outage in the window",
-                Description = $"{count} occurred while the Monitoring Agent kept probing ({realPhrase}).{where}{impact}",
+                Description = $"{count} occurred while the Monitoring Agent kept probing ({realPhrase}).{where}{impact}{UsageNote(fullOutages)}",
                 Recommendation = allUpstream
                     ? "No action needed on your side for an upstream outage; it is logged here so you can correlate it with ISP incidents."
                     : "Logged here so you can correlate it with ISP incidents; if the first ISP hop keeps dropping, check your modem/ONT and the line to your ISP.",
@@ -1212,7 +1284,7 @@ public class IspHealthScorer
             {
                 Severity = IspIssueSeverity.Info,
                 Title = multiple ? "Brief internet disruptions in the window" : "Brief internet disruption in the window",
-                Description = $"{count} occurred while the Monitoring Agent kept probing (so {(multiple ? "these are real, not monitoring gaps" : "this is real, not a monitoring gap")}).{where}{impact}",
+                Description = $"{count} occurred while the Monitoring Agent kept probing (so {(multiple ? "these are real, not monitoring gaps" : "this is real, not a monitoring gap")}).{where}{impact}{UsageNote(briefDisruptions)}",
                 Recommendation = "Short drops like these are usually transient upstream or transit events; logged here so you can spot a pattern of flapping.",
                 LinkUrl = "#isp-outages",
                 LinkText = "Shown on the timeline below."
@@ -1233,7 +1305,7 @@ public class IspHealthScorer
             {
                 Severity = IspIssueSeverity.Info,
                 Title = multiple ? "Partial-loss disruptions in the window" : "Partial-loss disruption in the window",
-                Description = $"{count} hit the path: many targets degraded at once without going fully dark, so the internet was lossy but not unreachable.{breadth}{impact}",
+                Description = $"{count} hit the path: many targets degraded at once without going fully dark, so the internet was lossy but not unreachable.{breadth}{impact}{UsageNote(partialDisruptions)}",
                 Recommendation = "Coincident partial loss across many targets is usually upstream/transit congestion or a brief routing wobble; logged so you can correlate it with ISP incidents or watch for a pattern.",
                 LinkUrl = "#isp-outages",
                 LinkText = "Shown on the timeline below."
@@ -1367,6 +1439,18 @@ public class IspHealthScorer
     /// </summary>
     private double OutageScorePenalty(double totalDowntimeMinutes) =>
         ScoreCurve.Interpolate(totalDowntimeMinutes, _options.OutageSeverityCurve);
+
+    /// <summary>A cosmetic note for an outage finding whose events fell during typically-idle hours.
+    /// The score impact already reflects the lower usage weight; this just explains why it's modest.
+    /// Empty when usage weighting is off or the events landed during normal/heavy-usage hours.</summary>
+    private string UsageNote(IReadOnlyCollection<OutageEvent> events)
+    {
+        if (!_options.UsageWeightingEnabled || events.Count == 0) return string.Empty;
+        if (events.Min(e => e.UsageWeight) >= _options.UsageQuietWeightThreshold) return string.Empty;
+        return events.Count > 1
+            ? " Some fell while your connection is typically idle, so the real-world impact was likely lower than the downtime suggests."
+            : " It fell while your connection is typically idle, so the real-world impact was likely lower than the downtime suggests.";
+    }
 
     private static string FormatOutageDuration(TimeSpan d) =>
         d.TotalMinutes < 90 ? $"{d.TotalMinutes:0} min" : $"{d.TotalHours:0.#} h";

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -25,6 +25,7 @@ public class IspHealthService
     private readonly MonitoringInfluxClient _influx;
     private readonly IDbContextFactory<NetworkOptimizerDbContext> _dbFactory;
     private readonly UniFiConnectionService _connectionService;
+    private readonly PhysicalLinkResolver _physicalLinkResolver;
     private readonly ILogger<IspHealthService> _logger;
     private readonly IspHealthOptions _options = new();
     private const int MaxCustomWindowHours = 720;  // 30-day cap on the date/time filter, matching the UI
@@ -49,12 +50,32 @@ public class IspHealthService
         MonitoringInfluxClient influx,
         IDbContextFactory<NetworkOptimizerDbContext> dbFactory,
         UniFiConnectionService connectionService,
+        PhysicalLinkResolver physicalLinkResolver,
         ILogger<IspHealthService> logger)
     {
         _influx = influx;
         _dbFactory = dbFactory;
         _connectionService = connectionService;
+        _physicalLinkResolver = physicalLinkResolver;
         _logger = logger;
+    }
+
+    /// <summary>
+    /// Persists the user's chosen physical-link source (used when more than one monitored
+    /// device matches the WAN's access technology) and forces a recompute so the Physical
+    /// Link factor reflects the pick. Pass null to clear the selection.
+    /// </summary>
+    public async Task SetPhysicalLinkSourceAsync(string? sourceKey, CancellationToken ct = default)
+    {
+        await using (var db = await _dbFactory.CreateDbContextAsync(ct))
+        {
+            var settings = await db.MonitoringSettings.FirstOrDefaultAsync(ct);
+            if (settings == null) return;
+            settings.PhysicalLinkSourceKey = string.IsNullOrWhiteSpace(sourceKey) ? null : sourceKey;
+            settings.UpdatedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync(ct);
+        }
+        await GetReportAsync(forceRefresh: true, ct);
     }
 
     public IspHealthOptions Options => _options;
@@ -573,11 +594,27 @@ public class IspHealthService
             outageHops, outages.Select(o => (o.Start, o.End)).ToList(), _options);
         outages = outages.Concat(partialDisruptions).OrderBy(o => o.Start).ToList();
 
+        // Weight each outage by the time-of-day usage fingerprint so a drop during heavy-usage hours
+        // counts in full and one during typically-idle hours dings less. Null fingerprint (weighting
+        // off, or too few days of data) leaves every UsageWeight at 1.0 - no grade-down.
+        var usageFingerprint = await BuildUsageFingerprintAsync(windowEnd, ct);
+        if (usageFingerprint != null)
+        {
+            var usageZone = TimeZoneInfo.Local;
+            foreach (var o in outages)
+                o.UsageWeight = UsageWeighting.Weight(
+                    usageFingerprint, UsageWeighting.LocalHoursSpanned(o.Start, o.End, usageZone), _options.UsageWeightFloor);
+        }
+
         // chartClusters (one line per cluster) is the chart view computed from the same
         // snapshot the detectors ran on, so deeper-cluster "+N ms hop" labels still match
         // event labels. It is published together with the report (see Snapshot).
         var primaryWanInterface = await GetPrimaryWanInterfaceAsync(ct);
         var loadExclusions = await BuildSqmProbeExclusionsAsync(windowStart, windowEnd, primaryWanInterface, ct);
+
+        // Match the WAN's access technology to one monitored physical device (ONT/SFP, cable
+        // modem, or cellular modem) and aggregate its window metrics for the Physical Link factor.
+        var physical = await _physicalLinkResolver.ResolveAsync(technology, windowStart, windowEnd, aggregate, ct);
 
         var inputs = new IspHealthInputs
         {
@@ -602,10 +639,14 @@ public class IspHealthService
             Outages = outages,
             SmartQueuesEnabled = smartQueuesEnabled,
             HopOrderKnown = hopOrderKnown,
-            LoadExclusionWindows = loadExclusions
+            LoadExclusionWindows = loadExclusions,
+            PhysicalLink = physical.Input
         };
 
         var report = new IspHealthScorer(_options, _logger).Score(inputs, profile);
+        report.PhysicalLinkCandidates = physical.Candidates;
+        report.PhysicalLinkSelectedKey = physical.SelectedKey;
+        report.PhysicalLinkAmbiguous = physical.Ambiguous;
         _logger.LogDebug("ISP Health computed: {Score} ({Tech}), {Events} congestion events, {Shifts} path shifts",
             report.OverallScore, profile.DisplayName, congestionEvents.Count, pathShifts.Count);
         return new ComputeOutcome(IspHealthStatus.Ready, report, chartClusters);
@@ -648,35 +689,98 @@ public class IspHealthService
     {
         try
         {
-            var devices = await _connectionService.GetDiscoveredDevicesAsync(ct);
-            var gw = devices?.FirstOrDefault(d => d.Type == DeviceType.Gateway || d.HardwareType == DeviceType.Gateway);
-            if (gw?.Mac == null)
+            var (mac, ifNames) = await ResolveWanCounterAsync(ct);
+            if (mac == null || ifNames == null || ifNames.Count == 0)
                 return new List<ThroughputSample>();
 
-            // ISP Health analyzes the CONFIGURED primary WAN (same WAN as the expected
-            // speeds and SQM exclusion), so the rate series must come from that WAN's
-            // SNMP counter interface (e.g. "eth6" for a VLAN-tagged primary), not the
-            // live active uplink in WanInterfaceNames. Fall back to the active uplink
-            // only if the config-primary cannot be resolved, so analysis still runs.
-            var primaryIfaces = await _connectionService.GetPrimaryWanInterfacesAsync(ct);
-            var wanCounterNames = !string.IsNullOrEmpty(primaryIfaces?.CounterIfName)
-                ? new List<string> { primaryIfaces!.CounterIfName! }
-                : gw.WanInterfaceNames;
-            if (wanCounterNames == null || wanCounterNames.Count == 0)
-            {
-                _logger.LogDebug("ISP Health: no WAN counter interface resolved for rate query");
-                return new List<ThroughputSample>();
-            }
-            if (primaryIfaces?.CounterIfName == null)
-                _logger.LogDebug("ISP Health: primary WAN unresolved, rate query falling back to active uplink {Ifaces}", string.Join(",", wanCounterNames));
-
-            var rates = await _influx.QueryGatewayWanRatesAsync(gw.Mac, wanCounterNames, from, to, aggregate, ct);
+            var rates = await _influx.QueryGatewayWanRatesAsync(mac, ifNames, from, to, aggregate, ct);
             return rates.Select(r => new ThroughputSample(r.Time, r.DownloadBps, r.UploadBps)).ToList();
         }
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "ISP Health could not query WAN rates");
             return new List<ThroughputSample>();
+        }
+    }
+
+    /// <summary>
+    /// Resolves the gateway MAC and the CONFIGURED primary WAN's SNMP counter interface(s) - the same
+    /// WAN as the expected speeds and SQM exclusion (e.g. "eth6" for a VLAN-tagged primary), not the
+    /// live active uplink. Falls back to the active uplink only if the config-primary can't be
+    /// resolved, so analysis still runs. Returns (null, null) when no gateway is discovered.
+    /// </summary>
+    private async Task<(string? Mac, List<string>? IfNames)> ResolveWanCounterAsync(CancellationToken ct)
+    {
+        var devices = await _connectionService.GetDiscoveredDevicesAsync(ct);
+        var gw = devices?.FirstOrDefault(d => d.Type == DeviceType.Gateway || d.HardwareType == DeviceType.Gateway);
+        if (gw?.Mac == null)
+            return (null, null);
+
+        var primaryIfaces = await _connectionService.GetPrimaryWanInterfacesAsync(ct);
+        var wanCounterNames = !string.IsNullOrEmpty(primaryIfaces?.CounterIfName)
+            ? new List<string> { primaryIfaces!.CounterIfName! }
+            : gw.WanInterfaceNames;
+        if (wanCounterNames == null || wanCounterNames.Count == 0)
+        {
+            _logger.LogDebug("ISP Health: no WAN counter interface resolved");
+            return (gw.Mac, null);
+        }
+        if (primaryIfaces?.CounterIfName == null)
+            _logger.LogDebug("ISP Health: primary WAN unresolved, falling back to active uplink {Ifaces}", string.Join(",", wanCounterNames));
+        return (gw.Mac, wanCounterNames);
+    }
+
+    /// <summary>
+    /// Hour-of-day usage fingerprint from the WAN throughput we already record (no new measurement):
+    /// per local hour-of-day, the fraction of sampled time the line was actively in use (DS/US above
+    /// the configured active thresholds). Drives time-of-day outage weighting. Returns null - so
+    /// weighting falls back to a flat 1.0 and outages are NOT graded down - when usage weighting is
+    /// off, no gateway/data is found, or the data spans fewer than <see cref="IspHealthOptions.UsageFingerprintMinHours"/>
+    /// hours (too little to read a time-of-day pattern). Uses whatever history exists up to the
+    /// lookback; the lookback is a ceiling, not a requirement, so ~a day of data is enough to attempt one.
+    /// </summary>
+    private async Task<double[]?> BuildUsageFingerprintAsync(DateTime windowEnd, CancellationToken ct)
+    {
+        if (!_options.UsageWeightingEnabled) return null;
+        try
+        {
+            var (mac, ifNames) = await ResolveWanCounterAsync(ct);
+            if (mac == null || ifNames == null || ifNames.Count == 0) return null;
+
+            var from = windowEnd.AddDays(-_options.UsageFingerprintLookbackDays);
+            // Active usage is sustained (streaming, calls, uploads); a 5-min mean is plenty to catch
+            // it and keeps the lookback series small.
+            var rates = await _influx.QueryGatewayWanRatesAsync(mac, ifNames, from, windowEnd, TimeSpan.FromMinutes(5), ct);
+            if (rates.Count == 0) return null;
+
+            var tz = TimeZoneInfo.Local;
+            var active = new double[24];
+            var total = new double[24];
+            DateTime? earliest = null, latest = null;
+            foreach (var r in rates)
+            {
+                var local = TimeZoneInfo.ConvertTimeFromUtc(DateTime.SpecifyKind(r.Time, DateTimeKind.Utc), tz);
+                total[local.Hour] += 1;
+                if (r.DownloadBps > _options.UsageActiveDownstreamBps || r.UploadBps > _options.UsageActiveUpstreamBps)
+                    active[local.Hour] += 1;
+                if (earliest is null || r.Time < earliest) earliest = r.Time;
+                if (latest is null || r.Time > latest) latest = r.Time;
+            }
+            // Need roughly a full daily cycle of data to read a time-of-day pattern; less than that
+            // can't distinguish "busy hour" from "quiet hour", so leave outages unweighted.
+            var spanHours = earliest is { } e && latest is { } l ? (l - e).TotalHours : 0;
+            if (spanHours < _options.UsageFingerprintMinHours) return null;
+
+            var fraction = new double[24];
+            for (var h = 0; h < 24; h++)
+                fraction[h] = total[h] > 0 ? active[h] / total[h] : 0.0;
+            _logger.LogDebug("ISP Health: usage fingerprint over {Span:0} h of data, peak-hour active {Peak:P0}", spanHours, fraction.Max());
+            return fraction;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "ISP Health: usage fingerprint build failed");
+            return null;
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OpticalSampleStats.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OpticalSampleStats.cs
@@ -1,0 +1,63 @@
+namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+
+/// <summary>
+/// Robust receive-power statistics for optical (SFP/ONT) DDM samples, with DDM read-artifact
+/// rejection. Cheap SFP DDM sticks occasionally return a garbage read where several fields glitch
+/// together in a single sample - RX dives while the reported temperature jumps tens of degrees,
+/// which is physically impossible between polls. Temperature is NOT a health metric here; it is the
+/// tell that flags and discards the bad read so it can't drag the RX statistics the score rides on.
+/// </summary>
+public static class OpticalSampleStats
+{
+    /// <summary>
+    /// A sample whose temperature deviates from the window median by more than this (C) is treated
+    /// as a DDM read artifact and dropped. Real thermal drift is gradual and small between polls;
+    /// the artifacts seen in the field jump 20-30+ C in one sample.
+    /// </summary>
+    public const double DdmTempArtifactDeltaC = 12.0;
+
+    /// <summary>Robust RX summary over a window after artifact rejection.</summary>
+    public sealed record RxStats(double? MedianDbm, double? WorstDbm, double? BaselineDbm, int CleanCount, int RejectedArtifacts);
+
+    /// <summary>
+    /// Computes median / worst / baseline RX over the samples, dropping DDM artifacts first.
+    /// Worst is the coldest CLEAN sample; baseline is the median of the earliest fifth (for the
+    /// trend check). Samples missing RX are ignored; samples missing temperature can't be judged
+    /// and are kept.
+    /// </summary>
+    public static RxStats Compute(IReadOnlyList<(DateTime Time, double? Rx, double? Temp)> samples)
+    {
+        var medianTemp = Median(samples.Where(s => s.Temp.HasValue).Select(s => s.Temp!.Value).ToList());
+
+        var rejected = 0;
+        var clean = new List<double>();
+        foreach (var s in samples.OrderBy(s => s.Time))
+        {
+            if (s.Rx is not double rx) continue;
+            if (medianTemp is double mt && s.Temp is double t && Math.Abs(t - mt) > DdmTempArtifactDeltaC)
+            {
+                rejected++;
+                continue;
+            }
+            clean.Add(rx);
+        }
+
+        return new RxStats(Median(clean), clean.Count > 0 ? clean.Min() : null, Baseline(clean), clean.Count, rejected);
+    }
+
+    internal static double? Median(List<double> values)
+    {
+        if (values.Count == 0) return null;
+        var sorted = values.OrderBy(v => v).ToList();
+        var mid = sorted.Count / 2;
+        return sorted.Count % 2 == 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2.0;
+    }
+
+    /// <summary>Median of the earliest fifth of the (time-ordered) clean samples - the trend baseline. Null when too sparse.</summary>
+    internal static double? Baseline(List<double> timeOrdered)
+    {
+        if (timeOrdered.Count < 5) return null;
+        var take = Math.Max(1, timeOrdered.Count / 5);
+        return Median(timeOrdered.Take(take).ToList());
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
@@ -329,11 +329,29 @@ public static class OutageDetector
         var onset = FirstDark(triggerTargets, start, end, options.OutageDarkLossPct) ?? start;
         var recovery = PreciseRecovery(triggerTargets, start, end, options.OutageDarkLossPct) ?? end;
 
+        // Breadth/depth over the reporting trigger (internet) targets, so a blackout carries the same
+        // severity = breadth x depth the scorer reads for partials: how many reporting targets went
+        // dark, and the worst loss reached. By the coverage gate breadth is already >= the dark
+        // fraction, but a near-total widespread drop still reads hotter than a borderline one.
+        int reportingTargets = 0, darkTargets = 0;
+        double eventPeakLoss = 0;
+        foreach (var target in triggerTargets)
+        {
+            var inWindow = target.Where(s => s.LossPercent.HasValue && s.Time >= start && s.Time < end).ToList();
+            if (inWindow.Count == 0) continue;
+            reportingTargets++;
+            eventPeakLoss = Math.Max(eventPeakLoss, inWindow.Max(s => s.LossPercent!.Value));
+            if (inWindow.Any(s => s.LossPercent!.Value >= options.OutageDarkLossPct)) darkTargets++;
+        }
+
         return new OutageEvent
         {
             Start = onset,
             End = recovery,
             IsBrief = recovery - onset < TimeSpan.FromSeconds(options.OutageBriefMaxSeconds),
+            PeakLossPct = eventPeakLoss,
+            DegradedTargetCount = darkTargets,
+            PathTargetCount = reportingTargets,
             Scope = scope,
             LastReachableHop = scope == OutageScope.Upstream ? lastReachable!.Name : null,
             Tiers = GroupAccessTiers(tiers, options)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkModels.cs
@@ -1,0 +1,120 @@
+using NetworkOptimizer.Web.Services.Monitoring;
+
+namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+
+/// <summary>The access medium of the matched physical link.</summary>
+public enum PhysicalMedium
+{
+    /// <summary>GPON / XGS-PON optical (SFP ONT or external ONT).</summary>
+    Pon,
+    /// <summary>Active Ethernet optical SFP.</summary>
+    ActiveEthernet,
+    /// <summary>DOCSIS cable modem.</summary>
+    Docsis,
+    /// <summary>Cellular (LTE / 5G) modem.</summary>
+    Cellular
+}
+
+/// <summary>
+/// Window-aggregated physical-link metrics for the ONE source matched to the WAN,
+/// assembled by <see cref="IspHealthService"/> from time-series plus the live poll
+/// snapshot. Consumed by <see cref="PhysicalLinkScorer"/> to produce the Access Layer
+/// Physical Link factor. Every field is optional so a partially-reporting source still
+/// scores on what it has; a medium with no usable signal yields a null factor score.
+/// </summary>
+public class PhysicalLinkInput
+{
+    public required PhysicalMedium Medium { get; init; }
+
+    /// <summary>Friendly source name for the factor verbiage (e.g. "AT&amp;T BGW320").</summary>
+    public required string SourceName { get; init; }
+
+    // --- Optical (PON / Active Ethernet) ---
+
+    /// <summary>Median ONT/SFP receive optical power over the window (dBm).</summary>
+    public double? RxPowerMedianDbm { get; init; }
+
+    /// <summary>Worst (coldest) sustained receive power in the window, for the worst-case cap.</summary>
+    public double? RxPowerWorstDbm { get; init; }
+
+    /// <summary>Earliest-window median receive power, the baseline the trend check compares against.</summary>
+    public double? RxPowerBaselineDbm { get; init; }
+
+    /// <summary>Transmit optical power (dBm); penalized only above the category high threshold.</summary>
+    public double? TxPowerDbm { get; init; }
+
+    /// <summary>O5 (Operation) state graded across the window from the link-status series: true when
+    /// every reported state was Operation, false when the link broke out of O5 at least once (a hard
+    /// fault), null when the source never reports an O-state (DDM sticks, most ONTs). Polls that omit
+    /// the status are ignored, so a missing reading never reads as a link-down.</summary>
+    public bool? PonOperational { get; init; }
+
+    /// <summary>PON type for display (GPON, XGS-PON); also selects the OLT-launch assumption.</summary>
+    public string? PonType { get; init; }
+
+    /// <summary>True when the configured access technology is XGS-PON (reliable even when the device
+    /// does not report PonType). Selects the higher XGS-PON ONU transmit-power threshold.</summary>
+    public bool IsXgsPon { get; init; }
+
+    /// <summary>Total uncorrectable-FEC codewords over the window (external ONT only). Graded as an
+    /// absolute per-day count - negligible on a healthy plant. Null when not reported.</summary>
+    public long? FecErrorsTotal { get; init; }
+
+    /// <summary>Total BIP (uncorrected bit) errors over the window (external ONT only).</summary>
+    public long? BipErrorsTotal { get; init; }
+
+    /// <summary>Length of the scoring window in days, for normalizing error counts to a per-day rate.</summary>
+    public double WindowDays { get; init; }
+
+    // --- DOCSIS ---
+
+    /// <summary>Downstream MER/SNR averaged over locked channels (dB).</summary>
+    public double? DsSnrDb { get; init; }
+
+    /// <summary>Downstream receive power averaged over locked channels (dBmV).</summary>
+    public double? DsPowerDbmv { get; init; }
+
+    /// <summary>Upstream transmit power averaged over locked channels (dBmV).</summary>
+    public double? UsPowerDbmv { get; init; }
+
+    /// <summary>Correctable codeword delta over the window.</summary>
+    public long? CorrectablesDelta { get; init; }
+
+    /// <summary>Uncorrectable codeword delta over the window.</summary>
+    public long? UncorrectablesDelta { get; init; }
+
+    /// <summary>Locked downstream channel count (latest in window).</summary>
+    public int? LockedDsChannels { get; init; }
+
+    /// <summary>Peak locked downstream channel count seen in the window.</summary>
+    public int? PeakDsChannels { get; init; }
+
+    /// <summary>Authoritative plant-generation tell: an active OFDMA upstream channel (live snapshot).</summary>
+    public bool? OfdmaActive { get; init; }
+
+    /// <summary>Modem model for display and the mid/high-split-only hint.</summary>
+    public string? ModemModel { get; init; }
+
+    // --- Cellular ---
+
+    /// <summary>Composite cellular signal quality 0-100, as computed by CellularModemStats.</summary>
+    public int? SignalQuality { get; init; }
+
+    /// <summary>Active network mode for display (LTE, 5G NSA, 5G SA).</summary>
+    public string? NetworkMode { get; init; }
+
+    /// <summary>True when a 5G-&gt;LTE mode downgrade was observed in the window.</summary>
+    public bool NetworkModeDowngraded { get; init; }
+
+    /// <summary>True when the modem is 5G-capable (so a downgrade is meaningful).</summary>
+    public bool Is5gCapable { get; init; }
+}
+
+/// <summary>The Physical Link factor plus any issues it raised.</summary>
+public sealed record PhysicalLinkResult(IspScoreFactor Factor, List<IspHealthIssue> Issues);
+
+/// <summary>
+/// One selectable physical-link source for the ambiguity picker. <see cref="Key"/> is the
+/// persisted token ("cm:3", "ont:2", "modem:1", "sfp:aa:bb:cc:dd:ee:ff/Port 1").
+/// </summary>
+public sealed record PhysicalLinkCandidate(string Key, string Label);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkResolver.cs
@@ -1,0 +1,354 @@
+using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Storage.Services;
+
+namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+
+/// <summary>
+/// Resolves the ONE physical-link source that belongs to the WAN being scored, by matching the
+/// configured access technology to a monitored device (ONT/SFP, cable modem, or cellular modem),
+/// then assembles its window-aggregated metrics (time-series) enriched with the live poll snapshot
+/// (PON link state, active OFDMA channel, 5G capability) into a <see cref="PhysicalLinkInput"/>.
+///
+/// Matching is conservative: a single in-medium candidate is used automatically; multiple
+/// candidates require the user's persisted pick (<see cref="MonitoringSettings.PhysicalLinkSourceKey"/>)
+/// and otherwise surface as an ambiguity the panel resolves with a dropdown. Registered as a
+/// singleton (all monitor services and the InfluxDB client are singletons).
+/// </summary>
+public class PhysicalLinkResolver
+{
+    private readonly IDbContextFactory<NetworkOptimizerDbContext> _dbFactory;
+    private readonly MonitoringInfluxClient _influx;
+    private readonly CableModemMonitorService _cmMonitor;
+    private readonly OntMonitorService _ontMonitor;
+    private readonly CellularModemService _cellularMonitor;
+    private readonly ILogger<PhysicalLinkResolver> _logger;
+
+    public PhysicalLinkResolver(
+        IDbContextFactory<NetworkOptimizerDbContext> dbFactory,
+        MonitoringInfluxClient influx,
+        CableModemMonitorService cmMonitor,
+        OntMonitorService ontMonitor,
+        CellularModemService cellularMonitor,
+        ILogger<PhysicalLinkResolver> logger)
+    {
+        _dbFactory = dbFactory;
+        _influx = influx;
+        _cmMonitor = cmMonitor;
+        _ontMonitor = ontMonitor;
+        _cellularMonitor = cellularMonitor;
+        _logger = logger;
+    }
+
+    /// <summary>One matched/selectable physical source.</summary>
+    private sealed record Cand(string Key, string Label, PhysicalMedium Medium, int? ConfigId, string? Mac, string? Port);
+
+    public async Task<PhysicalLinkResolution> ResolveAsync(
+        AccessTechnology tech, DateTime windowStart, DateTime windowEnd, TimeSpan aggregate, CancellationToken ct)
+    {
+        MonitoringSettings? settings;
+        List<Cand> candidates;
+        await using (var db = await _dbFactory.CreateDbContextAsync(ct))
+        {
+            settings = await db.MonitoringSettings.AsNoTracking().FirstOrDefaultAsync(ct);
+            candidates = await EnumerateCandidatesAsync(db, tech, ct);
+        }
+
+        var selectedKey = settings?.PhysicalLinkSourceKey;
+        var candidateModels = candidates.Select(c => new PhysicalLinkCandidate(c.Key, c.Label)).ToList();
+
+        if (candidates.Count == 0)
+            return new PhysicalLinkResolution(null, candidateModels, selectedKey, false);
+
+        Cand chosen;
+        if (candidates.Count == 1)
+        {
+            chosen = candidates[0];
+        }
+        else
+        {
+            var match = candidates.FirstOrDefault(c => c.Key == selectedKey);
+            if (match is null)
+            {
+                _logger.LogDebug("ISP Health physical link: {Count} candidates, none selected - ambiguous", candidates.Count);
+                return new PhysicalLinkResolution(null, candidateModels, null, true);
+            }
+            chosen = match;
+        }
+
+        var input = await AssembleAsync(chosen, tech == AccessTechnology.XgsPon, windowStart, windowEnd, aggregate, ct);
+        return new PhysicalLinkResolution(input, candidateModels, chosen.Key, false);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Candidate enumeration (access technology -> medium family)
+    // ---------------------------------------------------------------------------
+
+    private async Task<List<Cand>> EnumerateCandidatesAsync(NetworkOptimizerDbContext db, AccessTechnology tech, CancellationToken ct)
+    {
+        switch (tech)
+        {
+            case AccessTechnology.Gpon:
+            case AccessTechnology.XgsPon:
+                return await PonCandidatesAsync(db, ct);
+
+            case AccessTechnology.DirectEthernet:
+                return await SfpCandidatesAsync(db, SfpCategory.ActiveEthernet, PhysicalMedium.ActiveEthernet, ct);
+
+            case AccessTechnology.Docsis:
+                return await CableModemCandidatesAsync(db, ct);
+
+            case AccessTechnology.Cellular:
+                return await CellularCandidatesAsync(db, ct);
+
+            case AccessTechnology.PppoE:
+                // Carve-out: PPPoE often rides PON. If exactly one PON source is monitored,
+                // it is safe to assume it is the user's WAN; otherwise stay out of it.
+                var pon = await PonCandidatesAsync(db, ct);
+                return pon.Count == 1 ? pon : new List<Cand>();
+
+            default:
+                return new List<Cand>();
+        }
+    }
+
+    private async Task<List<Cand>> PonCandidatesAsync(NetworkOptimizerDbContext db, CancellationToken ct)
+    {
+        var sfps = await SfpCandidatesAsync(db, SfpCategory.Pon, PhysicalMedium.Pon, ct);
+        var onts = (await db.OntConfigurations.AsNoTracking().Where(o => o.Enabled).ToListAsync(ct))
+            .Where(o => IsFresh(o.LastPolled, o.PollingIntervalSeconds))
+            .Select(o => new Cand($"ont:{o.Id}", o.Name, PhysicalMedium.Pon, o.Id, null, null));
+        return sfps.Concat(onts).ToList();
+    }
+
+    private async Task<List<Cand>> SfpCandidatesAsync(NetworkOptimizerDbContext db, SfpCategory category, PhysicalMedium medium, CancellationToken ct)
+    {
+        return (await db.MonitoredSfps.AsNoTracking().Where(s => s.Category == category).ToListAsync(ct))
+            .Select(s => new Cand(
+                $"sfp:{s.DeviceMac}/{s.PortName}",
+                string.IsNullOrWhiteSpace(s.FriendlyName) ? s.PortName : s.FriendlyName!,
+                medium, null, s.DeviceMac, s.PortName))
+            .ToList();
+    }
+
+    private async Task<List<Cand>> CableModemCandidatesAsync(NetworkOptimizerDbContext db, CancellationToken ct)
+    {
+        return (await db.CmConfigurations.AsNoTracking().Where(c => c.Enabled).ToListAsync(ct))
+            .Where(c => IsFresh(c.LastPolled, c.PollingIntervalSeconds))
+            .Select(c => new Cand($"cm:{c.Id}", c.Name, PhysicalMedium.Docsis, c.Id, null, null))
+            .ToList();
+    }
+
+    private async Task<List<Cand>> CellularCandidatesAsync(NetworkOptimizerDbContext db, CancellationToken ct)
+    {
+        return (await db.ModemConfigurations.AsNoTracking().Where(m => m.Enabled).ToListAsync(ct))
+            .Where(m => IsFresh(m.LastPolled, m.PollingIntervalSeconds))
+            .Select(m => new Cand($"modem:{m.Id}", m.Name, PhysicalMedium.Cellular, m.Id, null, null))
+            .ToList();
+    }
+
+    /// <summary>A configured device counts as a candidate only if it polled recently (3x its interval, min 15 min).</summary>
+    private static bool IsFresh(DateTime? lastPolled, int intervalSeconds) =>
+        lastPolled.HasValue && DateTime.UtcNow - lastPolled.Value <= TimeSpan.FromSeconds(Math.Max(900, intervalSeconds * 3));
+
+    // ---------------------------------------------------------------------------
+    // Assembly (time-series window aggregate + live snapshot enrichment)
+    // ---------------------------------------------------------------------------
+
+    private async Task<PhysicalLinkInput?> AssembleAsync(
+        Cand c, bool isXgsPon, DateTime windowStart, DateTime windowEnd, TimeSpan aggregate, CancellationToken ct)
+    {
+        return c.Medium switch
+        {
+            PhysicalMedium.Pon when c.ConfigId is int ontId => await AssembleOntAsync(c, ontId, isXgsPon, windowStart, windowEnd, aggregate, ct),
+            PhysicalMedium.Pon => await AssembleSfpAsync(c, PhysicalMedium.Pon, isXgsPon, windowStart, windowEnd, aggregate, ct),
+            PhysicalMedium.ActiveEthernet => await AssembleSfpAsync(c, PhysicalMedium.ActiveEthernet, false, windowStart, windowEnd, aggregate, ct),
+            PhysicalMedium.Docsis when c.ConfigId is int cmId => await AssembleCableModemAsync(c, cmId, windowStart, windowEnd, aggregate, ct),
+            PhysicalMedium.Cellular when c.ConfigId is int modemId => await AssembleCellularAsync(c, modemId, windowStart, windowEnd, aggregate, ct),
+            _ => null
+        };
+    }
+
+    private async Task<PhysicalLinkInput?> AssembleSfpAsync(
+        Cand c, PhysicalMedium medium, bool isXgsPon, DateTime windowStart, DateTime windowEnd, TimeSpan aggregate, CancellationToken ct)
+    {
+        // SFP DDM only: TimeSpan.Zero => RAW (un-aggregated) so glitchy stick reads stay isolated,
+        // with temperature passed through so OpticalSampleStats can reject the artifacts (RX + temp
+        // glitch together). Mean aggregation would smear a glitch into a bucket that defeats the filter.
+        var dict = await _influx.QuerySfpByModulesAsync(new[] { (c.Mac!, c.Port!) }, windowStart, windowEnd, TimeSpan.Zero, ct);
+        var pts = dict.Values.FirstOrDefault() ?? new();
+        var stats = OpticalSampleStats.Compute(pts.Select(p => (p.Time, p.RxPowerDbm, p.TemperatureC)).ToList());
+        _logger.LogDebug("ISP Health physical: SFP {Key} - {N} samples, {Rej} DDM artifacts rejected, rxMed={Med} worst={Worst}",
+            c.Key, pts.Count, stats.RejectedArtifacts, stats.MedianDbm, stats.WorstDbm);
+
+        return new PhysicalLinkInput
+        {
+            Medium = medium,
+            SourceName = c.Label,
+            RxPowerMedianDbm = stats.MedianDbm,
+            RxPowerWorstDbm = stats.WorstDbm,
+            RxPowerBaselineDbm = stats.BaselineDbm,
+            TxPowerDbm = pts.OrderBy(p => p.Time).LastOrDefault(p => p.TxPowerDbm.HasValue)?.TxPowerDbm,
+            IsXgsPon = isXgsPon,
+            WindowDays = (windowEnd - windowStart).TotalDays
+        };
+    }
+
+    private async Task<PhysicalLinkInput?> AssembleOntAsync(
+        Cand c, int ontId, bool isXgsPon, DateTime windowStart, DateTime windowEnd, TimeSpan aggregate, CancellationToken ct)
+    {
+        // External ONT: vendor firmware, not a DDM stick - no read-artifact problem, so temperature is
+        // NOT passed for rejection (null temps => OpticalSampleStats keeps every sample). RAW points
+        // (TimeSpan.Zero) so the FEC/BIP per-poll deltas are real polls, comparable to the alert threshold.
+        var dict = await _influx.QueryOntAsync(windowStart, windowEnd, ontId.ToString(), TimeSpan.Zero, ct);
+        var pts = (dict.Values.FirstOrDefault() ?? new()).OrderBy(p => p.Time).ToList();
+        var stats = OpticalSampleStats.Compute(pts.Select(p => (p.Time, p.RxPowerDbm, (double?)null)).ToList());
+        var live = _ontMonitor.GetCachedStats(ontId);
+        var fecTotal = TotalIncrements(pts.Select(p => p.FecErrors).ToList());
+        var bipTotal = TotalIncrements(pts.Select(p => p.BipErrors).ToList());
+        var operational = ResolveOperationalFromHistory(pts);
+        _logger.LogDebug("ISP Health physical: ONT {Key} - {N} samples, rxMed={Med} worst={Worst}, op={Op}, fecTotal={Fec} bipTotal={Bip}",
+            c.Key, pts.Count, stats.MedianDbm, stats.WorstDbm, operational, fecTotal, bipTotal);
+
+        return new PhysicalLinkInput
+        {
+            Medium = PhysicalMedium.Pon,
+            SourceName = c.Label,
+            RxPowerMedianDbm = stats.MedianDbm,
+            RxPowerWorstDbm = stats.WorstDbm,
+            RxPowerBaselineDbm = stats.BaselineDbm,
+            TxPowerDbm = live?.TxPowerDbm ?? pts.LastOrDefault(p => p.TxPowerDbm.HasValue)?.TxPowerDbm,
+            PonOperational = operational,
+            PonType = live?.PonType,
+            IsXgsPon = isXgsPon,
+            FecErrorsTotal = fecTotal,
+            BipErrorsTotal = bipTotal,
+            WindowDays = (windowEnd - windowStart).TotalDays
+        };
+    }
+
+    /// <summary>Total positive increments of a cumulative error counter over the window, reset-guarded
+    /// (negative steps from a counter reset count as zero). Null when there aren't two readings.</summary>
+    private static long? TotalIncrements(IReadOnlyList<long?> counters)
+    {
+        long total = 0;
+        var any = false;
+        long? prev = null;
+        foreach (var v in counters)
+        {
+            if (v is not long cur) continue;
+            if (prev is long p)
+            {
+                var delta = cur - p;
+                if (delta > 0) total += delta;
+                any = true;
+            }
+            prev = cur;
+        }
+        return any ? total : (long?)null;
+    }
+
+    /// <summary>
+    /// Grades the PON O5 (Operation) state from the persisted series rather than a single live poll:
+    /// true if every reported state was Operation, false if the link broke out of O5 at least once
+    /// during the window. A poll that omits PON Link Status (a DDM stick that never reports it, or the
+    /// gateway's stats page momentarily dropping the row) parses to Unknown and is ignored - missing
+    /// status is absence of data, not a link-down. Returns null when the source reported no O-state at
+    /// all, so the factor never false-alarms on ONTs that don't expose it. Matches OntAlertEvaluator,
+    /// which likewise treats Unknown as "not down".
+    /// </summary>
+    internal static bool? ResolveOperationalFromHistory(IReadOnlyList<MonitoringInfluxClient.OntPoint> pts)
+    {
+        var known = pts
+            .Select(p => PonLinkStateExtensions.ParsePonLinkState(p.PonLinkStatus))
+            .Where(s => s != PonLinkState.Unknown)
+            .ToList();
+        if (known.Count == 0) return null;
+        return known.All(s => s == PonLinkState.Operation);
+    }
+
+    private async Task<PhysicalLinkInput?> AssembleCableModemAsync(
+        Cand c, int cmId, DateTime windowStart, DateTime windowEnd, TimeSpan aggregate, CancellationToken ct)
+    {
+        var dict = await _influx.QueryCableModemAsync(windowStart, windowEnd, cmId.ToString(), aggregate, ct);
+        var pts = (dict.Values.FirstOrDefault() ?? new()).OrderBy(p => p.Time).ToList();
+        var live = _cmMonitor.GetCachedStats(cmId);
+
+        var lockedDs = pts.LastOrDefault(p => p.LockedDsChannels.HasValue)?.LockedDsChannels;
+        var peakDs = pts.Where(p => p.LockedDsChannels.HasValue).Select(p => p.LockedDsChannels!.Value)
+            .DefaultIfEmpty().Max();
+
+        return new PhysicalLinkInput
+        {
+            Medium = PhysicalMedium.Docsis,
+            SourceName = c.Label,
+            DsSnrDb = Median(pts.Where(p => p.DsSnrAvgDb.HasValue).Select(p => p.DsSnrAvgDb!.Value).ToList()),
+            DsPowerDbmv = Median(pts.Where(p => p.DsPowerAvgDbmv.HasValue).Select(p => p.DsPowerAvgDbmv!.Value).ToList()),
+            UsPowerDbmv = Median(pts.Where(p => p.UsPowerAvgDbmv.HasValue).Select(p => p.UsPowerAvgDbmv!.Value).ToList()),
+            CorrectablesDelta = pts.Where(p => p.CorrDelta.HasValue).Sum(p => p.CorrDelta!.Value),
+            UncorrectablesDelta = pts.Where(p => p.UncorrDelta.HasValue).Sum(p => p.UncorrDelta!.Value),
+            LockedDsChannels = lockedDs,
+            PeakDsChannels = peakDs > 0 ? peakDs : null,
+            OfdmaActive = live != null
+                ? live.UpstreamChannels.Any(ch => (ch.ChannelType ?? "").Contains("OFDMA", StringComparison.OrdinalIgnoreCase))
+                : null,
+            ModemModel = string.IsNullOrWhiteSpace(live?.DeviceModel) ? null : live!.DeviceModel,
+            WindowDays = (windowEnd - windowStart).TotalDays
+        };
+    }
+
+    private async Task<PhysicalLinkInput?> AssembleCellularAsync(
+        Cand c, int modemId, DateTime windowStart, DateTime windowEnd, TimeSpan aggregate, CancellationToken ct)
+    {
+        // Cellular is keyed by modem_id + network_mode, so a mode change splits into several series.
+        var dict = await _influx.QueryCellularAsync(windowStart, windowEnd, modemId.ToString(), aggregate, ct);
+        var pts = dict.Values.SelectMany(v => v).OrderBy(p => p.Time).ToList();
+        var live = _cellularMonitor.GetCachedStats(modemId);
+
+        var qualities = pts.Where(p => p.SignalQuality.HasValue).Select(p => (double)p.SignalQuality!.Value).ToList();
+        var quality = Median(qualities);
+        if (quality is null && live != null) quality = live.SignalQuality;
+
+        var had5g = pts.Any(p => IsFiveG(p.NetworkMode)) || live?.Nr5g != null;
+        var latestMode = pts.LastOrDefault(p => !string.IsNullOrEmpty(p.NetworkMode))?.NetworkMode
+                         ?? (live != null ? live.NetworkModeLabel : null);
+        var downgraded = had5g && IsLte(latestMode);
+
+        return new PhysicalLinkInput
+        {
+            Medium = PhysicalMedium.Cellular,
+            SourceName = c.Label,
+            SignalQuality = quality is double q ? (int)Math.Round(q) : null,
+            NetworkMode = latestMode,
+            NetworkModeDowngraded = downgraded,
+            Is5gCapable = had5g,
+            WindowDays = (windowEnd - windowStart).TotalDays
+        };
+    }
+
+    private static bool IsFiveG(string? mode) =>
+        !string.IsNullOrEmpty(mode) && (mode.Contains("5G", StringComparison.OrdinalIgnoreCase) || mode.Contains("Nr5g", StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsLte(string? mode) =>
+        !string.IsNullOrEmpty(mode) && mode.Contains("LTE", StringComparison.OrdinalIgnoreCase) && !IsFiveG(mode);
+
+    // ---------------------------------------------------------------------------
+    // Aggregation helpers
+    // ---------------------------------------------------------------------------
+
+    private static double? Median(List<double> values)
+    {
+        if (values.Count == 0) return null;
+        var sorted = values.OrderBy(v => v).ToList();
+        var mid = sorted.Count / 2;
+        return sorted.Count % 2 == 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2.0;
+    }
+}
+
+/// <summary>Outcome of physical-link resolution for one report.</summary>
+public sealed record PhysicalLinkResolution(
+    PhysicalLinkInput? Input,
+    List<PhysicalLinkCandidate> Candidates,
+    string? SelectedKey,
+    bool Ambiguous);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkScorer.cs
@@ -1,0 +1,519 @@
+using System.Globalization;
+
+namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+
+/// <summary>
+/// Pure scorer for the Access Layer "Physical Link" factor. Given window-aggregated
+/// metrics for the one source matched to the WAN, produces a 0-100 sub-score plus any
+/// issues. No I/O; fully unit-testable.
+///
+/// Design (see research/isp-health/physical-link-access-scoring.md):
+/// - PON/AE grade on ABSOLUTE receive power margin-to-floor (a gentle healthy slope so
+///   more insertion loss reads slightly lower, never a flat 100), scored on the robust median
+///   after DDM read-artifact rejection (see OpticalSampleStats), with a worst-sustained cap and
+///   hard caps for a down PON link or hot TX. Temperature is NOT a health input here (the
+///   monitoring system alerts on optic temp); it only drives artifact rejection. The inferred
+///   splitter ratio is DISPLAY-ONLY verbiage derived from the optical power budget and never feeds
+///   the score. A reading colder than the coldest any realistic 1:64 split can produce is a
+///   bounded, baseline-free excess-loss flag.
+/// - DOCSIS grades MER, FEC (a 50/50 blend of the uncorrectable ratio and the per-day
+///   uncorrectable rate, the rate scaled up for 3.1 OFDM's higher codeword volume), and DS/US
+///   power, with a channel-loss cap. Plant generation is inferred from an active OFDMA channel,
+///   else plan speed.
+/// - Cellular passes the existing composite signal quality through.
+/// Reuses <see cref="PonThresholds"/> and <see cref="DocsisHealthThresholds"/> as the
+/// single source-of-truth for breach anchors.
+/// </summary>
+public static class PhysicalLinkScorer
+{
+    /// <summary>An RX drop of at least this many dB from the link's own baseline is developing loss.</summary>
+    private const double PonTrendDropDbm = 2.5;
+
+    /// <summary>Standard PON splitter rungs (ratio, typical insertion loss dB incl. excess), capped at 1:64.</summary>
+    private static readonly (int Ratio, double LossDb)[] SplitterRungs =
+    {
+        (2, 3.6), (4, 7.2), (8, 10.5), (16, 13.8), (32, 17.1), (64, 20.4)
+    };
+
+    /// <summary>Generic note appended to a factor description when a TRANSIENT event the snapshot
+    /// values don't show (a dip, an interruption/break, a developing drop, or an error burst) was
+    /// factored into the score. Steady-state conditions (marginal/hot power, low SNR, poor signal)
+    /// are visible in the displayed values, so they do NOT get this note.</summary>
+    private const string AnomalyNote = " A signal anomaly or interruption during this window was factored into the score.";
+
+    public static PhysicalLinkResult Score(PhysicalLinkInput input, double? expectedUploadMbps, double factorWeight, ILogger? logger = null)
+    {
+        return input.Medium switch
+        {
+            PhysicalMedium.Pon => ScoreOptical(input, factorWeight, isPon: true, logger),
+            PhysicalMedium.ActiveEthernet => ScoreOptical(input, factorWeight, isPon: false, logger),
+            PhysicalMedium.Docsis => ScoreDocsis(input, expectedUploadMbps, factorWeight),
+            PhysicalMedium.Cellular => ScoreCellular(input, factorWeight),
+            _ => new PhysicalLinkResult(NullFactor(factorWeight, "no usable physical-link data"), new())
+        };
+    }
+
+    // ---------------------------------------------------------------------------
+    // Optical: PON and Active Ethernet
+    // ---------------------------------------------------------------------------
+
+    private static PhysicalLinkResult ScoreOptical(PhysicalLinkInput input, double factorWeight, bool isPon, ILogger? logger)
+    {
+        var issues = new List<IspHealthIssue>();
+        var rx = input.RxPowerMedianDbm;
+        // Prefer the type the ONT actually reports; otherwise fall back to the configured access
+        // technology so the copy reads "GPON"/"XGS-PON" rather than a bare "PON".
+        var label = isPon
+            ? (FormatPonType(input.PonType) ?? (input.IsXgsPon ? "XGS-PON" : "GPON"))
+            : "Active Ethernet";
+
+        if (rx is null)
+            return new PhysicalLinkResult(NullFactor(factorWeight, $"{label} link not reporting optical power yet"), issues);
+
+        // The score curve rides PON receiver PHYSICS (marginal/floor), via the PonThresholds
+        // constants - deliberately NOT the user's SfpDdmThresholds alert override, which tunes when
+        // the SFP DDM alarm fires, not how ISP Health grades optical health. A tightened alert must
+        // not compress this curve. Gentle healthy slope, knee at the marginal anchor, zero at the
+        // receiver sensitivity floor. Warmer = healthier until overload.
+        var rxLow = isPon ? PonThresholds.PonRxPowerLowDbm : PonThresholds.AeRxPowerLowDbm;
+        var floor = isPon ? PonThresholds.PonRxFloorDbm : PonThresholds.AeRxFloorDbm;        // receiver sensitivity
+        var overload = isPon ? PonThresholds.PonRxOverloadDbm : PonThresholds.AeRxOverloadDbm;  // too hot
+        var healthyTop = isPon ? -24.0 : -13.0;        // top of the gentle in-spec slope (scoring-curve shape)
+
+        var score = ScoreCurve.Interpolate(rx.Value,
+            (floor, 0),
+            (floor + 1, 30),
+            (rxLow, 90),
+            (healthyTop, 95),
+            (overload, 100));
+
+        // Overload: penalize receive power hotter than the overload point (rare on PON).
+        var overloadScore = ScoreCurve.Interpolate(rx.Value,
+            (overload, 100), (overload + 2, 80), (overload + 5, 30), (overload + 8, 0));
+        score = Math.Min(score, overloadScore);
+
+        // Worst-sustained cap: a sustained excursion colder than the median pulls the score down.
+        if (input.RxPowerWorstDbm is double worst && worst < rx.Value)
+        {
+            var worstScore = ScoreCurve.Interpolate(worst,
+                (floor, 0), (floor + 1, 30), (rxLow, 90), (healthyTop, 95), (overload, 100));
+            score = Math.Min(score, 0.5 * (score + worstScore));
+        }
+
+        var rxText = $"{rx.Value.ToString("0.0", CultureInfo.InvariantCulture)} dBm RX";
+        var detailBits = new List<string>();
+
+        // Receive-power issues.
+        if (rx.Value <= floor)
+            issues.Add(new IspHealthIssue
+            {
+                Severity = IspIssueSeverity.Critical,
+                Title = $"{label}: optical signal below receiver sensitivity",
+                Description = $"{input.SourceName} receive power is {rxText}, at or below the receiver floor (~{floor:0} dBm). The link is at risk of dropping.",
+                Recommendation = "Inspect the fiber path: a dirty or loose connector, a macrobend, or a degraded splice can add several dB of loss."
+            });
+        else if (rx.Value <= rxLow)
+            issues.Add(new IspHealthIssue
+            {
+                Severity = IspIssueSeverity.Warning,
+                Title = $"{label}: marginal optical receive power",
+                Description = $"{input.SourceName} receive power is {rxText}, past the marginal threshold ({rxLow:0} dBm) and approaching the receiver floor.",
+                Recommendation = "Check the optical path for added loss (connectors, bends, splices)."
+            });
+        else if (rx.Value >= overload)
+            issues.Add(new IspHealthIssue
+            {
+                Severity = IspIssueSeverity.Warning,
+                Title = $"{label}: optical receive power too hot",
+                Description = $"{input.SourceName} receive power is {rxText}, near the receiver overload point ({overload:0} dBm).",
+                Recommendation = "An optical attenuator may be needed if the ONT sits very close to the OLT/splitter."
+            });
+
+        // PON-only: inferred split ratio (display verbiage) and bounded excess-loss flag.
+        if (isPon)
+        {
+            var split = InferSplitRatio(rx.Value, input.PonType);
+            if (split != null) detailBits.Add(split);
+
+            if (rx.Value < PonThresholds.PonExcessLossFloorDbm && rx.Value > floor)
+                issues.Add(new IspHealthIssue
+                {
+                    Severity = IspIssueSeverity.Warning,
+                    Title = "PON: excess optical loss",
+                    Description = $"{input.SourceName} receive power ({rxText}) is colder than the deepest realistic splitter (1:64) should produce, which points to extra loss on the drop rather than a larger split.",
+                    Recommendation = "Inspect the drop: a dirty/loose connector, a macrobend, or a degrading splice is the usual cause."
+                });
+
+            // Developing loss: a drop from the link's own baseline, independent of absolute level.
+            if (input.RxPowerBaselineDbm is double baseline && rx.Value <= baseline - PonTrendDropDbm)
+                issues.Add(new IspHealthIssue
+                {
+                    Severity = IspIssueSeverity.Warning,
+                    Title = "PON: receive power is degrading",
+                    Description = $"{input.SourceName} receive power fell {(baseline - rx.Value).ToString("0.0", CultureInfo.InvariantCulture)} dB over the window (from {baseline.ToString("0.0", CultureInfo.InvariantCulture)} to {rx.Value.ToString("0.0", CultureInfo.InvariantCulture)} dBm).",
+                    Recommendation = "A trending drop usually means a connector or splice is degrading - inspect the optical path."
+                });
+        }
+
+        // Caps and secondary signals. PonOperational reflects the O5 state across the WINDOW (from the
+        // series, not a single live poll), so a break may have happened earlier and since recovered -
+        // the copy is past/window tense, not "is down right now".
+        if (input.PonOperational == false)
+        {
+            score = Math.Min(score, 10);
+            issues.Add(new IspHealthIssue
+            {
+                Severity = IspIssueSeverity.Critical,
+                Title = $"{label}: link dropped out of O5",
+                Description = $"{input.SourceName} PON link left the Operation (O5) state at least once during this window - the optical link went down or re-ranged.",
+                Recommendation = "A single brief drop can be a re-range; repeated O5 breaks point to a fiber or ONT fault - inspect the ONT and the optical path."
+            });
+        }
+
+        var txHigh = isPon
+            ? (input.IsXgsPon ? PonThresholds.XgsPonTxPowerHighDbm : PonThresholds.PonTxPowerHighDbm)
+            : PonThresholds.AeTxPowerHighDbm;
+        if (input.TxPowerDbm is double tx && tx > txHigh)
+        {
+            score = Math.Min(score, 75);
+            issues.Add(new IspHealthIssue
+            {
+                Severity = IspIssueSeverity.Warning,
+                Title = $"{label}: transmit power high",
+                Description = $"{input.SourceName} transmit optical power is {tx.ToString("0.0", CultureInfo.InvariantCulture)} dBm, above the {txHigh:0} dBm threshold.",
+                Recommendation = "A consistently high TX can indicate the laser is compensating for path loss; inspect the optical path."
+            });
+        }
+
+        // FEC/BIP error corroboration (external ONT only; SFP DDM reports none). A healthy PON link
+        // logs a negligible BIP / uncorrectable-FEC count, so these are graded as an absolute count
+        // over the window normalized to a per-day rate (BIP and FEC sharing the same healthy line).
+        // A climbing count caps the optical score - real excess loss leaves error fingerprints,
+        // rather than inferring it circularly from RX-vs-split.
+        var fecPerDay = input.WindowDays > 0 && input.FecErrorsTotal is long fecT ? fecT / input.WindowDays : (double?)null;
+        var bipPerDay = input.WindowDays > 0 && input.BipErrorsTotal is long bipT ? bipT / input.WindowDays : (double?)null;
+        var errorScore = 100.0;
+        if (fecPerDay is double fpd) errorScore = Math.Min(errorScore, PonErrorPerDayScore(fpd));
+        if (bipPerDay is double bpd) errorScore = Math.Min(errorScore, PonErrorPerDayScore(bpd));
+        score = Math.Min(score, errorScore);
+        var errorsHigh = (fecPerDay is double f1 && f1 > PonThresholds.PonErrorsPerDayPoor)
+                         || (bipPerDay is double b1 && b1 > PonThresholds.PonErrorsPerDayPoor);
+        if (errorsHigh)
+            issues.Add(new IspHealthIssue
+            {
+                Severity = IspIssueSeverity.Warning,
+                Title = $"{label}: optical errors accumulating",
+                Description = $"{input.SourceName} is logging optical errors"
+                              + (fecPerDay is double f and > 0 ? $" (~{f.ToString("0", CultureInfo.InvariantCulture)}/day uncorrectable FEC)" : "")
+                              + (bipPerDay is double b and > 0 ? $" (~{b.ToString("0", CultureInfo.InvariantCulture)}/day BIP)" : "")
+                              + " - a healthy link sees a negligible count.",
+                Recommendation = "Inspect the drop for excess loss - a dirty/loose connector, a macrobend, or a degrading splice."
+            });
+
+        // Temperature is intentionally NOT a health input or display detail here - the monitoring
+        // system already alerts on optic temperature. Its only role for the Physical Link factor is
+        // upstream DDM read-artifact rejection (see OpticalSampleStats).
+
+        var finalScore = (int)Math.Round(score);
+        // Show TX alongside RX now that TX participates in scoring.
+        var valueText = input.TxPowerDbm is double txp
+            ? $"{rxText}, {txp.ToString("0.0", CultureInfo.InvariantCulture)} dBm TX"
+            : rxText;
+        // Note only TRANSIENT events the displayed RX/TX don't reveal: a receive-power dip (worst
+        // sample >0.5 dB below the median, where the worst-cap engaged - artifacts are already
+        // discarded so this is genuine), a link interruption (not in O5), a developing drop (trend
+        // vs baseline), or an FEC/BIP error burst. Steady marginal/hot RX or TX show in the values.
+        var transientAnomaly =
+            (input.RxPowerWorstDbm is double worstDip && rx.Value - worstDip > 0.5)
+            || input.PonOperational == false
+            || (isPon && input.RxPowerBaselineDbm is double baseDrop && rx.Value <= baseDrop - PonTrendDropDbm)
+            || errorsHigh;
+        var desc = $"{label} optical receive power scored on margin to the receiver floor"
+                   + (detailBits.Count > 0 ? $" ({string.Join(", ", detailBits)})." : ".")
+                   + (transientAnomaly ? AnomalyNote : "");
+
+        logger?.LogDebug(
+            "ISP Health physical(optical {Label}): '{Source}' rxMed={Rx} -> {Score} (worst={Worst}, baseline={Base}, op={Op}, tx={Tx}, fecScore={ErrScore}, {Detail})",
+            label, input.SourceName, FormatOrNull(rx), finalScore, FormatOrNull(input.RxPowerWorstDbm),
+            FormatOrNull(input.RxPowerBaselineDbm), input.PonOperational, FormatOrNull(input.TxPowerDbm),
+            (int)Math.Round(errorScore), detailBits.Count > 0 ? string.Join(", ", detailBits) : "n/a");
+
+        return new PhysicalLinkResult(Factor(factorWeight, finalScore, valueText, desc), issues);
+    }
+
+    private static string FormatOrNull(double? v) => v.HasValue ? v.Value.ToString("0.0", CultureInfo.InvariantCulture) : "n/a";
+
+    /// <summary>0-100 score for a PON per-day BIP/uncorrectable-FEC count: 100 at 0 (ideal), still
+    /// high through the good line (~few/day), poor past the poor line. BIP and FEC share this curve.</summary>
+    private static double PonErrorPerDayScore(double perDay) => ScoreCurve.Interpolate(perDay,
+        (0, 100), (PonThresholds.PonErrorsPerDayGood, 92),
+        (PonThresholds.PonErrorsPerDayPoor, 25), (PonThresholds.PonErrorsPerDayPoor * 4, 0));
+
+    /// <summary>
+    /// Inferred EFFECTIVE split ratio for display only, derived from the optical power budget:
+    ///   RX = OLT_launch - splitter_loss - distribution_loss
+    ///   =&gt; splitter_loss = OLT_launch - RX - distribution_loss   (snap to nearest standard rung)
+    /// The launch and distribution-loss constants are realistic typicals (common GPON B+ launch
+    /// and an average residential drop incl. nominal glass, splices, and un-cleaned connectors);
+    /// high-class OLTs are rare and XGS-PON launches hotter. These are starting defaults meant to
+    /// be nudged from field feedback - the model is the budget math, not a hand-tuned table. Never
+    /// feeds the score. Returns null when the math lands hotter than even a 1:2 split.
+    /// </summary>
+    internal static string? InferSplitRatio(double rxDbm, string? ponType)
+    {
+        var isXgs = (ponType ?? "").Contains("XGS", StringComparison.OrdinalIgnoreCase)
+                    || (ponType ?? "").Contains("10G", StringComparison.OrdinalIgnoreCase);
+        var oltLaunchDbm = isXgs ? 5.0 : 3.0;     // common launch (GPON B+; high-class C+ is the rare rural case)
+        const double distributionLossDb = 5.0;    // realistic drop: glass + splices + typical un-cleaned connectors
+                                                  // (puts the 1:32 -> 1:64 boundary near -20.75 dBm on GPON)
+        var splitterLoss = oltLaunchDbm - rxDbm - distributionLossDb;
+
+        // Colder than the deepest realistic 1:64 can produce is excess loss, not a bigger splitter.
+        if (rxDbm <= PonThresholds.PonExcessLossFloorDbm) return "est. 1:64+ split or excess loss";
+        if (splitterLoss < SplitterRungs[0].LossDb - 2.0) return null;  // too hot for even 1:2
+
+        var best = SplitterRungs[0];
+        foreach (var rung in SplitterRungs)
+            if (Math.Abs(rung.LossDb - splitterLoss) <= Math.Abs(best.LossDb - splitterLoss))
+                best = rung;
+
+        return $"est. 1:{best.Ratio} split";
+    }
+
+    private static string? FormatPonType(string? ponType)
+    {
+        if (string.IsNullOrWhiteSpace(ponType)) return null;
+        return ponType.Trim();
+    }
+
+    // ---------------------------------------------------------------------------
+    // DOCSIS
+    // ---------------------------------------------------------------------------
+
+    private static PhysicalLinkResult ScoreDocsis(PhysicalLinkInput input, double? expectedUploadMbps, double factorWeight)
+    {
+        var issues = new List<IspHealthIssue>();
+        var isOfdm = IsDocsis31(input, expectedUploadMbps);
+        // Transient events only (channel loss, uncorrectable error burst). Steady power/SNR
+        // conditions are visible in the displayed values, so they don't get the anomaly note.
+        var transientAnomaly = false;
+
+        var parts = new List<(double Score, double Weight)>();
+        var valueBits = new List<string>();   // headline (ValueText): SNR + US, the key factors
+        var detailBits = new List<string>();  // description: the other stats (DS power, FEC)
+
+        // Downstream MER/SNR.
+        if (input.DsSnrDb is double snr)
+        {
+            var floor = isOfdm ? DocsisHealthThresholds.DsMerFloorOfdmDb : DocsisHealthThresholds.DsMerFloorScQamDb;
+            var snrScore = ScoreCurve.Interpolate(snr,
+                (floor - 5, 0), (floor - 2, 30), (floor, 85), (DocsisHealthThresholds.DsMerIdealDb, 100));
+            parts.Add((snrScore, 0.40));
+            valueBits.Add($"SNR {snr.ToString("0.0", CultureInfo.InvariantCulture)} dB");
+            if (snr < floor)
+                issues.Add(new IspHealthIssue
+                {
+                    Severity = IspIssueSeverity.Warning,
+                    Title = "DOCSIS: low downstream SNR",
+                    Description = $"{input.SourceName} downstream MER/SNR is {snr.ToString("0.0", CultureInfo.InvariantCulture)} dB, below the {floor:0} dB floor for this plant.",
+                    Recommendation = "Low SNR drives uncorrectable errors. Check your coax, connectors, and any unused splitters first; if those are clean, the cause is usually plant-side (ingress, a failing amplifier, or the node) and needs a line tech."
+                });
+        }
+
+        // FEC sub-score = 50% RATIO + 50% RATE. The ratio unc/(corr+unc) is "how dominant are
+        // uncorrectables among errored codewords" (texture, gen-independent); the rate is
+        // uncorrectables/day (the magnitude gate, scaled up for 3.1's higher codeword volume). A
+        // moderate ratio with a low rate is normal - only a high rate (or a dominant ratio) drags it.
+        if (input.CorrectablesDelta is long corr && input.UncorrectablesDelta is long unc)
+        {
+            var denom = corr + unc;
+            var ratio = denom > 0 ? (double)unc / denom : 0.0;
+            var ratioScore = denom <= 0 ? 100.0 : ScoreCurve.Interpolate(ratio,
+                (0, 100), (DocsisHealthThresholds.FecUncorrRatioGood, 90), (DocsisHealthThresholds.FecUncorrRatioPoor, 0));
+
+            var rateGood = isOfdm ? DocsisHealthThresholds.UncorrPerDayGoodOfdm : DocsisHealthThresholds.UncorrPerDayGoodScQam;
+            var ratePoor = isOfdm ? DocsisHealthThresholds.UncorrPerDayPoorOfdm : DocsisHealthThresholds.UncorrPerDayPoorScQam;
+            var uncPerDay = input.WindowDays > 0 ? unc / input.WindowDays : 0.0;
+            var rateScore = ScoreCurve.Interpolate(uncPerDay, (0, 100), (rateGood, 92), (ratePoor, 25), (ratePoor * 10, 0));
+
+            parts.Add((0.5 * ratioScore + 0.5 * rateScore, 0.30));
+            detailBits.Add(unc == 0
+                ? "FEC clean"
+                : $"FEC {(ratio * 100).ToString("0.#", CultureInfo.InvariantCulture)}% uncorr (~{uncPerDay.ToString("0", CultureInfo.InvariantCulture)}/day)");
+
+            // Issue when uncorrectables dominate the errored codewords (>40%) or the rate is clearly high.
+            if (unc > 0 && (ratio > DocsisHealthThresholds.FecUncorrRatioIssue || uncPerDay >= ratePoor))
+            {
+                transientAnomaly = true;
+                issues.Add(new IspHealthIssue
+                {
+                    Severity = IspIssueSeverity.Warning,
+                    Title = "DOCSIS: uncorrectable errors",
+                    Description = $"{input.SourceName} uncorrectable codewords are {(ratio * 100).ToString("0.#", CultureInfo.InvariantCulture)}% of errored codewords"
+                                  + (uncPerDay > 0 ? $" (~{uncPerDay.ToString("0", CultureInfo.InvariantCulture)}/day)" : "") + ".",
+                    Recommendation = "Sustained uncorrectables mean data loss; check downstream SNR and the coax/connectors for ingress."
+                });
+            }
+        }
+
+        // Downstream power: tent centered near 0 dBmV.
+        if (input.DsPowerDbmv is double dsp)
+        {
+            var dsScore = ScoreCurve.Interpolate(dsp,
+                (DocsisHealthThresholds.DsPowerOutOfSpecLowDbmv, 0),
+                (DocsisHealthThresholds.DsPowerStarvedDbmv, 60),
+                (DocsisHealthThresholds.DsPowerIdealLowDbmv, 90),
+                (0, 100),
+                (DocsisHealthThresholds.DsPowerIdealHighDbmv, 90),
+                (DocsisHealthThresholds.DsPowerPadAdviseDbmv, 80),
+                (12, 40),
+                (DocsisHealthThresholds.DsPowerOutOfSpecHighDbmv, 0));
+            parts.Add((dsScore, 0.15));
+            // DS power: scored above (tent near 0 dBmV) and shown in the description, off the headline.
+            detailBits.Add($"DS {dsp.ToString("0.0", CultureInfo.InvariantCulture)} dBmV");
+            if (dsp > DocsisHealthThresholds.DsPowerPadAdviseDbmv)
+                issues.Add(new IspHealthIssue
+                {
+                    Severity = IspIssueSeverity.Warning,
+                    Title = "DOCSIS: downstream power too hot",
+                    Description = $"{input.SourceName} downstream receive power is {dsp.ToString("0.0", CultureInfo.InvariantCulture)} dBmV, above +{DocsisHealthThresholds.DsPowerPadAdviseDbmv:0} dBmV.",
+                    Recommendation = "Add a forward-path attenuator (pad) to bring downstream power back toward 0 dBmV."
+                });
+            else if (dsp < DocsisHealthThresholds.DsPowerStarvedDbmv)
+                issues.Add(new IspHealthIssue
+                {
+                    Severity = IspIssueSeverity.Warning,
+                    Title = "DOCSIS: downstream power starved",
+                    Description = $"{input.SourceName} downstream receive power is {dsp.ToString("0.0", CultureInfo.InvariantCulture)} dBmV, below {DocsisHealthThresholds.DsPowerStarvedDbmv:0} dBmV.",
+                    Recommendation = "Eliminate any unused splitters; if that doesn't help, a line tech may need to check your drop, the amplifier, or the node."
+                });
+        }
+
+        // Upstream power: straining as it climbs past ideal.
+        if (input.UsPowerDbmv is double usp)
+        {
+            var usScore = ScoreCurve.Interpolate(usp,
+                (30, 100),
+                (DocsisHealthThresholds.UsPowerIdealHighDbmv, 95),
+                (DocsisHealthThresholds.UsPowerDriftingDbmv, 90),
+                (DocsisHealthThresholds.UsPowerMarginalDbmv, 55),
+                (DocsisHealthThresholds.UsPowerCriticalDbmv, 25),
+                (DocsisHealthThresholds.UsPowerMaxDbmv, 0));
+            parts.Add((usScore, 0.15));
+            valueBits.Add($"US {usp.ToString("0.0", CultureInfo.InvariantCulture)} dBmV");
+            if (usp > DocsisHealthThresholds.UsPowerMarginalDbmv)
+                issues.Add(new IspHealthIssue
+                {
+                    Severity = IspIssueSeverity.Warning,
+                    Title = "DOCSIS: upstream transmit power high",
+                    Description = $"{input.SourceName} upstream transmit power is {usp.ToString("0.0", CultureInfo.InvariantCulture)} dBmV, past the {DocsisHealthThresholds.UsPowerMarginalDbmv:0} dBmV strain point.",
+                    Recommendation = "High upstream TX means the modem is compensating for return-path loss; check for excess attenuation, corrosion, or a failing tap."
+                });
+        }
+
+        if (parts.Count == 0)
+            return new PhysicalLinkResult(NullFactor(factorWeight, "cable modem not reporting RF metrics yet"), issues);
+
+        var totalWeight = parts.Sum(p => p.Weight);
+        var score = parts.Sum(p => p.Score * p.Weight) / totalWeight;
+
+        // Channel-loss cap: a sustained drop in locked downstream channels from the window peak.
+        if (input.LockedDsChannels is int locked && input.PeakDsChannels is int peak && peak - locked >= 4)
+        {
+            score = Math.Min(score, 40);
+            transientAnomaly = true;
+            issues.Add(new IspHealthIssue
+            {
+                Severity = IspIssueSeverity.Warning,
+                Title = "DOCSIS: downstream channels dropped",
+                Description = $"{input.SourceName} locked downstream channels fell from {peak} to {locked}.",
+                Recommendation = "Lost channels reduce capacity and signal a marginal plant; check downstream power and SNR."
+            });
+        }
+
+        var gen = isOfdm ? "DOCSIS 3.1" : "DOCSIS 3.0";
+        // Headline (ValueText) carries SNR + US; the description lists the other scored stats (DS, FEC).
+        var desc = $"{gen} cable-modem RF health"
+                   + (detailBits.Count > 0 ? $" ({string.Join(", ", detailBits)})." : ".")
+                   + (transientAnomaly ? AnomalyNote : "");
+        return new PhysicalLinkResult(
+            Factor(factorWeight, (int)Math.Round(score), string.Join(", ", valueBits), desc), issues);
+    }
+
+    /// <summary>
+    /// Plant generation: an active OFDMA upstream channel (live snapshot) is authoritative;
+    /// otherwise a provisioned upstream above the OFDMA-likely line is a strong hint. Absence
+    /// of an OFDMA reading is not proof of 3.0 when the plan speed is high.
+    /// </summary>
+    private static bool IsDocsis31(PhysicalLinkInput input, double? expectedUploadMbps)
+    {
+        if (input.OfdmaActive == true) return true;
+        if (expectedUploadMbps is double up && up > DocsisHealthThresholds.OfdmaLikelyUpstreamMbps) return true;
+        return false;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Cellular
+    // ---------------------------------------------------------------------------
+
+    private static PhysicalLinkResult ScoreCellular(PhysicalLinkInput input, double factorWeight)
+    {
+        var issues = new List<IspHealthIssue>();
+        if (input.SignalQuality is not int quality)
+            return new PhysicalLinkResult(NullFactor(factorWeight, "cellular modem not reporting signal yet"), issues);
+
+        double score = Math.Clamp(quality, 0, 100);
+
+        if (quality < 25)
+            issues.Add(new IspHealthIssue
+            {
+                Severity = IspIssueSeverity.Warning,
+                Title = "Cellular: poor signal",
+                Description = $"{input.SourceName} composite signal quality is {quality}/100.",
+                Recommendation = "Reposition the modem or antenna for a stronger signal; weak RF caps throughput and raises latency."
+            });
+
+        // A 5G->LTE downgrade only matters on a 5G-capable modem.
+        if (input.NetworkModeDowngraded && input.Is5gCapable)
+        {
+            score = Math.Max(0, score - 5);
+            issues.Add(new IspHealthIssue
+            {
+                Severity = IspIssueSeverity.Info,
+                Title = "Cellular: network downgraded to LTE",
+                Description = $"{input.SourceName} dropped from 5G to LTE during the window.",
+                Recommendation = "Intermittent 5G coverage reduces peak speeds; antenna placement can help hold 5G."
+            });
+        }
+
+        var modeBit = string.IsNullOrWhiteSpace(input.NetworkMode) ? "" : $" ({input.NetworkMode})";
+        // Only the 5G->LTE downgrade is a transient event; a steady poor signal shows in the value.
+        var desc = "Cellular composite signal quality (RSRP, SNR, RSRQ)."
+                   + (input.NetworkModeDowngraded && input.Is5gCapable ? AnomalyNote : "");
+        return new PhysicalLinkResult(
+            Factor(factorWeight, (int)Math.Round(score), $"Signal {quality}/100{modeBit}", desc),
+            issues);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Factor helpers
+    // ---------------------------------------------------------------------------
+
+    private static IspScoreFactor Factor(double weight, int score, string valueText, string description) => new()
+    {
+        Name = "Physical Link",
+        Score = score,
+        Weight = weight,
+        ValueText = valueText,
+        Description = description
+    };
+
+    private static IspScoreFactor NullFactor(double weight, string description) => new()
+    {
+        Name = "Physical Link",
+        Score = null,
+        Weight = weight,
+        ValueText = null,
+        Description = description
+    };
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/UsageWeighting.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/UsageWeighting.cs
@@ -1,0 +1,49 @@
+namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+
+/// <summary>
+/// Time-of-day usage weighting for outage severity. The service builds an hour-of-day fingerprint
+/// (per local hour, the fraction of time the WAN was actively in use) from throughput we already
+/// record; this pure helper turns that fingerprint plus an event's local hours into a 0..1 weight,
+/// normalized against the busiest hour and floored. An outage during the user's heavy-usage hours
+/// weighs in full; one during typically-idle hours weighs less, never below the floor (an outage is
+/// still an outage). All the timezone/Influx work lives in the service - this stays pure and testable.
+/// </summary>
+public static class UsageWeighting
+{
+    /// <summary>
+    /// Weight for an event covering <paramref name="localHours"/>, given the hour-of-day active
+    /// fraction profile. Normalized to the profile's peak hour so a lightly-used line still weighs its
+    /// own busiest hour at 1.0, then clamped to [<paramref name="floor"/>, 1]. Returns 1.0 (no
+    /// softening) when the profile is absent/degenerate or no hours are given.
+    /// </summary>
+    public static double Weight(double[]? hourlyActiveFraction, IReadOnlyCollection<int> localHours, double floor)
+    {
+        if (hourlyActiveFraction is not { Length: 24 } profile || localHours.Count == 0)
+            return 1.0;
+
+        var peak = profile.Max();
+        if (peak <= 0) return 1.0; // line never registered active anywhere - nothing to normalize against
+
+        var frac = localHours.Average(h => profile[h]);
+        var weight = floor + (1.0 - floor) * (frac / peak);
+        return Math.Clamp(weight, floor, 1.0);
+    }
+
+    /// <summary>
+    /// The distinct local hours-of-day an event in [<paramref name="startUtc"/>, <paramref name="endUtc"/>)
+    /// touches. A short event yields one hour; a multi-hour event yields every hour it spans, so its
+    /// weight averages across them. Bounded so a pathological span can't loop unbounded.
+    /// </summary>
+    public static IReadOnlyCollection<int> LocalHoursSpanned(DateTime startUtc, DateTime endUtc, TimeZoneInfo tz)
+    {
+        var localStart = TimeZoneInfo.ConvertTimeFromUtc(DateTime.SpecifyKind(startUtc, DateTimeKind.Utc), tz);
+        var localEnd = TimeZoneInfo.ConvertTimeFromUtc(DateTime.SpecifyKind(endUtc, DateTimeKind.Utc), tz);
+
+        var hours = new HashSet<int>();
+        var cursor = new DateTime(localStart.Year, localStart.Month, localStart.Day, localStart.Hour, 0, 0);
+        for (var i = 0; i < 48 && cursor <= localEnd; i++, cursor = cursor.AddHours(1))
+            hours.Add(cursor.Hour);
+        if (hours.Count == 0) hours.Add(localStart.Hour);
+        return hours;
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/OntAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/OntAlertEvaluator.cs
@@ -15,7 +15,7 @@ public class OntAlertEvaluator
 {
     private const double RxPowerLowDbm = PonThresholds.PonRxPowerLowDbm;
     private const double RxPowerHysteresisDbm = PonThresholds.PowerHysteresisDbm;
-    private const long FecErrorDeltaThreshold = 1000;
+    private const long FecErrorDeltaThreshold = PonThresholds.PonFecErrorSpikePerPoll;
 
     private readonly IAlertEventBus _eventBus;
     private readonly ILogger<OntAlertEvaluator> _logger;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/PonThresholds.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/PonThresholds.cs
@@ -11,8 +11,37 @@ public static class PonThresholds
 {
     // --- PON thresholds (SFP and external ONT share these) ---
     public const double PonRxPowerLowDbm = -25.0;
+    /// <summary>High ONU transmit power for GPON (Class B+ ONUs transmit ~+0.5 to +5 dBm).</summary>
     public const double PonTxPowerHighDbm = 4.0;
+    /// <summary>High ONU transmit power for XGS-PON, which transmits hotter (~+4 to +9 dBm). Set to the
+    /// same relative position in that range as GPON's +4 in +0.5..+5, so it flags before the +9 max.</summary>
+    public const double XgsPonTxPowerHighDbm = 8.0;
     public const double PonTempHighC = 75.0;
+
+    // --- PON receiver operating envelope (physics; consumed by ISP Health optical scoring) ---
+    /// <summary>ONU receiver sensitivity floor (GPON/XGS-PON Class B+); at/below this the link risks dropping.</summary>
+    public const double PonRxFloorDbm = -28.0;
+    /// <summary>ONU receiver overload point; receive power hotter than this risks saturating the receiver.</summary>
+    public const double PonRxOverloadDbm = -8.0;
+    /// <summary>Coldest receive power a realistic single/cascaded 1:64 split can produce. Below this is
+    /// excess loss (dirty connector, bend, splice), not a deeper splitter - 1:128 is not in the wild.</summary>
+    public const double PonExcessLossFloorDbm = -25.5;
+
+    // --- ONT error-counter spike thresholds (per poll) ---
+    /// <summary>Per-poll FEC corrected-error spike threshold. Corrected errors are benign in small
+    /// numbers (the FEC is doing its job); a sustained rate above this corroborates a marginal optic.</summary>
+    public const long PonFecErrorSpikePerPoll = 1000;
+    /// <summary>Per-poll BIP (bit-interleaved-parity) error threshold. BIP errors are uncorrected bit
+    /// errors, so this is stricter than the FEC corrected-error threshold.</summary>
+    public const long PonBipErrorSpikePerPoll = 100;
+
+    // --- ONT error-count health for ISP Health (absolute count over the window, per-day). ---
+    // A healthy PON link has a negligible BIP / uncorrectable-FEC count: 0 is ideal, a few per day
+    // (~5-10) is still good, and above ~50/day is poor. BIP and uncorrectable FEC share this line.
+    /// <summary>Per-day BIP/uncorrectable-FEC count that still scores well (a few errors/day; 0 is ideal).</summary>
+    public const double PonErrorsPerDayGood = 10.0;
+    /// <summary>Per-day BIP/uncorrectable-FEC count above which the link is poor (and an issue is raised).</summary>
+    public const double PonErrorsPerDayPoor = 50.0;
 
     // --- Hysteresis ---
     public const double PowerHysteresisDbm = 2.0;
@@ -22,6 +51,10 @@ public static class PonThresholds
     public const double AeRxPowerLowDbm = -14.0;
     public const double AeTxPowerHighDbm = 1.0;
     public const double AeTempHighC = 80.0;
+
+    // --- Active Ethernet receiver operating envelope ---
+    public const double AeRxFloorDbm = -16.0;
+    public const double AeRxOverloadDbm = -1.0;
 
     // --- Generic SFP thresholds ---
     public const double SfpTempHighGenericC = 87.0;

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -1901,7 +1901,7 @@ public class MonitoringCollectionAgent : BackgroundService
 
             var devices = await _connectionService.Client.GetDevicesAsync(ct);
             var filtered = devices?.Where(d =>
-                d.Adopted && d.State == 1 && !string.IsNullOrEmpty(d.Ip) && !string.IsNullOrEmpty(d.Mac))
+                d.Adopted && UniFiDeviceStateMap.IsOnline(d.State) && !string.IsNullOrEmpty(d.Ip) && !string.IsNullOrEmpty(d.Mac))
                 .ToList() ?? new List<UniFiDeviceResponse>();
             _cachedDevices = filtered;
             _cachedDevicesAt = DateTime.UtcNow;

--- a/src/NetworkOptimizer.Web/Services/OntProviders/Lantiq8311OntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/Lantiq8311OntProvider.cs
@@ -25,6 +25,14 @@ public sealed class Lantiq8311OntProvider : IOntProvider
     private const int TimeoutSeconds = 10;
     private const string GponStatusPath = "/cgi-bin/luci/admin/8311/gpon_status";
     private const string LoginPath = "/cgi-bin/luci";
+    // Raw `pontop -g "FEC Status & Counters" -b` text (text/plain). The DDM gpon_status JSON does not
+    // carry error counters; FEC/BIP only live on this pontop page.
+    private const string FecCountersPath = "/cgi-bin/luci/admin/8311/pontop/fec";
+
+    // KV row in the pontop batch output: "Label<padding> : Value". Only numeric-valued rows match
+    // (so "FEC upstream : ON" and the "OPTION  VALUE" header are skipped).
+    private static readonly Regex FecCounterRegex = new(
+        @"^(.*\S)\s+:\s+(\d+)\s*$", RegexOptions.Compiled);
 
     private readonly ILogger<Lantiq8311OntProvider> _logger;
 
@@ -55,6 +63,11 @@ public sealed class Lantiq8311OntProvider : IOntProvider
 
             var json = await client.GetStringAsync($"{baseUrl}{GponStatusPath}", cancellationToken);
             var stats = ParseGponStatus(json, context);
+
+            // Best-effort FEC/BIP counters from the pontop page. Fully isolated: any failure here must
+            // not affect the DDM stats already parsed above, so a missing page or parse error just
+            // leaves the error counters null.
+            await TryAddFecCountersAsync(client, baseUrl, stats, cancellationToken);
 
             _logger.LogDebug("8311 ONT {Name} polled: Rx={Rx} dBm, Tx={Tx} dBm, Temp={Temp} C, Mode={Mode}",
                 context.Name, stats.RxPowerDbm?.ToString("F2") ?? "-",
@@ -226,6 +239,47 @@ public sealed class Lantiq8311OntProvider : IOntProvider
         }
 
         return stats;
+    }
+
+    /// <summary>
+    /// Best-effort fetch + parse of the pontop "FEC Status &amp; Counters" page into the error counters.
+    /// Isolated in its own try/catch so a missing page, auth quirk, or format change can never disturb
+    /// the DDM stats; on any failure FecErrors/BipErrors simply stay null.
+    /// </summary>
+    private async Task TryAddFecCountersAsync(HttpClient client, string baseUrl, OntStats stats, CancellationToken ct)
+    {
+        try
+        {
+            var text = await client.GetStringAsync($"{baseUrl}{FecCountersPath}", ct);
+            ParseFecCounters(text, stats);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "8311 ONT {Name}: FEC/BIP counters unavailable", stats.DeviceName);
+        }
+    }
+
+    /// <summary>
+    /// Parses the raw pontop FEC page (KV rows "Label : Value"). Maps "Uncorrected FEC codewords" -&gt;
+    /// FecErrors and "BIP errors" -&gt; BipErrors - both read 0 on a healthy link, so they are clean
+    /// data-loss signals. "Corrected FEC codewords" is deliberately NOT used: FEC correcting errors is
+    /// benign (the optic is still delivering), so counting it would penalize a working link.
+    /// </summary>
+    internal static void ParseFecCounters(string text, OntStats stats)
+    {
+        foreach (var rawLine in text.Split('\n'))
+        {
+            var match = FecCounterRegex.Match(rawLine.TrimEnd('\r'));
+            if (!match.Success || !long.TryParse(match.Groups[2].Value, out var value))
+                continue;
+
+            var key = match.Groups[1].Value.Trim();
+            if (key.Equals("Uncorrected FEC codewords", StringComparison.OrdinalIgnoreCase))
+                stats.FecErrors = value;
+            else if (key.Equals("BIP errors", StringComparison.OrdinalIgnoreCase))
+                stats.BipErrors = value;
+        }
     }
 
     private static double? ParseNumericValue(string? text)

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -173,7 +173,7 @@ public class WiFiOptimizerService
             return _cachedAps;
         }
 
-        await RefreshDataAsync();
+        await RefreshDataAsync(bypassClientCache: forceRefresh);
         return _cachedAps ?? new List<AccessPointSnapshot>();
     }
 
@@ -289,7 +289,7 @@ public class WiFiOptimizerService
         return summary;
     }
 
-    private async Task RefreshDataAsync()
+    private async Task RefreshDataAsync(bool bypassClientCache = false)
     {
         if (_connectionService.Client == null)
         {
@@ -302,8 +302,10 @@ public class WiFiOptimizerService
             var provider = CreateProvider();
 
             // Fetch data in parallel - use Task.WhenAll to start all tasks,
-            // but handle individual failures so one bad task doesn't block everything
-            var apsTask = provider.GetAccessPointsAsync();
+            // but handle individual failures so one bad task doesn't block everything.
+            // On an explicit refresh (forceRefresh), bypass the client device-list cache so the
+            // AP snapshots reflect live state - e.g. a freshly re-paired mesh uplink.
+            var apsTask = provider.GetAccessPointsAsync(useCache: !bypassClientCache);
             var clientsTask = provider.GetWirelessClientsAsync();
             var roamingTask = provider.GetRoamingTopologyAsync();
             var wlanTask = provider.GetWlanConfigurationsAsync();

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -16197,6 +16197,10 @@ a.isp-health-hero-speed:hover {
     font-weight: 700;
 }
 
+.isp-card-body-tight-top {
+    padding-top: 6px;
+}
+
 .isp-factor-row {
     display: grid;
     grid-template-columns: minmax(110px, 1fr) minmax(60px, 130px) 34px;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1386,6 +1386,14 @@ a.stat-card-link:active {
     border-left-color: var(--danger-color);
 }
 
+.device-card.device-provisioning {
+    border-left-color: var(--warning-color);
+}
+
+.device-card.device-error {
+    border-left-color: var(--danger-color);
+}
+
 .device-header,
 .ap-header {
     display: flex;
@@ -1449,6 +1457,15 @@ a.stat-card-link:active {
 
 .status-dot.offline {
     background: var(--text-muted);
+}
+
+.status-dot.provisioning {
+    background: #fbbf24;
+    animation: pulse-yellow 2s infinite;
+}
+
+.status-dot.error {
+    background: var(--danger-color);
 }
 
 .device-body {
@@ -2045,6 +2062,11 @@ a.stat-card-link:active {
 .status-badge.status-error {
     background: rgba(239, 68, 68, 0.2);
     color: var(--danger-color);
+}
+
+.status-badge.status-provisioning {
+    background: rgba(231, 150, 19, 0.2);
+    color: var(--warning-color);
 }
 
 /* Buttons - Three colors only: primary (blue), secondary (grey), danger (red) */

--- a/src/NetworkOptimizer.WiFi/IWiFiDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/IWiFiDataProvider.cs
@@ -10,9 +10,11 @@ namespace NetworkOptimizer.WiFi;
 public interface IWiFiDataProvider
 {
     /// <summary>
-    /// Get current snapshot of all access points with Wi-Fi metrics
+    /// Get current snapshot of all access points with Wi-Fi metrics.
+    /// Pass <paramref name="useCache"/> = false to force a live device read, bypassing any
+    /// short-lived device-list cache (used by explicit user refresh and post-re-pair refresh).
     /// </summary>
-    Task<List<AccessPointSnapshot>> GetAccessPointsAsync(CancellationToken cancellationToken = default);
+    Task<List<AccessPointSnapshot>> GetAccessPointsAsync(CancellationToken cancellationToken = default, bool useCache = true);
 
     /// <summary>
     /// Get current snapshot of all wireless clients with connection details

--- a/src/NetworkOptimizer.WiFi/Models/AccessPointSnapshot.cs
+++ b/src/NetworkOptimizer.WiFi/Models/AccessPointSnapshot.cs
@@ -1,3 +1,5 @@
+using NetworkOptimizer.Core.Models;
+
 namespace NetworkOptimizer.WiFi.Models;
 
 /// <summary>
@@ -35,8 +37,18 @@ public class AccessPointSnapshot
     /// <summary>When this snapshot was taken</summary>
     public DateTimeOffset Timestamp { get; set; } = DateTimeOffset.UtcNow;
 
-    /// <summary>Whether this AP is currently online (State == 1 from UniFi API)</summary>
-    public bool IsOnline { get; set; } = true;
+    /// <summary>
+    /// Connection status derived from the UniFi device <c>state</c> (see UniFiDeviceStateMap).
+    /// Drives the status indicator; distinguishes provisioning/updating (yellow) from offline (grey).
+    /// </summary>
+    public DeviceStatus Status { get; set; } = new(DeviceStatusKind.Online, "Online");
+
+    /// <summary>
+    /// Whether this AP is fully online and actionable (the Online bucket: connected or
+    /// update-available). A provisioning/updating AP is not offline, but also not yet actionable -
+    /// use <see cref="Status"/> for display, this for gating actions like the backhaul re-scan.
+    /// </summary>
+    public bool IsOnline => Status.IsOnline;
 
     /// <summary>Whether this AP is a mesh child (has wireless uplink to another AP)</summary>
     public bool IsMeshChild { get; set; }

--- a/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
@@ -26,10 +26,10 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
     public string ProviderName => "UniFi Live";
     public bool SupportsHistoricalData => true; // Via stat/report endpoints
 
-    public async Task<List<AccessPointSnapshot>> GetAccessPointsAsync(CancellationToken cancellationToken = default)
+    public async Task<List<AccessPointSnapshot>> GetAccessPointsAsync(CancellationToken cancellationToken = default, bool useCache = true)
     {
         // Use UniFiDiscovery for centralized device classification (same as Audit and Speed Test)
-        var aps = await _discovery.DiscoverAccessPointsAsync(cancellationToken);
+        var aps = await _discovery.DiscoverAccessPointsAsync(cancellationToken, useCache);
         var timestamp = DateTimeOffset.UtcNow;
 
         // Build a set of AP MACs for mesh parent detection
@@ -932,7 +932,7 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
             FirmwareVersion = ap.Firmware,
             Ip = ap.IpAddress,
             Satisfaction = ap.Satisfaction,
-            IsOnline = ap.State == 1,
+            Status = UniFiDeviceStateMap.ToStatus(ap.State),
             Timestamp = timestamp,
             Radios = new List<RadioSnapshot>(),
             Vaps = new List<VapSnapshot>(),

--- a/tests/NetworkOptimizer.UniFi.Tests/UniFiDeviceStateTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/UniFiDeviceStateTests.cs
@@ -1,0 +1,57 @@
+using FluentAssertions;
+using NetworkOptimizer.Core.Models;
+using NetworkOptimizer.UniFi.Models;
+using Xunit;
+
+namespace NetworkOptimizer.UniFi.Tests;
+
+public class UniFiDeviceStateTests
+{
+    [Theory]
+    // Online bucket - green, actionable.
+    [InlineData(1, DeviceStatusKind.Online, "Online")]
+    [InlineData(3, DeviceStatusKind.Online, "Update Available")]
+    // Transitional bucket - yellow, not a fault but not actionable yet.
+    [InlineData(2, DeviceStatusKind.Transitional, "Pending")]
+    [InlineData(4, DeviceStatusKind.Transitional, "Updating")]
+    [InlineData(5, DeviceStatusKind.Transitional, "Provisioning")]
+    [InlineData(7, DeviceStatusKind.Transitional, "Adopting")]
+    [InlineData(8, DeviceStatusKind.Transitional, "Deleting")]
+    // Offline bucket - grey. All three map to the same label.
+    [InlineData(0, DeviceStatusKind.Offline, "Offline")]
+    [InlineData(6, DeviceStatusKind.Offline, "Offline")]
+    [InlineData(9, DeviceStatusKind.Offline, "Offline")]
+    // Error bucket - red.
+    [InlineData(10, DeviceStatusKind.Error, "Adoption Failed")]
+    [InlineData(11, DeviceStatusKind.Error, "Isolated")]
+    [InlineData(13, DeviceStatusKind.Error, "Incorrect Topology")]
+    // Unknown / unused values fall back to Offline rather than throwing.
+    [InlineData(12, DeviceStatusKind.Offline, "Offline")]
+    [InlineData(99, DeviceStatusKind.Offline, "Offline")]
+    public void ToStatus_maps_state_to_kind_and_label(int state, DeviceStatusKind kind, string label)
+    {
+        var status = UniFiDeviceStateMap.ToStatus(state);
+        status.Kind.Should().Be(kind);
+        status.Label.Should().Be(label);
+    }
+
+    [Theory]
+    // Only the Online bucket (connected, update-available) is actionable; provisioning is NOT.
+    [InlineData(1, true)]
+    [InlineData(3, true)]
+    [InlineData(5, false)]
+    [InlineData(4, false)]
+    [InlineData(0, false)]
+    [InlineData(10, false)]
+    public void IsOnline_is_true_only_for_the_online_bucket(int state, bool expected)
+        => UniFiDeviceStateMap.IsOnline(state).Should().Be(expected);
+
+    [Fact]
+    public void Provisioning_uses_the_yellow_dot_and_is_not_offline()
+    {
+        var status = UniFiDeviceStateMap.ToStatus((int)UniFiDeviceState.Provisioning);
+        status.CssClass.Should().Be("provisioning");
+        status.IsOffline.Should().BeFalse();
+        status.IsOnline.Should().BeFalse();
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -39,7 +39,8 @@ public class IspHealthScorerTests
         double? internetDeltaMs = null,
         bool lineIdle = false,
         bool hopOrderKnown = false,
-        List<OutageEvent>? outages = null)
+        List<OutageEvent>? outages = null,
+        TimeSpan? scoreWindow = null)
     {
         // lineIdle: a near-zero, flat WAN with no load bursts (~0% average load), for
         // exercising the load-calibrated packet-loss ceiling at the idle end.
@@ -60,7 +61,7 @@ public class IspHealthScorerTests
         return new IspHealthInputs
         {
             WindowStart = TestSeries.Start,
-            WindowEnd = TestSeries.Start + Day,
+            WindowEnd = TestSeries.Start + (scoreWindow ?? Day),
             FirstHopSeries = firstHop,
             AccessHopSeries = accessHops ?? new List<List<LatencySample>>(),
             FirstHopTargetId = firstHopTargetId,
@@ -102,6 +103,107 @@ public class IspHealthScorerTests
         OverallWith(10).Should().Be(86);
         OverallWith(60).Should().Be(55);
         OverallWith(480).Should().Be(10);
+    }
+
+    // A short, broad, near-total drop, like the user's 28 s / 100% across 5 of 9 targets.
+    private static OutageEvent ShortBroadOutage(int seconds = 28, double peakLossPct = 100, int degraded = 5, int total = 9) => new()
+    {
+        Start = TestSeries.Start.AddHours(2),
+        End = TestSeries.Start.AddHours(2).AddSeconds(seconds),
+        PeakLossPct = peakLossPct,
+        DegradedTargetCount = degraded,
+        PathTargetCount = total
+    };
+
+    [Fact]
+    public void Recurring_micro_outages_compound_far_beyond_one_point()
+    {
+        int DropFor(int count)
+        {
+            var events = new List<OutageEvent>();
+            for (var i = 0; i < count; i++)
+                events.Add(ShortBroadOutage());
+            return 100 - new IspHealthScorer(Options).Score(BuildInputs(outages: events), Gpon).OverallScore;
+        }
+
+        // A single 28 s near-total broad drop is felt: a few points, not the old flat 1.
+        var one = DropFor(1);
+        one.Should().BeInRange(2, 5);
+
+        // Ten of them across the window cost far more - the occurrence component compounds rather
+        // than collapsing to ~one point the way summed-duration alone would.
+        var ten = DropFor(10);
+        ten.Should().BeGreaterThan(5 * one);
+        ten.Should().BeGreaterThan(15);
+    }
+
+    [Fact]
+    public void Outage_penalty_scales_with_breadth_and_depth()
+    {
+        int Drop(OutageEvent o) => 100 - new IspHealthScorer(Options)
+            .Score(BuildInputs(outages: new List<OutageEvent> { o }), Gpon).OverallScore;
+
+        // Same 60 s duration; the broad near-total event must out-penalize the narrow shallow one
+        // purely on severity (breadth x depth), since their duration contribution is identical.
+        var broadDeep = Drop(ShortBroadOutage(seconds: 60, peakLossPct: 100, degraded: 8, total: 9));
+        var narrowShallow = Drop(ShortBroadOutage(seconds: 60, peakLossPct: 55, degraded: 4, total: 9));
+        broadDeep.Should().BeGreaterThan(narrowShallow);
+    }
+
+    [Fact]
+    public void Outage_at_a_quiet_usage_hour_is_softened_and_the_finding_says_so()
+    {
+        OutageEvent FullOutage(double usageWeight) => new()
+        {
+            Start = TestSeries.Start.AddHours(2),
+            End = TestSeries.Start.AddHours(2).AddMinutes(5),
+            PeakLossPct = 100,
+            DegradedTargetCount = 9,
+            PathTargetCount = 9,
+            UsageWeight = usageWeight
+        };
+        int Drop(OutageEvent o) => 100 - new IspHealthScorer(Options)
+            .Score(BuildInputs(outages: new List<OutageEvent> { o }), Gpon).OverallScore;
+
+        // Same outage, quiet-hour weight dings less than a busy-hour (full-weight) one.
+        Drop(FullOutage(0.5)).Should().BeLessThan(Drop(FullOutage(1.0)));
+
+        // And the finding explains the softening for a clearly quiet-time event.
+        var report = new IspHealthScorer(Options)
+            .Score(BuildInputs(outages: new List<OutageEvent> { FullOutage(0.4) }), Gpon);
+        report.Issues.Should().Contain(i => i.Description.Contains("typically idle"));
+    }
+
+    [Fact]
+    public void Micro_outages_weigh_less_over_a_longer_window_a_long_outage_does_not()
+    {
+        int Drop(List<OutageEvent> outages, TimeSpan window) => 100 - new IspHealthScorer(Options)
+            .Score(BuildInputs(outages: outages, scoreWindow: window), Gpon).OverallScore;
+
+        // Frequency is a rate: the same two micro-drops spread over a week is a steadier line than
+        // the same two in 48 h, so the occurrence-dominated penalty fades over the longer window.
+        var micros = new List<OutageEvent> { ShortBroadOutage(), ShortBroadOutage() };
+        var micro48h = Drop(micros, TimeSpan.FromHours(48));
+        var micro7d = Drop(micros, TimeSpan.FromDays(7));
+        micro7d.Should().BeLessThan(micro48h);
+        (micro48h - micro7d).Should().BeGreaterThanOrEqualTo(2);
+
+        // A long, duration-dominated outage weighs roughly the same in either window (duration is
+        // absolute; only its small occurrence part rescales).
+        var longOutage = new List<OutageEvent>
+        {
+            new()
+            {
+                Start = TestSeries.Start.AddHours(2),
+                End = TestSeries.Start.AddHours(4),
+                PeakLossPct = 100,
+                DegradedTargetCount = 9,
+                PathTargetCount = 9
+            }
+        };
+        var long48h = Drop(longOutage, TimeSpan.FromHours(48));
+        var long7d = Drop(longOutage, TimeSpan.FromDays(7));
+        long7d.Should().BeCloseTo(long48h, 3);
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OpticalSampleStatsTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OpticalSampleStatsTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.IspHealth;
+
+/// <summary>
+/// Tests for DDM read-artifact rejection. SFP sticks occasionally return a garbage DDM read where
+/// RX dives while the reported temperature jumps tens of degrees in one sample; those must not drag
+/// the RX statistics the Physical Link factor scores on.
+/// </summary>
+public class OpticalSampleStatsTests
+{
+    private static readonly DateTime T0 = new(2026, 6, 28, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void Rejects_ddm_artifacts_where_temperature_glitches_with_rx()
+    {
+        // 20 steady-state reads (~-22.7 dBm / ~44 C) plus the two real field artifacts:
+        // -25.53 dBm @ 10.85 C and -24.69 dBm @ 23.85 C - temperature physically can't drop 20-33 C
+        // in one poll, so the whole read is rejected.
+        var samples = new List<(DateTime, double?, double?)>();
+        for (var i = 0; i < 20; i++)
+            samples.Add((T0.AddMinutes(i), -22.6 - (i % 3) * 0.1, 43.85));
+        samples.Add((T0.AddMinutes(21), -25.53, 10.85));   // artifact
+        samples.Add((T0.AddMinutes(22), -24.69, 23.85));   // artifact
+
+        var stats = OpticalSampleStats.Compute(samples);
+
+        stats.RejectedArtifacts.Should().Be(2);
+        stats.MedianDbm.Should().BeInRange(-23.0, -22.4);
+        // The coldest CLEAN sample, not the -25.53 artifact, so the worst-cap can't be tripped by garbage.
+        stats.WorstDbm.Should().BeGreaterThan(-23.5);
+    }
+
+    [Fact]
+    public void Keeps_all_samples_when_temperature_is_stable()
+    {
+        var samples = Enumerable.Range(0, 10)
+            .Select(i => (T0.AddMinutes(i), (double?)(-22.5 - i * 0.05), (double?)44.0))
+            .ToList();
+
+        var stats = OpticalSampleStats.Compute(samples);
+
+        stats.RejectedArtifacts.Should().Be(0);
+        stats.CleanCount.Should().Be(10);
+        stats.WorstDbm.Should().BeApproximately(-22.95, 0.01);
+    }
+
+    [Fact]
+    public void Baseline_is_the_earliest_fifth_for_trend_detection()
+    {
+        // Earliest reads ~-19, drifting to ~-23: baseline should reflect the early ~-19, not the median.
+        var samples = Enumerable.Range(0, 20)
+            .Select(i => (T0.AddMinutes(i), (double?)(-19.0 - i * 0.2), (double?)44.0))
+            .ToList();
+
+        var stats = OpticalSampleStats.Compute(samples);
+
+        stats.BaselineDbm.Should().BeInRange(-19.6, -19.0);
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
@@ -69,6 +69,11 @@ public class OutageDetectorTests
         events[0].LastReachableHop.Should().Be("AT&T nokia-olt");
         events[0].Duration.Should().BeCloseTo(TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(1));
         events[0].IsBrief.Should().BeFalse();
+        // Breadth/depth are populated for blackouts too (both internet triggers went fully dark),
+        // so the scorer's severity = breadth x depth reads full for a real outage.
+        events[0].PeakLossPct.Should().Be(100);
+        events[0].DegradedTargetCount.Should().Be(2);
+        events[0].PathTargetCount.Should().Be(2);
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/PhysicalLinkResolverTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/PhysicalLinkResolverTests.cs
@@ -1,0 +1,57 @@
+using FluentAssertions;
+using NetworkOptimizer.Storage.Services;
+using NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.IspHealth;
+
+/// <summary>
+/// Unit tests for the resolver's PON O5-state derivation from the link-status series. The key
+/// property: a missing/omitted status (Unknown) is absence of data, never a link-down, and a
+/// source that never reports an O-state yields null so the factor can't false-alarm.
+/// </summary>
+public class PhysicalLinkResolverTests
+{
+    private static MonitoringInfluxClient.OntPoint Pt(string? status) =>
+        new() { Time = System.DateTime.UnixEpoch, PonLinkStatus = status };
+
+    [Fact]
+    public void Operational_is_null_when_no_o_state_is_ever_reported()
+    {
+        // DDM sticks and most ONTs never report an O-state - the field is simply absent.
+        var pts = new[] { Pt(null), Pt(null), Pt(null) };
+        PhysicalLinkResolver.ResolveOperationalFromHistory(pts).Should().BeNull();
+    }
+
+    [Fact]
+    public void Operational_is_true_when_every_reported_state_is_operation()
+    {
+        var pts = new[] { Pt("operation"), Pt("operation"), Pt("operation") };
+        PhysicalLinkResolver.ResolveOperationalFromHistory(pts).Should().BeTrue();
+    }
+
+    [Fact]
+    public void A_single_missing_status_among_operation_samples_is_not_a_break()
+    {
+        // The bug this fixes: a poll that drops the PON Link Status row (gateway stats page hiccup)
+        // lands as null/Unknown and must NOT read as a link-down.
+        var pts = new[] { Pt("operation"), Pt(null), Pt("operation") };
+        PhysicalLinkResolver.ResolveOperationalFromHistory(pts).Should().BeTrue();
+    }
+
+    [Fact]
+    public void A_known_non_operation_state_in_the_window_is_a_break()
+    {
+        var pts = new[] { Pt("operation"), Pt("popup"), Pt("operation") };
+        PhysicalLinkResolver.ResolveOperationalFromHistory(pts).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Influx_status_strings_round_trip_through_the_parser()
+    {
+        // ToInfluxValue() lower-cases the state; the parser must still recognize it.
+        PhysicalLinkResolver.ResolveOperationalFromHistory(new[] { Pt("ranging") }).Should().BeFalse();
+        PhysicalLinkResolver.ResolveOperationalFromHistory(new[] { Pt("emergency_stop") }).Should().BeFalse();
+        PhysicalLinkResolver.ResolveOperationalFromHistory(new[] { Pt("unknown") }).Should().BeNull();
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/PhysicalLinkScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/PhysicalLinkScorerTests.cs
@@ -1,0 +1,382 @@
+using FluentAssertions;
+using NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.IspHealth;
+
+/// <summary>
+/// Unit tests for the pure Access Layer Physical Link scorer: optical (PON/AE) margin-to-floor
+/// grading, the bounded born-lossy bracket, the display-only split-ratio inference, DOCSIS RF/FEC
+/// (3.0 vs 3.1) scoring, and cellular passthrough.
+/// </summary>
+public class PhysicalLinkScorerTests
+{
+    private const double Weight = 0.15;
+
+    private static PhysicalLinkResult ScorePon(double rx, double? worst = null, double? baseline = null,
+        bool? operational = null, double? tx = null, string ponType = "GPON",
+        long? fecTotal = null, long? bipTotal = null, double windowDays = 2.0) =>
+        PhysicalLinkScorer.Score(new PhysicalLinkInput
+        {
+            Medium = PhysicalMedium.Pon,
+            SourceName = "Test ONT",
+            RxPowerMedianDbm = rx,
+            RxPowerWorstDbm = worst,
+            RxPowerBaselineDbm = baseline,
+            PonOperational = operational,
+            TxPowerDbm = tx,
+            PonType = ponType,
+            FecErrorsTotal = fecTotal,
+            BipErrorsTotal = bipTotal,
+            WindowDays = windowDays
+        }, expectedUploadMbps: null, Weight);
+
+    // ---- PON receive-power grading ----
+
+    [Fact]
+    public void Pon_healthy_rx_scores_high_with_no_issues()
+    {
+        // TJ's real reading: -22 dBm on a 1:64 split is healthy with margin to the -28 floor.
+        var result = ScorePon(-22.0);
+        result.Factor.Score.Should().BeInRange(94, 98);
+        result.Issues.Should().BeEmpty();
+        result.Factor.Weight.Should().Be(Weight);
+    }
+
+    [Fact]
+    public void Pon_more_insertion_loss_scores_slightly_lower_but_still_healthy()
+    {
+        // The gentle healthy slope: a deeper-loss but in-spec link reads a touch lower, never a flat 100.
+        var shallow = ScorePon(-14.0).Factor.Score!.Value;   // ~1:16, low loss
+        var deep = ScorePon(-22.0).Factor.Score!.Value;      // ~1:64, more loss
+        shallow.Should().BeGreaterThan(deep);
+        deep.Should().BeGreaterThan(90);
+    }
+
+    [Fact]
+    public void Pon_marginal_rx_penalized_and_raises_warning()
+    {
+        var result = ScorePon(-26.0);
+        result.Factor.Score.Should().BeInRange(40, 75);
+        result.Issues.Should().Contain(i => i.Severity == IspIssueSeverity.Warning);
+    }
+
+    [Fact]
+    public void Pon_below_floor_is_critical_and_near_zero()
+    {
+        var result = ScorePon(-28.5);
+        result.Factor.Score.Should().BeLessThan(10);
+        result.Issues.Should().Contain(i => i.Severity == IspIssueSeverity.Critical);
+    }
+
+    [Fact]
+    public void Pon_born_lossy_bracket_flags_excess_loss_without_baseline()
+    {
+        // Colder than the coldest realistic 1:64 (~-25.5) is excess loss, not a bigger splitter.
+        var result = ScorePon(-26.0);
+        result.Issues.Should().Contain(i => i.Title.Contains("excess optical loss"));
+    }
+
+    [Fact]
+    public void Pon_link_not_operational_caps_score_and_is_critical()
+    {
+        var result = ScorePon(-22.0, operational: false);
+        result.Factor.Score.Should().BeLessThanOrEqualTo(10);
+        result.Issues.Should().Contain(i => i.Severity == IspIssueSeverity.Critical && i.Title.Contains("dropped out of O5"));
+    }
+
+    [Fact]
+    public void Pon_overload_is_penalized()
+    {
+        var result = ScorePon(-6.0);
+        result.Factor.Score.Should().BeLessThan(95);
+        result.Issues.Should().Contain(i => i.Title.Contains("too hot"));
+    }
+
+    [Fact]
+    public void Pon_trend_drop_from_baseline_raises_degrading_issue()
+    {
+        var result = ScorePon(-22.0, baseline: -19.0);   // fell 3 dB from its own baseline
+        result.Issues.Should().Contain(i => i.Title.Contains("degrading"));
+    }
+
+    [Fact]
+    public void Pon_elevated_errors_cap_score_and_warn()
+    {
+        // A high absolute error count (well above the ~50/day poor line) caps the optical score and
+        // raises an issue, even though the RX reading itself is fine.
+        var result = ScorePon(-20.0, fecTotal: 1000, windowDays: 2);   // ~500/day
+        result.Factor.Score.Should().BeLessThan(85);
+        result.Issues.Should().Contain(i => i.Title.Contains("optical errors accumulating"));
+    }
+
+    [Fact]
+    public void Pon_zero_errors_do_not_penalize()
+    {
+        var healthy = ScorePon(-20.0).Factor.Score!.Value;
+        var withZeroErrors = ScorePon(-20.0, fecTotal: 0, bipTotal: 0, windowDays: 2);
+        withZeroErrors.Factor.Score!.Value.Should().Be(healthy);
+        withZeroErrors.Issues.Should().NotContain(i => i.Title.Contains("optical errors"));
+    }
+
+    [Fact]
+    public void Pon_bip_errors_share_the_same_per_day_line_as_fec()
+    {
+        // BIP and uncorrectable FEC use the same per-day curve; a high BIP count raises the issue.
+        var result = ScorePon(-20.0, bipTotal: 1000, windowDays: 2);   // ~500/day
+        result.Issues.Should().Contain(i => i.Title.Contains("optical errors accumulating"));
+    }
+
+    [Fact]
+    public void Pon_value_text_shows_tx_when_present()
+    {
+        ScorePon(-20.0, tx: 2.5).Factor.ValueText.Should().Contain("TX");
+    }
+
+    [Fact]
+    public void Pon_healthy_steady_link_has_no_anomaly_note()
+    {
+        ScorePon(-22.0).Factor.Description.Should().NotContain("anomaly");
+    }
+
+    [Fact]
+    public void Pon_dip_appends_anomaly_note_even_without_an_issue()
+    {
+        // Worst sample well below the (healthy) median: the worst-cap engaged, so a dip was factored
+        // in even though no threshold-crossing issue was raised.
+        var result = ScorePon(-22.0, worst: -24.0);
+        result.Issues.Should().BeEmpty();
+        result.Factor.Description.Should().Contain("anomaly");
+    }
+
+    [Fact]
+    public void Pon_steady_marginal_rx_has_issue_but_no_anomaly_note()
+    {
+        // A steadily-low RX raises marginal/excess-loss issues but is NOT a transient event - it's
+        // visible in the displayed value, so it must not get the "anomaly during this window" note.
+        var result = ScorePon(-26.0);
+        result.Issues.Should().NotBeEmpty();
+        result.Factor.Description.Should().NotContain("anomaly");
+    }
+
+    [Fact]
+    public void Docsis_steady_hot_power_has_no_anomaly_note()
+    {
+        var result = ScoreDocsis(dsPower: 10);
+        result.Issues.Should().NotBeEmpty();
+        result.Factor.Description.Should().NotContain("anomaly");
+    }
+
+    [Fact]
+    public void Docsis_channel_loss_appends_anomaly_note()
+    {
+        ScoreDocsis(locked: 24, peak: 32).Factor.Description.Should().Contain("anomaly");
+    }
+
+    [Fact]
+    public void Pon_high_tx_power_caps_and_warns()
+    {
+        var result = ScorePon(-22.0, tx: 6.0);   // above PonTxPowerHighDbm (4.0)
+        result.Factor.Score.Should().BeLessThanOrEqualTo(75);
+        result.Issues.Should().Contain(i => i.Title.Contains("transmit power high"));
+    }
+
+    [Fact]
+    public void Pon_xgs_tolerates_higher_tx_than_gpon()
+    {
+        // +7 dBm ONU TX flags on GPON (>+4) but is normal on XGS-PON (<+8), which transmits hotter.
+        PhysicalLinkResult Tx7(bool xgs) => PhysicalLinkScorer.Score(new PhysicalLinkInput
+        {
+            Medium = PhysicalMedium.Pon, SourceName = "ONT", RxPowerMedianDbm = -20.0, TxPowerDbm = 7.0, IsXgsPon = xgs
+        }, null, Weight);
+
+        Tx7(false).Issues.Should().Contain(i => i.Title.Contains("transmit power high"));
+        Tx7(true).Issues.Should().NotContain(i => i.Title.Contains("transmit power high"));
+    }
+
+    // ---- Split-ratio inference (display only) ----
+
+    [Theory]
+    [InlineData(-16.0, "1:16")]
+    [InlineData(-19.5, "1:32")]
+    [InlineData(-20.5, "1:32")]   // field calibration: -20.5 stays in the 1:32 realm
+    [InlineData(-21.0, "1:64")]
+    [InlineData(-22.6, "1:64")]
+    public void Split_ratio_inference_snaps_to_nearest_rung(double rx, string expected)
+    {
+        PhysicalLinkScorer.InferSplitRatio(rx, "GPON").Should().Contain(expected);
+    }
+
+    [Fact]
+    public void Split_ratio_caps_at_1_64_for_very_cold_rx()
+    {
+        // Deeper than 1:64 is reported as 1:64+/excess, never 1:128.
+        PhysicalLinkScorer.InferSplitRatio(-30.0, "GPON").Should().Contain("1:64+");
+    }
+
+    // ---- Active Ethernet ----
+
+    [Fact]
+    public void ActiveEthernet_healthy_rx_scores_high()
+    {
+        var result = PhysicalLinkScorer.Score(new PhysicalLinkInput
+        {
+            Medium = PhysicalMedium.ActiveEthernet,
+            SourceName = "AE SFP",
+            RxPowerMedianDbm = -6.0
+        }, null, Weight);
+        result.Factor.Score.Should().BeGreaterThan(90);
+        result.Issues.Should().BeEmpty();
+    }
+
+    // ---- DOCSIS ----
+
+    private static PhysicalLinkResult ScoreDocsis(double? snr = 40, double? dsPower = 0, double? usPower = 44,
+        long corr = 1_000_000, long unc = 0, int? locked = 32, int? peak = 32, bool? ofdma = true,
+        double? expectedUp = null, double windowDays = 2.0) =>
+        PhysicalLinkScorer.Score(new PhysicalLinkInput
+        {
+            Medium = PhysicalMedium.Docsis,
+            SourceName = "Test CM",
+            DsSnrDb = snr,
+            DsPowerDbmv = dsPower,
+            UsPowerDbmv = usPower,
+            CorrectablesDelta = corr,
+            UncorrectablesDelta = unc,
+            LockedDsChannels = locked,
+            PeakDsChannels = peak,
+            OfdmaActive = ofdma,
+            WindowDays = windowDays
+        }, expectedUp, Weight);
+
+    [Fact]
+    public void Docsis_healthy_scores_high_with_no_issues()
+    {
+        var result = ScoreDocsis();
+        result.Factor.Score.Should().BeGreaterThan(92);
+        result.Issues.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Docsis_31_tolerates_a_higher_absolute_uncorrectable_rate()
+    {
+        // Same uncorrectable count: 3.1 OFDM processes ~10x the codewords, so its allowable per-day
+        // rate is higher and it scores above 3.0 SC-QAM for the same absolute count.
+        var ofdm = ScoreDocsis(corr: 1_000_000, unc: 30_000, ofdma: true).Factor.Score!.Value;
+        var scqam = ScoreDocsis(corr: 1_000_000, unc: 30_000, ofdma: false).Factor.Score!.Value;
+        ofdm.Should().BeGreaterThan(scqam);
+    }
+
+    [Fact]
+    public void Docsis_plant_generation_inferred_from_plan_speed_when_no_ofdma_reading()
+    {
+        // No live OFDMA reading, but a >50 Mbps plan implies OFDMA - more codewords, higher allowable rate.
+        var byPlan = ScoreDocsis(corr: 1_000_000, unc: 30_000, ofdma: null, expectedUp: 200).Factor.Score!.Value;
+        var legacy = ScoreDocsis(corr: 1_000_000, unc: 30_000, ofdma: null, expectedUp: 20).Factor.Score!.Value;
+        byPlan.Should().BeGreaterThan(legacy);
+    }
+
+    [Fact]
+    public void Docsis_high_ratio_but_low_rate_scores_ok_and_no_issue()
+    {
+        // The real-world case: uncorrectables are a high fraction of ERRORED codewords (30%) but the
+        // absolute rate is low. The rate half keeps the FEC score healthy and the issue (gated at the
+        // 40% ratio line, here just below... actually 30% < 40%) does not fire.
+        var result = ScoreDocsis(corr: 700, unc: 300, ofdma: true);   // ratio 30%, ~150/day
+        result.Factor.Score.Should().BeGreaterThan(85);
+        result.Issues.Should().NotContain(i => i.Title.Contains("uncorrectable"));
+    }
+
+    [Fact]
+    public void Docsis_uncorrectable_ratio_over_40pct_raises_issue()
+    {
+        var result = ScoreDocsis(corr: 400, unc: 600, ofdma: true);   // ratio 60% > 40%
+        result.Issues.Should().Contain(i => i.Title.Contains("uncorrectable"));
+    }
+
+    [Fact]
+    public void Docsis_hot_downstream_recommends_attenuator()
+    {
+        var result = ScoreDocsis(dsPower: 10);
+        result.Issues.Should().Contain(i => i.Title.Contains("downstream power too hot")
+            && i.Recommendation!.Contains("attenuator"));
+    }
+
+    [Fact]
+    public void Docsis_high_upstream_flags_straining()
+    {
+        var result = ScoreDocsis(usPower: 52);
+        result.Issues.Should().Contain(i => i.Title.Contains("upstream transmit power high"));
+    }
+
+    [Fact]
+    public void Docsis_channel_loss_caps_score()
+    {
+        var result = ScoreDocsis(locked: 24, peak: 32);   // dropped 8 channels
+        result.Factor.Score.Should().BeLessThanOrEqualTo(40);
+        result.Issues.Should().Contain(i => i.Title.Contains("channels dropped"));
+    }
+
+    [Fact]
+    public void Docsis_no_metrics_yields_null_factor()
+    {
+        var result = PhysicalLinkScorer.Score(new PhysicalLinkInput
+        {
+            Medium = PhysicalMedium.Docsis,
+            SourceName = "Dead CM"
+        }, null, Weight);
+        result.Factor.Score.Should().BeNull();
+    }
+
+    // ---- Cellular ----
+
+    [Fact]
+    public void Cellular_passes_signal_quality_through()
+    {
+        var result = PhysicalLinkScorer.Score(new PhysicalLinkInput
+        {
+            Medium = PhysicalMedium.Cellular,
+            SourceName = "U5G",
+            SignalQuality = 80,
+            NetworkMode = "5G SA"
+        }, null, Weight);
+        result.Factor.Score.Should().Be(80);
+        result.Issues.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Cellular_poor_signal_raises_warning()
+    {
+        var result = PhysicalLinkScorer.Score(new PhysicalLinkInput
+        {
+            Medium = PhysicalMedium.Cellular,
+            SourceName = "U5G",
+            SignalQuality = 18
+        }, null, Weight);
+        result.Issues.Should().Contain(i => i.Severity == IspIssueSeverity.Warning);
+    }
+
+    [Fact]
+    public void Cellular_5g_to_lte_downgrade_only_dings_when_5g_capable()
+    {
+        var capable = PhysicalLinkScorer.Score(new PhysicalLinkInput
+        {
+            Medium = PhysicalMedium.Cellular,
+            SourceName = "U5G",
+            SignalQuality = 70,
+            NetworkModeDowngraded = true,
+            Is5gCapable = true
+        }, null, Weight);
+        capable.Issues.Should().Contain(i => i.Title.Contains("downgraded to LTE"));
+
+        var lteOnly = PhysicalLinkScorer.Score(new PhysicalLinkInput
+        {
+            Medium = PhysicalMedium.Cellular,
+            SourceName = "LTE modem",
+            SignalQuality = 70,
+            NetworkModeDowngraded = true,
+            Is5gCapable = false
+        }, null, Weight);
+        lteOnly.Issues.Should().NotContain(i => i.Title.Contains("downgraded"));
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/UsageWeightingTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/UsageWeightingTests.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.IspHealth;
+
+/// <summary>
+/// Unit tests for the pure time-of-day usage weighting: peak-normalized weight with a floor, and
+/// the local-hours-spanned mapping. Service-side fingerprint building (Influx/timezone) is not
+/// covered here - this is the policy layer.
+/// </summary>
+public class UsageWeightingTests
+{
+    // A profile that is busy in the evening (hour 20 = peak) and quiet pre-dawn (hour 4).
+    private static double[] Profile()
+    {
+        var p = new double[24];
+        p[4] = 0.10;   // quiet
+        p[12] = 0.50;  // moderate
+        p[20] = 1.00;  // peak
+        return p;
+    }
+
+    [Fact]
+    public void Peak_hour_weighs_full()
+    {
+        UsageWeighting.Weight(Profile(), new[] { 20 }, floor: 0.5).Should().Be(1.0);
+    }
+
+    [Fact]
+    public void Quiet_hour_weighs_near_the_floor()
+    {
+        // 0.10 active / 1.00 peak = 0.1 -> floor + 0.5*0.1 = 0.55
+        UsageWeighting.Weight(Profile(), new[] { 4 }, floor: 0.5).Should().BeApproximately(0.55, 0.001);
+    }
+
+    [Fact]
+    public void Weight_never_drops_below_the_floor()
+    {
+        var p = new double[24];
+        p[20] = 1.0; // every other hour is 0 active
+        UsageWeighting.Weight(p, new[] { 3 }, floor: 0.5).Should().Be(0.5);
+    }
+
+    [Fact]
+    public void Missing_or_degenerate_profile_does_not_soften()
+    {
+        UsageWeighting.Weight(null, new[] { 12 }, 0.5).Should().Be(1.0);
+        UsageWeighting.Weight(new double[24], new[] { 12 }, 0.5).Should().Be(1.0); // all-zero peak
+        UsageWeighting.Weight(Profile(), System.Array.Empty<int>(), 0.5).Should().Be(1.0);
+    }
+
+    [Fact]
+    public void Multi_hour_event_averages_across_the_hours_it_spans()
+    {
+        // hours 12 (0.50) and 20 (1.00) -> avg 0.75 / peak 1.0 -> 0.5 + 0.5*0.75 = 0.875
+        UsageWeighting.Weight(Profile(), new[] { 12, 20 }, 0.5).Should().BeApproximately(0.875, 0.001);
+    }
+
+    [Fact]
+    public void Local_hours_spanned_is_a_single_hour_for_a_short_event()
+    {
+        var tz = TimeZoneInfo.Utc;
+        var start = new DateTime(2026, 6, 1, 20, 0, 30, DateTimeKind.Utc);
+        var hours = UsageWeighting.LocalHoursSpanned(start, start.AddSeconds(28), tz);
+        hours.Should().Equal(20);
+    }
+
+    [Fact]
+    public void Local_hours_spanned_covers_every_hour_a_long_event_touches()
+    {
+        var tz = TimeZoneInfo.Utc;
+        var start = new DateTime(2026, 6, 1, 23, 50, 0, DateTimeKind.Utc);
+        var hours = UsageWeighting.LocalHoursSpanned(start, start.AddMinutes(80), tz); // 23:50 -> 01:10
+        hours.Should().BeEquivalentTo(new[] { 23, 0, 1 });
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/Lantiq8311OntProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Lantiq8311OntProviderTests.cs
@@ -1,0 +1,65 @@
+using FluentAssertions;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Web.Services.OntProviders;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class Lantiq8311OntProviderTests
+{
+    // Verbatim output of `pontop -g "FEC Status & Counters" -b` from a real 8311/WAS-110 (healthy link).
+    private const string HealthyFecPage =
+        "Page: FEC Status & Counters\n" +
+        "OPTION                                              VALUE\n" +
+        "FEC upstream                                       : ON\n" +
+        "FEC downstream                                     : ON\n" +
+        " \n" +
+        "BIP errors                                         : 0\n" +
+        "Total FEC codewords                                : 289895929785\n" +
+        "Corrected FEC codewords                            : 0\n" +
+        "Uncorrected FEC codewords                          : 0\n" +
+        "Corrected FEC bytes                                : 0\n" +
+        "FEC errored seconds                                : 0\n";
+
+    [Fact]
+    public void ParseFecCounters_HealthyPage_ReadsZeroFecAndBip()
+    {
+        var stats = new OntStats();
+        Lantiq8311OntProvider.ParseFecCounters(HealthyFecPage, stats);
+
+        stats.FecErrors.Should().Be(0);
+        stats.BipErrors.Should().Be(0);
+    }
+
+    [Fact]
+    public void ParseFecCounters_DegradedPage_MapsUncorrectedAndBip_IgnoresCorrected()
+    {
+        var page =
+            "Page: FEC Status & Counters\n" +
+            "BIP errors                                         : 42\n" +
+            "Total FEC codewords                                : 289895929785\n" +
+            "Corrected FEC codewords                            : 150000\n" +
+            "Uncorrected FEC codewords                          : 1234\n" +
+            "FEC errored seconds                                : 7\n";
+
+        var stats = new OntStats();
+        Lantiq8311OntProvider.ParseFecCounters(page, stats);
+
+        // FecErrors is the data-loss signal (uncorrectable), NOT the benign corrected count.
+        stats.FecErrors.Should().Be(1234);
+        stats.BipErrors.Should().Be(42);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("garbage\nno colons here\nOPTION  VALUE")]
+    [InlineData("FEC upstream                                       : ON")]
+    public void ParseFecCounters_NoNumericRows_LeavesCountersNull(string text)
+    {
+        var stats = new OntStats();
+        Lantiq8311OntProvider.ParseFecCounters(text, stats);
+
+        stats.FecErrors.Should().BeNull();
+        stats.BipErrors.Should().BeNull();
+    }
+}

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using NetworkOptimizer.Core.Models;
 using NetworkOptimizer.WiFi.Data;
 using NetworkOptimizer.WiFi.Helpers;
 using NetworkOptimizer.WiFi.Models;
@@ -29,7 +30,7 @@ public class ChannelRecommendationServiceTests
         {
             Mac = mac,
             Name = name,
-            IsOnline = true,
+            Status = new(DeviceStatusKind.Online, "Online"),
             IsMeshChild = isMeshChild,
             MeshParentMac = meshParentMac,
             MeshUplinkBand = meshUplinkBand,
@@ -74,7 +75,7 @@ public class ChannelRecommendationServiceTests
             CreateAp("aa:bb:cc:dd:ee:01", "AP-1", RadioBand.Band5GHz, 36),
             new()
             {
-                Mac = "aa:bb:cc:dd:ee:02", Name = "AP-Offline", IsOnline = false,
+                Mac = "aa:bb:cc:dd:ee:02", Name = "AP-Offline", Status = new(DeviceStatusKind.Offline, "Offline"),
                 Radios = new() { new RadioSnapshot { Band = RadioBand.Band5GHz, Channel = 36, ChannelWidth = 80 } }
             }
         };


### PR DESCRIPTION
Bundles the work merged into dev since the last release (#926, #931, #932).

## ISP Health

- **Physical Link factor (fiber / DOCSIS / cellular)** in Access Layer scoring. Grades the real physical-layer health of the WAN's access medium - PON ONT optical receive/transmit power and O5 link state, DOCSIS MER/SNR, FEC and downstream/upstream power, cellular signal - matched automatically to the configured access technology. Omitted with no penalty when nothing matches; a picker disambiguates when several sources could.
- **Outage scoring rework.** Outages now score on duration plus a per-event occurrence cost (breadth x depth), so a short but widely-felt drop and a run of repeated micro-drops both register, while a long outage still dominates. Occurrence is judged as a rate against the window, so the same few micro-drops spread over a week score lower than the same number in 48 hours.
- **Time-of-day usage weighting.** An outage during the hours you actually use the connection counts in full; one during typically-idle hours dings less, weighted by a usage fingerprint built from the WAN throughput already recorded (no new data collected).
- **ISP Health tab** now auto-reloads the latest snapshot on the live view, and the hero pill no longer says "last N" for a custom window that ends in the past.

## Wi-Fi Optimizer

- **Cross-platform mesh re-pair** and **device status indicators** that distinguish a provisioning/updating AP (not yet actionable) from an offline one, with a live refresh that bypasses the device-list cache so a freshly re-paired uplink shows immediately.

## Under the hood

- The 8311 ONT provider parses FEC/BIP counters; new UniFi device-state mapping; completed the `device.*` alert event-type index.
