### PR TITLE
Fix mobile scroll lock after backgrounding; smooth the top-bar hide/reveal

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
+++ b/src/NetworkOptimizer.Web/Components/Layout/MainLayout.razor
@@ -232,6 +232,16 @@
             setTimeout(function() { window.scrollBy(0, 1); window.scrollBy(0, -1); }, 100);
         });
 
+        // iOS can restore from background with the window scrolled off (0,0); the body
+        // then swallows touch gestures and .main-content can't scroll until a tap resets it
+        function unstickViewport() {
+            if (window.scrollX || window.scrollY) window.scrollTo(0, 0);
+        }
+        window.addEventListener('pageshow', unstickViewport);
+        document.addEventListener('visibilitychange', function() {
+            if (!document.hidden) setTimeout(unstickViewport, 50);
+        });
+
         // Show nav bar when content shrinks below scrollable (e.g. tab switch to short content)
         var pageContent = document.querySelector('.page-content');
         if (window.innerWidth <= 1024 && pageContent) {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -3271,12 +3271,17 @@ select.form-control {
         height: auto;
         padding: 0.75rem 1rem;
         gap: 0.5rem;
-        transition: top 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+        transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
     }
 
+    /* Slide up by exactly the bar's own height (translateY %) so the full
+       transition is spent moving one bar-height - a gradual slide, not the
+       instant snap that top:-100% produced (that % resolves against the tall
+       scroll container, so the bar cleared the screen in a few ms). */
     .top-bar.top-bar-hidden {
         position: sticky;
-        top: -100%;
+        top: 0;
+        transform: translateY(-100%);
         pointer-events: none;
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -3178,16 +3178,12 @@ select.form-control {
 @media (max-width: 1024px) {
     /* Lock the viewport so only .main-content scrolls - iOS can otherwise scroll
        the body (esp. on return from background), swallowing touch gestures.
-       Scoped to the app shell so the login page can still scroll. */
-    html:has(.app-container) {
-        overflow: hidden;
-    }
-
+       overflow:hidden only (no position:fixed, which disturbs the dynamic-viewport
+       behavior the sticky top-bar hide rides on). Scoped to the app shell so the
+       login page can still scroll. */
+    html:has(.app-container),
     body:has(.app-container) {
         overflow: hidden;
-        position: fixed;
-        width: 100%;
-        height: 100%;
     }
 
     .content-grid {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -3176,6 +3176,20 @@ select.form-control {
 
 /* Responsive Design */
 @media (max-width: 1024px) {
+    /* Lock the viewport so only .main-content scrolls - iOS can otherwise scroll
+       the body (esp. on return from background), swallowing touch gestures.
+       Scoped to the app shell so the login page can still scroll. */
+    html:has(.app-container) {
+        overflow: hidden;
+    }
+
+    body:has(.app-container) {
+        overflow: hidden;
+        position: fixed;
+        width: 100%;
+        height: 100%;
+    }
+
     .content-grid {
         grid-template-columns: 1fr;
     }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -3271,17 +3271,20 @@ select.form-control {
         height: auto;
         padding: 0.75rem 1rem;
         gap: 0.5rem;
-        transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+        /* Base transition governs the reveal (returning to this state) - slower */
+        transition: transform 0.6s cubic-bezier(0.4, 0, 0.2, 1);
     }
 
     /* Slide up by exactly the bar's own height (translateY %) so the full
        transition is spent moving one bar-height - a gradual slide, not the
        instant snap that top:-100% produced (that % resolves against the tall
-       scroll container, so the bar cleared the screen in a few ms). */
+       scroll container, so the bar cleared the screen in a few ms).
+       Transition here governs the hide (entering this state) - kept quicker. */
     .top-bar.top-bar-hidden {
         position: sticky;
         top: 0;
         transform: translateY(-100%);
+        transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
         pointer-events: none;
     }
 


### PR DESCRIPTION
Fixes a mobile scroll-lock bug and smooths the top-bar hide/reveal.

## Scroll lock after backgrounding

On mobile (PWA standalone or a browser tab), returning to the app after it had been in the background could leave the page boxed in and unscrollable until you tapped around to break loose. iOS can restore the app with the window scrolled off origin, at which point the body swallows touch gestures instead of the inner scroll container.

Two layers address it:
- Lock the viewport (`overflow: hidden`, scoped to the app shell so the login page still scrolls) so only the main content area scrolls.
- On `pageshow`/return-to-foreground, snap a stray window scroll offset back to origin.

## Smoother top-bar hide/reveal

The mobile top bar hid by animating `top` toward `-100%`, which resolves against the tall scroll container, so the bar cleared the screen in the first few milliseconds of the transition - an abrupt snap. It now slides by `transform: translateY(-100%)` (exactly the bar's own height), so the full duration is spent on a gradual slide. The reveal is slightly slower than the hide.
