### PR TITLE
Multi-site: per-tab site context (a browser tab per site)

### DIFF
--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -98,6 +98,7 @@
         </div>
     </div>
 
+    <script>window.__noSiteDefault = "@(NetworkOptimizer.Web.Services.SiteManagementService.DefaultSiteSlug)";</script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/site-context.js")"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/chart-defaults.js")"></script>
     <script src="_framework/blazor.web.js"></script>

--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -98,6 +98,7 @@
         </div>
     </div>
 
+    <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/site-context.js")"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/chart-defaults.js")"></script>
     <script src="_framework/blazor.web.js"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/scrollRestoration.js")"></script>

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -354,6 +354,26 @@
     private bool sidebarOpen = false;
     private DotNetObjectReference<MainLayout>? _dotNetRef;
 
+    protected override void OnInitialized()
+    {
+        // Keep the header's Console Connected/Disconnected indicator live. On
+        // agent-proxied sites the console connects asynchronously after first paint
+        // (once the agent tunnel is up); without this subscription the header stays
+        // "Console Disconnected" until the next navigation.
+        ConnectionService.OnConnectionChanged += OnConnectionChanged;
+    }
+
+    private async void OnConnectionChanged()
+    {
+        // Fires from a background thread (console (re)connect); marshal to the
+        // dispatcher and swallow exceptions so this async void can't crash the circuit.
+        try
+        {
+            await InvokeAsync(StateHasChanged);
+        }
+        catch { /* component may be disposed */ }
+    }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -15,6 +15,7 @@
 @inject UniFiConnectionService ConnectionService
 @inject IConfiguration Configuration
 @inject SiteContextService SiteContext
+@inject SiteSwitchService SiteSwitch
 @inject SiteSpeedTestTargetResolver SiteTarget
 @inject NavigationManager NavigationManager
 @inject IJSRuntime JS
@@ -93,7 +94,7 @@
                     <strong>Device Offline</strong>
                     <span>This device is currently offline. Showing historical data. Live data will appear when it reconnects.</span>
                 </div>
-                <button class="btn btn-primary btn-sm" @onclick="() => NavigationManager.NavigateTo(NavigationManager.Uri, forceLoad: true)">Retry</button>
+                <button class="btn btn-primary btn-sm" @onclick="ReloadPageAsync">Retry</button>
             </div>
         </div>
     }
@@ -143,7 +144,7 @@
         <div class="card empty-state">
             <h3>Device Not Found</h3>
             <p>Could not identify your device on the network. Make sure you're connected and the UniFi Console is reachable.</p>
-            <button class="btn btn-primary" @onclick="() => NavigationManager.NavigateTo(NavigationManager.Uri, forceLoad: true)">Retry</button>
+            <button class="btn btn-primary" @onclick="ReloadPageAsync">Retry</button>
         </div>
     }
     else
@@ -1217,8 +1218,17 @@
         }
         catch { /* remembering is best-effort */ }
         Logger.LogDebug("Client identity (site {Site}): device picked manually ({Ip})", SiteContext.Slug, _pickerSelection);
-        NavigationManager.NavigateTo($"/client-dashboard?ip={Uri.EscapeDataString(_pickerSelection)}", forceLoad: true);
+        NavigationManager.NavigateTo(
+            await SiteSwitch.StampSiteAsync($"/client-dashboard?ip={Uri.EscapeDataString(_pickerSelection)}"),
+            forceLoad: true);
     }
+
+    /// <summary>
+    /// Full-page retry. The reload target is stamped with this tab's site so a tab
+    /// pinned to a non-default site doesn't fall back to the browser default.
+    /// </summary>
+    private async Task ReloadPageAsync() =>
+        NavigationManager.NavigateTo(await SiteSwitch.StampSiteAsync(NavigationManager.Uri), forceLoad: true);
 
     /// <summary>
     /// Lightweight 1s poll: only hits WiFiman for live signal/channel/band/rates.

--- a/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
@@ -25,8 +25,13 @@
 <div class="page-header">
     @* Site name next to the header (muted) when multi-site is enabled, including the
        main site, so each per-site tab is identifiable at a glance. *@
-    <h1>Dashboard@if (!string.IsNullOrEmpty(_siteName))
-        {<span class="page-header-suffix">@_siteName</span>}</h1>
+    <h1>
+        Dashboard
+        @if (!string.IsNullOrEmpty(_siteName))
+        {
+            <span class="page-header-suffix">@_siteName</span>
+        }
+    </h1>
     <div class="page-header-actions">
         @if (_editMode)
         {

--- a/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
@@ -14,6 +14,8 @@
 @inject NavigationManager NavigationManager
 @inject PullToRefreshState PtrState
 @inject IJSRuntime JS
+@inject SiteManagementService SiteManagement
+@inject SiteContextService SiteContext
 @implements IDisposable
 @rendermode InteractiveServer
 
@@ -21,7 +23,10 @@
 <NavigationLock OnBeforeInternalNavigation="OnBeforeInternalNavigation" ConfirmExternalNavigation="_editMode" />
 
 <div class="page-header">
-    <h1>Dashboard</h1>
+    @* Site name next to the header (muted) when multi-site is enabled, including the
+       main site, so each per-site tab is identifiable at a glance. *@
+    <h1>Dashboard@if (!string.IsNullOrEmpty(_siteName))
+        {<span class="page-header-suffix">@_siteName</span>}</h1>
     <div class="page-header-actions">
         @if (_editMode)
         {
@@ -207,6 +212,7 @@
 </div>
 
 @code {
+    private string _siteName = "";
     private bool _loading = true;
     private bool _speedTestLoading = true;
     private bool _wanTestLoading = true;
@@ -243,6 +249,14 @@
         PtrState.RefreshCallback = () => Task.WhenAll(
             LoadDashboardData(), LoadSpeedTestData(), LoadWanTestData(), LoadThreatData());
         PtrState.NotifyStateChanged = StateHasChanged;
+
+        // Show the current site's name next to the header when multi-site is enabled
+        // (including the main site) so each per-site tab is identifiable.
+        if (await SiteManagement.IsMultiSiteEnabledAsync())
+        {
+            var sites = await SiteManagement.GetSitesAsync();
+            _siteName = sites.FirstOrDefault(s => s.Slug == SiteContext.Slug)?.Name ?? "";
+        }
 
         _layout = await LayoutService.GetLayoutAsync();
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Login.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Login.razor
@@ -5,6 +5,7 @@
 @inject NavigationManager Navigation
 @inject IAdminAuthService AdminAuth
 @inject IJwtService JwtService
+@inject SiteSwitchService SiteSwitch
 
 <PageTitle>Login - Network Optimizer</PageTitle>
 
@@ -104,12 +105,15 @@
                 isRedirecting = true;
                 StateHasChanged();
 
-                // Set cookie and redirect to home
+                // Set cookie and redirect to home, keeping the tab's ?site= pin (the
+                // auth middleware carries it onto /login) so re-auth lands on the
+                // same site the tab was on.
                 // Note: forceLoad navigation will throw TaskCanceledException as the circuit
                 // is destroyed during the page reload - this is expected behavior
+                var returnUrl = await SiteSwitch.StampSiteAsync("/");
                 try
                 {
-                    Navigation.NavigateTo($"/api/auth/set-cookie?token={Uri.EscapeDataString(token)}&returnUrl=/", forceLoad: true);
+                    Navigation.NavigateTo($"/api/auth/set-cookie?token={Uri.EscapeDataString(token)}&returnUrl={Uri.EscapeDataString(returnUrl)}", forceLoad: true);
                 }
                 catch (TaskCanceledException)
                 {

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -2280,7 +2280,11 @@
     <!-- Threat Intelligence Configuration -->
     <div class="card settings-tab-security" id="threat-intelligence">
         <div class="card-header">
-            <h2 class="card-title">@(_multiSiteEnabled && SiteContext.IsDefault ? "Global Threat Intelligence" : "Threat Intelligence")</h2>
+            <h2 class="card-title">Threat Intelligence</h2>
+            @if (_multiSiteEnabled && SiteContext.IsDefault)
+            {
+                <span class="status-badge global-badge" data-tooltip="Applies to all sites (instance-wide)">Global</span>
+            }
         </div>
         <div class="card-body">
             <p class="section-description">

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -33,6 +33,7 @@
 @inject IHttpClientFactory HttpClientFactory
 @inject NavigationManager NavigationManager
 @inject SiteManagementService SiteManagement
+@inject SiteSwitchService SiteSwitch
 @inject AgentEnrollmentService AgentEnrollment
 @inject AgentServerUrlProvider AgentServerUrl
 @inject AgentTunnelRegistry TunnelRegistry
@@ -3292,22 +3293,14 @@
     }
 
     /// <summary>
-    /// Switch the active site to the given one. Site context is cookie-based, so a
-    /// full reload is required for every scoped service to resolve against the new
-    /// site's database (same mechanism as the header site switcher).
+    /// Switch the active site to the given one (same mechanism as the header site
+    /// switcher): make it the browser default and reload this tab pinned to it.
     /// </summary>
     private async Task SwitchToSiteAsync(Site site)
     {
         if (site.Slug == SiteContext.Slug)
             return;
-        await JS.InvokeVoidAsync("eval",
-            $"document.cookie = '{SiteContextService.CookieName}={site.Slug}; path=/; max-age=31536000; SameSite=Lax'");
-        // Drop any #fragment first: reloading the *same* URL with its fragment is a
-        // same-document navigation the browser won't actually reload, so the new site
-        // cookie would never take effect. The fragment is meaningless on another site anyway.
-        var target = NavigationManager.Uri;
-        var fragmentAt = target.IndexOf('#');
-        NavigationManager.NavigateTo(fragmentAt >= 0 ? target[..fragmentAt] : target, forceLoad: true);
+        await SiteSwitch.SwitchToAsync(site.Slug);
     }
 
     private async Task SiteNameEditKey(KeyboardEventArgs e, Site site)

--- a/src/NetworkOptimizer.Web/Components/Pages/Sites.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sites.razor
@@ -13,7 +13,7 @@
 @inject NetworkOptimizer.Storage.Services.SiteDbContextFactory SiteDb
 @inject NetworkOptimizer.Web.Services.Licensing.LicenseStateService LicenseState
 @inject NavigationManager NavigationManager
-@inject IJSRuntime JS
+@inject SiteSwitchService SiteSwitch
 
 <PageTitle>Sites - Network Optimizer</PageTitle>
 
@@ -212,10 +212,6 @@ else
         if (site.Slug == SiteContext.Slug)
             return;
 
-        // Site context is cookie-based; a full reload re-resolves every scoped
-        // service against the selected site's database.
-        await JS.InvokeVoidAsync("eval",
-            $"document.cookie = '{SiteContextService.CookieName}={site.Slug}; path=/; max-age=31536000; SameSite=Lax'");
-        NavigationManager.NavigateTo("/", forceLoad: true);
+        await SiteSwitch.SwitchToAsync(site.Slug, "/");
     }
 }

--- a/src/NetworkOptimizer.Web/Components/Pages/Sites.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sites.razor
@@ -13,7 +13,6 @@
 @inject NetworkOptimizer.Storage.Services.SiteDbContextFactory SiteDb
 @inject NetworkOptimizer.Web.Services.Licensing.LicenseStateService LicenseState
 @inject NavigationManager NavigationManager
-@inject SiteSwitchService SiteSwitch
 
 <PageTitle>Sites - Network Optimizer</PageTitle>
 
@@ -53,7 +52,12 @@ else
         @foreach (var site in _sites)
         {
             var isCurrent = site.Slug == SiteContext.Slug;
-            <div class="card site-card @(isCurrent ? "site-card-current" : "")" @onclick="() => SwitchToAsync(site)">
+            @* Real anchor so ctrl / cmd / shift / middle click opens the site in a new
+               tab; site-context.js turns a plain left click into the switch. *@
+            <a class="card site-card @(isCurrent ? "site-card-current" : "")"
+               href="@SiteHref(site)"
+               data-site-switch="@site.Slug"
+               data-site-current="@(isCurrent ? "" : null)">
                 <div class="site-card-header">
                     <span class="status-dot @(SiteConnections.GetFor(site.Slug).IsConnected ? "online" : "offline")" data-tooltip="@(SiteConnections.GetFor(site.Slug).IsConnected ? "Console connected" : "Console not connected")"></span>
                     <h3 class="site-card-name">@site.Name</h3>
@@ -64,7 +68,7 @@ else
                 </div>
                 @if (ConsoleHost(site.Id) is { Length: > 0 } host)
                 {
-                    <div class="site-card-console" data-tooltip="UniFi Console this site connects to">@host</div>
+                    <div class="site-card-console">@host</div>
                 }
                 <div class="site-card-meta">
                     <span class="site-card-slug">@site.Slug</span>
@@ -87,7 +91,7 @@ else
                         <span class="site-card-agents">@OnlineAgentCount(site.Id)/@AgentCount(site.Id) agents online</span>
                     }
                 </div>
-            </div>
+            </a>
         }
 
         <div class="card site-card site-card-add" @onclick="@(() => NavigationManager.NavigateTo("/settings?tab=multisite"))">
@@ -207,11 +211,8 @@ else
             ? Math.Max(0, (int)Math.Ceiling((deadline - DateTime.UtcNow).TotalDays))
             : 0;
 
-    private async Task SwitchToAsync(Site site)
-    {
-        if (site.Slug == SiteContext.Slug)
-            return;
-
-        await SiteSwitch.SwitchToAsync(site.Slug, "/");
-    }
+    /// <summary>The new site's dashboard, pinned - the card's anchor href. A plain click
+    /// switches here (via site-context.js); ctrl / cmd / shift / middle opens a new tab.</summary>
+    private static string SiteHref(Site site) =>
+        SiteContextService.WithSiteParam("/", site.Slug);
 }

--- a/src/NetworkOptimizer.Web/Components/Routes.razor
+++ b/src/NetworkOptimizer.Web/Components/Routes.razor
@@ -1,4 +1,6 @@
 @rendermode InteractiveServer
+@inject NavigationManager Navigation
+@inject SiteContextService SiteContext
 
 <Router AppAssembly="typeof(Program).Assembly">
     <Found Context="routeData">
@@ -6,3 +8,15 @@
         <FocusOnNavigate RouteData="routeData" Selector="h1" />
     </Found>
 </Router>
+<SiteTabSync />
+
+@code {
+    protected override void OnInitialized()
+    {
+        // Pin this scope to the site in the tab's URL before the Router renders
+        // anything that could resolve the site context. The circuit's WebSocket
+        // upgrade request only carries the shared site cookie, so without this pin
+        // every tab of the browser would collapse onto the same site.
+        SiteContext.PinFromUri(Navigation.Uri);
+    }
+}

--- a/src/NetworkOptimizer.Web/Components/Shared/SiteSetupWizard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SiteSetupWizard.razor
@@ -6,8 +6,7 @@
 @inject AgentEnrollmentService AgentEnrollment
 @inject NetworkOptimizer.Storage.Services.SiteDbContextFactory SiteDb
 @inject NetworkOptimizer.Web.Services.Licensing.LicenseStateService LicenseState
-@inject NavigationManager NavigationManager
-@inject IJSRuntime JS
+@inject SiteSwitchService SiteSwitch
 @implements IDisposable
 
 <div class="site-wizard">
@@ -430,9 +429,7 @@
         if (_site == null)
             return;
 
-        await JS.InvokeVoidAsync("eval",
-            $"document.cookie = '{SiteContextService.CookieName}={_site.Slug}; path=/; max-age=31536000; SameSite=Lax'");
-        NavigationManager.NavigateTo("/", forceLoad: true);
+        await SiteSwitch.SwitchToAsync(_site.Slug, "/");
     }
 
     private async Task ResetAsync()

--- a/src/NetworkOptimizer.Web/Components/Shared/SiteSwitcher.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SiteSwitcher.razor
@@ -3,8 +3,8 @@
 @inject SiteManagementService SiteManagement
 @inject SiteContextService SiteContext
 @inject SiteConnectionRegistry SiteConnections
+@inject SiteSwitchService SiteSwitch
 @inject NavigationManager NavigationManager
-@inject IJSRuntime JS
 
 @if (_enabled && _sites.Count > 0)
 {
@@ -23,14 +23,19 @@
             <div class="site-switcher-menu">
                 @foreach (var site in _sites)
                 {
-                    <button type="button" class="site-switcher-item @(site.Slug == SiteContext.Slug ? "active" : "")"
-                            @onclick="() => SwitchToAsync(site)">
+                    @* A real anchor so middle-click / ctrl+click opens the site in a new
+                       tab (the ?site= href pins that tab without touching this one or the
+                       browser default). A plain left click switches this tab and makes the
+                       site the browser default. *@
+                    <a class="site-switcher-item @(site.Slug == SiteContext.Slug ? "active" : "")"
+                       href="@GetSiteHref(site)"
+                       @onclick="() => SwitchToAsync(site)" @onclick:preventDefault @onclick:stopPropagation>
                         <span class="site-switcher-item-name">
                             <span class="status-dot @(SiteConnections.GetFor(site.Slug).IsConnected ? "online" : "offline")"></span>
                             @site.Name
                         </span>
                         <span class="site-switcher-item-slug">@site.Slug</span>
-                    </button>
+                    </a>
                 }
                 <a class="site-switcher-all" href="/sites" @onclick="CloseDropdown">All sites</a>
             </div>
@@ -59,52 +64,37 @@
 
     private void CloseDropdown() => _open = false;
 
+    /// <summary>Current page pinned to the given site - the middle-click new-tab target.</summary>
+    private string GetSiteHref(Site site) =>
+        SiteContextService.WithSiteParam(CurrentPageWithoutFragment(), site.Slug);
+
     private async Task SwitchToAsync(Site site)
     {
         _open = false;
         if (site.Slug == SiteContext.Slug)
             return;
 
-        // Site context is cookie-based; switching requires a full reload so every
-        // scoped service resolves against the new site's database.
-        await JS.InvokeVoidAsync("eval",
-            $"document.cookie = '{SiteContextService.CookieName}={site.Slug}; path=/; max-age=31536000; SameSite=Lax'");
+        await SiteSwitch.SwitchToAsync(site.Slug, CurrentPageWithoutFragment());
+    }
+
+    private string CurrentPageWithoutFragment()
+    {
         var target = NavigationManager.Uri;
 
-        // Drop any #fragment: reloading the *same* URL with its fragment is a
-        // same-document navigation the browser won't actually reload, so the new site
-        // cookie would never take effect. The fragment is meaningless on another site anyway.
+        // Drop any #fragment: it is meaningless on another site, and reloading the
+        // *same* URL with its fragment is a same-document navigation the browser
+        // won't actually perform.
         var fragmentAt = target.IndexOf('#');
         if (fragmentAt >= 0)
             target = target[..fragmentAt];
 
-        // Strip the ?site= selector: an alert "View" link pins the site through this
-        // query param, which wins over the cookie, so leaving it in place would
-        // immediately override the switch we just made.
-        target = RemoveSiteQueryParam(target);
-
         // The all-sites overview isn't a per-site page, so switching sites from it
         // should land on the new site's dashboard rather than reload the overview.
         var relative = NavigationManager.ToBaseRelativePath(target).TrimEnd('/');
-        if (string.Equals(relative, "sites", StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(relative, "sites", StringComparison.OrdinalIgnoreCase)
+            || relative.StartsWith("sites?", StringComparison.OrdinalIgnoreCase))
             target = NavigationManager.BaseUri;
 
-        NavigationManager.NavigateTo(target, forceLoad: true);
-    }
-
-    private static string RemoveSiteQueryParam(string url)
-    {
-        var queryAt = url.IndexOf('?');
-        if (queryAt < 0)
-            return url;
-
-        var kept = url[(queryAt + 1)..]
-            .Split('&', StringSplitOptions.RemoveEmptyEntries)
-            .Where(p => !p.Equals(SiteContextService.SiteQueryParam, StringComparison.OrdinalIgnoreCase)
-                     && !p.StartsWith(SiteContextService.SiteQueryParam + "=", StringComparison.OrdinalIgnoreCase))
-            .ToList();
-
-        var basePart = url[..queryAt];
-        return kept.Count > 0 ? $"{basePart}?{string.Join('&', kept)}" : basePart;
+        return target;
     }
 }

--- a/src/NetworkOptimizer.Web/Components/Shared/SiteSwitcher.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SiteSwitcher.razor
@@ -66,7 +66,7 @@
 
     /// <summary>Current page pinned to the given site - the middle-click new-tab target.</summary>
     private string GetSiteHref(Site site) =>
-        SiteContextService.WithSiteParam(CurrentPageWithoutFragment(), site.Slug);
+        SiteContextService.WithSiteParam(CurrentSwitchTarget(), site.Slug);
 
     private async Task SwitchToAsync(Site site)
     {
@@ -74,27 +74,24 @@
         if (site.Slug == SiteContext.Slug)
             return;
 
-        await SiteSwitch.SwitchToAsync(site.Slug, CurrentPageWithoutFragment());
+        await SiteSwitch.SwitchToAsync(site.Slug, CurrentSwitchTarget());
     }
 
-    private string CurrentPageWithoutFragment()
+    /// <summary>
+    /// Where a site switch from the current page should land. The #fragment is kept
+    /// so an anchored spot (e.g. a highlighted setting) carries to the new site; the
+    /// changed ?site= query still guarantees the full reload.
+    /// </summary>
+    private string CurrentSwitchTarget()
     {
-        var target = NavigationManager.Uri;
-
-        // Drop any #fragment: it is meaningless on another site, and reloading the
-        // *same* URL with its fragment is a same-document navigation the browser
-        // won't actually perform.
-        var fragmentAt = target.IndexOf('#');
-        if (fragmentAt >= 0)
-            target = target[..fragmentAt];
-
         // The all-sites overview isn't a per-site page, so switching sites from it
         // should land on the new site's dashboard rather than reload the overview.
-        var relative = NavigationManager.ToBaseRelativePath(target).TrimEnd('/');
-        if (string.Equals(relative, "sites", StringComparison.OrdinalIgnoreCase)
-            || relative.StartsWith("sites?", StringComparison.OrdinalIgnoreCase))
-            target = NavigationManager.BaseUri;
+        var pathOnly = NavigationManager.ToBaseRelativePath(NavigationManager.Uri)
+            .Split('?', '#')[0]
+            .TrimEnd('/');
+        if (string.Equals(pathOnly, "sites", StringComparison.OrdinalIgnoreCase))
+            return NavigationManager.BaseUri;
 
-        return target;
+        return NavigationManager.Uri;
     }
 }

--- a/src/NetworkOptimizer.Web/Components/Shared/SiteSwitcher.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SiteSwitcher.razor
@@ -3,7 +3,6 @@
 @inject SiteManagementService SiteManagement
 @inject SiteContextService SiteContext
 @inject SiteConnectionRegistry SiteConnections
-@inject SiteSwitchService SiteSwitch
 @inject NavigationManager NavigationManager
 
 @if (_enabled && _sites.Count > 0)
@@ -23,13 +22,17 @@
             <div class="site-switcher-menu">
                 @foreach (var site in _sites)
                 {
-                    @* A real anchor so middle-click / ctrl+click opens the site in a new
-                       tab (the ?site= href pins that tab without touching this one or the
-                       browser default). A plain left click switches this tab and makes the
-                       site the browser default. *@
+                    @* A real anchor whose href is this page pinned to the site. The
+                       site-context.js click handler turns a plain left click into the
+                       switch (cookie write + full reload, same target as the href) and
+                       preventDefaults it, while ctrl / cmd / shift / middle clicks fall
+                       through to the browser and open the site in a new tab - pinning
+                       that tab without touching this one or the browser default. Handled
+                       in JS, not @@onclick, so those modified clicks stay native. *@
                     <a class="site-switcher-item @(site.Slug == SiteContext.Slug ? "active" : "")"
                        href="@GetSiteHref(site)"
-                       @onclick="() => SwitchToAsync(site)" @onclick:preventDefault @onclick:stopPropagation>
+                       data-site-switch="@site.Slug"
+                       data-site-current="@(site.Slug == SiteContext.Slug ? "" : null)">
                         <span class="site-switcher-item-name">
                             <span class="status-dot @(SiteConnections.GetFor(site.Slug).IsConnected ? "online" : "offline")"></span>
                             @site.Name
@@ -64,18 +67,10 @@
 
     private void CloseDropdown() => _open = false;
 
-    /// <summary>Current page pinned to the given site - the middle-click new-tab target.</summary>
+    /// <summary>This page pinned to the given site - the anchor href (plain-click switch
+    /// target and modified-click new-tab target); see site-context.js.</summary>
     private string GetSiteHref(Site site) =>
         SiteContextService.WithSiteParam(CurrentSwitchTarget(), site.Slug);
-
-    private async Task SwitchToAsync(Site site)
-    {
-        _open = false;
-        if (site.Slug == SiteContext.Slug)
-            return;
-
-        await SiteSwitch.SwitchToAsync(site.Slug, CurrentSwitchTarget());
-    }
 
     /// <summary>
     /// Where a site switch from the current page should land. The #fragment is kept

--- a/src/NetworkOptimizer.Web/Components/Shared/SiteTabSync.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SiteTabSync.razor
@@ -1,0 +1,48 @@
+@* Keeps the tab's ?site= selector in the address bar (history.replaceState, no
+   reload) whenever multi-site is enabled, so refresh, duplicate-tab, and the
+   reconnect auto-reload all land back on this tab's site instead of the browser
+   default. Also feeds the fetch wrapper in site-context.js the slug it stamps
+   onto same-origin /api/ requests. Renders nothing. *@
+@implements IDisposable
+@inject NavigationManager Navigation
+@inject SiteContextService SiteContext
+@inject SiteManagementService SiteManagement
+@inject IJSRuntime JS
+
+@code {
+    private bool _active;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+            return;
+
+        _active = await SiteManagement.IsMultiSiteEnabledAsync();
+        if (!_active)
+            return;
+
+        Navigation.LocationChanged += OnLocationChanged;
+        await EnsureSiteParamAsync();
+    }
+
+    private async void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
+        => await EnsureSiteParamAsync();
+
+    private async Task EnsureSiteParamAsync()
+    {
+        try
+        {
+            await JS.InvokeVoidAsync("noSiteContext.ensureSiteParam", SiteContext.Slug);
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+        {
+            // Circuit tearing down (navigation away, tab close) - nothing to sync.
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_active)
+            Navigation.LocationChanged -= OnLocationChanged;
+    }
+}

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -267,6 +267,7 @@ builder.Services.AddScoped<NetworkOptimizer.Alerts.Interfaces.IAlertRepository, 
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.ISiteRepository, NetworkOptimizer.Storage.Repositories.SiteRepository>();
 builder.Services.AddScoped<SiteManagementService>();
 builder.Services.AddScoped<SiteContextService>();
+builder.Services.AddScoped<SiteSwitchService>();
 // The alert pipeline pins its scope to an event's originating site through this seam.
 builder.Services.AddScoped<NetworkOptimizer.Alerts.Interfaces.IAlertSiteScope>(sp =>
     sp.GetRequiredService<SiteContextService>());
@@ -528,7 +529,11 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 }
 
                 context.HandleResponse();
-                context.Response.Redirect("/login");
+                // Carry the tab's ?site= pin through login (same as the auth middleware).
+                var challengeSite = context.Request.Query[SiteContextService.SiteQueryParam].ToString();
+                context.Response.Redirect(string.IsNullOrEmpty(challengeSite)
+                    ? "/login"
+                    : $"/login?{SiteContextService.SiteQueryParam}={Uri.EscapeDataString(challengeSite)}");
                 return Task.CompletedTask;
             }
         };
@@ -1138,34 +1143,23 @@ app.Use(async (context, next) =>
             return;
         }
 
-        // Web pages redirect to login
-        context.Response.Redirect("/login");
+        // Web pages redirect to login. Carry the tab's ?site= pin through so the
+        // post-login redirect lands back on the site the tab was on.
+        var loginSite = context.Request.Query[SiteContextService.SiteQueryParam].ToString();
+        context.Response.Redirect(string.IsNullOrEmpty(loginSite)
+            ? "/login"
+            : $"/login?{SiteContextService.SiteQueryParam}={Uri.EscapeDataString(loginSite)}");
         return;
     }
 
     await next();
 });
 
-// Site selection via ?site=<slug>: alert "View" links carry the originating site so a
-// notification lands on the right site. Persist a valid value to the site cookie (same
-// attributes as the in-app switcher) so the whole session follows the link; validation
-// runs through the scoped site context, which checks the slug and its provisioned DB.
-app.Use(async (context, next) =>
-{
-    var siteParam = context.Request.Query[SiteContextService.SiteQueryParam].ToString();
-    if (!string.IsNullOrEmpty(siteParam)
-        && context.Request.Cookies[SiteContextService.CookieName] != siteParam
-        && context.RequestServices.GetRequiredService<SiteContextService>().IsSelectableSite(siteParam))
-    {
-        context.Response.Cookies.Append(SiteContextService.CookieName, siteParam, new CookieOptions
-        {
-            Path = "/",
-            MaxAge = TimeSpan.FromDays(365),
-            SameSite = SameSiteMode.Lax
-        });
-    }
-    await next();
-});
+// Site selection via ?site=<slug> is per browser tab: it wins over the site cookie on
+// every request (SiteContextService.Resolve), the circuit pins itself from the tab URL
+// (Routes.razor), and SiteTabSync keeps the selector in the address bar. It is never
+// persisted to the cookie - following an alert "View" link pins only that tab, and the
+// cookie remains the browser default written solely by an explicit switch in the UI.
 
 // Configure static files with custom MIME types for package downloads
 var contentTypeProvider = new FileExtensionContentTypeProvider();
@@ -1270,7 +1264,12 @@ app.MapGet("/api/auth/logout", (HttpContext context) =>
         Path = "/"
     });
 
-    return Results.Redirect("/login");
+    // Carry the tab's ?site= pin (stamped onto the logout link by site-context.js)
+    // through to the login page so logging back in returns to the same site.
+    var logoutSite = context.Request.Query[SiteContextService.SiteQueryParam].ToString();
+    return Results.Redirect(string.IsNullOrEmpty(logoutSite)
+        ? "/login"
+        : $"/login?{SiteContextService.SiteQueryParam}={Uri.EscapeDataString(logoutSite)}");
 });
 
 app.MapGet("/api/auth/check", async (HttpContext context, IJwtService jwt) =>

--- a/src/NetworkOptimizer.Web/Services/SiteContextService.cs
+++ b/src/NetworkOptimizer.Web/Services/SiteContextService.cs
@@ -5,7 +5,8 @@ using NetworkOptimizer.Storage.Services;
 namespace NetworkOptimizer.Web.Services;
 
 /// <summary>
-/// Scoped ambient site context. The current site is carried in a browser cookie
+/// Scoped ambient site context. The current site is carried in the URL's ?site=
+/// query parameter (per browser tab) with a cookie as the browser-wide default,
 /// so it is readable synchronously during prerender, in API endpoints, and when
 /// the scoped DbContext options are built - no site parameter threading anywhere.
 /// Scopes without an HTTP context (background jobs, startup) resolve to the
@@ -13,13 +14,19 @@ namespace NetworkOptimizer.Web.Services;
 /// </summary>
 public class SiteContextService : IAlertSiteScope
 {
-    /// <summary>Cookie carrying the selected site slug for this browser.</summary>
+    /// <summary>
+    /// Cookie carrying this browser's default site slug: the site used by any URL
+    /// that has no <see cref="SiteQueryParam"/> selector (new tabs, bare bookmarks).
+    /// Written only by an explicit switch in the UI, never by following a link.
+    /// </summary>
     public const string CookieName = "no-site";
 
     /// <summary>
-    /// Query-string parameter that selects a site for a single request (used by alert
-    /// "View" links so a notification lands on its originating site). A middleware
-    /// persists it to <see cref="CookieName"/> so the whole session follows the link.
+    /// Query-string parameter that pins a browser tab to a site. It wins over
+    /// <see cref="CookieName"/> on every request, the interactive circuit pins its
+    /// scope from it (<see cref="PinFromUri"/>), and the SiteTabSync component keeps
+    /// it in the address bar - so different tabs can work on different sites, and
+    /// alert "View" links land on their originating site without affecting other tabs.
     /// </summary>
     public const string SiteQueryParam = "site";
 
@@ -68,13 +75,91 @@ public class SiteContextService : IAlertSiteScope
         (slug == SiteManagementService.DefaultSiteSlug ||
          (StringUtilities.IsSlug(slug) && File.Exists(_dbPaths.GetSiteDbPath(slug, isDefault: false))));
 
+    /// <summary>
+    /// Pins this scope to the site carried in the given URL's ?site= parameter, if
+    /// present and selectable. Called by the interactive root component before any
+    /// other scoped service resolves the site, so a Blazor circuit follows its own
+    /// tab's URL rather than the shared browser cookie (the circuit's WebSocket
+    /// upgrade request carries only the cookie).
+    /// </summary>
+    public void PinFromUri(string uri)
+    {
+        var slug = GetSiteParam(uri);
+        if (slug != null && IsSelectableSite(slug))
+            _slug = slug;
+    }
+
+    /// <summary>
+    /// Returns the URL with its ?site= parameter set to the given slug (replacing any
+    /// existing value, preserving other query parameters). Full-page navigations must
+    /// stamp their target through this so a pinned tab keeps its site across the reload.
+    /// </summary>
+    public static string WithSiteParam(string url, string slug)
+    {
+        var fragment = "";
+        var fragmentAt = url.IndexOf('#');
+        if (fragmentAt >= 0)
+        {
+            fragment = url[fragmentAt..];
+            url = url[..fragmentAt];
+        }
+
+        var stripped = RemoveSiteParam(url);
+        var separator = stripped.Contains('?') ? '&' : '?';
+        return $"{stripped}{separator}{SiteQueryParam}={Uri.EscapeDataString(slug)}{fragment}";
+    }
+
+    /// <summary>Returns the URL with any ?site= parameter removed, other parameters and fragment intact.</summary>
+    public static string RemoveSiteParam(string url)
+    {
+        var fragment = "";
+        var fragmentAt = url.IndexOf('#');
+        if (fragmentAt >= 0)
+        {
+            fragment = url[fragmentAt..];
+            url = url[..fragmentAt];
+        }
+
+        var queryAt = url.IndexOf('?');
+        if (queryAt < 0)
+            return url + fragment;
+
+        var kept = url[(queryAt + 1)..]
+            .Split('&', StringSplitOptions.RemoveEmptyEntries)
+            .Where(p => !p.Equals(SiteQueryParam, StringComparison.OrdinalIgnoreCase)
+                     && !p.StartsWith(SiteQueryParam + "=", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        var basePart = url[..queryAt];
+        return (kept.Count > 0 ? $"{basePart}?{string.Join('&', kept)}" : basePart) + fragment;
+    }
+
+    private static string? GetSiteParam(string uri)
+    {
+        var queryAt = uri.IndexOf('?');
+        if (queryAt < 0)
+            return null;
+
+        var query = uri[(queryAt + 1)..];
+        var fragmentAt = query.IndexOf('#');
+        if (fragmentAt >= 0)
+            query = query[..fragmentAt];
+
+        var value = query
+            .Split('&', StringSplitOptions.RemoveEmptyEntries)
+            .Where(p => p.StartsWith(SiteQueryParam + "=", StringComparison.OrdinalIgnoreCase))
+            .Select(p => Uri.UnescapeDataString(p[(SiteQueryParam.Length + 1)..]))
+            .FirstOrDefault();
+        return string.IsNullOrEmpty(value) ? null : value;
+    }
+
     private string Resolve()
     {
         var request = _httpContextAccessor.HttpContext?.Request;
 
-        // A ?site= query param (an alert "View" link) wins over the cookie so the linked
-        // page renders the correct site on first paint, before the selection middleware's
-        // cookie takes effect on subsequent requests. An invalid value falls through.
+        // A ?site= query param (a tab pin or an alert "View" link) wins over the cookie
+        // so the page renders the correct site on first paint and API requests resolve
+        // the site of the tab that issued them. An invalid value falls through.
         var queryParam = request?.Query[SiteQueryParam].ToString();
         if (!string.IsNullOrEmpty(queryParam) && IsSelectableSite(queryParam))
             return queryParam;

--- a/src/NetworkOptimizer.Web/Services/SiteSwitchService.cs
+++ b/src/NetworkOptimizer.Web/Services/SiteSwitchService.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Shared site-switch navigation for the interactive UI. An explicit switch writes
+/// the site cookie (the browser-wide default for URLs without a ?site= selector)
+/// and reloads with ?site= stamped on the target, so the switching tab is pinned to
+/// the chosen site while other tabs keep theirs.
+/// </summary>
+public class SiteSwitchService
+{
+    private readonly IJSRuntime _js;
+    private readonly NavigationManager _navigation;
+    private readonly SiteContextService _siteContext;
+    private readonly SiteManagementService _siteManagement;
+
+    public SiteSwitchService(
+        IJSRuntime js,
+        NavigationManager navigation,
+        SiteContextService siteContext,
+        SiteManagementService siteManagement)
+    {
+        _js = js;
+        _navigation = navigation;
+        _siteContext = siteContext;
+        _siteManagement = siteManagement;
+    }
+
+    /// <summary>
+    /// Makes the given site this browser's default and reloads the tab onto it.
+    /// Site context is scoped per circuit, so a full reload is required for every
+    /// scoped service to resolve against the new site's database.
+    /// </summary>
+    /// <param name="slug">Slug of the site to switch to.</param>
+    /// <param name="targetUrl">
+    /// Page to land on, defaulting to the current URL. Any #fragment is dropped:
+    /// reloading the *same* URL with its fragment is a same-document navigation the
+    /// browser won't actually reload, and the fragment is meaningless on another site.
+    /// </param>
+    public async Task SwitchToAsync(string slug, string? targetUrl = null)
+    {
+        await _js.InvokeVoidAsync("eval",
+            $"document.cookie = '{SiteContextService.CookieName}={slug}; path=/; max-age=31536000; SameSite=Lax'");
+
+        var target = targetUrl ?? _navigation.Uri;
+        var fragmentAt = target.IndexOf('#');
+        if (fragmentAt >= 0)
+            target = target[..fragmentAt];
+
+        _navigation.NavigateTo(SiteContextService.WithSiteParam(target, slug), forceLoad: true);
+    }
+
+    /// <summary>
+    /// Stamps the current site onto a full-page navigation target so a pinned tab
+    /// keeps its site across the reload. Returns the URL unchanged when multi-site
+    /// is disabled, keeping single-site URLs clean.
+    /// </summary>
+    public async Task<string> StampSiteAsync(string url) =>
+        await _siteManagement.IsMultiSiteEnabledAsync()
+            ? SiteContextService.WithSiteParam(url, _siteContext.Slug)
+            : url;
+}

--- a/src/NetworkOptimizer.Web/Services/SiteSwitchService.cs
+++ b/src/NetworkOptimizer.Web/Services/SiteSwitchService.cs
@@ -35,21 +35,16 @@ public class SiteSwitchService
     /// </summary>
     /// <param name="slug">Slug of the site to switch to.</param>
     /// <param name="targetUrl">
-    /// Page to land on, defaulting to the current URL. Any #fragment is dropped:
-    /// reloading the *same* URL with its fragment is a same-document navigation the
-    /// browser won't actually reload, and the fragment is meaningless on another site.
+    /// Page to land on, defaulting to the current URL. Any #fragment is preserved so
+    /// switching sites from an anchored spot (e.g. a highlighted setting) lands on the
+    /// same spot on the new site; the changed ?site= query guarantees the full reload.
     /// </param>
     public async Task SwitchToAsync(string slug, string? targetUrl = null)
     {
         await _js.InvokeVoidAsync("eval",
             $"document.cookie = '{SiteContextService.CookieName}={slug}; path=/; max-age=31536000; SameSite=Lax'");
 
-        var target = targetUrl ?? _navigation.Uri;
-        var fragmentAt = target.IndexOf('#');
-        if (fragmentAt >= 0)
-            target = target[..fragmentAt];
-
-        _navigation.NavigateTo(SiteContextService.WithSiteParam(target, slug), forceLoad: true);
+        _navigation.NavigateTo(SiteContextService.WithSiteParam(targetUrl ?? _navigation.Uri, slug), forceLoad: true);
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -355,6 +355,13 @@ a:hover {
     margin-bottom: 4px;
 }
 
+.page-header-suffix {
+    margin-left: 0.5rem;
+    font-size: 0.875rem;
+    font-weight: 400;
+    color: var(--text-muted);
+}
+
 .page-header-actions {
     display: flex;
     align-items: center;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -353,13 +353,19 @@ a:hover {
     font-weight: 600;
     letter-spacing: -0.015em;
     margin-bottom: 4px;
+    display: flex;
+    align-items: center;
 }
 
 .page-header-suffix {
-    margin-left: 0.5rem;
+    margin-left: 0.75rem;
     font-size: 1.1rem;
     font-weight: 400;
     color: var(--text-muted);
+}
+
+h1:focus:not(:focus-visible) {
+    outline: none;
 }
 
 .page-header-actions {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -17517,10 +17517,13 @@ body.kiosk-mode .status-indicators {
 }
 
 .site-card {
+    display: block;
     padding: 1rem;
     cursor: pointer;
     border: 1px solid transparent;
     margin-bottom: 0;
+    color: var(--text-primary);
+    text-decoration: none;
     transition: background 0.15s, border-color 0.15s;
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -364,7 +364,7 @@ a:hover {
     color: var(--text-muted);
 }
 
-h1:focus:not(:focus-visible) {
+h1:focus {
     outline: none;
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -357,7 +357,7 @@ a:hover {
 
 .page-header-suffix {
     margin-left: 0.5rem;
-    font-size: 0.875rem;
+    font-size: 1.1rem;
     font-weight: 400;
     color: var(--text-muted);
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -911,7 +911,8 @@ class LanFlowMap2D {
         if(!d.ip)return;
         // Wi-Fi clients land on the Signal tab; wired clients go to the default tab.
         const tab=d.kind===NK.WifiClient?'&tab=signal':'';
-        window.location.href=`/client-dashboard?ip=${encodeURIComponent(d.ip)}${tab}`;
+        const url=`/client-dashboard?ip=${encodeURIComponent(d.ip)}${tab}`;
+        window.location.href=window.noSiteContext?window.noSiteContext.stampUrl(url):url;
     }
 
     _hitTest(sx,sy){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -3099,7 +3099,8 @@ export class LanFlowMap {
         // Wi-Fi clients land on the Signal tab; wired clients have no signal data,
         // so they go to the default tab.
         const tab = node.kind === NODE_KIND.WifiClient ? '&tab=signal' : '';
-        window.location.href = `/client-dashboard?ip=${encodeURIComponent(ip)}${tab}`;
+        const url = `/client-dashboard?ip=${encodeURIComponent(ip)}${tab}`;
+        window.location.href = window.noSiteContext ? window.noSiteContext.stampUrl(url) : url;
     }
 
     _showHover(node) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -1,0 +1,74 @@
+// Per-tab site context (multi-site). The server pins each Blazor circuit to the
+// site in the tab's ?site= query parameter; this file keeps that selector alive
+// on the browser side of the tab:
+//  - noSiteContext.ensureSiteParam(slug), called by SiteTabSync after every
+//    in-app navigation, re-stamps ?site= into the address bar via
+//    history.replaceState so refresh / duplicate-tab / reconnect reloads land
+//    back on this tab's site.
+//  - a fetch wrapper and an anchor-click handler stamp the tab's site onto
+//    same-origin /api/ requests (charts, PDF downloads, logout) so API endpoints
+//    resolve the same site as the page issuing them. Requests that already carry
+//    an explicit site parameter are left untouched.
+//  - noSiteContext.stampUrl(url) is for scripts that trigger full-page
+//    navigations themselves (e.g. the LAN flow maps) so those keep the pin too.
+// Single-site instances never see a slug here, so every path below is a no-op.
+(function () {
+    let slug = new URLSearchParams(window.location.search).get('site');
+
+    function stamp(rawUrl) {
+        if (!slug)
+            return rawUrl;
+        try {
+            const url = new URL(rawUrl, window.location.origin);
+            if (url.origin !== window.location.origin || url.searchParams.has('site'))
+                return rawUrl;
+            url.searchParams.set('site', slug);
+            return typeof rawUrl === 'string' && !rawUrl.startsWith(url.origin)
+                ? url.pathname + url.search + url.hash
+                : url.href;
+        } catch (e) {
+            return rawUrl;
+        }
+    }
+
+    window.noSiteContext = {
+        ensureSiteParam: function (s) {
+            slug = s;
+            const url = new URL(window.location.href);
+            if (url.searchParams.get('site') === s)
+                return;
+            url.searchParams.set('site', s);
+            history.replaceState(history.state, '', url);
+        },
+        stampUrl: stamp
+    };
+
+    // Anchors to /api/ (PDF download, logout) bypass both Blazor and fetch - the
+    // browser issues a plain document request. Rewrite the href at click time so
+    // the request carries the tab's site.
+    document.addEventListener('click', function (e) {
+        if (!slug)
+            return;
+        const link = e.target.closest && e.target.closest('a[href]');
+        if (!link || link.origin !== window.location.origin || !link.pathname.startsWith('/api/'))
+            return;
+        link.href = stamp(link.href);
+    }, true);
+
+    const originalFetch = window.fetch;
+    window.fetch = function (input, init) {
+        try {
+            if (slug) {
+                const raw = typeof input === 'string' ? input : (input instanceof URL ? input.href : null);
+                if (raw !== null) {
+                    const url = new URL(raw, window.location.origin);
+                    if (url.origin === window.location.origin && url.pathname.startsWith('/api/'))
+                        input = typeof input === 'string' ? stamp(raw) : new URL(stamp(url.href));
+                }
+            }
+        } catch (e) {
+            // Malformed input: let the original fetch produce the real error.
+        }
+        return originalFetch.call(this, input, init);
+    };
+})();

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -1,19 +1,53 @@
 // Per-tab site context (multi-site). The server pins each Blazor circuit to the
 // site in the tab's ?site= query parameter; this file keeps that selector alive
 // on the browser side of the tab:
-//  - noSiteContext.ensureSiteParam(slug), called by SiteTabSync after every
-//    in-app navigation, re-stamps ?site= into the address bar via
-//    history.replaceState so refresh / duplicate-tab / reconnect reloads land
-//    back on this tab's site.
+//  - noSiteContext.ensureSiteParam(slug), called by SiteTabSync (multi-site only)
+//    after every in-app navigation, re-stamps ?site= into the address bar via
+//    history.replaceState and remembers the slug in per-tab sessionStorage so
+//    refresh / duplicate-tab / reconnect reloads stay on this tab's site.
 //  - a fetch wrapper and an anchor-click handler stamp the tab's site onto
 //    same-origin /api/ requests (charts, PDF downloads, logout) so API endpoints
-//    resolve the same site as the page issuing them. Requests that already carry
-//    an explicit site parameter are left untouched.
+//    resolve the same site as the page issuing them.
 //  - noSiteContext.stampUrl(url) is for scripts that trigger full-page
 //    navigations themselves (e.g. the LAN flow maps) so those keep the pin too.
-// Single-site instances never see a slug here, so every path below is a no-op.
+//  - a load-time backstop: if a navigation dropped ?site= (a spot that forgot to
+//    stamp it), restore this tab's remembered site with a one-shot redirect
+//    instead of silently falling back to the browser-default cookie.
+//
+// Single-site safety: sessionStorage is written ONLY by ensureSiteParam, which
+// only runs when multi-site is enabled. So on a single-site instance nothing is
+// ever remembered, the backstop never fires, and every path below (all guarded
+// on a truthy slug) is a no-op.
 (function () {
+    const STORAGE_KEY = 'no-site-tab';
+
+    function remembered() {
+        try { return sessionStorage.getItem(STORAGE_KEY) || ''; } catch (e) { return ''; }
+    }
+    function remember(s) {
+        try { if (s) sessionStorage.setItem(STORAGE_KEY, s); } catch (e) { }
+    }
+    function cookieSite() {
+        const m = document.cookie.match(/(?:^|; )no-site=([^;]*)/);
+        return m ? decodeURIComponent(m[1]) : (window.__noSiteDefault || '');
+    }
+
     let slug = new URLSearchParams(window.location.search).get('site');
+
+    // Backstop (see header). A navigation with no ?site= would resolve the
+    // browser-default cookie server-side; if this tab is pinned to a different
+    // site, restore it. Only fires when a site was remembered (so never on
+    // single-site) and it differs from the default, so default-site tabs never
+    // pay a reload; the redirect target carries ?site= so it can never loop.
+    if (!slug) {
+        const want = remembered();
+        if (want && want !== cookieSite()) {
+            const url = new URL(window.location.href);
+            url.searchParams.set('site', want);
+            window.location.replace(url.href);
+            return;
+        }
+    }
 
     function stamp(rawUrl) {
         if (!slug)
@@ -34,6 +68,7 @@
     window.noSiteContext = {
         ensureSiteParam: function (s) {
             slug = s;
+            remember(s);
             const url = new URL(window.location.href);
             if (url.searchParams.get('site') === s)
                 return;

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -90,6 +90,27 @@
         link.href = stamp(link.href);
     }, true);
 
+    // Site-switch links (the header dropdown and the /sites cards). A plain left
+    // click switches this tab and makes the site the browser default; ctrl / cmd /
+    // shift / middle clicks fall through to the browser so the link's ?site= href
+    // opens in a new tab - pinning that tab without touching this one or the default.
+    // Handled here rather than with a Blazor @onclick so a modified click's native
+    // new-tab is never preventDefaulted, and so the switch stays a plain document
+    // navigation (window.open from a Blazor Server handler would be popup-blocked).
+    document.addEventListener('click', function (e) {
+        if (e.defaultPrevented || e.button !== 0 || e.ctrlKey || e.metaKey || e.shiftKey || e.altKey)
+            return;
+        const link = e.target.closest && e.target.closest('a[data-site-switch]');
+        if (!link)
+            return;
+        e.preventDefault();
+        if (link.hasAttribute('data-site-current'))
+            return;
+        const target = link.getAttribute('data-site-switch');
+        document.cookie = 'no-site=' + target + '; path=/; max-age=31536000; SameSite=Lax';
+        window.location.assign(link.href);
+    }, false);
+
     const originalFetch = window.fetch;
     window.fetch = function (input, init) {
         try {

--- a/tests/NetworkOptimizer.Web.Tests/SiteContextUrlTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/SiteContextUrlTests.cs
@@ -1,0 +1,46 @@
+using FluentAssertions;
+using NetworkOptimizer.Web.Services;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class SiteContextUrlTests
+{
+    [Theory]
+    [InlineData("/", "/?site=branch")]
+    [InlineData("/monitoring", "/monitoring?site=branch")]
+    [InlineData("/monitoring?tab=live", "/monitoring?tab=live&site=branch")]
+    [InlineData("/monitoring?site=main", "/monitoring?site=branch")]
+    [InlineData("/monitoring?site=main&tab=live", "/monitoring?tab=live&site=branch")]
+    [InlineData("https://example.com/monitoring?tab=live", "https://example.com/monitoring?tab=live&site=branch")]
+    public void WithSiteParam_SetsSiteAndPreservesOtherParams(string url, string expected)
+    {
+        SiteContextService.WithSiteParam(url, "branch").Should().Be(expected);
+    }
+
+    [Fact]
+    public void WithSiteParam_PreservesFragment()
+    {
+        SiteContextService.WithSiteParam("/monitoring?tab=live#section", "branch")
+            .Should().Be("/monitoring?tab=live&site=branch#section");
+    }
+
+    [Fact]
+    public void WithSiteParam_EscapesSlug()
+    {
+        SiteContextService.WithSiteParam("/", "a b").Should().Be("/?site=a%20b");
+    }
+
+    [Theory]
+    [InlineData("/monitoring", "/monitoring")]
+    [InlineData("/monitoring?site=main", "/monitoring")]
+    [InlineData("/monitoring?site=main&tab=live", "/monitoring?tab=live")]
+    [InlineData("/monitoring?tab=live&site=main", "/monitoring?tab=live")]
+    [InlineData("/monitoring?SITE=main", "/monitoring")]
+    [InlineData("/monitoring?site=main#frag", "/monitoring#frag")]
+    [InlineData("/monitoring?tab=live", "/monitoring?tab=live")]
+    public void RemoveSiteParam_StripsOnlySiteParam(string url, string expected)
+    {
+        SiteContextService.RemoveSiteParam(url).Should().Be(expected);
+    }
+}


### PR DESCRIPTION
## Per-tab site context (a browser tab per site)

With multi-site enabled, the selected site lived in a single browser-wide cookie, so every tab shared one site - there was no way to view Site A in one tab and Site B in another. Worse, opening an alert "View" link for another site silently switched every open tab to it.

This makes the site a property of the browser **tab**:

- **`?site=<slug>` in the URL pins that tab.** The Blazor circuit resolves its site from the tab's URL, the selector is kept in the address bar across in-app navigation, refresh, and reconnect, and same-origin API requests from the tab resolve that same site.
- **The site cookie is now just the browser default** for tabs opened without a selector (new tabs, bare bookmarks). It is written only by an explicit switch in the UI, so following an alert "View" link pins only the tab you opened it in and never disturbs your other tabs.
- **Open a site in a new tab:** ctrl / cmd / shift / middle click a site in the header switcher or on the /sites page opens it in a new tab, pinned, without changing your current tab or the browser default.
- A load-time safeguard restores a tab's site if a navigation ever drops the selector, so a tab can't silently fall back to the default.

**Single-site instances are unaffected:** URLs stay clean, cookie behavior is unchanged, and none of the per-tab machinery runs.

### Multi-site UI

- **Dashboard header** shows the current site's name (muted, next to "Dashboard") when multi-site is enabled, including the main site, so per-site tabs are identifiable at a glance.
- **Switching sites keeps your spot:** a switch preserves the URL's `#fragment`, so switching from an anchored setting lands on the same spot on the new site.
- **Threat Intelligence** settings card uses the standard "Global" badge like the other instance-wide cards, instead of a "Global Threat Intelligence" title.
- Removed a redundant tooltip on the site cards' console host.

### Fixes

- **Header console status now updates live.** The top-bar "Console Connected / Disconnected" indicator only refreshed on navigation, so on agent-proxied sites - where the console connects asynchronously after first paint - it stayed "Disconnected" until you navigated. It now updates as soon as the connection comes up.
- **No more focus box on every page load.** The page `<h1>` is focused on each navigation (a screen-reader affordance) and the browser drew a focus outline around it on every fresh load, including on mobile. The outline is now suppressed (keyboard access is unaffected).
