### PR TITLE
v2.0.1 Release Changes

### DIFF
--- a/NetworkOptimizer.sln
+++ b/NetworkOptimizer.sln
@@ -59,6 +59,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetworkOptimizer.Agent", "s
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetworkOptimizer.AgentProtocol", "src\NetworkOptimizer.AgentProtocol\NetworkOptimizer.AgentProtocol.csproj", "{CBF381E5-F3CF-4A4F-85C8-DD5BFAB51741}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetworkOptimizer.AgentProtocol.Tests", "tests\NetworkOptimizer.AgentProtocol.Tests\NetworkOptimizer.AgentProtocol.Tests.csproj", "{EC6241C2-8CD8-4321-B93C-3ACC408050E9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -381,6 +383,18 @@ Global
 		{CBF381E5-F3CF-4A4F-85C8-DD5BFAB51741}.Release|x64.Build.0 = Release|Any CPU
 		{CBF381E5-F3CF-4A4F-85C8-DD5BFAB51741}.Release|x86.ActiveCfg = Release|Any CPU
 		{CBF381E5-F3CF-4A4F-85C8-DD5BFAB51741}.Release|x86.Build.0 = Release|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Debug|x64.Build.0 = Debug|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Debug|x86.Build.0 = Debug|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Release|x64.ActiveCfg = Release|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Release|x64.Build.0 = Release|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Release|x86.ActiveCfg = Release|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -401,6 +415,7 @@ Global
 		{EC72C9AD-625C-4AA8-A7CC-744515E06F1E} = {5691A6DD-53B9-4CE0-A3C9-3D4F815E2120}
 		{01F2AE32-FE55-4892-B91B-CE2BC964F29D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{CBF381E5-F3CF-4A4F-85C8-DD5BFAB51741} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9} = {5691A6DD-53B9-4CE0-A3C9-3D4F815E2120}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F7E6D5C4-B3A2-9180-7F6E-5D4C3B2A1908}

--- a/TODO.md
+++ b/TODO.md
@@ -401,14 +401,35 @@ IPs. Commercial and even residential sites are stable enough in practice; a stol
 from a random IP then dies at the firewall before the bearer key is presented. Bearer
 key + rate-limiting stay as defense-in-depth behind it.
 
+Implemented (agent-owned proxy controls; revises an earlier "not worth it" call):
+- **Site-local proxy dial fence** (always on): `ProxyOpen` targets must be RFC1918 /
+  IPv6 unique-local / IPv6 link-local; hostnames are resolved once, every address
+  validated, and the dial uses the validated addresses. The earlier rationale ("gateway
+  SSH pivots anyway, so an allowlist contains nothing") was right about LAN containment
+  but missed the **internet-relay vector**: unrestricted `ProxyOpen` let a compromised
+  server use every site as a silent exit node against third parties - no gateway creds
+  needed, no footprint on customer equipment. The fence closes exactly that, and only
+  claims that.
+- **Operator pin** (`proxyAllowedCidrs` in agent.json): replaces the fence with an
+  operator-owned CIDR list - real reach-capping the server can't override, and the only
+  escape hatch for public-IP targets.
+- **Dial audit trail**: every proxy dial (allow + deny) journaled agent-side where the
+  server can't suppress it.
+- NOT built (still on record as not worth it): a **server-pushed device allowlist**
+  (UniFi device list + custom targets enforced agent-side). The server is authoritative
+  for tunnel config, so a compromised server pushes its own list; signing doesn't help
+  (server holds the key) and TOFU/ratcheting either blocks legit changes (device
+  adoption, DHCP renumbering) or degrades to log-only. All complexity, no unforgeable
+  containment - the three controls above are the honest subset.
+
 Considered and deliberately NOT implemented (rationale on record so it isn't re-litigated):
-- **Agent-side proxy dial allowlist** (restrict `ProxyOpen` targets to the gateway/known
-  devices): not an effective control. Gateway SSH already reaches the whole LAN, so
-  anything with gateway access pivots through it regardless; restricting the agent's dial
-  targets contains nothing against a compromised server. Pure complexity.
 - **Hard SSH host-key pinning**: impractical. UniFi regenerates SSH host keys on firmware
   upgrades (and adoption/factory reset), so a strict pin breaks SSH after routine updates
   and trains operators to click through warnings - worse than the soft tripwire above.
+- **Agent-side SSH command filtering**: impossible at the agent - the proxied SSH session
+  is encrypted end-to-end between the central server and the gateway's sshd; the agent
+  pumps opaque bytes. Command safety lives server-side (parameterized command
+  construction); the gateway-side option is `authorized_keys` forced commands.
 
 ### Credential Key: Hardening Follow-ups
 

--- a/TODO.md
+++ b/TODO.md
@@ -614,6 +614,11 @@ Goal: keep global channels applying everywhere, but let a site add its OWN addit
 - **Fix:** Replace with an enum `DnatCoverageType` for type safety and discoverability
 - **Scope:** `DnatDnsAnalyzer.cs` only - fully self-contained
 
+### Relocate DefaultSiteSlug Constant to a Shared Project
+- **Issue:** `SiteManagementService.DefaultSiteSlug` (`"main"`) lives in `NetworkOptimizer.Web`, but lower-level projects that reference only `NetworkOptimizer.Core` need the same value. `AlertProcessingService.ResolveSourceUrl` (`NetworkOptimizer.Alerts`) can't reference it - the dependency points the wrong way - so it hardcodes the literal `"main"` with a comment.
+- **Fix:** Move the constant down into a shared low-level home (`NetworkOptimizer.Core`), then repoint every reference (`SiteManagementService`, `SiteContextService`, `AlertProcessingService`, and any others).
+- **Scope:** Multiple projects; small but touches DI/reference sites, so needs a rebuild + test pass. Not urgent - the literal is correct as long as the constant stays `"main"`.
+
 ### ThirdPartyDnsDetector Probe Method Duplication
 - **Issue:** Two overloads of `TryProbePiholeEndpointAsync` and `TryProbeAdGuardHomeEndpointAsync` - one takes a full URL, one takes IP+port+scheme. The logic is nearly identical.
 - **Fix:** Unify into a single method that takes a URL string. The IP+port caller can construct the URL before calling.

--- a/src/NetworkOptimizer.Agent/ProbeRunner.cs
+++ b/src/NetworkOptimizer.Agent/ProbeRunner.cs
@@ -10,13 +10,16 @@ namespace NetworkOptimizer.Agent;
 /// The site's latency/loss probe engine. The server pushes the site's
 /// monitoring targets over the tunnel; this runner probes each on its own
 /// cadence (2 s scheduler tick, per-target intervals, bounded concurrency,
-/// mirroring the server's latency tier) and streams every result straight
-/// back. Created per tunnel connection: the server re-pushes config on every
-/// connect, and results have nowhere to go while the tunnel is down.
+/// mirroring the server's latency tier) and enqueues every result into the
+/// store-and-forward <see cref="ResultBuffer"/>. Runs for the life of the
+/// agent process: probing continues through tunnel outages - which is exactly
+/// when latency/loss data matters most - with the buffer holding the backlog
+/// and the last pushed target set staying in effect until the server
+/// re-pushes on reconnect.
 /// </summary>
 public sealed class ProbeRunner
 {
-    private readonly Func<AgentMessage, bool> _send;
+    private readonly Action<AgentMessage> _send;
     private readonly string? _defaultSourceIp;
     private readonly LocalProbeExecutor _executor = new(NullLogger<LocalProbeExecutor>.Instance);
     private readonly ConcurrentDictionary<string, DateTime> _lastProbed = new();
@@ -27,7 +30,7 @@ public sealed class ProbeRunner
     /// own. This is the probe-only multi-WAN deployment knob: the gateway
     /// policy-routes this source IP out a specific WAN.
     /// </param>
-    public ProbeRunner(Func<AgentMessage, bool> send, string? defaultSourceIp = null)
+    public ProbeRunner(Action<AgentMessage> send, string? defaultSourceIp = null)
     {
         _send = send;
         _defaultSourceIp = string.IsNullOrEmpty(defaultSourceIp) ? null : defaultSourceIp;
@@ -42,13 +45,13 @@ public sealed class ProbeRunner
     public async Task RunAsync(CancellationToken ct)
     {
         // Startup grace, mirroring the server latency tier's 20s initial delay
-        // (MonitoringCollectionAgent.RunTierAsync). A fresh ProbeRunner starts on every
-        // tunnel connect - the agent (re)starting, OR a NO-server restart that dropped
-        // and re-established the tunnel - and every target is "due" immediately. Probing
-        // the instant the process/link comes up catches the network still settling
-        // (routes, source-IP binds, the target device itself rebooting alongside) and
-        // records a false loss/latency spike right at the restart boundary. Wait for it
-        // to settle before the first tick, so no boundary sample is taken.
+        // (MonitoringCollectionAgent.RunTierAsync). At agent process start every target
+        // is "due" immediately, and probing the instant the process comes up catches
+        // the network still settling (routes, source-IP binds, the target device itself
+        // rebooting alongside) and records a false loss/latency spike right at the
+        // start boundary. Wait for it to settle before the first tick, so no boundary
+        // sample is taken. Tunnel reconnects no longer restart this runner, so no
+        // grace (or gap) applies there - probing runs continuously across outages.
         try { await Task.Delay(TimeSpan.FromSeconds(20), ct); }
         catch (OperationCanceledException) { return; }
 

--- a/src/NetworkOptimizer.Agent/Program.cs
+++ b/src/NetworkOptimizer.Agent/Program.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using NetworkOptimizer.Agent;
+using NetworkOptimizer.AgentProtocol;
 
 // On-site agent skeleton: enrolls against the central Network Optimizer server
 // with a one-time token, persists its agent key and site slug, then heartbeats.
@@ -185,6 +186,26 @@ if (config.LanSpeedTest)
         speedTestServer is { } relayServer ? relayServer.PostIperf3ResultAsync : null, cts.Token);
 }
 
+// Monitoring collectors and their store-and-forward buffer live for the whole
+// process, not per tunnel connection: probing and SNMP polling continue on the
+// last pushed config while the tunnel is down - exactly when outage data
+// matters most - and the buffered backlog (12 h / 64 MB caps, oldest dropped
+// first) replays over the tunnel on reconnect. Only started when a tunnel is
+// configured; without one no config ever arrives and there is nothing to run.
+ResultBuffer? resultBuffer = null;
+ProbeRunner? probeRunner = null;
+SnmpRunner? snmpRunner = null;
+Task? probeTask = null;
+Task? snmpTask = null;
+if (!string.IsNullOrEmpty(config.TunnelUrl))
+{
+    resultBuffer = new ResultBuffer();
+    probeRunner = new ProbeRunner(resultBuffer.Enqueue, config.ProbeSourceIp);
+    snmpRunner = new SnmpRunner(resultBuffer.Enqueue);
+    probeTask = probeRunner.RunAsync(cts.Token);
+    snmpTask = snmpRunner.RunAsync(cts.Token);
+}
+
 // Prefer the persistent gRPC tunnel; REST heartbeats keep the agent visible as
 // Online whenever the tunnel is unavailable (tunnel disabled server-side, an
 // older server, or a network drop between reconnect attempts).
@@ -192,19 +213,14 @@ while (!cts.IsCancellationRequested)
 {
     if (!string.IsNullOrEmpty(config.TunnelUrl))
     {
-        // The probe runner lives and dies with its tunnel connection: the
-        // server re-pushes probe config on every connect, and results have
-        // nowhere to go while the tunnel is down.
         using var connectionCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
         var tunnel = new TunnelClient();
-        var probeRunner = new ProbeRunner(tunnel.TrySend, config.ProbeSourceIp);
-        var snmpRunner = new SnmpRunner(tunnel);
         var proxyHandler = new ProxyHandler(tunnel, proxyPolicy);
         var iperf3ClientRunner = new Iperf3ClientRunner(tunnel);
         var uwnClientRunner = new UwnClientRunner(tunnel);
         var probeRequestRunner = new ProbeRequestRunner(tunnel);
-        tunnel.OnProbeConfig = probeRunner.UpdateConfig;
-        tunnel.OnSnmpConfig = snmpRunner.UpdateConfig;
+        tunnel.OnProbeConfig = probeRunner!.UpdateConfig;
+        tunnel.OnSnmpConfig = snmpRunner!.UpdateConfig;
         tunnel.OnWanSpeedTestConfig = wanConfig => speedTestServer?.UpdateWanServers(
             wanConfig.Servers.Select(s => new SpeedTestServer.WanServerEntry(s.ServerId, s.Url)).ToList(),
             wanConfig.DefaultServerId);
@@ -215,8 +231,17 @@ while (!cts.IsCancellationRequested)
         tunnel.OnIperf3Request = iperf3ClientRunner.HandleAsync;
         tunnel.OnUwnRequest = uwnClientRunner.HandleAsync;
         tunnel.OnProbeRequest = probeRequestRunner.HandleAsync;
-        var probeTask = probeRunner.RunAsync(connectionCts.Token);
-        var snmpTask = snmpRunner.RunAsync(connectionCts.Token);
+        // Server confirms persisted result frames; trim them from the buffer so
+        // only unacked data is retained for replay.
+        tunnel.OnResultAck = seq => resultBuffer!.MarkAcked(seq);
+        var backlog = resultBuffer!.Count;
+        if (backlog > 0)
+            Console.WriteLine($"Buffered backlog: {backlog} result message(s) (~{resultBuffer.ApproxBytes / 1024} KB) will flush once the tunnel connects");
+        var droppedOffline = resultBuffer.TakeDroppedCount();
+        if (droppedOffline > 0)
+            Console.Error.WriteLine($"Result buffer caps dropped the {droppedOffline} oldest message(s) while the tunnel was down");
+
+        var drainTask = tunnel.DrainResultsAsync(resultBuffer, connectionCts.Token);
         try
         {
             await tunnel.RunAsync(config.TunnelUrl, config.AgentKey!, version, lanIp, config.IgnoreSslErrors, cts.Token);
@@ -233,7 +258,9 @@ while (!cts.IsCancellationRequested)
         finally
         {
             connectionCts.Cancel();
-            try { await Task.WhenAll(probeTask, snmpTask); } catch (OperationCanceledException) { }
+            // Nothing to salvage: the drain only peeks, so every unacked frame is
+            // still in the buffer and replays on the next connection.
+            try { await drainTask; } catch (OperationCanceledException) { }
         }
     }
 
@@ -269,6 +296,14 @@ if (speedTestServer != null)
 if (iperf3Task != null)
 {
     try { await iperf3Task; } catch (OperationCanceledException) { }
+}
+if (probeTask != null)
+{
+    try { await probeTask; } catch (OperationCanceledException) { }
+}
+if (snmpTask != null)
+{
+    try { await snmpTask; } catch (OperationCanceledException) { }
 }
 
 Console.WriteLine("Agent stopped");

--- a/src/NetworkOptimizer.Agent/Program.cs
+++ b/src/NetworkOptimizer.Agent/Program.cs
@@ -59,6 +59,28 @@ if (!string.IsNullOrEmpty(config.TunnelUrl) && !IsHttpsUrl(config.TunnelUrl))
     return 1;
 }
 
+// Proxy dial policy: hardcoded site-local fence (RFC1918 / IPv6 local) unless the
+// operator pins an explicit CIDR list in agent.json, which fully replaces it. The
+// policy is agent-owned on purpose - nothing the server sends over the tunnel can
+// widen it. An invalid entry aborts startup: failing loud beats silently running
+// with a partial pin.
+var proxyPolicy = NetworkOptimizer.Core.Helpers.ProxyDialPolicy.SiteLocal;
+if (config.ProxyAllowedCidrs != null)
+{
+    var pinned = NetworkOptimizer.Core.Helpers.ProxyDialPolicy.FromPinnedCidrs(config.ProxyAllowedCidrs, out var policyError);
+    if (pinned == null)
+    {
+        Console.Error.WriteLine($"Invalid proxyAllowedCidrs in {configPath}: {policyError}");
+        return 1;
+    }
+    proxyPolicy = pinned;
+    Console.WriteLine($"Proxy dials pinned to {pinned.PinnedCount} operator-configured CIDR(s)");
+}
+else
+{
+    Console.WriteLine("Proxy dials restricted to site-local addresses (RFC1918 / IPv6 local)");
+}
+
 var version = Assembly.GetExecutingAssembly()
     .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "dev";
 
@@ -177,7 +199,7 @@ while (!cts.IsCancellationRequested)
         var tunnel = new TunnelClient();
         var probeRunner = new ProbeRunner(tunnel.TrySend, config.ProbeSourceIp);
         var snmpRunner = new SnmpRunner(tunnel);
-        var proxyHandler = new ProxyHandler(tunnel);
+        var proxyHandler = new ProxyHandler(tunnel, proxyPolicy);
         var iperf3ClientRunner = new Iperf3ClientRunner(tunnel);
         var uwnClientRunner = new UwnClientRunner(tunnel);
         var probeRequestRunner = new ProbeRequestRunner(tunnel);
@@ -255,6 +277,13 @@ return 0;
 namespace NetworkOptimizer.Agent
 {
     /// <summary>Agent configuration file contents (agent.json).</summary>
+    /// <remarks>
+    /// ProxyAllowedCidrs: operator pin for tunnel proxy dial targets (IPs or CIDRs).
+    /// When present it fully replaces the built-in site-local fence - both the
+    /// narrowing knob (pin to a management VLAN) and the only escape hatch for a
+    /// public-IP target. Include every subnet holding the UniFi Console, gateway,
+    /// devices used for SSH/speed tests, and modem/ONT/hotspot status pages.
+    /// </remarks>
     public record AgentConfig(
         string ServerUrl,
         string? EnrollmentToken,
@@ -264,7 +293,8 @@ namespace NetworkOptimizer.Agent
         string? TunnelUrl = null,
         string? ProbeSourceIp = null,
         bool LanSpeedTest = false,
-        int LanSpeedTestPort = 3000);
+        int LanSpeedTestPort = 3000,
+        IReadOnlyList<string>? ProxyAllowedCidrs = null);
 
     public record EnrollmentResponse(string AgentKey, string SiteSlug, int? TunnelPort = null);
 

--- a/src/NetworkOptimizer.Agent/ProxyHandler.cs
+++ b/src/NetworkOptimizer.Agent/ProxyHandler.cs
@@ -1,7 +1,9 @@
 using System.Collections.Concurrent;
+using System.Net;
 using System.Net.Sockets;
 using Google.Protobuf;
 using NetworkOptimizer.AgentProtocol;
+using NetworkOptimizer.Core.Helpers;
 
 namespace NetworkOptimizer.Agent;
 
@@ -12,17 +14,21 @@ namespace NetworkOptimizer.Agent;
 /// dies with its tunnel connection, like the probe runner.
 /// </summary>
 /// <remarks>
-/// Security model: the agent dials whatever host:port the server names, with no
-/// agent-side allowlist, and that is deliberate. The tunnel's legitimate job
-/// includes SSH to the site gateway, and the gateway is the LAN router - anything
-/// that can reach it already reaches the whole LAN - so an allowlist restricting
-/// proxy targets to "just the gateway" would contain nothing against a compromised
-/// central server (it would simply pivot through the gateway). The trust boundary
-/// is therefore the central server and the agentKey, not this dial path: harden
-/// the server (IP-allowlist the admin plane and this tunnel endpoint to your
-/// sites' IPs, strong auth, guard key material), and treat a server compromise as
-/// game-over for managed gateways, which is inherent to centralized gateway
-/// management. See the agent README "Security and hardening" section and TODO.md.
+/// Security model: dial targets are gated by a <see cref="ProxyDialPolicy"/> the
+/// agent owns - site-local addresses only by default, or the operator's pinned
+/// CIDR list from agent.json ("proxyAllowedCidrs"). Nothing on the tunnel can
+/// widen it, so a compromised central server cannot use this site as a relay to
+/// the internet, and an operator pin caps its LAN reach through this path to
+/// exactly the addresses listed. Every dial is journaled locally (allow and
+/// deny), an audit trail the server cannot suppress. What this deliberately does
+/// NOT claim: containment of a compromised server that holds gateway SSH
+/// credentials - the gateway is the LAN router, so that reach is LAN-wide
+/// regardless; protecting the central server remains the primary defense (see
+/// the agent README "Security and hardening" section and TODO.md). Hostnames are
+/// resolved once, every resolved address is validated, and the dial uses the
+/// validated addresses - a name that resolves to any out-of-scope address is
+/// refused outright rather than filtered, so DNS games can't split the check
+/// from the connect.
 /// </remarks>
 public sealed class ProxyHandler
 {
@@ -30,34 +36,69 @@ public sealed class ProxyHandler
     private static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(5);
 
     private readonly TunnelClient _tunnel;
+    private readonly ProxyDialPolicy _policy;
     private readonly ConcurrentDictionary<long, TcpClient> _connections = new();
 
-    public ProxyHandler(TunnelClient tunnel)
+    public ProxyHandler(TunnelClient tunnel, ProxyDialPolicy policy)
     {
         _tunnel = tunnel;
+        _policy = policy;
     }
 
     public async Task HandleOpenAsync(ProxyOpen open, CancellationToken ct)
     {
+        IPAddress[] addresses;
+        if (IPAddress.TryParse(open.Host, out var literal))
+        {
+            addresses = new[] { literal };
+        }
+        else
+        {
+            try
+            {
+                addresses = await Dns.GetHostAddressesAsync(open.Host, ct);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                await SendOpenFailureAsync(open.ConnectionId, $"could not resolve '{open.Host}': {ex.Message}", ct);
+                return;
+            }
+            if (addresses.Length == 0)
+            {
+                await SendOpenFailureAsync(open.ConnectionId, $"'{open.Host}' resolved to no addresses", ct);
+                return;
+            }
+        }
+
+        // All-or-nothing: one out-of-scope address in the resolution refuses the
+        // whole dial instead of narrowing to the in-scope subset.
+        var offender = addresses.FirstOrDefault(a => !_policy.IsAllowed(a));
+        if (offender != null)
+        {
+            var scope = _policy.IsDefault ? "site-local scope" : "the operator-pinned proxy scope";
+            Console.Error.WriteLine($"Proxy dial DENIED: {open.Host}:{open.Port} (conn {open.ConnectionId}) - {offender} is outside {scope}");
+            await SendOpenFailureAsync(open.ConnectionId,
+                $"proxy target denied by agent policy: {offender} is outside {scope}", ct);
+            return;
+        }
+
+        Console.WriteLine($"Proxy dial: {open.Host}:{open.Port} (conn {open.ConnectionId})");
+
         var client = new TcpClient();
         try
         {
             using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             connectCts.CancelAfter(ConnectTimeout);
-            await client.ConnectAsync(open.Host, open.Port, connectCts.Token);
+            // Dial the validated addresses, never the name - re-resolving here
+            // would let a changed DNS answer bypass the policy check above.
+            await client.ConnectAsync(addresses, open.Port, connectCts.Token);
         }
         catch (Exception ex)
         {
             client.Dispose();
-            await _tunnel.SendAsync(new AgentMessage
-            {
-                ProxyOpenResult = new ProxyOpenResult
-                {
-                    ConnectionId = open.ConnectionId,
-                    Ok = false,
-                    Error = ex is OperationCanceledException ? "connect timed out" : ex.Message,
-                }
-            }, ct);
+            var reason = ex is OperationCanceledException ? "connect timed out" : ex.Message;
+            Console.Error.WriteLine($"Proxy dial failed: {open.Host}:{open.Port} (conn {open.ConnectionId}) - {reason}");
+            await SendOpenFailureAsync(open.ConnectionId, reason, ct);
             return;
         }
 
@@ -101,6 +142,17 @@ public sealed class ProxyHandler
             }
         }
     }
+
+    private async Task SendOpenFailureAsync(long connectionId, string error, CancellationToken ct) =>
+        await _tunnel.SendAsync(new AgentMessage
+        {
+            ProxyOpenResult = new ProxyOpenResult
+            {
+                ConnectionId = connectionId,
+                Ok = false,
+                Error = error,
+            }
+        }, ct);
 
     public async Task HandleDataAsync(ProxyData data, CancellationToken ct)
     {

--- a/src/NetworkOptimizer.Agent/README.md
+++ b/src/NetworkOptimizer.Agent/README.md
@@ -265,12 +265,42 @@ is inherent to centralized gateway management, not a flaw of the tunnel - no
 protocol trick changes it, which is exactly why protecting the server is the
 whole ballgame.
 
-Two controls we deliberately did **not** build, so the reasoning is on record:
+### What the agent enforces on its own
 
-- **An agent-side allowlist on proxy dial targets** would contain nothing.
-  Gateway SSH already reaches the entire LAN, so anything with gateway access
-  pivots through it; restricting what the agent may dial doesn't limit a
-  compromised server, it just adds complexity.
+Three controls are agent-owned - nothing the server sends over the tunnel can
+change them:
+
+- **Site-local proxy fence (built in, always on).** The tunnel's TCP proxy
+  refuses to dial anything that is not a site-local address (RFC1918, IPv6
+  unique-local, IPv6 link-local). Everything the proxy legitimately reaches -
+  the UniFi Console, gateway/device SSH, modem/ONT/hotspot status pages - is
+  site-local, so normal setups never notice. What it closes is the quiet abuse
+  a compromised central server would otherwise get for free: using your site
+  as an exit node to relay attacks at third parties. Hostnames are resolved
+  once, every resolved address is checked, and the connection goes to the
+  checked address, so DNS tricks can't split the check from the dial.
+- **Operator pinning (`proxyAllowedCidrs` in `agent.json`, optional).** A list
+  of IPs/CIDRs that fully replaces the built-in fence. Pin it to narrow the
+  server's reach through the proxy to exactly the addresses you list (e.g.
+  just the management VLAN) - or to admit an exotic public-IP target, which is
+  the only escape hatch that exists. If you pin, include every subnet holding
+  the UniFi Console, the gateway, any devices used for SSH/speed tests or as
+  probe vantages, and modem/ONT/hotspot status pages - anything outside the
+  pin fails with a logged denial. An invalid entry aborts agent startup rather
+  than running half-pinned.
+- **Dial audit trail.** Every proxy dial (allowed or denied) is one line in
+  the agent's journal, with the target and connection id. The central server
+  cannot suppress or rotate it, so the site always has its own record of what
+  was reached through the tunnel: `journalctl -u netopt-agent | grep "Proxy dial"`.
+
+Honest scope: with gateway SSH credentials configured, a compromised central
+server still owns the LAN through the gateway - these controls close the
+internet-relay vector, cap what the proxy path can reach, and leave evidence;
+they do not (cannot) contain gateway-credential pivoting. That containment
+story remains server-side hardening, above.
+
+One control we deliberately did **not** build, so the reasoning is on record:
+
 - **Pinning the gateway's SSH host key** is impractical here: UniFi regenerates
   host keys on firmware upgrades (and adoption/factory reset), so a strict pin
   would break SSH after routine updates and train operators to click through
@@ -278,6 +308,13 @@ Two controls we deliberately did **not** build, so the reasoning is on record:
   gateway - is better addressed at the tunnel (guard the key, IP-allowlist, and
   one-tunnel-per-key), with at most a soft "host key changed" alert that never
   blocks.
+
+Also out of scope by design: filtering SSH *commands* at the agent. The proxied
+SSH session is encrypted end-to-end between the central server and the
+gateway's sshd; the agent pumps opaque bytes and cannot inspect them. Command
+safety lives server-side (parameterized command construction), and the
+gateway-side option (`authorized_keys` forced commands) is gateway
+configuration, not agent code.
 
 ## Local dev / testing
 

--- a/src/NetworkOptimizer.Agent/SnmpRunner.cs
+++ b/src/NetworkOptimizer.Agent/SnmpRunner.cs
@@ -8,14 +8,16 @@ namespace NetworkOptimizer.Agent;
 /// <summary>
 /// The site's SNMP poller. The server pushes the site's SNMP credentials and
 /// device list over the tunnel; this runner polls interface counters (fast
-/// cadence) and device health (medium cadence) locally and streams the raw
-/// samples back. Rate computation and storage happen server-side, mirroring
-/// the central collection agent's split. Lives and dies with its tunnel
-/// connection, like the probe runner.
+/// cadence) and device health (medium cadence) locally and enqueues the raw
+/// samples into the store-and-forward <see cref="ResultBuffer"/>. Rate
+/// computation and storage happen server-side, mirroring the central
+/// collection agent's split. Runs for the life of the agent process, like the
+/// probe runner: polling continues through tunnel outages on the last pushed
+/// config, and the buffered backlog replays on reconnect.
 /// </summary>
 public sealed class SnmpRunner
 {
-    private readonly TunnelClient _tunnel;
+    private readonly Action<AgentMessage> _send;
     private volatile SnmpConfig? _config;
     private SnmpPoller? _poller;
     private string _pollerKey = "";
@@ -25,9 +27,9 @@ public sealed class SnmpRunner
     // the agent either. Keyed by device MAC.
     private readonly SnmpFailureTracker _failures = new();
 
-    public SnmpRunner(TunnelClient tunnel)
+    public SnmpRunner(Action<AgentMessage> send)
     {
-        _tunnel = tunnel;
+        _send = send;
     }
 
     public void UpdateConfig(SnmpConfig config)
@@ -43,7 +45,9 @@ public sealed class SnmpRunner
 
     /// <summary>
     /// Handles the server's on-demand "Test OID" request: GET the single OID once against a
-    /// site-local device and return the raw value (correlated by request id).
+    /// site-local device and return the raw value (correlated by request id). The reply rides
+    /// the result buffer like everything else; if the tunnel drops first, the server has
+    /// already timed the request out and ignores the stale request id on replay.
     /// </summary>
     public async Task HandleOidQueryAsync(SnmpOidQuery query, CancellationToken ct)
     {
@@ -74,8 +78,7 @@ public sealed class SnmpRunner
         }
 
         Console.WriteLine($"OID test request {query.RequestId}: success={result.Success} value={result.Value} error={result.Error}");
-        try { await _tunnel.SendAsync(new AgentMessage { SnmpOidResult = result }, ct); }
-        catch (Exception ex) { Console.Error.WriteLine($"Failed to send OID test result {query.RequestId}: {ex.Message}"); }
+        _send(new AgentMessage { SnmpOidResult = result });
     }
 
     /// <summary>Interface counters on the fast cadence.</summary>
@@ -131,7 +134,7 @@ public sealed class SnmpRunner
                         });
                     }
                     if (batch.Interfaces.Count > 0)
-                        await _tunnel.SendAsync(new AgentMessage { SnmpResults = batch }, ct);
+                        _send(new AgentMessage { SnmpResults = batch });
                 }, ct);
             }
 
@@ -181,7 +184,7 @@ public sealed class SnmpRunner
                     await PollCustomOidsAsync(poller, ip, device, config, batch);
 
                     if (batch.Health.Count > 0 || batch.CustomOids.Count > 0)
-                        await _tunnel.SendAsync(new AgentMessage { SnmpResults = batch }, ct);
+                        _send(new AgentMessage { SnmpResults = batch });
                 }, ct);
             }
 

--- a/src/NetworkOptimizer.Agent/TunnelClient.cs
+++ b/src/NetworkOptimizer.Agent/TunnelClient.cs
@@ -10,14 +10,53 @@ namespace NetworkOptimizer.Agent;
 /// HTTP/2 tunnel port, authenticates with the agent key, then holds one
 /// bidirectional stream carrying heartbeats and probe results out and probe
 /// configuration in. All outbound writes funnel through a channel so multiple
-/// producers (heartbeat loop, probe runner) never race on the stream.
+/// producers (heartbeat loop, result-buffer drain, proxy handler) never race
+/// on the stream. Monitoring results reach the stream only through
+/// <see cref="DrainResultsAsync"/> from the process-wide
+/// <see cref="ResultBuffer"/>, which is what carries them across tunnel
+/// outages.
 /// </summary>
 public sealed class TunnelClient
 {
     // Wait (not drop) when full: proxied byte streams ride this channel and a
-    // dropped frame would corrupt them.
+    // dropped frame would corrupt them. Result frames also ride it, but they
+    // stay in the ResultBuffer until the server acks them, so a frame still on
+    // this channel when the tunnel tears down is simply re-sent on the next
+    // connection - nothing to salvage.
     private readonly Channel<AgentMessage> _outbound = Channel.CreateBounded<AgentMessage>(
         new BoundedChannelOptions(256) { FullMode = BoundedChannelFullMode.Wait });
+
+    // Backlog-flush tuning for DrainResultsAsync: coalescing consecutive
+    // batches slashes the server's per-batch overhead (DB round-trips, console
+    // cache lookups) when replaying hours of buffered data, and the headroom
+    // check keeps this flood from saturating the outbound channel so
+    // heartbeats and proxied console traffic still get through mid-flush.
+    private const int CoalesceMaxSamples = 500;
+    private const int OutboundHeadroomSlots = 64;
+
+    // The server is never silent on a healthy tunnel - it re-pushes the site's
+    // configs every 60 s - so 2.5 missed refresh cycles means the link is
+    // black-holed. A real WAN outage drops packets rather than resetting
+    // connections: without this watchdog the read loop would hang in MoveNext
+    // for the full TCP timeout (~15 min) before the reconnect loop - and the
+    // buffered-backlog flush - could run. Written by the read loop, watched by
+    // WatchInboundSilenceAsync.
+    private const long InboundSilenceTimeoutMs = 150_000;
+    private long _lastInboundTicks;
+
+    // Bound the post-connect handshake: the inbound-silence watchdog only arms
+    // once the server hello arrives, so without this a link black-holed between
+    // connect and hello would hang the read on dead TCP for the full OS timeout
+    // (~15 min) before the reconnect loop could retry.
+    private static readonly TimeSpan HelloTimeout = TimeSpan.FromSeconds(20);
+
+    // Set from the server hello. An older server that doesn't ack result frames
+    // (SupportsResultAck = false) means we can't rely on acks, so the drain trims
+    // each frame on send - the pre-ack behavior - instead of retaining the whole
+    // buffer and re-flushing it on every reconnect. A fresh TunnelClient per
+    // connection defaults this to false (keep until proven), which is the safe
+    // side: worst case a frame is re-sent, never dropped.
+    private volatile bool _ackless;
 
     /// <summary>Invoked whenever the server pushes a new probe configuration.</summary>
     public Action<ProbeConfig>? OnProbeConfig { get; set; }
@@ -48,6 +87,13 @@ public sealed class TunnelClient
 
     /// <summary>Server asks us to run an on-demand ping/traceroute from this host.</summary>
     public Func<ProbeRequest, CancellationToken, Task>? OnProbeRequest { get; set; }
+
+    /// <summary>
+    /// Server has persisted result frames up to (and including) this sequence.
+    /// Wired to <see cref="ResultBuffer.MarkAcked"/> so acked frames leave the
+    /// buffer; anything unacked replays on the next connection.
+    /// </summary>
+    public Action<long>? OnResultAck { get; set; }
 
     /// <summary>Queues a message for the stream pump. Safe from any thread.</summary>
     public bool TrySend(AgentMessage message) => _outbound.Writer.TryWrite(message);
@@ -104,27 +150,51 @@ public sealed class TunnelClient
 
         using var grpcChannel = GrpcChannel.ForAddress(tunnelUrl, new GrpcChannelOptions { HttpHandler = handler });
         var client = new AgentTunnel.AgentTunnelClient(grpcChannel);
-        using var call = client.Connect(cancellationToken: ct);
-
-        await call.RequestStream.WriteAsync(new AgentMessage
-        {
-            Hello = new AgentHello { AgentKey = agentKey, Version = version, LanIp = lanIp ?? "" }
-        }, ct);
-
-        if (!await call.ResponseStream.MoveNext(ct) || call.ResponseStream.Current.Hello is not { } hello)
-            throw new IOException("Tunnel closed before server hello");
-
-        var heartbeatInterval = TimeSpan.FromSeconds(Math.Max(5, hello.HeartbeatIntervalSeconds));
-        Console.WriteLine($"Tunnel open for site '{hello.SiteSlug}' (heartbeat every {heartbeatInterval.TotalSeconds:0}s)");
-
+        // The linked source scopes the whole call (not just the pump/heartbeat)
+        // so the inbound-silence watchdog can abort a black-holed read loop.
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        using var call = client.Connect(cancellationToken: linked.Token);
+
+        // The connection is up but the server hello has not arrived yet, and the
+        // inbound-silence watchdog below only arms once it has. Bound the handshake
+        // so a link black-holed in this window fails fast into a retry instead of
+        // hanging the read on dead TCP for the full OS timeout.
+        TimeSpan heartbeatInterval;
+        string siteSlug;
+        try
+        {
+            using var helloCts = CancellationTokenSource.CreateLinkedTokenSource(linked.Token);
+            helloCts.CancelAfter(HelloTimeout);
+
+            await call.RequestStream.WriteAsync(new AgentMessage
+            {
+                Hello = new AgentHello { AgentKey = agentKey, Version = version, LanIp = lanIp ?? "" }
+            }, helloCts.Token);
+
+            if (!await call.ResponseStream.MoveNext(helloCts.Token) || call.ResponseStream.Current.Hello is not { } hello)
+                throw new IOException("Tunnel closed before server hello");
+
+            heartbeatInterval = TimeSpan.FromSeconds(Math.Max(5, hello.HeartbeatIntervalSeconds));
+            siteSlug = hello.SiteSlug;
+            _ackless = !hello.SupportsResultAck;
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            throw new IOException($"No server hello within {HelloTimeout.TotalSeconds:0}s of connecting; assuming dead link");
+        }
+
+        Console.WriteLine($"Tunnel open for site '{siteSlug}' (heartbeat every {heartbeatInterval.TotalSeconds:0}s)");
+
+        Volatile.Write(ref _lastInboundTicks, Environment.TickCount64);
         var pumpTask = PumpOutboundAsync(call.RequestStream, linked.Token);
         var heartbeatTask = HeartbeatLoopAsync(heartbeatInterval, linked.Token);
+        var watchdogTask = WatchInboundSilenceAsync(linked, linked.Token);
 
         try
         {
-            while (await call.ResponseStream.MoveNext(ct))
+            while (await call.ResponseStream.MoveNext(linked.Token))
             {
+                Volatile.Write(ref _lastInboundTicks, Environment.TickCount64);
                 var message = call.ResponseStream.Current;
                 switch (message.PayloadCase)
                 {
@@ -175,6 +245,9 @@ public sealed class TunnelClient
                         if (OnProbeRequest is { } probeHandler)
                             _ = probeHandler(message.ProbeRequest, linked.Token);
                         break;
+                    case ServerMessage.PayloadOneofCase.ResultAck:
+                        OnResultAck?.Invoke((long)message.ResultAck.Sequence);
+                        break;
                 }
             }
         }
@@ -182,7 +255,64 @@ public sealed class TunnelClient
         {
             linked.Cancel();
             _outbound.Writer.TryComplete();
-            try { await Task.WhenAll(pumpTask, heartbeatTask); } catch (OperationCanceledException) { }
+            try { await Task.WhenAll(pumpTask, heartbeatTask, watchdogTask); } catch (OperationCanceledException) { }
+        }
+    }
+
+    /// <summary>
+    /// Forces a reconnect when nothing has arrived from the server past the
+    /// silence timeout. Cancelling the connection's source aborts the read loop;
+    /// the buffer keeps every unacked frame, so the reconnect replays them and a
+    /// forced reconnect never loses data.
+    /// </summary>
+    private async Task WatchInboundSilenceAsync(CancellationTokenSource connectionCts, CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(15), ct);
+            var silentMs = Environment.TickCount64 - Volatile.Read(ref _lastInboundTicks);
+            if (silentMs <= InboundSilenceTimeoutMs) continue;
+            Console.Error.WriteLine(
+                $"Tunnel silent for {silentMs / 1000}s (server config refresh is 60s); assuming dead link, reconnecting - results keep buffering");
+            connectionCts.Cancel();
+            return;
+        }
+    }
+
+    /// <summary>
+    /// Feeds this connection from the store-and-forward buffer until the tunnel
+    /// tears down. Frames are only PEEKED - each stays in the buffer until the
+    /// server acks it (<see cref="OnResultAck"/>), so a teardown mid-flush loses
+    /// nothing: every unacked frame replays on the next connection. FIFO order is
+    /// preserved end to end (the server's interface rate calculator needs
+    /// per-interface samples in chronological order): a fresh connection replays
+    /// from sequence 0, i.e. the oldest unacked frame.
+    /// </summary>
+    public async Task DrainResultsAsync(ResultBuffer buffer, CancellationToken ct)
+    {
+        long sentThroughSeq = 0;
+        while (!ct.IsCancellationRequested)
+        {
+            var frame = await buffer.TakeUnsentBatchAsync(sentThroughSeq, CoalesceMaxSamples, ct);
+
+            // Leave headroom so heartbeats and proxied console traffic still get
+            // through while a large backlog flushes.
+            while (_outbound.Reader.Count > OutboundHeadroomSlots)
+                await Task.Delay(20, ct);
+
+            // Tag the frame so the server can ack it; the buffer keeps the
+            // originals until that ack lands, so a black-holed write is not a loss.
+            frame.Message.Sequence = (ulong)frame.ThroughSeq;
+            if (!await SendAsync(frame.Message, ct))
+                return; // tunnel torn down; the buffer still holds every unacked frame
+            sentThroughSeq = frame.ThroughSeq;
+
+            // Against a server that can't ack (older build), no ResultAck will
+            // ever arrive, so trim on send to avoid an ever-growing buffer that
+            // re-flushes on every reconnect. Cumulative, so it also clears any
+            // frames sent before the hello revealed the server was ack-less.
+            if (_ackless)
+                buffer.MarkAcked(frame.ThroughSeq);
         }
     }
 

--- a/src/NetworkOptimizer.AgentProtocol/Protos/agent_tunnel.proto
+++ b/src/NetworkOptimizer.AgentProtocol/Protos/agent_tunnel.proto
@@ -27,6 +27,14 @@ message AgentMessage {
     ProbeResponse probe_response = 10;
     SnmpOidResult snmp_oid_result = 11;
   }
+  // Monotonic per-agent sequence for store-and-forward acking. Set on
+  // probe_results / snmp_results frames only; 0 on control frames and on older
+  // agents. The agent keeps the batch buffered until the server echoes this
+  // number in a ResultAck (persisted), then trims it. Without this, a
+  // black-holed tunnel - where TCP still "accepts" writes into a dead socket and
+  // reports success - would let the buffer drain into the void and silently lose
+  // an outage's worth of data.
+  uint64 sequence = 12;
 }
 
 message ServerMessage {
@@ -42,7 +50,17 @@ message ServerMessage {
     ProbeRequest probe_request = 9;
     SnmpOidQuery snmp_oid_query = 10;
     WanSpeedTestConfig wan_speedtest_config = 11;
+    ResultAck result_ack = 12;
   }
+}
+
+// Cumulative acknowledgement of store-and-forward result frames. Sent by the
+// server after a probe_results / snmp_results batch is persisted; acking
+// sequence N confirms every frame with sequence <= N. The agent then trims
+// those from its buffer. An unacked frame stays buffered and replays on the
+// next connection, so nothing is lost when a tunnel black-holes.
+message ResultAck {
+  uint64 sequence = 1;
 }
 
 // ---- WAN speed test routing (agent /wan/ router) ----
@@ -120,6 +138,12 @@ message ServerHello {
   string site_slug = 1;
   string agent_name = 2;
   int32 heartbeat_interval_seconds = 3;
+  // True on servers that acknowledge result frames (>= the store-and-forward
+  // ack protocol). Absent/false (an older server) tells the agent NOT to wait
+  // for acks: it trims each frame on send, matching the pre-ack behavior, so a
+  // newer agent against an older server doesn't retain its whole buffer and
+  // re-flush it on every reconnect.
+  bool supports_result_ack = 4;
 }
 
 message AgentHeartbeat {

--- a/src/NetworkOptimizer.AgentProtocol/ResultBuffer.cs
+++ b/src/NetworkOptimizer.AgentProtocol/ResultBuffer.cs
@@ -1,0 +1,210 @@
+namespace NetworkOptimizer.AgentProtocol;
+
+/// <summary>
+/// Store-and-forward buffer between the agent's collectors (probe and SNMP
+/// runners) and the tunnel. Collectors always enqueue here - never directly
+/// into a connection - so monitoring continues through tunnel outages and the
+/// backlog replays in order once the tunnel reconnects.
+///
+/// A message stays in the buffer until the SERVER acknowledges it (see
+/// <see cref="MarkAcked"/>), NOT when it is written to the socket. TCP reports a
+/// write into a black-holed connection as success (the bytes sit in the kernel
+/// send buffer and are discarded on teardown), so dropping a message on send
+/// would silently lose an outage's worth of data the moment the link goes dead.
+/// The drain therefore only ever PEEKS unsent entries
+/// (<see cref="TakeUnsentBatchAsync"/>); an unacked frame is re-sent on the next
+/// connection.
+///
+/// Bounded by sample age and total serialized size; when either cap is exceeded
+/// the OLDEST messages are dropped, since the newest data is the most valuable
+/// when the link returns - this is the only way a message leaves the buffer
+/// without being acked. Thread-safe for any number of producers and consumers.
+/// </summary>
+public sealed class ResultBuffer
+{
+    /// <summary>Oldest data worth replaying after an outage.</summary>
+    public static readonly TimeSpan DefaultMaxAge = TimeSpan.FromHours(12);
+
+    /// <summary>
+    /// Cap on total serialized message bytes. Sized so ~12 h of a typical
+    /// agent site's probe + SNMP output fits with room to spare (see the
+    /// per-sample estimates in the tunnel drain); a much larger site trims to
+    /// proportionally fewer hours instead of growing without bound.
+    /// </summary>
+    public const long DefaultMaxBytes = 64 * 1024 * 1024;
+
+    /// <summary>One buffered message and the monotonic sequence assigned at enqueue.</summary>
+    private readonly record struct Entry(long Seq, AgentMessage Message, DateTime EnqueuedUtc, int SizeBytes);
+
+    /// <summary>A coalesced frame ready to send, tagged with the highest sequence it covers.</summary>
+    public sealed record SendFrame(AgentMessage Message, long ThroughSeq);
+
+    private readonly LinkedList<Entry> _entries = new();
+    private readonly SemaphoreSlim _available = new(0);
+    private readonly object _lock = new();
+    private readonly TimeSpan _maxAge;
+    private readonly long _maxBytes;
+    private long _bytes;
+    private long _nextSeq;
+    private long _dropped;
+    private long _droppedUnreported;
+
+    public ResultBuffer(TimeSpan? maxAge = null, long? maxBytes = null)
+    {
+        _maxAge = maxAge ?? DefaultMaxAge;
+        _maxBytes = maxBytes ?? DefaultMaxBytes;
+    }
+
+    /// <summary>Number of buffered (unacked) messages.</summary>
+    public int Count
+    {
+        get { lock (_lock) return _entries.Count; }
+    }
+
+    /// <summary>Total serialized size of the buffered messages.</summary>
+    public long ApproxBytes
+    {
+        get { lock (_lock) return _bytes; }
+    }
+
+    /// <summary>Messages dropped by the age/size caps since construction.</summary>
+    public long DroppedTotal
+    {
+        get { lock (_lock) return _dropped; }
+    }
+
+    /// <summary>
+    /// Messages dropped since the last call, for periodic logging. Resets the
+    /// unreported counter.
+    /// </summary>
+    public long TakeDroppedCount()
+    {
+        lock (_lock)
+        {
+            var count = _droppedUnreported;
+            _droppedUnreported = 0;
+            return count;
+        }
+    }
+
+    /// <summary>
+    /// Appends a message with the next sequence number, evicting the oldest
+    /// entries past the caps.
+    /// </summary>
+    public void Enqueue(AgentMessage message)
+    {
+        lock (_lock)
+        {
+            var entry = new Entry(++_nextSeq, message, DateTime.UtcNow, message.CalculateSize());
+            _entries.AddLast(entry);
+            _bytes += entry.SizeBytes;
+            EvictLocked();
+        }
+        _available.Release();
+    }
+
+    /// <summary>
+    /// Peeks the oldest run of entries whose sequence is greater than
+    /// <paramref name="afterSeq"/>, coalescing consecutive same-type batches up
+    /// to <paramref name="maxSamples"/>, and returns them as one frame tagged
+    /// with the highest sequence it covers. Entries are NOT removed - they stay
+    /// buffered until <see cref="MarkAcked"/>. Waits until such an entry exists;
+    /// throws <see cref="OperationCanceledException"/> on cancellation.
+    /// A caller re-sending after a reconnect passes afterSeq = 0 to replay every
+    /// unacked entry from the oldest.
+    /// </summary>
+    public async ValueTask<SendFrame> TakeUnsentBatchAsync(long afterSeq, int maxSamples, CancellationToken ct)
+    {
+        while (true)
+        {
+            lock (_lock)
+            {
+                var frame = BuildUnsentFrameLocked(afterSeq, maxSamples);
+                if (frame != null)
+                    return frame;
+            }
+            await _available.WaitAsync(ct);
+            // Evictions and coalescing consume entries without matching permits,
+            // so drain any surplus and re-check under the lock. The synchronous
+            // BuildUnsentFrameLocked above is the source of truth; the permit is
+            // only a wake-up, so an over- or under-count never loses a frame.
+            while (_available.Wait(0)) { }
+        }
+    }
+
+    /// <summary>
+    /// Removes every buffered entry whose sequence is at or below
+    /// <paramref name="throughSeq"/> - the server's cumulative acknowledgement
+    /// that those frames are persisted. Sequences are monotonic and entries are
+    /// ordered, so the acked run is always at the front.
+    /// </summary>
+    public void MarkAcked(long throughSeq)
+    {
+        lock (_lock)
+        {
+            while (_entries.First is { } first && first.Value.Seq <= throughSeq)
+            {
+                _bytes -= first.Value.SizeBytes;
+                _entries.RemoveFirst();
+            }
+        }
+    }
+
+    private SendFrame? BuildUnsentFrameLocked(long afterSeq, int maxSamples)
+    {
+        var node = _entries.First;
+        while (node != null && node.Value.Seq <= afterSeq)
+            node = node.Next;
+        if (node == null)
+            return null;
+
+        // Clone so the buffered originals stay intact for a possible re-send;
+        // coalescing must never mutate what is still awaiting an ack.
+        var merged = node.Value.Message.Clone();
+        var throughSeq = node.Value.Seq;
+        node = node.Next;
+
+        if (merged.PayloadCase == AgentMessage.PayloadOneofCase.ProbeResults)
+        {
+            while (node != null
+                   && node.Value.Message.PayloadCase == AgentMessage.PayloadOneofCase.ProbeResults
+                   && merged.ProbeResults.Results.Count < maxSamples)
+            {
+                merged.ProbeResults.Results.AddRange(node.Value.Message.ProbeResults.Results);
+                throughSeq = node.Value.Seq;
+                node = node.Next;
+            }
+        }
+        else if (merged.PayloadCase == AgentMessage.PayloadOneofCase.SnmpResults)
+        {
+            int Samples() => merged.SnmpResults.Interfaces.Count
+                             + merged.SnmpResults.Health.Count
+                             + merged.SnmpResults.CustomOids.Count;
+            while (node != null
+                   && node.Value.Message.PayloadCase == AgentMessage.PayloadOneofCase.SnmpResults
+                   && Samples() < maxSamples)
+            {
+                merged.SnmpResults.Interfaces.AddRange(node.Value.Message.SnmpResults.Interfaces);
+                merged.SnmpResults.Health.AddRange(node.Value.Message.SnmpResults.Health);
+                merged.SnmpResults.CustomOids.AddRange(node.Value.Message.SnmpResults.CustomOids);
+                throughSeq = node.Value.Seq;
+                node = node.Next;
+            }
+        }
+
+        return new SendFrame(merged, throughSeq);
+    }
+
+    private void EvictLocked()
+    {
+        var cutoff = DateTime.UtcNow - _maxAge;
+        while (_entries.Count > 0
+               && (_bytes > _maxBytes || _entries.First!.Value.EnqueuedUtc < cutoff))
+        {
+            _bytes -= _entries.First!.Value.SizeBytes;
+            _entries.RemoveFirst();
+            _dropped++;
+            _droppedUnreported++;
+        }
+    }
+}

--- a/src/NetworkOptimizer.Alerts/AlertProcessingService.cs
+++ b/src/NetworkOptimizer.Alerts/AlertProcessingService.cs
@@ -8,7 +8,6 @@ using NetworkOptimizer.Alerts.Delivery;
 using NetworkOptimizer.Alerts.Events;
 using NetworkOptimizer.Alerts.Interfaces;
 using NetworkOptimizer.Alerts.Models;
-using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Core.Helpers;
 
 namespace NetworkOptimizer.Alerts;
@@ -302,20 +301,19 @@ public class AlertProcessingService : BackgroundService
     /// <summary>
     /// Resolves a relative SourceUrl (e.g., "/audit") to an absolute URL using the app's
     /// configured hostname. Falls back to the relative path if no hostname is configured.
-    /// For an alert from a non-default site, appends ?site=&lt;slug&gt; so the "View" link
-    /// lands on that site (the selection middleware persists it to the session cookie).
+    /// Always appends ?site=&lt;slug&gt; - including for the default site - so the "View"
+    /// link pins its own browser tab to the alert's originating site instead of resolving
+    /// the recipient's browser-default site cookie, which may point at another site.
     /// </summary>
     private string? ResolveSourceUrl(string? relativeUrl, string? siteSlug)
     {
         if (string.IsNullOrEmpty(relativeUrl))
             return null;
 
-        var url = relativeUrl;
-        if (!string.IsNullOrEmpty(siteSlug))
-        {
-            var separator = url.Contains('?') ? '&' : '?';
-            url = $"{url}{separator}site={Uri.EscapeDataString(siteSlug)}";
-        }
+        // The default site arrives here as null/empty; its selectable slug is "main".
+        var slug = string.IsNullOrEmpty(siteSlug) ? "main" : siteSlug;
+        var separator = relativeUrl.Contains('?') ? '&' : '?';
+        var url = $"{relativeUrl}{separator}site={Uri.EscapeDataString(slug)}";
 
         if (_appBaseUrl != null)
             return $"{_appBaseUrl}{url}";

--- a/src/NetworkOptimizer.Core/Helpers/NetworkUtilities.cs
+++ b/src/NetworkOptimizer.Core/Helpers/NetworkUtilities.cs
@@ -322,30 +322,17 @@ public static class NetworkUtilities
 
         // IPv6 Unique Local Address (fc00::/7, primarily fd00::/8 in practice)
         if (ip.AddressFamily == AddressFamily.InterNetworkV6)
-        {
-            var v6Bytes = ip.GetAddressBytes();
-            if ((v6Bytes[0] & 0xFE) == 0xFC)
-                return true;
-            return false;
-        }
+            return IsIPv6UniqueLocal(ip);
 
         // Only do byte checks for IPv4
         if (ip.AddressFamily != AddressFamily.InterNetwork)
             return false;
 
+        // 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 (RFC1918)
+        if (IsRfc1918(ip))
+            return true;
+
         var bytes = ip.GetAddressBytes();
-
-        // 10.0.0.0/8 (RFC1918)
-        if (bytes[0] == 10)
-            return true;
-
-        // 172.16.0.0/12 (RFC1918)
-        if (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31)
-            return true;
-
-        // 192.168.0.0/16 (RFC1918)
-        if (bytes[0] == 192 && bytes[1] == 168)
-            return true;
 
         // 127.0.0.0/8 (Loopback)
         if (bytes[0] == 127)
@@ -368,6 +355,39 @@ public static class NetworkUtilities
             return true;
 
         return false;
+    }
+
+    /// <summary>
+    /// Check if an IP address is in one of the three RFC1918 private IPv4 blocks
+    /// (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16). Stricter than
+    /// <see cref="IsPrivateIpAddress(IPAddress)"/>: loopback, link-local, CGNAT, and
+    /// multicast are NOT RFC1918. IPv4-mapped IPv6 addresses are unwrapped first.
+    /// </summary>
+    /// <param name="ip">Parsed IP address to check</param>
+    /// <returns>True if the IP is in an RFC1918 block</returns>
+    public static bool IsRfc1918(IPAddress ip)
+    {
+        if (ip.IsIPv4MappedToIPv6)
+            ip = ip.MapToIPv4();
+        if (ip.AddressFamily != AddressFamily.InterNetwork)
+            return false;
+
+        var bytes = ip.GetAddressBytes();
+        return bytes[0] == 10
+            || (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31)
+            || (bytes[0] == 192 && bytes[1] == 168);
+    }
+
+    /// <summary>
+    /// Check if an IP address is an IPv6 unique local address (fc00::/7, in practice fd00::/8).
+    /// </summary>
+    /// <param name="ip">Parsed IP address to check</param>
+    /// <returns>True if the IP is an IPv6 ULA</returns>
+    public static bool IsIPv6UniqueLocal(IPAddress ip)
+    {
+        if (ip.AddressFamily != AddressFamily.InterNetworkV6)
+            return false;
+        return (ip.GetAddressBytes()[0] & 0xFE) == 0xFC;
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Core/Helpers/ProxyDialPolicy.cs
+++ b/src/NetworkOptimizer.Core/Helpers/ProxyDialPolicy.cs
@@ -1,0 +1,97 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace NetworkOptimizer.Core.Helpers;
+
+/// <summary>
+/// Address-scope policy for the on-site agent's tunnel TCP proxy: decides whether a
+/// proxy dial target is inside the allowed scope. The default policy admits only
+/// site-local addresses (RFC1918, IPv6 unique-local, IPv6 link-local) and is
+/// hardcoded so a compromised central server cannot widen it over the tunnel - the
+/// tunnel carries no message that reaches this policy. An operator can replace the
+/// default with an explicit CIDR/host list via agent.json ("proxyAllowedCidrs"),
+/// which is both the narrowing knob (pin to a management VLAN) and the only escape
+/// hatch for an exotic public-IP target.
+/// </summary>
+public sealed class ProxyDialPolicy
+{
+    private readonly IReadOnlyList<string>? _pinnedCidrs;
+
+    private ProxyDialPolicy(IReadOnlyList<string>? pinnedCidrs)
+    {
+        _pinnedCidrs = pinnedCidrs;
+    }
+
+    /// <summary>The built-in default: RFC1918, IPv6 unique-local, and IPv6 link-local only.</summary>
+    public static ProxyDialPolicy SiteLocal { get; } = new(null);
+
+    /// <summary>Whether this is the built-in site-local default (no operator pin).</summary>
+    public bool IsDefault => _pinnedCidrs == null;
+
+    /// <summary>Number of operator-pinned entries; 0 for the default policy.</summary>
+    public int PinnedCount => _pinnedCidrs?.Count ?? 0;
+
+    /// <summary>
+    /// Build an operator-pinned policy from CIDR entries (bare IPs are treated as
+    /// /32 or /128). The pin fully replaces the site-local default. Returns null
+    /// with an error message when any entry is invalid or the list is empty -
+    /// callers must fail loudly rather than run with a partial or ambiguous pin.
+    /// </summary>
+    public static ProxyDialPolicy? FromPinnedCidrs(IEnumerable<string?> entries, out string? error)
+    {
+        var normalized = new List<string>();
+        foreach (var raw in entries)
+        {
+            var entry = raw?.Trim();
+            if (string.IsNullOrEmpty(entry))
+                continue;
+
+            if (entry.Contains('/'))
+            {
+                var (network, prefixLength) = NetworkUtilities.ParseCidr(entry);
+                var maxPrefix = network?.AddressFamily == AddressFamily.InterNetworkV6 ? 128 : 32;
+                if (network == null || prefixLength < 0 || prefixLength > maxPrefix)
+                {
+                    error = $"invalid CIDR '{entry}'";
+                    return null;
+                }
+                normalized.Add(entry);
+            }
+            else if (IPAddress.TryParse(entry, out var ip))
+            {
+                normalized.Add(ip.AddressFamily == AddressFamily.InterNetworkV6 ? $"{entry}/128" : $"{entry}/32");
+            }
+            else
+            {
+                error = $"invalid entry '{entry}' (expected an IP or CIDR)";
+                return null;
+            }
+        }
+
+        if (normalized.Count == 0)
+        {
+            error = "the list is empty";
+            return null;
+        }
+
+        error = null;
+        return new ProxyDialPolicy(normalized);
+    }
+
+    /// <summary>
+    /// Whether the policy allows dialing the given address. IPv4-mapped IPv6
+    /// addresses are unwrapped before evaluation so a public IPv4 target cannot
+    /// slip through as ::ffff:a.b.c.d.
+    /// </summary>
+    public bool IsAllowed(IPAddress address)
+    {
+        var ip = address.IsIPv4MappedToIPv6 ? address.MapToIPv4() : address;
+
+        if (_pinnedCidrs != null)
+            return _pinnedCidrs.Any(cidr => NetworkUtilities.IsIpInSubnet(ip, cidr));
+
+        return NetworkUtilities.IsRfc1918(ip)
+            || NetworkUtilities.IsIPv6UniqueLocal(ip)
+            || ip.IsIPv6LinkLocal;
+    }
+}

--- a/src/NetworkOptimizer.Storage/Migrations/20260712152329_AddLanFlakyHintDismissedAt.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260712152329_AddLanFlakyHintDismissedAt.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260712152329_AddLanFlakyHintDismissedAt")]
+    partial class AddLanFlakyHintDismissedAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260712152329_AddLanFlakyHintDismissedAt.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260712152329_AddLanFlakyHintDismissedAt.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLanFlakyHintDismissedAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LanFlakyHintDismissedAt",
+                table: "MonitoringTargets",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LanFlakyHintDismissedAt",
+                table: "MonitoringTargets");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/MonitoringTarget.cs
+++ b/src/NetworkOptimizer.Storage/Models/MonitoringTarget.cs
@@ -109,6 +109,14 @@ public class MonitoringTarget
     [MaxLength(200)]
     public string? AutoLabel { get; set; }
 
+    /// <summary>
+    /// When the user dismissed the "flaky LAN target" advisory for this target (the hint shown
+    /// on the LAN latency chart for non-gateway/non-AP fabric devices whose loss is usually a
+    /// measurement artifact). Null = never dismissed, so the hint may still show. Set once and
+    /// left; it only suppresses an advisory, so there's no un-dismiss path.
+    /// </summary>
+    public DateTime? LanFlakyHintDismissedAt { get; set; }
+
     public DateTime? LastVerified { get; set; }
 
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/src/NetworkOptimizer.Storage/Repositories/UniFiRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/UniFiRepository.cs
@@ -199,6 +199,12 @@ public class UniFiRepository : IUniFiRepository
     {
         try
         {
+            // Key auth wins: a configured key path drops the password (matching the
+            // gateway/UniFi SSH settings pages), so a broken key fails loudly instead
+            // of silently falling back to a stale stored password.
+            if (!string.IsNullOrEmpty(config.SshPrivateKeyPath))
+                config.SshPassword = null;
+
             if (config.Id > 0)
             {
                 var existing = await _context.DeviceSshConfigurations
@@ -214,7 +220,12 @@ public class UniFiRepository : IUniFiRepository
                     existing.Iperf3ParallelStreams = config.Iperf3ParallelStreams;
                     existing.Iperf3DurationSeconds = config.Iperf3DurationSeconds;
                     existing.SshUsername = config.SshUsername;
-                    existing.SshPassword = config.SshPassword;
+                    // Blank means keep: the edit form never round-trips the stored encrypted
+                    // password and only sets this field when the user typed a new one.
+                    if (!string.IsNullOrEmpty(config.SshPassword))
+                        existing.SshPassword = config.SshPassword;
+                    else if (!string.IsNullOrEmpty(config.SshPrivateKeyPath))
+                        existing.SshPassword = null;
                     existing.SshPrivateKeyPath = config.SshPrivateKeyPath;
                     existing.UpdatedAt = DateTime.UtcNow;
                 }

--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -87,13 +87,25 @@ public class UniFiApiClient : IDisposable
         _site = site;
         _ignoreSSLErrors = ignoreSSLErrors;
 
-        // Configure retry policy for transient failures
+        // Configure retry policy for transient failures. A console reached through
+        // an agent tunnel is dialed via a loopback proxy (127.0.0.1); when that
+        // tunnel is black-holed the proxy fast-fails the open, but this retry sits
+        // ABOVE the proxy and would otherwise stack the full 2+4+8s (~14s)
+        // exponential backoff onto every request - which reads as a frozen site
+        // switch on that site for the whole ~90s before the watchdog flips the
+        // console to awaiting-agent. Retrying a dead tunnel can't help, so
+        // agent-proxied consoles get a single quick retry. Directly-connected
+        // consoles keep the full backoff - a real transient blip there is worth
+        // riding out.
+        var viaAgentProxy = _controllerUrl.Contains("127.0.0.1");
         _retryPolicy = Policy
             .Handle<HttpRequestException>()
             .Or<TaskCanceledException>()
             .WaitAndRetryAsync(
-                retryCount: 3,
-                sleepDurationProvider: retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
+                retryCount: viaAgentProxy ? 1 : 3,
+                sleepDurationProvider: retryAttempt => viaAgentProxy
+                    ? TimeSpan.FromMilliseconds(500)
+                    : TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
                 onRetry: (exception, timespan, retryCount, context) =>
                 {
                     _logger.LogWarning("Retry {RetryCount} after {Timespan}s due to {Exception}",

--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -442,6 +442,64 @@
             });
             reconnectObserver.observe(reconnectModal, { attributes: true });
         }
+
+        // PWA / mobile resume recovery. When the app is backgrounded, iOS and
+        // Android suspend the tab and its Blazor WebSocket can die, but on resume
+        // Blazor often does NOT surface the reconnect modal (the socket still
+        // looks open to it), so the page sits on its stale prerender with frozen
+        // loading spinners until a manual refresh. Rather than reload on a blind
+        // timer - which threw away scroll position and in-page state even when
+        // the circuit had actually survived the backgrounding - PROBE the circuit
+        // on resume and only reload when it's genuinely dead. A live circuit
+        // answers the round-trip in a few ms; a dead-but-open socket never
+        // replies, so the timeout tells us a reload is really needed. The
+        // reconnect-modal observer above covers the case where Blazor detects the
+        // drop itself, so defer to it when it's showing.
+        (function () {
+            const STALE_HIDDEN_MS = 30000;
+            const PROBE_TIMEOUT_MS = 2500;
+            let hiddenAt = null;
+
+            function blazorHandlingDrop() {
+                const m = document.getElementById('components-reconnect-modal');
+                return !!m && (
+                    m.classList.contains('components-reconnect-show') ||
+                    m.classList.contains('components-reconnect-failed') ||
+                    m.classList.contains('components-reconnect-rejected'));
+            }
+
+            async function circuitAlive() {
+                if (!window.DotNet) return false;
+                try {
+                    await Promise.race([
+                        DotNet.invokeMethodAsync('NetworkOptimizer.Web', 'Ping'),
+                        new Promise((_, reject) =>
+                            setTimeout(() => reject(new Error('probe timeout')), PROBE_TIMEOUT_MS))
+                    ]);
+                    return true;
+                } catch {
+                    return false;
+                }
+            }
+
+            document.addEventListener('visibilitychange', async function () {
+                if (document.visibilityState === 'hidden') {
+                    hiddenAt = Date.now();
+                    return;
+                }
+                if (hiddenAt === null) return;
+                const hiddenMs = Date.now() - hiddenAt;
+                hiddenAt = null;
+                if (hiddenMs < STALE_HIDDEN_MS || blazorHandlingDrop()) return;
+
+                // Only reload when the circuit is genuinely dead; otherwise pick
+                // up exactly where we left off. Re-check the modal after the probe
+                // in case Blazor surfaced its own reconnect UI meanwhile.
+                if (!(await circuitAlive()) && !blazorHandlingDrop()) {
+                    location.reload();
+                }
+            });
+        })();
     </script>
 </body>
 

--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -98,6 +98,8 @@
         </div>
     </div>
 
+    <script>window.__noSiteDefault = "@(NetworkOptimizer.Web.Services.SiteManagementService.DefaultSiteSlug)";</script>
+    <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/site-context.js")"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/chart-defaults.js")"></script>
     <script src="_framework/blazor.web.js"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/scrollRestoration.js")"></script>

--- a/src/NetworkOptimizer.Web/CircuitLiveness.cs
+++ b/src/NetworkOptimizer.Web/CircuitLiveness.cs
@@ -1,0 +1,19 @@
+using Microsoft.JSInterop;
+
+namespace NetworkOptimizer.Web;
+
+/// <summary>
+/// A trivial round-trip the client can invoke to tell a live Blazor circuit
+/// from a dead-but-open socket. On PWA/mobile resume the WebSocket can be dead
+/// while still looking open to the client, so the resume handler in App.razor
+/// calls <see cref="Ping"/> with a short timeout: a fast reply means the
+/// circuit is fine (pick up seamlessly), and a timeout means it genuinely needs
+/// a reload. This replaces a blind time-based reload that fired even when the
+/// circuit had survived the backgrounding.
+/// </summary>
+public static class CircuitLiveness
+{
+    /// <summary>Returns immediately over the circuit; the value is unused - only that it round-trips.</summary>
+    [JSInvokable]
+    public static bool Ping() => true;
+}

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -354,6 +354,26 @@
     private bool sidebarOpen = false;
     private DotNetObjectReference<MainLayout>? _dotNetRef;
 
+    protected override void OnInitialized()
+    {
+        // Keep the header's Console Connected/Disconnected indicator live. On
+        // agent-proxied sites the console connects asynchronously after first paint
+        // (once the agent tunnel is up); without this subscription the header stays
+        // "Console Disconnected" until the next navigation.
+        ConnectionService.OnConnectionChanged += OnConnectionChanged;
+    }
+
+    private async void OnConnectionChanged()
+    {
+        // Fires from a background thread (console (re)connect); marshal to the
+        // dispatcher and swallow exceptions so this async void can't crash the circuit.
+        try
+        {
+            await InvokeAsync(StateHasChanged);
+        }
+        catch { /* component may be disposed */ }
+    }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)

--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -232,6 +232,16 @@
             setTimeout(function() { window.scrollBy(0, 1); window.scrollBy(0, -1); }, 100);
         });
 
+        // iOS can restore from background with the window scrolled off (0,0); the body
+        // then swallows touch gestures and .main-content can't scroll until a tap resets it
+        function unstickViewport() {
+            if (window.scrollX || window.scrollY) window.scrollTo(0, 0);
+        }
+        window.addEventListener('pageshow', unstickViewport);
+        document.addEventListener('visibilitychange', function() {
+            if (!document.hidden) setTimeout(unstickViewport, 50);
+        });
+
         // Show nav bar when content shrinks below scrollable (e.g. tab switch to short content)
         var pageContent = document.querySelector('.page-content');
         if (window.innerWidth <= 1024 && pageContent) {

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -15,6 +15,7 @@
 @inject UniFiConnectionService ConnectionService
 @inject IConfiguration Configuration
 @inject SiteContextService SiteContext
+@inject SiteSwitchService SiteSwitch
 @inject SiteSpeedTestTargetResolver SiteTarget
 @inject NavigationManager NavigationManager
 @inject IJSRuntime JS
@@ -93,7 +94,7 @@
                     <strong>Device Offline</strong>
                     <span>This device is currently offline. Showing historical data. Live data will appear when it reconnects.</span>
                 </div>
-                <button class="btn btn-primary btn-sm" @onclick="() => NavigationManager.NavigateTo(NavigationManager.Uri, forceLoad: true)">Retry</button>
+                <button class="btn btn-primary btn-sm" @onclick="ReloadPageAsync">Retry</button>
             </div>
         </div>
     }
@@ -143,7 +144,7 @@
         <div class="card empty-state">
             <h3>Device Not Found</h3>
             <p>Could not identify your device on the network. Make sure you're connected and the UniFi Console is reachable.</p>
-            <button class="btn btn-primary" @onclick="() => NavigationManager.NavigateTo(NavigationManager.Uri, forceLoad: true)">Retry</button>
+            <button class="btn btn-primary" @onclick="ReloadPageAsync">Retry</button>
         </div>
     }
     else
@@ -1217,8 +1218,17 @@
         }
         catch { /* remembering is best-effort */ }
         Logger.LogDebug("Client identity (site {Site}): device picked manually ({Ip})", SiteContext.Slug, _pickerSelection);
-        NavigationManager.NavigateTo($"/client-dashboard?ip={Uri.EscapeDataString(_pickerSelection)}", forceLoad: true);
+        NavigationManager.NavigateTo(
+            await SiteSwitch.StampSiteAsync($"/client-dashboard?ip={Uri.EscapeDataString(_pickerSelection)}"),
+            forceLoad: true);
     }
+
+    /// <summary>
+    /// Full-page retry. The reload target is stamped with this tab's site so a tab
+    /// pinned to a non-default site doesn't fall back to the browser default.
+    /// </summary>
+    private async Task ReloadPageAsync() =>
+        NavigationManager.NavigateTo(await SiteSwitch.StampSiteAsync(NavigationManager.Uri), forceLoad: true);
 
     /// <summary>
     /// Lightweight 1s poll: only hits WiFiman for live signal/channel/band/rates.

--- a/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
@@ -14,6 +14,8 @@
 @inject NavigationManager NavigationManager
 @inject PullToRefreshState PtrState
 @inject IJSRuntime JS
+@inject SiteManagementService SiteManagement
+@inject SiteContextService SiteContext
 @implements IDisposable
 @rendermode InteractiveServer
 
@@ -21,7 +23,15 @@
 <NavigationLock OnBeforeInternalNavigation="OnBeforeInternalNavigation" ConfirmExternalNavigation="_editMode" />
 
 <div class="page-header">
-    <h1>Dashboard</h1>
+    @* Site name next to the header (muted) when multi-site is enabled, including the
+       main site, so each per-site tab is identifiable at a glance. *@
+    <h1>
+        Dashboard
+        @if (!string.IsNullOrEmpty(_siteName))
+        {
+            <span class="page-header-suffix">@_siteName</span>
+        }
+    </h1>
     <div class="page-header-actions">
         @if (_editMode)
         {
@@ -207,6 +217,7 @@
 </div>
 
 @code {
+    private string _siteName = "";
     private bool _loading = true;
     private bool _speedTestLoading = true;
     private bool _wanTestLoading = true;
@@ -243,6 +254,14 @@
         PtrState.RefreshCallback = () => Task.WhenAll(
             LoadDashboardData(), LoadSpeedTestData(), LoadWanTestData(), LoadThreatData());
         PtrState.NotifyStateChanged = StateHasChanged;
+
+        // Show the current site's name next to the header when multi-site is enabled
+        // (including the main site) so each per-site tab is identifiable.
+        if (await SiteManagement.IsMultiSiteEnabledAsync())
+        {
+            var sites = await SiteManagement.GetSitesAsync();
+            _siteName = sites.FirstOrDefault(s => s.Slug == SiteContext.Slug)?.Name ?? "";
+        }
 
         _layout = await LayoutService.GetLayoutAsync();
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Login.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Login.razor
@@ -5,6 +5,7 @@
 @inject NavigationManager Navigation
 @inject IAdminAuthService AdminAuth
 @inject IJwtService JwtService
+@inject SiteSwitchService SiteSwitch
 
 <PageTitle>Login - Network Optimizer</PageTitle>
 
@@ -104,12 +105,15 @@
                 isRedirecting = true;
                 StateHasChanged();
 
-                // Set cookie and redirect to home
+                // Set cookie and redirect to home, keeping the tab's ?site= pin (the
+                // auth middleware carries it onto /login) so re-auth lands on the
+                // same site the tab was on.
                 // Note: forceLoad navigation will throw TaskCanceledException as the circuit
                 // is destroyed during the page reload - this is expected behavior
+                var returnUrl = await SiteSwitch.StampSiteAsync("/");
                 try
                 {
-                    Navigation.NavigateTo($"/api/auth/set-cookie?token={Uri.EscapeDataString(token)}&returnUrl=/", forceLoad: true);
+                    Navigation.NavigateTo($"/api/auth/set-cookie?token={Uri.EscapeDataString(token)}&returnUrl={Uri.EscapeDataString(returnUrl)}", forceLoad: true);
                 }
                 catch (TaskCanceledException)
                 {

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -3184,7 +3184,7 @@ else
                     "  window.__monitoringRef = ref;" +
                     $"  const m = await import('{VersionedJs("/js/lan-flow-map.js")}');" +
                     "  window.__lanFlowMap = m;" +
-                    "  await m.mount(canvasId);" +
+                    $"  await m.mount(canvasId, {{ storagePrefix: '{SiteCtx.ScopeStorageKey("lanFlowMap")}' }});" +
                     "}");
                 await JS.InvokeVoidAsync("__mountLanFlowMap", "lan-flow-map-canvas", _mapDotNetRef);
             }
@@ -3206,7 +3206,7 @@ else
             try
             {
                 await JS.InvokeVoidAsync("eval",
-                    $"(async () => {{ const m = await import('{VersionedJs("/js/lan-flow-map-2d.js")}'); window.__lanFlowMap2d = m; await m.mount('lan-flow-map-2d-stage'); }})();");
+                    $"(async () => {{ const m = await import('{VersionedJs("/js/lan-flow-map-2d.js")}'); window.__lanFlowMap2d = m; await m.mount('lan-flow-map-2d-stage', {{ storagePrefix: '{SiteCtx.ScopeStorageKey("lanFlowMap2d")}' }}); }})();");
             }
             catch (Exception ex) { _map2dMounted = false; Logger.LogDebug(ex, "2D map mount failed; will retry on next render"); }
         }

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -453,6 +453,42 @@ else
             </div>
         </div>
 
+        @* Flaky LAN target advisory: shown under the LAN chart when a non-gateway/non-AP fabric
+           target has elevated loss (issue #971). LAN-side sibling of the WAN FlakyTargetsCard. *@
+        @if (LanFlakyHintTargets.Count > 0)
+        {
+            <div class="card lan-flaky-hint">
+                <div class="card-body">
+                    <p class="section-description">
+                        <span class="lan-flaky-warn">&#9888;</span>
+                        These LAN devices are showing packet loss that's usually a measurement artifact -
+                        Wi-Fi roaming or the device deprioritizing pings - rather than a real network problem.
+                        If one isn't useful to monitor, pause it in Latency Targets to keep it out of your charts.
+                    </p>
+                    <ul class="lan-flaky-list">
+                        @foreach (var t in LanFlakyHintTargets)
+                        {
+                            <li>
+                                <span class="host-truncate">@t.Name</span>
+                                <span class="lan-flaky-actions">
+                                    <button class="btn btn-sm btn-secondary" @onclick="() => JumpToLatencyTargetAsync(t.Id)">Review in Latency Targets</button>
+                                    <button class="btn btn-sm btn-secondary" @onclick="() => DismissLanFlakyHintAsync(t)">Dismiss</button>
+                                </span>
+                            </li>
+                        }
+                    </ul>
+                </div>
+            </div>
+            <style>
+                .lan-flaky-hint { border-left: 3px solid var(--warning-color); margin-top: 1rem; }
+                .lan-flaky-warn { color: var(--warning-color); margin-right: 0.4rem; }
+                .lan-flaky-list { list-style: none; margin: 0.5rem 0 0; padding: 0; display: flex; flex-direction: column; gap: 0.5rem; }
+                .lan-flaky-list li { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; flex-wrap: wrap; }
+                .lan-flaky-list .host-truncate { font-size: 0.9rem; }
+                .lan-flaky-actions { display: flex; align-items: center; gap: 0.5rem; flex-shrink: 0; }
+            </style>
+        }
+
         <!-- Upstream tracer wizard -->
         <div id="upstream-discovery" style="margin-top: 1.5rem;">
             <UpstreamTracerPanel ForceExpand="_forceExpandUpstream" OnSaved="StateHasChanged" />
@@ -463,7 +499,7 @@ else
         </div>
 
         <div style="margin-top: 1.5rem;">
-            <LatencyTargetsCard Targets="_targets" WanContexts="_wanContexts" OnTargetsChanged="OnTargetsChanged" />
+            <LatencyTargetsCard @ref="_latencyTargetsCard" Targets="_targets" WanContexts="_wanContexts" OnTargetsChanged="OnTargetsChanged" />
         </div>
 
         @* Multi-WAN contexts management card hidden for now (GA). Re-enable by
@@ -1421,6 +1457,16 @@ else
     private bool _cmChartsMounted;
     private bool _ontChartsMounted;
 
+    // "Flaky LAN target" advisory shown under the LAN latency chart. The chart JS reports which
+    // Fabric targets have elevated loss over the visible window (via _latencyDotNetRef ->
+    // SetLanFlakyHints); the role/dismissed gating and the notice itself render here where the
+    // target metadata lives. _latencyTargetsCard is the @ref used to expand+scroll the matching
+    // Latency Targets row.
+    private DotNetObjectReference<Monitoring>? _latencyDotNetRef;
+    private LatencyTargetsCard? _latencyTargetsCard;
+    private bool _lanFlakyCategoryActive;
+    private List<string> _lanFlakyTargetIds = new();
+
     // Investigation state
     private bool _investigatingLoss;
     private bool _investigatingSfp;
@@ -2308,6 +2354,65 @@ else
         }
     }
 
+    // Called by latency-charts.js after each render with the LAN (Fabric) targets whose loss over
+    // the visible window is elevated. We store the ids only; the notice applies the role gate and
+    // per-target dismissal against _targets. A no-change guard avoids re-rendering on every poll.
+    [JSInvokable]
+    public void SetLanFlakyHints(string category, string[] flakyTargetIds)
+    {
+        var active = category == "Fabric";
+        var ids = flakyTargetIds?.ToList() ?? new List<string>();
+        if (active == _lanFlakyCategoryActive && ids.SequenceEqual(_lanFlakyTargetIds)) return;
+        _lanFlakyCategoryActive = active;
+        _lanFlakyTargetIds = ids;
+        InvokeAsync(StateHasChanged);
+    }
+
+    // Fabric targets the chart flagged as flaky, minus gateways/APs (real infra loss is worth
+    // investigating, not hiding) and minus targets whose hint the user already dismissed.
+    private IReadOnlyList<MonitoringTarget> LanFlakyHintTargets =>
+        !_lanFlakyCategoryActive
+            ? Array.Empty<MonitoringTarget>()
+            : _targets.Where(t => t.TargetType == MonitoringTargetType.Fabric
+                    && t.Enabled
+                    && t.LanFlakyHintDismissedAt == null
+                    && _lanFlakyTargetIds.Contains(t.TargetId)
+                    && !IsGatewayOrAp(t.AutoLabel))
+                .OrderBy(t => t.Name)
+                .ToList();
+
+    // AutoLabel is set at fabric-target discovery to "gateway" / "switch" / "ap" / "unknown"
+    // (MonitoringCollectionAgent.DescribeDeviceType). Only gateways and APs are suppressed - a
+    // switch-capability device such as a smart power strip still gets the hint.
+    private static bool IsGatewayOrAp(string? autoLabel) =>
+        autoLabel is "gateway" or "ap";
+
+    private async Task JumpToLatencyTargetAsync(int targetId)
+    {
+        if (_latencyTargetsCard != null)
+            await _latencyTargetsCard.ExpandAndHighlightAsync(targetId);
+    }
+
+    private async Task DismissLanFlakyHintAsync(MonitoringTarget target)
+    {
+        try
+        {
+            await using var db = SiteDb.CreateForSite(SiteCtx.Slug, SiteCtx.IsDefault);
+            var row = await db.MonitoringTargets.FindAsync(target.Id);
+            if (row != null)
+            {
+                row.LanFlakyHintDismissedAt = DateTime.UtcNow;
+                await db.SaveChangesAsync();
+            }
+        }
+        catch { }
+        // _targets is loaded AsNoTracking, so reflect the dismissal in memory to drop the row
+        // from the advisory immediately without waiting for a reload.
+        var local = _targets.FirstOrDefault(t => t.Id == target.Id);
+        if (local != null) local.LanFlakyHintDismissedAt = DateTime.UtcNow;
+        StateHasChanged();
+    }
+
     [JSInvokable]
     public async Task OnMapTimeChanged(string? isoTimestamp)
     {
@@ -3160,6 +3265,16 @@ else
             try
             {
                 var chartsUrl = VersionedJs("/js/latency-charts.js");
+                // Hand the chart module our DotNet ref (for the flaky-LAN-target callback) via a
+                // window slot before it mounts. Best-effort: the JS callback no-ops if it's absent,
+                // so a failure here never affects chart rendering.
+                _latencyDotNetRef ??= DotNetObjectReference.Create(this);
+                try
+                {
+                    await JS.InvokeVoidAsync("eval", "window.__netoptSetLatencyRef ||= function(r){ window.__netoptLatencyRef = r; };");
+                    await JS.InvokeVoidAsync("__netoptSetLatencyRef", _latencyDotNetRef);
+                }
+                catch { }
                 var postMount = "";
                 if (!string.IsNullOrEmpty(_preSelectCategory))
                 {
@@ -3179,6 +3294,9 @@ else
             _latencyChartsMounted = false;
             try { await JS.InvokeVoidAsync("eval", "window.__latencyCharts?.unmount();"); }
             catch { }
+            // The flaky-LAN advisory is tied to the live chart, so clear it when the chart leaves.
+            _lanFlakyCategoryActive = false;
+            _lanFlakyTargetIds = new();
             // The chart (and its highlight) is torn down on leave, so drop the loss-nav state
             // too - otherwise returning shows the card "active" with no highlight on the chart.
             // Deep-linked investigations re-arm via the query param on entry, so this is safe.
@@ -3337,6 +3455,7 @@ else
         _testFeedbackTimer?.Dispose();
         _sfpChartDebounce?.Dispose();
         _mapDotNetRef?.Dispose();
+        _latencyDotNetRef?.Dispose();
         if (_latencyChartsMounted)
         {
             try { _ = JS.InvokeVoidAsync("eval", "window.__latencyCharts?.unmount();").AsTask(); }

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -188,11 +188,22 @@
             </div>
 
             <div class="form-group">
-                <label class="checkbox-label">
-                    <input type="checkbox" @bind="ignoreControllerSSLErrors" />
-                    <span>Ignore SSL certificate errors</span>
-                </label>
-                <small class="form-help">Enable this for UniFi Consoles with self-signed certificates (default)</small>
+                @if (_currentSiteConsoleViaAgent)
+                {
+                    <label class="checkbox-label">
+                        <input type="checkbox" checked disabled />
+                        <span>Ignore SSL certificate errors</span>
+                    </label>
+                    <small class="form-help">Certificate validation isn't supported when connecting through the site's agent.</small>
+                }
+                else
+                {
+                    <label class="checkbox-label">
+                        <input type="checkbox" @bind="ignoreControllerSSLErrors" />
+                        <span>Ignore SSL certificate errors</span>
+                    </label>
+                    <small class="form-help">Enable this for UniFi Consoles with self-signed certificates (default)</small>
+                }
             </div>
 
             <div class="action-buttons">

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -33,6 +33,7 @@
 @inject IHttpClientFactory HttpClientFactory
 @inject NavigationManager NavigationManager
 @inject SiteManagementService SiteManagement
+@inject SiteSwitchService SiteSwitch
 @inject AgentEnrollmentService AgentEnrollment
 @inject AgentServerUrlProvider AgentServerUrl
 @inject AgentTunnelRegistry TunnelRegistry
@@ -2279,7 +2280,11 @@
     <!-- Threat Intelligence Configuration -->
     <div class="card settings-tab-security" id="threat-intelligence">
         <div class="card-header">
-            <h2 class="card-title">@(_multiSiteEnabled && SiteContext.IsDefault ? "Global Threat Intelligence" : "Threat Intelligence")</h2>
+            <h2 class="card-title">Threat Intelligence</h2>
+            @if (_multiSiteEnabled && SiteContext.IsDefault)
+            {
+                <span class="status-badge global-badge" data-tooltip="Applies to all sites (instance-wide)">Global</span>
+            }
         </div>
         <div class="card-body">
             <p class="section-description">
@@ -3292,22 +3297,14 @@
     }
 
     /// <summary>
-    /// Switch the active site to the given one. Site context is cookie-based, so a
-    /// full reload is required for every scoped service to resolve against the new
-    /// site's database (same mechanism as the header site switcher).
+    /// Switch the active site to the given one (same mechanism as the header site
+    /// switcher): make it the browser default and reload this tab pinned to it.
     /// </summary>
     private async Task SwitchToSiteAsync(Site site)
     {
         if (site.Slug == SiteContext.Slug)
             return;
-        await JS.InvokeVoidAsync("eval",
-            $"document.cookie = '{SiteContextService.CookieName}={site.Slug}; path=/; max-age=31536000; SameSite=Lax'");
-        // Drop any #fragment first: reloading the *same* URL with its fragment is a
-        // same-document navigation the browser won't actually reload, so the new site
-        // cookie would never take effect. The fragment is meaningless on another site anyway.
-        var target = NavigationManager.Uri;
-        var fragmentAt = target.IndexOf('#');
-        NavigationManager.NavigateTo(fragmentAt >= 0 ? target[..fragmentAt] : target, forceLoad: true);
+        await SiteSwitch.SwitchToAsync(site.Slug);
     }
 
     private async Task SiteNameEditKey(KeyboardEventArgs e, Site site)

--- a/src/NetworkOptimizer.Web/Components/Pages/Sites.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sites.razor
@@ -13,7 +13,6 @@
 @inject NetworkOptimizer.Storage.Services.SiteDbContextFactory SiteDb
 @inject NetworkOptimizer.Web.Services.Licensing.LicenseStateService LicenseState
 @inject NavigationManager NavigationManager
-@inject IJSRuntime JS
 
 <PageTitle>Sites - Network Optimizer</PageTitle>
 
@@ -53,7 +52,12 @@ else
         @foreach (var site in _sites)
         {
             var isCurrent = site.Slug == SiteContext.Slug;
-            <div class="card site-card @(isCurrent ? "site-card-current" : "")" @onclick="() => SwitchToAsync(site)">
+            @* Real anchor so ctrl / cmd / shift / middle click opens the site in a new
+               tab; site-context.js turns a plain left click into the switch. *@
+            <a class="card site-card @(isCurrent ? "site-card-current" : "")"
+               href="@SiteHref(site)"
+               data-site-switch="@site.Slug"
+               data-site-current="@(isCurrent ? "" : null)">
                 <div class="site-card-header">
                     <span class="status-dot @(SiteConnections.GetFor(site.Slug).IsConnected ? "online" : "offline")" data-tooltip="@(SiteConnections.GetFor(site.Slug).IsConnected ? "Console connected" : "Console not connected")"></span>
                     <h3 class="site-card-name">@site.Name</h3>
@@ -64,7 +68,7 @@ else
                 </div>
                 @if (ConsoleHost(site.Id) is { Length: > 0 } host)
                 {
-                    <div class="site-card-console" data-tooltip="UniFi Console this site connects to">@host</div>
+                    <div class="site-card-console">@host</div>
                 }
                 <div class="site-card-meta">
                     <span class="site-card-slug">@site.Slug</span>
@@ -87,7 +91,7 @@ else
                         <span class="site-card-agents">@OnlineAgentCount(site.Id)/@AgentCount(site.Id) agents online</span>
                     }
                 </div>
-            </div>
+            </a>
         }
 
         <div class="card site-card site-card-add" @onclick="@(() => NavigationManager.NavigateTo("/settings?tab=multisite"))">
@@ -207,15 +211,8 @@ else
             ? Math.Max(0, (int)Math.Ceiling((deadline - DateTime.UtcNow).TotalDays))
             : 0;
 
-    private async Task SwitchToAsync(Site site)
-    {
-        if (site.Slug == SiteContext.Slug)
-            return;
-
-        // Site context is cookie-based; a full reload re-resolves every scoped
-        // service against the selected site's database.
-        await JS.InvokeVoidAsync("eval",
-            $"document.cookie = '{SiteContextService.CookieName}={site.Slug}; path=/; max-age=31536000; SameSite=Lax'");
-        NavigationManager.NavigateTo("/", forceLoad: true);
-    }
+    /// <summary>The new site's dashboard, pinned - the card's anchor href. A plain click
+    /// switches here (via site-context.js); ctrl / cmd / shift / middle opens a new tab.</summary>
+    private static string SiteHref(Site site) =>
+        SiteContextService.WithSiteParam("/", site.Slug);
 }

--- a/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
@@ -637,12 +637,12 @@
 
                         <div class="form-group">
                             <label class="form-label">SSH Username</label>
-                            <input type="text" class="form-control" @bind="editingDevice.SshUsername" placeholder="(using global setting)" />
+                            <input type="text" class="form-control" autocomplete="off" @bind="editingDevice.SshUsername" placeholder="(using global setting)" />
                         </div>
 
                         <div class="form-group">
                             <label class="form-label">SSH Password</label>
-                            <input type="password" class="form-control" @bind="editingDevicePassword" placeholder="@(!string.IsNullOrWhiteSpace(editingDevice.SshPrivateKeyPath) ? "(using SSH key)" : editingDeviceHasSavedPassword ? "Saved – enter new to update" : "(using global setting)")" />
+                            <input type="password" class="form-control" autocomplete="new-password" data-1p-ignore data-lpignore="true" data-bwignore @bind="editingDevicePassword" placeholder="@(!string.IsNullOrWhiteSpace(editingDevice.SshPrivateKeyPath) ? "(using SSH key)" : editingDeviceHasSavedPassword ? "Saved – enter new to update" : "(using global setting)")" />
                             <span class="form-help">Password is encrypted at rest</span>
                         </div>
 

--- a/src/NetworkOptimizer.Web/Components/Routes.razor
+++ b/src/NetworkOptimizer.Web/Components/Routes.razor
@@ -1,4 +1,6 @@
 @rendermode InteractiveServer
+@inject NavigationManager Navigation
+@inject SiteContextService SiteContext
 
 <Router AppAssembly="typeof(Program).Assembly">
     <Found Context="routeData">
@@ -6,3 +8,15 @@
         <FocusOnNavigate RouteData="routeData" Selector="h1" />
     </Found>
 </Router>
+<SiteTabSync />
+
+@code {
+    protected override void OnInitialized()
+    {
+        // Pin this scope to the site in the tab's URL before the Router renders
+        // anything that could resolve the site context. The circuit's WebSocket
+        // upgrade request only carries the shared site cookie, so without this pin
+        // every tab of the browser would collapse onto the same site.
+        SiteContext.PinFromUri(Navigation.Uri);
+    }
+}

--- a/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
@@ -5,6 +5,7 @@
 @inject SiteContextService SiteCtx
 @inject NetworkOptimizer.Web.Services.Monitoring.ProbeExecutorFactory ExecutorFactory
 @inject NetworkOptimizer.Web.Services.Monitoring.AsnResolutionService AsnResolution
+@inject Microsoft.JSInterop.IJSRuntime JS
 
 <div class="card">
     <div class="card-header card-header-collapsible" @onclick="ToggleCollapse">
@@ -57,7 +58,7 @@
                     @foreach (var t in Targets.OrderBy(t => t.TargetType).ThenBy(t => t.Name))
                     {
                         var latest = LiveStats.GetTargetStats(t.TargetId);
-                        <tr style="@(t.Enabled ? "" : "opacity: 0.55;")">
+                        <tr id="latency-target-@t.Id" style="@(t.Enabled ? "" : "opacity: 0.55;")">
                             <td>
                                 <span class="status-badge @TargetTypeBadgeClass(t.TargetType)">
                                     @t.TargetType.ToDisplayName()
@@ -260,6 +261,30 @@
     private string? _addTargetError;
 
     private void ToggleCollapse() => _collapsed = !_collapsed;
+
+    /// <summary>
+    /// Expands the card (it defaults collapsed) and scrolls to a specific target's row with a
+    /// brief highlight. Called from the LAN flaky-target advisory so "review in Latency Targets"
+    /// lands the user on the exact row. Mirrors the scroll+outline pattern used elsewhere on the
+    /// monitoring page (Monitoring.ScrollToFlakyTargetsAsync).
+    /// </summary>
+    public async Task ExpandAndHighlightAsync(int targetId)
+    {
+        _collapsed = false;
+        StateHasChanged();
+        // Let the expand animation start and the row render before scrolling to it.
+        await Task.Delay(350);
+        await JS.InvokeVoidAsync("eval", $@"
+            (function() {{
+                var el = document.getElementById('latency-target-{targetId}');
+                if (el) {{
+                    el.scrollIntoView({{ behavior: 'smooth', block: 'center' }});
+                    el.style.transition = 'background-color 0.3s';
+                    el.style.backgroundColor = 'rgba(59, 130, 246, 0.18)';
+                    setTimeout(function() {{ el.style.backgroundColor = ''; }}, 2000);
+                }}
+            }})();");
+    }
 
     private async Task ToggleTargetAsync(int targetId)
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -39,6 +39,18 @@ else
         ? $"/monitoring?tab=devices&device={Uri.EscapeDataString(_gatewayMac)}"
         : "/monitoring?tab=devices";
     <div class="lv-panel">
+        @if (ShowConsoleDownBanner)
+        {
+            <div class="connection-banner">
+                <div class="banner-content">
+                    <span class="banner-icon">!</span>
+                    <div class="banner-text">
+                        <strong>@ConsoleDownTitle</strong>
+                        <span>@ConsoleDownMessage</span>
+                    </div>
+                </div>
+            </div>
+        }
         <div class="monitoring-stat-cards">
             @{ var wanRates = GetWanRates(); }
             <div class="monitoring-stat-card monitoring-stat-rate">
@@ -190,6 +202,7 @@ else
     [Parameter] public string MapMode { get; set; } = "2d";
 
     private bool _ready;
+    private bool _consoleUnreachable;
     private string? _gatewayMac;
     private List<string> _gatewayWanIfNames = new();
     private List<MonitoringTarget> _targets = new();
@@ -240,7 +253,7 @@ else
                         "window.__dashMountMap3d = async function(canvasId) {" +
                         $"  const m = await import('{VersionedJs("/js/lan-flow-map.js")}');" +
                         "  window.__dashLanFlowMap = m;" +
-                        "  await m.mount(canvasId,{storagePrefix:'dashLanFlowMap',signalHint:false});" +
+                        $"  await m.mount(canvasId,{{storagePrefix:'{SiteCtx.ScopeStorageKey("dashLanFlowMap")}',signalHint:false}});" +
                         "}");
                     await JS.InvokeVoidAsync("__dashMountMap3d", "dashboard-lan-flow-map-canvas");
                 }
@@ -249,7 +262,7 @@ else
                     await JS.InvokeVoidAsync("eval",
                         $"(async () => {{ const m = await import('{VersionedJs("/js/lan-flow-map-2d.js")}'); " +
                         "window.__dashLanFlowMap2d = m; m.startDataPolling(); " +
-                        "await m.mount('dashboard-lan-flow-map-2d-stage',{storagePrefix:'dashLanFlowMap2d',liveOnly:true}); })();");
+                        $"await m.mount('dashboard-lan-flow-map-2d-stage',{{storagePrefix:'{SiteCtx.ScopeStorageKey("dashLanFlowMap2d")}',liveOnly:true}}); }})();");
                 }
             }
             catch { _mapMounted = false; _mountedMode = null; }
@@ -314,13 +327,29 @@ else
 
             _targets = await db.MonitoringTargets.Where(t => t.Enabled).ToListAsync();
 
-            var devices = await ConnectionService.GetDiscoveredDevicesAsync();
-            if (devices != null)
+            // The gateway identity is only a nice-to-have for deep links; fetch it
+            // from the console but DON'T let a down console (an agent-tunnel outage)
+            // fail the whole panel and show the "not configured" empty state -
+            // monitoring IS configured, the console is just unreachable. Live stats
+            // come from the buffers/Influx, not this call; the console-down banner
+            // explains any staleness instead.
+            try
             {
-                var gw = devices.FirstOrDefault(d =>
-                    d.Type == DeviceType.Gateway || d.HardwareType == DeviceType.Gateway);
-                _gatewayMac = gw?.Mac?.Replace("-", ":").ToLowerInvariant();
-                _gatewayWanIfNames = gw?.WanInterfaceNames ?? new();
+                var devices = await ConnectionService.GetDiscoveredDevicesAsync();
+                if (devices != null)
+                {
+                    var gw = devices.FirstOrDefault(d =>
+                        d.Type == DeviceType.Gateway || d.HardwareType == DeviceType.Gateway);
+                    _gatewayMac = gw?.Mac?.Replace("-", ":").ToLowerInvariant();
+                    _gatewayWanIfNames = gw?.WanInterfaceNames ?? new();
+                }
+                _consoleUnreachable = false;
+            }
+            catch
+            {
+                // Console unreachable (agent tunnel down): keep prior gateway info
+                // and surface the banner rather than blanking the panel.
+                _consoleUnreachable = true;
             }
 
             _ready = true;
@@ -330,6 +359,21 @@ else
             _ready = false;
         }
     }
+
+    // Console-down banner: the console was unreachable this load, or the
+    // connection has flipped to awaiting-agent / disconnected.
+    private bool ShowConsoleDownBanner =>
+        _consoleUnreachable || (ConnectionService.IsInitialized && !ConnectionService.IsConnected);
+
+    private string ConsoleDownTitle =>
+        ConnectionService.IsAwaitingAgent ? "Agent offline"
+        : ConnectionService.IsConnected ? "Console not responding"
+        : "Console disconnected";
+
+    private string ConsoleDownMessage =>
+        !string.IsNullOrEmpty(ConnectionService.LastError)
+            ? ConnectionService.LastError!
+            : "The console isn't responding right now. Live data is paused until it reconnects.";
 
     private (double download, double upload) GetWanRates()
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
@@ -107,7 +107,9 @@ else if (IsShowingExternal && _externalOntStats != null)
     </div>
 
     <div class="sqm-actions">
-        <button class="btn btn-secondary" @onclick="RefreshExternal" @onclick:stopPropagation>Refresh</button>
+        <button class="btn btn-secondary" @onclick="RefreshExternal" @onclick:stopPropagation disabled="@_isRefreshing">
+            @if (_isRefreshing) { <span class="spinner-sm"></span> } else { <span>Refresh</span> }
+        </button>
         <a href="/settings#ont-monitoring" class="btn btn-primary" @onclick:stopPropagation>ONT Settings</a>
     </div>
 }
@@ -156,7 +158,9 @@ else if (IsShowingExternal)
     </div>
 
     <div class="sqm-actions">
-        <button class="btn btn-secondary" @onclick="RefreshExternal" @onclick:stopPropagation>Refresh</button>
+        <button class="btn btn-secondary" @onclick="RefreshExternal" @onclick:stopPropagation disabled="@_isRefreshing">
+            @if (_isRefreshing) { <span class="spinner-sm"></span> } else { <span>Refresh</span> }
+        </button>
         <a href="/settings#ont-monitoring" class="btn btn-primary" @onclick:stopPropagation>ONT Settings</a>
     </div>
 }
@@ -327,6 +331,7 @@ else
     private int _currentIndex = 0;
     private System.Threading.Timer? _refreshTimer;
     private OntStats? _externalOntStats;
+    private bool _isRefreshing;
 
     private int TotalCount => _monitoredOnts.Count + _externalOnts.Count;
     private bool IsShowingExternal => _currentIndex >= _monitoredOnts.Count;
@@ -425,10 +430,19 @@ else
     private async Task RefreshExternal()
     {
         var extIdx = _currentIndex - _monitoredOnts.Count;
-        if (extIdx < 0 || extIdx >= _externalOnts.Count) return;
-        await ExternalOntService.PollOntAsync(_externalOnts[extIdx].Id);
-        RefreshExternalStats();
+        if (extIdx < 0 || extIdx >= _externalOnts.Count || _isRefreshing) return;
+        _isRefreshing = true;
         StateHasChanged();
+        try
+        {
+            await ExternalOntService.PollOntAsync(_externalOnts[extIdx].Id);
+            RefreshExternalStats();
+        }
+        finally
+        {
+            _isRefreshing = false;
+            StateHasChanged();
+        }
     }
 
     private string ExternalRxClass()

--- a/src/NetworkOptimizer.Web/Components/Shared/PwaBanner.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/PwaBanner.razor
@@ -39,7 +39,7 @@
                     "window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true");
                 if (isStandalone) return;
 
-                var dismissed = await SettingsService.GetAsync(SystemSettingKeys.PwaBannerDismissed);
+                var dismissed = await SettingsService.GetGlobalAsync(SystemSettingKeys.PwaBannerDismissed);
                 if (string.IsNullOrEmpty(dismissed) || !dismissed.Equals("true", StringComparison.OrdinalIgnoreCase))
                 {
                     _visible = true;
@@ -58,7 +58,7 @@
         _visible = false;
         try
         {
-            await SettingsService.SetAsync(SystemSettingKeys.PwaBannerDismissed, "true");
+            await SettingsService.SetGlobalAsync(SystemSettingKeys.PwaBannerDismissed, "true");
         }
         catch
         {

--- a/src/NetworkOptimizer.Web/Components/Shared/SiteSetupWizard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SiteSetupWizard.razor
@@ -6,8 +6,7 @@
 @inject AgentEnrollmentService AgentEnrollment
 @inject NetworkOptimizer.Storage.Services.SiteDbContextFactory SiteDb
 @inject NetworkOptimizer.Web.Services.Licensing.LicenseStateService LicenseState
-@inject NavigationManager NavigationManager
-@inject IJSRuntime JS
+@inject SiteSwitchService SiteSwitch
 @implements IDisposable
 
 <div class="site-wizard">
@@ -430,9 +429,7 @@
         if (_site == null)
             return;
 
-        await JS.InvokeVoidAsync("eval",
-            $"document.cookie = '{SiteContextService.CookieName}={_site.Slug}; path=/; max-age=31536000; SameSite=Lax'");
-        NavigationManager.NavigateTo("/", forceLoad: true);
+        await SiteSwitch.SwitchToAsync(_site.Slug, "/");
     }
 
     private async Task ResetAsync()

--- a/src/NetworkOptimizer.Web/Components/Shared/SiteSwitcher.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SiteSwitcher.razor
@@ -4,7 +4,6 @@
 @inject SiteContextService SiteContext
 @inject SiteConnectionRegistry SiteConnections
 @inject NavigationManager NavigationManager
-@inject IJSRuntime JS
 
 @if (_enabled && _sites.Count > 0)
 {
@@ -23,14 +22,23 @@
             <div class="site-switcher-menu">
                 @foreach (var site in _sites)
                 {
-                    <button type="button" class="site-switcher-item @(site.Slug == SiteContext.Slug ? "active" : "")"
-                            @onclick="() => SwitchToAsync(site)">
+                    @* A real anchor whose href is this page pinned to the site. The
+                       site-context.js click handler turns a plain left click into the
+                       switch (cookie write + full reload, same target as the href) and
+                       preventDefaults it, while ctrl / cmd / shift / middle clicks fall
+                       through to the browser and open the site in a new tab - pinning
+                       that tab without touching this one or the browser default. Handled
+                       in JS, not @@onclick, so those modified clicks stay native. *@
+                    <a class="site-switcher-item @(site.Slug == SiteContext.Slug ? "active" : "")"
+                       href="@GetSiteHref(site)"
+                       data-site-switch="@site.Slug"
+                       data-site-current="@(site.Slug == SiteContext.Slug ? "" : null)">
                         <span class="site-switcher-item-name">
                             <span class="status-dot @(SiteConnections.GetFor(site.Slug).IsConnected ? "online" : "offline")"></span>
                             @site.Name
                         </span>
                         <span class="site-switcher-item-slug">@site.Slug</span>
-                    </button>
+                    </a>
                 }
                 <a class="site-switcher-all" href="/sites" @onclick="CloseDropdown">All sites</a>
             </div>
@@ -59,52 +67,26 @@
 
     private void CloseDropdown() => _open = false;
 
-    private async Task SwitchToAsync(Site site)
+    /// <summary>This page pinned to the given site - the anchor href (plain-click switch
+    /// target and modified-click new-tab target); see site-context.js.</summary>
+    private string GetSiteHref(Site site) =>
+        SiteContextService.WithSiteParam(CurrentSwitchTarget(), site.Slug);
+
+    /// <summary>
+    /// Where a site switch from the current page should land. The #fragment is kept
+    /// so an anchored spot (e.g. a highlighted setting) carries to the new site; the
+    /// changed ?site= query still guarantees the full reload.
+    /// </summary>
+    private string CurrentSwitchTarget()
     {
-        _open = false;
-        if (site.Slug == SiteContext.Slug)
-            return;
-
-        // Site context is cookie-based; switching requires a full reload so every
-        // scoped service resolves against the new site's database.
-        await JS.InvokeVoidAsync("eval",
-            $"document.cookie = '{SiteContextService.CookieName}={site.Slug}; path=/; max-age=31536000; SameSite=Lax'");
-        var target = NavigationManager.Uri;
-
-        // Drop any #fragment: reloading the *same* URL with its fragment is a
-        // same-document navigation the browser won't actually reload, so the new site
-        // cookie would never take effect. The fragment is meaningless on another site anyway.
-        var fragmentAt = target.IndexOf('#');
-        if (fragmentAt >= 0)
-            target = target[..fragmentAt];
-
-        // Strip the ?site= selector: an alert "View" link pins the site through this
-        // query param, which wins over the cookie, so leaving it in place would
-        // immediately override the switch we just made.
-        target = RemoveSiteQueryParam(target);
-
         // The all-sites overview isn't a per-site page, so switching sites from it
         // should land on the new site's dashboard rather than reload the overview.
-        var relative = NavigationManager.ToBaseRelativePath(target).TrimEnd('/');
-        if (string.Equals(relative, "sites", StringComparison.OrdinalIgnoreCase))
-            target = NavigationManager.BaseUri;
+        var pathOnly = NavigationManager.ToBaseRelativePath(NavigationManager.Uri)
+            .Split('?', '#')[0]
+            .TrimEnd('/');
+        if (string.Equals(pathOnly, "sites", StringComparison.OrdinalIgnoreCase))
+            return NavigationManager.BaseUri;
 
-        NavigationManager.NavigateTo(target, forceLoad: true);
-    }
-
-    private static string RemoveSiteQueryParam(string url)
-    {
-        var queryAt = url.IndexOf('?');
-        if (queryAt < 0)
-            return url;
-
-        var kept = url[(queryAt + 1)..]
-            .Split('&', StringSplitOptions.RemoveEmptyEntries)
-            .Where(p => !p.Equals(SiteContextService.SiteQueryParam, StringComparison.OrdinalIgnoreCase)
-                     && !p.StartsWith(SiteContextService.SiteQueryParam + "=", StringComparison.OrdinalIgnoreCase))
-            .ToList();
-
-        var basePart = url[..queryAt];
-        return kept.Count > 0 ? $"{basePart}?{string.Join('&', kept)}" : basePart;
+        return NavigationManager.Uri;
     }
 }

--- a/src/NetworkOptimizer.Web/Components/Shared/SiteTabSync.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SiteTabSync.razor
@@ -1,0 +1,48 @@
+@* Keeps the tab's ?site= selector in the address bar (history.replaceState, no
+   reload) whenever multi-site is enabled, so refresh, duplicate-tab, and the
+   reconnect auto-reload all land back on this tab's site instead of the browser
+   default. Also feeds the fetch wrapper in site-context.js the slug it stamps
+   onto same-origin /api/ requests. Renders nothing. *@
+@implements IDisposable
+@inject NavigationManager Navigation
+@inject SiteContextService SiteContext
+@inject SiteManagementService SiteManagement
+@inject IJSRuntime JS
+
+@code {
+    private bool _active;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+            return;
+
+        _active = await SiteManagement.IsMultiSiteEnabledAsync();
+        if (!_active)
+            return;
+
+        Navigation.LocationChanged += OnLocationChanged;
+        await EnsureSiteParamAsync();
+    }
+
+    private async void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
+        => await EnsureSiteParamAsync();
+
+    private async Task EnsureSiteParamAsync()
+    {
+        try
+        {
+            await JS.InvokeVoidAsync("noSiteContext.ensureSiteParam", SiteContext.Slug);
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+        {
+            // Circuit tearing down (navigation away, tab close) - nothing to sync.
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_active)
+            Navigation.LocationChanged -= OnLocationChanged;
+    }
+}

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -624,7 +624,7 @@
     {
         try
         {
-            var dismissed = await SettingsService.GetAsync(SystemSettingKeys.ChannelDisclaimerDismissed);
+            var dismissed = await SettingsService.GetGlobalAsync(SystemSettingKeys.ChannelDisclaimerDismissed);
             _channelDisclaimerDismissed = !string.IsNullOrEmpty(dismissed) && dismissed.Equals("true", StringComparison.OrdinalIgnoreCase);
         }
         catch { /* Non-critical */ }
@@ -1281,7 +1281,7 @@
         _channelDisclaimerDismissed = true;
         try
         {
-            await SettingsService.SetAsync(SystemSettingKeys.ChannelDisclaimerDismissed, "true");
+            await SettingsService.SetGlobalAsync(SystemSettingKeys.ChannelDisclaimerDismissed, "true");
         }
         catch { /* Still hide it */ }
     }

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -267,6 +267,7 @@ builder.Services.AddScoped<NetworkOptimizer.Alerts.Interfaces.IAlertRepository, 
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.ISiteRepository, NetworkOptimizer.Storage.Repositories.SiteRepository>();
 builder.Services.AddScoped<SiteManagementService>();
 builder.Services.AddScoped<SiteContextService>();
+builder.Services.AddScoped<SiteSwitchService>();
 // The alert pipeline pins its scope to an event's originating site through this seam.
 builder.Services.AddScoped<NetworkOptimizer.Alerts.Interfaces.IAlertSiteScope>(sp =>
     sp.GetRequiredService<SiteContextService>());
@@ -528,7 +529,11 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 }
 
                 context.HandleResponse();
-                context.Response.Redirect("/login");
+                // Carry the tab's ?site= pin through login (same as the auth middleware).
+                var challengeSite = context.Request.Query[SiteContextService.SiteQueryParam].ToString();
+                context.Response.Redirect(string.IsNullOrEmpty(challengeSite)
+                    ? "/login"
+                    : $"/login?{SiteContextService.SiteQueryParam}={Uri.EscapeDataString(challengeSite)}");
                 return Task.CompletedTask;
             }
         };
@@ -1138,34 +1143,23 @@ app.Use(async (context, next) =>
             return;
         }
 
-        // Web pages redirect to login
-        context.Response.Redirect("/login");
+        // Web pages redirect to login. Carry the tab's ?site= pin through so the
+        // post-login redirect lands back on the site the tab was on.
+        var loginSite = context.Request.Query[SiteContextService.SiteQueryParam].ToString();
+        context.Response.Redirect(string.IsNullOrEmpty(loginSite)
+            ? "/login"
+            : $"/login?{SiteContextService.SiteQueryParam}={Uri.EscapeDataString(loginSite)}");
         return;
     }
 
     await next();
 });
 
-// Site selection via ?site=<slug>: alert "View" links carry the originating site so a
-// notification lands on the right site. Persist a valid value to the site cookie (same
-// attributes as the in-app switcher) so the whole session follows the link; validation
-// runs through the scoped site context, which checks the slug and its provisioned DB.
-app.Use(async (context, next) =>
-{
-    var siteParam = context.Request.Query[SiteContextService.SiteQueryParam].ToString();
-    if (!string.IsNullOrEmpty(siteParam)
-        && context.Request.Cookies[SiteContextService.CookieName] != siteParam
-        && context.RequestServices.GetRequiredService<SiteContextService>().IsSelectableSite(siteParam))
-    {
-        context.Response.Cookies.Append(SiteContextService.CookieName, siteParam, new CookieOptions
-        {
-            Path = "/",
-            MaxAge = TimeSpan.FromDays(365),
-            SameSite = SameSiteMode.Lax
-        });
-    }
-    await next();
-});
+// Site selection via ?site=<slug> is per browser tab: it wins over the site cookie on
+// every request (SiteContextService.Resolve), the circuit pins itself from the tab URL
+// (Routes.razor), and SiteTabSync keeps the selector in the address bar. It is never
+// persisted to the cookie - following an alert "View" link pins only that tab, and the
+// cookie remains the browser default written solely by an explicit switch in the UI.
 
 // Configure static files with custom MIME types for package downloads
 var contentTypeProvider = new FileExtensionContentTypeProvider();
@@ -1270,7 +1264,12 @@ app.MapGet("/api/auth/logout", (HttpContext context) =>
         Path = "/"
     });
 
-    return Results.Redirect("/login");
+    // Carry the tab's ?site= pin (stamped onto the logout link by site-context.js)
+    // through to the login page so logging back in returns to the same site.
+    var logoutSite = context.Request.Query[SiteContextService.SiteQueryParam].ToString();
+    return Results.Redirect(string.IsNullOrEmpty(logoutSite)
+        ? "/login"
+        : $"/login?{SiteContextService.SiteQueryParam}={Uri.EscapeDataString(logoutSite)}");
 });
 
 app.MapGet("/api/auth/check", async (HttpContext context, IJwtService jwt) =>

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -46,6 +46,13 @@ public class AgentProbeResultSink
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _consoleFetchGate = new();
     private static readonly TimeSpan ConsoleCacheTtl = TimeSpan.FromSeconds(60);
 
+    // Samples older than this skip the alert state machines. Agents replay
+    // their store-and-forward backlog after a tunnel outage; feeding an
+    // hours-old down→up sequence through the evaluators would fire and resolve
+    // alerts long after the fact. History still lands in Influx and the live
+    // caches (replay is chronological, so the caches end on the newest sample).
+    private static readonly TimeSpan AlertFreshness = TimeSpan.FromMinutes(10);
+
     // Per-site topology-boundary aggregator (fabric sums, AP backhaul, gateway WAN),
     // the same LanFabricAggregator the directly-monitored fast tier uses. Keyed by slug
     // because this sink is a singleton serving every agent site.
@@ -106,10 +113,42 @@ public class AgentProbeResultSink
         });
     }
 
+    /// <summary>
+    /// Called by the tunnel watchdog when a still-registered tunnel goes silent
+    /// past the stale threshold (black-holed, not yet droppable at 90s). Flips
+    /// the site's console to awaiting-agent proactively, so a site nobody has
+    /// touched during the outage doesn't stay stale-green until first contact -
+    /// which made the first switch to it pay a dial-and-retry on every console
+    /// call. Fire-and-forget; the flip is idempotent.
+    /// </summary>
+    public void OnTunnelStale(AgentTunnelConnection connection)
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await _siteConnections.GetFor(connection.SiteSlug).NoteTunnelUnreachableAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Stale-tunnel awaiting-agent flip failed for site {Slug}", connection.SiteSlug);
+            }
+        });
+    }
+
     private async Task ReconnectConsoleIfViaAgentAsync(AgentTunnelConnection connection)
     {
         try
         {
+            // The 60s config refresh also lands here while a black-holed tunnel is
+            // still registered (the 90s watchdog hasn't reaped it). Reconnecting the
+            // console through a tunnel that's silent past the stale threshold just
+            // dials the dead loopback proxy and clobbers the awaiting-agent state the
+            // proxy's unreachable signal set. Skip; a real agent reconnect arrives
+            // with a fresh LastMessageAt and proceeds normally.
+            if (connection.IsStale)
+                return;
+
             var siteConnection = _siteConnections.GetFor(connection.SiteSlug);
             if (siteConnection.IsConnected || !await siteConnection.IsConsoleViaAgentAsync())
                 return;
@@ -745,6 +784,9 @@ public class AgentProbeResultSink
             // Threshold evaluation through the site's own evaluator instance, same
             // state machine the local medium tier runs. The name cache captured on
             // config push gives the alert a device label instead of a bare MAC.
+            // Replayed backlog samples skip evaluation (see AlertFreshness).
+            if (DateTime.UtcNow - timestamp > AlertFreshness)
+                continue;
             try
             {
                 string? deviceName = null;
@@ -809,20 +851,28 @@ public class AgentProbeResultSink
             }
         }
 
-        var deviceFields = new Dictionary<string, Dictionary<string, object>>();
+        // Grouped per timestamp as well as per target: a live batch carries one
+        // poll's worth of results (all the same stamp, one point per target,
+        // same as before), but an agent replaying its store-and-forward backlog
+        // after a tunnel outage coalesces many polls into one batch, and each
+        // poll must land at its own sample time - not the flush time.
+        var deviceFields = new Dictionary<(string Mac, long Ts), Dictionary<string, object>>();
         var deviceTypes = new Dictionary<string, string>();
-        var interfaceFields = new Dictionary<(string Mac, string IfName), Dictionary<string, object>>();
+        var interfaceFields = new Dictionary<(string Mac, string IfName, long Ts), Dictionary<string, object>>();
 
         foreach (var r in results)
         {
             var mac = NormalizeMac(r.DeviceMac);
             var valueType = (CustomOidValueType)r.ValueType;
+            var ts = r.TimestampUnixMs > 0
+                ? r.TimestampUnixMs
+                : DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             if (r.Scope == 0) // DeviceLevel
             {
                 if (string.IsNullOrEmpty(r.Value)) continue;
-                if (!deviceFields.TryGetValue(r.DeviceMac, out var fields))
+                if (!deviceFields.TryGetValue((r.DeviceMac, ts), out var fields))
                 {
-                    deviceFields[r.DeviceMac] = fields = new Dictionary<string, object>();
+                    deviceFields[(r.DeviceMac, ts)] = fields = new Dictionary<string, object>();
                     deviceTypes[r.DeviceMac] = deviceByMac.TryGetValue(mac, out var d)
                         ? d.DeviceType.ToString() : "unknown";
                 }
@@ -834,7 +884,7 @@ public class AgentProbeResultSink
                 foreach (var (ifIdx, raw) in r.InterfaceValues)
                 {
                     var ifName = idxMap != null && idxMap.TryGetValue(ifIdx, out var n) ? n : ifIdx;
-                    var key = (r.DeviceMac, ifName);
+                    var key = (r.DeviceMac, ifName, ts);
                     if (!interfaceFields.TryGetValue(key, out var fields))
                         interfaceFields[key] = fields = new Dictionary<string, object>();
                     fields[r.FieldName] = CustomOidValueParser.Parse(raw, valueType);
@@ -842,14 +892,15 @@ public class AgentProbeResultSink
             }
         }
 
-        var now = DateTime.UtcNow;
-        foreach (var (deviceMac, fields) in deviceFields)
+        foreach (var ((deviceMac, ts), fields) in deviceFields)
             await influx.WriteCustomFieldsAsync(
-                "device_health", deviceMac, fields, deviceTypes.GetValueOrDefault(deviceMac), null, null, now);
+                "device_health", deviceMac, fields, deviceTypes.GetValueOrDefault(deviceMac), null, null,
+                DateTimeOffset.FromUnixTimeMilliseconds(ts).UtcDateTime);
 
-        foreach (var ((deviceMac, ifName), fields) in interfaceFields)
+        foreach (var ((deviceMac, ifName, ts), fields) in interfaceFields)
             await influx.WriteCustomFieldsAsync(
-                "interface_counters", deviceMac, fields, null, ifName, null, now);
+                "interface_counters", deviceMac, fields, null, ifName, null,
+                DateTimeOffset.FromUnixTimeMilliseconds(ts).UtcDateTime);
     }
 
     /// <summary>Records a batch of probe results from an agent.</summary>
@@ -923,26 +974,30 @@ public class AgentProbeResultSink
             // State-change alerting through the site's own evaluator, exactly like
             // the local latency tier: up→down, down→up, sustained loss. The relayed
             // sample is rebuilt into the probe result shape the evaluator consumes.
-            try
+            // Replayed backlog samples skip evaluation (see AlertFreshness).
+            if (DateTime.UtcNow - timestamp <= AlertFreshness)
             {
-                var ping = new PingProbeResult
+                try
                 {
-                    Target = new ProbeTarget(target.Address, target.ProbeMode, target.Port),
-                    Vantage = new ProbeVantage(vantage, VantageKind.Server),
-                    Sent = result.Sent,
-                    Received = result.Received,
-                    Timestamp = timestamp,
-                    RttMinMs = result.HasRttMinMs ? result.RttMinMs : null,
-                    RttAvgMs = result.HasRttAvgMs ? result.RttAvgMs : null,
-                    RttMaxMs = result.HasRttMaxMs ? result.RttMaxMs : null,
-                    JitterMs = result.HasJitterMs ? result.JitterMs : null,
-                };
-                await _alertRegistry.GetFor(connection.SiteSlug).Targets.EvaluateAsync(target, ping, ct);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Alert evaluator failed for relayed target {Target} (site {Slug})",
-                    target.TargetId, connection.SiteSlug);
+                    var ping = new PingProbeResult
+                    {
+                        Target = new ProbeTarget(target.Address, target.ProbeMode, target.Port),
+                        Vantage = new ProbeVantage(vantage, VantageKind.Server),
+                        Sent = result.Sent,
+                        Received = result.Received,
+                        Timestamp = timestamp,
+                        RttMinMs = result.HasRttMinMs ? result.RttMinMs : null,
+                        RttAvgMs = result.HasRttAvgMs ? result.RttAvgMs : null,
+                        RttMaxMs = result.HasRttMaxMs ? result.RttMaxMs : null,
+                        JitterMs = result.HasJitterMs ? result.JitterMs : null,
+                    };
+                    await _alertRegistry.GetFor(connection.SiteSlug).Targets.EvaluateAsync(target, ping, ct);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Alert evaluator failed for relayed target {Target} (site {Slug})",
+                        target.TargetId, connection.SiteSlug);
+                }
             }
 
             if (result.Success)

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelProxyService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelProxyService.cs
@@ -18,9 +18,33 @@ namespace NetworkOptimizer.Web.Services;
 public class AgentTunnelProxyService : IDisposable
 {
     private const int FrameBytes = 32 * 1024;
-    private static readonly TimeSpan OpenTimeout = TimeSpan.FromSeconds(10);
+
+    // A live agent answers a ProxyOpen in well under a second (it's a local dial
+    // on its side), so a tight timeout still never trips a healthy tunnel but
+    // bounds the per-connection stall when the tunnel is black-holed and the
+    // answer never comes.
+    private static readonly TimeSpan OpenTimeout = TimeSpan.FromSeconds(3);
+
+    // Past AgentTunnelConnection.StaleThreshold of silence the tunnel is treated
+    // as black-holed and proxy opens are refused immediately instead of blocking
+    // - well before the 90s server watchdog drops the dead tunnel.
+
+    // After an open to a site times out, fast-fail further opens instead of each
+    // eating the full OpenTimeout. A page render (a site switch) fires a burst of
+    // console + SSH opens; in the first ~45s of an outage - before the liveness
+    // gate above can trip without false-failing a healthy tunnel - that burst
+    // would otherwise block OpenTimeout on every one, a 15s+ hang on the switch.
+    // Hold past the 45s gate so the breaker never expires and re-probes
+    // mid-outage; a shorter hold let a fresh burst time out every ~15s, a ~10s
+    // stall on any switch landing in that window. It still clears the instant the
+    // tunnel produces fresh inbound (recovery) - see the LastMessageAt check
+    // below - so a healthy tunnel is never held this long: its next heartbeat
+    // (<=30s) advances LastMessageAt and lets the open through.
+    private static readonly TimeSpan OpenBreakerHold = TimeSpan.FromSeconds(60);
+    private readonly ConcurrentDictionary<string, (DateTime Until, DateTime OpenedAtLastMsg)> _openBreaker = new();
 
     private readonly AgentTunnelRegistry _registry;
+    private readonly SiteConnectionRegistry _siteConnections;
     private readonly ILogger<AgentTunnelProxyService> _logger;
 
     private readonly ConcurrentDictionary<string, ProxyListener> _listeners = new();
@@ -28,9 +52,10 @@ public class AgentTunnelProxyService : IDisposable
     private readonly CancellationTokenSource _shutdown = new();
     private long _nextConnectionId;
 
-    public AgentTunnelProxyService(AgentTunnelRegistry registry, ILogger<AgentTunnelProxyService> logger)
+    public AgentTunnelProxyService(AgentTunnelRegistry registry, SiteConnectionRegistry siteConnections, ILogger<AgentTunnelProxyService> logger)
     {
         _registry = registry;
+        _siteConnections = siteConnections;
         _logger = logger;
     }
 
@@ -86,6 +111,41 @@ public class AgentTunnelProxyService : IDisposable
             return;
         }
 
+        // A black-holed tunnel stays registered (IsAgentOnline() true) until the
+        // 90s server watchdog drops it. Until then this dial would write into the
+        // dead socket and block the full OpenTimeout waiting for an answer that
+        // never comes - a multi-second freeze on every page load and site switch.
+        // If the tunnel has gone silent past the heartbeat window, treat it as
+        // down and refuse immediately so the console falls through to its
+        // error/awaiting-agent state instead of hanging the browser.
+        var silent = DateTime.UtcNow - agent.LastMessageAt;
+        if (silent > AgentTunnelConnection.StaleThreshold)
+        {
+            _logger.LogDebug("Proxy connect to {Host}:{Port} refused - agent {AgentId} silent for {Silent:n0}s (site {Slug})",
+                listener.TargetHost, listener.TargetPort, agent.AgentId, silent.TotalSeconds, listener.SiteSlug);
+            client.Dispose();
+            // Belt-and-braces with the watchdog's proactive flip: if a dial reaches
+            // a stale tunnel before the watchdog's next 15s tick has flipped the
+            // console, flip it now so this page's remaining calls short-circuit.
+            FlipConsoleAwaitingAgent(listener.SiteSlug);
+            return;
+        }
+
+        // Circuit breaker: a recent open to this site timed out and no inbound has
+        // arrived since, so the tunnel is almost certainly still black-holed.
+        // Fast-fail the render's remaining opens rather than eat OpenTimeout on
+        // each. Fresh inbound (LastMessageAt past when the breaker tripped) means
+        // the tunnel recovered, clearing this without needing a probe.
+        if (_openBreaker.TryGetValue(listener.SiteSlug, out var breaker)
+            && DateTime.UtcNow < breaker.Until
+            && agent.LastMessageAt <= breaker.OpenedAtLastMsg)
+        {
+            _logger.LogDebug("Proxy connect to {Host}:{Port} fast-refused - open breaker tripped for agent {AgentId} (site {Slug})",
+                listener.TargetHost, listener.TargetPort, agent.AgentId, listener.SiteSlug);
+            client.Dispose();
+            return;
+        }
+
         var id = Interlocked.Increment(ref _nextConnectionId);
         var connection = new ProxyConnection(id, client, agent);
         _connections[id] = connection;
@@ -111,6 +171,18 @@ public class AgentTunnelProxyService : IDisposable
             catch (OperationCanceledException)
             {
                 openError = "open timed out";
+                // Trip the breaker so the opens queued behind this one fast-fail
+                // instead of each blocking the full OpenTimeout.
+                var wasTripped = _openBreaker.TryGetValue(listener.SiteSlug, out var prev)
+                                 && DateTime.UtcNow < prev.Until;
+                _openBreaker[listener.SiteSlug] = (DateTime.UtcNow + OpenBreakerHold, agent.LastMessageAt);
+
+                // On the FIRST timeout of an outage, flip the site's console to
+                // awaiting-agent now (not at the 90s watchdog), so its page renders
+                // short-circuit console calls instead of each dialing the dead proxy
+                // and paying the retry backoff.
+                if (!wasTripped)
+                    FlipConsoleAwaitingAgent(listener.SiteSlug);
             }
             if (openError != null)
             {
@@ -119,6 +191,9 @@ public class AgentTunnelProxyService : IDisposable
                 CloseConnection(connection, notifyAgent: false);
                 return;
             }
+
+            // The tunnel answered, so clear any open breaker for this site.
+            _openBreaker.TryRemove(listener.SiteSlug, out _);
 
             // Local reads -> tunnel, with backpressure. The agent-to-local
             // direction is written by the tunnel read loop via OnProxyDataAsync.
@@ -183,6 +258,37 @@ public class AgentTunnelProxyService : IDisposable
     {
         foreach (var connection in _connections.Values.Where(c => ReferenceEquals(c.Agent, agent)))
             CloseConnection(connection, notifyAgent: false);
+    }
+
+    /// <summary>
+    /// Whether this site's tunnel path is currently suspect: no agent, an agent
+    /// silent past the stale threshold, or the open breaker tripped with no
+    /// fresh inbound since. Lets the console's connect-failure handling tell "the
+    /// tunnel is dead" (report awaiting-agent) apart from a genuine console-side
+    /// failure reached over a healthy tunnel (report the real error).
+    /// </summary>
+    public bool IsTunnelSuspect(string siteSlug)
+    {
+        var agent = _registry.GetForSite(siteSlug).FirstOrDefault();
+        if (agent == null || agent.IsStale) return true;
+        return _openBreaker.TryGetValue(siteSlug, out var breaker)
+               && DateTime.UtcNow < breaker.Until
+               && agent.LastMessageAt <= breaker.OpenedAtLastMsg;
+    }
+
+    /// <summary>
+    /// Flips the site's console to awaiting-agent off the dial path (fire-and-
+    /// forget, idempotent) the moment a dead tunnel is proven - by an open
+    /// timeout or a stale-gate refusal - so page renders short-circuit console
+    /// calls instead of paying dial-and-retry per call until the 90s watchdog.
+    /// </summary>
+    private void FlipConsoleAwaitingAgent(string siteSlug)
+    {
+        _ = Task.Run(async () =>
+        {
+            try { await _siteConnections.GetFor(siteSlug).NoteTunnelUnreachableAsync(); }
+            catch (Exception ex) { _logger.LogDebug(ex, "Awaiting-agent flip failed for site {Slug}", siteSlug); }
+        });
     }
 
     private void CloseConnection(ProxyConnection connection, bool notifyAgent)

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelRegistry.cs
@@ -91,6 +91,21 @@ public sealed class AgentTunnelConnection
     public DateTime ConnectedAt { get; }
     public DateTime LastMessageAt { get; internal set; }
 
+    /// <summary>
+    /// How long a tunnel may go silent before it counts as black-holed (agents
+    /// heartbeat every 30s and the server re-pushes configs every 60s, so a
+    /// healthy tunnel is never this quiet). A black-holed tunnel stays
+    /// REGISTERED until the 90s watchdog reaps it, so every consumer that asks
+    /// "is the agent there?" must use <see cref="IsStale"/> rather than mere
+    /// registration - the proxy's open gate, the console connect/wait paths,
+    /// and the config-refresh reconnect guard all share this single definition
+    /// so they can't disagree about the dead-but-registered window.
+    /// </summary>
+    public static readonly TimeSpan StaleThreshold = TimeSpan.FromSeconds(45);
+
+    /// <summary>True when nothing has arrived past <see cref="StaleThreshold"/>: dead-but-registered.</summary>
+    public bool IsStale => DateTime.UtcNow - LastMessageAt > StaleThreshold;
+
     private readonly CancellationTokenSource _dropCts = new();
 
     /// <summary>Cancelled when the server force-drops this connection (license enforcement).</summary>

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelService.cs
@@ -22,6 +22,16 @@ public class AgentTunnelService : AgentTunnel.AgentTunnelBase
     /// <summary>Heartbeat cadence handed to agents in the ServerHello.</summary>
     public const int HeartbeatIntervalSeconds = 30;
 
+    // A healthy agent is never silent longer than one heartbeat interval, so
+    // three missed heartbeats means the tunnel is dead even though TCP hasn't
+    // noticed (a WAN outage black-holes the connection rather than resetting
+    // it - the read loop would sit in MoveNext for the full TCP timeout,
+    // ~15 min). Dropping promptly matters beyond hygiene: the registry entry
+    // keeps IsAgentOnline() true, which blocks the console's awaiting-agent
+    // fail-fast flip - every page of the site (including a site switch) then
+    // hangs on proxy opens into the dead tunnel until they time out.
+    private static readonly TimeSpan LivenessTimeout = TimeSpan.FromSeconds(90);
+
     private readonly AgentEnrollmentService _enrollment;
     private readonly AgentTunnelRegistry _registry;
     private readonly AgentProbeResultSink _probeResultSink;
@@ -95,6 +105,7 @@ public class AgentTunnelService : AgentTunnel.AgentTunnelBase
         ct = streamCts.Token;
         Task? pumpTask = null;
         Task? refreshTask = null;
+        Task? livenessTask = null;
         try
         {
             await responseStream.WriteAsync(new ServerMessage
@@ -104,6 +115,7 @@ public class AgentTunnelService : AgentTunnel.AgentTunnelBase
                     SiteSlug = siteSlug,
                     AgentName = agent.Name,
                     HeartbeatIntervalSeconds = HeartbeatIntervalSeconds,
+                    SupportsResultAck = true,
                 }
             }, ct);
 
@@ -111,6 +123,7 @@ public class AgentTunnelService : AgentTunnel.AgentTunnelBase
             // traffic funnels through the connection's channel and this pump.
             pumpTask = PumpOutboundAsync(connection, responseStream, streamCts.Token);
             refreshTask = RefreshProbeConfigLoopAsync(connection, streamCts.Token);
+            livenessTask = WatchLivenessAsync(connection, streamCts.Token);
 
             await _probeResultSink.OnAgentConnectedAsync(connection, ct);
 
@@ -125,6 +138,11 @@ public class AgentTunnelService : AgentTunnel.AgentTunnelBase
                         break;
                     case AgentMessage.PayloadOneofCase.ProbeResults:
                         await _probeResultSink.RecordBatchAsync(connection, message.ProbeResults, ct);
+                        // Ack only after the batch is persisted, so the agent keeps it
+                        // buffered until we confirm it landed. Cumulative: sequence N
+                        // acks everything <= N. Sequence 0 = an older agent with no acking.
+                        if (message.Sequence > 0)
+                            connection.TrySend(new ServerMessage { ResultAck = new ResultAck { Sequence = message.Sequence } });
                         break;
                     case AgentMessage.PayloadOneofCase.ProxyOpenResult:
                         _proxy.OnProxyOpenResult(message.ProxyOpenResult);
@@ -137,6 +155,8 @@ public class AgentTunnelService : AgentTunnel.AgentTunnelBase
                         break;
                     case AgentMessage.PayloadOneofCase.SnmpResults:
                         await _probeResultSink.RecordSnmpBatchAsync(connection, message.SnmpResults, ct);
+                        if (message.Sequence > 0)
+                            connection.TrySend(new ServerMessage { ResultAck = new ResultAck { Sequence = message.Sequence } });
                         break;
                     case AgentMessage.PayloadOneofCase.Iperf3Result:
                         _iperf3.OnResult(message.Iperf3Result);
@@ -176,6 +196,7 @@ public class AgentTunnelService : AgentTunnel.AgentTunnelBase
             streamCts.Cancel();
             await AwaitQuietlyAsync(pumpTask);
             await AwaitQuietlyAsync(refreshTask);
+            await AwaitQuietlyAsync(livenessTask);
             _logger.LogInformation("Agent {Name} (id {Id}) tunnel closed", agent.Name, agent.Id);
         }
     }
@@ -202,6 +223,42 @@ public class AgentTunnelService : AgentTunnel.AgentTunnelBase
         {
             await Task.Delay(TimeSpan.FromSeconds(60), ct);
             await _probeResultSink.OnAgentConnectedAsync(connection, ct);
+        }
+    }
+
+    /// <summary>
+    /// Drops the connection when the agent has been silent past
+    /// <see cref="LivenessTimeout"/>. Cancelling the drop token aborts the
+    /// read loop, which runs the normal teardown: unregister, proxy/console
+    /// awaiting-agent flip, and the agent's own reconnect gets a clean slate.
+    /// Before that, the moment silence crosses the stale threshold, the site's
+    /// console is flipped to awaiting-agent proactively - without this, a site
+    /// nobody dialed during the outage stayed stale-green until first contact,
+    /// and that first switch paid a dial-and-retry on every console call for
+    /// the rest of the 90s window.
+    /// </summary>
+    private async Task WatchLivenessAsync(AgentTunnelConnection connection, CancellationToken ct)
+    {
+        var flaggedStale = false;
+        while (!ct.IsCancellationRequested)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(15), ct);
+            var silent = DateTime.UtcNow - connection.LastMessageAt;
+            if (!flaggedStale && silent > AgentTunnelConnection.StaleThreshold)
+            {
+                flaggedStale = true;
+                _logger.LogInformation(
+                    "Agent {Name} (id {Id}, site {Slug}) silent for {Silent:0}s; treating the tunnel as black-holed",
+                    connection.AgentName, connection.AgentId, connection.SiteSlug, silent.TotalSeconds);
+                _probeResultSink.OnTunnelStale(connection);
+            }
+            if (silent <= LivenessTimeout) continue;
+            _logger.LogWarning(
+                "Agent {Name} (id {Id}, site {Slug}) silent for {Silent:0}s (heartbeat is {Interval}s); dropping dead tunnel",
+                connection.AgentName, connection.AgentId, connection.SiteSlug,
+                silent.TotalSeconds, HeartbeatIntervalSeconds);
+            connection.Drop();
+            return;
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/AppVersionInfo.cs
+++ b/src/NetworkOptimizer.Web/Services/AppVersionInfo.cs
@@ -21,7 +21,7 @@ public static class AppVersionInfo
     /// are not flagged. The Multi-Site agent list shows an "Update agent"
     /// callout for enrolled agents reporting an older version than this.
     /// </summary>
-    public const string LatestAgentVersion = "2.0.0";
+    public const string LatestAgentVersion = "2.0.1";
 
     /// <summary>Full informational version (e.g. "1.4.2" or "0.0.0-alpha.0.12").</summary>
     public static string Informational { get; }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/StepChangeDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/StepChangeDetector.cs
@@ -44,7 +44,8 @@ public static class StepChangeDetector
             // A shift that lands mid-window leaves a transition window straddling both
             // levels, whose wide IQR overlaps the before-window and masks the step
             // (seen in real data). So also try comparing against the window after it,
-            // accepting the skipped window only when its median sits between the levels.
+            // rejecting the skipped window only when it is a stable level outside the
+            // two step levels (a genuine third level, not a transition).
             var detected = TryDetectStep(windows, i, afterIndex: i + 1, options)
                 ?? TryDetectStep(windows, i, afterIndex: i + 2, options);
             if (detected == null) continue;
@@ -92,11 +93,17 @@ public static class StepChangeDetector
         if (!IsStableLevel(before, options) || !IsStableLevel(after, options)) return null;
         if (afterIndex == beforeIndex + 2)
         {
-            var transition = windows[beforeIndex + 1].MedianMs;
-            var inBetween = delta > 0
-                ? transition > before.MedianMs && transition < after.MedianMs
-                : transition < before.MedianMs && transition > after.MedianMs;
-            if (!inBetween) return null;
+            // The skipped window mixes both levels, and which side its median lands on
+            // depends on where the crossing fell within it - noise can push it fractionally
+            // outside the [before, after] band (a real step-up was missed because a small
+            // pre-shift dip left the transition median 0.3 ms below the old level). Only a
+            // window that is itself a stable level outside the band disqualifies the skip:
+            // that is a distinct plateau (spike or dip), not a transition.
+            var transition = windows[beforeIndex + 1];
+            var lo = Math.Min(before.MedianMs, after.MedianMs);
+            var hi = Math.Max(before.MedianMs, after.MedianMs);
+            var inBetween = transition.MedianMs > lo && transition.MedianMs < hi;
+            if (!inBetween && IsStableLevel(transition, options)) return null;
         }
         if (!EstablishedAtOldLevel(windows, beforeIndex, delta, options)) return null;
         if (!PersistsAtNewLevel(windows, before.MedianMs, delta, afterIndex, options)) return null;

--- a/src/NetworkOptimizer.Web/Services/SiteContextService.cs
+++ b/src/NetworkOptimizer.Web/Services/SiteContextService.cs
@@ -5,7 +5,8 @@ using NetworkOptimizer.Storage.Services;
 namespace NetworkOptimizer.Web.Services;
 
 /// <summary>
-/// Scoped ambient site context. The current site is carried in a browser cookie
+/// Scoped ambient site context. The current site is carried in the URL's ?site=
+/// query parameter (per browser tab) with a cookie as the browser-wide default,
 /// so it is readable synchronously during prerender, in API endpoints, and when
 /// the scoped DbContext options are built - no site parameter threading anywhere.
 /// Scopes without an HTTP context (background jobs, startup) resolve to the
@@ -13,13 +14,19 @@ namespace NetworkOptimizer.Web.Services;
 /// </summary>
 public class SiteContextService : IAlertSiteScope
 {
-    /// <summary>Cookie carrying the selected site slug for this browser.</summary>
+    /// <summary>
+    /// Cookie carrying this browser's default site slug: the site used by any URL
+    /// that has no <see cref="SiteQueryParam"/> selector (new tabs, bare bookmarks).
+    /// Written only by an explicit switch in the UI, never by following a link.
+    /// </summary>
     public const string CookieName = "no-site";
 
     /// <summary>
-    /// Query-string parameter that selects a site for a single request (used by alert
-    /// "View" links so a notification lands on its originating site). A middleware
-    /// persists it to <see cref="CookieName"/> so the whole session follows the link.
+    /// Query-string parameter that pins a browser tab to a site. It wins over
+    /// <see cref="CookieName"/> on every request, the interactive circuit pins its
+    /// scope from it (<see cref="PinFromUri"/>), and the SiteTabSync component keeps
+    /// it in the address bar - so different tabs can work on different sites, and
+    /// alert "View" links land on their originating site without affecting other tabs.
     /// </summary>
     public const string SiteQueryParam = "site";
 
@@ -68,13 +75,91 @@ public class SiteContextService : IAlertSiteScope
         (slug == SiteManagementService.DefaultSiteSlug ||
          (StringUtilities.IsSlug(slug) && File.Exists(_dbPaths.GetSiteDbPath(slug, isDefault: false))));
 
+    /// <summary>
+    /// Pins this scope to the site carried in the given URL's ?site= parameter, if
+    /// present and selectable. Called by the interactive root component before any
+    /// other scoped service resolves the site, so a Blazor circuit follows its own
+    /// tab's URL rather than the shared browser cookie (the circuit's WebSocket
+    /// upgrade request carries only the cookie).
+    /// </summary>
+    public void PinFromUri(string uri)
+    {
+        var slug = GetSiteParam(uri);
+        if (slug != null && IsSelectableSite(slug))
+            _slug = slug;
+    }
+
+    /// <summary>
+    /// Returns the URL with its ?site= parameter set to the given slug (replacing any
+    /// existing value, preserving other query parameters). Full-page navigations must
+    /// stamp their target through this so a pinned tab keeps its site across the reload.
+    /// </summary>
+    public static string WithSiteParam(string url, string slug)
+    {
+        var fragment = "";
+        var fragmentAt = url.IndexOf('#');
+        if (fragmentAt >= 0)
+        {
+            fragment = url[fragmentAt..];
+            url = url[..fragmentAt];
+        }
+
+        var stripped = RemoveSiteParam(url);
+        var separator = stripped.Contains('?') ? '&' : '?';
+        return $"{stripped}{separator}{SiteQueryParam}={Uri.EscapeDataString(slug)}{fragment}";
+    }
+
+    /// <summary>Returns the URL with any ?site= parameter removed, other parameters and fragment intact.</summary>
+    public static string RemoveSiteParam(string url)
+    {
+        var fragment = "";
+        var fragmentAt = url.IndexOf('#');
+        if (fragmentAt >= 0)
+        {
+            fragment = url[fragmentAt..];
+            url = url[..fragmentAt];
+        }
+
+        var queryAt = url.IndexOf('?');
+        if (queryAt < 0)
+            return url + fragment;
+
+        var kept = url[(queryAt + 1)..]
+            .Split('&', StringSplitOptions.RemoveEmptyEntries)
+            .Where(p => !p.Equals(SiteQueryParam, StringComparison.OrdinalIgnoreCase)
+                     && !p.StartsWith(SiteQueryParam + "=", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        var basePart = url[..queryAt];
+        return (kept.Count > 0 ? $"{basePart}?{string.Join('&', kept)}" : basePart) + fragment;
+    }
+
+    private static string? GetSiteParam(string uri)
+    {
+        var queryAt = uri.IndexOf('?');
+        if (queryAt < 0)
+            return null;
+
+        var query = uri[(queryAt + 1)..];
+        var fragmentAt = query.IndexOf('#');
+        if (fragmentAt >= 0)
+            query = query[..fragmentAt];
+
+        var value = query
+            .Split('&', StringSplitOptions.RemoveEmptyEntries)
+            .Where(p => p.StartsWith(SiteQueryParam + "=", StringComparison.OrdinalIgnoreCase))
+            .Select(p => Uri.UnescapeDataString(p[(SiteQueryParam.Length + 1)..]))
+            .FirstOrDefault();
+        return string.IsNullOrEmpty(value) ? null : value;
+    }
+
     private string Resolve()
     {
         var request = _httpContextAccessor.HttpContext?.Request;
 
-        // A ?site= query param (an alert "View" link) wins over the cookie so the linked
-        // page renders the correct site on first paint, before the selection middleware's
-        // cookie takes effect on subsequent requests. An invalid value falls through.
+        // A ?site= query param (a tab pin or an alert "View" link) wins over the cookie
+        // so the page renders the correct site on first paint and API requests resolve
+        // the site of the tab that issued them. An invalid value falls through.
         var queryParam = request?.Query[SiteQueryParam].ToString();
         if (!string.IsNullOrEmpty(queryParam) && IsSelectableSite(queryParam))
             return queryParam;

--- a/src/NetworkOptimizer.Web/Services/SiteContextService.cs
+++ b/src/NetworkOptimizer.Web/Services/SiteContextService.cs
@@ -60,6 +60,16 @@ public class SiteContextService : IAlertSiteScope
     /// <summary>True when this scope operates on the default site (the main database).</summary>
     public bool IsDefault => Slug == SiteManagementService.DefaultSiteSlug;
 
+    /// <summary>
+    /// Scopes a browser-persistence key (localStorage) to the current site so
+    /// per-site view state - the 3D/2D LAN flow map camera, overlays, scrub
+    /// span - never collides across sites. The default site keeps the bare key
+    /// unchanged so existing saved state (and single-site installs) carry over;
+    /// other sites get a "{slug}:" prefix.
+    /// </summary>
+    public string ScopeStorageKey(string baseKey) =>
+        IsDefault ? baseKey : $"{Slug}:{baseKey}";
+
     /// <summary>SQLite database path for the current site.</summary>
     public string DbPath => _dbPaths.GetSiteDbPath(Slug, IsDefault);
 

--- a/src/NetworkOptimizer.Web/Services/SiteSwitchService.cs
+++ b/src/NetworkOptimizer.Web/Services/SiteSwitchService.cs
@@ -1,0 +1,59 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Shared site-switch navigation for the interactive UI. An explicit switch writes
+/// the site cookie (the browser-wide default for URLs without a ?site= selector)
+/// and reloads with ?site= stamped on the target, so the switching tab is pinned to
+/// the chosen site while other tabs keep theirs.
+/// </summary>
+public class SiteSwitchService
+{
+    private readonly IJSRuntime _js;
+    private readonly NavigationManager _navigation;
+    private readonly SiteContextService _siteContext;
+    private readonly SiteManagementService _siteManagement;
+
+    public SiteSwitchService(
+        IJSRuntime js,
+        NavigationManager navigation,
+        SiteContextService siteContext,
+        SiteManagementService siteManagement)
+    {
+        _js = js;
+        _navigation = navigation;
+        _siteContext = siteContext;
+        _siteManagement = siteManagement;
+    }
+
+    /// <summary>
+    /// Makes the given site this browser's default and reloads the tab onto it.
+    /// Site context is scoped per circuit, so a full reload is required for every
+    /// scoped service to resolve against the new site's database.
+    /// </summary>
+    /// <param name="slug">Slug of the site to switch to.</param>
+    /// <param name="targetUrl">
+    /// Page to land on, defaulting to the current URL. Any #fragment is preserved so
+    /// switching sites from an anchored spot (e.g. a highlighted setting) lands on the
+    /// same spot on the new site; the changed ?site= query guarantees the full reload.
+    /// </param>
+    public async Task SwitchToAsync(string slug, string? targetUrl = null)
+    {
+        await _js.InvokeVoidAsync("eval",
+            $"document.cookie = '{SiteContextService.CookieName}={slug}; path=/; max-age=31536000; SameSite=Lax'");
+
+        _navigation.NavigateTo(SiteContextService.WithSiteParam(targetUrl ?? _navigation.Uri, slug), forceLoad: true);
+    }
+
+    /// <summary>
+    /// Stamps the current site onto a full-page navigation target so a pinned tab
+    /// keeps its site across the reload. Returns the URL unchanged when multi-site
+    /// is disabled, keeping single-site URLs clean.
+    /// </summary>
+    public async Task<string> StampSiteAsync(string url) =>
+        await _siteManagement.IsMultiSiteEnabledAsync()
+            ? SiteContextService.WithSiteParam(url, _siteContext.Slug)
+            : url;
+}

--- a/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
@@ -180,6 +180,22 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     }
 
     /// <summary>
+    /// Whether this site's agent tunnel is registered AND alive (not silent past
+    /// the stale threshold). A black-holed tunnel stays registered until the 90s
+    /// watchdog reaps it, so <see cref="IsAgentOnline"/> reads stale-true for
+    /// that whole window - long enough for WaitForConnectionAsync to poll its
+    /// full timeout on every page load of the site (twice per page with
+    /// prerender), which is what made switching to an outaged site take ~10s+
+    /// while a known-offline site was instant. Connect/wait decisions must use
+    /// THIS; registration alone is only meaningful for teardown bookkeeping.
+    /// </summary>
+    private bool HasLiveAgentTunnel()
+    {
+        var registry = _serviceProvider.GetService<AgentTunnelRegistry>();
+        return registry != null && registry.GetForSite(SiteSlug).Any(a => !a.IsStale);
+    }
+
+    /// <summary>
     /// Called when this site's agent tunnel drops. When the console is reached
     /// through that tunnel, flip straight to the awaiting-agent state: the client
     /// stays "connected" otherwise, and every console call dials the dead loopback
@@ -208,6 +224,60 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
         _awaitingAgent = true;
         _lastError = AwaitingAgentMessage;
         OnConnectionChanged?.Invoke();
+    }
+
+    /// <summary>
+    /// Called the moment this site's agent tunnel is known black-holed - a proxy
+    /// open timed out, an open was refused for staleness, or the tunnel watchdog
+    /// saw it silent past the stale threshold - while the agent is still
+    /// registered, so the 90s server watchdog (which drives
+    /// <see cref="OnAgentTunnelDroppedAsync"/>) hasn't fired. Flips the console to
+    /// awaiting-agent NOW so its calls short-circuit at the IsConnected guard
+    /// instead of each dialing the dead loopback proxy and paying the retry
+    /// backoff - which read as a multi-second site switch for up to 90s. Unlike
+    /// OnAgentTunnelDroppedAsync it does NOT bail while the agent is still
+    /// registered, because the tunnel is proven dead regardless. Idempotent; the
+    /// agent-connected hook (on reconnect or the periodic refresh) re-establishes
+    /// the console when the tunnel returns.
+    /// </summary>
+    public async Task NoteTunnelUnreachableAsync()
+    {
+        if (!_isConnected && _client == null) return; // already down / awaiting - idempotent
+        if (!await IsConsoleViaAgentAsync()) return;   // only agent-routed consoles ride the tunnel
+        _logger.LogInformation(
+            "Site {Slug}'s agent tunnel is unreachable; flipping its console to awaiting-agent ahead of the watchdog", SiteSlug);
+        _client?.Dispose();
+        _client = null;
+        _isConnected = false;
+        _awaitingAgent = true;
+        _lastError = AwaitingAgentMessage;
+        OnConnectionChanged?.Invoke();
+    }
+
+    /// <summary>
+    /// Called after a connect attempt fails. When the console is agent-routed and
+    /// the tunnel itself is suspect (absent, stale, or open-breaker tripped), the
+    /// failure is a dead-tunnel symptom: the loopback proxy dial collapses
+    /// mid-TLS and parses as an "SSL certificate error" with advice the user
+    /// can't act on (proxied connections can't cert-match 127.0.0.1). Land in
+    /// awaiting-agent instead, so the banner tells the truth from the first
+    /// moment rather than flashing a bogus SSL error until the flip corrects it.
+    /// A genuine console-side failure over a HEALTHY tunnel keeps its real error.
+    /// </summary>
+    private async Task PreferAwaitingAgentOnDeadTunnelAsync()
+    {
+        try
+        {
+            if (!await IsConsoleViaAgentAsync()) return;
+            var proxy = _serviceProvider.GetService<AgentTunnelProxyService>();
+            if (proxy == null || !proxy.IsTunnelSuspect(SiteSlug)) return;
+            _awaitingAgent = true;
+            _lastError = AwaitingAgentMessage;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Dead-tunnel error remap failed for site {Slug}", SiteSlug);
+        }
     }
 
     /// <summary>
@@ -284,11 +354,11 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
                         await Task.Delay(1000);
 
                     // If this site's console is reached through its agent tunnel and no
-                    // agent has connected yet, defer: dialing the loopback proxy with no
-                    // agent behind it fails with a spurious SSL/EOF error on the dashboard.
+                    // live agent has connected yet, defer: dialing the loopback proxy with
+                    // no agent behind it fails with a spurious SSL/EOF error on the dashboard.
                     // OnAgentConnectedAsync establishes the console connection as soon as
                     // the tunnel comes up (often 20-30s after startup).
-                    if (await IsConsoleViaAgentAsync() && !IsAgentOnline())
+                    if (await IsConsoleViaAgentAsync() && !HasLiveAgentTunnel())
                     {
                         _awaitingAgent = true;
                         _lastError = AwaitingAgentMessage;
@@ -472,11 +542,12 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
 
             // Create new client
             var viaAgent = await IsConsoleViaAgentAsync();
-            if (viaAgent && !IsAgentOnline())
+            if (viaAgent && !HasLiveAgentTunnel())
             {
-                // Reached through the agent tunnel, which isn't up. Dialing the loopback
-                // proxy now fails with an SSL/EOF error that gets misreported as a
-                // certificate problem, so surface the real reason.
+                // Reached through the agent tunnel, which isn't up - or is
+                // dead-but-registered (black-holed). Dialing the loopback proxy now
+                // fails with an SSL/EOF error that gets misreported as a certificate
+                // problem, so surface the real reason.
                 _awaitingAgent = true;
                 _lastError = AwaitingAgentMessage;
                 return false;
@@ -537,6 +608,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
                 _logger.LogWarning("Failed to authenticate with UniFi controller");
                 _client.Dispose();
                 _client = null;
+                await PreferAwaitingAgentOnDeadTunnelAsync();
                 return false;
             }
         }
@@ -546,6 +618,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
             _logger.LogError(ex, "Error connecting to UniFi controller");
             _client?.Dispose();
             _client = null;
+            await PreferAwaitingAgentOnDeadTunnelAsync();
             return false;
         }
     }
@@ -597,11 +670,12 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
 
             // Create new client
             var viaAgent = await IsConsoleViaAgentAsync();
-            if (viaAgent && !IsAgentOnline())
+            if (viaAgent && !HasLiveAgentTunnel())
             {
-                // Reached through the agent tunnel, which isn't up. Dialing the loopback
-                // proxy now fails with an SSL/EOF error that gets misreported as a
-                // certificate problem, so surface the real reason.
+                // Reached through the agent tunnel, which isn't up - or is
+                // dead-but-registered (black-holed). Dialing the loopback proxy now
+                // fails with an SSL/EOF error that gets misreported as a certificate
+                // problem, so surface the real reason.
                 _awaitingAgent = true;
                 _lastError = AwaitingAgentMessage;
                 return false;
@@ -673,6 +747,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
                 _lastError = _client.LastLoginError ?? defaultError;
                 _client.Dispose();
                 _client = null;
+                await PreferAwaitingAgentOnDeadTunnelAsync();
                 return false;
             }
         }
@@ -682,6 +757,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
             _logger.LogWarning("Startup auto-connect timed out - console unreachable");
             _client?.Dispose();
             _client = null;
+            await PreferAwaitingAgentOnDeadTunnelAsync();
             return false;
         }
         catch (Exception ex)
@@ -690,6 +766,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
             _logger.LogError(ex, "Error connecting to UniFi controller");
             _client?.Dispose();
             _client = null;
+            await PreferAwaitingAgentOnDeadTunnelAsync();
             return false;
         }
     }
@@ -807,11 +884,12 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
         try
         {
             var viaAgent = await IsConsoleViaAgentAsync();
-            if (viaAgent && !IsAgentOnline())
+            if (viaAgent && !HasLiveAgentTunnel())
             {
-                // The console is reached through the agent tunnel, which isn't up. Dialing
-                // the loopback proxy now fails with an SSL/EOF error that gets misreported
-                // as a certificate problem, so return the real reason instead.
+                // The console is reached through the agent tunnel, which isn't up (or is
+                // dead-but-registered). Dialing the loopback proxy now fails with an
+                // SSL/EOF error that gets misreported as a certificate problem, so
+                // return the real reason instead.
                 return (false,
                     "This site's console is reached through its on-site agent tunnel, which isn't connected yet. Start the site's agent (or wait for it to come online), then test again.",
                     null);
@@ -980,6 +1058,12 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
         // If already connected, return immediately
         if (IsConnected) return true;
 
+        // Already flipped to awaiting-agent (tunnel down or proven black-holed):
+        // no poll can succeed until the agent reconnects, and pages reload via
+        // OnConnectionChanged when it does. Waiting here would stall every page
+        // render of the site for the full timeout.
+        if (IsAwaitingAgent) return false;
+
         // Check if we have saved credentials to connect with
         var settings = await GetSettingsAsync();
         if (!settings.IsConfigured || !settings.HasCredentials || !settings.RememberCredentials)
@@ -988,12 +1072,13 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
             return false;
         }
 
-        // If this site's console is reached through an agent tunnel that isn't up yet, don't
-        // block: the console connects asynchronously once the agent comes online
+        // If this site's console is reached through an agent tunnel that isn't up - or is
+        // dead-but-registered (black-holed, silent past the stale threshold) - don't block:
+        // the console connects asynchronously once the agent (re)connects
         // (OnAgentConnectedAsync), and pages reload via OnConnectionChanged. Polling the full
         // timeout here would stall the page render on every agent-site load or switch, which
         // is the single biggest cause of "the page takes forever to appear" on those sites.
-        if (await IsConsoleViaAgentAsync() && !IsAgentOnline())
+        if (await IsConsoleViaAgentAsync() && !HasLiveAgentTunnel())
             return false;
 
         var startTime = DateTime.UtcNow;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -436,10 +436,12 @@ h1:focus {
 
 .wan-live-chart-card {
     margin-bottom: 0;
+    overflow: visible;
 }
 .wan-live-chart-card > .card-body {
     padding: 0 0 0.3rem;
     margin-right: -0.75rem;
+    overflow: visible;
 }
 .wan-live-chart-card .apexcharts-canvas {
     min-height: 0;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -353,6 +353,19 @@ a:hover {
     font-weight: 600;
     letter-spacing: -0.015em;
     margin-bottom: 4px;
+    display: flex;
+    align-items: center;
+}
+
+.page-header-suffix {
+    margin-left: 0.75rem;
+    font-size: 1.1rem;
+    font-weight: 400;
+    color: var(--text-muted);
+}
+
+h1:focus {
+    outline: none;
 }
 
 .page-header-actions {
@@ -17517,10 +17530,13 @@ body.kiosk-mode .status-indicators {
 }
 
 .site-card {
+    display: block;
     padding: 1rem;
     cursor: pointer;
     border: 1px solid transparent;
     margin-bottom: 0;
+    color: var(--text-primary);
+    text-decoration: none;
     transition: background 0.15s, border-color 0.15s;
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -3176,6 +3176,16 @@ select.form-control {
 
 /* Responsive Design */
 @media (max-width: 1024px) {
+    /* Lock the viewport so only .main-content scrolls - iOS can otherwise scroll
+       the body (esp. on return from background), swallowing touch gestures.
+       overflow:hidden only (no position:fixed, which disturbs the dynamic-viewport
+       behavior the sticky top-bar hide rides on). Scoped to the app shell so the
+       login page can still scroll. */
+    html:has(.app-container),
+    body:has(.app-container) {
+        overflow: hidden;
+    }
+
     .content-grid {
         grid-template-columns: 1fr;
     }
@@ -3261,12 +3271,20 @@ select.form-control {
         height: auto;
         padding: 0.75rem 1rem;
         gap: 0.5rem;
-        transition: top 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+        /* Base transition governs the reveal (returning to this state) - slower */
+        transition: transform 0.6s cubic-bezier(0.4, 0, 0.2, 1);
     }
 
+    /* Slide up by exactly the bar's own height (translateY %) so the full
+       transition is spent moving one bar-height - a gradual slide, not the
+       instant snap that top:-100% produced (that % resolves against the tall
+       scroll container, so the bar cleared the screen in a few ms).
+       Transition here governs the hide (entering this state) - kept quicker. */
     .top-bar.top-bar-hidden {
         position: sticky;
-        top: -100%;
+        top: 0;
+        transform: translateY(-100%);
+        transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
         pointer-events: none;
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -911,7 +911,8 @@ class LanFlowMap2D {
         if(!d.ip)return;
         // Wi-Fi clients land on the Signal tab; wired clients go to the default tab.
         const tab=d.kind===NK.WifiClient?'&tab=signal':'';
-        window.location.href=`/client-dashboard?ip=${encodeURIComponent(d.ip)}${tab}`;
+        const url=`/client-dashboard?ip=${encodeURIComponent(d.ip)}${tab}`;
+        window.location.href=window.noSiteContext?window.noSiteContext.stampUrl(url):url;
     }
 
     _hitTest(sx,sy){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -781,11 +781,21 @@ class LanFlowMap2D {
         if(!this._root)return;
         this._calcBounds(true);
         const margin=10;
+        // On desktop the scrubber bar overlays the bottom of the stage (on mobile
+        // it's moved below the stage, so no overlap - no inset there). Reserve just
+        // the bar's height plus a few px so the bottom row sits right above it,
+        // without the wasteful gap a full extra margin would leave.
+        const overlays=this._scrubberEl&&this._scrubberEl.parentElement===this._el;
+        const topPad=margin;
+        const bottomPad=overlays?(this._scrubberEl.offsetHeight+4):margin;
+        const availH=Math.max(1,this._ch-topPad-bottomPad);
         const sx=(this._cw-margin*2)/this._bw;
-        const sy=(this._ch-margin*2)/this._bh;
+        const sy=availH/this._bh;
         this._scale=Math.min(sx,sy,2);
         this._ox=this._bx+this._bw/2;
-        this._oy=this._by+this._bh/2;
+        // Center within the [top .. just above the bar] band rather than the raw
+        // canvas, lifting the content clear of the scrubber bar.
+        this._oy=this._by+this._bh/2+(bottomPad-topPad)/(2*this._scale);
         this._isFitted=true;
         this._needsStaticRedraw=true;
     }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -3099,7 +3099,8 @@ export class LanFlowMap {
         // Wi-Fi clients land on the Signal tab; wired clients have no signal data,
         // so they go to the default tab.
         const tab = node.kind === NODE_KIND.WifiClient ? '&tab=signal' : '';
-        window.location.href = `/client-dashboard?ip=${encodeURIComponent(ip)}${tab}`;
+        const url = `/client-dashboard?ip=${encodeURIComponent(ip)}${tab}`;
+        window.location.href = window.noSiteContext ? window.noSiteContext.stampUrl(url) : url;
     }
 
     _showHover(node) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -277,6 +277,34 @@ function updateChartVisibility() {
     });
 }
 
+// Mean loss (%) over the visible window at or above which a LAN fabric target is treated as
+// flaky enough to advise pausing. Deliberately low: any sustained loss to a LAN device is
+// abnormal, so even a fraction of a percent is worth flagging as a poor measurement target.
+const LAN_FLAKY_LOSS_PCT = 0.5;
+
+// Report the current LAN (Fabric) category's flaky targets to Blazor so it can render the
+// "flaky LAN target" advisory. Detection only; the role/dismissed gating and the notice itself
+// live in Blazor (Monitoring.razor), which has the target metadata. Entirely best-effort:
+// wrapped so a failure here can never disturb chart rendering, and a no-op until Blazor has
+// handed us its DotNet reference via window.__netoptLatencyRef.
+function notifyLanFlakyHints(data) {
+    try {
+        const ref = window.__netoptLatencyRef;
+        if (!ref) return;
+        let ids = [];
+        if (currentCategory === 'Fabric' && data && Array.isArray(data.targets)) {
+            ids = data.targets.filter(t => {
+                const vals = (t.loss || []).map(p => p.value).filter(v => v != null);
+                if (!vals.length) return false;
+                const mean = vals.reduce((a, b) => a + b, 0) / vals.length;
+                return mean >= LAN_FLAKY_LOSS_PCT;
+            }).map(t => t.targetId);
+        }
+        // Fire-and-forget; swallow rejection if the Blazor circuit is already gone.
+        Promise.resolve(ref.invokeMethodAsync('SetLanFlakyHints', currentCategory, ids)).catch(() => { });
+    } catch { }
+}
+
 async function loadAndUpdate() {
     const data = await fetchData();
     if (!data || !data.targets) return;
@@ -315,6 +343,8 @@ async function loadAndUpdate() {
         renderBadges(container);
         renderStatsTable(container);
     }
+
+    notifyLanFlakyHints(data);
 
     // WAN rate chart - show for non-Fabric categories
     const showWanRate = currentCategory !== 'Fabric';

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -1,0 +1,130 @@
+// Per-tab site context (multi-site). The server pins each Blazor circuit to the
+// site in the tab's ?site= query parameter; this file keeps that selector alive
+// on the browser side of the tab:
+//  - noSiteContext.ensureSiteParam(slug), called by SiteTabSync (multi-site only)
+//    after every in-app navigation, re-stamps ?site= into the address bar via
+//    history.replaceState and remembers the slug in per-tab sessionStorage so
+//    refresh / duplicate-tab / reconnect reloads stay on this tab's site.
+//  - a fetch wrapper and an anchor-click handler stamp the tab's site onto
+//    same-origin /api/ requests (charts, PDF downloads, logout) so API endpoints
+//    resolve the same site as the page issuing them.
+//  - noSiteContext.stampUrl(url) is for scripts that trigger full-page
+//    navigations themselves (e.g. the LAN flow maps) so those keep the pin too.
+//  - a load-time backstop: if a navigation dropped ?site= (a spot that forgot to
+//    stamp it), restore this tab's remembered site with a one-shot redirect
+//    instead of silently falling back to the browser-default cookie.
+//
+// Single-site safety: sessionStorage is written ONLY by ensureSiteParam, which
+// only runs when multi-site is enabled. So on a single-site instance nothing is
+// ever remembered, the backstop never fires, and every path below (all guarded
+// on a truthy slug) is a no-op.
+(function () {
+    const STORAGE_KEY = 'no-site-tab';
+
+    function remembered() {
+        try { return sessionStorage.getItem(STORAGE_KEY) || ''; } catch (e) { return ''; }
+    }
+    function remember(s) {
+        try { if (s) sessionStorage.setItem(STORAGE_KEY, s); } catch (e) { }
+    }
+    function cookieSite() {
+        const m = document.cookie.match(/(?:^|; )no-site=([^;]*)/);
+        return m ? decodeURIComponent(m[1]) : (window.__noSiteDefault || '');
+    }
+
+    let slug = new URLSearchParams(window.location.search).get('site');
+
+    // Backstop (see header). A navigation with no ?site= would resolve the
+    // browser-default cookie server-side; if this tab is pinned to a different
+    // site, restore it. Only fires when a site was remembered (so never on
+    // single-site) and it differs from the default, so default-site tabs never
+    // pay a reload; the redirect target carries ?site= so it can never loop.
+    if (!slug) {
+        const want = remembered();
+        if (want && want !== cookieSite()) {
+            const url = new URL(window.location.href);
+            url.searchParams.set('site', want);
+            window.location.replace(url.href);
+            return;
+        }
+    }
+
+    function stamp(rawUrl) {
+        if (!slug)
+            return rawUrl;
+        try {
+            const url = new URL(rawUrl, window.location.origin);
+            if (url.origin !== window.location.origin || url.searchParams.has('site'))
+                return rawUrl;
+            url.searchParams.set('site', slug);
+            return typeof rawUrl === 'string' && !rawUrl.startsWith(url.origin)
+                ? url.pathname + url.search + url.hash
+                : url.href;
+        } catch (e) {
+            return rawUrl;
+        }
+    }
+
+    window.noSiteContext = {
+        ensureSiteParam: function (s) {
+            slug = s;
+            remember(s);
+            const url = new URL(window.location.href);
+            if (url.searchParams.get('site') === s)
+                return;
+            url.searchParams.set('site', s);
+            history.replaceState(history.state, '', url);
+        },
+        stampUrl: stamp
+    };
+
+    // Anchors to /api/ (PDF download, logout) bypass both Blazor and fetch - the
+    // browser issues a plain document request. Rewrite the href at click time so
+    // the request carries the tab's site.
+    document.addEventListener('click', function (e) {
+        if (!slug)
+            return;
+        const link = e.target.closest && e.target.closest('a[href]');
+        if (!link || link.origin !== window.location.origin || !link.pathname.startsWith('/api/'))
+            return;
+        link.href = stamp(link.href);
+    }, true);
+
+    // Site-switch links (the header dropdown and the /sites cards). A plain left
+    // click switches this tab and makes the site the browser default; ctrl / cmd /
+    // shift / middle clicks fall through to the browser so the link's ?site= href
+    // opens in a new tab - pinning that tab without touching this one or the default.
+    // Handled here rather than with a Blazor @onclick so a modified click's native
+    // new-tab is never preventDefaulted, and so the switch stays a plain document
+    // navigation (window.open from a Blazor Server handler would be popup-blocked).
+    document.addEventListener('click', function (e) {
+        if (e.defaultPrevented || e.button !== 0 || e.ctrlKey || e.metaKey || e.shiftKey || e.altKey)
+            return;
+        const link = e.target.closest && e.target.closest('a[data-site-switch]');
+        if (!link)
+            return;
+        e.preventDefault();
+        if (link.hasAttribute('data-site-current'))
+            return;
+        const target = link.getAttribute('data-site-switch');
+        document.cookie = 'no-site=' + target + '; path=/; max-age=31536000; SameSite=Lax';
+        window.location.assign(link.href);
+    }, false);
+
+    const originalFetch = window.fetch;
+    window.fetch = function (input, init) {
+        try {
+            if (slug) {
+                const raw = typeof input === 'string' ? input : (input instanceof URL ? input.href : null);
+                if (raw !== null) {
+                    const url = new URL(raw, window.location.origin);
+                    if (url.origin === window.location.origin && url.pathname.startsWith('/api/'))
+                        input = typeof input === 'string' ? stamp(raw) : new URL(stamp(url.href));
+                }
+            }
+        } catch (e) {
+            // Malformed input: let the original fetch produce the real error.
+        }
+        return originalFetch.call(this, input, init);
+    };
+})();

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -11,6 +11,13 @@ const POLL_MS = 2500;
 // Window-scroll redraw cadence. At 250ms each step moves well under a pixel
 // on typical widths, so the chart slides instead of visibly ticking.
 const SCROLL_MS = 250;
+// Occasionally re-pull the whole history window and merge it back in, so gaps
+// that filled AFTER the live buffer scrolled past them appear without a manual
+// refresh: a monitoring outage whose buffered samples replayed into Influx on
+// reconnect, or the cold-start gap before data first flowed. Live mode +
+// foreground only, and the newest live samples are kept, so the smooth edge
+// never regresses.
+const BACKFILL_MS = 60000;
 const COLOR_DL   = '#3b82f6';
 const COLOR_UL   = '#10b981';
 const COLOR_LOSS = '#ef4444';
@@ -19,6 +26,7 @@ const COLOR_RTT  = '#d946ef';
 let chart = null;
 let pollTimer = null;
 let scrollTimer = null;
+let backfillTimer = null;
 let buffer = [];
 let elId = null;
 let visHandler = null;
@@ -294,6 +302,43 @@ async function pollLive() {
     } catch { }
 }
 
+// Re-pull the full history window and merge it back over the buffer so gaps that
+// filled in after the buffer scrolled past them (outage backlog replay, cold
+// start) show up. Live mode + foreground only. The newest live samples - which
+// can be ahead of Influx ingestion - are kept ahead of the re-pulled history so
+// the live edge never flickers back.
+async function backfillHistory() {
+    if (!chart || !pollTimer || document.hidden) return;
+    const gen = mountGen;
+    const to = new Date();
+    const from = new Date(to.getTime() - HISTORY_MINUTES * 60000);
+    let points;
+    try {
+        const resp = await fetch(
+            `/api/monitoring/wan-live-chart-data?from=${from.toISOString()}&to=${to.toISOString()}`,
+            { credentials: 'same-origin' });
+        if (!resp.ok) return;
+        const data = await resp.json();
+        points = (data.points || []).map(p => ({
+            time: new Date(p.time).getTime(),
+            download: p.downloadBps,
+            upload: p.uploadBps,
+            rtt: p.rttMs,
+            loss: p.lossPercent ?? 0,
+        }));
+    } catch { return; }
+    // Bail if the mount changed or we left live mode while fetching.
+    if (gen !== mountGen || !pollTimer) return;
+    const newestHist = points.length ? points[points.length - 1].time : 0;
+    const liveTail = buffer.filter(p => p.time > newestHist);
+    const cutoff = Date.now() - HISTORY_MINUTES * 60000;
+    buffer = points.concat(liveTail).filter(p => p.time >= cutoff).sort((a, b) => a.time - b.time);
+    for (const p of buffer) {
+        if (p.time > lastSampleTime) lastSampleTime = p.time;
+    }
+    updateChart();
+}
+
 export async function mount(containerId, opts) {
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
@@ -318,6 +363,7 @@ export async function mount(containerId, opts) {
 
     pollTimer = setInterval(pollLive, interval);
     scrollTimer = setInterval(updateChart, SCROLL_MS);
+    backfillTimer = setInterval(backfillHistory, BACKFILL_MS);
 
     if (visHandler) document.removeEventListener('visibilitychange', visHandler);
     visHandler = async () => {
@@ -333,12 +379,14 @@ export function pause() {
     stopHistInterpolation();
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
+    if (backfillTimer) { clearInterval(backfillTimer); backfillTimer = null; }
 }
 
 export function resume() {
     if (!chart || pollTimer) return;
     pollTimer = setInterval(pollLive, POLL_MS);
     scrollTimer = setInterval(updateChart, SCROLL_MS);
+    backfillTimer = setInterval(backfillHistory, BACKFILL_MS);
 }
 
 // Render the historic view at a given playhead time from the current buffer.
@@ -407,11 +455,13 @@ export async function seekTime(isoTimestamp) {
         updateChart();
         pollTimer = setInterval(pollLive, POLL_MS);
         scrollTimer = setInterval(updateChart, SCROLL_MS);
+        backfillTimer = setInterval(backfillHistory, BACKFILL_MS);
         return;
     }
     // Historic mode: stop polling, fetch window centered on timestamp
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
+    if (backfillTimer) { clearInterval(backfillTimer); backfillTimer = null; }
     const at = new Date(isoTimestamp).getTime();
     histAt = at;
     histWall = Date.now();
@@ -461,6 +511,7 @@ export function unmount() {
     stopHistInterpolation();
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
+    if (backfillTimer) { clearInterval(backfillTimer); backfillTimer = null; }
     if (visHandler) { document.removeEventListener('visibilitychange', visHandler); visHandler = null; }
     if (chart) { chart.destroy(); chart = null; }
     buffer = [];

--- a/tests/NetworkOptimizer.AgentProtocol.Tests/NetworkOptimizer.AgentProtocol.Tests.csproj
+++ b/tests/NetworkOptimizer.AgentProtocol.Tests/NetworkOptimizer.AgentProtocol.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NetworkOptimizer.AgentProtocol\NetworkOptimizer.AgentProtocol.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/NetworkOptimizer.AgentProtocol.Tests/ResultBufferTests.cs
+++ b/tests/NetworkOptimizer.AgentProtocol.Tests/ResultBufferTests.cs
@@ -1,0 +1,268 @@
+using FluentAssertions;
+using Xunit;
+
+namespace NetworkOptimizer.AgentProtocol.Tests;
+
+public class ResultBufferTests
+{
+    private static AgentMessage ProbeMessage(string targetId, long timestampMs = 1000) => new()
+    {
+        ProbeResults = new ProbeResultBatch
+        {
+            Results =
+            {
+                new ProbeResult
+                {
+                    TargetId = targetId,
+                    TimestampUnixMs = timestampMs,
+                    Success = true,
+                    Sent = 5,
+                    Received = 5,
+                }
+            }
+        }
+    };
+
+    private static AgentMessage SnmpMessage(string deviceMac) => new()
+    {
+        SnmpResults = new SnmpResultBatch
+        {
+            Interfaces =
+            {
+                new SnmpInterfaceSample
+                {
+                    DeviceMac = deviceMac,
+                    IfName = "eth0",
+                    InOctets = 123456,
+                    OutOctets = 654321,
+                    TimestampUnixMs = 1000,
+                }
+            }
+        }
+    };
+
+    // Peek the oldest single frame (maxSamples: 1 disables coalescing) and ack it,
+    // mirroring a consumer that confirms each message - the ack-era stand-in for
+    // the old remove-on-dequeue.
+    private static async Task<AgentMessage> NextAsync(ResultBuffer buffer, CancellationToken ct = default)
+    {
+        var frame = await buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 1, ct);
+        buffer.MarkAcked(frame.ThroughSeq);
+        return frame.Message;
+    }
+
+    [Fact]
+    public async Task ReplaysInFifoOrder()
+    {
+        var buffer = new ResultBuffer();
+        buffer.Enqueue(ProbeMessage("a"));
+        buffer.Enqueue(SnmpMessage("aa:bb:cc:dd:ee:ff"));
+        buffer.Enqueue(ProbeMessage("b"));
+
+        (await NextAsync(buffer)).ProbeResults.Results[0].TargetId.Should().Be("a");
+        (await NextAsync(buffer)).PayloadCase.Should().Be(AgentMessage.PayloadOneofCase.SnmpResults);
+        (await NextAsync(buffer)).ProbeResults.Results[0].TargetId.Should().Be("b");
+        buffer.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task TakeWaitsForEnqueue()
+    {
+        var buffer = new ResultBuffer();
+        var take = buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 1, CancellationToken.None).AsTask();
+        take.IsCompleted.Should().BeFalse();
+
+        buffer.Enqueue(ProbeMessage("late"));
+        var frame = await take.WaitAsync(TimeSpan.FromSeconds(5));
+        frame.Message.ProbeResults.Results[0].TargetId.Should().Be("late");
+    }
+
+    [Fact]
+    public async Task TakeHonorsCancellation()
+    {
+        var buffer = new ResultBuffer();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+        var act = async () => await buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 1, cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task UnackedFramesReplayUntilAcked()
+    {
+        var buffer = new ResultBuffer();
+        buffer.Enqueue(ProbeMessage("a"));
+        buffer.Enqueue(ProbeMessage("b"));
+        buffer.Enqueue(ProbeMessage("c"));
+
+        // Drain all three without acking - as if the writes went into a black hole.
+        long cursor = 0;
+        for (var i = 0; i < 3; i++)
+        {
+            var f = await buffer.TakeUnsentBatchAsync(cursor, maxSamples: 1, CancellationToken.None);
+            cursor = f.ThroughSeq;
+        }
+        buffer.Count.Should().Be(3, "nothing was acked, so nothing is trimmed");
+
+        // A reconnect replays from the oldest unacked frame.
+        var replay = await buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 1, CancellationToken.None);
+        replay.Message.ProbeResults.Results[0].TargetId.Should().Be("a");
+
+        // Cumulative ack through the second frame trims a and b; only c remains.
+        buffer.MarkAcked(replay.ThroughSeq + 1);
+        buffer.Count.Should().Be(1);
+        (await buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 1, CancellationToken.None))
+            .Message.ProbeResults.Results[0].TargetId.Should().Be("c");
+    }
+
+    [Fact]
+    public async Task CoalesceMergesSameTypeUpToTheBoundary()
+    {
+        var buffer = new ResultBuffer();
+        buffer.Enqueue(SnmpMessage("aa:bb:cc:dd:ee:ff"));
+        buffer.Enqueue(SnmpMessage("11:22:33:44:55:66"));
+        buffer.Enqueue(ProbeMessage("behind"));
+
+        var frame = await buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 500, CancellationToken.None);
+        frame.Message.PayloadCase.Should().Be(AgentMessage.PayloadOneofCase.SnmpResults);
+        frame.Message.SnmpResults.Interfaces.Should().HaveCount(2, "consecutive SNMP batches coalesce");
+        buffer.MarkAcked(frame.ThroughSeq);
+
+        var next = await buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 500, CancellationToken.None);
+        next.Message.PayloadCase.Should().Be(AgentMessage.PayloadOneofCase.ProbeResults);
+        next.Message.ProbeResults.Results[0].TargetId.Should().Be("behind");
+    }
+
+    [Fact]
+    public async Task CoalescePeekLeavesOriginalsIntactUntilAcked()
+    {
+        var buffer = new ResultBuffer();
+        buffer.Enqueue(ProbeMessage("a"));
+        buffer.Enqueue(ProbeMessage("b"));
+
+        // Coalescing must not mutate or remove the buffered entries.
+        var frame = await buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 500, CancellationToken.None);
+        frame.Message.ProbeResults.Results.Should().HaveCount(2);
+        buffer.Count.Should().Be(2, "peek does not remove");
+
+        buffer.MarkAcked(frame.ThroughSeq);
+        buffer.Count.Should().Be(0, "the ack trims both coalesced frames");
+    }
+
+    [Fact]
+    public async Task ByteCapDropsOldestFirst()
+    {
+        var single = ProbeMessage("x").CalculateSize();
+        // Room for roughly three single-result messages.
+        var buffer = new ResultBuffer(maxBytes: single * 3 + 1);
+
+        for (var i = 0; i < 10; i++)
+            buffer.Enqueue(ProbeMessage($"t{i}"));
+
+        buffer.Count.Should().BeLessThan(10);
+        buffer.DroppedTotal.Should().Be(10 - buffer.Count);
+        buffer.ApproxBytes.Should().BeLessThanOrEqualTo(single * 3 + 1);
+
+        // The survivors are the newest, still in FIFO order. maxSamples 1 reads
+        // them one at a time.
+        var survivors = new List<int>();
+        while (buffer.Count > 0)
+        {
+            var frame = await buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 1, CancellationToken.None);
+            survivors.Add(int.Parse(frame.Message.ProbeResults.Results[0].TargetId[1..]));
+            buffer.MarkAcked(frame.ThroughSeq);
+        }
+        survivors.Should().BeInAscendingOrder();
+        survivors.Last().Should().Be(9);
+    }
+
+    [Fact]
+    public async Task AgeCapDropsExpiredEntries()
+    {
+        var buffer = new ResultBuffer(maxAge: TimeSpan.FromMilliseconds(50));
+        buffer.Enqueue(ProbeMessage("old"));
+        await Task.Delay(150);
+        buffer.Enqueue(ProbeMessage("new"));
+
+        buffer.Count.Should().Be(1);
+        buffer.DroppedTotal.Should().Be(1);
+        (await NextAsync(buffer)).ProbeResults.Results[0].TargetId.Should().Be("new");
+    }
+
+    [Fact]
+    public async Task EvictedPermitsDoNotStrandTheConsumer()
+    {
+        // Eviction removes entries without consuming semaphore permits; a consumer
+        // waking to no unsent entry must keep waiting, then still receive the next.
+        var buffer = new ResultBuffer(maxAge: TimeSpan.FromMilliseconds(50));
+        buffer.Enqueue(ProbeMessage("doomed"));
+        await Task.Delay(150);
+        buffer.Enqueue(ProbeMessage("evictor")); // evicts "doomed" on enqueue
+
+        (await NextAsync(buffer)).ProbeResults.Results[0].TargetId.Should().Be("evictor");
+
+        var pending = buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 1, CancellationToken.None).AsTask();
+        buffer.Enqueue(ProbeMessage("after"));
+        (await pending.WaitAsync(TimeSpan.FromSeconds(5)))
+            .Message.ProbeResults.Results[0].TargetId.Should().Be("after");
+    }
+
+    [Fact]
+    public void TakeDroppedCountResetsBetweenCalls()
+    {
+        var single = ProbeMessage("x").CalculateSize();
+        var buffer = new ResultBuffer(maxBytes: single);
+        buffer.Enqueue(ProbeMessage("a"));
+        buffer.Enqueue(ProbeMessage("b")); // drops "a"
+
+        buffer.TakeDroppedCount().Should().Be(1);
+        buffer.TakeDroppedCount().Should().Be(0);
+        buffer.DroppedTotal.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ByteAccountingTracksEnqueueAndAck()
+    {
+        var buffer = new ResultBuffer();
+        var message = ProbeMessage("sized");
+        buffer.Enqueue(message);
+        buffer.ApproxBytes.Should().Be(message.CalculateSize());
+
+        var frame = await buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 1, CancellationToken.None);
+        buffer.ApproxBytes.Should().Be(message.CalculateSize(), "peek does not change accounting");
+        buffer.MarkAcked(frame.ThroughSeq);
+        buffer.ApproxBytes.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ConcurrentProducersAndConsumerDeliverEverything()
+    {
+        var buffer = new ResultBuffer();
+        const int perProducer = 200;
+        var producers = Enumerable.Range(0, 4).Select(p => Task.Run(() =>
+        {
+            for (var i = 0; i < perProducer; i++)
+                buffer.Enqueue(ProbeMessage($"p{p}-{i}"));
+        })).ToArray();
+
+        var seen = new List<string>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        while (seen.Count < 4 * perProducer)
+        {
+            var frame = await buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 1, cts.Token);
+            seen.Add(frame.Message.ProbeResults.Results[0].TargetId);
+            buffer.MarkAcked(frame.ThroughSeq);
+        }
+
+        await Task.WhenAll(producers);
+        seen.Should().HaveCount(4 * perProducer);
+        seen.Should().OnlyHaveUniqueItems();
+
+        // Per-producer FIFO order survives interleaving.
+        for (var p = 0; p < 4; p++)
+        {
+            var indices = seen.Where(id => id.StartsWith($"p{p}-"))
+                .Select(id => int.Parse(id.Split('-')[1])).ToList();
+            indices.Should().BeInAscendingOrder();
+        }
+    }
+}

--- a/tests/NetworkOptimizer.Core.Tests/Helpers/NetworkUtilitiesTests.cs
+++ b/tests/NetworkOptimizer.Core.Tests/Helpers/NetworkUtilitiesTests.cs
@@ -553,4 +553,60 @@ public class NetworkUtilitiesTests
     }
 
     #endregion
+
+    #region IsRfc1918 Tests
+
+    [Theory]
+    [InlineData("10.0.0.1", true)]
+    [InlineData("10.255.255.255", true)]
+    [InlineData("172.16.0.1", true)]
+    [InlineData("172.31.255.254", true)]
+    [InlineData("192.168.0.1", true)]
+    [InlineData("192.168.255.254", true)]
+    // IPv4-mapped IPv6 forms unwrap before evaluation
+    [InlineData("::ffff:192.168.1.10", true)]
+    [InlineData("::ffff:203.0.113.5", false)]
+    // Adjacent and lookalike ranges are NOT RFC1918
+    [InlineData("9.255.255.255", false)]
+    [InlineData("11.0.0.1", false)]
+    [InlineData("172.15.255.255", false)]
+    [InlineData("172.32.0.1", false)]
+    [InlineData("192.167.1.1", false)]
+    [InlineData("192.169.1.1", false)]
+    // Private-adjacent classes IsPrivateIpAddress accepts but strict RFC1918 must not
+    [InlineData("127.0.0.1", false)]
+    [InlineData("169.254.10.10", false)]
+    [InlineData("100.64.0.1", false)]
+    [InlineData("224.0.0.1", false)]
+    [InlineData("0.0.0.0", false)]
+    // Public and IPv6
+    [InlineData("203.0.113.5", false)]
+    [InlineData("8.8.8.8", false)]
+    [InlineData("2001:db8::1", false)]
+    [InlineData("fd00::1", false)]
+    public void IsRfc1918_ClassifiesStrictly(string ip, bool expected)
+    {
+        NetworkUtilities.IsRfc1918(IPAddress.Parse(ip)).Should().Be(expected);
+    }
+
+    #endregion
+
+    #region IsIPv6UniqueLocal Tests
+
+    [Theory]
+    [InlineData("fc00::1", true)]
+    [InlineData("fd00::1", true)]
+    [InlineData("fdab:cdef::42", true)]
+    [InlineData("fbff::1", false)]
+    [InlineData("fe00::1", false)]
+    [InlineData("fe80::1", false)]
+    [InlineData("2001:db8::1", false)]
+    [InlineData("::1", false)]
+    [InlineData("192.168.1.1", false)]
+    public void IsIPv6UniqueLocal_ClassifiesFc00Slash7(string ip, bool expected)
+    {
+        NetworkUtilities.IsIPv6UniqueLocal(IPAddress.Parse(ip)).Should().Be(expected);
+    }
+
+    #endregion
 }

--- a/tests/NetworkOptimizer.Core.Tests/Helpers/ProxyDialPolicyTests.cs
+++ b/tests/NetworkOptimizer.Core.Tests/Helpers/ProxyDialPolicyTests.cs
@@ -1,0 +1,139 @@
+using System.Net;
+using FluentAssertions;
+using NetworkOptimizer.Core.Helpers;
+using Xunit;
+
+namespace NetworkOptimizer.Core.Tests.Helpers;
+
+public class ProxyDialPolicyTests
+{
+    #region Default (site-local) policy
+
+    [Theory]
+    // RFC1918
+    [InlineData("10.20.30.1", true)]
+    [InlineData("172.16.5.10", true)]
+    [InlineData("192.168.77.1", true)]
+    // IPv6 unique-local and link-local
+    [InlineData("fd00::1", true)]
+    [InlineData("fe80::1", true)]
+    // Public
+    [InlineData("203.0.113.5", false)]
+    [InlineData("8.8.8.8", false)]
+    [InlineData("2001:db8::1", false)]
+    // Loopback is not a proxy target (console/gateway/devices are never the agent itself)
+    [InlineData("127.0.0.1", false)]
+    [InlineData("::1", false)]
+    // IPv4 link-local and CGNAT: reviewed and excluded from the default fence
+    [InlineData("169.254.10.10", false)]
+    [InlineData("100.64.0.1", false)]
+    // Multicast / unspecified
+    [InlineData("224.0.0.1", false)]
+    [InlineData("0.0.0.0", false)]
+    public void SiteLocal_AllowsOnlySiteLocalAddresses(string ip, bool expected)
+    {
+        ProxyDialPolicy.SiteLocal.IsAllowed(IPAddress.Parse(ip)).Should().Be(expected);
+    }
+
+    [Fact]
+    public void SiteLocal_UnwrapsIPv4MappedIPv6()
+    {
+        // A public IPv4 must not slip through as ::ffff:a.b.c.d
+        ProxyDialPolicy.SiteLocal.IsAllowed(IPAddress.Parse("::ffff:203.0.113.5")).Should().BeFalse();
+        ProxyDialPolicy.SiteLocal.IsAllowed(IPAddress.Parse("::ffff:192.168.1.10")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void SiteLocal_IsDefault()
+    {
+        ProxyDialPolicy.SiteLocal.IsDefault.Should().BeTrue();
+        ProxyDialPolicy.SiteLocal.PinnedCount.Should().Be(0);
+    }
+
+    #endregion
+
+    #region Pinned policy
+
+    [Fact]
+    public void Pinned_ReplacesDefaultEntirely()
+    {
+        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { "10.20.30.0/24" }, out var error);
+
+        error.Should().BeNull();
+        policy.Should().NotBeNull();
+        policy!.IsDefault.Should().BeFalse();
+        policy.IsAllowed(IPAddress.Parse("10.20.30.1")).Should().BeTrue();
+        policy.IsAllowed(IPAddress.Parse("10.20.30.200")).Should().BeTrue();
+        // Site-local but outside the pin: denied (replace, not extend)
+        policy.IsAllowed(IPAddress.Parse("10.10.2.1")).Should().BeFalse();
+        policy.IsAllowed(IPAddress.Parse("192.168.1.1")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Pinned_CanAdmitPublicTargets()
+    {
+        // The operator escape hatch for an exotic public-IP custom target
+        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { "192.168.77.0/24", "203.0.113.5" }, out _);
+
+        policy!.IsAllowed(IPAddress.Parse("203.0.113.5")).Should().BeTrue();
+        policy.IsAllowed(IPAddress.Parse("203.0.113.6")).Should().BeFalse();
+        policy.IsAllowed(IPAddress.Parse("192.168.77.1")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Pinned_BareIpsBecomeExactMatches()
+    {
+        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { "10.20.30.1", "fd00::5" }, out _);
+
+        policy!.PinnedCount.Should().Be(2);
+        policy.IsAllowed(IPAddress.Parse("10.20.30.1")).Should().BeTrue();
+        policy.IsAllowed(IPAddress.Parse("10.20.30.2")).Should().BeFalse();
+        policy.IsAllowed(IPAddress.Parse("fd00::5")).Should().BeTrue();
+        policy.IsAllowed(IPAddress.Parse("fd00::6")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Pinned_UnwrapsIPv4MappedIPv6()
+    {
+        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { "192.168.1.0/24" }, out _);
+
+        policy!.IsAllowed(IPAddress.Parse("::ffff:192.168.1.10")).Should().BeTrue();
+        policy.IsAllowed(IPAddress.Parse("::ffff:192.168.2.10")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Pinned_SkipsBlankEntries()
+    {
+        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { " 10.20.30.0/24 ", "", "  ", null }, out var error);
+
+        error.Should().BeNull();
+        policy!.PinnedCount.Should().Be(1);
+        policy.IsAllowed(IPAddress.Parse("10.20.30.1")).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("not-an-ip")]
+    [InlineData("10.20.30.0/33")]
+    [InlineData("10.20.30.0/-1")]
+    [InlineData("banana/24")]
+    [InlineData("fd00::/129")]
+    public void Pinned_InvalidEntryFailsLoudly(string entry)
+    {
+        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { "10.20.30.0/24", entry }, out var error);
+
+        policy.Should().BeNull();
+        error.Should().NotBeNull();
+        error.Should().Contain(entry);
+    }
+
+    [Fact]
+    public void Pinned_EmptyListFailsLoudly()
+    {
+        var policy = ProxyDialPolicy.FromPinnedCidrs(new[] { "", "  " }, out var error);
+
+        policy.Should().BeNull();
+        error.Should().NotBeNull();
+    }
+
+    #endregion
+}

--- a/tests/NetworkOptimizer.Storage.Tests/UniFiRepositoryTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/UniFiRepositoryTests.cs
@@ -198,6 +198,109 @@ public class UniFiRepositoryTests : IDisposable
     }
 
     [Fact]
+    public async Task SaveDeviceSshConfigurationAsync_UpdateWithBlankPassword_KeepsStoredPassword()
+    {
+        // The edit form never round-trips the stored encrypted password; a blank
+        // incoming password on update means "unchanged", not "clear".
+        var device = new DeviceSshConfiguration
+        {
+            Name = "Device",
+            Host = "192.168.1.1",
+            SshUsername = "User1",
+            SshPassword = "encrypted-blob"
+        };
+        _context.DeviceSshConfigurations.Add(device);
+        await _context.SaveChangesAsync();
+
+        var update = new DeviceSshConfiguration
+        {
+            Id = device.Id,
+            Name = "Device",
+            Host = "192.168.1.1",
+            SshUsername = "User2",
+            SshPassword = null
+        };
+        await _repository.SaveDeviceSshConfigurationAsync(update);
+
+        var saved = await _context.DeviceSshConfigurations.FindAsync(device.Id);
+        saved!.SshUsername.Should().Be("User2");
+        saved.SshPassword.Should().Be("encrypted-blob");
+    }
+
+    [Fact]
+    public async Task SaveDeviceSshConfigurationAsync_UpdateWithNewPassword_Overwrites()
+    {
+        var device = new DeviceSshConfiguration
+        {
+            Name = "Device",
+            Host = "192.168.1.1",
+            SshPassword = "old-blob"
+        };
+        _context.DeviceSshConfigurations.Add(device);
+        await _context.SaveChangesAsync();
+
+        var update = new DeviceSshConfiguration
+        {
+            Id = device.Id,
+            Name = "Device",
+            Host = "192.168.1.1",
+            SshPassword = "new-blob"
+        };
+        await _repository.SaveDeviceSshConfigurationAsync(update);
+
+        var saved = await _context.DeviceSshConfigurations.FindAsync(device.Id);
+        saved!.SshPassword.Should().Be("new-blob");
+    }
+
+    [Fact]
+    public async Task SaveDeviceSshConfigurationAsync_UpdateWithKeyPath_ClearsStoredPassword()
+    {
+        // Switching to key auth drops the stored password (matching the gateway and
+        // UniFi SSH settings pages), so a broken key fails loudly instead of silently
+        // falling back to the old password.
+        var device = new DeviceSshConfiguration
+        {
+            Name = "Device",
+            Host = "192.168.1.1",
+            SshPassword = "encrypted-blob"
+        };
+        _context.DeviceSshConfigurations.Add(device);
+        await _context.SaveChangesAsync();
+
+        var update = new DeviceSshConfiguration
+        {
+            Id = device.Id,
+            Name = "Device",
+            Host = "192.168.1.1",
+            SshPassword = null,
+            SshPrivateKeyPath = "/app/ssh-keys/id_test"
+        };
+        await _repository.SaveDeviceSshConfigurationAsync(update);
+
+        var saved = await _context.DeviceSshConfigurations.FindAsync(device.Id);
+        saved!.SshPassword.Should().BeNull();
+        saved.SshPrivateKeyPath.Should().Be("/app/ssh-keys/id_test");
+    }
+
+    [Fact]
+    public async Task SaveDeviceSshConfigurationAsync_KeyPathWinsOverTypedPassword()
+    {
+        var device = new DeviceSshConfiguration
+        {
+            Name = "Device",
+            Host = "192.168.1.1",
+            SshPassword = "typed-blob",
+            SshPrivateKeyPath = "/app/ssh-keys/id_test"
+        };
+
+        await _repository.SaveDeviceSshConfigurationAsync(device);
+
+        var saved = await _context.DeviceSshConfigurations.FirstOrDefaultAsync(d => d.Name == "Device");
+        saved!.SshPassword.Should().BeNull();
+        saved.SshPrivateKeyPath.Should().Be("/app/ssh-keys/id_test");
+    }
+
+    [Fact]
     public async Task DeleteDeviceSshConfigurationAsync_RemovesDevice()
     {
         var device = new DeviceSshConfiguration { Name = "To Delete", Host = "192.168.1.1" };

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/StepChangeDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/StepChangeDetectorTests.cs
@@ -152,6 +152,44 @@ public class StepChangeDetectorTests
     }
 
     [Fact]
+    public void Mid_window_shift_with_transition_median_outside_band_is_detected()
+    {
+        // Production shape (Cloudflare path, Jul 2026): the shift landed mid-window and a
+        // small dip just before it left the transition window's median slightly BELOW the
+        // old level. Requiring the transition median to sit strictly between the levels
+        // rejected the step-up entirely, while the matching step-down was only caught
+        // because its transition median landed 0.01 ms inside the band.
+        var dipStart = TestSeries.Start.AddHours(12);
+        var shiftAt = dipStart.AddMinutes(20);
+        var samples = TestSeries.Flat(TestSeries.Start, Day, rttMs: 13.3, jitterMs: 0.3)
+            .WithSegment(dipStart, shiftAt, rttMs: 12.9, jitterMs: 0.3)
+            .WithSegment(shiftAt, TestSeries.Start + Day, rttMs: 17.5, jitterMs: 0.3);
+
+        var events = StepChangeDetector.DetectForSeries(TestSeries.Asn(64500, "TransitOne", samples), Options);
+
+        events.Should().ContainSingle();
+        events[0].Direction.Should().Be(PathShiftDirection.Up);
+        events[0].BeforeMedianMs.Should().BeApproximately(13.3, 0.1);
+        events[0].AfterMedianMs.Should().BeApproximately(17.5, 0.1);
+        events[0].Time.Should().BeCloseTo(shiftAt, TimeSpan.FromMinutes(10));
+    }
+
+    [Fact]
+    public void Stable_plateau_outside_the_band_does_not_bridge_a_step()
+    {
+        // A full window resting at its own level outside the two step levels is a distinct
+        // plateau, not a transition - the skip-one-window comparison must still reject it.
+        var plateauStart = TestSeries.Start.AddHours(12);
+        var samples = TestSeries.Flat(TestSeries.Start, Day, rttMs: 20, jitterMs: 0.3)
+            .WithSegment(plateauStart, plateauStart.AddMinutes(30), rttMs: 10, jitterMs: 0.3)
+            .WithSegment(plateauStart.AddMinutes(30), TestSeries.Start + Day, rttMs: 17, jitterMs: 0.3);
+
+        var events = StepChangeDetector.DetectForSeries(TestSeries.Asn(64500, "TransitOne", samples), Options);
+
+        events.Should().BeEmpty();
+    }
+
+    [Fact]
     public void Correlated_steps_across_targets_merge_into_one_event()
     {
         var stepAt = TestSeries.Start.AddHours(12);

--- a/tests/NetworkOptimizer.Web.Tests/SiteContextUrlTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/SiteContextUrlTests.cs
@@ -1,0 +1,46 @@
+using FluentAssertions;
+using NetworkOptimizer.Web.Services;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class SiteContextUrlTests
+{
+    [Theory]
+    [InlineData("/", "/?site=branch")]
+    [InlineData("/monitoring", "/monitoring?site=branch")]
+    [InlineData("/monitoring?tab=live", "/monitoring?tab=live&site=branch")]
+    [InlineData("/monitoring?site=main", "/monitoring?site=branch")]
+    [InlineData("/monitoring?site=main&tab=live", "/monitoring?tab=live&site=branch")]
+    [InlineData("https://example.com/monitoring?tab=live", "https://example.com/monitoring?tab=live&site=branch")]
+    public void WithSiteParam_SetsSiteAndPreservesOtherParams(string url, string expected)
+    {
+        SiteContextService.WithSiteParam(url, "branch").Should().Be(expected);
+    }
+
+    [Fact]
+    public void WithSiteParam_PreservesFragment()
+    {
+        SiteContextService.WithSiteParam("/monitoring?tab=live#section", "branch")
+            .Should().Be("/monitoring?tab=live&site=branch#section");
+    }
+
+    [Fact]
+    public void WithSiteParam_EscapesSlug()
+    {
+        SiteContextService.WithSiteParam("/", "a b").Should().Be("/?site=a%20b");
+    }
+
+    [Theory]
+    [InlineData("/monitoring", "/monitoring")]
+    [InlineData("/monitoring?site=main", "/monitoring")]
+    [InlineData("/monitoring?site=main&tab=live", "/monitoring?tab=live")]
+    [InlineData("/monitoring?tab=live&site=main", "/monitoring?tab=live")]
+    [InlineData("/monitoring?SITE=main", "/monitoring")]
+    [InlineData("/monitoring?site=main#frag", "/monitoring#frag")]
+    [InlineData("/monitoring?tab=live", "/monitoring?tab=live")]
+    public void RemoveSiteParam_StripsOnlySiteParam(string url, string expected)
+    {
+        SiteContextService.RemoveSiteParam(url).Should().Be(expected);
+    }
+}


### PR DESCRIPTION
v2.0.1 Release Changes — rolling `dev` into `main`.

## Multi-Site

- **External sites keep monitoring through tunnel and WAN outages.** When an external site's agent loses its connection to the server, the agent keeps polling probe and SNMP data locally and replays the backlog when the tunnel returns, so an outage no longer punches a hole in that site's history. Delivery is acknowledged end to end, so even a black-holed connection (one TCP still thinks is alive) can't silently drop the outage's data, and charts backfill the gap on their own once it lands.
- **Switching to an offline external site is fast, not a hang.** A site whose agent tunnel has gone dark is now detected quickly and its console flips to "waiting for the site's agent," so switching to it or loading its pages stays instant instead of freezing while the browser waits on the dead tunnel. Its Live View shows a clear agent-offline banner instead of the misleading "monitoring not configured" setup prompt, and the SSL-errors setting is shown as forced-on (it can't apply through the agent tunnel) rather than a toggle that does nothing.
- **Per-tab site context.** A browser tab is now pinned to a site through a `?site=` selector in its own URL rather than a single shared cookie, so you can keep different sites open in different tabs at once. The cookie stays as the browser-wide default for new tabs and bare bookmarks, written only by an explicit switch in the UI. Refresh, duplicate-tab, and reconnect reloads all stay on the tab's site; site-switch links open in a new tab on ctrl/cmd/shift/middle click.
- **Alert "View" links pin their originating site.** Every alert link now carries its site, including for the main site, so a notification always lands on the site it came from instead of following the recipient's browser-default. Following one pins only that tab and no longer rewrites the cookie for the whole session.
- **Site name shown next to the Dashboard header** when multi-site is enabled (including the main site), so each per-tab site is identifiable at a glance.
- **Threat Intelligence "Global" badge** on the main site replaces the longer inline heading.

## Monitoring Agent

- **Agent-owned proxy dial policy.** The on-site agent's tunnel TCP proxy now refuses to dial anything that isn't a site-local address (RFC1918 / IPv6 unique-local / link-local) by default, closing the internet-relay vector a compromised central server would otherwise get for free. Operators can pin an explicit CIDR/IP list in `agent.json` (`proxyAllowedCidrs`) to narrow reach further or admit an exotic public-IP target. Every dial (allow and deny) is journaled agent-side. Hostnames are resolved once and the connection goes to the validated address, so DNS games can't split the check from the connect. The policy is agent-owned; nothing on the tunnel can widen it.
- **Latest agent version bumped to 2.0.1.**

## Latency & ISP Health

- **Flaky LAN target advisory.** LAN latency charts now surface a dismissible hint when a non-gateway/non-AP fabric device shows packet loss that's usually a measurement artifact (Wi-Fi roaming, ping deprioritization) rather than a real problem, with a jump to that target's row in Latency Targets. Gateways and APs are excluded so real infrastructure loss is never hidden.
- **Path-shift detection accepts noisy transition windows.** A step change whose mid-window transition median lands just outside the before/after band (from a small pre-shift dip) is no longer discarded; only a window that is itself a stable third level still disqualifies the step.

## Fixes

- **Mobile scroll no longer locks up after the app is backgrounded,** and the top bar's hide/reveal on scroll is smoother.
- **Returning to the app on mobile keeps your place.** It only reloads when the connection is actually dead, instead of reloading on a timer after backgrounding.
- **Dismissed "install as an app" and channel-analysis banners stay dismissed** across site switches instead of reappearing on each site.
- **Live WAN chart and 2D network map no longer clip at their edges.** The WAN chart isn't cut off by its card, and the map's bottom row of devices clears the timeline scrubber.
- **ONT external refresh button** now disables and shows a spinner while polling, preventing double-taps.
- **Per-device SSH password handling.** Configuring a key path clears any stored password (matching the gateway/UniFi SSH settings pages) so a broken key fails loudly instead of silently falling back to a stale password; a blank password on edit means "keep", not "clear". The SSH fields opt out of password-manager autofill.
