### PR TITLE
Wi-Fi Channel Optimizer: long-term outcome + neighbor memory and soak-period suppression

### DIFF
--- a/src/NetworkOptimizer.Storage/Interfaces/IChannelMemoryRepository.cs
+++ b/src/NetworkOptimizer.Storage/Interfaces/IChannelMemoryRepository.cs
@@ -1,0 +1,74 @@
+using NetworkOptimizer.Storage.Models;
+
+namespace NetworkOptimizer.Storage.Interfaces;
+
+/// <summary>
+/// One attributed metrics sample for an AP radio: the utilization / interference / TX retry
+/// the radio measured while the given (channel, width) was live.
+/// </summary>
+/// <param name="ApMac">AP MAC (lowercase, colon-separated)</param>
+/// <param name="Band">Radio band code - "ng" (2.4 GHz), "na" (5 GHz), "6e" (6 GHz)</param>
+/// <param name="Channel">Control channel the sample is attributed to</param>
+/// <param name="WidthMhz">Channel width in MHz; 0 when unknown</param>
+/// <param name="TimestampUtc">When the sample was measured (UTC)</param>
+/// <param name="Utilization">Channel utilization percent (0-100)</param>
+/// <param name="Interference">Interference percent (0-100)</param>
+/// <param name="TxRetryPct">TX retry percent (0-100)</param>
+public record ChannelOutcomeSample(
+    string ApMac,
+    string Band,
+    int Channel,
+    int WidthMhz,
+    DateTime TimestampUtc,
+    double Utilization,
+    double Interference,
+    double TxRetryPct);
+
+/// <summary>
+/// Persistence for the Channel Recommendation engine's outcome memory: long-term
+/// per-(AP, band, channel, width) measured outcomes and the channel-change log used for
+/// metric attribution and soak-period suppression.
+/// </summary>
+public interface IChannelMemoryRepository
+{
+    /// <summary>
+    /// Aggregate the given samples into their daily (AP, band, channel, width) buckets,
+    /// creating buckets as needed.
+    /// </summary>
+    Task AddOutcomeSamplesAsync(IReadOnlyCollection<ChannelOutcomeSample> samples, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Persist one collection cycle atomically: outcome samples, change records, and the new
+    /// watermark commit together or not at all - so a partial failure can never advance the
+    /// watermark past unsaved data, nor leave saved samples that a retry would double-count.
+    /// </summary>
+    Task CommitCollectionAsync(
+        IReadOnlyCollection<ChannelOutcomeSample> samples,
+        IReadOnlyCollection<ApChannelChange> changes,
+        DateTime watermarkUtc,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Get all outcome buckets on or after the given UTC date.</summary>
+    Task<List<ApChannelOutcome>> GetOutcomesSinceAsync(DateTime sinceUtc, CancellationToken cancellationToken = default);
+
+    /// <summary>Get all channel-change records at or after the given UTC time, ordered chronologically.</summary>
+    Task<List<ApChannelChange>> GetChangesSinceAsync(DateTime sinceUtc, CancellationToken cancellationToken = default);
+
+    /// <summary>Get the most recent change record per (AP, band) - the last known live config.</summary>
+    Task<List<ApChannelChange>> GetLatestConfigsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Insert channel-change records. The caller is responsible for de-duplication.</summary>
+    Task AddChangesAsync(IReadOnlyCollection<ApChannelChange> changes, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Delete outcome buckets and change records older than the retention window. The most
+    /// recent change record per (AP, band) is always kept - it carries the last known config.
+    /// </summary>
+    Task PruneAsync(int retentionDays, CancellationToken cancellationToken = default);
+
+    /// <summary>End of the window the collector last aggregated, or null if it has never run.</summary>
+    Task<DateTime?> GetCollectionWatermarkAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Persist the end of the window the collector just aggregated.</summary>
+    Task SetCollectionWatermarkAsync(DateTime watermarkUtc, CancellationToken cancellationToken = default);
+}

--- a/src/NetworkOptimizer.Storage/Interfaces/IChannelMemoryRepository.cs
+++ b/src/NetworkOptimizer.Storage/Interfaces/IChannelMemoryRepository.cs
@@ -25,6 +25,27 @@ public record ChannelOutcomeSample(
     double TxRetryPct);
 
 /// <summary>
+/// One observation of a neighbor network by an AP radio, for the long-term neighbor memory.
+/// </summary>
+/// <param name="ApMac">Observing AP MAC (lowercase, colon-separated)</param>
+/// <param name="Band">Radio band code - "ng" (2.4 GHz), "na" (5 GHz), "6e" (6 GHz)</param>
+/// <param name="Bssid">Neighbor BSSID (lowercase, colon-separated)</param>
+/// <param name="Channel">Control channel the neighbor was seen on</param>
+/// <param name="WidthMhz">Neighbor channel width in MHz; 0 when unknown</param>
+/// <param name="SignalDbm">Observed signal strength in dBm</param>
+/// <param name="SeenAtUtc">When the neighbor was seen (UTC)</param>
+/// <param name="Ssid">Neighbor SSID, if any</param>
+public record NeighborSightingSample(
+    string ApMac,
+    string Band,
+    string Bssid,
+    int Channel,
+    int WidthMhz,
+    int SignalDbm,
+    DateTime SeenAtUtc,
+    string? Ssid);
+
+/// <summary>
 /// Persistence for the Channel Recommendation engine's outcome memory: long-term
 /// per-(AP, band, channel, width) measured outcomes and the channel-change log used for
 /// metric attribution and soak-period suppression.
@@ -61,10 +82,21 @@ public interface IChannelMemoryRepository
     Task AddChangesAsync(IReadOnlyCollection<ApChannelChange> changes, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Delete outcome buckets and change records older than the retention window. The most
-    /// recent change record per (AP, band) is always kept - it carries the last known config.
+    /// Upsert neighbor sightings into their (AP, band, BSSID, channel) rows: LastSeen advances,
+    /// FirstSeen holds, signal keeps the strongest observed, width and SSID follow the newest
+    /// sighting that knows them.
     /// </summary>
-    Task PruneAsync(int retentionDays, CancellationToken cancellationToken = default);
+    Task UpsertNeighborSightingsAsync(IReadOnlyCollection<NeighborSightingSample> sightings, CancellationToken cancellationToken = default);
+
+    /// <summary>Get neighbor sightings last seen at or after the given UTC time.</summary>
+    Task<List<ApNeighborSighting>> GetNeighborSightingsSinceAsync(DateTime lastSeenSinceUtc, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Delete outcome buckets and change records older than the retention window, and neighbor
+    /// sightings unseen for longer than their (shorter) retention. The most recent change record
+    /// per (AP, band) is always kept - it carries the last known config.
+    /// </summary>
+    Task PruneAsync(int retentionDays, int neighborRetentionDays, CancellationToken cancellationToken = default);
 
     /// <summary>End of the window the collector last aggregated, or null if it has never run.</summary>
     Task<DateTime?> GetCollectionWatermarkAsync(CancellationToken cancellationToken = default);

--- a/src/NetworkOptimizer.Storage/Migrations/20260701222603_AddChannelOutcomeMemory.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260701222603_AddChannelOutcomeMemory.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701222603_AddChannelOutcomeMemory")]
+    partial class AddChannelOutcomeMemory
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260701222603_AddChannelOutcomeMemory.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260701222603_AddChannelOutcomeMemory.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChannelOutcomeMemory : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ApChannelChanges",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    ApMac = table.Column<string>(type: "TEXT", maxLength: 17, nullable: false),
+                    Band = table.Column<string>(type: "TEXT", maxLength: 10, nullable: false),
+                    PreviousChannel = table.Column<int>(type: "INTEGER", nullable: true),
+                    PreviousWidthMhz = table.Column<int>(type: "INTEGER", nullable: true),
+                    NewChannel = table.Column<int>(type: "INTEGER", nullable: false),
+                    NewWidthMhz = table.Column<int>(type: "INTEGER", nullable: true),
+                    ChangedAtUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    Source = table.Column<string>(type: "TEXT", maxLength: 20, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ApChannelChanges", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ApChannelOutcomes",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    ApMac = table.Column<string>(type: "TEXT", maxLength: 17, nullable: false),
+                    Band = table.Column<string>(type: "TEXT", maxLength: 10, nullable: false),
+                    Channel = table.Column<int>(type: "INTEGER", nullable: false),
+                    WidthMhz = table.Column<int>(type: "INTEGER", nullable: false),
+                    BucketDate = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UtilizationSum = table.Column<double>(type: "REAL", nullable: false),
+                    InterferenceSum = table.Column<double>(type: "REAL", nullable: false),
+                    TxRetrySum = table.Column<double>(type: "REAL", nullable: false),
+                    SampleCount = table.Column<int>(type: "INTEGER", nullable: false),
+                    LastSampleUtc = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ApChannelOutcomes", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ApChannelChanges_ApMac_Band_ChangedAtUtc",
+                table: "ApChannelChanges",
+                columns: new[] { "ApMac", "Band", "ChangedAtUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ApChannelChanges_ChangedAtUtc",
+                table: "ApChannelChanges",
+                column: "ChangedAtUtc");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ApChannelOutcomes_ApMac_Band_Channel_WidthMhz_BucketDate",
+                table: "ApChannelOutcomes",
+                columns: new[] { "ApMac", "Band", "Channel", "WidthMhz", "BucketDate" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ApChannelOutcomes_BucketDate",
+                table: "ApChannelOutcomes",
+                column: "BucketDate");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ApChannelChanges");
+
+            migrationBuilder.DropTable(
+                name: "ApChannelOutcomes");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Migrations/20260702153630_AddNeighborSightingMemory.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260702153630_AddNeighborSightingMemory.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260702153630_AddNeighborSightingMemory")]
+    partial class AddNeighborSightingMemory
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260702153630_AddNeighborSightingMemory.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260702153630_AddNeighborSightingMemory.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNeighborSightingMemory : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ApNeighborSightings",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    ApMac = table.Column<string>(type: "TEXT", maxLength: 17, nullable: false),
+                    Band = table.Column<string>(type: "TEXT", maxLength: 10, nullable: false),
+                    Bssid = table.Column<string>(type: "TEXT", maxLength: 17, nullable: false),
+                    Channel = table.Column<int>(type: "INTEGER", nullable: false),
+                    WidthMhz = table.Column<int>(type: "INTEGER", nullable: false),
+                    SignalDbm = table.Column<int>(type: "INTEGER", nullable: false),
+                    Ssid = table.Column<string>(type: "TEXT", maxLength: 64, nullable: true),
+                    FirstSeenUtc = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    LastSeenUtc = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ApNeighborSightings", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ApNeighborSightings_ApMac_Band_Bssid_Channel",
+                table: "ApNeighborSightings",
+                columns: new[] { "ApMac", "Band", "Bssid", "Channel" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ApNeighborSightings_LastSeenUtc",
+                table: "ApNeighborSightings",
+                column: "LastSeenUtc");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ApNeighborSightings");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Migrations/20260702170555_AddNeighborSightingCount.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260702170555_AddNeighborSightingCount.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260702170555_AddNeighborSightingCount")]
+    partial class AddNeighborSightingCount
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260702170555_AddNeighborSightingCount.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260702170555_AddNeighborSightingCount.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNeighborSightingCount : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Backfill pre-existing rows at full weight: they were captured before the count
+            // existed, under the prior accepted behavior, and off-channel rows would never be
+            // re-counted (a serving radio can't currently see them). New sightings start at 1
+            // in code and climb, so the persistence gate applies going forward.
+            migrationBuilder.AddColumn<int>(
+                name: "SightingCount",
+                table: "ApNeighborSightings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 3);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SightingCount",
+                table: "ApNeighborSightings");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/ApChannelChange.cs
+++ b/src/NetworkOptimizer.Storage/Models/ApChannelChange.cs
@@ -1,0 +1,61 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace NetworkOptimizer.Storage.Models;
+
+/// <summary>
+/// A persisted AP radio channel-change record. Sourced from the UniFi Console's system log
+/// (which only retains a few days) plus our own observed config diffs, so the Channel
+/// Recommendation engine can attribute long-term metrics to the config that was actually live
+/// and suppress hop-back recommendations while a fresh channel change is still soaking.
+/// </summary>
+public class ApChannelChange
+{
+    [Key]
+    public int Id { get; set; }
+
+    /// <summary>AP MAC address (lowercase, colon-separated)</summary>
+    [Required]
+    [MaxLength(17)]
+    public string ApMac { get; set; } = "";
+
+    /// <summary>Radio band code - "ng" (2.4 GHz), "na" (5 GHz), "6e" (6 GHz)</summary>
+    [Required]
+    [MaxLength(10)]
+    public string Band { get; set; } = "";
+
+    /// <summary>Channel before the change; null for the first observation of this radio</summary>
+    public int? PreviousChannel { get; set; }
+
+    /// <summary>Channel width (MHz) before the change; null when unknown</summary>
+    public int? PreviousWidthMhz { get; set; }
+
+    /// <summary>Channel after the change</summary>
+    public int NewChannel { get; set; }
+
+    /// <summary>Channel width (MHz) after the change; null when unknown</summary>
+    public int? NewWidthMhz { get; set; }
+
+    /// <summary>When the change occurred (UTC). For observed diffs this is detection time,
+    /// which upper-bounds the real change time.</summary>
+    public DateTime ChangedAtUtc { get; set; }
+
+    /// <summary>Where the record came from (see <see cref="ApChannelChangeSource"/>)</summary>
+    [Required]
+    [MaxLength(20)]
+    public string Source { get; set; } = "";
+}
+
+/// <summary>
+/// Well-known <see cref="ApChannelChange.Source"/> values.
+/// </summary>
+public static class ApChannelChangeSource
+{
+    /// <summary>Parsed from a UniFi system-log channel-change event (authoritative timestamp)</summary>
+    public const string UniFiEvent = "unifi-event";
+
+    /// <summary>Detected by comparing the live radio config against the last known config</summary>
+    public const string Observed = "observed";
+
+    /// <summary>First sighting of this radio - establishes the baseline config, no prior channel</summary>
+    public const string Initial = "initial";
+}

--- a/src/NetworkOptimizer.Storage/Models/ApChannelOutcome.cs
+++ b/src/NetworkOptimizer.Storage/Models/ApChannelOutcome.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace NetworkOptimizer.Storage.Models;
+
+/// <summary>
+/// Long-term measured outcome for one AP radio config: a daily aggregate of channel utilization,
+/// interference, and TX retry percentages attributed to the (channel, width) that was actually
+/// live when each sample was taken. This is the Channel Recommendation engine's persistent
+/// memory of how tried configs really performed - it outlives the UniFi Console's short
+/// metrics retention, so channels the AP sat on weeks or months ago keep their measured
+/// ground truth instead of falling back to inferred scores.
+/// </summary>
+public class ApChannelOutcome
+{
+    [Key]
+    public int Id { get; set; }
+
+    /// <summary>AP MAC address (lowercase, colon-separated)</summary>
+    [Required]
+    [MaxLength(17)]
+    public string ApMac { get; set; } = "";
+
+    /// <summary>Radio band code - "ng" (2.4 GHz), "na" (5 GHz), "6e" (6 GHz)</summary>
+    [Required]
+    [MaxLength(10)]
+    public string Band { get; set; } = "";
+
+    /// <summary>Control channel the samples are attributed to</summary>
+    public int Channel { get; set; }
+
+    /// <summary>Channel width in MHz at sample time; 0 when unknown (samples attributed to a
+    /// channel the radio had already left, where the width at the time can't be recovered)</summary>
+    public int WidthMhz { get; set; }
+
+    /// <summary>UTC date bucket (midnight) the samples fall into</summary>
+    public DateTime BucketDate { get; set; }
+
+    /// <summary>Sum of channel utilization percentages across samples (divide by SampleCount for avg)</summary>
+    public double UtilizationSum { get; set; }
+
+    /// <summary>Sum of interference percentages across samples</summary>
+    public double InterferenceSum { get; set; }
+
+    /// <summary>Sum of TX retry percentages across samples</summary>
+    public double TxRetrySum { get; set; }
+
+    /// <summary>Number of samples aggregated into this bucket</summary>
+    public int SampleCount { get; set; }
+
+    /// <summary>Timestamp of the most recent sample in this bucket (UTC)</summary>
+    public DateTime LastSampleUtc { get; set; }
+}

--- a/src/NetworkOptimizer.Storage/Models/ApNeighborSighting.cs
+++ b/src/NetworkOptimizer.Storage/Models/ApNeighborSighting.cs
@@ -41,6 +41,12 @@ public class ApNeighborSighting
     /// only reads clean when its remembered neighbor was consistently weak.</summary>
     public int SignalDbm { get; set; }
 
+    /// <summary>Number of collection cycles this neighbor has been seen on this channel.
+    /// Distinguishes a durable neighbor (seen cycle after cycle) from a one-off (a guest
+    /// hotspot, a device passing through) so a transient sighting can't accumulate into
+    /// phantom load. Scales the remembered sighting's confidence at recommendation time.</summary>
+    public int SightingCount { get; set; }
+
     /// <summary>Neighbor SSID at last sighting (may be empty for hidden networks)</summary>
     [MaxLength(64)]
     public string? Ssid { get; set; }

--- a/src/NetworkOptimizer.Storage/Models/ApNeighborSighting.cs
+++ b/src/NetworkOptimizer.Storage/Models/ApNeighborSighting.cs
@@ -1,0 +1,53 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace NetworkOptimizer.Storage.Models;
+
+/// <summary>
+/// Long-term record of a neighbor network one of our AP radios has seen: one row per
+/// (AP, band, BSSID, channel). A serving radio (no dedicated scan radio) mostly hears
+/// neighbors on its own channel, so once it moves it forgets what the old channel's
+/// neighborhood looked like - this table remembers, letting the Channel Recommendation
+/// engine keep decayed neighbor evidence for channels the radio isn't currently on.
+/// A neighbor that moves channels gets a new row; the old row stops updating and ages out.
+/// </summary>
+public class ApNeighborSighting
+{
+    [Key]
+    public int Id { get; set; }
+
+    /// <summary>Observing AP MAC address (lowercase, colon-separated)</summary>
+    [Required]
+    [MaxLength(17)]
+    public string ApMac { get; set; } = "";
+
+    /// <summary>Radio band code - "ng" (2.4 GHz), "na" (5 GHz), "6e" (6 GHz)</summary>
+    [Required]
+    [MaxLength(10)]
+    public string Band { get; set; } = "";
+
+    /// <summary>Neighbor BSSID (lowercase, colon-separated)</summary>
+    [Required]
+    [MaxLength(17)]
+    public string Bssid { get; set; } = "";
+
+    /// <summary>Control channel the neighbor was seen on</summary>
+    public int Channel { get; set; }
+
+    /// <summary>Neighbor channel width in MHz; 0 when unknown</summary>
+    public int WidthMhz { get; set; }
+
+    /// <summary>Strongest signal (dBm) observed for this sighting. Deliberately the max, not
+    /// the latest - matching the conservative bias of the live sighting pool, so a channel
+    /// only reads clean when its remembered neighbor was consistently weak.</summary>
+    public int SignalDbm { get; set; }
+
+    /// <summary>Neighbor SSID at last sighting (may be empty for hidden networks)</summary>
+    [MaxLength(64)]
+    public string? Ssid { get; set; }
+
+    /// <summary>First time this neighbor was seen on this channel by this radio (UTC)</summary>
+    public DateTime FirstSeenUtc { get; set; }
+
+    /// <summary>Most recent sighting (UTC) - drives age decay and pruning</summary>
+    public DateTime LastSeenUtc { get; set; }
+}

--- a/src/NetworkOptimizer.Storage/Models/NetworkOptimizerDbContext.cs
+++ b/src/NetworkOptimizer.Storage/Models/NetworkOptimizerDbContext.cs
@@ -63,6 +63,7 @@ public class NetworkOptimizerDbContext : DbContext
     public DbSet<CustomOidConfiguration> CustomOidConfigurations { get; set; }
     public DbSet<ApChannelOutcome> ApChannelOutcomes { get; set; }
     public DbSet<ApChannelChange> ApChannelChanges { get; set; }
+    public DbSet<ApNeighborSighting> ApNeighborSightings { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -481,6 +482,14 @@ public class NetworkOptimizerDbContext : DbContext
             entity.ToTable("ApChannelChanges");
             entity.HasIndex(e => new { e.ApMac, e.Band, e.ChangedAtUtc });
             entity.HasIndex(e => e.ChangedAtUtc);
+        });
+
+        // ApNeighborSighting configuration (long-term neighbor memory)
+        modelBuilder.Entity<ApNeighborSighting>(entity =>
+        {
+            entity.ToTable("ApNeighborSightings");
+            entity.HasIndex(e => new { e.ApMac, e.Band, e.Bssid, e.Channel }).IsUnique();
+            entity.HasIndex(e => e.LastSeenUtc);
         });
     }
 }

--- a/src/NetworkOptimizer.Storage/Models/NetworkOptimizerDbContext.cs
+++ b/src/NetworkOptimizer.Storage/Models/NetworkOptimizerDbContext.cs
@@ -61,6 +61,8 @@ public class NetworkOptimizerDbContext : DbContext
     public DbSet<OntConfiguration> OntConfigurations { get; set; }
     public DbSet<MonitoringInterface> MonitoringInterfaces { get; set; }
     public DbSet<CustomOidConfiguration> CustomOidConfigurations { get; set; }
+    public DbSet<ApChannelOutcome> ApChannelOutcomes { get; set; }
+    public DbSet<ApChannelChange> ApChannelChanges { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -463,6 +465,22 @@ public class NetworkOptimizerDbContext : DbContext
             entity.ToTable("CustomOidConfigurations");
             entity.HasIndex(e => e.DeviceMac);
             entity.HasIndex(e => new { e.DeviceMac, e.Oid }).IsUnique();
+        });
+
+        // ApChannelOutcome configuration (channel recommendation outcome memory)
+        modelBuilder.Entity<ApChannelOutcome>(entity =>
+        {
+            entity.ToTable("ApChannelOutcomes");
+            entity.HasIndex(e => new { e.ApMac, e.Band, e.Channel, e.WidthMhz, e.BucketDate }).IsUnique();
+            entity.HasIndex(e => e.BucketDate);
+        });
+
+        // ApChannelChange configuration (persisted channel-change log)
+        modelBuilder.Entity<ApChannelChange>(entity =>
+        {
+            entity.ToTable("ApChannelChanges");
+            entity.HasIndex(e => new { e.ApMac, e.Band, e.ChangedAtUtc });
+            entity.HasIndex(e => e.ChangedAtUtc);
         });
     }
 }

--- a/src/NetworkOptimizer.Storage/Models/SystemSetting.cs
+++ b/src/NetworkOptimizer.Storage/Models/SystemSetting.cs
@@ -68,4 +68,7 @@ public static class SystemSettingKeys
 
     // Map / Satellite settings
     public const string MapboxApiKey = "map.mapbox_token";
+
+    // Channel outcome memory: end of the window the collector last aggregated (UTC, round-trip format)
+    public const string ChannelMemoryCollectionWatermark = "wifi.channel_memory_watermark";
 }

--- a/src/NetworkOptimizer.Storage/Repositories/ChannelMemoryRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/ChannelMemoryRepository.cs
@@ -1,0 +1,232 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NetworkOptimizer.Storage.Interfaces;
+using NetworkOptimizer.Storage.Models;
+
+namespace NetworkOptimizer.Storage.Repositories;
+
+/// <summary>
+/// SQLite-backed store for the Channel Recommendation engine's outcome memory.
+/// Factory-based (not scoped-context) so both the singleton background collector and
+/// scoped web services can share one registration.
+/// </summary>
+public class ChannelMemoryRepository : IChannelMemoryRepository
+{
+    private readonly IDbContextFactory<NetworkOptimizerDbContext> _dbFactory;
+    private readonly ILogger<ChannelMemoryRepository> _logger;
+
+    public ChannelMemoryRepository(
+        IDbContextFactory<NetworkOptimizerDbContext> dbFactory,
+        ILogger<ChannelMemoryRepository> logger)
+    {
+        _dbFactory = dbFactory ?? throw new ArgumentNullException(nameof(dbFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task AddOutcomeSamplesAsync(
+        IReadOnlyCollection<ChannelOutcomeSample> samples, CancellationToken cancellationToken = default)
+    {
+        if (samples.Count == 0) return;
+
+        await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
+        await UpsertSamplesCoreAsync(db, samples, cancellationToken);
+        await db.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task CommitCollectionAsync(
+        IReadOnlyCollection<ChannelOutcomeSample> samples,
+        IReadOnlyCollection<ApChannelChange> changes,
+        DateTime watermarkUtc,
+        CancellationToken cancellationToken = default)
+    {
+        await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
+
+        await UpsertSamplesCoreAsync(db, samples, cancellationToken);
+        AddChangesCore(db, changes);
+        await SetWatermarkCoreAsync(db, watermarkUtc, cancellationToken);
+
+        // Single SaveChanges = single transaction: samples, changes, and watermark are atomic.
+        await db.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<List<ApChannelOutcome>> GetOutcomesSinceAsync(
+        DateTime sinceUtc, CancellationToken cancellationToken = default)
+    {
+        await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
+        return await db.ApChannelOutcomes
+            .AsNoTracking()
+            .Where(o => o.BucketDate >= sinceUtc.Date)
+            .ToListAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<List<ApChannelChange>> GetChangesSinceAsync(
+        DateTime sinceUtc, CancellationToken cancellationToken = default)
+    {
+        await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
+        return await db.ApChannelChanges
+            .AsNoTracking()
+            .Where(c => c.ChangedAtUtc >= sinceUtc)
+            .OrderBy(c => c.ChangedAtUtc)
+            .ThenBy(c => c.Id)
+            .ToListAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<List<ApChannelChange>> GetLatestConfigsAsync(CancellationToken cancellationToken = default)
+    {
+        await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
+        var latestIds = await QueryLatestChangeIdsAsync(db, cancellationToken);
+
+        return await db.ApChannelChanges
+            .AsNoTracking()
+            .Where(c => latestIds.Contains(c.Id))
+            .ToListAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task AddChangesAsync(
+        IReadOnlyCollection<ApChannelChange> changes, CancellationToken cancellationToken = default)
+    {
+        if (changes.Count == 0) return;
+
+        await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
+        AddChangesCore(db, changes);
+        await db.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task PruneAsync(int retentionDays, CancellationToken cancellationToken = default)
+    {
+        await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
+        var cutoff = DateTime.UtcNow.AddDays(-retentionDays);
+
+        var outcomesPruned = await db.ApChannelOutcomes
+            .Where(o => o.BucketDate < cutoff.Date)
+            .ExecuteDeleteAsync(cancellationToken);
+
+        // Keep the newest change per (ApMac, Band) regardless of age - it is the last known config.
+        var keepIds = await QueryLatestChangeIdsAsync(db, cancellationToken);
+
+        var changesPruned = await db.ApChannelChanges
+            .Where(c => c.ChangedAtUtc < cutoff && !keepIds.Contains(c.Id))
+            .ExecuteDeleteAsync(cancellationToken);
+
+        if (outcomesPruned > 0 || changesPruned > 0)
+            _logger.LogDebug("Channel memory prune: removed {Outcomes} outcome buckets, {Changes} change records",
+                outcomesPruned, changesPruned);
+    }
+
+    /// <inheritdoc />
+    public async Task<DateTime?> GetCollectionWatermarkAsync(CancellationToken cancellationToken = default)
+    {
+        await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
+        var setting = await db.SystemSettings
+            .AsNoTracking()
+            .FirstOrDefaultAsync(s => s.Key == SystemSettingKeys.ChannelMemoryCollectionWatermark, cancellationToken);
+
+        if (setting?.Value == null) return null;
+        return DateTime.TryParse(setting.Value, null, System.Globalization.DateTimeStyles.RoundtripKind, out var parsed)
+            ? parsed
+            : null;
+    }
+
+    /// <inheritdoc />
+    public async Task SetCollectionWatermarkAsync(DateTime watermarkUtc, CancellationToken cancellationToken = default)
+    {
+        await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
+        await SetWatermarkCoreAsync(db, watermarkUtc, cancellationToken);
+        await db.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Stage sample aggregation into daily buckets on the given context (no save).
+    /// </summary>
+    private static async Task UpsertSamplesCoreAsync(
+        NetworkOptimizerDbContext db, IReadOnlyCollection<ChannelOutcomeSample> samples, CancellationToken cancellationToken)
+    {
+        var grouped = samples.GroupBy(s => (
+            ApMac: s.ApMac.ToLowerInvariant(),
+            s.Band,
+            s.Channel,
+            s.WidthMhz,
+            BucketDate: s.TimestampUtc.Date));
+
+        foreach (var group in grouped)
+        {
+            var key = group.Key;
+            var bucket = await db.ApChannelOutcomes.FirstOrDefaultAsync(o =>
+                o.ApMac == key.ApMac && o.Band == key.Band && o.Channel == key.Channel &&
+                o.WidthMhz == key.WidthMhz && o.BucketDate == key.BucketDate, cancellationToken);
+
+            if (bucket == null)
+            {
+                bucket = new ApChannelOutcome
+                {
+                    ApMac = key.ApMac,
+                    Band = key.Band,
+                    Channel = key.Channel,
+                    WidthMhz = key.WidthMhz,
+                    BucketDate = key.BucketDate
+                };
+                db.ApChannelOutcomes.Add(bucket);
+            }
+
+            foreach (var sample in group)
+            {
+                bucket.UtilizationSum += sample.Utilization;
+                bucket.InterferenceSum += sample.Interference;
+                bucket.TxRetrySum += sample.TxRetryPct;
+                bucket.SampleCount++;
+                if (sample.TimestampUtc > bucket.LastSampleUtc)
+                    bucket.LastSampleUtc = sample.TimestampUtc;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Stage change records on the given context (no save).
+    /// </summary>
+    private static void AddChangesCore(NetworkOptimizerDbContext db, IReadOnlyCollection<ApChannelChange> changes)
+    {
+        foreach (var change in changes)
+        {
+            change.ApMac = change.ApMac.ToLowerInvariant();
+            db.ApChannelChanges.Add(change);
+        }
+    }
+
+    /// <summary>
+    /// Stage the watermark setting on the given context (no save).
+    /// </summary>
+    private static async Task SetWatermarkCoreAsync(
+        NetworkOptimizerDbContext db, DateTime watermarkUtc, CancellationToken cancellationToken)
+    {
+        var setting = await db.SystemSettings
+            .FirstOrDefaultAsync(s => s.Key == SystemSettingKeys.ChannelMemoryCollectionWatermark, cancellationToken);
+
+        if (setting == null)
+        {
+            setting = new SystemSetting { Key = SystemSettingKeys.ChannelMemoryCollectionWatermark };
+            db.SystemSettings.Add(setting);
+        }
+        setting.Value = watermarkUtc.ToString("O");
+        setting.UpdatedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Ids of the most recent change record per (ApMac, Band); Id breaks ties for
+    /// same-timestamp records.
+    /// </summary>
+    private static Task<List<int>> QueryLatestChangeIdsAsync(
+        NetworkOptimizerDbContext db, CancellationToken cancellationToken)
+    {
+        return db.ApChannelChanges
+            .GroupBy(c => new { c.ApMac, c.Band })
+            .Select(g => g.OrderByDescending(c => c.ChangedAtUtc).ThenByDescending(c => c.Id).First().Id)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/NetworkOptimizer.Storage/Repositories/ChannelMemoryRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/ChannelMemoryRepository.cs
@@ -136,12 +136,17 @@ public class ChannelMemoryRepository : IChannelMemoryRepository
                     WidthMhz = newest.WidthMhz,
                     SignalDbm = maxSignal,
                     Ssid = newest.Ssid,
+                    SightingCount = 1,
                     FirstSeenUtc = firstSeen,
                     LastSeenUtc = newest.SeenAtUtc
                 });
                 continue;
             }
 
+            // One increment per upsert call: the collector runs this once per cycle with the
+            // current neighbor picture, so the count measures cycles-seen (the persistence
+            // signal), not how many samples happened to be in the batch.
+            row.SightingCount++;
             row.SignalDbm = Math.Max(row.SignalDbm, maxSignal);
             if (newest.SeenAtUtc > row.LastSeenUtc)
             {

--- a/src/NetworkOptimizer.Storage/Repositories/ChannelMemoryRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/ChannelMemoryRepository.cs
@@ -99,7 +99,75 @@ public class ChannelMemoryRepository : IChannelMemoryRepository
     }
 
     /// <inheritdoc />
-    public async Task PruneAsync(int retentionDays, CancellationToken cancellationToken = default)
+    public async Task UpsertNeighborSightingsAsync(
+        IReadOnlyCollection<NeighborSightingSample> sightings, CancellationToken cancellationToken = default)
+    {
+        if (sightings.Count == 0) return;
+
+        await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
+
+        // Group first: the same (AP, band, BSSID, channel) can occur multiple times in one
+        // batch, and two Adds for the same key would violate the unique index.
+        var grouped = sightings.GroupBy(s => (
+            ApMac: s.ApMac.ToLowerInvariant(),
+            s.Band,
+            Bssid: s.Bssid.ToLowerInvariant(),
+            s.Channel));
+
+        foreach (var group in grouped)
+        {
+            var key = group.Key;
+            var newest = group.OrderByDescending(s => s.SeenAtUtc).First();
+            var maxSignal = group.Max(s => s.SignalDbm);
+            var firstSeen = group.Min(s => s.SeenAtUtc);
+
+            var row = await db.ApNeighborSightings.FirstOrDefaultAsync(n =>
+                n.ApMac == key.ApMac && n.Band == key.Band &&
+                n.Bssid == key.Bssid && n.Channel == key.Channel, cancellationToken);
+
+            if (row == null)
+            {
+                db.ApNeighborSightings.Add(new ApNeighborSighting
+                {
+                    ApMac = key.ApMac,
+                    Band = key.Band,
+                    Bssid = key.Bssid,
+                    Channel = key.Channel,
+                    WidthMhz = newest.WidthMhz,
+                    SignalDbm = maxSignal,
+                    Ssid = newest.Ssid,
+                    FirstSeenUtc = firstSeen,
+                    LastSeenUtc = newest.SeenAtUtc
+                });
+                continue;
+            }
+
+            row.SignalDbm = Math.Max(row.SignalDbm, maxSignal);
+            if (newest.SeenAtUtc > row.LastSeenUtc)
+            {
+                row.LastSeenUtc = newest.SeenAtUtc;
+                if (newest.WidthMhz > 0) row.WidthMhz = newest.WidthMhz;
+                if (!string.IsNullOrEmpty(newest.Ssid)) row.Ssid = newest.Ssid;
+            }
+            if (firstSeen < row.FirstSeenUtc) row.FirstSeenUtc = firstSeen;
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<List<ApNeighborSighting>> GetNeighborSightingsSinceAsync(
+        DateTime lastSeenSinceUtc, CancellationToken cancellationToken = default)
+    {
+        await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
+        return await db.ApNeighborSightings
+            .AsNoTracking()
+            .Where(n => n.LastSeenUtc >= lastSeenSinceUtc)
+            .ToListAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task PruneAsync(int retentionDays, int neighborRetentionDays, CancellationToken cancellationToken = default)
     {
         await using var db = await _dbFactory.CreateDbContextAsync(cancellationToken);
         var cutoff = DateTime.UtcNow.AddDays(-retentionDays);
@@ -115,9 +183,14 @@ public class ChannelMemoryRepository : IChannelMemoryRepository
             .Where(c => c.ChangedAtUtc < cutoff && !keepIds.Contains(c.Id))
             .ExecuteDeleteAsync(cancellationToken);
 
-        if (outcomesPruned > 0 || changesPruned > 0)
-            _logger.LogDebug("Channel memory prune: removed {Outcomes} outcome buckets, {Changes} change records",
-                outcomesPruned, changesPruned);
+        var neighborCutoff = DateTime.UtcNow.AddDays(-neighborRetentionDays);
+        var sightingsPruned = await db.ApNeighborSightings
+            .Where(n => n.LastSeenUtc < neighborCutoff)
+            .ExecuteDeleteAsync(cancellationToken);
+
+        if (outcomesPruned > 0 || changesPruned > 0 || sightingsPruned > 0)
+            _logger.LogDebug("Channel memory prune: removed {Outcomes} outcome buckets, {Changes} change records, {Sightings} neighbor sightings",
+                outcomesPruned, changesPruned, sightingsPruned);
     }
 
     /// <inheritdoc />

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -226,6 +226,10 @@
                                         {
                                             <span class="mesh-link-badge" data-tooltip="Mesh uplink - shares channel with parent">Mesh</span>
                                         }
+                                        @if (rec.IsSoaking)
+                                        {
+                                            <span class="soak-badge" data-tooltip="@GetSoakTooltip(rec)">Soaking</span>
+                                        }
                                         @if (rec.IsUnplaced)
                                         {
                                             <span class="tooltip-icon tooltip-icon-sm" data-tooltip="Not placed on floor plan - using estimated interference">?</span>
@@ -303,6 +307,14 @@
                             No neighbor networks detected on this band. Recommendations are based on internal AP interference only.
                         </div>
                     }
+                    @if (plan.Recommendations.Any(r => r.IsSoaking))
+                    {
+                        <div class="recommendation-notice">
+                            Some APs changed channels recently. The channels they just left are excluded from
+                            recommendations for about a week so the new channel can prove itself on measured
+                            data - this prevents ping-ponging between configs. Hover an AP's Soaking badge for details.
+                        </div>
+                    }
 
                     <!-- How This Works -->
                     <details class="recommendation-explainer">
@@ -320,6 +332,7 @@
                                 <li><strong>Measured airtime and noise floor</strong> - reads each channel's actual utilization and RF noise floor from the radios' spectrum scans, so congestion and non-Wi-Fi interference (radar, microwaves, a noisy neighbor's gear) count even when no Wi-Fi network is visible there.</li>
                                 <li><strong>Neighboring networks</strong> - folds in UniFi's RF scan of networks you don't control, triangulated across all your APs for a fuller picture than any single AP sees.</li>
                                 <li><strong>30 days of history</strong> - per-channel utilization, interference, and TX-retry trends, so the plan reflects how channels behave over time, not one noisy snapshot.</li>
+                                <li><strong>Long-term outcome memory</strong> - how channels you've actually run performed (utilization, interference, TX retries) is recorded and kept for months, so a previously-tried channel is judged on its measured record instead of estimates. After a channel change, the abandoned channel isn't re-suggested for a week while the new one soaks.</li>
                                 <li><strong>Honest about the unknown</strong> - channels with no scan data are penalized for that uncertainty, so it won't push you onto an unseen channel unless your known channels are clearly worse.</li>
                                 <li><strong>Whole-network and per-AP</strong> - minimizes total interference across the site, then checks each AP individually, only suggesting a move that genuinely helps and never wrecking one AP to slightly help another.</li>
                                 <li><strong>Mesh and DFS aware</strong> - mesh APs stay on their parent's channel; DFS channels are handled per your preference.</li>
@@ -1042,6 +1055,17 @@
     private static string FormatScore(double score) => score.ToString("F1");
 
     private static string FormatPercent(double pct) => pct.ToString("F0");
+
+    private static string GetSoakTooltip(ApChannelRecommendation rec)
+    {
+        var channels = string.Join(", ", rec.SoakSuppressedChannels);
+        var chLabel = rec.SoakSuppressedChannels.Count == 1 ? "Ch" : "Channels";
+        var until = rec.SoakEndsAt.HasValue
+            ? $" until {rec.SoakEndsAt.Value.ToLocalTime():MMM d}"
+            : "";
+        return $"Channel changed recently. {chLabel} {channels} won't be re-suggested{until} " +
+               "so the new channel can prove itself on measured data.";
+    }
 
     private static string GetScoreClass(double score) => score switch
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -311,8 +311,9 @@
                     {
                         <div class="recommendation-notice">
                             Some APs changed channels recently. The channels they just left are excluded from
-                            recommendations for about a week so the new channel can prove itself on measured
-                            data - this prevents ping-ponging between configs. Hover an AP's Soaking badge for details.
+                            recommendations for a @(ChannelMemoryHelper.SoakPeriod.TotalHours.ToString("0"))-hour
+                            soak so the new channel can prove itself on measured data - this prevents
+                            ping-ponging between configs. Hover an AP's Soaking badge for details.
                         </div>
                     }
 
@@ -330,9 +331,9 @@
                                 <li><strong>Transmit-power aware</strong> - each AP's real EIRP is applied directionally, so a low-power AP correctly counts as a gentler neighbor than a full-power one.</li>
                                 <li><strong>Real contention, not raw signal</strong> - interference is measured against the CCA threshold (where radios actually defer), so barely-audible signals aren't over-counted.</li>
                                 <li><strong>Measured airtime and noise floor</strong> - reads each channel's actual utilization and RF noise floor from the radios' spectrum scans, so congestion and non-Wi-Fi interference (radar, microwaves, a noisy neighbor's gear) count even when no Wi-Fi network is visible there.</li>
-                                <li><strong>Neighboring networks</strong> - folds in UniFi's RF scan of networks you don't control, triangulated across all your APs for a fuller picture than any single AP sees.</li>
+                                <li><strong>Neighboring networks</strong> - folds in UniFi's RF scan of networks you don't control, triangulated across all your APs for a fuller picture than any single AP sees. Neighbors are also remembered for weeks (counting for less as the sighting ages), so an AP without a dedicated scan radio keeps what it learned about a channel's neighborhood even after moving off that channel.</li>
                                 <li><strong>30 days of history</strong> - per-channel utilization, interference, and TX-retry trends, so the plan reflects how channels behave over time, not one noisy snapshot.</li>
-                                <li><strong>Long-term outcome memory</strong> - how channels you've actually run performed (utilization, interference, TX retries) is recorded and kept for months, so a previously-tried channel is judged on its measured record instead of estimates. After a channel change, the abandoned channel isn't re-suggested for a week while the new one soaks.</li>
+                                <li><strong>Long-term outcome memory</strong> - how channels you've actually run performed (utilization, interference, TX retries) is recorded and kept for months, so a previously-tried channel is judged on its measured record instead of estimates. After a channel change, the abandoned channel isn't re-suggested during a @(ChannelMemoryHelper.SoakPeriod.TotalHours.ToString("0"))-hour soak while the new one proves itself.</li>
                                 <li><strong>Honest about the unknown</strong> - channels with no scan data are penalized for that uncertainty, so it won't push you onto an unseen channel unless your known channels are clearly worse.</li>
                                 <li><strong>Whole-network and per-AP</strong> - minimizes total interference across the site, then checks each AP individually, only suggesting a move that genuinely helps and never wrecking one AP to slightly help another.</li>
                                 <li><strong>Mesh and DFS aware</strong> - mesh APs stay on their parent's channel; DFS channels are handled per your preference.</li>
@@ -1061,7 +1062,7 @@
         var channels = string.Join(", ", rec.SoakSuppressedChannels);
         var chLabel = rec.SoakSuppressedChannels.Count == 1 ? "Ch" : "Channels";
         var until = rec.SoakEndsAt.HasValue
-            ? $" until {rec.SoakEndsAt.Value.ToLocalTime():MMM d}"
+            ? $" until {rec.SoakEndsAt.Value.ToLocalTime():MMM d h:mm tt}"
             : "";
         return $"Channel changed recently. {chLabel} {channels} won't be re-suggested{until} " +
                "so the new channel can prove itself on measured data.";

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -456,6 +456,13 @@ builder.Services.AddSingleton<NetworkOptimizer.WiFi.Data.AntennaPatternLoader>()
 builder.Services.AddSingleton<NetworkOptimizer.WiFi.Services.PropagationService>();
 builder.Services.AddSingleton<NetworkOptimizer.WiFi.Services.ChannelRecommendationService>();
 
+// Channel recommendation outcome memory: persistent store (factory-based, shared by the
+// singleton collector and scoped services) + background collector that attributes UniFi
+// radio metrics to the channel config that was live and maintains the change log.
+builder.Services.AddSingleton<NetworkOptimizer.Storage.Interfaces.IChannelMemoryRepository, NetworkOptimizer.Storage.Repositories.ChannelMemoryRepository>();
+builder.Services.AddSingleton<ChannelMemoryCollectionService>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<ChannelMemoryCollectionService>());
+
 // Add ApexCharts for Wi-Fi Optimizer visualizations
 builder.Services.AddApexCharts();
 

--- a/src/NetworkOptimizer.Web/Services/ChannelMemoryCollectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/ChannelMemoryCollectionService.cs
@@ -1,0 +1,302 @@
+using NetworkOptimizer.Storage.Interfaces;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.WiFi;
+using NetworkOptimizer.WiFi.Helpers;
+using NetworkOptimizer.WiFi.Models;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Background collector for the Channel Recommendation outcome memory. Periodically pulls
+/// hourly per-AP radio metrics and channel-change events from the UniFi Console, attributes
+/// each sample to the (channel, width) that was actually live at the time, and persists
+/// daily aggregates - building a long-term measured record of how each tried config really
+/// performed that outlives the console's short metrics retention. Also maintains the
+/// persisted channel-change log the soak-period suppression reads.
+///
+/// Data-integrity rules: all fetches throw on failure (an empty result must mean "no data",
+/// never "fetch failed" - a silent failure would misattribute samples or skip a window), a
+/// failed cycle persists nothing and leaves the watermark untouched so the window is
+/// re-collected next time, and samples + change records + watermark commit in one
+/// transaction so a partial write can never double-count on retry.
+/// </summary>
+public class ChannelMemoryCollectionService : BackgroundService
+{
+    /// <summary>Delay before the first collection so startup isn't burdened.</summary>
+    private static readonly TimeSpan InitialDelay = TimeSpan.FromMinutes(3);
+
+    /// <summary>
+    /// Collection cadence. Hourly UniFi metrics are retained for days, so an occasional
+    /// sweep loses nothing; 6 hours keeps the change log fresh enough for soak tracking
+    /// while staying negligible load.
+    /// </summary>
+    private static readonly TimeSpan CollectionInterval = TimeSpan.FromHours(6);
+
+    /// <summary>UniFi hourly report retention we can safely reach back into.</summary>
+    private static readonly TimeSpan MaxLookback = TimeSpan.FromDays(7);
+
+    /// <summary>How long outcome buckets and superseded change records are kept.</summary>
+    private const int RetentionDays = 365;
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IChannelMemoryRepository _repository;
+    private readonly UniFiConnectionService _connectionService;
+    private readonly ILogger<ChannelMemoryCollectionService> _logger;
+
+    public ChannelMemoryCollectionService(
+        IServiceScopeFactory scopeFactory,
+        IChannelMemoryRepository repository,
+        UniFiConnectionService connectionService,
+        ILogger<ChannelMemoryCollectionService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _repository = repository;
+        _connectionService = connectionService;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await Task.Delay(InitialDelay, stoppingToken);
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await CollectAsync(stoppingToken);
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    // Nothing was persisted and the watermark did not move - the whole
+                    // window is re-collected on the next cycle.
+                    _logger.LogWarning(ex, "Channel outcome memory collection cycle failed; window will be retried");
+                }
+
+                await Task.Delay(CollectionInterval, stoppingToken);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown
+        }
+    }
+
+    private async Task CollectAsync(CancellationToken cancellationToken)
+    {
+        if (!_connectionService.IsConnected)
+        {
+            _logger.LogDebug("Channel memory collection skipped - not connected to UniFi Console");
+            return;
+        }
+
+        // UniFi stamps hourly report rows at interval START, so a row is only complete once
+        // the next hour begins. Collect strictly whole hours: the window ends at the last
+        // hour boundary, and the watermark records that boundary - rows in [start, collectEnd)
+        // are aggregated exactly once, and the in-progress hour is picked up complete next cycle.
+        var now = DateTimeOffset.UtcNow;
+        var collectEnd = new DateTimeOffset(
+            now.UtcDateTime.Date.AddHours(now.UtcDateTime.Hour), TimeSpan.Zero);
+        var earliest = collectEnd - MaxLookback;
+        var watermark = await _repository.GetCollectionWatermarkAsync(cancellationToken);
+        var start = watermark.HasValue && watermark.Value > earliest.UtcDateTime
+            ? new DateTimeOffset(DateTime.SpecifyKind(watermark.Value, DateTimeKind.Utc))
+            : earliest;
+
+        if (collectEnd <= start)
+            return;
+
+        using var scope = _scopeFactory.CreateScope();
+        var wifiService = scope.ServiceProvider.GetRequiredService<WiFiOptimizerService>();
+
+        var aps = await wifiService.GetAccessPointsAsync();
+        var onlineAps = aps.Where(ap => ap.IsOnline).ToList();
+        if (onlineAps.Count == 0)
+        {
+            _logger.LogDebug("Channel memory collection skipped - no online APs");
+            return;
+        }
+
+        // Events are fetched over the full lookback (not just the collection window) so the
+        // attribution timeline knows which channel was live at the window's start. Both
+        // fetches throw on failure: proceeding with silently-empty events would attribute
+        // every sample to the current channel, and silently-empty metrics would advance the
+        // watermark past a window UniFi still has.
+        var fetchTasks = onlineAps.Select(async ap =>
+        {
+            var metricsTask = wifiService.GetApMetricsAsync(
+                new[] { ap.Mac }, start, collectEnd, MetricGranularity.Hourly, throwOnFailure: true);
+            var eventsTask = wifiService.GetChannelChangeEventsAsync(earliest, now, ap.Mac, throwOnFailure: true);
+            await Task.WhenAll(metricsTask, eventsTask);
+            return (Ap: ap, Metrics: metricsTask.Result, Events: eventsTask.Result);
+        });
+        var fetched = await Task.WhenAll(fetchTasks);
+
+        var latestConfigs = await _repository.GetLatestConfigsAsync(cancellationToken);
+        var bands = new[] { RadioBand.Band2_4GHz, RadioBand.Band5GHz, RadioBand.Band6GHz };
+        var samples = new List<ChannelOutcomeSample>();
+        var newChanges = new List<ApChannelChange>();
+
+        foreach (var (ap, metrics, events) in fetched)
+        {
+            var macLower = ap.Mac.ToLowerInvariant();
+
+            foreach (var band in bands)
+            {
+                var radio = ap.Radios.FirstOrDefault(r => r.Band == band && r.Channel.HasValue);
+                if (radio == null) continue;
+
+                var bandCode = band.ToUniFiCode();
+                var currentChannel = radio.Channel!.Value;
+                var currentWidth = radio.ChannelWidth ?? 0;
+                var bandEvents = events
+                    .Where(e => e.Band == band)
+                    .OrderBy(e => e.Timestamp)
+                    .ToList();
+
+                var lastKnown = latestConfigs.FirstOrDefault(c =>
+                    c.ApMac.Equals(macLower, StringComparison.OrdinalIgnoreCase) && c.Band == bandCode);
+
+                // The radio's current width can only be claimed for samples provably inside
+                // the CURRENT config period: either the period started at a change event in
+                // the event window (width observed now presumed to hold since then), or the
+                // last persisted config already had this channel at this width (both
+                // endpoints agree, no events in between). Anything else records width 0
+                // (unknown) - the merge treats unknown as compatible, so the data still
+                // counts; it just doesn't assert a specific width it can't know.
+                var lastEvent = bandEvents.Count > 0 ? bandEvents[^1] : null;
+                DateTimeOffset? widthValidFrom = null;
+                if (lastEvent != null && lastEvent.NewChannel == currentChannel)
+                    widthValidFrom = lastEvent.Timestamp;
+                else if (lastEvent == null && lastKnown != null &&
+                         lastKnown.NewChannel == currentChannel &&
+                         lastKnown.NewWidthMhz.HasValue && lastKnown.NewWidthMhz.Value == currentWidth)
+                    widthValidFrom = DateTimeOffset.MinValue;
+
+                // Attribute each hourly sample to the channel live at its timestamp.
+                // [start, collectEnd) matches the watermark semantics - no loss, no double count.
+                foreach (var metric in metrics)
+                {
+                    if (metric.Timestamp < start || metric.Timestamp >= collectEnd) continue;
+                    if (!metric.ByBand.TryGetValue(band, out var bandData) ||
+                        !bandData.ChannelUtilization.HasValue)
+                        continue;
+
+                    var channel = ChannelMemoryHelper.GetChannelAtTime(metric.Timestamp, bandEvents, currentChannel);
+                    // An event parsed without PREVIOUS_CHANNEL yields channel 0 for samples
+                    // predating it - not a real channel, don't create buckets for it.
+                    if (channel <= 0) continue;
+
+                    var width = channel == currentChannel &&
+                                widthValidFrom.HasValue && metric.Timestamp >= widthValidFrom.Value
+                        ? currentWidth
+                        : 0;
+                    samples.Add(new ChannelOutcomeSample(
+                        macLower,
+                        bandCode,
+                        channel,
+                        width,
+                        metric.Timestamp.UtcDateTime,
+                        bandData.ChannelUtilization ?? 0,
+                        bandData.Interference ?? 0,
+                        bandData.TxRetryPct ?? 0));
+                }
+
+                // Maintain the persisted change log. The last persisted record per radio is
+                // the de-duplication high-water: only events newer than it are appended.
+                if (lastKnown == null)
+                {
+                    newChanges.Add(new ApChannelChange
+                    {
+                        ApMac = macLower,
+                        Band = bandCode,
+                        NewChannel = currentChannel,
+                        NewWidthMhz = currentWidth > 0 ? currentWidth : null,
+                        ChangedAtUtc = now.UtcDateTime,
+                        Source = ApChannelChangeSource.Initial
+                    });
+                    continue;
+                }
+
+                var lastRecordedChannel = lastKnown.NewChannel;
+                var lastRecordedWidth = lastKnown.NewWidthMhz;
+                var lastRecordedAt = DateTime.SpecifyKind(lastKnown.ChangedAtUtc, DateTimeKind.Utc);
+                foreach (var evt in bandEvents.Where(e => e.Timestamp.UtcDateTime > lastRecordedAt))
+                {
+                    var isCurrentConfig = evt.NewChannel == currentChannel && evt == lastEvent;
+                    newChanges.Add(new ApChannelChange
+                    {
+                        ApMac = macLower,
+                        Band = bandCode,
+                        PreviousChannel = evt.PreviousChannel > 0 ? evt.PreviousChannel : null,
+                        NewChannel = evt.NewChannel,
+                        NewWidthMhz = isCurrentConfig && currentWidth > 0 ? currentWidth : null,
+                        ChangedAtUtc = evt.Timestamp.UtcDateTime,
+                        Source = ApChannelChangeSource.UniFiEvent
+                    });
+                    lastRecordedChannel = evt.NewChannel;
+                    lastRecordedWidth = isCurrentConfig && currentWidth > 0 ? currentWidth : null;
+                }
+
+                if (lastRecordedChannel != currentChannel)
+                {
+                    // The live config disagrees with everything recorded - the UniFi log
+                    // missed the change (or it aged out). The real change time is unknown:
+                    // if the gap reaches past the event-log window the change almost
+                    // certainly predates it (any change inside the window would be in the
+                    // events), so stamp it at the last recorded time rather than fabricate a
+                    // fresh soak for a config that may be fully soaked already. Inside the
+                    // window, detection latency is bounded by one collection cycle.
+                    var observedAt = lastRecordedAt <= earliest.UtcDateTime
+                        ? lastRecordedAt
+                        : Max(lastRecordedAt, (now - CollectionInterval).UtcDateTime);
+                    newChanges.Add(new ApChannelChange
+                    {
+                        ApMac = macLower,
+                        Band = bandCode,
+                        PreviousChannel = lastRecordedChannel,
+                        PreviousWidthMhz = lastRecordedChannel == lastKnown.NewChannel ? lastKnown.NewWidthMhz : null,
+                        NewChannel = currentChannel,
+                        NewWidthMhz = currentWidth > 0 ? currentWidth : null,
+                        ChangedAtUtc = observedAt,
+                        Source = ApChannelChangeSource.Observed
+                    });
+                }
+                else if (currentWidth > 0 && (lastRecordedWidth ?? 0) != currentWidth)
+                {
+                    // Width-only change (same channel) or a width first becoming known. UniFi
+                    // emits no event for these, so record it ourselves - it resets the
+                    // width-confidence boundary above so future cycles can claim the current
+                    // width (and stop claiming an old one). Harmless for soak: the soak
+                    // builder ignores records whose previous channel equals the current one.
+                    newChanges.Add(new ApChannelChange
+                    {
+                        ApMac = macLower,
+                        Band = bandCode,
+                        PreviousChannel = currentChannel,
+                        PreviousWidthMhz = lastRecordedWidth,
+                        NewChannel = currentChannel,
+                        NewWidthMhz = currentWidth,
+                        ChangedAtUtc = Max(lastRecordedAt, (now - CollectionInterval).UtcDateTime),
+                        Source = ApChannelChangeSource.Observed
+                    });
+                }
+            }
+        }
+
+        await _repository.CommitCollectionAsync(samples, newChanges, collectEnd.UtcDateTime, cancellationToken);
+        await _repository.PruneAsync(RetentionDays, cancellationToken);
+
+        _logger.LogDebug(
+            "Channel memory collection: {Samples} samples across {Aps} APs, {Changes} new change records " +
+            "(window {Start:MM/dd HH:mm} - {End:MM/dd HH:mm} UTC)",
+            samples.Count, onlineAps.Count, newChanges.Count, start, collectEnd);
+    }
+
+    private static DateTime Max(DateTime a, DateTime b) => a > b ? a : b;
+}

--- a/src/NetworkOptimizer.Web/Services/ChannelMemoryCollectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/ChannelMemoryCollectionService.cs
@@ -95,21 +95,7 @@ public class ChannelMemoryCollectionService : BackgroundService
             return;
         }
 
-        // UniFi stamps hourly report rows at interval START, so a row is only complete once
-        // the next hour begins. Collect strictly whole hours: the window ends at the last
-        // hour boundary, and the watermark records that boundary - rows in [start, collectEnd)
-        // are aggregated exactly once, and the in-progress hour is picked up complete next cycle.
         var now = DateTimeOffset.UtcNow;
-        var collectEnd = new DateTimeOffset(
-            now.UtcDateTime.Date.AddHours(now.UtcDateTime.Hour), TimeSpan.Zero);
-        var earliest = collectEnd - MaxLookback;
-        var watermark = await _repository.GetCollectionWatermarkAsync(cancellationToken);
-        var start = watermark.HasValue && watermark.Value > earliest.UtcDateTime
-            ? new DateTimeOffset(DateTime.SpecifyKind(watermark.Value, DateTimeKind.Utc))
-            : earliest;
-
-        if (collectEnd <= start)
-            return;
 
         using var scope = _scopeFactory.CreateScope();
         var wifiService = scope.ServiceProvider.GetRequiredService<WiFiOptimizerService>();
@@ -122,9 +108,10 @@ public class ChannelMemoryCollectionService : BackgroundService
             return;
         }
 
-        // Neighbor memory first, in its own try/catch: sightings are upserts keyed by
-        // last-seen (no watermark involved), so a metrics failure below must not starve
-        // them and a sighting failure must not abort the metrics cycle.
+        // Neighbor memory first, in its own try/catch and BEFORE the watermark early-return:
+        // sightings are upserts keyed by last-seen (no watermark involved), so they must run
+        // every cycle even when no new whole hour of metrics exists yet, a metrics failure
+        // below must not starve them, and a sighting failure must not abort the metrics cycle.
         try
         {
             await PersistNeighborSightingsAsync(wifiService, now, cancellationToken);
@@ -137,6 +124,21 @@ public class ChannelMemoryCollectionService : BackgroundService
         {
             _logger.LogDebug(ex, "Neighbor sighting persistence failed; will retry next cycle");
         }
+
+        // UniFi stamps hourly report rows at interval START, so a row is only complete once
+        // the next hour begins. Collect strictly whole hours: the window ends at the last
+        // hour boundary, and the watermark records that boundary - rows in [start, collectEnd)
+        // are aggregated exactly once, and the in-progress hour is picked up complete next cycle.
+        var collectEnd = new DateTimeOffset(
+            now.UtcDateTime.Date.AddHours(now.UtcDateTime.Hour), TimeSpan.Zero);
+        var earliest = collectEnd - MaxLookback;
+        var watermark = await _repository.GetCollectionWatermarkAsync(cancellationToken);
+        var start = watermark.HasValue && watermark.Value > earliest.UtcDateTime
+            ? new DateTimeOffset(DateTime.SpecifyKind(watermark.Value, DateTimeKind.Utc))
+            : earliest;
+
+        if (collectEnd <= start)
+            return;
 
         // Events are fetched over the full lookback (not just the collection window) so the
         // attribution timeline knows which channel was live at the window's start. Both

--- a/src/NetworkOptimizer.Web/Services/ChannelMemoryCollectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/ChannelMemoryCollectionService.cs
@@ -122,6 +122,22 @@ public class ChannelMemoryCollectionService : BackgroundService
             return;
         }
 
+        // Neighbor memory first, in its own try/catch: sightings are upserts keyed by
+        // last-seen (no watermark involved), so a metrics failure below must not starve
+        // them and a sighting failure must not abort the metrics cycle.
+        try
+        {
+            await PersistNeighborSightingsAsync(wifiService, now, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Neighbor sighting persistence failed; will retry next cycle");
+        }
+
         // Events are fetched over the full lookback (not just the collection window) so the
         // attribution timeline knows which channel was live at the window's start. Both
         // fetches throw on failure: proceeding with silently-empty events would attribute
@@ -290,12 +306,53 @@ public class ChannelMemoryCollectionService : BackgroundService
         }
 
         await _repository.CommitCollectionAsync(samples, newChanges, collectEnd.UtcDateTime, cancellationToken);
-        await _repository.PruneAsync(RetentionDays, cancellationToken);
+        await _repository.PruneAsync(RetentionDays, ChannelMemoryHelper.NeighborRetentionDays, cancellationToken);
 
         _logger.LogDebug(
             "Channel memory collection: {Samples} samples across {Aps} APs, {Changes} new change records " +
             "(window {Start:MM/dd HH:mm} - {End:MM/dd HH:mm} UTC)",
             samples.Count, onlineAps.Count, newChanges.Count, start, collectEnd);
+    }
+
+    /// <summary>
+    /// Persist the current neighbor picture into the long-term neighbor memory. UniFi's
+    /// rogue/neighbor table only carries recently-seen networks, so each cycle upserts what
+    /// the console still remembers; rows for neighbors that stay invisible stop updating and
+    /// age out. Own-network BSSIDs are modeled internally by the engine and are not stored.
+    /// </summary>
+    private async Task PersistNeighborSightingsAsync(
+        WiFiOptimizerService wifiService, DateTimeOffset now, CancellationToken cancellationToken)
+    {
+        var scans = await wifiService.GetChannelScanResultsAsync(startTime: now - MaxLookback);
+        if (scans.Count == 0) return;
+
+        var samples = new List<NeighborSightingSample>();
+        foreach (var scan in scans)
+        {
+            var bandCode = scan.Band.ToUniFiCode();
+            if (string.IsNullOrEmpty(bandCode)) continue;
+
+            foreach (var nb in scan.Neighbors)
+            {
+                if (string.IsNullOrEmpty(nb.Bssid) || nb.IsOwnNetwork) continue;
+                if (nb.Channel <= 0 || !nb.Signal.HasValue) continue;
+                if (nb.Signal.Value < ChannelMemoryHelper.MinPersistedNeighborSignalDbm) continue;
+
+                samples.Add(new NeighborSightingSample(
+                    scan.ApMac.ToLowerInvariant(),
+                    bandCode,
+                    nb.Bssid.ToLowerInvariant(),
+                    nb.Channel,
+                    nb.Width ?? 0,
+                    nb.Signal.Value,
+                    (nb.LastSeen ?? now).UtcDateTime,
+                    nb.Ssid));
+            }
+        }
+
+        if (samples.Count == 0) return;
+        await _repository.UpsertNeighborSightingsAsync(samples, cancellationToken);
+        _logger.LogDebug("Neighbor memory: upserted {Count} sightings", samples.Count);
     }
 
     private static DateTime Max(DateTime a, DateTime b) => a > b ? a : b;

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -843,6 +843,49 @@ public class WiFiOptimizerService
     }
 
     /// <summary>
+    /// Fold the persisted long-term neighbor memory into the pooled scan results (see
+    /// <see cref="ChannelMemoryHelper.MergeRememberedNeighbors"/>). Used by the channel
+    /// recommendation only; degrades gracefully to the live-only picture on any failure.
+    /// </summary>
+    private async Task<List<ChannelScanResult>> MergeRememberedNeighborsAsync(List<ChannelScanResult> pooled)
+    {
+        try
+        {
+            var now = DateTimeOffset.UtcNow;
+            var rows = await _channelMemoryRepository.GetNeighborSightingsSinceAsync(
+                now.UtcDateTime - ChannelMemoryHelper.NeighborMemoryWindow);
+            if (rows.Count == 0) return pooled;
+
+            var remembered = rows
+                .Select(r => new RememberedNeighborSighting(
+                    r.ApMac,
+                    RadioBandExtensions.FromUniFiCode(r.Band),
+                    r.Bssid,
+                    r.Channel,
+                    r.WidthMhz,
+                    r.SignalDbm,
+                    new DateTimeOffset(DateTime.SpecifyKind(r.LastSeenUtc, DateTimeKind.Utc)),
+                    r.Ssid))
+                .Where(s => s.Band != RadioBand.Unknown)
+                .ToList();
+
+            var merged = ChannelMemoryHelper.MergeRememberedNeighbors(pooled, remembered, now);
+
+            var addedCount = merged.Sum(s => s.Neighbors.Count) - pooled.Sum(s => s.Neighbors.Count);
+            if (addedCount > 0)
+                _logger.LogDebug(
+                    "[ChannelRec] neighbor memory added {Count} remembered sighting(s) beyond the live scan picture",
+                    addedCount);
+            return merged;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to merge remembered neighbor sightings");
+            return pooled;
+        }
+    }
+
+    /// <summary>
     /// Get regulatory channel availability data for the site's country.
     /// Cached for 30 minutes since regulatory data rarely changes.
     /// </summary>
@@ -1084,8 +1127,10 @@ public class WiFiOptimizerService
             var aps = apsTask.Result;
             var regulatoryData = regulatoryTask.Result;
             // Pool neighbor sightings across the rolling window so a single under-detecting scan
-            // can't flip marginal channel moves (the live RF Environment view still uses raw scans).
-            var scanResults = PoolNeighborSightings(scanTask.Result);
+            // can't flip marginal channel moves (the live RF Environment view still uses raw scans),
+            // then fold in the persisted neighbor memory so a serving radio keeps age-decayed
+            // neighbor evidence for channels it isn't currently on.
+            var scanResults = await MergeRememberedNeighborsAsync(PoolNeighborSightings(scanTask.Result));
 
             if (aps.Count == 0)
             {

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -864,6 +864,7 @@ public class WiFiOptimizerService
                     r.Channel,
                     r.WidthMhz,
                     r.SignalDbm,
+                    r.SightingCount,
                     new DateTimeOffset(DateTime.SpecifyKind(r.LastSeenUtc, DateTimeKind.Utc)),
                     r.Ssid))
                 .Where(s => s.Band != RadioBand.Unknown)

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -31,6 +31,7 @@ public class WiFiOptimizerService
     private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly PlannedApService _plannedApService;
     private readonly ChannelRecommendationService _channelRecommendationService;
+    private readonly NetworkOptimizer.Storage.Interfaces.IChannelMemoryRepository _channelMemoryRepository;
 
     // Cached data (refreshed on demand)
     private List<AccessPointSnapshot>? _cachedAps;
@@ -52,6 +53,7 @@ public class WiFiOptimizerService
         IServiceScopeFactory serviceScopeFactory,
         PlannedApService plannedApService,
         ChannelRecommendationService channelRecommendationService,
+        NetworkOptimizer.Storage.Interfaces.IChannelMemoryRepository channelMemoryRepository,
         ILogger<WiFiOptimizerService> logger,
         ILoggerFactory loggerFactory)
     {
@@ -64,6 +66,7 @@ public class WiFiOptimizerService
         _serviceScopeFactory = serviceScopeFactory;
         _plannedApService = plannedApService;
         _channelRecommendationService = channelRecommendationService;
+        _channelMemoryRepository = channelMemoryRepository;
         _logger = logger;
         _loggerFactory = loggerFactory;
         _healthScorer = new SiteHealthScorer();
@@ -910,14 +913,20 @@ public class WiFiOptimizerService
     /// <summary>
     /// Get per-AP Wi-Fi metrics time series (filtered by AP MAC)
     /// </summary>
+    /// <param name="throwOnFailure">When true, disconnection or a fetch failure throws instead
+    /// of returning an empty list, so callers that must not confuse "no data" with "fetch
+    /// failed" (the outcome-memory collector) can abort without corrupting their state.</param>
     public async Task<List<WiFi.Models.SiteWiFiMetrics>> GetApMetricsAsync(
         string[] apMacs,
         DateTimeOffset start,
         DateTimeOffset end,
-        WiFi.MetricGranularity granularity = WiFi.MetricGranularity.FiveMinutes)
+        WiFi.MetricGranularity granularity = WiFi.MetricGranularity.FiveMinutes,
+        bool throwOnFailure = false)
     {
         if (!_connectionService.IsConnected || _connectionService.Client == null)
         {
+            if (throwOnFailure)
+                throw new InvalidOperationException("Not connected to UniFi Console");
             _logger.LogDebug("Cannot get AP metrics - not connected to UniFi");
             return new List<WiFi.Models.SiteWiFiMetrics>();
         }
@@ -926,10 +935,11 @@ public class WiFiOptimizerService
         {
             var provider = CreateProvider();
 
-            return await provider.GetApMetricsAsync(apMacs, start, end, granularity);
+            return await provider.GetApMetricsAsync(apMacs, start, end, granularity, throwOnFailure: throwOnFailure);
         }
         catch (Exception ex)
         {
+            if (throwOnFailure) throw;
             _logger.LogError(ex, "Failed to get AP metrics for {ApMacs}", string.Join(",", apMacs));
             return new List<WiFi.Models.SiteWiFiMetrics>();
         }
@@ -937,23 +947,31 @@ public class WiFiOptimizerService
 
     /// <summary>
     /// Get AP channel change events from the system log (v2 API).
-    /// Returns empty list on failure - never throws.
+    /// Returns empty list on failure unless <paramref name="throwOnFailure"/> is set - an empty
+    /// list is indistinguishable from "no channel changes", which is exactly wrong for callers
+    /// attributing metrics to a channel timeline.
     /// </summary>
     public async Task<List<WiFi.Models.ChannelChangeEvent>> GetChannelChangeEventsAsync(
         DateTimeOffset start,
         DateTimeOffset end,
-        string? apMac = null)
+        string? apMac = null,
+        bool throwOnFailure = false)
     {
         if (!_connectionService.IsConnected || _connectionService.Client == null)
+        {
+            if (throwOnFailure)
+                throw new InvalidOperationException("Not connected to UniFi Console");
             return new List<WiFi.Models.ChannelChangeEvent>();
+        }
 
         try
         {
             var provider = CreateProvider();
-            return await provider.GetChannelChangeEventsAsync(start, end, apMac);
+            return await provider.GetChannelChangeEventsAsync(start, end, apMac, throwOnFailure: throwOnFailure);
         }
         catch (Exception ex)
         {
+            if (throwOnFailure) throw;
             _logger.LogDebug(ex, "Failed to get channel change events");
             return new List<WiFi.Models.ChannelChangeEvent>();
         }
@@ -1115,8 +1133,9 @@ public class WiFiOptimizerService
                 _logger.LogDebug(ex, "Failed to load propagation data for channel recommendations");
             }
 
-            // Fetch 30-day historical radio stats paired with channel change events
-            var historicalStress = await GetHistoricalStressAsync(aps);
+            // Fetch historical radio stats paired with channel change events (UniFi metrics
+            // window + persisted long-term outcome memory) and soak-period state
+            var historicalContext = await GetHistoricalContextAsync(aps);
 
             // Generate recommendations for each band that has APs
             var bands = new[] { RadioBand.Band2_4GHz, RadioBand.Band5GHz, RadioBand.Band6GHz };
@@ -1128,9 +1147,10 @@ public class WiFiOptimizerService
 
                 try
                 {
-                    var bandStress = historicalStress?.GetValueOrDefault(band);
+                    var bandStress = historicalContext?.Stress?.GetValueOrDefault(band);
+                    var bandSoak = historicalContext?.Soak.GetValueOrDefault(band);
                     var graph = _channelRecommendationService.BuildInterferenceGraph(
-                        aps, band, propCtx, scanResults, regulatoryData, options, bandStress);
+                        aps, band, propCtx, scanResults, regulatoryData, options, bandStress, bandSoak);
 
                     var plan = _channelRecommendationService.Optimize(
                         graph, band, regulatoryData, options, hasBuildingData);
@@ -1152,45 +1172,76 @@ public class WiFiOptimizerService
     }
 
     /// <summary>
-    /// Fetch per-AP historical radio stats (30 days, daily granularity) and pair with
-    /// channel change events to build per-channel stress maps. Returns stress data keyed
-    /// by band → AP MAC → channel → (avg util, avg interf, avg txRetry).
+    /// Historical inputs for the channel recommendation engine, built per run.
     /// </summary>
-    private async Task<Dictionary<RadioBand, Dictionary<string, Dictionary<int, (double Utilization, double Interference, double TxRetryPct)>>>?>
-        GetHistoricalStressAsync(List<AccessPointSnapshot> aps)
+    private sealed class HistoricalChannelContext
+    {
+        /// <summary>Per-channel measured stress keyed by band → AP MAC (lower) → channel.
+        /// Recent UniFi metrics merged with the persisted long-term outcome memory.</summary>
+        public Dictionary<RadioBand, Dictionary<string, Dictionary<int, (double Utilization, double Interference, double TxRetryPct)>>>? Stress { get; set; }
+
+        /// <summary>Soak-period state keyed by band → AP MAC (lower). An entry exists only
+        /// when the radio changed channels within the soak window.</summary>
+        public Dictionary<RadioBand, Dictionary<string, ChannelSoakInfo>> Soak { get; } = new();
+    }
+
+    /// <summary>
+    /// Build the engine's historical context: per-AP per-channel stress maps (7-day hourly +
+    /// 1-day 5-min UniFi metrics attributed to the channel actually live via change events,
+    /// extended with the persisted long-term outcome memory for channels the UniFi window no
+    /// longer covers) and soak-period state from recent channel changes (UniFi system log
+    /// plus the persisted change log).
+    /// </summary>
+    private async Task<HistoricalChannelContext?> GetHistoricalContextAsync(List<AccessPointSnapshot> aps)
     {
         if (!_connectionService.IsConnected || _connectionService.Client == null)
             return null;
 
+        var now = DateTimeOffset.UtcNow;
+        var onlineAps = aps.Where(ap => ap.IsOnline).ToList();
+        if (onlineAps.Count == 0) return null;
+
+        var context = new HistoricalChannelContext();
+        var bands = new[] { RadioBand.Band2_4GHz, RadioBand.Band5GHz, RadioBand.Band6GHz };
+
+        // Fetch 7-day hourly + 1-day 5-min metrics and channel change events concurrently.
+        // A failure here must not sink the whole context - the outcome memory and persisted
+        // change log below can still provide stress and soak data.
+        (string Mac, List<SiteWiFiMetrics> Metrics, List<SiteWiFiMetrics> RecentMetrics, List<ChannelChangeEvent> Events)[]? allResults = null;
         try
         {
-            var end = DateTimeOffset.UtcNow;
-            var start = end.AddDays(-7);
-            var onlineAps = aps.Where(ap => ap.IsOnline).ToList();
-            if (onlineAps.Count == 0) return null;
-
-            // Fetch 7-day hourly + 1-day 5-min metrics and channel change events concurrently
-            var recentStart = end.AddDays(-1);
+            var start = now.AddDays(-7);
+            var recentStart = now.AddDays(-1);
             var tasks = onlineAps.Select(async ap =>
             {
                 var metricsTask = GetApMetricsAsync(
-                    new[] { ap.Mac }, start, end, MetricGranularity.Hourly);
+                    new[] { ap.Mac }, start, now, MetricGranularity.Hourly);
                 var recentMetricsTask = GetApMetricsAsync(
-                    new[] { ap.Mac }, recentStart, end, MetricGranularity.FiveMinutes);
-                var eventsTask = GetChannelChangeEventsAsync(start, end, ap.Mac);
+                    new[] { ap.Mac }, recentStart, now, MetricGranularity.FiveMinutes);
+                var eventsTask = GetChannelChangeEventsAsync(start, now, ap.Mac);
 
                 await Task.WhenAll(metricsTask, recentMetricsTask, eventsTask);
 
                 return (ap.Mac, Metrics: metricsTask.Result, RecentMetrics: recentMetricsTask.Result, Events: eventsTask.Result);
             });
 
-            var allResults = await Task.WhenAll(tasks);
+            allResults = await Task.WhenAll(tasks);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to fetch historical stress metrics, continuing with outcome memory only");
+        }
 
-            var bands = new[] { RadioBand.Band2_4GHz, RadioBand.Band5GHz, RadioBand.Band6GHz };
+        if (allResults != null)
+        {
             var result = new Dictionary<RadioBand, Dictionary<string, Dictionary<int, (double, double, double)>>>();
             foreach (var band in bands)
                 result[band] = new Dictionary<string, Dictionary<int, (double, double, double)>>(StringComparer.OrdinalIgnoreCase);
 
+            // A failure in attribution/aggregation must not sink the whole context either -
+            // fall through with whatever stress was built plus the memory/soak sections below.
+            try
+            {
             foreach (var (mac, metrics, recentMetrics, events) in allResults)
             {
                 if (metrics.Count == 0) continue;
@@ -1222,7 +1273,10 @@ public class WiFiOptimizerService
                             !bandData.ChannelUtilization.HasValue)
                             continue;
 
-                        var channel = GetChannelAtTime(metric.Timestamp, bandEvents, radio.Channel!.Value);
+                        var channel = ChannelMemoryHelper.GetChannelAtTime(metric.Timestamp, bandEvents, radio.Channel!.Value);
+                        // An event parsed without PREVIOUS_CHANNEL yields channel 0 for samples
+                        // predating it - not a real channel, don't build stress for it.
+                        if (channel <= 0) continue;
                         if (!channelMetrics.ContainsKey(channel))
                             channelMetrics[channel] = new List<(double, double, double)>();
                         channelMetrics[channel].Add((
@@ -1239,7 +1293,7 @@ public class WiFiOptimizerService
                             !bandData.ChannelUtilization.HasValue)
                             continue;
 
-                        var channel = GetChannelAtTime(metric.Timestamp, bandEvents, radio.Channel!.Value);
+                        var channel = ChannelMemoryHelper.GetChannelAtTime(metric.Timestamp, bandEvents, radio.Channel!.Value);
                         if (channel == radio.Channel!.Value)
                         {
                             recentCurrentChannel.Add((
@@ -1287,37 +1341,132 @@ public class WiFiOptimizerService
                 }
             }
 
-            return result;
+            context.Stress = result;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to attribute historical stress metrics, continuing with outcome memory only");
+            }
+        }
+
+        // Extend the recent stress with the persisted long-term outcome memory: channels an
+        // AP sat on weeks or months ago keep their measured ground truth instead of scoring
+        // as unknown once they age out of the UniFi metrics window. Recent data wins for
+        // channels it covers.
+        try
+        {
+            var outcomes = await _channelMemoryRepository.GetOutcomesSinceAsync(
+                now.UtcDateTime - ChannelMemoryHelper.LongTermOutcomeWindow);
+            if (outcomes.Count > 0)
+            {
+                var outcomeLookup = outcomes.ToLookup(o => (o.ApMac, o.Band));
+                context.Stress ??= bands.ToDictionary(
+                    b => b,
+                    _ => new Dictionary<string, Dictionary<int, (double, double, double)>>(StringComparer.OrdinalIgnoreCase));
+
+                foreach (var band in bands)
+                {
+                    var bandCode = band.ToUniFiCode();
+                    foreach (var ap in onlineAps)
+                    {
+                        var radio = ap.Radios.FirstOrDefault(r => r.Band == band && r.Channel.HasValue);
+                        if (radio == null) continue;
+
+                        var macLower = ap.Mac.ToLowerInvariant();
+                        var buckets = outcomeLookup[(macLower, bandCode)]
+                            .Select(o => new ChannelOutcomeBucket(
+                                o.Channel, o.WidthMhz, o.UtilizationSum, o.InterferenceSum,
+                                o.TxRetrySum, o.SampleCount,
+                                new DateTimeOffset(DateTime.SpecifyKind(o.LastSampleUtc, DateTimeKind.Utc))))
+                            .ToList();
+                        if (buckets.Count == 0) continue;
+
+                        var recent = context.Stress[band].GetValueOrDefault(macLower);
+                        var merged = ChannelMemoryHelper.MergeLongTermOutcomes(
+                            recent, buckets, radio.ChannelWidth ?? 20, now);
+                        if (merged == null) continue;
+
+                        if (merged.Count > (recent?.Count ?? 0))
+                            _logger.LogDebug(
+                                "[ChannelRec] {ApName} {Band}: outcome memory added measured stress for " +
+                                "{Added} channel(s) beyond the UniFi metrics window",
+                                ap.Name, band, merged.Count - (recent?.Count ?? 0));
+                        context.Stress[band][macLower] = merged;
+                    }
+                }
+            }
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Failed to fetch historical stress metrics, falling back to snapshot");
-            return null;
+            _logger.LogDebug(ex, "Failed to merge long-term channel outcome memory");
         }
-    }
 
-    /// <summary>
-    /// Determine which channel an AP was on at a given timestamp by walking
-    /// the channel change event timeline backwards.
-    /// </summary>
-    private static int GetChannelAtTime(
-        DateTimeOffset timestamp,
-        List<ChannelChangeEvent> events,
-        int currentChannel)
-    {
-        // Walk events in reverse to find the most recent change before this timestamp
-        for (int i = events.Count - 1; i >= 0; i--)
+        // Soak-period state: channels a radio left within the soak window must not be
+        // recommended again yet. Union the UniFi system-log events with the persisted change
+        // log (which also catches changes UniFi's short retention has already dropped);
+        // BuildSoakInfo tolerates the duplicates the union produces.
+        try
         {
-            if (events[i].Timestamp <= timestamp)
-                return events[i].NewChannel;
+            List<Storage.Models.ApChannelChange> persistedChanges;
+            try
+            {
+                persistedChanges = await _channelMemoryRepository.GetChangesSinceAsync(
+                    now.UtcDateTime - ChannelMemoryHelper.SoakPeriod);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to load persisted channel changes for soak state");
+                persistedChanges = new List<Storage.Models.ApChannelChange>();
+            }
+
+            foreach (var band in bands)
+            {
+                var bandCode = band.ToUniFiCode();
+                var bandSoak = new Dictionary<string, ChannelSoakInfo>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var ap in onlineAps)
+                {
+                    var radio = ap.Radios.FirstOrDefault(r => r.Band == band && r.Channel.HasValue);
+                    if (radio == null) continue;
+
+                    var macLower = ap.Mac.ToLowerInvariant();
+                    var changeEvents = new List<ChannelChangeEvent>();
+
+                    if (allResults != null)
+                    {
+                        var apResult = allResults.FirstOrDefault(r =>
+                            r.Mac.Equals(ap.Mac, StringComparison.OrdinalIgnoreCase));
+                        if (apResult.Events != null)
+                            changeEvents.AddRange(apResult.Events.Where(e => e.Band == band));
+                    }
+
+                    changeEvents.AddRange(persistedChanges
+                        .Where(c => c.ApMac.Equals(macLower, StringComparison.OrdinalIgnoreCase) &&
+                                    c.Band == bandCode && c.PreviousChannel is > 0)
+                        .Select(c => new ChannelChangeEvent
+                        {
+                            Timestamp = new DateTimeOffset(DateTime.SpecifyKind(c.ChangedAtUtc, DateTimeKind.Utc)),
+                            ApMac = c.ApMac,
+                            Band = band,
+                            NewChannel = c.NewChannel,
+                            PreviousChannel = c.PreviousChannel!.Value
+                        }));
+
+                    var soak = ChannelMemoryHelper.BuildSoakInfo(changeEvents, radio.Channel!.Value, now);
+                    if (soak != null)
+                        bandSoak[macLower] = soak;
+                }
+
+                if (bandSoak.Count > 0)
+                    context.Soak[band] = bandSoak;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to build soak-period state");
         }
 
-        // Before any recorded change: use the first event's PreviousChannel if available
-        if (events.Count > 0)
-            return events[0].PreviousChannel;
-
-        // No change events at all: assume current channel
-        return currentChannel;
+        return context;
     }
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -11129,6 +11129,16 @@ a.path-hop.hop-clickable:hover {
     margin-left: 0.5rem;
 }
 
+.soak-badge {
+    font-size: 0.7rem;
+    font-weight: 500;
+    padding: 0.125rem 0.5rem;
+    background: rgba(43, 168, 154, 0.15);
+    color: #2ba89a;
+    border-radius: 3px;
+    margin-left: 0.5rem;
+}
+
 /* Recommend Best Channels button - accent gradient matching Cleanest Channels box */
 .btn-recommend {
     background: linear-gradient(135deg, var(--accent-color) 0%, var(--primary-color) 100%);

--- a/src/NetworkOptimizer.WiFi/Helpers/ChannelMemoryHelper.cs
+++ b/src/NetworkOptimizer.WiFi/Helpers/ChannelMemoryHelper.cs
@@ -11,11 +11,12 @@ public static class ChannelMemoryHelper
 {
     /// <summary>
     /// How long a fresh channel change must soak before the optimizer may recommend hopping
-    /// back to a channel the radio just left. One week covers a full weekly usage cycle and
-    /// gives the outcome memory enough attributed samples to judge the new channel on
-    /// measured data instead of inference. Applies to every band.
+    /// back to a channel the radio just left. 16 hours is enough for real-world load
+    /// (including an evening peak, for changes applied during the day) to expose problems
+    /// with the new channel, without freezing the plan for days; a genuinely bad move
+    /// escapes earlier via the catastrophic-score gate. Applies to every band.
     /// </summary>
-    public static readonly TimeSpan SoakPeriod = TimeSpan.FromDays(7);
+    public static readonly TimeSpan SoakPeriod = TimeSpan.FromHours(16);
 
     /// <summary>
     /// Minimum effective (age-decayed) sample weight before a long-term outcome is trusted to
@@ -40,6 +41,36 @@ public static class ChannelMemoryHelper
     /// (and at three half-lives the decayed weight is nearly gone anyway).
     /// </summary>
     public static readonly TimeSpan LongTermOutcomeWindow = TimeSpan.FromDays(180);
+
+    /// <summary>
+    /// Half-life for aging remembered neighbor sightings - much shorter than the outcome
+    /// half-life because neighbor networks churn (APs move, get reconfigured, hotspots come
+    /// and go) far faster than a channel's aggregate character drifts.
+    /// </summary>
+    public static readonly TimeSpan NeighborHalfLife = TimeSpan.FromDays(14);
+
+    /// <summary>
+    /// How far back remembered neighbor sightings are read and merged: three half-lives,
+    /// where a sighting's confidence has decayed to 12.5% and it effectively no longer
+    /// speaks. Keeps the fetch and the decay cutoff in one place.
+    /// </summary>
+    public static readonly TimeSpan NeighborMemoryWindow = TimeSpan.FromDays(42);
+
+    /// <summary>
+    /// Minimum age-decayed confidence for a remembered sighting to be merged. 0.125 = three
+    /// half-lives, matching <see cref="NeighborMemoryWindow"/>.
+    /// </summary>
+    public const double MinNeighborConfidence = 0.125;
+
+    /// <summary>
+    /// Weakest neighbor signal worth persisting. A few dB below the CCA threshold (-82 dBm,
+    /// where radios actually defer) so borderline neighbors whose signal fluctuates aren't
+    /// forgotten, while genuine noise-floor sightings don't accumulate rows.
+    /// </summary>
+    public const int MinPersistedNeighborSignalDbm = -90;
+
+    /// <summary>How long a neighbor sighting row is kept after its last sighting.</summary>
+    public const int NeighborRetentionDays = 60;
 
     /// <summary>
     /// Determine which channel an AP was on at a given timestamp by walking the
@@ -164,5 +195,110 @@ public static class ChannelMemoryHelper
         }
 
         return merged;
+    }
+
+    /// <summary>
+    /// Fold remembered neighbor sightings into the pooled live scan results, so a serving
+    /// radio keeps neighbor evidence for channels it isn't currently on - once it moves, its
+    /// live scan forgets the old channel's neighborhood within the hour. Remembered neighbors
+    /// enter with an age-decayed <see cref="NeighborNetwork.Confidence"/> (half-life
+    /// <see cref="NeighborHalfLife"/>) so they count for less as they age, and are dropped
+    /// entirely below <see cref="MinNeighborConfidence"/>.
+    ///
+    /// A remembered sighting is suppressed when the live picture supersedes it: the BSSID is
+    /// currently seen on a DIFFERENT channel anywhere on the band (it moved - the old row is
+    /// obsolete for everyone), or the observing AP itself already sees it live (the live
+    /// sighting carries the same evidence at full confidence). A same-channel sighting from a
+    /// radio that can't currently hear the neighbor is kept - it is a real per-observer
+    /// vantage that triangulation from the live observer would understate.
+    ///
+    /// Sightings for (AP, band) pairs with no scan entry are ignored - a synthetic scan entry
+    /// would make the engine believe it has live scan data it doesn't have. Returns new scan
+    /// objects; the inputs are not mutated.
+    /// </summary>
+    /// <param name="pooledScans">Live scan results, already pooled over the rolling sighting window</param>
+    /// <param name="remembered">Persisted sightings for all APs and bands</param>
+    /// <param name="now">Current time (UTC), the reference for age decay</param>
+    public static List<ChannelScanResult> MergeRememberedNeighbors(
+        List<ChannelScanResult> pooledScans,
+        IReadOnlyCollection<RememberedNeighborSighting> remembered,
+        DateTimeOffset now)
+    {
+        if (remembered.Count == 0) return pooledScans;
+
+        // Live picture per band: which channels each BSSID is currently seen on, and which
+        // APs currently see it (for the same-observer suppression).
+        var liveChannels = new Dictionary<(RadioBand Band, string Bssid), HashSet<int>>();
+        var liveObservers = new HashSet<(RadioBand Band, string ApMac, string Bssid)>();
+        foreach (var scan in pooledScans)
+        {
+            var apKey = scan.ApMac.ToLowerInvariant();
+            foreach (var nb in scan.Neighbors)
+            {
+                if (string.IsNullOrEmpty(nb.Bssid)) continue;
+                var bssidKey = nb.Bssid.ToLowerInvariant();
+                if (!liveChannels.TryGetValue((scan.Band, bssidKey), out var channels))
+                {
+                    channels = new HashSet<int>();
+                    liveChannels[(scan.Band, bssidKey)] = channels;
+                }
+                channels.Add(nb.Channel);
+                liveObservers.Add((scan.Band, apKey, bssidKey));
+            }
+        }
+
+        var rememberedByRadio = remembered
+            .ToLookup(s => (s.Band, ApMac: s.ApMac.ToLowerInvariant()));
+
+        var mergedScans = new List<ChannelScanResult>(pooledScans.Count);
+        foreach (var scan in pooledScans)
+        {
+            var apKey = scan.ApMac.ToLowerInvariant();
+            List<NeighborNetwork>? added = null;
+
+            foreach (var sighting in rememberedByRadio[(scan.Band, apKey)])
+            {
+                var ageDays = Math.Max(0, (now - sighting.LastSeenAt).TotalDays);
+                var confidence = Math.Pow(0.5, ageDays / NeighborHalfLife.TotalDays);
+                if (confidence < MinNeighborConfidence) continue;
+
+                var bssidKey = sighting.Bssid.ToLowerInvariant();
+                if (liveChannels.TryGetValue((scan.Band, bssidKey), out var channels))
+                {
+                    if (!channels.Contains(sighting.Channel)) continue;
+                    if (liveObservers.Contains((scan.Band, apKey, bssidKey))) continue;
+                }
+
+                added ??= new List<NeighborNetwork>();
+                added.Add(new NeighborNetwork
+                {
+                    Ssid = sighting.Ssid ?? string.Empty,
+                    Bssid = sighting.Bssid,
+                    Channel = sighting.Channel,
+                    Width = sighting.WidthMhz > 0 ? sighting.WidthMhz : null,
+                    Signal = sighting.SignalDbm,
+                    LastSeen = sighting.LastSeenAt,
+                    Confidence = confidence
+                });
+            }
+
+            if (added == null)
+            {
+                mergedScans.Add(scan);
+                continue;
+            }
+
+            mergedScans.Add(new ChannelScanResult
+            {
+                ApMac = scan.ApMac,
+                ApName = scan.ApName,
+                Band = scan.Band,
+                ScanTime = scan.ScanTime,
+                Channels = scan.Channels,
+                Neighbors = scan.Neighbors.Concat(added).ToList()
+            });
+        }
+
+        return mergedScans;
     }
 }

--- a/src/NetworkOptimizer.WiFi/Helpers/ChannelMemoryHelper.cs
+++ b/src/NetworkOptimizer.WiFi/Helpers/ChannelMemoryHelper.cs
@@ -1,0 +1,168 @@
+using NetworkOptimizer.WiFi.Models;
+
+namespace NetworkOptimizer.WiFi.Helpers;
+
+/// <summary>
+/// Pure logic for the channel recommendation outcome memory: attributing metrics to the
+/// config that was live at a given time, building soak-period state from channel-change
+/// events, and merging long-term persisted outcomes into the recent per-channel stress map.
+/// </summary>
+public static class ChannelMemoryHelper
+{
+    /// <summary>
+    /// How long a fresh channel change must soak before the optimizer may recommend hopping
+    /// back to a channel the radio just left. One week covers a full weekly usage cycle and
+    /// gives the outcome memory enough attributed samples to judge the new channel on
+    /// measured data instead of inference. Applies to every band.
+    /// </summary>
+    public static readonly TimeSpan SoakPeriod = TimeSpan.FromDays(7);
+
+    /// <summary>
+    /// Minimum effective (age-decayed) sample weight before a long-term outcome is trusted to
+    /// stand in as measured stress for a channel - roughly half a day of fresh residency,
+    /// enough to average out a burst without demanding a full day. As evidence ages past the
+    /// half-life its effective weight shrinks, so a channel whose record has mostly decayed
+    /// falls back to "unknown" and picks the uncertainty penalty back up naturally.
+    /// </summary>
+    public const int MinLongTermSamples = 12;
+
+    /// <summary>
+    /// Half-life for aging long-term outcomes: a bucket's weight halves every 60 days, so
+    /// month-old evidence speaks nearly at full strength while a five-month-old outcome
+    /// contributes ~25% - the RF neighborhood drifts, and the average should tilt toward
+    /// whatever was measured most recently.
+    /// </summary>
+    public static readonly TimeSpan OutcomeHalfLife = TimeSpan.FromDays(60);
+
+    /// <summary>
+    /// How far back persisted outcomes are read when feeding the engine. Beyond this the RF
+    /// neighborhood has likely drifted too much for old outcomes to speak for a channel
+    /// (and at three half-lives the decayed weight is nearly gone anyway).
+    /// </summary>
+    public static readonly TimeSpan LongTermOutcomeWindow = TimeSpan.FromDays(180);
+
+    /// <summary>
+    /// Determine which channel an AP was on at a given timestamp by walking the
+    /// channel change event timeline backwards.
+    /// </summary>
+    /// <param name="timestamp">Time the metric sample was taken</param>
+    /// <param name="events">Channel change events for one AP and band, sorted chronologically</param>
+    /// <param name="currentChannel">The radio's current channel (used when no events exist)</param>
+    public static int GetChannelAtTime(
+        DateTimeOffset timestamp,
+        List<ChannelChangeEvent> events,
+        int currentChannel)
+    {
+        // Walk events in reverse to find the most recent change before this timestamp
+        for (int i = events.Count - 1; i >= 0; i--)
+        {
+            if (events[i].Timestamp <= timestamp)
+                return events[i].NewChannel;
+        }
+
+        // Before any recorded change: use the first event's PreviousChannel if available
+        if (events.Count > 0)
+            return events[0].PreviousChannel;
+
+        // No change events at all: assume current channel
+        return currentChannel;
+    }
+
+    /// <summary>
+    /// Build soak-period state for one AP radio from its channel-change events (any order,
+    /// duplicates tolerated - the same change may arrive from both the UniFi system log and
+    /// the persisted change log). Returns null when nothing is soaking: no change happened
+    /// within the window, or every recently-left channel is the current channel again.
+    /// </summary>
+    /// <param name="events">Channel change events for one AP and band</param>
+    /// <param name="currentChannel">The radio's current channel - never soaked</param>
+    /// <param name="now">Current time (UTC)</param>
+    public static ChannelSoakInfo? BuildSoakInfo(
+        IEnumerable<ChannelChangeEvent> events,
+        int currentChannel,
+        DateTimeOffset now)
+    {
+        var windowStart = now - SoakPeriod;
+        var soaked = new HashSet<int>();
+        DateTimeOffset lastChange = DateTimeOffset.MinValue;
+
+        foreach (var evt in events)
+        {
+            if (evt.Timestamp < windowStart || evt.Timestamp > now) continue;
+            if (evt.Timestamp > lastChange) lastChange = evt.Timestamp;
+            if (evt.PreviousChannel > 0 && evt.PreviousChannel != currentChannel)
+                soaked.Add(evt.PreviousChannel);
+        }
+
+        if (soaked.Count == 0) return null;
+
+        return new ChannelSoakInfo
+        {
+            SoakedChannels = soaked,
+            LastChangeAt = lastChange,
+            SoakEndsAt = lastChange + SoakPeriod
+        };
+    }
+
+    /// <summary>
+    /// Merge long-term persisted outcomes into the recent (UniFi metrics window) per-channel
+    /// stress map for one AP radio. Recent data wins for channels it covers - it reflects
+    /// today's RF neighborhood; the memory fills in channels the radio sat on longer ago, so
+    /// a previously-tried channel keeps its measured ground truth instead of being scored on
+    /// inference. Buckets are matched on the radio's current width (plus unknown-width
+    /// buckets, which predate a width observation).
+    ///
+    /// Older evidence counts for less: each bucket's weight is its sample count decayed by
+    /// <see cref="OutcomeHalfLife"/>, so when a channel was tried at two different times the
+    /// average tilts toward the newer measurement. Channels whose total effective weight
+    /// falls below <paramref name="minSampleCount"/> are ignored - fully-aged memory reverts
+    /// to "unknown channel" rather than whispering stale numbers with full authority.
+    /// </summary>
+    /// <param name="recentStress">Per-channel stress from the recent metrics window; may be null</param>
+    /// <param name="longTermBuckets">Persisted outcome buckets for the same AP and band</param>
+    /// <param name="currentWidthMhz">The radio's current channel width</param>
+    /// <param name="now">Current time (UTC), the reference for age decay</param>
+    /// <param name="minSampleCount">Minimum effective (decayed) sample weight for a memory channel to count</param>
+    /// <returns>The merged map, or null when neither source has data</returns>
+    public static Dictionary<int, (double Utilization, double Interference, double TxRetryPct)>? MergeLongTermOutcomes(
+        Dictionary<int, (double Utilization, double Interference, double TxRetryPct)>? recentStress,
+        IEnumerable<ChannelOutcomeBucket> longTermBuckets,
+        int currentWidthMhz,
+        DateTimeOffset now,
+        int minSampleCount = MinLongTermSamples)
+    {
+        Dictionary<int, (double, double, double)>? merged = recentStress != null
+            ? new Dictionary<int, (double, double, double)>(recentStress)
+            : null;
+
+        var byChannel = longTermBuckets
+            .Where(b => b.WidthMhz == 0 || b.WidthMhz == currentWidthMhz)
+            .GroupBy(b => b.Channel);
+
+        foreach (var group in byChannel)
+        {
+            if (merged != null && merged.ContainsKey(group.Key)) continue;
+
+            double effectiveWeight = 0, utilSum = 0, interfSum = 0, txRetrySum = 0;
+            foreach (var bucket in group)
+            {
+                var ageDays = Math.Max(0, (now - bucket.LastSampleAt).TotalDays);
+                var decay = Math.Pow(0.5, ageDays / OutcomeHalfLife.TotalDays);
+                effectiveWeight += bucket.SampleCount * decay;
+                utilSum += bucket.UtilizationSum * decay;
+                interfSum += bucket.InterferenceSum * decay;
+                txRetrySum += bucket.TxRetrySum * decay;
+            }
+
+            if (effectiveWeight < minSampleCount) continue;
+
+            merged ??= new Dictionary<int, (double, double, double)>();
+            merged[group.Key] = (
+                utilSum / effectiveWeight,
+                interfSum / effectiveWeight,
+                txRetrySum / effectiveWeight);
+        }
+
+        return merged;
+    }
+}

--- a/src/NetworkOptimizer.WiFi/Helpers/ChannelMemoryHelper.cs
+++ b/src/NetworkOptimizer.WiFi/Helpers/ChannelMemoryHelper.cs
@@ -57,10 +57,20 @@ public static class ChannelMemoryHelper
     public static readonly TimeSpan NeighborMemoryWindow = TimeSpan.FromDays(42);
 
     /// <summary>
-    /// Minimum age-decayed confidence for a remembered sighting to be merged. 0.125 = three
-    /// half-lives, matching <see cref="NeighborMemoryWindow"/>.
+    /// Minimum (age × persistence) confidence for a remembered sighting to be merged. 0.125 =
+    /// three age half-lives at full persistence, matching <see cref="NeighborMemoryWindow"/>.
     /// </summary>
     public const double MinNeighborConfidence = 0.125;
+
+    /// <summary>
+    /// Sighting count at which a remembered neighbor is trusted at full weight. Collection runs
+    /// every few hours, so ~3 sightings means the neighbor has been seen consistently rather
+    /// than as a one-off (a guest hotspot, a device passing through, a neighbor since departed).
+    /// Below it, confidence - and thus both the neighbor's interference weight and the
+    /// observation credit it grants - scales down proportionally, so transient sightings can't
+    /// accumulate into phantom load on a channel. Tunable.
+    /// </summary>
+    public const int MinNeighborSightingsForFullWeight = 3;
 
     /// <summary>
     /// Weakest neighbor signal worth persisting. A few dB below the CCA threshold (-82 dBm,
@@ -258,8 +268,13 @@ public static class ChannelMemoryHelper
 
             foreach (var sighting in rememberedByRadio[(scan.Band, apKey)])
             {
+                // Confidence combines recency (age half-life) with persistence (how many
+                // cycles the neighbor has actually been seen). A durable neighbor counts at
+                // full recency weight; a one-off is scaled down so it can't inflate a channel.
                 var ageDays = Math.Max(0, (now - sighting.LastSeenAt).TotalDays);
-                var confidence = Math.Pow(0.5, ageDays / NeighborHalfLife.TotalDays);
+                var ageDecay = Math.Pow(0.5, ageDays / NeighborHalfLife.TotalDays);
+                var persistence = Math.Min(1.0, (double)sighting.SightingCount / MinNeighborSightingsForFullWeight);
+                var confidence = ageDecay * persistence;
                 if (confidence < MinNeighborConfidence) continue;
 
                 var bssidKey = sighting.Bssid.ToLowerInvariant();

--- a/src/NetworkOptimizer.WiFi/Models/ChannelMemory.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelMemory.cs
@@ -38,3 +38,26 @@ public record ChannelOutcomeBucket(
     double TxRetrySum,
     int SampleCount,
     DateTimeOffset LastSampleAt);
+
+/// <summary>
+/// One persisted neighbor sighting for an AP radio, storage-neutral so the engine project
+/// stays decoupled from the database layer. Lets a serving radio keep (age-decayed) neighbor
+/// evidence for channels it isn't currently on.
+/// </summary>
+/// <param name="ApMac">Observing AP MAC</param>
+/// <param name="Band">Radio band the neighbor was seen on</param>
+/// <param name="Bssid">Neighbor BSSID</param>
+/// <param name="Channel">Control channel the neighbor was seen on</param>
+/// <param name="WidthMhz">Neighbor channel width in MHz; 0 when unknown</param>
+/// <param name="SignalDbm">Strongest observed signal in dBm</param>
+/// <param name="LastSeenAt">Most recent sighting (UTC) - drives age decay</param>
+/// <param name="Ssid">Neighbor SSID, if any</param>
+public record RememberedNeighborSighting(
+    string ApMac,
+    RadioBand Band,
+    string Bssid,
+    int Channel,
+    int WidthMhz,
+    int SignalDbm,
+    DateTimeOffset LastSeenAt,
+    string? Ssid);

--- a/src/NetworkOptimizer.WiFi/Models/ChannelMemory.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelMemory.cs
@@ -50,6 +50,7 @@ public record ChannelOutcomeBucket(
 /// <param name="Channel">Control channel the neighbor was seen on</param>
 /// <param name="WidthMhz">Neighbor channel width in MHz; 0 when unknown</param>
 /// <param name="SignalDbm">Strongest observed signal in dBm</param>
+/// <param name="SightingCount">Collection cycles this neighbor has been seen - the persistence signal</param>
 /// <param name="LastSeenAt">Most recent sighting (UTC) - drives age decay</param>
 /// <param name="Ssid">Neighbor SSID, if any</param>
 public record RememberedNeighborSighting(
@@ -59,5 +60,6 @@ public record RememberedNeighborSighting(
     int Channel,
     int WidthMhz,
     int SignalDbm,
+    int SightingCount,
     DateTimeOffset LastSeenAt,
     string? Ssid);

--- a/src/NetworkOptimizer.WiFi/Models/ChannelMemory.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelMemory.cs
@@ -1,0 +1,40 @@
+namespace NetworkOptimizer.WiFi.Models;
+
+/// <summary>
+/// Soak-period state for one AP radio: the channels it recently moved OFF of, which the
+/// optimizer must not recommend hopping back to until the new channel has had time to prove
+/// itself (and the outcome memory has accumulated measured data for it). Applies to all bands.
+/// </summary>
+public class ChannelSoakInfo
+{
+    /// <summary>Channels this radio occupied within the soak window and then left.
+    /// Never contains the radio's current channel.</summary>
+    public HashSet<int> SoakedChannels { get; init; } = new();
+
+    /// <summary>When the most recent channel change happened (UTC)</summary>
+    public DateTimeOffset LastChangeAt { get; init; }
+
+    /// <summary>When the soak period ends (UTC): last change + soak window</summary>
+    public DateTimeOffset SoakEndsAt { get; init; }
+}
+
+/// <summary>
+/// One persisted daily outcome bucket for an AP radio config, storage-neutral so the engine
+/// project stays decoupled from the database layer. Sums divide by <see cref="SampleCount"/>
+/// to recover averages.
+/// </summary>
+/// <param name="Channel">Control channel the samples were attributed to</param>
+/// <param name="WidthMhz">Channel width in MHz; 0 when unknown</param>
+/// <param name="UtilizationSum">Sum of channel utilization percentages</param>
+/// <param name="InterferenceSum">Sum of interference percentages</param>
+/// <param name="TxRetrySum">Sum of TX retry percentages</param>
+/// <param name="SampleCount">Number of samples in the bucket</param>
+/// <param name="LastSampleAt">Most recent sample in the bucket (UTC)</param>
+public record ChannelOutcomeBucket(
+    int Channel,
+    int WidthMhz,
+    double UtilizationSum,
+    double InterferenceSum,
+    double TxRetrySum,
+    int SampleCount,
+    DateTimeOffset LastSampleAt);

--- a/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
@@ -39,6 +39,19 @@ public class ApChannelRecommendation
 
     /// <summary>Whether the recommended channel span is subject to DFS.</summary>
     public bool IsRecommendedDfsChannel { get; set; }
+
+    /// <summary>
+    /// Channels excluded from this AP's candidate set because the radio changed onto its
+    /// current channel recently and the abandoned config is still soaking. Empty when no
+    /// suppression was applied.
+    /// </summary>
+    public List<int> SoakSuppressedChannels { get; set; } = new();
+
+    /// <summary>When the active soak period ends (UTC); null when nothing is soaking.</summary>
+    public DateTimeOffset? SoakEndsAt { get; set; }
+
+    /// <summary>True when soak suppression narrowed this AP's candidate channels.</summary>
+    public bool IsSoaking => SoakSuppressedChannels.Count > 0;
 }
 
 /// <summary>
@@ -202,6 +215,13 @@ public class ApNode
 
     /// <summary>Index of this AP's mesh group leader, or -1 if not in a mesh group</summary>
     public int MeshGroupLeader { get; set; } = -1;
+
+    /// <summary>
+    /// Soak-period state for this radio: channels it recently moved off of, which the
+    /// optimizer must not hop back to while the new channel proves itself. Null when no
+    /// recent change is soaking.
+    /// </summary>
+    public ChannelSoakInfo? SoakInfo { get; set; }
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
@@ -144,6 +144,14 @@ public class InterferenceGraph
     public HashSet<int>[] DirectlyObservedChannels { get; set; } = [];
 
     /// <summary>
+    /// Per-AP channels this radio itself saw a neighbor on via the long-term neighbor memory
+    /// (a remembered sighting, not a live scan), mapped to the strongest such sighting's
+    /// age-decayed confidence. Real-but-dated evidence: it softens the unobserved-channel
+    /// uncertainty penalty at a reduced tier without granting a live sighting's full trust.
+    /// </summary>
+    public Dictionary<int, double>[] HistoricallyObservedChannels { get; set; } = [];
+
+    /// <summary>
     /// Per-AP channel scan metrics, keyed by (control channel, scan bandwidth MHz) so multiple-width
     /// buckets for the same channel can coexist (e.g. a BW20 and a BW160 reading of ch36). Value =
     /// (utilization %, noise floor dBm); NoiseFloor is null when the scan reported no reading, lower

--- a/src/NetworkOptimizer.WiFi/Models/ChannelScanResult.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelScanResult.cs
@@ -97,4 +97,12 @@ public class NeighborNetwork
 
     /// <summary>OUI (manufacturer) resolved from BSSID</summary>
     public string? Oui { get; set; }
+
+    /// <summary>
+    /// How much this sighting should count for, in (0, 1]. 1.0 = a live scan sighting.
+    /// Remembered sightings from the long-term neighbor memory enter with an age-decayed
+    /// confidence, scaling their interference weight down as they age - and they never
+    /// grant the full "directly observed" status a live sighting does.
+    /// </summary>
+    public double Confidence { get; set; } = 1.0;
 }

--- a/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
@@ -201,12 +201,17 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
         }
     }
 
+    /// <param name="throwOnFailure">When true, a fetch/parse failure propagates instead of
+    /// returning an empty list - so callers that must distinguish "no data" from "fetch failed"
+    /// (e.g. the outcome-memory collector, which would otherwise misattribute or skip a window)
+    /// can abort cleanly.</param>
     public async Task<List<SiteWiFiMetrics>> GetApMetricsAsync(
         string[] apMacs,
         DateTimeOffset start,
         DateTimeOffset end,
         MetricGranularity granularity = MetricGranularity.FiveMinutes,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        bool throwOnFailure = false)
     {
         var reportType = granularity switch
         {
@@ -253,6 +258,7 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
         }
         catch (Exception ex)
         {
+            if (throwOnFailure) throw;
             _logger.LogWarning(ex, "Failed to fetch AP metrics report");
             return new List<SiteWiFiMetrics>();
         }
@@ -261,11 +267,15 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
     /// <summary>
     /// Get AP channel change events from the v2 system log API.
     /// </summary>
+    /// <param name="throwOnFailure">When true, a fetch/parse failure propagates instead of
+    /// returning an empty list - an empty result is indistinguishable from "no changes", which
+    /// would silently misattribute samples for callers doing channel-timeline attribution.</param>
     public async Task<List<ChannelChangeEvent>> GetChannelChangeEventsAsync(
         DateTimeOffset start,
         DateTimeOffset end,
         string? apMac = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        bool throwOnFailure = false)
     {
         try
         {
@@ -285,6 +295,7 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
         }
         catch (Exception ex)
         {
+            if (throwOnFailure) throw;
             _logger.LogWarning(ex, "Failed to fetch channel change events");
             return new List<ChannelChangeEvent>();
         }

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -197,15 +197,20 @@ public class ChannelRecommendationService
     private const double CatastrophicAbsoluteScore = 4.0;
 
     /// <summary>
-    /// Measured airtime thresholds past which a freshly-changed channel counts as
-    /// catastrophically bad and the soak suppression is lifted. Anchored to the radio's own
-    /// time-averaged measurements (the comfort anchor's "genuinely usable" sits below 20%
-    /// external interference; 60%+ is a drowning channel; 40%+ TX retries means constant
-    /// collisions) - deliberately NOT the inferred score, which idle-neighbor external load
-    /// inflates past any absolute ceiling on dense bands. Tunable.
+    /// Measured EXTERNAL interference (other networks' airtime) past which a freshly-changed
+    /// channel counts as catastrophically bad and the soak suppression is lifted. Anchored to
+    /// the radio's own time-averaged interference - the same ground-truth channel-quality
+    /// signal the comfort anchor uses (comfortable sits below 20%; 70% means the channel is
+    /// dominated by other networks and is genuinely a disaster worth breaking soak for).
+    ///
+    /// Deliberately NOT the inferred score (idle-neighbor external load inflates it past any
+    /// absolute ceiling on dense bands, which would make soak a permanent no-op there), and
+    /// deliberately NOT utilization or TX retries: both are contaminated by the AP's OWN
+    /// serving traffic, which follows the radio to any channel, so a busy AP would keep
+    /// escaping soak no matter where it moved - the exact self-induced false positive this
+    /// feature exists to avoid. Tunable.
     /// </summary>
-    private const double CatastrophicInterferencePct = 60.0;
-    private const double CatastrophicTxRetryPct = 40.0;
+    private const double CatastrophicInterferencePct = 70.0;
 
     /// <summary>
     /// Minimum neighbor signal to count as external interference. Matches the CCA
@@ -1477,14 +1482,15 @@ public class ChannelRecommendationService
     }
 
     /// <summary>
-    /// Whether the AP's own measured (1d/7d) record for its current channel shows
-    /// catastrophic airtime - external interference or TX retries past the catastrophic
-    /// thresholds. This is the soak-escape signal, and it reads measured ground truth ONLY:
-    /// never <see cref="ApNode.PropagatedStress"/> or the inferred score, both of which
-    /// idle-neighbor load inflates (on a dense 2.4 GHz band every AP's score can sit far
-    /// above any absolute ceiling forever, which would make soak a permanent no-op there).
-    /// No averaged data for the new channel yet (e.g. within the first hour after a change)
-    /// means no escape - the soak is short, and rescue can wait for evidence.
+    /// Whether the AP's own measured (1d/7d) record for its current channel shows catastrophic
+    /// EXTERNAL interference - other networks' airtime past <see cref="CatastrophicInterferencePct"/>.
+    /// This is the soak-escape signal, and it reads measured ground truth ONLY: never
+    /// <see cref="ApNode.PropagatedStress"/> or the inferred score (idle-neighbor load inflates
+    /// both, so on a dense 2.4 GHz band every AP would sit above any absolute ceiling forever,
+    /// making soak a permanent no-op), and never utilization or TX retries (contaminated by the
+    /// AP's own serving traffic, which follows it to any channel). No averaged data for the new
+    /// channel yet (e.g. within the first hour after a change) means no escape - the soak is
+    /// short, and rescue can wait for evidence.
     /// </summary>
     private static bool IsCurrentChannelMeasurablySuffering(InterferenceGraph graph, RadioBand band, int apIndex)
     {
@@ -1496,8 +1502,7 @@ public class ChannelRecommendationService
         {
             var histSpan = ChannelSpanHelper.GetChannelSpan(band, histChannel, node.CurrentWidth);
             if (ChannelSpanHelper.SpansOverlap(currentSpan, histSpan))
-                return stress.Interference >= CatastrophicInterferencePct ||
-                       stress.TxRetryPct >= CatastrophicTxRetryPct;
+                return stress.Interference >= CatastrophicInterferencePct;
         }
         return false;
     }

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -304,7 +304,8 @@ public class ChannelRecommendationService
         List<ChannelScanResult>? scanResults,
         RegulatoryChannelData? regulatoryData,
         RecommendationOptions? options = null,
-        Dictionary<string, Dictionary<int, (double Utilization, double Interference, double TxRetryPct)>>? historicalStress = null)
+        Dictionary<string, Dictionary<int, (double Utilization, double Interference, double TxRetryPct)>>? historicalStress = null,
+        Dictionary<string, ChannelSoakInfo>? soakInfo = null)
     {
         var opts = options ?? new RecommendationOptions();
 
@@ -368,7 +369,8 @@ public class ChannelRecommendationService
                 ChannelUtilization = radio.ChannelUtilization ?? 0,
                 Interference = radio.Interference ?? 0,
                 TxRetriesPct = radio.TxRetriesPct ?? 0,
-                HistoricalStress = apHistStress
+                HistoricalStress = apHistStress,
+                SoakInfo = soakInfo?.GetValueOrDefault(macLower)
             });
 
             graph.ExternalLoad[i] = new Dictionary<int, double>();
@@ -478,6 +480,69 @@ public class ChannelRecommendationService
         var currentApScores = new double[n];
         for (int i = 0; i < n; i++)
             currentApScores[i] = ScoreAp(graph, currentAssignment, i, band);
+
+        // Soak-period suppression: an AP whose channel changed recently keeps the new config
+        // long enough to measure it, so channels the radio just left are removed from its
+        // candidate set - the search, per-AP fallback and altruistic passes all iterate
+        // ValidChannels, so one filter covers every move-decision path. Applies to every band.
+        // A mesh group moves as one (children mirror the leader's channel), so the LEADER's
+        // candidates are gated by the union of the whole group's soaked channels - otherwise
+        // the child-sync at the end would hop a soaking child straight back onto the channel
+        // it just left. A genuinely suffering group (any member's current score at the
+        // catastrophic ceiling) is exempt: soak prevents churn, not rescue. The current
+        // channel is never filtered, so the invalid-channel handling below is unaffected.
+        var soakRemoved = new List<int>?[n];
+        var soakEnds = new DateTimeOffset?[n];
+        for (int i = 0; i < n; i++)
+        {
+            var node = graph.Nodes[i];
+            // Children have no independent move decision - their soak is enforced on the leader.
+            if (node.MeshGroupLeader >= 0 && node.MeshGroupLeader != i) continue;
+
+            var soaked = new HashSet<int>(node.SoakInfo?.SoakedChannels ?? Enumerable.Empty<int>());
+            var soakEnd = node.SoakInfo?.SoakEndsAt ?? DateTimeOffset.MinValue;
+            var worstGroupScore = currentApScores[i];
+            for (int j = 0; j < n; j++)
+            {
+                if (j == i || graph.Nodes[j].MeshGroupLeader != i) continue;
+                if (graph.Nodes[j].SoakInfo is { } childSoak)
+                {
+                    soaked.UnionWith(childSoak.SoakedChannels);
+                    if (childSoak.SoakEndsAt > soakEnd) soakEnd = childSoak.SoakEndsAt;
+                }
+                worstGroupScore = Math.Max(worstGroupScore, currentApScores[j]);
+            }
+            if (soaked.Count == 0) continue;
+
+            if (worstGroupScore >= CatastrophicAbsoluteScore)
+            {
+                _logger.LogDebug(
+                    "[ChannelRec] {ApName} {Band}: soak suppression lifted - current score {Score:F3} " +
+                    "in the mesh group is at the catastrophic ceiling, all channels stay in play",
+                    node.Name, band, worstGroupScore);
+                continue;
+            }
+
+            var filtered = node.ValidChannels
+                .Where(ch => ch == node.CurrentChannel || !soaked.Contains(ch))
+                .ToArray();
+            if (filtered.Length == node.ValidChannels.Length) continue;
+            // An AP stuck on an invalid channel must move SOMEWHERE - if soak would empty its
+            // candidate set (current channel not valid, every valid channel recently left),
+            // leave the set alone rather than strand the search.
+            if (filtered.Length == 0) continue;
+
+            // Report only what was actually removed - a channel excluded for another reason
+            // (e.g. the user's DFS setting) must not be presented as merely soaking.
+            var removed = node.ValidChannels.Except(filtered).OrderBy(ch => ch).ToList();
+            _logger.LogDebug(
+                "[ChannelRec] {ApName} {Band}: soaking until {SoakEnd:MM/dd HH:mm} - excluding " +
+                "recently-left channel(s) [{Channels}] from candidates",
+                node.Name, band, soakEnd, string.Join(", ", removed));
+            node.ValidChannels = filtered;
+            soakRemoved[i] = removed;
+            soakEnds[i] = soakEnd;
+        }
 
         // Optimize
         (int Channel, int Width)[] bestAssignment;
@@ -611,7 +676,9 @@ public class ChannelRecommendationService
                 // Recommended DFS status is authoritatively recomputed against the final channel
                 // after reconciliation (the per-AP fallback, altruistic relocation and mesh sync
                 // can all rewrite the channel below). This initial value is the optimizer's raw pick.
-                IsRecommendedDfsChannel = IsDfsAssignment(band, recommendedChannel, recommendedWidth, graph.DfsChannels)
+                IsRecommendedDfsChannel = IsDfsAssignment(band, recommendedChannel, recommendedWidth, graph.DfsChannels),
+                SoakSuppressedChannels = soakRemoved[i] ?? new List<int>(),
+                SoakEndsAt = soakEnds[i]
             });
         }
 

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -197,6 +197,17 @@ public class ChannelRecommendationService
     private const double CatastrophicAbsoluteScore = 4.0;
 
     /// <summary>
+    /// Measured airtime thresholds past which a freshly-changed channel counts as
+    /// catastrophically bad and the soak suppression is lifted. Anchored to the radio's own
+    /// time-averaged measurements (the comfort anchor's "genuinely usable" sits below 20%
+    /// external interference; 60%+ is a drowning channel; 40%+ TX retries means constant
+    /// collisions) - deliberately NOT the inferred score, which idle-neighbor external load
+    /// inflates past any absolute ceiling on dense bands. Tunable.
+    /// </summary>
+    private const double CatastrophicInterferencePct = 60.0;
+    private const double CatastrophicTxRetryPct = 40.0;
+
+    /// <summary>
     /// Minimum neighbor signal to count as external interference. Matches the CCA
     /// (Clear Channel Assessment) threshold: below -82 dBm, radios don't defer
     /// transmission so the neighbor causes no real co-channel interference.
@@ -499,9 +510,13 @@ public class ChannelRecommendationService
         // A mesh group moves as one (children mirror the leader's channel), so the LEADER's
         // candidates are gated by the union of the whole group's soaked channels - otherwise
         // the child-sync at the end would hop a soaking child straight back onto the channel
-        // it just left. A genuinely suffering group (any member's current score at the
-        // catastrophic ceiling) is exempt: soak prevents churn, not rescue. The current
-        // channel is never filtered, so the invalid-channel handling below is unaffected.
+        // it just left. A group that is MEASURABLY suffering on the new channel (any member's
+        // measured airtime past the catastrophic thresholds) is exempt: soak prevents churn,
+        // not rescue. The escape deliberately requires the radio's own measured stress rather
+        // than the inferred score - on a dense band the score is inflated by idle-neighbor
+        // external load and can sit permanently above any absolute ceiling, which would make
+        // soak a no-op exactly where it matters most. The current channel is never filtered,
+        // so the invalid-channel handling below is unaffected.
         var soakRemoved = new List<int>?[n];
         var soakEnds = new DateTimeOffset?[n];
         for (int i = 0; i < n; i++)
@@ -512,7 +527,7 @@ public class ChannelRecommendationService
 
             var soaked = new HashSet<int>(node.SoakInfo?.SoakedChannels ?? Enumerable.Empty<int>());
             var soakEnd = node.SoakInfo?.SoakEndsAt ?? DateTimeOffset.MinValue;
-            var worstGroupScore = currentApScores[i];
+            var sufferingIndex = IsCurrentChannelMeasurablySuffering(graph, band, i) ? i : -1;
             for (int j = 0; j < n; j++)
             {
                 if (j == i || graph.Nodes[j].MeshGroupLeader != i) continue;
@@ -521,16 +536,17 @@ public class ChannelRecommendationService
                     soaked.UnionWith(childSoak.SoakedChannels);
                     if (childSoak.SoakEndsAt > soakEnd) soakEnd = childSoak.SoakEndsAt;
                 }
-                worstGroupScore = Math.Max(worstGroupScore, currentApScores[j]);
+                if (sufferingIndex < 0 && IsCurrentChannelMeasurablySuffering(graph, band, j))
+                    sufferingIndex = j;
             }
             if (soaked.Count == 0) continue;
 
-            if (worstGroupScore >= CatastrophicAbsoluteScore)
+            if (sufferingIndex >= 0)
             {
                 _logger.LogDebug(
-                    "[ChannelRec] {ApName} {Band}: soak suppression lifted - current score {Score:F3} " +
-                    "in the mesh group is at the catastrophic ceiling, all channels stay in play",
-                    node.Name, band, worstGroupScore);
+                    "[ChannelRec] {ApName} {Band}: soak suppression lifted - {SufferingAp} measures " +
+                    "catastrophic airtime on its current channel, all channels stay in play",
+                    node.Name, band, graph.Nodes[sufferingIndex].Name);
                 continue;
             }
 
@@ -1456,6 +1472,32 @@ public class ChannelRecommendationService
             var histSpan = ChannelSpanHelper.GetChannelSpan(band, histChannel, node.CurrentWidth);
             if (ChannelSpanHelper.SpansOverlap(currentSpan, histSpan))
                 return stress.Interference < ComfortableInterferencePct;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Whether the AP's own measured (1d/7d) record for its current channel shows
+    /// catastrophic airtime - external interference or TX retries past the catastrophic
+    /// thresholds. This is the soak-escape signal, and it reads measured ground truth ONLY:
+    /// never <see cref="ApNode.PropagatedStress"/> or the inferred score, both of which
+    /// idle-neighbor load inflates (on a dense 2.4 GHz band every AP's score can sit far
+    /// above any absolute ceiling forever, which would make soak a permanent no-op there).
+    /// No averaged data for the new channel yet (e.g. within the first hour after a change)
+    /// means no escape - the soak is short, and rescue can wait for evidence.
+    /// </summary>
+    private static bool IsCurrentChannelMeasurablySuffering(InterferenceGraph graph, RadioBand band, int apIndex)
+    {
+        var node = graph.Nodes[apIndex];
+        if (node.HistoricalStress == null || node.HistoricalStress.Count == 0) return false;
+
+        var currentSpan = ChannelSpanHelper.GetChannelSpan(band, node.CurrentChannel, node.CurrentWidth);
+        foreach (var (histChannel, stress) in node.HistoricalStress)
+        {
+            var histSpan = ChannelSpanHelper.GetChannelSpan(band, histChannel, node.CurrentWidth);
+            if (ChannelSpanHelper.SpansOverlap(currentSpan, histSpan))
+                return stress.Interference >= CatastrophicInterferencePct ||
+                       stress.TxRetryPct >= CatastrophicTxRetryPct;
         }
         return false;
     }

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -259,6 +259,15 @@ public class ChannelRecommendationService
     private const double ScanCoverageConfidence = 0.80;
 
     /// <summary>
+    /// Observation confidence for a candidate channel this radio saw a neighbor on via the
+    /// long-term neighbor memory (a remembered sighting, not a live scan). Real evidence the
+    /// radio itself gathered, but dated - the neighborhood may have changed since - so it
+    /// ranks below every live tier. Scaled by the sighting's age-decayed confidence, so a
+    /// week-old memory softens the uncertainty penalty more than a month-old one. Tunable.
+    /// </summary>
+    private const double RememberedSightingConfidence = 0.6;
+
+    /// <summary>
     /// Minimum internal (propagation) weight for a resident sibling AP to count as an observer
     /// of a channel. Below this the sibling is too far to characterize this AP's RF environment.
     /// </summary>
@@ -323,6 +332,7 @@ public class ChannelRecommendationService
             ExternalLoad = new Dictionary<int, double>[n],
             ExternalNeighbors = new Dictionary<(int Channel, int Width), double>[n],
             DirectlyObservedChannels = new HashSet<int>[n],
+            HistoricallyObservedChannels = new Dictionary<int, double>[n],
             ScanChannelData = new Dictionary<(int Channel, int Width), (int Utilization, int? NoiseFloor)>[n],
             MeshConstraints = new List<MeshConstraint>(),
             DfsChannels = new HashSet<int>(regulatoryData?.DfsChannels ?? [])
@@ -376,6 +386,7 @@ public class ChannelRecommendationService
             graph.ExternalLoad[i] = new Dictionary<int, double>();
             graph.ExternalNeighbors[i] = new Dictionary<(int Channel, int Width), double>();
             graph.DirectlyObservedChannels[i] = new HashSet<int>();
+            graph.HistoricallyObservedChannels[i] = new Dictionary<int, double>();
             graph.ScanChannelData[i] = new Dictionary<(int, int), (int, int?)>();
         }
 
@@ -1646,6 +1657,20 @@ public class ChannelRecommendationService
         if (graph.ScanChannelData[apIndex].Keys.Any(k => ChannelSpanHelper.SpansOverlap(apSpan, (k.Channel, k.Channel))))
             confidence = Math.Max(confidence, ScanCoverageConfidence);
 
+        // Remembered neighbor sighting: this radio itself saw the channel's neighborhood within
+        // the memory window - real evidence, decayed for age, at a reduced tier. Without this,
+        // remembered neighbors would paradoxically make a remembered channel score WORSE than a
+        // truly blind one (their load counts, plus the full uncertainty tax on top).
+        if (apIndex < graph.HistoricallyObservedChannels.Length &&
+            graph.HistoricallyObservedChannels[apIndex] is { Count: > 0 } histSightings)
+        {
+            foreach (var (histCh, sightingConf) in histSightings)
+            {
+                if (ChannelSpanHelper.SpansOverlap(apSpan, (histCh, histCh)))
+                    confidence = Math.Max(confidence, RememberedSightingConfidence * sightingConf);
+            }
+        }
+
         // Historic occupancy: we have measured airtime for this AP on an overlapping channel.
         if (node.HistoricalStress != null)
         {
@@ -1945,8 +1970,10 @@ public class ChannelRecommendationService
             macToIndex[bandAps[i].Mac] = i;
 
         // Phase 1: Pool all neighbor sightings by BSSID across all observers
-        // Each entry: (observerIndex, channel, width, signal)
-        var allNeighbors = new Dictionary<string, List<(int ObserverIndex, int Channel, int? Width, int Signal)>>(
+        // Each entry: (observerIndex, channel, width, signal, confidence). Confidence is 1.0
+        // for live scan sightings; remembered (long-term memory) sightings carry an
+        // age-decayed confidence that scales their weight down.
+        var allNeighbors = new Dictionary<string, List<(int ObserverIndex, int Channel, int? Width, int Signal, double Confidence)>>(
             StringComparer.OrdinalIgnoreCase);
 
         foreach (var scan in scanResults.Where(s => s.Band == band))
@@ -1960,10 +1987,10 @@ public class ChannelRecommendationService
             {
                 if (!allNeighbors.TryGetValue(neighbor.Bssid, out var sightings))
                 {
-                    sightings = new List<(int, int, int?, int)>();
+                    sightings = new List<(int, int, int?, int, double)>();
                     allNeighbors[neighbor.Bssid] = sightings;
                 }
-                sightings.Add((observerIndex, neighbor.Channel, neighbor.Width, neighbor.Signal!.Value));
+                sightings.Add((observerIndex, neighbor.Channel, neighbor.Width, neighbor.Signal!.Value, neighbor.Confidence));
             }
         }
 
@@ -1981,10 +2008,11 @@ public class ChannelRecommendationService
                 bool isDirect = false;
                 int bestObserverIndex = -1;
                 double bestProximity = 0;
+                double bestConfidence = 1.0;
 
-                foreach (var (observerIndex, channel, width, signal) in sightings)
+                foreach (var (observerIndex, channel, width, signal, confidence) in sightings)
                 {
-                    var neighborWeight = ChannelSpanHelper.SignalToInterferenceWeight(signal);
+                    var neighborWeight = ChannelSpanHelper.SignalToInterferenceWeight(signal) * confidence;
                     double effectiveWeight;
                     double proximity = 0;
 
@@ -2013,6 +2041,7 @@ public class ChannelRecommendationService
                         isDirect = observerIndex == j;
                         bestObserverIndex = observerIndex;
                         bestProximity = proximity;
+                        bestConfidence = confidence;
                     }
                 }
 
@@ -2041,7 +2070,18 @@ public class ChannelRecommendationService
                 if (isDirect)
                 {
                     directCount++;
-                    graph.DirectlyObservedChannels[j].Add(bestChannel);
+                    // Only a LIVE direct sighting fully observes the channel; a remembered one
+                    // is real-but-dated evidence and lands in the reduced-confidence tier.
+                    if (bestConfidence >= 1.0)
+                    {
+                        graph.DirectlyObservedChannels[j].Add(bestChannel);
+                    }
+                    else if (j < graph.HistoricallyObservedChannels.Length &&
+                             graph.HistoricallyObservedChannels[j] is { } histObserved)
+                    {
+                        histObserved[bestChannel] = Math.Max(
+                            histObserved.GetValueOrDefault(bestChannel), bestConfidence);
+                    }
                 }
                 else
                 {

--- a/tests/NetworkOptimizer.Storage.Tests/ChannelMemoryRepositoryTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/ChannelMemoryRepositoryTests.cs
@@ -122,7 +122,7 @@ public class ChannelMemoryRepositoryTests : IDisposable
             Sample(DateTime.UtcNow.AddDays(-1), channel: 6)
         });
 
-        await _repository.PruneAsync(retentionDays: 365);
+        await _repository.PruneAsync(retentionDays: 365, neighborRetentionDays: 60);
 
         var outcomes = await _repository.GetOutcomesSinceAsync(DateTime.UtcNow.AddDays(-500));
         outcomes.Should().HaveCount(1);
@@ -153,6 +153,63 @@ public class ChannelMemoryRepositoryTests : IDisposable
             .Which.SampleCount.Should().Be(2);
         (await _repository.GetChangesSinceAsync(DateTime.MinValue)).Should().ContainSingle();
         (await _repository.GetCollectionWatermarkAsync()).Should().Be(watermark);
+    }
+
+    private static NeighborSightingSample Sighting(
+        DateTime seenAt, string bssid = "11:22:33:44:55:66", int channel = 6,
+        string mac = "aa:bb:cc:dd:ee:01", string band = "ng",
+        int width = 20, int signal = -70, string? ssid = "Net") =>
+        new(mac, band, bssid, channel, width, signal, seenAt, ssid);
+
+    [Fact]
+    public async Task UpsertNeighborSightings_CreatesThenUpdatesRow()
+    {
+        var day1 = new DateTime(2026, 6, 20, 12, 0, 0, DateTimeKind.Utc);
+        var day2 = day1.AddDays(2);
+
+        await _repository.UpsertNeighborSightingsAsync(new[] { Sighting(day1, signal: -70) });
+        // Later, weaker sighting: LastSeen advances, signal keeps the strongest observed.
+        await _repository.UpsertNeighborSightingsAsync(new[] { Sighting(day2, signal: -78, width: 40) });
+
+        var rows = await _repository.GetNeighborSightingsSinceAsync(DateTime.MinValue);
+        var row = rows.Should().ContainSingle().Which;
+        row.FirstSeenUtc.Should().Be(day1);
+        row.LastSeenUtc.Should().Be(day2);
+        row.SignalDbm.Should().Be(-70, "the strongest observed signal is kept");
+        row.WidthMhz.Should().Be(40, "width follows the newest sighting");
+    }
+
+    [Fact]
+    public async Task UpsertNeighborSightings_SplitsRowsByChannel_AndDedupsWithinBatch()
+    {
+        var seen = new DateTime(2026, 6, 20, 12, 0, 0, DateTimeKind.Utc);
+
+        // Same key twice in one batch (must not violate the unique index) plus a second channel.
+        await _repository.UpsertNeighborSightingsAsync(new[]
+        {
+            Sighting(seen, channel: 6, signal: -75),
+            Sighting(seen.AddHours(1), channel: 6, signal: -68),
+            Sighting(seen, channel: 11)
+        });
+
+        var rows = await _repository.GetNeighborSightingsSinceAsync(DateTime.MinValue);
+        rows.Should().HaveCount(2);
+        rows.Single(r => r.Channel == 6).SignalDbm.Should().Be(-68);
+    }
+
+    [Fact]
+    public async Task Prune_RemovesSightingsUnseenPastRetention()
+    {
+        await _repository.UpsertNeighborSightingsAsync(new[]
+        {
+            Sighting(DateTime.UtcNow.AddDays(-90), bssid: "11:22:33:44:55:66"),
+            Sighting(DateTime.UtcNow.AddDays(-5), bssid: "22:33:44:55:66:77")
+        });
+
+        await _repository.PruneAsync(retentionDays: 365, neighborRetentionDays: 60);
+
+        var rows = await _repository.GetNeighborSightingsSinceAsync(DateTime.MinValue);
+        rows.Should().ContainSingle().Which.Bssid.Should().Be("22:33:44:55:66:77");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Storage.Tests/ChannelMemoryRepositoryTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/ChannelMemoryRepositoryTests.cs
@@ -177,6 +177,7 @@ public class ChannelMemoryRepositoryTests : IDisposable
         row.LastSeenUtc.Should().Be(day2);
         row.SignalDbm.Should().Be(-70, "the strongest observed signal is kept");
         row.WidthMhz.Should().Be(40, "width follows the newest sighting");
+        row.SightingCount.Should().Be(2, "each upsert cycle increments the count once");
     }
 
     [Fact]
@@ -194,7 +195,9 @@ public class ChannelMemoryRepositoryTests : IDisposable
 
         var rows = await _repository.GetNeighborSightingsSinceAsync(DateTime.MinValue);
         rows.Should().HaveCount(2);
-        rows.Single(r => r.Channel == 6).SignalDbm.Should().Be(-68);
+        var ch6 = rows.Single(r => r.Channel == 6);
+        ch6.SignalDbm.Should().Be(-68);
+        ch6.SightingCount.Should().Be(1, "two samples in one cycle count as a single sighting");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Storage.Tests/ChannelMemoryRepositoryTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/ChannelMemoryRepositoryTests.cs
@@ -1,0 +1,170 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NetworkOptimizer.Storage.Interfaces;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Storage.Repositories;
+using Xunit;
+
+namespace NetworkOptimizer.Storage.Tests;
+
+/// <summary>
+/// Uses SQLite in-memory (not the EF InMemory provider) because the repository relies on
+/// ExecuteDeleteAsync and grouped max-per-key queries that must translate to real SQL.
+/// </summary>
+public class ChannelMemoryRepositoryTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly ChannelMemoryRepository _repository;
+    private readonly IDbContextFactory<NetworkOptimizerDbContext> _factory;
+
+    public ChannelMemoryRepositoryTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<NetworkOptimizerDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+        _factory = new NetworkOptimizerDbContextFactory(options);
+
+        using var db = _factory.CreateDbContext();
+        db.Database.EnsureCreated();
+
+        var logger = new Mock<ILogger<ChannelMemoryRepository>>();
+        _repository = new ChannelMemoryRepository(_factory, logger.Object);
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+    }
+
+    private static ChannelOutcomeSample Sample(
+        DateTime timestamp, int channel = 6, string mac = "aa:bb:cc:dd:ee:01",
+        string band = "ng", int width = 20,
+        double util = 40, double interf = 30, double txRetry = 10) =>
+        new(mac, band, channel, width, timestamp, util, interf, txRetry);
+
+    [Fact]
+    public async Task AddOutcomeSamples_CreatesAndAccumulatesDailyBucket()
+    {
+        var day = new DateTime(2026, 6, 20, 0, 0, 0, DateTimeKind.Utc);
+
+        await _repository.AddOutcomeSamplesAsync(new[]
+        {
+            Sample(day.AddHours(1), util: 40, interf: 30, txRetry: 10),
+            Sample(day.AddHours(2), util: 60, interf: 50, txRetry: 20)
+        });
+        // Second call must accumulate into the same bucket, not create a duplicate
+        await _repository.AddOutcomeSamplesAsync(new[]
+        {
+            Sample(day.AddHours(3), util: 20, interf: 10, txRetry: 0)
+        });
+
+        var outcomes = await _repository.GetOutcomesSinceAsync(day.AddDays(-1));
+        outcomes.Should().HaveCount(1);
+        var bucket = outcomes[0];
+        bucket.SampleCount.Should().Be(3);
+        bucket.UtilizationSum.Should().BeApproximately(120, 0.001);
+        bucket.InterferenceSum.Should().BeApproximately(90, 0.001);
+        bucket.TxRetrySum.Should().BeApproximately(30, 0.001);
+        bucket.LastSampleUtc.Should().Be(day.AddHours(3));
+    }
+
+    [Fact]
+    public async Task AddOutcomeSamples_SplitsBucketsByDayChannelAndWidth()
+    {
+        var day = new DateTime(2026, 6, 20, 0, 0, 0, DateTimeKind.Utc);
+
+        await _repository.AddOutcomeSamplesAsync(new[]
+        {
+            Sample(day.AddHours(1), channel: 6, width: 20),
+            Sample(day.AddHours(2), channel: 1, width: 0),
+            Sample(day.AddDays(1).AddHours(1), channel: 6, width: 20)
+        });
+
+        var outcomes = await _repository.GetOutcomesSinceAsync(day.AddDays(-1));
+        outcomes.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task GetLatestConfigs_ReturnsNewestPerRadio()
+    {
+        await _repository.AddChangesAsync(new[]
+        {
+            new ApChannelChange { ApMac = "aa:bb:cc:dd:ee:01", Band = "ng", NewChannel = 1, ChangedAtUtc = DateTime.UtcNow.AddDays(-10), Source = ApChannelChangeSource.Initial },
+            new ApChannelChange { ApMac = "aa:bb:cc:dd:ee:01", Band = "ng", PreviousChannel = 1, NewChannel = 6, ChangedAtUtc = DateTime.UtcNow.AddDays(-2), Source = ApChannelChangeSource.UniFiEvent },
+            new ApChannelChange { ApMac = "aa:bb:cc:dd:ee:01", Band = "na", NewChannel = 36, ChangedAtUtc = DateTime.UtcNow.AddDays(-10), Source = ApChannelChangeSource.Initial }
+        });
+
+        var latest = await _repository.GetLatestConfigsAsync();
+
+        latest.Should().HaveCount(2);
+        latest.Single(c => c.Band == "ng").NewChannel.Should().Be(6);
+        latest.Single(c => c.Band == "na").NewChannel.Should().Be(36);
+    }
+
+    [Fact]
+    public async Task Prune_RemovesOldData_ButKeepsLatestChangePerRadio()
+    {
+        var old = DateTime.UtcNow.AddDays(-400);
+        await _repository.AddChangesAsync(new[]
+        {
+            new ApChannelChange { ApMac = "aa:bb:cc:dd:ee:01", Band = "ng", NewChannel = 1, ChangedAtUtc = old, Source = ApChannelChangeSource.Initial },
+            new ApChannelChange { ApMac = "aa:bb:cc:dd:ee:01", Band = "ng", PreviousChannel = 1, NewChannel = 6, ChangedAtUtc = old.AddDays(1), Source = ApChannelChangeSource.UniFiEvent }
+        });
+        await _repository.AddOutcomeSamplesAsync(new[]
+        {
+            Sample(old, channel: 1),
+            Sample(DateTime.UtcNow.AddDays(-1), channel: 6)
+        });
+
+        await _repository.PruneAsync(retentionDays: 365);
+
+        var outcomes = await _repository.GetOutcomesSinceAsync(DateTime.UtcNow.AddDays(-500));
+        outcomes.Should().HaveCount(1);
+        outcomes[0].Channel.Should().Be(6);
+
+        // The newest change survives as the last-known-config baseline even though it is
+        // past retention; the superseded one is gone.
+        var changes = await _repository.GetChangesSinceAsync(DateTime.MinValue);
+        changes.Should().HaveCount(1);
+        changes[0].NewChannel.Should().Be(6);
+    }
+
+    [Fact]
+    public async Task CommitCollection_PersistsSamplesChangesAndWatermarkTogether()
+    {
+        var day = new DateTime(2026, 6, 20, 0, 0, 0, DateTimeKind.Utc);
+        var watermark = new DateTime(2026, 6, 20, 6, 0, 0, DateTimeKind.Utc);
+
+        await _repository.CommitCollectionAsync(
+            new[] { Sample(day.AddHours(1)), Sample(day.AddHours(2)) },
+            new[]
+            {
+                new ApChannelChange { ApMac = "aa:bb:cc:dd:ee:01", Band = "ng", NewChannel = 6, ChangedAtUtc = day, Source = ApChannelChangeSource.Initial }
+            },
+            watermark);
+
+        (await _repository.GetOutcomesSinceAsync(day.AddDays(-1))).Should().ContainSingle()
+            .Which.SampleCount.Should().Be(2);
+        (await _repository.GetChangesSinceAsync(DateTime.MinValue)).Should().ContainSingle();
+        (await _repository.GetCollectionWatermarkAsync()).Should().Be(watermark);
+    }
+
+    [Fact]
+    public async Task CollectionWatermark_RoundTrips()
+    {
+        (await _repository.GetCollectionWatermarkAsync()).Should().BeNull();
+
+        var mark = new DateTime(2026, 6, 30, 18, 0, 0, DateTimeKind.Utc);
+        await _repository.SetCollectionWatermarkAsync(mark);
+        (await _repository.GetCollectionWatermarkAsync()).Should().Be(mark);
+
+        await _repository.SetCollectionWatermarkAsync(mark.AddHours(6));
+        (await _repository.GetCollectionWatermarkAsync()).Should().Be(mark.AddHours(6));
+    }
+}

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelMemoryHelperTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelMemoryHelperTests.cs
@@ -55,14 +55,15 @@ public class ChannelMemoryHelperTests
     [Fact]
     public void BuildSoakInfo_RecentChange_SoaksPreviousChannel()
     {
-        var events = new[] { Change(Now.AddDays(-2), from: 1, to: 6) };
+        var changedAt = Now - ChannelMemoryHelper.SoakPeriod / 2;
+        var events = new[] { Change(changedAt, from: 1, to: 6) };
 
         var soak = ChannelMemoryHelper.BuildSoakInfo(events, currentChannel: 6, Now);
 
         soak.Should().NotBeNull();
         soak!.SoakedChannels.Should().BeEquivalentTo(new[] { 1 });
-        soak.LastChangeAt.Should().Be(Now.AddDays(-2));
-        soak.SoakEndsAt.Should().Be(Now.AddDays(-2) + ChannelMemoryHelper.SoakPeriod);
+        soak.LastChangeAt.Should().Be(changedAt);
+        soak.SoakEndsAt.Should().Be(changedAt + ChannelMemoryHelper.SoakPeriod);
     }
 
     [Fact]
@@ -79,8 +80,8 @@ public class ChannelMemoryHelperTests
         // Hopped 6 -> 1 -> 6: channel 6 was "left" mid-window but the radio is back on it now.
         var events = new[]
         {
-            Change(Now.AddDays(-3), from: 6, to: 1),
-            Change(Now.AddDays(-1), from: 1, to: 6)
+            Change(Now - ChannelMemoryHelper.SoakPeriod * 0.75, from: 6, to: 1),
+            Change(Now - ChannelMemoryHelper.SoakPeriod * 0.25, from: 1, to: 6)
         };
 
         var soak = ChannelMemoryHelper.BuildSoakInfo(events, currentChannel: 6, Now);
@@ -95,8 +96,8 @@ public class ChannelMemoryHelperTests
         // The same change can arrive from both the UniFi system log and the persisted change log.
         var events = new[]
         {
-            Change(Now.AddDays(-2), from: 1, to: 6),
-            Change(Now.AddDays(-2), from: 1, to: 6)
+            Change(Now - ChannelMemoryHelper.SoakPeriod / 2, from: 1, to: 6),
+            Change(Now - ChannelMemoryHelper.SoakPeriod / 2, from: 1, to: 6)
         };
 
         var soak = ChannelMemoryHelper.BuildSoakInfo(events, currentChannel: 6, Now);
@@ -107,7 +108,7 @@ public class ChannelMemoryHelperTests
     [Fact]
     public void BuildSoakInfo_UnknownPreviousChannel_Ignored()
     {
-        var events = new[] { Change(Now.AddDays(-1), from: 0, to: 6) };
+        var events = new[] { Change(Now - ChannelMemoryHelper.SoakPeriod / 2, from: 0, to: 6) };
 
         ChannelMemoryHelper.BuildSoakInfo(events, currentChannel: 6, Now).Should().BeNull();
     }
@@ -235,5 +236,122 @@ public class ChannelMemoryHelperTests
     {
         ChannelMemoryHelper.MergeLongTermOutcomes(null, Array.Empty<ChannelOutcomeBucket>(), 20, Now)
             .Should().BeNull();
+    }
+
+    // --- MergeRememberedNeighbors ---
+
+    private static ChannelScanResult Scan(
+        string apMac, params NeighborNetwork[] neighbors) => new()
+    {
+        ApMac = apMac,
+        Band = RadioBand.Band2_4GHz,
+        ScanTime = Now,
+        Neighbors = neighbors.ToList()
+    };
+
+    private static NeighborNetwork LiveNeighbor(string bssid, int channel, int signal = -70) => new()
+    {
+        Bssid = bssid,
+        Channel = channel,
+        Signal = signal
+    };
+
+    private static RememberedNeighborSighting Remembered(
+        string apMac, string bssid, int channel, DateTimeOffset lastSeen, int signal = -65) => new(
+            apMac, RadioBand.Band2_4GHz, bssid, channel, WidthMhz: 20, signal, lastSeen, Ssid: "Net");
+
+    [Fact]
+    public void MergeRememberedNeighbors_AddsUnseenNeighbor_WithDecayedConfidence()
+    {
+        var scans = new List<ChannelScanResult> { Scan("aa:bb:cc:dd:ee:01") };
+        var remembered = new[]
+        {
+            Remembered("aa:bb:cc:dd:ee:01", "11:22:33:44:55:66", channel: 11,
+                lastSeen: Now - ChannelMemoryHelper.NeighborHalfLife)
+        };
+
+        var merged = ChannelMemoryHelper.MergeRememberedNeighbors(scans, remembered, Now);
+
+        var nb = merged.Single().Neighbors.Single();
+        nb.Bssid.Should().Be("11:22:33:44:55:66");
+        nb.Channel.Should().Be(11);
+        nb.Confidence.Should().BeApproximately(0.5, 0.001, "one half-life halves the confidence");
+        scans[0].Neighbors.Should().BeEmpty("the input scan must not be mutated");
+    }
+
+    [Fact]
+    public void MergeRememberedNeighbors_FullyAgedSighting_Dropped()
+    {
+        var scans = new List<ChannelScanResult> { Scan("aa:bb:cc:dd:ee:01") };
+        var remembered = new[]
+        {
+            Remembered("aa:bb:cc:dd:ee:01", "11:22:33:44:55:66", channel: 11,
+                lastSeen: Now - ChannelMemoryHelper.NeighborMemoryWindow - TimeSpan.FromDays(1))
+        };
+
+        var merged = ChannelMemoryHelper.MergeRememberedNeighbors(scans, remembered, Now);
+
+        merged.Single().Neighbors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MergeRememberedNeighbors_BssidLiveOnDifferentChannel_Suppressed()
+    {
+        // Another AP currently sees the BSSID on ch1 - it moved, so the remembered ch11 row
+        // is obsolete for everyone.
+        var scans = new List<ChannelScanResult>
+        {
+            Scan("aa:bb:cc:dd:ee:01"),
+            Scan("aa:bb:cc:dd:ee:02", LiveNeighbor("11:22:33:44:55:66", channel: 1))
+        };
+        var remembered = new[]
+        {
+            Remembered("aa:bb:cc:dd:ee:01", "11:22:33:44:55:66", channel: 11, lastSeen: Now.AddDays(-2))
+        };
+
+        var merged = ChannelMemoryHelper.MergeRememberedNeighbors(scans, remembered, Now);
+
+        merged[0].Neighbors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MergeRememberedNeighbors_BssidLiveOnSameChannel_KeptForOtherObserver()
+    {
+        // AP2 sees the neighbor live on ch6; AP1 can't currently hear it but remembers it on
+        // the same channel - AP1's own vantage is kept (triangulation would understate it),
+        // while a remembered sighting for AP2 itself is suppressed (its live sighting wins).
+        var scans = new List<ChannelScanResult>
+        {
+            Scan("aa:bb:cc:dd:ee:01"),
+            Scan("aa:bb:cc:dd:ee:02", LiveNeighbor("11:22:33:44:55:66", channel: 6))
+        };
+        var remembered = new[]
+        {
+            Remembered("aa:bb:cc:dd:ee:01", "11:22:33:44:55:66", channel: 6, lastSeen: Now.AddDays(-2)),
+            Remembered("aa:bb:cc:dd:ee:02", "11:22:33:44:55:66", channel: 6, lastSeen: Now.AddDays(-2))
+        };
+
+        var merged = ChannelMemoryHelper.MergeRememberedNeighbors(scans, remembered, Now);
+
+        merged[0].Neighbors.Should().ContainSingle()
+            .Which.Confidence.Should().BeLessThan(1.0);
+        merged[1].Neighbors.Should().ContainSingle("only the live sighting remains")
+            .Which.Confidence.Should().Be(1.0);
+    }
+
+    [Fact]
+    public void MergeRememberedNeighbors_NoScanEntryForRadio_SightingIgnored()
+    {
+        // No synthetic scan entries: the engine must not believe it has scan data it doesn't.
+        var scans = new List<ChannelScanResult> { Scan("aa:bb:cc:dd:ee:01") };
+        var remembered = new[]
+        {
+            Remembered("aa:bb:cc:dd:ee:99", "11:22:33:44:55:66", channel: 6, lastSeen: Now.AddDays(-1))
+        };
+
+        var merged = ChannelMemoryHelper.MergeRememberedNeighbors(scans, remembered, Now);
+
+        merged.Should().HaveCount(1);
+        merged[0].Neighbors.Should().BeEmpty();
     }
 }

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelMemoryHelperTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelMemoryHelperTests.cs
@@ -1,0 +1,239 @@
+using FluentAssertions;
+using NetworkOptimizer.WiFi.Helpers;
+using NetworkOptimizer.WiFi.Models;
+using Xunit;
+
+namespace NetworkOptimizer.WiFi.Tests;
+
+public class ChannelMemoryHelperTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 7, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private static ChannelChangeEvent Change(DateTimeOffset at, int from, int to) => new()
+    {
+        Timestamp = at,
+        ApMac = "aa:bb:cc:dd:ee:01",
+        Band = RadioBand.Band2_4GHz,
+        PreviousChannel = from,
+        NewChannel = to
+    };
+
+    // --- GetChannelAtTime ---
+
+    [Fact]
+    public void GetChannelAtTime_NoEvents_ReturnsCurrentChannel()
+    {
+        var channel = ChannelMemoryHelper.GetChannelAtTime(Now, new List<ChannelChangeEvent>(), 6);
+        channel.Should().Be(6);
+    }
+
+    [Fact]
+    public void GetChannelAtTime_BeforeFirstEvent_ReturnsFirstEventPreviousChannel()
+    {
+        var events = new List<ChannelChangeEvent> { Change(Now.AddDays(-1), from: 1, to: 6) };
+
+        var channel = ChannelMemoryHelper.GetChannelAtTime(Now.AddDays(-2), events, 6);
+
+        channel.Should().Be(1);
+    }
+
+    [Fact]
+    public void GetChannelAtTime_BetweenEvents_ReturnsChannelLiveAtThatTime()
+    {
+        var events = new List<ChannelChangeEvent>
+        {
+            Change(Now.AddDays(-5), from: 1, to: 6),
+            Change(Now.AddDays(-2), from: 6, to: 11)
+        };
+
+        ChannelMemoryHelper.GetChannelAtTime(Now.AddDays(-3), events, 11).Should().Be(6);
+        ChannelMemoryHelper.GetChannelAtTime(Now.AddDays(-1), events, 11).Should().Be(11);
+    }
+
+    // --- BuildSoakInfo ---
+
+    [Fact]
+    public void BuildSoakInfo_RecentChange_SoaksPreviousChannel()
+    {
+        var events = new[] { Change(Now.AddDays(-2), from: 1, to: 6) };
+
+        var soak = ChannelMemoryHelper.BuildSoakInfo(events, currentChannel: 6, Now);
+
+        soak.Should().NotBeNull();
+        soak!.SoakedChannels.Should().BeEquivalentTo(new[] { 1 });
+        soak.LastChangeAt.Should().Be(Now.AddDays(-2));
+        soak.SoakEndsAt.Should().Be(Now.AddDays(-2) + ChannelMemoryHelper.SoakPeriod);
+    }
+
+    [Fact]
+    public void BuildSoakInfo_ChangeOlderThanSoakPeriod_ReturnsNull()
+    {
+        var events = new[] { Change(Now - ChannelMemoryHelper.SoakPeriod - TimeSpan.FromHours(1), from: 1, to: 6) };
+
+        ChannelMemoryHelper.BuildSoakInfo(events, currentChannel: 6, Now).Should().BeNull();
+    }
+
+    [Fact]
+    public void BuildSoakInfo_PreviousChannelIsCurrentAgain_NotSoaked()
+    {
+        // Hopped 6 -> 1 -> 6: channel 6 was "left" mid-window but the radio is back on it now.
+        var events = new[]
+        {
+            Change(Now.AddDays(-3), from: 6, to: 1),
+            Change(Now.AddDays(-1), from: 1, to: 6)
+        };
+
+        var soak = ChannelMemoryHelper.BuildSoakInfo(events, currentChannel: 6, Now);
+
+        soak.Should().NotBeNull();
+        soak!.SoakedChannels.Should().BeEquivalentTo(new[] { 1 });
+    }
+
+    [Fact]
+    public void BuildSoakInfo_DuplicateEventsFromTwoSources_Tolerated()
+    {
+        // The same change can arrive from both the UniFi system log and the persisted change log.
+        var events = new[]
+        {
+            Change(Now.AddDays(-2), from: 1, to: 6),
+            Change(Now.AddDays(-2), from: 1, to: 6)
+        };
+
+        var soak = ChannelMemoryHelper.BuildSoakInfo(events, currentChannel: 6, Now);
+
+        soak!.SoakedChannels.Should().BeEquivalentTo(new[] { 1 });
+    }
+
+    [Fact]
+    public void BuildSoakInfo_UnknownPreviousChannel_Ignored()
+    {
+        var events = new[] { Change(Now.AddDays(-1), from: 0, to: 6) };
+
+        ChannelMemoryHelper.BuildSoakInfo(events, currentChannel: 6, Now).Should().BeNull();
+    }
+
+    // --- MergeLongTermOutcomes ---
+
+    private static ChannelOutcomeBucket Bucket(
+        int channel, int width, int samples, double util, double interf, double txRetry,
+        DateTimeOffset? lastSampleAt = null) => new(
+            channel, width,
+            UtilizationSum: util * samples,
+            InterferenceSum: interf * samples,
+            TxRetrySum: txRetry * samples,
+            SampleCount: samples,
+            LastSampleAt: lastSampleAt ?? Now.AddDays(-10));
+
+    [Fact]
+    public void MergeLongTermOutcomes_FillsChannelMissingFromRecent()
+    {
+        var recent = new Dictionary<int, (double, double, double)> { [6] = (30, 20, 10) };
+        var buckets = new[] { Bucket(1, 20, samples: 24, util: 50, interf: 40, txRetry: 15) };
+
+        var merged = ChannelMemoryHelper.MergeLongTermOutcomes(recent, buckets, currentWidthMhz: 20, Now);
+
+        merged.Should().NotBeNull();
+        merged![6].Should().Be((30d, 20d, 10d));
+        // Decay scales weight and sums equally, so a single bucket's averages are unchanged
+        merged[1].Utilization.Should().BeApproximately(50, 0.001);
+        merged[1].Interference.Should().BeApproximately(40, 0.001);
+        merged[1].TxRetryPct.Should().BeApproximately(15, 0.001);
+    }
+
+    [Fact]
+    public void MergeLongTermOutcomes_RecentDataWins()
+    {
+        var recent = new Dictionary<int, (double, double, double)> { [1] = (10, 10, 10) };
+        var buckets = new[] { Bucket(1, 20, samples: 100, util: 90, interf: 90, txRetry: 90) };
+
+        var merged = ChannelMemoryHelper.MergeLongTermOutcomes(recent, buckets, currentWidthMhz: 20, Now);
+
+        merged![1].Should().Be((10d, 10d, 10d));
+    }
+
+    [Fact]
+    public void MergeLongTermOutcomes_BelowMinSamples_Ignored()
+    {
+        var buckets = new[] { Bucket(1, 20, samples: ChannelMemoryHelper.MinLongTermSamples - 1, util: 50, interf: 40, txRetry: 15) };
+
+        var merged = ChannelMemoryHelper.MergeLongTermOutcomes(null, buckets, currentWidthMhz: 20, Now);
+
+        merged.Should().BeNull();
+    }
+
+    [Fact]
+    public void MergeLongTermOutcomes_OtherWidthExcluded_UnknownWidthIncluded()
+    {
+        var buckets = new[]
+        {
+            Bucket(1, 40, samples: 100, util: 90, interf: 90, txRetry: 90),
+            Bucket(11, 0, samples: 24, util: 30, interf: 20, txRetry: 5)
+        };
+
+        var merged = ChannelMemoryHelper.MergeLongTermOutcomes(null, buckets, currentWidthMhz: 20, Now);
+
+        merged.Should().NotBeNull();
+        merged!.Should().NotContainKey(1);
+        merged.Should().ContainKey(11);
+    }
+
+    [Fact]
+    public void MergeLongTermOutcomes_MultipleBuckets_WeightedAverage()
+    {
+        var buckets = new[]
+        {
+            Bucket(1, 20, samples: 10, util: 20, interf: 10, txRetry: 0),
+            Bucket(1, 20, samples: 30, util: 60, interf: 50, txRetry: 20)
+        };
+
+        var merged = ChannelMemoryHelper.MergeLongTermOutcomes(null, buckets, currentWidthMhz: 20, Now);
+
+        // Same age, so decay cancels: (20*10 + 60*30) / 40 = 50; (10*10 + 50*30) / 40 = 40;
+        // (0*10 + 20*30) / 40 = 15
+        merged![1].Utilization.Should().BeApproximately(50, 0.001);
+        merged[1].Interference.Should().BeApproximately(40, 0.001);
+        merged[1].TxRetryPct.Should().BeApproximately(15, 0.001);
+    }
+
+    [Fact]
+    public void MergeLongTermOutcomes_HalfLifeDecay_TiltsAverageTowardNewerEvidence()
+    {
+        // Equal sample counts, one bucket exactly one half-life older: its weight is halved,
+        // so the average lands at (30*1.0 + 90*0.5) / 1.5 = 50, not the flat midpoint 60.
+        var buckets = new[]
+        {
+            Bucket(1, 20, samples: 24, util: 30, interf: 30, txRetry: 30, lastSampleAt: Now),
+            Bucket(1, 20, samples: 24, util: 90, interf: 90, txRetry: 90,
+                lastSampleAt: Now - ChannelMemoryHelper.OutcomeHalfLife)
+        };
+
+        var merged = ChannelMemoryHelper.MergeLongTermOutcomes(null, buckets, currentWidthMhz: 20, Now);
+
+        merged![1].Utilization.Should().BeApproximately(50, 0.001);
+        merged[1].Interference.Should().BeApproximately(50, 0.001);
+        merged[1].TxRetryPct.Should().BeApproximately(50, 0.001);
+    }
+
+    [Fact]
+    public void MergeLongTermOutcomes_FullyAgedEvidence_RevertsToUnknown()
+    {
+        // A day's worth of samples from ~three half-lives ago decays to ~3 effective samples,
+        // below the minimum gate - stale memory must not speak with full authority.
+        var buckets = new[]
+        {
+            Bucket(1, 20, samples: 24, util: 50, interf: 40, txRetry: 15,
+                lastSampleAt: Now.AddDays(-170))
+        };
+
+        var merged = ChannelMemoryHelper.MergeLongTermOutcomes(null, buckets, currentWidthMhz: 20, Now);
+
+        merged.Should().BeNull();
+    }
+
+    [Fact]
+    public void MergeLongTermOutcomes_NoData_ReturnsNull()
+    {
+        ChannelMemoryHelper.MergeLongTermOutcomes(null, Array.Empty<ChannelOutcomeBucket>(), 20, Now)
+            .Should().BeNull();
+    }
+}

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelMemoryHelperTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelMemoryHelperTests.cs
@@ -257,8 +257,9 @@ public class ChannelMemoryHelperTests
     };
 
     private static RememberedNeighborSighting Remembered(
-        string apMac, string bssid, int channel, DateTimeOffset lastSeen, int signal = -65) => new(
-            apMac, RadioBand.Band2_4GHz, bssid, channel, WidthMhz: 20, signal, lastSeen, Ssid: "Net");
+        string apMac, string bssid, int channel, DateTimeOffset lastSeen, int signal = -65,
+        int sightingCount = 10) => new(
+            apMac, RadioBand.Band2_4GHz, bssid, channel, WidthMhz: 20, signal, sightingCount, lastSeen, Ssid: "Net");
 
     [Fact]
     public void MergeRememberedNeighbors_AddsUnseenNeighbor_WithDecayedConfidence()
@@ -277,6 +278,58 @@ public class ChannelMemoryHelperTests
         nb.Channel.Should().Be(11);
         nb.Confidence.Should().BeApproximately(0.5, 0.001, "one half-life halves the confidence");
         scans[0].Neighbors.Should().BeEmpty("the input scan must not be mutated");
+    }
+
+    [Fact]
+    public void MergeRememberedNeighbors_TransientSighting_ScaledDownByPersistence()
+    {
+        // Seen only once (a one-off): confidence is scaled by 1/MinSightings even though the
+        // sighting is fresh, so a transient neighbor can't accumulate into full phantom load.
+        var scans = new List<ChannelScanResult> { Scan("aa:bb:cc:dd:ee:01") };
+        var remembered = new[]
+        {
+            Remembered("aa:bb:cc:dd:ee:01", "11:22:33:44:55:66", channel: 11,
+                lastSeen: Now, sightingCount: 1)
+        };
+
+        var merged = ChannelMemoryHelper.MergeRememberedNeighbors(scans, remembered, Now);
+
+        var expected = 1.0 / ChannelMemoryHelper.MinNeighborSightingsForFullWeight;
+        merged.Single().Neighbors.Single().Confidence.Should().BeApproximately(expected, 0.001);
+    }
+
+    [Fact]
+    public void MergeRememberedNeighbors_DurableSighting_FullPersistence()
+    {
+        // Seen well past the full-weight threshold and fresh: confidence is the age decay
+        // (1.0) with no persistence penalty.
+        var scans = new List<ChannelScanResult> { Scan("aa:bb:cc:dd:ee:01") };
+        var remembered = new[]
+        {
+            Remembered("aa:bb:cc:dd:ee:01", "11:22:33:44:55:66", channel: 11,
+                lastSeen: Now, sightingCount: ChannelMemoryHelper.MinNeighborSightingsForFullWeight + 5)
+        };
+
+        var merged = ChannelMemoryHelper.MergeRememberedNeighbors(scans, remembered, Now);
+
+        merged.Single().Neighbors.Single().Confidence.Should().BeApproximately(1.0, 0.001);
+    }
+
+    [Fact]
+    public void MergeRememberedNeighbors_TransientAndAged_DroppedBelowFloor()
+    {
+        // One-off (persistence 1/3) AND two age half-lives old (0.25): combined confidence
+        // 0.083 falls below the 0.125 floor, so a stale transient is dropped entirely.
+        var scans = new List<ChannelScanResult> { Scan("aa:bb:cc:dd:ee:01") };
+        var remembered = new[]
+        {
+            Remembered("aa:bb:cc:dd:ee:01", "11:22:33:44:55:66", channel: 11,
+                lastSeen: Now - ChannelMemoryHelper.NeighborHalfLife * 2, sightingCount: 1)
+        };
+
+        var merged = ChannelMemoryHelper.MergeRememberedNeighbors(scans, remembered, Now);
+
+        merged.Single().Neighbors.Should().BeEmpty();
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -1509,14 +1509,11 @@ public class ChannelRecommendationServiceTests
 
     /// <summary>
     /// A single 5 GHz AP with heavy measured stress on its current channel. Historical stress
-    /// of X% yields roughly X/100 * (3.0 + 1.5 + 1.0) on the current channel, so ~55% lands
-    /// the score in the move window (2.0-4.0) and 90% trips the measured catastrophic airtime
-    /// thresholds (interference >= 60% / TX retries >= 40%) that lift soak suppression.
-    /// <paramref name="txRetryPct"/> overrides the TX retry component so a test can sit in
-    /// the move window without crossing the retry threshold.
+    /// of X% yields roughly X/100 * (3.0 + 1.5 + 1.0) on the current channel, so ~60% lands
+    /// the score in the move window (2.0-4.0) while staying below the measured external
+    /// interference threshold (70%) that lifts soak; 90% trips it.
     /// </summary>
-    private InterferenceGraph BuildStressedSingleApGraph(
-        double stressPct, ChannelSoakInfo? soak, double? txRetryPct = null)
+    private InterferenceGraph BuildStressedSingleApGraph(double stressPct, ChannelSoakInfo? soak)
     {
         var aps = new List<AccessPointSnapshot>
         {
@@ -1524,7 +1521,7 @@ public class ChannelRecommendationServiceTests
         };
         var stress = new Dictionary<string, Dictionary<int, (double, double, double)>>
         {
-            ["aa:bb:cc:dd:ee:01"] = new() { [36] = (stressPct, stressPct, txRetryPct ?? stressPct) }
+            ["aa:bb:cc:dd:ee:01"] = new() { [36] = (stressPct, stressPct, stressPct) }
         };
         var soakInfo = soak != null
             ? new Dictionary<string, ChannelSoakInfo> { ["aa:bb:cc:dd:ee:01"] = soak }
@@ -1538,9 +1535,9 @@ public class ChannelRecommendationServiceTests
     public void Optimize_SoakedChannels_NotRecommended()
     {
         // Leave exactly one non-soaked escape channel; the stressed AP must move there and
-        // report what was suppressed. 55% util/interference with 30% retries sits in the
-        // move window without tripping the measured catastrophic thresholds.
-        var probeGraph = BuildStressedSingleApGraph(55, soak: null, txRetryPct: 30);
+        // report what was suppressed. 60% interference sits in the move window while staying
+        // below the 70% escape threshold, so suppression stays active.
+        var probeGraph = BuildStressedSingleApGraph(60, soak: null);
         var validChannels = probeGraph.Nodes[0].ValidChannels;
         // The escape must not share ch36's bonding block, or the measured stress (applied by
         // span overlap) follows the AP there and no move clears the improvement gates.
@@ -1557,12 +1554,12 @@ public class ChannelRecommendationServiceTests
             SoakEndsAt = DateTimeOffset.UtcNow.AddDays(6)
         };
 
-        var graph = BuildStressedSingleApGraph(55, soak, txRetryPct: 30);
+        var graph = BuildStressedSingleApGraph(60, soak);
         var plan = _service.Optimize(graph, RadioBand.Band5GHz, null);
 
         var rec = plan.Recommendations[0];
-        rec.CurrentScore.Should().BeGreaterThanOrEqualTo(2.0,
-            "the test relies on an AP stressed enough to want a move");
+        rec.CurrentScore.Should().BeInRange(2.0, 4.0,
+            "the test relies on a stressed-but-not-catastrophic AP so suppression stays active");
         rec.IsChanged.Should().BeTrue("heavy measured stress on ch36 justifies a move");
         rec.RecommendedChannel.Should().Be(escapeChannel,
             "every other channel is soaking and must not be recommended");
@@ -1575,9 +1572,9 @@ public class ChannelRecommendationServiceTests
     [Fact]
     public void Optimize_SoakSuppression_LiftedForCatastrophicAp()
     {
-        // Soak EVERY alternative channel. An AP whose MEASURED airtime on the new channel is
-        // catastrophic (90% interference/retries) must still escape - soak prevents churn,
-        // not rescue.
+        // Soak EVERY alternative channel. An AP whose MEASURED external interference on the new
+        // channel is catastrophic (90%, past the 70% threshold) must still escape - soak
+        // prevents churn, not rescue.
         var probeGraph = BuildStressedSingleApGraph(90, soak: null);
         var soak = new ChannelSoakInfo
         {
@@ -1658,10 +1655,10 @@ public class ChannelRecommendationServiceTests
         // A mesh group moves as one: the leader is stressed enough to want a move, but the
         // CHILD is soaking on every alternative channel. The leader must stay put - otherwise
         // the child-sync would hop the child straight back onto a channel it just left.
-        // In the move window without tripping the measured catastrophic airtime thresholds.
+        // In the move window, below the 70% external interference escape threshold.
         var leaderStress = new Dictionary<string, Dictionary<int, (double, double, double)>>
         {
-            ["aa:bb:cc:dd:ee:01"] = new() { [36] = (55d, 55d, 30d) }
+            ["aa:bb:cc:dd:ee:01"] = new() { [36] = (60d, 60d, 60d) }
         };
         List<AccessPointSnapshot> BuildAps() => new()
         {

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -1470,4 +1470,171 @@ public class ChannelRecommendationServiceTests
                 $"(lower) than current {rec.CurrentScore:F3}");
         }
     }
+
+    // --- Soak-period suppression ---
+
+    /// <summary>
+    /// A single 5 GHz AP with heavy measured stress on its current channel. Historical stress
+    /// of X% yields roughly X/100 * (3.0 + 1.5 + 1.0) on the current channel, so 60% lands
+    /// the score in the move window (2.0-4.0) and 90% lands it at the catastrophic ceiling.
+    /// </summary>
+    private InterferenceGraph BuildStressedSingleApGraph(double stressPct, ChannelSoakInfo? soak)
+    {
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "AP-1", RadioBand.Band5GHz, 36)
+        };
+        var stress = new Dictionary<string, Dictionary<int, (double, double, double)>>
+        {
+            ["aa:bb:cc:dd:ee:01"] = new() { [36] = (stressPct, stressPct, stressPct) }
+        };
+        var soakInfo = soak != null
+            ? new Dictionary<string, ChannelSoakInfo> { ["aa:bb:cc:dd:ee:01"] = soak }
+            : null;
+
+        return _service.BuildInterferenceGraph(
+            aps, RadioBand.Band5GHz, null, null, null, null, stress, soakInfo);
+    }
+
+    [Fact]
+    public void Optimize_SoakedChannels_NotRecommended()
+    {
+        // Leave exactly one non-soaked escape channel; the stressed AP must move there and
+        // report what was suppressed.
+        var probeGraph = BuildStressedSingleApGraph(60, soak: null);
+        var validChannels = probeGraph.Nodes[0].ValidChannels;
+        // The escape must not share ch36's bonding block, or the measured stress (applied by
+        // span overlap) follows the AP there and no move clears the improvement gates.
+        var currentSpan = ChannelSpanHelper.GetChannelSpan(RadioBand.Band5GHz, 36, 80);
+        var escapeChannel = validChannels.First(ch =>
+            !ChannelSpanHelper.SpansOverlap(currentSpan, ChannelSpanHelper.GetChannelSpan(RadioBand.Band5GHz, ch, 80)));
+        var soakedValidChannels = validChannels.Where(ch => ch != 36 && ch != escapeChannel).ToHashSet();
+        var soak = new ChannelSoakInfo
+        {
+            // 9999 is not a valid candidate - it must not be reported as soak-suppressed
+            // (it was never removed by the soak filter).
+            SoakedChannels = soakedValidChannels.Append(9999).ToHashSet(),
+            LastChangeAt = DateTimeOffset.UtcNow.AddDays(-1),
+            SoakEndsAt = DateTimeOffset.UtcNow.AddDays(6)
+        };
+
+        var graph = BuildStressedSingleApGraph(60, soak);
+        var plan = _service.Optimize(graph, RadioBand.Band5GHz, null);
+
+        var rec = plan.Recommendations[0];
+        rec.CurrentScore.Should().BeInRange(2.0, 4.0,
+            "the test relies on a stressed-but-not-catastrophic AP so suppression stays active");
+        rec.IsChanged.Should().BeTrue("heavy measured stress on ch36 justifies a move");
+        rec.RecommendedChannel.Should().Be(escapeChannel,
+            "every other channel is soaking and must not be recommended");
+        rec.IsSoaking.Should().BeTrue();
+        rec.SoakSuppressedChannels.Should().BeEquivalentTo(soakedValidChannels,
+            "only channels actually removed from the candidate set are reported");
+        rec.SoakEndsAt.Should().Be(soak.SoakEndsAt);
+    }
+
+    [Fact]
+    public void Optimize_SoakSuppression_LiftedForCatastrophicAp()
+    {
+        // Soak EVERY alternative channel. A catastrophically suffering AP must still escape -
+        // soak prevents churn, not rescue.
+        var probeGraph = BuildStressedSingleApGraph(90, soak: null);
+        var soak = new ChannelSoakInfo
+        {
+            SoakedChannels = probeGraph.Nodes[0].ValidChannels.Where(ch => ch != 36).ToHashSet(),
+            LastChangeAt = DateTimeOffset.UtcNow.AddDays(-1),
+            SoakEndsAt = DateTimeOffset.UtcNow.AddDays(6)
+        };
+
+        var graph = BuildStressedSingleApGraph(90, soak);
+        var plan = _service.Optimize(graph, RadioBand.Band5GHz, null);
+
+        var rec = plan.Recommendations[0];
+        rec.CurrentScore.Should().BeGreaterThanOrEqualTo(4.0,
+            "the test relies on a catastrophic current score to lift suppression");
+        rec.IsChanged.Should().BeTrue("a catastrophic AP must be allowed to leave despite soak");
+        rec.IsSoaking.Should().BeFalse("lifted suppression is not reported as active");
+    }
+
+    [Fact]
+    public void Optimize_SoakWouldEmptyCandidates_InvalidChannelApStillMoves()
+    {
+        // A 2.4 GHz AP on non-standard ch3 must always move to 1/6/11. Even if all three are
+        // soaking, the empty-candidate guard keeps them available.
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "AP-1", RadioBand.Band2_4GHz, 3, width: 20)
+        };
+        var soakInfo = new Dictionary<string, ChannelSoakInfo>
+        {
+            ["aa:bb:cc:dd:ee:01"] = new ChannelSoakInfo
+            {
+                SoakedChannels = new HashSet<int> { 1, 6, 11 },
+                LastChangeAt = DateTimeOffset.UtcNow.AddDays(-1),
+                SoakEndsAt = DateTimeOffset.UtcNow.AddDays(6)
+            }
+        };
+
+        var graph = _service.BuildInterferenceGraph(
+            aps, RadioBand.Band2_4GHz, null, null, null, null, null, soakInfo);
+        var plan = _service.Optimize(graph, RadioBand.Band2_4GHz, null);
+
+        var rec = plan.Recommendations[0];
+        rec.RecommendedChannel.Should().BeOneOf(new[] { 1, 6, 11 },
+            "an AP on an invalid channel must still be moved somewhere valid");
+    }
+
+    [Fact]
+    public void Optimize_MeshChildSoak_GatesLeaderCandidates()
+    {
+        // A mesh group moves as one: the leader is stressed enough to want a move, but the
+        // CHILD is soaking on every alternative channel. The leader must stay put - otherwise
+        // the child-sync would hop the child straight back onto a channel it just left.
+        var leaderStress = new Dictionary<string, Dictionary<int, (double, double, double)>>
+        {
+            ["aa:bb:cc:dd:ee:01"] = new() { [36] = (60d, 60d, 60d) }
+        };
+        List<AccessPointSnapshot> BuildAps() => new()
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "Leader", RadioBand.Band5GHz, 36),
+            CreateAp("aa:bb:cc:dd:ee:02", "Child", RadioBand.Band5GHz, 36,
+                isMeshChild: true, meshParentMac: "aa:bb:cc:dd:ee:01",
+                meshUplinkBand: RadioBand.Band5GHz, meshUplinkChannel: 36)
+        };
+
+        var probeGraph = _service.BuildInterferenceGraph(
+            BuildAps(), RadioBand.Band5GHz, null, null, null, null, leaderStress);
+        var leaderChannels = probeGraph.Nodes.First(nd => nd.Name == "Leader").ValidChannels;
+
+        var soakInfo = new Dictionary<string, ChannelSoakInfo>
+        {
+            ["aa:bb:cc:dd:ee:02"] = new ChannelSoakInfo
+            {
+                SoakedChannels = leaderChannels.Where(ch => ch != 36).ToHashSet(),
+                LastChangeAt = DateTimeOffset.UtcNow.AddDays(-1),
+                SoakEndsAt = DateTimeOffset.UtcNow.AddDays(6)
+            }
+        };
+
+        var graph = _service.BuildInterferenceGraph(
+            BuildAps(), RadioBand.Band5GHz, null, null, null, null, leaderStress, soakInfo);
+        var plan = _service.Optimize(graph, RadioBand.Band5GHz, null);
+
+        var leaderRec = plan.Recommendations.First(r => r.ApName == "Leader");
+        var childRec = plan.Recommendations.First(r => r.ApName == "Child");
+        leaderRec.RecommendedChannel.Should().Be(36,
+            "every alternative is soaked by the mesh child, and the group moves as one");
+        childRec.RecommendedChannel.Should().Be(36);
+        leaderRec.IsSoaking.Should().BeTrue("the child's soak gated the leader's candidates");
+    }
+
+    [Fact]
+    public void Optimize_NoSoakInfo_BehaviorUnchanged()
+    {
+        var withSoakNull = BuildStressedSingleApGraph(60, soak: null);
+        var plan = _service.Optimize(withSoakNull, RadioBand.Band5GHz, null);
+
+        plan.Recommendations[0].IsSoaking.Should().BeFalse();
+        plan.Recommendations[0].SoakEndsAt.Should().BeNull();
+    }
 }

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -186,6 +186,40 @@ public class ChannelRecommendationServiceTests
         graph.ExternalLoad[0].Should().BeEmpty();
     }
 
+    [Fact]
+    public void BuildInterferenceGraph_RememberedNeighbor_WeightScaledByConfidence()
+    {
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "AP-1", RadioBand.Band5GHz, 36)
+        };
+
+        // Identical neighbors except confidence: the remembered one (0.5) must carry half
+        // the live one's weight, land in HistoricallyObservedChannels instead of
+        // DirectlyObservedChannels, and never grant the full "directly observed" status.
+        var scans = new List<ChannelScanResult>
+        {
+            new()
+            {
+                ApMac = "aa:bb:cc:dd:ee:01",
+                Band = RadioBand.Band5GHz,
+                Neighbors = new()
+                {
+                    new NeighborNetwork { Bssid = "ff:ff:ff:00:00:01", Channel = 36, Signal = -60, IsOwnNetwork = false },
+                    new NeighborNetwork { Bssid = "ff:ff:ff:00:00:02", Channel = 149, Signal = -60, IsOwnNetwork = false, Confidence = 0.5 }
+                }
+            }
+        };
+
+        var graph = _service.BuildInterferenceGraph(aps, RadioBand.Band5GHz, null, scans, null);
+
+        graph.ExternalLoad[0][149].Should().BeApproximately(graph.ExternalLoad[0][36] * 0.5, 0.001);
+        graph.DirectlyObservedChannels[0].Should().Contain(36);
+        graph.DirectlyObservedChannels[0].Should().NotContain(149);
+        graph.HistoricallyObservedChannels[0].Should().ContainKey(149)
+            .WhoseValue.Should().BeApproximately(0.5, 0.001);
+    }
+
     // --- Scoring ---
 
     [Fact]

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -1509,10 +1509,14 @@ public class ChannelRecommendationServiceTests
 
     /// <summary>
     /// A single 5 GHz AP with heavy measured stress on its current channel. Historical stress
-    /// of X% yields roughly X/100 * (3.0 + 1.5 + 1.0) on the current channel, so 60% lands
-    /// the score in the move window (2.0-4.0) and 90% lands it at the catastrophic ceiling.
+    /// of X% yields roughly X/100 * (3.0 + 1.5 + 1.0) on the current channel, so ~55% lands
+    /// the score in the move window (2.0-4.0) and 90% trips the measured catastrophic airtime
+    /// thresholds (interference >= 60% / TX retries >= 40%) that lift soak suppression.
+    /// <paramref name="txRetryPct"/> overrides the TX retry component so a test can sit in
+    /// the move window without crossing the retry threshold.
     /// </summary>
-    private InterferenceGraph BuildStressedSingleApGraph(double stressPct, ChannelSoakInfo? soak)
+    private InterferenceGraph BuildStressedSingleApGraph(
+        double stressPct, ChannelSoakInfo? soak, double? txRetryPct = null)
     {
         var aps = new List<AccessPointSnapshot>
         {
@@ -1520,7 +1524,7 @@ public class ChannelRecommendationServiceTests
         };
         var stress = new Dictionary<string, Dictionary<int, (double, double, double)>>
         {
-            ["aa:bb:cc:dd:ee:01"] = new() { [36] = (stressPct, stressPct, stressPct) }
+            ["aa:bb:cc:dd:ee:01"] = new() { [36] = (stressPct, stressPct, txRetryPct ?? stressPct) }
         };
         var soakInfo = soak != null
             ? new Dictionary<string, ChannelSoakInfo> { ["aa:bb:cc:dd:ee:01"] = soak }
@@ -1534,8 +1538,9 @@ public class ChannelRecommendationServiceTests
     public void Optimize_SoakedChannels_NotRecommended()
     {
         // Leave exactly one non-soaked escape channel; the stressed AP must move there and
-        // report what was suppressed.
-        var probeGraph = BuildStressedSingleApGraph(60, soak: null);
+        // report what was suppressed. 55% util/interference with 30% retries sits in the
+        // move window without tripping the measured catastrophic thresholds.
+        var probeGraph = BuildStressedSingleApGraph(55, soak: null, txRetryPct: 30);
         var validChannels = probeGraph.Nodes[0].ValidChannels;
         // The escape must not share ch36's bonding block, or the measured stress (applied by
         // span overlap) follows the AP there and no move clears the improvement gates.
@@ -1552,12 +1557,12 @@ public class ChannelRecommendationServiceTests
             SoakEndsAt = DateTimeOffset.UtcNow.AddDays(6)
         };
 
-        var graph = BuildStressedSingleApGraph(60, soak);
+        var graph = BuildStressedSingleApGraph(55, soak, txRetryPct: 30);
         var plan = _service.Optimize(graph, RadioBand.Band5GHz, null);
 
         var rec = plan.Recommendations[0];
-        rec.CurrentScore.Should().BeInRange(2.0, 4.0,
-            "the test relies on a stressed-but-not-catastrophic AP so suppression stays active");
+        rec.CurrentScore.Should().BeGreaterThanOrEqualTo(2.0,
+            "the test relies on an AP stressed enough to want a move");
         rec.IsChanged.Should().BeTrue("heavy measured stress on ch36 justifies a move");
         rec.RecommendedChannel.Should().Be(escapeChannel,
             "every other channel is soaking and must not be recommended");
@@ -1570,8 +1575,9 @@ public class ChannelRecommendationServiceTests
     [Fact]
     public void Optimize_SoakSuppression_LiftedForCatastrophicAp()
     {
-        // Soak EVERY alternative channel. A catastrophically suffering AP must still escape -
-        // soak prevents churn, not rescue.
+        // Soak EVERY alternative channel. An AP whose MEASURED airtime on the new channel is
+        // catastrophic (90% interference/retries) must still escape - soak prevents churn,
+        // not rescue.
         var probeGraph = BuildStressedSingleApGraph(90, soak: null);
         var soak = new ChannelSoakInfo
         {
@@ -1584,10 +1590,38 @@ public class ChannelRecommendationServiceTests
         var plan = _service.Optimize(graph, RadioBand.Band5GHz, null);
 
         var rec = plan.Recommendations[0];
-        rec.CurrentScore.Should().BeGreaterThanOrEqualTo(4.0,
-            "the test relies on a catastrophic current score to lift suppression");
-        rec.IsChanged.Should().BeTrue("a catastrophic AP must be allowed to leave despite soak");
+        rec.IsChanged.Should().BeTrue("a measurably suffering AP must be allowed to leave despite soak");
         rec.IsSoaking.Should().BeFalse("lifted suppression is not reported as active");
+    }
+
+    [Fact]
+    public void Optimize_SoakHolds_WhenScoreInflatedButMeasuredAirtimeFine()
+    {
+        // The dense-band failure mode the escape is anchored against: idle-neighbor external
+        // load can push the INFERRED score far past any absolute ceiling on every AP forever,
+        // while the radio's own measured airtime is fine. Soak must hold - an inferred-score
+        // escape would make soak a permanent no-op exactly where it matters most.
+        var probe = BuildStressedSingleApGraph(30, soak: null);
+        var soakedChannel = probe.Nodes[0].ValidChannels.First(ch => ch != 36);
+        var soak = new ChannelSoakInfo
+        {
+            SoakedChannels = new HashSet<int> { soakedChannel },
+            LastChangeAt = DateTimeOffset.UtcNow.AddHours(-2),
+            SoakEndsAt = DateTimeOffset.UtcNow.AddHours(14)
+        };
+
+        var graph = BuildStressedSingleApGraph(30, soak);
+        foreach (var ch in graph.Nodes[0].ValidChannels)
+            graph.ExternalLoad[0][ch] = 5.0;
+
+        var plan = _service.Optimize(graph, RadioBand.Band5GHz, null);
+
+        var rec = plan.Recommendations[0];
+        rec.CurrentScore.Should().BeGreaterThanOrEqualTo(4.0,
+            "the test relies on an inferred score past the old absolute ceiling");
+        rec.IsSoaking.Should().BeTrue(
+            "measured airtime is fine, so an inflated inferred score must not lift the soak");
+        rec.SoakSuppressedChannels.Should().Contain(soakedChannel);
     }
 
     [Fact]
@@ -1624,9 +1658,10 @@ public class ChannelRecommendationServiceTests
         // A mesh group moves as one: the leader is stressed enough to want a move, but the
         // CHILD is soaking on every alternative channel. The leader must stay put - otherwise
         // the child-sync would hop the child straight back onto a channel it just left.
+        // In the move window without tripping the measured catastrophic airtime thresholds.
         var leaderStress = new Dictionary<string, Dictionary<int, (double, double, double)>>
         {
-            ["aa:bb:cc:dd:ee:01"] = new() { [36] = (60d, 60d, 60d) }
+            ["aa:bb:cc:dd:ee:01"] = new() { [36] = (55d, 55d, 30d) }
         };
         List<AccessPointSnapshot> BuildAps() => new()
         {


### PR DESCRIPTION
Gives the Channel Recommendation engine a memory: it now learns from the channels you've actually run and the neighbors it has actually seen, instead of judging every candidate channel purely on a live snapshot. Everything here works on all three bands (2.4, 5, and 6 GHz); it just bites hardest on noisy 2.4 GHz sites, where a single scan can talk the optimizer into a confident but pointless channel swap.

## Long-term outcome memory

- **Measured record per channel** - the engine records how each channel actually performed for a radio (utilization, interference, TX retries) and keeps it for months, well past the UniFi Console's short metrics retention. A channel you ran three weeks ago is judged on what it really did, not on an estimate.
- **Attributed to the config that was live** - the console reports one value per band per hour with no channel attached, so samples are attributed to whichever channel the radio was actually on at the time by walking the channel-change history. Multi-channel history is built for a single radio even though the console only ever reports "now."
- **Ages out gracefully** - older evidence counts for less (60-day half-life), so the picture tilts toward recent measurements and a channel whose record has fully decayed quietly reverts to "unknown" rather than speaking with stale authority.

## Long-term neighbor memory

- **Neighbors are remembered, not just seen once** - a radio without a dedicated scan radio mostly hears neighbors on its own channel, and forgets the old channel's neighborhood within an hour of moving. Neighbor sightings are now persisted per (AP, band, BSSID, channel) so that knowledge accumulates across the rare moments a scan does happen.
- **Decayed and de-conflicted at recommendation time** - remembered neighbors fold into the live scan with an age-decayed confidence (2-week half-life) that scales down their weight, and are dropped when the live picture supersedes them (the network moved channels, or the AP can see it live right now). They inform a channel without ever masquerading as a fresh, fully-observed sighting.
- **Weighted by how consistently a neighbor is actually seen** - a neighbor observed cycle after cycle counts at full weight; a one-off (a guest hotspot, a device passing through, a neighbor since departed) is scaled down so transient sightings can't pile up into load a channel never really carried. Only genuinely-strong neighbors (above the interference threshold) ever contribute.

## Soak-period suppression

- **No ping-ponging after a change** - once a radio changes channel, the channel it just left is held out of the recommendations for a 16-hour soak, long enough for real-world load (including an evening peak) to prove the new channel out. Applies to every band.
- **Rescue still wins over churn** - if the radio's own measured external interference on the new channel is genuinely catastrophic (70%+ of airtime from other networks), the soak lifts so a bad move can be corrected. The escape reads measured external interference only, never the AP's own traffic or the inferred score, so a busy radio on a dense band - where the score is inflated by idle neighbors - can't keep escaping its own soak.

## UI

- A "Soaking" badge on any AP whose channel is in its soak window, with a tooltip showing which channels are held and until when, plus a plan-level notice and an updated "How This Works" explainer.

## Testing

Build is clean (0 warnings) and the full suite passes. New coverage spans the attribution/decay/merge/suppression logic, the repository (upsert accumulation, bucket splitting, latest-per-radio, retention/prune, atomic commit), and the engine's soak filter and confidence scaling. Deployed and verified live on both test sites: outcome and neighbor memory persisting, soak suppression engaging on a real channel change.
