### PR TITLE
Simplified Client Dashboard view for VPN clients

### DIFF
--- a/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
+++ b/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
@@ -69,6 +69,13 @@ public interface INetworkPathAnalyzer
     Task<(string? NetworkGroup, string? Name)> IdentifyWanConnectionAsync(
         string externalIp, double measuredDownloadMbps = 0, double measuredUploadMbps = 0,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Classifies a client IP as a VPN client type (Tailscale, Teleport, or a UniFi
+    /// remote-user VPN), or null when the IP is not VPN-sourced. Shares the same logic
+    /// used to prepend VPN hops to speed-test path traces.
+    /// </summary>
+    Task<HopType?> ClassifyVpnClientAsync(string clientIp, CancellationToken cancellationToken = default);
 }
 
 /// <summary>
@@ -2331,63 +2338,49 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
         // When only wanIp is provided, matches the specific WAN interface by IP.
         var (wanDownloadMbps, wanUploadMbps) = GetWanSpeed(topology, rawDevices, wanIp, resolvedWanGroup);
 
-        // Check for Tailscale CGNAT range: 100.64.0.0/10 (100.64.x.x - 100.127.x.x)
-        if (clientIp.StartsWith("100."))
-        {
-            var parts = clientIp.Split('.');
-            if (parts.Length >= 2 && int.TryParse(parts[1], out int secondOctet))
-            {
-                if (secondOctet >= 64 && secondOctet <= 127)
-                {
-                    // Store directional WAN speeds: Ingress=download (FromDevice), Egress=upload (ToDevice)
-                    return new NetworkHop
-                    {
-                        Type = HopType.Tailscale,
-                        DeviceName = "Tailscale",
-                        DeviceIp = clientIp,
-                        IngressSpeedMbps = wanDownloadMbps > 0 ? wanDownloadMbps : Math.Max(wanDownloadMbps, wanUploadMbps),
-                        EgressSpeedMbps = wanUploadMbps > 0 ? wanUploadMbps : Math.Max(wanDownloadMbps, wanUploadMbps),
-                        IngressPortName = "WAN",
-                        EgressPortName = "WAN",
-                        Notes = wanUploadMbps > 0
-                            ? $"Tailscale VPN (WAN: {wanDownloadMbps}/{wanUploadMbps} Mbps)"
-                            : "Tailscale VPN mesh"
-                    };
-                }
-            }
-        }
-
-        // Check for Teleport: 192.168.x.x that's NOT in any known UniFi network
-        if (clientIp.StartsWith("192.168."))
-        {
-            // Check if this IP is in any known UniFi network
-            var isInKnownNetwork = topology.Networks.Any(n =>
-                !string.IsNullOrEmpty(n.IpSubnet) && NetworkUtilities.IsIpInSubnet(clientIp, n.IpSubnet));
-
-            if (!isInKnownNetwork)
-            {
-                // Store directional WAN speeds: Ingress=download (FromDevice), Egress=upload (ToDevice)
-                return new NetworkHop
-                {
-                    Type = HopType.Teleport,
-                    DeviceName = "Teleport",
-                    DeviceIp = clientIp,
-                    IngressSpeedMbps = wanDownloadMbps > 0 ? wanDownloadMbps : Math.Max(wanDownloadMbps, wanUploadMbps),
-                    EgressSpeedMbps = wanUploadMbps > 0 ? wanUploadMbps : Math.Max(wanDownloadMbps, wanUploadMbps),
-                    IngressPortName = "WAN",
-                    EgressPortName = "WAN",
-                    Notes = wanUploadMbps > 0
-                        ? $"Teleport VPN (WAN: {wanDownloadMbps}/{wanUploadMbps} Mbps)"
-                        : "Teleport VPN gateway"
-                };
-            }
-        }
-
-        // Check for UniFi remote-user-vpn network (e.g., L2TP, OpenVPN server on gateway)
+        // The network this IP falls inside, if any (used for both VPN and external classification).
         var matchingNetwork = topology.Networks.FirstOrDefault(n =>
             !string.IsNullOrEmpty(n.IpSubnet) && NetworkUtilities.IsIpInSubnet(clientIp, n.IpSubnet));
 
-        if (matchingNetwork?.Purpose == "remote-user-vpn")
+        // Classify the VPN type (Tailscale / Teleport / remote-user VPN) via shared logic.
+        var vpnType = ClassifyVpnClient(clientIp, topology);
+        if (vpnType == HopType.Tailscale)
+        {
+            // Store directional WAN speeds: Ingress=download (FromDevice), Egress=upload (ToDevice)
+            return new NetworkHop
+            {
+                Type = HopType.Tailscale,
+                DeviceName = "Tailscale",
+                DeviceIp = clientIp,
+                IngressSpeedMbps = wanDownloadMbps > 0 ? wanDownloadMbps : Math.Max(wanDownloadMbps, wanUploadMbps),
+                EgressSpeedMbps = wanUploadMbps > 0 ? wanUploadMbps : Math.Max(wanDownloadMbps, wanUploadMbps),
+                IngressPortName = "WAN",
+                EgressPortName = "WAN",
+                Notes = wanUploadMbps > 0
+                    ? $"Tailscale VPN (WAN: {wanDownloadMbps}/{wanUploadMbps} Mbps)"
+                    : "Tailscale VPN mesh"
+            };
+        }
+
+        if (vpnType == HopType.Teleport)
+        {
+            // Store directional WAN speeds: Ingress=download (FromDevice), Egress=upload (ToDevice)
+            return new NetworkHop
+            {
+                Type = HopType.Teleport,
+                DeviceName = "Teleport",
+                DeviceIp = clientIp,
+                IngressSpeedMbps = wanDownloadMbps > 0 ? wanDownloadMbps : Math.Max(wanDownloadMbps, wanUploadMbps),
+                EgressSpeedMbps = wanUploadMbps > 0 ? wanUploadMbps : Math.Max(wanDownloadMbps, wanUploadMbps),
+                IngressPortName = "WAN",
+                EgressPortName = "WAN",
+                Notes = wanUploadMbps > 0
+                    ? $"Teleport VPN (WAN: {wanDownloadMbps}/{wanUploadMbps} Mbps)"
+                    : "Teleport VPN gateway"
+            };
+        }
+
+        if (vpnType == HopType.Vpn)
         {
             // Store directional WAN speeds: Ingress=download (FromDevice), Egress=upload (ToDevice)
             return new NetworkHop
@@ -2400,8 +2393,8 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                 IngressPortName = "WAN",
                 EgressPortName = "WAN",
                 Notes = wanUploadMbps > 0
-                    ? $"VPN ({matchingNetwork.Name}, WAN: {wanDownloadMbps}/{wanUploadMbps} Mbps)"
-                    : $"VPN ({matchingNetwork.Name})"
+                    ? $"VPN ({matchingNetwork?.Name}, WAN: {wanDownloadMbps}/{wanUploadMbps} Mbps)"
+                    : $"VPN ({matchingNetwork?.Name})"
             };
         }
 
@@ -2458,6 +2451,66 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
             return true;
 
         return false;
+    }
+
+    /// <summary>
+    /// Classifies a client IP as a VPN client type (Tailscale, Teleport, or a UniFi
+    /// remote-user VPN), or null when the IP is not VPN-sourced. This is the single
+    /// source of truth shared by speed-test hop creation (<see cref="DetectAndCreateVpnHop"/>)
+    /// and the Client Dashboard's simplified VPN view.
+    /// </summary>
+    /// <remarks>
+    /// The Tailscale check is pure-IP (CGNAT 100.64.0.0/10) and works with a null
+    /// topology. Teleport and remote-user-VPN classification need the topology's
+    /// networks; when topology is null only Tailscale can be identified.
+    /// </remarks>
+    public static HopType? ClassifyVpnClient(string clientIp, NetworkTopology? topology)
+    {
+        if (string.IsNullOrEmpty(clientIp) || !System.Net.IPAddress.TryParse(clientIp, out _))
+            return null;
+
+        // Tailscale CGNAT range: 100.64.0.0/10 (100.64.x.x - 100.127.x.x)
+        if (clientIp.StartsWith("100."))
+        {
+            var parts = clientIp.Split('.');
+            if (parts.Length >= 2 && int.TryParse(parts[1], out int secondOctet)
+                && secondOctet >= 64 && secondOctet <= 127)
+            {
+                return HopType.Tailscale;
+            }
+        }
+
+        if (topology == null)
+            return null;
+
+        // Teleport: 192.168.x.x that's NOT in any known UniFi network
+        if (clientIp.StartsWith("192.168."))
+        {
+            var isInKnownNetwork = topology.Networks.Any(n =>
+                !string.IsNullOrEmpty(n.IpSubnet) && NetworkUtilities.IsIpInSubnet(clientIp, n.IpSubnet));
+
+            if (!isInKnownNetwork)
+                return HopType.Teleport;
+        }
+
+        // UniFi remote-user-vpn network (e.g., L2TP, OpenVPN server on gateway)
+        var matchingNetwork = topology.Networks.FirstOrDefault(n =>
+            !string.IsNullOrEmpty(n.IpSubnet) && NetworkUtilities.IsIpInSubnet(clientIp, n.IpSubnet));
+
+        if (matchingNetwork?.Purpose == "remote-user-vpn")
+            return HopType.Vpn;
+
+        return null;
+    }
+
+    /// <inheritdoc />
+    public async Task<HopType?> ClassifyVpnClientAsync(string clientIp, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(clientIp))
+            return null;
+
+        var topology = await GetTopologyAsync(cancellationToken);
+        return ClassifyVpnClient(clientIp, topology);
     }
 
     /// <inheritdoc />

--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -413,7 +413,56 @@
         const reconnectModal = document.getElementById('components-reconnect-modal');
         if (reconnectModal) {
             let disconnectedAt = null;
+            let reloading = false;
+            let stuckSpinnerTimer = null;
             const MIN_DISCONNECT_TIME_MS = 1500; // Only reload if disconnected > 1.5s
+            const STUCK_SPINNER_MS = 5000;       // Probe cadence while the spinner is up
+            const HEALTH_TIMEOUT_MS = 2000;      // Give the liveness probe this long to answer
+
+            // A reload tears down the page (circuit, Blazor's retries, our timers), so
+            // whichever recovery path fires first wins; the guard just stops a later
+            // tick from calling reload again after one is already in flight.
+            function safeReload() {
+                if (reloading) return;
+                reloading = true;
+                location.reload();
+            }
+
+            // Endless-spinner safety hatch. Blazor can sit in the "reconnecting" state
+            // indefinitely when the socket is wedged (dead but still open to it) or its
+            // retries stall - the page stays frozen behind the modal with no class
+            // transition for the observer to react to. While the spinner is up, probe
+            // the server every few seconds: if the SERVER answers, the circuit is wedged
+            // but the app is fine, so reload into a fresh page; if it doesn't answer it's
+            // a restart/outage, so do nothing and let Blazor keep retrying (reloading into
+            // a dead server would only strand us). The ?probe= marker distinguishes these
+            // from deploy health checks in the access logs.
+            async function serverAlive() {
+                const ctrl = new AbortController();
+                const t = setTimeout(() => ctrl.abort(), HEALTH_TIMEOUT_MS);
+                try {
+                    const resp = await fetch('/api/health?probe=reconnect', { signal: ctrl.signal, cache: 'no-store' });
+                    return resp.ok;
+                } catch {
+                    return false;
+                } finally {
+                    clearTimeout(t);
+                }
+            }
+
+            function startStuckSpinnerWatch() {
+                if (stuckSpinnerTimer) return;
+                stuckSpinnerTimer = setInterval(async function () {
+                    if (await serverAlive()) safeReload();
+                }, STUCK_SPINNER_MS);
+            }
+
+            function stopStuckSpinnerWatch() {
+                if (stuckSpinnerTimer) {
+                    clearInterval(stuckSpinnerTimer);
+                    stuckSpinnerTimer = null;
+                }
+            }
 
             const reconnectObserver = new MutationObserver(function(mutations) {
                 mutations.forEach(function(mutation) {
@@ -426,16 +475,19 @@
                         if (isShowing && !disconnectedAt) {
                             // Record when we started showing the reconnect modal
                             disconnectedAt = Date.now();
+                            startStuckSpinnerWatch();
                         } else if (!isShowing && !isFailed && disconnectedAt) {
                             // Successfully reconnected - only reload if we were disconnected long enough
                             const disconnectDuration = Date.now() - disconnectedAt;
                             disconnectedAt = null;
+                            stopStuckSpinnerWatch();
                             if (disconnectDuration >= MIN_DISCONNECT_TIME_MS) {
-                                location.reload();
+                                safeReload();
                             }
                         } else if (isFailed) {
                             disconnectedAt = null;
-                            location.reload();
+                            stopStuckSpinnerWatch();
+                            safeReload();
                         }
                     }
                 });

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -1165,6 +1165,7 @@
 
     private string? _clientIp;
     private bool _awaitingSiteIdentity;
+    private System.Threading.Timer? _identityRetryTimer;
     private bool _showClientPicker;
     private List<ClientDashboardService.SelectableClient> _pickerClients = new();
     private string? _pickerSelection;
@@ -1228,64 +1229,109 @@
     /// </summary>
     private async Task ResolveSiteIdentityAsync()
     {
-        // The on-site agent's tunnel may still be coming up when the page first loads,
-        // so the resolver reports no agent target yet. Poll for a bounded window so
-        // identity resolves automatically once the agent connects, instead of dropping
-        // to the picker and forcing the viewer to refresh. Keep the loading skeleton up
-        // (via _awaitingSiteIdentity) while we wait.
-        var deadline = DateTime.UtcNow.AddSeconds(20);
-        string? ip = null;
-        var probed = false;
-        while (true)
-        {
-            try
-            {
-                var target = await SiteTarget.ResolveAsync();
-                if (target.UsesAgent && !string.IsNullOrEmpty(target.BaseUrl))
-                {
-                    probed = true;
-                    ip = await JS.InvokeAsync<string?>("eval",
-                        $"fetch('{target.BaseUrl}/netopt/whoami', {{signal: AbortSignal.timeout(4000)}})" +
-                        ".then(r => r.json()).then(j => j.ip).catch(() => null)");
-                }
-            }
-            catch { /* probe is best-effort; the picker below always works */ }
-
-            if (!string.IsNullOrEmpty(ip) && System.Net.IPAddress.TryParse(ip, out _))
-                break;
-
-            // Once the agent target is reachable, a null answer means the probe itself
-            // failed (e.g. certificate untrusted) - don't keep waiting, fall to the picker.
-            // Otherwise the agent isn't online yet: retry until the deadline.
-            if (probed || DateTime.UtcNow >= deadline)
-                break;
-
-            await Task.Delay(2000);
-        }
-
         _awaitingSiteIdentity = false;
 
-        if (!string.IsNullOrEmpty(ip) && System.Net.IPAddress.TryParse(ip, out _))
+        // One immediate attempt - resolves instantly on a warm agent connection.
+        if (await TryResolveSiteIdentityAsync())
         {
-            Logger.LogDebug("Client identity (site {Site}): agent whoami resolved {Ip}", SiteContext.Slug, ip);
-            _clientIp = ip;
-            await IdentifyAndLoadAsync();
-            if (_client != null)
-            {
-                StateHasChanged();
-                return;
-            }
-            // The agent answered but the address isn't a known client - pick manually.
-            Logger.LogDebug("Client identity (site {Site}): whoami address {Ip} not in the client list - showing picker", SiteContext.Slug, ip);
-            _clientIp = null;
-        }
-        else
-        {
-            Logger.LogDebug("Client identity (site {Site}): {Reason} - showing picker",
-                SiteContext.Slug, probed ? "agent whoami probe failed (offline or certificate untrusted)" : "no agent target to probe");
+            StateHasChanged();
+            return;
         }
 
+        // Cold connection: the on-site agent's tunnel or the UniFi console may still be
+        // coming up. Show the picker so the viewer can act right away, but keep probing
+        // in the background and auto-load once identity resolves - no manual refresh.
+        Logger.LogDebug("Client identity (site {Site}): not resolved yet, showing picker and retrying in the background", SiteContext.Slug);
         await ShowClientPickerAsync();
+        StartSiteIdentityRetry();
+    }
+
+    /// <summary>
+    /// One identity-resolution attempt: ask the on-site agent's speed-test listener who
+    /// we are (it sees the viewer's LAN source address, where this central server only
+    /// sees the site's WAN IP), then identify that IP against the site's console.
+    /// Returns true and loads the dashboard when a client is resolved.
+    /// </summary>
+    private async Task<bool> TryResolveSiteIdentityAsync()
+    {
+        string? ip = null;
+        try
+        {
+            var target = await SiteTarget.ResolveAsync();
+            if (target.UsesAgent && !string.IsNullOrEmpty(target.BaseUrl))
+            {
+                ip = await JS.InvokeAsync<string?>("eval",
+                    $"fetch('{target.BaseUrl}/netopt/whoami', {{signal: AbortSignal.timeout(4000)}})" +
+                    ".then(r => r.json()).then(j => j.ip).catch(() => null)");
+            }
+        }
+        catch { return false; }
+
+        if (string.IsNullOrEmpty(ip) || !System.Net.IPAddress.TryParse(ip, out _))
+            return false;
+
+        _clientIp = ip;
+        await IdentifyAndLoadAsync();
+        if (_client != null)
+        {
+            Logger.LogDebug("Client identity (site {Site}): agent whoami resolved {Ip}", SiteContext.Slug, ip);
+            return true;
+        }
+
+        // The agent answered but the console hasn't listed the client yet (still warming
+        // up on a cold connect) - clear so the next retry re-probes cleanly.
+        _clientIp = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Background retry for a cold agent/console connection. The agent's tunnel or the
+    /// UniFi console may still be coming up when the page first loads, so identity isn't
+    /// resolvable yet. Probe roughly once a second (up to 30s) so the dashboard fills in
+    /// snappily once the connection is live - the whoami endpoint is lightweight, so
+    /// hitting it a few times is cheap. Re-arms one-shot after each attempt completes so a
+    /// slow probe never overlaps the next. Stops early once the viewer picks manually.
+    /// </summary>
+    private void StartSiteIdentityRetry()
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(30);
+        _identityRetryTimer = new System.Threading.Timer(async _ =>
+        {
+            var done = false;
+            try
+            {
+                await InvokeAsync(async () =>
+                {
+                    // Stop if the picker is gone (viewer picked a device) or we timed out.
+                    if (!_showClientPicker || DateTime.UtcNow >= deadline)
+                    {
+                        done = true;
+                        return;
+                    }
+
+                    if (await TryResolveSiteIdentityAsync())
+                    {
+                        _showClientPicker = false;
+                        done = true;
+                        StateHasChanged();
+                    }
+                });
+            }
+            catch { /* keep retrying across transient errors */ }
+
+            if (done)
+            {
+                _identityRetryTimer?.Dispose();
+                _identityRetryTimer = null;
+            }
+            else
+            {
+                // Re-arm a single tick ~1s out (one-shot period) so a slow whoami never
+                // overlaps the next probe.
+                try { _identityRetryTimer?.Change(TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan); }
+                catch { /* timer disposed - nothing to re-arm */ }
+            }
+        }, null, TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan);
     }
 
     private async Task ShowClientPickerAsync()
@@ -2691,6 +2737,7 @@
     public async ValueTask DisposeAsync()
     {
         _pollTimer?.Dispose();
+        _identityRetryTimer?.Dispose();
 
         // Stop GPS watcher
         if (_gpsWatcherId.HasValue)

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -257,7 +257,6 @@
             <div class="identity-row-2">
                 @if (_client.IsVpn)
                 {
-                    <span class="identity-detail">@_client.Name</span>
                     <span class="identity-detail detail-dim">Remote client - limited data available</span>
                 }
                 else if (!_client.IsWired)
@@ -303,17 +302,17 @@
                 }
             </div>
             <div class="dashboard-controls">
-                <div class="tab-bar">
-                    <button class="tab-btn @(_activeTab == "speed" ? "active" : "")"
-                            @onclick='() => SetActiveTab("speed")'>Speed</button>
-                    @if (!_client.IsVpn)
-                    {
+                @if (!_client.IsVpn)
+                {
+                    <div class="tab-bar">
+                        <button class="tab-btn @(_activeTab == "speed" ? "active" : "")"
+                                @onclick='() => SetActiveTab("speed")'>Speed</button>
                         <button class="tab-btn @(_activeTab == "signal" ? "active" : "")"
                                 @onclick='() => SetActiveTab("signal")'>Signal</button>
                         <button class="tab-btn @(_activeTab == "connection" ? "active" : "")"
                                 @onclick='() => SetActiveTab("connection")'>Connection</button>
-                    }
-                </div>
+                    </div>
+                }
                 <div class="time-range-selector">
                     @foreach (var tf in _timeFilters)
                     {

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -1035,12 +1035,26 @@
         // Note: initial GPS request happens in OnAfterRenderAsync (needs JS interop)
 
         // VPN clients (Tailscale/Teleport/remote-user VPN) have no UniFi identity to poll
-        // and no L2 trace: every poll cycle would fail and trip the connection banner.
-        // They get a static simplified view (Speed tab only), so skip live polling entirely.
+        // and no L2 trace, so skip the signal/trace poll (it would fail and trip the
+        // connection banner). But new speed-test results should still appear live, so run
+        // a lightweight timer that just reloads the Speed tab data - no stat/sta, no trace.
         if (_client?.IsVpn == true)
         {
             _activeTab = "speed";
             _isLogging = false;
+
+            _pollTimer = new System.Threading.Timer(async _ =>
+            {
+                try
+                {
+                    await InvokeAsync(async () =>
+                    {
+                        await RefreshVpnSpeedAsync();
+                        StateHasChanged();
+                    });
+                }
+                catch { /* prevent timer death */ }
+            }, null, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
             return;
         }
 
@@ -1514,6 +1528,25 @@
                 await LoadConnectionDataAsync(from, to);
                 break;
         }
+    }
+
+    /// <summary>
+    /// Lightweight periodic refresh for VPN clients: reloads Speed tab results and charts
+    /// so new speed tests appear live, without the signal poll or L2 trace (neither of
+    /// which exists for VPN clients).
+    /// </summary>
+    private async Task RefreshVpnSpeedAsync()
+    {
+        if (_client == null) return;
+
+        // Don't disrupt a chart tooltip the user is hovering.
+        try { _isTooltipActive = await JS.InvokeAsync<bool>("eval", "!!document.querySelector('.apexcharts-tooltip-active')"); }
+        catch { _isTooltipActive = false; }
+
+        var (from, to) = GetTimeRange();
+        await LoadSpeedDataAsync(from, to);
+        if (!_isTooltipActive)
+            await UpdateActiveChartsAsync();
     }
 
     private async Task LoadSpeedDataAsync(DateTime from, DateTime to)

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -1228,20 +1228,40 @@
     /// </summary>
     private async Task ResolveSiteIdentityAsync()
     {
+        // The on-site agent's tunnel may still be coming up when the page first loads,
+        // so the resolver reports no agent target yet. Poll for a bounded window so
+        // identity resolves automatically once the agent connects, instead of dropping
+        // to the picker and forcing the viewer to refresh. Keep the loading skeleton up
+        // (via _awaitingSiteIdentity) while we wait.
+        var deadline = DateTime.UtcNow.AddSeconds(20);
         string? ip = null;
         var probed = false;
-        try
+        while (true)
         {
-            var target = await SiteTarget.ResolveAsync();
-            if (target.UsesAgent && !string.IsNullOrEmpty(target.BaseUrl))
+            try
             {
-                probed = true;
-                ip = await JS.InvokeAsync<string?>("eval",
-                    $"fetch('{target.BaseUrl}/netopt/whoami', {{signal: AbortSignal.timeout(4000)}})" +
-                    ".then(r => r.json()).then(j => j.ip).catch(() => null)");
+                var target = await SiteTarget.ResolveAsync();
+                if (target.UsesAgent && !string.IsNullOrEmpty(target.BaseUrl))
+                {
+                    probed = true;
+                    ip = await JS.InvokeAsync<string?>("eval",
+                        $"fetch('{target.BaseUrl}/netopt/whoami', {{signal: AbortSignal.timeout(4000)}})" +
+                        ".then(r => r.json()).then(j => j.ip).catch(() => null)");
+                }
             }
+            catch { /* probe is best-effort; the picker below always works */ }
+
+            if (!string.IsNullOrEmpty(ip) && System.Net.IPAddress.TryParse(ip, out _))
+                break;
+
+            // Once the agent target is reachable, a null answer means the probe itself
+            // failed (e.g. certificate untrusted) - don't keep waiting, fall to the picker.
+            // Otherwise the agent isn't online yet: retry until the deadline.
+            if (probed || DateTime.UtcNow >= deadline)
+                break;
+
+            await Task.Delay(2000);
         }
-        catch { /* probe is best-effort; the picker below always works */ }
 
         _awaitingSiteIdentity = false;
 

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -143,7 +143,22 @@
     {
         <div class="card empty-state">
             <h3>Device Not Found</h3>
-            <p>Could not identify your device on the network. Make sure you're connected and the UniFi Console is reachable.</p>
+            @if (!SiteContext.IsDefault)
+            {
+                <p>Could not identify your device on the network. Make sure you're connected and the UniFi Console is reachable.</p>
+            }
+            else if (!ConnectionService.IsConnected)
+            {
+                <p>The UniFi Console can't be reached right now, so your device can't be identified. Once the connection is restored, retry.</p>
+            }
+            else
+            {
+                <p>Your device isn't showing up in the UniFi Console's client list yet. If you just connected, give it a few seconds and retry.</p>
+                @if (!string.IsNullOrEmpty(_clientIp) && _clientIp != "unknown")
+                {
+                    <p class="empty-state-detail">Detected address: <code>@_clientIp</code></p>
+                }
+            }
             <button class="btn btn-primary" @onclick="ReloadPageAsync">Retry</button>
         </div>
     }
@@ -152,18 +167,33 @@
         @* Identity Bar *@
         <div class="card identity-bar">
             <div class="identity-row-1">
-                <div class="identity-info">
-                    <h2 class="identity-name">@_client.DisplayName</h2>
-                    <div class="identity-meta">
-                        <span>@_client.Mac</span>
-                        <span class="meta-sep">·</span>
-                        <span>@_client.Ip</span>
-                        @if (!string.IsNullOrEmpty(_client.Essid))
-                        {
+                <div class="identity-info @(_client.IsVpn ? "identity-info-vpn" : null)">
+                    @if (_client.IsVpn)
+                    {
+                        <span class="identity-vpn-icon @GetVpnTintClass(_client.VpnType)">
+                            <VpnIcon Type="_client.VpnType!.Value" Size="32" />
+                        </span>
+                        <div class="identity-text">
+                            <h2 class="identity-name">@_client.DisplayName</h2>
+                            <div class="identity-meta">
+                                <span>@_client.Ip</span>
+                            </div>
+                        </div>
+                    }
+                    else
+                    {
+                        <h2 class="identity-name">@_client.DisplayName</h2>
+                        <div class="identity-meta">
+                            <span>@_client.Mac</span>
                             <span class="meta-sep">·</span>
-                            <span data-tooltip="SSID">@_client.Essid</span>
-                        }
-                    </div>
+                            <span>@_client.Ip</span>
+                            @if (!string.IsNullOrEmpty(_client.Essid))
+                            {
+                                <span class="meta-sep">·</span>
+                                <span data-tooltip="SSID">@_client.Essid</span>
+                            }
+                        </div>
+                    }
                 </div>
                 <div class="identity-signal">
                     @if (!_client.IsWired && _client.SignalDbm.HasValue)
@@ -188,6 +218,8 @@
                             }
                         </div>
                     }
+                    @if (!_client.IsVpn)
+                    {
                     <div class="identity-live-group">
                         @if (_client.IsOffline)
                         {
@@ -219,10 +251,16 @@
                             </button>
                         }
                     </div>
+                    }
                 </div>
             </div>
             <div class="identity-row-2">
-                @if (!_client.IsWired)
+                @if (_client.IsVpn)
+                {
+                    <span class="identity-detail">@_client.Name</span>
+                    <span class="identity-detail detail-dim">Remote client - limited data available</span>
+                }
+                else if (!_client.IsWired)
                 {
                     <span class="band-badge @GetBandClass(_client.Band)">@(_client.BandDisplay ?? "—")</span>
                     <span class="identity-detail">
@@ -254,7 +292,7 @@
                 {
                     <span class="identity-detail">Wired</span>
                 }
-                @if (!_isOwnDevice && _client is { IsWired: false, IsOffline: false })
+                @if (!_isOwnDevice && !_client.IsVpn && _client is { IsWired: false, IsOffline: false })
                 {
                     <button class="btn btn-sm @(_isLogging ? "btn-danger" : "btn-primary") logging-toggle logging-toggle-desktop"
                             @onclick="ToggleLogging"
@@ -268,10 +306,13 @@
                 <div class="tab-bar">
                     <button class="tab-btn @(_activeTab == "speed" ? "active" : "")"
                             @onclick='() => SetActiveTab("speed")'>Speed</button>
-                    <button class="tab-btn @(_activeTab == "signal" ? "active" : "")"
-                            @onclick='() => SetActiveTab("signal")'>Signal</button>
-                    <button class="tab-btn @(_activeTab == "connection" ? "active" : "")"
-                            @onclick='() => SetActiveTab("connection")'>Connection</button>
+                    @if (!_client.IsVpn)
+                    {
+                        <button class="tab-btn @(_activeTab == "signal" ? "active" : "")"
+                                @onclick='() => SetActiveTab("signal")'>Signal</button>
+                        <button class="tab-btn @(_activeTab == "connection" ? "active" : "")"
+                                @onclick='() => SetActiveTab("connection")'>Connection</button>
+                    }
                 </div>
                 <div class="time-range-selector">
                     @foreach (var tf in _timeFilters)
@@ -430,7 +471,7 @@
                                             <th class="hide-mobile">From Device</th>
                                             <th class="hide-mobile">To Device</th>
                                             <th class="show-mobile">Result</th>
-                                            @if (!(_client?.IsWired == true))
+                                            @if (!HidesApRates)
                                             {
                                                 <th class="hide-mobile" data-tooltip="AP receive rate (from device)">RX Rate</th>
                                                 <th class="hide-mobile" data-tooltip="AP transmit rate (to device)">TX Rate</th>
@@ -451,7 +492,7 @@
                                                 <td class="hide-mobile"><span class="speed-down">@FormatSpeed(r.DownloadMbps, "F1")</span> Mbps</td>
                                                 <td class="hide-mobile"><span class="speed-up">@FormatSpeed(r.UploadMbps, "F1")</span> Mbps</td>
                                                 <td class="show-mobile"><span class="speed-down">@FormatSpeed(r.DownloadMbps, "F0")</span> / <span class="speed-up">@FormatSpeed(r.UploadMbps, "F0")</span></td>
-                                                @if (!(_client?.IsWired == true))
+                                                @if (!HidesApRates)
                                                 {
                                                     <td class="hide-mobile">@RenderRate(r.WifiRxRateKbps, "wifi-speed-rx")</td>
                                                     <td class="hide-mobile">@RenderRate(r.WifiTxRateKbps, "wifi-speed-tx")</td>
@@ -464,7 +505,7 @@
                                             @if (_expandedResultId == r.Id)
                                             {
                                                 <tr class="result-details-row">
-                                                    <td colspan="@(_client?.IsWired == true ? 6 : 8)">
+                                                    <td colspan="@(HidesApRates ? 6 : 8)">
                                                         <div class="result-details">
                                                             <SpeedTestDetails Result="r" HideDeviceName="true" HideClientDashboardLink="true" />
                                                         </div>
@@ -490,6 +531,7 @@
                     {
                         <SpeedTestMap Results="_speedResults" MapHeight="400px"
                                      ApMarkers="_apMapMarkers" AllowApEditing="false"
+                                     ShowExternalByDefault="_client?.IsVpn == true"
                                      TimeFilterHours="_selectedTimeFilter" />
                     }
                 </div>
@@ -993,6 +1035,16 @@
 
         // Note: initial GPS request happens in OnAfterRenderAsync (needs JS interop)
 
+        // VPN clients (Tailscale/Teleport/remote-user VPN) have no UniFi identity to poll
+        // and no L2 trace: every poll cycle would fail and trip the connection banner.
+        // They get a static simplified view (Speed tab only), so skip live polling entirely.
+        if (_client?.IsVpn == true)
+        {
+            _activeTab = "speed";
+            _isLogging = false;
+            return;
+        }
+
         // Start polling - 1s ticks when WiFiman is available.
         // Full poll (stat/sta + trace + storage) every 5th tick.
         // Lightweight WiFiman-only poll on other ticks for live signal updates.
@@ -1053,7 +1105,8 @@
         // Must be in OnAfterRenderAsync because JS interop isn't available during prerender
         _isInsecureContext = !await JS.InvokeAsync<bool>("eval", "window.isSecureContext");
         _isMobile = await JS.InvokeAsync<bool>("eval", "window.innerWidth <= 768");
-        _showGpsWarning = _isInsecureContext && _isOwnDevice;
+        // VPN clients have no GPS walk-test flow (no live polling), so never warn them.
+        _showGpsWarning = _isInsecureContext && _isOwnDevice && _client?.IsVpn != true;
 
         // Managed-site own-device identity needs JS (agent whoami probe / localStorage),
         // so it runs here rather than in OnInitializedAsync.
@@ -1076,6 +1129,11 @@
             // We don't have direct access to HttpContext IP in Blazor Server,
             // so we use JS interop to get the page URL and call the API
             _client = await GetClientIdentityAsync();
+
+            // VPN clients only get the Speed tab; force it before loading so a stale
+            // ?tab=signal/connection deep link doesn't load data they don't have.
+            if (_client?.IsVpn == true && _activeTab != "speed")
+                _activeTab = "speed";
 
             if (_client != null)
             {
@@ -1136,7 +1194,15 @@
         if (string.IsNullOrEmpty(_clientIp) || _clientIp == "unknown")
             return null;
 
-        return await DashboardService.IdentifyClientAsync(_clientIp);
+        var identity = await DashboardService.IdentifyClientAsync(_clientIp);
+
+        // A viewer reaching the dashboard over Tailscale/Teleport/remote-user VPN is never
+        // in the UniFi client list, so identity is null. Fall back to the simplified VPN
+        // view - default site only, so managed-site behavior (whoami/picker) is untouched.
+        if (identity == null && SiteContext.IsDefault)
+            identity = await DashboardService.IdentifyVpnClientAsync(_clientIp);
+
+        return identity;
     }
 
     /// <summary>
@@ -1453,7 +1519,10 @@
 
     private async Task LoadSpeedDataAsync(DateTime from, DateTime to)
     {
-        _speedResults = await DashboardService.GetSpeedResultsAsync(_client!.Mac, from, to);
+        // VPN clients have no UniFi MAC; their results are keyed by source IP (DeviceHost).
+        _speedResults = _client!.IsVpn
+            ? await DashboardService.GetSpeedResultsByHostAsync(_client.Ip ?? "", from, to)
+            : await DashboardService.GetSpeedResultsAsync(_client.Mac, from, to);
         _latestSpeedResult = _speedResults.FirstOrDefault();
 
         // Build chart data (UTC timestamps - JS formatter converts to browser local time)
@@ -1948,6 +2017,9 @@
     // Speed results pagination
     private int SpeedTotalPages => Math.Max(1, (int)Math.Ceiling(_speedResults.Count / (double)SpeedPageSize));
 
+    // AP RX/TX rate columns only apply to Wi-Fi clients - hide for wired and VPN clients.
+    private bool HidesApRates => _client?.IsWired == true || _client?.IsVpn == true;
+
     private IEnumerable<Iperf3Result> GetPagedSpeedResults()
     {
         return _speedResults.Skip((_speedPage - 1) * SpeedPageSize).Take(SpeedPageSize);
@@ -2339,6 +2411,14 @@
         _ => ""
     };
 
+    // Tint for the VPN logo in the identity bar, matching the speed-test trace hop colors.
+    private static string GetVpnTintClass(HopType? vpnType) => vpnType switch
+    {
+        HopType.Tailscale => "vpn-tint-tailscale",
+        HopType.Teleport => "vpn-tint-teleport",
+        _ => ""
+    };
+
     // Map a UniFi radio code to the FloorPlanEditor propagation band ("2.4" / "5" / "6").
     // Returns null when unknown so the editor keeps its current band.
     private static string? ClientBandToPropagationBand(string? band) => band switch
@@ -2611,7 +2691,36 @@
         gap: 12px;
         margin-bottom: 8px;
     }
+    .empty-state-detail {
+        font-size: 0.8125rem;
+        color: var(--text-muted);
+    }
+
     .identity-info {
+        min-width: 0;
+    }
+    .identity-info-vpn {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+    }
+    .identity-vpn-icon {
+        display: flex;
+        align-items: center;
+        flex-shrink: 0;
+        color: var(--text-secondary);
+    }
+    .identity-vpn-icon.vpn-tint-tailscale {
+        color: var(--primary-light);
+    }
+    .identity-vpn-icon.vpn-tint-teleport {
+        color: var(--purple-light);
+    }
+    .identity-vpn-icon .vpn-shield-icon {
+        width: 32px;
+        height: 32px;
+    }
+    .identity-text {
         min-width: 0;
     }
     .identity-name {

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -1229,11 +1229,15 @@
     /// </summary>
     private async Task ResolveSiteIdentityAsync()
     {
-        _awaitingSiteIdentity = false;
-
+        // Keep the loading skeleton up (via _awaitingSiteIdentity) through the whole
+        // attempt: clearing it early exposes a window where a poll-timer re-render would
+        // flash "Device Not Found" before the picker is ready. It is cleared only at a
+        // terminal state - here on success, or inside ShowClientPickerAsync when the
+        // picker becomes visible.
         // One immediate attempt - resolves instantly on a warm agent connection.
         if (await TryResolveSiteIdentityAsync())
         {
+            _awaitingSiteIdentity = false;
             StateHasChanged();
             return;
         }
@@ -1345,7 +1349,11 @@
                 _pickerSelection = remembered;
         }
         catch { /* no preselect without localStorage */ }
+        // Flip both flags together, with no await between, so a render can't catch a
+        // state where neither the skeleton nor the picker is showing (which would flash
+        // the "Device Not Found" card).
         _showClientPicker = true;
+        _awaitingSiteIdentity = false;
         _loading = false;
         StateHasChanged();
     }

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -178,20 +178,7 @@ else
 
         @if (_flakyTargetCount > 0)
         {
-            <div class="alert alert-info" style="margin-bottom: 1rem;">
-                <div class="banner-content">
-                    <span class="banner-icon banner-icon-info">i</span>
-                    <div class="banner-text" style="flex: 1;">
-                        @(_flakyTargetCount == 1
-                            ? "1 monitoring target looks flaky"
-                            : $"{_flakyTargetCount} monitoring targets look flaky")
-                        - high packet loss versus their peers, usually ICMP deprioritization. Review and disable them so they don't skew ISP Health.
-                    </div>
-                    <div class="banner-actions">
-                        <button class="btn btn-sm btn-primary" @onclick="GoToFlakyTargets">Review flaky targets</button>
-                    </div>
-                </div>
-            </div>
+            @FlakyTargetsBanner
         }
 
         @if (_upstreamNeedsReview && !_upstreamReviewDismissed)
@@ -336,6 +323,12 @@ else
     @* ──────────────── Tab: ISP Health ──────────────── *@
     @if (_activeTab == "isp-health" && _monitoringReady)
     {
+        @* Flaky internet targets skew the score shown here, so surface the same advisory
+           (#849) above the panel - not only on Live View where it was first detected. *@
+        @if (_flakyTargetCount > 0)
+        {
+            @FlakyTargetsBanner
+        }
         <IspHealthPanel />
     }
 
@@ -2040,9 +2033,29 @@ else
         SetActiveTab("setup");
     }
 
-    // Flaky-target banner state (#849). Detected once when Live View first loads; never polled.
+    // Flaky-target banner state (#849). Detected once when Live View or ISP Health first loads,
+    // and re-checked when targets change so addressing the flagged ones clears the banner. Not polled.
     private int _flakyTargetCount;
     private bool _flakyChecked;
+
+    // Shared markup for the flaky internet-target advisory (#849) so Live View and ISP Health
+    // render the identical banner. AccessIsp/Transit/InternetService targets with loss well above
+    // their peers distort ISP Health scoring, so the warning belongs both where you watch live and
+    // where you read the score.
+    private RenderFragment FlakyTargetsBanner => @<div class="alert alert-info" style="margin-bottom: 1rem;">
+        <div class="banner-content">
+            <span class="banner-icon banner-icon-info">i</span>
+            <div class="banner-text" style="flex: 1;">
+                @(_flakyTargetCount == 1
+                    ? "1 monitoring target looks flaky"
+                    : $"{_flakyTargetCount} monitoring targets look flaky")
+                - high packet loss versus their peers, usually ICMP deprioritization. Review and disable them so they don't skew ISP Health.
+            </div>
+            <div class="banner-actions">
+                <button class="btn btn-sm btn-primary" @onclick="GoToFlakyTargets">Review flaky targets</button>
+            </div>
+        </div>
+    </div>;
 
     private void GoToFlakyTargets()
     {
@@ -2168,6 +2181,16 @@ else
         await LoadTargetsAsync();
         if (UpstreamTargetSignature() != before)
             LanFlowMapCache.Invalidate();
+
+        // Re-check flaky targets when the advisory is up so disabling/pausing the flagged ones
+        // clears the banner (they drop out of the enabled pool). Only when a banner is showing -
+        // no need to add the loss queries to unrelated target edits.
+        if (_flakyTargetCount > 0)
+        {
+            try { _flakyTargetCount = (await FlakyTargets.DetectAsync()).Count; }
+            catch (Exception ex) { Logger.LogDebug(ex, "Flaky-target re-check after target change failed"); }
+        }
+
         StateHasChanged();
     }
 
@@ -3160,8 +3183,9 @@ else
         // Mount/unmount charts based on active tab. Only mount when the container
         // div exists in the DOM (i.e., the tab is active). Unmount when switching away.
 
-        // Flaky-target banner (#849): detect once, on the first time Live View is shown. No polling.
-        if (_activeTab == "live" && _monitoringReady && !_flakyChecked)
+        // Flaky-target banner (#849): detect once, the first time Live View or ISP Health is shown
+        // (both surface the banner). No polling.
+        if ((_activeTab == "live" || _activeTab == "isp-health") && _monitoringReady && !_flakyChecked)
         {
             _flakyChecked = true;
             try

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -1194,39 +1194,12 @@
     /// </summary>
     private RenderFragment GetHopIconMarkup(NetworkHop hop) => builder =>
     {
-        // VPN hops get custom SVG icons
-        if (hop.Type == HopType.Teleport)
+        // VPN hops get custom logos, shared with the Client Dashboard via VpnIcon.
+        if (hop.Type is HopType.Teleport or HopType.Tailscale or HopType.Vpn)
         {
-            builder.OpenElement(0, "svg");
-            builder.AddAttribute(1, "viewBox", "0 0 20 20");
-            builder.AddAttribute(2, "width", "24");
-            builder.AddAttribute(3, "height", "24");
-            builder.AddAttribute(4, "class", "vpn-icon teleport-icon");
-            builder.AddMarkupContent(5, @"<path fill-rule=""evenodd"" clip-rule=""evenodd"" d=""M5.111 7.255c-.125-1.072-.318-1.952-.544-2.55-.115-.3-.227-.502-.322-.618a.555.555 0 0 0-.066-.07.897.897 0 0 0-.183.243c-.156.27-.312.693-.45 1.26-.275 1.127-.45 2.708-.45 4.474 0 1.765.175 3.347.45 4.473.138.567.294.99.45 1.26.086.15.15.216.183.244a.558.558 0 0 0 .068-.072c.096-.12.21-.324.324-.63.228-.606.422-1.497.545-2.582a.5.5 0 1 1 .994.114c-.129 1.126-.335 2.107-.603 2.82-.133.354-.291.67-.483.908-.188.231-.47.459-.845.459-.51 0-.848-.41-1.05-.761-.223-.388-.407-.915-.555-1.523-.299-1.224-.478-2.89-.478-4.71 0-1.821.18-3.486.478-4.71.148-.609.332-1.136.555-1.523C3.331 3.41 3.67 3 4.18 3c.373 0 .653.224.84.454.192.235.35.548.483.898.267.704.473 1.673.603 2.788a.5.5 0 0 1-.994.115Zm-.96 8.736-.003.001h.003ZM15.543 4.706c-.227.597-.42 1.477-.545 2.55a.5.5 0 0 1-.993-.116c.13-1.115.336-2.084.603-2.788.132-.35.29-.663.482-.898.187-.23.467-.454.84-.454.511 0 .848.41 1.05.76.223.388.407.915.555 1.524.299 1.224.478 2.889.478 4.71 0 1.82-.18 3.486-.478 4.71-.148.608-.332 1.135-.555 1.523-.202.35-.539.76-1.05.76-.375 0-.656-.227-.844-.458-.193-.238-.351-.554-.484-.908-.268-.713-.474-1.694-.603-2.82a.5.5 0 1 1 .994-.114c.124 1.085.317 1.976.545 2.582.115.306.228.51.324.63a.562.562 0 0 0 .068.072.898.898 0 0 0 .183-.244c.156-.27.313-.693.45-1.26.275-1.126.45-2.708.45-4.473 0-1.766-.175-3.347-.45-4.474-.137-.567-.294-.99-.45-1.26a.896.896 0 0 0-.183-.243.554.554 0 0 0-.066.07c-.095.116-.207.318-.321.619Zm.418 11.286h-.002.002ZM7.557 9.684a.5.5 0 0 0 0 .707l2.122 2.122a.5.5 0 0 0 .707 0l2.123-2.122a.5.5 0 0 0 0-.707L10.386 7.56a.5.5 0 0 0-.707 0L7.557 9.684Zm1.06.353 1.416 1.416 1.415-1.416-1.415-1.415-1.416 1.415Z"" fill=""currentColor""/>");
-            builder.CloseElement();
-            return;
-        }
-
-        if (hop.Type == HopType.Tailscale)
-        {
-            builder.OpenElement(0, "svg");
-            builder.AddAttribute(1, "viewBox", "0 0 20 20");
-            builder.AddAttribute(2, "width", "24");
-            builder.AddAttribute(3, "height", "24");
-            builder.AddAttribute(4, "class", "vpn-icon tailscale-icon");
-            // Official Tailscale logo - 3x3 dot grid: middle row + center bottom solid, corners faded
-            builder.AddMarkupContent(5, @"<ellipse cx=""2.45"" cy=""10.18"" rx=""2.45"" ry=""2.44"" fill=""currentColor""/><ellipse cx=""9.79"" cy=""10.18"" rx=""2.45"" ry=""2.44"" fill=""currentColor""/><ellipse cx=""17.13"" cy=""10.18"" rx=""2.45"" ry=""2.44"" fill=""currentColor""/><ellipse cx=""9.79"" cy=""17.51"" rx=""2.45"" ry=""2.44"" fill=""currentColor""/><ellipse opacity=""0.2"" cx=""2.45"" cy=""2.86"" rx=""2.45"" ry=""2.44"" fill=""currentColor""/><ellipse opacity=""0.2"" cx=""9.79"" cy=""2.86"" rx=""2.45"" ry=""2.44"" fill=""currentColor""/><ellipse opacity=""0.2"" cx=""17.13"" cy=""2.86"" rx=""2.45"" ry=""2.44"" fill=""currentColor""/><ellipse opacity=""0.2"" cx=""2.45"" cy=""17.51"" rx=""2.45"" ry=""2.44"" fill=""currentColor""/><ellipse opacity=""0.2"" cx=""17.13"" cy=""17.51"" rx=""2.45"" ry=""2.44"" fill=""currentColor""/>");
-            builder.CloseElement();
-            return;
-        }
-
-        if (hop.Type == HopType.Vpn)
-        {
-            builder.OpenElement(0, "img");
-            builder.AddAttribute(1, "src", "/icons/shield-v2.png");
-            builder.AddAttribute(2, "alt", "VPN");
-            builder.AddAttribute(3, "class", "vpn-icon vpn-shield-icon");
-            builder.CloseElement();
+            builder.OpenComponent<VpnIcon>(0);
+            builder.AddComponentParameter(1, nameof(VpnIcon.Type), hop.Type);
+            builder.CloseComponent();
             return;
         }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestMap.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestMap.razor
@@ -518,13 +518,17 @@
         if (TimeFilterHours.HasValue && TimeFilterHours != _lastExternalTimeFilter)
         {
             _lastExternalTimeFilter = TimeFilterHours;
+            // Treat an external time-filter change like a slider move: clear any manual
+            // pan/zoom so this filter change - and the new results that arrive under it -
+            // auto-fit the visible set back into view.
+            userHasZoomed = false;
             var targetIndex = FindClosestBreakpointIndex(TimeFilterHours.Value);
             if (targetIndex != sliderValue)
             {
                 sliderValue = targetIndex;
                 if (mapInitialized)
                 {
-                    await UpdateMarkers(fitBounds: !userHasZoomed);
+                    await UpdateMarkers(fitBounds: true);
                     StateHasChanged();
                     return; // Markers already updated, skip the count check below
                 }

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestMap.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestMap.razor
@@ -542,7 +542,9 @@
             lastResultCount = currentCount;
             lastNewestResultId = newestId;
             lastFilteredCount = filteredCount;
-            await UpdateMarkers(fitBounds: false);
+            // Auto-fit so a freshly arrived result is brought into view, unless the user
+            // has manually panned/zoomed - same guard the slider and filter toggles use.
+            await UpdateMarkers(fitBounds: !userHasZoomed);
             await UpdateApMarkers(); // Rebuild popups with fresh device test data
             StateHasChanged();
         }

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestMap.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestMap.razor
@@ -169,6 +169,14 @@
     [Parameter]
     public int? TimeFilterHours { get; set; }
 
+    /// <summary>
+    /// Pre-select the External layer on first load. Used by the VPN client dashboard,
+    /// where every result is External - otherwise the map would render blank until the
+    /// user toggles the External filter on. The toggle still works normally afterward.
+    /// </summary>
+    [Parameter]
+    public bool ShowExternalByDefault { get; set; }
+
     /// <summary>Fires when the time slider changes, passing the number of hours (0 = all time)</summary>
     [Parameter]
     public EventCallback<int> OnTimeRangeChanged { get; set; }
@@ -486,6 +494,11 @@
 
     protected override async Task OnInitializedAsync()
     {
+        // When all results are External (e.g. a VPN client dashboard), start with the
+        // External layer visible so markers show without an extra toggle.
+        if (ShowExternalByDefault)
+            ShowExternal = true;
+
         // Load networks for VPN detection
         _networks = await ConnectionService.GetNetworksAsync();
     }

--- a/src/NetworkOptimizer.Web/Components/Shared/VpnIcon.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/VpnIcon.razor
@@ -1,0 +1,39 @@
+@using NetworkOptimizer.UniFi.Models
+
+@* Renders the VPN-type logo used for VPN hops in speed-test path traces.
+   Shared by SpeedTestDetails (trace) and the Client Dashboard (simplified VPN view)
+   so both render identical markup. Renders nothing for non-VPN hop types. *@
+
+@if (Type == HopType.Teleport)
+{
+    <svg viewBox="0 0 20 20" width="@Size" height="@Size" class="vpn-icon teleport-icon">
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M5.111 7.255c-.125-1.072-.318-1.952-.544-2.55-.115-.3-.227-.502-.322-.618a.555.555 0 0 0-.066-.07.897.897 0 0 0-.183.243c-.156.27-.312.693-.45 1.26-.275 1.127-.45 2.708-.45 4.474 0 1.765.175 3.347.45 4.473.138.567.294.99.45 1.26.086.15.15.216.183.244a.558.558 0 0 0 .068-.072c.096-.12.21-.324.324-.63.228-.606.422-1.497.545-2.582a.5.5 0 1 1 .994.114c-.129 1.126-.335 2.107-.603 2.82-.133.354-.291.67-.483.908-.188.231-.47.459-.845.459-.51 0-.848-.41-1.05-.761-.223-.388-.407-.915-.555-1.523-.299-1.224-.478-2.89-.478-4.71 0-1.821.18-3.486.478-4.71.148-.609.332-1.136.555-1.523C3.331 3.41 3.67 3 4.18 3c.373 0 .653.224.84.454.192.235.35.548.483.898.267.704.473 1.673.603 2.788a.5.5 0 0 1-.994.115Zm-.96 8.736-.003.001h.003ZM15.543 4.706c-.227.597-.42 1.477-.545 2.55a.5.5 0 0 1-.993-.116c.13-1.115.336-2.084.603-2.788.132-.35.29-.663.482-.898.187-.23.467-.454.84-.454.511 0 .848.41 1.05.76.223.388.407.915.555 1.524.299 1.224.478 2.889.478 4.71 0 1.82-.18 3.486-.478 4.71-.148.608-.332 1.135-.555 1.523-.202.35-.539.76-1.05.76-.375 0-.656-.227-.844-.458-.193-.238-.351-.554-.484-.908-.268-.713-.474-1.694-.603-2.82a.5.5 0 1 1 .994-.114c.124 1.085.317 1.976.545 2.582.115.306.228.51.324.63a.562.562 0 0 0 .068.072.898.898 0 0 0 .183-.244c.156-.27.313-.693.45-1.26.275-1.126.45-2.708.45-4.473 0-1.766-.175-3.347-.45-4.474-.137-.567-.294-.99-.45-1.26a.896.896 0 0 0-.183-.243.554.554 0 0 0-.066.07c-.095.116-.207.318-.321.619Zm.418 11.286h-.002.002ZM7.557 9.684a.5.5 0 0 0 0 .707l2.122 2.122a.5.5 0 0 0 .707 0l2.123-2.122a.5.5 0 0 0 0-.707L10.386 7.56a.5.5 0 0 0-.707 0L7.557 9.684Zm1.06.353 1.416 1.416 1.415-1.416-1.415-1.415-1.416 1.415Z" fill="currentColor" />
+    </svg>
+}
+else if (Type == HopType.Tailscale)
+{
+    @* Official Tailscale logo - 3x3 dot grid: middle row + center bottom solid, corners faded *@
+    <svg viewBox="0 0 20 20" width="@Size" height="@Size" class="vpn-icon tailscale-icon">
+        <ellipse cx="2.45" cy="10.18" rx="2.45" ry="2.44" fill="currentColor" />
+        <ellipse cx="9.79" cy="10.18" rx="2.45" ry="2.44" fill="currentColor" />
+        <ellipse cx="17.13" cy="10.18" rx="2.45" ry="2.44" fill="currentColor" />
+        <ellipse cx="9.79" cy="17.51" rx="2.45" ry="2.44" fill="currentColor" />
+        <ellipse opacity="0.2" cx="2.45" cy="2.86" rx="2.45" ry="2.44" fill="currentColor" />
+        <ellipse opacity="0.2" cx="9.79" cy="2.86" rx="2.45" ry="2.44" fill="currentColor" />
+        <ellipse opacity="0.2" cx="17.13" cy="2.86" rx="2.45" ry="2.44" fill="currentColor" />
+        <ellipse opacity="0.2" cx="2.45" cy="17.51" rx="2.45" ry="2.44" fill="currentColor" />
+        <ellipse opacity="0.2" cx="17.13" cy="17.51" rx="2.45" ry="2.44" fill="currentColor" />
+    </svg>
+}
+else if (Type == HopType.Vpn)
+{
+    <img src="/icons/shield-v2.png" alt="VPN" class="vpn-icon vpn-shield-icon" />
+}
+
+@code {
+    /// <summary>The VPN hop type to render. Non-VPN types render nothing.</summary>
+    [Parameter] public HopType Type { get; set; }
+
+    /// <summary>SVG icon size in px (Tailscale/Teleport). The shield PNG is sized via CSS.</summary>
+    [Parameter] public int Size { get; set; } = 24;
+}

--- a/src/NetworkOptimizer.Web/Models/ClientDashboardModels.cs
+++ b/src/NetworkOptimizer.Web/Models/ClientDashboardModels.cs
@@ -52,6 +52,15 @@ public class ClientIdentity
     /// <summary>True when signal data was sourced from the WiFiman realtime endpoint</summary>
     public bool HasWiFiManData { get; set; }
 
+    /// <summary>
+    /// VPN hop type when this client connects through Tailscale, Teleport, or a UniFi
+    /// remote-user VPN. Set only for the simplified VPN dashboard view; null otherwise.
+    /// </summary>
+    public HopType? VpnType { get; set; }
+
+    /// <summary>True when this is a VPN-sourced client (renders the simplified dashboard view)</summary>
+    public bool IsVpn => VpnType != null;
+
     /// <summary>Best display name (Name > Hostname > MAC)</summary>
     public string DisplayName => !string.IsNullOrEmpty(Name) ? Name
         : !string.IsNullOrEmpty(Hostname) ? Hostname

--- a/src/NetworkOptimizer.Web/Services/ClientDashboardService.cs
+++ b/src/NetworkOptimizer.Web/Services/ClientDashboardService.cs
@@ -223,9 +223,9 @@ public class ClientDashboardService
 
             var name = vpnType switch
             {
-                HopType.Tailscale => "Tailscale VPN",
-                HopType.Teleport => "Teleport VPN",
-                _ => "VPN"
+                HopType.Tailscale => "Tailscale Client",
+                HopType.Teleport => "Teleport Client",
+                _ => "VPN Client"
             };
 
             _logger.LogDebug("Identified VPN client {Ip} as {VpnType}", clientIp, vpnType);

--- a/src/NetworkOptimizer.Web/Services/ClientDashboardService.cs
+++ b/src/NetworkOptimizer.Web/Services/ClientDashboardService.cs
@@ -204,6 +204,48 @@ public class ClientDashboardService
     }
 
     /// <summary>
+    /// Identify a client that reaches the dashboard through a VPN (Tailscale, Teleport,
+    /// or a UniFi remote-user VPN). These clients never appear in the UniFi client list,
+    /// so <see cref="IdentifyClientAsync"/> returns null for them. Returns a synthetic
+    /// identity carrying the VPN type and IP for the simplified dashboard view, or null
+    /// when the IP is not VPN-sourced (or the console is unreachable).
+    /// </summary>
+    public async Task<ClientIdentity?> IdentifyVpnClientAsync(string clientIp)
+    {
+        if (!_connectionService.IsConnected || _connectionService.Client == null)
+            return null;
+
+        try
+        {
+            var vpnType = await _pathAnalyzer.ClassifyVpnClientAsync(clientIp);
+            if (vpnType == null)
+                return null;
+
+            var name = vpnType switch
+            {
+                HopType.Tailscale => "Tailscale VPN",
+                HopType.Teleport => "Teleport VPN",
+                _ => "VPN"
+            };
+
+            _logger.LogDebug("Identified VPN client {Ip} as {VpnType}", clientIp, vpnType);
+            return new ClientIdentity
+            {
+                Mac = "",
+                Name = name,
+                Ip = clientIp,
+                IsWired = false,
+                VpnType = vpnType
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to classify VPN client {Ip}", clientIp);
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Poll current signal quality for a client, run a trace, store the result, and return live data.
     /// </summary>
     public async Task<SignalPollResult?> PollSignalAsync(
@@ -468,6 +510,30 @@ public class ClientDashboardService
                        || r.Direction == SpeedTestDirection.ClientToServer
                        || r.Direction == SpeedTestDirection.BrowserToServer)
                       && r.ClientMac == mac
+                      && r.TestTime >= from
+                      && r.TestTime <= to)
+            .OrderByDescending(r => r.TestTime)
+            .ToListAsync();
+    }
+
+    /// <summary>
+    /// Get speed test results for a client by its source host/IP, within a time range.
+    /// Used for VPN clients (Tailscale/Teleport/remote-user VPN), which have no UniFi MAC:
+    /// their browser/iperf3 results store <c>DeviceHost</c> = the VPN IP and a null MAC,
+    /// so the MAC-keyed <see cref="GetSpeedResultsAsync"/> can't find them.
+    /// </summary>
+    public async Task<List<Iperf3Result>> GetSpeedResultsByHostAsync(
+        string host, DateTime from, DateTime to)
+    {
+        await using var db = CreateSiteDb();
+
+        // Same LAN directions as the MAC-keyed query - the client's LAN throughput
+        // history, not its internet speed.
+        return await db.Iperf3Results
+            .Where(r => (r.Direction == SpeedTestDirection.ServerToDevice
+                       || r.Direction == SpeedTestDirection.ClientToServer
+                       || r.Direction == SpeedTestDirection.BrowserToServer)
+                      && r.DeviceHost == host
                       && r.TestTime >= from
                       && r.TestTime <= to)
             .OrderByDescending(r => r.TestTime)

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -105,13 +105,21 @@
             return;
         e.preventDefault();
         if (link.hasAttribute('data-site-current')) {
-            // Plain click on the already-active site: don't reload, just close the
-            // dropdown. Click the switcher backdrop so Blazor's open state stays in
-            // sync (its @onclick runs CloseDropdown). Reached only for plain left
-            // clicks - the modified-click guard above already returned, so ctrl / cmd /
-            // shift / middle clicks still open the site in a new tab untouched.
+            // Plain click on the already-active site. Two hosts carry these anchors:
+            //  - the header dropdown, where a backdrop is present: just close the
+            //    dropdown (don't reload). Clicking the backdrop keeps Blazor's open
+            //    state in sync (its @onclick runs CloseDropdown).
+            //  - the /sites page, where there's no dropdown: navigate to the card's
+            //    href (the site's dashboard) instead of dead-clicking.
+            // Reached only for plain left clicks - the modified-click guard above already
+            // returned, so ctrl / cmd / shift / middle clicks still open the site in a new
+            // tab untouched.
             const backdrop = document.querySelector('.site-switcher-backdrop');
-            if (backdrop) backdrop.click();
+            if (backdrop) {
+                backdrop.click();
+            } else {
+                window.location.assign(link.href);
+            }
             return;
         }
         const target = link.getAttribute('data-site-switch');

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -104,8 +104,16 @@
         if (!link)
             return;
         e.preventDefault();
-        if (link.hasAttribute('data-site-current'))
+        if (link.hasAttribute('data-site-current')) {
+            // Plain click on the already-active site: don't reload, just close the
+            // dropdown. Click the switcher backdrop so Blazor's open state stays in
+            // sync (its @onclick runs CloseDropdown). Reached only for plain left
+            // clicks - the modified-click guard above already returned, so ctrl / cmd /
+            // shift / middle clicks still open the site in a new tab untouched.
+            const backdrop = document.querySelector('.site-switcher-backdrop');
+            if (backdrop) backdrop.click();
             return;
+        }
         const target = link.getAttribute('data-site-switch');
         document.cookie = 'no-site=' + target + '; path=/; max-age=31536000; SameSite=Lax';
         window.location.assign(link.href);

--- a/tests/NetworkOptimizer.UniFi.Tests/ClassifyVpnClientTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/ClassifyVpnClientTests.cs
@@ -1,0 +1,113 @@
+using FluentAssertions;
+using NetworkOptimizer.UniFi.Models;
+using Xunit;
+
+namespace NetworkOptimizer.UniFi.Tests;
+
+/// <summary>
+/// Tests for <see cref="NetworkPathAnalyzer.ClassifyVpnClient"/>, the shared VPN client
+/// classifier used by both speed-test hop creation and the Client Dashboard.
+/// </summary>
+public class ClassifyVpnClientTests
+{
+    private static NetworkTopology TopologyWith(params NetworkInfo[] networks) =>
+        new() { Networks = networks.ToList() };
+
+    // A representative corporate LAN the test IPs can be checked against.
+    private static NetworkInfo LanNetwork() => new()
+    {
+        Name = "Default",
+        Purpose = "corporate",
+        IpSubnet = "192.168.1.0/24"
+    };
+
+    [Theory]
+    [InlineData("100.64.0.1")]
+    [InlineData("100.100.100.100")]
+    [InlineData("100.127.255.254")]
+    public void TailscaleCgnatRange_ClassifiedAsTailscale(string ip)
+    {
+        NetworkPathAnalyzer.ClassifyVpnClient(ip, TopologyWith(LanNetwork()))
+            .Should().Be(HopType.Tailscale);
+    }
+
+    [Theory]
+    [InlineData("100.63.255.255")]  // just below the CGNAT block
+    [InlineData("100.128.0.0")]     // just above the CGNAT block
+    public void HundredDotOutsideCgnat_NotTailscale(string ip)
+    {
+        NetworkPathAnalyzer.ClassifyVpnClient(ip, TopologyWith(LanNetwork()))
+            .Should().NotBe(HopType.Tailscale);
+    }
+
+    [Fact]
+    public void Tailscale_ClassifiedWithNullTopology()
+    {
+        // Tailscale is a pure-IP (CGNAT) check and must work without topology.
+        NetworkPathAnalyzer.ClassifyVpnClient("100.64.0.5", null)
+            .Should().Be(HopType.Tailscale);
+    }
+
+    [Fact]
+    public void Private192_NotInAnyNetwork_ClassifiedAsTeleport()
+    {
+        // 192.168.x.x not inside any known UniFi network is Teleport.
+        NetworkPathAnalyzer.ClassifyVpnClient("192.168.77.5", TopologyWith(LanNetwork()))
+            .Should().Be(HopType.Teleport);
+    }
+
+    [Fact]
+    public void Private192_InsideKnownNetwork_NotVpn()
+    {
+        NetworkPathAnalyzer.ClassifyVpnClient("192.168.1.50", TopologyWith(LanNetwork()))
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void RemoteUserVpnSubnet_ClassifiedAsVpn()
+    {
+        var vpnNetwork = new NetworkInfo
+        {
+            Name = "VPN",
+            Purpose = "remote-user-vpn",
+            IpSubnet = "10.20.0.0/24"
+        };
+
+        NetworkPathAnalyzer.ClassifyVpnClient("10.20.0.7", TopologyWith(LanNetwork(), vpnNetwork))
+            .Should().Be(HopType.Vpn);
+    }
+
+    [Fact]
+    public void NormalLanClient_NotVpn()
+    {
+        NetworkPathAnalyzer.ClassifyVpnClient("192.168.1.100", TopologyWith(LanNetwork()))
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void NonPrivateExternalIp_NotVpn()
+    {
+        // A public IP not in any network is external, but not a VPN client type.
+        NetworkPathAnalyzer.ClassifyVpnClient("203.0.113.10", TopologyWith(LanNetwork()))
+            .Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-an-ip")]
+    [InlineData("999.999.999.999")]
+    public void InvalidIp_ReturnsNull(string ip)
+    {
+        NetworkPathAnalyzer.ClassifyVpnClient(ip, TopologyWith(LanNetwork()))
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void NullTopology_TeleportNotClassified()
+    {
+        // Teleport needs the network list to confirm the IP is not local; without
+        // topology only Tailscale can be identified.
+        NetworkPathAnalyzer.ClassifyVpnClient("192.168.77.5", null)
+            .Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Simplified Client Dashboard view for VPN clients

Viewers who reach the Client Dashboard over a VPN (Tailscale, Teleport, or a UniFi remote-user VPN) never appear in the UniFi client list, so the dashboard previously showed "Device Not Found." They now get a purpose-built simplified view.

### VPN client view
- Detects Tailscale (CGNAT `100.64.0.0/10`), Teleport, and remote-user-VPN clients using the same classification that already drives the VPN hop in speed-test path traces - extracted into a single shared `ClassifyVpnClient` so hop creation and the dashboard can't drift apart.
- Shows the same VPN logo used in the trace (extracted to a shared `VpnIcon` component), the client name (`Tailscale Client` / `Teleport Client` / `VPN Client`) and IP, the two speed-test buttons, speed results, and the speed map (its External layer is pre-selected so the markers aren't hidden).
- Speed results are looked up by source IP, since VPN clients have no UniFi MAC. New results refresh live on the same cadence as Wi-Fi clients.
- Signal/Connection tabs and live signal polling are omitted for VPN clients (no such data exists for them); the per-result path trace still shows the topology.

### Managed-site identity on a cold connection
- On a managed site, client identity comes from the on-site agent's whoami probe. If the agent's tunnel or the console was still coming up at page load, the probe was skipped and the viewer was stranded on the device picker until a manual refresh.
- The dashboard now shows the picker immediately (still usable) but keeps probing in the background about once a second for up to 30s, auto-loading the moment identity resolves. Picking a device manually stops the retry.

### Flaky-target advisory on ISP Health
- The "N monitoring targets look flaky" advisory (internet/transit targets with loss well above their peers, which skew ISP Health scoring) was only shown on the Live View tab, and only detected on that tab's first load. It now also renders above the ISP Health panel - where the score it's warning about actually lives - and detection fires on the first load of either tab, so going straight to your score still surfaces the warning. Shared render fragment so both tabs show the identical banner.
- The banner now clears once the flagged targets are addressed: disabling/pausing them drops them from the enabled pool and re-detection (run when the banner is showing and a target changes) lowers the count, hiding the banner when it reaches zero - no reload needed.

### Smaller fixes
- Sites page: clicking the site you're already on now opens its dashboard instead of dead-clicking (the current-site anchor's href already points there; the click handler just wasn't navigating when no dropdown was present). Ctrl/cmd/shift/middle-click still opens the site in a new tab, unaffected.
- PWA: break out of a wedged reconnect spinner. Blazor can sit in the "Reconnecting..." state indefinitely when the socket is dead-but-open or its retries stall, leaving the page frozen behind the modal with no class transition for the existing reconnect handler to react to. While the spinner is up, a 5s interval probes `/api/health`: if the server answers, the circuit is wedged but the app is fine, so it reloads; if it doesn't answer, it's a restart/outage, so it waits and re-probes (reloading into a dead server would only strand the user). Recovers the moment the server returns; a guard prevents a double reload if Blazor's own reconnect wins the race.
- Speed test map: auto-fit the view when new results arrive and when the time range changes, unless the user has manually panned/zoomed. Previously a freshly-completed test could land off-screen, and after a manual pan the map stayed frozen even when the time filter was changed. A time-range change now reframes the map the same way the map's own slider already did. Applies to both the VPN client map and the normal LAN speed test map.
- Site switcher: clicking the already-active site closes the dropdown instead of doing nothing. Handled in the existing JS click handler after the modified-click guard, so ctrl/cmd/shift/middle-click "open site in a new tab" is unaffected.
- Clearer "Device Not Found" copy on the local site: distinguishes "console unreachable" from "console fine but your device isn't listed yet," and surfaces the detected address.

Managed-site behavior is otherwise unchanged. Adds unit tests for the VPN classifier across the CGNAT boundaries, Teleport, remote-user-VPN, and non-VPN cases.
