### PR TITLE
Add Telekom Glasfaser-Modem 2 ONT provider

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1194,6 +1194,7 @@
                                 <option value="realtek-ont">Realtek ONT Stick (HTTP)</option>
                                 <option value="8311">8311 Community Firmware (HTTP)</option>
                                 <option value="quantum-q1000k">Quantum Fiber Q1000K (HTTP)</option>
+                                <option value="telekom-modem2">Telekom Glasfaser-Modem 2 (HTTP)</option>
                                 <option value="generic-http-ont">Generic HTTP ONT</option>
                             </select>
                         </div>
@@ -4473,6 +4474,7 @@
         "realtek-ont" => "Realtek ONT Stick (HTTP)",
         "8311" => "8311 Community Firmware (HTTP)",
         "quantum-q1000k" => "Quantum Fiber Q1000K (HTTP)",
+        "telekom-modem2" => "Telekom Glasfaser-Modem 2 (HTTP)",
         "generic-http-ont" => "Generic HTTP ONT",
         _ => provider,
     };

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -210,6 +210,7 @@ builder.Services.AddSingleton<IOntProvider, RealtekOntProvider>();
 builder.Services.AddSingleton<IOntProvider, Lantiq8311OntProvider>();
 builder.Services.AddSingleton<IOntProvider, QuantumQ1000kOntProvider>();
 builder.Services.AddSingleton<IOntProvider, GenericHttpOntProvider>();
+builder.Services.AddSingleton<IOntProvider, TelekomModem2OntProvider>();
 builder.Services.AddSingleton<OntMonitorService>();
 
 // Register iperf3 Speed Test service (singleton - tracks running tests, uses UniFiSshService)

--- a/src/NetworkOptimizer.Web/Services/OntProviders/TelekomModem2OntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/TelekomModem2OntProvider.cs
@@ -1,0 +1,188 @@
+using System.Globalization;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Monitoring.Providers;
+
+namespace NetworkOptimizer.Web.Services.OntProviders;
+
+/// <summary>
+/// ONT provider for the Deutsche Telekom "Glasfaser-Modem 2" GPON ONT, used in
+/// modem/bridge mode ahead of a third-party router on Telekom FTTH connections.
+/// Unlike every other provider here, no login/session is needed: the device
+/// serves DDM/link stats openly over plain HTTP at /ONT/client/data/Status.json,
+/// which the same page the LAN-connected web UI polls for its Status view.
+/// </summary>
+public sealed class TelekomModem2OntProvider : IOntProvider
+{
+    public string ProviderKey => "telekom-modem2";
+    public string DisplayName => "Telekom Glasfaser-Modem 2 (HTTP)";
+
+    private const int TimeoutSeconds = 10;
+    private const string StatusPath = "/ONT/client/data/Status.json";
+
+    private readonly ILogger<TelekomModem2OntProvider> _logger;
+
+    public TelekomModem2OntProvider(ILogger<TelekomModem2OntProvider> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<OntStats?> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+        {
+            _logger.LogWarning("Telekom Modem 2 ONT poll requested but Host is empty (config {Id})", context.Id);
+            return null;
+        }
+
+        try
+        {
+            using var client = CreateClient();
+            var json = await client.GetStringAsync($"{BuildBaseUrl(context)}{StatusPath}", cancellationToken);
+
+            var stats = new OntStats
+            {
+                Timestamp = DateTime.UtcNow,
+                DeviceHost = context.Host,
+                DeviceName = context.Name,
+                DeviceModel = "Glasfaser-Modem 2",
+            };
+            ApplyStatus(json, stats);
+
+            _logger.LogDebug(
+                "Telekom Modem 2 ONT {Name} polled: Rx={Rx} dBm, Tx={Tx} dBm, Link={Link}",
+                context.Name, stats.RxPowerDbm?.ToString("F2") ?? "-",
+                stats.TxPowerDbm?.ToString("F2") ?? "-", stats.LinkState ?? "-");
+
+            return stats;
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error polling Telekom Modem 2 ONT {Name} at {Host}", context.Name, context.Host);
+            return null;
+        }
+    }
+
+    public async Task<(bool Success, string Message)> TestConnectionAsync(
+        OntPollContext context, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+            return (false, "Host is empty");
+
+        try
+        {
+            using var client = CreateClient();
+            var json = await client.GetStringAsync($"{BuildBaseUrl(context)}{StatusPath}", cancellationToken);
+
+            var stats = new OntStats();
+            ApplyStatus(json, stats);
+
+            if (stats.RxPowerDbm is null && stats.TxPowerDbm is null)
+                return (false, "Connected but response does not contain expected PON status fields");
+
+            return (true,
+                $"Connected (HTTP) - RX: {stats.RxPowerDbm?.ToString("F2") ?? "?"} dBm, TX: {stats.TxPowerDbm?.ToString("F2") ?? "?"} dBm");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Connection failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Parses the flat array of {"vartype","varid","varvalue"} entries returned by
+    /// Status.json. Defensive throughout: any missing or malformed field is simply
+    /// left at its OntStats default rather than throwing.
+    /// </summary>
+    internal static void ApplyStatus(string json, OntStats stats)
+    {
+        var values = ParseVarArray(json);
+
+        if (GetValue(values, "device_name") is { Length: > 0 } deviceName)
+            stats.DeviceModel = deviceName;
+
+        if (GetValue(values, "hardware_revision") is { Length: > 0 } hwRevision)
+            stats.VendorPn = hwRevision;
+
+        if (GetValue(values, "serial_number") is { Length: > 0 } serial)
+            stats.VendorSn = serial;
+
+        stats.TxPowerDbm = ParseDouble(GetValue(values, "txpower")) ?? stats.TxPowerDbm;
+        stats.RxPowerDbm = ParseDouble(GetValue(values, "rxpower")) ?? stats.RxPowerDbm;
+        stats.BipErrors = ParseLong(GetValue(values, "rxbip_crc")) ?? stats.BipErrors;
+        stats.LinkUptimeSeconds = ParseLong(GetValue(values, "stability")) ?? stats.LinkUptimeSeconds;
+
+        // hardware_state's own semantics (from the device's status.js): "0" is a hardware
+        // fault, any other value (including absent/unknown) reads as Ok. ploam_success
+        // confirms the ONU finished GPON activation; together they gate whether we trust
+        // "Operation" or need to fall back to whatever transitional ploam_state reports.
+        var hardwareOk = GetValue(values, "hardware_state") != "0";
+        var ploamSuccess = GetValue(values, "ploam_success") == "1";
+        var up = hardwareOk && ploamSuccess;
+
+        stats.PonLinkStatus = up
+            ? PonLinkState.Operation
+            : PonLinkStateExtensions.ParsePonLinkState(GetValue(values, "ploam_state"));
+        stats.OperationalStatus = up ? "Up" : "Down";
+        stats.LinkState = stats.PonLinkStatus.ToDisplayString();
+    }
+
+    private static Dictionary<string, string> ParseVarArray(string json)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array)
+                return result;
+
+            foreach (var entry in doc.RootElement.EnumerateArray())
+            {
+                if (!entry.TryGetProperty("vartype", out var typeEl) || typeEl.GetString() != "value")
+                    continue;
+                if (!entry.TryGetProperty("varid", out var idEl) || !entry.TryGetProperty("varvalue", out var valueEl))
+                    continue;
+
+                var id = idEl.GetString();
+                var value = valueEl.GetString();
+                if (!string.IsNullOrEmpty(id) && value != null)
+                    result[id] = value;
+            }
+        }
+        catch (JsonException) { }
+
+        return result;
+    }
+
+    private static string? GetValue(Dictionary<string, string> values, string key) =>
+        values.TryGetValue(key, out var v) ? v : null;
+
+    private static double? ParseDouble(string? text) =>
+        double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out var val) ? val : null;
+
+    private static long? ParseLong(string? text) =>
+        long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var val) ? val : null;
+
+    /// <summary>
+    /// The device's firmware rejects requests with no Accept-Language header at all as an
+    /// "Invalid Request" 400 (confirmed live: identical requests succeed once this header is
+    /// present, regardless of network path). Matches Netzwerkfehler/hass-GFM2, a working Home
+    /// Assistant integration for this same device, which sets exactly this header and nothing
+    /// else beyond a plain GET.
+    /// </summary>
+    internal static HttpClient CreateClient()
+    {
+        var client = new HttpClient { Timeout = TimeSpan.FromSeconds(TimeoutSeconds) };
+        client.DefaultRequestHeaders.Add("Accept-Language", "en");
+        return client;
+    }
+
+    private static string BuildBaseUrl(OntPollContext context)
+    {
+        var port = context.Port > 0 ? context.Port : 80;
+        var portSuffix = port == 80 ? "" : $":{port}";
+        return $"http://{context.Host}{portSuffix}";
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/TelekomModem2OntProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/TelekomModem2OntProviderTests.cs
@@ -1,0 +1,114 @@
+using FluentAssertions;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Web.Services.OntProviders;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class TelekomModem2OntProviderTests
+{
+    // Captured verbatim from a live Glasfaser-Modem 2's /ONT/client/data/Status.json.
+    private const string FullStatusJson = """
+        [
+          {"vartype":"value","varid":"device_name","varvalue":"Glasfaser-Modem 2"},
+          {"vartype":"value","varid":"rebooting","varvalue":"0"},
+          {"vartype":"value","varid":"ploam_state","varvalue":""},
+          {"vartype":"value","varid":"ploam_success","varvalue":"1"},
+          {"vartype":"value","varid":"save_fails","varvalue":"0"},
+          {"vartype":"value","varid":"service_mode","varvalue":"0"},
+          {"vartype":"page_title","varid":"title","varvalue":"Glasfaser-Modem 2 Konfigurationsprogramm"},
+          {"vartype":"value","varid":"datetime","varvalue":"05.07.2026 00:23:38"},
+          {"vartype":"value","varid":"firmware_version","varvalue":"090144.1.0.001"},
+          {"vartype":"value","varid":"hardware_revision","varvalue":"V1"},
+          {"vartype":"value","varid":"fw_version_standby","varvalue":"090144.1.0.001"},
+          {"vartype":"value","varid":"hardware_state","varvalue":"1"},
+          {"vartype":"value","varid":"txpackets","varvalue":"1875424524"},
+          {"vartype":"value","varid":"txbytes","varvalue":"2288625314980"},
+          {"vartype":"value","varid":"rxpackets","varvalue":"820314346"},
+          {"vartype":"value","varid":"rxbytes","varvalue":"522995802597"},
+          {"vartype":"value","varid":"rxdrop_packets","varvalue":"0"},
+          {"vartype":"value","varid":"link_status","varvalue":"0"},
+          {"vartype":"value","varid":"stability","varvalue":"1247559"},
+          {"vartype":"value","varid":"rxbip_crc","varvalue":"0"},
+          {"vartype":"value","varid":"serial_number","varvalue":"53434F4D00C0FFEE"},
+          {"vartype":"value","varid":"txpower","varvalue":"2.39"},
+          {"vartype":"value","varid":"rxpower","varvalue":"-16.13"},
+          {"vartype":"value","varid":"ui_version","varvalue":"2.18.161"}
+        ]
+        """;
+
+    [Fact]
+    public void ApplyStatus_FullFixture_MapsAllFields()
+    {
+        var stats = new OntStats();
+
+        TelekomModem2OntProvider.ApplyStatus(FullStatusJson, stats);
+
+        stats.DeviceModel.Should().Be("Glasfaser-Modem 2");
+        stats.VendorPn.Should().Be("V1");
+        stats.VendorSn.Should().Be("53434F4D00C0FFEE");
+        stats.TxPowerDbm.Should().BeApproximately(2.39, 0.0001);
+        stats.RxPowerDbm.Should().BeApproximately(-16.13, 0.0001);
+        stats.BipErrors.Should().Be(0);
+        stats.LinkUptimeSeconds.Should().Be(1247559);
+        stats.PonLinkStatus.Should().Be(PonLinkState.Operation);
+        stats.OperationalStatus.Should().Be("Up");
+        stats.LinkState.Should().Be("Connected (O5)");
+        stats.PonType.Should().BeNull();
+    }
+
+    [Fact]
+    public void ApplyStatus_HardwareFault_SetsDown()
+    {
+        var stats = new OntStats();
+        var json = """
+            [{"vartype":"value","varid":"hardware_state","varvalue":"0"},
+             {"vartype":"value","varid":"ploam_success","varvalue":"1"},
+             {"vartype":"value","varid":"ploam_state","varvalue":""}]
+            """;
+
+        TelekomModem2OntProvider.ApplyStatus(json, stats);
+
+        stats.OperationalStatus.Should().Be("Down");
+        stats.PonLinkStatus.Should().Be(PonLinkState.Unknown);
+    }
+
+    [Fact]
+    public void ApplyStatus_NotYetActivated_FallsBackToPloamState()
+    {
+        var stats = new OntStats();
+        var json = """
+            [{"vartype":"value","varid":"hardware_state","varvalue":"1"},
+             {"vartype":"value","varid":"ploam_success","varvalue":"0"},
+             {"vartype":"value","varid":"ploam_state","varvalue":"O4"}]
+            """;
+
+        TelekomModem2OntProvider.ApplyStatus(json, stats);
+
+        stats.OperationalStatus.Should().Be("Down");
+        stats.PonLinkStatus.Should().Be(PonLinkState.Ranging);
+    }
+
+    [Fact]
+    public void ApplyStatus_MalformedJson_DoesNotThrowAndLeavesDefaults()
+    {
+        var stats = new OntStats();
+
+        var act = () => TelekomModem2OntProvider.ApplyStatus("not json", stats);
+
+        act.Should().NotThrow();
+        stats.RxPowerDbm.Should().BeNull();
+        stats.TxPowerDbm.Should().BeNull();
+    }
+
+    [Fact]
+    public void CreateClient_SetsAcceptLanguageHeader()
+    {
+        // The device's firmware rejects any request missing this header with a malformed
+        // "400 Bad Request" - confirmed live against a real Glasfaser-Modem 2, and matches
+        // Netzwerkfehler/hass-GFM2 (a working Home Assistant integration for this device).
+        using var client = TelekomModem2OntProvider.CreateClient();
+
+        client.DefaultRequestHeaders.AcceptLanguage.ToString().Should().Be("en");
+    }
+}


### PR DESCRIPTION
## Motivation

I run Network Optimizer on my own network (Telekom FTTH in Germany, UCG-Fiber). The ONT is Telekom's own "Glasfaser-Modem 2", which none of the existing ONT providers can talk to. This adds a provider for it, so its optical stats show up in ONT Device Monitoring like any other supported ONT.

## What it does

New `TelekomModem2OntProvider` (`ProviderKey: telekom-modem2`), registered in DI and selectable in the Settings ONT dropdown.

- Polls `/ONT/client/data/Status.json` over plain HTTP - the same endpoint the device's own web UI uses for its Status view. No login or session is needed; the device serves this openly.
- Maps TX/RX power, BIP errors (`rxbip_crc`), link uptime (`stability`), serial number, and hardware revision. Up/Down is derived from `hardware_state` + `ploam_success`, following the semantics of the device's own `status.js`.
- Parsing is defensive: missing or malformed fields fall back to `OntStats` defaults instead of throwing.

One firmware quirk worth knowing about: the device rejects any request that has no `Accept-Language` header at all, with a malformed 400 response (a raw `UNKNOWN 400 Bad Request` status line that strict HTTP clients refuse to parse). The provider always sends `Accept-Language: en`. Confirmed against real hardware, and consistent with [Netzwerkfehler/hass-GFM2](https://github.com/Netzwerkfehler/hass-GFM2), a working Home Assistant integration for this device, which sets exactly this header.

## Testing

- Unit tests parse a fixture captured verbatim from a real device (serial scrambled), plus degraded-link, malformed-JSON, and header cases.
- Verified end-to-end on my live Glasfaser-Modem 2 behind the UCG-Fiber's WAN port: Test Connection returns real values (`Connected (HTTP) - RX: -16.13 dBm, TX: 2.39 dBm`), and polling has been running against the device.
- Full solution test suite is green.

Heads-up: on my network the ONT shares its management IP (192.168.100.1) with a Starlink dish on the other WAN, so reliably testing this provider needed the duplicate-IP alias support in #963. The two PRs are independent code-wise (both add one line to `Program.cs`, that's the only overlap).

## Tooling disclosure

Per CODING_STANDARDS.md: this was built with heavy AI assistance (Claude Code - Sonnet/Opus/Fable - for implementation, GPT-5.5/Codex as an independent adversarial reviewer). Design decisions, every review round, and all live hardware verification were driven and checked by me. Happy to adjust anything that doesn't meet the bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
