### PR TITLE
Channel Optimizer: measured RF spectrum data, on-demand scans, and safer recommendations

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,20 +2,33 @@
 
 ## Channel Recommendation: Engine-Review Follow-ups (recalibration-sensitive)
 
-From the full engine review. The clear correctness bugs and the live measured-floor issues are
-already fixed and shipped (floor candidate-only + proximity-weighted + gate-scaled; propagated stress
-split from measured; noise floor wired in; DFS penalty span-aware; fallback baseline). These five
-remain. They all shift the recommendation DISTRIBUTION and the gate thresholds are calibrated to
-current behavior, so each needs a live before/after comparison on the NAS + Mac sites (and ideally a
-fleet sample) to land safely - not a blind edit.
+**PICK UP HERE next session.** Branch `bugfix/channelrec-altruism`. Everything below is TABLED for the
+current release - none are release-critical (the only finding that produced an actual invalid output,
+#4's net-worse recommendation, is fixed + guardrailed). These remaining items shift the recommendation
+DISTRIBUTION and the gate thresholds are calibrated to current behavior, so each needs a live
+before/after on the NAS + Mac sites (and ideally a fleet sample), not a blind edit.
 
-- [ ] **Inconsistent objective (sum-of-ScoreAp vs ScoreAssignment).** The search minimizes
-  `ScoreAssignment` (each internal pair counted once, symmetric). The auxiliary passes (per-AP
-  fallback net-benefit, altruistic "others", crowding friction, comfort "others") sum `ScoreAp`
-  deltas, which count each internal pair ~2x (directional both ways) - so a move the search rejected
-  can be re-approved by an auxiliary pass on an inconsistent yardstick. Fix: express the auxiliary
-  net/others measures as `ScoreAssignment`-deltas (or halve the internal contribution in the per-AP
-  sum), then re-tune MinApAbsoluteImprovement / MinApScoreToMove against the new scale.
+**Already shipped on this branch (baseline, deployed to NAS + Mac):**
+- Measured floor #2 (candidate-only, proximity-weighted sibling, gate-scaled); propagated stress split
+  from measured `HistoricalStress`; DFS penalty span-aware; per-AP fallback baseline fix.
+- Spectrum-scan noise floor wired into scoring (mean-util / worst-noise, verified vs UniFi BW160);
+  scans run at the radio's live BW; `ScanChannelData` keyed by (channel, width) with span aggregation.
+- Cross-vantage: an AP's CURRENT channel is scored from the closest off-channel sibling, not its own
+  self-contaminated read (mesh/camera traffic that follows the AP).
+- Net-worse guardrail + fallback net-benefit on `ScoreAssignment` (finding #4, largely done).
+- Win 1: gap-aware quick-scan prompt (value-first copy, mesh APs excluded, warning tailored by
+  `HasDedicatedScanRadio` + mesh role); disclaimer auto-hides when no scan gaps.
+
+**Remaining engine findings (tabled):**
+
+- [~] **Inconsistent objective (sum-of-ScoreAp vs ScoreAssignment).** The search minimizes
+  `ScoreAssignment` (each internal pair counted once, symmetric). The auxiliary passes sum `ScoreAp`
+  deltas, which count each internal pair ~2x - so a move the search rejected can be re-approved on an
+  inconsistent yardstick. **Largely fixed:** the per-AP fallback now uses the `ScoreAssignment` delta
+  for its net-benefit check + selection, and a global guardrail drops any final plan whose network
+  score is worse than current (this hit live as a net-worse recommendation, Front Yard ch1->ch6).
+  Remaining (lower priority now, backstopped by the guardrail): the altruistic "others" and comfort
+  passes still use sum-of-`ScoreAp` internally - convert them too for cleanliness.
 - [ ] **Position-dependence in the post-passes.** Per-AP fallback, altruistic, crowding, and comfort
   all loop in AP array order and mutate the plan in place, so earlier APs shift later APs' baselines.
   The main search is most-constrained-first; the post-passes aren't. Fix: order them deterministically
@@ -656,11 +669,17 @@ Shared piece to build once: a "trigger -> poll `quick_scan_state.in_progress` un
 results -> re-run rec" helper. Expose the trigger through `IWiFiDataProvider` (it currently lives
 only on `UniFiApiClient`).
 
-- [ ] **Win 1 (gap-aware prompt)** - on the recommendation page, when a band/AP has no recent
-  measurement (empty `ScanChannelData`; we already log the fallback), offer a one-click "run a quick
-  scan on [these APs/bands]?" that scans exactly the gaps, polls, and re-runs. *(In progress this session.)*
-- [ ] **Win 2 (manual "Refresh measurements" button)** - stagger a quick-scan across all APs for the
-  current band (or all bands), then re-run when done. Same async flow as Win 1, just "all" not "gaps".
+- [x] **Win 1 (gap-aware prompt)** - DONE & shipped. Gap banner offers a one-click quick scan of the
+  gapped (AP, band)s (mesh APs excluded, per-AP-serial/cross-AP-parallel, scans at live BW), polls,
+  re-runs. Warning tailored by `HasDedicatedScanRadio` + mesh role; disclaimer auto-hides when no gaps.
+- [ ] **NEXT: Win 2 (staleness + manual "Refresh measurements" button)** - two parts:
+  1. *Staleness:* scan data currently never expires - the provider stamps `ScanTime = fetch-time`
+     (not the real scan time), so a days-old scan reads as fresh and never becomes a gap. Propagate the
+     real `spectrum_table_time` into `ChannelScanResult.ScanTime`, then treat an (AP, band) as a gap if
+     missing OR older than a threshold (~7 days). The gap banner then reappears on its own for stale
+     radios. Low effort, no recalibration risk.
+  2. *Manual refresh button* in the same banner area: stagger a quick-scan across all APs (reuse
+     `RunQuickScansAsync`), re-run when done. Harmless, cheap.
 - [ ] **Win 3 (scheduled off-peak sweep)** - background job that sweeps quick-scans across APs/bands
   during low-utilization hours, determined from the 1d/7d historic stress we already compute. Stagger
   ONE band at a time PER AP (parallel across APs - a radio scans one band at a time); never take the

--- a/TODO.md
+++ b/TODO.md
@@ -603,3 +603,29 @@ knows the swap is actually worse for util/interference. The "improvement" came a
 - [ ] When a candidate assignment matches a previously-tried combo, prefer measured outcome over inferred score
 - [ ] Down-weight (or flag) recommendations whose predicted gain rests mostly on propagated stress
 - [ ] Distinguish self-induced load from environmental interference - don't credit a move for escaping the AP's own traffic
+
+## Channel Recommendation: Spectrum-Scan UX (background / on-demand quick-scans)
+
+We now read per-channel measured occupancy from UniFi's `stat/spectrum-scan/{mac}` and can trigger
+scans via `cmd/devmgr` quick-scan (`UniFiApiClient.TriggerQuickScanAsync`). A quick-scan does NOT
+disconnect clients (only a FULL scan does), but it's slow per band per AP, so we never run it inline
+with a recommendation. The recommender reads whatever scan results are cached; a band/AP with no
+recent scan falls back to the neighbor-scan (external) proxy. Lead all UX with "won't disconnect
+clients" - that's why quick-scan is safe to offer freely.
+
+Shared piece to build once: a "trigger -> poll `quick_scan_state.in_progress` until done -> read
+results -> re-run rec" helper. Expose the trigger through `IWiFiDataProvider` (it currently lives
+only on `UniFiApiClient`).
+
+- [ ] **Win 1 (gap-aware prompt)** - on the recommendation page, when a band/AP has no recent
+  measurement (empty `ScanChannelData`; we already log the fallback), offer a one-click "run a quick
+  scan on [these APs/bands]?" that scans exactly the gaps, polls, and re-runs. *(In progress this session.)*
+- [ ] **Win 2 (manual "Refresh measurements" button)** - stagger a quick-scan across all APs for the
+  current band (or all bands), then re-run when done. Same async flow as Win 1, just "all" not "gaps".
+- [ ] **Win 3 (scheduled off-peak sweep)** - background job that sweeps quick-scans across APs/bands
+  during low-utilization hours, determined from the 1d/7d historic stress we already compute. Stagger
+  ONE radio at a time (never take the whole site's airtime off-channel at once) so the spectrum cache
+  stays fresh and recommendations are always well-grounded with zero user action.
+- [ ] **Deep-analysis mode (premium, user-initiated)** - trigger fresh scans on ALL radios, wait,
+  then recommend on fully-measured data. Best accuracy, slow (minutes); distinct from the fast
+  everyday rec.

--- a/TODO.md
+++ b/TODO.md
@@ -663,8 +663,14 @@ only on `UniFiApiClient`).
   current band (or all bands), then re-run when done. Same async flow as Win 1, just "all" not "gaps".
 - [ ] **Win 3 (scheduled off-peak sweep)** - background job that sweeps quick-scans across APs/bands
   during low-utilization hours, determined from the 1d/7d historic stress we already compute. Stagger
-  ONE radio at a time (never take the whole site's airtime off-channel at once) so the spectrum cache
-  stays fresh and recommendations are always well-grounded with zero user action.
+  ONE band at a time PER AP (parallel across APs - a radio scans one band at a time); never take the
+  whole site's airtime off-channel at once. Spectrum cache stays fresh, recommendations always
+  well-grounded, zero user action.
+  - **Scan-hardware-aware scheduling (use `HasDedicatedScanRadio`):** APs with a dedicated all-band
+    scan radio (verified: phy reports Band 1+2+4) scan with ZERO disruption to clients or mesh
+    uplinks - so scan those freely/immediately, anytime. Only serving-radio APs (no scan radio) need
+    the off-peak window. Mesh parents WITHOUT a scan radio are the most disruptive (scanning the uplink
+    band drops children) - schedule those most conservatively or skip their uplink band.
 - [ ] **Deep-analysis mode (premium, user-initiated)** - trigger fresh scans on ALL radios, wait,
   then recommend on fully-measured data. Best accuracy, slow (minutes); distinct from the fast
   everyday rec.

--- a/TODO.md
+++ b/TODO.md
@@ -695,3 +695,14 @@ only on `UniFiApiClient`).
 - [ ] **Deep-analysis mode (premium, user-initiated)** - trigger fresh scans on ALL radios, wait,
   then recommend on fully-measured data. Best accuracy, slow (minutes); distinct from the fast
   everyday rec.
+- [ ] **Large-deployment UX / verbiage (> ~8 APs).** The gap prompt, manual refresh, and rec copy are
+  tuned for small sites. At higher AP counts revisit:
+  - *Scan flow:* running quick scans across many APs is slow even parallel-across-APs, and it currently
+    blocks the Blazor circuit with a spinner. Background it with real progress (per-AP/percent), or
+    batch and let the rec refresh incrementally.
+  - *Verbiage/counts:* "N radios haven't been scanned" and the gap banner read fine for 3-5 radios but
+    get unwieldy at 20+; consider summarizing ("most radios", grouped by AP, collapsible detail).
+  - *Rec table density* and "How This Works" at scale.
+  - *Perf (profile, don't assume):* the per-AP fallback recomputes `ScoreAssignment` per candidate and
+    `ScanReadingForScoring` loops siblings for current-channel reads - both negligible at small n but
+    worth checking on large sites before they bite.

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,40 @@
 # Network Optimizer - TODO / Future Enhancements
 
+## Channel Recommendation: Engine-Review Follow-ups (recalibration-sensitive)
+
+From the full engine review. The clear correctness bugs and the live measured-floor issues are
+already fixed and shipped (floor candidate-only + proximity-weighted + gate-scaled; propagated stress
+split from measured; noise floor wired in; DFS penalty span-aware; fallback baseline). These five
+remain. They all shift the recommendation DISTRIBUTION and the gate thresholds are calibrated to
+current behavior, so each needs a live before/after comparison on the NAS + Mac sites (and ideally a
+fleet sample) to land safely - not a blind edit.
+
+- [ ] **Inconsistent objective (sum-of-ScoreAp vs ScoreAssignment).** The search minimizes
+  `ScoreAssignment` (each internal pair counted once, symmetric). The auxiliary passes (per-AP
+  fallback net-benefit, altruistic "others", crowding friction, comfort "others") sum `ScoreAp`
+  deltas, which count each internal pair ~2x (directional both ways) - so a move the search rejected
+  can be re-approved by an auxiliary pass on an inconsistent yardstick. Fix: express the auxiliary
+  net/others measures as `ScoreAssignment`-deltas (or halve the internal contribution in the per-AP
+  sum), then re-tune MinApAbsoluteImprovement / MinApScoreToMove against the new scale.
+- [ ] **Position-dependence in the post-passes.** Per-AP fallback, altruistic, crowding, and comfort
+  all loop in AP array order and mutate the plan in place, so earlier APs shift later APs' baselines.
+  The main search is most-constrained-first; the post-passes aren't. Fix: order them deterministically
+  by something meaningful (e.g. current score, most-constrained) and add a current-channel tiebreak
+  when candidates are near-tied (the greedy phase already does this).
+- [ ] **Global avg-improvement gate doesn't actually prevent churn.** When avg improvement <
+  threshold the plan reverts to current, but the per-AP fallback and altruistic passes then run on the
+  reverted plan and can still introduce moves. Decide intent: should "network not worth touching" be a
+  hard stop on all per-AP moves too? (Design call - confirm desired behavior before changing.)
+- [ ] **Threshold-cliff churn.** All the gates are hard cliffs evaluated against scores driven by the
+  rogue scan (a few dB of snapshot variance can flip a recommendation on/off between runs). Determinism
+  protects against algorithmic randomness, not input variance. Fix: hysteresis / a dead-band on the
+  move decision, or smoothing the external input over multiple snapshots. (Feature-sized.)
+- [ ] **Width double-discount.** In `BuildExternalLoad` a narrow neighbor inside a wider victim is
+  scaled by the width ratio (0.25x for 20-in-80) AND stored only on its narrow sub-channel - but in
+  OFDM a 20 MHz interferer makes the whole 80 MHz block CCA-busy. The common case is under-weighted.
+  Fix: a narrower-than-victim interferer should count against the full overlapping span without the
+  width-ratio discount. Shifts external magnitudes - re-validate.
+
 ## LAN Speed Test
 
 ### Path Analysis Enhancements

--- a/TODO.md
+++ b/TODO.md
@@ -643,10 +643,14 @@ knows the swap is actually worse for util/interference. The "improvement" came a
 
 We now read per-channel measured occupancy from UniFi's `stat/spectrum-scan/{mac}` and can trigger
 scans via `cmd/devmgr` quick-scan (`UniFiApiClient.TriggerQuickScanAsync`). A quick-scan does NOT
-disconnect clients (only a FULL scan does), but it's slow per band per AP, so we never run it inline
-with a recommendation. The recommender reads whatever scan results are cached; a band/AP with no
-recent scan falls back to the neighbor-scan (external) proxy. Lead all UX with "won't disconnect
-clients" - that's why quick-scan is safe to offer freely.
+disconnect clients (the association stays up - only a FULL scan drops clients), BUT it briefly steps
+each radio off its channel, so real-time traffic (video calls, gaming, an active speed test) can
+hiccup for a moment - verified live (an iperf3 run died mid-scan; Wi-Fi stayed connected). It's also
+slow per band per AP, so we never run it inline with a recommendation. The recommender reads whatever
+scan results are cached; a band/AP with no recent scan falls back to the neighbor-scan (external)
+proxy. UX should be honest: "clients stay connected, but real-time traffic may briefly hiccup -
+best run during low-usage times" (NOT "won't disrupt"). Mesh/wireless-uplink APs can't quick-scan at
+all (controller refuses - it'd drop their uplink), so exclude them from gap prompts.
 
 Shared piece to build once: a "trigger -> poll `quick_scan_state.in_progress` until done -> read
 results -> re-run rec" helper. Expose the trigger through `IWiFiDataProvider` (it currently lives

--- a/TODO.md
+++ b/TODO.md
@@ -672,7 +672,9 @@ only on `UniFiApiClient`).
 - [x] **Win 1 (gap-aware prompt)** - DONE & shipped. Gap banner offers a one-click quick scan of the
   gapped (AP, band)s (mesh APs excluded, per-AP-serial/cross-AP-parallel, scans at live BW), polls,
   re-runs. Warning tailored by `HasDedicatedScanRadio` + mesh role; disclaimer auto-hides when no gaps.
-- [ ] **NEXT: Win 2 (staleness + manual "Refresh measurements" button)** - two parts:
+- [ ] **Win 2 (staleness + manual "Refresh measurements" button)** - can wait for a PATCH after this
+  minor release: there's a natural window between when people pick up the feature and when their scan
+  data goes stale, so no rush. Two parts:
   1. *Staleness:* scan data currently never expires - the provider stamps `ScanTime = fetch-time`
      (not the real scan time), so a days-old scan reads as fresh and never becomes a gap. Propagate the
      real `spectrum_table_time` into `ChannelScanResult.ScanTime`, then treat an (AP, band) as a gap if

--- a/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
@@ -1346,6 +1346,24 @@ public class ScanRadioEntry
     /// </summary>
     [JsonPropertyName("spectrum_table")]
     public List<SpectrumEntry>? SpectrumTable { get; set; }
+
+    /// <summary>Unix time (seconds) the spectrum_table was last populated.</summary>
+    [JsonPropertyName("spectrum_table_time")]
+    public long? SpectrumTableTime { get; set; }
+}
+
+/// <summary>
+/// Response item from GET /api/s/{site}/stat/spectrum-scan/{mac} - per-AP RF spectrum scan
+/// results (per-channel utilization/interference across each band), held from the AP's last scan.
+/// </summary>
+public class UniFiSpectrumScanResponse
+{
+    [JsonPropertyName("mac")]
+    public string Mac { get; set; } = string.Empty;
+
+    /// <summary>One entry per radio (radio = "ng"/"na"/"6e"), each with its own spectrum_table.</summary>
+    [JsonPropertyName("scans")]
+    public List<ScanRadioEntry>? Scans { get; set; }
 }
 
 /// <summary>
@@ -1372,10 +1390,18 @@ public class SpectrumEntry
     public int? Utilization { get; set; }
 
     /// <summary>
-    /// Interference level
+    /// Interference level (dBm noise/interference floor for the channel)
     /// </summary>
     [JsonPropertyName("interference")]
     public int? Interference { get; set; }
+
+    /// <summary>Number of other BSSIDs the scan detected on this channel.</summary>
+    [JsonPropertyName("other_bss_count")]
+    public int? OtherBssCount { get; set; }
+
+    /// <summary>Number of samples the scan collected for this channel (0 = stale/unsampled).</summary>
+    [JsonPropertyName("total_samples")]
+    public int? TotalSamples { get; set; }
 
     /// <summary>
     /// Whether this is a DFS channel

--- a/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
@@ -1364,6 +1364,18 @@ public class UniFiSpectrumScanResponse
     /// <summary>One entry per radio (radio = "ng"/"na"/"6e"), each with its own spectrum_table.</summary>
     [JsonPropertyName("scans")]
     public List<ScanRadioEntry>? Scans { get; set; }
+
+    /// <summary>State of the most recent quick-scan on this AP (whether one is still running).</summary>
+    [JsonPropertyName("quick_scan_state")]
+    public UniFiQuickScanState? QuickScanState { get; set; }
+}
+
+/// <summary>Quick-scan progress state from the spectrum-scan endpoint.</summary>
+public class UniFiQuickScanState
+{
+    /// <summary>True while a quick-scan is still in progress (results not yet final).</summary>
+    [JsonPropertyName("in_progress")]
+    public bool InProgress { get; set; }
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -2413,6 +2413,65 @@ public class UniFiApiClient : IDisposable
         return new List<UniFiRogueApResponse>();
     }
 
+    /// <summary>
+    /// GET /api/s/{site}/stat/spectrum-scan/{mac} - per-AP RF spectrum scan results held from the
+    /// AP's last scan (per-channel utilization % / interference dBm across each band). Returns null
+    /// if the AP has no cached scan or the call fails. Does NOT trigger a scan - see
+    /// <see cref="TriggerQuickScanAsync"/>.
+    /// </summary>
+    public async Task<UniFiSpectrumScanResponse?> GetSpectrumScanAsync(
+        string apMac,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await ExecuteApiCallAsync<UniFiApiResponse<UniFiSpectrumScanResponse>>(
+            () => _httpClient!.GetAsync(BuildApiPath($"stat/spectrum-scan/{apMac}"), cancellationToken),
+            cancellationToken);
+
+        if (response?.Meta.Rc == "ok")
+            return response.Data.FirstOrDefault();
+
+        _logger.LogDebug("No cached spectrum scan for AP {Mac}", apMac);
+        return null;
+    }
+
+    /// <summary>
+    /// POST /api/s/{site}/cmd/devmgr - trigger a quick RF spectrum scan on an AP's band. A quick
+    /// scan does NOT disconnect clients (unlike a full scan), but it still takes time per band, so
+    /// this is intended for background/scheduled refresh - never inline with a recommendation
+    /// request. Read the results later via <see cref="GetSpectrumScanAsync"/>.
+    /// </summary>
+    /// <param name="apMac">AP MAC address.</param>
+    /// <param name="band">UniFi band code: "ng" (2.4 GHz), "na" (5 GHz), "6e" (6 GHz).</param>
+    /// <param name="bandwidthMhz">Scan bandwidth in MHz (e.g. 20).</param>
+    public async Task<bool> TriggerQuickScanAsync(
+        string apMac,
+        string band,
+        int bandwidthMhz = 20,
+        CancellationToken cancellationToken = default)
+    {
+        var body = new Dictionary<string, object>
+        {
+            ["mac"] = apMac,
+            ["scan-band"] = band,
+            ["scan-bw"] = bandwidthMhz,
+            ["cmd"] = "quick-scan"
+        };
+        var content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
+
+        var response = await ExecuteApiCallAsync<UniFiApiResponse<object>>(
+            () => _httpClient!.PostAsync(BuildApiPath("cmd/devmgr"), content, cancellationToken),
+            cancellationToken);
+
+        if (response?.Meta.Rc == "ok")
+        {
+            _logger.LogDebug("Triggered quick scan on AP {Mac} band {Band}", apMac, band);
+            return true;
+        }
+
+        _logger.LogWarning("Failed to trigger quick scan on AP {Mac} band {Band}", apMac, band);
+        return false;
+    }
+
     #endregion
 
     #region Threat Management APIs

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -134,14 +134,17 @@
                             Without a measurement the optimizer infers those channels from neighboring
                             networks instead of seeing them directly. A quick scan reads the real airtime
                             and noise floor on each channel, so the recommendations reflect what's actually
-                            on the air - not a guess. It won't disconnect clients.
+                            on the air - not a guess. Heads up: scanning briefly steps each radio off its
+                            channel - clients stay connected, but real-time traffic (video calls, gaming, an
+                            active speed test) can hiccup for a moment. Much lighter than a full scan, but
+                            best run during low-usage times.
                         </div>
                         <button class="btn btn-primary btn-sm" @onclick="RunGapScans" disabled="@_scanningGaps"
-                                data-tooltip="Runs a quick RF scan to measure these channels - it won't disconnect clients">
+                                data-tooltip="Each radio briefly steps off-channel to measure - clients stay connected, but real-time traffic can hiccup for a moment">
                             @if (_scanningGaps)
                             {
                                 <span class="spinner spinner-sm"></span>
-                                <span>Scanning @_scanGaps.Count @(_scanGaps.Count == 1 ? "radio" : "radios")… won't disconnect clients</span>
+                                <span>Scanning @_scanGaps.Count @(_scanGaps.Count == 1 ? "radio" : "radios")… real-time traffic may briefly hiccup</span>
                             }
                             else
                             {

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -487,11 +487,7 @@
                                 </div>
                                 <div class="ap-col ap-width-col">@(radio.ChannelWidth ?? 20) MHz</div>
                                 <div class="ap-col ap-power-col">
-                                    <EirpBar Radio="radio" Model="@ap.Model" />
-                                    @if (!string.IsNullOrEmpty(radio.TxPowerMode))
-                                    {
-                                        <span class="power-mode">(@radio.TxPowerMode)</span>
-                                    }
+                                    <EirpBar Radio="radio" Model="@ap.Model" ModeLabel="@radio.TxPowerMode" />
                                 </div>
                                 <div class="ap-col ap-util-col">
                                     <div class="util-bar-container">

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -130,9 +130,11 @@
                 {
                     <div class="alert-info scan-gap-banner">
                         <div class="scan-gap-text">
-                            <strong>@_scanGaps.Count</strong> @(_scanGaps.Count == 1 ? "radio has" : "radios have")
-                            no recent RF measurement, so @(_scanGaps.Count == 1 ? "it falls" : "they fall") back to neighbor scans:
-                            <span class="scan-gap-list">@string.Join(", ", _scanGaps.Select(g => $"{g.ApName} · {g.Band.ToDisplayString()}"))</span>
+                            <strong>@_scanGaps.Count @(_scanGaps.Count == 1 ? "radio hasn't" : "radios haven't") been scanned recently.</strong>
+                            Without a measurement the optimizer infers those channels from neighboring
+                            networks instead of seeing them directly. A quick scan reads the real airtime
+                            and noise floor on each channel, so the recommendations reflect what's actually
+                            on the air - not a guess. It won't disconnect clients.
                         </div>
                         <button class="btn btn-primary btn-sm" @onclick="RunGapScans" disabled="@_scanningGaps"
                                 data-tooltip="Runs a quick RF scan to measure these channels - it won't disconnect clients">

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -109,7 +109,9 @@
                     <button class="btn btn-sm btn-ghost" @onclick="() => { _showRecommendations = false; _channelPlans.Clear(); }"><span class="btn-label-full">Show Current Channels</span><span class="btn-label-compact">Show Current</span></button>
                 </div>
 
-                @if (!_channelDisclaimerDismissed)
+                @* Auto-hide once every scannable radio has a measurement (no gaps): the rec is then
+                   grounded in measured airtime/noise, not flying on the unreliable neighbor scan. *@
+                @if (!_channelDisclaimerDismissed && _scanGaps.Count > 0)
                 {
                     <div class="channel-disclaimer">
                         <div class="disclaimer-content">

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -126,6 +126,29 @@
                     </div>
                 }
 
+                @if (_scanGaps.Count > 0)
+                {
+                    <div class="alert-info scan-gap-banner">
+                        <div class="scan-gap-text">
+                            <strong>@_scanGaps.Count</strong> @(_scanGaps.Count == 1 ? "radio has" : "radios have")
+                            no recent RF measurement, so @(_scanGaps.Count == 1 ? "it falls" : "they fall") back to neighbor scans:
+                            <span class="scan-gap-list">@string.Join(", ", _scanGaps.Select(g => $"{g.ApName} · {g.Band.ToDisplayString()}"))</span>
+                        </div>
+                        <button class="btn btn-primary btn-sm" @onclick="RunGapScans" disabled="@_scanningGaps"
+                                data-tooltip="Runs a quick RF scan to measure these channels - it won't disconnect clients">
+                            @if (_scanningGaps)
+                            {
+                                <span class="spinner spinner-sm"></span>
+                                <span>Scanning @_scanGaps.Count @(_scanGaps.Count == 1 ? "radio" : "radios")… won't disconnect clients</span>
+                            }
+                            else
+                            {
+                                <span>Run quick scan</span>
+                            }
+                        </button>
+                    </div>
+                }
+
                 @if (_channelPlan is { } plan)
                 {
                     <!-- Network Score Summary -->
@@ -177,29 +200,6 @@
                                 DFS channels can't be avoided at 160 MHz - all bonding groups include DFS frequencies. Results shown are the same as Include DFS.
                             </div>
                         }
-                    }
-
-                    @if (_scanGaps.Count > 0)
-                    {
-                        <div class="alert-info scan-gap-banner">
-                            <div class="scan-gap-text">
-                                <strong>@_scanGaps.Count</strong> @(_scanGaps.Count == 1 ? "radio has" : "radios have")
-                                no recent RF measurement, so @(_scanGaps.Count == 1 ? "it falls" : "they fall") back to neighbor scans:
-                                <span class="scan-gap-list">@string.Join(", ", _scanGaps.Select(g => $"{g.ApName} · {g.Band.ToDisplayString()}"))</span>
-                            </div>
-                            <button class="btn btn-primary btn-sm" @onclick="RunGapScans" disabled="@_scanningGaps"
-                                    data-tooltip="Runs a quick RF scan to measure these channels - it won't disconnect clients">
-                                @if (_scanningGaps)
-                                {
-                                    <span class="spinner spinner-sm"></span>
-                                    <span>Scanning @_scanGaps.Count @(_scanGaps.Count == 1 ? "radio" : "radios")… won't disconnect clients</span>
-                                }
-                                else
-                                {
-                                    <span>Run quick scan</span>
-                                }
-                            </button>
-                        </div>
                     }
 
                     <!-- Per-AP Recommendation Table -->

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -487,7 +487,11 @@
                                 </div>
                                 <div class="ap-col ap-width-col">@(radio.ChannelWidth ?? 20) MHz</div>
                                 <div class="ap-col ap-power-col">
-                                    <EirpBar Radio="radio" Model="@ap.Model" ModeLabel="@radio.TxPowerMode" />
+                                    <EirpBar Radio="radio" Model="@ap.Model" />
+                                    @if (!string.IsNullOrEmpty(radio.TxPowerMode))
+                                    {
+                                        <span class="power-mode-below">@radio.TxPowerMode</span>
+                                    }
                                 </div>
                                 <div class="ap-col ap-util-col">
                                     <div class="util-bar-container">

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -288,6 +288,14 @@
                             External neighbor networks are not factored in.
                         </div>
                     }
+                    else if (!plan.HasNeighborNetworks && plan.HasMeasuredChannelData)
+                    {
+                        <div class="recommendation-notice">
+                            No neighbor networks detected on this band, but measured channel occupancy and noise floor
+                            from RF scans are factored in - so these recommendations reflect real on-air conditions, not
+                            just internal AP interference.
+                        </div>
+                    }
                     else if (!plan.HasNeighborNetworks)
                     {
                         <div class="recommendation-notice">
@@ -301,12 +309,14 @@
                         <div class="recommendation-explainer-content">
                             <p>
                                 Most channel pickers just count nearby networks. This builds a physical model of your
-                                RF environment and solves for the channel plan that minimizes real interference:
+                                RF environment, measures what's actually on each channel, and solves for the channel
+                                plan that minimizes real interference:
                             </p>
                             <ul>
                                 <li><strong>Signal propagation</strong> - models how far each AP's signal actually reaches using your floor plan, wall materials, and per-radio antenna patterns, not distance alone.</li>
                                 <li><strong>Transmit-power aware</strong> - each AP's real EIRP is applied directionally, so a low-power AP correctly counts as a gentler neighbor than a full-power one.</li>
                                 <li><strong>Real contention, not raw signal</strong> - interference is measured against the CCA threshold (where radios actually defer), so barely-audible signals aren't over-counted.</li>
+                                <li><strong>Measured airtime and noise floor</strong> - reads each channel's actual utilization and RF noise floor from the radios' spectrum scans, so congestion and non-Wi-Fi interference (radar, microwaves, a noisy neighbor's gear) count even when no Wi-Fi network is visible there.</li>
                                 <li><strong>Neighboring networks</strong> - folds in UniFi's RF scan of networks you don't control, triangulated across all your APs for a fuller picture than any single AP sees.</li>
                                 <li><strong>30 days of history</strong> - per-channel utilization, interference, and TX-retry trends, so the plan reflects how channels behave over time, not one noisy snapshot.</li>
                                 <li><strong>Honest about the unknown</strong> - channels with no scan data are penalized for that uncertainty, so it won't push you onto an unseen channel unless your known channels are clearly worse.</li>

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -134,17 +134,14 @@
                             Without a measurement the optimizer infers those channels from neighboring
                             networks instead of seeing them directly. A quick scan reads the real airtime
                             and noise floor on each channel, so the recommendations reflect what's actually
-                            on the air - not a guess. Heads up: scanning briefly steps each radio off its
-                            channel - clients stay connected, but real-time traffic (video calls, gaming, an
-                            active speed test) can hiccup for a moment. Much lighter than a full scan, but
-                            best run during low-usage times.
+                            on the air - not a guess. @ScanDisruptionNote()
                         </div>
                         <button class="btn btn-primary btn-sm" @onclick="RunGapScans" disabled="@_scanningGaps"
-                                data-tooltip="Each radio briefly steps off-channel to measure - clients stay connected, but real-time traffic can hiccup for a moment">
+                                data-tooltip="Runs a quick RF scan to measure these channels">
                             @if (_scanningGaps)
                             {
                                 <span class="spinner spinner-sm"></span>
-                                <span>Scanning @_scanGaps.Count @(_scanGaps.Count == 1 ? "radio" : "radios")… real-time traffic may briefly hiccup</span>
+                                <span>Scanning @_scanGaps.Count @(_scanGaps.Count == 1 ? "radio" : "radios")…</span>
                             }
                             else
                             {
@@ -914,9 +911,30 @@
     }
 
     // (AP, band) pairs whose recommendation falls back to neighbor scans because they have no recent
-    // per-channel spectrum measurement. A non-disruptive quick-scan fills them.
+    // per-channel spectrum measurement. A quick-scan fills them.
     private List<SpectrumScanGap> _scanGaps = new();
     private bool _scanningGaps;
+
+    // Disruption note tailored to the gapped APs' scan hardware: an AP with a dedicated scan radio
+    // measures without touching its serving radios (no client impact); without one, scanning briefly
+    // steps the serving radio off-channel and a mesh parent can drop the devices meshed through it.
+    private string ScanDisruptionNote()
+    {
+        var clean = _scanGaps.Count(g => g.HasDedicatedScanRadio);
+        var disruptive = _scanGaps.Count - clean;
+        var meshNote = _scanGaps.Any(g => g.IsMeshParent && !g.HasDedicatedScanRadio)
+            ? ", and may briefly drop devices meshed through an AP" : "";
+
+        if (disruptive == 0)
+            return "These scan on a dedicated radio, so running won't disrupt clients.";
+        if (clean == 0)
+            return $"Heads up: scanning briefly steps each radio off its channel - clients stay connected, "
+                 + $"but real-time traffic (video calls, gaming) can hiccup for a moment{meshNote}. "
+                 + "Much lighter than a full scan, but best run during low-usage times.";
+        return $"{clean} of these scan on a dedicated radio with no client impact; the other {disruptive} "
+             + $"briefly step their serving radio off-channel, so real-time traffic can hiccup{meshNote} - "
+             + "best run during low-usage times.";
+    }
 
     private async Task LoadScanGapsAsync()
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -179,6 +179,29 @@
                         }
                     }
 
+                    @if (_scanGaps.Count > 0)
+                    {
+                        <div class="alert-info scan-gap-banner">
+                            <div class="scan-gap-text">
+                                <strong>@_scanGaps.Count</strong> @(_scanGaps.Count == 1 ? "radio has" : "radios have")
+                                no recent RF measurement, so @(_scanGaps.Count == 1 ? "it falls" : "they fall") back to neighbor scans:
+                                <span class="scan-gap-list">@string.Join(", ", _scanGaps.Select(g => $"{g.ApName} · {g.Band.ToDisplayString()}"))</span>
+                            </div>
+                            <button class="btn btn-primary btn-sm" @onclick="RunGapScans" disabled="@_scanningGaps"
+                                    data-tooltip="Runs a quick RF scan to measure these channels - it won't disconnect clients">
+                                @if (_scanningGaps)
+                                {
+                                    <span class="spinner spinner-sm"></span>
+                                    <span>Scanning @_scanGaps.Count @(_scanGaps.Count == 1 ? "radio" : "radios")… won't disconnect clients</span>
+                                }
+                                else
+                                {
+                                    <span>Run quick scan</span>
+                                }
+                            </button>
+                        </div>
+                    }
+
                     <!-- Per-AP Recommendation Table -->
                     <div class="aps-band-table rec-table">
                         <div class="rec-header">
@@ -876,10 +899,51 @@
             _channelPlans = await WiFiService.GetAllChannelRecommendationsAsync(options);
             _showRecommendations = _channelPlans.Count > 0;
             AutoSelectBandWithRecommendations();
+            await LoadScanGapsAsync();
         }
         finally
         {
             _loadingRecommendations = false;
+            StateHasChanged();
+        }
+    }
+
+    // (AP, band) pairs whose recommendation falls back to neighbor scans because they have no recent
+    // per-channel spectrum measurement. A non-disruptive quick-scan fills them.
+    private List<SpectrumScanGap> _scanGaps = new();
+    private bool _scanningGaps;
+
+    private async Task LoadScanGapsAsync()
+    {
+        try
+        {
+            _scanGaps = await WiFiService.GetSpectrumScanGapsAsync();
+        }
+        catch
+        {
+            _scanGaps = new();
+        }
+    }
+
+    private async Task RunGapScans()
+    {
+        if (_scanningGaps || _scanGaps.Count == 0) return;
+
+        _scanningGaps = true;
+        StateHasChanged();
+        try
+        {
+            var targets = _scanGaps.Select(g => (g.ApMac, g.BandCode)).ToList();
+            await WiFiService.RunQuickScansAsync(targets);
+
+            // Re-run recommendations on the fresh spectrum data, then re-check what's still missing.
+            var options = new RecommendationOptions { DfsPreference = _dfsPreference };
+            _channelPlans = await WiFiService.GetAllChannelRecommendationsAsync(options);
+            await LoadScanGapsAsync();
+        }
+        finally
+        {
+            _scanningGaps = false;
             StateHasChanged();
         }
     }

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -487,7 +487,7 @@
                                 </div>
                                 <div class="ap-col ap-width-col">@(radio.ChannelWidth ?? 20) MHz</div>
                                 <div class="ap-col ap-power-col">
-                                    <span class="power-value">@(radio.TxPower?.ToString() ?? "-")</span>
+                                    <EirpBar Radio="radio" Model="@ap.Model" />
                                     @if (!string.IsNullOrEmpty(radio.TxPowerMode))
                                     {
                                         <span class="power-mode">(@radio.TxPowerMode)</span>

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/EirpBar.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/EirpBar.razor
@@ -1,0 +1,81 @@
+@using NetworkOptimizer.WiFi
+@using NetworkOptimizer.WiFi.Data
+@using NetworkOptimizer.WiFi.Models
+
+@{
+    var maxEirp = GetMaxEirp(Model, Radio);
+    var txPowerPct = GetPowerPercentage(Radio.TxPower ?? 0, maxEirp);
+    var eirpPct = GetPowerPercentage(Radio.Eirp ?? Radio.TxPower ?? 0, maxEirp);
+    var powerClass = GetPowerClass(Radio);
+    var hasGain = Radio.AntennaGain.HasValue && Radio.AntennaGain > 0;
+}
+<div class="power-bar-container" data-tooltip="TX: @(Radio.TxPower ?? 0) dBm@(hasGain ? $" + {Radio.AntennaGain} dBi gain = {Radio.Eirp} dBm EIRP" : "") (max @maxEirp dBm EIRP)">
+    <div class="power-bar-stack">
+        <div class="power-bar-tx @powerClass" style="width: @txPowerPct%"></div>
+        @if (hasGain)
+        {
+            <div class="power-bar-gain @powerClass" style="width: @(eirpPct - txPowerPct)%"></div>
+        }
+    </div>
+    <span class="power-values">
+        <span class="power-tx">@(Radio.TxPower ?? 0)</span>
+        @if (hasGain)
+        {
+            <span class="power-eirp">→ @Radio.Eirp</span>
+        }
+        <span class="power-unit">dBm</span>
+    </span>
+</div>
+
+@code {
+    /// <summary>The radio whose TX power / EIRP to render.</summary>
+    [Parameter, EditorRequired] public RadioSnapshot Radio { get; set; } = default!;
+
+    /// <summary>AP model, used to resolve the catalog max EIRP for the bar scale.</summary>
+    [Parameter] public string Model { get; set; } = "";
+
+    /// <summary>
+    /// Get the max EIRP for a radio, using catalog data with the same clamping logic as ApMapService.
+    /// Falls back to the radio's own MaxTxPower + AntennaGain if catalog doesn't have the model.
+    /// </summary>
+    private int GetMaxEirp(string model, RadioSnapshot radio)
+    {
+        var bandKey = radio.Band.ToPropagationBand();
+        if (ApModelCatalog.TryGetBandDefaults(model, bandKey, out var catalogDefaults))
+        {
+            var (gain, maxTx, _) = ApModelCatalog.ResolveForMode(catalogDefaults, radio.AntennaMode);
+
+            // Use catalog max if UniFi reports higher (same 2 dBm tolerance as ApMapService)
+            var apiMax = radio.MaxTxPower ?? maxTx;
+            var clampedMax = (apiMax >= maxTx + 2) ? maxTx : apiMax;
+
+            // Use catalog gain if UniFi reports higher
+            var apiGain = radio.AntennaGain ?? gain;
+            var clampedGain = (apiGain >= gain + 2) ? gain : apiGain;
+
+            return clampedMax + clampedGain;
+        }
+
+        // Fallback: use whatever UniFi reports
+        var fallbackMax = radio.MaxTxPower ?? radio.TxPower ?? 20;
+        return fallbackMax + (radio.AntennaGain ?? 0);
+    }
+
+    private double GetPowerPercentage(int power, int maxEirp)
+    {
+        if (maxEirp <= 0) return 0;
+        return Math.Min(100, Math.Max(0, (double)power / maxEirp * 100));
+    }
+
+    private string GetPowerClass(RadioSnapshot radio)
+    {
+        var mode = radio.TxPowerMode?.ToLower() ?? "auto";
+        return mode switch
+        {
+            "high" => "power-high",
+            "medium" => "power-medium",
+            "low" => "power-low",
+            _ => "power-auto"
+        };
+    }
+}

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/EirpBar.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/EirpBar.razor
@@ -17,10 +17,6 @@
             <div class="power-bar-gain @powerClass" style="width: @(eirpPct - txPowerPct)%"></div>
         }
     </div>
-    @if (!string.IsNullOrEmpty(ModeLabel))
-    {
-        <span class="power-mode-center">@ModeLabel</span>
-    }
     <span class="power-values">
         <span class="power-tx">@(Radio.TxPower ?? 0)</span>
         @if (hasGain)
@@ -37,9 +33,6 @@
 
     /// <summary>AP model, used to resolve the catalog max EIRP for the bar scale.</summary>
     [Parameter] public string Model { get; set; } = "";
-
-    /// <summary>Optional power-mode label (e.g. "auto", "high") rendered centered on the bar.</summary>
-    [Parameter] public string? ModeLabel { get; set; }
 
     /// <summary>
     /// Get the max EIRP for a radio, using catalog data with the same clamping logic as ApMapService.

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/EirpBar.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/EirpBar.razor
@@ -17,6 +17,10 @@
             <div class="power-bar-gain @powerClass" style="width: @(eirpPct - txPowerPct)%"></div>
         }
     </div>
+    @if (!string.IsNullOrEmpty(ModeLabel))
+    {
+        <span class="power-mode-center">@ModeLabel</span>
+    }
     <span class="power-values">
         <span class="power-tx">@(Radio.TxPower ?? 0)</span>
         @if (hasGain)
@@ -33,6 +37,9 @@
 
     /// <summary>AP model, used to resolve the catalog max EIRP for the bar scale.</summary>
     [Parameter] public string Model { get; set; } = "";
+
+    /// <summary>Optional power-mode label (e.g. "auto", "high") rendered centered on the bar.</summary>
+    [Parameter] public string? ModeLabel { get; set; }
 
     /// <summary>
     /// Get the max EIRP for a radio, using catalog data with the same clamping logic as ApMapService.

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/PowerCoverageAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/PowerCoverageAnalysis.razor
@@ -112,33 +112,12 @@
                         <div class="radio-power-list">
                             @foreach (var radio in ap.Radios.Where(r => r.Channel.HasValue).OrderBy(r => r.Band))
                             {
-                                var maxEirp = GetMaxEirp(ap.Model, radio);
-                                var txPowerPct = GetPowerPercentage(radio.TxPower ?? 0, maxEirp);
-                                var eirpPct = GetPowerPercentage(radio.Eirp ?? radio.TxPower ?? 0, maxEirp);
-                                var powerClass = GetPowerClass(radio);
-                                var hasGain = radio.AntennaGain.HasValue && radio.AntennaGain > 0;
                                 <div class="radio-power-item">
                                     <div class="radio-info">
                                         <span class="radio-band @GetBandCssClass(radio.Band)">@radio.Band.ToDisplayString()</span>
                                         <span class="radio-channel">Ch @radio.Channel</span>
                                     </div>
-                                    <div class="power-bar-container" data-tooltip="TX: @(radio.TxPower ?? 0) dBm@(hasGain ? $" + {radio.AntennaGain} dBi gain = {radio.Eirp} dBm EIRP" : "") (max @maxEirp dBm EIRP)">
-                                        <div class="power-bar-stack">
-                                            <div class="power-bar-tx @powerClass" style="width: @txPowerPct%"></div>
-                                            @if (hasGain)
-                                            {
-                                                <div class="power-bar-gain @powerClass" style="width: @(eirpPct - txPowerPct)%"></div>
-                                            }
-                                        </div>
-                                        <span class="power-values">
-                                            <span class="power-tx">@(radio.TxPower ?? 0)</span>
-                                            @if (hasGain)
-                                            {
-                                                <span class="power-eirp">→ @radio.Eirp</span>
-                                            }
-                                            <span class="power-unit">dBm</span>
-                                        </span>
-                                    </div>
+                                    <EirpBar Radio="radio" Model="@ap.Model" />
                                     <div class="power-mode">
                                         @(radio.TxPowerMode ?? "auto")
                                     </div>
@@ -482,51 +461,6 @@
                            !i.Title.Contains("Co-Channel"))
                 .ToList();
         }
-    }
-
-    /// <summary>
-    /// Get the max EIRP for a radio, using catalog data with the same clamping logic as ApMapService.
-    /// Falls back to the radio's own MaxTxPower + AntennaGain if catalog doesn't have the model.
-    /// </summary>
-    private int GetMaxEirp(string model, RadioSnapshot radio)
-    {
-        var bandKey = radio.Band.ToPropagationBand();
-        if (ApModelCatalog.TryGetBandDefaults(model, bandKey, out var catalogDefaults))
-        {
-            var (gain, maxTx, _) = ApModelCatalog.ResolveForMode(catalogDefaults, radio.AntennaMode);
-
-            // Use catalog max if UniFi reports higher (same 2 dBm tolerance as ApMapService)
-            var apiMax = radio.MaxTxPower ?? maxTx;
-            var clampedMax = (apiMax >= maxTx + 2) ? maxTx : apiMax;
-
-            // Use catalog gain if UniFi reports higher
-            var apiGain = radio.AntennaGain ?? gain;
-            var clampedGain = (apiGain >= gain + 2) ? gain : apiGain;
-
-            return clampedMax + clampedGain;
-        }
-
-        // Fallback: use whatever UniFi reports
-        var fallbackMax = radio.MaxTxPower ?? radio.TxPower ?? 20;
-        return fallbackMax + (radio.AntennaGain ?? 0);
-    }
-
-    private double GetPowerPercentage(int power, int maxEirp)
-    {
-        if (maxEirp <= 0) return 0;
-        return Math.Min(100, Math.Max(0, (double)power / maxEirp * 100));
-    }
-
-    private string GetPowerClass(RadioSnapshot radio)
-    {
-        var mode = radio.TxPowerMode?.ToLower() ?? "auto";
-        return mode switch
-        {
-            "high" => "power-high",
-            "medium" => "power-medium",
-            "low" => "power-low",
-            _ => "power-auto"
-        };
     }
 
     private string GetBandCssClass(RadioBand band) => band switch

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -621,10 +621,18 @@ public class WiFiOptimizerService
             .ToList();
     }
 
+    private const int QuickScanPollIntervalSeconds = 3;
+    private const int QuickScanPerBandTimeoutSeconds = 45;
+
     /// <summary>
     /// Trigger non-disruptive quick RF scans on the given (AP, band) targets, wait for them to
-    /// finish (polling, with a timeout), then invalidate the scan cache so the next recommendation
-    /// picks up the fresh per-channel measurements. A quick-scan does NOT disconnect clients.
+    /// finish, then invalidate the scan cache so the next recommendation picks up the fresh
+    /// per-channel measurements. A quick-scan does NOT disconnect clients.
+    ///
+    /// A radio can only scan ONE band at a time, so an AP's bands are scanned SEQUENTIALLY (trigger,
+    /// wait for the AP to go idle, then the next band). Different APs scan CONCURRENTLY. Firing all of
+    /// an AP's bands at once makes all but one fail - that's why an unfiltered batch only ever filled
+    /// one gap per AP.
     /// </summary>
     public async Task RunQuickScansAsync(
         IEnumerable<(string ApMac, string BandCode)> targets,
@@ -635,45 +643,65 @@ public class WiFiOptimizerService
             return;
 
         var provider = CreateProvider();
-        var scannedMacs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var (apMac, bandCode) in list)
-        {
-            try
-            {
-                if (await provider.TriggerQuickScanAsync(apMac, bandCode, cancellationToken))
-                    scannedMacs.Add(apMac);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Quick scan trigger failed for {Mac} band {Band}", apMac, bandCode);
-            }
-        }
-
-        // Poll until every triggered AP reports its quick-scan idle, or we hit the timeout.
-        var deadline = DateTimeOffset.UtcNow.AddSeconds(60);
-        while (scannedMacs.Count > 0 && DateTimeOffset.UtcNow < deadline)
-        {
-            await Task.Delay(TimeSpan.FromSeconds(3), cancellationToken);
-
-            var anyRunning = false;
-            foreach (var mac in scannedMacs)
-            {
-                try
-                {
-                    if (await provider.IsQuickScanInProgressAsync(mac, cancellationToken)) { anyRunning = true; break; }
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogDebug(ex, "Quick scan status poll failed for {Mac}", mac);
-                }
-            }
-            if (!anyRunning) break;
-        }
+        var perApScans = list
+            .GroupBy(t => t.ApMac, StringComparer.OrdinalIgnoreCase)
+            .Select(g => ScanApBandsSequentiallyAsync(
+                provider, g.Key, g.Select(t => t.BandCode).Distinct(StringComparer.OrdinalIgnoreCase).ToList(), cancellationToken));
+        await Task.WhenAll(perApScans);
 
         // Fresh scans are in - drop the cached snapshot so the next fetch re-reads the spectrum data.
         _cachedScanResults = null;
         _cachedScanResultsTimeKey = null;
+    }
+
+    /// <summary>
+    /// Scan one AP's bands one at a time, waiting for each to finish before starting the next, since
+    /// the radio can only scan a single band at a time. Different APs run this concurrently.
+    /// </summary>
+    private async Task ScanApBandsSequentiallyAsync(
+        UniFiLiveDataProvider provider, string apMac, List<string> bandCodes, CancellationToken cancellationToken)
+    {
+        foreach (var bandCode in bandCodes)
+        {
+            try
+            {
+                if (!await provider.TriggerQuickScanAsync(apMac, bandCode, cancellationToken))
+                    continue;
+                await WaitForQuickScanIdleAsync(provider, apMac, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Quick scan failed for {Mac} band {Band}", apMac, bandCode);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Poll an AP until its quick-scan reports idle (or the per-band timeout), so the next band on the
+    /// same AP doesn't start while this one is still running.
+    /// </summary>
+    private async Task WaitForQuickScanIdleAsync(
+        UniFiLiveDataProvider provider, string apMac, CancellationToken cancellationToken)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(QuickScanPerBandTimeoutSeconds);
+        // Give the controller a moment to mark the scan in-progress before the first check.
+        await Task.Delay(TimeSpan.FromSeconds(QuickScanPollIntervalSeconds), cancellationToken);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            bool inProgress;
+            try
+            {
+                inProgress = await provider.IsQuickScanInProgressAsync(apMac, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Quick scan status poll failed for {Mac}", apMac);
+                break;
+            }
+            if (!inProgress) break;
+            await Task.Delay(TimeSpan.FromSeconds(QuickScanPollIntervalSeconds), cancellationToken);
+        }
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -663,10 +663,19 @@ public class WiFiOptimizerService
 
         var provider = CreateProvider();
 
+        // Scan each band at the radio's CURRENT operating width so the radio doesn't reconfigure
+        // (less disruption) and the result buckets line up with the operating channel.
+        var widthByApBand = new Dictionary<(string Mac, string BandCode), int>();
+        foreach (var ap in await provider.GetAccessPointsAsync())
+            foreach (var radio in ap.Radios)
+                if (radio.ChannelWidth is int w)
+                    widthByApBand[(ap.Mac, radio.Band.ToUniFiCode())] = w;
+
         var perApScans = list
             .GroupBy(t => t.ApMac, StringComparer.OrdinalIgnoreCase)
             .Select(g => ScanApBandsSequentiallyAsync(
-                provider, g.Key, g.Select(t => t.BandCode).Distinct(StringComparer.OrdinalIgnoreCase).ToList(), cancellationToken));
+                provider, g.Key, g.Select(t => t.BandCode).Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+                widthByApBand, cancellationToken));
         await Task.WhenAll(perApScans);
 
         // Fresh scans are in - drop the cached snapshot so the next fetch re-reads the spectrum data.
@@ -679,13 +688,16 @@ public class WiFiOptimizerService
     /// the radio can only scan a single band at a time. Different APs run this concurrently.
     /// </summary>
     private async Task ScanApBandsSequentiallyAsync(
-        UniFiLiveDataProvider provider, string apMac, List<string> bandCodes, CancellationToken cancellationToken)
+        UniFiLiveDataProvider provider, string apMac, List<string> bandCodes,
+        IReadOnlyDictionary<(string Mac, string BandCode), int> widthByApBand, CancellationToken cancellationToken)
     {
         foreach (var bandCode in bandCodes)
         {
+            // Scan at the radio's current width (fall back to 20 MHz if unknown).
+            var bandwidthMhz = widthByApBand.TryGetValue((apMac, bandCode), out var w) ? w : 20;
             try
             {
-                if (!await provider.TriggerQuickScanAsync(apMac, bandCode, cancellationToken))
+                if (!await provider.TriggerQuickScanAsync(apMac, bandCode, bandwidthMhz, cancellationToken))
                     continue;
                 // Wait for THIS band to finish before starting the next on the same AP. If it doesn't
                 // finish in time, skip the AP's remaining bands rather than fire into a still-busy

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -615,14 +615,22 @@ public class WiFiOptimizerService
         var scans = await GetChannelScanResultsAsync(
             startTime: DateTimeOffset.UtcNow.AddHours(-ChannelRecommendationService.ScanLookbackHours));
 
+        // Mesh (wireless-uplink) APs can't quick-scan without dropping their uplink, so the controller
+        // refuses - don't list gaps the user can never fill.
+        var provider = CreateProvider();
+        var meshChildMacs = (await provider.GetAccessPointsAsync())
+            .Where(a => a.IsMeshChild)
+            .Select(a => a.Mac)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
         return scans
-            .Where(s => s.Channels.Count == 0)
+            .Where(s => s.Channels.Count == 0 && !meshChildMacs.Contains(s.ApMac))
             .Select(s => new SpectrumScanGap(s.ApMac, s.ApName ?? s.ApMac, s.Band, s.Band.ToUniFiCode()))
             .ToList();
     }
 
     private const int QuickScanPollIntervalSeconds = 3;
-    private const int QuickScanPerBandTimeoutSeconds = 45;
+    private const int QuickScanPerBandTimeoutSeconds = 150;
 
     /// <summary>
     /// Trigger non-disruptive quick RF scans on the given (AP, band) targets, wait for them to
@@ -668,7 +676,16 @@ public class WiFiOptimizerService
             {
                 if (!await provider.TriggerQuickScanAsync(apMac, bandCode, cancellationToken))
                     continue;
-                await WaitForQuickScanIdleAsync(provider, apMac, cancellationToken);
+                // Wait for THIS band to finish before starting the next on the same AP. If it doesn't
+                // finish in time, skip the AP's remaining bands rather than fire into a still-busy
+                // radio (which the controller rejects with api.err.QuickScanInProgress).
+                if (!await WaitForQuickScanIdleAsync(provider, apMac, cancellationToken))
+                {
+                    _logger.LogDebug(
+                        "Quick scan on {Mac} still running after {Timeout}s; skipping its remaining bands",
+                        apMac, QuickScanPerBandTimeoutSeconds);
+                    break;
+                }
             }
             catch (Exception ex)
             {
@@ -678,10 +695,11 @@ public class WiFiOptimizerService
     }
 
     /// <summary>
-    /// Poll an AP until its quick-scan reports idle (or the per-band timeout), so the next band on the
-    /// same AP doesn't start while this one is still running.
+    /// Poll an AP until its quick-scan reports idle, so the next band on the same AP doesn't start
+    /// while this one is still running. Returns true when the AP went idle, false if it was still
+    /// in-progress at the timeout (caller should not start another band on it).
     /// </summary>
-    private async Task WaitForQuickScanIdleAsync(
+    private async Task<bool> WaitForQuickScanIdleAsync(
         UniFiLiveDataProvider provider, string apMac, CancellationToken cancellationToken)
     {
         var deadline = DateTimeOffset.UtcNow.AddSeconds(QuickScanPerBandTimeoutSeconds);
@@ -689,19 +707,19 @@ public class WiFiOptimizerService
         await Task.Delay(TimeSpan.FromSeconds(QuickScanPollIntervalSeconds), cancellationToken);
         while (DateTimeOffset.UtcNow < deadline)
         {
-            bool inProgress;
             try
             {
-                inProgress = await provider.IsQuickScanInProgressAsync(apMac, cancellationToken);
+                if (!await provider.IsQuickScanInProgressAsync(apMac, cancellationToken))
+                    return true;
             }
             catch (Exception ex)
             {
                 _logger.LogDebug(ex, "Quick scan status poll failed for {Mac}", apMac);
-                break;
+                return true; // can't tell - assume done rather than block the AP's other bands
             }
-            if (!inProgress) break;
             await Task.Delay(TimeSpan.FromSeconds(QuickScanPollIntervalSeconds), cancellationToken);
         }
+        return false;
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -615,17 +615,28 @@ public class WiFiOptimizerService
         var scans = await GetChannelScanResultsAsync(
             startTime: DateTimeOffset.UtcNow.AddHours(-ChannelRecommendationService.ScanLookbackHours));
 
+        var provider = CreateProvider();
+        var aps = await provider.GetAccessPointsAsync();
+        var apByMac = aps.ToDictionary(a => a.Mac, StringComparer.OrdinalIgnoreCase);
+
         // Mesh (wireless-uplink) APs can't quick-scan without dropping their uplink, so the controller
         // refuses - don't list gaps the user can never fill.
-        var provider = CreateProvider();
-        var meshChildMacs = (await provider.GetAccessPointsAsync())
-            .Where(a => a.IsMeshChild)
+        var meshChildMacs = aps.Where(a => a.IsMeshChild)
             .Select(a => a.Mac)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         return scans
             .Where(s => s.Channels.Count == 0 && !meshChildMacs.Contains(s.ApMac))
-            .Select(s => new SpectrumScanGap(s.ApMac, s.ApName ?? s.ApMac, s.Band, s.Band.ToUniFiCode()))
+            .Select(s =>
+            {
+                apByMac.TryGetValue(s.ApMac, out var ap);
+                var hasScanRadio = ap?.HasDedicatedScanRadio ?? false;
+                // A mesh parent only matters for the warning when it lacks a dedicated scan radio
+                // (then scanning its uplink band drops children; with a scan radio the uplink is safe).
+                var isMeshParent = (ap?.MeshChildren.Count ?? 0) > 0;
+                return new SpectrumScanGap(
+                    s.ApMac, s.ApName ?? s.ApMac, s.Band, s.Band.ToUniFiCode(), hasScanRadio, isMeshParent);
+            })
             .ToList();
     }
 

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -605,6 +605,78 @@ public class WiFiOptimizerService
     }
 
     /// <summary>
+    /// (AP, band) pairs that have no recent per-channel spectrum-scan measurement, so their channel
+    /// recommendation falls back to the neighbor (external) scan. A non-disruptive quick-scan fills
+    /// them (see <see cref="RunQuickScansAsync"/>). Derived from the same scan snapshot the
+    /// recommendation uses, so it reflects exactly what the engine is working with.
+    /// </summary>
+    public async Task<List<SpectrumScanGap>> GetSpectrumScanGapsAsync()
+    {
+        var scans = await GetChannelScanResultsAsync(
+            startTime: DateTimeOffset.UtcNow.AddHours(-ChannelRecommendationService.ScanLookbackHours));
+
+        return scans
+            .Where(s => s.Channels.Count == 0)
+            .Select(s => new SpectrumScanGap(s.ApMac, s.ApName ?? s.ApMac, s.Band, s.Band.ToUniFiCode()))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Trigger non-disruptive quick RF scans on the given (AP, band) targets, wait for them to
+    /// finish (polling, with a timeout), then invalidate the scan cache so the next recommendation
+    /// picks up the fresh per-channel measurements. A quick-scan does NOT disconnect clients.
+    /// </summary>
+    public async Task RunQuickScansAsync(
+        IEnumerable<(string ApMac, string BandCode)> targets,
+        CancellationToken cancellationToken = default)
+    {
+        var list = targets.ToList();
+        if (list.Count == 0 || !_connectionService.IsConnected || _connectionService.Client == null)
+            return;
+
+        var provider = CreateProvider();
+        var scannedMacs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (apMac, bandCode) in list)
+        {
+            try
+            {
+                if (await provider.TriggerQuickScanAsync(apMac, bandCode, cancellationToken))
+                    scannedMacs.Add(apMac);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Quick scan trigger failed for {Mac} band {Band}", apMac, bandCode);
+            }
+        }
+
+        // Poll until every triggered AP reports its quick-scan idle, or we hit the timeout.
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(60);
+        while (scannedMacs.Count > 0 && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(3), cancellationToken);
+
+            var anyRunning = false;
+            foreach (var mac in scannedMacs)
+            {
+                try
+                {
+                    if (await provider.IsQuickScanInProgressAsync(mac, cancellationToken)) { anyRunning = true; break; }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Quick scan status poll failed for {Mac}", mac);
+                }
+            }
+            if (!anyRunning) break;
+        }
+
+        // Fresh scans are in - drop the cached snapshot so the next fetch re-reads the spectrum data.
+        _cachedScanResults = null;
+        _cachedScanResultsTimeKey = null;
+    }
+
+    /// <summary>
     /// Record each fresh scan's neighbor sightings into the rolling per-(AP, band) history (and
     /// prune anything past the window). Called once per fresh scan fetch; does not modify the
     /// scans, so callers still get the raw live scan back.

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -10870,7 +10870,7 @@ a.path-hop.hop-clickable:hover {
 
 .aps-header {
     display: grid;
-    grid-template-columns: 2fr 0.8fr 0.8fr 1.6fr 1.2fr 0.8fr 0.6fr;
+    grid-template-columns: 2fr 0.8fr 0.8fr 200px 1.2fr 0.8fr 0.6fr;
     gap: 0.5rem;
     padding: 0.75rem 1rem;
     background: var(--bg-tertiary);
@@ -10882,7 +10882,7 @@ a.path-hop.hop-clickable:hover {
 
 .aps-row {
     display: grid;
-    grid-template-columns: 2fr 0.8fr 0.8fr 1.6fr 1.2fr 0.8fr 0.6fr;
+    grid-template-columns: 2fr 0.8fr 0.8fr 200px 1.2fr 0.8fr 0.6fr;
     gap: 0.5rem;
     padding: 0.75rem 1rem;
     border-top: 1px solid var(--border-color);
@@ -10896,6 +10896,11 @@ a.path-hop.hop-clickable:hover {
 
 .aps-row.clickable {
     cursor: pointer;
+}
+
+.aps-row .ap-power-col .power-bar-container {
+    max-width: 200px;
+    background: var(--bg-primary);
 }
 
 .ap-name-col {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -10870,7 +10870,7 @@ a.path-hop.hop-clickable:hover {
 
 .aps-header {
     display: grid;
-    grid-template-columns: 2fr 0.8fr 0.8fr 1fr 1.2fr 0.8fr 0.6fr;
+    grid-template-columns: 2fr 0.8fr 0.8fr 1.6fr 1.2fr 0.8fr 0.6fr;
     gap: 0.5rem;
     padding: 0.75rem 1rem;
     background: var(--bg-tertiary);
@@ -10882,7 +10882,7 @@ a.path-hop.hop-clickable:hover {
 
 .aps-row {
     display: grid;
-    grid-template-columns: 2fr 0.8fr 0.8fr 1fr 1.2fr 0.8fr 0.6fr;
+    grid-template-columns: 2fr 0.8fr 0.8fr 1.6fr 1.2fr 0.8fr 0.6fr;
     gap: 0.5rem;
     padding: 0.75rem 1rem;
     border-top: 1px solid var(--border-color);

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -3710,6 +3710,31 @@ select.form-control {
     gap: 1rem;
 }
 
+.scan-gap-banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+    padding: 0.75rem 1rem;
+    border-radius: var(--border-radius);
+    margin-bottom: 1rem;
+    font-size: 0.85rem;
+}
+
+.scan-gap-banner .scan-gap-text {
+    flex: 1;
+    min-width: 12rem;
+}
+
+.scan-gap-banner .scan-gap-list {
+    color: var(--text-muted);
+}
+
+.scan-gap-banner .btn {
+    flex-shrink: 0;
+}
+
 .banner-icon {
     font-size: 1.5rem;
     background: rgba(255, 255, 255, 0.2);

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -10899,8 +10899,20 @@ a.path-hop.hop-clickable:hover {
 }
 
 .aps-row .ap-power-col .power-bar-container {
-    max-width: 180px;
+    max-width: 170px;
     background: var(--bg-tertiary);
+}
+
+.power-mode-center {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    text-transform: capitalize;
+    z-index: 1;
+    pointer-events: none;
 }
 
 .ap-name-col {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -10899,8 +10899,8 @@ a.path-hop.hop-clickable:hover {
 }
 
 .aps-row .ap-power-col .power-bar-container {
-    max-width: 200px;
-    background: var(--bg-primary);
+    max-width: 180px;
+    background: var(--bg-tertiary);
 }
 
 .ap-name-col {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -3727,10 +3727,6 @@ select.form-control {
     min-width: 12rem;
 }
 
-.scan-gap-banner .scan-gap-list {
-    color: var(--text-muted);
-}
-
 .scan-gap-banner .btn {
     flex-shrink: 0;
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -10903,16 +10903,14 @@ a.path-hop.hop-clickable:hover {
     background: var(--bg-tertiary);
 }
 
-.power-mode-center {
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
+.aps-row .ap-power-col .power-mode-below {
+    display: block;
+    max-width: 170px;
+    text-align: center;
+    margin-top: 3px;
     font-size: 0.7rem;
     color: var(--text-muted);
     text-transform: capitalize;
-    z-index: 1;
-    pointer-events: none;
 }
 
 .ap-name-col {

--- a/src/NetworkOptimizer.WiFi/IWiFiDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/IWiFiDataProvider.cs
@@ -77,6 +77,20 @@ public interface IWiFiDataProvider
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Trigger a non-disruptive quick RF spectrum scan on an AP's band. A quick scan does NOT
+    /// disconnect clients (unlike a full scan), but takes time per band - intended for on-demand or
+    /// background refresh, never inline with a recommendation. Read results later via the scan APIs.
+    /// </summary>
+    /// <param name="apMac">AP MAC address.</param>
+    /// <param name="bandCode">UniFi band code: "ng" (2.4), "na" (5), "6e" (6).</param>
+    Task<bool> TriggerQuickScanAsync(string apMac, string bandCode, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Whether a quick-scan is still running on the given AP (results not yet final).
+    /// </summary>
+    Task<bool> IsQuickScanInProgressAsync(string apMac, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Whether this provider supports historical/time-series queries
     /// </summary>
     bool SupportsHistoricalData { get; }

--- a/src/NetworkOptimizer.WiFi/IWiFiDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/IWiFiDataProvider.cs
@@ -77,13 +77,16 @@ public interface IWiFiDataProvider
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Trigger a non-disruptive quick RF spectrum scan on an AP's band. A quick scan does NOT
-    /// disconnect clients (unlike a full scan), but takes time per band - intended for on-demand or
-    /// background refresh, never inline with a recommendation. Read results later via the scan APIs.
+    /// Trigger a quick RF spectrum scan on an AP's band. A quick scan does NOT disconnect clients
+    /// (unlike a full scan), but takes time per band - intended for on-demand or background refresh,
+    /// never inline with a recommendation. Read results later via the scan APIs.
     /// </summary>
     /// <param name="apMac">AP MAC address.</param>
     /// <param name="bandCode">UniFi band code: "ng" (2.4), "na" (5), "6e" (6).</param>
-    Task<bool> TriggerQuickScanAsync(string apMac, string bandCode, CancellationToken cancellationToken = default);
+    /// <param name="bandwidthMhz">Scan bandwidth - should match the radio's CURRENT operating width
+    /// so the radio doesn't reconfigure (less disruption) and the result buckets line up with the
+    /// operating channel.</param>
+    Task<bool> TriggerQuickScanAsync(string apMac, string bandCode, int bandwidthMhz, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Whether a quick-scan is still running on the given AP (results not yet final).

--- a/src/NetworkOptimizer.WiFi/Models/AccessPointSnapshot.cs
+++ b/src/NetworkOptimizer.WiFi/Models/AccessPointSnapshot.cs
@@ -53,6 +53,14 @@ public class AccessPointSnapshot
     /// <summary>Whether this AP is a mesh child (has wireless uplink to another AP)</summary>
     public bool IsMeshChild { get; set; }
 
+    /// <summary>
+    /// Whether this AP has a dedicated scan radio (an all-band radio that measures the RF
+    /// environment without taking a serving radio off-channel). When true, a quick scan is
+    /// non-disruptive to clients and mesh uplinks; when false, scanning borrows the serving radio
+    /// and briefly interrupts that band. Sourced from the device's scan_radio_table.
+    /// </summary>
+    public bool HasDedicatedScanRadio { get; set; }
+
     /// <summary>MAC address of the mesh parent AP (if this is a mesh child)</summary>
     public string? MeshParentMac { get; set; }
 

--- a/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
@@ -1,6 +1,12 @@
 namespace NetworkOptimizer.WiFi.Models;
 
 /// <summary>
+/// An (AP, band) that has no recent per-channel spectrum-scan measurement, so its channel
+/// recommendation falls back to the neighbor (external) scan. A non-disruptive quick-scan can fill it.
+/// </summary>
+public record SpectrumScanGap(string ApMac, string ApName, RadioBand Band, string BandCode);
+
+/// <summary>
 /// Per-AP channel recommendation: current vs recommended (channel, width) tuple.
 /// </summary>
 public class ApChannelRecommendation

--- a/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
@@ -2,9 +2,13 @@ namespace NetworkOptimizer.WiFi.Models;
 
 /// <summary>
 /// An (AP, band) that has no recent per-channel spectrum-scan measurement, so its channel
-/// recommendation falls back to the neighbor (external) scan. A non-disruptive quick-scan can fill it.
+/// recommendation falls back to the neighbor (external) scan. A quick-scan can fill it.
+/// <paramref name="HasDedicatedScanRadio"/> = the AP scans on a dedicated radio (no client impact);
+/// otherwise scanning briefly interrupts that band. <paramref name="IsMeshParent"/> = scanning this
+/// AP (when it lacks a dedicated scan radio) can also briefly drop devices meshed through it.
 /// </summary>
-public record SpectrumScanGap(string ApMac, string ApName, RadioBand Band, string BandCode);
+public record SpectrumScanGap(
+    string ApMac, string ApName, RadioBand Band, string BandCode, bool HasDedicatedScanRadio, bool IsMeshParent);
 
 /// <summary>
 /// Per-AP channel recommendation: current vs recommended (channel, width) tuple.

--- a/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
@@ -124,10 +124,13 @@ public class InterferenceGraph
     public HashSet<int>[] DirectlyObservedChannels { get; set; } = [];
 
     /// <summary>
-    /// Per-AP channel scan metrics. ScanChannelData[apIndex][channel] = (utilization %, noise floor
-    /// dBm). NoiseFloor is null when the scan reported no reading; lower (more negative) is cleaner.
+    /// Per-AP channel scan metrics, keyed by (control channel, scan bandwidth MHz) so multiple-width
+    /// buckets for the same channel can coexist (e.g. a BW20 and a BW160 reading of ch36). Value =
+    /// (utilization %, noise floor dBm); NoiseFloor is null when the scan reported no reading, lower
+    /// (more negative) is cleaner. The scorer reads it via ScanOverSpan, which prefers an exact
+    /// operating-width bucket and otherwise aggregates the finest sub-channels across the span.
     /// </summary>
-    public Dictionary<int, (int Utilization, int? NoiseFloor)>[] ScanChannelData { get; set; } = [];
+    public Dictionary<(int Channel, int Width), (int Utilization, int? NoiseFloor)>[] ScanChannelData { get; set; } = [];
 
     public List<MeshConstraint> MeshConstraints { get; set; } = new();
 

--- a/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
@@ -119,8 +119,11 @@ public class InterferenceGraph
     /// </summary>
     public HashSet<int>[] DirectlyObservedChannels { get; set; } = [];
 
-    /// <summary>Per-AP channel scan metrics (utilization/interference). ScanChannelData[apIndex][channel] = (util, interf)</summary>
-    public Dictionary<int, (int Utilization, int Interference)>[] ScanChannelData { get; set; } = [];
+    /// <summary>
+    /// Per-AP channel scan metrics. ScanChannelData[apIndex][channel] = (utilization %, noise floor
+    /// dBm). NoiseFloor is null when the scan reported no reading; lower (more negative) is cleaner.
+    /// </summary>
+    public Dictionary<int, (int Utilization, int? NoiseFloor)>[] ScanChannelData { get; set; } = [];
 
     public List<MeshConstraint> MeshConstraints { get; set; } = new();
 
@@ -167,11 +170,21 @@ public class ApNode
     public double TxRetriesPct { get; set; }
 
     /// <summary>
-    /// Per-channel historical stress from 30-day metrics paired with channel change events.
+    /// Per-channel historical stress from 30-day metrics paired with channel change events. This is
+    /// the AP's OWN measured reality - "ground truth" for the channels it has actually sat on.
     /// Key = channel number, Value = (avg utilization %, avg interference %, avg TX retry %).
     /// Null if historical data is unavailable.
     /// </summary>
     public Dictionary<int, (double Utilization, double Interference, double TxRetryPct)>? HistoricalStress { get; set; }
+
+    /// <summary>
+    /// Per-channel stress ESTIMATED from nearby APs' measurements (proximity-scaled, dampened) for
+    /// channels this AP has never sat on. Kept separate from <see cref="HistoricalStress"/> so the
+    /// scorer can use it as a soft estimate for the stress penalty WITHOUT it masquerading as this
+    /// AP's own measurement - the "ground-truth" consumers (comfort anchor, measured floor's sibling
+    /// lookup, observation confidence) read only the real <see cref="HistoricalStress"/>.
+    /// </summary>
+    public Dictionary<int, (double Utilization, double Interference, double TxRetryPct)>? PropagatedStress { get; set; }
 
     /// <summary>Index of this AP's mesh group leader, or -1 if not in a mesh group</summary>
     public int MeshGroupLeader { get; set; } = -1;

--- a/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
@@ -92,17 +92,19 @@ public class InterferenceGraph
     /// </summary>
     public double[,] DirectionalWeights { get; set; } = new double[0, 0];
 
-    /// <summary>Per-AP external load by channel number. ExternalLoad[apIndex][channel] = weight</summary>
+    /// <summary>Per-AP external load by channel number. ExternalLoad[apIndex][channel] = total weight</summary>
     public Dictionary<int, double>[] ExternalLoad { get; set; } = [];
 
     /// <summary>
-    /// Per-AP channel width (MHz) of the neighbors pooled at each external-load channel.
-    /// ExternalLoadWidths[apIndex][channel] = width. Lets the scorer model a wide neighbor's full
-    /// spectral footprint: a 40 MHz neighbor on 2.4 GHz ch11 also steps on ch6, so its load must
-    /// count against any candidate channel its span overlaps, not just its control channel. A
-    /// channel absent from this map is treated as 20 MHz (a point at its control channel).
+    /// Per-AP external load pooled by (control channel, width). ExternalNeighbors[apIndex][(channel,
+    /// width)] = weight. Keeping weight separated by width lets the scorer model each neighbor's true
+    /// spectral footprint: a 40 MHz neighbor on 2.4 GHz ch11 steps on ch6, so its weight counts
+    /// against any candidate channel its span overlaps - WITHOUT dragging the 20 MHz neighbors that
+    /// share its control channel along with it (pooling everything to one width over-spilled them).
+    /// When empty (e.g. a unit test that sets only <see cref="ExternalLoad"/>), the scorer falls back
+    /// to treating each external-load channel as a 20 MHz point.
     /// </summary>
-    public Dictionary<int, int>[] ExternalLoadWidths { get; set; } = [];
+    public Dictionary<(int Channel, int Width), double>[] ExternalNeighbors { get; set; } = [];
 
     /// <summary>
     /// Per-AP set of channels with at least one direct neighbor observation.

--- a/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
@@ -96,6 +96,15 @@ public class InterferenceGraph
     public Dictionary<int, double>[] ExternalLoad { get; set; } = [];
 
     /// <summary>
+    /// Per-AP channel width (MHz) of the neighbors pooled at each external-load channel.
+    /// ExternalLoadWidths[apIndex][channel] = width. Lets the scorer model a wide neighbor's full
+    /// spectral footprint: a 40 MHz neighbor on 2.4 GHz ch11 also steps on ch6, so its load must
+    /// count against any candidate channel its span overlaps, not just its control channel. A
+    /// channel absent from this map is treated as 20 MHz (a point at its control channel).
+    /// </summary>
+    public Dictionary<int, int>[] ExternalLoadWidths { get; set; } = [];
+
+    /// <summary>
     /// Per-AP set of channels with at least one direct neighbor observation.
     /// Channels NOT in this set have only triangulated (estimated) external load data,
     /// which is less reliable. Used by the scorer to penalize unobserved channels.

--- a/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
@@ -67,6 +67,13 @@ public class ChannelPlan
     public int UnplacedApCount { get; set; }
     public bool HasScanData { get; set; }
     public bool HasNeighborNetworks { get; set; }
+
+    /// <summary>
+    /// True when we have per-channel spectrum measurements (utilization / noise floor) for this band,
+    /// so the recommendation is grounded in measured airtime and RF noise - not just neighbor scans or
+    /// internal AP interference - even when no neighbor networks were detected.
+    /// </summary>
+    public bool HasMeasuredChannelData { get; set; }
     public bool HasBuildingData { get; set; }
 
     /// <summary>

--- a/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
@@ -26,6 +26,17 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
     public string ProviderName => "UniFi Live";
     public bool SupportsHistoricalData => true; // Via stat/report endpoints
 
+    /// <inheritdoc />
+    public Task<bool> TriggerQuickScanAsync(string apMac, string bandCode, CancellationToken cancellationToken = default)
+        => _client.TriggerQuickScanAsync(apMac, bandCode, cancellationToken: cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<bool> IsQuickScanInProgressAsync(string apMac, CancellationToken cancellationToken = default)
+    {
+        var scan = await _client.GetSpectrumScanAsync(apMac, cancellationToken);
+        return scan?.QuickScanState?.InProgress == true;
+    }
+
     public async Task<List<AccessPointSnapshot>> GetAccessPointsAsync(CancellationToken cancellationToken = default, bool useCache = true)
     {
         // Use UniFiDiscovery for centralized device classification (same as Audit and Speed Test)

--- a/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
@@ -755,6 +755,19 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
                 ?? ap.RadioTable?.Select(r => r.Radio).Distinct().ToList()
                 ?? new List<string>();
 
+            // Per-AP cached RF spectrum scan (per-channel utilization/interference across each band).
+            // This is the populated source - ap.ScanRadioTable in /stat/device is typically empty.
+            // A GET only; we never trigger a scan inline (see UniFiApiClient.TriggerQuickScanAsync).
+            UniFiSpectrumScanResponse? spectrumScan = null;
+            try
+            {
+                spectrumScan = await _client.GetSpectrumScanAsync(ap.Mac, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Spectrum scan fetch failed for AP {Mac}", ap.Mac);
+            }
+
             foreach (var bandCode in radioBands)
             {
                 var band = RadioBandExtensions.FromUniFiCode(bandCode);
@@ -768,8 +781,10 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
                     Neighbors = new List<NeighborNetwork>()
                 };
 
-                // Add spectrum data if available from scan_radio_table
-                var scanRadio = ap.ScanRadioTable?.FirstOrDefault(sr => sr.Radio == bandCode);
+                // Per-channel measured occupancy from the AP's last RF scan. Prefer the dedicated
+                // spectrum-scan endpoint (the populated source); fall back to scan_radio_table.
+                var scanRadio = spectrumScan?.Scans?.FirstOrDefault(sr => sr.Radio == bandCode)
+                    ?? ap.ScanRadioTable?.FirstOrDefault(sr => sr.Radio == bandCode);
                 if (scanRadio?.SpectrumTable != null)
                 {
                     foreach (var spectrum in scanRadio.SpectrumTable)
@@ -779,7 +794,12 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
                             Channel = spectrum.Channel,
                             Width = spectrum.Width,
                             Utilization = spectrum.Utilization,
-                            Interference = spectrum.Interference,
+                            // The scan's "interference" is a dBm floor, not a percentage. Keep it out
+                            // of the percentage-based Interference field (the scorer treats that as
+                            // 0-100) and store it as the noise floor; NeighborCount carries the
+                            // detected BSSID count. The measured %-occupancy lives in Utilization.
+                            NoiseFloor = spectrum.Interference,
+                            NeighborCount = spectrum.OtherBssCount ?? 0,
                             IsDfs = spectrum.IsDfs ?? false,
                             DfsState = spectrum.DfsState
                         });

--- a/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
@@ -967,6 +967,7 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
             Timestamp = timestamp,
             Radios = new List<RadioSnapshot>(),
             Vaps = new List<VapSnapshot>(),
+            HasDedicatedScanRadio = ap.HasDedicatedScanRadio,
             IsMeshChild = isMeshChild,
             MeshParentMac = meshParentMac,
             MeshUplinkBand = meshUplinkBand,

--- a/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
@@ -27,8 +27,8 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
     public bool SupportsHistoricalData => true; // Via stat/report endpoints
 
     /// <inheritdoc />
-    public Task<bool> TriggerQuickScanAsync(string apMac, string bandCode, CancellationToken cancellationToken = default)
-        => _client.TriggerQuickScanAsync(apMac, bandCode, cancellationToken: cancellationToken);
+    public Task<bool> TriggerQuickScanAsync(string apMac, string bandCode, int bandwidthMhz, CancellationToken cancellationToken = default)
+        => _client.TriggerQuickScanAsync(apMac, bandCode, bandwidthMhz, cancellationToken);
 
     /// <inheritdoc />
     public async Task<bool> IsQuickScanInProgressAsync(string apMac, CancellationToken cancellationToken = default)

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -145,6 +145,14 @@ public class ChannelRecommendationService
     private const double ComfortableInterferencePct = 20.0;
 
     /// <summary>
+    /// Converts a measured channel occupancy percentage (0-100) to the external-load score scale,
+    /// used by the measured-congestion floor (#2). Scaled so ~50% airtime maps to ~7.5 (a busy
+    /// external load) and a fully-saturated 100% channel maps to 15 (just above the worst real
+    /// external values). Tunable.
+    /// </summary>
+    private const double MeasuredCongestionToLoadScale = 0.15;
+
+    /// <summary>
     /// Maximum allowed score degradation for any individual AP in a recommended plan.
     /// 1.5 = AP's score can increase by up to 50%. Prevents sacrificing one AP
     /// too heavily for network-wide improvement.
@@ -216,6 +224,14 @@ public class ChannelRecommendationService
     /// though from its own location, so confidence is high but below historic/direct.
     /// </summary>
     private const double SiblingResidentConfidence = 0.70;
+
+    /// <summary>
+    /// Observation confidence from spectrum-scan coverage of a channel: the radio directly measured
+    /// the channel's airtime, so it isn't "unknown" - but it's a one-shot sample, so it reduces the
+    /// uncertainty penalty without erasing it (the scan is a reference, not the authority for a
+    /// move-to channel). Between sibling-resident and historic. Tunable.
+    /// </summary>
+    private const double ScanCoverageConfidence = 0.80;
 
     /// <summary>
     /// Minimum internal (propagation) weight for a resident sibling AP to count as an observer
@@ -1083,15 +1099,21 @@ public class ChannelRecommendationService
             }
         }
 
-        // External interference (neighbor networks)
+        // External interference (neighbor networks), floored by measured congestion (#2): the scan
+        // can UNDER-state a channel (non-beaconing/hidden airtime the rogue scan never sees), so
+        // raise it to what the radio measured. It is a floor only - never lower the proxy, because
+        // the BSSIDs the scan DID detect are real and will transmit even if idle this instant.
         for (int i = 0; i < n; i++)
         {
             var apSpan = ChannelSpanHelper.GetChannelSpan(band, assignment[i].Channel, assignment[i].Width);
+            double externalLoad = 0;
             foreach (var (extSpan, extWeight) in ExternalContributors(graph, band, i))
             {
                 if (ChannelSpanHelper.SpansOverlap(apSpan, extSpan))
-                    score += extWeight;
+                    externalLoad += extWeight;
             }
+            var measured = MeasuredCongestionLoad(graph, band, i, assignment);
+            score += measured > externalLoad ? measured : externalLoad;
         }
 
         // Channel scan data (utilization/interference from RF environment scan)
@@ -1157,13 +1179,17 @@ public class ChannelRecommendationService
             score += graph.DirectionalWeights[j, apIndex] * overlapFactor * InternalCoChannelMultiplier;
         }
 
-        // External interference
+        // External interference, floored by measured congestion (#2): raise a channel the rogue scan
+        // under-states up to what the radio measured, but never lower it - detected BSSIDs are real.
         var apSpan = ChannelSpanHelper.GetChannelSpan(band, assignment[apIndex].Channel, assignment[apIndex].Width);
+        double externalLoad = 0;
         foreach (var (extSpan, extWeight) in ExternalContributors(graph, band, apIndex))
         {
             if (ChannelSpanHelper.SpansOverlap(apSpan, extSpan))
-                score += extWeight;
+                externalLoad += extWeight;
         }
+        var measuredLoad = MeasuredCongestionLoad(graph, band, apIndex, assignment);
+        score += measuredLoad > externalLoad ? measuredLoad : externalLoad;
 
         // Channel scan data (scaled by band stress multiplier)
         var bandStress = GetBandStressMultiplier(band);
@@ -1302,6 +1328,44 @@ public class ChannelRecommendationService
     }
 
     /// <summary>
+    /// Measured-congestion FLOOR (#2) for the AP's assigned channel, on the external-load scale. The
+    /// rogue/neighbor scan only sees beaconing BSSIDs, so it can UNDER-state a channel that's
+    /// genuinely busy (the inverted ch1 case: low scan weight, but high measured airtime from
+    /// non-beaconing or hidden sources). This raises the channel's congestion to what the radio
+    /// actually measured, from the best signals we have: the AP's OWN spectrum-scan utilization for
+    /// the channel (right vantage, all scanned channels), or a sibling AP's time-averaged external
+    /// interference for a channel it currently occupies (averaged, and a real signal we'd also
+    /// collide with our own AP there). Takes the higher of those. The caller uses it as a FLOOR only
+    /// - it never LOWERS the proxy, because the BSSIDs the scan DID detect are real and will transmit
+    /// even if idle this instant; the scan is a reference, not the authority. Returns -1 when no
+    /// measurement exists.
+    /// </summary>
+    private double MeasuredCongestionLoad(InterferenceGraph graph, RadioBand band, int apIndex, (int Channel, int Width)[] assignment)
+    {
+        var apSpan = ChannelSpanHelper.GetChannelSpan(band, assignment[apIndex].Channel, assignment[apIndex].Width);
+        double measuredPct = -1;
+
+        // The AP's own spectrum-scan utilization for the assigned channel (its own vantage).
+        if (graph.ScanChannelData[apIndex].TryGetValue(assignment[apIndex].Channel, out var scan))
+            measuredPct = Math.Max(measuredPct, scan.Utilization);
+
+        // A sibling AP's time-averaged external interference for a channel it currently sits on.
+        var n = graph.Nodes.Count;
+        for (int j = 0; j < n; j++)
+        {
+            if (j == apIndex) continue;
+            var sibling = graph.Nodes[j];
+            if (sibling.HistoricalStress == null) continue;
+            var siblingSpan = ChannelSpanHelper.GetChannelSpan(band, sibling.CurrentChannel, sibling.CurrentWidth);
+            if (!ChannelSpanHelper.SpansOverlap(apSpan, siblingSpan)) continue;
+            if (sibling.HistoricalStress.TryGetValue(sibling.CurrentChannel, out var stress))
+                measuredPct = Math.Max(measuredPct, stress.Interference);
+        }
+
+        return measuredPct < 0 ? -1 : measuredPct * MeasuredCongestionToLoadScale;
+    }
+
+    /// <summary>
     /// Each external contributor to an AP as a (channel span, weight) pair, accounting for the
     /// neighbor's width so a wide neighbor's load is tested against its full span (e.g. a 40 MHz
     /// neighbor on 2.4 GHz ch11 also covers ch6) - and ONLY that neighbor's weight spills, not the
@@ -1356,6 +1420,12 @@ public class ChannelRecommendationService
 
         double confidence = 0;
         var node = graph.Nodes[apIndex];
+
+        // Spectrum-scan coverage: the radio directly measured the channel's airtime, so it isn't
+        // "unknown" even if it heard no beaconing neighbor there. But it's a one-shot sample, so it
+        // only partially resolves the uncertainty - the scan informs the move, it doesn't crown it.
+        if (graph.ScanChannelData[apIndex].Keys.Any(ch => ChannelSpanHelper.SpansOverlap(apSpan, (ch, ch))))
+            confidence = Math.Max(confidence, ScanCoverageConfidence);
 
         // Historic occupancy: we have measured airtime for this AP on an overlapping channel.
         if (node.HistoricalStress != null)

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -2595,6 +2595,7 @@ public class ChannelRecommendationService
         var n = graph.Nodes.Count;
         if (n == 0) return;
 
+        var bandStress = GetBandStressMultiplier(band);
         var sb = new StringBuilder();
         sb.AppendLine($"[ChannelRec] === {phase}: Per-AP channel scores ({band}) ===");
         sb.AppendLine($"  Current assignment: {string.Join(", ", Enumerable.Range(0, n).Select(i => $"{graph.Nodes[i].Name}=ch{currentAssignment[i].Channel}"))}");
@@ -2636,54 +2637,34 @@ public class ChannelRecommendationService
                         externalScore += extW;
                 }
 
+                // #2 measured floor: a candidate channel's congestion is raised to what the radio
+                // measured where that exceeds the neighbor-scan proxy (matches ScoreAp).
+                var measuredFloor = MeasuredCongestionLoad(graph, band, i, testAssignment);
+                if (measuredFloor > externalScore) externalScore = measuredFloor;
+
+                // Scan: measured utilization + noise floor, band-weighted (matches ScoreAp).
+                double scanUtil = 0, scanNoise = 0;
                 if (graph.ScanChannelData[i].TryGetValue(ch, out var scanData))
                 {
-                    scanScore = scanData.Utilization * ScanUtilizationWeight
-                              + ScanNoiseFloorPenalty(scanData.NoiseFloor);
+                    scanUtil = scanData.Utilization * ScanUtilizationWeight * bandStress;
+                    scanNoise = ScanNoiseFloorPenalty(scanData.NoiseFloor) * bandStress;
                 }
+                scanScore = scanUtil + scanNoise;
 
-                // Historical channel stress penalty
-                double stressScore = 0;
-                var testSpan = ChannelSpanHelper.GetChannelSpan(band, ch, currentAssignment[i].Width);
-
-                if (node.HistoricalStress != null && node.HistoricalStress.Count > 0)
-                {
-                    foreach (var (histCh, stress) in node.HistoricalStress)
-                    {
-                        if (stress.TxRetryPct < StressMinThreshold &&
-                            stress.Utilization < StressMinThreshold &&
-                            stress.Interference < StressMinThreshold)
-                            continue;
-                        var histSpan = ChannelSpanHelper.GetChannelSpan(band, histCh, node.CurrentWidth);
-                        if (ChannelSpanHelper.SpansOverlap(testSpan, histSpan))
-                        {
-                            stressScore += (stress.TxRetryPct / 100.0) * TxRetryStressWeight
-                                + (stress.Utilization / 100.0) * UtilizationStressWeight
-                                + (stress.Interference / 100.0) * InterferenceStressWeight;
-                        }
-                    }
-                }
-                else if (node.TxRetriesPct >= StressMinThreshold ||
-                    node.ChannelUtilization >= StressMinThreshold ||
-                    node.Interference >= StressMinThreshold)
-                {
-                    var currentSpan = ChannelSpanHelper.GetChannelSpan(band, node.CurrentChannel, node.CurrentWidth);
-                    if (ChannelSpanHelper.SpansOverlap(currentSpan, testSpan))
-                    {
-                        stressScore = (node.TxRetriesPct / 100.0) * TxRetryStressWeight
-                                    + (node.ChannelUtilization / 100.0) * UtilizationStressWeight
-                                    + (node.Interference / 100.0) * InterferenceStressWeight;
-                    }
-                }
+                // Stress: reuse the real penalty so the breakdown reconciles with the score
+                // (measured historical stress un-scaled, neighbor-propagated fallback band-weighted).
+                var (histPenalty, fallbackPenalty) = ComputeStressPenalty(graph, band, i, testAssignment);
+                var stressScore = histPenalty + fallbackPenalty * bandStress;
 
                 // Unobserved channel uncertainty (confidence-weighted, matches ScoreAp/ScoreAssignment)
                 double unobservedPenalty = ComputeUnobservedPenalty(graph, band, i, testAssignment);
 
                 var total = internalScore + externalScore + scanScore + stressScore + unobservedPenalty;
                 var marker = ch == currentAssignment[i].Channel ? " <<<" : "";
-                var stressStr = stressScore > 0 ? $" + stress={stressScore:F3}(raw)" : "";
+                var scanStr = scanScore > 0 ? $" + scan={scanScore:F3}(util {scanUtil:F2}/nf {scanNoise:F2})" : "";
+                var stressStr = stressScore > 0 ? $" + stress={stressScore:F3}" : "";
                 var unobsStr = unobservedPenalty > 0 ? $" + unobs={unobservedPenalty:F3}" : "";
-                sb.AppendLine($"    ch{ch,3}: internal={internalScore:F3} + external={externalScore:F3} + scan={scanScore:F3}{stressStr}{unobsStr} = {total:F3}{marker}");
+                sb.AppendLine($"    ch{ch,3}: internal={internalScore:F3} + external={externalScore:F3}{scanStr}{stressStr}{unobsStr} = {total:F3}{marker}");
             }
         }
 

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -268,6 +268,7 @@ public class ChannelRecommendationService
             InternalWeights = new double[n, n],
             DirectionalWeights = new double[n, n],
             ExternalLoad = new Dictionary<int, double>[n],
+            ExternalLoadWidths = new Dictionary<int, int>[n],
             DirectlyObservedChannels = new HashSet<int>[n],
             ScanChannelData = new Dictionary<int, (int Utilization, int Interference)>[n],
             MeshConstraints = new List<MeshConstraint>(),
@@ -309,6 +310,7 @@ public class ChannelRecommendationService
             });
 
             graph.ExternalLoad[i] = new Dictionary<int, double>();
+            graph.ExternalLoadWidths[i] = new Dictionary<int, int>();
             graph.DirectlyObservedChannels[i] = new HashSet<int>();
             graph.ScanChannelData[i] = new Dictionary<int, (int, int)>();
         }
@@ -1016,7 +1018,7 @@ public class ChannelRecommendationService
             var apSpan = ChannelSpanHelper.GetChannelSpan(band, assignment[i].Channel, assignment[i].Width);
             foreach (var (extChannel, extWeight) in graph.ExternalLoad[i])
             {
-                var extSpan = (Low: extChannel, High: extChannel);
+                var extSpan = ExternalNeighborSpan(graph, band, i, extChannel);
                 if (ChannelSpanHelper.SpansOverlap(apSpan, extSpan))
                     score += extWeight;
             }
@@ -1089,7 +1091,7 @@ public class ChannelRecommendationService
         var apSpan = ChannelSpanHelper.GetChannelSpan(band, assignment[apIndex].Channel, assignment[apIndex].Width);
         foreach (var (extChannel, extWeight) in graph.ExternalLoad[apIndex])
         {
-            var extSpan = (Low: extChannel, High: extChannel);
+            var extSpan = ExternalNeighborSpan(graph, band, apIndex, extChannel);
             if (ChannelSpanHelper.SpansOverlap(apSpan, extSpan))
                 score += extWeight;
         }
@@ -1143,7 +1145,7 @@ public class ChannelRecommendationService
         double triangulatedLoad = 0;
         foreach (var (extChannel, extWeight) in graph.ExternalLoad[apIndex])
         {
-            if (ChannelSpanHelper.SpansOverlap(apSpan, (extChannel, extChannel)))
+            if (ChannelSpanHelper.SpansOverlap(apSpan, ExternalNeighborSpan(graph, band, apIndex, extChannel)))
                 triangulatedLoad += extWeight;
         }
 
@@ -1204,6 +1206,23 @@ public class ChannelRecommendationService
 
         if (mean <= CrowdingFrictionScoreBaseline) return 1.0;
         return Math.Min(mean / CrowdingFrictionScoreBaseline, MaxCrowdingFriction);
+    }
+
+    /// <summary>
+    /// The channel span a pooled external-load entry occupies, accounting for the neighbor's width.
+    /// A wide neighbor steps on more than its control channel (e.g. a 40 MHz AP on 2.4 GHz ch11 also
+    /// covers ch6), so its load must be tested against the full span, not a single point. Falls back
+    /// to a 20 MHz point when no width was recorded for the channel.
+    /// </summary>
+    private static (int Low, int High) ExternalNeighborSpan(
+        InterferenceGraph graph, RadioBand band, int apIndex, int extChannel)
+    {
+        int width = 20;
+        if (graph.ExternalLoadWidths != null && apIndex < graph.ExternalLoadWidths.Length &&
+            graph.ExternalLoadWidths[apIndex] != null &&
+            graph.ExternalLoadWidths[apIndex].TryGetValue(extChannel, out var w))
+            width = w;
+        return ChannelSpanHelper.GetChannelSpan(band, extChannel, width);
     }
 
     /// <summary>
@@ -1414,7 +1433,7 @@ public class ChannelRecommendationService
         double externalLoad = 0;
         foreach (var (extChannel, extWeight) in graph.ExternalLoad[apIndex])
         {
-            if (ChannelSpanHelper.SpansOverlap(currentSpan, (extChannel, extChannel)))
+            if (ChannelSpanHelper.SpansOverlap(currentSpan, ExternalNeighborSpan(graph, band, apIndex, extChannel)))
                 externalLoad += extWeight;
         }
 
@@ -1610,6 +1629,14 @@ public class ChannelRecommendationService
                 if (!graph.ExternalLoad[j].ContainsKey(bestChannel))
                     graph.ExternalLoad[j][bestChannel] = 0;
                 graph.ExternalLoad[j][bestChannel] += bestWeight;
+
+                // Track the widest neighbor pooled at this channel so the scorer can account for its
+                // full spectral footprint (e.g. a 40 MHz neighbor on 2.4 GHz ch11 also steps on ch6).
+                // Widest is conservative: it never makes an occupied channel read as clear.
+                var sightingWidth = bestWidth ?? 20;
+                if (!graph.ExternalLoadWidths[j].TryGetValue(bestChannel, out var existingWidth) ||
+                    sightingWidth > existingWidth)
+                    graph.ExternalLoadWidths[j][bestChannel] = sightingWidth;
 
                 if (isDirect)
                 {
@@ -2015,7 +2042,7 @@ public class ChannelRecommendationService
         // measured load already drives the score and no friction applies.
         var span = ChannelSpanHelper.GetChannelSpan(band, assigned.Channel, assigned.Width);
         bool haveEvidence = graph.ExternalLoad[apIndex].Keys
-            .Any(extCh => ChannelSpanHelper.SpansOverlap(span, (extCh, extCh)));
+            .Any(extCh => ChannelSpanHelper.SpansOverlap(span, ExternalNeighborSpan(graph, band, apIndex, extCh)));
         if (haveEvidence) return 0;
 
         return DfsDepartureFrictionPenalty;
@@ -2397,7 +2424,7 @@ public class ChannelRecommendationService
                 var apSpan = ChannelSpanHelper.GetChannelSpan(band, ch, currentAssignment[i].Width);
                 foreach (var (extCh, extW) in graph.ExternalLoad[i])
                 {
-                    if (ChannelSpanHelper.SpansOverlap(apSpan, (extCh, extCh)))
+                    if (ChannelSpanHelper.SpansOverlap(apSpan, ExternalNeighborSpan(graph, band, i, extCh)))
                         externalScore += extW;
                 }
 

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -120,6 +120,20 @@ public class ChannelRecommendationService
     private const double UnknownChannelPenalty = 0.15;
 
     /// <summary>
+    /// 2.4 GHz crowding friction baseline. 2.4 GHz has only three non-overlapping channels, so when
+    /// the whole band is congested a channel change buys little and risks shuffling APs onto each
+    /// other. Once the mean current per-AP score on 2.4 GHz exceeds this baseline, the optimizer
+    /// raises the net-benefit a move must clear, scaled by how far past the baseline the band is
+    /// (capped at <see cref="MaxCrowdingFriction"/>). Below the baseline, and on every other band,
+    /// there is no friction. 4.0 is roughly where a 2.4 GHz AP is clearly contended on the
+    /// CCA-anchored scale, so friction only engages once the band is genuinely busy.
+    /// </summary>
+    private const double CrowdingFrictionScoreBaseline = 4.0;
+
+    /// <summary>Maximum 2.4 GHz crowding friction multiplier (see <see cref="CrowdingFrictionScoreBaseline"/>).</summary>
+    private const double MaxCrowdingFriction = 3.0;
+
+    /// <summary>
     /// Maximum allowed score degradation for any individual AP in a recommended plan.
     /// 1.5 = AP's score can increase by up to 50%. Prevents sacrificing one AP
     /// too heavily for network-wide improvement.
@@ -879,6 +893,57 @@ public class ChannelRecommendationService
             }
         }
 
+        // 2.4 GHz crowding friction: in a broadly congested 2.4 GHz band, a channel change buys
+        // little and can shuffle APs onto each other, so hold an AP on its current channel unless
+        // its move clears a crowding-scaled net-site-benefit bar. The benefit sums EVERY AP's
+        // interference, so a co-channel collision is counted against both victims, not netted away.
+        // No-op on other bands and on an uncrowded 2.4 GHz band; an AP on an invalid channel still
+        // moves. Runs before the mesh sync below so a reverted leader re-aligns its children.
+        var crowdingFriction = ComputeBandCrowdingFriction(band, currentApScores);
+        if (crowdingFriction > 1.0)
+        {
+            var netBenefitBar = MinApAbsoluteImprovement * (crowdingFriction - 1.0);
+            bool revertedAny;
+            do
+            {
+                revertedAny = false;
+                for (int i = 0; i < n; i++)
+                {
+                    var node = graph.Nodes[i];
+                    var rec = plan.Recommendations[i];
+                    if (rec.RecommendedChannel == node.CurrentChannel && rec.RecommendedWidth == node.CurrentWidth)
+                        continue;
+                    // Mesh children follow their leader; an AP stuck on an invalid channel must move.
+                    if (node.MeshGroupLeader >= 0 && node.MeshGroupLeader != i) continue;
+                    if (!node.ValidChannels.Contains(node.CurrentChannel)) continue;
+
+                    var revertedAssignment = ((int Channel, int Width)[])finalAssignment.Clone();
+                    revertedAssignment[i] = (node.CurrentChannel, node.CurrentWidth);
+                    ApplyMeshConstraints(graph, revertedAssignment);
+
+                    double withMove = 0, withoutMove = 0;
+                    for (int j = 0; j < n; j++)
+                    {
+                        withMove += ScoreAp(graph, finalAssignment, j, band);
+                        withoutMove += ScoreAp(graph, revertedAssignment, j, band);
+                    }
+                    if (withoutMove - withMove >= netBenefitBar) continue; // the move earns its keep
+
+                    _logger.LogDebug(
+                        "[ChannelRec] 2.4 GHz crowding friction: reverting {ApName} ch{Rec} → ch{Cur}; net " +
+                        "site benefit {Net:F3} below the crowded-band bar {Bar:F3} (friction {Friction:F2})",
+                        node.Name, rec.RecommendedChannel, node.CurrentChannel,
+                        withoutMove - withMove, netBenefitBar, crowdingFriction);
+
+                    rec.RecommendedChannel = node.CurrentChannel;
+                    rec.RecommendedWidth = node.CurrentWidth;
+                    finalAssignment[i] = (node.CurrentChannel, node.CurrentWidth);
+                    ApplyMeshConstraints(graph, finalAssignment);
+                    revertedAny = true;
+                }
+            } while (revertedAny);
+        }
+
         // Sync mesh children to their leader's final channel. The leader may have moved or
         // been reverted during reconciliation; the child must mirror wherever it landed so the
         // displayed plan is physically valid (a backhaul pair shares one channel) and the
@@ -1119,6 +1184,26 @@ public class ChannelRecommendationService
 
         var basePenalty = estimatedLoad * GetUnobservedMultiplier(band);
         return (1.0 - confidence) * basePenalty;
+    }
+
+    /// <summary>
+    /// A &gt;= 1.0 multiplier capturing how congested a 2.4 GHz band is, used to raise the net
+    /// benefit a channel move must clear before it's worth recommending. Returns 1.0 (no friction)
+    /// on every other band and when the mean current per-AP score is at or below
+    /// <see cref="CrowdingFrictionScoreBaseline"/>; above the baseline it grows with the mean score,
+    /// capped at <see cref="MaxCrowdingFriction"/>. 2.4 GHz only: with just three non-overlapping
+    /// channels, once they are all busy no move meaningfully helps, so the optimizer should hold put.
+    /// </summary>
+    private static double ComputeBandCrowdingFriction(RadioBand band, double[] currentApScores)
+    {
+        if (band != RadioBand.Band2_4GHz || currentApScores.Length == 0) return 1.0;
+
+        double sum = 0;
+        foreach (var s in currentApScores) sum += s;
+        var mean = sum / currentApScores.Length;
+
+        if (mean <= CrowdingFrictionScoreBaseline) return 1.0;
+        return Math.Min(mean / CrowdingFrictionScoreBaseline, MaxCrowdingFriction);
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -311,7 +311,7 @@ public class ChannelRecommendationService
             ExternalLoad = new Dictionary<int, double>[n],
             ExternalNeighbors = new Dictionary<(int Channel, int Width), double>[n],
             DirectlyObservedChannels = new HashSet<int>[n],
-            ScanChannelData = new Dictionary<int, (int Utilization, int? NoiseFloor)>[n],
+            ScanChannelData = new Dictionary<(int Channel, int Width), (int Utilization, int? NoiseFloor)>[n],
             MeshConstraints = new List<MeshConstraint>(),
             DfsChannels = new HashSet<int>(regulatoryData?.DfsChannels ?? [])
         };
@@ -363,7 +363,7 @@ public class ChannelRecommendationService
             graph.ExternalLoad[i] = new Dictionary<int, double>();
             graph.ExternalNeighbors[i] = new Dictionary<(int Channel, int Width), double>();
             graph.DirectlyObservedChannels[i] = new HashSet<int>();
-            graph.ScanChannelData[i] = new Dictionary<int, (int, int?)>();
+            graph.ScanChannelData[i] = new Dictionary<(int, int), (int, int?)>();
         }
 
         // Build pairwise internal interference weights
@@ -1142,8 +1142,7 @@ public class ChannelRecommendationService
         {
             if (graph.ScanChannelData[i].Count == 0) continue;
 
-            var ch = assignment[i].Channel;
-            if (graph.ScanChannelData[i].TryGetValue(ch, out var scanData))
+            if (ScanOverSpan(graph, band, i, assignment[i].Channel, assignment[i].Width) is { } scanData)
             {
                 score += scanData.Utilization * ScanUtilizationWeight * bandStress;
                 score += ScanNoiseFloorPenalty(scanData.NoiseFloor) * bandStress;
@@ -1210,10 +1209,9 @@ public class ChannelRecommendationService
         var measuredLoad = MeasuredCongestionLoad(graph, band, apIndex, assignment);
         score += measuredLoad > externalLoad ? measuredLoad : externalLoad;
 
-        // Channel scan data (scaled by band stress multiplier)
+        // Channel scan data (scaled by band stress multiplier), aggregated over the channel's span.
         var bandStress = GetBandStressMultiplier(band);
-        var ch = assignment[apIndex].Channel;
-        if (graph.ScanChannelData[apIndex].TryGetValue(ch, out var scanData))
+        if (ScanOverSpan(graph, band, apIndex, assignment[apIndex].Channel, assignment[apIndex].Width) is { } scanData)
         {
             score += scanData.Utilization * ScanUtilizationWeight * bandStress;
             score += ScanNoiseFloorPenalty(scanData.NoiseFloor) * bandStress;
@@ -1375,6 +1373,42 @@ public class ChannelRecommendationService
         return excessDb * ScanNoiseFloorWeight;
     }
 
+    /// <summary>
+    /// The spectrum-scan reading for an operating (channel, width). Prefers a bucket measured at that
+    /// exact width - UniFi already aggregated that channel - so we use its own number. Otherwise the
+    /// scan is finer than the operating channel (e.g. BW20 buckets under a 160 MHz channel), and
+    /// reading only the control bucket would judge a wide channel by one-eighth of its spectrum; so we
+    /// aggregate the finest sub-channels across the span the way UniFi's wide-channel scan does
+    /// (verified against a BW160-vs-BW20 capture): utilization = MEAN of the sub-channels, noise floor
+    /// = MAX (worst) of them. Returns null when no bucket overlaps the span.
+    /// </summary>
+    private static (int Utilization, int? NoiseFloor)? ScanOverSpan(
+        InterferenceGraph graph, RadioBand band, int apIndex, int channel, int width)
+    {
+        var buckets = graph.ScanChannelData[apIndex];
+        if (buckets.Count == 0) return null;
+
+        // 1) Exact operating-width bucket - trust UniFi's own aggregation for that channel.
+        if (buckets.TryGetValue((channel, width), out var exact)) return exact;
+
+        // 2) Aggregate the finest sub-channels overlapping the span (don't mix widths).
+        var span = ChannelSpanHelper.GetChannelSpan(band, channel, width);
+        var overlapping = buckets
+            .Where(kv => ChannelSpanHelper.SpansOverlap(span, (kv.Key.Channel, kv.Key.Channel)))
+            .ToList();
+        if (overlapping.Count == 0) return null;
+
+        var finestWidth = overlapping.Min(kv => kv.Key.Width);
+        var fine = overlapping.Where(kv => kv.Key.Width == finestWidth).ToList();
+
+        var util = (int)Math.Round(fine.Average(kv => (double)kv.Value.Utilization));
+        int? worstNoise = null;
+        foreach (var kv in fine)
+            if (kv.Value.NoiseFloor is int nf)
+                worstNoise = worstNoise is int n ? Math.Max(n, nf) : nf; // higher (less negative) dBm = worse
+        return (util, worstNoise);
+    }
+
     private double MeasuredCongestionLoad(InterferenceGraph graph, RadioBand band, int apIndex, (int Channel, int Width)[] assignment)
     {
         var node = graph.Nodes[apIndex];
@@ -1387,7 +1421,7 @@ public class ChannelRecommendationService
         // channel), so using it there would bias toward a move; the current channel's congestion is
         // governed by the external load + the interference-based comfort anchor (#1) instead.
         if (assignedChannel != node.CurrentChannel &&
-            graph.ScanChannelData[apIndex].TryGetValue(assignedChannel, out var scan))
+            ScanOverSpan(graph, band, apIndex, assignedChannel, assignment[apIndex].Width) is { } scan)
             measuredPct = Math.Max(measuredPct, scan.Utilization);
 
         // A sibling AP's time-averaged external interference for a channel it currently sits on,
@@ -1467,7 +1501,7 @@ public class ChannelRecommendationService
         // Spectrum-scan coverage: the radio directly measured the channel's airtime, so it isn't
         // "unknown" even if it heard no beaconing neighbor there. But it's a one-shot sample, so it
         // only partially resolves the uncertainty - the scan informs the move, it doesn't crown it.
-        if (graph.ScanChannelData[apIndex].Keys.Any(ch => ChannelSpanHelper.SpansOverlap(apSpan, (ch, ch))))
+        if (graph.ScanChannelData[apIndex].Keys.Any(k => ChannelSpanHelper.SpansOverlap(apSpan, (k.Channel, k.Channel))))
             confidence = Math.Max(confidence, ScanCoverageConfidence);
 
         // Historic occupancy: we have measured airtime for this AP on an overlapping channel.
@@ -1973,9 +2007,10 @@ public class ChannelRecommendationService
             {
                 if (chInfo.Utilization.HasValue || chInfo.NoiseFloor.HasValue)
                 {
-                    graph.ScanChannelData[apIndex][chInfo.Channel] = (
-                        chInfo.Utilization ?? 0,
-                        chInfo.NoiseFloor);
+                    // Key by (channel, width) so a channel's BW20 and BW160 readings coexist; the
+                    // scorer (ScanOverSpan) picks the right one for the operating width.
+                    var key = (chInfo.Channel, chInfo.Width ?? 20);
+                    graph.ScanChannelData[apIndex][key] = (chInfo.Utilization ?? 0, chInfo.NoiseFloor);
                 }
             }
         }
@@ -2570,8 +2605,8 @@ public class ChannelRecommendationService
                 continue;
             }
             var metrics = graph.ScanChannelData[i]
-                .OrderBy(kv => kv.Key)
-                .Select(kv => $"ch{kv.Key}=util:{kv.Value.Utilization}%/nf:{(kv.Value.NoiseFloor.HasValue ? kv.Value.NoiseFloor + "dBm" : "n/a")}");
+                .OrderBy(kv => kv.Key.Channel).ThenBy(kv => kv.Key.Width)
+                .Select(kv => $"ch{kv.Key.Channel}/{kv.Key.Width}=util:{kv.Value.Utilization}%/nf:{(kv.Value.NoiseFloor.HasValue ? kv.Value.NoiseFloor + "dBm" : "n/a")}");
             sb.AppendLine($"    {graph.Nodes[i].Name}: {string.Join(", ", metrics)}");
         }
 
@@ -2642,9 +2677,9 @@ public class ChannelRecommendationService
                 var measuredFloor = MeasuredCongestionLoad(graph, band, i, testAssignment);
                 if (measuredFloor > externalScore) externalScore = measuredFloor;
 
-                // Scan: measured utilization + noise floor, band-weighted (matches ScoreAp).
+                // Scan: measured utilization + noise floor, band-weighted, span-aggregated (matches ScoreAp).
                 double scanUtil = 0, scanNoise = 0;
-                if (graph.ScanChannelData[i].TryGetValue(ch, out var scanData))
+                if (ScanOverSpan(graph, band, i, ch, currentAssignment[i].Width) is { } scanData)
                 {
                     scanUtil = scanData.Utilization * ScanUtilizationWeight * bandStress;
                     scanNoise = ScanNoiseFloorPenalty(scanData.NoiseFloor) * bandStress;

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -268,7 +268,7 @@ public class ChannelRecommendationService
             InternalWeights = new double[n, n],
             DirectionalWeights = new double[n, n],
             ExternalLoad = new Dictionary<int, double>[n],
-            ExternalLoadWidths = new Dictionary<int, int>[n],
+            ExternalNeighbors = new Dictionary<(int Channel, int Width), double>[n],
             DirectlyObservedChannels = new HashSet<int>[n],
             ScanChannelData = new Dictionary<int, (int Utilization, int Interference)>[n],
             MeshConstraints = new List<MeshConstraint>(),
@@ -310,7 +310,7 @@ public class ChannelRecommendationService
             });
 
             graph.ExternalLoad[i] = new Dictionary<int, double>();
-            graph.ExternalLoadWidths[i] = new Dictionary<int, int>();
+            graph.ExternalNeighbors[i] = new Dictionary<(int Channel, int Width), double>();
             graph.DirectlyObservedChannels[i] = new HashSet<int>();
             graph.ScanChannelData[i] = new Dictionary<int, (int, int)>();
         }
@@ -1016,9 +1016,8 @@ public class ChannelRecommendationService
         for (int i = 0; i < n; i++)
         {
             var apSpan = ChannelSpanHelper.GetChannelSpan(band, assignment[i].Channel, assignment[i].Width);
-            foreach (var (extChannel, extWeight) in graph.ExternalLoad[i])
+            foreach (var (extSpan, extWeight) in ExternalContributors(graph, band, i))
             {
-                var extSpan = ExternalNeighborSpan(graph, band, i, extChannel);
                 if (ChannelSpanHelper.SpansOverlap(apSpan, extSpan))
                     score += extWeight;
             }
@@ -1089,9 +1088,8 @@ public class ChannelRecommendationService
 
         // External interference
         var apSpan = ChannelSpanHelper.GetChannelSpan(band, assignment[apIndex].Channel, assignment[apIndex].Width);
-        foreach (var (extChannel, extWeight) in graph.ExternalLoad[apIndex])
+        foreach (var (extSpan, extWeight) in ExternalContributors(graph, band, apIndex))
         {
-            var extSpan = ExternalNeighborSpan(graph, band, apIndex, extChannel);
             if (ChannelSpanHelper.SpansOverlap(apSpan, extSpan))
                 score += extWeight;
         }
@@ -1143,9 +1141,9 @@ public class ChannelRecommendationService
         if (confidence >= 1.0) return 0;
 
         double triangulatedLoad = 0;
-        foreach (var (extChannel, extWeight) in graph.ExternalLoad[apIndex])
+        foreach (var (extSpan, extWeight) in ExternalContributors(graph, band, apIndex))
         {
-            if (ChannelSpanHelper.SpansOverlap(apSpan, ExternalNeighborSpan(graph, band, apIndex, extChannel)))
+            if (ChannelSpanHelper.SpansOverlap(apSpan, extSpan))
                 triangulatedLoad += extWeight;
         }
 
@@ -1209,20 +1207,26 @@ public class ChannelRecommendationService
     }
 
     /// <summary>
-    /// The channel span a pooled external-load entry occupies, accounting for the neighbor's width.
-    /// A wide neighbor steps on more than its control channel (e.g. a 40 MHz AP on 2.4 GHz ch11 also
-    /// covers ch6), so its load must be tested against the full span, not a single point. Falls back
-    /// to a 20 MHz point when no width was recorded for the channel.
+    /// Each external contributor to an AP as a (channel span, weight) pair, accounting for the
+    /// neighbor's width so a wide neighbor's load is tested against its full span (e.g. a 40 MHz
+    /// neighbor on 2.4 GHz ch11 also covers ch6) - and ONLY that neighbor's weight spills, not the
+    /// 20 MHz neighbors sharing its control channel. Falls back to treating each
+    /// <see cref="InterferenceGraph.ExternalLoad"/> channel as a 20 MHz point when no per-width data
+    /// exists (e.g. a unit test that populates ExternalLoad directly).
     /// </summary>
-    private static (int Low, int High) ExternalNeighborSpan(
-        InterferenceGraph graph, RadioBand band, int apIndex, int extChannel)
+    private static IEnumerable<((int Low, int High) Span, double Weight)> ExternalContributors(
+        InterferenceGraph graph, RadioBand band, int apIndex)
     {
-        int width = 20;
-        if (graph.ExternalLoadWidths != null && apIndex < graph.ExternalLoadWidths.Length &&
-            graph.ExternalLoadWidths[apIndex] != null &&
-            graph.ExternalLoadWidths[apIndex].TryGetValue(extChannel, out var w))
-            width = w;
-        return ChannelSpanHelper.GetChannelSpan(band, extChannel, width);
+        var byWidth = graph.ExternalNeighbors;
+        if (byWidth != null && apIndex < byWidth.Length && byWidth[apIndex] is { Count: > 0 } neighbors)
+        {
+            foreach (var ((channel, width), weight) in neighbors)
+                yield return (ChannelSpanHelper.GetChannelSpan(band, channel, width), weight);
+            yield break;
+        }
+
+        foreach (var (channel, weight) in graph.ExternalLoad[apIndex])
+            yield return ((channel, channel), weight);
     }
 
     /// <summary>
@@ -1431,9 +1435,9 @@ public class ChannelRecommendationService
 
         // Compute external load on this channel span to set a floor
         double externalLoad = 0;
-        foreach (var (extChannel, extWeight) in graph.ExternalLoad[apIndex])
+        foreach (var (extSpan, extWeight) in ExternalContributors(graph, band, apIndex))
         {
-            if (ChannelSpanHelper.SpansOverlap(currentSpan, ExternalNeighborSpan(graph, band, apIndex, extChannel)))
+            if (ChannelSpanHelper.SpansOverlap(currentSpan, extSpan))
                 externalLoad += extWeight;
         }
 
@@ -1630,13 +1634,12 @@ public class ChannelRecommendationService
                     graph.ExternalLoad[j][bestChannel] = 0;
                 graph.ExternalLoad[j][bestChannel] += bestWeight;
 
-                // Track the widest neighbor pooled at this channel so the scorer can account for its
-                // full spectral footprint (e.g. a 40 MHz neighbor on 2.4 GHz ch11 also steps on ch6).
-                // Widest is conservative: it never makes an occupied channel read as clear.
+                // Pool by (channel, width) so the scorer can account for each neighbor's true
+                // spectral footprint (a 40 MHz neighbor on 2.4 GHz ch11 also steps on ch6) WITHOUT
+                // dragging the 20 MHz neighbors that share its control channel into spilling too.
                 var sightingWidth = bestWidth ?? 20;
-                if (!graph.ExternalLoadWidths[j].TryGetValue(bestChannel, out var existingWidth) ||
-                    sightingWidth > existingWidth)
-                    graph.ExternalLoadWidths[j][bestChannel] = sightingWidth;
+                var key = (bestChannel, sightingWidth);
+                graph.ExternalNeighbors[j][key] = graph.ExternalNeighbors[j].GetValueOrDefault(key) + bestWeight;
 
                 if (isDirect)
                 {
@@ -2041,8 +2044,8 @@ public class ChannelRecommendationService
         // overlapping it - direct or triangulated from a sibling's scan - is real evidence, so its
         // measured load already drives the score and no friction applies.
         var span = ChannelSpanHelper.GetChannelSpan(band, assigned.Channel, assigned.Width);
-        bool haveEvidence = graph.ExternalLoad[apIndex].Keys
-            .Any(extCh => ChannelSpanHelper.SpansOverlap(span, ExternalNeighborSpan(graph, band, apIndex, extCh)));
+        bool haveEvidence = ExternalContributors(graph, band, apIndex)
+            .Any(c => ChannelSpanHelper.SpansOverlap(span, c.Span));
         if (haveEvidence) return 0;
 
         return DfsDepartureFrictionPenalty;
@@ -2422,9 +2425,9 @@ public class ChannelRecommendationService
                 }
 
                 var apSpan = ChannelSpanHelper.GetChannelSpan(band, ch, currentAssignment[i].Width);
-                foreach (var (extCh, extW) in graph.ExternalLoad[i])
+                foreach (var (extSpan, extW) in ExternalContributors(graph, band, i))
                 {
-                    if (ChannelSpanHelper.SpansOverlap(apSpan, ExternalNeighborSpan(graph, band, i, extCh)))
+                    if (ChannelSpanHelper.SpansOverlap(apSpan, extSpan))
                         externalScore += extW;
                 }
 

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -1142,7 +1142,7 @@ public class ChannelRecommendationService
         {
             if (graph.ScanChannelData[i].Count == 0) continue;
 
-            if (ScanOverSpan(graph, band, i, assignment[i].Channel, assignment[i].Width) is { } scanData)
+            if (ScanReadingForScoring(graph, band, i, assignment[i].Channel, assignment[i].Width) is { } scanData)
             {
                 score += scanData.Utilization * ScanUtilizationWeight * bandStress;
                 score += ScanNoiseFloorPenalty(scanData.NoiseFloor) * bandStress;
@@ -1211,7 +1211,7 @@ public class ChannelRecommendationService
 
         // Channel scan data (scaled by band stress multiplier), aggregated over the channel's span.
         var bandStress = GetBandStressMultiplier(band);
-        if (ScanOverSpan(graph, band, apIndex, assignment[apIndex].Channel, assignment[apIndex].Width) is { } scanData)
+        if (ScanReadingForScoring(graph, band, apIndex, assignment[apIndex].Channel, assignment[apIndex].Width) is { } scanData)
         {
             score += scanData.Utilization * ScanUtilizationWeight * bandStress;
             score += ScanNoiseFloorPenalty(scanData.NoiseFloor) * bandStress;
@@ -1407,6 +1407,43 @@ public class ChannelRecommendationService
             if (kv.Value.NoiseFloor is int nf)
                 worstNoise = worstNoise is int n ? Math.Max(n, nf) : nf; // higher (less negative) dBm = worse
         return (util, worstNoise);
+    }
+
+    /// <summary>
+    /// The scan reading to SCORE a channel with. For a candidate channel the AP's own scan is clean
+    /// (it wasn't transmitting there when it scanned). For the AP's CURRENT channel its own scan is
+    /// contaminated by traffic that FOLLOWS the AP - its serving load and, importantly, a mesh uplink
+    /// carrying the same traffic (e.g. a camera feed) to whatever channel the AP moves to. Counting
+    /// that against the current channel wrongly singles it out for an inescapable, self-induced load.
+    /// So for the current channel we use the CLOSEST sibling that ISN'T on that channel - its read is
+    /// a clean off-channel external scan of it - and fall back to the AP's own reading only when no
+    /// sibling has a view (e.g. a single-AP site).
+    /// </summary>
+    private static (int Utilization, int? NoiseFloor)? ScanReadingForScoring(
+        InterferenceGraph graph, RadioBand band, int apIndex, int channel, int width)
+    {
+        if (channel != graph.Nodes[apIndex].CurrentChannel)
+            return ScanOverSpan(graph, band, apIndex, channel, width);
+
+        var targetSpan = ChannelSpanHelper.GetChannelSpan(band, channel, width);
+        double bestWeight = -1;
+        (int Utilization, int? NoiseFloor)? best = null;
+        var n = graph.Nodes.Count;
+        for (int j = 0; j < n; j++)
+        {
+            if (j == apIndex) continue;
+            var sibling = graph.Nodes[j];
+            var siblingSpan = ChannelSpanHelper.GetChannelSpan(band, sibling.CurrentChannel, sibling.CurrentWidth);
+            if (ChannelSpanHelper.SpansOverlap(targetSpan, siblingSpan)) continue; // on the channel - its read is self-contaminated too
+            if (ScanOverSpan(graph, band, j, channel, width) is not { } reading) continue;
+            var weight = graph.InternalWeights[apIndex, j];
+            if (weight > bestWeight)
+            {
+                bestWeight = weight;
+                best = reading;
+            }
+        }
+        return best ?? ScanOverSpan(graph, band, apIndex, channel, width);
     }
 
     private double MeasuredCongestionLoad(InterferenceGraph graph, RadioBand band, int apIndex, (int Channel, int Width)[] assignment)
@@ -2677,9 +2714,10 @@ public class ChannelRecommendationService
                 var measuredFloor = MeasuredCongestionLoad(graph, band, i, testAssignment);
                 if (measuredFloor > externalScore) externalScore = measuredFloor;
 
-                // Scan: measured utilization + noise floor, band-weighted, span-aggregated (matches ScoreAp).
+                // Scan: measured utilization + noise floor, band-weighted, span-aggregated, with the
+                // current channel read cross-vantage (matches ScoreAp).
                 double scanUtil = 0, scanNoise = 0;
-                if (ScanOverSpan(graph, band, i, ch, currentAssignment[i].Width) is { } scanData)
+                if (ScanReadingForScoring(graph, band, i, ch, currentAssignment[i].Width) is { } scanData)
                 {
                     scanUtil = scanData.Utilization * ScanUtilizationWeight * bandStress;
                     scanNoise = ScanNoiseFloorPenalty(scanData.NoiseFloor) * bandStress;

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -766,10 +766,13 @@ public class ChannelRecommendationService
             if (scoreInFinal < MinApScoreToMove) continue;
             if (!node.ValidChannels.Contains(node.CurrentChannel)) continue;
 
-            // Try each valid channel and find the best that meets all constraints
+            // Try each valid channel and find the best that meets all constraints. Selection and the
+            // net-benefit test are on the NETWORK objective so a fallback move can never raise it.
             int fallbackChannel = -1;
             int fallbackWidth = node.CurrentWidth;
             double fallbackScore = scoreInFinal;
+            var netBefore = ScoreAssignment(graph, finalAssignment, band);
+            var bestNet = netBefore;
 
             foreach (var candidateCh in node.ValidChannels)
             {
@@ -792,25 +795,16 @@ public class ChannelRecommendationService
                     pctImprovement < MinApImprovementPercent)
                     continue;
 
-                // A standalone move may degrade other APs, but only if it still improves the site
-                // overall (this AP's gain exceeds the total degradation it causes) and never pushes
-                // any single AP past the catastrophic cap.
+                // Catastrophic guard: never push any single AP past the catastrophic cap. Measure each
+                // victim against its score in the REALIZED plan (finalAssignment), the same baseline
+                // the mover's gain uses.
                 bool reject = false;
-                double totalDegradation = 0;
                 for (int j = 0; j < n; j++)
                 {
                     if (j == i) continue;
                     if (currentApScores[j] <= 0) continue;
-                    // Measure the victim against its score in the REALIZED plan (finalAssignment), the
-                    // same baseline the mover's gain uses - not the original score. Otherwise an AP
-                    // that already improved earlier in the plan could be pushed back up (but still
-                    // below its original) and register zero degradation, letting a net-negative move
-                    // through.
                     var otherInFinal = ScoreAp(graph, finalAssignment, j, band);
                     var otherScore = ScoreAp(graph, trial, j, band);
-                    if (otherScore > otherInFinal) totalDegradation += otherScore - otherInFinal;
-
-                    // Catastrophic: this move would push a victim into genuinely bad territory.
                     if (otherScore > CatastrophicAbsoluteScore && otherScore > otherInFinal)
                     {
                         _logger.LogDebug(
@@ -824,22 +818,24 @@ public class ChannelRecommendationService
                 }
                 if (reject) continue;
 
-                // Net-benefit: the AP's own improvement must outweigh the total degradation it
-                // causes to others, otherwise the move makes the site no better.
-                if (absImprovement <= totalDegradation)
+                // Net-benefit measured on the ACTUAL network objective (ScoreAssignment), NOT a sum of
+                // per-AP scores. Summing ScoreAp double-counts a newly-created co-channel pair, so it
+                // can call a net-WORSENING move "positive" - e.g. moving an AP onto a channel a sibling
+                // already occupies (the Front Yard ch1->ch6 case that raised the network score). Pick
+                // the candidate that lowers the network score the most; require a strict improvement.
+                var netAfter = ScoreAssignment(graph, trial, band);
+                if (netAfter >= bestNet)
                 {
                     _logger.LogDebug(
-                        "[ChannelRec] Per-AP fallback: {ApName} -> ch{Ch} improves {Abs:F3} but degrades " +
-                        "others by {Deg:F3} total (not net-positive for the site), skipping",
-                        node.Name, candidateCh, absImprovement, totalDegradation);
+                        "[ChannelRec] Per-AP fallback: {ApName} -> ch{Ch} network {Before:F3}->{After:F3} " +
+                        "is not a net improvement, skipping",
+                        node.Name, candidateCh, netBefore, netAfter);
                     continue;
                 }
 
-                if (candidateScore < fallbackScore)
-                {
-                    fallbackScore = candidateScore;
-                    fallbackChannel = candidateCh;
-                }
+                bestNet = netAfter;
+                fallbackScore = candidateScore;
+                fallbackChannel = candidateCh;
             }
 
             if (fallbackChannel >= 0)
@@ -1064,6 +1060,25 @@ public class ChannelRecommendationService
             plan.Recommendations[i].RecommendedChannel = leaderRec.RecommendedChannel;
             plan.Recommendations[i].RecommendedWidth = leaderRec.RecommendedWidth;
             finalAssignment[i] = (leaderRec.RecommendedChannel, leaderRec.RecommendedWidth);
+        }
+
+        // Global guardrail: never emit a plan that RAISES the network score. The post-passes
+        // (per-AP fallback, altruistic) judge benefit per AP, and a per-AP proxy can disagree with the
+        // network objective; if the final plan isn't a net improvement over current, drop every move
+        // and keep the current assignment. (Higher ScoreAssignment = worse.)
+        var finalNetworkScore = ScoreAssignment(graph, finalAssignment, band);
+        if (finalNetworkScore > currentNetworkScore)
+        {
+            _logger.LogDebug(
+                "[ChannelRec] {Band}: final plan network {Final:F3} is worse than current {Current:F3} - reverting all moves",
+                band, finalNetworkScore, currentNetworkScore);
+            for (int i = 0; i < n; i++)
+            {
+                var node = graph.Nodes[i];
+                finalAssignment[i] = (node.CurrentChannel, node.CurrentWidth);
+                plan.Recommendations[i].RecommendedChannel = node.CurrentChannel;
+                plan.Recommendations[i].RecommendedWidth = node.CurrentWidth;
+            }
         }
 
         // Re-score ALL APs against the final assignment for accurate display.

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -528,6 +528,7 @@ public class ChannelRecommendationService
             UnplacedApCount = graph.Nodes.Count(node => !node.IsPlaced),
             HasScanData = graph.HasScanData,
             HasNeighborNetworks = graph.ExternalLoad.Any(d => d.Count > 0),
+            HasMeasuredChannelData = graph.ScanChannelData.Any(d => d.Count > 0),
             HasBuildingData = hasBuildingData,
             DfsAvoidanceNotPossible = graph.DfsAvoidanceFallback
         };

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -809,6 +809,16 @@ public class ChannelRecommendationService
             var moverScore = ScoreAp(graph, finalAssignment, i, band);
             if (moverScore >= MinApScoreToMove) continue;
 
+            // Interference borne by every OTHER AP today. The altruistic pass only fires when a
+            // move reduces THIS - the mover's own score is deliberately excluded, because improving
+            // the mover is the per-AP fallback's job and it already declined to move this healthy
+            // AP. Gating on total network score instead would let a healthy AP relocate purely for
+            // its own gain (e.g. chasing a quieter channel it shares with no neighbor), which is not
+            // altruism and sneaks past the per-AP move threshold.
+            double othersBaseline = 0;
+            for (int j = 0; j < n; j++)
+                if (j != i) othersBaseline += ScoreAp(graph, finalAssignment, j, band);
+
             int bestCh = -1;
             var bestNetwork = baselineNetworkScore;
             foreach (var candidateCh in node.ValidChannels)
@@ -837,10 +847,18 @@ public class ChannelRecommendationService
                 }
                 if (catastrophic) continue;
 
-                // Accept only on a meaningful site-wide improvement (DFS-aware, like the search).
+                // The neighbors must genuinely benefit: require a meaningful drop in the OTHER APs'
+                // interference, not just a lower total (which the mover's own score change inflates).
+                double othersTrial = 0;
+                for (int j = 0; j < n; j++)
+                    if (j != i) othersTrial += ScoreAp(graph, trial, j, band);
+                if (othersBaseline - othersTrial < MinApAbsoluteImprovement) continue;
+
+                // Among genuinely altruistic moves, pick the best site-wide outcome (DFS-aware,
+                // like the search) and never accept one that makes the whole site worse.
                 var trialNetwork = AddDfsPenalty(graph, trial, band, opts.DfsPreference,
                     ScoreAssignment(graph, trial, band));
-                if (baselineNetworkScore - trialNetwork >= MinApAbsoluteImprovement && trialNetwork < bestNetwork)
+                if (trialNetwork < bestNetwork)
                 {
                     bestNetwork = trialNetwork;
                     bestCh = candidateCh;
@@ -1051,7 +1069,6 @@ public class ChannelRecommendationService
         (int Channel, int Width)[] assignment)
     {
         var directChannels = graph.DirectlyObservedChannels[apIndex];
-        if (directChannels.Count == 0) return 0;
 
         var apSpan = ChannelSpanHelper.GetChannelSpan(band, assignment[apIndex].Channel, assignment[apIndex].Width);
 
@@ -1074,8 +1091,11 @@ public class ChannelRecommendationService
         // as quiet, not be assumed as busy as wherever we happen to sit.
         //
         // Only a channel with NO sighting at all (no direct, no triangulated) is a true blind spot.
-        // Floor it at this AP's best observed load so a blind channel never scores better than a
+        // Floor it at this AP's best KNOWN load so a blind channel never scores better than a
         // barely-seen one - otherwise the engine eagerly jumps onto channels it has zero data for.
+        // Prefer directly-observed channels as the floor; an AP with NO direct scan data at all
+        // (fully blind on this band) still floors against its triangulated neighbor load, so a
+        // blind radio carries real uncertainty instead of reading a deceptive 0.
         double estimatedLoad;
         if (triangulatedLoad > 0)
         {
@@ -1083,13 +1103,18 @@ public class ChannelRecommendationService
         }
         else
         {
-            double minDirectLoad = double.MaxValue;
+            double minKnownLoad = double.MaxValue;
             foreach (var dc in directChannels)
             {
                 if (graph.ExternalLoad[apIndex].TryGetValue(dc, out var directWeight))
-                    minDirectLoad = Math.Min(minDirectLoad, directWeight);
+                    minKnownLoad = Math.Min(minKnownLoad, directWeight);
             }
-            estimatedLoad = minDirectLoad == double.MaxValue ? 0 : minDirectLoad;
+            if (minKnownLoad == double.MaxValue)
+            {
+                foreach (var (_, extWeight) in graph.ExternalLoad[apIndex])
+                    minKnownLoad = Math.Min(minKnownLoad, extWeight);
+            }
+            estimatedLoad = minKnownLoad == double.MaxValue ? 0 : minKnownLoad;
         }
 
         var basePenalty = estimatedLoad * GetUnobservedMultiplier(band);

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -38,8 +38,21 @@ public class ChannelRecommendationService
     /// <summary>Weight multiplier for channel scan utilization in scoring (0-1 scale)</summary>
     private const double ScanUtilizationWeight = 0.02;
 
-    /// <summary>Weight multiplier for channel scan interference in scoring (0-1 scale)</summary>
-    private const double ScanInterferenceWeight = 0.03;
+    /// <summary>
+    /// Spectrum-scan noise floor (dBm) at or below which a channel is treated as RF-clean; only the
+    /// energy ABOVE this reference is penalized. Near -90 dBm a channel is quiet; higher (less
+    /// negative) readings mean non-Wi-Fi energy (radar, microwaves, etc.) or a strong interferer
+    /// raising the floor and hurting SNR - a real signal that utilization alone misses (a channel can
+    /// be idle yet noisy). Tunable; verify against logged live values.
+    /// </summary>
+    private const double ScanNoiseFloorReferenceDbm = -90.0;
+
+    /// <summary>Score penalty per dB of scan noise floor above the clean reference. -70 dBm (20 dB over)
+    /// adds ~1.8 before the band-stress multiplier. Tunable.</summary>
+    private const double ScanNoiseFloorWeight = 0.09;
+
+    /// <summary>Cap on noise-floor excess (dB) so an out-of-range/garbage reading can't dominate.</summary>
+    private const double ScanNoiseFloorMaxExcessDb = 45.0;
 
     /// <summary>
     /// Weight for TX retry stress penalty. High TX retries indicate the external load
@@ -145,12 +158,13 @@ public class ChannelRecommendationService
     private const double ComfortableInterferencePct = 20.0;
 
     /// <summary>
-    /// Converts a measured channel occupancy percentage (0-100) to the external-load score scale,
-    /// used by the measured-congestion floor (#2). Scaled so ~50% airtime maps to ~7.5 (a busy
-    /// external load) and a fully-saturated 100% channel maps to 15 (just above the worst real
-    /// external values). Tunable.
+    /// Converts a measured channel occupancy percentage (0-100) to the per-AP score scale used by
+    /// the absolute gates, for the measured-congestion floor (#2). Anchored to those gates rather
+    /// than to the (over-stated) external proxy: ~40% airtime lands near <see cref="MinApScoreToMove"/>
+    /// (2.0) and ~80% near <see cref="CatastrophicAbsoluteScore"/> (4.0), so a moderately busy channel
+    /// reads as moderate - not catastrophic. Tunable.
     /// </summary>
-    private const double MeasuredCongestionToLoadScale = 0.15;
+    private const double MeasuredCongestionToLoadScale = 0.05;
 
     /// <summary>
     /// Maximum allowed score degradation for any individual AP in a recommended plan.
@@ -297,7 +311,7 @@ public class ChannelRecommendationService
             ExternalLoad = new Dictionary<int, double>[n],
             ExternalNeighbors = new Dictionary<(int Channel, int Width), double>[n],
             DirectlyObservedChannels = new HashSet<int>[n],
-            ScanChannelData = new Dictionary<int, (int Utilization, int Interference)>[n],
+            ScanChannelData = new Dictionary<int, (int Utilization, int? NoiseFloor)>[n],
             MeshConstraints = new List<MeshConstraint>(),
             DfsChannels = new HashSet<int>(regulatoryData?.DfsChannels ?? [])
         };
@@ -349,7 +363,7 @@ public class ChannelRecommendationService
             graph.ExternalLoad[i] = new Dictionary<int, double>();
             graph.ExternalNeighbors[i] = new Dictionary<(int Channel, int Width), double>();
             graph.DirectlyObservedChannels[i] = new HashSet<int>();
-            graph.ScanChannelData[i] = new Dictionary<int, (int, int)>();
+            graph.ScanChannelData[i] = new Dictionary<int, (int, int?)>();
         }
 
         // Build pairwise internal interference weights
@@ -786,18 +800,23 @@ public class ChannelRecommendationService
                 for (int j = 0; j < n; j++)
                 {
                     if (j == i) continue;
-                    var otherCurrent = currentApScores[j];
-                    if (otherCurrent <= 0) continue;
+                    if (currentApScores[j] <= 0) continue;
+                    // Measure the victim against its score in the REALIZED plan (finalAssignment), the
+                    // same baseline the mover's gain uses - not the original score. Otherwise an AP
+                    // that already improved earlier in the plan could be pushed back up (but still
+                    // below its original) and register zero degradation, letting a net-negative move
+                    // through.
+                    var otherInFinal = ScoreAp(graph, finalAssignment, j, band);
                     var otherScore = ScoreAp(graph, trial, j, band);
-                    if (otherScore > otherCurrent) totalDegradation += otherScore - otherCurrent;
+                    if (otherScore > otherInFinal) totalDegradation += otherScore - otherInFinal;
 
                     // Catastrophic: this move would push a victim into genuinely bad territory.
-                    if (otherScore > CatastrophicAbsoluteScore && otherScore > otherCurrent)
+                    if (otherScore > CatastrophicAbsoluteScore && otherScore > otherInFinal)
                     {
                         _logger.LogDebug(
                             "[ChannelRec] Per-AP fallback: {ApName} -> ch{Ch} would push {Victim} " +
                             "{From:F3}->{To:F3} above the {Cap:F1} ceiling, skipping",
-                            node.Name, candidateCh, graph.Nodes[j].Name, otherCurrent, otherScore,
+                            node.Name, candidateCh, graph.Nodes[j].Name, otherInFinal, otherScore,
                             CatastrophicAbsoluteScore);
                         reject = true;
                         break;
@@ -1127,7 +1146,7 @@ public class ChannelRecommendationService
             if (graph.ScanChannelData[i].TryGetValue(ch, out var scanData))
             {
                 score += scanData.Utilization * ScanUtilizationWeight * bandStress;
-                score += scanData.Interference * ScanInterferenceWeight * bandStress;
+                score += ScanNoiseFloorPenalty(scanData.NoiseFloor) * bandStress;
             }
         }
 
@@ -1197,7 +1216,7 @@ public class ChannelRecommendationService
         if (graph.ScanChannelData[apIndex].TryGetValue(ch, out var scanData))
         {
             score += scanData.Utilization * ScanUtilizationWeight * bandStress;
-            score += scanData.Interference * ScanInterferenceWeight * bandStress;
+            score += ScanNoiseFloorPenalty(scanData.NoiseFloor) * bandStress;
         }
 
         // Historical stress (undampened) + current stats fallback (dampened)
@@ -1340,16 +1359,40 @@ public class ChannelRecommendationService
     /// even if idle this instant; the scan is a reference, not the authority. Returns -1 when no
     /// measurement exists.
     /// </summary>
+    /// <summary>
+    /// Score penalty from a channel's spectrum-scan noise floor (dBm): the energy ABOVE the clean
+    /// reference, capped, times the per-dB weight. Returns 0 when there's no reading. Captures RF
+    /// energy - non-Wi-Fi interference or a strong interferer - that raw utilization misses (a channel
+    /// can be idle in airtime yet have a high noise floor, e.g. 2.4 GHz ch11). The noise floor is the
+    /// ambient RF level, NOT the AP's own traffic (that shows up as utilization), so unlike the
+    /// utilization floor it's safe to apply on the AP's current channel too. Caller scales by band
+    /// stress.
+    /// </summary>
+    private static double ScanNoiseFloorPenalty(int? noiseFloorDbm)
+    {
+        if (noiseFloorDbm is not int nf) return 0;
+        var excessDb = Math.Min(ScanNoiseFloorMaxExcessDb, Math.Max(0.0, nf - ScanNoiseFloorReferenceDbm));
+        return excessDb * ScanNoiseFloorWeight;
+    }
+
     private double MeasuredCongestionLoad(InterferenceGraph graph, RadioBand band, int apIndex, (int Channel, int Width)[] assignment)
     {
-        var apSpan = ChannelSpanHelper.GetChannelSpan(band, assignment[apIndex].Channel, assignment[apIndex].Width);
+        var node = graph.Nodes[apIndex];
+        var assignedChannel = assignment[apIndex].Channel;
+        var apSpan = ChannelSpanHelper.GetChannelSpan(band, assignedChannel, assignment[apIndex].Width);
         double measuredPct = -1;
 
-        // The AP's own spectrum-scan utilization for the assigned channel (its own vantage).
-        if (graph.ScanChannelData[apIndex].TryGetValue(assignment[apIndex].Channel, out var scan))
+        // The AP's own spectrum-scan utilization - only for a CANDIDATE channel. On its CURRENT
+        // channel the scan radio also hears the AP's own serving traffic (which follows it to any
+        // channel), so using it there would bias toward a move; the current channel's congestion is
+        // governed by the external load + the interference-based comfort anchor (#1) instead.
+        if (assignedChannel != node.CurrentChannel &&
+            graph.ScanChannelData[apIndex].TryGetValue(assignedChannel, out var scan))
             measuredPct = Math.Max(measuredPct, scan.Utilization);
 
-        // A sibling AP's time-averaged external interference for a channel it currently sits on.
+        // A sibling AP's time-averaged external interference for a channel it currently sits on,
+        // scaled by how strongly THIS AP hears that sibling (proximity) - a distant sibling's local
+        // noise isn't our experience. Reads only real (measured) HistoricalStress, never propagated.
         var n = graph.Nodes.Count;
         for (int j = 0; j < n; j++)
         {
@@ -1359,7 +1402,7 @@ public class ChannelRecommendationService
             var siblingSpan = ChannelSpanHelper.GetChannelSpan(band, sibling.CurrentChannel, sibling.CurrentWidth);
             if (!ChannelSpanHelper.SpansOverlap(apSpan, siblingSpan)) continue;
             if (sibling.HistoricalStress.TryGetValue(sibling.CurrentChannel, out var stress))
-                measuredPct = Math.Max(measuredPct, stress.Interference);
+                measuredPct = Math.Max(measuredPct, stress.Interference * graph.InternalWeights[apIndex, j]);
         }
 
         return measuredPct < 0 ? -1 : measuredPct * MeasuredCongestionToLoadScale;
@@ -1475,7 +1518,20 @@ public class ChannelRecommendationService
         var node = graph.Nodes[apIndex];
         var assignedSpan = ChannelSpanHelper.GetChannelSpan(band, assignment[apIndex].Channel, assignment[apIndex].Width);
 
-        if (node.HistoricalStress != null && node.HistoricalStress.Count > 0)
+        // Combine measured history (ground truth) with neighbor-estimated (propagated) stress for
+        // channels this AP never sat on; real measurements win where both have an entry. The
+        // propagated estimates are legitimate here (a soft channel-preference signal) but stay out of
+        // the ground-truth consumers (comfort anchor, measured floor's sibling lookup, confidence).
+        var effectiveStress = node.HistoricalStress;
+        if (node.PropagatedStress is { Count: > 0 })
+        {
+            effectiveStress = new Dictionary<int, (double Utilization, double Interference, double TxRetryPct)>(node.PropagatedStress);
+            if (node.HistoricalStress != null)
+                foreach (var (measuredCh, measuredStress) in node.HistoricalStress)
+                    effectiveStress[measuredCh] = measuredStress;
+        }
+
+        if (effectiveStress != null && effectiveStress.Count > 0)
         {
             // Per-channel historical stress: check each historically stressed channel
             // and apply its penalty if the assigned channel overlaps its span.
@@ -1488,7 +1544,7 @@ public class ChannelRecommendationService
             double utilizationPenalty = 0;
             bool hasDataForAssignedChannel = false;
 
-            foreach (var (histChannel, stress) in node.HistoricalStress)
+            foreach (var (histChannel, stress) in effectiveStress)
             {
                 var histSpan = ChannelSpanHelper.GetChannelSpan(band, histChannel, node.CurrentWidth);
                 if (ChannelSpanHelper.SpansOverlap(assignedSpan, histSpan))
@@ -1890,29 +1946,12 @@ public class ChannelRecommendationService
             }
         }
 
-        // Merge propagated stress into each node's historical stress
+        // Store propagated stress in its OWN field - never merged into measured HistoricalStress.
+        // The stress penalty uses it as a soft estimate for channels this AP never sat on, but the
+        // ground-truth consumers (comfort anchor, measured floor's sibling lookup, observation
+        // confidence) read only the real HistoricalStress, so estimates can't masquerade as measured.
         foreach (var (nodeIdx, channels) in propagated)
-        {
-            var node = graph.Nodes[nodeIdx];
-            node.HistoricalStress ??= new Dictionary<int, (double, double, double)>();
-
-            foreach (var (ch, stress) in channels)
-            {
-                if (node.HistoricalStress.TryGetValue(ch, out var own))
-                {
-                    // AP has its own data for this channel - take the max
-                    node.HistoricalStress[ch] = (
-                        Math.Max(own.Utilization, stress.Util),
-                        Math.Max(own.Interference, stress.Interf),
-                        Math.Max(own.TxRetryPct, stress.TxRetry));
-                }
-                else
-                {
-                    // AP has no data for this channel - add the propagated data
-                    node.HistoricalStress[ch] = (stress.Util, stress.Interf, stress.TxRetry);
-                }
-            }
-        }
+            graph.Nodes[nodeIdx].PropagatedStress = channels;
     }
 
     private static void BuildScanChannelData(
@@ -1932,11 +1971,11 @@ public class ChannelRecommendationService
 
             foreach (var chInfo in scan.Channels)
             {
-                if (chInfo.Utilization.HasValue || chInfo.Interference.HasValue)
+                if (chInfo.Utilization.HasValue || chInfo.NoiseFloor.HasValue)
                 {
                     graph.ScanChannelData[apIndex][chInfo.Channel] = (
                         chInfo.Utilization ?? 0,
-                        chInfo.Interference ?? 0);
+                        chInfo.NoiseFloor);
                 }
             }
         }
@@ -2166,9 +2205,10 @@ public class ChannelRecommendationService
         double penalty = 0;
         for (int i = 0; i < assignment.Length; i++)
         {
-            var ch = assignment[i].Channel;
-            // DFS range: 52-64 (UNII-2), 100-144 (UNII-2C)
-            if ((ch >= 52 && ch <= 64) || (ch >= 100 && ch <= 144))
+            // Span-aware: an 80/160 MHz block whose bonding span includes any DFS sub-channel is a
+            // DFS assignment even when its control channel isn't (e.g. 160 MHz at control ch36 spans
+            // 36-64, covering DFS 52-64). Uses the regulatory DFS set, matching the DFS badge.
+            if (IsDfsAssignment(band, assignment[i].Channel, assignment[i].Width, graph.DfsChannels))
             {
                 // Conservative confidence for now (no DFS event history available)
                 double confidence = 0.7;
@@ -2521,7 +2561,7 @@ public class ChannelRecommendationService
         }
 
         // Scan channel data per AP
-        sb.AppendLine("  Scan channel metrics (utilization/interference):");
+        sb.AppendLine("  Scan channel metrics (utilization / noise floor):");
         for (int i = 0; i < n; i++)
         {
             if (graph.ScanChannelData[i].Count == 0)
@@ -2531,7 +2571,7 @@ public class ChannelRecommendationService
             }
             var metrics = graph.ScanChannelData[i]
                 .OrderBy(kv => kv.Key)
-                .Select(kv => $"ch{kv.Key}=util:{kv.Value.Utilization}%/interf:{kv.Value.Interference}%");
+                .Select(kv => $"ch{kv.Key}=util:{kv.Value.Utilization}%/nf:{(kv.Value.NoiseFloor.HasValue ? kv.Value.NoiseFloor + "dBm" : "n/a")}");
             sb.AppendLine($"    {graph.Nodes[i].Name}: {string.Join(", ", metrics)}");
         }
 
@@ -2599,7 +2639,7 @@ public class ChannelRecommendationService
                 if (graph.ScanChannelData[i].TryGetValue(ch, out var scanData))
                 {
                     scanScore = scanData.Utilization * ScanUtilizationWeight
-                              + scanData.Interference * ScanInterferenceWeight;
+                              + ScanNoiseFloorPenalty(scanData.NoiseFloor);
                 }
 
                 // Historical channel stress penalty

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -134,6 +134,17 @@ public class ChannelRecommendationService
     private const double MaxCrowdingFriction = 3.0;
 
     /// <summary>
+    /// A channel is "measurably comfortable" when the AP's own radio reports time-averaged (1d/7d)
+    /// EXTERNAL-network interference on it (airtime from other people's networks) below this percent.
+    /// The external neighbor scan counts visible-but-idle BSSIDs and can inflate a fine channel into a
+    /// bogus move recommendation; the radio's measured interference is the ground truth for the
+    /// channel it sits on. We gate on interference (not utilization, which is partly the AP's own
+    /// serving traffic that follows it to any channel). Below ~20% external airtime a 2.4/5 GHz
+    /// channel is genuinely usable, so we don't churn off it for the AP's own benefit. Tunable.
+    /// </summary>
+    private const double ComfortableInterferencePct = 20.0;
+
+    /// <summary>
     /// Maximum allowed score degradation for any individual AP in a recommended plan.
     /// 1.5 = AP's score can increase by up to 50%. Prevents sacrificing one AP
     /// too heavily for network-wide improvement.
@@ -292,6 +303,16 @@ public class ChannelRecommendationService
             Dictionary<int, (double, double, double)>? apHistStress = null;
             if (historicalStress != null)
                 historicalStress.TryGetValue(macLower, out apHistStress);
+
+            // Visibility: if an AP has no time-averaged channel metrics, the stress term falls back
+            // to the AP's live (instantaneous) radio stats for its current channel - which a burst
+            // of client activity can inflate. Log it so we can confirm both sites are using the
+            // historical (1d/7d) data wherever it exists.
+            if (apHistStress == null || apHistStress.Count == 0)
+                _logger.LogDebug(
+                    "[ChannelRec] {ApName} {Band}: no historical channel metrics - stress falls back " +
+                    "to live radio stats for the current channel only",
+                    ap.Name, band);
 
             graph.Nodes.Add(new ApNode
             {
@@ -946,6 +967,56 @@ public class ChannelRecommendationService
             } while (revertedAny);
         }
 
+        // Measured-comfort anchor (#1): don't churn an AP off a channel that its own radio measures
+        // as quiet from OUTSIDE networks (low time-averaged external-network interference) unless the
+        // move actually reduces co-channel interference to one of OUR OWN sibling APs. The external
+        // neighbor scan counts visible-but-idle BSSIDs and can inflate an externally-clean channel
+        // into a bogus move; the radio's 1d/7d interference measurement is ground truth for the
+        // channel it sits on. Self-benefit moves off such a channel are reverted; a genuine move
+        // that unsticks two of our APs sharing a channel still goes through.
+        bool comfortReverted;
+        do
+        {
+            comfortReverted = false;
+            for (int i = 0; i < n; i++)
+            {
+                var node = graph.Nodes[i];
+                var rec = plan.Recommendations[i];
+                if (rec.RecommendedChannel == node.CurrentChannel && rec.RecommendedWidth == node.CurrentWidth)
+                    continue;
+                if (node.MeshGroupLeader >= 0 && node.MeshGroupLeader != i) continue;
+                if (!node.ValidChannels.Contains(node.CurrentChannel)) continue;
+                if (!IsCurrentChannelComfortable(graph, band, i)) continue;
+
+                // Interference borne by our OTHER managed APs as recommended vs with this AP reverted
+                // (moving this AP only changes the co-channel interference it imposes on them).
+                var revertTrial = ((int Channel, int Width)[])finalAssignment.Clone();
+                revertTrial[i] = (node.CurrentChannel, node.CurrentWidth);
+                ApplyMeshConstraints(graph, revertTrial);
+
+                double othersWithMove = 0, othersReverted = 0;
+                for (int j = 0; j < n; j++)
+                {
+                    if (j == i) continue;
+                    othersWithMove += ScoreAp(graph, finalAssignment, j, band);
+                    othersReverted += ScoreAp(graph, revertTrial, j, band);
+                }
+                // Keep it put unless the move meaningfully reduces interference to our own sibling APs.
+                if (othersReverted - othersWithMove >= MinApAbsoluteImprovement) continue;
+
+                _logger.LogDebug(
+                    "[ChannelRec] Measured-comfort: keeping {ApName} on ch{Cur} (radio measures it " +
+                    "externally quiet; proposed ch{Rec} didn't help our own APs)",
+                    node.Name, node.CurrentChannel, rec.RecommendedChannel);
+
+                rec.RecommendedChannel = node.CurrentChannel;
+                rec.RecommendedWidth = node.CurrentWidth;
+                finalAssignment[i] = (node.CurrentChannel, node.CurrentWidth);
+                ApplyMeshConstraints(graph, finalAssignment);
+                comfortReverted = true;
+            }
+        } while (comfortReverted);
+
         // Sync mesh children to their leader's final channel. The leader may have moved or
         // been reverted during reconciliation; the child must mirror wherever it landed so the
         // displayed plan is physically valid (a backhaul pair shares one channel) and the
@@ -1204,6 +1275,30 @@ public class ChannelRecommendationService
 
         if (mean <= CrowdingFrictionScoreBaseline) return 1.0;
         return Math.Min(mean / CrowdingFrictionScoreBaseline, MaxCrowdingFriction);
+    }
+
+    /// <summary>
+    /// Whether the AP's current channel is "measurably comfortable" - its own radio reports
+    /// time-averaged (1d/7d) EXTERNAL-network interference on it (airtime used by other people's
+    /// networks) below <see cref="ComfortableInterferencePct"/>. Requires historical metrics (no
+    /// averaged data → not claimed comfortable). Uses interference, not utilization, so the AP's own
+    /// serving traffic (which follows it to any channel) doesn't make a fine channel read as busy.
+    /// The measured-comfort anchor uses this to avoid churning an AP off a genuinely-clean channel
+    /// just because the external neighbor scan sees a lot of idle BSSIDs.
+    /// </summary>
+    private bool IsCurrentChannelComfortable(InterferenceGraph graph, RadioBand band, int apIndex)
+    {
+        var node = graph.Nodes[apIndex];
+        if (node.HistoricalStress == null || node.HistoricalStress.Count == 0) return false;
+
+        var currentSpan = ChannelSpanHelper.GetChannelSpan(band, node.CurrentChannel, node.CurrentWidth);
+        foreach (var (histChannel, stress) in node.HistoricalStress)
+        {
+            var histSpan = ChannelSpanHelper.GetChannelSpan(band, histChannel, node.CurrentWidth);
+            if (ChannelSpanHelper.SpansOverlap(currentSpan, histSpan))
+                return stress.Interference < ComfortableInterferencePct;
+        }
+        return false;
     }
 
     /// <summary>

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -888,27 +888,28 @@ public class ChannelRecommendationServiceTests
     }
 
     [Fact]
-    public void ScoreAssignment_MeasuredFloor_RaisesUnderstated_ButNeverDiscountsKnownBssids()
+    public void ScoreAssignment_MeasuredFloor_RaisesUnderstatedCandidate_ButNeverDiscountsKnownBssids()
     {
-        // Floor: the rogue scan barely registers ch36 (0.5) but the radio measures it genuinely busy
-        // (50% airtime - non-beaconing/hidden congestion), so congestion is RAISED to the measurement.
-        // Not a cap: a channel with many KNOWN BSSIDs (proxy 8.0) that the scan happens to catch idle
-        // (5%) keeps its proxy - detected BSSIDs are real and the scan is only a reference.
+        // The measured floor applies to CANDIDATE channels (a move-to). AP currently on ch36; we
+        // score it on the candidate ch40. Floor: the scan barely registers ch40 (0.5 proxy) but the
+        // radio measures it 50% busy, so congestion is RAISED to the measurement. Not a cap: a
+        // candidate with many KNOWN BSSIDs (proxy 8.0) that scans idle (5%) keeps its proxy -
+        // detected BSSIDs are real and the scan is only a reference.
         var reg = StdUsRegulatory();
         var options = new RecommendationOptions();
 
         InterferenceGraph Build(double externalLoad, int scanUtil)
         {
-            var g = SingleApGraph(36, externalLoad: new() { { 36, externalLoad } }, directlyObserved: new(), reg, options);
-            g.ScanChannelData[0] = new Dictionary<int, (int Utilization, int Interference)> { { 36, (scanUtil, 0) } };
+            var g = SingleApGraph(36, externalLoad: new() { { 40, externalLoad } }, directlyObserved: new(), reg, options);
+            g.ScanChannelData[0] = new Dictionary<int, (int Utilization, int? NoiseFloor)> { { 40, (scanUtil, (int?)null) } };
             return g;
         }
 
-        var understated = _service.ScoreAssignment(Build(0.5, 50), new[] { (36, 80) }, RadioBand.Band5GHz);
-        var knownButIdle = _service.ScoreAssignment(Build(8.0, 5), new[] { (36, 80) }, RadioBand.Band5GHz);
+        var understated = _service.ScoreAssignment(Build(0.5, 50), new[] { (40, 80) }, RadioBand.Band5GHz);
+        var knownButIdle = _service.ScoreAssignment(Build(8.0, 5), new[] { (40, 80) }, RadioBand.Band5GHz);
 
-        understated.Should().BeGreaterThan(6.0,
-            "an under-stated channel is floored up to the measured 50% airtime (~7.5), not left at the 0.5 proxy");
+        understated.Should().BeGreaterThan(2.0,
+            "an under-stated candidate is floored up to the measured 50% airtime (~2.5 at the 0.05 scale), not left at the 0.5 proxy");
         knownButIdle.Should().BeGreaterThan(7.0,
             "the 8.0 of known BSSIDs is kept - a one-shot idle scan never discounts detected APs");
     }

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -915,6 +915,52 @@ public class ChannelRecommendationServiceTests
     }
 
     [Fact]
+    public void MeasuredFloor_AppliesToCandidateNotCurrentChannel_OwnUtilizationBiasRemoved()
+    {
+        // The own-scan utilization floor must NOT inflate the AP's CURRENT channel - its scan radio
+        // also hears its own serving traffic, which follows it anywhere. Same measured 60% util: on a
+        // candidate it floors the score up; on the current channel it does not.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions();
+
+        InterferenceGraph Build(int scanChannel)
+        {
+            var g = SingleApGraph(36, externalLoad: new() { { 36, 0.5 }, { 40, 0.5 } }, directlyObserved: new(), reg, options);
+            g.ScanChannelData[0] = new Dictionary<int, (int Utilization, int? NoiseFloor)> { { scanChannel, (60, (int?)null) } };
+            return g;
+        }
+
+        var current = _service.ScoreAssignment(Build(36), new[] { (36, 80) }, RadioBand.Band5GHz);
+        var candidate = _service.ScoreAssignment(Build(40), new[] { (40, 80) }, RadioBand.Band5GHz);
+
+        candidate.Should().BeGreaterThan(current + 1.5,
+            "60% measured util floors a candidate channel (~3.0) but not the current channel, whose airtime is the AP's own traffic");
+    }
+
+    [Fact]
+    public void ScoreAssignment_NoiseFloor_PenalizesNoisyChannelOverQuietOne()
+    {
+        // Two candidates, identical low utilization, differing only in measured noise floor: the
+        // noisy one (-50 dBm) must score worse than the pristine one (-95 dBm). Utilization alone
+        // would tie them - the noise floor is the RF-energy signal that breaks the tie.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions();
+
+        InterferenceGraph Build(int noiseFloor)
+        {
+            var g = SingleApGraph(36, externalLoad: new() { { 40, 0.5 } }, directlyObserved: new(), reg, options);
+            g.ScanChannelData[0] = new Dictionary<int, (int Utilization, int? NoiseFloor)> { { 40, (5, (int?)noiseFloor) } };
+            return g;
+        }
+
+        var noisy = _service.ScoreAssignment(Build(-50), new[] { (40, 80) }, RadioBand.Band5GHz);
+        var quiet = _service.ScoreAssignment(Build(-95), new[] { (40, 80) }, RadioBand.Band5GHz);
+
+        noisy.Should().BeGreaterThan(quiet + 1.5,
+            "a high noise floor (RF energy that utilization misses) penalizes the channel even at equal airtime");
+    }
+
+    [Fact]
     public void Optimize_MeasuredComfortableCurrentChannel_NotChurnedForOwnBenefit()
     {
         // The reported class: the external neighbor scan inflates a channel that the AP's own radio

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -888,6 +888,32 @@ public class ChannelRecommendationServiceTests
     }
 
     [Fact]
+    public void ScoreAssignment_MeasuredFloor_RaisesUnderstated_ButNeverDiscountsKnownBssids()
+    {
+        // Floor: the rogue scan barely registers ch36 (0.5) but the radio measures it genuinely busy
+        // (50% airtime - non-beaconing/hidden congestion), so congestion is RAISED to the measurement.
+        // Not a cap: a channel with many KNOWN BSSIDs (proxy 8.0) that the scan happens to catch idle
+        // (5%) keeps its proxy - detected BSSIDs are real and the scan is only a reference.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions();
+
+        InterferenceGraph Build(double externalLoad, int scanUtil)
+        {
+            var g = SingleApGraph(36, externalLoad: new() { { 36, externalLoad } }, directlyObserved: new(), reg, options);
+            g.ScanChannelData[0] = new Dictionary<int, (int Utilization, int Interference)> { { 36, (scanUtil, 0) } };
+            return g;
+        }
+
+        var understated = _service.ScoreAssignment(Build(0.5, 50), new[] { (36, 80) }, RadioBand.Band5GHz);
+        var knownButIdle = _service.ScoreAssignment(Build(8.0, 5), new[] { (36, 80) }, RadioBand.Band5GHz);
+
+        understated.Should().BeGreaterThan(6.0,
+            "an under-stated channel is floored up to the measured 50% airtime (~7.5), not left at the 0.5 proxy");
+        knownButIdle.Should().BeGreaterThan(7.0,
+            "the 8.0 of known BSSIDs is kept - a one-shot idle scan never discounts detected APs");
+    }
+
+    [Fact]
     public void Optimize_MeasuredComfortableCurrentChannel_NotChurnedForOwnBenefit()
     {
         // The reported class: the external neighbor scan inflates a channel that the AP's own radio

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -672,11 +672,12 @@ public class ChannelRecommendationServiceTests
         // The reported case: a congested DFS AP, a non-DFS channel that a sibling scanned and found
         // clean (triangulated, not in this AP's own direct set). Triangulation is real evidence, so
         // the clean non-DFS channel should win - the engine must NOT floor or friction it into
-        // losing to a directly-observed-but-occupied DFS channel.
+        // losing to a directly-observed-but-occupied DFS channel. The current channel is loaded
+        // above the per-AP move threshold so the move routes through the normal per-AP path.
         var reg = StdUsRegulatory();
         var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
         var graph = SingleApGraph(52,
-            externalLoad: new() { { 52, 1.5 }, { 36, 0.2 } }, // ch52 directly heard busy; ch36 triangulated clean
+            externalLoad: new() { { 52, 2.5 }, { 36, 0.2 } }, // ch52 directly heard busy; ch36 triangulated clean
             directlyObserved: new() { 52 },                   // ch36 NOT directly observed by this AP
             reg, options);
 
@@ -687,6 +688,96 @@ public class ChannelRecommendationServiceTests
             "a sibling-scanned clean channel is real evidence and beats a directly-observed occupied DFS channel");
         subject.IsCurrentDfsChannel.Should().BeTrue("ch52 (UNII-2) is a DFS channel");
         subject.IsRecommendedDfsChannel.Should().BeFalse("ch36 (UNII-1) is not a DFS channel");
+    }
+
+    [Fact]
+    public void Optimize_AltruisticRelocation_DoesNotMoveHealthyApWhenNoNeighborBenefits()
+    {
+        // The reported Mac case: two APs that share no spectrum (ch36 and ch149). The ch36 AP is
+        // healthy (below the per-AP move threshold) and a cleaner channel exists, but relocating it
+        // only lowers ITS OWN score - it cannot declutter the ch149 neighbor. The altruistic pass
+        // must NOT move it. Before the fix the gate measured total network score, which the mover's
+        // own drop inflates, so it relocated the AP onto an unshared channel for no one's benefit.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "Mover", RadioBand.Band5GHz, 36, width: 20),
+            CreateAp("aa:bb:cc:dd:ee:02", "Bystander", RadioBand.Band5GHz, 149, width: 20)
+        };
+        var graph = _service.BuildInterferenceGraph(aps, RadioBand.Band5GHz, null, null, reg, options);
+        // Mover sits on a lightly-loaded ch36 with a clean, directly-observed non-DFS ch161 nearby.
+        graph.ExternalLoad[0] = new() { { 36, 0.8 } };
+        graph.DirectlyObservedChannels[0] = new() { 36, 161 };
+        // Bystander is healthy on ch149 and overlaps neither ch36 nor the mover's alternatives.
+        graph.ExternalLoad[1] = new() { { 149, 0.3 } };
+        graph.DirectlyObservedChannels[1] = new() { 149 };
+
+        var plan = _service.Optimize(graph, RadioBand.Band5GHz, reg, options);
+
+        var mover = plan.Recommendations.First(r => r.ApMac == "aa:bb:cc:dd:ee:01");
+        mover.RecommendedChannel.Should().Be(36,
+            "a healthy AP must not relocate when the move helps no neighbor - that just chases its own score");
+        mover.IsChanged.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Optimize_AltruisticRelocation_StillMovesHealthyApThatDecluttersCoChannelNeighbor()
+    {
+        // Regression guard for the legitimate altruistic path: a healthy AP that interferes with a
+        // co-channel neighbor SHOULD relocate, because the neighbor genuinely benefits. The neighbor
+        // suffers from the shared channel but stays below the move threshold, so it can't rescue
+        // itself - only the mover relocating helps it. The per-AP path won't move the mover either
+        // (it too is below the threshold); only the altruistic pass can, and it must still fire when
+        // the OTHER AP's score actually drops.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "Mover", RadioBand.Band5GHz, 36, width: 20),
+            CreateAp("aa:bb:cc:dd:ee:02", "Victim", RadioBand.Band5GHz, 36, width: 20)
+        };
+        var graph = _service.BuildInterferenceGraph(aps, RadioBand.Band5GHz, null, null, reg, options);
+        // Asymmetric coupling: the mover blasts the victim (0.5 -> 1.5 co-channel pain, real but
+        // under the 2.0 move threshold so the victim can't escape on its own), but barely hears it
+        // back (0.1 -> 0.3), so the mover stays comfortably healthy on the shared channel.
+        graph.InternalWeights[0, 1] = graph.InternalWeights[1, 0] = 0.5;
+        graph.DirectionalWeights[0, 1] = 0.5; // mover -> victim (strong)
+        graph.DirectionalWeights[1, 0] = 0.1; // victim -> mover (weak)
+        graph.ExternalLoad[0] = new() { { 36, 0.0 }, { 161, 0.0 } };
+        graph.DirectlyObservedChannels[0] = new() { 36, 161 };
+        graph.ExternalLoad[1] = new() { { 36, 0.0 } };
+        graph.DirectlyObservedChannels[1] = new() { 36 };
+
+        var plan = _service.Optimize(graph, RadioBand.Band5GHz, reg, options);
+
+        var mover = plan.Recommendations.First(r => r.ApMac == "aa:bb:cc:dd:ee:01");
+        var victim = plan.Recommendations.First(r => r.ApMac == "aa:bb:cc:dd:ee:02");
+        mover.RecommendedChannel.Should().NotBe(36,
+            "the mover should relocate to declutter the co-channel victim that genuinely benefits");
+        victim.RecommendedChannel.Should().Be(36,
+            "the victim is below the move threshold and is decluttered by the mover leaving, not by moving itself");
+    }
+
+    [Fact]
+    public void ScoreAssignment_BlindApUnobservedChannel_FlooredAgainstTriangulatedLoad()
+    {
+        // Fix for the deceptive 0.0: an AP with NO direct scan data on the band (fully blind, only
+        // triangulated neighbor sightings) used to short-circuit the unobserved penalty to 0, so an
+        // unscanned channel read as a perfect 0.0 and won relocations. It must instead floor against
+        // the AP's known (triangulated) load so a blind channel carries real uncertainty.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var graph = SingleApGraph(36,
+            externalLoad: new() { { 36, 0.2 } }, // a single triangulated sighting; nothing on ch100
+            directlyObserved: new(),             // fully blind - no direct scans on this band
+            reg, options);
+
+        var onUnobserved = _service.ScoreAssignment(graph, new[] { (100, 80) }, RadioBand.Band5GHz);
+
+        onUnobserved.Should().BeGreaterThan(0, "an unobserved channel must never score a deceptive 0.0");
+        onUnobserved.Should().BeApproximately(0.4, 0.05,
+            "a blind AP floors an unscanned channel at its triangulated load (0.2) x the 5 GHz uncertainty multiplier (2.0)");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -844,6 +844,38 @@ public class ChannelRecommendationServiceTests
     }
 
     [Fact]
+    public void ScoreAssignment_WideNeighbor_StepsOnAdjacentChannel()
+    {
+        // A 40 MHz neighbor on 2.4 GHz ch11 spectrally covers ch6 too (span 7-14 vs ch6's 4-8), so
+        // its load must count against a candidate ch6, not just its control channel. A 20 MHz
+        // neighbor on ch11 does not reach ch6. Without width-aware overlap, ch6 reads deceptively
+        // clear right next to an inconsiderate wide neighbor.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions();
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "AP", RadioBand.Band2_4GHz, 11, width: 20)
+        };
+
+        InterferenceGraph Build(int neighborWidth)
+        {
+            var g = _service.BuildInterferenceGraph(aps, RadioBand.Band2_4GHz, null, null, reg, options);
+            g.ExternalLoad[0] = new() { { 11, 1.0 } };
+            g.ExternalLoadWidths[0] = new() { { 11, neighborWidth } };
+            g.DirectlyObservedChannels[0] = new() { 11 };
+            return g;
+        }
+
+        var ch6NextToNarrow = _service.ScoreAssignment(Build(20), new[] { (6, 20) }, RadioBand.Band2_4GHz);
+        var ch6NextToWide = _service.ScoreAssignment(Build(40), new[] { (6, 20) }, RadioBand.Band2_4GHz);
+
+        ch6NextToWide.Should().BeGreaterThan(ch6NextToNarrow,
+            "a 40 MHz neighbor on ch11 steps on ch6, so it must raise ch6's score; a 20 MHz one does not");
+        (ch6NextToWide - ch6NextToNarrow).Should().BeApproximately(1.0, 0.01,
+            "the wide neighbor's full weight reaches ch6 once spectral width is accounted for");
+    }
+
+    [Fact]
     public void Optimize_PinnedAp_ChannelUnchanged()
     {
         var aps = new List<AccessPointSnapshot>

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -888,6 +888,32 @@ public class ChannelRecommendationServiceTests
     }
 
     [Fact]
+    public void Optimize_MeasuredComfortableCurrentChannel_NotChurnedForOwnBenefit()
+    {
+        // The reported class: the external neighbor scan inflates a channel that the AP's own radio
+        // measures as externally quiet (low 1d/7d interference). Without the measured-comfort anchor
+        // the optimizer moves the AP off it; with it, a lone AP (no sibling to declutter) stays put.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var graph = SingleApGraph(52,
+            externalLoad: new() { { 52, 6.0 }, { 36, 0.0 } }, // scan says ch52 busy, ch36 clean
+            directlyObserved: new() { 52, 36 },
+            reg, options);
+        // ...but the radio measured ch52 at only 10% external interference (< the comfortable bar).
+        graph.Nodes[0].HistoricalStress = new Dictionary<int, (double Utilization, double Interference, double TxRetryPct)>
+        {
+            { 52, (15.0, 10.0, 2.0) }
+        };
+
+        var plan = _service.Optimize(graph, RadioBand.Band5GHz, reg, options);
+
+        var subject = plan.Recommendations.Single();
+        subject.RecommendedChannel.Should().Be(52,
+            "the radio measures ch52 as externally quiet, so it must not be churned off it on the neighbor scan alone");
+        subject.IsChanged.Should().BeFalse();
+    }
+
+    [Fact]
     public void Optimize_PinnedAp_ChannelUnchanged()
     {
         var aps = new List<AccessPointSnapshot>

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -901,7 +901,7 @@ public class ChannelRecommendationServiceTests
         InterferenceGraph Build(double externalLoad, int scanUtil)
         {
             var g = SingleApGraph(36, externalLoad: new() { { 40, externalLoad } }, directlyObserved: new(), reg, options);
-            g.ScanChannelData[0] = new Dictionary<int, (int Utilization, int? NoiseFloor)> { { 40, (scanUtil, (int?)null) } };
+            g.ScanChannelData[0] = new Dictionary<(int Channel, int Width), (int Utilization, int? NoiseFloor)> { { (40, 80), (scanUtil, (int?)null) } };
             return g;
         }
 
@@ -926,7 +926,7 @@ public class ChannelRecommendationServiceTests
         InterferenceGraph Build(int scanChannel)
         {
             var g = SingleApGraph(36, externalLoad: new() { { 36, 0.5 }, { 40, 0.5 } }, directlyObserved: new(), reg, options);
-            g.ScanChannelData[0] = new Dictionary<int, (int Utilization, int? NoiseFloor)> { { scanChannel, (60, (int?)null) } };
+            g.ScanChannelData[0] = new Dictionary<(int Channel, int Width), (int Utilization, int? NoiseFloor)> { { (scanChannel, 80), (60, (int?)null) } };
             return g;
         }
 
@@ -949,7 +949,7 @@ public class ChannelRecommendationServiceTests
         InterferenceGraph Build(int noiseFloor)
         {
             var g = SingleApGraph(36, externalLoad: new() { { 40, 0.5 } }, directlyObserved: new(), reg, options);
-            g.ScanChannelData[0] = new Dictionary<int, (int Utilization, int? NoiseFloor)> { { 40, (5, (int?)noiseFloor) } };
+            g.ScanChannelData[0] = new Dictionary<(int Channel, int Width), (int Utilization, int? NoiseFloor)> { { (40, 80), (5, (int?)noiseFloor) } };
             return g;
         }
 
@@ -958,6 +958,33 @@ public class ChannelRecommendationServiceTests
 
         noisy.Should().BeGreaterThan(quiet + 1.5,
             "a high noise floor (RF energy that utilization misses) penalizes the channel even at equal airtime");
+    }
+
+    [Fact]
+    public void ScanOverSpan_AggregatesSubChannels_CatchesNoiseAnywhereInTheSpan()
+    {
+        // A 160 MHz channel's badness can sit on a non-control 20 MHz sub-channel. With BW20 buckets
+        // the scorer must aggregate across the whole span (noise floor = worst sub-channel), not read
+        // only the control bucket - else a clean control channel would hide a noisy bonded sub-channel.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions();
+
+        InterferenceGraph Build(int noisySubChannel)
+        {
+            var g = SingleApGraph(100, externalLoad: new(), directlyObserved: new(), reg, options);
+            var scan = new Dictionary<(int Channel, int Width), (int Utilization, int? NoiseFloor)>();
+            foreach (var ch in new[] { 36, 40, 44, 48, 52, 56, 60, 64 })
+                scan[(ch, 20)] = (0, ch == noisySubChannel ? -50 : -96);
+            g.ScanChannelData[0] = scan;
+            return g;
+        }
+
+        var noisyOnControl = _service.ScoreAssignment(Build(36), new[] { (36, 160) }, RadioBand.Band5GHz);
+        var noisyOnSubChannel = _service.ScoreAssignment(Build(56), new[] { (36, 160) }, RadioBand.Band5GHz);
+
+        noisyOnSubChannel.Should().BeApproximately(noisyOnControl, 0.01,
+            "noise floor aggregates as the worst sub-channel across the 160 span, so it's caught whether on the control channel or a bonded sub-channel");
+        noisyOnSubChannel.Should().BeGreaterThan(1.5, "a -50 dBm sub-channel meaningfully penalizes the 160 MHz channel");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -781,6 +781,69 @@ public class ChannelRecommendationServiceTests
     }
 
     [Fact]
+    public void Optimize_Crowded24GHz_SuppressesMarginalCollisionMove()
+    {
+        // In a saturated 2.4 GHz band, the optimizer was shoving a congested AP onto a neighbor's
+        // channel for a tiny net gain (the unobserved floor over-priced the one empty lane). The
+        // crowding friction must hold it put: a move that nets little once both co-channel victims
+        // are counted isn't worth the churn when the whole band is already busy.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "Living Room", RadioBand.Band2_4GHz, 1, width: 20),
+            CreateAp("aa:bb:cc:dd:ee:02", "Downstairs", RadioBand.Band2_4GHz, 11, width: 20)
+        };
+        var graph = _service.BuildInterferenceGraph(aps, RadioBand.Band2_4GHz, null, null, reg, options);
+        graph.InternalWeights[0, 1] = graph.InternalWeights[1, 0] = 1.0;
+        graph.DirectionalWeights[0, 1] = graph.DirectionalWeights[1, 0] = 1.0;
+        // Every channel is busy. ch1 is the least-bad, so the search wants to pile Downstairs onto
+        // Living Room's ch1 - a co-channel collision whose net site benefit is negative.
+        graph.ExternalLoad[0] = new() { { 1, 4.0 }, { 6, 8.0 }, { 11, 9.0 } };
+        graph.DirectlyObservedChannels[0] = new() { 1, 6, 11 };
+        graph.ExternalLoad[1] = new() { { 1, 4.0 }, { 6, 8.0 }, { 11, 9.0 } };
+        graph.DirectlyObservedChannels[1] = new() { 1, 6, 11 };
+
+        var plan = _service.Optimize(graph, RadioBand.Band2_4GHz, reg, options);
+
+        var downstairs = plan.Recommendations.First(r => r.ApMac == "aa:bb:cc:dd:ee:02");
+        downstairs.RecommendedChannel.Should().Be(11,
+            "in a crowded 2.4 GHz band a move onto a neighbor's channel isn't worth the churn");
+        downstairs.RecommendedChannel.Should().NotBe(1, "it must not be shoved into a co-channel collision");
+    }
+
+    [Fact]
+    public void Optimize_Crowded24GHz_StillSpreadsClusteredAps()
+    {
+        // The crowding friction must not stop us spreading APs apart: three APs piled on ch1 hurt
+        // each other badly, and splitting them across 1/6/11 is a large net win (each resolved
+        // collision frees both victims), so it clears the crowded-band bar with room to spare.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "AP-1", RadioBand.Band2_4GHz, 1, width: 20),
+            CreateAp("aa:bb:cc:dd:ee:02", "AP-2", RadioBand.Band2_4GHz, 1, width: 20),
+            CreateAp("aa:bb:cc:dd:ee:03", "AP-3", RadioBand.Band2_4GHz, 1, width: 20)
+        };
+        var graph = _service.BuildInterferenceGraph(aps, RadioBand.Band2_4GHz, null, null, reg, options);
+        for (int a = 0; a < 3; a++)
+            for (int b = 0; b < 3; b++)
+                if (a != b) { graph.InternalWeights[a, b] = 1.0; graph.DirectionalWeights[a, b] = 1.0; }
+        for (int a = 0; a < 3; a++)
+        {
+            graph.ExternalLoad[a] = new() { { 1, 2.0 }, { 6, 2.0 }, { 11, 2.0 } };
+            graph.DirectlyObservedChannels[a] = new() { 1, 6, 11 };
+        }
+
+        var plan = _service.Optimize(graph, RadioBand.Band2_4GHz, reg, options);
+
+        var channels = plan.Recommendations.Select(r => r.RecommendedChannel).Distinct().ToList();
+        channels.Should().HaveCountGreaterThan(1,
+            "clustered APs must still be spread across 2.4 GHz channels despite the crowding friction");
+    }
+
+    [Fact]
     public void Optimize_PinnedAp_ChannelUnchanged()
     {
         var aps = new List<AccessPointSnapshot>

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -988,6 +988,35 @@ public class ChannelRecommendationServiceTests
     }
 
     [Fact]
+    public void CurrentChannel_ScoredFromSiblingVantage_NotSelfContaminatedReading()
+    {
+        // An AP's own scan of its CURRENT channel is contaminated by traffic that follows it (serving
+        // load / a mesh uplink). The scorer must read the current channel from a clean off-channel
+        // sibling instead. Here Subject (ch36) reads its own ch36 noisy (-40, self), but Sibling (on
+        // ch149, off ch36) sees ch36 clean (-90). Subject's score should reflect the clean -90.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions();
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "Subject", RadioBand.Band5GHz, 36),
+            CreateAp("aa:bb:cc:dd:ee:02", "Sibling", RadioBand.Band5GHz, 149)
+        };
+        var assignment = new[] { (36, 80), (149, 80) };
+
+        var withSiblingView = _service.BuildInterferenceGraph(aps, RadioBand.Band5GHz, null, null, reg, options);
+        withSiblingView.ScanChannelData[0] = new() { { (36, 80), (0, (int?)(-40)) } }; // self-contaminated
+        withSiblingView.ScanChannelData[1] = new() { { (36, 80), (0, (int?)(-90)) } }; // sibling's clean view of ch36
+        var crossVantage = _service.ScoreAssignment(withSiblingView, assignment, RadioBand.Band5GHz);
+
+        var noSiblingView = _service.BuildInterferenceGraph(aps, RadioBand.Band5GHz, null, null, reg, options);
+        noSiblingView.ScanChannelData[0] = new() { { (36, 80), (0, (int?)(-40)) } }; // only the self read exists
+        var selfContaminated = _service.ScoreAssignment(noSiblingView, assignment, RadioBand.Band5GHz);
+
+        crossVantage.Should().BeLessThan(selfContaminated - 1.0,
+            "the current channel is scored from the sibling's clean -90 view; only when no sibling has a view does it fall back to the self-contaminated -40");
+    }
+
+    [Fact]
     public void Optimize_MeasuredComfortableCurrentChannel_NotChurnedForOwnBenefit()
     {
         // The reported class: the external neighbor scan inflates a channel that the AP's own radio

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -1017,6 +1017,32 @@ public class ChannelRecommendationServiceTests
     }
 
     [Fact]
+    public void Optimize_RecommendedNetworkScore_NeverWorseThanCurrent()
+    {
+        // Invariant: the engine must never recommend a plan that RAISES (worsens) the network score.
+        // A per-AP fallback move can help the mover but collide with a sibling and worsen the network
+        // (the Front Yard ch1->ch6 case, where sum-of-ScoreAp called a net-worsening move "positive").
+        // The fallback's network-objective net check + the global guardrail must prevent that.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions();
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "A", RadioBand.Band2_4GHz, 1),
+            CreateAp("aa:bb:cc:dd:ee:02", "B", RadioBand.Band2_4GHz, 6),
+            CreateAp("aa:bb:cc:dd:ee:03", "C", RadioBand.Band2_4GHz, 11)
+        };
+        var graph = _service.BuildInterferenceGraph(aps, RadioBand.Band2_4GHz, null, null, reg, options);
+        graph.ExternalLoad[0] = new() { { 1, 4.0 } };  // A's current channel is loaded - it wants to move
+        graph.ExternalLoad[1] = new() { { 6, 1.0 } };
+        graph.ExternalLoad[2] = new() { { 11, 1.0 } };
+
+        var plan = _service.Optimize(graph, RadioBand.Band2_4GHz, reg, options);
+
+        plan.RecommendedNetworkScore.Should().BeLessThanOrEqualTo(plan.CurrentNetworkScore + 1e-6,
+            "the engine must never recommend a plan that raises the network score");
+    }
+
+    [Fact]
     public void Optimize_MeasuredComfortableCurrentChannel_NotChurnedForOwnBenefit()
     {
         // The reported class: the external neighbor scan inflates a channel that the AP's own radio

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -848,8 +848,8 @@ public class ChannelRecommendationServiceTests
     {
         // A 40 MHz neighbor on 2.4 GHz ch11 spectrally covers ch6 too (span 7-14 vs ch6's 4-8), so
         // its load must count against a candidate ch6, not just its control channel. A 20 MHz
-        // neighbor on ch11 does not reach ch6. Without width-aware overlap, ch6 reads deceptively
-        // clear right next to an inconsiderate wide neighbor.
+        // neighbor on ch11 does not reach ch6. And crucially, 20 MHz neighbors that share the wide
+        // neighbor's control channel must NOT be dragged into spilling along with it.
         var reg = StdUsRegulatory();
         var options = new RecommendationOptions();
         var aps = new List<AccessPointSnapshot>
@@ -857,22 +857,34 @@ public class ChannelRecommendationServiceTests
             CreateAp("aa:bb:cc:dd:ee:01", "AP", RadioBand.Band2_4GHz, 11, width: 20)
         };
 
-        InterferenceGraph Build(int neighborWidth)
+        InterferenceGraph Build(params (int Channel, int Width, double Weight)[] neighbors)
         {
             var g = _service.BuildInterferenceGraph(aps, RadioBand.Band2_4GHz, null, null, reg, options);
-            g.ExternalLoad[0] = new() { { 11, 1.0 } };
-            g.ExternalLoadWidths[0] = new() { { 11, neighborWidth } };
+            g.ExternalLoad[0] = new();
+            g.ExternalNeighbors[0] = new();
+            foreach (var (ch, w, weight) in neighbors)
+            {
+                g.ExternalLoad[0][ch] = g.ExternalLoad[0].GetValueOrDefault(ch) + weight;
+                g.ExternalNeighbors[0][(ch, w)] = g.ExternalNeighbors[0].GetValueOrDefault((ch, w)) + weight;
+            }
             g.DirectlyObservedChannels[0] = new() { 11 };
             return g;
         }
 
-        var ch6NextToNarrow = _service.ScoreAssignment(Build(20), new[] { (6, 20) }, RadioBand.Band2_4GHz);
-        var ch6NextToWide = _service.ScoreAssignment(Build(40), new[] { (6, 20) }, RadioBand.Band2_4GHz);
+        var ch6Narrow = _service.ScoreAssignment(Build((11, 20, 1.0)), new[] { (6, 20) }, RadioBand.Band2_4GHz);
+        var ch6Wide = _service.ScoreAssignment(Build((11, 40, 1.0)), new[] { (6, 20) }, RadioBand.Band2_4GHz);
 
-        ch6NextToWide.Should().BeGreaterThan(ch6NextToNarrow,
-            "a 40 MHz neighbor on ch11 steps on ch6, so it must raise ch6's score; a 20 MHz one does not");
-        (ch6NextToWide - ch6NextToNarrow).Should().BeApproximately(1.0, 0.01,
-            "the wide neighbor's full weight reaches ch6 once spectral width is accounted for");
+        ch6Wide.Should().BeGreaterThan(ch6Narrow,
+            "a 40 MHz neighbor on ch11 steps on ch6, so it raises ch6's score; a 20 MHz one does not");
+        (ch6Wide - ch6Narrow).Should().BeApproximately(1.0, 0.01,
+            "only the wide neighbor's weight reaches ch6 once spectral width is accounted for");
+
+        // The fix for the over-spill: a pile of 20 MHz neighbors on ch11 plus ONE 40 MHz neighbor
+        // there must spill only the 40 MHz neighbor's weight into ch6 - the 20 MHz weight stays put.
+        var ch6Mixed = _service.ScoreAssignment(
+            Build((11, 20, 5.0), (11, 40, 1.0)), new[] { (6, 20) }, RadioBand.Band2_4GHz);
+        (ch6Mixed - ch6Narrow).Should().BeApproximately(1.0, 0.01,
+            "only the 40 MHz neighbor (1.0) spills to ch6; the 5.0 of 20 MHz neighbors on ch11 do not");
     }
 
     [Fact]


### PR DESCRIPTION
Brings measured RF spectrum data into the Channel Optimizer, adds on-demand scanning, and makes the recommendations safer and more honest.

## Measured RF spectrum in scoring

- Recommendations now factor in UniFi's per-channel spectrum scan: actual airtime utilization and RF noise floor, not just a count of neighboring networks. A channel that looks quiet by neighbor count but is noisy in RF (radar, microwaves, other non-Wi-Fi interference, or hidden congestion) is now correctly penalized.
- Width-aware: for wide channels the sub-channel measurements are aggregated the way UniFi's own wide-channel scan does (utilization = mean of the sub-channels, noise floor = worst), so a 160 MHz channel is judged on its whole span, not just its control sub-channel.
- An AP's current channel is scored from a neighboring AP's vantage where the AP's own reading is self-contaminated by traffic that follows it to any channel (for example a mesh uplink carrying a camera feed), so it isn't penalized for load it can't escape by moving.

## On-demand RF scans

- When a radio has no recent spectrum measurement, the recommendation page shows a prompt to run a quick scan on exactly those radios, then re-runs the recommendation on the fresh data.
- Scans run at each radio's current bandwidth (so the radio doesn't reconfigure), one band at a time per AP and in parallel across APs. Mesh APs are excluded because they can't scan without dropping their wireless uplink.
- The prompt's wording adapts to each AP's scan hardware (APs with a dedicated scan radio measure with no client impact; the rest get an honest heads-up), and the neighbor-scan reliability disclaimer hides itself once every scannable radio has a measurement.

## Safer, more honest recommendations

- The engine never recommends a channel plan that would raise (worsen) the overall network score, and per-AP fallback moves are judged on the real network objective rather than a per-AP proxy, so a move that helps one AP but collides with a neighbor is not suggested.
- Measured channel occupancy is trusted over the neighbor scan (which can misreport channels), and a wide neighbor's full spectral footprint is counted against every channel it overlaps.
- Refinements to altruistic relocation (must actually help neighbors), DFS handling (span-aware penalty, badge, and friction), and 2.4 GHz churn resistance.

## UI

- EIRP power bar in the Channel Analysis Radios table, matching the Power and Coverage view.
- Clearer "How This Works" explainer and data-quality notices that reflect what each recommendation is actually based on.

## Testing

- 0 build warnings; full test suite passing, including new coverage for the noise-floor scoring, width-aware span aggregation, cross-vantage current-channel reads, and the never-worsen-the-network guardrail.
