### PR TITLE
Detect mid-window path shifts whose transition sample lands outside the step band

### DIFF
--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/StepChangeDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/StepChangeDetector.cs
@@ -44,7 +44,8 @@ public static class StepChangeDetector
             // A shift that lands mid-window leaves a transition window straddling both
             // levels, whose wide IQR overlaps the before-window and masks the step
             // (seen in real data). So also try comparing against the window after it,
-            // accepting the skipped window only when its median sits between the levels.
+            // rejecting the skipped window only when it is a stable level outside the
+            // two step levels (a genuine third level, not a transition).
             var detected = TryDetectStep(windows, i, afterIndex: i + 1, options)
                 ?? TryDetectStep(windows, i, afterIndex: i + 2, options);
             if (detected == null) continue;
@@ -92,11 +93,17 @@ public static class StepChangeDetector
         if (!IsStableLevel(before, options) || !IsStableLevel(after, options)) return null;
         if (afterIndex == beforeIndex + 2)
         {
-            var transition = windows[beforeIndex + 1].MedianMs;
-            var inBetween = delta > 0
-                ? transition > before.MedianMs && transition < after.MedianMs
-                : transition < before.MedianMs && transition > after.MedianMs;
-            if (!inBetween) return null;
+            // The skipped window mixes both levels, and which side its median lands on
+            // depends on where the crossing fell within it - noise can push it fractionally
+            // outside the [before, after] band (a real step-up was missed because a small
+            // pre-shift dip left the transition median 0.3 ms below the old level). Only a
+            // window that is itself a stable level outside the band disqualifies the skip:
+            // that is a distinct plateau (spike or dip), not a transition.
+            var transition = windows[beforeIndex + 1];
+            var lo = Math.Min(before.MedianMs, after.MedianMs);
+            var hi = Math.Max(before.MedianMs, after.MedianMs);
+            var inBetween = transition.MedianMs > lo && transition.MedianMs < hi;
+            if (!inBetween && IsStableLevel(transition, options)) return null;
         }
         if (!EstablishedAtOldLevel(windows, beforeIndex, delta, options)) return null;
         if (!PersistsAtNewLevel(windows, before.MedianMs, delta, afterIndex, options)) return null;

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/StepChangeDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/StepChangeDetectorTests.cs
@@ -152,6 +152,44 @@ public class StepChangeDetectorTests
     }
 
     [Fact]
+    public void Mid_window_shift_with_transition_median_outside_band_is_detected()
+    {
+        // Production shape (Cloudflare path, Jul 2026): the shift landed mid-window and a
+        // small dip just before it left the transition window's median slightly BELOW the
+        // old level. Requiring the transition median to sit strictly between the levels
+        // rejected the step-up entirely, while the matching step-down was only caught
+        // because its transition median landed 0.01 ms inside the band.
+        var dipStart = TestSeries.Start.AddHours(12);
+        var shiftAt = dipStart.AddMinutes(20);
+        var samples = TestSeries.Flat(TestSeries.Start, Day, rttMs: 13.3, jitterMs: 0.3)
+            .WithSegment(dipStart, shiftAt, rttMs: 12.9, jitterMs: 0.3)
+            .WithSegment(shiftAt, TestSeries.Start + Day, rttMs: 17.5, jitterMs: 0.3);
+
+        var events = StepChangeDetector.DetectForSeries(TestSeries.Asn(64500, "TransitOne", samples), Options);
+
+        events.Should().ContainSingle();
+        events[0].Direction.Should().Be(PathShiftDirection.Up);
+        events[0].BeforeMedianMs.Should().BeApproximately(13.3, 0.1);
+        events[0].AfterMedianMs.Should().BeApproximately(17.5, 0.1);
+        events[0].Time.Should().BeCloseTo(shiftAt, TimeSpan.FromMinutes(10));
+    }
+
+    [Fact]
+    public void Stable_plateau_outside_the_band_does_not_bridge_a_step()
+    {
+        // A full window resting at its own level outside the two step levels is a distinct
+        // plateau, not a transition - the skip-one-window comparison must still reject it.
+        var plateauStart = TestSeries.Start.AddHours(12);
+        var samples = TestSeries.Flat(TestSeries.Start, Day, rttMs: 20, jitterMs: 0.3)
+            .WithSegment(plateauStart, plateauStart.AddMinutes(30), rttMs: 10, jitterMs: 0.3)
+            .WithSegment(plateauStart.AddMinutes(30), TestSeries.Start + Day, rttMs: 17, jitterMs: 0.3);
+
+        var events = StepChangeDetector.DetectForSeries(TestSeries.Asn(64500, "TransitOne", samples), Options);
+
+        events.Should().BeEmpty();
+    }
+
+    [Fact]
     public void Correlated_steps_across_targets_merge_into_one_event()
     {
         var stepAt = TestSeries.Start.AddHours(12);


### PR DESCRIPTION
## What

Fixes an asymmetry in ISP Health path-shift detection where one half of a shift (usually the step-up) could be silently dropped while its matching half was reported, leaving the Path & Congestion Events list with an unpaired step.

When a routing shift lands in the middle of an aggregation window, that window straddles both RTT levels and its wide IQR masks the step, so the detector skips it and compares the windows on either side. That skip was only allowed when the straddling window's median sat strictly between the two levels. In practice the median lands wherever the majority of the window's samples fell, and ordinary noise (or a small dip right before the shift) can push it a fraction outside the band - so a genuine transition was rejected. Whether a given shift survived came down to which side of the band its transition sample happened to land on, which is why step-ups and step-downs on the same path were detected inconsistently.

The skip is now rejected only when the straddling window is itself a *stable* level outside the band - a distinct plateau (a spike or dip), not a transition. A true transition window has a wide IQR and is no longer discarded.

## Impact

Recovers previously-missed halves of real shifts and, because a missed step no longer starves the cross-path correlation stage, improves attribution: a shift that steps a transit hop and a downstream CDN together now correlates and is labeled by the on-path transit hop rather than defaulting to the nearer CDN endpoint. Every recovered event is the matching half of an already-detected shift, so the change only adds true positives.

Informational events only - never affects the ISP Health score.

## Tests

Two regression tests added: a mid-window shift whose transition median falls just outside the band (must detect), and a stable plateau outside the band (must still not bridge a step). Full suite green.