### PR TITLE
Wi-Fi Optimizer: stop treating Wi-Fi-less gateways as empty access points

### DIFF
--- a/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
@@ -215,13 +215,35 @@ public class UniFiDiscovery
     }
 
     /// <summary>
+    /// The handful of gateway-class consoles that DO have integrated Wi-Fi radios, keyed by
+    /// FriendlyModelName (the UI display name). Gateways are overwhelmingly Wi-Fi-less, so this
+    /// is an allow-list: any gateway not listed here is treated as gateway-only, regardless of
+    /// what radio_table the API reports (some Wi-Fi-less gateways, e.g. UXG-Fiber on certain
+    /// firmware, emit phantom radio entries). Exact match cleanly separates the original "UDM"
+    /// (has Wi-Fi) from "UDM-Pro"/"UDM-SE"/"UDM-Pro-Max" (Wi-Fi-less).
+    ///
+    /// If UniFi ships a NEW gateway with built-in Wi-Fi (rare), add its FriendlyModelName here,
+    /// or it won't appear in the Wi-Fi Optimizer. See the matching note in UniFiProductDatabase.
+    /// </summary>
+    private static readonly HashSet<string> WifiCapableGateways = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "UDM",            // original Dream Machine
+        "UDW",            // Dream Wall
+        "UDR",            // Dream Router
+        "UDR7",           // Dream Router 7
+        "UDR-5G-Max",     // Dream Router 5G Max
+        "UX",             // Express
+        "UX7",            // Express 7
+        "UCG-Industrial", // only UCG with integrated Wi-Fi
+    };
+
+    /// <summary>
     /// Returns true for gateway-class consoles that do NOT have integrated Wi-Fi radios.
     /// The UniFi API sometimes reports radio_table entries for these devices even though
-    /// they have no wireless capability. Uses FriendlyModelName (the UI display name)
-    /// as the source of truth rather than trusting API radio data.
-    /// Excludes: UDM-Pro, UDM-SE, UDM-Pro-Max (start with "UDM-"), EFG (Enterprise Fortress
-    /// Gateway, starts with "EFG"), and EF-Core (Enterprise Firewall Core).
-    /// Allows: UDM (original Dream Machine), UDR, UX, etc. which have real Wi-Fi.
+    /// they have no wireless capability, so we decide by model rather than trusting API radio
+    /// data: any gateway whose FriendlyModelName is not in <see cref="WifiCapableGateways"/> is
+    /// treated as gateway-only. Excludes: UXG-*, UCG-Max/Fiber/Ultra, UDM-Pro/SE/Max, EFG,
+    /// EF-Core, USG-*. Allows: UDM, UDR(7)/UDR-5G-Max, UX(7), UDW, UCG-Industrial.
     /// </summary>
     internal static bool IsGatewayOnlyConsole(DiscoveredDevice device)
         => IsGatewayOnlyConsole(device.FriendlyModelName);
@@ -230,11 +252,7 @@ public class UniFiDiscovery
         => IsGatewayOnlyConsole(device.FriendlyModelName);
 
     private static bool IsGatewayOnlyConsole(string friendlyModelName)
-    {
-        return friendlyModelName.StartsWith("UDM-", StringComparison.OrdinalIgnoreCase) ||
-               friendlyModelName.StartsWith("EFG", StringComparison.OrdinalIgnoreCase) ||
-               friendlyModelName.StartsWith("EF-Core", StringComparison.OrdinalIgnoreCase);
-    }
+        => !WifiCapableGateways.Contains(friendlyModelName);
 
     /// <summary>
     /// Gets the gateway IP from the default LAN network configuration.

--- a/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
@@ -202,9 +202,16 @@ public class UniFiDiscovery
     /// Discovers all devices with wireless radios for WiFi Optimizer.
     /// Includes traditional APs (type=uap), UDM/UX mesh APs, and gateway-class devices
     /// (UDR, UX, UDM) that have integrated wireless radios broadcasting Wi-Fi.
-    /// Excludes gateway-only consoles (UDM-Pro, UDM-SE, UDM-Pro-Max, EFG) that report
-    /// radio_table entries in the API but don't actually have Wi-Fi radios.
-    /// SmartPower devices (USP-Strip, USP-Plug) are excluded via DeviceType classification.
+    ///
+    /// Our basic "is this an AP" signal for a gateway is "does it report a non-empty
+    /// radio_table". That works for every device we've ever captured EXCEPT that certain
+    /// UniFi Network firmware hands back GARBAGE radio data: it populates radio_table for
+    /// Wi-Fi-less gateways that have no radios at all (a UXG-Fiber on firmware 5.0.16 -
+    /// see issue #994). Those phantom entries false-positive the radio_table check and the
+    /// gateway shows up as an AP with zero clients ("Significant Load Imbalance"). We can't
+    /// trust the API's radio data for gateways, so <see cref="IsGatewayOnlyConsole"/> makes
+    /// the final call by model. SmartPower devices (USP-Strip, USP-Plug) are excluded via
+    /// DeviceType classification.
     /// </summary>
     public async Task<List<DiscoveredDevice>> DiscoverAccessPointsAsync(CancellationToken cancellationToken = default, bool useCache = true)
     {
@@ -216,11 +223,15 @@ public class UniFiDiscovery
 
     /// <summary>
     /// The handful of gateway-class consoles that DO have integrated Wi-Fi radios, keyed by
-    /// FriendlyModelName (the UI display name). Gateways are overwhelmingly Wi-Fi-less, so this
-    /// is an allow-list: any gateway not listed here is treated as gateway-only, regardless of
-    /// what radio_table the API reports (some Wi-Fi-less gateways, e.g. UXG-Fiber on certain
-    /// firmware, emit phantom radio entries). Exact match cleanly separates the original "UDM"
-    /// (has Wi-Fi) from "UDM-Pro"/"UDM-SE"/"UDM-Pro-Max" (Wi-Fi-less).
+    /// FriendlyModelName (the UI display name).
+    ///
+    /// This is an allow-list ONLY because the UniFi Network API can't be trusted to report a
+    /// gateway's radio capability honestly: on some firmware it emits phantom radio_table
+    /// entries for gateways that physically have no Wi-Fi (issue #994). We would much rather
+    /// key off the reported radios, but that data is garbage for this class of device, so we
+    /// fall back to a curated model list. Gateways are overwhelmingly Wi-Fi-less, so anything
+    /// not listed here is treated as gateway-only. Exact match cleanly separates the original
+    /// "UDM" (has Wi-Fi) from "UDM-Pro"/"UDM-SE"/"UDM-Pro-Max" (Wi-Fi-less).
     ///
     /// If UniFi ships a NEW gateway with built-in Wi-Fi (rare), add its FriendlyModelName here,
     /// or it won't appear in the Wi-Fi Optimizer. See the matching note in UniFiProductDatabase.
@@ -239,11 +250,12 @@ public class UniFiDiscovery
 
     /// <summary>
     /// Returns true for gateway-class consoles that do NOT have integrated Wi-Fi radios.
-    /// The UniFi API sometimes reports radio_table entries for these devices even though
-    /// they have no wireless capability, so we decide by model rather than trusting API radio
-    /// data: any gateway whose FriendlyModelName is not in <see cref="WifiCapableGateways"/> is
-    /// treated as gateway-only. Excludes: UXG-*, UCG-Max/Fiber/Ultra, UDM-Pro/SE/Max, EFG,
-    /// EF-Core, USG-*. Allows: UDM, UDR(7)/UDR-5G-Max, UX(7), UDW, UCG-Industrial.
+    /// Decides by model, NOT by the API's reported radio_table, because that data is
+    /// unreliable for gateways: some UniFi Network firmware reports phantom radio entries for
+    /// Wi-Fi-less gateways (issue #994), so trusting it false-positives them as APs. Any
+    /// gateway whose FriendlyModelName is not in <see cref="WifiCapableGateways"/> is treated
+    /// as gateway-only. Excludes: UXG-*, UCG-Max/Fiber/Ultra, UDM-Pro/SE/Max, EFG, EF-Core,
+    /// USG-*. Allows: UDM, UDR(7)/UDR-5G-Max, UX(7), UDW, UCG-Industrial.
     /// </summary>
     internal static bool IsGatewayOnlyConsole(DiscoveredDevice device)
         => IsGatewayOnlyConsole(device.FriendlyModelName);

--- a/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
@@ -216,6 +216,20 @@ public class UniFiDiscovery
     public async Task<List<DiscoveredDevice>> DiscoverAccessPointsAsync(CancellationToken cancellationToken = default, bool useCache = true)
     {
         var devices = await DiscoverDevicesAsync(cancellationToken, useCache);
+
+        // Breadcrumb: a gateway that reports radios but is excluded by the model allow-list.
+        // Normally this is the intended behavior (phantom radios on a Wi-Fi-less gateway, #994),
+        // but if a genuinely Wi-Fi-capable gateway we haven't listed shows up here, this log is
+        // how we'd catch it instead of it silently vanishing from the Wi-Fi Optimizer.
+        foreach (var d in devices.Where(d =>
+                     d.Type == DeviceType.Gateway && d.RadioTable is { Count: > 0 } && IsGatewayOnlyConsole(d)))
+        {
+            _logger.LogDebug(
+                "Excluding gateway {Name} ({Model}) from AP list: reports {RadioCount} radio(s) but is not in " +
+                "the Wi-Fi-capable gateway allow-list. If this model has integrated Wi-Fi, add it to WifiCapableGateways.",
+                d.Name, d.FriendlyModelName, d.RadioTable!.Count);
+        }
+
         return devices.Where(d =>
             d.Type == DeviceType.AccessPoint ||
             (d.Type == DeviceType.Gateway && d.RadioTable is { Count: > 0 } && !IsGatewayOnlyConsole(d))).ToList();

--- a/src/NetworkOptimizer.UniFi/UniFiProductDatabase.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiProductDatabase.cs
@@ -128,6 +128,10 @@ public static class UniFiProductDatabase
         // =====================================================================
         // GATEWAYS / SECURITY GATEWAYS
         // =====================================================================
+        // NOTE: Gateways default to NO integrated Wi-Fi. If a gateway you add
+        // below has built-in Wi-Fi (rare - the Dream/Express line + UCG-Industrial),
+        // also add its friendly name to WifiCapableGateways in UniFiDiscovery.cs,
+        // or it won't appear in the Wi-Fi Optimizer.
 
         // ----- UniFi Dream Machine family -----
         { "UDM", "UDM" },

--- a/src/NetworkOptimizer.UniFi/UniFiProductDatabase.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiProductDatabase.cs
@@ -128,10 +128,12 @@ public static class UniFiProductDatabase
         // =====================================================================
         // GATEWAYS / SECURITY GATEWAYS
         // =====================================================================
-        // NOTE: Gateways default to NO integrated Wi-Fi. If a gateway you add
-        // below has built-in Wi-Fi (rare - the Dream/Express line + UCG-Industrial),
-        // also add its friendly name to WifiCapableGateways in UniFiDiscovery.cs,
-        // or it won't appear in the Wi-Fi Optimizer.
+        // NOTE: Gateways default to NO integrated Wi-Fi. We can't trust the UniFi API's
+        // radio_table to tell us which gateways have Wi-Fi - some firmware reports phantom
+        // radios for Wi-Fi-less gateways (issue #994) - so the Wi-Fi ones are a curated
+        // allow-list. If a gateway you add below has built-in Wi-Fi (rare - the Dream/Express
+        // line + UCG-Industrial), also add its friendly name to WifiCapableGateways in
+        // UniFiDiscovery.cs, or it won't appear in the Wi-Fi Optimizer.
 
         // ----- UniFi Dream Machine family -----
         { "UDM", "UDM" },

--- a/tests/NetworkOptimizer.UniFi.Tests/GatewayApExclusionTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/GatewayApExclusionTests.cs
@@ -81,21 +81,36 @@ public class GatewayApExclusionTests
     }
 
     [Theory]
-    [InlineData("UXGPRO", "UXGPRO")]     // Gateway Pro
-    [InlineData("UXGENT", "UXGENT")]      // Gateway Enterprise
-    [InlineData("UDMA6A8", "UCGF")]       // Cloud Gateway Fiber
-    [InlineData("UDRULT", "UDRULT")]      // UCG-Ultra
-    [InlineData("UXGB", "UXGB")]          // Gateway Max
-    public void OtherGatewayOnly_NotMatchedButNoRadios(string model, string shortname)
+    [InlineData("UXGPRO", "UXGPRO", "UXG-Pro")]        // Gateway Pro
+    [InlineData("UXGENT", "UXGENT", "UXG-Enterprise")]  // Gateway Enterprise
+    [InlineData("UXGA6AA", "UXGF", "UXG-Fiber")]        // UXG-Fiber (issue #994)
+    [InlineData("UXG", "UXG", "UXG-Lite")]              // Gateway Lite
+    [InlineData("UXGB", "UXGB", "UXG-Max")]             // Gateway Max
+    [InlineData("UDMA6A8", "UCGF", "UCG-Fiber")]        // Cloud Gateway Fiber
+    [InlineData("UCGMAX", "UCGMAX", "UCG-Max")]         // Cloud Gateway Max
+    [InlineData("UDRULT", "UDRULT", "UCG-Ultra")]       // Cloud Gateway Ultra
+    public void OtherGatewayOnly_ExcludedEvenWithPhantomRadios(string model, string shortname, string expectedFriendlyName)
     {
-        // These don't start with "UDM-" or "EFG" but also have no Wi-Fi.
-        // They're not caught by IsGatewayOnlyConsole, but they also won't
-        // have radio_table entries in the real API, so the RadioTable check
-        // in DiscoverAccessPointsAsync filters them out.
-        var device = CreateGatewayDevice(model, shortname, radioCount: 0);
+        // These Wi-Fi-less gateways aren't in the WifiCapableGateways allow-list, so they must be
+        // excluded even when the API reports phantom radio_table entries (UXG-Fiber on firmware
+        // 5.0.16 does exactly this - issue #994). We no longer rely on the API omitting radios.
+        var device = CreateGatewayDevice(model, shortname, radioCount: 2);
 
-        // No radio_table → filtered by the Count > 0 check, not by IsGatewayOnlyConsole
-        device.RadioTable.Should().BeNull();
+        device.FriendlyModelName.Should().Be(expectedFriendlyName,
+            $"model={model} shortname={shortname} should resolve to {expectedFriendlyName}");
+        UniFiDiscovery.IsGatewayOnlyConsole(device).Should().BeTrue(
+            $"{expectedFriendlyName} has no integrated Wi-Fi");
+    }
+
+    [Fact]
+    public void UcgIndustrial_Allowed()
+    {
+        // The one UCG with integrated Wi-Fi.
+        var device = CreateGatewayDevice("UDMA6AD", "UCG-Industrial", radioCount: 2);
+
+        device.FriendlyModelName.Should().Be("UCG-Industrial");
+        UniFiDiscovery.IsGatewayOnlyConsole(device).Should().BeFalse(
+            "UCG-Industrial has integrated Wi-Fi");
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Wi-Fi Optimizer

- **Wi-Fi-less gateways no longer show up as empty access points** - A UXG-Fiber (and any gateway without integrated Wi-Fi) could appear in the Wi-Fi Optimizer as an access point with zero clients, which then tripped a false "Significant Load Imbalance". The cause is a UniFi Network API quirk: on some firmware (e.g. UXG-Fiber on 5.0.16) the API returns phantom `radio_table` entries for gateways that physically have no radios, so our "reports radios, therefore it's an AP" heuristic false-positived them.

  Gateway Wi-Fi capability is now decided by model instead of by the API's unreliable radio data. Because gateways are overwhelmingly Wi-Fi-less and the Wi-Fi ones are a short, stable set (Dream Machine, Dream Router/7/5G-Max, Dream Wall, Express/7, UCG-Industrial), the check is a curated allow-list: any gateway not on it is treated as gateway-only regardless of what radios the API claims. All gateways that genuinely have integrated Wi-Fi behave exactly as before, so AP-mode devices (e.g. an Express 7 uplinked as an AP) are unaffected.

  A note at the gateway model table and a debug log for any radio-reporting gateway that gets excluded make sure a future Wi-Fi gateway we haven't listed gets caught rather than silently disappearing.

Fixes #994
