### PR TITLE
Agent-owned proxy dial policy (site-local fence, operator pinning, dial audit log)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -401,14 +401,35 @@ IPs. Commercial and even residential sites are stable enough in practice; a stol
 from a random IP then dies at the firewall before the bearer key is presented. Bearer
 key + rate-limiting stay as defense-in-depth behind it.
 
+Implemented (agent-owned proxy controls; revises an earlier "not worth it" call):
+- **Site-local proxy dial fence** (always on): `ProxyOpen` targets must be RFC1918 /
+  IPv6 unique-local / IPv6 link-local; hostnames are resolved once, every address
+  validated, and the dial uses the validated addresses. The earlier rationale ("gateway
+  SSH pivots anyway, so an allowlist contains nothing") was right about LAN containment
+  but missed the **internet-relay vector**: unrestricted `ProxyOpen` let a compromised
+  server use every site as a silent exit node against third parties - no gateway creds
+  needed, no footprint on customer equipment. The fence closes exactly that, and only
+  claims that.
+- **Operator pin** (`proxyAllowedCidrs` in agent.json): replaces the fence with an
+  operator-owned CIDR list - real reach-capping the server can't override, and the only
+  escape hatch for public-IP targets.
+- **Dial audit trail**: every proxy dial (allow + deny) journaled agent-side where the
+  server can't suppress it.
+- NOT built (still on record as not worth it): a **server-pushed device allowlist**
+  (UniFi device list + custom targets enforced agent-side). The server is authoritative
+  for tunnel config, so a compromised server pushes its own list; signing doesn't help
+  (server holds the key) and TOFU/ratcheting either blocks legit changes (device
+  adoption, DHCP renumbering) or degrades to log-only. All complexity, no unforgeable
+  containment - the three controls above are the honest subset.
+
 Considered and deliberately NOT implemented (rationale on record so it isn't re-litigated):
-- **Agent-side proxy dial allowlist** (restrict `ProxyOpen` targets to the gateway/known
-  devices): not an effective control. Gateway SSH already reaches the whole LAN, so
-  anything with gateway access pivots through it regardless; restricting the agent's dial
-  targets contains nothing against a compromised server. Pure complexity.
 - **Hard SSH host-key pinning**: impractical. UniFi regenerates SSH host keys on firmware
   upgrades (and adoption/factory reset), so a strict pin breaks SSH after routine updates
   and trains operators to click through warnings - worse than the soft tripwire above.
+- **Agent-side SSH command filtering**: impossible at the agent - the proxied SSH session
+  is encrypted end-to-end between the central server and the gateway's sshd; the agent
+  pumps opaque bytes. Command safety lives server-side (parameterized command
+  construction); the gateway-side option is `authorized_keys` forced commands.
 
 ### Credential Key: Hardening Follow-ups
 

--- a/src/NetworkOptimizer.Agent/Program.cs
+++ b/src/NetworkOptimizer.Agent/Program.cs
@@ -59,6 +59,28 @@ if (!string.IsNullOrEmpty(config.TunnelUrl) && !IsHttpsUrl(config.TunnelUrl))
     return 1;
 }
 
+// Proxy dial policy: hardcoded site-local fence (RFC1918 / IPv6 local) unless the
+// operator pins an explicit CIDR list in agent.json, which fully replaces it. The
+// policy is agent-owned on purpose - nothing the server sends over the tunnel can
+// widen it. An invalid entry aborts startup: failing loud beats silently running
+// with a partial pin.
+var proxyPolicy = NetworkOptimizer.Core.Helpers.ProxyDialPolicy.SiteLocal;
+if (config.ProxyAllowedCidrs != null)
+{
+    var pinned = NetworkOptimizer.Core.Helpers.ProxyDialPolicy.FromPinnedCidrs(config.ProxyAllowedCidrs, out var policyError);
+    if (pinned == null)
+    {
+        Console.Error.WriteLine($"Invalid proxyAllowedCidrs in {configPath}: {policyError}");
+        return 1;
+    }
+    proxyPolicy = pinned;
+    Console.WriteLine($"Proxy dials pinned to {pinned.PinnedCount} operator-configured CIDR(s)");
+}
+else
+{
+    Console.WriteLine("Proxy dials restricted to site-local addresses (RFC1918 / IPv6 local)");
+}
+
 var version = Assembly.GetExecutingAssembly()
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "dev";
 
@@ -177,7 +199,7 @@ while (!cts.IsCancellationRequested)
         var tunnel = new TunnelClient();
         var probeRunner = new ProbeRunner(tunnel.TrySend, config.ProbeSourceIp);
         var snmpRunner = new SnmpRunner(tunnel);
-        var proxyHandler = new ProxyHandler(tunnel);
+        var proxyHandler = new ProxyHandler(tunnel, proxyPolicy);
         var iperf3ClientRunner = new Iperf3ClientRunner(tunnel);
         var uwnClientRunner = new UwnClientRunner(tunnel);
         var probeRequestRunner = new ProbeRequestRunner(tunnel);
@@ -255,6 +277,13 @@ return 0;
 namespace NetworkOptimizer.Agent
 {
     /// <summary>Agent configuration file contents (agent.json).</summary>
+    /// <remarks>
+    /// ProxyAllowedCidrs: operator pin for tunnel proxy dial targets (IPs or CIDRs).
+    /// When present it fully replaces the built-in site-local fence - both the
+    /// narrowing knob (pin to a management VLAN) and the only escape hatch for a
+    /// public-IP target. Include every subnet holding the UniFi Console, gateway,
+    /// devices used for SSH/speed tests, and modem/ONT/hotspot status pages.
+    /// </remarks>
     public record AgentConfig(
         string ServerUrl,
         string? EnrollmentToken,
@@ -264,7 +293,8 @@ namespace NetworkOptimizer.Agent
         string? TunnelUrl = null,
         string? ProbeSourceIp = null,
         bool LanSpeedTest = false,
-        int LanSpeedTestPort = 3000);
+        int LanSpeedTestPort = 3000,
+        IReadOnlyList<string>? ProxyAllowedCidrs = null);
 
     public record EnrollmentResponse(string AgentKey, string SiteSlug, int? TunnelPort = null);
 

--- a/src/NetworkOptimizer.Agent/ProxyHandler.cs
+++ b/src/NetworkOptimizer.Agent/ProxyHandler.cs
@@ -1,7 +1,9 @@
 using System.Collections.Concurrent;
+using System.Net;
 using System.Net.Sockets;
 using Google.Protobuf;
 using NetworkOptimizer.AgentProtocol;
+using NetworkOptimizer.Core.Helpers;
 
 namespace NetworkOptimizer.Agent;
 
@@ -12,17 +14,21 @@ namespace NetworkOptimizer.Agent;
 /// dies with its tunnel connection, like the probe runner.
 /// </summary>
 /// <remarks>
-/// Security model: the agent dials whatever host:port the server names, with no
-/// agent-side allowlist, and that is deliberate. The tunnel's legitimate job
-/// includes SSH to the site gateway, and the gateway is the LAN router - anything
-/// that can reach it already reaches the whole LAN - so an allowlist restricting
-/// proxy targets to "just the gateway" would contain nothing against a compromised
-/// central server (it would simply pivot through the gateway). The trust boundary
-/// is therefore the central server and the agentKey, not this dial path: harden
-/// the server (IP-allowlist the admin plane and this tunnel endpoint to your
-/// sites' IPs, strong auth, guard key material), and treat a server compromise as
-/// game-over for managed gateways, which is inherent to centralized gateway
-/// management. See the agent README "Security and hardening" section and TODO.md.
+/// Security model: dial targets are gated by a <see cref="ProxyDialPolicy"/> the
+/// agent owns - site-local addresses only by default, or the operator's pinned
+/// CIDR list from agent.json ("proxyAllowedCidrs"). Nothing on the tunnel can
+/// widen it, so a compromised central server cannot use this site as a relay to
+/// the internet, and an operator pin caps its LAN reach through this path to
+/// exactly the addresses listed. Every dial is journaled locally (allow and
+/// deny), an audit trail the server cannot suppress. What this deliberately does
+/// NOT claim: containment of a compromised server that holds gateway SSH
+/// credentials - the gateway is the LAN router, so that reach is LAN-wide
+/// regardless; protecting the central server remains the primary defense (see
+/// the agent README "Security and hardening" section and TODO.md). Hostnames are
+/// resolved once, every resolved address is validated, and the dial uses the
+/// validated addresses - a name that resolves to any out-of-scope address is
+/// refused outright rather than filtered, so DNS games can't split the check
+/// from the connect.
 /// </remarks>
 public sealed class ProxyHandler
 {
@@ -30,34 +36,69 @@ public sealed class ProxyHandler
     private static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(5);
 
     private readonly TunnelClient _tunnel;
+    private readonly ProxyDialPolicy _policy;
     private readonly ConcurrentDictionary<long, TcpClient> _connections = new();
 
-    public ProxyHandler(TunnelClient tunnel)
+    public ProxyHandler(TunnelClient tunnel, ProxyDialPolicy policy)
     {
         _tunnel = tunnel;
+        _policy = policy;
     }
 
     public async Task HandleOpenAsync(ProxyOpen open, CancellationToken ct)
     {
+        IPAddress[] addresses;
+        if (IPAddress.TryParse(open.Host, out var literal))
+        {
+            addresses = new[] { literal };
+        }
+        else
+        {
+            try
+            {
+                addresses = await Dns.GetHostAddressesAsync(open.Host, ct);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                await SendOpenFailureAsync(open.ConnectionId, $"could not resolve '{open.Host}': {ex.Message}", ct);
+                return;
+            }
+            if (addresses.Length == 0)
+            {
+                await SendOpenFailureAsync(open.ConnectionId, $"'{open.Host}' resolved to no addresses", ct);
+                return;
+            }
+        }
+
+        // All-or-nothing: one out-of-scope address in the resolution refuses the
+        // whole dial instead of narrowing to the in-scope subset.
+        var offender = addresses.FirstOrDefault(a => !_policy.IsAllowed(a));
+        if (offender != null)
+        {
+            var scope = _policy.IsDefault ? "site-local scope" : "the operator-pinned proxy scope";
+            Console.Error.WriteLine($"Proxy dial DENIED: {open.Host}:{open.Port} (conn {open.ConnectionId}) - {offender} is outside {scope}");
+            await SendOpenFailureAsync(open.ConnectionId,
+                $"proxy target denied by agent policy: {offender} is outside {scope}", ct);
+            return;
+        }
+
+        Console.WriteLine($"Proxy dial: {open.Host}:{open.Port} (conn {open.ConnectionId})");
+
         var client = new TcpClient();
         try
         {
             using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             connectCts.CancelAfter(ConnectTimeout);
-            await client.ConnectAsync(open.Host, open.Port, connectCts.Token);
+            // Dial the validated addresses, never the name - re-resolving here
+            // would let a changed DNS answer bypass the policy check above.
+            await client.ConnectAsync(addresses, open.Port, connectCts.Token);
         }
         catch (Exception ex)
         {
             client.Dispose();
-            await _tunnel.SendAsync(new AgentMessage
-            {
-                ProxyOpenResult = new ProxyOpenResult
-                {
-                    ConnectionId = open.ConnectionId,
-                    Ok = false,
-                    Error = ex is OperationCanceledException ? "connect timed out" : ex.Message,
-                }
-            }, ct);
+            var reason = ex is OperationCanceledException ? "connect timed out" : ex.Message;
+            Console.Error.WriteLine($"Proxy dial failed: {open.Host}:{open.Port} (conn {open.ConnectionId}) - {reason}");
+            await SendOpenFailureAsync(open.ConnectionId, reason, ct);
             return;
         }
 
@@ -101,6 +142,17 @@ public sealed class ProxyHandler
             }
         }
     }
+
+    private async Task SendOpenFailureAsync(long connectionId, string error, CancellationToken ct) =>
+        await _tunnel.SendAsync(new AgentMessage
+        {
+            ProxyOpenResult = new ProxyOpenResult
+            {
+                ConnectionId = connectionId,
+                Ok = false,
+                Error = error,
+            }
+        }, ct);
 
     public async Task HandleDataAsync(ProxyData data, CancellationToken ct)
     {

--- a/src/NetworkOptimizer.Agent/README.md
+++ b/src/NetworkOptimizer.Agent/README.md
@@ -265,12 +265,42 @@ is inherent to centralized gateway management, not a flaw of the tunnel - no
 protocol trick changes it, which is exactly why protecting the server is the
 whole ballgame.
 
-Two controls we deliberately did **not** build, so the reasoning is on record:
+### What the agent enforces on its own
 
-- **An agent-side allowlist on proxy dial targets** would contain nothing.
-  Gateway SSH already reaches the entire LAN, so anything with gateway access
-  pivots through it; restricting what the agent may dial doesn't limit a
-  compromised server, it just adds complexity.
+Three controls are agent-owned - nothing the server sends over the tunnel can
+change them:
+
+- **Site-local proxy fence (built in, always on).** The tunnel's TCP proxy
+  refuses to dial anything that is not a site-local address (RFC1918, IPv6
+  unique-local, IPv6 link-local). Everything the proxy legitimately reaches -
+  the UniFi Console, gateway/device SSH, modem/ONT/hotspot status pages - is
+  site-local, so normal setups never notice. What it closes is the quiet abuse
+  a compromised central server would otherwise get for free: using your site
+  as an exit node to relay attacks at third parties. Hostnames are resolved
+  once, every resolved address is checked, and the connection goes to the
+  checked address, so DNS tricks can't split the check from the dial.
+- **Operator pinning (`proxyAllowedCidrs` in `agent.json`, optional).** A list
+  of IPs/CIDRs that fully replaces the built-in fence. Pin it to narrow the
+  server's reach through the proxy to exactly the addresses you list (e.g.
+  just the management VLAN) - or to admit an exotic public-IP target, which is
+  the only escape hatch that exists. If you pin, include every subnet holding
+  the UniFi Console, the gateway, any devices used for SSH/speed tests or as
+  probe vantages, and modem/ONT/hotspot status pages - anything outside the
+  pin fails with a logged denial. An invalid entry aborts agent startup rather
+  than running half-pinned.
+- **Dial audit trail.** Every proxy dial (allowed or denied) is one line in
+  the agent's journal, with the target and connection id. The central server
+  cannot suppress or rotate it, so the site always has its own record of what
+  was reached through the tunnel: `journalctl -u netopt-agent | grep "Proxy dial"`.
+
+Honest scope: with gateway SSH credentials configured, a compromised central
+server still owns the LAN through the gateway - these controls close the
+internet-relay vector, cap what the proxy path can reach, and leave evidence;
+they do not (cannot) contain gateway-credential pivoting. That containment
+story remains server-side hardening, above.
+
+One control we deliberately did **not** build, so the reasoning is on record:
+
 - **Pinning the gateway's SSH host key** is impractical here: UniFi regenerates
   host keys on firmware upgrades (and adoption/factory reset), so a strict pin
   would break SSH after routine updates and train operators to click through
@@ -278,6 +308,13 @@ Two controls we deliberately did **not** build, so the reasoning is on record:
   gateway - is better addressed at the tunnel (guard the key, IP-allowlist, and
   one-tunnel-per-key), with at most a soft "host key changed" alert that never
   blocks.
+
+Also out of scope by design: filtering SSH *commands* at the agent. The proxied
+SSH session is encrypted end-to-end between the central server and the
+gateway's sshd; the agent pumps opaque bytes and cannot inspect them. Command
+safety lives server-side (parameterized command construction), and the
+gateway-side option (`authorized_keys` forced commands) is gateway
+configuration, not agent code.
 
 ## Local dev / testing
 

--- a/src/NetworkOptimizer.Core/Helpers/NetworkUtilities.cs
+++ b/src/NetworkOptimizer.Core/Helpers/NetworkUtilities.cs
@@ -322,30 +322,17 @@ public static class NetworkUtilities
 
         // IPv6 Unique Local Address (fc00::/7, primarily fd00::/8 in practice)
         if (ip.AddressFamily == AddressFamily.InterNetworkV6)
-        {
-            var v6Bytes = ip.GetAddressBytes();
-            if ((v6Bytes[0] & 0xFE) == 0xFC)
-                return true;
-            return false;
-        }
+            return IsIPv6UniqueLocal(ip);
 
         // Only do byte checks for IPv4
         if (ip.AddressFamily != AddressFamily.InterNetwork)
             return false;
 
+        // 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 (RFC1918)
+        if (IsRfc1918(ip))
+            return true;
+
         var bytes = ip.GetAddressBytes();
-
-        // 10.0.0.0/8 (RFC1918)
-        if (bytes[0] == 10)
-            return true;
-
-        // 172.16.0.0/12 (RFC1918)
-        if (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31)
-            return true;
-
-        // 192.168.0.0/16 (RFC1918)
-        if (bytes[0] == 192 && bytes[1] == 168)
-            return true;
 
         // 127.0.0.0/8 (Loopback)
         if (bytes[0] == 127)
@@ -368,6 +355,39 @@ public static class NetworkUtilities
             return true;
 
         return false;
+    }
+
+    /// <summary>
+    /// Check if an IP address is in one of the three RFC1918 private IPv4 blocks
+    /// (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16). Stricter than
+    /// <see cref="IsPrivateIpAddress(IPAddress)"/>: loopback, link-local, CGNAT, and
+    /// multicast are NOT RFC1918. IPv4-mapped IPv6 addresses are unwrapped first.
+    /// </summary>
+    /// <param name="ip">Parsed IP address to check</param>
+    /// <returns>True if the IP is in an RFC1918 block</returns>
+    public static bool IsRfc1918(IPAddress ip)
+    {
+        if (ip.IsIPv4MappedToIPv6)
+            ip = ip.MapToIPv4();
+        if (ip.AddressFamily != AddressFamily.InterNetwork)
+            return false;
+
+        var bytes = ip.GetAddressBytes();
+        return bytes[0] == 10
+            || (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31)
+            || (bytes[0] == 192 && bytes[1] == 168);
+    }
+
+    /// <summary>
+    /// Check if an IP address is an IPv6 unique local address (fc00::/7, in practice fd00::/8).
+    /// </summary>
+    /// <param name="ip">Parsed IP address to check</param>
+    /// <returns>True if the IP is an IPv6 ULA</returns>
+    public static bool IsIPv6UniqueLocal(IPAddress ip)
+    {
+        if (ip.AddressFamily != AddressFamily.InterNetworkV6)
+            return false;
+        return (ip.GetAddressBytes()[0] & 0xFE) == 0xFC;
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Core/Helpers/ProxyDialPolicy.cs
+++ b/src/NetworkOptimizer.Core/Helpers/ProxyDialPolicy.cs
@@ -1,0 +1,97 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace NetworkOptimizer.Core.Helpers;
+
+/// <summary>
+/// Address-scope policy for the on-site agent's tunnel TCP proxy: decides whether a
+/// proxy dial target is inside the allowed scope. The default policy admits only
+/// site-local addresses (RFC1918, IPv6 unique-local, IPv6 link-local) and is
+/// hardcoded so a compromised central server cannot widen it over the tunnel - the
+/// tunnel carries no message that reaches this policy. An operator can replace the
+/// default with an explicit CIDR/host list via agent.json ("proxyAllowedCidrs"),
+/// which is both the narrowing knob (pin to a management VLAN) and the only escape
+/// hatch for an exotic public-IP target.
+/// </summary>
+public sealed class ProxyDialPolicy
+{
+    private readonly IReadOnlyList<string>? _pinnedCidrs;
+
+    private ProxyDialPolicy(IReadOnlyList<string>? pinnedCidrs)
+    {
+        _pinnedCidrs = pinnedCidrs;
+    }
+
+    /// <summary>The built-in default: RFC1918, IPv6 unique-local, and IPv6 link-local only.</summary>
+    public static ProxyDialPolicy SiteLocal { get; } = new(null);
+
+    /// <summary>Whether this is the built-in site-local default (no operator pin).</summary>
+    public bool IsDefault => _pinnedCidrs == null;
+
+    /// <summary>Number of operator-pinned entries; 0 for the default policy.</summary>
+    public int PinnedCount => _pinnedCidrs?.Count ?? 0;
+
+    /// <summary>
+    /// Build an operator-pinned policy from CIDR entries (bare IPs are treated as
+    /// /32 or /128). The pin fully replaces the site-local default. Returns null
+    /// with an error message when any entry is invalid or the list is empty -
+    /// callers must fail loudly rather than run with a partial or ambiguous pin.
+    /// </summary>
+    public static ProxyDialPolicy? FromPinnedCidrs(IEnumerable<string?> entries, out string? error)
+    {
+        var normalized = new List<string>();
+        foreach (var raw in entries)
+        {
+            var entry = raw?.Trim();
+            if (string.IsNullOrEmpty(entry))
+                continue;
+
+            if (entry.Contains('/'))
+            {
+                var (network, prefixLength) = NetworkUtilities.ParseCidr(entry);
+                var maxPrefix = network?.AddressFamily == AddressFamily.InterNetworkV6 ? 128 : 32;
+                if (network == null || prefixLength < 0 || prefixLength > maxPrefix)
+                {
+                    error = $"invalid CIDR '{entry}'";
+                    return null;
+                }
+                normalized.Add(entry);
+            }
+            else if (IPAddress.TryParse(entry, out var ip))
+            {
+                normalized.Add(ip.AddressFamily == AddressFamily.InterNetworkV6 ? $"{entry}/128" : $"{entry}/32");
+            }
+            else
+            {
+                error = $"invalid entry '{entry}' (expected an IP or CIDR)";
+                return null;
+            }
+        }
+
+        if (normalized.Count == 0)
+        {
+            error = "the list is empty";
+            return null;
+        }
+
+        error = null;
+        return new ProxyDialPolicy(normalized);
+    }
+
+    /// <summary>
+    /// Whether the policy allows dialing the given address. IPv4-mapped IPv6
+    /// addresses are unwrapped before evaluation so a public IPv4 target cannot
+    /// slip through as ::ffff:a.b.c.d.
+    /// </summary>
+    public bool IsAllowed(IPAddress address)
+    {
+        var ip = address.IsIPv4MappedToIPv6 ? address.MapToIPv4() : address;
+
+        if (_pinnedCidrs != null)
+            return _pinnedCidrs.Any(cidr => NetworkUtilities.IsIpInSubnet(ip, cidr));
+
+        return NetworkUtilities.IsRfc1918(ip)
+            || NetworkUtilities.IsIPv6UniqueLocal(ip)
+            || ip.IsIPv6LinkLocal;
+    }
+}

--- a/src/NetworkOptimizer.Storage/Repositories/UniFiRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/UniFiRepository.cs
@@ -214,7 +214,10 @@ public class UniFiRepository : IUniFiRepository
                     existing.Iperf3ParallelStreams = config.Iperf3ParallelStreams;
                     existing.Iperf3DurationSeconds = config.Iperf3DurationSeconds;
                     existing.SshUsername = config.SshUsername;
-                    existing.SshPassword = config.SshPassword;
+                    // Blank means keep: the edit form never round-trips the stored encrypted
+                    // password and only sets this field when the user typed a new one.
+                    if (!string.IsNullOrEmpty(config.SshPassword))
+                        existing.SshPassword = config.SshPassword;
                     existing.SshPrivateKeyPath = config.SshPrivateKeyPath;
                     existing.UpdatedAt = DateTime.UtcNow;
                 }

--- a/src/NetworkOptimizer.Storage/Repositories/UniFiRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/UniFiRepository.cs
@@ -199,6 +199,12 @@ public class UniFiRepository : IUniFiRepository
     {
         try
         {
+            // Key auth wins: a configured key path drops the password (matching the
+            // gateway/UniFi SSH settings pages), so a broken key fails loudly instead
+            // of silently falling back to a stale stored password.
+            if (!string.IsNullOrEmpty(config.SshPrivateKeyPath))
+                config.SshPassword = null;
+
             if (config.Id > 0)
             {
                 var existing = await _context.DeviceSshConfigurations
@@ -218,6 +224,8 @@ public class UniFiRepository : IUniFiRepository
                     // password and only sets this field when the user typed a new one.
                     if (!string.IsNullOrEmpty(config.SshPassword))
                         existing.SshPassword = config.SshPassword;
+                    else if (!string.IsNullOrEmpty(config.SshPrivateKeyPath))
+                        existing.SshPassword = null;
                     existing.SshPrivateKeyPath = config.SshPrivateKeyPath;
                     existing.UpdatedAt = DateTime.UtcNow;
                 }

--- a/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
@@ -637,12 +637,12 @@
 
                         <div class="form-group">
                             <label class="form-label">SSH Username</label>
-                            <input type="text" class="form-control" @bind="editingDevice.SshUsername" placeholder="(using global setting)" />
+                            <input type="text" class="form-control" autocomplete="off" @bind="editingDevice.SshUsername" placeholder="(using global setting)" />
                         </div>
 
                         <div class="form-group">
                             <label class="form-label">SSH Password</label>
-                            <input type="password" class="form-control" @bind="editingDevicePassword" placeholder="@(!string.IsNullOrWhiteSpace(editingDevice.SshPrivateKeyPath) ? "(using SSH key)" : editingDeviceHasSavedPassword ? "Saved – enter new to update" : "(using global setting)")" />
+                            <input type="password" class="form-control" autocomplete="new-password" data-1p-ignore data-lpignore="true" data-bwignore @bind="editingDevicePassword" placeholder="@(!string.IsNullOrWhiteSpace(editingDevice.SshPrivateKeyPath) ? "(using SSH key)" : editingDeviceHasSavedPassword ? "Saved – enter new to update" : "(using global setting)")" />
                             <span class="form-help">Password is encrypted at rest</span>
                         </div>
 

--- a/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
@@ -107,7 +107,9 @@ else if (IsShowingExternal && _externalOntStats != null)
     </div>
 
     <div class="sqm-actions">
-        <button class="btn btn-secondary" @onclick="RefreshExternal" @onclick:stopPropagation>Refresh</button>
+        <button class="btn btn-secondary" @onclick="RefreshExternal" @onclick:stopPropagation disabled="@_isRefreshing">
+            @if (_isRefreshing) { <span class="spinner-sm"></span> } else { <span>Refresh</span> }
+        </button>
         <a href="/settings#ont-monitoring" class="btn btn-primary" @onclick:stopPropagation>ONT Settings</a>
     </div>
 }
@@ -156,7 +158,9 @@ else if (IsShowingExternal)
     </div>
 
     <div class="sqm-actions">
-        <button class="btn btn-secondary" @onclick="RefreshExternal" @onclick:stopPropagation>Refresh</button>
+        <button class="btn btn-secondary" @onclick="RefreshExternal" @onclick:stopPropagation disabled="@_isRefreshing">
+            @if (_isRefreshing) { <span class="spinner-sm"></span> } else { <span>Refresh</span> }
+        </button>
         <a href="/settings#ont-monitoring" class="btn btn-primary" @onclick:stopPropagation>ONT Settings</a>
     </div>
 }
@@ -327,6 +331,7 @@ else
     private int _currentIndex = 0;
     private System.Threading.Timer? _refreshTimer;
     private OntStats? _externalOntStats;
+    private bool _isRefreshing;
 
     private int TotalCount => _monitoredOnts.Count + _externalOnts.Count;
     private bool IsShowingExternal => _currentIndex >= _monitoredOnts.Count;
@@ -425,10 +430,19 @@ else
     private async Task RefreshExternal()
     {
         var extIdx = _currentIndex - _monitoredOnts.Count;
-        if (extIdx < 0 || extIdx >= _externalOnts.Count) return;
-        await ExternalOntService.PollOntAsync(_externalOnts[extIdx].Id);
-        RefreshExternalStats();
+        if (extIdx < 0 || extIdx >= _externalOnts.Count || _isRefreshing) return;
+        _isRefreshing = true;
         StateHasChanged();
+        try
+        {
+            await ExternalOntService.PollOntAsync(_externalOnts[extIdx].Id);
+            RefreshExternalStats();
+        }
+        finally
+        {
+            _isRefreshing = false;
+            StateHasChanged();
+        }
     }
 
     private string ExternalRxClass()

--- a/tests/NetworkOptimizer.Core.Tests/Helpers/NetworkUtilitiesTests.cs
+++ b/tests/NetworkOptimizer.Core.Tests/Helpers/NetworkUtilitiesTests.cs
@@ -553,4 +553,60 @@ public class NetworkUtilitiesTests
     }
 
     #endregion
+
+    #region IsRfc1918 Tests
+
+    [Theory]
+    [InlineData("10.0.0.1", true)]
+    [InlineData("10.255.255.255", true)]
+    [InlineData("172.16.0.1", true)]
+    [InlineData("172.31.255.254", true)]
+    [InlineData("192.168.0.1", true)]
+    [InlineData("192.168.255.254", true)]
+    // IPv4-mapped IPv6 forms unwrap before evaluation
+    [InlineData("::ffff:192.168.1.10", true)]
+    [InlineData("::ffff:203.0.113.5", false)]
+    // Adjacent and lookalike ranges are NOT RFC1918
+    [InlineData("9.255.255.255", false)]
+    [InlineData("11.0.0.1", false)]
+    [InlineData("172.15.255.255", false)]
+    [InlineData("172.32.0.1", false)]
+    [InlineData("192.167.1.1", false)]
+    [InlineData("192.169.1.1", false)]
+    // Private-adjacent classes IsPrivateIpAddress accepts but strict RFC1918 must not
+    [InlineData("127.0.0.1", false)]
+    [InlineData("169.254.10.10", false)]
+    [InlineData("100.64.0.1", false)]
+    [InlineData("224.0.0.1", false)]
+    [InlineData("0.0.0.0", false)]
+    // Public and IPv6
+    [InlineData("203.0.113.5", false)]
+    [InlineData("8.8.8.8", false)]
+    [InlineData("2001:db8::1", false)]
+    [InlineData("fd00::1", false)]
+    public void IsRfc1918_ClassifiesStrictly(string ip, bool expected)
+    {
+        NetworkUtilities.IsRfc1918(IPAddress.Parse(ip)).Should().Be(expected);
+    }
+
+    #endregion
+
+    #region IsIPv6UniqueLocal Tests
+
+    [Theory]
+    [InlineData("fc00::1", true)]
+    [InlineData("fd00::1", true)]
+    [InlineData("fdab:cdef::42", true)]
+    [InlineData("fbff::1", false)]
+    [InlineData("fe00::1", false)]
+    [InlineData("fe80::1", false)]
+    [InlineData("2001:db8::1", false)]
+    [InlineData("::1", false)]
+    [InlineData("192.168.1.1", false)]
+    public void IsIPv6UniqueLocal_ClassifiesFc00Slash7(string ip, bool expected)
+    {
+        NetworkUtilities.IsIPv6UniqueLocal(IPAddress.Parse(ip)).Should().Be(expected);
+    }
+
+    #endregion
 }

--- a/tests/NetworkOptimizer.Core.Tests/Helpers/ProxyDialPolicyTests.cs
+++ b/tests/NetworkOptimizer.Core.Tests/Helpers/ProxyDialPolicyTests.cs
@@ -11,9 +11,9 @@ public class ProxyDialPolicyTests
 
     [Theory]
     // RFC1918
-    [InlineData("10.10.1.1", true)]
+    [InlineData("10.20.30.1", true)]
     [InlineData("172.16.5.10", true)]
-    [InlineData("192.168.50.1", true)]
+    [InlineData("192.168.77.1", true)]
     // IPv6 unique-local and link-local
     [InlineData("fd00::1", true)]
     [InlineData("fe80::1", true)]
@@ -57,13 +57,13 @@ public class ProxyDialPolicyTests
     [Fact]
     public void Pinned_ReplacesDefaultEntirely()
     {
-        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { "10.10.1.0/24" }, out var error);
+        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { "10.20.30.0/24" }, out var error);
 
         error.Should().BeNull();
         policy.Should().NotBeNull();
         policy!.IsDefault.Should().BeFalse();
-        policy.IsAllowed(IPAddress.Parse("10.10.1.1")).Should().BeTrue();
-        policy.IsAllowed(IPAddress.Parse("10.10.1.200")).Should().BeTrue();
+        policy.IsAllowed(IPAddress.Parse("10.20.30.1")).Should().BeTrue();
+        policy.IsAllowed(IPAddress.Parse("10.20.30.200")).Should().BeTrue();
         // Site-local but outside the pin: denied (replace, not extend)
         policy.IsAllowed(IPAddress.Parse("10.10.2.1")).Should().BeFalse();
         policy.IsAllowed(IPAddress.Parse("192.168.1.1")).Should().BeFalse();
@@ -73,21 +73,21 @@ public class ProxyDialPolicyTests
     public void Pinned_CanAdmitPublicTargets()
     {
         // The operator escape hatch for an exotic public-IP custom target
-        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { "192.168.50.0/24", "203.0.113.5" }, out _);
+        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { "192.168.77.0/24", "203.0.113.5" }, out _);
 
         policy!.IsAllowed(IPAddress.Parse("203.0.113.5")).Should().BeTrue();
         policy.IsAllowed(IPAddress.Parse("203.0.113.6")).Should().BeFalse();
-        policy.IsAllowed(IPAddress.Parse("192.168.50.1")).Should().BeTrue();
+        policy.IsAllowed(IPAddress.Parse("192.168.77.1")).Should().BeTrue();
     }
 
     [Fact]
     public void Pinned_BareIpsBecomeExactMatches()
     {
-        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { "10.10.1.1", "fd00::5" }, out _);
+        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { "10.20.30.1", "fd00::5" }, out _);
 
         policy!.PinnedCount.Should().Be(2);
-        policy.IsAllowed(IPAddress.Parse("10.10.1.1")).Should().BeTrue();
-        policy.IsAllowed(IPAddress.Parse("10.10.1.2")).Should().BeFalse();
+        policy.IsAllowed(IPAddress.Parse("10.20.30.1")).Should().BeTrue();
+        policy.IsAllowed(IPAddress.Parse("10.20.30.2")).Should().BeFalse();
         policy.IsAllowed(IPAddress.Parse("fd00::5")).Should().BeTrue();
         policy.IsAllowed(IPAddress.Parse("fd00::6")).Should().BeFalse();
     }
@@ -104,22 +104,22 @@ public class ProxyDialPolicyTests
     [Fact]
     public void Pinned_SkipsBlankEntries()
     {
-        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { " 10.10.1.0/24 ", "", "  ", null }, out var error);
+        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { " 10.20.30.0/24 ", "", "  ", null }, out var error);
 
         error.Should().BeNull();
         policy!.PinnedCount.Should().Be(1);
-        policy.IsAllowed(IPAddress.Parse("10.10.1.1")).Should().BeTrue();
+        policy.IsAllowed(IPAddress.Parse("10.20.30.1")).Should().BeTrue();
     }
 
     [Theory]
     [InlineData("not-an-ip")]
-    [InlineData("10.10.1.0/33")]
-    [InlineData("10.10.1.0/-1")]
+    [InlineData("10.20.30.0/33")]
+    [InlineData("10.20.30.0/-1")]
     [InlineData("banana/24")]
     [InlineData("fd00::/129")]
     public void Pinned_InvalidEntryFailsLoudly(string entry)
     {
-        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { "10.10.1.0/24", entry }, out var error);
+        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { "10.20.30.0/24", entry }, out var error);
 
         policy.Should().BeNull();
         error.Should().NotBeNull();

--- a/tests/NetworkOptimizer.Core.Tests/Helpers/ProxyDialPolicyTests.cs
+++ b/tests/NetworkOptimizer.Core.Tests/Helpers/ProxyDialPolicyTests.cs
@@ -1,0 +1,139 @@
+using System.Net;
+using FluentAssertions;
+using NetworkOptimizer.Core.Helpers;
+using Xunit;
+
+namespace NetworkOptimizer.Core.Tests.Helpers;
+
+public class ProxyDialPolicyTests
+{
+    #region Default (site-local) policy
+
+    [Theory]
+    // RFC1918
+    [InlineData("10.10.1.1", true)]
+    [InlineData("172.16.5.10", true)]
+    [InlineData("192.168.50.1", true)]
+    // IPv6 unique-local and link-local
+    [InlineData("fd00::1", true)]
+    [InlineData("fe80::1", true)]
+    // Public
+    [InlineData("203.0.113.5", false)]
+    [InlineData("8.8.8.8", false)]
+    [InlineData("2001:db8::1", false)]
+    // Loopback is not a proxy target (console/gateway/devices are never the agent itself)
+    [InlineData("127.0.0.1", false)]
+    [InlineData("::1", false)]
+    // IPv4 link-local and CGNAT: reviewed and excluded from the default fence
+    [InlineData("169.254.10.10", false)]
+    [InlineData("100.64.0.1", false)]
+    // Multicast / unspecified
+    [InlineData("224.0.0.1", false)]
+    [InlineData("0.0.0.0", false)]
+    public void SiteLocal_AllowsOnlySiteLocalAddresses(string ip, bool expected)
+    {
+        ProxyDialPolicy.SiteLocal.IsAllowed(IPAddress.Parse(ip)).Should().Be(expected);
+    }
+
+    [Fact]
+    public void SiteLocal_UnwrapsIPv4MappedIPv6()
+    {
+        // A public IPv4 must not slip through as ::ffff:a.b.c.d
+        ProxyDialPolicy.SiteLocal.IsAllowed(IPAddress.Parse("::ffff:203.0.113.5")).Should().BeFalse();
+        ProxyDialPolicy.SiteLocal.IsAllowed(IPAddress.Parse("::ffff:192.168.1.10")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void SiteLocal_IsDefault()
+    {
+        ProxyDialPolicy.SiteLocal.IsDefault.Should().BeTrue();
+        ProxyDialPolicy.SiteLocal.PinnedCount.Should().Be(0);
+    }
+
+    #endregion
+
+    #region Pinned policy
+
+    [Fact]
+    public void Pinned_ReplacesDefaultEntirely()
+    {
+        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { "10.10.1.0/24" }, out var error);
+
+        error.Should().BeNull();
+        policy.Should().NotBeNull();
+        policy!.IsDefault.Should().BeFalse();
+        policy.IsAllowed(IPAddress.Parse("10.10.1.1")).Should().BeTrue();
+        policy.IsAllowed(IPAddress.Parse("10.10.1.200")).Should().BeTrue();
+        // Site-local but outside the pin: denied (replace, not extend)
+        policy.IsAllowed(IPAddress.Parse("10.10.2.1")).Should().BeFalse();
+        policy.IsAllowed(IPAddress.Parse("192.168.1.1")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Pinned_CanAdmitPublicTargets()
+    {
+        // The operator escape hatch for an exotic public-IP custom target
+        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { "192.168.50.0/24", "203.0.113.5" }, out _);
+
+        policy!.IsAllowed(IPAddress.Parse("203.0.113.5")).Should().BeTrue();
+        policy.IsAllowed(IPAddress.Parse("203.0.113.6")).Should().BeFalse();
+        policy.IsAllowed(IPAddress.Parse("192.168.50.1")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Pinned_BareIpsBecomeExactMatches()
+    {
+        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { "10.10.1.1", "fd00::5" }, out _);
+
+        policy!.PinnedCount.Should().Be(2);
+        policy.IsAllowed(IPAddress.Parse("10.10.1.1")).Should().BeTrue();
+        policy.IsAllowed(IPAddress.Parse("10.10.1.2")).Should().BeFalse();
+        policy.IsAllowed(IPAddress.Parse("fd00::5")).Should().BeTrue();
+        policy.IsAllowed(IPAddress.Parse("fd00::6")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Pinned_UnwrapsIPv4MappedIPv6()
+    {
+        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { "192.168.1.0/24" }, out _);
+
+        policy!.IsAllowed(IPAddress.Parse("::ffff:192.168.1.10")).Should().BeTrue();
+        policy.IsAllowed(IPAddress.Parse("::ffff:192.168.2.10")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Pinned_SkipsBlankEntries()
+    {
+        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { " 10.10.1.0/24 ", "", "  ", null }, out var error);
+
+        error.Should().BeNull();
+        policy!.PinnedCount.Should().Be(1);
+        policy.IsAllowed(IPAddress.Parse("10.10.1.1")).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("not-an-ip")]
+    [InlineData("10.10.1.0/33")]
+    [InlineData("10.10.1.0/-1")]
+    [InlineData("banana/24")]
+    [InlineData("fd00::/129")]
+    public void Pinned_InvalidEntryFailsLoudly(string entry)
+    {
+        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { "10.10.1.0/24", entry }, out var error);
+
+        policy.Should().BeNull();
+        error.Should().NotBeNull();
+        error.Should().Contain(entry);
+    }
+
+    [Fact]
+    public void Pinned_EmptyListFailsLoudly()
+    {
+        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { "", "  " }, out var error);
+
+        policy.Should().BeNull();
+        error.Should().NotBeNull();
+    }
+
+    #endregion
+}

--- a/tests/NetworkOptimizer.Storage.Tests/UniFiRepositoryTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/UniFiRepositoryTests.cs
@@ -198,6 +198,61 @@ public class UniFiRepositoryTests : IDisposable
     }
 
     [Fact]
+    public async Task SaveDeviceSshConfigurationAsync_UpdateWithBlankPassword_KeepsStoredPassword()
+    {
+        // The edit form never round-trips the stored encrypted password; a blank
+        // incoming password on update means "unchanged", not "clear".
+        var device = new DeviceSshConfiguration
+        {
+            Name = "Device",
+            Host = "192.168.1.1",
+            SshUsername = "User1",
+            SshPassword = "encrypted-blob"
+        };
+        _context.DeviceSshConfigurations.Add(device);
+        await _context.SaveChangesAsync();
+
+        var update = new DeviceSshConfiguration
+        {
+            Id = device.Id,
+            Name = "Device",
+            Host = "192.168.1.1",
+            SshUsername = "User2",
+            SshPassword = null
+        };
+        await _repository.SaveDeviceSshConfigurationAsync(update);
+
+        var saved = await _context.DeviceSshConfigurations.FindAsync(device.Id);
+        saved!.SshUsername.Should().Be("User2");
+        saved.SshPassword.Should().Be("encrypted-blob");
+    }
+
+    [Fact]
+    public async Task SaveDeviceSshConfigurationAsync_UpdateWithNewPassword_Overwrites()
+    {
+        var device = new DeviceSshConfiguration
+        {
+            Name = "Device",
+            Host = "192.168.1.1",
+            SshPassword = "old-blob"
+        };
+        _context.DeviceSshConfigurations.Add(device);
+        await _context.SaveChangesAsync();
+
+        var update = new DeviceSshConfiguration
+        {
+            Id = device.Id,
+            Name = "Device",
+            Host = "192.168.1.1",
+            SshPassword = "new-blob"
+        };
+        await _repository.SaveDeviceSshConfigurationAsync(update);
+
+        var saved = await _context.DeviceSshConfigurations.FindAsync(device.Id);
+        saved!.SshPassword.Should().Be("new-blob");
+    }
+
+    [Fact]
     public async Task DeleteDeviceSshConfigurationAsync_RemovesDevice()
     {
         var device = new DeviceSshConfiguration { Name = "To Delete", Host = "192.168.1.1" };

--- a/tests/NetworkOptimizer.Storage.Tests/UniFiRepositoryTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/UniFiRepositoryTests.cs
@@ -253,6 +253,54 @@ public class UniFiRepositoryTests : IDisposable
     }
 
     [Fact]
+    public async Task SaveDeviceSshConfigurationAsync_UpdateWithKeyPath_ClearsStoredPassword()
+    {
+        // Switching to key auth drops the stored password (matching the gateway and
+        // UniFi SSH settings pages), so a broken key fails loudly instead of silently
+        // falling back to the old password.
+        var device = new DeviceSshConfiguration
+        {
+            Name = "Device",
+            Host = "192.168.1.1",
+            SshPassword = "encrypted-blob"
+        };
+        _context.DeviceSshConfigurations.Add(device);
+        await _context.SaveChangesAsync();
+
+        var update = new DeviceSshConfiguration
+        {
+            Id = device.Id,
+            Name = "Device",
+            Host = "192.168.1.1",
+            SshPassword = null,
+            SshPrivateKeyPath = "/app/ssh-keys/id_test"
+        };
+        await _repository.SaveDeviceSshConfigurationAsync(update);
+
+        var saved = await _context.DeviceSshConfigurations.FindAsync(device.Id);
+        saved!.SshPassword.Should().BeNull();
+        saved.SshPrivateKeyPath.Should().Be("/app/ssh-keys/id_test");
+    }
+
+    [Fact]
+    public async Task SaveDeviceSshConfigurationAsync_KeyPathWinsOverTypedPassword()
+    {
+        var device = new DeviceSshConfiguration
+        {
+            Name = "Device",
+            Host = "192.168.1.1",
+            SshPassword = "typed-blob",
+            SshPrivateKeyPath = "/app/ssh-keys/id_test"
+        };
+
+        await _repository.SaveDeviceSshConfigurationAsync(device);
+
+        var saved = await _context.DeviceSshConfigurations.FirstOrDefaultAsync(d => d.Name == "Device");
+        saved!.SshPassword.Should().BeNull();
+        saved.SshPrivateKeyPath.Should().Be("/app/ssh-keys/id_test");
+    }
+
+    [Fact]
     public async Task DeleteDeviceSshConfigurationAsync_RemovesDevice()
     {
         var device = new DeviceSshConfiguration { Name = "To Delete", Host = "192.168.1.1" };


### PR DESCRIPTION
## What

The on-site agent now enforces its own policy on tunnel TCP proxy dials (`ProxyOpen`), plus a small dashboard polish on the ONT stats panel.

### Agent: site-local proxy dial policy

Previously the agent dialed any `host:port` the central server named. It now refuses targets outside site-local address space (RFC1918, IPv6 unique-local, IPv6 link-local) by default:

- **Agent-owned by design** - the policy is not configurable over the tunnel, so a compromised or misbehaving central server cannot widen it and cannot use a site as a relay toward the internet. Everything the proxy legitimately reaches (UniFi Console, gateway/device SSH, modem/ONT/hotspot status pages) is site-local, so existing setups are unaffected.
- **Operator pinning** - an optional `proxyAllowedCidrs` list in `agent.json` fully replaces the built-in fence: narrow the server's reach to specific subnets, or admit an unusual public-IP target. Invalid entries abort agent startup rather than running half-pinned.
- **DNS-safe validation** - hostnames are resolved once, every resolved address is validated, and the connection goes to the validated addresses; a name resolving to any out-of-scope address is refused outright.
- **Dial audit trail** - every proxy dial (allowed or denied) is journaled on the agent host with the target and connection id, giving each site its own record of what was reached through the tunnel. Denials also surface in the server logs with the reason.

`NetworkUtilities` gains strict `IsRfc1918()` / `IsIPv6UniqueLocal()` predicates (with `IsPrivateIpAddress()` refactored to reuse them), and the new `ProxyDialPolicy` helper carries the policy logic with full unit coverage, including IPv4-mapped IPv6 unwrapping so public addresses can't slip through as `::ffff:a.b.c.d`.

The agent README "Security and hardening" section and TODO.md are updated to match: what these controls do and do not claim, the pinning coverage checklist, and why SSH command filtering cannot live at the agent (the proxied SSH session is encrypted end-to-end; the agent pumps opaque bytes).

No protocol change - new agents work against any server version, and older agents keep their current behavior until updated.

### Dashboard

- **ONT stats panel** - the Refresh button now shows a spinner and disables while polling, matching the cable modem and cellular panels.

### Fixes

- **Custom speed test device: editing wiped the stored SSH password** - the repository update path copied the password field unconditionally, but the edit form deliberately sends it blank to mean "unchanged". Renaming a device or changing its username silently cleared its saved SSH password, breaking subsequent tests until it was re-entered. Blank now means keep, and configuring a private key path clears the stored password (key auth and password auth are mutually exclusive, matching the gateway and UniFi SSH settings pages) - so a broken key file fails loudly instead of silently falling back to a stale password. Both behaviors are regression-tested. The device form's credential inputs also gain the `autocomplete`/password-manager opt-out attributes the Settings forms already had, so browser extensions can't autofill them.

## Testing

- Full test suite green; new unit coverage for the dial policy (default fence, pinning semantics, invalid-entry handling), the address predicates, and the device-password preserve-on-blank repository behavior.
- Verified live on two agent-backed sites: tunnels reconnect and the console, gateway SSH, UniFi device speed tests, and a custom device speed test all ride the proxy with audit lines and zero denials; Network Tools probes (agent and device vantage) unaffected.
- Negative path verified live: a deliberately narrow pin denies with a clear journal line and server-side error, and recovers on revert.

