### PR TITLE
Multi-site: keep external sites monitoring through tunnel outages, without data loss or UI hangs

### DIFF
--- a/NetworkOptimizer.sln
+++ b/NetworkOptimizer.sln
@@ -59,6 +59,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetworkOptimizer.Agent", "s
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetworkOptimizer.AgentProtocol", "src\NetworkOptimizer.AgentProtocol\NetworkOptimizer.AgentProtocol.csproj", "{CBF381E5-F3CF-4A4F-85C8-DD5BFAB51741}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetworkOptimizer.AgentProtocol.Tests", "tests\NetworkOptimizer.AgentProtocol.Tests\NetworkOptimizer.AgentProtocol.Tests.csproj", "{EC6241C2-8CD8-4321-B93C-3ACC408050E9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -381,6 +383,18 @@ Global
 		{CBF381E5-F3CF-4A4F-85C8-DD5BFAB51741}.Release|x64.Build.0 = Release|Any CPU
 		{CBF381E5-F3CF-4A4F-85C8-DD5BFAB51741}.Release|x86.ActiveCfg = Release|Any CPU
 		{CBF381E5-F3CF-4A4F-85C8-DD5BFAB51741}.Release|x86.Build.0 = Release|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Debug|x64.Build.0 = Debug|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Debug|x86.Build.0 = Debug|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Release|x64.ActiveCfg = Release|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Release|x64.Build.0 = Release|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Release|x86.ActiveCfg = Release|Any CPU
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -401,6 +415,7 @@ Global
 		{EC72C9AD-625C-4AA8-A7CC-744515E06F1E} = {5691A6DD-53B9-4CE0-A3C9-3D4F815E2120}
 		{01F2AE32-FE55-4892-B91B-CE2BC964F29D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{CBF381E5-F3CF-4A4F-85C8-DD5BFAB51741} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{EC6241C2-8CD8-4321-B93C-3ACC408050E9} = {5691A6DD-53B9-4CE0-A3C9-3D4F815E2120}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F7E6D5C4-B3A2-9180-7F6E-5D4C3B2A1908}

--- a/src/NetworkOptimizer.Agent/ProbeRunner.cs
+++ b/src/NetworkOptimizer.Agent/ProbeRunner.cs
@@ -10,13 +10,16 @@ namespace NetworkOptimizer.Agent;
 /// The site's latency/loss probe engine. The server pushes the site's
 /// monitoring targets over the tunnel; this runner probes each on its own
 /// cadence (2 s scheduler tick, per-target intervals, bounded concurrency,
-/// mirroring the server's latency tier) and streams every result straight
-/// back. Created per tunnel connection: the server re-pushes config on every
-/// connect, and results have nowhere to go while the tunnel is down.
+/// mirroring the server's latency tier) and enqueues every result into the
+/// store-and-forward <see cref="ResultBuffer"/>. Runs for the life of the
+/// agent process: probing continues through tunnel outages - which is exactly
+/// when latency/loss data matters most - with the buffer holding the backlog
+/// and the last pushed target set staying in effect until the server
+/// re-pushes on reconnect.
 /// </summary>
 public sealed class ProbeRunner
 {
-    private readonly Func<AgentMessage, bool> _send;
+    private readonly Action<AgentMessage> _send;
     private readonly string? _defaultSourceIp;
     private readonly LocalProbeExecutor _executor = new(NullLogger<LocalProbeExecutor>.Instance);
     private readonly ConcurrentDictionary<string, DateTime> _lastProbed = new();
@@ -27,7 +30,7 @@ public sealed class ProbeRunner
     /// own. This is the probe-only multi-WAN deployment knob: the gateway
     /// policy-routes this source IP out a specific WAN.
     /// </param>
-    public ProbeRunner(Func<AgentMessage, bool> send, string? defaultSourceIp = null)
+    public ProbeRunner(Action<AgentMessage> send, string? defaultSourceIp = null)
     {
         _send = send;
         _defaultSourceIp = string.IsNullOrEmpty(defaultSourceIp) ? null : defaultSourceIp;
@@ -42,13 +45,13 @@ public sealed class ProbeRunner
     public async Task RunAsync(CancellationToken ct)
     {
         // Startup grace, mirroring the server latency tier's 20s initial delay
-        // (MonitoringCollectionAgent.RunTierAsync). A fresh ProbeRunner starts on every
-        // tunnel connect - the agent (re)starting, OR a NO-server restart that dropped
-        // and re-established the tunnel - and every target is "due" immediately. Probing
-        // the instant the process/link comes up catches the network still settling
-        // (routes, source-IP binds, the target device itself rebooting alongside) and
-        // records a false loss/latency spike right at the restart boundary. Wait for it
-        // to settle before the first tick, so no boundary sample is taken.
+        // (MonitoringCollectionAgent.RunTierAsync). At agent process start every target
+        // is "due" immediately, and probing the instant the process comes up catches
+        // the network still settling (routes, source-IP binds, the target device itself
+        // rebooting alongside) and records a false loss/latency spike right at the
+        // start boundary. Wait for it to settle before the first tick, so no boundary
+        // sample is taken. Tunnel reconnects no longer restart this runner, so no
+        // grace (or gap) applies there - probing runs continuously across outages.
         try { await Task.Delay(TimeSpan.FromSeconds(20), ct); }
         catch (OperationCanceledException) { return; }
 

--- a/src/NetworkOptimizer.Agent/Program.cs
+++ b/src/NetworkOptimizer.Agent/Program.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using NetworkOptimizer.Agent;
+using NetworkOptimizer.AgentProtocol;
 
 // On-site agent skeleton: enrolls against the central Network Optimizer server
 // with a one-time token, persists its agent key and site slug, then heartbeats.
@@ -185,6 +186,26 @@ if (config.LanSpeedTest)
         speedTestServer is { } relayServer ? relayServer.PostIperf3ResultAsync : null, cts.Token);
 }
 
+// Monitoring collectors and their store-and-forward buffer live for the whole
+// process, not per tunnel connection: probing and SNMP polling continue on the
+// last pushed config while the tunnel is down - exactly when outage data
+// matters most - and the buffered backlog (12 h / 64 MB caps, oldest dropped
+// first) replays over the tunnel on reconnect. Only started when a tunnel is
+// configured; without one no config ever arrives and there is nothing to run.
+ResultBuffer? resultBuffer = null;
+ProbeRunner? probeRunner = null;
+SnmpRunner? snmpRunner = null;
+Task? probeTask = null;
+Task? snmpTask = null;
+if (!string.IsNullOrEmpty(config.TunnelUrl))
+{
+    resultBuffer = new ResultBuffer();
+    probeRunner = new ProbeRunner(resultBuffer.Enqueue, config.ProbeSourceIp);
+    snmpRunner = new SnmpRunner(resultBuffer.Enqueue);
+    probeTask = probeRunner.RunAsync(cts.Token);
+    snmpTask = snmpRunner.RunAsync(cts.Token);
+}
+
 // Prefer the persistent gRPC tunnel; REST heartbeats keep the agent visible as
 // Online whenever the tunnel is unavailable (tunnel disabled server-side, an
 // older server, or a network drop between reconnect attempts).
@@ -192,19 +213,14 @@ while (!cts.IsCancellationRequested)
 {
     if (!string.IsNullOrEmpty(config.TunnelUrl))
     {
-        // The probe runner lives and dies with its tunnel connection: the
-        // server re-pushes probe config on every connect, and results have
-        // nowhere to go while the tunnel is down.
         using var connectionCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
         var tunnel = new TunnelClient();
-        var probeRunner = new ProbeRunner(tunnel.TrySend, config.ProbeSourceIp);
-        var snmpRunner = new SnmpRunner(tunnel);
         var proxyHandler = new ProxyHandler(tunnel, proxyPolicy);
         var iperf3ClientRunner = new Iperf3ClientRunner(tunnel);
         var uwnClientRunner = new UwnClientRunner(tunnel);
         var probeRequestRunner = new ProbeRequestRunner(tunnel);
-        tunnel.OnProbeConfig = probeRunner.UpdateConfig;
-        tunnel.OnSnmpConfig = snmpRunner.UpdateConfig;
+        tunnel.OnProbeConfig = probeRunner!.UpdateConfig;
+        tunnel.OnSnmpConfig = snmpRunner!.UpdateConfig;
         tunnel.OnWanSpeedTestConfig = wanConfig => speedTestServer?.UpdateWanServers(
             wanConfig.Servers.Select(s => new SpeedTestServer.WanServerEntry(s.ServerId, s.Url)).ToList(),
             wanConfig.DefaultServerId);
@@ -215,8 +231,14 @@ while (!cts.IsCancellationRequested)
         tunnel.OnIperf3Request = iperf3ClientRunner.HandleAsync;
         tunnel.OnUwnRequest = uwnClientRunner.HandleAsync;
         tunnel.OnProbeRequest = probeRequestRunner.HandleAsync;
-        var probeTask = probeRunner.RunAsync(connectionCts.Token);
-        var snmpTask = snmpRunner.RunAsync(connectionCts.Token);
+        var backlog = resultBuffer!.Count;
+        if (backlog > 0)
+            Console.WriteLine($"Buffered backlog: {backlog} result message(s) (~{resultBuffer.ApproxBytes / 1024} KB) will flush once the tunnel connects");
+        var droppedOffline = resultBuffer.TakeDroppedCount();
+        if (droppedOffline > 0)
+            Console.Error.WriteLine($"Result buffer caps dropped the {droppedOffline} oldest message(s) while the tunnel was down");
+
+        var drainTask = tunnel.DrainResultsAsync(resultBuffer, connectionCts.Token);
         try
         {
             await tunnel.RunAsync(config.TunnelUrl, config.AgentKey!, version, lanIp, config.IgnoreSslErrors, cts.Token);
@@ -233,7 +255,11 @@ while (!cts.IsCancellationRequested)
         finally
         {
             connectionCts.Cancel();
-            try { await Task.WhenAll(probeTask, snmpTask); } catch (OperationCanceledException) { }
+            // Order matters for FIFO replay: the drain requeues its in-hand
+            // message first, then the salvage inserts the (older) messages
+            // still parked in the outbound channel ahead of it.
+            try { await drainTask; } catch (OperationCanceledException) { }
+            tunnel.SalvageUnsentInto(resultBuffer);
         }
     }
 
@@ -269,6 +295,14 @@ if (speedTestServer != null)
 if (iperf3Task != null)
 {
     try { await iperf3Task; } catch (OperationCanceledException) { }
+}
+if (probeTask != null)
+{
+    try { await probeTask; } catch (OperationCanceledException) { }
+}
+if (snmpTask != null)
+{
+    try { await snmpTask; } catch (OperationCanceledException) { }
 }
 
 Console.WriteLine("Agent stopped");

--- a/src/NetworkOptimizer.Agent/Program.cs
+++ b/src/NetworkOptimizer.Agent/Program.cs
@@ -231,6 +231,9 @@ while (!cts.IsCancellationRequested)
         tunnel.OnIperf3Request = iperf3ClientRunner.HandleAsync;
         tunnel.OnUwnRequest = uwnClientRunner.HandleAsync;
         tunnel.OnProbeRequest = probeRequestRunner.HandleAsync;
+        // Server confirms persisted result frames; trim them from the buffer so
+        // only unacked data is retained for replay.
+        tunnel.OnResultAck = seq => resultBuffer!.MarkAcked(seq);
         var backlog = resultBuffer!.Count;
         if (backlog > 0)
             Console.WriteLine($"Buffered backlog: {backlog} result message(s) (~{resultBuffer.ApproxBytes / 1024} KB) will flush once the tunnel connects");
@@ -255,11 +258,9 @@ while (!cts.IsCancellationRequested)
         finally
         {
             connectionCts.Cancel();
-            // Order matters for FIFO replay: the drain requeues its in-hand
-            // message first, then the salvage inserts the (older) messages
-            // still parked in the outbound channel ahead of it.
+            // Nothing to salvage: the drain only peeks, so every unacked frame is
+            // still in the buffer and replays on the next connection.
             try { await drainTask; } catch (OperationCanceledException) { }
-            tunnel.SalvageUnsentInto(resultBuffer);
         }
     }
 

--- a/src/NetworkOptimizer.Agent/SnmpRunner.cs
+++ b/src/NetworkOptimizer.Agent/SnmpRunner.cs
@@ -8,14 +8,16 @@ namespace NetworkOptimizer.Agent;
 /// <summary>
 /// The site's SNMP poller. The server pushes the site's SNMP credentials and
 /// device list over the tunnel; this runner polls interface counters (fast
-/// cadence) and device health (medium cadence) locally and streams the raw
-/// samples back. Rate computation and storage happen server-side, mirroring
-/// the central collection agent's split. Lives and dies with its tunnel
-/// connection, like the probe runner.
+/// cadence) and device health (medium cadence) locally and enqueues the raw
+/// samples into the store-and-forward <see cref="ResultBuffer"/>. Rate
+/// computation and storage happen server-side, mirroring the central
+/// collection agent's split. Runs for the life of the agent process, like the
+/// probe runner: polling continues through tunnel outages on the last pushed
+/// config, and the buffered backlog replays on reconnect.
 /// </summary>
 public sealed class SnmpRunner
 {
-    private readonly TunnelClient _tunnel;
+    private readonly Action<AgentMessage> _send;
     private volatile SnmpConfig? _config;
     private SnmpPoller? _poller;
     private string _pollerKey = "";
@@ -25,9 +27,9 @@ public sealed class SnmpRunner
     // the agent either. Keyed by device MAC.
     private readonly SnmpFailureTracker _failures = new();
 
-    public SnmpRunner(TunnelClient tunnel)
+    public SnmpRunner(Action<AgentMessage> send)
     {
-        _tunnel = tunnel;
+        _send = send;
     }
 
     public void UpdateConfig(SnmpConfig config)
@@ -43,7 +45,9 @@ public sealed class SnmpRunner
 
     /// <summary>
     /// Handles the server's on-demand "Test OID" request: GET the single OID once against a
-    /// site-local device and return the raw value (correlated by request id).
+    /// site-local device and return the raw value (correlated by request id). The reply rides
+    /// the result buffer like everything else; if the tunnel drops first, the server has
+    /// already timed the request out and ignores the stale request id on replay.
     /// </summary>
     public async Task HandleOidQueryAsync(SnmpOidQuery query, CancellationToken ct)
     {
@@ -74,8 +78,7 @@ public sealed class SnmpRunner
         }
 
         Console.WriteLine($"OID test request {query.RequestId}: success={result.Success} value={result.Value} error={result.Error}");
-        try { await _tunnel.SendAsync(new AgentMessage { SnmpOidResult = result }, ct); }
-        catch (Exception ex) { Console.Error.WriteLine($"Failed to send OID test result {query.RequestId}: {ex.Message}"); }
+        _send(new AgentMessage { SnmpOidResult = result });
     }
 
     /// <summary>Interface counters on the fast cadence.</summary>
@@ -131,7 +134,7 @@ public sealed class SnmpRunner
                         });
                     }
                     if (batch.Interfaces.Count > 0)
-                        await _tunnel.SendAsync(new AgentMessage { SnmpResults = batch }, ct);
+                        _send(new AgentMessage { SnmpResults = batch });
                 }, ct);
             }
 
@@ -181,7 +184,7 @@ public sealed class SnmpRunner
                     await PollCustomOidsAsync(poller, ip, device, config, batch);
 
                     if (batch.Health.Count > 0 || batch.CustomOids.Count > 0)
-                        await _tunnel.SendAsync(new AgentMessage { SnmpResults = batch }, ct);
+                        _send(new AgentMessage { SnmpResults = batch });
                 }, ct);
             }
 

--- a/src/NetworkOptimizer.Agent/TunnelClient.cs
+++ b/src/NetworkOptimizer.Agent/TunnelClient.cs
@@ -38,6 +38,16 @@ public sealed class TunnelClient
     private const int CoalesceMaxSamples = 500;
     private const int OutboundHeadroomSlots = 64;
 
+    // The server is never silent on a healthy tunnel - it re-pushes the site's
+    // configs every 60 s - so 2.5 missed refresh cycles means the link is
+    // black-holed. A real WAN outage drops packets rather than resetting
+    // connections: without this watchdog the read loop would hang in MoveNext
+    // for the full TCP timeout (~15 min) before the reconnect loop - and the
+    // buffered-backlog flush - could run. Written by the read loop, watched by
+    // WatchInboundSilenceAsync.
+    private const long InboundSilenceTimeoutMs = 150_000;
+    private long _lastInboundTicks;
+
     /// <summary>Invoked whenever the server pushes a new probe configuration.</summary>
     public Action<ProbeConfig>? OnProbeConfig { get; set; }
 
@@ -123,27 +133,32 @@ public sealed class TunnelClient
 
         using var grpcChannel = GrpcChannel.ForAddress(tunnelUrl, new GrpcChannelOptions { HttpHandler = handler });
         var client = new AgentTunnel.AgentTunnelClient(grpcChannel);
-        using var call = client.Connect(cancellationToken: ct);
+        // The linked source scopes the whole call (not just the pump/heartbeat)
+        // so the inbound-silence watchdog can abort a black-holed read loop.
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        using var call = client.Connect(cancellationToken: linked.Token);
 
         await call.RequestStream.WriteAsync(new AgentMessage
         {
             Hello = new AgentHello { AgentKey = agentKey, Version = version, LanIp = lanIp ?? "" }
-        }, ct);
+        }, linked.Token);
 
-        if (!await call.ResponseStream.MoveNext(ct) || call.ResponseStream.Current.Hello is not { } hello)
+        if (!await call.ResponseStream.MoveNext(linked.Token) || call.ResponseStream.Current.Hello is not { } hello)
             throw new IOException("Tunnel closed before server hello");
 
         var heartbeatInterval = TimeSpan.FromSeconds(Math.Max(5, hello.HeartbeatIntervalSeconds));
         Console.WriteLine($"Tunnel open for site '{hello.SiteSlug}' (heartbeat every {heartbeatInterval.TotalSeconds:0}s)");
 
-        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        Volatile.Write(ref _lastInboundTicks, Environment.TickCount64);
         var pumpTask = PumpOutboundAsync(call.RequestStream, linked.Token);
         var heartbeatTask = HeartbeatLoopAsync(heartbeatInterval, linked.Token);
+        var watchdogTask = WatchInboundSilenceAsync(linked, linked.Token);
 
         try
         {
-            while (await call.ResponseStream.MoveNext(ct))
+            while (await call.ResponseStream.MoveNext(linked.Token))
             {
+                Volatile.Write(ref _lastInboundTicks, Environment.TickCount64);
                 var message = call.ResponseStream.Current;
                 switch (message.PayloadCase)
                 {
@@ -201,7 +216,27 @@ public sealed class TunnelClient
         {
             linked.Cancel();
             _outbound.Writer.TryComplete();
-            try { await Task.WhenAll(pumpTask, heartbeatTask); } catch (OperationCanceledException) { }
+            try { await Task.WhenAll(pumpTask, heartbeatTask, watchdogTask); } catch (OperationCanceledException) { }
+        }
+    }
+
+    /// <summary>
+    /// Forces a reconnect when nothing has arrived from the server past the
+    /// silence timeout. Cancelling the connection's source aborts the read
+    /// loop; the caller's reconnect loop then salvages the outbound channel
+    /// and keeps buffering, so a forced reconnect never loses data.
+    /// </summary>
+    private async Task WatchInboundSilenceAsync(CancellationTokenSource connectionCts, CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(15), ct);
+            var silentMs = Environment.TickCount64 - Volatile.Read(ref _lastInboundTicks);
+            if (silentMs <= InboundSilenceTimeoutMs) continue;
+            Console.Error.WriteLine(
+                $"Tunnel silent for {silentMs / 1000}s (server config refresh is 60s); assuming dead link, reconnecting - results keep buffering");
+            connectionCts.Cancel();
+            return;
         }
     }
 

--- a/src/NetworkOptimizer.Agent/TunnelClient.cs
+++ b/src/NetworkOptimizer.Agent/TunnelClient.cs
@@ -48,6 +48,12 @@ public sealed class TunnelClient
     private const long InboundSilenceTimeoutMs = 150_000;
     private long _lastInboundTicks;
 
+    // Bound the post-connect handshake: the inbound-silence watchdog only arms
+    // once the server hello arrives, so without this a link black-holed between
+    // connect and hello would hang the read on dead TCP for the full OS timeout
+    // (~15 min) before the reconnect loop could retry.
+    private static readonly TimeSpan HelloTimeout = TimeSpan.FromSeconds(20);
+
     /// <summary>Invoked whenever the server pushes a new probe configuration.</summary>
     public Action<ProbeConfig>? OnProbeConfig { get; set; }
 
@@ -138,16 +144,34 @@ public sealed class TunnelClient
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);
         using var call = client.Connect(cancellationToken: linked.Token);
 
-        await call.RequestStream.WriteAsync(new AgentMessage
+        // The connection is up but the server hello has not arrived yet, and the
+        // inbound-silence watchdog below only arms once it has. Bound the handshake
+        // so a link black-holed in this window fails fast into a retry instead of
+        // hanging the read on dead TCP for the full OS timeout.
+        TimeSpan heartbeatInterval;
+        string siteSlug;
+        try
         {
-            Hello = new AgentHello { AgentKey = agentKey, Version = version, LanIp = lanIp ?? "" }
-        }, linked.Token);
+            using var helloCts = CancellationTokenSource.CreateLinkedTokenSource(linked.Token);
+            helloCts.CancelAfter(HelloTimeout);
 
-        if (!await call.ResponseStream.MoveNext(linked.Token) || call.ResponseStream.Current.Hello is not { } hello)
-            throw new IOException("Tunnel closed before server hello");
+            await call.RequestStream.WriteAsync(new AgentMessage
+            {
+                Hello = new AgentHello { AgentKey = agentKey, Version = version, LanIp = lanIp ?? "" }
+            }, helloCts.Token);
 
-        var heartbeatInterval = TimeSpan.FromSeconds(Math.Max(5, hello.HeartbeatIntervalSeconds));
-        Console.WriteLine($"Tunnel open for site '{hello.SiteSlug}' (heartbeat every {heartbeatInterval.TotalSeconds:0}s)");
+            if (!await call.ResponseStream.MoveNext(helloCts.Token) || call.ResponseStream.Current.Hello is not { } hello)
+                throw new IOException("Tunnel closed before server hello");
+
+            heartbeatInterval = TimeSpan.FromSeconds(Math.Max(5, hello.HeartbeatIntervalSeconds));
+            siteSlug = hello.SiteSlug;
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            throw new IOException($"No server hello within {HelloTimeout.TotalSeconds:0}s of connecting; assuming dead link");
+        }
+
+        Console.WriteLine($"Tunnel open for site '{siteSlug}' (heartbeat every {heartbeatInterval.TotalSeconds:0}s)");
 
         Volatile.Write(ref _lastInboundTicks, Environment.TickCount64);
         var pumpTask = PumpOutboundAsync(call.RequestStream, linked.Token);

--- a/src/NetworkOptimizer.Agent/TunnelClient.cs
+++ b/src/NetworkOptimizer.Agent/TunnelClient.cs
@@ -10,7 +10,11 @@ namespace NetworkOptimizer.Agent;
 /// HTTP/2 tunnel port, authenticates with the agent key, then holds one
 /// bidirectional stream carrying heartbeats and probe results out and probe
 /// configuration in. All outbound writes funnel through a channel so multiple
-/// producers (heartbeat loop, probe runner) never race on the stream.
+/// producers (heartbeat loop, result-buffer drain, proxy handler) never race
+/// on the stream. Monitoring results reach the stream only through
+/// <see cref="DrainResultsAsync"/> from the process-wide
+/// <see cref="ResultBuffer"/>, which is what carries them across tunnel
+/// outages.
 /// </summary>
 public sealed class TunnelClient
 {
@@ -18,6 +22,21 @@ public sealed class TunnelClient
     // dropped frame would corrupt them.
     private readonly Channel<AgentMessage> _outbound = Channel.CreateBounded<AgentMessage>(
         new BoundedChannelOptions(256) { FullMode = BoundedChannelFullMode.Wait });
+
+    // Message the pump has taken off the channel but not confirmed written, so
+    // SalvageUnsentInto can recover it after teardown. A message that was in
+    // fact written but never reached the server replays as a duplicate on the
+    // next connection - harmless, since every sample carries its own timestamp
+    // and re-writes the same point.
+    private volatile AgentMessage? _pumpInFlight;
+
+    // Backlog-flush tuning for DrainResultsAsync: coalescing consecutive
+    // batches slashes the server's per-batch overhead (DB round-trips, console
+    // cache lookups) when replaying hours of buffered data, and the headroom
+    // check keeps this flood from saturating the outbound channel so
+    // heartbeats and proxied console traffic still get through mid-flush.
+    private const int CoalesceMaxSamples = 500;
+    private const int OutboundHeadroomSlots = 64;
 
     /// <summary>Invoked whenever the server pushes a new probe configuration.</summary>
     public Action<ProbeConfig>? OnProbeConfig { get; set; }
@@ -186,11 +205,110 @@ public sealed class TunnelClient
         }
     }
 
+    /// <summary>
+    /// Feeds this connection from the store-and-forward buffer until the
+    /// tunnel tears down. FIFO order is preserved end to end - the server's
+    /// interface rate calculator needs per-interface samples in chronological
+    /// order - and nothing is lost on teardown: the in-hand message is
+    /// requeued here, and the caller recovers whatever reached the outbound
+    /// channel via <see cref="SalvageUnsentInto"/> AFTER this task completes
+    /// (channel leftovers are older than the in-hand message, and
+    /// RequeueFront slots them back in ahead of it).
+    /// </summary>
+    public async Task DrainResultsAsync(ResultBuffer buffer, CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            AgentMessage? message = null;
+            try
+            {
+                message = await buffer.DequeueAsync(ct);
+                CoalesceBacklog(buffer, message);
+                while (_outbound.Reader.Count > OutboundHeadroomSlots)
+                    await Task.Delay(20, ct);
+                if (!await SendAsync(message, ct))
+                {
+                    buffer.RequeueFront([message]);
+                    return;
+                }
+                message = null;
+            }
+            catch (OperationCanceledException)
+            {
+                if (message != null)
+                    buffer.RequeueFront([message]);
+                return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Merges consecutive same-type result batches from the buffer into
+    /// <paramref name="message"/>, up to <see cref="CoalesceMaxSamples"/>
+    /// samples. Only a backlog coalesces - in live flow the buffer is empty and
+    /// each batch ships as produced.
+    /// </summary>
+    private static void CoalesceBacklog(ResultBuffer buffer, AgentMessage message)
+    {
+        if (message.PayloadCase == AgentMessage.PayloadOneofCase.ProbeResults)
+        {
+            while (message.ProbeResults.Results.Count < CoalesceMaxSamples
+                   && buffer.TryDequeueIf(
+                       m => m.PayloadCase == AgentMessage.PayloadOneofCase.ProbeResults, out var next))
+            {
+                message.ProbeResults.Results.AddRange(next.ProbeResults.Results);
+            }
+        }
+        else if (message.PayloadCase == AgentMessage.PayloadOneofCase.SnmpResults)
+        {
+            int Samples() => message.SnmpResults.Interfaces.Count
+                             + message.SnmpResults.Health.Count
+                             + message.SnmpResults.CustomOids.Count;
+            while (Samples() < CoalesceMaxSamples
+                   && buffer.TryDequeueIf(
+                       m => m.PayloadCase == AgentMessage.PayloadOneofCase.SnmpResults, out var next))
+            {
+                message.SnmpResults.Interfaces.AddRange(next.SnmpResults.Interfaces);
+                message.SnmpResults.Health.AddRange(next.SnmpResults.Health);
+                message.SnmpResults.CustomOids.AddRange(next.SnmpResults.CustomOids);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Recovers monitoring results still parked in the (now closed) outbound
+    /// channel back into the buffer, so a tunnel drop or failed connect loses
+    /// nothing. Call after <see cref="RunAsync"/> has returned AND the drain
+    /// task has completed - the drain requeues its own in-hand message first,
+    /// and these channel items are older, so inserting them at the front last
+    /// restores exact FIFO order. Request/response payloads (proxy frames, OID
+    /// test replies, speed-test results) are connection-scoped and discarded.
+    /// </summary>
+    public void SalvageUnsentInto(ResultBuffer buffer)
+    {
+        var leftovers = new List<AgentMessage>();
+        if (_pumpInFlight is { } inFlight && IsBufferable(inFlight))
+            leftovers.Add(inFlight);
+        _pumpInFlight = null;
+        while (_outbound.Reader.TryRead(out var message))
+        {
+            if (IsBufferable(message))
+                leftovers.Add(message);
+        }
+        buffer.RequeueFront(leftovers);
+    }
+
+    private static bool IsBufferable(AgentMessage message) =>
+        message.PayloadCase is AgentMessage.PayloadOneofCase.ProbeResults
+            or AgentMessage.PayloadOneofCase.SnmpResults;
+
     private async Task PumpOutboundAsync(IClientStreamWriter<AgentMessage> requestStream, CancellationToken ct)
     {
         await foreach (var message in _outbound.Reader.ReadAllAsync(ct))
         {
+            _pumpInFlight = message;
             await requestStream.WriteAsync(message, ct);
+            _pumpInFlight = null;
         }
     }
 

--- a/src/NetworkOptimizer.Agent/TunnelClient.cs
+++ b/src/NetworkOptimizer.Agent/TunnelClient.cs
@@ -19,16 +19,12 @@ namespace NetworkOptimizer.Agent;
 public sealed class TunnelClient
 {
     // Wait (not drop) when full: proxied byte streams ride this channel and a
-    // dropped frame would corrupt them.
+    // dropped frame would corrupt them. Result frames also ride it, but they
+    // stay in the ResultBuffer until the server acks them, so a frame still on
+    // this channel when the tunnel tears down is simply re-sent on the next
+    // connection - nothing to salvage.
     private readonly Channel<AgentMessage> _outbound = Channel.CreateBounded<AgentMessage>(
         new BoundedChannelOptions(256) { FullMode = BoundedChannelFullMode.Wait });
-
-    // Message the pump has taken off the channel but not confirmed written, so
-    // SalvageUnsentInto can recover it after teardown. A message that was in
-    // fact written but never reached the server replays as a duplicate on the
-    // next connection - harmless, since every sample carries its own timestamp
-    // and re-writes the same point.
-    private volatile AgentMessage? _pumpInFlight;
 
     // Backlog-flush tuning for DrainResultsAsync: coalescing consecutive
     // batches slashes the server's per-batch overhead (DB round-trips, console
@@ -53,6 +49,14 @@ public sealed class TunnelClient
     // connect and hello would hang the read on dead TCP for the full OS timeout
     // (~15 min) before the reconnect loop could retry.
     private static readonly TimeSpan HelloTimeout = TimeSpan.FromSeconds(20);
+
+    // Set from the server hello. An older server that doesn't ack result frames
+    // (SupportsResultAck = false) means we can't rely on acks, so the drain trims
+    // each frame on send - the pre-ack behavior - instead of retaining the whole
+    // buffer and re-flushing it on every reconnect. A fresh TunnelClient per
+    // connection defaults this to false (keep until proven), which is the safe
+    // side: worst case a frame is re-sent, never dropped.
+    private volatile bool _ackless;
 
     /// <summary>Invoked whenever the server pushes a new probe configuration.</summary>
     public Action<ProbeConfig>? OnProbeConfig { get; set; }
@@ -83,6 +87,13 @@ public sealed class TunnelClient
 
     /// <summary>Server asks us to run an on-demand ping/traceroute from this host.</summary>
     public Func<ProbeRequest, CancellationToken, Task>? OnProbeRequest { get; set; }
+
+    /// <summary>
+    /// Server has persisted result frames up to (and including) this sequence.
+    /// Wired to <see cref="ResultBuffer.MarkAcked"/> so acked frames leave the
+    /// buffer; anything unacked replays on the next connection.
+    /// </summary>
+    public Action<long>? OnResultAck { get; set; }
 
     /// <summary>Queues a message for the stream pump. Safe from any thread.</summary>
     public bool TrySend(AgentMessage message) => _outbound.Writer.TryWrite(message);
@@ -165,6 +176,7 @@ public sealed class TunnelClient
 
             heartbeatInterval = TimeSpan.FromSeconds(Math.Max(5, hello.HeartbeatIntervalSeconds));
             siteSlug = hello.SiteSlug;
+            _ackless = !hello.SupportsResultAck;
         }
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {
@@ -233,6 +245,9 @@ public sealed class TunnelClient
                         if (OnProbeRequest is { } probeHandler)
                             _ = probeHandler(message.ProbeRequest, linked.Token);
                         break;
+                    case ServerMessage.PayloadOneofCase.ResultAck:
+                        OnResultAck?.Invoke((long)message.ResultAck.Sequence);
+                        break;
                 }
             }
         }
@@ -246,9 +261,9 @@ public sealed class TunnelClient
 
     /// <summary>
     /// Forces a reconnect when nothing has arrived from the server past the
-    /// silence timeout. Cancelling the connection's source aborts the read
-    /// loop; the caller's reconnect loop then salvages the outbound channel
-    /// and keeps buffering, so a forced reconnect never loses data.
+    /// silence timeout. Cancelling the connection's source aborts the read loop;
+    /// the buffer keeps every unacked frame, so the reconnect replays them and a
+    /// forced reconnect never loses data.
     /// </summary>
     private async Task WatchInboundSilenceAsync(CancellationTokenSource connectionCts, CancellationToken ct)
     {
@@ -265,109 +280,47 @@ public sealed class TunnelClient
     }
 
     /// <summary>
-    /// Feeds this connection from the store-and-forward buffer until the
-    /// tunnel tears down. FIFO order is preserved end to end - the server's
-    /// interface rate calculator needs per-interface samples in chronological
-    /// order - and nothing is lost on teardown: the in-hand message is
-    /// requeued here, and the caller recovers whatever reached the outbound
-    /// channel via <see cref="SalvageUnsentInto"/> AFTER this task completes
-    /// (channel leftovers are older than the in-hand message, and
-    /// RequeueFront slots them back in ahead of it).
+    /// Feeds this connection from the store-and-forward buffer until the tunnel
+    /// tears down. Frames are only PEEKED - each stays in the buffer until the
+    /// server acks it (<see cref="OnResultAck"/>), so a teardown mid-flush loses
+    /// nothing: every unacked frame replays on the next connection. FIFO order is
+    /// preserved end to end (the server's interface rate calculator needs
+    /// per-interface samples in chronological order): a fresh connection replays
+    /// from sequence 0, i.e. the oldest unacked frame.
     /// </summary>
     public async Task DrainResultsAsync(ResultBuffer buffer, CancellationToken ct)
     {
+        long sentThroughSeq = 0;
         while (!ct.IsCancellationRequested)
         {
-            AgentMessage? message = null;
-            try
-            {
-                message = await buffer.DequeueAsync(ct);
-                CoalesceBacklog(buffer, message);
-                while (_outbound.Reader.Count > OutboundHeadroomSlots)
-                    await Task.Delay(20, ct);
-                if (!await SendAsync(message, ct))
-                {
-                    buffer.RequeueFront([message]);
-                    return;
-                }
-                message = null;
-            }
-            catch (OperationCanceledException)
-            {
-                if (message != null)
-                    buffer.RequeueFront([message]);
-                return;
-            }
+            var frame = await buffer.TakeUnsentBatchAsync(sentThroughSeq, CoalesceMaxSamples, ct);
+
+            // Leave headroom so heartbeats and proxied console traffic still get
+            // through while a large backlog flushes.
+            while (_outbound.Reader.Count > OutboundHeadroomSlots)
+                await Task.Delay(20, ct);
+
+            // Tag the frame so the server can ack it; the buffer keeps the
+            // originals until that ack lands, so a black-holed write is not a loss.
+            frame.Message.Sequence = (ulong)frame.ThroughSeq;
+            if (!await SendAsync(frame.Message, ct))
+                return; // tunnel torn down; the buffer still holds every unacked frame
+            sentThroughSeq = frame.ThroughSeq;
+
+            // Against a server that can't ack (older build), no ResultAck will
+            // ever arrive, so trim on send to avoid an ever-growing buffer that
+            // re-flushes on every reconnect. Cumulative, so it also clears any
+            // frames sent before the hello revealed the server was ack-less.
+            if (_ackless)
+                buffer.MarkAcked(frame.ThroughSeq);
         }
     }
-
-    /// <summary>
-    /// Merges consecutive same-type result batches from the buffer into
-    /// <paramref name="message"/>, up to <see cref="CoalesceMaxSamples"/>
-    /// samples. Only a backlog coalesces - in live flow the buffer is empty and
-    /// each batch ships as produced.
-    /// </summary>
-    private static void CoalesceBacklog(ResultBuffer buffer, AgentMessage message)
-    {
-        if (message.PayloadCase == AgentMessage.PayloadOneofCase.ProbeResults)
-        {
-            while (message.ProbeResults.Results.Count < CoalesceMaxSamples
-                   && buffer.TryDequeueIf(
-                       m => m.PayloadCase == AgentMessage.PayloadOneofCase.ProbeResults, out var next))
-            {
-                message.ProbeResults.Results.AddRange(next.ProbeResults.Results);
-            }
-        }
-        else if (message.PayloadCase == AgentMessage.PayloadOneofCase.SnmpResults)
-        {
-            int Samples() => message.SnmpResults.Interfaces.Count
-                             + message.SnmpResults.Health.Count
-                             + message.SnmpResults.CustomOids.Count;
-            while (Samples() < CoalesceMaxSamples
-                   && buffer.TryDequeueIf(
-                       m => m.PayloadCase == AgentMessage.PayloadOneofCase.SnmpResults, out var next))
-            {
-                message.SnmpResults.Interfaces.AddRange(next.SnmpResults.Interfaces);
-                message.SnmpResults.Health.AddRange(next.SnmpResults.Health);
-                message.SnmpResults.CustomOids.AddRange(next.SnmpResults.CustomOids);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Recovers monitoring results still parked in the (now closed) outbound
-    /// channel back into the buffer, so a tunnel drop or failed connect loses
-    /// nothing. Call after <see cref="RunAsync"/> has returned AND the drain
-    /// task has completed - the drain requeues its own in-hand message first,
-    /// and these channel items are older, so inserting them at the front last
-    /// restores exact FIFO order. Request/response payloads (proxy frames, OID
-    /// test replies, speed-test results) are connection-scoped and discarded.
-    /// </summary>
-    public void SalvageUnsentInto(ResultBuffer buffer)
-    {
-        var leftovers = new List<AgentMessage>();
-        if (_pumpInFlight is { } inFlight && IsBufferable(inFlight))
-            leftovers.Add(inFlight);
-        _pumpInFlight = null;
-        while (_outbound.Reader.TryRead(out var message))
-        {
-            if (IsBufferable(message))
-                leftovers.Add(message);
-        }
-        buffer.RequeueFront(leftovers);
-    }
-
-    private static bool IsBufferable(AgentMessage message) =>
-        message.PayloadCase is AgentMessage.PayloadOneofCase.ProbeResults
-            or AgentMessage.PayloadOneofCase.SnmpResults;
 
     private async Task PumpOutboundAsync(IClientStreamWriter<AgentMessage> requestStream, CancellationToken ct)
     {
         await foreach (var message in _outbound.Reader.ReadAllAsync(ct))
         {
-            _pumpInFlight = message;
             await requestStream.WriteAsync(message, ct);
-            _pumpInFlight = null;
         }
     }
 

--- a/src/NetworkOptimizer.AgentProtocol/Protos/agent_tunnel.proto
+++ b/src/NetworkOptimizer.AgentProtocol/Protos/agent_tunnel.proto
@@ -27,6 +27,14 @@ message AgentMessage {
     ProbeResponse probe_response = 10;
     SnmpOidResult snmp_oid_result = 11;
   }
+  // Monotonic per-agent sequence for store-and-forward acking. Set on
+  // probe_results / snmp_results frames only; 0 on control frames and on older
+  // agents. The agent keeps the batch buffered until the server echoes this
+  // number in a ResultAck (persisted), then trims it. Without this, a
+  // black-holed tunnel - where TCP still "accepts" writes into a dead socket and
+  // reports success - would let the buffer drain into the void and silently lose
+  // an outage's worth of data.
+  uint64 sequence = 12;
 }
 
 message ServerMessage {
@@ -42,7 +50,17 @@ message ServerMessage {
     ProbeRequest probe_request = 9;
     SnmpOidQuery snmp_oid_query = 10;
     WanSpeedTestConfig wan_speedtest_config = 11;
+    ResultAck result_ack = 12;
   }
+}
+
+// Cumulative acknowledgement of store-and-forward result frames. Sent by the
+// server after a probe_results / snmp_results batch is persisted; acking
+// sequence N confirms every frame with sequence <= N. The agent then trims
+// those from its buffer. An unacked frame stays buffered and replays on the
+// next connection, so nothing is lost when a tunnel black-holes.
+message ResultAck {
+  uint64 sequence = 1;
 }
 
 // ---- WAN speed test routing (agent /wan/ router) ----
@@ -120,6 +138,12 @@ message ServerHello {
   string site_slug = 1;
   string agent_name = 2;
   int32 heartbeat_interval_seconds = 3;
+  // True on servers that acknowledge result frames (>= the store-and-forward
+  // ack protocol). Absent/false (an older server) tells the agent NOT to wait
+  // for acks: it trims each frame on send, matching the pre-ack behavior, so a
+  // newer agent against an older server doesn't retain its whole buffer and
+  // re-flush it on every reconnect.
+  bool supports_result_ack = 4;
 }
 
 message AgentHeartbeat {

--- a/src/NetworkOptimizer.AgentProtocol/ResultBuffer.cs
+++ b/src/NetworkOptimizer.AgentProtocol/ResultBuffer.cs
@@ -4,10 +4,21 @@ namespace NetworkOptimizer.AgentProtocol;
 /// Store-and-forward buffer between the agent's collectors (probe and SNMP
 /// runners) and the tunnel. Collectors always enqueue here - never directly
 /// into a connection - so monitoring continues through tunnel outages and the
-/// backlog replays in order once the tunnel reconnects. Bounded by sample age
-/// and total serialized size; when either cap is exceeded the OLDEST messages
-/// are dropped, since the newest data is the most valuable when the link
-/// returns. Thread-safe for any number of producers and consumers.
+/// backlog replays in order once the tunnel reconnects.
+///
+/// A message stays in the buffer until the SERVER acknowledges it (see
+/// <see cref="MarkAcked"/>), NOT when it is written to the socket. TCP reports a
+/// write into a black-holed connection as success (the bytes sit in the kernel
+/// send buffer and are discarded on teardown), so dropping a message on send
+/// would silently lose an outage's worth of data the moment the link goes dead.
+/// The drain therefore only ever PEEKS unsent entries
+/// (<see cref="TakeUnsentBatchAsync"/>); an unacked frame is re-sent on the next
+/// connection.
+///
+/// Bounded by sample age and total serialized size; when either cap is exceeded
+/// the OLDEST messages are dropped, since the newest data is the most valuable
+/// when the link returns - this is the only way a message leaves the buffer
+/// without being acked. Thread-safe for any number of producers and consumers.
 /// </summary>
 public sealed class ResultBuffer
 {
@@ -22,7 +33,11 @@ public sealed class ResultBuffer
     /// </summary>
     public const long DefaultMaxBytes = 64 * 1024 * 1024;
 
-    private readonly record struct Entry(AgentMessage Message, DateTime EnqueuedUtc, int SizeBytes);
+    /// <summary>One buffered message and the monotonic sequence assigned at enqueue.</summary>
+    private readonly record struct Entry(long Seq, AgentMessage Message, DateTime EnqueuedUtc, int SizeBytes);
+
+    /// <summary>A coalesced frame ready to send, tagged with the highest sequence it covers.</summary>
+    public sealed record SendFrame(AgentMessage Message, long ThroughSeq);
 
     private readonly LinkedList<Entry> _entries = new();
     private readonly SemaphoreSlim _available = new(0);
@@ -30,6 +45,7 @@ public sealed class ResultBuffer
     private readonly TimeSpan _maxAge;
     private readonly long _maxBytes;
     private long _bytes;
+    private long _nextSeq;
     private long _dropped;
     private long _droppedUnreported;
 
@@ -39,7 +55,7 @@ public sealed class ResultBuffer
         _maxBytes = maxBytes ?? DefaultMaxBytes;
     }
 
-    /// <summary>Number of buffered messages.</summary>
+    /// <summary>Number of buffered (unacked) messages.</summary>
     public int Count
     {
         get { lock (_lock) return _entries.Count; }
@@ -71,12 +87,15 @@ public sealed class ResultBuffer
         }
     }
 
-    /// <summary>Appends a message, evicting the oldest entries past the caps.</summary>
+    /// <summary>
+    /// Appends a message with the next sequence number, evicting the oldest
+    /// entries past the caps.
+    /// </summary>
     public void Enqueue(AgentMessage message)
     {
         lock (_lock)
         {
-            var entry = new Entry(message, DateTime.UtcNow, message.CalculateSize());
+            var entry = new Entry(++_nextSeq, message, DateTime.UtcNow, message.CalculateSize());
             _entries.AddLast(entry);
             _bytes += entry.SizeBytes;
             EvictLocked();
@@ -85,72 +104,95 @@ public sealed class ResultBuffer
     }
 
     /// <summary>
-    /// Reinserts messages at the FRONT, preserving their order, so a failed
-    /// send slots back in ahead of everything enqueued since. Entries get a
-    /// fresh age stamp - they were dequeued seconds ago at most, so the age
-    /// cap distortion is negligible.
+    /// Peeks the oldest run of entries whose sequence is greater than
+    /// <paramref name="afterSeq"/>, coalescing consecutive same-type batches up
+    /// to <paramref name="maxSamples"/>, and returns them as one frame tagged
+    /// with the highest sequence it covers. Entries are NOT removed - they stay
+    /// buffered until <see cref="MarkAcked"/>. Waits until such an entry exists;
+    /// throws <see cref="OperationCanceledException"/> on cancellation.
+    /// A caller re-sending after a reconnect passes afterSeq = 0 to replay every
+    /// unacked entry from the oldest.
     /// </summary>
-    public void RequeueFront(IReadOnlyList<AgentMessage> messages)
-    {
-        if (messages.Count == 0) return;
-        lock (_lock)
-        {
-            var now = DateTime.UtcNow;
-            for (var i = messages.Count - 1; i >= 0; i--)
-            {
-                var entry = new Entry(messages[i], now, messages[i].CalculateSize());
-                _entries.AddFirst(entry);
-                _bytes += entry.SizeBytes;
-            }
-            EvictLocked();
-        }
-        _available.Release(messages.Count);
-    }
-
-    /// <summary>
-    /// Takes the oldest message, waiting until one is available. Throws
-    /// <see cref="OperationCanceledException"/> on cancellation.
-    /// </summary>
-    public async ValueTask<AgentMessage> DequeueAsync(CancellationToken ct)
+    public async ValueTask<SendFrame> TakeUnsentBatchAsync(long afterSeq, int maxSamples, CancellationToken ct)
     {
         while (true)
         {
-            // Evictions and TryDequeueIf remove entries without consuming
-            // permits, so a wake-up can find the list empty - loop and wait
-            // for the next permit. Permits never undercount entries.
-            await _available.WaitAsync(ct);
             lock (_lock)
             {
-                if (_entries.Count > 0)
-                    return TakeFirstLocked();
+                var frame = BuildUnsentFrameLocked(afterSeq, maxSamples);
+                if (frame != null)
+                    return frame;
             }
+            await _available.WaitAsync(ct);
+            // Evictions and coalescing consume entries without matching permits,
+            // so drain any surplus and re-check under the lock. The synchronous
+            // BuildUnsentFrameLocked above is the source of truth; the permit is
+            // only a wake-up, so an over- or under-count never loses a frame.
+            while (_available.Wait(0)) { }
         }
     }
 
     /// <summary>
-    /// Takes the oldest message only if it satisfies <paramref name="predicate"/>.
-    /// Used by the tunnel drain to coalesce a backlog of same-type batches.
+    /// Removes every buffered entry whose sequence is at or below
+    /// <paramref name="throughSeq"/> - the server's cumulative acknowledgement
+    /// that those frames are persisted. Sequences are monotonic and entries are
+    /// ordered, so the acked run is always at the front.
     /// </summary>
-    public bool TryDequeueIf(Func<AgentMessage, bool> predicate, out AgentMessage message)
+    public void MarkAcked(long throughSeq)
     {
         lock (_lock)
         {
-            if (_entries.Count > 0 && predicate(_entries.First!.Value.Message))
+            while (_entries.First is { } first && first.Value.Seq <= throughSeq)
             {
-                message = TakeFirstLocked();
-                return true;
+                _bytes -= first.Value.SizeBytes;
+                _entries.RemoveFirst();
             }
         }
-        message = null!;
-        return false;
     }
 
-    private AgentMessage TakeFirstLocked()
+    private SendFrame? BuildUnsentFrameLocked(long afterSeq, int maxSamples)
     {
-        var entry = _entries.First!.Value;
-        _entries.RemoveFirst();
-        _bytes -= entry.SizeBytes;
-        return entry.Message;
+        var node = _entries.First;
+        while (node != null && node.Value.Seq <= afterSeq)
+            node = node.Next;
+        if (node == null)
+            return null;
+
+        // Clone so the buffered originals stay intact for a possible re-send;
+        // coalescing must never mutate what is still awaiting an ack.
+        var merged = node.Value.Message.Clone();
+        var throughSeq = node.Value.Seq;
+        node = node.Next;
+
+        if (merged.PayloadCase == AgentMessage.PayloadOneofCase.ProbeResults)
+        {
+            while (node != null
+                   && node.Value.Message.PayloadCase == AgentMessage.PayloadOneofCase.ProbeResults
+                   && merged.ProbeResults.Results.Count < maxSamples)
+            {
+                merged.ProbeResults.Results.AddRange(node.Value.Message.ProbeResults.Results);
+                throughSeq = node.Value.Seq;
+                node = node.Next;
+            }
+        }
+        else if (merged.PayloadCase == AgentMessage.PayloadOneofCase.SnmpResults)
+        {
+            int Samples() => merged.SnmpResults.Interfaces.Count
+                             + merged.SnmpResults.Health.Count
+                             + merged.SnmpResults.CustomOids.Count;
+            while (node != null
+                   && node.Value.Message.PayloadCase == AgentMessage.PayloadOneofCase.SnmpResults
+                   && Samples() < maxSamples)
+            {
+                merged.SnmpResults.Interfaces.AddRange(node.Value.Message.SnmpResults.Interfaces);
+                merged.SnmpResults.Health.AddRange(node.Value.Message.SnmpResults.Health);
+                merged.SnmpResults.CustomOids.AddRange(node.Value.Message.SnmpResults.CustomOids);
+                throughSeq = node.Value.Seq;
+                node = node.Next;
+            }
+        }
+
+        return new SendFrame(merged, throughSeq);
     }
 
     private void EvictLocked()

--- a/src/NetworkOptimizer.AgentProtocol/ResultBuffer.cs
+++ b/src/NetworkOptimizer.AgentProtocol/ResultBuffer.cs
@@ -1,0 +1,168 @@
+namespace NetworkOptimizer.AgentProtocol;
+
+/// <summary>
+/// Store-and-forward buffer between the agent's collectors (probe and SNMP
+/// runners) and the tunnel. Collectors always enqueue here - never directly
+/// into a connection - so monitoring continues through tunnel outages and the
+/// backlog replays in order once the tunnel reconnects. Bounded by sample age
+/// and total serialized size; when either cap is exceeded the OLDEST messages
+/// are dropped, since the newest data is the most valuable when the link
+/// returns. Thread-safe for any number of producers and consumers.
+/// </summary>
+public sealed class ResultBuffer
+{
+    /// <summary>Oldest data worth replaying after an outage.</summary>
+    public static readonly TimeSpan DefaultMaxAge = TimeSpan.FromHours(12);
+
+    /// <summary>
+    /// Cap on total serialized message bytes. Sized so ~12 h of a typical
+    /// agent site's probe + SNMP output fits with room to spare (see the
+    /// per-sample estimates in the tunnel drain); a much larger site trims to
+    /// proportionally fewer hours instead of growing without bound.
+    /// </summary>
+    public const long DefaultMaxBytes = 64 * 1024 * 1024;
+
+    private readonly record struct Entry(AgentMessage Message, DateTime EnqueuedUtc, int SizeBytes);
+
+    private readonly LinkedList<Entry> _entries = new();
+    private readonly SemaphoreSlim _available = new(0);
+    private readonly object _lock = new();
+    private readonly TimeSpan _maxAge;
+    private readonly long _maxBytes;
+    private long _bytes;
+    private long _dropped;
+    private long _droppedUnreported;
+
+    public ResultBuffer(TimeSpan? maxAge = null, long? maxBytes = null)
+    {
+        _maxAge = maxAge ?? DefaultMaxAge;
+        _maxBytes = maxBytes ?? DefaultMaxBytes;
+    }
+
+    /// <summary>Number of buffered messages.</summary>
+    public int Count
+    {
+        get { lock (_lock) return _entries.Count; }
+    }
+
+    /// <summary>Total serialized size of the buffered messages.</summary>
+    public long ApproxBytes
+    {
+        get { lock (_lock) return _bytes; }
+    }
+
+    /// <summary>Messages dropped by the age/size caps since construction.</summary>
+    public long DroppedTotal
+    {
+        get { lock (_lock) return _dropped; }
+    }
+
+    /// <summary>
+    /// Messages dropped since the last call, for periodic logging. Resets the
+    /// unreported counter.
+    /// </summary>
+    public long TakeDroppedCount()
+    {
+        lock (_lock)
+        {
+            var count = _droppedUnreported;
+            _droppedUnreported = 0;
+            return count;
+        }
+    }
+
+    /// <summary>Appends a message, evicting the oldest entries past the caps.</summary>
+    public void Enqueue(AgentMessage message)
+    {
+        lock (_lock)
+        {
+            var entry = new Entry(message, DateTime.UtcNow, message.CalculateSize());
+            _entries.AddLast(entry);
+            _bytes += entry.SizeBytes;
+            EvictLocked();
+        }
+        _available.Release();
+    }
+
+    /// <summary>
+    /// Reinserts messages at the FRONT, preserving their order, so a failed
+    /// send slots back in ahead of everything enqueued since. Entries get a
+    /// fresh age stamp - they were dequeued seconds ago at most, so the age
+    /// cap distortion is negligible.
+    /// </summary>
+    public void RequeueFront(IReadOnlyList<AgentMessage> messages)
+    {
+        if (messages.Count == 0) return;
+        lock (_lock)
+        {
+            var now = DateTime.UtcNow;
+            for (var i = messages.Count - 1; i >= 0; i--)
+            {
+                var entry = new Entry(messages[i], now, messages[i].CalculateSize());
+                _entries.AddFirst(entry);
+                _bytes += entry.SizeBytes;
+            }
+            EvictLocked();
+        }
+        _available.Release(messages.Count);
+    }
+
+    /// <summary>
+    /// Takes the oldest message, waiting until one is available. Throws
+    /// <see cref="OperationCanceledException"/> on cancellation.
+    /// </summary>
+    public async ValueTask<AgentMessage> DequeueAsync(CancellationToken ct)
+    {
+        while (true)
+        {
+            // Evictions and TryDequeueIf remove entries without consuming
+            // permits, so a wake-up can find the list empty - loop and wait
+            // for the next permit. Permits never undercount entries.
+            await _available.WaitAsync(ct);
+            lock (_lock)
+            {
+                if (_entries.Count > 0)
+                    return TakeFirstLocked();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Takes the oldest message only if it satisfies <paramref name="predicate"/>.
+    /// Used by the tunnel drain to coalesce a backlog of same-type batches.
+    /// </summary>
+    public bool TryDequeueIf(Func<AgentMessage, bool> predicate, out AgentMessage message)
+    {
+        lock (_lock)
+        {
+            if (_entries.Count > 0 && predicate(_entries.First!.Value.Message))
+            {
+                message = TakeFirstLocked();
+                return true;
+            }
+        }
+        message = null!;
+        return false;
+    }
+
+    private AgentMessage TakeFirstLocked()
+    {
+        var entry = _entries.First!.Value;
+        _entries.RemoveFirst();
+        _bytes -= entry.SizeBytes;
+        return entry.Message;
+    }
+
+    private void EvictLocked()
+    {
+        var cutoff = DateTime.UtcNow - _maxAge;
+        while (_entries.Count > 0
+               && (_bytes > _maxBytes || _entries.First!.Value.EnqueuedUtc < cutoff))
+        {
+            _bytes -= _entries.First!.Value.SizeBytes;
+            _entries.RemoveFirst();
+            _dropped++;
+            _droppedUnreported++;
+        }
+    }
+}

--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -87,13 +87,25 @@ public class UniFiApiClient : IDisposable
         _site = site;
         _ignoreSSLErrors = ignoreSSLErrors;
 
-        // Configure retry policy for transient failures
+        // Configure retry policy for transient failures. A console reached through
+        // an agent tunnel is dialed via a loopback proxy (127.0.0.1); when that
+        // tunnel is black-holed the proxy fast-fails the open, but this retry sits
+        // ABOVE the proxy and would otherwise stack the full 2+4+8s (~14s)
+        // exponential backoff onto every request - which reads as a frozen site
+        // switch on that site for the whole ~90s before the watchdog flips the
+        // console to awaiting-agent. Retrying a dead tunnel can't help, so
+        // agent-proxied consoles get a single quick retry. Directly-connected
+        // consoles keep the full backoff - a real transient blip there is worth
+        // riding out.
+        var viaAgentProxy = _controllerUrl.Contains("127.0.0.1");
         _retryPolicy = Policy
             .Handle<HttpRequestException>()
             .Or<TaskCanceledException>()
             .WaitAndRetryAsync(
-                retryCount: 3,
-                sleepDurationProvider: retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
+                retryCount: viaAgentProxy ? 1 : 3,
+                sleepDurationProvider: retryAttempt => viaAgentProxy
+                    ? TimeSpan.FromMilliseconds(500)
+                    : TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
                 onRetry: (exception, timespan, retryCount, context) =>
                 {
                     _logger.LogWarning("Retry {RetryCount} after {Timespan}s due to {Exception}",

--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -442,6 +442,39 @@
             });
             reconnectObserver.observe(reconnectModal, { attributes: true });
         }
+
+        // PWA / mobile resume recovery. When the app is backgrounded, iOS and
+        // Android suspend the tab and its Blazor WebSocket dies, but on resume
+        // Blazor often does NOT surface the reconnect modal (the socket looks
+        // open to it), so the page sits on its stale prerender with frozen
+        // loading spinners until a manual refresh - exactly what a user sees
+        // returning to a long-backgrounded dashboard. If the tab was hidden
+        // long enough that the circuit almost certainly dropped, reload on
+        // resume. The reconnect-modal observer above already covers the case
+        // where Blazor DOES detect the drop, so defer to it when it's showing
+        // to avoid a double reload. scrollRestoration.js and the site-context
+        // pin keep the reload on the same place and site.
+        (function () {
+            const STALE_HIDDEN_MS = 30000;
+            let hiddenAt = null;
+            document.addEventListener('visibilitychange', function () {
+                if (document.visibilityState === 'hidden') {
+                    hiddenAt = Date.now();
+                    return;
+                }
+                if (hiddenAt === null) return;
+                const hiddenMs = Date.now() - hiddenAt;
+                hiddenAt = null;
+                const modal = document.getElementById('components-reconnect-modal');
+                const blazorHandlingDrop = modal && (
+                    modal.classList.contains('components-reconnect-show') ||
+                    modal.classList.contains('components-reconnect-failed') ||
+                    modal.classList.contains('components-reconnect-rejected'));
+                if (hiddenMs >= STALE_HIDDEN_MS && !blazorHandlingDrop) {
+                    location.reload();
+                }
+            });
+        })();
     </script>
 </body>
 

--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -444,20 +444,45 @@
         }
 
         // PWA / mobile resume recovery. When the app is backgrounded, iOS and
-        // Android suspend the tab and its Blazor WebSocket dies, but on resume
-        // Blazor often does NOT surface the reconnect modal (the socket looks
-        // open to it), so the page sits on its stale prerender with frozen
-        // loading spinners until a manual refresh - exactly what a user sees
-        // returning to a long-backgrounded dashboard. If the tab was hidden
-        // long enough that the circuit almost certainly dropped, reload on
-        // resume. The reconnect-modal observer above already covers the case
-        // where Blazor DOES detect the drop, so defer to it when it's showing
-        // to avoid a double reload. scrollRestoration.js and the site-context
-        // pin keep the reload on the same place and site.
+        // Android suspend the tab and its Blazor WebSocket can die, but on resume
+        // Blazor often does NOT surface the reconnect modal (the socket still
+        // looks open to it), so the page sits on its stale prerender with frozen
+        // loading spinners until a manual refresh. Rather than reload on a blind
+        // timer - which threw away scroll position and in-page state even when
+        // the circuit had actually survived the backgrounding - PROBE the circuit
+        // on resume and only reload when it's genuinely dead. A live circuit
+        // answers the round-trip in a few ms; a dead-but-open socket never
+        // replies, so the timeout tells us a reload is really needed. The
+        // reconnect-modal observer above covers the case where Blazor detects the
+        // drop itself, so defer to it when it's showing.
         (function () {
             const STALE_HIDDEN_MS = 30000;
+            const PROBE_TIMEOUT_MS = 2500;
             let hiddenAt = null;
-            document.addEventListener('visibilitychange', function () {
+
+            function blazorHandlingDrop() {
+                const m = document.getElementById('components-reconnect-modal');
+                return !!m && (
+                    m.classList.contains('components-reconnect-show') ||
+                    m.classList.contains('components-reconnect-failed') ||
+                    m.classList.contains('components-reconnect-rejected'));
+            }
+
+            async function circuitAlive() {
+                if (!window.DotNet) return false;
+                try {
+                    await Promise.race([
+                        DotNet.invokeMethodAsync('NetworkOptimizer.Web', 'Ping'),
+                        new Promise((_, reject) =>
+                            setTimeout(() => reject(new Error('probe timeout')), PROBE_TIMEOUT_MS))
+                    ]);
+                    return true;
+                } catch {
+                    return false;
+                }
+            }
+
+            document.addEventListener('visibilitychange', async function () {
                 if (document.visibilityState === 'hidden') {
                     hiddenAt = Date.now();
                     return;
@@ -465,12 +490,12 @@
                 if (hiddenAt === null) return;
                 const hiddenMs = Date.now() - hiddenAt;
                 hiddenAt = null;
-                const modal = document.getElementById('components-reconnect-modal');
-                const blazorHandlingDrop = modal && (
-                    modal.classList.contains('components-reconnect-show') ||
-                    modal.classList.contains('components-reconnect-failed') ||
-                    modal.classList.contains('components-reconnect-rejected'));
-                if (hiddenMs >= STALE_HIDDEN_MS && !blazorHandlingDrop) {
+                if (hiddenMs < STALE_HIDDEN_MS || blazorHandlingDrop()) return;
+
+                // Only reload when the circuit is genuinely dead; otherwise pick
+                // up exactly where we left off. Re-check the modal after the probe
+                // in case Blazor surfaced its own reconnect UI meanwhile.
+                if (!(await circuitAlive()) && !blazorHandlingDrop()) {
                     location.reload();
                 }
             });

--- a/src/NetworkOptimizer.Web/CircuitLiveness.cs
+++ b/src/NetworkOptimizer.Web/CircuitLiveness.cs
@@ -1,0 +1,19 @@
+using Microsoft.JSInterop;
+
+namespace NetworkOptimizer.Web;
+
+/// <summary>
+/// A trivial round-trip the client can invoke to tell a live Blazor circuit
+/// from a dead-but-open socket. On PWA/mobile resume the WebSocket can be dead
+/// while still looking open to the client, so the resume handler in App.razor
+/// calls <see cref="Ping"/> with a short timeout: a fast reply means the
+/// circuit is fine (pick up seamlessly), and a timeout means it genuinely needs
+/// a reload. This replaces a blind time-based reload that fired even when the
+/// circuit had survived the backgrounding.
+/// </summary>
+public static class CircuitLiveness
+{
+    /// <summary>Returns immediately over the circuit; the value is unused - only that it round-trips.</summary>
+    [JSInvokable]
+    public static bool Ping() => true;
+}

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -3184,7 +3184,7 @@ else
                     "  window.__monitoringRef = ref;" +
                     $"  const m = await import('{VersionedJs("/js/lan-flow-map.js")}');" +
                     "  window.__lanFlowMap = m;" +
-                    "  await m.mount(canvasId);" +
+                    $"  await m.mount(canvasId, {{ storagePrefix: '{SiteCtx.ScopeStorageKey("lanFlowMap")}' }});" +
                     "}");
                 await JS.InvokeVoidAsync("__mountLanFlowMap", "lan-flow-map-canvas", _mapDotNetRef);
             }
@@ -3206,7 +3206,7 @@ else
             try
             {
                 await JS.InvokeVoidAsync("eval",
-                    $"(async () => {{ const m = await import('{VersionedJs("/js/lan-flow-map-2d.js")}'); window.__lanFlowMap2d = m; await m.mount('lan-flow-map-2d-stage'); }})();");
+                    $"(async () => {{ const m = await import('{VersionedJs("/js/lan-flow-map-2d.js")}'); window.__lanFlowMap2d = m; await m.mount('lan-flow-map-2d-stage', {{ storagePrefix: '{SiteCtx.ScopeStorageKey("lanFlowMap2d")}' }}); }})();");
             }
             catch (Exception ex) { _map2dMounted = false; Logger.LogDebug(ex, "2D map mount failed; will retry on next render"); }
         }

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -194,7 +194,7 @@
                         <input type="checkbox" checked disabled />
                         <span>Ignore SSL certificate errors</span>
                     </label>
-                    <small class="form-help">Always on for consoles connected via the site's agent: the connection rides the agent tunnel, so the console's certificate can't be matched against the tunnel endpoint.</small>
+                    <small class="form-help">Certificate validation isn't supported when connecting through the site's agent.</small>
                 }
                 else
                 {

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -188,11 +188,22 @@
             </div>
 
             <div class="form-group">
-                <label class="checkbox-label">
-                    <input type="checkbox" @bind="ignoreControllerSSLErrors" />
-                    <span>Ignore SSL certificate errors</span>
-                </label>
-                <small class="form-help">Enable this for UniFi Consoles with self-signed certificates (default)</small>
+                @if (_currentSiteConsoleViaAgent)
+                {
+                    <label class="checkbox-label">
+                        <input type="checkbox" checked disabled />
+                        <span>Ignore SSL certificate errors</span>
+                    </label>
+                    <small class="form-help">Always on for consoles connected via the site's agent: the connection rides the agent tunnel, so the console's certificate can't be matched against the tunnel endpoint.</small>
+                }
+                else
+                {
+                    <label class="checkbox-label">
+                        <input type="checkbox" @bind="ignoreControllerSSLErrors" />
+                        <span>Ignore SSL certificate errors</span>
+                    </label>
+                    <small class="form-help">Enable this for UniFi Consoles with self-signed certificates (default)</small>
+                }
             </div>
 
             <div class="action-buttons">

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -240,7 +240,7 @@ else
                         "window.__dashMountMap3d = async function(canvasId) {" +
                         $"  const m = await import('{VersionedJs("/js/lan-flow-map.js")}');" +
                         "  window.__dashLanFlowMap = m;" +
-                        "  await m.mount(canvasId,{storagePrefix:'dashLanFlowMap',signalHint:false});" +
+                        $"  await m.mount(canvasId,{{storagePrefix:'{SiteCtx.ScopeStorageKey("dashLanFlowMap")}',signalHint:false}});" +
                         "}");
                     await JS.InvokeVoidAsync("__dashMountMap3d", "dashboard-lan-flow-map-canvas");
                 }
@@ -249,7 +249,7 @@ else
                     await JS.InvokeVoidAsync("eval",
                         $"(async () => {{ const m = await import('{VersionedJs("/js/lan-flow-map-2d.js")}'); " +
                         "window.__dashLanFlowMap2d = m; m.startDataPolling(); " +
-                        "await m.mount('dashboard-lan-flow-map-2d-stage',{storagePrefix:'dashLanFlowMap2d',liveOnly:true}); })();");
+                        $"await m.mount('dashboard-lan-flow-map-2d-stage',{{storagePrefix:'{SiteCtx.ScopeStorageKey("dashLanFlowMap2d")}',liveOnly:true}}); }})();");
                 }
             }
             catch { _mapMounted = false; _mountedMode = null; }

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -39,6 +39,18 @@ else
         ? $"/monitoring?tab=devices&device={Uri.EscapeDataString(_gatewayMac)}"
         : "/monitoring?tab=devices";
     <div class="lv-panel">
+        @if (ShowConsoleDownBanner)
+        {
+            <div class="connection-banner">
+                <div class="banner-content">
+                    <span class="banner-icon">!</span>
+                    <div class="banner-text">
+                        <strong>@ConsoleDownTitle</strong>
+                        <span>@ConsoleDownMessage</span>
+                    </div>
+                </div>
+            </div>
+        }
         <div class="monitoring-stat-cards">
             @{ var wanRates = GetWanRates(); }
             <div class="monitoring-stat-card monitoring-stat-rate">
@@ -190,6 +202,7 @@ else
     [Parameter] public string MapMode { get; set; } = "2d";
 
     private bool _ready;
+    private bool _consoleUnreachable;
     private string? _gatewayMac;
     private List<string> _gatewayWanIfNames = new();
     private List<MonitoringTarget> _targets = new();
@@ -314,13 +327,29 @@ else
 
             _targets = await db.MonitoringTargets.Where(t => t.Enabled).ToListAsync();
 
-            var devices = await ConnectionService.GetDiscoveredDevicesAsync();
-            if (devices != null)
+            // The gateway identity is only a nice-to-have for deep links; fetch it
+            // from the console but DON'T let a down console (an agent-tunnel outage)
+            // fail the whole panel and show the "not configured" empty state -
+            // monitoring IS configured, the console is just unreachable. Live stats
+            // come from the buffers/Influx, not this call; the console-down banner
+            // explains any staleness instead.
+            try
             {
-                var gw = devices.FirstOrDefault(d =>
-                    d.Type == DeviceType.Gateway || d.HardwareType == DeviceType.Gateway);
-                _gatewayMac = gw?.Mac?.Replace("-", ":").ToLowerInvariant();
-                _gatewayWanIfNames = gw?.WanInterfaceNames ?? new();
+                var devices = await ConnectionService.GetDiscoveredDevicesAsync();
+                if (devices != null)
+                {
+                    var gw = devices.FirstOrDefault(d =>
+                        d.Type == DeviceType.Gateway || d.HardwareType == DeviceType.Gateway);
+                    _gatewayMac = gw?.Mac?.Replace("-", ":").ToLowerInvariant();
+                    _gatewayWanIfNames = gw?.WanInterfaceNames ?? new();
+                }
+                _consoleUnreachable = false;
+            }
+            catch
+            {
+                // Console unreachable (agent tunnel down): keep prior gateway info
+                // and surface the banner rather than blanking the panel.
+                _consoleUnreachable = true;
             }
 
             _ready = true;
@@ -330,6 +359,21 @@ else
             _ready = false;
         }
     }
+
+    // Console-down banner: the console was unreachable this load, or the
+    // connection has flipped to awaiting-agent / disconnected.
+    private bool ShowConsoleDownBanner =>
+        _consoleUnreachable || (ConnectionService.IsInitialized && !ConnectionService.IsConnected);
+
+    private string ConsoleDownTitle =>
+        ConnectionService.IsAwaitingAgent ? "Agent offline"
+        : ConnectionService.IsConnected ? "Console not responding"
+        : "Console disconnected";
+
+    private string ConsoleDownMessage =>
+        !string.IsNullOrEmpty(ConnectionService.LastError)
+            ? ConnectionService.LastError!
+            : "The console isn't responding right now. Live data is paused until it reconnects.";
 
     private (double download, double upload) GetWanRates()
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/PwaBanner.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/PwaBanner.razor
@@ -39,7 +39,7 @@
                     "window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true");
                 if (isStandalone) return;
 
-                var dismissed = await SettingsService.GetAsync(SystemSettingKeys.PwaBannerDismissed);
+                var dismissed = await SettingsService.GetGlobalAsync(SystemSettingKeys.PwaBannerDismissed);
                 if (string.IsNullOrEmpty(dismissed) || !dismissed.Equals("true", StringComparison.OrdinalIgnoreCase))
                 {
                     _visible = true;
@@ -58,7 +58,7 @@
         _visible = false;
         try
         {
-            await SettingsService.SetAsync(SystemSettingKeys.PwaBannerDismissed, "true");
+            await SettingsService.SetGlobalAsync(SystemSettingKeys.PwaBannerDismissed, "true");
         }
         catch
         {

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -624,7 +624,7 @@
     {
         try
         {
-            var dismissed = await SettingsService.GetAsync(SystemSettingKeys.ChannelDisclaimerDismissed);
+            var dismissed = await SettingsService.GetGlobalAsync(SystemSettingKeys.ChannelDisclaimerDismissed);
             _channelDisclaimerDismissed = !string.IsNullOrEmpty(dismissed) && dismissed.Equals("true", StringComparison.OrdinalIgnoreCase);
         }
         catch { /* Non-critical */ }
@@ -1281,7 +1281,7 @@
         _channelDisclaimerDismissed = true;
         try
         {
-            await SettingsService.SetAsync(SystemSettingKeys.ChannelDisclaimerDismissed, "true");
+            await SettingsService.SetGlobalAsync(SystemSettingKeys.ChannelDisclaimerDismissed, "true");
         }
         catch { /* Still hide it */ }
     }

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -113,6 +113,29 @@ public class AgentProbeResultSink
         });
     }
 
+    /// <summary>
+    /// Called by the tunnel watchdog when a still-registered tunnel goes silent
+    /// past the stale threshold (black-holed, not yet droppable at 90s). Flips
+    /// the site's console to awaiting-agent proactively, so a site nobody has
+    /// touched during the outage doesn't stay stale-green until first contact -
+    /// which made the first switch to it pay a dial-and-retry on every console
+    /// call. Fire-and-forget; the flip is idempotent.
+    /// </summary>
+    public void OnTunnelStale(AgentTunnelConnection connection)
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await _siteConnections.GetFor(connection.SiteSlug).NoteTunnelUnreachableAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Stale-tunnel awaiting-agent flip failed for site {Slug}", connection.SiteSlug);
+            }
+        });
+    }
+
     private async Task ReconnectConsoleIfViaAgentAsync(AgentTunnelConnection connection)
     {
         try

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -46,6 +46,13 @@ public class AgentProbeResultSink
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _consoleFetchGate = new();
     private static readonly TimeSpan ConsoleCacheTtl = TimeSpan.FromSeconds(60);
 
+    // Samples older than this skip the alert state machines. Agents replay
+    // their store-and-forward backlog after a tunnel outage; feeding an
+    // hours-old down→up sequence through the evaluators would fire and resolve
+    // alerts long after the fact. History still lands in Influx and the live
+    // caches (replay is chronological, so the caches end on the newest sample).
+    private static readonly TimeSpan AlertFreshness = TimeSpan.FromMinutes(10);
+
     // Per-site topology-boundary aggregator (fabric sums, AP backhaul, gateway WAN),
     // the same LanFabricAggregator the directly-monitored fast tier uses. Keyed by slug
     // because this sink is a singleton serving every agent site.
@@ -745,6 +752,9 @@ public class AgentProbeResultSink
             // Threshold evaluation through the site's own evaluator instance, same
             // state machine the local medium tier runs. The name cache captured on
             // config push gives the alert a device label instead of a bare MAC.
+            // Replayed backlog samples skip evaluation (see AlertFreshness).
+            if (DateTime.UtcNow - timestamp > AlertFreshness)
+                continue;
             try
             {
                 string? deviceName = null;
@@ -809,20 +819,28 @@ public class AgentProbeResultSink
             }
         }
 
-        var deviceFields = new Dictionary<string, Dictionary<string, object>>();
+        // Grouped per timestamp as well as per target: a live batch carries one
+        // poll's worth of results (all the same stamp, one point per target,
+        // same as before), but an agent replaying its store-and-forward backlog
+        // after a tunnel outage coalesces many polls into one batch, and each
+        // poll must land at its own sample time - not the flush time.
+        var deviceFields = new Dictionary<(string Mac, long Ts), Dictionary<string, object>>();
         var deviceTypes = new Dictionary<string, string>();
-        var interfaceFields = new Dictionary<(string Mac, string IfName), Dictionary<string, object>>();
+        var interfaceFields = new Dictionary<(string Mac, string IfName, long Ts), Dictionary<string, object>>();
 
         foreach (var r in results)
         {
             var mac = NormalizeMac(r.DeviceMac);
             var valueType = (CustomOidValueType)r.ValueType;
+            var ts = r.TimestampUnixMs > 0
+                ? r.TimestampUnixMs
+                : DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             if (r.Scope == 0) // DeviceLevel
             {
                 if (string.IsNullOrEmpty(r.Value)) continue;
-                if (!deviceFields.TryGetValue(r.DeviceMac, out var fields))
+                if (!deviceFields.TryGetValue((r.DeviceMac, ts), out var fields))
                 {
-                    deviceFields[r.DeviceMac] = fields = new Dictionary<string, object>();
+                    deviceFields[(r.DeviceMac, ts)] = fields = new Dictionary<string, object>();
                     deviceTypes[r.DeviceMac] = deviceByMac.TryGetValue(mac, out var d)
                         ? d.DeviceType.ToString() : "unknown";
                 }
@@ -834,7 +852,7 @@ public class AgentProbeResultSink
                 foreach (var (ifIdx, raw) in r.InterfaceValues)
                 {
                     var ifName = idxMap != null && idxMap.TryGetValue(ifIdx, out var n) ? n : ifIdx;
-                    var key = (r.DeviceMac, ifName);
+                    var key = (r.DeviceMac, ifName, ts);
                     if (!interfaceFields.TryGetValue(key, out var fields))
                         interfaceFields[key] = fields = new Dictionary<string, object>();
                     fields[r.FieldName] = CustomOidValueParser.Parse(raw, valueType);
@@ -842,14 +860,15 @@ public class AgentProbeResultSink
             }
         }
 
-        var now = DateTime.UtcNow;
-        foreach (var (deviceMac, fields) in deviceFields)
+        foreach (var ((deviceMac, ts), fields) in deviceFields)
             await influx.WriteCustomFieldsAsync(
-                "device_health", deviceMac, fields, deviceTypes.GetValueOrDefault(deviceMac), null, null, now);
+                "device_health", deviceMac, fields, deviceTypes.GetValueOrDefault(deviceMac), null, null,
+                DateTimeOffset.FromUnixTimeMilliseconds(ts).UtcDateTime);
 
-        foreach (var ((deviceMac, ifName), fields) in interfaceFields)
+        foreach (var ((deviceMac, ifName, ts), fields) in interfaceFields)
             await influx.WriteCustomFieldsAsync(
-                "interface_counters", deviceMac, fields, null, ifName, null, now);
+                "interface_counters", deviceMac, fields, null, ifName, null,
+                DateTimeOffset.FromUnixTimeMilliseconds(ts).UtcDateTime);
     }
 
     /// <summary>Records a batch of probe results from an agent.</summary>
@@ -923,26 +942,30 @@ public class AgentProbeResultSink
             // State-change alerting through the site's own evaluator, exactly like
             // the local latency tier: up→down, down→up, sustained loss. The relayed
             // sample is rebuilt into the probe result shape the evaluator consumes.
-            try
+            // Replayed backlog samples skip evaluation (see AlertFreshness).
+            if (DateTime.UtcNow - timestamp <= AlertFreshness)
             {
-                var ping = new PingProbeResult
+                try
                 {
-                    Target = new ProbeTarget(target.Address, target.ProbeMode, target.Port),
-                    Vantage = new ProbeVantage(vantage, VantageKind.Server),
-                    Sent = result.Sent,
-                    Received = result.Received,
-                    Timestamp = timestamp,
-                    RttMinMs = result.HasRttMinMs ? result.RttMinMs : null,
-                    RttAvgMs = result.HasRttAvgMs ? result.RttAvgMs : null,
-                    RttMaxMs = result.HasRttMaxMs ? result.RttMaxMs : null,
-                    JitterMs = result.HasJitterMs ? result.JitterMs : null,
-                };
-                await _alertRegistry.GetFor(connection.SiteSlug).Targets.EvaluateAsync(target, ping, ct);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Alert evaluator failed for relayed target {Target} (site {Slug})",
-                    target.TargetId, connection.SiteSlug);
+                    var ping = new PingProbeResult
+                    {
+                        Target = new ProbeTarget(target.Address, target.ProbeMode, target.Port),
+                        Vantage = new ProbeVantage(vantage, VantageKind.Server),
+                        Sent = result.Sent,
+                        Received = result.Received,
+                        Timestamp = timestamp,
+                        RttMinMs = result.HasRttMinMs ? result.RttMinMs : null,
+                        RttAvgMs = result.HasRttAvgMs ? result.RttAvgMs : null,
+                        RttMaxMs = result.HasRttMaxMs ? result.RttMaxMs : null,
+                        JitterMs = result.HasJitterMs ? result.JitterMs : null,
+                    };
+                    await _alertRegistry.GetFor(connection.SiteSlug).Targets.EvaluateAsync(target, ping, ct);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Alert evaluator failed for relayed target {Target} (site {Slug})",
+                        target.TargetId, connection.SiteSlug);
+                }
             }
 
             if (result.Success)

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -117,6 +117,15 @@ public class AgentProbeResultSink
     {
         try
         {
+            // The 60s config refresh also lands here while a black-holed tunnel is
+            // still registered (the 90s watchdog hasn't reaped it). Reconnecting the
+            // console through a tunnel that's silent past the stale threshold just
+            // dials the dead loopback proxy and clobbers the awaiting-agent state the
+            // proxy's unreachable signal set. Skip; a real agent reconnect arrives
+            // with a fresh LastMessageAt and proceeds normally.
+            if (connection.IsStale)
+                return;
+
             var siteConnection = _siteConnections.GetFor(connection.SiteSlug);
             if (siteConnection.IsConnected || !await siteConnection.IsConsoleViaAgentAsync())
                 return;

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelProxyService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelProxyService.cs
@@ -25,11 +25,9 @@ public class AgentTunnelProxyService : IDisposable
     // answer never comes.
     private static readonly TimeSpan OpenTimeout = TimeSpan.FromSeconds(3);
 
-    // A healthy tunnel stamps LastMessageAt at least every 30s (agent heartbeat),
-    // plus 60s server config re-pushes. Past this it's treated as black-holed and
-    // proxy opens are refused immediately instead of blocking - well before the
-    // 90s server watchdog drops the dead tunnel.
-    private static readonly TimeSpan StaleTunnelThreshold = TimeSpan.FromSeconds(45);
+    // Past AgentTunnelConnection.StaleThreshold of silence the tunnel is treated
+    // as black-holed and proxy opens are refused immediately instead of blocking
+    // - well before the 90s server watchdog drops the dead tunnel.
 
     // After an open to a site times out, fast-fail further opens instead of each
     // eating the full OpenTimeout. A page render (a site switch) fires a burst of
@@ -121,7 +119,7 @@ public class AgentTunnelProxyService : IDisposable
         // down and refuse immediately so the console falls through to its
         // error/awaiting-agent state instead of hanging the browser.
         var silent = DateTime.UtcNow - agent.LastMessageAt;
-        if (silent > StaleTunnelThreshold)
+        if (silent > AgentTunnelConnection.StaleThreshold)
         {
             _logger.LogDebug("Proxy connect to {Host}:{Port} refused - agent {AgentId} silent for {Silent:n0}s (site {Slug})",
                 listener.TargetHost, listener.TargetPort, agent.AgentId, silent.TotalSeconds, listener.SiteSlug);

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelProxyService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelProxyService.cs
@@ -18,7 +18,18 @@ namespace NetworkOptimizer.Web.Services;
 public class AgentTunnelProxyService : IDisposable
 {
     private const int FrameBytes = 32 * 1024;
-    private static readonly TimeSpan OpenTimeout = TimeSpan.FromSeconds(10);
+
+    // A live agent answers a ProxyOpen in well under a second (it's a local dial
+    // on its side), so a tight timeout still never trips a healthy tunnel but
+    // bounds the per-connection stall when the tunnel is black-holed and the
+    // answer never comes.
+    private static readonly TimeSpan OpenTimeout = TimeSpan.FromSeconds(3);
+
+    // A healthy tunnel stamps LastMessageAt at least every 30s (agent heartbeat),
+    // plus 60s server config re-pushes. Past this it's treated as black-holed and
+    // proxy opens are refused immediately instead of blocking - well before the
+    // 90s server watchdog drops the dead tunnel.
+    private static readonly TimeSpan StaleTunnelThreshold = TimeSpan.FromSeconds(45);
 
     private readonly AgentTunnelRegistry _registry;
     private readonly ILogger<AgentTunnelProxyService> _logger;
@@ -82,6 +93,22 @@ public class AgentTunnelProxyService : IDisposable
         {
             _logger.LogDebug("Proxy connect to {Host}:{Port} refused - no agent online for site {Slug}",
                 listener.TargetHost, listener.TargetPort, listener.SiteSlug);
+            client.Dispose();
+            return;
+        }
+
+        // A black-holed tunnel stays registered (IsAgentOnline() true) until the
+        // 90s server watchdog drops it. Until then this dial would write into the
+        // dead socket and block the full OpenTimeout waiting for an answer that
+        // never comes - a multi-second freeze on every page load and site switch.
+        // If the tunnel has gone silent past the heartbeat window, treat it as
+        // down and refuse immediately so the console falls through to its
+        // error/awaiting-agent state instead of hanging the browser.
+        var silent = DateTime.UtcNow - agent.LastMessageAt;
+        if (silent > StaleTunnelThreshold)
+        {
+            _logger.LogDebug("Proxy connect to {Host}:{Port} refused - agent {AgentId} silent for {Silent:n0}s (site {Slug})",
+                listener.TargetHost, listener.TargetPort, agent.AgentId, silent.TotalSeconds, listener.SiteSlug);
             client.Dispose();
             return;
         }

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelProxyService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelProxyService.cs
@@ -124,6 +124,10 @@ public class AgentTunnelProxyService : IDisposable
             _logger.LogDebug("Proxy connect to {Host}:{Port} refused - agent {AgentId} silent for {Silent:n0}s (site {Slug})",
                 listener.TargetHost, listener.TargetPort, agent.AgentId, silent.TotalSeconds, listener.SiteSlug);
             client.Dispose();
+            // Belt-and-braces with the watchdog's proactive flip: if a dial reaches
+            // a stale tunnel before the watchdog's next 15s tick has flipped the
+            // console, flip it now so this page's remaining calls short-circuit.
+            FlipConsoleAwaitingAgent(listener.SiteSlug);
             return;
         }
 
@@ -176,16 +180,9 @@ public class AgentTunnelProxyService : IDisposable
                 // On the FIRST timeout of an outage, flip the site's console to
                 // awaiting-agent now (not at the 90s watchdog), so its page renders
                 // short-circuit console calls instead of each dialing the dead proxy
-                // and paying the retry backoff. Fire-and-forget; the flip is idempotent.
+                // and paying the retry backoff.
                 if (!wasTripped)
-                {
-                    var slug = listener.SiteSlug;
-                    _ = Task.Run(async () =>
-                    {
-                        try { await _siteConnections.GetFor(slug).NoteProxyUnreachableAsync(); }
-                        catch (Exception ex) { _logger.LogDebug(ex, "Early awaiting-agent flip failed for site {Slug}", slug); }
-                    });
-                }
+                    FlipConsoleAwaitingAgent(listener.SiteSlug);
             }
             if (openError != null)
             {
@@ -261,6 +258,21 @@ public class AgentTunnelProxyService : IDisposable
     {
         foreach (var connection in _connections.Values.Where(c => ReferenceEquals(c.Agent, agent)))
             CloseConnection(connection, notifyAgent: false);
+    }
+
+    /// <summary>
+    /// Flips the site's console to awaiting-agent off the dial path (fire-and-
+    /// forget, idempotent) the moment a dead tunnel is proven - by an open
+    /// timeout or a stale-gate refusal - so page renders short-circuit console
+    /// calls instead of paying dial-and-retry per call until the 90s watchdog.
+    /// </summary>
+    private void FlipConsoleAwaitingAgent(string siteSlug)
+    {
+        _ = Task.Run(async () =>
+        {
+            try { await _siteConnections.GetFor(siteSlug).NoteTunnelUnreachableAsync(); }
+            catch (Exception ex) { _logger.LogDebug(ex, "Awaiting-agent flip failed for site {Slug}", siteSlug); }
+        });
     }
 
     private void CloseConnection(ProxyConnection connection, bool notifyAgent)

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelProxyService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelProxyService.cs
@@ -46,6 +46,7 @@ public class AgentTunnelProxyService : IDisposable
     private readonly ConcurrentDictionary<string, (DateTime Until, DateTime OpenedAtLastMsg)> _openBreaker = new();
 
     private readonly AgentTunnelRegistry _registry;
+    private readonly SiteConnectionRegistry _siteConnections;
     private readonly ILogger<AgentTunnelProxyService> _logger;
 
     private readonly ConcurrentDictionary<string, ProxyListener> _listeners = new();
@@ -53,9 +54,10 @@ public class AgentTunnelProxyService : IDisposable
     private readonly CancellationTokenSource _shutdown = new();
     private long _nextConnectionId;
 
-    public AgentTunnelProxyService(AgentTunnelRegistry registry, ILogger<AgentTunnelProxyService> logger)
+    public AgentTunnelProxyService(AgentTunnelRegistry registry, SiteConnectionRegistry siteConnections, ILogger<AgentTunnelProxyService> logger)
     {
         _registry = registry;
+        _siteConnections = siteConnections;
         _logger = logger;
     }
 
@@ -169,7 +171,23 @@ public class AgentTunnelProxyService : IDisposable
                 openError = "open timed out";
                 // Trip the breaker so the opens queued behind this one fast-fail
                 // instead of each blocking the full OpenTimeout.
+                var wasTripped = _openBreaker.TryGetValue(listener.SiteSlug, out var prev)
+                                 && DateTime.UtcNow < prev.Until;
                 _openBreaker[listener.SiteSlug] = (DateTime.UtcNow + OpenBreakerHold, agent.LastMessageAt);
+
+                // On the FIRST timeout of an outage, flip the site's console to
+                // awaiting-agent now (not at the 90s watchdog), so its page renders
+                // short-circuit console calls instead of each dialing the dead proxy
+                // and paying the retry backoff. Fire-and-forget; the flip is idempotent.
+                if (!wasTripped)
+                {
+                    var slug = listener.SiteSlug;
+                    _ = Task.Run(async () =>
+                    {
+                        try { await _siteConnections.GetFor(slug).NoteProxyUnreachableAsync(); }
+                        catch (Exception ex) { _logger.LogDebug(ex, "Early awaiting-agent flip failed for site {Slug}", slug); }
+                    });
+                }
             }
             if (openError != null)
             {

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelProxyService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelProxyService.cs
@@ -261,6 +261,22 @@ public class AgentTunnelProxyService : IDisposable
     }
 
     /// <summary>
+    /// Whether this site's tunnel path is currently suspect: no agent, an agent
+    /// silent past the stale threshold, or the open breaker tripped with no
+    /// fresh inbound since. Lets the console's connect-failure handling tell "the
+    /// tunnel is dead" (report awaiting-agent) apart from a genuine console-side
+    /// failure reached over a healthy tunnel (report the real error).
+    /// </summary>
+    public bool IsTunnelSuspect(string siteSlug)
+    {
+        var agent = _registry.GetForSite(siteSlug).FirstOrDefault();
+        if (agent == null || agent.IsStale) return true;
+        return _openBreaker.TryGetValue(siteSlug, out var breaker)
+               && DateTime.UtcNow < breaker.Until
+               && agent.LastMessageAt <= breaker.OpenedAtLastMsg;
+    }
+
+    /// <summary>
     /// Flips the site's console to awaiting-agent off the dial path (fire-and-
     /// forget, idempotent) the moment a dead tunnel is proven - by an open
     /// timeout or a stale-gate refusal - so page renders short-circuit console

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelProxyService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelProxyService.cs
@@ -31,6 +31,16 @@ public class AgentTunnelProxyService : IDisposable
     // 90s server watchdog drops the dead tunnel.
     private static readonly TimeSpan StaleTunnelThreshold = TimeSpan.FromSeconds(45);
 
+    // After an open to a site times out, fast-fail further opens for this long
+    // instead of each eating the full OpenTimeout. A page render (a site switch)
+    // fires a burst of console + SSH opens; in the first ~45s of an outage -
+    // before the liveness gate above can trip without false-failing a healthy
+    // tunnel - that burst would otherwise block OpenTimeout on every one, which
+    // read as a 15s+ hang on the switch. The breaker self-clears the instant the
+    // tunnel produces fresh inbound (recovery); see the LastMessageAt check below.
+    private static readonly TimeSpan OpenBreakerCooldown = TimeSpan.FromSeconds(15);
+    private readonly ConcurrentDictionary<string, (DateTime Until, DateTime OpenedAtLastMsg)> _openBreaker = new();
+
     private readonly AgentTunnelRegistry _registry;
     private readonly ILogger<AgentTunnelProxyService> _logger;
 
@@ -113,6 +123,21 @@ public class AgentTunnelProxyService : IDisposable
             return;
         }
 
+        // Circuit breaker: a recent open to this site timed out and no inbound has
+        // arrived since, so the tunnel is almost certainly still black-holed.
+        // Fast-fail the render's remaining opens rather than eat OpenTimeout on
+        // each. Fresh inbound (LastMessageAt past when the breaker tripped) means
+        // the tunnel recovered, clearing this without needing a probe.
+        if (_openBreaker.TryGetValue(listener.SiteSlug, out var breaker)
+            && DateTime.UtcNow < breaker.Until
+            && agent.LastMessageAt <= breaker.OpenedAtLastMsg)
+        {
+            _logger.LogDebug("Proxy connect to {Host}:{Port} fast-refused - open breaker tripped for agent {AgentId} (site {Slug})",
+                listener.TargetHost, listener.TargetPort, agent.AgentId, listener.SiteSlug);
+            client.Dispose();
+            return;
+        }
+
         var id = Interlocked.Increment(ref _nextConnectionId);
         var connection = new ProxyConnection(id, client, agent);
         _connections[id] = connection;
@@ -138,6 +163,9 @@ public class AgentTunnelProxyService : IDisposable
             catch (OperationCanceledException)
             {
                 openError = "open timed out";
+                // Trip the breaker so the opens queued behind this one fast-fail
+                // instead of each blocking the full OpenTimeout.
+                _openBreaker[listener.SiteSlug] = (DateTime.UtcNow + OpenBreakerCooldown, agent.LastMessageAt);
             }
             if (openError != null)
             {
@@ -146,6 +174,9 @@ public class AgentTunnelProxyService : IDisposable
                 CloseConnection(connection, notifyAgent: false);
                 return;
             }
+
+            // The tunnel answered, so clear any open breaker for this site.
+            _openBreaker.TryRemove(listener.SiteSlug, out _);
 
             // Local reads -> tunnel, with backpressure. The agent-to-local
             // direction is written by the tunnel read loop via OnProxyDataAsync.

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelProxyService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelProxyService.cs
@@ -31,14 +31,18 @@ public class AgentTunnelProxyService : IDisposable
     // 90s server watchdog drops the dead tunnel.
     private static readonly TimeSpan StaleTunnelThreshold = TimeSpan.FromSeconds(45);
 
-    // After an open to a site times out, fast-fail further opens for this long
-    // instead of each eating the full OpenTimeout. A page render (a site switch)
-    // fires a burst of console + SSH opens; in the first ~45s of an outage -
-    // before the liveness gate above can trip without false-failing a healthy
-    // tunnel - that burst would otherwise block OpenTimeout on every one, which
-    // read as a 15s+ hang on the switch. The breaker self-clears the instant the
-    // tunnel produces fresh inbound (recovery); see the LastMessageAt check below.
-    private static readonly TimeSpan OpenBreakerCooldown = TimeSpan.FromSeconds(15);
+    // After an open to a site times out, fast-fail further opens instead of each
+    // eating the full OpenTimeout. A page render (a site switch) fires a burst of
+    // console + SSH opens; in the first ~45s of an outage - before the liveness
+    // gate above can trip without false-failing a healthy tunnel - that burst
+    // would otherwise block OpenTimeout on every one, a 15s+ hang on the switch.
+    // Hold past the 45s gate so the breaker never expires and re-probes
+    // mid-outage; a shorter hold let a fresh burst time out every ~15s, a ~10s
+    // stall on any switch landing in that window. It still clears the instant the
+    // tunnel produces fresh inbound (recovery) - see the LastMessageAt check
+    // below - so a healthy tunnel is never held this long: its next heartbeat
+    // (<=30s) advances LastMessageAt and lets the open through.
+    private static readonly TimeSpan OpenBreakerHold = TimeSpan.FromSeconds(60);
     private readonly ConcurrentDictionary<string, (DateTime Until, DateTime OpenedAtLastMsg)> _openBreaker = new();
 
     private readonly AgentTunnelRegistry _registry;
@@ -165,7 +169,7 @@ public class AgentTunnelProxyService : IDisposable
                 openError = "open timed out";
                 // Trip the breaker so the opens queued behind this one fast-fail
                 // instead of each blocking the full OpenTimeout.
-                _openBreaker[listener.SiteSlug] = (DateTime.UtcNow + OpenBreakerCooldown, agent.LastMessageAt);
+                _openBreaker[listener.SiteSlug] = (DateTime.UtcNow + OpenBreakerHold, agent.LastMessageAt);
             }
             if (openError != null)
             {

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelRegistry.cs
@@ -91,6 +91,21 @@ public sealed class AgentTunnelConnection
     public DateTime ConnectedAt { get; }
     public DateTime LastMessageAt { get; internal set; }
 
+    /// <summary>
+    /// How long a tunnel may go silent before it counts as black-holed (agents
+    /// heartbeat every 30s and the server re-pushes configs every 60s, so a
+    /// healthy tunnel is never this quiet). A black-holed tunnel stays
+    /// REGISTERED until the 90s watchdog reaps it, so every consumer that asks
+    /// "is the agent there?" must use <see cref="IsStale"/> rather than mere
+    /// registration - the proxy's open gate, the console connect/wait paths,
+    /// and the config-refresh reconnect guard all share this single definition
+    /// so they can't disagree about the dead-but-registered window.
+    /// </summary>
+    public static readonly TimeSpan StaleThreshold = TimeSpan.FromSeconds(45);
+
+    /// <summary>True when nothing has arrived past <see cref="StaleThreshold"/>: dead-but-registered.</summary>
+    public bool IsStale => DateTime.UtcNow - LastMessageAt > StaleThreshold;
+
     private readonly CancellationTokenSource _dropCts = new();
 
     /// <summary>Cancelled when the server force-drops this connection (license enforcement).</summary>

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelService.cs
@@ -22,6 +22,16 @@ public class AgentTunnelService : AgentTunnel.AgentTunnelBase
     /// <summary>Heartbeat cadence handed to agents in the ServerHello.</summary>
     public const int HeartbeatIntervalSeconds = 30;
 
+    // A healthy agent is never silent longer than one heartbeat interval, so
+    // three missed heartbeats means the tunnel is dead even though TCP hasn't
+    // noticed (a WAN outage black-holes the connection rather than resetting
+    // it - the read loop would sit in MoveNext for the full TCP timeout,
+    // ~15 min). Dropping promptly matters beyond hygiene: the registry entry
+    // keeps IsAgentOnline() true, which blocks the console's awaiting-agent
+    // fail-fast flip - every page of the site (including a site switch) then
+    // hangs on proxy opens into the dead tunnel until they time out.
+    private static readonly TimeSpan LivenessTimeout = TimeSpan.FromSeconds(90);
+
     private readonly AgentEnrollmentService _enrollment;
     private readonly AgentTunnelRegistry _registry;
     private readonly AgentProbeResultSink _probeResultSink;
@@ -95,6 +105,7 @@ public class AgentTunnelService : AgentTunnel.AgentTunnelBase
         ct = streamCts.Token;
         Task? pumpTask = null;
         Task? refreshTask = null;
+        Task? livenessTask = null;
         try
         {
             await responseStream.WriteAsync(new ServerMessage
@@ -111,6 +122,7 @@ public class AgentTunnelService : AgentTunnel.AgentTunnelBase
             // traffic funnels through the connection's channel and this pump.
             pumpTask = PumpOutboundAsync(connection, responseStream, streamCts.Token);
             refreshTask = RefreshProbeConfigLoopAsync(connection, streamCts.Token);
+            livenessTask = WatchLivenessAsync(connection, streamCts.Token);
 
             await _probeResultSink.OnAgentConnectedAsync(connection, ct);
 
@@ -176,6 +188,7 @@ public class AgentTunnelService : AgentTunnel.AgentTunnelBase
             streamCts.Cancel();
             await AwaitQuietlyAsync(pumpTask);
             await AwaitQuietlyAsync(refreshTask);
+            await AwaitQuietlyAsync(livenessTask);
             _logger.LogInformation("Agent {Name} (id {Id}) tunnel closed", agent.Name, agent.Id);
         }
     }
@@ -202,6 +215,28 @@ public class AgentTunnelService : AgentTunnel.AgentTunnelBase
         {
             await Task.Delay(TimeSpan.FromSeconds(60), ct);
             await _probeResultSink.OnAgentConnectedAsync(connection, ct);
+        }
+    }
+
+    /// <summary>
+    /// Drops the connection when the agent has been silent past
+    /// <see cref="LivenessTimeout"/>. Cancelling the drop token aborts the
+    /// read loop, which runs the normal teardown: unregister, proxy/console
+    /// awaiting-agent flip, and the agent's own reconnect gets a clean slate.
+    /// </summary>
+    private async Task WatchLivenessAsync(AgentTunnelConnection connection, CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(15), ct);
+            var silent = DateTime.UtcNow - connection.LastMessageAt;
+            if (silent <= LivenessTimeout) continue;
+            _logger.LogWarning(
+                "Agent {Name} (id {Id}, site {Slug}) silent for {Silent:0}s (heartbeat is {Interval}s); dropping dead tunnel",
+                connection.AgentName, connection.AgentId, connection.SiteSlug,
+                silent.TotalSeconds, HeartbeatIntervalSeconds);
+            connection.Drop();
+            return;
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelService.cs
@@ -115,6 +115,7 @@ public class AgentTunnelService : AgentTunnel.AgentTunnelBase
                     SiteSlug = siteSlug,
                     AgentName = agent.Name,
                     HeartbeatIntervalSeconds = HeartbeatIntervalSeconds,
+                    SupportsResultAck = true,
                 }
             }, ct);
 
@@ -137,6 +138,11 @@ public class AgentTunnelService : AgentTunnel.AgentTunnelBase
                         break;
                     case AgentMessage.PayloadOneofCase.ProbeResults:
                         await _probeResultSink.RecordBatchAsync(connection, message.ProbeResults, ct);
+                        // Ack only after the batch is persisted, so the agent keeps it
+                        // buffered until we confirm it landed. Cumulative: sequence N
+                        // acks everything <= N. Sequence 0 = an older agent with no acking.
+                        if (message.Sequence > 0)
+                            connection.TrySend(new ServerMessage { ResultAck = new ResultAck { Sequence = message.Sequence } });
                         break;
                     case AgentMessage.PayloadOneofCase.ProxyOpenResult:
                         _proxy.OnProxyOpenResult(message.ProxyOpenResult);
@@ -149,6 +155,8 @@ public class AgentTunnelService : AgentTunnel.AgentTunnelBase
                         break;
                     case AgentMessage.PayloadOneofCase.SnmpResults:
                         await _probeResultSink.RecordSnmpBatchAsync(connection, message.SnmpResults, ct);
+                        if (message.Sequence > 0)
+                            connection.TrySend(new ServerMessage { ResultAck = new ResultAck { Sequence = message.Sequence } });
                         break;
                     case AgentMessage.PayloadOneofCase.Iperf3Result:
                         _iperf3.OnResult(message.Iperf3Result);

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelService.cs
@@ -231,13 +231,27 @@ public class AgentTunnelService : AgentTunnel.AgentTunnelBase
     /// <see cref="LivenessTimeout"/>. Cancelling the drop token aborts the
     /// read loop, which runs the normal teardown: unregister, proxy/console
     /// awaiting-agent flip, and the agent's own reconnect gets a clean slate.
+    /// Before that, the moment silence crosses the stale threshold, the site's
+    /// console is flipped to awaiting-agent proactively - without this, a site
+    /// nobody dialed during the outage stayed stale-green until first contact,
+    /// and that first switch paid a dial-and-retry on every console call for
+    /// the rest of the 90s window.
     /// </summary>
     private async Task WatchLivenessAsync(AgentTunnelConnection connection, CancellationToken ct)
     {
+        var flaggedStale = false;
         while (!ct.IsCancellationRequested)
         {
             await Task.Delay(TimeSpan.FromSeconds(15), ct);
             var silent = DateTime.UtcNow - connection.LastMessageAt;
+            if (!flaggedStale && silent > AgentTunnelConnection.StaleThreshold)
+            {
+                flaggedStale = true;
+                _logger.LogInformation(
+                    "Agent {Name} (id {Id}, site {Slug}) silent for {Silent:0}s; treating the tunnel as black-holed",
+                    connection.AgentName, connection.AgentId, connection.SiteSlug, silent.TotalSeconds);
+                _probeResultSink.OnTunnelStale(connection);
+            }
             if (silent <= LivenessTimeout) continue;
             _logger.LogWarning(
                 "Agent {Name} (id {Id}, site {Slug}) silent for {Silent:0}s (heartbeat is {Interval}s); dropping dead tunnel",

--- a/src/NetworkOptimizer.Web/Services/SiteContextService.cs
+++ b/src/NetworkOptimizer.Web/Services/SiteContextService.cs
@@ -60,6 +60,16 @@ public class SiteContextService : IAlertSiteScope
     /// <summary>True when this scope operates on the default site (the main database).</summary>
     public bool IsDefault => Slug == SiteManagementService.DefaultSiteSlug;
 
+    /// <summary>
+    /// Scopes a browser-persistence key (localStorage) to the current site so
+    /// per-site view state - the 3D/2D LAN flow map camera, overlays, scrub
+    /// span - never collides across sites. The default site keeps the bare key
+    /// unchanged so existing saved state (and single-site installs) carry over;
+    /// other sites get a "{slug}:" prefix.
+    /// </summary>
+    public string ScopeStorageKey(string baseKey) =>
+        IsDefault ? baseKey : $"{Slug}:{baseKey}";
+
     /// <summary>SQLite database path for the current site.</summary>
     public string DbPath => _dbPaths.GetSiteDbPath(Slug, IsDefault);
 

--- a/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
@@ -255,6 +255,32 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     }
 
     /// <summary>
+    /// Called after a connect attempt fails. When the console is agent-routed and
+    /// the tunnel itself is suspect (absent, stale, or open-breaker tripped), the
+    /// failure is a dead-tunnel symptom: the loopback proxy dial collapses
+    /// mid-TLS and parses as an "SSL certificate error" with advice the user
+    /// can't act on (proxied connections can't cert-match 127.0.0.1). Land in
+    /// awaiting-agent instead, so the banner tells the truth from the first
+    /// moment rather than flashing a bogus SSL error until the flip corrects it.
+    /// A genuine console-side failure over a HEALTHY tunnel keeps its real error.
+    /// </summary>
+    private async Task PreferAwaitingAgentOnDeadTunnelAsync()
+    {
+        try
+        {
+            if (!await IsConsoleViaAgentAsync()) return;
+            var proxy = _serviceProvider.GetService<AgentTunnelProxyService>();
+            if (proxy == null || !proxy.IsTunnelSuspect(SiteSlug)) return;
+            _awaitingAgent = true;
+            _lastError = AwaitingAgentMessage;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Dead-tunnel error remap failed for site {Slug}", SiteSlug);
+        }
+    }
+
+    /// <summary>
     /// When the site's console is reached through its agent tunnel, rewrites
     /// the controller URL to the loopback proxy endpoint that forwards over
     /// the tunnel. Callers must also force ignore-SSL for proxied connections:
@@ -582,6 +608,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
                 _logger.LogWarning("Failed to authenticate with UniFi controller");
                 _client.Dispose();
                 _client = null;
+                await PreferAwaitingAgentOnDeadTunnelAsync();
                 return false;
             }
         }
@@ -591,6 +618,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
             _logger.LogError(ex, "Error connecting to UniFi controller");
             _client?.Dispose();
             _client = null;
+            await PreferAwaitingAgentOnDeadTunnelAsync();
             return false;
         }
     }
@@ -719,6 +747,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
                 _lastError = _client.LastLoginError ?? defaultError;
                 _client.Dispose();
                 _client = null;
+                await PreferAwaitingAgentOnDeadTunnelAsync();
                 return false;
             }
         }
@@ -728,6 +757,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
             _logger.LogWarning("Startup auto-connect timed out - console unreachable");
             _client?.Dispose();
             _client = null;
+            await PreferAwaitingAgentOnDeadTunnelAsync();
             return false;
         }
         catch (Exception ex)
@@ -736,6 +766,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
             _logger.LogError(ex, "Error connecting to UniFi controller");
             _client?.Dispose();
             _client = null;
+            await PreferAwaitingAgentOnDeadTunnelAsync();
             return false;
         }
     }

--- a/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
@@ -211,6 +211,33 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     }
 
     /// <summary>
+    /// Called by the tunnel proxy the instant it confirms this site's agent tunnel
+    /// is black-holed (a proxy open timed out) - while the agent is still
+    /// registered, so the 90s server watchdog (which drives
+    /// <see cref="OnAgentTunnelDroppedAsync"/>) hasn't fired. Flips the console to
+    /// awaiting-agent NOW so its calls short-circuit at the IsConnected guard
+    /// instead of each dialing the dead loopback proxy and paying the retry
+    /// backoff - which read as a multi-second site switch for up to 90s. Unlike
+    /// OnAgentTunnelDroppedAsync it does NOT bail while the agent is still
+    /// registered, because the proxy has proven the tunnel dead regardless.
+    /// Idempotent; the agent-connected hook (on reconnect or the periodic refresh)
+    /// re-establishes the console when the tunnel returns.
+    /// </summary>
+    public async Task NoteProxyUnreachableAsync()
+    {
+        if (!_isConnected && _client == null) return; // already down / awaiting - idempotent
+        if (!await IsConsoleViaAgentAsync()) return;   // only agent-routed consoles reach the proxy
+        _logger.LogInformation(
+            "Tunnel proxy reports site {Slug} unreachable; flipping its console to awaiting-agent ahead of the watchdog", SiteSlug);
+        _client?.Dispose();
+        _client = null;
+        _isConnected = false;
+        _awaitingAgent = true;
+        _lastError = AwaitingAgentMessage;
+        OnConnectionChanged?.Invoke();
+    }
+
+    /// <summary>
     /// When the site's console is reached through its agent tunnel, rewrites
     /// the controller URL to the loopback proxy endpoint that forwards over
     /// the tunnel. Callers must also force ignore-SSL for proxied connections:

--- a/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
@@ -180,6 +180,22 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     }
 
     /// <summary>
+    /// Whether this site's agent tunnel is registered AND alive (not silent past
+    /// the stale threshold). A black-holed tunnel stays registered until the 90s
+    /// watchdog reaps it, so <see cref="IsAgentOnline"/> reads stale-true for
+    /// that whole window - long enough for WaitForConnectionAsync to poll its
+    /// full timeout on every page load of the site (twice per page with
+    /// prerender), which is what made switching to an outaged site take ~10s+
+    /// while a known-offline site was instant. Connect/wait decisions must use
+    /// THIS; registration alone is only meaningful for teardown bookkeeping.
+    /// </summary>
+    private bool HasLiveAgentTunnel()
+    {
+        var registry = _serviceProvider.GetService<AgentTunnelRegistry>();
+        return registry != null && registry.GetForSite(SiteSlug).Any(a => !a.IsStale);
+    }
+
+    /// <summary>
     /// Called when this site's agent tunnel drops. When the console is reached
     /// through that tunnel, flip straight to the awaiting-agent state: the client
     /// stays "connected" otherwise, and every console call dials the dead loopback
@@ -311,11 +327,11 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
                         await Task.Delay(1000);
 
                     // If this site's console is reached through its agent tunnel and no
-                    // agent has connected yet, defer: dialing the loopback proxy with no
-                    // agent behind it fails with a spurious SSL/EOF error on the dashboard.
+                    // live agent has connected yet, defer: dialing the loopback proxy with
+                    // no agent behind it fails with a spurious SSL/EOF error on the dashboard.
                     // OnAgentConnectedAsync establishes the console connection as soon as
                     // the tunnel comes up (often 20-30s after startup).
-                    if (await IsConsoleViaAgentAsync() && !IsAgentOnline())
+                    if (await IsConsoleViaAgentAsync() && !HasLiveAgentTunnel())
                     {
                         _awaitingAgent = true;
                         _lastError = AwaitingAgentMessage;
@@ -499,11 +515,12 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
 
             // Create new client
             var viaAgent = await IsConsoleViaAgentAsync();
-            if (viaAgent && !IsAgentOnline())
+            if (viaAgent && !HasLiveAgentTunnel())
             {
-                // Reached through the agent tunnel, which isn't up. Dialing the loopback
-                // proxy now fails with an SSL/EOF error that gets misreported as a
-                // certificate problem, so surface the real reason.
+                // Reached through the agent tunnel, which isn't up - or is
+                // dead-but-registered (black-holed). Dialing the loopback proxy now
+                // fails with an SSL/EOF error that gets misreported as a certificate
+                // problem, so surface the real reason.
                 _awaitingAgent = true;
                 _lastError = AwaitingAgentMessage;
                 return false;
@@ -624,11 +641,12 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
 
             // Create new client
             var viaAgent = await IsConsoleViaAgentAsync();
-            if (viaAgent && !IsAgentOnline())
+            if (viaAgent && !HasLiveAgentTunnel())
             {
-                // Reached through the agent tunnel, which isn't up. Dialing the loopback
-                // proxy now fails with an SSL/EOF error that gets misreported as a
-                // certificate problem, so surface the real reason.
+                // Reached through the agent tunnel, which isn't up - or is
+                // dead-but-registered (black-holed). Dialing the loopback proxy now
+                // fails with an SSL/EOF error that gets misreported as a certificate
+                // problem, so surface the real reason.
                 _awaitingAgent = true;
                 _lastError = AwaitingAgentMessage;
                 return false;
@@ -834,11 +852,12 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
         try
         {
             var viaAgent = await IsConsoleViaAgentAsync();
-            if (viaAgent && !IsAgentOnline())
+            if (viaAgent && !HasLiveAgentTunnel())
             {
-                // The console is reached through the agent tunnel, which isn't up. Dialing
-                // the loopback proxy now fails with an SSL/EOF error that gets misreported
-                // as a certificate problem, so return the real reason instead.
+                // The console is reached through the agent tunnel, which isn't up (or is
+                // dead-but-registered). Dialing the loopback proxy now fails with an
+                // SSL/EOF error that gets misreported as a certificate problem, so
+                // return the real reason instead.
                 return (false,
                     "This site's console is reached through its on-site agent tunnel, which isn't connected yet. Start the site's agent (or wait for it to come online), then test again.",
                     null);
@@ -1007,6 +1026,12 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
         // If already connected, return immediately
         if (IsConnected) return true;
 
+        // Already flipped to awaiting-agent (tunnel down or proven black-holed):
+        // no poll can succeed until the agent reconnects, and pages reload via
+        // OnConnectionChanged when it does. Waiting here would stall every page
+        // render of the site for the full timeout.
+        if (IsAwaitingAgent) return false;
+
         // Check if we have saved credentials to connect with
         var settings = await GetSettingsAsync();
         if (!settings.IsConfigured || !settings.HasCredentials || !settings.RememberCredentials)
@@ -1015,12 +1040,13 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
             return false;
         }
 
-        // If this site's console is reached through an agent tunnel that isn't up yet, don't
-        // block: the console connects asynchronously once the agent comes online
+        // If this site's console is reached through an agent tunnel that isn't up - or is
+        // dead-but-registered (black-holed, silent past the stale threshold) - don't block:
+        // the console connects asynchronously once the agent (re)connects
         // (OnAgentConnectedAsync), and pages reload via OnConnectionChanged. Polling the full
         // timeout here would stall the page render on every agent-site load or switch, which
         // is the single biggest cause of "the page takes forever to appear" on those sites.
-        if (await IsConsoleViaAgentAsync() && !IsAgentOnline())
+        if (await IsConsoleViaAgentAsync() && !HasLiveAgentTunnel())
             return false;
 
         var startTime = DateTime.UtcNow;

--- a/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
@@ -227,24 +227,25 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     }
 
     /// <summary>
-    /// Called by the tunnel proxy the instant it confirms this site's agent tunnel
-    /// is black-holed (a proxy open timed out) - while the agent is still
+    /// Called the moment this site's agent tunnel is known black-holed - a proxy
+    /// open timed out, an open was refused for staleness, or the tunnel watchdog
+    /// saw it silent past the stale threshold - while the agent is still
     /// registered, so the 90s server watchdog (which drives
     /// <see cref="OnAgentTunnelDroppedAsync"/>) hasn't fired. Flips the console to
     /// awaiting-agent NOW so its calls short-circuit at the IsConnected guard
     /// instead of each dialing the dead loopback proxy and paying the retry
     /// backoff - which read as a multi-second site switch for up to 90s. Unlike
     /// OnAgentTunnelDroppedAsync it does NOT bail while the agent is still
-    /// registered, because the proxy has proven the tunnel dead regardless.
-    /// Idempotent; the agent-connected hook (on reconnect or the periodic refresh)
-    /// re-establishes the console when the tunnel returns.
+    /// registered, because the tunnel is proven dead regardless. Idempotent; the
+    /// agent-connected hook (on reconnect or the periodic refresh) re-establishes
+    /// the console when the tunnel returns.
     /// </summary>
-    public async Task NoteProxyUnreachableAsync()
+    public async Task NoteTunnelUnreachableAsync()
     {
         if (!_isConnected && _client == null) return; // already down / awaiting - idempotent
-        if (!await IsConsoleViaAgentAsync()) return;   // only agent-routed consoles reach the proxy
+        if (!await IsConsoleViaAgentAsync()) return;   // only agent-routed consoles ride the tunnel
         _logger.LogInformation(
-            "Tunnel proxy reports site {Slug} unreachable; flipping its console to awaiting-agent ahead of the watchdog", SiteSlug);
+            "Site {Slug}'s agent tunnel is unreachable; flipping its console to awaiting-agent ahead of the watchdog", SiteSlug);
         _client?.Dispose();
         _client = null;
         _isConnected = false;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -436,10 +436,12 @@ h1:focus {
 
 .wan-live-chart-card {
     margin-bottom: 0;
+    overflow: visible;
 }
 .wan-live-chart-card > .card-body {
     padding: 0 0 0.3rem;
     margin-right: -0.75rem;
+    overflow: visible;
 }
 .wan-live-chart-card .apexcharts-canvas {
     min-height: 0;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -781,11 +781,20 @@ class LanFlowMap2D {
         if(!this._root)return;
         this._calcBounds(true);
         const margin=10;
+        // On desktop the scrubber bar overlays the bottom of the stage (on mobile
+        // it's moved below the stage, so no overlap); left unaccounted the lowest
+        // devices hide behind it. Reserve its height plus a little breathing room
+        // so they clear the bar and the whole map rides a touch higher.
+        const overlays=this._scrubberEl&&this._scrubberEl.parentElement===this._el;
+        const bottomInset=overlays?(this._scrubberEl.offsetHeight+6):0;
+        const availH=Math.max(1,this._ch-margin*2-bottomInset);
         const sx=(this._cw-margin*2)/this._bw;
-        const sy=(this._ch-margin*2)/this._bh;
+        const sy=availH/this._bh;
         this._scale=Math.min(sx,sy,2);
         this._ox=this._bx+this._bw/2;
-        this._oy=this._by+this._bh/2;
+        // Center within the timeline-free region rather than the raw canvas, which
+        // sits above the midpoint, lifting the content clear of the scrubber bar.
+        this._oy=this._by+this._bh/2+bottomInset/(2*this._scale);
         this._isFitted=true;
         this._needsStaticRedraw=true;
     }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -782,19 +782,20 @@ class LanFlowMap2D {
         this._calcBounds(true);
         const margin=10;
         // On desktop the scrubber bar overlays the bottom of the stage (on mobile
-        // it's moved below the stage, so no overlap); left unaccounted the lowest
-        // devices hide behind it. Reserve its height plus a little breathing room
-        // so they clear the bar and the whole map rides a touch higher.
+        // it's moved below the stage, so no overlap - no inset there). Reserve just
+        // the bar's height plus a few px so the bottom row sits right above it,
+        // without the wasteful gap a full extra margin would leave.
         const overlays=this._scrubberEl&&this._scrubberEl.parentElement===this._el;
-        const bottomInset=overlays?(this._scrubberEl.offsetHeight+6):0;
-        const availH=Math.max(1,this._ch-margin*2-bottomInset);
+        const topPad=margin;
+        const bottomPad=overlays?(this._scrubberEl.offsetHeight+4):margin;
+        const availH=Math.max(1,this._ch-topPad-bottomPad);
         const sx=(this._cw-margin*2)/this._bw;
         const sy=availH/this._bh;
         this._scale=Math.min(sx,sy,2);
         this._ox=this._bx+this._bw/2;
-        // Center within the timeline-free region rather than the raw canvas, which
-        // sits above the midpoint, lifting the content clear of the scrubber bar.
-        this._oy=this._by+this._bh/2+bottomInset/(2*this._scale);
+        // Center within the [top .. just above the bar] band rather than the raw
+        // canvas, lifting the content clear of the scrubber bar.
+        this._oy=this._by+this._bh/2+(bottomPad-topPad)/(2*this._scale);
         this._isFitted=true;
         this._needsStaticRedraw=true;
     }

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -11,6 +11,13 @@ const POLL_MS = 2500;
 // Window-scroll redraw cadence. At 250ms each step moves well under a pixel
 // on typical widths, so the chart slides instead of visibly ticking.
 const SCROLL_MS = 250;
+// Occasionally re-pull the whole history window and merge it back in, so gaps
+// that filled AFTER the live buffer scrolled past them appear without a manual
+// refresh: a monitoring outage whose buffered samples replayed into Influx on
+// reconnect, or the cold-start gap before data first flowed. Live mode +
+// foreground only, and the newest live samples are kept, so the smooth edge
+// never regresses.
+const BACKFILL_MS = 60000;
 const COLOR_DL   = '#3b82f6';
 const COLOR_UL   = '#10b981';
 const COLOR_LOSS = '#ef4444';
@@ -19,6 +26,7 @@ const COLOR_RTT  = '#d946ef';
 let chart = null;
 let pollTimer = null;
 let scrollTimer = null;
+let backfillTimer = null;
 let buffer = [];
 let elId = null;
 let visHandler = null;
@@ -294,6 +302,43 @@ async function pollLive() {
     } catch { }
 }
 
+// Re-pull the full history window and merge it back over the buffer so gaps that
+// filled in after the buffer scrolled past them (outage backlog replay, cold
+// start) show up. Live mode + foreground only. The newest live samples - which
+// can be ahead of Influx ingestion - are kept ahead of the re-pulled history so
+// the live edge never flickers back.
+async function backfillHistory() {
+    if (!chart || !pollTimer || document.hidden) return;
+    const gen = mountGen;
+    const to = new Date();
+    const from = new Date(to.getTime() - HISTORY_MINUTES * 60000);
+    let points;
+    try {
+        const resp = await fetch(
+            `/api/monitoring/wan-live-chart-data?from=${from.toISOString()}&to=${to.toISOString()}`,
+            { credentials: 'same-origin' });
+        if (!resp.ok) return;
+        const data = await resp.json();
+        points = (data.points || []).map(p => ({
+            time: new Date(p.time).getTime(),
+            download: p.downloadBps,
+            upload: p.uploadBps,
+            rtt: p.rttMs,
+            loss: p.lossPercent ?? 0,
+        }));
+    } catch { return; }
+    // Bail if the mount changed or we left live mode while fetching.
+    if (gen !== mountGen || !pollTimer) return;
+    const newestHist = points.length ? points[points.length - 1].time : 0;
+    const liveTail = buffer.filter(p => p.time > newestHist);
+    const cutoff = Date.now() - HISTORY_MINUTES * 60000;
+    buffer = points.concat(liveTail).filter(p => p.time >= cutoff).sort((a, b) => a.time - b.time);
+    for (const p of buffer) {
+        if (p.time > lastSampleTime) lastSampleTime = p.time;
+    }
+    updateChart();
+}
+
 export async function mount(containerId, opts) {
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
@@ -318,6 +363,7 @@ export async function mount(containerId, opts) {
 
     pollTimer = setInterval(pollLive, interval);
     scrollTimer = setInterval(updateChart, SCROLL_MS);
+    backfillTimer = setInterval(backfillHistory, BACKFILL_MS);
 
     if (visHandler) document.removeEventListener('visibilitychange', visHandler);
     visHandler = async () => {
@@ -333,12 +379,14 @@ export function pause() {
     stopHistInterpolation();
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
+    if (backfillTimer) { clearInterval(backfillTimer); backfillTimer = null; }
 }
 
 export function resume() {
     if (!chart || pollTimer) return;
     pollTimer = setInterval(pollLive, POLL_MS);
     scrollTimer = setInterval(updateChart, SCROLL_MS);
+    backfillTimer = setInterval(backfillHistory, BACKFILL_MS);
 }
 
 // Render the historic view at a given playhead time from the current buffer.
@@ -407,11 +455,13 @@ export async function seekTime(isoTimestamp) {
         updateChart();
         pollTimer = setInterval(pollLive, POLL_MS);
         scrollTimer = setInterval(updateChart, SCROLL_MS);
+        backfillTimer = setInterval(backfillHistory, BACKFILL_MS);
         return;
     }
     // Historic mode: stop polling, fetch window centered on timestamp
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
+    if (backfillTimer) { clearInterval(backfillTimer); backfillTimer = null; }
     const at = new Date(isoTimestamp).getTime();
     histAt = at;
     histWall = Date.now();
@@ -461,6 +511,7 @@ export function unmount() {
     stopHistInterpolation();
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
+    if (backfillTimer) { clearInterval(backfillTimer); backfillTimer = null; }
     if (visHandler) { document.removeEventListener('visibilitychange', visHandler); visHandler = null; }
     if (chart) { chart.destroy(); chart = null; }
     buffer = [];

--- a/tests/NetworkOptimizer.AgentProtocol.Tests/NetworkOptimizer.AgentProtocol.Tests.csproj
+++ b/tests/NetworkOptimizer.AgentProtocol.Tests/NetworkOptimizer.AgentProtocol.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NetworkOptimizer.AgentProtocol\NetworkOptimizer.AgentProtocol.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/NetworkOptimizer.AgentProtocol.Tests/ResultBufferTests.cs
+++ b/tests/NetworkOptimizer.AgentProtocol.Tests/ResultBufferTests.cs
@@ -41,44 +41,115 @@ public class ResultBufferTests
         }
     };
 
+    // Peek the oldest single frame (maxSamples: 1 disables coalescing) and ack it,
+    // mirroring a consumer that confirms each message - the ack-era stand-in for
+    // the old remove-on-dequeue.
+    private static async Task<AgentMessage> NextAsync(ResultBuffer buffer, CancellationToken ct = default)
+    {
+        var frame = await buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 1, ct);
+        buffer.MarkAcked(frame.ThroughSeq);
+        return frame.Message;
+    }
+
     [Fact]
-    public async Task DequeuesInFifoOrder()
+    public async Task ReplaysInFifoOrder()
     {
         var buffer = new ResultBuffer();
         buffer.Enqueue(ProbeMessage("a"));
         buffer.Enqueue(SnmpMessage("aa:bb:cc:dd:ee:ff"));
         buffer.Enqueue(ProbeMessage("b"));
 
-        (await buffer.DequeueAsync(CancellationToken.None)).ProbeResults.Results[0].TargetId.Should().Be("a");
-        (await buffer.DequeueAsync(CancellationToken.None)).PayloadCase
-            .Should().Be(AgentMessage.PayloadOneofCase.SnmpResults);
-        (await buffer.DequeueAsync(CancellationToken.None)).ProbeResults.Results[0].TargetId.Should().Be("b");
+        (await NextAsync(buffer)).ProbeResults.Results[0].TargetId.Should().Be("a");
+        (await NextAsync(buffer)).PayloadCase.Should().Be(AgentMessage.PayloadOneofCase.SnmpResults);
+        (await NextAsync(buffer)).ProbeResults.Results[0].TargetId.Should().Be("b");
         buffer.Count.Should().Be(0);
     }
 
     [Fact]
-    public async Task DequeueWaitsForEnqueue()
+    public async Task TakeWaitsForEnqueue()
     {
         var buffer = new ResultBuffer();
-        var dequeue = buffer.DequeueAsync(CancellationToken.None).AsTask();
-        dequeue.IsCompleted.Should().BeFalse();
+        var take = buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 1, CancellationToken.None).AsTask();
+        take.IsCompleted.Should().BeFalse();
 
         buffer.Enqueue(ProbeMessage("late"));
-        var message = await dequeue.WaitAsync(TimeSpan.FromSeconds(5));
-        message.ProbeResults.Results[0].TargetId.Should().Be("late");
+        var frame = await take.WaitAsync(TimeSpan.FromSeconds(5));
+        frame.Message.ProbeResults.Results[0].TargetId.Should().Be("late");
     }
 
     [Fact]
-    public async Task DequeueHonorsCancellation()
+    public async Task TakeHonorsCancellation()
     {
         var buffer = new ResultBuffer();
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
-        var act = async () => await buffer.DequeueAsync(cts.Token);
+        var act = async () => await buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 1, cts.Token);
         await act.Should().ThrowAsync<OperationCanceledException>();
     }
 
     [Fact]
-    public void ByteCapDropsOldestFirst()
+    public async Task UnackedFramesReplayUntilAcked()
+    {
+        var buffer = new ResultBuffer();
+        buffer.Enqueue(ProbeMessage("a"));
+        buffer.Enqueue(ProbeMessage("b"));
+        buffer.Enqueue(ProbeMessage("c"));
+
+        // Drain all three without acking - as if the writes went into a black hole.
+        long cursor = 0;
+        for (var i = 0; i < 3; i++)
+        {
+            var f = await buffer.TakeUnsentBatchAsync(cursor, maxSamples: 1, CancellationToken.None);
+            cursor = f.ThroughSeq;
+        }
+        buffer.Count.Should().Be(3, "nothing was acked, so nothing is trimmed");
+
+        // A reconnect replays from the oldest unacked frame.
+        var replay = await buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 1, CancellationToken.None);
+        replay.Message.ProbeResults.Results[0].TargetId.Should().Be("a");
+
+        // Cumulative ack through the second frame trims a and b; only c remains.
+        buffer.MarkAcked(replay.ThroughSeq + 1);
+        buffer.Count.Should().Be(1);
+        (await buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 1, CancellationToken.None))
+            .Message.ProbeResults.Results[0].TargetId.Should().Be("c");
+    }
+
+    [Fact]
+    public async Task CoalesceMergesSameTypeUpToTheBoundary()
+    {
+        var buffer = new ResultBuffer();
+        buffer.Enqueue(SnmpMessage("aa:bb:cc:dd:ee:ff"));
+        buffer.Enqueue(SnmpMessage("11:22:33:44:55:66"));
+        buffer.Enqueue(ProbeMessage("behind"));
+
+        var frame = await buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 500, CancellationToken.None);
+        frame.Message.PayloadCase.Should().Be(AgentMessage.PayloadOneofCase.SnmpResults);
+        frame.Message.SnmpResults.Interfaces.Should().HaveCount(2, "consecutive SNMP batches coalesce");
+        buffer.MarkAcked(frame.ThroughSeq);
+
+        var next = await buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 500, CancellationToken.None);
+        next.Message.PayloadCase.Should().Be(AgentMessage.PayloadOneofCase.ProbeResults);
+        next.Message.ProbeResults.Results[0].TargetId.Should().Be("behind");
+    }
+
+    [Fact]
+    public async Task CoalescePeekLeavesOriginalsIntactUntilAcked()
+    {
+        var buffer = new ResultBuffer();
+        buffer.Enqueue(ProbeMessage("a"));
+        buffer.Enqueue(ProbeMessage("b"));
+
+        // Coalescing must not mutate or remove the buffered entries.
+        var frame = await buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 500, CancellationToken.None);
+        frame.Message.ProbeResults.Results.Should().HaveCount(2);
+        buffer.Count.Should().Be(2, "peek does not remove");
+
+        buffer.MarkAcked(frame.ThroughSeq);
+        buffer.Count.Should().Be(0, "the ack trims both coalesced frames");
+    }
+
+    [Fact]
+    public async Task ByteCapDropsOldestFirst()
     {
         var single = ProbeMessage("x").CalculateSize();
         // Room for roughly three single-result messages.
@@ -91,10 +162,15 @@ public class ResultBufferTests
         buffer.DroppedTotal.Should().Be(10 - buffer.Count);
         buffer.ApproxBytes.Should().BeLessThanOrEqualTo(single * 3 + 1);
 
-        // The survivors are the newest, still in FIFO order.
+        // The survivors are the newest, still in FIFO order. maxSamples 1 reads
+        // them one at a time.
         var survivors = new List<int>();
-        while (buffer.TryDequeueIf(_ => true, out var message))
-            survivors.Add(int.Parse(message.ProbeResults.Results[0].TargetId[1..]));
+        while (buffer.Count > 0)
+        {
+            var frame = await buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 1, CancellationToken.None);
+            survivors.Add(int.Parse(frame.Message.ProbeResults.Results[0].TargetId[1..]));
+            buffer.MarkAcked(frame.ThroughSeq);
+        }
         survivors.Should().BeInAscendingOrder();
         survivors.Last().Should().Be(9);
     }
@@ -109,64 +185,25 @@ public class ResultBufferTests
 
         buffer.Count.Should().Be(1);
         buffer.DroppedTotal.Should().Be(1);
-        (await buffer.DequeueAsync(CancellationToken.None)).ProbeResults.Results[0].TargetId.Should().Be("new");
+        (await NextAsync(buffer)).ProbeResults.Results[0].TargetId.Should().Be("new");
     }
 
     [Fact]
     public async Task EvictedPermitsDoNotStrandTheConsumer()
     {
-        // Eviction removes entries without consuming semaphore permits; a
-        // consumer waking to an empty buffer must keep waiting, then still
-        // receive the next real message.
+        // Eviction removes entries without consuming semaphore permits; a consumer
+        // waking to no unsent entry must keep waiting, then still receive the next.
         var buffer = new ResultBuffer(maxAge: TimeSpan.FromMilliseconds(50));
         buffer.Enqueue(ProbeMessage("doomed"));
         await Task.Delay(150);
         buffer.Enqueue(ProbeMessage("evictor")); // evicts "doomed" on enqueue
 
-        (await buffer.DequeueAsync(CancellationToken.None)).ProbeResults.Results[0].TargetId.Should().Be("evictor");
+        (await NextAsync(buffer)).ProbeResults.Results[0].TargetId.Should().Be("evictor");
 
-        var pending = buffer.DequeueAsync(CancellationToken.None).AsTask();
+        var pending = buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 1, CancellationToken.None).AsTask();
         buffer.Enqueue(ProbeMessage("after"));
-        (await pending.WaitAsync(TimeSpan.FromSeconds(5))).ProbeResults.Results[0].TargetId.Should().Be("after");
-    }
-
-    [Fact]
-    public async Task RequeueFrontRestoresOrderAheadOfNewerEntries()
-    {
-        var buffer = new ResultBuffer();
-        buffer.Enqueue(ProbeMessage("newer"));
-
-        buffer.RequeueFront([ProbeMessage("salvaged-1"), ProbeMessage("salvaged-2")]);
-
-        (await buffer.DequeueAsync(CancellationToken.None)).ProbeResults.Results[0].TargetId.Should().Be("salvaged-1");
-        (await buffer.DequeueAsync(CancellationToken.None)).ProbeResults.Results[0].TargetId.Should().Be("salvaged-2");
-        (await buffer.DequeueAsync(CancellationToken.None)).ProbeResults.Results[0].TargetId.Should().Be("newer");
-    }
-
-    [Fact]
-    public void RequeueFrontOfNothingIsANoOp()
-    {
-        var buffer = new ResultBuffer();
-        buffer.RequeueFront([]);
-        buffer.Count.Should().Be(0);
-        buffer.ApproxBytes.Should().Be(0);
-    }
-
-    [Fact]
-    public void TryDequeueIfOnlyTakesMatchingHead()
-    {
-        var buffer = new ResultBuffer();
-        buffer.TryDequeueIf(_ => true, out _).Should().BeFalse("buffer is empty");
-
-        buffer.Enqueue(SnmpMessage("aa:bb:cc:dd:ee:ff"));
-        buffer.Enqueue(ProbeMessage("behind"));
-
-        buffer.TryDequeueIf(m => m.PayloadCase == AgentMessage.PayloadOneofCase.ProbeResults, out _)
-            .Should().BeFalse("head is an SNMP batch");
-        buffer.TryDequeueIf(m => m.PayloadCase == AgentMessage.PayloadOneofCase.SnmpResults, out var snmp)
-            .Should().BeTrue();
-        snmp.SnmpResults.Interfaces[0].DeviceMac.Should().Be("aa:bb:cc:dd:ee:ff");
-        buffer.Count.Should().Be(1);
+        (await pending.WaitAsync(TimeSpan.FromSeconds(5)))
+            .Message.ProbeResults.Results[0].TargetId.Should().Be("after");
     }
 
     [Fact]
@@ -183,14 +220,16 @@ public class ResultBufferTests
     }
 
     [Fact]
-    public void ByteAccountingTracksEnqueueAndDequeue()
+    public async Task ByteAccountingTracksEnqueueAndAck()
     {
         var buffer = new ResultBuffer();
         var message = ProbeMessage("sized");
         buffer.Enqueue(message);
         buffer.ApproxBytes.Should().Be(message.CalculateSize());
 
-        buffer.TryDequeueIf(_ => true, out _).Should().BeTrue();
+        var frame = await buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 1, CancellationToken.None);
+        buffer.ApproxBytes.Should().Be(message.CalculateSize(), "peek does not change accounting");
+        buffer.MarkAcked(frame.ThroughSeq);
         buffer.ApproxBytes.Should().Be(0);
     }
 
@@ -209,8 +248,9 @@ public class ResultBufferTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         while (seen.Count < 4 * perProducer)
         {
-            var message = await buffer.DequeueAsync(cts.Token);
-            seen.Add(message.ProbeResults.Results[0].TargetId);
+            var frame = await buffer.TakeUnsentBatchAsync(afterSeq: 0, maxSamples: 1, cts.Token);
+            seen.Add(frame.Message.ProbeResults.Results[0].TargetId);
+            buffer.MarkAcked(frame.ThroughSeq);
         }
 
         await Task.WhenAll(producers);

--- a/tests/NetworkOptimizer.AgentProtocol.Tests/ResultBufferTests.cs
+++ b/tests/NetworkOptimizer.AgentProtocol.Tests/ResultBufferTests.cs
@@ -1,0 +1,228 @@
+using FluentAssertions;
+using Xunit;
+
+namespace NetworkOptimizer.AgentProtocol.Tests;
+
+public class ResultBufferTests
+{
+    private static AgentMessage ProbeMessage(string targetId, long timestampMs = 1000) => new()
+    {
+        ProbeResults = new ProbeResultBatch
+        {
+            Results =
+            {
+                new ProbeResult
+                {
+                    TargetId = targetId,
+                    TimestampUnixMs = timestampMs,
+                    Success = true,
+                    Sent = 5,
+                    Received = 5,
+                }
+            }
+        }
+    };
+
+    private static AgentMessage SnmpMessage(string deviceMac) => new()
+    {
+        SnmpResults = new SnmpResultBatch
+        {
+            Interfaces =
+            {
+                new SnmpInterfaceSample
+                {
+                    DeviceMac = deviceMac,
+                    IfName = "eth0",
+                    InOctets = 123456,
+                    OutOctets = 654321,
+                    TimestampUnixMs = 1000,
+                }
+            }
+        }
+    };
+
+    [Fact]
+    public async Task DequeuesInFifoOrder()
+    {
+        var buffer = new ResultBuffer();
+        buffer.Enqueue(ProbeMessage("a"));
+        buffer.Enqueue(SnmpMessage("aa:bb:cc:dd:ee:ff"));
+        buffer.Enqueue(ProbeMessage("b"));
+
+        (await buffer.DequeueAsync(CancellationToken.None)).ProbeResults.Results[0].TargetId.Should().Be("a");
+        (await buffer.DequeueAsync(CancellationToken.None)).PayloadCase
+            .Should().Be(AgentMessage.PayloadOneofCase.SnmpResults);
+        (await buffer.DequeueAsync(CancellationToken.None)).ProbeResults.Results[0].TargetId.Should().Be("b");
+        buffer.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task DequeueWaitsForEnqueue()
+    {
+        var buffer = new ResultBuffer();
+        var dequeue = buffer.DequeueAsync(CancellationToken.None).AsTask();
+        dequeue.IsCompleted.Should().BeFalse();
+
+        buffer.Enqueue(ProbeMessage("late"));
+        var message = await dequeue.WaitAsync(TimeSpan.FromSeconds(5));
+        message.ProbeResults.Results[0].TargetId.Should().Be("late");
+    }
+
+    [Fact]
+    public async Task DequeueHonorsCancellation()
+    {
+        var buffer = new ResultBuffer();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+        var act = async () => await buffer.DequeueAsync(cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public void ByteCapDropsOldestFirst()
+    {
+        var single = ProbeMessage("x").CalculateSize();
+        // Room for roughly three single-result messages.
+        var buffer = new ResultBuffer(maxBytes: single * 3 + 1);
+
+        for (var i = 0; i < 10; i++)
+            buffer.Enqueue(ProbeMessage($"t{i}"));
+
+        buffer.Count.Should().BeLessThan(10);
+        buffer.DroppedTotal.Should().Be(10 - buffer.Count);
+        buffer.ApproxBytes.Should().BeLessThanOrEqualTo(single * 3 + 1);
+
+        // The survivors are the newest, still in FIFO order.
+        var survivors = new List<int>();
+        while (buffer.TryDequeueIf(_ => true, out var message))
+            survivors.Add(int.Parse(message.ProbeResults.Results[0].TargetId[1..]));
+        survivors.Should().BeInAscendingOrder();
+        survivors.Last().Should().Be(9);
+    }
+
+    [Fact]
+    public async Task AgeCapDropsExpiredEntries()
+    {
+        var buffer = new ResultBuffer(maxAge: TimeSpan.FromMilliseconds(50));
+        buffer.Enqueue(ProbeMessage("old"));
+        await Task.Delay(150);
+        buffer.Enqueue(ProbeMessage("new"));
+
+        buffer.Count.Should().Be(1);
+        buffer.DroppedTotal.Should().Be(1);
+        (await buffer.DequeueAsync(CancellationToken.None)).ProbeResults.Results[0].TargetId.Should().Be("new");
+    }
+
+    [Fact]
+    public async Task EvictedPermitsDoNotStrandTheConsumer()
+    {
+        // Eviction removes entries without consuming semaphore permits; a
+        // consumer waking to an empty buffer must keep waiting, then still
+        // receive the next real message.
+        var buffer = new ResultBuffer(maxAge: TimeSpan.FromMilliseconds(50));
+        buffer.Enqueue(ProbeMessage("doomed"));
+        await Task.Delay(150);
+        buffer.Enqueue(ProbeMessage("evictor")); // evicts "doomed" on enqueue
+
+        (await buffer.DequeueAsync(CancellationToken.None)).ProbeResults.Results[0].TargetId.Should().Be("evictor");
+
+        var pending = buffer.DequeueAsync(CancellationToken.None).AsTask();
+        buffer.Enqueue(ProbeMessage("after"));
+        (await pending.WaitAsync(TimeSpan.FromSeconds(5))).ProbeResults.Results[0].TargetId.Should().Be("after");
+    }
+
+    [Fact]
+    public async Task RequeueFrontRestoresOrderAheadOfNewerEntries()
+    {
+        var buffer = new ResultBuffer();
+        buffer.Enqueue(ProbeMessage("newer"));
+
+        buffer.RequeueFront([ProbeMessage("salvaged-1"), ProbeMessage("salvaged-2")]);
+
+        (await buffer.DequeueAsync(CancellationToken.None)).ProbeResults.Results[0].TargetId.Should().Be("salvaged-1");
+        (await buffer.DequeueAsync(CancellationToken.None)).ProbeResults.Results[0].TargetId.Should().Be("salvaged-2");
+        (await buffer.DequeueAsync(CancellationToken.None)).ProbeResults.Results[0].TargetId.Should().Be("newer");
+    }
+
+    [Fact]
+    public void RequeueFrontOfNothingIsANoOp()
+    {
+        var buffer = new ResultBuffer();
+        buffer.RequeueFront([]);
+        buffer.Count.Should().Be(0);
+        buffer.ApproxBytes.Should().Be(0);
+    }
+
+    [Fact]
+    public void TryDequeueIfOnlyTakesMatchingHead()
+    {
+        var buffer = new ResultBuffer();
+        buffer.TryDequeueIf(_ => true, out _).Should().BeFalse("buffer is empty");
+
+        buffer.Enqueue(SnmpMessage("aa:bb:cc:dd:ee:ff"));
+        buffer.Enqueue(ProbeMessage("behind"));
+
+        buffer.TryDequeueIf(m => m.PayloadCase == AgentMessage.PayloadOneofCase.ProbeResults, out _)
+            .Should().BeFalse("head is an SNMP batch");
+        buffer.TryDequeueIf(m => m.PayloadCase == AgentMessage.PayloadOneofCase.SnmpResults, out var snmp)
+            .Should().BeTrue();
+        snmp.SnmpResults.Interfaces[0].DeviceMac.Should().Be("aa:bb:cc:dd:ee:ff");
+        buffer.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public void TakeDroppedCountResetsBetweenCalls()
+    {
+        var single = ProbeMessage("x").CalculateSize();
+        var buffer = new ResultBuffer(maxBytes: single);
+        buffer.Enqueue(ProbeMessage("a"));
+        buffer.Enqueue(ProbeMessage("b")); // drops "a"
+
+        buffer.TakeDroppedCount().Should().Be(1);
+        buffer.TakeDroppedCount().Should().Be(0);
+        buffer.DroppedTotal.Should().Be(1);
+    }
+
+    [Fact]
+    public void ByteAccountingTracksEnqueueAndDequeue()
+    {
+        var buffer = new ResultBuffer();
+        var message = ProbeMessage("sized");
+        buffer.Enqueue(message);
+        buffer.ApproxBytes.Should().Be(message.CalculateSize());
+
+        buffer.TryDequeueIf(_ => true, out _).Should().BeTrue();
+        buffer.ApproxBytes.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ConcurrentProducersAndConsumerDeliverEverything()
+    {
+        var buffer = new ResultBuffer();
+        const int perProducer = 200;
+        var producers = Enumerable.Range(0, 4).Select(p => Task.Run(() =>
+        {
+            for (var i = 0; i < perProducer; i++)
+                buffer.Enqueue(ProbeMessage($"p{p}-{i}"));
+        })).ToArray();
+
+        var seen = new List<string>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        while (seen.Count < 4 * perProducer)
+        {
+            var message = await buffer.DequeueAsync(cts.Token);
+            seen.Add(message.ProbeResults.Results[0].TargetId);
+        }
+
+        await Task.WhenAll(producers);
+        seen.Should().HaveCount(4 * perProducer);
+        seen.Should().OnlyHaveUniqueItems();
+
+        // Per-producer FIFO order survives interleaving.
+        for (var p = 0; p < 4; p++)
+        {
+            var indices = seen.Where(id => id.StartsWith($"p{p}-"))
+                .Select(id => int.Parse(id.Split('-')[1])).ToList();
+            indices.Should().BeInAscendingOrder();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Multi-site monitoring reaches an external (additional) site through an on-site agent that tunnels back to the server - the default/home site is monitored directly with no agent, so everything about the agent path is multi-site. This branch makes that path resilient to tunnel/WAN outages: an external site keeps collecting while its tunnel is down, no monitoring data is lost across the outage, and neither the server nor the browser hangs on a dead tunnel. A few general UI fixes that touch the whole app (not multi-site) also landed on this branch and are listed at the end.

## No data loss when an external site's tunnel goes down

- The agent's probe and SNMP collectors now run for the life of the agent process rather than per tunnel connection, so they keep polling on the last pushed config while the tunnel is down - previously they were torn down with the connection and the outage window was simply lost. Results buffer on the agent (12h / 64MB, oldest dropped) and replay FIFO on reconnect; interface rates stay correct across the gap, and replayed samples land at their real timestamps and skip alert evaluation so a replayed down/up sequence can't fire alerts hours late.
- Delivery is acknowledged end to end: the agent keeps each result frame buffered until the server confirms it persisted, then trims it. A WAN black-hole (where TCP reports a write into a dead socket as "success") used to drain the buffer into the void and silently lose an outage's worth of data; it now backfills the full window at the samples' original timestamps. Rolling-upgrade safe via a `ServerHello` capability flag (a newer agent falls back cleanly against an older server; an older agent is unaffected by a newer server).

## Fail fast on a dead tunnel (no server or browser hangs on an external site)

- Server- and agent-side liveness watchdogs drop a black-holed tunnel within ~2 minutes instead of riding the ~15-minute TCP timeout, and the post-connect handshake is bounded so a link black-holed mid-connect can't wedge the reconnect loop.
- Switching to an external site whose tunnel just went dark no longer hangs. A dead-but-registered tunnel (black-holed, but not yet reaped by the watchdog) is now treated as absent everywhere it matters: page renders no longer sit in the pre-render connection wait polling its full timeout, and every affected site's console flips to "awaiting agent" as soon as the outage is known - on the first proxy-open timeout (~3s) for a site being viewed, and proactively from the tunnel watchdog for sites nobody has touched, so none of them stays stale-green waiting to be discovered by a dial. The periodic config refresh no longer un-flips that state by re-dialing the dead tunnel, a per-site breaker collapses the burst of proxy opens a page render fires, and the console's HTTP client no longer stacks its ~14s transient-retry backoff onto agent-proxied calls. Net effect: the first contact with a fresh outage costs one ~3s probe; everything after that is as fast as a known-offline site. The directly-monitored home console is on a different path and keeps its full retry behavior.

## Multi-site UI

- During an outage an external site's Live View shows a console-down / awaiting-agent banner instead of the misleading "Monitoring not configured" setup prompt (a down console made a device fetch throw and blank the whole panel).
- A connect attempt that fails because the tunnel is dead now reports "waiting for the site's agent" from the first moment, instead of flashing a bogus SSL-certificate error until the awaiting-agent state caught up. A genuine console-side failure over a healthy tunnel keeps its real error.
- Settings shows "Ignore SSL certificate errors" as checked and disabled for consoles connected through the site's agent (certificate validation isn't supported on that path, and has always been forced there), instead of presenting a toggle that does nothing. Directly-connected consoles keep the normal toggle.
- The live WAN chart periodically re-pulls its history so gaps that fill in after the live edge scrolled past them appear on their own - the outage's replayed samples on reconnect, and the cold-start gap before data first flowed. The live edge is preserved, so the smooth scroll never regresses.
- LAN flow map view state (3D/2D camera, overlays, scrub span) is scoped per site, so switching sites no longer inherits the previous site's camera and overlays.
- App-wide banner dismissals (the PWA install nudge and the WiFi channel-analysis disclaimer) are now stored globally instead of per-site, so dismissing one no longer makes it reappear when you switch sites. Genuinely site-specific dismissals stay per-site.

## General UI fixes on this branch (not multi-site)

- 2D LAN flow map: the fit no longer clips the bottom row of devices under the timeline scrubber bar.
- Live WAN chart: no longer clipped by its card's rounded-corner overflow on the dashboard and Live View.
- PWA / mobile resume: probes the live Blazor circuit on resume and only reloads when it's genuinely dead, instead of reloading on a blind timer after backgrounding (which discarded your place on the page).
