### PR TITLE
ISP Health: loading spinner, DOCSIS 3.1/4.0 label, WoodyNet/PCH transit exclusion

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -60,9 +60,9 @@
 
 @if (_loading)
 {
-    <div class="loading-container">
-        <div class="spinner"></div>
-        <p>Analyzing recent ISP data...</p>
+    <div class="isp-health-loading card">
+        <div class="isp-health-loading-spinner"></div>
+        <p class="isp-health-loading-text">Analyzing recent ISP data...</p>
     </div>
 }
 else if (_report == null)

--- a/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
@@ -3,6 +3,7 @@ using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
 using NetworkOptimizer.Web.Services;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Endpoints;
 
@@ -199,7 +200,8 @@ public static class MonitoringChartEndpoints
             // target_id set (full scan, ~400ms+).
             await using var db = await dbFactory.CreateDbContextAsync(ct);
             var targets = await db.MonitoringTargets.AsNoTracking()
-                .Where(t => t.TargetType == targetType && t.Enabled)
+                .Where(t => t.TargetType == targetType && t.Enabled
+                    && (t.AsnNumber == null || !WellKnownAsns.NonTransitInfrastructure.Contains(t.AsnNumber.Value)))
                 .OrderBy(t => t.Name)
                 .Select(t => new { t.TargetId, t.Name })
                 .ToListAsync(ct);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -332,7 +332,10 @@ public class IspHealthService
         }
 
         var ispTargets = targets.Where(t => t.TargetType == MonitoringTargetType.AccessIsp).ToList();
-        var transitTargets = targets.Where(t => t.TargetType == MonitoringTargetType.Transit).ToList();
+        // WoodyNet / PCH (AS42, AS715) and similar IXP/anycast-DNS infrastructure are not
+        // transit; drop them so they never enter scoring, the per-ASN cards, or the chart clusters.
+        var transitTargets = targets.Where(t => t.TargetType == MonitoringTargetType.Transit
+            && !(t.AsnNumber is int a && WellKnownAsns.NonTransitInfrastructure.Contains(a))).ToList();
         if (ispTargets.Count == 0 && transitTargets.Count == 0)
             return new ComputeOutcome(IspHealthStatus.NeedsDiscovery, null, new List<AsnSeries>());
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkScorer.cs
@@ -423,7 +423,9 @@ public static class PhysicalLinkScorer
             });
         }
 
-        var gen = isOfdm ? "DOCSIS 3.1" : "DOCSIS 3.0";
+        // An active OFDMA channel proves an OFDM-capable plant but can't tell 3.1 from 4.0
+        // (4.0 also runs OFDMA), so we name both rather than claim 3.1 specifically.
+        var gen = isOfdm ? "DOCSIS 3.1/4.0" : "DOCSIS 3.0";
         // Headline (ValueText) carries SNR + US; the description lists the other scored stats (DS, FEC).
         var desc = $"{gen} cable-modem RF health"
                    + (detailBits.Count > 0 ? $" ({string.Join(", ", detailBits)})." : ".")

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -991,11 +991,11 @@ public class UpstreamTracerService
 
         _nearTransitAsns.Clear();
         _nearTransitAsns.UnionWith(
-            ComputeNearTransitAsns(traceSequences, asnByIp, accessAsnNumbers, destinationAsns, Tier1Asns));
+            ComputeNearTransitAsns(traceSequences, asnByIp, accessAsnNumbers, destinationAsns, WellKnownAsns.Tier1));
 
         _excludedTier1Asns.Clear();
         _excludedTier1Asns.UnionWith(
-            ComputeExcludedTier1Asns(traceSequences, asnByIp, Tier1Asns, accessAsnNumbers));
+            ComputeExcludedTier1Asns(traceSequences, asnByIp, WellKnownAsns.Tier1, accessAsnNumbers));
 
         var transitGroups = _mergedHops
             .Where(h => h.Asn != null
@@ -1930,33 +1930,6 @@ public class UpstreamTracerService
     /// </summary>
     internal static string CleanAsnName(string? name) =>
         NetworkOptimizer.Core.Helpers.NetworkFormatHelpers.CleanOrgName(name);
-
-    // Tier-1 (settlement-free) networks, with the sibling ASNs that show up in real
-    // US traces. Two tier-1s adjacent on a path is core peering, not our access ISP's
-    // transit, so a tier-1 sitting directly above another tier-1 is excluded as a
-    // candidate. Stable set - revisit only on major carrier M&A. Last reviewed 2026-06.
-    //
-    // Hurricane Electric (AS6939) is deliberately NOT included: it isn't settlement-free
-    // on IPv4 (buys paid transit; Cogent won't peer), so its presence beneath a tier-1
-    // carries no reliable "core peering" signal. A tier-1 reached via HE still surfaces
-    // as a candidate and can simply be unchecked in the discovery review list.
-    internal static readonly HashSet<int> Tier1Asns = new()
-    {
-        3356, 209, 3549, 3561,            // Lumen / Level 3 / CenturyLink / Global Crossing / Savvis
-        7018, 2386, 7132, 6389, 2686,     // AT&T (incl. legacy SBC / BellSouth ASNs seen in US traces)
-        701, 702, 703,     // Verizon (UUNET)
-        2914,              // NTT (GIN)
-        174, 1239,         // Cogent (1239 = ex-SprintLink, sold to Cogent 2023)
-        1299,              // Arelion (ex-Telia)
-        3257,              // GTT (backbone now EXA Infrastructure; ASN still registered GTT)
-        6453,              // Tata
-        6461,              // Zayo
-        6762,              // Telecom Italia Sparkle
-        3491,              // PCCW Global
-        5511,              // Orange
-        12956,             // Telxius (Telefonica)
-        3320,              // Deutsche Telekom
-    };
 
     /// <summary>
     /// Near-transit ASNs: every ASN that appears as the 1st or 2nd distinct non-access,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1004,6 +1004,7 @@ public class UpstreamTracerService
                         && !(h.Asn.Name != null && destinationOrgs.Contains(h.Asn.Name.Trim()))
                         && !transitProbeAddresses.Contains(h.Address)
                         && !_excludedTier1Asns.Contains(h.Asn.Asn)
+                        && !WellKnownAsns.NonTransitInfrastructure.Contains(h.Asn.Asn)
                         && (!transitProbeAsns.Contains(h.Asn.Asn)
                             || _nearTransitAsns.Contains(h.Asn.Asn)))
             .GroupBy(h => h.Asn!.Asn)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/WellKnownAsns.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/WellKnownAsns.cs
@@ -1,18 +1,49 @@
 namespace NetworkOptimizer.Web.Services.Monitoring;
 
 /// <summary>
-/// Well-known ASNs that appear on traceroutes but are not commercial transit, so ISP
-/// Health must not grade, chart, or display them as Transit. They surface on a path
-/// because of IXP route servers or anycast DNS endpoints, not because they haul our
-/// traffic upstream. Discovery never proposes them as transit targets, and the scoring,
-/// chart, and live-stats read paths drop any rows already committed.
+/// Catalog of hardcoded well-known ASN sets used by upstream classification and ISP
+/// Health: the tier-1 carrier set (for core-peering detection) and the non-transit
+/// infrastructure set (ASNs that ride a traceroute but never haul our traffic upstream).
 /// </summary>
 internal static class WellKnownAsns
 {
     /// <summary>
     /// WoodyNet / Packet Clearing House (PCH): operates IXP route servers and anycast
     /// DNS infrastructure, not a transit carrier (AS42 = WOODYNET-1, AS715 = WOODYNET-2).
-    /// Exposed as an array so EF Core translates Contains() to a SQL IN on the DB read paths.
+    /// These appear on a path via IX fabric or anycast DNS endpoints, so ISP Health must
+    /// not grade, chart, or display them as Transit. Discovery never proposes them as
+    /// transit targets, and the scoring, chart, and live-stats read paths drop any rows
+    /// already committed. Exposed as an array so EF Core translates Contains() to a SQL IN
+    /// on the DB read paths.
     /// </summary>
     public static readonly int[] NonTransitInfrastructure = { 42, 715 };
+
+    /// <summary>
+    /// Tier-1 (settlement-free) networks, with the sibling ASNs that show up in real
+    /// US traces. Two tier-1s adjacent on a path is core peering, not our access ISP's
+    /// transit, so a tier-1 sitting directly above another tier-1 is excluded as a
+    /// candidate. Stable set - revisit only on major carrier M&amp;A. Last reviewed 2026-06.
+    ///
+    /// Hurricane Electric (AS6939) is deliberately NOT included: it isn't settlement-free
+    /// on IPv4 (buys paid transit; Cogent won't peer), so its presence beneath a tier-1
+    /// carries no reliable "core peering" signal. A tier-1 reached via HE still surfaces
+    /// as a candidate and can simply be unchecked in the discovery review list.
+    /// </summary>
+    public static readonly HashSet<int> Tier1 = new()
+    {
+        3356, 209, 3549, 3561,            // Lumen / Level 3 / CenturyLink / Global Crossing / Savvis
+        7018, 2386, 7132, 6389, 2686,     // AT&T (incl. legacy SBC / BellSouth ASNs seen in US traces)
+        701, 702, 703,     // Verizon (UUNET)
+        2914,              // NTT (GIN)
+        174, 1239,         // Cogent (1239 = ex-SprintLink, sold to Cogent 2023)
+        1299,              // Arelion (ex-Telia)
+        3257,              // GTT (backbone now EXA Infrastructure; ASN still registered GTT)
+        6453,              // Tata
+        6461,              // Zayo
+        6762,              // Telecom Italia Sparkle
+        3491,              // PCCW Global
+        5511,              // Orange
+        12956,             // Telxius (Telefonica)
+        3320,              // Deutsche Telekom
+    };
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/WellKnownAsns.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/WellKnownAsns.cs
@@ -1,0 +1,18 @@
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Well-known ASNs that appear on traceroutes but are not commercial transit, so ISP
+/// Health must not grade, chart, or display them as Transit. They surface on a path
+/// because of IXP route servers or anycast DNS endpoints, not because they haul our
+/// traffic upstream. Discovery never proposes them as transit targets, and the scoring,
+/// chart, and live-stats read paths drop any rows already committed.
+/// </summary>
+internal static class WellKnownAsns
+{
+    /// <summary>
+    /// WoodyNet / Packet Clearing House (PCH): operates IXP route servers and anycast
+    /// DNS infrastructure, not a transit carrier (AS42 = WOODYNET-1, AS715 = WOODYNET-2).
+    /// Exposed as an array so EF Core translates Contains() to a SQL IN on the DB read paths.
+    /// </summary>
+    public static readonly int[] NonTransitInfrastructure = { 42, 715 };
+}

--- a/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Services;
 
@@ -304,7 +305,8 @@ public class MonitoringLiveStats
         var targets = await db.MonitoringTargets.AsNoTracking()
             .Where(t => t.Enabled
                 && (t.TargetType == MonitoringTargetType.AccessIsp
-                    || t.TargetType == MonitoringTargetType.Transit))
+                    || t.TargetType == MonitoringTargetType.Transit)
+                && (t.AsnNumber == null || !WellKnownAsns.NonTransitInfrastructure.Contains(t.AsnNumber.Value)))
             .Select(t => new { t.TargetId, t.TargetType })
             .ToListAsync(ct);
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -16071,6 +16071,39 @@ tr.stats-row-filtered {
     z-index: 1;
 }
 
+.isp-health-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1.25rem;
+    min-height: 320px;
+    overflow: hidden;
+    border: 1px solid var(--border-color);
+    background:
+        radial-gradient(ellipse 60% 120% at 18% 0%, rgba(5, 80, 181, 0.12), transparent 60%),
+        radial-gradient(ellipse 50% 100% at 85% 100%, rgba(43, 168, 154, 0.08), transparent 65%),
+        var(--bg-card);
+}
+
+.isp-health-loading-spinner {
+    width: 54px;
+    height: 54px;
+    border-radius: 50%;
+    background: conic-gradient(from 0deg, transparent 0%, var(--primary-color) 45%, #2ba89a 100%);
+    -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 5px), #000 calc(100% - 4px));
+    mask: radial-gradient(farthest-side, transparent calc(100% - 5px), #000 calc(100% - 4px));
+    filter: drop-shadow(0 4px 16px rgba(43, 168, 154, 0.28));
+    animation: spin 0.9s linear infinite;
+}
+
+.isp-health-loading-text {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    letter-spacing: 0.01em;
+}
+
 .isp-health-hero {
     position: relative;
     margin-bottom: 1rem;

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
@@ -997,6 +997,14 @@ public class ComputeExcludedTier1AsnsTests
         // signal and stays out of the adjacency set.
         WellKnownAsns.Tier1.Should().NotContain(6939);
     }
+
+    [Fact]
+    public void NonTransitInfrastructure_includes_woodynet_pch()
+    {
+        // WoodyNet / PCH (AS42, AS715) runs IXP route servers and anycast DNS, not
+        // commercial transit, so both stay in the non-transit exclusion set.
+        WellKnownAsns.NonTransitInfrastructure.Should().Contain(new[] { 42, 715 });
+    }
 }
 
 public class AccessIspFallbackTests

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
@@ -986,7 +986,7 @@ public class ComputeExcludedTier1AsnsTests
     {
         // Core tier-1s, plus the corrected AS1239 (now Cogent) and active AT&T/Lumen
         // sibling ASNs that show up in US traces.
-        UpstreamTracerService.Tier1Asns.Should().Contain(
+        WellKnownAsns.Tier1.Should().Contain(
             new[] { 3356, 174, 7018, 2914, 1299, 6461, 1239, 7132, 3561 });
     }
 
@@ -995,7 +995,7 @@ public class ComputeExcludedTier1AsnsTests
     {
         // AS6939 is not settlement-free on IPv4, so it carries no reliable core-peering
         // signal and stays out of the adjacency set.
-        UpstreamTracerService.Tier1Asns.Should().NotContain(6939);
+        WellKnownAsns.Tier1.Should().NotContain(6939);
     }
 }
 


### PR DESCRIPTION
Four focused ISP Health changes.

## Branded loading spinner

The ISP Health tab's initial load showed a tiny, left-aligned spinner in an undefined `.loading-container`. Replaced with a centered loading state that matches the ISP Health hero card: the same blue-to-teal radial-gradient wash, card border and radius, and a conic-gradient ring spinner with a soft drop-shadow. Purely visual; reuses the existing `spin` keyframes.

## "DOCSIS 3.1/4.0" in Physical Link

An active OFDMA channel proves an OFDM-capable plant but does not distinguish DOCSIS 3.1 from 4.0 (4.0 also runs OFDMA). The Physical Link RF-health description now reads "DOCSIS 3.1/4.0" when OFDMA is detected, instead of claiming 3.1 specifically.

## Exclude WoodyNet / PCH (AS42, AS715) from Transit

WoodyNet / Packet Clearing House operates IXP route servers and anycast DNS infrastructure, not commercial transit. It lands on a traceroute via IX fabric or anycast DNS endpoints, not by hauling traffic upstream, so it does not belong in the Transit dimension. It is now excluded at discovery (never proposed as a transit target) and at every transit read path: scoring, the per-ASN "Networks on Your Path" cards, the latency chart, and live-stats. Existing target rows are left in place, just no longer surfaced as Transit.

## Consolidate well-known ASN sets

New `WellKnownAsns` holds the hardcoded ASN catalogs in one place: the tier-1 carrier set (relocated from `UpstreamTracerService`, behavior unchanged) and the new non-transit-infrastructure set.

## Testing

- `dotnet build`: 0 warnings
- `NetworkOptimizer.Web.Tests`: 484 passing
