### PR TITLE
ISP Health & Network Performance: investigation tools, anycast RTT lines, smarter loss advice

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -241,6 +241,28 @@ The following were implemented in the WiFi Optimizer feature:
 
 ## Monitoring
 
+### Investigation Functions (Network Performance tab)
+The Investigate card currently jumps the latency charts to the most recent **packet-loss** and **loaded-loss** events and steps event-to-event (coalesced, peak-loss minute). Ideas to extend it:
+
+**Reuse detectors ISP Health already computes (low effort - mostly wiring existing results into `navigateToTime` + buttons):**
+- **Congestion events** - `CongestionLocalizer` already produces events with disposition (confirmed / self-inflicted / control-plane-noise) and scope (hop / ASN / shared). Add an Investigate button that jumps the latency charts to each event, with the highlight band colored shared-vs-local like the ISP Health chart. Strongest detector, currently invisible on these charts.
+- **Path-shift events** - `StepChangeDetector` already finds RTT step changes; jump to the step with a "+N ms" label.
+- **Outages** - `OutageDetector` already classifies full / partial / brief; jump to the outage window and show the recovery shape.
+- **Unify the two views** - make the ISP Health "Path & Congestion Events" timeline items deep-link into the latency charts (the way the loss findings now do via `?investigate=`).
+
+**New detections (more work):**
+- **Bufferbloat events** - loaded *latency* spikes (the `latencyTriggered` signal), distinct from loaded loss; bufferbloat often has zero loss, so the loss buttons miss it.
+- **Jitter spikes** - sustained P95 jitter excursions.
+- **Saturation events** - when WAN throughput pegged at/over the configured plan; pairs with loaded loss to answer "was the line actually maxed."
+
+**UX upgrades to what exists:**
+- **"Worst in window" vs "most recent"** - a jump-to-peak mode that lands on the highest-loss event directly instead of stepping from the latest.
+- **Verdict line on landing** - when landing on a loss event, append what it was (loaded vs idle, which hop/ASN, congestion disposition) so "0.7% loss" becomes "0.7% loss, self-inflicted bufferbloat at your access egress." The localizer already computes this.
+- **Per-target investigate** - click a target in the stats table to step through just that target's events.
+
+Suggested order: congestion / path-shift / outage navigation first (cheap, consistent), then the verdict line (makes every investigation land with an explanation, not just a number).
+- **Relevant code:** `MonitoringInfluxClient.FindRecentLossEventAsync` / `FindRecentLoadedLossEventAsync` (+ `SelectBoundaryEvent` coalescing), `Monitoring.razor` Investigate card + `NavigateToLossEvent`, `latency-charts.js` `navigateToTime` / `buildInvestigateAnnotations`, `IspHealthService` (`CongestionLocalizer`, `StepChangeDetector`, `OutageDetector` outputs already on the report).
+
 ### Multi-WAN Support (ISP Health & NMS)
 - ISP Health currently grades a single (primary) WAN. Several inputs are read globally rather than scoped to the WAN being scored:
   - **Upstream ancestry / `hopOrderKnown`** (`IspHealthService.ComputeAsync`): `UpstreamDiscoveries` are queried across all WANs. Rows carry `WanInterface`, and the tracer persists per-WAN, but the scorer reads them globally - so a second WAN's discovery data can flip the jitter-absolve gate (and the routes-through witnesses) for a WAN that has no ancestry of its own. Scope the discovery query and `hopOrderKnown` by `WanInterface`.

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -2160,9 +2160,10 @@ from(bucket: ""{_longtermBucket}"")
     /// <summary>One qualifying loss minute before coalescing into an event.</summary>
     private readonly record struct LossMinute(DateTime Time, double Loss, string? TargetId, string TargetType);
 
-    /// <summary>Loss minutes within this gap of each other are treated as one event, so a
-    /// brief dip (e.g. a one-minute lull mid-burst) doesn't split a sustained loss period.</summary>
-    private static readonly TimeSpan LossEventCoalesceGap = TimeSpan.FromMinutes(2);
+    /// <summary>Loss minutes more than this far apart start a new event. Set to one minute so
+    /// only truly adjacent minutes coalesce; a single clean minute (load/loss dropping out, then
+    /// resuming) splits the burst, keeping back-to-back transfer spikes as distinct events.</summary>
+    private static readonly TimeSpan LossEventCoalesceGap = TimeSpan.FromMinutes(1);
 
     /// <summary>
     /// Coalesce time-ascending loss minutes into events (gap &lt;= <see cref="LossEventCoalesceGap"/>)

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -1999,7 +1999,6 @@ from(bucket: ""{_longtermBucket}"")
 
         var rangeStart = after ?? DateTime.UtcNow.AddDays(-30);
         var rangeStop = before ?? DateTime.UtcNow;
-        var sortDesc = !after.HasValue;
 
         var targetFilter = "";
         if (enabledTargetIds != null && enabledTargetIds.Count > 0)
@@ -2008,6 +2007,9 @@ from(bucket: ""{_longtermBucket}"")
             targetFilter = $"\n  |> filter(fn: (r) => {conditions})";
         }
 
+        // Pull every qualifying loss minute in the window time-ascending, then coalesce into
+        // events in memory. The caller bounds the window to just before/after the current event
+        // (via before/after), so the boundary event we want is fully inside the range.
         var flux = $@"
 from(bucket: ""{_bucket}"")
   |> range(start: {ToFluxInstant(rangeStart)}, stop: {ToFluxInstant(rangeStop)})
@@ -2017,24 +2019,18 @@ from(bucket: ""{_bucket}"")
   |> aggregateWindow(every: 1m, fn: mean, createEmpty: false)
   |> filter(fn: (r) => r._value > 1.0)
   |> group()
-  |> sort(columns: [""_time""], desc: {(sortDesc ? "true" : "false")})
-  |> limit(n: 1)
+  |> sort(columns: [""_time""], desc: false)
 ";
+        var minutes = new List<LossMinute>();
         await foreach (var record in QueryFluxAsync(flux, ct))
         {
             var time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow);
             var targetId = record.GetValueByKey("target_id") as string;
             var targetType = record.GetValueByKey("target_type") as string ?? "internetservice";
-            var loss = AsDoubleOrNull(record.GetValueByKey("_value"));
-            return new RecentLossEvent
-            {
-                Timestamp = time,
-                TargetType = targetType,
-                TargetId = targetId,
-                LossPercent = loss ?? 0
-            };
+            var loss = AsDoubleOrNull(record.GetValueByKey("_value")) ?? 0;
+            minutes.Add(new LossMinute(time, loss, targetId, targetType));
         }
-        return null;
+        return SelectBoundaryEvent(minutes, pickEarliest: after.HasValue);
     }
 
     /// <summary>
@@ -2057,7 +2053,6 @@ from(bucket: ""{_bucket}"")
 
         var rangeStart = after ?? DateTime.UtcNow.AddDays(-30);
         var rangeStop = before ?? DateTime.UtcNow;
-        var sortDesc = !after.HasValue;
 
         var targetFilter = "";
         if (enabledTargetIds != null && enabledTargetIds.Count > 0)
@@ -2094,24 +2089,18 @@ load = from(bucket: ""{_bucket}"")
   |> unique(column: ""_time"")
 
 join.inner(left: loss, right: load, on: (l, r) => l._time == r._time, as: (l, r) => l)
-  |> sort(columns: [""_time""], desc: {(sortDesc ? "true" : "false")})
-  |> limit(n: 1)
+  |> sort(columns: [""_time""], desc: false)
 ";
+        var minutes = new List<LossMinute>();
         await foreach (var record in QueryFluxAsync(flux, ct))
         {
             var time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow);
             var targetId = record.GetValueByKey("target_id") as string;
             var targetType = record.GetValueByKey("target_type") as string ?? "internetservice";
-            var loss = AsDoubleOrNull(record.GetValueByKey("_value"));
-            return new RecentLossEvent
-            {
-                Timestamp = time,
-                TargetType = targetType,
-                TargetId = targetId,
-                LossPercent = loss ?? 0
-            };
+            var loss = AsDoubleOrNull(record.GetValueByKey("_value")) ?? 0;
+            minutes.Add(new LossMinute(time, loss, targetId, targetType));
         }
-        return null;
+        return SelectBoundaryEvent(minutes, pickEarliest: after.HasValue);
     }
 
     /// <summary>
@@ -2155,10 +2144,68 @@ from(bucket: ""{_longtermBucket}"")
 
     public record RecentLossEvent
     {
+        /// <summary>The peak-loss minute of the coalesced event, used to center the chart.</summary>
         public required DateTime Timestamp { get; init; }
         public required string TargetType { get; init; }
         public string? TargetId { get; init; }
         public double LossPercent { get; init; }
+
+        /// <summary>First and last loss minute of the coalesced event. Stepping back queries
+        /// strictly before <see cref="EventStart"/>; stepping forward strictly after
+        /// <see cref="EventEnd"/>, so a sustained loss burst is one stop, not many.</summary>
+        public DateTime EventStart { get; init; }
+        public DateTime EventEnd { get; init; }
+    }
+
+    /// <summary>One qualifying loss minute before coalescing into an event.</summary>
+    private readonly record struct LossMinute(DateTime Time, double Loss, string? TargetId, string TargetType);
+
+    /// <summary>Loss minutes within this gap of each other are treated as one event, so a
+    /// brief dip (e.g. a one-minute lull mid-burst) doesn't split a sustained loss period.</summary>
+    private static readonly TimeSpan LossEventCoalesceGap = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// Coalesce time-ascending loss minutes into events (gap &lt;= <see cref="LossEventCoalesceGap"/>)
+    /// and return the boundary event represented by its peak-loss minute: the earliest event when
+    /// stepping forward (<paramref name="pickEarliest"/>), else the latest. Stepping by event, not
+    /// by minute, keeps a multi-minute burst from fragmenting into separate stops.
+    /// </summary>
+    private static RecentLossEvent? SelectBoundaryEvent(List<LossMinute> minutes, bool pickEarliest)
+    {
+        if (minutes.Count == 0) return null;
+
+        var eventStart = minutes[0].Time;
+        var eventEnd = minutes[0].Time;
+        var peak = minutes[0];
+        var events = new List<(DateTime Start, DateTime End, LossMinute Peak)>();
+        for (var i = 1; i < minutes.Count; i++)
+        {
+            var m = minutes[i];
+            if (m.Time - eventEnd > LossEventCoalesceGap)
+            {
+                events.Add((eventStart, eventEnd, peak));
+                eventStart = m.Time;
+                eventEnd = m.Time;
+                peak = m;
+            }
+            else
+            {
+                eventEnd = m.Time;
+                if (m.Loss > peak.Loss) peak = m;
+            }
+        }
+        events.Add((eventStart, eventEnd, peak));
+
+        var chosen = pickEarliest ? events[0] : events[^1];
+        return new RecentLossEvent
+        {
+            Timestamp = chosen.Peak.Time,
+            TargetType = chosen.Peak.TargetType,
+            TargetId = chosen.Peak.TargetId,
+            LossPercent = chosen.Peak.Loss,
+            EventStart = chosen.Start,
+            EventEnd = chosen.End,
+        };
     }
 
     public record RecentSfpAnomaly

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -2697,7 +2697,7 @@ else
     // The 1-minute aggregateWindow buckets are stamped at their STOP edge, so the bucket at
     // EventStart holds data from the minute before it; an exclusive range stop at EventStart
     // would still return that bucket. Step back a full minute so the current event's first
-    // bucket is actually excluded (the coalesce gap guarantees the previous event is >= 3 min
+    // bucket is actually excluded (the coalesce gap guarantees the previous event is >= 2 min
     // earlier, so it is never dropped). Forward needs no such fudge: the current event's data
     // all precedes the EventEnd stamp, so an inclusive start just past EventEnd excludes it.
     private Task LossNavBack() => _lossNavEventStart.HasValue

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -324,7 +324,7 @@ else
         <!-- Quick investigation -->
         <div class="card">
             <div class="card-header card-header-collapsible" @onclick="ToggleInvestigateCollapse">
-                <h2 class="card-title">Investigate</h2>
+                <h2 class="card-title"><img src="/icons/port-scan.png" alt="" class="card-title-icon" />Investigate</h2>
                 <span class="issue-type-chevron">@(_investigateCollapsed ? "▼" : "▲")</span>
             </div>
             <div class="expand-wrapper @(!_investigateCollapsed && _investigateStateLoaded ? "expanded" : "")" style="@(!_investigateStateLoaded ? "display:none" : "")">
@@ -622,7 +622,7 @@ else
         <!-- SFP investigation -->
         <div class="card" style="margin-top: 1.5rem;">
             <div class="card-header">
-                <h2 class="card-title">Investigate</h2>
+                <h2 class="card-title"><img src="/icons/port-scan.png" alt="" class="card-title-icon" />Investigate</h2>
             </div>
             <div class="card-body" style="display: flex; gap: 0.75rem; flex-wrap: wrap;">
                 <button class="btn btn-secondary" @onclick="InvestigateSfpAnomaly" disabled="@_investigatingSfp"
@@ -2694,8 +2694,14 @@ else
     private Task InvestigateLoadedLoss() => NavigateToLossEvent(null, null, loadedOnly: true);
     // Step to the previous/next distinct event by querying strictly outside the current
     // event's bounds, so a multi-minute burst is one stop rather than one stop per minute.
+    // The 1-minute aggregateWindow buckets are stamped at their STOP edge, so the bucket at
+    // EventStart holds data from the minute before it; an exclusive range stop at EventStart
+    // would still return that bucket. Step back a full minute so the current event's first
+    // bucket is actually excluded (the coalesce gap guarantees the previous event is >= 3 min
+    // earlier, so it is never dropped). Forward needs no such fudge: the current event's data
+    // all precedes the EventEnd stamp, so an inclusive start just past EventEnd excludes it.
     private Task LossNavBack() => _lossNavEventStart.HasValue
-        ? NavigateToLossEvent(_lossNavEventStart.Value, null, _lossNavLoadedOnly) : Task.CompletedTask;
+        ? NavigateToLossEvent(_lossNavEventStart.Value.AddMinutes(-1), null, _lossNavLoadedOnly) : Task.CompletedTask;
     private Task LossNavForward() => _lossNavEventEnd.HasValue
         ? NavigateToLossEvent(null, _lossNavEventEnd.Value.AddSeconds(1), _lossNavLoadedOnly) : Task.CompletedTask;
 
@@ -2764,7 +2770,7 @@ else
             StateHasChanged();
             var annotationLabel = $"{(loadedOnly ? "Loaded" : "Packet")} loss {result.LossPercent:0.#}%";
             await JS.InvokeVoidAsync("eval",
-                $"window.__latencyCharts?.navigateToTime('{result.Timestamp:o}', '{category}', '{annotationLabel}', {(loadedOnly ? "true" : "false")});");
+                $"window.__latencyCharts?.navigateToTime('{result.Timestamp:o}', '{category}', '{annotationLabel}', {(loadedOnly ? "true" : "false")}, '{result.EventStart:o}', '{result.EventEnd:o}');");
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1626,7 +1626,12 @@ else
     private bool _deviceTempCollapsed = true;
     private bool _sfpThresholdsCollapsed = true;
     // Investigate card collapse, persisted to localStorage like the Monitoring Interfaces card.
+    // _investigateCollapsed is the live (possibly force-opened) state; _investigateSavedCollapsed
+    // is the user's persisted preference. A deep-linked investigation force-opens the live state
+    // only, and leaving the tab reverts to the saved preference, so the link never counts as a
+    // user-set expand.
     private bool _investigateCollapsed = true;
+    private bool _investigateSavedCollapsed = true;
     private bool _investigateStateLoaded;
     private const string InvestigateCollapseKey = "monitoring-investigate-collapsed";
 
@@ -2686,6 +2691,9 @@ else
     private async Task ToggleInvestigateCollapse()
     {
         _investigateCollapsed = !_investigateCollapsed;
+        // A manual toggle is a real preference: update the saved baseline too, so leaving the
+        // tab (which reverts to the baseline) keeps the user's choice rather than undoing it.
+        _investigateSavedCollapsed = _investigateCollapsed;
         try { await JS.InvokeVoidAsync("localStorage.setItem", InvestigateCollapseKey, _investigateCollapsed ? "true" : "false"); }
         catch { }
     }
@@ -2860,7 +2868,8 @@ else
             try { val = await JS.InvokeAsync<string>("localStorage.getItem", InvestigateCollapseKey); }
             catch { }
             // Saved preference wins; with none, default to expanded so the controls are discoverable.
-            _investigateCollapsed = val == "true";
+            _investigateSavedCollapsed = val == "true";
+            _investigateCollapsed = _investigateSavedCollapsed;
             StateHasChanged();
         }
 
@@ -2870,7 +2879,8 @@ else
             var kind = _pendingInvestigateParam;
             _pendingInvestigateParam = null;
             // Open the (possibly collapsed) card so the deep-linked result and nav controls are
-            // visible. Transient: not persisted, so the user's saved preference is preserved.
+            // visible. Live state only - the saved preference is untouched, and leaving the tab
+            // reverts to it, so a linkable investigation never counts as a user-set expand.
             _investigateCollapsed = false;
             await NavigateToLossEvent(null, null, loadedOnly: kind == "loaded-loss");
         }
@@ -3006,6 +3016,9 @@ else
             // too - otherwise returning shows the card "active" with no highlight on the chart.
             // Deep-linked investigations re-arm via the query param on entry, so this is safe.
             ResetLossNavState();
+            // Revert any transient deep-link force-open to the user's saved preference, so a
+            // linkable investigation never lingers as an expand the user didn't choose.
+            _investigateCollapsed = _investigateSavedCollapsed;
         }
 
         if (_scrollToDiscoveryPending && _activeTab == "performance")

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -323,9 +323,12 @@ else
 
         <!-- Quick investigation -->
         <div class="card">
-            <div class="card-header">
+            <div class="card-header card-header-collapsible" @onclick="ToggleInvestigateCollapse">
                 <h2 class="card-title">Investigate</h2>
+                <span class="issue-type-chevron">@(_investigateCollapsed ? "▼" : "▲")</span>
             </div>
+            <div class="expand-wrapper @(!_investigateCollapsed && _investigateStateLoaded ? "expanded" : "")" style="@(!_investigateStateLoaded ? "display:none" : "")">
+            <div class="expand-content">
             <div class="card-body" style="display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center;">
                 @if (_lossNavActive)
                 {
@@ -355,6 +358,8 @@ else
                 {
                     <span class="page-description" style="align-self: center;">@_lossInvestigateResult</span>
                 }
+            </div>
+            </div>
             </div>
         </div>
 
@@ -1391,6 +1396,10 @@ else
     private string? _pendingInvestigateParam;
     private bool _lossNavActive;
     private DateTime? _lossNavTimestamp;
+    // Bounds of the current coalesced loss event, so back/forward step past the whole event
+    // rather than minute-by-minute through it.
+    private DateTime? _lossNavEventStart;
+    private DateTime? _lossNavEventEnd;
 
     private static readonly HashSet<string> ValidTabs = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -1616,6 +1625,10 @@ else
     private bool _tempThresholdsSaved;
     private bool _deviceTempCollapsed = true;
     private bool _sfpThresholdsCollapsed = true;
+    // Investigate card collapse, persisted to localStorage like the Monitoring Interfaces card.
+    private bool _investigateCollapsed = true;
+    private bool _investigateStateLoaded;
+    private const string InvestigateCollapseKey = "monitoring-investigate-collapsed";
 
     // Clear the transient "Saved" confirmations so they don't linger after the
     // user edits a field or navigates back into the tab.
@@ -2670,17 +2683,28 @@ else
 
     // ─── Investigation ───
 
+    private async Task ToggleInvestigateCollapse()
+    {
+        _investigateCollapsed = !_investigateCollapsed;
+        try { await JS.InvokeVoidAsync("localStorage.setItem", InvestigateCollapseKey, _investigateCollapsed ? "true" : "false"); }
+        catch { }
+    }
+
     private Task InvestigatePacketLoss() => NavigateToLossEvent(null, null, loadedOnly: false);
     private Task InvestigateLoadedLoss() => NavigateToLossEvent(null, null, loadedOnly: true);
-    private Task LossNavBack() => _lossNavTimestamp.HasValue
-        ? NavigateToLossEvent(_lossNavTimestamp.Value.AddMinutes(-1), null, _lossNavLoadedOnly) : Task.CompletedTask;
-    private Task LossNavForward() => _lossNavTimestamp.HasValue
-        ? NavigateToLossEvent(null, _lossNavTimestamp.Value.AddMinutes(1), _lossNavLoadedOnly) : Task.CompletedTask;
+    // Step to the previous/next distinct event by querying strictly outside the current
+    // event's bounds, so a multi-minute burst is one stop rather than one stop per minute.
+    private Task LossNavBack() => _lossNavEventStart.HasValue
+        ? NavigateToLossEvent(_lossNavEventStart.Value, null, _lossNavLoadedOnly) : Task.CompletedTask;
+    private Task LossNavForward() => _lossNavEventEnd.HasValue
+        ? NavigateToLossEvent(null, _lossNavEventEnd.Value.AddSeconds(1), _lossNavLoadedOnly) : Task.CompletedTask;
 
     private async Task LossNavDeactivate()
     {
         _lossNavActive = false;
         _lossNavTimestamp = null;
+        _lossNavEventStart = null;
+        _lossNavEventEnd = null;
         _lossInvestigateResult = null;
         _lossNavLoadedOnly = false;
         StateHasChanged();
@@ -2729,6 +2753,8 @@ else
             };
             _lossNavActive = true;
             _lossNavTimestamp = result.Timestamp;
+            _lossNavEventStart = result.EventStart;
+            _lossNavEventEnd = result.EventEnd;
             var delta = DateTime.UtcNow - result.Timestamp;
             var ago = delta.TotalMinutes < 60 ? $"{(int)delta.TotalMinutes}m ago"
                 : delta.TotalHours < 24 ? $"{(int)delta.TotalHours}h ago"
@@ -2811,11 +2837,28 @@ else
             await ScrollToMonitoringInterfacesAsync();
         }
 
+        // Load the Investigate card's saved collapse state once the performance tab is shown.
+        // Set the loaded flag before the await so this can't re-enter on later renders; the body
+        // stays collapsed (default) until the preference resolves, so nothing flashes open.
+        if (_activeTab == "performance" && _monitoringReady && !_investigateStateLoaded)
+        {
+            _investigateStateLoaded = true;
+            string? val = null;
+            try { val = await JS.InvokeAsync<string>("localStorage.getItem", InvestigateCollapseKey); }
+            catch { }
+            // Saved preference wins; with none, default to expanded so the controls are discoverable.
+            _investigateCollapsed = val == "true";
+            StateHasChanged();
+        }
+
         // Deep-linked investigation fires once the performance tab and its chart exist
         if (_pendingInvestigateParam != null && _activeTab == "performance" && _monitoringReady && !_investigatingLoss)
         {
             var kind = _pendingInvestigateParam;
             _pendingInvestigateParam = null;
+            // Open the (possibly collapsed) card so the deep-linked result and nav controls are
+            // visible. Transient: not persisted, so the user's saved preference is preserved.
+            _investigateCollapsed = false;
             await NavigateToLossEvent(null, null, loadedOnly: kind == "loaded-loss");
         }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -2705,7 +2705,9 @@ else
     private Task LossNavForward() => _lossNavEventEnd.HasValue
         ? NavigateToLossEvent(null, _lossNavEventEnd.Value.AddSeconds(1), _lossNavLoadedOnly) : Task.CompletedTask;
 
-    private async Task LossNavDeactivate()
+    // Clear the loss-investigation state (no chart call). Used both by the Exit button and
+    // when leaving the performance tab, so the card never shows "active" without a live chart.
+    private void ResetLossNavState()
     {
         _lossNavActive = false;
         _lossNavTimestamp = null;
@@ -2713,6 +2715,11 @@ else
         _lossNavEventEnd = null;
         _lossInvestigateResult = null;
         _lossNavLoadedOnly = false;
+    }
+
+    private async Task LossNavDeactivate()
+    {
+        ResetLossNavState();
         StateHasChanged();
         await JS.InvokeVoidAsync("eval", "window.__latencyCharts?.restoreState();");
     }
@@ -2995,6 +3002,10 @@ else
             _latencyChartsMounted = false;
             try { await JS.InvokeVoidAsync("eval", "window.__latencyCharts?.unmount();"); }
             catch { }
+            // The chart (and its highlight) is torn down on leave, so drop the loss-nav state
+            // too - otherwise returning shows the card "active" with no highlight on the chart.
+            // Deep-linked investigations re-arm via the query param on entry, so this is safe.
+            ResetLossNavState();
         }
 
         if (_scrollToDiscoveryPending && _activeTab == "performance")
@@ -3056,6 +3067,8 @@ else
             _sfpChartsMounted = false;
             try { await JS.InvokeVoidAsync("eval", "window.__sfpCharts?.unmount();"); }
             catch { }
+            // Drop the stale SFP investigation result; its chart jump is gone with the unmount.
+            _sfpInvestigateResult = null;
         }
 
         if (_scrollToSfpChartsPending && _activeTab == "sfp" && _sfpChartsMounted)

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -321,8 +321,45 @@ else
             @UpstreamReviewBanner
         }
 
+        <!-- Quick investigation -->
+        <div class="card">
+            <div class="card-header">
+                <h2 class="card-title">Investigate</h2>
+            </div>
+            <div class="card-body" style="display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center;">
+                @if (_lossNavActive)
+                {
+                    <button class="btn btn-sm btn-secondary loss-nav-arrow" @onclick="LossNavBack" disabled="@_investigatingLoss"
+                            data-tooltip="Previous loss event">&#x25C0;</button>
+                    <button class="btn btn-primary" @onclick="LossNavDeactivate"
+                            data-tooltip="Exit @(_lossNavLoadedOnly ? "loaded" : "packet") loss investigation">
+                        @(_lossNavLoadedOnly ? "Loaded Loss Events" : "Packet Loss Events")
+                    </button>
+                    <button class="btn btn-sm btn-secondary loss-nav-arrow" @onclick="LossNavForward" disabled="@_investigatingLoss"
+                            data-tooltip="Next loss event">&#x25B6;</button>
+                }
+                else
+                {
+                    <button class="btn btn-secondary" @onclick="InvestigatePacketLoss" disabled="@_investigatingLoss"
+                            data-tooltip="Find the most recent packet loss event across ISP, Transit, and Internet targets and jump to it on the chart">
+                        @if (_investigatingLoss && !_lossNavLoadedOnly) { <span class="spinner-sm"></span> }
+                        else { <span>Packet Loss Events</span> }
+                    </button>
+                    <button class="btn btn-secondary" @onclick="InvestigateLoadedLoss" disabled="@_investigatingLoss"
+                            data-tooltip="Find the most recent loss event that happened while the WAN was under load - the SQM/bufferbloat signal">
+                        @if (_investigatingLoss && _lossNavLoadedOnly) { <span class="spinner-sm"></span> }
+                        else { <span>Loaded Loss Events</span> }
+                    </button>
+                }
+                @if (!string.IsNullOrEmpty(_lossInvestigateResult))
+                {
+                    <span class="page-description" style="align-self: center;">@_lossInvestigateResult</span>
+                }
+            </div>
+        </div>
+
         <!-- Latency time-series charts -->
-        <div class="card" id="latency-charts-container">
+        <div class="card" id="latency-charts-container" style="margin-top: 1.5rem;">
             <div class="card-header monitoring-chart-header">
                 <h2 class="card-title">Latency &amp; Packet Loss</h2>
                 <div style="display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap;">
@@ -382,43 +419,6 @@ else
                     <div class="latency-wan-rate-chart"></div>
                 </div>
                 <div class="latency-stats-table"></div>
-            </div>
-        </div>
-
-        <!-- Quick investigation -->
-        <div class="card" style="margin-top: 1.5rem;">
-            <div class="card-header">
-                <h2 class="card-title">Investigate</h2>
-            </div>
-            <div class="card-body" style="display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center;">
-                @if (_lossNavActive)
-                {
-                    <button class="btn btn-sm btn-secondary" @onclick="LossNavBack" disabled="@_investigatingLoss"
-                            data-tooltip="Previous loss event">&#x25C0;</button>
-                    <button class="btn btn-primary" @onclick="LossNavDeactivate"
-                            data-tooltip="Exit @(_lossNavLoadedOnly ? "loaded" : "packet") loss investigation">
-                        @(_lossNavLoadedOnly ? "Loaded Loss Events" : "Packet Loss Events")
-                    </button>
-                    <button class="btn btn-sm btn-secondary" @onclick="LossNavForward" disabled="@_investigatingLoss"
-                            data-tooltip="Next loss event">&#x25B6;</button>
-                }
-                else
-                {
-                    <button class="btn btn-secondary" @onclick="InvestigatePacketLoss" disabled="@_investigatingLoss"
-                            data-tooltip="Find the most recent packet loss event across ISP, Transit, and Internet targets and jump to it on the chart">
-                        @if (_investigatingLoss && !_lossNavLoadedOnly) { <span class="spinner-sm"></span> }
-                        else { <span>Packet Loss Events</span> }
-                    </button>
-                    <button class="btn btn-secondary" @onclick="InvestigateLoadedLoss" disabled="@_investigatingLoss"
-                            data-tooltip="Find the most recent loss event that happened while the WAN was under load - the SQM/bufferbloat signal">
-                        @if (_investigatingLoss && _lossNavLoadedOnly) { <span class="spinner-sm"></span> }
-                        else { <span>Loaded Loss Events</span> }
-                    </button>
-                }
-                @if (!string.IsNullOrEmpty(_lossInvestigateResult))
-                {
-                    <span class="page-description" style="align-self: center;">@_lossInvestigateResult</span>
-                }
             </div>
         </div>
 
@@ -2736,8 +2736,9 @@ else
             var localTime = result.Timestamp.ToLocalTime().ToString("M/d h:mm tt");
             _lossInvestigateResult = $"{result.LossPercent:0.#}% loss {ago} ({localTime})";
             StateHasChanged();
+            var annotationLabel = $"{(loadedOnly ? "Loaded" : "Packet")} loss {result.LossPercent:0.#}%";
             await JS.InvokeVoidAsync("eval",
-                $"window.__latencyCharts?.navigateToTime('{result.Timestamp:o}', '{category}');");
+                $"window.__latencyCharts?.navigateToTime('{result.Timestamp:o}', '{category}', '{annotationLabel}', {(loadedOnly ? "true" : "false")});");
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -232,6 +232,13 @@ else
                                     }
                                 </div>
                             }
+                            @if (!string.IsNullOrEmpty(issue.InvestigateUrl))
+                            {
+                                <div class="issue-investigate">
+                                    <a class="isp-factor-link" href="@issue.InvestigateUrl"
+                                       data-tooltip="Jump to the most recent matching loss event on the Network Performance charts">@(issue.InvestigateText ?? "Investigate on the charts")</a>
+                                </div>
+                            }
                         </div>
                     </div>
                 }

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -150,7 +150,7 @@ else
             <div class="isp-health-hero-gauge">
                 <IspHealthScoreGauge Score="r.OverallScore" Label="ISP Health" />
                 <div class="isp-health-profile-chip isp-health-profile-chip-selectable"
-                     data-tooltip="Score thresholds are tuned to this access technology. Change it here to re-score now.">
+                     data-tooltip="Thresholds are tuned per access technology; change it to re-score.">
                     Scored as @r.Profile.DisplayName &middot; @ScoredWindowLabel(r)
                     <span class="isp-profile-chip-caret"></span>
                     <select class="isp-profile-chip-select" aria-label="Access technology"
@@ -256,7 +256,7 @@ else
                         @if (dimension == r.AccessDimension)
                         {
                             <select class="isp-access-tech-select" aria-label="Access technology"
-                                    data-tooltip="Score thresholds are tuned to this access technology. Change it here to re-score now."
+                                    data-tooltip="Thresholds are tuned per access technology; change it to re-score."
                                     value="@((int)r.AccessTechnology)" @onchange="OnAccessTechnologyChanged">
                                 @foreach (var tech in ProfileTechOptions)
                                 {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -587,6 +587,11 @@ public class IspHealthInputs
     /// <summary>Whether UniFi Smart Queues is already enabled on the WAN.</summary>
     public bool SmartQueuesEnabled { get; init; }
 
+    /// <summary>Whether OUR Adaptive SQM is enabled and configured for the primary WAN. Distinct
+    /// from <see cref="SmartQueuesEnabled"/> (UniFi's base feature); used so the loaded-loss
+    /// recommendation never pitches Adaptive SQM to someone already running it.</summary>
+    public bool AdaptiveSqmEnabled { get; init; }
+
     /// <summary>
     /// Time windows to exclude from loaded-line analysis. Adaptive SQM speed probes
     /// briefly crank the HTB rate for an unshaped measurement; the resulting bufferbloat

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -151,6 +151,11 @@ public class IspHealthIssue
     public string? Recommendation { get; init; }
     public string? LinkUrl { get; init; }
     public string? LinkText { get; init; }
+
+    /// <summary>Optional deep-link to the matching loss event on the Network Performance charts,
+    /// mirroring the Access Layer sub-score headers (e.g. ?investigate=loaded-loss).</summary>
+    public string? InvestigateUrl { get; init; }
+    public string? InvestigateText { get; init; }
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -570,6 +570,11 @@ public sealed record AccessProfile(
     double LoadedDeltaExcellentMs,
     double LoadedDeltaAcceptableMs,
     bool IsNeutral = false,
+    // True for shared-medium access where capacity is contended across subscribers
+    // (cable/DOCSIS, PON, fixed wireless, cellular, LEO). Persistent loss on these can
+    // mean an oversubscribed segment, not just a local physical-plant fault. False for
+    // dedicated point-to-point media (DSL pair, Active Ethernet / DIA).
+    bool SharedMedium = true,
     // Per-tech jitter band (P95 jitter, ms). When set, jitter is scored straight off the band -
     // (ideal,100) (typical,90) (poor,25) (2*poor,0) - so a medium's inherent jitter (e.g. DOCSIS's
     // ~3 ms request-grant) reads as normal instead of being graded against a sub-ms path floor.
@@ -630,6 +635,7 @@ public static class IspHealthProfiles
             LoadedLossDownLowPct: 1.0, LoadedLossDownHighPct: 2.0,
             LoadedLossUpLowPct: 0.5, LoadedLossUpHighPct: 1.0,
             LoadedDeltaExcellentMs: 2.0, LoadedDeltaAcceptableMs: 10.0,
+            SharedMedium: false,
             JitterIdealMs: 0.4, JitterTypicalMs: 0.7, JitterPoorMs: 3.0),
 
         AccessTechnology.FixedWireless => new AccessProfile("Fixed Wireless",
@@ -654,6 +660,7 @@ public static class IspHealthProfiles
             LoadedLossDownLowPct: 3.0, LoadedLossDownHighPct: 5.0,
             LoadedLossUpLowPct: 3.0, LoadedLossUpHighPct: 5.0,
             LoadedDeltaExcellentMs: 5.0, LoadedDeltaAcceptableMs: 20.0,
+            SharedMedium: false,
             JitterIdealMs: 1.0, JitterTypicalMs: 2.0, JitterPoorMs: 5.0),
 
         AccessTechnology.PppoE => NeutralProfile("PPPoE"),

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -1326,10 +1326,26 @@ public class IspHealthScorer
         var (latencyTriggered, lossTriggered) = SqmTriggers(inputs, profile, loadWindows, loadedDeltas);
         if (latencyTriggered || lossTriggered)
         {
-            var recommendation = inputs.SmartQueuesEnabled
-                ? "Smart Queues is enabled on this WAN but the line still degrades under load; check that its configured rates match what the line actually delivers."
-                : "Enable Smart Queues (SQM) on this WAN in UniFi Network (Settings, Internet, your WAN, Smart Queues).";
-            if (inputs.CongestionEvents.Count(e => e.Disposition == CongestionDisposition.Confirmed) >= _options.SqmRecurringCongestionEvents)
+            // Adaptive SQM (our feature) overrides the UniFi Smart Queues messaging: if it is
+            // already managing this WAN, don't pitch it or tell the user to enable Smart Queues.
+            // Loss under load despite Adaptive SQM points at its rates sitting above what the line
+            // currently delivers, or at it having been paused/disabled.
+            string recommendation;
+            if (inputs.AdaptiveSqmEnabled)
+            {
+                recommendation = "Adaptive SQM is managing this WAN, so loss under load usually means its rates are set above what the line is currently delivering, or it was recently paused or disabled. Confirm it is active and that its rates track a fresh speed test.";
+            }
+            else if (inputs.SmartQueuesEnabled)
+            {
+                recommendation = "Smart Queues is enabled on this WAN but the line still degrades under load; check that its configured rates match what the line actually delivers.";
+            }
+            else
+            {
+                recommendation = "Enable Smart Queues (SQM) on this WAN in UniFi Network (Settings, Internet, your WAN, Smart Queues).";
+            }
+            // Only pitch Adaptive SQM when the WAN isn't already running it.
+            if (!inputs.AdaptiveSqmEnabled
+                && inputs.CongestionEvents.Count(e => e.Disposition == CongestionDisposition.Confirmed) >= _options.SqmRecurringCongestionEvents)
             {
                 recommendation += " This connection also shows a recurring congestion pattern; consider Adaptive SQM, which tracks time-of-day capacity changes automatically.";
             }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -1326,14 +1326,15 @@ public class IspHealthScorer
         var (latencyTriggered, lossTriggered) = SqmTriggers(inputs, profile, loadWindows, loadedDeltas);
         if (latencyTriggered || lossTriggered)
         {
-            // Adaptive SQM (our feature) overrides the UniFi Smart Queues messaging: if it is
-            // already managing this WAN, don't pitch it or tell the user to enable Smart Queues.
-            // Loss under load despite Adaptive SQM points at its rates sitting above what the line
-            // currently delivers, or at it having been paused/disabled.
+            // Adaptive SQM (our feature) overrides the UniFi Smart Queues messaging: we can see
+            // it's already shaping this WAN, so don't pitch it or tell the user to enable Smart
+            // Queues. Loss under load while it shapes means the rate it holds isn't backing off
+            // enough for the real-time capacity drop, so point at its own tuning knobs (Severity
+            // deepens the time-of-day dips; nominal speeds set the ceiling everything scales from).
             string recommendation;
             if (inputs.AdaptiveSqmEnabled)
             {
-                recommendation = "Adaptive SQM is managing this WAN, so loss under load usually means its rates are set above what the line is currently delivering, or it was recently paused or disabled. Confirm it is active and that its rates track a fresh speed test.";
+                recommendation = "Adaptive SQM is already shaping this WAN, so loss under load means the rate it holds isn't backing off enough when the line congests. In your Adaptive SQM settings, raise the Severity so the peak-hour rate dips go deeper, or lower the nominal download/upload if the line consistently delivers less than its plan. If loss persists once the rate is pulled down, the drops are upstream and only your ISP can fix them.";
             }
             else if (inputs.SmartQueuesEnabled)
             {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -1354,7 +1354,9 @@ public class IspHealthScorer
                     Description = "Packet loss exceeds the acceptable band for this connection type when the line is loaded.",
                     Recommendation = recommendation,
                     LinkUrl = "/sqm",
-                    LinkText = "Adaptive SQM"
+                    LinkText = "Adaptive SQM",
+                    InvestigateUrl = "/monitoring?tab=performance&investigate=loaded-loss",
+                    InvestigateText = "Investigate on the charts"
                 });
             }
         }
@@ -1386,12 +1388,32 @@ public class IspHealthScorer
         var idleLossFactor = report.AccessDimension.Factors.FirstOrDefault(f => f.Name == "Packet Loss");
         if (idleLossFactor?.Score is < 70)
         {
+            // Dedicated point-to-point media (DSL pair, Active Ethernet / DIA) have no
+            // contended segment, so persistent loss there is a physical-plant fault. On
+            // shared media the same loss can equally be an oversubscribed segment upstream,
+            // and on the neutral PPPoE/Other profile the medium is unknown so we hedge.
+            string lossRecommendation;
+            if (!profile.SharedMedium)
+            {
+                lossRecommendation = "Persistent loss regardless of load usually points at the physical layer: check optics, connectors, or line/signal levels, and raise it with your ISP.";
+            }
+            else if (profile.IsNeutral)
+            {
+                lossRecommendation = "Persistent loss regardless of load points at the access layer: a physical-plant fault (optics, connectors, coax fittings, or signal levels), or - if your line runs over a shared medium like cable, PON, fixed wireless, or cellular - an oversubscribed segment carrying too many subscribers. Raise it with your ISP either way.";
+            }
+            else
+            {
+                lossRecommendation = $"Persistent loss regardless of load points at the access layer: a physical-plant fault (optics, connectors, coax fittings, or signal levels), or an oversubscribed segment upstream, since {profile.DisplayName} shares capacity across subscribers. Raise it with your ISP.";
+            }
+
             issues.Add(new IspHealthIssue
             {
                 Severity = IspIssueSeverity.Warning,
                 Title = "Packet loss above acceptable",
                 Description = $"Average packet loss of {idleLossFactor.ValueText} exceeds the {FormatPct(profile.IdleLossAcceptablePct)} acceptable ceiling for {profile.DisplayName}.",
-                Recommendation = "Persistent loss regardless of load usually points at the physical layer: check optics, connectors, coax fittings, or signal levels, and raise it with your ISP."
+                Recommendation = lossRecommendation,
+                InvestigateUrl = "/monitoring?tab=performance&investigate=packet-loss",
+                InvestigateText = "Investigate on the charts"
             });
         }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -468,6 +468,15 @@ public class IspHealthService
             })
             .ToList();
 
+        // Surface the well-known anycast DNS endpoints (Cloudflare 1.1.1.1, Google 8.8.8.8)
+        // as their own lines on the Per-Network RTT chart. They already feed loss, path-shift,
+        // and congestion detection (as destination witnesses); they are also exceptionally
+        // stable, so plotting them gives a known-good baseline to read a noisy ISP or transit
+        // hop against. Only the anycast DNS targets are charted, not arbitrary discovered
+        // InternetService destinations.
+        chartClusters.AddRange(internetTargetSeries
+            .Where(s => s.HopIps.Any(AnycastDnsIps.Contains)));
+
         // Per-target (hop-granularity) series for the congestion localizer: clustering would
         // lump a clean middle hop with a hot one and re-merge an off-path ASN, so detection and
         // localization run at the individual hop. Destinations come in as witnesses only.

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -658,6 +658,7 @@ public class IspHealthService
         // event labels. It is published together with the report (see Snapshot).
         var primaryWanInterface = await GetPrimaryWanInterfaceAsync(ct);
         var loadExclusions = await BuildSqmProbeExclusionsAsync(windowStart, windowEnd, primaryWanInterface, ct);
+        var adaptiveSqmEnabled = await IsAdaptiveSqmEnabledAsync(primaryWanInterface, ct);
 
         // Match the WAN's access technology to one monitored physical device (ONT/SFP, cable
         // modem, or cellular modem) and aggregate its window metrics for the Physical Link factor.
@@ -685,6 +686,7 @@ public class IspHealthService
             PathShifts = pathShifts,
             Outages = outages,
             SmartQueuesEnabled = smartQueuesEnabled,
+            AdaptiveSqmEnabled = adaptiveSqmEnabled,
             HopOrderKnown = hopOrderKnown,
             LoadExclusionWindows = loadExclusions,
             PhysicalLink = physical.Input
@@ -941,6 +943,23 @@ public class IspHealthService
             }
         }
         return exclusions;
+    }
+
+    /// <summary>
+    /// True when OUR Adaptive SQM is enabled and configured for the primary WAN (an enabled
+    /// <see cref="SqmWanConfiguration"/> matching the interface). Distinct from UniFi's base
+    /// Smart Queues toggle (<see cref="IspHealthInputs.SmartQueuesEnabled"/>); the loaded-loss
+    /// recommendation uses this so it never tells a user to "consider Adaptive SQM" when they
+    /// already run it.
+    /// </summary>
+    private async Task<bool> IsAdaptiveSqmEnabledAsync(string? primaryWanInterface, CancellationToken ct)
+    {
+        if (string.IsNullOrEmpty(primaryWanInterface)) return false;
+        await using var db = await _dbFactory.CreateDbContextAsync(ct);
+        var sqmConfigs = await db.SqmWanConfigurations.AsNoTracking()
+            .Where(c => c.Enabled)
+            .ToListAsync(ct);
+        return sqmConfigs.Any(c => string.Equals(c.Interface, primaryWanInterface, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -226,6 +226,14 @@ a:hover {
     font-weight: 500;
 }
 
+.card-title-icon {
+    width: 1.75rem;
+    height: 1.4rem;
+    object-fit: contain;
+    vertical-align: middle;
+    margin-right: 0.45rem;
+}
+
 .nav-sub-item {
     padding-left: 1rem;
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2811,6 +2811,11 @@ select.form-control {
     color: var(--text-primary);
 }
 
+.issue-investigate {
+    margin-top: 0.5rem;
+    font-size: 0.875rem;
+}
+
 .issue-recommendation a,
 .issue-type-recommendation a,
 .issue-description a,

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2102,6 +2102,12 @@ a.btn-sm {
     line-height: 28px;
 }
 
+@media (max-width: 768px) {
+    .loss-nav-arrow {
+        min-width: 4rem;
+    }
+}
+
 .btn-group-wrap {
     display: flex;
     flex-wrap: wrap;

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -46,21 +46,24 @@ let visibilityObserver = null;
 let isInViewport = true;
 let lastFetchData = null;
 let savedState = null;
-let investigateMarker = null;  // { ts, label, loaded } while investigating a loss event
+let investigateMarker = null;  // { startMs, endMs, label, loaded } while investigating a loss event
 
 // Highlight the investigated loss event on the RTT and loss charts, mirroring the
-// shaded event annotations on the ISP Health chart. Loaded-loss events are amber
-// (the SQM/bufferbloat signal); plain packet-loss events are info blue.
+// shaded event annotations on the ISP Health chart. The band spans the actual coalesced
+// event so it stays tight around the loss instead of trailing past it. Loaded-loss events
+// are amber (the SQM/bufferbloat signal); plain packet-loss events are info blue.
 function buildInvestigateAnnotations() {
     if (!investigateMarker) return { xaxis: [] };
-    const { ts, label, loaded } = investigateMarker;
-    const half = 60000; // ±1 min band, visible inside the ~20 min investigation window
+    const { startMs, endMs, label, loaded } = investigateMarker;
+    // The 1-min loss buckets are stamped at their stop edge, so the first bucket (startMs)
+    // covers data from the minute before it; back the band start up one minute to match.
+    const bucketMs = 60000;
     const color = loaded ? '#f59e0b' : '#4797ff';
     const labelBg = loaded ? '#78350f' : '#1e3a5f';
     return {
         xaxis: [{
-            x: ts - half,
-            x2: ts + half,
+            x: startMs - bucketMs,
+            x2: endMs,
             fillColor: color,
             opacity: 0.15,
             borderColor: color,
@@ -598,13 +601,20 @@ export async function mount(elId) {
     startPoll();
 }
 
-export function navigateToTime(isoTimestamp, category, label, loaded) {
+export function navigateToTime(isoTimestamp, category, label, loaded, eventStartIso, eventEndIso) {
     if (!savedState) {
         savedState = { category: currentCategory, rangeHours: currentRangeHours,
             customFrom, customTo, isCustomRange, windowOffset, visibility: { ...visibility } };
     }
     const ts = new Date(isoTimestamp).getTime();
-    investigateMarker = label ? { ts, label, loaded: !!loaded } : null;
+    investigateMarker = label
+        ? {
+            startMs: eventStartIso ? new Date(eventStartIso).getTime() : ts,
+            endMs: eventEndIso ? new Date(eventEndIso).getTime() : ts,
+            label,
+            loaded: !!loaded,
+        }
+        : null;
     const windowMs = 10 * 60000; // 10 min window centered on event
     customFrom = new Date(ts - windowMs);
     customTo = new Date(ts + windowMs);

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -46,6 +46,31 @@ let visibilityObserver = null;
 let isInViewport = true;
 let lastFetchData = null;
 let savedState = null;
+let investigateMarker = null;  // { ts, label, loaded } while investigating a loss event
+
+// Highlight the investigated loss event on the RTT and loss charts, mirroring the
+// shaded event annotations on the ISP Health chart. Loaded-loss events are amber
+// (the SQM/bufferbloat signal); plain packet-loss events are info blue.
+function buildInvestigateAnnotations() {
+    if (!investigateMarker) return { xaxis: [] };
+    const { ts, label, loaded } = investigateMarker;
+    const half = 60000; // ±1 min band, visible inside the ~20 min investigation window
+    const color = loaded ? '#f59e0b' : '#4797ff';
+    const labelBg = loaded ? '#78350f' : '#1e3a5f';
+    return {
+        xaxis: [{
+            x: ts - half,
+            x2: ts + half,
+            fillColor: color,
+            opacity: 0.15,
+            borderColor: color,
+            label: {
+                text: label,
+                style: { color: '#ededef', background: labelBg, fontSize: '10px' },
+            },
+        }],
+    };
+}
 
 function baseChartOpts(type, yTitle, yFormatter, extraOpts) {
     return {
@@ -248,6 +273,10 @@ async function loadAndUpdate() {
 
     if (rttChart) rttChart.updateSeries(rttSeries, false);
     if (lossChart) lossChart.updateSeries(lossSeries, false);
+
+    const annotations = buildInvestigateAnnotations();
+    if (rttChart) rttChart.updateOptions({ annotations }, false, false);
+    if (lossChart) lossChart.updateOptions({ annotations }, false, false);
 
     updateChartVisibility();
 
@@ -569,12 +598,13 @@ export async function mount(elId) {
     startPoll();
 }
 
-export function navigateToTime(isoTimestamp, category) {
+export function navigateToTime(isoTimestamp, category, label, loaded) {
     if (!savedState) {
         savedState = { category: currentCategory, rangeHours: currentRangeHours,
             customFrom, customTo, isCustomRange, windowOffset, visibility: { ...visibility } };
     }
     const ts = new Date(isoTimestamp).getTime();
+    investigateMarker = label ? { ts, label, loaded: !!loaded } : null;
     const windowMs = 10 * 60000; // 10 min window centered on event
     customFrom = new Date(ts - windowMs);
     customTo = new Date(ts + windowMs);
@@ -598,6 +628,7 @@ export function navigateToTime(isoTimestamp, category) {
 
 export function restoreState() {
     if (!savedState) return;
+    investigateMarker = null;
     currentCategory = savedState.category;
     currentRangeHours = savedState.rangeHours;
     customFrom = savedState.customFrom;
@@ -672,5 +703,6 @@ export function unmount() {
     customTo = null;
     lastFetchData = null;
     savedState = null;
+    investigateMarker = null;
     isInViewport = true;
 }


### PR DESCRIPTION
## ISP Health

- **Investigate links on loss findings** - the "Packet loss under load" and "Packet loss above acceptable" findings now link to the matching event on the Network Performance charts, the same way the Access Layer sub-score headers do, so it's easy to confirm which series drove the finding instead of inferring it from unrelated WAN speed tests. (#936)
- **Anycast DNS on the Per-Network RTT chart** - Cloudflare (1.1.1.1) and Google (8.8.8.8) now plot as their own lines. They already feed loss, path-shift, and congestion detection and are exceptionally stable, so they give a known-good baseline to read a noisy ISP or transit hop against.
- **Access-tech-aware persistent-loss advice** - the "Packet loss above acceptable" recommendation now names oversubscription alongside physical-plant faults on shared media (cable/DOCSIS, PON, fixed wireless, cellular, LEO), stays physical-layer only on dedicated media (DSL, Active Ethernet / DIA), and hedges on the neutral PPPoE/Other profile where the medium is unknown.
- **Adaptive SQM-aware loaded-loss advice** - when Adaptive SQM is already shaping the WAN, the loaded-loss recommendation points at its own tuning knobs (Severity, nominal speeds) instead of telling the user to enable Smart Queues or "consider Adaptive SQM."
- **Tighter access-technology tooltip.**

## Network Performance

- **Investigate card** moved above the Latency & Packet Loss chart, made collapsible with a saved collapse state, and given the Monitoring icon. A linked investigation opens it transiently without changing the saved preference, and the state clears when leaving the tab.
- **Event-based loss investigation** - stepping through Packet Loss / Loaded Loss events now coalesces contiguous loss minutes into distinct events and steps event-to-event (landing on each event's peak-loss minute) rather than minute-by-minute. The investigated event is highlighted on the RTT and loss charts with a labeled band tight to the event.
- **Mobile** - narrower loss-event nav arrows.

## Docs

- TODO: ideas for further investigation functions (congestion / path-shift / outage navigation, a verdict line on landing, per-target investigate, and more).
