### PR TITLE
API key console connections self-heal (#986); UniFi Console and On-Site Agent connection alerts; Multi-Site Disable / Remove Site (#982)

### DIFF
--- a/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
+++ b/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
@@ -161,6 +161,26 @@ public static class DefaultAlertRules
             CooldownSeconds = 86400 // 24 hours
         },
 
+        // --- UniFi Console (enabled by default - a dead console connection silently blanks most features) ---
+        new AlertRule
+        {
+            Name = "UniFi Console: Connection Failed",
+            IsEnabled = true,
+            EventTypePattern = "console.connection_failed",
+            Source = "console",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 1800 // 30 minutes - the connection service fires once per outage
+        },
+        new AlertRule
+        {
+            Name = "UniFi Console: Connection Restored",
+            IsEnabled = true,
+            EventTypePattern = "console.connection_restored",
+            Source = "console",
+            MinSeverity = AlertSeverity.Info,
+            CooldownSeconds = 60 // 1 minute - restores are paired with failure events
+        },
+
         // --- Monitoring (enabled by default - users opted into monitoring by configuring it) ---
         new AlertRule
         {

--- a/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
+++ b/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
@@ -181,6 +181,26 @@ public static class DefaultAlertRules
             CooldownSeconds = 60 // 1 minute - restores are paired with failure events
         },
 
+        // --- On-Site Agent (enabled by default - an offline agent takes its whole site dark) ---
+        new AlertRule
+        {
+            Name = "On-Site Agent: Offline",
+            IsEnabled = true,
+            EventTypePattern = "agent.offline",
+            Source = "agent",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 1800 // 30 minutes - the monitor fires once per outage
+        },
+        new AlertRule
+        {
+            Name = "On-Site Agent: Reconnected",
+            IsEnabled = true,
+            EventTypePattern = "agent.reconnected",
+            Source = "agent",
+            MinSeverity = AlertSeverity.Info,
+            CooldownSeconds = 60 // 1 minute - reconnects are paired with offline events
+        },
+
         // --- Monitoring (enabled by default - users opted into monitoring by configuring it) ---
         new AlertRule
         {

--- a/src/NetworkOptimizer.Storage/Interfaces/ISiteRepository.cs
+++ b/src/NetworkOptimizer.Storage/Interfaces/ISiteRepository.cs
@@ -22,4 +22,7 @@ public interface ISiteRepository
 
     /// <summary>Updates a site's mutable fields (name, enabled, sort order, notes). The slug is never changed.</summary>
     Task UpdateAsync(Site site, CancellationToken cancellationToken = default);
+
+    /// <summary>Removes a site from the registry. Does not touch the site's database file.</summary>
+    Task DeleteAsync(int id, CancellationToken cancellationToken = default);
 }

--- a/src/NetworkOptimizer.Storage/Repositories/SiteRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/SiteRepository.cs
@@ -71,4 +71,16 @@ public class SiteRepository : ISiteRepository
         existing.UpdatedAt = DateTime.UtcNow;
         await context.SaveChangesAsync(cancellationToken);
     }
+
+    public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        var existing = await context.Sites.FindAsync(new object[] { id }, cancellationToken);
+        if (existing == null)
+            return;
+
+        context.Sites.Remove(existing);
+        await context.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation("Deleted site {Slug} (id {Id}) from the registry", existing.Slug, id);
+    }
 }

--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -43,6 +43,8 @@ public class UniFiApiClient : IDisposable
     private DateTime _deviceResponseCacheTime = DateTime.MinValue;
     private static readonly TimeSpan DeviceResponseCacheTtl = TimeSpan.FromSeconds(15);
     private bool _isAuthenticated = false;
+    private DateTime _lastApiKeyRevalidationAttempt = DateTime.MinValue;
+    private static readonly TimeSpan ApiKeyRevalidationInterval = TimeSpan.FromSeconds(60);
     private bool _isUniFiOs = false; // True for UDM/UCG, false for standalone controller
     private bool _pathDetected = false;
     private bool _useStandaloneLogin = false; // True for standalone Network controllers (uses /api/login)
@@ -459,17 +461,22 @@ public class UniFiApiClient : IDisposable
 
     /// <summary>
     /// Ensures we're authenticated, re-authenticating if necessary.
-    /// For API key auth, if we've already been marked as unauthenticated (e.g., 401 response),
-    /// re-login won't help since the key is either valid or not - return false immediately.
+    /// For API key auth a 401/403 usually means the Network application was restarting or
+    /// wedged (upgrades, provisioning), not that the key was revoked - the proxy returns
+    /// auth errors while the app is down. Re-validate the key, throttled so a genuinely
+    /// revoked key costs at most one probe per interval instead of one per API call.
     /// </summary>
     private async Task<bool> EnsureAuthenticatedAsync(CancellationToken cancellationToken = default)
     {
         if (_isAuthenticated)
             return true;
 
-        // API key auth is stateless - if we got a 401, re-sending the same key won't help
         if (UseApiKey)
-            return false;
+        {
+            if (DateTime.UtcNow - _lastApiKeyRevalidationAttempt < ApiKeyRevalidationInterval)
+                return false;
+            _lastApiKeyRevalidationAttempt = DateTime.UtcNow;
+        }
 
         return await LoginAsync(cancellationToken);
     }

--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -72,6 +72,15 @@ public class UniFiApiClient : IDisposable
     /// </summary>
     public bool UseApiKey => !string.IsNullOrEmpty(_apiKey);
 
+    /// <summary>
+    /// Raised after every real login/validation attempt with the outcome and, on failure,
+    /// the login error. Lets the owning connection service track consecutive auth failures
+    /// (console restarting, upgrading, or unreachable) for alerting. Not raised for the
+    /// already-authenticated fast path. Handlers must be cheap and must not call back into
+    /// this client - the event fires while the auth lock is held.
+    /// </summary>
+    public event Action<bool, string?>? AuthProbeCompleted;
+
     public UniFiApiClient(
         ILogger<UniFiApiClient> logger,
         string controllerHost,
@@ -242,18 +251,21 @@ public class UniFiApiClient : IDisposable
                             ? "Invalid API key. Check that it was copied correctly and has not been revoked."
                             : $"API key validation failed with status {(int)validateResponse.StatusCode}.";
                         _logger.LogWarning("API key validation failed: {StatusCode}", validateResponse.StatusCode);
+                        AuthProbeCompleted?.Invoke(false, _lastLoginError);
                         return false;
                     }
 
                     _isAuthenticated = true;
                     await DetectControllerTypeAsync(cancellationToken);
                     _logger.LogInformation("API key authentication validated (UniFi OS: {IsUniFiOs})", _isUniFiOs);
+                    AuthProbeCompleted?.Invoke(true, null);
                     return true;
                 }
                 catch (Exception ex)
                 {
                     _lastLoginError = ParseExceptionError(ex);
                     _logger.LogError(ex, "Exception validating API key");
+                    AuthProbeCompleted?.Invoke(false, _lastLoginError);
                     return false;
                 }
             }
@@ -300,6 +312,7 @@ public class UniFiApiClient : IDisposable
 
                 // Parse error response for user-friendly message
                 _lastLoginError = ParseLoginError(response.StatusCode, errorBody);
+                AuthProbeCompleted?.Invoke(false, _lastLoginError);
                 return false;
             }
 
@@ -334,12 +347,14 @@ public class UniFiApiClient : IDisposable
             // Detect controller type after successful authentication
             await DetectControllerTypeAsync(cancellationToken);
 
+            AuthProbeCompleted?.Invoke(true, null);
             return true;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Exception during login");
             _lastLoginError = ParseExceptionError(ex);
+            AuthProbeCompleted?.Invoke(false, _lastLoginError);
             return false;
         }
         finally

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -1598,6 +1598,13 @@
                     </div>
                 </div>
                 <div>
+                    <h4 class="event-type-group-header">On-Site Agent</h4>
+                    <div class="event-type-key-list">
+                        <div @onclick='() => SelectEventType("agent.offline")'><code>agent.offline</code> <span>Site agent offline past the grace period</span></div>
+                        <div @onclick='() => SelectEventType("agent.reconnected")'><code>agent.reconnected</code> <span>Site agent came back online</span></div>
+                    </div>
+                </div>
+                <div>
                     <h4 class="event-type-group-header">Monitoring</h4>
                     <div class="event-type-key-list">
                         <div @onclick='() => SelectEventType("monitoring.target_offline")'><code>monitoring.target_offline</code> <span>Probe target went offline</span></div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -1591,6 +1591,13 @@
                     </div>
                 </div>
                 <div>
+                    <h4 class="event-type-group-header">UniFi Console</h4>
+                    <div class="event-type-key-list">
+                        <div @onclick='() => SelectEventType("console.connection_failed")'><code>console.connection_failed</code> <span>Console connection or authentication failing</span></div>
+                        <div @onclick='() => SelectEventType("console.connection_restored")'><code>console.connection_restored</code> <span>Console connection recovered</span></div>
+                    </div>
+                </div>
+                <div>
                     <h4 class="event-type-group-header">Monitoring</h4>
                     <div class="event-type-key-list">
                         <div @onclick='() => SelectEventType("monitoring.target_offline")'><code>monitoring.target_offline</code> <span>Probe target went offline</span></div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -3164,6 +3164,7 @@
         ["map"] = "application",
         ["data-management"] = "application",
         ["multi-site"] = "multisite",
+        ["site-agent-setup"] = "multisite",
     };
 
     private static string ResolveTab(string? param) =>
@@ -3223,6 +3224,10 @@
                     el.style.outlineOffset = '4px';
                     el.style.borderRadius = '12px';
                     setTimeout(function() { el.style.outline = ''; el.style.outlineOffset = ''; }, 2000);
+                }
+                if ('" + anchor + @"' === 'site-agent-setup') {
+                    var inp = document.getElementById('site-name-input');
+                    if (inp) inp.focus({ preventScroll: true });
                 }
             })();");
     }

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -3306,10 +3306,9 @@
 
     private async Task ToggleSiteEnabled(Site site)
     {
-        var message = site.Enabled
-            ? $"Disable site \"{site.Name}\"? Monitoring stops and it disappears from the site switcher. All of its data is kept, and you can re-enable it here anytime."
-            : $"Enable site \"{site.Name}\"? Monitoring and its UniFi Console connection resume.";
-        if (!await JS.InvokeAsync<bool>("confirm", message))
+        // Disabling pauses a live site, so it confirms; re-enabling is harmless.
+        if (site.Enabled && !await JS.InvokeAsync<bool>("confirm",
+                $"Disable site \"{site.Name}\"? Monitoring stops and it disappears from the site switcher. All of its data is kept, and you can re-enable it here anytime."))
             return;
 
         try

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -2883,6 +2883,10 @@
                                             {
                                                 <span class="status-badge">Default</span>
                                             }
+                                            else if (!site.Enabled)
+                                            {
+                                                <span class="status-badge">Disabled</span>
+                                            }
                                             else
                                             {
                                                 var agentStatus = SiteAgentStatus(site.Id);
@@ -3039,6 +3043,32 @@
                                                                     https on the agent port. Doesn't affect the network path trace.
                                                                 </small>
                                                             </div>
+                                                        </div>
+
+                                                        <div class="site-config-section">
+                                                            <div class="site-config-section-title">Disable / Remove Site</div>
+                                                            @if (site.Slug == SiteContext.Slug)
+                                                            {
+                                                                <p class="site-config-empty">
+                                                                    You're currently viewing this site. Switch to another site to disable or remove it.
+                                                                </p>
+                                                            }
+                                                            else
+                                                            {
+                                                                <p class="form-help">
+                                                                    Disabling stops monitoring and hides the site from the site switcher; all of its
+                                                                    data is kept and it can be re-enabled here anytime. Removing is permanent: the
+                                                                    site, its database, and its agent enrollments are deleted.
+                                                                </p>
+                                                                <div class="site-agent-actions">
+                                                                    <button type="button" class="btn btn-secondary btn-sm" @onclick="() => ToggleSiteEnabled(site)">
+                                                                        @(site.Enabled ? "Disable Site" : "Enable Site")
+                                                                    </button>
+                                                                    <button type="button" class="btn btn-danger btn-sm" @onclick="() => RemoveSite(site)">
+                                                                        Remove Site
+                                                                    </button>
+                                                                </div>
+                                                            }
                                                         </div>
                                                     }
                                                 </div>
@@ -3272,6 +3302,52 @@
         _sites = await SiteManagement.GetSitesAsync();
         await LoadAgentsAsync();
         StateHasChanged();
+    }
+
+    private async Task ToggleSiteEnabled(Site site)
+    {
+        var message = site.Enabled
+            ? $"Disable site \"{site.Name}\"? Monitoring stops and it disappears from the site switcher. All of its data is kept, and you can re-enable it here anytime."
+            : $"Enable site \"{site.Name}\"? Monitoring and its UniFi Console connection resume.";
+        if (!await JS.InvokeAsync<bool>("confirm", message))
+            return;
+
+        try
+        {
+            await SiteManagement.SetSiteEnabledAsync(site, !site.Enabled);
+        }
+        catch (Exception ex)
+        {
+            _multiSiteMessage = ex.Message;
+            _multiSiteMessageClass = "danger";
+            return;
+        }
+        await RefreshSites();
+    }
+
+    private async Task RemoveSite(Site site)
+    {
+        if (!await JS.InvokeAsync<bool>("confirm",
+                $"Remove site \"{site.Name}\" permanently? This deletes the site, its database (monitoring history, speed test results, settings), and its agent enrollments."))
+            return;
+        if (!await JS.InvokeAsync<bool>("confirm",
+                $"Last check: \"{site.Name}\" and all of its data will be gone for good. This cannot be undone. Remove it?"))
+            return;
+
+        try
+        {
+            await SiteManagement.DeleteSiteAsync(site);
+        }
+        catch (Exception ex)
+        {
+            _multiSiteMessage = ex.Message;
+            _multiSiteMessageClass = "danger";
+            return;
+        }
+        _expandedSiteId = null;
+        _multiSiteMessage = $"Site \"{site.Name}\" was removed.";
+        _multiSiteMessageClass = "success";
+        await RefreshSites();
     }
 
     // Inline site rename (the slug/Site ID stays immutable).

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -3327,7 +3327,7 @@
     private async Task RemoveSite(Site site)
     {
         if (!await JS.InvokeAsync<bool>("confirm",
-                $"Remove site \"{site.Name}\" permanently? This deletes the site, its database (monitoring history, speed test results, settings), and its agent enrollments."))
+                $"Remove site \"{site.Name}\" permanently? This deletes the site, its database (monitoring history, speed test results, settings), and its agent enrollments. Its InfluxDB buckets are not removed - delete those in InfluxDB if you no longer want them."))
             return;
         if (!await JS.InvokeAsync<bool>("confirm",
                 $"Last check: \"{site.Name}\" and all of its data will be gone for good. This cannot be undone. Remove it?"))

--- a/src/NetworkOptimizer.Web/Components/Pages/Sites.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sites.razor
@@ -115,7 +115,7 @@ else
         _enabled = await SiteManagement.IsMultiSiteEnabledAsync();
         if (_enabled)
         {
-            _sites = await SiteManagement.GetSitesAsync();
+            _sites = (await SiteManagement.GetSitesAsync()).Where(s => s.Enabled).ToList();
             _agents = await AgentEnrollment.GetAllAgentsAsync();
             await LoadConsoleHostsAsync();
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Sites.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sites.razor
@@ -94,7 +94,7 @@ else
             </a>
         }
 
-        <div class="card site-card site-card-add" @onclick="@(() => NavigationManager.NavigateTo("/settings?tab=multisite"))">
+        <div class="card site-card site-card-add" @onclick="@(() => NavigationManager.NavigateTo("/settings?tab=multisite#site-agent-setup"))">
             <span class="site-card-add-plus">+</span>
             <span>Add Site</span>
         </div>

--- a/src/NetworkOptimizer.Web/Components/Shared/SiteSetupWizard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SiteSetupWizard.razor
@@ -64,7 +64,7 @@
         {
             <div class="form-group">
                 <div class="input-with-button">
-                    <input type="text" class="form-control" @bind="_name" @bind:event="oninput"
+                    <input type="text" id="site-name-input" class="form-control" @bind="_name" @bind:event="oninput"
                            placeholder="Site name (e.g. Lake House)" autocomplete="off" data-1p-ignore data-lpignore="true" data-bwignore />
                     <button type="button" class="btn btn-primary btn-sm" @onclick="CreateSiteAsync"
                             disabled="@(_busy || string.IsNullOrWhiteSpace(_name))">

--- a/src/NetworkOptimizer.Web/Components/Shared/SiteSetupWizard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SiteSetupWizard.razor
@@ -294,6 +294,13 @@
 
     private async Task CreateSiteAsync()
     {
+        // A fast double-click queues both click events before the disabled state
+        // renders; the circuit runs them sequentially, so by the time the second
+        // arrives _busy is false again and it would create a duplicate site
+        // (name-2). _site stays set after success, so it swallows the straggler.
+        if (_busy || _site != null)
+            return;
+
         _busy = true;
         _message = "";
         StateHasChanged();

--- a/src/NetworkOptimizer.Web/Components/Shared/SiteSetupWizard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SiteSetupWizard.razor
@@ -304,6 +304,10 @@
         _busy = true;
         _message = "";
         StateHasChanged();
+        // SQLite completes EF's async calls synchronously, so provisioning never
+        // yields and the queued spinner render would only flush after it finishes.
+        // Yield once so the disabled+spinner state reaches the browser first.
+        await Task.Yield();
 
         try
         {

--- a/src/NetworkOptimizer.Web/Components/Shared/SiteSwitcher.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SiteSwitcher.razor
@@ -58,7 +58,9 @@
         if (!_enabled)
             return;
 
-        _sites = await SiteManagement.GetSitesAsync();
+        // Disabled sites are managed (re-enabled/removed) from Settings - Multi-Site;
+        // they don't belong in the switcher.
+        _sites = (await SiteManagement.GetSitesAsync()).Where(s => s.Enabled).ToList();
         _currentSite = _sites.FirstOrDefault(s => s.Slug == SiteContext.Slug)
             ?? _sites.FirstOrDefault(s => s.IsDefault);
     }

--- a/src/NetworkOptimizer.Web/Components/Shared/SiteSwitcher.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SiteSwitcher.razor
@@ -7,7 +7,7 @@
 
 @if (_enabled && _sites.Count > 0)
 {
-    <div class="site-switcher">
+    <div class="site-switcher" @onkeydown="HandleKeyDown">
         <button type="button" class="site-switcher-trigger" @onclick="ToggleDropdown" @onclick:stopPropagation="true">
             <img src="/icons/sites.png" alt="" class="site-switcher-icon" />
             <span class="site-switcher-name">@(_currentSite?.Name ?? "Site")</span>
@@ -66,6 +66,12 @@
     private void ToggleDropdown() => _open = !_open;
 
     private void CloseDropdown() => _open = false;
+
+    private void HandleKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape")
+            _open = false;
+    }
 
     /// <summary>This page pinned to the given site - the anchor href (plain-click switch
     /// target and modified-click new-tab target); see site-context.js.</summary>

--- a/src/NetworkOptimizer.Web/Components/Shared/SiteSwitcher.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SiteSwitcher.razor
@@ -3,7 +3,9 @@
 @inject SiteManagementService SiteManagement
 @inject SiteContextService SiteContext
 @inject SiteConnectionRegistry SiteConnections
+@inject SiteRegistryChangeNotifier ChangeNotifier
 @inject NavigationManager NavigationManager
+@implements IDisposable
 
 @if (_enabled && _sites.Count > 0)
 {
@@ -54,6 +56,12 @@
 
     protected override async Task OnInitializedAsync()
     {
+        ChangeNotifier.SitesChanged += OnSitesChanged;
+        await LoadSitesAsync();
+    }
+
+    private async Task LoadSitesAsync()
+    {
         _enabled = await SiteManagement.IsMultiSiteEnabledAsync();
         if (!_enabled)
             return;
@@ -63,6 +71,30 @@
         _sites = (await SiteManagement.GetSitesAsync()).Where(s => s.Enabled).ToList();
         _currentSite = _sites.FirstOrDefault(s => s.Slug == SiteContext.Slug)
             ?? _sites.FirstOrDefault(s => s.IsDefault);
+    }
+
+    // Raised from whichever circuit changed the registry (create, rename,
+    // enable/disable, remove, multi-site toggle) - rebuild this circuit's list.
+    private void OnSitesChanged()
+    {
+        _ = InvokeAsync(async () =>
+        {
+            try
+            {
+                await LoadSitesAsync();
+                _open = false;
+                StateHasChanged();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Circuit torn down between the event and the dispatch - nothing to update.
+            }
+        });
+    }
+
+    public void Dispose()
+    {
+        ChangeNotifier.SitesChanged -= OnSitesChanged;
     }
 
     private void ToggleDropdown() => _open = !_open;

--- a/src/NetworkOptimizer.Web/Components/Shared/SitesOverviewCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SitesOverviewCard.razor
@@ -72,7 +72,7 @@
     {
         if (await SiteManagement.IsMultiSiteEnabledAsync())
         {
-            _sites = await SiteManagement.GetSitesAsync();
+            _sites = (await SiteManagement.GetSitesAsync()).Where(s => s.Enabled).ToList();
             _agents = await AgentEnrollment.GetAllAgentsAsync();
 
             // Same 10s refresh as the Sites and Settings pages, so the Agents

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -923,6 +923,18 @@ using (var scope = app.Services.CreateScope())
     // Seed default alert rules - insert any missing rules by EventTypePattern
     {
         var defaults = NetworkOptimizer.Alerts.DefaultAlertRules.GetDefaults();
+
+        // On-Site Agent rules only make sense on the main site when the default site
+        // itself has an agent (secondary sites get theirs from the per-site seed above).
+        // Skipping them keeps a single-site install's Rules list free of agent entries;
+        // enrolling a default-site agent later seeds them at that point.
+        var defaultSiteId = db.Sites
+            .Where(s => s.Slug == SiteManagementService.DefaultSiteSlug)
+            .Select(s => (int?)s.Id)
+            .FirstOrDefault();
+        if (defaultSiteId == null || !db.SiteAgents.Any(a => a.SiteId == defaultSiteId))
+            defaults = defaults.Where(d => d.Source != "agent").ToList();
+
         var existingPatterns = db.AlertRules.Select(r => r.EventTypePattern).ToHashSet();
         var missing = defaults.Where(d => !existingPatterns.Contains(d.EventTypePattern)).ToList();
         if (missing.Count > 0)

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -418,6 +418,7 @@ builder.Services.AddSingleton<NetworkOptimizer.Alerts.AlertProcessingService>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<NetworkOptimizer.Alerts.AlertProcessingService>());
 builder.Services.AddSingleton<NetworkOptimizer.Alerts.DigestService>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<NetworkOptimizer.Alerts.DigestService>());
+builder.Services.AddHostedService<AgentConnectionAlertMonitor>();
 // IDigestStateStore adapter: persists digest "last sent" timestamps via SystemSettings
 builder.Services.AddScoped<NetworkOptimizer.Alerts.Interfaces.IDigestStateStore, DigestStateStoreAdapter>();
 // ISecretDecryptor adapter: bridges Alerts project's interface to existing credential protection

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -265,6 +265,7 @@ builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.ISpeedTestReposit
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.ISqmRepository, NetworkOptimizer.Storage.Repositories.SqmRepository>();
 builder.Services.AddScoped<NetworkOptimizer.Alerts.Interfaces.IAlertRepository, NetworkOptimizer.Storage.Repositories.AlertRepository>();
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.ISiteRepository, NetworkOptimizer.Storage.Repositories.SiteRepository>();
+builder.Services.AddSingleton<SiteRegistryChangeNotifier>();
 builder.Services.AddScoped<SiteManagementService>();
 builder.Services.AddScoped<SiteContextService>();
 builder.Services.AddScoped<SiteSwitchService>();

--- a/src/NetworkOptimizer.Web/Services/AgentConnectionAlertMonitor.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentConnectionAlertMonitor.cs
@@ -70,10 +70,11 @@ public class AgentConnectionAlertMonitor : BackgroundService
 
         // Only agents that completed enrollment and have contacted us at least
         // once can go "offline" - a freshly enrolled agent that never connected
-        // is a setup in progress, not an outage.
+        // is a setup in progress, not an outage. Disabled sites are excluded:
+        // taking a paused site's agent down is intentional, not an outage.
         var agents = await db.SiteAgents.AsNoTracking()
             .Where(a => a.Enabled && a.EnrolledAt != null && a.LastSeenAt != null)
-            .Join(db.Sites.AsNoTracking(), a => a.SiteId, s => s.Id,
+            .Join(db.Sites.AsNoTracking().Where(s => s.Enabled), a => a.SiteId, s => s.Id,
                 (a, s) => new { Agent = a, s.Slug })
             .ToListAsync(ct);
 

--- a/src/NetworkOptimizer.Web/Services/AgentConnectionAlertMonitor.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentConnectionAlertMonitor.cs
@@ -1,0 +1,149 @@
+using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Alerts.Events;
+using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Storage.Models;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Periodically sweeps enrolled agents and raises alert events when one stays
+/// offline past the grace threshold, pairing each with a reconnect event when it
+/// comes back. Sweeps <see cref="AgentTunnelRegistry.IsAgentLive"/> (open tunnel,
+/// or heartbeat freshness for REST-only agents and reconnect gaps) instead of
+/// hooking tunnel teardown, so agent redeploys and transient tunnel bounces never
+/// alert - only an agent continuously offline for the full threshold does.
+/// </summary>
+public class AgentConnectionAlertMonitor : BackgroundService
+{
+    private static readonly TimeSpan SweepInterval = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan OfflineThreshold = TimeSpan.FromMinutes(3);
+
+    private readonly IDbContextFactory<NetworkOptimizerDbContext> _mainDbFactory;
+    private readonly AgentTunnelRegistry _tunnelRegistry;
+    private readonly IAlertEventBus _alertBus;
+    private readonly ILogger<AgentConnectionAlertMonitor> _logger;
+
+    // Per-agent sweep state. Only touched by the sweep loop, no locking needed.
+    private sealed class AgentState
+    {
+        public DateTime OfflineSince;
+        public bool Alerted;
+    }
+
+    private readonly Dictionary<int, AgentState> _states = new();
+
+    public AgentConnectionAlertMonitor(
+        IDbContextFactory<NetworkOptimizerDbContext> mainDbFactory,
+        AgentTunnelRegistry tunnelRegistry,
+        IAlertEventBus alertBus,
+        ILogger<AgentConnectionAlertMonitor> logger)
+    {
+        _mainDbFactory = mainDbFactory;
+        _tunnelRegistry = tunnelRegistry;
+        _alertBus = alertBus;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(SweepInterval, stoppingToken);
+                await SweepAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Agent connection alert sweep failed");
+            }
+        }
+    }
+
+    private async Task SweepAsync(CancellationToken ct)
+    {
+        await using var db = await _mainDbFactory.CreateDbContextAsync(ct);
+
+        // Only agents that completed enrollment and have contacted us at least
+        // once can go "offline" - a freshly enrolled agent that never connected
+        // is a setup in progress, not an outage.
+        var agents = await db.SiteAgents.AsNoTracking()
+            .Where(a => a.Enabled && a.EnrolledAt != null && a.LastSeenAt != null)
+            .Join(db.Sites.AsNoTracking(), a => a.SiteId, s => s.Id,
+                (a, s) => new { Agent = a, s.Slug })
+            .ToListAsync(ct);
+
+        var now = DateTime.UtcNow;
+        var seen = new HashSet<int>();
+
+        foreach (var entry in agents)
+        {
+            var agent = entry.Agent;
+            seen.Add(agent.Id);
+
+            if (_tunnelRegistry.IsAgentLive(agent))
+            {
+                if (_states.Remove(agent.Id, out var prior) && prior.Alerted)
+                {
+                    await PublishAsync("agent.reconnected", AlertSeverity.Info,
+                        "On-Site Agent reconnected",
+                        $"Agent \"{agent.Name}\" is back online.",
+                        agent, entry.Slug, ct);
+                }
+                continue;
+            }
+
+            if (!_states.TryGetValue(agent.Id, out var state))
+            {
+                _states[agent.Id] = new AgentState { OfflineSince = now };
+                continue;
+            }
+
+            if (!state.Alerted && now - state.OfflineSince >= OfflineThreshold)
+            {
+                state.Alerted = true;
+                var lastSeen = agent.LastSeenAt.HasValue
+                    ? $"Last seen {agent.LastSeenAt:u}."
+                    : "";
+                await PublishAsync("agent.offline", AlertSeverity.Warning,
+                    "On-Site Agent offline",
+                    $"Agent \"{agent.Name}\" has been offline for over {(int)OfflineThreshold.TotalMinutes} minutes. Its site's monitoring, speed tests, and console connection are unavailable until it reconnects. {lastSeen}",
+                    agent, entry.Slug, ct);
+            }
+        }
+
+        // Forget agents that were deleted or disabled mid-outage.
+        foreach (var staleId in _states.Keys.Where(id => !seen.Contains(id)).ToList())
+            _states.Remove(staleId);
+    }
+
+    private async Task PublishAsync(
+        string eventType, AlertSeverity severity, string title, string message,
+        SiteAgent agent, string siteSlug, CancellationToken ct)
+    {
+        try
+        {
+            await _alertBus.PublishAsync(new AlertEvent
+            {
+                EventType = eventType,
+                Source = "agent",
+                Severity = severity,
+                Title = title,
+                Message = message,
+                DeviceName = agent.Name,
+                DeviceIp = agent.LanIp,
+                SiteSlug = siteSlug == SiteManagementService.DefaultSiteSlug ? null : siteSlug
+            }, ct);
+            _logger.LogInformation("Published {EventType} for agent {Name} (site {Site})",
+                eventType, agent.Name, siteSlug);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to publish {EventType} for agent {Name}", eventType, agent.Name);
+        }
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/AgentEnrollmentService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentEnrollmentService.cs
@@ -145,6 +145,26 @@ public class AgentEnrollmentService
         agent.UpdatedAt = DateTime.UtcNow;
         await db.SaveChangesAsync();
 
+        // The startup seed skips On-Site Agent alert rules while the default site has
+        // no agent; the first default-site enrollment is the moment they become relevant.
+        if (site.Slug == SiteManagementService.DefaultSiteSlug)
+        {
+            var agentRuleDefaults = NetworkOptimizer.Alerts.DefaultAlertRules.GetDefaults()
+                .Where(r => r.Source == "agent")
+                .ToList();
+            var existingPatterns = await db.AlertRules
+                .Where(r => r.Source == "agent")
+                .Select(r => r.EventTypePattern)
+                .ToListAsync();
+            var missingRules = agentRuleDefaults.Where(d => !existingPatterns.Contains(d.EventTypePattern)).ToList();
+            if (missingRules.Count > 0)
+            {
+                db.AlertRules.AddRange(missingRules);
+                await db.SaveChangesAsync();
+                _logger.LogInformation("Seeded {Count} On-Site Agent alert rule(s) for the default site", missingRules.Count);
+            }
+        }
+
         _logger.LogInformation("Agent {Name} (id {Id}) enrolled for site {Slug}", agent.Name, agent.Id, site.Slug);
         return (true, key, site.Slug, null);
     }

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionRegistry.cs
@@ -53,6 +53,17 @@ public class MonitoringCollectionRegistry : BackgroundService
     /// <summary>The default site's collection agent.</summary>
     public MonitoringCollectionAgent GetDefault() => GetFor(SiteManagementService.DefaultSiteSlug);
 
+    /// <summary>
+    /// Stops and forgets a site's collection instance immediately (site disabled or
+    /// removed) instead of waiting for the next reconcile pass - a removal deletes
+    /// the site's database files right after, so its loops must be down first.
+    /// </summary>
+    public async Task StopForSiteAsync(string slug, CancellationToken ct = default)
+    {
+        await StopInstanceAsync(slug, ct);
+        _instances.TryRemove(slug, out _);
+    }
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         // The default site collects from startup (pre-multi-site behavior) unless

--- a/src/NetworkOptimizer.Web/Services/SiteConnectionRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/SiteConnectionRegistry.cs
@@ -29,6 +29,16 @@ public class SiteConnectionRegistry : IDisposable
     /// <summary>The default site's connection.</summary>
     public UniFiConnectionService GetDefault() => GetFor(SiteManagementService.DefaultSiteSlug);
 
+    /// <summary>
+    /// Disposes and forgets a site's connection (site disabled or removed).
+    /// A later GetFor recreates it fresh - e.g. when the site is re-enabled.
+    /// </summary>
+    public void RemoveFor(string slug)
+    {
+        if (_connections.TryRemove(slug, out var connection))
+            connection.DisposeOwned();
+    }
+
     public void Dispose()
     {
         foreach (var connection in _connections.Values)

--- a/src/NetworkOptimizer.Web/Services/SiteManagementService.cs
+++ b/src/NetworkOptimizer.Web/Services/SiteManagementService.cs
@@ -23,6 +23,7 @@ public class SiteManagementService
     private readonly Licensing.LicenseActivationService _activation;
     private readonly SiteConnectionRegistry _siteConnections;
     private readonly MonitoringCollectionRegistry _collectionRegistry;
+    private readonly SiteRegistryChangeNotifier _changeNotifier;
     private readonly ILogger<SiteManagementService> _logger;
 
     public SiteManagementService(
@@ -33,6 +34,7 @@ public class SiteManagementService
         Licensing.LicenseActivationService activation,
         SiteConnectionRegistry siteConnections,
         MonitoringCollectionRegistry collectionRegistry,
+        SiteRegistryChangeNotifier changeNotifier,
         ILogger<SiteManagementService> logger)
     {
         _siteRepository = siteRepository;
@@ -42,6 +44,7 @@ public class SiteManagementService
         _activation = activation;
         _siteConnections = siteConnections;
         _collectionRegistry = collectionRegistry;
+        _changeNotifier = changeNotifier;
         _logger = logger;
     }
 
@@ -90,6 +93,7 @@ public class SiteManagementService
         // when the license snapshot is unchanged (e.g. the main site was already covered),
         // so force subscribers to reload rather than relying on a snapshot diff.
         await _licenseState.RecomputeAsync(alwaysNotify: true);
+        _changeNotifier.NotifySitesChanged();
         _logger.LogInformation("Multi-site management {State}", enabled ? "enabled" : "disabled");
     }
 
@@ -126,7 +130,11 @@ public class SiteManagementService
     }
 
     /// <summary>Updates a site's mutable fields (name, enabled, sort order, notes).</summary>
-    public Task UpdateSiteAsync(Site site) => _siteRepository.UpdateAsync(site);
+    public async Task UpdateSiteAsync(Site site)
+    {
+        await _siteRepository.UpdateAsync(site);
+        _changeNotifier.NotifySitesChanged();
+    }
 
     /// <summary>
     /// Enables or disables a secondary site. Disabling stops its monitoring
@@ -150,6 +158,7 @@ public class SiteManagementService
         // pass picks the site up within its cadence, and the next page view or
         // agent connect re-establishes the console connection.
 
+        _changeNotifier.NotifySitesChanged();
         _logger.LogInformation("Site {Slug} {State}", site.Slug, enabled ? "enabled" : "disabled");
     }
 
@@ -194,6 +203,7 @@ public class SiteManagementService
 
         // Free the site's license seat.
         await _licenseState.RecomputeAsync();
+        _changeNotifier.NotifySitesChanged();
         _logger.LogInformation("Removed site {Slug} (id {Id}) and its data", site.Slug, site.Id);
     }
 
@@ -230,6 +240,7 @@ public class SiteManagementService
         // Licensing card reflects the new site immediately (no manual license refresh needed).
         await _activation.AutoAssignAsync();
         await _licenseState.RecomputeAsync();
+        _changeNotifier.NotifySitesChanged();
         return site;
     }
 

--- a/src/NetworkOptimizer.Web/Services/SiteManagementService.cs
+++ b/src/NetworkOptimizer.Web/Services/SiteManagementService.cs
@@ -21,6 +21,8 @@ public class SiteManagementService
     private readonly SiteDatabasePaths _dbPaths;
     private readonly Licensing.LicenseStateService _licenseState;
     private readonly Licensing.LicenseActivationService _activation;
+    private readonly SiteConnectionRegistry _siteConnections;
+    private readonly MonitoringCollectionRegistry _collectionRegistry;
     private readonly ILogger<SiteManagementService> _logger;
 
     public SiteManagementService(
@@ -29,6 +31,8 @@ public class SiteManagementService
         SiteDatabasePaths dbPaths,
         Licensing.LicenseStateService licenseState,
         Licensing.LicenseActivationService activation,
+        SiteConnectionRegistry siteConnections,
+        MonitoringCollectionRegistry collectionRegistry,
         ILogger<SiteManagementService> logger)
     {
         _siteRepository = siteRepository;
@@ -36,6 +40,8 @@ public class SiteManagementService
         _dbPaths = dbPaths;
         _licenseState = licenseState;
         _activation = activation;
+        _siteConnections = siteConnections;
+        _collectionRegistry = collectionRegistry;
         _logger = logger;
     }
 
@@ -121,6 +127,75 @@ public class SiteManagementService
 
     /// <summary>Updates a site's mutable fields (name, enabled, sort order, notes).</summary>
     public Task UpdateSiteAsync(Site site) => _siteRepository.UpdateAsync(site);
+
+    /// <summary>
+    /// Enables or disables a secondary site. Disabling stops its monitoring
+    /// collection and drops its console connection immediately and hides it from
+    /// the site switcher; all of its data is kept and re-enabling restores it.
+    /// </summary>
+    public async Task SetSiteEnabledAsync(Site site, bool enabled)
+    {
+        if (site.IsDefault)
+            throw new InvalidOperationException("The default site cannot be disabled.");
+
+        site.Enabled = enabled;
+        await _siteRepository.UpdateAsync(site);
+
+        if (!enabled)
+        {
+            await _collectionRegistry.StopForSiteAsync(site.Slug);
+            _siteConnections.RemoveFor(site.Slug);
+        }
+        // Re-enable needs no explicit start: the collection registry's reconcile
+        // pass picks the site up within its cadence, and the next page view or
+        // agent connect re-establishes the console connection.
+
+        _logger.LogInformation("Site {Slug} {State}", site.Slug, enabled ? "enabled" : "disabled");
+    }
+
+    /// <summary>
+    /// Permanently removes a secondary site: stops its monitoring collection,
+    /// drops its console connection, deletes its agents and registry row, and
+    /// deletes its database directory. Irreversible.
+    /// </summary>
+    public async Task DeleteSiteAsync(Site site)
+    {
+        if (site.IsDefault)
+            throw new InvalidOperationException("The default site cannot be removed.");
+
+        // Disable first so the reconcile pass can't restart collection between
+        // the stop below and the registry row disappearing.
+        site.Enabled = false;
+        await _siteRepository.UpdateAsync(site);
+        await _collectionRegistry.StopForSiteAsync(site.Slug);
+        _siteConnections.RemoveFor(site.Slug);
+
+        await using (var db = await _mainDbFactory.CreateDbContextAsync())
+        {
+            await db.SiteAgents.Where(a => a.SiteId == site.Id).ExecuteDeleteAsync();
+        }
+        await _siteRepository.DeleteAsync(site.Id);
+
+        // SQLite connection pooling keeps file handles open after the contexts are
+        // disposed; clear the pools so the directory delete doesn't hit locked files.
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        try
+        {
+            var dir = _dbPaths.GetSiteDataDir(site.Slug);
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Site {Slug} was removed but its data directory could not be deleted; remove sites/{Slug} manually",
+                site.Slug, site.Slug);
+        }
+
+        // Free the site's license seat.
+        await _licenseState.RecomputeAsync();
+        _logger.LogInformation("Removed site {Slug} (id {Id}) and its data", site.Slug, site.Id);
+    }
 
     /// <summary>
     /// Previews the slug that would be generated for a site name, including

--- a/src/NetworkOptimizer.Web/Services/SiteRegistryChangeNotifier.cs
+++ b/src/NetworkOptimizer.Web/Services/SiteRegistryChangeNotifier.cs
@@ -1,0 +1,16 @@
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// App-wide broadcast for site registry changes (create, rename, enable/disable,
+/// remove, multi-site toggle). SiteManagementService raises it; live UI that
+/// renders the site list (the site switcher in every open circuit) subscribes and
+/// rebuilds. A singleton because the publisher and subscribers live in different
+/// circuits/scopes. Handlers are invoked on the publisher's thread - subscribers
+/// must marshal to their own dispatcher (InvokeAsync) before touching state.
+/// </summary>
+public class SiteRegistryChangeNotifier
+{
+    public event Action? SitesChanged;
+
+    public void NotifySitesChanged() => SitesChanged?.Invoke();
+}

--- a/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using NetworkOptimizer.Alerts.Events;
+using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Core.Helpers;
 using NetworkOptimizer.Core.Interfaces;
 using NetworkOptimizer.Storage.Interfaces;
@@ -39,6 +41,18 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     private bool _isConnected;
     private string? _lastError;
     private DateTime? _lastConnectedAt;
+
+    // Console connection alerting: armed after the first successful auth so setup-time
+    // failures never alert; fires once per outage after two consecutive failed auth
+    // probes spanning at least the minimum window (so second-scale cookie re-login
+    // bursts and single blips during provisioning restarts stay silent).
+    private IAlertEventBus? _alertBus;
+    private bool _consoleAlertArmed;
+    private bool _consoleAlertActive;
+    private int _consecutiveAuthFailures;
+    private DateTime _firstAuthFailureAt;
+    private readonly object _consoleAlertLock = new();
+    private static readonly TimeSpan ConsoleFailureMinWindow = TimeSpan.FromSeconds(50);
 
     // Cache to avoid repeated DB queries
     private DateTime _cacheTime = DateTime.MinValue;
@@ -95,6 +109,99 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
         var scope = _serviceProvider.CreateScope();
         scope.ServiceProvider.GetRequiredService<SiteContextService>().OverrideSite(SiteSlug);
         return scope;
+    }
+
+    /// <summary>
+    /// Tracks auth probe outcomes from the API client (login attempts and the API-key
+    /// revalidation probes) and raises console connection alerts. Suppressed until the
+    /// first successful connection and while the site's agent tunnel is still coming up.
+    /// </summary>
+    private void HandleAuthProbe(bool success, string? error)
+    {
+        bool publishFailed = false, publishRestored = false;
+        lock (_consoleAlertLock)
+        {
+            if (success)
+            {
+                if (_consoleAlertActive)
+                {
+                    _consoleAlertActive = false;
+                    publishRestored = true;
+                }
+                _consoleAlertArmed = true;
+                _consecutiveAuthFailures = 0;
+            }
+            else
+            {
+                if (!_consoleAlertArmed || IsAwaitingAgent)
+                    return;
+
+                if (_consecutiveAuthFailures == 0)
+                    _firstAuthFailureAt = DateTime.UtcNow;
+                _consecutiveAuthFailures++;
+
+                if (!_consoleAlertActive
+                    && _consecutiveAuthFailures >= 2
+                    && DateTime.UtcNow - _firstAuthFailureAt >= ConsoleFailureMinWindow)
+                {
+                    _consoleAlertActive = true;
+                    publishFailed = true;
+                }
+            }
+        }
+
+        if (publishFailed)
+        {
+            PublishConsoleAlert("console.connection_failed", AlertSeverity.Warning,
+                "UniFi Console connection failed",
+                $"Repeated attempts to authenticate with the UniFi Console have failed. Features that read the console API (Wi-Fi Optimizer, Config Optimizer, Security Audit, Threat Intelligence) are unavailable until it recovers. Last error: {error ?? "unknown"}");
+        }
+        if (publishRestored)
+        {
+            PublishConsoleAlert("console.connection_restored", AlertSeverity.Info,
+                "UniFi Console connection restored",
+                "The connection to the UniFi Console has recovered.");
+        }
+    }
+
+    /// <summary>
+    /// Clears the consecutive-failure count on intentional teardown (manual disconnect,
+    /// agent tunnel drop) so failures from before the teardown can't pair with a failure
+    /// from a later reconnect attempt and fire a spurious alert. Keeps the active-alert
+    /// flag so a restore still pairs with an already-published failure.
+    /// </summary>
+    private void ResetConsoleFailureCount()
+    {
+        lock (_consoleAlertLock)
+        {
+            _consecutiveAuthFailures = 0;
+        }
+    }
+
+    private void PublishConsoleAlert(string eventType, AlertSeverity severity, string title, string message)
+    {
+        try
+        {
+            var bus = _alertBus ??= _serviceProvider.GetService<IAlertEventBus>();
+            if (bus == null)
+                return;
+
+            var evt = new AlertEvent
+            {
+                EventType = eventType,
+                Source = "console",
+                Severity = severity,
+                Title = title,
+                Message = message,
+                SiteSlug = SiteSlug == SiteManagementService.DefaultSiteSlug ? null : SiteSlug
+            };
+            _ = Task.Run(() => bus.PublishAsync(evt).AsTask());
+            _logger.LogInformation("Published {EventType} alert event for site {Site}", eventType, SiteSlug);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to publish console connection alert event");
+        }
     }
 
     /// <summary>Per-site setting key: reach this site's console through its agent tunnel.</summary>
@@ -223,6 +330,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
         _isConnected = false;
         _awaitingAgent = true;
         _lastError = AwaitingAgentMessage;
+        ResetConsoleFailureCount();
         OnConnectionChanged?.Invoke();
     }
 
@@ -251,6 +359,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
         _isConnected = false;
         _awaitingAgent = true;
         _lastError = AwaitingAgentMessage;
+        ResetConsoleFailureCount();
         OnConnectionChanged?.Invoke();
     }
 
@@ -562,6 +671,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
                 config.IgnoreControllerSSLErrors || viaAgent,
                 config.ApiKey
             );
+            _client.AuthProbeCompleted += HandleAuthProbe;
 
             // Attempt to authenticate
             var success = await _client.LoginAsync();
@@ -690,6 +800,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
                 config.IgnoreControllerSSLErrors || viaAgent,
                 config.ApiKey
             );
+            _client.AuthProbeCompleted += HandleAuthProbe;
 
             var success = await _client.LoginAsync(cts.Token);
 
@@ -865,6 +976,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
         }
 
         _isConnected = false;
+        ResetConsoleFailureCount();
         ClearCaches();
         _logger.LogInformation("Disconnected from UniFi controller");
         OnConnectionChanged?.Invoke();

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2435,7 +2435,7 @@ select.form-control {
 .form-help {
     display: block;
     margin-top: 0.25rem;
-    font-size: 0.75rem;
+    font-size: 0.8rem;
     color: var(--text-muted);
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -127,6 +127,35 @@
         window.location.assign(link.href);
     }, false);
 
+    // Keyboard navigation for the header site switcher menu: Down/Up move focus
+    // through the items (Down from the trigger enters the list), Enter activates
+    // natively (anchor click lands in the site-switch handler above), and Space
+    // activates too per the ARIA menu pattern - menu items respond to both keys
+    // even though bare links are Enter-only. Escape close lives in the Blazor
+    // component, which owns the open state.
+    document.addEventListener('keydown', function (e) {
+        const host = e.target.closest && e.target.closest('.site-switcher');
+        if (!host)
+            return;
+        const menu = host.querySelector('.site-switcher-menu');
+        if (!menu)
+            return;
+        const items = Array.from(menu.querySelectorAll('a[href]'));
+        if (items.length === 0)
+            return;
+        const idx = items.indexOf(document.activeElement);
+        if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+            e.preventDefault();
+            const next = e.key === 'ArrowDown'
+                ? (idx + 1) % items.length
+                : (idx <= 0 ? items.length - 1 : idx - 1);
+            items[next].focus();
+        } else if (e.key === ' ' && idx >= 0) {
+            e.preventDefault();
+            items[idx].click();
+        }
+    }, false);
+
     const originalFetch = window.fetch;
     window.fetch = function (input, init) {
         try {


### PR DESCRIPTION
Fixes #986
Fixes #982

## Settings - Connection

- **API key connections now self-heal after a UniFi Network application restart or upgrade** - While the Network application is restarting, upgrading, or wedged, its proxy answers API calls with 401/403 even though the key is still valid. The client treated any auth failure in API key mode as a revoked key and permanently stopped calling the console - every feature that reads the API (Wi-Fi Optimizer, Config Optimizer, Security Audit, Threat Intelligence, SNMP detection) went dark until the app was restarted or the connection re-saved. The client now re-validates the key instead, throttled to one probe per minute so a genuinely revoked key stays cheap, and recovers on its own within a minute of the console coming back.

Username/password (cookie) authentication is unaffected - it already re-logged in on auth failures.

## Multi-Site

- **Disable / Remove Site** - New third section in a site's Configuration panel (Settings - Multi-Site), alongside Agent and Settings. Disable stops the site's monitoring and console connection immediately and hides it from the site switcher and Sites views; all data is kept and the site can be re-enabled in place (no confirmation needed to re-enable). Remove is permanent, behind a double confirmation: it deletes the site, its database, and its agent enrollments, and frees the license seat. InfluxDB buckets are left in place (deleting them needs the admin token, which is never stored) and the confirmation says so. Both actions are blocked for the default site and for the site you're currently viewing.
- **Create Site responsiveness** - Two fixes for the accidental duplicate site from #982: the spinner/disabled state now actually renders during the multi-second provisioning (SQLite completes EF's async calls synchronously, so the render never flushed before), and a re-entrancy guard swallows the double-click that previously created a "-2" copy.
- **Add Site jumps to the form** - The + card on the Sites page now lands on the add form scrolled into view with the name field focused, instead of just opening the Multi-Site settings tab.
- **Site switcher stays current** - The switcher rebuilds in every open tab when sites are created, renamed, enabled/disabled, or removed, instead of waiting for a page reload.
- **Site switcher keyboard support** - Escape closes the dropdown, Up/Down arrows move through the sites (Down from the trigger enters the list), and Enter or Space selects. Tab and Shift+Tab keep their native behavior.

## Alerts & Schedule - Rules

- **New UniFi Console event types** - `console.connection_failed` (Warning) fires after two consecutive failed authentication attempts spanning at least the revalidation interval, and `console.connection_restored` (Info) fires when the connection recovers. Per-site, armed only after a successful connection (setup-time failures never alert), suppressed while a site's agent tunnel is still coming up, and a 30-minute failure cooldown keeps a flapping console upgrade to a single alert.
- **New On-Site Agent event types** - `agent.offline` (Warning) fires when an enrolled agent has been continuously offline for 3 minutes, and `agent.reconnected` (Info) pairs with it when the agent comes back. Offline is judged by the same live definition the UI uses (open tunnel or fresh heartbeat) via a periodic sweep, so agent redeploys and brief tunnel bounces stay silent. Agents that have never connected, are disabled, or belong to a disabled site don't alert.
- **Seeding** - Default rules seed on startup, and at site creation for new sites. The On-Site Agent rules skip the main site unless the default site has its own agent (enrolling one seeds them at that moment), so single-site installs don't see agent rules they can't use. All four types are listed in the event type patterns catalog, and alerts deliver through all existing Notification Channels.

## Fixes

- **Form help text legibility** - Bumped from 0.75rem to 0.8rem across settings forms.

**Workaround for the #986 wedge on older versions:** re-save the connection in Settings - Connection (a plain Test Connection is not enough - it tests with a separate temporary client).

