### PR TITLE
Live View: timeline window presets - scrub back up to 90 days

### DIFF
--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -773,6 +773,31 @@ from(bucket: ""{_bucket}"")
     }
 
     /// <summary>
+    /// Earliest interface_counters point in the primary bucket - the effective floor for
+    /// historic playback. first() runs per series (pushed down, cheap), then min picks the
+    /// oldest across series. Returns null when unconfigured or no data exists yet.
+    /// </summary>
+    public async Task<DateTime?> QueryEarliestInterfaceDataAsync(CancellationToken ct = default)
+    {
+        if (!IsConfigured) return null;
+        var flux = $@"
+from(bucket: ""{_bucket}"")
+  |> range(start: -90d)
+  |> filter(fn: (r) => r._measurement == ""interface_counters"")
+  |> filter(fn: (r) => r._field == ""rate_in_bps"")
+  |> first()
+  |> group()
+  |> min(column: ""_time"")
+";
+        await foreach (var record in QueryFluxAsync(flux, ct))
+        {
+            var time = record.GetTimeInDateTime();
+            if (time != null) return ToUtc(time.Value);
+        }
+        return null;
+    }
+
+    /// <summary>
     /// Batch variant: fetches interface rates for a set of devices in one query.
     /// Returns results grouped by device MAC for caller-side partitioning.
     /// </summary>

--- a/src/NetworkOptimizer.Web/Endpoints/LanFlowMapEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/LanFlowMapEndpoints.cs
@@ -52,6 +52,13 @@ public static class LanFlowMapEndpoints
                 }
             });
 
+        app.MapGet("/api/monitoring/lan-flow-map/history/range",
+            async (LanFlowMapService svc, CancellationToken ct) =>
+            {
+                var earliest = await svc.GetHistoryStartAsync(ct);
+                return Results.Ok(new { earliest });
+            });
+
         app.MapGet("/api/monitoring/lan-flow-map/speed-tests",
             async (LanFlowMapService svc, DateTime? since, DateTime? until, CancellationToken ct) =>
             {

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapCache.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapCache.cs
@@ -70,6 +70,12 @@ public class LanFlowMapCache
 
     /// <summary>Cached InfluxDB results for historic playback, shared across scoped service instances.</summary>
     public HistoricDataCache? HistoricData { get; set; }
+
+    /// <summary>Earliest interface_counters timestamp - the floor of the playback timeline.</summary>
+    public DateTime? EarliestData { get; set; }
+
+    /// <summary>When <see cref="EarliestData"/> was last queried.</summary>
+    public DateTime EarliestDataAt { get; set; } = DateTime.MinValue;
 }
 
 public record HistoricDataCache(

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -457,8 +457,19 @@ public class LanFlowMapService
         var ttl = _cache.EarliestData == null ? TimeSpan.FromMinutes(5) : TimeSpan.FromHours(1);
         if (DateTime.UtcNow - _cache.EarliestDataAt < ttl)
             return _cache.EarliestData;
-        _cache.EarliestData = await _influx.QueryEarliestInterfaceDataAsync(ct);
-        _cache.EarliestDataAt = DateTime.UtcNow;
+        try
+        {
+            // Keep a known-good floor on transient failures (Influx restart,
+            // auth blip) - a null answer must not clobber the cached value.
+            var earliest = await _influx.QueryEarliestInterfaceDataAsync(ct);
+            if (earliest != null) _cache.EarliestData = earliest;
+            _cache.EarliestDataAt = DateTime.UtcNow;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogDebug(ex, "Earliest-data query failed; keeping cached timeline floor");
+            _cache.EarliestDataAt = DateTime.UtcNow;
+        }
         return _cache.EarliestData;
     }
 

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -447,6 +447,22 @@ public class LanFlowMapService
     }
 
     /// <summary>
+    /// Earliest instant historic playback can reach - the first interface_counters point
+    /// in the primary bucket. It only moves forward slowly (retention trimming), so a
+    /// non-null answer is cached for an hour; null (no data yet) retries after 5 minutes
+    /// so a fresh monitoring setup picks up its timeline floor quickly.
+    /// </summary>
+    public async Task<DateTime?> GetHistoryStartAsync(CancellationToken ct = default)
+    {
+        var ttl = _cache.EarliestData == null ? TimeSpan.FromMinutes(5) : TimeSpan.FromHours(1);
+        if (DateTime.UtcNow - _cache.EarliestDataAt < ttl)
+            return _cache.EarliestData;
+        _cache.EarliestData = await _influx.QueryEarliestInterfaceDataAsync(ct);
+        _cache.EarliestDataAt = DateTime.UtcNow;
+        return _cache.EarliestData;
+    }
+
+    /// <summary>
     /// Historic snapshot for the timeline scrubber. Queries InfluxDB at the requested
     /// instant +/- a small window matching the fast-tier interval (5 s).
     /// </summary>

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15464,7 +15464,7 @@ tr.stats-row-filtered {
    jumps right under the cursor as it approaches the live edge. */
 .lan-flow-map-scrubber-row [data-role="right"] {
     display: inline-block;
-    min-width: 7.5rem;
+    min-width: min(7.5rem, 30vw);
     text-align: center;
     font-variant-numeric: tabular-nums;
     white-space: nowrap;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15918,6 +15918,7 @@ tr.stats-row-filtered {
     position: relative;
 }
 .lan-flow-map-2d-stage {
+    position: relative;
     width: 100%;
     height: clamp(520px, 70vh, 820px);
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15411,9 +15411,53 @@ tr.stats-row-filtered {
     font-size: 0.78rem;
     color: var(--text-secondary);
 }
+.lan-flow-map-scrubber-track {
+    flex: 1;
+    position: relative;
+    display: flex;
+    align-items: center;
+}
 .lan-flow-map-scrubber-range {
     flex: 1;
     accent-color: var(--speed-download-color, #3385d6);
+}
+.lan-flow-map-scrubber-ticks {
+    position: absolute;
+    left: 8px;
+    right: 8px;
+    top: 0;
+    bottom: 0;
+    pointer-events: none;
+}
+.lan-flow-map-scrubber-tick {
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 1px;
+    height: 0.6rem;
+    background: rgba(255, 255, 255, 0.22);
+}
+.lan-flow-map-scrubber-window {
+    background: transparent;
+    border: 1px solid var(--border-color, #334155);
+    color: var(--text-secondary);
+    height: 1.75rem;
+    border-radius: 0.25rem;
+    font-size: 0.72rem;
+    padding: 0 0.2rem;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+.lan-flow-map-scrubber-window:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+}
+.lan-flow-map-scrubber-window option {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+}
+.lan-flow-map-scrubber-window option:disabled {
+    color: var(--text-muted);
 }
 /* Right label swaps between "Live" and a long locale datetime as the user
    scrubs; without a min-width the flex row reflows and the slider thumb
@@ -15847,6 +15891,9 @@ tr.stats-row-filtered {
         border-top: 1px solid rgba(255, 255, 255, 0.06);
     }
     .lan-flow-map-speed-control {
+        display: none;
+    }
+    .lan-flow-map-scrubber-row [data-role="left"] {
         display: none;
     }
     .lan-flow-map-signal-hint {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-data.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-data.js
@@ -24,9 +24,8 @@ let _mode = 'live';
 let _scrubberValue = 10000;
 let _scrubberRight = 'Live';
 let _playbackSpeed = 1;
-// Timeline window the slider spans: { startMs, endMs, presetKey, trailing,
-// leftLabel, disabledKeys }. trailing means the right edge tracks now (Live
-// reachable); an anchored window is pinned around a historic instant.
+// Timeline window the slider spans: { startMs, endMs, presetKey, leftLabel,
+// disabledKeys }. The window always trails now, so the right edge is Live.
 let _scrubberWindow = null;
 let _listeners = new Set();
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-data.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-data.js
@@ -2,6 +2,18 @@
 // The 3D map publishes data here after each fetch; the 2D map subscribes
 // so only one set of API calls runs. Pure pub/sub - no fetching.
 
+// Timeline window presets for the shared scrubber. 'max' spans back to the
+// earliest stored data point (bounded by the primary bucket's 90-day retention).
+export const SCRUBBER_PRESETS = [
+    { key: '1h',  ms: 3600000,       label: '1h' },
+    { key: '6h',  ms: 6 * 3600000,   label: '6h' },
+    { key: '24h', ms: 24 * 3600000,  label: '24h' },
+    { key: '3d',  ms: 3 * 86400000,  label: '3d' },
+    { key: '7d',  ms: 7 * 86400000,  label: '7d' },
+    { key: '30d', ms: 30 * 86400000, label: '30d' },
+    { key: 'max', ms: null,          label: 'Max' },
+];
+
 let _snapshot = null;
 let _liveRates = {};
 let _cloudStats = {};
@@ -12,6 +24,10 @@ let _mode = 'live';
 let _scrubberValue = 10000;
 let _scrubberRight = 'Live';
 let _playbackSpeed = 1;
+// Timeline window the slider spans: { startMs, endMs, presetKey, trailing,
+// leftLabel, disabledKeys }. trailing means the right edge tracks now (Live
+// reachable); an anchored window is pinned around a historic instant.
+let _scrubberWindow = null;
 let _listeners = new Set();
 
 export function getSnapshot()  { return _snapshot; }
@@ -22,6 +38,7 @@ export function getClientStats() { return _clientStats; }
 export function isPaused()       { return _paused; }
 export function getMode()        { return _mode; }
 export function getScrubber()    { return { value: _scrubberValue, right: _scrubberRight, speed: _playbackSpeed }; }
+export function getScrubberWindow() { return _scrubberWindow; }
 
 export function subscribe(fn) {
     _listeners.add(fn);
@@ -65,6 +82,36 @@ export function publishScrubber(value, rightLabel, speed) {
     _scrubberRight = rightLabel;
     _playbackSpeed = speed;
     _notify('scrubber');
+}
+
+export function publishScrubberWindow(win) {
+    _scrubberWindow = win;
+    _notify('scrubber-window');
+}
+
+// Render local-midnight tick marks onto a scrubber track overlay so multi-day
+// windows have day-boundary orientation. Shared by the 3D scrubber and its 2D
+// mirror. Windows under two days get no ticks; wide windows thin to ~12 ticks.
+export function renderScrubberTicks(el, startMs, endMs) {
+    if (!el) return;
+    el.innerHTML = '';
+    const span = endMs - startMs;
+    if (span < 48 * 3600000) return;
+    const stepDays = Math.max(1, Math.round(span / (12 * 86400000)));
+    const first = new Date(startMs);
+    first.setHours(24, 0, 0, 0);
+    let day = 0;
+    for (let t = first.getTime(); t < endMs; day++) {
+        if (day % stepDays === 0) {
+            const tick = document.createElement('span');
+            tick.className = 'lan-flow-map-scrubber-tick';
+            tick.style.left = `${((t - startMs) / span * 100).toFixed(2)}%`;
+            el.appendChild(tick);
+        }
+        const next = new Date(t);
+        next.setHours(24, 0, 0, 0);
+        t = next.getTime();
+    }
 }
 
 // Standalone data poller for contexts without the 3D map (e.g. dashboard).

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -3,7 +3,7 @@
 // zero duplicate API calls. GPU-composited canvas for smooth particle animation.
 
 // KEEP IN SYNC: lan-flow-map.js imports the same module. Both must use the same ?v= or they get separate instances.
-import * as flowData from './lan-flow-data.js?v=3';
+import * as flowData from './lan-flow-data.js?v=4';
 
 function demoMask(text) {
     const dm = window.DemoMask;
@@ -317,6 +317,8 @@ class LanFlowMap2D {
                 this._needsStaticRedraw=true;
             }else if(ev==='scrubber'||ev==='playstate'){
                 this._syncScrubber();
+            }else if(ev==='scrubber-window'){
+                this._syncScrubberWindow();
             }
         });
         this._lastFrame=performance.now();
@@ -493,10 +495,7 @@ class LanFlowMap2D {
         modeBadge.setAttribute('data-tooltip-hover-only','');
         modeBadge.addEventListener('click',()=>{
             const inst=window.__lanFlowMap?.getInstance?.();
-            if(inst&&inst._mode==='historic'){
-                const r=inst._panels?.scrubberRange;
-                if(r){r.value=10000;r.dispatchEvent(new Event('change'));}
-            }
+            if(inst&&inst._mode==='historic')inst._returnToLive();
         });
         status.appendChild(modeBadge);
         this._el.appendChild(status);
@@ -514,10 +513,24 @@ class LanFlowMap2D {
                     <span class="lan-flow-map-speed-label" data-role="speed-label">1x</span>
                     <button class="lan-flow-map-speed-step" data-dir="1" type="button" aria-label="Faster">+</button>
                 </div>
+                <select class="lan-flow-map-scrubber-window" data-role="window" aria-label="Timeline range"></select>
                 <span data-role="left">-24h</span>
-                <input class="lan-flow-map-scrubber-range" type="range" min="0" max="10000" value="10000" />
+                <span class="lan-flow-map-scrubber-track">
+                    <input class="lan-flow-map-scrubber-range" type="range" min="0" max="10000" value="10000" />
+                    <span class="lan-flow-map-scrubber-ticks" data-role="ticks"></span>
+                </span>
                 <span data-role="right">Live</span>
             </div>`;
+        const windowSel=scrubber.querySelector('[data-role="window"]');
+        for(const p of flowData.SCRUBBER_PRESETS){
+            const opt=document.createElement('option');
+            opt.value=p.key;opt.textContent=p.label;
+            windowSel.appendChild(opt);
+        }
+        windowSel.addEventListener('change',()=>{
+            const inst=window.__lanFlowMap?.getInstance?.();
+            if(inst)inst._setScrubSpan(windowSel.value);
+        });
         // Forward all interactions to the 3D map
         const fwd=()=>window.__lanFlowMap?.getInstance?.();
         const sRange=scrubber.querySelector('.lan-flow-map-scrubber-range');
@@ -567,10 +580,15 @@ class LanFlowMap2D {
         this._el.appendChild(scrubber);
         this._scrubberEls={
             range:sRange,
+            left:scrubber.querySelector('[data-role="left"]'),
             right:scrubber.querySelector('[data-role="right"]'),
             playPause:scrubber.querySelector('[data-role="playpause"]'),
             speedLabel:scrubber.querySelector('[data-role="speed-label"]'),
+            windowSel,
+            ticks:scrubber.querySelector('[data-role="ticks"]'),
         };
+        // Adopt whatever window the 3D map already published (it usually mounts first).
+        this._syncScrubberWindow();
 
         // Events
         canvas.addEventListener('wheel',(e)=>this._onWheel(e),{passive:false});
@@ -752,6 +770,19 @@ class LanFlowMap2D {
                 if(this._modeBadge._tippy)this._modeBadge._tippy.destroy();
             }
         }
+    }
+
+    _syncScrubberWindow(){
+        if(!this._scrubberEls)return;
+        const win=flowData.getScrubberWindow();
+        if(!win)return;
+        this._scrubberEls.left.textContent=win.leftLabel;
+        const sel=this._scrubberEls.windowSel;
+        if(sel){
+            sel.value=win.presetKey;
+            for(const opt of sel.options)opt.disabled=win.disabledKeys?.includes(opt.value)??false;
+        }
+        flowData.renderScrubberTicks(this._scrubberEls.ticks,win.startMs,win.endMs);
     }
 
     _isNodeVisible(n){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -527,6 +527,7 @@ class LanFlowMap2D {
             opt.value=p.key;opt.textContent=p.label;
             windowSel.appendChild(opt);
         }
+        windowSel.value='24h';
         windowSel.addEventListener('change',()=>{
             const inst=window.__lanFlowMap?.getInstance?.();
             if(inst)inst._setScrubSpan(windowSel.value);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -531,18 +531,21 @@ class LanFlowMap2D {
             const inst=window.__lanFlowMap?.getInstance?.();
             if(inst)inst._setScrubSpan(windowSel.value);
         });
-        // Arrow left/right float up to timeline scrubbing (on the 3D instance);
-        // without this the focused dropdown consumes them as value changes.
+        // Arrow left/right (and Shift for fast scrub) float up to timeline
+        // scrubbing (on the 3D instance); without this the focused dropdown
+        // consumes arrows as value changes.
         windowSel.addEventListener('keydown',(e)=>{
+            const inst=window.__lanFlowMap?.getInstance?.();
+            if(e.key==='Shift'){if(inst&&inst._keys)inst._keys.shift=true;return;}
             if(e.key!=='ArrowLeft'&&e.key!=='ArrowRight')return;
             e.preventDefault();
-            const inst=window.__lanFlowMap?.getInstance?.();
             if(inst&&inst._keys)inst._keys[e.key.toLowerCase()]=true;
         });
         windowSel.addEventListener('keyup',(e)=>{
-            if(e.key!=='ArrowLeft'&&e.key!=='ArrowRight')return;
             const inst=window.__lanFlowMap?.getInstance?.();
             if(!inst)return;
+            if(e.key==='Shift'){if(inst._keys)inst._keys.shift=false;return;}
+            if(e.key!=='ArrowLeft'&&e.key!=='ArrowRight')return;
             if(inst._keys)inst._keys[e.key.toLowerCase()]=false;
             inst._arrowScrubStart=null;
         });

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -531,6 +531,21 @@ class LanFlowMap2D {
             const inst=window.__lanFlowMap?.getInstance?.();
             if(inst)inst._setScrubSpan(windowSel.value);
         });
+        // Arrow left/right float up to timeline scrubbing (on the 3D instance);
+        // without this the focused dropdown consumes them as value changes.
+        windowSel.addEventListener('keydown',(e)=>{
+            if(e.key!=='ArrowLeft'&&e.key!=='ArrowRight')return;
+            e.preventDefault();
+            const inst=window.__lanFlowMap?.getInstance?.();
+            if(inst&&inst._keys)inst._keys[e.key.toLowerCase()]=true;
+        });
+        windowSel.addEventListener('keyup',(e)=>{
+            if(e.key!=='ArrowLeft'&&e.key!=='ArrowRight')return;
+            const inst=window.__lanFlowMap?.getInstance?.();
+            if(!inst)return;
+            if(inst._keys)inst._keys[e.key.toLowerCase()]=false;
+            inst._arrowScrubStart=null;
+        });
         // Forward all interactions to the 3D map
         const fwd=()=>window.__lanFlowMap?.getInstance?.();
         const sRange=scrubber.querySelector('.lan-flow-map-scrubber-range');

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -531,12 +531,17 @@ class LanFlowMap2D {
             const inst=window.__lanFlowMap?.getInstance?.();
             if(inst)inst._setScrubSpan(windowSel.value);
         });
-        // Arrow left/right (and Shift for fast scrub) float up to timeline
-        // scrubbing (on the 3D instance); without this the focused dropdown
-        // consumes arrows as value changes.
+        // Arrow left/right (with Shift for fast scrub) and Space float up to
+        // timeline scrubbing and play/pause (on the 3D instance); without this
+        // the focused dropdown consumes them natively.
         windowSel.addEventListener('keydown',(e)=>{
             const inst=window.__lanFlowMap?.getInstance?.();
             if(e.key==='Shift'){if(inst&&inst._keys)inst._keys.shift=true;return;}
+            if(e.key===' '){
+                e.preventDefault();
+                if(inst)inst._togglePlayPause();
+                return;
+            }
             if(e.key!=='ArrowLeft'&&e.key!=='ArrowRight')return;
             e.preventDefault();
             if(inst&&inst._keys)inst._keys[e.key.toLowerCase()]=true;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -332,6 +332,9 @@ class LanFlowMap2D {
         if(this._onKeyDown)document.removeEventListener('keydown',this._onKeyDown);
         if(this._isFullscreen)this._el.classList.remove('lan-flow-map-fullscreen');
         this._streams=[];
+        // The mobile scrubber lives outside _el (below the stage), so clearing
+        // _el's children alone would leave it behind on unmount.
+        if(this._scrubberEl)this._scrubberEl.remove();
         this._el.innerHTML='';
     }
 
@@ -601,7 +604,15 @@ class LanFlowMap2D {
                 }
             });
         }
-        this._el.appendChild(scrubber);
+        // Mobile: place the scrubber below the stage like the 3D map does, so
+        // the stage bottom stays the canvas bottom and the mode badge anchors
+        // to the same spot as on 3D instead of dropping onto the scrubber row.
+        if(isMobile&&this._el.parentElement){
+            this._el.parentElement.insertBefore(scrubber,this._el.nextSibling);
+        }else{
+            this._el.appendChild(scrubber);
+        }
+        this._scrubberEl=scrubber;
         this._scrubberEls={
             range:sRange,
             left:scrubber.querySelector('[data-role="left"]'),

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -334,6 +334,7 @@ class LanFlowMap2D {
         this._streams=[];
         // The mobile scrubber lives outside _el (below the stage), so clearing
         // _el's children alone would leave it behind on unmount.
+        if(this._scrubberMq)this._scrubberMq.removeEventListener('change',this._placeScrubber);
         if(this._scrubberEl)this._scrubberEl.remove();
         this._el.innerHTML='';
     }
@@ -607,11 +608,18 @@ class LanFlowMap2D {
         // Mobile: place the scrubber below the stage like the 3D map does, so
         // the stage bottom stays the canvas bottom and the mode badge anchors
         // to the same spot as on 3D instead of dropping onto the scrubber row.
-        if(isMobile&&this._el.parentElement){
-            this._el.parentElement.insertBefore(scrubber,this._el.nextSibling);
-        }else{
-            this._el.appendChild(scrubber);
-        }
+        // Tracked live, not just at mount - the breakpoint CSS applies on
+        // resize, so the DOM placement must follow it.
+        this._scrubberMq=window.matchMedia('(max-width: 768px)');
+        this._placeScrubber=()=>{
+            if(this._scrubberMq.matches&&this._el.parentElement){
+                this._el.parentElement.insertBefore(scrubber,this._el.nextSibling);
+            }else{
+                this._el.appendChild(scrubber);
+            }
+        };
+        this._placeScrubber();
+        this._scrubberMq.addEventListener('change',this._placeScrubber);
         this._scrubberEl=scrubber;
         this._scrubberEls={
             range:sRange,

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -182,16 +182,13 @@ export class LanFlowMap {
         this._dotnetRef = window.__monitoringRef || null;
         this._playbackSpeed = 1;  // real-time multiplier
         this._playbackAccum = 0;  // fractional slider unit accumulator
-        // Timeline window: the slider spans _scrubSpan ms. _scrubEnd null means the
-        // window trails now (right edge = Live, like a fixed -24h view); a fixed ms
-        // timestamp means the window is anchored around a historic instant so the
-        // user can zoom in on an event older than half the span.
+        // Timeline window: the slider spans the latest _scrubSpan ms, always
+        // trailing now so the right edge is Live and recent time stays reachable.
         let savedSpan = null;
         try { savedSpan = localStorage.getItem(this._storagePrefix + 'ScrubSpan'); } catch { /* localStorage unavailable */ }
         const savedPreset = flowData.SCRUBBER_PRESETS.find(p => p.key === savedSpan);
         this._scrubSpanKey = savedPreset ? savedPreset.key : '24h';
         this._scrubSpan = savedPreset?.ms ?? 24 * 3600000;
-        this._scrubEnd = null;
         this._dataStartMs = null; // earliest stored point; clamps Max and disables too-wide presets
 
         this._panels = {};        // DOM refs for overlay UI
@@ -1861,21 +1858,6 @@ export class LanFlowMap {
             }
             flowData.publishScrubber(clamped, rightLabel, this._playbackSpeed);
             tickCount++;
-            // An anchored window's right edge is a fixed historic instant, not
-            // Live - park playback there paused instead of snapping to live.
-            if (clamped >= 9998 && this._scrubEnd !== null) {
-                this._stopHistoricPlayback();
-                this._paused = true;
-                this._syncPlayPauseIcon();
-                const endAt = new Date(this._scrubEnd);
-                this._historicAt = endAt;
-                this._playbackTime = endAt;
-                flowData.publishPlayState(true, this._mode);
-                this._notifyPlayState();
-                this._notifyStatCards(endAt);
-                this._loadHistoric(endAt);
-                return;
-            }
             // Refresh map and stat cards periodically
             if (tickCount % DATA_REFRESH_TICKS === 0 || clamped >= 9998) {
                 if (clamped >= 9998) {
@@ -2222,7 +2204,7 @@ export class LanFlowMap {
         // Trailing multi-day windows slide with now, so the midnight ticks drift;
         // a slow refresh keeps them honest on long-open pages.
         this._windowTickTimer = setInterval(() => {
-            if (this._scrubEnd === null && this._scrubSpan >= 48 * 3600000) this._publishWindow();
+            if (this._scrubSpan >= 48 * 3600000) this._publishWindow();
         }, 60000);
 
         this._buildSignalMapHint();
@@ -2515,10 +2497,10 @@ export class LanFlowMap {
         if (label) label.textContent = `${this._playbackSpeed}x`;
     }
 
-    // Current timeline window bounds. Trailing windows slide with now so Live is
-    // always the right edge; anchored windows are fixed around a historic instant.
+    // Current timeline window bounds. The window slides with now so Live is
+    // always the right edge.
     _scrubWindowBounds() {
-        const end = this._scrubEnd ?? Date.now();
+        const end = Date.now();
         return { start: end - this._scrubSpan, end };
     }
 
@@ -2535,10 +2517,9 @@ export class LanFlowMap {
         return Math.max(0, Math.min(10000, Math.round((ms - start) / span * 10000)));
     }
 
-    // The right edge only means Live while the window trails now; an anchored
-    // window's right edge is a fixed historic instant.
+    // The window trails now, so the right edge of the slider is Live.
     _isLiveValue(value) {
-        return value >= 9998 && this._scrubEnd === null;
+        return value >= 9998;
     }
 
     // Widest selectable span: capped by the primary bucket's 90-day retention and,
@@ -2549,12 +2530,11 @@ export class LanFlowMap {
         return Math.max(3600000, Math.min(cap, now - this._dataStartMs));
     }
 
-    // Switch the timeline window preset. At Live the window just becomes a wider or
-    // narrower trailing view. Parked at a historic instant, the window re-anchors
-    // around that instant (zoom-around-thumb) so the user can find an event on a
-    // coarse window, then narrow the preset to fine-scrub it. The right edge clamps
-    // to now; if the new window reaches now it falls back to trailing so a drag to
-    // the right edge still lands on Live.
+    // Switch the timeline window preset. The window always spans the latest N back
+    // from now. At Live nothing else moves. Parked or playing at a historic instant,
+    // the instant stays under the thumb when it still falls inside the new window;
+    // an instant older than the new window clamps to the left edge (the oldest
+    // reachable point) and seeks there.
     _setScrubSpan(key) {
         const preset = flowData.SCRUBBER_PRESETS.find(p => p.key === key);
         if (!preset) return;
@@ -2566,18 +2546,25 @@ export class LanFlowMap {
         try { localStorage.setItem(this._storagePrefix + 'ScrubSpan', key); } catch { /* localStorage unavailable */ }
         if (this._mode === 'live' || this._isLiveValue(value)) {
             this._scrubSpan = span;
-            this._scrubEnd = null;
         } else {
             // Resolve the current instant against the OLD window before resizing.
             const at = (this._historicAt ?? this._scrubberValueToTime(value)).getTime();
             this._scrubSpan = span;
-            const end = Math.min(at + span / 2, now);
-            this._scrubEnd = (now - end < 5000) ? null : end;
-            if (range) {
-                range.value = this._timeToScrubberValue(at);
+            const clampedAt = Math.max(at, now - span);
+            if (range) range.value = this._timeToScrubberValue(clampedAt);
+            if (clampedAt !== at) {
+                // The old position fell off the narrower window: seek to the
+                // new left edge, keeping any running playback going from there.
+                const atDate = new Date(clampedAt);
+                this._historicAt = atDate;
+                if (this._historicPlaybackTimer) this._playbackTime = atDate;
+                this._onScrubberInput(Number(range?.value ?? 0));
+                this._notifyStatCards(atDate);
+                this._loadHistoric(atDate);
+            } else {
                 // The instant under the thumb didn't move, so no data refetch -
                 // just refresh the position label and mirror state.
-                this._onScrubberInput(Number(range.value));
+                this._onScrubberInput(Number(range?.value ?? 0));
             }
         }
         if (this._panels.scrubberWindow) this._panels.scrubberWindow.value = key;
@@ -2611,20 +2598,15 @@ export class LanFlowMap {
     }
 
     _returnToLive() {
-        this._scrubEnd = null;
-        this._publishWindow();
         const range = this._panels.scrubberRange;
         if (range) range.value = 10000;
         this._onScrubberChange(10000);
     }
 
     _windowLeftLabel() {
-        if (this._scrubEnd === null) {
-            const p = flowData.SCRUBBER_PRESETS.find(x => x.key === this._scrubSpanKey);
-            if (p?.ms != null) return `-${p.label}`;
-            return `-${_fmtSpan(this._scrubSpan)}`;
-        }
-        return _fmtDateTime(new Date(this._scrubEnd - this._scrubSpan));
+        const p = flowData.SCRUBBER_PRESETS.find(x => x.key === this._scrubSpanKey);
+        if (p?.ms != null) return `-${p.label}`;
+        return `-${_fmtSpan(this._scrubSpan)}`;
     }
 
     // Refresh the 3D scrubber's window-dependent UI (left label, preset select,
@@ -2644,7 +2626,6 @@ export class LanFlowMap {
             startMs: start,
             endMs: end,
             presetKey: this._scrubSpanKey,
-            trailing: this._scrubEnd === null,
             leftLabel: this._windowLeftLabel(),
             disabledKeys: disabled,
         });

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2092,10 +2092,13 @@ export class LanFlowMap {
         }
         windowSel.value = this._scrubSpanKey;
         windowSel.addEventListener('change', () => this._setScrubSpan(windowSel.value));
-        // Arrow left/right float up to timeline scrubbing; without this the
-        // focused dropdown consumes them as value changes. Other keys stay
-        // native so the dropdown remains keyboard-operable (Enter/Space/Up/Down).
+        // Arrow left/right (and Shift for fast scrub) float up to timeline
+        // scrubbing; without this the focused dropdown consumes arrows as value
+        // changes and the global key handler ignores keys while a select has
+        // focus. Other keys stay native so the dropdown remains keyboard-operable
+        // (Enter/Space/Up/Down).
         windowSel.addEventListener('keydown', (e) => {
+            if (e.key === 'Shift') { this._keys.shift = true; return; }
             if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
             e.preventDefault();
             this._keys[e.key.toLowerCase()] = true;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -15,7 +15,7 @@ import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js'
 import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 import { buildBuildings } from './lan-flow-buildings.js?v=1';
 // KEEP IN SYNC: lan-flow-map-2d.js imports the same module. Both must use the same ?v= or they get separate instances.
-import * as flowData from './lan-flow-data.js?v=3';
+import * as flowData from './lan-flow-data.js?v=4';
 
 const COLORS = {
     background: 0x202023,
@@ -182,7 +182,17 @@ export class LanFlowMap {
         this._dotnetRef = window.__monitoringRef || null;
         this._playbackSpeed = 1;  // real-time multiplier
         this._playbackAccum = 0;  // fractional slider unit accumulator
-        this._scrubberOrigin = Date.now() - 24 * 3600000; // left edge anchored at mount - 24h
+        // Timeline window: the slider spans _scrubSpan ms. _scrubEnd null means the
+        // window trails now (right edge = Live, like a fixed -24h view); a fixed ms
+        // timestamp means the window is anchored around a historic instant so the
+        // user can zoom in on an event older than half the span.
+        let savedSpan = null;
+        try { savedSpan = localStorage.getItem(this._storagePrefix + 'ScrubSpan'); } catch { /* localStorage unavailable */ }
+        const savedPreset = flowData.SCRUBBER_PRESETS.find(p => p.key === savedSpan);
+        this._scrubSpanKey = savedPreset ? savedPreset.key : '24h';
+        this._scrubSpan = savedPreset?.ms ?? 24 * 3600000;
+        this._scrubEnd = null;
+        this._dataStartMs = null; // earliest stored point; clamps Max and disables too-wide presets
 
         this._panels = {};        // DOM refs for overlay UI
         this._floatingLabels = new Map();  // nodeId -> { el, nameEl, rateEl }
@@ -448,6 +458,7 @@ export class LanFlowMap {
         if (this._pollTimer) clearInterval(this._pollTimer);
         if (this._historicPlaybackTimer) clearInterval(this._historicPlaybackTimer);
         if (this._snapshotTimer) clearInterval(this._snapshotTimer);
+        if (this._windowTickTimer) clearInterval(this._windowTickTimer);
         if (this._resizeObserver) this._resizeObserver.disconnect();
         if (this._onKeyDown) document.removeEventListener('keydown', this._onKeyDown);
         if (this._onKeyUp) document.removeEventListener('keyup', this._onKeyUp);
@@ -1840,21 +1851,31 @@ export class LanFlowMap {
             this._playbackTime = new Date(
                 this._playbackTime.getTime() + TICK_MS * this._playbackSpeed);
             // Derive slider position from the timestamp (inverse of _scrubberValueToTime)
-            const now = Date.now();
-            const span = now - this._scrubberOrigin;
-            const value = span > 0
-                ? Math.round((this._playbackTime.getTime() - this._scrubberOrigin) / span * 10000)
-                : 10000;
-            const clamped = Math.max(0, Math.min(10000, value));
+            const clamped = this._timeToScrubberValue(this._playbackTime.getTime());
             range.value = clamped;
             // Update the time label from the continuous timestamp, not the
             // integer slider position (which only moves every ~86s at 1x).
-            const rightLabel = (clamped >= 9998) ? 'Live' : _fmtDateTime(this._playbackTime);
+            const rightLabel = this._isLiveValue(clamped) ? 'Live' : _fmtDateTime(this._playbackTime);
             if (this._panels.scrubberRight) {
                 this._panels.scrubberRight.textContent = rightLabel;
             }
             flowData.publishScrubber(clamped, rightLabel, this._playbackSpeed);
             tickCount++;
+            // An anchored window's right edge is a fixed historic instant, not
+            // Live - park playback there paused instead of snapping to live.
+            if (clamped >= 9998 && this._scrubEnd !== null) {
+                this._stopHistoricPlayback();
+                this._paused = true;
+                this._syncPlayPauseIcon();
+                const endAt = new Date(this._scrubEnd);
+                this._historicAt = endAt;
+                this._playbackTime = endAt;
+                flowData.publishPlayState(true, this._mode);
+                this._notifyPlayState();
+                this._notifyStatCards(endAt);
+                this._loadHistoric(endAt);
+                return;
+            }
             // Refresh map and stat cards periodically
             if (tickCount % DATA_REFRESH_TICKS === 0 || clamped >= 9998) {
                 if (clamped >= 9998) {
@@ -2051,9 +2072,7 @@ export class LanFlowMap {
         modeBadge.setAttribute('data-tooltip-hover-only', '');
         modeBadge.addEventListener('click', () => {
             if (this._mode === 'live') return;
-            const range = this._panels.scrubberRange;
-            if (range) range.value = 10000;
-            this._onScrubberChange(10000);
+            this._returnToLive();
         });
         status.appendChild(modeBadge);
         this._panels.status = status;
@@ -2073,11 +2092,24 @@ export class LanFlowMap {
                     <span class="lan-flow-map-speed-label" data-role="speed-label">1x</span>
                     <button class="lan-flow-map-speed-step" data-dir="1" type="button" aria-label="Faster">+</button>
                 </div>
+                <select class="lan-flow-map-scrubber-window" data-role="window" aria-label="Timeline range"></select>
                 <span data-role="left">-24h</span>
-                <input class="lan-flow-map-scrubber-range" type="range" min="0" max="10000" value="10000" />
+                <span class="lan-flow-map-scrubber-track">
+                    <input class="lan-flow-map-scrubber-range" type="range" min="0" max="10000" value="10000" />
+                    <span class="lan-flow-map-scrubber-ticks" data-role="ticks"></span>
+                </span>
                 <span data-role="right">Live</span>
             </div>
         `;
+        const windowSel = scrubber.querySelector('[data-role="window"]');
+        for (const p of flowData.SCRUBBER_PRESETS) {
+            const opt = document.createElement('option');
+            opt.value = p.key;
+            opt.textContent = p.label;
+            windowSel.appendChild(opt);
+        }
+        windowSel.value = this._scrubSpanKey;
+        windowSel.addEventListener('change', () => this._setScrubSpan(windowSel.value));
         const range = scrubber.querySelector('.lan-flow-map-scrubber-range');
         this._scrubberInputDebounce = null;
         range.addEventListener('input', (e) => {
@@ -2156,9 +2188,7 @@ export class LanFlowMap {
                     this._panels.scrubberRight?.textContent ?? 'Live',
                     this._playbackSpeed);
                 if (this._mode === 'live' && this._playbackSpeed < 1) {
-                    const now = Date.now();
-                    const span = now - this._scrubberOrigin;
-                    const nearNow = span > 0 ? Math.floor((now - 5000 - this._scrubberOrigin) / span * 10000) : 9997;
+                    const nearNow = this._timeToScrubberValue(Date.now() - 5000);
                     const clamped = Math.min(nearNow, 9997);
                     if (this._panels.scrubberRange) this._panels.scrubberRange.value = clamped;
                     this._onScrubberInput(clamped);
@@ -2183,8 +2213,17 @@ export class LanFlowMap {
         this._panels.scrubberLeft = scrubber.querySelector('[data-role="left"]');
         this._panels.scrubberRight = scrubber.querySelector('[data-role="right"]');
         this._panels.scrubberPlayPause = playPause;
+        this._panels.scrubberWindow = windowSel;
+        this._panels.scrubberTicks = scrubber.querySelector('[data-role="ticks"]');
         this._paused = false;
         this._syncSpeedLabel();
+        this._publishWindow();
+        this._loadHistoryRange();
+        // Trailing multi-day windows slide with now, so the midnight ticks drift;
+        // a slow refresh keeps them honest on long-open pages.
+        this._windowTickTimer = setInterval(() => {
+            if (this._scrubEnd === null && this._scrubSpan >= 48 * 3600000) this._publishWindow();
+        }, 60000);
 
         this._buildSignalMapHint();
     }
@@ -2391,7 +2430,7 @@ export class LanFlowMap {
     _onScrubberInput(value) {
         // Visual-only update while dragging - cheap label refresh.
         const at = this._scrubberValueToTime(value);
-        const rightLabel = (value >= 9998) ? 'Live' : _fmtDateTime(at);
+        const rightLabel = this._isLiveValue(value) ? 'Live' : _fmtDateTime(at);
         if (this._panels.scrubberRight) {
             this._panels.scrubberRight.textContent = rightLabel;
         }
@@ -2399,7 +2438,7 @@ export class LanFlowMap {
     }
 
     async _onScrubberChange(value) {
-        if (value >= 9998) {
+        if (this._isLiveValue(value)) {
             // Snap back to live.
             this._stopHistoricPlayback();
             this._mode = 'live';
@@ -2476,12 +2515,139 @@ export class LanFlowMap {
         if (label) label.textContent = `${this._playbackSpeed}x`;
     }
 
+    // Current timeline window bounds. Trailing windows slide with now so Live is
+    // always the right edge; anchored windows are fixed around a historic instant.
+    _scrubWindowBounds() {
+        const end = this._scrubEnd ?? Date.now();
+        return { start: end - this._scrubSpan, end };
+    }
+
     _scrubberValueToTime(value) {
-        // Range 0..10000 maps from the anchored origin (mount - 24h) to now.
-        // The window grows as the page stays open so recent time is always reachable.
+        // Range 0..10000 maps linearly across the current window.
+        const { start, end } = this._scrubWindowBounds();
+        return new Date(start + (value / 10000) * (end - start));
+    }
+
+    _timeToScrubberValue(ms) {
+        const { start, end } = this._scrubWindowBounds();
+        const span = end - start;
+        if (span <= 0) return 10000;
+        return Math.max(0, Math.min(10000, Math.round((ms - start) / span * 10000)));
+    }
+
+    // The right edge only means Live while the window trails now; an anchored
+    // window's right edge is a fixed historic instant.
+    _isLiveValue(value) {
+        return value >= 9998 && this._scrubEnd === null;
+    }
+
+    // Widest selectable span: capped by the primary bucket's 90-day retention and,
+    // once known, by the earliest stored data point.
+    _maxScrubSpan(now = Date.now()) {
+        const cap = 90 * 86400000;
+        if (this._dataStartMs == null) return cap;
+        return Math.max(3600000, Math.min(cap, now - this._dataStartMs));
+    }
+
+    // Switch the timeline window preset. At Live the window just becomes a wider or
+    // narrower trailing view. Parked at a historic instant, the window re-anchors
+    // around that instant (zoom-around-thumb) so the user can find an event on a
+    // coarse window, then narrow the preset to fine-scrub it. The right edge clamps
+    // to now; if the new window reaches now it falls back to trailing so a drag to
+    // the right edge still lands on Live.
+    _setScrubSpan(key) {
+        const preset = flowData.SCRUBBER_PRESETS.find(p => p.key === key);
+        if (!preset) return;
         const now = Date.now();
-        const ms = this._scrubberOrigin + (value / 10000) * (now - this._scrubberOrigin);
-        return new Date(ms);
+        const span = Math.min(preset.ms ?? this._maxScrubSpan(now), this._maxScrubSpan(now));
+        const range = this._panels.scrubberRange;
+        const value = Number(range?.value ?? 10000);
+        this._scrubSpanKey = key;
+        try { localStorage.setItem(this._storagePrefix + 'ScrubSpan', key); } catch { /* localStorage unavailable */ }
+        if (this._mode === 'live' || this._isLiveValue(value)) {
+            this._scrubSpan = span;
+            this._scrubEnd = null;
+        } else {
+            // Resolve the current instant against the OLD window before resizing.
+            const at = (this._historicAt ?? this._scrubberValueToTime(value)).getTime();
+            this._scrubSpan = span;
+            const end = Math.min(at + span / 2, now);
+            this._scrubEnd = (now - end < 5000) ? null : end;
+            if (range) {
+                range.value = this._timeToScrubberValue(at);
+                // The instant under the thumb didn't move, so no data refetch -
+                // just refresh the position label and mirror state.
+                this._onScrubberInput(Number(range.value));
+            }
+        }
+        if (this._panels.scrubberWindow) this._panels.scrubberWindow.value = key;
+        this._publishWindow();
+    }
+
+    // One-time fetch of the earliest stored data point so Max spans to real data
+    // instead of a mostly-empty 90-day track on young installs.
+    async _loadHistoryRange() {
+        try {
+            const res = await fetch(`${this.apiBase}/history/range`, { credentials: 'same-origin' });
+            if (!res.ok) return;
+            const data = await res.json();
+            if (!data?.earliest) return;
+            this._dataStartMs = new Date(data.earliest).getTime();
+            const avail = this._maxScrubSpan();
+            const current = flowData.SCRUBBER_PRESETS.find(p => p.key === this._scrubSpanKey);
+            // A preset wider than the stored history is a mostly-empty track;
+            // fall back to Max, which spans exactly the data that exists.
+            if (current?.ms != null && current.ms > avail) this._setScrubSpan('max');
+            else if (this._scrubSpanKey === 'max') this._setScrubSpan('max'); // recompute span from data start
+            else this._publishWindow();
+        } catch { /* keep the 90d fallback */ }
+    }
+
+    _disabledPresetKeys() {
+        const avail = this._maxScrubSpan();
+        return flowData.SCRUBBER_PRESETS
+            .filter(p => p.ms != null && p.ms > avail)
+            .map(p => p.key);
+    }
+
+    _returnToLive() {
+        this._scrubEnd = null;
+        this._publishWindow();
+        const range = this._panels.scrubberRange;
+        if (range) range.value = 10000;
+        this._onScrubberChange(10000);
+    }
+
+    _windowLeftLabel() {
+        if (this._scrubEnd === null) {
+            const p = flowData.SCRUBBER_PRESETS.find(x => x.key === this._scrubSpanKey);
+            if (p?.ms != null) return `-${p.label}`;
+            return `-${_fmtSpan(this._scrubSpan)}`;
+        }
+        return _fmtDateTime(new Date(this._scrubEnd - this._scrubSpan));
+    }
+
+    // Refresh the 3D scrubber's window-dependent UI (left label, preset select,
+    // disabled options, midnight ticks) and publish to the shared store so the
+    // 2D mirror renders identically.
+    _publishWindow() {
+        const sel = this._panels.scrubberWindow;
+        const disabled = this._disabledPresetKeys();
+        if (sel) {
+            sel.value = this._scrubSpanKey;
+            for (const opt of sel.options) opt.disabled = disabled.includes(opt.value);
+        }
+        if (this._panels.scrubberLeft) this._panels.scrubberLeft.textContent = this._windowLeftLabel();
+        const { start, end } = this._scrubWindowBounds();
+        flowData.renderScrubberTicks(this._panels.scrubberTicks, start, end);
+        flowData.publishScrubberWindow({
+            startMs: start,
+            endMs: end,
+            presetKey: this._scrubSpanKey,
+            trailing: this._scrubEnd === null,
+            leftLabel: this._windowLeftLabel(),
+            disabledKeys: disabled,
+        });
     }
 
     async _loadHistoric(at) {
@@ -3666,6 +3832,13 @@ function formatAge(ms) {
 }
 
 const _p = (n) => String(n).padStart(2, '0');
+// Compact duration for the trailing Max window's left label, e.g. -12d or -18h.
+function _fmtSpan(ms) {
+    const days = ms / 86400000;
+    if (days >= 2) return `${Math.round(days)}d`;
+    return `${Math.round(ms / 3600000)}h`;
+}
+
 function _fmtDateTime(d) {
     return `${_p(d.getMonth()+1)}/${_p(d.getDate())}/${String(d.getFullYear()).slice(2)} ${_p(d.getHours())}:${_p(d.getMinutes())}:${_p(d.getSeconds())}`;
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2092,6 +2092,14 @@ export class LanFlowMap {
         }
         windowSel.value = this._scrubSpanKey;
         windowSel.addEventListener('change', () => this._setScrubSpan(windowSel.value));
+        // Arrow left/right float up to timeline scrubbing; without this the
+        // focused dropdown consumes them as value changes. Other keys stay
+        // native so the dropdown remains keyboard-operable (Enter/Space/Up/Down).
+        windowSel.addEventListener('keydown', (e) => {
+            if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+            e.preventDefault();
+            this._keys[e.key.toLowerCase()] = true;
+        });
         const range = scrubber.querySelector('.lan-flow-map-scrubber-range');
         this._scrubberInputDebounce = null;
         range.addEventListener('input', (e) => {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2092,13 +2092,18 @@ export class LanFlowMap {
         }
         windowSel.value = this._scrubSpanKey;
         windowSel.addEventListener('change', () => this._setScrubSpan(windowSel.value));
-        // Arrow left/right (and Shift for fast scrub) float up to timeline
-        // scrubbing; without this the focused dropdown consumes arrows as value
-        // changes and the global key handler ignores keys while a select has
-        // focus. Other keys stay native so the dropdown remains keyboard-operable
-        // (Enter/Space/Up/Down).
+        // Arrow left/right (with Shift for fast scrub) and Space float up to
+        // timeline scrubbing and play/pause; without this the focused dropdown
+        // consumes them natively and the global key handler ignores keys while
+        // a select has focus. Enter/Up/Down stay native so the dropdown remains
+        // keyboard-operable.
         windowSel.addEventListener('keydown', (e) => {
             if (e.key === 'Shift') { this._keys.shift = true; return; }
+            if (e.key === ' ') {
+                e.preventDefault();
+                this._togglePlayPause();
+                return;
+            }
             if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
             e.preventDefault();
             this._keys[e.key.toLowerCase()] = true;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1840,9 +1840,16 @@ export class LanFlowMap {
         const TICK_MS = 1000;
         const DATA_REFRESH_TICKS = 1;
         // Seed from the exact parked instant when known - requantizing through
-        // the slider value can be minutes off on a wide window.
-        this._playbackTime = this._historicAt ?? this._scrubberValueToTime(
+        // the slider value can be minutes off on a wide window. But only when
+        // the thumb still agrees with it: a quick scrub right before resuming
+        // may not have flushed through the debounced change handler yet, and
+        // then the thumb position is the user's intent, not the stale instant.
+        const fromValue = this._scrubberValueToTime(
             Number(this._panels.scrubberRange?.value ?? 500));
+        const stepMs = this._scrubSpan / 10000;
+        this._playbackTime =
+            (this._historicAt && Math.abs(this._historicAt.getTime() - fromValue.getTime()) <= stepMs)
+                ? this._historicAt : fromValue;
         let tickCount = 0;
         this._historicPlaybackTimer = setInterval(() => {
             if (this._paused) return;
@@ -2472,6 +2479,9 @@ export class LanFlowMap {
         const at = this._scrubberValueToTime(value);
         this._mode = 'historic';
         this._historicAt = at;
+        // Redirect any running playback to the new position - otherwise its
+        // next tick snaps the thumb back to wherever it was playing.
+        if (this._historicPlaybackTimer) this._playbackTime = at;
         if (this._panels.modeBadge) {
             this._panels.modeBadge.textContent = 'Historic';
             this._panels.modeBadge.classList.add('is-historic');

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -188,7 +188,9 @@ export class LanFlowMap {
         try { savedSpan = localStorage.getItem(this._storagePrefix + 'ScrubSpan'); } catch { /* localStorage unavailable */ }
         const savedPreset = flowData.SCRUBBER_PRESETS.find(p => p.key === savedSpan);
         this._scrubSpanKey = savedPreset ? savedPreset.key : '24h';
-        this._scrubSpan = savedPreset?.ms ?? 24 * 3600000;
+        // A restored 'max' preset (ms: null) seeds at the 90-day retention cap;
+        // _loadHistoryRange narrows it to the actual data start once known.
+        this._scrubSpan = savedPreset ? (savedPreset.ms ?? 90 * 86400000) : 24 * 3600000;
         this._dataStartMs = null; // earliest stored point; clamps Max and disables too-wide presets
 
         this._panels = {};        // DOM refs for overlay UI
@@ -1837,7 +1839,9 @@ export class LanFlowMap {
         // Track playback as a continuous timestamp, not integer slider units.
         const TICK_MS = 1000;
         const DATA_REFRESH_TICKS = 1;
-        this._playbackTime = this._scrubberValueToTime(
+        // Seed from the exact parked instant when known - requantizing through
+        // the slider value can be minutes off on a wide window.
+        this._playbackTime = this._historicAt ?? this._scrubberValueToTime(
             Number(this._panels.scrubberRange?.value ?? 500));
         let tickCount = 0;
         this._historicPlaybackTimer = setInterval(() => {
@@ -1850,21 +1854,26 @@ export class LanFlowMap {
             // Derive slider position from the timestamp (inverse of _scrubberValueToTime)
             const clamped = this._timeToScrubberValue(this._playbackTime.getTime());
             range.value = clamped;
+            // Live detection is time-based - on a wide window the last slider
+            // step spans many minutes and value-based detection would snap
+            // playback to Live long before it actually caught up to now.
+            const atLive = this._playbackTime.getTime() >= Date.now() - 2000;
             // Update the time label from the continuous timestamp, not the
             // integer slider position (which only moves every ~86s at 1x).
-            const rightLabel = this._isLiveValue(clamped) ? 'Live' : _fmtDateTime(this._playbackTime);
+            const rightLabel = atLive ? 'Live' : _fmtDateTime(this._playbackTime);
             if (this._panels.scrubberRight) {
                 this._panels.scrubberRight.textContent = rightLabel;
             }
             flowData.publishScrubber(clamped, rightLabel, this._playbackSpeed);
             tickCount++;
             // Refresh map and stat cards periodically
-            if (tickCount % DATA_REFRESH_TICKS === 0 || clamped >= 9998) {
-                if (clamped >= 9998) {
+            if (tickCount % DATA_REFRESH_TICKS === 0 || atLive) {
+                if (atLive) {
                     if (this._historicPlaybackTimer) {
                         clearInterval(this._historicPlaybackTimer);
                         this._historicPlaybackTimer = null;
                     }
+                    range.value = 10000;
                     this._onScrubberChange(10000);
                 } else {
                     this._historicAt = this._playbackTime;
@@ -2113,7 +2122,7 @@ export class LanFlowMap {
         range.addEventListener('input', (e) => {
             const val = Number(e.target.value);
             this._onScrubberInput(val);
-            if (this._mode === 'live' && val < 9998) {
+            if (this._mode === 'live' && !this._isLiveValue(val)) {
                 this._mode = 'historic';
                 this._paused = true;
                 this._syncPlayPauseIcon();
@@ -2533,9 +2542,13 @@ export class LanFlowMap {
         return Math.max(0, Math.min(10000, Math.round((ms - start) / span * 10000)));
     }
 
-    // The window trails now, so the right edge of the slider is Live.
+    // The window trails now, so the right edge of the slider is Live. Near-edge
+    // values only count as Live when they are also near now in TIME - on a wide
+    // window the last couple of slider steps span many minutes, and a position
+    // parked "10 minutes ago" must not read (or snap) as Live.
     _isLiveValue(value) {
-        return value >= 9998;
+        if (value < 9998) return false;
+        return Date.now() - this._scrubberValueToTime(value).getTime() < 60000;
     }
 
     // Widest selectable span: capped by the primary bucket's 90-day retention and,
@@ -2567,20 +2580,21 @@ export class LanFlowMap {
             const at = (this._historicAt ?? this._scrubberValueToTime(value)).getTime();
             this._scrubSpan = span;
             const clampedAt = Math.max(at, now - span);
+            const atDate = new Date(clampedAt);
+            this._historicAt = atDate;
             if (range) range.value = this._timeToScrubberValue(clampedAt);
+            // Label from the true instant, not the requantized slider value -
+            // near the live edge of a wide window the rounded value would read
+            // back as Live (or minutes off) while the data stays historic.
+            const rightLabel = _fmtDateTime(atDate);
+            if (this._panels.scrubberRight) this._panels.scrubberRight.textContent = rightLabel;
+            flowData.publishScrubber(Number(range?.value ?? 0), rightLabel, this._playbackSpeed);
             if (clampedAt !== at) {
                 // The old position fell off the narrower window: seek to the
                 // new left edge, keeping any running playback going from there.
-                const atDate = new Date(clampedAt);
-                this._historicAt = atDate;
                 if (this._historicPlaybackTimer) this._playbackTime = atDate;
-                this._onScrubberInput(Number(range?.value ?? 0));
                 this._notifyStatCards(atDate);
                 this._loadHistoric(atDate);
-            } else {
-                // The instant under the thumb didn't move, so no data refetch -
-                // just refresh the position label and mirror state.
-                this._onScrubberInput(Number(range?.value ?? 0));
             }
         }
         if (this._panels.scrubberWindow) this._panels.scrubberWindow.value = key;


### PR DESCRIPTION
## Summary

The Live View timeline scrubber (shared by the 3D map, 2D map, port stats playback, and WAN chart) was fixed at the last 24 hours. Monitoring data is stored raw at 5 s cadence for 90 days, so the limit was purely UI. This adds a window preset selector to the scrubber bar: **1h / 6h / 24h / 3d / 7d / 30d / Max**.

## How it works

- **The window always spans the latest N** ending at Live. Switching presets keeps the current playback instant under the thumb when it still fits; a position older than the new window clamps to the window's left edge and seeks there, whether playback is running or parked.
- **Max clamps to real data.** A new `GET /api/monitoring/lan-flow-map/history/range` endpoint returns the earliest stored `interface_counters` point (cached server-side), so a young install gets a track spanning exactly its data instead of a mostly empty 90 days. Presets wider than the stored history are disabled.
- **Time-based Live detection.** On wide windows the last slider steps span many minutes, so "Live" is now determined by proximity to now in time, not slider position - a position parked 10 minutes back no longer reads or snaps to Live, and playback ends exactly when it catches up to now.
- **Midnight tick marks** render on the track for windows of 2 days or more (thinned to ~12 on wide windows) for day-boundary orientation.
- **Keyboard passthrough on the preset dropdown**: with the dropdown focused, arrow keys scrub the timeline (Shift for fast scrub) and Space toggles play/pause instead of operating the select; Enter/Up/Down still work the dropdown.
- The chosen preset persists per browser, and the left edge label follows the window (-24h, -7d, etc.).

Both scrubbers (3D and the 2D mirror) stay in sync through the shared data store, and the port stats table and WAN chart follow the same instant unchanged since they consume absolute timestamps.

The earliest-data lookup degrades gracefully: transient InfluxDB failures keep the cached answer and the UI falls back to the 90-day retention cap.


## Fixes

- 2D map mobile mode scrubber now correctly renders under the 2D canvas area
