### PR TITLE
ISP Health: adaptive fallback window for slower hardware (#941)

### DIFF
--- a/src/NetworkOptimizer.Storage/Migrations/20260701210000_AddIspHealthScoreWindow.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260701210000_AddIspHealthScoreWindow.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701210000_AddIspHealthScoreWindow")]
+    partial class AddIspHealthScoreWindow
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260701210000_AddIspHealthScoreWindow.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260701210000_AddIspHealthScoreWindow.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIspHealthScoreWindow : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "IspHealthScoreWindowHours",
+                table: "MonitoringSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 48);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IspHealthScoreWindowHours",
+                table: "MonitoringSettings");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/MonitoringSettings.cs
+++ b/src/NetworkOptimizer.Storage/Models/MonitoringSettings.cs
@@ -129,6 +129,13 @@ public class MonitoringSettings
     [MaxLength(120)]
     public string? PhysicalLinkSourceKey { get; set; }
 
+    /// <summary>
+    /// Target trailing window (hours) for the auto-computed ISP Health score and the tab's default
+    /// view. This is the ceiling the compute aims for; on slower hardware where the target exceeds the
+    /// per-compute time budget it automatically falls back to a shorter window (24 h, then 16 h).
+    /// </summary>
+    public int IspHealthScoreWindowHours { get; set; } = 48;
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -137,6 +137,12 @@ public class MonitoringInfluxClient : IAsyncDisposable
                 .Url(url)
                 .AuthenticateToken(plainToken)
                 .LogLevel(InfluxDB.Client.Core.LogLevel.None)
+                // The client default query timeout (~10 s) cancels heavy reads (e.g. a 48 h ISP Health
+                // window on a slow spinning-disk NAS with a Comcast-style hop-heavy path - see #941)
+                // before they finish, surfacing as a TaskCanceledException that reads as a hard failure.
+                // Raise it well past ISP Health's own per-compute budget so that budget is the single
+                // authority on when to give up (and fall back to a shorter window), not the transport.
+                .TimeOut(TimeSpan.FromSeconds(60))
                 .Build();
 
             _client = new InfluxDBClient(options);

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -181,7 +181,7 @@ else
             <div class="isp-health-hero-gauge">
                 <IspHealthScoreGauge Score="r.OverallScore" Label="ISP Health" />
                 <div class="isp-health-profile-chip isp-health-profile-chip-selectable"
-                     data-tooltip="Thresholds are tuned per access technology; change it to re-score.">
+                     data-tooltip="Thresholds are tuned per access technology; change it to re-score." data-tooltip-hover-only>
                     Scored as @r.Profile.DisplayName &middot; @ScoredWindowLabel(r)
                     <span class="isp-profile-chip-caret"></span>
                     <select class="isp-profile-chip-select" aria-label="Access technology"
@@ -288,7 +288,7 @@ else
                         @if (dimension == r.AccessDimension)
                         {
                             <select class="isp-access-tech-select" aria-label="Access technology"
-                                    data-tooltip="Thresholds are tuned per access technology; change it to re-score."
+                                    data-tooltip="Thresholds are tuned per access technology; change it to re-score." data-tooltip-hover-only
                                     value="@((int)r.AccessTechnology)" @onchange="OnAccessTechnologyChanged">
                                 @foreach (var tech in ProfileTechOptions)
                                 {

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -16,6 +16,19 @@
         {
             <div class="isp-popover-backdrop" @onclick="() => _showCustomPopover = false"></div>
         }
+        @{
+            var effWin = IspHealth.EffectiveWindowHours;
+            var cfgWin = IspHealth.ConfiguredWindowHours;
+            var windowReduced = effWin > 0 && cfgWin > 0 && effWin < cfgWin;
+        }
+        @if (windowReduced)
+        {
+            <button class="isp-window-reduced" @onclick="RetryFullWindowAsync" disabled="@(_refreshing || _windowComputing)"
+                    data-tooltip="Auto-reduced to @(effWin) h: the @(cfgWin) h window took longer than this hardware's time budget to compute, so the live score and default view use a shorter window. Tap to retry the full window (e.g. after a hardware upgrade)." data-tooltip-hover-only>
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" /></svg>
+                <span>@(effWin)h</span>
+            </button>
+        }
         <div class="time-range-selector @(_showCustomPopover ? "isp-filter-raised" : "")" style="position: relative;">
             @foreach (var p in FilterPresets)
             {
@@ -607,6 +620,35 @@ else
     private DateTime _customTo = DateTime.Now;
 
     private bool IsLiveWindow => !_isCustom && _selectedPreset == DefaultPresetHours;
+
+    /// <summary>
+    /// User asked to retry the full configured window from the "reduced window" badge (e.g. after a
+    /// hardware upgrade). Reset the auto-fallback so the next compute re-probes the target, then force
+    /// a recompute; if the box still can't finish it in time it simply drops back and the badge
+    /// returns. Only swaps the displayed report when on the live view.
+    /// </summary>
+    private async Task RetryFullWindowAsync()
+    {
+        if (_refreshing || _windowComputing) return;
+        IspHealth.RetryConfiguredWindow();
+        _refreshing = true;
+        StateHasChanged();
+        try
+        {
+            var report = await IspHealth.GetReportAsync(forceRefresh: true);
+            if (IsLiveWindow)
+            {
+                _report = report;
+                try { await JS.InvokeVoidAsync("eval", "window.__ispHealthCharts?.reload?.();"); }
+                catch { /* chart not mounted yet */ }
+            }
+        }
+        finally
+        {
+            _refreshing = false;
+        }
+        StateHasChanged();
+    }
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -6,9 +6,10 @@
 @inject IJSRuntime JS
 @inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
 
-@* Date/time filter (left) + Refresh. Default 48 h is the live/cached view and the only state
-   where Refresh is enabled; any other selection recomputes off-cache and locks Refresh. Always
-   rendered (once past initial load) so a custom window with no data can still be switched back. *@
+@* Date/time filter (left) + Refresh. The live/cached view (the effective auto-computed window, which
+   auto-fallback may have reduced below the configured target) is the only state where Refresh is
+   enabled; any other selection recomputes off-cache and locks Refresh. Always rendered (once past
+   initial load) so a custom window with no data can still be switched back. *@
 @if (!_loading)
 {
     <div class="isp-health-toolbar">
@@ -24,7 +25,7 @@
         @if (windowReduced)
         {
             <button class="isp-window-reduced" @onclick="RetryFullWindowAsync" disabled="@(_refreshing || _windowComputing)"
-                    data-tooltip="Auto-reduced to @(effWin) h: the @(cfgWin) h window took longer than this hardware's time budget to compute, so the live score and default view use a shorter window. Tap to retry the full window (e.g. after a hardware upgrade)." data-tooltip-hover-only>
+                    data-tooltip="ISP Health is slow-running on your box, so we dropped the window to @(effWin)h. Tap to retry, and adjust if your hardware has changed." data-tooltip-hover-only>
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" /></svg>
                 <span>@(effWin)h</span>
             </button>
@@ -590,9 +591,10 @@ else
     private bool _showAllIspHops;
     private System.Threading.Timer? _ageTimer;
 
-    // Date/time filter. Never persisted: OnInitializedAsync always starts on 48 h, so leaving
-    // and returning to the tab (and every auto-computed path) resets to the live window.
-    private static readonly (string Label, int Hours)[] FilterPresets =
+    // Date/time filter. Never persisted: OnInitializedAsync starts on the live window (the effective
+    // auto-computed window, which auto-fallback may have reduced below the configured target), so
+    // leaving and returning to the tab - and every auto-computed path - resets to the live view.
+    private static readonly (string Label, int Hours)[] BasePresets =
     {
         ("24h", 24), ("48h", 48), ("7d", 168), ("14d", 336), ("30d", 720)
     };
@@ -600,6 +602,32 @@ else
     private const int MaxRangeHours = 720;   // 30-day / 1-month hard cap
     private const int MinRangeHours = 4;     // smallest custom window
     private int _selectedPreset = DefaultPresetHours;
+    // True while the selection follows the live/cached auto-computed report (rather than a preset or
+    // custom window computed off-cache). While set, _selectedPreset is kept in sync with the effective
+    // (possibly reduced) window so the matching button stays highlighted.
+    private bool _followLive = true;
+
+    // The live/cached window in hours: the effective auto-computed window (reduced by auto-fallback
+    // when the box can't finish the configured target in time), else the configured target, else 48.
+    private int LiveWindowHours => IspHealth.EffectiveWindowHours > 0
+        ? IspHealth.EffectiveWindowHours
+        : (IspHealth.ConfiguredWindowHours > 0 ? IspHealth.ConfiguredWindowHours : DefaultPresetHours);
+
+    // Presets shown in the selector: the base set plus the live window when auto-fallback landed on a
+    // value that isn't already a preset (e.g. the 16 h rung), so the active default always has a button.
+    private IEnumerable<(string Label, int Hours)> FilterPresets
+    {
+        get
+        {
+            var live = LiveWindowHours;
+            if (BasePresets.Any(p => p.Hours == live))
+                return BasePresets;
+            return BasePresets.Append((Label: FormatPresetLabel(live), Hours: live)).OrderBy(p => p.Hours);
+        }
+    }
+
+    private static string FormatPresetLabel(int hours) =>
+        hours % 24 == 0 ? $"{hours / 24}d" : $"{hours}h";
     private bool _isCustom;
     private bool _showCustomPopover;
     private bool _windowComputing;
@@ -619,7 +647,7 @@ else
     private DateTime _customFrom = DateTime.Now.AddDays(-2);
     private DateTime _customTo = DateTime.Now;
 
-    private bool IsLiveWindow => !_isCustom && _selectedPreset == DefaultPresetHours;
+    private bool IsLiveWindow => !_isCustom && _followLive;
 
     /// <summary>
     /// User asked to retry the full configured window from the "reduced window" badge (e.g. after a
@@ -647,6 +675,8 @@ else
         {
             _refreshing = false;
         }
+        // The retry may restore the full window or drop again; re-sync the highlighted button.
+        if (_followLive) _selectedPreset = LiveWindowHours;
         StateHasChanged();
     }
 
@@ -666,6 +696,9 @@ else
         {
             _loading = false;
         }
+
+        // Highlight the button for the effective (possibly auto-reduced) live window.
+        if (_followLive) _selectedPreset = LiveWindowHours;
 
         // Re-render every 30 s so "Last updated: N min ago" ages on its own, and - on the live
         // 48 h view - pull the latest cached snapshot so the tab follows the background recompute
@@ -702,6 +735,8 @@ else
             catch { /* never let a fetch fault kill the timer */ }
             finally { _autoReloading = false; }
         }
+        // Follow a background auto-fallback: keep the live button on the effective window.
+        if (_followLive) _selectedPreset = LiveWindowHours;
         StateHasChanged();
     }
 
@@ -867,7 +902,7 @@ else
         {
             // Seed both pickers from the active window so they reflect the current filter.
             _customTo = (_windowEnd ?? DateTime.UtcNow).ToLocalTime();
-            _customFrom = (_windowStart ?? DateTime.UtcNow.AddHours(-DefaultPresetHours)).ToLocalTime();
+            _customFrom = (_windowStart ?? DateTime.UtcNow.AddHours(-LiveWindowHours)).ToLocalTime();
         }
     }
 
@@ -876,8 +911,11 @@ else
         _showCustomPopover = false;
         _isCustom = false;
         _selectedPreset = hours;
-        if (hours == DefaultPresetHours)
-            await LoadWindowAsync(null, null);   // back to the live/cached 48 h report
+        // Selecting the live window follows the cached auto-computed report; anything else computes
+        // that window off-cache.
+        _followLive = hours == LiveWindowHours;
+        if (_followLive)
+            await LoadWindowAsync(null, null);   // back to the live/cached report
         else
         {
             var end = DateTime.UtcNow;

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -163,9 +163,14 @@ else
        score never displays a stale number mid-recompute. The detail cards below stay put. *@
     @if (_refreshing || _windowComputing)
     {
-        <div class="isp-health-loading card isp-health-hero-loading">
-            <div class="isp-health-loading-spinner"></div>
-            <p class="isp-health-loading-text">Analyzing ISP and transit data...</p>
+        @* Reuse the hero's exact card + card-body chain so the spinner box matches the score box to
+           the pixel (a single min-height on .isp-health-hero-body governs both); only the inner layout
+           differs, which doesn't affect the outer height. *@
+        <div class="isp-health-hero card">
+            <div class="card-body isp-health-hero-body isp-health-hero-body-loading">
+                <div class="isp-health-loading-spinner"></div>
+                <p class="isp-health-loading-text">Analyzing ISP and transit data...</p>
+            </div>
         </div>
     }
     else

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -25,7 +25,7 @@
         @if (windowReduced)
         {
             <button class="isp-window-reduced" @onclick="RetryFullWindowAsync" disabled="@(_refreshing || _windowComputing)"
-                    data-tooltip="ISP Health is slow-running on your box, so we dropped the window to @(effWin)h. Tap to retry, and adjust if your hardware has changed." data-tooltip-hover-only>
+                    data-tooltip="ISP Health is slow-running on your box, so we dropped the default window to @(effWin)h. Tap to retry, and adjust if your hardware has changed." data-tooltip-hover-only>
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" /></svg>
                 <span>@(effWin)h</span>
             </button>
@@ -158,6 +158,18 @@ else
             </div>
         </div>
     }
+    @* While an explicit recompute is in flight (Refresh, a time-window change, or an access-tech
+       change) swap just the hero for the same area spinner shown on initial load, so the headline
+       score never displays a stale number mid-recompute. The detail cards below stay put. *@
+    @if (_refreshing || _windowComputing)
+    {
+        <div class="isp-health-loading card isp-health-hero-loading">
+            <div class="isp-health-loading-spinner"></div>
+            <p class="isp-health-loading-text">Analyzing recent ISP data...</p>
+        </div>
+    }
+    else
+    {
     <div class="isp-health-hero card">
         <span class="isp-health-updated">Last updated: @TimeFormatHelper.FormatRelativeTimeShort(r.ComputedAt)</span>
         <div class="card-body isp-health-hero-body">
@@ -216,6 +228,7 @@ else
             </div>
         </div>
     </div>
+    }
 
     @if (r.Issues.Count > 0)
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -76,7 +76,7 @@
 {
     <div class="isp-health-loading card">
         <div class="isp-health-loading-spinner"></div>
-        <p class="isp-health-loading-text">Analyzing recent ISP data...</p>
+        <p class="isp-health-loading-text">Analyzing recent ISP and transit data...</p>
     </div>
 }
 else if (_report == null)
@@ -165,7 +165,7 @@ else
     {
         <div class="isp-health-loading card isp-health-hero-loading">
             <div class="isp-health-loading-spinner"></div>
-            <p class="isp-health-loading-text">Analyzing recent ISP data...</p>
+            <p class="isp-health-loading-text">Analyzing ISP and transit data...</p>
         </div>
     }
     else

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -9,8 +9,23 @@ namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
 /// </summary>
 public class IspHealthOptions
 {
-    /// <summary>Trailing analysis window in hours.</summary>
+    /// <summary>Trailing analysis window in hours. The built-in default target; the per-site
+    /// configurable target (MonitoringSettings.IspHealthScoreWindowHours) overrides it.</summary>
     public int ScoreWindowHours { get; set; } = 48;
+
+    /// <summary>
+    /// Trailing windows (hours) the auto-computed score falls back through, longest first, when a
+    /// compute exceeds <see cref="ComputeBudget"/> on slower hardware. Only rungs at or below the
+    /// configured target window are used; a rung below <see cref="MinDataHours"/> is skipped.
+    /// </summary>
+    public int[] ScoreWindowLadderHours { get; set; } = { 48, 24, 16 };
+
+    /// <summary>
+    /// Per-attempt time budget for an auto-computed score. If a window's compute exceeds it, the auto
+    /// path abandons that window and drops to the next-shorter rung. Kept under the ~30 s HTTP/circuit
+    /// timeout so the default view never hangs on a window the hardware cannot finish in time.
+    /// </summary>
+    public TimeSpan ComputeBudget { get; set; } = TimeSpan.FromSeconds(25);
 
     /// <summary>Minimum hours of latency data required before a score is shown (new installs).</summary>
     public int MinDataHours { get; set; } = 4;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -45,6 +45,13 @@ public class IspHealthService
     private CustomWindowSnapshot? _customCache;
     private IspHealthStatus _status = IspHealthStatus.Computing;
     private volatile bool _computing;
+    // Trailing window (hours) the last successful auto-compute used. Drops down the ladder when a
+    // longer window exceeds the compute budget on this hardware; resets to 0 on process restart so the
+    // configured target is re-probed once after each deploy. 0 until the first auto-compute runs.
+    private volatile int _effectiveWindowHours;
+    // Configured target window (hours), cached from MonitoringSettings on each auto-compute so the
+    // dashboard tile and tab can read it without a DB hit. 0 until the first auto-compute runs.
+    private volatile int _configuredWindowHours;
 
     public IspHealthService(
         MonitoringInfluxClient influx,
@@ -185,15 +192,125 @@ public class IspHealthService
 
     public IspHealthStatus Status => _cached != null ? IspHealthStatus.Ready : _status;
 
+    /// <summary>The trailing window (hours) the auto-computed score and default view currently use.
+    /// Falls below the configured target on slower hardware that can't finish the longer window inside
+    /// the compute budget. 0 until the first auto-compute completes.</summary>
+    public int EffectiveWindowHours => _effectiveWindowHours;
+
+    /// <summary>The configured target window (hours) the auto-compute aims for (per-site setting, or
+    /// the built-in default). 0 until the first auto-compute runs.</summary>
+    public int ConfiguredWindowHours => _configuredWindowHours;
+
+    /// <summary>
+    /// Re-probe the configured target window on the next auto-compute. Wired to the "reduced window"
+    /// badge so a user who thinks the hardware can now handle the full window (e.g. after an upgrade)
+    /// can ask for it: resets the fallback to start the ladder at the target again, and drops the
+    /// cached shorter report so the next read recomputes.
+    /// </summary>
+    public void RetryConfiguredWindow()
+    {
+        _effectiveWindowHours = 0;
+        _cached = null;
+    }
+
     private async Task<(IspHealthReport? Report, List<AsnSeries> ChartClusters)> ComputeAsync(CancellationToken ct)
     {
-        // Canonical/auto-computed path: always the trailing ScoreWindowHours (48 h). Publishes
-        // the readiness status the dashboard tile reads.
-        var windowEnd = DateTime.UtcNow;
-        var windowStart = windowEnd.AddHours(-_options.ScoreWindowHours);
-        var outcome = await ComputeCoreAsync(windowStart, windowEnd, null, ct);
-        _status = outcome.Status;
-        return (outcome.Report, outcome.ChartClusters);
+        // Canonical/auto-computed path. It targets the configured window (default 48 h) but drops down
+        // ScoreWindowLadderHours whenever a window's compute exceeds ComputeBudget, so on slower NAS
+        // hardware the default view and dashboard score fall back to a window the box can actually
+        // finish (24 h, then 16 h) instead of hanging past the HTTP timeout. Publishes the readiness
+        // status the dashboard tile reads.
+        var ceiling = await ResolveConfiguredWindowHoursAsync(ct);
+        _configuredWindowHours = ceiling;
+        var budget = ResolveComputeBudget();
+
+        var ladder = _options.ScoreWindowLadderHours
+            .Where(h => h <= ceiling && h >= _options.MinDataHours)
+            .OrderByDescending(h => h)
+            .ToList();
+        if (ladder.Count == 0) ladder.Add(Math.Max(ceiling, _options.MinDataHours));
+
+        // Resume at the current effective rung so a box that already fell back doesn't re-attempt the
+        // too-slow longer windows on every refresh. A process restart resets _effectiveWindowHours, so
+        // the ceiling is re-probed once on the first compute after each deploy.
+        var startIdx = 0;
+        if (_effectiveWindowHours > 0)
+        {
+            var resume = ladder.FindIndex(h => h <= _effectiveWindowHours);
+            startIdx = resume < 0 ? 0 : resume;
+        }
+
+        for (var i = startIdx; i < ladder.Count; i++)
+        {
+            var hours = ladder[i];
+            var windowEnd = DateTime.UtcNow;
+            var windowStart = windowEnd.AddHours(-hours);
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            using var budgetCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            budgetCts.CancelAfter(budget);
+            try
+            {
+                var outcome = await ComputeCoreAsync(windowStart, windowEnd, null, budgetCts.Token);
+                _effectiveWindowHours = hours;
+                _status = outcome.Status;
+                _logger.LogDebug("ISP Health auto-compute at {Hours}h completed in {Ms}ms (status {Status})",
+                    hours, sw.ElapsedMilliseconds, outcome.Status);
+                if (hours < ceiling)
+                    _logger.LogInformation(
+                        "ISP Health auto-compute using a {Hours}h window (target {Ceiling}h): the longer window exceeded the {Budget}s time budget on this hardware",
+                        hours, ceiling, (int)budget.TotalSeconds);
+                return (outcome.Report, outcome.ChartClusters);
+            }
+            catch (OperationCanceledException) when (budgetCts.IsCancellationRequested && !ct.IsCancellationRequested)
+            {
+                var next = i + 1 < ladder.Count ? ladder[i + 1] : hours;
+                _effectiveWindowHours = next;
+                _logger.LogInformation(
+                    "ISP Health {Hours}h auto-compute exceeded the {Budget}s time budget after {Ms}ms; falling back to {Next}h",
+                    hours, (int)budget.TotalSeconds, sw.ElapsedMilliseconds, next);
+            }
+        }
+
+        // Every rung exceeded the budget: leave the funnel status so the tile/tab report progress and
+        // the next cycle retries. Don't publish a stale report.
+        _logger.LogWarning(
+            "ISP Health auto-compute could not finish any window ({Ladder}h) within the {Budget}s budget",
+            string.Join("/", ladder), (int)budget.TotalSeconds);
+        _status = IspHealthStatus.Computing;
+        return (null, new List<AsnSeries>());
+    }
+
+    /// <summary>
+    /// Configured target window (hours) from MonitoringSettings, floored at MinDataHours and defaulting
+    /// to the built-in ScoreWindowHours when unset or unreadable.
+    /// </summary>
+    private async Task<int> ResolveConfiguredWindowHoursAsync(CancellationToken ct)
+    {
+        try
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync(ct);
+            var settings = await db.MonitoringSettings.AsNoTracking().FirstOrDefaultAsync(ct);
+            var hours = settings?.IspHealthScoreWindowHours ?? _options.ScoreWindowHours;
+            return hours >= _options.MinDataHours ? hours : _options.ScoreWindowHours;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "ISP Health could not read the configured score window; using default {Default}h", _options.ScoreWindowHours);
+            return _options.ScoreWindowHours;
+        }
+    }
+
+    /// <summary>
+    /// Per-attempt compute budget: the ISP_HEALTH_COMPUTE_BUDGET_SECONDS env var when set (used to
+    /// force the window fallback on fast hardware for testing, or to tune for a specific box), else the
+    /// built-in <see cref="IspHealthOptions.ComputeBudget"/> default.
+    /// </summary>
+    private TimeSpan ResolveComputeBudget()
+    {
+        var raw = Environment.GetEnvironmentVariable("ISP_HEALTH_COMPUTE_BUDGET_SECONDS");
+        if (double.TryParse(raw, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var seconds) && seconds > 0)
+            return TimeSpan.FromSeconds(seconds);
+        return _options.ComputeBudget;
     }
 
     /// <summary>
@@ -541,6 +658,10 @@ public class IspHealthService
             Load = loadByTime,
             HasTraceMap = hopOrderKnown
         };
+        // Compute-budget checkpoints between the heavy in-memory phases: the Influx reads above honor
+        // the token, but the detectors/scorer are CPU loops, so a deadline that fires mid-compute is
+        // caught at the next phase boundary and abandons the attempt (the auto path then drops a rung).
+        ct.ThrowIfCancellationRequested();
         var congestionEvents = CongestionLocalizer.Localize(localizerSeries, congestionTopology, _options);
         if (referenceEvents != null)
             congestionEvents = GateAgainstCanonical(congestionEvents, referenceEvents, windowEnd);
@@ -642,6 +763,7 @@ public class IspHealthService
             .Concat(orderedWanHops.Select((x, i) =>
                 new OutageDetector.Hop(x.Name, baseDepth + i, x.Series, x.Groupable, x.AsnLabel)))
             .ToList();
+        ct.ThrowIfCancellationRequested();
         var outages = OutageDetector.Detect(internetTriggerTargets, outageHops, _options);
         // Second pass: coincident partial-loss disruptions (the path getting lossy but not dark)
         // across the full set of monitored hops, excluding windows already flagged as blackouts.
@@ -700,6 +822,7 @@ public class IspHealthService
             PhysicalLink = physical.Input
         };
 
+        ct.ThrowIfCancellationRequested();
         var report = new IspHealthScorer(_options, _logger).Score(inputs, profile);
         report.AccessTechnology = technology;
         report.PhysicalLinkCandidates = physical.Candidates;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -224,8 +224,13 @@ public class IspHealthService
         _configuredWindowHours = ceiling;
         var budget = ResolveComputeBudget();
 
-        var ladder = _options.ScoreWindowLadderHours
-            .Where(h => h <= ceiling && h >= _options.MinDataHours)
+        // Always attempt the configured target first, then the standard rungs strictly below it, so a
+        // ceiling that isn't itself a ScoreWindowLadderHours value (e.g. 36 h) still tries the target
+        // before falling back rather than jumping straight to the nearest shorter rung.
+        var ladder = new[] { ceiling }
+            .Concat(_options.ScoreWindowLadderHours.Where(h => h < ceiling))
+            .Where(h => h >= _options.MinDataHours)
+            .Distinct()
             .OrderByDescending(h => h)
             .ToList();
         if (ladder.Count == 0) ladder.Add(Math.Max(ceiling, _options.MinDataHours));

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -16176,6 +16176,11 @@ tr.stats-row-filtered {
         var(--bg-card);
 }
 
+.isp-health-hero-loading {
+    min-height: 200px;
+    margin-bottom: 1rem;
+}
+
 .isp-health-hero-body {
     display: grid;
     grid-template-columns: auto 1fr auto;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -16187,6 +16187,7 @@ tr.stats-row-filtered {
     align-items: center;
     gap: 2rem;
     padding: 1.5rem 2rem;
+    min-height: 248px;
 }
 
 .isp-health-hero-gauge {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -16088,6 +16088,31 @@ tr.stats-row-filtered {
     justify-content: center;
 }
 
+.isp-window-reduced {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    height: 30px;
+    padding: 0 10px;
+    border: 1px solid var(--warning-color);
+    border-radius: 6px;
+    background: rgba(231, 150, 19, 0.12);
+    color: var(--warning-color);
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.isp-window-reduced:hover {
+    background: rgba(231, 150, 19, 0.2);
+}
+
+.isp-window-reduced:disabled {
+    opacity: 0.6;
+    cursor: default;
+}
+
 .isp-popover-backdrop {
     position: fixed;
     inset: 0;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -16177,7 +16177,7 @@ tr.stats-row-filtered {
 }
 
 .isp-health-hero-loading {
-    min-height: 200px;
+    min-height: 248px;
     margin-bottom: 1rem;
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -16176,18 +16176,21 @@ tr.stats-row-filtered {
         var(--bg-card);
 }
 
-.isp-health-hero-loading {
-    min-height: 248px;
-    margin-bottom: 1rem;
-}
-
 .isp-health-hero-body {
     display: grid;
     grid-template-columns: auto 1fr auto;
     align-items: center;
     gap: 2rem;
     padding: 1.5rem 2rem;
-    min-height: 248px;
+    min-height: 249px;
+}
+
+.isp-health-hero-body-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1.25rem;
 }
 
 .isp-health-hero-gauge {


### PR DESCRIPTION
## Adaptive ISP Health window for slower hardware

On lower-grade NAS hardware (spinning disks, modest CPUs) the 48h ISP Health computation could run past the request timeout and fail to load the score at all (#941). This makes the auto-computed score and the tab's default view adapt to what the box can actually finish.

### What changed

- **Adaptive fallback window.** The auto-computed score targets a configurable trailing window (default 48h) and, whenever a window's compute exceeds a per-attempt time budget, automatically falls back to a shorter one (48h → 24h → 16h). Slow boxes get a real score on a window they can finish instead of hanging. The chosen window is sticky per process, so only the first compute after a restart re-probes the full target.

- **Root-cause timeout fix (#941).** The InfluxDB client's short default query timeout was cancelling heavy reads mid-flight and surfacing as a hard failure. It's now raised well past the compute budget so ISP Health's own budget is the single authority on when to give up.

- **Reduced-window badge.** When the window has been auto-reduced, a small badge appears to the left of the date-range selector showing the effective window, with a tooltip explaining why. Tapping it re-probes the full target (e.g. after a hardware upgrade); if the box still can't finish in time it simply drops back.

- **Selector reflects the active window.** The date-range selector's default button now tracks the effective (possibly reduced) window, so the highlighted default and the Refresh action always match what's actually being shown.

- **Hero loading state.** On an explicit recompute (Refresh, a time-window change, or an access-technology change) the headline score area shows the same styled spinner used on initial load instead of a stale number, while the detail cards below stay in place.

- **Per-site setting.** New `MonitoringSettings.IspHealthScoreWindowHours` (default 48) sets the target window; the fallback ladder always attempts the configured target first before stepping down.

### Notes

- The budget can be overridden via `ISP_HEALTH_COMPUTE_BUDGET_SECONDS` for tuning/testing.
- INFO logs record any fallback/reduction; DEBUG logs record per-attempt timing.
- Verified on a native test site by forcing a low budget: the 48h → 24h fallback, the badge, and the selector default all behave as intended.
