### PR TITLE
v1.24.0 Release Changes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -241,6 +241,28 @@ The following were implemented in the WiFi Optimizer feature:
 
 ## Monitoring
 
+### Investigation Functions (Network Performance tab)
+The Investigate card currently jumps the latency charts to the most recent **packet-loss** and **loaded-loss** events and steps event-to-event (coalesced, peak-loss minute). Ideas to extend it:
+
+**Reuse detectors ISP Health already computes (low effort - mostly wiring existing results into `navigateToTime` + buttons):**
+- **Congestion events** - `CongestionLocalizer` already produces events with disposition (confirmed / self-inflicted / control-plane-noise) and scope (hop / ASN / shared). Add an Investigate button that jumps the latency charts to each event, with the highlight band colored shared-vs-local like the ISP Health chart. Strongest detector, currently invisible on these charts.
+- **Path-shift events** - `StepChangeDetector` already finds RTT step changes; jump to the step with a "+N ms" label.
+- **Outages** - `OutageDetector` already classifies full / partial / brief; jump to the outage window and show the recovery shape.
+- **Unify the two views** - make the ISP Health "Path & Congestion Events" timeline items deep-link into the latency charts (the way the loss findings now do via `?investigate=`).
+
+**New detections (more work):**
+- **Bufferbloat events** - loaded *latency* spikes (the `latencyTriggered` signal), distinct from loaded loss; bufferbloat often has zero loss, so the loss buttons miss it.
+- **Jitter spikes** - sustained P95 jitter excursions.
+- **Saturation events** - when WAN throughput pegged at/over the configured plan; pairs with loaded loss to answer "was the line actually maxed."
+
+**UX upgrades to what exists:**
+- **"Worst in window" vs "most recent"** - a jump-to-peak mode that lands on the highest-loss event directly instead of stepping from the latest.
+- **Verdict line on landing** - when landing on a loss event, append what it was (loaded vs idle, which hop/ASN, congestion disposition) so "0.7% loss" becomes "0.7% loss, self-inflicted bufferbloat at your access egress." The localizer already computes this.
+- **Per-target investigate** - click a target in the stats table to step through just that target's events.
+
+Suggested order: congestion / path-shift / outage navigation first (cheap, consistent), then the verdict line (makes every investigation land with an explanation, not just a number).
+- **Relevant code:** `MonitoringInfluxClient.FindRecentLossEventAsync` / `FindRecentLoadedLossEventAsync` (+ `SelectBoundaryEvent` coalescing), `Monitoring.razor` Investigate card + `NavigateToLossEvent`, `latency-charts.js` `navigateToTime` / `buildInvestigateAnnotations`, `IspHealthService` (`CongestionLocalizer`, `StepChangeDetector`, `OutageDetector` outputs already on the report).
+
 ### Multi-WAN Support (ISP Health & NMS)
 - ISP Health currently grades a single (primary) WAN. Several inputs are read globally rather than scoped to the WAN being scored:
   - **Upstream ancestry / `hopOrderKnown`** (`IspHealthService.ComputeAsync`): `UpstreamDiscoveries` are queried across all WANs. Rows carry `WanInterface`, and the tracer persists per-WAN, but the scorer reads them globally - so a second WAN's discovery data can flip the jitter-absolve gate (and the routes-through witnesses) for a WAN that has no ancestry of its own. Scope the discovery query and `hopOrderKnown` by `WanInterface`.

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,53 @@
 # Network Optimizer - TODO / Future Enhancements
 
+## Channel Recommendation: Engine-Review Follow-ups (recalibration-sensitive)
+
+**PICK UP HERE next session.** Branch `bugfix/channelrec-altruism`. Everything below is TABLED for the
+current release - none are release-critical (the only finding that produced an actual invalid output,
+#4's net-worse recommendation, is fixed + guardrailed). These remaining items shift the recommendation
+DISTRIBUTION and the gate thresholds are calibrated to current behavior, so each needs a live
+before/after on the NAS + Mac sites (and ideally a fleet sample), not a blind edit.
+
+**Already shipped on this branch (baseline, deployed to NAS + Mac):**
+- Measured floor #2 (candidate-only, proximity-weighted sibling, gate-scaled); propagated stress split
+  from measured `HistoricalStress`; DFS penalty span-aware; per-AP fallback baseline fix.
+- Spectrum-scan noise floor wired into scoring (mean-util / worst-noise, verified vs UniFi BW160);
+  scans run at the radio's live BW; `ScanChannelData` keyed by (channel, width) with span aggregation.
+- Cross-vantage: an AP's CURRENT channel is scored from the closest off-channel sibling, not its own
+  self-contaminated read (mesh/camera traffic that follows the AP).
+- Net-worse guardrail + fallback net-benefit on `ScoreAssignment` (finding #4, largely done).
+- Win 1: gap-aware quick-scan prompt (value-first copy, mesh APs excluded, warning tailored by
+  `HasDedicatedScanRadio` + mesh role); disclaimer auto-hides when no scan gaps.
+
+**Remaining engine findings (tabled):**
+
+- [~] **Inconsistent objective (sum-of-ScoreAp vs ScoreAssignment).** The search minimizes
+  `ScoreAssignment` (each internal pair counted once, symmetric). The auxiliary passes sum `ScoreAp`
+  deltas, which count each internal pair ~2x - so a move the search rejected can be re-approved on an
+  inconsistent yardstick. **Largely fixed:** the per-AP fallback now uses the `ScoreAssignment` delta
+  for its net-benefit check + selection, and a global guardrail drops any final plan whose network
+  score is worse than current (this hit live as a net-worse recommendation, Front Yard ch1->ch6).
+  Remaining (lower priority now, backstopped by the guardrail): the altruistic "others" and comfort
+  passes still use sum-of-`ScoreAp` internally - convert them too for cleanliness.
+- [ ] **Position-dependence in the post-passes.** Per-AP fallback, altruistic, crowding, and comfort
+  all loop in AP array order and mutate the plan in place, so earlier APs shift later APs' baselines.
+  The main search is most-constrained-first; the post-passes aren't. Fix: order them deterministically
+  by something meaningful (e.g. current score, most-constrained) and add a current-channel tiebreak
+  when candidates are near-tied (the greedy phase already does this).
+- [ ] **Global avg-improvement gate doesn't actually prevent churn.** When avg improvement <
+  threshold the plan reverts to current, but the per-AP fallback and altruistic passes then run on the
+  reverted plan and can still introduce moves. Decide intent: should "network not worth touching" be a
+  hard stop on all per-AP moves too? (Design call - confirm desired behavior before changing.)
+- [ ] **Threshold-cliff churn.** All the gates are hard cliffs evaluated against scores driven by the
+  rogue scan (a few dB of snapshot variance can flip a recommendation on/off between runs). Determinism
+  protects against algorithmic randomness, not input variance. Fix: hysteresis / a dead-band on the
+  move decision, or smoothing the external input over multiple snapshots. (Feature-sized.)
+- [ ] **Width double-discount.** In `BuildExternalLoad` a narrow neighbor inside a wider victim is
+  scaled by the width ratio (0.25x for 20-in-80) AND stored only on its narrow sub-channel - but in
+  OFDM a 20 MHz interferer makes the whole 80 MHz block CCA-busy. The common case is under-weighted.
+  Fix: a narrower-than-victim interferer should count against the full overlapping span without the
+  width-ratio discount. Shifts external magnitudes - re-validate.
+
 ## LAN Speed Test
 
 ### Path Analysis Enhancements
@@ -603,3 +651,58 @@ knows the swap is actually worse for util/interference. The "improvement" came a
 - [ ] When a candidate assignment matches a previously-tried combo, prefer measured outcome over inferred score
 - [ ] Down-weight (or flag) recommendations whose predicted gain rests mostly on propagated stress
 - [ ] Distinguish self-induced load from environmental interference - don't credit a move for escaping the AP's own traffic
+
+## Channel Recommendation: Spectrum-Scan UX (background / on-demand quick-scans)
+
+We now read per-channel measured occupancy from UniFi's `stat/spectrum-scan/{mac}` and can trigger
+scans via `cmd/devmgr` quick-scan (`UniFiApiClient.TriggerQuickScanAsync`). A quick-scan does NOT
+disconnect clients (the association stays up - only a FULL scan drops clients), BUT it briefly steps
+each radio off its channel, so real-time traffic (video calls, gaming, an active speed test) can
+hiccup for a moment - verified live (an iperf3 run died mid-scan; Wi-Fi stayed connected). It's also
+slow per band per AP, so we never run it inline with a recommendation. The recommender reads whatever
+scan results are cached; a band/AP with no recent scan falls back to the neighbor-scan (external)
+proxy. UX should be honest: "clients stay connected, but real-time traffic may briefly hiccup -
+best run during low-usage times" (NOT "won't disrupt"). Mesh/wireless-uplink APs can't quick-scan at
+all (controller refuses - it'd drop their uplink), so exclude them from gap prompts.
+
+Shared piece to build once: a "trigger -> poll `quick_scan_state.in_progress` until done -> read
+results -> re-run rec" helper. Expose the trigger through `IWiFiDataProvider` (it currently lives
+only on `UniFiApiClient`).
+
+- [x] **Win 1 (gap-aware prompt)** - DONE & shipped. Gap banner offers a one-click quick scan of the
+  gapped (AP, band)s (mesh APs excluded, per-AP-serial/cross-AP-parallel, scans at live BW), polls,
+  re-runs. Warning tailored by `HasDedicatedScanRadio` + mesh role; disclaimer auto-hides when no gaps.
+- [ ] **Win 2 (staleness + manual "Refresh measurements" button)** - can wait for a PATCH after this
+  minor release: there's a natural window between when people pick up the feature and when their scan
+  data goes stale, so no rush. Two parts:
+  1. *Staleness:* scan data currently never expires - the provider stamps `ScanTime = fetch-time`
+     (not the real scan time), so a days-old scan reads as fresh and never becomes a gap. Propagate the
+     real `spectrum_table_time` into `ChannelScanResult.ScanTime`, then treat an (AP, band) as a gap if
+     missing OR older than a threshold (~7 days). The gap banner then reappears on its own for stale
+     radios. Low effort, no recalibration risk.
+  2. *Manual refresh button* in the same banner area: stagger a quick-scan across all APs (reuse
+     `RunQuickScansAsync`), re-run when done. Harmless, cheap.
+- [ ] **Win 3 (scheduled off-peak sweep)** - background job that sweeps quick-scans across APs/bands
+  during low-utilization hours, determined from the 1d/7d historic stress we already compute. Stagger
+  ONE band at a time PER AP (parallel across APs - a radio scans one band at a time); never take the
+  whole site's airtime off-channel at once. Spectrum cache stays fresh, recommendations always
+  well-grounded, zero user action.
+  - **Scan-hardware-aware scheduling (use `HasDedicatedScanRadio`):** APs with a dedicated all-band
+    scan radio (verified: phy reports Band 1+2+4) scan with ZERO disruption to clients or mesh
+    uplinks - so scan those freely/immediately, anytime. Only serving-radio APs (no scan radio) need
+    the off-peak window. Mesh parents WITHOUT a scan radio are the most disruptive (scanning the uplink
+    band drops children) - schedule those most conservatively or skip their uplink band.
+- [ ] **Deep-analysis mode (premium, user-initiated)** - trigger fresh scans on ALL radios, wait,
+  then recommend on fully-measured data. Best accuracy, slow (minutes); distinct from the fast
+  everyday rec.
+- [ ] **Large-deployment UX / verbiage (> ~8 APs).** The gap prompt, manual refresh, and rec copy are
+  tuned for small sites. At higher AP counts revisit:
+  - *Scan flow:* running quick scans across many APs is slow even parallel-across-APs, and it currently
+    blocks the Blazor circuit with a spinner. Background it with real progress (per-AP/percent), or
+    batch and let the rec refresh incrementally.
+  - *Verbiage/counts:* "N radios haven't been scanned" and the gap banner read fine for 3-5 radios but
+    get unwieldy at 20+; consider summarizing ("most radios", grouped by AP, collapsible detail).
+  - *Rec table density* and "How This Works" at scale.
+  - *Perf (profile, don't assume):* the per-AP fallback recomputes `ScoreAssignment` per candidate and
+    `ScanReadingForScoring` loops siblings for current-channel reads - both negligible at small n but
+    worth checking on large sites before they bite.

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -1999,7 +1999,6 @@ from(bucket: ""{_longtermBucket}"")
 
         var rangeStart = after ?? DateTime.UtcNow.AddDays(-30);
         var rangeStop = before ?? DateTime.UtcNow;
-        var sortDesc = !after.HasValue;
 
         var targetFilter = "";
         if (enabledTargetIds != null && enabledTargetIds.Count > 0)
@@ -2008,6 +2007,9 @@ from(bucket: ""{_longtermBucket}"")
             targetFilter = $"\n  |> filter(fn: (r) => {conditions})";
         }
 
+        // Pull every qualifying loss minute in the window time-ascending, then coalesce into
+        // events in memory. The caller bounds the window to just before/after the current event
+        // (via before/after), so the boundary event we want is fully inside the range.
         var flux = $@"
 from(bucket: ""{_bucket}"")
   |> range(start: {ToFluxInstant(rangeStart)}, stop: {ToFluxInstant(rangeStop)})
@@ -2017,24 +2019,18 @@ from(bucket: ""{_bucket}"")
   |> aggregateWindow(every: 1m, fn: mean, createEmpty: false)
   |> filter(fn: (r) => r._value > 1.0)
   |> group()
-  |> sort(columns: [""_time""], desc: {(sortDesc ? "true" : "false")})
-  |> limit(n: 1)
+  |> sort(columns: [""_time""], desc: false)
 ";
+        var minutes = new List<LossMinute>();
         await foreach (var record in QueryFluxAsync(flux, ct))
         {
             var time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow);
             var targetId = record.GetValueByKey("target_id") as string;
             var targetType = record.GetValueByKey("target_type") as string ?? "internetservice";
-            var loss = AsDoubleOrNull(record.GetValueByKey("_value"));
-            return new RecentLossEvent
-            {
-                Timestamp = time,
-                TargetType = targetType,
-                TargetId = targetId,
-                LossPercent = loss ?? 0
-            };
+            var loss = AsDoubleOrNull(record.GetValueByKey("_value")) ?? 0;
+            minutes.Add(new LossMinute(time, loss, targetId, targetType));
         }
-        return null;
+        return SelectBoundaryEvent(minutes, pickEarliest: after.HasValue);
     }
 
     /// <summary>
@@ -2057,7 +2053,6 @@ from(bucket: ""{_bucket}"")
 
         var rangeStart = after ?? DateTime.UtcNow.AddDays(-30);
         var rangeStop = before ?? DateTime.UtcNow;
-        var sortDesc = !after.HasValue;
 
         var targetFilter = "";
         if (enabledTargetIds != null && enabledTargetIds.Count > 0)
@@ -2094,24 +2089,18 @@ load = from(bucket: ""{_bucket}"")
   |> unique(column: ""_time"")
 
 join.inner(left: loss, right: load, on: (l, r) => l._time == r._time, as: (l, r) => l)
-  |> sort(columns: [""_time""], desc: {(sortDesc ? "true" : "false")})
-  |> limit(n: 1)
+  |> sort(columns: [""_time""], desc: false)
 ";
+        var minutes = new List<LossMinute>();
         await foreach (var record in QueryFluxAsync(flux, ct))
         {
             var time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow);
             var targetId = record.GetValueByKey("target_id") as string;
             var targetType = record.GetValueByKey("target_type") as string ?? "internetservice";
-            var loss = AsDoubleOrNull(record.GetValueByKey("_value"));
-            return new RecentLossEvent
-            {
-                Timestamp = time,
-                TargetType = targetType,
-                TargetId = targetId,
-                LossPercent = loss ?? 0
-            };
+            var loss = AsDoubleOrNull(record.GetValueByKey("_value")) ?? 0;
+            minutes.Add(new LossMinute(time, loss, targetId, targetType));
         }
-        return null;
+        return SelectBoundaryEvent(minutes, pickEarliest: after.HasValue);
     }
 
     /// <summary>
@@ -2155,10 +2144,69 @@ from(bucket: ""{_longtermBucket}"")
 
     public record RecentLossEvent
     {
+        /// <summary>The peak-loss minute of the coalesced event, used to center the chart.</summary>
         public required DateTime Timestamp { get; init; }
         public required string TargetType { get; init; }
         public string? TargetId { get; init; }
         public double LossPercent { get; init; }
+
+        /// <summary>First and last loss minute of the coalesced event. Stepping back queries
+        /// strictly before <see cref="EventStart"/>; stepping forward strictly after
+        /// <see cref="EventEnd"/>, so a sustained loss burst is one stop, not many.</summary>
+        public DateTime EventStart { get; init; }
+        public DateTime EventEnd { get; init; }
+    }
+
+    /// <summary>One qualifying loss minute before coalescing into an event.</summary>
+    private readonly record struct LossMinute(DateTime Time, double Loss, string? TargetId, string TargetType);
+
+    /// <summary>Loss minutes more than this far apart start a new event. Set to one minute so
+    /// only truly adjacent minutes coalesce; a single clean minute (load/loss dropping out, then
+    /// resuming) splits the burst, keeping back-to-back transfer spikes as distinct events.</summary>
+    private static readonly TimeSpan LossEventCoalesceGap = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Coalesce time-ascending loss minutes into events (gap &lt;= <see cref="LossEventCoalesceGap"/>)
+    /// and return the boundary event represented by its peak-loss minute: the earliest event when
+    /// stepping forward (<paramref name="pickEarliest"/>), else the latest. Stepping by event, not
+    /// by minute, keeps a multi-minute burst from fragmenting into separate stops.
+    /// </summary>
+    private static RecentLossEvent? SelectBoundaryEvent(List<LossMinute> minutes, bool pickEarliest)
+    {
+        if (minutes.Count == 0) return null;
+
+        var eventStart = minutes[0].Time;
+        var eventEnd = minutes[0].Time;
+        var peak = minutes[0];
+        var events = new List<(DateTime Start, DateTime End, LossMinute Peak)>();
+        for (var i = 1; i < minutes.Count; i++)
+        {
+            var m = minutes[i];
+            if (m.Time - eventEnd > LossEventCoalesceGap)
+            {
+                events.Add((eventStart, eventEnd, peak));
+                eventStart = m.Time;
+                eventEnd = m.Time;
+                peak = m;
+            }
+            else
+            {
+                eventEnd = m.Time;
+                if (m.Loss > peak.Loss) peak = m;
+            }
+        }
+        events.Add((eventStart, eventEnd, peak));
+
+        var chosen = pickEarliest ? events[0] : events[^1];
+        return new RecentLossEvent
+        {
+            Timestamp = chosen.Peak.Time,
+            TargetType = chosen.Peak.TargetType,
+            TargetId = chosen.Peak.TargetId,
+            LossPercent = chosen.Peak.Loss,
+            EventStart = chosen.Start,
+            EventEnd = chosen.End,
+        };
     }
 
     public record RecentSfpAnomaly

--- a/src/NetworkOptimizer.UniFi/Helpers/RadioAiSettings.cs
+++ b/src/NetworkOptimizer.UniFi/Helpers/RadioAiSettings.cs
@@ -1,0 +1,101 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NetworkOptimizer.Core;
+using NetworkOptimizer.UniFi.Models;
+
+namespace NetworkOptimizer.UniFi.Helpers;
+
+/// <summary>
+/// A single per-radio entry from the UniFi "radio_ai" setting's radios_configuration array.
+/// </summary>
+[VendorSpecific("UniFi", "Parses radio_ai.radios_configuration entries from UniFi settings JSON")]
+public class RadioAiRadioConfig
+{
+    /// <summary>
+    /// Radio band identifier: "ng" (2.4 GHz), "na" (5 GHz), "6e" (6 GHz).
+    /// </summary>
+    [JsonPropertyName("radio")]
+    public string? Radio { get; set; }
+
+    /// <summary>
+    /// Whether the console's Auto-Optimize (RF Scanning) feature is allowed to use
+    /// DFS channels on this radio. May arrive as a bool, string, or 0/1 number.
+    /// </summary>
+    [JsonPropertyName("dfs")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
+    public bool Dfs { get; set; }
+
+    /// <summary>
+    /// Configured channel width (MHz) for this radio.
+    /// </summary>
+    [JsonPropertyName("channel_width")]
+    [JsonConverter(typeof(FlexibleIntConverter))]
+    public int? ChannelWidth { get; set; }
+}
+
+/// <summary>
+/// Resolved UniFi "radio_ai" (Auto-Optimize / RF Scanning) settings.
+/// Exposes the per-radio DFS preference so the channel recommender can default
+/// its DFS toggle to match how the console is configured.
+/// </summary>
+[VendorSpecific("UniFi", "Parses UniFi settings JSON 'data' array with 'key' discriminator (radio_ai)")]
+public class RadioAiSettings
+{
+    /// <summary>UniFi radio identifier for the 5 GHz band.</summary>
+    public const string Radio5GHz = "na";
+
+    private IReadOnlyList<RadioAiRadioConfig> RadiosConfiguration { get; init; } = Array.Empty<RadioAiRadioConfig>();
+
+    /// <summary>
+    /// Parse from settings JSON (the root response from GetSettingsRawAsync).
+    /// Looks for the "radio_ai" object in the data array.
+    /// Returns null if settings unavailable or the radio_ai key is absent.
+    /// </summary>
+    public static RadioAiSettings? FromSettingsJson(JsonDocument? settingsData)
+    {
+        if (settingsData == null)
+            return null;
+
+        if (!settingsData.RootElement.TryGetProperty("data", out var data) ||
+            data.ValueKind != JsonValueKind.Array)
+            return null;
+
+        foreach (var item in data.EnumerateArray())
+        {
+            if (!item.TryGetProperty("key", out var key) ||
+                key.GetString() != "radio_ai")
+                continue;
+
+            var radios = new List<RadioAiRadioConfig>();
+            if (item.TryGetProperty("radios_configuration", out var radiosConfig) &&
+                radiosConfig.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var radio in radiosConfig.EnumerateArray())
+                {
+                    var parsed = radio.Deserialize<RadioAiRadioConfig>();
+                    if (parsed != null)
+                        radios.Add(parsed);
+                }
+            }
+
+            return new RadioAiSettings { RadiosConfiguration = radios };
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Whether DFS channels are enabled in the console's Auto-Optimize configuration
+    /// for the given radio (e.g. "na" for 5 GHz). Returns null when the radio is absent
+    /// so callers can fall back to their own default.
+    /// </summary>
+    public bool? GetDfsEnabled(string radio)
+    {
+        foreach (var cfg in RadiosConfiguration)
+        {
+            if (string.Equals(cfg.Radio, radio, StringComparison.OrdinalIgnoreCase))
+                return cfg.Dfs;
+        }
+        return null;
+    }
+}

--- a/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
@@ -1346,6 +1346,36 @@ public class ScanRadioEntry
     /// </summary>
     [JsonPropertyName("spectrum_table")]
     public List<SpectrumEntry>? SpectrumTable { get; set; }
+
+    /// <summary>Unix time (seconds) the spectrum_table was last populated.</summary>
+    [JsonPropertyName("spectrum_table_time")]
+    public long? SpectrumTableTime { get; set; }
+}
+
+/// <summary>
+/// Response item from GET /api/s/{site}/stat/spectrum-scan/{mac} - per-AP RF spectrum scan
+/// results (per-channel utilization/interference across each band), held from the AP's last scan.
+/// </summary>
+public class UniFiSpectrumScanResponse
+{
+    [JsonPropertyName("mac")]
+    public string Mac { get; set; } = string.Empty;
+
+    /// <summary>One entry per radio (radio = "ng"/"na"/"6e"), each with its own spectrum_table.</summary>
+    [JsonPropertyName("scans")]
+    public List<ScanRadioEntry>? Scans { get; set; }
+
+    /// <summary>State of the most recent quick-scan on this AP (whether one is still running).</summary>
+    [JsonPropertyName("quick_scan_state")]
+    public UniFiQuickScanState? QuickScanState { get; set; }
+}
+
+/// <summary>Quick-scan progress state from the spectrum-scan endpoint.</summary>
+public class UniFiQuickScanState
+{
+    /// <summary>True while a quick-scan is still in progress (results not yet final).</summary>
+    [JsonPropertyName("in_progress")]
+    public bool InProgress { get; set; }
 }
 
 /// <summary>
@@ -1372,10 +1402,18 @@ public class SpectrumEntry
     public int? Utilization { get; set; }
 
     /// <summary>
-    /// Interference level
+    /// Interference level (dBm noise/interference floor for the channel)
     /// </summary>
     [JsonPropertyName("interference")]
     public int? Interference { get; set; }
+
+    /// <summary>Number of other BSSIDs the scan detected on this channel.</summary>
+    [JsonPropertyName("other_bss_count")]
+    public int? OtherBssCount { get; set; }
+
+    /// <summary>Number of samples the scan collected for this channel (0 = stale/unsampled).</summary>
+    [JsonPropertyName("total_samples")]
+    public int? TotalSamples { get; set; }
 
     /// <summary>
     /// Whether this is a DFS channel

--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -2413,6 +2413,65 @@ public class UniFiApiClient : IDisposable
         return new List<UniFiRogueApResponse>();
     }
 
+    /// <summary>
+    /// GET /api/s/{site}/stat/spectrum-scan/{mac} - per-AP RF spectrum scan results held from the
+    /// AP's last scan (per-channel utilization % / interference dBm across each band). Returns null
+    /// if the AP has no cached scan or the call fails. Does NOT trigger a scan - see
+    /// <see cref="TriggerQuickScanAsync"/>.
+    /// </summary>
+    public async Task<UniFiSpectrumScanResponse?> GetSpectrumScanAsync(
+        string apMac,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await ExecuteApiCallAsync<UniFiApiResponse<UniFiSpectrumScanResponse>>(
+            () => _httpClient!.GetAsync(BuildApiPath($"stat/spectrum-scan/{apMac}"), cancellationToken),
+            cancellationToken);
+
+        if (response?.Meta.Rc == "ok")
+            return response.Data.FirstOrDefault();
+
+        _logger.LogDebug("No cached spectrum scan for AP {Mac}", apMac);
+        return null;
+    }
+
+    /// <summary>
+    /// POST /api/s/{site}/cmd/devmgr - trigger a quick RF spectrum scan on an AP's band. A quick
+    /// scan does NOT disconnect clients (unlike a full scan), but it still takes time per band, so
+    /// this is intended for background/scheduled refresh - never inline with a recommendation
+    /// request. Read the results later via <see cref="GetSpectrumScanAsync"/>.
+    /// </summary>
+    /// <param name="apMac">AP MAC address.</param>
+    /// <param name="band">UniFi band code: "ng" (2.4 GHz), "na" (5 GHz), "6e" (6 GHz).</param>
+    /// <param name="bandwidthMhz">Scan bandwidth in MHz (e.g. 20).</param>
+    public async Task<bool> TriggerQuickScanAsync(
+        string apMac,
+        string band,
+        int bandwidthMhz = 20,
+        CancellationToken cancellationToken = default)
+    {
+        var body = new Dictionary<string, object>
+        {
+            ["mac"] = apMac,
+            ["scan-band"] = band,
+            ["scan-bw"] = bandwidthMhz,
+            ["cmd"] = "quick-scan"
+        };
+        var content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
+
+        var response = await ExecuteApiCallAsync<UniFiApiResponse<object>>(
+            () => _httpClient!.PostAsync(BuildApiPath("cmd/devmgr"), content, cancellationToken),
+            cancellationToken);
+
+        if (response?.Meta.Rc == "ok")
+        {
+            _logger.LogDebug("Triggered quick scan on AP {Mac} band {Band}", apMac, band);
+            return true;
+        }
+
+        _logger.LogWarning("Failed to trigger quick scan on AP {Mac} band {Band}", apMac, band);
+        return false;
+    }
+
     #endregion
 
     #region Threat Management APIs

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
@@ -641,6 +641,7 @@
     private int _selectedServerId;
     private bool _loading;
     private List<Iperf3Result> _results = new();
+    private (int Count, int MaxId) _resultsSignature;
     private int _expandedId;
     private int _page = 1;
     private const int PageSize = 20;
@@ -743,8 +744,10 @@
             {
                 await InvokeAsync(async () =>
                 {
-                    await LoadResults();
-                    await RenderActiveChart();
+                    if (await LoadResults())
+                        await RenderActiveChart();
+                    else
+                        StateHasChanged();
                 });
             }
             catch { }
@@ -763,14 +766,18 @@
         return server?.Name ?? serverId;
     }
 
-    private async Task LoadResults()
+    private async Task<bool> LoadResults()
     {
         _loading = true;
         try
         {
             _results = await ClientSpeedTestService.GetWanResultsAsync(200);
+            var signature = (_results.Count, _results.Count == 0 ? 0 : _results.Max(r => r.Id));
+            var changed = signature != _resultsSignature;
+            _resultsSignature = signature;
             TransformChartData();
             ApplyChartFilters();
+            return changed;
         }
         finally
         {

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
@@ -744,7 +744,7 @@
                 await InvokeAsync(async () =>
                 {
                     await LoadResults();
-                    StateHasChanged();
+                    await RenderActiveChart();
                 });
             }
             catch { }

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -321,8 +321,50 @@ else
             @UpstreamReviewBanner
         }
 
+        <!-- Quick investigation -->
+        <div class="card">
+            <div class="card-header card-header-collapsible" @onclick="ToggleInvestigateCollapse">
+                <h2 class="card-title"><img src="/icons/port-scan.png" alt="" class="card-title-icon" />Investigate</h2>
+                <span class="issue-type-chevron">@(_investigateCollapsed ? "▼" : "▲")</span>
+            </div>
+            <div class="expand-wrapper @(!_investigateCollapsed && _investigateStateLoaded ? "expanded" : "")" style="@(!_investigateStateLoaded ? "display:none" : "")">
+            <div class="expand-content">
+            <div class="card-body" style="display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center;">
+                @if (_lossNavActive)
+                {
+                    <button class="btn btn-sm btn-secondary loss-nav-arrow" @onclick="LossNavBack" disabled="@_investigatingLoss"
+                            data-tooltip="Previous loss event">&#x25C0;</button>
+                    <button class="btn btn-primary" @onclick="LossNavDeactivate"
+                            data-tooltip="Exit @(_lossNavLoadedOnly ? "loaded" : "packet") loss investigation">
+                        @(_lossNavLoadedOnly ? "Loaded Loss Events" : "Packet Loss Events")
+                    </button>
+                    <button class="btn btn-sm btn-secondary loss-nav-arrow" @onclick="LossNavForward" disabled="@_investigatingLoss"
+                            data-tooltip="Next loss event">&#x25B6;</button>
+                }
+                else
+                {
+                    <button class="btn btn-secondary" @onclick="InvestigatePacketLoss" disabled="@_investigatingLoss"
+                            data-tooltip="Find the most recent packet loss event across ISP, Transit, and Internet targets and jump to it on the chart">
+                        @if (_investigatingLoss && !_lossNavLoadedOnly) { <span class="spinner-sm"></span> }
+                        else { <span>Packet Loss Events</span> }
+                    </button>
+                    <button class="btn btn-secondary" @onclick="InvestigateLoadedLoss" disabled="@_investigatingLoss"
+                            data-tooltip="Find the most recent loss event that happened while the WAN was under load - the SQM/bufferbloat signal">
+                        @if (_investigatingLoss && _lossNavLoadedOnly) { <span class="spinner-sm"></span> }
+                        else { <span>Loaded Loss Events</span> }
+                    </button>
+                }
+                @if (!string.IsNullOrEmpty(_lossInvestigateResult))
+                {
+                    <span class="page-description" style="align-self: center;">@_lossInvestigateResult</span>
+                }
+            </div>
+            </div>
+            </div>
+        </div>
+
         <!-- Latency time-series charts -->
-        <div class="card" id="latency-charts-container">
+        <div class="card" id="latency-charts-container" style="margin-top: 1.5rem;">
             <div class="card-header monitoring-chart-header">
                 <h2 class="card-title">Latency &amp; Packet Loss</h2>
                 <div style="display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap;">
@@ -382,43 +424,6 @@ else
                     <div class="latency-wan-rate-chart"></div>
                 </div>
                 <div class="latency-stats-table"></div>
-            </div>
-        </div>
-
-        <!-- Quick investigation -->
-        <div class="card" style="margin-top: 1.5rem;">
-            <div class="card-header">
-                <h2 class="card-title">Investigate</h2>
-            </div>
-            <div class="card-body" style="display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center;">
-                @if (_lossNavActive)
-                {
-                    <button class="btn btn-sm btn-secondary" @onclick="LossNavBack" disabled="@_investigatingLoss"
-                            data-tooltip="Previous loss event">&#x25C0;</button>
-                    <button class="btn btn-primary" @onclick="LossNavDeactivate"
-                            data-tooltip="Exit @(_lossNavLoadedOnly ? "loaded" : "packet") loss investigation">
-                        @(_lossNavLoadedOnly ? "Loaded Loss Events" : "Packet Loss Events")
-                    </button>
-                    <button class="btn btn-sm btn-secondary" @onclick="LossNavForward" disabled="@_investigatingLoss"
-                            data-tooltip="Next loss event">&#x25B6;</button>
-                }
-                else
-                {
-                    <button class="btn btn-secondary" @onclick="InvestigatePacketLoss" disabled="@_investigatingLoss"
-                            data-tooltip="Find the most recent packet loss event across ISP, Transit, and Internet targets and jump to it on the chart">
-                        @if (_investigatingLoss && !_lossNavLoadedOnly) { <span class="spinner-sm"></span> }
-                        else { <span>Packet Loss Events</span> }
-                    </button>
-                    <button class="btn btn-secondary" @onclick="InvestigateLoadedLoss" disabled="@_investigatingLoss"
-                            data-tooltip="Find the most recent loss event that happened while the WAN was under load - the SQM/bufferbloat signal">
-                        @if (_investigatingLoss && _lossNavLoadedOnly) { <span class="spinner-sm"></span> }
-                        else { <span>Loaded Loss Events</span> }
-                    </button>
-                }
-                @if (!string.IsNullOrEmpty(_lossInvestigateResult))
-                {
-                    <span class="page-description" style="align-self: center;">@_lossInvestigateResult</span>
-                }
             </div>
         </div>
 
@@ -617,7 +622,7 @@ else
         <!-- SFP investigation -->
         <div class="card" style="margin-top: 1.5rem;">
             <div class="card-header">
-                <h2 class="card-title">Investigate</h2>
+                <h2 class="card-title"><img src="/icons/port-scan.png" alt="" class="card-title-icon" />Investigate</h2>
             </div>
             <div class="card-body" style="display: flex; gap: 0.75rem; flex-wrap: wrap;">
                 <button class="btn btn-secondary" @onclick="InvestigateSfpAnomaly" disabled="@_investigatingSfp"
@@ -1391,6 +1396,10 @@ else
     private string? _pendingInvestigateParam;
     private bool _lossNavActive;
     private DateTime? _lossNavTimestamp;
+    // Bounds of the current coalesced loss event, so back/forward step past the whole event
+    // rather than minute-by-minute through it.
+    private DateTime? _lossNavEventStart;
+    private DateTime? _lossNavEventEnd;
 
     private static readonly HashSet<string> ValidTabs = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -1616,6 +1625,15 @@ else
     private bool _tempThresholdsSaved;
     private bool _deviceTempCollapsed = true;
     private bool _sfpThresholdsCollapsed = true;
+    // Investigate card collapse, persisted to localStorage like the Monitoring Interfaces card.
+    // _investigateCollapsed is the live (possibly force-opened) state; _investigateSavedCollapsed
+    // is the user's persisted preference. A deep-linked investigation force-opens the live state
+    // only, and leaving the tab reverts to the saved preference, so the link never counts as a
+    // user-set expand.
+    private bool _investigateCollapsed = true;
+    private bool _investigateSavedCollapsed = true;
+    private bool _investigateStateLoaded;
+    private const string InvestigateCollapseKey = "monitoring-investigate-collapsed";
 
     // Clear the transient "Saved" confirmations so they don't linger after the
     // user edits a field or navigates back into the tab.
@@ -2670,19 +2688,46 @@ else
 
     // ─── Investigation ───
 
+    private async Task ToggleInvestigateCollapse()
+    {
+        _investigateCollapsed = !_investigateCollapsed;
+        // A manual toggle is a real preference: update the saved baseline too, so leaving the
+        // tab (which reverts to the baseline) keeps the user's choice rather than undoing it.
+        _investigateSavedCollapsed = _investigateCollapsed;
+        try { await JS.InvokeVoidAsync("localStorage.setItem", InvestigateCollapseKey, _investigateCollapsed ? "true" : "false"); }
+        catch { }
+    }
+
     private Task InvestigatePacketLoss() => NavigateToLossEvent(null, null, loadedOnly: false);
     private Task InvestigateLoadedLoss() => NavigateToLossEvent(null, null, loadedOnly: true);
-    private Task LossNavBack() => _lossNavTimestamp.HasValue
-        ? NavigateToLossEvent(_lossNavTimestamp.Value.AddMinutes(-1), null, _lossNavLoadedOnly) : Task.CompletedTask;
-    private Task LossNavForward() => _lossNavTimestamp.HasValue
-        ? NavigateToLossEvent(null, _lossNavTimestamp.Value.AddMinutes(1), _lossNavLoadedOnly) : Task.CompletedTask;
+    // Step to the previous/next distinct event by querying strictly outside the current
+    // event's bounds, so a multi-minute burst is one stop rather than one stop per minute.
+    // The 1-minute aggregateWindow buckets are stamped at their STOP edge, so the bucket at
+    // EventStart holds data from the minute before it; an exclusive range stop at EventStart
+    // would still return that bucket. Step back a full minute so the current event's first
+    // bucket is actually excluded (the coalesce gap guarantees the previous event is >= 2 min
+    // earlier, so it is never dropped). Forward needs no such fudge: the current event's data
+    // all precedes the EventEnd stamp, so an inclusive start just past EventEnd excludes it.
+    private Task LossNavBack() => _lossNavEventStart.HasValue
+        ? NavigateToLossEvent(_lossNavEventStart.Value.AddMinutes(-1), null, _lossNavLoadedOnly) : Task.CompletedTask;
+    private Task LossNavForward() => _lossNavEventEnd.HasValue
+        ? NavigateToLossEvent(null, _lossNavEventEnd.Value.AddSeconds(1), _lossNavLoadedOnly) : Task.CompletedTask;
 
-    private async Task LossNavDeactivate()
+    // Clear the loss-investigation state (no chart call). Used both by the Exit button and
+    // when leaving the performance tab, so the card never shows "active" without a live chart.
+    private void ResetLossNavState()
     {
         _lossNavActive = false;
         _lossNavTimestamp = null;
+        _lossNavEventStart = null;
+        _lossNavEventEnd = null;
         _lossInvestigateResult = null;
         _lossNavLoadedOnly = false;
+    }
+
+    private async Task LossNavDeactivate()
+    {
+        ResetLossNavState();
         StateHasChanged();
         await JS.InvokeVoidAsync("eval", "window.__latencyCharts?.restoreState();");
     }
@@ -2729,6 +2774,8 @@ else
             };
             _lossNavActive = true;
             _lossNavTimestamp = result.Timestamp;
+            _lossNavEventStart = result.EventStart;
+            _lossNavEventEnd = result.EventEnd;
             var delta = DateTime.UtcNow - result.Timestamp;
             var ago = delta.TotalMinutes < 60 ? $"{(int)delta.TotalMinutes}m ago"
                 : delta.TotalHours < 24 ? $"{(int)delta.TotalHours}h ago"
@@ -2736,8 +2783,9 @@ else
             var localTime = result.Timestamp.ToLocalTime().ToString("M/d h:mm tt");
             _lossInvestigateResult = $"{result.LossPercent:0.#}% loss {ago} ({localTime})";
             StateHasChanged();
+            var annotationLabel = $"{(loadedOnly ? "Loaded" : "Packet")} loss {result.LossPercent:0.#}%";
             await JS.InvokeVoidAsync("eval",
-                $"window.__latencyCharts?.navigateToTime('{result.Timestamp:o}', '{category}');");
+                $"window.__latencyCharts?.navigateToTime('{result.Timestamp:o}', '{category}', '{annotationLabel}', {(loadedOnly ? "true" : "false")}, '{result.EventStart:o}', '{result.EventEnd:o}');");
         }
         catch (Exception ex)
         {
@@ -2810,11 +2858,30 @@ else
             await ScrollToMonitoringInterfacesAsync();
         }
 
+        // Load the Investigate card's saved collapse state once the performance tab is shown.
+        // Set the loaded flag before the await so this can't re-enter on later renders; the body
+        // stays collapsed (default) until the preference resolves, so nothing flashes open.
+        if (_activeTab == "performance" && _monitoringReady && !_investigateStateLoaded)
+        {
+            _investigateStateLoaded = true;
+            string? val = null;
+            try { val = await JS.InvokeAsync<string>("localStorage.getItem", InvestigateCollapseKey); }
+            catch { }
+            // Saved preference wins; with none, default to expanded so the controls are discoverable.
+            _investigateSavedCollapsed = val == "true";
+            _investigateCollapsed = _investigateSavedCollapsed;
+            StateHasChanged();
+        }
+
         // Deep-linked investigation fires once the performance tab and its chart exist
         if (_pendingInvestigateParam != null && _activeTab == "performance" && _monitoringReady && !_investigatingLoss)
         {
             var kind = _pendingInvestigateParam;
             _pendingInvestigateParam = null;
+            // Open the (possibly collapsed) card so the deep-linked result and nav controls are
+            // visible. Live state only - the saved preference is untouched, and leaving the tab
+            // reverts to it, so a linkable investigation never counts as a user-set expand.
+            _investigateCollapsed = false;
             await NavigateToLossEvent(null, null, loadedOnly: kind == "loaded-loss");
         }
 
@@ -2945,6 +3012,13 @@ else
             _latencyChartsMounted = false;
             try { await JS.InvokeVoidAsync("eval", "window.__latencyCharts?.unmount();"); }
             catch { }
+            // The chart (and its highlight) is torn down on leave, so drop the loss-nav state
+            // too - otherwise returning shows the card "active" with no highlight on the chart.
+            // Deep-linked investigations re-arm via the query param on entry, so this is safe.
+            ResetLossNavState();
+            // Revert any transient deep-link force-open to the user's saved preference, so a
+            // linkable investigation never lingers as an expand the user didn't choose.
+            _investigateCollapsed = _investigateSavedCollapsed;
         }
 
         if (_scrollToDiscoveryPending && _activeTab == "performance")
@@ -3006,6 +3080,8 @@ else
             _sfpChartsMounted = false;
             try { await JS.InvokeVoidAsync("eval", "window.__sfpCharts?.unmount();"); }
             catch { }
+            // Drop the stale SFP investigation result; its chart jump is gone with the unmount.
+            _sfpInvestigateResult = null;
         }
 
         if (_scrollToSfpChartsPending && _activeTab == "sfp" && _sfpChartsMounted)

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -236,7 +236,7 @@ else
                             {
                                 <div class="issue-investigate">
                                     <a class="isp-factor-link" href="@issue.InvestigateUrl"
-                                       data-tooltip="Jump to the most recent matching loss event on the Network Performance charts">@(issue.InvestigateText ?? "Investigate on the charts")</a>
+                                       data-tooltip="Jump to the most recent matching loss event on the Network Performance charts" data-tooltip-hover-only>@(issue.InvestigateText ?? "Investigate on the charts")</a>
                                 </div>
                             }
                         </div>
@@ -359,7 +359,7 @@ else
                                     @if (investigateUrl != null)
                                     {
                                         <a class="isp-factor-name isp-factor-link" href="@investigateUrl"
-                                           data-tooltip="@investigateTooltip">@factor.Name</a>
+                                           data-tooltip="@investigateTooltip" data-tooltip-hover-only>@factor.Name</a>
                                     }
                                     else
                                     {

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -150,7 +150,7 @@ else
             <div class="isp-health-hero-gauge">
                 <IspHealthScoreGauge Score="r.OverallScore" Label="ISP Health" />
                 <div class="isp-health-profile-chip isp-health-profile-chip-selectable"
-                     data-tooltip="Score thresholds are tuned to this access technology. Change it here to re-score now.">
+                     data-tooltip="Thresholds are tuned per access technology; change it to re-score.">
                     Scored as @r.Profile.DisplayName &middot; @ScoredWindowLabel(r)
                     <span class="isp-profile-chip-caret"></span>
                     <select class="isp-profile-chip-select" aria-label="Access technology"
@@ -232,6 +232,13 @@ else
                                     }
                                 </div>
                             }
+                            @if (!string.IsNullOrEmpty(issue.InvestigateUrl))
+                            {
+                                <div class="issue-investigate">
+                                    <a class="isp-factor-link" href="@issue.InvestigateUrl"
+                                       data-tooltip="Jump to the most recent matching loss event on the Network Performance charts">@(issue.InvestigateText ?? "Investigate on the charts")</a>
+                                </div>
+                            }
                         </div>
                     </div>
                 }
@@ -249,7 +256,7 @@ else
                         @if (dimension == r.AccessDimension)
                         {
                             <select class="isp-access-tech-select" aria-label="Access technology"
-                                    data-tooltip="Score thresholds are tuned to this access technology. Change it here to re-score now."
+                                    data-tooltip="Thresholds are tuned per access technology; change it to re-score."
                                     value="@((int)r.AccessTechnology)" @onchange="OnAccessTechnologyChanged">
                                 @foreach (var tech in ProfileTechOptions)
                                 {

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -60,9 +60,9 @@
 
 @if (_loading)
 {
-    <div class="loading-container">
-        <div class="spinner"></div>
-        <p>Analyzing recent ISP data...</p>
+    <div class="isp-health-loading card">
+        <div class="isp-health-loading-spinner"></div>
+        <p class="isp-health-loading-text">Analyzing recent ISP data...</p>
     </div>
 }
 else if (_report == null)

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -311,11 +311,19 @@ else
                         {
                             <div class="isp-factor-row">
                                 <div class="isp-factor-label">
-                                    @{ var investigateUrl = FactorInvestigateUrl(factor.Name); }
+                                    @{
+                                        var isPhysicalLink = factor.Name == "Physical Link";
+                                        var investigateUrl = isPhysicalLink
+                                            ? PhysicalLinkInvestigateUrl(r.PhysicalLinkSelectedKey)
+                                            : FactorInvestigateUrl(factor.Name);
+                                        var investigateTooltip = isPhysicalLink
+                                            ? PhysicalLinkInvestigateTooltip(r.PhysicalLinkSelectedKey, r.PhysicalLinkMedium)
+                                            : "Jump to the most recent matching loss event on the Network Performance charts";
+                                    }
                                     @if (investigateUrl != null)
                                     {
                                         <a class="isp-factor-name isp-factor-link" href="@investigateUrl"
-                                           data-tooltip="Jump to the most recent matching loss event on the Network Performance charts">@factor.Name</a>
+                                           data-tooltip="@investigateTooltip">@factor.Name</a>
                                     }
                                     else
                                     {
@@ -961,6 +969,62 @@ else
         "Loaded Loss" => "/monitoring?tab=performance&investigate=loaded-loss",
         _ => null
     };
+
+    /// <summary>
+    /// Deep-link for the Physical Link factor to the monitoring tab for the matched access-link
+    /// device. The selected-source key encodes the source type and id ("cm:3", "ont:2",
+    /// "modem:1", "sfp:&lt;mac&gt;/&lt;port&gt;"), which maps directly to the CM / ONT / SFP /
+    /// Cellular stats tabs and their solo-device query params.
+    /// </summary>
+    private static string? PhysicalLinkInvestigateUrl(string? selectedKey)
+    {
+        if (string.IsNullOrEmpty(selectedKey))
+            return null;
+        var idx = selectedKey.IndexOf(':');
+        if (idx <= 0 || idx == selectedKey.Length - 1)
+            return null;
+        var prefix = selectedKey[..idx];
+        var raw = selectedKey[(idx + 1)..];
+        return prefix switch
+        {
+            "cm" => $"/monitoring?tab=cm&cm={Uri.EscapeDataString(raw)}",
+            "ont" => $"/monitoring?tab=ont&ont={Uri.EscapeDataString(raw)}",
+            // The SFP charts solo on the "mac:port" module key (MAC colon-normalized,
+            // lowercased) the device panels emit, not the resolver's "mac/port" token.
+            "sfp" => $"/monitoring?tab=sfp&sfp={Uri.EscapeDataString(SfpModuleKey(raw))}",
+            "modem" => $"/monitoring?tab=cellular&modem={Uri.EscapeDataString(raw)}",
+            _ => null
+        };
+    }
+
+    /// <summary>Converts a resolver SFP token ("&lt;mac&gt;/&lt;port&gt;") to the chart module
+    /// key ("&lt;mac&gt;:&lt;port&gt;" with the MAC colon-normalized and lowercased).</summary>
+    private static string SfpModuleKey(string macSlashPort)
+    {
+        var slash = macSlashPort.IndexOf('/');
+        if (slash < 0)
+            return macSlashPort;
+        var mac = macSlashPort[..slash].Replace("-", ":").ToLowerInvariant();
+        var port = macSlashPort[(slash + 1)..];
+        return $"{mac}:{port}";
+    }
+
+    private static string PhysicalLinkInvestigateTooltip(string? selectedKey, PhysicalMedium? medium)
+    {
+        var idx = selectedKey?.IndexOf(':') ?? -1;
+        var prefix = idx > 0 ? selectedKey![..idx] : "";
+        return prefix switch
+        {
+            "cm" => "Jump to the CM Stats charts for this cable modem",
+            "ont" => "Jump to the ONT Stats charts for this ONT",
+            // A PON SFP is an ONT; an Active Ethernet SFP is just a transceiver.
+            "sfp" => medium == PhysicalMedium.Pon
+                ? "Jump to the SFP Stats charts for this ONT"
+                : "Jump to the SFP Stats charts for this transceiver",
+            "modem" => "Jump to the Cellular Stats charts for this modem",
+            _ => "Jump to the monitoring charts for this access link"
+        };
+    }
 
     private static string FormatSpeed(double? mbps) => mbps.HasValue ? mbps.Value.ToString(mbps >= 100 ? "0" : "0.#") : "--";
 

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -1,4 +1,5 @@
 @using NetworkOptimizer.Web.Services.Monitoring.IspHealth
+@using NetworkOptimizer.Storage.Models
 @implements IDisposable
 @inject IspHealthService IspHealth
 @inject NavigationManager NavigationManager
@@ -86,10 +87,16 @@ else if (_report == null)
             <div class="banner-content">
                 <span class="banner-icon banner-icon-info">i</span>
                 <div class="banner-text" style="flex: 1;">
-                    Select your access network technology (GPON, DOCSIS, Starlink, ...) in Upstream Discovery so ISP Health can grade against the right expectations.
+                    <span>Pick your access network technology so ISP Health can grade against the right expectations. You can also set it during <a href="/monitoring?tab=performance&amp;discover=1">Upstream Discovery</a>.</span>
                 </div>
                 <div class="banner-actions">
-                    <button class="btn btn-sm btn-primary" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&discover=1"))">Open Upstream Discovery</button>
+                    <select class="form-control" style="max-width: 240px;" aria-label="Access technology" @onchange="OnAccessTechnologyChanged">
+                        <option value="" selected disabled>Select technology...</option>
+                        @foreach (var tech in ProfileTechOptions)
+                        {
+                            <option value="@((int)tech)">@FormatTechName(tech)</option>
+                        }
+                    </select>
                 </div>
             </div>
         </div>
@@ -142,8 +149,17 @@ else
         <div class="card-body isp-health-hero-body">
             <div class="isp-health-hero-gauge">
                 <IspHealthScoreGauge Score="r.OverallScore" Label="ISP Health" />
-                <div class="isp-health-profile-chip" data-tooltip="Thresholds are tuned to the access technology selected in Upstream Discovery">
+                <div class="isp-health-profile-chip isp-health-profile-chip-selectable"
+                     data-tooltip="Score thresholds are tuned to this access technology. Change it here to re-score now.">
                     Scored as @r.Profile.DisplayName &middot; @ScoredWindowLabel(r)
+                    <span class="isp-profile-chip-caret"></span>
+                    <select class="isp-profile-chip-select" aria-label="Access technology"
+                            value="@((int)r.AccessTechnology)" @onchange="OnAccessTechnologyChanged">
+                        @foreach (var tech in ProfileTechOptions)
+                        {
+                            <option value="@((int)tech)" selected="@(tech == r.AccessTechnology)">@FormatTechName(tech)</option>
+                        }
+                    </select>
                 </div>
             </div>
             <a href="/wan-speedtest" class="isp-health-hero-speed">
@@ -228,7 +244,20 @@ else
         {
             <div class="card isp-health-card">
                 <div class="card-header isp-dimension-header">
-                    <h2 class="card-title">@dimension.Name</h2>
+                    <h2 class="card-title@(dimension == r.AccessDimension ? " isp-access-tech-title" : "")">
+                        @dimension.Name
+                        @if (dimension == r.AccessDimension)
+                        {
+                            <select class="isp-access-tech-select" aria-label="Access technology"
+                                    data-tooltip="Score thresholds are tuned to this access technology. Change it here to re-score now."
+                                    value="@((int)r.AccessTechnology)" @onchange="OnAccessTechnologyChanged">
+                                @foreach (var tech in ProfileTechOptions)
+                                {
+                                    <option value="@((int)tech)" selected="@(tech == r.AccessTechnology)">@FormatTechName(tech)</option>
+                                }
+                            </select>
+                        }
+                    </h2>
                     <span class="isp-dimension-score @ScoreTextClass(dimension.Score)">@(dimension.Score?.ToString() ?? "--")</span>
                 </div>
                 <div class="card-body isp-card-body-tight-top">
@@ -351,7 +380,7 @@ else
                                         ? "More than one monitored access-link device matches this WAN. Choose which one feeds the score:"
                                         : "Scoring the selected access-link device. Change it here if needed:")
                                 </div>
-                                <select class="form-control" style="max-width: 320px;"
+                                <select class="form-control isp-physical-link-source"
                                         value="@(r.PhysicalLinkSelectedKey ?? "")" @onchange="OnPhysicalLinkSourceChanged">
                                     <option value="">Choose a source...</option>
                                     @foreach (var cand in r.PhysicalLinkCandidates)
@@ -668,6 +697,66 @@ else
             _report = await IspHealth.GetReportForWindowAsync(_windowStart.Value, _windowEnd.Value, forceRefresh: true);
         StateHasChanged();
     }
+
+    /// <summary>
+    /// Overrides the scored access technology from the pill selector and reloads the report for the
+    /// current window so the score and thresholds reflect the new technology immediately.
+    /// </summary>
+    private async Task OnAccessTechnologyChanged(ChangeEventArgs e)
+    {
+        if (!int.TryParse(e.Value?.ToString(), out var techValue))
+            return;
+        if (_refreshing || _windowComputing)
+            return;
+        // Drive the Refresh button's "Loading" spinner while the override re-scores,
+        // the same as a time-window change.
+        _windowComputing = true;
+        StateHasChanged();
+        try
+        {
+            await IspHealth.SetAccessTechnologyAsync((AccessTechnology)techValue);
+            if (IsLiveWindow)
+                _report = await IspHealth.GetReportAsync();
+            else if (_windowStart.HasValue && _windowEnd.HasValue)
+                _report = await IspHealth.GetReportForWindowAsync(_windowStart.Value, _windowEnd.Value, forceRefresh: true);
+        }
+        finally
+        {
+            _windowComputing = false;
+            StateHasChanged();
+        }
+    }
+
+    /// <summary>
+    /// Access technologies offered by the pill selector - only those with a scoring profile
+    /// (<see cref="IspHealthProfiles.GetProfile"/>), since the pill is only shown when scoring is
+    /// active. Unknown / PppoE / Other are excluded: picking them would null the profile and
+    /// collapse the pill into the "needs technology" empty state.
+    /// </summary>
+    private static readonly AccessTechnology[] ProfileTechOptions =
+    [
+        AccessTechnology.Gpon,
+        AccessTechnology.XgsPon,
+        AccessTechnology.Docsis,
+        AccessTechnology.Dsl,
+        AccessTechnology.DirectEthernet,
+        AccessTechnology.FixedWireless,
+        AccessTechnology.Cellular,
+        AccessTechnology.Satellite
+    ];
+
+    private static string FormatTechName(AccessTechnology tech) => tech switch
+    {
+        AccessTechnology.Gpon => "GPON",
+        AccessTechnology.XgsPon => "XGS-PON",
+        AccessTechnology.Docsis => "DOCSIS (Cable)",
+        AccessTechnology.DirectEthernet => "Active Ethernet",
+        AccessTechnology.FixedWireless => "Fixed Wireless",
+        AccessTechnology.Satellite => "Satellite",
+        AccessTechnology.Cellular => "Cellular",
+        AccessTechnology.Dsl => "DSL (ADSL/VDSL)",
+        _ => tech.ToString()
+    };
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -106,7 +106,7 @@
             <div class="recommendation-view">
                 <div class="section-header">
                     <h4>Recommended Channel Plan - @_selectedBand.ToDisplayString()</h4>
-                    <button class="btn btn-sm btn-ghost" @onclick="() => { _showRecommendations = false; _channelPlans.Clear(); }">Show Current Channels</button>
+                    <button class="btn btn-sm btn-ghost" @onclick="() => { _showRecommendations = false; _channelPlans.Clear(); }"><span class="btn-label-full">Show Current Channels</span><span class="btn-label-compact">Show Current</span></button>
                 </div>
 
                 @if (!_channelDisclaimerDismissed)

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -579,6 +579,13 @@
 
         await LoadDataAsync();
 
+        // Default the DFS toggle to match the console's Auto-Optimize configuration
+        // (dfs=true -> Include DFS, dfs=false -> Avoid DFS). Falls back to the field
+        // default when the setting is unavailable.
+        var autoOptimizeDfs = await WiFiService.GetAutoOptimizeDfsEnabledAsync();
+        if (autoOptimizeDfs.HasValue)
+            _dfsPreference = autoOptimizeDfs.Value ? DfsPreference.IncludeWithPenalty : DfsPreference.Exclude;
+
         // Apply initial filters from parent navigation (explicit band is treated as a manual pick)
         if (InitialBand.HasValue)
         {

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -109,7 +109,9 @@
                     <button class="btn btn-sm btn-ghost" @onclick="() => { _showRecommendations = false; _channelPlans.Clear(); }"><span class="btn-label-full">Show Current Channels</span><span class="btn-label-compact">Show Current</span></button>
                 </div>
 
-                @if (!_channelDisclaimerDismissed)
+                @* Auto-hide once every scannable radio has a measurement (no gaps): the rec is then
+                   grounded in measured airtime/noise, not flying on the unreliable neighbor scan. *@
+                @if (!_channelDisclaimerDismissed && _scanGaps.Count > 0)
                 {
                     <div class="channel-disclaimer">
                         <div class="disclaimer-content">
@@ -123,6 +125,31 @@
                             </span>
                         </div>
                         <button class="disclaimer-dismiss-btn" @onclick="DismissChannelDisclaimerAsync">Got it</button>
+                    </div>
+                }
+
+                @if (_scanGaps.Count > 0)
+                {
+                    <div class="alert-info scan-gap-banner">
+                        <div class="scan-gap-text">
+                            <strong>@_scanGaps.Count @(_scanGaps.Count == 1 ? "radio hasn't" : "radios haven't") been scanned recently.</strong>
+                            Without a measurement the optimizer infers those channels from neighboring
+                            networks instead of seeing them directly. A quick scan reads the real airtime
+                            and noise floor on each channel, so the recommendations reflect what's actually
+                            on the air - not a guess. @ScanDisruptionNote()
+                        </div>
+                        <button class="btn btn-primary btn-sm" @onclick="RunGapScans" disabled="@_scanningGaps"
+                                data-tooltip="Runs a quick RF scan to measure these channels">
+                            @if (_scanningGaps)
+                            {
+                                <span class="spinner spinner-sm"></span>
+                                <span>Scanning @_scanGaps.Count @(_scanGaps.Count == 1 ? "radio" : "radios")…</span>
+                            }
+                            else
+                            {
+                                <span>Run quick scan</span>
+                            }
+                        </button>
                     </div>
                 }
 
@@ -261,6 +288,14 @@
                             External neighbor networks are not factored in.
                         </div>
                     }
+                    else if (!plan.HasNeighborNetworks && plan.HasMeasuredChannelData)
+                    {
+                        <div class="recommendation-notice">
+                            No neighbor networks detected on this band, but measured channel occupancy and noise floor
+                            from RF scans are factored in - so these recommendations reflect real on-air conditions, not
+                            just internal AP interference.
+                        </div>
+                    }
                     else if (!plan.HasNeighborNetworks)
                     {
                         <div class="recommendation-notice">
@@ -274,12 +309,14 @@
                         <div class="recommendation-explainer-content">
                             <p>
                                 Most channel pickers just count nearby networks. This builds a physical model of your
-                                RF environment and solves for the channel plan that minimizes real interference:
+                                RF environment, measures what's actually on each channel, and solves for the channel
+                                plan that minimizes real interference:
                             </p>
                             <ul>
                                 <li><strong>Signal propagation</strong> - models how far each AP's signal actually reaches using your floor plan, wall materials, and per-radio antenna patterns, not distance alone.</li>
                                 <li><strong>Transmit-power aware</strong> - each AP's real EIRP is applied directionally, so a low-power AP correctly counts as a gentler neighbor than a full-power one.</li>
                                 <li><strong>Real contention, not raw signal</strong> - interference is measured against the CCA threshold (where radios actually defer), so barely-audible signals aren't over-counted.</li>
+                                <li><strong>Measured airtime and noise floor</strong> - reads each channel's actual utilization and RF noise floor from the radios' spectrum scans, so congestion and non-Wi-Fi interference (radar, microwaves, a noisy neighbor's gear) count even when no Wi-Fi network is visible there.</li>
                                 <li><strong>Neighboring networks</strong> - folds in UniFi's RF scan of networks you don't control, triangulated across all your APs for a fuller picture than any single AP sees.</li>
                                 <li><strong>30 days of history</strong> - per-channel utilization, interference, and TX-retry trends, so the plan reflects how channels behave over time, not one noisy snapshot.</li>
                                 <li><strong>Honest about the unknown</strong> - channels with no scan data are penalized for that uncertainty, so it won't push you onto an unseen channel unless your known channels are clearly worse.</li>
@@ -487,10 +524,10 @@
                                 </div>
                                 <div class="ap-col ap-width-col">@(radio.ChannelWidth ?? 20) MHz</div>
                                 <div class="ap-col ap-power-col">
-                                    <span class="power-value">@(radio.TxPower?.ToString() ?? "-")</span>
+                                    <EirpBar Radio="radio" Model="@ap.Model" />
                                     @if (!string.IsNullOrEmpty(radio.TxPowerMode))
                                     {
-                                        <span class="power-mode">(@radio.TxPowerMode)</span>
+                                        <span class="power-mode-below">@radio.TxPowerMode</span>
                                     }
                                 </div>
                                 <div class="ap-col ap-util-col">
@@ -876,10 +913,72 @@
             _channelPlans = await WiFiService.GetAllChannelRecommendationsAsync(options);
             _showRecommendations = _channelPlans.Count > 0;
             AutoSelectBandWithRecommendations();
+            await LoadScanGapsAsync();
         }
         finally
         {
             _loadingRecommendations = false;
+            StateHasChanged();
+        }
+    }
+
+    // (AP, band) pairs whose recommendation falls back to neighbor scans because they have no recent
+    // per-channel spectrum measurement. A quick-scan fills them.
+    private List<SpectrumScanGap> _scanGaps = new();
+    private bool _scanningGaps;
+
+    // Disruption note tailored to the gapped APs' scan hardware: an AP with a dedicated scan radio
+    // measures without touching its serving radios (no client impact); without one, scanning briefly
+    // steps the serving radio off-channel and a mesh parent can drop the devices meshed through it.
+    private string ScanDisruptionNote()
+    {
+        var clean = _scanGaps.Count(g => g.HasDedicatedScanRadio);
+        var disruptive = _scanGaps.Count - clean;
+        var meshNote = _scanGaps.Any(g => g.IsMeshParent && !g.HasDedicatedScanRadio)
+            ? ", and may briefly drop devices meshed through an AP" : "";
+
+        if (disruptive == 0)
+            return "These scan on a dedicated radio, so running won't disrupt clients.";
+        if (clean == 0)
+            return $"Heads up: scanning briefly steps each radio off its channel - clients stay connected, "
+                 + $"but real-time traffic (video calls, gaming) can hiccup for a moment{meshNote}. "
+                 + "Much lighter than a full scan, but best run during low-usage times.";
+        return $"{clean} of these scan on a dedicated radio with no client impact; the other {disruptive} "
+             + $"briefly step their serving radio off-channel, so real-time traffic can hiccup{meshNote} - "
+             + "best run during low-usage times.";
+    }
+
+    private async Task LoadScanGapsAsync()
+    {
+        try
+        {
+            _scanGaps = await WiFiService.GetSpectrumScanGapsAsync();
+        }
+        catch
+        {
+            _scanGaps = new();
+        }
+    }
+
+    private async Task RunGapScans()
+    {
+        if (_scanningGaps || _scanGaps.Count == 0) return;
+
+        _scanningGaps = true;
+        StateHasChanged();
+        try
+        {
+            var targets = _scanGaps.Select(g => (g.ApMac, g.BandCode)).ToList();
+            await WiFiService.RunQuickScansAsync(targets);
+
+            // Re-run recommendations on the fresh spectrum data, then re-check what's still missing.
+            var options = new RecommendationOptions { DfsPreference = _dfsPreference };
+            _channelPlans = await WiFiService.GetAllChannelRecommendationsAsync(options);
+            await LoadScanGapsAsync();
+        }
+        finally
+        {
+            _scanningGaps = false;
             StateHasChanged();
         }
     }

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -211,9 +211,13 @@
                                     @if (rec.IsChanged)
                                     {
                                         <span>Ch @rec.CurrentChannel / @(rec.CurrentWidth) MHz</span>
+                                        @if (rec.IsCurrentDfsChannel)
+                                        {
+                                            <span class="dfs-badge">DFS</span>
+                                        }
                                         <span class="channel-change-arrow"><svg width="20" height="14" viewBox="0 0 20 14" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12 1L19 7L12 13M19 7H1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
                                         <span class="rec-changed">Ch @rec.RecommendedChannel / @(rec.RecommendedWidth) MHz</span>
-                                        @if (rec.IsDfsChannel)
+                                        @if (rec.IsRecommendedDfsChannel)
                                         {
                                             <span class="dfs-badge">DFS</span>
                                         }
@@ -221,6 +225,10 @@
                                     else
                                     {
                                         <span>Ch @rec.CurrentChannel / @(rec.CurrentWidth) MHz</span>
+                                        @if (rec.IsCurrentDfsChannel)
+                                        {
+                                            <span class="dfs-badge">DFS</span>
+                                        }
                                         <span class="rec-no-change">(No change)</span>
                                     }
                                 </div>

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/EirpBar.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/EirpBar.razor
@@ -1,0 +1,81 @@
+@using NetworkOptimizer.WiFi
+@using NetworkOptimizer.WiFi.Data
+@using NetworkOptimizer.WiFi.Models
+
+@{
+    var maxEirp = GetMaxEirp(Model, Radio);
+    var txPowerPct = GetPowerPercentage(Radio.TxPower ?? 0, maxEirp);
+    var eirpPct = GetPowerPercentage(Radio.Eirp ?? Radio.TxPower ?? 0, maxEirp);
+    var powerClass = GetPowerClass(Radio);
+    var hasGain = Radio.AntennaGain.HasValue && Radio.AntennaGain > 0;
+}
+<div class="power-bar-container" data-tooltip="TX: @(Radio.TxPower ?? 0) dBm@(hasGain ? $" + {Radio.AntennaGain} dBi gain = {Radio.Eirp} dBm EIRP" : "") (max @maxEirp dBm EIRP)">
+    <div class="power-bar-stack">
+        <div class="power-bar-tx @powerClass" style="width: @txPowerPct%"></div>
+        @if (hasGain)
+        {
+            <div class="power-bar-gain @powerClass" style="width: @(eirpPct - txPowerPct)%"></div>
+        }
+    </div>
+    <span class="power-values">
+        <span class="power-tx">@(Radio.TxPower ?? 0)</span>
+        @if (hasGain)
+        {
+            <span class="power-eirp">→ @Radio.Eirp</span>
+        }
+        <span class="power-unit">dBm</span>
+    </span>
+</div>
+
+@code {
+    /// <summary>The radio whose TX power / EIRP to render.</summary>
+    [Parameter, EditorRequired] public RadioSnapshot Radio { get; set; } = default!;
+
+    /// <summary>AP model, used to resolve the catalog max EIRP for the bar scale.</summary>
+    [Parameter] public string Model { get; set; } = "";
+
+    /// <summary>
+    /// Get the max EIRP for a radio, using catalog data with the same clamping logic as ApMapService.
+    /// Falls back to the radio's own MaxTxPower + AntennaGain if catalog doesn't have the model.
+    /// </summary>
+    private int GetMaxEirp(string model, RadioSnapshot radio)
+    {
+        var bandKey = radio.Band.ToPropagationBand();
+        if (ApModelCatalog.TryGetBandDefaults(model, bandKey, out var catalogDefaults))
+        {
+            var (gain, maxTx, _) = ApModelCatalog.ResolveForMode(catalogDefaults, radio.AntennaMode);
+
+            // Use catalog max if UniFi reports higher (same 2 dBm tolerance as ApMapService)
+            var apiMax = radio.MaxTxPower ?? maxTx;
+            var clampedMax = (apiMax >= maxTx + 2) ? maxTx : apiMax;
+
+            // Use catalog gain if UniFi reports higher
+            var apiGain = radio.AntennaGain ?? gain;
+            var clampedGain = (apiGain >= gain + 2) ? gain : apiGain;
+
+            return clampedMax + clampedGain;
+        }
+
+        // Fallback: use whatever UniFi reports
+        var fallbackMax = radio.MaxTxPower ?? radio.TxPower ?? 20;
+        return fallbackMax + (radio.AntennaGain ?? 0);
+    }
+
+    private double GetPowerPercentage(int power, int maxEirp)
+    {
+        if (maxEirp <= 0) return 0;
+        return Math.Min(100, Math.Max(0, (double)power / maxEirp * 100));
+    }
+
+    private string GetPowerClass(RadioSnapshot radio)
+    {
+        var mode = radio.TxPowerMode?.ToLower() ?? "auto";
+        return mode switch
+        {
+            "high" => "power-high",
+            "medium" => "power-medium",
+            "low" => "power-low",
+            _ => "power-auto"
+        };
+    }
+}

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/PowerCoverageAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/PowerCoverageAnalysis.razor
@@ -112,33 +112,12 @@
                         <div class="radio-power-list">
                             @foreach (var radio in ap.Radios.Where(r => r.Channel.HasValue).OrderBy(r => r.Band))
                             {
-                                var maxEirp = GetMaxEirp(ap.Model, radio);
-                                var txPowerPct = GetPowerPercentage(radio.TxPower ?? 0, maxEirp);
-                                var eirpPct = GetPowerPercentage(radio.Eirp ?? radio.TxPower ?? 0, maxEirp);
-                                var powerClass = GetPowerClass(radio);
-                                var hasGain = radio.AntennaGain.HasValue && radio.AntennaGain > 0;
                                 <div class="radio-power-item">
                                     <div class="radio-info">
                                         <span class="radio-band @GetBandCssClass(radio.Band)">@radio.Band.ToDisplayString()</span>
                                         <span class="radio-channel">Ch @radio.Channel</span>
                                     </div>
-                                    <div class="power-bar-container" data-tooltip="TX: @(radio.TxPower ?? 0) dBm@(hasGain ? $" + {radio.AntennaGain} dBi gain = {radio.Eirp} dBm EIRP" : "") (max @maxEirp dBm EIRP)">
-                                        <div class="power-bar-stack">
-                                            <div class="power-bar-tx @powerClass" style="width: @txPowerPct%"></div>
-                                            @if (hasGain)
-                                            {
-                                                <div class="power-bar-gain @powerClass" style="width: @(eirpPct - txPowerPct)%"></div>
-                                            }
-                                        </div>
-                                        <span class="power-values">
-                                            <span class="power-tx">@(radio.TxPower ?? 0)</span>
-                                            @if (hasGain)
-                                            {
-                                                <span class="power-eirp">→ @radio.Eirp</span>
-                                            }
-                                            <span class="power-unit">dBm</span>
-                                        </span>
-                                    </div>
+                                    <EirpBar Radio="radio" Model="@ap.Model" />
                                     <div class="power-mode">
                                         @(radio.TxPowerMode ?? "auto")
                                     </div>
@@ -482,51 +461,6 @@
                            !i.Title.Contains("Co-Channel"))
                 .ToList();
         }
-    }
-
-    /// <summary>
-    /// Get the max EIRP for a radio, using catalog data with the same clamping logic as ApMapService.
-    /// Falls back to the radio's own MaxTxPower + AntennaGain if catalog doesn't have the model.
-    /// </summary>
-    private int GetMaxEirp(string model, RadioSnapshot radio)
-    {
-        var bandKey = radio.Band.ToPropagationBand();
-        if (ApModelCatalog.TryGetBandDefaults(model, bandKey, out var catalogDefaults))
-        {
-            var (gain, maxTx, _) = ApModelCatalog.ResolveForMode(catalogDefaults, radio.AntennaMode);
-
-            // Use catalog max if UniFi reports higher (same 2 dBm tolerance as ApMapService)
-            var apiMax = radio.MaxTxPower ?? maxTx;
-            var clampedMax = (apiMax >= maxTx + 2) ? maxTx : apiMax;
-
-            // Use catalog gain if UniFi reports higher
-            var apiGain = radio.AntennaGain ?? gain;
-            var clampedGain = (apiGain >= gain + 2) ? gain : apiGain;
-
-            return clampedMax + clampedGain;
-        }
-
-        // Fallback: use whatever UniFi reports
-        var fallbackMax = radio.MaxTxPower ?? radio.TxPower ?? 20;
-        return fallbackMax + (radio.AntennaGain ?? 0);
-    }
-
-    private double GetPowerPercentage(int power, int maxEirp)
-    {
-        if (maxEirp <= 0) return 0;
-        return Math.Min(100, Math.Max(0, (double)power / maxEirp * 100));
-    }
-
-    private string GetPowerClass(RadioSnapshot radio)
-    {
-        var mode = radio.TxPowerMode?.ToLower() ?? "auto";
-        return mode switch
-        {
-            "high" => "power-high",
-            "medium" => "power-medium",
-            "low" => "power-low",
-            _ => "power-auto"
-        };
     }
 
     private string GetBandCssClass(RadioBand band) => band switch

--- a/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
@@ -3,6 +3,7 @@ using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
 using NetworkOptimizer.Web.Services;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Endpoints;
 
@@ -199,7 +200,8 @@ public static class MonitoringChartEndpoints
             // target_id set (full scan, ~400ms+).
             await using var db = await dbFactory.CreateDbContextAsync(ct);
             var targets = await db.MonitoringTargets.AsNoTracking()
-                .Where(t => t.TargetType == targetType && t.Enabled)
+                .Where(t => t.TargetType == targetType && t.Enabled
+                    && (t.AsnNumber == null || !WellKnownAsns.NonTransitInfrastructure.Contains(t.AsnNumber.Value)))
                 .OrderBy(t => t.Name)
                 .Select(t => new { t.TargetId, t.Name })
                 .ToListAsync(ct);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -151,6 +151,11 @@ public class IspHealthIssue
     public string? Recommendation { get; init; }
     public string? LinkUrl { get; init; }
     public string? LinkText { get; init; }
+
+    /// <summary>Optional deep-link to the matching loss event on the Network Performance charts,
+    /// mirroring the Access Layer sub-score headers (e.g. ?investigate=loaded-loss).</summary>
+    public string? InvestigateUrl { get; init; }
+    public string? InvestigateText { get; init; }
 }
 
 /// <summary>
@@ -581,6 +586,11 @@ public class IspHealthInputs
 
     /// <summary>Whether UniFi Smart Queues is already enabled on the WAN.</summary>
     public bool SmartQueuesEnabled { get; init; }
+
+    /// <summary>Whether OUR Adaptive SQM is enabled and configured for the primary WAN. Distinct
+    /// from <see cref="SmartQueuesEnabled"/> (UniFi's base feature); used so the loaded-loss
+    /// recommendation never pitches Adaptive SQM to someone already running it.</summary>
+    public bool AdaptiveSqmEnabled { get; init; }
 
     /// <summary>
     /// Time windows to exclude from loaded-line analysis. Adaptive SQM speed probes

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -1,3 +1,5 @@
+using NetworkOptimizer.Storage.Models;
+
 namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
 
 /// <summary>Readiness of the ISP Health pipeline, used by the live view tiles.</summary>
@@ -390,6 +392,11 @@ public class IspHealthReport
     public DateTime WindowStart { get; init; }
     public DateTime WindowEnd { get; init; }
     public required AccessProfile Profile { get; init; }
+
+    /// <summary>The access technology that selected <see cref="Profile"/>, so the UI can offer a
+    /// quick re-score by changing it (the pill selector) without round-tripping Upstream Discovery.</summary>
+    public AccessTechnology AccessTechnology { get; set; }
+
     public required IspScoreDimension AccessDimension { get; init; }
     public required IspScoreDimension TransitDimension { get; init; }
     public required IspScoreDimension IspAsnDimension { get; init; }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -436,6 +436,11 @@ public class IspHealthReport
     /// <summary>The currently selected physical-link source key (e.g. "cm:3"), if any.</summary>
     public string? PhysicalLinkSelectedKey { get; set; }
 
+    /// <summary>The access medium of the selected physical-link source, for display verbiage
+    /// (e.g. a PON SFP reads as an ONT, an Active Ethernet SFP as a transceiver). Null when no
+    /// single source matched.</summary>
+    public PhysicalMedium? PhysicalLinkMedium { get; set; }
+
     /// <summary>True when multiple sources matched and the user has not yet picked one.</summary>
     public bool PhysicalLinkAmbiguous { get; set; }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -597,8 +597,11 @@ public static class IspHealthProfiles
             LoadedDeltaExcellentMs: 2.0, LoadedDeltaAcceptableMs: 10.0,
             JitterIdealMs: 0.4, JitterTypicalMs: 0.7, JitterPoorMs: 3.0),
 
+        // XGS-PON sits a notch below GPON on idle RTT: its low-latency DBA runs shorter upstream
+        // grant cycles than GPON's ~1-2 ms, and the 10G upstream cuts serialization, so the
+        // first-hop floor is lower. Loss/jitter/loaded bands stay as the optical defaults.
         AccessTechnology.XgsPon => new AccessProfile("XGS-PON",
-            IdleRttIdealMs: 1.5, IdleRttNormalLowMs: 2.0, IdleRttNormalHighMs: 3.0, IdleRttPoorMs: 8.0,
+            IdleRttIdealMs: 1.0, IdleRttNormalLowMs: 1.5, IdleRttNormalHighMs: 2.5, IdleRttPoorMs: 7.0,
             IdleLossIdealPct: 0.02, IdleLossAcceptablePct: 0.05,
             LoadedLossDownLowPct: 0.5, LoadedLossDownHighPct: 1.0,
             LoadedLossUpLowPct: 0.25, LoadedLossUpHighPct: 0.5,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -570,6 +570,11 @@ public sealed record AccessProfile(
     double LoadedDeltaExcellentMs,
     double LoadedDeltaAcceptableMs,
     bool IsNeutral = false,
+    // True for shared-medium access where capacity is contended across subscribers
+    // (cable/DOCSIS, PON, fixed wireless, cellular, LEO). Persistent loss on these can
+    // mean an oversubscribed segment, not just a local physical-plant fault. False for
+    // dedicated point-to-point media (DSL pair, Active Ethernet / DIA).
+    bool SharedMedium = true,
     // Per-tech jitter band (P95 jitter, ms). When set, jitter is scored straight off the band -
     // (ideal,100) (typical,90) (poor,25) (2*poor,0) - so a medium's inherent jitter (e.g. DOCSIS's
     // ~3 ms request-grant) reads as normal instead of being graded against a sub-ms path floor.
@@ -630,6 +635,7 @@ public static class IspHealthProfiles
             LoadedLossDownLowPct: 1.0, LoadedLossDownHighPct: 2.0,
             LoadedLossUpLowPct: 0.5, LoadedLossUpHighPct: 1.0,
             LoadedDeltaExcellentMs: 2.0, LoadedDeltaAcceptableMs: 10.0,
+            SharedMedium: false,
             JitterIdealMs: 0.4, JitterTypicalMs: 0.7, JitterPoorMs: 3.0),
 
         AccessTechnology.FixedWireless => new AccessProfile("Fixed Wireless",
@@ -654,6 +660,7 @@ public static class IspHealthProfiles
             LoadedLossDownLowPct: 3.0, LoadedLossDownHighPct: 5.0,
             LoadedLossUpLowPct: 3.0, LoadedLossUpHighPct: 5.0,
             LoadedDeltaExcellentMs: 5.0, LoadedDeltaAcceptableMs: 20.0,
+            SharedMedium: false,
             JitterIdealMs: 1.0, JitterTypicalMs: 2.0, JitterPoorMs: 5.0),
 
         AccessTechnology.PppoE => NeutralProfile("PPPoE"),

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -1326,10 +1326,27 @@ public class IspHealthScorer
         var (latencyTriggered, lossTriggered) = SqmTriggers(inputs, profile, loadWindows, loadedDeltas);
         if (latencyTriggered || lossTriggered)
         {
-            var recommendation = inputs.SmartQueuesEnabled
-                ? "Smart Queues is enabled on this WAN but the line still degrades under load; check that its configured rates match what the line actually delivers."
-                : "Enable Smart Queues (SQM) on this WAN in UniFi Network (Settings, Internet, your WAN, Smart Queues).";
-            if (inputs.CongestionEvents.Count(e => e.Disposition == CongestionDisposition.Confirmed) >= _options.SqmRecurringCongestionEvents)
+            // Adaptive SQM (our feature) overrides the UniFi Smart Queues messaging: we can see
+            // it's already shaping this WAN, so don't pitch it or tell the user to enable Smart
+            // Queues. Loss under load while it shapes means the rate it holds isn't backing off
+            // enough for the real-time capacity drop, so point at its own tuning knobs (Severity
+            // deepens the time-of-day dips; nominal speeds set the ceiling everything scales from).
+            string recommendation;
+            if (inputs.AdaptiveSqmEnabled)
+            {
+                recommendation = "Adaptive SQM is already shaping this WAN, so loss under load means the rate it holds isn't backing off enough when the line congests. In your Adaptive SQM settings, raise the Severity so the peak-hour rate dips go deeper, or lower the nominal download/upload if the line consistently delivers less than its plan. If loss persists once the rate is pulled down, the drops are upstream and only your ISP can fix them.";
+            }
+            else if (inputs.SmartQueuesEnabled)
+            {
+                recommendation = "Smart Queues is enabled on this WAN but the line still degrades under load; check that its configured rates match what the line actually delivers.";
+            }
+            else
+            {
+                recommendation = "Enable Smart Queues (SQM) on this WAN in UniFi Network (Settings, Internet, your WAN, Smart Queues).";
+            }
+            // Only pitch Adaptive SQM when the WAN isn't already running it.
+            if (!inputs.AdaptiveSqmEnabled
+                && inputs.CongestionEvents.Count(e => e.Disposition == CongestionDisposition.Confirmed) >= _options.SqmRecurringCongestionEvents)
             {
                 recommendation += " This connection also shows a recurring congestion pattern; consider Adaptive SQM, which tracks time-of-day capacity changes automatically.";
             }
@@ -1354,7 +1371,9 @@ public class IspHealthScorer
                     Description = "Packet loss exceeds the acceptable band for this connection type when the line is loaded.",
                     Recommendation = recommendation,
                     LinkUrl = "/sqm",
-                    LinkText = "Adaptive SQM"
+                    LinkText = "Adaptive SQM",
+                    InvestigateUrl = "/monitoring?tab=performance&investigate=loaded-loss",
+                    InvestigateText = "Investigate on the charts"
                 });
             }
         }
@@ -1386,12 +1405,32 @@ public class IspHealthScorer
         var idleLossFactor = report.AccessDimension.Factors.FirstOrDefault(f => f.Name == "Packet Loss");
         if (idleLossFactor?.Score is < 70)
         {
+            // Dedicated point-to-point media (DSL pair, Active Ethernet / DIA) have no
+            // contended segment, so persistent loss there is a physical-plant fault. On
+            // shared media the same loss can equally be an oversubscribed segment upstream,
+            // and on the neutral PPPoE/Other profile the medium is unknown so we hedge.
+            string lossRecommendation;
+            if (!profile.SharedMedium)
+            {
+                lossRecommendation = "Persistent loss regardless of load usually points at the physical layer: check optics, connectors, or line/signal levels, and raise it with your ISP.";
+            }
+            else if (profile.IsNeutral)
+            {
+                lossRecommendation = "Persistent loss regardless of load points at the access layer: a physical-plant fault (optics, connectors, coax fittings, or signal levels), or - if your line runs over a shared medium like cable, PON, fixed wireless, or cellular - an oversubscribed segment carrying too many subscribers. Raise it with your ISP either way.";
+            }
+            else
+            {
+                lossRecommendation = $"Persistent loss regardless of load points at the access layer: a physical-plant fault (optics, connectors, coax fittings, or signal levels), or an oversubscribed segment upstream, since {profile.DisplayName} shares capacity across subscribers. Raise it with your ISP.";
+            }
+
             issues.Add(new IspHealthIssue
             {
                 Severity = IspIssueSeverity.Warning,
                 Title = "Packet loss above acceptable",
                 Description = $"Average packet loss of {idleLossFactor.ValueText} exceeds the {FormatPct(profile.IdleLossAcceptablePct)} acceptable ceiling for {profile.DisplayName}.",
-                Recommendation = "Persistent loss regardless of load usually points at the physical layer: check optics, connectors, coax fittings, or signal levels, and raise it with your ISP."
+                Recommendation = lossRecommendation,
+                InvestigateUrl = "/monitoring?tab=performance&investigate=packet-loss",
+                InvestigateText = "Investigate on the charts"
             });
         }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -646,6 +646,7 @@ public class IspHealthService
         var report = new IspHealthScorer(_options, _logger).Score(inputs, profile);
         report.PhysicalLinkCandidates = physical.Candidates;
         report.PhysicalLinkSelectedKey = physical.SelectedKey;
+        report.PhysicalLinkMedium = physical.Input?.Medium;
         report.PhysicalLinkAmbiguous = physical.Ambiguous;
         _logger.LogDebug("ISP Health computed: {Score} ({Tech}), {Events} congestion events, {Shifts} path shifts",
             report.OverallScore, profile.DisplayName, congestionEvents.Count, pathShifts.Count);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -78,6 +78,38 @@ public class IspHealthService
         await GetReportAsync(forceRefresh: true, ct);
     }
 
+    /// <summary>
+    /// Overrides the scored access technology from the ISP Health selector and recomputes. Writes
+    /// it the same way Upstream Discovery commits it: to the primary WAN's discovery context,
+    /// created if missing. That is the row the scorer reads and the one a later discovery run
+    /// preserves (it only proposes a technology when none is set), so the override sticks until the
+    /// user changes it again here or in the discovery review. The legacy
+    /// MonitoringSettings.AccessTechnology is intentionally left untouched - it is read only as a
+    /// fallback for installs that predate the per-WAN context.
+    /// </summary>
+    public async Task SetAccessTechnologyAsync(AccessTechnology technology, CancellationToken ct = default)
+    {
+        await using (var db = await _dbFactory.CreateDbContextAsync(ct))
+        {
+            // Primary WAN context, wan-first like the reader's ordering - but NOT filtered to
+            // non-Unknown: setting it when it is currently unset is the whole point. Create it if
+            // the table is empty, matching Upstream Discovery's create-if-missing on commit.
+            var ctxRow = (await db.WanDiscoveryContexts.ToListAsync(ct))
+                .OrderBy(c => string.Equals(c.WanInterface, "wan", StringComparison.OrdinalIgnoreCase) ? 0 : 1)
+                .FirstOrDefault();
+            if (ctxRow == null)
+            {
+                ctxRow = new WanDiscoveryContext { WanInterface = "wan" };
+                db.WanDiscoveryContexts.Add(ctxRow);
+            }
+            ctxRow.AccessTechnology = technology;
+            ctxRow.UpdatedAt = DateTime.UtcNow;
+
+            await db.SaveChangesAsync(ct);
+        }
+        await GetReportAsync(forceRefresh: true, ct);
+    }
+
     public IspHealthOptions Options => _options;
 
     /// <summary>
@@ -127,7 +159,13 @@ public class IspHealthService
 
             _computing = true;
             var (report, chartClusters) = await ComputeAsync(ct);
-            if (report != null) _cached = new Snapshot(report, chartClusters);
+            if (report != null)
+                _cached = new Snapshot(report, chartClusters);
+            else if (forceRefresh)
+                // A forced recompute that lost readiness (e.g. the technology was unset) must drop
+                // the stale snapshot, otherwise Status keeps reporting Ready off the old cache and
+                // the panel shows a generic error instead of the right prerequisite funnel.
+                _cached = null;
             return report;
         }
         finally
@@ -644,6 +682,7 @@ public class IspHealthService
         };
 
         var report = new IspHealthScorer(_options, _logger).Score(inputs, profile);
+        report.AccessTechnology = technology;
         report.PhysicalLinkCandidates = physical.Candidates;
         report.PhysicalLinkSelectedKey = physical.SelectedKey;
         report.PhysicalLinkMedium = physical.Input?.Medium;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -332,7 +332,10 @@ public class IspHealthService
         }
 
         var ispTargets = targets.Where(t => t.TargetType == MonitoringTargetType.AccessIsp).ToList();
-        var transitTargets = targets.Where(t => t.TargetType == MonitoringTargetType.Transit).ToList();
+        // WoodyNet / PCH (AS42, AS715) and similar IXP/anycast-DNS infrastructure are not
+        // transit; drop them so they never enter scoring, the per-ASN cards, or the chart clusters.
+        var transitTargets = targets.Where(t => t.TargetType == MonitoringTargetType.Transit
+            && !(t.AsnNumber is int a && WellKnownAsns.NonTransitInfrastructure.Contains(a))).ToList();
         if (ispTargets.Count == 0 && transitTargets.Count == 0)
             return new ComputeOutcome(IspHealthStatus.NeedsDiscovery, null, new List<AsnSeries>());
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -468,6 +468,15 @@ public class IspHealthService
             })
             .ToList();
 
+        // Surface the well-known anycast DNS endpoints (Cloudflare 1.1.1.1, Google 8.8.8.8)
+        // as their own lines on the Per-Network RTT chart. They already feed loss, path-shift,
+        // and congestion detection (as destination witnesses); they are also exceptionally
+        // stable, so plotting them gives a known-good baseline to read a noisy ISP or transit
+        // hop against. Only the anycast DNS targets are charted, not arbitrary discovered
+        // InternetService destinations.
+        chartClusters.AddRange(internetTargetSeries
+            .Where(s => s.HopIps.Any(AnycastDnsIps.Contains)));
+
         // Per-target (hop-granularity) series for the congestion localizer: clustering would
         // lump a clean middle hop with a hot one and re-merge an off-path ASN, so detection and
         // localization run at the individual hop. Destinations come in as witnesses only.
@@ -649,6 +658,7 @@ public class IspHealthService
         // event labels. It is published together with the report (see Snapshot).
         var primaryWanInterface = await GetPrimaryWanInterfaceAsync(ct);
         var loadExclusions = await BuildSqmProbeExclusionsAsync(windowStart, windowEnd, primaryWanInterface, ct);
+        var adaptiveSqmEnabled = await IsAdaptiveSqmEnabledAsync(primaryWanInterface, ct);
 
         // Match the WAN's access technology to one monitored physical device (ONT/SFP, cable
         // modem, or cellular modem) and aggregate its window metrics for the Physical Link factor.
@@ -676,6 +686,7 @@ public class IspHealthService
             PathShifts = pathShifts,
             Outages = outages,
             SmartQueuesEnabled = smartQueuesEnabled,
+            AdaptiveSqmEnabled = adaptiveSqmEnabled,
             HopOrderKnown = hopOrderKnown,
             LoadExclusionWindows = loadExclusions,
             PhysicalLink = physical.Input
@@ -932,6 +943,23 @@ public class IspHealthService
             }
         }
         return exclusions;
+    }
+
+    /// <summary>
+    /// True when OUR Adaptive SQM is enabled and configured for the primary WAN (an enabled
+    /// <see cref="SqmWanConfiguration"/> matching the interface). Distinct from UniFi's base
+    /// Smart Queues toggle (<see cref="IspHealthInputs.SmartQueuesEnabled"/>); the loaded-loss
+    /// recommendation uses this so it never tells a user to "consider Adaptive SQM" when they
+    /// already run it.
+    /// </summary>
+    private async Task<bool> IsAdaptiveSqmEnabledAsync(string? primaryWanInterface, CancellationToken ct)
+    {
+        if (string.IsNullOrEmpty(primaryWanInterface)) return false;
+        await using var db = await _dbFactory.CreateDbContextAsync(ct);
+        var sqmConfigs = await db.SqmWanConfigurations.AsNoTracking()
+            .Where(c => c.Enabled)
+            .ToListAsync(ct);
+        return sqmConfigs.Any(c => string.Equals(c.Interface, primaryWanInterface, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkModels.cs
@@ -49,11 +49,10 @@ public class PhysicalLinkInput
     /// the status are ignored, so a missing reading never reads as a link-down.</summary>
     public bool? PonOperational { get; init; }
 
-    /// <summary>PON type for display (GPON, XGS-PON); also selects the OLT-launch assumption.</summary>
-    public string? PonType { get; init; }
-
-    /// <summary>True when the configured access technology is XGS-PON (reliable even when the device
-    /// does not report PonType). Selects the higher XGS-PON ONU transmit-power threshold.</summary>
+    /// <summary>True when the configured access technology is XGS-PON. Drives the GPON/XGS-PON
+    /// display copy, the OLT-launch assumption for the split-ratio estimate, and the higher
+    /// XGS-PON ONU transmit-power threshold - the user's selection, not the device's self-report,
+    /// which many ONTs omit or report inconsistently.</summary>
     public bool IsXgsPon { get; init; }
 
     /// <summary>Total uncorrectable-FEC codewords over the window (external ONT only). Graded as an

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkResolver.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Core.Helpers;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
@@ -127,9 +128,22 @@ public class PhysicalLinkResolver
         return (await db.MonitoredSfps.AsNoTracking().Where(s => s.Category == category).ToListAsync(ct))
             .Select(s => new Cand(
                 $"sfp:{s.DeviceMac}/{s.PortName}",
-                string.IsNullOrWhiteSpace(s.FriendlyName) ? s.PortName : s.FriendlyName!,
+                SfpDisplayLabel(s),
                 medium, null, s.DeviceMac, s.PortName))
             .ToList();
+    }
+
+    /// <summary>Friendly label for an SFP source: the user's name if set, otherwise the cleaned
+    /// transceiver vendor plus its port (e.g. "Ubiquiti SFP on Port 7"), falling back to just the
+    /// port when no vendor is reported.</summary>
+    private static string SfpDisplayLabel(MonitoredSfp s)
+    {
+        if (!string.IsNullOrWhiteSpace(s.FriendlyName))
+            return s.FriendlyName!;
+        var vendor = NetworkFormatHelpers.CleanOrgName(s.SfpVendor);
+        return string.IsNullOrEmpty(vendor)
+            ? $"SFP on Port {s.PortName}"
+            : $"{vendor} SFP on Port {s.PortName}";
     }
 
     private async Task<List<Cand>> CableModemCandidatesAsync(NetworkOptimizerDbContext db, CancellationToken ct)
@@ -220,7 +234,6 @@ public class PhysicalLinkResolver
             RxPowerBaselineDbm = stats.BaselineDbm,
             TxPowerDbm = live?.TxPowerDbm ?? pts.LastOrDefault(p => p.TxPowerDbm.HasValue)?.TxPowerDbm,
             PonOperational = operational,
-            PonType = live?.PonType,
             IsXgsPon = isXgsPon,
             FecErrorsTotal = fecTotal,
             BipErrorsTotal = bipTotal,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkScorer.cs
@@ -61,10 +61,10 @@ public static class PhysicalLinkScorer
     {
         var issues = new List<IspHealthIssue>();
         var rx = input.RxPowerMedianDbm;
-        // Prefer the type the ONT actually reports; otherwise fall back to the configured access
-        // technology so the copy reads "GPON"/"XGS-PON" rather than a bare "PON".
+        // The configured access technology drives the copy so it reads "GPON"/"XGS-PON"
+        // consistently with the user's selection, not whatever the ONT happens to report.
         var label = isPon
-            ? (FormatPonType(input.PonType) ?? (input.IsXgsPon ? "XGS-PON" : "GPON"))
+            ? (input.IsXgsPon ? "XGS-PON" : "GPON")
             : "Active Ethernet";
 
         if (rx is null)
@@ -132,7 +132,7 @@ public static class PhysicalLinkScorer
         // PON-only: inferred split ratio (display verbiage) and bounded excess-loss flag.
         if (isPon)
         {
-            var split = InferSplitRatio(rx.Value, input.PonType);
+            var split = InferSplitRatio(rx.Value, input.IsXgsPon);
             if (split != null) detailBits.Add(split);
 
             if (rx.Value < PonThresholds.PonExcessLossFloorDbm && rx.Value > floor)
@@ -259,10 +259,8 @@ public static class PhysicalLinkScorer
     /// be nudged from field feedback - the model is the budget math, not a hand-tuned table. Never
     /// feeds the score. Returns null when the math lands hotter than even a 1:2 split.
     /// </summary>
-    internal static string? InferSplitRatio(double rxDbm, string? ponType)
+    internal static string? InferSplitRatio(double rxDbm, bool isXgs)
     {
-        var isXgs = (ponType ?? "").Contains("XGS", StringComparison.OrdinalIgnoreCase)
-                    || (ponType ?? "").Contains("10G", StringComparison.OrdinalIgnoreCase);
         var oltLaunchDbm = isXgs ? 5.0 : 3.0;     // common launch (GPON B+; high-class C+ is the rare rural case)
         const double distributionLossDb = 5.0;    // realistic drop: glass + splices + typical un-cleaned connectors
                                                   // (puts the 1:32 -> 1:64 boundary near -20.75 dBm on GPON)
@@ -278,12 +276,6 @@ public static class PhysicalLinkScorer
                 best = rung;
 
         return $"est. 1:{best.Ratio} split";
-    }
-
-    private static string? FormatPonType(string? ponType)
-    {
-        if (string.IsNullOrWhiteSpace(ponType)) return null;
-        return ponType.Trim();
     }
 
     // ---------------------------------------------------------------------------

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkScorer.cs
@@ -423,7 +423,9 @@ public static class PhysicalLinkScorer
             });
         }
 
-        var gen = isOfdm ? "DOCSIS 3.1" : "DOCSIS 3.0";
+        // An active OFDMA channel proves an OFDM-capable plant but can't tell 3.1 from 4.0
+        // (4.0 also runs OFDMA), so we name both rather than claim 3.1 specifically.
+        var gen = isOfdm ? "DOCSIS 3.1/4.0" : "DOCSIS 3.0";
         // Headline (ValueText) carries SNR + US; the description lists the other scored stats (DS, FEC).
         var desc = $"{gen} cable-modem RF health"
                    + (detailBits.Count > 0 ? $" ({string.Join(", ", detailBits)})." : ".")

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -991,11 +991,11 @@ public class UpstreamTracerService
 
         _nearTransitAsns.Clear();
         _nearTransitAsns.UnionWith(
-            ComputeNearTransitAsns(traceSequences, asnByIp, accessAsnNumbers, destinationAsns, Tier1Asns));
+            ComputeNearTransitAsns(traceSequences, asnByIp, accessAsnNumbers, destinationAsns, WellKnownAsns.Tier1));
 
         _excludedTier1Asns.Clear();
         _excludedTier1Asns.UnionWith(
-            ComputeExcludedTier1Asns(traceSequences, asnByIp, Tier1Asns, accessAsnNumbers));
+            ComputeExcludedTier1Asns(traceSequences, asnByIp, WellKnownAsns.Tier1, accessAsnNumbers));
 
         var transitGroups = _mergedHops
             .Where(h => h.Asn != null
@@ -1004,6 +1004,7 @@ public class UpstreamTracerService
                         && !(h.Asn.Name != null && destinationOrgs.Contains(h.Asn.Name.Trim()))
                         && !transitProbeAddresses.Contains(h.Address)
                         && !_excludedTier1Asns.Contains(h.Asn.Asn)
+                        && !WellKnownAsns.NonTransitInfrastructure.Contains(h.Asn.Asn)
                         && (!transitProbeAsns.Contains(h.Asn.Asn)
                             || _nearTransitAsns.Contains(h.Asn.Asn)))
             .GroupBy(h => h.Asn!.Asn)
@@ -1929,33 +1930,6 @@ public class UpstreamTracerService
     /// </summary>
     internal static string CleanAsnName(string? name) =>
         NetworkOptimizer.Core.Helpers.NetworkFormatHelpers.CleanOrgName(name);
-
-    // Tier-1 (settlement-free) networks, with the sibling ASNs that show up in real
-    // US traces. Two tier-1s adjacent on a path is core peering, not our access ISP's
-    // transit, so a tier-1 sitting directly above another tier-1 is excluded as a
-    // candidate. Stable set - revisit only on major carrier M&A. Last reviewed 2026-06.
-    //
-    // Hurricane Electric (AS6939) is deliberately NOT included: it isn't settlement-free
-    // on IPv4 (buys paid transit; Cogent won't peer), so its presence beneath a tier-1
-    // carries no reliable "core peering" signal. A tier-1 reached via HE still surfaces
-    // as a candidate and can simply be unchecked in the discovery review list.
-    internal static readonly HashSet<int> Tier1Asns = new()
-    {
-        3356, 209, 3549, 3561,            // Lumen / Level 3 / CenturyLink / Global Crossing / Savvis
-        7018, 2386, 7132, 6389, 2686,     // AT&T (incl. legacy SBC / BellSouth ASNs seen in US traces)
-        701, 702, 703,     // Verizon (UUNET)
-        2914,              // NTT (GIN)
-        174, 1239,         // Cogent (1239 = ex-SprintLink, sold to Cogent 2023)
-        1299,              // Arelion (ex-Telia)
-        3257,              // GTT (backbone now EXA Infrastructure; ASN still registered GTT)
-        6453,              // Tata
-        6461,              // Zayo
-        6762,              // Telecom Italia Sparkle
-        3491,              // PCCW Global
-        5511,              // Orange
-        12956,             // Telxius (Telefonica)
-        3320,              // Deutsche Telekom
-    };
 
     /// <summary>
     /// Near-transit ASNs: every ASN that appears as the 1st or 2nd distinct non-access,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/WellKnownAsns.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/WellKnownAsns.cs
@@ -1,0 +1,49 @@
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Catalog of hardcoded well-known ASN sets used by upstream classification and ISP
+/// Health: the tier-1 carrier set (for core-peering detection) and the non-transit
+/// infrastructure set (ASNs that ride a traceroute but never haul our traffic upstream).
+/// </summary>
+internal static class WellKnownAsns
+{
+    /// <summary>
+    /// WoodyNet / Packet Clearing House (PCH): operates IXP route servers and anycast
+    /// DNS infrastructure, not a transit carrier (AS42 = WOODYNET-1, AS715 = WOODYNET-2).
+    /// These appear on a path via IX fabric or anycast DNS endpoints, so ISP Health must
+    /// not grade, chart, or display them as Transit. Discovery never proposes them as
+    /// transit targets, and the scoring, chart, and live-stats read paths drop any rows
+    /// already committed. Exposed as an array so EF Core translates Contains() to a SQL IN
+    /// on the DB read paths.
+    /// </summary>
+    public static readonly int[] NonTransitInfrastructure = { 42, 715 };
+
+    /// <summary>
+    /// Tier-1 (settlement-free) networks, with the sibling ASNs that show up in real
+    /// US traces. Two tier-1s adjacent on a path is core peering, not our access ISP's
+    /// transit, so a tier-1 sitting directly above another tier-1 is excluded as a
+    /// candidate. Stable set - revisit only on major carrier M&amp;A. Last reviewed 2026-06.
+    ///
+    /// Hurricane Electric (AS6939) is deliberately NOT included: it isn't settlement-free
+    /// on IPv4 (buys paid transit; Cogent won't peer), so its presence beneath a tier-1
+    /// carries no reliable "core peering" signal. A tier-1 reached via HE still surfaces
+    /// as a candidate and can simply be unchecked in the discovery review list.
+    /// </summary>
+    public static readonly HashSet<int> Tier1 = new()
+    {
+        3356, 209, 3549, 3561,            // Lumen / Level 3 / CenturyLink / Global Crossing / Savvis
+        7018, 2386, 7132, 6389, 2686,     // AT&T (incl. legacy SBC / BellSouth ASNs seen in US traces)
+        701, 702, 703,     // Verizon (UUNET)
+        2914,              // NTT (GIN)
+        174, 1239,         // Cogent (1239 = ex-SprintLink, sold to Cogent 2023)
+        1299,              // Arelion (ex-Telia)
+        3257,              // GTT (backbone now EXA Infrastructure; ASN still registered GTT)
+        6453,              // Tata
+        6461,              // Zayo
+        6762,              // Telecom Italia Sparkle
+        3491,              // PCCW Global
+        5511,              // Orange
+        12956,             // Telxius (Telefonica)
+        3320,              // Deutsche Telekom
+    };
+}

--- a/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Services;
 
@@ -304,7 +305,8 @@ public class MonitoringLiveStats
         var targets = await db.MonitoringTargets.AsNoTracking()
             .Where(t => t.Enabled
                 && (t.TargetType == MonitoringTargetType.AccessIsp
-                    || t.TargetType == MonitoringTargetType.Transit))
+                    || t.TargetType == MonitoringTargetType.Transit)
+                && (t.AsnNumber == null || !WellKnownAsns.NonTransitInfrastructure.Contains(t.AsnNumber.Value)))
             .Select(t => new { t.TargetId, t.TargetType })
             .ToListAsync(ct);
 

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -605,6 +605,147 @@ public class WiFiOptimizerService
     }
 
     /// <summary>
+    /// (AP, band) pairs that have no recent per-channel spectrum-scan measurement, so their channel
+    /// recommendation falls back to the neighbor (external) scan. A non-disruptive quick-scan fills
+    /// them (see <see cref="RunQuickScansAsync"/>). Derived from the same scan snapshot the
+    /// recommendation uses, so it reflects exactly what the engine is working with.
+    /// </summary>
+    public async Task<List<SpectrumScanGap>> GetSpectrumScanGapsAsync()
+    {
+        var scans = await GetChannelScanResultsAsync(
+            startTime: DateTimeOffset.UtcNow.AddHours(-ChannelRecommendationService.ScanLookbackHours));
+
+        var provider = CreateProvider();
+        var aps = await provider.GetAccessPointsAsync();
+        var apByMac = aps.ToDictionary(a => a.Mac, StringComparer.OrdinalIgnoreCase);
+
+        // Mesh (wireless-uplink) APs can't quick-scan without dropping their uplink, so the controller
+        // refuses - don't list gaps the user can never fill.
+        var meshChildMacs = aps.Where(a => a.IsMeshChild)
+            .Select(a => a.Mac)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return scans
+            .Where(s => s.Channels.Count == 0 && !meshChildMacs.Contains(s.ApMac))
+            .Select(s =>
+            {
+                apByMac.TryGetValue(s.ApMac, out var ap);
+                var hasScanRadio = ap?.HasDedicatedScanRadio ?? false;
+                // A mesh parent only matters for the warning when it lacks a dedicated scan radio
+                // (then scanning its uplink band drops children; with a scan radio the uplink is safe).
+                var isMeshParent = (ap?.MeshChildren.Count ?? 0) > 0;
+                return new SpectrumScanGap(
+                    s.ApMac, s.ApName ?? s.ApMac, s.Band, s.Band.ToUniFiCode(), hasScanRadio, isMeshParent);
+            })
+            .ToList();
+    }
+
+    private const int QuickScanPollIntervalSeconds = 3;
+    private const int QuickScanPerBandTimeoutSeconds = 150;
+
+    /// <summary>
+    /// Trigger non-disruptive quick RF scans on the given (AP, band) targets, wait for them to
+    /// finish, then invalidate the scan cache so the next recommendation picks up the fresh
+    /// per-channel measurements. A quick-scan does NOT disconnect clients.
+    ///
+    /// A radio can only scan ONE band at a time, so an AP's bands are scanned SEQUENTIALLY (trigger,
+    /// wait for the AP to go idle, then the next band). Different APs scan CONCURRENTLY. Firing all of
+    /// an AP's bands at once makes all but one fail - that's why an unfiltered batch only ever filled
+    /// one gap per AP.
+    /// </summary>
+    public async Task RunQuickScansAsync(
+        IEnumerable<(string ApMac, string BandCode)> targets,
+        CancellationToken cancellationToken = default)
+    {
+        var list = targets.ToList();
+        if (list.Count == 0 || !_connectionService.IsConnected || _connectionService.Client == null)
+            return;
+
+        var provider = CreateProvider();
+
+        // Scan each band at the radio's CURRENT operating width so the radio doesn't reconfigure
+        // (less disruption) and the result buckets line up with the operating channel.
+        var widthByApBand = new Dictionary<(string Mac, string BandCode), int>();
+        foreach (var ap in await provider.GetAccessPointsAsync())
+            foreach (var radio in ap.Radios)
+                if (radio.ChannelWidth is int w)
+                    widthByApBand[(ap.Mac, radio.Band.ToUniFiCode())] = w;
+
+        var perApScans = list
+            .GroupBy(t => t.ApMac, StringComparer.OrdinalIgnoreCase)
+            .Select(g => ScanApBandsSequentiallyAsync(
+                provider, g.Key, g.Select(t => t.BandCode).Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+                widthByApBand, cancellationToken));
+        await Task.WhenAll(perApScans);
+
+        // Fresh scans are in - drop the cached snapshot so the next fetch re-reads the spectrum data.
+        _cachedScanResults = null;
+        _cachedScanResultsTimeKey = null;
+    }
+
+    /// <summary>
+    /// Scan one AP's bands one at a time, waiting for each to finish before starting the next, since
+    /// the radio can only scan a single band at a time. Different APs run this concurrently.
+    /// </summary>
+    private async Task ScanApBandsSequentiallyAsync(
+        UniFiLiveDataProvider provider, string apMac, List<string> bandCodes,
+        IReadOnlyDictionary<(string Mac, string BandCode), int> widthByApBand, CancellationToken cancellationToken)
+    {
+        foreach (var bandCode in bandCodes)
+        {
+            // Scan at the radio's current width (fall back to 20 MHz if unknown).
+            var bandwidthMhz = widthByApBand.TryGetValue((apMac, bandCode), out var w) ? w : 20;
+            try
+            {
+                if (!await provider.TriggerQuickScanAsync(apMac, bandCode, bandwidthMhz, cancellationToken))
+                    continue;
+                // Wait for THIS band to finish before starting the next on the same AP. If it doesn't
+                // finish in time, skip the AP's remaining bands rather than fire into a still-busy
+                // radio (which the controller rejects with api.err.QuickScanInProgress).
+                if (!await WaitForQuickScanIdleAsync(provider, apMac, cancellationToken))
+                {
+                    _logger.LogDebug(
+                        "Quick scan on {Mac} still running after {Timeout}s; skipping its remaining bands",
+                        apMac, QuickScanPerBandTimeoutSeconds);
+                    break;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Quick scan failed for {Mac} band {Band}", apMac, bandCode);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Poll an AP until its quick-scan reports idle, so the next band on the same AP doesn't start
+    /// while this one is still running. Returns true when the AP went idle, false if it was still
+    /// in-progress at the timeout (caller should not start another band on it).
+    /// </summary>
+    private async Task<bool> WaitForQuickScanIdleAsync(
+        UniFiLiveDataProvider provider, string apMac, CancellationToken cancellationToken)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(QuickScanPerBandTimeoutSeconds);
+        // Give the controller a moment to mark the scan in-progress before the first check.
+        await Task.Delay(TimeSpan.FromSeconds(QuickScanPollIntervalSeconds), cancellationToken);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            try
+            {
+                if (!await provider.IsQuickScanInProgressAsync(apMac, cancellationToken))
+                    return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Quick scan status poll failed for {Mac}", apMac);
+                return true; // can't tell - assume done rather than block the AP's other bands
+            }
+            await Task.Delay(TimeSpan.FromSeconds(QuickScanPollIntervalSeconds), cancellationToken);
+        }
+        return false;
+    }
+
+    /// <summary>
     /// Record each fresh scan's neighbor sightings into the rolling per-(AP, band) history (and
     /// prune anything past the window). Called once per fresh scan fetch; does not modify the
     /// scans, so callers still get the raw live scan back.

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using NetworkOptimizer.Audit.Analyzers;
 using NetworkOptimizer.UniFi;
+using NetworkOptimizer.UniFi.Helpers;
 using NetworkOptimizer.WiFi;
 using NetworkOptimizer.WiFi.Analyzers;
 using NetworkOptimizer.WiFi.Helpers;
@@ -839,6 +840,31 @@ public class WiFiOptimizerService
         {
             _logger.LogError(ex, "Failed to get client events for {ClientMac}", clientMac);
             return new List<WiFi.Models.ClientConnectionEvent>();
+        }
+    }
+
+    /// <summary>
+    /// Read the console's configured DFS preference for the 5 GHz radio from the
+    /// "radio_ai" (Auto-Optimize / RF Scanning) settings. Returns true when DFS is
+    /// enabled, false when it is disabled, or null when unavailable so callers can
+    /// fall back to their own default.
+    /// </summary>
+    public async Task<bool?> GetAutoOptimizeDfsEnabledAsync()
+    {
+        var client = _connectionService.Client;
+        if (client == null)
+            return null;
+
+        try
+        {
+            using var settings = await client.GetSettingsRawAsync();
+            var radioAi = RadioAiSettings.FromSettingsJson(settings);
+            return radioAi?.GetDfsEnabled(RadioAiSettings.Radio5GHz);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to read radio_ai DFS preference");
+            return null;
         }
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -4993,6 +4993,10 @@ tr:hover .snmp-row-chevron {
     display: none !important;
 }
 
+.btn-label-compact {
+    display: none;
+}
+
 .col-actions {
     width: 1%;
     white-space: nowrap;
@@ -5032,6 +5036,14 @@ tr:hover .snmp-row-chevron {
 
     .show-mobile {
         display: table-cell !important;
+    }
+
+    .btn-label-full {
+        display: none;
+    }
+
+    .btn-label-compact {
+        display: inline;
     }
 
     .host-truncate {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -16071,6 +16071,39 @@ tr.stats-row-filtered {
     z-index: 1;
 }
 
+.isp-health-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1.25rem;
+    min-height: 320px;
+    overflow: hidden;
+    border: 1px solid var(--border-color);
+    background:
+        radial-gradient(ellipse 60% 120% at 18% 0%, rgba(5, 80, 181, 0.12), transparent 60%),
+        radial-gradient(ellipse 50% 100% at 85% 100%, rgba(43, 168, 154, 0.08), transparent 65%),
+        var(--bg-card);
+}
+
+.isp-health-loading-spinner {
+    width: 54px;
+    height: 54px;
+    border-radius: 50%;
+    background: conic-gradient(from 0deg, transparent 0%, var(--primary-color) 45%, #2ba89a 100%);
+    -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 5px), #000 calc(100% - 4px));
+    mask: radial-gradient(farthest-side, transparent calc(100% - 5px), #000 calc(100% - 4px));
+    filter: drop-shadow(0 4px 16px rgba(43, 168, 154, 0.28));
+    animation: spin 0.9s linear infinite;
+}
+
+.isp-health-loading-text {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    letter-spacing: 0.01em;
+}
+
 .isp-health-hero {
     position: relative;
     margin-bottom: 1rem;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -3710,6 +3710,27 @@ select.form-control {
     gap: 1rem;
 }
 
+.scan-gap-banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+    padding: 0.75rem 1rem;
+    border-radius: var(--border-radius);
+    margin-bottom: 1rem;
+    font-size: 0.85rem;
+}
+
+.scan-gap-banner .scan-gap-text {
+    flex: 1;
+    min-width: 12rem;
+}
+
+.scan-gap-banner .btn {
+    flex-shrink: 0;
+}
+
 .banner-icon {
     font-size: 1.5rem;
     background: rgba(255, 255, 255, 0.2);
@@ -10870,7 +10891,7 @@ a.path-hop.hop-clickable:hover {
 
 .aps-header {
     display: grid;
-    grid-template-columns: 2fr 0.8fr 0.8fr 1fr 1.2fr 0.8fr 0.6fr;
+    grid-template-columns: 2fr 0.8fr 0.8fr 200px 1.2fr 0.8fr 0.6fr;
     gap: 0.5rem;
     padding: 0.75rem 1rem;
     background: var(--bg-tertiary);
@@ -10882,7 +10903,7 @@ a.path-hop.hop-clickable:hover {
 
 .aps-row {
     display: grid;
-    grid-template-columns: 2fr 0.8fr 0.8fr 1fr 1.2fr 0.8fr 0.6fr;
+    grid-template-columns: 2fr 0.8fr 0.8fr 200px 1.2fr 0.8fr 0.6fr;
     gap: 0.5rem;
     padding: 0.75rem 1rem;
     border-top: 1px solid var(--border-color);
@@ -10896,6 +10917,21 @@ a.path-hop.hop-clickable:hover {
 
 .aps-row.clickable {
     cursor: pointer;
+}
+
+.aps-row .ap-power-col .power-bar-container {
+    max-width: 170px;
+    background: var(--bg-tertiary);
+}
+
+.aps-row .ap-power-col .power-mode-below {
+    display: block;
+    max-width: 170px;
+    text-align: center;
+    margin-top: 3px;
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    text-transform: capitalize;
 }
 
 .ap-name-col {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -16113,6 +16113,82 @@ tr.stats-row-filtered {
     white-space: nowrap;
 }
 
+.isp-health-profile-chip-selectable {
+    position: relative;
+    cursor: pointer;
+    transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+.isp-health-profile-chip-selectable:hover {
+    border-color: var(--primary-color);
+    color: var(--text-primary);
+}
+
+.isp-profile-chip-caret {
+    display: inline-block;
+    width: 13px;
+    height: 13px;
+    margin-right: -0.4rem;
+    vertical-align: middle;
+    background: no-repeat center/13px url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='13' height='13' viewBox='0 0 24 24' fill='none' stroke='%235c5c66' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+}
+
+.isp-access-tech-title {
+    display: inline-flex;
+    align-items: center;
+}
+
+.isp-physical-link-source {
+    max-width: 320px;
+    margin-top: 0.5rem;
+}
+
+.isp-access-tech-select {
+    margin-left: 0.75rem;
+    padding: 0 1.1rem 0 0;
+    border: none;
+    background-color: transparent;
+    color: var(--text-muted);
+    font-size: 0.8125rem;
+    font-weight: 400;
+    vertical-align: middle;
+    cursor: pointer;
+    appearance: none;
+    -webkit-appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%235c5c66' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right center;
+}
+
+.isp-access-tech-select:hover {
+    color: var(--text-primary);
+}
+
+.isp-access-tech-select option {
+    background: var(--bg-primary);
+    color: var(--text-primary);
+}
+
+.isp-profile-chip-select {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    opacity: 0;
+    cursor: pointer;
+    border: none;
+    appearance: none;
+    -webkit-appearance: none;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+}
+
+.isp-profile-chip-select option {
+    background: var(--bg-primary);
+    color: var(--text-primary);
+}
+
 a.isp-health-hero-speed {
     display: flex;
     flex-direction: column;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -226,6 +226,14 @@ a:hover {
     font-weight: 500;
 }
 
+.card-title-icon {
+    width: 1.75rem;
+    height: 1.4rem;
+    object-fit: contain;
+    vertical-align: middle;
+    margin-right: 0.45rem;
+}
+
 .nav-sub-item {
     padding-left: 1rem;
 }
@@ -2102,6 +2110,12 @@ a.btn-sm {
     line-height: 28px;
 }
 
+@media (max-width: 768px) {
+    .loss-nav-arrow {
+        min-width: 4rem;
+    }
+}
+
 .btn-group-wrap {
     display: flex;
     flex-wrap: wrap;
@@ -2809,6 +2823,11 @@ select.form-control {
 
 .issue-recommendation strong {
     color: var(--text-primary);
+}
+
+.issue-investigate {
+    margin-top: 0.5rem;
+    font-size: 0.875rem;
 }
 
 .issue-recommendation a,

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -94,10 +94,6 @@ a {
     transition: color 0.15s ease-out;
 }
 
-a:visited {
-    color: inherit;
-}
-
 .page-description a,
 .page-description a:visited {
     color: var(--primary-color);

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -46,6 +46,34 @@ let visibilityObserver = null;
 let isInViewport = true;
 let lastFetchData = null;
 let savedState = null;
+let investigateMarker = null;  // { startMs, endMs, label, loaded } while investigating a loss event
+
+// Highlight the investigated loss event on the RTT and loss charts, mirroring the
+// shaded event annotations on the ISP Health chart. The band spans the actual coalesced
+// event so it stays tight around the loss instead of trailing past it. Loaded-loss events
+// are amber (the SQM/bufferbloat signal); plain packet-loss events are info blue.
+function buildInvestigateAnnotations() {
+    if (!investigateMarker) return { xaxis: [] };
+    const { startMs, endMs, label, loaded } = investigateMarker;
+    // The 1-min loss buckets are stamped at their stop edge, so the first bucket (startMs)
+    // covers data from the minute before it; back the band start up one minute to match.
+    const bucketMs = 60000;
+    const color = loaded ? '#f59e0b' : '#4797ff';
+    const labelBg = loaded ? '#78350f' : '#1e3a5f';
+    return {
+        xaxis: [{
+            x: startMs - bucketMs,
+            x2: endMs,
+            fillColor: color,
+            opacity: 0.15,
+            borderColor: color,
+            label: {
+                text: label,
+                style: { color: '#ededef', background: labelBg, fontSize: '10px' },
+            },
+        }],
+    };
+}
 
 function baseChartOpts(type, yTitle, yFormatter, extraOpts) {
     return {
@@ -248,6 +276,10 @@ async function loadAndUpdate() {
 
     if (rttChart) rttChart.updateSeries(rttSeries, false);
     if (lossChart) lossChart.updateSeries(lossSeries, false);
+
+    const annotations = buildInvestigateAnnotations();
+    if (rttChart) rttChart.updateOptions({ annotations }, false, false);
+    if (lossChart) lossChart.updateOptions({ annotations }, false, false);
 
     updateChartVisibility();
 
@@ -569,12 +601,20 @@ export async function mount(elId) {
     startPoll();
 }
 
-export function navigateToTime(isoTimestamp, category) {
+export function navigateToTime(isoTimestamp, category, label, loaded, eventStartIso, eventEndIso) {
     if (!savedState) {
         savedState = { category: currentCategory, rangeHours: currentRangeHours,
             customFrom, customTo, isCustomRange, windowOffset, visibility: { ...visibility } };
     }
     const ts = new Date(isoTimestamp).getTime();
+    investigateMarker = label
+        ? {
+            startMs: eventStartIso ? new Date(eventStartIso).getTime() : ts,
+            endMs: eventEndIso ? new Date(eventEndIso).getTime() : ts,
+            label,
+            loaded: !!loaded,
+        }
+        : null;
     const windowMs = 10 * 60000; // 10 min window centered on event
     customFrom = new Date(ts - windowMs);
     customTo = new Date(ts + windowMs);
@@ -598,6 +638,7 @@ export function navigateToTime(isoTimestamp, category) {
 
 export function restoreState() {
     if (!savedState) return;
+    investigateMarker = null;
     currentCategory = savedState.category;
     currentRangeHours = savedState.rangeHours;
     customFrom = savedState.customFrom;
@@ -672,5 +713,6 @@ export function unmount() {
     customTo = null;
     lastFetchData = null;
     savedState = null;
+    investigateMarker = null;
     isInViewport = true;
 }

--- a/src/NetworkOptimizer.WiFi/IWiFiDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/IWiFiDataProvider.cs
@@ -77,6 +77,23 @@ public interface IWiFiDataProvider
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Trigger a quick RF spectrum scan on an AP's band. A quick scan does NOT disconnect clients
+    /// (unlike a full scan), but takes time per band - intended for on-demand or background refresh,
+    /// never inline with a recommendation. Read results later via the scan APIs.
+    /// </summary>
+    /// <param name="apMac">AP MAC address.</param>
+    /// <param name="bandCode">UniFi band code: "ng" (2.4), "na" (5), "6e" (6).</param>
+    /// <param name="bandwidthMhz">Scan bandwidth - should match the radio's CURRENT operating width
+    /// so the radio doesn't reconfigure (less disruption) and the result buckets line up with the
+    /// operating channel.</param>
+    Task<bool> TriggerQuickScanAsync(string apMac, string bandCode, int bandwidthMhz, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Whether a quick-scan is still running on the given AP (results not yet final).
+    /// </summary>
+    Task<bool> IsQuickScanInProgressAsync(string apMac, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Whether this provider supports historical/time-series queries
     /// </summary>
     bool SupportsHistoricalData { get; }

--- a/src/NetworkOptimizer.WiFi/Models/AccessPointSnapshot.cs
+++ b/src/NetworkOptimizer.WiFi/Models/AccessPointSnapshot.cs
@@ -53,6 +53,14 @@ public class AccessPointSnapshot
     /// <summary>Whether this AP is a mesh child (has wireless uplink to another AP)</summary>
     public bool IsMeshChild { get; set; }
 
+    /// <summary>
+    /// Whether this AP has a dedicated scan radio (an all-band radio that measures the RF
+    /// environment without taking a serving radio off-channel). When true, a quick scan is
+    /// non-disruptive to clients and mesh uplinks; when false, scanning borrows the serving radio
+    /// and briefly interrupts that band. Sourced from the device's scan_radio_table.
+    /// </summary>
+    public bool HasDedicatedScanRadio { get; set; }
+
     /// <summary>MAC address of the mesh parent AP (if this is a mesh child)</summary>
     public string? MeshParentMac { get; set; }
 

--- a/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
@@ -1,6 +1,16 @@
 namespace NetworkOptimizer.WiFi.Models;
 
 /// <summary>
+/// An (AP, band) that has no recent per-channel spectrum-scan measurement, so its channel
+/// recommendation falls back to the neighbor (external) scan. A quick-scan can fill it.
+/// <paramref name="HasDedicatedScanRadio"/> = the AP scans on a dedicated radio (no client impact);
+/// otherwise scanning briefly interrupts that band. <paramref name="IsMeshParent"/> = scanning this
+/// AP (when it lacks a dedicated scan radio) can also briefly drop devices meshed through it.
+/// </summary>
+public record SpectrumScanGap(
+    string ApMac, string ApName, RadioBand Band, string BandCode, bool HasDedicatedScanRadio, bool IsMeshParent);
+
+/// <summary>
 /// Per-AP channel recommendation: current vs recommended (channel, width) tuple.
 /// </summary>
 public class ApChannelRecommendation
@@ -57,6 +67,13 @@ public class ChannelPlan
     public int UnplacedApCount { get; set; }
     public bool HasScanData { get; set; }
     public bool HasNeighborNetworks { get; set; }
+
+    /// <summary>
+    /// True when we have per-channel spectrum measurements (utilization / noise floor) for this band,
+    /// so the recommendation is grounded in measured airtime and RF noise - not just neighbor scans or
+    /// internal AP interference - even when no neighbor networks were detected.
+    /// </summary>
+    public bool HasMeasuredChannelData { get; set; }
     public bool HasBuildingData { get; set; }
 
     /// <summary>
@@ -92,8 +109,19 @@ public class InterferenceGraph
     /// </summary>
     public double[,] DirectionalWeights { get; set; } = new double[0, 0];
 
-    /// <summary>Per-AP external load by channel number. ExternalLoad[apIndex][channel] = weight</summary>
+    /// <summary>Per-AP external load by channel number. ExternalLoad[apIndex][channel] = total weight</summary>
     public Dictionary<int, double>[] ExternalLoad { get; set; } = [];
+
+    /// <summary>
+    /// Per-AP external load pooled by (control channel, width). ExternalNeighbors[apIndex][(channel,
+    /// width)] = weight. Keeping weight separated by width lets the scorer model each neighbor's true
+    /// spectral footprint: a 40 MHz neighbor on 2.4 GHz ch11 steps on ch6, so its weight counts
+    /// against any candidate channel its span overlaps - WITHOUT dragging the 20 MHz neighbors that
+    /// share its control channel along with it (pooling everything to one width over-spilled them).
+    /// When empty (e.g. a unit test that sets only <see cref="ExternalLoad"/>), the scorer falls back
+    /// to treating each external-load channel as a 20 MHz point.
+    /// </summary>
+    public Dictionary<(int Channel, int Width), double>[] ExternalNeighbors { get; set; } = [];
 
     /// <summary>
     /// Per-AP set of channels with at least one direct neighbor observation.
@@ -102,8 +130,14 @@ public class InterferenceGraph
     /// </summary>
     public HashSet<int>[] DirectlyObservedChannels { get; set; } = [];
 
-    /// <summary>Per-AP channel scan metrics (utilization/interference). ScanChannelData[apIndex][channel] = (util, interf)</summary>
-    public Dictionary<int, (int Utilization, int Interference)>[] ScanChannelData { get; set; } = [];
+    /// <summary>
+    /// Per-AP channel scan metrics, keyed by (control channel, scan bandwidth MHz) so multiple-width
+    /// buckets for the same channel can coexist (e.g. a BW20 and a BW160 reading of ch36). Value =
+    /// (utilization %, noise floor dBm); NoiseFloor is null when the scan reported no reading, lower
+    /// (more negative) is cleaner. The scorer reads it via ScanOverSpan, which prefers an exact
+    /// operating-width bucket and otherwise aggregates the finest sub-channels across the span.
+    /// </summary>
+    public Dictionary<(int Channel, int Width), (int Utilization, int? NoiseFloor)>[] ScanChannelData { get; set; } = [];
 
     public List<MeshConstraint> MeshConstraints { get; set; } = new();
 
@@ -150,11 +184,21 @@ public class ApNode
     public double TxRetriesPct { get; set; }
 
     /// <summary>
-    /// Per-channel historical stress from 30-day metrics paired with channel change events.
+    /// Per-channel historical stress from 30-day metrics paired with channel change events. This is
+    /// the AP's OWN measured reality - "ground truth" for the channels it has actually sat on.
     /// Key = channel number, Value = (avg utilization %, avg interference %, avg TX retry %).
     /// Null if historical data is unavailable.
     /// </summary>
     public Dictionary<int, (double Utilization, double Interference, double TxRetryPct)>? HistoricalStress { get; set; }
+
+    /// <summary>
+    /// Per-channel stress ESTIMATED from nearby APs' measurements (proximity-scaled, dampened) for
+    /// channels this AP has never sat on. Kept separate from <see cref="HistoricalStress"/> so the
+    /// scorer can use it as a soft estimate for the stress penalty WITHOUT it masquerading as this
+    /// AP's own measurement - the "ground-truth" consumers (comfort anchor, measured floor's sibling
+    /// lookup, observation confidence) read only the real <see cref="HistoricalStress"/>.
+    /// </summary>
+    public Dictionary<int, (double Utilization, double Interference, double TxRetryPct)>? PropagatedStress { get; set; }
 
     /// <summary>Index of this AP's mesh group leader, or -1 if not in a mesh group</summary>
     public int MeshGroupLeader { get; set; } = -1;

--- a/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
@@ -104,6 +104,21 @@ public class InterferenceGraph
 
     /// <summary>Whether scan results existed for this band (UniFi provided RF scan data)</summary>
     public bool HasScanData { get; set; }
+
+    /// <summary>
+    /// 5 GHz DFS channels for the site's regulatory domain (from <see cref="RegulatoryChannelData"/>).
+    /// Empty when no regulatory data is available, in which case DFS reasoning falls back to the
+    /// standard UNII-2/2C ranges. Used for the DFS badge and the DFS-departure friction.
+    /// </summary>
+    public HashSet<int> DfsChannels { get; set; } = new();
+
+    /// <summary>
+    /// When true, the scorer adds friction to moving an AP off a DFS channel onto a non-DFS
+    /// channel it has no scan data for. Set by the optimizer for 5 GHz except in Avoid-DFS mode,
+    /// where leaving DFS is the user's explicit goal. Off by default so direct scorer calls are
+    /// unaffected.
+    /// </summary>
+    public bool ApplyDfsDepartureFriction { get; set; }
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
@@ -23,7 +23,12 @@ public class ApChannelRecommendation
     public bool IsChanged => CurrentChannel != RecommendedChannel || CurrentWidth != RecommendedWidth;
     public bool IsMeshConstrained { get; set; }
     public bool IsUnplaced { get; set; }
-    public bool IsDfsChannel { get; set; }
+
+    /// <summary>Whether the AP's current channel span is subject to DFS.</summary>
+    public bool IsCurrentDfsChannel { get; set; }
+
+    /// <summary>Whether the recommended channel span is subject to DFS.</summary>
+    public bool IsRecommendedDfsChannel { get; set; }
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
@@ -26,6 +26,17 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
     public string ProviderName => "UniFi Live";
     public bool SupportsHistoricalData => true; // Via stat/report endpoints
 
+    /// <inheritdoc />
+    public Task<bool> TriggerQuickScanAsync(string apMac, string bandCode, int bandwidthMhz, CancellationToken cancellationToken = default)
+        => _client.TriggerQuickScanAsync(apMac, bandCode, bandwidthMhz, cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<bool> IsQuickScanInProgressAsync(string apMac, CancellationToken cancellationToken = default)
+    {
+        var scan = await _client.GetSpectrumScanAsync(apMac, cancellationToken);
+        return scan?.QuickScanState?.InProgress == true;
+    }
+
     public async Task<List<AccessPointSnapshot>> GetAccessPointsAsync(CancellationToken cancellationToken = default, bool useCache = true)
     {
         // Use UniFiDiscovery for centralized device classification (same as Audit and Speed Test)
@@ -755,6 +766,19 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
                 ?? ap.RadioTable?.Select(r => r.Radio).Distinct().ToList()
                 ?? new List<string>();
 
+            // Per-AP cached RF spectrum scan (per-channel utilization/interference across each band).
+            // This is the populated source - ap.ScanRadioTable in /stat/device is typically empty.
+            // A GET only; we never trigger a scan inline (see UniFiApiClient.TriggerQuickScanAsync).
+            UniFiSpectrumScanResponse? spectrumScan = null;
+            try
+            {
+                spectrumScan = await _client.GetSpectrumScanAsync(ap.Mac, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Spectrum scan fetch failed for AP {Mac}", ap.Mac);
+            }
+
             foreach (var bandCode in radioBands)
             {
                 var band = RadioBandExtensions.FromUniFiCode(bandCode);
@@ -768,8 +792,10 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
                     Neighbors = new List<NeighborNetwork>()
                 };
 
-                // Add spectrum data if available from scan_radio_table
-                var scanRadio = ap.ScanRadioTable?.FirstOrDefault(sr => sr.Radio == bandCode);
+                // Per-channel measured occupancy from the AP's last RF scan. Prefer the dedicated
+                // spectrum-scan endpoint (the populated source); fall back to scan_radio_table.
+                var scanRadio = spectrumScan?.Scans?.FirstOrDefault(sr => sr.Radio == bandCode)
+                    ?? ap.ScanRadioTable?.FirstOrDefault(sr => sr.Radio == bandCode);
                 if (scanRadio?.SpectrumTable != null)
                 {
                     foreach (var spectrum in scanRadio.SpectrumTable)
@@ -779,7 +805,12 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
                             Channel = spectrum.Channel,
                             Width = spectrum.Width,
                             Utilization = spectrum.Utilization,
-                            Interference = spectrum.Interference,
+                            // The scan's "interference" is a dBm floor, not a percentage. Keep it out
+                            // of the percentage-based Interference field (the scorer treats that as
+                            // 0-100) and store it as the noise floor; NeighborCount carries the
+                            // detected BSSID count. The measured %-occupancy lives in Utilization.
+                            NoiseFloor = spectrum.Interference,
+                            NeighborCount = spectrum.OtherBssCount ?? 0,
                             IsDfs = spectrum.IsDfs ?? false,
                             DfsState = spectrum.DfsState
                         });
@@ -936,6 +967,7 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
             Timestamp = timestamp,
             Radios = new List<RadioSnapshot>(),
             Vaps = new List<VapSnapshot>(),
+            HasDedicatedScanRadio = ap.HasDedicatedScanRadio,
             IsMeshChild = isMeshChild,
             MeshParentMac = meshParentMac,
             MeshUplinkBand = meshUplinkBand,

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -1065,21 +1065,34 @@ public class ChannelRecommendationService
                 triangulatedLoad += extWeight;
         }
 
-        // Floor: an unobserved channel is at least as loaded as this AP's best observed channel.
-        double minDirectLoad = double.MaxValue;
-        foreach (var dc in directChannels)
+        // Estimate the channel's load to apply the uncertainty premium to.
+        //
+        // If we have a triangulated sighting on this channel (a sibling AP scanned it and reported
+        // a neighbor), that's a real measurement - trust it. It keeps the band uncertainty
+        // multiplier below, since the observer isn't at this AP's exact spot, but it is NOT floored
+        // up to our best observed channel: a channel a sibling scanned and found quiet should read
+        // as quiet, not be assumed as busy as wherever we happen to sit.
+        //
+        // Only a channel with NO sighting at all (no direct, no triangulated) is a true blind spot.
+        // Floor it at this AP's best observed load so a blind channel never scores better than a
+        // barely-seen one - otherwise the engine eagerly jumps onto channels it has zero data for.
+        double estimatedLoad;
+        if (triangulatedLoad > 0)
         {
-            if (graph.ExternalLoad[apIndex].TryGetValue(dc, out var directWeight))
-                minDirectLoad = Math.Min(minDirectLoad, directWeight);
+            estimatedLoad = triangulatedLoad;
         }
-        if (minDirectLoad == double.MaxValue) minDirectLoad = 0;
+        else
+        {
+            double minDirectLoad = double.MaxValue;
+            foreach (var dc in directChannels)
+            {
+                if (graph.ExternalLoad[apIndex].TryGetValue(dc, out var directWeight))
+                    minDirectLoad = Math.Min(minDirectLoad, directWeight);
+            }
+            estimatedLoad = minDirectLoad == double.MaxValue ? 0 : minDirectLoad;
+        }
 
-        // Apply the band uncertainty multiplier to the best available estimate - the triangulated
-        // load OR the floor. A channel with zero observations falls back to the floor, and it must
-        // carry the SAME uncertainty premium as a partially-triangulated one. Otherwise a totally-
-        // blind channel would be penalized LESS than a barely-seen one, and the engine would too
-        // eagerly recommend moving onto a channel it has no scan data for.
-        var basePenalty = Math.Max(triangulatedLoad, minDirectLoad) * GetUnobservedMultiplier(band);
+        var basePenalty = estimatedLoad * GetUnobservedMultiplier(band);
         return (1.0 - confidence) * basePenalty;
     }
 
@@ -1862,14 +1875,15 @@ public class ChannelRecommendationService
     }
 
     /// <summary>
-    /// Friction for moving an AP off a DFS channel onto a non-DFS channel that has no direct
-    /// neighbor observation. Returns <see cref="DfsDepartureFrictionPenalty"/> only when the AP
-    /// currently sits on a DFS channel, the proposed channel is non-DFS and different, and the
-    /// proposed channel's span has zero direct neighbor sightings. A DFS channel is typically
-    /// underused, so abandoning a working one for a channel we know nothing about risks trading a
-    /// known-decent channel for a hidden mess; require real evidence before making that move.
-    /// Gated by <see cref="InterferenceGraph.ApplyDfsDepartureFriction"/> (off in Avoid-DFS mode,
-    /// where leaving DFS is the user's explicit goal).
+    /// Friction for moving an AP off a DFS channel onto a non-DFS channel we have no neighbor data
+    /// for. Returns <see cref="DfsDepartureFrictionPenalty"/> only when the AP currently sits on a
+    /// DFS channel, the proposed channel is non-DFS and different, and we have NO sighting on it at
+    /// all - neither a direct scan by this AP nor a triangulated neighbor from a sibling that
+    /// scanned it. A DFS channel is typically underused, so abandoning a working one for a channel
+    /// no one has any data on risks trading a known-decent channel for a hidden mess. A channel a
+    /// sibling has already scanned is real evidence (its measured load drives the score normally)
+    /// and earns no friction. Gated by <see cref="InterferenceGraph.ApplyDfsDepartureFriction"/>
+    /// (off in Avoid-DFS mode, where leaving DFS is the user's explicit goal).
     /// </summary>
     private double ComputeDfsDepartureFriction(
         InterferenceGraph graph,
@@ -1886,12 +1900,13 @@ public class ChannelRecommendationService
         if (!IsDfsAssignment(band, node.CurrentChannel, node.CurrentWidth, graph.DfsChannels)) return 0;
         if (IsDfsAssignment(band, assigned.Channel, assigned.Width, graph.DfsChannels)) return 0;
 
-        // Only when the destination has no direct neighbor observation. A channel we've actually
-        // scanned and found quiet is real evidence and earns no friction.
+        // Only when we have no neighbor data for the destination at all. Any external-load entry
+        // overlapping it - direct or triangulated from a sibling's scan - is real evidence, so its
+        // measured load already drives the score and no friction applies.
         var span = ChannelSpanHelper.GetChannelSpan(band, assigned.Channel, assigned.Width);
-        bool observed = graph.DirectlyObservedChannels[apIndex]
-            .Any(dc => ChannelSpanHelper.SpansOverlap(span, (dc, dc)));
-        if (observed) return 0;
+        bool haveEvidence = graph.ExternalLoad[apIndex].Keys
+            .Any(extCh => ChannelSpanHelper.SpansOverlap(span, (extCh, extCh)));
+        if (haveEvidence) return 0;
 
         return DfsDepartureFrictionPenalty;
     }

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -38,8 +38,21 @@ public class ChannelRecommendationService
     /// <summary>Weight multiplier for channel scan utilization in scoring (0-1 scale)</summary>
     private const double ScanUtilizationWeight = 0.02;
 
-    /// <summary>Weight multiplier for channel scan interference in scoring (0-1 scale)</summary>
-    private const double ScanInterferenceWeight = 0.03;
+    /// <summary>
+    /// Spectrum-scan noise floor (dBm) at or below which a channel is treated as RF-clean; only the
+    /// energy ABOVE this reference is penalized. Near -90 dBm a channel is quiet; higher (less
+    /// negative) readings mean non-Wi-Fi energy (radar, microwaves, etc.) or a strong interferer
+    /// raising the floor and hurting SNR - a real signal that utilization alone misses (a channel can
+    /// be idle yet noisy). Tunable; verify against logged live values.
+    /// </summary>
+    private const double ScanNoiseFloorReferenceDbm = -90.0;
+
+    /// <summary>Score penalty per dB of scan noise floor above the clean reference. -70 dBm (20 dB over)
+    /// adds ~1.8 before the band-stress multiplier. Tunable.</summary>
+    private const double ScanNoiseFloorWeight = 0.09;
+
+    /// <summary>Cap on noise-floor excess (dB) so an out-of-range/garbage reading can't dominate.</summary>
+    private const double ScanNoiseFloorMaxExcessDb = 45.0;
 
     /// <summary>
     /// Weight for TX retry stress penalty. High TX retries indicate the external load
@@ -120,6 +133,40 @@ public class ChannelRecommendationService
     private const double UnknownChannelPenalty = 0.15;
 
     /// <summary>
+    /// 2.4 GHz crowding friction baseline. 2.4 GHz has only three non-overlapping channels, so when
+    /// the whole band is congested a channel change buys little and risks shuffling APs onto each
+    /// other. Once the mean current per-AP score on 2.4 GHz exceeds this baseline, the optimizer
+    /// raises the net-benefit a move must clear, scaled by how far past the baseline the band is
+    /// (capped at <see cref="MaxCrowdingFriction"/>). Below the baseline, and on every other band,
+    /// there is no friction. 4.0 is roughly where a 2.4 GHz AP is clearly contended on the
+    /// CCA-anchored scale, so friction only engages once the band is genuinely busy.
+    /// </summary>
+    private const double CrowdingFrictionScoreBaseline = 4.0;
+
+    /// <summary>Maximum 2.4 GHz crowding friction multiplier (see <see cref="CrowdingFrictionScoreBaseline"/>).</summary>
+    private const double MaxCrowdingFriction = 3.0;
+
+    /// <summary>
+    /// A channel is "measurably comfortable" when the AP's own radio reports time-averaged (1d/7d)
+    /// EXTERNAL-network interference on it (airtime from other people's networks) below this percent.
+    /// The external neighbor scan counts visible-but-idle BSSIDs and can inflate a fine channel into a
+    /// bogus move recommendation; the radio's measured interference is the ground truth for the
+    /// channel it sits on. We gate on interference (not utilization, which is partly the AP's own
+    /// serving traffic that follows it to any channel). Below ~20% external airtime a 2.4/5 GHz
+    /// channel is genuinely usable, so we don't churn off it for the AP's own benefit. Tunable.
+    /// </summary>
+    private const double ComfortableInterferencePct = 20.0;
+
+    /// <summary>
+    /// Converts a measured channel occupancy percentage (0-100) to the per-AP score scale used by
+    /// the absolute gates, for the measured-congestion floor (#2). Anchored to those gates rather
+    /// than to the (over-stated) external proxy: ~40% airtime lands near <see cref="MinApScoreToMove"/>
+    /// (2.0) and ~80% near <see cref="CatastrophicAbsoluteScore"/> (4.0), so a moderately busy channel
+    /// reads as moderate - not catastrophic. Tunable.
+    /// </summary>
+    private const double MeasuredCongestionToLoadScale = 0.05;
+
+    /// <summary>
     /// Maximum allowed score degradation for any individual AP in a recommended plan.
     /// 1.5 = AP's score can increase by up to 50%. Prevents sacrificing one AP
     /// too heavily for network-wide improvement.
@@ -193,6 +240,14 @@ public class ChannelRecommendationService
     private const double SiblingResidentConfidence = 0.70;
 
     /// <summary>
+    /// Observation confidence from spectrum-scan coverage of a channel: the radio directly measured
+    /// the channel's airtime, so it isn't "unknown" - but it's a one-shot sample, so it reduces the
+    /// uncertainty penalty without erasing it (the scan is a reference, not the authority for a
+    /// move-to channel). Between sibling-resident and historic. Tunable.
+    /// </summary>
+    private const double ScanCoverageConfidence = 0.80;
+
+    /// <summary>
     /// Minimum internal (propagation) weight for a resident sibling AP to count as an observer
     /// of a channel. Below this the sibling is too far to characterize this AP's RF environment.
     /// </summary>
@@ -254,8 +309,9 @@ public class ChannelRecommendationService
             InternalWeights = new double[n, n],
             DirectionalWeights = new double[n, n],
             ExternalLoad = new Dictionary<int, double>[n],
+            ExternalNeighbors = new Dictionary<(int Channel, int Width), double>[n],
             DirectlyObservedChannels = new HashSet<int>[n],
-            ScanChannelData = new Dictionary<int, (int Utilization, int Interference)>[n],
+            ScanChannelData = new Dictionary<(int Channel, int Width), (int Utilization, int? NoiseFloor)>[n],
             MeshConstraints = new List<MeshConstraint>(),
             DfsChannels = new HashSet<int>(regulatoryData?.DfsChannels ?? [])
         };
@@ -278,6 +334,16 @@ public class ChannelRecommendationService
             if (historicalStress != null)
                 historicalStress.TryGetValue(macLower, out apHistStress);
 
+            // Visibility: if an AP has no time-averaged channel metrics, the stress term falls back
+            // to the AP's live (instantaneous) radio stats for its current channel - which a burst
+            // of client activity can inflate. Log it so we can confirm both sites are using the
+            // historical (1d/7d) data wherever it exists.
+            if (apHistStress == null || apHistStress.Count == 0)
+                _logger.LogDebug(
+                    "[ChannelRec] {ApName} {Band}: no historical channel metrics - stress falls back " +
+                    "to live radio stats for the current channel only",
+                    ap.Name, band);
+
             graph.Nodes.Add(new ApNode
             {
                 Mac = ap.Mac,
@@ -295,8 +361,9 @@ public class ChannelRecommendationService
             });
 
             graph.ExternalLoad[i] = new Dictionary<int, double>();
+            graph.ExternalNeighbors[i] = new Dictionary<(int Channel, int Width), double>();
             graph.DirectlyObservedChannels[i] = new HashSet<int>();
-            graph.ScanChannelData[i] = new Dictionary<int, (int, int)>();
+            graph.ScanChannelData[i] = new Dictionary<(int, int), (int, int?)>();
         }
 
         // Build pairwise internal interference weights
@@ -461,6 +528,7 @@ public class ChannelRecommendationService
             UnplacedApCount = graph.Nodes.Count(node => !node.IsPlaced),
             HasScanData = graph.HasScanData,
             HasNeighborNetworks = graph.ExternalLoad.Any(d => d.Count > 0),
+            HasMeasuredChannelData = graph.ScanChannelData.Any(d => d.Count > 0),
             HasBuildingData = hasBuildingData,
             DfsAvoidanceNotPossible = graph.DfsAvoidanceFallback
         };
@@ -699,10 +767,13 @@ public class ChannelRecommendationService
             if (scoreInFinal < MinApScoreToMove) continue;
             if (!node.ValidChannels.Contains(node.CurrentChannel)) continue;
 
-            // Try each valid channel and find the best that meets all constraints
+            // Try each valid channel and find the best that meets all constraints. Selection and the
+            // net-benefit test are on the NETWORK objective so a fallback move can never raise it.
             int fallbackChannel = -1;
             int fallbackWidth = node.CurrentWidth;
             double fallbackScore = scoreInFinal;
+            var netBefore = ScoreAssignment(graph, finalAssignment, band);
+            var bestNet = netBefore;
 
             foreach (var candidateCh in node.ValidChannels)
             {
@@ -725,26 +796,22 @@ public class ChannelRecommendationService
                     pctImprovement < MinApImprovementPercent)
                     continue;
 
-                // A standalone move may degrade other APs, but only if it still improves the site
-                // overall (this AP's gain exceeds the total degradation it causes) and never pushes
-                // any single AP past the catastrophic cap.
+                // Catastrophic guard: never push any single AP past the catastrophic cap. Measure each
+                // victim against its score in the REALIZED plan (finalAssignment), the same baseline
+                // the mover's gain uses.
                 bool reject = false;
-                double totalDegradation = 0;
                 for (int j = 0; j < n; j++)
                 {
                     if (j == i) continue;
-                    var otherCurrent = currentApScores[j];
-                    if (otherCurrent <= 0) continue;
+                    if (currentApScores[j] <= 0) continue;
+                    var otherInFinal = ScoreAp(graph, finalAssignment, j, band);
                     var otherScore = ScoreAp(graph, trial, j, band);
-                    if (otherScore > otherCurrent) totalDegradation += otherScore - otherCurrent;
-
-                    // Catastrophic: this move would push a victim into genuinely bad territory.
-                    if (otherScore > CatastrophicAbsoluteScore && otherScore > otherCurrent)
+                    if (otherScore > CatastrophicAbsoluteScore && otherScore > otherInFinal)
                     {
                         _logger.LogDebug(
                             "[ChannelRec] Per-AP fallback: {ApName} -> ch{Ch} would push {Victim} " +
                             "{From:F3}->{To:F3} above the {Cap:F1} ceiling, skipping",
-                            node.Name, candidateCh, graph.Nodes[j].Name, otherCurrent, otherScore,
+                            node.Name, candidateCh, graph.Nodes[j].Name, otherInFinal, otherScore,
                             CatastrophicAbsoluteScore);
                         reject = true;
                         break;
@@ -752,22 +819,24 @@ public class ChannelRecommendationService
                 }
                 if (reject) continue;
 
-                // Net-benefit: the AP's own improvement must outweigh the total degradation it
-                // causes to others, otherwise the move makes the site no better.
-                if (absImprovement <= totalDegradation)
+                // Net-benefit measured on the ACTUAL network objective (ScoreAssignment), NOT a sum of
+                // per-AP scores. Summing ScoreAp double-counts a newly-created co-channel pair, so it
+                // can call a net-WORSENING move "positive" - e.g. moving an AP onto a channel a sibling
+                // already occupies (the Front Yard ch1->ch6 case that raised the network score). Pick
+                // the candidate that lowers the network score the most; require a strict improvement.
+                var netAfter = ScoreAssignment(graph, trial, band);
+                if (netAfter >= bestNet)
                 {
                     _logger.LogDebug(
-                        "[ChannelRec] Per-AP fallback: {ApName} -> ch{Ch} improves {Abs:F3} but degrades " +
-                        "others by {Deg:F3} total (not net-positive for the site), skipping",
-                        node.Name, candidateCh, absImprovement, totalDegradation);
+                        "[ChannelRec] Per-AP fallback: {ApName} -> ch{Ch} network {Before:F3}->{After:F3} " +
+                        "is not a net improvement, skipping",
+                        node.Name, candidateCh, netBefore, netAfter);
                     continue;
                 }
 
-                if (candidateScore < fallbackScore)
-                {
-                    fallbackScore = candidateScore;
-                    fallbackChannel = candidateCh;
-                }
+                bestNet = netAfter;
+                fallbackScore = candidateScore;
+                fallbackChannel = candidateCh;
             }
 
             if (fallbackChannel >= 0)
@@ -809,6 +878,16 @@ public class ChannelRecommendationService
             var moverScore = ScoreAp(graph, finalAssignment, i, band);
             if (moverScore >= MinApScoreToMove) continue;
 
+            // Interference borne by every OTHER AP today. The altruistic pass only fires when a
+            // move reduces THIS - the mover's own score is deliberately excluded, because improving
+            // the mover is the per-AP fallback's job and it already declined to move this healthy
+            // AP. Gating on total network score instead would let a healthy AP relocate purely for
+            // its own gain (e.g. chasing a quieter channel it shares with no neighbor), which is not
+            // altruism and sneaks past the per-AP move threshold.
+            double othersBaseline = 0;
+            for (int j = 0; j < n; j++)
+                if (j != i) othersBaseline += ScoreAp(graph, finalAssignment, j, band);
+
             int bestCh = -1;
             var bestNetwork = baselineNetworkScore;
             foreach (var candidateCh in node.ValidChannels)
@@ -837,10 +916,18 @@ public class ChannelRecommendationService
                 }
                 if (catastrophic) continue;
 
-                // Accept only on a meaningful site-wide improvement (DFS-aware, like the search).
+                // The neighbors must genuinely benefit: require a meaningful drop in the OTHER APs'
+                // interference, not just a lower total (which the mover's own score change inflates).
+                double othersTrial = 0;
+                for (int j = 0; j < n; j++)
+                    if (j != i) othersTrial += ScoreAp(graph, trial, j, band);
+                if (othersBaseline - othersTrial < MinApAbsoluteImprovement) continue;
+
+                // Among genuinely altruistic moves, pick the best site-wide outcome (DFS-aware,
+                // like the search) and never accept one that makes the whole site worse.
                 var trialNetwork = AddDfsPenalty(graph, trial, band, opts.DfsPreference,
                     ScoreAssignment(graph, trial, band));
-                if (baselineNetworkScore - trialNetwork >= MinApAbsoluteImprovement && trialNetwork < bestNetwork)
+                if (trialNetwork < bestNetwork)
                 {
                     bestNetwork = trialNetwork;
                     bestCh = candidateCh;
@@ -861,6 +948,107 @@ public class ChannelRecommendationService
             }
         }
 
+        // 2.4 GHz crowding friction: in a broadly congested 2.4 GHz band, a channel change buys
+        // little and can shuffle APs onto each other, so hold an AP on its current channel unless
+        // its move clears a crowding-scaled net-site-benefit bar. The benefit sums EVERY AP's
+        // interference, so a co-channel collision is counted against both victims, not netted away.
+        // No-op on other bands and on an uncrowded 2.4 GHz band; an AP on an invalid channel still
+        // moves. Runs before the mesh sync below so a reverted leader re-aligns its children.
+        var crowdingFriction = ComputeBandCrowdingFriction(band, currentApScores);
+        if (crowdingFriction > 1.0)
+        {
+            var netBenefitBar = MinApAbsoluteImprovement * (crowdingFriction - 1.0);
+            bool revertedAny;
+            do
+            {
+                revertedAny = false;
+                for (int i = 0; i < n; i++)
+                {
+                    var node = graph.Nodes[i];
+                    var rec = plan.Recommendations[i];
+                    if (rec.RecommendedChannel == node.CurrentChannel && rec.RecommendedWidth == node.CurrentWidth)
+                        continue;
+                    // Mesh children follow their leader; an AP stuck on an invalid channel must move.
+                    if (node.MeshGroupLeader >= 0 && node.MeshGroupLeader != i) continue;
+                    if (!node.ValidChannels.Contains(node.CurrentChannel)) continue;
+
+                    var revertedAssignment = ((int Channel, int Width)[])finalAssignment.Clone();
+                    revertedAssignment[i] = (node.CurrentChannel, node.CurrentWidth);
+                    ApplyMeshConstraints(graph, revertedAssignment);
+
+                    double withMove = 0, withoutMove = 0;
+                    for (int j = 0; j < n; j++)
+                    {
+                        withMove += ScoreAp(graph, finalAssignment, j, band);
+                        withoutMove += ScoreAp(graph, revertedAssignment, j, band);
+                    }
+                    if (withoutMove - withMove >= netBenefitBar) continue; // the move earns its keep
+
+                    _logger.LogDebug(
+                        "[ChannelRec] 2.4 GHz crowding friction: reverting {ApName} ch{Rec} → ch{Cur}; net " +
+                        "site benefit {Net:F3} below the crowded-band bar {Bar:F3} (friction {Friction:F2})",
+                        node.Name, rec.RecommendedChannel, node.CurrentChannel,
+                        withoutMove - withMove, netBenefitBar, crowdingFriction);
+
+                    rec.RecommendedChannel = node.CurrentChannel;
+                    rec.RecommendedWidth = node.CurrentWidth;
+                    finalAssignment[i] = (node.CurrentChannel, node.CurrentWidth);
+                    ApplyMeshConstraints(graph, finalAssignment);
+                    revertedAny = true;
+                }
+            } while (revertedAny);
+        }
+
+        // Measured-comfort anchor (#1): don't churn an AP off a channel that its own radio measures
+        // as quiet from OUTSIDE networks (low time-averaged external-network interference) unless the
+        // move actually reduces co-channel interference to one of OUR OWN sibling APs. The external
+        // neighbor scan counts visible-but-idle BSSIDs and can inflate an externally-clean channel
+        // into a bogus move; the radio's 1d/7d interference measurement is ground truth for the
+        // channel it sits on. Self-benefit moves off such a channel are reverted; a genuine move
+        // that unsticks two of our APs sharing a channel still goes through.
+        bool comfortReverted;
+        do
+        {
+            comfortReverted = false;
+            for (int i = 0; i < n; i++)
+            {
+                var node = graph.Nodes[i];
+                var rec = plan.Recommendations[i];
+                if (rec.RecommendedChannel == node.CurrentChannel && rec.RecommendedWidth == node.CurrentWidth)
+                    continue;
+                if (node.MeshGroupLeader >= 0 && node.MeshGroupLeader != i) continue;
+                if (!node.ValidChannels.Contains(node.CurrentChannel)) continue;
+                if (!IsCurrentChannelComfortable(graph, band, i)) continue;
+
+                // Interference borne by our OTHER managed APs as recommended vs with this AP reverted
+                // (moving this AP only changes the co-channel interference it imposes on them).
+                var revertTrial = ((int Channel, int Width)[])finalAssignment.Clone();
+                revertTrial[i] = (node.CurrentChannel, node.CurrentWidth);
+                ApplyMeshConstraints(graph, revertTrial);
+
+                double othersWithMove = 0, othersReverted = 0;
+                for (int j = 0; j < n; j++)
+                {
+                    if (j == i) continue;
+                    othersWithMove += ScoreAp(graph, finalAssignment, j, band);
+                    othersReverted += ScoreAp(graph, revertTrial, j, band);
+                }
+                // Keep it put unless the move meaningfully reduces interference to our own sibling APs.
+                if (othersReverted - othersWithMove >= MinApAbsoluteImprovement) continue;
+
+                _logger.LogDebug(
+                    "[ChannelRec] Measured-comfort: keeping {ApName} on ch{Cur} (radio measures it " +
+                    "externally quiet; proposed ch{Rec} didn't help our own APs)",
+                    node.Name, node.CurrentChannel, rec.RecommendedChannel);
+
+                rec.RecommendedChannel = node.CurrentChannel;
+                rec.RecommendedWidth = node.CurrentWidth;
+                finalAssignment[i] = (node.CurrentChannel, node.CurrentWidth);
+                ApplyMeshConstraints(graph, finalAssignment);
+                comfortReverted = true;
+            }
+        } while (comfortReverted);
+
         // Sync mesh children to their leader's final channel. The leader may have moved or
         // been reverted during reconciliation; the child must mirror wherever it landed so the
         // displayed plan is physically valid (a backhaul pair shares one channel) and the
@@ -873,6 +1061,25 @@ public class ChannelRecommendationService
             plan.Recommendations[i].RecommendedChannel = leaderRec.RecommendedChannel;
             plan.Recommendations[i].RecommendedWidth = leaderRec.RecommendedWidth;
             finalAssignment[i] = (leaderRec.RecommendedChannel, leaderRec.RecommendedWidth);
+        }
+
+        // Global guardrail: never emit a plan that RAISES the network score. The post-passes
+        // (per-AP fallback, altruistic) judge benefit per AP, and a per-AP proxy can disagree with the
+        // network objective; if the final plan isn't a net improvement over current, drop every move
+        // and keep the current assignment. (Higher ScoreAssignment = worse.)
+        var finalNetworkScore = ScoreAssignment(graph, finalAssignment, band);
+        if (finalNetworkScore > currentNetworkScore)
+        {
+            _logger.LogDebug(
+                "[ChannelRec] {Band}: final plan network {Final:F3} is worse than current {Current:F3} - reverting all moves",
+                band, finalNetworkScore, currentNetworkScore);
+            for (int i = 0; i < n; i++)
+            {
+                var node = graph.Nodes[i];
+                finalAssignment[i] = (node.CurrentChannel, node.CurrentWidth);
+                plan.Recommendations[i].RecommendedChannel = node.CurrentChannel;
+                plan.Recommendations[i].RecommendedWidth = node.CurrentWidth;
+            }
         }
 
         // Re-score ALL APs against the final assignment for accurate display.
@@ -927,16 +1134,21 @@ public class ChannelRecommendationService
             }
         }
 
-        // External interference (neighbor networks)
+        // External interference (neighbor networks), floored by measured congestion (#2): the scan
+        // can UNDER-state a channel (non-beaconing/hidden airtime the rogue scan never sees), so
+        // raise it to what the radio measured. It is a floor only - never lower the proxy, because
+        // the BSSIDs the scan DID detect are real and will transmit even if idle this instant.
         for (int i = 0; i < n; i++)
         {
             var apSpan = ChannelSpanHelper.GetChannelSpan(band, assignment[i].Channel, assignment[i].Width);
-            foreach (var (extChannel, extWeight) in graph.ExternalLoad[i])
+            double externalLoad = 0;
+            foreach (var (extSpan, extWeight) in ExternalContributors(graph, band, i))
             {
-                var extSpan = (Low: extChannel, High: extChannel);
                 if (ChannelSpanHelper.SpansOverlap(apSpan, extSpan))
-                    score += extWeight;
+                    externalLoad += extWeight;
             }
+            var measured = MeasuredCongestionLoad(graph, band, i, assignment);
+            score += measured > externalLoad ? measured : externalLoad;
         }
 
         // Channel scan data (utilization/interference from RF environment scan)
@@ -946,11 +1158,10 @@ public class ChannelRecommendationService
         {
             if (graph.ScanChannelData[i].Count == 0) continue;
 
-            var ch = assignment[i].Channel;
-            if (graph.ScanChannelData[i].TryGetValue(ch, out var scanData))
+            if (ScanReadingForScoring(graph, band, i, assignment[i].Channel, assignment[i].Width) is { } scanData)
             {
                 score += scanData.Utilization * ScanUtilizationWeight * bandStress;
-                score += scanData.Interference * ScanInterferenceWeight * bandStress;
+                score += ScanNoiseFloorPenalty(scanData.NoiseFloor) * bandStress;
             }
         }
 
@@ -1002,22 +1213,24 @@ public class ChannelRecommendationService
             score += graph.DirectionalWeights[j, apIndex] * overlapFactor * InternalCoChannelMultiplier;
         }
 
-        // External interference
+        // External interference, floored by measured congestion (#2): raise a channel the rogue scan
+        // under-states up to what the radio measured, but never lower it - detected BSSIDs are real.
         var apSpan = ChannelSpanHelper.GetChannelSpan(band, assignment[apIndex].Channel, assignment[apIndex].Width);
-        foreach (var (extChannel, extWeight) in graph.ExternalLoad[apIndex])
+        double externalLoad = 0;
+        foreach (var (extSpan, extWeight) in ExternalContributors(graph, band, apIndex))
         {
-            var extSpan = (Low: extChannel, High: extChannel);
             if (ChannelSpanHelper.SpansOverlap(apSpan, extSpan))
-                score += extWeight;
+                externalLoad += extWeight;
         }
+        var measuredLoad = MeasuredCongestionLoad(graph, band, apIndex, assignment);
+        score += measuredLoad > externalLoad ? measuredLoad : externalLoad;
 
-        // Channel scan data (scaled by band stress multiplier)
+        // Channel scan data (scaled by band stress multiplier), aggregated over the channel's span.
         var bandStress = GetBandStressMultiplier(band);
-        var ch = assignment[apIndex].Channel;
-        if (graph.ScanChannelData[apIndex].TryGetValue(ch, out var scanData))
+        if (ScanReadingForScoring(graph, band, apIndex, assignment[apIndex].Channel, assignment[apIndex].Width) is { } scanData)
         {
             score += scanData.Utilization * ScanUtilizationWeight * bandStress;
-            score += scanData.Interference * ScanInterferenceWeight * bandStress;
+            score += ScanNoiseFloorPenalty(scanData.NoiseFloor) * bandStress;
         }
 
         // Historical stress (undampened) + current stats fallback (dampened)
@@ -1051,7 +1264,6 @@ public class ChannelRecommendationService
         (int Channel, int Width)[] assignment)
     {
         var directChannels = graph.DirectlyObservedChannels[apIndex];
-        if (directChannels.Count == 0) return 0;
 
         var apSpan = ChannelSpanHelper.GetChannelSpan(band, assignment[apIndex].Channel, assignment[apIndex].Width);
 
@@ -1059,9 +1271,9 @@ public class ChannelRecommendationService
         if (confidence >= 1.0) return 0;
 
         double triangulatedLoad = 0;
-        foreach (var (extChannel, extWeight) in graph.ExternalLoad[apIndex])
+        foreach (var (extSpan, extWeight) in ExternalContributors(graph, band, apIndex))
         {
-            if (ChannelSpanHelper.SpansOverlap(apSpan, (extChannel, extChannel)))
+            if (ChannelSpanHelper.SpansOverlap(apSpan, extSpan))
                 triangulatedLoad += extWeight;
         }
 
@@ -1074,8 +1286,11 @@ public class ChannelRecommendationService
         // as quiet, not be assumed as busy as wherever we happen to sit.
         //
         // Only a channel with NO sighting at all (no direct, no triangulated) is a true blind spot.
-        // Floor it at this AP's best observed load so a blind channel never scores better than a
+        // Floor it at this AP's best KNOWN load so a blind channel never scores better than a
         // barely-seen one - otherwise the engine eagerly jumps onto channels it has zero data for.
+        // Prefer directly-observed channels as the floor; an AP with NO direct scan data at all
+        // (fully blind on this band) still floors against its triangulated neighbor load, so a
+        // blind radio carries real uncertainty instead of reading a deceptive 0.
         double estimatedLoad;
         if (triangulatedLoad > 0)
         {
@@ -1083,17 +1298,224 @@ public class ChannelRecommendationService
         }
         else
         {
-            double minDirectLoad = double.MaxValue;
+            double minKnownLoad = double.MaxValue;
             foreach (var dc in directChannels)
             {
                 if (graph.ExternalLoad[apIndex].TryGetValue(dc, out var directWeight))
-                    minDirectLoad = Math.Min(minDirectLoad, directWeight);
+                    minKnownLoad = Math.Min(minKnownLoad, directWeight);
             }
-            estimatedLoad = minDirectLoad == double.MaxValue ? 0 : minDirectLoad;
+            if (minKnownLoad == double.MaxValue)
+            {
+                foreach (var (_, extWeight) in graph.ExternalLoad[apIndex])
+                    minKnownLoad = Math.Min(minKnownLoad, extWeight);
+            }
+            estimatedLoad = minKnownLoad == double.MaxValue ? 0 : minKnownLoad;
         }
 
         var basePenalty = estimatedLoad * GetUnobservedMultiplier(band);
         return (1.0 - confidence) * basePenalty;
+    }
+
+    /// <summary>
+    /// A &gt;= 1.0 multiplier capturing how congested a 2.4 GHz band is, used to raise the net
+    /// benefit a channel move must clear before it's worth recommending. Returns 1.0 (no friction)
+    /// on every other band and when the mean current per-AP score is at or below
+    /// <see cref="CrowdingFrictionScoreBaseline"/>; above the baseline it grows with the mean score,
+    /// capped at <see cref="MaxCrowdingFriction"/>. 2.4 GHz only: with just three non-overlapping
+    /// channels, once they are all busy no move meaningfully helps, so the optimizer should hold put.
+    /// </summary>
+    private static double ComputeBandCrowdingFriction(RadioBand band, double[] currentApScores)
+    {
+        if (band != RadioBand.Band2_4GHz || currentApScores.Length == 0) return 1.0;
+
+        double sum = 0;
+        foreach (var s in currentApScores) sum += s;
+        var mean = sum / currentApScores.Length;
+
+        if (mean <= CrowdingFrictionScoreBaseline) return 1.0;
+        return Math.Min(mean / CrowdingFrictionScoreBaseline, MaxCrowdingFriction);
+    }
+
+    /// <summary>
+    /// Whether the AP's current channel is "measurably comfortable" - its own radio reports
+    /// time-averaged (1d/7d) EXTERNAL-network interference on it (airtime used by other people's
+    /// networks) below <see cref="ComfortableInterferencePct"/>. Requires historical metrics (no
+    /// averaged data → not claimed comfortable). Uses interference, not utilization, so the AP's own
+    /// serving traffic (which follows it to any channel) doesn't make a fine channel read as busy.
+    /// The measured-comfort anchor uses this to avoid churning an AP off a genuinely-clean channel
+    /// just because the external neighbor scan sees a lot of idle BSSIDs.
+    /// </summary>
+    private bool IsCurrentChannelComfortable(InterferenceGraph graph, RadioBand band, int apIndex)
+    {
+        var node = graph.Nodes[apIndex];
+        if (node.HistoricalStress == null || node.HistoricalStress.Count == 0) return false;
+
+        var currentSpan = ChannelSpanHelper.GetChannelSpan(band, node.CurrentChannel, node.CurrentWidth);
+        foreach (var (histChannel, stress) in node.HistoricalStress)
+        {
+            var histSpan = ChannelSpanHelper.GetChannelSpan(band, histChannel, node.CurrentWidth);
+            if (ChannelSpanHelper.SpansOverlap(currentSpan, histSpan))
+                return stress.Interference < ComfortableInterferencePct;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Measured-congestion FLOOR (#2) for the AP's assigned channel, on the external-load scale. The
+    /// rogue/neighbor scan only sees beaconing BSSIDs, so it can UNDER-state a channel that's
+    /// genuinely busy (the inverted ch1 case: low scan weight, but high measured airtime from
+    /// non-beaconing or hidden sources). This raises the channel's congestion to what the radio
+    /// actually measured, from the best signals we have: the AP's OWN spectrum-scan utilization for
+    /// the channel (right vantage, all scanned channels), or a sibling AP's time-averaged external
+    /// interference for a channel it currently occupies (averaged, and a real signal we'd also
+    /// collide with our own AP there). Takes the higher of those. The caller uses it as a FLOOR only
+    /// - it never LOWERS the proxy, because the BSSIDs the scan DID detect are real and will transmit
+    /// even if idle this instant; the scan is a reference, not the authority. Returns -1 when no
+    /// measurement exists.
+    /// </summary>
+    /// <summary>
+    /// Score penalty from a channel's spectrum-scan noise floor (dBm): the energy ABOVE the clean
+    /// reference, capped, times the per-dB weight. Returns 0 when there's no reading. Captures RF
+    /// energy - non-Wi-Fi interference or a strong interferer - that raw utilization misses (a channel
+    /// can be idle in airtime yet have a high noise floor, e.g. 2.4 GHz ch11). The noise floor is the
+    /// ambient RF level, NOT the AP's own traffic (that shows up as utilization), so unlike the
+    /// utilization floor it's safe to apply on the AP's current channel too. Caller scales by band
+    /// stress.
+    /// </summary>
+    private static double ScanNoiseFloorPenalty(int? noiseFloorDbm)
+    {
+        if (noiseFloorDbm is not int nf) return 0;
+        var excessDb = Math.Min(ScanNoiseFloorMaxExcessDb, Math.Max(0.0, nf - ScanNoiseFloorReferenceDbm));
+        return excessDb * ScanNoiseFloorWeight;
+    }
+
+    /// <summary>
+    /// The spectrum-scan reading for an operating (channel, width). Prefers a bucket measured at that
+    /// exact width - UniFi already aggregated that channel - so we use its own number. Otherwise the
+    /// scan is finer than the operating channel (e.g. BW20 buckets under a 160 MHz channel), and
+    /// reading only the control bucket would judge a wide channel by one-eighth of its spectrum; so we
+    /// aggregate the finest sub-channels across the span the way UniFi's wide-channel scan does
+    /// (verified against a BW160-vs-BW20 capture): utilization = MEAN of the sub-channels, noise floor
+    /// = MAX (worst) of them. Returns null when no bucket overlaps the span.
+    /// </summary>
+    private static (int Utilization, int? NoiseFloor)? ScanOverSpan(
+        InterferenceGraph graph, RadioBand band, int apIndex, int channel, int width)
+    {
+        var buckets = graph.ScanChannelData[apIndex];
+        if (buckets.Count == 0) return null;
+
+        // 1) Exact operating-width bucket - trust UniFi's own aggregation for that channel.
+        if (buckets.TryGetValue((channel, width), out var exact)) return exact;
+
+        // 2) Aggregate the finest sub-channels overlapping the span (don't mix widths).
+        var span = ChannelSpanHelper.GetChannelSpan(band, channel, width);
+        var overlapping = buckets
+            .Where(kv => ChannelSpanHelper.SpansOverlap(span, (kv.Key.Channel, kv.Key.Channel)))
+            .ToList();
+        if (overlapping.Count == 0) return null;
+
+        var finestWidth = overlapping.Min(kv => kv.Key.Width);
+        var fine = overlapping.Where(kv => kv.Key.Width == finestWidth).ToList();
+
+        var util = (int)Math.Round(fine.Average(kv => (double)kv.Value.Utilization));
+        int? worstNoise = null;
+        foreach (var kv in fine)
+            if (kv.Value.NoiseFloor is int nf)
+                worstNoise = worstNoise is int n ? Math.Max(n, nf) : nf; // higher (less negative) dBm = worse
+        return (util, worstNoise);
+    }
+
+    /// <summary>
+    /// The scan reading to SCORE a channel with. For a candidate channel the AP's own scan is clean
+    /// (it wasn't transmitting there when it scanned). For the AP's CURRENT channel its own scan is
+    /// contaminated by traffic that FOLLOWS the AP - its serving load and, importantly, a mesh uplink
+    /// carrying the same traffic (e.g. a camera feed) to whatever channel the AP moves to. Counting
+    /// that against the current channel wrongly singles it out for an inescapable, self-induced load.
+    /// So for the current channel we use the CLOSEST sibling that ISN'T on that channel - its read is
+    /// a clean off-channel external scan of it - and fall back to the AP's own reading only when no
+    /// sibling has a view (e.g. a single-AP site).
+    /// </summary>
+    private static (int Utilization, int? NoiseFloor)? ScanReadingForScoring(
+        InterferenceGraph graph, RadioBand band, int apIndex, int channel, int width)
+    {
+        if (channel != graph.Nodes[apIndex].CurrentChannel)
+            return ScanOverSpan(graph, band, apIndex, channel, width);
+
+        var targetSpan = ChannelSpanHelper.GetChannelSpan(band, channel, width);
+        double bestWeight = -1;
+        (int Utilization, int? NoiseFloor)? best = null;
+        var n = graph.Nodes.Count;
+        for (int j = 0; j < n; j++)
+        {
+            if (j == apIndex) continue;
+            var sibling = graph.Nodes[j];
+            var siblingSpan = ChannelSpanHelper.GetChannelSpan(band, sibling.CurrentChannel, sibling.CurrentWidth);
+            if (ChannelSpanHelper.SpansOverlap(targetSpan, siblingSpan)) continue; // on the channel - its read is self-contaminated too
+            if (ScanOverSpan(graph, band, j, channel, width) is not { } reading) continue;
+            var weight = graph.InternalWeights[apIndex, j];
+            if (weight > bestWeight)
+            {
+                bestWeight = weight;
+                best = reading;
+            }
+        }
+        return best ?? ScanOverSpan(graph, band, apIndex, channel, width);
+    }
+
+    private double MeasuredCongestionLoad(InterferenceGraph graph, RadioBand band, int apIndex, (int Channel, int Width)[] assignment)
+    {
+        var node = graph.Nodes[apIndex];
+        var assignedChannel = assignment[apIndex].Channel;
+        var apSpan = ChannelSpanHelper.GetChannelSpan(band, assignedChannel, assignment[apIndex].Width);
+        double measuredPct = -1;
+
+        // The AP's own spectrum-scan utilization - only for a CANDIDATE channel. On its CURRENT
+        // channel the scan radio also hears the AP's own serving traffic (which follows it to any
+        // channel), so using it there would bias toward a move; the current channel's congestion is
+        // governed by the external load + the interference-based comfort anchor (#1) instead.
+        if (assignedChannel != node.CurrentChannel &&
+            ScanOverSpan(graph, band, apIndex, assignedChannel, assignment[apIndex].Width) is { } scan)
+            measuredPct = Math.Max(measuredPct, scan.Utilization);
+
+        // A sibling AP's time-averaged external interference for a channel it currently sits on,
+        // scaled by how strongly THIS AP hears that sibling (proximity) - a distant sibling's local
+        // noise isn't our experience. Reads only real (measured) HistoricalStress, never propagated.
+        var n = graph.Nodes.Count;
+        for (int j = 0; j < n; j++)
+        {
+            if (j == apIndex) continue;
+            var sibling = graph.Nodes[j];
+            if (sibling.HistoricalStress == null) continue;
+            var siblingSpan = ChannelSpanHelper.GetChannelSpan(band, sibling.CurrentChannel, sibling.CurrentWidth);
+            if (!ChannelSpanHelper.SpansOverlap(apSpan, siblingSpan)) continue;
+            if (sibling.HistoricalStress.TryGetValue(sibling.CurrentChannel, out var stress))
+                measuredPct = Math.Max(measuredPct, stress.Interference * graph.InternalWeights[apIndex, j]);
+        }
+
+        return measuredPct < 0 ? -1 : measuredPct * MeasuredCongestionToLoadScale;
+    }
+
+    /// <summary>
+    /// Each external contributor to an AP as a (channel span, weight) pair, accounting for the
+    /// neighbor's width so a wide neighbor's load is tested against its full span (e.g. a 40 MHz
+    /// neighbor on 2.4 GHz ch11 also covers ch6) - and ONLY that neighbor's weight spills, not the
+    /// 20 MHz neighbors sharing its control channel. Falls back to treating each
+    /// <see cref="InterferenceGraph.ExternalLoad"/> channel as a 20 MHz point when no per-width data
+    /// exists (e.g. a unit test that populates ExternalLoad directly).
+    /// </summary>
+    private static IEnumerable<((int Low, int High) Span, double Weight)> ExternalContributors(
+        InterferenceGraph graph, RadioBand band, int apIndex)
+    {
+        var byWidth = graph.ExternalNeighbors;
+        if (byWidth != null && apIndex < byWidth.Length && byWidth[apIndex] is { Count: > 0 } neighbors)
+        {
+            foreach (var ((channel, width), weight) in neighbors)
+                yield return (ChannelSpanHelper.GetChannelSpan(band, channel, width), weight);
+            yield break;
+        }
+
+        foreach (var (channel, weight) in graph.ExternalLoad[apIndex])
+            yield return ((channel, channel), weight);
     }
 
     /// <summary>
@@ -1128,6 +1550,12 @@ public class ChannelRecommendationService
 
         double confidence = 0;
         var node = graph.Nodes[apIndex];
+
+        // Spectrum-scan coverage: the radio directly measured the channel's airtime, so it isn't
+        // "unknown" even if it heard no beaconing neighbor there. But it's a one-shot sample, so it
+        // only partially resolves the uncertainty - the scan informs the move, it doesn't crown it.
+        if (graph.ScanChannelData[apIndex].Keys.Any(k => ChannelSpanHelper.SpansOverlap(apSpan, (k.Channel, k.Channel))))
+            confidence = Math.Max(confidence, ScanCoverageConfidence);
 
         // Historic occupancy: we have measured airtime for this AP on an overlapping channel.
         if (node.HistoricalStress != null)
@@ -1177,7 +1605,20 @@ public class ChannelRecommendationService
         var node = graph.Nodes[apIndex];
         var assignedSpan = ChannelSpanHelper.GetChannelSpan(band, assignment[apIndex].Channel, assignment[apIndex].Width);
 
-        if (node.HistoricalStress != null && node.HistoricalStress.Count > 0)
+        // Combine measured history (ground truth) with neighbor-estimated (propagated) stress for
+        // channels this AP never sat on; real measurements win where both have an entry. The
+        // propagated estimates are legitimate here (a soft channel-preference signal) but stay out of
+        // the ground-truth consumers (comfort anchor, measured floor's sibling lookup, confidence).
+        var effectiveStress = node.HistoricalStress;
+        if (node.PropagatedStress is { Count: > 0 })
+        {
+            effectiveStress = new Dictionary<int, (double Utilization, double Interference, double TxRetryPct)>(node.PropagatedStress);
+            if (node.HistoricalStress != null)
+                foreach (var (measuredCh, measuredStress) in node.HistoricalStress)
+                    effectiveStress[measuredCh] = measuredStress;
+        }
+
+        if (effectiveStress != null && effectiveStress.Count > 0)
         {
             // Per-channel historical stress: check each historically stressed channel
             // and apply its penalty if the assigned channel overlaps its span.
@@ -1190,7 +1631,7 @@ public class ChannelRecommendationService
             double utilizationPenalty = 0;
             bool hasDataForAssignedChannel = false;
 
-            foreach (var (histChannel, stress) in node.HistoricalStress)
+            foreach (var (histChannel, stress) in effectiveStress)
             {
                 var histSpan = ChannelSpanHelper.GetChannelSpan(band, histChannel, node.CurrentWidth);
                 if (ChannelSpanHelper.SpansOverlap(assignedSpan, histSpan))
@@ -1302,9 +1743,9 @@ public class ChannelRecommendationService
 
         // Compute external load on this channel span to set a floor
         double externalLoad = 0;
-        foreach (var (extChannel, extWeight) in graph.ExternalLoad[apIndex])
+        foreach (var (extSpan, extWeight) in ExternalContributors(graph, band, apIndex))
         {
-            if (ChannelSpanHelper.SpansOverlap(currentSpan, (extChannel, extChannel)))
+            if (ChannelSpanHelper.SpansOverlap(currentSpan, extSpan))
                 externalLoad += extWeight;
         }
 
@@ -1501,6 +1942,13 @@ public class ChannelRecommendationService
                     graph.ExternalLoad[j][bestChannel] = 0;
                 graph.ExternalLoad[j][bestChannel] += bestWeight;
 
+                // Pool by (channel, width) so the scorer can account for each neighbor's true
+                // spectral footprint (a 40 MHz neighbor on 2.4 GHz ch11 also steps on ch6) WITHOUT
+                // dragging the 20 MHz neighbors that share its control channel into spilling too.
+                var sightingWidth = bestWidth ?? 20;
+                var key = (bestChannel, sightingWidth);
+                graph.ExternalNeighbors[j][key] = graph.ExternalNeighbors[j].GetValueOrDefault(key) + bestWeight;
+
                 if (isDirect)
                 {
                     directCount++;
@@ -1585,29 +2033,12 @@ public class ChannelRecommendationService
             }
         }
 
-        // Merge propagated stress into each node's historical stress
+        // Store propagated stress in its OWN field - never merged into measured HistoricalStress.
+        // The stress penalty uses it as a soft estimate for channels this AP never sat on, but the
+        // ground-truth consumers (comfort anchor, measured floor's sibling lookup, observation
+        // confidence) read only the real HistoricalStress, so estimates can't masquerade as measured.
         foreach (var (nodeIdx, channels) in propagated)
-        {
-            var node = graph.Nodes[nodeIdx];
-            node.HistoricalStress ??= new Dictionary<int, (double, double, double)>();
-
-            foreach (var (ch, stress) in channels)
-            {
-                if (node.HistoricalStress.TryGetValue(ch, out var own))
-                {
-                    // AP has its own data for this channel - take the max
-                    node.HistoricalStress[ch] = (
-                        Math.Max(own.Utilization, stress.Util),
-                        Math.Max(own.Interference, stress.Interf),
-                        Math.Max(own.TxRetryPct, stress.TxRetry));
-                }
-                else
-                {
-                    // AP has no data for this channel - add the propagated data
-                    node.HistoricalStress[ch] = (stress.Util, stress.Interf, stress.TxRetry);
-                }
-            }
-        }
+            graph.Nodes[nodeIdx].PropagatedStress = channels;
     }
 
     private static void BuildScanChannelData(
@@ -1627,11 +2058,12 @@ public class ChannelRecommendationService
 
             foreach (var chInfo in scan.Channels)
             {
-                if (chInfo.Utilization.HasValue || chInfo.Interference.HasValue)
+                if (chInfo.Utilization.HasValue || chInfo.NoiseFloor.HasValue)
                 {
-                    graph.ScanChannelData[apIndex][chInfo.Channel] = (
-                        chInfo.Utilization ?? 0,
-                        chInfo.Interference ?? 0);
+                    // Key by (channel, width) so a channel's BW20 and BW160 readings coexist; the
+                    // scorer (ScanOverSpan) picks the right one for the operating width.
+                    var key = (chInfo.Channel, chInfo.Width ?? 20);
+                    graph.ScanChannelData[apIndex][key] = (chInfo.Utilization ?? 0, chInfo.NoiseFloor);
                 }
             }
         }
@@ -1861,9 +2293,10 @@ public class ChannelRecommendationService
         double penalty = 0;
         for (int i = 0; i < assignment.Length; i++)
         {
-            var ch = assignment[i].Channel;
-            // DFS range: 52-64 (UNII-2), 100-144 (UNII-2C)
-            if ((ch >= 52 && ch <= 64) || (ch >= 100 && ch <= 144))
+            // Span-aware: an 80/160 MHz block whose bonding span includes any DFS sub-channel is a
+            // DFS assignment even when its control channel isn't (e.g. 160 MHz at control ch36 spans
+            // 36-64, covering DFS 52-64). Uses the regulatory DFS set, matching the DFS badge.
+            if (IsDfsAssignment(band, assignment[i].Channel, assignment[i].Width, graph.DfsChannels))
             {
                 // Conservative confidence for now (no DFS event history available)
                 double confidence = 0.7;
@@ -1904,8 +2337,8 @@ public class ChannelRecommendationService
         // overlapping it - direct or triangulated from a sibling's scan - is real evidence, so its
         // measured load already drives the score and no friction applies.
         var span = ChannelSpanHelper.GetChannelSpan(band, assigned.Channel, assigned.Width);
-        bool haveEvidence = graph.ExternalLoad[apIndex].Keys
-            .Any(extCh => ChannelSpanHelper.SpansOverlap(span, (extCh, extCh)));
+        bool haveEvidence = ExternalContributors(graph, band, apIndex)
+            .Any(c => ChannelSpanHelper.SpansOverlap(span, c.Span));
         if (haveEvidence) return 0;
 
         return DfsDepartureFrictionPenalty;
@@ -2216,7 +2649,7 @@ public class ChannelRecommendationService
         }
 
         // Scan channel data per AP
-        sb.AppendLine("  Scan channel metrics (utilization/interference):");
+        sb.AppendLine("  Scan channel metrics (utilization / noise floor):");
         for (int i = 0; i < n; i++)
         {
             if (graph.ScanChannelData[i].Count == 0)
@@ -2225,8 +2658,8 @@ public class ChannelRecommendationService
                 continue;
             }
             var metrics = graph.ScanChannelData[i]
-                .OrderBy(kv => kv.Key)
-                .Select(kv => $"ch{kv.Key}=util:{kv.Value.Utilization}%/interf:{kv.Value.Interference}%");
+                .OrderBy(kv => kv.Key.Channel).ThenBy(kv => kv.Key.Width)
+                .Select(kv => $"ch{kv.Key.Channel}/{kv.Key.Width}=util:{kv.Value.Utilization}%/nf:{(kv.Value.NoiseFloor.HasValue ? kv.Value.NoiseFloor + "dBm" : "n/a")}");
             sb.AppendLine($"    {graph.Nodes[i].Name}: {string.Join(", ", metrics)}");
         }
 
@@ -2250,6 +2683,7 @@ public class ChannelRecommendationService
         var n = graph.Nodes.Count;
         if (n == 0) return;
 
+        var bandStress = GetBandStressMultiplier(band);
         var sb = new StringBuilder();
         sb.AppendLine($"[ChannelRec] === {phase}: Per-AP channel scores ({band}) ===");
         sb.AppendLine($"  Current assignment: {string.Join(", ", Enumerable.Range(0, n).Select(i => $"{graph.Nodes[i].Name}=ch{currentAssignment[i].Channel}"))}");
@@ -2285,60 +2719,41 @@ public class ChannelRecommendationService
                 }
 
                 var apSpan = ChannelSpanHelper.GetChannelSpan(band, ch, currentAssignment[i].Width);
-                foreach (var (extCh, extW) in graph.ExternalLoad[i])
+                foreach (var (extSpan, extW) in ExternalContributors(graph, band, i))
                 {
-                    if (ChannelSpanHelper.SpansOverlap(apSpan, (extCh, extCh)))
+                    if (ChannelSpanHelper.SpansOverlap(apSpan, extSpan))
                         externalScore += extW;
                 }
 
-                if (graph.ScanChannelData[i].TryGetValue(ch, out var scanData))
-                {
-                    scanScore = scanData.Utilization * ScanUtilizationWeight
-                              + scanData.Interference * ScanInterferenceWeight;
-                }
+                // #2 measured floor: a candidate channel's congestion is raised to what the radio
+                // measured where that exceeds the neighbor-scan proxy (matches ScoreAp).
+                var measuredFloor = MeasuredCongestionLoad(graph, band, i, testAssignment);
+                if (measuredFloor > externalScore) externalScore = measuredFloor;
 
-                // Historical channel stress penalty
-                double stressScore = 0;
-                var testSpan = ChannelSpanHelper.GetChannelSpan(band, ch, currentAssignment[i].Width);
+                // Scan: measured utilization + noise floor, band-weighted, span-aggregated, with the
+                // current channel read cross-vantage (matches ScoreAp).
+                double scanUtil = 0, scanNoise = 0;
+                if (ScanReadingForScoring(graph, band, i, ch, currentAssignment[i].Width) is { } scanData)
+                {
+                    scanUtil = scanData.Utilization * ScanUtilizationWeight * bandStress;
+                    scanNoise = ScanNoiseFloorPenalty(scanData.NoiseFloor) * bandStress;
+                }
+                scanScore = scanUtil + scanNoise;
 
-                if (node.HistoricalStress != null && node.HistoricalStress.Count > 0)
-                {
-                    foreach (var (histCh, stress) in node.HistoricalStress)
-                    {
-                        if (stress.TxRetryPct < StressMinThreshold &&
-                            stress.Utilization < StressMinThreshold &&
-                            stress.Interference < StressMinThreshold)
-                            continue;
-                        var histSpan = ChannelSpanHelper.GetChannelSpan(band, histCh, node.CurrentWidth);
-                        if (ChannelSpanHelper.SpansOverlap(testSpan, histSpan))
-                        {
-                            stressScore += (stress.TxRetryPct / 100.0) * TxRetryStressWeight
-                                + (stress.Utilization / 100.0) * UtilizationStressWeight
-                                + (stress.Interference / 100.0) * InterferenceStressWeight;
-                        }
-                    }
-                }
-                else if (node.TxRetriesPct >= StressMinThreshold ||
-                    node.ChannelUtilization >= StressMinThreshold ||
-                    node.Interference >= StressMinThreshold)
-                {
-                    var currentSpan = ChannelSpanHelper.GetChannelSpan(band, node.CurrentChannel, node.CurrentWidth);
-                    if (ChannelSpanHelper.SpansOverlap(currentSpan, testSpan))
-                    {
-                        stressScore = (node.TxRetriesPct / 100.0) * TxRetryStressWeight
-                                    + (node.ChannelUtilization / 100.0) * UtilizationStressWeight
-                                    + (node.Interference / 100.0) * InterferenceStressWeight;
-                    }
-                }
+                // Stress: reuse the real penalty so the breakdown reconciles with the score
+                // (measured historical stress un-scaled, neighbor-propagated fallback band-weighted).
+                var (histPenalty, fallbackPenalty) = ComputeStressPenalty(graph, band, i, testAssignment);
+                var stressScore = histPenalty + fallbackPenalty * bandStress;
 
                 // Unobserved channel uncertainty (confidence-weighted, matches ScoreAp/ScoreAssignment)
                 double unobservedPenalty = ComputeUnobservedPenalty(graph, band, i, testAssignment);
 
                 var total = internalScore + externalScore + scanScore + stressScore + unobservedPenalty;
                 var marker = ch == currentAssignment[i].Channel ? " <<<" : "";
-                var stressStr = stressScore > 0 ? $" + stress={stressScore:F3}(raw)" : "";
+                var scanStr = scanScore > 0 ? $" + scan={scanScore:F3}(util {scanUtil:F2}/nf {scanNoise:F2})" : "";
+                var stressStr = stressScore > 0 ? $" + stress={stressScore:F3}" : "";
                 var unobsStr = unobservedPenalty > 0 ? $" + unobs={unobservedPenalty:F3}" : "";
-                sb.AppendLine($"    ch{ch,3}: internal={internalScore:F3} + external={externalScore:F3} + scan={scanScore:F3}{stressStr}{unobsStr} = {total:F3}{marker}");
+                sb.AppendLine($"    ch{ch,3}: internal={internalScore:F3} + external={externalScore:F3}{scanStr}{stressStr}{unobsStr} = {total:F3}{marker}");
             }
         }
 

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -528,10 +528,11 @@ public class ChannelRecommendationService
                 RecommendedScore = recommendedApScore,
                 IsMeshConstrained = node.MeshGroupLeader >= 0 && node.MeshGroupLeader != i,
                 IsUnplaced = !node.IsPlaced,
-                // Authoritatively recomputed against the final channel after reconciliation (the
-                // per-AP fallback, altruistic relocation and mesh sync can all rewrite the channel
-                // below). This initial value is the optimizer's raw pick.
-                IsDfsChannel = IsDfsAssignment(band, recommendedChannel, recommendedWidth, graph.DfsChannels)
+                IsCurrentDfsChannel = IsDfsAssignment(band, node.CurrentChannel, node.CurrentWidth, graph.DfsChannels),
+                // Recommended DFS status is authoritatively recomputed against the final channel
+                // after reconciliation (the per-AP fallback, altruistic relocation and mesh sync
+                // can all rewrite the channel below). This initial value is the optimizer's raw pick.
+                IsRecommendedDfsChannel = IsDfsAssignment(band, recommendedChannel, recommendedWidth, graph.DfsChannels)
             });
         }
 
@@ -884,7 +885,7 @@ public class ChannelRecommendationService
         {
             var rec = plan.Recommendations[i];
             rec.RecommendedScore = ScoreAp(graph, finalAssignment, i, band);
-            rec.IsDfsChannel = IsDfsAssignment(band, rec.RecommendedChannel, rec.RecommendedWidth, graph.DfsChannels);
+            rec.IsRecommendedDfsChannel = IsDfsAssignment(band, rec.RecommendedChannel, rec.RecommendedWidth, graph.DfsChannels);
         }
 
         // Display scores without DFS penalty for consistency across modes.

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -21,6 +21,17 @@ public class ChannelRecommendationService
     /// <summary>DFS penalty base (equivalent to a moderate neighbor)</summary>
     private const double DfsPenaltyBase = 0.5;
 
+    /// <summary>
+    /// Friction for moving an AP off a DFS channel onto a non-DFS channel we have no direct
+    /// neighbor observation of. DFS channels are typically underused, so abandoning a working one
+    /// for a channel we have zero scan data on risks trading a known-decent channel for a hidden
+    /// mess - the apparent "improvement" may be nothing more than the absence of data. This fixed
+    /// cost is added to the candidate in the search-decision scoring so the move only wins on a
+    /// clearly substantial net gain (roughly double the normal <see cref="MinApAbsoluteImprovement"/>
+    /// bar), not on missing data. A genuinely congested DFS channel still clears it. Tunable.
+    /// </summary>
+    private const double DfsDepartureFrictionPenalty = 0.6;
+
     /// <summary>Number of random restarts for optimization</summary>
     private const int RandomRestarts = 8;
 
@@ -245,7 +256,8 @@ public class ChannelRecommendationService
             ExternalLoad = new Dictionary<int, double>[n],
             DirectlyObservedChannels = new HashSet<int>[n],
             ScanChannelData = new Dictionary<int, (int Utilization, int Interference)>[n],
-            MeshConstraints = new List<MeshConstraint>()
+            MeshConstraints = new List<MeshConstraint>(),
+            DfsChannels = new HashSet<int>(regulatoryData?.DfsChannels ?? [])
         };
 
         // Build nodes
@@ -343,6 +355,12 @@ public class ChannelRecommendationService
             return new ChannelPlan { Band = band };
         }
 
+        // Apply DFS-departure friction on 5 GHz except in Avoid-DFS mode (where leaving DFS is the
+        // user's explicit goal). The scorer reads this flag, so the friction reaches every
+        // move-decision path - search, per-AP gates, fallback and altruistic relocation alike.
+        graph.ApplyDfsDepartureFriction =
+            band == RadioBand.Band5GHz && opts.DfsPreference != DfsPreference.Exclude;
+
         // Score current assignment
         var currentAssignment = new (int Channel, int Width)[n];
         for (int i = 0; i < n; i++)
@@ -435,9 +453,6 @@ public class ChannelRecommendationService
         }
 
         // Build result
-        var dfsChannels = regulatoryData?.DfsChannels ?? [];
-        var dfsSet = new HashSet<int>(dfsChannels);
-
         var plan = new ChannelPlan
         {
             Band = band,
@@ -513,7 +528,10 @@ public class ChannelRecommendationService
                 RecommendedScore = recommendedApScore,
                 IsMeshConstrained = node.MeshGroupLeader >= 0 && node.MeshGroupLeader != i,
                 IsUnplaced = !node.IsPlaced,
-                IsDfsChannel = band == RadioBand.Band5GHz && dfsSet.Contains(recommendedChannel)
+                // Authoritatively recomputed against the final channel after reconciliation (the
+                // per-AP fallback, altruistic relocation and mesh sync can all rewrite the channel
+                // below). This initial value is the optimizer's raw pick.
+                IsDfsChannel = IsDfsAssignment(band, recommendedChannel, recommendedWidth, graph.DfsChannels)
             });
         }
 
@@ -859,9 +877,14 @@ public class ChannelRecommendationService
         // Re-score ALL APs against the final assignment for accurate display.
         // Unchanged APs may still be affected by other APs' moves (e.g., a neighbor
         // moved onto or off their channel), so their displayed score must reflect reality.
+        // Also recompute the DFS badge here: the channel may have been rewritten by the
+        // per-AP fallback, altruistic relocation or mesh sync since it was first set, so the
+        // badge must reflect the channel actually shown, not the optimizer's original pick.
         for (int i = 0; i < n; i++)
         {
-            plan.Recommendations[i].RecommendedScore = ScoreAp(graph, finalAssignment, i, band);
+            var rec = plan.Recommendations[i];
+            rec.RecommendedScore = ScoreAp(graph, finalAssignment, i, band);
+            rec.IsDfsChannel = IsDfsAssignment(band, rec.RecommendedChannel, rec.RecommendedWidth, graph.DfsChannels);
         }
 
         // Display scores without DFS penalty for consistency across modes.
@@ -944,6 +967,10 @@ public class ChannelRecommendationService
         for (int i = 0; i < n; i++)
             score += ComputeUnobservedPenalty(graph, band, i, assignment);
 
+        // Friction against blindly leaving a DFS channel for an unobserved non-DFS one
+        for (int i = 0; i < n; i++)
+            score += ComputeDfsDepartureFriction(graph, band, i, assignment[i]);
+
         return score;
     }
 
@@ -998,6 +1025,9 @@ public class ChannelRecommendationService
 
         // Unobserved channel uncertainty (confidence-weighted)
         score += ComputeUnobservedPenalty(graph, band, apIndex, assignment);
+
+        // Friction against blindly leaving a DFS channel for an unobserved non-DFS one
+        score += ComputeDfsDepartureFriction(graph, band, apIndex, assignment[apIndex]);
 
         return score;
     }
@@ -1810,7 +1840,10 @@ public class ChannelRecommendationService
         if (dfsPref == DfsPreference.Exclude)
             return baseScore; // DFS channels already excluded from valid set
 
-        // IncludeWithPenalty
+        // IncludeWithPenalty: mild penalty for occupying a DFS channel (radar-interruption risk).
+        // The DFS-departure friction (the inverse bias - don't blindly leave DFS) lives in
+        // ScoreAp/ScoreAssignment instead, so it applies on every move-decision path, not just the
+        // search/altruistic paths that route through here.
         double penalty = 0;
         for (int i = 0; i < assignment.Length; i++)
         {
@@ -1825,6 +1858,62 @@ public class ChannelRecommendationService
         }
 
         return baseScore + penalty;
+    }
+
+    /// <summary>
+    /// Friction for moving an AP off a DFS channel onto a non-DFS channel that has no direct
+    /// neighbor observation. Returns <see cref="DfsDepartureFrictionPenalty"/> only when the AP
+    /// currently sits on a DFS channel, the proposed channel is non-DFS and different, and the
+    /// proposed channel's span has zero direct neighbor sightings. A DFS channel is typically
+    /// underused, so abandoning a working one for a channel we know nothing about risks trading a
+    /// known-decent channel for a hidden mess; require real evidence before making that move.
+    /// Gated by <see cref="InterferenceGraph.ApplyDfsDepartureFriction"/> (off in Avoid-DFS mode,
+    /// where leaving DFS is the user's explicit goal).
+    /// </summary>
+    private double ComputeDfsDepartureFriction(
+        InterferenceGraph graph,
+        RadioBand band,
+        int apIndex,
+        (int Channel, int Width) assigned)
+    {
+        if (!graph.ApplyDfsDepartureFriction) return 0;
+
+        var node = graph.Nodes[apIndex];
+        if (assigned.Channel == node.CurrentChannel) return 0; // not moving
+
+        // Must currently be on DFS and proposing a non-DFS channel.
+        if (!IsDfsAssignment(band, node.CurrentChannel, node.CurrentWidth, graph.DfsChannels)) return 0;
+        if (IsDfsAssignment(band, assigned.Channel, assigned.Width, graph.DfsChannels)) return 0;
+
+        // Only when the destination has no direct neighbor observation. A channel we've actually
+        // scanned and found quiet is real evidence and earns no friction.
+        var span = ChannelSpanHelper.GetChannelSpan(band, assigned.Channel, assigned.Width);
+        bool observed = graph.DirectlyObservedChannels[apIndex]
+            .Any(dc => ChannelSpanHelper.SpansOverlap(span, (dc, dc)));
+        if (observed) return 0;
+
+        return DfsDepartureFrictionPenalty;
+    }
+
+    /// <summary>
+    /// Whether a 5 GHz channel assignment is subject to DFS. Considers the full bonding span, not
+    /// just the control channel: an 80/160 MHz block whose span includes any DFS sub-channel is a
+    /// DFS assignment (the radio must perform radar detection across the whole block). Uses the
+    /// site's regulatory DFS set when available, falling back to the standard UNII-2/2C ranges.
+    /// Mirrors the bonding-group DFS logic in <see cref="RegulatoryChannelData.GetChannels"/>.
+    /// </summary>
+    private static bool IsDfsAssignment(RadioBand band, int channel, int width, HashSet<int> dfsSet)
+    {
+        if (band != RadioBand.Band5GHz) return false;
+        var span = ChannelSpanHelper.GetChannelSpan(band, channel, width);
+        for (int c = span.Low; c <= span.High; c += 4)
+        {
+            bool isDfs = dfsSet.Count > 0
+                ? dfsSet.Contains(c)
+                : (c >= 52 && c <= 64) || (c >= 100 && c <= 144);
+            if (isDfs) return true;
+        }
+        return false;
     }
 
     private ((int Channel, int Width)[] Assignment, double Score) ExhaustiveSearch(

--- a/tests/NetworkOptimizer.UniFi.Tests/RadioAiSettingsTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/RadioAiSettingsTests.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using NetworkOptimizer.UniFi.Helpers;
+using Xunit;
+
+namespace NetworkOptimizer.UniFi.Tests;
+
+public class RadioAiSettingsTests
+{
+    private static JsonDocument Settings(string radioAiBody) =>
+        JsonDocument.Parse($$"""
+        {
+            "data": [
+                { "key": "global_switch", "jumboframe_enabled": true },
+                { "key": "radio_ai", {{radioAiBody}} }
+            ]
+        }
+        """);
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    public void GetDfsEnabled_returns_configured_value_for_5ghz(bool dfs, bool expected)
+    {
+        var json = Settings($$"""
+            "radios_configuration": [
+                { "dfs": false, "channel_width": 20, "radio": "ng" },
+                { "dfs": {{(dfs ? "true" : "false")}}, "channel_width": 160, "radio": "na" },
+                { "dfs": true, "channel_width": 160, "radio": "6e" }
+            ]
+        """);
+
+        var settings = RadioAiSettings.FromSettingsJson(json);
+
+        Assert.NotNull(settings);
+        Assert.Equal(expected, settings!.GetDfsEnabled(RadioAiSettings.Radio5GHz));
+    }
+
+    [Theory]
+    [InlineData("\"true\"", true)]
+    [InlineData("\"false\"", false)]
+    [InlineData("1", true)]
+    [InlineData("0", false)]
+    public void GetDfsEnabled_handles_flexible_bool_encodings(string dfsJson, bool expected)
+    {
+        var json = Settings($$"""
+            "radios_configuration": [
+                { "dfs": {{dfsJson}}, "channel_width": 160, "radio": "na" }
+            ]
+        """);
+
+        var settings = RadioAiSettings.FromSettingsJson(json);
+
+        Assert.Equal(expected, settings!.GetDfsEnabled(RadioAiSettings.Radio5GHz));
+    }
+
+    [Fact]
+    public void GetDfsEnabled_returns_null_when_radio_absent()
+    {
+        var json = Settings($$"""
+            "radios_configuration": [
+                { "dfs": true, "channel_width": 20, "radio": "ng" }
+            ]
+        """);
+
+        var settings = RadioAiSettings.FromSettingsJson(json);
+
+        Assert.NotNull(settings);
+        Assert.Null(settings!.GetDfsEnabled(RadioAiSettings.Radio5GHz));
+    }
+
+    [Fact]
+    public void FromSettingsJson_returns_null_when_radio_ai_key_absent()
+    {
+        using var json = JsonDocument.Parse("""
+        { "data": [ { "key": "global_switch", "jumboframe_enabled": true } ] }
+        """);
+
+        Assert.Null(RadioAiSettings.FromSettingsJson(json));
+    }
+
+    [Fact]
+    public void FromSettingsJson_returns_null_for_null_input() =>
+        Assert.Null(RadioAiSettings.FromSettingsJson(null));
+}

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/PhysicalLinkScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/PhysicalLinkScorerTests.cs
@@ -14,7 +14,7 @@ public class PhysicalLinkScorerTests
     private const double Weight = 0.15;
 
     private static PhysicalLinkResult ScorePon(double rx, double? worst = null, double? baseline = null,
-        bool? operational = null, double? tx = null, string ponType = "GPON",
+        bool? operational = null, double? tx = null, bool isXgsPon = false,
         long? fecTotal = null, long? bipTotal = null, double windowDays = 2.0) =>
         PhysicalLinkScorer.Score(new PhysicalLinkInput
         {
@@ -25,7 +25,7 @@ public class PhysicalLinkScorerTests
             RxPowerBaselineDbm = baseline,
             PonOperational = operational,
             TxPowerDbm = tx,
-            PonType = ponType,
+            IsXgsPon = isXgsPon,
             FecErrorsTotal = fecTotal,
             BipErrorsTotal = bipTotal,
             WindowDays = windowDays
@@ -204,14 +204,14 @@ public class PhysicalLinkScorerTests
     [InlineData(-22.6, "1:64")]
     public void Split_ratio_inference_snaps_to_nearest_rung(double rx, string expected)
     {
-        PhysicalLinkScorer.InferSplitRatio(rx, "GPON").Should().Contain(expected);
+        PhysicalLinkScorer.InferSplitRatio(rx, isXgs: false).Should().Contain(expected);
     }
 
     [Fact]
     public void Split_ratio_caps_at_1_64_for_very_cold_rx()
     {
         // Deeper than 1:64 is reported as 1:64+/excess, never 1:128.
-        PhysicalLinkScorer.InferSplitRatio(-30.0, "GPON").Should().Contain("1:64+");
+        PhysicalLinkScorer.InferSplitRatio(-30.0, isXgs: false).Should().Contain("1:64+");
     }
 
     // ---- Active Ethernet ----

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
@@ -986,7 +986,7 @@ public class ComputeExcludedTier1AsnsTests
     {
         // Core tier-1s, plus the corrected AS1239 (now Cogent) and active AT&T/Lumen
         // sibling ASNs that show up in US traces.
-        UpstreamTracerService.Tier1Asns.Should().Contain(
+        WellKnownAsns.Tier1.Should().Contain(
             new[] { 3356, 174, 7018, 2914, 1299, 6461, 1239, 7132, 3561 });
     }
 
@@ -995,7 +995,15 @@ public class ComputeExcludedTier1AsnsTests
     {
         // AS6939 is not settlement-free on IPv4, so it carries no reliable core-peering
         // signal and stays out of the adjacency set.
-        UpstreamTracerService.Tier1Asns.Should().NotContain(6939);
+        WellKnownAsns.Tier1.Should().NotContain(6939);
+    }
+
+    [Fact]
+    public void NonTransitInfrastructure_includes_woodynet_pch()
+    {
+        // WoodyNet / PCH (AS42, AS715) runs IXP route servers and anycast DNS, not
+        // commercial transit, so both stay in the non-transit exclusion set.
+        WellKnownAsns.NonTransitInfrastructure.Should().Contain(new[] { 42, 715 });
     }
 }
 

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -571,6 +571,98 @@ public class ChannelRecommendationServiceTests
         }
     }
 
+    // Standard US 5 GHz regulatory channel set (80 MHz bonding groups + DFS list).
+    private static RegulatoryChannelData StdUsRegulatory() => new()
+    {
+        Channels5GHz = new Dictionary<int, int[]>
+        {
+            { 20, new[] { 36, 40, 44, 48, 52, 56, 60, 64, 100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144, 149, 153, 157, 161, 165 } },
+            { 80, new[] { 36, 52, 100, 116, 132, 149 } }
+        },
+        DfsChannels = new[] { 52, 56, 60, 64, 100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144 }
+    };
+
+    // A single 5 GHz AP on the given channel, with the given per-channel external load and the set
+    // of channels it has directly observed. Mirrors the live-graph shape the optimizer consumes.
+    private InterferenceGraph SingleApGraph(
+        int currentChannel,
+        Dictionary<int, double> externalLoad,
+        HashSet<int> directlyObserved,
+        RegulatoryChannelData reg,
+        RecommendationOptions options)
+    {
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "Subject", RadioBand.Band5GHz, currentChannel, hasDfs: true)
+        };
+        var graph = _service.BuildInterferenceGraph(aps, RadioBand.Band5GHz, null, null, reg, options);
+        graph.ExternalLoad[0] = externalLoad;
+        graph.DirectlyObservedChannels[0] = directlyObserved;
+        return graph;
+    }
+
+    [Fact]
+    public void Optimize_DfsToUnobservedNonDfs_FrictionKeepsApOnDfs()
+    {
+        // The reported case (Mac site): an AP healthy on a DFS channel with one known neighbor, and
+        // a non-DFS channel it has NO scan data for. Without friction the engine jumps to the
+        // non-DFS channel because it "looks" empty - but that emptiness is just missing data.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var graph = SingleApGraph(52,
+            externalLoad: new() { { 52, 0.55 } },
+            directlyObserved: new(), // only triangulated data, like the live Mac AP
+            reg, options);
+
+        var plan = _service.Optimize(graph, RadioBand.Band5GHz, reg, options);
+
+        var subject = plan.Recommendations.Single();
+        subject.RecommendedChannel.Should().Be(52,
+            "leaving a working DFS channel for a non-DFS channel with no scan data is a blind bet");
+        subject.IsChanged.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Optimize_DfsToObservedCleanNonDfs_MoveAllowed_BadgeNotDfs()
+    {
+        // Friction is waived when the non-DFS destination has real scan evidence it's clean. A
+        // congested DFS AP should still move - and the DFS badge must reflect the final non-DFS
+        // channel, not the optimizer's first pick (the stale-badge bug).
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var graph = SingleApGraph(52,
+            externalLoad: new() { { 52, 2.5 }, { 36, 0.0 } }, // current DFS busy, ch36 scanned clean
+            directlyObserved: new() { 52, 36 },
+            reg, options);
+
+        var plan = _service.Optimize(graph, RadioBand.Band5GHz, reg, options);
+
+        var subject = plan.Recommendations.Single();
+        subject.RecommendedChannel.Should().Be(36);
+        subject.IsChanged.Should().BeTrue();
+        subject.IsDfsChannel.Should().BeFalse("ch36 (UNII-1) is not a DFS channel");
+    }
+
+    [Fact]
+    public void Optimize_RecommendsDfsChannel_BadgeIsDfs()
+    {
+        // A congested non-DFS AP with a clean, observed DFS channel available: the move is to DFS
+        // (no departure friction - it's moving onto DFS, not off it) and the badge must show DFS.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var graph = SingleApGraph(149,
+            externalLoad: new() { { 149, 3.0 }, { 100, 0.5 }, { 116, 2.0 }, { 132, 2.0 } },
+            directlyObserved: new() { 149, 100, 116, 132 },
+            reg, options);
+
+        var plan = _service.Optimize(graph, RadioBand.Band5GHz, reg, options);
+
+        var subject = plan.Recommendations.Single();
+        subject.RecommendedChannel.Should().Be(100);
+        subject.IsChanged.Should().BeTrue();
+        subject.IsDfsChannel.Should().BeTrue("ch100 (UNII-2C) is a DFS channel");
+    }
+
     [Fact]
     public void Optimize_PinnedAp_ChannelUnchanged()
     {

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -672,11 +672,12 @@ public class ChannelRecommendationServiceTests
         // The reported case: a congested DFS AP, a non-DFS channel that a sibling scanned and found
         // clean (triangulated, not in this AP's own direct set). Triangulation is real evidence, so
         // the clean non-DFS channel should win - the engine must NOT floor or friction it into
-        // losing to a directly-observed-but-occupied DFS channel.
+        // losing to a directly-observed-but-occupied DFS channel. The current channel is loaded
+        // above the per-AP move threshold so the move routes through the normal per-AP path.
         var reg = StdUsRegulatory();
         var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
         var graph = SingleApGraph(52,
-            externalLoad: new() { { 52, 1.5 }, { 36, 0.2 } }, // ch52 directly heard busy; ch36 triangulated clean
+            externalLoad: new() { { 52, 2.5 }, { 36, 0.2 } }, // ch52 directly heard busy; ch36 triangulated clean
             directlyObserved: new() { 52 },                   // ch36 NOT directly observed by this AP
             reg, options);
 
@@ -687,6 +688,384 @@ public class ChannelRecommendationServiceTests
             "a sibling-scanned clean channel is real evidence and beats a directly-observed occupied DFS channel");
         subject.IsCurrentDfsChannel.Should().BeTrue("ch52 (UNII-2) is a DFS channel");
         subject.IsRecommendedDfsChannel.Should().BeFalse("ch36 (UNII-1) is not a DFS channel");
+    }
+
+    [Fact]
+    public void Optimize_AltruisticRelocation_DoesNotMoveHealthyApWhenNoNeighborBenefits()
+    {
+        // The reported Mac case: two APs that share no spectrum (ch36 and ch149). The ch36 AP is
+        // healthy (below the per-AP move threshold) and a cleaner channel exists, but relocating it
+        // only lowers ITS OWN score - it cannot declutter the ch149 neighbor. The altruistic pass
+        // must NOT move it. Before the fix the gate measured total network score, which the mover's
+        // own drop inflates, so it relocated the AP onto an unshared channel for no one's benefit.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "Mover", RadioBand.Band5GHz, 36, width: 20),
+            CreateAp("aa:bb:cc:dd:ee:02", "Bystander", RadioBand.Band5GHz, 149, width: 20)
+        };
+        var graph = _service.BuildInterferenceGraph(aps, RadioBand.Band5GHz, null, null, reg, options);
+        // Mover sits on a lightly-loaded ch36 with a clean, directly-observed non-DFS ch161 nearby.
+        graph.ExternalLoad[0] = new() { { 36, 0.8 } };
+        graph.DirectlyObservedChannels[0] = new() { 36, 161 };
+        // Bystander is healthy on ch149 and overlaps neither ch36 nor the mover's alternatives.
+        graph.ExternalLoad[1] = new() { { 149, 0.3 } };
+        graph.DirectlyObservedChannels[1] = new() { 149 };
+
+        var plan = _service.Optimize(graph, RadioBand.Band5GHz, reg, options);
+
+        var mover = plan.Recommendations.First(r => r.ApMac == "aa:bb:cc:dd:ee:01");
+        mover.RecommendedChannel.Should().Be(36,
+            "a healthy AP must not relocate when the move helps no neighbor - that just chases its own score");
+        mover.IsChanged.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Optimize_AltruisticRelocation_StillMovesHealthyApThatDecluttersCoChannelNeighbor()
+    {
+        // Regression guard for the legitimate altruistic path: a healthy AP that interferes with a
+        // co-channel neighbor SHOULD relocate, because the neighbor genuinely benefits. The neighbor
+        // suffers from the shared channel but stays below the move threshold, so it can't rescue
+        // itself - only the mover relocating helps it. The per-AP path won't move the mover either
+        // (it too is below the threshold); only the altruistic pass can, and it must still fire when
+        // the OTHER AP's score actually drops.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "Mover", RadioBand.Band5GHz, 36, width: 20),
+            CreateAp("aa:bb:cc:dd:ee:02", "Victim", RadioBand.Band5GHz, 36, width: 20)
+        };
+        var graph = _service.BuildInterferenceGraph(aps, RadioBand.Band5GHz, null, null, reg, options);
+        // Asymmetric coupling: the mover blasts the victim (0.5 -> 1.5 co-channel pain, real but
+        // under the 2.0 move threshold so the victim can't escape on its own), but barely hears it
+        // back (0.1 -> 0.3), so the mover stays comfortably healthy on the shared channel.
+        graph.InternalWeights[0, 1] = graph.InternalWeights[1, 0] = 0.5;
+        graph.DirectionalWeights[0, 1] = 0.5; // mover -> victim (strong)
+        graph.DirectionalWeights[1, 0] = 0.1; // victim -> mover (weak)
+        graph.ExternalLoad[0] = new() { { 36, 0.0 }, { 161, 0.0 } };
+        graph.DirectlyObservedChannels[0] = new() { 36, 161 };
+        graph.ExternalLoad[1] = new() { { 36, 0.0 } };
+        graph.DirectlyObservedChannels[1] = new() { 36 };
+
+        var plan = _service.Optimize(graph, RadioBand.Band5GHz, reg, options);
+
+        var mover = plan.Recommendations.First(r => r.ApMac == "aa:bb:cc:dd:ee:01");
+        var victim = plan.Recommendations.First(r => r.ApMac == "aa:bb:cc:dd:ee:02");
+        mover.RecommendedChannel.Should().NotBe(36,
+            "the mover should relocate to declutter the co-channel victim that genuinely benefits");
+        victim.RecommendedChannel.Should().Be(36,
+            "the victim is below the move threshold and is decluttered by the mover leaving, not by moving itself");
+    }
+
+    [Fact]
+    public void ScoreAssignment_BlindApUnobservedChannel_FlooredAgainstTriangulatedLoad()
+    {
+        // Fix for the deceptive 0.0: an AP with NO direct scan data on the band (fully blind, only
+        // triangulated neighbor sightings) used to short-circuit the unobserved penalty to 0, so an
+        // unscanned channel read as a perfect 0.0 and won relocations. It must instead floor against
+        // the AP's known (triangulated) load so a blind channel carries real uncertainty.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var graph = SingleApGraph(36,
+            externalLoad: new() { { 36, 0.2 } }, // a single triangulated sighting; nothing on ch100
+            directlyObserved: new(),             // fully blind - no direct scans on this band
+            reg, options);
+
+        var onUnobserved = _service.ScoreAssignment(graph, new[] { (100, 80) }, RadioBand.Band5GHz);
+
+        onUnobserved.Should().BeGreaterThan(0, "an unobserved channel must never score a deceptive 0.0");
+        onUnobserved.Should().BeApproximately(0.4, 0.05,
+            "a blind AP floors an unscanned channel at its triangulated load (0.2) x the 5 GHz uncertainty multiplier (2.0)");
+    }
+
+    [Fact]
+    public void Optimize_Crowded24GHz_SuppressesMarginalCollisionMove()
+    {
+        // In a saturated 2.4 GHz band, the optimizer was shoving a congested AP onto a neighbor's
+        // channel for a tiny net gain (the unobserved floor over-priced the one empty lane). The
+        // crowding friction must hold it put: a move that nets little once both co-channel victims
+        // are counted isn't worth the churn when the whole band is already busy.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "Living Room", RadioBand.Band2_4GHz, 1, width: 20),
+            CreateAp("aa:bb:cc:dd:ee:02", "Downstairs", RadioBand.Band2_4GHz, 11, width: 20)
+        };
+        var graph = _service.BuildInterferenceGraph(aps, RadioBand.Band2_4GHz, null, null, reg, options);
+        graph.InternalWeights[0, 1] = graph.InternalWeights[1, 0] = 1.0;
+        graph.DirectionalWeights[0, 1] = graph.DirectionalWeights[1, 0] = 1.0;
+        // Every channel is busy. ch1 is the least-bad, so the search wants to pile Downstairs onto
+        // Living Room's ch1 - a co-channel collision whose net site benefit is negative.
+        graph.ExternalLoad[0] = new() { { 1, 4.0 }, { 6, 8.0 }, { 11, 9.0 } };
+        graph.DirectlyObservedChannels[0] = new() { 1, 6, 11 };
+        graph.ExternalLoad[1] = new() { { 1, 4.0 }, { 6, 8.0 }, { 11, 9.0 } };
+        graph.DirectlyObservedChannels[1] = new() { 1, 6, 11 };
+
+        var plan = _service.Optimize(graph, RadioBand.Band2_4GHz, reg, options);
+
+        var downstairs = plan.Recommendations.First(r => r.ApMac == "aa:bb:cc:dd:ee:02");
+        downstairs.RecommendedChannel.Should().Be(11,
+            "in a crowded 2.4 GHz band a move onto a neighbor's channel isn't worth the churn");
+        downstairs.RecommendedChannel.Should().NotBe(1, "it must not be shoved into a co-channel collision");
+    }
+
+    [Fact]
+    public void Optimize_Crowded24GHz_StillSpreadsClusteredAps()
+    {
+        // The crowding friction must not stop us spreading APs apart: three APs piled on ch1 hurt
+        // each other badly, and splitting them across 1/6/11 is a large net win (each resolved
+        // collision frees both victims), so it clears the crowded-band bar with room to spare.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "AP-1", RadioBand.Band2_4GHz, 1, width: 20),
+            CreateAp("aa:bb:cc:dd:ee:02", "AP-2", RadioBand.Band2_4GHz, 1, width: 20),
+            CreateAp("aa:bb:cc:dd:ee:03", "AP-3", RadioBand.Band2_4GHz, 1, width: 20)
+        };
+        var graph = _service.BuildInterferenceGraph(aps, RadioBand.Band2_4GHz, null, null, reg, options);
+        for (int a = 0; a < 3; a++)
+            for (int b = 0; b < 3; b++)
+                if (a != b) { graph.InternalWeights[a, b] = 1.0; graph.DirectionalWeights[a, b] = 1.0; }
+        for (int a = 0; a < 3; a++)
+        {
+            graph.ExternalLoad[a] = new() { { 1, 2.0 }, { 6, 2.0 }, { 11, 2.0 } };
+            graph.DirectlyObservedChannels[a] = new() { 1, 6, 11 };
+        }
+
+        var plan = _service.Optimize(graph, RadioBand.Band2_4GHz, reg, options);
+
+        var channels = plan.Recommendations.Select(r => r.RecommendedChannel).Distinct().ToList();
+        channels.Should().HaveCountGreaterThan(1,
+            "clustered APs must still be spread across 2.4 GHz channels despite the crowding friction");
+    }
+
+    [Fact]
+    public void ScoreAssignment_WideNeighbor_StepsOnAdjacentChannel()
+    {
+        // A 40 MHz neighbor on 2.4 GHz ch11 spectrally covers ch6 too (span 7-14 vs ch6's 4-8), so
+        // its load must count against a candidate ch6, not just its control channel. A 20 MHz
+        // neighbor on ch11 does not reach ch6. And crucially, 20 MHz neighbors that share the wide
+        // neighbor's control channel must NOT be dragged into spilling along with it.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions();
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "AP", RadioBand.Band2_4GHz, 11, width: 20)
+        };
+
+        InterferenceGraph Build(params (int Channel, int Width, double Weight)[] neighbors)
+        {
+            var g = _service.BuildInterferenceGraph(aps, RadioBand.Band2_4GHz, null, null, reg, options);
+            g.ExternalLoad[0] = new();
+            g.ExternalNeighbors[0] = new();
+            foreach (var (ch, w, weight) in neighbors)
+            {
+                g.ExternalLoad[0][ch] = g.ExternalLoad[0].GetValueOrDefault(ch) + weight;
+                g.ExternalNeighbors[0][(ch, w)] = g.ExternalNeighbors[0].GetValueOrDefault((ch, w)) + weight;
+            }
+            g.DirectlyObservedChannels[0] = new() { 11 };
+            return g;
+        }
+
+        var ch6Narrow = _service.ScoreAssignment(Build((11, 20, 1.0)), new[] { (6, 20) }, RadioBand.Band2_4GHz);
+        var ch6Wide = _service.ScoreAssignment(Build((11, 40, 1.0)), new[] { (6, 20) }, RadioBand.Band2_4GHz);
+
+        ch6Wide.Should().BeGreaterThan(ch6Narrow,
+            "a 40 MHz neighbor on ch11 steps on ch6, so it raises ch6's score; a 20 MHz one does not");
+        (ch6Wide - ch6Narrow).Should().BeApproximately(1.0, 0.01,
+            "only the wide neighbor's weight reaches ch6 once spectral width is accounted for");
+
+        // The fix for the over-spill: a pile of 20 MHz neighbors on ch11 plus ONE 40 MHz neighbor
+        // there must spill only the 40 MHz neighbor's weight into ch6 - the 20 MHz weight stays put.
+        var ch6Mixed = _service.ScoreAssignment(
+            Build((11, 20, 5.0), (11, 40, 1.0)), new[] { (6, 20) }, RadioBand.Band2_4GHz);
+        (ch6Mixed - ch6Narrow).Should().BeApproximately(1.0, 0.01,
+            "only the 40 MHz neighbor (1.0) spills to ch6; the 5.0 of 20 MHz neighbors on ch11 do not");
+    }
+
+    [Fact]
+    public void ScoreAssignment_MeasuredFloor_RaisesUnderstatedCandidate_ButNeverDiscountsKnownBssids()
+    {
+        // The measured floor applies to CANDIDATE channels (a move-to). AP currently on ch36; we
+        // score it on the candidate ch40. Floor: the scan barely registers ch40 (0.5 proxy) but the
+        // radio measures it 50% busy, so congestion is RAISED to the measurement. Not a cap: a
+        // candidate with many KNOWN BSSIDs (proxy 8.0) that scans idle (5%) keeps its proxy -
+        // detected BSSIDs are real and the scan is only a reference.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions();
+
+        InterferenceGraph Build(double externalLoad, int scanUtil)
+        {
+            var g = SingleApGraph(36, externalLoad: new() { { 40, externalLoad } }, directlyObserved: new(), reg, options);
+            g.ScanChannelData[0] = new Dictionary<(int Channel, int Width), (int Utilization, int? NoiseFloor)> { { (40, 80), (scanUtil, (int?)null) } };
+            return g;
+        }
+
+        var understated = _service.ScoreAssignment(Build(0.5, 50), new[] { (40, 80) }, RadioBand.Band5GHz);
+        var knownButIdle = _service.ScoreAssignment(Build(8.0, 5), new[] { (40, 80) }, RadioBand.Band5GHz);
+
+        understated.Should().BeGreaterThan(2.0,
+            "an under-stated candidate is floored up to the measured 50% airtime (~2.5 at the 0.05 scale), not left at the 0.5 proxy");
+        knownButIdle.Should().BeGreaterThan(7.0,
+            "the 8.0 of known BSSIDs is kept - a one-shot idle scan never discounts detected APs");
+    }
+
+    [Fact]
+    public void MeasuredFloor_AppliesToCandidateNotCurrentChannel_OwnUtilizationBiasRemoved()
+    {
+        // The own-scan utilization floor must NOT inflate the AP's CURRENT channel - its scan radio
+        // also hears its own serving traffic, which follows it anywhere. Same measured 60% util: on a
+        // candidate it floors the score up; on the current channel it does not.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions();
+
+        InterferenceGraph Build(int scanChannel)
+        {
+            var g = SingleApGraph(36, externalLoad: new() { { 36, 0.5 }, { 40, 0.5 } }, directlyObserved: new(), reg, options);
+            g.ScanChannelData[0] = new Dictionary<(int Channel, int Width), (int Utilization, int? NoiseFloor)> { { (scanChannel, 80), (60, (int?)null) } };
+            return g;
+        }
+
+        var current = _service.ScoreAssignment(Build(36), new[] { (36, 80) }, RadioBand.Band5GHz);
+        var candidate = _service.ScoreAssignment(Build(40), new[] { (40, 80) }, RadioBand.Band5GHz);
+
+        candidate.Should().BeGreaterThan(current + 1.5,
+            "60% measured util floors a candidate channel (~3.0) but not the current channel, whose airtime is the AP's own traffic");
+    }
+
+    [Fact]
+    public void ScoreAssignment_NoiseFloor_PenalizesNoisyChannelOverQuietOne()
+    {
+        // Two candidates, identical low utilization, differing only in measured noise floor: the
+        // noisy one (-50 dBm) must score worse than the pristine one (-95 dBm). Utilization alone
+        // would tie them - the noise floor is the RF-energy signal that breaks the tie.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions();
+
+        InterferenceGraph Build(int noiseFloor)
+        {
+            var g = SingleApGraph(36, externalLoad: new() { { 40, 0.5 } }, directlyObserved: new(), reg, options);
+            g.ScanChannelData[0] = new Dictionary<(int Channel, int Width), (int Utilization, int? NoiseFloor)> { { (40, 80), (5, (int?)noiseFloor) } };
+            return g;
+        }
+
+        var noisy = _service.ScoreAssignment(Build(-50), new[] { (40, 80) }, RadioBand.Band5GHz);
+        var quiet = _service.ScoreAssignment(Build(-95), new[] { (40, 80) }, RadioBand.Band5GHz);
+
+        noisy.Should().BeGreaterThan(quiet + 1.5,
+            "a high noise floor (RF energy that utilization misses) penalizes the channel even at equal airtime");
+    }
+
+    [Fact]
+    public void ScanOverSpan_AggregatesSubChannels_CatchesNoiseAnywhereInTheSpan()
+    {
+        // A 160 MHz channel's badness can sit on a non-control 20 MHz sub-channel. With BW20 buckets
+        // the scorer must aggregate across the whole span (noise floor = worst sub-channel), not read
+        // only the control bucket - else a clean control channel would hide a noisy bonded sub-channel.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions();
+
+        InterferenceGraph Build(int noisySubChannel)
+        {
+            var g = SingleApGraph(100, externalLoad: new(), directlyObserved: new(), reg, options);
+            var scan = new Dictionary<(int Channel, int Width), (int Utilization, int? NoiseFloor)>();
+            foreach (var ch in new[] { 36, 40, 44, 48, 52, 56, 60, 64 })
+                scan[(ch, 20)] = (0, ch == noisySubChannel ? -50 : -96);
+            g.ScanChannelData[0] = scan;
+            return g;
+        }
+
+        var noisyOnControl = _service.ScoreAssignment(Build(36), new[] { (36, 160) }, RadioBand.Band5GHz);
+        var noisyOnSubChannel = _service.ScoreAssignment(Build(56), new[] { (36, 160) }, RadioBand.Band5GHz);
+
+        noisyOnSubChannel.Should().BeApproximately(noisyOnControl, 0.01,
+            "noise floor aggregates as the worst sub-channel across the 160 span, so it's caught whether on the control channel or a bonded sub-channel");
+        noisyOnSubChannel.Should().BeGreaterThan(1.5, "a -50 dBm sub-channel meaningfully penalizes the 160 MHz channel");
+    }
+
+    [Fact]
+    public void CurrentChannel_ScoredFromSiblingVantage_NotSelfContaminatedReading()
+    {
+        // An AP's own scan of its CURRENT channel is contaminated by traffic that follows it (serving
+        // load / a mesh uplink). The scorer must read the current channel from a clean off-channel
+        // sibling instead. Here Subject (ch36) reads its own ch36 noisy (-40, self), but Sibling (on
+        // ch149, off ch36) sees ch36 clean (-90). Subject's score should reflect the clean -90.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions();
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "Subject", RadioBand.Band5GHz, 36),
+            CreateAp("aa:bb:cc:dd:ee:02", "Sibling", RadioBand.Band5GHz, 149)
+        };
+        var assignment = new[] { (36, 80), (149, 80) };
+
+        var withSiblingView = _service.BuildInterferenceGraph(aps, RadioBand.Band5GHz, null, null, reg, options);
+        withSiblingView.ScanChannelData[0] = new() { { (36, 80), (0, (int?)(-40)) } }; // self-contaminated
+        withSiblingView.ScanChannelData[1] = new() { { (36, 80), (0, (int?)(-90)) } }; // sibling's clean view of ch36
+        var crossVantage = _service.ScoreAssignment(withSiblingView, assignment, RadioBand.Band5GHz);
+
+        var noSiblingView = _service.BuildInterferenceGraph(aps, RadioBand.Band5GHz, null, null, reg, options);
+        noSiblingView.ScanChannelData[0] = new() { { (36, 80), (0, (int?)(-40)) } }; // only the self read exists
+        var selfContaminated = _service.ScoreAssignment(noSiblingView, assignment, RadioBand.Band5GHz);
+
+        crossVantage.Should().BeLessThan(selfContaminated - 1.0,
+            "the current channel is scored from the sibling's clean -90 view; only when no sibling has a view does it fall back to the self-contaminated -40");
+    }
+
+    [Fact]
+    public void Optimize_RecommendedNetworkScore_NeverWorseThanCurrent()
+    {
+        // Invariant: the engine must never recommend a plan that RAISES (worsens) the network score.
+        // A per-AP fallback move can help the mover but collide with a sibling and worsen the network
+        // (the Front Yard ch1->ch6 case, where sum-of-ScoreAp called a net-worsening move "positive").
+        // The fallback's network-objective net check + the global guardrail must prevent that.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions();
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "A", RadioBand.Band2_4GHz, 1),
+            CreateAp("aa:bb:cc:dd:ee:02", "B", RadioBand.Band2_4GHz, 6),
+            CreateAp("aa:bb:cc:dd:ee:03", "C", RadioBand.Band2_4GHz, 11)
+        };
+        var graph = _service.BuildInterferenceGraph(aps, RadioBand.Band2_4GHz, null, null, reg, options);
+        graph.ExternalLoad[0] = new() { { 1, 4.0 } };  // A's current channel is loaded - it wants to move
+        graph.ExternalLoad[1] = new() { { 6, 1.0 } };
+        graph.ExternalLoad[2] = new() { { 11, 1.0 } };
+
+        var plan = _service.Optimize(graph, RadioBand.Band2_4GHz, reg, options);
+
+        plan.RecommendedNetworkScore.Should().BeLessThanOrEqualTo(plan.CurrentNetworkScore + 1e-6,
+            "the engine must never recommend a plan that raises the network score");
+    }
+
+    [Fact]
+    public void Optimize_MeasuredComfortableCurrentChannel_NotChurnedForOwnBenefit()
+    {
+        // The reported class: the external neighbor scan inflates a channel that the AP's own radio
+        // measures as externally quiet (low 1d/7d interference). Without the measured-comfort anchor
+        // the optimizer moves the AP off it; with it, a lone AP (no sibling to declutter) stays put.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var graph = SingleApGraph(52,
+            externalLoad: new() { { 52, 6.0 }, { 36, 0.0 } }, // scan says ch52 busy, ch36 clean
+            directlyObserved: new() { 52, 36 },
+            reg, options);
+        // ...but the radio measured ch52 at only 10% external interference (< the comfortable bar).
+        graph.Nodes[0].HistoricalStress = new Dictionary<int, (double Utilization, double Interference, double TxRetryPct)>
+        {
+            { 52, (15.0, 10.0, 2.0) }
+        };
+
+        var plan = _service.Optimize(graph, RadioBand.Band5GHz, reg, options);
+
+        var subject = plan.Recommendations.Single();
+        subject.RecommendedChannel.Should().Be(52,
+            "the radio measures ch52 as externally quiet, so it must not be churned off it on the neighbor scan alone");
+        subject.IsChanged.Should().BeFalse();
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -640,7 +640,8 @@ public class ChannelRecommendationServiceTests
         var subject = plan.Recommendations.Single();
         subject.RecommendedChannel.Should().Be(36);
         subject.IsChanged.Should().BeTrue();
-        subject.IsDfsChannel.Should().BeFalse("ch36 (UNII-1) is not a DFS channel");
+        subject.IsCurrentDfsChannel.Should().BeTrue("ch52 (UNII-2) is a DFS channel");
+        subject.IsRecommendedDfsChannel.Should().BeFalse("ch36 (UNII-1) is not a DFS channel");
     }
 
     [Fact]
@@ -660,7 +661,8 @@ public class ChannelRecommendationServiceTests
         var subject = plan.Recommendations.Single();
         subject.RecommendedChannel.Should().Be(100);
         subject.IsChanged.Should().BeTrue();
-        subject.IsDfsChannel.Should().BeTrue("ch100 (UNII-2C) is a DFS channel");
+        subject.IsCurrentDfsChannel.Should().BeFalse("ch149 (UNII-3) is not a DFS channel");
+        subject.IsRecommendedDfsChannel.Should().BeTrue("ch100 (UNII-2C) is a DFS channel");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -295,9 +295,10 @@ public class ChannelRecommendationServiceTests
         var scoreWithHistory = _service.ScoreAssignment(graph, assignment, RadioBand.Band5GHz);
 
         scoreWithHistory.Should().BeLessThan(scoreNoHistory);
-        // History keeps only 15% of the cliff, so the gap is 0.85 of the full penalty. The floor
-        // now carries the band uncertainty multiplier (x2.0 on 5 GHz), so the base penalty is 2.0.
-        (scoreNoHistory - scoreWithHistory).Should().BeApproximately(1.7, 0.05);
+        // History keeps only 15% of the cliff, so the gap is 0.85 of the full penalty. ch149 has a
+        // triangulated sighting (0.5), which is trusted as-is (no floor) and carries the band
+        // uncertainty multiplier (x2.0 on 5 GHz), so the base penalty is 1.0 and the gap is 0.85.
+        (scoreNoHistory - scoreWithHistory).Should().BeApproximately(0.85, 0.05);
     }
 
     [Fact]
@@ -663,6 +664,29 @@ public class ChannelRecommendationServiceTests
         subject.IsChanged.Should().BeTrue();
         subject.IsCurrentDfsChannel.Should().BeFalse("ch149 (UNII-3) is not a DFS channel");
         subject.IsRecommendedDfsChannel.Should().BeTrue("ch100 (UNII-2C) is a DFS channel");
+    }
+
+    [Fact]
+    public void Optimize_TriangulatedCleanNonDfs_PreferredOverObservedDfs()
+    {
+        // The reported case: a congested DFS AP, a non-DFS channel that a sibling scanned and found
+        // clean (triangulated, not in this AP's own direct set). Triangulation is real evidence, so
+        // the clean non-DFS channel should win - the engine must NOT floor or friction it into
+        // losing to a directly-observed-but-occupied DFS channel.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var graph = SingleApGraph(52,
+            externalLoad: new() { { 52, 1.5 }, { 36, 0.2 } }, // ch52 directly heard busy; ch36 triangulated clean
+            directlyObserved: new() { 52 },                   // ch36 NOT directly observed by this AP
+            reg, options);
+
+        var plan = _service.Optimize(graph, RadioBand.Band5GHz, reg, options);
+
+        var subject = plan.Recommendations.Single();
+        subject.RecommendedChannel.Should().Be(36,
+            "a sibling-scanned clean channel is real evidence and beats a directly-observed occupied DFS channel");
+        subject.IsCurrentDfsChannel.Should().BeTrue("ch52 (UNII-2) is a DFS channel");
+        subject.IsRecommendedDfsChannel.Should().BeFalse("ch36 (UNII-1) is not a DFS channel");
     }
 
     [Fact]


### PR DESCRIPTION
Net changes on `dev` since v1.23.4:

## ISP Health

- **Pick your access technology right from ISP Health** - The "Scored as ..." pill and the Access Layer header are now selectors. Choose your access technology (GPON, XGS-PON, DOCSIS, Active Ethernet, DSL, Fixed Wireless, Cellular, Satellite) and ISP Health re-scores against the right expectations immediately, without a trip through Upstream Discovery. When the technology is the only thing not set yet, the prompt offers the picker inline. Your choice sticks and can still be changed during Upstream Discovery.
- **Physical Link links to its monitoring** - The Access Layer "Physical Link" line is now a link, like the other items there. It jumps straight to the matched access-link device's monitoring (CM, ONT, SFP, or Cellular stats) and focuses that device's charts. The wording adapts to the source, so a PON SFP reads as an ONT while an Active Ethernet SFP reads as a transceiver.
- **Jump from a loss finding to the event** - The "Packet loss under load" and "Packet loss above acceptable" findings now link straight to the matching event on the Network Performance charts, the same way the Access Layer sub-score headers do, so you can confirm what drove a finding instead of guessing.
- **Cloudflare and Google on the Per-Network RTT chart** - The two anycast DNS endpoints now plot as their own lines. They already feed loss, path-shift, and congestion detection and are very stable, so they give a known-good baseline to read a noisy ISP or transit hop against.
- **Smarter persistent-loss advice** - The "Packet loss above acceptable" recommendation now names oversubscription alongside physical-plant faults on shared connections (cable, PON, fixed wireless, cellular, satellite), stays physical-layer only on dedicated lines (DSL, Active Ethernet / DIA), and hedges where the medium is unknown.
- **Loaded-loss advice respects Adaptive SQM** - When Adaptive SQM is already shaping the WAN, the loaded-loss recommendation points at its own tuning knobs (Severity, nominal speeds) instead of telling you to enable Smart Queues.
- **Sharper XGS-PON expectations** - XGS-PON now scores against a lower idle-latency band than GPON, reflecting its shorter upstream grant cycles and faster upstream.
- **Clearer source labels** - When more than one access-link device matches the WAN, the source picker names each as "Vendor SFP on Port N" instead of a bare port number.
- **Route-server and anycast-DNS networks no longer scored as Transit** - Networks like WoodyNet / Packet Clearing House run IXP route servers and anycast DNS, so they turn up on a traceroute without ever hauling your traffic upstream. ISP Health now leaves them out of the Transit dimension everywhere (scoring, the per-network cards, the Per-Network RTT chart, and live stats), so a route-server hop can't pull down a Transit grade it has nothing to do with.
- **"DOCSIS 3.1/4.0" when OFDMA is detected** - The Physical Link readout now reads "DOCSIS 3.1/4.0" when it sees an active OFDMA channel. OFDMA proves an OFDM-capable plant but doesn't distinguish 3.1 from 4.0 (4.0 runs OFDMA too), so it names both rather than claiming 3.1.
- **Cleaner first-load spinner** - The ISP Health tab's initial load now shows a centered, on-brand spinner that matches the health card, instead of a small spinner tucked in the corner.

## Network Performance

- **Investigate moved up and collapsible** - The Investigate panel now sits above the Latency & Packet Loss chart, collapses with a remembered state, and carries the Monitoring icon.
- **Step through loss events, not minutes** - Investigating Packet Loss or Loaded Loss now groups a sustained burst into a single event and steps event-to-event, landing on each event's worst minute, instead of one stop per minute. The event you land on is highlighted on the round-trip-time and loss charts with a labeled band tight to the loss.

## Wi-Fi Optimizer

- **Recommendations now measure the air, not just count networks** - Channel recommendations factor in each channel's real airtime utilization and RF noise floor from the spectrum scan, so a channel that looks empty by neighbor count but is actually noisy (radar, microwaves, other non-Wi-Fi interference, or hidden congestion) is correctly avoided. Wide channels are judged across their whole span, matching how a bonded channel actually behaves.
- **Fill measurement gaps with a one-click scan** - When a radio has no recent RF measurement, the Channel Analysis page offers to run a quick scan on exactly those radios, then re-runs the recommendation on the fresh data. Scans run at each radio's current channel width and one band at a time per AP; mesh APs are skipped (they can't scan without dropping their uplink), and APs with a dedicated scan radio scan with no client impact.
- **Never recommends a change that makes things worse** - A recommended channel plan is now guaranteed never to score worse than your current one, and a per-AP move that would help one AP but collide with a neighbor is no longer suggested.
- **More accurate current-channel reading** - An AP is no longer penalized for congestion it carries with it (such as a mesh uplink's own traffic that follows it to any channel); its current channel is judged from a neighboring AP's cleaner view.
- **EIRP power bar in the Radios table** - The Channel Analysis Radios table now shows the same TX/EIRP power bar as the Power and Coverage view.
- **DFS channels are clearly flagged** - Channel recommendations now show a DFS badge on both the current and the recommended channel, computed against the channel actually shown. Wide-channel bonding is accounted for, so a block whose span reaches into DFS frequencies is flagged even when its control channel isn't DFS.
- **DFS toggle follows your UniFi setting** - The Channel Plan's DFS toggle now starts from your UniFi Auto-Optimize DFS preference instead of a fixed default.
- **Won't abandon a working DFS channel on a guess** - The optimizer now resists moving an AP off a DFS channel onto a channel it has no scan data for, since an unscanned channel can look empty simply because nothing has measured it. A genuinely congested DFS channel, or a target with real scan evidence, still moves.
- **Trusts a nearby AP's scan as real data** - When one AP has scanned a channel, that reading now counts as evidence for nearby APs too. Recommendations prefer genuinely clean channels instead of skipping them as "unobserved" and landing on an occupied channel they happened to measure directly.

## Client WAN Speed Test

- **Charts keep up with new results** - The results charts now redraw when a new test lands during auto-refresh, and skip redundant redraws when nothing changed.

## Fixes

- **Visited links stay readable** - Visited links keep the normal link color instead of fading into the body text.
- **Shorter button label on mobile** - The Channel Plan "Show Current Channels" button condenses to "Show Current" on narrow screens.

---

_Release notes and version to be finalized before tagging._
