### PR TITLE
v2.0.2 Release Changes

### DIFF
--- a/src/NetworkOptimizer.Core/Helpers/VersionUtilities.cs
+++ b/src/NetworkOptimizer.Core/Helpers/VersionUtilities.cs
@@ -49,6 +49,20 @@ public static class VersionUtilities
         return candPre.Length < reqPre.Length;
     }
 
+    /// <summary>
+    /// The version as shown to users: build metadata after '+' stripped
+    /// ("2.0.1+ed2714ca..." -> "2.0.1"), prerelease identifiers kept
+    /// ("2.0.0-beta.2+3449fbae" -> "2.0.0-beta.2"), matching the footer's
+    /// format. Null/blank and metadata-free inputs pass through unchanged.
+    /// </summary>
+    public static string? StripBuildMetadata(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+            return version;
+        var plus = version.IndexOf('+');
+        return plus >= 0 ? version[..plus] : version;
+    }
+
     private static (Version? Core, string[] Prerelease) Split(string version)
     {
         var v = version.Trim().TrimStart('v', 'V');

--- a/src/NetworkOptimizer.Monitoring/Providers/CmPollContext.cs
+++ b/src/NetworkOptimizer.Monitoring/Providers/CmPollContext.cs
@@ -12,8 +12,11 @@ public sealed record CmPollContext
     /// <summary>Friendly name for logs and UI.</summary>
     public required string Name { get; init; }
 
-    /// <summary>Host or IP for the cable modem.</summary>
+    /// <summary>Host or IP for the cable modem. On agent-routed sites this is the tunnel-proxy loopback endpoint, not the device's own address.</summary>
     public required string Host { get; init; }
+
+    /// <summary>The configured device host before any tunnel-proxy rewrite; use for logs so failures name the real device.</summary>
+    public string? ConfiguredHost { get; init; }
 
     /// <summary>HTTP port; 0 means provider default (typically 80).</summary>
     public int Port { get; init; }

--- a/src/NetworkOptimizer.Monitoring/Providers/ModemPollContext.cs
+++ b/src/NetworkOptimizer.Monitoring/Providers/ModemPollContext.cs
@@ -14,8 +14,11 @@ public sealed record ModemPollContext
     /// <summary>Friendly name for logs and UI.</summary>
     public required string Name { get; init; }
 
-    /// <summary>Host or IP for the modem.</summary>
+    /// <summary>Host or IP for the modem. On agent-routed sites (HTTP and per-modem-SSH providers) this is the tunnel-proxy loopback endpoint, not the device's own address.</summary>
     public required string Host { get; init; }
+
+    /// <summary>The configured device host before any tunnel-proxy rewrite; use for logs and stored stats so they name the real device.</summary>
+    public string? ConfiguredHost { get; init; }
 
     /// <summary>Port; 0 means provider default.</summary>
     public int Port { get; init; }

--- a/src/NetworkOptimizer.Monitoring/Providers/NetgearModelJsonParser.cs
+++ b/src/NetworkOptimizer.Monitoring/Providers/NetgearModelJsonParser.cs
@@ -32,7 +32,7 @@ public static class NetgearModelJsonParser
         var stats = new CellularModemStats
         {
             Timestamp = DateTime.UtcNow,
-            ModemHost = context.Host,
+            ModemHost = context.ConfiguredHost ?? context.Host,
             ModemName = context.Name,
             ModemModel = TryGetString(root, "general", "deviceName") ?? context.ModemType,
         };

--- a/src/NetworkOptimizer.Monitoring/Providers/OntPollContext.cs
+++ b/src/NetworkOptimizer.Monitoring/Providers/OntPollContext.cs
@@ -12,8 +12,11 @@ public sealed record OntPollContext
     /// <summary>Friendly name for logs and UI.</summary>
     public required string Name { get; init; }
 
-    /// <summary>Host or IP for the ONT device.</summary>
+    /// <summary>Host or IP for the ONT device. On agent-routed sites this is the tunnel-proxy loopback endpoint, not the device's own address.</summary>
     public required string Host { get; init; }
+
+    /// <summary>The configured device host before any tunnel-proxy rewrite; use for logs so failures name the real device.</summary>
+    public string? ConfiguredHost { get; init; }
 
     /// <summary>Port; 0 means provider default (typically 80 for HTTP, 22 for SSH).</summary>
     public int Port { get; init; }

--- a/src/NetworkOptimizer.Storage/Models/SystemSetting.cs
+++ b/src/NetworkOptimizer.Storage/Models/SystemSetting.cs
@@ -85,6 +85,12 @@ public static class SystemSettingKeys
     // key is this prefix + WanInterface; the value is a JSON map of ASN identity -> miss count.
     public const string UpstreamAbsentAsnCountsPrefix = "upstream.absent_asn_counts.";
 
+    // Per-WAN "seen but declined" access-ISP change memory. The full key is this prefix +
+    // WanInterface; the value is the new access ASN the user said was NOT a provider switch,
+    // so the same detected change doesn't re-prompt on every discovery run. Cleared when a
+    // later ISP change is confirmed (fresh baseline).
+    public const string UpstreamDeclinedAccessAsnPrefix = "upstream.declined_access_asn.";
+
     // Map / Satellite settings
     public const string MapboxApiKey = "map.mapbox_token";
 

--- a/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
+++ b/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
@@ -69,6 +69,13 @@ public interface INetworkPathAnalyzer
     Task<(string? NetworkGroup, string? Name)> IdentifyWanConnectionAsync(
         string externalIp, double measuredDownloadMbps = 0, double measuredUploadMbps = 0,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Classifies a client IP as a VPN client type (Tailscale, Teleport, or a UniFi
+    /// remote-user VPN), or null when the IP is not VPN-sourced. Shares the same logic
+    /// used to prepend VPN hops to speed-test path traces.
+    /// </summary>
+    Task<HopType?> ClassifyVpnClientAsync(string clientIp, CancellationToken cancellationToken = default);
 }
 
 /// <summary>
@@ -2331,63 +2338,49 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
         // When only wanIp is provided, matches the specific WAN interface by IP.
         var (wanDownloadMbps, wanUploadMbps) = GetWanSpeed(topology, rawDevices, wanIp, resolvedWanGroup);
 
-        // Check for Tailscale CGNAT range: 100.64.0.0/10 (100.64.x.x - 100.127.x.x)
-        if (clientIp.StartsWith("100."))
-        {
-            var parts = clientIp.Split('.');
-            if (parts.Length >= 2 && int.TryParse(parts[1], out int secondOctet))
-            {
-                if (secondOctet >= 64 && secondOctet <= 127)
-                {
-                    // Store directional WAN speeds: Ingress=download (FromDevice), Egress=upload (ToDevice)
-                    return new NetworkHop
-                    {
-                        Type = HopType.Tailscale,
-                        DeviceName = "Tailscale",
-                        DeviceIp = clientIp,
-                        IngressSpeedMbps = wanDownloadMbps > 0 ? wanDownloadMbps : Math.Max(wanDownloadMbps, wanUploadMbps),
-                        EgressSpeedMbps = wanUploadMbps > 0 ? wanUploadMbps : Math.Max(wanDownloadMbps, wanUploadMbps),
-                        IngressPortName = "WAN",
-                        EgressPortName = "WAN",
-                        Notes = wanUploadMbps > 0
-                            ? $"Tailscale VPN (WAN: {wanDownloadMbps}/{wanUploadMbps} Mbps)"
-                            : "Tailscale VPN mesh"
-                    };
-                }
-            }
-        }
-
-        // Check for Teleport: 192.168.x.x that's NOT in any known UniFi network
-        if (clientIp.StartsWith("192.168."))
-        {
-            // Check if this IP is in any known UniFi network
-            var isInKnownNetwork = topology.Networks.Any(n =>
-                !string.IsNullOrEmpty(n.IpSubnet) && NetworkUtilities.IsIpInSubnet(clientIp, n.IpSubnet));
-
-            if (!isInKnownNetwork)
-            {
-                // Store directional WAN speeds: Ingress=download (FromDevice), Egress=upload (ToDevice)
-                return new NetworkHop
-                {
-                    Type = HopType.Teleport,
-                    DeviceName = "Teleport",
-                    DeviceIp = clientIp,
-                    IngressSpeedMbps = wanDownloadMbps > 0 ? wanDownloadMbps : Math.Max(wanDownloadMbps, wanUploadMbps),
-                    EgressSpeedMbps = wanUploadMbps > 0 ? wanUploadMbps : Math.Max(wanDownloadMbps, wanUploadMbps),
-                    IngressPortName = "WAN",
-                    EgressPortName = "WAN",
-                    Notes = wanUploadMbps > 0
-                        ? $"Teleport VPN (WAN: {wanDownloadMbps}/{wanUploadMbps} Mbps)"
-                        : "Teleport VPN gateway"
-                };
-            }
-        }
-
-        // Check for UniFi remote-user-vpn network (e.g., L2TP, OpenVPN server on gateway)
+        // The network this IP falls inside, if any (used for both VPN and external classification).
         var matchingNetwork = topology.Networks.FirstOrDefault(n =>
             !string.IsNullOrEmpty(n.IpSubnet) && NetworkUtilities.IsIpInSubnet(clientIp, n.IpSubnet));
 
-        if (matchingNetwork?.Purpose == "remote-user-vpn")
+        // Classify the VPN type (Tailscale / Teleport / remote-user VPN) via shared logic.
+        var vpnType = ClassifyVpnClient(clientIp, topology);
+        if (vpnType == HopType.Tailscale)
+        {
+            // Store directional WAN speeds: Ingress=download (FromDevice), Egress=upload (ToDevice)
+            return new NetworkHop
+            {
+                Type = HopType.Tailscale,
+                DeviceName = "Tailscale",
+                DeviceIp = clientIp,
+                IngressSpeedMbps = wanDownloadMbps > 0 ? wanDownloadMbps : Math.Max(wanDownloadMbps, wanUploadMbps),
+                EgressSpeedMbps = wanUploadMbps > 0 ? wanUploadMbps : Math.Max(wanDownloadMbps, wanUploadMbps),
+                IngressPortName = "WAN",
+                EgressPortName = "WAN",
+                Notes = wanUploadMbps > 0
+                    ? $"Tailscale VPN (WAN: {wanDownloadMbps}/{wanUploadMbps} Mbps)"
+                    : "Tailscale VPN mesh"
+            };
+        }
+
+        if (vpnType == HopType.Teleport)
+        {
+            // Store directional WAN speeds: Ingress=download (FromDevice), Egress=upload (ToDevice)
+            return new NetworkHop
+            {
+                Type = HopType.Teleport,
+                DeviceName = "Teleport",
+                DeviceIp = clientIp,
+                IngressSpeedMbps = wanDownloadMbps > 0 ? wanDownloadMbps : Math.Max(wanDownloadMbps, wanUploadMbps),
+                EgressSpeedMbps = wanUploadMbps > 0 ? wanUploadMbps : Math.Max(wanDownloadMbps, wanUploadMbps),
+                IngressPortName = "WAN",
+                EgressPortName = "WAN",
+                Notes = wanUploadMbps > 0
+                    ? $"Teleport VPN (WAN: {wanDownloadMbps}/{wanUploadMbps} Mbps)"
+                    : "Teleport VPN gateway"
+            };
+        }
+
+        if (vpnType == HopType.Vpn)
         {
             // Store directional WAN speeds: Ingress=download (FromDevice), Egress=upload (ToDevice)
             return new NetworkHop
@@ -2400,8 +2393,8 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                 IngressPortName = "WAN",
                 EgressPortName = "WAN",
                 Notes = wanUploadMbps > 0
-                    ? $"VPN ({matchingNetwork.Name}, WAN: {wanDownloadMbps}/{wanUploadMbps} Mbps)"
-                    : $"VPN ({matchingNetwork.Name})"
+                    ? $"VPN ({matchingNetwork?.Name}, WAN: {wanDownloadMbps}/{wanUploadMbps} Mbps)"
+                    : $"VPN ({matchingNetwork?.Name})"
             };
         }
 
@@ -2458,6 +2451,66 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
             return true;
 
         return false;
+    }
+
+    /// <summary>
+    /// Classifies a client IP as a VPN client type (Tailscale, Teleport, or a UniFi
+    /// remote-user VPN), or null when the IP is not VPN-sourced. This is the single
+    /// source of truth shared by speed-test hop creation (<see cref="DetectAndCreateVpnHop"/>)
+    /// and the Client Dashboard's simplified VPN view.
+    /// </summary>
+    /// <remarks>
+    /// The Tailscale check is pure-IP (CGNAT 100.64.0.0/10) and works with a null
+    /// topology. Teleport and remote-user-VPN classification need the topology's
+    /// networks; when topology is null only Tailscale can be identified.
+    /// </remarks>
+    public static HopType? ClassifyVpnClient(string clientIp, NetworkTopology? topology)
+    {
+        if (string.IsNullOrEmpty(clientIp) || !System.Net.IPAddress.TryParse(clientIp, out _))
+            return null;
+
+        // Tailscale CGNAT range: 100.64.0.0/10 (100.64.x.x - 100.127.x.x)
+        if (clientIp.StartsWith("100."))
+        {
+            var parts = clientIp.Split('.');
+            if (parts.Length >= 2 && int.TryParse(parts[1], out int secondOctet)
+                && secondOctet >= 64 && secondOctet <= 127)
+            {
+                return HopType.Tailscale;
+            }
+        }
+
+        if (topology == null)
+            return null;
+
+        // Teleport: 192.168.x.x that's NOT in any known UniFi network
+        if (clientIp.StartsWith("192.168."))
+        {
+            var isInKnownNetwork = topology.Networks.Any(n =>
+                !string.IsNullOrEmpty(n.IpSubnet) && NetworkUtilities.IsIpInSubnet(clientIp, n.IpSubnet));
+
+            if (!isInKnownNetwork)
+                return HopType.Teleport;
+        }
+
+        // UniFi remote-user-vpn network (e.g., L2TP, OpenVPN server on gateway)
+        var matchingNetwork = topology.Networks.FirstOrDefault(n =>
+            !string.IsNullOrEmpty(n.IpSubnet) && NetworkUtilities.IsIpInSubnet(clientIp, n.IpSubnet));
+
+        if (matchingNetwork?.Purpose == "remote-user-vpn")
+            return HopType.Vpn;
+
+        return null;
+    }
+
+    /// <inheritdoc />
+    public async Task<HopType?> ClassifyVpnClientAsync(string clientIp, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(clientIp))
+            return null;
+
+        var topology = await GetTopologyAsync(cancellationToken);
+        return ClassifyVpnClient(clientIp, topology);
     }
 
     /// <inheritdoc />

--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -413,7 +413,56 @@
         const reconnectModal = document.getElementById('components-reconnect-modal');
         if (reconnectModal) {
             let disconnectedAt = null;
+            let reloading = false;
+            let stuckSpinnerTimer = null;
             const MIN_DISCONNECT_TIME_MS = 1500; // Only reload if disconnected > 1.5s
+            const STUCK_SPINNER_MS = 5000;       // Probe cadence while the spinner is up
+            const HEALTH_TIMEOUT_MS = 2000;      // Give the liveness probe this long to answer
+
+            // A reload tears down the page (circuit, Blazor's retries, our timers), so
+            // whichever recovery path fires first wins; the guard just stops a later
+            // tick from calling reload again after one is already in flight.
+            function safeReload() {
+                if (reloading) return;
+                reloading = true;
+                location.reload();
+            }
+
+            // Endless-spinner safety hatch. Blazor can sit in the "reconnecting" state
+            // indefinitely when the socket is wedged (dead but still open to it) or its
+            // retries stall - the page stays frozen behind the modal with no class
+            // transition for the observer to react to. While the spinner is up, probe
+            // the server every few seconds: if the SERVER answers, the circuit is wedged
+            // but the app is fine, so reload into a fresh page; if it doesn't answer it's
+            // a restart/outage, so do nothing and let Blazor keep retrying (reloading into
+            // a dead server would only strand us). The ?probe= marker distinguishes these
+            // from deploy health checks in the access logs.
+            async function serverAlive() {
+                const ctrl = new AbortController();
+                const t = setTimeout(() => ctrl.abort(), HEALTH_TIMEOUT_MS);
+                try {
+                    const resp = await fetch('/api/health?probe=reconnect', { signal: ctrl.signal, cache: 'no-store' });
+                    return resp.ok;
+                } catch {
+                    return false;
+                } finally {
+                    clearTimeout(t);
+                }
+            }
+
+            function startStuckSpinnerWatch() {
+                if (stuckSpinnerTimer) return;
+                stuckSpinnerTimer = setInterval(async function () {
+                    if (await serverAlive()) safeReload();
+                }, STUCK_SPINNER_MS);
+            }
+
+            function stopStuckSpinnerWatch() {
+                if (stuckSpinnerTimer) {
+                    clearInterval(stuckSpinnerTimer);
+                    stuckSpinnerTimer = null;
+                }
+            }
 
             const reconnectObserver = new MutationObserver(function(mutations) {
                 mutations.forEach(function(mutation) {
@@ -426,16 +475,19 @@
                         if (isShowing && !disconnectedAt) {
                             // Record when we started showing the reconnect modal
                             disconnectedAt = Date.now();
+                            startStuckSpinnerWatch();
                         } else if (!isShowing && !isFailed && disconnectedAt) {
                             // Successfully reconnected - only reload if we were disconnected long enough
                             const disconnectDuration = Date.now() - disconnectedAt;
                             disconnectedAt = null;
+                            stopStuckSpinnerWatch();
                             if (disconnectDuration >= MIN_DISCONNECT_TIME_MS) {
-                                location.reload();
+                                safeReload();
                             }
                         } else if (isFailed) {
                             disconnectedAt = null;
-                            location.reload();
+                            stopStuckSpinnerWatch();
+                            safeReload();
                         }
                     }
                 });

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -143,7 +143,22 @@
     {
         <div class="card empty-state">
             <h3>Device Not Found</h3>
-            <p>Could not identify your device on the network. Make sure you're connected and the UniFi Console is reachable.</p>
+            @if (!SiteContext.IsDefault)
+            {
+                <p>Could not identify your device on the network. Make sure you're connected and the UniFi Console is reachable.</p>
+            }
+            else if (!ConnectionService.IsConnected)
+            {
+                <p>The UniFi Console can't be reached right now, so your device can't be identified. Once the connection is restored, retry.</p>
+            }
+            else
+            {
+                <p>Your device isn't showing up in the UniFi Console's client list yet. If you just connected, give it a few seconds and retry.</p>
+                @if (!string.IsNullOrEmpty(_clientIp) && _clientIp != "unknown")
+                {
+                    <p class="empty-state-detail">Detected address: <code>@_clientIp</code></p>
+                }
+            }
             <button class="btn btn-primary" @onclick="ReloadPageAsync">Retry</button>
         </div>
     }
@@ -152,18 +167,33 @@
         @* Identity Bar *@
         <div class="card identity-bar">
             <div class="identity-row-1">
-                <div class="identity-info">
-                    <h2 class="identity-name">@_client.DisplayName</h2>
-                    <div class="identity-meta">
-                        <span>@_client.Mac</span>
-                        <span class="meta-sep">·</span>
-                        <span>@_client.Ip</span>
-                        @if (!string.IsNullOrEmpty(_client.Essid))
-                        {
+                <div class="identity-info @(_client.IsVpn ? "identity-info-vpn" : null)">
+                    @if (_client.IsVpn)
+                    {
+                        <span class="identity-vpn-icon @GetVpnTintClass(_client.VpnType)">
+                            <VpnIcon Type="_client.VpnType!.Value" Size="32" />
+                        </span>
+                        <div class="identity-text">
+                            <h2 class="identity-name">@_client.DisplayName</h2>
+                            <div class="identity-meta">
+                                <span>@_client.Ip</span>
+                            </div>
+                        </div>
+                    }
+                    else
+                    {
+                        <h2 class="identity-name">@_client.DisplayName</h2>
+                        <div class="identity-meta">
+                            <span>@_client.Mac</span>
                             <span class="meta-sep">·</span>
-                            <span data-tooltip="SSID">@_client.Essid</span>
-                        }
-                    </div>
+                            <span>@_client.Ip</span>
+                            @if (!string.IsNullOrEmpty(_client.Essid))
+                            {
+                                <span class="meta-sep">·</span>
+                                <span data-tooltip="SSID">@_client.Essid</span>
+                            }
+                        </div>
+                    }
                 </div>
                 <div class="identity-signal">
                     @if (!_client.IsWired && _client.SignalDbm.HasValue)
@@ -188,6 +218,8 @@
                             }
                         </div>
                     }
+                    @if (!_client.IsVpn)
+                    {
                     <div class="identity-live-group">
                         @if (_client.IsOffline)
                         {
@@ -219,10 +251,15 @@
                             </button>
                         }
                     </div>
+                    }
                 </div>
             </div>
             <div class="identity-row-2">
-                @if (!_client.IsWired)
+                @if (_client.IsVpn)
+                {
+                    <span class="identity-detail detail-dim">Remote client - limited data available</span>
+                }
+                else if (!_client.IsWired)
                 {
                     <span class="band-badge @GetBandClass(_client.Band)">@(_client.BandDisplay ?? "—")</span>
                     <span class="identity-detail">
@@ -254,7 +291,7 @@
                 {
                     <span class="identity-detail">Wired</span>
                 }
-                @if (!_isOwnDevice && _client is { IsWired: false, IsOffline: false })
+                @if (!_isOwnDevice && !_client.IsVpn && _client is { IsWired: false, IsOffline: false })
                 {
                     <button class="btn btn-sm @(_isLogging ? "btn-danger" : "btn-primary") logging-toggle logging-toggle-desktop"
                             @onclick="ToggleLogging"
@@ -265,14 +302,17 @@
                 }
             </div>
             <div class="dashboard-controls">
-                <div class="tab-bar">
-                    <button class="tab-btn @(_activeTab == "speed" ? "active" : "")"
-                            @onclick='() => SetActiveTab("speed")'>Speed</button>
-                    <button class="tab-btn @(_activeTab == "signal" ? "active" : "")"
-                            @onclick='() => SetActiveTab("signal")'>Signal</button>
-                    <button class="tab-btn @(_activeTab == "connection" ? "active" : "")"
-                            @onclick='() => SetActiveTab("connection")'>Connection</button>
-                </div>
+                @if (!_client.IsVpn)
+                {
+                    <div class="tab-bar">
+                        <button class="tab-btn @(_activeTab == "speed" ? "active" : "")"
+                                @onclick='() => SetActiveTab("speed")'>Speed</button>
+                        <button class="tab-btn @(_activeTab == "signal" ? "active" : "")"
+                                @onclick='() => SetActiveTab("signal")'>Signal</button>
+                        <button class="tab-btn @(_activeTab == "connection" ? "active" : "")"
+                                @onclick='() => SetActiveTab("connection")'>Connection</button>
+                    </div>
+                }
                 <div class="time-range-selector">
                     @foreach (var tf in _timeFilters)
                     {
@@ -430,7 +470,7 @@
                                             <th class="hide-mobile">From Device</th>
                                             <th class="hide-mobile">To Device</th>
                                             <th class="show-mobile">Result</th>
-                                            @if (!(_client?.IsWired == true))
+                                            @if (!HidesApRates)
                                             {
                                                 <th class="hide-mobile" data-tooltip="AP receive rate (from device)">RX Rate</th>
                                                 <th class="hide-mobile" data-tooltip="AP transmit rate (to device)">TX Rate</th>
@@ -451,7 +491,7 @@
                                                 <td class="hide-mobile"><span class="speed-down">@FormatSpeed(r.DownloadMbps, "F1")</span> Mbps</td>
                                                 <td class="hide-mobile"><span class="speed-up">@FormatSpeed(r.UploadMbps, "F1")</span> Mbps</td>
                                                 <td class="show-mobile"><span class="speed-down">@FormatSpeed(r.DownloadMbps, "F0")</span> / <span class="speed-up">@FormatSpeed(r.UploadMbps, "F0")</span></td>
-                                                @if (!(_client?.IsWired == true))
+                                                @if (!HidesApRates)
                                                 {
                                                     <td class="hide-mobile">@RenderRate(r.WifiRxRateKbps, "wifi-speed-rx")</td>
                                                     <td class="hide-mobile">@RenderRate(r.WifiTxRateKbps, "wifi-speed-tx")</td>
@@ -464,7 +504,7 @@
                                             @if (_expandedResultId == r.Id)
                                             {
                                                 <tr class="result-details-row">
-                                                    <td colspan="@(_client?.IsWired == true ? 6 : 8)">
+                                                    <td colspan="@(HidesApRates ? 6 : 8)">
                                                         <div class="result-details">
                                                             <SpeedTestDetails Result="r" HideDeviceName="true" HideClientDashboardLink="true" />
                                                         </div>
@@ -490,6 +530,7 @@
                     {
                         <SpeedTestMap Results="_speedResults" MapHeight="400px"
                                      ApMarkers="_apMapMarkers" AllowApEditing="false"
+                                     ShowExternalByDefault="_client?.IsVpn == true"
                                      TimeFilterHours="_selectedTimeFilter" />
                     }
                 </div>
@@ -993,6 +1034,30 @@
 
         // Note: initial GPS request happens in OnAfterRenderAsync (needs JS interop)
 
+        // VPN clients (Tailscale/Teleport/remote-user VPN) have no UniFi identity to poll
+        // and no L2 trace, so skip the signal/trace poll (it would fail and trip the
+        // connection banner). But new speed-test results should still appear live, so run
+        // a lightweight timer that just reloads the Speed tab data - no stat/sta, no trace.
+        if (_client?.IsVpn == true)
+        {
+            _activeTab = "speed";
+            _isLogging = false;
+
+            _pollTimer = new System.Threading.Timer(async _ =>
+            {
+                try
+                {
+                    await InvokeAsync(async () =>
+                    {
+                        await RefreshVpnSpeedAsync();
+                        StateHasChanged();
+                    });
+                }
+                catch { /* prevent timer death */ }
+            }, null, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
+            return;
+        }
+
         // Start polling - 1s ticks when WiFiman is available.
         // Full poll (stat/sta + trace + storage) every 5th tick.
         // Lightweight WiFiman-only poll on other ticks for live signal updates.
@@ -1053,7 +1118,8 @@
         // Must be in OnAfterRenderAsync because JS interop isn't available during prerender
         _isInsecureContext = !await JS.InvokeAsync<bool>("eval", "window.isSecureContext");
         _isMobile = await JS.InvokeAsync<bool>("eval", "window.innerWidth <= 768");
-        _showGpsWarning = _isInsecureContext && _isOwnDevice;
+        // VPN clients have no GPS walk-test flow (no live polling), so never warn them.
+        _showGpsWarning = _isInsecureContext && _isOwnDevice && _client?.IsVpn != true;
 
         // Managed-site own-device identity needs JS (agent whoami probe / localStorage),
         // so it runs here rather than in OnInitializedAsync.
@@ -1077,6 +1143,11 @@
             // so we use JS interop to get the page URL and call the API
             _client = await GetClientIdentityAsync();
 
+            // VPN clients only get the Speed tab; force it before loading so a stale
+            // ?tab=signal/connection deep link doesn't load data they don't have.
+            if (_client?.IsVpn == true && _activeTab != "speed")
+                _activeTab = "speed";
+
             if (_client != null)
             {
                 await LoadTabDataAsync();
@@ -1094,6 +1165,7 @@
 
     private string? _clientIp;
     private bool _awaitingSiteIdentity;
+    private System.Threading.Timer? _identityRetryTimer;
     private bool _showClientPicker;
     private List<ClientDashboardService.SelectableClient> _pickerClients = new();
     private string? _pickerSelection;
@@ -1136,7 +1208,15 @@
         if (string.IsNullOrEmpty(_clientIp) || _clientIp == "unknown")
             return null;
 
-        return await DashboardService.IdentifyClientAsync(_clientIp);
+        var identity = await DashboardService.IdentifyClientAsync(_clientIp);
+
+        // A viewer reaching the dashboard over Tailscale/Teleport/remote-user VPN is never
+        // in the UniFi client list, so identity is null. Fall back to the simplified VPN
+        // view - default site only, so managed-site behavior (whoami/picker) is untouched.
+        if (identity == null && SiteContext.IsDefault)
+            identity = await DashboardService.IdentifyVpnClientAsync(_clientIp);
+
+        return identity;
     }
 
     /// <summary>
@@ -1149,44 +1229,113 @@
     /// </summary>
     private async Task ResolveSiteIdentityAsync()
     {
+        // Keep the loading skeleton up (via _awaitingSiteIdentity) through the whole
+        // attempt: clearing it early exposes a window where a poll-timer re-render would
+        // flash "Device Not Found" before the picker is ready. It is cleared only at a
+        // terminal state - here on success, or inside ShowClientPickerAsync when the
+        // picker becomes visible.
+        // One immediate attempt - resolves instantly on a warm agent connection.
+        if (await TryResolveSiteIdentityAsync())
+        {
+            _awaitingSiteIdentity = false;
+            StateHasChanged();
+            return;
+        }
+
+        // Cold connection: the on-site agent's tunnel or the UniFi console may still be
+        // coming up. Show the picker so the viewer can act right away, but keep probing
+        // in the background and auto-load once identity resolves - no manual refresh.
+        Logger.LogDebug("Client identity (site {Site}): not resolved yet, showing picker and retrying in the background", SiteContext.Slug);
+        await ShowClientPickerAsync();
+        StartSiteIdentityRetry();
+    }
+
+    /// <summary>
+    /// One identity-resolution attempt: ask the on-site agent's speed-test listener who
+    /// we are (it sees the viewer's LAN source address, where this central server only
+    /// sees the site's WAN IP), then identify that IP against the site's console.
+    /// Returns true and loads the dashboard when a client is resolved.
+    /// </summary>
+    private async Task<bool> TryResolveSiteIdentityAsync()
+    {
         string? ip = null;
-        var probed = false;
         try
         {
             var target = await SiteTarget.ResolveAsync();
             if (target.UsesAgent && !string.IsNullOrEmpty(target.BaseUrl))
             {
-                probed = true;
                 ip = await JS.InvokeAsync<string?>("eval",
                     $"fetch('{target.BaseUrl}/netopt/whoami', {{signal: AbortSignal.timeout(4000)}})" +
                     ".then(r => r.json()).then(j => j.ip).catch(() => null)");
             }
         }
-        catch { /* probe is best-effort; the picker below always works */ }
+        catch { return false; }
 
-        _awaitingSiteIdentity = false;
+        if (string.IsNullOrEmpty(ip) || !System.Net.IPAddress.TryParse(ip, out _))
+            return false;
 
-        if (!string.IsNullOrEmpty(ip) && System.Net.IPAddress.TryParse(ip, out _))
+        _clientIp = ip;
+        await IdentifyAndLoadAsync();
+        if (_client != null)
         {
             Logger.LogDebug("Client identity (site {Site}): agent whoami resolved {Ip}", SiteContext.Slug, ip);
-            _clientIp = ip;
-            await IdentifyAndLoadAsync();
-            if (_client != null)
-            {
-                StateHasChanged();
-                return;
-            }
-            // The agent answered but the address isn't a known client - pick manually.
-            Logger.LogDebug("Client identity (site {Site}): whoami address {Ip} not in the client list - showing picker", SiteContext.Slug, ip);
-            _clientIp = null;
-        }
-        else
-        {
-            Logger.LogDebug("Client identity (site {Site}): {Reason} - showing picker",
-                SiteContext.Slug, probed ? "agent whoami probe failed (offline or certificate untrusted)" : "no agent target to probe");
+            return true;
         }
 
-        await ShowClientPickerAsync();
+        // The agent answered but the console hasn't listed the client yet (still warming
+        // up on a cold connect) - clear so the next retry re-probes cleanly.
+        _clientIp = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Background retry for a cold agent/console connection. The agent's tunnel or the
+    /// UniFi console may still be coming up when the page first loads, so identity isn't
+    /// resolvable yet. Probe roughly once a second (up to 30s) so the dashboard fills in
+    /// snappily once the connection is live - the whoami endpoint is lightweight, so
+    /// hitting it a few times is cheap. Re-arms one-shot after each attempt completes so a
+    /// slow probe never overlaps the next. Stops early once the viewer picks manually.
+    /// </summary>
+    private void StartSiteIdentityRetry()
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(30);
+        _identityRetryTimer = new System.Threading.Timer(async _ =>
+        {
+            var done = false;
+            try
+            {
+                await InvokeAsync(async () =>
+                {
+                    // Stop if the picker is gone (viewer picked a device) or we timed out.
+                    if (!_showClientPicker || DateTime.UtcNow >= deadline)
+                    {
+                        done = true;
+                        return;
+                    }
+
+                    if (await TryResolveSiteIdentityAsync())
+                    {
+                        _showClientPicker = false;
+                        done = true;
+                        StateHasChanged();
+                    }
+                });
+            }
+            catch { /* keep retrying across transient errors */ }
+
+            if (done)
+            {
+                _identityRetryTimer?.Dispose();
+                _identityRetryTimer = null;
+            }
+            else
+            {
+                // Re-arm a single tick ~1s out (one-shot period) so a slow whoami never
+                // overlaps the next probe.
+                try { _identityRetryTimer?.Change(TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan); }
+                catch { /* timer disposed - nothing to re-arm */ }
+            }
+        }, null, TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan);
     }
 
     private async Task ShowClientPickerAsync()
@@ -1200,7 +1349,11 @@
                 _pickerSelection = remembered;
         }
         catch { /* no preselect without localStorage */ }
+        // Flip both flags together, with no await between, so a render can't catch a
+        // state where neither the skeleton nor the picker is showing (which would flash
+        // the "Device Not Found" card).
         _showClientPicker = true;
+        _awaitingSiteIdentity = false;
         _loading = false;
         StateHasChanged();
     }
@@ -1451,9 +1604,31 @@
         }
     }
 
+    /// <summary>
+    /// Lightweight periodic refresh for VPN clients: reloads Speed tab results and charts
+    /// so new speed tests appear live, without the signal poll or L2 trace (neither of
+    /// which exists for VPN clients).
+    /// </summary>
+    private async Task RefreshVpnSpeedAsync()
+    {
+        if (_client == null) return;
+
+        // Don't disrupt a chart tooltip the user is hovering.
+        try { _isTooltipActive = await JS.InvokeAsync<bool>("eval", "!!document.querySelector('.apexcharts-tooltip-active')"); }
+        catch { _isTooltipActive = false; }
+
+        var (from, to) = GetTimeRange();
+        await LoadSpeedDataAsync(from, to);
+        if (!_isTooltipActive)
+            await UpdateActiveChartsAsync();
+    }
+
     private async Task LoadSpeedDataAsync(DateTime from, DateTime to)
     {
-        _speedResults = await DashboardService.GetSpeedResultsAsync(_client!.Mac, from, to);
+        // VPN clients have no UniFi MAC; their results are keyed by source IP (DeviceHost).
+        _speedResults = _client!.IsVpn
+            ? await DashboardService.GetSpeedResultsByHostAsync(_client.Ip ?? "", from, to)
+            : await DashboardService.GetSpeedResultsAsync(_client.Mac, from, to);
         _latestSpeedResult = _speedResults.FirstOrDefault();
 
         // Build chart data (UTC timestamps - JS formatter converts to browser local time)
@@ -1948,6 +2123,9 @@
     // Speed results pagination
     private int SpeedTotalPages => Math.Max(1, (int)Math.Ceiling(_speedResults.Count / (double)SpeedPageSize));
 
+    // AP RX/TX rate columns only apply to Wi-Fi clients - hide for wired and VPN clients.
+    private bool HidesApRates => _client?.IsWired == true || _client?.IsVpn == true;
+
     private IEnumerable<Iperf3Result> GetPagedSpeedResults()
     {
         return _speedResults.Skip((_speedPage - 1) * SpeedPageSize).Take(SpeedPageSize);
@@ -2339,6 +2517,14 @@
         _ => ""
     };
 
+    // Tint for the VPN logo in the identity bar, matching the speed-test trace hop colors.
+    private static string GetVpnTintClass(HopType? vpnType) => vpnType switch
+    {
+        HopType.Tailscale => "vpn-tint-tailscale",
+        HopType.Teleport => "vpn-tint-teleport",
+        _ => ""
+    };
+
     // Map a UniFi radio code to the FloorPlanEditor propagation band ("2.4" / "5" / "6").
     // Returns null when unknown so the editor keeps its current band.
     private static string? ClientBandToPropagationBand(string? band) => band switch
@@ -2559,6 +2745,7 @@
     public async ValueTask DisposeAsync()
     {
         _pollTimer?.Dispose();
+        _identityRetryTimer?.Dispose();
 
         // Stop GPS watcher
         if (_gpsWatcherId.HasValue)
@@ -2611,7 +2798,36 @@
         gap: 12px;
         margin-bottom: 8px;
     }
+    .empty-state-detail {
+        font-size: 0.8125rem;
+        color: var(--text-muted);
+    }
+
     .identity-info {
+        min-width: 0;
+    }
+    .identity-info-vpn {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+    }
+    .identity-vpn-icon {
+        display: flex;
+        align-items: center;
+        flex-shrink: 0;
+        color: var(--text-secondary);
+    }
+    .identity-vpn-icon.vpn-tint-tailscale {
+        color: var(--primary-light);
+    }
+    .identity-vpn-icon.vpn-tint-teleport {
+        color: var(--purple-light);
+    }
+    .identity-vpn-icon .vpn-shield-icon {
+        width: 32px;
+        height: 32px;
+    }
+    .identity-text {
         min-width: 0;
     }
     .identity-name {

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -2178,9 +2178,17 @@ else
         // cost a UniFi API call plus Influx queries, so this avoids needless hits. The banner
         // and stat cards re-query the DB live regardless.
         var before = UpstreamTargetSignature();
+        var beforeIspHealth = IspHealthInputSignature();
         await LoadTargetsAsync();
         if (UpstreamTargetSignature() != before)
             LanFlowMapCache.Invalidate();
+
+        // Pausing/disabling a scored WAN-path target (e.g. a flaky one skewing the score) changes
+        // the ISP Health inputs, so drop the cached report and let the next visit to the tab
+        // recompute. Gated on the scored set actually changing so unrelated edits (intervals,
+        // renames) don't force a CPU-bound recompute.
+        if (IspHealthInputSignature() != beforeIspHealth)
+            IspHealthService.Invalidate();
 
         // Re-check flaky targets when the advisory is up so disabling/pausing the flagged ones
         // clears the banner (they drop out of the enabled pool). Only when a banner is showing -
@@ -2200,6 +2208,18 @@ else
         string.Join("|", _targets
             .Where(t => t.Enabled
                 && t.TargetType is MonitoringTargetType.AccessIsp or MonitoringTargetType.Transit)
+            .OrderBy(t => t.Id)
+            .Select(t => t.Id));
+
+    // Enabled AccessIsp/Transit/InternetService target IDs - the set ISP Health scoring consumes.
+    // Used to detect when a target change should invalidate the cached ISP Health report so the
+    // score reflects the new set (e.g. a disabled flaky target no longer skewing it).
+    private string IspHealthInputSignature() =>
+        string.Join("|", _targets
+            .Where(t => t.Enabled
+                && t.TargetType is MonitoringTargetType.AccessIsp
+                    or MonitoringTargetType.Transit
+                    or MonitoringTargetType.InternetService)
             .OrderBy(t => t.Id)
             .Select(t => t.Id));
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -178,20 +178,7 @@ else
 
         @if (_flakyTargetCount > 0)
         {
-            <div class="alert alert-info" style="margin-bottom: 1rem;">
-                <div class="banner-content">
-                    <span class="banner-icon banner-icon-info">i</span>
-                    <div class="banner-text" style="flex: 1;">
-                        @(_flakyTargetCount == 1
-                            ? "1 monitoring target looks flaky"
-                            : $"{_flakyTargetCount} monitoring targets look flaky")
-                        - high packet loss versus their peers, usually ICMP deprioritization. Review and disable them so they don't skew ISP Health.
-                    </div>
-                    <div class="banner-actions">
-                        <button class="btn btn-sm btn-primary" @onclick="GoToFlakyTargets">Review flaky targets</button>
-                    </div>
-                </div>
-            </div>
+            @FlakyTargetsBanner
         }
 
         @if (_upstreamNeedsReview && !_upstreamReviewDismissed)
@@ -336,6 +323,12 @@ else
     @* ──────────────── Tab: ISP Health ──────────────── *@
     @if (_activeTab == "isp-health" && _monitoringReady)
     {
+        @* Flaky internet targets skew the score shown here, so surface the same advisory
+           (#849) above the panel - not only on Live View where it was first detected. *@
+        @if (_flakyTargetCount > 0)
+        {
+            @FlakyTargetsBanner
+        }
         <IspHealthPanel />
     }
 
@@ -2040,9 +2033,29 @@ else
         SetActiveTab("setup");
     }
 
-    // Flaky-target banner state (#849). Detected once when Live View first loads; never polled.
+    // Flaky-target banner state (#849). Detected once when Live View or ISP Health first loads,
+    // and re-checked when targets change so addressing the flagged ones clears the banner. Not polled.
     private int _flakyTargetCount;
     private bool _flakyChecked;
+
+    // Shared markup for the flaky internet-target advisory (#849) so Live View and ISP Health
+    // render the identical banner. AccessIsp/Transit/InternetService targets with loss well above
+    // their peers distort ISP Health scoring, so the warning belongs both where you watch live and
+    // where you read the score.
+    private RenderFragment FlakyTargetsBanner => @<div class="alert alert-info" style="margin-bottom: 1rem;">
+        <div class="banner-content">
+            <span class="banner-icon banner-icon-info">i</span>
+            <div class="banner-text" style="flex: 1;">
+                @(_flakyTargetCount == 1
+                    ? "1 monitoring target looks flaky"
+                    : $"{_flakyTargetCount} monitoring targets look flaky")
+                - high packet loss versus their peers, usually ICMP deprioritization. Review and disable them so they don't skew ISP Health.
+            </div>
+            <div class="banner-actions">
+                <button class="btn btn-sm btn-primary" @onclick="GoToFlakyTargets">Review flaky targets</button>
+            </div>
+        </div>
+    </div>;
 
     private void GoToFlakyTargets()
     {
@@ -2168,6 +2181,16 @@ else
         await LoadTargetsAsync();
         if (UpstreamTargetSignature() != before)
             LanFlowMapCache.Invalidate();
+
+        // Re-check flaky targets when the advisory is up so disabling/pausing the flagged ones
+        // clears the banner (they drop out of the enabled pool). Only when a banner is showing -
+        // no need to add the loss queries to unrelated target edits.
+        if (_flakyTargetCount > 0)
+        {
+            try { _flakyTargetCount = (await FlakyTargets.DetectAsync()).Count; }
+            catch (Exception ex) { Logger.LogDebug(ex, "Flaky-target re-check after target change failed"); }
+        }
+
         StateHasChanged();
     }
 
@@ -3160,8 +3183,9 @@ else
         // Mount/unmount charts based on active tab. Only mount when the container
         // div exists in the DOM (i.e., the tab is active). Unmount when switching away.
 
-        // Flaky-target banner (#849): detect once, on the first time Live View is shown. No polling.
-        if (_activeTab == "live" && _monitoringReady && !_flakyChecked)
+        // Flaky-target banner (#849): detect once, the first time Live View or ISP Health is shown
+        // (both surface the banner). No polling.
+        if ((_activeTab == "live" || _activeTab == "isp-health") && _monitoringReady && !_flakyChecked)
         {
             _flakyChecked = true;
             try

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -2856,7 +2856,7 @@
                                             @if (_editingSiteId == site.Id)
                                             {
                                                 <div class="site-name-edit">
-                                                    <input type="text" class="form-control" @bind="_editSiteName" @bind:event="oninput"
+                                                    <input type="text" class="form-control" @ref="_siteNameInput" @bind="_editSiteName" @bind:event="oninput"
                                                            @onkeydown="@(e => SiteNameEditKey(e, site))" autocomplete="off" data-1p-ignore data-lpignore="true" data-bwignore />
                                                     <button type="button" class="btn btn-primary btn-sm" @onclick="() => SaveSiteName(site)"
                                                             disabled="@string.IsNullOrWhiteSpace(_editSiteName)">Save</button>
@@ -3277,11 +3277,15 @@
     // Inline site rename (the slug/Site ID stays immutable).
     private int? _editingSiteId;
     private string _editSiteName = "";
+    private ElementReference _siteNameInput;
 
-    private void StartSiteNameEdit(Site site)
+    private async Task StartSiteNameEdit(Site site)
     {
         _editingSiteId = site.Id;
         _editSiteName = site.Name;
+        StateHasChanged();
+        await Task.Delay(1); // Allow render to complete
+        await _siteNameInput.FocusAsync();
     }
 
     private void CancelSiteNameEdit()

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -993,7 +993,7 @@
             else if (discoveredModems.Count > 0)
             {
                 <div class="table-responsive">
-                <table class="data-table">
+                <table class="data-table settings-table">
                     <thead>
                         <tr>
                             <th>Name</th>
@@ -1053,7 +1053,7 @@
             @if (modemConfigs.Count > 0)
             {
                 <div class="table-responsive">
-                <table class="data-table">
+                <table class="data-table settings-table">
                     <thead>
                         <tr>
                             <th>Name</th>
@@ -1263,7 +1263,7 @@
             @if (_cmConfigs.Count > 0)
             {
                 <div class="table-responsive">
-                <table class="data-table">
+                <table class="data-table settings-table">
                     <thead>
                         <tr>
                             <th>Name</th>
@@ -1436,7 +1436,7 @@
             @if (_ontConfigs.Count > 0)
             {
                 <div class="table-responsive">
-                <table class="data-table">
+                <table class="data-table settings-table">
                     <thead>
                         <tr>
                             <th>Name</th>
@@ -2838,7 +2838,7 @@
                 <div class="form-group">
                     <label class="form-label">Sites</label>
                     <div class="table-responsive">
-                        <table class="data-table">
+                        <table class="data-table settings-table">
                             <thead>
                                 <tr>
                                     <th>Name</th>

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -2932,7 +2932,7 @@
                                                                         }
                                                                         else if (TunnelRegistry.IsAgentLive(agent))
                                                                         {
-                                                                            <text>Online@(TunnelRegistry.IsConnected(agent.Id) ? " (tunnel)" : "")@(agent.LastVersion != null ? $" - v{agent.LastVersion}" : "")</text>
+                                                                            <text>Online@(TunnelRegistry.IsConnected(agent.Id) ? " (tunnel)" : "")@(agent.LastVersion != null ? $" - v{NetworkOptimizer.Core.Helpers.VersionUtilities.StripBuildMetadata(agent.LastVersion)}" : "")</text>
                                                                             @if (AgentVersionOutdated(agent))
                                                                             {
                                                                                 <span class="status-warning" data-tooltip="A newer agent release (v@(AppVersionInfo.LatestAgentVersion)) is available. Update agents whenever a release calls for it.">

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -1194,39 +1194,12 @@
     /// </summary>
     private RenderFragment GetHopIconMarkup(NetworkHop hop) => builder =>
     {
-        // VPN hops get custom SVG icons
-        if (hop.Type == HopType.Teleport)
+        // VPN hops get custom logos, shared with the Client Dashboard via VpnIcon.
+        if (hop.Type is HopType.Teleport or HopType.Tailscale or HopType.Vpn)
         {
-            builder.OpenElement(0, "svg");
-            builder.AddAttribute(1, "viewBox", "0 0 20 20");
-            builder.AddAttribute(2, "width", "24");
-            builder.AddAttribute(3, "height", "24");
-            builder.AddAttribute(4, "class", "vpn-icon teleport-icon");
-            builder.AddMarkupContent(5, @"<path fill-rule=""evenodd"" clip-rule=""evenodd"" d=""M5.111 7.255c-.125-1.072-.318-1.952-.544-2.55-.115-.3-.227-.502-.322-.618a.555.555 0 0 0-.066-.07.897.897 0 0 0-.183.243c-.156.27-.312.693-.45 1.26-.275 1.127-.45 2.708-.45 4.474 0 1.765.175 3.347.45 4.473.138.567.294.99.45 1.26.086.15.15.216.183.244a.558.558 0 0 0 .068-.072c.096-.12.21-.324.324-.63.228-.606.422-1.497.545-2.582a.5.5 0 1 1 .994.114c-.129 1.126-.335 2.107-.603 2.82-.133.354-.291.67-.483.908-.188.231-.47.459-.845.459-.51 0-.848-.41-1.05-.761-.223-.388-.407-.915-.555-1.523-.299-1.224-.478-2.89-.478-4.71 0-1.821.18-3.486.478-4.71.148-.609.332-1.136.555-1.523C3.331 3.41 3.67 3 4.18 3c.373 0 .653.224.84.454.192.235.35.548.483.898.267.704.473 1.673.603 2.788a.5.5 0 0 1-.994.115Zm-.96 8.736-.003.001h.003ZM15.543 4.706c-.227.597-.42 1.477-.545 2.55a.5.5 0 0 1-.993-.116c.13-1.115.336-2.084.603-2.788.132-.35.29-.663.482-.898.187-.23.467-.454.84-.454.511 0 .848.41 1.05.76.223.388.407.915.555 1.524.299 1.224.478 2.889.478 4.71 0 1.82-.18 3.486-.478 4.71-.148.608-.332 1.135-.555 1.523-.202.35-.539.76-1.05.76-.375 0-.656-.227-.844-.458-.193-.238-.351-.554-.484-.908-.268-.713-.474-1.694-.603-2.82a.5.5 0 1 1 .994-.114c.124 1.085.317 1.976.545 2.582.115.306.228.51.324.63a.562.562 0 0 0 .068.072.898.898 0 0 0 .183-.244c.156-.27.313-.693.45-1.26.275-1.126.45-2.708.45-4.473 0-1.766-.175-3.347-.45-4.474-.137-.567-.294-.99-.45-1.26a.896.896 0 0 0-.183-.243.554.554 0 0 0-.066.07c-.095.116-.207.318-.321.619Zm.418 11.286h-.002.002ZM7.557 9.684a.5.5 0 0 0 0 .707l2.122 2.122a.5.5 0 0 0 .707 0l2.123-2.122a.5.5 0 0 0 0-.707L10.386 7.56a.5.5 0 0 0-.707 0L7.557 9.684Zm1.06.353 1.416 1.416 1.415-1.416-1.415-1.415-1.416 1.415Z"" fill=""currentColor""/>");
-            builder.CloseElement();
-            return;
-        }
-
-        if (hop.Type == HopType.Tailscale)
-        {
-            builder.OpenElement(0, "svg");
-            builder.AddAttribute(1, "viewBox", "0 0 20 20");
-            builder.AddAttribute(2, "width", "24");
-            builder.AddAttribute(3, "height", "24");
-            builder.AddAttribute(4, "class", "vpn-icon tailscale-icon");
-            // Official Tailscale logo - 3x3 dot grid: middle row + center bottom solid, corners faded
-            builder.AddMarkupContent(5, @"<ellipse cx=""2.45"" cy=""10.18"" rx=""2.45"" ry=""2.44"" fill=""currentColor""/><ellipse cx=""9.79"" cy=""10.18"" rx=""2.45"" ry=""2.44"" fill=""currentColor""/><ellipse cx=""17.13"" cy=""10.18"" rx=""2.45"" ry=""2.44"" fill=""currentColor""/><ellipse cx=""9.79"" cy=""17.51"" rx=""2.45"" ry=""2.44"" fill=""currentColor""/><ellipse opacity=""0.2"" cx=""2.45"" cy=""2.86"" rx=""2.45"" ry=""2.44"" fill=""currentColor""/><ellipse opacity=""0.2"" cx=""9.79"" cy=""2.86"" rx=""2.45"" ry=""2.44"" fill=""currentColor""/><ellipse opacity=""0.2"" cx=""17.13"" cy=""2.86"" rx=""2.45"" ry=""2.44"" fill=""currentColor""/><ellipse opacity=""0.2"" cx=""2.45"" cy=""17.51"" rx=""2.45"" ry=""2.44"" fill=""currentColor""/><ellipse opacity=""0.2"" cx=""17.13"" cy=""17.51"" rx=""2.45"" ry=""2.44"" fill=""currentColor""/>");
-            builder.CloseElement();
-            return;
-        }
-
-        if (hop.Type == HopType.Vpn)
-        {
-            builder.OpenElement(0, "img");
-            builder.AddAttribute(1, "src", "/icons/shield-v2.png");
-            builder.AddAttribute(2, "alt", "VPN");
-            builder.AddAttribute(3, "class", "vpn-icon vpn-shield-icon");
-            builder.CloseElement();
+            builder.OpenComponent<VpnIcon>(0);
+            builder.AddComponentParameter(1, nameof(VpnIcon.Type), hop.Type);
+            builder.CloseComponent();
             return;
         }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestMap.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestMap.razor
@@ -169,6 +169,14 @@
     [Parameter]
     public int? TimeFilterHours { get; set; }
 
+    /// <summary>
+    /// Pre-select the External layer on first load. Used by the VPN client dashboard,
+    /// where every result is External - otherwise the map would render blank until the
+    /// user toggles the External filter on. The toggle still works normally afterward.
+    /// </summary>
+    [Parameter]
+    public bool ShowExternalByDefault { get; set; }
+
     /// <summary>Fires when the time slider changes, passing the number of hours (0 = all time)</summary>
     [Parameter]
     public EventCallback<int> OnTimeRangeChanged { get; set; }
@@ -486,6 +494,11 @@
 
     protected override async Task OnInitializedAsync()
     {
+        // When all results are External (e.g. a VPN client dashboard), start with the
+        // External layer visible so markers show without an extra toggle.
+        if (ShowExternalByDefault)
+            ShowExternal = true;
+
         // Load networks for VPN detection
         _networks = await ConnectionService.GetNetworksAsync();
     }
@@ -505,13 +518,17 @@
         if (TimeFilterHours.HasValue && TimeFilterHours != _lastExternalTimeFilter)
         {
             _lastExternalTimeFilter = TimeFilterHours;
+            // Treat an external time-filter change like a slider move: clear any manual
+            // pan/zoom so this filter change - and the new results that arrive under it -
+            // auto-fit the visible set back into view.
+            userHasZoomed = false;
             var targetIndex = FindClosestBreakpointIndex(TimeFilterHours.Value);
             if (targetIndex != sliderValue)
             {
                 sliderValue = targetIndex;
                 if (mapInitialized)
                 {
-                    await UpdateMarkers(fitBounds: !userHasZoomed);
+                    await UpdateMarkers(fitBounds: true);
                     StateHasChanged();
                     return; // Markers already updated, skip the count check below
                 }
@@ -529,7 +546,9 @@
             lastResultCount = currentCount;
             lastNewestResultId = newestId;
             lastFilteredCount = filteredCount;
-            await UpdateMarkers(fitBounds: false);
+            // Auto-fit so a freshly arrived result is brought into view, unless the user
+            // has manually panned/zoomed - same guard the slider and filter toggles use.
+            await UpdateMarkers(fitBounds: !userHasZoomed);
             await UpdateApMarkers(); // Rebuild popups with fresh device test data
             StateHasChanged();
         }

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -107,6 +107,40 @@
 
             @if (_state.Step == TracerStep.ReviewingResults)
             {
+                @if (_state.IspChange != null)
+                {
+                    var change = _state.IspChange;
+                    <div class="alert alert-warning isp-change-review">
+                        <strong>Did you switch internet providers?</strong>
+                        <p>
+                            This discovery reached the internet through
+                            <code>AS@(change.NewAsnNumber)</code> <span class="text-muted">(@change.NewAsnName)</span>,
+                            but your upstream monitoring is set up for
+                            <code>AS@(change.OldAsnNumber)</code> <span class="text-muted">(@change.OldAsnName)</span>.
+                            Pick an answer below, then save.
+                        </p>
+                        <div class="isp-change-choices">
+                            <label class="isp-change-choice">
+                                <input type="radio" name="isp-change" checked="@(change.Confirmed == true)"
+                                       @onchange="() => change.Confirmed = true" />
+                                <span>
+                                    <strong>Yes, I switched providers - start fresh.</strong>
+                                    Saving pauses @(change.TargetCount == 1 ? "your 1 current upstream monitoring target" : $"all {change.TargetCount} current upstream monitoring targets")@(change.ManualCount > 0 ? $" (including {change.ManualCount} hand-added)" : "") for this connection
+                                    and the results below become your new baseline. Nothing is deleted.
+                                </span>
+                            </label>
+                            <label class="isp-change-choice">
+                                <input type="radio" name="isp-change" checked="@(change.Confirmed == false)"
+                                       @onchange="() => change.Confirmed = false" />
+                                <span>
+                                    <strong>No, keep monitoring my current targets.</strong>
+                                    Everything stays as it is, and we won't ask again about this network.
+                                </span>
+                            </label>
+                        </div>
+                    </div>
+                }
+
                 <div class="form-group">
                     <label class="form-label">Access network technology</label>
                     <select class="form-control" style="max-width: 250px;@(_state.AccessTechnology == AccessTechnology.Unknown ? " outline: 2px solid rgba(59, 130, 246, 0.5); outline-offset: 2px; border-radius: 6px;" : "")"
@@ -246,6 +280,67 @@
                     </div>
                 }
 
+                @if (_state.RemovedTransitAsns.Count > 0)
+                {
+                    <div class="form-group">
+                        <label class="form-label">No longer on your path</label>
+                        <p class="section-description">These transit networks were being monitored but haven't appeared in the last several discovery runs - your ISP no longer routes through them, so their targets would report false problems. They'll be paused when you save; re-check any you want to keep. Nothing is deleted.</p>
+                        <div class="table-responsive">
+                            <table class="data-table">
+                                <thead>
+                                    <tr>
+                                        <th style="width: 115px;">Keep Active</th>
+                                        <th>ASN</th>
+                                        <th>Targets to pause</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var removed in _state.RemovedTransitAsns)
+                                    {
+                                        <tr class="@(removed.Keep ? "" : "row-disabled")">
+                                            <td>
+                                                <input type="checkbox" checked="@removed.Keep"
+                                                       @onchange="e => removed.Keep = (bool)e.Value!" />
+                                            </td>
+                                            <td><code>AS@(removed.AsnNumber)</code> <span class="text-muted">@removed.AsnName</span></td>
+                                            <td>@(removed.TargetCount == 1 ? "1 target" : $"{removed.TargetCount} targets")@(removed.ManualCount > 0 ? $" ({removed.ManualCount} hand-added)" : "")</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                }
+
+                @if (_state.PendingRemovalTransitAsns.Count > 0)
+                {
+                    <div class="form-group">
+                        <label class="form-label">Tracking possible removals</label>
+                        <p class="section-description">These transit networks are no longer on your path this run. We're tracking them - after the remaining discovery runs shown below without them reappearing, we'll help you remove the affected targets. Nothing changes until then.</p>
+                        <div class="table-responsive">
+                            <table class="data-table">
+                                <thead>
+                                    <tr>
+                                        <th>ASN</th>
+                                        <th>Status</th>
+                                        <th>Affected targets</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var pending in _state.PendingRemovalTransitAsns)
+                                    {
+                                        <tr>
+                                            <td><code>AS@(pending.AsnNumber)</code> <span class="text-muted">@pending.AsnName</span></td>
+                                            <td>Absent @pending.MissCount of @(pending.MissCount + pending.RunsRemaining) runs - @(pending.RunsRemaining == 1 ? "1 more run" : $"{pending.RunsRemaining} more runs") to confirm</td>
+                                            <td>@(pending.TargetCount == 1 ? "1 target" : $"{pending.TargetCount} targets")@(pending.ManualCount > 0 ? $" ({pending.ManualCount} hand-added)" : "")</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                }
+
                 @if (PathEndHosts.Count > 0)
                 {
                     <div class="form-group">
@@ -283,7 +378,8 @@
                     </div>
                 }
 
-                @if (_state.AccessHops.Count == 0 && _state.TransitAsns.Count == 0)
+                @if (_state.AccessHops.Count == 0 && _state.TransitAsns.Count == 0
+                     && _state.RemovedTransitAsns.Count == 0 && _state.PendingRemovalTransitAsns.Count == 0)
                 {
                     <div class="alert alert-info">
                         No upstream hops responded to either ICMP or UDP traceroute. Your
@@ -293,9 +389,13 @@
 
                 <div class="action-buttons">
                     <button class="btn btn-secondary" @onclick="StartAsync">Re-run discovery</button>
-                    @if (_state.AccessHops.Any(h => h.Enabled) || _state.TransitAsns.Any(a => a.Enabled))
+                    @if (_state.AccessHops.Any(h => h.Enabled) || _state.TransitAsns.Any(a => a.Enabled) || _state.RemovedTransitAsns.Count > 0)
                     {
-                        <button class="btn btn-primary" @onclick="CommitAsync">Save monitoring targets</button>
+                        <button class="btn btn-primary" @onclick="CommitAsync"
+                                disabled="@(_state.IspChange is { Confirmed: null })"
+                                data-tooltip="@(_state.IspChange is { Confirmed: null } ? "Answer the provider question above first" : null)">
+                            Save monitoring targets
+                        </button>
                     }
                 </div>
             }
@@ -525,4 +625,8 @@
 <style>
     .row-disabled { opacity: 0.45; }
     .form-control-sm { padding: 0.25rem 0.5rem; font-size: 0.875rem; }
+    .isp-change-review { margin-bottom: 1rem; }
+    .isp-change-review p { margin: 0.5rem 0 0; }
+    .isp-change-choices { display: flex; flex-direction: column; gap: 0.5rem; margin-top: 0.75rem; }
+    .isp-change-choice { display: flex; align-items: baseline; gap: 0.5rem; cursor: pointer; }
 </style>

--- a/src/NetworkOptimizer.Web/Components/Shared/VpnIcon.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/VpnIcon.razor
@@ -1,0 +1,39 @@
+@using NetworkOptimizer.UniFi.Models
+
+@* Renders the VPN-type logo used for VPN hops in speed-test path traces.
+   Shared by SpeedTestDetails (trace) and the Client Dashboard (simplified VPN view)
+   so both render identical markup. Renders nothing for non-VPN hop types. *@
+
+@if (Type == HopType.Teleport)
+{
+    <svg viewBox="0 0 20 20" width="@Size" height="@Size" class="vpn-icon teleport-icon">
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M5.111 7.255c-.125-1.072-.318-1.952-.544-2.55-.115-.3-.227-.502-.322-.618a.555.555 0 0 0-.066-.07.897.897 0 0 0-.183.243c-.156.27-.312.693-.45 1.26-.275 1.127-.45 2.708-.45 4.474 0 1.765.175 3.347.45 4.473.138.567.294.99.45 1.26.086.15.15.216.183.244a.558.558 0 0 0 .068-.072c.096-.12.21-.324.324-.63.228-.606.422-1.497.545-2.582a.5.5 0 1 1 .994.114c-.129 1.126-.335 2.107-.603 2.82-.133.354-.291.67-.483.908-.188.231-.47.459-.845.459-.51 0-.848-.41-1.05-.761-.223-.388-.407-.915-.555-1.523-.299-1.224-.478-2.89-.478-4.71 0-1.821.18-3.486.478-4.71.148-.609.332-1.136.555-1.523C3.331 3.41 3.67 3 4.18 3c.373 0 .653.224.84.454.192.235.35.548.483.898.267.704.473 1.673.603 2.788a.5.5 0 0 1-.994.115Zm-.96 8.736-.003.001h.003ZM15.543 4.706c-.227.597-.42 1.477-.545 2.55a.5.5 0 0 1-.993-.116c.13-1.115.336-2.084.603-2.788.132-.35.29-.663.482-.898.187-.23.467-.454.84-.454.511 0 .848.41 1.05.76.223.388.407.915.555 1.524.299 1.224.478 2.889.478 4.71 0 1.82-.18 3.486-.478 4.71-.148.608-.332 1.135-.555 1.523-.202.35-.539.76-1.05.76-.375 0-.656-.227-.844-.458-.193-.238-.351-.554-.484-.908-.268-.713-.474-1.694-.603-2.82a.5.5 0 1 1 .994-.114c.124 1.085.317 1.976.545 2.582.115.306.228.51.324.63a.562.562 0 0 0 .068.072.898.898 0 0 0 .183-.244c.156-.27.313-.693.45-1.26.275-1.126.45-2.708.45-4.473 0-1.766-.175-3.347-.45-4.474-.137-.567-.294-.99-.45-1.26a.896.896 0 0 0-.183-.243.554.554 0 0 0-.066.07c-.095.116-.207.318-.321.619Zm.418 11.286h-.002.002ZM7.557 9.684a.5.5 0 0 0 0 .707l2.122 2.122a.5.5 0 0 0 .707 0l2.123-2.122a.5.5 0 0 0 0-.707L10.386 7.56a.5.5 0 0 0-.707 0L7.557 9.684Zm1.06.353 1.416 1.416 1.415-1.416-1.415-1.415-1.416 1.415Z" fill="currentColor" />
+    </svg>
+}
+else if (Type == HopType.Tailscale)
+{
+    @* Official Tailscale logo - 3x3 dot grid: middle row + center bottom solid, corners faded *@
+    <svg viewBox="0 0 20 20" width="@Size" height="@Size" class="vpn-icon tailscale-icon">
+        <ellipse cx="2.45" cy="10.18" rx="2.45" ry="2.44" fill="currentColor" />
+        <ellipse cx="9.79" cy="10.18" rx="2.45" ry="2.44" fill="currentColor" />
+        <ellipse cx="17.13" cy="10.18" rx="2.45" ry="2.44" fill="currentColor" />
+        <ellipse cx="9.79" cy="17.51" rx="2.45" ry="2.44" fill="currentColor" />
+        <ellipse opacity="0.2" cx="2.45" cy="2.86" rx="2.45" ry="2.44" fill="currentColor" />
+        <ellipse opacity="0.2" cx="9.79" cy="2.86" rx="2.45" ry="2.44" fill="currentColor" />
+        <ellipse opacity="0.2" cx="17.13" cy="2.86" rx="2.45" ry="2.44" fill="currentColor" />
+        <ellipse opacity="0.2" cx="2.45" cy="17.51" rx="2.45" ry="2.44" fill="currentColor" />
+        <ellipse opacity="0.2" cx="17.13" cy="17.51" rx="2.45" ry="2.44" fill="currentColor" />
+    </svg>
+}
+else if (Type == HopType.Vpn)
+{
+    <img src="/icons/shield-v2.png" alt="VPN" class="vpn-icon vpn-shield-icon" />
+}
+
+@code {
+    /// <summary>The VPN hop type to render. Non-VPN types render nothing.</summary>
+    [Parameter] public HopType Type { get; set; }
+
+    /// <summary>SVG icon size in px (Tailscale/Teleport). The shield PNG is sized via CSS.</summary>
+    [Parameter] public int Size { get; set; } = 24;
+}

--- a/src/NetworkOptimizer.Web/Models/ClientDashboardModels.cs
+++ b/src/NetworkOptimizer.Web/Models/ClientDashboardModels.cs
@@ -52,6 +52,15 @@ public class ClientIdentity
     /// <summary>True when signal data was sourced from the WiFiman realtime endpoint</summary>
     public bool HasWiFiManData { get; set; }
 
+    /// <summary>
+    /// VPN hop type when this client connects through Tailscale, Teleport, or a UniFi
+    /// remote-user VPN. Set only for the simplified VPN dashboard view; null otherwise.
+    /// </summary>
+    public HopType? VpnType { get; set; }
+
+    /// <summary>True when this is a VPN-sourced client (renders the simplified dashboard view)</summary>
+    public bool IsVpn => VpnType != null;
+
     /// <summary>Best display name (Name > Hostname > MAC)</summary>
     public string DisplayName => !string.IsNullOrEmpty(Name) ? Name
         : !string.IsNullOrEmpty(Hostname) ? Hostname

--- a/src/NetworkOptimizer.Web/Services/CableModemMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemMonitorService.cs
@@ -282,6 +282,7 @@ public sealed class CableModemMonitorService : IDisposable
             Id = config.Id,
             Name = config.Name,
             Host = host,
+            ConfiguredHost = config.Host,
             Port = port,
             Username = config.Username,
             Password = password,

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/ArrisSurfboardHnapProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/ArrisSurfboardHnapProvider.cs
@@ -74,7 +74,7 @@ public sealed class ArrisSurfboardHnapProvider : ICableModemProvider, IDisposabl
         catch (Exception ex)
         {
             _sessions.TryRemove(context.Id, out _);
-            _logger.LogWarning(ex, "Error polling ARRIS Surfboard HNAP {Name} at {Host}", context.Name, context.Host);
+            _logger.LogWarning(ex, "Error polling ARRIS Surfboard HNAP {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
             return null;
         }
     }
@@ -148,7 +148,7 @@ public sealed class ArrisSurfboardHnapProvider : ICableModemProvider, IDisposabl
         catch (Exception ex)
         {
             _sessions.TryRemove(context.Id, out _);
-            _logger.LogDebug(ex, "ARRIS Surfboard HNAP request failed for {Name} at {Host}", context.Name, context.Host);
+            _logger.LogDebug(ex, "ARRIS Surfboard HNAP request failed for {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
             return null;
         }
     }

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/ArrisSurfboardHnapProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/ArrisSurfboardHnapProvider.cs
@@ -489,7 +489,7 @@ public sealed class ArrisSurfboardHnapProvider : ICableModemProvider, IDisposabl
         var stats = new CableModemStats
         {
             Timestamp = DateTime.UtcNow,
-            DeviceHost = context.Host,
+            DeviceHost = context.ConfiguredHost ?? context.Host,
             DeviceName = context.Name,
             DeviceModel = "ARRIS Surfboard HNAP",
         };

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/ArrisSurfboardHttpProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/ArrisSurfboardHttpProvider.cs
@@ -78,7 +78,7 @@ public sealed class ArrisSurfboardHttpProvider : ICableModemProvider, IDisposabl
             }
 
             _logger.LogWarning("ARRIS Surfboard {Name} at {Host}: both SB8200 and SB6183 fetch failed",
-                context.Name, context.Host);
+                context.Name, context.ConfiguredHost ?? context.Host);
             return null;
         }
         catch (OperationCanceledException)
@@ -87,7 +87,7 @@ public sealed class ArrisSurfboardHttpProvider : ICableModemProvider, IDisposabl
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Error polling ARRIS Surfboard {Name} at {Host}", context.Name, context.Host);
+            _logger.LogWarning(ex, "Error polling ARRIS Surfboard {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
             return null;
         }
     }
@@ -229,14 +229,14 @@ public sealed class ArrisSurfboardHttpProvider : ICableModemProvider, IDisposabl
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogDebug("ARRIS SB8200 auth returned {Status} for {Host}",
-                    response.StatusCode, context.Host);
+                    response.StatusCode, context.ConfiguredHost ?? context.Host);
                 return null;
             }
 
             var token = await response.Content.ReadAsStringAsync(cancellationToken);
             if (string.IsNullOrWhiteSpace(token))
             {
-                _logger.LogDebug("ARRIS SB8200 auth returned empty token for {Host}", context.Host);
+                _logger.LogDebug("ARRIS SB8200 auth returned empty token for {Host}", context.ConfiguredHost ?? context.Host);
                 return null;
             }
 
@@ -244,7 +244,7 @@ public sealed class ArrisSurfboardHttpProvider : ICableModemProvider, IDisposabl
         }
         catch (HttpRequestException ex)
         {
-            _logger.LogDebug(ex, "ARRIS SB8200 auth request failed for {Host}", context.Host);
+            _logger.LogDebug(ex, "ARRIS SB8200 auth request failed for {Host}", context.ConfiguredHost ?? context.Host);
             return null;
         }
     }

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/ArrisSurfboardHttpProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/ArrisSurfboardHttpProvider.cs
@@ -319,7 +319,7 @@ public sealed class ArrisSurfboardHttpProvider : ICableModemProvider, IDisposabl
         var stats = new CableModemStats
         {
             Timestamp = DateTime.UtcNow,
-            DeviceHost = context.Host,
+            DeviceHost = context.ConfiguredHost ?? context.Host,
             DeviceName = context.Name,
             DeviceModel = "ARRIS SB8200",
         };
@@ -350,7 +350,7 @@ public sealed class ArrisSurfboardHttpProvider : ICableModemProvider, IDisposabl
         var stats = new CableModemStats
         {
             Timestamp = DateTime.UtcNow,
-            DeviceHost = context.Host,
+            DeviceHost = context.ConfiguredHost ?? context.Host,
             DeviceName = context.Name,
             DeviceModel = "ARRIS SB6183",
         };

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/MotorolaHnapProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/MotorolaHnapProvider.cs
@@ -96,7 +96,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
             var sessionInfo = await EnsureSessionAsync(client, context, cancellationToken);
             if (sessionInfo == null)
             {
-                _logger.LogWarning("Motorola HNAP {Name} at {Host}: login failed", context.Name, context.Host);
+                _logger.LogWarning("Motorola HNAP {Name} at {Host}: login failed", context.Name, context.ConfiguredHost ?? context.Host);
                 return null;
             }
 
@@ -113,7 +113,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
             if (response == null)
             {
                 _sessions.TryRemove(context.Id, out _);
-                _logger.LogWarning("Motorola HNAP {Name} at {Host}: GetMultipleHNAPs failed", context.Name, context.Host);
+                _logger.LogWarning("Motorola HNAP {Name} at {Host}: GetMultipleHNAPs failed", context.Name, context.ConfiguredHost ?? context.Host);
                 return null;
             }
 
@@ -132,7 +132,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         catch (Exception ex)
         {
             _sessions.TryRemove(context.Id, out _);
-            _logger.LogWarning(ex, "Error polling Motorola HNAP {Name} at {Host}", context.Name, context.Host);
+            _logger.LogWarning(ex, "Error polling Motorola HNAP {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
             return null;
         }
     }

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/MotorolaHnapProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/MotorolaHnapProvider.cs
@@ -468,7 +468,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         var stats = new CableModemStats
         {
             Timestamp = DateTime.UtcNow,
-            DeviceHost = context.Host,
+            DeviceHost = context.ConfiguredHost ?? context.Host,
             DeviceName = context.Name,
             DeviceModel = "Motorola",
         };

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
@@ -132,7 +132,7 @@ public sealed class NetgearCmProvider : ICableModemProvider
                 {
                     _logger.LogWarning(
                         "Netgear CM at {Host} returned empty response (attempt {Attempt}/{Max})",
-                        context.Host, attempt, MaxRetries);
+                        context.ConfiguredHost ?? context.Host, attempt, MaxRetries);
                     if (attempt < MaxRetries)
                     {
                         await Task.Delay(RetryDelay, cancellationToken);
@@ -160,7 +160,7 @@ public sealed class NetgearCmProvider : ICableModemProvider
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Error polling Netgear CM {Name} at {Host}", context.Name, context.Host);
+                _logger.LogWarning(ex, "Error polling Netgear CM {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
                 return null;
             }
         }

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
@@ -828,7 +828,7 @@ public sealed class NetgearCmProvider : ICableModemProvider
         var stats = new CableModemStats
         {
             Timestamp = DateTime.UtcNow,
-            DeviceHost = context.Host,
+            DeviceHost = context.ConfiguredHost ?? context.Host,
             DeviceName = context.Name,
             DeviceModel = "Netgear",
         };

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
@@ -52,7 +52,7 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
                 {
                     _logger.LogWarning(
                         "Xfinity Gateway at {Host} returned empty response (attempt {Attempt}/{Max})",
-                        context.Host, attempt, MaxRetries);
+                        context.ConfiguredHost ?? context.Host, attempt, MaxRetries);
                     if (attempt < MaxRetries)
                     {
                         await Task.Delay(RetryDelay, cancellationToken);
@@ -80,7 +80,7 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Error polling Xfinity Gateway {Name} at {Host}", context.Name, context.Host);
+                _logger.LogWarning(ex, "Error polling Xfinity Gateway {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
                 return null;
             }
         }
@@ -161,7 +161,7 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
         if (!loginResponse.IsSuccessStatusCode)
         {
             _logger.LogDebug("Xfinity Gateway login returned {Status} for {Host}",
-                loginResponse.StatusCode, context.Host);
+                loginResponse.StatusCode, context.ConfiguredHost ?? context.Host);
             return null;
         }
 
@@ -169,7 +169,7 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
         if (!response.IsSuccessStatusCode)
         {
             _logger.LogDebug("Xfinity Gateway status page returned {Status} for {Host}",
-                response.StatusCode, context.Host);
+                response.StatusCode, context.ConfiguredHost ?? context.Host);
             return null;
         }
 
@@ -180,7 +180,7 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
         if (IsLoginPage(html))
         {
             _logger.LogDebug("Xfinity Gateway at {Host}: login failed, got redirected back to login page",
-                context.Host);
+                context.ConfiguredHost ?? context.Host);
             return null;
         }
 

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
@@ -205,7 +205,7 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
         var stats = new CableModemStats
         {
             Timestamp = DateTime.UtcNow,
-            DeviceHost = context.Host,
+            DeviceHost = context.ConfiguredHost ?? context.Host,
             DeviceName = context.Name,
             DeviceModel = ExtractProductType(doc) ?? "Xfinity Gateway",
         };

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/NetgearNighthawkHotspotProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/NetgearNighthawkHotspotProvider.cs
@@ -63,7 +63,7 @@ public sealed class NetgearNighthawkHotspotProvider : ICellularModemProvider, ID
             var json = await FetchModelJsonAsync(context, requireAuth: hasPassword, cancellationToken);
             if (json == null)
             {
-                _logger.LogWarning("Netgear poll for {Name} ({Host}) returned no data", context.Name, context.Host);
+                _logger.LogWarning("Netgear poll for {Name} ({Host}) returned no data", context.Name, context.ConfiguredHost ?? context.Host);
                 return null;
             }
 
@@ -72,7 +72,7 @@ public sealed class NetgearNighthawkHotspotProvider : ICellularModemProvider, ID
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error polling Netgear modem {Name} at {Host}", context.Name, context.Host);
+            _logger.LogError(ex, "Error polling Netgear modem {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
             return null;
         }
     }
@@ -128,7 +128,7 @@ public sealed class NetgearNighthawkHotspotProvider : ICellularModemProvider, ID
         {
             _logger.LogInformation(
                 "Netgear session for {Host} expired (302 to /sess_cd_tmp), rebuilding",
-                context.Host);
+                context.ConfiguredHost ?? context.Host);
             InvalidateSession(context.Host);
 
             session = await GetOrCreateSessionAsync(context, requireAuth, cancellationToken);
@@ -217,7 +217,7 @@ public sealed class NetgearNighthawkHotspotProvider : ICellularModemProvider, ID
             var loggedIn = await LoginAsync(session, context.Host, context.Password!, cancellationToken);
             if (!loggedIn)
             {
-                _logger.LogWarning("Netgear login failed for {Host}", context.Host);
+                _logger.LogWarning("Netgear login failed for {Host}", context.ConfiguredHost ?? context.Host);
                 // Keep the anonymous session - polling can still return signal data
             }
             else

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/QmicliModemProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/QmicliModemProvider.cs
@@ -73,7 +73,7 @@ public sealed class QmicliModemProvider : ICellularModemProvider
                 return null;
             }
 
-            var stats = UiwwandParser.Parse(output, context.Host, context.Name, context.ModemType);
+            var stats = UiwwandParser.Parse(output, context.ConfiguredHost ?? context.Host, context.Name, context.ModemType);
 
             if (stats != null && stats.Lte == null && stats.Nr5g == null)
             {

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/QmicliModemProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/QmicliModemProvider.cs
@@ -37,7 +37,7 @@ public sealed class QmicliModemProvider : ICellularModemProvider
         ModemPollContext context,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation("Polling modem {Name} at {Host}", context.Name, context.Host);
+        _logger.LogInformation("Polling modem {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
 
         // Try uiwwand first - available on all modern UniFi cellular modems
         var stats = await TryPollViaUiwwandAsync(context);
@@ -110,7 +110,7 @@ public sealed class QmicliModemProvider : ICellularModemProvider
         {
             var stats = new CellularModemStats
             {
-                ModemHost = context.Host,
+                ModemHost = context.ConfiguredHost ?? context.Host,
                 ModemName = context.Name,
                 ModemModel = context.ModemType,
                 Timestamp = DateTime.UtcNow,

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/QuectelAtModemProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/QuectelAtModemProvider.cs
@@ -38,7 +38,7 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
         ModemPollContext context,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation("Polling GL-iNet modem {Name} at {Host}", context.Name, context.Host);
+        _logger.LogInformation("Polling GL-iNet modem {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
 
         var connection = ToConnectionInfo(context);
         if (!connection.HasCredentials)
@@ -58,7 +58,7 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
                 return null;
             }
 
-            var stats = QuectelAtParser.Parse(result.Output, context.Host, context.Name, context.ModemType);
+            var stats = QuectelAtParser.Parse(result.Output, context.ConfiguredHost ?? context.Host, context.Name, context.ModemType);
 
             if (stats != null)
             {

--- a/src/NetworkOptimizer.Web/Services/CellularModemService.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemService.cs
@@ -225,6 +225,7 @@ public class CellularModemService : ICellularModemService
             Id = modem.Id,
             Name = modem.Name,
             Host = host,
+            ConfiguredHost = modem.Host,
             Port = port,
             Username = string.IsNullOrEmpty(modem.Username) ? null : modem.Username,
             Password = password,

--- a/src/NetworkOptimizer.Web/Services/ClientDashboardService.cs
+++ b/src/NetworkOptimizer.Web/Services/ClientDashboardService.cs
@@ -204,6 +204,48 @@ public class ClientDashboardService
     }
 
     /// <summary>
+    /// Identify a client that reaches the dashboard through a VPN (Tailscale, Teleport,
+    /// or a UniFi remote-user VPN). These clients never appear in the UniFi client list,
+    /// so <see cref="IdentifyClientAsync"/> returns null for them. Returns a synthetic
+    /// identity carrying the VPN type and IP for the simplified dashboard view, or null
+    /// when the IP is not VPN-sourced (or the console is unreachable).
+    /// </summary>
+    public async Task<ClientIdentity?> IdentifyVpnClientAsync(string clientIp)
+    {
+        if (!_connectionService.IsConnected || _connectionService.Client == null)
+            return null;
+
+        try
+        {
+            var vpnType = await _pathAnalyzer.ClassifyVpnClientAsync(clientIp);
+            if (vpnType == null)
+                return null;
+
+            var name = vpnType switch
+            {
+                HopType.Tailscale => "Tailscale Client",
+                HopType.Teleport => "Teleport Client",
+                _ => "VPN Client"
+            };
+
+            _logger.LogDebug("Identified VPN client {Ip} as {VpnType}", clientIp, vpnType);
+            return new ClientIdentity
+            {
+                Mac = "",
+                Name = name,
+                Ip = clientIp,
+                IsWired = false,
+                VpnType = vpnType
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to classify VPN client {Ip}", clientIp);
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Poll current signal quality for a client, run a trace, store the result, and return live data.
     /// </summary>
     public async Task<SignalPollResult?> PollSignalAsync(
@@ -468,6 +510,30 @@ public class ClientDashboardService
                        || r.Direction == SpeedTestDirection.ClientToServer
                        || r.Direction == SpeedTestDirection.BrowserToServer)
                       && r.ClientMac == mac
+                      && r.TestTime >= from
+                      && r.TestTime <= to)
+            .OrderByDescending(r => r.TestTime)
+            .ToListAsync();
+    }
+
+    /// <summary>
+    /// Get speed test results for a client by its source host/IP, within a time range.
+    /// Used for VPN clients (Tailscale/Teleport/remote-user VPN), which have no UniFi MAC:
+    /// their browser/iperf3 results store <c>DeviceHost</c> = the VPN IP and a null MAC,
+    /// so the MAC-keyed <see cref="GetSpeedResultsAsync"/> can't find them.
+    /// </summary>
+    public async Task<List<Iperf3Result>> GetSpeedResultsByHostAsync(
+        string host, DateTime from, DateTime to)
+    {
+        await using var db = CreateSiteDb();
+
+        // Same LAN directions as the MAC-keyed query - the client's LAN throughput
+        // history, not its internet speed.
+        return await db.Iperf3Results
+            .Where(r => (r.Direction == SpeedTestDirection.ServerToDevice
+                       || r.Direction == SpeedTestDirection.ClientToServer
+                       || r.Direction == SpeedTestDirection.BrowserToServer)
+                      && r.DeviceHost == host
                       && r.TestTime >= from
                       && r.TestTime <= to)
             .OrderByDescending(r => r.TestTime)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/FlakyTargetService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/FlakyTargetService.cs
@@ -52,6 +52,32 @@ public class FlakyTargetService
     private const double SharedLossHeavyPct = 5.0;
     /// <summary>Minimum surviving bins before we'll judge a target. 3 x 10 min = help from ~30 min in, not 6 h.</summary>
     private const int MinTargetBins = 3;
+    /// <summary>
+    /// Recovery window: a target whose full-window metric says flaky but whose surviving bins in
+    /// this trailing slice (anchored to the pool's newest surviving bin, not wall clock) are back
+    /// under the threshold is treated as recovered and not presented. Keeps a stable-flaky-stable
+    /// excursion from nagging for the rest of the 48 h lookback, while an always-flaky target
+    /// (ICMP deprioritization is persistent) keeps failing the recent slice and stays flagged.
+    /// </summary>
+    private const int RecoveryWindowHours = 3;
+    /// <summary>
+    /// Recovery needs at least this many surviving bins (>= ~1 h of evidence) inside the window.
+    /// Fewer - the target went dark or barely reports - can't prove stability, so it stays flagged.
+    /// </summary>
+    private const int MinRecoveryBins = 6;
+    /// <summary>
+    /// A bin at or above this loss counts as hard-down (total outage) rather than the partial,
+    /// load-dependent loss that signals ICMP deprioritization.
+    /// </summary>
+    private const double HardDownLossPct = 95.0;
+    /// <summary>
+    /// Fast recovery for hard-down episodes: when the median over-threshold bin was hard-down
+    /// (median, so the partial-loss bins an aggregate window produces at the outage's edges
+    /// don't disqualify it), the episode was a binary outage, not flakiness - once the hop
+    /// answers cleanly again there's little ambiguity, so this many consecutive clean bins
+    /// (~30 min) clear the flag instead of waiting out the full recovery window.
+    /// </summary>
+    private const int HardDownRecoveryBins = 3;
 
     /// <summary>One flagged target plus the evidence behind the call.</summary>
     public record FlakyTarget(
@@ -136,6 +162,16 @@ public class FlakyTargetService
     /// (e.g. 2.86% -> 4.5%), the trimmed mean stays put (~4%). Bins where >= half the pool loses
     /// heavily are excluded first as path-wide events, and a target needs <see cref="MinTargetBins"/>
     /// surviving bins to be judged. The peer baseline still uses a plain median across the pool.
+    ///
+    /// Recovery gate: a target the full-window metric flags is dropped when its bins in the
+    /// trailing <see cref="RecoveryWindowHours"/> (>= <see cref="MinRecoveryBins"/> of them) are
+    /// back under the same threshold - a stable-flaky-stable excursion stops being presented as
+    /// soon as recent evidence says it's fine, instead of nagging until the bad bins dilute out
+    /// of the 48 h lookback. An always-flaky target keeps failing the recent slice and a target
+    /// that went dark has no recent bins to prove recovery with, so both stay flagged. Hard-down
+    /// episodes (median over-threshold bin >= <see cref="HardDownLossPct"/>) recover faster: a
+    /// binary outage that ended needs only <see cref="HardDownRecoveryBins"/> consecutive clean
+    /// bins, since down-then-up carries none of partial loss's ambiguity.
     /// </summary>
     internal static IReadOnlyList<FlakyTarget> Analyze(
         Dictionary<string, Dictionary<DateTime, double>> lossByTarget,
@@ -173,13 +209,52 @@ public class FlakyTargetService
         var baseline = Median(allLosses);
         var threshold = Math.Max(LossMultiplier * baseline, LossAbsoluteFloorPct);
 
+        // Anchor the recovery window to the pool's newest surviving bin rather than wall clock,
+        // so the analysis stays pure and a stale data set doesn't read as "everyone recovered".
+        var newestBin = allBins.Where(b => !excludedBins.Contains(b)).Max();
+        var recoveryCutoff = newestBin - TimeSpan.FromHours(RecoveryWindowHours);
+
         var flaky = new List<FlakyTarget>();
         foreach (var (targetId, bins) in lossByTarget)
         {
-            var survivors = bins.Where(kv => !excludedBins.Contains(kv.Key)).Select(kv => kv.Value).ToList();
-            if (survivors.Count < MinTargetBins) continue;
+            var survivorPairs = bins.Where(kv => !excludedBins.Contains(kv.Key)).ToList();
+            if (survivorPairs.Count < MinTargetBins) continue;
+            var survivors = survivorPairs.Select(kv => kv.Value).ToList();
             var metric = TrimmedMean(survivors);
             if (metric < threshold) continue;
+
+            // Hard-down fast path: when the over-threshold bins were essentially total loss, the
+            // episode was a binary outage (reboot, maintenance, transient route change) rather
+            // than the partial-loss signature of ICMP deprioritization. Down-then-up is a state
+            // transition, so a short clean streak is enough evidence - no need to wait for the
+            // outage bins to dilute out of the full recovery window. Judged on the MEDIAN
+            // over-threshold bin: the aggregate bins straddling the outage's edges average to
+            // partial loss (observed 52.8% on a real recovery) and must not disqualify the
+            // episode, while genuinely mixed partial-loss flakiness pulls the median below the
+            // bar and falls through to the standard gate below.
+            var overBins = survivorPairs.Where(kv => kv.Value >= threshold).Select(kv => kv.Value).ToList();
+            if (overBins.Count > 0 && Median(overBins) >= HardDownLossPct)
+            {
+                var latest = survivorPairs.OrderByDescending(kv => kv.Key)
+                    .Take(HardDownRecoveryBins).Select(kv => kv.Value).ToList();
+                if (latest.Count >= HardDownRecoveryBins && latest.All(l => l < threshold))
+                {
+                    logger?.LogDebug("Flaky-target detect: {Target} was hard-down ({Metric:0.0}%) but its last {Bins} bins are clean; treating the outage as over",
+                        targetId, metric, HardDownRecoveryBins);
+                    continue;
+                }
+            }
+
+            // Recovery gate: historically flaky, but its recent bins are clean by the same
+            // threshold - stable again, so stop presenting it. Judged only with enough recent
+            // evidence; a target that went dark can't prove recovery and stays flagged.
+            var recent = survivorPairs.Where(kv => kv.Key > recoveryCutoff).Select(kv => kv.Value).ToList();
+            if (recent.Count >= MinRecoveryBins && TrimmedMean(recent) < threshold)
+            {
+                logger?.LogDebug("Flaky-target detect: {Target} historically flaky ({Metric:0.0}%) but stable over the last {Hours}h; treating as recovered",
+                    targetId, metric, RecoveryWindowHours);
+                continue;
+            }
 
             if (!byId.TryGetValue(targetId, out var t)) continue;
             var over = survivors.Count(l => l >= threshold);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -269,11 +269,17 @@ public class IspHealthService
 
     /// <summary>Pipeline readiness, for the tab's prerequisite funnels.</summary>
     /// <summary>
-    /// Drop the cached report so the next <see cref="GetReportAsync"/> recomputes from current
-    /// data. Called when Upstream Discovery is committed, so the "re-run discovery" banner
-    /// clears as soon as the user revisits the tab, without a manual refresh.
+    /// Drop the cached reports - both the default window and any custom-window view - so the next
+    /// <see cref="GetReportAsync"/> / custom-window read recomputes from current data. Called when
+    /// Upstream Discovery is committed (so the "re-run discovery" banner clears on the next visit)
+    /// and when the scored target set changes (e.g. a flaky target is disabled), so the score
+    /// refreshes without a manual refresh.
     /// </summary>
-    public void Invalidate() => _cached = null;
+    public void Invalidate()
+    {
+        _cached = null;
+        _customCache = null;
+    }
 
     public IspHealthStatus Status => _cached != null ? IspHealthStatus.Ready : _status;
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -47,6 +47,9 @@ public class IspHealthService
     private Snapshot? _cached;
     private CustomWindowSnapshot? _customCache;
     private IspHealthStatus _status = IspHealthStatus.Computing;
+    // Set by Invalidate() to force the next read to recompute while KEEPING _cached, so the
+    // glanceable tiles keep serving the prior score instead of dropping to a setup prerequisite.
+    private bool _recomputePending;
     private volatile bool _computing;
     // Trailing window (hours) the last successful auto-compute used. Drops down the ladder when a
     // longer window exceeds the compute budget on this hardware; resets to 0 on process restart so the
@@ -199,7 +202,7 @@ public class IspHealthService
         // kicked off once the tile crosses DashboardScoreTtl (or on first populate); the ISP
         // Health tab uses the shorter CacheTtl (via GetReportAsync) for fresher detail.
         var report = _cached?.Report;
-        if (report != null && DateTime.UtcNow - report.ComputedAt < _options.DashboardScoreTtl)
+        if (report != null && !_recomputePending && DateTime.UtcNow - report.ComputedAt < _options.DashboardScoreTtl)
             return new IspHealthSnapshot(IspHealthStatus.Ready, report.OverallScore, report.ComputedAt);
 
         // Managed site whose console isn't up yet: serve any stale report, but don't kick a
@@ -226,12 +229,16 @@ public class IspHealthService
 
     public async Task<IspHealthReport?> GetReportAsync(bool forceRefresh = false, CancellationToken ct = default)
     {
+        // A pending invalidation forces a recompute like forceRefresh, but without the connection-
+        // cache clear below - the scored inputs changed (a target was toggled), not the console data.
+        var mustRecompute = forceRefresh || _recomputePending;
         var cached = _cached?.Report;
-        if (!forceRefresh && cached != null && DateTime.UtcNow - cached.ComputedAt < _options.CacheTtl)
+        if (!mustRecompute && cached != null && DateTime.UtcNow - cached.ComputedAt < _options.CacheTtl)
             return cached;
 
         // Defer computing until the console connection is up (expected ISP speeds come from
         // it). Serve any existing report; otherwise publish AwaitingConnection for the funnels.
+        // Keep _recomputePending set so the recompute happens once the connection lands.
         if (!CanCompute)
         {
             if (cached == null)
@@ -243,7 +250,8 @@ public class IspHealthService
         try
         {
             cached = _cached?.Report;
-            if (!forceRefresh && cached != null && DateTime.UtcNow - cached.ComputedAt < _options.CacheTtl)
+            mustRecompute = forceRefresh || _recomputePending;
+            if (!mustRecompute && cached != null && DateTime.UtcNow - cached.ComputedAt < _options.CacheTtl)
                 return cached;
 
             if (forceRefresh)
@@ -251,6 +259,8 @@ public class IspHealthService
 
             _computing = true;
             var (report, chartClusters) = await ComputeAsync(ct);
+            // One forced recompute consumed; future reads fall back to normal TTL rules.
+            _recomputePending = false;
             if (report != null)
                 _cached = new Snapshot(report, chartClusters);
             else if (forceRefresh)
@@ -269,15 +279,17 @@ public class IspHealthService
 
     /// <summary>Pipeline readiness, for the tab's prerequisite funnels.</summary>
     /// <summary>
-    /// Drop the cached reports - both the default window and any custom-window view - so the next
-    /// <see cref="GetReportAsync"/> / custom-window read recomputes from current data. Called when
-    /// Upstream Discovery is committed (so the "re-run discovery" banner clears on the next visit)
-    /// and when the scored target set changes (e.g. a flaky target is disabled), so the score
-    /// refreshes without a manual refresh.
+    /// Force the next <see cref="GetReportAsync"/> / custom-window read to recompute from current
+    /// data, without discarding the last score. Called when Upstream Discovery is committed (so the
+    /// "re-run discovery" banner clears on the next visit) and when the scored target set changes
+    /// (e.g. a flaky target is disabled), so the score refreshes without a manual refresh.
+    /// The cached report is KEPT so the glanceable Live-view tiles keep showing the prior score
+    /// (Ready) while the recompute runs, instead of dropping to a "set up ISP Health" prerequisite
+    /// state. The custom-window dedup cache is cleared (the detail tab renders its own loading state).
     /// </summary>
     public void Invalidate()
     {
-        _cached = null;
+        _recomputePending = true;
         _customCache = null;
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamRediscoveryService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamRediscoveryService.cs
@@ -19,14 +19,24 @@ public class UpstreamRediscoveryService : BackgroundService
     private static readonly TimeSpan TickInterval = TimeSpan.FromHours(1);
     private static readonly TimeSpan RediscoveryThreshold = TimeSpan.FromDays(7);
 
-    // An auto-discovered ASN must be absent from this many consecutive runs before it's a
-    // removal candidate - long enough (3 cycles) to ride out an incomplete/degraded run.
+    // An auto-discovered ASN must be absent from this many gated increments before it's a removal
+    // candidate. Combined with AbsentIncrementGate, that's a real-time floor (3 increments >= 6h
+    // apart => absence sustained >= ~12h), long enough to ride out maintenance windows and to keep
+    // a transit provider's brief drain from confirming.
     private const int RemovalConfirmRuns = 3;
 
+    // Per-ASN minimum time between miss-counter increments. A completed run that finds an ASN still
+    // absent but within this window of its last increment HOLDS the count instead of advancing, so
+    // rapid manual traces (or a tight recheck) can't stack the counter - absence has to persist
+    // across real time, not just across runs. Kept in step with PendingRecheckInterval so scheduled
+    // rechecks reliably clear the gate.
+    private static readonly TimeSpan AbsentIncrementGate = TimeSpan.FromHours(6);
+
     // While a removal counter is pending (some ASN currently absent), re-check on this shorter
-    // cadence instead of the full threshold, so a real removal confirms in ~3 days rather than
-    // ~3 weeks and a transient miss clears the next day.
-    private static readonly TimeSpan PendingRecheckInterval = TimeSpan.FromHours(24);
+    // cadence instead of the full threshold, so a real removal confirms in ~12-18h rather than
+    // ~3 weeks and a transient miss clears quickly. Matched to AbsentIncrementGate so each recheck
+    // lands just past the gate and actually advances the counter.
+    private static readonly TimeSpan PendingRecheckInterval = TimeSpan.FromHours(6);
 
     private readonly IDbContextFactory<NetworkOptimizerDbContext> _dbFactory;
     private readonly NetworkOptimizer.Storage.Services.SiteDbContextFactory _siteDbFactory;
@@ -123,28 +133,17 @@ public class UpstreamRediscoveryService : BackgroundService
             return;
         }
 
-        // Compare on a stable upstream-ASN identity scoped to the WAN this run discovered.
-        // A run never writes MonitoringTargets (commit only happens on user review), so the
-        // committed views are read here, where State.WanInterface is known.
-        var wanInterface = tracer.State.WanInterface ?? "wan";
-        var (monitoredAsns, autoEnabledAsns) = await BuildCommittedViewsAsync(db, wanInterface, ct);
-        var candidate = BuildCandidateSignature(tracer.State);
+        // The tracer already ran the shared post-run evaluation when the run settled in
+        // ReviewingResults - it does the same for manually-started runs, so the absence counters
+        // advance exactly once per completed run regardless of who initiated it. Read the staged
+        // outcome here.
+        var added = tracer.State.DiscoveryAddedAsns;
+        var removedToPause = tracer.State.RemovedTransitAsns;
+        var ispChange = tracer.State.IspChange;
 
-        var priorMissCounts = await LoadMissCountsAsync(db, wanInterface, ct);
-        var eval = EvaluateChange(monitoredAsns, autoEnabledAsns, candidate, priorMissCounts, RemovalConfirmRuns);
-
-        // Removed-detection is persistence-gated: an ASN must be absent from RemovalConfirmRuns
-        // runs in a row before it's confirmed removed, so a single incomplete/degraded run only
-        // bumps a counter that resets the moment the ASN reappears.
-        var confirmedRemoved = eval.RemovalCandidates;
-
-        // Persist the updated counters (upserted into the same SaveChanges below). The map only
-        // holds currently-absent ASNs, so reappeared/removed ones are pruned by omission.
-        await SaveMissCountsAsync(db, wanInterface, eval.NewMissCounts, ct);
-
-        if (eval.Added.Count == 0 && confirmedRemoved.Count == 0)
+        if (added.Count == 0 && removedToPause.Count == 0 && ispChange == null)
         {
-            _logger.LogInformation("Re-discovery matched committed ASNs (no change); rolling forward LastUpstreamDiscoveryAt");
+            _logger.LogInformation("Re-discovery matched committed ASNs (no actionable change); rolling forward LastUpstreamDiscoveryAt");
             settings.LastUpstreamDiscoveryAt = DateTime.UtcNow;
             settings.UpdatedAt = DateTime.UtcNow;
             await db.SaveChangesAsync(ct);
@@ -153,8 +152,9 @@ public class UpstreamRediscoveryService : BackgroundService
             return;
         }
 
-        _logger.LogInformation("Re-discovery found upstream changes; flagging for review. Added: [{Added}] Removed: [{Removed}]",
-            string.Join(", ", eval.Added), string.Join(", ", confirmedRemoved));
+        _logger.LogInformation("Re-discovery found upstream changes; flagging for review. Added: [{Added}] Off-path (to pause): [{Removed}] ISP change: {IspChange}",
+            string.Join(", ", added), string.Join(", ", removedToPause.Select(r => $"AS{r.AsnNumber}")),
+            ispChange == null ? "none" : $"AS{ispChange.OldAsnNumber} -> AS{ispChange.NewAsnNumber}");
 
         settings.UpstreamDiscoveryNeedsReview = true;
         settings.UpdatedAt = DateTime.UtcNow;
@@ -167,7 +167,15 @@ public class UpstreamRediscoveryService : BackgroundService
     internal sealed record ChangeEvaluation(
         List<string> Added,
         List<string> RemovalCandidates,
-        Dictionary<string, int> NewMissCounts);
+        Dictionary<string, MissRecord> NewMisses);
+
+    /// <summary>
+    /// A per-ASN absence counter: the consecutive-miss <paramref name="Count"/> plus
+    /// <paramref name="LastIncrementUtc"/>, the time it last advanced, so the increment can be
+    /// time-gated (at most once per <see cref="AbsentIncrementGate"/>). Legacy stored counters
+    /// (a bare int) load with <see cref="DateTime.MinValue"/>, i.e. immediately gate-eligible.
+    /// </summary>
+    internal readonly record struct MissRecord(int Count, DateTime LastIncrementUtc);
 
     /// <summary>
     /// Two committed views, both keyed on the stable ASN identity (see IdentityKey):
@@ -176,13 +184,17 @@ public class UpstreamRediscoveryService : BackgroundService
     /// auto-discovered (DirectRouter/PathProxy/L2Neighbor) on this WAN, plus all UserProvided
     /// (WAN-agnostic, since a hand-added Cogent may carry an empty/other WanInterface). Discovery
     /// finding one of these is not "added".</item>
-    /// <item><b>AutoEnabled</b> (removed-eligibility): enabled, auto-discovered ASNs on this WAN.
-    /// Only these are eligible to be flagged "removed" - UserProvided and disabled targets are
-    /// excluded so a curated or intentionally-off target never nags.</item>
+    /// <item><b>RemovalEligible</b> (removed-eligibility): ASNs auto-discovered
+    /// (DirectRouter/PathProxy/L2Neighbor) on this WAN at some point - enabled OR NOT, since a
+    /// flaky auto target the user paused must stay eligible so its dangling hand-added siblings
+    /// get caught when the ASN goes dark - that still have at least one enabled target row
+    /// (auto on this WAN or UserProvided on any WAN). A fully-disabled ASN has nothing to pause,
+    /// so counting it would only pin the recheck cadence; a manual-only ASN carries no auto
+    /// evidence, so we can't conclude it's off-path.</item>
     /// </list>
     /// Both are reachability-independent (no relation to whether a hop answered ping this run).
     /// </summary>
-    internal static async Task<(HashSet<string> Monitored, HashSet<string> AutoEnabled)> BuildCommittedViewsAsync(
+    internal static async Task<(HashSet<string> Monitored, HashSet<string> RemovalEligible)> BuildCommittedViewsAsync(
         NetworkOptimizerDbContext db, string wanInterface, CancellationToken ct)
     {
         var rows = await db.MonitoringTargets
@@ -195,75 +207,403 @@ public class UpstreamRediscoveryService : BackgroundService
             .ToListAsync(ct);
 
         var monitored = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var autoEnabled = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var autoEvidence = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var hasEnabledRow = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var t in rows)
         {
             var key = IdentityKey(t.TargetType, t.AsnNumber, t.Address);
             monitored.Add(key);
-            if (t.Enabled && t.WanInterface == wanInterface
+            if (t.WanInterface == wanInterface
                 && (t.DiscoveryMethod == DiscoveryMethod.DirectRouter
                     || t.DiscoveryMethod == DiscoveryMethod.PathProxy
                     || t.DiscoveryMethod == DiscoveryMethod.L2Neighbor))
-                autoEnabled.Add(key);
+                autoEvidence.Add(key);
+            if (t.Enabled)
+                hasEnabledRow.Add(key);
         }
-        return (monitored, autoEnabled);
+        var removalEligible = new HashSet<string>(autoEvidence, StringComparer.OrdinalIgnoreCase);
+        removalEligible.IntersectWith(hasEnabledRow);
+        return (monitored, removalEligible);
     }
 
     /// <summary>
     /// Pure change-detection. Added = discovered ASNs not already monitored (flag now). Missing =
-    /// removal-eligible ASNs absent this run; each bumps a consecutive-miss counter and only
-    /// becomes a removal candidate once it reaches <paramref name="removalThreshold"/> runs. The
-    /// returned counter map holds only currently-absent ASNs, so reappeared ones reset by omission.
+    /// removal-eligible ASNs absent this run; each bumps a consecutive-miss counter, but only when
+    /// it's been at least <paramref name="incrementGate"/> since that ASN last incremented (a
+    /// too-soon miss holds the count and its timestamp, so absence must persist across real time,
+    /// not just across runs). An ASN becomes a removal candidate once its count reaches
+    /// <paramref name="removalThreshold"/> - a confirmed ASN that's gated this run stays a
+    /// candidate. The returned map holds only currently-absent ASNs, so reappeared ones reset by
+    /// omission. <paramref name="nowUtc"/> is passed in so this stays pure and deterministic.
     /// </summary>
     internal static ChangeEvaluation EvaluateChange(
         HashSet<string> monitoredAsns,
-        HashSet<string> autoEnabledAsns,
+        HashSet<string> removalEligibleAsns,
         HashSet<string> candidate,
-        IReadOnlyDictionary<string, int> priorMissCounts,
+        IReadOnlyDictionary<string, MissRecord> priorMisses,
+        DateTime nowUtc,
+        TimeSpan incrementGate,
         int removalThreshold)
     {
         var added = candidate.Except(monitoredAsns).OrderBy(x => x).ToList();
 
-        var newCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var newMisses = new Dictionary<string, MissRecord>(StringComparer.OrdinalIgnoreCase);
         var removalCandidates = new List<string>();
-        foreach (var key in autoEnabledAsns)
+        foreach (var key in removalEligibleAsns)
         {
             if (candidate.Contains(key)) continue; // present this run - counter resets (omitted)
-            var count = (priorMissCounts.TryGetValue(key, out var prev) ? prev : 0) + 1;
-            newCounts[key] = count;
+            var hadPrior = priorMisses.TryGetValue(key, out var prior);
+            int count;
+            DateTime lastIncrement;
+            if (hadPrior && nowUtc - prior.LastIncrementUtc < incrementGate)
+            {
+                // Gated: absent again, but too soon since the last increment - hold as-is.
+                count = prior.Count;
+                lastIncrement = prior.LastIncrementUtc;
+            }
+            else
+            {
+                count = (hadPrior ? prior.Count : 0) + 1;
+                lastIncrement = nowUtc;
+            }
+            newMisses[key] = new MissRecord(count, lastIncrement);
             if (count >= removalThreshold) removalCandidates.Add(key);
         }
         removalCandidates.Sort(StringComparer.OrdinalIgnoreCase);
-        return new ChangeEvaluation(added, removalCandidates, newCounts);
+        return new ChangeEvaluation(added, removalCandidates, newMisses);
+    }
+
+    /// <summary>
+    /// Shared post-run change evaluation, called by the tracer whenever a discovery run settles
+    /// in ReviewingResults - scheduled AND manually-started runs alike, so removal evidence
+    /// accumulates the same regardless of who initiated the run. Bumps the per-WAN miss counters
+    /// (time-gated: at most one increment per ASN per AbsentIncrementGate, so rapid manual traces
+    /// can't stack them), prunes confirmations with no pause action, persists the counters, and
+    /// stages the added keys plus the confirmed off-path transit ASNs on the tracer state for the
+    /// review UI and the scheduler's gate. Removed-detection stays persistence-gated: a single
+    /// incomplete/degraded run only bumps a counter that resets the moment the ASN reappears.
+    /// </summary>
+    internal static async Task EvaluateCompletedRunAsync(
+        NetworkOptimizerDbContext db, UpstreamTracerState state, CancellationToken ct)
+    {
+        var wanInterface = state.WanInterface ?? "wan";
+        var (monitoredAsns, removalEligibleAsns) = await BuildCommittedViewsAsync(db, wanInterface, ct);
+        var candidate = BuildCandidateSignature(state);
+
+        // A changed access ISP supersedes per-transit off-path handling: the whole upstream path
+        // is replaced at once, so staging N individual transit removals alongside would be noise.
+        // Stage only the ISP-change question (plus the added keys for the scheduler's gate) and
+        // leave the miss counters frozen - a confirm wipes them wholesale, and a decline lets the
+        // next unchanged run resume advancing them normally. No multi-run miss-gate here: the
+        // access ASN is the stable first hop and the event is user-confirmed, so one run with a
+        // valid different ASN is enough to prompt.
+        state.IspChange = await DetectAccessIspChangeAsync(db, wanInterface, state, ct);
+        if (state.IspChange != null)
+        {
+            state.DiscoveryAddedAsns = candidate.Except(monitoredAsns).OrderBy(x => x).ToList();
+            state.RemovedTransitAsns = new();
+            state.PendingRemovalTransitAsns = new();
+            return;
+        }
+
+        var priorMisses = await LoadMissCountsAsync(db, wanInterface, ct);
+        var eval = EvaluateChange(monitoredAsns, removalEligibleAsns, candidate, priorMisses,
+            DateTime.UtcNow, AbsentIncrementGate, RemovalConfirmRuns);
+
+        var removedToPause = await BuildRemovedTransitAsnsAsync(db, wanInterface, eval.RemovalCandidates, ct);
+
+        // Confirmed keys with no pause action (access/path tiers, which this detector doesn't act
+        // on) must not keep a counter pinned at the threshold: any non-null counter map holds
+        // pendingRecheck on, which would lock the site into the recheck cadence forever. Prune them
+        // so the evidence re-accumulates instead.
+        var actionable = new HashSet<string>(
+            removedToPause.Select(r => "transit:as" + r.AsnNumber), StringComparer.OrdinalIgnoreCase);
+        foreach (var key in eval.RemovalCandidates)
+            if (!actionable.Contains(key)) eval.NewMisses.Remove(key);
+
+        // The map only holds currently-absent ASNs, so reappeared/removed ones prune by omission.
+        await SaveMissCountsAsync(db, wanInterface, eval.NewMisses, ct);
+        await db.SaveChangesAsync(ct);
+
+        // Transit ASNs absent this run but still below the confirm threshold: surface them read-only
+        // in the review as "tracking toward removal" so the detection isn't invisible until it
+        // suddenly confirms. Pending and confirmed are mutually exclusive (one count per key), and
+        // an eligible ASN always has >=1 enabled target, so BuildRemovedTransitAsnsAsync resolves a
+        // target count for each. RunsRemaining is remaining gated increments; each is >= the gate
+        // apart, so it's also a rough remaining-time floor.
+        var pendingKeys = eval.NewMisses
+            .Where(kv => kv.Value.Count < RemovalConfirmRuns
+                && kv.Key.StartsWith("transit:as", StringComparison.OrdinalIgnoreCase))
+            .Select(kv => kv.Key)
+            .ToList();
+        var pendingInfo = await BuildRemovedTransitAsnsAsync(db, wanInterface, pendingKeys, ct);
+        var pending = pendingInfo
+            .Select(r => new PendingRemovalTransitAsn
+            {
+                AsnNumber = r.AsnNumber,
+                AsnName = r.AsnName,
+                TargetCount = r.TargetCount,
+                ManualCount = r.ManualCount,
+                MissCount = eval.NewMisses["transit:as" + r.AsnNumber].Count,
+                RunsRemaining = RemovalConfirmRuns - eval.NewMisses["transit:as" + r.AsnNumber].Count,
+            })
+            .OrderBy(p => p.AsnNumber)
+            .ToList();
+
+        state.DiscoveryAddedAsns = eval.Added;
+        state.RemovedTransitAsns = removedToPause;
+        state.PendingRemovalTransitAsns = pending;
+    }
+
+    /// <summary>
+    /// Maps confirmed-removed identity keys to review entries: <c>transit:as{n}</c> keys only,
+    /// resolved to the enabled Transit targets that would be paused - auto targets scoped to this
+    /// WAN, UserProvided targets matched by ASN regardless of WAN (hand-added rows are
+    /// WAN-agnostic). An ASN with nothing enabled yields no entry (nothing to do, no nag).
+    /// </summary>
+    internal static async Task<List<RemovedTransitAsn>> BuildRemovedTransitAsnsAsync(
+        NetworkOptimizerDbContext db, string wanInterface, IReadOnlyList<string> confirmedRemoved, CancellationToken ct)
+    {
+        var asns = new List<int>();
+        foreach (var key in confirmedRemoved)
+        {
+            if (!key.StartsWith("transit:as", StringComparison.OrdinalIgnoreCase)) continue;
+            if (int.TryParse(key.AsSpan("transit:as".Length), out var asn)) asns.Add(asn);
+        }
+        if (asns.Count == 0) return new();
+
+        var targets = await db.MonitoringTargets
+            .Where(t => t.TargetType == MonitoringTargetType.Transit && t.Enabled
+                && t.AsnNumber != null && asns.Contains(t.AsnNumber.Value)
+                && (t.DiscoveryMethod == DiscoveryMethod.UserProvided || t.WanInterface == wanInterface))
+            .Select(t => new { t.AsnNumber, t.AsnName, t.DiscoveryMethod })
+            .ToListAsync(ct);
+
+        return targets
+            .GroupBy(t => t.AsnNumber!.Value)
+            .Select(g => new RemovedTransitAsn
+            {
+                AsnNumber = g.Key,
+                AsnName = g.Select(x => x.AsnName).FirstOrDefault(n => !string.IsNullOrEmpty(n)) ?? $"AS{g.Key}",
+                TargetCount = g.Count(),
+                ManualCount = g.Count(x => x.DiscoveryMethod == DiscoveryMethod.UserProvided),
+                Keep = false,
+            })
+            .OrderBy(r => r.AsnNumber)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Detects a candidate access-ISP change for the run: every access ASN this run resolved is
+    /// different from every access ASN committed for the WAN. Guards: a run that failed to
+    /// attribute any access ASN never triggers (null/unresolved is not a change); no committed
+    /// auto-discovered access ASN means there's no baseline to differ from (first run); any
+    /// overlap between the two sets means the provider is unchanged; and a new primary ASN the
+    /// user already declined is suppressed. Returns the staged candidate with the reset scope
+    /// pre-counted for the review, or null.
+    /// </summary>
+    internal static async Task<IspChangeCandidate?> DetectAccessIspChangeAsync(
+        NetworkOptimizerDbContext db, string wanInterface, UpstreamTracerState state, CancellationToken ct)
+    {
+        var newAsns = state.AccessHops
+            .Where(h => h.AsnNumber.HasValue)
+            .Select(h => h.AsnNumber!.Value)
+            .ToList();
+        if (newAsns.Count == 0) return null;
+
+        // The stored access ISP: auto-discovered AccessIsp rows on this WAN, enabled or not - a
+        // paused access target still records who the provider was. UserProvided rows are excluded
+        // since a hand-added access target carries no discovery evidence of the provider.
+        var oldRows = await db.MonitoringTargets
+            .Where(t => t.TargetType == MonitoringTargetType.AccessIsp
+                && t.WanInterface == wanInterface
+                && t.AsnNumber != null
+                && t.DiscoveryMethod != DiscoveryMethod.UserProvided)
+            .Select(t => new { t.AsnNumber, t.AsnName })
+            .ToListAsync(ct);
+        if (oldRows.Count == 0) return null;
+
+        var oldSet = oldRows.Select(r => r.AsnNumber!.Value).ToHashSet();
+        if (newAsns.Any(oldSet.Contains)) return null;
+
+        var newPrimary = newAsns
+            .GroupBy(a => a)
+            .OrderByDescending(g => g.Count()).ThenBy(g => newAsns.IndexOf(g.Key))
+            .First().Key;
+
+        var declinedRow = await db.SystemSettings.AsNoTracking()
+            .FirstOrDefaultAsync(s => s.Key == DeclinedAccessAsnKey(wanInterface), ct);
+        if (int.TryParse(declinedRow?.Value, out var declinedAsn) && declinedAsn == newPrimary)
+            return null;
+
+        var oldPrimary = oldRows
+            .GroupBy(r => r.AsnNumber!.Value)
+            .OrderByDescending(g => g.Count()).ThenBy(g => g.Key)
+            .First().Key;
+        var oldName = oldRows.Where(r => r.AsnNumber == oldPrimary)
+            .Select(r => r.AsnName).FirstOrDefault(n => !string.IsNullOrEmpty(n)) ?? $"AS{oldPrimary}";
+        var newName = state.AccessHops
+            .Where(h => h.AsnNumber == newPrimary)
+            .Select(h => h.AsnName).FirstOrDefault(n => !string.IsNullOrEmpty(n)) ?? $"AS{newPrimary}";
+
+        var scope = await LoadIspResetScopeAsync(db, wanInterface, ct);
+        return new IspChangeCandidate
+        {
+            OldAsnNumber = oldPrimary,
+            OldAsnName = oldName,
+            NewAsnNumber = newPrimary,
+            NewAsnName = newName,
+            TargetCount = scope.Count,
+            ManualCount = scope.Count(t => t.DiscoveryMethod == DiscoveryMethod.UserProvided),
+        };
+    }
+
+    /// <summary>
+    /// The targets a confirmed ISP-change reset pauses: every enabled upstream monitoring target
+    /// for the connection across all three tiers (access, transit, path-proxy). Auto-discovered
+    /// rows are scoped to this WAN; UserProvided rows count when assigned to this WAN or to no
+    /// WAN (hand-added rows are often WAN-agnostic), so a reset on one WAN never touches manual
+    /// targets pinned to another.
+    /// </summary>
+    internal static Task<List<MonitoringTarget>> LoadIspResetScopeAsync(
+        NetworkOptimizerDbContext db, string wanInterface, CancellationToken ct) =>
+        db.MonitoringTargets
+            .Where(t => t.Enabled
+                && (t.TargetType == MonitoringTargetType.AccessIsp
+                    || t.TargetType == MonitoringTargetType.Transit
+                    || t.TargetType == MonitoringTargetType.InternetService)
+                && (t.DiscoveryMethod == DiscoveryMethod.UserProvided
+                    ? (t.WanInterface == wanInterface || t.WanInterface == null || t.WanInterface == "")
+                    : t.WanInterface == wanInterface))
+            .ToListAsync(ct);
+
+    /// <summary>
+    /// Applies a confirmed ISP change for the WAN: pauses (Enabled = false, never deletes) every
+    /// target in the reset scope, wipes the WAN's absent-ASN miss counters (they described the
+    /// old provider's path), and clears any recorded decline. The caller then commits the fresh
+    /// candidates as the new baseline. Does not SaveChanges; the caller's does. Returns how many
+    /// targets were paused.
+    /// </summary>
+    internal static async Task<int> ApplyIspChangeResetAsync(
+        NetworkOptimizerDbContext db, string wanInterface, CancellationToken ct)
+    {
+        var stale = await LoadIspResetScopeAsync(db, wanInterface, ct);
+        foreach (var t in stale) t.Enabled = false;
+
+        await SaveMissCountsAsync(db, wanInterface, new(StringComparer.OrdinalIgnoreCase), ct);
+
+        var declined = await db.SystemSettings
+            .FirstOrDefaultAsync(s => s.Key == DeclinedAccessAsnKey(wanInterface), ct);
+        if (declined != null)
+        {
+            declined.Value = null;
+            declined.UpdatedAt = DateTime.UtcNow;
+        }
+        return stale.Count;
+    }
+
+    /// <summary>
+    /// Records a declined ISP change: the user said the new access ASN is not a provider switch,
+    /// so detection suppresses that ASN for the WAN instead of re-prompting every run. Does not
+    /// SaveChanges; the caller's does.
+    /// </summary>
+    internal static async Task RecordDeclinedIspChangeAsync(
+        NetworkOptimizerDbContext db, string wanInterface, int declinedNewAsn, CancellationToken ct)
+    {
+        var key = DeclinedAccessAsnKey(wanInterface);
+        var row = await db.SystemSettings.FirstOrDefaultAsync(s => s.Key == key, ct);
+        if (row == null)
+        {
+            db.SystemSettings.Add(new SystemSetting
+            {
+                Key = key,
+                Value = declinedNewAsn.ToString(),
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            });
+        }
+        else
+        {
+            row.Value = declinedNewAsn.ToString();
+            row.UpdatedAt = DateTime.UtcNow;
+        }
+    }
+
+    private static string DeclinedAccessAsnKey(string wanInterface) =>
+        SystemSettingKeys.UpstreamDeclinedAccessAsnPrefix + wanInterface;
+
+    /// <summary>
+    /// Removes the given identity keys from the WAN's absent-ASN miss counters. Called by commit
+    /// for the surfaced off-path ASNs: a kept ASN would otherwise still sit at the confirm
+    /// threshold and re-flag review on the very next daily recheck - clearing it makes the
+    /// evidence re-accumulate from zero instead. Does not SaveChanges; the caller's does.
+    /// </summary>
+    internal static async Task ClearMissCountKeysAsync(
+        NetworkOptimizerDbContext db, string wanInterface, IEnumerable<string> keys, CancellationToken ct)
+    {
+        var misses = await LoadMissCountsAsync(db, wanInterface, ct);
+        var removed = false;
+        foreach (var key in keys)
+            removed |= misses.Remove(key);
+        if (removed)
+            await SaveMissCountsAsync(db, wanInterface, misses, ct);
     }
 
     private static string MissCountsKey(string wanInterface) =>
         SystemSettingKeys.UpstreamAbsentAsnCountsPrefix + wanInterface;
 
-    private static async Task<Dictionary<string, int>> LoadMissCountsAsync(
+    /// <summary>
+    /// Loads the per-WAN absent-ASN counters. The stored value is a JSON map of identity key to
+    /// <c>{"c":count,"t":lastIncrementUtc}</c>. Legacy values (a bare int per key, from before the
+    /// increment gate) parse with <see cref="DateTime.MinValue"/> so they're immediately
+    /// gate-eligible on the next run - no migration needed.
+    /// </summary>
+    private static async Task<Dictionary<string, MissRecord>> LoadMissCountsAsync(
         NetworkOptimizerDbContext db, string wanInterface, CancellationToken ct)
     {
+        var result = new Dictionary<string, MissRecord>(StringComparer.OrdinalIgnoreCase);
         var row = await db.SystemSettings.FirstOrDefaultAsync(s => s.Key == MissCountsKey(wanInterface), ct);
-        if (string.IsNullOrEmpty(row?.Value)) return new(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrEmpty(row?.Value)) return result;
         try
         {
-            var map = JsonSerializer.Deserialize<Dictionary<string, int>>(row.Value);
-            return map == null ? new(StringComparer.OrdinalIgnoreCase) : new(map, StringComparer.OrdinalIgnoreCase);
+            using var doc = JsonDocument.Parse(row.Value);
+            foreach (var prop in doc.RootElement.EnumerateObject())
+            {
+                if (prop.Value.ValueKind == JsonValueKind.Number)
+                {
+                    // Legacy {key:int}: no timestamp recorded, so treat as long-ago (not gated).
+                    var legacy = prop.Value.GetInt32();
+                    if (legacy > 0) result[prop.Name] = new MissRecord(legacy, DateTime.MinValue);
+                }
+                else if (prop.Value.ValueKind == JsonValueKind.Object)
+                {
+                    var count = prop.Value.TryGetProperty("c", out var c) ? c.GetInt32() : 0;
+                    var when = prop.Value.TryGetProperty("t", out var t) && t.TryGetDateTime(out var dt)
+                        ? DateTime.SpecifyKind(dt, DateTimeKind.Utc)
+                        : DateTime.MinValue;
+                    if (count > 0) result[prop.Name] = new MissRecord(count, when);
+                }
+            }
         }
         catch
         {
             return new(StringComparer.OrdinalIgnoreCase);
         }
+        return result;
     }
 
     /// <summary>Upserts the counter map into the SystemSetting row. Does not SaveChanges - the
     /// caller's SaveChanges persists it alongside the settings update.</summary>
     private static async Task SaveMissCountsAsync(
-        NetworkOptimizerDbContext db, string wanInterface, Dictionary<string, int> counts, CancellationToken ct)
+        NetworkOptimizerDbContext db, string wanInterface, Dictionary<string, MissRecord> misses, CancellationToken ct)
     {
         var key = MissCountsKey(wanInterface);
         var row = await db.SystemSettings.FirstOrDefaultAsync(s => s.Key == key, ct);
-        var value = counts.Count == 0 ? null : JsonSerializer.Serialize(counts);
+        var value = misses.Count == 0
+            ? null
+            : JsonSerializer.Serialize(misses.ToDictionary(
+                kv => kv.Key,
+                kv => new { c = kv.Value.Count, t = kv.Value.LastIncrementUtc }));
         if (row == null)
         {
             if (value == null) return;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -231,7 +231,7 @@ public class UpstreamTracerService
             // keeps the scheduled run 1:1 with a user-initiated run.
             var preservedTech = State.AccessTechnology;
             if (preservedTech == AccessTechnology.Unknown)
-                preservedTech = await LoadPersistedAccessTechnologyAsync(ct);
+                preservedTech = await LoadPersistedAccessTechnologyAsync(State.WanInterface, ct);
             State = new UpstreamTracerState
             {
                 Step = TracerStep.DetectingPublicIp,
@@ -251,20 +251,39 @@ public class UpstreamTracerService
     public Task WaitForCompletionAsync() => _runningTask ?? Task.CompletedTask;
 
     /// <summary>
-    /// Reads the most-recently-discovered WAN's saved access technology from the DB.
-    /// Fallback for when a run starts (notably the background re-discovery scheduler)
-    /// without the UI having hydrated the in-memory state first. Returns Unknown when
-    /// nothing is persisted yet.
+    /// Reads the saved access technology from the DB. Fallback for when a run starts
+    /// (notably the background re-discovery scheduler) without the UI having hydrated
+    /// the in-memory state first. The technology is per-WAN, so the traced WAN's own
+    /// context row wins when <paramref name="wanInterface"/> is known; otherwise (and
+    /// when that row has nothing set) any row with a known technology is used,
+    /// recency-ordered - the old "most recent row, whatever it holds" pick returned
+    /// Unknown on multi-WAN installs whenever a different WAN's row was fresher, which
+    /// mislabeled the first-mile device (e.g. "cisco-access" instead of "cisco-olt" on
+    /// a saved-GPON install). Last resort is the legacy single-WAN
+    /// MonitoringSettings.AccessTechnology from installs that predate per-WAN contexts.
+    /// Returns Unknown when nothing is persisted anywhere.
     /// </summary>
-    private async Task<AccessTechnology> LoadPersistedAccessTechnologyAsync(CancellationToken ct)
+    private async Task<AccessTechnology> LoadPersistedAccessTechnologyAsync(string? wanInterface, CancellationToken ct)
     {
         try
         {
             await using var db = await CreateDbAsync(ct);
-            var ctx = await db.WanDiscoveryContexts
+            var contexts = await db.WanDiscoveryContexts.AsNoTracking().ToListAsync(ct);
+
+            var own = contexts.FirstOrDefault(c =>
+                wanInterface != null &&
+                string.Equals(c.WanInterface, wanInterface, StringComparison.OrdinalIgnoreCase));
+            if (own != null && own.AccessTechnology != AccessTechnology.Unknown)
+                return own.AccessTechnology;
+
+            var known = contexts
+                .Where(c => c.AccessTechnology != AccessTechnology.Unknown)
                 .OrderByDescending(c => c.LastDiscoveryAt ?? c.UpdatedAt)
-                .FirstOrDefaultAsync(ct);
-            return ctx?.AccessTechnology ?? AccessTechnology.Unknown;
+                .FirstOrDefault();
+            if (known != null) return known.AccessTechnology;
+
+            var settings = await db.MonitoringSettings.AsNoTracking().FirstOrDefaultAsync(ct);
+            return settings?.AccessTechnology ?? AccessTechnology.Unknown;
         }
         catch (Exception ex)
         {
@@ -291,6 +310,11 @@ public class UpstreamTracerService
         try
         {
             if (!await DetectPublicIpAsync(ct)) return;
+            // The access technology is stored per-WAN; the pre-run load couldn't key on
+            // the WAN yet. Now that detection resolved which WAN we're tracing, retry
+            // against its own context row before any technology-driven labeling runs.
+            if (State.AccessTechnology == AccessTechnology.Unknown)
+                State.AccessTechnology = await LoadPersistedAccessTechnologyAsync(State.WanInterface, ct);
             if (!await DiscoverL2NeighborAsync(ct)) return;
             await TraceAccessIspAsync(ct);
             await TraceTransitAsnsAsync(ct);
@@ -544,8 +568,6 @@ public class UpstreamTracerService
         //  1) port_table.uplink_ifname - UniFi's kernel device name for
         //     the uplink, correct for VLAN-tagged sub-interfaces too.
         //  2) `ip -o -4 addr show` line owning the known WAN IP.
-        // No default-route lookup: UniFi gateways run policy routing with
-        // per-WAN tables, so the default isn't in the main table.
         var candidates = new List<string>();
         if (!string.IsNullOrEmpty(_wanUplinkIfName))
         {
@@ -571,6 +593,22 @@ public class UpstreamTracerService
             }
         }
 
+        // The WAN's default gateway from the routing tables. UniFi gateways run policy
+        // routing with per-WAN tables, so the default isn't in the main table - but
+        // `ip route show table all` surfaces every table's default route, and the line
+        // whose dev is our WAN interface names the true next hop. This is authoritative:
+        // on a shared WAN subnet (metro Ethernet, two sites on one carrier segment) the
+        // neighbor table also carries OTHER same-subnet hosts, and heuristic scoring can
+        // pick one of those peers over the actual gateway. We still read the gateway's
+        // MAC from `ip neigh` below - the routing table only supplies WHICH IP to pick.
+        string? routeShowAll = null;
+        {
+            var (routeOk, routeOut) = await _gatewaySsh.RunCommandAsync(
+                "ip route show table all 2>/dev/null | grep '^default' | head -20",
+                TimeSpan.FromSeconds(5), ct);
+            if (routeOk && !string.IsNullOrWhiteSpace(routeOut)) routeShowAll = routeOut;
+        }
+
         string? neighborMac = null;
         string? neighborIp = null;
         string? wanDevice = null;
@@ -582,7 +620,8 @@ public class UpstreamTracerService
             var (ok, output) = await _gatewaySsh.RunCommandAsync(cmd, TimeSpan.FromSeconds(5), ct);
             if (!ok || string.IsNullOrWhiteSpace(output)) continue;
 
-            var selected = SelectWanNeighbor(output, wanCidr);
+            var defaultGatewayIp = SelectWanDefaultGateway(routeShowAll, ifaceCandidate);
+            var selected = SelectWanNeighbor(output, wanCidr, defaultGatewayIp);
             if (selected != null)
             {
                 neighborIp = selected.Value.Ip;
@@ -643,11 +682,33 @@ public class UpstreamTracerService
     }
 
     /// <summary>
+    /// Parses `ip route show table all` output for the default route egressing the given
+    /// WAN interface and returns its gateway ("via") address. UniFi gateways run policy
+    /// routing, so each WAN's default lives in its own table (`default via 203.0.113.1
+    /// dev eth8 table 201 ...`); matching on the dev finds ours regardless of table
+    /// number. Returns the first match (multiple tables for one WAN name the same next
+    /// hop). On-link defaults without a `via` (PPPoE's `default dev ppp0 scope link`)
+    /// yield null - there's no gateway address, and no MAC to look up either.
+    /// </summary>
+    internal static string? SelectWanDefaultGateway(string? routeShowAllOutput, string wanIface)
+    {
+        if (string.IsNullOrWhiteSpace(routeShowAllOutput) || string.IsNullOrEmpty(wanIface)) return null;
+        var m = Regex.Match(routeShowAllOutput,
+            @"^default\s+via\s+(?<gw>\d{1,3}(?:\.\d{1,3}){3})\s+dev\s+" + Regex.Escape(wanIface) + @"(\s|$)",
+            RegexOptions.Multiline);
+        return m.Success ? m.Groups["gw"].Value : null;
+    }
+
+    /// <summary>
     /// Picks the WAN-side L2 neighbor from `ip neigh show dev &lt;wan&gt;` output. A CPE
     /// bridged in front of the gateway (an ISP modem/router in passthrough) lists both
     /// its LAN-side RFC1918 address and the carrier-side address under the same MAC;
     /// the LAN-side entry often sorts first, and taking the first lladdr line mislabeled
-    /// a private CPE IP as an ISP hop. Preference order: in the WAN subnet (the real
+    /// a private CPE IP as an ISP hop. When the WAN's routed default gateway is known
+    /// (from <see cref="SelectWanDefaultGateway"/>) its entry wins outright - on a shared
+    /// WAN subnet the neighbor table also lists unrelated same-subnet hosts (another
+    /// site's gateway on the same carrier segment), and no heuristic can rank those below
+    /// the true next hop reliably. Otherwise preference order: in the WAN subnet (the real
     /// ISP-side gateway is by definition on-link with our WAN IP) &gt; address class
     /// (public &gt; CGNAT &gt; private) &gt; freshness (REACHABLE/DELAY/PROBE over STALE).
     /// FAILED and INCOMPLETE entries carry no lladdr and never match. IPv6 link-local
@@ -658,7 +719,9 @@ public class UpstreamTracerService
     /// <param name="ipNeighOutput">Raw `ip neigh show dev &lt;wan&gt;` output.</param>
     /// <param name="wanCidr">The gateway's WAN address in CIDR form (e.g. "203.0.113.5/24")
     /// used to recognize the on-link ISP gateway. Null/empty falls back to class+freshness.</param>
-    public static (string Ip, string Mac)? SelectWanNeighbor(string? ipNeighOutput, string? wanCidr = null)
+    /// <param name="defaultGatewayIp">The WAN's routed default gateway, when known. Its
+    /// neighbor entry is returned outright, bypassing the heuristic scoring.</param>
+    public static (string Ip, string Mac)? SelectWanNeighbor(string? ipNeighOutput, string? wanCidr = null, string? defaultGatewayIp = null)
     {
         if (string.IsNullOrWhiteSpace(ipNeighOutput)) return null;
 
@@ -670,6 +733,10 @@ public class UpstreamTracerService
             var ipText = m.Groups[1].Value;
             if (!System.Net.IPAddress.TryParse(ipText, out var ip)) continue;
             if (ip.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork) continue;
+
+            // The routed next hop IS the first-mile device; no scoring needed.
+            if (defaultGatewayIp != null && string.Equals(ipText, defaultGatewayIp, StringComparison.OrdinalIgnoreCase))
+                return (ipText, m.Groups[2].Value.ToLowerInvariant());
 
             // UniFi's default WAN SLA probe targets keep a neighbor entry on the WAN
             // interface but are public DNS resolvers, never the L2 next hop.
@@ -720,6 +787,18 @@ public class UpstreamTracerService
     // the reachability step can fall back to a curated endpoint even when none of the
     // access hops responded (the access pool can be empty/unreachable yet the ASN known).
     private int? _accessAsn;
+
+    // Cleaned display name for _accessAsn - from its hops' ASN attribution, or from the
+    // WAN IP lookup when the ASN was derived from the WAN address and no hop carries the
+    // name. Used by the curated-fallback injection for labeling.
+    private string? _accessAsnName;
+
+    // Destination (CDN endpoint) ASNs and org names from the rotation, resolved once per
+    // run during the access step (they gate the access-ISP pick) and reused by the transit
+    // step. Transit-probe endpoints are excluded on purpose - their ASN is allowed to
+    // surface as transit.
+    private readonly HashSet<int> _destinationAsns = new();
+    private readonly HashSet<string> _destinationOrgs = new(StringComparer.OrdinalIgnoreCase);
 
     // The 1st/2nd-degree non-access ASNs off each trace (union): the access ISP's
     // direct upstream and that upstream's upstream. A transit-probe ASN (Lumen, AT&T,
@@ -808,11 +887,26 @@ public class UpstreamTracerService
             .Where(h => !_gatewayIps.Contains(h.Address))
             .ToList();
 
-        // Identify the access ISP ASN: the first non-null ASN seen at the lowest hop
-        // numbers across the traces. Hops in private/CGNAT space (Asn == null) are
-        // skipped over; they don't have a public ASN.
-        var firstPublicHop = candidateHops.FirstOrDefault(h => h.Asn != null);
-        var accessAsn = firstPublicHop?.Asn?.Asn;
+        // Resolve the destination (CDN) ASNs up front: the access-ISP pick below must
+        // never crown a probe destination's own ASN, and the transit step reuses the sets.
+        await ResolveDestinationAsnsAsync(ct);
+
+        // The WAN IP's own ASN is the strongest access-ISP signal when the address is
+        // public: it's the ISP's customer allocation, independent of which routers
+        // answer traceroute. ResolveAsync returns null for CGNAT/private WAN addresses.
+        AsnLookup? wanIpAsn = null;
+        if (!string.IsNullOrEmpty(State.WanIpAddress))
+            wanIpAsn = await _asnResolution.ResolveAsync(State.WanIpAddress, ct);
+
+        // Identify the access ISP ASN. The old heuristic ("first hop with a resolvable
+        // ASN across the merged pool") broke on ISPs like Bell Canada (#984) whose entire
+        // first mile is RFC1918 plus public space deliberately NOT announced in BGP: the
+        // first attributable hop was the probed CDN's own edge, and the destination
+        // (Cloudflare) got crowned as the access ISP. DetermineAccessAsn combines the
+        // WAN IP's ASN with per-trace voting instead.
+        var asnByIp = BuildAsnByIpMap();
+        var traceSequences = BuildTraceSequences();
+        var accessAsn = DetermineAccessAsn(traceSequences, asnByIp, wanIpAsn?.Asn, _destinationAsns);
         // Remember it so the reachability step can reach for a curated fallback endpoint
         // even when the access pool ends up empty or entirely unreachable.
         _accessAsn = accessAsn;
@@ -833,6 +927,26 @@ public class UpstreamTracerService
             _accessHopsResolved = candidateHops
                 .TakeWhile(h => h.Asn == null)
                 .ToList();
+        }
+
+        // Unannounced first-mile hops: an ISP like Bell (#984) numbers its aggregation
+        // layer from public or CGNAT space that carries no BGP attribution (Asn == null),
+        // upstream of its announced routers. Any such hop appearing BEFORE the first
+        // access-ASN hop on its own trace sits on the customer side of the ISP's
+        // announced border - it is access infrastructure, positionally attributed.
+        // RFC1918 prefix hops stay excluded (a bridged CPE's LAN address or a double-NAT
+        // middlebox is not ISP infra); the reachability gate later disables any of these
+        // that don't answer ping.
+        if (accessAsn.HasValue)
+        {
+            var alreadyIncluded = new HashSet<string>(
+                _accessHopsResolved.Select(h => h.Address), StringComparer.OrdinalIgnoreCase);
+            var unannounced = CollectUnannouncedAccessAddresses(traceSequences, asnByIp, accessAsn.Value)
+                .Where(a => !alreadyIncluded.Contains(a) && !_gatewayIps.Contains(a) && byIp.ContainsKey(a))
+                .Select(a => byIp[a])
+                .OrderBy(h => h.HopNumber)
+                .ToList();
+            _accessHopsResolved = unannounced.Concat(_accessHopsResolved).ToList();
         }
 
         // Walk each individual trace to find border hops: an access-ASN hop
@@ -863,7 +977,12 @@ public class UpstreamTracerService
             }
         }
 
-        var orgName = CleanAsnName(firstPublicHop?.Asn?.Name);
+        // Access org display name: from an attributed access hop when one exists, else
+        // from the WAN IP lookup (a fully silent/unannounced first mile still labels).
+        var accessAsnRawName = _accessHopsResolved.FirstOrDefault(h => h.Asn != null)?.Asn?.Name
+                               ?? (accessAsn.HasValue && accessAsn.Value == wanIpAsn?.Asn ? wanIpAsn.Name : null);
+        var orgName = CleanAsnName(accessAsnRawName);
+        _accessAsnName = string.IsNullOrEmpty(orgName) ? null : orgName;
         State.AccessHops = _accessHopsResolved.Select(h => new AccessHopCandidate
         {
             TargetId = $"access-{NormalizeMacForId(h.Address)}",
@@ -960,6 +1079,7 @@ public class UpstreamTracerService
         var accessAsnNumbers = new HashSet<int>(_accessHopsResolved
             .Where(h => h.Asn != null)
             .Select(h => h.Asn!.Asn));
+        if (_accessAsn.HasValue) accessAsnNumbers.Add(_accessAsn.Value);
 
         // Also drop any ASN that's a CDN destination - the CDN's own edge routers
         // respond to traceroute from inside the CDN's ASN, so without this filter
@@ -973,16 +1093,8 @@ public class UpstreamTracerService
         // the same org get excluded (e.g. probing Microsoft 13.107.42.14 lives
         // in AS8068 but the trace traverses Microsoft's AS8075 backbone too -
         // both are Microsoft, neither belongs in the transit list).
-        var destinationAsns = new HashSet<int>();
-        var destinationOrgs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var endpoint in CdnRotation)
-        {
-            if (endpoint.IsTransitProbe) continue;
-            var destAsn = await _asnResolution.ResolveAsync(endpoint.Address, ct);
-            if (destAsn == null) continue;
-            destinationAsns.Add(destAsn.Asn);
-            if (!string.IsNullOrWhiteSpace(destAsn.Name)) destinationOrgs.Add(destAsn.Name.Trim());
-        }
+        var destinationAsns = _destinationAsns;
+        var destinationOrgs = _destinationOrgs;
 
         // Also exclude the transit-probe endpoints themselves from the hop pool.
         // Their job is to force the path through a specific ASN so real transit
@@ -1014,16 +1126,8 @@ public class UpstreamTracerService
         // heterogeneous traces, so a multi-homed access ISP's other upstreams (or a
         // near probe endpoint) can occupy the global "first two" slots at a lower hop
         // number and crowd out a genuine direct upstream.
-        var asnByIp = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-        foreach (var h in _mergedHops)
-            if (h.Asn != null) asnByIp.TryAdd(h.Address, h.Asn.Asn);
-        var traceSequences = _lastTraces
-            .Select(t => (IReadOnlyList<string>)t.Hops
-                .Where(hp => hp.Responded && !string.IsNullOrEmpty(hp.Address))
-                .OrderBy(hp => hp.HopNumber)
-                .Select(hp => hp.Address!)
-                .ToList())
-            .ToList();
+        var asnByIp = BuildAsnByIpMap();
+        var traceSequences = BuildTraceSequences();
 
         _nearTransitAsns.Clear();
         _nearTransitAsns.UnionWith(
@@ -1543,8 +1647,7 @@ public class UpstreamTracerService
         // cleared the gate is always the better monitor than a city-PoP speedtest endpoint.
         if (State.AccessHops.Any(h => h.Enabled && !h.Unreachable)) return;
 
-        var orgName = CleanAsnName(_accessHopsResolved.FirstOrDefault()?.Asn?.Name);
-        if (string.IsNullOrEmpty(orgName)) orgName = $"AS{asn}";
+        var orgName = _accessAsnName ?? $"AS{asn}";
 
         // Resolve + ping each curated host; keep the reachable ones with their measured RTT.
         var probed = new List<AccessFallbackProbe>();
@@ -1841,7 +1944,12 @@ public class UpstreamTracerService
         ctxRow.L2NeighborMac = State.WanNeighborMac;
         ctxRow.L2NeighborIp = State.WanNeighborIp;
         ctxRow.L2NeighborOui = State.WanNeighborOuiVendor;
-        ctxRow.AccessTechnology = State.AccessTechnology;
+        // Never write Unknown over a saved technology: the ISP Health selector writes
+        // to this row too, and a run that started without the tech hydrated would
+        // otherwise wipe the user's setting (discovery only ever proposes, per the
+        // SetAccessTechnologyAsync contract).
+        if (State.AccessTechnology != AccessTechnology.Unknown)
+            ctxRow.AccessTechnology = State.AccessTechnology;
         ctxRow.LastDiscoveryAt = DateTime.UtcNow;
         ctxRow.NeedsReview = false;
         ctxRow.UpdatedAt = DateTime.UtcNow;
@@ -2109,6 +2217,136 @@ public class UpstreamTracerService
     /// </summary>
     internal static string CleanAsnName(string? name) =>
         NetworkOptimizer.Core.Helpers.NetworkFormatHelpers.CleanOrgName(name);
+
+    /// <summary>Hop address → ASN for every ASN-attributed hop in the last sweep.</summary>
+    private Dictionary<string, int> BuildAsnByIpMap()
+    {
+        var asnByIp = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var h in _mergedHops)
+            if (h.Asn != null) asnByIp.TryAdd(h.Address, h.Asn.Asn);
+        return asnByIp;
+    }
+
+    /// <summary>Per-trace responding hop addresses in hop order, from the last sweep.</summary>
+    private List<IReadOnlyList<string>> BuildTraceSequences() =>
+        _lastTraces
+            .Select(t => (IReadOnlyList<string>)t.Hops
+                .Where(hp => hp.Responded && !string.IsNullOrEmpty(hp.Address))
+                .OrderBy(hp => hp.HopNumber)
+                .Select(hp => hp.Address!)
+                .ToList())
+            .ToList();
+
+    /// <summary>
+    /// Resolves the ASN + org name of every non-transit-probe endpoint in the rotation
+    /// into <see cref="_destinationAsns"/> / <see cref="_destinationOrgs"/>. Called once
+    /// per run from the access step; the transit step reuses the sets.
+    /// </summary>
+    private async Task ResolveDestinationAsnsAsync(CancellationToken ct)
+    {
+        _destinationAsns.Clear();
+        _destinationOrgs.Clear();
+        foreach (var endpoint in CdnRotation)
+        {
+            if (endpoint.IsTransitProbe) continue;
+            var destAsn = await _asnResolution.ResolveAsync(endpoint.Address, ct);
+            if (destAsn == null) continue;
+            _destinationAsns.Add(destAsn.Asn);
+            if (!string.IsNullOrWhiteSpace(destAsn.Name)) _destinationOrgs.Add(destAsn.Name.Trim());
+        }
+    }
+
+    /// <summary>
+    /// Picks the access ISP's ASN from the discovery sweep. The naive "first hop with a
+    /// resolvable ASN" heuristic fails when the ISP's entire first mile is unattributable:
+    /// Bell Canada (#984) runs its PPPoE aggregation on RFC1918 plus public /16s it
+    /// deliberately does not announce in BGP, so the first attributable hop was the probed
+    /// CDN's own edge and Cloudflare got crowned as the access ISP.
+    ///
+    /// Two signals replace it:
+    ///  1. The WAN IP's own ASN (the ISP's customer allocation) wins whenever it is
+    ///     resolvable AND corroborated - it appears on some hop, or no per-trace votes
+    ///     exist at all (fully silent first mile: keep it for labeling and the curated
+    ///     fallback endpoints).
+    ///  2. Otherwise per-trace voting: each trace nominates its first ASN-attributed hop,
+    ///     skipping destination ASNs - a destination's edge only appears on traces toward
+    ///     itself, while the true access ISP fronts essentially every trace. Most votes
+    ///     wins; ties break toward the ASN seen at the shallowest hop, then lowest ASN.
+    /// A destination ASN can still win via signal 1: an access ISP could legitimately be
+    /// one of the orgs we probe.
+    /// </summary>
+    internal static int? DetermineAccessAsn(
+        IEnumerable<IReadOnlyList<string>> traceAddressSequences,
+        IReadOnlyDictionary<string, int> asnByIp,
+        int? wanIpAsn,
+        IReadOnlySet<int> destinationAsns)
+    {
+        var votes = new Dictionary<int, (int Count, int BestDepth)>();
+        foreach (var trace in traceAddressSequences)
+        {
+            var depth = 0;
+            foreach (var address in trace)
+            {
+                depth++;
+                if (!asnByIp.TryGetValue(address, out var asn)) continue;
+                if (destinationAsns.Contains(asn) && asn != wanIpAsn) continue;
+                votes[asn] = votes.TryGetValue(asn, out var v)
+                    ? (v.Count + 1, Math.Min(v.BestDepth, depth))
+                    : (1, depth);
+                break;
+            }
+        }
+
+        if (wanIpAsn is int wan
+            && (votes.ContainsKey(wan) || votes.Count == 0 || asnByIp.Values.Contains(wan)))
+            return wan;
+
+        if (votes.Count == 0) return null;
+        return votes
+            .OrderByDescending(kv => kv.Value.Count)
+            .ThenBy(kv => kv.Value.BestDepth)
+            .ThenBy(kv => kv.Key)
+            .First().Key;
+    }
+
+    /// <summary>
+    /// Positional attribution for an ISP's unannounced first mile. Collects hop addresses
+    /// that appear BEFORE the first access-ASN hop on their own trace and carry no BGP
+    /// attribution but sit in public or shared/CGNAT (RFC 6598) space - Bell's 142.124.x
+    /// aggregation hops (#984). Being upstream of us and downstream of the ISP's announced
+    /// border makes them the ISP's access infrastructure even though no ASN maps to them.
+    /// RFC1918 hops are excluded: those can be a bridged CPE's LAN side or a double-NAT
+    /// middlebox. Traces whose first attributed hop is NOT the access ASN (e.g. a trace
+    /// that only ever surfaces the destination's edge) contribute nothing - we can't prove
+    /// their prefix hops sit below the access border. Dedupes across traces, preserves
+    /// first-seen order.
+    /// </summary>
+    internal static List<string> CollectUnannouncedAccessAddresses(
+        IEnumerable<IReadOnlyList<string>> traceAddressSequences,
+        IReadOnlyDictionary<string, int> asnByIp,
+        int accessAsn)
+    {
+        var result = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var trace in traceAddressSequences)
+        {
+            var prefix = new List<string>();
+            foreach (var address in trace)
+            {
+                if (asnByIp.TryGetValue(address, out var asn))
+                {
+                    if (asn == accessAsn)
+                        foreach (var p in prefix)
+                            if (seen.Add(p)) result.Add(p);
+                    break;
+                }
+                var cls = NetworkUtilities.ClassifyPublicAddress(address);
+                if (cls is PublicAddressClass.PublicIPv4 or PublicAddressClass.Cgnat)
+                    prefix.Add(address);
+            }
+        }
+        return result;
+    }
 
     /// <summary>
     /// Near-transit ASNs: every ASN that appears as the 1st or 2nd distinct non-access,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -295,6 +295,22 @@ public class UpstreamTracerService
             await TraceAccessIspAsync(ct);
             await TraceTransitAsnsAsync(ct);
             await VerifyReachabilityAsync(ct);
+
+            // Shared post-run change evaluation - manual and scheduled runs alike advance the
+            // per-WAN absence counters exactly once per completed run, and both stage any
+            // confirmed off-path transit ASNs for the review. A failure here only skips the
+            // counters for this run; the review of the discovered candidates still proceeds.
+            try
+            {
+                await using var evalDb = await CreateDbAsync(ct);
+                await UpstreamRediscoveryService.EvaluateCompletedRunAsync(evalDb, State, ct);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Post-run off-path evaluation failed; absence counters not advanced this run");
+            }
+
             State.Step = TracerStep.ReviewingResults;
             State.CurrentActivity = "Review the discovered upstream path. Confirm to commit.";
             State.CompletedAt = DateTime.UtcNow;
@@ -1733,6 +1749,25 @@ public class UpstreamTracerService
         // WanDiscoveryContexts per WAN.
         var wanInterface = State.WanInterface ?? "wan";
 
+        // A confirmed provider change resets the connection's upstream monitoring wholesale:
+        // pause every enabled access/transit/path target - auto-discovered and hand-added alike
+        // (manual rows pinned to another WAN survive) - and wipe the WAN's off-path evidence,
+        // so the freshly discovered candidates upserted below become the new baseline. Runs
+        // before the upserts so the fresh targets come back enabled. A decline records the new
+        // ASN so the same change doesn't re-prompt every run.
+        if (State.IspChange is { Confirmed: true } confirmedChange)
+        {
+            var paused = await UpstreamRediscoveryService.ApplyIspChangeResetAsync(db, wanInterface, ct);
+            _logger.LogInformation("Commit: ISP change AS{Old} -> AS{New} confirmed; paused {Count} upstream target(s) on {Wan} for a fresh baseline",
+                confirmedChange.OldAsnNumber, confirmedChange.NewAsnNumber, paused, wanInterface);
+        }
+        else if (State.IspChange is { Confirmed: false } declinedChange)
+        {
+            await UpstreamRediscoveryService.RecordDeclinedIspChangeAsync(db, wanInterface, declinedChange.NewAsnNumber, ct);
+            _logger.LogInformation("Commit: ISP change AS{Old} -> AS{New} declined; keeping existing targets",
+                declinedChange.OldAsnNumber, declinedChange.NewAsnNumber);
+        }
+
         foreach (var hop in State.AccessHops.Where(h => h.Enabled))
         {
             _logger.LogDebug("Commit access hop: id={TargetId} label='{Label}' addr={Address}", hop.TargetId, hop.Label, hop.Address);
@@ -1765,6 +1800,32 @@ public class UpstreamTracerService
                 existing.Name = transit.Label ?? transit.AsnName;
                 if (!string.IsNullOrEmpty(transit.AsnName)) existing.AsnName = transit.AsnName;
             }
+        }
+
+        // Confirmed off-path transit ASNs the user didn't re-check: pause every enabled Transit
+        // target in the ASN - auto-discovered AND hand-added - since the ISP no longer routes
+        // through it, so they're false targets skewing ISP Health. Paused (Enabled=false), never
+        // deleted. Auto targets are scoped to this WAN; UserProvided ones are WAN-agnostic.
+        if (State.RemovedTransitAsns.Count > 0)
+        {
+            foreach (var removed in State.RemovedTransitAsns.Where(r => !r.Keep))
+            {
+                var stale = await db.MonitoringTargets
+                    .Where(t => t.TargetType == MonitoringTargetType.Transit && t.Enabled
+                        && t.AsnNumber == removed.AsnNumber
+                        && (t.DiscoveryMethod == DiscoveryMethod.UserProvided || t.WanInterface == wanInterface))
+                    .ToListAsync(ct);
+                foreach (var t in stale) t.Enabled = false;
+                if (stale.Count > 0)
+                    _logger.LogInformation("Commit: paused {Count} off-path transit target(s) for AS{Asn} ({Name})",
+                        stale.Count, removed.AsnNumber, removed.AsnName);
+            }
+
+            // Clear the surfaced ASNs' miss counters - kept AND paused. A kept ASN would otherwise
+            // still sit at the confirm threshold and re-flag review on the next daily recheck;
+            // clearing makes its off-path evidence re-accumulate from zero instead.
+            await UpstreamRediscoveryService.ClearMissCountKeysAsync(db, wanInterface,
+                State.RemovedTransitAsns.Select(r => "transit:as" + r.AsnNumber), ct);
         }
 
         // Per-WAN tracer state. WanDiscoveryContexts is the new source of truth;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerState.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerState.cs
@@ -29,6 +29,38 @@ public class UpstreamTracerState
     public List<AccessHopCandidate> AccessHops { get; set; } = new();
     public List<TransitAsnCandidate> TransitAsns { get; set; } = new();
 
+    /// <summary>
+    /// Transit ASNs the scheduled re-discovery confirmed are no longer on our path (absent from
+    /// several consecutive runs). Surfaced in the review pre-unchecked; committing with an entry
+    /// left unchecked pauses every enabled Transit target in that ASN. In-memory only (like the
+    /// rest of the review state): a restart during the review window loses the list, but the
+    /// persisted miss counters re-populate it on the next background recheck.
+    /// </summary>
+    public List<RemovedTransitAsn> RemovedTransitAsns { get; set; } = new();
+
+    /// <summary>
+    /// Transit ASNs currently absent from discovery but not yet confirmed removed (consecutive-miss
+    /// count below the threshold). Informational only - surfaced read-only in the review so the user
+    /// knows we noticed the ASN went off-path and are tracking it toward removal. Populated on every
+    /// completed run (manual and scheduled) from the same evaluation, so the count stays accurate.
+    /// </summary>
+    public List<PendingRemovalTransitAsn> PendingRemovalTransitAsns { get; set; } = new();
+
+    /// <summary>
+    /// Identity keys this run discovered that the committed target set doesn't cover yet.
+    /// Staged by the shared post-run evaluation for the re-discovery scheduler's review gate.
+    /// </summary>
+    public List<string> DiscoveryAddedAsns { get; set; } = new();
+
+    /// <summary>
+    /// Staged when this run resolved a valid access ISP ASN that differs from every access ASN
+    /// committed for the WAN - a candidate provider change. Supersedes per-transit off-path
+    /// staging for the run (a switched provider replaces the whole path at once, not N transit
+    /// removals). Null when the access ASN is unchanged, unresolved this run, or the user
+    /// already declined this same new ASN. In-memory only, like the rest of the review state.
+    /// </summary>
+    public IspChangeCandidate? IspChange { get; set; }
+
     // Per-CDN trace summaries for the live progress UI.
     public List<TraceSummary> Traces { get; set; } = new();
 
@@ -103,6 +135,67 @@ public class TransitAsnCandidate
     /// stored choices.
     /// </summary>
     public bool PreservedFromExisting { get; set; }
+}
+
+/// <summary>
+/// A transit ASN that auto-discovery confirmed is no longer on our path (absent from several
+/// consecutive re-discovery runs). Surfaced in the review pre-unchecked; committing with it
+/// left unchecked pauses every enabled Transit target in the ASN - auto-discovered and hand-
+/// added alike - since if the ISP no longer routes through the ASN, all its targets are false.
+/// </summary>
+public class RemovedTransitAsn
+{
+    public int AsnNumber { get; set; }
+    public required string AsnName { get; set; }
+    /// <summary>Enabled Transit targets in this ASN that would be paused (auto + manual).</summary>
+    public int TargetCount { get; set; }
+    /// <summary>How many of those are hand-added (UserProvided), for the review note.</summary>
+    public int ManualCount { get; set; }
+    /// <summary>Checkbox state. Default false = pause on commit; user re-checks to keep monitoring.</summary>
+    public bool Keep { get; set; }
+}
+
+/// <summary>
+/// A transit ASN that has gone absent from discovery but hasn't yet hit the consecutive-miss
+/// threshold for removal. Surfaced read-only in the review ("we're tracking this; N more runs
+/// without it and we'll help you remove its targets"). No checkbox, no commit action - purely a
+/// heads-up so the off-path detection isn't invisible until it suddenly confirms.
+/// </summary>
+public class PendingRemovalTransitAsn
+{
+    public int AsnNumber { get; set; }
+    public required string AsnName { get; set; }
+    /// <summary>Consecutive runs this ASN has been absent so far.</summary>
+    public int MissCount { get; set; }
+    /// <summary>Runs still needed without it present before it's confirmed for removal.</summary>
+    public int RunsRemaining { get; set; }
+    /// <summary>Enabled Transit targets that would be paused once confirmed (auto + manual).</summary>
+    public int TargetCount { get; set; }
+    /// <summary>How many of those are hand-added (UserProvided).</summary>
+    public int ManualCount { get; set; }
+}
+
+/// <summary>
+/// A detected access-ISP change awaiting the user's answer in the review. Confirmed stays null
+/// until they pick; the commit button is gated on a decision. Confirming pauses every enabled
+/// upstream target for the connection - access, transit, and path-proxy tiers, auto-discovered
+/// and hand-added alike (manual targets pinned to a different WAN survive) - wipes the WAN's
+/// off-path miss counters, and lets this run's candidates repopulate as the new baseline.
+/// Declining leaves targets untouched and records the new ASN so the same change doesn't
+/// re-prompt every run. Paused targets are never deleted.
+/// </summary>
+public class IspChangeCandidate
+{
+    public int OldAsnNumber { get; set; }
+    public required string OldAsnName { get; set; }
+    public int NewAsnNumber { get; set; }
+    public required string NewAsnName { get; set; }
+    /// <summary>Enabled upstream targets across all tiers a confirm would pause.</summary>
+    public int TargetCount { get; set; }
+    /// <summary>How many of those are hand-added (UserProvided).</summary>
+    public int ManualCount { get; set; }
+    /// <summary>Null until the user decides; true = start fresh, false = keep monitoring.</summary>
+    public bool? Confirmed { get; set; }
 }
 
 /// <summary>One CDN traceroute summary for the live progress UI.</summary>

--- a/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
@@ -332,6 +332,7 @@ public class OntMonitorService : IDisposable
             Id = config.Id,
             Name = config.Name,
             Host = host,
+            ConfiguredHost = config.Host,
             Port = port,
             Username = string.IsNullOrEmpty(config.Username) ? null : config.Username,
             Password = password,

--- a/src/NetworkOptimizer.Web/Services/OntProviders/AttGatewayOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/AttGatewayOntProvider.cs
@@ -91,12 +91,12 @@ public class AttGatewayOntProvider : IOntProvider
             using var client = CreateHttpClient();
             var baseUrl = await ResolveBaseUrlAsync(client, context, cancellationToken);
             if (baseUrl == null)
-                return (false, $"Could not reach {context.Host} via HTTP or HTTPS");
+                return (false, $"Could not reach {context.ConfiguredHost ?? context.Host} via HTTP or HTTPS");
 
             var url = $"{baseUrl}/cgi-bin/fiberstat.ha";
             using var response = await client.GetAsync(url, cancellationToken);
             if (!response.IsSuccessStatusCode)
-                return (false, $"HTTP {(int)response.StatusCode} from {context.Host}");
+                return (false, $"HTTP {(int)response.StatusCode} from {context.ConfiguredHost ?? context.Host}");
 
             var html = await response.Content.ReadAsStringAsync(cancellationToken);
             var scheme = baseUrl.StartsWith("https") ? "HTTPS" : "HTTP";

--- a/src/NetworkOptimizer.Web/Services/OntProviders/AttGatewayOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/AttGatewayOntProvider.cs
@@ -48,7 +48,7 @@ public class AttGatewayOntProvider : IOntProvider
             var stats = new OntStats
             {
                 Timestamp = DateTime.UtcNow,
-                DeviceHost = context.Host,
+                DeviceHost = context.ConfiguredHost ?? context.Host,
                 DeviceName = context.Name,
                 DeviceModel = "AT&T Gateway"
             };

--- a/src/NetworkOptimizer.Web/Services/OntProviders/AttGatewayOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/AttGatewayOntProvider.cs
@@ -41,7 +41,7 @@ public class AttGatewayOntProvider : IOntProvider
             var baseUrl = await ResolveBaseUrlAsync(client, context, cancellationToken);
             if (baseUrl == null)
             {
-                _logger.LogWarning("Failed to reach AT&T gateway at {Host} via HTTP or HTTPS", context.Host);
+                _logger.LogWarning("Failed to reach AT&T gateway at {Host} via HTTP or HTTPS", context.ConfiguredHost ?? context.Host);
                 return null;
             }
 
@@ -56,7 +56,7 @@ public class AttGatewayOntProvider : IOntProvider
             var fiberHtml = await FetchPageAsync(client, $"{baseUrl}/cgi-bin/fiberstat.ha", cancellationToken);
             if (fiberHtml == null)
             {
-                _logger.LogWarning("Failed to fetch fiberstat.ha from {Host}", context.Host);
+                _logger.LogWarning("Failed to fetch fiberstat.ha from {Host}", context.ConfiguredHost ?? context.Host);
                 return null;
             }
 
@@ -78,7 +78,7 @@ public class AttGatewayOntProvider : IOntProvider
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Error polling AT&T gateway at {Host}", context.Host);
+            _logger.LogWarning(ex, "Error polling AT&T gateway at {Host}", context.ConfiguredHost ?? context.Host);
             return null;
         }
     }

--- a/src/NetworkOptimizer.Web/Services/OntProviders/GenericHttpOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/GenericHttpOntProvider.cs
@@ -47,7 +47,7 @@ public class GenericHttpOntProvider : IOntProvider
                 using var response = await client.GetAsync(primaryUrl, cancellationToken);
                 if (response.IsSuccessStatusCode)
                     return (true, $"{primaryScheme.ToUpperInvariant()} {(int)response.StatusCode} - device is reachable");
-                return (false, $"{primaryScheme.ToUpperInvariant()} {(int)response.StatusCode} from {context.Host}");
+                return (false, $"{primaryScheme.ToUpperInvariant()} {(int)response.StatusCode} from {context.ConfiguredHost ?? context.Host}");
             }
             catch (HttpRequestException)
             {
@@ -59,7 +59,7 @@ public class GenericHttpOntProvider : IOntProvider
             using var fb = await client.GetAsync(fallbackUrl, cancellationToken);
             if (fb.IsSuccessStatusCode)
                 return (true, $"{fallbackScheme.ToUpperInvariant()} {(int)fb.StatusCode} - device is reachable");
-            return (false, $"{fallbackScheme.ToUpperInvariant()} {(int)fb.StatusCode} from {context.Host}");
+            return (false, $"{fallbackScheme.ToUpperInvariant()} {(int)fb.StatusCode} from {context.ConfiguredHost ?? context.Host}");
         }
         catch (HttpRequestException ex)
         {

--- a/src/NetworkOptimizer.Web/Services/OntProviders/Lantiq8311OntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/Lantiq8311OntProvider.cs
@@ -80,7 +80,7 @@ public sealed class Lantiq8311OntProvider : IOntProvider
         catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Error polling 8311 ONT {Name} at {Host}", context.Name, context.Host);
+            _logger.LogWarning(ex, "Error polling 8311 ONT {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
             return null;
         }
     }
@@ -235,7 +235,7 @@ public sealed class Lantiq8311OntProvider : IOntProvider
         }
         catch (JsonException ex)
         {
-            _logger.LogDebug(ex, "Failed to parse 8311 gpon_status JSON from {Host}", context.Host);
+            _logger.LogDebug(ex, "Failed to parse 8311 gpon_status JSON from {Host}", context.ConfiguredHost ?? context.Host);
         }
 
         return stats;

--- a/src/NetworkOptimizer.Web/Services/OntProviders/Lantiq8311OntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/Lantiq8311OntProvider.cs
@@ -162,7 +162,7 @@ public sealed class Lantiq8311OntProvider : IOntProvider
         var stats = new OntStats
         {
             Timestamp = DateTime.UtcNow,
-            DeviceHost = context.Host,
+            DeviceHost = context.ConfiguredHost ?? context.Host,
             DeviceName = context.Name,
             DeviceModel = "8311 ONT",
         };

--- a/src/NetworkOptimizer.Web/Services/OntProviders/QuantumQ1000kOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/QuantumQ1000kOntProvider.cs
@@ -85,7 +85,7 @@ public sealed class QuantumQ1000kOntProvider : IOntProvider
         catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Error polling Quantum Q1000K ONT {Name} at {Host}", context.Name, context.Host);
+            _logger.LogWarning(ex, "Error polling Quantum Q1000K ONT {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
             return null;
         }
     }

--- a/src/NetworkOptimizer.Web/Services/OntProviders/QuantumQ1000kOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/QuantumQ1000kOntProvider.cs
@@ -59,7 +59,7 @@ public sealed class QuantumQ1000kOntProvider : IOntProvider
             var stats = new OntStats
             {
                 Timestamp = DateTime.UtcNow,
-                DeviceHost = context.Host,
+                DeviceHost = context.ConfiguredHost ?? context.Host,
                 DeviceName = context.Name,
                 DeviceModel = "Quantum Q1000K",
             };

--- a/src/NetworkOptimizer.Web/Services/OntProviders/RealtekOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/RealtekOntProvider.cs
@@ -61,7 +61,7 @@ public sealed class RealtekOntProvider : IOntProvider
         catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Error polling Realtek ONT {Name} at {Host}", context.Name, context.Host);
+            _logger.LogWarning(ex, "Error polling Realtek ONT {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
             return null;
         }
     }
@@ -138,7 +138,7 @@ public sealed class RealtekOntProvider : IOntProvider
         try
         {
             using var probe = await client2.GetAsync(fallbackUrl, ct);
-            _logger.LogInformation("Realtek ONT {Host} reachable via {Scheme}", context.Host, fallbackScheme.ToUpperInvariant());
+            _logger.LogInformation("Realtek ONT {Host} reachable via {Scheme}", context.ConfiguredHost ?? context.Host, fallbackScheme.ToUpperInvariant());
             return (fallbackUrl, client2, handler2);
         }
         catch

--- a/src/NetworkOptimizer.Web/Services/OntProviders/RealtekOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/RealtekOntProvider.cs
@@ -214,7 +214,7 @@ public sealed class RealtekOntProvider : IOntProvider
         var stats = new OntStats
         {
             Timestamp = DateTime.UtcNow,
-            DeviceHost = context.Host,
+            DeviceHost = context.ConfiguredHost ?? context.Host,
             DeviceName = context.Name,
             DeviceModel = "Realtek ONT",
         };

--- a/src/NetworkOptimizer.Web/Services/OntProviders/TelekomModem2OntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/TelekomModem2OntProvider.cs
@@ -44,7 +44,7 @@ public sealed class TelekomModem2OntProvider : IOntProvider
             var stats = new OntStats
             {
                 Timestamp = DateTime.UtcNow,
-                DeviceHost = context.Host,
+                DeviceHost = context.ConfiguredHost ?? context.Host,
                 DeviceName = context.Name,
                 DeviceModel = "Glasfaser-Modem 2",
             };

--- a/src/NetworkOptimizer.Web/Services/OntProviders/TelekomModem2OntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/TelekomModem2OntProvider.cs
@@ -60,7 +60,7 @@ public sealed class TelekomModem2OntProvider : IOntProvider
         catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Error polling Telekom Modem 2 ONT {Name} at {Host}", context.Name, context.Host);
+            _logger.LogWarning(ex, "Error polling Telekom Modem 2 ONT {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
             return null;
         }
     }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -17875,6 +17875,10 @@ body.kiosk-mode .status-indicators {
     padding: 0.35rem 0;
 }
 
+.settings-table tr:not(.history-details-row):hover {
+    background: var(--bg-inset);
+}
+
 .site-name-cell {
     display: inline-flex;
     align-items: center;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -5,6 +5,8 @@
 
 /* CSS Variables for theming - Ozark Connect Brand Colors */
 :root {
+    color-scheme: dark;
+
     /* Typography - Two font families only */
     --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     --font-mono: 'SF Mono', SFMono-Regular, ui-monospace, Menlo, Consolas, monospace;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -39,6 +39,7 @@
     --bg-elevated: #2c2c30;
     --bg-card: #161618;
     --bg-hover: #232326;
+    --bg-hover-subtle: #1c1c1f;
     --surface: #161618;
     --surface-secondary: #1c1c1f;
 
@@ -17876,7 +17877,7 @@ body.kiosk-mode .status-indicators {
 }
 
 .settings-table tr:not(.history-details-row):hover {
-    background: var(--bg-inset);
+    background: var(--bg-hover-subtle);
 }
 
 .site-name-cell {

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -104,8 +104,24 @@
         if (!link)
             return;
         e.preventDefault();
-        if (link.hasAttribute('data-site-current'))
+        if (link.hasAttribute('data-site-current')) {
+            // Plain click on the already-active site. Two hosts carry these anchors:
+            //  - the header dropdown, where a backdrop is present: just close the
+            //    dropdown (don't reload). Clicking the backdrop keeps Blazor's open
+            //    state in sync (its @onclick runs CloseDropdown).
+            //  - the /sites page, where there's no dropdown: navigate to the card's
+            //    href (the site's dashboard) instead of dead-clicking.
+            // Reached only for plain left clicks - the modified-click guard above already
+            // returned, so ctrl / cmd / shift / middle clicks still open the site in a new
+            // tab untouched.
+            const backdrop = document.querySelector('.site-switcher-backdrop');
+            if (backdrop) {
+                backdrop.click();
+            } else {
+                window.location.assign(link.href);
+            }
             return;
+        }
         const target = link.getAttribute('data-site-switch');
         document.cookie = 'no-site=' + target + '; path=/; max-age=31536000; SameSite=Lax';
         window.location.assign(link.href);

--- a/tests/NetworkOptimizer.Core.Tests/VersionUtilitiesTests.cs
+++ b/tests/NetworkOptimizer.Core.Tests/VersionUtilitiesTests.cs
@@ -46,4 +46,15 @@ public class VersionUtilitiesTests
     {
         VersionUtilities.IsOlderThan(candidate, required).Should().BeFalse();
     }
+
+    [Theory]
+    [InlineData("2.0.1+ed2714ca72415f2d08512e643c", "2.0.1")]
+    [InlineData("2.0.0-beta.2.14+3449fbae", "2.0.0-beta.2.14")]
+    [InlineData("2.0.1", "2.0.1")]
+    [InlineData("", "")]
+    [InlineData(null, null)]
+    public void StripBuildMetadata_DropsPlusSuffixOnly(string? version, string? expected)
+    {
+        VersionUtilities.StripBuildMetadata(version).Should().Be(expected);
+    }
 }

--- a/tests/NetworkOptimizer.UniFi.Tests/ClassifyVpnClientTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/ClassifyVpnClientTests.cs
@@ -1,0 +1,113 @@
+using FluentAssertions;
+using NetworkOptimizer.UniFi.Models;
+using Xunit;
+
+namespace NetworkOptimizer.UniFi.Tests;
+
+/// <summary>
+/// Tests for <see cref="NetworkPathAnalyzer.ClassifyVpnClient"/>, the shared VPN client
+/// classifier used by both speed-test hop creation and the Client Dashboard.
+/// </summary>
+public class ClassifyVpnClientTests
+{
+    private static NetworkTopology TopologyWith(params NetworkInfo[] networks) =>
+        new() { Networks = networks.ToList() };
+
+    // A representative corporate LAN the test IPs can be checked against.
+    private static NetworkInfo LanNetwork() => new()
+    {
+        Name = "Default",
+        Purpose = "corporate",
+        IpSubnet = "192.168.1.0/24"
+    };
+
+    [Theory]
+    [InlineData("100.64.0.1")]
+    [InlineData("100.100.100.100")]
+    [InlineData("100.127.255.254")]
+    public void TailscaleCgnatRange_ClassifiedAsTailscale(string ip)
+    {
+        NetworkPathAnalyzer.ClassifyVpnClient(ip, TopologyWith(LanNetwork()))
+            .Should().Be(HopType.Tailscale);
+    }
+
+    [Theory]
+    [InlineData("100.63.255.255")]  // just below the CGNAT block
+    [InlineData("100.128.0.0")]     // just above the CGNAT block
+    public void HundredDotOutsideCgnat_NotTailscale(string ip)
+    {
+        NetworkPathAnalyzer.ClassifyVpnClient(ip, TopologyWith(LanNetwork()))
+            .Should().NotBe(HopType.Tailscale);
+    }
+
+    [Fact]
+    public void Tailscale_ClassifiedWithNullTopology()
+    {
+        // Tailscale is a pure-IP (CGNAT) check and must work without topology.
+        NetworkPathAnalyzer.ClassifyVpnClient("100.64.0.5", null)
+            .Should().Be(HopType.Tailscale);
+    }
+
+    [Fact]
+    public void Private192_NotInAnyNetwork_ClassifiedAsTeleport()
+    {
+        // 192.168.x.x not inside any known UniFi network is Teleport.
+        NetworkPathAnalyzer.ClassifyVpnClient("192.168.77.5", TopologyWith(LanNetwork()))
+            .Should().Be(HopType.Teleport);
+    }
+
+    [Fact]
+    public void Private192_InsideKnownNetwork_NotVpn()
+    {
+        NetworkPathAnalyzer.ClassifyVpnClient("192.168.1.50", TopologyWith(LanNetwork()))
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void RemoteUserVpnSubnet_ClassifiedAsVpn()
+    {
+        var vpnNetwork = new NetworkInfo
+        {
+            Name = "VPN",
+            Purpose = "remote-user-vpn",
+            IpSubnet = "10.20.0.0/24"
+        };
+
+        NetworkPathAnalyzer.ClassifyVpnClient("10.20.0.7", TopologyWith(LanNetwork(), vpnNetwork))
+            .Should().Be(HopType.Vpn);
+    }
+
+    [Fact]
+    public void NormalLanClient_NotVpn()
+    {
+        NetworkPathAnalyzer.ClassifyVpnClient("192.168.1.100", TopologyWith(LanNetwork()))
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void NonPrivateExternalIp_NotVpn()
+    {
+        // A public IP not in any network is external, but not a VPN client type.
+        NetworkPathAnalyzer.ClassifyVpnClient("203.0.113.10", TopologyWith(LanNetwork()))
+            .Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-an-ip")]
+    [InlineData("999.999.999.999")]
+    public void InvalidIp_ReturnsNull(string ip)
+    {
+        NetworkPathAnalyzer.ClassifyVpnClient(ip, TopologyWith(LanNetwork()))
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void NullTopology_TeleportNotClassified()
+    {
+        // Teleport needs the network list to confirm the IP is not local; without
+        // topology only Tailscale can be identified.
+        NetworkPathAnalyzer.ClassifyVpnClient("192.168.77.5", null)
+            .Should().BeNull();
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/FlakyTargetServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/FlakyTargetServiceTests.cs
@@ -22,8 +22,10 @@ public class FlakyTargetServiceTests
         foreach (var (id, losses) in targets)
         {
             var bins = new Dictionary<DateTime, double>();
+            // A negative loss is a gap sentinel: no bin reported at that slot.
             for (var i = 0; i < losses.Length; i++)
-                bins[Base.AddMinutes(10 * i)] = losses[i];
+                if (losses[i] >= 0)
+                    bins[Base.AddMinutes(10 * i)] = losses[i];
             loss[id] = bins;
             meta[id] = new MonitoringTarget
             {
@@ -89,6 +91,148 @@ public class FlakyTargetServiceTests
             ("clean-b", new[] { 0.0, 0, 0, 0, 0, 0 }));
 
         FlakyTargetService.Analyze(loss, meta).Should().BeEmpty();
+    }
+
+    // ---- Recovery gate: stable -> flaky -> stable stops being presented ----
+
+    /// <summary>Losses: `head` copies of `headLoss` followed by `tail` copies of `tailLoss`.</summary>
+    private static double[] Run(int head, double headLoss, int tail, double tailLoss) =>
+        Enumerable.Repeat(headLoss, head).Concat(Enumerable.Repeat(tailLoss, tail)).ToArray();
+
+    [Fact]
+    public void Recovered_target_is_no_longer_flagged()
+    {
+        // Flaky for the first 2h, clean for the following 4h. The full-window trimmed mean
+        // (~6.5%) still says flaky, but the trailing 3h is clean - recovered, not presented.
+        var (loss, meta) = Build(
+            ("recovered", Run(12, 20.0, 24, 0.0)),
+            ("clean-a", Run(36, 0.0, 0, 0.0)),
+            ("clean-b", Run(36, 0.0, 0, 0.0)));
+
+        FlakyTargetService.Analyze(loss, meta).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Always_flaky_target_with_long_history_stays_flagged()
+    {
+        // Flaky since it was added, including the trailing window - the recovery gate must not
+        // clear it.
+        var (loss, meta) = Build(
+            ("always-flaky", Run(36, 8.0, 0, 0.0)),
+            ("clean-a", Run(36, 0.0, 0, 0.0)),
+            ("clean-b", Run(36, 0.0, 0, 0.0)));
+
+        FlakyTargetService.Analyze(loss, meta).Should().ContainSingle()
+            .Which.TargetId.Should().Be("always-flaky");
+    }
+
+    [Fact]
+    public void Target_that_went_dark_cannot_prove_recovery_and_stays_flagged()
+    {
+        // Flaky, then stopped reporting entirely while peers kept going: no recent bins means
+        // no evidence of stability, so it stays flagged.
+        var (loss, meta) = Build(
+            ("went-dark", Run(12, 20.0, 24, -1.0)),
+            ("clean-a", Run(36, 0.0, 0, 0.0)),
+            ("clean-b", Run(36, 0.0, 0, 0.0)));
+
+        FlakyTargetService.Analyze(loss, meta).Should().ContainSingle()
+            .Which.TargetId.Should().Be("went-dark");
+    }
+
+    [Fact]
+    public void Too_few_recent_bins_do_not_clear_the_flag()
+    {
+        // Only 3 clean bins inside the recovery window (< MinRecoveryBins of 6): not enough
+        // evidence to call it stable again.
+        var (loss, meta) = Build(
+            ("barely-back", Run(12, 20.0, 21, -1.0).Concat(Run(3, 0.0, 0, 0.0)).ToArray()),
+            ("clean-a", Run(36, 0.0, 0, 0.0)),
+            ("clean-b", Run(36, 0.0, 0, 0.0)));
+
+        FlakyTargetService.Analyze(loss, meta).Should().ContainSingle()
+            .Which.TargetId.Should().Be("barely-back");
+    }
+
+    [Fact]
+    public void Hard_down_target_recovers_after_a_short_clean_streak()
+    {
+        // A total outage (100% bins) that ended: three clean bins (~30 min) clear it via the
+        // hard-down fast path, long before the outage bins dilute out of the recovery window.
+        var (loss, meta) = Build(
+            ("outage-over", Run(12, 100.0, 3, 0.0)),
+            ("clean-a", Run(15, 0.0, 0, 0.0)),
+            ("clean-b", Run(15, 0.0, 0, 0.0)));
+
+        FlakyTargetService.Analyze(loss, meta).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Hard_down_target_still_down_stays_flagged()
+    {
+        var (loss, meta) = Build(
+            ("still-down", Run(15, 100.0, 0, 0.0)),
+            ("clean-a", Run(15, 0.0, 0, 0.0)),
+            ("clean-b", Run(15, 0.0, 0, 0.0)));
+
+        FlakyTargetService.Analyze(loss, meta).Should().ContainSingle()
+            .Which.TargetId.Should().Be("still-down");
+    }
+
+    [Fact]
+    public void Partial_loss_target_does_not_get_the_hard_down_fast_path()
+    {
+        // Same shape as the outage case but with partial (deprioritization-style) loss: a short
+        // clean streak is NOT enough - it must satisfy the full recovery window instead.
+        var (loss, meta) = Build(
+            ("partial-loss", Run(12, 20.0, 3, 0.0)),
+            ("clean-a", Run(15, 0.0, 0, 0.0)),
+            ("clean-b", Run(15, 0.0, 0, 0.0)));
+
+        FlakyTargetService.Analyze(loss, meta).Should().ContainSingle()
+            .Which.TargetId.Should().Be("partial-loss");
+    }
+
+    [Fact]
+    public void Outage_with_a_partial_boundary_bin_still_gets_the_fast_path()
+    {
+        // Real recovery shape: the aggregate bin straddling the moment the hop came back
+        // averages to partial loss (observed 52.8%). The median over-threshold bin is still
+        // 100%, so the boundary bin must not disqualify the fast path.
+        var (loss, meta) = Build(
+            ("boundary", Run(11, 100.0, 1, 52.8).Concat(Run(3, 0.0, 0, 0.0)).ToArray()),
+            ("clean-a", Run(15, 0.0, 0, 0.0)),
+            ("clean-b", Run(15, 0.0, 0, 0.0)));
+
+        FlakyTargetService.Analyze(loss, meta).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Genuinely_mixed_partial_loss_episode_does_not_get_the_fast_path()
+    {
+        // Half the over-threshold bins are partial (deprioritization-style) loss: the median
+        // falls below the hard-down bar, so the short streak must not clear it.
+        var (loss, meta) = Build(
+            ("mixed", Run(6, 100.0, 6, 20.0).Concat(Run(3, 0.0, 0, 0.0)).ToArray()),
+            ("clean-a", Run(15, 0.0, 0, 0.0)),
+            ("clean-b", Run(15, 0.0, 0, 0.0)));
+
+        FlakyTargetService.Analyze(loss, meta).Should().ContainSingle()
+            .Which.TargetId.Should().Be("mixed");
+    }
+
+    [Fact]
+    public void Target_flaky_again_after_a_clean_stretch_is_flagged()
+    {
+        // Clean history, then flaky through the trailing window - the recovery gate only clears
+        // targets that are currently stable, never ones that are currently flaky.
+        var (loss, meta) = Build(
+            ("relapsed", Run(18, 0.0, 18, 8.0)),
+            ("clean-a", Run(36, 0.0, 0, 0.0)),
+            ("clean-b", Run(36, 0.0, 0, 0.0)));
+
+        FlakyTargetService.Analyze(loss, meta).Should().ContainSingle()
+            .Which.TargetId.Should().Be("relapsed");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamIspChangeResetTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamIspChangeResetTests.cs
@@ -150,6 +150,46 @@ public class UpstreamIspChangeResetTests : IDisposable
         change.Should().BeNull();
     }
 
+    // ---- Injected-fallback baseline (no reachable first-mile router) ----
+
+    [Fact]
+    public async Task Fallback_only_baseline_with_same_asn_does_not_false_positive()
+    {
+        // A user whose access-ISP routers are all ICMP-silent has no DirectRouter/L2Neighbor
+        // access target - only a ConfiguredFallback speedtest endpoint, stamped with _accessAsn.
+        // A fresh run resolving the same access ASN (via a fallback hop again) must NOT read as
+        // a provider change: detection keys on the ASN, which is identical on both sides.
+        _db.MonitoringTargets.Add(Target("203.0.113.9", MonitoringTargetType.AccessIsp, OldAccessAsn, "wan",
+            DiscoveryMethod.ConfiguredFallback));
+        await _db.SaveChangesAsync();
+        var state = new UpstreamTracerState
+        {
+            WanInterface = "wan",
+            AccessHops = { FallbackHop("203.0.113.9", OldAccessAsn) },
+        };
+
+        var change = await UpstreamRediscoveryService.DetectAccessIspChangeAsync(_db, "wan", state, CancellationToken.None);
+
+        change.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Fallback_only_baseline_counts_as_baseline_so_a_real_change_still_fires()
+    {
+        // The flip side: a fallback baseline is still a baseline (only UserProvided is excluded),
+        // so a genuinely different access ASN this run correctly triggers the change flow.
+        _db.MonitoringTargets.Add(Target("203.0.113.9", MonitoringTargetType.AccessIsp, OldAccessAsn, "wan",
+            DiscoveryMethod.ConfiguredFallback));
+        await _db.SaveChangesAsync();
+        var state = RunState(NewAccessAsn);
+
+        var change = await UpstreamRediscoveryService.DetectAccessIspChangeAsync(_db, "wan", state, CancellationToken.None);
+
+        change.Should().NotBeNull();
+        change!.OldAsnNumber.Should().Be(OldAccessAsn);
+        change.NewAsnNumber.Should().Be(NewAccessAsn);
+    }
+
     // ---- Reset scope ----
 
     [Fact]
@@ -320,17 +360,29 @@ public class UpstreamIspChangeResetTests : IDisposable
         Method = DiscoveryMethod.DirectRouter,
     };
 
-    private static MonitoringTarget Target(string address, MonitoringTargetType type, int? asn,
-        string wan, DiscoveryMethod? method, bool enabled = true, string? asnName = null) => new()
+    // An injected curated speedtest endpoint, adopted as the access target when no first-mile
+    // router answered ICMP. Carries _accessAsn just like a real access hop.
+    private static AccessHopCandidate FallbackHop(string address, int? asn, string? asnName = null) => new()
     {
-        TargetId = $"{type}-{address}",
-        Name = $"{type} {address}",
+        TargetId = $"access-fallback-{address}",
+        Label = $"Fallback {address}",
         Address = address,
-        TargetType = type,
         AsnNumber = asn,
         AsnName = asnName,
-        WanInterface = wan,
-        DiscoveryMethod = method,
-        Enabled = enabled,
+        Method = DiscoveryMethod.ConfiguredFallback,
     };
+
+    private static MonitoringTarget Target(string address, MonitoringTargetType type, int? asn,
+        string wan, DiscoveryMethod? method, bool enabled = true, string? asnName = null) => new()
+        {
+            TargetId = $"{type}-{address}",
+            Name = $"{type} {address}",
+            Address = address,
+            TargetType = type,
+            AsnNumber = asn,
+            AsnName = asnName,
+            WanInterface = wan,
+            DiscoveryMethod = method,
+            Enabled = enabled,
+        };
 }

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamIspChangeResetTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamIspChangeResetTests.cs
@@ -1,0 +1,336 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services.Monitoring;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+/// <summary>
+/// The "your ISP changed" reset for upstream discovery. A completed run whose resolved access
+/// ASN differs from every committed access ASN stages a user-confirmed ISP change, which
+/// supersedes per-transit off-path staging for that run. Confirming pauses every upstream
+/// target for the connection (all tiers, auto and hand-added; manual targets pinned to another
+/// WAN survive) and wipes the WAN's off-path evidence; declining records the new ASN so the
+/// same change doesn't re-prompt.
+///
+/// All ASNs are RFC 5398 documentation ASNs (64496-64511) and all IPs are RFC 5737 ranges.
+/// </summary>
+public class UpstreamIspChangeResetTests : IDisposable
+{
+    private const int OldAccessAsn = 64496;
+    private const int NewAccessAsn = 64497;
+    private const int TransitAsn = 64498;
+    private const int PathAsn = 64499;
+    private const int UserAsn = 64500;
+
+    private readonly NetworkOptimizerDbContext _db;
+
+    public UpstreamIspChangeResetTests()
+    {
+        var options = new DbContextOptionsBuilder<NetworkOptimizerDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        _db = new NetworkOptimizerDbContext(options);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    // ---- Detection ----
+
+    [Fact]
+    public async Task Detects_change_when_access_asn_differs()
+    {
+        SeedCommittedAccess(OldAccessAsn, name: "Old Provider");
+        var state = RunState(NewAccessAsn, newName: "New Provider");
+
+        var change = await UpstreamRediscoveryService.DetectAccessIspChangeAsync(_db, "wan", state, CancellationToken.None);
+
+        change.Should().NotBeNull();
+        change!.OldAsnNumber.Should().Be(OldAccessAsn);
+        change.OldAsnName.Should().Be("Old Provider");
+        change.NewAsnNumber.Should().Be(NewAccessAsn);
+        change.NewAsnName.Should().Be("New Provider");
+        change.Confirmed.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task No_change_when_run_resolved_no_access_asn()
+    {
+        // A run that failed to attribute the access ASN must NOT read as a provider change.
+        SeedCommittedAccess(OldAccessAsn);
+        var state = new UpstreamTracerState
+        {
+            WanInterface = "wan",
+            AccessHops = { Hop("192.0.2.9", asn: null) },
+        };
+
+        var change = await UpstreamRediscoveryService.DetectAccessIspChangeAsync(_db, "wan", state, CancellationToken.None);
+
+        change.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task No_change_when_access_asn_unchanged()
+    {
+        SeedCommittedAccess(OldAccessAsn);
+        var state = RunState(OldAccessAsn);
+
+        var change = await UpstreamRediscoveryService.DetectAccessIspChangeAsync(_db, "wan", state, CancellationToken.None);
+
+        change.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task No_change_when_nothing_committed_yet()
+    {
+        var state = RunState(NewAccessAsn);
+
+        var change = await UpstreamRediscoveryService.DetectAccessIspChangeAsync(_db, "wan", state, CancellationToken.None);
+
+        change.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task No_change_when_any_resolved_asn_overlaps_committed()
+    {
+        // The run sees both the stored ASN and a new one (e.g. a re-attributed middle hop):
+        // the provider is still on the path, so it's not a switch.
+        SeedCommittedAccess(OldAccessAsn);
+        var state = new UpstreamTracerState
+        {
+            WanInterface = "wan",
+            AccessHops = { Hop("192.0.2.10", NewAccessAsn), Hop("192.0.2.11", OldAccessAsn) },
+        };
+
+        var change = await UpstreamRediscoveryService.DetectAccessIspChangeAsync(_db, "wan", state, CancellationToken.None);
+
+        change.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task No_change_when_new_asn_was_declined()
+    {
+        SeedCommittedAccess(OldAccessAsn);
+        await UpstreamRediscoveryService.RecordDeclinedIspChangeAsync(_db, "wan", NewAccessAsn, CancellationToken.None);
+        await _db.SaveChangesAsync();
+        var state = RunState(NewAccessAsn);
+
+        var change = await UpstreamRediscoveryService.DetectAccessIspChangeAsync(_db, "wan", state, CancellationToken.None);
+
+        change.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Decline_of_one_asn_does_not_suppress_a_different_one()
+    {
+        SeedCommittedAccess(OldAccessAsn);
+        await UpstreamRediscoveryService.RecordDeclinedIspChangeAsync(_db, "wan", 64511, CancellationToken.None);
+        await _db.SaveChangesAsync();
+        var state = RunState(NewAccessAsn);
+
+        var change = await UpstreamRediscoveryService.DetectAccessIspChangeAsync(_db, "wan", state, CancellationToken.None);
+
+        change.Should().NotBeNull();
+        change!.NewAsnNumber.Should().Be(NewAccessAsn);
+    }
+
+    [Fact]
+    public async Task UserProvided_access_rows_are_not_the_stored_baseline()
+    {
+        // A hand-added access target carries no discovery evidence of the provider - with only
+        // manual rows committed there's no baseline, so no change fires.
+        _db.MonitoringTargets.Add(Target("192.0.2.1", MonitoringTargetType.AccessIsp, OldAccessAsn, "wan", DiscoveryMethod.UserProvided));
+        await _db.SaveChangesAsync();
+        var state = RunState(NewAccessAsn);
+
+        var change = await UpstreamRediscoveryService.DetectAccessIspChangeAsync(_db, "wan", state, CancellationToken.None);
+
+        change.Should().BeNull();
+    }
+
+    // ---- Reset scope ----
+
+    [Fact]
+    public async Task Detection_counts_reset_scope_across_tiers_including_wan_agnostic_manual()
+    {
+        SeedCommittedAccess(OldAccessAsn);
+        _db.MonitoringTargets.AddRange(
+            // enabled tiers on this WAN - counted
+            Target("198.51.100.1", MonitoringTargetType.Transit, TransitAsn, "wan", DiscoveryMethod.DirectRouter),
+            Target("203.0.113.5", MonitoringTargetType.InternetService, PathAsn, "wan", DiscoveryMethod.PathProxy),
+            // hand-added, WAN-agnostic - counted and reported as manual
+            Target("203.0.113.1", MonitoringTargetType.Transit, UserAsn, "", DiscoveryMethod.UserProvided),
+            // hand-added but pinned to another WAN - survives the reset, not counted
+            Target("203.0.113.2", MonitoringTargetType.Transit, UserAsn, "wan2", DiscoveryMethod.UserProvided),
+            // other-WAN auto - not counted
+            Target("198.51.100.2", MonitoringTargetType.Transit, TransitAsn, "wan2", DiscoveryMethod.DirectRouter),
+            // disabled - already paused, not counted
+            Target("198.51.100.3", MonitoringTargetType.Transit, TransitAsn, "wan", DiscoveryMethod.DirectRouter, enabled: false));
+        await _db.SaveChangesAsync();
+        var state = RunState(NewAccessAsn);
+
+        var change = await UpstreamRediscoveryService.DetectAccessIspChangeAsync(_db, "wan", state, CancellationToken.None);
+
+        change.Should().NotBeNull();
+        // committed access row + transit + path + WAN-agnostic manual
+        change!.TargetCount.Should().Be(4);
+        change.ManualCount.Should().Be(1);
+    }
+
+    // ---- Supersede: no per-transit staging when an ISP change fires ----
+
+    [Fact]
+    public async Task CompletedRun_with_isp_change_stages_no_transit_removals_and_freezes_counters()
+    {
+        // Transit ASN sits one gated increment from confirming - a normal run would confirm it.
+        SeedCommittedAccess(OldAccessAsn);
+        _db.MonitoringTargets.Add(Target("198.51.100.1", MonitoringTargetType.Transit, TransitAsn, "wan", DiscoveryMethod.DirectRouter));
+        var counterJson = $"{{\"transit:as{TransitAsn}\":{{\"c\":2,\"t\":\"{DateTime.UtcNow.AddHours(-24):o}\"}}}}";
+        _db.SystemSettings.Add(new SystemSetting
+        {
+            Key = SystemSettingKeys.UpstreamAbsentAsnCountsPrefix + "wan",
+            Value = counterJson,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+
+        // New access ASN, and the transit ASN absent this run.
+        var state = RunState(NewAccessAsn);
+
+        await UpstreamRediscoveryService.EvaluateCompletedRunAsync(_db, state, CancellationToken.None);
+
+        state.IspChange.Should().NotBeNull();
+        state.RemovedTransitAsns.Should().BeEmpty();
+        state.PendingRemovalTransitAsns.Should().BeEmpty();
+        // Counters frozen, not advanced and not cleared - a confirm wipes them, a decline
+        // lets the next unchanged run resume normally.
+        var row = await _db.SystemSettings.SingleAsync(
+            s => s.Key == SystemSettingKeys.UpstreamAbsentAsnCountsPrefix + "wan");
+        row.Value.Should().Be(counterJson);
+    }
+
+    [Fact]
+    public async Task CompletedRun_without_isp_change_stages_transit_removals_normally()
+    {
+        SeedCommittedAccess(OldAccessAsn);
+        _db.MonitoringTargets.Add(Target("198.51.100.1", MonitoringTargetType.Transit, TransitAsn, "wan", DiscoveryMethod.DirectRouter));
+        _db.SystemSettings.Add(new SystemSetting
+        {
+            Key = SystemSettingKeys.UpstreamAbsentAsnCountsPrefix + "wan",
+            Value = $"{{\"transit:as{TransitAsn}\":{{\"c\":2,\"t\":\"{DateTime.UtcNow.AddHours(-24):o}\"}}}}",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+
+        var state = RunState(OldAccessAsn); // same provider, transit ASN absent
+
+        await UpstreamRediscoveryService.EvaluateCompletedRunAsync(_db, state, CancellationToken.None);
+
+        state.IspChange.Should().BeNull();
+        state.RemovedTransitAsns.Should().ContainSingle().Which.AsnNumber.Should().Be(TransitAsn);
+    }
+
+    // ---- Reset / decline application ----
+
+    [Fact]
+    public async Task ApplyReset_pauses_scope_and_wipes_counters_and_decline_memory()
+    {
+        _db.MonitoringTargets.AddRange(
+            Target("192.0.2.1", MonitoringTargetType.AccessIsp, OldAccessAsn, "wan", DiscoveryMethod.DirectRouter),
+            Target("198.51.100.1", MonitoringTargetType.Transit, TransitAsn, "wan", DiscoveryMethod.DirectRouter),
+            Target("203.0.113.5", MonitoringTargetType.InternetService, PathAsn, "wan", DiscoveryMethod.PathProxy),
+            Target("203.0.113.1", MonitoringTargetType.Transit, UserAsn, "", DiscoveryMethod.UserProvided),
+            // pinned to another WAN - must survive
+            Target("203.0.113.2", MonitoringTargetType.Transit, UserAsn, "wan2", DiscoveryMethod.UserProvided),
+            Target("198.51.100.2", MonitoringTargetType.Transit, TransitAsn, "wan2", DiscoveryMethod.DirectRouter));
+        _db.SystemSettings.AddRange(
+            new SystemSetting
+            {
+                Key = SystemSettingKeys.UpstreamAbsentAsnCountsPrefix + "wan",
+                Value = $"{{\"transit:as{TransitAsn}\":3}}",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            },
+            new SystemSetting
+            {
+                Key = SystemSettingKeys.UpstreamDeclinedAccessAsnPrefix + "wan",
+                Value = NewAccessAsn.ToString(),
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            });
+        await _db.SaveChangesAsync();
+
+        var paused = await UpstreamRediscoveryService.ApplyIspChangeResetAsync(_db, "wan", CancellationToken.None);
+        await _db.SaveChangesAsync();
+
+        paused.Should().Be(4);
+        var targets = await _db.MonitoringTargets.ToListAsync();
+        targets.Where(t => t.WanInterface == "wan" || t.WanInterface == "")
+            .Should().OnlyContain(t => !t.Enabled);
+        targets.Where(t => t.WanInterface == "wan2")
+            .Should().OnlyContain(t => t.Enabled);
+
+        (await _db.SystemSettings.SingleAsync(s => s.Key == SystemSettingKeys.UpstreamAbsentAsnCountsPrefix + "wan"))
+            .Value.Should().BeNull();
+        (await _db.SystemSettings.SingleAsync(s => s.Key == SystemSettingKeys.UpstreamDeclinedAccessAsnPrefix + "wan"))
+            .Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RecordDecline_upserts_the_new_asn()
+    {
+        await UpstreamRediscoveryService.RecordDeclinedIspChangeAsync(_db, "wan", NewAccessAsn, CancellationToken.None);
+        await _db.SaveChangesAsync();
+        await UpstreamRediscoveryService.RecordDeclinedIspChangeAsync(_db, "wan", 64511, CancellationToken.None);
+        await _db.SaveChangesAsync();
+
+        var row = await _db.SystemSettings.SingleAsync(
+            s => s.Key == SystemSettingKeys.UpstreamDeclinedAccessAsnPrefix + "wan");
+        row.Value.Should().Be("64511");
+    }
+
+    // ---- helpers ----
+
+    private void SeedCommittedAccess(int asn, string? name = null)
+    {
+        _db.MonitoringTargets.Add(Target("192.0.2.1", MonitoringTargetType.AccessIsp, asn, "wan",
+            DiscoveryMethod.DirectRouter, asnName: name));
+        _db.SaveChanges();
+    }
+
+    // Run state whose access hop resolved to `newAsn`; no transit ASNs, so any removal-eligible
+    // transit ASN reads as absent this run.
+    private static UpstreamTracerState RunState(int newAsn, string? newName = null) => new()
+    {
+        WanInterface = "wan",
+        AccessHops = { Hop("192.0.2.20", newAsn, newName) },
+    };
+
+    private static AccessHopCandidate Hop(string address, int? asn, string? asnName = null) => new()
+    {
+        TargetId = $"access-{address}",
+        Label = $"Access {address}",
+        Address = address,
+        AsnNumber = asn,
+        AsnName = asnName,
+        Method = DiscoveryMethod.DirectRouter,
+    };
+
+    private static MonitoringTarget Target(string address, MonitoringTargetType type, int? asn,
+        string wan, DiscoveryMethod? method, bool enabled = true, string? asnName = null) => new()
+    {
+        TargetId = $"{type}-{address}",
+        Name = $"{type} {address}",
+        Address = address,
+        TargetType = type,
+        AsnNumber = asn,
+        AsnName = asnName,
+        WanInterface = wan,
+        DiscoveryMethod = method,
+        Enabled = enabled,
+    };
+}

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamRediscoverySignatureTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamRediscoverySignatureTests.cs
@@ -10,7 +10,8 @@ namespace NetworkOptimizer.Web.Tests;
 /// Change-detection for the scheduled upstream re-discovery. Keys on a stable upstream-ASN
 /// identity (ECMP-proof), flags ADDED ASNs immediately, and gates REMOVED behind a consecutive-
 /// miss counter so incomplete/degraded runs don't nag. UserProvided (hand-added) targets suppress
-/// "added" but are never eligible for "removed".
+/// "added" and never make an ASN removal-eligible on their own - but once an auto-discovered
+/// sibling proves the ASN was on the path, a confirmed removal pauses hand-added targets too.
 ///
 /// All ASNs are RFC 5398 documentation ASNs (64496-64511) and all IPs are RFC 5737 ranges.
 /// </summary>
@@ -134,21 +135,38 @@ public class UpstreamRediscoverySignatureTests : IDisposable
     }
 
     [Fact]
-    public async Task AutoEnabled_view_is_enabled_auto_this_wan_only()
+    public async Task RemovalEligible_requires_auto_evidence_and_an_enabled_row()
     {
         _db.MonitoringTargets.AddRange(
+            // enabled auto - eligible
             Target("198.51.100.1", MonitoringTargetType.Transit, TransitAsnA, "wan", DiscoveryMethod.DirectRouter),
-            // disabled - excluded from removed-eligibility
+            // disabled auto with no enabled sibling - fully-disabled ASN, nothing to pause, not eligible
             Target("198.51.100.9", MonitoringTargetType.Transit, TransitAsnB, "wan", DiscoveryMethod.DirectRouter, enabled: false),
-            // UserProvided - excluded from removed-eligibility
+            // UserProvided only - no auto evidence the ASN was ever on the path, not eligible
             Target("203.0.113.1", MonitoringTargetType.Transit, UserAsn, "wan", DiscoveryMethod.UserProvided),
             // other WAN - excluded
             Target("198.51.100.10", MonitoringTargetType.Transit, PathAsn, "wan2", DiscoveryMethod.DirectRouter));
         await _db.SaveChangesAsync();
 
-        var (_, autoEnabled) = await UpstreamRediscoveryService.BuildCommittedViewsAsync(_db, "wan", CancellationToken.None);
+        var (_, removalEligible) = await UpstreamRediscoveryService.BuildCommittedViewsAsync(_db, "wan", CancellationToken.None);
 
-        autoEnabled.Should().BeEquivalentTo(new[] { $"transit:as{TransitAsnA}" });
+        removalEligible.Should().BeEquivalentTo(new[] { $"transit:as{TransitAsnA}" });
+    }
+
+    [Fact]
+    public async Task RemovalEligible_keeps_paused_auto_asn_with_enabled_manual_sibling()
+    {
+        // The dangling-manual case: the flaky auto target was paused, but a hand-added target in
+        // the same ASN is still enabled - the ASN must stay eligible so the sibling gets caught
+        // when the ASN goes dark. The manual row is WAN-agnostic (empty WanInterface).
+        _db.MonitoringTargets.AddRange(
+            Target("198.51.100.1", MonitoringTargetType.Transit, TransitAsnA, "wan", DiscoveryMethod.DirectRouter, enabled: false),
+            Target("203.0.113.1", MonitoringTargetType.Transit, TransitAsnA, "", DiscoveryMethod.UserProvided));
+        await _db.SaveChangesAsync();
+
+        var (_, removalEligible) = await UpstreamRediscoveryService.BuildCommittedViewsAsync(_db, "wan", CancellationToken.None);
+
+        removalEligible.Should().BeEquivalentTo(new[] { $"transit:as{TransitAsnA}" });
     }
 
     // ---- EvaluateChange ----
@@ -159,7 +177,7 @@ public class UpstreamRediscoverySignatureTests : IDisposable
         var monitored = Set($"transit:as{TransitAsnA}");
         var candidate = Set($"transit:as{TransitAsnA}", $"transit:as{TransitAsnB}");
 
-        var eval = UpstreamRediscoveryService.EvaluateChange(monitored, Set(), candidate, Empty, 3);
+        var eval = UpstreamRediscoveryService.EvaluateChange(monitored, Set(), candidate, Empty, Now, Gate, 3);
 
         eval.Added.Should().BeEquivalentTo(new[] { $"transit:as{TransitAsnB}" });
         eval.RemovalCandidates.Should().BeEmpty();
@@ -172,7 +190,7 @@ public class UpstreamRediscoverySignatureTests : IDisposable
         var monitored = Set($"transit:as{UserAsn}");
         var candidate = Set($"transit:as{UserAsn}");
 
-        var eval = UpstreamRediscoveryService.EvaluateChange(monitored, Set(), candidate, Empty, 3);
+        var eval = UpstreamRediscoveryService.EvaluateChange(monitored, Set(), candidate, Empty, Now, Gate, 3);
 
         eval.Added.Should().BeEmpty();
     }
@@ -183,9 +201,10 @@ public class UpstreamRediscoverySignatureTests : IDisposable
         var autoEnabled = Set($"transit:as{TransitAsnA}");
         var candidate = Set(); // A missing this run
 
-        var eval = UpstreamRediscoveryService.EvaluateChange(Set(), autoEnabled, candidate, Empty, 3);
+        var eval = UpstreamRediscoveryService.EvaluateChange(Set(), autoEnabled, candidate, Empty, Now, Gate, 3);
 
-        eval.NewMissCounts.Should().ContainKey($"transit:as{TransitAsnA}").WhoseValue.Should().Be(1);
+        eval.NewMisses.Should().ContainKey($"transit:as{TransitAsnA}").WhoseValue.Count.Should().Be(1);
+        eval.NewMisses[$"transit:as{TransitAsnA}"].LastIncrementUtc.Should().Be(Now);
         eval.RemovalCandidates.Should().BeEmpty();
     }
 
@@ -194,11 +213,11 @@ public class UpstreamRediscoverySignatureTests : IDisposable
     {
         var autoEnabled = Set($"transit:as{TransitAsnA}");
         var candidate = Set();
-        var prior = new Dictionary<string, int> { [$"transit:as{TransitAsnA}"] = 2 };
+        var prior = Prior($"transit:as{TransitAsnA}", 2); // last increment well past the gate
 
-        var eval = UpstreamRediscoveryService.EvaluateChange(Set(), autoEnabled, candidate, prior, 3);
+        var eval = UpstreamRediscoveryService.EvaluateChange(Set(), autoEnabled, candidate, prior, Now, Gate, 3);
 
-        eval.NewMissCounts[$"transit:as{TransitAsnA}"].Should().Be(3);
+        eval.NewMisses[$"transit:as{TransitAsnA}"].Count.Should().Be(3);
         eval.RemovalCandidates.Should().BeEquivalentTo(new[] { $"transit:as{TransitAsnA}" });
     }
 
@@ -207,35 +226,291 @@ public class UpstreamRediscoverySignatureTests : IDisposable
     {
         var autoEnabled = Set($"transit:as{TransitAsnA}");
         var candidate = Set($"transit:as{TransitAsnA}"); // present again
-        var prior = new Dictionary<string, int> { [$"transit:as{TransitAsnA}"] = 2 };
+        var prior = Prior($"transit:as{TransitAsnA}", 2);
 
-        var eval = UpstreamRediscoveryService.EvaluateChange(Set(), autoEnabled, candidate, prior, 3);
+        var eval = UpstreamRediscoveryService.EvaluateChange(Set(), autoEnabled, candidate, prior, Now, Gate, 3);
 
-        eval.NewMissCounts.Should().NotContainKey($"transit:as{TransitAsnA}"); // pruned by omission
+        eval.NewMisses.Should().NotContainKey($"transit:as{TransitAsnA}"); // pruned by omission
         eval.RemovalCandidates.Should().BeEmpty();
     }
 
     [Fact]
-    public void Disabled_flaky_target_neither_added_nor_removed()
+    public void Miss_within_gate_holds_count_and_timestamp_instead_of_incrementing()
     {
-        // Monitored (suppresses added) but NOT auto-enabled (not removal-eligible). Discovery still
-        // finds the ASN, so nothing flags - and nothing would get silently re-enabled by a commit.
+        // Absent again, but only 1h since the last increment (< 6h gate): count must NOT advance,
+        // and the timestamp must stay put so the next in-window miss is also held.
+        var autoEnabled = Set($"transit:as{TransitAsnA}");
+        var candidate = Set();
+        var lastInc = Now.AddHours(-1);
+        var prior = Prior($"transit:as{TransitAsnA}", 2, hoursAgo: 1);
+
+        var eval = UpstreamRediscoveryService.EvaluateChange(Set(), autoEnabled, candidate, prior, Now, Gate, 3);
+
+        eval.NewMisses[$"transit:as{TransitAsnA}"].Count.Should().Be(2); // held, not 3
+        eval.NewMisses[$"transit:as{TransitAsnA}"].LastIncrementUtc.Should().Be(lastInc);
+        eval.RemovalCandidates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Miss_after_gate_elapses_increments()
+    {
+        var autoEnabled = Set($"transit:as{TransitAsnA}");
+        var candidate = Set();
+        var prior = Prior($"transit:as{TransitAsnA}", 1, hoursAgo: 6); // exactly at the gate
+
+        var eval = UpstreamRediscoveryService.EvaluateChange(Set(), autoEnabled, candidate, prior, Now, Gate, 3);
+
+        eval.NewMisses[$"transit:as{TransitAsnA}"].Count.Should().Be(2);
+        eval.NewMisses[$"transit:as{TransitAsnA}"].LastIncrementUtc.Should().Be(Now);
+    }
+
+    [Fact]
+    public void Confirmed_asn_gated_this_run_stays_a_removal_candidate()
+    {
+        // Already at threshold and absent again within the gate: it holds at 3 (doesn't climb) but
+        // must remain a removal candidate so a gated recheck can't un-confirm it.
+        var autoEnabled = Set($"transit:as{TransitAsnA}");
+        var candidate = Set();
+        var prior = Prior($"transit:as{TransitAsnA}", 3, hoursAgo: 1);
+
+        var eval = UpstreamRediscoveryService.EvaluateChange(Set(), autoEnabled, candidate, prior, Now, Gate, 3);
+
+        eval.NewMisses[$"transit:as{TransitAsnA}"].Count.Should().Be(3);
+        eval.RemovalCandidates.Should().BeEquivalentTo(new[] { $"transit:as{TransitAsnA}" });
+    }
+
+    [Fact]
+    public void Fully_disabled_asn_neither_added_nor_removed()
+    {
+        // Monitored (suppresses added) but not removal-eligible (every target in the ASN is
+        // disabled - nothing to pause). Discovery still finds the ASN, so nothing flags - and
+        // nothing would get silently re-enabled by a commit.
         var monitored = Set($"transit:as{TransitAsnB}");
-        var autoEnabled = Set(); // disabled => not eligible for removed
+        var removalEligible = Set(); // fully disabled => not eligible for removed
         var candidate = Set($"transit:as{TransitAsnB}");
 
-        var eval = UpstreamRediscoveryService.EvaluateChange(monitored, autoEnabled, candidate, Empty, 3);
+        var eval = UpstreamRediscoveryService.EvaluateChange(monitored, removalEligible, candidate, Empty, Now, Gate, 3);
 
         eval.Added.Should().BeEmpty();
         eval.RemovalCandidates.Should().BeEmpty();
-        eval.NewMissCounts.Should().BeEmpty();
+        eval.NewMisses.Should().BeEmpty();
+    }
+
+    // ---- BuildRemovedTransitAsns (pause entries) ----
+
+    [Fact]
+    public async Task RemovedTransitAsns_counts_enabled_auto_and_wan_agnostic_manual_targets()
+    {
+        _db.MonitoringTargets.AddRange(
+            Target("198.51.100.1", MonitoringTargetType.Transit, TransitAsnA, "wan", DiscoveryMethod.DirectRouter),
+            // hand-added, WAN-agnostic - counted and reported as manual
+            Target("203.0.113.1", MonitoringTargetType.Transit, TransitAsnA, "", DiscoveryMethod.UserProvided),
+            // disabled - already paused, not counted
+            Target("198.51.100.2", MonitoringTargetType.Transit, TransitAsnA, "wan", DiscoveryMethod.DirectRouter, enabled: false),
+            // other-WAN auto - not counted
+            Target("198.51.100.3", MonitoringTargetType.Transit, TransitAsnA, "wan2", DiscoveryMethod.DirectRouter),
+            // other ASN, not in the confirmed list - no entry
+            Target("198.51.100.4", MonitoringTargetType.Transit, TransitAsnB, "wan", DiscoveryMethod.DirectRouter));
+        await _db.SaveChangesAsync();
+
+        var result = await UpstreamRediscoveryService.BuildRemovedTransitAsnsAsync(
+            _db, "wan", new[] { $"transit:as{TransitAsnA}" }, CancellationToken.None);
+
+        var entry = result.Should().ContainSingle().Subject;
+        entry.AsnNumber.Should().Be(TransitAsnA);
+        entry.TargetCount.Should().Be(2);
+        entry.ManualCount.Should().Be(1);
+        entry.Keep.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RemovedTransitAsns_ignores_non_transit_keys_address_keys_and_fully_disabled_asns()
+    {
+        _db.MonitoringTargets.AddRange(
+            // fully disabled ASN - confirmed removed but nothing to pause -> no entry, no nag
+            Target("198.51.100.9", MonitoringTargetType.Transit, TransitAsnB, "wan", DiscoveryMethod.DirectRouter, enabled: false),
+            // enabled access target - access keys aren't handled by this detector
+            Target("192.0.2.1", MonitoringTargetType.AccessIsp, AccessAsn, "wan", DiscoveryMethod.DirectRouter));
+        await _db.SaveChangesAsync();
+
+        var result = await UpstreamRediscoveryService.BuildRemovedTransitAsnsAsync(
+            _db, "wan",
+            new[] { $"transit:as{TransitAsnB}", $"access:as{AccessAsn}", "transit:198.51.100.77", $"path:as{PathAsn}" },
+            CancellationToken.None);
+
+        result.Should().BeEmpty();
+    }
+
+    // ---- Miss-counter clearing on commit ----
+
+    [Fact]
+    public async Task ClearMissCountKeys_removes_only_the_given_keys()
+    {
+        _db.SystemSettings.Add(new SystemSetting
+        {
+            Key = SystemSettingKeys.UpstreamAbsentAsnCountsPrefix + "wan",
+            Value = $"{{\"transit:as{TransitAsnA}\":3,\"access:as{AccessAsn}\":2}}",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+
+        await UpstreamRediscoveryService.ClearMissCountKeysAsync(
+            _db, "wan", new[] { $"transit:as{TransitAsnA}" }, CancellationToken.None);
+        await _db.SaveChangesAsync();
+
+        var row = await _db.SystemSettings.SingleAsync(
+            s => s.Key == SystemSettingKeys.UpstreamAbsentAsnCountsPrefix + "wan");
+        row.Value.Should().Contain($"access:as{AccessAsn}").And.NotContain($"transit:as{TransitAsnA}");
+    }
+
+    // ---- EvaluateCompletedRunAsync (pending vs confirmed staging) ----
+
+    [Fact]
+    public async Task CompletedRun_stages_pending_tracking_when_below_threshold()
+    {
+        // Dangling-manual AS: auto evidence disabled, manual enabled, absent this run, prior count 1
+        // last incremented well past the gate so this run advances it.
+        SeedDanglingManualAsn(TransitAsnA, priorCount: 1, lastIncrementUtc: DateTime.UtcNow.AddHours(-24));
+        var state = AbsentRunState(TransitAsnA);
+
+        await UpstreamRediscoveryService.EvaluateCompletedRunAsync(_db, state, CancellationToken.None);
+
+        state.RemovedTransitAsns.Should().BeEmpty();
+        var p = state.PendingRemovalTransitAsns.Should().ContainSingle().Subject;
+        p.AsnNumber.Should().Be(TransitAsnA);
+        p.MissCount.Should().Be(2);       // 1 -> 2
+        p.RunsRemaining.Should().Be(1);   // threshold 3 - 2
+        p.TargetCount.Should().Be(1);     // only the enabled manual row would pause
+        p.ManualCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CompletedRun_confirms_and_leaves_pending_empty_at_threshold()
+    {
+        // Same dangling-manual AS, but prior count 2 (past the gate) -> this run hits threshold 3.
+        SeedDanglingManualAsn(TransitAsnA, priorCount: 2, lastIncrementUtc: DateTime.UtcNow.AddHours(-24));
+        var state = AbsentRunState(TransitAsnA);
+
+        await UpstreamRediscoveryService.EvaluateCompletedRunAsync(_db, state, CancellationToken.None);
+
+        state.PendingRemovalTransitAsns.Should().BeEmpty();
+        var r = state.RemovedTransitAsns.Should().ContainSingle().Subject;
+        r.AsnNumber.Should().Be(TransitAsnA);
+        r.TargetCount.Should().Be(1);
+        r.ManualCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CompletedRun_holds_count_when_within_gate()
+    {
+        // Prior increment 1h ago (< 6h gate): an absent run must NOT advance the count - it stays
+        // pending at 2 rather than confirming, so rapid re-traces can't rush a removal.
+        SeedDanglingManualAsn(TransitAsnA, priorCount: 2, lastIncrementUtc: DateTime.UtcNow.AddHours(-1));
+        var state = AbsentRunState(TransitAsnA);
+
+        await UpstreamRediscoveryService.EvaluateCompletedRunAsync(_db, state, CancellationToken.None);
+
+        state.RemovedTransitAsns.Should().BeEmpty();
+        var p = state.PendingRemovalTransitAsns.Should().ContainSingle().Subject;
+        p.MissCount.Should().Be(2);
+        p.RunsRemaining.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CompletedRun_confirms_once_gate_has_elapsed()
+    {
+        // Same count, but the last increment was 7h ago (> 6h gate): this run advances 2 -> 3.
+        SeedDanglingManualAsn(TransitAsnA, priorCount: 2, lastIncrementUtc: DateTime.UtcNow.AddHours(-7));
+        var state = AbsentRunState(TransitAsnA);
+
+        await UpstreamRediscoveryService.EvaluateCompletedRunAsync(_db, state, CancellationToken.None);
+
+        state.PendingRemovalTransitAsns.Should().BeEmpty();
+        state.RemovedTransitAsns.Should().ContainSingle().Which.AsnNumber.Should().Be(TransitAsnA);
+    }
+
+    [Fact]
+    public async Task CompletedRun_reads_legacy_intonly_counter_and_advances()
+    {
+        // Legacy stored format (a bare int, no timestamp) must load as immediately gate-eligible so
+        // an in-flight counter from before the gate keeps advancing after upgrade.
+        SeedLegacyDanglingManualAsn(TransitAsnA, priorCount: 2);
+        var state = AbsentRunState(TransitAsnA);
+
+        await UpstreamRediscoveryService.EvaluateCompletedRunAsync(_db, state, CancellationToken.None);
+
+        state.PendingRemovalTransitAsns.Should().BeEmpty();
+        state.RemovedTransitAsns.Should().ContainSingle().Which.AsnNumber.Should().Be(TransitAsnA);
     }
 
     // ---- helpers ----
 
+    private void SeedDanglingManualTargets(int asn)
+    {
+        _db.MonitoringTargets.AddRange(
+            Target("198.51.100.1", MonitoringTargetType.Transit, asn, "wan", DiscoveryMethod.DirectRouter, enabled: false),
+            Target("203.0.113.1", MonitoringTargetType.Transit, asn, "", DiscoveryMethod.UserProvided));
+    }
+
+    // Dangling-manual ASN with a current-format counter (count + last-increment timestamp).
+    private void SeedDanglingManualAsn(int asn, int priorCount, DateTime lastIncrementUtc)
+    {
+        SeedDanglingManualTargets(asn);
+        _db.SystemSettings.Add(new SystemSetting
+        {
+            Key = SystemSettingKeys.UpstreamAbsentAsnCountsPrefix + "wan",
+            Value = $"{{\"transit:as{asn}\":{{\"c\":{priorCount},\"t\":\"{lastIncrementUtc:o}\"}}}}",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        _db.SaveChanges();
+    }
+
+    // Dangling-manual ASN with a legacy counter (a bare int, no timestamp).
+    private void SeedLegacyDanglingManualAsn(int asn, int priorCount)
+    {
+        SeedDanglingManualTargets(asn);
+        _db.SystemSettings.Add(new SystemSetting
+        {
+            Key = SystemSettingKeys.UpstreamAbsentAsnCountsPrefix + "wan",
+            Value = $"{{\"transit:as{asn}\":{priorCount}}}",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        _db.SaveChanges();
+    }
+
+    // Run state whose candidate signature excludes `absentAsn` (an unrelated ASN is present so the
+    // signature isn't empty), i.e. the given ASN went off-path this run.
+    private static UpstreamTracerState AbsentRunState(int absentAsn)
+    {
+        var other = absentAsn == TransitAsnB ? TransitAsnA : TransitAsnB;
+        return new UpstreamTracerState
+        {
+            WanInterface = "wan",
+            TransitAsns = { Transit("198.51.100.9", other, DiscoveryMethod.DirectRouter) },
+        };
+    }
+
+
     private static HashSet<string> Set(params string[] keys) => new(keys, StringComparer.OrdinalIgnoreCase);
 
-    private static readonly Dictionary<string, int> Empty = new(StringComparer.OrdinalIgnoreCase);
+    // Fixed evaluation clock + gate for the pure EvaluateChange tests.
+    private static readonly DateTime Now = new(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly TimeSpan Gate = TimeSpan.FromHours(6);
+
+    private static readonly Dictionary<string, UpstreamRediscoveryService.MissRecord> Empty =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    // A prior-miss map with one entry whose last increment was `hoursAgo` before Now (default well
+    // past the gate, so the next miss increments).
+    private static Dictionary<string, UpstreamRediscoveryService.MissRecord> Prior(
+        string key, int count, double hoursAgo = 24) =>
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            [key] = new UpstreamRediscoveryService.MissRecord(count, Now.AddHours(-hoursAgo)),
+        };
 
     private static AccessHopCandidate Hop(string address, int? asn, bool enabled = true, bool unreachable = false) => new()
     {

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamTracerL2NeighborTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamTracerL2NeighborTests.cs
@@ -13,6 +13,86 @@ namespace NetworkOptimizer.Web.Tests;
 public class UpstreamTracerL2NeighborTests
 {
     [Fact]
+    public void Routed_default_gateway_wins_over_higher_scoring_same_subnet_peer()
+    {
+        // Shared WAN subnet (metro Ethernet / two sites on one carrier segment): a peer
+        // host is REACHABLE and public while the true gateway is STALE - the heuristic
+        // scoring would pick the peer, the routed gateway must win.
+        const string output = """
+            203.0.113.7 lladdr aa:bb:cc:dd:ee:01 REACHABLE
+            203.0.113.1 lladdr aa:bb:cc:dd:ee:06 STALE
+            """;
+
+        var selected = UpstreamTracerService.SelectWanNeighbor(output, "203.0.113.5/24", "203.0.113.1");
+
+        selected!.Value.Ip.Should().Be("203.0.113.1");
+        selected.Value.Mac.Should().Be("aa:bb:cc:dd:ee:06");
+    }
+
+    [Fact]
+    public void Falls_back_to_scoring_when_routed_gateway_has_no_neighbor_entry()
+    {
+        const string output = """
+            192.168.1.254 lladdr aa:bb:cc:dd:ee:06 STALE
+            203.0.113.1 lladdr aa:bb:cc:dd:ee:06 REACHABLE
+            """;
+
+        UpstreamTracerService.SelectWanNeighbor(output, null, "198.51.100.99")!
+            .Value.Ip.Should().Be("203.0.113.1");
+    }
+
+    [Fact]
+    public void SelectWanDefaultGateway_finds_the_wan_table_default()
+    {
+        const string routes = """
+            default via 192.168.1.1 dev br0 table 205
+            default via 203.0.113.1 dev eth8 table 201
+            default via 198.51.100.1 dev eth9 table 202
+            """;
+
+        UpstreamTracerService.SelectWanDefaultGateway(routes, "eth8").Should().Be("203.0.113.1");
+        UpstreamTracerService.SelectWanDefaultGateway(routes, "eth9").Should().Be("198.51.100.1");
+    }
+
+    [Fact]
+    public void SelectWanDefaultGateway_matches_whole_iface_name_only()
+    {
+        // "eth8" must not match "eth8.35"'s line and vice versa.
+        const string routes = """
+            default via 203.0.113.1 dev eth8.35 table 201
+            """;
+
+        UpstreamTracerService.SelectWanDefaultGateway(routes, "eth8").Should().BeNull();
+        UpstreamTracerService.SelectWanDefaultGateway(routes, "eth8.35").Should().Be("203.0.113.1");
+    }
+
+    [Fact]
+    public void SelectWanDefaultGateway_ignores_onlink_ppp_default()
+    {
+        // PPPoE default has no "via" - no gateway address (and no MAC) to extract.
+        const string routes = """
+            default dev ppp0 scope link table 201
+            """;
+
+        UpstreamTracerService.SelectWanDefaultGateway(routes, "ppp0").Should().BeNull();
+    }
+
+    [Fact]
+    public void SelectWanDefaultGateway_handles_metric_and_proto_suffixes()
+    {
+        const string routes = "default via 203.0.113.1 dev eth8 proto static metric 220";
+
+        UpstreamTracerService.SelectWanDefaultGateway(routes, "eth8").Should().Be("203.0.113.1");
+    }
+
+    [Fact]
+    public void SelectWanDefaultGateway_returns_null_for_empty_input()
+    {
+        UpstreamTracerService.SelectWanDefaultGateway(null, "eth8").Should().BeNull();
+        UpstreamTracerService.SelectWanDefaultGateway("", "eth8").Should().BeNull();
+    }
+
+    [Fact]
     public void Prefers_public_reachable_over_private_stale_with_same_mac()
     {
         const string output = """

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
@@ -1007,6 +1007,214 @@ public class ComputeExcludedTier1AsnsTests
     }
 }
 
+public class DetermineAccessAsnTests
+{
+    // Real ASNs because the logic keys on destination sets built from real endpoints;
+    // all hop IPs are RFC 5737 documentation addresses.
+    private const int Bell = 577;
+    private const int Cloudflare = 13335;
+    private const int Google = 15169;
+
+    private static IReadOnlySet<int> Dest => new HashSet<int> { Cloudflare, Google };
+    private static IReadOnlySet<int> NoDest => new HashSet<int>();
+
+    private static Dictionary<string, int> Map(params (string Ip, int Asn)[] e)
+        => e.ToDictionary(x => x.Ip, x => x.Asn, StringComparer.OrdinalIgnoreCase);
+
+    // The #984 shape: Bell's first mile is RFC1918 + unannounced public space (absent
+    // from the ASN map), so on the Cloudflare trace the first attributable hop is
+    // Cloudflare's own edge. Bell only appears on the Google trace, one hop deeper.
+    private static readonly IReadOnlyList<string>[] BellTraces =
+    {
+        new[] { "10.0.0.2", "203.0.113.10", "203.0.113.11", "198.51.100.7", "198.51.100.8" }, // -> 1.1.1.1: CF edge at depth 4
+        new[] { "10.0.0.2", "203.0.113.10", "203.0.113.12", "192.0.2.60", "198.51.100.9" },   // -> 8.8.8.8: Bell at depth 4
+    };
+
+    private static readonly Dictionary<string, int> BellMap = Map(
+        ("198.51.100.7", Cloudflare), ("198.51.100.8", Cloudflare),
+        ("192.0.2.60", Bell), ("198.51.100.9", Google));
+
+    [Fact]
+    public void Destination_edge_is_not_crowned_access_isp()
+    {
+        // Even with no WAN IP signal (CGNAT), voting skips destination ASNs: the
+        // Cloudflare trace contributes no vote, the Google trace votes Bell.
+        UpstreamTracerService.DetermineAccessAsn(BellTraces, BellMap, wanIpAsn: null, Dest)
+            .Should().Be(Bell);
+    }
+
+    [Fact]
+    public void Wan_ip_asn_wins_when_corroborated_by_a_hop()
+    {
+        UpstreamTracerService.DetermineAccessAsn(BellTraces, BellMap, wanIpAsn: Bell, Dest)
+            .Should().Be(Bell);
+    }
+
+    [Fact]
+    public void Wan_ip_asn_kept_when_no_hop_is_attributable_at_all()
+    {
+        // Fully silent/unannounced first mile and no announced ISP hop responded:
+        // keep the WAN allocation's ASN for labeling and curated fallbacks.
+        var traces = new[] { new[] { "10.0.0.2", "203.0.113.10" } };
+        UpstreamTracerService.DetermineAccessAsn(traces, new Dictionary<string, int>(), Bell, Dest)
+            .Should().Be(Bell);
+    }
+
+    [Fact]
+    public void Uncorroborated_wan_asn_defers_to_the_voted_winner()
+    {
+        // WAN allocation resolves to a sibling ASN that never appears on any hop;
+        // the ASN actually fronting the traces wins.
+        UpstreamTracerService.DetermineAccessAsn(BellTraces, BellMap, wanIpAsn: 64499, Dest)
+            .Should().Be(Bell);
+    }
+
+    [Fact]
+    public void Wan_asn_that_is_also_a_destination_can_win()
+    {
+        // An access ISP that is one of our probed orgs is legitimate when the WAN
+        // IP itself resolves to it - the destination skip only guards voting.
+        var traces = new IReadOnlyList<string>[] { new[] { "198.51.100.9" } };
+        var map = Map(("198.51.100.9", Google));
+        UpstreamTracerService.DetermineAccessAsn(traces, map, wanIpAsn: Google, Dest)
+            .Should().Be(Google);
+    }
+
+    [Fact]
+    public void Majority_vote_beats_a_single_shallower_sighting()
+    {
+        var traces = new IReadOnlyList<string>[]
+        {
+            new[] { "192.0.2.1" },                            // odd ASN out at depth 1
+            new[] { "203.0.113.1", "203.0.113.2", "192.0.2.10" },
+            new[] { "203.0.113.1", "203.0.113.3", "192.0.2.11" },
+            new[] { "203.0.113.1", "203.0.113.4", "192.0.2.12" },
+        };
+        var map = Map(("192.0.2.1", 64501),
+            ("192.0.2.10", 64502), ("192.0.2.11", 64502), ("192.0.2.12", 64502));
+        UpstreamTracerService.DetermineAccessAsn(traces, map, null, NoDest)
+            .Should().Be(64502);
+    }
+
+    [Fact]
+    public void Vote_tie_breaks_toward_the_shallowest_hop()
+    {
+        var traces = new IReadOnlyList<string>[]
+        {
+            new[] { "192.0.2.1" },                  // ASN 64510 at depth 1
+            new[] { "203.0.113.1", "192.0.2.2" },   // ASN 64505 at depth 2
+        };
+        var map = Map(("192.0.2.1", 64510), ("192.0.2.2", 64505));
+        UpstreamTracerService.DetermineAccessAsn(traces, map, null, NoDest)
+            .Should().Be(64510);
+    }
+
+    [Fact]
+    public void Simple_announced_first_hop_still_wins()
+    {
+        var traces = new IReadOnlyList<string>[] { new[] { "192.0.2.1", "198.51.100.7" } };
+        var map = Map(("192.0.2.1", 64500), ("198.51.100.7", Cloudflare));
+        UpstreamTracerService.DetermineAccessAsn(traces, map, null, Dest)
+            .Should().Be(64500);
+    }
+
+    [Fact]
+    public void No_data_yields_null()
+    {
+        UpstreamTracerService.DetermineAccessAsn(
+                Array.Empty<IReadOnlyList<string>>(), new Dictionary<string, int>(), null, NoDest)
+            .Should().BeNull();
+    }
+}
+
+public class CollectUnannouncedAccessAddressesTests
+{
+    private const int Bell = 577;
+    private const int Cloudflare = 13335;
+
+    private static Dictionary<string, int> Map(params (string Ip, int Asn)[] e)
+        => e.ToDictionary(x => x.Ip, x => x.Asn, StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void Unannounced_public_hops_before_the_access_border_are_attributed()
+    {
+        // The #984 shape: RFC1918, then unannounced public space, then the announced
+        // access-ASN border. The public hops are kept; the RFC1918 hop is not.
+        var traces = new IReadOnlyList<string>[]
+        {
+            new[] { "10.0.0.2", "203.0.113.10", "203.0.113.11", "192.0.2.60" }
+        };
+        var map = Map(("192.0.2.60", Bell));
+
+        UpstreamTracerService.CollectUnannouncedAccessAddresses(traces, map, Bell)
+            .Should().Equal("203.0.113.10", "203.0.113.11");
+    }
+
+    [Fact]
+    public void Cgnat_prefix_hops_are_attributed()
+    {
+        var traces = new IReadOnlyList<string>[] { new[] { "100.64.0.5", "192.0.2.60" } };
+        var map = Map(("192.0.2.60", Bell));
+
+        UpstreamTracerService.CollectUnannouncedAccessAddresses(traces, map, Bell)
+            .Should().Equal("100.64.0.5");
+    }
+
+    [Fact]
+    public void Rfc1918_hops_are_never_attributed()
+    {
+        var traces = new IReadOnlyList<string>[] { new[] { "10.0.0.2", "172.16.0.2", "192.168.1.2", "192.0.2.60" } };
+        var map = Map(("192.0.2.60", Bell));
+
+        UpstreamTracerService.CollectUnannouncedAccessAddresses(traces, map, Bell)
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Trace_whose_first_attributed_hop_is_not_the_access_asn_contributes_nothing()
+    {
+        // A trace that only ever surfaces the destination's edge can't prove its
+        // unattributed prefix sits below the access border.
+        var traces = new IReadOnlyList<string>[]
+        {
+            new[] { "203.0.113.10", "198.51.100.7" }
+        };
+        var map = Map(("198.51.100.7", Cloudflare));
+
+        UpstreamTracerService.CollectUnannouncedAccessAddresses(traces, map, Bell)
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Dedupes_across_traces_preserving_first_seen_order()
+    {
+        var traces = new IReadOnlyList<string>[]
+        {
+            new[] { "203.0.113.10", "192.0.2.60" },
+            new[] { "203.0.113.10", "203.0.113.12", "192.0.2.61" },
+        };
+        var map = Map(("192.0.2.60", Bell), ("192.0.2.61", Bell));
+
+        UpstreamTracerService.CollectUnannouncedAccessAddresses(traces, map, Bell)
+            .Should().Equal("203.0.113.10", "203.0.113.12");
+    }
+
+    [Fact]
+    public void Hops_after_the_access_border_are_not_attributed()
+    {
+        // Only the pre-border prefix counts: unattributed hops BETWEEN access and
+        // transit (e.g. an IXP LAN) must not be pulled into the access cloud.
+        var traces = new IReadOnlyList<string>[]
+        {
+            new[] { "192.0.2.60", "203.0.113.50", "198.51.100.7" }
+        };
+        var map = Map(("192.0.2.60", Bell), ("198.51.100.7", Cloudflare));
+
+        UpstreamTracerService.CollectUnannouncedAccessAddresses(traces, map, Bell)
+            .Should().BeEmpty();
+    }
+}
+
 public class AccessIspFallbackTests
 {
     [Fact]


### PR DESCRIPTION
Placeholder roll-up for the next patch release. More changes will be added before it ships.

## Client Performance

- **Simplified view for VPN clients** - Tailscale, Teleport, and UniFi remote-user-VPN clients (which never appear in the UniFi client list) now get a purpose-built dashboard: the same VPN logo used in path traces, the client name and IP, both speed-test buttons, live speed results, the speed map, and per-result path traces. Detection reuses the same classifier that drives the VPN hop in traces.
- **Clearer "device not found" copy** on the local site - distinguishes "console unreachable" from "console fine but your device isn't listed yet," and surfaces the detected address.
- **Managed-site cold connection** - when the on-site agent's tunnel is still coming up, the dashboard shows the device picker immediately and keeps probing in the background, auto-loading the moment identity resolves instead of stranding you until a manual refresh.

## LAN Speed Test

- **Speed map auto-fit on new results and time-range changes** - a freshly completed test, or changing the time range, now brings the visible results back into view (unless you've manually panned or zoomed). Applies to both the LAN Speed Test map and the Client Performance speed map.

## Monitoring

- **Off-path transit networks get cleaned up** - when your ISP re-routes and stops sending traffic through a transit network, the monitoring targets for it keep reporting loss and latency for a path you no longer use, dragging down ISP Health. The Setup tab's Upstream path discovery now notices when a transit ASN has been off your path for a sustained stretch and surfaces it in the review so you can pause its targets on save. Hand-added targets in that network are caught too, and nothing is ever deleted.
- **"Did you switch internet providers?"** - when Upstream path discovery finds your access ISP itself changed (a whole new provider, not just a re-route), it asks. Confirm and it pauses all your old upstream targets in one step and adopts the freshly discovered path as the new baseline; decline and it leaves everything alone and won't ask again about that network. One trace, one save, no dangling old targets reporting 100% loss.
- **Right access ISP on silent first miles** - some fiber and PPPoE setups have a first mile that doesn't announce itself (the ISP's own routers resolve to no ASN), which let Upstream path discovery crown the wrong provider as your access ISP - in one case a DNS resolver's own edge (Cloudflare) instead of the real ISP. Detection now anchors on your gateway's public WAN address, so the actual ISP is identified even when every early hop is silent, and those first-mile hops become monitorable targets instead of being mislabeled or dropped.
- **First-mile device picks the real WAN gateway** - on a shared WAN segment (metro Ethernet, two sites on one carrier subnet), the first-mile device could be read from an unrelated neighbor on the same segment. It now uses the WAN's actual default gateway from the routing table, so the right upstream device is identified.
- **Flaky monitoring targets advisory clears itself when things recover** - a target flagged in the Flaky monitoring targets advisory now drops off the list once its recent monitoring is clean again, instead of nagging for up to two days while the old bad data ages out. A target that was fully offline and comes back clears within about half an hour, while genuinely flaky partial loss still has to prove itself stable over a few hours.
- **Flaky monitoring targets advisory on ISP Health** - the advisory (internet/transit targets whose loss skews ISP Health scoring) now also appears on the ISP Health tab where the score lives, not only on Live View, and it clears automatically once you disable the flagged targets.
- **Device-host naming in logs** - ONT, cable modem, and cellular modem poll failures and stored host names now name the configured device host instead of the internal tunnel-proxy loopback, so logs point at the real device on agent-routed sites.
- **Agent versions without build metadata** - agent version labels drop the `+build` suffix, matching the footer.

## Reconnecting

- **Break out of a wedged reconnect spinner** - if the "Reconnecting..." spinner is stuck (dead-but-open socket or stalled retries), the app probes the server every few seconds and reloads once it answers; if the server is down it waits and re-probes rather than reloading into a dead server.

## Multi-Site

- **Current site opens its dashboard** - clicking the site you're already on now opens its dashboard instead of doing nothing. Ctrl/cmd/shift/middle-click still opens the site in a new tab.

## Settings

- **Settings polish** - darker settings-table row hover so rows read differently from buttons, native form controls (number spinners, date/color pickers) rendered in dark chrome, and the site-name field is focused when you click its edit button.
