### PR TITLE
Monitoring: per-site show/hide for hardware stat tabs, cleaner links, and no stale Error on agent drop

### DIFF
--- a/src/NetworkOptimizer.Storage/Migrations/20260716032657_AddMonitoringTabVisibility.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260716032657_AddMonitoringTabVisibility.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260716032657_AddMonitoringTabVisibility")]
+    partial class AddMonitoringTabVisibility
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260716032657_AddMonitoringTabVisibility.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260716032657_AddMonitoringTabVisibility.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMonitoringTabVisibility : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "ShowCellularTab",
+                table: "MonitoringSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "ShowCmTab",
+                table: "MonitoringSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "ShowOntTab",
+                table: "MonitoringSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "ShowStarlinkTab",
+                table: "MonitoringSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ShowCellularTab",
+                table: "MonitoringSettings");
+
+            migrationBuilder.DropColumn(
+                name: "ShowCmTab",
+                table: "MonitoringSettings");
+
+            migrationBuilder.DropColumn(
+                name: "ShowOntTab",
+                table: "MonitoringSettings");
+
+            migrationBuilder.DropColumn(
+                name: "ShowStarlinkTab",
+                table: "MonitoringSettings");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/MonitoringSettings.cs
+++ b/src/NetworkOptimizer.Storage/Models/MonitoringSettings.cs
@@ -136,6 +136,16 @@ public class MonitoringSettings
     /// </summary>
     public int IspHealthScoreWindowHours { get; set; } = 48;
 
+    // Per-site visibility of the optional per-hardware Monitoring stat tabs.
+    // Default true (shown), preserving the historical always-visible behavior;
+    // a user not running that hardware can hide its tab from the Monitoring nav
+    // via the matching Settings section. Only the tab button is affected - the
+    // underlying monitoring/polling is unchanged.
+    public bool ShowCmTab { get; set; } = true;
+    public bool ShowOntTab { get; set; } = true;
+    public bool ShowCellularTab { get; set; } = true;
+    public bool ShowStarlinkTab { get; set; } = true;
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
@@ -566,12 +566,16 @@
 
     private RenderFragment RenderCellularStats => __builder =>
     {
-        <div class="card clickable-card" @onclick="NavigateToCellularChart">
+        // Only a whole-card link when there's a modem to view; otherwise the card
+        // shows its own configure affordance and clicking it would just bounce to an
+        // empty tab.
+        var hasDevice = _cellularPanel?.CurrentModemId != null;
+        <div class="card @(hasDevice ? "clickable-card" : "")" @onclick="NavigateToCellularChart">
             <div class="card-header">
                 <h2 class="card-title">Cellular Stats (5G / LTE)</h2>
             </div>
             <div class="card-body">
-                <CellularStatsPanel @ref="_cellularPanel" />
+                <CellularStatsPanel @ref="_cellularPanel" OnDataLoaded="StateHasChanged" />
             </div>
         </div>
     };
@@ -581,7 +585,8 @@
         // The panel renders its own empty-state when no monitored ONT exists, so the
         // card stays on the dashboard but tells the user how to enable it. Mirrors the
         // CellularStats card's "configure" affordance.
-        <div class="card clickable-card" @onclick="NavigateToOntChart">
+        var hasDevice = _ontPanel?.HasContent == true;
+        <div class="card @(hasDevice ? "clickable-card" : "")" @onclick="NavigateToOntChart">
             <div class="card-header">
                 <h2 class="card-title">@(_ontPanel?.HasAnyAe == true ? "Fiber Stats" : "ONT Stats (GPON / XGS-PON)")</h2>
             </div>
@@ -593,24 +598,26 @@
 
     private RenderFragment RenderStarlinkStats => __builder =>
     {
-        <div class="card clickable-card" @onclick="NavigateToStarlinkChart">
+        var hasDevice = _starlinkPanel?.CurrentStarlinkId != null;
+        <div class="card @(hasDevice ? "clickable-card" : "")" @onclick="NavigateToStarlinkChart">
             <div class="card-header">
                 <h2 class="card-title">Starlink Stats</h2>
             </div>
             <div class="card-body">
-                <StarlinkStatsPanel @ref="_starlinkPanel" />
+                <StarlinkStatsPanel @ref="_starlinkPanel" OnDataLoaded="StateHasChanged" />
             </div>
         </div>
     };
 
     private RenderFragment RenderCmStats => __builder =>
     {
-        <div class="card clickable-card" @onclick="NavigateToCmChart">
+        var hasDevice = _cmPanel?.CurrentCmId != null;
+        <div class="card @(hasDevice ? "clickable-card" : "")" @onclick="NavigateToCmChart">
             <div class="card-header">
                 <h2 class="card-title">Cable Modem Stats (DOCSIS)</h2>
             </div>
             <div class="card-body">
-                <CmStatsPanel @ref="_cmPanel" />
+                <CmStatsPanel @ref="_cmPanel" OnDataLoaded="StateHasChanged" />
             </div>
         </div>
     };
@@ -1241,6 +1248,7 @@
 
     private void NavigateToOntChart()
     {
+        if (_ontPanel?.HasContent != true) return;
         if (_ontPanel?.IsCurrentExternal == true)
         {
             var ontId = _ontPanel.CurrentExternalOntId;
@@ -1260,28 +1268,22 @@
     private void NavigateToCellularChart()
     {
         var modemId = _cellularPanel?.CurrentModemId;
-        var url = modemId != null
-            ? $"/monitoring?tab=cellular&modem={Uri.EscapeDataString(modemId)}"
-            : "/monitoring?tab=cellular";
-        NavigationManager.NavigateTo(url);
+        if (modemId == null) return;
+        NavigationManager.NavigateTo($"/monitoring?tab=cellular&modem={Uri.EscapeDataString(modemId)}");
     }
 
     private void NavigateToStarlinkChart()
     {
         var starlinkId = _starlinkPanel?.CurrentStarlinkId;
-        var url = starlinkId != null
-            ? $"/monitoring?tab=starlink&starlink={Uri.EscapeDataString(starlinkId)}"
-            : "/monitoring?tab=starlink";
-        NavigationManager.NavigateTo(url);
+        if (starlinkId == null) return;
+        NavigationManager.NavigateTo($"/monitoring?tab=starlink&starlink={Uri.EscapeDataString(starlinkId)}");
     }
 
     private void NavigateToCmChart()
     {
         var cmId = _cmPanel?.CurrentCmId;
-        var url = cmId != null
-            ? $"/monitoring?tab=cm&cm={Uri.EscapeDataString(cmId)}"
-            : "/monitoring?tab=cm";
-        NavigationManager.NavigateTo(url);
+        if (cmId == null) return;
+        NavigationManager.NavigateTo($"/monitoring?tab=cm&cm={Uri.EscapeDataString(cmId)}");
     }
 
 }

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -24,6 +24,7 @@
 @inject Microsoft.JSInterop.IJSRuntime JS
 @inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
 @inject NavigationManager NavigationManager
+@inject PersistentComponentState PersistState
 @inject NetworkOptimizer.Web.Services.Monitoring.UpstreamTracerService UpstreamTracer
 @inject ISystemSettingsService SystemSettings
 @inject DashboardLayoutService DashboardLayout
@@ -125,9 +126,11 @@ else
                 SFP Stats
             </button>
             @* Optional per-hardware tabs, hidden from the nav when the matching
-               Settings toggle is off. ResolveDefaultTab redirects a pinned ?tab=
-               off a hidden tab, so the active tab is never one of these when hidden. *@
-            @if (_showCmTab)
+               Settings toggle is off. Gated on _tabVisibilityLoaded so they don't
+               flash in at their default before per-site settings load.
+               ResolveDefaultTab redirects a pinned ?tab= off a hidden tab, so the
+               active tab is never one of these when hidden. *@
+            @if (_tabVisibilityLoaded && _showCmTab)
             {
                 <button class="wifi-view-tab @(_activeTab == "cm" ? "active" : "")"
                         @onclick="@(() => SetActiveTab("cm"))"
@@ -135,7 +138,7 @@ else
                     CM Stats
                 </button>
             }
-            @if (_showOntTab)
+            @if (_tabVisibilityLoaded && _showOntTab)
             {
                 <button class="wifi-view-tab @(_activeTab == "ont" ? "active" : "")"
                         @onclick="@(() => SetActiveTab("ont"))"
@@ -143,7 +146,7 @@ else
                     ONT Stats
                 </button>
             }
-            @if (_showCellularTab)
+            @if (_tabVisibilityLoaded && _showCellularTab)
             {
                 <button class="wifi-view-tab @(_activeTab == "cellular" ? "active" : "")"
                         @onclick="@(() => SetActiveTab("cellular"))"
@@ -151,7 +154,7 @@ else
                     Cellular Stats
                 </button>
             }
-            @if (_showStarlinkTab)
+            @if (_tabVisibilityLoaded && _showStarlinkTab)
             {
                 <button class="wifi-view-tab @(_activeTab == "starlink" ? "active" : "")"
                         @onclick="@(() => SetActiveTab("starlink"))"
@@ -646,7 +649,8 @@ else
                 }
             </div>
         }
-        <SfpModulesCard AllSfps="_allSfps" Targets="_targets" DeviceIpByMac="_deviceIpByMac" OnSfpChanged="OnSfpChanged" />
+        <SfpModulesCard AllSfps="_allSfps" Targets="_targets" DeviceIpByMac="_deviceIpByMac" OnSfpChanged="OnSfpChanged"
+                        ForceExpand="@(string.Equals(ExpandParam, "optical", StringComparison.OrdinalIgnoreCase))" />
 
         @if (_monitoredSfps.Count > 0)
         {
@@ -1508,6 +1512,9 @@ else
     [SupplyParameterFromQuery(Name = "starlink")]
     public string? StarlinkParam { get; set; }
 
+    [SupplyParameterFromQuery(Name = "expand")]
+    public string? ExpandParam { get; set; }
+
     [SupplyParameterFromQuery(Name = "mifip")]
     public string? MiTargetParam { get; set; }
 
@@ -1562,6 +1569,11 @@ else
     private bool _showOntTab = true;
     private bool _showCellularTab = true;
     private bool _showStarlinkTab = true;
+    // Gate the optional tabs until visibility is known, and carry it from prerender
+    // to the interactive circuit so the hideable tabs don't flash in before load.
+    private bool _tabVisibilityLoaded;
+    private PersistingComponentStateSubscription _tabVisPersistSub;
+    private const string TabVisStateKey = "monitoring-tab-visibility";
     private bool _forceExpandUpstream;
 
     // "Results ready" banner for the scheduled upstream re-discovery, surfaced on the
@@ -1756,6 +1768,23 @@ else
     {
         ConnectionService.OnConnectionChanged += OnConnectionChanged;
 
+        // Restore tab visibility persisted from prerender so the interactive render
+        // shows the correct tabs immediately instead of flashing the default (all shown).
+        _tabVisPersistSub = PersistState.RegisterOnPersisting(() =>
+        {
+            PersistState.PersistAsJson(TabVisStateKey,
+                new[] { _showCmTab, _showOntTab, _showCellularTab, _showStarlinkTab });
+            return Task.CompletedTask;
+        });
+        if (PersistState.TryTakeFromJson<bool[]>(TabVisStateKey, out var tabVis) && tabVis is { Length: 4 })
+        {
+            _showCmTab = tabVis[0];
+            _showOntTab = tabVis[1];
+            _showCellularTab = tabVis[2];
+            _showStarlinkTab = tabVis[3];
+            _tabVisibilityLoaded = true;
+        }
+
         var settings = await SnmpDetection.GetOrCreateSettingsAsync();
         _snmpState = settings.SnmpDetectionState;
         await RefreshInfluxStateAsync(settings);
@@ -1765,6 +1794,7 @@ else
         _showOntTab = settings.ShowOntTab;
         _showCellularTab = settings.ShowCellularTab;
         _showStarlinkTab = settings.ShowStarlinkTab;
+        _tabVisibilityLoaded = true;
         LoadSfpThresholdInputs(settings);
         await LoadTargetsAsync();
 
@@ -3688,6 +3718,7 @@ else
     public void Dispose()
     {
         ConnectionService.OnConnectionChanged -= OnConnectionChanged;
+        _tabVisPersistSub.Dispose();
         _liveRefreshTimer?.Dispose();
         _dataRefreshTimer?.Dispose();
         _testFeedbackTimer?.Dispose();

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -124,26 +124,42 @@ else
                     disabled="@(!_monitoringReady)">
                 SFP Stats
             </button>
-            <button class="wifi-view-tab @(_activeTab == "cm" ? "active" : "")"
-                    @onclick="@(() => SetActiveTab("cm"))"
-                    disabled="@(!_monitoringReady)">
-                CM Stats
-            </button>
-            <button class="wifi-view-tab @(_activeTab == "ont" ? "active" : "")"
-                    @onclick="@(() => SetActiveTab("ont"))"
-                    disabled="@(!_monitoringReady)">
-                ONT Stats
-            </button>
-            <button class="wifi-view-tab @(_activeTab == "cellular" ? "active" : "")"
-                    @onclick="@(() => SetActiveTab("cellular"))"
-                    disabled="@(!_monitoringReady)">
-                Cellular Stats
-            </button>
-            <button class="wifi-view-tab @(_activeTab == "starlink" ? "active" : "")"
-                    @onclick="@(() => SetActiveTab("starlink"))"
-                    disabled="@(!_monitoringReady)">
-                Starlink Stats
-            </button>
+            @* Optional per-hardware tabs: hidden from the nav when the matching
+               Settings toggle is off, but still shown while it is the active tab
+               so a direct link (e.g. a dashboard card) never lands on a tab with
+               no button. *@
+            @if (_showCmTab || _activeTab == "cm")
+            {
+                <button class="wifi-view-tab @(_activeTab == "cm" ? "active" : "")"
+                        @onclick="@(() => SetActiveTab("cm"))"
+                        disabled="@(!_monitoringReady)">
+                    CM Stats
+                </button>
+            }
+            @if (_showOntTab || _activeTab == "ont")
+            {
+                <button class="wifi-view-tab @(_activeTab == "ont" ? "active" : "")"
+                        @onclick="@(() => SetActiveTab("ont"))"
+                        disabled="@(!_monitoringReady)">
+                    ONT Stats
+                </button>
+            }
+            @if (_showCellularTab || _activeTab == "cellular")
+            {
+                <button class="wifi-view-tab @(_activeTab == "cellular" ? "active" : "")"
+                        @onclick="@(() => SetActiveTab("cellular"))"
+                        disabled="@(!_monitoringReady)">
+                    Cellular Stats
+                </button>
+            }
+            @if (_showStarlinkTab || _activeTab == "starlink")
+            {
+                <button class="wifi-view-tab @(_activeTab == "starlink" ? "active" : "")"
+                        @onclick="@(() => SetActiveTab("starlink"))"
+                        disabled="@(!_monitoringReady)">
+                    Starlink Stats
+                </button>
+            }
             <button class="wifi-view-tab" @onclick='() => NavigationManager.NavigateTo("/alerts?tab=data-usage")'>
                 Data Usage
             </button>
@@ -804,7 +820,7 @@ else
         {
         @if (!_cmHasDevices)
         {
-            <div class="card" style="margin-top: 1.5rem;">
+            <div class="card">
                 <div class="card-header monitoring-chart-header">
                     <h2 class="card-title">Cable Modem Signal History</h2>
                     <a href="/settings#cable-modem" class="tooltip-icon settings-link" data-tooltip="Cable Modem settings">
@@ -818,7 +834,7 @@ else
         }
         else
         {
-        <div class="card" style="margin-top: 1.5rem;" id="cm-charts-container">
+        <div class="card" id="cm-charts-container">
             <div class="card-header monitoring-chart-header">
                 <h2 class="card-title">Cable Modem Signal History</h2>
                 <div style="display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap;">
@@ -905,7 +921,7 @@ else
         {
         @if (!_ontHasDevices && _monitoredSfps.Any(s => s.Category == SfpCategory.Pon))
         {
-            <div class="card" style="margin-top: 1.5rem;">
+            <div class="card">
                 <div class="card-header monitoring-chart-header">
                     <h2 class="card-title">ONT Signal History</h2>
                     <a href="/settings#ont-monitoring" class="tooltip-icon settings-link" data-tooltip="ONT monitoring settings">
@@ -919,7 +935,7 @@ else
         }
         else if (!_ontHasDevices)
         {
-            <div class="card" style="margin-top: 1.5rem;">
+            <div class="card">
                 <div class="card-header monitoring-chart-header">
                     <h2 class="card-title">ONT Signal History</h2>
                     <a href="/settings#ont-monitoring" class="tooltip-icon settings-link" data-tooltip="ONT monitoring settings">
@@ -933,7 +949,7 @@ else
         }
         else
         {
-        <div class="card" style="margin-top: 1.5rem;" id="ont-charts-container">
+        <div class="card" id="ont-charts-container">
             <div class="card-header monitoring-chart-header">
                 <h2 class="card-title">ONT Signal History</h2>
                 <div style="display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap;">
@@ -1012,7 +1028,7 @@ else
         {
         @if (!_cellularHasDevices)
         {
-            <div class="card" style="margin-top: 1.5rem;">
+            <div class="card">
                 <div class="card-header monitoring-chart-header">
                     <h2 class="card-title">Cellular Signal History</h2>
                     <a href="/settings#cellular-modem" class="tooltip-icon settings-link" data-tooltip="Cellular Modem settings">
@@ -1026,7 +1042,7 @@ else
         }
         else
         {
-        <div class="card" style="margin-top: 1.5rem;" id="cellular-charts-container">
+        <div class="card" id="cellular-charts-container">
             <div class="card-header monitoring-chart-header">
                 <h2 class="card-title">Cellular Signal History</h2>
                 <div style="display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap;">
@@ -1113,7 +1129,7 @@ else
         {
         @if (!_starlinkHasDevices)
         {
-            <div class="card" style="margin-top: 1.5rem;">
+            <div class="card">
                 <div class="card-header monitoring-chart-header">
                     <h2 class="card-title">Starlink Terminal History</h2>
                     <a href="/settings#starlink" class="tooltip-icon settings-link" data-tooltip="Starlink settings">
@@ -1127,7 +1143,7 @@ else
         }
         else
         {
-        <div class="card" style="margin-top: 1.5rem;" id="starlink-charts-container">
+        <div class="card" id="starlink-charts-container">
             <div class="card-header monitoring-chart-header">
                 <h2 class="card-title">Starlink Terminal History</h2>
                 <div style="display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap;">
@@ -1542,6 +1558,11 @@ else
     private bool _ontHasDevices;
     private bool _cellularHasDevices;
     private bool _starlinkHasDevices;
+    // Per-site Monitoring tab visibility (from MonitoringSettings; default shown).
+    private bool _showCmTab = true;
+    private bool _showOntTab = true;
+    private bool _showCellularTab = true;
+    private bool _showStarlinkTab = true;
     private bool _forceExpandUpstream;
 
     // "Results ready" banner for the scheduled upstream re-discovery, surfaced on the
@@ -1723,6 +1744,10 @@ else
         await RefreshInfluxStateAsync(settings);
         _switchTempThresholdInput = settings.SwitchTempHighC;
         _gatewayTempThresholdInput = settings.GatewayTempHighC;
+        _showCmTab = settings.ShowCmTab;
+        _showOntTab = settings.ShowOntTab;
+        _showCellularTab = settings.ShowCellularTab;
+        _showStarlinkTab = settings.ShowStarlinkTab;
         LoadSfpThresholdInputs(settings);
         await LoadTargetsAsync();
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -124,11 +124,10 @@ else
                     disabled="@(!_monitoringReady)">
                 SFP Stats
             </button>
-            @* Optional per-hardware tabs: hidden from the nav when the matching
-               Settings toggle is off, but still shown while it is the active tab
-               so a direct link (e.g. a dashboard card) never lands on a tab with
-               no button. *@
-            @if (_showCmTab || _activeTab == "cm")
+            @* Optional per-hardware tabs, hidden from the nav when the matching
+               Settings toggle is off. ResolveDefaultTab redirects a pinned ?tab=
+               off a hidden tab, so the active tab is never one of these when hidden. *@
+            @if (_showCmTab)
             {
                 <button class="wifi-view-tab @(_activeTab == "cm" ? "active" : "")"
                         @onclick="@(() => SetActiveTab("cm"))"
@@ -136,7 +135,7 @@ else
                     CM Stats
                 </button>
             }
-            @if (_showOntTab || _activeTab == "ont")
+            @if (_showOntTab)
             {
                 <button class="wifi-view-tab @(_activeTab == "ont" ? "active" : "")"
                         @onclick="@(() => SetActiveTab("ont"))"
@@ -144,7 +143,7 @@ else
                     ONT Stats
                 </button>
             }
-            @if (_showCellularTab || _activeTab == "cellular")
+            @if (_showCellularTab)
             {
                 <button class="wifi-view-tab @(_activeTab == "cellular" ? "active" : "")"
                         @onclick="@(() => SetActiveTab("cellular"))"
@@ -152,7 +151,7 @@ else
                     Cellular Stats
                 </button>
             }
-            @if (_showStarlinkTab || _activeTab == "starlink")
+            @if (_showStarlinkTab)
             {
                 <button class="wifi-view-tab @(_activeTab == "starlink" ? "active" : "")"
                         @onclick="@(() => SetActiveTab("starlink"))"
@@ -1621,6 +1620,21 @@ else
         "live", "isp-health", "performance", "devices", "sfp", "cm", "ont", "cellular", "starlink", "setup"
     };
 
+    /// <summary>
+    /// True when <paramref name="tab"/> is one of the optional per-hardware stat tabs
+    /// that this site has hidden. Used so a pinned ?tab= (e.g. after switching to a
+    /// site that doesn't show that tab) falls back to the default instead of landing
+    /// on a hidden tab.
+    /// </summary>
+    private bool IsHardwareTabHidden(string tab) => tab switch
+    {
+        "cm" => !_showCmTab,
+        "ont" => !_showOntTab,
+        "cellular" => !_showCellularTab,
+        "starlink" => !_showStarlinkTab,
+        _ => false
+    };
+
     private string ResolveDefaultTab()
     {
         // Every tab except Setup is gated on _monitoringReady and renders blank when
@@ -1628,7 +1642,10 @@ else
         // explicit ?tab= so a deep-link (e.g. a Device Status dashboard click ->
         // ?tab=devices) into an unconfigured site lands on Setup, not a blank tab.
         if (!_monitoringReady) return "setup";
-        if (TabParam != null && ValidTabs.Contains(TabParam))
+        // A pinned ?tab= for a hardware stat tab hidden on this site (common after a
+        // site switch, where the tab is carried in the URL) falls through to the
+        // default rather than opening a tab the site chose to hide.
+        if (TabParam != null && ValidTabs.Contains(TabParam) && !IsHardwareTabHidden(TabParam.ToLowerInvariant()))
             return TabParam.ToLowerInvariant();
         if (_influxReachable == false || _snmpState == SnmpDetectionState.PollFailing)
             return "setup";

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1478,10 +1478,6 @@
                 Monitor ONT devices (fiber optic terminals) for signal levels, temperature, and link state.
             </p>
 
-            <div class="alert alert-info">
-                Using an SFP ONT with DDM support? Use <strong>Set ONT</strong> on the <a href="/monitoring?tab=sfp&expand=optical">SFP Stats</a> tab to read its optical levels off the port. External polling below is for ONTs monitored over the network instead.
-            </div>
-
             @if (_monitoringSettings != null)
             {
                 <div class="form-group">
@@ -1651,6 +1647,10 @@
                     }
                 </div>
             }
+
+            <div class="alert alert-info">
+                Using an SFP ONT with DDM support? Use <strong>Set ONT</strong> on the <a href="/monitoring?tab=sfp&expand=optical">SFP Stats</a> tab to read its optical levels off the port. The external polling here is for ONTs monitored over the network instead.
+            </div>
         </div>
     </div>
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1454,6 +1454,10 @@
                 Monitor ONT devices (fiber optic terminals) for signal levels, temperature, and link state.
             </p>
 
+            <div class="alert alert-info">
+                Using an SFP ONT with DDM support? Its optical levels are read from the gateway port automatically and appear on the <a href="/monitoring?tab=sfp">SFP Stats</a> tab. The external polling below is only for standalone ONTs that aren't plugged into a UniFi port.
+            </div>
+
             @if (_monitoringSettings != null)
             {
                 <div class="form-group">

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -962,6 +962,16 @@
                 SSH credentials are required for Ubiquiti and GL-iNet modems.
             </p>
 
+            @if (_monitoringSettings != null)
+            {
+                <div class="form-group">
+                    <label class="checkbox-label">
+                        <input type="checkbox" @bind="_monitoringSettings.ShowCellularTab" @bind:after="SaveTabVisibilityAsync" />
+                        <span>Show the Cellular Stats tab in Monitoring</span>
+                    </label>
+                </div>
+            }
+
             @if (sshSettings?.HasCredentials != true &&
                  modemConfigs.Any(m => string.IsNullOrWhiteSpace(m.Provider) || m.Provider == "qmicli"))
             {
@@ -1261,6 +1271,16 @@
                 Monitor external cable modems (DOCSIS) for signal quality, SNR, and error rates.
             </p>
 
+            @if (_monitoringSettings != null)
+            {
+                <div class="form-group">
+                    <label class="checkbox-label">
+                        <input type="checkbox" @bind="_monitoringSettings.ShowCmTab" @bind:after="SaveTabVisibilityAsync" />
+                        <span>Show the CM Stats tab in Monitoring</span>
+                    </label>
+                </div>
+            }
+
             @if (_cmConfigs.Count > 0)
             {
                 <div class="table-responsive">
@@ -1434,6 +1454,16 @@
                 Monitor ONT devices (fiber optic terminals) for signal levels, temperature, and link state.
             </p>
 
+            @if (_monitoringSettings != null)
+            {
+                <div class="form-group">
+                    <label class="checkbox-label">
+                        <input type="checkbox" @bind="_monitoringSettings.ShowOntTab" @bind:after="SaveTabVisibilityAsync" />
+                        <span>Show the ONT Stats tab in Monitoring</span>
+                    </label>
+                </div>
+            }
+
             @if (_ontConfigs.Count > 0)
             {
                 <div class="table-responsive">
@@ -1606,6 +1636,16 @@
             <p class="section-description">
                 Monitor Starlink terminals over the dish's local gRPC API for power draw, obstruction, outages, and alignment.
             </p>
+
+            @if (_monitoringSettings != null)
+            {
+                <div class="form-group">
+                    <label class="checkbox-label">
+                        <input type="checkbox" @bind="_monitoringSettings.ShowStarlinkTab" @bind:after="SaveTabVisibilityAsync" />
+                        <span>Show the Starlink Stats tab in Monitoring</span>
+                    </label>
+                </div>
+            }
 
             @if (_starlinkConfigs.Count > 0)
             {
@@ -7135,6 +7175,32 @@
         catch
         {
             _monitoringSettings = null;
+        }
+    }
+
+    /// <summary>
+    /// Persist the per-site Monitoring stat-tab visibility toggles. The settings row
+    /// returned by GetOrCreateSettingsAsync is detached, so the change is written
+    /// through a fresh site-scoped context (matching the temp-threshold save path).
+    /// </summary>
+    private async Task SaveTabVisibilityAsync()
+    {
+        if (_monitoringSettings == null) return;
+        try
+        {
+            await using var db = SiteDb.CreateForSite(SiteContext.Slug, SiteContext.IsDefault);
+            var settings = await db.MonitoringSettings.FirstOrDefaultAsync() ?? new MonitoringSettings();
+            if (settings.Id == 0) db.MonitoringSettings.Add(settings);
+            settings.ShowCmTab = _monitoringSettings.ShowCmTab;
+            settings.ShowOntTab = _monitoringSettings.ShowOntTab;
+            settings.ShowCellularTab = _monitoringSettings.ShowCellularTab;
+            settings.ShowStarlinkTab = _monitoringSettings.ShowStarlinkTab;
+            settings.UpdatedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync();
+        }
+        catch
+        {
+            // Best-effort persistence; the toggle keeps its in-memory state either way.
         }
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1455,7 +1455,7 @@
             </p>
 
             <div class="alert alert-info">
-                Using an SFP ONT with DDM support? Its optical levels are read from the gateway port automatically and appear on the <a href="/monitoring?tab=sfp">SFP Stats</a> tab. The external polling below is only for standalone ONTs that aren't plugged into a UniFi port.
+                Using an SFP ONT with DDM support? Use <strong>Set ONT</strong> on the <a href="/monitoring?tab=sfp&expand=optical">SFP Stats</a> tab to read its optical levels off the port. External polling below is for ONTs monitored over the network instead.
             </div>
 
             @if (_monitoringSettings != null)

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -952,7 +952,15 @@
     <!-- 6. Cellular Modem -->
     <div class="card settings-tab-monitoring" id="cellular-modem">
         <div class="card-header">
-            <h2 class="card-title">Cellular Modem (5G/LTE)</h2>
+            <div class="card-header-left">
+                <h2 class="card-title">Cellular Modem (5G/LTE)</h2>
+                @if (_monitoringSettings?.ShowCellularTab == true)
+                {
+                    <a href="/monitoring?tab=cellular" class="settings-title-link" data-tooltip="Open Cellular Stats">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"></path><path d="M10 14 21 3"></path><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path></svg>
+                    </a>
+                }
+            </div>
             <span class="status-badge status-@modemStatus.ToLower()">@modemStatus</span>
         </div>
         <div class="card-body">
@@ -1263,7 +1271,15 @@
     <!-- Cable Modem Monitoring -->
     <div class="card settings-tab-monitoring" id="cable-modem">
         <div class="card-header">
-            <h2 class="card-title">Cable Modem Monitoring</h2>
+            <div class="card-header-left">
+                <h2 class="card-title">Cable Modem Monitoring</h2>
+                @if (_monitoringSettings?.ShowCmTab == true)
+                {
+                    <a href="/monitoring?tab=cm" class="settings-title-link" data-tooltip="Open CM Stats">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"></path><path d="M10 14 21 3"></path><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path></svg>
+                    </a>
+                }
+            </div>
             <span class="status-badge status-@_cmStatus.ToLower()">@_cmStatus</span>
         </div>
         <div class="card-body">
@@ -1446,7 +1462,15 @@
     <!-- ONT Device Monitoring -->
     <div class="card settings-tab-monitoring" id="ont-monitoring">
         <div class="card-header">
-            <h2 class="card-title">ONT Device Monitoring</h2>
+            <div class="card-header-left">
+                <h2 class="card-title">ONT Device Monitoring</h2>
+                @if (_monitoringSettings?.ShowOntTab == true)
+                {
+                    <a href="/monitoring?tab=ont" class="settings-title-link" data-tooltip="Open ONT Stats">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"></path><path d="M10 14 21 3"></path><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path></svg>
+                    </a>
+                }
+            </div>
             <span class="status-badge status-@_ontStatus.ToLower()">@_ontStatus</span>
         </div>
         <div class="card-body">
@@ -1633,7 +1657,15 @@
     <!-- Starlink Monitoring -->
     <div class="card settings-tab-monitoring" id="starlink">
         <div class="card-header">
-            <h2 class="card-title">Starlink Monitoring</h2>
+            <div class="card-header-left">
+                <h2 class="card-title">Starlink Monitoring</h2>
+                @if (_monitoringSettings?.ShowStarlinkTab == true)
+                {
+                    <a href="/monitoring?tab=starlink" class="settings-title-link" data-tooltip="Open Starlink Stats">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"></path><path d="M10 14 21 3"></path><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path></svg>
+                    </a>
+                }
+            </div>
             <span class="status-badge status-@_starlinkStatus.ToLower()">@_starlinkStatus</span>
         </div>
         <div class="card-body">

--- a/src/NetworkOptimizer.Web/Components/Shared/CellularStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/CellularStatsPanel.razor
@@ -441,9 +441,14 @@
         ? configuredModems[currentModemIndex].Id.ToString()
         : null;
 
+    /// <summary>Raised after the initial load so the dashboard card can re-evaluate
+    /// whether there is a device to link to.</summary>
+    [Parameter] public EventCallback OnDataLoaded { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
         await LoadStats();
+        await OnDataLoaded.InvokeAsync();
 
         // Start auto-refresh timer (every 30 seconds) to pick up cached stats from background polling
         _refreshTimer = new System.Threading.Timer(

--- a/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
@@ -171,10 +171,15 @@
     private bool _isRefreshing;
     private System.Threading.Timer? _refreshTimer;
 
+    /// <summary>Raised after the initial load so the dashboard card can re-evaluate
+    /// whether there is a device to link to.</summary>
+    [Parameter] public EventCallback OnDataLoaded { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
         await LoadAsync();
         _isLoading = false;
+        await OnDataLoaded.InvokeAsync();
         _refreshTimer = new System.Threading.Timer(async _ =>
         {
             try { await InvokeAsync(async () => { await LoadStatsAsync(); StateHasChanged(); }); }

--- a/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
@@ -338,6 +338,9 @@ else
 
     public bool HasAnyAe => _monitoredOnts.Any(s => s.IsActiveEthernet);
 
+    /// <summary>Whether there's any monitored SFP module or configured external ONT to show.</summary>
+    public bool HasContent => _monitoredOnts.Count > 0 || _externalOnts.Count > 0;
+
     /// <summary>Whether the current item is an external ONT (for navigation routing)</summary>
     public bool IsCurrentExternal => IsShowingExternal;
 

--- a/src/NetworkOptimizer.Web/Components/Shared/SfpModulesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SfpModulesCard.razor
@@ -174,22 +174,42 @@ else
     [Parameter]
     public EventCallback OnSfpChanged { get; set; }
 
+    /// <summary>When set (via a deep link), start expanded regardless of the saved
+    /// collapse preference. Applied once so the user can still collapse it after.</summary>
+    [Parameter]
+    public bool ForceExpand { get; set; }
+
     private bool _collapsed = false;
     private bool _stateLoaded = false;
+    private bool _forceExpandApplied = false;
     private int _page = 0;
     private const int PageSize = 10;
     private const string CollapseKey = "sfp-modules-collapsed";
+
+    protected override void OnParametersSet()
+    {
+        // Honor a deep link's expand request once; the user can still collapse after.
+        if (ForceExpand && !_forceExpandApplied)
+        {
+            _collapsed = false;
+            _forceExpandApplied = true;
+        }
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
-            try
+            // Skip the saved collapse preference when a deep link asked to expand.
+            if (!ForceExpand)
             {
-                var val = await JS.InvokeAsync<string>("localStorage.getItem", CollapseKey);
-                if (val == "true") _collapsed = true;
+                try
+                {
+                    var val = await JS.InvokeAsync<string>("localStorage.getItem", CollapseKey);
+                    if (val == "true") _collapsed = true;
+                }
+                catch { }
             }
-            catch { }
             _stateLoaded = true;
             StateHasChanged();
         }

--- a/src/NetworkOptimizer.Web/Components/Shared/StarlinkStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/StarlinkStatsPanel.razor
@@ -299,9 +299,14 @@
         ? configuredTerminals[currentIndex].Id.ToString()
         : null;
 
+    /// <summary>Raised after the initial load so the dashboard card can re-evaluate
+    /// whether there is a device to link to.</summary>
+    [Parameter] public EventCallback OnDataLoaded { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
         await LoadStats();
+        await OnDataLoaded.InvokeAsync();
 
         // Pick up cached stats from background polling
         _refreshTimer = new System.Threading.Timer(

--- a/src/NetworkOptimizer.Web/Services/CableModemMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemMonitorService.cs
@@ -174,6 +174,12 @@ public sealed class CableModemMonitorService : IDisposable
     private async Task PollAllAsync()
     {
         if (!Active) return;
+        // While an agent-routed site's tunnel is down, every poll fails and stamps a
+        // misleading device error, so the Settings card reads "Error" for a device
+        // that's actually fine and recovers as soon as the agent returns. Skip polling
+        // until the agent is back (the last known state and any real error are kept).
+        if (await _tunnelRouting.IsViaAgentAsync(_siteSlug) && !_tunnelRouting.IsAgentOnline(_siteSlug))
+            return;
         if (_isPolling)
         {
             _logger.LogDebug("CM PollAllAsync skipped - already polling");

--- a/src/NetworkOptimizer.Web/Services/CellularModemService.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemService.cs
@@ -344,6 +344,12 @@ public class CellularModemService : ICellularModemService
     private async Task PollAllModemsAsync()
     {
         if (!Active) return;
+        // While an agent-routed site's tunnel is down, every poll fails and stamps a
+        // misleading device error, so the Settings card reads "Error" for a device
+        // that's actually fine and recovers as soon as the agent returns. Skip polling
+        // until the agent is back (the last known state and any real error are kept).
+        if (await _tunnelRouting.IsViaAgentAsync(_siteSlug) && !_tunnelRouting.IsAgentOnline(_siteSlug))
+            return;
         if (_isPolling) return;
 
         try

--- a/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
@@ -168,6 +168,12 @@ public class OntMonitorService : IDisposable
     private async Task PollAllAsync()
     {
         if (!Active) return;
+        // While an agent-routed site's tunnel is down, every poll fails and stamps a
+        // misleading device error, so the Settings card reads "Error" for a device
+        // that's actually fine and recovers as soon as the agent returns. Skip polling
+        // until the agent is back (the last known state and any real error are kept).
+        if (await _tunnelRouting.IsViaAgentAsync(_siteSlug) && !_tunnelRouting.IsAgentOnline(_siteSlug))
+            return;
         if (_isPolling)
         {
             _logger.LogDebug("ONT PollAllAsync skipped - already polling");

--- a/src/NetworkOptimizer.Web/Services/StarlinkMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/StarlinkMonitorService.cs
@@ -170,6 +170,12 @@ public sealed class StarlinkMonitorService : IDisposable
     private async Task PollAllAsync()
     {
         if (!Active) return;
+        // While an agent-routed site's tunnel is down, every poll fails and stamps a
+        // misleading device error, so the Settings card reads "Error" for a device
+        // that's actually fine and recovers as soon as the agent returns. Skip polling
+        // until the agent is back (the last known state and any real error are kept).
+        if (await _tunnelRouting.IsViaAgentAsync(_siteSlug) && !_tunnelRouting.IsAgentOnline(_siteSlug))
+            return;
         if (_isPolling)
         {
             _logger.LogDebug("Starlink PollAllAsync skipped - already polling");

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -481,7 +481,7 @@ h1:focus {
 }
 
 @media (max-width: 768px) {
-    .monitoring-chart-header {
+    .monitoring-chart-header:has(.settings-link) {
         padding-right: 2.75rem;
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -513,6 +513,17 @@ h1:focus {
     gap: 0.5rem;
 }
 
+.settings-title-link {
+    display: inline-flex;
+    align-items: center;
+    color: var(--text-muted);
+    transition: color 0.15s ease;
+}
+
+.settings-title-link:hover {
+    color: var(--primary-color);
+}
+
 .card-header-right {
     display: flex;
     align-items: center;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -477,6 +477,22 @@ h1:focus {
     min-height: 59px;
     flex-wrap: wrap;
     gap: 0.75rem;
+    position: relative;
+}
+
+@media (max-width: 768px) {
+    .monitoring-chart-header {
+        padding-right: 2.75rem;
+    }
+
+    .monitoring-chart-header .settings-link {
+        position: absolute;
+        top: 12px;
+        right: 16px;
+        height: 1.6875rem;
+        display: flex;
+        align-items: center;
+    }
 }
 
 .card-header-collapsible {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -477,21 +477,23 @@ h1:focus {
     min-height: 59px;
     flex-wrap: wrap;
     gap: 0.75rem;
-    position: relative;
 }
 
 @media (max-width: 768px) {
-    .monitoring-chart-header:has(.settings-link) {
+    .monitoring-chart-header:has(.time-range-selector):has(.settings-link) {
+        position: relative;
         padding-right: 2.75rem;
     }
 
-    .monitoring-chart-header .settings-link {
+    .monitoring-chart-header:has(.time-range-selector):has(.settings-link) .card-title {
+        line-height: 24px;
+    }
+
+    .monitoring-chart-header:has(.time-range-selector):has(.settings-link) .settings-link {
         position: absolute;
-        top: 12px;
+        top: 16px;
         right: 16px;
-        height: 1.6875rem;
-        display: flex;
-        align-items: center;
+        margin: 0;
     }
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -491,8 +491,8 @@ h1:focus {
 
     .monitoring-chart-header:has(.time-range-selector):has(.settings-link) .settings-link {
         position: absolute;
-        top: 16px;
-        right: 16px;
+        top: 4px;
+        right: 0;
         margin: 0;
     }
 }


### PR DESCRIPTION
Lets you hide the per-hardware Monitoring tabs you don't use, tidies how the stat cards and Settings sections link into Monitoring, and stops a dropped agent from making a healthy device look like it errored.

## Monitoring

- **Show/hide the CM Stats, ONT Stats, Cellular Stats, and Starlink Stats tabs per site** - Each tab now has a "Show this tab in Monitoring" toggle in its Settings section (Cable Modem Monitoring, ONT Device Monitoring, Cellular Modem, Starlink Monitoring). All tabs stay visible by default; hiding one just drops it from the Monitoring nav for that site. Switching to a site that hides your current tab lands you on the default tab instead of a stranded one, and hidden tabs no longer flash in before the page finishes loading.
- **Mobile chart headers** - The settings gear on the CM/ONT/Cellular/Starlink history cards now sits pinned top-right, aligned with the title, whether or not the time-range control has wrapped below it.
- **Tighter top spacing** - Removed the extra top margin on the first card of each hardware stat tab so it sits flush under the tab bar.

## Dashboard

- **Stat cards only link when there's something to view** - The Cable Modem Stats, ONT Stats, Cellular Stats, and Starlink Stats cards are whole-card links only when a device is actually configured. With nothing to show, the card keeps its own Configure button instead of bouncing you to an empty tab.

## Settings

- **Jump to the matching Monitoring tab** - A link icon next to each of the Cable Modem Monitoring, ONT Device Monitoring, Cellular Modem, and Starlink Monitoring card titles opens that tab (shown only when the tab is visible).
- **SFP ONT guidance** - ONT Device Monitoring now explains that an SFP ONT with DDM is read off the gateway port via Set ONT on the SFP Stats tab, with a link that opens SFP Stats with the Optical (SFP / ONT) table expanded. External polling there is for ONTs monitored over the network instead.

## Fixes

- **A dropped on-site agent no longer shows a device as errored** - When a site is set to reach its modem/ONT through its agent and that agent goes offline, monitoring now pauses polling for that site instead of recording a failed-poll error against the device. The Settings status badge stays accurate and the device reads healthy again the moment the agent reconnects, rather than showing Error until the next poll.
