### PR TITLE
Flag flaky LAN latency targets with a dismissible advisory

### DIFF
--- a/src/NetworkOptimizer.Storage/Migrations/20260712152329_AddLanFlakyHintDismissedAt.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260712152329_AddLanFlakyHintDismissedAt.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260712152329_AddLanFlakyHintDismissedAt")]
+    partial class AddLanFlakyHintDismissedAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260712152329_AddLanFlakyHintDismissedAt.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260712152329_AddLanFlakyHintDismissedAt.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLanFlakyHintDismissedAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LanFlakyHintDismissedAt",
+                table: "MonitoringTargets",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LanFlakyHintDismissedAt",
+                table: "MonitoringTargets");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/MonitoringTarget.cs
+++ b/src/NetworkOptimizer.Storage/Models/MonitoringTarget.cs
@@ -109,6 +109,14 @@ public class MonitoringTarget
     [MaxLength(200)]
     public string? AutoLabel { get; set; }
 
+    /// <summary>
+    /// When the user dismissed the "flaky LAN target" advisory for this target (the hint shown
+    /// on the LAN latency chart for non-gateway/non-AP fabric devices whose loss is usually a
+    /// measurement artifact). Null = never dismissed, so the hint may still show. Set once and
+    /// left; it only suppresses an advisory, so there's no un-dismiss path.
+    /// </summary>
+    public DateTime? LanFlakyHintDismissedAt { get; set; }
+
     public DateTime? LastVerified { get; set; }
 
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -453,6 +453,42 @@ else
             </div>
         </div>
 
+        @* Flaky LAN target advisory: shown under the LAN chart when a non-gateway/non-AP fabric
+           target has elevated loss (issue #971). LAN-side sibling of the WAN FlakyTargetsCard. *@
+        @if (LanFlakyHintTargets.Count > 0)
+        {
+            <div class="card lan-flaky-hint">
+                <div class="card-body">
+                    <p class="section-description">
+                        <span class="lan-flaky-warn">&#9888;</span>
+                        These LAN devices are showing packet loss that's usually a measurement artifact -
+                        Wi-Fi roaming or the device deprioritizing pings - rather than a real network problem.
+                        If one isn't useful to monitor, disable it in Latency Targets to keep it out of your charts.
+                    </p>
+                    <ul class="lan-flaky-list">
+                        @foreach (var t in LanFlakyHintTargets)
+                        {
+                            <li>
+                                <span class="host-truncate">@t.Name</span>
+                                <span class="lan-flaky-actions">
+                                    <button class="btn btn-sm btn-secondary" @onclick="() => JumpToLatencyTargetAsync(t.Id)">Review in Latency Targets</button>
+                                    <button class="btn btn-sm btn-secondary lan-flaky-dismiss" @onclick="() => DismissLanFlakyHintAsync(t)" data-tooltip="Dismiss this hint">&times;</button>
+                                </span>
+                            </li>
+                        }
+                    </ul>
+                </div>
+            </div>
+            <style>
+                .lan-flaky-hint { border-left: 3px solid var(--warning-color); margin-top: 1rem; }
+                .lan-flaky-warn { color: var(--warning-color); margin-right: 0.4rem; }
+                .lan-flaky-list { list-style: none; margin: 0.5rem 0 0; padding: 0; display: flex; flex-direction: column; gap: 0.5rem; }
+                .lan-flaky-list li { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; flex-wrap: wrap; }
+                .lan-flaky-actions { display: flex; align-items: center; gap: 0.5rem; flex-shrink: 0; }
+                .lan-flaky-dismiss { line-height: 1; }
+            </style>
+        }
+
         <!-- Upstream tracer wizard -->
         <div id="upstream-discovery" style="margin-top: 1.5rem;">
             <UpstreamTracerPanel ForceExpand="_forceExpandUpstream" OnSaved="StateHasChanged" />
@@ -463,7 +499,7 @@ else
         </div>
 
         <div style="margin-top: 1.5rem;">
-            <LatencyTargetsCard Targets="_targets" WanContexts="_wanContexts" OnTargetsChanged="OnTargetsChanged" />
+            <LatencyTargetsCard @ref="_latencyTargetsCard" Targets="_targets" WanContexts="_wanContexts" OnTargetsChanged="OnTargetsChanged" />
         </div>
 
         @* Multi-WAN contexts management card hidden for now (GA). Re-enable by
@@ -1421,6 +1457,16 @@ else
     private bool _cmChartsMounted;
     private bool _ontChartsMounted;
 
+    // "Flaky LAN target" advisory shown under the LAN latency chart. The chart JS reports which
+    // Fabric targets have elevated loss over the visible window (via _latencyDotNetRef ->
+    // SetLanFlakyHints); the role/dismissed gating and the notice itself render here where the
+    // target metadata lives. _latencyTargetsCard is the @ref used to expand+scroll the matching
+    // Latency Targets row.
+    private DotNetObjectReference<Monitoring>? _latencyDotNetRef;
+    private LatencyTargetsCard? _latencyTargetsCard;
+    private bool _lanFlakyCategoryActive;
+    private List<string> _lanFlakyTargetIds = new();
+
     // Investigation state
     private bool _investigatingLoss;
     private bool _investigatingSfp;
@@ -2308,6 +2354,65 @@ else
         }
     }
 
+    // Called by latency-charts.js after each render with the LAN (Fabric) targets whose loss over
+    // the visible window is elevated. We store the ids only; the notice applies the role gate and
+    // per-target dismissal against _targets. A no-change guard avoids re-rendering on every poll.
+    [JSInvokable]
+    public void SetLanFlakyHints(string category, string[] flakyTargetIds)
+    {
+        var active = category == "Fabric";
+        var ids = flakyTargetIds?.ToList() ?? new List<string>();
+        if (active == _lanFlakyCategoryActive && ids.SequenceEqual(_lanFlakyTargetIds)) return;
+        _lanFlakyCategoryActive = active;
+        _lanFlakyTargetIds = ids;
+        InvokeAsync(StateHasChanged);
+    }
+
+    // Fabric targets the chart flagged as flaky, minus gateways/APs (real infra loss is worth
+    // investigating, not hiding) and minus targets whose hint the user already dismissed.
+    private IReadOnlyList<MonitoringTarget> LanFlakyHintTargets =>
+        !_lanFlakyCategoryActive
+            ? Array.Empty<MonitoringTarget>()
+            : _targets.Where(t => t.TargetType == MonitoringTargetType.Fabric
+                    && t.Enabled
+                    && t.LanFlakyHintDismissedAt == null
+                    && _lanFlakyTargetIds.Contains(t.TargetId)
+                    && !IsGatewayOrAp(t.AutoLabel))
+                .OrderBy(t => t.Name)
+                .ToList();
+
+    // AutoLabel is set at fabric-target discovery to "gateway" / "switch" / "ap" / "unknown"
+    // (MonitoringCollectionAgent.DescribeDeviceType). Only gateways and APs are suppressed - a
+    // switch-capability device such as a smart power strip still gets the hint.
+    private static bool IsGatewayOrAp(string? autoLabel) =>
+        autoLabel is "gateway" or "ap";
+
+    private async Task JumpToLatencyTargetAsync(int targetId)
+    {
+        if (_latencyTargetsCard != null)
+            await _latencyTargetsCard.ExpandAndHighlightAsync(targetId);
+    }
+
+    private async Task DismissLanFlakyHintAsync(MonitoringTarget target)
+    {
+        try
+        {
+            await using var db = SiteDb.CreateForSite(SiteCtx.Slug, SiteCtx.IsDefault);
+            var row = await db.MonitoringTargets.FindAsync(target.Id);
+            if (row != null)
+            {
+                row.LanFlakyHintDismissedAt = DateTime.UtcNow;
+                await db.SaveChangesAsync();
+            }
+        }
+        catch { }
+        // _targets is loaded AsNoTracking, so reflect the dismissal in memory to drop the row
+        // from the advisory immediately without waiting for a reload.
+        var local = _targets.FirstOrDefault(t => t.Id == target.Id);
+        if (local != null) local.LanFlakyHintDismissedAt = DateTime.UtcNow;
+        StateHasChanged();
+    }
+
     [JSInvokable]
     public async Task OnMapTimeChanged(string? isoTimestamp)
     {
@@ -3160,6 +3265,16 @@ else
             try
             {
                 var chartsUrl = VersionedJs("/js/latency-charts.js");
+                // Hand the chart module our DotNet ref (for the flaky-LAN-target callback) via a
+                // window slot before it mounts. Best-effort: the JS callback no-ops if it's absent,
+                // so a failure here never affects chart rendering.
+                _latencyDotNetRef ??= DotNetObjectReference.Create(this);
+                try
+                {
+                    await JS.InvokeVoidAsync("eval", "window.__netoptSetLatencyRef ||= function(r){ window.__netoptLatencyRef = r; };");
+                    await JS.InvokeVoidAsync("__netoptSetLatencyRef", _latencyDotNetRef);
+                }
+                catch { }
                 var postMount = "";
                 if (!string.IsNullOrEmpty(_preSelectCategory))
                 {
@@ -3179,6 +3294,9 @@ else
             _latencyChartsMounted = false;
             try { await JS.InvokeVoidAsync("eval", "window.__latencyCharts?.unmount();"); }
             catch { }
+            // The flaky-LAN advisory is tied to the live chart, so clear it when the chart leaves.
+            _lanFlakyCategoryActive = false;
+            _lanFlakyTargetIds = new();
             // The chart (and its highlight) is torn down on leave, so drop the loss-nav state
             // too - otherwise returning shows the card "active" with no highlight on the chart.
             // Deep-linked investigations re-arm via the query param on entry, so this is safe.
@@ -3337,6 +3455,7 @@ else
         _testFeedbackTimer?.Dispose();
         _sfpChartDebounce?.Dispose();
         _mapDotNetRef?.Dispose();
+        _latencyDotNetRef?.Dispose();
         if (_latencyChartsMounted)
         {
             try { _ = JS.InvokeVoidAsync("eval", "window.__latencyCharts?.unmount();").AsTask(); }

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -463,7 +463,7 @@ else
                         <span class="lan-flaky-warn">&#9888;</span>
                         These LAN devices are showing packet loss that's usually a measurement artifact -
                         Wi-Fi roaming or the device deprioritizing pings - rather than a real network problem.
-                        If one isn't useful to monitor, disable it in Latency Targets to keep it out of your charts.
+                        If one isn't useful to monitor, pause it in Latency Targets to keep it out of your charts.
                     </p>
                     <ul class="lan-flaky-list">
                         @foreach (var t in LanFlakyHintTargets)
@@ -472,7 +472,7 @@ else
                                 <span class="host-truncate">@t.Name</span>
                                 <span class="lan-flaky-actions">
                                     <button class="btn btn-sm btn-secondary" @onclick="() => JumpToLatencyTargetAsync(t.Id)">Review in Latency Targets</button>
-                                    <button class="btn btn-sm btn-secondary lan-flaky-dismiss" @onclick="() => DismissLanFlakyHintAsync(t)" data-tooltip="Dismiss this hint">&times;</button>
+                                    <button class="btn btn-sm btn-secondary" @onclick="() => DismissLanFlakyHintAsync(t)">Dismiss</button>
                                 </span>
                             </li>
                         }
@@ -484,8 +484,8 @@ else
                 .lan-flaky-warn { color: var(--warning-color); margin-right: 0.4rem; }
                 .lan-flaky-list { list-style: none; margin: 0.5rem 0 0; padding: 0; display: flex; flex-direction: column; gap: 0.5rem; }
                 .lan-flaky-list li { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; flex-wrap: wrap; }
+                .lan-flaky-list .host-truncate { font-size: 0.9rem; }
                 .lan-flaky-actions { display: flex; align-items: center; gap: 0.5rem; flex-shrink: 0; }
-                .lan-flaky-dismiss { line-height: 1; }
             </style>
         }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
@@ -5,6 +5,7 @@
 @inject SiteContextService SiteCtx
 @inject NetworkOptimizer.Web.Services.Monitoring.ProbeExecutorFactory ExecutorFactory
 @inject NetworkOptimizer.Web.Services.Monitoring.AsnResolutionService AsnResolution
+@inject Microsoft.JSInterop.IJSRuntime JS
 
 <div class="card">
     <div class="card-header card-header-collapsible" @onclick="ToggleCollapse">
@@ -57,7 +58,7 @@
                     @foreach (var t in Targets.OrderBy(t => t.TargetType).ThenBy(t => t.Name))
                     {
                         var latest = LiveStats.GetTargetStats(t.TargetId);
-                        <tr style="@(t.Enabled ? "" : "opacity: 0.55;")">
+                        <tr id="latency-target-@t.Id" style="@(t.Enabled ? "" : "opacity: 0.55;")">
                             <td>
                                 <span class="status-badge @TargetTypeBadgeClass(t.TargetType)">
                                     @t.TargetType.ToDisplayName()
@@ -260,6 +261,30 @@
     private string? _addTargetError;
 
     private void ToggleCollapse() => _collapsed = !_collapsed;
+
+    /// <summary>
+    /// Expands the card (it defaults collapsed) and scrolls to a specific target's row with a
+    /// brief highlight. Called from the LAN flaky-target advisory so "review in Latency Targets"
+    /// lands the user on the exact row. Mirrors the scroll+outline pattern used elsewhere on the
+    /// monitoring page (Monitoring.ScrollToFlakyTargetsAsync).
+    /// </summary>
+    public async Task ExpandAndHighlightAsync(int targetId)
+    {
+        _collapsed = false;
+        StateHasChanged();
+        // Let the expand animation start and the row render before scrolling to it.
+        await Task.Delay(350);
+        await JS.InvokeVoidAsync("eval", $@"
+            (function() {{
+                var el = document.getElementById('latency-target-{targetId}');
+                if (el) {{
+                    el.scrollIntoView({{ behavior: 'smooth', block: 'center' }});
+                    el.style.transition = 'background-color 0.3s';
+                    el.style.backgroundColor = 'rgba(59, 130, 246, 0.18)';
+                    setTimeout(function() {{ el.style.backgroundColor = ''; }}, 2000);
+                }}
+            }})();");
+    }
 
     private async Task ToggleTargetAsync(int targetId)
     {

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -278,7 +278,7 @@ function updateChartVisibility() {
 }
 
 // Mean loss (%) over the visible window at or above which a LAN fabric target is treated as
-// flaky enough to advise disabling. Deliberately low: any sustained loss to a LAN device is
+// flaky enough to advise pausing. Deliberately low: any sustained loss to a LAN device is
 // abnormal, so even a fraction of a percent is worth flagging as a poor measurement target.
 const LAN_FLAKY_LOSS_PCT = 0.5;
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -277,6 +277,34 @@ function updateChartVisibility() {
     });
 }
 
+// Mean loss (%) over the visible window at or above which a LAN fabric target is treated as
+// flaky enough to advise disabling. Matches FlakyTargetService.LossAbsoluteFloorPct so the two
+// flaky-target surfaces agree on "meaningful loss".
+const LAN_FLAKY_LOSS_PCT = 3;
+
+// Report the current LAN (Fabric) category's flaky targets to Blazor so it can render the
+// "flaky LAN target" advisory. Detection only; the role/dismissed gating and the notice itself
+// live in Blazor (Monitoring.razor), which has the target metadata. Entirely best-effort:
+// wrapped so a failure here can never disturb chart rendering, and a no-op until Blazor has
+// handed us its DotNet reference via window.__netoptLatencyRef.
+function notifyLanFlakyHints(data) {
+    try {
+        const ref = window.__netoptLatencyRef;
+        if (!ref) return;
+        let ids = [];
+        if (currentCategory === 'Fabric' && data && Array.isArray(data.targets)) {
+            ids = data.targets.filter(t => {
+                const vals = (t.loss || []).map(p => p.value).filter(v => v != null);
+                if (!vals.length) return false;
+                const mean = vals.reduce((a, b) => a + b, 0) / vals.length;
+                return mean >= LAN_FLAKY_LOSS_PCT;
+            }).map(t => t.targetId);
+        }
+        // Fire-and-forget; swallow rejection if the Blazor circuit is already gone.
+        Promise.resolve(ref.invokeMethodAsync('SetLanFlakyHints', currentCategory, ids)).catch(() => { });
+    } catch { }
+}
+
 async function loadAndUpdate() {
     const data = await fetchData();
     if (!data || !data.targets) return;
@@ -315,6 +343,8 @@ async function loadAndUpdate() {
         renderBadges(container);
         renderStatsTable(container);
     }
+
+    notifyLanFlakyHints(data);
 
     // WAN rate chart - show for non-Fabric categories
     const showWanRate = currentCategory !== 'Fabric';

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -278,9 +278,9 @@ function updateChartVisibility() {
 }
 
 // Mean loss (%) over the visible window at or above which a LAN fabric target is treated as
-// flaky enough to advise disabling. Matches FlakyTargetService.LossAbsoluteFloorPct so the two
-// flaky-target surfaces agree on "meaningful loss".
-const LAN_FLAKY_LOSS_PCT = 3;
+// flaky enough to advise disabling. Deliberately low: any sustained loss to a LAN device is
+// abnormal, so even a fraction of a percent is worth flagging as a poor measurement target.
+const LAN_FLAKY_LOSS_PCT = 0.5;
 
 // Report the current LAN (Fabric) category's flaky targets to Blazor so it can render the
 // "flaky LAN target" advisory. Detection only; the role/dismissed gating and the notice itself


### PR DESCRIPTION
## What

On **Network Performance → Latency & Packet Loss**, when the chart's **LAN** view shows a device target (anything that isn't your gateway or an access point) with sustained packet loss, a small advisory now appears beneath the chart. It explains that loss to a LAN device - a smart plug, sensor, or mesh leaf device - is usually a measurement artifact (Wi-Fi roaming, or the device deprioritizing pings) rather than a real network problem, and offers to jump straight to that target in **Latency Targets** to pause it.

Each hint can be dismissed per target, and the dismissal persists.

## Why

Users see alarming packet loss on LAN devices that aren't meaningful monitoring targets - for example a mesh-connected smart power strip that roams to a distant AP - and reasonably wonder if something is broken. This surfaces the explanation in context and makes it a one-click trip to pause the target instead of hunting for it in the list.

## Details

- Flags a fabric target when its **mean loss over the currently visible chart window is >= 0.5%**.
- **Gateways and access points are excluded** - loss on those is worth investigating, not quieting. Everything else (switches, smart-power devices, etc.) is eligible.
- Detection reuses the chart's existing data (no new queries); the role and dismissal gating render in Blazor.
- Adds a nullable `MonitoringTarget.LanFlakyHintDismissedAt` column (additive EF migration).

Closes #971.
