### PR TITLE
ISP Health: recognize brief WAN load and show congestion events' real latency/jitter rise

### DIFF
--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
@@ -441,16 +441,41 @@ public static class CongestionLocalizer
         (DateTime Start, DateTime End) window,
         IspHealthOptions options)
     {
-        // Metrics come from the culprit hop when it has its own elevation, else the worst member.
-        var metricSource = identity != null
+        // Metrics come from the culprit hop when it fired its own event, else the worst member (for span)
+        // - but see the magnitude fallback below when the named hop itself didn't fire.
+        var identityFired = identity != null
             && eventsBySeries.TryGetValue(identity, out var idEvents)
-            && idEvents.Any(e => Overlaps(e.Start, e.End, window.Start, window.End))
-            ? new List<AsnSeries> { identity }
-            : members;
+            && idEvents.Any(e => Overlaps(e.Start, e.End, window.Start, window.End));
+        var metricSource = identityFired ? new List<AsnSeries> { identity! } : members;
         var sourceEvents = metricSource
             .SelectMany(m => eventsBySeries[m].Where(e => Overlaps(e.Start, e.End, window.Start, window.End)))
             .ToList();
         var worst = sourceEvents.OrderByDescending(e => e.PeakRttMs - e.BaselineRttMs).First();
+
+        // When the named bottleneck hop DIDN'T fire its own event (a brief burst under the 30-min bar, so
+        // it's only the derived bottleneck), its magnitudes aren't in sourceEvents and the worst member is
+        // a deeper hop whose burst-event peak sits near baseline - the row would report a near-zero delta
+        // on the wrong hop. Compute the named hop's OWN in-window magnitudes from its samples instead
+        // (baseline median -> p90 RTT, median -> max jitter), mirroring BuildSharedIncident's fallback, so
+        // the row shows the named hop's real rise.
+        double baseRtt, peakRtt, baseJit, peakJit;
+        if (!identityFired && identity != null)
+        {
+            var ix = Index(identity);
+            var inR = ix.InWindowRtt(window.Start, window.End);
+            var inJ = ix.InWindowJitter(window.Start, window.End);
+            baseRtt = ix.BaselineRttMedian(inR) ?? 0;
+            peakRtt = inR.Count > 0 ? SeriesStats.Percentile(inR, 0.90) ?? baseRtt : baseRtt;
+            baseJit = ix.BaselineJitterMedian(inJ) ?? 0;
+            peakJit = inJ.Count > 0 ? inJ.Max() : baseJit;
+        }
+        else
+        {
+            baseRtt = worst.BaselineRttMs;
+            peakRtt = worst.PeakRttMs;
+            baseJit = worst.BaselineJitterMs;
+            peakJit = worst.PeakJitterMs;
+        }
         // The penalized ASN/targets are the bottleneck hop when localized; downstream victims
         // are excluded. An unlocalized event has no single culprit, so it keeps the full set.
         var id = identity != null ? new List<AsnSeries> { identity } : members;
@@ -471,10 +496,10 @@ public static class CongestionLocalizer
             AsnNumbers = id.Select(m => m.AsnNumber).Distinct().ToList(),
             AsnNames = id.Select(m => m.AsnName ?? $"AS{m.AsnNumber}").Distinct().ToList(),
             TargetIds = id.SelectMany(m => m.TargetIds).Distinct().ToList(),
-            BaselineRttMs = worst.BaselineRttMs,
-            PeakRttMs = worst.PeakRttMs,
-            BaselineJitterMs = worst.BaselineJitterMs,
-            PeakJitterMs = worst.PeakJitterMs
+            BaselineRttMs = baseRtt,
+            PeakRttMs = peakRtt,
+            BaselineJitterMs = baseJit,
+            PeakJitterMs = peakJit
         };
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
@@ -89,7 +89,16 @@ public static class CongestionLocalizer
                 list.Add(s);
             }
 
-            var loadCoincident = LoadCoincident(window.Start, window.End, topology, options);
+            // Two arms, OR'd. The window-fraction test (LoadCoincident) catches SUSTAINED load that fills
+            // the event window. It misses a brief saturation inside a bucket-PADDED window (a ~5-min burst
+            // straddling a 15-min boundary reports over 30 min, so 5 min of real load averages below the
+            // bar). The nearest-hop arm recovers that: it samples load only at the ACCESS-layer hop's own
+            // elevated moments, which track local load, rather than the whole window or the deeper transit
+            // hops (those spike sporadically across a far wider span and smear the correlation). OR'ing a
+            // second arm onto the untouched first can only ADD load-coincidence, never remove it, so
+            // sustained events cannot regress.
+            var loadCoincident = LoadCoincident(window.Start, window.End, topology, options)
+                || LoadCoincidentAtNearestHop(elevatedSeries, window.Start, window.End, topology, options);
             var anchoredWithData = anchored.Where(s => HasDataInWindow(s, window.Start, window.End)).ToList();
 
             // Each anchored path's RTT rise over its OWN baseline. Under load every path picks up a
@@ -480,6 +489,69 @@ public static class CongestionLocalizer
     }
 
     /// <summary>
+    /// Load-coincidence measured only at the NEAREST elevated hop's own excursion moments. The window
+    /// fraction dilutes a brief-but-real saturation across a bucket-padded window; this doesn't. The
+    /// nearest hop (lowest in-window baseline RTT = the access layer) is used because its elevation
+    /// tracks local load, whereas deeper transit hops spike sporadically across a much wider span and
+    /// drag the correlation down (observed: pooling all fired hops gave 0.45, the access hop alone 0.74).
+    /// A sample counts as elevated when its RTT clears the hop's own MAD-scaled bar (the detector's own
+    /// criterion, so a naturally noisy hop isn't tripped) OR its jitter rose (mirrors the propagation
+    /// test, catching jitter-driven events). Those moments are pooled into LoadWindowSeconds buckets, one
+    /// vote each, matched to the WAN utilization in the same bucket; coincident when the high-load share
+    /// clears CongestionLoadCoincidenceFraction. Unknown load never claims coincidence.
+    /// </summary>
+    private static bool LoadCoincidentAtNearestHop(
+        IReadOnlyList<AsnSeries> elevatedSeries, DateTime winStart, DateTime winEnd,
+        CongestionTopology topology, IspHealthOptions options)
+    {
+        var bucketTicks = TimeSpan.FromSeconds(Math.Max(1, options.LoadWindowSeconds)).Ticks;
+        var loadByBucket = new Dictionary<long, double>();
+        foreach (var l in topology.Load)
+            if (l.Utilization.HasValue)
+                loadByBucket[l.Time.Ticks / bucketTicks] = l.Utilization.Value;
+        if (loadByBucket.Count == 0) return false; // unknown load -> never claim self-inflicted
+
+        // Nearest / cleanest elevated hop = lowest in-window baseline RTT (the access layer).
+        AsnSeries? nearest = null;
+        var nearestBase = double.MaxValue;
+        foreach (var s in elevatedSeries)
+        {
+            var b = Index(s).BaselineRttMedian(Index(s).InWindowRtt(winStart, winEnd));
+            if (b.HasValue && b.Value < nearestBase) { nearestBase = b.Value; nearest = s; }
+        }
+        if (nearest == null) return false;
+
+        var ix = Index(nearest);
+        // MAD-scaled RTT bar, matching the detector's own elevation threshold, so a hop with a naturally
+        // wide baseline is judged against its own noise rather than a fixed absolute delta.
+        var rtts = nearest.Samples.Where(x => x.RttAvgMs.HasValue).Select(x => x.RttAvgMs!.Value).OrderBy(v => v).ToList();
+        var mad = 0.0;
+        if (rtts.Count > 0)
+        {
+            var med = rtts[rtts.Count / 2];
+            var devs = rtts.Select(v => Math.Abs(v - med)).OrderBy(v => v).ToList();
+            mad = devs[devs.Count / 2];
+        }
+        var rttThreshold = nearestBase + Math.Max(options.CongestionRttMinDeltaMs, options.CongestionRttDeltaFactor * mad);
+        var baseJit = ix.BaselineJitterMedian(ix.InWindowJitter(winStart, winEnd));
+
+        int high = 0, total = 0;
+        var counted = new HashSet<long>();
+        foreach (var ticks in ix.ExcursionTicks(winStart, winEnd, rttThreshold, baseJit,
+                     options.CongestionPropagationJitterFactor, options.CongestionPropagationJitterFloorMs))
+        {
+            var bucket = ticks / bucketTicks;
+            if (!counted.Add(bucket)) continue;               // one vote per load-window bucket
+            if (loadByBucket.TryGetValue(bucket, out var util))
+            {
+                total++;
+                if (util >= options.CongestionLoadHighFraction) high++;
+            }
+        }
+        return total > 0 && (double)high / total >= options.CongestionLoadCoincidenceFraction;
+    }
+
+    /// <summary>
     /// A softer "elevated in this window" test than firing a full congestion event, used for the
     /// propagation and clean-control checks so the localizer doesn't absolve a genuine bottleneck as
     /// control-plane noise just because nothing downstream fired its own event. A hop counts as
@@ -630,6 +702,28 @@ public static class CongestionLocalizer
 
         public List<double> InWindowRtt(DateTime start, DateTime end) => Collect(_rtt, start, end);
         public List<double> InWindowJitter(DateTime start, DateTime end) => Collect(_jit, start, end);
+
+        /// <summary>
+        /// Ticks of in-window samples elevated over this hop's OWN baseline - RTT above
+        /// <paramref name="rttThreshold"/>, OR (when <paramref name="baseJitter"/> is known) jitter above
+        /// baseline by both the ratio <paramref name="jitterFactor"/> and the absolute floor
+        /// <paramref name="jitterFloorMs"/> (mirrors the propagation test, so a jitter-driven event with
+        /// flat RTT still yields its elevated moments). The excursion timestamps, for matching against the
+        /// WAN load series.
+        /// </summary>
+        public IEnumerable<long> ExcursionTicks(DateTime start, DateTime end, double rttThreshold,
+            double? baseJitter, double jitterFactor, double jitterFloorMs)
+        {
+            var (lo, hi) = Range(start, end);
+            for (var i = lo; i < hi; i++)
+            {
+                var rttHot = _rtt[i].HasValue && _rtt[i]!.Value > rttThreshold;
+                var jitHot = _jit[i].HasValue && baseJitter.HasValue
+                    && _jit[i]!.Value > baseJitter.Value * jitterFactor
+                    && _jit[i]!.Value - baseJitter.Value >= jitterFloorMs;
+                if (rttHot || jitHot) yield return _ticks[i];
+            }
+        }
 
         public double? BaselineRttMedian(List<double> inWindow) => PercentileExcluding(_rttAsc, inWindow, 0.5);
         public double? BaselineRttPercentile(List<double> inWindow, double p) => PercentileExcluding(_rttAsc, inWindow, p);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/CongestionLocalizer.cs
@@ -450,32 +450,27 @@ public static class CongestionLocalizer
         var sourceEvents = metricSource
             .SelectMany(m => eventsBySeries[m].Where(e => Overlaps(e.Start, e.End, window.Start, window.End)))
             .ToList();
-        var worst = sourceEvents.OrderByDescending(e => e.PeakRttMs - e.BaselineRttMs).First();
 
-        // When the named bottleneck hop DIDN'T fire its own event (a brief burst under the 30-min bar, so
-        // it's only the derived bottleneck), its magnitudes aren't in sourceEvents and the worst member is
-        // a deeper hop whose burst-event peak sits near baseline - the row would report a near-zero delta
-        // on the wrong hop. Compute the named hop's OWN in-window magnitudes from its samples instead
-        // (baseline median -> p90 RTT, median -> max jitter), mirroring BuildSharedIncident's fallback, so
-        // the row shows the named hop's real rise.
-        double baseRtt, peakRtt, baseJit, peakJit;
-        if (!identityFired && identity != null)
-        {
-            var ix = Index(identity);
-            var inR = ix.InWindowRtt(window.Start, window.End);
-            var inJ = ix.InWindowJitter(window.Start, window.End);
-            baseRtt = ix.BaselineRttMedian(inR) ?? 0;
-            peakRtt = inR.Count > 0 ? SeriesStats.Percentile(inR, 0.90) ?? baseRtt : baseRtt;
-            baseJit = ix.BaselineJitterMedian(inJ) ?? 0;
-            peakJit = inJ.Count > 0 ? inJ.Max() : baseJit;
-        }
-        else
-        {
-            baseRtt = worst.BaselineRttMs;
-            peakRtt = worst.PeakRttMs;
-            baseJit = worst.BaselineJitterMs;
-            peakJit = worst.PeakJitterMs;
-        }
+        // The row's magnitudes come from ONE hop's own in-window samples: the named bottleneck when
+        // localized, else the member with the largest fired rise. Sampling (baseline median -> p90 RTT,
+        // median -> max jitter) rather than reusing the fired event's peak matters because the detector
+        // reports PeakRttMs/PeakJitterMs as the bucket MEDIAN - which sits near baseline for a burst or
+        // jitter-driven event (its elevation is in the p90/spikes, not the median), so the row would show
+        // a ~0 delta. This also covers a derived bottleneck that never fired its own event. Mirrors
+        // BuildSharedIncident's owner-magnitude computation.
+        var metricHop = identity ?? members
+            .OrderByDescending(m => eventsBySeries.TryGetValue(m, out var es)
+                ? es.Where(e => Overlaps(e.Start, e.End, window.Start, window.End))
+                     .Select(e => e.PeakRttMs - e.BaselineRttMs).DefaultIfEmpty(0).Max()
+                : 0)
+            .First();
+        var mix = Index(metricHop);
+        var inR = mix.InWindowRtt(window.Start, window.End);
+        var inJ = mix.InWindowJitter(window.Start, window.End);
+        var baseRtt = mix.BaselineRttMedian(inR) ?? 0;
+        var peakRtt = inR.Count > 0 ? SeriesStats.Percentile(inR, 0.90) ?? baseRtt : baseRtt;
+        var baseJit = mix.BaselineJitterMedian(inJ) ?? 0;
+        var peakJit = inJ.Count > 0 ? inJ.Max() : baseJit;
         // The penalized ASN/targets are the bottleneck hop when localized; downstream victims
         // are excluded. An unlocalized event has no single culprit, so it keeps the full set.
         var id = identity != null ? new List<AsnSeries> { identity } : members;

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
@@ -251,6 +251,31 @@ public class CongestionLocalizerTests
     }
 
     [Fact]
+    public void Named_bottleneck_that_did_not_fire_reports_its_own_rise_not_a_deeper_member()
+    {
+        // The access hop is elevated only briefly (excursions inside one bucket -> no fired 30-min event),
+        // so it's the DERIVED bottleneck; a deeper hop fired with a small near-baseline delta. The row must
+        // report the named access hop's OWN rise (from its samples), not the deeper member's numbers.
+        var burstStart = HumpStart.AddMinutes(3);
+        var burstEnd = HumpStart.AddMinutes(9);   // 6 min, one bucket -> no fired event, but IsElevated
+        var accessShortBurst = Flat(3).WithSegment(burstStart, burstEnd, rttMs: 20, jitterMs: 6);
+        var deepSmall = Flat(10).WithSegment(HumpStart, HumpStart.AddMinutes(45), rttMs: 13, jitterMs: 3); // fires, small delta
+
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, accessShortBurst),
+            Hop(200, Transit, deepSmall, Bng),
+            Dest(DestCorridor, deepSmall, Bng, Transit)   // downstream witness -> propagated (Confirmed)
+        };
+
+        var events = CongestionLocalizer.Localize(series, Topo(load: false), Options);
+
+        var e = events.Single(x => x.BottleneckHopIp == Bng);
+        e.BaselineRttMs.Should().BeApproximately(3, 2);          // the access hop's baseline, not the deep hop's ~10
+        e.PeakRttMs.Should().BeGreaterThan(e.BaselineRttMs + 3); // shows a real rise, not a ~0 delta
+    }
+
+    [Fact]
     public void Dead_end_transit_is_unverifiable_and_not_merged_into_the_corridor_event()
     {
         var series = new List<AsnSeries>

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
@@ -175,6 +175,82 @@ public class CongestionLocalizerTests
     }
 
     [Fact]
+    public void Brief_load_at_the_access_hop_registers_despite_a_wide_transit_hop_and_padded_window()
+    {
+        // The access hop bursts for ~6 min straddling the 15-min bucket boundary, so the event reports
+        // over a padded 30-min window. A deeper transit hop is elevated across the WHOLE window (its
+        // spikes miss the brief load), so the window-fraction test dilutes to ~0.2 and would read False.
+        // The nearest-hop arm samples load only at the ACCESS hop's own excursions (all under the load)
+        // and correctly registers it as load-coincident. Mirrors the real 14:45 event.
+        var burstStart = HumpStart.AddMinutes(12);
+        var burstEnd = HumpStart.AddMinutes(18);
+        List<LatencySample> AccessBurst() => Flat(5).WithSegment(burstStart, burstEnd, rttMs: 30, jitterMs: 6);
+        // Deep transit hop elevated across the whole padded window - its excursions span it and mostly
+        // miss the 6-min load, so pooling/window-fraction is diluted below the bar.
+        List<LatencySample> WideTransit() => Flat(30).WithSegment(HumpStart, HumpStart.AddMinutes(30), rttMs: 35, jitterMs: 4);
+
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, AccessBurst()),
+            Hop(100, Border, AccessBurst(), Bng),
+            Hop(200, Transit, WideTransit(), Bng, Border),
+            Dest(DestCorridor, AccessBurst(), Bng, Border, Transit)
+        };
+
+        var load = new List<(DateTime, double?)>();
+        for (var t = HumpStart; t < HumpStart.AddMinutes(30); t = t.AddMinutes(1))
+            load.Add((t, t >= burstStart && t < burstEnd ? 0.9 : 0.1)); // high only during the burst
+        var topo = new CongestionTopology
+        {
+            AccessEgressHopIps = new HashSet<string>(new[] { Bng }, StringComparer.OrdinalIgnoreCase),
+            HopNumberByIp = HopNumbers,
+            Load = load,
+            HasTraceMap = true
+        };
+
+        var events = CongestionLocalizer.Localize(series, topo, Options);
+
+        events.Should().NotBeEmpty();
+        events.Should().OnlyContain(e => e.LoadCoincident);
+    }
+
+    [Fact]
+    public void Brief_load_that_misses_the_access_hop_elevation_is_not_load_coincident()
+    {
+        // Same shape, but the load spike is EARLY (before the access burst) - the access hop rose when
+        // the line was NOT loaded. Neither arm should fire: window-fraction is diluted, and the nearest-
+        // hop arm sees low load at the access hop's excursion moments. Guards against a false positive.
+        var burstStart = HumpStart.AddMinutes(12);
+        var burstEnd = HumpStart.AddMinutes(18);
+        List<LatencySample> AccessBurst() => Flat(5).WithSegment(burstStart, burstEnd, rttMs: 30, jitterMs: 6);
+        List<LatencySample> WideTransit() => Flat(30).WithSegment(HumpStart, HumpStart.AddMinutes(30), rttMs: 35, jitterMs: 4);
+
+        var series = new List<AsnSeries>
+        {
+            Hop(100, Bng, AccessBurst()),
+            Hop(100, Border, AccessBurst(), Bng),
+            Hop(200, Transit, WideTransit(), Bng, Border),
+            Dest(DestCorridor, AccessBurst(), Bng, Border, Transit)
+        };
+
+        var load = new List<(DateTime, double?)>();
+        for (var t = HumpStart; t < HumpStart.AddMinutes(30); t = t.AddMinutes(1))
+            load.Add((t, t < HumpStart.AddMinutes(6) ? 0.9 : 0.1)); // high early, NOT during the burst
+        var topo = new CongestionTopology
+        {
+            AccessEgressHopIps = new HashSet<string>(new[] { Bng }, StringComparer.OrdinalIgnoreCase),
+            HopNumberByIp = HopNumbers,
+            Load = load,
+            HasTraceMap = true
+        };
+
+        var events = CongestionLocalizer.Localize(series, topo, Options);
+
+        events.Should().NotBeEmpty();
+        events.Should().OnlyContain(e => !e.LoadCoincident);
+    }
+
+    [Fact]
     public void Dead_end_transit_is_unverifiable_and_not_merged_into_the_corridor_event()
     {
         var series = new List<AsnSeries>

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/CongestionLocalizerTests.cs
@@ -276,6 +276,37 @@ public class CongestionLocalizerTests
     }
 
     [Fact]
+    public void Burst_event_reports_the_spike_magnitude_not_the_bucket_median()
+    {
+        // An intermittent-spike ("burst") event: RTT/jitter medians stay near baseline, only sporadic
+        // samples spike. The detector reports peak as the bucket MEDIAN, which hides the spikes, so the
+        // row would show a ~0 delta. The row must report the spike magnitude (sample p90 RTT / max jitter).
+        // Uses an off-trace-map target (unlocalized, identity == null) - e.g. a speedtest / endpoint target.
+        var samples = TestSeries.Flat(TestSeries.Start, Day, rttMs: 2, jitterMs: 0.3)
+            .Select((s, i) => s.Time >= HumpStart && s.Time < HumpStart.AddMinutes(45) && i % 3 == 0
+                ? new LatencySample(s.Time, 8, 8 + 5, 5, 0)   // sporadic spike: RTT 8 ms, jitter 5 ms
+                : s)
+            .ToList();
+        var series = new List<AsnSeries>
+        {
+            new() { AsnNumber = 500, AsnName = "AS500", TargetIds = { "203.0.113.9" }, Samples = samples, HopIps = { "203.0.113.9" } }
+        };
+        var topo = new CongestionTopology
+        {
+            HopNumberByIp = HopNumbers,
+            Load = new List<(DateTime, double?)>(),
+            HasTraceMap = true
+        };
+
+        var events = CongestionLocalizer.Localize(series, topo, Options);
+
+        events.Should().NotBeEmpty();
+        var e = events[0];
+        e.PeakRttMs.Should().BeGreaterThan(5);      // reflects the ~8 ms spike, not the ~2 ms bucket median
+        e.PeakJitterMs.Should().BeGreaterThan(2);   // reflects the ~5 ms jitter spike, not the flat median
+    }
+
+    [Fact]
     public void Dead_end_transit_is_unverifiable_and_not_merged_into_the_corridor_event()
     {
         var series = new List<AsnSeries>


### PR DESCRIPTION
Two fixes to how ISP Health reports congestion events.

## Brief WAN load is now recognized

A congestion event that coincided with a brief WAN saturation (a short download, a quick speed test) was reported as external congestion instead of "under heavy WAN load." Load coincidence was measured as the fraction of the whole event window that was saturated, but events are bucketed to a 30-minute minimum, so a genuine ~5-minute saturation inside that window averaged out below the threshold.

Load is now also sampled at the nearest access-layer hop's own elevated moments, which track local load rather than being diluted by the padded window or by deeper transit hops that spike across a much wider span. Sustained-load events are unchanged: the new check is an additional arm OR'd onto the existing one, so nothing that classified as loaded before can stop doing so.

## Congestion rows show the affected hop's real rise

A congestion event row could show a near-zero latency/jitter delta that didn't reflect what actually happened: an access hop's event displaying a deeper hop's flat numbers, or a spike-driven (bursty) event showing its baseline because the reported peak was the bucket median.

Event magnitudes are now taken from the affected hop's own in-window samples (its baseline, its p90 latency and peak jitter), so the row shows the hop's real rise. This is display-only and does not affect scoring.
