### PR TITLE
Wi-Fi Optimizer: default DFS toggle from console Auto-Optimize setting

### DIFF
--- a/src/NetworkOptimizer.UniFi/Helpers/RadioAiSettings.cs
+++ b/src/NetworkOptimizer.UniFi/Helpers/RadioAiSettings.cs
@@ -1,0 +1,101 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NetworkOptimizer.Core;
+using NetworkOptimizer.UniFi.Models;
+
+namespace NetworkOptimizer.UniFi.Helpers;
+
+/// <summary>
+/// A single per-radio entry from the UniFi "radio_ai" setting's radios_configuration array.
+/// </summary>
+[VendorSpecific("UniFi", "Parses radio_ai.radios_configuration entries from UniFi settings JSON")]
+public class RadioAiRadioConfig
+{
+    /// <summary>
+    /// Radio band identifier: "ng" (2.4 GHz), "na" (5 GHz), "6e" (6 GHz).
+    /// </summary>
+    [JsonPropertyName("radio")]
+    public string? Radio { get; set; }
+
+    /// <summary>
+    /// Whether the console's Auto-Optimize (RF Scanning) feature is allowed to use
+    /// DFS channels on this radio. May arrive as a bool, string, or 0/1 number.
+    /// </summary>
+    [JsonPropertyName("dfs")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
+    public bool Dfs { get; set; }
+
+    /// <summary>
+    /// Configured channel width (MHz) for this radio.
+    /// </summary>
+    [JsonPropertyName("channel_width")]
+    [JsonConverter(typeof(FlexibleIntConverter))]
+    public int? ChannelWidth { get; set; }
+}
+
+/// <summary>
+/// Resolved UniFi "radio_ai" (Auto-Optimize / RF Scanning) settings.
+/// Exposes the per-radio DFS preference so the channel recommender can default
+/// its DFS toggle to match how the console is configured.
+/// </summary>
+[VendorSpecific("UniFi", "Parses UniFi settings JSON 'data' array with 'key' discriminator (radio_ai)")]
+public class RadioAiSettings
+{
+    /// <summary>UniFi radio identifier for the 5 GHz band.</summary>
+    public const string Radio5GHz = "na";
+
+    private IReadOnlyList<RadioAiRadioConfig> RadiosConfiguration { get; init; } = Array.Empty<RadioAiRadioConfig>();
+
+    /// <summary>
+    /// Parse from settings JSON (the root response from GetSettingsRawAsync).
+    /// Looks for the "radio_ai" object in the data array.
+    /// Returns null if settings unavailable or the radio_ai key is absent.
+    /// </summary>
+    public static RadioAiSettings? FromSettingsJson(JsonDocument? settingsData)
+    {
+        if (settingsData == null)
+            return null;
+
+        if (!settingsData.RootElement.TryGetProperty("data", out var data) ||
+            data.ValueKind != JsonValueKind.Array)
+            return null;
+
+        foreach (var item in data.EnumerateArray())
+        {
+            if (!item.TryGetProperty("key", out var key) ||
+                key.GetString() != "radio_ai")
+                continue;
+
+            var radios = new List<RadioAiRadioConfig>();
+            if (item.TryGetProperty("radios_configuration", out var radiosConfig) &&
+                radiosConfig.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var radio in radiosConfig.EnumerateArray())
+                {
+                    var parsed = radio.Deserialize<RadioAiRadioConfig>();
+                    if (parsed != null)
+                        radios.Add(parsed);
+                }
+            }
+
+            return new RadioAiSettings { RadiosConfiguration = radios };
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Whether DFS channels are enabled in the console's Auto-Optimize configuration
+    /// for the given radio (e.g. "na" for 5 GHz). Returns null when the radio is absent
+    /// so callers can fall back to their own default.
+    /// </summary>
+    public bool? GetDfsEnabled(string radio)
+    {
+        foreach (var cfg in RadiosConfiguration)
+        {
+            if (string.Equals(cfg.Radio, radio, StringComparison.OrdinalIgnoreCase))
+                return cfg.Dfs;
+        }
+        return null;
+    }
+}

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -579,6 +579,13 @@
 
         await LoadDataAsync();
 
+        // Default the DFS toggle to match the console's Auto-Optimize configuration
+        // (dfs=true -> Include DFS, dfs=false -> Avoid DFS). Falls back to the field
+        // default when the setting is unavailable.
+        var autoOptimizeDfs = await WiFiService.GetAutoOptimizeDfsEnabledAsync();
+        if (autoOptimizeDfs.HasValue)
+            _dfsPreference = autoOptimizeDfs.Value ? DfsPreference.IncludeWithPenalty : DfsPreference.Exclude;
+
         // Apply initial filters from parent navigation (explicit band is treated as a manual pick)
         if (InitialBand.HasValue)
         {

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using NetworkOptimizer.Audit.Analyzers;
 using NetworkOptimizer.UniFi;
+using NetworkOptimizer.UniFi.Helpers;
 using NetworkOptimizer.WiFi;
 using NetworkOptimizer.WiFi.Analyzers;
 using NetworkOptimizer.WiFi.Helpers;
@@ -839,6 +840,31 @@ public class WiFiOptimizerService
         {
             _logger.LogError(ex, "Failed to get client events for {ClientMac}", clientMac);
             return new List<WiFi.Models.ClientConnectionEvent>();
+        }
+    }
+
+    /// <summary>
+    /// Read the console's configured DFS preference for the 5 GHz radio from the
+    /// "radio_ai" (Auto-Optimize / RF Scanning) settings. Returns true when DFS is
+    /// enabled, false when it is disabled, or null when unavailable so callers can
+    /// fall back to their own default.
+    /// </summary>
+    public async Task<bool?> GetAutoOptimizeDfsEnabledAsync()
+    {
+        var client = _connectionService.Client;
+        if (client == null)
+            return null;
+
+        try
+        {
+            using var settings = await client.GetSettingsRawAsync();
+            var radioAi = RadioAiSettings.FromSettingsJson(settings);
+            return radioAi?.GetDfsEnabled(RadioAiSettings.Radio5GHz);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to read radio_ai DFS preference");
+            return null;
         }
     }
 

--- a/tests/NetworkOptimizer.UniFi.Tests/RadioAiSettingsTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/RadioAiSettingsTests.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using NetworkOptimizer.UniFi.Helpers;
+using Xunit;
+
+namespace NetworkOptimizer.UniFi.Tests;
+
+public class RadioAiSettingsTests
+{
+    private static JsonDocument Settings(string radioAiBody) =>
+        JsonDocument.Parse($$"""
+        {
+            "data": [
+                { "key": "global_switch", "jumboframe_enabled": true },
+                { "key": "radio_ai", {{radioAiBody}} }
+            ]
+        }
+        """);
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    public void GetDfsEnabled_returns_configured_value_for_5ghz(bool dfs, bool expected)
+    {
+        var json = Settings($$"""
+            "radios_configuration": [
+                { "dfs": false, "channel_width": 20, "radio": "ng" },
+                { "dfs": {{(dfs ? "true" : "false")}}, "channel_width": 160, "radio": "na" },
+                { "dfs": true, "channel_width": 160, "radio": "6e" }
+            ]
+        """);
+
+        var settings = RadioAiSettings.FromSettingsJson(json);
+
+        Assert.NotNull(settings);
+        Assert.Equal(expected, settings!.GetDfsEnabled(RadioAiSettings.Radio5GHz));
+    }
+
+    [Theory]
+    [InlineData("\"true\"", true)]
+    [InlineData("\"false\"", false)]
+    [InlineData("1", true)]
+    [InlineData("0", false)]
+    public void GetDfsEnabled_handles_flexible_bool_encodings(string dfsJson, bool expected)
+    {
+        var json = Settings($$"""
+            "radios_configuration": [
+                { "dfs": {{dfsJson}}, "channel_width": 160, "radio": "na" }
+            ]
+        """);
+
+        var settings = RadioAiSettings.FromSettingsJson(json);
+
+        Assert.Equal(expected, settings!.GetDfsEnabled(RadioAiSettings.Radio5GHz));
+    }
+
+    [Fact]
+    public void GetDfsEnabled_returns_null_when_radio_absent()
+    {
+        var json = Settings($$"""
+            "radios_configuration": [
+                { "dfs": true, "channel_width": 20, "radio": "ng" }
+            ]
+        """);
+
+        var settings = RadioAiSettings.FromSettingsJson(json);
+
+        Assert.NotNull(settings);
+        Assert.Null(settings!.GetDfsEnabled(RadioAiSettings.Radio5GHz));
+    }
+
+    [Fact]
+    public void FromSettingsJson_returns_null_when_radio_ai_key_absent()
+    {
+        using var json = JsonDocument.Parse("""
+        { "data": [ { "key": "global_switch", "jumboframe_enabled": true } ] }
+        """);
+
+        Assert.Null(RadioAiSettings.FromSettingsJson(json));
+    }
+
+    [Fact]
+    public void FromSettingsJson_returns_null_for_null_input() =>
+        Assert.Null(RadioAiSettings.FromSettingsJson(null));
+}


### PR DESCRIPTION
The Channel Recommendation screen's 5 GHz DFS toggle now defaults to match how your UniFi Console's Auto-Optimize (RF Scanning) is configured, instead of always starting on Include DFS.

## What changed

- Read the console's `radio_ai` `radios_configuration` and default the 5 GHz DFS toggle from it:
  - DFS enabled on the console -> **Include DFS**
  - DFS disabled on the console -> **Avoid DFS**
- Falls back to the previous **Include DFS** default when the setting is unavailable (not connected, key absent, etc.).
- The default applies on load; once you pick a toggle option yourself, your choice is preserved (Refresh and re-running recommendations don't reset it).

## Why

If you've told your console to avoid DFS, the recommendations should start from that same assumption rather than making you flip the toggle every time you open the Channels tab.

## Notes

- Parsing uses the existing `FlexibleBoolConverter` so the `dfs` value is tolerated as a bool, string, or 0/1.
- New `RadioAiSettings` helper follows the existing `GlobalSwitchSettings` settings-parse pattern.
- Unit tests cover the true/false defaults, flexible bool encodings, missing radio, missing key, and null input.