### PR TITLE
ISP Health: temperature-compensate optical RX and window-grade TX so transient DDM reads don't skew Physical Link

### DIFF
--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OpticalSampleStats.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OpticalSampleStats.cs
@@ -2,44 +2,111 @@ namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
 
 /// <summary>
 /// Robust receive-power statistics for optical (SFP/ONT) DDM samples, with DDM read-artifact
-/// rejection. Cheap SFP DDM sticks occasionally return a garbage read where several fields glitch
-/// together in a single sample - RX dives while the reported temperature jumps tens of degrees,
-/// which is physically impossible between polls. Temperature is NOT a health metric here; it is the
-/// tell that flags and discards the bad read so it can't drag the RX statistics the score rides on.
+/// rejection and temperature detrending.
+///
+/// Two things distort the RX series the Physical Link score rides on:
+/// <list type="bullet">
+/// <item>A HARD read artifact where temperature jumps tens of degrees in one sample (physically
+///   impossible between polls), dragging RX with it. These are rejected outright.</item>
+/// <item>A real, repeatable coupling between the DDM temperature reading and the reported RX power
+///   (measured at ~0.1 dB per C on a GPON ONT optic, holding on both cooling and warming). This is
+///   NOT an optical fault - it is the optic reading a bit lower when it runs cooler - so a temperature
+///   swing must not masquerade as a signal dip. We fit the coupling slope from a wide history and
+///   DETREND RX to a reference temperature before computing the stats, rather than discarding the
+///   samples. A dip steeper than the coupling explains (or one with no temperature move at all)
+///   survives detrending and is still seen as a real optical anomaly.</item>
+/// </list>
+/// Temperature is NOT a health metric here; it only drives artifact rejection and the detrend.
 /// </summary>
 public static class OpticalSampleStats
 {
     /// <summary>
     /// A sample whose temperature deviates from the window median by more than this (C) is treated
     /// as a DDM read artifact and dropped. Real thermal drift is gradual and small between polls;
-    /// the artifacts seen in the field jump 20-30+ C in one sample.
+    /// the hard artifacts seen in the field jump 20-30+ C in one sample, so their temperature can't be
+    /// trusted to detrend against either.
     /// </summary>
     public const double DdmTempArtifactDeltaC = 12.0;
 
-    /// <summary>Robust RX summary over a window after artifact rejection.</summary>
+    /// <summary>Coupling fit needs at least this many distinct 1 C temperature bins.</summary>
+    public const int CouplingMinBins = 3;
+
+    /// <summary>Coupling fit needs the binned temperatures to span at least this many C, or there is
+    /// too little leverage to trust a slope (a pinned-temperature window) and detrending is skipped.</summary>
+    public const double CouplingMinSpanC = 5.0;
+
+    /// <summary>Theil-Sen only pairs temperature bins at least this far apart, so DDM quantization on a
+    /// 1 C step can't dominate the pairwise slopes.</summary>
+    public const double CouplingMinPairSpanC = 3.0;
+
+    /// <summary>The fitted coupling slope is clamped to [0, this] dB/C - a physically-plausible band
+    /// that bounds the damage from a pathological fit while comfortably covering real optics (~0.1).</summary>
+    public const double CouplingMaxSlopeDbmPerC = 0.3;
+
+    /// <summary>Robust RX summary over a window after artifact rejection and temperature detrending.</summary>
     public sealed record RxStats(double? MedianDbm, double? WorstDbm, double? BaselineDbm, int CleanCount, int RejectedArtifacts);
 
     /// <summary>
-    /// Computes median / worst / baseline RX over the samples, dropping DDM artifacts first.
-    /// Worst is the coldest CLEAN sample; baseline is the median of the earliest fifth (for the
-    /// trend check). Samples missing RX are ignored; samples missing temperature can't be judged
-    /// and are kept.
+    /// Robust least-squares-style slope of RX (dBm) vs temperature (C): Theil-Sen (median pairwise
+    /// slope) over per-1 C temperature-bin medians, so DDM quantization and a stray garbage bin can't
+    /// dominate. Returns null when the samples lack the temperature spread to fit a trustworthy slope,
+    /// and clamps the result to a physically-plausible band. Feed this the WIDE history so a mostly
+    /// pinned optic still has the occasional excursion to fit against.
     /// </summary>
-    public static RxStats Compute(IReadOnlyList<(DateTime Time, double? Rx, double? Temp)> samples)
+    public static double? FitCouplingSlope(IReadOnlyList<(DateTime Time, double? Rx, double? Temp)> samples)
     {
-        var medianTemp = Median(samples.Where(s => s.Temp.HasValue).Select(s => s.Temp!.Value).ToList());
+        var byBin = new Dictionary<int, List<double>>();
+        foreach (var s in samples)
+            if (s.Rx is double rx && s.Temp is double t)
+            {
+                var bin = (int)Math.Round(t);
+                if (!byBin.TryGetValue(bin, out var list)) byBin[bin] = list = new List<double>();
+                list.Add(rx);
+            }
+
+        var bins = byBin.Select(b => (T: (double)b.Key, Rx: Median(b.Value)!.Value)).OrderBy(b => b.T).ToList();
+        if (bins.Count < CouplingMinBins || bins[^1].T - bins[0].T < CouplingMinSpanC) return null;
+
+        var slopes = new List<double>();
+        for (var i = 0; i < bins.Count; i++)
+            for (var j = i + 1; j < bins.Count; j++)
+                if (bins[j].T - bins[i].T >= CouplingMinPairSpanC)
+                    slopes.Add((bins[j].Rx - bins[i].Rx) / (bins[j].T - bins[i].T));
+
+        var slope = Median(slopes);
+        return slope is double k ? Math.Clamp(k, 0.0, CouplingMaxSlopeDbmPerC) : (double?)null;
+    }
+
+    /// <summary>
+    /// Computes median / worst / baseline RX over the samples, dropping hard DDM artifacts and then
+    /// detrending RX to the window's reference (median) temperature by the supplied coupling slope so
+    /// temperature-driven variation doesn't read as an optical dip. Worst is the coldest CLEAN,
+    /// detrended sample; baseline is the median of the earliest fifth (for the trend check). Samples
+    /// missing RX are ignored; samples missing temperature can't be judged or detrended and pass
+    /// through as-is. Pass a null slope (or fit failure) to skip detrending.
+    /// </summary>
+    public static RxStats Compute(IReadOnlyList<(DateTime Time, double? Rx, double? Temp)> samples, double? couplingSlopeDbmPerC = null)
+    {
+        var ordered = samples.OrderBy(s => s.Time).ToList();
+        var medianTemp = Median(ordered.Where(s => s.Temp.HasValue).Select(s => s.Temp!.Value).ToList());
 
         var rejected = 0;
-        var clean = new List<double>();
-        foreach (var s in samples.OrderBy(s => s.Time))
+        var clean = new List<double>();  // detrended, time-ordered
+        foreach (var s in ordered)
         {
             if (s.Rx is not double rx) continue;
-            if (medianTemp is double mt && s.Temp is double t && Math.Abs(t - mt) > DdmTempArtifactDeltaC)
+            if (medianTemp is double mt && s.Temp is double artT && Math.Abs(artT - mt) > DdmTempArtifactDeltaC)
             {
                 rejected++;
                 continue;
             }
-            clean.Add(rx);
+            // Detrend the reading to the reference temperature using the optic's coupling slope, so a
+            // cooler/warmer optic doesn't register as a weaker/stronger link. A reading with no
+            // temperature (or no fitted slope) can't be corrected and is used as-is.
+            var adjusted = (couplingSlopeDbmPerC is double k && medianTemp is double refT && s.Temp is double t)
+                ? rx - k * (t - refT)
+                : rx;
+            clean.Add(adjusted);
         }
 
         return new RxStats(Median(clean), clean.Count > 0 ? clean.Min() : null, Baseline(clean), clean.Count, rejected);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OpticalSampleStats.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OpticalSampleStats.cs
@@ -112,6 +112,29 @@ public static class OpticalSampleStats
         return new RxStats(Median(clean), clean.Count > 0 ? clean.Min() : null, Baseline(clean), clean.Count, rejected);
     }
 
+    /// <summary>
+    /// Robust transmit-power summary for the transmit-power-high rule: the window median (the typical
+    /// level, for display) and the highest CLEAN sample (the spike the rule grades), after dropping the
+    /// same hard temperature-jump reads that corrupt RX - a lone DDM glitch rides that bad read, so it
+    /// can't inflate the spike. TX is NOT temperature-detrended: it is a near-constant laser output set
+    /// by ranging, not a margin-graded receive level. Samples missing temperature can't be judged and
+    /// are kept; a null spike/median means no TX was reported.
+    /// </summary>
+    public static (double? MedianDbm, double? SpikeDbm) ComputeTx(IReadOnlyList<(DateTime Time, double? Tx, double? Temp)> samples)
+    {
+        var medianTemp = Median(samples.Where(s => s.Temp.HasValue).Select(s => s.Temp!.Value).ToList());
+
+        var clean = new List<double>();
+        foreach (var s in samples)
+        {
+            if (s.Tx is not double tx) continue;
+            if (medianTemp is double mt && s.Temp is double t && Math.Abs(t - mt) > DdmTempArtifactDeltaC) continue;
+            clean.Add(tx);
+        }
+
+        return (Median(clean), clean.Count > 0 ? clean.Max() : (double?)null);
+    }
+
     internal static double? Median(List<double> values)
     {
         if (values.Count == 0) return null;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkModels.cs
@@ -40,8 +40,14 @@ public class PhysicalLinkInput
     /// <summary>Earliest-window median receive power, the baseline the trend check compares against.</summary>
     public double? RxPowerBaselineDbm { get; init; }
 
-    /// <summary>Transmit optical power (dBm); penalized only above the category high threshold.</summary>
+    /// <summary>Median transmit optical power over the window (dBm) - the typical level, shown in the
+    /// factor value. Not the scoring input: the transmit-power-high rule grades the spike below.</summary>
     public double? TxPowerDbm { get; init; }
+
+    /// <summary>Highest CLEAN transmit optical power in the window (dBm), the spike the transmit-power-high
+    /// rule grades - the transmit counterpart of <see cref="RxPowerWorstDbm"/>. Artifact reads are
+    /// dropped first so a lone DDM glitch can't trip the rule; a real or sustained hot laser still does.</summary>
+    public double? TxPowerSpikeDbm { get; init; }
 
     /// <summary>O5 (Operation) state graded across the window from the link-status series: true when
     /// every reported state was Operation, false when the link broke out of O5 at least once (a hard

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkResolver.cs
@@ -184,17 +184,29 @@ public class PhysicalLinkResolver
         };
     }
 
+    /// <summary>How far back to pull SFP DDM history to fit the temperature-vs-RX coupling slope. A
+    /// mostly pinned optic needs a wide window to catch the occasional temperature excursion that
+    /// gives the fit leverage. The scoring window (<=48h) is a subset of this, so one raw query serves
+    /// both - the 7-day pull is ~150 KB and returns in tens of milliseconds.</summary>
+    private static readonly TimeSpan CouplingFitHistory = TimeSpan.FromDays(7);
+
     private async Task<PhysicalLinkInput?> AssembleSfpAsync(
         Cand c, PhysicalMedium medium, bool isXgsPon, DateTime windowStart, DateTime windowEnd, TimeSpan aggregate, CancellationToken ct)
     {
-        // SFP DDM only: TimeSpan.Zero => RAW (un-aggregated) so glitchy stick reads stay isolated,
-        // with temperature passed through so OpticalSampleStats can reject the artifacts (RX + temp
-        // glitch together). Mean aggregation would smear a glitch into a bucket that defeats the filter.
-        var dict = await _influx.QuerySfpByModulesAsync(new[] { (c.Mac!, c.Port!) }, windowStart, windowEnd, TimeSpan.Zero, ct);
-        var pts = dict.Values.FirstOrDefault() ?? new();
-        var stats = OpticalSampleStats.Compute(pts.Select(p => (p.Time, p.RxPowerDbm, p.TemperatureC)).ToList());
-        _logger.LogDebug("ISP Health physical: SFP {Key} - {N} samples, {Rej} DDM artifacts rejected, rxMed={Med} worst={Worst}",
-            c.Key, pts.Count, stats.RejectedArtifacts, stats.MedianDbm, stats.WorstDbm);
+        // SFP DDM only: TimeSpan.Zero => RAW (un-aggregated) so glitchy stick reads and temperature
+        // excursions stay isolated - mean aggregation would smear them into buckets that defeat both
+        // artifact rejection and the coupling fit. Pull the wider fit history in one query and score
+        // on the in-window subset.
+        var fitStart = windowEnd - CouplingFitHistory;
+        var dict = await _influx.QuerySfpByModulesAsync(new[] { (c.Mac!, c.Port!) }, fitStart, windowEnd, TimeSpan.Zero, ct);
+        var allPts = dict.Values.FirstOrDefault() ?? new();
+        var coupling = OpticalSampleStats.FitCouplingSlope(allPts.Select(p => (p.Time, p.RxPowerDbm, p.TemperatureC)).ToList());
+
+        var pts = allPts.Where(p => p.Time >= windowStart).ToList();
+        var stats = OpticalSampleStats.Compute(pts.Select(p => (p.Time, p.RxPowerDbm, p.TemperatureC)).ToList(), coupling);
+        _logger.LogDebug("ISP Health physical: SFP {Key} - {N} window samples ({All} over {Days}d fit), {Rej} DDM artifacts rejected, coupling={Slope} dB/C, rxMed={Med} worst={Worst}",
+            c.Key, pts.Count, allPts.Count, CouplingFitHistory.TotalDays, stats.RejectedArtifacts,
+            coupling?.ToString("0.000") ?? "n/a", stats.MedianDbm, stats.WorstDbm);
 
         return new PhysicalLinkInput
         {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkResolver.cs
@@ -204,9 +204,13 @@ public class PhysicalLinkResolver
 
         var pts = allPts.Where(p => p.Time >= windowStart).ToList();
         var stats = OpticalSampleStats.Compute(pts.Select(p => (p.Time, p.RxPowerDbm, p.TemperatureC)).ToList(), coupling);
-        _logger.LogDebug("ISP Health physical: SFP {Key} - {N} window samples ({All} over {Days}d fit), {Rej} DDM artifacts rejected, coupling={Slope} dB/C, rxMed={Med} worst={Worst}",
+        // TX over the whole window: median for the displayed level, highest clean sample for the
+        // transmit-power-high rule (the spike). A lone DDM glitch rides the temperature-jump read that
+        // ComputeTx already discards, so it skews neither.
+        var tx = OpticalSampleStats.ComputeTx(pts.Select(p => (p.Time, p.TxPowerDbm, p.TemperatureC)).ToList());
+        _logger.LogDebug("ISP Health physical: SFP {Key} - {N} window samples ({All} over {Days}d fit), {Rej} DDM artifacts rejected, coupling={Slope} dB/C, rxMed={Med} worst={Worst}, txMed={TxMed} spike={TxSpike}",
             c.Key, pts.Count, allPts.Count, CouplingFitHistory.TotalDays, stats.RejectedArtifacts,
-            coupling?.ToString("0.000") ?? "n/a", stats.MedianDbm, stats.WorstDbm);
+            coupling?.ToString("0.000") ?? "n/a", stats.MedianDbm, stats.WorstDbm, tx.MedianDbm, tx.SpikeDbm);
 
         return new PhysicalLinkInput
         {
@@ -215,10 +219,8 @@ public class PhysicalLinkResolver
             RxPowerMedianDbm = stats.MedianDbm,
             RxPowerWorstDbm = stats.WorstDbm,
             RxPowerBaselineDbm = stats.BaselineDbm,
-            // Window median TX, not the latest sample: DDM TX is near-constant on a PON ONU but throws
-            // the occasional lone glitch, and the median shrugs it off (a stray high read can't skew the
-            // display or falsely trip the transmit-power-high cap the way the latest reading could).
-            TxPowerDbm = Median(pts.Where(p => p.TxPowerDbm.HasValue).Select(p => p.TxPowerDbm!.Value).ToList()),
+            TxPowerDbm = tx.MedianDbm,
+            TxPowerSpikeDbm = tx.SpikeDbm,
             IsXgsPon = isXgsPon,
             WindowDays = (windowEnd - windowStart).TotalDays
         };
@@ -233,6 +235,7 @@ public class PhysicalLinkResolver
         var dict = await _influx.QueryOntAsync(windowStart, windowEnd, ontId.ToString(), TimeSpan.Zero, ct);
         var pts = (dict.Values.FirstOrDefault() ?? new()).OrderBy(p => p.Time).ToList();
         var stats = OpticalSampleStats.Compute(pts.Select(p => (p.Time, p.RxPowerDbm, (double?)null)).ToList());
+        var ontTx = OpticalSampleStats.ComputeTx(pts.Select(p => (p.Time, p.TxPowerDbm, (double?)null)).ToList());
         var live = _ontMonitor.GetCachedStats(ontId);
         var fecTotal = TotalIncrements(pts.Select(p => p.FecErrors).ToList());
         var bipTotal = TotalIncrements(pts.Select(p => p.BipErrors).ToList());
@@ -247,7 +250,12 @@ public class PhysicalLinkResolver
             RxPowerMedianDbm = stats.MedianDbm,
             RxPowerWorstDbm = stats.WorstDbm,
             RxPowerBaselineDbm = stats.BaselineDbm,
-            TxPowerDbm = live?.TxPowerDbm ?? pts.LastOrDefault(p => p.TxPowerDbm.HasValue)?.TxPowerDbm,
+            // TX over the whole window, not one poll: median for the displayed level, highest sample for
+            // the transmit-power-high rule. Fall back to the live poll only when the window has no TX
+            // history yet (a freshly-added ONT). No temperature is passed, so nothing is rejected -
+            // external ONT firmware doesn't have the DDM read-glitch problem.
+            TxPowerDbm = ontTx.MedianDbm ?? live?.TxPowerDbm,
+            TxPowerSpikeDbm = ontTx.SpikeDbm ?? live?.TxPowerDbm,
             PonOperational = operational,
             IsXgsPon = isXgsPon,
             FecErrorsTotal = fecTotal,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkResolver.cs
@@ -215,7 +215,10 @@ public class PhysicalLinkResolver
             RxPowerMedianDbm = stats.MedianDbm,
             RxPowerWorstDbm = stats.WorstDbm,
             RxPowerBaselineDbm = stats.BaselineDbm,
-            TxPowerDbm = pts.OrderBy(p => p.Time).LastOrDefault(p => p.TxPowerDbm.HasValue)?.TxPowerDbm,
+            // Window median TX, not the latest sample: DDM TX is near-constant on a PON ONU but throws
+            // the occasional lone glitch, and the median shrugs it off (a stray high read can't skew the
+            // display or falsely trip the transmit-power-high cap the way the latest reading could).
+            TxPowerDbm = Median(pts.Where(p => p.TxPowerDbm.HasValue).Select(p => p.TxPowerDbm!.Value).ToList()),
             IsXgsPon = isXgsPon,
             WindowDays = (windowEnd - windowStart).TotalDays
         };

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkScorer.cs
@@ -173,14 +173,19 @@ public static class PhysicalLinkScorer
         var txHigh = isPon
             ? (input.IsXgsPon ? PonThresholds.XgsPonTxPowerHighDbm : PonThresholds.PonTxPowerHighDbm)
             : PonThresholds.AeTxPowerHighDbm;
-        if (input.TxPowerDbm is double tx && tx > txHigh)
+        // Grade the TX SPIKE (highest clean sample), the transmit counterpart of the RX worst - a real
+        // or sustained hot laser trips it, a lone glitch (already artifact-rejected) can't. "Peaked at"
+        // when only the spike is over; "is" when the typical (median) level is over too, so the copy
+        // matches what the displayed median TX shows.
+        if (input.TxPowerSpikeDbm is double txSpike && txSpike > txHigh)
         {
             score = Math.Min(score, 75);
+            var sustained = input.TxPowerDbm is double txMed && txMed > txHigh;
             issues.Add(new IspHealthIssue
             {
                 Severity = IspIssueSeverity.Warning,
                 Title = $"{label}: transmit power high",
-                Description = $"{input.SourceName} transmit optical power is {tx.ToString("0.0", CultureInfo.InvariantCulture)} dBm, above the {txHigh:0} dBm threshold.",
+                Description = $"{input.SourceName} transmit optical power {(sustained ? "is" : "peaked at")} {txSpike.ToString("0.0", CultureInfo.InvariantCulture)} dBm, above the {txHigh:0} dBm threshold.",
                 Recommendation = "A consistently high TX can indicate the laser is compensating for path loss; inspect the optical path."
             });
         }
@@ -221,13 +226,18 @@ public static class PhysicalLinkScorer
             : rxText;
         // Note only TRANSIENT events the displayed RX/TX don't reveal: a receive-power dip (worst
         // sample >0.5 dB below the median, where the worst-cap engaged - artifacts are already
-        // discarded so this is genuine), a link interruption (not in O5), a developing drop (trend
-        // vs baseline), or an FEC/BIP error burst. Steady marginal/hot RX or TX show in the values.
+        // discarded so this is genuine), a transmit-power spike (highest sample over the threshold
+        // while the displayed median TX is not - a sustained hot TX shows in the value instead), a link
+        // interruption (not in O5), a developing drop (trend vs baseline), or an FEC/BIP error burst.
+        // Steady marginal/hot RX or TX show in the values.
+        var txSpikeTransient = input.TxPowerSpikeDbm is double ts && ts > txHigh
+                               && !(input.TxPowerDbm is double tm && tm > txHigh);
         var transientAnomaly =
             (input.RxPowerWorstDbm is double worstDip && rx.Value - worstDip > 0.5)
             || input.PonOperational == false
             || (isPon && input.RxPowerBaselineDbm is double baseDrop && rx.Value <= baseDrop - PonTrendDropDbm)
-            || errorsHigh;
+            || errorsHigh
+            || txSpikeTransient;
         var desc = $"{label} optical receive power scored on margin to the receiver floor"
                    + (detailBits.Count > 0 ? $" ({string.Join(", ", detailBits)})." : ".")
                    + (transientAnomaly ? AnomalyNote : "");

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OpticalSampleStatsTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OpticalSampleStatsTests.cs
@@ -105,6 +105,36 @@ public class OpticalSampleStatsTests
     }
 
     [Fact]
+    public void ComputeTx_spike_rejects_a_temperature_artifact_read()
+    {
+        // Steady 3.0 dBm TX plus one 3.9 dBm read on a garbage temperature (34 C below median): the
+        // spike must be the clean 3.0, not the glitch, so a lone bad read can't trip the high-TX rule.
+        var samples = new List<(DateTime, double?, double?)>();
+        for (var i = 0; i < 12; i++) samples.Add((T0.AddMinutes(i), (double?)3.0, (double?)44.0));
+        samples.Add((T0.AddMinutes(12), 3.9, 10.0));   // artifact: temp jump rides the same bad read
+
+        var (median, spike) = OpticalSampleStats.ComputeTx(samples);
+
+        median.Should().BeApproximately(3.0, 0.01);
+        spike.Should().BeApproximately(3.0, 0.01);      // 3.9 glitch discarded
+    }
+
+    [Fact]
+    public void ComputeTx_spike_keeps_a_real_high_tx_at_normal_temperature()
+    {
+        // A genuinely hot transmit sample at a normal temperature is not an artifact - it must survive
+        // as the spike so the transmit-power-high rule can grade it, while the median stays typical.
+        var samples = new List<(DateTime, double?, double?)>();
+        for (var i = 0; i < 12; i++) samples.Add((T0.AddMinutes(i), (double?)3.0, (double?)44.0));
+        samples.Add((T0.AddMinutes(12), 4.5, 44.0));   // real hot read, temperature normal
+
+        var (median, spike) = OpticalSampleStats.ComputeTx(samples);
+
+        median.Should().BeApproximately(3.0, 0.05);
+        spike.Should().BeApproximately(4.5, 0.01);
+    }
+
+    [Fact]
     public void Baseline_is_the_earliest_fifth_for_trend_detection()
     {
         // Earliest reads ~-19, drifting to ~-23: baseline should reflect the early ~-19, not the median.

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OpticalSampleStatsTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OpticalSampleStatsTests.cs
@@ -48,6 +48,63 @@ public class OpticalSampleStatsTests
     }
 
     [Fact]
+    public void FitCouplingSlope_recovers_a_known_slope()
+    {
+        // RX rides temperature at exactly 0.10 dB/C across a 20 C spread; the fit should recover it.
+        var samples = new List<(DateTime, double?, double?)>();
+        var t0 = T0;
+        foreach (var temp in new[] { 40.0, 44.0, 48.0, 52.0, 56.0, 60.0 })
+            for (var k = 0; k < 3; k++)
+            {
+                samples.Add((t0, (double?)(-22.0 + 0.10 * (temp - 50.0)), (double?)temp));
+                t0 = t0.AddMinutes(1);
+            }
+
+        OpticalSampleStats.FitCouplingSlope(samples).Should().BeApproximately(0.10, 0.005);
+    }
+
+    [Fact]
+    public void FitCouplingSlope_is_null_when_temperature_is_pinned()
+    {
+        // No temperature spread to fit against - the optic is thermally pinned, so no slope.
+        var samples = Enumerable.Range(0, 30)
+            .Select(i => (T0.AddMinutes(i), (double?)(-22.6 - (i % 4) * 0.05), (double?)44.0))
+            .ToList();
+
+        OpticalSampleStats.FitCouplingSlope(samples).Should().BeNull();
+    }
+
+    [Fact]
+    public void Detrend_normalizes_a_temperature_driven_dip()
+    {
+        // A single cooler poll reads RX low purely from the ~0.11 dB/C coupling (-23.4 dBm at 37 C vs
+        // -22.6 at 44 C). Detrended to the reference temperature it lands back at baseline, so it must
+        // NOT survive as the worst sample - a temperature swing is not an optical dip.
+        var samples = new List<(DateTime, double?, double?)>();
+        for (var i = 0; i < 11; i++) samples.Add((T0.AddMinutes(i), (double?)-22.6, (double?)44.0));
+        samples.Add((T0.AddMinutes(11), -23.4, 37.0));   // temp-driven dip on the coupling line
+
+        var stats = OpticalSampleStats.Compute(samples, couplingSlopeDbmPerC: 0.11);
+
+        stats.WorstDbm.Should().BeGreaterThan(-22.8);      // -23.4 normalized away, not the worst
+        stats.MedianDbm.Should().BeApproximately(-22.6, 0.05);
+    }
+
+    [Fact]
+    public void Detrend_keeps_a_real_optical_dip_at_flat_temperature()
+    {
+        // RX dives with temperature unchanged - detrending does nothing (temp == reference), so the
+        // real optical dip survives as the worst sample and drives scoring.
+        var samples = new List<(DateTime, double?, double?)>();
+        for (var i = 0; i < 11; i++) samples.Add((T0.AddMinutes(i), (double?)-22.6, (double?)44.0));
+        samples.Add((T0.AddMinutes(11), -25.0, 44.0));   // real dip, temperature flat
+
+        var stats = OpticalSampleStats.Compute(samples, couplingSlopeDbmPerC: 0.11);
+
+        stats.WorstDbm.Should().BeApproximately(-25.0, 0.01);
+    }
+
+    [Fact]
     public void Baseline_is_the_earliest_fifth_for_trend_detection()
     {
         // Earliest reads ~-19, drifting to ~-23: baseline should reflect the early ~-19, not the median.

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/PhysicalLinkScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/PhysicalLinkScorerTests.cs
@@ -15,7 +15,7 @@ public class PhysicalLinkScorerTests
 
     private static PhysicalLinkResult ScorePon(double rx, double? worst = null, double? baseline = null,
         bool? operational = null, double? tx = null, bool isXgsPon = false,
-        long? fecTotal = null, long? bipTotal = null, double windowDays = 2.0) =>
+        long? fecTotal = null, long? bipTotal = null, double windowDays = 2.0, double? txSpike = null) =>
         PhysicalLinkScorer.Score(new PhysicalLinkInput
         {
             Medium = PhysicalMedium.Pon,
@@ -25,6 +25,7 @@ public class PhysicalLinkScorerTests
             RxPowerBaselineDbm = baseline,
             PonOperational = operational,
             TxPowerDbm = tx,
+            TxPowerSpikeDbm = txSpike ?? tx,   // default: a steady TX (spike == median)
             IsXgsPon = isXgsPon,
             FecErrorsTotal = fecTotal,
             BipErrorsTotal = bipTotal,
@@ -176,9 +177,31 @@ public class PhysicalLinkScorerTests
     [Fact]
     public void Pon_high_tx_power_caps_and_warns()
     {
-        var result = ScorePon(-22.0, tx: 6.0);   // above PonTxPowerHighDbm (4.0)
+        var result = ScorePon(-22.0, tx: 6.0);   // sustained TX above PonTxPowerHighDbm (4.0)
         result.Factor.Score.Should().BeLessThanOrEqualTo(75);
         result.Issues.Should().Contain(i => i.Title.Contains("transmit power high"));
+        // Sustained (median over threshold): "is", and no transient anomaly note.
+        result.Factor.Description.Should().NotContain("anomaly");
+    }
+
+    [Fact]
+    public void Pon_transient_tx_spike_caps_warns_and_notes_anomaly()
+    {
+        // Displayed (median) TX is normal but the window's highest clean sample spiked over the
+        // threshold - the rule grades the spike, and the note explains the value doesn't show it.
+        var result = ScorePon(-22.0, tx: 3.0, txSpike: 6.0);
+        result.Factor.Score.Should().BeLessThanOrEqualTo(75);
+        result.Issues.Should().Contain(i => i.Title.Contains("transmit power high")
+                                            && i.Description.Contains("peaked at"));
+        result.Factor.Description.Should().Contain("anomaly");
+    }
+
+    [Fact]
+    public void Pon_normal_tx_spike_does_not_warn()
+    {
+        // A spike still under the threshold must not trip the rule.
+        var result = ScorePon(-22.0, tx: 3.0, txSpike: 3.8);
+        result.Issues.Should().NotContain(i => i.Title.Contains("transmit power high"));
     }
 
     [Fact]
@@ -187,7 +210,8 @@ public class PhysicalLinkScorerTests
         // +7 dBm ONU TX flags on GPON (>+4) but is normal on XGS-PON (<+8), which transmits hotter.
         PhysicalLinkResult Tx7(bool xgs) => PhysicalLinkScorer.Score(new PhysicalLinkInput
         {
-            Medium = PhysicalMedium.Pon, SourceName = "ONT", RxPowerMedianDbm = -20.0, TxPowerDbm = 7.0, IsXgsPon = xgs
+            Medium = PhysicalMedium.Pon, SourceName = "ONT", RxPowerMedianDbm = -20.0,
+            TxPowerDbm = 7.0, TxPowerSpikeDbm = 7.0, IsXgsPon = xgs
         }, null, Weight);
 
         Tx7(false).Issues.Should().Contain(i => i.Title.Contains("transmit power high"));


### PR DESCRIPTION
## What & why

The ISP Health **Physical Link** factor scored a GPON SFP ONT's optical power off metrics that a single bad or unrepresentative DDM read could skew. This makes both receive and transmit power robust to that, grading each over the whole window the way the rest of the factor already does.

### Receive power - temperature compensation

A GPON ONT optic's DDM receive-power reading carries a real, repeatable temperature bias: RX reads a bit lower when the optic runs cooler and higher when it runs warmer (measured at ~0.1 dB/°C, holding on both cooling and warming). This is a property of the reading, not the optical link, but a brief thermal swing could drop a single poll's RX far enough to append "A signal anomaly or interruption during this window was factored into the score" - a false alarm on a healthy link.

- Fit the per-optic temperature↔RX coupling slope from a 7-day history (robust Theil-Sen over 1 °C temperature-bin medians), so a mostly thermally-stable optic still has the occasional excursion to fit against.
- Detrend RX to the window's reference temperature before computing the median / worst / baseline the score rides on. Temperature-driven variation normalizes out instead of being discarded.
- A genuine optical dip - steeper than the coupling explains, or with no temperature movement at all - survives detrending and is still flagged.

### Transmit power - window spike instead of one sample

The transmit-power-high rule read a single TX sample (the latest), so a lone DDM glitch could trip it and a real spike between polls could be missed.

- The displayed TX is now the window median (the typical level).
- The rule grades the window's highest clean sample (the spike) - the transmit counterpart of the receive worst-case - with the same artifact rejection, so a lone glitch can't trip it while a sustained or genuinely hot laser still does.
- A spike the displayed median doesn't show also appends the transient anomaly note, consistent with how a receive-power dip is surfaced.

## Scope

- Only the ISP Health Physical Link factor is affected. SFP **temperature monitoring and alerting** is a separate path and is untouched - this transforms RX/TX only and never modifies the temperature series.
- The existing hard temperature-jump artifact rejection (±12 °C) is retained as a backstop, and now also cleans the TX spike (a lone glitch rides that same bad read).
- Both the SFP and external-ONT source paths get the window treatment.
- One raw DDM query is widened to 7 days to serve the coupling fit and the in-window stats (~150 KB, tens of milliseconds).

## Tests

Coverage for coupling-slope recovery and the pinned-temperature (no-fit) case, a temperature-driven dip normalizing away vs a real flat-temperature dip still surfacing, TX spike rejection of an artifact read vs keeping a real hot read, and the scorer grading a sustained high TX vs a transient spike (with the anomaly note). Full Web test project green (493).
