### PR TITLE
Channel Optimizer: clearer scan permission errors and tighter scan UX

### DIFF
--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -584,7 +584,8 @@ public class UniFiApiClient : IDisposable
     /// </summary>
     private async Task<T?> ExecuteApiCallAsync<T>(
         Func<Task<HttpResponseMessage>> apiCall,
-        CancellationToken cancellationToken = default) where T : class
+        CancellationToken cancellationToken = default,
+        bool throwOnPermissionError = false) where T : class
     {
         if (!await EnsureAuthenticatedAsync(cancellationToken))
         {
@@ -595,6 +596,18 @@ public class UniFiApiClient : IDisposable
         return await _retryPolicy.ExecuteAsync(async () =>
         {
             var response = await apiCall();
+
+            // A 403 with api.err.NoPermission means the credentials are valid but lack the required
+            // access level - re-authenticating won't fix it. Surface it (for mutative callers that
+            // opt in) instead of looping through a pointless re-auth that just spams the log.
+            if (throwOnPermissionError && response.StatusCode == HttpStatusCode.Forbidden)
+            {
+                var body = await response.Content.ReadAsStringAsync(cancellationToken);
+                if (body.Contains("api.err.NoPermission", StringComparison.OrdinalIgnoreCase))
+                    throw new UniFiPermissionException(
+                        "The UniFi account lacks permission to run RF spectrum scans. In UniFi Network, " +
+                        "give this account (or API key) the Network: Site Admin role, then try again.");
+            }
 
             // Handle authentication failures
             if (response.StatusCode == HttpStatusCode.Unauthorized ||
@@ -2458,9 +2471,12 @@ public class UniFiApiClient : IDisposable
         };
         var content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
 
+        // Opt into permission-error surfacing: this is a mutative call, so a NoPermission 403 is a
+        // real, actionable failure (insufficient role) rather than a transient/auth-expiry hiccup.
         var response = await ExecuteApiCallAsync<UniFiApiResponse<object>>(
             () => _httpClient!.PostAsync(BuildApiPath("cmd/devmgr"), content, cancellationToken),
-            cancellationToken);
+            cancellationToken,
+            throwOnPermissionError: true);
 
         if (response?.Meta.Rc == "ok")
         {

--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -606,7 +606,7 @@ public class UniFiApiClient : IDisposable
                 if (body.Contains("api.err.NoPermission", StringComparison.OrdinalIgnoreCase))
                     throw new UniFiPermissionException(
                         "The UniFi account lacks permission to run RF spectrum scans. In UniFi Network, " +
-                        "give this account (or API key) the Network: Site Admin role, then try again.");
+                        "give this account the Network: Site Admin role, then try again.");
             }
 
             // Handle authentication failures

--- a/src/NetworkOptimizer.UniFi/UniFiPermissionException.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiPermissionException.cs
@@ -1,0 +1,15 @@
+namespace NetworkOptimizer.UniFi;
+
+/// <summary>
+/// Thrown when the UniFi Console rejects a request with <c>api.err.NoPermission</c> (HTTP 403) -
+/// the credentials are valid but the account/API key lacks the required access level. Re-authenticating
+/// does not help, so callers that make mutative requests (e.g. triggering an RF spectrum scan) can
+/// catch this and surface an actionable message instead of a generic failure.
+/// </summary>
+public class UniFiPermissionException : Exception
+{
+    public UniFiPermissionException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -191,7 +191,6 @@
                             <li>Copy the generated API key and paste it above - UniFi Network will only display it once, so make sure to copy it before dismissing the dialog</li>
                         </ol>
                         <p><strong>Note:</strong> API keys require a UniFi OS console (UDM, UCG, UDR, or UniFi OS Server). Legacy standalone Network Server installations without UniFi OS must use Local Account authentication.</p>
-                        <p>The key inherits the role of the account that creates it. To run the Channel Optimizer's on-demand RF spectrum scans, create it under an account with the Network: Site Admin role.</p>
                     </div>
                 </details>
             }

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -191,6 +191,7 @@
                             <li>Copy the generated API key and paste it above - UniFi Network will only display it once, so make sure to copy it before dismissing the dialog</li>
                         </ol>
                         <p><strong>Note:</strong> API keys require a UniFi OS console (UDM, UCG, UDR, or UniFi OS Server). Legacy standalone Network Server installations without UniFi OS must use Local Account authentication.</p>
+                        <p>The key inherits the role of the account that creates it. To run the Channel Optimizer's on-demand RF spectrum scans, create it under an account with the Network: Site Admin role.</p>
                     </div>
                 </details>
             }
@@ -218,7 +219,7 @@
                             <li>Uncheck <strong>Use a Predefined Role</strong></li>
                             <li>Set permissions:
                                 <ul>
-                                    <li><strong>Network:</strong> View Only</li>
+                                    <li><strong>Network:</strong> Site Admin</li>
                                     <li><strong>Protect:</strong> View Only</li>
                                     <li><strong>User &amp; Account Management:</strong> None</li>
                                 </ul>
@@ -226,6 +227,7 @@
                             <li>Set a secure password and save</li>
                         </ol>
                         <p>Use this username and password in the fields above.</p>
+                        <p><strong>Why Site Admin?</strong> Network has no granular role between View Only and Site Admin, and the Channel Optimizer's on-demand RF spectrum scans need write access. View Only works for everything else, so pick it instead if you don't plan to run scans.</p>
                     </div>
                 </details>
             }

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -140,7 +140,7 @@
                             @if (_scanningGaps)
                             {
                                 <span class="spinner spinner-sm"></span>
-                                <span>Scanning…</span>
+                                <span>@ScanProgressLabel()</span>
                             }
                             else
                             {
@@ -927,8 +927,17 @@
     // per-channel spectrum measurement. A quick-scan fills them.
     private List<SpectrumScanGap> _scanGaps = new();
     private bool _scanningGaps;
+    // Progress for the running gap scan: bands started so far, and the total to scan. Drives the
+    // "Scanning… X/N bands" label so a multi-minute serial scan reads as working, not hung.
+    private int _scanCompletedBands;
+    private int _scanTotalBands;
     // Set when a scan fails because the UniFi account lacks the Site Admin role.
     private string? _scanError;
+
+    private string ScanProgressLabel() =>
+        _scanTotalBands > 1
+            ? $"Scanning… {Math.Clamp(_scanCompletedBands, 1, _scanTotalBands)}/{_scanTotalBands} bands"
+            : "Scanning…";
 
     // Disruption note tailored to the gapped APs' scan hardware: an AP with a dedicated scan radio
     // measures without touching its serving radios (no client impact); without one, scanning briefly
@@ -963,11 +972,20 @@
 
         _scanningGaps = true;
         _scanError = null;
+        _scanCompletedBands = 0;
+        _scanTotalBands = _scanGaps.Count; // one band scan per gapped (AP, band)
         StateHasChanged();
         try
         {
             var targets = _scanGaps.Select(g => (g.ApMac, g.BandCode)).ToList();
-            await WiFiService.RunQuickScansAsync(targets);
+            // Report progress on the Blazor circuit's context; Math.Max keeps the count monotonic
+            // even if concurrent APs report band starts out of order.
+            var progress = new Progress<int>(n =>
+            {
+                _scanCompletedBands = Math.Max(_scanCompletedBands, n);
+                InvokeAsync(StateHasChanged);
+            });
+            await WiFiService.RunQuickScansAsync(targets, progress);
 
             // Re-run recommendations on the fresh spectrum data, then re-check what's still missing.
             var options = new RecommendationOptions { DfsPreference = _dfsPreference };

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -132,18 +132,15 @@
                 {
                     <div class="alert-info scan-gap-banner">
                         <div class="scan-gap-text">
-                            <strong>@_scanGaps.Count @(_scanGaps.Count == 1 ? "radio hasn't" : "radios haven't") been scanned recently.</strong>
-                            Without a measurement the optimizer infers those channels from neighboring
-                            networks instead of seeing them directly. A quick scan reads the real airtime
-                            and noise floor on each channel, so the recommendations reflect what's actually
-                            on the air - not a guess. @ScanDisruptionNote()
+                            <strong>@_scanGaps.Count @(_scanGaps.Count == 1 ? "radio needs" : "radios need") a scan.</strong>
+                            Their channels are estimated from nearby networks, not measured. @ScanDisruptionNote()
                         </div>
                         <button class="btn btn-primary btn-sm" @onclick="RunGapScans" disabled="@_scanningGaps"
-                                data-tooltip="Runs a quick RF scan to measure these channels">
+                                data-tooltip="Runs a quick RF scan to measure the real airtime and noise floor on these channels, so the recommendations reflect what's actually on the air instead of a guess.">
                             @if (_scanningGaps)
                             {
                                 <span class="spinner spinner-sm"></span>
-                                <span>Scanning @_scanGaps.Count @(_scanGaps.Count == 1 ? "radio" : "radios")…</span>
+                                <span>Scanning…</span>
                             }
                             else
                             {
@@ -151,6 +148,10 @@
                             }
                         </button>
                     </div>
+                    @if (_scanError is not null)
+                    {
+                        <div class="alert-danger scan-error-banner">@_scanError</div>
+                    }
                 }
 
                 @if (_channelPlan is { } plan)
@@ -926,6 +927,8 @@
     // per-channel spectrum measurement. A quick-scan fills them.
     private List<SpectrumScanGap> _scanGaps = new();
     private bool _scanningGaps;
+    // Set when a scan fails because the UniFi account lacks the Site Admin role.
+    private string? _scanError;
 
     // Disruption note tailored to the gapped APs' scan hardware: an AP with a dedicated scan radio
     // measures without touching its serving radios (no client impact); without one, scanning briefly
@@ -935,17 +938,11 @@
         var clean = _scanGaps.Count(g => g.HasDedicatedScanRadio);
         var disruptive = _scanGaps.Count - clean;
         var meshNote = _scanGaps.Any(g => g.IsMeshParent && !g.HasDedicatedScanRadio)
-            ? ", and may briefly drop devices meshed through an AP" : "";
+            ? " (and devices meshed through an AP)" : "";
 
         if (disruptive == 0)
-            return "These scan on a dedicated radio, so running won't disrupt clients.";
-        if (clean == 0)
-            return $"Heads up: scanning briefly steps each radio off its channel - clients stay connected, "
-                 + $"but real-time traffic (video calls, gaming) can hiccup for a moment{meshNote}. "
-                 + "Much lighter than a full scan, but best run during low-usage times.";
-        return $"{clean} of these scan on a dedicated radio with no client impact; the other {disruptive} "
-             + $"briefly step their serving radio off-channel, so real-time traffic can hiccup{meshNote} - "
-             + "best run during low-usage times.";
+            return "Won't disrupt clients.";
+        return $"May briefly interrupt {(clean == 0 ? "clients" : "some clients")}{meshNote}; best at quiet times.";
     }
 
     private async Task LoadScanGapsAsync()
@@ -965,6 +962,7 @@
         if (_scanningGaps || _scanGaps.Count == 0) return;
 
         _scanningGaps = true;
+        _scanError = null;
         StateHasChanged();
         try
         {
@@ -975,6 +973,10 @@
             var options = new RecommendationOptions { DfsPreference = _dfsPreference };
             _channelPlans = await WiFiService.GetAllChannelRecommendationsAsync(options);
             await LoadScanGapsAsync();
+        }
+        catch (ScanPermissionException ex)
+        {
+            _scanError = ex.Message;
         }
         finally
         {

--- a/src/NetworkOptimizer.Web/Services/ScanPermissionException.cs
+++ b/src/NetworkOptimizer.Web/Services/ScanPermissionException.cs
@@ -1,0 +1,14 @@
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Thrown by <see cref="WiFiOptimizerService.RunQuickScansAsync"/> when the UniFi account lacks the
+/// permission needed to trigger an RF spectrum scan. Carries a user-facing message the UI can show
+/// directly, keeping the underlying UniFi exception type out of the Blazor components.
+/// </summary>
+public class ScanPermissionException : Exception
+{
+    public ScanPermissionException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -676,7 +676,16 @@ public class WiFiOptimizerService
             .Select(g => ScanApBandsSequentiallyAsync(
                 provider, g.Key, g.Select(t => t.BandCode).Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
                 widthByApBand, cancellationToken));
-        await Task.WhenAll(perApScans);
+        try
+        {
+            await Task.WhenAll(perApScans);
+        }
+        catch (UniFiPermissionException ex)
+        {
+            // Insufficient UniFi role - re-throw as a UI-facing error so the user knows to fix
+            // permissions rather than retry. Nothing scanned, so the cache stays valid.
+            throw new ScanPermissionException(ex.Message);
+        }
 
         // Fresh scans are in - drop the cached snapshot so the next fetch re-reads the spectrum data.
         _cachedScanResults = null;
@@ -709,6 +718,12 @@ public class WiFiOptimizerService
                         apMac, QuickScanPerBandTimeoutSeconds);
                     break;
                 }
+            }
+            catch (UniFiPermissionException)
+            {
+                // Insufficient role affects every scan, not just this band - stop and let the caller
+                // surface it rather than swallowing it and hammering the controller with more 403s.
+                throw;
             }
             catch (Exception ex)
             {

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -655,6 +655,7 @@ public class WiFiOptimizerService
     /// </summary>
     public async Task RunQuickScansAsync(
         IEnumerable<(string ApMac, string BandCode)> targets,
+        IProgress<int>? progress = null,
         CancellationToken cancellationToken = default)
     {
         var list = targets.ToList();
@@ -671,11 +672,22 @@ public class WiFiOptimizerService
                 if (radio.ChannelWidth is int w)
                     widthByApBand[(ap.Mac, radio.Band.ToUniFiCode())] = w;
 
+        // Report progress as each band scan STARTS (bands run sequentially within an AP but APs run
+        // concurrently, so the counter is shared and bumped atomically). Counting at start - not
+        // completion - means the UI shows "scanning band N" while that band is actually in flight,
+        // and never sits at 0. Total = list.Count (one scan per gapped (AP, band) target).
+        var bandsStarted = 0;
+        void ReportBandStart()
+        {
+            if (progress != null)
+                progress.Report(Interlocked.Increment(ref bandsStarted));
+        }
+
         var perApScans = list
             .GroupBy(t => t.ApMac, StringComparer.OrdinalIgnoreCase)
             .Select(g => ScanApBandsSequentiallyAsync(
                 provider, g.Key, g.Select(t => t.BandCode).Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
-                widthByApBand, cancellationToken));
+                widthByApBand, ReportBandStart, cancellationToken));
         try
         {
             await Task.WhenAll(perApScans);
@@ -698,10 +710,12 @@ public class WiFiOptimizerService
     /// </summary>
     private async Task ScanApBandsSequentiallyAsync(
         UniFiLiveDataProvider provider, string apMac, List<string> bandCodes,
-        IReadOnlyDictionary<(string Mac, string BandCode), int> widthByApBand, CancellationToken cancellationToken)
+        IReadOnlyDictionary<(string Mac, string BandCode), int> widthByApBand,
+        Action? onBandStart, CancellationToken cancellationToken)
     {
         foreach (var bandCode in bandCodes)
         {
+            onBandStart?.Invoke();
             // Scan at the radio's current width (fall back to 20 MHz if unknown).
             var bandwidthMhz = widthByApBand.TryGetValue((apMac, bandCode), out var w) ? w : 20;
             try

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -3731,6 +3731,17 @@ select.form-control {
     flex-shrink: 0;
 }
 
+.scan-error-banner {
+    margin-bottom: 1rem;
+    font-size: 0.85rem;
+}
+
+@media (max-width: 768px) {
+    .scan-gap-banner .btn {
+        width: 100%;
+    }
+}
+
 .banner-icon {
     font-size: 1.5rem;
     background: rgba(255, 255, 255, 0.2);

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -147,6 +147,17 @@ public class ChannelRecommendationService
     private const double MaxCrowdingFriction = 3.0;
 
     /// <summary>
+    /// Minimum whole-site improvement (as a percent of the current network score) required before ANY
+    /// 2.4 GHz channel move is recommended. 2.4 GHz is low-value and inherently congested - three
+    /// usable channels, legacy and IoT clients - so a marginal site gain just shuffles interference
+    /// between APs and isn't worth the churn. The other bands recommend on any net improvement (still
+    /// subject to the per-AP move gates); only 2.4 GHz must clear this higher whole-site bar. Applied
+    /// as a final guardrail after all optimization passes, and skipped when any AP sits on an invalid
+    /// channel (those always move to 1/6/11 regardless). Tunable.
+    /// </summary>
+    private const double MinBand24NetworkImprovementPercent = 8.0;
+
+    /// <summary>
     /// A channel is "measurably comfortable" when the AP's own radio reports time-averaged (1d/7d)
     /// EXTERNAL-network interference on it (airtime from other people's networks) below this percent.
     /// The external neighbor scan counts visible-but-idle BSSIDs and can inflate a fine channel into a
@@ -1067,12 +1078,23 @@ public class ChannelRecommendationService
         // (per-AP fallback, altruistic) judge benefit per AP, and a per-AP proxy can disagree with the
         // network objective; if the final plan isn't a net improvement over current, drop every move
         // and keep the current assignment. (Higher ScoreAssignment = worse.)
+        //
+        // 2.4 GHz additionally requires the whole-site gain to clear MinBand24NetworkImprovementPercent:
+        // the band is low-value and congested, so a marginal site improvement (e.g. a 3% drop that just
+        // moves one AP onto a neighbor's channel) isn't worth the churn. Skipped when an AP is on an
+        // invalid channel - those must always move to 1/6/11 no matter how small the site gain looks.
         var finalNetworkScore = ScoreAssignment(graph, finalAssignment, band);
-        if (finalNetworkScore > currentNetworkScore)
+        var networkImprovementPct = currentNetworkScore > 0
+            ? (currentNetworkScore - finalNetworkScore) / currentNetworkScore * 100
+            : 0;
+        var band24GainTooSmall = band == RadioBand.Band2_4GHz && !hasInvalidChannelAps &&
+                                 networkImprovementPct < MinBand24NetworkImprovementPercent;
+        if (finalNetworkScore > currentNetworkScore || band24GainTooSmall)
         {
             _logger.LogDebug(
-                "[ChannelRec] {Band}: final plan network {Final:F3} is worse than current {Current:F3} - reverting all moves",
-                band, finalNetworkScore, currentNetworkScore);
+                "[ChannelRec] {Band}: final plan network {Final:F3} vs current {Current:F3} " +
+                "({Pct:F1}% improvement) doesn't justify moves - reverting all",
+                band, finalNetworkScore, currentNetworkScore, networkImprovementPct);
             for (int i = 0; i < n; i++)
             {
                 var node = graph.Nodes[i];


### PR DESCRIPTION
Addresses the follow-ups from #942, plus a Channel Optimizer recommendation tweak.

## What changed

**Scan permission errors are now surfaced, not swallowed**
Triggering an RF spectrum scan is the first semi-mutative call the app makes to UniFi Network, so a read-only account gets a 403 (`api.err.NoPermission`). Previously that failed silently after a misleading re-auth cycle that spammed the log. Now the scan trigger detects the permission error, skips the pointless re-auth, and the Channel Optimizer shows an actionable message telling the user to grant the account the Network: Site Admin role.

**Trimmed the scan-gap banner**
The banner explaining why a radio needs a scan was far too wordy, especially on mobile. It's now a short headline plus one line, with the detailed "why" moved into the button's tooltip and the client-disruption note condensed. The scan button also goes full-width on narrow screens for a cleaner tap target.

**Per-band progress on the scan button**
A gap scan runs each AP's bands one at a time (~1 minute each), so a multi-band scan takes several minutes with nothing but a spinner - it reads as hung. The button now shows live progress ("Scanning… 2/3 bands") as each band starts, so a long run clearly reads as working.

**Updated the Console connection guidance in Settings**
The restricted-setup instructions recommended Network: View Only, which can't run scans. They now recommend Network: Site Admin with a short note explaining that View Only still covers everything except on-demand RF spectrum scans (Network has no granular role in between).

**Higher bar for 2.4 GHz channel moves**
2.4 GHz is low-value and inherently congested (three usable channels, legacy and IoT clients), so a marginal site improvement just shuffles interference between APs and isn't worth the churn. 2.4 GHz now requires the whole-site score to improve by at least 8% before any move is recommended; a 3% gain that just moves one AP onto a neighbor's channel is held instead. Other bands are unchanged (they recommend on any net improvement, still subject to the per-AP move gates). Skipped when an AP is on an invalid channel, which always moves to 1/6/11.

## Why

Users on least-privilege accounts hit a dead end with no explanation when running a scan, and the guidance pointed them at a role that can't do it. This makes the requirement clear both before (Settings) and after (the error) they hit it, cuts the wall of text around the scan button, and gives honest feedback during the multi-minute scan. The 2.4 GHz change stops the optimizer from recommending churn that barely moves the needle on the band where a channel shuffle is close to zero-sum.
