### PR TITLE
v1.24.1 Release Changes

### DIFF
--- a/src/NetworkOptimizer.Storage/Migrations/20260701210000_AddIspHealthScoreWindow.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260701210000_AddIspHealthScoreWindow.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701210000_AddIspHealthScoreWindow")]
+    partial class AddIspHealthScoreWindow
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260701210000_AddIspHealthScoreWindow.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260701210000_AddIspHealthScoreWindow.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIspHealthScoreWindow : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "IspHealthScoreWindowHours",
+                table: "MonitoringSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 48);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IspHealthScoreWindowHours",
+                table: "MonitoringSettings");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/MonitoringSettings.cs
+++ b/src/NetworkOptimizer.Storage/Models/MonitoringSettings.cs
@@ -129,6 +129,13 @@ public class MonitoringSettings
     [MaxLength(120)]
     public string? PhysicalLinkSourceKey { get; set; }
 
+    /// <summary>
+    /// Target trailing window (hours) for the auto-computed ISP Health score and the tab's default
+    /// view. This is the ceiling the compute aims for; on slower hardware where the target exceeds the
+    /// per-compute time budget it automatically falls back to a shorter window (24 h, then 16 h).
+    /// </summary>
+    public int IspHealthScoreWindowHours { get; set; } = 48;
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -2104,6 +2104,42 @@ join.inner(left: loss, right: load, on: (l, r) => l._time == r._time, as: (l, r)
     }
 
     /// <summary>
+    /// Pooled per-sample mean loss_percent across an explicit set of targets over a window - the same
+    /// per-sample mean ISP Health's loss factors compute. The caller passes the exact loss-pool target
+    /// IDs (see <c>IspHealthService.GetLossPoolTargetIdsAsync</c>) so the Investigate highlight reads
+    /// the very pool the score is graded on. The loss event finders report a single target's PEAK-loss
+    /// minute to center the chart on the worst point; this is the pooled average over the coalesced
+    /// event window instead. Null when the set is empty or no loss samples fall in the window.
+    /// </summary>
+    public async Task<double?> QueryMeanLossAcrossTargetsAsync(
+        IReadOnlyCollection<string> targetIds,
+        DateTime from,
+        DateTime to,
+        CancellationToken ct = default)
+    {
+        if (!IsConfigured) await ReconfigureAsync(ct);
+        if (!IsConfigured || targetIds.Count == 0) return null;
+        var idFilter = string.Join(" or ", targetIds.Select(id => $@"r.target_id == ""{SanitizeFluxString(id)}"""));
+        // group() collapses every target's per-sample loss into one table so mean() is the pooled
+        // average across the whole set, not per target.
+        var flux = $@"
+from(bucket: ""{_bucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""latency"")
+  |> filter(fn: (r) => {idFilter})
+  |> filter(fn: (r) => r._field == ""loss_percent"")
+  |> group()
+  |> mean()
+";
+        await foreach (var record in QueryFluxAsync(flux, ct))
+        {
+            var v = AsDoubleOrNull(record.GetValueByKey("_value"));
+            if (v != null) return v;
+        }
+        return null;
+    }
+
+    /// <summary>
     /// Find the most recent SFP anomaly: temperature above PON threshold (75 C) or
     /// RX power below PON threshold (-25 dBm). Scans the last 7 days.
     /// </summary>

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -137,6 +137,12 @@ public class MonitoringInfluxClient : IAsyncDisposable
                 .Url(url)
                 .AuthenticateToken(plainToken)
                 .LogLevel(InfluxDB.Client.Core.LogLevel.None)
+                // The client default query timeout (~10 s) cancels heavy reads (e.g. a 48 h ISP Health
+                // window on a slow spinning-disk NAS with a Comcast-style hop-heavy path - see #941)
+                // before they finish, surfacing as a TaskCanceledException that reads as a hard failure.
+                // Raise it well past ISP Health's own per-compute budget so that budget is the single
+                // authority on when to give up (and fall back to a shorter window), not the transport.
+                .TimeOut(TimeSpan.FromSeconds(60))
                 .Build();
 
             _client = new InfluxDBClient(options);

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -773,6 +773,31 @@ from(bucket: ""{_bucket}"")
     }
 
     /// <summary>
+    /// Earliest interface_counters point in the primary bucket - the effective floor for
+    /// historic playback. first() runs per series (pushed down, cheap), then min picks the
+    /// oldest across series. Returns null when unconfigured or no data exists yet.
+    /// </summary>
+    public async Task<DateTime?> QueryEarliestInterfaceDataAsync(CancellationToken ct = default)
+    {
+        if (!IsConfigured) return null;
+        var flux = $@"
+from(bucket: ""{_bucket}"")
+  |> range(start: -90d)
+  |> filter(fn: (r) => r._measurement == ""interface_counters"")
+  |> filter(fn: (r) => r._field == ""rate_in_bps"")
+  |> first()
+  |> group()
+  |> min(column: ""_time"")
+";
+        await foreach (var record in QueryFluxAsync(flux, ct))
+        {
+            var time = record.GetTimeInDateTime();
+            if (time != null) return ToUtc(time.Value);
+        }
+        return null;
+    }
+
+    /// <summary>
     /// Batch variant: fetches interface rates for a set of devices in one query.
     /// Returns results grouped by device MAC for caller-side partitioning.
     /// </summary>

--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -584,7 +584,8 @@ public class UniFiApiClient : IDisposable
     /// </summary>
     private async Task<T?> ExecuteApiCallAsync<T>(
         Func<Task<HttpResponseMessage>> apiCall,
-        CancellationToken cancellationToken = default) where T : class
+        CancellationToken cancellationToken = default,
+        bool throwOnPermissionError = false) where T : class
     {
         if (!await EnsureAuthenticatedAsync(cancellationToken))
         {
@@ -595,6 +596,18 @@ public class UniFiApiClient : IDisposable
         return await _retryPolicy.ExecuteAsync(async () =>
         {
             var response = await apiCall();
+
+            // A 403 with api.err.NoPermission means the credentials are valid but lack the required
+            // access level - re-authenticating won't fix it. Surface it (for mutative callers that
+            // opt in) instead of looping through a pointless re-auth that just spams the log.
+            if (throwOnPermissionError && response.StatusCode == HttpStatusCode.Forbidden)
+            {
+                var body = await response.Content.ReadAsStringAsync(cancellationToken);
+                if (body.Contains("api.err.NoPermission", StringComparison.OrdinalIgnoreCase))
+                    throw new UniFiPermissionException(
+                        "The UniFi account lacks permission to run RF spectrum scans. In UniFi Network, " +
+                        "give this account the Network: Site Admin role, then try again.");
+            }
 
             // Handle authentication failures
             if (response.StatusCode == HttpStatusCode.Unauthorized ||
@@ -2458,9 +2471,12 @@ public class UniFiApiClient : IDisposable
         };
         var content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
 
+        // Opt into permission-error surfacing: this is a mutative call, so a NoPermission 403 is a
+        // real, actionable failure (insufficient role) rather than a transient/auth-expiry hiccup.
         var response = await ExecuteApiCallAsync<UniFiApiResponse<object>>(
             () => _httpClient!.PostAsync(BuildApiPath("cmd/devmgr"), content, cancellationToken),
-            cancellationToken);
+            cancellationToken,
+            throwOnPermissionError: true);
 
         if (response?.Meta.Rc == "ok")
         {

--- a/src/NetworkOptimizer.UniFi/UniFiPermissionException.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiPermissionException.cs
@@ -1,0 +1,15 @@
+namespace NetworkOptimizer.UniFi;
+
+/// <summary>
+/// Thrown when the UniFi Console rejects a request with <c>api.err.NoPermission</c> (HTTP 403) -
+/// the credentials are valid but the account/API key lacks the required access level. Re-authenticating
+/// does not help, so callers that make mutative requests (e.g. triggering an RF spectrum scan) can
+/// catch this and surface an actionable message instead of a generic failure.
+/// </summary>
+public class UniFiPermissionException : Exception
+{
+    public UniFiPermissionException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -2781,9 +2781,18 @@ else
                 : delta.TotalHours < 24 ? $"{(int)delta.TotalHours}h ago"
                 : $"{(int)delta.TotalDays}d ago";
             var localTime = result.Timestamp.ToLocalTime().ToString("M/d h:mm tt");
-            _lossInvestigateResult = $"{result.LossPercent:0.#}% loss {ago} ({localTime})";
+            // The event is found on its single worst target's peak minute, but the highlight should
+            // read the loss the score is actually graded on: the pooled per-sample mean across the
+            // exact ISP Health loss pool (access + transit excl. non-transit infra + anycast DNS) over
+            // the event window. The band's start is backed up one bucket, so pool over the same widened
+            // window. Fall back to the peak target's value if the pooled query returns nothing.
+            var poolIds = await IspHealthService.GetLossPoolTargetIdsAsync();
+            var pooledLoss = await InfluxClient.QueryMeanLossAcrossTargetsAsync(
+                poolIds, result.EventStart.AddMinutes(-1), result.EventEnd)
+                ?? result.LossPercent;
+            _lossInvestigateResult = $"{pooledLoss:0.#}% loss {ago} ({localTime})";
             StateHasChanged();
-            var annotationLabel = $"{(loadedOnly ? "Loaded" : "Packet")} loss {result.LossPercent:0.#}%";
+            var annotationLabel = $"{(loadedOnly ? "Loaded" : "Packet")} loss {pooledLoss:0.#}%";
             await JS.InvokeVoidAsync("eval",
                 $"window.__latencyCharts?.navigateToTime('{result.Timestamp:o}', '{category}', '{annotationLabel}', {(loadedOnly ? "true" : "false")}, '{result.EventStart:o}', '{result.EventEnd:o}');");
         }

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -218,7 +218,7 @@
                             <li>Uncheck <strong>Use a Predefined Role</strong></li>
                             <li>Set permissions:
                                 <ul>
-                                    <li><strong>Network:</strong> View Only</li>
+                                    <li><strong>Network:</strong> Site Admin</li>
                                     <li><strong>Protect:</strong> View Only</li>
                                     <li><strong>User &amp; Account Management:</strong> None</li>
                                 </ul>
@@ -226,6 +226,7 @@
                             <li>Set a secure password and save</li>
                         </ol>
                         <p>Use this username and password in the fields above.</p>
+                        <p><strong>Why Site Admin?</strong> Network has no granular role between View Only and Site Admin, and the Channel Optimizer's on-demand RF spectrum scans need write access. View Only works for everything else, so pick it instead if you don't plan to run scans.</p>
                     </div>
                 </details>
             }

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -933,11 +933,15 @@ else
             // feed stays readable and still agrees with the cards (which badge only confirmed).
             // A localized, propagated bottleneck names the hop AND the hops beyond it in the subject,
             // which replaces the old trailing "it propagates ..." sentence. Sibling-confirmed,
-            // clean-parallel, and unlocalized events don't get it.
+            // clean-parallel, and unlocalized events don't get it. Require a placed bottleneck hop
+            // (BottleneckHopIp) so an un-traced target that only surfaced as an unlocalized Confirmed
+            // event - e.g. an access-ISP leaf with no saved trace - is never described as a hop with
+            // topology beyond it; only genuinely localized hops and shared-incident owners carry a hop IP.
             var beyond = evt.Disposition == CongestionDisposition.Confirmed
                 && !evt.ConfirmedBySibling
                 && !(evt.LoadCoincident && evt.CleanParallelPaths > 0)
                 && !evt.IsShared
+                && evt.BottleneckHopIp != null
                 ? " and the hops beyond" : "";
             var lead = $"{span} of elevated latency and jitter on {where}{beyond}{load} ({mag}).";
             var (badge, badgeClass, text) = evt.Disposition switch

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -6,15 +6,29 @@
 @inject IJSRuntime JS
 @inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
 
-@* Date/time filter (left) + Refresh. Default 48 h is the live/cached view and the only state
-   where Refresh is enabled; any other selection recomputes off-cache and locks Refresh. Always
-   rendered (once past initial load) so a custom window with no data can still be switched back. *@
+@* Date/time filter (left) + Refresh. The live/cached view (the effective auto-computed window, which
+   auto-fallback may have reduced below the configured target) is the only state where Refresh is
+   enabled; any other selection recomputes off-cache and locks Refresh. Always rendered (once past
+   initial load) so a custom window with no data can still be switched back. *@
 @if (!_loading)
 {
     <div class="isp-health-toolbar">
         @if (_showCustomPopover)
         {
             <div class="isp-popover-backdrop" @onclick="() => _showCustomPopover = false"></div>
+        }
+        @{
+            var effWin = IspHealth.EffectiveWindowHours;
+            var cfgWin = IspHealth.ConfiguredWindowHours;
+            var windowReduced = effWin > 0 && cfgWin > 0 && effWin < cfgWin;
+        }
+        @if (windowReduced)
+        {
+            <button class="isp-window-reduced" @onclick="RetryFullWindowAsync" disabled="@(_refreshing || _windowComputing)"
+                    data-tooltip="ISP Health is slow-running on your box, so we dropped the default window to @(effWin)h. Tap to retry, and adjust if your hardware has changed." data-tooltip-hover-only>
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" /></svg>
+                <span>@(effWin)h</span>
+            </button>
         }
         <div class="time-range-selector @(_showCustomPopover ? "isp-filter-raised" : "")" style="position: relative;">
             @foreach (var p in FilterPresets)
@@ -62,7 +76,7 @@
 {
     <div class="isp-health-loading card">
         <div class="isp-health-loading-spinner"></div>
-        <p class="isp-health-loading-text">Analyzing recent ISP data...</p>
+        <p class="isp-health-loading-text">Analyzing recent ISP and transit data...</p>
     </div>
 }
 else if (_report == null)
@@ -144,13 +158,30 @@ else
             </div>
         </div>
     }
+    @* While an explicit recompute is in flight (Refresh, a time-window change, or an access-tech
+       change) swap just the hero for the same area spinner shown on initial load, so the headline
+       score never displays a stale number mid-recompute. The detail cards below stay put. *@
+    @if (_refreshing || _windowComputing)
+    {
+        @* Reuse the hero's exact card + card-body chain so the spinner box matches the score box to
+           the pixel (a single min-height on .isp-health-hero-body governs both); only the inner layout
+           differs, which doesn't affect the outer height. *@
+        <div class="isp-health-hero card">
+            <div class="card-body isp-health-hero-body isp-health-hero-body-loading">
+                <div class="isp-health-loading-spinner"></div>
+                <p class="isp-health-loading-text">Analyzing ISP and transit data...</p>
+            </div>
+        </div>
+    }
+    else
+    {
     <div class="isp-health-hero card">
         <span class="isp-health-updated">Last updated: @TimeFormatHelper.FormatRelativeTimeShort(r.ComputedAt)</span>
         <div class="card-body isp-health-hero-body">
             <div class="isp-health-hero-gauge">
                 <IspHealthScoreGauge Score="r.OverallScore" Label="ISP Health" />
                 <div class="isp-health-profile-chip isp-health-profile-chip-selectable"
-                     data-tooltip="Thresholds are tuned per access technology; change it to re-score.">
+                     data-tooltip="Thresholds are tuned per access technology; change it to re-score." data-tooltip-hover-only>
                     Scored as @r.Profile.DisplayName &middot; @ScoredWindowLabel(r)
                     <span class="isp-profile-chip-caret"></span>
                     <select class="isp-profile-chip-select" aria-label="Access technology"
@@ -202,6 +233,7 @@ else
             </div>
         </div>
     </div>
+    }
 
     @if (r.Issues.Count > 0)
     {
@@ -256,7 +288,7 @@ else
                         @if (dimension == r.AccessDimension)
                         {
                             <select class="isp-access-tech-select" aria-label="Access technology"
-                                    data-tooltip="Thresholds are tuned per access technology; change it to re-score."
+                                    data-tooltip="Thresholds are tuned per access technology; change it to re-score." data-tooltip-hover-only
                                     value="@((int)r.AccessTechnology)" @onchange="OnAccessTechnologyChanged">
                                 @foreach (var tech in ProfileTechOptions)
                                 {
@@ -577,9 +609,10 @@ else
     private bool _showAllIspHops;
     private System.Threading.Timer? _ageTimer;
 
-    // Date/time filter. Never persisted: OnInitializedAsync always starts on 48 h, so leaving
-    // and returning to the tab (and every auto-computed path) resets to the live window.
-    private static readonly (string Label, int Hours)[] FilterPresets =
+    // Date/time filter. Never persisted: OnInitializedAsync starts on the live window (the effective
+    // auto-computed window, which auto-fallback may have reduced below the configured target), so
+    // leaving and returning to the tab - and every auto-computed path - resets to the live view.
+    private static readonly (string Label, int Hours)[] BasePresets =
     {
         ("24h", 24), ("48h", 48), ("7d", 168), ("14d", 336), ("30d", 720)
     };
@@ -587,6 +620,32 @@ else
     private const int MaxRangeHours = 720;   // 30-day / 1-month hard cap
     private const int MinRangeHours = 4;     // smallest custom window
     private int _selectedPreset = DefaultPresetHours;
+    // True while the selection follows the live/cached auto-computed report (rather than a preset or
+    // custom window computed off-cache). While set, _selectedPreset is kept in sync with the effective
+    // (possibly reduced) window so the matching button stays highlighted.
+    private bool _followLive = true;
+
+    // The live/cached window in hours: the effective auto-computed window (reduced by auto-fallback
+    // when the box can't finish the configured target in time), else the configured target, else 48.
+    private int LiveWindowHours => IspHealth.EffectiveWindowHours > 0
+        ? IspHealth.EffectiveWindowHours
+        : (IspHealth.ConfiguredWindowHours > 0 ? IspHealth.ConfiguredWindowHours : DefaultPresetHours);
+
+    // Presets shown in the selector: the base set plus the live window when auto-fallback landed on a
+    // value that isn't already a preset (e.g. the 16 h rung), so the active default always has a button.
+    private IEnumerable<(string Label, int Hours)> FilterPresets
+    {
+        get
+        {
+            var live = LiveWindowHours;
+            if (BasePresets.Any(p => p.Hours == live))
+                return BasePresets;
+            return BasePresets.Append((Label: FormatPresetLabel(live), Hours: live)).OrderBy(p => p.Hours);
+        }
+    }
+
+    private static string FormatPresetLabel(int hours) =>
+        hours % 24 == 0 ? $"{hours / 24}d" : $"{hours}h";
     private bool _isCustom;
     private bool _showCustomPopover;
     private bool _windowComputing;
@@ -606,7 +665,38 @@ else
     private DateTime _customFrom = DateTime.Now.AddDays(-2);
     private DateTime _customTo = DateTime.Now;
 
-    private bool IsLiveWindow => !_isCustom && _selectedPreset == DefaultPresetHours;
+    private bool IsLiveWindow => !_isCustom && _followLive;
+
+    /// <summary>
+    /// User asked to retry the full configured window from the "reduced window" badge (e.g. after a
+    /// hardware upgrade). Reset the auto-fallback so the next compute re-probes the target, then force
+    /// a recompute; if the box still can't finish it in time it simply drops back and the badge
+    /// returns. Only swaps the displayed report when on the live view.
+    /// </summary>
+    private async Task RetryFullWindowAsync()
+    {
+        if (_refreshing || _windowComputing) return;
+        IspHealth.RetryConfiguredWindow();
+        _refreshing = true;
+        StateHasChanged();
+        try
+        {
+            var report = await IspHealth.GetReportAsync(forceRefresh: true);
+            if (IsLiveWindow)
+            {
+                _report = report;
+                try { await JS.InvokeVoidAsync("eval", "window.__ispHealthCharts?.reload?.();"); }
+                catch { /* chart not mounted yet */ }
+            }
+        }
+        finally
+        {
+            _refreshing = false;
+        }
+        // The retry may restore the full window or drop again; re-sync the highlighted button.
+        if (_followLive) _selectedPreset = LiveWindowHours;
+        StateHasChanged();
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -624,6 +714,9 @@ else
         {
             _loading = false;
         }
+
+        // Highlight the button for the effective (possibly auto-reduced) live window.
+        if (_followLive) _selectedPreset = LiveWindowHours;
 
         // Re-render every 30 s so "Last updated: N min ago" ages on its own, and - on the live
         // 48 h view - pull the latest cached snapshot so the tab follows the background recompute
@@ -660,6 +753,8 @@ else
             catch { /* never let a fetch fault kill the timer */ }
             finally { _autoReloading = false; }
         }
+        // Follow a background auto-fallback: keep the live button on the effective window.
+        if (_followLive) _selectedPreset = LiveWindowHours;
         StateHasChanged();
     }
 
@@ -825,7 +920,7 @@ else
         {
             // Seed both pickers from the active window so they reflect the current filter.
             _customTo = (_windowEnd ?? DateTime.UtcNow).ToLocalTime();
-            _customFrom = (_windowStart ?? DateTime.UtcNow.AddHours(-DefaultPresetHours)).ToLocalTime();
+            _customFrom = (_windowStart ?? DateTime.UtcNow.AddHours(-LiveWindowHours)).ToLocalTime();
         }
     }
 
@@ -834,8 +929,11 @@ else
         _showCustomPopover = false;
         _isCustom = false;
         _selectedPreset = hours;
-        if (hours == DefaultPresetHours)
-            await LoadWindowAsync(null, null);   // back to the live/cached 48 h report
+        // Selecting the live window follows the cached auto-computed report; anything else computes
+        // that window off-cache.
+        _followLive = hours == LiveWindowHours;
+        if (_followLive)
+            await LoadWindowAsync(null, null);   // back to the live/cached report
         else
         {
             var end = DateTime.UtcNow;

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -132,18 +132,15 @@
                 {
                     <div class="alert-info scan-gap-banner">
                         <div class="scan-gap-text">
-                            <strong>@_scanGaps.Count @(_scanGaps.Count == 1 ? "radio hasn't" : "radios haven't") been scanned recently.</strong>
-                            Without a measurement the optimizer infers those channels from neighboring
-                            networks instead of seeing them directly. A quick scan reads the real airtime
-                            and noise floor on each channel, so the recommendations reflect what's actually
-                            on the air - not a guess. @ScanDisruptionNote()
+                            <strong>@_scanGaps.Count @(_scanGaps.Count == 1 ? "radio needs" : "radios need") a scan.</strong>
+                            Their channels are estimated from nearby networks, not measured. @ScanDisruptionNote()
                         </div>
                         <button class="btn btn-primary btn-sm" @onclick="RunGapScans" disabled="@_scanningGaps"
-                                data-tooltip="Runs a quick RF scan to measure these channels">
+                                data-tooltip="Runs a quick RF scan to measure the real airtime and noise floor on these channels, so the recommendations reflect what's actually on the air instead of a guess.">
                             @if (_scanningGaps)
                             {
                                 <span class="spinner spinner-sm"></span>
-                                <span>Scanning @_scanGaps.Count @(_scanGaps.Count == 1 ? "radio" : "radios")…</span>
+                                <span>@ScanProgressLabel()</span>
                             }
                             else
                             {
@@ -151,6 +148,10 @@
                             }
                         </button>
                     </div>
+                    @if (_scanError is not null)
+                    {
+                        <div class="alert-danger scan-error-banner">@_scanError</div>
+                    }
                 }
 
                 @if (_channelPlan is { } plan)
@@ -926,6 +927,17 @@
     // per-channel spectrum measurement. A quick-scan fills them.
     private List<SpectrumScanGap> _scanGaps = new();
     private bool _scanningGaps;
+    // Progress for the running gap scan: bands started so far, and the total to scan. Drives the
+    // "Scanning… X/N bands" label so a multi-minute serial scan reads as working, not hung.
+    private int _scanCompletedBands;
+    private int _scanTotalBands;
+    // Set when a scan fails because the UniFi account lacks the Site Admin role.
+    private string? _scanError;
+
+    private string ScanProgressLabel() =>
+        _scanTotalBands > 1
+            ? $"Scanning… {Math.Clamp(_scanCompletedBands, 1, _scanTotalBands)}/{_scanTotalBands} bands"
+            : "Scanning…";
 
     // Disruption note tailored to the gapped APs' scan hardware: an AP with a dedicated scan radio
     // measures without touching its serving radios (no client impact); without one, scanning briefly
@@ -935,17 +947,11 @@
         var clean = _scanGaps.Count(g => g.HasDedicatedScanRadio);
         var disruptive = _scanGaps.Count - clean;
         var meshNote = _scanGaps.Any(g => g.IsMeshParent && !g.HasDedicatedScanRadio)
-            ? ", and may briefly drop devices meshed through an AP" : "";
+            ? " (and devices meshed through an AP)" : "";
 
         if (disruptive == 0)
-            return "These scan on a dedicated radio, so running won't disrupt clients.";
-        if (clean == 0)
-            return $"Heads up: scanning briefly steps each radio off its channel - clients stay connected, "
-                 + $"but real-time traffic (video calls, gaming) can hiccup for a moment{meshNote}. "
-                 + "Much lighter than a full scan, but best run during low-usage times.";
-        return $"{clean} of these scan on a dedicated radio with no client impact; the other {disruptive} "
-             + $"briefly step their serving radio off-channel, so real-time traffic can hiccup{meshNote} - "
-             + "best run during low-usage times.";
+            return "Won't disrupt clients.";
+        return $"May briefly interrupt {(clean == 0 ? "clients" : "some clients")}{meshNote}; best at quiet times.";
     }
 
     private async Task LoadScanGapsAsync()
@@ -965,16 +971,30 @@
         if (_scanningGaps || _scanGaps.Count == 0) return;
 
         _scanningGaps = true;
+        _scanError = null;
+        _scanCompletedBands = 0;
+        _scanTotalBands = _scanGaps.Count; // one band scan per gapped (AP, band)
         StateHasChanged();
         try
         {
             var targets = _scanGaps.Select(g => (g.ApMac, g.BandCode)).ToList();
-            await WiFiService.RunQuickScansAsync(targets);
+            // Report progress on the Blazor circuit's context; Math.Max keeps the count monotonic
+            // even if concurrent APs report band starts out of order.
+            var progress = new Progress<int>(n =>
+            {
+                _scanCompletedBands = Math.Max(_scanCompletedBands, n);
+                InvokeAsync(StateHasChanged);
+            });
+            await WiFiService.RunQuickScansAsync(targets, progress);
 
             // Re-run recommendations on the fresh spectrum data, then re-check what's still missing.
             var options = new RecommendationOptions { DfsPreference = _dfsPreference };
             _channelPlans = await WiFiService.GetAllChannelRecommendationsAsync(options);
             await LoadScanGapsAsync();
+        }
+        catch (ScanPermissionException ex)
+        {
+            _scanError = ex.Message;
         }
         finally
         {

--- a/src/NetworkOptimizer.Web/Endpoints/LanFlowMapEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/LanFlowMapEndpoints.cs
@@ -52,6 +52,13 @@ public static class LanFlowMapEndpoints
                 }
             });
 
+        app.MapGet("/api/monitoring/lan-flow-map/history/range",
+            async (LanFlowMapService svc, CancellationToken ct) =>
+            {
+                var earliest = await svc.GetHistoryStartAsync(ct);
+                return Results.Ok(new { earliest });
+            });
+
         app.MapGet("/api/monitoring/lan-flow-map/speed-tests",
             async (LanFlowMapService svc, DateTime? since, DateTime? until, CancellationToken ct) =>
             {

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapCache.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapCache.cs
@@ -70,6 +70,12 @@ public class LanFlowMapCache
 
     /// <summary>Cached InfluxDB results for historic playback, shared across scoped service instances.</summary>
     public HistoricDataCache? HistoricData { get; set; }
+
+    /// <summary>Earliest interface_counters timestamp - the floor of the playback timeline.</summary>
+    public DateTime? EarliestData { get; set; }
+
+    /// <summary>When <see cref="EarliestData"/> was last queried.</summary>
+    public DateTime EarliestDataAt { get; set; } = DateTime.MinValue;
 }
 
 public record HistoricDataCache(

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -447,6 +447,33 @@ public class LanFlowMapService
     }
 
     /// <summary>
+    /// Earliest instant historic playback can reach - the first interface_counters point
+    /// in the primary bucket. It only moves forward slowly (retention trimming), so a
+    /// non-null answer is cached for an hour; null (no data yet) retries after 5 minutes
+    /// so a fresh monitoring setup picks up its timeline floor quickly.
+    /// </summary>
+    public async Task<DateTime?> GetHistoryStartAsync(CancellationToken ct = default)
+    {
+        var ttl = _cache.EarliestData == null ? TimeSpan.FromMinutes(5) : TimeSpan.FromHours(1);
+        if (DateTime.UtcNow - _cache.EarliestDataAt < ttl)
+            return _cache.EarliestData;
+        try
+        {
+            // Keep a known-good floor on transient failures (Influx restart,
+            // auth blip) - a null answer must not clobber the cached value.
+            var earliest = await _influx.QueryEarliestInterfaceDataAsync(ct);
+            if (earliest != null) _cache.EarliestData = earliest;
+            _cache.EarliestDataAt = DateTime.UtcNow;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogDebug(ex, "Earliest-data query failed; keeping cached timeline floor");
+            _cache.EarliestDataAt = DateTime.UtcNow;
+        }
+        return _cache.EarliestData;
+    }
+
+    /// <summary>
     /// Historic snapshot for the timeline scrubber. Queries InfluxDB at the requested
     /// instant +/- a small window matching the fast-tier interval (5 s).
     /// </summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionDetector.cs
@@ -27,12 +27,16 @@ public static class CongestionDetector
         var samples = series.Samples.Where(s => s.RttAvgMs.HasValue).OrderBy(s => s.Time).ToList();
         if (samples.Count == 0) return new List<CongestionEvent>();
 
-        var allRtts = samples.Select(s => s.RttAvgMs!.Value).ToList();
-        var allJitters = samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
-        var baselineRtt = SeriesStats.Median(allRtts);
-        var rttMad = SeriesStats.Mad(allRtts);
-        var baselineP90 = SeriesStats.Percentile(allRtts, 0.90);
-        var baselineJitter = allJitters.Count > 0 ? SeriesStats.Median(allJitters) : null;
+        // Sort each array once and derive median/MAD/p90 from it, rather than letting each SeriesStats
+        // call sort again (Median + Mad + Percentile would sort the RTT array 4x). Bit-identical.
+        var allRtts = samples.Select(s => s.RttAvgMs!.Value).ToArray();
+        Array.Sort(allRtts);
+        var allJitters = samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToArray();
+        Array.Sort(allJitters);
+        var baselineRtt = SeriesStats.MedianSorted(allRtts);
+        var baselineP90 = SeriesStats.PercentileSorted(allRtts, 0.90);
+        var rttMad = baselineRtt.HasValue ? SeriesStats.MadSorted(allRtts, baselineRtt.Value) : null;
+        var baselineJitter = allJitters.Length > 0 ? SeriesStats.MedianSorted(allJitters) : null;
         if (baselineRtt == null || rttMad == null || baselineP90 == null) return new List<CongestionEvent>();
 
         var bucketSize = TimeSpan.FromMinutes(options.CongestionBucketMinutes);
@@ -41,12 +45,15 @@ public static class CongestionDetector
             .OrderBy(g => g.Key)
             .Select(g =>
             {
-                var rtts = g.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
+                var rtts = g.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToArray();
+                Array.Sort(rtts);
+                var jit = g.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToArray();
+                Array.Sort(jit);
                 return new Bucket(
                     g.Key,
-                    SeriesStats.Median(rtts),
-                    SeriesStats.Percentile(rtts, 0.90),
-                    SeriesStats.Median(g.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList()));
+                    SeriesStats.MedianSorted(rtts),
+                    SeriesStats.PercentileSorted(rtts, 0.90),
+                    SeriesStats.MedianSorted(jit));
             })
             .ToList();
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
 
 /// <summary>
@@ -94,12 +96,13 @@ public static class CongestionLocalizer
             // shared FLOOR of added delay; localized congestion is the rise ABOVE that floor.
             double RttRise(AsnSeries s)
             {
-                var inW = s.Samples.Where(x => x.Time >= window.Start && x.Time <= window.End && x.RttAvgMs.HasValue)
-                    .Select(x => x.RttAvgMs!.Value).ToList();
-                var baseW = s.Samples.Where(x => (x.Time < window.Start || x.Time > window.End) && x.RttAvgMs.HasValue)
-                    .Select(x => x.RttAvgMs!.Value).ToList();
+                // In-window samples come from a binary-searched slice; the baseline (the series minus
+                // that slice) is read off a precomputed sorted array by value-exclusion, so this is
+                // identical to the prior full-scan + sort but far cheaper. See SeriesIndex.
+                var ix = Index(s);
+                var inW = ix.InWindowRtt(window.Start, window.End);
                 var im = SeriesStats.Median(inW);
-                var bm = SeriesStats.Median(baseW);
+                var bm = ix.BaselineRttMedian(inW);
                 return im.HasValue && bm.HasValue ? Math.Max(0, im.Value - bm.Value) : 0;
             }
             var relElevated = anchoredWithData.Where(s => IsElevated(s, window.Start, window.End)).ToList();
@@ -219,13 +222,12 @@ public static class CongestionLocalizer
         }
         else
         {
-            var inR = owner.Samples.Where(x => x.Time >= start && x.Time <= end && x.RttAvgMs.HasValue).Select(x => x.RttAvgMs!.Value).ToList();
-            var baseR = owner.Samples.Where(x => (x.Time < start || x.Time > end) && x.RttAvgMs.HasValue).Select(x => x.RttAvgMs!.Value).ToList();
-            var inJ = owner.Samples.Where(x => x.Time >= start && x.Time <= end).Select(x => x.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
-            var baseJ = owner.Samples.Where(x => x.Time < start || x.Time > end).Select(x => x.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
-            baseRtt = SeriesStats.Median(baseR) ?? 0;
+            var ix = Index(owner);
+            var inR = ix.InWindowRtt(start, end);
+            var inJ = ix.InWindowJitter(start, end);
+            baseRtt = ix.BaselineRttMedian(inR) ?? 0;
             peakRtt = inR.Count > 0 ? SeriesStats.Percentile(inR, 0.90) ?? baseRtt : baseRtt;
-            baseJit = SeriesStats.Median(baseJ) ?? 0;
+            baseJit = ix.BaselineJitterMedian(inJ) ?? 0;
             peakJit = inJ.Count > 0 ? inJ.Max() : baseJit;
         }
 
@@ -489,15 +491,11 @@ public static class CongestionLocalizer
     /// </summary>
     internal static bool ElevatedInWindow(AsnSeries series, DateTime start, DateTime end, IspHealthOptions options)
     {
-        var inWindow = series.Samples
-            .Where(x => x.Time >= start && x.Time <= end && x.RttAvgMs.HasValue)
-            .Select(x => x.RttAvgMs!.Value).ToList();
-        var baseline = series.Samples
-            .Where(x => (x.Time < start || x.Time > end) && x.RttAvgMs.HasValue)
-            .Select(x => x.RttAvgMs!.Value).ToList();
-        if (inWindow.Count == 0 || baseline.Count == 0) return false;
+        var ix = Index(series);
+        var inWindow = ix.InWindowRtt(start, end);
+        if (inWindow.Count == 0 || ix.RttCount - inWindow.Count == 0) return false;
 
-        var baselineP90 = SeriesStats.Percentile(baseline, 0.90);
+        var baselineP90 = ix.BaselineRttPercentile(inWindow, 0.90);
         if (baselineP90.HasValue)
         {
             var threshold = baselineP90.Value + options.CongestionRttMinDeltaMs;
@@ -509,16 +507,11 @@ public static class CongestionLocalizer
         // median RTT barely moves, so RTT-only propagation misses it. Compare in-window median jitter
         // to this hop's OWN baseline median (relative, with a small absolute floor so a near-zero hop
         // isn't tripped by a sub-ms ratio swing).
-        var inJitter = series.Samples
-            .Where(x => x.Time >= start && x.Time <= end).Select(x => x.EffectiveJitterMs)
-            .Where(j => j.HasValue).Select(j => j!.Value).ToList();
-        var baseJitter = series.Samples
-            .Where(x => x.Time < start || x.Time > end).Select(x => x.EffectiveJitterMs)
-            .Where(j => j.HasValue).Select(j => j!.Value).ToList();
-        if (inJitter.Count == 0 || baseJitter.Count == 0) return false;
+        var inJitter = ix.InWindowJitter(start, end);
+        if (inJitter.Count == 0 || ix.JitterCount - inJitter.Count == 0) return false;
 
         var inJitMedian = SeriesStats.Median(inJitter);
-        var baseJitMedian = SeriesStats.Median(baseJitter);
+        var baseJitMedian = ix.BaselineJitterMedian(inJitter);
         return inJitMedian.HasValue && baseJitMedian.HasValue
             && inJitMedian.Value >= baseJitMedian.Value * options.CongestionPropagationJitterFactor
             && inJitMedian.Value - baseJitMedian.Value >= options.CongestionPropagationJitterFloorMs;
@@ -536,7 +529,7 @@ public static class CongestionLocalizer
     /// data then (a newer target added after a past event, or a monitoring gap) reads as unknown,
     /// never as "clean" - so absence of data can't pad the clean-control or clean-parallel evidence.</summary>
     private static bool HasDataInWindow(AsnSeries series, DateTime start, DateTime end) =>
-        series.Samples.Any(x => x.Time >= start && x.Time <= end && x.RttAvgMs.HasValue);
+        Index(series).HasRttInWindow(start, end);
 
     /// <summary>
     /// True when the series' in-window median rose above its out-of-window baseline median by at least
@@ -546,14 +539,10 @@ public static class CongestionLocalizer
     /// </summary>
     private static bool RoseInWindow(AsnSeries series, DateTime start, DateTime end, IspHealthOptions options)
     {
-        var inWindow = series.Samples
-            .Where(x => x.Time >= start && x.Time <= end && x.RttAvgMs.HasValue)
-            .Select(x => x.RttAvgMs!.Value).ToList();
-        var baseline = series.Samples
-            .Where(x => (x.Time < start || x.Time > end) && x.RttAvgMs.HasValue)
-            .Select(x => x.RttAvgMs!.Value).ToList();
-        if (inWindow.Count == 0 || baseline.Count == 0) return false;
-        var bMed = SeriesStats.Median(baseline);
+        var ix = Index(series);
+        var inWindow = ix.InWindowRtt(start, end);
+        if (inWindow.Count == 0 || ix.RttCount - inWindow.Count == 0) return false;
+        var bMed = ix.BaselineRttMedian(inWindow);
         // Use a high in-window percentile, not the median: an event with a strong core and a long
         // mild tail dilutes the median toward baseline, so a path that genuinely rose for a good part
         // of the window flickers in and out of "rose" across recomputes and the line-wide breadth
@@ -585,4 +574,123 @@ public static class CongestionLocalizer
 
     private static bool Overlaps(DateTime aStart, DateTime aEnd, DateTime bStart, DateTime bEnd) =>
         aStart < bEnd && bStart < aEnd;
+
+    // ---- Fast windowed statistics (exact, precomputed per series) ----
+
+    // Per-series index, keyed by reference and weak so it is freed with the series. A series'
+    // samples are immutable for the life of a Localize call, so caching the sorted views is safe and
+    // lets the windowed elevation/rise tests avoid re-scanning and re-sorting the full series on
+    // every call - the localizer's dominant cost at long windows.
+    private static readonly ConditionalWeakTable<AsnSeries, SeriesIndex> _indexCache = new();
+    private static SeriesIndex Index(AsnSeries s) => _indexCache.GetValue(s, static key => new SeriesIndex(key));
+
+    /// <summary>
+    /// Precomputed sorted views of one series for the windowed elevation/rise tests. Sample times are
+    /// held ascending for binary-searched in-window slicing; RTT and jitter values are also kept sorted
+    /// ascending so a baseline statistic (the series minus the in-window slice) can be read by exact
+    /// value-exclusion instead of re-collecting and re-sorting the whole series. Every result is
+    /// identical to the prior full-scan code - only faster.
+    /// </summary>
+    private sealed class SeriesIndex
+    {
+        private readonly long[] _ticks;     // sample times, ascending
+        private readonly double?[] _rtt;    // RttAvgMs in the same (time) order as _ticks
+        private readonly double?[] _jit;    // EffectiveJitterMs in time order
+        private readonly double[] _rttAsc;  // all non-null RttAvgMs, ascending
+        private readonly double[] _jitAsc;  // all non-null EffectiveJitterMs, ascending
+
+        public SeriesIndex(AsnSeries s)
+        {
+            // Sort by time defensively: callers pass time-sorted per-target series, but the prior
+            // full-scan code did not depend on ordering, so don't silently assume it here either.
+            var ordered = s.Samples.OrderBy(x => x.Time).ToArray();
+            _ticks = new long[ordered.Length];
+            _rtt = new double?[ordered.Length];
+            _jit = new double?[ordered.Length];
+            for (var i = 0; i < ordered.Length; i++)
+            {
+                _ticks[i] = ordered[i].Time.Ticks;
+                _rtt[i] = ordered[i].RttAvgMs;
+                _jit[i] = ordered[i].EffectiveJitterMs;
+            }
+            _rttAsc = _rtt.Where(v => v.HasValue).Select(v => v!.Value).OrderBy(v => v).ToArray();
+            _jitAsc = _jit.Where(v => v.HasValue).Select(v => v!.Value).OrderBy(v => v).ToArray();
+        }
+
+        public int RttCount => _rttAsc.Length;
+        public int JitterCount => _jitAsc.Length;
+
+        public bool HasRttInWindow(DateTime start, DateTime end)
+        {
+            var (lo, hi) = Range(start, end);
+            for (var i = lo; i < hi; i++)
+                if (_rtt[i].HasValue) return true;
+            return false;
+        }
+
+        public List<double> InWindowRtt(DateTime start, DateTime end) => Collect(_rtt, start, end);
+        public List<double> InWindowJitter(DateTime start, DateTime end) => Collect(_jit, start, end);
+
+        public double? BaselineRttMedian(List<double> inWindow) => PercentileExcluding(_rttAsc, inWindow, 0.5);
+        public double? BaselineRttPercentile(List<double> inWindow, double p) => PercentileExcluding(_rttAsc, inWindow, p);
+        public double? BaselineJitterMedian(List<double> inWindow) => PercentileExcluding(_jitAsc, inWindow, 0.5);
+
+        private List<double> Collect(double?[] values, DateTime start, DateTime end)
+        {
+            var (lo, hi) = Range(start, end);
+            var list = new List<double>(Math.Max(0, hi - lo));
+            for (var i = lo; i < hi; i++)
+                if (values[i].HasValue) list.Add(values[i]!.Value);
+            return list;
+        }
+
+        // [lo, hi) index range of samples with start &lt;= time &lt;= end.
+        private (int lo, int hi) Range(DateTime start, DateTime end)
+            => (LowerBound(_ticks, start.Ticks), UpperBound(_ticks, end.Ticks));
+
+        private static int LowerBound(long[] a, long key)
+        {
+            int lo = 0, hi = a.Length;
+            while (lo < hi) { var m = (lo + hi) >> 1; if (a[m] < key) lo = m + 1; else hi = m; }
+            return lo;
+        }
+
+        private static int UpperBound(long[] a, long key)
+        {
+            int lo = 0, hi = a.Length;
+            while (lo < hi) { var m = (lo + hi) >> 1; if (a[m] <= key) lo = m + 1; else hi = m; }
+            return lo;
+        }
+
+        /// <summary>
+        /// Percentile of <paramref name="fullAsc"/> with the values in <paramref name="excl"/> removed,
+        /// matching <see cref="SeriesStats.Percentile"/> exactly (same rank + interpolation) but without
+        /// materializing or sorting the baseline. <paramref name="excl"/> is always a sub-multiset of
+        /// <paramref name="fullAsc"/> (the in-window slice), so values match bit-for-bit and duplicates
+        /// are skipped one-for-one during the merge. Null when the baseline is empty.
+        /// </summary>
+        private static double? PercentileExcluding(double[] fullAsc, List<double> excl, double p)
+        {
+            var n = fullAsc.Length - excl.Count;
+            if (n <= 0) return null;
+            var ex = excl.ToArray();
+            Array.Sort(ex);
+            var rank = p * (n - 1);
+            var loR = (int)Math.Floor(rank);
+            var hiR = (int)Math.Ceiling(rank);
+            double vLo = 0, vHi = 0;
+            bool gotLo = false, gotHi = false;
+            int bi = -1, ei = 0;
+            for (var i = 0; i < fullAsc.Length; i++)
+            {
+                if (ei < ex.Length && fullAsc[i] == ex[ei]) { ei++; continue; }
+                bi++;
+                if (bi == loR) { vLo = fullAsc[i]; gotLo = true; }
+                if (bi == hiR) { vHi = fullAsc[i]; gotHi = true; break; }
+            }
+            if (!gotLo) return null;
+            if (loR == hiR || !gotHi) return vLo;
+            return vLo + (vHi - vLo) * (rank - loR);
+        }
+    }
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -9,8 +9,23 @@ namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
 /// </summary>
 public class IspHealthOptions
 {
-    /// <summary>Trailing analysis window in hours.</summary>
+    /// <summary>Trailing analysis window in hours. The built-in default target; the per-site
+    /// configurable target (MonitoringSettings.IspHealthScoreWindowHours) overrides it.</summary>
     public int ScoreWindowHours { get; set; } = 48;
+
+    /// <summary>
+    /// Trailing windows (hours) the auto-computed score falls back through, longest first, when a
+    /// compute exceeds <see cref="ComputeBudget"/> on slower hardware. Only rungs at or below the
+    /// configured target window are used; a rung below <see cref="MinDataHours"/> is skipped.
+    /// </summary>
+    public int[] ScoreWindowLadderHours { get; set; } = { 48, 24, 16 };
+
+    /// <summary>
+    /// Per-attempt time budget for an auto-computed score. If a window's compute exceeds it, the auto
+    /// path abandons that window and drops to the next-shorter rung. Kept under the ~30 s HTTP/circuit
+    /// timeout so the default view never hangs on a window the hardware cannot finish in time.
+    /// </summary>
+    public TimeSpan ComputeBudget { get; set; } = TimeSpan.FromSeconds(25);
 
     /// <summary>Minimum hours of latency data required before a score is shown (new installs).</summary>
     public int MinDataHours { get; set; } = 4;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -719,8 +719,11 @@ public class IspHealthScorer
         var losses = series.Samples.Where(s => s.LossPercent.HasValue && !InOutage(s.Time)).Select(s => s.LossPercent!.Value).ToList();
         var jitters = series.Samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
 
-        var medianRtt = SeriesStats.Median(rtts);
-        var mad = SeriesStats.Mad(rtts);
+        // Sort the RTT set once; median, MAD, and the winsorized-mean / P95 below all read from it.
+        var sortedRtts = rtts.ToArray();
+        Array.Sort(sortedRtts);
+        var medianRtt = SeriesStats.MedianSorted(sortedRtts);
+        var mad = medianRtt.HasValue ? SeriesStats.MadSorted(sortedRtts, medianRtt.Value) : null;
 
         // Jitter and stability are absolve-only across clusters. The nearest cluster's
         // variance can be false (ICMP deprioritization at that hop); a cleaner farther
@@ -863,8 +866,8 @@ public class IspHealthScorer
             MedianRttMs = medianRtt,
             // Displayed RTT: winsorized mean (P99-capped) so sustained elevation shows but a
             // flap can't distort it. Reach (above) stays on the median - that measures distance.
-            MeanRttMs = SeriesStats.WinsorizedMean(rtts, _options.RttWinsorPercentile),
-            P95RttMs = SeriesStats.Percentile(rtts, 0.95),
+            MeanRttMs = SeriesStats.WinsorizedMeanSorted(sortedRtts, _options.RttWinsorPercentile),
+            P95RttMs = SeriesStats.PercentileSorted(sortedRtts, 0.95),
             // Raw near-cluster median, informational only. The displayed and scored jitter
             // is the effective (absolve/assimilated) value below.
             MedianJitterMs = jitters.Count > 0 ? SeriesStats.Median(jitters) : null,
@@ -921,9 +924,10 @@ public class IspHealthScorer
     /// <summary>RTT stability ratio (MAD / median) of a sample set; lower is steadier. Null without RTT.</summary>
     private static double? StabilityRatioOf(IReadOnlyList<LatencySample> samples)
     {
-        var rtts = samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
-        var median = SeriesStats.Median(rtts);
-        var mad = SeriesStats.Mad(rtts);
+        var rtts = samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToArray();
+        Array.Sort(rtts);
+        var median = SeriesStats.MedianSorted(rtts);
+        var mad = median.HasValue ? SeriesStats.MadSorted(rtts, median.Value) : null;
         return median is > 0 && mad.HasValue ? mad.Value / median.Value : null;
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -359,6 +359,11 @@ public class IspHealthService
         var aggregate = TimeSpan.FromSeconds(Math.Max(
             _options.LoadWindowSeconds, (windowEnd - windowStart).TotalSeconds / 25000.0));
 
+        // All target types read at the fine window. Coarsening transit/internet RTT bought a modest
+        // 48h deserialize win but shifted congestion localization (the bottleneck walk keys on RTT
+        // bursts, which a coarse mean blunts), so it diverged from the fine-resolution attribution on
+        // transit-heavy paths. Kept fine everywhere; the compute-time wins now come from the in-memory
+        // detector/scorer paths, not from coarsening the input.
         var ispSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.AccessIsp, windowStart, windowEnd, aggregate, ct);
         var transitSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.Transit, windowStart, windowEnd, aggregate, ct);
         var internetSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.InternetService, windowStart, windowEnd, aggregate, ct);
@@ -843,6 +848,31 @@ public class IspHealthService
     {
         var (down, up, _, _) = await ResolveExpectedSpeedsAsync(ct);
         return (down, up);
+    }
+
+    /// <summary>
+    /// The exact set of target IDs whose loss ISP Health pools into the Packet Loss and Loaded Loss
+    /// factors: every enabled access ISP hop, every enabled transit hop except non-transit IXP /
+    /// anycast infrastructure (WoodyNet / PCH), and the well-known anycast DNS resolvers. Kept here as
+    /// the single source of the pool definition (mirrors the lossPool built in ComputeCoreAsync) so the
+    /// Investigate loss highlight can average the very pool the score is graded on instead of a
+    /// per-type approximation, and the two can never drift.
+    /// </summary>
+    public async Task<List<string>> GetLossPoolTargetIdsAsync(CancellationToken ct = default)
+    {
+        await using var db = await _dbFactory.CreateDbContextAsync(ct);
+        var targets = await db.MonitoringTargets.AsNoTracking()
+            .Where(t => t.Enabled && (t.TargetType == MonitoringTargetType.AccessIsp
+                || t.TargetType == MonitoringTargetType.Transit
+                || t.TargetType == MonitoringTargetType.InternetService))
+            .ToListAsync(ct);
+        return targets
+            .Where(t => t.TargetType == MonitoringTargetType.AccessIsp
+                || (t.TargetType == MonitoringTargetType.Transit
+                    && !(t.AsnNumber is int a && WellKnownAsns.NonTransitInfrastructure.Contains(a)))
+                || (t.TargetType == MonitoringTargetType.InternetService && AnycastDnsIps.Contains(t.Address)))
+            .Select(t => t.TargetId)
+            .ToList();
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -45,6 +45,13 @@ public class IspHealthService
     private CustomWindowSnapshot? _customCache;
     private IspHealthStatus _status = IspHealthStatus.Computing;
     private volatile bool _computing;
+    // Trailing window (hours) the last successful auto-compute used. Drops down the ladder when a
+    // longer window exceeds the compute budget on this hardware; resets to 0 on process restart so the
+    // configured target is re-probed once after each deploy. 0 until the first auto-compute runs.
+    private volatile int _effectiveWindowHours;
+    // Configured target window (hours), cached from MonitoringSettings on each auto-compute so the
+    // dashboard tile and tab can read it without a DB hit. 0 until the first auto-compute runs.
+    private volatile int _configuredWindowHours;
 
     public IspHealthService(
         MonitoringInfluxClient influx,
@@ -185,15 +192,130 @@ public class IspHealthService
 
     public IspHealthStatus Status => _cached != null ? IspHealthStatus.Ready : _status;
 
+    /// <summary>The trailing window (hours) the auto-computed score and default view currently use.
+    /// Falls below the configured target on slower hardware that can't finish the longer window inside
+    /// the compute budget. 0 until the first auto-compute completes.</summary>
+    public int EffectiveWindowHours => _effectiveWindowHours;
+
+    /// <summary>The configured target window (hours) the auto-compute aims for (per-site setting, or
+    /// the built-in default). 0 until the first auto-compute runs.</summary>
+    public int ConfiguredWindowHours => _configuredWindowHours;
+
+    /// <summary>
+    /// Re-probe the configured target window on the next auto-compute. Wired to the "reduced window"
+    /// badge so a user who thinks the hardware can now handle the full window (e.g. after an upgrade)
+    /// can ask for it: resets the fallback to start the ladder at the target again, and drops the
+    /// cached shorter report so the next read recomputes.
+    /// </summary>
+    public void RetryConfiguredWindow()
+    {
+        _effectiveWindowHours = 0;
+        _cached = null;
+    }
+
     private async Task<(IspHealthReport? Report, List<AsnSeries> ChartClusters)> ComputeAsync(CancellationToken ct)
     {
-        // Canonical/auto-computed path: always the trailing ScoreWindowHours (48 h). Publishes
-        // the readiness status the dashboard tile reads.
-        var windowEnd = DateTime.UtcNow;
-        var windowStart = windowEnd.AddHours(-_options.ScoreWindowHours);
-        var outcome = await ComputeCoreAsync(windowStart, windowEnd, null, ct);
-        _status = outcome.Status;
-        return (outcome.Report, outcome.ChartClusters);
+        // Canonical/auto-computed path. It targets the configured window (default 48 h) but drops down
+        // ScoreWindowLadderHours whenever a window's compute exceeds ComputeBudget, so on slower NAS
+        // hardware the default view and dashboard score fall back to a window the box can actually
+        // finish (24 h, then 16 h) instead of hanging past the HTTP timeout. Publishes the readiness
+        // status the dashboard tile reads.
+        var ceiling = await ResolveConfiguredWindowHoursAsync(ct);
+        _configuredWindowHours = ceiling;
+        var budget = ResolveComputeBudget();
+
+        // Always attempt the configured target first, then the standard rungs strictly below it, so a
+        // ceiling that isn't itself a ScoreWindowLadderHours value (e.g. 36 h) still tries the target
+        // before falling back rather than jumping straight to the nearest shorter rung.
+        var ladder = new[] { ceiling }
+            .Concat(_options.ScoreWindowLadderHours.Where(h => h < ceiling))
+            .Where(h => h >= _options.MinDataHours)
+            .Distinct()
+            .OrderByDescending(h => h)
+            .ToList();
+        if (ladder.Count == 0) ladder.Add(Math.Max(ceiling, _options.MinDataHours));
+
+        // Resume at the current effective rung so a box that already fell back doesn't re-attempt the
+        // too-slow longer windows on every refresh. A process restart resets _effectiveWindowHours, so
+        // the ceiling is re-probed once on the first compute after each deploy.
+        var startIdx = 0;
+        if (_effectiveWindowHours > 0)
+        {
+            var resume = ladder.FindIndex(h => h <= _effectiveWindowHours);
+            startIdx = resume < 0 ? 0 : resume;
+        }
+
+        for (var i = startIdx; i < ladder.Count; i++)
+        {
+            var hours = ladder[i];
+            var windowEnd = DateTime.UtcNow;
+            var windowStart = windowEnd.AddHours(-hours);
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            using var budgetCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            budgetCts.CancelAfter(budget);
+            try
+            {
+                var outcome = await ComputeCoreAsync(windowStart, windowEnd, null, budgetCts.Token);
+                _effectiveWindowHours = hours;
+                _status = outcome.Status;
+                _logger.LogDebug("ISP Health auto-compute at {Hours}h completed in {Ms}ms (status {Status})",
+                    hours, sw.ElapsedMilliseconds, outcome.Status);
+                if (hours < ceiling)
+                    _logger.LogInformation(
+                        "ISP Health auto-compute using a {Hours}h window (target {Ceiling}h): the longer window exceeded the {Budget}s time budget on this hardware",
+                        hours, ceiling, (int)budget.TotalSeconds);
+                return (outcome.Report, outcome.ChartClusters);
+            }
+            catch (OperationCanceledException) when (budgetCts.IsCancellationRequested && !ct.IsCancellationRequested)
+            {
+                var next = i + 1 < ladder.Count ? ladder[i + 1] : hours;
+                _effectiveWindowHours = next;
+                _logger.LogInformation(
+                    "ISP Health {Hours}h auto-compute exceeded the {Budget}s time budget after {Ms}ms; falling back to {Next}h",
+                    hours, (int)budget.TotalSeconds, sw.ElapsedMilliseconds, next);
+            }
+        }
+
+        // Every rung exceeded the budget: leave the funnel status so the tile/tab report progress and
+        // the next cycle retries. Don't publish a stale report.
+        _logger.LogWarning(
+            "ISP Health auto-compute could not finish any window ({Ladder}h) within the {Budget}s budget",
+            string.Join("/", ladder), (int)budget.TotalSeconds);
+        _status = IspHealthStatus.Computing;
+        return (null, new List<AsnSeries>());
+    }
+
+    /// <summary>
+    /// Configured target window (hours) from MonitoringSettings, floored at MinDataHours and defaulting
+    /// to the built-in ScoreWindowHours when unset or unreadable.
+    /// </summary>
+    private async Task<int> ResolveConfiguredWindowHoursAsync(CancellationToken ct)
+    {
+        try
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync(ct);
+            var settings = await db.MonitoringSettings.AsNoTracking().FirstOrDefaultAsync(ct);
+            var hours = settings?.IspHealthScoreWindowHours ?? _options.ScoreWindowHours;
+            return hours >= _options.MinDataHours ? hours : _options.ScoreWindowHours;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "ISP Health could not read the configured score window; using default {Default}h", _options.ScoreWindowHours);
+            return _options.ScoreWindowHours;
+        }
+    }
+
+    /// <summary>
+    /// Per-attempt compute budget: the ISP_HEALTH_COMPUTE_BUDGET_SECONDS env var when set (used to
+    /// force the window fallback on fast hardware for testing, or to tune for a specific box), else the
+    /// built-in <see cref="IspHealthOptions.ComputeBudget"/> default.
+    /// </summary>
+    private TimeSpan ResolveComputeBudget()
+    {
+        var raw = Environment.GetEnvironmentVariable("ISP_HEALTH_COMPUTE_BUDGET_SECONDS");
+        if (double.TryParse(raw, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var seconds) && seconds > 0)
+            return TimeSpan.FromSeconds(seconds);
+        return _options.ComputeBudget;
     }
 
     /// <summary>
@@ -541,6 +663,10 @@ public class IspHealthService
             Load = loadByTime,
             HasTraceMap = hopOrderKnown
         };
+        // Compute-budget checkpoints between the heavy in-memory phases: the Influx reads above honor
+        // the token, but the detectors/scorer are CPU loops, so a deadline that fires mid-compute is
+        // caught at the next phase boundary and abandons the attempt (the auto path then drops a rung).
+        ct.ThrowIfCancellationRequested();
         var congestionEvents = CongestionLocalizer.Localize(localizerSeries, congestionTopology, _options);
         if (referenceEvents != null)
             congestionEvents = GateAgainstCanonical(congestionEvents, referenceEvents, windowEnd);
@@ -642,6 +768,7 @@ public class IspHealthService
             .Concat(orderedWanHops.Select((x, i) =>
                 new OutageDetector.Hop(x.Name, baseDepth + i, x.Series, x.Groupable, x.AsnLabel)))
             .ToList();
+        ct.ThrowIfCancellationRequested();
         var outages = OutageDetector.Detect(internetTriggerTargets, outageHops, _options);
         // Second pass: coincident partial-loss disruptions (the path getting lossy but not dark)
         // across the full set of monitored hops, excluding windows already flagged as blackouts.
@@ -700,6 +827,7 @@ public class IspHealthService
             PhysicalLink = physical.Input
         };
 
+        ct.ThrowIfCancellationRequested();
         var report = new IspHealthScorer(_options, _logger).Score(inputs, profile);
         report.AccessTechnology = technology;
         report.PhysicalLinkCandidates = physical.Candidates;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
@@ -234,17 +234,31 @@ public static class OutageDetector
         IReadOnlyList<IReadOnlyList<LatencySample>> targets, TimeSpan windowSize)
     {
         var perBucket = new Dictionary<DateTime, List<double>>();
+        // Accumulate sum+count per bucket manually rather than GroupBy(...).Average(): the loss
+        // series are coarse relative to the outage bucket, so most buckets hold a single sample and
+        // GroupBy would allocate one IGrouping per bucket per hop. Summation stays in source order,
+        // so the per-bucket mean is bit-identical to the GroupBy version.
+        var sum = new Dictionary<DateTime, double>();
+        var cnt = new Dictionary<DateTime, int>();
         foreach (var target in targets)
         {
-            foreach (var g in target.Where(s => s.LossPercent.HasValue)
-                         .GroupBy(s => CongestionDetector.FloorTime(s.Time, windowSize)))
+            sum.Clear();
+            cnt.Clear();
+            foreach (var s in target)
             {
-                if (!perBucket.TryGetValue(g.Key, out var list))
+                if (!s.LossPercent.HasValue) continue;
+                var b = CongestionDetector.FloorTime(s.Time, windowSize);
+                sum[b] = (sum.TryGetValue(b, out var sv) ? sv : 0d) + s.LossPercent.Value;
+                cnt[b] = (cnt.TryGetValue(b, out var cv) ? cv : 0) + 1;
+            }
+            foreach (var kv in cnt)
+            {
+                if (!perBucket.TryGetValue(kv.Key, out var list))
                 {
                     list = new List<double>();
-                    perBucket[g.Key] = list;
+                    perBucket[kv.Key] = list;
                 }
-                list.Add(g.Average(s => s.LossPercent!.Value));
+                list.Add(sum[kv.Key] / kv.Value);
             }
         }
         return perBucket;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/SeriesStats.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/SeriesStats.cs
@@ -42,6 +42,48 @@ internal static class SeriesStats
         return Median(deviations);
     }
 
+    // ---- Pre-sorted variants ----
+    // When several statistics are needed over the same series, the caller sorts once and uses these
+    // instead of the list overloads (each of which sorts internally). Results are identical.
+
+    /// <summary>Percentile of an already ascending-sorted list, matching <see cref="Percentile"/>.</summary>
+    public static double? PercentileSorted(IReadOnlyList<double> sortedAsc, double p)
+    {
+        if (sortedAsc.Count == 0) return null;
+        var rank = p * (sortedAsc.Count - 1);
+        var lo = (int)Math.Floor(rank);
+        var hi = (int)Math.Ceiling(rank);
+        if (lo == hi) return sortedAsc[lo];
+        return sortedAsc[lo] + (sortedAsc[hi] - sortedAsc[lo]) * (rank - lo);
+    }
+
+    /// <summary>Median of an already ascending-sorted list, matching <see cref="Median"/>.</summary>
+    public static double? MedianSorted(IReadOnlyList<double> sortedAsc) => PercentileSorted(sortedAsc, 0.5);
+
+    /// <summary>
+    /// MAD given the series already ascending-sorted and its (pre-computed) median, so the median
+    /// isn't re-sorted for. Identical result to <see cref="Mad"/>.
+    /// </summary>
+    public static double? MadSorted(IReadOnlyList<double> sortedAsc, double median)
+    {
+        if (sortedAsc.Count == 0) return null;
+        var dev = new double[sortedAsc.Count];
+        for (var i = 0; i < sortedAsc.Count; i++) dev[i] = Math.Abs(sortedAsc[i] - median);
+        Array.Sort(dev);
+        return PercentileSorted(dev, 0.5);
+    }
+
+    /// <summary>Winsorized mean of an already ascending-sorted list, matching <see cref="WinsorizedMean"/>.</summary>
+    public static double? WinsorizedMeanSorted(IReadOnlyList<double> sortedAsc, double upperPercentile)
+    {
+        if (sortedAsc.Count == 0) return null;
+        var cap = PercentileSorted(sortedAsc, upperPercentile);
+        if (cap == null) return null;
+        double sum = 0;
+        for (var i = 0; i < sortedAsc.Count; i++) sum += Math.Min(sortedAsc[i], cap.Value);
+        return sum / sortedAsc.Count;
+    }
+
     /// <summary>Interquartile range as (q1, q3), or null when empty.</summary>
     public static (double Q1, double Q3)? Iqr(IReadOnlyList<double> values)
     {

--- a/src/NetworkOptimizer.Web/Services/ScanPermissionException.cs
+++ b/src/NetworkOptimizer.Web/Services/ScanPermissionException.cs
@@ -1,0 +1,14 @@
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Thrown by <see cref="WiFiOptimizerService.RunQuickScansAsync"/> when the UniFi account lacks the
+/// permission needed to trigger an RF spectrum scan. Carries a user-facing message the UI can show
+/// directly, keeping the underlying UniFi exception type out of the Blazor components.
+/// </summary>
+public class ScanPermissionException : Exception
+{
+    public ScanPermissionException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -655,6 +655,7 @@ public class WiFiOptimizerService
     /// </summary>
     public async Task RunQuickScansAsync(
         IEnumerable<(string ApMac, string BandCode)> targets,
+        IProgress<int>? progress = null,
         CancellationToken cancellationToken = default)
     {
         var list = targets.ToList();
@@ -671,12 +672,32 @@ public class WiFiOptimizerService
                 if (radio.ChannelWidth is int w)
                     widthByApBand[(ap.Mac, radio.Band.ToUniFiCode())] = w;
 
+        // Report progress as each band scan STARTS (bands run sequentially within an AP but APs run
+        // concurrently, so the counter is shared and bumped atomically). Counting at start - not
+        // completion - means the UI shows "scanning band N" while that band is actually in flight,
+        // and never sits at 0. Total = list.Count (one scan per gapped (AP, band) target).
+        var bandsStarted = 0;
+        void ReportBandStart()
+        {
+            if (progress != null)
+                progress.Report(Interlocked.Increment(ref bandsStarted));
+        }
+
         var perApScans = list
             .GroupBy(t => t.ApMac, StringComparer.OrdinalIgnoreCase)
             .Select(g => ScanApBandsSequentiallyAsync(
                 provider, g.Key, g.Select(t => t.BandCode).Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
-                widthByApBand, cancellationToken));
-        await Task.WhenAll(perApScans);
+                widthByApBand, ReportBandStart, cancellationToken));
+        try
+        {
+            await Task.WhenAll(perApScans);
+        }
+        catch (UniFiPermissionException ex)
+        {
+            // Insufficient UniFi role - re-throw as a UI-facing error so the user knows to fix
+            // permissions rather than retry. Nothing scanned, so the cache stays valid.
+            throw new ScanPermissionException(ex.Message);
+        }
 
         // Fresh scans are in - drop the cached snapshot so the next fetch re-reads the spectrum data.
         _cachedScanResults = null;
@@ -689,10 +710,12 @@ public class WiFiOptimizerService
     /// </summary>
     private async Task ScanApBandsSequentiallyAsync(
         UniFiLiveDataProvider provider, string apMac, List<string> bandCodes,
-        IReadOnlyDictionary<(string Mac, string BandCode), int> widthByApBand, CancellationToken cancellationToken)
+        IReadOnlyDictionary<(string Mac, string BandCode), int> widthByApBand,
+        Action? onBandStart, CancellationToken cancellationToken)
     {
         foreach (var bandCode in bandCodes)
         {
+            onBandStart?.Invoke();
             // Scan at the radio's current width (fall back to 20 MHz if unknown).
             var bandwidthMhz = widthByApBand.TryGetValue((apMac, bandCode), out var w) ? w : 20;
             try
@@ -709,6 +732,12 @@ public class WiFiOptimizerService
                         apMac, QuickScanPerBandTimeoutSeconds);
                     break;
                 }
+            }
+            catch (UniFiPermissionException)
+            {
+                // Insufficient role affects every scan, not just this band - stop and let the caller
+                // surface it rather than swallowing it and hammering the controller with more 403s.
+                throw;
             }
             catch (Exception ex)
             {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -16088,6 +16088,31 @@ tr.stats-row-filtered {
     justify-content: center;
 }
 
+.isp-window-reduced {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    height: 30px;
+    padding: 0 10px;
+    border: 1px solid var(--warning-color);
+    border-radius: 6px;
+    background: rgba(231, 150, 19, 0.12);
+    color: var(--warning-color);
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.isp-window-reduced:hover {
+    background: rgba(231, 150, 19, 0.2);
+}
+
+.isp-window-reduced:disabled {
+    opacity: 0.6;
+    cursor: default;
+}
+
 .isp-popover-backdrop {
     position: fixed;
     inset: 0;
@@ -16157,6 +16182,15 @@ tr.stats-row-filtered {
     align-items: center;
     gap: 2rem;
     padding: 1.5rem 2rem;
+    min-height: 249px;
+}
+
+.isp-health-hero-body-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1.25rem;
 }
 
 .isp-health-hero-gauge {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15411,16 +15411,60 @@ tr.stats-row-filtered {
     font-size: 0.78rem;
     color: var(--text-secondary);
 }
+.lan-flow-map-scrubber-track {
+    flex: 1;
+    position: relative;
+    display: flex;
+    align-items: center;
+}
 .lan-flow-map-scrubber-range {
     flex: 1;
     accent-color: var(--speed-download-color, #3385d6);
+}
+.lan-flow-map-scrubber-ticks {
+    position: absolute;
+    left: 8px;
+    right: 8px;
+    top: 0;
+    bottom: 0;
+    pointer-events: none;
+}
+.lan-flow-map-scrubber-tick {
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 1px;
+    height: 0.6rem;
+    background: rgba(255, 255, 255, 0.22);
+}
+.lan-flow-map-scrubber-window {
+    background: transparent;
+    border: 1px solid var(--border-color, #334155);
+    color: var(--text-secondary);
+    height: 1.75rem;
+    border-radius: 0.25rem;
+    font-size: 0.72rem;
+    padding: 0 0.2rem;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+.lan-flow-map-scrubber-window:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+}
+.lan-flow-map-scrubber-window option {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+}
+.lan-flow-map-scrubber-window option:disabled {
+    color: var(--text-muted);
 }
 /* Right label swaps between "Live" and a long locale datetime as the user
    scrubs; without a min-width the flex row reflows and the slider thumb
    jumps right under the cursor as it approaches the live edge. */
 .lan-flow-map-scrubber-row [data-role="right"] {
     display: inline-block;
-    min-width: 7.5rem;
+    min-width: min(7.5rem, 30vw);
     text-align: center;
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
@@ -15849,6 +15893,9 @@ tr.stats-row-filtered {
     .lan-flow-map-speed-control {
         display: none;
     }
+    .lan-flow-map-scrubber-row [data-role="left"] {
+        display: none;
+    }
     .lan-flow-map-signal-hint {
         top: 0.5rem;
         max-width: calc(100% - 1rem);
@@ -15871,6 +15918,7 @@ tr.stats-row-filtered {
     position: relative;
 }
 .lan-flow-map-2d-stage {
+    position: relative;
     width: 100%;
     height: clamp(520px, 70vh, 820px);
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -3731,6 +3731,17 @@ select.form-control {
     flex-shrink: 0;
 }
 
+.scan-error-banner {
+    margin-bottom: 1rem;
+    font-size: 0.85rem;
+}
+
+@media (max-width: 768px) {
+    .scan-gap-banner .btn {
+        width: 100%;
+    }
+}
+
 .banner-icon {
     font-size: 1.5rem;
     background: rgba(255, 255, 255, 0.2);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-data.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-data.js
@@ -2,6 +2,18 @@
 // The 3D map publishes data here after each fetch; the 2D map subscribes
 // so only one set of API calls runs. Pure pub/sub - no fetching.
 
+// Timeline window presets for the shared scrubber. 'max' spans back to the
+// earliest stored data point (bounded by the primary bucket's 90-day retention).
+export const SCRUBBER_PRESETS = [
+    { key: '1h',  ms: 3600000,       label: '1h' },
+    { key: '6h',  ms: 6 * 3600000,   label: '6h' },
+    { key: '24h', ms: 24 * 3600000,  label: '24h' },
+    { key: '3d',  ms: 3 * 86400000,  label: '3d' },
+    { key: '7d',  ms: 7 * 86400000,  label: '7d' },
+    { key: '30d', ms: 30 * 86400000, label: '30d' },
+    { key: 'max', ms: null,          label: 'Max' },
+];
+
 let _snapshot = null;
 let _liveRates = {};
 let _cloudStats = {};
@@ -12,6 +24,9 @@ let _mode = 'live';
 let _scrubberValue = 10000;
 let _scrubberRight = 'Live';
 let _playbackSpeed = 1;
+// Timeline window the slider spans: { startMs, endMs, presetKey, leftLabel,
+// disabledKeys }. The window always trails now, so the right edge is Live.
+let _scrubberWindow = null;
 let _listeners = new Set();
 
 export function getSnapshot()  { return _snapshot; }
@@ -22,6 +37,7 @@ export function getClientStats() { return _clientStats; }
 export function isPaused()       { return _paused; }
 export function getMode()        { return _mode; }
 export function getScrubber()    { return { value: _scrubberValue, right: _scrubberRight, speed: _playbackSpeed }; }
+export function getScrubberWindow() { return _scrubberWindow; }
 
 export function subscribe(fn) {
     _listeners.add(fn);
@@ -65,6 +81,36 @@ export function publishScrubber(value, rightLabel, speed) {
     _scrubberRight = rightLabel;
     _playbackSpeed = speed;
     _notify('scrubber');
+}
+
+export function publishScrubberWindow(win) {
+    _scrubberWindow = win;
+    _notify('scrubber-window');
+}
+
+// Render local-midnight tick marks onto a scrubber track overlay so multi-day
+// windows have day-boundary orientation. Shared by the 3D scrubber and its 2D
+// mirror. Windows under two days get no ticks; wide windows thin to ~12 ticks.
+export function renderScrubberTicks(el, startMs, endMs) {
+    if (!el) return;
+    el.innerHTML = '';
+    const span = endMs - startMs;
+    if (span < 48 * 3600000) return;
+    const stepDays = Math.max(1, Math.round(span / (12 * 86400000)));
+    const first = new Date(startMs);
+    first.setHours(24, 0, 0, 0);
+    let day = 0;
+    for (let t = first.getTime(); t < endMs; day++) {
+        if (day % stepDays === 0) {
+            const tick = document.createElement('span');
+            tick.className = 'lan-flow-map-scrubber-tick';
+            tick.style.left = `${((t - startMs) / span * 100).toFixed(2)}%`;
+            el.appendChild(tick);
+        }
+        const next = new Date(t);
+        next.setHours(24, 0, 0, 0);
+        t = next.getTime();
+    }
 }
 
 // Standalone data poller for contexts without the 3D map (e.g. dashboard).

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -3,7 +3,7 @@
 // zero duplicate API calls. GPU-composited canvas for smooth particle animation.
 
 // KEEP IN SYNC: lan-flow-map.js imports the same module. Both must use the same ?v= or they get separate instances.
-import * as flowData from './lan-flow-data.js?v=3';
+import * as flowData from './lan-flow-data.js?v=4';
 
 function demoMask(text) {
     const dm = window.DemoMask;
@@ -317,6 +317,8 @@ class LanFlowMap2D {
                 this._needsStaticRedraw=true;
             }else if(ev==='scrubber'||ev==='playstate'){
                 this._syncScrubber();
+            }else if(ev==='scrubber-window'){
+                this._syncScrubberWindow();
             }
         });
         this._lastFrame=performance.now();
@@ -330,6 +332,10 @@ class LanFlowMap2D {
         if(this._onKeyDown)document.removeEventListener('keydown',this._onKeyDown);
         if(this._isFullscreen)this._el.classList.remove('lan-flow-map-fullscreen');
         this._streams=[];
+        // The mobile scrubber lives outside _el (below the stage), so clearing
+        // _el's children alone would leave it behind on unmount.
+        if(this._scrubberMq)this._scrubberMq.removeEventListener('change',this._placeScrubber);
+        if(this._scrubberEl)this._scrubberEl.remove();
         this._el.innerHTML='';
     }
 
@@ -493,10 +499,7 @@ class LanFlowMap2D {
         modeBadge.setAttribute('data-tooltip-hover-only','');
         modeBadge.addEventListener('click',()=>{
             const inst=window.__lanFlowMap?.getInstance?.();
-            if(inst&&inst._mode==='historic'){
-                const r=inst._panels?.scrubberRange;
-                if(r){r.value=10000;r.dispatchEvent(new Event('change'));}
-            }
+            if(inst&&inst._mode==='historic')inst._returnToLive();
         });
         status.appendChild(modeBadge);
         this._el.appendChild(status);
@@ -514,10 +517,48 @@ class LanFlowMap2D {
                     <span class="lan-flow-map-speed-label" data-role="speed-label">1x</span>
                     <button class="lan-flow-map-speed-step" data-dir="1" type="button" aria-label="Faster">+</button>
                 </div>
+                <select class="lan-flow-map-scrubber-window" data-role="window" aria-label="Timeline range"></select>
                 <span data-role="left">-24h</span>
-                <input class="lan-flow-map-scrubber-range" type="range" min="0" max="10000" value="10000" />
+                <span class="lan-flow-map-scrubber-track">
+                    <input class="lan-flow-map-scrubber-range" type="range" min="0" max="10000" value="10000" />
+                    <span class="lan-flow-map-scrubber-ticks" data-role="ticks"></span>
+                </span>
                 <span data-role="right">Live</span>
             </div>`;
+        const windowSel=scrubber.querySelector('[data-role="window"]');
+        for(const p of flowData.SCRUBBER_PRESETS){
+            const opt=document.createElement('option');
+            opt.value=p.key;opt.textContent=p.label;
+            windowSel.appendChild(opt);
+        }
+        windowSel.value='24h';
+        windowSel.addEventListener('change',()=>{
+            const inst=window.__lanFlowMap?.getInstance?.();
+            if(inst)inst._setScrubSpan(windowSel.value);
+        });
+        // Arrow left/right (with Shift for fast scrub) and Space float up to
+        // timeline scrubbing and play/pause (on the 3D instance); without this
+        // the focused dropdown consumes them natively.
+        windowSel.addEventListener('keydown',(e)=>{
+            const inst=window.__lanFlowMap?.getInstance?.();
+            if(e.key==='Shift'){if(inst&&inst._keys)inst._keys.shift=true;return;}
+            if(e.key===' '){
+                e.preventDefault();
+                if(inst)inst._togglePlayPause();
+                return;
+            }
+            if(e.key!=='ArrowLeft'&&e.key!=='ArrowRight')return;
+            e.preventDefault();
+            if(inst&&inst._keys)inst._keys[e.key.toLowerCase()]=true;
+        });
+        windowSel.addEventListener('keyup',(e)=>{
+            const inst=window.__lanFlowMap?.getInstance?.();
+            if(!inst)return;
+            if(e.key==='Shift'){if(inst._keys)inst._keys.shift=false;return;}
+            if(e.key!=='ArrowLeft'&&e.key!=='ArrowRight')return;
+            if(inst._keys)inst._keys[e.key.toLowerCase()]=false;
+            inst._arrowScrubStart=null;
+        });
         // Forward all interactions to the 3D map
         const fwd=()=>window.__lanFlowMap?.getInstance?.();
         const sRange=scrubber.querySelector('.lan-flow-map-scrubber-range');
@@ -564,13 +605,33 @@ class LanFlowMap2D {
                 }
             });
         }
-        this._el.appendChild(scrubber);
+        // Mobile: place the scrubber below the stage like the 3D map does, so
+        // the stage bottom stays the canvas bottom and the mode badge anchors
+        // to the same spot as on 3D instead of dropping onto the scrubber row.
+        // Tracked live, not just at mount - the breakpoint CSS applies on
+        // resize, so the DOM placement must follow it.
+        this._scrubberMq=window.matchMedia('(max-width: 768px)');
+        this._placeScrubber=()=>{
+            if(this._scrubberMq.matches&&this._el.parentElement){
+                this._el.parentElement.insertBefore(scrubber,this._el.nextSibling);
+            }else{
+                this._el.appendChild(scrubber);
+            }
+        };
+        this._placeScrubber();
+        this._scrubberMq.addEventListener('change',this._placeScrubber);
+        this._scrubberEl=scrubber;
         this._scrubberEls={
             range:sRange,
+            left:scrubber.querySelector('[data-role="left"]'),
             right:scrubber.querySelector('[data-role="right"]'),
             playPause:scrubber.querySelector('[data-role="playpause"]'),
             speedLabel:scrubber.querySelector('[data-role="speed-label"]'),
+            windowSel,
+            ticks:scrubber.querySelector('[data-role="ticks"]'),
         };
+        // Adopt whatever window the 3D map already published (it usually mounts first).
+        this._syncScrubberWindow();
 
         // Events
         canvas.addEventListener('wheel',(e)=>this._onWheel(e),{passive:false});
@@ -752,6 +813,19 @@ class LanFlowMap2D {
                 if(this._modeBadge._tippy)this._modeBadge._tippy.destroy();
             }
         }
+    }
+
+    _syncScrubberWindow(){
+        if(!this._scrubberEls)return;
+        const win=flowData.getScrubberWindow();
+        if(!win)return;
+        this._scrubberEls.left.textContent=win.leftLabel;
+        const sel=this._scrubberEls.windowSel;
+        if(sel){
+            sel.value=win.presetKey;
+            for(const opt of sel.options)opt.disabled=win.disabledKeys?.includes(opt.value)??false;
+        }
+        flowData.renderScrubberTicks(this._scrubberEls.ticks,win.startMs,win.endMs);
     }
 
     _isNodeVisible(n){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -15,7 +15,7 @@ import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js'
 import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 import { buildBuildings } from './lan-flow-buildings.js?v=1';
 // KEEP IN SYNC: lan-flow-map-2d.js imports the same module. Both must use the same ?v= or they get separate instances.
-import * as flowData from './lan-flow-data.js?v=3';
+import * as flowData from './lan-flow-data.js?v=4';
 
 const COLORS = {
     background: 0x202023,
@@ -182,7 +182,16 @@ export class LanFlowMap {
         this._dotnetRef = window.__monitoringRef || null;
         this._playbackSpeed = 1;  // real-time multiplier
         this._playbackAccum = 0;  // fractional slider unit accumulator
-        this._scrubberOrigin = Date.now() - 24 * 3600000; // left edge anchored at mount - 24h
+        // Timeline window: the slider spans the latest _scrubSpan ms, always
+        // trailing now so the right edge is Live and recent time stays reachable.
+        let savedSpan = null;
+        try { savedSpan = localStorage.getItem(this._storagePrefix + 'ScrubSpan'); } catch { /* localStorage unavailable */ }
+        const savedPreset = flowData.SCRUBBER_PRESETS.find(p => p.key === savedSpan);
+        this._scrubSpanKey = savedPreset ? savedPreset.key : '24h';
+        // A restored 'max' preset (ms: null) seeds at the 90-day retention cap;
+        // _loadHistoryRange narrows it to the actual data start once known.
+        this._scrubSpan = savedPreset ? (savedPreset.ms ?? 90 * 86400000) : 24 * 3600000;
+        this._dataStartMs = null; // earliest stored point; clamps Max and disables too-wide presets
 
         this._panels = {};        // DOM refs for overlay UI
         this._floatingLabels = new Map();  // nodeId -> { el, nameEl, rateEl }
@@ -448,6 +457,7 @@ export class LanFlowMap {
         if (this._pollTimer) clearInterval(this._pollTimer);
         if (this._historicPlaybackTimer) clearInterval(this._historicPlaybackTimer);
         if (this._snapshotTimer) clearInterval(this._snapshotTimer);
+        if (this._windowTickTimer) clearInterval(this._windowTickTimer);
         if (this._resizeObserver) this._resizeObserver.disconnect();
         if (this._onKeyDown) document.removeEventListener('keydown', this._onKeyDown);
         if (this._onKeyUp) document.removeEventListener('keyup', this._onKeyUp);
@@ -1829,8 +1839,17 @@ export class LanFlowMap {
         // Track playback as a continuous timestamp, not integer slider units.
         const TICK_MS = 1000;
         const DATA_REFRESH_TICKS = 1;
-        this._playbackTime = this._scrubberValueToTime(
+        // Seed from the exact parked instant when known - requantizing through
+        // the slider value can be minutes off on a wide window. But only when
+        // the thumb still agrees with it: a quick scrub right before resuming
+        // may not have flushed through the debounced change handler yet, and
+        // then the thumb position is the user's intent, not the stale instant.
+        const fromValue = this._scrubberValueToTime(
             Number(this._panels.scrubberRange?.value ?? 500));
+        const stepMs = this._scrubSpan / 10000;
+        this._playbackTime =
+            (this._historicAt && Math.abs(this._historicAt.getTime() - fromValue.getTime()) <= stepMs)
+                ? this._historicAt : fromValue;
         let tickCount = 0;
         this._historicPlaybackTimer = setInterval(() => {
             if (this._paused) return;
@@ -1840,28 +1859,28 @@ export class LanFlowMap {
             this._playbackTime = new Date(
                 this._playbackTime.getTime() + TICK_MS * this._playbackSpeed);
             // Derive slider position from the timestamp (inverse of _scrubberValueToTime)
-            const now = Date.now();
-            const span = now - this._scrubberOrigin;
-            const value = span > 0
-                ? Math.round((this._playbackTime.getTime() - this._scrubberOrigin) / span * 10000)
-                : 10000;
-            const clamped = Math.max(0, Math.min(10000, value));
+            const clamped = this._timeToScrubberValue(this._playbackTime.getTime());
             range.value = clamped;
+            // Live detection is time-based - on a wide window the last slider
+            // step spans many minutes and value-based detection would snap
+            // playback to Live long before it actually caught up to now.
+            const atLive = this._playbackTime.getTime() >= Date.now() - 2000;
             // Update the time label from the continuous timestamp, not the
             // integer slider position (which only moves every ~86s at 1x).
-            const rightLabel = (clamped >= 9998) ? 'Live' : _fmtDateTime(this._playbackTime);
+            const rightLabel = atLive ? 'Live' : _fmtDateTime(this._playbackTime);
             if (this._panels.scrubberRight) {
                 this._panels.scrubberRight.textContent = rightLabel;
             }
             flowData.publishScrubber(clamped, rightLabel, this._playbackSpeed);
             tickCount++;
             // Refresh map and stat cards periodically
-            if (tickCount % DATA_REFRESH_TICKS === 0 || clamped >= 9998) {
-                if (clamped >= 9998) {
+            if (tickCount % DATA_REFRESH_TICKS === 0 || atLive) {
+                if (atLive) {
                     if (this._historicPlaybackTimer) {
                         clearInterval(this._historicPlaybackTimer);
                         this._historicPlaybackTimer = null;
                     }
+                    range.value = 10000;
                     this._onScrubberChange(10000);
                 } else {
                     this._historicAt = this._playbackTime;
@@ -2051,9 +2070,7 @@ export class LanFlowMap {
         modeBadge.setAttribute('data-tooltip-hover-only', '');
         modeBadge.addEventListener('click', () => {
             if (this._mode === 'live') return;
-            const range = this._panels.scrubberRange;
-            if (range) range.value = 10000;
-            this._onScrubberChange(10000);
+            this._returnToLive();
         });
         status.appendChild(modeBadge);
         this._panels.status = status;
@@ -2073,17 +2090,46 @@ export class LanFlowMap {
                     <span class="lan-flow-map-speed-label" data-role="speed-label">1x</span>
                     <button class="lan-flow-map-speed-step" data-dir="1" type="button" aria-label="Faster">+</button>
                 </div>
+                <select class="lan-flow-map-scrubber-window" data-role="window" aria-label="Timeline range"></select>
                 <span data-role="left">-24h</span>
-                <input class="lan-flow-map-scrubber-range" type="range" min="0" max="10000" value="10000" />
+                <span class="lan-flow-map-scrubber-track">
+                    <input class="lan-flow-map-scrubber-range" type="range" min="0" max="10000" value="10000" />
+                    <span class="lan-flow-map-scrubber-ticks" data-role="ticks"></span>
+                </span>
                 <span data-role="right">Live</span>
             </div>
         `;
+        const windowSel = scrubber.querySelector('[data-role="window"]');
+        for (const p of flowData.SCRUBBER_PRESETS) {
+            const opt = document.createElement('option');
+            opt.value = p.key;
+            opt.textContent = p.label;
+            windowSel.appendChild(opt);
+        }
+        windowSel.value = this._scrubSpanKey;
+        windowSel.addEventListener('change', () => this._setScrubSpan(windowSel.value));
+        // Arrow left/right (with Shift for fast scrub) and Space float up to
+        // timeline scrubbing and play/pause; without this the focused dropdown
+        // consumes them natively and the global key handler ignores keys while
+        // a select has focus. Enter/Up/Down stay native so the dropdown remains
+        // keyboard-operable.
+        windowSel.addEventListener('keydown', (e) => {
+            if (e.key === 'Shift') { this._keys.shift = true; return; }
+            if (e.key === ' ') {
+                e.preventDefault();
+                this._togglePlayPause();
+                return;
+            }
+            if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+            e.preventDefault();
+            this._keys[e.key.toLowerCase()] = true;
+        });
         const range = scrubber.querySelector('.lan-flow-map-scrubber-range');
         this._scrubberInputDebounce = null;
         range.addEventListener('input', (e) => {
             const val = Number(e.target.value);
             this._onScrubberInput(val);
-            if (this._mode === 'live' && val < 9998) {
+            if (this._mode === 'live' && !this._isLiveValue(val)) {
                 this._mode = 'historic';
                 this._paused = true;
                 this._syncPlayPauseIcon();
@@ -2156,9 +2202,7 @@ export class LanFlowMap {
                     this._panels.scrubberRight?.textContent ?? 'Live',
                     this._playbackSpeed);
                 if (this._mode === 'live' && this._playbackSpeed < 1) {
-                    const now = Date.now();
-                    const span = now - this._scrubberOrigin;
-                    const nearNow = span > 0 ? Math.floor((now - 5000 - this._scrubberOrigin) / span * 10000) : 9997;
+                    const nearNow = this._timeToScrubberValue(Date.now() - 5000);
                     const clamped = Math.min(nearNow, 9997);
                     if (this._panels.scrubberRange) this._panels.scrubberRange.value = clamped;
                     this._onScrubberInput(clamped);
@@ -2183,8 +2227,17 @@ export class LanFlowMap {
         this._panels.scrubberLeft = scrubber.querySelector('[data-role="left"]');
         this._panels.scrubberRight = scrubber.querySelector('[data-role="right"]');
         this._panels.scrubberPlayPause = playPause;
+        this._panels.scrubberWindow = windowSel;
+        this._panels.scrubberTicks = scrubber.querySelector('[data-role="ticks"]');
         this._paused = false;
         this._syncSpeedLabel();
+        this._publishWindow();
+        this._loadHistoryRange();
+        // Trailing multi-day windows slide with now, so the midnight ticks drift;
+        // a slow refresh keeps them honest on long-open pages.
+        this._windowTickTimer = setInterval(() => {
+            if (this._scrubSpan >= 48 * 3600000) this._publishWindow();
+        }, 60000);
 
         this._buildSignalMapHint();
     }
@@ -2391,7 +2444,7 @@ export class LanFlowMap {
     _onScrubberInput(value) {
         // Visual-only update while dragging - cheap label refresh.
         const at = this._scrubberValueToTime(value);
-        const rightLabel = (value >= 9998) ? 'Live' : _fmtDateTime(at);
+        const rightLabel = this._isLiveValue(value) ? 'Live' : _fmtDateTime(at);
         if (this._panels.scrubberRight) {
             this._panels.scrubberRight.textContent = rightLabel;
         }
@@ -2399,7 +2452,7 @@ export class LanFlowMap {
     }
 
     async _onScrubberChange(value) {
-        if (value >= 9998) {
+        if (this._isLiveValue(value)) {
             // Snap back to live.
             this._stopHistoricPlayback();
             this._mode = 'live';
@@ -2426,6 +2479,9 @@ export class LanFlowMap {
         const at = this._scrubberValueToTime(value);
         this._mode = 'historic';
         this._historicAt = at;
+        // Redirect any running playback to the new position - otherwise its
+        // next tick snaps the thumb back to wherever it was playing.
+        if (this._historicPlaybackTimer) this._playbackTime = at;
         if (this._panels.modeBadge) {
             this._panels.modeBadge.textContent = 'Historic';
             this._panels.modeBadge.classList.add('is-historic');
@@ -2476,12 +2532,143 @@ export class LanFlowMap {
         if (label) label.textContent = `${this._playbackSpeed}x`;
     }
 
+    // Current timeline window bounds. The window slides with now so Live is
+    // always the right edge.
+    _scrubWindowBounds() {
+        const end = Date.now();
+        return { start: end - this._scrubSpan, end };
+    }
+
     _scrubberValueToTime(value) {
-        // Range 0..10000 maps from the anchored origin (mount - 24h) to now.
-        // The window grows as the page stays open so recent time is always reachable.
+        // Range 0..10000 maps linearly across the current window.
+        const { start, end } = this._scrubWindowBounds();
+        return new Date(start + (value / 10000) * (end - start));
+    }
+
+    _timeToScrubberValue(ms) {
+        const { start, end } = this._scrubWindowBounds();
+        const span = end - start;
+        if (span <= 0) return 10000;
+        return Math.max(0, Math.min(10000, Math.round((ms - start) / span * 10000)));
+    }
+
+    // The window trails now, so the right edge of the slider is Live. Near-edge
+    // values only count as Live when they are also near now in TIME - on a wide
+    // window the last couple of slider steps span many minutes, and a position
+    // parked "10 minutes ago" must not read (or snap) as Live.
+    _isLiveValue(value) {
+        if (value < 9998) return false;
+        return Date.now() - this._scrubberValueToTime(value).getTime() < 60000;
+    }
+
+    // Widest selectable span: capped by the primary bucket's 90-day retention and,
+    // once known, by the earliest stored data point.
+    _maxScrubSpan(now = Date.now()) {
+        const cap = 90 * 86400000;
+        if (this._dataStartMs == null) return cap;
+        return Math.max(3600000, Math.min(cap, now - this._dataStartMs));
+    }
+
+    // Switch the timeline window preset. The window always spans the latest N back
+    // from now. At Live nothing else moves. Parked or playing at a historic instant,
+    // the instant stays under the thumb when it still falls inside the new window;
+    // an instant older than the new window clamps to the left edge (the oldest
+    // reachable point) and seeks there.
+    _setScrubSpan(key) {
+        const preset = flowData.SCRUBBER_PRESETS.find(p => p.key === key);
+        if (!preset) return;
         const now = Date.now();
-        const ms = this._scrubberOrigin + (value / 10000) * (now - this._scrubberOrigin);
-        return new Date(ms);
+        const span = Math.min(preset.ms ?? this._maxScrubSpan(now), this._maxScrubSpan(now));
+        const range = this._panels.scrubberRange;
+        const value = Number(range?.value ?? 10000);
+        this._scrubSpanKey = key;
+        try { localStorage.setItem(this._storagePrefix + 'ScrubSpan', key); } catch { /* localStorage unavailable */ }
+        if (this._mode === 'live' || this._isLiveValue(value)) {
+            this._scrubSpan = span;
+        } else {
+            // Resolve the current instant against the OLD window before resizing.
+            const at = (this._historicAt ?? this._scrubberValueToTime(value)).getTime();
+            this._scrubSpan = span;
+            const clampedAt = Math.max(at, now - span);
+            const atDate = new Date(clampedAt);
+            this._historicAt = atDate;
+            if (range) range.value = this._timeToScrubberValue(clampedAt);
+            // Label from the true instant, not the requantized slider value -
+            // near the live edge of a wide window the rounded value would read
+            // back as Live (or minutes off) while the data stays historic.
+            const rightLabel = _fmtDateTime(atDate);
+            if (this._panels.scrubberRight) this._panels.scrubberRight.textContent = rightLabel;
+            flowData.publishScrubber(Number(range?.value ?? 0), rightLabel, this._playbackSpeed);
+            if (clampedAt !== at) {
+                // The old position fell off the narrower window: seek to the
+                // new left edge, keeping any running playback going from there.
+                if (this._historicPlaybackTimer) this._playbackTime = atDate;
+                this._notifyStatCards(atDate);
+                this._loadHistoric(atDate);
+            }
+        }
+        if (this._panels.scrubberWindow) this._panels.scrubberWindow.value = key;
+        this._publishWindow();
+    }
+
+    // One-time fetch of the earliest stored data point so Max spans to real data
+    // instead of a mostly-empty 90-day track on young installs.
+    async _loadHistoryRange() {
+        try {
+            const res = await fetch(`${this.apiBase}/history/range`, { credentials: 'same-origin' });
+            if (!res.ok) return;
+            const data = await res.json();
+            if (!data?.earliest) return;
+            this._dataStartMs = new Date(data.earliest).getTime();
+            const avail = this._maxScrubSpan();
+            const current = flowData.SCRUBBER_PRESETS.find(p => p.key === this._scrubSpanKey);
+            // A preset wider than the stored history is a mostly-empty track;
+            // fall back to Max, which spans exactly the data that exists.
+            if (current?.ms != null && current.ms > avail) this._setScrubSpan('max');
+            else if (this._scrubSpanKey === 'max') this._setScrubSpan('max'); // recompute span from data start
+            else this._publishWindow();
+        } catch { /* keep the 90d fallback */ }
+    }
+
+    _disabledPresetKeys() {
+        const avail = this._maxScrubSpan();
+        return flowData.SCRUBBER_PRESETS
+            .filter(p => p.ms != null && p.ms > avail)
+            .map(p => p.key);
+    }
+
+    _returnToLive() {
+        const range = this._panels.scrubberRange;
+        if (range) range.value = 10000;
+        this._onScrubberChange(10000);
+    }
+
+    _windowLeftLabel() {
+        const p = flowData.SCRUBBER_PRESETS.find(x => x.key === this._scrubSpanKey);
+        if (p?.ms != null) return `-${p.label}`;
+        return `-${_fmtSpan(this._scrubSpan)}`;
+    }
+
+    // Refresh the 3D scrubber's window-dependent UI (left label, preset select,
+    // disabled options, midnight ticks) and publish to the shared store so the
+    // 2D mirror renders identically.
+    _publishWindow() {
+        const sel = this._panels.scrubberWindow;
+        const disabled = this._disabledPresetKeys();
+        if (sel) {
+            sel.value = this._scrubSpanKey;
+            for (const opt of sel.options) opt.disabled = disabled.includes(opt.value);
+        }
+        if (this._panels.scrubberLeft) this._panels.scrubberLeft.textContent = this._windowLeftLabel();
+        const { start, end } = this._scrubWindowBounds();
+        flowData.renderScrubberTicks(this._panels.scrubberTicks, start, end);
+        flowData.publishScrubberWindow({
+            startMs: start,
+            endMs: end,
+            presetKey: this._scrubSpanKey,
+            leftLabel: this._windowLeftLabel(),
+            disabledKeys: disabled,
+        });
     }
 
     async _loadHistoric(at) {
@@ -3666,6 +3853,13 @@ function formatAge(ms) {
 }
 
 const _p = (n) => String(n).padStart(2, '0');
+// Compact duration for the trailing Max window's left label, e.g. -12d or -18h.
+function _fmtSpan(ms) {
+    const days = ms / 86400000;
+    if (days >= 2) return `${Math.round(days)}d`;
+    return `${Math.round(ms / 3600000)}h`;
+}
+
 function _fmtDateTime(d) {
     return `${_p(d.getMonth()+1)}/${_p(d.getDate())}/${String(d.getFullYear()).slice(2)} ${_p(d.getHours())}:${_p(d.getMinutes())}:${_p(d.getSeconds())}`;
 }

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -147,6 +147,17 @@ public class ChannelRecommendationService
     private const double MaxCrowdingFriction = 3.0;
 
     /// <summary>
+    /// Minimum whole-site improvement (as a percent of the current network score) required before ANY
+    /// 2.4 GHz channel move is recommended. 2.4 GHz is low-value and inherently congested - three
+    /// usable channels, legacy and IoT clients - so a marginal site gain just shuffles interference
+    /// between APs and isn't worth the churn. The other bands recommend on any net improvement (still
+    /// subject to the per-AP move gates); only 2.4 GHz must clear this higher whole-site bar. Applied
+    /// as a final guardrail after all optimization passes, and skipped when any AP sits on an invalid
+    /// channel (those always move to 1/6/11 regardless). Tunable.
+    /// </summary>
+    private const double MinBand24NetworkImprovementPercent = 8.0;
+
+    /// <summary>
     /// A channel is "measurably comfortable" when the AP's own radio reports time-averaged (1d/7d)
     /// EXTERNAL-network interference on it (airtime from other people's networks) below this percent.
     /// The external neighbor scan counts visible-but-idle BSSIDs and can inflate a fine channel into a
@@ -1067,12 +1078,23 @@ public class ChannelRecommendationService
         // (per-AP fallback, altruistic) judge benefit per AP, and a per-AP proxy can disagree with the
         // network objective; if the final plan isn't a net improvement over current, drop every move
         // and keep the current assignment. (Higher ScoreAssignment = worse.)
+        //
+        // 2.4 GHz additionally requires the whole-site gain to clear MinBand24NetworkImprovementPercent:
+        // the band is low-value and congested, so a marginal site improvement (e.g. a 3% drop that just
+        // moves one AP onto a neighbor's channel) isn't worth the churn. Skipped when an AP is on an
+        // invalid channel - those must always move to 1/6/11 no matter how small the site gain looks.
         var finalNetworkScore = ScoreAssignment(graph, finalAssignment, band);
-        if (finalNetworkScore > currentNetworkScore)
+        var networkImprovementPct = currentNetworkScore > 0
+            ? (currentNetworkScore - finalNetworkScore) / currentNetworkScore * 100
+            : 0;
+        var band24GainTooSmall = band == RadioBand.Band2_4GHz && !hasInvalidChannelAps &&
+                                 networkImprovementPct < MinBand24NetworkImprovementPercent;
+        if (finalNetworkScore > currentNetworkScore || band24GainTooSmall)
         {
             _logger.LogDebug(
-                "[ChannelRec] {Band}: final plan network {Final:F3} is worse than current {Current:F3} - reverting all moves",
-                band, finalNetworkScore, currentNetworkScore);
+                "[ChannelRec] {Band}: final plan network {Final:F3} vs current {Current:F3} " +
+                "({Pct:F1}% improvement) doesn't justify moves - reverting all",
+                band, finalNetworkScore, currentNetworkScore, networkImprovementPct);
             for (int i = 0; i < n; i++)
             {
                 var node = graph.Nodes[i];


### PR DESCRIPTION
This pull request consolidates several major feature enhancements, UI polish items, and critical performance optimizations across the Live View Timeline, Channel Optimizer, and ISP Health subsystems.

---

## What Changed & Key Enhancements

### 1. Live View Timeline Scrubber Expansion

The Live View timeline scrubber (shared across 3D map, 2D map, port stats playback, and WAN chart) has been unlocked from its 24-hour restriction to support historical data scaling up to the 90-day retention cap.

* **Window Preset Selector:** Added a new preset selector (`1h`, `6h`, `24h`, `3d`, `7d`, `30d`, `Max`).
* **Dynamic Max Clamp:** Introduced a new `GET /api/monitoring/lan-flow-map/history/range` endpoint that fetches and caches the earliest stored data point. Younger installs will cleanly clamp to their actual data duration rather than showing an empty 90-day track. Presets wider than available history are automatically disabled.
* **Time-Based Live Detection:** "Live" status is now evaluated by proximity to real-time rather than slider position. This prevents a thumb parked minutes back from snapping to Live, ensuring playback stops precisely at "now."
* **UI/UX Polish:** Added automatic midnight tick marks for windows $\ge$ 2 days, persisted the chosen preset per-browser, and implemented fully functional keyboard passthrough (Arrow keys scrub, Space toggles play/pause) when the preset dropdown is focused.
* **Resiliency:** Handles transient InfluxDB failures gracefully by falling back to the cached range or the 90-day hard cap.

### 2. Channel Optimizer & Scan UX Refactoring

Addressed user roadblocks and noise around the RF spectrum scanning flow, prioritizing permission clarity and smarter recommendation thresholds.

* **Surfaced Scan Permissions:** Instead of silently failing and spamming logs via a loop on read-only accounts, the app now catches the `403 (api.err.NoPermission)` error immediately. It skips the re-auth loop and prompts the user to upgrade to the `Network: Site Admin` role.
* **Streamlined Scan UI:** Compressed the wordy scan-gap banner into a concise headline + single line for a cleaner mobile layout, moving the verbose explanation to a tooltip. The scan button now features full-width targeting on narrow screens and displays real-time per-band progress (e.g., *"Scanning… 2/3 bands"*) to prevent the app from appearing frozen.
* **Higher Bar for 2.4 GHz Optimization:** To reduce low-value channel churn on the inherently congested 2.4 GHz band, recommendations now require a minimum whole-site score improvement of **8%** (up from 3%). Other bands remain unchanged. Invalid channels are exempted and will always trigger a fix.
* **Updated Settings Guidance:** Documentation instructions now correctly recommend `Network: Site Admin` for restricted setups, noting that `View Only` remains sufficient for everything except on-demand RF scans.

### 3. ISP Health Performance Optimizations

Optimized hot paths within the in-memory detector and scorer to resolve timeouts and high CPU utilization on lower-power NAS hardware. Computations are **bit-identical** to previous versions.

* **Congestion Localizer Fast-Path:** Replaced redundant, full-series re-scans and re-sorts with a precomputed index. It now leverages binary-searched in-window slices and exact value-exclusion for the baseline, resulting in a **~5x performance boost** on 30-day windows.
* **Single Sort Execution:** Modified detectors and the per-ASN scorer to sort the series once and derive required statistics (median, MAD, percentile, winsorized mean) from that single pass, eliminating 4-5 repetitive sorting routines.
* **Leaner Allocation:** Streamlined outage and partial-loss passes to accumulate per-bucket sums directly, eliminating per-bucket object allocation overhead.

### 4. Adaptive ISP Health Window & Timeout Mitigations

Introduced an automated fallback mechanism to guarantee that lower-grade hardware can still compute and render ISP Health data without hitting request timeouts.

* **Adaptive Fallback Ladder:** If a hardware configuration cannot complete a score computation within the designated time budget, the engine automatically steps down to a shorter window ($48\text{h} \to 24\text{h} \to 16\text{h}$). This fallback state is sticky per-process to prevent continuous re-probing.
* **Reduced-Window Indicator:** Displays a small badge next to the date-range selector when a fallback occurs. Hovering provides an explanatory tooltip, and clicking it manual-triggers a full-target re-probe.
* **InfluxDB Timeout Fix:** Raised the InfluxDB client's short default query timeout well past the compute budget, correcting a root-cause bug where heavy reads were being cut off mid-flight (#941).
* **UI Consistency:** The date-range selector's default button dynamically adapts to match the active, fallback window. Recomputes (via Refresh or configuration changes) now properly show a styled hero loading spinner instead of stale data.

---

## Bug Fixes

* **2D Map Mobile:** Fixed a layout bug where the mobile mode timeline scrubber failed to align, forcing it to correctly render beneath the 2D canvas area.
* **Congestion Timeline Phrasing:** The phrase *"and the hops beyond"* is now strictly gated on a successfully placed bottleneck hop. This prevents unlocalized events on targets without saved traces from misidentifying endpoints as intermediate hops.
* **Loss % Investigation Pooling:** The Latency & Packet Loss "Investigate" band now reflects the pooled mean loss across the exact set of targets used to grade Packet and Loaded Loss, eliminating visual drift against the computed score.

---

## Testing & Verification

* **Build status:** Full solution compiled with 0 warnings.
* **Regression suites:** All tests pass. Real-data replay and regression suites verify that the ISP Health performance refactor produces bit-identical scoring and event outputs.
* **Environment validation:** Successfully verified both locally on Mac and natively on low-spec NAS test environments (manually validating fallback steps, UX badges, and InfluxDB timeout fixes by forcing a constrained budget environment).