### PR TITLE
Notify users of pre-release builds (on by default, opt-out)

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -2364,6 +2364,23 @@
         </div>
     </div>
 
+    <!-- Software Updates -->
+    <div class="card">
+        <div class="card-header">
+            <h2 class="card-title">Software Updates</h2>
+        </div>
+        <div class="card-body">
+            <label class="checkbox-label">
+                <input type="checkbox" @bind="receivePrereleaseUpdates" @bind:after="SavePrereleaseSetting" />
+                Receive pre-release update notifications
+            </label>
+            <p class="form-help">
+                Shows a banner when a preview (beta) build is available so you can try new features
+                early. Stable update notifications are unaffected either way.
+            </p>
+        </div>
+    </div>
+
     <!-- 14. Data Management -->
     <div class="card">
         <div class="card-header">
@@ -2708,6 +2725,7 @@
 
     // Application Settings
     private int alertRetention = 30;
+    private bool receivePrereleaseUpdates = true; // default ON; dismissing the preview banner opts out
 
     // Security Audit Settings
     private bool allowAppleStreamingOnMainNetwork = false;
@@ -2854,6 +2872,11 @@
         hasControllerApiKey = connectionSettings.HasApiKey;
 
         UpdateControllerStatus();
+
+        // Pre-release update notifications default ON (null); only an explicit "false" opts out.
+        var prereleaseSetting = await SystemSettings.GetAsync("updates.include_prereleases");
+        receivePrereleaseUpdates = prereleaseSetting is null || (bool.TryParse(prereleaseSetting, out var prPre) && prPre);
+
         await LoadGatewaySettings();
         await LoadSshSettings();
         await LoadModemConfigs();
@@ -4430,6 +4453,11 @@
         var provider = e.Value?.ToString() ?? "att-gateway";
         _editingOnt.Provider = provider;
         _editingOnt.Port = GetOntProviderDefaultPort(provider);
+    }
+
+    private async Task SavePrereleaseSetting()
+    {
+        await SystemSettings.SetAsync("updates.include_prereleases", receivePrereleaseUpdates ? "true" : "false");
     }
 
     private static int GetOntProviderDefaultPort(string provider) => provider switch

--- a/src/NetworkOptimizer.Web/Components/Shared/UpdateChecker.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpdateChecker.razor
@@ -1,5 +1,6 @@
 @using System.Reflection
 @inject IJSRuntime JS
+@inject NetworkOptimizer.Web.Services.SystemSettingsService SettingsService
 
 @if (updateAvailable && !string.IsNullOrEmpty(latestVersion))
 {
@@ -11,17 +12,22 @@
                 </svg>
             </span>
             <div class="banner-text">
-                <strong style="color: #4ade80;">Update Available: v@(latestVersion)</strong>
-                <span style="color: #86b89a;">A new version of Network Optimizer is available.</span>
+                <strong style="color: #4ade80;">@(isPrerelease ? "Preview Available" : "Update Available"): v@(latestVersion)</strong>
+                <span style="color: #86b89a;">@(isPrerelease ? "A preview build is ready to try - see what's new." : "A new version of Network Optimizer is available.")</span>
             </div>
             <a href="https://github.com/Ozark-Connect/NetworkOptimizer/blob/main/docker/DEPLOYMENT.md#upgrade-procedure" target="_blank" rel="noopener noreferrer" class="btn btn-outline-light">Upgrade Guide</a>
             <a href="@releaseUrl" target="_blank" rel="noopener noreferrer" class="btn btn-success">View Release</a>
+            @if (isPrerelease)
+            {
+                <button type="button" class="btn btn-outline-light" @onclick="DismissPrereleases">Dismiss</button>
+            }
         </div>
     </div>
 }
 
 @code {
     private bool updateAvailable = false;
+    private bool isPrerelease = false;
     private string? latestVersion;
     private string? releaseUrl;
 
@@ -41,13 +47,19 @@
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
                 ?.InformationalVersion ?? "0.0.0";
 
-            var result = await JS.InvokeAsync<UpdateCheckResult?>("updateChecker.checkForUpdate", currentVersion);
+            // Pre-release notifications are ON by default so everyone hears about big preview
+            // releases; dismissing the banner (or the Settings toggle) writes "false" to opt out.
+            var raw = await SettingsService.GetAsync("updates.include_prereleases");
+            var includePrereleases = raw is null || (bool.TryParse(raw, out var pre) && pre);
+
+            var result = await JS.InvokeAsync<UpdateCheckResult?>("updateChecker.checkForUpdate", currentVersion, includePrereleases);
 
             if (result?.UpdateAvailable == true)
             {
                 updateAvailable = true;
                 latestVersion = result.LatestVersion;
                 releaseUrl = result.ReleaseUrl ?? "https://github.com/Ozark-Connect/NetworkOptimizer/releases/latest";
+                isPrerelease = latestVersion?.Contains('-') == true;
                 StateHasChanged();
             }
         }
@@ -55,6 +67,14 @@
         {
             // Silently fail - update check is non-critical
         }
+    }
+
+    private async Task DismissPrereleases()
+    {
+        // Opt out of pre-release notifications (re-enable any time in Settings).
+        await SettingsService.SetAsync("updates.include_prereleases", "false");
+        updateAvailable = false;
+        StateHasChanged();
     }
 
     private class UpdateCheckResult

--- a/src/NetworkOptimizer.Web/wwwroot/js/updateCheck.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/updateCheck.js
@@ -1,21 +1,33 @@
 // Client-side update checker - fetches from GitHub API directly
 // Caches results in localStorage, only checks every 15 minutes
+//
+// Two modes:
+// - Stable (default): hits /releases/latest, which GitHub defines to EXCLUDE
+//   prereleases, and compares numeric cores only (suffixes stripped).
+// - Pre-release opt-in: hits the /releases list (which includes prereleases),
+//   picks the highest by full semver, and compares suffix-aware so a tester on
+//   2.0.0-beta.1 is nudged to 2.0.0-beta.2 / 2.0.0 but never "downgraded" to an
+//   older stable. Off by default so the stable majority is untouched.
 
 window.updateChecker = {
     CACHE_KEY: 'networkOptimizer_updateCheck',
     CACHE_DURATION_MS: 15 * 60 * 1000, // 15 minutes
     GITHUB_API_URL: 'https://api.github.com/repos/Ozark-Connect/NetworkOptimizer/releases/latest',
+    GITHUB_RELEASES_URL: 'https://api.github.com/repos/Ozark-Connect/NetworkOptimizer/releases?per_page=30',
 
-    async checkForUpdate(currentVersion) {
+    async checkForUpdate(currentVersion, includePrereleases = false) {
         try {
-            // Check cache first
-            const cached = this.getCached();
+            // Check cache first (keyed by mode so toggling the opt-in re-fetches)
+            const cached = this.getCached(includePrereleases);
             if (cached) {
-                return this.compareVersions(currentVersion, cached.latestVersion);
+                return includePrereleases
+                    ? this.compareVersionsPrecise(currentVersion, cached.latestVersion, cached.releaseUrl)
+                    : this.compareVersions(currentVersion, cached.latestVersion, cached.releaseUrl);
             }
 
             // Fetch from GitHub
-            const response = await fetch(this.GITHUB_API_URL, {
+            const url = includePrereleases ? this.GITHUB_RELEASES_URL : this.GITHUB_API_URL;
+            const response = await fetch(url, {
                 headers: { 'Accept': 'application/vnd.github.v3+json' }
             });
 
@@ -25,32 +37,53 @@ window.updateChecker = {
             }
 
             const data = await response.json();
-            const latestVersion = data.tag_name?.replace(/^v/, '') || null;
-            const releaseUrl = data.html_url || null;
+
+            let latestVersion, releaseUrl;
+            if (includePrereleases) {
+                // The list includes prereleases (but not drafts, for anonymous callers).
+                // Pick the highest by semver rather than trusting list order.
+                let best = null;
+                for (const r of (Array.isArray(data) ? data : [])) {
+                    if (r.draft) continue;
+                    const v = r.tag_name?.replace(/^v/, '');
+                    if (!v) continue;
+                    if (!best || this.compareSemver(v, best.version) > 0) {
+                        best = { version: v, url: r.html_url };
+                    }
+                }
+                latestVersion = best?.version || null;
+                releaseUrl = best?.url || null;
+            } else {
+                latestVersion = data.tag_name?.replace(/^v/, '') || null;
+                releaseUrl = data.html_url || null;
+            }
 
             // Cache the result
-            this.setCache(latestVersion, releaseUrl);
+            this.setCache(latestVersion, releaseUrl, includePrereleases);
 
-            return this.compareVersions(currentVersion, latestVersion, releaseUrl);
+            return includePrereleases
+                ? this.compareVersionsPrecise(currentVersion, latestVersion, releaseUrl)
+                : this.compareVersions(currentVersion, latestVersion, releaseUrl);
         } catch (error) {
             console.warn('Update check error:', error);
             return null;
         }
     },
 
-    getCached() {
+    getCached(includePrereleases = false) {
         try {
             const cached = localStorage.getItem(this.CACHE_KEY);
             if (!cached) return null;
 
-            const { timestamp, latestVersion, releaseUrl } = JSON.parse(cached);
+            const { timestamp, latestVersion, releaseUrl, prereleases } = JSON.parse(cached);
             const age = Date.now() - timestamp;
 
-            if (age < this.CACHE_DURATION_MS) {
+            // A cache entry is only valid for the mode it was fetched in.
+            if (age < this.CACHE_DURATION_MS && !!prereleases === !!includePrereleases) {
                 return { latestVersion, releaseUrl };
             }
 
-            // Cache expired
+            // Cache expired or from the other mode
             localStorage.removeItem(this.CACHE_KEY);
             return null;
         } catch {
@@ -58,12 +91,13 @@ window.updateChecker = {
         }
     },
 
-    setCache(latestVersion, releaseUrl) {
+    setCache(latestVersion, releaseUrl, includePrereleases = false) {
         try {
             localStorage.setItem(this.CACHE_KEY, JSON.stringify({
                 timestamp: Date.now(),
                 latestVersion,
-                releaseUrl
+                releaseUrl,
+                prereleases: !!includePrereleases
             }));
         } catch {
             // localStorage might be full or disabled
@@ -100,5 +134,69 @@ window.updateChecker = {
         }
 
         return { updateAvailable: false };
+    },
+
+    // Suffix-aware comparison for the pre-release opt-in path: an update is only
+    // offered when the candidate is strictly greater by full semver, so a beta
+    // tester is never nudged "up" to an older stable release.
+    compareVersionsPrecise(current, latest, releaseUrl) {
+        if (!current || !latest) return null;
+
+        // Skip check for source builds
+        if (current.replace(/^v/, '').startsWith('0.0.0')) {
+            return null;
+        }
+
+        if (this.compareSemver(latest, current) > 0) {
+            return { updateAvailable: true, latestVersion: latest, releaseUrl };
+        }
+        return { updateAvailable: false };
+    },
+
+    // Parse into { core: [major, minor, patch], pre: [identifiers] }, dropping the
+    // 'v' prefix and +build metadata. A missing pre-release means a final release.
+    parseSemver(v) {
+        const clean = v.replace(/^v/, '').split('+')[0];
+        const dash = clean.indexOf('-');
+        const core = (dash === -1 ? clean : clean.slice(0, dash)).split('.').map(Number);
+        const pre = dash === -1 ? [] : clean.slice(dash + 1).split('.');
+        return { core, pre };
+    },
+
+    // Full semver precedence: -1 / 0 / 1. Core compared numerically; a release
+    // outranks a prerelease of the same core; prerelease identifiers per semver
+    // (numeric < alphanumeric, more identifiers win when all preceding are equal).
+    compareSemver(a, b) {
+        const pa = this.parseSemver(a);
+        const pb = this.parseSemver(b);
+
+        for (let i = 0; i < 3; i++) {
+            const d = (pa.core[i] || 0) - (pb.core[i] || 0);
+            if (d !== 0) return d > 0 ? 1 : -1;
+        }
+
+        if (pa.pre.length === 0 && pb.pre.length === 0) return 0;
+        if (pa.pre.length === 0) return 1;  // release > prerelease
+        if (pb.pre.length === 0) return -1;
+
+        const n = Math.max(pa.pre.length, pb.pre.length);
+        for (let i = 0; i < n; i++) {
+            if (i >= pa.pre.length) return -1; // fewer identifiers = lower
+            if (i >= pb.pre.length) return 1;
+            const x = pa.pre[i], y = pb.pre[i];
+            const xn = /^\d+$/.test(x), yn = /^\d+$/.test(y);
+            if (xn && yn) {
+                const d = Number(x) - Number(y);
+                if (d !== 0) return d > 0 ? 1 : -1;
+            } else if (xn) {
+                return -1; // numeric identifiers have lower precedence than alphanumeric
+            } else if (yn) {
+                return 1;
+            } else if (x !== y) {
+                return x < y ? -1 : 1;
+            }
+        }
+
+        return 0;
     }
 };


### PR DESCRIPTION
Rolls up `dev` for the next stable patch. Net change vs `main`: the update checker can now surface pre-release builds so users hear about upcoming preview releases, with a Settings toggle and one-click opt-out.

## What changed
- **Pre-release awareness in the update checker** — when enabled, it reads the full `/releases` list (which includes prereleases) and picks the highest build by **full semver**, comparing suffix-aware so a preview tester is nudged forward (`beta.1 → beta.2 → final`) but never "up" to an older stable. The stable path (`/releases/latest`, core-only compare) is unchanged; the result is cached per mode.
- **On by default** — the banner labels a preview as "Preview Available" and shows a **Dismiss** button that opts out.
- **Opting out only silences previews** — stable update notifications keep working regardless (they always route through `/releases/latest`).
- **Settings → Software Updates** toggle to turn it on or off.

## Why
Preview builds are published as GitHub prereleases, which `/releases/latest` excludes by definition, so today no one hears about them in-app. This lets users opt to see them. Default-on is intentional so the whole base learns about significant upcoming releases; it's informational only - `:latest` never moves onto a prerelease, so nothing is auto-upgraded.