### PR TITLE
ISP Health: faster computation on lower-power hardware, plus two fixes

### DIFF
--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -2161,39 +2161,29 @@ join.inner(left: loss, right: load, on: (l, r) => l._time == r._time, as: (l, r)
     }
 
     /// <summary>
-    /// Mean loss_percent pooled across every enabled target of one type over a window, weighting
-    /// all their samples equally - the same per-sample mean ISP Health's loss factors use. The loss
-    /// event finders report a single target's PEAK-loss minute (to center the chart on the worst
-    /// point); this gives the type-wide average over the coalesced event window, so the Investigate
-    /// highlight reflects what the whole tier did - close to the pooled figure ISP Health scores -
-    /// rather than the single worst target. Null when no loss samples fall in the window.
+    /// Pooled per-sample mean loss_percent across an explicit set of targets over a window - the same
+    /// per-sample mean ISP Health's loss factors compute. The caller passes the exact loss-pool target
+    /// IDs (see <c>IspHealthService.GetLossPoolTargetIdsAsync</c>) so the Investigate highlight reads
+    /// the very pool the score is graded on. The loss event finders report a single target's PEAK-loss
+    /// minute to center the chart on the worst point; this is the pooled average over the coalesced
+    /// event window instead. Null when the set is empty or no loss samples fall in the window.
     /// </summary>
-    public async Task<double?> QueryMeanLossByTargetTypeAsync(
-        MonitoringTargetType targetType,
+    public async Task<double?> QueryMeanLossAcrossTargetsAsync(
+        IReadOnlyCollection<string> targetIds,
         DateTime from,
         DateTime to,
-        IReadOnlyCollection<string>? enabledTargetIds = null,
         CancellationToken ct = default)
     {
         if (!IsConfigured) await ReconfigureAsync(ct);
-        if (!IsConfigured) return null;
-        var typeTag = targetType.ToString().ToLowerInvariant();
-        var typeFilter = targetType == MonitoringTargetType.InternetService
-            ? @"r.target_type == ""internetservice"" or r.target_type == ""wan"""
-            : $@"r.target_type == ""{typeTag}""";
-        var targetFilter = "";
-        if (enabledTargetIds != null && enabledTargetIds.Count > 0)
-        {
-            var conditions = string.Join(" or ", enabledTargetIds.Select(id => $@"r.target_id == ""{SanitizeFluxString(id)}"""));
-            targetFilter = $"\n  |> filter(fn: (r) => {conditions})";
-        }
+        if (!IsConfigured || targetIds.Count == 0) return null;
+        var idFilter = string.Join(" or ", targetIds.Select(id => $@"r.target_id == ""{SanitizeFluxString(id)}"""));
         // group() collapses every target's per-sample loss into one table so mean() is the pooled
-        // average across the whole tier, not per target.
+        // average across the whole set, not per target.
         var flux = $@"
 from(bucket: ""{_bucket}"")
   |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
   |> filter(fn: (r) => r._measurement == ""latency"")
-  |> filter(fn: (r) => {typeFilter}){targetFilter}
+  |> filter(fn: (r) => {idFilter})
   |> filter(fn: (r) => r._field == ""loss_percent"")
   |> group()
   |> mean()

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -1238,6 +1238,63 @@ from(bucket: ""{_bucket}"")
     }
 
     /// <summary>
+    /// Two-resolution variant of <see cref="QueryLatencyDetailByTargetTypeAsync"/> that reads RTT,
+    /// max RTT, and jitter at a COARSE aggregate while reading loss at a FINE aggregate, then merges
+    /// the two grids per target. RTT/jitter only feed the 15-min congestion and 30-min step buckets
+    /// and whole-window per-ASN statistics, so their fine-resolution volume is wasted; loss must stay
+    /// fine because outage detection buckets it at 15-30 s. On the merged series, RTT points carry a
+    /// null loss and loss points carry a null RTT: every consumer filters by the field it reads
+    /// (RttAvgMs.HasValue for congestion/step, LossPercent.HasValue for outage / the loss pool), so
+    /// the disjoint timestamps are consumed cleanly. rtt_max_ms rides with rtt_avg_ms and jitter_ms
+    /// on the same coarse row because <see cref="LatencySample.EffectiveJitterMs"/> derives jitter
+    /// from (rtt_max - rtt_avg) when jitter_ms is absent. Cuts the transit/internet payload the app
+    /// deserializes without touching any loss-based detection. Used for Transit and InternetService;
+    /// AccessIsp stays fully fine (its RTT drives the loaded-latency delta).
+    /// </summary>
+    public async Task<Dictionary<string, List<LatencySeriesPoint>>> QueryLatencyDetailTieredByTargetTypeAsync(
+        MonitoringTargetType targetType,
+        DateTime from,
+        DateTime to,
+        TimeSpan coarseAggregate,
+        TimeSpan fineAggregate,
+        CancellationToken ct = default)
+    {
+        if (!IsConfigured) await ReconfigureAsync(ct);
+        if (!IsConfigured) return new Dictionary<string, List<LatencySeriesPoint>>();
+        var typeTag = targetType.ToString().ToLowerInvariant();
+        var typeFilter = targetType == MonitoringTargetType.InternetService
+            ? @"r.target_type == ""internetservice"" or r.target_type == ""wan"""
+            : $@"r.target_type == ""{typeTag}""";
+
+        string BuildFlux(string fieldFilter, TimeSpan window) => $@"
+from(bucket: ""{_bucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""latency"")
+  |> filter(fn: (r) => {typeFilter})
+  |> filter(fn: (r) => {fieldFilter})
+  |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
+  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
+";
+        var coarseTask = QueryRawAsync(
+            BuildFlux(@"r._field == ""rtt_avg_ms"" or r._field == ""rtt_max_ms"" or r._field == ""jitter_ms""", coarseAggregate), ct);
+        var fineTask = QueryRawAsync(
+            BuildFlux(@"r._field == ""loss_percent""", fineAggregate), ct);
+        await Task.WhenAll(coarseTask, fineTask);
+
+        var merged = ParseLatencyDetailCsv(await coarseTask);
+        foreach (var (target, lossPoints) in ParseLatencyDetailCsv(await fineTask))
+        {
+            if (merged.TryGetValue(target, out var list)) list.AddRange(lossPoints);
+            else merged[target] = lossPoints;
+        }
+        // The two grids interleave (coarse RTT rows and fine loss rows at different instants), so
+        // re-sort each target by time - the detectors and per-ASN grading assume chronological order.
+        foreach (var list in merged.Values)
+            list.Sort((a, b) => a.Time.CompareTo(b.Time));
+        return merged;
+    }
+
+    /// <summary>
     /// Per-window rtt/jitter/loss detail for a single target by its id - used to pull just the LAN
     /// gateway's loss for outage scoping without loading every fabric device's series.
     /// </summary>

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -1232,6 +1232,7 @@ from(bucket: ""{_bucket}"")
   |> filter(fn: (r) => {typeFilter})
   |> filter(fn: (r) => r._field == ""rtt_avg_ms"" or r._field == ""rtt_max_ms"" or r._field == ""jitter_ms"" or r._field == ""loss_percent"")
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
+  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
         return ParseLatencyDetailCsv(await QueryRawAsync(flux, ct));
     }
@@ -1272,6 +1273,7 @@ from(bucket: ""{_bucket}"")
   |> filter(fn: (r) => {typeFilter})
   |> filter(fn: (r) => {fieldFilter})
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
+  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
         var coarseTask = QueryRawAsync(
             BuildFlux(@"r._field == ""rtt_avg_ms"" or r._field == ""rtt_max_ms"" or r._field == ""jitter_ms""", coarseAggregate), ct);
@@ -1313,6 +1315,7 @@ from(bucket: ""{_bucket}"")
   |> filter(fn: (r) => r.target_id == ""{targetId}"")
   |> filter(fn: (r) => r._field == ""rtt_avg_ms"" or r._field == ""rtt_max_ms"" or r._field == ""jitter_ms"" or r._field == ""loss_percent"")
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
+  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
         var byTarget = ParseLatencyDetailCsv(await QueryRawAsync(flux, ct));
         // Single target filter, but flatten defensively in case the pivot emits more than one key.
@@ -1910,34 +1913,24 @@ from(bucket: ""{_longtermBucket}"")
         }
     }
 
-    private struct LatencyPointBuilder
-    {
-        public DateTime Time;
-        public double? Rtt, RttMax, Jitter, Loss;
-    }
-
     /// <summary>
-    /// Parses the annotated-CSV result of an UN-PIVOTED latency-detail query (long format: one row per
-    /// (target_id, _field, _time), columns _time, _value, _field, target_id) into per-target point
-    /// lists. Accumulates each field onto a per-(target, time) builder and emits sorted points - i.e.
-    /// it does client-side what a Flux <c>pivot()</c> would do on the server, which was ~half the read
-    /// cost (measured), while producing identical points. Span-based: annotation rows (#...) are skipped
-    /// and the column header is re-read whenever Flux emits one, so column order is never assumed.
-    /// Tag/field values in this measurement never contain commas, so a plain comma split is safe.
+    /// Parses the annotated-CSV result of a latency-detail pivot query (columns target_id, _time,
+    /// rtt_avg_ms, rtt_max_ms, jitter_ms, loss_percent) directly into per-target point lists. Span-
+    /// based: the only allocations are the per-target list, the distinct target_id keys, and the
+    /// points themselves - no FluxRecord, no boxing, no intermediate copy. Annotation rows (#...) are
+    /// skipped and the column header is re-read whenever Flux emits one (default annotated dialect),
+    /// so column order is never assumed. Tag/field values in this measurement never contain commas,
+    /// so a plain comma split is safe.
     /// </summary>
     internal static Dictionary<string, List<LatencySeriesPoint>> ParseLatencyDetailCsv(string csv)
     {
         var result = new Dictionary<string, List<LatencySeriesPoint>>();
         if (string.IsNullOrEmpty(csv)) return result;
 
-        // Per target: (time ticks) -> accumulating builder, so the four fields (which arrive on
-        // separate rows / tables in the long format) merge back onto one point per timestamp.
-        var byTarget = new Dictionary<string, Dictionary<long, LatencyPointBuilder>>();
-
-        int iTime = -1, iValue = -1, iField = -1, iTarget = -1;
+        int iTime = -1, iTarget = -1, iRtt = -1, iRttMax = -1, iJitter = -1, iLoss = -1;
         var expectHeader = true; // first non-# line is a header (annotated dialect re-arms this after each #-block)
         string? lastKey = null;
-        Dictionary<long, LatencyPointBuilder>? lastMap = null;
+        List<LatencySeriesPoint>? lastList = null;
 
         var span = csv.AsSpan();
         int pos = 0;
@@ -1952,16 +1945,18 @@ from(bucket: ""{_longtermBucket}"")
 
             if (expectHeader)
             {
-                iTime = iValue = iField = iTarget = -1;
+                iTime = iTarget = iRtt = iRttMax = iJitter = iLoss = -1;
                 int col = 0, p = 0;
                 while (true)
                 {
                     var comma = line.Slice(p).IndexOf(',');
                     var cell = comma < 0 ? line.Slice(p) : line.Slice(p, comma);
                     if (cell.SequenceEqual("_time")) iTime = col;
-                    else if (cell.SequenceEqual("_value")) iValue = col;
-                    else if (cell.SequenceEqual("_field")) iField = col;
                     else if (cell.SequenceEqual("target_id")) iTarget = col;
+                    else if (cell.SequenceEqual("rtt_avg_ms")) iRtt = col;
+                    else if (cell.SequenceEqual("rtt_max_ms")) iRttMax = col;
+                    else if (cell.SequenceEqual("jitter_ms")) iJitter = col;
+                    else if (cell.SequenceEqual("loss_percent")) iLoss = col;
                     col++;
                     if (comma < 0) break;
                     p += comma + 1;
@@ -1970,68 +1965,56 @@ from(bucket: ""{_longtermBucket}"")
                 continue;
             }
 
-            if (iTime < 0 || iValue < 0 || iField < 0 || iTarget < 0) continue;
+            if (iTime < 0 || iTarget < 0) continue;
 
-            ReadOnlySpan<char> tTime = default, tValue = default, tField = default, tTarget = default;
+            ReadOnlySpan<char> tTime = default, tTarget = default, tRtt = default, tRttMax = default, tJitter = default, tLoss = default;
             int c = 0, q = 0;
             while (true)
             {
                 var comma = line.Slice(q).IndexOf(',');
                 var cell = comma < 0 ? line.Slice(q) : line.Slice(q, comma);
                 if (c == iTime) tTime = cell;
-                else if (c == iValue) tValue = cell;
-                else if (c == iField) tField = cell;
                 else if (c == iTarget) tTarget = cell;
+                else if (c == iRtt) tRtt = cell;
+                else if (c == iRttMax) tRttMax = cell;
+                else if (c == iJitter) tJitter = cell;
+                else if (c == iLoss) tLoss = cell;
                 c++;
                 if (comma < 0) break;
                 q += comma + 1;
             }
 
-            if (tTarget.IsEmpty || tTime.IsEmpty || tField.IsEmpty) continue;
+            if (tTarget.IsEmpty || tTime.IsEmpty) continue;
             if (!DateTime.TryParse(tTime, System.Globalization.CultureInfo.InvariantCulture,
                     System.Globalization.DateTimeStyles.RoundtripKind, out var time))
                 continue;
 
-            // Rows are grouped by (target, field), so reuse the target's map across a run.
-            Dictionary<long, LatencyPointBuilder>? map;
+            // Rows are grouped by target, so reuse the key/list across a run rather than re-allocating.
+            List<LatencySeriesPoint>? list;
             if (lastKey != null && tTarget.SequenceEqual(lastKey))
             {
-                map = lastMap;
+                list = lastList;
             }
             else
             {
                 var key = tTarget.ToString();
-                if (!byTarget.TryGetValue(key, out map)) { map = new Dictionary<long, LatencyPointBuilder>(); byTarget[key] = map; }
+                if (!result.TryGetValue(key, out list)) { list = new List<LatencySeriesPoint>(); result[key] = list; }
                 lastKey = key;
-                lastMap = map;
+                lastList = list;
             }
 
-            var utc = ToUtc(time);
-            map!.TryGetValue(utc.Ticks, out var b);
-            b.Time = utc;
-            var v = ParseDoubleOrNull(tValue);
-            if (tField.SequenceEqual("rtt_avg_ms")) b.Rtt = v;
-            else if (tField.SequenceEqual("rtt_max_ms")) b.RttMax = v;
-            else if (tField.SequenceEqual("jitter_ms")) b.Jitter = v;
-            else if (tField.SequenceEqual("loss_percent")) b.Loss = v;
-            map[utc.Ticks] = b;
+            list!.Add(new LatencySeriesPoint
+            {
+                Time = ToUtc(time),
+                RttAvgMs = ParseDoubleOrNull(tRtt),
+                RttMaxMs = ParseDoubleOrNull(tRttMax),
+                JitterMs = ParseDoubleOrNull(tJitter),
+                LossPercent = ParseDoubleOrNull(tLoss)
+            });
         }
 
-        foreach (var (target, map) in byTarget)
-        {
-            var list = new List<LatencySeriesPoint>(map.Count);
-            foreach (var b in map.Values)
-                list.Add(new LatencySeriesPoint
-                {
-                    Time = b.Time,
-                    RttAvgMs = b.Rtt,
-                    RttMaxMs = b.RttMax,
-                    JitterMs = b.Jitter,
-                    LossPercent = b.Loss
-                });
+        foreach (var list in result.Values)
             list.Sort((a, b) => a.Time.CompareTo(b.Time));
-            result[target] = list;
-        }
         return result;
     }
 

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -2161,6 +2161,52 @@ join.inner(left: loss, right: load, on: (l, r) => l._time == r._time, as: (l, r)
     }
 
     /// <summary>
+    /// Mean loss_percent pooled across every enabled target of one type over a window, weighting
+    /// all their samples equally - the same per-sample mean ISP Health's loss factors use. The loss
+    /// event finders report a single target's PEAK-loss minute (to center the chart on the worst
+    /// point); this gives the type-wide average over the coalesced event window, so the Investigate
+    /// highlight reflects what the whole tier did - close to the pooled figure ISP Health scores -
+    /// rather than the single worst target. Null when no loss samples fall in the window.
+    /// </summary>
+    public async Task<double?> QueryMeanLossByTargetTypeAsync(
+        MonitoringTargetType targetType,
+        DateTime from,
+        DateTime to,
+        IReadOnlyCollection<string>? enabledTargetIds = null,
+        CancellationToken ct = default)
+    {
+        if (!IsConfigured) await ReconfigureAsync(ct);
+        if (!IsConfigured) return null;
+        var typeTag = targetType.ToString().ToLowerInvariant();
+        var typeFilter = targetType == MonitoringTargetType.InternetService
+            ? @"r.target_type == ""internetservice"" or r.target_type == ""wan"""
+            : $@"r.target_type == ""{typeTag}""";
+        var targetFilter = "";
+        if (enabledTargetIds != null && enabledTargetIds.Count > 0)
+        {
+            var conditions = string.Join(" or ", enabledTargetIds.Select(id => $@"r.target_id == ""{SanitizeFluxString(id)}"""));
+            targetFilter = $"\n  |> filter(fn: (r) => {conditions})";
+        }
+        // group() collapses every target's per-sample loss into one table so mean() is the pooled
+        // average across the whole tier, not per target.
+        var flux = $@"
+from(bucket: ""{_bucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""latency"")
+  |> filter(fn: (r) => {typeFilter}){targetFilter}
+  |> filter(fn: (r) => r._field == ""loss_percent"")
+  |> group()
+  |> mean()
+";
+        await foreach (var record in QueryFluxAsync(flux, ct))
+        {
+            var v = AsDoubleOrNull(record.GetValueByKey("_value"));
+            if (v != null) return v;
+        }
+        return null;
+    }
+
+    /// <summary>
     /// Find the most recent SFP anomaly: temperature above PON threshold (75 C) or
     /// RX power below PON threshold (-25 dBm). Scans the last 7 days.
     /// </summary>

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -1238,18 +1238,22 @@ from(bucket: ""{_bucket}"")
     }
 
     /// <summary>
-    /// Two-resolution variant of <see cref="QueryLatencyDetailByTargetTypeAsync"/> that reads RTT,
-    /// max RTT, and jitter at a COARSE aggregate while reading loss at a FINE aggregate, then merges
-    /// the two grids per target. RTT/jitter only feed the 15-min congestion and 30-min step buckets
-    /// and whole-window per-ASN statistics, so their fine-resolution volume is wasted; loss must stay
-    /// fine because outage detection buckets it at 15-30 s. On the merged series, RTT points carry a
-    /// null loss and loss points carry a null RTT: every consumer filters by the field it reads
-    /// (RttAvgMs.HasValue for congestion/step, LossPercent.HasValue for outage / the loss pool), so
-    /// the disjoint timestamps are consumed cleanly. rtt_max_ms rides with rtt_avg_ms and jitter_ms
-    /// on the same coarse row because <see cref="LatencySample.EffectiveJitterMs"/> derives jitter
-    /// from (rtt_max - rtt_avg) when jitter_ms is absent. Cuts the transit/internet payload the app
-    /// deserializes without touching any loss-based detection. Used for Transit and InternetService;
-    /// AccessIsp stays fully fine (its RTT drives the loaded-latency delta).
+    /// Two-resolution variant of <see cref="QueryLatencyDetailByTargetTypeAsync"/> that reads
+    /// <c>rtt_avg_ms</c> at a COARSE aggregate while reading <c>loss_percent</c> AND <c>jitter_ms</c> at
+    /// a FINE aggregate, then merges the two grids per target. Only mean RTT is coarsened: it feeds the
+    /// 15-min congestion and 30-min step buckets and whole-window per-ASN medians, which don't need fine
+    /// resolution. Jitter stays FINE because mean-aggregating it dilutes the bursts that drive congestion
+    /// detection and the per-ASN P95 - coarsening it visibly under-scored the transit dimension on
+    /// transit-heavy sites. Loss stays fine for outage's 15-30 s buckets. On the merged series, coarse
+    /// rows carry only rtt_avg (null jitter/loss) and fine rows carry loss+jitter (null rtt_avg), so every
+    /// consumer filters by the field it reads (RttAvgMs.HasValue for congestion RTT/step, EffectiveJitterMs
+    /// for jitter, LossPercent.HasValue for outage / the loss pool) and the disjoint timestamps are
+    /// consumed cleanly. <c>rtt_max_ms</c> is NOT fetched for these types: its only use is the
+    /// EffectiveJitterMs fallback (rtt_max - rtt_avg) when jitter is absent, which can't be computed
+    /// against a coarse rtt_avg anyway - and jitter is essentially always present. Keeping rtt_max off
+    /// the coarse rows is also what prevents them from producing a stray coarse EffectiveJitter that
+    /// would contaminate the fine jitter stats. Used for Transit and InternetService; AccessIsp stays
+    /// fully fine (its RTT drives the loaded-latency delta).
     /// </summary>
     public async Task<Dictionary<string, List<LatencySeriesPoint>>> QueryLatencyDetailTieredByTargetTypeAsync(
         MonitoringTargetType targetType,
@@ -1276,18 +1280,18 @@ from(bucket: ""{_bucket}"")
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
         var coarseTask = QueryRawAsync(
-            BuildFlux(@"r._field == ""rtt_avg_ms"" or r._field == ""rtt_max_ms"" or r._field == ""jitter_ms""", coarseAggregate), ct);
+            BuildFlux(@"r._field == ""rtt_avg_ms""", coarseAggregate), ct);
         var fineTask = QueryRawAsync(
-            BuildFlux(@"r._field == ""loss_percent""", fineAggregate), ct);
+            BuildFlux(@"r._field == ""loss_percent"" or r._field == ""jitter_ms""", fineAggregate), ct);
         await Task.WhenAll(coarseTask, fineTask);
 
         var merged = ParseLatencyDetailCsv(await coarseTask);
-        foreach (var (target, lossPoints) in ParseLatencyDetailCsv(await fineTask))
+        foreach (var (target, finePoints) in ParseLatencyDetailCsv(await fineTask))
         {
-            if (merged.TryGetValue(target, out var list)) list.AddRange(lossPoints);
-            else merged[target] = lossPoints;
+            if (merged.TryGetValue(target, out var list)) list.AddRange(finePoints);
+            else merged[target] = finePoints;
         }
-        // The two grids interleave (coarse RTT rows and fine loss rows at different instants), so
+        // The two grids interleave (coarse RTT rows and fine loss/jitter rows at different instants), so
         // re-sort each target by time - the detectors and per-ASN grading assume chronological order.
         foreach (var list in merged.Values)
             list.Sort((a, b) => a.Time.CompareTo(b.Time));

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -1238,67 +1238,6 @@ from(bucket: ""{_bucket}"")
     }
 
     /// <summary>
-    /// Two-resolution variant of <see cref="QueryLatencyDetailByTargetTypeAsync"/> that reads
-    /// <c>rtt_avg_ms</c> at a COARSE aggregate while reading <c>loss_percent</c> AND <c>jitter_ms</c> at
-    /// a FINE aggregate, then merges the two grids per target. Only mean RTT is coarsened: it feeds the
-    /// 15-min congestion and 30-min step buckets and whole-window per-ASN medians, which don't need fine
-    /// resolution. Jitter stays FINE because mean-aggregating it dilutes the bursts that drive congestion
-    /// detection and the per-ASN P95 - coarsening it visibly under-scored the transit dimension on
-    /// transit-heavy sites. Loss stays fine for outage's 15-30 s buckets. On the merged series, coarse
-    /// rows carry only rtt_avg (null jitter/loss) and fine rows carry loss+jitter (null rtt_avg), so every
-    /// consumer filters by the field it reads (RttAvgMs.HasValue for congestion RTT/step, EffectiveJitterMs
-    /// for jitter, LossPercent.HasValue for outage / the loss pool) and the disjoint timestamps are
-    /// consumed cleanly. <c>rtt_max_ms</c> is NOT fetched for these types: its only use is the
-    /// EffectiveJitterMs fallback (rtt_max - rtt_avg) when jitter is absent, which can't be computed
-    /// against a coarse rtt_avg anyway - and jitter is essentially always present. Keeping rtt_max off
-    /// the coarse rows is also what prevents them from producing a stray coarse EffectiveJitter that
-    /// would contaminate the fine jitter stats. Used for Transit and InternetService; AccessIsp stays
-    /// fully fine (its RTT drives the loaded-latency delta).
-    /// </summary>
-    public async Task<Dictionary<string, List<LatencySeriesPoint>>> QueryLatencyDetailTieredByTargetTypeAsync(
-        MonitoringTargetType targetType,
-        DateTime from,
-        DateTime to,
-        TimeSpan coarseAggregate,
-        TimeSpan fineAggregate,
-        CancellationToken ct = default)
-    {
-        if (!IsConfigured) await ReconfigureAsync(ct);
-        if (!IsConfigured) return new Dictionary<string, List<LatencySeriesPoint>>();
-        var typeTag = targetType.ToString().ToLowerInvariant();
-        var typeFilter = targetType == MonitoringTargetType.InternetService
-            ? @"r.target_type == ""internetservice"" or r.target_type == ""wan"""
-            : $@"r.target_type == ""{typeTag}""";
-
-        string BuildFlux(string fieldFilter, TimeSpan window) => $@"
-from(bucket: ""{_bucket}"")
-  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
-  |> filter(fn: (r) => r._measurement == ""latency"")
-  |> filter(fn: (r) => {typeFilter})
-  |> filter(fn: (r) => {fieldFilter})
-  |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
-  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
-";
-        var coarseTask = QueryRawAsync(
-            BuildFlux(@"r._field == ""rtt_avg_ms""", coarseAggregate), ct);
-        var fineTask = QueryRawAsync(
-            BuildFlux(@"r._field == ""loss_percent"" or r._field == ""jitter_ms""", fineAggregate), ct);
-        await Task.WhenAll(coarseTask, fineTask);
-
-        var merged = ParseLatencyDetailCsv(await coarseTask);
-        foreach (var (target, finePoints) in ParseLatencyDetailCsv(await fineTask))
-        {
-            if (merged.TryGetValue(target, out var list)) list.AddRange(finePoints);
-            else merged[target] = finePoints;
-        }
-        // The two grids interleave (coarse RTT rows and fine loss/jitter rows at different instants), so
-        // re-sort each target by time - the detectors and per-ASN grading assume chronological order.
-        foreach (var list in merged.Values)
-            list.Sort((a, b) => a.Time.CompareTo(b.Time));
-        return merged;
-    }
-
-    /// <summary>
     /// Per-window rtt/jitter/loss detail for a single target by its id - used to pull just the LAN
     /// gateway's loss for outage scoping without loading every fabric device's series.
     /// </summary>

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -1232,7 +1232,6 @@ from(bucket: ""{_bucket}"")
   |> filter(fn: (r) => {typeFilter})
   |> filter(fn: (r) => r._field == ""rtt_avg_ms"" or r._field == ""rtt_max_ms"" or r._field == ""jitter_ms"" or r._field == ""loss_percent"")
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
-  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
         return ParseLatencyDetailCsv(await QueryRawAsync(flux, ct));
     }
@@ -1273,7 +1272,6 @@ from(bucket: ""{_bucket}"")
   |> filter(fn: (r) => {typeFilter})
   |> filter(fn: (r) => {fieldFilter})
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
-  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
         var coarseTask = QueryRawAsync(
             BuildFlux(@"r._field == ""rtt_avg_ms"" or r._field == ""rtt_max_ms"" or r._field == ""jitter_ms""", coarseAggregate), ct);
@@ -1315,7 +1313,6 @@ from(bucket: ""{_bucket}"")
   |> filter(fn: (r) => r.target_id == ""{targetId}"")
   |> filter(fn: (r) => r._field == ""rtt_avg_ms"" or r._field == ""rtt_max_ms"" or r._field == ""jitter_ms"" or r._field == ""loss_percent"")
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
-  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
         var byTarget = ParseLatencyDetailCsv(await QueryRawAsync(flux, ct));
         // Single target filter, but flatten defensively in case the pivot emits more than one key.
@@ -1913,24 +1910,34 @@ from(bucket: ""{_longtermBucket}"")
         }
     }
 
+    private struct LatencyPointBuilder
+    {
+        public DateTime Time;
+        public double? Rtt, RttMax, Jitter, Loss;
+    }
+
     /// <summary>
-    /// Parses the annotated-CSV result of a latency-detail pivot query (columns target_id, _time,
-    /// rtt_avg_ms, rtt_max_ms, jitter_ms, loss_percent) directly into per-target point lists. Span-
-    /// based: the only allocations are the per-target list, the distinct target_id keys, and the
-    /// points themselves - no FluxRecord, no boxing, no intermediate copy. Annotation rows (#...) are
-    /// skipped and the column header is re-read whenever Flux emits one (default annotated dialect),
-    /// so column order is never assumed. Tag/field values in this measurement never contain commas,
-    /// so a plain comma split is safe.
+    /// Parses the annotated-CSV result of an UN-PIVOTED latency-detail query (long format: one row per
+    /// (target_id, _field, _time), columns _time, _value, _field, target_id) into per-target point
+    /// lists. Accumulates each field onto a per-(target, time) builder and emits sorted points - i.e.
+    /// it does client-side what a Flux <c>pivot()</c> would do on the server, which was ~half the read
+    /// cost (measured), while producing identical points. Span-based: annotation rows (#...) are skipped
+    /// and the column header is re-read whenever Flux emits one, so column order is never assumed.
+    /// Tag/field values in this measurement never contain commas, so a plain comma split is safe.
     /// </summary>
     internal static Dictionary<string, List<LatencySeriesPoint>> ParseLatencyDetailCsv(string csv)
     {
         var result = new Dictionary<string, List<LatencySeriesPoint>>();
         if (string.IsNullOrEmpty(csv)) return result;
 
-        int iTime = -1, iTarget = -1, iRtt = -1, iRttMax = -1, iJitter = -1, iLoss = -1;
+        // Per target: (time ticks) -> accumulating builder, so the four fields (which arrive on
+        // separate rows / tables in the long format) merge back onto one point per timestamp.
+        var byTarget = new Dictionary<string, Dictionary<long, LatencyPointBuilder>>();
+
+        int iTime = -1, iValue = -1, iField = -1, iTarget = -1;
         var expectHeader = true; // first non-# line is a header (annotated dialect re-arms this after each #-block)
         string? lastKey = null;
-        List<LatencySeriesPoint>? lastList = null;
+        Dictionary<long, LatencyPointBuilder>? lastMap = null;
 
         var span = csv.AsSpan();
         int pos = 0;
@@ -1945,18 +1952,16 @@ from(bucket: ""{_longtermBucket}"")
 
             if (expectHeader)
             {
-                iTime = iTarget = iRtt = iRttMax = iJitter = iLoss = -1;
+                iTime = iValue = iField = iTarget = -1;
                 int col = 0, p = 0;
                 while (true)
                 {
                     var comma = line.Slice(p).IndexOf(',');
                     var cell = comma < 0 ? line.Slice(p) : line.Slice(p, comma);
                     if (cell.SequenceEqual("_time")) iTime = col;
+                    else if (cell.SequenceEqual("_value")) iValue = col;
+                    else if (cell.SequenceEqual("_field")) iField = col;
                     else if (cell.SequenceEqual("target_id")) iTarget = col;
-                    else if (cell.SequenceEqual("rtt_avg_ms")) iRtt = col;
-                    else if (cell.SequenceEqual("rtt_max_ms")) iRttMax = col;
-                    else if (cell.SequenceEqual("jitter_ms")) iJitter = col;
-                    else if (cell.SequenceEqual("loss_percent")) iLoss = col;
                     col++;
                     if (comma < 0) break;
                     p += comma + 1;
@@ -1965,56 +1970,68 @@ from(bucket: ""{_longtermBucket}"")
                 continue;
             }
 
-            if (iTime < 0 || iTarget < 0) continue;
+            if (iTime < 0 || iValue < 0 || iField < 0 || iTarget < 0) continue;
 
-            ReadOnlySpan<char> tTime = default, tTarget = default, tRtt = default, tRttMax = default, tJitter = default, tLoss = default;
+            ReadOnlySpan<char> tTime = default, tValue = default, tField = default, tTarget = default;
             int c = 0, q = 0;
             while (true)
             {
                 var comma = line.Slice(q).IndexOf(',');
                 var cell = comma < 0 ? line.Slice(q) : line.Slice(q, comma);
                 if (c == iTime) tTime = cell;
+                else if (c == iValue) tValue = cell;
+                else if (c == iField) tField = cell;
                 else if (c == iTarget) tTarget = cell;
-                else if (c == iRtt) tRtt = cell;
-                else if (c == iRttMax) tRttMax = cell;
-                else if (c == iJitter) tJitter = cell;
-                else if (c == iLoss) tLoss = cell;
                 c++;
                 if (comma < 0) break;
                 q += comma + 1;
             }
 
-            if (tTarget.IsEmpty || tTime.IsEmpty) continue;
+            if (tTarget.IsEmpty || tTime.IsEmpty || tField.IsEmpty) continue;
             if (!DateTime.TryParse(tTime, System.Globalization.CultureInfo.InvariantCulture,
                     System.Globalization.DateTimeStyles.RoundtripKind, out var time))
                 continue;
 
-            // Rows are grouped by target, so reuse the key/list across a run rather than re-allocating.
-            List<LatencySeriesPoint>? list;
+            // Rows are grouped by (target, field), so reuse the target's map across a run.
+            Dictionary<long, LatencyPointBuilder>? map;
             if (lastKey != null && tTarget.SequenceEqual(lastKey))
             {
-                list = lastList;
+                map = lastMap;
             }
             else
             {
                 var key = tTarget.ToString();
-                if (!result.TryGetValue(key, out list)) { list = new List<LatencySeriesPoint>(); result[key] = list; }
+                if (!byTarget.TryGetValue(key, out map)) { map = new Dictionary<long, LatencyPointBuilder>(); byTarget[key] = map; }
                 lastKey = key;
-                lastList = list;
+                lastMap = map;
             }
 
-            list!.Add(new LatencySeriesPoint
-            {
-                Time = ToUtc(time),
-                RttAvgMs = ParseDoubleOrNull(tRtt),
-                RttMaxMs = ParseDoubleOrNull(tRttMax),
-                JitterMs = ParseDoubleOrNull(tJitter),
-                LossPercent = ParseDoubleOrNull(tLoss)
-            });
+            var utc = ToUtc(time);
+            map!.TryGetValue(utc.Ticks, out var b);
+            b.Time = utc;
+            var v = ParseDoubleOrNull(tValue);
+            if (tField.SequenceEqual("rtt_avg_ms")) b.Rtt = v;
+            else if (tField.SequenceEqual("rtt_max_ms")) b.RttMax = v;
+            else if (tField.SequenceEqual("jitter_ms")) b.Jitter = v;
+            else if (tField.SequenceEqual("loss_percent")) b.Loss = v;
+            map[utc.Ticks] = b;
         }
 
-        foreach (var list in result.Values)
+        foreach (var (target, map) in byTarget)
+        {
+            var list = new List<LatencySeriesPoint>(map.Count);
+            foreach (var b in map.Values)
+                list.Add(new LatencySeriesPoint
+                {
+                    Time = b.Time,
+                    RttAvgMs = b.Rtt,
+                    RttMaxMs = b.RttMax,
+                    JitterMs = b.Jitter,
+                    LossPercent = b.Loss
+                });
             list.Sort((a, b) => a.Time.CompareTo(b.Time));
+            result[target] = list;
+        }
         return result;
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -2766,11 +2766,11 @@ else
                 _lossInvestigateResult = after.HasValue ? "No newer events" : "No older events";
                 return;
             }
-            var (targetType, category) = result.TargetType switch
+            var category = result.TargetType switch
             {
-                "accessisp" => (MonitoringTargetType.AccessIsp, "AccessIsp"),
-                "transit" => (MonitoringTargetType.Transit, "Transit"),
-                _ => (MonitoringTargetType.InternetService, "InternetService")
+                "accessisp" => "AccessIsp",
+                "transit" => "Transit",
+                _ => "InternetService"
             };
             _lossNavActive = true;
             _lossNavTimestamp = result.Timestamp;
@@ -2782,12 +2782,13 @@ else
                 : $"{(int)delta.TotalDays}d ago";
             var localTime = result.Timestamp.ToLocalTime().ToString("M/d h:mm tt");
             // The event is found on its single worst target's peak minute, but the highlight should
-            // read the loss the whole tier saw over the event - the pooled per-sample mean across all
-            // enabled targets of that type, matching (ish) what ISP Health's loss factors score. The
-            // band's start is backed up one bucket, so pool over the same widened window. Fall back to
-            // the peak target's value if the pooled query returns nothing.
-            var pooledLoss = await InfluxClient.QueryMeanLossByTargetTypeAsync(
-                targetType, result.EventStart.AddMinutes(-1), result.EventEnd, enabledIds)
+            // read the loss the score is actually graded on: the pooled per-sample mean across the
+            // exact ISP Health loss pool (access + transit excl. non-transit infra + anycast DNS) over
+            // the event window. The band's start is backed up one bucket, so pool over the same widened
+            // window. Fall back to the peak target's value if the pooled query returns nothing.
+            var poolIds = await IspHealthService.GetLossPoolTargetIdsAsync();
+            var pooledLoss = await InfluxClient.QueryMeanLossAcrossTargetsAsync(
+                poolIds, result.EventStart.AddMinutes(-1), result.EventEnd)
                 ?? result.LossPercent;
             _lossInvestigateResult = $"{pooledLoss:0.#}% loss {ago} ({localTime})";
             StateHasChanged();

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -2766,11 +2766,11 @@ else
                 _lossInvestigateResult = after.HasValue ? "No newer events" : "No older events";
                 return;
             }
-            var category = result.TargetType switch
+            var (targetType, category) = result.TargetType switch
             {
-                "accessisp" => "AccessIsp",
-                "transit" => "Transit",
-                _ => "InternetService"
+                "accessisp" => (MonitoringTargetType.AccessIsp, "AccessIsp"),
+                "transit" => (MonitoringTargetType.Transit, "Transit"),
+                _ => (MonitoringTargetType.InternetService, "InternetService")
             };
             _lossNavActive = true;
             _lossNavTimestamp = result.Timestamp;
@@ -2781,9 +2781,17 @@ else
                 : delta.TotalHours < 24 ? $"{(int)delta.TotalHours}h ago"
                 : $"{(int)delta.TotalDays}d ago";
             var localTime = result.Timestamp.ToLocalTime().ToString("M/d h:mm tt");
-            _lossInvestigateResult = $"{result.LossPercent:0.#}% loss {ago} ({localTime})";
+            // The event is found on its single worst target's peak minute, but the highlight should
+            // read the loss the whole tier saw over the event - the pooled per-sample mean across all
+            // enabled targets of that type, matching (ish) what ISP Health's loss factors score. The
+            // band's start is backed up one bucket, so pool over the same widened window. Fall back to
+            // the peak target's value if the pooled query returns nothing.
+            var pooledLoss = await InfluxClient.QueryMeanLossByTargetTypeAsync(
+                targetType, result.EventStart.AddMinutes(-1), result.EventEnd, enabledIds)
+                ?? result.LossPercent;
+            _lossInvestigateResult = $"{pooledLoss:0.#}% loss {ago} ({localTime})";
             StateHasChanged();
-            var annotationLabel = $"{(loadedOnly ? "Loaded" : "Packet")} loss {result.LossPercent:0.#}%";
+            var annotationLabel = $"{(loadedOnly ? "Loaded" : "Packet")} loss {pooledLoss:0.#}%";
             await JS.InvokeVoidAsync("eval",
                 $"window.__latencyCharts?.navigateToTime('{result.Timestamp:o}', '{category}', '{annotationLabel}', {(loadedOnly ? "true" : "false")}, '{result.EventStart:o}', '{result.EventEnd:o}');");
         }

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -933,11 +933,15 @@ else
             // feed stays readable and still agrees with the cards (which badge only confirmed).
             // A localized, propagated bottleneck names the hop AND the hops beyond it in the subject,
             // which replaces the old trailing "it propagates ..." sentence. Sibling-confirmed,
-            // clean-parallel, and unlocalized events don't get it.
+            // clean-parallel, and unlocalized events don't get it. Require a placed bottleneck hop
+            // (BottleneckHopIp) so an un-traced target that only surfaced as an unlocalized Confirmed
+            // event - e.g. an access-ISP leaf with no saved trace - is never described as a hop with
+            // topology beyond it; only genuinely localized hops and shared-incident owners carry a hop IP.
             var beyond = evt.Disposition == CongestionDisposition.Confirmed
                 && !evt.ConfirmedBySibling
                 && !(evt.LoadCoincident && evt.CleanParallelPaths > 0)
                 && !evt.IsShared
+                && evt.BottleneckHopIp != null
                 ? " and the hops beyond" : "";
             var lead = $"{span} of elevated latency and jitter on {where}{beyond}{load} ({mag}).";
             var (badge, badgeClass, text) = evt.Disposition switch

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionDetector.cs
@@ -27,12 +27,16 @@ public static class CongestionDetector
         var samples = series.Samples.Where(s => s.RttAvgMs.HasValue).OrderBy(s => s.Time).ToList();
         if (samples.Count == 0) return new List<CongestionEvent>();
 
-        var allRtts = samples.Select(s => s.RttAvgMs!.Value).ToList();
-        var allJitters = samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
-        var baselineRtt = SeriesStats.Median(allRtts);
-        var rttMad = SeriesStats.Mad(allRtts);
-        var baselineP90 = SeriesStats.Percentile(allRtts, 0.90);
-        var baselineJitter = allJitters.Count > 0 ? SeriesStats.Median(allJitters) : null;
+        // Sort each array once and derive median/MAD/p90 from it, rather than letting each SeriesStats
+        // call sort again (Median + Mad + Percentile would sort the RTT array 4x). Bit-identical.
+        var allRtts = samples.Select(s => s.RttAvgMs!.Value).ToArray();
+        Array.Sort(allRtts);
+        var allJitters = samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToArray();
+        Array.Sort(allJitters);
+        var baselineRtt = SeriesStats.MedianSorted(allRtts);
+        var baselineP90 = SeriesStats.PercentileSorted(allRtts, 0.90);
+        var rttMad = baselineRtt.HasValue ? SeriesStats.MadSorted(allRtts, baselineRtt.Value) : null;
+        var baselineJitter = allJitters.Length > 0 ? SeriesStats.MedianSorted(allJitters) : null;
         if (baselineRtt == null || rttMad == null || baselineP90 == null) return new List<CongestionEvent>();
 
         var bucketSize = TimeSpan.FromMinutes(options.CongestionBucketMinutes);
@@ -41,12 +45,15 @@ public static class CongestionDetector
             .OrderBy(g => g.Key)
             .Select(g =>
             {
-                var rtts = g.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
+                var rtts = g.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToArray();
+                Array.Sort(rtts);
+                var jit = g.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToArray();
+                Array.Sort(jit);
                 return new Bucket(
                     g.Key,
-                    SeriesStats.Median(rtts),
-                    SeriesStats.Percentile(rtts, 0.90),
-                    SeriesStats.Median(g.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList()));
+                    SeriesStats.MedianSorted(rtts),
+                    SeriesStats.PercentileSorted(rtts, 0.90),
+                    SeriesStats.MedianSorted(jit));
             })
             .ToList();
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionDetector.cs
@@ -24,12 +24,17 @@ public static class CongestionDetector
     /// <summary>Detects events within a single ASN's series. Exposed for replay against exported data.</summary>
     public static List<CongestionEvent> DetectForSeries(AsnSeries series, IspHealthOptions options)
     {
-        var samples = series.Samples.Where(s => s.RttAvgMs.HasValue).OrderBy(s => s.Time).ToList();
-        if (samples.Count == 0) return new List<CongestionEvent>();
+        // RTT and jitter can arrive on separate rows: the tiered transit/internet fetch reads coarse
+        // mean RTT and fine jitter as disjoint points, so gather each field's samples independently
+        // rather than reading jitter off the RTT-bearing rows only. Identical for co-located data (any
+        // row with RTT also has jitter, and loss-only rows have neither), so every all-fine site and
+        // the tests are unchanged; it only lets the fine jitter rows through on the tiered path.
+        var samples = series.Samples.Where(s => s.RttAvgMs.HasValue || s.EffectiveJitterMs.HasValue).OrderBy(s => s.Time).ToList();
 
         // Sort each array once and derive median/MAD/p90 from it, rather than letting each SeriesStats
         // call sort again (Median + Mad + Percentile would sort the RTT array 4x). Bit-identical.
-        var allRtts = samples.Select(s => s.RttAvgMs!.Value).ToArray();
+        var allRtts = samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToArray();
+        if (allRtts.Length == 0) return new List<CongestionEvent>();
         Array.Sort(allRtts);
         var allJitters = samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToArray();
         Array.Sort(allJitters);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionDetector.cs
@@ -24,17 +24,12 @@ public static class CongestionDetector
     /// <summary>Detects events within a single ASN's series. Exposed for replay against exported data.</summary>
     public static List<CongestionEvent> DetectForSeries(AsnSeries series, IspHealthOptions options)
     {
-        // RTT and jitter can arrive on separate rows: the tiered transit/internet fetch reads coarse
-        // mean RTT and fine jitter as disjoint points, so gather each field's samples independently
-        // rather than reading jitter off the RTT-bearing rows only. Identical for co-located data (any
-        // row with RTT also has jitter, and loss-only rows have neither), so every all-fine site and
-        // the tests are unchanged; it only lets the fine jitter rows through on the tiered path.
-        var samples = series.Samples.Where(s => s.RttAvgMs.HasValue || s.EffectiveJitterMs.HasValue).OrderBy(s => s.Time).ToList();
+        var samples = series.Samples.Where(s => s.RttAvgMs.HasValue).OrderBy(s => s.Time).ToList();
+        if (samples.Count == 0) return new List<CongestionEvent>();
 
         // Sort each array once and derive median/MAD/p90 from it, rather than letting each SeriesStats
         // call sort again (Median + Mad + Percentile would sort the RTT array 4x). Bit-identical.
-        var allRtts = samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToArray();
-        if (allRtts.Length == 0) return new List<CongestionEvent>();
+        var allRtts = samples.Select(s => s.RttAvgMs!.Value).ToArray();
         Array.Sort(allRtts);
         var allJitters = samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToArray();
         Array.Sort(allJitters);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
 
 /// <summary>
@@ -94,12 +96,13 @@ public static class CongestionLocalizer
             // shared FLOOR of added delay; localized congestion is the rise ABOVE that floor.
             double RttRise(AsnSeries s)
             {
-                var inW = s.Samples.Where(x => x.Time >= window.Start && x.Time <= window.End && x.RttAvgMs.HasValue)
-                    .Select(x => x.RttAvgMs!.Value).ToList();
-                var baseW = s.Samples.Where(x => (x.Time < window.Start || x.Time > window.End) && x.RttAvgMs.HasValue)
-                    .Select(x => x.RttAvgMs!.Value).ToList();
+                // In-window samples come from a binary-searched slice; the baseline (the series minus
+                // that slice) is read off a precomputed sorted array by value-exclusion, so this is
+                // identical to the prior full-scan + sort but far cheaper. See SeriesIndex.
+                var ix = Index(s);
+                var inW = ix.InWindowRtt(window.Start, window.End);
                 var im = SeriesStats.Median(inW);
-                var bm = SeriesStats.Median(baseW);
+                var bm = ix.BaselineRttMedian(inW);
                 return im.HasValue && bm.HasValue ? Math.Max(0, im.Value - bm.Value) : 0;
             }
             var relElevated = anchoredWithData.Where(s => IsElevated(s, window.Start, window.End)).ToList();
@@ -219,13 +222,12 @@ public static class CongestionLocalizer
         }
         else
         {
-            var inR = owner.Samples.Where(x => x.Time >= start && x.Time <= end && x.RttAvgMs.HasValue).Select(x => x.RttAvgMs!.Value).ToList();
-            var baseR = owner.Samples.Where(x => (x.Time < start || x.Time > end) && x.RttAvgMs.HasValue).Select(x => x.RttAvgMs!.Value).ToList();
-            var inJ = owner.Samples.Where(x => x.Time >= start && x.Time <= end).Select(x => x.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
-            var baseJ = owner.Samples.Where(x => x.Time < start || x.Time > end).Select(x => x.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
-            baseRtt = SeriesStats.Median(baseR) ?? 0;
+            var ix = Index(owner);
+            var inR = ix.InWindowRtt(start, end);
+            var inJ = ix.InWindowJitter(start, end);
+            baseRtt = ix.BaselineRttMedian(inR) ?? 0;
             peakRtt = inR.Count > 0 ? SeriesStats.Percentile(inR, 0.90) ?? baseRtt : baseRtt;
-            baseJit = SeriesStats.Median(baseJ) ?? 0;
+            baseJit = ix.BaselineJitterMedian(inJ) ?? 0;
             peakJit = inJ.Count > 0 ? inJ.Max() : baseJit;
         }
 
@@ -489,15 +491,11 @@ public static class CongestionLocalizer
     /// </summary>
     internal static bool ElevatedInWindow(AsnSeries series, DateTime start, DateTime end, IspHealthOptions options)
     {
-        var inWindow = series.Samples
-            .Where(x => x.Time >= start && x.Time <= end && x.RttAvgMs.HasValue)
-            .Select(x => x.RttAvgMs!.Value).ToList();
-        var baseline = series.Samples
-            .Where(x => (x.Time < start || x.Time > end) && x.RttAvgMs.HasValue)
-            .Select(x => x.RttAvgMs!.Value).ToList();
-        if (inWindow.Count == 0 || baseline.Count == 0) return false;
+        var ix = Index(series);
+        var inWindow = ix.InWindowRtt(start, end);
+        if (inWindow.Count == 0 || ix.RttCount - inWindow.Count == 0) return false;
 
-        var baselineP90 = SeriesStats.Percentile(baseline, 0.90);
+        var baselineP90 = ix.BaselineRttPercentile(inWindow, 0.90);
         if (baselineP90.HasValue)
         {
             var threshold = baselineP90.Value + options.CongestionRttMinDeltaMs;
@@ -509,16 +507,11 @@ public static class CongestionLocalizer
         // median RTT barely moves, so RTT-only propagation misses it. Compare in-window median jitter
         // to this hop's OWN baseline median (relative, with a small absolute floor so a near-zero hop
         // isn't tripped by a sub-ms ratio swing).
-        var inJitter = series.Samples
-            .Where(x => x.Time >= start && x.Time <= end).Select(x => x.EffectiveJitterMs)
-            .Where(j => j.HasValue).Select(j => j!.Value).ToList();
-        var baseJitter = series.Samples
-            .Where(x => x.Time < start || x.Time > end).Select(x => x.EffectiveJitterMs)
-            .Where(j => j.HasValue).Select(j => j!.Value).ToList();
-        if (inJitter.Count == 0 || baseJitter.Count == 0) return false;
+        var inJitter = ix.InWindowJitter(start, end);
+        if (inJitter.Count == 0 || ix.JitterCount - inJitter.Count == 0) return false;
 
         var inJitMedian = SeriesStats.Median(inJitter);
-        var baseJitMedian = SeriesStats.Median(baseJitter);
+        var baseJitMedian = ix.BaselineJitterMedian(inJitter);
         return inJitMedian.HasValue && baseJitMedian.HasValue
             && inJitMedian.Value >= baseJitMedian.Value * options.CongestionPropagationJitterFactor
             && inJitMedian.Value - baseJitMedian.Value >= options.CongestionPropagationJitterFloorMs;
@@ -536,7 +529,7 @@ public static class CongestionLocalizer
     /// data then (a newer target added after a past event, or a monitoring gap) reads as unknown,
     /// never as "clean" - so absence of data can't pad the clean-control or clean-parallel evidence.</summary>
     private static bool HasDataInWindow(AsnSeries series, DateTime start, DateTime end) =>
-        series.Samples.Any(x => x.Time >= start && x.Time <= end && x.RttAvgMs.HasValue);
+        Index(series).HasRttInWindow(start, end);
 
     /// <summary>
     /// True when the series' in-window median rose above its out-of-window baseline median by at least
@@ -546,14 +539,10 @@ public static class CongestionLocalizer
     /// </summary>
     private static bool RoseInWindow(AsnSeries series, DateTime start, DateTime end, IspHealthOptions options)
     {
-        var inWindow = series.Samples
-            .Where(x => x.Time >= start && x.Time <= end && x.RttAvgMs.HasValue)
-            .Select(x => x.RttAvgMs!.Value).ToList();
-        var baseline = series.Samples
-            .Where(x => (x.Time < start || x.Time > end) && x.RttAvgMs.HasValue)
-            .Select(x => x.RttAvgMs!.Value).ToList();
-        if (inWindow.Count == 0 || baseline.Count == 0) return false;
-        var bMed = SeriesStats.Median(baseline);
+        var ix = Index(series);
+        var inWindow = ix.InWindowRtt(start, end);
+        if (inWindow.Count == 0 || ix.RttCount - inWindow.Count == 0) return false;
+        var bMed = ix.BaselineRttMedian(inWindow);
         // Use a high in-window percentile, not the median: an event with a strong core and a long
         // mild tail dilutes the median toward baseline, so a path that genuinely rose for a good part
         // of the window flickers in and out of "rose" across recomputes and the line-wide breadth
@@ -585,4 +574,123 @@ public static class CongestionLocalizer
 
     private static bool Overlaps(DateTime aStart, DateTime aEnd, DateTime bStart, DateTime bEnd) =>
         aStart < bEnd && bStart < aEnd;
+
+    // ---- Fast windowed statistics (exact, precomputed per series) ----
+
+    // Per-series index, keyed by reference and weak so it is freed with the series. A series'
+    // samples are immutable for the life of a Localize call, so caching the sorted views is safe and
+    // lets the windowed elevation/rise tests avoid re-scanning and re-sorting the full series on
+    // every call - the localizer's dominant cost at long windows.
+    private static readonly ConditionalWeakTable<AsnSeries, SeriesIndex> _indexCache = new();
+    private static SeriesIndex Index(AsnSeries s) => _indexCache.GetValue(s, static key => new SeriesIndex(key));
+
+    /// <summary>
+    /// Precomputed sorted views of one series for the windowed elevation/rise tests. Sample times are
+    /// held ascending for binary-searched in-window slicing; RTT and jitter values are also kept sorted
+    /// ascending so a baseline statistic (the series minus the in-window slice) can be read by exact
+    /// value-exclusion instead of re-collecting and re-sorting the whole series. Every result is
+    /// identical to the prior full-scan code - only faster.
+    /// </summary>
+    private sealed class SeriesIndex
+    {
+        private readonly long[] _ticks;     // sample times, ascending
+        private readonly double?[] _rtt;    // RttAvgMs in the same (time) order as _ticks
+        private readonly double?[] _jit;    // EffectiveJitterMs in time order
+        private readonly double[] _rttAsc;  // all non-null RttAvgMs, ascending
+        private readonly double[] _jitAsc;  // all non-null EffectiveJitterMs, ascending
+
+        public SeriesIndex(AsnSeries s)
+        {
+            // Sort by time defensively: callers pass time-sorted per-target series, but the prior
+            // full-scan code did not depend on ordering, so don't silently assume it here either.
+            var ordered = s.Samples.OrderBy(x => x.Time).ToArray();
+            _ticks = new long[ordered.Length];
+            _rtt = new double?[ordered.Length];
+            _jit = new double?[ordered.Length];
+            for (var i = 0; i < ordered.Length; i++)
+            {
+                _ticks[i] = ordered[i].Time.Ticks;
+                _rtt[i] = ordered[i].RttAvgMs;
+                _jit[i] = ordered[i].EffectiveJitterMs;
+            }
+            _rttAsc = _rtt.Where(v => v.HasValue).Select(v => v!.Value).OrderBy(v => v).ToArray();
+            _jitAsc = _jit.Where(v => v.HasValue).Select(v => v!.Value).OrderBy(v => v).ToArray();
+        }
+
+        public int RttCount => _rttAsc.Length;
+        public int JitterCount => _jitAsc.Length;
+
+        public bool HasRttInWindow(DateTime start, DateTime end)
+        {
+            var (lo, hi) = Range(start, end);
+            for (var i = lo; i < hi; i++)
+                if (_rtt[i].HasValue) return true;
+            return false;
+        }
+
+        public List<double> InWindowRtt(DateTime start, DateTime end) => Collect(_rtt, start, end);
+        public List<double> InWindowJitter(DateTime start, DateTime end) => Collect(_jit, start, end);
+
+        public double? BaselineRttMedian(List<double> inWindow) => PercentileExcluding(_rttAsc, inWindow, 0.5);
+        public double? BaselineRttPercentile(List<double> inWindow, double p) => PercentileExcluding(_rttAsc, inWindow, p);
+        public double? BaselineJitterMedian(List<double> inWindow) => PercentileExcluding(_jitAsc, inWindow, 0.5);
+
+        private List<double> Collect(double?[] values, DateTime start, DateTime end)
+        {
+            var (lo, hi) = Range(start, end);
+            var list = new List<double>(Math.Max(0, hi - lo));
+            for (var i = lo; i < hi; i++)
+                if (values[i].HasValue) list.Add(values[i]!.Value);
+            return list;
+        }
+
+        // [lo, hi) index range of samples with start &lt;= time &lt;= end.
+        private (int lo, int hi) Range(DateTime start, DateTime end)
+            => (LowerBound(_ticks, start.Ticks), UpperBound(_ticks, end.Ticks));
+
+        private static int LowerBound(long[] a, long key)
+        {
+            int lo = 0, hi = a.Length;
+            while (lo < hi) { var m = (lo + hi) >> 1; if (a[m] < key) lo = m + 1; else hi = m; }
+            return lo;
+        }
+
+        private static int UpperBound(long[] a, long key)
+        {
+            int lo = 0, hi = a.Length;
+            while (lo < hi) { var m = (lo + hi) >> 1; if (a[m] <= key) lo = m + 1; else hi = m; }
+            return lo;
+        }
+
+        /// <summary>
+        /// Percentile of <paramref name="fullAsc"/> with the values in <paramref name="excl"/> removed,
+        /// matching <see cref="SeriesStats.Percentile"/> exactly (same rank + interpolation) but without
+        /// materializing or sorting the baseline. <paramref name="excl"/> is always a sub-multiset of
+        /// <paramref name="fullAsc"/> (the in-window slice), so values match bit-for-bit and duplicates
+        /// are skipped one-for-one during the merge. Null when the baseline is empty.
+        /// </summary>
+        private static double? PercentileExcluding(double[] fullAsc, List<double> excl, double p)
+        {
+            var n = fullAsc.Length - excl.Count;
+            if (n <= 0) return null;
+            var ex = excl.ToArray();
+            Array.Sort(ex);
+            var rank = p * (n - 1);
+            var loR = (int)Math.Floor(rank);
+            var hiR = (int)Math.Ceiling(rank);
+            double vLo = 0, vHi = 0;
+            bool gotLo = false, gotHi = false;
+            int bi = -1, ei = 0;
+            for (var i = 0; i < fullAsc.Length; i++)
+            {
+                if (ei < ex.Length && fullAsc[i] == ex[ei]) { ei++; continue; }
+                bi++;
+                if (bi == loR) { vLo = fullAsc[i]; gotLo = true; }
+                if (bi == hiR) { vHi = fullAsc[i]; gotHi = true; break; }
+            }
+            if (!gotLo) return null;
+            if (loR == hiR || !gotHi) return vLo;
+            return vLo + (vHi - vLo) * (rank - loR);
+        }
+    }
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -719,8 +719,11 @@ public class IspHealthScorer
         var losses = series.Samples.Where(s => s.LossPercent.HasValue && !InOutage(s.Time)).Select(s => s.LossPercent!.Value).ToList();
         var jitters = series.Samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
 
-        var medianRtt = SeriesStats.Median(rtts);
-        var mad = SeriesStats.Mad(rtts);
+        // Sort the RTT set once; median, MAD, and the winsorized-mean / P95 below all read from it.
+        var sortedRtts = rtts.ToArray();
+        Array.Sort(sortedRtts);
+        var medianRtt = SeriesStats.MedianSorted(sortedRtts);
+        var mad = medianRtt.HasValue ? SeriesStats.MadSorted(sortedRtts, medianRtt.Value) : null;
 
         // Jitter and stability are absolve-only across clusters. The nearest cluster's
         // variance can be false (ICMP deprioritization at that hop); a cleaner farther
@@ -863,8 +866,8 @@ public class IspHealthScorer
             MedianRttMs = medianRtt,
             // Displayed RTT: winsorized mean (P99-capped) so sustained elevation shows but a
             // flap can't distort it. Reach (above) stays on the median - that measures distance.
-            MeanRttMs = SeriesStats.WinsorizedMean(rtts, _options.RttWinsorPercentile),
-            P95RttMs = SeriesStats.Percentile(rtts, 0.95),
+            MeanRttMs = SeriesStats.WinsorizedMeanSorted(sortedRtts, _options.RttWinsorPercentile),
+            P95RttMs = SeriesStats.PercentileSorted(sortedRtts, 0.95),
             // Raw near-cluster median, informational only. The displayed and scored jitter
             // is the effective (absolve/assimilated) value below.
             MedianJitterMs = jitters.Count > 0 ? SeriesStats.Median(jitters) : null,
@@ -921,9 +924,10 @@ public class IspHealthScorer
     /// <summary>RTT stability ratio (MAD / median) of a sample set; lower is steadier. Null without RTT.</summary>
     private static double? StabilityRatioOf(IReadOnlyList<LatencySample> samples)
     {
-        var rtts = samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
-        var median = SeriesStats.Median(rtts);
-        var mad = SeriesStats.Mad(rtts);
+        var rtts = samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToArray();
+        Array.Sort(rtts);
+        var median = SeriesStats.MedianSorted(rtts);
+        var mad = median.HasValue ? SeriesStats.MadSorted(rtts, median.Value) : null;
         return median is > 0 && mad.HasValue ? mad.Value / median.Value : null;
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -359,20 +359,15 @@ public class IspHealthService
         // LoadWindowSeconds, so the auto-computed report is unchanged.
         var aggregate = TimeSpan.FromSeconds(Math.Max(
             _options.LoadWindowSeconds, (windowEnd - windowStart).TotalSeconds / 25000.0));
-        // Transit and InternetService mean RTT only feeds the 15-min congestion and 30-min step buckets
-        // and whole-window per-ASN medians, so pulling it at the fine load-classification resolution is
-        // wasted volume (the dominant cost is the app deserializing these series - see research
-        // profiling). Read their RTT at a coarser window; JITTER and loss stay fine (fine jitter because
-        // mean-coarsening dilutes the bursts congestion detection and the per-ASN P95 key on, and loss
-        // because outage buckets it at 15-30 s). Clamped so it stays well under the 15-min congestion
-        // bucket (>= ~7 samples/bucket) and never finer than the fine window on long ranges.
-        var coarseAggregate = TimeSpan.FromSeconds(Math.Clamp(aggregate.TotalSeconds * 8, 60, 120));
 
-        // AccessIsp stays fully fine: its first-hop RTT drives the loaded-latency delta, matched
-        // against the fine LoadWindowSeconds throughput grid.
+        // All target types read at the fine window. Coarsening transit/internet RTT bought a modest
+        // 48h deserialize win but shifted congestion localization (the bottleneck walk keys on RTT
+        // bursts, which a coarse mean blunts), so it diverged from the fine-resolution attribution on
+        // transit-heavy paths. Kept fine everywhere; the compute-time wins now come from the in-memory
+        // detector/scorer paths, not from coarsening the input.
         var ispSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.AccessIsp, windowStart, windowEnd, aggregate, ct);
-        var transitSeriesTask = _influx.QueryLatencyDetailTieredByTargetTypeAsync(MonitoringTargetType.Transit, windowStart, windowEnd, coarseAggregate, aggregate, ct);
-        var internetSeriesTask = _influx.QueryLatencyDetailTieredByTargetTypeAsync(MonitoringTargetType.InternetService, windowStart, windowEnd, coarseAggregate, aggregate, ct);
+        var transitSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.Transit, windowStart, windowEnd, aggregate, ct);
+        var internetSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.InternetService, windowStart, windowEnd, aggregate, ct);
         var ratesTask = QueryWanRatesAsync(windowStart, windowEnd, aggregate, ct);
         var speedsTask = ResolveExpectedSpeedsAsync(ct);
         var speedTestsTask = LoadWanSpeedTestsAsync(windowStart, windowEnd, ct);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -265,6 +265,7 @@ public class IspHealthService
         if (!_influx.IsConfigured && !await _influx.ReconfigureAsync(ct))
             return new ComputeOutcome(IspHealthStatus.NotConfigured, null, new List<AsnSeries>());
 
+        var perf = System.Diagnostics.Stopwatch.StartNew(); // TEMP ISPPERF
         AccessTechnology technology;
         List<MonitoringTarget> targets;
         // Enabled fabric (UniFi device) targets, used only to find the LAN gateway's monitoring
@@ -366,6 +367,7 @@ public class IspHealthService
         // congestion bucket (>= ~7 samples/bucket) and never finer than the fine window on long ranges.
         var coarseAggregate = TimeSpan.FromSeconds(Math.Clamp(aggregate.TotalSeconds * 8, 60, 120));
 
+        var msSetup = perf.ElapsedMilliseconds; // TEMP ISPPERF
         // AccessIsp stays fully fine: its first-hop RTT drives the loaded-latency delta, matched
         // against the fine LoadWindowSeconds throughput grid.
         var ispSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.AccessIsp, windowStart, windowEnd, aggregate, ct);
@@ -378,6 +380,7 @@ public class IspHealthService
             ? Task.FromResult(new List<MonitoringInfluxClient.LatencySeriesPoint>())
             : _influx.QueryLatencyDetailByTargetIdAsync(gatewayTarget.TargetId, windowStart, windowEnd, aggregate, ct);
         await Task.WhenAll(ispSeriesTask, transitSeriesTask, internetSeriesTask, ratesTask, speedsTask, speedTestsTask, gatewaySeriesTask);
+        var msQ = perf.ElapsedMilliseconds; // TEMP ISPPERF
 
         var ispSeries = ToSamples(await ispSeriesTask);
         var transitSeries = ToSamples(await transitSeriesTask);
@@ -545,13 +548,16 @@ public class IspHealthService
             Load = loadByTime,
             HasTraceMap = hopOrderKnown
         };
+        var msPrep = perf.ElapsedMilliseconds; // TEMP ISPPERF
         var congestionEvents = CongestionLocalizer.Localize(localizerSeries, congestionTopology, _options);
+        var msLoc = perf.ElapsedMilliseconds; // TEMP ISPPERF
         if (referenceEvents != null)
             congestionEvents = GateAgainstCanonical(congestionEvents, referenceEvents, windowEnd);
         // On a long (coarse-aggregate) window, snap congestion boundaries back to fine resolution so
         // a marginal event's 15-min bucket edges don't land off where the canonical view would place
         // them. No-op at canonical resolution; reads run concurrently (see method).
         await RefineCongestionBoundariesAsync(congestionEvents, aggregate, ct);
+        var msRef = perf.ElapsedMilliseconds; // TEMP ISPPERF
         foreach (var ce in congestionEvents)
             _logger.LogDebug(
                 "ISP Health congestion: {Disposition} at {Hop} ({Label}) conf={Confidence} load={Load} - {Reason}",
@@ -562,6 +568,7 @@ public class IspHealthService
         // network show up on every path that crosses it (per the real shift examples)
         var stepInput = allClusters.Concat(internetTargetSeries).ToList();
         var pathShifts = StepChangeDetector.Detect(stepInput, _options);
+        var msStep = perf.ElapsedMilliseconds; // TEMP ISPPERF
 
         // Outage detection: the internet targets going dark defines an outage; every hop is
         // carried (ordered nearest-first by the hop map, RTT tiebreaker) to shape it and
@@ -652,6 +659,7 @@ public class IspHealthService
         var partialDisruptions = OutageDetector.DetectPartial(
             outageHops, outages.Select(o => (o.Start, o.End)).ToList(), _options);
         outages = outages.Concat(partialDisruptions).OrderBy(o => o.Start).ToList();
+        var msOut = perf.ElapsedMilliseconds; // TEMP ISPPERF
 
         // Weight each outage by the time-of-day usage fingerprint so a drop during heavy-usage hours
         // counts in full and one during typically-idle hours dings less. Null fingerprint (weighting
@@ -704,7 +712,11 @@ public class IspHealthService
             PhysicalLink = physical.Input
         };
 
+        var msPost = perf.ElapsedMilliseconds; // TEMP ISPPERF
         var report = new IspHealthScorer(_options, _logger).Score(inputs, profile);
+        var msScore = perf.ElapsedMilliseconds; // TEMP ISPPERF
+        _logger.LogInformation("TEMP ISPPERF window={Win:0}h setup={Setup}ms queries={Q}ms prep={Prep}ms localize={Loc}ms refine={Ref}ms step={Step}ms outage={Out}ms postio={Post}ms score={Score}ms total={Total}ms", // TEMP ISPPERF
+            (windowEnd - windowStart).TotalHours, msSetup, msQ - msSetup, msPrep - msQ, msLoc - msPrep, msRef - msLoc, msStep - msRef, msOut - msStep, msPost - msOut, msScore - msPost, msScore); // TEMP ISPPERF
         report.AccessTechnology = technology;
         report.PhysicalLinkCandidates = physical.Candidates;
         report.PhysicalLinkSelectedKey = physical.SelectedKey;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -358,10 +358,19 @@ public class IspHealthService
         // LoadWindowSeconds, so the auto-computed report is unchanged.
         var aggregate = TimeSpan.FromSeconds(Math.Max(
             _options.LoadWindowSeconds, (windowEnd - windowStart).TotalSeconds / 25000.0));
+        // Transit and InternetService RTT/jitter only feed the 15-min congestion and 30-min step
+        // buckets and whole-window per-ASN statistics, so pulling them at the fine load-classification
+        // resolution is wasted volume (the dominant cost is the app deserializing these series - see
+        // research profiling). Read their RTT/jitter at a coarser window while keeping their loss fine
+        // for outage detection (buckets loss at 15-30 s). Clamped so it stays well under the 15-min
+        // congestion bucket (>= ~7 samples/bucket) and never finer than the fine window on long ranges.
+        var coarseAggregate = TimeSpan.FromSeconds(Math.Clamp(aggregate.TotalSeconds * 8, 60, 120));
 
+        // AccessIsp stays fully fine: its first-hop RTT drives the loaded-latency delta, matched
+        // against the fine LoadWindowSeconds throughput grid.
         var ispSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.AccessIsp, windowStart, windowEnd, aggregate, ct);
-        var transitSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.Transit, windowStart, windowEnd, aggregate, ct);
-        var internetSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.InternetService, windowStart, windowEnd, aggregate, ct);
+        var transitSeriesTask = _influx.QueryLatencyDetailTieredByTargetTypeAsync(MonitoringTargetType.Transit, windowStart, windowEnd, coarseAggregate, aggregate, ct);
+        var internetSeriesTask = _influx.QueryLatencyDetailTieredByTargetTypeAsync(MonitoringTargetType.InternetService, windowStart, windowEnd, coarseAggregate, aggregate, ct);
         var ratesTask = QueryWanRatesAsync(windowStart, windowEnd, aggregate, ct);
         var speedsTask = ResolveExpectedSpeedsAsync(ct);
         var speedTestsTask = LoadWanSpeedTestsAsync(windowStart, windowEnd, ct);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -265,6 +265,7 @@ public class IspHealthService
         if (!_influx.IsConfigured && !await _influx.ReconfigureAsync(ct))
             return new ComputeOutcome(IspHealthStatus.NotConfigured, null, new List<AsnSeries>());
 
+        var perfSw = System.Diagnostics.Stopwatch.StartNew(); // TEMP ISPPERF
         AccessTechnology technology;
         List<MonitoringTarget> targets;
         // Enabled fabric (UniFi device) targets, used only to find the LAN gateway's monitoring
@@ -358,12 +359,13 @@ public class IspHealthService
         // LoadWindowSeconds, so the auto-computed report is unchanged.
         var aggregate = TimeSpan.FromSeconds(Math.Max(
             _options.LoadWindowSeconds, (windowEnd - windowStart).TotalSeconds / 25000.0));
-        // Transit and InternetService RTT/jitter only feed the 15-min congestion and 30-min step
-        // buckets and whole-window per-ASN statistics, so pulling them at the fine load-classification
-        // resolution is wasted volume (the dominant cost is the app deserializing these series - see
-        // research profiling). Read their RTT/jitter at a coarser window while keeping their loss fine
-        // for outage detection (buckets loss at 15-30 s). Clamped so it stays well under the 15-min
-        // congestion bucket (>= ~7 samples/bucket) and never finer than the fine window on long ranges.
+        // Transit and InternetService mean RTT only feeds the 15-min congestion and 30-min step buckets
+        // and whole-window per-ASN medians, so pulling it at the fine load-classification resolution is
+        // wasted volume (the dominant cost is the app deserializing these series - see research
+        // profiling). Read their RTT at a coarser window; JITTER and loss stay fine (fine jitter because
+        // mean-coarsening dilutes the bursts congestion detection and the per-ASN P95 key on, and loss
+        // because outage buckets it at 15-30 s). Clamped so it stays well under the 15-min congestion
+        // bucket (>= ~7 samples/bucket) and never finer than the fine window on long ranges.
         var coarseAggregate = TimeSpan.FromSeconds(Math.Clamp(aggregate.TotalSeconds * 8, 60, 120));
 
         // AccessIsp stays fully fine: its first-hop RTT drives the loaded-latency delta, matched
@@ -712,6 +714,8 @@ public class IspHealthService
         report.PhysicalLinkAmbiguous = physical.Ambiguous;
         _logger.LogDebug("ISP Health computed: {Score} ({Tech}), {Events} congestion events, {Shifts} path shifts",
             report.OverallScore, profile.DisplayName, congestionEvents.Count, pathShifts.Count);
+        _logger.LogInformation("TEMP ISPPERF window={Win:0}h total={Total}ms score={Score}", // TEMP ISPPERF
+            (windowEnd - windowStart).TotalHours, perfSw.ElapsedMilliseconds, report.OverallScore); // TEMP ISPPERF
         return new ComputeOutcome(IspHealthStatus.Ready, report, chartClusters);
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -855,6 +855,31 @@ public class IspHealthService
     }
 
     /// <summary>
+    /// The exact set of target IDs whose loss ISP Health pools into the Packet Loss and Loaded Loss
+    /// factors: every enabled access ISP hop, every enabled transit hop except non-transit IXP /
+    /// anycast infrastructure (WoodyNet / PCH), and the well-known anycast DNS resolvers. Kept here as
+    /// the single source of the pool definition (mirrors the lossPool built in ComputeCoreAsync) so the
+    /// Investigate loss highlight can average the very pool the score is graded on instead of a
+    /// per-type approximation, and the two can never drift.
+    /// </summary>
+    public async Task<List<string>> GetLossPoolTargetIdsAsync(CancellationToken ct = default)
+    {
+        await using var db = await _dbFactory.CreateDbContextAsync(ct);
+        var targets = await db.MonitoringTargets.AsNoTracking()
+            .Where(t => t.Enabled && (t.TargetType == MonitoringTargetType.AccessIsp
+                || t.TargetType == MonitoringTargetType.Transit
+                || t.TargetType == MonitoringTargetType.InternetService))
+            .ToListAsync(ct);
+        return targets
+            .Where(t => t.TargetType == MonitoringTargetType.AccessIsp
+                || (t.TargetType == MonitoringTargetType.Transit
+                    && !(t.AsnNumber is int a && WellKnownAsns.NonTransitInfrastructure.Contains(a)))
+                || (t.TargetType == MonitoringTargetType.InternetService && AnycastDnsIps.Contains(t.Address)))
+            .Select(t => t.TargetId)
+            .ToList();
+    }
+
+    /// <summary>
     /// Expected speeds are configured values, never measured: the UniFi WAN provider
     /// capabilities (ISP speeds the user set in UniFi Network) with the Adaptive SQM
     /// nominal speeds as fallback.

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -265,7 +265,6 @@ public class IspHealthService
         if (!_influx.IsConfigured && !await _influx.ReconfigureAsync(ct))
             return new ComputeOutcome(IspHealthStatus.NotConfigured, null, new List<AsnSeries>());
 
-        var perfSw = System.Diagnostics.Stopwatch.StartNew(); // TEMP ISPPERF
         AccessTechnology technology;
         List<MonitoringTarget> targets;
         // Enabled fabric (UniFi device) targets, used only to find the LAN gateway's monitoring
@@ -709,8 +708,6 @@ public class IspHealthService
         report.PhysicalLinkAmbiguous = physical.Ambiguous;
         _logger.LogDebug("ISP Health computed: {Score} ({Tech}), {Events} congestion events, {Shifts} path shifts",
             report.OverallScore, profile.DisplayName, congestionEvents.Count, pathShifts.Count);
-        _logger.LogInformation("TEMP ISPPERF window={Win:0}h total={Total}ms score={Score}", // TEMP ISPPERF
-            (windowEnd - windowStart).TotalHours, perfSw.ElapsedMilliseconds, report.OverallScore); // TEMP ISPPERF
         return new ComputeOutcome(IspHealthStatus.Ready, report, chartClusters);
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -265,7 +265,6 @@ public class IspHealthService
         if (!_influx.IsConfigured && !await _influx.ReconfigureAsync(ct))
             return new ComputeOutcome(IspHealthStatus.NotConfigured, null, new List<AsnSeries>());
 
-        var perf = System.Diagnostics.Stopwatch.StartNew(); // TEMP ISPPERF
         AccessTechnology technology;
         List<MonitoringTarget> targets;
         // Enabled fabric (UniFi device) targets, used only to find the LAN gateway's monitoring
@@ -367,7 +366,6 @@ public class IspHealthService
         // congestion bucket (>= ~7 samples/bucket) and never finer than the fine window on long ranges.
         var coarseAggregate = TimeSpan.FromSeconds(Math.Clamp(aggregate.TotalSeconds * 8, 60, 120));
 
-        var msSetup = perf.ElapsedMilliseconds; // TEMP ISPPERF
         // AccessIsp stays fully fine: its first-hop RTT drives the loaded-latency delta, matched
         // against the fine LoadWindowSeconds throughput grid.
         var ispSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.AccessIsp, windowStart, windowEnd, aggregate, ct);
@@ -380,7 +378,6 @@ public class IspHealthService
             ? Task.FromResult(new List<MonitoringInfluxClient.LatencySeriesPoint>())
             : _influx.QueryLatencyDetailByTargetIdAsync(gatewayTarget.TargetId, windowStart, windowEnd, aggregate, ct);
         await Task.WhenAll(ispSeriesTask, transitSeriesTask, internetSeriesTask, ratesTask, speedsTask, speedTestsTask, gatewaySeriesTask);
-        var msQ = perf.ElapsedMilliseconds; // TEMP ISPPERF
 
         var ispSeries = ToSamples(await ispSeriesTask);
         var transitSeries = ToSamples(await transitSeriesTask);
@@ -548,16 +545,13 @@ public class IspHealthService
             Load = loadByTime,
             HasTraceMap = hopOrderKnown
         };
-        var msPrep = perf.ElapsedMilliseconds; // TEMP ISPPERF
         var congestionEvents = CongestionLocalizer.Localize(localizerSeries, congestionTopology, _options);
-        var msLoc = perf.ElapsedMilliseconds; // TEMP ISPPERF
         if (referenceEvents != null)
             congestionEvents = GateAgainstCanonical(congestionEvents, referenceEvents, windowEnd);
         // On a long (coarse-aggregate) window, snap congestion boundaries back to fine resolution so
         // a marginal event's 15-min bucket edges don't land off where the canonical view would place
         // them. No-op at canonical resolution; reads run concurrently (see method).
         await RefineCongestionBoundariesAsync(congestionEvents, aggregate, ct);
-        var msRef = perf.ElapsedMilliseconds; // TEMP ISPPERF
         foreach (var ce in congestionEvents)
             _logger.LogDebug(
                 "ISP Health congestion: {Disposition} at {Hop} ({Label}) conf={Confidence} load={Load} - {Reason}",
@@ -568,7 +562,6 @@ public class IspHealthService
         // network show up on every path that crosses it (per the real shift examples)
         var stepInput = allClusters.Concat(internetTargetSeries).ToList();
         var pathShifts = StepChangeDetector.Detect(stepInput, _options);
-        var msStep = perf.ElapsedMilliseconds; // TEMP ISPPERF
 
         // Outage detection: the internet targets going dark defines an outage; every hop is
         // carried (ordered nearest-first by the hop map, RTT tiebreaker) to shape it and
@@ -659,7 +652,6 @@ public class IspHealthService
         var partialDisruptions = OutageDetector.DetectPartial(
             outageHops, outages.Select(o => (o.Start, o.End)).ToList(), _options);
         outages = outages.Concat(partialDisruptions).OrderBy(o => o.Start).ToList();
-        var msOut = perf.ElapsedMilliseconds; // TEMP ISPPERF
 
         // Weight each outage by the time-of-day usage fingerprint so a drop during heavy-usage hours
         // counts in full and one during typically-idle hours dings less. Null fingerprint (weighting
@@ -712,11 +704,7 @@ public class IspHealthService
             PhysicalLink = physical.Input
         };
 
-        var msPost = perf.ElapsedMilliseconds; // TEMP ISPPERF
         var report = new IspHealthScorer(_options, _logger).Score(inputs, profile);
-        var msScore = perf.ElapsedMilliseconds; // TEMP ISPPERF
-        _logger.LogInformation("TEMP ISPPERF window={Win:0}h setup={Setup}ms queries={Q}ms prep={Prep}ms localize={Loc}ms refine={Ref}ms step={Step}ms outage={Out}ms postio={Post}ms score={Score}ms total={Total}ms", // TEMP ISPPERF
-            (windowEnd - windowStart).TotalHours, msSetup, msQ - msSetup, msPrep - msQ, msLoc - msPrep, msRef - msLoc, msStep - msRef, msOut - msStep, msPost - msOut, msScore - msPost, msScore); // TEMP ISPPERF
         report.AccessTechnology = technology;
         report.PhysicalLinkCandidates = physical.Candidates;
         report.PhysicalLinkSelectedKey = physical.SelectedKey;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
@@ -234,17 +234,31 @@ public static class OutageDetector
         IReadOnlyList<IReadOnlyList<LatencySample>> targets, TimeSpan windowSize)
     {
         var perBucket = new Dictionary<DateTime, List<double>>();
+        // Accumulate sum+count per bucket manually rather than GroupBy(...).Average(): the loss
+        // series are coarse relative to the outage bucket, so most buckets hold a single sample and
+        // GroupBy would allocate one IGrouping per bucket per hop. Summation stays in source order,
+        // so the per-bucket mean is bit-identical to the GroupBy version.
+        var sum = new Dictionary<DateTime, double>();
+        var cnt = new Dictionary<DateTime, int>();
         foreach (var target in targets)
         {
-            foreach (var g in target.Where(s => s.LossPercent.HasValue)
-                         .GroupBy(s => CongestionDetector.FloorTime(s.Time, windowSize)))
+            sum.Clear();
+            cnt.Clear();
+            foreach (var s in target)
             {
-                if (!perBucket.TryGetValue(g.Key, out var list))
+                if (!s.LossPercent.HasValue) continue;
+                var b = CongestionDetector.FloorTime(s.Time, windowSize);
+                sum[b] = (sum.TryGetValue(b, out var sv) ? sv : 0d) + s.LossPercent.Value;
+                cnt[b] = (cnt.TryGetValue(b, out var cv) ? cv : 0) + 1;
+            }
+            foreach (var kv in cnt)
+            {
+                if (!perBucket.TryGetValue(kv.Key, out var list))
                 {
                     list = new List<double>();
-                    perBucket[g.Key] = list;
+                    perBucket[kv.Key] = list;
                 }
-                list.Add(g.Average(s => s.LossPercent!.Value));
+                list.Add(sum[kv.Key] / kv.Value);
             }
         }
         return perBucket;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/SeriesStats.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/SeriesStats.cs
@@ -73,6 +73,17 @@ internal static class SeriesStats
         return PercentileSorted(dev, 0.5);
     }
 
+    /// <summary>Winsorized mean of an already ascending-sorted list, matching <see cref="WinsorizedMean"/>.</summary>
+    public static double? WinsorizedMeanSorted(IReadOnlyList<double> sortedAsc, double upperPercentile)
+    {
+        if (sortedAsc.Count == 0) return null;
+        var cap = PercentileSorted(sortedAsc, upperPercentile);
+        if (cap == null) return null;
+        double sum = 0;
+        for (var i = 0; i < sortedAsc.Count; i++) sum += Math.Min(sortedAsc[i], cap.Value);
+        return sum / sortedAsc.Count;
+    }
+
     /// <summary>Interquartile range as (q1, q3), or null when empty.</summary>
     public static (double Q1, double Q3)? Iqr(IReadOnlyList<double> values)
     {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/SeriesStats.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/SeriesStats.cs
@@ -42,6 +42,37 @@ internal static class SeriesStats
         return Median(deviations);
     }
 
+    // ---- Pre-sorted variants ----
+    // When several statistics are needed over the same series, the caller sorts once and uses these
+    // instead of the list overloads (each of which sorts internally). Results are identical.
+
+    /// <summary>Percentile of an already ascending-sorted list, matching <see cref="Percentile"/>.</summary>
+    public static double? PercentileSorted(IReadOnlyList<double> sortedAsc, double p)
+    {
+        if (sortedAsc.Count == 0) return null;
+        var rank = p * (sortedAsc.Count - 1);
+        var lo = (int)Math.Floor(rank);
+        var hi = (int)Math.Ceiling(rank);
+        if (lo == hi) return sortedAsc[lo];
+        return sortedAsc[lo] + (sortedAsc[hi] - sortedAsc[lo]) * (rank - lo);
+    }
+
+    /// <summary>Median of an already ascending-sorted list, matching <see cref="Median"/>.</summary>
+    public static double? MedianSorted(IReadOnlyList<double> sortedAsc) => PercentileSorted(sortedAsc, 0.5);
+
+    /// <summary>
+    /// MAD given the series already ascending-sorted and its (pre-computed) median, so the median
+    /// isn't re-sorted for. Identical result to <see cref="Mad"/>.
+    /// </summary>
+    public static double? MadSorted(IReadOnlyList<double> sortedAsc, double median)
+    {
+        if (sortedAsc.Count == 0) return null;
+        var dev = new double[sortedAsc.Count];
+        for (var i = 0; i < sortedAsc.Count; i++) dev[i] = Math.Abs(sortedAsc[i] - median);
+        Array.Sort(dev);
+        return PercentileSorted(dev, 0.5);
+    }
+
     /// <summary>Interquartile range as (q1, q3), or null when empty.</summary>
     public static (double Q1, double Q3)? Iqr(IReadOnlyList<double> values)
     {

--- a/tests/NetworkOptimizer.Storage.Tests/MonitoringInfluxCsvParserTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/MonitoringInfluxCsvParserTests.cs
@@ -11,24 +11,17 @@ namespace NetworkOptimizer.Storage.Tests;
 /// </summary>
 public class MonitoringInfluxCsvParserTests
 {
-    // Annotated CSV exactly as Flux returns the UN-PIVOTED latency-detail query: one row per
-    // (target_id, _field, _time), fields spread across separate tables and arriving out of time order.
-    // The parser must reassemble them onto one point per (target, timestamp), map by column name (the
-    // _time/_value/_field/target_id columns can sit anywhere), and sort by time.
+    // Annotated CSV exactly as Flux returns the latency-detail pivot query. The field columns are in
+    // a deliberately non-positional order (jitter, loss, rtt_avg, rtt_max) to prove the parser maps
+    // by column name, not index.
     private const string Csv =
-        "#group,false,false,true,true,false,false,true,true,true,true,false\r\n" +
-        "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string,string\r\n" +
+        "#group,false,false,true,true,false,true,true,false,false,false,false\r\n" +
+        "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double,double,double,double\r\n" +
         "#default,_result,,,,,,,,,,\r\n" +
-        ",result,table,_start,_stop,_time,_value,_field,_measurement,target_id,target_type,vantage_point\r\n" +
-        ",,0,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T01:00:00Z,0.7,jitter_ms,latency,transit-x,transit,server\r\n" +
-        ",,0,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,0.3,jitter_ms,latency,transit-x,transit,server\r\n" +
-        ",,1,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T01:00:00Z,0,loss_percent,latency,transit-x,transit,server\r\n" +
-        ",,1,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,0,loss_percent,latency,transit-x,transit,server\r\n" +
-        ",,2,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T01:00:00Z,3,rtt_avg_ms,latency,transit-x,transit,server\r\n" +
-        ",,2,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,2.8,rtt_avg_ms,latency,transit-x,transit,server\r\n" +
-        ",,3,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T01:00:00Z,3.4,rtt_max_ms,latency,transit-x,transit,server\r\n" +
-        ",,3,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,3.1,rtt_max_ms,latency,transit-x,transit,server\r\n" +
-        ",,4,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,12.3,rtt_avg_ms,latency,cdn-y,internetservice,server\r\n";
+        ",result,table,_start,_stop,_time,target_id,target_type,jitter_ms,loss_percent,rtt_avg_ms,rtt_max_ms\r\n" +
+        ",,0,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T01:00:00Z,transit-x,transit,0.7,0,3,3.4\r\n" +
+        ",,0,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,transit-x,transit,0.3,0,2.8,3.1\r\n" +
+        ",,1,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,cdn-y,internetservice,,,12.3,\r\n";
 
     [Fact]
     public void Parses_points_per_target_mapping_columns_by_name()

--- a/tests/NetworkOptimizer.Storage.Tests/MonitoringInfluxCsvParserTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/MonitoringInfluxCsvParserTests.cs
@@ -11,17 +11,24 @@ namespace NetworkOptimizer.Storage.Tests;
 /// </summary>
 public class MonitoringInfluxCsvParserTests
 {
-    // Annotated CSV exactly as Flux returns the latency-detail pivot query. The field columns are in
-    // a deliberately non-positional order (jitter, loss, rtt_avg, rtt_max) to prove the parser maps
-    // by column name, not index.
+    // Annotated CSV exactly as Flux returns the UN-PIVOTED latency-detail query: one row per
+    // (target_id, _field, _time), fields spread across separate tables and arriving out of time order.
+    // The parser must reassemble them onto one point per (target, timestamp), map by column name (the
+    // _time/_value/_field/target_id columns can sit anywhere), and sort by time.
     private const string Csv =
-        "#group,false,false,true,true,false,true,true,false,false,false,false\r\n" +
-        "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double,double,double,double\r\n" +
+        "#group,false,false,true,true,false,false,true,true,true,true,false\r\n" +
+        "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string,string\r\n" +
         "#default,_result,,,,,,,,,,\r\n" +
-        ",result,table,_start,_stop,_time,target_id,target_type,jitter_ms,loss_percent,rtt_avg_ms,rtt_max_ms\r\n" +
-        ",,0,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T01:00:00Z,transit-x,transit,0.7,0,3,3.4\r\n" +
-        ",,0,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,transit-x,transit,0.3,0,2.8,3.1\r\n" +
-        ",,1,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,cdn-y,internetservice,,,12.3,\r\n";
+        ",result,table,_start,_stop,_time,_value,_field,_measurement,target_id,target_type,vantage_point\r\n" +
+        ",,0,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T01:00:00Z,0.7,jitter_ms,latency,transit-x,transit,server\r\n" +
+        ",,0,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,0.3,jitter_ms,latency,transit-x,transit,server\r\n" +
+        ",,1,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T01:00:00Z,0,loss_percent,latency,transit-x,transit,server\r\n" +
+        ",,1,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,0,loss_percent,latency,transit-x,transit,server\r\n" +
+        ",,2,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T01:00:00Z,3,rtt_avg_ms,latency,transit-x,transit,server\r\n" +
+        ",,2,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,2.8,rtt_avg_ms,latency,transit-x,transit,server\r\n" +
+        ",,3,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T01:00:00Z,3.4,rtt_max_ms,latency,transit-x,transit,server\r\n" +
+        ",,3,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,3.1,rtt_max_ms,latency,transit-x,transit,server\r\n" +
+        ",,4,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,12.3,rtt_avg_ms,latency,cdn-y,internetservice,server\r\n";
 
     [Fact]
     public void Parses_points_per_target_mapping_columns_by_name()


### PR DESCRIPTION
## What & why

ISP Health's report computation was heavy enough to be slow (and occasionally time out) on lower-power NAS hardware. This optimizes the in-memory detector and scorer hot paths so the compute is meaningfully faster, with bit-identical scoring, and fixes two smaller issues found along the way.

## Performance (results unchanged)

- **Congestion localizer fast-path.** The per-event elevation/rise tests re-scanned each full series and re-sorted the out-of-window baseline on every call, which dominated long-window computes. They now read from a per-series precomputed index: binary-searched in-window slices, plus exact value-exclusion for the baseline so the median/percentile is read off a pre-sorted array without re-sorting. Measured roughly 5x faster localization at a 30-day window.
- **Sort once.** The detectors and per-ASN scorer sorted the same series 4-5 times (median + MAD + percentile + winsorized mean, each re-sorting internally). They now sort once and derive the statistics from it.
- **Leaner outage bucketing.** The outage and partial-loss passes accumulate per-bucket sums directly instead of allocating a grouping object per bucket.

All of the above are bit-identical. The full suite, including the real-data replay and regression tests, confirms scores and events are unchanged.

## Fixes

- **Congestion timeline: don't claim "and the hops beyond" for an unlocalized event.** A target with no saved trace could surface as an unlocalized congestion event and still get the "and the hops beyond" phrasing, describing an endpoint as an intermediate hop with topology past it. The phrasing is now gated on a placed bottleneck hop, so only genuinely localized hops (and shared-incident owners) carry it.
- **Investigate loss %: pool across the exact scored set.** The Latency & Packet Loss "Investigate" highlight labeled the shaded band with a single target's peak-loss minute. It now shows the pooled mean loss across the same set of targets the Packet Loss and Loaded Loss factors are graded on, sourced from one definition so the two cannot drift. It reads lower and reflects what the score is actually computed on.

## Testing

- Full solution build: 0 warnings.
- All tests pass, including the ISP Health real-data replay and regression suites; scoring and events are bit-identical apart from the two intended fixes above.
- Verified on the NAS and Mac test sites.
