### PR TITLE
Monitoring - Setup: Upstream path discovery no longer mislabels the access ISP on unannounced first miles (#984)

### DIFF
--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -231,7 +231,7 @@ public class UpstreamTracerService
             // keeps the scheduled run 1:1 with a user-initiated run.
             var preservedTech = State.AccessTechnology;
             if (preservedTech == AccessTechnology.Unknown)
-                preservedTech = await LoadPersistedAccessTechnologyAsync(ct);
+                preservedTech = await LoadPersistedAccessTechnologyAsync(State.WanInterface, ct);
             State = new UpstreamTracerState
             {
                 Step = TracerStep.DetectingPublicIp,
@@ -251,20 +251,39 @@ public class UpstreamTracerService
     public Task WaitForCompletionAsync() => _runningTask ?? Task.CompletedTask;
 
     /// <summary>
-    /// Reads the most-recently-discovered WAN's saved access technology from the DB.
-    /// Fallback for when a run starts (notably the background re-discovery scheduler)
-    /// without the UI having hydrated the in-memory state first. Returns Unknown when
-    /// nothing is persisted yet.
+    /// Reads the saved access technology from the DB. Fallback for when a run starts
+    /// (notably the background re-discovery scheduler) without the UI having hydrated
+    /// the in-memory state first. The technology is per-WAN, so the traced WAN's own
+    /// context row wins when <paramref name="wanInterface"/> is known; otherwise (and
+    /// when that row has nothing set) any row with a known technology is used,
+    /// recency-ordered - the old "most recent row, whatever it holds" pick returned
+    /// Unknown on multi-WAN installs whenever a different WAN's row was fresher, which
+    /// mislabeled the first-mile device (e.g. "cisco-access" instead of "cisco-olt" on
+    /// a saved-GPON install). Last resort is the legacy single-WAN
+    /// MonitoringSettings.AccessTechnology from installs that predate per-WAN contexts.
+    /// Returns Unknown when nothing is persisted anywhere.
     /// </summary>
-    private async Task<AccessTechnology> LoadPersistedAccessTechnologyAsync(CancellationToken ct)
+    private async Task<AccessTechnology> LoadPersistedAccessTechnologyAsync(string? wanInterface, CancellationToken ct)
     {
         try
         {
             await using var db = await CreateDbAsync(ct);
-            var ctx = await db.WanDiscoveryContexts
+            var contexts = await db.WanDiscoveryContexts.AsNoTracking().ToListAsync(ct);
+
+            var own = contexts.FirstOrDefault(c =>
+                wanInterface != null &&
+                string.Equals(c.WanInterface, wanInterface, StringComparison.OrdinalIgnoreCase));
+            if (own != null && own.AccessTechnology != AccessTechnology.Unknown)
+                return own.AccessTechnology;
+
+            var known = contexts
+                .Where(c => c.AccessTechnology != AccessTechnology.Unknown)
                 .OrderByDescending(c => c.LastDiscoveryAt ?? c.UpdatedAt)
-                .FirstOrDefaultAsync(ct);
-            return ctx?.AccessTechnology ?? AccessTechnology.Unknown;
+                .FirstOrDefault();
+            if (known != null) return known.AccessTechnology;
+
+            var settings = await db.MonitoringSettings.AsNoTracking().FirstOrDefaultAsync(ct);
+            return settings?.AccessTechnology ?? AccessTechnology.Unknown;
         }
         catch (Exception ex)
         {
@@ -291,6 +310,11 @@ public class UpstreamTracerService
         try
         {
             if (!await DetectPublicIpAsync(ct)) return;
+            // The access technology is stored per-WAN; the pre-run load couldn't key on
+            // the WAN yet. Now that detection resolved which WAN we're tracing, retry
+            // against its own context row before any technology-driven labeling runs.
+            if (State.AccessTechnology == AccessTechnology.Unknown)
+                State.AccessTechnology = await LoadPersistedAccessTechnologyAsync(State.WanInterface, ct);
             if (!await DiscoverL2NeighborAsync(ct)) return;
             await TraceAccessIspAsync(ct);
             await TraceTransitAsnsAsync(ct);
@@ -1920,7 +1944,12 @@ public class UpstreamTracerService
         ctxRow.L2NeighborMac = State.WanNeighborMac;
         ctxRow.L2NeighborIp = State.WanNeighborIp;
         ctxRow.L2NeighborOui = State.WanNeighborOuiVendor;
-        ctxRow.AccessTechnology = State.AccessTechnology;
+        // Never write Unknown over a saved technology: the ISP Health selector writes
+        // to this row too, and a run that started without the tech hydrated would
+        // otherwise wipe the user's setting (discovery only ever proposes, per the
+        // SetAccessTechnologyAsync contract).
+        if (State.AccessTechnology != AccessTechnology.Unknown)
+            ctxRow.AccessTechnology = State.AccessTechnology;
         ctxRow.LastDiscoveryAt = DateTime.UtcNow;
         ctxRow.NeedsReview = false;
         ctxRow.UpdatedAt = DateTime.UtcNow;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -544,8 +544,6 @@ public class UpstreamTracerService
         //  1) port_table.uplink_ifname - UniFi's kernel device name for
         //     the uplink, correct for VLAN-tagged sub-interfaces too.
         //  2) `ip -o -4 addr show` line owning the known WAN IP.
-        // No default-route lookup: UniFi gateways run policy routing with
-        // per-WAN tables, so the default isn't in the main table.
         var candidates = new List<string>();
         if (!string.IsNullOrEmpty(_wanUplinkIfName))
         {
@@ -571,6 +569,22 @@ public class UpstreamTracerService
             }
         }
 
+        // The WAN's default gateway from the routing tables. UniFi gateways run policy
+        // routing with per-WAN tables, so the default isn't in the main table - but
+        // `ip route show table all` surfaces every table's default route, and the line
+        // whose dev is our WAN interface names the true next hop. This is authoritative:
+        // on a shared WAN subnet (metro Ethernet, two sites on one carrier segment) the
+        // neighbor table also carries OTHER same-subnet hosts, and heuristic scoring can
+        // pick one of those peers over the actual gateway. We still read the gateway's
+        // MAC from `ip neigh` below - the routing table only supplies WHICH IP to pick.
+        string? routeShowAll = null;
+        {
+            var (routeOk, routeOut) = await _gatewaySsh.RunCommandAsync(
+                "ip route show table all 2>/dev/null | grep '^default' | head -20",
+                TimeSpan.FromSeconds(5), ct);
+            if (routeOk && !string.IsNullOrWhiteSpace(routeOut)) routeShowAll = routeOut;
+        }
+
         string? neighborMac = null;
         string? neighborIp = null;
         string? wanDevice = null;
@@ -582,7 +596,8 @@ public class UpstreamTracerService
             var (ok, output) = await _gatewaySsh.RunCommandAsync(cmd, TimeSpan.FromSeconds(5), ct);
             if (!ok || string.IsNullOrWhiteSpace(output)) continue;
 
-            var selected = SelectWanNeighbor(output, wanCidr);
+            var defaultGatewayIp = SelectWanDefaultGateway(routeShowAll, ifaceCandidate);
+            var selected = SelectWanNeighbor(output, wanCidr, defaultGatewayIp);
             if (selected != null)
             {
                 neighborIp = selected.Value.Ip;
@@ -643,11 +658,33 @@ public class UpstreamTracerService
     }
 
     /// <summary>
+    /// Parses `ip route show table all` output for the default route egressing the given
+    /// WAN interface and returns its gateway ("via") address. UniFi gateways run policy
+    /// routing, so each WAN's default lives in its own table (`default via 203.0.113.1
+    /// dev eth8 table 201 ...`); matching on the dev finds ours regardless of table
+    /// number. Returns the first match (multiple tables for one WAN name the same next
+    /// hop). On-link defaults without a `via` (PPPoE's `default dev ppp0 scope link`)
+    /// yield null - there's no gateway address, and no MAC to look up either.
+    /// </summary>
+    internal static string? SelectWanDefaultGateway(string? routeShowAllOutput, string wanIface)
+    {
+        if (string.IsNullOrWhiteSpace(routeShowAllOutput) || string.IsNullOrEmpty(wanIface)) return null;
+        var m = Regex.Match(routeShowAllOutput,
+            @"^default\s+via\s+(?<gw>\d{1,3}(?:\.\d{1,3}){3})\s+dev\s+" + Regex.Escape(wanIface) + @"(\s|$)",
+            RegexOptions.Multiline);
+        return m.Success ? m.Groups["gw"].Value : null;
+    }
+
+    /// <summary>
     /// Picks the WAN-side L2 neighbor from `ip neigh show dev &lt;wan&gt;` output. A CPE
     /// bridged in front of the gateway (an ISP modem/router in passthrough) lists both
     /// its LAN-side RFC1918 address and the carrier-side address under the same MAC;
     /// the LAN-side entry often sorts first, and taking the first lladdr line mislabeled
-    /// a private CPE IP as an ISP hop. Preference order: in the WAN subnet (the real
+    /// a private CPE IP as an ISP hop. When the WAN's routed default gateway is known
+    /// (from <see cref="SelectWanDefaultGateway"/>) its entry wins outright - on a shared
+    /// WAN subnet the neighbor table also lists unrelated same-subnet hosts (another
+    /// site's gateway on the same carrier segment), and no heuristic can rank those below
+    /// the true next hop reliably. Otherwise preference order: in the WAN subnet (the real
     /// ISP-side gateway is by definition on-link with our WAN IP) &gt; address class
     /// (public &gt; CGNAT &gt; private) &gt; freshness (REACHABLE/DELAY/PROBE over STALE).
     /// FAILED and INCOMPLETE entries carry no lladdr and never match. IPv6 link-local
@@ -658,7 +695,9 @@ public class UpstreamTracerService
     /// <param name="ipNeighOutput">Raw `ip neigh show dev &lt;wan&gt;` output.</param>
     /// <param name="wanCidr">The gateway's WAN address in CIDR form (e.g. "203.0.113.5/24")
     /// used to recognize the on-link ISP gateway. Null/empty falls back to class+freshness.</param>
-    public static (string Ip, string Mac)? SelectWanNeighbor(string? ipNeighOutput, string? wanCidr = null)
+    /// <param name="defaultGatewayIp">The WAN's routed default gateway, when known. Its
+    /// neighbor entry is returned outright, bypassing the heuristic scoring.</param>
+    public static (string Ip, string Mac)? SelectWanNeighbor(string? ipNeighOutput, string? wanCidr = null, string? defaultGatewayIp = null)
     {
         if (string.IsNullOrWhiteSpace(ipNeighOutput)) return null;
 
@@ -670,6 +709,10 @@ public class UpstreamTracerService
             var ipText = m.Groups[1].Value;
             if (!System.Net.IPAddress.TryParse(ipText, out var ip)) continue;
             if (ip.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork) continue;
+
+            // The routed next hop IS the first-mile device; no scoring needed.
+            if (defaultGatewayIp != null && string.Equals(ipText, defaultGatewayIp, StringComparison.OrdinalIgnoreCase))
+                return (ipText, m.Groups[2].Value.ToLowerInvariant());
 
             // UniFi's default WAN SLA probe targets keep a neighbor entry on the WAN
             // interface but are public DNS resolvers, never the L2 next hop.

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -721,6 +721,18 @@ public class UpstreamTracerService
     // access hops responded (the access pool can be empty/unreachable yet the ASN known).
     private int? _accessAsn;
 
+    // Cleaned display name for _accessAsn - from its hops' ASN attribution, or from the
+    // WAN IP lookup when the ASN was derived from the WAN address and no hop carries the
+    // name. Used by the curated-fallback injection for labeling.
+    private string? _accessAsnName;
+
+    // Destination (CDN endpoint) ASNs and org names from the rotation, resolved once per
+    // run during the access step (they gate the access-ISP pick) and reused by the transit
+    // step. Transit-probe endpoints are excluded on purpose - their ASN is allowed to
+    // surface as transit.
+    private readonly HashSet<int> _destinationAsns = new();
+    private readonly HashSet<string> _destinationOrgs = new(StringComparer.OrdinalIgnoreCase);
+
     // The 1st/2nd-degree non-access ASNs off each trace (union): the access ISP's
     // direct upstream and that upstream's upstream. A transit-probe ASN (Lumen, AT&T,
     // INDATEL) only counts as *our* ISP's transit when it lands in this window -
@@ -808,11 +820,26 @@ public class UpstreamTracerService
             .Where(h => !_gatewayIps.Contains(h.Address))
             .ToList();
 
-        // Identify the access ISP ASN: the first non-null ASN seen at the lowest hop
-        // numbers across the traces. Hops in private/CGNAT space (Asn == null) are
-        // skipped over; they don't have a public ASN.
-        var firstPublicHop = candidateHops.FirstOrDefault(h => h.Asn != null);
-        var accessAsn = firstPublicHop?.Asn?.Asn;
+        // Resolve the destination (CDN) ASNs up front: the access-ISP pick below must
+        // never crown a probe destination's own ASN, and the transit step reuses the sets.
+        await ResolveDestinationAsnsAsync(ct);
+
+        // The WAN IP's own ASN is the strongest access-ISP signal when the address is
+        // public: it's the ISP's customer allocation, independent of which routers
+        // answer traceroute. ResolveAsync returns null for CGNAT/private WAN addresses.
+        AsnLookup? wanIpAsn = null;
+        if (!string.IsNullOrEmpty(State.WanIpAddress))
+            wanIpAsn = await _asnResolution.ResolveAsync(State.WanIpAddress, ct);
+
+        // Identify the access ISP ASN. The old heuristic ("first hop with a resolvable
+        // ASN across the merged pool") broke on ISPs like Bell Canada (#984) whose entire
+        // first mile is RFC1918 plus public space deliberately NOT announced in BGP: the
+        // first attributable hop was the probed CDN's own edge, and the destination
+        // (Cloudflare) got crowned as the access ISP. DetermineAccessAsn combines the
+        // WAN IP's ASN with per-trace voting instead.
+        var asnByIp = BuildAsnByIpMap();
+        var traceSequences = BuildTraceSequences();
+        var accessAsn = DetermineAccessAsn(traceSequences, asnByIp, wanIpAsn?.Asn, _destinationAsns);
         // Remember it so the reachability step can reach for a curated fallback endpoint
         // even when the access pool ends up empty or entirely unreachable.
         _accessAsn = accessAsn;
@@ -833,6 +860,26 @@ public class UpstreamTracerService
             _accessHopsResolved = candidateHops
                 .TakeWhile(h => h.Asn == null)
                 .ToList();
+        }
+
+        // Unannounced first-mile hops: an ISP like Bell (#984) numbers its aggregation
+        // layer from public or CGNAT space that carries no BGP attribution (Asn == null),
+        // upstream of its announced routers. Any such hop appearing BEFORE the first
+        // access-ASN hop on its own trace sits on the customer side of the ISP's
+        // announced border - it is access infrastructure, positionally attributed.
+        // RFC1918 prefix hops stay excluded (a bridged CPE's LAN address or a double-NAT
+        // middlebox is not ISP infra); the reachability gate later disables any of these
+        // that don't answer ping.
+        if (accessAsn.HasValue)
+        {
+            var alreadyIncluded = new HashSet<string>(
+                _accessHopsResolved.Select(h => h.Address), StringComparer.OrdinalIgnoreCase);
+            var unannounced = CollectUnannouncedAccessAddresses(traceSequences, asnByIp, accessAsn.Value)
+                .Where(a => !alreadyIncluded.Contains(a) && !_gatewayIps.Contains(a) && byIp.ContainsKey(a))
+                .Select(a => byIp[a])
+                .OrderBy(h => h.HopNumber)
+                .ToList();
+            _accessHopsResolved = unannounced.Concat(_accessHopsResolved).ToList();
         }
 
         // Walk each individual trace to find border hops: an access-ASN hop
@@ -863,7 +910,12 @@ public class UpstreamTracerService
             }
         }
 
-        var orgName = CleanAsnName(firstPublicHop?.Asn?.Name);
+        // Access org display name: from an attributed access hop when one exists, else
+        // from the WAN IP lookup (a fully silent/unannounced first mile still labels).
+        var accessAsnRawName = _accessHopsResolved.FirstOrDefault(h => h.Asn != null)?.Asn?.Name
+                               ?? (accessAsn.HasValue && accessAsn.Value == wanIpAsn?.Asn ? wanIpAsn.Name : null);
+        var orgName = CleanAsnName(accessAsnRawName);
+        _accessAsnName = string.IsNullOrEmpty(orgName) ? null : orgName;
         State.AccessHops = _accessHopsResolved.Select(h => new AccessHopCandidate
         {
             TargetId = $"access-{NormalizeMacForId(h.Address)}",
@@ -960,6 +1012,7 @@ public class UpstreamTracerService
         var accessAsnNumbers = new HashSet<int>(_accessHopsResolved
             .Where(h => h.Asn != null)
             .Select(h => h.Asn!.Asn));
+        if (_accessAsn.HasValue) accessAsnNumbers.Add(_accessAsn.Value);
 
         // Also drop any ASN that's a CDN destination - the CDN's own edge routers
         // respond to traceroute from inside the CDN's ASN, so without this filter
@@ -973,16 +1026,8 @@ public class UpstreamTracerService
         // the same org get excluded (e.g. probing Microsoft 13.107.42.14 lives
         // in AS8068 but the trace traverses Microsoft's AS8075 backbone too -
         // both are Microsoft, neither belongs in the transit list).
-        var destinationAsns = new HashSet<int>();
-        var destinationOrgs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var endpoint in CdnRotation)
-        {
-            if (endpoint.IsTransitProbe) continue;
-            var destAsn = await _asnResolution.ResolveAsync(endpoint.Address, ct);
-            if (destAsn == null) continue;
-            destinationAsns.Add(destAsn.Asn);
-            if (!string.IsNullOrWhiteSpace(destAsn.Name)) destinationOrgs.Add(destAsn.Name.Trim());
-        }
+        var destinationAsns = _destinationAsns;
+        var destinationOrgs = _destinationOrgs;
 
         // Also exclude the transit-probe endpoints themselves from the hop pool.
         // Their job is to force the path through a specific ASN so real transit
@@ -1014,16 +1059,8 @@ public class UpstreamTracerService
         // heterogeneous traces, so a multi-homed access ISP's other upstreams (or a
         // near probe endpoint) can occupy the global "first two" slots at a lower hop
         // number and crowd out a genuine direct upstream.
-        var asnByIp = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-        foreach (var h in _mergedHops)
-            if (h.Asn != null) asnByIp.TryAdd(h.Address, h.Asn.Asn);
-        var traceSequences = _lastTraces
-            .Select(t => (IReadOnlyList<string>)t.Hops
-                .Where(hp => hp.Responded && !string.IsNullOrEmpty(hp.Address))
-                .OrderBy(hp => hp.HopNumber)
-                .Select(hp => hp.Address!)
-                .ToList())
-            .ToList();
+        var asnByIp = BuildAsnByIpMap();
+        var traceSequences = BuildTraceSequences();
 
         _nearTransitAsns.Clear();
         _nearTransitAsns.UnionWith(
@@ -1543,8 +1580,7 @@ public class UpstreamTracerService
         // cleared the gate is always the better monitor than a city-PoP speedtest endpoint.
         if (State.AccessHops.Any(h => h.Enabled && !h.Unreachable)) return;
 
-        var orgName = CleanAsnName(_accessHopsResolved.FirstOrDefault()?.Asn?.Name);
-        if (string.IsNullOrEmpty(orgName)) orgName = $"AS{asn}";
+        var orgName = _accessAsnName ?? $"AS{asn}";
 
         // Resolve + ping each curated host; keep the reachable ones with their measured RTT.
         var probed = new List<AccessFallbackProbe>();
@@ -2109,6 +2145,136 @@ public class UpstreamTracerService
     /// </summary>
     internal static string CleanAsnName(string? name) =>
         NetworkOptimizer.Core.Helpers.NetworkFormatHelpers.CleanOrgName(name);
+
+    /// <summary>Hop address → ASN for every ASN-attributed hop in the last sweep.</summary>
+    private Dictionary<string, int> BuildAsnByIpMap()
+    {
+        var asnByIp = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var h in _mergedHops)
+            if (h.Asn != null) asnByIp.TryAdd(h.Address, h.Asn.Asn);
+        return asnByIp;
+    }
+
+    /// <summary>Per-trace responding hop addresses in hop order, from the last sweep.</summary>
+    private List<IReadOnlyList<string>> BuildTraceSequences() =>
+        _lastTraces
+            .Select(t => (IReadOnlyList<string>)t.Hops
+                .Where(hp => hp.Responded && !string.IsNullOrEmpty(hp.Address))
+                .OrderBy(hp => hp.HopNumber)
+                .Select(hp => hp.Address!)
+                .ToList())
+            .ToList();
+
+    /// <summary>
+    /// Resolves the ASN + org name of every non-transit-probe endpoint in the rotation
+    /// into <see cref="_destinationAsns"/> / <see cref="_destinationOrgs"/>. Called once
+    /// per run from the access step; the transit step reuses the sets.
+    /// </summary>
+    private async Task ResolveDestinationAsnsAsync(CancellationToken ct)
+    {
+        _destinationAsns.Clear();
+        _destinationOrgs.Clear();
+        foreach (var endpoint in CdnRotation)
+        {
+            if (endpoint.IsTransitProbe) continue;
+            var destAsn = await _asnResolution.ResolveAsync(endpoint.Address, ct);
+            if (destAsn == null) continue;
+            _destinationAsns.Add(destAsn.Asn);
+            if (!string.IsNullOrWhiteSpace(destAsn.Name)) _destinationOrgs.Add(destAsn.Name.Trim());
+        }
+    }
+
+    /// <summary>
+    /// Picks the access ISP's ASN from the discovery sweep. The naive "first hop with a
+    /// resolvable ASN" heuristic fails when the ISP's entire first mile is unattributable:
+    /// Bell Canada (#984) runs its PPPoE aggregation on RFC1918 plus public /16s it
+    /// deliberately does not announce in BGP, so the first attributable hop was the probed
+    /// CDN's own edge and Cloudflare got crowned as the access ISP.
+    ///
+    /// Two signals replace it:
+    ///  1. The WAN IP's own ASN (the ISP's customer allocation) wins whenever it is
+    ///     resolvable AND corroborated - it appears on some hop, or no per-trace votes
+    ///     exist at all (fully silent first mile: keep it for labeling and the curated
+    ///     fallback endpoints).
+    ///  2. Otherwise per-trace voting: each trace nominates its first ASN-attributed hop,
+    ///     skipping destination ASNs - a destination's edge only appears on traces toward
+    ///     itself, while the true access ISP fronts essentially every trace. Most votes
+    ///     wins; ties break toward the ASN seen at the shallowest hop, then lowest ASN.
+    /// A destination ASN can still win via signal 1: an access ISP could legitimately be
+    /// one of the orgs we probe.
+    /// </summary>
+    internal static int? DetermineAccessAsn(
+        IEnumerable<IReadOnlyList<string>> traceAddressSequences,
+        IReadOnlyDictionary<string, int> asnByIp,
+        int? wanIpAsn,
+        IReadOnlySet<int> destinationAsns)
+    {
+        var votes = new Dictionary<int, (int Count, int BestDepth)>();
+        foreach (var trace in traceAddressSequences)
+        {
+            var depth = 0;
+            foreach (var address in trace)
+            {
+                depth++;
+                if (!asnByIp.TryGetValue(address, out var asn)) continue;
+                if (destinationAsns.Contains(asn) && asn != wanIpAsn) continue;
+                votes[asn] = votes.TryGetValue(asn, out var v)
+                    ? (v.Count + 1, Math.Min(v.BestDepth, depth))
+                    : (1, depth);
+                break;
+            }
+        }
+
+        if (wanIpAsn is int wan
+            && (votes.ContainsKey(wan) || votes.Count == 0 || asnByIp.Values.Contains(wan)))
+            return wan;
+
+        if (votes.Count == 0) return null;
+        return votes
+            .OrderByDescending(kv => kv.Value.Count)
+            .ThenBy(kv => kv.Value.BestDepth)
+            .ThenBy(kv => kv.Key)
+            .First().Key;
+    }
+
+    /// <summary>
+    /// Positional attribution for an ISP's unannounced first mile. Collects hop addresses
+    /// that appear BEFORE the first access-ASN hop on their own trace and carry no BGP
+    /// attribution but sit in public or shared/CGNAT (RFC 6598) space - Bell's 142.124.x
+    /// aggregation hops (#984). Being upstream of us and downstream of the ISP's announced
+    /// border makes them the ISP's access infrastructure even though no ASN maps to them.
+    /// RFC1918 hops are excluded: those can be a bridged CPE's LAN side or a double-NAT
+    /// middlebox. Traces whose first attributed hop is NOT the access ASN (e.g. a trace
+    /// that only ever surfaces the destination's edge) contribute nothing - we can't prove
+    /// their prefix hops sit below the access border. Dedupes across traces, preserves
+    /// first-seen order.
+    /// </summary>
+    internal static List<string> CollectUnannouncedAccessAddresses(
+        IEnumerable<IReadOnlyList<string>> traceAddressSequences,
+        IReadOnlyDictionary<string, int> asnByIp,
+        int accessAsn)
+    {
+        var result = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var trace in traceAddressSequences)
+        {
+            var prefix = new List<string>();
+            foreach (var address in trace)
+            {
+                if (asnByIp.TryGetValue(address, out var asn))
+                {
+                    if (asn == accessAsn)
+                        foreach (var p in prefix)
+                            if (seen.Add(p)) result.Add(p);
+                    break;
+                }
+                var cls = NetworkUtilities.ClassifyPublicAddress(address);
+                if (cls is PublicAddressClass.PublicIPv4 or PublicAddressClass.Cgnat)
+                    prefix.Add(address);
+            }
+        }
+        return result;
+    }
 
     /// <summary>
     /// Near-transit ASNs: every ASN that appears as the 1st or 2nd distinct non-access,

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamTracerL2NeighborTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamTracerL2NeighborTests.cs
@@ -13,6 +13,86 @@ namespace NetworkOptimizer.Web.Tests;
 public class UpstreamTracerL2NeighborTests
 {
     [Fact]
+    public void Routed_default_gateway_wins_over_higher_scoring_same_subnet_peer()
+    {
+        // Shared WAN subnet (metro Ethernet / two sites on one carrier segment): a peer
+        // host is REACHABLE and public while the true gateway is STALE - the heuristic
+        // scoring would pick the peer, the routed gateway must win.
+        const string output = """
+            203.0.113.7 lladdr aa:bb:cc:dd:ee:01 REACHABLE
+            203.0.113.1 lladdr aa:bb:cc:dd:ee:06 STALE
+            """;
+
+        var selected = UpstreamTracerService.SelectWanNeighbor(output, "203.0.113.5/24", "203.0.113.1");
+
+        selected!.Value.Ip.Should().Be("203.0.113.1");
+        selected.Value.Mac.Should().Be("aa:bb:cc:dd:ee:06");
+    }
+
+    [Fact]
+    public void Falls_back_to_scoring_when_routed_gateway_has_no_neighbor_entry()
+    {
+        const string output = """
+            192.168.1.254 lladdr aa:bb:cc:dd:ee:06 STALE
+            203.0.113.1 lladdr aa:bb:cc:dd:ee:06 REACHABLE
+            """;
+
+        UpstreamTracerService.SelectWanNeighbor(output, null, "198.51.100.99")!
+            .Value.Ip.Should().Be("203.0.113.1");
+    }
+
+    [Fact]
+    public void SelectWanDefaultGateway_finds_the_wan_table_default()
+    {
+        const string routes = """
+            default via 192.168.1.1 dev br0 table 205
+            default via 203.0.113.1 dev eth8 table 201
+            default via 198.51.100.1 dev eth9 table 202
+            """;
+
+        UpstreamTracerService.SelectWanDefaultGateway(routes, "eth8").Should().Be("203.0.113.1");
+        UpstreamTracerService.SelectWanDefaultGateway(routes, "eth9").Should().Be("198.51.100.1");
+    }
+
+    [Fact]
+    public void SelectWanDefaultGateway_matches_whole_iface_name_only()
+    {
+        // "eth8" must not match "eth8.35"'s line and vice versa.
+        const string routes = """
+            default via 203.0.113.1 dev eth8.35 table 201
+            """;
+
+        UpstreamTracerService.SelectWanDefaultGateway(routes, "eth8").Should().BeNull();
+        UpstreamTracerService.SelectWanDefaultGateway(routes, "eth8.35").Should().Be("203.0.113.1");
+    }
+
+    [Fact]
+    public void SelectWanDefaultGateway_ignores_onlink_ppp_default()
+    {
+        // PPPoE default has no "via" - no gateway address (and no MAC) to extract.
+        const string routes = """
+            default dev ppp0 scope link table 201
+            """;
+
+        UpstreamTracerService.SelectWanDefaultGateway(routes, "ppp0").Should().BeNull();
+    }
+
+    [Fact]
+    public void SelectWanDefaultGateway_handles_metric_and_proto_suffixes()
+    {
+        const string routes = "default via 203.0.113.1 dev eth8 proto static metric 220";
+
+        UpstreamTracerService.SelectWanDefaultGateway(routes, "eth8").Should().Be("203.0.113.1");
+    }
+
+    [Fact]
+    public void SelectWanDefaultGateway_returns_null_for_empty_input()
+    {
+        UpstreamTracerService.SelectWanDefaultGateway(null, "eth8").Should().BeNull();
+        UpstreamTracerService.SelectWanDefaultGateway("", "eth8").Should().BeNull();
+    }
+
+    [Fact]
     public void Prefers_public_reachable_over_private_stale_with_same_mac()
     {
         const string output = """

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
@@ -1007,6 +1007,214 @@ public class ComputeExcludedTier1AsnsTests
     }
 }
 
+public class DetermineAccessAsnTests
+{
+    // Real ASNs because the logic keys on destination sets built from real endpoints;
+    // all hop IPs are RFC 5737 documentation addresses.
+    private const int Bell = 577;
+    private const int Cloudflare = 13335;
+    private const int Google = 15169;
+
+    private static IReadOnlySet<int> Dest => new HashSet<int> { Cloudflare, Google };
+    private static IReadOnlySet<int> NoDest => new HashSet<int>();
+
+    private static Dictionary<string, int> Map(params (string Ip, int Asn)[] e)
+        => e.ToDictionary(x => x.Ip, x => x.Asn, StringComparer.OrdinalIgnoreCase);
+
+    // The #984 shape: Bell's first mile is RFC1918 + unannounced public space (absent
+    // from the ASN map), so on the Cloudflare trace the first attributable hop is
+    // Cloudflare's own edge. Bell only appears on the Google trace, one hop deeper.
+    private static readonly IReadOnlyList<string>[] BellTraces =
+    {
+        new[] { "10.0.0.2", "203.0.113.10", "203.0.113.11", "198.51.100.7", "198.51.100.8" }, // -> 1.1.1.1: CF edge at depth 4
+        new[] { "10.0.0.2", "203.0.113.10", "203.0.113.12", "192.0.2.60", "198.51.100.9" },   // -> 8.8.8.8: Bell at depth 4
+    };
+
+    private static readonly Dictionary<string, int> BellMap = Map(
+        ("198.51.100.7", Cloudflare), ("198.51.100.8", Cloudflare),
+        ("192.0.2.60", Bell), ("198.51.100.9", Google));
+
+    [Fact]
+    public void Destination_edge_is_not_crowned_access_isp()
+    {
+        // Even with no WAN IP signal (CGNAT), voting skips destination ASNs: the
+        // Cloudflare trace contributes no vote, the Google trace votes Bell.
+        UpstreamTracerService.DetermineAccessAsn(BellTraces, BellMap, wanIpAsn: null, Dest)
+            .Should().Be(Bell);
+    }
+
+    [Fact]
+    public void Wan_ip_asn_wins_when_corroborated_by_a_hop()
+    {
+        UpstreamTracerService.DetermineAccessAsn(BellTraces, BellMap, wanIpAsn: Bell, Dest)
+            .Should().Be(Bell);
+    }
+
+    [Fact]
+    public void Wan_ip_asn_kept_when_no_hop_is_attributable_at_all()
+    {
+        // Fully silent/unannounced first mile and no announced ISP hop responded:
+        // keep the WAN allocation's ASN for labeling and curated fallbacks.
+        var traces = new[] { new[] { "10.0.0.2", "203.0.113.10" } };
+        UpstreamTracerService.DetermineAccessAsn(traces, new Dictionary<string, int>(), Bell, Dest)
+            .Should().Be(Bell);
+    }
+
+    [Fact]
+    public void Uncorroborated_wan_asn_defers_to_the_voted_winner()
+    {
+        // WAN allocation resolves to a sibling ASN that never appears on any hop;
+        // the ASN actually fronting the traces wins.
+        UpstreamTracerService.DetermineAccessAsn(BellTraces, BellMap, wanIpAsn: 64499, Dest)
+            .Should().Be(Bell);
+    }
+
+    [Fact]
+    public void Wan_asn_that_is_also_a_destination_can_win()
+    {
+        // An access ISP that is one of our probed orgs is legitimate when the WAN
+        // IP itself resolves to it - the destination skip only guards voting.
+        var traces = new IReadOnlyList<string>[] { new[] { "198.51.100.9" } };
+        var map = Map(("198.51.100.9", Google));
+        UpstreamTracerService.DetermineAccessAsn(traces, map, wanIpAsn: Google, Dest)
+            .Should().Be(Google);
+    }
+
+    [Fact]
+    public void Majority_vote_beats_a_single_shallower_sighting()
+    {
+        var traces = new IReadOnlyList<string>[]
+        {
+            new[] { "192.0.2.1" },                            // odd ASN out at depth 1
+            new[] { "203.0.113.1", "203.0.113.2", "192.0.2.10" },
+            new[] { "203.0.113.1", "203.0.113.3", "192.0.2.11" },
+            new[] { "203.0.113.1", "203.0.113.4", "192.0.2.12" },
+        };
+        var map = Map(("192.0.2.1", 64501),
+            ("192.0.2.10", 64502), ("192.0.2.11", 64502), ("192.0.2.12", 64502));
+        UpstreamTracerService.DetermineAccessAsn(traces, map, null, NoDest)
+            .Should().Be(64502);
+    }
+
+    [Fact]
+    public void Vote_tie_breaks_toward_the_shallowest_hop()
+    {
+        var traces = new IReadOnlyList<string>[]
+        {
+            new[] { "192.0.2.1" },                  // ASN 64510 at depth 1
+            new[] { "203.0.113.1", "192.0.2.2" },   // ASN 64505 at depth 2
+        };
+        var map = Map(("192.0.2.1", 64510), ("192.0.2.2", 64505));
+        UpstreamTracerService.DetermineAccessAsn(traces, map, null, NoDest)
+            .Should().Be(64510);
+    }
+
+    [Fact]
+    public void Simple_announced_first_hop_still_wins()
+    {
+        var traces = new IReadOnlyList<string>[] { new[] { "192.0.2.1", "198.51.100.7" } };
+        var map = Map(("192.0.2.1", 64500), ("198.51.100.7", Cloudflare));
+        UpstreamTracerService.DetermineAccessAsn(traces, map, null, Dest)
+            .Should().Be(64500);
+    }
+
+    [Fact]
+    public void No_data_yields_null()
+    {
+        UpstreamTracerService.DetermineAccessAsn(
+                Array.Empty<IReadOnlyList<string>>(), new Dictionary<string, int>(), null, NoDest)
+            .Should().BeNull();
+    }
+}
+
+public class CollectUnannouncedAccessAddressesTests
+{
+    private const int Bell = 577;
+    private const int Cloudflare = 13335;
+
+    private static Dictionary<string, int> Map(params (string Ip, int Asn)[] e)
+        => e.ToDictionary(x => x.Ip, x => x.Asn, StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void Unannounced_public_hops_before_the_access_border_are_attributed()
+    {
+        // The #984 shape: RFC1918, then unannounced public space, then the announced
+        // access-ASN border. The public hops are kept; the RFC1918 hop is not.
+        var traces = new IReadOnlyList<string>[]
+        {
+            new[] { "10.0.0.2", "203.0.113.10", "203.0.113.11", "192.0.2.60" }
+        };
+        var map = Map(("192.0.2.60", Bell));
+
+        UpstreamTracerService.CollectUnannouncedAccessAddresses(traces, map, Bell)
+            .Should().Equal("203.0.113.10", "203.0.113.11");
+    }
+
+    [Fact]
+    public void Cgnat_prefix_hops_are_attributed()
+    {
+        var traces = new IReadOnlyList<string>[] { new[] { "100.64.0.5", "192.0.2.60" } };
+        var map = Map(("192.0.2.60", Bell));
+
+        UpstreamTracerService.CollectUnannouncedAccessAddresses(traces, map, Bell)
+            .Should().Equal("100.64.0.5");
+    }
+
+    [Fact]
+    public void Rfc1918_hops_are_never_attributed()
+    {
+        var traces = new IReadOnlyList<string>[] { new[] { "10.0.0.2", "172.16.0.2", "192.168.1.2", "192.0.2.60" } };
+        var map = Map(("192.0.2.60", Bell));
+
+        UpstreamTracerService.CollectUnannouncedAccessAddresses(traces, map, Bell)
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Trace_whose_first_attributed_hop_is_not_the_access_asn_contributes_nothing()
+    {
+        // A trace that only ever surfaces the destination's edge can't prove its
+        // unattributed prefix sits below the access border.
+        var traces = new IReadOnlyList<string>[]
+        {
+            new[] { "203.0.113.10", "198.51.100.7" }
+        };
+        var map = Map(("198.51.100.7", Cloudflare));
+
+        UpstreamTracerService.CollectUnannouncedAccessAddresses(traces, map, Bell)
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Dedupes_across_traces_preserving_first_seen_order()
+    {
+        var traces = new IReadOnlyList<string>[]
+        {
+            new[] { "203.0.113.10", "192.0.2.60" },
+            new[] { "203.0.113.10", "203.0.113.12", "192.0.2.61" },
+        };
+        var map = Map(("192.0.2.60", Bell), ("192.0.2.61", Bell));
+
+        UpstreamTracerService.CollectUnannouncedAccessAddresses(traces, map, Bell)
+            .Should().Equal("203.0.113.10", "203.0.113.12");
+    }
+
+    [Fact]
+    public void Hops_after_the_access_border_are_not_attributed()
+    {
+        // Only the pre-border prefix counts: unattributed hops BETWEEN access and
+        // transit (e.g. an IXP LAN) must not be pulled into the access cloud.
+        var traces = new IReadOnlyList<string>[]
+        {
+            new[] { "192.0.2.60", "203.0.113.50", "198.51.100.7" }
+        };
+        var map = Map(("192.0.2.60", Bell), ("198.51.100.7", Cloudflare));
+
+        UpstreamTracerService.CollectUnannouncedAccessAddresses(traces, map, Bell)
+            .Should().BeEmpty();
+    }
+}
+
 public class AccessIspFallbackTests
 {
     [Fact]


### PR DESCRIPTION
Fixes #984.

## Root cause

The **Upstream path discovery** access-ISP pick was "first hop with a resolvable ASN across the merged trace pool". Bell Canada's PPPoE first mile is RFC1918 plus public /16s Bell deliberately does **not** announce in BGP (142.124.x / 142.125.x - the gap in Bell's otherwise-announced 142.112-142.127 range), so every early hop resolved to a null ASN. The first attributable hop was then Cloudflare's own edge on the 1.1.1.1 trace, so AS13335 was crowned the access ISP (with 1.1.1.1 itself as a "first-mile hop") and Bell AS577 fell through to the Transit networks list. The transit step already excluded destination ASNs for exactly this reason; the access step had no such guard.

## Fix 1: access-ISP ASN detection

`DetermineAccessAsn` replaces the heuristic with two signals:

- **WAN IP ASN as the primary signal** - the gateway's public WAN address resolves to the ISP's customer allocation (AS577 for the reporter), independent of which routers answer traceroute. It wins when corroborated by any hop, or when no hop is attributable at all (fully silent first mile - keeps labeling and the curated fallback endpoints working). An uncorroborated WAN ASN (sibling-ASN allocations) defers to voting.
- **Per-trace voting as the fallback** (CGNAT WANs) - each trace nominates its first attributed hop, skipping destination ASNs: a destination's edge only appears on traces toward itself, while the real access ISP fronts essentially every trace.

Plus positional attribution for the unannounced first mile (`CollectUnannouncedAccessAddresses`): hops that appear before the first access-ASN hop on their own trace and sit in unattributed public or CGNAT space are the ISP's aggregation layer, and now join the access hop pool (Bell's 142.124.x hops respond at 3-5 ms and become monitorable). RFC1918 prefix hops stay excluded - a bridged CPE's LAN side or a double-NAT middlebox must never be labeled ISP infrastructure. The existing reachability gate still disables anything that doesn't answer ping.

Destination ASN/org resolution is hoisted into a shared once-per-run step so the access and transit passes gate on the same sets.

## Fix 2: WAN L2 neighbor picks the routed default gateway

Related first-hop flaw found while reviewing: `SelectWanNeighbor` scored `ip neigh` entries heuristically (subnet > address class > freshness). On a shared WAN subnet (metro Ethernet, two sites on one carrier segment) the neighbor table also lists unrelated same-subnet hosts, and a peer (e.g. another site's gateway, REACHABLE while the true gateway is STALE) could win the scoring and be labeled the first-mile device.

Now the WAN's default gateway is read from `ip route show table all` (UniFi policy routing keeps each WAN's default in its own table; matching on `dev <wan-iface>` finds it regardless of table number) and that IP's neighbor entry wins outright - the MAC still comes from `ip neigh`, so OUI/first-mile-device labeling is unchanged. The heuristic scoring remains as fallback when no routed gateway is visible (on-link/PPPoE defaults have no `via` and no MAC).

## Tests

22 new unit tests: a repro of the exact #984 trace shape (unattributable prefix, Cloudflare edge shallower than Bell's first announced hop) for both the CGNAT-voting and WAN-ASN paths, WAN-ASN corroboration/deference, tie-breaks, CGNAT/RFC1918 handling, the IXP-LAN non-attribution case, the shared-WAN-subnet peer-vs-gateway case, and `ip route show table all` parsing (VLAN sub-interfaces, PPPoE on-link defaults, metric/proto suffixes). Full suite passes; zero build warnings.