### PR TITLE
Starlink monitoring: dashboard card, Monitoring - Starlink Stats tab, and ISP Health scoring

### DIFF
--- a/src/NetworkOptimizer.Monitoring/Models/StarlinkObstructionMap.cs
+++ b/src/NetworkOptimizer.Monitoring/Models/StarlinkObstructionMap.cs
@@ -1,0 +1,28 @@
+namespace NetworkOptimizer.Monitoring.Models;
+
+/// <summary>
+/// The dish's obstruction sky map: a square grid of per-patch SNR samples in
+/// the dish reference frame. Values are 0..1 SNR quality, or -1 for patches
+/// the dish has not yet measured. Rendered client-side as the familiar
+/// sky-dome view; never persisted to time series.
+/// </summary>
+public class StarlinkObstructionMap
+{
+    /// <summary>When the map was fetched (UTC)</summary>
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+
+    /// <summary>Grid rows</summary>
+    public int NumRows { get; set; }
+
+    /// <summary>Grid columns</summary>
+    public int NumCols { get; set; }
+
+    /// <summary>Row-major SNR samples, length NumRows * NumCols; -1 = unmeasured</summary>
+    public float[] Snr { get; set; } = Array.Empty<float>();
+
+    /// <summary>Angular radius of the map from boresight, degrees</summary>
+    public double MaxThetaDeg { get; set; }
+
+    /// <summary>Reference frame the map is expressed in (e.g. "FRAME_UT")</summary>
+    public string? ReferenceFrame { get; set; }
+}

--- a/src/NetworkOptimizer.Monitoring/Models/StarlinkStats.cs
+++ b/src/NetworkOptimizer.Monitoring/Models/StarlinkStats.cs
@@ -1,0 +1,108 @@
+namespace NetworkOptimizer.Monitoring.Models;
+
+/// <summary>
+/// Snapshot of a Starlink user terminal's health, taken from the dish's local
+/// gRPC status API. Link latency/throughput are deliberately absent - the
+/// Monitoring pipeline already measures RTT and WAN throughput with better
+/// fidelity; this model carries what only the dish can report.
+/// </summary>
+public class StarlinkStats
+{
+    /// <summary>When these stats were collected (UTC)</summary>
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+
+    // Device identity
+    /// <summary>Terminal ID (e.g. "ut01234567-...")</summary>
+    public string? DeviceId { get; set; }
+    /// <summary>Hardware revision (e.g. "rev4_panda_prod1")</summary>
+    public string? HardwareVersion { get; set; }
+    /// <summary>Firmware version string</summary>
+    public string? SoftwareVersion { get; set; }
+    /// <summary>ISO country code the terminal reports</summary>
+    public string? CountryCode { get; set; }
+    /// <summary>Number of boots the terminal has recorded</summary>
+    public int? BootCount { get; set; }
+    /// <summary>Seconds since the dish last booted</summary>
+    public long? UptimeSeconds { get; set; }
+
+    // Physical link
+    /// <summary>Negotiated Ethernet speed between dish and router/LAN, Mbps</summary>
+    public int? EthSpeedMbps { get; set; }
+    /// <summary>Instantaneous power draw in watts (heater spikes show here)</summary>
+    public double? PowerInWatts { get; set; }
+    /// <summary>Average power draw over the samples since the previous poll, watts</summary>
+    public double? PowerInAvgWatts { get; set; }
+    /// <summary>Peak power draw over the samples since the previous poll, watts</summary>
+    public double? PowerInMaxWatts { get; set; }
+
+    // Obstruction
+    /// <summary>Fraction of sky time obstructed (0..1)</summary>
+    public double? FractionObstructed { get; set; }
+    /// <summary>Whether the dish considers itself obstructed right now</summary>
+    public bool? CurrentlyObstructed { get; set; }
+    /// <summary>Seconds of valid obstruction measurement backing FractionObstructed</summary>
+    public double? ObstructionValidSeconds { get; set; }
+    /// <summary>Average duration of prolonged obstructions, seconds (null when the dish has none to report)</summary>
+    public double? AvgProlongedObstructionDurationSeconds { get; set; }
+
+    // Signal / positioning
+    /// <summary>Whether SNR is above the noise floor</summary>
+    public bool? IsSnrAboveNoiseFloor { get; set; }
+    /// <summary>Whether the dish reports persistently low SNR</summary>
+    public bool? IsSnrPersistentlyLow { get; set; }
+    /// <summary>Whether GPS has a valid fix</summary>
+    public bool? GpsValid { get; set; }
+    /// <summary>Number of GPS satellites in the solution</summary>
+    public int? GpsSatellites { get; set; }
+    /// <summary>Dish mechanical tilt from vertical, degrees</summary>
+    public double? TiltAngleDeg { get; set; }
+    /// <summary>Current boresight azimuth, degrees</summary>
+    public double? BoresightAzimuthDeg { get; set; }
+    /// <summary>Current boresight elevation, degrees</summary>
+    public double? BoresightElevationDeg { get; set; }
+    /// <summary>Desired boresight azimuth, degrees</summary>
+    public double? DesiredBoresightAzimuthDeg { get; set; }
+    /// <summary>Desired boresight elevation, degrees</summary>
+    public double? DesiredBoresightElevationDeg { get; set; }
+    /// <summary>Attitude estimate uncertainty, degrees</summary>
+    public double? AttitudeUncertaintyDeg { get; set; }
+
+    // Loss seen by the dish itself (to its ground station), from the 1 Hz
+    // history ring buffer, aggregated over the samples since the previous poll
+    /// <summary>Mean pop ping drop rate (0..1) since the previous poll</summary>
+    public double? PingDropRateAvg { get; set; }
+    /// <summary>Worst 1-second pop ping drop rate (0..1) since the previous poll</summary>
+    public double? PingDropRateMax { get; set; }
+
+    // Outages (from the dish's outage log)
+    /// <summary>Outages recorded in the samples since the previous poll</summary>
+    public int OutageCountDelta { get; set; }
+    /// <summary>Total outage seconds in the samples since the previous poll</summary>
+    public double OutageSecondsDelta { get; set; }
+    /// <summary>Cause of the most recent outage (e.g. "NO_PINGS", "OBSTRUCTED")</summary>
+    public string? LastOutageCause { get; set; }
+    /// <summary>Start of the most recent outage (UTC)</summary>
+    public DateTime? LastOutageAt { get; set; }
+    /// <summary>Duration of the most recent outage, seconds</summary>
+    public double? LastOutageDurationSeconds { get; set; }
+
+    // Service state
+    /// <summary>Names of alerts currently raised by the dish (empty when healthy)</summary>
+    public List<string> ActiveAlerts { get; set; } = new();
+    /// <summary>Terminal disablement code ("OKAY" when in service)</summary>
+    public string? DisablementCode { get; set; }
+    /// <summary>Software update state (e.g. "IDLE", "FETCHING", "REBOOT_REQUIRED")</summary>
+    public string? SoftwareUpdateState { get; set; }
+    /// <summary>Mobility class (e.g. "STATIONARY", "MOBILE")</summary>
+    public string? MobilityClass { get; set; }
+    /// <summary>Service plan class (e.g. "CONSUMER", "BUSINESS")</summary>
+    public string? ClassOfService { get; set; }
+    /// <summary>Why downlink bandwidth is being limited (e.g. "NO_LIMIT", "POLICY_LIMIT")</summary>
+    public string? DownlinkRestrictedReason { get; set; }
+    /// <summary>Why uplink bandwidth is being limited</summary>
+    public string? UplinkRestrictedReason { get; set; }
+    /// <summary>Hardware self-test result from diagnostics ("PASSED"/"FAILED"), null if unavailable</summary>
+    public string? HardwareSelfTest { get; set; }
+    /// <summary>Failing self-test codes when HardwareSelfTest is "FAILED"</summary>
+    public List<string> HardwareSelfTestCodes { get; set; } = new();
+}

--- a/src/NetworkOptimizer.Monitoring/Providers/IStarlinkProvider.cs
+++ b/src/NetworkOptimizer.Monitoring/Providers/IStarlinkProvider.cs
@@ -1,0 +1,49 @@
+using NetworkOptimizer.Monitoring.Models;
+
+namespace NetworkOptimizer.Monitoring.Providers;
+
+/// <summary>
+/// Strategy interface for polling Starlink user terminal stats.
+/// Implementations encapsulate the transport (the dish's local gRPC API)
+/// so StarlinkMonitorService stays transport-agnostic.
+/// </summary>
+public interface IStarlinkProvider
+{
+    /// <summary>
+    /// Stable identifier used to resolve a provider for a configured terminal.
+    /// Lowercase, hyphenated (e.g. "starlink-grpc").
+    /// Must be unique across providers.
+    /// </summary>
+    string ProviderKey { get; }
+
+    /// <summary>
+    /// Human-readable name shown in the UI and logs.
+    /// </summary>
+    string DisplayName { get; }
+
+    /// <summary>
+    /// Poll the terminal and return its current stats.
+    /// Implementations should log internally and return null on transport
+    /// or parsing failure; throwing is reserved for programming errors.
+    /// </summary>
+    Task<StarlinkStats?> PollAsync(
+        StarlinkPollContext context,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Fetch the dish's obstruction sky map. Larger payload than a status
+    /// poll, so callers fetch it on a slower cadence than PollAsync.
+    /// Returns null on transport failure.
+    /// </summary>
+    Task<StarlinkObstructionMap?> GetObstructionMapAsync(
+        StarlinkPollContext context,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Verify connectivity without performing a full poll.
+    /// Used by the Settings page Test button.
+    /// </summary>
+    Task<(bool Success, string Message)> TestConnectionAsync(
+        StarlinkPollContext context,
+        CancellationToken cancellationToken = default);
+}

--- a/src/NetworkOptimizer.Monitoring/Providers/StarlinkPollContext.cs
+++ b/src/NetworkOptimizer.Monitoring/Providers/StarlinkPollContext.cs
@@ -1,0 +1,23 @@
+namespace NetworkOptimizer.Monitoring.Providers;
+
+/// <summary>
+/// Provider-agnostic poll context for Starlink terminal providers.
+/// Decouples IStarlinkProvider from Storage/EF concerns.
+/// </summary>
+public sealed record StarlinkPollContext
+{
+    /// <summary>Configuration ID for caching keys and diagnostics.</summary>
+    public required int Id { get; init; }
+
+    /// <summary>Friendly name for logs and UI.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Host or IP of the dish's gRPC endpoint. On agent-routed sites this is the tunnel-proxy loopback endpoint, not the dish's own address.</summary>
+    public required string Host { get; init; }
+
+    /// <summary>The configured device host before any tunnel-proxy rewrite; use for logs so failures name the real device.</summary>
+    public string? ConfiguredHost { get; init; }
+
+    /// <summary>gRPC port; 0 means provider default (9200).</summary>
+    public int Port { get; init; }
+}

--- a/src/NetworkOptimizer.Storage/Interfaces/IStarlinkRepository.cs
+++ b/src/NetworkOptimizer.Storage/Interfaces/IStarlinkRepository.cs
@@ -1,0 +1,15 @@
+using NetworkOptimizer.Storage.Models;
+
+namespace NetworkOptimizer.Storage.Interfaces;
+
+/// <summary>
+/// Repository for Starlink terminal configurations
+/// </summary>
+public interface IStarlinkRepository
+{
+    Task<List<StarlinkConfiguration>> GetStarlinkConfigurationsAsync(CancellationToken cancellationToken = default);
+    Task<List<StarlinkConfiguration>> GetEnabledStarlinkConfigurationsAsync(CancellationToken cancellationToken = default);
+    Task<StarlinkConfiguration?> GetStarlinkConfigurationAsync(int id, CancellationToken cancellationToken = default);
+    Task SaveStarlinkConfigurationAsync(StarlinkConfiguration config, CancellationToken cancellationToken = default);
+    Task DeleteStarlinkConfigurationAsync(int id, CancellationToken cancellationToken = default);
+}

--- a/src/NetworkOptimizer.Storage/Migrations/20260716021353_AddStarlinkConfigurations.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260716021353_AddStarlinkConfigurations.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260716021353_AddStarlinkConfigurations")]
+    partial class AddStarlinkConfigurations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");
@@ -1611,10 +1614,6 @@ namespace NetworkOptimizer.Storage.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("INTEGER");
 
-                    b.Property<string>("AliasIp")
-                        .HasMaxLength(64)
-                        .HasColumnType("TEXT");
-
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("TEXT");
 
@@ -1666,16 +1665,10 @@ namespace NetworkOptimizer.Storage.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("AliasIp")
-                        .IsUnique();
-
-                    b.HasIndex("GatewayLocalIp")
-                        .IsUnique();
-
-                    b.HasIndex("Name")
-                        .IsUnique();
-
                     b.HasIndex("TargetIp");
+
+                    b.HasIndex("WanIfName", "Name")
+                        .IsUnique();
 
                     b.ToTable("MonitoringInterfaces", (string)null);
                 });

--- a/src/NetworkOptimizer.Storage/Migrations/20260716021353_AddStarlinkConfigurations.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260716021353_AddStarlinkConfigurations.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStarlinkConfigurations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "StarlinkConfigurations",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 100, nullable: false),
+                    Provider = table.Column<string>(type: "TEXT", maxLength: 50, nullable: false),
+                    Host = table.Column<string>(type: "TEXT", maxLength: 255, nullable: false),
+                    Port = table.Column<int>(type: "INTEGER", nullable: false),
+                    Enabled = table.Column<bool>(type: "INTEGER", nullable: false),
+                    PollingIntervalSeconds = table.Column<int>(type: "INTEGER", nullable: false),
+                    LastPolled = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    LastError = table.Column<string>(type: "TEXT", maxLength: 1000, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StarlinkConfigurations", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StarlinkConfigurations_Enabled",
+                table: "StarlinkConfigurations",
+                column: "Enabled");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StarlinkConfigurations_Host",
+                table: "StarlinkConfigurations",
+                column: "Host");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "StarlinkConfigurations");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/NetworkOptimizerDbContext.cs
+++ b/src/NetworkOptimizer.Storage/Models/NetworkOptimizerDbContext.cs
@@ -59,6 +59,7 @@ public class NetworkOptimizerDbContext : DbContext
     public DbSet<OuiVendor> OuiVendors { get; set; }
     public DbSet<CmConfiguration> CmConfigurations { get; set; }
     public DbSet<OntConfiguration> OntConfigurations { get; set; }
+    public DbSet<StarlinkConfiguration> StarlinkConfigurations { get; set; }
     public DbSet<MonitoringInterface> MonitoringInterfaces { get; set; }
     public DbSet<CustomOidConfiguration> CustomOidConfigurations { get; set; }
     public DbSet<ApChannelOutcome> ApChannelOutcomes { get; set; }
@@ -159,6 +160,14 @@ public class NetworkOptimizerDbContext : DbContext
         modelBuilder.Entity<OntConfiguration>(entity =>
         {
             entity.ToTable("OntConfigurations");
+            entity.HasIndex(e => e.Host);
+            entity.HasIndex(e => e.Enabled);
+        });
+
+        // StarlinkConfiguration configuration
+        modelBuilder.Entity<StarlinkConfiguration>(entity =>
+        {
+            entity.ToTable("StarlinkConfigurations");
             entity.HasIndex(e => e.Host);
             entity.HasIndex(e => e.Enabled);
         });

--- a/src/NetworkOptimizer.Storage/Models/StarlinkConfiguration.cs
+++ b/src/NetworkOptimizer.Storage/Models/StarlinkConfiguration.cs
@@ -1,0 +1,53 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace NetworkOptimizer.Storage.Models;
+
+/// <summary>
+/// Configuration for a Starlink user terminal polled over its local gRPC API.
+/// The Provider column routes to the matching IStarlinkProvider.
+/// </summary>
+public class StarlinkConfiguration
+{
+    [Key]
+    public int Id { get; set; }
+
+    /// <summary>Friendly name for this terminal (e.g., "Starlink Roof")</summary>
+    [Required]
+    [MaxLength(100)]
+    public string Name { get; set; } = "";
+
+    /// <summary>
+    /// Provider key (e.g. "starlink-grpc") that selects which
+    /// IStarlinkProvider handles this terminal.
+    /// </summary>
+    [Required]
+    [MaxLength(50)]
+    public string Provider { get; set; } = "starlink-grpc";
+
+    /// <summary>Hostname or IP of the dish's gRPC endpoint (192.168.100.1 on a stock install)</summary>
+    [Required]
+    [MaxLength(255)]
+    public string Host { get; set; } = "192.168.100.1";
+
+    /// <summary>gRPC port (default 9200)</summary>
+    public int Port { get; set; } = 9200;
+
+    /// <summary>Whether this terminal is enabled for polling</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>Polling interval in seconds (default 60)</summary>
+    public int PollingIntervalSeconds { get; set; } = 60;
+
+    /// <summary>Last successful poll timestamp</summary>
+    public DateTime? LastPolled { get; set; }
+
+    /// <summary>Last poll error message (null if successful)</summary>
+    [MaxLength(1000)]
+    public string? LastError { get; set; }
+
+    /// <summary>When this configuration was created</summary>
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>When this configuration was last updated</summary>
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/NetworkOptimizer.Storage/Repositories/StarlinkRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/StarlinkRepository.cs
@@ -1,0 +1,126 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NetworkOptimizer.Storage.Interfaces;
+using NetworkOptimizer.Storage.Models;
+
+namespace NetworkOptimizer.Storage.Repositories;
+
+/// <summary>
+/// Repository for Starlink terminal configurations
+/// </summary>
+public class StarlinkRepository : IStarlinkRepository
+{
+    private readonly NetworkOptimizerDbContext _context;
+    private readonly ILogger<StarlinkRepository> _logger;
+
+    public StarlinkRepository(NetworkOptimizerDbContext context, ILogger<StarlinkRepository> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<List<StarlinkConfiguration>> GetStarlinkConfigurationsAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await _context.StarlinkConfigurations
+                .AsNoTracking()
+                .OrderBy(c => c.Name)
+                .ToListAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get Starlink configurations");
+            throw;
+        }
+    }
+
+    public async Task<List<StarlinkConfiguration>> GetEnabledStarlinkConfigurationsAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await _context.StarlinkConfigurations
+                .AsNoTracking()
+                .Where(c => c.Enabled)
+                .OrderBy(c => c.Name)
+                .ToListAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get enabled Starlink configurations");
+            throw;
+        }
+    }
+
+    public async Task<StarlinkConfiguration?> GetStarlinkConfigurationAsync(int id, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await _context.StarlinkConfigurations
+                .AsNoTracking()
+                .FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get Starlink configuration {Id}", id);
+            throw;
+        }
+    }
+
+    public async Task SaveStarlinkConfigurationAsync(StarlinkConfiguration config, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (config.Id > 0)
+            {
+                var existing = await _context.StarlinkConfigurations
+                    .FirstOrDefaultAsync(c => c.Id == config.Id, cancellationToken);
+                if (existing != null)
+                {
+                    existing.Name = config.Name;
+                    existing.Provider = config.Provider;
+                    existing.Host = config.Host;
+                    existing.Port = config.Port;
+                    existing.Enabled = config.Enabled;
+                    existing.PollingIntervalSeconds = config.PollingIntervalSeconds;
+                    existing.LastPolled = config.LastPolled;
+                    existing.LastError = config.LastError;
+                    existing.UpdatedAt = DateTime.UtcNow;
+                }
+            }
+            else
+            {
+                config.CreatedAt = DateTime.UtcNow;
+                config.UpdatedAt = DateTime.UtcNow;
+                _context.StarlinkConfigurations.Add(config);
+            }
+
+            await _context.SaveChangesAsync(cancellationToken);
+            _logger.LogDebug("Saved Starlink configuration {Name} ({Host})", config.Name, config.Host);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save Starlink configuration {Name}", config.Name);
+            throw;
+        }
+    }
+
+    public async Task DeleteStarlinkConfigurationAsync(int id, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var config = await _context.StarlinkConfigurations.FindAsync([id], cancellationToken);
+            if (config != null)
+            {
+                _context.StarlinkConfigurations.Remove(config);
+                await _context.SaveChangesAsync(cancellationToken);
+                _logger.LogDebug("Deleted Starlink configuration {Id}", id);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to delete Starlink configuration {Id}", id);
+            throw;
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -897,6 +897,79 @@ from(bucket: ""{_longtermBucket}"")
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Write Starlink terminal health metrics for time-series charting.
+    /// Link latency/throughput are intentionally absent (the monitoring
+    /// pipeline measures those); these are dish-only signals.
+    /// </summary>
+    public Task WriteStarlinkAsync(
+        string starlinkId,
+        string starlinkName,
+        double? powerInW,
+        double? powerInAvgW,
+        double? powerInMaxW,
+        double? pingDropRateAvg,
+        double? pingDropRateMax,
+        double? fractionObstructed,
+        bool? currentlyObstructed,
+        int? ethSpeedMbps,
+        long? uptimeS,
+        int? gpsSats,
+        bool? gpsValid,
+        double? tiltAngleDeg,
+        double? alignmentOffsetDeg,
+        double? attitudeUncertaintyDeg,
+        int outageCountDelta,
+        double outageSecondsDelta,
+        int alertCount,
+        string? alerts,
+        bool? snrPersistentlyLow,
+        string? softwareUpdateState,
+        string? disablementCode,
+        string? dlRestrictedReason,
+        string? ulRestrictedReason,
+        string? hardwareSelfTest,
+        string? classOfService,
+        string? mobilityClass,
+        DateTime timestamp)
+    {
+        if (!IsConfigured) return Task.CompletedTask;
+        var point = PointData.Measurement("starlink")
+            .Tag("starlink_id", starlinkId)
+            .Tag("starlink_name", starlinkName)
+            .Timestamp(timestamp.ToUniversalTime(), WritePrecision.Ns);
+
+        if (powerInW.HasValue) point = point.Field("power_in_w", powerInW.Value);
+        if (powerInAvgW.HasValue) point = point.Field("power_in_avg_w", powerInAvgW.Value);
+        if (powerInMaxW.HasValue) point = point.Field("power_in_max_w", powerInMaxW.Value);
+        if (pingDropRateAvg.HasValue) point = point.Field("ping_drop_rate_avg", pingDropRateAvg.Value);
+        if (pingDropRateMax.HasValue) point = point.Field("ping_drop_rate_max", pingDropRateMax.Value);
+        if (fractionObstructed.HasValue) point = point.Field("fraction_obstructed", fractionObstructed.Value);
+        if (currentlyObstructed.HasValue) point = point.Field("currently_obstructed", currentlyObstructed.Value);
+        if (ethSpeedMbps.HasValue) point = point.Field("eth_speed_mbps", ethSpeedMbps.Value);
+        if (uptimeS.HasValue) point = point.Field("uptime_s", uptimeS.Value);
+        if (gpsSats.HasValue) point = point.Field("gps_sats", gpsSats.Value);
+        if (gpsValid.HasValue) point = point.Field("gps_valid", gpsValid.Value);
+        if (tiltAngleDeg.HasValue) point = point.Field("tilt_angle_deg", tiltAngleDeg.Value);
+        if (alignmentOffsetDeg.HasValue) point = point.Field("alignment_offset_deg", alignmentOffsetDeg.Value);
+        if (attitudeUncertaintyDeg.HasValue) point = point.Field("attitude_uncertainty_deg", attitudeUncertaintyDeg.Value);
+        point = point.Field("outage_count_delta", outageCountDelta);
+        point = point.Field("outage_seconds_delta", outageSecondsDelta);
+        point = point.Field("alert_count", alertCount);
+        if (!string.IsNullOrEmpty(alerts)) point = point.Field("alerts", alerts);
+        if (snrPersistentlyLow.HasValue) point = point.Field("snr_persistently_low", snrPersistentlyLow.Value);
+        if (!string.IsNullOrEmpty(softwareUpdateState)) point = point.Field("software_update_state", softwareUpdateState);
+        if (!string.IsNullOrEmpty(disablementCode)) point = point.Field("disablement_code", disablementCode);
+        if (!string.IsNullOrEmpty(dlRestrictedReason)) point = point.Field("dl_restricted_reason", dlRestrictedReason);
+        if (!string.IsNullOrEmpty(ulRestrictedReason)) point = point.Field("ul_restricted_reason", ulRestrictedReason);
+        if (!string.IsNullOrEmpty(hardwareSelfTest)) point = point.Field("hardware_self_test", hardwareSelfTest);
+        if (!string.IsNullOrEmpty(classOfService)) point = point.Field("class_of_service", classOfService);
+        if (!string.IsNullOrEmpty(mobilityClass)) point = point.Field("mobility_class", mobilityClass);
+
+        Enqueue(point, longterm: true);
+        return Task.CompletedTask;
+    }
+
     public Task WriteEventAsync(
         string deviceMac,
         string eventType,
@@ -1837,6 +1910,80 @@ union(tables: [gauges, deltas])
     }
 
     /// <summary>
+    /// Query Starlink terminal metrics over a time range.
+    /// Returns dict keyed by starlink_id.
+    /// </summary>
+    public async Task<Dictionary<string, List<StarlinkPoint>>> QueryStarlinkAsync(
+        DateTime from,
+        DateTime to,
+        string? starlinkId = null,
+        TimeSpan? aggregateWindow = null,
+        CancellationToken ct = default)
+    {
+        if (!IsConfigured) await ReconfigureAsync(ct);
+        if (!IsConfigured) return new Dictionary<string, List<StarlinkPoint>>();
+        var window = aggregateWindow ?? PickAggregateWindow(to - from);
+
+        var idFilter = !string.IsNullOrEmpty(starlinkId)
+            ? $@"|> filter(fn: (r) => r.starlink_id == ""{SanitizeFluxString(starlinkId)}"")"
+            : "";
+
+        var winDur = ToFluxDuration(window);
+        var flux = $@"
+gauges = from(bucket: ""{_longtermBucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""starlink"")
+  {idFilter}
+  |> filter(fn: (r) => r._field == ""power_in_avg_w"" or r._field == ""ping_drop_rate_avg"" or r._field == ""fraction_obstructed"" or r._field == ""eth_speed_mbps"" or r._field == ""uptime_s"" or r._field == ""gps_sats"" or r._field == ""alignment_offset_deg"" or r._field == ""alert_count"")
+  |> aggregateWindow(every: {winDur}, fn: last, createEmpty: false)
+
+peaks = from(bucket: ""{_longtermBucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""starlink"")
+  {idFilter}
+  |> filter(fn: (r) => r._field == ""power_in_max_w"" or r._field == ""ping_drop_rate_max"")
+  |> aggregateWindow(every: {winDur}, fn: max, createEmpty: false)
+
+deltas = from(bucket: ""{_longtermBucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""starlink"")
+  {idFilter}
+  |> filter(fn: (r) => r._field == ""outage_count_delta"" or r._field == ""outage_seconds_delta"")
+  |> aggregateWindow(every: {winDur}, fn: sum, createEmpty: false)
+
+union(tables: [gauges, peaks, deltas])
+  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
+";
+        var results = new Dictionary<string, List<StarlinkPoint>>();
+        await foreach (var record in QueryFluxAsync(flux, ct))
+        {
+            var key = record.GetValueByKey("starlink_id") as string ?? "unknown";
+            if (!results.TryGetValue(key, out var list))
+            {
+                list = new List<StarlinkPoint>();
+                results[key] = list;
+            }
+            list.Add(new StarlinkPoint
+            {
+                Time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow),
+                PowerInAvgW = AsDoubleOrNull(record.GetValueByKey("power_in_avg_w")),
+                PowerInMaxW = AsDoubleOrNull(record.GetValueByKey("power_in_max_w")),
+                PingDropRateAvg = AsDoubleOrNull(record.GetValueByKey("ping_drop_rate_avg")),
+                PingDropRateMax = AsDoubleOrNull(record.GetValueByKey("ping_drop_rate_max")),
+                FractionObstructed = AsDoubleOrNull(record.GetValueByKey("fraction_obstructed")),
+                EthSpeedMbps = AsIntOrNull(record.GetValueByKey("eth_speed_mbps")),
+                UptimeS = AsLongOrNull(record.GetValueByKey("uptime_s")),
+                GpsSats = AsIntOrNull(record.GetValueByKey("gps_sats")),
+                AlignmentOffsetDeg = AsDoubleOrNull(record.GetValueByKey("alignment_offset_deg")),
+                OutageCountDelta = AsLongOrNull(record.GetValueByKey("outage_count_delta")),
+                OutageSecondsDelta = AsDoubleOrNull(record.GetValueByKey("outage_seconds_delta")),
+                AlertCount = AsIntOrNull(record.GetValueByKey("alert_count")),
+            });
+        }
+        return results;
+    }
+
+    /// <summary>
     /// Query external ONT metrics over a time range.
     /// Returns dict keyed by ont_id.
     /// </summary>
@@ -2615,6 +2762,23 @@ from(bucket: ""{_longtermBucket}"")
         public int? LockedUsChannels { get; init; }
         public long? CorrDelta { get; init; }
         public long? UncorrDelta { get; init; }
+    }
+
+    public record StarlinkPoint
+    {
+        public required DateTime Time { get; init; }
+        public double? PowerInAvgW { get; init; }
+        public double? PowerInMaxW { get; init; }
+        public double? PingDropRateAvg { get; init; }
+        public double? PingDropRateMax { get; init; }
+        public double? FractionObstructed { get; init; }
+        public int? EthSpeedMbps { get; init; }
+        public long? UptimeS { get; init; }
+        public int? GpsSats { get; init; }
+        public double? AlignmentOffsetDeg { get; init; }
+        public long? OutageCountDelta { get; init; }
+        public double? OutageSecondsDelta { get; init; }
+        public int? AlertCount { get; init; }
     }
 
     public record OntPoint

--- a/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
@@ -225,6 +225,7 @@
     private bool _editMode;
     private OntStatsPanel? _ontPanel;
     private CellularStatsPanel? _cellularPanel;
+    private StarlinkStatsPanel? _starlinkPanel;
     private CmStatsPanel? _cmPanel;
     private DashboardLayout? _layout;
     private int deviceCount = 0;
@@ -276,6 +277,7 @@
         DashboardCards.SqmStatus => RenderSqmStatus,
         DashboardCards.ThreatTrends => RenderThreatTrends,
         DashboardCards.CellularStats => RenderCellularStats,
+        DashboardCards.StarlinkStats => RenderStarlinkStats,
         DashboardCards.CmStats => RenderCmStats,
         DashboardCards.OntStats => RenderOntStats,
         DashboardCards.SpeedTests => RenderSpeedTests,
@@ -585,6 +587,18 @@
             </div>
             <div class="card-body">
                 <OntStatsPanel @ref="_ontPanel" OnDataLoaded="StateHasChanged" />
+            </div>
+        </div>
+    };
+
+    private RenderFragment RenderStarlinkStats => __builder =>
+    {
+        <div class="card clickable-card" @onclick="NavigateToStarlinkChart">
+            <div class="card-header">
+                <h2 class="card-title">Starlink Stats</h2>
+            </div>
+            <div class="card-body">
+                <StarlinkStatsPanel @ref="_starlinkPanel" />
             </div>
         </div>
     };
@@ -1249,6 +1263,15 @@
         var url = modemId != null
             ? $"/monitoring?tab=cellular&modem={Uri.EscapeDataString(modemId)}"
             : "/monitoring?tab=cellular";
+        NavigationManager.NavigateTo(url);
+    }
+
+    private void NavigateToStarlinkChart()
+    {
+        var starlinkId = _starlinkPanel?.CurrentStarlinkId;
+        var url = starlinkId != null
+            ? $"/monitoring?tab=starlink&starlink={Uri.EscapeDataString(starlinkId)}"
+            : "/monitoring?tab=starlink";
         NavigationManager.NavigateTo(url);
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -30,6 +30,7 @@
 @inject CableModemMonitorService CmMonitorService
 @inject OntMonitorService OntMonitorService
 @inject CellularModemService CellularModemService
+@inject StarlinkMonitorService StarlinkMonitor
 @inject MonitoringCollectionAgent CollectionAgent
 @inject IspHealthService IspHealthService
 @inject NetworkOptimizer.Web.Services.Monitoring.FlakyTargetService FlakyTargets
@@ -137,6 +138,11 @@ else
                     @onclick="@(() => SetActiveTab("cellular"))"
                     disabled="@(!_monitoringReady)">
                 Cellular Stats
+            </button>
+            <button class="wifi-view-tab @(_activeTab == "starlink" ? "active" : "")"
+                    @onclick="@(() => SetActiveTab("starlink"))"
+                    disabled="@(!_monitoringReady)">
+                Starlink Stats
             </button>
             <button class="wifi-view-tab" @onclick='() => NavigationManager.NavigateTo("/alerts?tab=data-usage")'>
                 Data Usage
@@ -1084,6 +1090,115 @@ else
         }
     }
 
+    @* ──────────────── Tab: Starlink Stats ──────────────── *@
+    @if (_activeTab == "starlink" && _monitoringReady)
+    {
+        @if (_influxReachable == false)
+        {
+            <div class="alert alert-warning" style="margin-bottom: 1rem;">
+                <strong>InfluxDB: @ShortInfluxStatus()</strong> - Starlink chart data is unavailable. Check the <a href="javascript:void(0)" @onclick='() => SetActiveTab("setup")' @onclick:preventDefault>Setup</a> tab to review connection status.
+                @if (!string.IsNullOrEmpty(_influxError))
+                {
+                    <div style="margin-top: 0.25rem; font-size: 0.85rem; opacity: 0.8;">@_influxError</div>
+                }
+            </div>
+        }
+        else if (_influxReachable != true)
+        {
+            <div class="loading-container" style="padding: 3rem;">
+                <div class="spinner"></div>
+            </div>
+        }
+        @if (_influxReachable == true)
+        {
+        @if (!_starlinkHasDevices)
+        {
+            <div class="card" style="margin-top: 1.5rem;">
+                <div class="card-header monitoring-chart-header">
+                    <h2 class="card-title">Starlink Terminal History</h2>
+                    <a href="/settings#starlink" class="tooltip-icon settings-link" data-tooltip="Starlink settings">
+                        <img src="/images/gear.svg" alt="" style="width:16px;height:16px;" />
+                    </a>
+                </div>
+                <div class="card-body" style="text-align: center; padding: 2rem;">
+                    <p class="page-description">No Starlink terminals configured. Add one in <a href="/settings#starlink">Settings</a> to start monitoring.</p>
+                </div>
+            </div>
+        }
+        else
+        {
+        <div class="card" style="margin-top: 1.5rem;" id="starlink-charts-container">
+            <div class="card-header monitoring-chart-header">
+                <h2 class="card-title">Starlink Terminal History</h2>
+                <div style="display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap;">
+                    <button class="time-btn" data-shift="back" data-tooltip="Shift window back">&#x25C0;</button>
+                    <div class="time-range-selector" style="position: relative;">
+                        <button class="time-btn" data-range="0">15m</button>
+                        <button class="time-btn" data-range="1">1h</button>
+                        <button class="time-btn" data-range="6">6h</button>
+                        <button class="time-btn active" data-range="24">24h</button>
+                        <button class="time-btn" data-range="168">7d</button>
+                        <button class="time-btn" data-range="720">30d</button>
+                        <button class="time-btn custom-range-btn" data-action="custom-range" data-tooltip="Custom date range" data-tooltip-hover-only>
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+                        </button>
+                        <div class="custom-range-popover" data-popover="custom-range">
+                            <div class="custom-range-form">
+                                <div class="custom-range-title">Custom Range</div>
+                                <div class="custom-range-field">
+                                    <label>From</label>
+                                    <input type="datetime-local" data-input="from" class="custom-range-input" />
+                                </div>
+                                <div class="custom-range-field">
+                                    <label>To</label>
+                                    <input type="datetime-local" data-input="to" class="custom-range-input" />
+                                </div>
+                                <div class="custom-range-actions">
+                                    <button class="btn btn-sm btn-secondary" data-action="cancel-custom">Cancel</button>
+                                    <button class="btn btn-sm btn-primary" data-action="apply-custom">Apply</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <button class="time-btn" data-shift="forward" data-tooltip="Shift window forward">&#x25B6;</button>
+                    <a href="/settings#starlink" class="tooltip-icon settings-link" data-tooltip="Starlink settings">
+                        <img src="/images/gear.svg" alt="" style="width:16px;height:16px;" />
+                    </a>
+                </div>
+            </div>
+            <div class="card-body">
+                <div class="starlink-filter-badges wan-filter-badges"></div>
+                <div class="chart-card">
+                    <div class="chart-header"><h3 class="chart-title">Power Draw (W)</h3></div>
+                    <div class="starlink-power-chart"></div>
+                </div>
+                <div class="chart-card" style="margin-top: 1rem;">
+                    <div class="chart-header"><h3 class="chart-title">Dish Ping Drop Rate (%)</h3></div>
+                    <div class="starlink-drop-chart"></div>
+                </div>
+                <div class="chart-card" style="margin-top: 1rem;">
+                    <div class="chart-header"><h3 class="chart-title">Sky Obstruction (%)</h3></div>
+                    <div class="starlink-obstruction-chart"></div>
+                </div>
+                <div class="chart-card" style="margin-top: 1rem;">
+                    <div class="chart-header"><h3 class="chart-title">Outage Seconds</h3></div>
+                    <div class="starlink-outage-chart"></div>
+                </div>
+                <div class="chart-card" style="margin-top: 1rem;">
+                    <div class="chart-header"><h3 class="chart-title">GPS Satellites</h3></div>
+                    <div class="starlink-gps-chart"></div>
+                </div>
+                <div class="chart-card" style="margin-top: 1rem;">
+                    <div class="chart-header"><h3 class="chart-title">Alignment Offset (deg)</h3></div>
+                    <div class="starlink-alignment-chart"></div>
+                </div>
+                <div class="starlink-stats-table"></div>
+            </div>
+        </div>
+        }
+        }
+    }
+
     @* ──────────────── Tab: Setup ──────────────── *@
     @if (_activeTab == "setup")
     {
@@ -1375,6 +1490,9 @@ else
     [SupplyParameterFromQuery(Name = "ont")]
     public string? OntParam { get; set; }
 
+    [SupplyParameterFromQuery(Name = "starlink")]
+    public string? StarlinkParam { get; set; }
+
     [SupplyParameterFromQuery(Name = "mifip")]
     public string? MiTargetParam { get; set; }
 
@@ -1385,6 +1503,7 @@ else
     private string? _soloCellularModemId;
     private string? _soloCmId;
     private string? _soloOntId;
+    private string? _soloStarlinkId;
 
     private bool _upstreamDiscoveryPendingSave =>
         UpstreamTracer.State.Step == NetworkOptimizer.Web.Services.Monitoring.TracerStep.ReviewingResults;
@@ -1422,6 +1541,7 @@ else
     private bool _cmHasDevices;
     private bool _ontHasDevices;
     private bool _cellularHasDevices;
+    private bool _starlinkHasDevices;
     private bool _forceExpandUpstream;
 
     // "Results ready" banner for the scheduled upstream re-discovery, surfaced on the
@@ -1447,6 +1567,7 @@ else
     private bool _healthChartsMounted;
     private bool _sfpChartsMounted;
     private bool _cellularChartsMounted;
+    private bool _starlinkChartsMounted;
     private bool _cmChartsMounted;
     private bool _ontChartsMounted;
 
@@ -1476,7 +1597,7 @@ else
 
     private static readonly HashSet<string> ValidTabs = new(StringComparer.OrdinalIgnoreCase)
     {
-        "live", "isp-health", "performance", "devices", "sfp", "cm", "ont", "cellular", "setup"
+        "live", "isp-health", "performance", "devices", "sfp", "cm", "ont", "cellular", "starlink", "setup"
     };
 
     private string ResolveDefaultTab()
@@ -1570,6 +1691,11 @@ else
             _soloOntId = OntParam;
         }
 
+        if (!string.IsNullOrEmpty(StarlinkParam) && _activeTab == "starlink")
+        {
+            _soloStarlinkId = StarlinkParam;
+        }
+
         // Expand on any funnel deep-link from the monitor forms. Those links always carry
         // mitype (cm/wmodem/ont), even when the Host field was empty so mifip is blank, so
         // mitype is the reliable "set up a monitoring interface" signal.
@@ -1606,6 +1732,8 @@ else
         _ontHasDevices = ontConfigs.Count > 0;
         var cellConfigs = await CellularModemService.GetModemsAsync();
         _cellularHasDevices = cellConfigs.Count > 0;
+        var starlinkConfigs = await StarlinkMonitor.GetConfigsAsync();
+        _starlinkHasDevices = starlinkConfigs.Count > 0;
 
         _mapOrder2dFirst = await SystemSettings.GetGlobalAsync(SystemSettingKeys.MonitoringLiveMapOrder) == "2d-first";
         var dashLayout = await DashboardLayout.GetLayoutAsync();
@@ -3137,11 +3265,11 @@ else
         {
             if (_mapMounted || _map2dMounted || _wanLiveChartMounted || _portStatsMounted
                 || _latencyChartsMounted || _healthChartsMounted || _sfpChartsMounted
-                || _cellularChartsMounted || _cmChartsMounted || _ontChartsMounted)
+                || _cellularChartsMounted || _starlinkChartsMounted || _cmChartsMounted || _ontChartsMounted)
             {
                 _mapMounted = _map2dMounted = _wanLiveChartMounted = _portStatsMounted = false;
                 _latencyChartsMounted = _healthChartsMounted = _sfpChartsMounted = false;
-                _cellularChartsMounted = _cmChartsMounted = _ontChartsMounted = false;
+                _cellularChartsMounted = _starlinkChartsMounted = _cmChartsMounted = _ontChartsMounted = false;
                 try
                 {
                     await JS.InvokeVoidAsync("eval",
@@ -3149,6 +3277,7 @@ else
                         "window.__wanLiveChart?.unmount(); window.__portStatsTable?.unmount();" +
                         "window.__latencyCharts?.unmount(); window.__healthCharts?.unmount();" +
                         "window.__sfpCharts?.unmount(); window.__cellularCharts?.unmount();" +
+                        "window.__starlinkCharts?.unmount();" +
                         "window.__cmCharts?.unmount(); window.__ontCharts?.unmount();");
                 }
                 catch { }
@@ -3443,6 +3572,29 @@ else
             catch { }
         }
 
+        // Starlink charts - Starlink tab only (wait for InfluxDB like the cellular charts)
+        if (_activeTab == "starlink" && _monitoringReady && _influxReachable == true && !_starlinkChartsMounted)
+        {
+            _starlinkChartsMounted = true;
+            try
+            {
+                var starlinkUrl = VersionedJs("/js/starlink-charts.js");
+                var soloJs = !string.IsNullOrEmpty(_soloStarlinkId)
+                    ? $"m.soloDevice('{System.Text.Encodings.Web.JavaScriptEncoder.Default.Encode(_soloStarlinkId)}');"
+                    : "";
+                await JS.InvokeVoidAsync("eval",
+                    $"(async () => {{ const m = await import('{starlinkUrl}'); window.__starlinkCharts = m; await m.mount('starlink-charts-container'); {soloJs} }})();");
+                _soloStarlinkId = null;
+            }
+            catch (Exception ex) { _starlinkChartsMounted = false; Logger.LogDebug(ex, "Starlink charts mount failed; will retry on next render"); }
+        }
+        else if ((_activeTab != "starlink" || _influxReachable != true) && _starlinkChartsMounted)
+        {
+            _starlinkChartsMounted = false;
+            try { await JS.InvokeVoidAsync("eval", "window.__starlinkCharts?.unmount();"); }
+            catch { }
+        }
+
         // CM charts
         if (_activeTab == "cm" && _monitoringReady && _influxReachable == true && !_cmChartsMounted)
         {
@@ -3518,6 +3670,11 @@ else
         if (_cellularChartsMounted)
         {
             try { _ = JS.InvokeVoidAsync("eval", "window.__cellularCharts?.unmount();").AsTask(); }
+            catch { }
+        }
+        if (_starlinkChartsMounted)
+        {
+            try { _ = JS.InvokeVoidAsync("eval", "window.__starlinkCharts?.unmount();").AsTask(); }
             catch { }
         }
         if (_cmChartsMounted)

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -42,6 +42,7 @@
 @inject MonitoringInfluxClient InfluxClient
 @inject CableModemMonitorService CmMonitorService
 @inject OntMonitorService OntMonitorService
+@inject StarlinkMonitorService StarlinkMonitor
 @inject Microsoft.EntityFrameworkCore.IDbContextFactory<NetworkOptimizer.Storage.Models.NetworkOptimizerDbContext> DbFactory
 @using NetworkOptimizer.Alerts.Models
 @using NetworkOptimizer.Web.Components.Shared
@@ -1588,6 +1589,156 @@
                     {
                         <div class="mi-funnel">
                             Can't reach it? <a href="@MonitoringInterfaceLink(_ontTestedHost, "ont")">Set up a monitoring interface →</a>
+                        </div>
+                    }
+                </div>
+            }
+        </div>
+    </div>
+
+    <!-- Starlink Monitoring -->
+    <div class="card settings-tab-monitoring" id="starlink">
+        <div class="card-header">
+            <h2 class="card-title">Starlink Monitoring</h2>
+            <span class="status-badge status-@_starlinkStatus.ToLower()">@_starlinkStatus</span>
+        </div>
+        <div class="card-body">
+            <p class="section-description">
+                Monitor Starlink terminals over the dish's local gRPC API for power draw, obstruction, outages, and alignment.
+            </p>
+
+            @if (_starlinkConfigs.Count > 0)
+            {
+                <div class="table-responsive">
+                <table class="data-table settings-table">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Host</th>
+                            <th>Provider</th>
+                            <th>Enabled</th>
+                            <th>Last Polled</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var terminal in _starlinkConfigs)
+                        {
+                            <tr>
+                                <td>@terminal.Name</td>
+                                <td><code>@terminal.Host</code></td>
+                                <td>@GetStarlinkProviderDisplayName(terminal.Provider)</td>
+                                <td>
+                                    @if (terminal.Enabled)
+                                    {
+                                        <span class="status-badge status-connected">Enabled</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="status-badge status-disconnected">Disabled</span>
+                                    }
+                                </td>
+                                <td>@(terminal.LastPolled?.ToLocalTime().ToString("g") ?? "Never")</td>
+                                <td>
+                                    <div class="btn-group-wrap">
+                                        <button class="btn btn-secondary btn-sm" @onclick="() => EditStarlink(terminal)">Edit</button>
+                                        <button class="btn btn-secondary btn-sm" @onclick="() => TestStarlink(terminal)" disabled="@(_starlinkTestingId == terminal.Id)">
+                                            @if (_starlinkTestingId == terminal.Id)
+                                            {
+                                                <span class="spinner"></span>
+                                            }
+                                            else
+                                            {
+                                                <span>Test</span>
+                                            }
+                                        </button>
+                                        <button class="btn btn-danger btn-sm" @onclick="() => DeleteStarlink(terminal.Id)">Delete</button>
+                                    </div>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+                </div>
+            }
+            else
+            {
+                <p class="empty-state">No Starlink terminals configured. Add one below to start monitoring dish health.</p>
+            }
+
+            <details class="add-form" open="@_starlinkFormVisible">
+                <summary @onclick="() => _starlinkFormVisible = !_starlinkFormVisible">@(_editingStarlink.Id > 0 ? "Edit Starlink Terminal" : "Add Starlink Terminal")</summary>
+                <div class="add-form-content add-form-content-spaced">
+                    <div class="form-row">
+                        <div class="form-group" style="flex: 2;">
+                            <label class="form-label">Name</label>
+                            <input type="text" class="form-control" @bind="_editingStarlink.Name" placeholder="Starlink Roof" required />
+                        </div>
+                        <div class="form-group" style="flex: 2;">
+                            <label class="form-label">Provider</label>
+                            <select class="form-control" @bind="_editingStarlink.Provider">
+                                <option value="starlink-grpc">Starlink (local gRPC)</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-group" style="flex: 2;">
+                            <label class="form-label">Host / IP</label>
+                            <input type="text" class="form-control" @bind="_editingStarlink.Host" placeholder="192.168.100.1" required />
+                            <small class="form-help">
+                                Behind your WAN and unreachable for polling?
+                                <a href="@MonitoringInterfaceLink(_editingStarlink.Host, "starlink")">Set up a monitoring interface →</a>
+                            </small>
+                        </div>
+                        <div class="form-group" style="flex: 1;">
+                            <label class="form-label">Port</label>
+                            <input type="number" class="form-control" @bind="_editingStarlink.Port" min="1" max="65535" />
+                        </div>
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-group" style="flex: 1;">
+                            <label class="form-label">Polling Interval (sec)</label>
+                            <input type="number" class="form-control" @bind="_editingStarlink.PollingIntervalSeconds" min="30" max="3600" />
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label class="checkbox-label">
+                            <input type="checkbox" @bind="_editingStarlink.Enabled" />
+                            <span>Enable polling</span>
+                        </label>
+                    </div>
+
+                    <div class="action-buttons">
+                        <button class="btn btn-primary" @onclick="SaveStarlink" disabled="@_savingStarlink">
+                            @if (_savingStarlink)
+                            {
+                                <span class="spinner"></span>
+                                <span>Saving...</span>
+                            }
+                            else
+                            {
+                                <span>@(_editingStarlink.Id > 0 ? "Update Starlink Terminal" : "Add Starlink Terminal")</span>
+                            }
+                        </button>
+                        @if (_editingStarlink.Id > 0)
+                        {
+                            <button class="btn btn-secondary" @onclick="CancelEditStarlink">Cancel</button>
+                        }
+                    </div>
+                </div>
+            </details>
+
+            @if (!string.IsNullOrEmpty(_starlinkTestResult))
+            {
+                <div class="alert alert-@_starlinkTestResultClass" style="margin-top: 1rem;">
+                    @_starlinkTestResult
+                    @if (LooksUnreachable(_starlinkTestResult) && !string.IsNullOrWhiteSpace(_starlinkTestedHost))
+                    {
+                        <div class="mi-funnel">
+                            Can't reach it? <a href="@MonitoringInterfaceLink(_starlinkTestedHost, "starlink")">Set up a monitoring interface →</a>
                         </div>
                     }
                 </div>
@@ -3150,6 +3301,7 @@
         ["cellular-modem"] = "monitoring",
         ["cable-modem"] = "monitoring",
         ["ont-monitoring"] = "monitoring",
+        ["starlink"] = "monitoring",
         ["speed-test-settings"] = "speedtests",
         ["external-speedtest-settings"] = "speedtests",
         ["security-audit"] = "security",
@@ -3739,6 +3891,17 @@
     private int? _ontTestingId;
     private string _ontStatus = "Inactive";
 
+    // Starlink Monitoring
+    private List<StarlinkConfiguration> _starlinkConfigs = new();
+    private StarlinkConfiguration _editingStarlink = new();
+    private bool _starlinkFormVisible;
+    private bool _savingStarlink;
+    private string? _starlinkTestResult;
+    private string _starlinkTestResultClass = "info";
+    private int? _starlinkTestingId;
+    private string? _starlinkTestedHost;
+    private string _starlinkStatus = "Inactive";
+
     // Gateway SSH
     private GatewaySshSettings? gatewaySettings;
     private string gatewayHost = "";
@@ -3985,6 +4148,7 @@
         await LoadModemConfigs();
         await LoadCmSettings();
         await LoadOntSettings();
+        await LoadStarlinkSettings();
         await LoadDiscoveredModems();
         await LoadIperf3Settings();
         await LoadExtServers();
@@ -5599,6 +5763,142 @@
         "quantum-q1000k" => "Quantum Fiber Q1000K (HTTP)",
         "telekom-modem2" => "Telekom Glasfaser-Modem 2 (HTTP)",
         "generic-http-ont" => "Generic HTTP ONT",
+        _ => provider,
+    };
+
+    // --- Starlink Monitoring ---
+
+    private async Task LoadStarlinkSettings()
+    {
+        try
+        {
+            _starlinkConfigs = await StarlinkMonitor.GetConfigsAsync();
+            if (_starlinkConfigs.Any(c => !string.IsNullOrEmpty(c.LastError)))
+                _starlinkStatus = "Error";
+            else if (_starlinkConfigs.Any(c => c.Enabled))
+                _starlinkStatus = "Active";
+            else
+                _starlinkStatus = "Inactive";
+        }
+        catch (Exception ex)
+        {
+            _starlinkStatus = "Error";
+            _starlinkTestResult = $"Error loading Starlink configs: {ex.Message}";
+            _starlinkTestResultClass = "danger";
+        }
+    }
+
+    private async Task SaveStarlink()
+    {
+        if (string.IsNullOrWhiteSpace(_editingStarlink.Name) || string.IsNullOrWhiteSpace(_editingStarlink.Host))
+        {
+            _starlinkTestResult = "Name and Host are required.";
+            _starlinkTestResultClass = "danger";
+            return;
+        }
+
+        _savingStarlink = true;
+        _starlinkTestResult = null;
+        StateHasChanged();
+
+        try
+        {
+            var isNew = _editingStarlink.Id == 0;
+            _editingStarlink.UpdatedAt = DateTime.UtcNow;
+            if (isNew)
+                _editingStarlink.CreatedAt = DateTime.UtcNow;
+
+            await StarlinkMonitor.SaveStarlinkAsync(_editingStarlink);
+            _starlinkTestResult = isNew ? "Starlink terminal added successfully" : "Starlink terminal updated successfully";
+            _starlinkTestResultClass = "success";
+
+            await LoadStarlinkSettings();
+            CancelEditStarlink();
+        }
+        catch (Exception ex)
+        {
+            _starlinkTestResult = $"Error saving Starlink terminal: {ex.Message}";
+            _starlinkTestResultClass = "danger";
+        }
+        finally
+        {
+            _savingStarlink = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task DeleteStarlink(int id)
+    {
+        try
+        {
+            await StarlinkMonitor.DeleteStarlinkAsync(id);
+            _starlinkTestResult = "Starlink terminal deleted.";
+            _starlinkTestResultClass = "success";
+            await LoadStarlinkSettings();
+        }
+        catch (Exception ex)
+        {
+            _starlinkTestResult = $"Error deleting Starlink terminal: {ex.Message}";
+            _starlinkTestResultClass = "danger";
+        }
+        StateHasChanged();
+    }
+
+    private async Task TestStarlink(StarlinkConfiguration config)
+    {
+        _starlinkTestingId = config.Id;
+        _starlinkTestedHost = config.Host;
+        _starlinkTestResult = $"Testing {config.Name}...";
+        _starlinkTestResultClass = "info";
+        StateHasChanged();
+
+        try
+        {
+            var (success, message) = await StarlinkMonitor.ProbeAsync(config);
+            _starlinkTestResult = message;
+            _starlinkTestResultClass = success ? "success" : "danger";
+            if (success)
+                await LoadStarlinkSettings();
+        }
+        catch (Exception ex)
+        {
+            _starlinkTestResult = $"Error: {ex.Message}";
+            _starlinkTestResultClass = "danger";
+        }
+        finally
+        {
+            _starlinkTestingId = null;
+            StateHasChanged();
+        }
+    }
+
+    private void EditStarlink(StarlinkConfiguration config)
+    {
+        _editingStarlink = new StarlinkConfiguration
+        {
+            Id = config.Id,
+            Name = config.Name,
+            Provider = config.Provider,
+            Host = config.Host,
+            Port = config.Port,
+            PollingIntervalSeconds = config.PollingIntervalSeconds,
+            Enabled = config.Enabled,
+            LastPolled = config.LastPolled,
+            LastError = config.LastError,
+            CreatedAt = config.CreatedAt,
+        };
+        _starlinkFormVisible = true;
+    }
+
+    private void CancelEditStarlink()
+    {
+        _editingStarlink = new StarlinkConfiguration();
+        _starlinkFormVisible = false;
+    }
+
+    private static string GetStarlinkProviderDisplayName(string provider) => provider switch
+    {
+        "starlink-grpc" => "Starlink (local gRPC)",
         _ => provider,
     };
 

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -478,6 +478,7 @@
         "cm" => "cmodem",
         "wmodem" => "wmodem",
         "ont" => "ont",
+        "starlink" => "starlink",
         _ => "modem"
     };
 

--- a/src/NetworkOptimizer.Web/Components/Shared/StarlinkStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/StarlinkStatsPanel.razor
@@ -505,11 +505,15 @@
         if (stats.SoftwareUpdateState is not null and not "Idle" and not "SoftwareUpdateStateUnknown" and not "Unknown")
             notices.Add($"Software update: {HumanizeToken(stats.SoftwareUpdateState)}");
 
-        // Restriction reasons are noisy: PolicyLimit/LowSpeedPolicyLimit is ordinary
-        // plan shaping on virtually every Starlink plan. Only an overage cap is
-        // actionable, so that's the only one surfaced.
+        // Restriction reasons, filtered for signal: plain PolicyLimit is ordinary
+        // shaping on virtually every plan (silent). OverageLimit means the data
+        // allowance ran out; LowSpeedPolicyLimit means the plan itself is a
+        // reduced-speed tier (Standby and similar) - both explain a slow speed
+        // test without pointing at the network.
         if (stats.DownlinkRestrictedReason == "OverageLimit" || stats.UplinkRestrictedReason == "OverageLimit")
             notices.Add("Speeds reduced: the plan's data allowance has been used up");
+        else if (stats.DownlinkRestrictedReason == "LowSpeedPolicyLimit" || stats.UplinkRestrictedReason == "LowSpeedPolicyLimit")
+            notices.Add("Speeds are capped by a reduced-speed plan tier (such as Standby)");
 
         // Hardware self-test is deliberately NOT surfaced: healthy dishes routinely
         // report FAILED with codes like DBF_NUM_FEMS (a few dead front-end modules

--- a/src/NetworkOptimizer.Web/Components/Shared/StarlinkStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/StarlinkStatsPanel.razor
@@ -505,14 +505,11 @@
         if (stats.SoftwareUpdateState is not null and not "Idle" and not "SoftwareUpdateStateUnknown" and not "Unknown")
             notices.Add($"Software update: {HumanizeToken(stats.SoftwareUpdateState)}");
 
-        var dlLimited = IsLimited(stats.DownlinkRestrictedReason);
-        var ulLimited = IsLimited(stats.UplinkRestrictedReason);
-        if (dlLimited && ulLimited)
-            notices.Add("Speeds are limited by the service plan");
-        else if (dlLimited)
-            notices.Add($"Download limited: {HumanizeToken(stats.DownlinkRestrictedReason!)}");
-        else if (ulLimited)
-            notices.Add($"Upload limited: {HumanizeToken(stats.UplinkRestrictedReason!)}");
+        // Restriction reasons are noisy: PolicyLimit/LowSpeedPolicyLimit is ordinary
+        // plan shaping on virtually every Starlink plan. Only an overage cap is
+        // actionable, so that's the only one surfaced.
+        if (stats.DownlinkRestrictedReason == "OverageLimit" || stats.UplinkRestrictedReason == "OverageLimit")
+            notices.Add("Speeds reduced: the plan's data allowance has been used up");
 
         // Hardware self-test is deliberately NOT surfaced: healthy dishes routinely
         // report FAILED with codes like DBF_NUM_FEMS (a few dead front-end modules
@@ -521,9 +518,6 @@
 
         return notices;
     }
-
-    private static bool IsLimited(string? reason) =>
-        reason is not null and not "NoLimit" and not "Unknown";
 
     /// <summary>"thermal_throttle" or "ThermalThrottle" -> "Thermal throttle".</summary>
     private static string HumanizeToken(string token)

--- a/src/NetworkOptimizer.Web/Components/Shared/StarlinkStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/StarlinkStatsPanel.razor
@@ -514,13 +514,10 @@
         else if (ulLimited)
             notices.Add($"Upload limited: {HumanizeToken(stats.UplinkRestrictedReason!)}");
 
-        if (stats.HardwareSelfTest == "Failed")
-        {
-            var codes = stats.HardwareSelfTestCodes.Count > 0
-                ? $" ({string.Join(", ", stats.HardwareSelfTestCodes)})"
-                : "";
-            notices.Add($"Hardware self-test failed{codes}");
-        }
+        // Hardware self-test is deliberately NOT surfaced: healthy dishes routinely
+        // report FAILED with codes like DBF_NUM_FEMS (a few dead front-end modules
+        // is normal attrition), so it reads as a false alarm. Still stored in the
+        // time series for fleet-level analysis.
 
         return notices;
     }

--- a/src/NetworkOptimizer.Web/Components/Shared/StarlinkStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/StarlinkStatsPanel.razor
@@ -1,0 +1,550 @@
+@using NetworkOptimizer.Web.Services
+@using NetworkOptimizer.Monitoring.Models
+@inject StarlinkMonitorService StarlinkService
+@inject IJSRuntime JS
+@implements IAsyncDisposable
+
+<div class="starlink-stats-panel">
+    @if (isLoading)
+    {
+        <div class="loading-state">
+            <span class="spinner"></span>
+            <span>Loading Starlink stats...</span>
+        </div>
+    }
+    else if (!hasConfiguredTerminals)
+    {
+        <div class="sqm-unavailable">
+            <div class="sqm-status">
+                <span class="status-indicator status-disconnected"></span>
+                <span class="status-label">No Data</span>
+            </div>
+            <p class="status-message">No Starlink terminal configured.</p>
+            <div class="sqm-actions">
+                <a href="/settings#starlink" class="btn btn-primary" @onclick:stopPropagation>Configure Starlink</a>
+            </div>
+        </div>
+    }
+    else
+    {
+        <div class="sqm-header">
+            <div class="sqm-status">
+                <span class="status-indicator status-@GetStatusClass()"></span>
+                <span class="status-label">@configuredTerminals[currentIndex].Name</span>
+            </div>
+            <div class="starlink-header-right">
+                @if (configuredTerminals.Count > 1)
+                {
+                    <div class="modem-nav">
+                        <button class="nav-btn" @onclick="PreviousTerminal" @onclick:stopPropagation disabled="@(currentIndex == 0)">&#x2039;</button>
+                        <span class="modem-counter">@(currentIndex + 1)/@configuredTerminals.Count</span>
+                        <button class="nav-btn" @onclick="NextTerminal" @onclick:stopPropagation disabled="@(currentIndex >= configuredTerminals.Count - 1)">&#x203A;</button>
+                    </div>
+                }
+                @if (stats != null)
+                {
+                    <div class="tc-timestamp">
+                        <small>Updated: @stats.Timestamp.ToLocalTime().ToString("HH:mm:ss")</small>
+                    </div>
+                }
+            </div>
+        </div>
+
+        <div class="starlink-layout">
+            <div class="starlink-sky">
+                <canvas @ref="mapCanvas" width="246" height="246" class="starlink-sky-canvas"></canvas>
+                @if (obstructionMap == null)
+                {
+                    <div class="starlink-sky-placeholder">
+                        <span class="spinner-sm"></span>
+                        <span>Mapping sky...</span>
+                    </div>
+                }
+                <div class="starlink-sky-caption">Sky view from dish - obstructions in red</div>
+            </div>
+
+            <div class="starlink-metrics">
+                @if (stats == null)
+                {
+                    <p class="status-message">Waiting for first poll...</p>
+                }
+                else
+                {
+                    <div class="starlink-metric-row">
+                        <span class="starlink-metric-label">Obstructed</span>
+                        <span class="starlink-metric-value @GetObstructionClass()">
+                            @(stats.FractionObstructed.HasValue ? (stats.FractionObstructed.Value * 100).ToString("0.##") + "%" : "-")
+                            @if (stats.CurrentlyObstructed == true)
+                            {
+                                <span class="starlink-badge starlink-badge-danger">now</span>
+                            }
+                        </span>
+                    </div>
+                    <div class="starlink-metric-row">
+                        <span class="starlink-metric-label">Dish loss</span>
+                        <span class="starlink-metric-value @GetDropRateClass()">@FormatDropRate()</span>
+                    </div>
+                    <div class="starlink-metric-row">
+                        <span class="starlink-metric-label">Power</span>
+                        <span class="starlink-metric-value">@FormatPower()</span>
+                    </div>
+                    <div class="starlink-metric-row">
+                        <span class="starlink-metric-label">Ethernet</span>
+                        <span class="starlink-metric-value @(stats.EthSpeedMbps < 1000 ? "fair" : "")">
+                            @(stats.EthSpeedMbps.HasValue ? $"{stats.EthSpeedMbps} Mbps" : "-")
+                        </span>
+                    </div>
+                    <div class="starlink-metric-row">
+                        <span class="starlink-metric-label">Uptime</span>
+                        <span class="starlink-metric-value">@FormatUptime()</span>
+                    </div>
+                    <div class="starlink-metric-row">
+                        <span class="starlink-metric-label">GPS</span>
+                        <span class="starlink-metric-value @(stats.GpsValid == false ? "poor" : "")">
+                            @(stats.GpsSatellites.HasValue ? $"{stats.GpsSatellites} sats" : "-")
+                        </span>
+                    </div>
+                    @if (stats.LastOutageAt.HasValue)
+                    {
+                        <div class="starlink-metric-row">
+                            <span class="starlink-metric-label">Last outage</span>
+                            <span class="starlink-metric-value">@FormatLastOutage()</span>
+                        </div>
+                    }
+                }
+            </div>
+        </div>
+
+        @if (stats != null)
+        {
+            @if (stats.ActiveAlerts.Count > 0)
+            {
+                <div class="starlink-alerts">
+                    @foreach (var alert in stats.ActiveAlerts)
+                    {
+                        <span class="starlink-badge starlink-badge-warning">@HumanizeToken(alert)</span>
+                    }
+                </div>
+            }
+            @foreach (var notice in GetNotices())
+            {
+                <div class="starlink-notice">@notice</div>
+            }
+        }
+
+        <div class="sqm-actions">
+            <button class="btn btn-secondary" @onclick="RefreshStats" @onclick:stopPropagation disabled="@isRefreshing">
+                @if (isRefreshing)
+                {
+                    <span class="spinner-sm"></span>
+                }
+                else
+                {
+                    <span>Refresh</span>
+                }
+            </button>
+            <a href="/settings#starlink" class="btn btn-primary" @onclick:stopPropagation>Starlink Settings</a>
+        </div>
+    }
+</div>
+
+<style>
+    .starlink-stats-panel {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .starlink-header-right {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+    }
+
+    .starlink-layout {
+        display: flex;
+        gap: 1rem;
+        align-items: flex-start;
+    }
+
+    .starlink-sky {
+        position: relative;
+        flex-shrink: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.35rem;
+    }
+
+    .starlink-sky-canvas {
+        width: 164px;
+        height: 164px;
+        border-radius: 50%;
+        background: var(--bg-tertiary);
+        box-shadow: 0 0 18px rgba(43, 168, 154, 0.12), inset 0 0 12px rgba(0, 0, 0, 0.4);
+    }
+
+    .starlink-sky-placeholder {
+        position: absolute;
+        top: 0;
+        width: 164px;
+        height: 164px;
+        border-radius: 50%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+        font-size: 0.75rem;
+        color: var(--text-muted, #888);
+    }
+
+    .starlink-sky-caption {
+        font-size: 0.7rem;
+        color: var(--text-muted, #888);
+    }
+
+    .starlink-metrics {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+        min-width: 0;
+    }
+
+    .starlink-metric-row {
+        display: flex;
+        justify-content: space-between;
+        gap: 0.5rem;
+        font-size: 0.85rem;
+    }
+
+    .starlink-metric-label {
+        color: var(--text-muted, #888);
+        flex-shrink: 0;
+    }
+
+    .starlink-metric-value {
+        font-family: monospace;
+        color: var(--text-primary);
+        text-align: right;
+        display: flex;
+        align-items: center;
+        gap: 0.35rem;
+    }
+
+    .starlink-metric-value.good { color: var(--success-color, #22c55e); }
+    .starlink-metric-value.fair { color: var(--warning-color, #f59e0b); }
+    .starlink-metric-value.poor { color: var(--danger-color, #ef4444); }
+
+    .starlink-alerts {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.35rem;
+    }
+
+    .starlink-badge {
+        padding: 2px 8px;
+        border-radius: 4px;
+        font-size: 0.7rem;
+        font-weight: 600;
+    }
+
+    .starlink-badge-warning {
+        background: rgba(231, 150, 19, 0.18);
+        color: var(--warning-color, #e79613);
+    }
+
+    .starlink-badge-danger {
+        background: rgba(238, 99, 104, 0.18);
+        color: var(--danger-color, #ee6368);
+    }
+
+    .starlink-notice {
+        font-size: 0.75rem;
+        color: var(--text-secondary, #a0a0a8);
+        font-style: italic;
+    }
+
+    @@media (max-width: 768px) {
+        .starlink-layout {
+            flex-direction: column;
+            align-items: center;
+        }
+
+        .starlink-metrics {
+            width: 100%;
+        }
+    }
+</style>
+
+@code {
+    private StarlinkStats? stats;
+    private StarlinkObstructionMap? obstructionMap;
+    private bool isLoading = true;
+    private bool isRefreshing = false;
+    private bool hasConfiguredTerminals = false;
+    private List<NetworkOptimizer.Storage.Models.StarlinkConfiguration> configuredTerminals = new();
+    private int currentIndex = 0;
+    private System.Threading.Timer? _refreshTimer;
+
+    private ElementReference mapCanvas;
+    private IJSObjectReference? _mapModule;
+    private string? _renderedMapStamp;
+
+    /// <summary>
+    /// The terminal ID currently displayed, for deep-linking to charts.
+    /// </summary>
+    public string? CurrentStarlinkId => configuredTerminals.Count > 0 && currentIndex < configuredTerminals.Count
+        ? configuredTerminals[currentIndex].Id.ToString()
+        : null;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadStats();
+
+        // Pick up cached stats from background polling
+        _refreshTimer = new System.Threading.Timer(
+            async _ => await InvokeAsync(() =>
+            {
+                if (!isRefreshing && !isLoading && configuredTerminals.Count > 0 && currentIndex < configuredTerminals.Count)
+                {
+                    var terminal = configuredTerminals[currentIndex];
+                    var newStats = StarlinkService.GetCachedStats(terminal.Id);
+                    if (newStats != null)
+                    {
+                        stats = newStats;
+                        obstructionMap = StarlinkService.GetCachedObstructionMap(terminal.Id);
+                        StateHasChanged();
+                    }
+                }
+            }),
+            null,
+            TimeSpan.FromSeconds(15),
+            TimeSpan.FromSeconds(15));
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (obstructionMap == null) return;
+
+        var stamp = $"{CurrentStarlinkId}:{obstructionMap.Timestamp:O}";
+        if (stamp == _renderedMapStamp) return;
+
+        try
+        {
+            _mapModule ??= await JS.InvokeAsync<IJSObjectReference>(
+                "import", "/js/starlink-obstruction-map.js?v=1");
+            await _mapModule.InvokeVoidAsync("render", mapCanvas, new
+            {
+                rows = obstructionMap.NumRows,
+                cols = obstructionMap.NumCols,
+                snr = obstructionMap.Snr,
+            });
+            _renderedMapStamp = stamp;
+        }
+        catch (JSDisconnectedException)
+        {
+            // Circuit gone; nothing to render
+        }
+    }
+
+    private async Task LoadStats()
+    {
+        isLoading = true;
+        try
+        {
+            configuredTerminals = await StarlinkService.GetConfigsAsync();
+            hasConfiguredTerminals = configuredTerminals.Any();
+
+            if (hasConfiguredTerminals)
+            {
+                var enabledIndex = configuredTerminals.FindIndex(t => t.Enabled);
+                currentIndex = enabledIndex >= 0 ? enabledIndex : 0;
+                await ShowStatsForCurrentTerminal(pollIfEmpty: true);
+            }
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+
+    private async Task RefreshStats()
+    {
+        isRefreshing = true;
+        StateHasChanged();
+
+        try
+        {
+            if (configuredTerminals.Count > 0 && currentIndex < configuredTerminals.Count)
+            {
+                var terminal = configuredTerminals[currentIndex];
+                await StarlinkService.PollStarlinkAsync(terminal.Id);
+                stats = StarlinkService.GetCachedStats(terminal.Id);
+                obstructionMap = StarlinkService.GetCachedObstructionMap(terminal.Id);
+            }
+        }
+        finally
+        {
+            isRefreshing = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task PreviousTerminal()
+    {
+        if (currentIndex > 0)
+        {
+            currentIndex--;
+            await ShowStatsForCurrentTerminal(pollIfEmpty: true);
+        }
+    }
+
+    private async Task NextTerminal()
+    {
+        if (currentIndex < configuredTerminals.Count - 1)
+        {
+            currentIndex++;
+            await ShowStatsForCurrentTerminal(pollIfEmpty: true);
+        }
+    }
+
+    private async Task ShowStatsForCurrentTerminal(bool pollIfEmpty)
+    {
+        if (configuredTerminals.Count == 0 || currentIndex >= configuredTerminals.Count) return;
+
+        var terminal = configuredTerminals[currentIndex];
+        stats = StarlinkService.GetCachedStats(terminal.Id);
+        obstructionMap = StarlinkService.GetCachedObstructionMap(terminal.Id);
+        StateHasChanged();
+
+        if (stats == null && pollIfEmpty)
+        {
+            await StarlinkService.PollStarlinkAsync(terminal.Id);
+            stats = StarlinkService.GetCachedStats(terminal.Id);
+            obstructionMap = StarlinkService.GetCachedObstructionMap(terminal.Id);
+            StateHasChanged();
+        }
+    }
+
+    private string GetStatusClass()
+    {
+        if (stats == null) return "disconnected";
+        if (stats.DisablementCode is not null && stats.DisablementCode != "Okay") return "disconnected";
+        if (stats.ActiveAlerts.Count > 0 || stats.CurrentlyObstructed == true) return "warning";
+        return "active";
+    }
+
+    private string GetObstructionClass()
+    {
+        if (stats?.FractionObstructed is not double f) return "";
+        if (f < 0.002) return "good";
+        if (f < 0.01) return "fair";
+        return "poor";
+    }
+
+    private string GetDropRateClass()
+    {
+        if (stats?.PingDropRateAvg is not double d) return "";
+        if (d < 0.005) return "good";
+        if (d < 0.02) return "fair";
+        return "poor";
+    }
+
+    private string FormatDropRate()
+    {
+        if (stats?.PingDropRateAvg is not double avg) return "-";
+        var s = (avg * 100).ToString("0.##") + "%";
+        if (stats.PingDropRateMax is double max && max > avg)
+            s += $" (peak {(max * 100).ToString("0.#")}%)";
+        return s;
+    }
+
+    private string FormatPower()
+    {
+        if (stats?.PowerInWatts is not double w) return "-";
+        var s = w.ToString("0") + " W";
+        if (stats.PowerInMaxWatts is double max && max > w)
+            s += $" (peak {max:0} W)";
+        return s;
+    }
+
+    private string FormatUptime()
+    {
+        if (stats?.UptimeSeconds is not long s) return "-";
+        var t = TimeSpan.FromSeconds(s);
+        if (t.TotalDays >= 1) return $"{(int)t.TotalDays}d {t.Hours}h";
+        if (t.TotalHours >= 1) return $"{(int)t.TotalHours}h {t.Minutes}m";
+        return $"{t.Minutes}m";
+    }
+
+    private string FormatLastOutage()
+    {
+        if (stats?.LastOutageAt is not DateTime at) return "-";
+        var ago = DateTime.UtcNow - at;
+        string agoText = ago.TotalDays >= 1 ? $"{(int)ago.TotalDays}d ago"
+            : ago.TotalHours >= 1 ? $"{(int)ago.TotalHours}h ago"
+            : $"{Math.Max(0, (int)ago.TotalMinutes)}m ago";
+        var cause = stats.LastOutageCause != null ? HumanizeToken(stats.LastOutageCause) : "Outage";
+        return $"{cause}, {agoText}";
+    }
+
+    /// <summary>
+    /// Notable service states worth a line under the metrics; healthy values
+    /// (Okay, Idle, NoLimit) stay silent.
+    /// </summary>
+    private List<string> GetNotices()
+    {
+        var notices = new List<string>();
+        if (stats == null) return notices;
+
+        if (stats.DisablementCode is not null and not "Okay" and not "UnknownState")
+            notices.Add($"Service disabled: {HumanizeToken(stats.DisablementCode)}");
+
+        if (stats.SoftwareUpdateState is not null and not "Idle" and not "SoftwareUpdateStateUnknown" and not "Unknown")
+            notices.Add($"Software update: {HumanizeToken(stats.SoftwareUpdateState)}");
+
+        var dlLimited = IsLimited(stats.DownlinkRestrictedReason);
+        var ulLimited = IsLimited(stats.UplinkRestrictedReason);
+        if (dlLimited && ulLimited)
+            notices.Add("Speeds are limited by the service plan");
+        else if (dlLimited)
+            notices.Add($"Download limited: {HumanizeToken(stats.DownlinkRestrictedReason!)}");
+        else if (ulLimited)
+            notices.Add($"Upload limited: {HumanizeToken(stats.UplinkRestrictedReason!)}");
+
+        if (stats.HardwareSelfTest == "Failed")
+        {
+            var codes = stats.HardwareSelfTestCodes.Count > 0
+                ? $" ({string.Join(", ", stats.HardwareSelfTestCodes)})"
+                : "";
+            notices.Add($"Hardware self-test failed{codes}");
+        }
+
+        return notices;
+    }
+
+    private static bool IsLimited(string? reason) =>
+        reason is not null and not "NoLimit" and not "Unknown";
+
+    /// <summary>"thermal_throttle" or "ThermalThrottle" -> "Thermal throttle".</summary>
+    private static string HumanizeToken(string token)
+    {
+        if (string.IsNullOrEmpty(token)) return token;
+        var words = System.Text.RegularExpressions.Regex
+            .Replace(token.Replace('_', ' '), "(?<=[a-z0-9])(?=[A-Z])", " ")
+            .ToLowerInvariant();
+        return char.ToUpperInvariant(words[0]) + words[1..];
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _refreshTimer?.Dispose();
+        if (_mapModule != null)
+        {
+            try { await _mapModule.DisposeAsync(); }
+            catch (JSDisconnectedException) { }
+        }
+    }
+}

--- a/src/NetworkOptimizer.Web/Endpoints/StarlinkChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/StarlinkChartEndpoints.cs
@@ -1,0 +1,138 @@
+using NetworkOptimizer.Storage.Services;
+using NetworkOptimizer.Web.Services;
+
+namespace NetworkOptimizer.Web.Endpoints;
+
+/// <summary>
+/// REST endpoints for Starlink terminal monitoring data: time-series metrics
+/// for charting, the cached obstruction sky map, and live cached stats.
+/// Mirrors the cellular/CM chart endpoint pattern.
+/// </summary>
+public static class StarlinkChartEndpoints
+{
+    public static void Map(WebApplication app)
+    {
+        app.MapGet("/api/monitoring/starlink-chart", async (
+            MonitoringInfluxClient influx,
+            StarlinkMonitorService starlinkService,
+            int? rangeHours,
+            DateTime? from,
+            DateTime? to,
+            string? starlinkId,
+            CancellationToken ct) =>
+        {
+            DateTime queryFrom, queryTo;
+            if (from.HasValue && to.HasValue)
+            {
+                queryFrom = from.Value.ToUniversalTime();
+                queryTo = to.Value.ToUniversalTime();
+            }
+            else
+            {
+                var hours = rangeHours ?? 1;
+                queryTo = DateTime.UtcNow;
+                queryFrom = hours == 0 ? queryTo.AddMinutes(-15) : queryTo.AddHours(-hours);
+            }
+
+            var data = await influx.QueryStarlinkAsync(queryFrom, queryTo, starlinkId, ct: ct);
+
+            var configs = await starlinkService.GetConfigsAsync();
+            var nameMap = configs.ToDictionary(c => c.Id.ToString(), c => c.Name);
+
+            // Only surface terminals that still have a config. Deleting a config
+            // leaves its historical series in InfluxDB; without this filter those
+            // orphaned starlink_ids show up as phantom entries on the chart.
+            var result = data
+                .Where(kvp => nameMap.ContainsKey(kvp.Key))
+                .Select(kvp =>
+            {
+                var name = nameMap[kvp.Key];
+
+                return new
+                {
+                    id = kvp.Key,
+                    label = name,
+                    data = kvp.Value.Select(p => new
+                    {
+                        time = p.Time.ToString("o"),
+                        powerAvg = p.PowerInAvgW,
+                        powerMax = p.PowerInMaxW,
+                        dropAvg = p.PingDropRateAvg,
+                        dropMax = p.PingDropRateMax,
+                        obstructed = p.FractionObstructed,
+                        outageSeconds = p.OutageSecondsDelta,
+                        outageCount = p.OutageCountDelta,
+                        gpsSats = p.GpsSats,
+                        alignment = p.AlignmentOffsetDeg,
+                        ethSpeed = p.EthSpeedMbps,
+                        uptime = p.UptimeS,
+                        alerts = p.AlertCount,
+                    })
+                };
+            });
+
+            return Results.Ok(new { devices = result });
+        });
+
+        app.MapGet("/api/monitoring/starlink/{id:int}/obstruction-map", (
+            StarlinkMonitorService starlinkService,
+            int id) =>
+        {
+            var map = starlinkService.GetCachedObstructionMap(id);
+            if (map == null)
+                return Results.NotFound();
+
+            return Results.Ok(new
+            {
+                numRows = map.NumRows,
+                numCols = map.NumCols,
+                maxThetaDeg = map.MaxThetaDeg,
+                snr = map.Snr,
+                timestamp = map.Timestamp.ToString("o"),
+            });
+        });
+
+        app.MapGet("/api/monitoring/starlink/stats", async (
+            StarlinkMonitorService starlinkService) =>
+        {
+            var configs = await starlinkService.GetConfigsAsync();
+            var cached = starlinkService.GetAllCachedStats();
+
+            var terminals = configs.Select(c =>
+            {
+                cached.TryGetValue(c.Id, out var s);
+                return new
+                {
+                    id = c.Id,
+                    name = c.Name,
+                    enabled = c.Enabled,
+                    lastPolled = c.LastPolled?.ToString("o"),
+                    lastError = c.LastError,
+                    stats = s == null ? null : new
+                    {
+                        timestamp = s.Timestamp.ToString("o"),
+                        uptimeSeconds = s.UptimeSeconds,
+                        softwareVersion = s.SoftwareVersion,
+                        hardwareVersion = s.HardwareVersion,
+                        ethSpeedMbps = s.EthSpeedMbps,
+                        powerInWatts = s.PowerInWatts,
+                        powerInAvgWatts = s.PowerInAvgWatts,
+                        powerInMaxWatts = s.PowerInMaxWatts,
+                        fractionObstructed = s.FractionObstructed,
+                        currentlyObstructed = s.CurrentlyObstructed,
+                        pingDropRateAvg = s.PingDropRateAvg,
+                        pingDropRateMax = s.PingDropRateMax,
+                        gpsValid = s.GpsValid,
+                        gpsSatellites = s.GpsSatellites,
+                        alignmentOffsetDeg = StarlinkMonitorService.ComputeAlignmentOffsetDeg(s),
+                        outageCountDelta = s.OutageCountDelta,
+                        outageSecondsDelta = s.OutageSecondsDelta,
+                        activeAlerts = s.ActiveAlerts,
+                    },
+                };
+            });
+
+            return Results.Ok(new { terminals });
+        });
+    }
+}

--- a/src/NetworkOptimizer.Web/NetworkOptimizer.Web.csproj
+++ b/src/NetworkOptimizer.Web/NetworkOptimizer.Web.csproj
@@ -41,12 +41,17 @@
   <ItemGroup>
     <PackageReference Include="Blazor-ApexCharts" Version="6.1.1-ozarkconnect.2" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.80.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.80.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.7" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="SSH.NET" Version="2025.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="Protos\starlink_device.proto" GrpcServices="Client" />
   </ItemGroup>
 
 </Project>

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -260,6 +260,7 @@ builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.IUniFiRepository,
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.IModemRepository, NetworkOptimizer.Storage.Repositories.ModemRepository>();
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.ICmRepository, NetworkOptimizer.Storage.Repositories.CmRepository>();
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.IOntRepository, NetworkOptimizer.Storage.Repositories.OntRepository>();
+builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.IStarlinkRepository, NetworkOptimizer.Storage.Repositories.StarlinkRepository>();
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.IMonitoringInterfaceRepository, NetworkOptimizer.Storage.Repositories.MonitoringInterfaceRepository>();
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.ISpeedTestRepository, NetworkOptimizer.Storage.Repositories.SpeedTestRepository>();
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.ISqmRepository, NetworkOptimizer.Storage.Repositories.SqmRepository>();
@@ -353,6 +354,13 @@ builder.Services.AddSingleton<IOntProvider, GenericHttpOntProvider>();
 builder.Services.AddSingleton<IOntProvider, TelekomModem2OntProvider>();
 builder.Services.AddScoped(sp => sp.GetRequiredService<ModemMonitorRegistry>()
     .GetFor(sp.GetRequiredService<SiteContextService>().Slug).Ont);
+
+// Starlink terminal monitoring is per site through ModemMonitorRegistry, which
+// builds each site's provider set (the gRPC provider keeps per-config history
+// state, so instances are per site like the cellular providers). Scoped
+// resolution forwards to the current site's monitor.
+builder.Services.AddScoped(sp => sp.GetRequiredService<ModemMonitorRegistry>()
+    .GetFor(sp.GetRequiredService<SiteContextService>().Slug).Starlink);
 
 // LAN iperf3 speed test per site (registry-owned): devices, credentials, and
 // results live in that site's database; tests run against that site's devices.
@@ -1984,6 +1992,7 @@ SfpChartEndpoints.Map(app);
 CellularChartEndpoints.Map(app);
 CmChartEndpoints.Map(app);
 OntChartEndpoints.Map(app);
+StarlinkChartEndpoints.Map(app);
 SnmpEndpoints.Map(app);
 
 app.Run();

--- a/src/NetworkOptimizer.Web/Protos/starlink_device.proto
+++ b/src/NetworkOptimizer.Web/Protos/starlink_device.proto
@@ -1,0 +1,295 @@
+// Trimmed subset of the Starlink user terminal gRPC API (SpaceX.API.Device),
+// reconstructed from the dish's own gRPC reflection (apiVersion 42).
+// Field numbers MUST match the dish's descriptors; names are cosmetic.
+// Only read-only requests used for monitoring are included - unknown fields
+// in responses are skipped by protobuf, so newer/richer firmware payloads
+// parse fine. No control RPCs (reboot, stow, config) are declared.
+syntax = "proto3";
+
+package SpaceX.API.Device;
+
+option csharp_namespace = "NetworkOptimizer.Web.Services.StarlinkProviders.Proto";
+
+service Device {
+  rpc Handle(Request) returns (Response);
+}
+
+message Request {
+  oneof request {
+    GetStatusRequest get_status = 1004;
+    GetHistoryRequest get_history = 1007;
+    GetDeviceInfoRequest get_device_info = 1008;
+    DishGetObstructionMapRequest dish_get_obstruction_map = 2008;
+    GetDiagnosticsRequest get_diagnostics = 6000;
+  }
+}
+
+message Response {
+  uint64 id = 1;
+  uint64 api_version = 3;
+  oneof response {
+    GetDeviceInfoResponse get_device_info = 1004;
+    DishGetStatusResponse dish_get_status = 2004;
+    DishGetHistoryResponse dish_get_history = 2006;
+    DishGetObstructionMapResponse dish_get_obstruction_map = 2008;
+    DishGetDiagnosticsResponse dish_get_diagnostics = 6001;
+  }
+}
+
+message GetStatusRequest {
+}
+
+message GetHistoryRequest {
+}
+
+message GetDeviceInfoRequest {
+}
+
+message DishGetObstructionMapRequest {
+}
+
+message GetDiagnosticsRequest {
+}
+
+message GetDeviceInfoResponse {
+  DeviceInfo device_info = 1;
+}
+
+message DeviceInfo {
+  string id = 1;
+  string hardware_version = 2;
+  string software_version = 3;
+  string country_code = 4;
+  int32 utc_offset_s = 5;
+  int32 bootcount = 8;
+  int64 generation_number = 12;
+  string build_id = 15;
+}
+
+message DeviceState {
+  uint64 uptime_s = 1;
+}
+
+message DishGetStatusResponse {
+  DeviceInfo device_info = 1;
+  DeviceState device_state = 2;
+  float pop_ping_drop_rate = 1003;
+  DishObstructionStats obstruction_stats = 1004;
+  DishAlerts alerts = 1005;
+  float boresight_azimuth_deg = 1011;
+  float boresight_elevation_deg = 1012;
+  DishGpsStats gps_stats = 1015;
+  int32 eth_speed_mbps = 1016;
+  UserMobilityClass mobility_class = 1017;
+  bool is_snr_above_noise_floor = 1018;
+  UserClassOfService class_of_service = 1020;
+  SoftwareUpdateState software_update_state = 1021;
+  bool is_snr_persistently_low = 1022;
+  UtDisablementCode disablement_code = 1024;
+  SoftwareUpdateStats software_update_stats = 1026;
+  AlignmentStats alignment_stats = 1027;
+  bool swupdate_reboot_ready = 1030;
+  int32 seconds_until_swupdate_reboot_possible = 1031;
+  RateLimitReason dl_bandwidth_restricted_reason = 1044;
+  RateLimitReason ul_bandwidth_restricted_reason = 1045;
+  bool treat_as_metered = 1056;
+}
+
+message DishObstructionStats {
+  float fraction_obstructed = 1;
+  float valid_s = 4;
+  bool currently_obstructed = 5;
+  float avg_prolonged_obstruction_duration_s = 6;
+  float avg_prolonged_obstruction_interval_s = 7;
+  bool avg_prolonged_obstruction_valid = 8;
+  float time_obstructed = 9;
+  uint32 patches_valid = 10;
+}
+
+message DishAlerts {
+  bool motors_stuck = 1;
+  bool thermal_shutdown = 2;
+  bool thermal_throttle = 3;
+  bool unexpected_location = 4;
+  bool mast_not_near_vertical = 5;
+  bool slow_ethernet_speeds = 6;
+  bool roaming = 7;
+  bool install_pending = 8;
+  bool is_heating = 9;
+  bool power_supply_thermal_throttle = 10;
+  bool is_power_save_idle = 11;
+  bool dbf_telem_stale = 14;
+  bool low_motor_current = 16;
+  bool lower_signal_than_predicted = 17;
+  bool slow_ethernet_speeds_100 = 18;
+  bool obstruction_map_reset = 19;
+  bool dish_water_detected = 20;
+  bool router_water_detected = 21;
+  bool upsu_router_port_slow = 22;
+  bool no_ethernet_link = 23;
+}
+
+message DishGpsStats {
+  bool gps_valid = 1;
+  uint32 gps_sats = 2;
+  AttitudeEstimationState pnt_filter_convergence_state = 5;
+}
+
+message AlignmentStats {
+  float tilt_angle_deg = 3;
+  float boresight_azimuth_deg = 4;
+  float boresight_elevation_deg = 5;
+  AttitudeEstimationState attitude_estimation_state = 6;
+  float attitude_uncertainty_deg = 7;
+  float desired_boresight_azimuth_deg = 8;
+  float desired_boresight_elevation_deg = 9;
+}
+
+message SoftwareUpdateStats {
+  SoftwareUpdateState software_update_state = 1;
+  float software_update_progress = 2;
+  bool update_requires_reboot = 3;
+  int64 reboot_scheduled_utc_time = 4;
+}
+
+message DishGetHistoryResponse {
+  uint64 current = 1;
+  repeated float pop_ping_drop_rate = 1001;
+  repeated DishOutage outages = 1009;
+  repeated float power_in = 1010;
+}
+
+message DishOutage {
+  enum Cause {
+    UNKNOWN = 0;
+    BOOTING = 1;
+    STOWED = 2;
+    THERMAL_SHUTDOWN = 3;
+    NO_SCHEDULE = 4;
+    NO_SATS = 5;
+    OBSTRUCTED = 6;
+    NO_DOWNLINK = 7;
+    NO_PINGS = 8;
+    ACTUATOR_ACTIVITY = 9;
+    CABLE_TEST = 10;
+    SLEEPING = 11;
+    SKY_SEARCH = 13;
+    INHIBIT_RF = 14;
+  }
+  Cause cause = 1;
+  int64 start_timestamp_ns = 2;
+  uint64 duration_ns = 3;
+  bool did_switch = 4;
+}
+
+message DishGetObstructionMapResponse {
+  uint32 num_rows = 1;
+  uint32 num_cols = 2;
+  repeated float snr = 3;
+  float max_theta_deg = 5;
+  ObstructionMapReferenceFrame map_reference_frame = 6;
+}
+
+message DishGetDiagnosticsResponse {
+  enum TestResult {
+    NO_RESULT = 0;
+    PASSED = 1;
+    FAILED = 2;
+  }
+  enum TestResultCode {
+    GENERAL = 0;
+    BOOT_UP = 1;
+    CPU_VOLTAGE = 2;
+    DBF_AAP_CS = 3;
+    DBF_NUM_FEMS = 4;
+    DBF_READ_ERRORS = 5;
+    DBF_T_DIE_0 = 6;
+    DBF_T_DIE_1 = 7;
+    DBF_T_DIE_0_VALID = 8;
+    DBF_T_DIE_1_VALID = 9;
+    ETH_PRIME = 10;
+    EIRP = 11;
+    FEM_CUT = 12;
+    FUSE_AVS = 13;
+    GPS = 14;
+    IMU = 15;
+    PHY = 16;
+    SCP_ERROR = 17;
+    TEMPERATURE = 18;
+    VTSENS = 19;
+  }
+  string id = 1;
+  string hardware_version = 2;
+  string software_version = 3;
+  TestResult hardware_self_test = 7;
+  repeated TestResultCode hardware_self_test_codes = 11;
+}
+
+enum UserMobilityClass {
+  STATIONARY = 0;
+  NOMADIC = 1;
+  MOBILE = 2;
+}
+
+enum UserClassOfService {
+  UNKNOWN_USER_CLASS_OF_SERVICE = 0;
+  CONSUMER = 1;
+  BUSINESS = 2;
+  BUSINESS_PLUS = 3;
+  COMMERCIAL_AVIATION = 4;
+}
+
+enum SoftwareUpdateState {
+  SOFTWARE_UPDATE_STATE_UNKNOWN = 0;
+  IDLE = 1;
+  FETCHING = 2;
+  PRE_CHECK = 3;
+  WRITING = 4;
+  POST_CHECK = 5;
+  REBOOT_REQUIRED = 6;
+  DISABLED = 7;
+  FAULTED = 8;
+}
+
+enum AttitudeEstimationState {
+  FILTER_RESET = 0;
+  FILTER_UNCONVERGED = 1;
+  FILTER_CONVERGED = 2;
+  FILTER_FAULTED = 3;
+  FILTER_INVALID = 4;
+}
+
+enum UtDisablementCode {
+  UNKNOWN_STATE = 0;
+  OKAY = 1;
+  NO_ACTIVE_ACCOUNT = 2;
+  TOO_FAR_FROM_SERVICE_ADDRESS = 3;
+  IN_OCEAN = 4;
+  BLOCKED_COUNTRY = 6;
+  DATA_OVERAGE_SANDBOX_POLICY = 7;
+  CELL_IS_DISABLED = 8;
+  ROAM_RESTRICTED = 10;
+  UNKNOWN_LOCATION = 11;
+  ACCOUNT_DISABLED = 12;
+  UNSUPPORTED_VERSION = 13;
+  MOVING_TOO_FAST_FOR_POLICY = 14;
+  UNDER_AVIATION_FLYOVER_LIMITS = 15;
+  BLOCKED_AREA = 16;
+}
+
+// Lives in SpaceX.API.Telemetron.Public.Integrations upstream; enums are
+// varint on the wire, so redeclaring it in this package is wire-compatible.
+enum RateLimitReason {
+  UNKNOWN = 0;
+  NO_LIMIT = 1;
+  POLICY_LIMIT = 2;
+  USER_CUSTOM_LIMIT = 3;
+  OVERAGE_LIMIT = 5;
+  LOW_SPEED_POLICY_LIMIT = 6;
+}
+
+enum ObstructionMapReferenceFrame {
+  FRAME_UNKNOWN = 0;
+  FRAME_EARTH = 1;
+  FRAME_UT = 2;
+}

--- a/src/NetworkOptimizer.Web/Services/DashboardLayoutService.cs
+++ b/src/NetworkOptimizer.Web/Services/DashboardLayoutService.cs
@@ -15,6 +15,7 @@ public static class DashboardCards
     public const string CellularStats = "cellular-stats";
     public const string CmStats = "cm-stats";
     public const string OntStats = "ont-stats";
+    public const string StarlinkStats = "starlink-stats";
     public const string SpeedTests = "speed-tests";
     public const string WiFiOptimizer = "wifi-optimizer";
     public const string RecentAlerts = "recent-alerts";
@@ -25,7 +26,7 @@ public static class DashboardCards
     public static readonly string[] All =
     [
         StatsRow, SecurityPosture, SqmStatus, ThreatTrends, CellularStats, CmStats, OntStats,
-        SpeedTests, WiFiOptimizer, RecentAlerts, DeviceStatus, LiveView
+        StarlinkStats, SpeedTests, WiFiOptimizer, RecentAlerts, DeviceStatus, LiveView
     ];
 
     /// <summary>Default full-width cards</summary>
@@ -44,6 +45,7 @@ public static class DashboardCards
         CellularStats => "Cellular Stats",
         CmStats => "Cable Modem Stats",
         OntStats => "ONT Stats",
+        StarlinkStats => "Starlink Stats",
         SpeedTests => "Speed Tests",
         WiFiOptimizer => "Wi-Fi Optimizer",
         RecentAlerts => "Recent Security Findings",

--- a/src/NetworkOptimizer.Web/Services/ModemMonitorRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/ModemMonitorRegistry.cs
@@ -23,7 +23,8 @@ public class ModemMonitorRegistry : BackgroundService
     public sealed record SiteModemMonitors(
         CableModemMonitorService CableModem,
         OntMonitorService Ont,
-        CellularModemService Cellular);
+        CellularModemService Cellular,
+        StarlinkMonitorService Starlink);
 
     private static readonly TimeSpan ReconcileInterval = TimeSpan.FromSeconds(30);
 
@@ -61,11 +62,20 @@ public class ModemMonitorRegistry : BackgroundService
                 ActivatorUtilities.CreateInstance<NetgearNighthawkHotspotProvider>(_serviceProvider),
                 ActivatorUtilities.CreateInstance<QuectelAtModemProvider>(_serviceProvider),
             };
+            // Starlink providers are also per site: the gRPC provider keeps
+            // per-config history-counter state keyed by configuration ID, which
+            // must not collide across site databases.
+            var starlinkProviders = new List<IStarlinkProvider>
+            {
+                ActivatorUtilities.CreateInstance<StarlinkProviders.StarlinkGrpcProvider>(_serviceProvider),
+            };
             return new SiteModemMonitors(
                 ActivatorUtilities.CreateInstance<CableModemMonitorService>(_serviceProvider, s),
                 ActivatorUtilities.CreateInstance<OntMonitorService>(_serviceProvider, s),
                 ActivatorUtilities.CreateInstance<CellularModemService>(
-                    _serviceProvider, s, siteSsh, (IEnumerable<ICellularModemProvider>)cellularProviders));
+                    _serviceProvider, s, siteSsh, (IEnumerable<ICellularModemProvider>)cellularProviders),
+                ActivatorUtilities.CreateInstance<StarlinkMonitorService>(
+                    _serviceProvider, s, (IEnumerable<IStarlinkProvider>)starlinkProviders));
         });
 
     /// <summary>The default site's modem monitors.</summary>
@@ -101,6 +111,7 @@ public class ModemMonitorRegistry : BackgroundService
             bundle.CableModem.DisposeOwned();
             bundle.Ont.DisposeOwned();
             bundle.Cellular.DisposeOwned();
+            bundle.Starlink.DisposeOwned();
         }
     }
 
@@ -153,6 +164,11 @@ public class ModemMonitorRegistry : BackgroundService
         {
             bundle.Cellular.Active = active;
             _logger.LogInformation("Cellular modem monitoring {State} for a site", active ? "activated" : "deactivated");
+        }
+        if (bundle.Starlink.Active != active)
+        {
+            bundle.Starlink.Active = active;
+            _logger.LogInformation("Starlink monitoring {State} for a site", active ? "activated" : "deactivated");
         }
     }
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkModels.cs
@@ -12,7 +12,9 @@ public enum PhysicalMedium
     /// <summary>DOCSIS cable modem.</summary>
     Docsis,
     /// <summary>Cellular (LTE / 5G) modem.</summary>
-    Cellular
+    Cellular,
+    /// <summary>Satellite (Starlink) terminal.</summary>
+    Satellite
 }
 
 /// <summary>
@@ -113,6 +115,35 @@ public class PhysicalLinkInput
 
     /// <summary>True when the modem is 5G-capable (so a downgrade is meaningful).</summary>
     public bool Is5gCapable { get; init; }
+
+    // --- Satellite (Starlink) ---
+
+    /// <summary>Median fraction of sky time obstructed over the window (0..1).</summary>
+    public double? ObstructionFraction { get; init; }
+
+    /// <summary>Whether the dish reported itself obstructed on the latest poll.</summary>
+    public bool? CurrentlyObstructed { get; init; }
+
+    /// <summary>Mean dish-to-ground ping drop rate over the window (0..1), from the dish's own 1 Hz history.</summary>
+    public double? DishDropRateAvg { get; init; }
+
+    /// <summary>Worst 1-second dish drop rate seen in the window (0..1).</summary>
+    public double? DishDropRateMax { get; init; }
+
+    /// <summary>Dish-logged outage seconds over the window, normalized per day via <see cref="WindowDays"/>.</summary>
+    public double? OutageSecondsTotal { get; init; }
+
+    /// <summary>Dish-logged outage count over the window.</summary>
+    public long? OutageCountTotal { get; init; }
+
+    /// <summary>True when the dish reports persistently low SNR (live snapshot).</summary>
+    public bool? SnrPersistentlyLow { get; init; }
+
+    /// <summary>Alert names currently raised by the dish (live snapshot), e.g. "thermal_throttle".</summary>
+    public IReadOnlyList<string>? DishAlerts { get; init; }
+
+    /// <summary>Negotiated dish-to-router Ethernet speed (live snapshot), for the slow-link advisory.</summary>
+    public int? EthSpeedMbps { get; init; }
 }
 
 /// <summary>The Physical Link factor plus any issues it raised.</summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkResolver.cs
@@ -27,6 +27,7 @@ public class PhysicalLinkResolver
     private readonly CableModemMonitorService _cmMonitor;
     private readonly OntMonitorService _ontMonitor;
     private readonly CellularModemService _cellularMonitor;
+    private readonly StarlinkMonitorService _starlinkMonitor;
     private readonly ILogger<PhysicalLinkResolver> _logger;
     private readonly string _siteSlug;
     private readonly bool _isDefault;
@@ -48,6 +49,7 @@ public class PhysicalLinkResolver
         _cmMonitor = monitors.CableModem;
         _ontMonitor = monitors.Ont;
         _cellularMonitor = monitors.Cellular;
+        _starlinkMonitor = monitors.Starlink;
         _logger = logger;
     }
 
@@ -120,6 +122,9 @@ public class PhysicalLinkResolver
             case AccessTechnology.Cellular:
                 return await CellularCandidatesAsync(db, ct);
 
+            case AccessTechnology.Satellite:
+                return await StarlinkCandidatesAsync(db, ct);
+
             case AccessTechnology.PppoE:
                 // Carve-out: PPPoE often rides PON. If exactly one PON source is monitored,
                 // it is safe to assume it is the user's WAN; otherwise stay out of it.
@@ -179,6 +184,14 @@ public class PhysicalLinkResolver
             .ToList();
     }
 
+    private async Task<List<Cand>> StarlinkCandidatesAsync(NetworkOptimizerDbContext db, CancellationToken ct)
+    {
+        return (await db.StarlinkConfigurations.AsNoTracking().Where(s => s.Enabled).ToListAsync(ct))
+            .Where(s => IsFresh(s.LastPolled, s.PollingIntervalSeconds))
+            .Select(s => new Cand($"starlink:{s.Id}", s.Name, PhysicalMedium.Satellite, s.Id, null, null))
+            .ToList();
+    }
+
     /// <summary>A configured device counts as a candidate only if it polled recently (3x its interval, min 15 min).</summary>
     private static bool IsFresh(DateTime? lastPolled, int intervalSeconds) =>
         lastPolled.HasValue && DateTime.UtcNow - lastPolled.Value <= TimeSpan.FromSeconds(Math.Max(900, intervalSeconds * 3));
@@ -197,6 +210,7 @@ public class PhysicalLinkResolver
             PhysicalMedium.ActiveEthernet => await AssembleSfpAsync(c, PhysicalMedium.ActiveEthernet, false, windowStart, windowEnd, aggregate, ct),
             PhysicalMedium.Docsis when c.ConfigId is int cmId => await AssembleCableModemAsync(c, cmId, windowStart, windowEnd, aggregate, ct),
             PhysicalMedium.Cellular when c.ConfigId is int modemId => await AssembleCellularAsync(c, modemId, windowStart, windowEnd, aggregate, ct),
+            PhysicalMedium.Satellite when c.ConfigId is int starlinkId => await AssembleStarlinkAsync(c, starlinkId, windowStart, windowEnd, aggregate, ct),
             _ => null
         };
     }
@@ -376,6 +390,50 @@ public class PhysicalLinkResolver
             NetworkMode = latestMode,
             NetworkModeDowngraded = downgraded,
             Is5gCapable = had5g,
+            WindowDays = (windowEnd - windowStart).TotalDays
+        };
+    }
+
+    private async Task<PhysicalLinkInput?> AssembleStarlinkAsync(
+        Cand c, int starlinkId, DateTime windowStart, DateTime windowEnd, TimeSpan aggregate, CancellationToken ct)
+    {
+        var dict = await _influx.QueryStarlinkAsync(windowStart, windowEnd, starlinkId.ToString(), aggregate, ct);
+        var pts = (dict.Values.FirstOrDefault() ?? new()).OrderBy(p => p.Time).ToList();
+        var live = _starlinkMonitor.GetCachedStats(starlinkId);
+
+        // outage_seconds/count are per-poll deltas summed per aggregate bucket, so summing
+        // buckets recovers the window total. Drop-rate avg is per-poll means; the median of
+        // those is robust to a lone weather burst, while the max keeps the worst second.
+        var outageSeconds = pts.Any(p => p.OutageSecondsDelta.HasValue)
+            ? pts.Where(p => p.OutageSecondsDelta.HasValue).Sum(p => p.OutageSecondsDelta!.Value)
+            : (double?)null;
+        var outageCount = pts.Any(p => p.OutageCountDelta.HasValue)
+            ? pts.Where(p => p.OutageCountDelta.HasValue).Sum(p => p.OutageCountDelta!.Value)
+            : (long?)null;
+
+        var obstruction = Median(pts.Where(p => p.FractionObstructed.HasValue).Select(p => p.FractionObstructed!.Value).ToList())
+                          ?? live?.FractionObstructed;
+        var dropAvg = Median(pts.Where(p => p.PingDropRateAvg.HasValue).Select(p => p.PingDropRateAvg!.Value).ToList())
+                      ?? live?.PingDropRateAvg;
+        var dropMax = pts.Where(p => p.PingDropRateMax.HasValue).Select(p => p.PingDropRateMax!.Value)
+            .DefaultIfEmpty().Max();
+
+        _logger.LogDebug("ISP Health physical: Starlink {Key} - {N} samples, obstructed={Obs}, dropAvg={Drop}, outage={OutS}s/{OutN}",
+            c.Key, pts.Count, obstruction, dropAvg, outageSeconds, outageCount);
+
+        return new PhysicalLinkInput
+        {
+            Medium = PhysicalMedium.Satellite,
+            SourceName = c.Label,
+            ObstructionFraction = obstruction,
+            CurrentlyObstructed = live?.CurrentlyObstructed,
+            DishDropRateAvg = dropAvg,
+            DishDropRateMax = dropMax > 0 ? dropMax : null,
+            OutageSecondsTotal = outageSeconds,
+            OutageCountTotal = outageCount,
+            SnrPersistentlyLow = live?.IsSnrPersistentlyLow,
+            DishAlerts = live?.ActiveAlerts,
+            EthSpeedMbps = live?.EthSpeedMbps,
             WindowDays = (windowEnd - windowStart).TotalDays
         };
     }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkScorer.cs
@@ -49,6 +49,7 @@ public static class PhysicalLinkScorer
             PhysicalMedium.ActiveEthernet => ScoreOptical(input, factorWeight, isPon: false, logger),
             PhysicalMedium.Docsis => ScoreDocsis(input, expectedUploadMbps, factorWeight),
             PhysicalMedium.Cellular => ScoreCellular(input, factorWeight),
+            PhysicalMedium.Satellite => ScoreSatellite(input, factorWeight),
             _ => new PhysicalLinkResult(NullFactor(factorWeight, "no usable physical-link data"), new())
         };
     }
@@ -497,6 +498,164 @@ public static class PhysicalLinkScorer
         return new PhysicalLinkResult(
             Factor(factorWeight, (int)Math.Round(score), $"Signal {quality}/100{modeBit}", desc),
             issues);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Satellite (Starlink)
+    // ---------------------------------------------------------------------------
+
+    /// <summary>Dish alerts that cap the score when raised (live snapshot): name -> (cap, severity, copy).</summary>
+    private static readonly (string Alert, int Cap, IspIssueSeverity Severity, string Title, string Recommendation)[] SatelliteCapAlerts =
+    {
+        ("thermal_shutdown", 10, IspIssueSeverity.Critical, "Starlink: dish in thermal shutdown",
+            "The dish has shut down its radio from heat. Shade the dish or improve airflow; service is down until it cools."),
+        ("thermal_throttle", 50, IspIssueSeverity.Warning, "Starlink: dish thermally throttled",
+            "The dish is reducing performance from heat. Shade the dish or improve airflow."),
+        ("power_supply_thermal_throttle", 50, IspIssueSeverity.Warning, "Starlink: power supply thermally throttled",
+            "The power supply is overheating; move it somewhere cooler or improve airflow."),
+        ("mast_not_near_vertical", 70, IspIssueSeverity.Warning, "Starlink: mast is not vertical",
+            "A tilted mount degrades tracking. Level the mount so the dish can align properly."),
+        ("dish_water_detected", 60, IspIssueSeverity.Warning, "Starlink: water detected in the dish",
+            "The dish is reporting water intrusion; inspect the unit and its cable connections."),
+        ("lower_signal_than_predicted", 75, IspIssueSeverity.Warning, "Starlink: signal lower than predicted",
+            "The dish sees weaker signal than its ephemeris predicts, which usually means partial blockage or misalignment."),
+    };
+
+    private static PhysicalLinkResult ScoreSatellite(PhysicalLinkInput input, double factorWeight)
+    {
+        var issues = new List<IspHealthIssue>();
+        var parts = new List<(double Score, double Weight)>();
+        var valueBits = new List<string>();
+        var detailBits = new List<string>();
+        var transientAnomaly = false;
+
+        // Sky obstruction: the defining Starlink plant metric. Fraction of sky
+        // time obstructed, graded on the dish's own reporting conventions.
+        if (input.ObstructionFraction is double obstructed)
+        {
+            var obstructionScore = ScoreCurve.Interpolate(obstructed,
+                (0, 100),
+                (StarlinkHealthThresholds.ObstructionFractionGood, 92),
+                (StarlinkHealthThresholds.ObstructionFractionPoor, 40),
+                (StarlinkHealthThresholds.ObstructionFractionCritical, 0));
+            parts.Add((obstructionScore, 0.40));
+            valueBits.Add($"{(obstructed * 100).ToString("0.##", CultureInfo.InvariantCulture)}% obstructed");
+
+            if (obstructed >= StarlinkHealthThresholds.ObstructionFractionPoor)
+                issues.Add(new IspHealthIssue
+                {
+                    Severity = IspIssueSeverity.Warning,
+                    Title = "Starlink: sky obstruction",
+                    Description = $"{input.SourceName} is obstructed {(obstructed * 100).ToString("0.#", CultureInfo.InvariantCulture)}% of the time - enough to cause regular interruptions.",
+                    Recommendation = "Check the obstruction map for the blocked direction and relocate the dish or clear the obstruction (trees are the usual cause)."
+                });
+        }
+
+        // Dish-to-ground loss from the dish's own 1 Hz ping history - loss the
+        // dish sees on the satellite path itself, upstream of anything local.
+        if (input.DishDropRateAvg is double drop)
+        {
+            var dropScore = ScoreCurve.Interpolate(drop,
+                (0, 100),
+                (StarlinkHealthThresholds.DropRateGood, 90),
+                (0.01, 60),
+                (StarlinkHealthThresholds.DropRatePoor, 20),
+                (0.10, 0));
+            parts.Add((dropScore, 0.35));
+            valueBits.Add($"{(drop * 100).ToString("0.##", CultureInfo.InvariantCulture)}% loss");
+
+            if (drop >= StarlinkHealthThresholds.DropRatePoor)
+                issues.Add(new IspHealthIssue
+                {
+                    Severity = IspIssueSeverity.Warning,
+                    Title = "Starlink: high dish-side packet loss",
+                    Description = $"{input.SourceName} is dropping {(drop * 100).ToString("0.#", CultureInfo.InvariantCulture)}% of its own pings to the ground station.",
+                    Recommendation = "Sustained dish-side loss points to obstruction, weather, or cell congestion rather than anything on your LAN."
+                });
+        }
+
+        // Outage burden from the dish outage log, normalized to seconds/day.
+        if (input.OutageSecondsTotal is double outageS && input.WindowDays > 0)
+        {
+            var perDay = outageS / input.WindowDays;
+            var outageScore = ScoreCurve.Interpolate(perDay,
+                (0, 100),
+                (StarlinkHealthThresholds.OutageSecondsPerDayGood, 90),
+                (60, 60),
+                (StarlinkHealthThresholds.OutageSecondsPerDayPoor, 25),
+                (StarlinkHealthThresholds.OutageSecondsPerDayPoor * 4, 0));
+            parts.Add((outageScore, 0.25));
+            if (perDay > 0)
+            {
+                detailBits.Add($"~{perDay.ToString("0", CultureInfo.InvariantCulture)} s/day outage"
+                               + (input.OutageCountTotal is long oc and > 0 ? $" across {oc} event{(oc == 1 ? "" : "s")}" : ""));
+                transientAnomaly = true;
+            }
+
+            if (perDay >= StarlinkHealthThresholds.OutageSecondsPerDayPoor)
+                issues.Add(new IspHealthIssue
+                {
+                    Severity = IspIssueSeverity.Warning,
+                    Title = "Starlink: frequent outages",
+                    Description = $"{input.SourceName} logged ~{perDay.ToString("0", CultureInfo.InvariantCulture)} seconds of outage per day over this window.",
+                    Recommendation = "Check the outage causes on the Starlink Stats tab - obstruction outages need a clearer sky view; NO_SATS/NO_DOWNLINK bursts are usually constellation or weather."
+                });
+        }
+
+        if (parts.Count == 0)
+            return new PhysicalLinkResult(NullFactor(factorWeight, "Starlink terminal not reporting health data yet"), issues);
+
+        var totalWeight = parts.Sum(p => p.Weight);
+        var score = parts.Sum(p => p.Score * p.Weight) / totalWeight;
+
+        // Persistently low SNR is the dish's own "signal is degraded" verdict.
+        if (input.SnrPersistentlyLow == true)
+        {
+            score = Math.Min(score, 40);
+            issues.Add(new IspHealthIssue
+            {
+                Severity = IspIssueSeverity.Warning,
+                Title = "Starlink: persistently low SNR",
+                Description = $"{input.SourceName} reports its signal-to-noise ratio has been persistently low.",
+                Recommendation = "Check for partial obstructions or snow/debris on the dish."
+            });
+        }
+
+        // Alert-driven caps (thermal, tilt, water, low signal).
+        if (input.DishAlerts is { Count: > 0 } alerts)
+        {
+            foreach (var (alert, cap, severity, title, recommendation) in SatelliteCapAlerts)
+            {
+                if (!alerts.Contains(alert, StringComparer.OrdinalIgnoreCase)) continue;
+                score = Math.Min(score, cap);
+                issues.Add(new IspHealthIssue
+                {
+                    Severity = severity,
+                    Title = title,
+                    Description = $"{input.SourceName} is raising the {alert.Replace('_', ' ')} alert.",
+                    Recommendation = recommendation
+                });
+            }
+        }
+
+        // Slow negotiated Ethernet is LAN-side, not the ISP - advisory only, no cap,
+        // but it silently bottlenecks every measurement downstream of the dish.
+        if (input.EthSpeedMbps is int eth and > 0 and < 1000)
+            issues.Add(new IspHealthIssue
+            {
+                Severity = IspIssueSeverity.Info,
+                Title = "Starlink: Ethernet negotiated below 1 Gbps",
+                Description = $"{input.SourceName} negotiated {eth} Mbps to the router, which caps throughput below what the dish can deliver.",
+                Recommendation = "Check the cable and connectors between the dish/power supply and the router; a damaged run commonly negotiates 100 Mbps."
+            });
+
+        var finalScore = (int)Math.Round(score);
+        var desc = "Starlink dish health scored on sky obstruction, dish-to-ground loss, and outage burden"
+                   + (detailBits.Count > 0 ? $" ({string.Join(", ", detailBits)})." : ".")
+                   + (transientAnomaly ? AnomalyNote : "");
+        var valueText = valueBits.Count > 0 ? string.Join(", ", valueBits) : "dish reporting";
+        return new PhysicalLinkResult(
+            Factor(factorWeight, finalScore, valueText, desc), issues);
     }
 
     // ---------------------------------------------------------------------------

--- a/src/NetworkOptimizer.Web/Services/Monitoring/StarlinkHealthThresholds.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/StarlinkHealthThresholds.cs
@@ -1,0 +1,32 @@
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Starlink terminal health anchors used by ISP Health's Physical Link factor.
+/// Sourced from the dish's own reporting conventions: the Starlink app flags
+/// obstruction above roughly 1-2% of sky time, and a healthy stationary dish
+/// with clear sky sits well under 0.1% obstructed with near-zero dish-side
+/// ping drop. Starting anchors, meant to be nudged from field feedback.
+/// </summary>
+public static class StarlinkHealthThresholds
+{
+    /// <summary>Fraction of sky time obstructed that still reads as excellent (0.1%).</summary>
+    public const double ObstructionFractionGood = 0.001;
+
+    /// <summary>Obstruction fraction where service impact becomes noticeable (2%); the app-level "obstructed" territory.</summary>
+    public const double ObstructionFractionPoor = 0.02;
+
+    /// <summary>Obstruction fraction treated as fully degraded (10%).</summary>
+    public const double ObstructionFractionCritical = 0.10;
+
+    /// <summary>Mean dish-to-ground ping drop rate that still reads as excellent (0.2%).</summary>
+    public const double DropRateGood = 0.002;
+
+    /// <summary>Mean drop rate where the link is clearly degraded (5%).</summary>
+    public const double DropRatePoor = 0.05;
+
+    /// <summary>Outage seconds per day that still reads as excellent (a single brief beam re-range).</summary>
+    public const double OutageSecondsPerDayGood = 10;
+
+    /// <summary>Outage seconds per day that is clearly degraded (~5 min/day of dead air).</summary>
+    public const double OutageSecondsPerDayPoor = 300;
+}

--- a/src/NetworkOptimizer.Web/Services/StarlinkMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/StarlinkMonitorService.cs
@@ -1,0 +1,434 @@
+using System.Collections.Concurrent;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Storage.Interfaces;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Storage.Services;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Polls configured Starlink terminals on a timer, caches the latest stats and
+/// obstruction sky map, and writes time-series data to InfluxDB. Mirrors the
+/// CableModemMonitorService pattern. One instance exists per site, owned by
+/// <see cref="ModemMonitorRegistry"/>: configurations and stats belong to that
+/// site, and dish gRPC calls route through the site's agent tunnel when its
+/// devices are reached that way. The registry flips <see cref="Active"/> as
+/// sites are enabled and disabled; only active instances poll.
+/// </summary>
+public sealed class StarlinkMonitorService : IDisposable
+{
+    /// <summary>How often the obstruction sky map is refreshed; it changes slowly and is a ~60 KB payload.</summary>
+    private static readonly TimeSpan ObstructionMapRefresh = TimeSpan.FromMinutes(5);
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly SiteTunnelRouting _tunnelRouting;
+    private readonly MonitoringInfluxClient _influx;
+    private readonly ILogger<StarlinkMonitorService> _logger;
+    private readonly Dictionary<string, IStarlinkProvider> _providers;
+    private readonly Timer _pollingTimer;
+    private readonly string _siteSlug;
+
+    private readonly ConcurrentDictionary<int, StarlinkStats> _statsCache = new();
+    private readonly ConcurrentDictionary<int, StarlinkObstructionMap> _obstructionMapCache = new();
+    private volatile bool _hasPrimedOnce;
+
+    private bool _isPolling;
+
+    /// <summary>
+    /// Whether the timer-driven poll loop runs. The registry keeps the default
+    /// site's instance always active and toggles non-default instances with
+    /// their site's Enabled flag. Manual polls from the UI work regardless.
+    /// </summary>
+    public bool Active { get; set; }
+
+    public StarlinkMonitorService(
+        IServiceScopeFactory scopeFactory,
+        IEnumerable<IStarlinkProvider> providers,
+        SiteTunnelRouting tunnelRouting,
+        MonitoringInfluxRegistry influxRegistry,
+        ILogger<StarlinkMonitorService> logger,
+        string siteSlug = SiteManagementService.DefaultSiteSlug)
+    {
+        _scopeFactory = scopeFactory;
+        _tunnelRouting = tunnelRouting;
+        _siteSlug = string.IsNullOrEmpty(siteSlug) ? SiteManagementService.DefaultSiteSlug : siteSlug;
+        Active = _siteSlug == SiteManagementService.DefaultSiteSlug;
+        _influx = influxRegistry.GetFor(_siteSlug);
+        _logger = logger;
+        _providers = providers.ToDictionary(p => p.ProviderKey, StringComparer.OrdinalIgnoreCase);
+
+        // Prime poll 5 s after startup so dashboard has data; then check every 60 s
+        _pollingTimer = new Timer(
+            _ => _ = PollAllAsync(),
+            null,
+            TimeSpan.FromSeconds(5),
+            TimeSpan.FromSeconds(60));
+    }
+
+    /// <summary>
+    /// Creates a DI scope pinned to this instance's site so scoped services
+    /// (repositories, DbContext) hit this site's database.
+    /// </summary>
+    private IServiceScope CreateSiteScope()
+    {
+        var scope = _scopeFactory.CreateScope();
+        scope.ServiceProvider.GetRequiredService<SiteContextService>().OverrideSite(_siteSlug);
+        return scope;
+    }
+
+    /// <summary>
+    /// Get cached stats for a specific terminal without polling.
+    /// </summary>
+    public StarlinkStats? GetCachedStats(int id)
+    {
+        return _statsCache.TryGetValue(id, out var stats) ? stats : null;
+    }
+
+    /// <summary>
+    /// Get all cached terminal stats.
+    /// </summary>
+    public IReadOnlyDictionary<int, StarlinkStats> GetAllCachedStats()
+    {
+        return _statsCache;
+    }
+
+    /// <summary>
+    /// Get the cached obstruction sky map for a terminal, if one has been fetched.
+    /// </summary>
+    public StarlinkObstructionMap? GetCachedObstructionMap(int id)
+    {
+        return _obstructionMapCache.TryGetValue(id, out var map) ? map : null;
+    }
+
+    /// <summary>
+    /// Manually trigger a poll for a specific terminal.
+    /// </summary>
+    public async Task PollStarlinkAsync(int id)
+    {
+        var config = await GetConfigAsync(id);
+        if (config == null)
+        {
+            _logger.LogWarning("PollStarlinkAsync called for unknown Starlink config {Id}", id);
+            return;
+        }
+
+        await PollSingleAsync(config);
+    }
+
+    /// <summary>
+    /// Save a Starlink terminal configuration.
+    /// </summary>
+    public async Task SaveStarlinkAsync(StarlinkConfiguration config)
+    {
+        var isNew = config.Id == 0;
+
+        using var scope = CreateSiteScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IStarlinkRepository>();
+        await repo.SaveStarlinkConfigurationAsync(config);
+
+        if (isNew)
+            await AlertRuleAutoEnable.EnableBySourceAsync(scope, "starlink", _logger);
+    }
+
+    /// <summary>
+    /// Get all Starlink terminal configurations (enabled and disabled).
+    /// </summary>
+    public async Task<List<StarlinkConfiguration>> GetConfigsAsync()
+    {
+        using var scope = CreateSiteScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IStarlinkRepository>();
+        return await repo.GetStarlinkConfigurationsAsync();
+    }
+
+    /// <summary>
+    /// Delete a Starlink terminal configuration and clear its cached stats.
+    /// </summary>
+    public async Task DeleteStarlinkAsync(int id)
+    {
+        using var scope = CreateSiteScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IStarlinkRepository>();
+        await repo.DeleteStarlinkConfigurationAsync(id);
+
+        _statsCache.TryRemove(id, out _);
+        _obstructionMapCache.TryRemove(id, out _);
+    }
+
+    /// <summary>
+    /// Test connectivity to a terminal using the configured provider.
+    /// </summary>
+    public async Task<(bool Success, string Message)> ProbeAsync(StarlinkConfiguration config)
+    {
+        var provider = ResolveProvider(config.Provider);
+        if (provider == null)
+            return (false, $"No provider registered for '{config.Provider}'");
+
+        var context = await ToContextAsync(config);
+        return await provider.TestConnectionAsync(context);
+    }
+
+    private async Task PollAllAsync()
+    {
+        if (!Active) return;
+        if (_isPolling)
+        {
+            _logger.LogDebug("Starlink PollAllAsync skipped - already polling");
+            return;
+        }
+
+        try
+        {
+            _isPolling = true;
+            var forceAll = !_hasPrimedOnce;
+            _logger.LogDebug("Starlink PollAllAsync starting (forceAll={ForceAll})", forceAll);
+
+            using var scope = CreateSiteScope();
+            var repo = scope.ServiceProvider.GetRequiredService<IStarlinkRepository>();
+            var configs = await repo.GetEnabledStarlinkConfigurationsAsync();
+            _logger.LogDebug("Starlink PollAllAsync found {Count} enabled configs", configs.Count);
+
+            foreach (var config in configs)
+            {
+                if (!forceAll && config.LastPolled.HasValue)
+                {
+                    var elapsed = DateTime.UtcNow - config.LastPolled.Value;
+                    if (elapsed.TotalSeconds < config.PollingIntervalSeconds)
+                        continue;
+                }
+
+                await PollSingleAsync(config);
+            }
+
+            _hasPrimedOnce = true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in Starlink polling timer");
+        }
+        finally
+        {
+            _isPolling = false;
+        }
+    }
+
+    private async Task PollSingleAsync(StarlinkConfiguration config)
+    {
+        var provider = ResolveProvider(config.Provider);
+        if (provider == null)
+        {
+            await UpdateConfigErrorAsync(config.Id, $"No provider registered for '{config.Provider}'");
+            return;
+        }
+
+        var context = await ToContextAsync(config);
+
+        try
+        {
+            var stats = await provider.PollAsync(context);
+
+            if (stats != null)
+            {
+                _statsCache[config.Id] = stats;
+                await UpdateConfigSuccessAsync(config.Id);
+                WriteToInflux(config, stats);
+                await RefreshObstructionMapAsync(provider, context, config.Id);
+            }
+            else
+            {
+                await UpdateConfigErrorAsync(config.Id, "Poll returned no data");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error polling Starlink terminal {Name} ({Id})", config.Name, config.Id);
+            await UpdateConfigErrorAsync(config.Id, ex.Message);
+        }
+    }
+
+    private async Task RefreshObstructionMapAsync(
+        IStarlinkProvider provider, StarlinkPollContext context, int configId)
+    {
+        if (_obstructionMapCache.TryGetValue(configId, out var cached) &&
+            DateTime.UtcNow - cached.Timestamp < ObstructionMapRefresh)
+        {
+            return;
+        }
+
+        var map = await provider.GetObstructionMapAsync(context);
+        if (map != null)
+            _obstructionMapCache[configId] = map;
+    }
+
+    private IStarlinkProvider? ResolveProvider(string providerKey)
+    {
+        if (string.IsNullOrWhiteSpace(providerKey))
+        {
+            _logger.LogWarning("Starlink configuration has empty provider key");
+            return null;
+        }
+
+        if (_providers.TryGetValue(providerKey, out var provider))
+            return provider;
+
+        _logger.LogWarning("No Starlink provider registered for key '{Key}'", providerKey);
+        return null;
+    }
+
+    private async Task<StarlinkPollContext> ToContextAsync(StarlinkConfiguration config)
+    {
+        // gRPC to agent sites goes through the tunnel proxy: the channel dials
+        // a loopback endpoint whose bytes the agent pumps to the dish inside
+        // the site's network (the proxy is a raw TCP relay, so plaintext
+        // HTTP/2 passes through unmodified).
+        var (host, port) = await _tunnelRouting.RouteAsync(_siteSlug, config.Host, config.Port);
+
+        return new StarlinkPollContext
+        {
+            Id = config.Id,
+            Name = config.Name,
+            Host = host,
+            ConfiguredHost = config.Host,
+            Port = port,
+        };
+    }
+
+    private async Task UpdateConfigSuccessAsync(int id)
+    {
+        try
+        {
+            using var scope = CreateSiteScope();
+            var repo = scope.ServiceProvider.GetRequiredService<IStarlinkRepository>();
+            var config = await repo.GetStarlinkConfigurationAsync(id);
+            if (config != null)
+            {
+                config.LastPolled = DateTime.UtcNow;
+                config.LastError = null;
+                config.UpdatedAt = DateTime.UtcNow;
+                await repo.SaveStarlinkConfigurationAsync(config);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to update Starlink config {Id} after successful poll", id);
+        }
+    }
+
+    private async Task UpdateConfigErrorAsync(int id, string error)
+    {
+        try
+        {
+            using var scope = CreateSiteScope();
+            var repo = scope.ServiceProvider.GetRequiredService<IStarlinkRepository>();
+            var config = await repo.GetStarlinkConfigurationAsync(id);
+            if (config != null)
+            {
+                config.LastError = error.Length > 1000 ? error[..1000] : error;
+                config.UpdatedAt = DateTime.UtcNow;
+                await repo.SaveStarlinkConfigurationAsync(config);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to update Starlink config {Id} after error", id);
+        }
+    }
+
+    private async Task<StarlinkConfiguration?> GetConfigAsync(int id)
+    {
+        using var scope = CreateSiteScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IStarlinkRepository>();
+        return await repo.GetStarlinkConfigurationAsync(id);
+    }
+
+    /// <summary>
+    /// Write Starlink terminal metrics to InfluxDB.
+    /// </summary>
+    private void WriteToInflux(StarlinkConfiguration config, StarlinkStats stats)
+    {
+        try
+        {
+            var alignmentOffset = ComputeAlignmentOffsetDeg(stats);
+
+            // Fire-and-forget write to InfluxDB
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await _influx.WriteStarlinkAsync(
+                        starlinkId: config.Id.ToString(),
+                        starlinkName: config.Name,
+                        powerInW: stats.PowerInWatts,
+                        powerInAvgW: stats.PowerInAvgWatts,
+                        powerInMaxW: stats.PowerInMaxWatts,
+                        pingDropRateAvg: stats.PingDropRateAvg,
+                        pingDropRateMax: stats.PingDropRateMax,
+                        fractionObstructed: stats.FractionObstructed,
+                        currentlyObstructed: stats.CurrentlyObstructed,
+                        ethSpeedMbps: stats.EthSpeedMbps,
+                        uptimeS: stats.UptimeSeconds,
+                        gpsSats: stats.GpsSatellites,
+                        gpsValid: stats.GpsValid,
+                        tiltAngleDeg: stats.TiltAngleDeg,
+                        alignmentOffsetDeg: alignmentOffset,
+                        attitudeUncertaintyDeg: stats.AttitudeUncertaintyDeg,
+                        outageCountDelta: stats.OutageCountDelta,
+                        outageSecondsDelta: stats.OutageSecondsDelta,
+                        alertCount: stats.ActiveAlerts.Count,
+                        alerts: stats.ActiveAlerts.Count > 0 ? string.Join(",", stats.ActiveAlerts) : null,
+                        snrPersistentlyLow: stats.IsSnrPersistentlyLow,
+                        softwareUpdateState: stats.SoftwareUpdateState,
+                        disablementCode: stats.DisablementCode,
+                        dlRestrictedReason: stats.DownlinkRestrictedReason,
+                        ulRestrictedReason: stats.UplinkRestrictedReason,
+                        hardwareSelfTest: stats.HardwareSelfTest,
+                        classOfService: stats.ClassOfService,
+                        mobilityClass: stats.MobilityClass,
+                        timestamp: stats.Timestamp);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Failed to write Starlink stats to InfluxDB for {Name}", config.Name);
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Error computing InfluxDB write for Starlink terminal {Name}", config.Name);
+        }
+    }
+
+    /// <summary>
+    /// Angular offset between the dish's actual and desired boresight, degrees.
+    /// Azimuth error is scaled by cos(elevation) so it measures true sky angle
+    /// rather than compass degrees (which inflate near zenith).
+    /// </summary>
+    internal static double? ComputeAlignmentOffsetDeg(StarlinkStats stats)
+    {
+        if (stats.BoresightAzimuthDeg is not double az ||
+            stats.BoresightElevationDeg is not double el ||
+            stats.DesiredBoresightAzimuthDeg is not double desiredAz ||
+            stats.DesiredBoresightElevationDeg is not double desiredEl)
+        {
+            return null;
+        }
+
+        var dAz = ((az - desiredAz + 540) % 360) - 180;
+        var dEl = el - desiredEl;
+        var azSky = dAz * Math.Cos(el * Math.PI / 180.0);
+        return Math.Sqrt(azSky * azSky + dEl * dEl);
+    }
+
+    /// <summary>
+    /// No-op. Owned by ModemMonitorRegistry but scope-forwarded, so the DI
+    /// container calls Dispose at request/circuit scope end; disposing the poll
+    /// timer here would silently stop the shared monitor. Only the registry
+    /// tears it down, via DisposeOwned. Mirrors UniFiConnectionService.
+    /// </summary>
+    public void Dispose() { }
+
+    /// <summary>Real teardown, invoked only by the owning registry.</summary>
+    internal void DisposeOwned()
+    {
+        _pollingTimer.Dispose();
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/StarlinkProviders/StarlinkGrpcProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/StarlinkProviders/StarlinkGrpcProvider.cs
@@ -1,0 +1,343 @@
+using System.Collections.Concurrent;
+using Grpc.Core;
+using Grpc.Net.Client;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.StarlinkProviders.Proto;
+
+namespace NetworkOptimizer.Web.Services.StarlinkProviders;
+
+/// <summary>
+/// Polls a Starlink user terminal over its local gRPC API (192.168.100.1:9200
+/// on a stock install). The API is unversioned and community-documented, so
+/// parsing is defensive: the proto is a trimmed field-number-exact subset and
+/// unknown fields from newer firmware are skipped by protobuf.
+/// Instances are per site (like the cellular providers), so per-config delta
+/// state keyed by configuration ID cannot collide across sites.
+/// </summary>
+public class StarlinkGrpcProvider : IStarlinkProvider
+{
+    /// <summary>Default gRPC port on the dish.</summary>
+    public const int DefaultPort = 9200;
+
+    // GPS epoch (1980-01-06) to Unix epoch offset, minus current leap seconds.
+    // Outage timestamps in get_history are GPS-epoch nanoseconds.
+    private const long GpsToUnixSeconds = 315964800 - 18;
+
+    private readonly ILogger<StarlinkGrpcProvider> _logger;
+
+    // History ring buffers are 1 Hz with a monotonic sample counter; remember
+    // the counter and poll time per config so aggregates cover exactly the
+    // samples since the previous poll (the CM correctables-delta pattern).
+    private readonly ConcurrentDictionary<int, ulong> _lastHistoryCounter = new();
+    private readonly ConcurrentDictionary<int, DateTime> _lastPollUtc = new();
+
+    public StarlinkGrpcProvider(ILogger<StarlinkGrpcProvider> logger)
+    {
+        _logger = logger;
+    }
+
+    public string ProviderKey => "starlink-grpc";
+
+    public string DisplayName => "Starlink (local gRPC)";
+
+    public async Task<StarlinkStats?> PollAsync(
+        StarlinkPollContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var channel = CreateChannel(context);
+            var client = new Device.DeviceClient(channel);
+
+            var statusResp = await CallAsync(client, new Request { GetStatus = new GetStatusRequest() }, cancellationToken);
+            if (statusResp?.ResponseCase != Response.ResponseOneofCase.DishGetStatus)
+            {
+                _logger.LogWarning("Starlink {Name} ({Host}): status poll returned {Case}",
+                    context.Name, context.ConfiguredHost ?? context.Host, statusResp?.ResponseCase);
+                return null;
+            }
+
+            var status = statusResp.DishGetStatus;
+            var stats = MapStatus(status);
+
+            try
+            {
+                var historyResp = await CallAsync(client, new Request { GetHistory = new GetHistoryRequest() }, cancellationToken);
+                if (historyResp?.ResponseCase == Response.ResponseOneofCase.DishGetHistory)
+                    ApplyHistory(stats, historyResp.DishGetHistory, context.Id);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Starlink {Name}: history fetch failed; status-only poll", context.Name);
+            }
+
+            try
+            {
+                var diagResp = await CallAsync(client, new Request { GetDiagnostics = new GetDiagnosticsRequest() }, cancellationToken);
+                if (diagResp?.ResponseCase == Response.ResponseOneofCase.DishGetDiagnostics)
+                    ApplyDiagnostics(stats, diagResp.DishGetDiagnostics);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Starlink {Name}: diagnostics fetch failed; skipping self-test result", context.Name);
+            }
+
+            _lastPollUtc[context.Id] = stats.Timestamp;
+            return stats;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Starlink {Name} ({Host}): poll failed",
+                context.Name, context.ConfiguredHost ?? context.Host);
+            return null;
+        }
+    }
+
+    public async Task<StarlinkObstructionMap?> GetObstructionMapAsync(
+        StarlinkPollContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var channel = CreateChannel(context);
+            var client = new Device.DeviceClient(channel);
+
+            var resp = await CallAsync(client, new Request { DishGetObstructionMap = new DishGetObstructionMapRequest() }, cancellationToken);
+            if (resp?.ResponseCase != Response.ResponseOneofCase.DishGetObstructionMap)
+                return null;
+
+            var map = resp.DishGetObstructionMap;
+            if (map.NumRows == 0 || map.NumCols == 0 || map.Snr.Count != map.NumRows * map.NumCols)
+            {
+                _logger.LogDebug("Starlink {Name}: obstruction map malformed ({Rows}x{Cols}, {Samples} samples)",
+                    context.Name, map.NumRows, map.NumCols, map.Snr.Count);
+                return null;
+            }
+
+            return new StarlinkObstructionMap
+            {
+                Timestamp = DateTime.UtcNow,
+                NumRows = (int)map.NumRows,
+                NumCols = (int)map.NumCols,
+                Snr = map.Snr.ToArray(),
+                MaxThetaDeg = map.MaxThetaDeg,
+                ReferenceFrame = map.MapReferenceFrame.ToString(),
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Starlink {Name} ({Host}): obstruction map fetch failed",
+                context.Name, context.ConfiguredHost ?? context.Host);
+            return null;
+        }
+    }
+
+    public async Task<(bool Success, string Message)> TestConnectionAsync(
+        StarlinkPollContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var channel = CreateChannel(context);
+            var client = new Device.DeviceClient(channel);
+
+            var resp = await CallAsync(client, new Request { GetDeviceInfo = new GetDeviceInfoRequest() }, cancellationToken);
+            if (resp?.ResponseCase != Response.ResponseOneofCase.GetDeviceInfo)
+                return (false, "Dish answered, but not with device info - is this a Starlink terminal?");
+
+            var info = resp.GetDeviceInfo.DeviceInfo;
+            return (true, $"Connected: {info?.HardwareVersion} running {info?.SoftwareVersion}");
+        }
+        catch (RpcException ex)
+        {
+            return (false, $"gRPC error: {ex.Status.StatusCode} - {ex.Status.Detail}");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Connection failed: {ex.Message}");
+        }
+    }
+
+    private static GrpcChannel CreateChannel(StarlinkPollContext context)
+    {
+        var port = context.Port > 0 ? context.Port : DefaultPort;
+        return GrpcChannel.ForAddress($"http://{context.Host}:{port}");
+    }
+
+    private static async Task<Response?> CallAsync(
+        Device.DeviceClient client, Request request, CancellationToken ct)
+    {
+        return await client.HandleAsync(
+            request,
+            deadline: DateTime.UtcNow.AddSeconds(10),
+            cancellationToken: ct);
+    }
+
+    private static StarlinkStats MapStatus(DishGetStatusResponse status)
+    {
+        var stats = new StarlinkStats
+        {
+            Timestamp = DateTime.UtcNow,
+            DeviceId = NullIfEmpty(status.DeviceInfo?.Id),
+            HardwareVersion = NullIfEmpty(status.DeviceInfo?.HardwareVersion),
+            SoftwareVersion = NullIfEmpty(status.DeviceInfo?.SoftwareVersion),
+            CountryCode = NullIfEmpty(status.DeviceInfo?.CountryCode),
+            BootCount = status.DeviceInfo?.Bootcount,
+            UptimeSeconds = (long?)status.DeviceState?.UptimeS,
+            EthSpeedMbps = status.EthSpeedMbps > 0 ? status.EthSpeedMbps : null,
+            IsSnrAboveNoiseFloor = status.IsSnrAboveNoiseFloor,
+            IsSnrPersistentlyLow = status.IsSnrPersistentlyLow,
+            MobilityClass = status.MobilityClass.ToString(),
+            ClassOfService = status.ClassOfService.ToString(),
+            SoftwareUpdateState = status.SoftwareUpdateState.ToString(),
+            DisablementCode = status.DisablementCode.ToString(),
+            DownlinkRestrictedReason = status.DlBandwidthRestrictedReason.ToString(),
+            UplinkRestrictedReason = status.UlBandwidthRestrictedReason.ToString(),
+        };
+
+        if (status.ObstructionStats != null)
+        {
+            var o = status.ObstructionStats;
+            stats.FractionObstructed = FiniteOrNull(o.FractionObstructed);
+            stats.CurrentlyObstructed = o.CurrentlyObstructed;
+            stats.ObstructionValidSeconds = FiniteOrNull(o.ValidS);
+            if (o.AvgProlongedObstructionValid)
+                stats.AvgProlongedObstructionDurationSeconds = FiniteOrNull(o.AvgProlongedObstructionDurationS);
+        }
+
+        if (status.GpsStats != null)
+        {
+            stats.GpsValid = status.GpsStats.GpsValid;
+            stats.GpsSatellites = (int)status.GpsStats.GpsSats;
+        }
+
+        if (status.AlignmentStats != null)
+        {
+            var a = status.AlignmentStats;
+            stats.TiltAngleDeg = FiniteOrNull(a.TiltAngleDeg);
+            stats.BoresightAzimuthDeg = FiniteOrNull(a.BoresightAzimuthDeg);
+            stats.BoresightElevationDeg = FiniteOrNull(a.BoresightElevationDeg);
+            stats.DesiredBoresightAzimuthDeg = FiniteOrNull(a.DesiredBoresightAzimuthDeg);
+            stats.DesiredBoresightElevationDeg = FiniteOrNull(a.DesiredBoresightElevationDeg);
+            stats.AttitudeUncertaintyDeg = FiniteOrNull(a.AttitudeUncertaintyDeg);
+        }
+
+        if (status.Alerts != null)
+        {
+            // Walk the DishAlerts descriptor so alerts added by newer firmware
+            // (and declared in the proto) surface without a mapping table.
+            foreach (var field in DishAlerts.Descriptor.Fields.InFieldNumberOrder())
+            {
+                if (field.FieldType == Google.Protobuf.Reflection.FieldType.Bool &&
+                    field.Accessor.GetValue(status.Alerts) is true)
+                {
+                    stats.ActiveAlerts.Add(field.Name);
+                }
+            }
+        }
+
+        return stats;
+    }
+
+    private void ApplyHistory(StarlinkStats stats, DishGetHistoryResponse history, int configId)
+    {
+        var counter = history.Current;
+        var bufferLen = Math.Max(history.PopPingDropRate.Count, history.PowerIn.Count);
+        if (counter == 0 || bufferLen == 0) return;
+
+        // Number of new 1 Hz samples since the previous poll, capped at the
+        // ring buffer length. First poll (or counter reset after reboot)
+        // aggregates over the full buffer.
+        long window = bufferLen;
+        if (_lastHistoryCounter.TryGetValue(configId, out var prev) && counter > prev)
+            window = Math.Min((long)(counter - prev), bufferLen);
+        window = Math.Min(window, (long)counter);
+        _lastHistoryCounter[configId] = counter;
+
+        AggregateRing(history.PopPingDropRate, counter, window,
+            out var dropAvg, out var dropMax, out _);
+        stats.PingDropRateAvg = dropAvg;
+        stats.PingDropRateMax = dropMax;
+
+        AggregateRing(history.PowerIn, counter, window,
+            out var powerAvg, out var powerMax, out var powerLatest);
+        stats.PowerInAvgWatts = powerAvg;
+        stats.PowerInMaxWatts = powerMax;
+        stats.PowerInWatts = powerLatest;
+
+        if (history.Outages.Count > 0)
+        {
+            var windowStart = stats.Timestamp.AddSeconds(-window);
+            foreach (var outage in history.Outages)
+            {
+                var startUtc = GpsNsToUtc(outage.StartTimestampNs);
+                var durationS = outage.DurationNs / 1e9;
+
+                if (stats.LastOutageAt is null || startUtc > stats.LastOutageAt)
+                {
+                    stats.LastOutageAt = startUtc;
+                    stats.LastOutageCause = outage.Cause.ToString();
+                    stats.LastOutageDurationSeconds = durationS;
+                }
+
+                if (startUtc >= windowStart)
+                {
+                    stats.OutageCountDelta++;
+                    stats.OutageSecondsDelta += durationS;
+                }
+            }
+        }
+    }
+
+    private static void ApplyDiagnostics(StarlinkStats stats, DishGetDiagnosticsResponse diag)
+    {
+        if (diag.HardwareSelfTest != DishGetDiagnosticsResponse.Types.TestResult.NoResult)
+        {
+            stats.HardwareSelfTest = diag.HardwareSelfTest.ToString();
+            foreach (var code in diag.HardwareSelfTestCodes)
+                stats.HardwareSelfTestCodes.Add(code.ToString());
+        }
+    }
+
+    /// <summary>
+    /// Aggregate the newest <paramref name="window"/> samples of a 1 Hz ring
+    /// buffer whose write position is <paramref name="counter"/> % length.
+    /// </summary>
+    private static void AggregateRing(
+        IReadOnlyList<float> ring, ulong counter, long window,
+        out double? avg, out double? max, out double? latest)
+    {
+        avg = null;
+        max = null;
+        latest = null;
+        if (ring.Count == 0 || window <= 0) return;
+
+        double sum = 0;
+        double maxSeen = double.MinValue;
+        long counted = 0;
+        for (long k = 0; k < Math.Min(window, ring.Count); k++)
+        {
+            var idx = (long)((counter - 1 - (ulong)k) % (ulong)ring.Count);
+            var v = ring[(int)idx];
+            if (float.IsNaN(v) || float.IsInfinity(v)) continue;
+            if (k == 0) latest = v;
+            sum += v;
+            if (v > maxSeen) maxSeen = v;
+            counted++;
+        }
+
+        if (counted == 0) return;
+        avg = sum / counted;
+        max = maxSeen;
+    }
+
+    private static DateTime GpsNsToUtc(long gpsNs) =>
+        DateTimeOffset.FromUnixTimeSeconds(gpsNs / 1_000_000_000 + GpsToUnixSeconds).UtcDateTime;
+
+    private static double? FiniteOrNull(float value) =>
+        float.IsNaN(value) || float.IsInfinity(value) ? null : value;
+
+    private static string? NullIfEmpty(string? value) =>
+        string.IsNullOrEmpty(value) ? null : value;
+}

--- a/src/NetworkOptimizer.Web/wwwroot/js/starlink-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/starlink-charts.js
@@ -1,0 +1,532 @@
+// Starlink terminal time-series charts: power draw, ping drop rate, obstruction,
+// outage seconds, GPS satellites, alignment offset.
+// Same control pattern as cellular-charts.js and cm-charts.js.
+
+import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=4';
+
+const PALETTE = window.Apex?.colors || ['#2ba89a', '#3b82f6', '#a78bfa', '#ef5858', '#f59e0b', '#10b981'];
+const _esc = document.createElement('span');
+function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
+
+const POLL_INTERVALS = { 0: 10000, 1: 10000, 6: 15000, 24: 30000, 168: 60000, 720: 60000 };
+const RANGE_MS = { 0: 15*60000, 1: 3600000, 6: 6*3600000, 24: 86400000, 168: 7*86400000, 720: 30*86400000 };
+
+let powerChart = null;
+let dropChart = null;
+let obstructionChart = null;
+let outageChart = null;
+let gpsChart = null;
+let alignmentChart = null;
+let pollTimer = null;
+let currentRangeHours = 24;
+let windowOffset = 0;
+let isCustomRange = false;
+let customFrom = null;
+let customTo = null;
+let containerId = null;
+let fetchController = null;
+let deviceMeta = [];
+let visibility = {};
+let visibilityObserver = null;
+let isInViewport = true;
+let lastData = null;
+
+// Paired charts carry an avg (solid) and max (dashed) series per terminal;
+// the suffixes let visibility toggling reach both.
+function chartsWithSuffixes() {
+    return [
+        { chart: powerChart, suffixes: [' (avg)', ' (max)'] },
+        { chart: dropChart, suffixes: [' (avg)', ' (max)'] },
+        { chart: obstructionChart, suffixes: [''] },
+        { chart: outageChart, suffixes: [''] },
+        { chart: gpsChart, suffixes: [''] },
+        { chart: alignmentChart, suffixes: [''] },
+    ];
+}
+
+function baseOpts(height, yTitle, yFormatter, extra) {
+    return {
+        chart: {
+            type: 'area', height,
+            background: 'transparent',
+            toolbar: { show: false },
+            zoom: { enabled: !matchMedia('(pointer:coarse)').matches, type: 'x', allowMouseWheelZoom: false },
+            events: { beforeZoom: (ctx, opts) => applyDragZoom(opts?.xaxis) },
+            animations: { enabled: false },
+        },
+        stroke: { curve: 'smooth', width: 2 },
+        fill: {
+            type: 'gradient',
+            gradient: { shadeIntensity: 0.3, opacityFrom: 0.4, opacityTo: 0.05 },
+        },
+        markers: { size: 0 },
+        dataLabels: { enabled: false },
+        xaxis: {
+            type: 'datetime',
+            labels: {
+                style: { colors: '#9ca3af' },
+                datetimeUTC: false,
+                datetimeFormatter: { hour: 'HH:mm', day: 'MMM dd' },
+            },
+        },
+        yaxis: {
+            title: { text: yTitle, style: { color: '#9ca3af' } },
+            labels: { style: { colors: '#9ca3af' }, formatter: yFormatter },
+        },
+        grid: { borderColor: '#374151', strokeDashArray: 3 },
+        legend: { show: false },
+        tooltip: { theme: 'dark', shared: true, x: { format: 'MMM dd, HH:mm:ss' } },
+        noData: { text: 'No data in this time range', style: { color: '#64748b' } },
+        ...extra,
+    };
+}
+
+function buildQueryParams() {
+    let params = '';
+    if (isCustomRange && customFrom && customTo) {
+        params = `from=${customFrom.toISOString()}&to=${customTo.toISOString()}`;
+    } else if (windowOffset !== 0) {
+        const now = Date.now();
+        const rangeMs = RANGE_MS[currentRangeHours] || 3600000;
+        const to = new Date(now + windowOffset);
+        const from = new Date(to.getTime() - rangeMs);
+        params = `from=${from.toISOString()}&to=${to.toISOString()}`;
+    } else {
+        params = `rangeHours=${currentRangeHours}`;
+    }
+    return params;
+}
+
+async function fetchData() {
+    if (fetchController) fetchController.abort();
+    fetchController = new AbortController();
+    try {
+        const resp = await fetch(`/api/monitoring/starlink-chart?${buildQueryParams()}`,
+            { signal: fetchController.signal });
+        if (!resp.ok) return null;
+        return await resp.json();
+    } catch (e) {
+        if (e.name === 'AbortError') return null;
+        return null;
+    }
+}
+
+function renderBadges(container) {
+    const el = container.querySelector('.starlink-filter-badges');
+    if (!el) return;
+    if (deviceMeta.length <= 1) { el.innerHTML = ''; return; }
+    el.innerHTML = deviceMeta.map(m => {
+        const vis = visibility[m.id] !== false;
+        return `<button class="wan-filter-badge ${vis ? 'active' : 'inactive'}" data-device="${m.id}">
+            <span class="wan-badge-dot" style="background-color: ${m.color}"></span>
+            <span>${escapeHtml(m.label)}</span>
+        </button>`;
+    }).join('');
+    if (!el._delegated) {
+        el._delegated = true;
+        el.addEventListener('click', (e) => {
+            const btn = e.target.closest('button[data-device]');
+            if (!btn) return;
+            const id = btn.dataset.device;
+            if (e.ctrlKey || e.metaKey) {
+                visibility[id] = visibility[id] === false ? undefined : false;
+            } else {
+                const allVis = deviceMeta.every(m => visibility[m.id] !== false);
+                const onlyThis = visibility[id] !== false
+                    && deviceMeta.filter(m => m.id !== id).every(m => visibility[m.id] === false);
+                if (onlyThis) { visibility = {}; }
+                else if (allVis) { deviceMeta.forEach(m => visibility[m.id] = m.id === id); }
+                else { visibility[id] = visibility[id] === false; }
+            }
+            updateVisibility();
+            renderBadges(container);
+            renderStatsTable(container, false);
+        });
+    }
+}
+
+function updateVisibility() {
+    deviceMeta.forEach(m => {
+        const vis = visibility[m.id] !== false;
+        chartsWithSuffixes().forEach(({ chart, suffixes }) => {
+            if (!chart) return;
+            suffixes.forEach(suffix => {
+                if (vis) chart.showSeries(m.label + suffix);
+                else chart.hideSeries(m.label + suffix);
+            });
+        });
+    });
+}
+
+const pct = v => v != null ? v * 100 : null;
+
+async function loadAndUpdate() {
+    const data = await fetchData();
+    if (!data?.devices) return;
+    deviceMeta = data.devices.map((d, i) => ({
+        id: d.id, label: d.label, color: PALETTE[i % PALETTE.length],
+    }));
+
+    const powerSeries = [];
+    const dropSeries = [];
+    const obstructionSeries = [];
+    const outageSeries = [];
+    const gpsSeries = [];
+    const alignmentSeries = [];
+    data.devices.forEach((d, i) => {
+        const color = PALETTE[i % PALETTE.length];
+        const pts = d.data || [];
+        const map = (sel) => pts.filter(p => sel(p) != null).map(p => ({ x: new Date(p.time).getTime(), y: sel(p) }));
+        powerSeries.push(
+            { name: `${d.label} (avg)`, color, data: map(p => p.powerAvg) },
+            { name: `${d.label} (max)`, color, data: map(p => p.powerMax) });
+        dropSeries.push(
+            { name: `${d.label} (avg)`, color, data: map(p => pct(p.dropAvg)) },
+            { name: `${d.label} (max)`, color, data: map(p => pct(p.dropMax)) });
+        obstructionSeries.push({ name: d.label, color, data: map(p => pct(p.obstructed)) });
+        outageSeries.push({ name: d.label, color, data: map(p => p.outageSeconds) });
+        gpsSeries.push({ name: d.label, color, data: map(p => p.gpsSats) });
+        alignmentSeries.push({ name: d.label, color, data: map(p => p.alignment) });
+    });
+
+    // Solid avg / dashed max per terminal on the paired charts
+    const pairedDash = data.devices.flatMap(() => [0, 5]);
+    if (powerChart) {
+        powerChart.updateOptions({ stroke: { curve: 'smooth', width: 2, dashArray: pairedDash } }, false, false);
+        powerChart.updateSeries(powerSeries, false);
+    }
+    if (dropChart) {
+        dropChart.updateOptions({ stroke: { curve: 'smooth', width: 2, dashArray: pairedDash } }, false, false);
+        dropChart.updateSeries(dropSeries, false);
+    }
+    if (obstructionChart) obstructionChart.updateSeries(obstructionSeries, false);
+    if (outageChart) outageChart.updateSeries(outageSeries, false);
+    if (gpsChart) gpsChart.updateSeries(gpsSeries, false);
+    if (alignmentChart) alignmentChart.updateSeries(alignmentSeries, false);
+
+    updateVisibility();
+    lastData = data;
+    const container = document.getElementById(containerId);
+    if (container) {
+        renderBadges(container);
+        renderStatsTable(container);
+    }
+}
+
+const fmtW = v => v != null ? v.toFixed(1) + ' W' : '-';
+const fmtPct = v => v != null ? v.toFixed(2) + '%' : '-';
+const fmtSec = v => v != null ? v.toFixed(0) + ' s' : '-';
+const fmtSats = v => v != null ? v.toFixed(1) : '-';
+const fmtDeg = v => v != null ? v.toFixed(2) + '°' : '-';
+
+function renderStatsTable(container, showAll) {
+    const el = container.querySelector('.starlink-stats-table');
+    if (!el || !lastData?.devices?.length) { if (el) el.innerHTML = ''; return; }
+
+    const rows = lastData.devices.map(d => {
+        const pts = d.data || [];
+        const power = computeStats(pts.map(p => p.powerAvg).filter(v => v != null));
+        const powerMax = computeStats(pts.map(p => p.powerMax).filter(v => v != null));
+        const drop = computeStats(pts.map(p => pct(p.dropAvg)).filter(v => v != null));
+        const dropMax = computeStats(pts.map(p => pct(p.dropMax)).filter(v => v != null));
+        const obstr = computeStats(pts.map(p => pct(p.obstructed)).filter(v => v != null));
+        const gps = computeStats(pts.map(p => p.gpsSats).filter(v => v != null));
+        const align = computeStats(pts.map(p => p.alignment).filter(v => v != null));
+        const outageSum = pts.reduce((s, p) => s + (p.outageSeconds ?? 0), 0);
+        const meta = deviceMeta.find(mm => mm.id === d.id);
+        return { id: d.id, label: d.label, color: meta?.color || '#9ca3af',
+            visible: meta && visibility[meta.id] !== false,
+            values: [power?.mean, powerMax?.max, drop?.mean, dropMax?.max,
+                obstr?.mean, obstr?.max, outageSum, gps?.mean, align?.mean, align?.max] };
+    });
+
+    renderTable(el, container, {
+        nameHeader: 'Terminal', rows, showAllRows: showAll,
+        columns: [
+            { header: 'Power Mean', format: fmtW }, { header: 'Power Max', format: fmtW },
+            { header: 'Drop Mean', format: fmtPct }, { header: 'Drop Max', format: fmtPct },
+            { header: 'Obstr Mean', format: fmtPct }, { header: 'Obstr Max', format: fmtPct },
+            { header: 'Outage Total', format: fmtSec },
+            { header: 'GPS Mean', format: fmtSats },
+            { header: 'Align Mean', format: fmtDeg }, { header: 'Align Max', format: fmtDeg },
+        ],
+        filter: { meta: () => deviceMeta, key: 'id', visibility: () => visibility,
+            resetVisibility: () => { visibility = {}; },
+            onChanged: (c) => { updateVisibility(); renderBadges(c); renderStatsTable(c, true); } },
+    });
+}
+
+function isVisible() { return isInViewport; }
+
+function startPoll() {
+    stopPoll();
+    if (windowOffset !== 0 || isCustomRange) return;
+    if (!isVisible()) return;
+    pollTimer = setInterval(loadAndUpdate, POLL_INTERVALS[currentRangeHours] || 60000);
+}
+function stopPoll() { if (pollTimer) { clearInterval(pollTimer); pollTimer = null; } }
+
+function toLocalDatetimeString(d) {
+    const pad = n => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function getEffectiveFrom() {
+    if (isCustomRange && customFrom) return customFrom;
+    if (windowOffset !== 0) return new Date(Date.now() + windowOffset - (RANGE_MS[currentRangeHours] || 3600000));
+    return null;
+}
+function getEffectiveTo() {
+    if (isCustomRange && customTo) return customTo;
+    if (windowOffset !== 0) return new Date(Date.now() + windowOffset);
+    return null;
+}
+
+function updateCustomLabel(container) {
+    const btn = container.querySelector('.custom-range-btn');
+    if (!btn) return;
+    let clearBtn = btn.querySelector('.custom-range-clear');
+    const label = btn.querySelector('.custom-range-label');
+    if (label) label.remove();
+    const active = isCustomRange || windowOffset !== 0;
+    if (active) {
+        btn.classList.add('active');
+        const from = getEffectiveFrom(), to = getEffectiveTo();
+        if (from && to) {
+            const fmt = d => d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+            btn.setAttribute('data-tooltip', `${fmt(from)} - ${fmt(to)}`);
+        }
+        if (!clearBtn) {
+            clearBtn = document.createElement('span');
+            clearBtn.className = 'custom-range-clear';
+            clearBtn.textContent = '×';
+            clearBtn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                selectPresetRange(container, currentRangeHours);
+            });
+            btn.appendChild(clearBtn);
+        }
+    } else {
+        btn.classList.remove('active');
+        btn.setAttribute('data-tooltip', 'Custom date range');
+        if (clearBtn) clearBtn.remove();
+    }
+}
+
+// Grafana-style drag-select on a chart becomes a custom time window,
+// synced to the range selector (custom-range button + popover inputs).
+function applyDragZoom(xaxis) {
+    const container = document.getElementById(containerId);
+    if (container && xaxis && Number.isFinite(xaxis.min) && Number.isFinite(xaxis.max) && xaxis.min < xaxis.max) {
+        customFrom = new Date(xaxis.min);
+        customTo = new Date(xaxis.max);
+        isCustomRange = true;
+        windowOffset = 0;
+        container.querySelectorAll('[data-range]').forEach(b => b.classList.remove('active'));
+        const fromInput = container.querySelector('[data-input="from"]');
+        const toInput = container.querySelector('[data-input="to"]');
+        if (fromInput) fromInput.value = toLocalDatetimeString(customFrom);
+        if (toInput) toInput.value = toLocalDatetimeString(customTo);
+        updateCustomLabel(container);
+        loadAndUpdate();
+        startPoll();
+    }
+    // Cancel ApexCharts' client-side zoom; the refetch repaints the selected window
+    return { xaxis: { min: undefined, max: undefined } };
+}
+
+function selectPresetRange(container, hours) {
+    currentRangeHours = hours;
+    windowOffset = 0;
+    isCustomRange = false;
+    customFrom = null;
+    customTo = null;
+    container.querySelectorAll('[data-range]').forEach(b => b.classList.remove('active'));
+    const btn = container.querySelector(`[data-range="${hours}"]`);
+    if (btn) btn.classList.add('active');
+    const fromInput = container.querySelector('[data-input="from"]');
+    const toInput = container.querySelector('[data-input="to"]');
+    if (fromInput && toInput) {
+        const now = Date.now();
+        const rangeMs = RANGE_MS[hours] || 86400000;
+        fromInput.value = toLocalDatetimeString(new Date(now - rangeMs));
+        toInput.value = toLocalDatetimeString(new Date(now));
+    }
+    container.querySelector('[data-popover="custom-range"]')?.classList.remove('open');
+    updateCustomLabel(container);
+    loadAndUpdate();
+    startPoll();
+}
+
+function shiftWindow(container, direction) {
+    const rangeMs = isCustomRange && customFrom && customTo
+        ? customTo.getTime() - customFrom.getTime()
+        : RANGE_MS[currentRangeHours] || 3600000;
+    const shiftMs = rangeMs * 0.5;
+    if (isCustomRange && customFrom && customTo) {
+        const delta = direction === 'back' ? -shiftMs : shiftMs;
+        customFrom = new Date(customFrom.getTime() + delta);
+        customTo = new Date(customTo.getTime() + delta);
+    } else {
+        windowOffset += direction === 'back' ? -shiftMs : shiftMs;
+        if (windowOffset > 0) windowOffset = 0;
+    }
+    const fromInput = container.querySelector('[data-input="from"]');
+    const toInput = container.querySelector('[data-input="to"]');
+    const ef = getEffectiveFrom(), et = getEffectiveTo();
+    if (fromInput && ef) fromInput.value = toLocalDatetimeString(ef);
+    if (toInput && et) toInput.value = toLocalDatetimeString(et);
+    updateCustomLabel(container);
+    loadAndUpdate();
+    startPoll();
+}
+
+export async function mount(elId) {
+    // Reset all state in case unmount didn't complete (Blazor Dispose race)
+    stopPoll();
+    currentRangeHours = 24;
+    windowOffset = 0;
+    isCustomRange = false;
+    customFrom = null;
+    customTo = null;
+    deviceMeta = [];
+    visibility = {};
+    containerId = elId;
+    const container = document.getElementById(elId);
+    if (!container) return;
+
+    const powerEl = container.querySelector('.starlink-power-chart');
+    const dropEl = container.querySelector('.starlink-drop-chart');
+    const obstructionEl = container.querySelector('.starlink-obstruction-chart');
+    const outageEl = container.querySelector('.starlink-outage-chart');
+    const gpsEl = container.querySelector('.starlink-gps-chart');
+    const alignmentEl = container.querySelector('.starlink-alignment-chart');
+    if (!powerEl || !dropEl || !obstructionEl || !outageEl || !gpsEl || !alignmentEl) return;
+
+    if (powerChart) { powerChart.destroy(); powerChart = null; }
+    if (dropChart) { dropChart.destroy(); dropChart = null; }
+    if (obstructionChart) { obstructionChart.destroy(); obstructionChart = null; }
+    if (outageChart) { outageChart.destroy(); outageChart = null; }
+    if (gpsChart) { gpsChart.destroy(); gpsChart = null; }
+    if (alignmentChart) { alignmentChart.destroy(); alignmentChart = null; }
+
+    powerChart = new ApexCharts(powerEl, {
+        ...baseOpts(200, 'W', v => v != null ? v.toFixed(0) + ' W' : ''),
+        series: [], colors: PALETTE,
+    });
+    dropChart = new ApexCharts(dropEl, {
+        ...baseOpts(160, '%', v => v != null ? v.toFixed(1) + '%' : ''),
+        series: [], colors: PALETTE,
+    });
+    obstructionChart = new ApexCharts(obstructionEl, {
+        ...baseOpts(160, '%', v => v != null ? v.toFixed(2) + '%' : ''),
+        series: [], colors: PALETTE,
+    });
+    outageChart = new ApexCharts(outageEl, {
+        ...baseOpts(160, 's', v => v != null ? v.toFixed(0) + ' s' : ''),
+        series: [], colors: PALETTE,
+    });
+    gpsChart = new ApexCharts(gpsEl, {
+        ...baseOpts(160, 'sats', v => v != null ? v.toFixed(0) : ''),
+        series: [], colors: PALETTE,
+    });
+    alignmentChart = new ApexCharts(alignmentEl, {
+        ...baseOpts(160, 'deg', v => v != null ? v.toFixed(1) + '°' : ''),
+        series: [], colors: PALETTE,
+    });
+
+    await powerChart.render();
+    await dropChart.render();
+    await obstructionChart.render();
+    await outageChart.render();
+    await gpsChart.render();
+    await alignmentChart.render();
+
+    container.querySelectorAll('[data-range]').forEach(btn => {
+        btn.addEventListener('click', () => selectPresetRange(container, parseInt(btn.dataset.range)));
+    });
+
+    container.querySelectorAll('[data-shift]').forEach(btn => {
+        btn.addEventListener('click', () => shiftWindow(container, btn.dataset.shift));
+    });
+
+    const popover = container.querySelector('[data-popover="custom-range"]');
+    const fromInput = container.querySelector('[data-input="from"]');
+    const toInput = container.querySelector('[data-input="to"]');
+
+    container.querySelector('[data-action="custom-range"]')?.addEventListener('click', () => {
+        const now = new Date();
+        const rangeMs = RANGE_MS[currentRangeHours] || 3600000;
+        if (!fromInput.value) fromInput.value = toLocalDatetimeString(new Date(now.getTime() - rangeMs));
+        if (!toInput.value) toInput.value = toLocalDatetimeString(now);
+        popover?.classList.toggle('open');
+    });
+
+    container.querySelector('[data-action="cancel-custom"]')?.addEventListener('click', () => {
+        popover?.classList.remove('open');
+    });
+
+    container.querySelector('[data-action="apply-custom"]')?.addEventListener('click', () => {
+        const from = fromInput?.value ? new Date(fromInput.value) : null;
+        const to = toInput?.value ? new Date(toInput.value) : null;
+        if (!from || !to || isNaN(from) || isNaN(to) || from >= to) return;
+        customFrom = from;
+        customTo = to;
+        isCustomRange = true;
+        windowOffset = 0;
+        container.querySelectorAll('[data-range]').forEach(b => b.classList.remove('active'));
+        popover?.classList.remove('open');
+        updateCustomLabel(container);
+        loadAndUpdate();
+        startPoll();
+    });
+
+    document.addEventListener('click', (e) => {
+        if (!popover?.classList.contains('open')) return;
+        const customBtn = container.querySelector('[data-action="custom-range"]');
+        if (popover.contains(e.target) || customBtn?.contains(e.target)) return;
+        popover.classList.remove('open');
+    });
+
+    visibilityObserver = new IntersectionObserver(([entry]) => {
+        const was = isVisible();
+        isInViewport = entry.isIntersecting;
+        if (isVisible() && !was) { loadAndUpdate(); startPoll(); }
+        else if (!isVisible() && was) { stopPoll(); }
+    }, { threshold: 0 });
+    visibilityObserver.observe(container);
+
+    await loadAndUpdate();
+    startPoll();
+}
+
+export function soloDevice(deviceId) {
+    if (!deviceMeta.length) return;
+    deviceMeta.forEach(m => { visibility[m.id] = m.id === deviceId; });
+    updateVisibility();
+    const container = document.getElementById(containerId);
+    if (container) { renderBadges(container); renderStatsTable(container, false); }
+}
+
+export function unmount() {
+    stopPoll();
+    if (visibilityObserver) { visibilityObserver.disconnect(); visibilityObserver = null; }
+    if (fetchController) { fetchController.abort(); fetchController = null; }
+    if (powerChart) { powerChart.destroy(); powerChart = null; }
+    if (dropChart) { dropChart.destroy(); dropChart = null; }
+    if (obstructionChart) { obstructionChart.destroy(); obstructionChart = null; }
+    if (outageChart) { outageChart.destroy(); outageChart = null; }
+    if (gpsChart) { gpsChart.destroy(); gpsChart = null; }
+    if (alignmentChart) { alignmentChart.destroy(); alignmentChart = null; }
+    containerId = null;
+    deviceMeta = [];
+    visibility = {};
+    lastData = null;
+    currentRangeHours = 24;
+    windowOffset = 0;
+    isCustomRange = false;
+    customFrom = null;
+    customTo = null;
+    isInViewport = true;
+}

--- a/src/NetworkOptimizer.Web/wwwroot/js/starlink-obstruction-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/starlink-obstruction-map.js
@@ -1,0 +1,102 @@
+// Renders the Starlink obstruction sky map onto a canvas.
+// The dish reports a square grid of per-direction SNR samples (0..1, -1 =
+// unmeasured) already projected as a disc in the dish reference frame:
+// boresight at the center, max_theta_deg at the rim. Clear sky renders in
+// the app's teal, obstructions ramp amber -> red, unmeasured stays dark.
+
+const COLORS = {
+    ringStroke: 'rgba(55, 65, 81, 0.9)',      // grid line color
+    rimStroke: 'rgba(160, 160, 168, 0.35)',
+    unmeasured: [22, 22, 24, 255],            // --bg-secondary
+    boresight: 'rgba(237, 237, 239, 0.9)',
+};
+
+// SNR 0..1 -> RGBA. Obstruction severity uses the app's signal palette:
+// >=0.9 clear teal, then emerald/yellow/orange down to red for fully blocked.
+function snrColor(v) {
+    if (v >= 0.9) {
+        // Clear sky: deep teal, brightening slightly with quality
+        const t = (v - 0.9) / 0.1;
+        return [Math.round(27 + 16 * t), Math.round(138 + 30 * t), Math.round(128 + 26 * t), 255]; // #2ba89a family
+    }
+    if (v >= 0.65) {
+        const t = (v - 0.65) / 0.25;
+        return [Math.round(234 - 190 * t), Math.round(179 - 25 * t), Math.round(8 + 100 * t), 255]; // yellow -> teal-green
+    }
+    if (v >= 0.35) {
+        const t = (v - 0.35) / 0.3;
+        return [Math.round(249 - 15 * t), Math.round(115 + 64 * t), Math.round(22 - 14 * t), 255]; // orange -> yellow
+    }
+    const t = Math.max(v, 0) / 0.35;
+    return [239, Math.round(68 + 47 * t), Math.round(68 - 46 * t), 255]; // red -> orange
+}
+
+/**
+ * Draw the obstruction map. data: { rows, cols, snr: number[] }.
+ * The canvas is cleared and fully repainted.
+ */
+export function render(canvas, data) {
+    if (!canvas || !data || !data.rows || !data.cols || !data.snr) return;
+
+    const ctx = canvas.getContext('2d');
+    const size = canvas.width; // square canvas
+    ctx.clearRect(0, 0, size, canvas.height);
+
+    // Paint the grid into an offscreen canvas at native resolution, then
+    // scale up with smoothing so patches blend into a soft dome.
+    const off = document.createElement('canvas');
+    off.width = data.cols;
+    off.height = data.rows;
+    const offCtx = off.getContext('2d');
+    const img = offCtx.createImageData(data.cols, data.rows);
+
+    const cx = (data.cols - 1) / 2;
+    const cy = (data.rows - 1) / 2;
+    const radius = Math.min(cx, cy);
+
+    for (let r = 0; r < data.rows; r++) {
+        for (let c = 0; c < data.cols; c++) {
+            const v = data.snr[r * data.cols + c];
+            const inside = ((c - cx) ** 2 + (r - cy) ** 2) <= radius * radius;
+            const px = (r * data.cols + c) * 4;
+            const rgba = (!inside || v < 0) ? COLORS.unmeasured : snrColor(v);
+            img.data[px] = rgba[0];
+            img.data[px + 1] = rgba[1];
+            img.data[px + 2] = rgba[2];
+            img.data[px + 3] = inside ? rgba[3] : 0;
+        }
+    }
+    offCtx.putImageData(img, 0, 0);
+
+    // Clip to the dome circle and draw scaled
+    const center = size / 2;
+    const domeR = size / 2 - 2;
+    ctx.save();
+    ctx.beginPath();
+    ctx.arc(center, center, domeR, 0, Math.PI * 2);
+    ctx.clip();
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = 'high';
+    ctx.drawImage(off, 0, 0, size, size);
+    ctx.restore();
+
+    // Elevation rings (1/3 and 2/3 of the dome) + rim
+    ctx.lineWidth = 1;
+    ctx.strokeStyle = COLORS.ringStroke;
+    for (const f of [1 / 3, 2 / 3]) {
+        ctx.beginPath();
+        ctx.arc(center, center, domeR * f, 0, Math.PI * 2);
+        ctx.stroke();
+    }
+    ctx.strokeStyle = COLORS.rimStroke;
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.arc(center, center, domeR, 0, Math.PI * 2);
+    ctx.stroke();
+
+    // Boresight marker
+    ctx.fillStyle = COLORS.boresight;
+    ctx.beginPath();
+    ctx.arc(center, center, 2.5, 0, Math.PI * 2);
+    ctx.fill();
+}

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/PhysicalLinkScorerSatelliteTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/PhysicalLinkScorerSatelliteTests.cs
@@ -1,0 +1,103 @@
+using FluentAssertions;
+using NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.IspHealth;
+
+/// <summary>
+/// Unit tests for the Satellite (Starlink) arm of the Physical Link scorer:
+/// obstruction/drop-rate/outage blending, the SNR and dish-alert caps, and the
+/// LAN-side Ethernet advisory.
+/// </summary>
+public class PhysicalLinkScorerSatelliteTests
+{
+    private const double Weight = 0.15;
+
+    private static PhysicalLinkResult ScoreSat(
+        double? obstruction = null, double? dropAvg = null, double? outageSeconds = null,
+        long? outageCount = null, bool? snrLow = null, string[]? alerts = null,
+        int? ethSpeed = null, double windowDays = 2.0) =>
+        PhysicalLinkScorer.Score(new PhysicalLinkInput
+        {
+            Medium = PhysicalMedium.Satellite,
+            SourceName = "Test Starlink",
+            ObstructionFraction = obstruction,
+            DishDropRateAvg = dropAvg,
+            OutageSecondsTotal = outageSeconds,
+            OutageCountTotal = outageCount,
+            SnrPersistentlyLow = snrLow,
+            DishAlerts = alerts,
+            EthSpeedMbps = ethSpeed,
+            WindowDays = windowDays
+        }, expectedUploadMbps: null, Weight);
+
+    [Fact]
+    public void Satellite_clear_sky_scores_high_with_no_issues()
+    {
+        // TJ's real dish: 0.06% obstructed, near-zero drop, no outages in window.
+        var result = ScoreSat(obstruction: 0.0006, dropAvg: 0.001, outageSeconds: 0);
+        result.Factor.Score.Should().BeGreaterThan(90);
+        result.Issues.Should().BeEmpty();
+        result.Factor.Weight.Should().Be(Weight);
+    }
+
+    [Fact]
+    public void Satellite_heavy_obstruction_penalized_and_raises_warning()
+    {
+        var result = ScoreSat(obstruction: 0.05, dropAvg: 0.001, outageSeconds: 0);
+        result.Factor.Score.Should().BeLessThan(75);
+        result.Issues.Should().Contain(i => i.Title.Contains("obstruction"));
+    }
+
+    [Fact]
+    public void Satellite_high_drop_rate_penalized_and_raises_warning()
+    {
+        var result = ScoreSat(obstruction: 0.0005, dropAvg: 0.08, outageSeconds: 0);
+        result.Factor.Score.Should().BeLessThan(75);
+        result.Issues.Should().Contain(i => i.Title.Contains("packet loss"));
+    }
+
+    [Fact]
+    public void Satellite_outage_burden_drags_score_and_notes_anomaly()
+    {
+        // ~600 s/day of dead air over a 2-day window.
+        var result = ScoreSat(obstruction: 0.0005, dropAvg: 0.001, outageSeconds: 1200, outageCount: 20);
+        result.Factor.Score.Should().BeLessThan(90);
+        result.Issues.Should().Contain(i => i.Title.Contains("outages"));
+        result.Factor.Description.Should().Contain("anomaly");
+    }
+
+    [Fact]
+    public void Satellite_persistently_low_snr_caps_score()
+    {
+        var result = ScoreSat(obstruction: 0.0005, dropAvg: 0.001, outageSeconds: 0, snrLow: true);
+        result.Factor.Score.Should().BeLessThanOrEqualTo(40);
+        result.Issues.Should().Contain(i => i.Title.Contains("SNR"));
+    }
+
+    [Fact]
+    public void Satellite_thermal_shutdown_caps_to_critical()
+    {
+        var result = ScoreSat(obstruction: 0.0005, dropAvg: 0.001, outageSeconds: 0,
+            alerts: new[] { "thermal_shutdown" });
+        result.Factor.Score.Should().BeLessThanOrEqualTo(10);
+        result.Issues.Should().Contain(i => i.Severity == IspIssueSeverity.Critical);
+    }
+
+    [Fact]
+    public void Satellite_slow_ethernet_is_advisory_only()
+    {
+        var withSlowEth = ScoreSat(obstruction: 0.0005, dropAvg: 0.001, outageSeconds: 0, ethSpeed: 100);
+        var withFastEth = ScoreSat(obstruction: 0.0005, dropAvg: 0.001, outageSeconds: 0, ethSpeed: 1000);
+        withSlowEth.Factor.Score.Should().Be(withFastEth.Factor.Score);
+        withSlowEth.Issues.Should().ContainSingle(i => i.Severity == IspIssueSeverity.Info);
+        withFastEth.Issues.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Satellite_no_data_yields_null_factor()
+    {
+        var result = ScoreSat();
+        result.Factor.Score.Should().BeNull();
+    }
+}


### PR DESCRIPTION
Adds first-class monitoring for Starlink dishes. The dish exposes a local gRPC API (192.168.100.1:9200) with no authentication from the LAN side, so the app polls it directly for the health signals only the dish can report, feeding a new dashboard card, a Monitoring tab, and ISP Health scoring.

Latency and throughput are deliberately left out: the monitoring pipeline already measures RTT and WAN speed with better fidelity. This tracks what the dish uniquely knows.

## Dashboard - Starlink Stats

- **Starlink Stats card** - Live panel centered on the obstruction sky map, rendered from the dish's own 123x123 SNR grid so blockages show up exactly where they sit in the sky. Alongside it: sky-obstruction percentage, dish-side packet loss, power draw, negotiated Ethernet speed, uptime, GPS fix, last outage, and any active dish alerts. Present by default with a configure prompt when no dish is set up, matching the Cable Modem and ONT cards.

## Monitoring - Starlink Stats

- **New tab** to the right of Cellular Stats with history charts for power draw, dish ping-drop rate, sky obstruction, outage seconds, GPS satellite count, and alignment offset. Supports multiple dishes.

## Settings - Starlink Monitoring

- **Add and manage dishes** (host defaults to 192.168.100.1, port 9200) with a connection test. No credentials, since the local API is unauthenticated.

## Monitoring - ISP Health

- **Starlink as the Physical Link source** for WANs set to the Satellite access technology, scored on sky obstruction, dish-to-ground packet loss, and outage burden, with caps for thermal shutdown, tilt, water intrusion, and persistently low SNR. Slow-negotiated-Ethernet is surfaced as advice without penalizing the ISP score.

## Notes

- Time-series metrics (power, obstruction, loss, outages, alerts, alignment, states) persist to a new `starlink` measurement. The obstruction map is cached and refreshed on a slower cadence.
- Works for external sites through the on-site agent tunnel, using the same routing seam as the cable modem and ONT monitors.
- The dish's gRPC API is community-documented and unversioned, so the client parses defensively and tolerates firmware field drift.
