### PR TITLE
Pause off-path transit ASNs, reset on ISP change, and unflag recovered flaky targets

### DIFF
--- a/src/NetworkOptimizer.Storage/Models/SystemSetting.cs
+++ b/src/NetworkOptimizer.Storage/Models/SystemSetting.cs
@@ -85,6 +85,12 @@ public static class SystemSettingKeys
     // key is this prefix + WanInterface; the value is a JSON map of ASN identity -> miss count.
     public const string UpstreamAbsentAsnCountsPrefix = "upstream.absent_asn_counts.";
 
+    // Per-WAN "seen but declined" access-ISP change memory. The full key is this prefix +
+    // WanInterface; the value is the new access ASN the user said was NOT a provider switch,
+    // so the same detected change doesn't re-prompt on every discovery run. Cleared when a
+    // later ISP change is confirmed (fresh baseline).
+    public const string UpstreamDeclinedAccessAsnPrefix = "upstream.declined_access_asn.";
+
     // Map / Satellite settings
     public const string MapboxApiKey = "map.mapbox_token";
 

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -255,7 +255,7 @@
                             <table class="data-table">
                                 <thead>
                                     <tr>
-                                        <th style="width: 40px;">Keep</th>
+                                        <th style="width: 90px;">Keep Active</th>
                                         <th>ASN</th>
                                         <th>Targets to pause</th>
                                     </tr>

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -246,6 +246,38 @@
                     </div>
                 }
 
+                @if (_state.RemovedTransitAsns.Count > 0)
+                {
+                    <div class="form-group">
+                        <label class="form-label">No longer on your path</label>
+                        <p class="section-description">These transit networks were being monitored but haven't appeared in the last several discovery runs - your ISP no longer routes through them, so their targets would report false problems. They'll be paused when you save; re-check any you want to keep. Nothing is deleted.</p>
+                        <div class="table-responsive">
+                            <table class="data-table">
+                                <thead>
+                                    <tr>
+                                        <th style="width: 40px;">Keep</th>
+                                        <th>ASN</th>
+                                        <th>Targets to pause</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var removed in _state.RemovedTransitAsns)
+                                    {
+                                        <tr class="@(removed.Keep ? "" : "row-disabled")">
+                                            <td>
+                                                <input type="checkbox" checked="@removed.Keep"
+                                                       @onchange="e => removed.Keep = (bool)e.Value!" />
+                                            </td>
+                                            <td><code>AS@(removed.AsnNumber)</code> <span class="text-muted">@removed.AsnName</span></td>
+                                            <td>@(removed.TargetCount == 1 ? "1 target" : $"{removed.TargetCount} targets")@(removed.ManualCount > 0 ? $" ({removed.ManualCount} hand-added)" : "")</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                }
+
                 @if (PathEndHosts.Count > 0)
                 {
                     <div class="form-group">
@@ -283,7 +315,7 @@
                     </div>
                 }
 
-                @if (_state.AccessHops.Count == 0 && _state.TransitAsns.Count == 0)
+                @if (_state.AccessHops.Count == 0 && _state.TransitAsns.Count == 0 && _state.RemovedTransitAsns.Count == 0)
                 {
                     <div class="alert alert-info">
                         No upstream hops responded to either ICMP or UDP traceroute. Your
@@ -293,7 +325,7 @@
 
                 <div class="action-buttons">
                     <button class="btn btn-secondary" @onclick="StartAsync">Re-run discovery</button>
-                    @if (_state.AccessHops.Any(h => h.Enabled) || _state.TransitAsns.Any(a => a.Enabled))
+                    @if (_state.AccessHops.Any(h => h.Enabled) || _state.TransitAsns.Any(a => a.Enabled) || _state.RemovedTransitAsns.Count > 0)
                     {
                         <button class="btn btn-primary" @onclick="CommitAsync">Save monitoring targets</button>
                     }

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -255,7 +255,7 @@
                             <table class="data-table">
                                 <thead>
                                     <tr>
-                                        <th style="width: 90px;">Keep Active</th>
+                                        <th style="width: 115px;">Keep Active</th>
                                         <th>ASN</th>
                                         <th>Targets to pause</th>
                                     </tr>

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -107,6 +107,40 @@
 
             @if (_state.Step == TracerStep.ReviewingResults)
             {
+                @if (_state.IspChange != null)
+                {
+                    var change = _state.IspChange;
+                    <div class="alert alert-warning isp-change-review">
+                        <strong>Did you switch internet providers?</strong>
+                        <p>
+                            This discovery reached the internet through
+                            <code>AS@(change.NewAsnNumber)</code> <span class="text-muted">(@change.NewAsnName)</span>,
+                            but your upstream monitoring is set up for
+                            <code>AS@(change.OldAsnNumber)</code> <span class="text-muted">(@change.OldAsnName)</span>.
+                            Pick an answer below, then save.
+                        </p>
+                        <div class="isp-change-choices">
+                            <label class="isp-change-choice">
+                                <input type="radio" name="isp-change" checked="@(change.Confirmed == true)"
+                                       @onchange="() => change.Confirmed = true" />
+                                <span>
+                                    <strong>Yes, I switched providers - start fresh.</strong>
+                                    Saving pauses @(change.TargetCount == 1 ? "your 1 current upstream monitoring target" : $"all {change.TargetCount} current upstream monitoring targets")@(change.ManualCount > 0 ? $" (including {change.ManualCount} hand-added)" : "") for this connection
+                                    and the results below become your new baseline. Nothing is deleted.
+                                </span>
+                            </label>
+                            <label class="isp-change-choice">
+                                <input type="radio" name="isp-change" checked="@(change.Confirmed == false)"
+                                       @onchange="() => change.Confirmed = false" />
+                                <span>
+                                    <strong>No, keep monitoring my current targets.</strong>
+                                    Everything stays as it is, and we won't ask again about this network.
+                                </span>
+                            </label>
+                        </div>
+                    </div>
+                }
+
                 <div class="form-group">
                     <label class="form-label">Access network technology</label>
                     <select class="form-control" style="max-width: 250px;@(_state.AccessTechnology == AccessTechnology.Unknown ? " outline: 2px solid rgba(59, 130, 246, 0.5); outline-offset: 2px; border-radius: 6px;" : "")"
@@ -357,7 +391,11 @@
                     <button class="btn btn-secondary" @onclick="StartAsync">Re-run discovery</button>
                     @if (_state.AccessHops.Any(h => h.Enabled) || _state.TransitAsns.Any(a => a.Enabled) || _state.RemovedTransitAsns.Count > 0)
                     {
-                        <button class="btn btn-primary" @onclick="CommitAsync">Save monitoring targets</button>
+                        <button class="btn btn-primary" @onclick="CommitAsync"
+                                disabled="@(_state.IspChange is { Confirmed: null })"
+                                data-tooltip="@(_state.IspChange is { Confirmed: null } ? "Answer the provider question above first" : null)">
+                            Save monitoring targets
+                        </button>
                     }
                 </div>
             }
@@ -587,4 +625,8 @@
 <style>
     .row-disabled { opacity: 0.45; }
     .form-control-sm { padding: 0.25rem 0.5rem; font-size: 0.875rem; }
+    .isp-change-review { margin-bottom: 1rem; }
+    .isp-change-review p { margin: 0.5rem 0 0; }
+    .isp-change-choices { display: flex; flex-direction: column; gap: 0.5rem; margin-top: 0.75rem; }
+    .isp-change-choice { display: flex; align-items: baseline; gap: 0.5rem; cursor: pointer; }
 </style>

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -278,6 +278,35 @@
                     </div>
                 }
 
+                @if (_state.PendingRemovalTransitAsns.Count > 0)
+                {
+                    <div class="form-group">
+                        <label class="form-label">Tracking possible removals</label>
+                        <p class="section-description">These transit networks are no longer on your path this run. We're tracking them - after the remaining discovery runs shown below without them reappearing, we'll help you remove the affected targets. Nothing changes until then.</p>
+                        <div class="table-responsive">
+                            <table class="data-table">
+                                <thead>
+                                    <tr>
+                                        <th>ASN</th>
+                                        <th>Status</th>
+                                        <th>Affected targets</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var pending in _state.PendingRemovalTransitAsns)
+                                    {
+                                        <tr>
+                                            <td><code>AS@(pending.AsnNumber)</code> <span class="text-muted">@pending.AsnName</span></td>
+                                            <td>Absent @pending.MissCount of @(pending.MissCount + pending.RunsRemaining) runs - @(pending.RunsRemaining == 1 ? "1 more run" : $"{pending.RunsRemaining} more runs") to confirm</td>
+                                            <td>@(pending.TargetCount == 1 ? "1 target" : $"{pending.TargetCount} targets")@(pending.ManualCount > 0 ? $" ({pending.ManualCount} hand-added)" : "")</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                }
+
                 @if (PathEndHosts.Count > 0)
                 {
                     <div class="form-group">
@@ -315,7 +344,8 @@
                     </div>
                 }
 
-                @if (_state.AccessHops.Count == 0 && _state.TransitAsns.Count == 0 && _state.RemovedTransitAsns.Count == 0)
+                @if (_state.AccessHops.Count == 0 && _state.TransitAsns.Count == 0
+                     && _state.RemovedTransitAsns.Count == 0 && _state.PendingRemovalTransitAsns.Count == 0)
                 {
                     <div class="alert alert-info">
                         No upstream hops responded to either ICMP or UDP traceroute. Your

--- a/src/NetworkOptimizer.Web/Services/Monitoring/FlakyTargetService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/FlakyTargetService.cs
@@ -52,6 +52,19 @@ public class FlakyTargetService
     private const double SharedLossHeavyPct = 5.0;
     /// <summary>Minimum surviving bins before we'll judge a target. 3 x 10 min = help from ~30 min in, not 6 h.</summary>
     private const int MinTargetBins = 3;
+    /// <summary>
+    /// Recovery window: a target whose full-window metric says flaky but whose surviving bins in
+    /// this trailing slice (anchored to the pool's newest surviving bin, not wall clock) are back
+    /// under the threshold is treated as recovered and not presented. Keeps a stable-flaky-stable
+    /// excursion from nagging for the rest of the 48 h lookback, while an always-flaky target
+    /// (ICMP deprioritization is persistent) keeps failing the recent slice and stays flagged.
+    /// </summary>
+    private const int RecoveryWindowHours = 3;
+    /// <summary>
+    /// Recovery needs at least this many surviving bins (>= ~1 h of evidence) inside the window.
+    /// Fewer - the target went dark or barely reports - can't prove stability, so it stays flagged.
+    /// </summary>
+    private const int MinRecoveryBins = 6;
 
     /// <summary>One flagged target plus the evidence behind the call.</summary>
     public record FlakyTarget(
@@ -136,6 +149,13 @@ public class FlakyTargetService
     /// (e.g. 2.86% -> 4.5%), the trimmed mean stays put (~4%). Bins where >= half the pool loses
     /// heavily are excluded first as path-wide events, and a target needs <see cref="MinTargetBins"/>
     /// surviving bins to be judged. The peer baseline still uses a plain median across the pool.
+    ///
+    /// Recovery gate: a target the full-window metric flags is dropped when its bins in the
+    /// trailing <see cref="RecoveryWindowHours"/> (>= <see cref="MinRecoveryBins"/> of them) are
+    /// back under the same threshold - a stable-flaky-stable excursion stops being presented as
+    /// soon as recent evidence says it's fine, instead of nagging until the bad bins dilute out
+    /// of the 48 h lookback. An always-flaky target keeps failing the recent slice and a target
+    /// that went dark has no recent bins to prove recovery with, so both stay flagged.
     /// </summary>
     internal static IReadOnlyList<FlakyTarget> Analyze(
         Dictionary<string, Dictionary<DateTime, double>> lossByTarget,
@@ -173,13 +193,30 @@ public class FlakyTargetService
         var baseline = Median(allLosses);
         var threshold = Math.Max(LossMultiplier * baseline, LossAbsoluteFloorPct);
 
+        // Anchor the recovery window to the pool's newest surviving bin rather than wall clock,
+        // so the analysis stays pure and a stale data set doesn't read as "everyone recovered".
+        var newestBin = allBins.Where(b => !excludedBins.Contains(b)).Max();
+        var recoveryCutoff = newestBin - TimeSpan.FromHours(RecoveryWindowHours);
+
         var flaky = new List<FlakyTarget>();
         foreach (var (targetId, bins) in lossByTarget)
         {
-            var survivors = bins.Where(kv => !excludedBins.Contains(kv.Key)).Select(kv => kv.Value).ToList();
-            if (survivors.Count < MinTargetBins) continue;
+            var survivorPairs = bins.Where(kv => !excludedBins.Contains(kv.Key)).ToList();
+            if (survivorPairs.Count < MinTargetBins) continue;
+            var survivors = survivorPairs.Select(kv => kv.Value).ToList();
             var metric = TrimmedMean(survivors);
             if (metric < threshold) continue;
+
+            // Recovery gate: historically flaky, but its recent bins are clean by the same
+            // threshold - stable again, so stop presenting it. Judged only with enough recent
+            // evidence; a target that went dark can't prove recovery and stays flagged.
+            var recent = survivorPairs.Where(kv => kv.Key > recoveryCutoff).Select(kv => kv.Value).ToList();
+            if (recent.Count >= MinRecoveryBins && TrimmedMean(recent) < threshold)
+            {
+                logger?.LogDebug("Flaky-target detect: {Target} historically flaky ({Metric:0.0}%) but stable over the last {Hours}h; treating as recovered",
+                    targetId, metric, RecoveryWindowHours);
+                continue;
+            }
 
             if (!byId.TryGetValue(targetId, out var t)) continue;
             var over = survivors.Count(l => l >= threshold);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/FlakyTargetService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/FlakyTargetService.cs
@@ -71,10 +71,11 @@ public class FlakyTargetService
     /// </summary>
     private const double HardDownLossPct = 95.0;
     /// <summary>
-    /// Fast recovery for hard-down episodes: when every over-threshold bin was hard-down, the
-    /// episode was a binary outage, not flakiness - once the hop answers cleanly again there's
-    /// little ambiguity, so this many consecutive clean bins (~30 min) clear the flag instead of
-    /// waiting out the full recovery window.
+    /// Fast recovery for hard-down episodes: when the median over-threshold bin was hard-down
+    /// (median, so the partial-loss bins an aggregate window produces at the outage's edges
+    /// don't disqualify it), the episode was a binary outage, not flakiness - once the hop
+    /// answers cleanly again there's little ambiguity, so this many consecutive clean bins
+    /// (~30 min) clear the flag instead of waiting out the full recovery window.
     /// </summary>
     private const int HardDownRecoveryBins = 3;
 
@@ -168,7 +169,7 @@ public class FlakyTargetService
     /// soon as recent evidence says it's fine, instead of nagging until the bad bins dilute out
     /// of the 48 h lookback. An always-flaky target keeps failing the recent slice and a target
     /// that went dark has no recent bins to prove recovery with, so both stay flagged. Hard-down
-    /// episodes (every over-threshold bin >= <see cref="HardDownLossPct"/>) recover faster: a
+    /// episodes (median over-threshold bin >= <see cref="HardDownLossPct"/>) recover faster: a
     /// binary outage that ended needs only <see cref="HardDownRecoveryBins"/> consecutive clean
     /// bins, since down-then-up carries none of partial loss's ambiguity.
     /// </summary>
@@ -222,14 +223,17 @@ public class FlakyTargetService
             var metric = TrimmedMean(survivors);
             if (metric < threshold) continue;
 
-            // Hard-down fast path: when every over-threshold bin was essentially total loss, the
+            // Hard-down fast path: when the over-threshold bins were essentially total loss, the
             // episode was a binary outage (reboot, maintenance, transient route change) rather
             // than the partial-loss signature of ICMP deprioritization. Down-then-up is a state
             // transition, so a short clean streak is enough evidence - no need to wait for the
-            // outage bins to dilute out of the full recovery window. Mixed episodes (any partial-
-            // loss bin over threshold) fall through to the standard gate below.
-            var overBins = survivorPairs.Where(kv => kv.Value >= threshold).ToList();
-            if (overBins.Count > 0 && overBins.All(kv => kv.Value >= HardDownLossPct))
+            // outage bins to dilute out of the full recovery window. Judged on the MEDIAN
+            // over-threshold bin: the aggregate bins straddling the outage's edges average to
+            // partial loss (observed 52.8% on a real recovery) and must not disqualify the
+            // episode, while genuinely mixed partial-loss flakiness pulls the median below the
+            // bar and falls through to the standard gate below.
+            var overBins = survivorPairs.Where(kv => kv.Value >= threshold).Select(kv => kv.Value).ToList();
+            if (overBins.Count > 0 && Median(overBins) >= HardDownLossPct)
             {
                 var latest = survivorPairs.OrderByDescending(kv => kv.Key)
                     .Take(HardDownRecoveryBins).Select(kv => kv.Value).ToList();

--- a/src/NetworkOptimizer.Web/Services/Monitoring/FlakyTargetService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/FlakyTargetService.cs
@@ -65,6 +65,18 @@ public class FlakyTargetService
     /// Fewer - the target went dark or barely reports - can't prove stability, so it stays flagged.
     /// </summary>
     private const int MinRecoveryBins = 6;
+    /// <summary>
+    /// A bin at or above this loss counts as hard-down (total outage) rather than the partial,
+    /// load-dependent loss that signals ICMP deprioritization.
+    /// </summary>
+    private const double HardDownLossPct = 95.0;
+    /// <summary>
+    /// Fast recovery for hard-down episodes: when every over-threshold bin was hard-down, the
+    /// episode was a binary outage, not flakiness - once the hop answers cleanly again there's
+    /// little ambiguity, so this many consecutive clean bins (~30 min) clear the flag instead of
+    /// waiting out the full recovery window.
+    /// </summary>
+    private const int HardDownRecoveryBins = 3;
 
     /// <summary>One flagged target plus the evidence behind the call.</summary>
     public record FlakyTarget(
@@ -155,7 +167,10 @@ public class FlakyTargetService
     /// back under the same threshold - a stable-flaky-stable excursion stops being presented as
     /// soon as recent evidence says it's fine, instead of nagging until the bad bins dilute out
     /// of the 48 h lookback. An always-flaky target keeps failing the recent slice and a target
-    /// that went dark has no recent bins to prove recovery with, so both stay flagged.
+    /// that went dark has no recent bins to prove recovery with, so both stay flagged. Hard-down
+    /// episodes (every over-threshold bin >= <see cref="HardDownLossPct"/>) recover faster: a
+    /// binary outage that ended needs only <see cref="HardDownRecoveryBins"/> consecutive clean
+    /// bins, since down-then-up carries none of partial loss's ambiguity.
     /// </summary>
     internal static IReadOnlyList<FlakyTarget> Analyze(
         Dictionary<string, Dictionary<DateTime, double>> lossByTarget,
@@ -206,6 +221,25 @@ public class FlakyTargetService
             var survivors = survivorPairs.Select(kv => kv.Value).ToList();
             var metric = TrimmedMean(survivors);
             if (metric < threshold) continue;
+
+            // Hard-down fast path: when every over-threshold bin was essentially total loss, the
+            // episode was a binary outage (reboot, maintenance, transient route change) rather
+            // than the partial-loss signature of ICMP deprioritization. Down-then-up is a state
+            // transition, so a short clean streak is enough evidence - no need to wait for the
+            // outage bins to dilute out of the full recovery window. Mixed episodes (any partial-
+            // loss bin over threshold) fall through to the standard gate below.
+            var overBins = survivorPairs.Where(kv => kv.Value >= threshold).ToList();
+            if (overBins.Count > 0 && overBins.All(kv => kv.Value >= HardDownLossPct))
+            {
+                var latest = survivorPairs.OrderByDescending(kv => kv.Key)
+                    .Take(HardDownRecoveryBins).Select(kv => kv.Value).ToList();
+                if (latest.Count >= HardDownRecoveryBins && latest.All(l => l < threshold))
+                {
+                    logger?.LogDebug("Flaky-target detect: {Target} was hard-down ({Metric:0.0}%) but its last {Bins} bins are clean; treating the outage as over",
+                        targetId, metric, HardDownRecoveryBins);
+                    continue;
+                }
+            }
 
             // Recovery gate: historically flaky, but its recent bins are clean by the same
             // threshold - stable again, so stop presenting it. Judged only with enough recent

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamRediscoveryService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamRediscoveryService.cs
@@ -269,8 +269,34 @@ public class UpstreamRediscoveryService : BackgroundService
         await SaveMissCountsAsync(db, wanInterface, eval.NewMissCounts, ct);
         await db.SaveChangesAsync(ct);
 
+        // Transit ASNs absent this run but still below the confirm threshold: surface them read-only
+        // in the review as "tracking toward removal" so the detection isn't invisible until it
+        // suddenly confirms. Pending and confirmed are mutually exclusive (one count per key), and
+        // an eligible ASN always has >=1 enabled target, so BuildRemovedTransitAsnsAsync resolves a
+        // target count for each. RunsRemaining is run-count based today; when the per-ASN time gate
+        // lands, revisit the copy to express remaining time rather than remaining runs.
+        var pendingKeys = eval.NewMissCounts
+            .Where(kv => kv.Value < RemovalConfirmRuns
+                && kv.Key.StartsWith("transit:as", StringComparison.OrdinalIgnoreCase))
+            .Select(kv => kv.Key)
+            .ToList();
+        var pendingInfo = await BuildRemovedTransitAsnsAsync(db, wanInterface, pendingKeys, ct);
+        var pending = pendingInfo
+            .Select(r => new PendingRemovalTransitAsn
+            {
+                AsnNumber = r.AsnNumber,
+                AsnName = r.AsnName,
+                TargetCount = r.TargetCount,
+                ManualCount = r.ManualCount,
+                MissCount = eval.NewMissCounts["transit:as" + r.AsnNumber],
+                RunsRemaining = RemovalConfirmRuns - eval.NewMissCounts["transit:as" + r.AsnNumber],
+            })
+            .OrderBy(p => p.AsnNumber)
+            .ToList();
+
         state.DiscoveryAddedAsns = eval.Added;
         state.RemovedTransitAsns = removedToPause;
+        state.PendingRemovalTransitAsns = pending;
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamRediscoveryService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamRediscoveryService.cs
@@ -123,28 +123,16 @@ public class UpstreamRediscoveryService : BackgroundService
             return;
         }
 
-        // Compare on a stable upstream-ASN identity scoped to the WAN this run discovered.
-        // A run never writes MonitoringTargets (commit only happens on user review), so the
-        // committed views are read here, where State.WanInterface is known.
-        var wanInterface = tracer.State.WanInterface ?? "wan";
-        var (monitoredAsns, autoEnabledAsns) = await BuildCommittedViewsAsync(db, wanInterface, ct);
-        var candidate = BuildCandidateSignature(tracer.State);
+        // The tracer already ran the shared post-run evaluation when the run settled in
+        // ReviewingResults - it does the same for manually-started runs, so the absence counters
+        // advance exactly once per completed run regardless of who initiated it. Read the staged
+        // outcome here.
+        var added = tracer.State.DiscoveryAddedAsns;
+        var removedToPause = tracer.State.RemovedTransitAsns;
 
-        var priorMissCounts = await LoadMissCountsAsync(db, wanInterface, ct);
-        var eval = EvaluateChange(monitoredAsns, autoEnabledAsns, candidate, priorMissCounts, RemovalConfirmRuns);
-
-        // Removed-detection is persistence-gated: an ASN must be absent from RemovalConfirmRuns
-        // runs in a row before it's confirmed removed, so a single incomplete/degraded run only
-        // bumps a counter that resets the moment the ASN reappears.
-        var confirmedRemoved = eval.RemovalCandidates;
-
-        // Persist the updated counters (upserted into the same SaveChanges below). The map only
-        // holds currently-absent ASNs, so reappeared/removed ones are pruned by omission.
-        await SaveMissCountsAsync(db, wanInterface, eval.NewMissCounts, ct);
-
-        if (eval.Added.Count == 0 && confirmedRemoved.Count == 0)
+        if (added.Count == 0 && removedToPause.Count == 0)
         {
-            _logger.LogInformation("Re-discovery matched committed ASNs (no change); rolling forward LastUpstreamDiscoveryAt");
+            _logger.LogInformation("Re-discovery matched committed ASNs (no actionable change); rolling forward LastUpstreamDiscoveryAt");
             settings.LastUpstreamDiscoveryAt = DateTime.UtcNow;
             settings.UpdatedAt = DateTime.UtcNow;
             await db.SaveChangesAsync(ct);
@@ -153,8 +141,8 @@ public class UpstreamRediscoveryService : BackgroundService
             return;
         }
 
-        _logger.LogInformation("Re-discovery found upstream changes; flagging for review. Added: [{Added}] Removed: [{Removed}]",
-            string.Join(", ", eval.Added), string.Join(", ", confirmedRemoved));
+        _logger.LogInformation("Re-discovery found upstream changes; flagging for review. Added: [{Added}] Off-path (to pause): [{Removed}]",
+            string.Join(", ", added), string.Join(", ", removedToPause.Select(r => $"AS{r.AsnNumber}")));
 
         settings.UpstreamDiscoveryNeedsReview = true;
         settings.UpdatedAt = DateTime.UtcNow;
@@ -176,13 +164,17 @@ public class UpstreamRediscoveryService : BackgroundService
     /// auto-discovered (DirectRouter/PathProxy/L2Neighbor) on this WAN, plus all UserProvided
     /// (WAN-agnostic, since a hand-added Cogent may carry an empty/other WanInterface). Discovery
     /// finding one of these is not "added".</item>
-    /// <item><b>AutoEnabled</b> (removed-eligibility): enabled, auto-discovered ASNs on this WAN.
-    /// Only these are eligible to be flagged "removed" - UserProvided and disabled targets are
-    /// excluded so a curated or intentionally-off target never nags.</item>
+    /// <item><b>RemovalEligible</b> (removed-eligibility): ASNs auto-discovered
+    /// (DirectRouter/PathProxy/L2Neighbor) on this WAN at some point - enabled OR NOT, since a
+    /// flaky auto target the user paused must stay eligible so its dangling hand-added siblings
+    /// get caught when the ASN goes dark - that still have at least one enabled target row
+    /// (auto on this WAN or UserProvided on any WAN). A fully-disabled ASN has nothing to pause,
+    /// so counting it would only pin the recheck cadence; a manual-only ASN carries no auto
+    /// evidence, so we can't conclude it's off-path.</item>
     /// </list>
     /// Both are reachability-independent (no relation to whether a hop answered ping this run).
     /// </summary>
-    internal static async Task<(HashSet<string> Monitored, HashSet<string> AutoEnabled)> BuildCommittedViewsAsync(
+    internal static async Task<(HashSet<string> Monitored, HashSet<string> RemovalEligible)> BuildCommittedViewsAsync(
         NetworkOptimizerDbContext db, string wanInterface, CancellationToken ct)
     {
         var rows = await db.MonitoringTargets
@@ -195,18 +187,23 @@ public class UpstreamRediscoveryService : BackgroundService
             .ToListAsync(ct);
 
         var monitored = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var autoEnabled = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var autoEvidence = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var hasEnabledRow = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var t in rows)
         {
             var key = IdentityKey(t.TargetType, t.AsnNumber, t.Address);
             monitored.Add(key);
-            if (t.Enabled && t.WanInterface == wanInterface
+            if (t.WanInterface == wanInterface
                 && (t.DiscoveryMethod == DiscoveryMethod.DirectRouter
                     || t.DiscoveryMethod == DiscoveryMethod.PathProxy
                     || t.DiscoveryMethod == DiscoveryMethod.L2Neighbor))
-                autoEnabled.Add(key);
+                autoEvidence.Add(key);
+            if (t.Enabled)
+                hasEnabledRow.Add(key);
         }
-        return (monitored, autoEnabled);
+        var removalEligible = new HashSet<string>(autoEvidence, StringComparer.OrdinalIgnoreCase);
+        removalEligible.IntersectWith(hasEnabledRow);
+        return (monitored, removalEligible);
     }
 
     /// <summary>
@@ -217,7 +214,7 @@ public class UpstreamRediscoveryService : BackgroundService
     /// </summary>
     internal static ChangeEvaluation EvaluateChange(
         HashSet<string> monitoredAsns,
-        HashSet<string> autoEnabledAsns,
+        HashSet<string> removalEligibleAsns,
         HashSet<string> candidate,
         IReadOnlyDictionary<string, int> priorMissCounts,
         int removalThreshold)
@@ -226,7 +223,7 @@ public class UpstreamRediscoveryService : BackgroundService
 
         var newCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         var removalCandidates = new List<string>();
-        foreach (var key in autoEnabledAsns)
+        foreach (var key in removalEligibleAsns)
         {
             if (candidate.Contains(key)) continue; // present this run - counter resets (omitted)
             var count = (priorMissCounts.TryGetValue(key, out var prev) ? prev : 0) + 1;
@@ -235,6 +232,100 @@ public class UpstreamRediscoveryService : BackgroundService
         }
         removalCandidates.Sort(StringComparer.OrdinalIgnoreCase);
         return new ChangeEvaluation(added, removalCandidates, newCounts);
+    }
+
+    /// <summary>
+    /// Shared post-run change evaluation, called by the tracer whenever a discovery run settles
+    /// in ReviewingResults - scheduled AND manually-started runs alike, so the "absent for
+    /// RemovalConfirmRuns consecutive runs" evidence advances exactly once per completed run
+    /// regardless of who initiated it. Bumps the per-WAN consecutive-miss counters, prunes
+    /// confirmations with no pause action, persists the counters, and stages the added keys plus
+    /// the confirmed off-path transit ASNs on the tracer state for the review UI and the
+    /// scheduler's gate. Removed-detection stays persistence-gated: a single incomplete/degraded
+    /// run only bumps a counter that resets the moment the ASN reappears.
+    /// </summary>
+    internal static async Task EvaluateCompletedRunAsync(
+        NetworkOptimizerDbContext db, UpstreamTracerState state, CancellationToken ct)
+    {
+        var wanInterface = state.WanInterface ?? "wan";
+        var (monitoredAsns, removalEligibleAsns) = await BuildCommittedViewsAsync(db, wanInterface, ct);
+        var candidate = BuildCandidateSignature(state);
+
+        var priorMissCounts = await LoadMissCountsAsync(db, wanInterface, ct);
+        var eval = EvaluateChange(monitoredAsns, removalEligibleAsns, candidate, priorMissCounts, RemovalConfirmRuns);
+
+        var removedToPause = await BuildRemovedTransitAsnsAsync(db, wanInterface, eval.RemovalCandidates, ct);
+
+        // Confirmed keys with no pause action (access/path tiers, which this detector doesn't act
+        // on) must not keep a counter pinned at the threshold: any non-null counter map holds
+        // pendingRecheck on, which would lock the site into daily re-discovery forever. Prune them
+        // so the evidence re-accumulates instead.
+        var actionable = new HashSet<string>(
+            removedToPause.Select(r => "transit:as" + r.AsnNumber), StringComparer.OrdinalIgnoreCase);
+        foreach (var key in eval.RemovalCandidates)
+            if (!actionable.Contains(key)) eval.NewMissCounts.Remove(key);
+
+        // The map only holds currently-absent ASNs, so reappeared/removed ones prune by omission.
+        await SaveMissCountsAsync(db, wanInterface, eval.NewMissCounts, ct);
+        await db.SaveChangesAsync(ct);
+
+        state.DiscoveryAddedAsns = eval.Added;
+        state.RemovedTransitAsns = removedToPause;
+    }
+
+    /// <summary>
+    /// Maps confirmed-removed identity keys to review entries: <c>transit:as{n}</c> keys only,
+    /// resolved to the enabled Transit targets that would be paused - auto targets scoped to this
+    /// WAN, UserProvided targets matched by ASN regardless of WAN (hand-added rows are
+    /// WAN-agnostic). An ASN with nothing enabled yields no entry (nothing to do, no nag).
+    /// </summary>
+    internal static async Task<List<RemovedTransitAsn>> BuildRemovedTransitAsnsAsync(
+        NetworkOptimizerDbContext db, string wanInterface, IReadOnlyList<string> confirmedRemoved, CancellationToken ct)
+    {
+        var asns = new List<int>();
+        foreach (var key in confirmedRemoved)
+        {
+            if (!key.StartsWith("transit:as", StringComparison.OrdinalIgnoreCase)) continue;
+            if (int.TryParse(key.AsSpan("transit:as".Length), out var asn)) asns.Add(asn);
+        }
+        if (asns.Count == 0) return new();
+
+        var targets = await db.MonitoringTargets
+            .Where(t => t.TargetType == MonitoringTargetType.Transit && t.Enabled
+                && t.AsnNumber != null && asns.Contains(t.AsnNumber.Value)
+                && (t.DiscoveryMethod == DiscoveryMethod.UserProvided || t.WanInterface == wanInterface))
+            .Select(t => new { t.AsnNumber, t.AsnName, t.DiscoveryMethod })
+            .ToListAsync(ct);
+
+        return targets
+            .GroupBy(t => t.AsnNumber!.Value)
+            .Select(g => new RemovedTransitAsn
+            {
+                AsnNumber = g.Key,
+                AsnName = g.Select(x => x.AsnName).FirstOrDefault(n => !string.IsNullOrEmpty(n)) ?? $"AS{g.Key}",
+                TargetCount = g.Count(),
+                ManualCount = g.Count(x => x.DiscoveryMethod == DiscoveryMethod.UserProvided),
+                Keep = false,
+            })
+            .OrderBy(r => r.AsnNumber)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Removes the given identity keys from the WAN's absent-ASN miss counters. Called by commit
+    /// for the surfaced off-path ASNs: a kept ASN would otherwise still sit at the confirm
+    /// threshold and re-flag review on the very next daily recheck - clearing it makes the
+    /// evidence re-accumulate from zero instead. Does not SaveChanges; the caller's does.
+    /// </summary>
+    internal static async Task ClearMissCountKeysAsync(
+        NetworkOptimizerDbContext db, string wanInterface, IEnumerable<string> keys, CancellationToken ct)
+    {
+        var counts = await LoadMissCountsAsync(db, wanInterface, ct);
+        var removed = false;
+        foreach (var key in keys)
+            removed |= counts.Remove(key);
+        if (removed)
+            await SaveMissCountsAsync(db, wanInterface, counts, ct);
     }
 
     private static string MissCountsKey(string wanInterface) =>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamRediscoveryService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamRediscoveryService.cs
@@ -19,14 +19,24 @@ public class UpstreamRediscoveryService : BackgroundService
     private static readonly TimeSpan TickInterval = TimeSpan.FromHours(1);
     private static readonly TimeSpan RediscoveryThreshold = TimeSpan.FromDays(7);
 
-    // An auto-discovered ASN must be absent from this many consecutive runs before it's a
-    // removal candidate - long enough (3 cycles) to ride out an incomplete/degraded run.
+    // An auto-discovered ASN must be absent from this many gated increments before it's a removal
+    // candidate. Combined with AbsentIncrementGate, that's a real-time floor (3 increments >= 6h
+    // apart => absence sustained >= ~12h), long enough to ride out maintenance windows and to keep
+    // a transit provider's brief drain from confirming.
     private const int RemovalConfirmRuns = 3;
 
+    // Per-ASN minimum time between miss-counter increments. A completed run that finds an ASN still
+    // absent but within this window of its last increment HOLDS the count instead of advancing, so
+    // rapid manual traces (or a tight recheck) can't stack the counter - absence has to persist
+    // across real time, not just across runs. Kept in step with PendingRecheckInterval so scheduled
+    // rechecks reliably clear the gate.
+    private static readonly TimeSpan AbsentIncrementGate = TimeSpan.FromHours(6);
+
     // While a removal counter is pending (some ASN currently absent), re-check on this shorter
-    // cadence instead of the full threshold, so a real removal confirms in ~3 days rather than
-    // ~3 weeks and a transient miss clears the next day.
-    private static readonly TimeSpan PendingRecheckInterval = TimeSpan.FromHours(24);
+    // cadence instead of the full threshold, so a real removal confirms in ~12-18h rather than
+    // ~3 weeks and a transient miss clears quickly. Matched to AbsentIncrementGate so each recheck
+    // lands just past the gate and actually advances the counter.
+    private static readonly TimeSpan PendingRecheckInterval = TimeSpan.FromHours(6);
 
     private readonly IDbContextFactory<NetworkOptimizerDbContext> _dbFactory;
     private readonly NetworkOptimizer.Storage.Services.SiteDbContextFactory _siteDbFactory;
@@ -155,7 +165,15 @@ public class UpstreamRediscoveryService : BackgroundService
     internal sealed record ChangeEvaluation(
         List<string> Added,
         List<string> RemovalCandidates,
-        Dictionary<string, int> NewMissCounts);
+        Dictionary<string, MissRecord> NewMisses);
+
+    /// <summary>
+    /// A per-ASN absence counter: the consecutive-miss <paramref name="Count"/> plus
+    /// <paramref name="LastIncrementUtc"/>, the time it last advanced, so the increment can be
+    /// time-gated (at most once per <see cref="AbsentIncrementGate"/>). Legacy stored counters
+    /// (a bare int) load with <see cref="DateTime.MinValue"/>, i.e. immediately gate-eligible.
+    /// </summary>
+    internal readonly record struct MissRecord(int Count, DateTime LastIncrementUtc);
 
     /// <summary>
     /// Two committed views, both keyed on the stable ASN identity (see IdentityKey):
@@ -208,41 +226,60 @@ public class UpstreamRediscoveryService : BackgroundService
 
     /// <summary>
     /// Pure change-detection. Added = discovered ASNs not already monitored (flag now). Missing =
-    /// removal-eligible ASNs absent this run; each bumps a consecutive-miss counter and only
-    /// becomes a removal candidate once it reaches <paramref name="removalThreshold"/> runs. The
-    /// returned counter map holds only currently-absent ASNs, so reappeared ones reset by omission.
+    /// removal-eligible ASNs absent this run; each bumps a consecutive-miss counter, but only when
+    /// it's been at least <paramref name="incrementGate"/> since that ASN last incremented (a
+    /// too-soon miss holds the count and its timestamp, so absence must persist across real time,
+    /// not just across runs). An ASN becomes a removal candidate once its count reaches
+    /// <paramref name="removalThreshold"/> - a confirmed ASN that's gated this run stays a
+    /// candidate. The returned map holds only currently-absent ASNs, so reappeared ones reset by
+    /// omission. <paramref name="nowUtc"/> is passed in so this stays pure and deterministic.
     /// </summary>
     internal static ChangeEvaluation EvaluateChange(
         HashSet<string> monitoredAsns,
         HashSet<string> removalEligibleAsns,
         HashSet<string> candidate,
-        IReadOnlyDictionary<string, int> priorMissCounts,
+        IReadOnlyDictionary<string, MissRecord> priorMisses,
+        DateTime nowUtc,
+        TimeSpan incrementGate,
         int removalThreshold)
     {
         var added = candidate.Except(monitoredAsns).OrderBy(x => x).ToList();
 
-        var newCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var newMisses = new Dictionary<string, MissRecord>(StringComparer.OrdinalIgnoreCase);
         var removalCandidates = new List<string>();
         foreach (var key in removalEligibleAsns)
         {
             if (candidate.Contains(key)) continue; // present this run - counter resets (omitted)
-            var count = (priorMissCounts.TryGetValue(key, out var prev) ? prev : 0) + 1;
-            newCounts[key] = count;
+            var hadPrior = priorMisses.TryGetValue(key, out var prior);
+            int count;
+            DateTime lastIncrement;
+            if (hadPrior && nowUtc - prior.LastIncrementUtc < incrementGate)
+            {
+                // Gated: absent again, but too soon since the last increment - hold as-is.
+                count = prior.Count;
+                lastIncrement = prior.LastIncrementUtc;
+            }
+            else
+            {
+                count = (hadPrior ? prior.Count : 0) + 1;
+                lastIncrement = nowUtc;
+            }
+            newMisses[key] = new MissRecord(count, lastIncrement);
             if (count >= removalThreshold) removalCandidates.Add(key);
         }
         removalCandidates.Sort(StringComparer.OrdinalIgnoreCase);
-        return new ChangeEvaluation(added, removalCandidates, newCounts);
+        return new ChangeEvaluation(added, removalCandidates, newMisses);
     }
 
     /// <summary>
     /// Shared post-run change evaluation, called by the tracer whenever a discovery run settles
-    /// in ReviewingResults - scheduled AND manually-started runs alike, so the "absent for
-    /// RemovalConfirmRuns consecutive runs" evidence advances exactly once per completed run
-    /// regardless of who initiated it. Bumps the per-WAN consecutive-miss counters, prunes
-    /// confirmations with no pause action, persists the counters, and stages the added keys plus
-    /// the confirmed off-path transit ASNs on the tracer state for the review UI and the
-    /// scheduler's gate. Removed-detection stays persistence-gated: a single incomplete/degraded
-    /// run only bumps a counter that resets the moment the ASN reappears.
+    /// in ReviewingResults - scheduled AND manually-started runs alike, so removal evidence
+    /// accumulates the same regardless of who initiated the run. Bumps the per-WAN miss counters
+    /// (time-gated: at most one increment per ASN per AbsentIncrementGate, so rapid manual traces
+    /// can't stack them), prunes confirmations with no pause action, persists the counters, and
+    /// stages the added keys plus the confirmed off-path transit ASNs on the tracer state for the
+    /// review UI and the scheduler's gate. Removed-detection stays persistence-gated: a single
+    /// incomplete/degraded run only bumps a counter that resets the moment the ASN reappears.
     /// </summary>
     internal static async Task EvaluateCompletedRunAsync(
         NetworkOptimizerDbContext db, UpstreamTracerState state, CancellationToken ct)
@@ -251,32 +288,33 @@ public class UpstreamRediscoveryService : BackgroundService
         var (monitoredAsns, removalEligibleAsns) = await BuildCommittedViewsAsync(db, wanInterface, ct);
         var candidate = BuildCandidateSignature(state);
 
-        var priorMissCounts = await LoadMissCountsAsync(db, wanInterface, ct);
-        var eval = EvaluateChange(monitoredAsns, removalEligibleAsns, candidate, priorMissCounts, RemovalConfirmRuns);
+        var priorMisses = await LoadMissCountsAsync(db, wanInterface, ct);
+        var eval = EvaluateChange(monitoredAsns, removalEligibleAsns, candidate, priorMisses,
+            DateTime.UtcNow, AbsentIncrementGate, RemovalConfirmRuns);
 
         var removedToPause = await BuildRemovedTransitAsnsAsync(db, wanInterface, eval.RemovalCandidates, ct);
 
         // Confirmed keys with no pause action (access/path tiers, which this detector doesn't act
         // on) must not keep a counter pinned at the threshold: any non-null counter map holds
-        // pendingRecheck on, which would lock the site into daily re-discovery forever. Prune them
+        // pendingRecheck on, which would lock the site into the recheck cadence forever. Prune them
         // so the evidence re-accumulates instead.
         var actionable = new HashSet<string>(
             removedToPause.Select(r => "transit:as" + r.AsnNumber), StringComparer.OrdinalIgnoreCase);
         foreach (var key in eval.RemovalCandidates)
-            if (!actionable.Contains(key)) eval.NewMissCounts.Remove(key);
+            if (!actionable.Contains(key)) eval.NewMisses.Remove(key);
 
         // The map only holds currently-absent ASNs, so reappeared/removed ones prune by omission.
-        await SaveMissCountsAsync(db, wanInterface, eval.NewMissCounts, ct);
+        await SaveMissCountsAsync(db, wanInterface, eval.NewMisses, ct);
         await db.SaveChangesAsync(ct);
 
         // Transit ASNs absent this run but still below the confirm threshold: surface them read-only
         // in the review as "tracking toward removal" so the detection isn't invisible until it
         // suddenly confirms. Pending and confirmed are mutually exclusive (one count per key), and
         // an eligible ASN always has >=1 enabled target, so BuildRemovedTransitAsnsAsync resolves a
-        // target count for each. RunsRemaining is run-count based today; when the per-ASN time gate
-        // lands, revisit the copy to express remaining time rather than remaining runs.
-        var pendingKeys = eval.NewMissCounts
-            .Where(kv => kv.Value < RemovalConfirmRuns
+        // target count for each. RunsRemaining is remaining gated increments; each is >= the gate
+        // apart, so it's also a rough remaining-time floor.
+        var pendingKeys = eval.NewMisses
+            .Where(kv => kv.Value.Count < RemovalConfirmRuns
                 && kv.Key.StartsWith("transit:as", StringComparison.OrdinalIgnoreCase))
             .Select(kv => kv.Key)
             .ToList();
@@ -288,8 +326,8 @@ public class UpstreamRediscoveryService : BackgroundService
                 AsnName = r.AsnName,
                 TargetCount = r.TargetCount,
                 ManualCount = r.ManualCount,
-                MissCount = eval.NewMissCounts["transit:as" + r.AsnNumber],
-                RunsRemaining = RemovalConfirmRuns - eval.NewMissCounts["transit:as" + r.AsnNumber],
+                MissCount = eval.NewMisses["transit:as" + r.AsnNumber].Count,
+                RunsRemaining = RemovalConfirmRuns - eval.NewMisses["transit:as" + r.AsnNumber].Count,
             })
             .OrderBy(p => p.AsnNumber)
             .ToList();
@@ -346,41 +384,69 @@ public class UpstreamRediscoveryService : BackgroundService
     internal static async Task ClearMissCountKeysAsync(
         NetworkOptimizerDbContext db, string wanInterface, IEnumerable<string> keys, CancellationToken ct)
     {
-        var counts = await LoadMissCountsAsync(db, wanInterface, ct);
+        var misses = await LoadMissCountsAsync(db, wanInterface, ct);
         var removed = false;
         foreach (var key in keys)
-            removed |= counts.Remove(key);
+            removed |= misses.Remove(key);
         if (removed)
-            await SaveMissCountsAsync(db, wanInterface, counts, ct);
+            await SaveMissCountsAsync(db, wanInterface, misses, ct);
     }
 
     private static string MissCountsKey(string wanInterface) =>
         SystemSettingKeys.UpstreamAbsentAsnCountsPrefix + wanInterface;
 
-    private static async Task<Dictionary<string, int>> LoadMissCountsAsync(
+    /// <summary>
+    /// Loads the per-WAN absent-ASN counters. The stored value is a JSON map of identity key to
+    /// <c>{"c":count,"t":lastIncrementUtc}</c>. Legacy values (a bare int per key, from before the
+    /// increment gate) parse with <see cref="DateTime.MinValue"/> so they're immediately
+    /// gate-eligible on the next run - no migration needed.
+    /// </summary>
+    private static async Task<Dictionary<string, MissRecord>> LoadMissCountsAsync(
         NetworkOptimizerDbContext db, string wanInterface, CancellationToken ct)
     {
+        var result = new Dictionary<string, MissRecord>(StringComparer.OrdinalIgnoreCase);
         var row = await db.SystemSettings.FirstOrDefaultAsync(s => s.Key == MissCountsKey(wanInterface), ct);
-        if (string.IsNullOrEmpty(row?.Value)) return new(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrEmpty(row?.Value)) return result;
         try
         {
-            var map = JsonSerializer.Deserialize<Dictionary<string, int>>(row.Value);
-            return map == null ? new(StringComparer.OrdinalIgnoreCase) : new(map, StringComparer.OrdinalIgnoreCase);
+            using var doc = JsonDocument.Parse(row.Value);
+            foreach (var prop in doc.RootElement.EnumerateObject())
+            {
+                if (prop.Value.ValueKind == JsonValueKind.Number)
+                {
+                    // Legacy {key:int}: no timestamp recorded, so treat as long-ago (not gated).
+                    var legacy = prop.Value.GetInt32();
+                    if (legacy > 0) result[prop.Name] = new MissRecord(legacy, DateTime.MinValue);
+                }
+                else if (prop.Value.ValueKind == JsonValueKind.Object)
+                {
+                    var count = prop.Value.TryGetProperty("c", out var c) ? c.GetInt32() : 0;
+                    var when = prop.Value.TryGetProperty("t", out var t) && t.TryGetDateTime(out var dt)
+                        ? DateTime.SpecifyKind(dt, DateTimeKind.Utc)
+                        : DateTime.MinValue;
+                    if (count > 0) result[prop.Name] = new MissRecord(count, when);
+                }
+            }
         }
         catch
         {
             return new(StringComparer.OrdinalIgnoreCase);
         }
+        return result;
     }
 
     /// <summary>Upserts the counter map into the SystemSetting row. Does not SaveChanges - the
     /// caller's SaveChanges persists it alongside the settings update.</summary>
     private static async Task SaveMissCountsAsync(
-        NetworkOptimizerDbContext db, string wanInterface, Dictionary<string, int> counts, CancellationToken ct)
+        NetworkOptimizerDbContext db, string wanInterface, Dictionary<string, MissRecord> misses, CancellationToken ct)
     {
         var key = MissCountsKey(wanInterface);
         var row = await db.SystemSettings.FirstOrDefaultAsync(s => s.Key == key, ct);
-        var value = counts.Count == 0 ? null : JsonSerializer.Serialize(counts);
+        var value = misses.Count == 0
+            ? null
+            : JsonSerializer.Serialize(misses.ToDictionary(
+                kv => kv.Key,
+                kv => new { c = kv.Value.Count, t = kv.Value.LastIncrementUtc }));
         if (row == null)
         {
             if (value == null) return;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamRediscoveryService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamRediscoveryService.cs
@@ -139,8 +139,9 @@ public class UpstreamRediscoveryService : BackgroundService
         // outcome here.
         var added = tracer.State.DiscoveryAddedAsns;
         var removedToPause = tracer.State.RemovedTransitAsns;
+        var ispChange = tracer.State.IspChange;
 
-        if (added.Count == 0 && removedToPause.Count == 0)
+        if (added.Count == 0 && removedToPause.Count == 0 && ispChange == null)
         {
             _logger.LogInformation("Re-discovery matched committed ASNs (no actionable change); rolling forward LastUpstreamDiscoveryAt");
             settings.LastUpstreamDiscoveryAt = DateTime.UtcNow;
@@ -151,8 +152,9 @@ public class UpstreamRediscoveryService : BackgroundService
             return;
         }
 
-        _logger.LogInformation("Re-discovery found upstream changes; flagging for review. Added: [{Added}] Off-path (to pause): [{Removed}]",
-            string.Join(", ", added), string.Join(", ", removedToPause.Select(r => $"AS{r.AsnNumber}")));
+        _logger.LogInformation("Re-discovery found upstream changes; flagging for review. Added: [{Added}] Off-path (to pause): [{Removed}] ISP change: {IspChange}",
+            string.Join(", ", added), string.Join(", ", removedToPause.Select(r => $"AS{r.AsnNumber}")),
+            ispChange == null ? "none" : $"AS{ispChange.OldAsnNumber} -> AS{ispChange.NewAsnNumber}");
 
         settings.UpstreamDiscoveryNeedsReview = true;
         settings.UpdatedAt = DateTime.UtcNow;
@@ -288,6 +290,22 @@ public class UpstreamRediscoveryService : BackgroundService
         var (monitoredAsns, removalEligibleAsns) = await BuildCommittedViewsAsync(db, wanInterface, ct);
         var candidate = BuildCandidateSignature(state);
 
+        // A changed access ISP supersedes per-transit off-path handling: the whole upstream path
+        // is replaced at once, so staging N individual transit removals alongside would be noise.
+        // Stage only the ISP-change question (plus the added keys for the scheduler's gate) and
+        // leave the miss counters frozen - a confirm wipes them wholesale, and a decline lets the
+        // next unchanged run resume advancing them normally. No multi-run miss-gate here: the
+        // access ASN is the stable first hop and the event is user-confirmed, so one run with a
+        // valid different ASN is enough to prompt.
+        state.IspChange = await DetectAccessIspChangeAsync(db, wanInterface, state, ct);
+        if (state.IspChange != null)
+        {
+            state.DiscoveryAddedAsns = candidate.Except(monitoredAsns).OrderBy(x => x).ToList();
+            state.RemovedTransitAsns = new();
+            state.PendingRemovalTransitAsns = new();
+            return;
+        }
+
         var priorMisses = await LoadMissCountsAsync(db, wanInterface, ct);
         var eval = EvaluateChange(monitoredAsns, removalEligibleAsns, candidate, priorMisses,
             DateTime.UtcNow, AbsentIncrementGate, RemovalConfirmRuns);
@@ -374,6 +392,145 @@ public class UpstreamRediscoveryService : BackgroundService
             .OrderBy(r => r.AsnNumber)
             .ToList();
     }
+
+    /// <summary>
+    /// Detects a candidate access-ISP change for the run: every access ASN this run resolved is
+    /// different from every access ASN committed for the WAN. Guards: a run that failed to
+    /// attribute any access ASN never triggers (null/unresolved is not a change); no committed
+    /// auto-discovered access ASN means there's no baseline to differ from (first run); any
+    /// overlap between the two sets means the provider is unchanged; and a new primary ASN the
+    /// user already declined is suppressed. Returns the staged candidate with the reset scope
+    /// pre-counted for the review, or null.
+    /// </summary>
+    internal static async Task<IspChangeCandidate?> DetectAccessIspChangeAsync(
+        NetworkOptimizerDbContext db, string wanInterface, UpstreamTracerState state, CancellationToken ct)
+    {
+        var newAsns = state.AccessHops
+            .Where(h => h.AsnNumber.HasValue)
+            .Select(h => h.AsnNumber!.Value)
+            .ToList();
+        if (newAsns.Count == 0) return null;
+
+        // The stored access ISP: auto-discovered AccessIsp rows on this WAN, enabled or not - a
+        // paused access target still records who the provider was. UserProvided rows are excluded
+        // since a hand-added access target carries no discovery evidence of the provider.
+        var oldRows = await db.MonitoringTargets
+            .Where(t => t.TargetType == MonitoringTargetType.AccessIsp
+                && t.WanInterface == wanInterface
+                && t.AsnNumber != null
+                && t.DiscoveryMethod != DiscoveryMethod.UserProvided)
+            .Select(t => new { t.AsnNumber, t.AsnName })
+            .ToListAsync(ct);
+        if (oldRows.Count == 0) return null;
+
+        var oldSet = oldRows.Select(r => r.AsnNumber!.Value).ToHashSet();
+        if (newAsns.Any(oldSet.Contains)) return null;
+
+        var newPrimary = newAsns
+            .GroupBy(a => a)
+            .OrderByDescending(g => g.Count()).ThenBy(g => newAsns.IndexOf(g.Key))
+            .First().Key;
+
+        var declinedRow = await db.SystemSettings.AsNoTracking()
+            .FirstOrDefaultAsync(s => s.Key == DeclinedAccessAsnKey(wanInterface), ct);
+        if (int.TryParse(declinedRow?.Value, out var declinedAsn) && declinedAsn == newPrimary)
+            return null;
+
+        var oldPrimary = oldRows
+            .GroupBy(r => r.AsnNumber!.Value)
+            .OrderByDescending(g => g.Count()).ThenBy(g => g.Key)
+            .First().Key;
+        var oldName = oldRows.Where(r => r.AsnNumber == oldPrimary)
+            .Select(r => r.AsnName).FirstOrDefault(n => !string.IsNullOrEmpty(n)) ?? $"AS{oldPrimary}";
+        var newName = state.AccessHops
+            .Where(h => h.AsnNumber == newPrimary)
+            .Select(h => h.AsnName).FirstOrDefault(n => !string.IsNullOrEmpty(n)) ?? $"AS{newPrimary}";
+
+        var scope = await LoadIspResetScopeAsync(db, wanInterface, ct);
+        return new IspChangeCandidate
+        {
+            OldAsnNumber = oldPrimary,
+            OldAsnName = oldName,
+            NewAsnNumber = newPrimary,
+            NewAsnName = newName,
+            TargetCount = scope.Count,
+            ManualCount = scope.Count(t => t.DiscoveryMethod == DiscoveryMethod.UserProvided),
+        };
+    }
+
+    /// <summary>
+    /// The targets a confirmed ISP-change reset pauses: every enabled upstream monitoring target
+    /// for the connection across all three tiers (access, transit, path-proxy). Auto-discovered
+    /// rows are scoped to this WAN; UserProvided rows count when assigned to this WAN or to no
+    /// WAN (hand-added rows are often WAN-agnostic), so a reset on one WAN never touches manual
+    /// targets pinned to another.
+    /// </summary>
+    internal static Task<List<MonitoringTarget>> LoadIspResetScopeAsync(
+        NetworkOptimizerDbContext db, string wanInterface, CancellationToken ct) =>
+        db.MonitoringTargets
+            .Where(t => t.Enabled
+                && (t.TargetType == MonitoringTargetType.AccessIsp
+                    || t.TargetType == MonitoringTargetType.Transit
+                    || t.TargetType == MonitoringTargetType.InternetService)
+                && (t.DiscoveryMethod == DiscoveryMethod.UserProvided
+                    ? (t.WanInterface == wanInterface || t.WanInterface == null || t.WanInterface == "")
+                    : t.WanInterface == wanInterface))
+            .ToListAsync(ct);
+
+    /// <summary>
+    /// Applies a confirmed ISP change for the WAN: pauses (Enabled = false, never deletes) every
+    /// target in the reset scope, wipes the WAN's absent-ASN miss counters (they described the
+    /// old provider's path), and clears any recorded decline. The caller then commits the fresh
+    /// candidates as the new baseline. Does not SaveChanges; the caller's does. Returns how many
+    /// targets were paused.
+    /// </summary>
+    internal static async Task<int> ApplyIspChangeResetAsync(
+        NetworkOptimizerDbContext db, string wanInterface, CancellationToken ct)
+    {
+        var stale = await LoadIspResetScopeAsync(db, wanInterface, ct);
+        foreach (var t in stale) t.Enabled = false;
+
+        await SaveMissCountsAsync(db, wanInterface, new(StringComparer.OrdinalIgnoreCase), ct);
+
+        var declined = await db.SystemSettings
+            .FirstOrDefaultAsync(s => s.Key == DeclinedAccessAsnKey(wanInterface), ct);
+        if (declined != null)
+        {
+            declined.Value = null;
+            declined.UpdatedAt = DateTime.UtcNow;
+        }
+        return stale.Count;
+    }
+
+    /// <summary>
+    /// Records a declined ISP change: the user said the new access ASN is not a provider switch,
+    /// so detection suppresses that ASN for the WAN instead of re-prompting every run. Does not
+    /// SaveChanges; the caller's does.
+    /// </summary>
+    internal static async Task RecordDeclinedIspChangeAsync(
+        NetworkOptimizerDbContext db, string wanInterface, int declinedNewAsn, CancellationToken ct)
+    {
+        var key = DeclinedAccessAsnKey(wanInterface);
+        var row = await db.SystemSettings.FirstOrDefaultAsync(s => s.Key == key, ct);
+        if (row == null)
+        {
+            db.SystemSettings.Add(new SystemSetting
+            {
+                Key = key,
+                Value = declinedNewAsn.ToString(),
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            });
+        }
+        else
+        {
+            row.Value = declinedNewAsn.ToString();
+            row.UpdatedAt = DateTime.UtcNow;
+        }
+    }
+
+    private static string DeclinedAccessAsnKey(string wanInterface) =>
+        SystemSettingKeys.UpstreamDeclinedAccessAsnPrefix + wanInterface;
 
     /// <summary>
     /// Removes the given identity keys from the WAN's absent-ASN miss counters. Called by commit

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -295,6 +295,22 @@ public class UpstreamTracerService
             await TraceAccessIspAsync(ct);
             await TraceTransitAsnsAsync(ct);
             await VerifyReachabilityAsync(ct);
+
+            // Shared post-run change evaluation - manual and scheduled runs alike advance the
+            // per-WAN absence counters exactly once per completed run, and both stage any
+            // confirmed off-path transit ASNs for the review. A failure here only skips the
+            // counters for this run; the review of the discovered candidates still proceeds.
+            try
+            {
+                await using var evalDb = await CreateDbAsync(ct);
+                await UpstreamRediscoveryService.EvaluateCompletedRunAsync(evalDb, State, ct);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Post-run off-path evaluation failed; absence counters not advanced this run");
+            }
+
             State.Step = TracerStep.ReviewingResults;
             State.CurrentActivity = "Review the discovered upstream path. Confirm to commit.";
             State.CompletedAt = DateTime.UtcNow;
@@ -1765,6 +1781,32 @@ public class UpstreamTracerService
                 existing.Name = transit.Label ?? transit.AsnName;
                 if (!string.IsNullOrEmpty(transit.AsnName)) existing.AsnName = transit.AsnName;
             }
+        }
+
+        // Confirmed off-path transit ASNs the user didn't re-check: pause every enabled Transit
+        // target in the ASN - auto-discovered AND hand-added - since the ISP no longer routes
+        // through it, so they're false targets skewing ISP Health. Paused (Enabled=false), never
+        // deleted. Auto targets are scoped to this WAN; UserProvided ones are WAN-agnostic.
+        if (State.RemovedTransitAsns.Count > 0)
+        {
+            foreach (var removed in State.RemovedTransitAsns.Where(r => !r.Keep))
+            {
+                var stale = await db.MonitoringTargets
+                    .Where(t => t.TargetType == MonitoringTargetType.Transit && t.Enabled
+                        && t.AsnNumber == removed.AsnNumber
+                        && (t.DiscoveryMethod == DiscoveryMethod.UserProvided || t.WanInterface == wanInterface))
+                    .ToListAsync(ct);
+                foreach (var t in stale) t.Enabled = false;
+                if (stale.Count > 0)
+                    _logger.LogInformation("Commit: paused {Count} off-path transit target(s) for AS{Asn} ({Name})",
+                        stale.Count, removed.AsnNumber, removed.AsnName);
+            }
+
+            // Clear the surfaced ASNs' miss counters - kept AND paused. A kept ASN would otherwise
+            // still sit at the confirm threshold and re-flag review on the next daily recheck;
+            // clearing makes its off-path evidence re-accumulate from zero instead.
+            await UpstreamRediscoveryService.ClearMissCountKeysAsync(db, wanInterface,
+                State.RemovedTransitAsns.Select(r => "transit:as" + r.AsnNumber), ct);
         }
 
         // Per-WAN tracer state. WanDiscoveryContexts is the new source of truth;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1749,6 +1749,25 @@ public class UpstreamTracerService
         // WanDiscoveryContexts per WAN.
         var wanInterface = State.WanInterface ?? "wan";
 
+        // A confirmed provider change resets the connection's upstream monitoring wholesale:
+        // pause every enabled access/transit/path target - auto-discovered and hand-added alike
+        // (manual rows pinned to another WAN survive) - and wipe the WAN's off-path evidence,
+        // so the freshly discovered candidates upserted below become the new baseline. Runs
+        // before the upserts so the fresh targets come back enabled. A decline records the new
+        // ASN so the same change doesn't re-prompt every run.
+        if (State.IspChange is { Confirmed: true } confirmedChange)
+        {
+            var paused = await UpstreamRediscoveryService.ApplyIspChangeResetAsync(db, wanInterface, ct);
+            _logger.LogInformation("Commit: ISP change AS{Old} -> AS{New} confirmed; paused {Count} upstream target(s) on {Wan} for a fresh baseline",
+                confirmedChange.OldAsnNumber, confirmedChange.NewAsnNumber, paused, wanInterface);
+        }
+        else if (State.IspChange is { Confirmed: false } declinedChange)
+        {
+            await UpstreamRediscoveryService.RecordDeclinedIspChangeAsync(db, wanInterface, declinedChange.NewAsnNumber, ct);
+            _logger.LogInformation("Commit: ISP change AS{Old} -> AS{New} declined; keeping existing targets",
+                declinedChange.OldAsnNumber, declinedChange.NewAsnNumber);
+        }
+
         foreach (var hop in State.AccessHops.Where(h => h.Enabled))
         {
             _logger.LogDebug("Commit access hop: id={TargetId} label='{Label}' addr={Address}", hop.TargetId, hop.Label, hop.Address);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerState.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerState.cs
@@ -52,6 +52,15 @@ public class UpstreamTracerState
     /// </summary>
     public List<string> DiscoveryAddedAsns { get; set; } = new();
 
+    /// <summary>
+    /// Staged when this run resolved a valid access ISP ASN that differs from every access ASN
+    /// committed for the WAN - a candidate provider change. Supersedes per-transit off-path
+    /// staging for the run (a switched provider replaces the whole path at once, not N transit
+    /// removals). Null when the access ASN is unchanged, unresolved this run, or the user
+    /// already declined this same new ASN. In-memory only, like the rest of the review state.
+    /// </summary>
+    public IspChangeCandidate? IspChange { get; set; }
+
     // Per-CDN trace summaries for the live progress UI.
     public List<TraceSummary> Traces { get; set; } = new();
 
@@ -164,6 +173,29 @@ public class PendingRemovalTransitAsn
     public int TargetCount { get; set; }
     /// <summary>How many of those are hand-added (UserProvided).</summary>
     public int ManualCount { get; set; }
+}
+
+/// <summary>
+/// A detected access-ISP change awaiting the user's answer in the review. Confirmed stays null
+/// until they pick; the commit button is gated on a decision. Confirming pauses every enabled
+/// upstream target for the connection - access, transit, and path-proxy tiers, auto-discovered
+/// and hand-added alike (manual targets pinned to a different WAN survive) - wipes the WAN's
+/// off-path miss counters, and lets this run's candidates repopulate as the new baseline.
+/// Declining leaves targets untouched and records the new ASN so the same change doesn't
+/// re-prompt every run. Paused targets are never deleted.
+/// </summary>
+public class IspChangeCandidate
+{
+    public int OldAsnNumber { get; set; }
+    public required string OldAsnName { get; set; }
+    public int NewAsnNumber { get; set; }
+    public required string NewAsnName { get; set; }
+    /// <summary>Enabled upstream targets across all tiers a confirm would pause.</summary>
+    public int TargetCount { get; set; }
+    /// <summary>How many of those are hand-added (UserProvided).</summary>
+    public int ManualCount { get; set; }
+    /// <summary>Null until the user decides; true = start fresh, false = keep monitoring.</summary>
+    public bool? Confirmed { get; set; }
 }
 
 /// <summary>One CDN traceroute summary for the live progress UI.</summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerState.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerState.cs
@@ -39,6 +39,14 @@ public class UpstreamTracerState
     public List<RemovedTransitAsn> RemovedTransitAsns { get; set; } = new();
 
     /// <summary>
+    /// Transit ASNs currently absent from discovery but not yet confirmed removed (consecutive-miss
+    /// count below the threshold). Informational only - surfaced read-only in the review so the user
+    /// knows we noticed the ASN went off-path and are tracking it toward removal. Populated on every
+    /// completed run (manual and scheduled) from the same evaluation, so the count stays accurate.
+    /// </summary>
+    public List<PendingRemovalTransitAsn> PendingRemovalTransitAsns { get; set; } = new();
+
+    /// <summary>
     /// Identity keys this run discovered that the committed target set doesn't cover yet.
     /// Staged by the shared post-run evaluation for the re-discovery scheduler's review gate.
     /// </summary>
@@ -136,6 +144,26 @@ public class RemovedTransitAsn
     public int ManualCount { get; set; }
     /// <summary>Checkbox state. Default false = pause on commit; user re-checks to keep monitoring.</summary>
     public bool Keep { get; set; }
+}
+
+/// <summary>
+/// A transit ASN that has gone absent from discovery but hasn't yet hit the consecutive-miss
+/// threshold for removal. Surfaced read-only in the review ("we're tracking this; N more runs
+/// without it and we'll help you remove its targets"). No checkbox, no commit action - purely a
+/// heads-up so the off-path detection isn't invisible until it suddenly confirms.
+/// </summary>
+public class PendingRemovalTransitAsn
+{
+    public int AsnNumber { get; set; }
+    public required string AsnName { get; set; }
+    /// <summary>Consecutive runs this ASN has been absent so far.</summary>
+    public int MissCount { get; set; }
+    /// <summary>Runs still needed without it present before it's confirmed for removal.</summary>
+    public int RunsRemaining { get; set; }
+    /// <summary>Enabled Transit targets that would be paused once confirmed (auto + manual).</summary>
+    public int TargetCount { get; set; }
+    /// <summary>How many of those are hand-added (UserProvided).</summary>
+    public int ManualCount { get; set; }
 }
 
 /// <summary>One CDN traceroute summary for the live progress UI.</summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerState.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerState.cs
@@ -29,6 +29,21 @@ public class UpstreamTracerState
     public List<AccessHopCandidate> AccessHops { get; set; } = new();
     public List<TransitAsnCandidate> TransitAsns { get; set; } = new();
 
+    /// <summary>
+    /// Transit ASNs the scheduled re-discovery confirmed are no longer on our path (absent from
+    /// several consecutive runs). Surfaced in the review pre-unchecked; committing with an entry
+    /// left unchecked pauses every enabled Transit target in that ASN. In-memory only (like the
+    /// rest of the review state): a restart during the review window loses the list, but the
+    /// persisted miss counters re-populate it on the next background recheck.
+    /// </summary>
+    public List<RemovedTransitAsn> RemovedTransitAsns { get; set; } = new();
+
+    /// <summary>
+    /// Identity keys this run discovered that the committed target set doesn't cover yet.
+    /// Staged by the shared post-run evaluation for the re-discovery scheduler's review gate.
+    /// </summary>
+    public List<string> DiscoveryAddedAsns { get; set; } = new();
+
     // Per-CDN trace summaries for the live progress UI.
     public List<TraceSummary> Traces { get; set; } = new();
 
@@ -103,6 +118,24 @@ public class TransitAsnCandidate
     /// stored choices.
     /// </summary>
     public bool PreservedFromExisting { get; set; }
+}
+
+/// <summary>
+/// A transit ASN that auto-discovery confirmed is no longer on our path (absent from several
+/// consecutive re-discovery runs). Surfaced in the review pre-unchecked; committing with it
+/// left unchecked pauses every enabled Transit target in the ASN - auto-discovered and hand-
+/// added alike - since if the ISP no longer routes through the ASN, all its targets are false.
+/// </summary>
+public class RemovedTransitAsn
+{
+    public int AsnNumber { get; set; }
+    public required string AsnName { get; set; }
+    /// <summary>Enabled Transit targets in this ASN that would be paused (auto + manual).</summary>
+    public int TargetCount { get; set; }
+    /// <summary>How many of those are hand-added (UserProvided), for the review note.</summary>
+    public int ManualCount { get; set; }
+    /// <summary>Checkbox state. Default false = pause on commit; user re-checks to keep monitoring.</summary>
+    public bool Keep { get; set; }
 }
 
 /// <summary>One CDN traceroute summary for the live progress UI.</summary>

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/FlakyTargetServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/FlakyTargetServiceTests.cs
@@ -155,6 +155,59 @@ public class FlakyTargetServiceTests
     }
 
     [Fact]
+    public void Hard_down_target_recovers_after_a_short_clean_streak()
+    {
+        // A total outage (100% bins) that ended: three clean bins (~30 min) clear it via the
+        // hard-down fast path, long before the outage bins dilute out of the recovery window.
+        var (loss, meta) = Build(
+            ("outage-over", Run(12, 100.0, 3, 0.0)),
+            ("clean-a", Run(15, 0.0, 0, 0.0)),
+            ("clean-b", Run(15, 0.0, 0, 0.0)));
+
+        FlakyTargetService.Analyze(loss, meta).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Hard_down_target_still_down_stays_flagged()
+    {
+        var (loss, meta) = Build(
+            ("still-down", Run(15, 100.0, 0, 0.0)),
+            ("clean-a", Run(15, 0.0, 0, 0.0)),
+            ("clean-b", Run(15, 0.0, 0, 0.0)));
+
+        FlakyTargetService.Analyze(loss, meta).Should().ContainSingle()
+            .Which.TargetId.Should().Be("still-down");
+    }
+
+    [Fact]
+    public void Partial_loss_target_does_not_get_the_hard_down_fast_path()
+    {
+        // Same shape as the outage case but with partial (deprioritization-style) loss: a short
+        // clean streak is NOT enough - it must satisfy the full recovery window instead.
+        var (loss, meta) = Build(
+            ("partial-loss", Run(12, 20.0, 3, 0.0)),
+            ("clean-a", Run(15, 0.0, 0, 0.0)),
+            ("clean-b", Run(15, 0.0, 0, 0.0)));
+
+        FlakyTargetService.Analyze(loss, meta).Should().ContainSingle()
+            .Which.TargetId.Should().Be("partial-loss");
+    }
+
+    [Fact]
+    public void Mixed_outage_and_partial_loss_does_not_get_the_fast_path()
+    {
+        // One over-threshold bin at partial loss alongside the 100% bins: the episode isn't a
+        // clean binary outage, so the short streak must not clear it.
+        var (loss, meta) = Build(
+            ("mixed", Run(11, 100.0, 1, 20.0).Concat(Run(3, 0.0, 0, 0.0)).ToArray()),
+            ("clean-a", Run(15, 0.0, 0, 0.0)),
+            ("clean-b", Run(15, 0.0, 0, 0.0)));
+
+        FlakyTargetService.Analyze(loss, meta).Should().ContainSingle()
+            .Which.TargetId.Should().Be("mixed");
+    }
+
+    [Fact]
     public void Target_flaky_again_after_a_clean_stretch_is_flagged()
     {
         // Clean history, then flaky through the trailing window - the recovery gate only clears

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/FlakyTargetServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/FlakyTargetServiceTests.cs
@@ -194,12 +194,26 @@ public class FlakyTargetServiceTests
     }
 
     [Fact]
-    public void Mixed_outage_and_partial_loss_does_not_get_the_fast_path()
+    public void Outage_with_a_partial_boundary_bin_still_gets_the_fast_path()
     {
-        // One over-threshold bin at partial loss alongside the 100% bins: the episode isn't a
-        // clean binary outage, so the short streak must not clear it.
+        // Real recovery shape: the aggregate bin straddling the moment the hop came back
+        // averages to partial loss (observed 52.8%). The median over-threshold bin is still
+        // 100%, so the boundary bin must not disqualify the fast path.
         var (loss, meta) = Build(
-            ("mixed", Run(11, 100.0, 1, 20.0).Concat(Run(3, 0.0, 0, 0.0)).ToArray()),
+            ("boundary", Run(11, 100.0, 1, 52.8).Concat(Run(3, 0.0, 0, 0.0)).ToArray()),
+            ("clean-a", Run(15, 0.0, 0, 0.0)),
+            ("clean-b", Run(15, 0.0, 0, 0.0)));
+
+        FlakyTargetService.Analyze(loss, meta).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Genuinely_mixed_partial_loss_episode_does_not_get_the_fast_path()
+    {
+        // Half the over-threshold bins are partial (deprioritization-style) loss: the median
+        // falls below the hard-down bar, so the short streak must not clear it.
+        var (loss, meta) = Build(
+            ("mixed", Run(6, 100.0, 6, 20.0).Concat(Run(3, 0.0, 0, 0.0)).ToArray()),
             ("clean-a", Run(15, 0.0, 0, 0.0)),
             ("clean-b", Run(15, 0.0, 0, 0.0)));
 

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/FlakyTargetServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/FlakyTargetServiceTests.cs
@@ -22,8 +22,10 @@ public class FlakyTargetServiceTests
         foreach (var (id, losses) in targets)
         {
             var bins = new Dictionary<DateTime, double>();
+            // A negative loss is a gap sentinel: no bin reported at that slot.
             for (var i = 0; i < losses.Length; i++)
-                bins[Base.AddMinutes(10 * i)] = losses[i];
+                if (losses[i] >= 0)
+                    bins[Base.AddMinutes(10 * i)] = losses[i];
             loss[id] = bins;
             meta[id] = new MonitoringTarget
             {
@@ -89,6 +91,81 @@ public class FlakyTargetServiceTests
             ("clean-b", new[] { 0.0, 0, 0, 0, 0, 0 }));
 
         FlakyTargetService.Analyze(loss, meta).Should().BeEmpty();
+    }
+
+    // ---- Recovery gate: stable -> flaky -> stable stops being presented ----
+
+    /// <summary>Losses: `head` copies of `headLoss` followed by `tail` copies of `tailLoss`.</summary>
+    private static double[] Run(int head, double headLoss, int tail, double tailLoss) =>
+        Enumerable.Repeat(headLoss, head).Concat(Enumerable.Repeat(tailLoss, tail)).ToArray();
+
+    [Fact]
+    public void Recovered_target_is_no_longer_flagged()
+    {
+        // Flaky for the first 2h, clean for the following 4h. The full-window trimmed mean
+        // (~6.5%) still says flaky, but the trailing 3h is clean - recovered, not presented.
+        var (loss, meta) = Build(
+            ("recovered", Run(12, 20.0, 24, 0.0)),
+            ("clean-a", Run(36, 0.0, 0, 0.0)),
+            ("clean-b", Run(36, 0.0, 0, 0.0)));
+
+        FlakyTargetService.Analyze(loss, meta).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Always_flaky_target_with_long_history_stays_flagged()
+    {
+        // Flaky since it was added, including the trailing window - the recovery gate must not
+        // clear it.
+        var (loss, meta) = Build(
+            ("always-flaky", Run(36, 8.0, 0, 0.0)),
+            ("clean-a", Run(36, 0.0, 0, 0.0)),
+            ("clean-b", Run(36, 0.0, 0, 0.0)));
+
+        FlakyTargetService.Analyze(loss, meta).Should().ContainSingle()
+            .Which.TargetId.Should().Be("always-flaky");
+    }
+
+    [Fact]
+    public void Target_that_went_dark_cannot_prove_recovery_and_stays_flagged()
+    {
+        // Flaky, then stopped reporting entirely while peers kept going: no recent bins means
+        // no evidence of stability, so it stays flagged.
+        var (loss, meta) = Build(
+            ("went-dark", Run(12, 20.0, 24, -1.0)),
+            ("clean-a", Run(36, 0.0, 0, 0.0)),
+            ("clean-b", Run(36, 0.0, 0, 0.0)));
+
+        FlakyTargetService.Analyze(loss, meta).Should().ContainSingle()
+            .Which.TargetId.Should().Be("went-dark");
+    }
+
+    [Fact]
+    public void Too_few_recent_bins_do_not_clear_the_flag()
+    {
+        // Only 3 clean bins inside the recovery window (< MinRecoveryBins of 6): not enough
+        // evidence to call it stable again.
+        var (loss, meta) = Build(
+            ("barely-back", Run(12, 20.0, 21, -1.0).Concat(Run(3, 0.0, 0, 0.0)).ToArray()),
+            ("clean-a", Run(36, 0.0, 0, 0.0)),
+            ("clean-b", Run(36, 0.0, 0, 0.0)));
+
+        FlakyTargetService.Analyze(loss, meta).Should().ContainSingle()
+            .Which.TargetId.Should().Be("barely-back");
+    }
+
+    [Fact]
+    public void Target_flaky_again_after_a_clean_stretch_is_flagged()
+    {
+        // Clean history, then flaky through the trailing window - the recovery gate only clears
+        // targets that are currently stable, never ones that are currently flaky.
+        var (loss, meta) = Build(
+            ("relapsed", Run(18, 0.0, 18, 8.0)),
+            ("clean-a", Run(36, 0.0, 0, 0.0)),
+            ("clean-b", Run(36, 0.0, 0, 0.0)));
+
+        FlakyTargetService.Analyze(loss, meta).Should().ContainSingle()
+            .Which.TargetId.Should().Be("relapsed");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamIspChangeResetTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamIspChangeResetTests.cs
@@ -1,0 +1,336 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services.Monitoring;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+/// <summary>
+/// The "your ISP changed" reset for upstream discovery. A completed run whose resolved access
+/// ASN differs from every committed access ASN stages a user-confirmed ISP change, which
+/// supersedes per-transit off-path staging for that run. Confirming pauses every upstream
+/// target for the connection (all tiers, auto and hand-added; manual targets pinned to another
+/// WAN survive) and wipes the WAN's off-path evidence; declining records the new ASN so the
+/// same change doesn't re-prompt.
+///
+/// All ASNs are RFC 5398 documentation ASNs (64496-64511) and all IPs are RFC 5737 ranges.
+/// </summary>
+public class UpstreamIspChangeResetTests : IDisposable
+{
+    private const int OldAccessAsn = 64496;
+    private const int NewAccessAsn = 64497;
+    private const int TransitAsn = 64498;
+    private const int PathAsn = 64499;
+    private const int UserAsn = 64500;
+
+    private readonly NetworkOptimizerDbContext _db;
+
+    public UpstreamIspChangeResetTests()
+    {
+        var options = new DbContextOptionsBuilder<NetworkOptimizerDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        _db = new NetworkOptimizerDbContext(options);
+        _db.Database.EnsureCreated();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    // ---- Detection ----
+
+    [Fact]
+    public async Task Detects_change_when_access_asn_differs()
+    {
+        SeedCommittedAccess(OldAccessAsn, name: "Old Provider");
+        var state = RunState(NewAccessAsn, newName: "New Provider");
+
+        var change = await UpstreamRediscoveryService.DetectAccessIspChangeAsync(_db, "wan", state, CancellationToken.None);
+
+        change.Should().NotBeNull();
+        change!.OldAsnNumber.Should().Be(OldAccessAsn);
+        change.OldAsnName.Should().Be("Old Provider");
+        change.NewAsnNumber.Should().Be(NewAccessAsn);
+        change.NewAsnName.Should().Be("New Provider");
+        change.Confirmed.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task No_change_when_run_resolved_no_access_asn()
+    {
+        // A run that failed to attribute the access ASN must NOT read as a provider change.
+        SeedCommittedAccess(OldAccessAsn);
+        var state = new UpstreamTracerState
+        {
+            WanInterface = "wan",
+            AccessHops = { Hop("192.0.2.9", asn: null) },
+        };
+
+        var change = await UpstreamRediscoveryService.DetectAccessIspChangeAsync(_db, "wan", state, CancellationToken.None);
+
+        change.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task No_change_when_access_asn_unchanged()
+    {
+        SeedCommittedAccess(OldAccessAsn);
+        var state = RunState(OldAccessAsn);
+
+        var change = await UpstreamRediscoveryService.DetectAccessIspChangeAsync(_db, "wan", state, CancellationToken.None);
+
+        change.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task No_change_when_nothing_committed_yet()
+    {
+        var state = RunState(NewAccessAsn);
+
+        var change = await UpstreamRediscoveryService.DetectAccessIspChangeAsync(_db, "wan", state, CancellationToken.None);
+
+        change.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task No_change_when_any_resolved_asn_overlaps_committed()
+    {
+        // The run sees both the stored ASN and a new one (e.g. a re-attributed middle hop):
+        // the provider is still on the path, so it's not a switch.
+        SeedCommittedAccess(OldAccessAsn);
+        var state = new UpstreamTracerState
+        {
+            WanInterface = "wan",
+            AccessHops = { Hop("192.0.2.10", NewAccessAsn), Hop("192.0.2.11", OldAccessAsn) },
+        };
+
+        var change = await UpstreamRediscoveryService.DetectAccessIspChangeAsync(_db, "wan", state, CancellationToken.None);
+
+        change.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task No_change_when_new_asn_was_declined()
+    {
+        SeedCommittedAccess(OldAccessAsn);
+        await UpstreamRediscoveryService.RecordDeclinedIspChangeAsync(_db, "wan", NewAccessAsn, CancellationToken.None);
+        await _db.SaveChangesAsync();
+        var state = RunState(NewAccessAsn);
+
+        var change = await UpstreamRediscoveryService.DetectAccessIspChangeAsync(_db, "wan", state, CancellationToken.None);
+
+        change.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Decline_of_one_asn_does_not_suppress_a_different_one()
+    {
+        SeedCommittedAccess(OldAccessAsn);
+        await UpstreamRediscoveryService.RecordDeclinedIspChangeAsync(_db, "wan", 64511, CancellationToken.None);
+        await _db.SaveChangesAsync();
+        var state = RunState(NewAccessAsn);
+
+        var change = await UpstreamRediscoveryService.DetectAccessIspChangeAsync(_db, "wan", state, CancellationToken.None);
+
+        change.Should().NotBeNull();
+        change!.NewAsnNumber.Should().Be(NewAccessAsn);
+    }
+
+    [Fact]
+    public async Task UserProvided_access_rows_are_not_the_stored_baseline()
+    {
+        // A hand-added access target carries no discovery evidence of the provider - with only
+        // manual rows committed there's no baseline, so no change fires.
+        _db.MonitoringTargets.Add(Target("192.0.2.1", MonitoringTargetType.AccessIsp, OldAccessAsn, "wan", DiscoveryMethod.UserProvided));
+        await _db.SaveChangesAsync();
+        var state = RunState(NewAccessAsn);
+
+        var change = await UpstreamRediscoveryService.DetectAccessIspChangeAsync(_db, "wan", state, CancellationToken.None);
+
+        change.Should().BeNull();
+    }
+
+    // ---- Reset scope ----
+
+    [Fact]
+    public async Task Detection_counts_reset_scope_across_tiers_including_wan_agnostic_manual()
+    {
+        SeedCommittedAccess(OldAccessAsn);
+        _db.MonitoringTargets.AddRange(
+            // enabled tiers on this WAN - counted
+            Target("198.51.100.1", MonitoringTargetType.Transit, TransitAsn, "wan", DiscoveryMethod.DirectRouter),
+            Target("203.0.113.5", MonitoringTargetType.InternetService, PathAsn, "wan", DiscoveryMethod.PathProxy),
+            // hand-added, WAN-agnostic - counted and reported as manual
+            Target("203.0.113.1", MonitoringTargetType.Transit, UserAsn, "", DiscoveryMethod.UserProvided),
+            // hand-added but pinned to another WAN - survives the reset, not counted
+            Target("203.0.113.2", MonitoringTargetType.Transit, UserAsn, "wan2", DiscoveryMethod.UserProvided),
+            // other-WAN auto - not counted
+            Target("198.51.100.2", MonitoringTargetType.Transit, TransitAsn, "wan2", DiscoveryMethod.DirectRouter),
+            // disabled - already paused, not counted
+            Target("198.51.100.3", MonitoringTargetType.Transit, TransitAsn, "wan", DiscoveryMethod.DirectRouter, enabled: false));
+        await _db.SaveChangesAsync();
+        var state = RunState(NewAccessAsn);
+
+        var change = await UpstreamRediscoveryService.DetectAccessIspChangeAsync(_db, "wan", state, CancellationToken.None);
+
+        change.Should().NotBeNull();
+        // committed access row + transit + path + WAN-agnostic manual
+        change!.TargetCount.Should().Be(4);
+        change.ManualCount.Should().Be(1);
+    }
+
+    // ---- Supersede: no per-transit staging when an ISP change fires ----
+
+    [Fact]
+    public async Task CompletedRun_with_isp_change_stages_no_transit_removals_and_freezes_counters()
+    {
+        // Transit ASN sits one gated increment from confirming - a normal run would confirm it.
+        SeedCommittedAccess(OldAccessAsn);
+        _db.MonitoringTargets.Add(Target("198.51.100.1", MonitoringTargetType.Transit, TransitAsn, "wan", DiscoveryMethod.DirectRouter));
+        var counterJson = $"{{\"transit:as{TransitAsn}\":{{\"c\":2,\"t\":\"{DateTime.UtcNow.AddHours(-24):o}\"}}}}";
+        _db.SystemSettings.Add(new SystemSetting
+        {
+            Key = SystemSettingKeys.UpstreamAbsentAsnCountsPrefix + "wan",
+            Value = counterJson,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+
+        // New access ASN, and the transit ASN absent this run.
+        var state = RunState(NewAccessAsn);
+
+        await UpstreamRediscoveryService.EvaluateCompletedRunAsync(_db, state, CancellationToken.None);
+
+        state.IspChange.Should().NotBeNull();
+        state.RemovedTransitAsns.Should().BeEmpty();
+        state.PendingRemovalTransitAsns.Should().BeEmpty();
+        // Counters frozen, not advanced and not cleared - a confirm wipes them, a decline
+        // lets the next unchanged run resume normally.
+        var row = await _db.SystemSettings.SingleAsync(
+            s => s.Key == SystemSettingKeys.UpstreamAbsentAsnCountsPrefix + "wan");
+        row.Value.Should().Be(counterJson);
+    }
+
+    [Fact]
+    public async Task CompletedRun_without_isp_change_stages_transit_removals_normally()
+    {
+        SeedCommittedAccess(OldAccessAsn);
+        _db.MonitoringTargets.Add(Target("198.51.100.1", MonitoringTargetType.Transit, TransitAsn, "wan", DiscoveryMethod.DirectRouter));
+        _db.SystemSettings.Add(new SystemSetting
+        {
+            Key = SystemSettingKeys.UpstreamAbsentAsnCountsPrefix + "wan",
+            Value = $"{{\"transit:as{TransitAsn}\":{{\"c\":2,\"t\":\"{DateTime.UtcNow.AddHours(-24):o}\"}}}}",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+
+        var state = RunState(OldAccessAsn); // same provider, transit ASN absent
+
+        await UpstreamRediscoveryService.EvaluateCompletedRunAsync(_db, state, CancellationToken.None);
+
+        state.IspChange.Should().BeNull();
+        state.RemovedTransitAsns.Should().ContainSingle().Which.AsnNumber.Should().Be(TransitAsn);
+    }
+
+    // ---- Reset / decline application ----
+
+    [Fact]
+    public async Task ApplyReset_pauses_scope_and_wipes_counters_and_decline_memory()
+    {
+        _db.MonitoringTargets.AddRange(
+            Target("192.0.2.1", MonitoringTargetType.AccessIsp, OldAccessAsn, "wan", DiscoveryMethod.DirectRouter),
+            Target("198.51.100.1", MonitoringTargetType.Transit, TransitAsn, "wan", DiscoveryMethod.DirectRouter),
+            Target("203.0.113.5", MonitoringTargetType.InternetService, PathAsn, "wan", DiscoveryMethod.PathProxy),
+            Target("203.0.113.1", MonitoringTargetType.Transit, UserAsn, "", DiscoveryMethod.UserProvided),
+            // pinned to another WAN - must survive
+            Target("203.0.113.2", MonitoringTargetType.Transit, UserAsn, "wan2", DiscoveryMethod.UserProvided),
+            Target("198.51.100.2", MonitoringTargetType.Transit, TransitAsn, "wan2", DiscoveryMethod.DirectRouter));
+        _db.SystemSettings.AddRange(
+            new SystemSetting
+            {
+                Key = SystemSettingKeys.UpstreamAbsentAsnCountsPrefix + "wan",
+                Value = $"{{\"transit:as{TransitAsn}\":3}}",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            },
+            new SystemSetting
+            {
+                Key = SystemSettingKeys.UpstreamDeclinedAccessAsnPrefix + "wan",
+                Value = NewAccessAsn.ToString(),
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            });
+        await _db.SaveChangesAsync();
+
+        var paused = await UpstreamRediscoveryService.ApplyIspChangeResetAsync(_db, "wan", CancellationToken.None);
+        await _db.SaveChangesAsync();
+
+        paused.Should().Be(4);
+        var targets = await _db.MonitoringTargets.ToListAsync();
+        targets.Where(t => t.WanInterface == "wan" || t.WanInterface == "")
+            .Should().OnlyContain(t => !t.Enabled);
+        targets.Where(t => t.WanInterface == "wan2")
+            .Should().OnlyContain(t => t.Enabled);
+
+        (await _db.SystemSettings.SingleAsync(s => s.Key == SystemSettingKeys.UpstreamAbsentAsnCountsPrefix + "wan"))
+            .Value.Should().BeNull();
+        (await _db.SystemSettings.SingleAsync(s => s.Key == SystemSettingKeys.UpstreamDeclinedAccessAsnPrefix + "wan"))
+            .Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RecordDecline_upserts_the_new_asn()
+    {
+        await UpstreamRediscoveryService.RecordDeclinedIspChangeAsync(_db, "wan", NewAccessAsn, CancellationToken.None);
+        await _db.SaveChangesAsync();
+        await UpstreamRediscoveryService.RecordDeclinedIspChangeAsync(_db, "wan", 64511, CancellationToken.None);
+        await _db.SaveChangesAsync();
+
+        var row = await _db.SystemSettings.SingleAsync(
+            s => s.Key == SystemSettingKeys.UpstreamDeclinedAccessAsnPrefix + "wan");
+        row.Value.Should().Be("64511");
+    }
+
+    // ---- helpers ----
+
+    private void SeedCommittedAccess(int asn, string? name = null)
+    {
+        _db.MonitoringTargets.Add(Target("192.0.2.1", MonitoringTargetType.AccessIsp, asn, "wan",
+            DiscoveryMethod.DirectRouter, asnName: name));
+        _db.SaveChanges();
+    }
+
+    // Run state whose access hop resolved to `newAsn`; no transit ASNs, so any removal-eligible
+    // transit ASN reads as absent this run.
+    private static UpstreamTracerState RunState(int newAsn, string? newName = null) => new()
+    {
+        WanInterface = "wan",
+        AccessHops = { Hop("192.0.2.20", newAsn, newName) },
+    };
+
+    private static AccessHopCandidate Hop(string address, int? asn, string? asnName = null) => new()
+    {
+        TargetId = $"access-{address}",
+        Label = $"Access {address}",
+        Address = address,
+        AsnNumber = asn,
+        AsnName = asnName,
+        Method = DiscoveryMethod.DirectRouter,
+    };
+
+    private static MonitoringTarget Target(string address, MonitoringTargetType type, int? asn,
+        string wan, DiscoveryMethod? method, bool enabled = true, string? asnName = null) => new()
+    {
+        TargetId = $"{type}-{address}",
+        Name = $"{type} {address}",
+        Address = address,
+        TargetType = type,
+        AsnNumber = asn,
+        AsnName = asnName,
+        WanInterface = wan,
+        DiscoveryMethod = method,
+        Enabled = enabled,
+    };
+}

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamRediscoverySignatureTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamRediscoverySignatureTests.cs
@@ -177,7 +177,7 @@ public class UpstreamRediscoverySignatureTests : IDisposable
         var monitored = Set($"transit:as{TransitAsnA}");
         var candidate = Set($"transit:as{TransitAsnA}", $"transit:as{TransitAsnB}");
 
-        var eval = UpstreamRediscoveryService.EvaluateChange(monitored, Set(), candidate, Empty, 3);
+        var eval = UpstreamRediscoveryService.EvaluateChange(monitored, Set(), candidate, Empty, Now, Gate, 3);
 
         eval.Added.Should().BeEquivalentTo(new[] { $"transit:as{TransitAsnB}" });
         eval.RemovalCandidates.Should().BeEmpty();
@@ -190,7 +190,7 @@ public class UpstreamRediscoverySignatureTests : IDisposable
         var monitored = Set($"transit:as{UserAsn}");
         var candidate = Set($"transit:as{UserAsn}");
 
-        var eval = UpstreamRediscoveryService.EvaluateChange(monitored, Set(), candidate, Empty, 3);
+        var eval = UpstreamRediscoveryService.EvaluateChange(monitored, Set(), candidate, Empty, Now, Gate, 3);
 
         eval.Added.Should().BeEmpty();
     }
@@ -201,9 +201,10 @@ public class UpstreamRediscoverySignatureTests : IDisposable
         var autoEnabled = Set($"transit:as{TransitAsnA}");
         var candidate = Set(); // A missing this run
 
-        var eval = UpstreamRediscoveryService.EvaluateChange(Set(), autoEnabled, candidate, Empty, 3);
+        var eval = UpstreamRediscoveryService.EvaluateChange(Set(), autoEnabled, candidate, Empty, Now, Gate, 3);
 
-        eval.NewMissCounts.Should().ContainKey($"transit:as{TransitAsnA}").WhoseValue.Should().Be(1);
+        eval.NewMisses.Should().ContainKey($"transit:as{TransitAsnA}").WhoseValue.Count.Should().Be(1);
+        eval.NewMisses[$"transit:as{TransitAsnA}"].LastIncrementUtc.Should().Be(Now);
         eval.RemovalCandidates.Should().BeEmpty();
     }
 
@@ -212,11 +213,11 @@ public class UpstreamRediscoverySignatureTests : IDisposable
     {
         var autoEnabled = Set($"transit:as{TransitAsnA}");
         var candidate = Set();
-        var prior = new Dictionary<string, int> { [$"transit:as{TransitAsnA}"] = 2 };
+        var prior = Prior($"transit:as{TransitAsnA}", 2); // last increment well past the gate
 
-        var eval = UpstreamRediscoveryService.EvaluateChange(Set(), autoEnabled, candidate, prior, 3);
+        var eval = UpstreamRediscoveryService.EvaluateChange(Set(), autoEnabled, candidate, prior, Now, Gate, 3);
 
-        eval.NewMissCounts[$"transit:as{TransitAsnA}"].Should().Be(3);
+        eval.NewMisses[$"transit:as{TransitAsnA}"].Count.Should().Be(3);
         eval.RemovalCandidates.Should().BeEquivalentTo(new[] { $"transit:as{TransitAsnA}" });
     }
 
@@ -225,12 +226,57 @@ public class UpstreamRediscoverySignatureTests : IDisposable
     {
         var autoEnabled = Set($"transit:as{TransitAsnA}");
         var candidate = Set($"transit:as{TransitAsnA}"); // present again
-        var prior = new Dictionary<string, int> { [$"transit:as{TransitAsnA}"] = 2 };
+        var prior = Prior($"transit:as{TransitAsnA}", 2);
 
-        var eval = UpstreamRediscoveryService.EvaluateChange(Set(), autoEnabled, candidate, prior, 3);
+        var eval = UpstreamRediscoveryService.EvaluateChange(Set(), autoEnabled, candidate, prior, Now, Gate, 3);
 
-        eval.NewMissCounts.Should().NotContainKey($"transit:as{TransitAsnA}"); // pruned by omission
+        eval.NewMisses.Should().NotContainKey($"transit:as{TransitAsnA}"); // pruned by omission
         eval.RemovalCandidates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Miss_within_gate_holds_count_and_timestamp_instead_of_incrementing()
+    {
+        // Absent again, but only 1h since the last increment (< 6h gate): count must NOT advance,
+        // and the timestamp must stay put so the next in-window miss is also held.
+        var autoEnabled = Set($"transit:as{TransitAsnA}");
+        var candidate = Set();
+        var lastInc = Now.AddHours(-1);
+        var prior = Prior($"transit:as{TransitAsnA}", 2, hoursAgo: 1);
+
+        var eval = UpstreamRediscoveryService.EvaluateChange(Set(), autoEnabled, candidate, prior, Now, Gate, 3);
+
+        eval.NewMisses[$"transit:as{TransitAsnA}"].Count.Should().Be(2); // held, not 3
+        eval.NewMisses[$"transit:as{TransitAsnA}"].LastIncrementUtc.Should().Be(lastInc);
+        eval.RemovalCandidates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Miss_after_gate_elapses_increments()
+    {
+        var autoEnabled = Set($"transit:as{TransitAsnA}");
+        var candidate = Set();
+        var prior = Prior($"transit:as{TransitAsnA}", 1, hoursAgo: 6); // exactly at the gate
+
+        var eval = UpstreamRediscoveryService.EvaluateChange(Set(), autoEnabled, candidate, prior, Now, Gate, 3);
+
+        eval.NewMisses[$"transit:as{TransitAsnA}"].Count.Should().Be(2);
+        eval.NewMisses[$"transit:as{TransitAsnA}"].LastIncrementUtc.Should().Be(Now);
+    }
+
+    [Fact]
+    public void Confirmed_asn_gated_this_run_stays_a_removal_candidate()
+    {
+        // Already at threshold and absent again within the gate: it holds at 3 (doesn't climb) but
+        // must remain a removal candidate so a gated recheck can't un-confirm it.
+        var autoEnabled = Set($"transit:as{TransitAsnA}");
+        var candidate = Set();
+        var prior = Prior($"transit:as{TransitAsnA}", 3, hoursAgo: 1);
+
+        var eval = UpstreamRediscoveryService.EvaluateChange(Set(), autoEnabled, candidate, prior, Now, Gate, 3);
+
+        eval.NewMisses[$"transit:as{TransitAsnA}"].Count.Should().Be(3);
+        eval.RemovalCandidates.Should().BeEquivalentTo(new[] { $"transit:as{TransitAsnA}" });
     }
 
     [Fact]
@@ -243,11 +289,11 @@ public class UpstreamRediscoverySignatureTests : IDisposable
         var removalEligible = Set(); // fully disabled => not eligible for removed
         var candidate = Set($"transit:as{TransitAsnB}");
 
-        var eval = UpstreamRediscoveryService.EvaluateChange(monitored, removalEligible, candidate, Empty, 3);
+        var eval = UpstreamRediscoveryService.EvaluateChange(monitored, removalEligible, candidate, Empty, Now, Gate, 3);
 
         eval.Added.Should().BeEmpty();
         eval.RemovalCandidates.Should().BeEmpty();
-        eval.NewMissCounts.Should().BeEmpty();
+        eval.NewMisses.Should().BeEmpty();
     }
 
     // ---- BuildRemovedTransitAsns (pause entries) ----
@@ -323,8 +369,9 @@ public class UpstreamRediscoverySignatureTests : IDisposable
     [Fact]
     public async Task CompletedRun_stages_pending_tracking_when_below_threshold()
     {
-        // Dangling-manual AS: auto evidence disabled, manual enabled, absent this run, prior count 1.
-        SeedDanglingManualAsn(TransitAsnA, priorCount: 1);
+        // Dangling-manual AS: auto evidence disabled, manual enabled, absent this run, prior count 1
+        // last incremented well past the gate so this run advances it.
+        SeedDanglingManualAsn(TransitAsnA, priorCount: 1, lastIncrementUtc: DateTime.UtcNow.AddHours(-24));
         var state = AbsentRunState(TransitAsnA);
 
         await UpstreamRediscoveryService.EvaluateCompletedRunAsync(_db, state, CancellationToken.None);
@@ -341,8 +388,8 @@ public class UpstreamRediscoverySignatureTests : IDisposable
     [Fact]
     public async Task CompletedRun_confirms_and_leaves_pending_empty_at_threshold()
     {
-        // Same dangling-manual AS, but prior count 2 -> this run hits the threshold of 3.
-        SeedDanglingManualAsn(TransitAsnA, priorCount: 2);
+        // Same dangling-manual AS, but prior count 2 (past the gate) -> this run hits threshold 3.
+        SeedDanglingManualAsn(TransitAsnA, priorCount: 2, lastIncrementUtc: DateTime.UtcNow.AddHours(-24));
         var state = AbsentRunState(TransitAsnA);
 
         await UpstreamRediscoveryService.EvaluateCompletedRunAsync(_db, state, CancellationToken.None);
@@ -354,13 +401,76 @@ public class UpstreamRediscoverySignatureTests : IDisposable
         r.ManualCount.Should().Be(1);
     }
 
+    [Fact]
+    public async Task CompletedRun_holds_count_when_within_gate()
+    {
+        // Prior increment 1h ago (< 6h gate): an absent run must NOT advance the count - it stays
+        // pending at 2 rather than confirming, so rapid re-traces can't rush a removal.
+        SeedDanglingManualAsn(TransitAsnA, priorCount: 2, lastIncrementUtc: DateTime.UtcNow.AddHours(-1));
+        var state = AbsentRunState(TransitAsnA);
+
+        await UpstreamRediscoveryService.EvaluateCompletedRunAsync(_db, state, CancellationToken.None);
+
+        state.RemovedTransitAsns.Should().BeEmpty();
+        var p = state.PendingRemovalTransitAsns.Should().ContainSingle().Subject;
+        p.MissCount.Should().Be(2);
+        p.RunsRemaining.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CompletedRun_confirms_once_gate_has_elapsed()
+    {
+        // Same count, but the last increment was 7h ago (> 6h gate): this run advances 2 -> 3.
+        SeedDanglingManualAsn(TransitAsnA, priorCount: 2, lastIncrementUtc: DateTime.UtcNow.AddHours(-7));
+        var state = AbsentRunState(TransitAsnA);
+
+        await UpstreamRediscoveryService.EvaluateCompletedRunAsync(_db, state, CancellationToken.None);
+
+        state.PendingRemovalTransitAsns.Should().BeEmpty();
+        state.RemovedTransitAsns.Should().ContainSingle().Which.AsnNumber.Should().Be(TransitAsnA);
+    }
+
+    [Fact]
+    public async Task CompletedRun_reads_legacy_intonly_counter_and_advances()
+    {
+        // Legacy stored format (a bare int, no timestamp) must load as immediately gate-eligible so
+        // an in-flight counter from before the gate keeps advancing after upgrade.
+        SeedLegacyDanglingManualAsn(TransitAsnA, priorCount: 2);
+        var state = AbsentRunState(TransitAsnA);
+
+        await UpstreamRediscoveryService.EvaluateCompletedRunAsync(_db, state, CancellationToken.None);
+
+        state.PendingRemovalTransitAsns.Should().BeEmpty();
+        state.RemovedTransitAsns.Should().ContainSingle().Which.AsnNumber.Should().Be(TransitAsnA);
+    }
+
     // ---- helpers ----
 
-    private void SeedDanglingManualAsn(int asn, int priorCount)
+    private void SeedDanglingManualTargets(int asn)
     {
         _db.MonitoringTargets.AddRange(
             Target("198.51.100.1", MonitoringTargetType.Transit, asn, "wan", DiscoveryMethod.DirectRouter, enabled: false),
             Target("203.0.113.1", MonitoringTargetType.Transit, asn, "", DiscoveryMethod.UserProvided));
+    }
+
+    // Dangling-manual ASN with a current-format counter (count + last-increment timestamp).
+    private void SeedDanglingManualAsn(int asn, int priorCount, DateTime lastIncrementUtc)
+    {
+        SeedDanglingManualTargets(asn);
+        _db.SystemSettings.Add(new SystemSetting
+        {
+            Key = SystemSettingKeys.UpstreamAbsentAsnCountsPrefix + "wan",
+            Value = $"{{\"transit:as{asn}\":{{\"c\":{priorCount},\"t\":\"{lastIncrementUtc:o}\"}}}}",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        _db.SaveChanges();
+    }
+
+    // Dangling-manual ASN with a legacy counter (a bare int, no timestamp).
+    private void SeedLegacyDanglingManualAsn(int asn, int priorCount)
+    {
+        SeedDanglingManualTargets(asn);
         _db.SystemSettings.Add(new SystemSetting
         {
             Key = SystemSettingKeys.UpstreamAbsentAsnCountsPrefix + "wan",
@@ -386,7 +496,21 @@ public class UpstreamRediscoverySignatureTests : IDisposable
 
     private static HashSet<string> Set(params string[] keys) => new(keys, StringComparer.OrdinalIgnoreCase);
 
-    private static readonly Dictionary<string, int> Empty = new(StringComparer.OrdinalIgnoreCase);
+    // Fixed evaluation clock + gate for the pure EvaluateChange tests.
+    private static readonly DateTime Now = new(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly TimeSpan Gate = TimeSpan.FromHours(6);
+
+    private static readonly Dictionary<string, UpstreamRediscoveryService.MissRecord> Empty =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    // A prior-miss map with one entry whose last increment was `hoursAgo` before Now (default well
+    // past the gate, so the next miss increments).
+    private static Dictionary<string, UpstreamRediscoveryService.MissRecord> Prior(
+        string key, int count, double hoursAgo = 24) =>
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            [key] = new UpstreamRediscoveryService.MissRecord(count, Now.AddHours(-hoursAgo)),
+        };
 
     private static AccessHopCandidate Hop(string address, int? asn, bool enabled = true, bool unreachable = false) => new()
     {

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamRediscoverySignatureTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamRediscoverySignatureTests.cs
@@ -318,7 +318,71 @@ public class UpstreamRediscoverySignatureTests : IDisposable
         row.Value.Should().Contain($"access:as{AccessAsn}").And.NotContain($"transit:as{TransitAsnA}");
     }
 
+    // ---- EvaluateCompletedRunAsync (pending vs confirmed staging) ----
+
+    [Fact]
+    public async Task CompletedRun_stages_pending_tracking_when_below_threshold()
+    {
+        // Dangling-manual AS: auto evidence disabled, manual enabled, absent this run, prior count 1.
+        SeedDanglingManualAsn(TransitAsnA, priorCount: 1);
+        var state = AbsentRunState(TransitAsnA);
+
+        await UpstreamRediscoveryService.EvaluateCompletedRunAsync(_db, state, CancellationToken.None);
+
+        state.RemovedTransitAsns.Should().BeEmpty();
+        var p = state.PendingRemovalTransitAsns.Should().ContainSingle().Subject;
+        p.AsnNumber.Should().Be(TransitAsnA);
+        p.MissCount.Should().Be(2);       // 1 -> 2
+        p.RunsRemaining.Should().Be(1);   // threshold 3 - 2
+        p.TargetCount.Should().Be(1);     // only the enabled manual row would pause
+        p.ManualCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CompletedRun_confirms_and_leaves_pending_empty_at_threshold()
+    {
+        // Same dangling-manual AS, but prior count 2 -> this run hits the threshold of 3.
+        SeedDanglingManualAsn(TransitAsnA, priorCount: 2);
+        var state = AbsentRunState(TransitAsnA);
+
+        await UpstreamRediscoveryService.EvaluateCompletedRunAsync(_db, state, CancellationToken.None);
+
+        state.PendingRemovalTransitAsns.Should().BeEmpty();
+        var r = state.RemovedTransitAsns.Should().ContainSingle().Subject;
+        r.AsnNumber.Should().Be(TransitAsnA);
+        r.TargetCount.Should().Be(1);
+        r.ManualCount.Should().Be(1);
+    }
+
     // ---- helpers ----
+
+    private void SeedDanglingManualAsn(int asn, int priorCount)
+    {
+        _db.MonitoringTargets.AddRange(
+            Target("198.51.100.1", MonitoringTargetType.Transit, asn, "wan", DiscoveryMethod.DirectRouter, enabled: false),
+            Target("203.0.113.1", MonitoringTargetType.Transit, asn, "", DiscoveryMethod.UserProvided));
+        _db.SystemSettings.Add(new SystemSetting
+        {
+            Key = SystemSettingKeys.UpstreamAbsentAsnCountsPrefix + "wan",
+            Value = $"{{\"transit:as{asn}\":{priorCount}}}",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        _db.SaveChanges();
+    }
+
+    // Run state whose candidate signature excludes `absentAsn` (an unrelated ASN is present so the
+    // signature isn't empty), i.e. the given ASN went off-path this run.
+    private static UpstreamTracerState AbsentRunState(int absentAsn)
+    {
+        var other = absentAsn == TransitAsnB ? TransitAsnA : TransitAsnB;
+        return new UpstreamTracerState
+        {
+            WanInterface = "wan",
+            TransitAsns = { Transit("198.51.100.9", other, DiscoveryMethod.DirectRouter) },
+        };
+    }
+
 
     private static HashSet<string> Set(params string[] keys) => new(keys, StringComparer.OrdinalIgnoreCase);
 

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamRediscoverySignatureTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamRediscoverySignatureTests.cs
@@ -10,7 +10,8 @@ namespace NetworkOptimizer.Web.Tests;
 /// Change-detection for the scheduled upstream re-discovery. Keys on a stable upstream-ASN
 /// identity (ECMP-proof), flags ADDED ASNs immediately, and gates REMOVED behind a consecutive-
 /// miss counter so incomplete/degraded runs don't nag. UserProvided (hand-added) targets suppress
-/// "added" but are never eligible for "removed".
+/// "added" and never make an ASN removal-eligible on their own - but once an auto-discovered
+/// sibling proves the ASN was on the path, a confirmed removal pauses hand-added targets too.
 ///
 /// All ASNs are RFC 5398 documentation ASNs (64496-64511) and all IPs are RFC 5737 ranges.
 /// </summary>
@@ -134,21 +135,38 @@ public class UpstreamRediscoverySignatureTests : IDisposable
     }
 
     [Fact]
-    public async Task AutoEnabled_view_is_enabled_auto_this_wan_only()
+    public async Task RemovalEligible_requires_auto_evidence_and_an_enabled_row()
     {
         _db.MonitoringTargets.AddRange(
+            // enabled auto - eligible
             Target("198.51.100.1", MonitoringTargetType.Transit, TransitAsnA, "wan", DiscoveryMethod.DirectRouter),
-            // disabled - excluded from removed-eligibility
+            // disabled auto with no enabled sibling - fully-disabled ASN, nothing to pause, not eligible
             Target("198.51.100.9", MonitoringTargetType.Transit, TransitAsnB, "wan", DiscoveryMethod.DirectRouter, enabled: false),
-            // UserProvided - excluded from removed-eligibility
+            // UserProvided only - no auto evidence the ASN was ever on the path, not eligible
             Target("203.0.113.1", MonitoringTargetType.Transit, UserAsn, "wan", DiscoveryMethod.UserProvided),
             // other WAN - excluded
             Target("198.51.100.10", MonitoringTargetType.Transit, PathAsn, "wan2", DiscoveryMethod.DirectRouter));
         await _db.SaveChangesAsync();
 
-        var (_, autoEnabled) = await UpstreamRediscoveryService.BuildCommittedViewsAsync(_db, "wan", CancellationToken.None);
+        var (_, removalEligible) = await UpstreamRediscoveryService.BuildCommittedViewsAsync(_db, "wan", CancellationToken.None);
 
-        autoEnabled.Should().BeEquivalentTo(new[] { $"transit:as{TransitAsnA}" });
+        removalEligible.Should().BeEquivalentTo(new[] { $"transit:as{TransitAsnA}" });
+    }
+
+    [Fact]
+    public async Task RemovalEligible_keeps_paused_auto_asn_with_enabled_manual_sibling()
+    {
+        // The dangling-manual case: the flaky auto target was paused, but a hand-added target in
+        // the same ASN is still enabled - the ASN must stay eligible so the sibling gets caught
+        // when the ASN goes dark. The manual row is WAN-agnostic (empty WanInterface).
+        _db.MonitoringTargets.AddRange(
+            Target("198.51.100.1", MonitoringTargetType.Transit, TransitAsnA, "wan", DiscoveryMethod.DirectRouter, enabled: false),
+            Target("203.0.113.1", MonitoringTargetType.Transit, TransitAsnA, "", DiscoveryMethod.UserProvided));
+        await _db.SaveChangesAsync();
+
+        var (_, removalEligible) = await UpstreamRediscoveryService.BuildCommittedViewsAsync(_db, "wan", CancellationToken.None);
+
+        removalEligible.Should().BeEquivalentTo(new[] { $"transit:as{TransitAsnA}" });
     }
 
     // ---- EvaluateChange ----
@@ -216,19 +234,88 @@ public class UpstreamRediscoverySignatureTests : IDisposable
     }
 
     [Fact]
-    public void Disabled_flaky_target_neither_added_nor_removed()
+    public void Fully_disabled_asn_neither_added_nor_removed()
     {
-        // Monitored (suppresses added) but NOT auto-enabled (not removal-eligible). Discovery still
-        // finds the ASN, so nothing flags - and nothing would get silently re-enabled by a commit.
+        // Monitored (suppresses added) but not removal-eligible (every target in the ASN is
+        // disabled - nothing to pause). Discovery still finds the ASN, so nothing flags - and
+        // nothing would get silently re-enabled by a commit.
         var monitored = Set($"transit:as{TransitAsnB}");
-        var autoEnabled = Set(); // disabled => not eligible for removed
+        var removalEligible = Set(); // fully disabled => not eligible for removed
         var candidate = Set($"transit:as{TransitAsnB}");
 
-        var eval = UpstreamRediscoveryService.EvaluateChange(monitored, autoEnabled, candidate, Empty, 3);
+        var eval = UpstreamRediscoveryService.EvaluateChange(monitored, removalEligible, candidate, Empty, 3);
 
         eval.Added.Should().BeEmpty();
         eval.RemovalCandidates.Should().BeEmpty();
         eval.NewMissCounts.Should().BeEmpty();
+    }
+
+    // ---- BuildRemovedTransitAsns (pause entries) ----
+
+    [Fact]
+    public async Task RemovedTransitAsns_counts_enabled_auto_and_wan_agnostic_manual_targets()
+    {
+        _db.MonitoringTargets.AddRange(
+            Target("198.51.100.1", MonitoringTargetType.Transit, TransitAsnA, "wan", DiscoveryMethod.DirectRouter),
+            // hand-added, WAN-agnostic - counted and reported as manual
+            Target("203.0.113.1", MonitoringTargetType.Transit, TransitAsnA, "", DiscoveryMethod.UserProvided),
+            // disabled - already paused, not counted
+            Target("198.51.100.2", MonitoringTargetType.Transit, TransitAsnA, "wan", DiscoveryMethod.DirectRouter, enabled: false),
+            // other-WAN auto - not counted
+            Target("198.51.100.3", MonitoringTargetType.Transit, TransitAsnA, "wan2", DiscoveryMethod.DirectRouter),
+            // other ASN, not in the confirmed list - no entry
+            Target("198.51.100.4", MonitoringTargetType.Transit, TransitAsnB, "wan", DiscoveryMethod.DirectRouter));
+        await _db.SaveChangesAsync();
+
+        var result = await UpstreamRediscoveryService.BuildRemovedTransitAsnsAsync(
+            _db, "wan", new[] { $"transit:as{TransitAsnA}" }, CancellationToken.None);
+
+        var entry = result.Should().ContainSingle().Subject;
+        entry.AsnNumber.Should().Be(TransitAsnA);
+        entry.TargetCount.Should().Be(2);
+        entry.ManualCount.Should().Be(1);
+        entry.Keep.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RemovedTransitAsns_ignores_non_transit_keys_address_keys_and_fully_disabled_asns()
+    {
+        _db.MonitoringTargets.AddRange(
+            // fully disabled ASN - confirmed removed but nothing to pause -> no entry, no nag
+            Target("198.51.100.9", MonitoringTargetType.Transit, TransitAsnB, "wan", DiscoveryMethod.DirectRouter, enabled: false),
+            // enabled access target - access keys aren't handled by this detector
+            Target("192.0.2.1", MonitoringTargetType.AccessIsp, AccessAsn, "wan", DiscoveryMethod.DirectRouter));
+        await _db.SaveChangesAsync();
+
+        var result = await UpstreamRediscoveryService.BuildRemovedTransitAsnsAsync(
+            _db, "wan",
+            new[] { $"transit:as{TransitAsnB}", $"access:as{AccessAsn}", "transit:198.51.100.77", $"path:as{PathAsn}" },
+            CancellationToken.None);
+
+        result.Should().BeEmpty();
+    }
+
+    // ---- Miss-counter clearing on commit ----
+
+    [Fact]
+    public async Task ClearMissCountKeys_removes_only_the_given_keys()
+    {
+        _db.SystemSettings.Add(new SystemSetting
+        {
+            Key = SystemSettingKeys.UpstreamAbsentAsnCountsPrefix + "wan",
+            Value = $"{{\"transit:as{TransitAsnA}\":3,\"access:as{AccessAsn}\":2}}",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+
+        await UpstreamRediscoveryService.ClearMissCountKeysAsync(
+            _db, "wan", new[] { $"transit:as{TransitAsnA}" }, CancellationToken.None);
+        await _db.SaveChangesAsync();
+
+        var row = await _db.SystemSettings.SingleAsync(
+            s => s.Key == SystemSettingKeys.UpstreamAbsentAsnCountsPrefix + "wan");
+        row.Value.Should().Contain($"access:as{AccessAsn}").And.NotContain($"transit:as{TransitAsnA}");
     }
 
     // ---- helpers ----


### PR DESCRIPTION
## What this does

When a transit network (ASN) stops carrying your traffic - your ISP re-routes and no longer sends packets through it - the monitoring targets set up for that network become dead weight: they report loss and latency for a path you no longer use, dragging down ISP Health. This adds detection and cleanup for that case, plus the wholesale version of the same event: a review-gated "did you switch providers?" reset when discovery finds the access ISP itself changed, and recovery awareness so the flaky-target advisory stops flagging targets that have stabilized again.

When Upstream Discovery (scheduled or manual) finds a transit ASN has dropped off your path for several consecutive runs, the review surfaces a "No longer on your path" section listing the affected targets. Saving pauses them; you can re-check any you want to keep. Nothing is ever deleted.

## Off-path transit pause

- **Review-gated, never silent.** Off-path ASNs appear in the discovery review pre-unchecked; you confirm on save. Targets are paused (Enabled = false), never removed.
- **Handles hand-added targets.** Targets you added by hand in an ASN are included when that ASN goes dark, so they can't dangle enabled and keep feeding false data - even if you'd previously paused the ASN's auto-discovered target for being flaky. An ASN is only eligible if it was auto-discovered on your path at some point, so a purely manual ASN with no path evidence is never touched. An ASN with nothing enabled left is a no-op (no nag).
- **Time-gated confirmation.** Absence has to persist across real elapsed time, not just across however many discovery runs happen to fire. Each absence observation counts at most once per 6 hours, so a genuine off-path change needs roughly 12h+ of sustained absence to confirm. That rides out maintenance windows and transit drains, and rapid manual re-traces can't rush it. Any single run where the ASN reappears resets the evidence.
- **Tracking heads-up.** Before an ASN reaches the confirmation threshold, the review shows a read-only "Tracking possible removals" note ("absent 2 of 3 runs, 1 more to confirm") so the detection is visible rather than appearing out of nowhere when it acts.
- **Transit only.** Access-ISP and path-proxy tiers are out of scope for the per-ASN cleanup; a whole-connection change is handled by the ISP-change reset below.

## "Your ISP changed" reset

A provider switch replaces the entire upstream path at once - handling it as N transit removals would be confusing, and the old access targets would dangle enabled at 100% loss. Instead:

- **Detection.** A completed run whose resolved access ASN differs from every committed access ASN for the WAN stages an ISP change. Single run is enough (the access ASN is the stable first hop and the event is user-confirmed); a run that failed to attribute the access ASN never triggers. While staged, per-transit off-path handling is superseded for that run and its absence counters are frozen.
- **One trace, one save.** The same run's review shows a "Did you switch internet providers?" card above the discovered targets, with the AS-to-AS comparison and the reset scope (N targets, M hand-added). Save is disabled until you answer.
- **Confirm = start fresh.** Pauses every enabled upstream target for the connection across all three tiers (access, transit, path-proxy), auto-discovered and hand-added alike - manual targets pinned to a different WAN survive - wipes the WAN's off-path evidence, and commits that run's candidates as the new baseline. Paused, never deleted.
- **Decline = keep monitoring.** Targets stay untouched, and the declined ASN is remembered per WAN so the same change doesn't re-prompt every run. Confirming a later change clears the memory.

## Flaky targets: recovery awareness

The flaky-target advisory judged loss over the whole 48h lookback, so a target that went flaky (or dark) and then stabilized kept getting flagged until the bad bins diluted out - up to two days of stale nagging. Two recovery paths now clear the flag:

- **Standard recovery.** A flagged target whose bins in the trailing 3 hours (at least ~1h of evidence) are back under the same threshold is treated as recovered and not presented. Always-flaky targets keep failing the recent slice and stay flagged; a target that went dark has no recent bins to prove recovery with, so it stays flagged too.
- **Hard-down fast path.** When the median over-threshold bin was essentially total loss (>= 95%; a median so the partial-loss aggregate bins at an outage's edges don't disqualify it), the episode was a binary outage (reboot, maintenance, transient route change) rather than the partial-loss signature of ICMP deprioritization - so three consecutive clean bins (~30 min) clear it instead of waiting for the outage bins to leave the window. Genuinely mixed partial-loss episodes still need the full standard recovery.

## Testing

Unit and integration coverage for the off-path eligibility rules (including the dangling hand-added case), the pending-vs-confirmed staging, the 6h increment gate (hold vs advance), backward-compatible loading of the pre-gate counter format, ISP-change detection guards (unresolved runs, first run, ASN overlap, decline memory), the supersede behavior (counters frozen, no transit staging), the reset scope and decline recording, and both flaky recovery paths (recovered, always-flaky, went-dark, too-few-recent-bins, relapsed, hard-down recovered / still down / partial-loss and mixed episodes excluded from the fast path). Full suite passing, zero build warnings.

